### PR TITLE
fix(cluster): add missing k9s build stage to Dockerfile.cluster

### DIFF
--- a/deploy/docker/Dockerfile.cluster
+++ b/deploy/docker/Dockerfile.cluster
@@ -30,12 +30,25 @@
 # Bump K3S_VERSION when a release with updated dependencies ships.
 
 ARG K3S_VERSION=v1.35.2-k3s1
+ARG K9S_VERSION=v0.50.18
 ARG NVIDIA_CONTAINER_TOOLKIT_VERSION=1.18.2-1
 
 # ---------------------------------------------------------------------------
 # Stage 1: Extract k3s artifacts from upstream rancher image (Alpine-based)
 # ---------------------------------------------------------------------------
 FROM rancher/k3s:${K3S_VERSION} AS k3s
+
+# ---------------------------------------------------------------------------
+# Stage 1b: Download k9s binary for interactive cluster debugging
+# ---------------------------------------------------------------------------
+FROM ubuntu:24.04 AS k9s
+ARG K9S_VERSION
+ARG TARGETARCH
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
+    curl -fsSL "https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_Linux_${TARGETARCH}.tar.gz" \
+      | tar xz -C /tmp k9s && \
+    chmod +x /tmp/k9s && \
+    rm -rf /var/lib/apt/lists/*
 
 # ---------------------------------------------------------------------------
 # Stage 2: Install NVIDIA container toolkit on Ubuntu


### PR DESCRIPTION
## Summary
- The `COPY --from=k9s` instruction added in #252 referenced a build stage that didn't exist, causing Docker to look for `docker.io/library/k9s:latest` which fails with a 401/not-found error
- Adds a new multi-arch build stage that downloads the k9s binary (v0.50.18) from the official [derailed/k9s](https://github.com/derailed/k9s) GitHub releases using `TARGETARCH` for `linux/amd64` and `linux/arm64` support
- Fixes the `build-cluster / Build cluster` job failure in the [Publish workflow](https://github.com/NVIDIA/OpenShell/actions/runs/22986545354/job/66738641963)