### PR TITLE
ci: add publish workflow and refactor e2e into reusable workflow

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,57 @@
+name: E2E Test
+
+on:
+  workflow_call:
+    inputs:
+      image-tag:
+        description: "Image tag to test (typically the commit SHA)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  e2e:
+    name: E2E
+    runs-on: build-amd64
+    timeout-minutes: 30
+    container:
+      image: ghcr.io/nvidia/nv-agent-env/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --privileged
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+    env:
+      MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      IMAGE_TAG: ${{ inputs.image-tag }}
+      NAVIGATOR_REGISTRY: ghcr.io/nvidia/nv-agent-env
+      NAVIGATOR_REGISTRY_HOST: ghcr.io
+      NAVIGATOR_REGISTRY_NAMESPACE: nvidia/nv-agent-env
+      NAVIGATOR_REGISTRY_USERNAME: ${{ github.actor }}
+      NAVIGATOR_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Pull cluster image
+        run: docker pull ghcr.io/nvidia/nv-agent-env/cluster:${{ inputs.image-tag }}
+
+      - name: Install Python dependencies and generate protobuf stubs
+        run: uv sync --frozen && mise run --no-prepare python:proto
+
+      - name: Bootstrap and deploy cluster
+        env:
+          GATEWAY_HOST: host.docker.internal
+          GATEWAY_PORT: "8080"
+          SKIP_IMAGE_PUSH: "1"
+          NAVIGATOR_CLUSTER_IMAGE: ghcr.io/nvidia/nv-agent-env/cluster:${{ inputs.image-tag }}
+        run: mise run --no-prepare --skip-deps cluster
+
+      - name: Run E2E tests
+        run: mise run --no-prepare --skip-deps test:e2e:sandbox

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,8 +1,6 @@
 name: E2E
 
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
@@ -12,64 +10,25 @@ permissions:
 
 jobs:
   build-server:
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'e2e')
+    if: contains(github.event.pull_request.labels.*.name, 'e2e')
     uses: ./.github/workflows/docker-build.yml
     with:
       component: server
 
   build-sandbox:
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'e2e')
+    if: contains(github.event.pull_request.labels.*.name, 'e2e')
     uses: ./.github/workflows/docker-build.yml
     with:
       component: sandbox
 
   build-cluster:
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'e2e')
+    if: contains(github.event.pull_request.labels.*.name, 'e2e')
     uses: ./.github/workflows/docker-build.yml
     with:
       component: cluster
 
   e2e:
-    name: E2E
     needs: [build-server, build-sandbox, build-cluster]
-    runs-on: build-amd64
-    timeout-minutes: 30
-    container:
-      image: ghcr.io/nvidia/nv-agent-env/ci:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-      options: --privileged
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
-    env:
-      MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      IMAGE_TAG: ${{ github.sha }}
-      # Use GHCR as the image registry for both push (from CI) and pull (from k3s).
-      NAVIGATOR_REGISTRY: ghcr.io/nvidia/nv-agent-env
-      NAVIGATOR_REGISTRY_HOST: ghcr.io
-      NAVIGATOR_REGISTRY_NAMESPACE: nvidia/nv-agent-env
-      NAVIGATOR_REGISTRY_USERNAME: ${{ github.actor }}
-      NAVIGATOR_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-
-      - name: Pull cluster image
-        run: docker pull ghcr.io/nvidia/nv-agent-env/cluster:${{ github.sha }}
-
-      - name: Install Python dependencies and generate protobuf stubs
-        run: uv sync --frozen && mise run --no-prepare python:proto
-
-      - name: Bootstrap and deploy cluster
-        env:
-          GATEWAY_HOST: host.docker.internal
-          GATEWAY_PORT: "8080"
-          SKIP_IMAGE_PUSH: "1"
-          NAVIGATOR_CLUSTER_IMAGE: ghcr.io/nvidia/nv-agent-env/cluster:${{ github.sha }}
-        run: mise run --no-prepare --skip-deps cluster
-
-      - name: Run E2E tests
-        run: mise run --no-prepare --skip-deps test:e2e:sandbox
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      image-tag: ${{ github.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,115 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Build container images to GHCR (same as E2E pipeline)
+  # ---------------------------------------------------------------------------
+  build-server:
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      component: server
+
+  build-sandbox:
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      component: sandbox
+
+  build-cluster:
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      component: cluster
+
+  # ---------------------------------------------------------------------------
+  # Run E2E tests against the built images
+  # ---------------------------------------------------------------------------
+  e2e:
+    needs: [build-server, build-sandbox, build-cluster]
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      image-tag: ${{ github.sha }}
+
+  # ---------------------------------------------------------------------------
+  # Publish multi-arch container images to ECR
+  # ---------------------------------------------------------------------------
+  publish-containers:
+    name: Publish Containers
+    needs: [e2e]
+    runs-on: build-amd64
+    timeout-minutes: 120
+    container:
+      image: ghcr.io/nvidia/nv-agent-env/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --privileged
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+    env:
+      MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-west-2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history needed for setuptools_scm version
+
+      - name: Install Python dependencies
+        run: uv sync --frozen
+
+      - name: Compute version
+        id: version
+        run: |
+          VERSION_DOCKER=$(uv run python build/scripts/release.py get-version --docker)
+          echo "docker=$VERSION_DOCKER" >> "$GITHUB_OUTPUT"
+          echo "Docker image version: $VERSION_DOCKER"
+
+      - name: Set version in source files
+        run: mise run --no-prepare version:set
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Log in to ECR
+        run: aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 524473328983.dkr.ecr.us-west-2.amazonaws.com
+
+      - name: Set up Docker Buildx
+        uses: ./.github/actions/setup-buildx
+
+      - name: Build and push multi-arch images to ECR
+        env:
+          DOCKER_BUILDER: navigator
+          IMAGE_TAG: dev
+          TAG_LATEST: "true"
+          EXTRA_DOCKER_TAGS: ${{ steps.version.outputs.docker }}
+        run: mise run --no-prepare docker:publish:cluster:multiarch
+
+  # ---------------------------------------------------------------------------
+  # Publish Python packages (placeholder)
+  # ---------------------------------------------------------------------------
+  publish-python:
+    name: Publish Python
+    needs: [e2e]
+    runs-on: build-amd64
+    if: false  # TODO: Enable when Python packaging is ready
+    container:
+      image: ghcr.io/nvidia/nv-agent-env/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Placeholder
+        run: echo "Python packaging not yet implemented"


### PR DESCRIPTION
## Summary
- Extract the E2E test job into a reusable workflow (`e2e-test.yml`) so it can be shared between the PR e2e pipeline and the new publish pipeline
- Add a `publish.yml` workflow that builds container images, runs E2E tests, then pushes multi-arch images to ECR (triggers on push to main + manual dispatch)
- Simplify `e2e.yml` to only trigger on PRs with the `e2e` label (main branch is now covered by publish)
- Include a placeholder job for Python packaging builds

## Workflow Architecture

```
publish.yml (push to main / workflow_dispatch)
├── build-server    → docker-build.yml (reusable)
├── build-sandbox   → docker-build.yml (reusable)
├── build-cluster   → docker-build.yml (reusable)
├── e2e             → e2e-test.yml (reusable, depends on builds)
├── publish-containers (depends on e2e) → multi-arch ECR push
└── publish-python  (placeholder, disabled)

e2e.yml (PRs with 'e2e' label only)
├── build-server    → docker-build.yml
├── build-sandbox   → docker-build.yml
├── build-cluster   → docker-build.yml
└── e2e             → e2e-test.yml
```


## Test Plan
- Manually trigger the publish workflow via `workflow_dispatch` to validate the pipeline