### PR TITLE
fix(ci): standardize safe tag fetches

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Fetch tags
         run: git fetch --tags --force
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,6 +74,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Fetch tags
         run: git fetch --tags --force
 
@@ -137,6 +140,9 @@ jobs:
 
       - name: Mark workspace safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Fetch tags
+        run: git fetch --tags --force
 
       - name: Compute Python version
         id: version
@@ -270,6 +276,9 @@ jobs:
       - name: Mark workspace safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Fetch tags
+        run: git fetch --tags --force
+
       - name: Install tools
         run: mise install
 
@@ -358,6 +367,9 @@ jobs:
 
       - name: Mark workspace safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Fetch tags
+        run: git fetch --tags --force
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/NemoClaw/actions/runs/22789880653/job/66114338702

## Summary
- keep explicit `git fetch --tags --force` steps in versioning jobs
- mark `$GITHUB_WORKSPACE` as a safe Git directory before every manual tag fetch
- apply the same checkout + safe-directory + tag-fetch pattern across Docker build and publish workflows

## Why
We want one consistent pattern for version discovery in CI: full checkout history, an explicit tag refresh, and a safe workspace configuration before any manual Git command. Some jobs already marked the workspace safe, but the containerized Docker build jobs did not, which caused `git fetch --tags --force` to fail with Git's dubious ownership protection. This change keeps the explicit tag fetches and standardizes the required safety setup everywhere they run.