### PR TITLE
fix(server): merge provider credentials/config on update instead of replacing

### DIFF
--- a/crates/navigator-cli/src/main.rs
+++ b/crates/navigator-cli/src/main.rs
@@ -444,17 +444,13 @@ enum ProviderCommands {
         names: bool,
     },
 
-    /// Update an existing provider config.
+    /// Update an existing provider's credentials or config.
     Update {
         /// Provider name.
         #[arg(add = ArgValueCompleter::new(completers::complete_provider_names))]
         name: String,
 
-        /// Provider type.
-        #[arg(long = "type", value_enum)]
-        provider_type: CliProviderType,
-
-        /// Load provider credentials/config from existing local state.
+        /// Re-discover credentials from existing local state (e.g. env vars, config files).
         #[arg(long, conflicts_with = "credentials")]
         from_existing: bool,
 
@@ -1573,7 +1569,6 @@ async fn main() -> Result<()> {
                 }
                 ProviderCommands::Update {
                     name,
-                    provider_type,
                     from_existing,
                     credentials,
                     config,
@@ -1581,7 +1576,6 @@ async fn main() -> Result<()> {
                     run::provider_update(
                         endpoint,
                         &name,
-                        provider_type.as_str(),
                         from_existing,
                         &credentials,
                         &config,

--- a/crates/navigator-cli/src/run.rs
+++ b/crates/navigator-cli/src/run.rs
@@ -2686,7 +2686,6 @@ pub async fn provider_list(
 pub async fn provider_update(
     server: &str,
     name: &str,
-    provider_type: &str,
     from_existing: bool,
     credentials: &[String],
     config: &[String],
@@ -2700,14 +2699,22 @@ pub async fn provider_update(
 
     let mut client = grpc_client(server, tls).await?;
 
-    let provider_type = normalize_provider_type(provider_type)
-        .ok_or_else(|| miette::miette!("unsupported provider type: {provider_type}"))?
-        .to_string();
-
     let mut credential_map = parse_credential_pairs(credentials)?;
     let mut config_map = parse_key_value_pairs(config, "--config")?;
 
     if from_existing {
+        // Fetch the existing provider to discover its type for credential lookup.
+        let existing = client
+            .get_provider(GetProviderRequest {
+                name: name.to_string(),
+            })
+            .await
+            .into_diagnostic()?
+            .into_inner()
+            .provider
+            .ok_or_else(|| miette::miette!("provider '{name}' not found"))?;
+
+        let provider_type = existing.r#type;
         let registry = ProviderRegistry::new();
         let discovered = registry
             .discover_existing(&provider_type)
@@ -2731,7 +2738,7 @@ pub async fn provider_update(
             provider: Some(Provider {
                 id: String::new(),
                 name: name.to_string(),
-                r#type: provider_type,
+                r#type: String::new(),
                 credentials: credential_map,
                 config: config_map,
             }),

--- a/crates/navigator-cli/tests/ensure_providers_integration.rs
+++ b/crates/navigator-cli/tests/ensure_providers_integration.rs
@@ -248,12 +248,28 @@ impl Navigator for TestNavigator {
             .get(&provider.name)
             .cloned()
             .ok_or_else(|| Status::not_found("provider not found"))?;
+        // Merge semantics: empty map = no change, empty value = delete key.
+        let merge = |mut base: std::collections::HashMap<String, String>,
+                     incoming: std::collections::HashMap<String, String>|
+         -> std::collections::HashMap<String, String> {
+            if incoming.is_empty() {
+                return base;
+            }
+            for (k, v) in incoming {
+                if v.is_empty() {
+                    base.remove(&k);
+                } else {
+                    base.insert(k, v);
+                }
+            }
+            base
+        };
         let updated = Provider {
             id: existing.id,
             name: provider.name,
-            r#type: provider.r#type,
-            credentials: provider.credentials,
-            config: provider.config,
+            r#type: existing.r#type,
+            credentials: merge(existing.credentials, provider.credentials),
+            config: merge(existing.config, provider.config),
         };
         providers.insert(updated.name.clone(), updated.clone());
         Ok(Response::new(ProviderResponse {

--- a/crates/navigator-cli/tests/provider_commands_integration.rs
+++ b/crates/navigator-cli/tests/provider_commands_integration.rs
@@ -202,12 +202,28 @@ impl Navigator for TestNavigator {
             .get(&provider.name)
             .cloned()
             .ok_or_else(|| Status::not_found("provider not found"))?;
+        // Merge semantics: empty map = no change, empty value = delete key.
+        let merge = |mut base: std::collections::HashMap<String, String>,
+                     incoming: std::collections::HashMap<String, String>|
+         -> std::collections::HashMap<String, String> {
+            if incoming.is_empty() {
+                return base;
+            }
+            for (k, v) in incoming {
+                if v.is_empty() {
+                    base.remove(&k);
+                } else {
+                    base.insert(k, v);
+                }
+            }
+            base
+        };
         let updated = Provider {
             id: existing.id,
             name: provider.name,
-            r#type: provider.r#type,
-            credentials: provider.credentials,
-            config: provider.config,
+            r#type: existing.r#type,
+            credentials: merge(existing.credentials, provider.credentials),
+            config: merge(existing.config, provider.config),
         };
         providers.insert(updated.name.clone(), updated.clone());
         Ok(Response::new(ProviderResponse {
@@ -398,7 +414,6 @@ async fn provider_cli_run_functions_support_full_crud_flow() {
     run::provider_update(
         &ts.endpoint,
         "my-claude",
-        "claude",
         false,
         &["API_KEY=rotated".to_string()],
         &["profile=prod".to_string()],

--- a/crates/navigator-server/src/grpc.rs
+++ b/crates/navigator-server/src/grpc.rs
@@ -2245,15 +2245,34 @@ async fn list_provider_records(
     Ok(providers)
 }
 
+/// Merge an incoming map into an existing map.
+///
+/// - If `incoming` is empty, return `existing` unchanged (no-op).
+/// - Otherwise, upsert all incoming entries into `existing`.
+/// - Entries with an empty-string value are removed (delete semantics).
+fn merge_map(
+    mut existing: std::collections::HashMap<String, String>,
+    incoming: std::collections::HashMap<String, String>,
+) -> std::collections::HashMap<String, String> {
+    if incoming.is_empty() {
+        return existing;
+    }
+    for (key, value) in incoming {
+        if value.is_empty() {
+            existing.remove(&key);
+        } else {
+            existing.insert(key, value);
+        }
+    }
+    existing
+}
+
 async fn update_provider_record(
     store: &crate::persistence::Store,
     provider: Provider,
 ) -> Result<Provider, Status> {
     if provider.name.is_empty() {
         return Err(Status::invalid_argument("provider.name is required"));
-    }
-    if provider.r#type.trim().is_empty() {
-        return Err(Status::invalid_argument("provider.type is required"));
     }
 
     let existing = store
@@ -2265,13 +2284,26 @@ async fn update_provider_record(
         return Err(Status::not_found("provider not found"));
     };
 
+    // Provider type is immutable after creation. Reject if the caller
+    // sends a non-empty type that differs from the existing one.
+    let incoming_type = provider.r#type.trim();
+    if !incoming_type.is_empty()
+        && incoming_type.to_ascii_lowercase() != existing.r#type.trim().to_ascii_lowercase()
+    {
+        return Err(Status::invalid_argument(
+            "provider type cannot be changed; delete and recreate the provider",
+        ));
+    }
+
     let updated = Provider {
         id: existing.id,
         name: existing.name,
-        r#type: provider.r#type,
-        credentials: provider.credentials,
-        config: provider.config,
+        r#type: existing.r#type,
+        credentials: merge_map(existing.credentials, provider.credentials),
+        config: merge_map(existing.config, provider.config),
     };
+
+    validate_provider_fields(&updated)?;
 
     store
         .put_message(&updated)
@@ -2436,10 +2468,23 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(updated.id, provider_id);
+        // Updated credential has new value.
         assert_eq!(
             updated.credentials.get("API_TOKEN"),
             Some(&"rotated-token".to_string())
         );
+        // Non-updated credential is preserved (not clobbered).
+        assert_eq!(
+            updated.credentials.get("SECONDARY"),
+            Some(&"secondary-token".to_string())
+        );
+        // Updated config has new value.
+        assert_eq!(
+            updated.config.get("endpoint"),
+            Some(&"https://gitlab.com".to_string())
+        );
+        // Non-updated config is preserved (not clobbered).
+        assert_eq!(updated.config.get("region"), Some(&"us-west".to_string()));
 
         let deleted = delete_provider_record(&store, "gitlab-local")
             .await
@@ -2488,7 +2533,7 @@ mod tests {
             Provider {
                 id: String::new(),
                 name: "missing".to_string(),
-                r#type: "gitlab".to_string(),
+                r#type: String::new(),
                 credentials: HashMap::new(),
                 config: HashMap::new(),
             },
@@ -2496,6 +2541,163 @@ mod tests {
         .await
         .unwrap_err();
         assert_eq!(update_missing_err.code(), Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn update_provider_empty_maps_is_noop() {
+        let store = Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .unwrap();
+
+        let created = provider_with_values("noop-test", "nvidia");
+        let persisted = create_provider_record(&store, created).await.unwrap();
+
+        // Update with empty type, empty credentials, empty config = no changes.
+        let updated = update_provider_record(
+            &store,
+            Provider {
+                id: String::new(),
+                name: "noop-test".to_string(),
+                r#type: String::new(),
+                credentials: HashMap::new(),
+                config: HashMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(updated.id, persisted.id);
+        assert_eq!(updated.r#type, "nvidia");
+        assert_eq!(updated.credentials.len(), 2);
+        assert_eq!(
+            updated.credentials.get("API_TOKEN"),
+            Some(&"token-123".to_string())
+        );
+        assert_eq!(
+            updated.credentials.get("SECONDARY"),
+            Some(&"secondary-token".to_string())
+        );
+        assert_eq!(updated.config.len(), 2);
+        assert_eq!(
+            updated.config.get("endpoint"),
+            Some(&"https://example.com".to_string())
+        );
+        assert_eq!(updated.config.get("region"), Some(&"us-west".to_string()));
+    }
+
+    #[tokio::test]
+    async fn update_provider_empty_value_deletes_key() {
+        let store = Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .unwrap();
+
+        let created = provider_with_values("delete-key-test", "openai");
+        create_provider_record(&store, created).await.unwrap();
+
+        // Send SECONDARY with empty value to delete it; API_TOKEN untouched.
+        let updated = update_provider_record(
+            &store,
+            Provider {
+                id: String::new(),
+                name: "delete-key-test".to_string(),
+                r#type: String::new(),
+                credentials: std::iter::once(("SECONDARY".to_string(), String::new())).collect(),
+                config: std::iter::once(("region".to_string(), String::new())).collect(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(updated.credentials.len(), 1);
+        assert_eq!(
+            updated.credentials.get("API_TOKEN"),
+            Some(&"token-123".to_string())
+        );
+        assert!(updated.credentials.get("SECONDARY").is_none());
+        assert_eq!(updated.config.len(), 1);
+        assert_eq!(
+            updated.config.get("endpoint"),
+            Some(&"https://example.com".to_string())
+        );
+        assert!(updated.config.get("region").is_none());
+    }
+
+    #[tokio::test]
+    async fn update_provider_empty_type_preserves_existing() {
+        let store = Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .unwrap();
+
+        let created = provider_with_values("type-preserve-test", "anthropic");
+        create_provider_record(&store, created).await.unwrap();
+
+        let updated = update_provider_record(
+            &store,
+            Provider {
+                id: String::new(),
+                name: "type-preserve-test".to_string(),
+                r#type: String::new(),
+                credentials: HashMap::new(),
+                config: HashMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(updated.r#type, "anthropic");
+    }
+
+    #[tokio::test]
+    async fn update_provider_rejects_type_change() {
+        let store = Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .unwrap();
+
+        let created = provider_with_values("type-change-test", "nvidia");
+        create_provider_record(&store, created).await.unwrap();
+
+        let err = update_provider_record(
+            &store,
+            Provider {
+                id: String::new(),
+                name: "type-change-test".to_string(),
+                r#type: "openai".to_string(),
+                credentials: HashMap::new(),
+                config: HashMap::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("type cannot be changed"));
+    }
+
+    #[tokio::test]
+    async fn update_provider_validates_merged_result() {
+        let store = Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .unwrap();
+
+        let created = provider_with_values("validate-merge-test", "gitlab");
+        create_provider_record(&store, created).await.unwrap();
+
+        // Add credentials that exceed the max key length to trigger validation.
+        let oversized_key = "K".repeat(MAX_MAP_KEY_LEN + 1);
+        let err = update_provider_record(
+            &store,
+            Provider {
+                id: String::new(),
+                name: "validate-merge-test".to_string(),
+                r#type: String::new(),
+                credentials: std::iter::once((oversized_key, "value".to_string())).collect(),
+                config: HashMap::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.code(), Code::InvalidArgument);
     }
 
     #[tokio::test]

--- a/e2e/python/test_sandbox_providers.py
+++ b/e2e/python/test_sandbox_providers.py
@@ -213,3 +213,162 @@ def test_credentials_not_in_persisted_spec_environment(
             assert "ANTHROPIC_API_KEY" not in persisted_env, (
                 "credentials should not be persisted in sandbox spec environment"
             )
+
+
+# ---------------------------------------------------------------------------
+# Provider update merge semantics
+# ---------------------------------------------------------------------------
+
+
+def test_update_provider_preserves_unset_credentials_and_config(
+    sandbox_client: SandboxClient,
+) -> None:
+    """Updating one credential must not clobber other credentials or config."""
+    stub = sandbox_client._stub
+    name = "merge-test-preserve"
+    _delete_provider(stub, name)
+
+    try:
+        stub.CreateProvider(
+            navigator_pb2.CreateProviderRequest(
+                provider=datamodel_pb2.Provider(
+                    name=name,
+                    type="generic",
+                    credentials={"KEY_A": "val-a", "KEY_B": "val-b"},
+                    config={"BASE_URL": "https://example.com"},
+                )
+            )
+        )
+
+        # Update only KEY_A; send empty config map (= no change).
+        stub.UpdateProvider(
+            navigator_pb2.UpdateProviderRequest(
+                provider=datamodel_pb2.Provider(
+                    name=name,
+                    type="",
+                    credentials={"KEY_A": "rotated-a"},
+                )
+            )
+        )
+
+        got = stub.GetProvider(navigator_pb2.GetProviderRequest(name=name))
+        p = got.provider
+        assert p.credentials["KEY_A"] == "rotated-a"
+        assert p.credentials["KEY_B"] == "val-b", "KEY_B should be preserved"
+        assert p.config["BASE_URL"] == "https://example.com", (
+            "config should be preserved"
+        )
+    finally:
+        _delete_provider(stub, name)
+
+
+def test_update_provider_empty_maps_preserves_all(
+    sandbox_client: SandboxClient,
+) -> None:
+    """Sending empty credential and config maps should be a no-op."""
+    stub = sandbox_client._stub
+    name = "merge-test-noop"
+    _delete_provider(stub, name)
+
+    try:
+        stub.CreateProvider(
+            navigator_pb2.CreateProviderRequest(
+                provider=datamodel_pb2.Provider(
+                    name=name,
+                    type="generic",
+                    credentials={"TOKEN": "secret"},
+                    config={"URL": "https://api.example.com"},
+                )
+            )
+        )
+
+        stub.UpdateProvider(
+            navigator_pb2.UpdateProviderRequest(
+                provider=datamodel_pb2.Provider(
+                    name=name,
+                    type="",
+                )
+            )
+        )
+
+        got = stub.GetProvider(navigator_pb2.GetProviderRequest(name=name))
+        p = got.provider
+        assert p.credentials["TOKEN"] == "secret"
+        assert p.config["URL"] == "https://api.example.com"
+    finally:
+        _delete_provider(stub, name)
+
+
+def test_update_provider_merges_config_preserves_credentials(
+    sandbox_client: SandboxClient,
+) -> None:
+    """Updating only config should not touch credentials."""
+    stub = sandbox_client._stub
+    name = "merge-test-config-only"
+    _delete_provider(stub, name)
+
+    try:
+        stub.CreateProvider(
+            navigator_pb2.CreateProviderRequest(
+                provider=datamodel_pb2.Provider(
+                    name=name,
+                    type="generic",
+                    credentials={"API_KEY": "original-key"},
+                    config={"ENDPOINT": "https://old.example.com"},
+                )
+            )
+        )
+
+        # Send only config update, empty credentials map.
+        stub.UpdateProvider(
+            navigator_pb2.UpdateProviderRequest(
+                provider=datamodel_pb2.Provider(
+                    name=name,
+                    type="",
+                    config={"ENDPOINT": "https://new.example.com"},
+                )
+            )
+        )
+
+        got = stub.GetProvider(navigator_pb2.GetProviderRequest(name=name))
+        p = got.provider
+        assert p.credentials["API_KEY"] == "original-key", (
+            "credentials should be untouched"
+        )
+        assert p.config["ENDPOINT"] == "https://new.example.com"
+    finally:
+        _delete_provider(stub, name)
+
+
+def test_update_provider_rejects_type_change(
+    sandbox_client: SandboxClient,
+) -> None:
+    """Attempting to change a provider's type must be rejected."""
+    stub = sandbox_client._stub
+    name = "merge-test-type-reject"
+    _delete_provider(stub, name)
+
+    try:
+        stub.CreateProvider(
+            navigator_pb2.CreateProviderRequest(
+                provider=datamodel_pb2.Provider(
+                    name=name,
+                    type="generic",
+                    credentials={"KEY": "val"},
+                )
+            )
+        )
+
+        with pytest.raises(grpc.RpcError) as exc_info:
+            stub.UpdateProvider(
+                navigator_pb2.UpdateProviderRequest(
+                    provider=datamodel_pb2.Provider(
+                        name=name,
+                        type="nvidia",
+                    )
+                )
+            )
+        assert exc_info.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+        assert "type cannot be changed" in exc_info.value.details()
+    finally:
+        _delete_provider(stub, name)


### PR DESCRIPTION
## Summary

- **Fixes the provider update clobber bug** (#199): `UpdateProvider` RPC was doing full replacement of `credentials` and `config` maps, silently destroying data when callers (TUI, CLI) sent partial updates. Now uses merge semantics: empty map = no change, non-empty map = upsert, empty-string value = delete key.
- **Makes provider `type` immutable** after creation — server rejects updates where incoming type differs from existing, CLI removes `--type` from the update command entirely.
- **Adds `validate_provider_fields()` call on update path** — previously only called on create, so invalid fields could be introduced via update.

## Merge Semantics

| Incoming map | Incoming key value | Behavior |
|---|---|---|
| Empty (`{}`) | — | Preserve all existing keys |
| Non-empty | Non-empty string | Upsert (add or overwrite) |
| Non-empty | Empty string (`""`) | Delete that key |

## Changes

### Server (`navigator-server/src/grpc.rs`)
- New `merge_map()` helper implementing the merge/delete semantics
- Rewrote `update_provider_record()` to use merge for both `credentials` and `config`
- Added type immutability check (rejects if incoming type differs from existing)
- Added `validate_provider_fields()` call on merged result
- 6 new unit tests + updated existing test assertions

### CLI (`navigator-cli`)
- Removed `--type` flag from `provider update` command
- Simplified `provider_update()`: sends empty type string, fetches provider type from server for `--from-existing` credential discovery
- Updated integration test mocks with merge semantics

### E2E Tests (`e2e/python/test_sandbox_providers.py`)
- `test_update_provider_rejects_type_change` — verifies type immutability
- `test_update_provider_merges_config_preserves_credentials` — verifies config merge + credential preservation
- `test_update_provider_preserves_unset_credentials_and_config` — verifies empty maps are no-ops
- `test_update_provider_empty_maps_preserves_all` — verifies complete no-op update

## Testing

- All unit tests pass (`cargo test --workspace`)
- All 4 new E2E tests pass
- Pre-existing E2E sandbox exec tests have unrelated failures (sandbox infrastructure issue, not caused by this change)
- `mise run pre-commit` passes (pre-existing license check failures on unrelated files)

Closes #199