### PR TITLE
fix(cluster): add openssl package to cluster image

### DIFF
--- a/deploy/docker/Dockerfile.cluster
+++ b/deploy/docker/Dockerfile.cluster
@@ -18,6 +18,9 @@
 ARG K3S_VERSION=v1.29.8-k3s1
 FROM rancher/k3s:${K3S_VERSION}
 
+# Install openssl (used by entrypoint to generate SSH handshake secret)
+RUN apk add --no-cache openssl
+
 # Create directories for manifests, charts, and configuration
 RUN mkdir -p /var/lib/rancher/k3s/server/manifests \
              /var/lib/rancher/k3s/server/static/charts \


### PR DESCRIPTION
Closes #136

## Summary
- Adds `apk add --no-cache openssl` to `Dockerfile.cluster`
- The entrypoint script uses `openssl rand -hex 32` to generate the SSH handshake secret (added in #127 / c6919aa), but the `rancher/k3s` base image does not include `openssl`
- Without this, the container exits immediately with code 127 (`openssl: not found`)