### PR TITLE
fix(cluster): replace openssl with /dev/urandom in cluster image

### DIFF
--- a/deploy/docker/Dockerfile.cluster
+++ b/deploy/docker/Dockerfile.cluster
@@ -18,9 +18,6 @@
 ARG K3S_VERSION=v1.29.8-k3s1
 FROM rancher/k3s:${K3S_VERSION}
 
-# Install openssl (used by entrypoint to generate SSH handshake secret)
-RUN apk add --no-cache openssl
-
 # Create directories for manifests, charts, and configuration
 RUN mkdir -p /var/lib/rancher/k3s/server/manifests \
              /var/lib/rancher/k3s/server/static/charts \

--- a/deploy/docker/cluster-entrypoint.sh
+++ b/deploy/docker/cluster-entrypoint.sh
@@ -252,7 +252,7 @@ fi
 # Generate a random SSH handshake secret for the NSSH1 HMAC handshake between
 # the gateway and sandbox SSH servers. This is required — the server will refuse
 # to start without it.
-SSH_HANDSHAKE_SECRET="${SSH_HANDSHAKE_SECRET:-$(openssl rand -hex 32)}"
+SSH_HANDSHAKE_SECRET="${SSH_HANDSHAKE_SECRET:-$(head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \n')}"
 
 # Inject SSH gateway host/port into the HelmChart manifest so the navigator
 # server returns the correct address to CLI clients for SSH proxy CONNECT.


### PR DESCRIPTION
## Summary

- Removed `RUN apk add --no-cache openssl` from `Dockerfile.cluster` — the `rancher/k3s` base image is BusyBox-based with no package manager, so `apk` is not available
- Replaced `openssl rand -hex 32` in `cluster-entrypoint.sh` with `head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \n'`, which produces an identical 64-character hex string using only BusyBox builtins

## Test Plan

- Verified `mise run docker:build:cluster` succeeds (previously failed with `apk: not found`)
- Verified the `/dev/urandom` replacement produces correct 64-char hex output inside the k3s container