### PR TITLE
fix(bootstrap): handle IP:port REGISTRY_HOST in DNS probes

### DIFF
--- a/crates/navigator-bootstrap/src/lib.rs
+++ b/crates/navigator-bootstrap/src/lib.rs
@@ -772,8 +772,16 @@ async fn probe_container_dns(docker: &Docker, container_name: &str) -> Result<bo
         vec![
             "sh".to_string(),
             "-c".to_string(),
-            "nslookup \"${REGISTRY_HOST:-ghcr.io}\" >/dev/null 2>&1 && echo DNS_OK || echo DNS_FAIL"
-                .to_string(),
+            // Strip port from REGISTRY_HOST and fall back to COMMUNITY_REGISTRY_HOST
+            // (or ghcr.io) when the host part is an IP address, since nslookup
+            // cannot resolve raw IPs and would false-positive as a DNS failure.
+            concat!(
+                "dns_host=\"${REGISTRY_HOST:-ghcr.io}\"; ",
+                "dns_host=\"${dns_host%%:*}\"; ",
+                "case \"$dns_host\" in [0-9]*) dns_host=\"${COMMUNITY_REGISTRY_HOST:-ghcr.io}\" ;; esac; ",
+                "nslookup \"$dns_host\" >/dev/null 2>&1 && echo DNS_OK || echo DNS_FAIL",
+            )
+            .to_string(),
         ],
     )
     .await?;

--- a/deploy/docker/cluster-entrypoint.sh
+++ b/deploy/docker/cluster-entrypoint.sh
@@ -126,7 +126,14 @@ fi
 # the CLI polling loop can detect this early and fail fast.
 # ---------------------------------------------------------------------------
 verify_dns() {
+    # Strip port from REGISTRY_HOST and fall back to COMMUNITY_REGISTRY_HOST
+    # (or ghcr.io) when the host part is an IP address, since nslookup cannot
+    # resolve raw IPs and would false-positive as a DNS failure.
     local dns_target="${REGISTRY_HOST:-ghcr.io}"
+    dns_target="${dns_target%%:*}"
+    case "$dns_target" in
+        [0-9]*) dns_target="${COMMUNITY_REGISTRY_HOST:-ghcr.io}" ;;
+    esac
     local attempts=5
     local i=1
     while [ "$i" -le "$attempts" ]; do
@@ -140,7 +147,7 @@ verify_dns() {
 }
 
 if ! verify_dns; then
-    echo "DNS_PROBE_FAILED: cannot resolve ${REGISTRY_HOST:-ghcr.io} after DNS proxy setup"
+    echo "DNS_PROBE_FAILED: cannot resolve DNS after proxy setup (REGISTRY_HOST=${REGISTRY_HOST:-ghcr.io})"
     echo "  resolv.conf: $(cat "$RESOLV_CONF")"
     echo "  This usually means Docker DNS forwarding is broken."
     echo "  Try restarting Docker or pruning networks: docker network prune -f"

--- a/deploy/docker/cluster-healthcheck.sh
+++ b/deploy/docker/cluster-healthcheck.sh
@@ -13,7 +13,14 @@ export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 # can't start, etc.). Fail fast with a clear signal instead of letting the
 # health check return unhealthy for 5+ minutes with no useful output.
 # ---------------------------------------------------------------------------
+# Strip port from REGISTRY_HOST and fall back to COMMUNITY_REGISTRY_HOST
+# (or ghcr.io) when the host part is an IP address, since nslookup cannot
+# resolve raw IPs and would false-positive as a DNS failure.
 DNS_TARGET="${REGISTRY_HOST:-ghcr.io}"
+DNS_TARGET="${DNS_TARGET%%:*}"
+case "$DNS_TARGET" in
+    [0-9]*) DNS_TARGET="${COMMUNITY_REGISTRY_HOST:-ghcr.io}" ;;
+esac
 if ! nslookup "$DNS_TARGET" >/dev/null 2>&1; then
     echo "HEALTHCHECK_DNS_FAILURE: cannot resolve $DNS_TARGET" >&2
     exit 1


### PR DESCRIPTION
## Summary

- DNS health probes in the bootstrap, entrypoint, and healthcheck scripts passed `REGISTRY_HOST` directly to `nslookup`. In local registry mode `REGISTRY_HOST=127.0.0.1:5000`, which is an IP:port — not a valid `nslookup` target. This caused all three probe sites to false-positive as DNS failures, aborting an otherwise healthy cluster deployment.
- Fix strips the port and falls back to `COMMUNITY_REGISTRY_HOST` (defaults to `ghcr.io`) when the host part is an IP address.

## What was happening

`mise run cluster` (and `openshell gateway start` for local deploys) failed with:

```
Error: × K8s namespace not ready
  ╰─▶ dial tcp: lookup registry: Try again
      DNS resolution is failing inside the gateway container.
```

Despite DNS working correctly inside the container — the cluster was actually healthy with all pods running.

## Root cause

Three independent DNS probes all had the same bug:

| File | Function | What it ran |
|------|----------|-------------|
| `crates/navigator-bootstrap/src/lib.rs` | `probe_container_dns()` | `nslookup "$REGISTRY_HOST"` |
| `deploy/docker/cluster-entrypoint.sh` | `verify_dns()` | `nslookup "$REGISTRY_HOST"` |
| `deploy/docker/cluster-healthcheck.sh` | pre-flight DNS check | `nslookup "$REGISTRY_HOST"` |

When `REGISTRY_HOST=127.0.0.1:5000`, `nslookup "127.0.0.1:5000"` always fails (IP:port is not a hostname). The bootstrap probe hit its failure threshold (2 consecutive failures) and aborted. The healthcheck probe caused Docker to mark the container as unhealthy, triggering a second failure path.

## Fix

All three sites now: strip the port from `REGISTRY_HOST`, check if the remaining host part is an IP address, and if so fall back to `COMMUNITY_REGISTRY_HOST` (defaults to `ghcr.io`) for the DNS resolution test.