### PR TITLE
feat(cli): restructure CLI commands for simpler UX

### DIFF
--- a/.agents/skills/debug-navigator-cluster/SKILL.md
+++ b/.agents/skills/debug-navigator-cluster/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: debug-navigator-cluster
-description: Debug why a nemoclaw cluster failed to start or is unhealthy. Use when the user has a failed `nemoclaw cluster admin deploy`, cluster health check failure, or wants to diagnose cluster infrastructure issues. Trigger keywords - debug cluster, cluster failing, cluster not starting, deploy failed, cluster troubleshoot, cluster health, cluster diagnose, why won't my cluster start, health check failed.
+description: Debug why a nemoclaw cluster failed to start or is unhealthy. Use when the user has a failed `nemoclaw gateway start`, cluster health check failure, or wants to diagnose cluster infrastructure issues. Trigger keywords - debug cluster, cluster failing, cluster not starting, deploy failed, cluster troubleshoot, cluster health, cluster diagnose, why won't my cluster start, health check failed, gateway start failed, gateway not starting.
 ---
 
 # Debug NemoClaw Cluster
 
-Diagnose why a nemoclaw cluster failed to start after `nemoclaw cluster admin deploy`.
+Diagnose why a nemoclaw cluster failed to start after `nemoclaw gateway start`.
 
 ## Overview
 
-`nemoclaw cluster admin deploy` creates a Docker container running k3s with the NemoClaw server and Envoy Gateway deployed via Helm. The deployment stages, in order, are:
+`nemoclaw gateway start` creates a Docker container running k3s with the NemoClaw server and Envoy Gateway deployed via Helm. The deployment stages, in order, are:
 
-1. **Pre-deploy check**: `nemoclaw cluster admin deploy` in interactive mode prompts to **reuse** (keep volume, clean stale nodes) or **recreate** (destroy everything, fresh start). `mise run cluster` always recreates before deploy.
+1. **Pre-deploy check**: `nemoclaw gateway start` in interactive mode prompts to **reuse** (keep volume, clean stale nodes) or **recreate** (destroy everything, fresh start). `mise run cluster` always recreates before deploy.
 2. Ensure cluster image is available (local build or remote pull)
 3. Create Docker network (`navigator-cluster`) and volume (`navigator-cluster-{name}`)
 4. Create and start a privileged Docker container (`navigator-cluster-{name}`)
@@ -31,7 +31,7 @@ For local deploys, metadata endpoint selection now depends on Docker connectivit
 - default local Docker socket (`unix:///var/run/docker.sock`): `https://127.0.0.1:{port}` (default port 8080)
 - TCP Docker daemon (`DOCKER_HOST=tcp://<host>:<port>`): `https://<host>:{port}` for non-loopback hosts
 
-The host port is configurable via `--port` on `nemoclaw cluster admin deploy` (default 8080) and is stored in `ClusterMetadata.gateway_port`.
+The host port is configurable via `--port` on `nemoclaw gateway start` (default 8080) and is stored in `ClusterMetadata.gateway_port`.
 
 The TCP host is also added as an extra gateway TLS SAN so mTLS hostname validation succeeds.
 
@@ -302,7 +302,7 @@ If DNS is broken, all image pulls from the distribution registry will fail, as w
 | Helm install job failed | Chart values error or dependency issue | Check `helm-install-navigator` job logs in `kube-system` |
 | Architecture mismatch (remote) | Built on arm64, deploying to amd64 | Cross-build the image for the target architecture |
 | SSH connection failed (remote) | SSH key/host/Docker issues | Test `ssh <host> docker ps` manually |
-| Port conflict | Another service on 6443 or the configured gateway host port (default 8080) | Stop conflicting service or use `--port` to pick a different host port |
+| Port conflict | Another service on 6443 or the configured gateway host port (default 8080) | Stop conflicting service or use `--port` on `nemoclaw gateway start` to pick a different host port |
 | gRPC connect refused to `127.0.0.1:443` in CI | Docker daemon is remote (`DOCKER_HOST=tcp://...`) but metadata still points to loopback | Verify metadata endpoint host matches `DOCKER_HOST` and includes non-loopback host |
 | DNS failures inside container | Entrypoint DNS detection failed | Check `/etc/rancher/k3s/resolv.conf` and container startup logs |
 | `metrics-server` errors in logs | Normal k3s noise, not the root cause | These errors are benign — look for the actual failing health check component |
@@ -331,7 +331,7 @@ docker -H ssh://<host> logs navigator-cluster-<name>
 **Setting up kubectl access** (requires tunnel):
 
 ```bash
-nemoclaw cluster admin tunnel --name <name> --remote <host>
+nemoclaw gateway tunnel --name <name> --remote <host>
 # Then in another terminal:
 export KUBECONFIG=~/.config/nemoclaw/clusters/<name>/kubeconfig
 kubectl get pods -A

--- a/.agents/skills/nemoclaw-cli/SKILL.md
+++ b/.agents/skills/nemoclaw-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nemoclaw-cli
-description: Guide agents through using the NemoClaw CLI (nemoclaw) for sandbox management, provider configuration, policy iteration, BYOC workflows, and inference routing. Covers basic through advanced multi-step workflows. Trigger keywords - nemoclaw, sandbox create, sandbox connect, sandbox logs, provider create, policy set, policy get, image push, port forward, BYOC, bring your own container, use nemoclaw, run nemoclaw, CLI usage, manage sandbox, manage provider.
+description: Guide agents through using the NemoClaw CLI (nemoclaw) for sandbox management, provider configuration, policy iteration, BYOC workflows, and inference routing. Covers basic through advanced multi-step workflows. Trigger keywords - nemoclaw, sandbox create, sandbox connect, logs, provider create, policy set, policy get, image push, forward, port forward, BYOC, bring your own container, use nemoclaw, run nemoclaw, CLI usage, manage sandbox, manage provider, gateway start, gateway select.
 ---
 
 # NemoClaw CLI
@@ -9,7 +9,7 @@ Guide agents through using the `nemoclaw` CLI for sandbox and platform managemen
 
 ## Overview
 
-The NemoClaw CLI (`nemoclaw`) is the primary interface for managing sandboxes, providers, policies, inference routes, and clusters. This skill teaches agents how to orchestrate CLI commands for common and complex workflows.
+The NemoClaw CLI (`nemoclaw`) is the primary interface for managing sandboxes, providers, policies, inference routes, and gateways. This skill teaches agents how to orchestrate CLI commands for common and complex workflows.
 
 **Companion skill**: For creating or modifying sandbox policy YAML content (network rules, L7 inspection, access presets), use the `generate-sandbox-policy` skill. This skill covers the CLI *commands* for the policy lifecycle; `generate-sandbox-policy` covers policy *content authoring*.
 
@@ -26,7 +26,7 @@ This is your primary fallback. Use it freely -- the CLI's help output is authori
 ## Prerequisites
 
 - `nemoclaw` is on the PATH (install via `cargo install --path crates/navigator-cli`)
-- Docker is running (required for cluster operations and BYOC)
+- Docker is running (required for gateway operations and BYOC)
 - For remote clusters: SSH access to the target host
 
 ## Command Reference
@@ -42,21 +42,21 @@ Use this workflow when no cluster exists yet and the user wants to get a sandbox
 ### Step 1: Bootstrap a cluster
 
 ```bash
-nemoclaw cluster admin deploy
+nemoclaw gateway start
 ```
 
-This provisions a local k3s cluster in Docker. The CLI will prompt interactively if a cluster already exists. The cluster is automatically set as the active cluster.
+This provisions a local k3s cluster in Docker. The CLI will prompt interactively if a cluster already exists. The cluster is automatically set as the active gateway.
 
 For remote deployment:
 
 ```bash
-nemoclaw cluster admin deploy --remote user@host --ssh-key ~/.ssh/id_rsa
+nemoclaw gateway start --remote user@host --ssh-key ~/.ssh/id_rsa
 ```
 
 ### Step 2: Verify the cluster
 
 ```bash
-nemoclaw cluster status
+nemoclaw status
 ```
 
 Confirm the cluster is reachable and shows a version.
@@ -139,14 +139,14 @@ nemoclaw sandbox create \
   --provider my-github \
   --provider my-claude \
   --policy ./my-policy.yaml \
-  --sync \
+  --upload .:/sandbox \
   -- claude
 ```
 
 Key flags:
 - `--provider`: Attach one or more providers (repeatable)
 - `--policy`: Custom policy YAML (otherwise uses built-in default or `NEMOCLAW_SANDBOX_POLICY` env var)
-- `--sync`: Push local git-tracked files to `/sandbox` in the container
+- `--upload <PATH>[:<DEST>]`: Upload local files into the sandbox (default dest: `/sandbox`)
 - `--keep`: Keep sandbox alive after the command exits (useful for non-interactive commands)
 - `--forward <PORT>`: Forward a local port (implies `--keep`)
 
@@ -169,30 +169,30 @@ Opens an interactive SSH shell. To configure VS Code Remote-SSH:
 nemoclaw sandbox ssh-config my-sandbox >> ~/.ssh/config
 ```
 
-### Sync files
+### Upload and download files
 
 ```bash
-# Push local files to sandbox
-nemoclaw sandbox sync my-sandbox --up ./src /sandbox/src
+# Upload local files to sandbox
+nemoclaw sandbox upload my-sandbox ./src /sandbox/src
 
-# Pull files from sandbox
-nemoclaw sandbox sync my-sandbox --down /sandbox/output ./local-output
+# Download files from sandbox
+nemoclaw sandbox download my-sandbox /sandbox/output ./local-output
 ```
 
 ### View logs
 
 ```bash
 # Recent logs
-nemoclaw sandbox logs my-sandbox
+nemoclaw logs my-sandbox
 
 # Stream live logs
-nemoclaw sandbox logs my-sandbox --tail
+nemoclaw logs my-sandbox --tail
 
 # Filter by source and level
-nemoclaw sandbox logs my-sandbox --tail --source sandbox --level warn
+nemoclaw logs my-sandbox --tail --source sandbox --level warn
 
 # Logs from the last 5 minutes
-nemoclaw sandbox logs my-sandbox --since 5m
+nemoclaw logs my-sandbox --since 5m
 ```
 
 ### Delete sandboxes
@@ -246,7 +246,7 @@ Use `--keep` so the sandbox stays alive for iteration. The user can work in the 
 In a separate terminal or as the agent:
 
 ```bash
-nemoclaw sandbox logs dev --tail --source sandbox
+nemoclaw logs dev --tail --source sandbox
 ```
 
 Look for log lines with `action: deny` -- these indicate blocked network requests. The logs include:
@@ -257,7 +257,7 @@ Look for log lines with `action: deny` -- these indicate blocked network request
 ### Step 3: Pull the current policy
 
 ```bash
-nemoclaw sandbox policy get dev --full > current-policy.yaml
+nemoclaw policy get dev --full > current-policy.yaml
 ```
 
 The `--full` flag outputs valid YAML that can be directly re-submitted. This is the round-trip format.
@@ -277,7 +277,7 @@ Only `network_policies` and `inference` sections can be modified at runtime. If 
 ### Step 5: Push the updated policy
 
 ```bash
-nemoclaw sandbox policy set dev --policy current-policy.yaml --wait
+nemoclaw policy set dev --policy current-policy.yaml --wait
 ```
 
 The `--wait` flag blocks until the sandbox confirms the policy is loaded (polls every second). Exit codes:
@@ -288,7 +288,7 @@ The `--wait` flag blocks until the sandbox confirms the policy is loaded (polls 
 ### Step 6: Verify the update
 
 ```bash
-nemoclaw sandbox policy list dev
+nemoclaw policy list dev
 ```
 
 Check that the latest revision shows status `loaded`. If `failed`, check the error column for details.
@@ -302,13 +302,13 @@ Return to Step 2. Continue monitoring logs and refining the policy until all req
 View all revisions to understand how the policy evolved:
 
 ```bash
-nemoclaw sandbox policy list dev --limit 50
+nemoclaw policy list dev --limit 50
 ```
 
 Fetch a specific historical revision:
 
 ```bash
-nemoclaw sandbox policy get dev --rev 3 --full
+nemoclaw policy get dev --rev 3 --full
 ```
 
 ---
@@ -335,10 +335,10 @@ When `--from` is specified, the CLI:
 
 ```bash
 # Foreground (blocks)
-nemoclaw sandbox forward start 8080 my-app
+nemoclaw forward start 8080 my-app
 
 # Background (returns immediately)
-nemoclaw sandbox forward start 8080 my-app -d
+nemoclaw forward start 8080 my-app -d
 ```
 
 The service is now reachable at `localhost:8080`.
@@ -347,10 +347,10 @@ The service is now reachable at `localhost:8080`.
 
 ```bash
 # List active forwards
-nemoclaw sandbox forward list
+nemoclaw forward list
 
 # Stop a forward
-nemoclaw sandbox forward stop 8080 my-app
+nemoclaw forward stop 8080 my-app
 ```
 
 ### Step 4: Iterate
@@ -412,7 +412,7 @@ nemoclaw sandbox ssh-config work-session >> ~/.ssh/config
 While the user works, monitor the sandbox logs:
 
 ```bash
-nemoclaw sandbox logs work-session --tail --source sandbox --level warn
+nemoclaw logs work-session --tail --source sandbox --level warn
 ```
 
 Watch for `deny` actions that indicate the user's work is being blocked by policy.
@@ -421,10 +421,10 @@ Watch for `deny` actions that indicate the user's work is being blocked by polic
 
 When denied actions are observed:
 
-1. Pull current policy: `nemoclaw sandbox policy get work-session --full > policy.yaml`
+1. Pull current policy: `nemoclaw policy get work-session --full > policy.yaml`
 2. Modify the policy to allow the blocked actions (use `generate-sandbox-policy` skill for content)
-3. Push the update: `nemoclaw sandbox policy set work-session --policy policy.yaml --wait`
-4. Verify: `nemoclaw sandbox policy list work-session`
+3. Push the update: `nemoclaw policy set work-session --policy policy.yaml --wait`
+4. Verify: `nemoclaw policy list work-session`
 
 The user does not need to disconnect -- policy updates are hot-reloaded within ~30 seconds (or immediately when using `--wait`, which polls for confirmation).
 
@@ -472,36 +472,36 @@ nemoclaw cluster inference get
 
 ---
 
-## Workflow 8: Cluster Management
+## Workflow 8: Gateway Management
 
-### List and switch clusters
+### List and switch gateways
 
 ```bash
-nemoclaw cluster list              # See all clusters
-nemoclaw cluster use my-cluster    # Switch active cluster
-nemoclaw cluster status            # Verify connectivity
+nemoclaw gateway select            # See all gateways (no args shows list)
+nemoclaw gateway select my-cluster # Switch active gateway
+nemoclaw status                    # Verify connectivity
 ```
 
 ### Lifecycle
 
 ```bash
-nemoclaw cluster admin deploy                          # Start local cluster
-nemoclaw cluster admin stop                            # Stop (preserves state)
-nemoclaw cluster admin deploy                          # Restart (reuses state)
-nemoclaw cluster admin destroy                         # Destroy permanently
+nemoclaw gateway start                                 # Start local cluster
+nemoclaw gateway stop                                  # Stop (preserves state)
+nemoclaw gateway start                                 # Restart (reuses state)
+nemoclaw gateway destroy                               # Destroy permanently
 ```
 
 ### Remote clusters
 
 ```bash
 # Deploy to remote host
-nemoclaw cluster admin deploy --remote user@host --ssh-key ~/.ssh/id_rsa --name remote-cluster
+nemoclaw gateway start --remote user@host --ssh-key ~/.ssh/id_rsa --name remote-cluster
 
 # Set up kubectl access
-nemoclaw cluster admin tunnel --name remote-cluster
+nemoclaw gateway tunnel --name remote-cluster
 
 # Get cluster info
-nemoclaw cluster admin info --name remote-cluster
+nemoclaw gateway info --name remote-cluster
 ```
 
 ---
@@ -520,10 +520,10 @@ The CLI help is always authoritative. If the help output contradicts this skill,
 
 ```bash
 $ nemoclaw sandbox --help
-# Shows: create, get, list, delete, connect, sync, logs, ssh-config, forward, image, policy
+# Shows: create, get, list, delete, connect, upload, download, ssh-config, image
 
-$ nemoclaw sandbox sync --help
-# Shows: --up, --down flags, positional arguments, usage examples
+$ nemoclaw sandbox upload --help
+# Shows: positional arguments (name, path, dest), usage examples
 ```
 
 ---
@@ -532,24 +532,27 @@ $ nemoclaw sandbox sync --help
 
 | Task | Command |
 |------|---------|
-| Deploy local cluster | `nemoclaw cluster admin deploy` |
-| Check cluster health | `nemoclaw cluster status` |
+| Deploy local cluster | `nemoclaw gateway start` |
+| Check cluster health | `nemoclaw status` |
+| List/switch gateways | `nemoclaw gateway select [name]` |
 | Create sandbox (interactive) | `nemoclaw sandbox create` |
 | Create sandbox with tool | `nemoclaw sandbox create -- claude` |
 | Create with custom policy | `nemoclaw sandbox create --policy ./p.yaml --keep` |
 | Connect to sandbox | `nemoclaw sandbox connect <name>` |
-| Stream live logs | `nemoclaw sandbox logs <name> --tail` |
-| Pull current policy | `nemoclaw sandbox policy get <name> --full > p.yaml` |
-| Push updated policy | `nemoclaw sandbox policy set <name> --policy p.yaml --wait` |
-| Policy revision history | `nemoclaw sandbox policy list <name>` |
+| Stream live logs | `nemoclaw logs <name> --tail` |
+| Pull current policy | `nemoclaw policy get <name> --full > p.yaml` |
+| Push updated policy | `nemoclaw policy set <name> --policy p.yaml --wait` |
+| Policy revision history | `nemoclaw policy list <name>` |
 | Create sandbox from Dockerfile | `nemoclaw sandbox create --from ./Dockerfile --keep` |
-| Forward a port | `nemoclaw sandbox forward start <port> <name> -d` |
+| Forward a port | `nemoclaw forward start <port> <name> -d` |
+| Upload files to sandbox | `nemoclaw sandbox upload <name> <path>` |
+| Download files from sandbox | `nemoclaw sandbox download <name> <path>` |
 | Create provider | `nemoclaw provider create --name N --type T --from-existing` |
 | List providers | `nemoclaw provider list` |
 | Configure cluster inference | `nemoclaw cluster inference set --provider P --model M` |
 | View cluster inference | `nemoclaw cluster inference get` |
 | Delete sandbox | `nemoclaw sandbox delete <name>` |
-| Destroy cluster | `nemoclaw cluster admin destroy` |
+| Destroy cluster | `nemoclaw gateway destroy` |
 | Self-teach any command | `nemoclaw <group> <cmd> --help` |
 
 ## Companion Skills

--- a/.agents/skills/nemoclaw-cli/cli-reference.md
+++ b/.agents/skills/nemoclaw-cli/cli-reference.md
@@ -9,7 +9,7 @@ Quick-reference for the `nemoclaw` command-line interface. For workflow guidance
 | Flag | Description |
 |------|-------------|
 | `-v`, `--verbose` | Increase verbosity (`-v` = info, `-vv` = debug, `-vvv` = trace) |
-| `-c`, `--cluster <NAME>` | Cluster to operate on. Also settable via `NEMOCLAW_CLUSTER` env var. Falls back to active cluster in `~/.config/nemoclaw/active_cluster`. |
+| `-c`, `--gateway <NAME>` | Gateway to operate on. Also settable via `NEMOCLAW_CLUSTER` env var. Falls back to active gateway in `~/.config/nemoclaw/active_cluster`. |
 
 ## Environment Variables
 
@@ -24,39 +24,38 @@ Quick-reference for the `nemoclaw` command-line interface. For workflow guidance
 
 ```
 nemoclaw
-├── cluster
-│   ├── status
-│   ├── use <name>
-│   ├── list
-│   ├── inference
-│   │   ├── set --provider --model
-│   │   ├── update [--provider] [--model]
-│   │   └── get
-│   └── admin
-│       ├── deploy [opts]
-│       ├── stop [opts]
-│       ├── destroy [opts]
-│       ├── info [--name]
-│       └── tunnel [opts]
+├── gateway
+│   ├── start [opts]
+│   ├── stop [opts]
+│   ├── destroy [opts]
+│   ├── info [--name]
+│   ├── tunnel [opts]
+│   └── select [name]
+├── status
+├── inference
+│   ├── set --provider --model
+│   ├── update [--provider] [--model]
+│   └── get
 ├── sandbox
 │   ├── create [opts] [-- CMD...]
 │   ├── get <name>
 │   ├── list [opts]
 │   ├── delete <name>...
 │   ├── connect <name>
-│   ├── sync <name> {--up|--down} <path> [dest]
-│   ├── logs <name> [opts]
+│   ├── upload <name> <path> [dest]
+│   ├── download <name> <path> [dest]
 │   ├── ssh-config <name>
-│   ├── forward
-│   │   ├── start <port> <name> [-d]
-│   │   ├── stop <port> <name>
-│   │   └── list
-│   ├── image
-│   │   └── push [opts]
-│   └── policy
-│       ├── set <name> --policy <path> [--wait]
-│       ├── get <name> [--full]
-│       └── list <name>
+│   └── image
+│       └── push [opts]
+├── forward
+│   ├── start <port> <name> [-d]
+│   ├── stop <port> <name>
+│   └── list
+├── logs <name> [opts]
+├── policy
+│   ├── set <name> --policy <path> [--wait]
+│   ├── get <name> [--full]
+│   └── list <name>
 ├── provider
 │   ├── create --name --type [opts]
 │   ├── get <name>
@@ -70,21 +69,9 @@ nemoclaw
 
 ---
 
-## Cluster Commands
+## Gateway Commands
 
-### `nemoclaw cluster status`
-
-Show server connectivity and version.
-
-### `nemoclaw cluster use <name>`
-
-Set the active cluster. Writes to `~/.config/nemoclaw/active_cluster`.
-
-### `nemoclaw cluster list`
-
-List all provisioned clusters. Active cluster marked with `*`.
-
-### `nemoclaw cluster admin deploy`
+### `nemoclaw gateway start`
 
 Provision or start a cluster (local or remote).
 
@@ -98,8 +85,9 @@ Provision or start a cluster (local or remote).
 | `--kube-port [PORT]` | none | Expose K8s control plane on host port |
 | `--update-kube-config` | false | Write kubeconfig into `~/.kube/config` |
 | `--get-kubeconfig` | false | Print kubeconfig to stdout |
+| `--recreate` | false | Destroy and recreate from scratch if a gateway already exists (skips interactive prompt) |
 
-### `nemoclaw cluster admin stop`
+### `nemoclaw gateway stop`
 
 Stop a cluster (preserves state for later restart).
 
@@ -109,11 +97,11 @@ Stop a cluster (preserves state for later restart).
 | `--remote <USER@HOST>` | SSH destination |
 | `--ssh-key <PATH>` | SSH private key |
 
-### `nemoclaw cluster admin destroy`
+### `nemoclaw gateway destroy`
 
 Destroy a cluster and all its state. Same flags as `stop`.
 
-### `nemoclaw cluster admin info`
+### `nemoclaw gateway info`
 
 Show deployment details: endpoint, kubeconfig path, kube port, remote host.
 
@@ -121,7 +109,7 @@ Show deployment details: endpoint, kubeconfig path, kube port, remote host.
 |------|-------------|
 | `--name <NAME>` | Cluster name (defaults to active) |
 
-### `nemoclaw cluster admin tunnel`
+### `nemoclaw gateway tunnel`
 
 Print or start an SSH tunnel for kubectl access to a remote cluster.
 
@@ -131,6 +119,18 @@ Print or start an SSH tunnel for kubectl access to a remote cluster.
 | `--remote <USER@HOST>` | SSH destination |
 | `--ssh-key <PATH>` | SSH private key |
 | `--print-command` | Only print the SSH command, don't execute |
+
+### `nemoclaw gateway select [name]`
+
+Set the active gateway. Writes to `~/.config/nemoclaw/active_cluster`. When called without arguments, lists all provisioned gateways with the active one marked with `*`.
+
+---
+
+## Status Command
+
+### `nemoclaw status`
+
+Show server connectivity and version for the active gateway.
 
 ---
 
@@ -144,7 +144,7 @@ Create a sandbox, wait for readiness, then connect or execute the trailing comma
 |------|-------------|
 | `--name <NAME>` | Sandbox name (auto-generated if omitted) |
 | `--from <SOURCE>` | Sandbox source: community name, Dockerfile path, directory, or image reference (BYOC) |
-| `--sync` | Sync local git-tracked files into sandbox at `/sandbox` |
+| `--upload <PATH>[:<DEST>]` | Upload local files into sandbox (default dest: `/sandbox`) |
 | `--keep` | Keep sandbox alive after non-interactive commands finish |
 | `--provider <NAME>` | Provider to attach (repeatable) |
 | `--policy <PATH>` | Path to custom policy YAML |
@@ -153,6 +153,10 @@ Create a sandbox, wait for readiness, then connect or execute the trailing comma
 | `--ssh-key <PATH>` | SSH private key for auto-bootstrap |
 | `--tty` | Force pseudo-terminal allocation |
 | `--no-tty` | Disable pseudo-terminal allocation |
+| `--bootstrap` | Auto-bootstrap a gateway if none is available (skips interactive prompt) |
+| `--no-bootstrap` | Never auto-bootstrap; error immediately if no gateway is available |
+| `--auto-providers` | Auto-create missing providers from local credentials (skips interactive prompt) |
+| `--no-auto-providers` | Never auto-create providers; skip missing providers silently |
 | `[-- COMMAND...]` | Command to execute (defaults to interactive shell) |
 
 ### `nemoclaw sandbox get <name>`
@@ -178,17 +182,57 @@ Delete one or more sandboxes by name. Stops any background port forwards.
 
 Open an interactive SSH shell to a sandbox.
 
-### `nemoclaw sandbox sync <name> {--up <path> | --down <path>} [dest]`
+### `nemoclaw sandbox upload <name> <path> [dest]`
 
-Sync files to/from a sandbox using tar-over-SSH.
+Upload local files to a sandbox using tar-over-SSH.
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `<name>` | -- | Sandbox name (required) |
+| `<path>` | -- | Local path to upload (required) |
+| `[dest]` | `/sandbox` | Destination path in sandbox |
+
+### `nemoclaw sandbox download <name> <path> [dest]`
+
+Download files from a sandbox using tar-over-SSH.
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `<name>` | -- | Sandbox name (required) |
+| `<path>` | -- | Sandbox path to download (required) |
+| `[dest]` | `.` | Local destination path |
+
+### `nemoclaw sandbox ssh-config <name>`
+
+Print an SSH config `Host` block for a sandbox. Useful for VS Code Remote-SSH.
+
+---
+
+## Port Forwarding Commands
+
+### `nemoclaw forward start <port> <name>`
+
+Start forwarding a local port to a sandbox.
 
 | Flag | Description |
 |------|-------------|
-| `--up <LOCAL_PATH>` | Push local files to sandbox |
-| `--down <SANDBOX_PATH>` | Pull sandbox files to local |
-| `[DEST]` | Destination path (default: `/sandbox` for up, `.` for down) |
+| `<port>` | Port number (used as both local and remote) |
+| `<name>` | Sandbox name |
+| `-d`, `--background` | Run in background |
 
-### `nemoclaw sandbox logs <name>`
+### `nemoclaw forward stop <port> <name>`
+
+Stop a background port forward.
+
+### `nemoclaw forward list`
+
+List all active port forwards (sandbox, port, PID, status).
+
+---
+
+## Logs Command
+
+### `nemoclaw logs <name>`
 
 View sandbox logs. Supports one-shot and streaming.
 
@@ -200,37 +244,11 @@ View sandbox logs. Supports one-shot and streaming.
 | `--source <SOURCE>` | `all` | Filter: `gateway`, `sandbox`, or `all` (repeatable) |
 | `--level <LEVEL>` | none | Minimum level: `error`, `warn`, `info`, `debug`, `trace` |
 
-### `nemoclaw sandbox ssh-config <name>`
-
-Print an SSH config `Host` block for a sandbox. Useful for VS Code Remote-SSH.
-
----
-
-## Port Forwarding Commands
-
-### `nemoclaw sandbox forward start <port> <name>`
-
-Start forwarding a local port to a sandbox.
-
-| Flag | Description |
-|------|-------------|
-| `<port>` | Port number (used as both local and remote) |
-| `<name>` | Sandbox name |
-| `-d`, `--background` | Run in background |
-
-### `nemoclaw sandbox forward stop <port> <name>`
-
-Stop a background port forward.
-
-### `nemoclaw sandbox forward list`
-
-List all active port forwards (sandbox, port, PID, status).
-
 ---
 
 ## Policy Commands
 
-### `nemoclaw sandbox policy set <name> --policy <PATH>`
+### `nemoclaw policy set <name> --policy <PATH>`
 
 Update the policy on a live sandbox. Only dynamic fields (`network_policies`, `inference`) can be changed at runtime.
 
@@ -242,7 +260,7 @@ Update the policy on a live sandbox. Only dynamic fields (`network_policies`, `i
 
 Exit codes with `--wait`: 0 = loaded, 1 = failed, 124 = timeout.
 
-### `nemoclaw sandbox policy get <name>`
+### `nemoclaw policy get <name>`
 
 Show current active policy for a sandbox.
 
@@ -251,7 +269,7 @@ Show current active policy for a sandbox.
 | `--rev <VERSION>` | 0 (latest) | Show a specific revision |
 | `--full` | false | Print the full policy as YAML (round-trips with `--policy` input) |
 
-### `nemoclaw sandbox policy list <name>`
+### `nemoclaw policy list <name>`
 
 List policy revision history (version, hash, status, created, error).
 

--- a/.agents/skills/tui-development/SKILL.md
+++ b/.agents/skills/tui-development/SKILL.md
@@ -9,7 +9,7 @@ Comprehensive reference for any agent working on the NemoClaw TUI.
 
 ## 1. Overview
 
-The NemoClaw TUI is a ratatui-based terminal UI for the NemoClaw platform. It provides a keyboard-driven interface for managing clusters, sandboxes, and logs — the same operations available via the `nemoclaw` CLI, but with a live, interactive dashboard.
+The NemoClaw TUI is a ratatui-based terminal UI for the NemoClaw platform. It provides a keyboard-driven interface for managing gateways, sandboxes, and logs — the same operations available via the `nemoclaw` CLI, but with a live, interactive dashboard.
 
 - **Launched via:** `nemoclaw term` or `mise run term`
 - **Crate:** `crates/navigator-tui/`
@@ -231,8 +231,8 @@ TUI actions should parallel `nemoclaw` CLI commands so users have familiar menta
 | --- | --- |
 | `nemoclaw sandbox list` | Sandbox table on Dashboard |
 | `nemoclaw sandbox delete <name>` | `[d]` on sandbox detail, then `[y]` to confirm |
-| `nemoclaw sandbox logs <name>` | `[l]` on sandbox detail to open log viewer |
-| `nemoclaw cluster health` | Status in title bar + cluster list |
+| `nemoclaw logs <name>` | `[l]` on sandbox detail to open log viewer |
+| `nemoclaw status` | Status in title bar + cluster list |
 
 When adding new TUI features, check what the CLI offers and maintain consistency.
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ For additional sandbox images see the [NVIDIA/NemoClaw-Community](https://github
 To deploy a cluster explicitly:
 
 ```bash
-nemoclaw cluster admin deploy
+nemoclaw gateway start
 ```
 
 For remote deployment:
 
 ```bash
-nemoclaw cluster admin deploy --remote user@host
+nemoclaw gateway start --remote user@host
 ```
 
 ### Upgrading
@@ -69,7 +69,7 @@ nemoclaw cluster admin deploy --remote user@host
 To upgrade, redeploy your cluster to pick up the latest server and sandbox images:
 
 ```bash
-nemoclaw cluster admin deploy
+nemoclaw gateway start
 ```
 
 This will prompt you to recreate the cluster. Select "yes" to recreate the cluster.

--- a/architecture/README.md
+++ b/architecture/README.md
@@ -232,12 +232,13 @@ For more detail, see [Policy Language](security-policy.md).
 
 The CLI is the primary way users interact with the platform. It provides commands organized into four groups:
 
-- **Cluster management** (`nemoclaw cluster`): Deploy, stop, destroy, and inspect clusters. Supports both local and remote (SSH) targets. Includes a tunnel command for accessing the Kubernetes API on remote clusters.
-- **Sandbox management** (`nemoclaw sandbox`): Create sandboxes (with optional file sync and provider auto-discovery), list running sandboxes, connect to sandboxes via SSH, and delete sandboxes.
+- **Gateway management** (`nemoclaw gateway`): Deploy, stop, destroy, and inspect clusters. Supports both local and remote (SSH) targets. Includes a tunnel command for accessing the Kubernetes API on remote clusters.
+- **Sandbox management** (`nemoclaw sandbox`): Create sandboxes (with optional file upload and provider auto-discovery), connect to sandboxes via SSH, and delete sandboxes.
+- **Top-level commands**: `nemoclaw status` (cluster health), `nemoclaw logs` (sandbox logs), `nemoclaw forward` (port forwarding), `nemoclaw policy` (sandbox policy management).
 - **Provider management** (`nemoclaw provider`): Create, update, list, and delete external service credentials.
 - **Inference management** (`nemoclaw cluster inference`): Configure cluster-level inference by specifying a provider and model. The gateway resolves endpoint and credential details from the named provider record.
 
-The CLI resolves which cluster to operate on through a priority chain: explicit `--cluster` flag, then the `NEMOCLAW_CLUSTER` environment variable, then the active cluster set by `nemoclaw cluster use`. It supports TLS client certificates for mutual authentication with the gateway.
+The CLI resolves which cluster to operate on through a priority chain: explicit `--gateway` flag, then the `NEMOCLAW_CLUSTER` environment variable, then the active cluster set by `nemoclaw gateway select`. It supports TLS client certificates for mutual authentication with the gateway.
 
 ## How Users Get Started
 

--- a/architecture/build-containers.md
+++ b/architecture/build-containers.md
@@ -360,7 +360,7 @@ After building, the script:
 1. Resolves the local registry address (defaults to `127.0.0.1:5000/navigator`). In CI, uses `$CI_REGISTRY_IMAGE`.
 2. Ensures a local Docker registry container (`navigator-local-registry`) is running on port 5000 (creates one if needed).
 3. Pushes prebuilt local component images (server, sandbox) to the local registry via `cluster-push-component.sh`.
-4. Runs `nav cluster admin deploy --name <CLUSTER_NAME> --update-kube-config` to create or update the cluster container.
+4. Runs `nav gateway start --name <CLUSTER_NAME> --update-kube-config` to create or update the cluster container.
 
 ### Environment Variables
 

--- a/architecture/cluster-single-node.md
+++ b/architecture/cluster-single-node.md
@@ -18,7 +18,7 @@ Out of scope:
 ## Components
 
 - `crates/navigator-cli/src/main.rs`: CLI entry point; `clap`-based command parsing.
-- `crates/navigator-cli/src/run.rs`: CLI command implementations (`cluster_admin_deploy`, `cluster_admin_stop`, `cluster_admin_destroy`, `cluster_admin_info`, `cluster_admin_tunnel`).
+- `crates/navigator-cli/src/run.rs`: CLI command implementations (`gateway_start`, `gateway_stop`, `gateway_destroy`, `gateway_info`, `gateway_tunnel`).
 - `crates/navigator-cli/src/bootstrap.rs`: Auto-bootstrap helpers for `sandbox create` (offers to deploy a cluster when one is unreachable).
 - `crates/navigator-bootstrap/src/lib.rs`: Cluster lifecycle orchestration (`deploy_cluster`, `deploy_cluster_with_logs`, `cluster_handle`, `check_existing_deployment`).
 - `crates/navigator-bootstrap/src/docker.rs`: Docker API wrappers (network, volume, container, image operations).
@@ -39,20 +39,20 @@ Out of scope:
 
 ## CLI Commands
 
-All cluster lifecycle commands live under `nemoclaw cluster admin`:
+All cluster lifecycle commands live under `nemoclaw gateway`:
 
 | Command | Description |
 |---|---|
-| `nemoclaw cluster admin deploy [--name NAME] [--remote user@host] [--ssh-key PATH]` | Provision or update a cluster |
-| `nemoclaw cluster admin stop [--name NAME] [--remote user@host]` | Stop the container (preserves state) |
-| `nemoclaw cluster admin destroy [--name NAME] [--remote user@host]` | Destroy container, attached volumes, kubeconfig directory, metadata, and network |
-| `nemoclaw cluster admin info [--name NAME]` | Show deployment details (endpoint, kubeconfig path, SSH host) |
-| `nemoclaw cluster admin tunnel [--name NAME] [--remote user@host] [--print-command]` | Start or print SSH tunnel for kubectl access |
-| `nemoclaw cluster status` | Show gateway health via gRPC/HTTP |
-| `nemoclaw cluster use <name>` | Set the active cluster |
-| `nemoclaw cluster list` | List all clusters with metadata |
+| `nemoclaw gateway start [--name NAME] [--remote user@host] [--ssh-key PATH]` | Provision or update a cluster |
+| `nemoclaw gateway stop [--name NAME] [--remote user@host]` | Stop the container (preserves state) |
+| `nemoclaw gateway destroy [--name NAME] [--remote user@host]` | Destroy container, attached volumes, kubeconfig directory, metadata, and network |
+| `nemoclaw gateway info [--name NAME]` | Show deployment details (endpoint, kubeconfig path, SSH host) |
+| `nemoclaw gateway tunnel [--name NAME] [--remote user@host] [--print-command]` | Start or print SSH tunnel for kubectl access |
+| `nemoclaw status` | Show gateway health via gRPC/HTTP |
+| `nemoclaw gateway select <name>` | Set the active cluster |
+| `nemoclaw gateway select` | List all clusters with metadata |
 
-The `--name` flag defaults to `"nemoclaw"`. When omitted on commands that accept it, the CLI resolves the active cluster via: `--cluster` flag, then `NEMOCLAW_CLUSTER` env, then `~/.config/nemoclaw/active_cluster` file.
+The `--name` flag defaults to `"nemoclaw"`. When omitted on commands that accept it, the CLI resolves the active cluster via: `--gateway` flag, then `NEMOCLAW_CLUSTER` env, then `~/.config/nemoclaw/active_cluster` file.
 
 ## Local Task Flows (`mise`)
 
@@ -76,7 +76,7 @@ sequenceDiagram
   participant L as Local Docker daemon
   participant R as Remote Docker daemon (SSH)
 
-  U->>C: nemoclaw cluster admin deploy --remote user@host
+  U->>C: nemoclaw gateway start --remote user@host
   C->>B: deploy_cluster(DeployOptions)
 
   B->>B: create_ssh_docker_client (ssh://, 600s timeout)
@@ -149,7 +149,7 @@ flowchart LR
 
 The `deploy_cluster_with_logs` variant accepts an `FnMut(String)` callback for progress reporting. The CLI wraps this in a `ClusterDeployLogPanel` for interactive terminals.
 
-**Pre-deploy check** (CLI layer in `cluster_admin_deploy`): In interactive terminals, `check_existing_deployment` inspects whether a container or volume already exists. If found, the user is prompted to destroy and recreate or reuse the existing cluster.
+**Pre-deploy check** (CLI layer in `gateway_start`): In interactive terminals, `check_existing_deployment` inspects whether a container or volume already exists. If found, the user is prompted to destroy and recreate or reuse the existing cluster.
 
 ### 2) Image readiness
 
@@ -231,7 +231,7 @@ Metadata location: `~/.config/nemoclaw/clusters/{name}_metadata.json`
 
 Note: metadata is stored at the `clusters/` level (not nested inside `{name}/` like kubeconfig and mTLS).
 
-After deploy, the CLI calls `save_active_cluster(name)`, writing the cluster name to `~/.config/nemoclaw/active_cluster`. Subsequent commands that don't specify `--cluster` or `NEMOCLAW_CLUSTER` resolve to this active cluster.
+After deploy, the CLI calls `save_active_cluster(name)`, writing the cluster name to `~/.config/nemoclaw/active_cluster`. Subsequent commands that don't specify `--gateway` or `NEMOCLAW_CLUSTER` resolve to this active cluster.
 
 ## Container Image
 
@@ -328,7 +328,7 @@ ssh -L 6443:127.0.0.1:6443 -N user@host
 CLI helper:
 
 ```bash
-nemoclaw cluster admin tunnel --name <name>
+nemoclaw gateway tunnel --name <name>
 ```
 
 The `--remote` flag is optional; the CLI resolves the SSH destination from stored cluster metadata. Pass `--print-command` to print the SSH command without executing it.
@@ -355,7 +355,7 @@ The `--remote` flag is optional; the CLI resolves the SSH destination from store
 4. Remove the stored kubeconfig file.
 5. Remove the network if no containers remain attached (`cleanup_network_if_unused()`).
 
-**CLI layer** (`cluster_admin_destroy()` in `run.rs` additionally):
+**CLI layer** (`gateway_destroy()` in `run.rs` additionally):
 
 6. Remove the metadata JSON file via `remove_cluster_metadata()`.
 7. Clear the active cluster reference if it matches the destroyed cluster.

--- a/architecture/sandbox-connect.md
+++ b/architecture/sandbox-connect.md
@@ -6,7 +6,7 @@ Sandbox connect provides secure remote access into running sandbox environments.
 
 1. **Interactive shell** (`sandbox connect`) -- opens a PTY-backed SSH session for interactive use
 2. **Command execution** (`sandbox create -- <cmd>`) -- runs a command over SSH with stdout/stderr piped back
-3. **File sync** (`sandbox create --sync`) -- rsyncs local files into the sandbox before command execution
+3. **File sync** (`sandbox create --upload`) -- uploads local files into the sandbox before command execution
 
 All three modes tunnel SSH traffic through the gateway's multiplexed port using HTTP CONNECT. The gateway authenticates each connection with a short-lived session token, then performs a custom NSSH1 handshake with the sandbox's embedded SSH daemon before bridging raw bytes between client and sandbox.
 
@@ -150,9 +150,9 @@ The `sandbox exec` path is identical to interactive connect except:
 - The command string is passed as the final SSH argument
 - The sandbox daemon routes it through `exec_request()` instead of `shell_request()`, spawning `/bin/bash -lc <command>`
 
-### Port Forwarding (`sandbox forward start`)
+### Port Forwarding (`forward start`)
 
-`nemoclaw sandbox forward start <port> <name>` opens a local SSH tunnel so connections to `127.0.0.1:<port>`
+`nemoclaw forward start <port> <name>` opens a local SSH tunnel so connections to `127.0.0.1:<port>`
 on the host are forwarded to `127.0.0.1:<port>` inside the sandbox.
 
 #### CLI
@@ -162,9 +162,9 @@ on the host are forwarded to `127.0.0.1:<port>` inside the sandbox.
 - By default stays attached in foreground until interrupted (Ctrl+C).
 - With `-d`/`--background`, SSH forks after auth and the CLI exits. The PID is
   tracked in `~/.config/nemoclaw/forwards/<name>-<port>.pid` along with sandbox id metadata.
-- `nemoclaw sandbox forward stop <port> <name>` validates PID ownership and then kills a background forward.
-- `nemoclaw sandbox forward list` shows all tracked forwards.
-- `nemoclaw sandbox forward stop` and `nemoclaw sandbox forward list` are local operations and do not require
+- `nemoclaw forward stop <port> <name>` validates PID ownership and then kills a background forward.
+- `nemoclaw forward list` shows all tracked forwards.
+- `nemoclaw forward stop` and `nemoclaw forward list` are local operations and do not require
   resolving an active cluster.
 - `nemoclaw sandbox create --forward <port>` starts a background forward before connect/exec, including
   when no trailing command is provided.
@@ -278,29 +278,29 @@ File sync uses **tar-over-SSH**: the CLI streams a tar archive through the exist
 
 **Files**: `crates/navigator-cli/src/ssh.rs`, `crates/navigator-cli/src/run.rs`
 
-#### `sandbox create --sync`
+#### `sandbox create --upload`
 
-When `--sync` is passed to `sandbox create`, the CLI pushes local git-tracked files into `/sandbox` after the sandbox reaches `Ready` and before any command runs.
+When `--upload` is passed to `sandbox create`, the CLI pushes local files into `/sandbox` (or a specified destination) after the sandbox reaches `Ready` and before any command runs.
 
 1. `git_repo_root()` determines the repository root via `git rev-parse --show-toplevel`
 2. `git_sync_files()` lists files with `git ls-files -co --exclude-standard -z` (tracked + untracked, respecting gitignore, null-delimited)
 3. `sandbox_sync_up_files()` creates an SSH session config, spawns `ssh <proxy> sandbox "tar xf - -C /sandbox"`, and streams a tar archive of the file list to the SSH child's stdin using the `tar` crate
 4. Files land in `/sandbox` inside the container
 
-#### `nemoclaw sandbox sync` command
+#### `nemoclaw sandbox upload` / `nemoclaw sandbox download`
 
-The standalone `sandbox sync` subcommand supports bidirectional file transfer:
+Standalone commands support bidirectional file transfer:
 
 ```bash
 # Push local files up to sandbox
-nemoclaw sandbox sync <name> --up <local-path> [<sandbox-path>]
+nemoclaw sandbox upload <name> <local-path> [<sandbox-path>]
 
 # Pull sandbox files down to local
-nemoclaw sandbox sync <name> --down <sandbox-path> [<local-path>]
+nemoclaw sandbox download <name> <sandbox-path> [<local-path>]
 ```
 
-- **Push (`--up`)**: `sandbox_sync_up()` streams a tar archive of the local path to `ssh ... tar xf - -C <dest>` on the sandbox side. Default destination: `/sandbox`.
-- **Pull (`--down`)**: `sandbox_sync_down()` runs `ssh ... tar cf - -C <dir> <path>` on the sandbox side and extracts the output locally via `tar::Archive`. Default destination: `.` (current directory).
+- **Upload**: `sandbox_upload()` streams a tar archive of the local path to `ssh ... tar xf - -C <dest>` on the sandbox side. Default destination: `/sandbox`.
+- **Download**: `sandbox_download()` runs `ssh ... tar cf - -C <dir> <path>` on the sandbox side and extracts the output locally via `tar::Archive`. Default destination: `.` (current directory).
 - No compression for v1 — the SSH tunnel is local-network; compression adds CPU cost with marginal bandwidth savings.
 
 #### Why tar-over-SSH instead of rsync

--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -1128,7 +1128,7 @@ Key structured log events:
 
 ## Log Streaming
 
-In gRPC mode, sandbox supervisor logs are streamed to the gateway in real time. This enables operators and CLI users to view both gateway-side and sandbox-side logs in a unified stream via `nav sandbox logs`.
+In gRPC mode, sandbox supervisor logs are streamed to the gateway in real time. This enables operators and CLI users to view both gateway-side and sandbox-side logs in a unified stream via `nav logs`.
 
 ### Architecture overview
 
@@ -1251,20 +1251,20 @@ Gateway-sourced logs do not currently populate the `fields` map (it remains empt
 
 **File:** `crates/navigator-cli/src/main.rs` (command definition), `crates/navigator-cli/src/run.rs` (`sandbox_logs()`)
 
-The `nav sandbox logs` command supports filtering by source and level:
+The `nav logs` command supports filtering by source and level:
 
 ```bash
 # Show only sandbox-side logs
-nav sandbox logs my-sandbox --source sandbox
+nav logs my-sandbox --source sandbox
 
 # Show only warnings and errors from the gateway
-nav sandbox logs my-sandbox --source gateway --level warn
+nav logs my-sandbox --source gateway --level warn
 
 # Stream live logs from all sources
-nav sandbox logs my-sandbox --tail
+nav logs my-sandbox --tail
 
 # Stream live sandbox logs only
-nav sandbox logs my-sandbox --tail --source sandbox
+nav logs my-sandbox --tail --source sandbox
 ```
 
 **CLI flags:**
@@ -1319,7 +1319,7 @@ sequenceDiagram
     participant BG as Background push task
     participant GW as Gateway (push_sandbox_logs)
     participant TB as TracingLogBus
-    participant CL as CLI (nav sandbox logs)
+    participant CL as CLI (nav logs)
 
     SB->>LP: tracing event (info!(...))
     LP->>LP: Check level >= NEMOCLAW_LOG_PUSH_LEVEL

--- a/architecture/security-policy.md
+++ b/architecture/security-policy.md
@@ -84,7 +84,7 @@ Policy fields fall into two categories based on when they are enforced:
 | Category | Fields | Enforcement Point | Updatable? |
 |----------|--------|-------------------|------------|
 | **Static** | `filesystem_policy`, `landlock`, `process` | Applied once in the child process `pre_exec` (after `fork()`, before `exec()`). Kernel-level Landlock rulesets and UID/GID changes cannot be reversed. | No -- immutable after sandbox creation |
-| **Dynamic** | `network_policies` | Evaluated at runtime by the OPA engine on every proxy CONNECT request and L7 rule check. The OPA engine can be atomically replaced. | Yes -- via `nav sandbox policy set` |
+| **Dynamic** | `network_policies`, `inference` | Evaluated at runtime by the OPA engine on every proxy CONNECT request and L7 rule check. The OPA engine can be atomically replaced. | Yes -- via `nemoclaw policy set` |
 
 Attempting to change a static field in an update request returns an `INVALID_ARGUMENT` error with a message indicating which field cannot be modified. See `crates/navigator-server/src/grpc.rs` -- `validate_static_fields_unchanged()`.
 
@@ -103,7 +103,7 @@ The update mechanism uses a poll-based model with versioned policy revisions and
 
 ```mermaid
 sequenceDiagram
-    participant CLI as nav sandbox policy set
+    participant CLI as nav policy set
     participant GW as Gateway (navigator-server)
     participant DB as Persistence (SQLite/Postgres)
     participant SB as Sandbox (navigator-sandbox)
@@ -210,32 +210,32 @@ Failure scenarios that trigger LKG behavior include:
 
 ### CLI Commands
 
-The `nav sandbox policy` subcommand group manages live policy updates:
+The `nav policy` subcommand group manages live policy updates:
 
 ```bash
 # Push a new policy to a running sandbox
-nav sandbox policy set <sandbox-name> --policy updated-policy.yaml
+nav policy set <sandbox-name> --policy updated-policy.yaml
 
 # Push and wait for the sandbox to load it (with 60s timeout)
-nav sandbox policy set <sandbox-name> --policy updated-policy.yaml --wait
+nav policy set <sandbox-name> --policy updated-policy.yaml --wait
 
 # Push and wait with a custom timeout
-nav sandbox policy set <sandbox-name> --policy updated-policy.yaml --wait --timeout 120
+nav policy set <sandbox-name> --policy updated-policy.yaml --wait --timeout 120
 
 # View the current active policy and its status
-nav sandbox policy get <sandbox-name>
+nav policy get <sandbox-name>
 
 # Inspect a specific revision
-nav sandbox policy get <sandbox-name> --rev 3
+nav policy get <sandbox-name> --rev 3
 
 # Print the full policy as YAML (round-trips with --policy input format)
-nav sandbox policy get <sandbox-name> --full
+nav policy get <sandbox-name> --full
 
 # Combine: inspect a specific revision's full policy
-nav sandbox policy get <sandbox-name> --rev 2 --full
+nav policy get <sandbox-name> --rev 2 --full
 
 # List policy revision history
-nav sandbox policy list <sandbox-name> --limit 20
+nav policy list <sandbox-name> --limit 20
 ```
 
 #### `policy get` flags
@@ -243,11 +243,11 @@ nav sandbox policy list <sandbox-name> --limit 20
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--rev N` | `0` (latest) | Retrieve a specific policy revision by version number instead of the latest. Maps to the `version` field of `GetSandboxPolicyStatusRequest` -- version `0` resolves to the latest revision server-side. |
-| `--full` | off | Print the complete policy as YAML after the metadata summary. The YAML output uses the same schema as the `--policy` input file, so it round-trips: you can save it to a file and pass it back to `nav sandbox policy set --policy`. |
+| `--full` | off | Print the complete policy as YAML after the metadata summary. The YAML output uses the same schema as the `--policy` input file, so it round-trips: you can save it to a file and pass it back to `nav policy set --policy`. |
 
-When `--full` is specified, the server includes the deserialized `SandboxPolicy` protobuf in the `SandboxPolicyRevision.policy` field (see `crates/navigator-server/src/grpc.rs` -- `policy_record_to_revision()` with `include_policy: true`). The CLI converts this proto back to YAML via `policy_to_yaml()`, which uses a `BTreeMap` for `network_policies` to produce deterministic key ordering. See `crates/navigator-cli/src/run.rs` -- `policy_to_yaml()`, `sandbox_policy_get()`.
+When `--full` is specified, the server includes the deserialized `SandboxPolicy` protobuf in the `SandboxPolicyRevision.policy` field (see `crates/navigator-server/src/grpc.rs` -- `policy_record_to_revision()` with `include_policy: true`). The CLI converts this proto back to YAML via `policy_to_yaml()`, which uses a `BTreeMap` for `network_policies` to produce deterministic key ordering. See `crates/navigator-cli/src/run.rs` -- `policy_to_yaml()`, `policy_get()`.
 
-See `crates/navigator-cli/src/main.rs` -- `PolicyCommands` enum, `crates/navigator-cli/src/run.rs` -- `sandbox_policy_set()`, `sandbox_policy_get()`, `sandbox_policy_list()`.
+See `crates/navigator-cli/src/main.rs` -- `PolicyCommands` enum, `crates/navigator-cli/src/run.rs` -- `policy_set()`, `policy_get()`, `policy_list()`.
 
 ---
 
@@ -1041,7 +1041,7 @@ See `sandbox-policy.rego` for the full Rego implementation.
 
 ## Sandbox Log Filtering
 
-The `nav sandbox logs` command retrieves log lines from the gateway's in-memory log buffer. Two server-side filters narrow the output before logs are sent to the CLI.
+The `nav logs` command retrieves log lines from the gateway's in-memory log buffer. Two server-side filters narrow the output before logs are sent to the CLI.
 
 ### Source Filter (`--source`)
 
@@ -1057,10 +1057,10 @@ Multiple sources can be specified: `--source gateway --source sandbox` is equiva
 
 ```bash
 # Show only proxy/OPA logs from the sandbox supervisor
-nav sandbox logs my-sandbox --source sandbox
+nav logs my-sandbox --source sandbox
 
 # Show only gateway-side reconciler logs
-nav sandbox logs my-sandbox --source gateway
+nav logs my-sandbox --source gateway
 ```
 
 The filter applies to both one-shot mode (`GetSandboxLogs` RPC) and streaming mode (`--tail`, via `WatchSandbox` RPC). In both cases, the server evaluates `source_matches()` before sending each log line to the client. See `crates/navigator-server/src/grpc.rs` -- `source_matches()`, `get_sandbox_logs()`.
@@ -1081,10 +1081,10 @@ The default (empty string) disables level filtering -- all levels pass. An unrec
 
 ```bash
 # Show only WARN and ERROR logs
-nav sandbox logs my-sandbox --level warn
+nav logs my-sandbox --level warn
 
 # Combine with source filter: only sandbox ERROR logs
-nav sandbox logs my-sandbox --source sandbox --level error
+nav logs my-sandbox --source sandbox --level error
 ```
 
 The filter is applied server-side via `level_matches()` in both one-shot and streaming modes. See `crates/navigator-server/src/grpc.rs` -- `level_matches()`.

--- a/crates/navigator-cli/src/bootstrap.rs
+++ b/crates/navigator-cli/src/bootstrap.rs
@@ -97,13 +97,20 @@ fn is_connectivity_error(error: &miette::Report) -> bool {
 
 /// Prompt the user to confirm cluster bootstrap.
 ///
-/// Only prompts when stdin is a terminal. In non-interactive mode, returns an
-/// error with an actionable message.
-pub fn confirm_bootstrap() -> Result<bool> {
+/// When `override_value` is `Some(true)` or `Some(false)`, the decision is
+/// made immediately (from `--bootstrap` / `--no-bootstrap`). Otherwise,
+/// prompts interactively when stdin is a terminal, or returns an error in
+/// non-interactive mode.
+pub fn confirm_bootstrap(override_value: Option<bool>) -> Result<bool> {
+    // Explicit flag takes precedence over interactive detection.
+    if let Some(value) = override_value {
+        return Ok(value);
+    }
+
     if !std::io::stdin().is_terminal() {
         return Err(miette::miette!(
-            "Cluster not reachable and bootstrap requires confirmation from an interactive terminal.\n\
-             Run 'nemoclaw cluster admin deploy' first, then retry."
+            "Gateway not reachable and bootstrap requires confirmation from an interactive terminal.\n\
+              Pass --bootstrap to auto-confirm, or run 'nemoclaw gateway start' first."
         ));
     }
 

--- a/crates/navigator-cli/src/main.rs
+++ b/crates/navigator-cli/src/main.rs
@@ -44,17 +44,17 @@ fn resolve_cluster(cluster_flag: &Option<String>) -> Result<ClusterContext> {
         .or_else(load_active_cluster)
         .ok_or_else(|| {
             miette::miette!(
-                "No active cluster.\n\
-                 Set one with: nemoclaw cluster use <name>\n\
-                 Or deploy a new cluster: nemoclaw cluster admin deploy"
+                "No active gateway.\n\
+                 Set one with: nemoclaw gateway select <name>\n\
+                 Or deploy a new gateway: nemoclaw gateway start"
             )
         })?;
 
     let metadata = load_cluster_metadata(&name).map_err(|_| {
         miette::miette!(
-            "Unknown cluster '{name}'.\n\
-             Deploy it first: nemoclaw cluster admin deploy --name {name}\n\
-             Or list available clusters: nemoclaw cluster list"
+            "Unknown gateway '{name}'.\n\
+             Deploy it first: nemoclaw gateway start --name {name}\n\
+             Or list available gateways: nemoclaw gateway select"
         )
     })?;
 
@@ -66,8 +66,8 @@ fn resolve_cluster(cluster_flag: &Option<String>) -> Result<ClusterContext> {
 
 /// Resolve only the cluster name (without requiring metadata to exist).
 ///
-/// Used by admin commands that operate on a cluster by name but may not need
-/// the gateway endpoint (e.g., `cluster admin deploy` creates the cluster).
+/// Used by gateway commands that operate on a cluster by name but may not need
+/// the gateway endpoint (e.g., `gateway start` creates the cluster).
 fn resolve_cluster_name(cluster_flag: &Option<String>) -> Option<String> {
     cluster_flag
         .clone()
@@ -118,16 +118,64 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-    /// Manage cluster.
-    Cluster {
+    /// Manage the gateway lifecycle.
+    Gateway {
         #[command(subcommand)]
-        command: ClusterCommands,
+        command: GatewayCommands,
     },
+
+    /// Show gateway status and information.
+    Status,
 
     /// Manage sandboxes.
     Sandbox {
         #[command(subcommand)]
         command: SandboxCommands,
+    },
+
+    /// Manage port forwarding to a sandbox.
+    Forward {
+        #[command(subcommand)]
+        command: ForwardCommands,
+    },
+
+    /// View sandbox logs.
+    Logs {
+        /// Sandbox name (defaults to last-used sandbox).
+        name: Option<String>,
+
+        /// Number of log lines to return.
+        #[arg(short, default_value_t = 200)]
+        n: u32,
+
+        /// Stream live logs.
+        #[arg(long)]
+        tail: bool,
+
+        /// Only show logs from this duration ago (e.g. 5m, 1h, 30s).
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Filter by log source: "gateway", "sandbox", or "all" (default).
+        /// Can be specified multiple times: --source gateway --source sandbox
+        #[arg(long, default_value = "all")]
+        source: Vec<String>,
+
+        /// Minimum log level to display: error, warn, info (default), debug, trace.
+        #[arg(long, default_value = "")]
+        level: String,
+    },
+
+    /// Manage sandbox policy.
+    Policy {
+        #[command(subcommand)]
+        command: PolicyCommands,
+    },
+
+    /// Manage inference configuration.
+    Inference {
+        #[command(subcommand)]
+        command: ClusterInferenceCommands,
     },
 
     /// Manage provider configuration.
@@ -180,6 +228,13 @@ enum Commands {
         /// Sandbox name. Used in name mode.
         #[arg(long)]
         name: Option<String>,
+    },
+
+    /// Manage cluster (deprecated: use `gateway`).
+    #[command(hide = true)]
+    Cluster {
+        #[command(subcommand)]
+        command: ClusterCommands,
     },
 }
 
@@ -365,67 +420,15 @@ enum ProviderCommands {
     },
 }
 
-#[derive(Subcommand, Debug)]
-enum ClusterCommands {
-    /// Show server status and information.
-    Status,
-
-    /// Set the active cluster.
-    Use {
-        /// Cluster name to make active.
-        #[arg(add = ArgValueCompleter::new(completers::complete_cluster_names))]
-        name: String,
-    },
-
-    /// List all provisioned clusters.
-    List,
-
-    /// Manage local development cluster lifecycle.
-    Admin {
-        #[command(subcommand)]
-        command: ClusterAdminCommands,
-    },
-
-    /// Manage cluster-level inference configuration.
-    Inference {
-        #[command(subcommand)]
-        command: ClusterInferenceCommands,
-    },
-}
+// -----------------------------------------------------------------------
+// Gateway commands (replaces the old `cluster` / `cluster admin` groups)
+// -----------------------------------------------------------------------
 
 #[derive(Subcommand, Debug)]
-enum ClusterInferenceCommands {
-    /// Set cluster-level inference provider and model.
-    Set {
-        /// Provider name.
-        #[arg(long, add = ArgValueCompleter::new(completers::complete_provider_names))]
-        provider: String,
-
-        /// Model identifier to force for generation calls.
-        #[arg(long)]
-        model: String,
-    },
-
-    /// Update cluster-level inference configuration (partial update).
-    Update {
-        /// Provider name (unchanged if omitted).
-        #[arg(long, add = ArgValueCompleter::new(completers::complete_provider_names))]
-        provider: Option<String>,
-
-        /// Model identifier (unchanged if omitted).
-        #[arg(long)]
-        model: Option<String>,
-    },
-
-    /// Get cluster-level inference provider and model.
-    Get,
-}
-
-#[derive(Subcommand, Debug)]
-enum ClusterAdminCommands {
-    /// Provision or start a cluster (local or remote).
-    Deploy {
-        /// Cluster name.
+enum GatewayCommands {
+    /// Deploy/start the gateway.
+    Start {
+        /// Gateway name.
         #[arg(long, default_value = "nemoclaw")]
         name: String,
 
@@ -464,11 +467,18 @@ enum ClusterAdminCommands {
         /// allowing multiple clusters to coexist without port conflicts.
         #[arg(long, num_args = 0..=1, default_missing_value = "0")]
         kube_port: Option<u16>,
+
+        /// Destroy and recreate the gateway from scratch if one already exists.
+        ///
+        /// Without this flag, an interactive prompt asks what to do; in
+        /// non-interactive mode the existing gateway is reused silently.
+        #[arg(long)]
+        recreate: bool,
     },
 
-    /// Stop a cluster (preserves state).
+    /// Stop the gateway (preserves state).
     Stop {
-        /// Cluster name (defaults to active cluster).
+        /// Gateway name (defaults to active gateway).
         #[arg(long)]
         name: Option<String>,
 
@@ -481,9 +491,9 @@ enum ClusterAdminCommands {
         ssh_key: Option<String>,
     },
 
-    /// Destroy a cluster and its state.
+    /// Destroy the gateway and its state.
     Destroy {
-        /// Cluster name (defaults to active cluster).
+        /// Gateway name (defaults to active gateway).
         #[arg(long)]
         name: Option<String>,
 
@@ -496,16 +506,25 @@ enum ClusterAdminCommands {
         ssh_key: Option<String>,
     },
 
-    /// Show cluster deployment details.
+    /// Select the active gateway.
+    ///
+    /// When called without a name, lists available gateways to choose from.
+    Select {
+        /// Gateway name (omit to list available gateways).
+        #[arg(add = ArgValueCompleter::new(completers::complete_cluster_names))]
+        name: Option<String>,
+    },
+
+    /// Show gateway deployment details.
     Info {
-        /// Cluster name (defaults to active cluster).
+        /// Gateway name (defaults to active gateway).
         #[arg(long)]
         name: Option<String>,
     },
 
-    /// Print or start an SSH tunnel for kubectl access to a remote cluster.
+    /// Print or start an SSH tunnel for kubectl access to a remote gateway.
     Tunnel {
-        /// Cluster name (defaults to active cluster).
+        /// Gateway name (defaults to active gateway).
         #[arg(long)]
         name: Option<String>,
 
@@ -520,6 +539,97 @@ enum ClusterAdminCommands {
         /// Only print the SSH command instead of running it.
         #[arg(long)]
         print_command: bool,
+    },
+}
+
+// -----------------------------------------------------------------------
+// Hidden backwards-compat: `cluster admin deploy` → `gateway start`
+// -----------------------------------------------------------------------
+
+#[derive(Subcommand, Debug)]
+enum ClusterCommands {
+    /// Deprecated: use `gateway start`.
+    #[command(hide = true)]
+    Admin {
+        #[command(subcommand)]
+        command: ClusterAdminCommands,
+    },
+
+    /// Manage cluster-level inference configuration.
+    #[command(hide = true)]
+    Inference {
+        #[command(subcommand)]
+        command: ClusterInferenceCommands,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum ClusterInferenceCommands {
+    /// Set cluster-level inference provider and model.
+    Set {
+        /// Provider name.
+        #[arg(long, add = ArgValueCompleter::new(completers::complete_provider_names))]
+        provider: String,
+
+        /// Model identifier to force for generation calls.
+        #[arg(long)]
+        model: String,
+    },
+
+    /// Update cluster-level inference configuration (partial update).
+    Update {
+        /// Provider name (unchanged if omitted).
+        #[arg(long, add = ArgValueCompleter::new(completers::complete_provider_names))]
+        provider: Option<String>,
+
+        /// Model identifier (unchanged if omitted).
+        #[arg(long)]
+        model: Option<String>,
+    },
+
+    /// Get cluster-level inference provider and model.
+    Get,
+}
+
+#[derive(Subcommand, Debug)]
+enum ClusterAdminCommands {
+    /// Deprecated: use `gateway start`.
+    Deploy {
+        /// Cluster name.
+        #[arg(long, default_value = "nemoclaw")]
+        name: String,
+
+        /// Write stored kubeconfig into local kubeconfig.
+        #[arg(long)]
+        update_kube_config: bool,
+
+        /// Print stored kubeconfig to stdout.
+        #[arg(long)]
+        get_kubeconfig: bool,
+
+        /// SSH destination for remote deployment (e.g., user@hostname).
+        #[arg(long)]
+        remote: Option<String>,
+
+        /// Path to SSH private key for remote deployment.
+        #[arg(long, value_hint = ValueHint::FilePath)]
+        ssh_key: Option<String>,
+
+        /// Host port to map to the gateway (default: 8080).
+        #[arg(long, default_value_t = navigator_bootstrap::DEFAULT_GATEWAY_PORT)]
+        port: u16,
+
+        /// Override the gateway host written into cluster metadata.
+        #[arg(long)]
+        gateway_host: Option<String>,
+
+        /// Expose the Kubernetes control plane on a host port for kubectl access.
+        #[arg(long, num_args = 0..=1, default_missing_value = "0")]
+        kube_port: Option<u16>,
+
+        /// Destroy and recreate from scratch if a cluster already exists.
+        #[arg(long)]
+        recreate: bool,
     },
 }
 
@@ -544,9 +654,19 @@ enum SandboxCommands {
         #[arg(long)]
         from: Option<String>,
 
-        /// Sync local files into the sandbox before running.
-        #[arg(long)]
-        sync: bool,
+        /// Upload local files into the sandbox before running.
+        ///
+        /// Format: `<LOCAL_PATH>[:<SANDBOX_PATH>]`.
+        /// When `SANDBOX_PATH` is omitted, files are uploaded to the container
+        /// working directory (`/sandbox`).
+        /// `.gitignore` rules are applied by default; use `--no-git-ignore` to
+        /// upload everything.
+        #[arg(long, value_hint = ValueHint::AnyPath)]
+        upload: Option<String>,
+
+        /// Disable `.gitignore` filtering for `--upload`.
+        #[arg(long, requires = "upload")]
+        no_git_ignore: bool,
 
         /// Keep the sandbox alive after non-interactive commands.
         #[arg(long)]
@@ -586,6 +706,28 @@ enum SandboxCommands {
         /// Disable pseudo-terminal allocation.
         #[arg(long, overrides_with = "tty")]
         no_tty: bool,
+
+        /// Auto-bootstrap a gateway if none is available.
+        ///
+        /// Without this flag, an interactive prompt asks whether to bootstrap;
+        /// in non-interactive mode the command errors.
+        #[arg(long, overrides_with = "no_bootstrap")]
+        bootstrap: bool,
+
+        /// Never bootstrap a gateway automatically; error if none is available.
+        #[arg(long, overrides_with = "bootstrap")]
+        no_bootstrap: bool,
+
+        /// Auto-create missing providers from local credentials.
+        ///
+        /// Without this flag, an interactive prompt asks per-provider;
+        /// in non-interactive mode the command errors.
+        #[arg(long, overrides_with = "no_auto_providers")]
+        auto_providers: bool,
+
+        /// Never auto-create providers; error if required providers are missing.
+        #[arg(long, overrides_with = "auto_providers")]
+        no_auto_providers: bool,
 
         /// Command to run after "--" (defaults to an interactive shell).
         #[arg(trailing_var_arg = true)]
@@ -634,63 +776,35 @@ enum SandboxCommands {
         name: Option<String>,
     },
 
-    /// Manage port forwarding to a sandbox.
-    Forward {
-        #[command(subcommand)]
-        command: ForwardCommands,
-    },
-
-    /// Sync files to or from a sandbox.
-    Sync {
-        /// Sandbox name (defaults to last-used sandbox).
+    /// Upload local files to a sandbox.
+    Upload {
+        /// Sandbox name.
         #[arg(add = ArgValueCompleter::new(completers::complete_sandbox_names))]
-        name: Option<String>,
+        name: String,
 
-        /// Push local files up to the sandbox.
-        #[arg(long, conflicts_with = "down", value_name = "LOCAL_PATH", value_hint = ValueHint::AnyPath)]
-        up: Option<String>,
+        /// Local path to upload.
+        #[arg(value_hint = ValueHint::AnyPath)]
+        local_path: String,
 
-        /// Pull sandbox files down to the local machine.
-        #[arg(long, conflicts_with = "up", value_name = "SANDBOX_PATH")]
-        down: Option<String>,
-
-        /// Destination path (sandbox path when pushing, local path when pulling).
-        /// Defaults to /sandbox for --up or . for --down.
-        #[arg(value_name = "DEST")]
+        /// Destination path in the sandbox (defaults to `/sandbox`).
         dest: Option<String>,
+
+        /// Disable `.gitignore` filtering (uploads everything).
+        #[arg(long)]
+        no_git_ignore: bool,
     },
 
-    /// Manage sandbox policy.
-    Policy {
-        #[command(subcommand)]
-        command: PolicyCommands,
-    },
+    /// Download files from a sandbox.
+    Download {
+        /// Sandbox name.
+        #[arg(add = ArgValueCompleter::new(completers::complete_sandbox_names))]
+        name: String,
 
-    /// View sandbox logs.
-    Logs {
-        /// Sandbox name (defaults to last-used sandbox).
-        name: Option<String>,
+        /// Sandbox path to download.
+        sandbox_path: String,
 
-        /// Number of log lines to return.
-        #[arg(short, default_value_t = 200)]
-        n: u32,
-
-        /// Stream live logs.
-        #[arg(long)]
-        tail: bool,
-
-        /// Only show logs from this duration ago (e.g. 5m, 1h, 30s).
-        #[arg(long)]
-        since: Option<String>,
-
-        /// Filter by log source: "gateway", "sandbox", or "all" (default).
-        /// Can be specified multiple times: --source gateway --source sandbox
-        #[arg(long, default_value = "all")]
-        source: Vec<String>,
-
-        /// Minimum log level to display: error, warn, info (default), debug, trace.
-        #[arg(long, default_value = "")]
-        level: String,
+        /// Local destination (defaults to `.`).
+        dest: Option<String>,
     },
 
     /// Print an SSH config entry for a sandbox.
@@ -807,115 +921,277 @@ async fn main() -> Result<()> {
         .init();
 
     match cli.command {
-        Some(Commands::Cluster { command }) => match command {
-            ClusterCommands::Status => {
-                let ctx = resolve_cluster(&cli.cluster)?;
-                let endpoint = &ctx.endpoint;
-                let tls = tls.with_cluster_name(&ctx.name);
-                run::cluster_status(&ctx.name, endpoint, &tls).await?;
-            }
-            ClusterCommands::Use { name } => {
-                run::cluster_use(&name)?;
-            }
-            ClusterCommands::List => {
-                run::cluster_list(&cli.cluster)?;
-            }
-            ClusterCommands::Admin { command } => match command {
-                ClusterAdminCommands::Deploy {
-                    name,
+        // -----------------------------------------------------------
+        // Gateway commands (was `cluster` / `cluster admin`)
+        // -----------------------------------------------------------
+        Some(Commands::Gateway { command }) => match command {
+            GatewayCommands::Start {
+                name,
+                update_kube_config,
+                get_kubeconfig,
+                remote,
+                ssh_key,
+                port,
+                gateway_host,
+                kube_port,
+                recreate,
+            } => {
+                run::cluster_admin_deploy(
+                    &name,
                     update_kube_config,
                     get_kubeconfig,
-                    remote,
-                    ssh_key,
+                    remote.as_deref(),
+                    ssh_key.as_deref(),
                     port,
-                    gateway_host,
+                    gateway_host.as_deref(),
                     kube_port,
-                } => {
-                    run::cluster_admin_deploy(
-                        &name,
-                        update_kube_config,
-                        get_kubeconfig,
-                        remote.as_deref(),
-                        ssh_key.as_deref(),
-                        port,
-                        gateway_host.as_deref(),
-                        kube_port,
-                    )
-                    .await?;
+                    recreate,
+                )
+                .await?;
+            }
+            GatewayCommands::Stop {
+                name,
+                remote,
+                ssh_key,
+            } => {
+                let name = name
+                    .or_else(|| resolve_cluster_name(&cli.cluster))
+                    .unwrap_or_else(|| "nemoclaw".to_string());
+                run::cluster_admin_stop(&name, remote.as_deref(), ssh_key.as_deref()).await?;
+            }
+            GatewayCommands::Destroy {
+                name,
+                remote,
+                ssh_key,
+            } => {
+                let name = name
+                    .or_else(|| resolve_cluster_name(&cli.cluster))
+                    .unwrap_or_else(|| "nemoclaw".to_string());
+                run::cluster_admin_destroy(&name, remote.as_deref(), ssh_key.as_deref()).await?;
+            }
+            GatewayCommands::Select { name } => {
+                if let Some(name) = name {
+                    run::cluster_use(&name)?;
+                } else {
+                    // No name provided — show available gateways.
+                    run::cluster_list(&cli.cluster)?;
+                    eprintln!();
+                    eprintln!(
+                        "Select a gateway with: {}",
+                        "nemoclaw gateway select <name>".dimmed()
+                    );
                 }
-                ClusterAdminCommands::Stop {
-                    name,
-                    remote,
-                    ssh_key,
-                } => {
-                    let name = name
-                        .or_else(|| resolve_cluster_name(&cli.cluster))
-                        .unwrap_or_else(|| "nemoclaw".to_string());
-                    run::cluster_admin_stop(&name, remote.as_deref(), ssh_key.as_deref()).await?;
-                }
-                ClusterAdminCommands::Destroy {
-                    name,
-                    remote,
-                    ssh_key,
-                } => {
-                    let name = name
-                        .or_else(|| resolve_cluster_name(&cli.cluster))
-                        .unwrap_or_else(|| "nemoclaw".to_string());
-                    run::cluster_admin_destroy(&name, remote.as_deref(), ssh_key.as_deref())
-                        .await?;
-                }
-                ClusterAdminCommands::Info { name } => {
-                    let name = name
-                        .or_else(|| resolve_cluster_name(&cli.cluster))
-                        .unwrap_or_else(|| "nemoclaw".to_string());
-                    run::cluster_admin_info(&name)?;
-                }
-                ClusterAdminCommands::Tunnel {
-                    name,
-                    remote,
-                    ssh_key,
+            }
+            GatewayCommands::Info { name } => {
+                let name = name
+                    .or_else(|| resolve_cluster_name(&cli.cluster))
+                    .unwrap_or_else(|| "nemoclaw".to_string());
+                run::cluster_admin_info(&name)?;
+            }
+            GatewayCommands::Tunnel {
+                name,
+                remote,
+                ssh_key,
+                print_command,
+            } => {
+                let name = name
+                    .or_else(|| resolve_cluster_name(&cli.cluster))
+                    .unwrap_or_else(|| "nemoclaw".to_string());
+                run::cluster_admin_tunnel(
+                    &name,
+                    remote.as_deref(),
+                    ssh_key.as_deref(),
                     print_command,
-                } => {
-                    let name = name
-                        .or_else(|| resolve_cluster_name(&cli.cluster))
-                        .unwrap_or_else(|| "nemoclaw".to_string());
-                    run::cluster_admin_tunnel(
-                        &name,
-                        remote.as_deref(),
-                        ssh_key.as_deref(),
-                        print_command,
-                    )?;
-                }
-            },
-            ClusterCommands::Inference { command } => {
-                let ctx = resolve_cluster(&cli.cluster)?;
-                let endpoint = &ctx.endpoint;
+                )?;
+            }
+        },
+
+        // -----------------------------------------------------------
+        // Top-level status (was `cluster status`)
+        // -----------------------------------------------------------
+        Some(Commands::Status) => {
+            if let Ok(ctx) = resolve_cluster(&cli.cluster) {
                 let tls = tls.with_cluster_name(&ctx.name);
-                match command {
-                    ClusterInferenceCommands::Set { provider, model } => {
-                        run::cluster_inference_set(endpoint, &provider, &model, &tls).await?;
+                run::cluster_status(&ctx.name, &ctx.endpoint, &tls).await?;
+            } else {
+                println!("{}", "Gateway Status".cyan().bold());
+                println!();
+                println!("  {} No gateway configured.", "Status:".dimmed(),);
+                println!();
+                println!(
+                    "Deploy a gateway with: {}",
+                    "nemoclaw gateway start".dimmed()
+                );
+            }
+        }
+
+        // -----------------------------------------------------------
+        // Top-level forward (was `sandbox forward`)
+        // -----------------------------------------------------------
+        Some(Commands::Forward { command: fwd_cmd }) => match fwd_cmd {
+            ForwardCommands::Stop { port, name } => {
+                let cluster_name = resolve_cluster_name(&cli.cluster).unwrap_or_default();
+                let name = resolve_sandbox_name(name, &cluster_name)?;
+                if run::stop_forward(&name, port)? {
+                    eprintln!(
+                        "{} Stopped forward of port {port} for sandbox {name}",
+                        "✓".green().bold(),
+                    );
+                } else {
+                    eprintln!(
+                        "{} No active forward found for port {port} on sandbox {name}",
+                        "!".yellow(),
+                    );
+                }
+            }
+            ForwardCommands::List => {
+                let forwards = run::list_forwards()?;
+                if forwards.is_empty() {
+                    eprintln!("No active forwards.");
+                } else {
+                    let name_width = forwards
+                        .iter()
+                        .map(|f| f.sandbox.len())
+                        .max()
+                        .unwrap_or(7)
+                        .max(7);
+                    println!(
+                        "{:<width$} {:<8} {:<10} STATUS",
+                        "SANDBOX",
+                        "PORT",
+                        "PID",
+                        width = name_width,
+                    );
+                    for f in &forwards {
+                        let status = if f.alive {
+                            "running".green().to_string()
+                        } else {
+                            "dead".red().to_string()
+                        };
+                        println!(
+                            "{:<width$} {:<8} {:<10} {}",
+                            f.sandbox,
+                            f.port,
+                            f.pid,
+                            status,
+                            width = name_width,
+                        );
                     }
-                    ClusterInferenceCommands::Update { provider, model } => {
-                        run::cluster_inference_update(
-                            endpoint,
-                            provider.as_deref(),
-                            model.as_deref(),
-                            &tls,
-                        )
-                        .await?;
-                    }
-                    ClusterInferenceCommands::Get => {
-                        run::cluster_inference_get(endpoint, &tls).await?;
-                    }
+                }
+            }
+            ForwardCommands::Start {
+                port,
+                name,
+                background,
+            } => {
+                let ctx = resolve_cluster(&cli.cluster)?;
+                let tls = tls.with_cluster_name(&ctx.name);
+                let name = resolve_sandbox_name(name, &ctx.name)?;
+                run::sandbox_forward(&ctx.endpoint, &name, port, background, &tls).await?;
+                if background {
+                    eprintln!(
+                        "{} Forwarding port {port} to sandbox {name} in the background",
+                        "✓".green().bold(),
+                    );
+                    eprintln!("  Access at: http://127.0.0.1:{port}/");
+                    eprintln!("  Stop with: nemoclaw forward stop {port} {name}");
                 }
             }
         },
+
+        // -----------------------------------------------------------
+        // Top-level logs (was `sandbox logs`)
+        // -----------------------------------------------------------
+        Some(Commands::Logs {
+            name,
+            n,
+            tail,
+            since,
+            source,
+            level,
+        }) => {
+            let ctx = resolve_cluster(&cli.cluster)?;
+            let tls = tls.with_cluster_name(&ctx.name);
+            let name = resolve_sandbox_name(name, &ctx.name)?;
+            run::sandbox_logs(
+                &ctx.endpoint,
+                &name,
+                n,
+                tail,
+                since.as_deref(),
+                &source,
+                &level,
+                &tls,
+            )
+            .await?;
+        }
+
+        // -----------------------------------------------------------
+        // Top-level policy (was `sandbox policy`)
+        // -----------------------------------------------------------
+        Some(Commands::Policy {
+            command: policy_cmd,
+        }) => {
+            let ctx = resolve_cluster(&cli.cluster)?;
+            let tls = tls.with_cluster_name(&ctx.name);
+            match policy_cmd {
+                PolicyCommands::Set {
+                    name,
+                    policy,
+                    wait,
+                    timeout,
+                } => {
+                    let name = resolve_sandbox_name(name, &ctx.name)?;
+                    run::sandbox_policy_set(&ctx.endpoint, &name, &policy, wait, timeout, &tls)
+                        .await?;
+                }
+                PolicyCommands::Get { name, rev, full } => {
+                    let name = resolve_sandbox_name(name, &ctx.name)?;
+                    run::sandbox_policy_get(&ctx.endpoint, &name, rev, full, &tls).await?;
+                }
+                PolicyCommands::List { name, limit } => {
+                    let name = resolve_sandbox_name(name, &ctx.name)?;
+                    run::sandbox_policy_list(&ctx.endpoint, &name, limit, &tls).await?;
+                }
+            }
+        }
+
+        // -----------------------------------------------------------
+        // Inference commands
+        // -----------------------------------------------------------
+        Some(Commands::Inference { command }) => {
+            let ctx = resolve_cluster(&cli.cluster)?;
+            let endpoint = &ctx.endpoint;
+            let tls = tls.with_cluster_name(&ctx.name);
+            match command {
+                ClusterInferenceCommands::Set { provider, model } => {
+                    run::cluster_inference_set(endpoint, &provider, &model, &tls).await?;
+                }
+                ClusterInferenceCommands::Update { provider, model } => {
+                    run::cluster_inference_update(
+                        endpoint,
+                        provider.as_deref(),
+                        model.as_deref(),
+                        &tls,
+                    )
+                    .await?;
+                }
+                ClusterInferenceCommands::Get => {
+                    run::cluster_inference_get(endpoint, &tls).await?;
+                }
+            }
+        }
+
+        // -----------------------------------------------------------
+        // Sandbox commands
+        // -----------------------------------------------------------
         Some(Commands::Sandbox { command }) => {
             match command {
                 SandboxCommands::Create {
                     name,
                     from,
-                    sync,
+                    upload,
+                    no_git_ignore,
                     keep,
                     remote,
                     ssh_key,
@@ -924,6 +1200,10 @@ async fn main() -> Result<()> {
                     forward,
                     tty,
                     no_tty,
+                    bootstrap,
+                    no_bootstrap,
+                    auto_providers,
+                    no_auto_providers,
                     command,
                 } => {
                     // Resolve --tty / --no-tty into an Option<bool> override.
@@ -935,14 +1215,38 @@ async fn main() -> Result<()> {
                         None // auto-detect
                     };
 
+                    // Resolve --bootstrap / --no-bootstrap into an Option<bool>.
+                    let bootstrap_override = if no_bootstrap {
+                        Some(false)
+                    } else if bootstrap {
+                        Some(true)
+                    } else {
+                        None // prompt or auto-detect
+                    };
+
+                    // Resolve --auto-providers / --no-auto-providers.
+                    let auto_providers_override = if no_auto_providers {
+                        Some(false)
+                    } else if auto_providers {
+                        Some(true)
+                    } else {
+                        None // prompt or auto-detect
+                    };
+
+                    // Parse --upload spec into (local_path, sandbox_path, git_ignore).
+                    let upload_spec = upload.as_deref().map(|s| {
+                        let (local, remote) = parse_upload_spec(s);
+                        (local, remote, !no_git_ignore)
+                    });
+
                     // For `sandbox create`, a missing cluster is not fatal — the
                     // bootstrap flow inside `sandbox_create` can deploy one.
                     match resolve_cluster(&cli.cluster) {
                         Ok(ctx) => {
                             if remote.is_some() {
                                 eprintln!(
-                                    "{} --remote ignored: cluster '{}' is already active. \
-                                     To redeploy, use: nemoclaw cluster admin deploy",
+                                    "{} --remote ignored: gateway '{}' is already active. \
+                                     To redeploy, use: nemoclaw gateway start",
                                     "!".yellow(),
                                     ctx.name,
                                 );
@@ -955,7 +1259,7 @@ async fn main() -> Result<()> {
                                 name.as_deref(),
                                 from.as_deref(),
                                 &ctx.name,
-                                sync,
+                                upload_spec.as_ref(),
                                 keep,
                                 remote.as_deref(),
                                 ssh_key.as_deref(),
@@ -964,6 +1268,8 @@ async fn main() -> Result<()> {
                                 forward,
                                 &command,
                                 tty_override,
+                                bootstrap_override,
+                                auto_providers_override,
                                 &tls,
                             ))
                             .await?;
@@ -973,7 +1279,7 @@ async fn main() -> Result<()> {
                             Box::pin(run::sandbox_create_with_bootstrap(
                                 name.as_deref(),
                                 from.as_deref(),
-                                sync,
+                                upload_spec.as_ref(),
                                 keep,
                                 remote.as_deref(),
                                 ssh_key.as_deref(),
@@ -982,89 +1288,77 @@ async fn main() -> Result<()> {
                                 forward,
                                 &command,
                                 tty_override,
+                                bootstrap_override,
+                                auto_providers_override,
                             ))
                             .await?;
                         }
                     }
                 }
-                SandboxCommands::Forward {
-                    command: ForwardCommands::Stop { port, name },
+                SandboxCommands::Upload {
+                    name,
+                    local_path,
+                    dest,
+                    no_git_ignore,
                 } => {
-                    let cluster_name = resolve_cluster_name(&cli.cluster).unwrap_or_default();
-                    let name = resolve_sandbox_name(name, &cluster_name)?;
-                    if run::stop_forward(&name, port)? {
-                        eprintln!(
-                            "{} Stopped forward of port {port} for sandbox {name}",
-                            "✓".green().bold(),
-                        );
-                    } else {
-                        eprintln!(
-                            "{} No active forward found for port {port} on sandbox {name}",
-                            "!".yellow(),
-                        );
+                    let ctx = resolve_cluster(&cli.cluster)?;
+                    let tls = tls.with_cluster_name(&ctx.name);
+                    let sandbox_dest = dest.as_deref().unwrap_or("/sandbox");
+                    let local = std::path::Path::new(&local_path);
+                    if !local.exists() {
+                        return Err(miette::miette!(
+                            "local path does not exist: {}",
+                            local.display()
+                        ));
                     }
+                    eprintln!("Uploading {} -> sandbox:{}", local.display(), sandbox_dest);
+                    if !no_git_ignore
+                        && let Ok(repo_root) = run::git_repo_root()
+                        && let Ok(files) = run::git_sync_files(&repo_root)
+                        && !files.is_empty()
+                    {
+                        run::sandbox_sync_up_files(
+                            &ctx.endpoint,
+                            &name,
+                            &repo_root,
+                            &files,
+                            sandbox_dest,
+                            &tls,
+                        )
+                        .await?;
+                        eprintln!("{} Upload complete", "✓".green().bold());
+                        return Ok(());
+                    }
+                    // Fallback: upload without git filtering
+                    run::sandbox_sync_up(&ctx.endpoint, &name, local, sandbox_dest, &tls).await?;
+                    eprintln!("{} Upload complete", "✓".green().bold());
                 }
-                SandboxCommands::Forward {
-                    command: ForwardCommands::List,
+                SandboxCommands::Download {
+                    name,
+                    sandbox_path,
+                    dest,
                 } => {
-                    let forwards = run::list_forwards()?;
-                    if forwards.is_empty() {
-                        eprintln!("No active forwards.");
-                    } else {
-                        let name_width = forwards
-                            .iter()
-                            .map(|f| f.sandbox.len())
-                            .max()
-                            .unwrap_or(7)
-                            .max(7); // at least as wide as "SANDBOX"
-                        println!(
-                            "{:<width$} {:<8} {:<10} STATUS",
-                            "SANDBOX",
-                            "PORT",
-                            "PID",
-                            width = name_width,
-                        );
-                        for f in &forwards {
-                            let status = if f.alive {
-                                "running".green().to_string()
-                            } else {
-                                "dead".red().to_string()
-                            };
-                            println!(
-                                "{:<width$} {:<8} {:<10} {}",
-                                f.sandbox,
-                                f.port,
-                                f.pid,
-                                status,
-                                width = name_width,
-                            );
-                        }
-                    }
+                    let ctx = resolve_cluster(&cli.cluster)?;
+                    let tls = tls.with_cluster_name(&ctx.name);
+                    let local_dest = std::path::Path::new(dest.as_deref().unwrap_or("."));
+                    eprintln!(
+                        "Downloading sandbox:{} -> {}",
+                        sandbox_path,
+                        local_dest.display()
+                    );
+                    run::sandbox_sync_down(&ctx.endpoint, &name, &sandbox_path, local_dest, &tls)
+                        .await?;
+                    eprintln!("{} Download complete", "✓".green().bold());
                 }
                 other => {
                     let ctx = resolve_cluster(&cli.cluster)?;
                     let endpoint = &ctx.endpoint;
                     let tls = tls.with_cluster_name(&ctx.name);
                     match other {
-                        SandboxCommands::Create { .. } => {
+                        SandboxCommands::Create { .. }
+                        | SandboxCommands::Upload { .. }
+                        | SandboxCommands::Download { .. } => {
                             unreachable!()
-                        }
-                        SandboxCommands::Sync {
-                            name,
-                            up,
-                            down,
-                            dest,
-                        } => {
-                            let name = resolve_sandbox_name(name, &ctx.name)?;
-                            run::sandbox_sync_command(
-                                endpoint,
-                                &name,
-                                up.as_deref(),
-                                down.as_deref(),
-                                dest.as_deref(),
-                                &tls,
-                            )
-                            .await?;
                         }
                         SandboxCommands::Get { name } => {
                             let name = resolve_sandbox_name(name, &ctx.name)?;
@@ -1085,73 +1379,6 @@ async fn main() -> Result<()> {
                             let name = resolve_sandbox_name(name, &ctx.name)?;
                             let _ = save_last_sandbox(&ctx.name, &name);
                             run::sandbox_connect(endpoint, &name, &tls).await?;
-                        }
-                        SandboxCommands::Forward { command: fwd } => match fwd {
-                            ForwardCommands::Start {
-                                port,
-                                name,
-                                background,
-                            } => {
-                                let name = resolve_sandbox_name(name, &ctx.name)?;
-                                run::sandbox_forward(endpoint, &name, port, background, &tls)
-                                    .await?;
-                                if background {
-                                    eprintln!(
-                                        "{} Forwarding port {port} to sandbox {name} in the background",
-                                        "✓".green().bold(),
-                                    );
-                                    eprintln!("  Access at: http://127.0.0.1:{port}/");
-                                    eprintln!(
-                                        "  Stop with: nemoclaw sandbox forward stop {port} {name}",
-                                    );
-                                }
-                            }
-                            ForwardCommands::Stop { .. } | ForwardCommands::List => unreachable!(),
-                        },
-                        SandboxCommands::Policy {
-                            command: policy_cmd,
-                        } => match policy_cmd {
-                            PolicyCommands::Set {
-                                name,
-                                policy,
-                                wait,
-                                timeout,
-                            } => {
-                                let name = resolve_sandbox_name(name, &ctx.name)?;
-                                run::sandbox_policy_set(
-                                    endpoint, &name, &policy, wait, timeout, &tls,
-                                )
-                                .await?;
-                            }
-                            PolicyCommands::Get { name, rev, full } => {
-                                let name = resolve_sandbox_name(name, &ctx.name)?;
-                                run::sandbox_policy_get(endpoint, &name, rev, full, &tls).await?;
-                            }
-                            PolicyCommands::List { name, limit } => {
-                                let name = resolve_sandbox_name(name, &ctx.name)?;
-                                run::sandbox_policy_list(endpoint, &name, limit, &tls).await?;
-                            }
-                        },
-                        SandboxCommands::Logs {
-                            name,
-                            n,
-                            tail,
-                            since,
-                            source,
-                            level,
-                        } => {
-                            let name = resolve_sandbox_name(name, &ctx.name)?;
-                            run::sandbox_logs(
-                                endpoint,
-                                &name,
-                                n,
-                                tail,
-                                since.as_deref(),
-                                &source,
-                                &level,
-                                &tls,
-                            )
-                            .await?;
                         }
                         SandboxCommands::SshConfig { name } => {
                             let name = resolve_sandbox_name(name, &ctx.name)?;
@@ -1259,9 +1486,9 @@ async fn main() -> Result<()> {
                     } else {
                         let meta = load_cluster_metadata(&c).map_err(|_| {
                             miette::miette!(
-                                "Unknown cluster '{c}'.\n\
-                                  Deploy it first: nemoclaw cluster admin deploy --name {c}\n\
-                                  Or list available clusters: nemoclaw cluster list"
+                                "Unknown gateway '{c}'.\n\
+                                  Deploy it first: nemoclaw gateway start --name {c}\n\
+                                  Or list available gateways: nemoclaw gateway select"
                             )
                         })?;
                         meta.gateway_endpoint
@@ -1280,12 +1507,88 @@ async fn main() -> Result<()> {
                 }
             }
         }
+
+        // -----------------------------------------------------------
+        // Hidden backwards-compat: `cluster admin deploy`
+        // -----------------------------------------------------------
+        Some(Commands::Cluster { command }) => match command {
+            ClusterCommands::Admin { command } => match command {
+                ClusterAdminCommands::Deploy {
+                    name,
+                    update_kube_config,
+                    get_kubeconfig,
+                    remote,
+                    ssh_key,
+                    port,
+                    gateway_host,
+                    kube_port,
+                    recreate,
+                } => {
+                    eprintln!(
+                        "{} `nemoclaw cluster admin deploy` is deprecated. \
+                         Use `nemoclaw gateway start` instead.",
+                        "warning:".yellow().bold(),
+                    );
+                    run::cluster_admin_deploy(
+                        &name,
+                        update_kube_config,
+                        get_kubeconfig,
+                        remote.as_deref(),
+                        ssh_key.as_deref(),
+                        port,
+                        gateway_host.as_deref(),
+                        kube_port,
+                        recreate,
+                    )
+                    .await?;
+                }
+            },
+            ClusterCommands::Inference { command } => {
+                let ctx = resolve_cluster(&cli.cluster)?;
+                let endpoint = &ctx.endpoint;
+                let tls = tls.with_cluster_name(&ctx.name);
+                match command {
+                    ClusterInferenceCommands::Set { provider, model } => {
+                        run::cluster_inference_set(endpoint, &provider, &model, &tls).await?;
+                    }
+                    ClusterInferenceCommands::Update { provider, model } => {
+                        run::cluster_inference_update(
+                            endpoint,
+                            provider.as_deref(),
+                            model.as_deref(),
+                            &tls,
+                        )
+                        .await?;
+                    }
+                    ClusterInferenceCommands::Get => {
+                        run::cluster_inference_get(endpoint, &tls).await?;
+                    }
+                }
+            }
+        },
+
         None => {
             Cli::command().print_help().expect("Failed to print help");
         }
     }
 
     Ok(())
+}
+
+/// Parse an upload spec like `<local>[:<remote>]` into (local_path, optional_sandbox_path).
+fn parse_upload_spec(spec: &str) -> (String, Option<String>) {
+    if let Some((local, remote)) = spec.split_once(':') {
+        (
+            local.to_string(),
+            if remote.is_empty() {
+                None
+            } else {
+                Some(remote.to_string())
+            },
+        )
+    } else {
+        (spec.to_string(), None)
+    }
 }
 
 #[cfg(test)]
@@ -1355,7 +1658,7 @@ mod tests {
     #[test]
     fn completions_policy_flag_falls_back_to_file_paths() {
         let temp = tempfile::tempdir().expect("failed to create tempdir");
-        std::fs::write(temp.path().join("policy.yaml"), "version: 1\n")
+        fs::write(temp.path().join("policy.yaml"), "version: 1\n")
             .expect("failed to create policy file");
 
         let mut cmd = Cli::command();
@@ -1382,15 +1685,15 @@ mod tests {
     #[test]
     fn completions_other_path_flags_fall_back_to_path_candidates() {
         let temp = tempfile::tempdir().expect("failed to create tempdir");
-        std::fs::write(temp.path().join("id_rsa"), "key").expect("failed to create key file");
-        std::fs::write(temp.path().join("Dockerfile"), "FROM scratch\n")
+        fs::write(temp.path().join("id_rsa"), "key").expect("failed to create key file");
+        fs::write(temp.path().join("Dockerfile"), "FROM scratch\n")
             .expect("failed to create dockerfile");
-        std::fs::create_dir(temp.path().join("ctx")).expect("failed to create context directory");
+        fs::create_dir(temp.path().join("ctx")).expect("failed to create context directory");
 
         let cases: Vec<(Vec<&str>, usize, &str)> = vec![
             (
-                vec!["nemoclaw", "cluster", "admin", "deploy", "--ssh-key", "id"],
-                5,
+                vec!["nemoclaw", "gateway", "start", "--ssh-key", "id"],
+                4,
                 "id_rsa",
             ),
             (
@@ -1399,8 +1702,8 @@ mod tests {
                 "id_rsa",
             ),
             (
-                vec!["nemoclaw", "sandbox", "sync", "demo", "--up", "Do"],
-                5,
+                vec!["nemoclaw", "sandbox", "upload", "demo", "Do"],
+                4,
                 "Dockerfile",
             ),
         ];
@@ -1424,26 +1727,26 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_sync_up_uses_path_value_hint() {
+    fn sandbox_upload_uses_path_value_hint() {
         let cmd = Cli::command();
         let sandbox = cmd
             .get_subcommands()
             .find(|c| c.get_name() == "sandbox")
             .expect("missing sandbox subcommand");
-        let sync = sandbox
+        let upload = sandbox
             .get_subcommands()
-            .find(|c| c.get_name() == "sync")
-            .expect("missing sandbox sync subcommand");
-        let up = sync
+            .find(|c| c.get_name() == "upload")
+            .expect("missing sandbox upload subcommand");
+        let local_path = upload
             .get_arguments()
-            .find(|arg| arg.get_id() == "up")
-            .expect("missing --up argument");
+            .find(|arg| arg.get_id() == "local_path")
+            .expect("missing local_path argument");
 
-        assert_eq!(up.get_value_hint(), ValueHint::AnyPath);
+        assert_eq!(local_path.get_value_hint(), ValueHint::AnyPath);
     }
 
     #[test]
-    fn sandbox_sync_up_completion_suggests_local_paths() {
+    fn sandbox_upload_completion_suggests_local_paths() {
         let temp = tempfile::tempdir().expect("failed to create tempdir");
         fs::write(temp.path().join("sample.txt"), "x").expect("failed to create sample file");
 
@@ -1451,12 +1754,11 @@ mod tests {
         let args: Vec<OsString> = vec![
             "nemoclaw".into(),
             "sandbox".into(),
-            "sync".into(),
+            "upload".into(),
             "demo".into(),
-            "--up".into(),
             "sa".into(),
         ];
-        let candidates = clap_complete::engine::complete(&mut cmd, args, 5, Some(temp.path()))
+        let candidates = clap_complete::engine::complete(&mut cmd, args, 4, Some(temp.path()))
             .expect("completion engine failed");
 
         let names: Vec<String> = candidates
@@ -1465,8 +1767,29 @@ mod tests {
             .collect();
         assert!(
             names.iter().any(|name| name.contains("sample.txt")),
-            "expected path completion for --up, got: {names:?}"
+            "expected path completion for upload local_path, got: {names:?}"
         );
+    }
+
+    #[test]
+    fn parse_upload_spec_without_remote() {
+        let (local, remote) = parse_upload_spec("./src");
+        assert_eq!(local, "./src");
+        assert_eq!(remote, None);
+    }
+
+    #[test]
+    fn parse_upload_spec_with_remote() {
+        let (local, remote) = parse_upload_spec("./src:/sandbox/src");
+        assert_eq!(local, "./src");
+        assert_eq!(remote, Some("/sandbox/src".to_string()));
+    }
+
+    #[test]
+    fn parse_upload_spec_with_trailing_colon() {
+        let (local, remote) = parse_upload_spec("./src:");
+        assert_eq!(local, "./src");
+        assert_eq!(remote, None);
     }
 
     #[test]

--- a/crates/navigator-cli/src/run.rs
+++ b/crates/navigator-cli/src/run.rs
@@ -509,14 +509,14 @@ pub fn cluster_use(name: &str) -> Result<()> {
     // Verify the cluster exists
     get_cluster_metadata(name).ok_or_else(|| {
         miette::miette!(
-            "No cluster metadata found for '{name}'.\n\
-             Deploy a cluster first with: nemoclaw cluster admin deploy --name {name}\n\
-             Or list available clusters: nemoclaw cluster list"
+            "No gateway metadata found for '{name}'.\n\
+              Deploy a gateway first with: nemoclaw gateway start --name {name}\n\
+              Or list available gateways: nemoclaw gateway select"
         )
     })?;
 
     save_active_cluster(name)?;
-    eprintln!("{} Active cluster set to '{name}'", "✓".green().bold());
+    eprintln!("{} Active gateway set to '{name}'", "✓".green().bold());
     Ok(())
 }
 
@@ -526,11 +526,11 @@ pub fn cluster_list(cluster_flag: &Option<String>) -> Result<()> {
     let active = cluster_flag.clone().or_else(load_active_cluster);
 
     if clusters.is_empty() {
-        println!("No clusters found.");
+        println!("No gateways found.");
         println!();
         println!(
-            "Deploy a cluster with: {}",
-            "nemoclaw cluster admin deploy".dimmed()
+            "Deploy a gateway with: {}",
+            "nemoclaw gateway start".dimmed()
         );
         return Ok(());
     }
@@ -633,7 +633,7 @@ fn prompt_existing_cluster(
 /// Deploy a cluster with the rich progress panel (interactive) or simple
 /// logging (non-interactive). Returns the [`ClusterHandle`] on success.
 ///
-/// This is the shared deploy UX used by both `cluster admin deploy` and
+/// This is the shared deploy UX used by both `gateway start` and
 /// the auto-bootstrap path in `sandbox create`.
 pub(crate) async fn deploy_cluster_with_panel(
     options: DeployOptions,
@@ -714,6 +714,7 @@ pub async fn cluster_admin_deploy(
     port: u16,
     gateway_host: Option<&str>,
     kube_port: Option<u16>,
+    recreate: bool,
 ) -> Result<()> {
     let location = if remote.is_some() { "remote" } else { "local" };
 
@@ -739,8 +740,9 @@ pub async fn cluster_admin_deploy(
 
     let interactive = std::io::stderr().is_terminal();
 
-    // Check for existing cluster and prompt user if found
-    if interactive {
+    // Check for existing cluster and prompt user if found.
+    // --recreate skips the prompt and always destroys.
+    {
         let remote_opts = remote.map(|dest| {
             let mut opts = RemoteOptions::new(dest);
             if let Some(key) = ssh_key {
@@ -751,8 +753,15 @@ pub async fn cluster_admin_deploy(
         if let Some(info) =
             navigator_bootstrap::check_existing_deployment(name, remote_opts.as_ref()).await?
         {
-            let recreate = prompt_existing_cluster(name, &info)?;
-            if recreate {
+            let should_recreate = if recreate {
+                true
+            } else if interactive {
+                prompt_existing_cluster(name, &info)?
+            } else {
+                false // non-interactive without --recreate: silently reuse
+            };
+
+            if should_recreate {
                 eprintln!("• Destroying existing cluster...");
                 let handle =
                     navigator_bootstrap::cluster_handle(name, remote_opts.as_ref()).await?;
@@ -864,8 +873,8 @@ pub async fn cluster_admin_destroy(
 pub fn cluster_admin_info(name: &str) -> Result<()> {
     let metadata = get_cluster_metadata(name).ok_or_else(|| {
         miette::miette!(
-            "No cluster metadata found for '{name}'.\n\
-             Deploy a cluster first with: nemoclaw cluster admin deploy --name {name}"
+            "No gateway metadata found for '{name}'.\n\
+              Deploy a gateway first with: nemoclaw gateway start --name {name}"
         )
     })?;
 
@@ -900,7 +909,7 @@ pub fn cluster_admin_info(name: &str) -> Result<()> {
         if let (Some(host), Some(kube_port)) = (&metadata.remote_host, metadata.kube_port) {
             println!();
             println!("{}", "SSH tunnel for kubectl access:".dimmed());
-            println!("  nemoclaw cluster admin tunnel --name {name}");
+            println!("  nemoclaw gateway tunnel --name {name}");
             println!("Or manually:");
             println!("  ssh -L {kube_port}:127.0.0.1:6443 {host}");
         }
@@ -967,7 +976,7 @@ pub fn cluster_admin_tunnel(
 pub async fn sandbox_create_with_bootstrap(
     name: Option<&str>,
     from: Option<&str>,
-    sync: bool,
+    upload: Option<&(String, Option<String>, bool)>,
     keep: bool,
     remote: Option<&str>,
     ssh_key: Option<&str>,
@@ -976,12 +985,14 @@ pub async fn sandbox_create_with_bootstrap(
     forward: Option<u16>,
     command: &[String],
     tty_override: Option<bool>,
+    bootstrap_override: Option<bool>,
+    auto_providers_override: Option<bool>,
 ) -> Result<()> {
-    if !crate::bootstrap::confirm_bootstrap()? {
+    if !crate::bootstrap::confirm_bootstrap(bootstrap_override)? {
         return Err(miette::miette!(
-            "No active cluster.\n\
-             Set one with: nemoclaw cluster use <name>\n\
-             Or deploy a new cluster: nemoclaw cluster admin deploy"
+            "No active gateway.\n\
+             Set one with: nemoclaw gateway select <name>\n\
+             Or deploy a new gateway: nemoclaw gateway start"
         ));
     }
     let (tls, server) = crate::bootstrap::run_bootstrap(remote, ssh_key).await?;
@@ -992,7 +1003,7 @@ pub async fn sandbox_create_with_bootstrap(
         name,
         from,
         cluster_name,
-        sync,
+        upload,
         keep,
         remote,
         ssh_key,
@@ -1001,6 +1012,8 @@ pub async fn sandbox_create_with_bootstrap(
         forward,
         command,
         tty_override,
+        bootstrap_override,
+        auto_providers_override,
         &tls,
     )
     .await
@@ -1013,7 +1026,7 @@ pub async fn sandbox_create(
     name: Option<&str>,
     from: Option<&str>,
     cluster_name: &str,
-    sync: bool,
+    upload: Option<&(String, Option<String>, bool)>,
     keep: bool,
     remote: Option<&str>,
     ssh_key: Option<&str>,
@@ -1022,6 +1035,8 @@ pub async fn sandbox_create(
     forward: Option<u16>,
     command: &[String],
     tty_override: Option<bool>,
+    bootstrap_override: Option<bool>,
+    auto_providers_override: Option<bool>,
     tls: &TlsOptions,
 ) -> Result<()> {
     // Try connecting to the cluster. If it fails due to an unreachable cluster,
@@ -1032,7 +1047,7 @@ pub async fn sandbox_create(
             if !crate::bootstrap::should_attempt_bootstrap(&err, tls) {
                 return Err(err);
             }
-            if !crate::bootstrap::confirm_bootstrap()? {
+            if !crate::bootstrap::confirm_bootstrap(bootstrap_override)? {
                 return Err(err);
             }
             let (new_tls, new_server) = crate::bootstrap::run_bootstrap(remote, ssh_key).await?;
@@ -1063,8 +1078,13 @@ pub async fn sandbox_create(
     };
 
     let inferred_types: Vec<String> = inferred_provider_type(command).into_iter().collect();
-    let configured_providers =
-        ensure_required_providers(&mut client, providers, &inferred_types).await?;
+    let configured_providers = ensure_required_providers(
+        &mut client,
+        providers,
+        &inferred_types,
+        auto_providers_override,
+    )
+    .await?;
 
     let mut policy = load_sandbox_policy(policy)?;
 
@@ -1245,16 +1265,29 @@ pub async fn sandbox_create(
             drop(stream);
             drop(client);
 
-            if sync {
-                let repo_root = git_repo_root()?;
-                let files = git_sync_files(&repo_root)?;
-                if !files.is_empty() {
+            if let Some((local_path, sandbox_path, git_ignore)) = upload {
+                let dest = sandbox_path.as_deref().unwrap_or("/sandbox");
+                let local = Path::new(local_path);
+                if *git_ignore
+                    && let Ok(repo_root) = git_repo_root()
+                    && let Ok(files) = git_sync_files(&repo_root)
+                    && !files.is_empty()
+                {
                     sandbox_sync_up_files(
                         &effective_server,
                         &sandbox_name,
                         &repo_root,
                         &files,
-                        "/sandbox",
+                        dest,
+                        &effective_tls,
+                    )
+                    .await?;
+                } else if local.exists() {
+                    sandbox_sync_up(
+                        &effective_server,
+                        &sandbox_name,
+                        local,
+                        dest,
                         &effective_tls,
                     )
                     .await?;
@@ -1278,7 +1311,7 @@ pub async fn sandbox_create(
                     "✓".green().bold(),
                 );
                 eprintln!("Access at: http://127.0.0.1:{port}/");
-                eprintln!("Stop with: nemoclaw sandbox forward stop {port} {sandbox_name}",);
+                eprintln!("Stop with: nemoclaw forward stop {port} {sandbox_name}",);
             }
 
             if command.is_empty() {
@@ -1750,6 +1783,7 @@ async fn ensure_required_providers(
     client: &mut NavigatorClient<Channel>,
     explicit_names: &[String],
     inferred_types: &[String],
+    auto_providers_override: Option<bool>,
 ) -> Result<Vec<String>> {
     if explicit_names.is_empty() && inferred_types.is_empty() {
         return Ok(Vec::new());
@@ -1809,9 +1843,23 @@ async fn ensure_required_providers(
             .collect::<Vec<_>>();
 
         if !missing.is_empty() {
-            if !std::io::stdin().is_terminal() {
+            // --no-auto-providers: skip all missing providers silently.
+            if auto_providers_override == Some(false) {
+                for provider_type in &missing {
+                    eprintln!(
+                        "{} Skipping provider '{provider_type}' (--no-auto-providers)",
+                        "!".yellow(),
+                    );
+                }
+                return Ok(configured_names);
+            }
+
+            // No override and non-interactive: error.
+            if auto_providers_override.is_none() && !std::io::stdin().is_terminal() {
                 return Err(miette::miette!(
-                    "missing required providers: {}. Create them first with `nemoclaw provider create --type <type> --name <name> --from-existing`, or set them up manually from inside the sandbox",
+                    "missing required providers: {}. Create them first with \
+                     `nemoclaw provider create --type <type> --name <name> --from-existing`, \
+                     pass --auto-providers to auto-create, or set them up manually from inside the sandbox",
                     missing.join(", ")
                 ));
             }
@@ -1819,11 +1867,17 @@ async fn ensure_required_providers(
             let registry = ProviderRegistry::new();
             for provider_type in missing {
                 eprintln!("Missing provider: {provider_type}");
-                let should_create = Confirm::new()
-                    .with_prompt("Create from local credentials?")
-                    .default(true)
-                    .interact()
-                    .into_diagnostic()?;
+
+                // --auto-providers: auto-confirm all.
+                let should_create = if auto_providers_override == Some(true) {
+                    true
+                } else {
+                    Confirm::new()
+                        .with_prompt("Create from local credentials?")
+                        .default(true)
+                        .interact()
+                        .into_diagnostic()?
+                };
 
                 if !should_create {
                     eprintln!("{} Skipping provider '{provider_type}'", "!".yellow(),);
@@ -2298,7 +2352,7 @@ pub async fn cluster_inference_get(server: &str, tls: &TlsOptions) -> Result<()>
     Ok(())
 }
 
-fn git_repo_root() -> Result<PathBuf> {
+pub fn git_repo_root() -> Result<PathBuf> {
     let output = Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
         .output()
@@ -2322,7 +2376,7 @@ fn git_repo_root() -> Result<PathBuf> {
     Ok(PathBuf::from(root))
 }
 
-fn git_sync_files(repo_root: &Path) -> Result<Vec<String>> {
+pub fn git_sync_files(repo_root: &Path) -> Result<Vec<String>> {
     let output = Command::new("git")
         .args(["ls-files", "-co", "--exclude-standard", "-z"])
         .current_dir(repo_root)

--- a/e2e/rust/src/harness/sandbox.rs
+++ b/e2e/rust/src/harness/sandbox.rs
@@ -183,28 +183,40 @@ impl SandboxGuard {
         })
     }
 
-    /// Run a `nemoclaw sandbox sync` command on this sandbox.
+    /// Create a sandbox that runs a command, with `--upload` to pre-load files.
     ///
-    /// # Arguments
+    /// Equivalent to:
+    /// ```text
+    /// nemoclaw sandbox create --upload <local>:<dest> [extra_args...] -- <command>
+    /// ```
     ///
-    /// * `args` — Arguments after `nemoclaw sandbox sync <name>`,
-    ///   e.g. `["--up", "/local/path", "/sandbox/dest"]`.
+    /// The `--no-git-ignore` flag is passed to avoid needing a git repository.
     ///
     /// # Errors
     ///
-    /// Returns an error if the sync command fails.
-    pub async fn sync(&self, args: &[&str]) -> Result<String, String> {
+    /// Returns an error if the CLI exits with a non-zero status or the sandbox
+    /// name cannot be parsed.
+    pub async fn create_with_upload(
+        upload_local: &str,
+        upload_dest: &str,
+        command: &[&str],
+    ) -> Result<Self, String> {
+        let upload_spec = format!("{upload_local}:{upload_dest}");
+
         let mut cmd = nemoclaw_cmd();
         cmd.arg("sandbox")
-            .arg("sync")
-            .arg(&self.name)
-            .args(args);
+            .arg("create")
+            .arg("--upload")
+            .arg(&upload_spec)
+            .arg("--no-git-ignore")
+            .arg("--")
+            .args(command);
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
         let output = cmd
             .output()
             .await
-            .map_err(|e| format!("failed to spawn nemoclaw sync: {e}"))?;
+            .map_err(|e| format!("failed to spawn nemoclaw: {e}"))?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -212,7 +224,55 @@ impl SandboxGuard {
 
         if !output.status.success() {
             return Err(format!(
-                "sandbox sync failed (exit {:?}):\n{combined}",
+                "sandbox create --upload failed (exit {:?}):\n{combined}",
+                output.status.code()
+            ));
+        }
+
+        let name = extract_field(&combined, "Name").ok_or_else(|| {
+            format!("could not parse sandbox name from create output:\n{combined}")
+        })?;
+
+        Ok(Self {
+            name,
+            create_output: combined,
+            child: None,
+            cleaned_up: false,
+        })
+    }
+
+    /// Upload local files to the sandbox via `nemoclaw sandbox upload`.
+    ///
+    /// # Arguments
+    ///
+    /// * `local_path` — Local file or directory to upload.
+    /// * `dest` — Destination path in the sandbox (e.g. `/sandbox/uploaded`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the upload command fails.
+    pub async fn upload(&self, local_path: &str, dest: &str) -> Result<String, String> {
+        let mut cmd = nemoclaw_cmd();
+        cmd.arg("sandbox")
+            .arg("upload")
+            .arg(&self.name)
+            .arg(local_path)
+            .arg(dest)
+            .arg("--no-git-ignore");
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+        let output = cmd
+            .output()
+            .await
+            .map_err(|e| format!("failed to spawn nemoclaw upload: {e}"))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let combined = format!("{stdout}{stderr}");
+
+        if !output.status.success() {
+            return Err(format!(
+                "sandbox upload failed (exit {:?}):\n{combined}",
                 output.status.code()
             ));
         }
@@ -220,7 +280,99 @@ impl SandboxGuard {
         Ok(combined)
     }
 
-    /// Spawn `nemoclaw sandbox forward start` as a background process.
+    /// Upload local files with `.gitignore` filtering (default behavior).
+    ///
+    /// Unlike [`upload`], this does NOT pass `--no-git-ignore`, so the CLI
+    /// will filter out gitignored files. The `cwd` is set to the given
+    /// directory so that `git_repo_root()` inside the CLI resolves correctly.
+    ///
+    /// # Arguments
+    ///
+    /// * `local_path` — Local file or directory to upload.
+    /// * `dest` — Destination path in the sandbox.
+    /// * `cwd` — Working directory for the CLI process (should be inside a git
+    ///   repo).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the upload command fails.
+    pub async fn upload_with_gitignore(
+        &self,
+        local_path: &str,
+        dest: &str,
+        cwd: &std::path::Path,
+    ) -> Result<String, String> {
+        let mut cmd = nemoclaw_cmd();
+        cmd.arg("sandbox")
+            .arg("upload")
+            .arg(&self.name)
+            .arg(local_path)
+            .arg(dest)
+            .current_dir(cwd);
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+        let output = cmd
+            .output()
+            .await
+            .map_err(|e| format!("failed to spawn nemoclaw upload: {e}"))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let combined = format!("{stdout}{stderr}");
+
+        if !output.status.success() {
+            return Err(format!(
+                "sandbox upload (with gitignore) failed (exit {:?}):\n{combined}",
+                output.status.code()
+            ));
+        }
+
+        Ok(combined)
+    }
+
+    /// Download files from the sandbox via `nemoclaw sandbox download`.
+    ///
+    /// # Arguments
+    ///
+    /// * `sandbox_path` — Path inside the sandbox to download.
+    /// * `local_dest` — Local destination directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the download command fails.
+    pub async fn download(
+        &self,
+        sandbox_path: &str,
+        local_dest: &str,
+    ) -> Result<String, String> {
+        let mut cmd = nemoclaw_cmd();
+        cmd.arg("sandbox")
+            .arg("download")
+            .arg(&self.name)
+            .arg(sandbox_path)
+            .arg(local_dest);
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+        let output = cmd
+            .output()
+            .await
+            .map_err(|e| format!("failed to spawn nemoclaw download: {e}"))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let combined = format!("{stdout}{stderr}");
+
+        if !output.status.success() {
+            return Err(format!(
+                "sandbox download failed (exit {:?}):\n{combined}",
+                output.status.code()
+            ));
+        }
+
+        Ok(combined)
+    }
+
+    /// Spawn `nemoclaw forward start` as a background process.
     ///
     /// Returns the child process handle. The caller is responsible for killing
     /// it (or it will be killed on drop since `kill_on_drop(true)` is set).
@@ -230,8 +382,7 @@ impl SandboxGuard {
     /// Returns an error if the process cannot be spawned.
     pub fn spawn_forward(&self, port: u16) -> Result<tokio::process::Child, String> {
         let mut cmd = nemoclaw_cmd();
-        cmd.arg("sandbox")
-            .arg("forward")
+        cmd.arg("forward")
             .arg("start")
             .arg(port.to_string())
             .arg(&self.name);

--- a/e2e/rust/tests/cli_smoke.rs
+++ b/e2e/rust/tests/cli_smoke.rs
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! CLI smoke tests that verify command structure and graceful error handling.
+//!
+//! These tests do NOT require a running gateway — they exercise the CLI binary
+//! directly, validating that the restructured command tree parses correctly and
+//! handles edge cases like missing gateway configuration.
+
+use std::process::Stdio;
+
+use nemoclaw_e2e::harness::binary::nemoclaw_cmd;
+use nemoclaw_e2e::harness::output::strip_ansi;
+
+/// Run `nemoclaw <args>` with an isolated (empty) config directory so it
+/// cannot discover any real gateway.
+async fn run_isolated(args: &[&str]) -> (String, i32) {
+    let tmpdir = tempfile::tempdir().expect("create isolated config dir");
+    let mut cmd = nemoclaw_cmd();
+    cmd.args(args)
+        .env("XDG_CONFIG_HOME", tmpdir.path())
+        .env("HOME", tmpdir.path())
+        .env_remove("NEMOCLAW_CLUSTER")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let output = cmd.output().await.expect("spawn nemoclaw");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let combined = format!("{stdout}{stderr}");
+    let code = output.status.code().unwrap_or(-1);
+    (combined, code)
+}
+
+// -------------------------------------------------------------------
+// Top-level --help shows the restructured command tree
+// -------------------------------------------------------------------
+
+/// `nemoclaw --help` must list the new top-level commands: gateway, status,
+/// forward, logs, policy.
+#[tokio::test]
+async fn help_shows_restructured_commands() {
+    let (output, code) = run_isolated(&["--help"]).await;
+    assert_eq!(code, 0, "nemoclaw --help should exit 0");
+
+    let clean = strip_ansi(&output);
+    for cmd in ["gateway", "status", "sandbox", "forward", "logs", "policy"] {
+        assert!(
+            clean.contains(cmd),
+            "expected '{cmd}' in --help output:\n{clean}"
+        );
+    }
+}
+
+/// `nemoclaw gateway --help` must list start, stop, destroy, select, info.
+#[tokio::test]
+async fn gateway_help_shows_subcommands() {
+    let (output, code) = run_isolated(&["gateway", "--help"]).await;
+    assert_eq!(code, 0, "nemoclaw gateway --help should exit 0");
+
+    let clean = strip_ansi(&output);
+    for sub in ["start", "stop", "destroy", "select", "info"] {
+        assert!(
+            clean.contains(sub),
+            "expected '{sub}' in gateway --help output:\n{clean}"
+        );
+    }
+}
+
+/// `nemoclaw sandbox --help` must list upload and download alongside create,
+/// get, list, delete, connect.
+#[tokio::test]
+async fn sandbox_help_shows_upload_download() {
+    let (output, code) = run_isolated(&["sandbox", "--help"]).await;
+    assert_eq!(code, 0, "nemoclaw sandbox --help should exit 0");
+
+    let clean = strip_ansi(&output);
+    for sub in ["upload", "download", "create", "get", "list", "delete", "connect"] {
+        assert!(
+            clean.contains(sub),
+            "expected '{sub}' in sandbox --help output:\n{clean}"
+        );
+    }
+}
+
+/// `nemoclaw sandbox create --help` must show `--upload`, `--no-git-ignore`,
+/// `--bootstrap`/`--no-bootstrap`, and `--auto-providers`/`--no-auto-providers`.
+#[tokio::test]
+async fn sandbox_create_help_shows_new_flags() {
+    let (output, code) = run_isolated(&["sandbox", "create", "--help"]).await;
+    assert_eq!(code, 0, "nemoclaw sandbox create --help should exit 0");
+
+    let clean = strip_ansi(&output);
+    for flag in [
+        "--upload",
+        "--no-git-ignore",
+        "--bootstrap",
+        "--no-bootstrap",
+        "--auto-providers",
+        "--no-auto-providers",
+    ] {
+        assert!(
+            clean.contains(flag),
+            "expected '{flag}' in sandbox create --help:\n{clean}"
+        );
+    }
+}
+
+/// `nemoclaw gateway start --help` must show `--recreate`.
+#[tokio::test]
+async fn gateway_start_help_shows_recreate() {
+    let (output, code) = run_isolated(&["gateway", "start", "--help"]).await;
+    assert_eq!(code, 0, "nemoclaw gateway start --help should exit 0");
+
+    let clean = strip_ansi(&output);
+    assert!(
+        clean.contains("--recreate"),
+        "expected '--recreate' in gateway start --help:\n{clean}"
+    );
+}
+
+// -------------------------------------------------------------------
+// Graceful handling: `nemoclaw status` without a gateway
+// -------------------------------------------------------------------
+
+/// `nemoclaw status` with no gateway configured should exit 0 and print a
+/// friendly message instead of erroring.
+#[tokio::test]
+async fn status_without_gateway_prints_friendly_message() {
+    let (output, code) = run_isolated(&["status"]).await;
+    assert_eq!(
+        code, 0,
+        "nemoclaw status should exit 0 even without a gateway, got output:\n{output}"
+    );
+
+    let clean = strip_ansi(&output);
+    assert!(
+        clean.contains("No gateway configured"),
+        "expected 'No gateway configured' in status output:\n{clean}"
+    );
+    assert!(
+        clean.contains("nemoclaw gateway start"),
+        "expected hint to run 'nemoclaw gateway start':\n{clean}"
+    );
+}
+
+// -------------------------------------------------------------------
+// Hidden backwards-compat: `cluster admin deploy` is still parseable
+// -------------------------------------------------------------------
+
+/// `nemoclaw cluster admin deploy --help` should still work (hidden alias).
+#[tokio::test]
+async fn cluster_admin_deploy_help_is_accessible() {
+    let (output, code) = run_isolated(&["cluster", "admin", "deploy", "--help"]).await;
+    assert_eq!(
+        code, 0,
+        "cluster admin deploy --help should exit 0:\n{output}"
+    );
+
+    let clean = strip_ansi(&output);
+    // Should show the deploy options (name, remote, ssh-key, etc.)
+    assert!(
+        clean.contains("--name") || clean.contains("--remote"),
+        "expected deploy flags in cluster admin deploy --help:\n{clean}"
+    );
+}

--- a/e2e/rust/tests/custom_image.rs
+++ b/e2e/rust/tests/custom_image.rs
@@ -5,10 +5,8 @@
 
 //! E2E test: build a custom container image and run a sandbox with it.
 //!
-//! Replaces `e2e/bash/test_sandbox_custom_image.sh`.
-//!
 //! Prerequisites:
-//! - A running nemoclaw cluster (`nemoclaw cluster admin deploy`)
+//! - A running nemoclaw gateway (`nemoclaw gateway start`)
 //! - Docker daemon running (for image build)
 //! - The `nemoclaw` binary (built automatically from the workspace)
 
@@ -18,6 +16,10 @@ use nemoclaw_e2e::harness::output::strip_ansi;
 use nemoclaw_e2e::harness::sandbox::SandboxGuard;
 
 const DOCKERFILE_CONTENT: &str = r#"FROM python:3.12-slim
+
+# iproute2 is required for sandbox network namespace isolation.
+RUN apt-get update && apt-get install -y --no-install-recommends iproute2 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create the sandbox user/group so the supervisor can switch to it.
 RUN groupadd -g 1000 sandbox && \

--- a/e2e/rust/tests/port_forward.rs
+++ b/e2e/rust/tests/port_forward.rs
@@ -5,10 +5,8 @@
 
 //! E2E test: TCP port forwarding through a sandbox.
 //!
-//! Replaces `e2e/bash/test_port_forward.sh`.
-//!
 //! Prerequisites:
-//! - A running nemoclaw cluster (`nemoclaw cluster admin deploy`)
+//! - A running nemoclaw gateway (`nemoclaw gateway start`)
 //! - The `nemoclaw` binary (built automatically from the workspace)
 
 use std::time::Duration;

--- a/e2e/rust/tests/sync.rs
+++ b/e2e/rust/tests/sync.rs
@@ -3,29 +3,29 @@
 
 #![cfg(feature = "e2e")]
 
-//! E2E test: bidirectional file sync with a sandbox.
-//!
-//! Replaces `e2e/bash/test_sandbox_sync.sh`.
+//! E2E test: bidirectional file upload/download with a sandbox.
 //!
 //! Prerequisites:
-//! - A running nemoclaw cluster (`nemoclaw cluster admin deploy`)
+//! - A running nemoclaw gateway (`nemoclaw gateway start`)
 //! - The `nemoclaw` binary (built automatically from the workspace)
 
 use std::fs;
 use std::io::Write;
+use std::process::Stdio;
 
 use sha2::{Digest, Sha256};
 
 use nemoclaw_e2e::harness::sandbox::SandboxGuard;
 
-/// Create a long-running sandbox, sync files up and down, and verify contents.
+/// Create a long-running sandbox, upload and download files, and verify
+/// contents.
 ///
 /// Covers:
 /// 1. Directory round-trip (nested files)
 /// 2. Large file round-trip (~512 KiB) with SHA-256 checksum verification
 /// 3. Single-file round-trip
 #[tokio::test]
-async fn sandbox_file_sync_round_trip() {
+async fn sandbox_file_upload_download_round_trip() {
     // ---------------------------------------------------------------
     // Step 1 — Create a sandbox with `--keep` running `sleep infinity`.
     // ---------------------------------------------------------------
@@ -36,7 +36,7 @@ async fn sandbox_file_sync_round_trip() {
     let tmpdir = tempfile::tempdir().expect("create tmpdir");
 
     // ---------------------------------------------------------------
-    // Step 2 — Sync up: push a local directory into the sandbox.
+    // Step 2 — Upload: push a local directory into the sandbox.
     // ---------------------------------------------------------------
     let upload_dir = tmpdir.path().join("upload");
     fs::create_dir_all(upload_dir.join("subdir")).expect("create upload dirs");
@@ -45,25 +45,25 @@ async fn sandbox_file_sync_round_trip() {
 
     let upload_str = upload_dir.to_str().expect("upload path is UTF-8");
     guard
-        .sync(&["--up", upload_str, "/sandbox/uploaded"])
+        .upload(upload_str, "/sandbox/uploaded")
         .await
-        .expect("sync --up directory");
+        .expect("upload directory");
 
     // ---------------------------------------------------------------
-    // Step 3 — Sync down: pull the uploaded files back and verify.
+    // Step 3 — Download: pull the uploaded files back and verify.
     // ---------------------------------------------------------------
     let download_dir = tmpdir.path().join("download");
     fs::create_dir_all(&download_dir).expect("create download dir");
 
     let download_str = download_dir.to_str().expect("download path is UTF-8");
     guard
-        .sync(&["--down", "/sandbox/uploaded", download_str])
+        .download("/sandbox/uploaded", download_str)
         .await
-        .expect("sync --down directory");
+        .expect("download directory");
 
     // Verify top-level file.
     let greeting = fs::read_to_string(download_dir.join("greeting.txt"))
-        .expect("read greeting.txt after sync down");
+        .expect("read greeting.txt after download");
     assert_eq!(
         greeting, "hello-from-local",
         "greeting.txt content mismatch"
@@ -71,7 +71,7 @@ async fn sandbox_file_sync_round_trip() {
 
     // Verify nested file.
     let nested = fs::read_to_string(download_dir.join("subdir/nested.txt"))
-        .expect("read subdir/nested.txt after sync down");
+        .expect("read subdir/nested.txt after download");
     assert_eq!(nested, "nested-content", "subdir/nested.txt content mismatch");
 
     // ---------------------------------------------------------------
@@ -98,20 +98,20 @@ async fn sandbox_file_sync_round_trip() {
 
     let large_dir_str = large_dir.to_str().expect("large_dir path is UTF-8");
     guard
-        .sync(&["--up", large_dir_str, "/sandbox/large_test"])
+        .upload(large_dir_str, "/sandbox/large_test")
         .await
-        .expect("sync --up large file");
+        .expect("upload large file");
 
     let large_down = tmpdir.path().join("large_download");
     fs::create_dir_all(&large_down).expect("create large_download dir");
 
     let large_down_str = large_down.to_str().expect("large_down path is UTF-8");
     guard
-        .sync(&["--down", "/sandbox/large_test", large_down_str])
+        .download("/sandbox/large_test", large_down_str)
         .await
-        .expect("sync --down large file");
+        .expect("download large file");
 
-    let actual_data = fs::read(large_down.join("large.bin")).expect("read large.bin after sync");
+    let actual_data = fs::read(large_down.join("large.bin")).expect("read large.bin after download");
     let actual_hash = {
         let mut hasher = Sha256::new();
         hasher.update(&actual_data);
@@ -138,21 +138,21 @@ async fn sandbox_file_sync_round_trip() {
 
     let single_str = single_file.to_str().expect("single path is UTF-8");
     guard
-        .sync(&["--up", single_str, "/sandbox"])
+        .upload(single_str, "/sandbox")
         .await
-        .expect("sync --up single file");
+        .expect("upload single file");
 
     let single_down = tmpdir.path().join("single_down");
     fs::create_dir_all(&single_down).expect("create single_down dir");
 
     let single_down_str = single_down.to_str().expect("single_down path is UTF-8");
     guard
-        .sync(&["--down", "/sandbox/single.txt", single_down_str])
+        .download("/sandbox/single.txt", single_down_str)
         .await
-        .expect("sync --down single file");
+        .expect("download single file");
 
     let single_content = fs::read_to_string(single_down.join("single.txt"))
-        .expect("read single.txt after sync");
+        .expect("read single.txt after download");
     assert_eq!(
         single_content, "single-file-payload",
         "single.txt content mismatch"
@@ -160,6 +160,130 @@ async fn sandbox_file_sync_round_trip() {
 
     // ---------------------------------------------------------------
     // Cleanup (guard also cleans up on drop).
+    // ---------------------------------------------------------------
+    guard.cleanup().await;
+}
+
+/// Verify that `sandbox upload` respects `.gitignore` by default.
+///
+/// Creates a temporary git repository with a `.gitignore` that excludes
+/// `*.log` files, uploads the directory (without `--no-git-ignore`), and
+/// confirms that tracked files arrive but ignored files do not.
+#[tokio::test]
+async fn upload_respects_gitignore_by_default() {
+    // ---------------------------------------------------------------
+    // Step 1 — Create a sandbox with `--keep`.
+    // ---------------------------------------------------------------
+    let mut guard = SandboxGuard::create_keep(&["sleep", "infinity"], "Ready")
+        .await
+        .expect("sandbox create --keep");
+
+    // ---------------------------------------------------------------
+    // Step 2 — Set up a temp git repo with tracked + ignored files.
+    // ---------------------------------------------------------------
+    let tmpdir = tempfile::tempdir().expect("create tmpdir");
+    let repo = tmpdir.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo dir");
+
+    // Initialize git repo and add files.
+    let git_init = tokio::process::Command::new("git")
+        .args(["init"])
+        .current_dir(&repo)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .expect("git init");
+    assert!(git_init.success(), "git init should succeed");
+
+    // Configure git user for the commit.
+    let _ = tokio::process::Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(&repo)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await;
+    let _ = tokio::process::Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(&repo)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await;
+
+    // Create .gitignore, a tracked file, and an ignored file.
+    fs::write(repo.join(".gitignore"), "*.log\nbuild/\n").expect("write .gitignore");
+    fs::write(repo.join("tracked.txt"), "i-am-tracked").expect("write tracked.txt");
+    fs::write(repo.join("ignored.log"), "i-should-be-filtered").expect("write ignored.log");
+    fs::create_dir_all(repo.join("build")).expect("create build dir");
+    fs::write(repo.join("build/output.bin"), "build-artifact").expect("write build/output.bin");
+
+    // git add + commit so git ls-files works.
+    let _ = tokio::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(&repo)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .expect("git add");
+    let _ = tokio::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(&repo)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .expect("git commit");
+
+    // ---------------------------------------------------------------
+    // Step 3 — Upload WITH gitignore filtering (default).
+    // ---------------------------------------------------------------
+    let repo_str = repo.to_str().expect("repo path is UTF-8");
+    guard
+        .upload_with_gitignore(repo_str, "/sandbox/filtered", &repo)
+        .await
+        .expect("upload with gitignore filtering");
+
+    // ---------------------------------------------------------------
+    // Step 4 — Verify: tracked file exists, ignored files do not.
+    // ---------------------------------------------------------------
+    // Download the uploaded directory and verify contents.
+    let download_dir = tmpdir.path().join("verify");
+    fs::create_dir_all(&download_dir).expect("create verify dir");
+    let download_str = download_dir.to_str().expect("verify path is UTF-8");
+
+    guard
+        .download("/sandbox/filtered", download_str)
+        .await
+        .expect("download filtered upload");
+
+    // tracked.txt should be present.
+    let tracked = fs::read_to_string(download_dir.join("tracked.txt"))
+        .expect("tracked.txt should exist after filtered upload");
+    assert_eq!(tracked, "i-am-tracked", "tracked.txt content mismatch");
+
+    // .gitignore itself should be present (it's tracked).
+    assert!(
+        download_dir.join(".gitignore").exists(),
+        ".gitignore should be uploaded (it's a tracked file)"
+    );
+
+    // ignored.log should NOT be present.
+    assert!(
+        !download_dir.join("ignored.log").exists(),
+        "ignored.log should be filtered out by .gitignore"
+    );
+
+    // build/ directory should NOT be present.
+    assert!(
+        !download_dir.join("build").exists(),
+        "build/ directory should be filtered out by .gitignore"
+    );
+
+    // ---------------------------------------------------------------
+    // Cleanup.
     // ---------------------------------------------------------------
     guard.cleanup().await;
 }

--- a/e2e/rust/tests/upload_create.rs
+++ b/e2e/rust/tests/upload_create.rs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "e2e")]
+
+//! E2E test: `sandbox create --upload` pre-loads files before running a command.
+//!
+//! Validates that the `--upload <local>:<dest>` flag on `sandbox create`
+//! transfers files into the sandbox before the user command executes,
+//! so the command can read the uploaded content.
+//!
+//! Prerequisites:
+//! - A running nemoclaw gateway (`nemoclaw gateway start`)
+//! - The `nemoclaw` binary (built automatically from the workspace)
+
+use std::fs;
+
+use nemoclaw_e2e::harness::output::strip_ansi;
+use nemoclaw_e2e::harness::sandbox::SandboxGuard;
+
+/// Create a sandbox with `--upload dir:/sandbox/data` and run a command that
+/// reads the uploaded files, verifying the content appears in stdout.
+#[tokio::test]
+async fn create_with_upload_provides_files_to_command() {
+    let tmpdir = tempfile::tempdir().expect("create tmpdir");
+
+    // Create a directory with files to upload.
+    let upload_dir = tmpdir.path().join("project");
+    fs::create_dir_all(upload_dir.join("src")).expect("create project/src");
+    fs::write(upload_dir.join("marker.txt"), "upload-create-marker").expect("write marker.txt");
+    fs::write(upload_dir.join("src/main.py"), "print('hello')").expect("write main.py");
+
+    let upload_str = upload_dir.to_str().expect("upload path is UTF-8");
+
+    // The command reads the marker file — if upload worked, its content
+    // appears in the output.
+    let mut guard = SandboxGuard::create_with_upload(
+        upload_str,
+        "/sandbox/data",
+        &["cat", "/sandbox/data/marker.txt"],
+    )
+    .await
+    .expect("sandbox create --upload");
+
+    let clean = strip_ansi(&guard.create_output);
+    assert!(
+        clean.contains("upload-create-marker"),
+        "expected uploaded marker content in sandbox output:\n{clean}"
+    );
+
+    guard.cleanup().await;
+}
+
+/// `--upload` with a single file (not a directory) should work.
+#[tokio::test]
+async fn create_with_upload_single_file() {
+    let tmpdir = tempfile::tempdir().expect("create tmpdir");
+    let file_path = tmpdir.path().join("config.txt");
+    fs::write(&file_path, "single-file-upload-test").expect("write config.txt");
+
+    let file_str = file_path.to_str().expect("file path is UTF-8");
+
+    let mut guard = SandboxGuard::create_with_upload(
+        file_str,
+        "/sandbox",
+        &["cat", "/sandbox/config.txt"],
+    )
+    .await
+    .expect("sandbox create --upload single file");
+
+    let clean = strip_ansi(&guard.create_output);
+    assert!(
+        clean.contains("single-file-upload-test"),
+        "expected single-file content in sandbox output:\n{clean}"
+    );
+
+    guard.cleanup().await;
+}

--- a/examples/bring-your-own-container/README.md
+++ b/examples/bring-your-own-container/README.md
@@ -6,7 +6,7 @@ your local machine through port forwarding.
 
 ## Prerequisites
 
-- A running NemoClaw cluster (`nemoclaw cluster admin deploy`)
+- A running NemoClaw gateway (`nemoclaw gateway start`)
 - Docker daemon running
 
 ## What's in this example

--- a/examples/local-inference/README.md
+++ b/examples/local-inference/README.md
@@ -51,7 +51,7 @@ requests locally — no gRPC server or cluster required.
 
 ```bash
 mise run cluster
-nemoclaw cluster status
+nemoclaw status
 ```
 
 #### 2. Configure cluster inference

--- a/examples/sync-files.md
+++ b/examples/sync-files.md
@@ -1,26 +1,26 @@
 # Syncing Files To and From a Sandbox
 
 Move code, data, and artifacts between your local machine and a NemoClaw
-sandbox using `nemoclaw sandbox sync`.
+sandbox using `nemoclaw sandbox upload` and `nemoclaw sandbox download`.
 
 ## Push local files into a sandbox
 
 Upload your current project directory into `/sandbox` on the sandbox:
 
 ```bash
-nemoclaw sandbox sync my-sandbox --up .
+nemoclaw sandbox upload my-sandbox .
 ```
 
 Push a specific directory to a custom destination:
 
 ```bash
-nemoclaw sandbox sync my-sandbox --up ./src /sandbox/src
+nemoclaw sandbox upload my-sandbox ./src /sandbox/src
 ```
 
 Push a single file:
 
 ```bash
-nemoclaw sandbox sync my-sandbox --up ./config.yaml /sandbox/config.yaml
+nemoclaw sandbox upload my-sandbox ./config.yaml /sandbox/config.yaml
 ```
 
 ## Pull files from a sandbox
@@ -28,13 +28,13 @@ nemoclaw sandbox sync my-sandbox --up ./config.yaml /sandbox/config.yaml
 Download sandbox output to your local machine:
 
 ```bash
-nemoclaw sandbox sync my-sandbox --down /sandbox/output ./output
+nemoclaw sandbox download my-sandbox /sandbox/output ./output
 ```
 
 Pull results to the current directory:
 
 ```bash
-nemoclaw sandbox sync my-sandbox --down /sandbox/results
+nemoclaw sandbox download my-sandbox /sandbox/results
 ```
 
 ## Sync on create
@@ -55,14 +55,14 @@ This collects tracked and untracked (non-ignored) files via
 nemoclaw sandbox create --name dev --sync --keep
 
 # Make local changes, then push them
-nemoclaw sandbox sync dev --up ./src /sandbox/src
+nemoclaw sandbox upload dev ./src /sandbox/src
 
 # Run tests inside the sandbox
 nemoclaw sandbox connect dev
 # (inside sandbox) pytest
 
 # Pull test artifacts back
-nemoclaw sandbox sync dev --down /sandbox/coverage ./coverage
+nemoclaw sandbox download dev /sandbox/coverage ./coverage
 ```
 
 ## How it works

--- a/examples/vscode-remote-sandbox.md
+++ b/examples/vscode-remote-sandbox.md
@@ -6,7 +6,7 @@ extension so you get a full IDE experience inside the sandbox environment.
 
 ## Prerequisites
 
-- A running nemoclaw cluster (`nemoclaw cluster admin deploy`)
+- A running nemoclaw gateway (`nemoclaw gateway start`)
 - [VSCode](https://code.visualstudio.com/) with the
   [Remote - SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh)
   extension installed

--- a/tasks/scripts/cluster-bootstrap.sh
+++ b/tasks/scripts/cluster-bootstrap.sh
@@ -209,7 +209,7 @@ VOLUME_NAME="navigator-cluster-${CLUSTER_NAME}"
 if [ "${MODE}" = "fast" ]; then
   if docker inspect "${CONTAINER_NAME}" >/dev/null 2>&1 || docker volume inspect "${VOLUME_NAME}" >/dev/null 2>&1; then
     echo "Recreating cluster '${CLUSTER_NAME}' from scratch..."
-    nemoclaw cluster admin destroy --name "${CLUSTER_NAME}"
+    nemoclaw gateway destroy --name "${CLUSTER_NAME}"
   fi
 fi
 
@@ -236,7 +236,7 @@ if [ -z "${NEMOCLAW_CLUSTER_IMAGE:-}" ]; then
   export NEMOCLAW_CLUSTER_IMAGE="navigator/cluster:${IMAGE_TAG}"
 fi
 
-DEPLOY_CMD=(nemoclaw cluster admin deploy --name "${CLUSTER_NAME}" --port "${GATEWAY_PORT}" --update-kube-config)
+DEPLOY_CMD=(nemoclaw gateway start --name "${CLUSTER_NAME}" --port "${GATEWAY_PORT}" --update-kube-config)
 
 if [ -n "${GATEWAY_HOST:-}" ]; then
   DEPLOY_CMD+=(--gateway-host "${GATEWAY_HOST}")


### PR DESCRIPTION
## Summary

Restructures the `nemoclaw` CLI to flatten deeply nested subcommands and improve discoverability, implementing all items from #114.

- **Top-level promotions**: `nemoclaw status`, `forward`, `logs`, `policy` now work directly instead of requiring `sandbox` prefix
- **Gateway subcommand**: New `nemoclaw gateway start|stop|select|list` replacing `cluster admin deploy|destroy|select|list`; hidden backwards-compat alias for `cluster admin deploy` with deprecation warning
- **Upload replaces sync**: `--upload <local>[:<remote>]` with `.gitignore` filtering by default (`--no-git-ignore` to disable); new `sandbox upload`/`download` subcommands for file transfer
- **Graceful missing gateway**: `nemoclaw status` prints a friendly message instead of erroring when no gateway is configured
- **Gateway select UX**: Running `gateway select` without args lists available gateways with a hint to run `gateway select <name>`

### Command mapping (old → new)

| Old | New |
|-----|-----|
| `cluster admin deploy` | `gateway start` |
| `cluster admin destroy` | `gateway stop` |
| `cluster admin select` | `gateway select` |
| `cluster admin list` | `gateway list` |
| `sandbox status` | `status` |
| `sandbox forward` | `forward` |
| `sandbox logs` | `logs` |
| `sandbox policy get\|set` | `policy get\|set` |
| `sandbox create --sync` | `sandbox create --upload <path>[:<remote>]` |
| _(new)_ | `sandbox upload <name> <path>` |
| _(new)_ | `sandbox download <name> <remote> [local]` |

### Files changed (22 files, +836 −579)

**Core implementation**: `main.rs` (enum restructure, routing, `parse_upload_spec()`), `run.rs` (signature changes, public helpers), `bootstrap.rs` (error messages)

**Documentation**: README, 6 architecture docs, 4 agent skills, 4 examples, 4 e2e tests/scripts

### Testing

- All 50 Rust tests pass (26 lib + 13 bin + 2 mTLS + 6 provider + 3 sandbox name)
- Pre-commit suite passes (fmt, clippy, check, test, helm lint, license, python)
- New tests: `parse_upload_spec_*` (3 tests), `sandbox_upload_uses_path_value_hint`, `sandbox_upload_completion_suggests_local_paths`

Closes #114