### PR TITLE
fix(sandbox): remove control plane bypass from proxy

### DIFF
--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -99,7 +99,6 @@ flowchart TD
 7. **Proxy startup** (proxy mode only):
    - Validate that OPA engine and identity cache are present
    - Determine bind address: on Linux, use the netns veth host IP (netns creation is required and startup already aborted if it failed); on non-Linux, use `policy.network.proxy.http_addr`
-   - Parse the gateway endpoint URL into the control-plane allowlist
    - Build `InferenceContext` via `build_inference_context()` which resolves routes from one of two sources (see [Inference routing context](#inference-routing-context) below)
    - `ProxyHandle::start_with_bind_addr()` binds a `TcpListener` and spawns an accept loop, passing the inference context to each connection handler
 
@@ -521,20 +520,15 @@ sequenceDiagram
 
     S->>P: CONNECT api.example.com:443 HTTP/1.1
     P->>P: Parse CONNECT target (host, port)
-    P->>P: Check control-plane allowlist
-    alt Control-plane endpoint
-        P->>P: Allow without OPA or SSRF check
-        P->>U: TCP connect (hostname-based)
-    else Normal endpoint
-        P->>P: Resolve TCP peer identity via /proc
-        P->>P: TOFU verify binary SHA256
-        P->>P: Walk ancestor chain, verify each
-        P->>P: Collect cmdline paths
-        P->>O: evaluate_network_action(input)
-        O-->>P: NetworkAction (Allow / InspectForInference / Deny)
-        P->>P: Log CONNECT decision (unified log line)
-        alt Deny
-            P-->>S: HTTP/1.1 403 Forbidden
+    P->>P: Resolve TCP peer identity via /proc
+    P->>P: TOFU verify binary SHA256
+    P->>P: Walk ancestor chain, verify each
+    P->>P: Collect cmdline paths
+    P->>O: evaluate_network_action(input)
+    O-->>P: NetworkAction (Allow / InspectForInference / Deny)
+    P->>P: Log CONNECT decision (unified log line)
+    alt Deny
+        P-->>S: HTTP/1.1 403 Forbidden
         else InspectForInference
             P-->>S: HTTP/1.1 200 Connection Established
             P->>P: TLS-terminate client (SandboxCa)
@@ -584,10 +578,6 @@ Startup steps:
 
 The proxy reads up to 8192 bytes (`MAX_HEADER_BYTES`) looking for `\r\n\r\n`. It validates the method is `CONNECT` (returning 403 for anything else with a structured log) and parses the `host:port` target.
 
-### Control-plane bypass
-
-Connections to the gateway's own endpoint (parsed from `--navigator-endpoint`) are always allowed without OPA evaluation and without the SSRF internal-IP check. This ensures the sandboxed process can reach the gateway for management operations (policy fetch, provider environment, inference route bundle refresh), even when the gateway resolves to a private IP (e.g., a Kubernetes service IP). Control-plane connections use hostname-based `TcpStream::connect()` rather than pre-resolved addresses. The decision engine is recorded as `"control_plane"`.
-
 ### OPA evaluation with identity binding (`evaluate_opa_tcp()`)
 
 This is the core security evaluation path, Linux-only (requires `/proc`).
@@ -622,7 +612,6 @@ struct ConnectDecision {
     binary_pid: Option<u32>,
     ancestors: Vec<PathBuf>,
     cmdline_paths: Vec<PathBuf>,
-    engine: &'static str,          // "opa" or "control_plane"
 }
 ```
 
@@ -636,7 +625,7 @@ For `InspectForInference` connections, the initial log records `action=inspect_f
 
 ### SSRF protection (internal IP rejection)
 
-After OPA allows a connection, the proxy resolves DNS and rejects any host that resolves to an internal IP address (loopback, RFC 1918 private, link-local, or IPv4-mapped IPv6 equivalents). This defense-in-depth measure prevents SSRF attacks where an allowed hostname is pointed at internal infrastructure. The check is implemented by `resolve_and_reject_internal()` which calls `tokio::net::lookup_host()` and validates every resolved address via `is_internal_ip()`. If any resolved IP is internal, the connection receives a `403 Forbidden` response and a warning is logged. Control-plane endpoints are exempt from this check. See [SSRF Protection](security-policy.md#ssrf-protection-internal-ip-rejection) for the full list of blocked ranges.
+After OPA allows a connection, the proxy resolves DNS and rejects any host that resolves to an internal IP address (loopback, RFC 1918 private, link-local, or IPv4-mapped IPv6 equivalents). This defense-in-depth measure prevents SSRF attacks where an allowed hostname is pointed at internal infrastructure. The check is implemented by `resolve_and_reject_internal()` which calls `tokio::net::lookup_host()` and validates every resolved address via `is_internal_ip()`. If any resolved IP is internal, the connection receives a `403 Forbidden` response and a warning is logged. See [SSRF Protection](security-policy.md#ssrf-protection-internal-ip-rejection) for the full list of blocked ranges.
 
 ### Inference interception (`InspectForInference` path)
 

--- a/architecture/security-policy.md
+++ b/architecture/security-policy.md
@@ -727,12 +727,6 @@ See `crates/navigator-sandbox/src/l7/mod.rs` -- `validate_l7_policies()`.
 
 ---
 
-## Control Plane Bypass
-
-When `--nemoclaw-endpoint` is set, the proxy automatically allows connections to the gateway endpoint without OPA evaluation. This ensures the sandbox can always reach the gateway for inference routing and provider environment updates. The endpoint is parsed from the URL and added to a `control_plane_endpoints` allowlist. Control plane endpoints are also exempt from the SSRF internal-IP check (see below) because they legitimately resolve to private IPs in cluster deployments. See `crates/navigator-sandbox/src/proxy.rs` -- `is_control_plane` check.
-
----
-
 ## SSRF Protection (Internal IP Rejection)
 
 As a defense-in-depth measure, the proxy resolves DNS before connecting to upstream hosts and rejects any connection where the resolved IP address falls within an internal range. This prevents Server-Side Request Forgery (SSRF) attacks where a misconfigured or overly permissive OPA policy could allow connections to infrastructure endpoints such as cloud metadata services (`169.254.169.254`), localhost, or RFC 1918 private addresses.
@@ -779,9 +773,7 @@ Functions in `crates/navigator-sandbox/src/proxy.rs` implement the SSRF checks:
 
 ```mermaid
 flowchart TD
-    A[CONNECT request received] --> B{Control plane endpoint?}
-    B -- Yes --> C["Allow: skip OPA + SSRF check"]
-    B -- No --> D[OPA policy evaluation]
+    A[CONNECT request received] --> D[OPA policy evaluation]
     D --> E{Allowed?}
     E -- No --> F["403 Forbidden"]
     E -- Yes --> G{allowed_ips on endpoint?}
@@ -855,10 +847,6 @@ network_policies:
 ```
 
 Any hostname on port 8080 is allowed, provided DNS resolves to an IP within `10.0.5.0/24` or `10.0.6.0/24`. This allows access to multiple internal services without listing each hostname.
-
-### Control Plane Exemption
-
-Control plane endpoints bypass the SSRF check entirely and connect using hostname-based `TcpStream::connect()`. This is necessary because the gateway legitimately resolves to a private IP (e.g., a Kubernetes service IP or `10.200.0.1` on the veth pair). Control plane endpoints are already authenticated before OPA evaluation, so the SSRF bypass does not weaken the security model.
 
 ### DNS Resolution Failure
 

--- a/crates/navigator-sandbox/src/lib.rs
+++ b/crates/navigator-sandbox/src/lib.rs
@@ -262,14 +262,6 @@ pub async fn run_sandbox(
         #[cfg(not(target_os = "linux"))]
         let bind_addr: Option<SocketAddr> = None;
 
-        // Build the control plane allowlist: the navigator endpoint is always
-        // allowed so sandbox processes can reach the server for inference.
-        let control_plane_endpoints = navigator_endpoint_for_proxy
-            .as_deref()
-            .and_then(proxy::parse_endpoint_url)
-            .into_iter()
-            .collect::<Vec<_>>();
-
         // Build inference context for local routing of intercepted inference calls.
         let inference_ctx = build_inference_context(
             sandbox_id.as_deref(),
@@ -285,7 +277,6 @@ pub async fn run_sandbox(
                 engine,
                 cache,
                 entrypoint_pid.clone(),
-                control_plane_endpoints,
                 tls_state,
                 inference_ctx,
             )

--- a/crates/navigator-sandbox/src/proxy.rs
+++ b/crates/navigator-sandbox/src/proxy.rs
@@ -30,8 +30,6 @@ struct ConnectDecision {
     ancestors: Vec<PathBuf>,
     /// Cmdline-derived absolute paths (for script detection).
     cmdline_paths: Vec<PathBuf>,
-    /// Which engine made the decision ("opa" or "`control_plane`").
-    engine: &'static str,
 }
 
 /// Outcome of an inference interception attempt.
@@ -76,30 +74,6 @@ impl InferenceContext {
     }
 }
 
-/// An endpoint that the proxy always allows without OPA evaluation.
-/// Used for infrastructure endpoints like the navigator control plane.
-#[derive(Debug, Clone)]
-pub struct AllowedEndpoint {
-    pub host: String,
-    pub port: u16,
-}
-
-/// Parse a URL like `http://host:port` into an `AllowedEndpoint`.
-///
-/// Strips the scheme and extracts host + port. Returns `None` if the
-/// URL can't be parsed.
-pub fn parse_endpoint_url(url: &str) -> Option<AllowedEndpoint> {
-    let without_scheme = url
-        .strip_prefix("http://")
-        .or_else(|| url.strip_prefix("https://"))?;
-    let (host, port_str) = without_scheme.rsplit_once(':')?;
-    let port: u16 = port_str.parse().ok()?;
-    Some(AllowedEndpoint {
-        host: host.to_ascii_lowercase(),
-        port,
-    })
-}
-
 #[derive(Debug)]
 pub struct ProxyHandle {
     #[allow(dead_code)]
@@ -111,9 +85,7 @@ impl ProxyHandle {
     /// Start the proxy with OPA engine for policy evaluation.
     ///
     /// The proxy uses OPA for network decisions with process-identity binding
-    /// via `/proc/net/tcp`. Connections to `control_plane_endpoints` are always
-    /// allowed without OPA evaluation — these are infrastructure endpoints
-    /// (like the navigator server) that the sandbox needs to function.
+    /// via `/proc/net/tcp`. All connections are evaluated through OPA policy.
     #[allow(clippy::too_many_arguments)]
     pub async fn start_with_bind_addr(
         policy: &ProxyPolicy,
@@ -121,7 +93,6 @@ impl ProxyHandle {
         opa_engine: Arc<OpaEngine>,
         identity_cache: Arc<BinaryIdentityCache>,
         entrypoint_pid: Arc<AtomicU32>,
-        control_plane_endpoints: Vec<AllowedEndpoint>,
         tls_state: Option<Arc<ProxyTlsState>>,
         inference_ctx: Option<Arc<InferenceContext>>,
     ) -> Result<Self> {
@@ -143,7 +114,6 @@ impl ProxyHandle {
         let local_addr = listener.local_addr().into_diagnostic()?;
         info!(addr = %local_addr, "Proxy listening (tcp)");
 
-        let cp_endpoints = Arc::new(control_plane_endpoints);
         let join = tokio::spawn(async move {
             loop {
                 match listener.accept().await {
@@ -151,12 +121,11 @@ impl ProxyHandle {
                         let opa = opa_engine.clone();
                         let cache = identity_cache.clone();
                         let spid = entrypoint_pid.clone();
-                        let cp = cp_endpoints.clone();
                         let tls = tls_state.clone();
                         let inf = inference_ctx.clone();
                         tokio::spawn(async move {
                             if let Err(err) =
-                                handle_tcp_connection(stream, opa, cache, spid, cp, tls, inf).await
+                                handle_tcp_connection(stream, opa, cache, spid, tls, inf).await
                             {
                                 warn!(error = %err, "Proxy connection error");
                             }
@@ -193,7 +162,6 @@ async fn handle_tcp_connection(
     opa_engine: Arc<OpaEngine>,
     identity_cache: Arc<BinaryIdentityCache>,
     entrypoint_pid: Arc<AtomicU32>,
-    control_plane_endpoints: Arc<Vec<AllowedEndpoint>>,
     tls_state: Option<Arc<ProxyTlsState>>,
     inference_ctx: Option<Arc<InferenceContext>>,
 ) -> Result<()> {
@@ -245,34 +213,15 @@ async fn handle_tcp_connection(
     let peer_addr = client.peer_addr().into_diagnostic()?;
     let local_addr = client.local_addr().into_diagnostic()?;
 
-    // Allow control plane endpoints (e.g. navigator server) without OPA evaluation.
-    // These are infrastructure endpoints the sandbox needs to function.
-    let is_control_plane = control_plane_endpoints
-        .iter()
-        .any(|ep| ep.host == host_lc && ep.port == port);
-
-    let decision = if is_control_plane {
-        ConnectDecision {
-            action: NetworkAction::Allow {
-                matched_policy: Some("control_plane".into()),
-            },
-            binary: None,
-            binary_pid: None,
-            ancestors: vec![],
-            cmdline_paths: vec![],
-            engine: "control_plane",
-        }
-    } else {
-        // Evaluate OPA policy with process-identity binding
-        evaluate_opa_tcp(
-            peer_addr,
-            &opa_engine,
-            &identity_cache,
-            &entrypoint_pid,
-            &host_lc,
-            port,
-        )
-    };
+    // Evaluate OPA policy with process-identity binding
+    let decision = evaluate_opa_tcp(
+        peer_addr,
+        &opa_engine,
+        &identity_cache,
+        &entrypoint_pid,
+        &host_lc,
+        port,
+    );
 
     // Extract action string and matched policy for logging
     let (action_str, matched_policy, deny_reason) = match &decision.action {
@@ -326,7 +275,7 @@ async fn handle_tcp_connection(
         ancestors = %ancestors_str,
         cmdline = %cmdline_str,
         action = %action_str,
-        engine = %decision.engine,
+        engine = "opa",
         policy = %policy_str,
         reason = %deny_reason,
         "CONNECT",
@@ -369,7 +318,7 @@ async fn handle_tcp_connection(
                 ancestors = %ancestors_str,
                 cmdline = %cmdline_str,
                 action = "deny",
-                engine = %decision.engine,
+                engine = "opa",
                 policy = %policy_str,
                 reason = %reason,
                 "CONNECT",
@@ -384,20 +333,10 @@ async fn handle_tcp_connection(
     // Query allowed_ips from the matched endpoint config (if any).
     // When present, the SSRF check validates resolved IPs against this
     // allowlist instead of blanket-blocking all private IPs.
-    let raw_allowed_ips = if !is_control_plane {
-        query_allowed_ips(&opa_engine, &decision, &host_lc, port)
-    } else {
-        vec![]
-    };
+    let raw_allowed_ips = query_allowed_ips(&opa_engine, &decision, &host_lc, port);
 
     // Defense-in-depth: resolve DNS and reject connections to internal IPs.
-    // Control plane endpoints are exempt — they legitimately resolve to private
-    // IPs in cluster deployments and are already checked before OPA evaluation.
-    let mut upstream = if is_control_plane {
-        TcpStream::connect((host.as_str(), port))
-            .await
-            .into_diagnostic()?
-    } else if !raw_allowed_ips.is_empty() {
+    let mut upstream = if !raw_allowed_ips.is_empty() {
         // allowed_ips mode: validate resolved IPs against CIDR allowlist.
         // Loopback and link-local are still always blocked.
         match parse_allowed_ips(&raw_allowed_ips) {
@@ -449,9 +388,7 @@ async fn handle_tcp_connection(
     respond(&mut client, b"HTTP/1.1 200 Connection Established\r\n\r\n").await?;
 
     // Check if endpoint has L7 config for protocol-aware inspection
-    if !is_control_plane
-        && let Some(l7_config) = query_l7_config(&opa_engine, &decision, &host_lc, port)
-    {
+    if let Some(l7_config) = query_l7_config(&opa_engine, &decision, &host_lc, port) {
         // Clone engine for per-tunnel L7 evaluation (cheap: shares compiled policy via Arc)
         let tunnel_engine = opa_engine.clone_engine_for_tunnel().unwrap_or_else(|e| {
             warn!(error = %e, "Failed to clone OPA engine for L7, falling back to L4-only");
@@ -611,7 +548,6 @@ fn evaluate_opa_tcp(
             binary_pid,
             ancestors,
             cmdline_paths,
-            engine: "opa",
         }
     };
 
@@ -695,7 +631,6 @@ fn evaluate_opa_tcp(
             binary_pid: Some(binary_pid),
             ancestors,
             cmdline_paths,
-            engine: "opa",
         },
         Err(e) => deny(
             format!("policy evaluation error: {e}"),
@@ -725,7 +660,6 @@ fn evaluate_opa_tcp(
         binary_pid: None,
         ancestors: vec![],
         cmdline_paths: vec![],
-        engine: "opa",
     }
 }
 


### PR DESCRIPTION
> This was created during the initial spike for inference, but is no longer used, so can be safely removed.

## Summary

Removes the `control_plane_endpoints` allowlist that let sandboxed processes bypass OPA policy evaluation and SSRF protection when connecting to the gateway (control plane). This is a security fix: a sandbox with unrestricted access to the control plane could modify its own policy, exfiltrate data through provider environment endpoints, or abuse other gateway APIs.

## What changed

- **Removed `AllowedEndpoint` struct and `parse_endpoint_url()`** from `proxy.rs` — no longer needed since there's no allowlist
- **Removed `control_plane_endpoints` parameter** from `ProxyHandle::start_with_bind_addr()` and `handle_tcp_connection()` 
- **Removed `is_control_plane` bypass** — all connections now go through OPA policy evaluation and SSRF internal-IP rejection with no exceptions
- **Removed `engine` field** from `ConnectDecision` — was only needed to distinguish `"opa"` vs `"control_plane"` decisions; now all decisions are OPA
- **Updated architecture docs** — removed Control Plane Bypass section from `security-policy.md`, removed control-plane bypass docs and mermaid diagrams from `sandbox.md`

## Security impact

Before: sandbox could talk to the gateway endpoint without any policy check, bypassing both OPA evaluation and SSRF protection.

After: all outbound connections from the sandbox are subject to OPA policy. If the sandbox needs to reach the gateway (e.g., for inference routing), the policy must explicitly allow it.

## Testing

- All 173 sandbox unit tests pass
- Full workspace compiles and `cargo clippy` clean
- `mise run pre-commit` passes