### PR TITLE
fix(cli): scope git-aware sandbox uploads to requested path

### DIFF
--- a/crates/navigator-cli/src/main.rs
+++ b/crates/navigator-cli/src/main.rs
@@ -1312,15 +1312,11 @@ async fn main() -> Result<()> {
                         ));
                     }
                     eprintln!("Uploading {} -> sandbox:{}", local.display(), sandbox_dest);
-                    if !no_git_ignore
-                        && let Ok(repo_root) = run::git_repo_root()
-                        && let Ok(files) = run::git_sync_files(&repo_root)
-                        && !files.is_empty()
-                    {
+                    if !no_git_ignore && let Ok((base_dir, files)) = run::git_sync_files(local) {
                         run::sandbox_sync_up_files(
                             &ctx.endpoint,
                             &name,
-                            &repo_root,
+                            &base_dir,
                             &files,
                             sandbox_dest,
                             &tls,

--- a/crates/navigator-cli/src/run.rs
+++ b/crates/navigator-cli/src/run.rs
@@ -1268,15 +1268,11 @@ pub async fn sandbox_create(
             if let Some((local_path, sandbox_path, git_ignore)) = upload {
                 let dest = sandbox_path.as_deref().unwrap_or("/sandbox");
                 let local = Path::new(local_path);
-                if *git_ignore
-                    && let Ok(repo_root) = git_repo_root()
-                    && let Ok(files) = git_sync_files(&repo_root)
-                    && !files.is_empty()
-                {
+                if *git_ignore && let Ok((base_dir, files)) = git_sync_files(local) {
                     sandbox_sync_up_files(
                         &effective_server,
                         &sandbox_name,
-                        &repo_root,
+                        &base_dir,
                         &files,
                         dest,
                         &effective_tls,
@@ -2352,9 +2348,17 @@ pub async fn cluster_inference_get(server: &str, tls: &TlsOptions) -> Result<()>
     Ok(())
 }
 
-pub fn git_repo_root() -> Result<PathBuf> {
+pub fn git_repo_root(local_path: &Path) -> Result<PathBuf> {
+    let git_dir = if local_path.is_dir() {
+        local_path
+    } else {
+        local_path
+            .parent()
+            .ok_or_else(|| miette::miette!("path has no parent: {}", local_path.display()))?
+    };
     let output = Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
+        .current_dir(git_dir)
         .output()
         .into_diagnostic()
         .wrap_err("failed to run git rev-parse")?;
@@ -2376,10 +2380,51 @@ pub fn git_repo_root() -> Result<PathBuf> {
     Ok(PathBuf::from(root))
 }
 
-pub fn git_sync_files(repo_root: &Path) -> Result<Vec<String>> {
+pub fn git_sync_files(local_path: &Path) -> Result<(PathBuf, Vec<String>)> {
+    let repo_root = std::fs::canonicalize(git_repo_root(local_path)?)
+        .into_diagnostic()
+        .wrap_err("failed to canonicalize git repository root")?;
+    let local_path = if local_path.is_absolute() {
+        local_path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .into_diagnostic()
+            .wrap_err("failed to resolve current directory")?
+            .join(local_path)
+    };
+    let local_path = std::fs::canonicalize(local_path)
+        .into_diagnostic()
+        .wrap_err("failed to canonicalize local upload path")?;
+    let relative_path = local_path
+        .strip_prefix(&repo_root)
+        .into_diagnostic()
+        .wrap_err_with(|| {
+            format!(
+                "local path '{}' is not inside git repository '{}'",
+                local_path.display(),
+                repo_root.display()
+            )
+        })?;
+
+    let is_file = local_path.is_file();
+    let base_dir = if is_file {
+        local_path
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| miette::miette!("path has no parent: {}", local_path.display()))?
+    } else {
+        local_path.clone()
+    };
+    let pathspec = if relative_path.as_os_str().is_empty() {
+        None
+    } else {
+        Some(relative_path.to_string_lossy().into_owned())
+    };
+
     let output = Command::new("git")
         .args(["ls-files", "-co", "--exclude-standard", "-z"])
-        .current_dir(repo_root)
+        .args(pathspec.as_deref())
+        .current_dir(&repo_root)
         .output()
         .into_diagnostic()
         .wrap_err("failed to run git ls-files")?;
@@ -2396,11 +2441,29 @@ pub fn git_sync_files(repo_root: &Path) -> Result<Vec<String>> {
         if entry.is_empty() {
             continue;
         }
-        let path = String::from_utf8_lossy(entry).to_string();
-        files.push(path);
+        let repo_relative = Path::new(std::str::from_utf8(entry).into_diagnostic()?);
+        let path = if is_file {
+            repo_relative
+                .file_name()
+                .map(PathBuf::from)
+                .ok_or_else(|| {
+                    miette::miette!("path has no file name: {}", repo_relative.display())
+                })?
+        } else if relative_path.as_os_str().is_empty() {
+            repo_relative.to_path_buf()
+        } else {
+            repo_relative
+                .strip_prefix(relative_path)
+                .into_diagnostic()?
+                .to_path_buf()
+        };
+        if path.as_os_str().is_empty() {
+            continue;
+        }
+        files.push(path.to_string_lossy().into_owned());
     }
 
-    Ok(files)
+    Ok((base_dir, files))
 }
 
 // ---------------------------------------------------------------------------
@@ -2787,7 +2850,10 @@ fn print_log_line(log: &navigator_core::proto::SandboxLogLine) {
 
 #[cfg(test)]
 mod tests {
-    use super::{inferred_provider_type, parse_credential_pairs};
+    use super::{git_sync_files, inferred_provider_type, parse_credential_pairs};
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
 
     struct EnvVarGuard {
         key: &'static str,
@@ -2901,5 +2967,55 @@ mod tests {
     fn inferred_provider_type_handles_full_path() {
         let result = inferred_provider_type(&["/usr/local/bin/claude".to_string()]);
         assert_eq!(result, Some("claude".to_string()));
+    }
+
+    fn init_git_repo(path: &Path) {
+        let status = Command::new("git")
+            .args(["init"])
+            .current_dir(path)
+            .status()
+            .expect("git init");
+        assert!(status.success(), "git init should succeed");
+    }
+
+    #[test]
+    fn git_sync_files_scopes_single_file_to_requested_path() {
+        let tmpdir = tempfile::tempdir().expect("create tmpdir");
+        let repo = tmpdir.path().join("repo");
+        fs::create_dir_all(repo.join("nested")).expect("create repo");
+        init_git_repo(&repo);
+
+        fs::write(repo.join("tracked.txt"), "tracked").expect("write tracked.txt");
+        fs::write(repo.join("nested/other.txt"), "other").expect("write other.txt");
+
+        let result = git_sync_files(&repo.join("tracked.txt"));
+        let (base_dir, files) = result.expect("git_sync_files should succeed");
+        assert_eq!(
+            base_dir,
+            fs::canonicalize(&repo).expect("canonicalize repo path")
+        );
+        assert_eq!(files, vec!["tracked.txt"]);
+    }
+
+    #[test]
+    fn git_sync_files_scopes_directory_to_requested_subtree() {
+        let tmpdir = tempfile::tempdir().expect("create tmpdir");
+        let repo = tmpdir.path().join("repo");
+        fs::create_dir_all(repo.join("nested/inner")).expect("create repo");
+        init_git_repo(&repo);
+
+        fs::write(repo.join("nested/file.txt"), "file").expect("write file.txt");
+        fs::write(repo.join("nested/inner/child.txt"), "child").expect("write child.txt");
+        fs::write(repo.join("top.txt"), "top").expect("write top.txt");
+
+        let result = git_sync_files(&repo.join("nested"));
+        let (base_dir, mut files) = result.expect("git_sync_files should succeed");
+        files.sort();
+
+        assert_eq!(
+            base_dir,
+            fs::canonicalize(repo.join("nested")).expect("canonicalize nested path")
+        );
+        assert_eq!(files, vec!["file.txt", "inner/child.txt"]);
     }
 }

--- a/e2e/rust/tests/sync.rs
+++ b/e2e/rust/tests/sync.rs
@@ -287,3 +287,60 @@ async fn upload_respects_gitignore_by_default() {
     // ---------------------------------------------------------------
     guard.cleanup().await;
 }
+
+/// Verify that uploading a single tracked file from inside a git repo does not
+/// expand to the entire repository.
+#[tokio::test]
+async fn upload_single_file_from_git_repo_only_uploads_that_file() {
+    let mut guard = SandboxGuard::create_keep(&["sleep", "infinity"], "Ready")
+        .await
+        .expect("sandbox create --keep");
+
+    let tmpdir = tempfile::tempdir().expect("create tmpdir");
+    let repo = tmpdir.path().join("repo");
+    fs::create_dir_all(repo.join("nested")).expect("create repo dir");
+
+    let git_init = tokio::process::Command::new("git")
+        .args(["init"])
+        .current_dir(&repo)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .expect("git init");
+    assert!(git_init.success(), "git init should succeed");
+
+    fs::write(repo.join(".gitignore"), "*.log\n").expect("write .gitignore");
+    fs::write(repo.join("nested/config.txt"), "single-file-from-repo").expect("write config.txt");
+    fs::write(repo.join("tracked.txt"), "should-not-upload").expect("write tracked.txt");
+    fs::write(repo.join("ignored.log"), "ignored").expect("write ignored.log");
+
+    let local_path = repo.join("nested/config.txt");
+    let local_str = local_path.to_str().expect("local path is UTF-8");
+    guard
+        .upload_with_gitignore(local_str, "/sandbox/single-file", &repo)
+        .await
+        .expect("upload single tracked file with gitignore");
+
+    let download_dir = tmpdir.path().join("single-file-download");
+    fs::create_dir_all(&download_dir).expect("create download dir");
+    let download_str = download_dir.to_str().expect("download path is UTF-8");
+
+    guard
+        .download("/sandbox/single-file", download_str)
+        .await
+        .expect("download uploaded single file");
+
+    let uploaded = fs::read_to_string(download_dir.join("config.txt")).expect("read config.txt");
+    assert_eq!(uploaded, "single-file-from-repo");
+    assert!(
+        !download_dir.join("tracked.txt").exists(),
+        "tracked.txt should not have been uploaded"
+    );
+    assert!(
+        !download_dir.join("ignored.log").exists(),
+        "ignored.log should not have been uploaded"
+    );
+
+    guard.cleanup().await;
+}


### PR DESCRIPTION
## Issue

Running this, when there is a git repo in parent of data would result in uploading the whole git repo, rather than just the `./data/AGENTS.md` file.

```bash
nemoclaw sandbox upload mcp-probe-retest2 ./data/AGENTS.md /sandbox/xxx
Uploading ./data/AGENTS.md -> sandbox:/sandbox/foo
✓ Upload complete
```

## Summary
- scope git-aware `sandbox upload` and `sandbox create --upload` file discovery to the requested local path instead of the repository root
- preserve the requested subtree shape for directory uploads and only send the selected file for single-file uploads
- add unit and e2e coverage for uploading a single tracked file from inside a git repository

## Testing
- cargo test -p navigator-cli git_sync_files_
- CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo test --manifest-path \"e2e/rust/Cargo.toml\" --features e2e --test sync --no-run
- CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo test --manifest-path \"e2e/rust/Cargo.toml\" --features e2e --test sync upload_single_file_from_git_repo_only_uploads_that_file -- --nocapture