### PR TITLE
fix(bootstrap): use host cgroup namespace for gateway container

### DIFF
--- a/crates/openshell-bootstrap/src/docker.rs
+++ b/crates/openshell-bootstrap/src/docker.rs
@@ -10,8 +10,8 @@ use bollard::API_DEFAULT_VERSION;
 use bollard::Docker;
 use bollard::errors::Error as BollardError;
 use bollard::models::{
-    ContainerCreateBody, DeviceRequest, HostConfig, NetworkCreateRequest, NetworkDisconnectRequest,
-    PortBinding, VolumeCreateRequest,
+    ContainerCreateBody, DeviceRequest, HostConfig, HostConfigCgroupnsModeEnum,
+    NetworkCreateRequest, NetworkDisconnectRequest, PortBinding, VolumeCreateRequest,
 };
 use bollard::query_parameters::{
     CreateContainerOptions, CreateImageOptions, InspectContainerOptions, InspectNetworkOptions,
@@ -523,6 +523,11 @@ pub async fn ensure_container(
 
     let mut host_config = HostConfig {
         privileged: Some(true),
+        // Use host cgroup namespace so k3s kubelet can manage cgroup controllers
+        // (cpu, cpuset, memory, pids, etc.) required for pod QoS. With cgroup v2
+        // and a private cgroupns, the controllers are not delegated into the
+        // container's namespace, causing kubelet ContainerManager to fail.
+        cgroupns_mode: Some(HostConfigCgroupnsModeEnum::HOST),
         port_bindings: Some(port_bindings),
         binds: Some(vec![format!("{}:/var/lib/rancher/k3s", volume_name(name))]),
         network_mode: Some(network_name(name)),


### PR DESCRIPTION
## Summary
- Set `cgroupns_mode: host` on the gateway Docker container to fix k3s startup failures on Docker Desktop 29.x with cgroup v2
- Without this, the kubelet's ContainerManager fails: `cgroup ["kubepods"] has some missing controllers: cpu, cpuset, hugetlb, memory, pids`

## Root Cause
Docker Desktop 29.x (Docker Engine 28.x+) defaults to `cgroupns: private`. With cgroup v2, a private cgroup namespace doesn't delegate the required controllers into the container's namespace. The k3s kubelet then fails to create QoS cgroup hierarchy for pod management.

## Fix
Explicitly set `cgroupns_mode: host` in `HostConfig` when creating the gateway container. This is:
- **Backwards compatible** with all Docker versions (host mode was the pre-20.10 default)
- **Consistent** with how k3d and other k3s-in-Docker tooling operate
- **No security regression** since the container already runs with `privileged: true`

## Testing
- Verified gateway starts successfully with `openshell gateway start` on Docker Desktop 29.2.1 / macOS 26.2 / cgroup v2
- `cargo check -p openshell-bootstrap` passes
- `mise run pre-commit` passes