### PR TITLE
fix(ci): harden cargo build retry by wiping target dir and disabling sccache

### DIFF
--- a/deploy/docker/cross-build.sh
+++ b/deploy/docker/cross-build.sh
@@ -108,13 +108,17 @@ cargo_cross_build() {
   # "No such file or directory" writing .d files if deps/ is missing.
   mkdir -p "$(cross_output_dir "$profile")/deps"
   # Retry once after cleaning if the build fails. BuildKit cargo-target cache
-  # mounts can retain stale .rmeta files from prior builds with different
-  # dependency versions; cargo clean purges them so the retry succeeds.
-  # sccache still has the compiled objects, so the clean rebuild is fast.
+  # mounts can retain stale .rmeta/.rlib files from prior builds with different
+  # dependency versions or profiles. We wipe the entire target directory
+  # (rm -rf is more thorough than cargo clean, which relies on its own stale
+  # metadata) and disable sccache for the retry — a corrupt sccache cache
+  # entry can cause "extern location does not exist" errors even on a
+  # freshly-cleaned target dir, so falling back to raw rustc is safer.
   if ! cargo build $target_flag "$@"; then
-    echo "cargo build failed; cleaning stale target cache and retrying..." >&2
-    cargo clean 2>/dev/null || true
+    echo "cargo build failed; cleaning stale target cache and retrying without sccache..." >&2
+    rm -rf /build/target/*
     mkdir -p "$(cross_output_dir "$profile")/deps"
+    unset RUSTC_WRAPPER 2>/dev/null || true
     cargo build $target_flag "$@"
   fi
 }


### PR DESCRIPTION
Closes the failure in https://github.com/NVIDIA/NemoClaw/actions/runs/22637081076/job/65603656552

## Summary
- Replace `cargo clean` with `rm -rf /build/target/*` in the build retry path for a thorough wipe that doesn't depend on cargo's own (potentially stale) metadata
- Disable sccache (`unset RUSTC_WRAPPER`) on retry so a corrupt memcached cache entry can't reproduce the same "extern location does not exist" failure

## Context
The multi-arch publish job fails during the sandbox image build with:
```
error: extern location for version_check does not exist:
  /build/target/release/deps/libversion_check-45553e03c8e9d00c.rlib
```
The existing retry logic (`cargo clean` + retry) failed with the identical error because:
1. `cargo clean` relies on its own metadata to decide what to remove — when the metadata itself is stale on BuildKit cache mounts shared across different build profiles (debug vs release), it may not clean everything.
2. sccache remained enabled during the retry, so a corrupt/stale memcached cache entry would reproduce the same failure even after cleaning the target directory.