### PR TITLE
chore(ci): upload Python wheels to release assets

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -140,6 +140,13 @@ jobs:
           aws s3 ls "s3://${NAV_PYPI_S3_BUCKET}/${S3_PREFIX}/"
           echo "s3_prefix=${S3_PREFIX}" >> "$GITHUB_OUTPUT"
 
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-wheels
+          path: target/wheels/*.whl
+          retention-days: 5
+
   publish-python:
     name: Publish Python
     needs: [build-python-wheels]
@@ -371,11 +378,11 @@ jobs:
           retention-days: 5
 
   # ---------------------------------------------------------------------------
-  # Create / update the devel GitHub Release with CLI binaries
+  # Create / update the devel GitHub Release with CLI binaries and wheels
   # ---------------------------------------------------------------------------
   release-devel:
     name: Release Devel
-    needs: [build-cli-linux, build-cli-macos]
+    needs: [build-cli-linux, build-cli-macos, build-python-wheels]
     runs-on: build-amd64
     timeout-minutes: 10
     steps:
@@ -388,11 +395,17 @@ jobs:
           path: release/
           merge-multiple: true
 
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-wheels
+          path: release/
+
       - name: Generate checksums
         run: |
           set -euo pipefail
           cd release
-          sha256sum *.tar.gz > openshell-checksums-sha256.txt
+          sha256sum *.tar.gz *.whl > openshell-checksums-sha256.txt
           cat openshell-checksums-sha256.txt
 
       - name: Move devel tag
@@ -438,9 +451,11 @@ jobs:
             | `openshell-x86_64-unknown-linux-musl.tar.gz` | Linux x86_64 | `gh release download devel --repo NVIDIA/OpenShell --pattern "openshell-x86_64-unknown-linux-musl.tar.gz" -O - \| tar xz && sudo install -m 755 openshell /usr/local/bin/openshell` |
             | `openshell-aarch64-unknown-linux-musl.tar.gz` | Linux aarch64 / ARM64 | `gh release download devel --repo NVIDIA/OpenShell --pattern "openshell-aarch64-unknown-linux-musl.tar.gz" -O - \| tar xz && sudo install -m 755 openshell /usr/local/bin/openshell` |
             | `openshell-aarch64-apple-darwin.tar.gz` | macOS Apple Silicon | `gh release download devel --repo NVIDIA/OpenShell --pattern "openshell-aarch64-apple-darwin.tar.gz" -O - \| tar xz && sudo install -m 755 openshell /usr/local/bin/openshell` |
+            | `openshell-*.whl` | Python wheels | `gh release download devel --repo NVIDIA/OpenShell --pattern "openshell-*.whl"` |
             | `openshell-checksums-sha256.txt` | — | SHA256 checksums for all archives |
           files: |
             release/openshell-x86_64-unknown-linux-musl.tar.gz
             release/openshell-aarch64-unknown-linux-musl.tar.gz
             release/openshell-aarch64-apple-darwin.tar.gz
+            release/*.whl
             release/openshell-checksums-sha256.txt

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -148,6 +148,13 @@ jobs:
           aws s3 ls "s3://${NAV_PYPI_S3_BUCKET}/${S3_PREFIX}/"
           echo "s3_prefix=${S3_PREFIX}" >> "$GITHUB_OUTPUT"
 
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-wheels
+          path: target/wheels/*.whl
+          retention-days: 5
+
   publish-python:
     name: Publish Python
     needs: [build-python-wheels]
@@ -379,11 +386,11 @@ jobs:
           retention-days: 5
 
   # ---------------------------------------------------------------------------
-  # Create a tagged GitHub Release with CLI binaries
+  # Create a tagged GitHub Release with CLI binaries and wheels
   # ---------------------------------------------------------------------------
   release:
     name: Release
-    needs: [compute-versions, build-cli-linux, build-cli-macos, publish-python, tag-ghcr-release]
+    needs: [compute-versions, build-cli-linux, build-cli-macos, build-python-wheels, publish-python, tag-ghcr-release]
     runs-on: build-amd64
     timeout-minutes: 10
     steps:
@@ -396,11 +403,17 @@ jobs:
           path: release/
           merge-multiple: true
 
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-wheels
+          path: release/
+
       - name: Generate checksums
         run: |
           set -euo pipefail
           cd release
-          sha256sum *.tar.gz > openshell-checksums-sha256.txt
+          sha256sum *.tar.gz *.whl > openshell-checksums-sha256.txt
           cat openshell-checksums-sha256.txt
 
       - name: Create GitHub Release
@@ -444,9 +457,11 @@ jobs:
             | `openshell-x86_64-unknown-linux-musl.tar.gz` | Linux x86_64 |
             | `openshell-aarch64-unknown-linux-musl.tar.gz` | Linux aarch64 / ARM64 |
             | `openshell-aarch64-apple-darwin.tar.gz` | macOS Apple Silicon |
+            | `openshell-*.whl` | Python wheels |
             | `openshell-checksums-sha256.txt` | SHA256 checksums for all archives |
           files: |
             release/openshell-x86_64-unknown-linux-musl.tar.gz
             release/openshell-aarch64-unknown-linux-musl.tar.gz
             release/openshell-aarch64-apple-darwin.tar.gz
+            release/*.whl
             release/openshell-checksums-sha256.txt


### PR DESCRIPTION
## Summary

Update the dev and tagged release workflows so the wheels built in `build-python-wheels` are also attached to the GitHub release assets.

## Related Issue

N/A

## Changes

- upload built wheel files as workflow artifacts in both release workflows
- download wheel artifacts in the release jobs and publish them alongside the CLI tarballs
- include wheel files in the generated checksum manifest and release asset tables

## Testing

- [x] Ruby YAML parse validation for `.github/workflows/release-dev.yml`
- [x] Ruby YAML parse validation for `.github/workflows/release-tag.yml`

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)