### PR TITLE
chore(docs): Show bleeding-edge docs HTML

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -26,6 +26,8 @@ jobs:
             credentials:
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}
+        permissions:
+            contents: read
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -50,7 +52,7 @@ jobs:
                   retention-days: 1
 
     publish:
-        if: false # disabled until GitHub Pages is configured
+        if: github.repository_owner == 'NVIDIA'
         needs: [build]
         runs-on: build-arm64
         container:
@@ -58,40 +60,15 @@ jobs:
             credentials:
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}
+        permissions:
+            contents: write
+            pages: read
         steps:
-            - uses: actions/checkout@v4
-              with:
-                  ref: "gh-pages"
-
-            - name: Initialize Git configuration
-              run: |
-                  git config --global --add safe.directory "$GITHUB_WORKSPACE"
-                  git config --global user.name "github-actions[bot]"
-                  git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
             - name: Download artifacts
               uses: actions/download-artifact@v4
               with:
                   name: html-build-artifact
-                  path: ${{ github.ref_name }}
-
-            - name: Copy HTML directories
-              run: |
-                  ls -asl
-                  for i in `ls -d *`
-                  do
-                    echo "Git adding ${i}"
-                    git add "${i}"
-                  done
-            - name: Check or create dot-no-jekyll file
-
-              run: |
-                  if [ -f ".nojekyll" ]; then
-                    echo "The dot-no-jekyll file already exists."
-                    exit 0
-                  fi
-                  touch .nojekyll
-                  git add .nojekyll
+                  path: ./_site
 
             - name: Check or create redirect page
               env:
@@ -124,11 +101,15 @@ jobs:
                   echo '</html>'                                                                                >> index.html
                   git add index.html
 
-            - name: Commit changes to the GitHub Pages branch
-              run: |
-                  git status
-                  if git commit -m 'Pushing changes to GitHub Pages.'; then
-                    git push -f
-                  else
-                   echo "Nothing changed."
-                  fi
+
+            - name: Deploy to GitHub Pages
+              uses: peaceiris/actions-gh-pages@v4
+              with:
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+                publish_dir: ./_site
+                destination_dir: ${{ github.ref_name }}
+                keep_files: true
+                enable_jekyll: false
+                commit_message: "Deploy to GitHub Pages"
+                user_name: "github-actions[bot]"
+                user_email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
The goals:
- Add docs at https://cuddly-tribble-p3evl8k.pages.github.io/main to show the bleeding edge documentation, this is typically a good review URL before publishing docs for a release.
- Only build for the NVIDIA repo and not forks. (I'm kind of assuming that folks don't use GH pages for their forks.)
- Add a redirect for https://cuddly-tribble-p3evl8k.pages.github.io/ to https://cuddly-tribble-p3evl8k.pages.github.io/main.

GH pages are always public, so please do not merge until after you want the world to find the bleeding edge docs.