### PR TITLE
fix(ci): pin Python to 3.12.12 to avoid broken 3.12.13 source build

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,7 @@ redactions = ["*_TOKEN", "*_PASSWORD"]
 experimental = true
 
 [tools]
-python = "3.12"
+python = "3.12.12"
 rust = "stable"
 kubectl = "1.35.1"
 uv = "0.10.2"


### PR DESCRIPTION
## Summary
- Pins Python from floating `3.12` to exact `3.12.12` in `mise.toml`
- Python 3.12.13 was recently released with no precompiled binaries available for the CI runner platforms (Ubuntu 24.04 amd64/arm64)
- The floating `"3.12"` spec resolved to 3.12.13, and the fallback source build fails during `ensurepip`, breaking all 8 jobs across both Checks and Publish workflows

## Root Cause
`mise install` resolves `python = "3.12"` to the latest 3.12.x patch. When 3.12.13 was released without precompiled binaries, mise fell back to `python-build` which fails with:
```
BUILD FAILED (Ubuntu 24.04 using python-build 2.6.25)
subprocess.CalledProcessError: Command '[...pip...]' returned non-zero exit status 1.
```

The previous passing run (commit 4058f5b) used Python 3.12.12 which had a precompiled binary available.