### PR TITLE
fix(sandbox): verify effective UID/GID after privilege drop

### DIFF
--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -950,9 +950,14 @@ Wraps `tokio::process::Child` + PID. Platform-specific `spawn()` methods delegat
 Resolves user/group names from policy, then:
 1. `initgroups()` to set supplementary groups (Linux only, not macOS)
 2. `setgid()` to target group
-3. `setuid()` to target user
+3. Verify `getegid()` matches the target GID
+4. `setuid()` to target user
+5. Verify `geteuid()` matches the target UID
+6. Verify `setuid(0)` fails (confirms root cannot be re-acquired)
 
 The ordering is significant: `initgroups`/`setgid` must happen before `setuid` because switching user may drop the privileges needed for group manipulation. Similarly, privilege dropping must happen before Landlock because Landlock may block access to `/etc/passwd` and `/etc/group`.
+
+Steps 3, 5, and 6 are defense-in-depth post-condition checks (CWE-250 / CERT POS37-C). All three syscalls (`geteuid`, `getegid`, `setuid`) are async-signal-safe, so they are safe to call in the `pre_exec` context. The checks add negligible overhead while guarding against hypothetical kernel-level defects that could cause `setuid`/`setgid` to return success without actually changing the effective IDs.
 
 ### `ProcessStatus`
 

--- a/architecture/security-policy.md
+++ b/architecture/security-policy.md
@@ -364,9 +364,12 @@ Controls privilege dropping for the sandboxed process. **Static field** -- immut
 
 1. `initgroups()` -- set supplementary groups for the target user
 2. `setgid()` -- switch to the target group
-3. `setuid()` -- switch to the target user
+3. Verify `getegid()` matches the target GID (defense-in-depth, CWE-250 / CERT POS37-C)
+4. `setuid()` -- switch to the target user
+5. Verify `geteuid()` matches the target UID
+6. Verify `setuid(0)` fails -- confirms root cannot be re-acquired
 
-This happens before Landlock and seccomp are applied because `initgroups` needs access to `/etc/group` and `/etc/passwd`, which Landlock may subsequently block. See `crates/navigator-sandbox/src/process.rs` -- `drop_privileges()`.
+This happens before Landlock and seccomp are applied because `initgroups` needs access to `/etc/group` and `/etc/passwd`, which Landlock may subsequently block. The post-condition checks (steps 3, 5, 6) are async-signal-safe and add negligible overhead while guarding against hypothetical kernel-level defects. See `crates/navigator-sandbox/src/process.rs` -- `drop_privileges()`.
 
 ```yaml
 process:

--- a/crates/navigator-sandbox/src/process.rs
+++ b/crates/navigator-sandbox/src/process.rs
@@ -408,8 +408,39 @@ pub fn drop_privileges(policy: &SandboxPolicy) -> Result<()> {
 
     nix::unistd::setgid(group.gid).into_diagnostic()?;
 
+    // Verify effective GID actually changed (defense-in-depth, CWE-250 / CERT POS37-C)
+    let effective_gid = nix::unistd::getegid();
+    if effective_gid != group.gid {
+        return Err(miette::miette!(
+            "Privilege drop verification failed: expected effective GID {}, got {}",
+            group.gid,
+            effective_gid
+        ));
+    }
+
     if user_name.is_some() {
         nix::unistd::setuid(user.uid).into_diagnostic()?;
+
+        // Verify effective UID actually changed (defense-in-depth, CWE-250 / CERT POS37-C)
+        let effective_uid = nix::unistd::geteuid();
+        if effective_uid != user.uid {
+            return Err(miette::miette!(
+                "Privilege drop verification failed: expected effective UID {}, got {}",
+                user.uid,
+                effective_uid
+            ));
+        }
+
+        // Verify root cannot be re-acquired (CERT POS37-C hardening).
+        // If we dropped from root, setuid(0) must fail; success means privileges
+        // were not fully relinquished.
+        if nix::unistd::setuid(nix::unistd::Uid::from_raw(0)).is_ok() && user.uid.as_raw() != 0 {
+            return Err(miette::miette!(
+                "Privilege drop verification failed: process can still re-acquire root (UID 0) \
+                 after switching to UID {}",
+                user.uid
+            ));
+        }
     }
 
     Ok(())
@@ -462,5 +493,94 @@ impl From<std::process::ExitStatus> for ProcessStatus {
                 signal: None,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::{
+        FilesystemPolicy, LandlockPolicy, NetworkPolicy, ProcessPolicy, SandboxPolicy,
+    };
+
+    /// Helper to create a minimal `SandboxPolicy` with the given process policy.
+    fn policy_with_process(process: ProcessPolicy) -> SandboxPolicy {
+        SandboxPolicy {
+            version: 1,
+            filesystem: FilesystemPolicy::default(),
+            network: NetworkPolicy::default(),
+            landlock: LandlockPolicy::default(),
+            process,
+        }
+    }
+
+    #[test]
+    fn drop_privileges_noop_when_no_user_or_group() {
+        let policy = policy_with_process(ProcessPolicy {
+            run_as_user: None,
+            run_as_group: None,
+        });
+        assert!(drop_privileges(&policy).is_ok());
+    }
+
+    #[test]
+    fn drop_privileges_noop_when_empty_strings() {
+        let policy = policy_with_process(ProcessPolicy {
+            run_as_user: Some(String::new()),
+            run_as_group: Some(String::new()),
+        });
+        assert!(drop_privileges(&policy).is_ok());
+    }
+
+    #[test]
+    fn drop_privileges_succeeds_for_current_user() {
+        // Resolve the current user's name so we can ask drop_privileges to
+        // "switch" to the user we're already running as.  This exercises the
+        // full verification path (getegid/geteuid checks) without needing root.
+        let current_user = User::from_uid(nix::unistd::geteuid())
+            .expect("getpwuid")
+            .expect("current user entry");
+        let current_group = Group::from_gid(nix::unistd::getegid())
+            .expect("getgrgid")
+            .expect("current group entry");
+
+        let policy = policy_with_process(ProcessPolicy {
+            run_as_user: Some(current_user.name),
+            run_as_group: Some(current_group.name),
+        });
+
+        assert!(drop_privileges(&policy).is_ok());
+    }
+
+    #[test]
+    fn drop_privileges_fails_for_nonexistent_user() {
+        let policy = policy_with_process(ProcessPolicy {
+            run_as_user: Some("__nonexistent_test_user_42__".to_string()),
+            run_as_group: None,
+        });
+
+        let result = drop_privileges(&policy);
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("not found"),
+            "expected 'not found' in error: {msg}"
+        );
+    }
+
+    #[test]
+    fn drop_privileges_fails_for_nonexistent_group() {
+        let policy = policy_with_process(ProcessPolicy {
+            run_as_user: None,
+            run_as_group: Some("__nonexistent_test_group_42__".to_string()),
+        });
+
+        let result = drop_privileges(&policy);
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("not found"),
+            "expected 'not found' in error: {msg}"
+        );
     }
 }


### PR DESCRIPTION
> **🏗️ build-from-issue-agent**

Closes #32

## Summary
Add defense-in-depth post-condition checks in `drop_privileges()` to verify that `setgid()`/`setuid()` actually changed the effective IDs, and that root cannot be re-acquired after dropping privileges. This hardens the sandbox privilege-drop path per CWE-250 and CERT POS37-C.

## Changes Made
- `crates/navigator-sandbox/src/process.rs`: Added `getegid()` verification after `setgid()`, `geteuid()` verification after `setuid()`, and a `setuid(0)` re-acquisition guard. Added 5 unit tests for the `drop_privileges()` function.
- `architecture/security-policy.md`: Updated enforcement sequence to document the new verification steps (steps 3, 5, 6).
- `architecture/sandbox.md`: Updated `drop_privileges()` section to document the post-condition checks and their safety properties.

## Deviations from Plan
None — implemented as planned.

## Tests Added
- **Unit:** 5 tests in `process::tests` — covers no-op paths (no user/group, empty strings), current-user success path (exercises full verification), and error paths for nonexistent user/group.
- **Integration:** N/A
- **E2E:** N/A — existing sandbox E2E tests exercise the full pre_exec chain implicitly.

## Documentation Updated
- `architecture/security-policy.md` — enforcement sequence now includes verification steps
- `architecture/sandbox.md` — `drop_privileges()` description now documents post-condition checks

## Verification
- [x] Pre-commit checks passing (failures are pre-existing: `tmp/network_checks.py` license header, `navigator-cli` completer test)
- [ ] E2E tests (not applicable)
- [x] Architecture documentation updated