### PR TITLE
fix(bootstrap): update hardcoded navigator namespace refs to openshell

### DIFF
--- a/crates/navigator-bootstrap/src/lib.rs
+++ b/crates/navigator-bootstrap/src/lib.rs
@@ -42,8 +42,8 @@ use crate::metadata::{
 use crate::mtls::store_pki_bundle;
 use crate::pki::generate_pki;
 use crate::runtime::{
-    clean_stale_nodes, exec_capture_with_exit, fetch_recent_logs, navigator_workload_exists,
-    restart_navigator_deployment, wait_for_gateway_ready, wait_for_kubeconfig,
+    clean_stale_nodes, exec_capture_with_exit, fetch_recent_logs, openshell_workload_exists,
+    restart_openshell_deployment, wait_for_gateway_ready, wait_for_kubeconfig,
 };
 
 pub use crate::docker::ExistingGatewayInfo;
@@ -390,17 +390,17 @@ where
     // We check workload presence before reconciliation. On a fresh/recreated
     // cluster, secrets are always newly generated and a restart is unnecessary.
     // Restarting only when workload pre-existed avoids extra rollout latency.
-    let workload_existed_before_pki = navigator_workload_exists(&target_docker, &name).await?;
+    let workload_existed_before_pki = openshell_workload_exists(&target_docker, &name).await?;
     log("[progress] Reconciling TLS certificates".to_string());
     let (pki_bundle, rotated) = reconcile_pki(&target_docker, &name, &extra_sans, &log).await?;
 
     if rotated && workload_existed_before_pki {
-        // If a navigator workload is already running, it must be restarted so
+        // If an openshell workload is already running, it must be restarted so
         // it picks up the new TLS secrets before we write CLI-side certs.
         // A failed rollout is a hard error — CLI certs must not be persisted
         // if the server cannot come up with the new PKI.
-        log("[progress] PKI rotated — restarting navigator workload".to_string());
-        restart_navigator_deployment(&target_docker, &name).await?;
+        log("[progress] PKI rotated — restarting openshell workload".to_string());
+        restart_openshell_deployment(&target_docker, &name).await?;
     }
 
     log("[progress] Storing CLI mTLS credentials".to_string());
@@ -440,8 +440,8 @@ where
             )
             .await?;
 
-            log("[progress] Restarting navigator deployment".to_string());
-            restart_navigator_deployment(&target_docker, &name).await?;
+            log("[progress] Restarting openshell deployment".to_string());
+            restart_openshell_deployment(&target_docker, &name).await?;
         }
     }
 
@@ -683,7 +683,7 @@ async fn load_existing_pki_bundle(
         async move {
             let jsonpath = format!("{{.data.{}}}", key.replace('.', "\\."));
             let cmd = format!(
-                "KUBECONFIG={kubeconfig} kubectl get secret {secret} -n navigator -o jsonpath='{jsonpath}' 2>/dev/null"
+                "KUBECONFIG={kubeconfig} kubectl get secret {secret} -n openshell -o jsonpath='{jsonpath}' 2>/dev/null"
             );
             let (output, exit_code) = exec_capture_with_exit(
                 &docker,

--- a/crates/navigator-bootstrap/src/runtime.rs
+++ b/crates/navigator-bootstrap/src/runtime.rs
@@ -357,16 +357,16 @@ pub async fn clean_stale_nodes(docker: &Docker, name: &str) -> Result<usize> {
     Ok(count)
 }
 
-/// Restart the navigator workload so pods pick up updated images or secrets.
+/// Restart the openshell workload so pods pick up updated images or secrets.
 ///
 /// Probes for a `StatefulSet` first, then falls back to a `Deployment`, matching
 /// the same detection pattern used by `cluster-deploy-fast.sh`.
-pub async fn restart_navigator_deployment(docker: &Docker, name: &str) -> Result<()> {
+pub async fn restart_openshell_deployment(docker: &Docker, name: &str) -> Result<()> {
     let cname = container_name(name);
 
     // Detect which workload kind exists in the cluster.
-    let workload_kind = detect_navigator_workload_kind(docker, &cname).await?;
-    let workload_ref = format!("{workload_kind}/navigator");
+    let workload_kind = detect_openshell_workload_kind(docker, &cname).await?;
+    let workload_ref = format!("{workload_kind}/openshell");
 
     let (restart_output, restart_exit) = exec_capture_with_exit(
         docker,
@@ -375,14 +375,14 @@ pub async fn restart_navigator_deployment(docker: &Docker, name: &str) -> Result
             "sh".to_string(),
             "-c".to_string(),
             format!(
-                "KUBECONFIG={KUBECONFIG_PATH} kubectl rollout restart {workload_ref} -n navigator"
+                "KUBECONFIG={KUBECONFIG_PATH} kubectl rollout restart {workload_ref} -n openshell"
             ),
         ],
     )
     .await?;
     if restart_exit != 0 {
         return Err(miette::miette!(
-            "failed to restart navigator {workload_ref} (exit code {restart_exit})\n{restart_output}"
+            "failed to restart openshell {workload_ref} (exit code {restart_exit})\n{restart_output}"
         ));
     }
 
@@ -393,32 +393,32 @@ pub async fn restart_navigator_deployment(docker: &Docker, name: &str) -> Result
             "sh".to_string(),
             "-c".to_string(),
             format!(
-                "KUBECONFIG={KUBECONFIG_PATH} kubectl rollout status {workload_ref} -n navigator --timeout=180s"
+                "KUBECONFIG={KUBECONFIG_PATH} kubectl rollout status {workload_ref} -n openshell --timeout=180s"
             ),
         ],
     )
     .await?;
     if status_exit != 0 {
         return Err(miette::miette!(
-            "navigator rollout status failed for {workload_ref} (exit code {status_exit})\n{status_output}"
+            "openshell rollout status failed for {workload_ref} (exit code {status_exit})\n{status_output}"
         ));
     }
 
     Ok(())
 }
 
-/// Check whether a navigator workload exists in the cluster (`StatefulSet` or `Deployment`).
-pub async fn navigator_workload_exists(docker: &Docker, name: &str) -> Result<bool> {
+/// Check whether an openshell workload exists in the cluster (`StatefulSet` or `Deployment`).
+pub async fn openshell_workload_exists(docker: &Docker, name: &str) -> Result<bool> {
     let cname = container_name(name);
-    match detect_navigator_workload_kind(docker, &cname).await {
+    match detect_openshell_workload_kind(docker, &cname).await {
         Ok(_) => Ok(true),
         Err(_) => Ok(false),
     }
 }
 
-/// Detect whether navigator is deployed as a `StatefulSet` or `Deployment`.
+/// Detect whether openshell is deployed as a `StatefulSet` or `Deployment`.
 /// Returns "statefulset" or "deployment".
-async fn detect_navigator_workload_kind(docker: &Docker, container_name: &str) -> Result<String> {
+async fn detect_openshell_workload_kind(docker: &Docker, container_name: &str) -> Result<String> {
     // Check StatefulSet first (primary workload type for fresh deploys)
     let (_, ss_exit) = exec_capture_with_exit(
         docker,
@@ -427,7 +427,7 @@ async fn detect_navigator_workload_kind(docker: &Docker, container_name: &str) -
             "sh".to_string(),
             "-c".to_string(),
             format!(
-                "KUBECONFIG={KUBECONFIG_PATH} kubectl get statefulset/navigator -n navigator -o name 2>/dev/null"
+                "KUBECONFIG={KUBECONFIG_PATH} kubectl get statefulset/openshell -n openshell -o name 2>/dev/null"
             ),
         ],
     )
@@ -444,7 +444,7 @@ async fn detect_navigator_workload_kind(docker: &Docker, container_name: &str) -
             "sh".to_string(),
             "-c".to_string(),
             format!(
-                "KUBECONFIG={KUBECONFIG_PATH} kubectl get deployment/navigator -n navigator -o name 2>/dev/null"
+                "KUBECONFIG={KUBECONFIG_PATH} kubectl get deployment/openshell -n openshell -o name 2>/dev/null"
             ),
         ],
     )
@@ -454,7 +454,7 @@ async fn detect_navigator_workload_kind(docker: &Docker, container_name: &str) -
     }
 
     Err(miette::miette!(
-        "no navigator workload (statefulset or deployment) found in namespace 'navigator'"
+        "no openshell workload (statefulset or deployment) found in namespace 'openshell'"
     ))
 }
 


### PR DESCRIPTION
## Summary

Fixes cluster startup hang caused by namespace/workload name mismatch after the navigator → openshell rename.

- Update secret fetch in `lib.rs` to use `-n openshell` instead of `-n navigator`
- Rename functions in `runtime.rs` (`restart_navigator_deployment` → `restart_openshell_deployment`, etc.)
- Update all kubectl commands to reference `openshell` namespace and `openshell` workloads

## Problem

The previous rename commit (#208) missed hardcoded namespace and workload references in the bootstrap code:
- Helm chart deploys to `openshell` namespace with `openshell-*` resources
- Bootstrap code was looking for secrets in `navigator` namespace
- Bootstrap code was looking for `statefulset/navigator` or `deployment/navigator` workloads

This caused `openshell gateway start` to hang indefinitely because the TLS secrets were never found (they were created in the correct `openshell` namespace but bootstrap was looking in `navigator`).

## Test Plan

- Verified with `mise run pre-commit` (all checks pass)
- Manual testing: `openshell gateway start` should now complete successfully