### PR TITLE
fix(sandbox): improve inference route refresh with conditional fetch and configurable interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,6 +2818,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/architecture/README.md
+++ b/architecture/README.md
@@ -171,7 +171,7 @@ The inference routing system transparently intercepts AI inference API calls fro
 **How it works end-to-end:**
 
 1. An operator configures cluster-level inference via `nemoclaw cluster inference set --provider <name> --model <id>`. This stores a reference to the named provider and model on the gateway.
-2. When a sandbox starts, the supervisor fetches an inference bundle from the gateway via the `GetInferenceBundle` RPC. The gateway resolves the stored provider reference into a complete route: endpoint URL, API key, supported protocols, provider type, and auth metadata. The sandbox refreshes this bundle every 30 seconds.
+2. When a sandbox starts, the supervisor fetches an inference bundle from the gateway via the `GetInferenceBundle` RPC. The gateway resolves the stored provider reference into a complete route: endpoint URL, API key, supported protocols, provider type, and auth metadata. The sandbox refreshes this bundle eagerly in the background every 5 seconds by default (override with `NEMOCLAW_ROUTE_REFRESH_INTERVAL_SECS`).
 3. The agent sends requests to `https://inference.local` using standard OpenAI or Anthropic SDK calls.
 4. The sandbox proxy intercepts the HTTPS CONNECT to `inference.local` (bypassing OPA policy evaluation), TLS-terminates the connection using the sandbox's ephemeral CA, and parses the HTTP request.
 5. Known inference API patterns are detected (e.g., `POST /v1/chat/completions` for OpenAI, `POST /v1/messages` for Anthropic, `GET /v1/models` for model discovery). Matching requests are forwarded to the first compatible route by the `navigator-router`, which rewrites the auth header, injects provider-specific default headers (e.g., `anthropic-version` for Anthropic), and overrides the model field in the request body.

--- a/architecture/inference-routing.md
+++ b/architecture/inference-routing.md
@@ -100,6 +100,8 @@ Files:
 - `crates/navigator-sandbox/src/lib.rs` -- inference context initialization, route refresh
 - `crates/navigator-sandbox/src/grpc_client.rs` -- `fetch_inference_bundle()`
 
+In cluster mode, the sandbox starts a background refresh loop as soon as the inference context is created. The loop polls the gateway every 5 seconds by default (`NEMOCLAW_ROUTE_REFRESH_INTERVAL_SECS` override) and uses the bundle revision hash to skip no-op cache writes.
+
 ### Interception flow
 
 The proxy handles only `CONNECT` requests to `inference.local`. Non-CONNECT requests (any method, any host) are rejected with `403`.

--- a/crates/navigator-sandbox/Cargo.toml
+++ b/crates/navigator-sandbox/Cargo.toml
@@ -77,6 +77,7 @@ uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3"
+temp-env = "0.3"
 
 [lints]
 workspace = true

--- a/crates/navigator-sandbox/src/lib.rs
+++ b/crates/navigator-sandbox/src/lib.rs
@@ -72,6 +72,31 @@ fn disable_inference_on_empty_routes(source: InferenceRouteSource) -> bool {
     !matches!(source, InferenceRouteSource::Cluster)
 }
 
+fn route_refresh_interval_secs() -> u64 {
+    match std::env::var("NEMOCLAW_ROUTE_REFRESH_INTERVAL_SECS") {
+        Ok(value) => match value.parse::<u64>() {
+            Ok(interval) if interval > 0 => interval,
+            Ok(_) => {
+                warn!(
+                    default_interval_secs = DEFAULT_ROUTE_REFRESH_INTERVAL_SECS,
+                    "Ignoring zero route refresh interval"
+                );
+                DEFAULT_ROUTE_REFRESH_INTERVAL_SECS
+            }
+            Err(error) => {
+                warn!(
+                    interval = %value,
+                    error = %error,
+                    default_interval_secs = DEFAULT_ROUTE_REFRESH_INTERVAL_SECS,
+                    "Ignoring invalid route refresh interval"
+                );
+                DEFAULT_ROUTE_REFRESH_INTERVAL_SECS
+            }
+        },
+        Err(_) => DEFAULT_ROUTE_REFRESH_INTERVAL_SECS,
+    }
+}
+
 #[cfg(target_os = "linux")]
 static MANAGED_CHILDREN: LazyLock<Mutex<HashSet<i32>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
@@ -630,32 +655,20 @@ async fn build_inference_context(
         Router::new().map_err(|e| miette::miette!("failed to initialize inference router: {e}"))?;
     let patterns = l7::inference::default_patterns();
 
-    // Build optional refresh config — the background loop is spawned lazily on
-    // the first inference request so sandboxes that never call inference.local
-    // never poll the gateway.
-    let refresh_config = if matches!(source, InferenceRouteSource::Cluster)
+    let ctx = Arc::new(proxy::InferenceContext::new(patterns, router, routes));
+
+    // Spawn background route cache refresh for cluster mode at startup so
+    // request handling never depends on control-plane latency.
+    if matches!(source, InferenceRouteSource::Cluster)
         && let (Some(_id), Some(endpoint)) = (sandbox_id, navigator_endpoint)
     {
-        let interval_secs: u64 = std::env::var("NEMOCLAW_ROUTE_REFRESH_INTERVAL_SECS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(DEFAULT_ROUTE_REFRESH_INTERVAL_SECS);
-
-        Some(proxy::RouteRefreshConfig {
-            endpoint: endpoint.to_string(),
-            interval_secs,
+        spawn_route_refresh(
+            ctx.route_cache(),
+            endpoint.to_string(),
+            route_refresh_interval_secs(),
             initial_revision,
-        })
-    } else {
-        None
-    };
-
-    let ctx = Arc::new(proxy::InferenceContext::new(
-        patterns,
-        router,
-        routes,
-        refresh_config,
-    ));
+        );
+    }
 
     Ok(Some(ctx))
 }
@@ -686,8 +699,8 @@ pub(crate) fn bundle_to_resolved_routes(
 ///
 /// The loop uses the bundle `revision` hash to avoid unnecessary cache writes
 /// when routes haven't changed. `initial_revision` is the revision captured
-/// during the first fetch in [`build_inference_context`] so the very first tick
-/// can already skip a no-op update.
+/// during the startup fetch in [`build_inference_context`] so the first refresh
+/// cycle can already skip a no-op update.
 pub(crate) fn spawn_route_refresh(
     cache: Arc<tokio::sync::RwLock<Vec<navigator_router::config::ResolvedRoute>>>,
     endpoint: String,
@@ -1181,6 +1194,10 @@ async fn run_policy_poll_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use temp_env::with_vars;
+
+    static ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+        std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
 
     #[test]
     fn bundle_to_resolved_routes_converts_all_fields() {
@@ -1467,6 +1484,45 @@ filesystem_policy:
     #[test]
     fn default_route_refresh_interval_is_five_seconds() {
         assert_eq!(DEFAULT_ROUTE_REFRESH_INTERVAL_SECS, 5);
+    }
+
+    #[test]
+    fn route_refresh_interval_uses_env_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        with_vars(
+            [("NEMOCLAW_ROUTE_REFRESH_INTERVAL_SECS", Some("9"))],
+            || {
+                assert_eq!(route_refresh_interval_secs(), 9);
+            },
+        );
+    }
+
+    #[test]
+    fn route_refresh_interval_rejects_zero() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        with_vars(
+            [("NEMOCLAW_ROUTE_REFRESH_INTERVAL_SECS", Some("0"))],
+            || {
+                assert_eq!(
+                    route_refresh_interval_secs(),
+                    DEFAULT_ROUTE_REFRESH_INTERVAL_SECS
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn route_refresh_interval_rejects_invalid_values() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        with_vars(
+            [("NEMOCLAW_ROUTE_REFRESH_INTERVAL_SECS", Some("abc"))],
+            || {
+                assert_eq!(
+                    route_refresh_interval_secs(),
+                    DEFAULT_ROUTE_REFRESH_INTERVAL_SECS
+                );
+            },
+        );
     }
 
     #[tokio::test]

--- a/crates/navigator-sandbox/src/proxy.rs
+++ b/crates/navigator-sandbox/src/proxy.rs
@@ -44,31 +44,13 @@ enum InferenceOutcome {
     Denied { reason: String },
 }
 
-/// Configuration for the background route-refresh loop.
-///
-/// Stored on [`InferenceContext`] so the refresh task can be spawned lazily on
-/// the first inference request instead of unconditionally at startup.
-pub struct RouteRefreshConfig {
-    pub endpoint: String,
-    pub interval_secs: u64,
-    pub initial_revision: Option<String>,
-}
-
 /// Inference routing context for sandbox-local execution.
 ///
 /// Holds a `Router` (HTTP client) and a cached set of resolved routes.
-/// In cluster mode the background refresh loop is spawned lazily on the first
-/// inference request (see [`ensure_refresh_started`]) so sandboxes that never
-/// use inference never poll.
 pub struct InferenceContext {
     pub patterns: Vec<crate::l7::inference::InferenceApiPattern>,
     router: navigator_router::Router,
     routes: Arc<tokio::sync::RwLock<Vec<navigator_router::config::ResolvedRoute>>>,
-    /// Set once the background refresh task has been spawned. `None` for
-    /// file-based routes (no refresh needed).
-    refresh_started: tokio::sync::OnceCell<()>,
-    /// Configuration consumed by the first call to [`ensure_refresh_started`].
-    refresh_config: std::sync::Mutex<Option<RouteRefreshConfig>>,
 }
 
 impl InferenceContext {
@@ -76,68 +58,19 @@ impl InferenceContext {
         patterns: Vec<crate::l7::inference::InferenceApiPattern>,
         router: navigator_router::Router,
         routes: Vec<navigator_router::config::ResolvedRoute>,
-        refresh_config: Option<RouteRefreshConfig>,
     ) -> Self {
         Self {
             patterns,
             router,
             routes: Arc::new(tokio::sync::RwLock::new(routes)),
-            refresh_started: tokio::sync::OnceCell::new(),
-            refresh_config: std::sync::Mutex::new(refresh_config),
         }
     }
 
-    /// Get a handle to the route cache (used in tests to inspect cached routes).
-    #[cfg(test)]
+    /// Get a handle to the route cache for background refresh.
     pub fn route_cache(
         &self,
     ) -> Arc<tokio::sync::RwLock<Vec<navigator_router::config::ResolvedRoute>>> {
         self.routes.clone()
-    }
-
-    /// Ensure the route cache is fresh and the background refresh loop is
-    /// running. On the first call this fetches the latest bundle from the
-    /// gateway (so callers never see stale startup-time routes) and then
-    /// spawns the periodic refresh task. Subsequent calls are a no-op
-    /// (single atomic load via `OnceCell`).
-    pub async fn ensure_refresh_started(&self) {
-        self.refresh_started
-            .get_or_init(|| async {
-                let config = self.refresh_config.lock().expect("lock poisoned").take();
-                if let Some(cfg) = config {
-                    // Fetch fresh routes so the very first inference call never
-                    // uses stale startup-time data.
-                    let initial_revision =
-                        match crate::grpc_client::fetch_inference_bundle(&cfg.endpoint).await {
-                            Ok(bundle) => {
-                                let revision = bundle.revision.clone();
-                                let routes = crate::bundle_to_resolved_routes(&bundle);
-                                info!(
-                                    route_count = routes.len(),
-                                    revision = %revision,
-                                    "Refreshed inference routes on first call"
-                                );
-                                *self.routes.write().await = routes;
-                                Some(revision)
-                            }
-                            Err(e) => {
-                                warn!(
-                                    error = %e,
-                                    "Failed to refresh routes on first call, using startup routes"
-                                );
-                                cfg.initial_revision
-                            }
-                        };
-
-                    crate::spawn_route_refresh(
-                        self.routes.clone(),
-                        cfg.endpoint,
-                        cfg.interval_secs,
-                        initial_revision,
-                    );
-                }
-            })
-            .await;
     }
 }
 
@@ -835,10 +768,6 @@ async fn route_inference_request(
             kind = %pattern.kind,
             "Intercepted inference request, routing locally"
         );
-
-        // Lazily start the background route-refresh loop on the first
-        // inference call so sandboxes that never use inference never poll.
-        ctx.ensure_refresh_started().await;
 
         // Strip credential + framing/hop-by-hop headers.
         let filtered_headers = sanitize_inference_request_headers(&request.headers);


### PR DESCRIPTION
> **🏗️ build-from-issue-agent**

Closes #184

## Summary
Restores eager inference route refresh at sandbox startup so `inference.local` requests never block on a control-plane fetch. The refresh loop keeps the revision-based no-op skip, validates `NEMOCLAW_ROUTE_REFRESH_INTERVAL_SECS`, and defaults to a 5 second poll interval.

## Changes Made
- `crates/navigator-sandbox/src/lib.rs`
  - start the cluster route refresh loop when the inference context is created instead of on first request
  - add `route_refresh_interval_secs()` to reject `0` and invalid env values and fall back to the default
  - keep revision-aware refresh behavior using the startup bundle revision
  - add env-var tests using `temp_env`
- `crates/navigator-sandbox/src/proxy.rs`
  - remove the lazy-start refresh path from `InferenceContext`
  - keep request routing off the control-plane path
- `architecture/README.md`
  - document eager background refresh with a 5 second default
- `architecture/inference-routing.md`
  - document the startup refresh loop and env override

## Why
The lazy first-request refresh path introduced cold-start latency, head-of-line blocking, and stale-route fallback behavior that made revocation semantics harder to reason about. Eager background refresh is simpler and keeps inference request handling predictable.

## Tests Added
- `default_route_refresh_interval_is_five_seconds`
- `route_refresh_interval_uses_env_override`
- `route_refresh_interval_rejects_zero`
- `route_refresh_interval_rejects_invalid_values`

## Verification
- [x] `cargo test -p navigator-sandbox --lib`
- [x] `mise run pre-commit`