### PR TITLE
fix(sandbox): treat IPv6 ULA addresses as internal

### DIFF
--- a/architecture/security-policy.md
+++ b/architecture/security-policy.md
@@ -845,6 +845,7 @@ These ranges are blocked by default but can be selectively allowed via the `allo
 | `10.0.0.0/8` | RFC 1918 private (Class A) |
 | `172.16.0.0/12` | RFC 1918 private (Class B) |
 | `192.168.0.0/16` | RFC 1918 private (Class C) |
+| `fc00::/7` | IPv6 Unique Local Address (ULA) private space |
 
 ### Implementation
 

--- a/crates/navigator-sandbox/src/proxy.rs
+++ b/crates/navigator-sandbox/src/proxy.rs
@@ -951,7 +951,7 @@ fn query_l7_config(
 /// This is a defense-in-depth check to prevent SSRF via the CONNECT proxy.
 /// It covers:
 /// - IPv4 loopback (127.0.0.0/8), private (10/8, 172.16/12, 192.168/16), link-local (169.254/16)
-/// - IPv6 loopback (`::1`), link-local (`fe80::/10`)
+/// - IPv6 loopback (`::1`), link-local (`fe80::/10`), ULA (`fc00::/7`)
 /// - IPv4-mapped IPv6 addresses (`::ffff:x.x.x.x`) are unwrapped and checked as IPv4
 fn is_internal_ip(ip: IpAddr) -> bool {
     match ip {
@@ -962,6 +962,10 @@ fn is_internal_ip(ip: IpAddr) -> bool {
             }
             // fe80::/10 — IPv6 link-local
             if (v6.segments()[0] & 0xffc0) == 0xfe80 {
+                return true;
+            }
+            // fc00::/7 — IPv6 unique local addresses (ULA)
+            if (v6.segments()[0] & 0xfe00) == 0xfc00 {
                 return true;
             }
             // Check IPv4-mapped IPv6 (::ffff:x.x.x.x)
@@ -1679,6 +1683,14 @@ mod tests {
         // fe80::1
         assert!(is_internal_ip(IpAddr::V6(Ipv6Addr::new(
             0xfe80, 0, 0, 0, 0, 0, 0, 1
+        ))));
+    }
+
+    #[test]
+    fn test_rejects_ipv6_unique_local_address() {
+        // fdc4:f303:9324::254
+        assert!(is_internal_ip(IpAddr::V6(Ipv6Addr::new(
+            0xfdc4, 0xf303, 0x9324, 0, 0, 0, 0, 0x0254
         ))));
     }
 


### PR DESCRIPTION
## Summary
- classify IPv6 ULA addresses in `fc00::/7` as internal in the sandbox proxy SSRF check
- add regression coverage for the host-side ULA address seen from `host.docker.internal`
- document `fc00::/7` in the security policy reference so the allowlist behavior matches the implementation

## Context
- this fixes a sandbox networking issue where `host.docker.internal` resolved to both IPv4 and IPv6, but the IPv6 ULA address was not treated as internal
- on the plain HTTP forward-proxy path, that caused requests to be denied before reaching the host MCP server even when policy and `allowed_ips` were configured correctly
- the concrete regression case here is `fdc4:f303:9324::254`, which should be treated as private/internal like RFC1918 IPv4 addresses

Policy I was using:

```
network_policies:
  host_mcp:
    name: host-mcp
    endpoints:
      - host: host.docker.internal
        port: 8001
        allowed_ips:
          - "172.29.0.254"
          - "fdc4:f303:9324::254"
    binaries:
      - { path: /usr/bin/node }
```

## Test Plan
- `cargo test -p navigator-sandbox proxy::tests`
- `mise run pre-commit`