### PR TITLE
chore(docker): migrate base container images to nvcr.io/nvidia/base/ubuntu:noble-20251013

### DIFF
--- a/deploy/docker/Dockerfile.ci
+++ b/deploy/docker/Dockerfile.ci
@@ -6,7 +6,7 @@
 # CI runner image with all development tools pre-installed
 # Rebuild triggered automatically when mise.toml or this file changes
 
-FROM ubuntu:24.04
+FROM nvcr.io/nvidia/base/ubuntu:noble-20251013
 
 ARG DOCKER_VERSION=29.3.0
 ARG BUILDX_VERSION=v0.32.1

--- a/deploy/docker/Dockerfile.cluster
+++ b/deploy/docker/Dockerfile.cluster
@@ -3,7 +3,11 @@
 
 # k3s cluster image with OpenShell Helm charts and manifests
 #
-# This image is based on k3s and includes:
+# Multi-stage build: extracts k3s artifacts from the upstream rancher/k3s
+# Alpine image and layers them onto the NVIDIA Ubuntu base image.
+#
+# This image includes:
+# - k3s binary and all supporting binaries (containerd-shim, runc, CNI, etc.)
 # - Packaged OpenShell Helm chart
 # - HelmChart CR for auto-deploying OpenShell
 # - Custom entrypoint for DNS configuration in Docker environments
@@ -23,15 +27,63 @@
 #   GHSA-9h8m-3fm2-qjrq  otel/sdk v1.39.0 (macOS-only PATH hijack; N/A for Linux)
 #   CVE-2024-36623       docker/docker v25.0.8 (streamformatter race condition)
 # Bump K3S_VERSION when a release with updated dependencies ships.
+
+# ---------------------------------------------------------------------------
+# Stage 1: Extract k3s artifacts from upstream rancher image (Alpine-based)
+# ---------------------------------------------------------------------------
 ARG K3S_VERSION=v1.35.2-k3s1
-FROM rancher/k3s:${K3S_VERSION}
+FROM rancher/k3s:${K3S_VERSION} AS k3s
+
+# ---------------------------------------------------------------------------
+# Stage 2: Runtime on NVIDIA hardened Ubuntu base
+# ---------------------------------------------------------------------------
+FROM nvcr.io/nvidia/base/ubuntu:noble-20251013
+
+# Install runtime dependencies that k3s expects from the host OS.
+# - iptables: used by flannel/kube-proxy for network policy and NAT rules
+# - mount/umount: needed by kubelet for volume mounts (provided by mount package)
+# - ca-certificates: TLS verification for registry pulls
+# - conntrack: k3s/kube-proxy uses conntrack for connection tracking
+# - dnsutils: nslookup used by entrypoint/healthcheck for DNS probe
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    iptables \
+    mount \
+    dnsutils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the full /bin directory from k3s (contains all statically-linked
+# binaries and their symlinks: k3s, kubectl, crictl, ctr, containerd,
+# containerd-shim-runc-v2, runc, cni plugins, busybox, coreutils,
+# ip, ipset, conntrack, nsenter, pigz, etc.)
+COPY --from=k3s /bin/ /bin/
+
+# Copy iptables/nftables tooling (xtables-nft-multi, iptables-detect.sh, etc.)
+# These are in /bin/aux/ in the k3s image and must be on PATH.
+# Note: the Ubuntu iptables package provides /usr/sbin/iptables, but k3s
+# expects its own bundled version at /bin/aux/iptables. Both are on PATH;
+# k3s finds its copy via /bin/aux in PATH.
+
+# Copy CA certificates from k3s (bundled Alpine CA bundle).
+# The Ubuntu ca-certificates package also installs certs; having both is fine.
+COPY --from=k3s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/k3s-ca-certificates.crt
+
+# Copy timezone data used by k3s/Go for time.LoadLocation
+COPY --from=k3s /usr/share/zoneinfo/ /usr/share/zoneinfo/
+
+# Set environment variables matching the upstream k3s image.
+# PATH includes /bin/aux for iptables tooling and /var/lib/rancher/k3s/data/cni
+# for runtime-extracted CNI binaries.
+ENV PATH="/var/lib/rancher/k3s/data/cni:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/bin/aux" \
+    CRI_CONFIG_FILE="/var/lib/rancher/k3s/agent/etc/crictl.yaml"
 
 # Create directories for manifests, charts, and configuration
 RUN mkdir -p /var/lib/rancher/k3s/server/manifests \
              /var/lib/rancher/k3s/server/static/charts \
              /etc/rancher/k3s \
              /opt/openshell/manifests \
-             /opt/openshell/charts
+             /opt/openshell/charts \
+             /run/flannel
 
 # Copy entrypoint script that configures DNS for Docker environments
 # This script detects the host gateway IP and configures CoreDNS to use it

--- a/deploy/docker/Dockerfile.server
+++ b/deploy/docker/Dockerfile.server
@@ -79,8 +79,8 @@ RUN --mount=type=cache,id=cargo-registry-server-${TARGETARCH},sharing=locked,tar
     cp "$(cross_output_dir release)/navigator-server" /build/navigator-server
 
 # Stage 2: Runtime (uses target platform)
-# Pin to specific Debian point release for reproducible builds.
-FROM debian:bookworm-20260223-slim AS runtime
+# NVIDIA hardened Ubuntu base for supply chain consistency.
+FROM nvcr.io/nvidia/base/ubuntu:noble-20251013 AS runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/deploy/docker/sandbox/Dockerfile.base
+++ b/deploy/docker/sandbox/Dockerfile.base
@@ -86,21 +86,24 @@ RUN --mount=type=cache,id=cargo-registry-sandbox-${TARGETARCH},sharing=locked,ta
     cp "$(cross_output_dir "$RUST_BUILD_PROFILE")/navigator-sandbox" /build/out/
 
 # Stage 2: Python base (uses target platform)
-# Pin to specific Python patch + Debian release for reproducible builds.
-# CVE-2025-13836 (stdlib urllib Content-Length OOM) affects Python <= 3.12.13;
-# update to python:3.12.14-slim-bookworm (or later) when released.
-FROM python:3.12.13-slim-bookworm AS base
+# NVIDIA hardened Ubuntu base for supply chain consistency.
+# Ubuntu Noble ships Python 3.12 natively; install from default repos.
+FROM nvcr.io/nvidia/base/ubuntu:noble-20251013 AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
 WORKDIR /sandbox
 
-# Install system dependencies
-# iproute2 is needed for network namespace management (ip netns, veth pairs)
+# Install Python 3.12 and system dependencies.
+# python3.12-venv provides the venv module (required by uv venv).
+# iproute2 is needed for network namespace management (ip netns, veth pairs).
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.12 python3.12-venv python3.12-dev python3-pip \
     curl dnsutils iproute2 iputils-ping \
     net-tools netcat-openbsd traceroute \
+    && ln -sf /usr/bin/python3.12 /usr/local/bin/python3 \
+    && ln -sf /usr/bin/python3.12 /usr/local/bin/python \
     && rm -rf /var/lib/apt/lists/*
 
 # Create supervisor and sandbox users/groups
@@ -135,7 +138,7 @@ FROM base AS coding-agents
 # CVE-2026-21637, CVE-2025-59466, CVE-2025-59465, CVE-2025-55131 affect
 # Node.js <= 22.22.1. Update to 22.23.0+ when a patched release ships.
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y --no-install-recommends build-essential git nodejs=22.22.1-1nodesource1 python3 nano && \
+    apt-get install -y --no-install-recommends build-essential git nodejs=22.22.1-1nodesource1 nano && \
     rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI (gh) from the official apt repository


### PR DESCRIPTION
Closes #244

## Summary
- Migrate all production container runtime stages to `nvcr.io/nvidia/base/ubuntu:noble-20251013` for supply chain consistency
- Convert `Dockerfile.cluster` from single-stage `rancher/k3s` (Alpine) to a multistage build that extracts k3s artifacts onto the NVIDIA Ubuntu base
- Install Python 3.12 from Ubuntu Noble system packages in the sandbox base image (replaces `python:3.12-slim-bookworm`)

## Changes

| Dockerfile | Previous Base (runtime) | New Base |
|---|---|---|
| `Dockerfile.ci` | `ubuntu:24.04` | `nvcr.io/nvidia/base/ubuntu:noble-20251013` |
| `Dockerfile.server` | `debian:bookworm-20260223-slim` | `nvcr.io/nvidia/base/ubuntu:noble-20251013` |
| `sandbox/Dockerfile.base` | `python:3.12.13-slim-bookworm` | `nvcr.io/nvidia/base/ubuntu:noble-20251013` + system Python 3.12 |
| `Dockerfile.cluster` | `rancher/k3s:v1.35.2-k3s1` | Multistage: k3s artifacts → `nvcr.io/nvidia/base/ubuntu:noble-20251013` |

### Dockerfile.cluster details
The cluster image is now a two-stage build:
1. **Stage 1** (`k3s`): Pulls `rancher/k3s` as an artifact source only
2. **Stage 2** (runtime): NVIDIA Ubuntu base with:
   - All k3s binaries copied from `/bin/` (k3s, kubectl, containerd-shim-runc-v2, runc, CNI plugins, busybox, coreutils, iptables tooling, etc.)
   - Ubuntu runtime deps: `iptables`, `mount`, `ca-certificates`, `dnsutils`
   - PATH and env vars matching upstream k3s image

## Test Plan
- Pre-commit checks pass locally (all Rust/Python tests, linting, formatting)
- E2E label applied — CI will build and test all container images