### PR TITLE
feat(cli): add no-verify inference flag

### DIFF
--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -902,6 +902,13 @@ enum InferenceCommands {
         /// agent harness) and is not accessible to user code.
         #[arg(long)]
         system: bool,
+
+        /// Skip endpoint verification before saving the route.
+        ///
+        /// Accepted now so scripts can opt out explicitly ahead of a future
+        /// default switch to verification.
+        #[arg(long)]
+        no_verify: bool,
     },
 
     /// Update gateway-level inference configuration (partial update).
@@ -918,6 +925,13 @@ enum InferenceCommands {
         /// Target the system inference route.
         #[arg(long)]
         system: bool,
+
+        /// Skip endpoint verification before saving the route.
+        ///
+        /// Accepted now so scripts can opt out explicitly ahead of a future
+        /// default switch to verification.
+        #[arg(long)]
+        no_verify: bool,
     },
 
     /// Get gateway-level inference provider and model.
@@ -1757,6 +1771,7 @@ async fn main() -> Result<()> {
                     provider,
                     model,
                     system,
+                    no_verify: _,
                 } => {
                     let route_name = if system { "sandbox-system" } else { "" };
                     run::gateway_inference_set(endpoint, &provider, &model, route_name, &tls)
@@ -1766,6 +1781,7 @@ async fn main() -> Result<()> {
                     provider,
                     model,
                     system,
+                    no_verify: _,
                 } => {
                     let route_name = if system { "sandbox-system" } else { "" };
                     run::gateway_inference_update(
@@ -2688,5 +2704,53 @@ mod tests {
             }
             other => panic!("expected SshProxy, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn inference_set_accepts_no_verify_flag() {
+        let cli = Cli::try_parse_from([
+            "openshell",
+            "inference",
+            "set",
+            "--provider",
+            "openai-dev",
+            "--model",
+            "gpt-4.1",
+            "--no-verify",
+        ])
+        .expect("inference set should parse --no-verify");
+
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Inference {
+                command: Some(InferenceCommands::Set {
+                    no_verify: true,
+                    ..
+                })
+            })
+        ));
+    }
+
+    #[test]
+    fn inference_update_accepts_no_verify_flag() {
+        let cli = Cli::try_parse_from([
+            "openshell",
+            "inference",
+            "update",
+            "--provider",
+            "openai-dev",
+            "--no-verify",
+        ])
+        .expect("inference update should parse --no-verify");
+
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Inference {
+                command: Some(InferenceCommands::Update {
+                    no_verify: true,
+                    ..
+                })
+            })
+        ));
     }
 }

--- a/docs/inference/configure.md
+++ b/docs/inference/configure.md
@@ -135,7 +135,9 @@ Use this endpoint when inference should stay local to the host for privacy and s
 
 ### Verify the Endpoint from a Sandbox
 
-`openshell inference get` confirms the configuration was saved, but does not verify the upstream endpoint is reachable. To confirm end-to-end connectivity, connect to a sandbox and run:
+`openshell inference get` confirms the configuration was saved, but does not verify the upstream endpoint is reachable. The CLI also accepts `--no-verify` on `openshell inference set` and `openshell inference update` so automation can opt out explicitly ahead of a future verify-by-default rollout.
+
+To confirm end-to-end connectivity, connect to a sandbox and run:
 
 ```bash
 curl https://inference.local/v1/responses \


### PR DESCRIPTION
## Summary
- add `--no-verify` to `openshell inference set` and `openshell inference update`
- accept the flag as a no-op today so scripts can opt out explicitly ahead of a future verify-by-default rollout
- document the rollout rationale in the inference configuration guide

## Related Issue
- groundwork for #273

## Changes
- extend the inference CLI command surface with `--no-verify` on `set` and `update`
- keep runtime behavior unchanged for now by accepting and ignoring the flag
- add CLI parsing tests for both commands and update docs to explain why the flag exists before the default changes

## Testing
- `cargo test -p openshell-cli inference_ -- --nocapture`

## Checklist
- [x] Tests added or updated for changed behavior
- [x] Documentation updated if user-facing behavior changed
- [x] No unrelated files changed