### PR TITLE
fix(ci): drop unnecessary pipefail in docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Compute cargo version
         id: version
         run: |
-          set -euo pipefail
+          set -eu
           echo "cargo_version=$(uv run python tasks/scripts/release.py get-version --cargo)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR


### PR DESCRIPTION
## Summary
- remove `pipefail` from the reusable Docker build workflow's compute-version step
- keep the explicit safe-directory and `git fetch --tags --force` setup introduced in #165

## Why
PR #165 standardized explicit tag refreshes across CI, but the reusable `.github/workflows/docker-build.yml` workflow still runs steps with `sh` by default. The compute-version step only executes a single command substitution, so `pipefail` provides no benefit there and causes `/bin/sh` to fail with `Illegal option -o pipefail`. Dropping it fixes the workflow without changing the tag-fetch policy.