### PR TITLE
refactor(cli): remove global --tls-ca, --tls-cert, --tls-key flags

### DIFF
--- a/crates/navigator-cli/src/bootstrap.rs
+++ b/crates/navigator-cli/src/bootstrap.rs
@@ -24,8 +24,8 @@ const DEFAULT_CLUSTER_NAME: &str = "navigator";
 /// Returns `false` for explicit TLS configuration errors, auth failures, and other
 /// non-connectivity issues.
 pub fn should_attempt_bootstrap(error: &miette::Report, tls: &TlsOptions) -> bool {
-    // If the user explicitly provided TLS options and they failed, that's a
-    // configuration error, not a missing-cluster situation.
+    // If TLS paths were explicitly provided (e.g. in tests) and they failed,
+    // that's a configuration error, not a missing-cluster situation.
     if tls.has_any() {
         return is_connectivity_error(error);
     }

--- a/crates/navigator-cli/src/completers.rs
+++ b/crates/navigator-cli/src/completers.rs
@@ -80,7 +80,7 @@ async fn completion_grpc_client(
     server: &str,
     cluster_name: &str,
 ) -> Option<NavigatorClient<Channel>> {
-    let tls_opts = TlsOptions::new(None, None, None).with_cluster_name(cluster_name);
+    let tls_opts = TlsOptions::default().with_cluster_name(cluster_name);
     let materials = require_tls_materials(server, &tls_opts).ok()?;
     let tls_config = build_tonic_tls_config(&materials);
     let endpoint = Endpoint::from_shared(server.to_string())

--- a/crates/navigator-cli/src/main.rs
+++ b/crates/navigator-cli/src/main.rs
@@ -89,18 +89,6 @@ struct Cli {
     #[arg(long, short, global = true, env = "NAVIGATOR_CLUSTER")]
     cluster: Option<String>,
 
-    /// Path to TLS CA certificate (PEM).
-    #[arg(long, env = "NAVIGATOR_TLS_CA", global = true)]
-    tls_ca: Option<PathBuf>,
-
-    /// Path to TLS client certificate (PEM).
-    #[arg(long, env = "NAVIGATOR_TLS_CERT", global = true)]
-    tls_cert: Option<PathBuf>,
-
-    /// Path to TLS client private key (PEM).
-    #[arg(long, env = "NAVIGATOR_TLS_KEY", global = true)]
-    tls_key: Option<PathBuf>,
-
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -814,7 +802,7 @@ async fn main() -> Result<()> {
     CompleteEnv::with_factory(Cli::command).complete();
 
     let cli = Cli::parse();
-    let tls = TlsOptions::new(cli.tls_ca, cli.tls_cert, cli.tls_key);
+    let tls = TlsOptions::default();
 
     // Set up logging based on verbosity
     let log_level = match cli.verbose {


### PR DESCRIPTION
## Summary
- Removed the three global CLI flags (`--tls-ca`, `--tls-cert`, `--tls-key`) from the `Cli` struct
- TLS certificates are always resolved automatically from cluster metadata, making explicit CLI flags unnecessary
- The `TlsOptions` struct, `new()` constructor, and all auto-resolution logic remain intact for programmatic and test use