### PR TITLE
fix(ci): use docker-safe publish image tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,11 +80,12 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags --force
 
-      - name: Compute cargo version
+      - name: Compute image versions
         id: version
         run: |
           set -euo pipefail
           echo "cargo_version=$(uv run python tasks/scripts/release.py get-version --cargo)" >> "$GITHUB_OUTPUT"
+          echo "docker_version=$(uv run python tasks/scripts/release.py get-version --docker)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
@@ -100,7 +101,7 @@ jobs:
           DOCKER_BUILDER: navigator
           IMAGE_TAG: dev
           TAG_LATEST: "true"
-          EXTRA_DOCKER_TAGS: ${{ steps.version.outputs.cargo_version }}
+          EXTRA_DOCKER_TAGS: ${{ steps.version.outputs.docker_version }}
           NEMOCLAW_CARGO_VERSION: ${{ steps.version.outputs.cargo_version }}
         run: mise run --no-prepare docker:publish:cluster:multiarch
 


### PR DESCRIPTION
## Summary
- compute both Cargo and Docker-safe release versions in the publish workflow
- keep `NEMOCLAW_CARGO_VERSION` on the Cargo version for artifact metadata
- use the Docker-safe version output for `EXTRA_DOCKER_TAGS` during multi-arch image publish

## Why
The publish pipeline now refreshes tags successfully, but `Publish Containers` still fails when the computed Cargo version includes `+` metadata (for example `0.5.1-dev.53+g683c56992`). Docker tags cannot contain `+`, and `tasks/scripts/release.py get-version --docker` already provides the sanitized form. This change uses that existing docker-safe output for image tags while preserving the Cargo version where the build metadata is still needed.