### PR TITLE
feat(tui): auto-refresh sandbox policy view when new versions are detected

### DIFF
--- a/architecture/tui.md
+++ b/architecture/tui.md
@@ -114,6 +114,8 @@ Press `Esc` to cancel and return to Normal mode. `Backspace` deletes characters 
 
 The TUI automatically polls the cluster every **2 seconds**. Both cluster health and the sandbox list update on each tick, so the display stays current without manual refreshing. This uses the same gRPC calls as the CLI — no additional server-side setup is required.
 
+When viewing a sandbox, the policy pane auto-refreshes when a new policy version is detected. The sandbox list response includes `current_policy_version` for each sandbox; on every tick the TUI compares this against the currently displayed policy version and re-fetches the full policy only when they differ. This avoids extra RPCs during normal operation while ensuring policy updates appear within the polling interval. The user's scroll position is preserved across auto-refreshes.
+
 ## Theme
 
 The TUI uses a dark terminal theme based on the NVIDIA brand palette:

--- a/crates/navigator-tui/src/app.rs
+++ b/crates/navigator-tui/src/app.rs
@@ -307,6 +307,7 @@ pub struct App {
     pub sandbox_created: Vec<String>,
     pub sandbox_images: Vec<String>,
     pub sandbox_notes: Vec<String>,
+    pub sandbox_policy_versions: Vec<u32>,
     pub sandbox_selected: usize,
     pub sandbox_count: usize,
 
@@ -384,6 +385,7 @@ impl App {
             sandbox_created: Vec::new(),
             sandbox_images: Vec::new(),
             sandbox_notes: Vec::new(),
+            sandbox_policy_versions: Vec::new(),
             sandbox_selected: 0,
             sandbox_count: 0,
             confirm_delete: false,
@@ -1297,6 +1299,7 @@ impl App {
         self.sandbox_created.clear();
         self.sandbox_images.clear();
         self.sandbox_notes.clear();
+        self.sandbox_policy_versions.clear();
         self.sandbox_selected = 0;
         self.sandbox_count = 0;
         self.sandbox_log_lines.clear();

--- a/crates/navigator-tui/src/lib.rs
+++ b/crates/navigator-tui/src/lib.rs
@@ -189,6 +189,19 @@ pub async fn run(channel: Channel, cluster_name: &str, endpoint: &str) -> Result
             Some(Event::Tick) => {
                 refresh_cluster_list(&mut app);
                 refresh_data(&mut app).await;
+
+                // Auto-refresh the policy view when a new version is detected.
+                if app.screen == Screen::Sandbox {
+                    let displayed = app.sandbox_policy.as_ref().map_or(0, |p| p.version);
+                    let listed = app
+                        .sandbox_policy_versions
+                        .get(app.sandbox_selected)
+                        .copied()
+                        .unwrap_or(0);
+                    if listed > 0 && listed != displayed {
+                        refresh_sandbox_policy(&mut app).await;
+                    }
+                }
             }
             Some(Event::Redraw) => {
                 // Check if a buffered sandbox CreateResult is ready to finalize.
@@ -1640,6 +1653,9 @@ async fn refresh_sandboxes(app: &mut App) {
                 .map(|s| format_timestamp(s.created_at_ms))
                 .collect();
 
+            app.sandbox_policy_versions =
+                sandboxes.iter().map(|s| s.current_policy_version).collect();
+
             // Build NOTES column from active port forwards.
             let forwards = navigator_core::forward::list_forwards().unwrap_or_default();
             app.sandbox_notes = sandboxes
@@ -1650,6 +1666,43 @@ async fn refresh_sandboxes(app: &mut App) {
             if app.sandbox_selected >= app.sandbox_count && app.sandbox_count > 0 {
                 app.sandbox_selected = app.sandbox_count - 1;
             }
+        }
+    }
+}
+
+/// Re-fetch only the sandbox policy when a version change is detected.
+///
+/// Unlike `fetch_sandbox_detail()`, this skips the `GetSandbox` metadata call
+/// and preserves the current scroll position so the user isn't disrupted.
+async fn refresh_sandbox_policy(app: &mut App) {
+    let sandbox_id = match app.selected_sandbox_id() {
+        Some(id) => id.to_string(),
+        None => return,
+    };
+
+    let policy_req = navigator_core::proto::GetSandboxPolicyRequest { sandbox_id };
+
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        app.client.get_sandbox_policy(policy_req),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => {
+            let inner = resp.into_inner();
+            if let Some(mut policy) = inner.policy {
+                // Use the version from the policy history, not from the
+                // policy proto's own version field (which is always 1).
+                policy.version = inner.version;
+                app.policy_lines = render_policy_lines(&policy);
+                app.sandbox_policy = Some(policy);
+            }
+        }
+        Ok(Err(e)) => {
+            tracing::warn!("failed to refresh sandbox policy: {}", e.message());
+        }
+        Err(_) => {
+            tracing::warn!("sandbox policy refresh timed out");
         }
     }
 }


### PR DESCRIPTION
> **🏗️ build-from-issue-agent**

Closes #196

## Summary
Adds auto-refresh for the sandbox policy view in the TUI using a hybrid version-check approach. The existing 2-second sandbox list refresh already returns `current_policy_version` for each sandbox — this change stores those versions and compares against the currently displayed policy version. Only when a mismatch is detected does it fire a `GetSandboxPolicy` RPC to fetch the updated policy. This adds zero extra RPCs during normal operation.

## Changes Made
- `crates/navigator-tui/src/app.rs`: Added `sandbox_policy_versions: Vec<u32>` field to App struct, initialized in `new()`, cleared in `reset_sandbox_state()`
- `crates/navigator-tui/src/lib.rs`: Store `current_policy_version` in `refresh_sandboxes()`, added version-check in the Tick handler that triggers `refresh_sandbox_policy()` when the user is on the Sandbox screen and the version differs, added `refresh_sandbox_policy()` function that fetches and re-renders the policy without resetting scroll position
- `architecture/tui.md`: Documented the new policy auto-refresh behavior in the Data Refresh section

## Deviations from Plan
None — implemented as planned.

## Tests Added
- **Unit:** N/A — TUI crate has no existing test infrastructure; the change is a thin integration layer with no complex logic to unit test in isolation
- **Integration:** N/A
- **E2E:** N/A — no changes under `e2e/`

## Documentation Updated
- `architecture/tui.md`: Added paragraph describing policy auto-refresh behavior

## Verification
- [x] Pre-commit checks passing (unit tests, lint, format)
- [x] Architecture documentation updated