### PR TITLE
chore(cluster): extract only supervisor binary during fast deploy

### DIFF
--- a/deploy/docker/Dockerfile.cluster
+++ b/deploy/docker/Dockerfile.cluster
@@ -140,6 +140,14 @@ RUN --mount=type=cache,id=cargo-registry-supervisor-${TARGETARCH},sharing=locked
     cp "$(cross_output_dir release)/openshell-sandbox" /build/out/
 
 # ---------------------------------------------------------------------------
+# Stage 1e: Minimal extraction stage for supervisor binary
+# ---------------------------------------------------------------------------
+# Used by cluster-deploy-fast.sh with --target supervisor-out --output type=local
+# to extract only the ~50MB binary instead of the full ~900MB build tree.
+FROM scratch AS supervisor-out
+COPY --from=supervisor-builder /build/out/openshell-sandbox /openshell-sandbox
+
+# ---------------------------------------------------------------------------
 # Stage 2: Install NVIDIA container toolkit on Ubuntu
 # ---------------------------------------------------------------------------
 FROM ubuntu:24.04 AS nvidia-toolkit

--- a/tasks/scripts/cluster-deploy-fast.sh
+++ b/tasks/scripts/cluster-deploy-fast.sh
@@ -321,7 +321,7 @@ if [[ "${build_supervisor}" == "1" ]]; then
 
   docker buildx build \
     --file deploy/docker/Dockerfile.cluster \
-    --target supervisor-builder \
+    --target supervisor-out \
     --build-arg "BUILDARCH=$(docker version --format '{{.Server.Arch}}')" \
     --build-arg "TARGETARCH=${CLUSTER_ARCH}" \
     --output "type=local,dest=${SUPERVISOR_BUILD_DIR}" \
@@ -330,7 +330,7 @@ if [[ "${build_supervisor}" == "1" ]]; then
 
   # Copy the built binary into the running k3s container
   docker exec "${CONTAINER_NAME}" mkdir -p /opt/openshell/bin
-  docker cp "${SUPERVISOR_BUILD_DIR}/build/out/openshell-sandbox" \
+  docker cp "${SUPERVISOR_BUILD_DIR}/openshell-sandbox" \
     "${CONTAINER_NAME}:/opt/openshell/bin/openshell-sandbox"
   docker exec "${CONTAINER_NAME}" chmod 755 /opt/openshell/bin/openshell-sandbox
 


### PR DESCRIPTION
## Summary
- Add a minimal `FROM scratch` extraction stage (`supervisor-out`) to `Dockerfile.cluster` that copies only the supervisor binary
- Update `cluster-deploy-fast.sh` to target `supervisor-out` instead of `supervisor-builder`
- Fixes the `--output type=local` export dumping the entire ~900MB Rust build tree through Docker Desktop's VM filesystem layer

## Problem
During `mise run cluster` incremental deploys, the supervisor binary build step was exporting **876MB** (the full Rust build tree from the `supervisor-builder` stage) just to extract a single ~50MB binary. On Docker Desktop for Mac, this VM-to-host file transfer took **300+ seconds** at ~2.8 MB/s.

## Fix
A `FROM scratch AS supervisor-out` stage copies only `/build/out/openshell-sandbox` from the builder. The `--output type=local` now exports ~50MB instead of ~900MB.

## Results
| Metric | Before | After |
|---|---|---|
| Supervisor build + deploy | 312+ seconds | ~41 seconds |
| Total incremental deploy | 500+ seconds | ~204 seconds |

## Test Plan
- Ran `mise run cluster` with a source change to `openshell-core`, verified supervisor binary was built, exported, and copied into the running cluster container
- Verified full deploy completes successfully with helm upgrade and pod rollout