### PR TITLE
chore(cluster): upgrade k3s to v1.35.2 and remove K3S_VERSION from mise.toml

### DIFF
--- a/architecture/build-containers.md
+++ b/architecture/build-containers.md
@@ -99,7 +99,7 @@ A k3s image with bundled Helm charts and Kubernetes manifests for single-contain
 
 **Defined in** `deploy/docker/Dockerfile.cluster`.
 
-**Base image:** `rancher/k3s:v1.29.8-k3s1` (configurable via `K3S_VERSION` build arg).
+**Base image:** `rancher/k3s:v1.35.2-k3s1` (configurable via `K3S_VERSION` build arg).
 
 **Layers added:**
 
@@ -368,7 +368,7 @@ After building, the script:
 |---|---|---|
 | `IMAGE_TAG` | `dev` | Tag for built images |
 | `RUST_BUILD_PROFILE` | `debug` | `debug` or `release` for sandbox builds |
-| `K3S_VERSION` | `v1.29.8-k3s1` | k3s version for cluster image |
+| `K3S_VERSION` | `v1.35.2-k3s1` | k3s version for cluster image (optional override; default in Dockerfile.cluster) |
 
 | `CLUSTER_NAME` | basename of `$PWD` | Name for local cluster deployment |
 | `DOCKER_PLATFORM` | (unset) | Target platform for multi-arch builds (e.g., `linux/amd64`) |

--- a/architecture/cluster-single-node.md
+++ b/architecture/cluster-single-node.md
@@ -238,7 +238,7 @@ After deploy, the CLI calls `save_active_cluster(name)`, writing the cluster nam
 The cluster image is defined in `deploy/docker/Dockerfile.cluster`:
 
 ```
-Base:  rancher/k3s:v1.29.8-k3s1
+Base:  rancher/k3s:v1.35.2-k3s1
 ```
 
 Layers added:

--- a/architecture/system-architecture.md
+++ b/architecture/system-architecture.md
@@ -17,7 +17,7 @@ graph TB
     %% ============================================================
     subgraph Cluster["NemoClaw Cluster Container (Docker)"]
 
-        subgraph K3s["k3s (v1.29.8-k3s1)"]
+        subgraph K3s["k3s (v1.35.2-k3s1)"]
             KubeAPI["Kubernetes API<br/>:6443"]
             HelmController["Helm Controller"]
             LocalPathProv["local-path-provisioner"]

--- a/deploy/docker/Dockerfile.cluster
+++ b/deploy/docker/Dockerfile.cluster
@@ -15,7 +15,7 @@
 # The helm charts are built by the docker:build:cluster mise task
 # and placed in deploy/docker/.build/ before this Dockerfile is built.
 
-ARG K3S_VERSION=v1.34.5-k3s1
+ARG K3S_VERSION=v1.35.2-k3s1
 FROM rancher/k3s:${K3S_VERSION}
 
 # Create directories for manifests, charts, and configuration

--- a/mise.toml
+++ b/mise.toml
@@ -38,7 +38,6 @@ SCCACHE_DIR = "{{config_root}}/.cache/sccache"
 NAV_PYPI_REPOSITORY_URL = "https://urm.nvidia.com/artifactory/api/pypi/nv-shared-pypi-local"
 
 # Shared build constants (overridable via environment)
-K3S_VERSION = "{{env.K3S_VERSION | default(value='v1.34.5-k3s1')}}"
 DOCKER_BUILDKIT = "1"
 
 [vars]

--- a/tasks/scripts/docker-build-cluster.sh
+++ b/tasks/scripts/docker-build-cluster.sh
@@ -7,7 +7,7 @@
 #
 # Environment:
 #   IMAGE_TAG                - Image tag (default: dev)
-#   K3S_VERSION              - k3s version (set by mise.toml [env])
+#   K3S_VERSION              - k3s version override (optional; default in Dockerfile.cluster)
 
 #   DOCKER_PLATFORM          - Target platform (optional)
 #   DOCKER_BUILDER           - Buildx builder name (default: auto-select)
@@ -68,7 +68,7 @@ docker buildx build \
   ${CACHE_ARGS[@]+"${CACHE_ARGS[@]}"} \
   -f deploy/docker/Dockerfile.cluster \
   -t ${IMAGE_NAME}:${IMAGE_TAG} \
-  --build-arg K3S_VERSION=${K3S_VERSION} \
+  ${K3S_VERSION:+--build-arg K3S_VERSION=${K3S_VERSION}} \
   ${OUTPUT_FLAG} \
   .
 

--- a/tasks/scripts/docker-publish-multiarch.sh
+++ b/tasks/scripts/docker-publish-multiarch.sh
@@ -11,7 +11,7 @@
 #
 # Environment:
 #   IMAGE_TAG                - Image tag (default: dev)
-#   K3S_VERSION              - k3s version (set by mise.toml [env])
+#   K3S_VERSION              - k3s version override (optional; default in Dockerfile.cluster)
 
 #   DOCKER_PLATFORMS         - Target platforms (default: linux/amd64,linux/arm64)
 #   RUST_BUILD_PROFILE       - Rust build profile for sandbox (default: release)
@@ -197,7 +197,7 @@ docker buildx build \
   --platform "${PLATFORMS}" \
   -f deploy/docker/Dockerfile.cluster \
   -t "${CLUSTER_IMAGE}:${IMAGE_TAG}" \
-  --build-arg K3S_VERSION=${K3S_VERSION} \
+  ${K3S_VERSION:+--build-arg K3S_VERSION=${K3S_VERSION}} \
   ${EXTRA_BUILD_FLAGS} \
   --push \
   .


### PR DESCRIPTION
## Summary
- Upgrade k3s base image from v1.34.5-k3s1 to v1.35.2-k3s1 (latest stable)
- Remove `K3S_VERSION` env var from `mise.toml`, making `Dockerfile.cluster` ARG default the single source of truth
- Make build scripts pass `--build-arg K3S_VERSION` only when the env var is explicitly set, so the Dockerfile default applies by default
- Update architecture docs to reflect the new version