### PR TITLE
ci(canary): add two-step gateway start + sandbox create canary test

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -20,12 +20,18 @@ defaults:
     shell: bash
 
 jobs:
-  canary-auto-bootstrap:
-    name: Canary Auto-Bootstrap (${{ matrix.arch }})
+  canary:
+    name: Canary ${{ matrix.mode }} (${{ matrix.arch }})
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - amd64
+          - arm64
+        mode:
+          - auto-bootstrap
+          - two-step
         include:
           - arch: amd64
             runner: build-amd64
@@ -95,15 +101,22 @@ jobs:
             echo "${BRIDGE_IP} host.docker.internal" >> /etc/hosts
           fi
 
+      # Two-step mode: explicitly start the gateway before creating a sandbox.
+      # --gateway-host is required because the gateway container is a Docker
+      # sibling (not in the same network namespace). Without it the metadata
+      # stores 127.0.0.1 which is unreachable from this CI container.
+      - name: Start gateway
+        if: matrix.mode == 'two-step'
+        run: |
+          set -euo pipefail
+          echo "Starting gateway..."
+          openshell gateway start --gateway-host "$OPENSHELL_GATEWAY_HOST"
+
       - name: Run canary test
         run: |
           set -euo pipefail
 
-          # Single-command canary: tests the full zero-to-sandbox path.
-          # `sandbox create` detects no gateway, auto-bootstraps one (using
-          # OPENSHELL_GATEWAY_HOST for the advertised address), then creates
-          # a sandbox and runs the command inside it.
-          echo "Creating sandbox (with auto-bootstrap) and running 'echo hello world'..."
+          echo "Creating sandbox and running 'echo hello world'..."
           OUTPUT=$(openshell sandbox create --no-keep --no-tty -- echo "hello world" 2>&1) || {
             EXIT_CODE=$?
             echo "::error::openshell sandbox create failed with exit code ${EXIT_CODE}"
@@ -117,112 +130,5 @@ jobs:
             echo "Canary test passed: 'hello world' found in output"
           else
             echo "::error::Canary test failed: 'hello world' not found in output"
-            exit 1
-          fi
-
-  canary-two-step:
-    name: Canary Two-Step (${{ matrix.arch }})
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            runner: build-amd64
-            target: x86_64-unknown-linux-musl
-          - arch: arm64
-            runner: build-arm64
-            target: aarch64-unknown-linux-musl
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
-    container:
-      image: ghcr.io/nvidia/openshell/ci:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-      options: --privileged
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
-    env:
-      OPENSHELL_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      OPENSHELL_GATEWAY_HOST: host.docker.internal
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Determine release tag
-        id: release
-        run: |
-          set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
-          else
-            WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
-            if [ "$WORKFLOW_NAME" = "Release Dev" ]; then
-              echo "tag=devel" >> "$GITHUB_OUTPUT"
-            elif [ "$WORKFLOW_NAME" = "Release Tag" ]; then
-              TAG="${{ github.event.workflow_run.head_branch }}"
-              if [ -z "$TAG" ]; then
-                echo "::error::Could not determine release tag from workflow_run"
-                exit 1
-              fi
-              echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-            else
-              echo "::error::Unexpected triggering workflow: ${WORKFLOW_NAME}"
-              exit 1
-            fi
-          fi
-
-      - name: Install CLI from GitHub Release
-        run: ./install.sh
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENSHELL_VERSION: ${{ steps.release.outputs.tag }}
-
-      - name: Verify CLI installation
-        run: openshell --version
-
-      - name: Resolve gateway host
-        run: |
-          # On Linux CI runners host.docker.internal is not set automatically
-          # (it's a Docker Desktop feature). Add it via the Docker bridge IP.
-          if ! getent hosts host.docker.internal >/dev/null 2>&1; then
-            BRIDGE_IP=$(docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}')
-            echo "Adding /etc/hosts entry: ${BRIDGE_IP} host.docker.internal"
-            echo "${BRIDGE_IP} host.docker.internal" >> /etc/hosts
-          fi
-
-      - name: Start gateway
-        run: |
-          set -euo pipefail
-
-          # Two-step canary: explicitly start the gateway first, then create
-          # a sandbox against it. This tests the `gateway start` + `sandbox
-          # create` flow separately from the auto-bootstrap path.
-          #
-          # --gateway-host is required because the gateway container is a
-          # Docker sibling (not in the same network namespace). Without it
-          # the metadata stores 127.0.0.1 which is unreachable from this
-          # CI container.
-          echo "Starting gateway..."
-          openshell gateway start --gateway-host "$OPENSHELL_GATEWAY_HOST"
-
-      - name: Run canary test
-        run: |
-          set -euo pipefail
-
-          echo "Creating sandbox against running gateway..."
-          OUTPUT=$(openshell sandbox create --no-keep --no-tty -- echo "hello world" 2>&1) || {
-            EXIT_CODE=$?
-            echo "::error::openshell sandbox create failed with exit code ${EXIT_CODE}"
-            echo "$OUTPUT"
-            exit $EXIT_CODE
-          }
-
-          echo "$OUTPUT"
-
-          if echo "$OUTPUT" | grep -q "hello world"; then
-            echo "Two-step canary test passed: 'hello world' found in output"
-          else
-            echo "::error::Two-step canary test failed: 'hello world' not found in output"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Add a two-step canary test (`gateway start` → `sandbox create`) that runs in parallel with the existing auto-bootstrap canary. Consolidates both test modes into a single job using an `arch × mode` matrix to eliminate duplication.

## Changes

- Added `mode` dimension (`auto-bootstrap`, `two-step`) to the canary matrix, producing 4 jobs (2 arch × 2 mode)
- The `Start gateway` step is conditionally run only for `two-step` mode via `if: matrix.mode == 'two-step'`
- Passes `--gateway-host "$OPENSHELL_GATEWAY_HOST"` to `gateway start` — required because the gateway container is a Docker sibling, not in the CI container's network namespace (without it, metadata stores `127.0.0.1` which is unreachable)
- Unified the canary test step across both modes — `sandbox create --no-keep --no-tty -- echo "hello world"` with grep validation

## Testing

- [x] Workflow run passed on all 4 jobs (auto-bootstrap amd64/arm64, two-step amd64/arm64): https://github.com/NVIDIA/OpenShell/actions/runs/23116229638
- [x] Verified `Start gateway` step is correctly skipped (`-`) for auto-bootstrap jobs

## Checklist

- [x] Follows Conventional Commits
- [ ] Architecture docs updated (if applicable)