### PR TITLE
fix(cluster): skip DNS probe for IP-literal registry hosts

### DIFF
--- a/crates/navigator-bootstrap/src/lib.rs
+++ b/crates/navigator-bootstrap/src/lib.rs
@@ -766,14 +766,24 @@ async fn load_existing_pki_bundle(
 /// Returns `Ok(true)` if DNS is functional, `Ok(false)` if the probe ran but
 /// resolution failed, and `Err` if the exec itself failed.
 async fn probe_container_dns(docker: &Docker, container_name: &str) -> Result<bool> {
+    // The probe must handle IP-literal registry hosts (e.g. 127.0.0.1:5000)
+    // which don't need DNS resolution. Strip the port suffix since nslookup
+    // doesn't understand host:port, and skip the probe entirely for IP
+    // literals.
     let (output, exit_code) = exec_capture_with_exit(
         docker,
         container_name,
         vec![
             "sh".to_string(),
             "-c".to_string(),
-            "nslookup \"${REGISTRY_HOST:-ghcr.io}\" >/dev/null 2>&1 && echo DNS_OK || echo DNS_FAIL"
-                .to_string(),
+            concat!(
+                "host=\"${REGISTRY_HOST:-ghcr.io}\"; ",
+                "host=\"${host%%:*}\"; ",
+                "echo \"$host\" | grep -qE '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$' && { echo DNS_OK; exit 0; }; ",
+                "echo \"$host\" | grep -qE '^\\[?[0-9a-fA-F:]+\\]?$' && { echo DNS_OK; exit 0; }; ",
+                "nslookup \"$host\" >/dev/null 2>&1 && echo DNS_OK || echo DNS_FAIL",
+            )
+            .to_string(),
         ],
     )
     .await?;

--- a/deploy/docker/cluster-entrypoint.sh
+++ b/deploy/docker/cluster-entrypoint.sh
@@ -125,12 +125,36 @@ fi
 # spin for minutes with opaque "Try again" errors. Log a clear marker so
 # the CLI polling loop can detect this early and fail fast.
 # ---------------------------------------------------------------------------
+
+# Check whether a string looks like an IP address (v4 or v6) with an
+# optional port suffix.  When the registry host is an IP literal, DNS
+# resolution is not required and we should skip the nslookup probe.
+is_ip_literal() {
+    # Strip an optional :port suffix
+    local host="${1%:*}"
+    # IPv4: digits and dots only
+    echo "$host" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' && return 0
+    # IPv6 (bare or bracketed)
+    echo "$host" | grep -qE '^\[?[0-9a-fA-F:]+\]?$' && return 0
+    return 1
+}
+
 verify_dns() {
     local dns_target="${REGISTRY_HOST:-ghcr.io}"
+
+    # IP-literal registry hosts (e.g. 127.0.0.1:5000) don't need DNS.
+    if is_ip_literal "$dns_target"; then
+        echo "Registry host is an IP literal ($dns_target), skipping DNS probe"
+        return 0
+    fi
+
+    # Strip port suffix — nslookup doesn't understand host:port.
+    local lookup_host="${dns_target%%:*}"
+
     local attempts=5
     local i=1
     while [ "$i" -le "$attempts" ]; do
-        if nslookup "$dns_target" >/dev/null 2>&1; then
+        if nslookup "$lookup_host" >/dev/null 2>&1; then
             return 0
         fi
         sleep 1
@@ -402,6 +426,18 @@ else
     # Remove the placeholder line entirely so invalid YAML isn't left behind
     sed -i '/__CHART_CHECKSUM__/d' "$HELMCHART"
 fi
+
+# ---------------------------------------------------------------------------
+# Ensure flannel CNI directories exist
+# ---------------------------------------------------------------------------
+# k3s uses flannel as its default CNI. Flannel writes subnet configuration to
+# /run/flannel/subnet.env during startup. When running inside a Docker
+# container, /run/flannel/ may not exist, causing a race where kubelet tries
+# to create pod sandboxes before flannel can write the file. Without it, every
+# pod (including CoreDNS) fails with:
+#   plugin type="flannel" failed (add): failed to load flannel 'subnet.env'
+# Pre-creating the directory eliminates this failure mode.
+mkdir -p /run/flannel
 
 # Docker Desktop can briefly start the container before its bridge default route
 # is fully installed. k3s exits immediately in that state, so wait briefly for

--- a/deploy/docker/cluster-healthcheck.sh
+++ b/deploy/docker/cluster-healthcheck.sh
@@ -13,10 +13,23 @@ export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 # can't start, etc.). Fail fast with a clear signal instead of letting the
 # health check return unhealthy for 5+ minutes with no useful output.
 # ---------------------------------------------------------------------------
+
+# Check whether a string looks like an IP address (v4 or v6) with optional port.
+is_ip_literal() {
+    local host="${1%:*}"
+    echo "$host" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' && return 0
+    echo "$host" | grep -qE '^\[?[0-9a-fA-F:]+\]?$' && return 0
+    return 1
+}
+
 DNS_TARGET="${REGISTRY_HOST:-ghcr.io}"
-if ! nslookup "$DNS_TARGET" >/dev/null 2>&1; then
-    echo "HEALTHCHECK_DNS_FAILURE: cannot resolve $DNS_TARGET" >&2
-    exit 1
+# IP-literal registry hosts (e.g. 127.0.0.1:5000) don't need DNS resolution.
+if ! is_ip_literal "$DNS_TARGET"; then
+    DNS_LOOKUP="${DNS_TARGET%%:*}"
+    if ! nslookup "$DNS_LOOKUP" >/dev/null 2>&1; then
+        echo "HEALTHCHECK_DNS_FAILURE: cannot resolve $DNS_TARGET" >&2
+        exit 1
+    fi
 fi
 
 kubectl get --raw='/readyz' >/dev/null 2>&1 || exit 1


### PR DESCRIPTION
## Summary
- DNS probes (`nslookup`) in the entrypoint, healthcheck, and Rust bootstrap always failed when `REGISTRY_HOST` is an IP:port combo (e.g. `127.0.0.1:5000` for local registries), because `nslookup` can't parse host:port and reverse-PTR lookups on loopback are unreliable
- This caused the healthcheck to permanently emit `HEALTHCHECK_DNS_FAILURE` and the Rust-side `probe_container_dns` to trigger early abort with "K8s namespace not ready / DNS resolution is failing" — even though the cluster was otherwise healthy
- All three DNS probe sites now detect IP-literal hosts (IPv4/IPv6) and skip the probe; hostname registries with port suffixes are also handled correctly

## Changes
- **`deploy/docker/cluster-entrypoint.sh`** — Added `is_ip_literal()` helper; `verify_dns()` skips `nslookup` for IP literals and strips port suffixes for hostnames. Pre-creates `/run/flannel/` to reduce transient CNI errors during k3s startup.
- **`deploy/docker/cluster-healthcheck.sh`** — Same `is_ip_literal()` check; skips DNS probe for IP addresses.
- **`crates/navigator-bootstrap/src/lib.rs`** — `probe_container_dns()` detects IPv4/IPv6 literals in the container shell and reports `DNS_OK` immediately.

## Test Plan
- Ran `mise run cluster` end-to-end — cluster starts successfully with local registry (`127.0.0.1:5000`)
- Ran `mise run pre-commit` — all checks pass
- Verified container logs show `Registry host is an IP literal (127.0.0.1:5000), skipping DNS probe` instead of `DNS_PROBE_FAILED`