### PR TITLE
fix(cli): use line-based stdin read for gateway recreate prompt

### DIFF
--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -1346,6 +1346,7 @@ pub async fn gateway_admin_deploy(
                 } else {
                     "volume only"
                 };
+                eprintln!();
                 eprintln!(
                     "{} Gateway '{name}' already exists ({status}).",
                     "!".yellow().bold()
@@ -1353,6 +1354,7 @@ pub async fn gateway_admin_deploy(
                 if let Some(image) = &existing.container_image {
                     eprintln!("  {} {}", "Image:".dimmed(), image);
                 }
+                eprintln!();
                 eprint!("Destroy and recreate? [y/N] ");
                 std::io::stderr().flush().ok();
                 let mut input = String::new();


### PR DESCRIPTION
## Summary

- Replace `dialoguer::Confirm::interact()` with `std::io::stdin().read_line()` for the gateway recreate prompt — `interact()` puts the terminal in raw mode which causes it to return immediately without waiting for input
- Fix interactive detection to check both stdin and stderr are TTYs (`std::io::stdin().is_terminal() && std::io::stderr().is_terminal()`), matching the pattern used in `gateway_select`
- Restore `volume only` status label and image info in the prompt output

## Context

After the gateway teardown consolidation in #281, `openshell gateway start` with an existing gateway shows the "Destroy and recreate?" prompt but exits immediately without waiting for user input. The `dialoguer::Confirm::interact()` call uses raw terminal mode which fails silently in some environments, causing the default (No) to be accepted instantly.

The fix reverts to the proven `stdin().read_line()` approach which blocks reliably on a full line of input.

## Test Plan

- `cargo check -p openshell-cli` passes
- `mise run pre-commit` passes