### PR TITLE
fix(ci): use BuildKit secrets instead of build-arg for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -36,10 +36,12 @@ jobs:
         uses: ./.github/actions/setup-buildx
 
       - name: Build and push CI image
+        env:
+          MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
-            --build-arg MISE_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            --secret id=MISE_GITHUB_TOKEN,env=MISE_GITHUB_TOKEN \
             --push \
             -t ${{ env.CI_IMAGE }}:${{ github.sha }} \
             -t ${{ env.CI_IMAGE }}:latest \

--- a/deploy/docker/Dockerfile.ci
+++ b/deploy/docker/Dockerfile.ci
@@ -77,8 +77,9 @@ RUN curl https://mise.run | sh
 COPY mise.toml /opt/mise/mise.toml
 COPY tasks/ /opt/mise/tasks/
 WORKDIR /opt/mise
-ARG MISE_GITHUB_TOKEN
-RUN mise trust /opt/mise/mise.toml && \
+RUN --mount=type=secret,id=MISE_GITHUB_TOKEN \
+    export MISE_GITHUB_TOKEN="$(cat /run/secrets/MISE_GITHUB_TOKEN 2>/dev/null || true)" && \
+    mise trust /opt/mise/mise.toml && \
     env -u RUSTC_WRAPPER mise install && \
     /root/.cargo/bin/rustup component remove rust-docs || true && \
     rm -rf /root/.rustup/toolchains/*/share/doc /root/.rustup/toolchains/*/share/man


### PR DESCRIPTION
## Summary
- `MISE_GITHUB_TOKEN` was passed via `--build-arg` in the CI image build, which persists the value in Docker image layer metadata (extractable via `docker history` / `docker inspect`)
- Switched to BuildKit `--mount=type=secret` so the token is only available as a tmpfs file during the `RUN` step and is never written to any image layer
- Local builds without the secret continue to work (graceful fallback to empty string)

## Changes
- **`.github/workflows/ci-image.yml`** — replaced `--build-arg MISE_GITHUB_TOKEN=...` with `--secret id=MISE_GITHUB_TOKEN,env=MISE_GITHUB_TOKEN`; token is set as a step-level `env` var
- **`deploy/docker/Dockerfile.ci`** — removed `ARG MISE_GITHUB_TOKEN`; added `--mount=type=secret,id=MISE_GITHUB_TOKEN` to the `RUN` instruction that calls `mise install`

## Testing
- The Dockerfile already has `# syntax=docker/dockerfile:1.4` (BuildKit enabled), so `--mount=type=secret` is fully supported
- The `2>/dev/null || true` fallback ensures local builds without the secret still work
- CI will validate on next push to `main` after merge