### PR TITLE
ci(canary): switch to single-command sandbox create canary

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -45,6 +45,11 @@ jobs:
         - /var/run/docker.sock:/var/run/docker.sock
     env:
       OPENSHELL_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # The CI container mounts the host Docker socket, so the gateway
+      # container is a sibling — not reachable at 127.0.0.1 from inside
+      # this container. OPENSHELL_GATEWAY_HOST tells the auto-bootstrap
+      # to advertise a reachable address instead.
+      OPENSHELL_GATEWAY_HOST: host.docker.internal
     steps:
       - uses: actions/checkout@v4
 
@@ -90,18 +95,15 @@ jobs:
             echo "${BRIDGE_IP} host.docker.internal" >> /etc/hosts
           fi
 
-      - name: Start gateway
-        env:
-          # Use OPENSHELL_GATEWAY_HOST when supported (CLI >= next release),
-          # fall back to the explicit --gateway-host flag for older CLIs.
-          OPENSHELL_GATEWAY_HOST: host.docker.internal
-        run: openshell gateway start --gateway-host host.docker.internal
-
       - name: Run canary test
         run: |
           set -euo pipefail
 
-          echo "Creating sandbox and running 'echo hello world'..."
+          # Single-command canary: tests the full zero-to-sandbox path.
+          # `sandbox create` detects no gateway, auto-bootstraps one (using
+          # OPENSHELL_GATEWAY_HOST for the advertised address), then creates
+          # a sandbox and runs the command inside it.
+          echo "Creating sandbox (with auto-bootstrap) and running 'echo hello world'..."
           OUTPUT=$(openshell sandbox create --no-keep --no-tty -- echo "hello world" 2>&1) || {
             EXIT_CODE=$?
             echo "::error::openshell sandbox create failed with exit code ${EXIT_CODE}"


### PR DESCRIPTION
## Summary

Switch the release canary from the two-step path (`gateway start` + `sandbox create`) to a single `sandbox create` that auto-bootstraps everything. This tests the real zero-to-sandbox user experience.

## Changes

- Remove the explicit `gateway start` step
- Set `OPENSHELL_GATEWAY_HOST=host.docker.internal` as a job-level env var so auto-bootstrap advertises a reachable address
- `sandbox create` now handles the full lifecycle: detect no gateway, bootstrap one, create a sandbox, run the command

## Testing

- [ ] Trigger canary via `workflow_dispatch` with `tag=devel` to validate