### PR TITLE
ci(release): add canary triggered after release workflow

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -1,4 +1,4 @@
-name: Acceptance Test
+name: Release Canary
 
 on:
   workflow_dispatch:
@@ -21,7 +21,7 @@ defaults:
 
 jobs:
   acceptance:
-    name: Acceptance (${{ matrix.arch }})
+    name: Canary (${{ matrix.arch }})
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
@@ -92,7 +92,7 @@ jobs:
       - name: Verify CLI installation
         run: openshell --version
 
-      - name: Run acceptance test
+      - name: Run canary test
         run: |
           set -euo pipefail
 
@@ -107,8 +107,8 @@ jobs:
           echo "$OUTPUT"
 
           if echo "$OUTPUT" | grep -q "hello world"; then
-            echo "Acceptance test passed: 'hello world' found in output"
+            echo "Canary test passed: 'hello world' found in output"
           else
-            echo "::error::Acceptance test failed: 'hello world' not found in output"
+            echo "::error::Canary test failed: 'hello world' not found in output"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Adds a new `acceptance-test.yml` GitHub Actions workflow that runs automatically after `Release Dev` and `Release Tag` workflows complete successfully
- Installs the CLI from the corresponding GitHub release artifact and runs `openshell sandbox create --no-keep --no-tty -- echo "hello world"` as a smoke test
- Tests both amd64 and arm64 architectures in parallel using a matrix strategy

## Test Plan
- Workflow will trigger automatically on the next successful release (dev or tag)
- Validates the released CLI binary can be installed and execute a basic sandbox operation end-to-end