### PR TITLE
fix(docker): remove unsupported npm dedupe -g command

### DIFF
--- a/deploy/docker/sandbox/Dockerfile.base
+++ b/deploy/docker/sandbox/Dockerfile.base
@@ -160,11 +160,9 @@ RUN npm install -g npm@11.11.0
 # reproducible builds. Force-upgrade tar and @hono/node-server afterward to
 # resolve transitive dependency vulnerabilities (GHSA-wc8c-qw6v-h7f6,
 # GHSA-r6q2-hw4h-h46w, GHSA-qffp-2rhf-9h96, GHSA-8qq5-rm4j-mr97,
-# GHSA-83g3-92jg-28cx, GHSA-34x7-hfp2-rc4v). Dedupe removes nested copies of
-# the old versions that scanners may still detect.
+# GHSA-83g3-92jg-28cx, GHSA-34x7-hfp2-rc4v).
 RUN npm install -g opencode-ai@1.2.18 @openai/codex@0.111.0 && \
-    npm install -g tar@7.5.11 @hono/node-server@1.19.11 && \
-    npm dedupe -g
+    npm install -g tar@7.5.11 @hono/node-server@1.19.11
 
 # Install ai-pim-utils (NVIDIA PIM CLI tools: outlook, calendar, transcripts, etc.)
 # The install script auto-detects Debian and installs via .deb package to /usr/bin.


### PR DESCRIPTION
## Summary

- Remove `npm dedupe -g` from sandbox Dockerfile which fails with npm 11 (error code EDEDUPEGLOBAL)
- npm 11 does not support global deduplication mode

## Context

The sandbox container build failed because `npm dedupe -g` is not supported in npm 11:

```
npm error code EDEDUPEGLOBAL
npm error `npm dedupe` does not work in global mode.
```

The dedupe was intended to remove nested copies of vulnerable dependencies, but the force-upgrade of `tar@7.5.11` and `@hono/node-server@1.19.11` already ensures the patched versions are installed.

Fixes failing build: https://github.com/NVIDIA/NemoClaw/actions/runs/22887390563/job/66403149325