### PR TITLE
fix(ci): add workflows permission to publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   packages: write
+  workflows: write
 
 defaults:
   run:


### PR DESCRIPTION
## Summary

- Adds `workflows: write` permission to the Publish workflow's top-level permissions block
- Fixes the "Release Devel" job failure caused by `git push --force origin devel` being rejected when the tagged commit includes workflow file changes

## Context

The `release-devel` job force-pushes the `devel` tag to the latest commit on main. GitHub requires the `workflows` permission to push any ref where the diff (relative to the old ref target) includes files under `.github/workflows/`. This was a latent issue that first surfaced when PR #277 (crate rename) modified `.github/workflows/docker-build.yml`.

Failed run: https://github.com/NVIDIA/OpenShell/actions/runs/23043678584/job/66928323078