### PR TITLE
docs: reset CONTRIBUTING.md and add mise run docs task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,12 +37,12 @@ mise trust
 mise run sandbox
 ```
 
-## `nemoclaw` Shortcut
+## Building the `nemoclaw` CLI
 
 Inside this repository, `nemoclaw` is a local shortcut script at `scripts/bin/nemoclaw`. The script will
 
-1. Builds `navigator-cli` if needed.
-2. Runs the local debug CLI binary (`target/debug/nemoclaw`).
+1. Build `navigator-cli` if needed.
+2. Run the local debug CLI binary under `target/debug/nemoclaw`.
 
 Because `mise` adds `scripts/bin` to `PATH` for this project, you can run `nemoclaw` directly from the repo.
 
@@ -57,24 +57,24 @@ These are the primary `mise` tasks for day-to-day development:
 
 | Task               | Purpose                                                 |
 | ------------------ | ------------------------------------------------------- |
-| `mise run docs`    | Build and serve documentation locally                   |
 | `mise run cluster` | Bootstrap or incremental deploy                         |
 | `mise run sandbox` | Create a sandbox on the running cluster                 |
 | `mise run test`    | Default test suite                                      |
 | `mise run e2e`     | Default end-to-end test lane                            |
 | `mise run ci`      | Full local CI checks (lint, compile/type checks, tests) |
+| `mise run docs`    | Build and serve documentation locally                   |
 | `mise run clean`   | Clean build artifacts                                   |
 
 ## Project Structure
 
-| Path | Purpose |
-|---|---|
-| `crates/` | Rust crates |
-| `python/` | Python SDK and bindings |
-| `proto/` | Protocol buffer definitions |
-| `tasks/` | `mise` task definitions and build scripts |
-| `deploy/` | Dockerfiles, Helm chart, Kubernetes manifests |
-| `architecture/` | Architecture docs and plans |
+| Path            | Purpose                                       |
+| --------------- | --------------------------------------------- |
+| `crates/`       | Rust crates                                   |
+| `python/`       | Python SDK and bindings                       |
+| `proto/`        | Protocol buffer definitions                   |
+| `tasks/`        | `mise` task definitions and build scripts     |
+| `deploy/`       | Dockerfiles, Helm chart, Kubernetes manifests |
+| `architecture/` | Architecture docs and plans                   |
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary
- Reset `CONTRIBUTING.md` to b62c42f to remove post-commit drift
- Added `mise run docs` row to the Main Tasks table