### PR TITLE
docs(docker): document CVE-2025-55130 as already fixed in sandbox Node.js pin

### DIFF
--- a/deploy/docker/sandbox/Dockerfile.base
+++ b/deploy/docker/sandbox/Dockerfile.base
@@ -135,8 +135,14 @@ FROM base AS coding-agents
 # Include a minimal native toolchain so npm can compile optional native
 # dependencies on platforms where prebuilt artifacts are unavailable.
 # Pin to a specific patch version for reproducible builds.
-# CVE-2026-21637, CVE-2025-59466, CVE-2025-59465, CVE-2025-55131 affect
-# Node.js <= 22.22.1. Update to 22.23.0+ when a patched release ships.
+# Jan 2026 Node.js security release (22.22.0) fixed:
+#   CVE-2025-55130  - symlink permission bypass       (High)   - fixed 22.22.0
+#   CVE-2025-55131  - buffer alloc race condition      (High)   - fixed 22.22.0
+#   CVE-2025-59465  - HTTP/2 HEADERS crash             (High)   - fixed 22.22.0
+#   CVE-2025-59466  - async_hooks stack overflow DoS   (Medium) - fixed 22.22.0
+#   CVE-2026-21637  - TLS PSK/ALPN callback DoS        (Medium) - fixed 22.22.0
+# Current pin (22.22.1) includes all fixes. Scanner reports matching the
+# Debian source tracker (which tracks its own rebuild) are false positives.
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y --no-install-recommends build-essential git nodejs=22.22.1-1nodesource1 nano && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- Adds CVE-2025-55130 (symlink permission bypass, High severity) to the CVE tracking comment in `Dockerfile.base`
- Corrects the comment to show all five Jan 2026 Node.js security CVEs are **already fixed** in the pinned version (22.22.1 >= 22.22.0)
- Notes that scanner reports matching the Debian source tracker are false positives (Debian tracks its own source rebuild, not the NodeSource binary we install)

## Context

Container vulnerability scanners flagged `CVE-2025-55130` against `ghcr.io/nvidia/openshell/sandbox:latest`. The sandbox installs Node.js `22.22.1-1nodesource1` from the NodeSource APT repo, which already includes the fix shipped in the [Node.js 22.22.0 security release](https://nodejs.org/en/blog/vulnerability/december-2025-security-releases#bypass-file-system-permissions-using-crafted-symlinks-cve-2025-55130---high) (Jan 13, 2026). The scanner is matching against the [Debian source tracker](https://security-tracker.debian.org/tracker/CVE-2025-55130), which tracks Debian's own `nodejs` source package rebuild -- not the NodeSource binary package.

### CVEs documented (all fixed in 22.22.0, included in our 22.22.1 pin)

| CVE | Description | Severity |
|-----|-------------|----------|
| CVE-2025-55130 | Symlink permission bypass | High |
| CVE-2025-55131 | Buffer alloc race condition | High |
| CVE-2025-59465 | HTTP/2 HEADERS crash | High |
| CVE-2025-59466 | async_hooks stack overflow DoS | Medium |
| CVE-2026-21637 | TLS PSK/ALPN callback DoS | Medium |

## No version change needed

The container is **not vulnerable**. This is a comment-only change to accurately document the CVE status and prevent future triage churn on scanner false positives.