### PR TITLE
fix(tui): use correct ssh-proxy CLI args in shell connect and exec

### DIFF
--- a/crates/navigator-tui/src/lib.rs
+++ b/crates/navigator-tui/src/lib.rs
@@ -708,11 +708,11 @@ async fn handle_shell_connect(
         }
     };
     let exe_str = shell_escape(&exe.to_string_lossy());
+    let cluster = shell_escape(&app.cluster_name);
     let proxy_command = format!(
-        "{exe_str} ssh-proxy --gateway {gateway_url} --sandbox-id {} --token {}",
+        "{exe_str} ssh-proxy --gateway-endpoint {gateway_url} --sandbox-id {} --token {} --gateway {cluster}",
         session.sandbox_id, session.token,
     );
-
     // Step 5: Build the SSH command.
     let mut command = std::process::Command::new("ssh");
     command
@@ -850,8 +850,9 @@ async fn handle_exec_command(
         }
     };
     let exe_str = shell_escape(&exe.to_string_lossy());
+    let cluster = shell_escape(&app.cluster_name);
     let proxy_command = format!(
-        "{exe_str} ssh-proxy --gateway {gateway_url} --sandbox-id {} --token {}",
+        "{exe_str} ssh-proxy --gateway-endpoint {gateway_url} --sandbox-id {} --token {} --gateway {cluster}",
         session.sandbox_id, session.token,
     );
 


### PR DESCRIPTION
Closes #188

## Summary
- The TUI `handle_shell_connect` and `handle_exec_command` were using `--gateway` (cluster name flag) to pass the gateway URL, and omitting the cluster name entirely. After the `--gateway` → `--gateway-endpoint` rename in #175, this caused `ssh-proxy` to fail immediately — producing the flash-and-return behavior and eventual terminal corruption.
- Changed both functions to use `--gateway-endpoint` for the URL and `--gateway` for the cluster name, matching the format already used by `start_port_forwards` and the CLI's `ssh_session_config`.

## Test Plan
- Manual: launched TUI, pressed `[s]` on a sandbox, shell session connected successfully.
- `mise run pre-commit` passes (all tests, clippy, fmt).