### PR TITLE
docs: simplify quickstart install, reorder sections, and clean up sandbox docs

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -32,73 +32,27 @@ This page gets you from zero to a running, policy-enforced sandbox in two comman
 
 Before you begin, make sure you have:
 
-- Python 3.12 or later.
-- [uv](https://docs.astral.sh/uv/) installed.
 - Docker Desktop running on your machine.
 
 For a complete list of requirements, refer to {doc}`../reference/support-matrix`.
 
 ## Install the OpenShell CLI
 
-Install the `openshell` package into a virtual environment.
-
-Activate your virtual environment:
+Run the install script:
 
 ```console
-$ uv venv && source .venv/bin/activate
+$ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
 ```
 
-Install the CLI:
+If you prefer [uv](https://docs.astral.sh/uv/):
 
 ```console
-$ uv pip install openshell
+$ uv tool install -U openshell
 ```
 
 :::{tip}
 Run `openshell --help` in your terminal to see the full CLI reference, including all commands and flags. You can also clone the [NVIDIA OpenShell GitHub repository](https://github.com/NVIDIA/OpenShell) and use the `/openshell-cli` skill to load the CLI reference into your agent.
 :::
-
-## Deploy a Gateway (Optional)
-
-Running `openshell sandbox create` without a gateway auto-bootstraps a local one.
-To start the gateway explicitly or deploy to a remote host, choose the tab that matches your setup.
-
-:::::{tab-set}
-
-::::{tab-item} Brev
-
-:::{note}
-Deploy an OpenShell gateway on Brev by clicking **Deploy** on the [OpenShell Launchable](https://brev.nvidia.com/launchable/deploy/now?launchableID=env-3Ap3tL55zq4a8kew1AuW0FpSLsg).
-:::
-
-After the instance starts running, find the gateway URL in the Brev console under **Using Secure Links**.
-Copy the shareable URL for **port 8080**, which is the gateway endpoint.
-
-```console
-$ openshell gateway add https://<your-port-8080-url>.brevlab.com
-$ openshell status
-```
-
-::::
-
-::::{tab-item} DGX Spark
-
-:::{note}
-Set up your Spark with NVIDIA Sync first, or make sure SSH access is configured (such as SSH keys added to the host).
-:::
-
-Deploy to a DGX Spark machine over SSH:
-
-```console
-$ openshell gateway start --remote <username>@<spark-ssid>.local
-$ openshell status
-```
-
-After `openshell status` shows the gateway as healthy, all subsequent commands route through the SSH tunnel.
-
-::::
-
-:::::
 
 ## Create Your First OpenShell Sandbox
 
@@ -171,3 +125,47 @@ $ openshell sandbox create --from base
 ```
 
 :::
+
+::::
+
+## Deploy a Gateway (Optional)
+
+Running `openshell sandbox create` without a gateway auto-bootstraps a local one.
+To start the gateway explicitly or deploy to a remote host, choose the tab that matches your setup.
+
+:::::{tab-set}
+
+::::{tab-item} Brev
+
+:::{note}
+Deploy an OpenShell gateway on Brev by clicking **Deploy** on the [OpenShell Launchable](https://brev.nvidia.com/launchable/deploy/now?launchableID=env-3Ap3tL55zq4a8kew1AuW0FpSLsg).
+:::
+
+After the instance starts running, find the gateway URL in the Brev console under **Using Secure Links**.
+Copy the shareable URL for **port 8080**, which is the gateway endpoint.
+
+```console
+$ openshell gateway add https://<your-port-8080-url>.brevlab.com
+$ openshell status
+```
+
+::::
+
+::::{tab-item} DGX Spark
+
+:::{note}
+Set up your Spark with NVIDIA Sync first, or make sure SSH access is configured (such as SSH keys added to the host).
+:::
+
+Deploy to a DGX Spark machine over SSH:
+
+```console
+$ openshell gateway start --remote <username>@<spark-ssid>.local
+$ openshell status
+```
+
+After `openshell status` shows the gateway as healthy, all subsequent commands route through the SSH tunnel.
+
+::::
+
+:::::

--- a/docs/sandboxes/community-sandboxes.md
+++ b/docs/sandboxes/community-sandboxes.md
@@ -45,7 +45,6 @@ The following community sandboxes are available in the catalog.
 | `base` | Foundational image with system tools and dev environment |
 | `openclaw` | Open agent manipulation and control |
 | `sdg` | Synthetic data generation workflows |
-| `simulation` | General-purpose simulation sandboxes |
 
 ## Use a Community Sandbox
 

--- a/docs/sandboxes/index.md
+++ b/docs/sandboxes/index.md
@@ -38,7 +38,7 @@ A gateway provisions sandboxes, brokers CLI requests, enforces policies, and man
 |---|---|---|
 | **Local** | Docker on your workstation | Solo development and quick iteration. The CLI auto-bootstraps a local gateway if none exists. |
 | **Remote** | Docker on a remote host via SSH | Running sandboxes on a more powerful machine (for example, a DGX Spark) while keeping the CLI on your laptop. |
-| **Cloud** | Behind a reverse proxy (for example, Cloudflare Access) | Shared team environments where multiple users connect to the same gateway through browser-based authentication. |
+| **Cloud** | Behind a reverse proxy (for example, Cloudflare Access) | Individual users accessing OpenShell behind a cloud VM. Cloud gateways are not yet intended for shared team access. |
 
 All three types expose the same API surface. Sandboxes, policies, and providers work identically regardless of where the gateway runs. The only difference is how the CLI reaches the gateway, whether through a direct Docker socket, SSH tunnel, or HTTPS through a proxy.
 

--- a/docs/sandboxes/manage-gateways.md
+++ b/docs/sandboxes/manage-gateways.md
@@ -164,15 +164,6 @@ $ openshell gateway info
 $ openshell gateway info --name my-remote-cluster
 ```
 
-## Advanced Start Options
-
-| Flag | Purpose |
-|---|---|
-| `--gpu` | Enable NVIDIA GPU passthrough. Requires NVIDIA drivers and the Container Toolkit on the host. |
-| `--plaintext` | Listen on HTTP instead of mTLS. Use behind a TLS-terminating reverse proxy. |
-| `--disable-gateway-auth` | Skip mTLS client certificate checks. Use when a reverse proxy cannot forward client certs. |
-| `--registry-token` | GitHub PAT with `read:packages` scope for pulling container images from ghcr.io. Also configurable with `OPENSHELL_REGISTRY_TOKEN`. |
-
 ## Stop and Destroy
 
 Stop a gateway while preserving its state for later restart:

--- a/docs/sandboxes/manage-providers.md
+++ b/docs/sandboxes/manage-providers.md
@@ -137,7 +137,6 @@ The following provider types are supported.
 | `gitlab` | `GITLAB_TOKEN`, `GLAB_TOKEN`, `CI_JOB_TOKEN` | GitLab API, `glab` CLI |
 | `nvidia` | `NVIDIA_API_KEY` | NVIDIA API Catalog |
 | `generic` | User-defined | Any service with custom credentials |
-| `outlook` | *(none: no auto-discovery)* | Microsoft Outlook integration |
 
 :::{tip}
 Use the `generic` type for any service not listed above. You define the

--- a/docs/sandboxes/manage-sandboxes.md
+++ b/docs/sandboxes/manage-sandboxes.md
@@ -69,27 +69,6 @@ $ openshell sandbox create --from my-registry.example.com/my-image:latest
 
 The CLI resolves community names against the [OpenShell Community](https://github.com/NVIDIA/OpenShell-Community) catalog, pulls the bundled Dockerfile and policy, builds the image locally, and creates the sandbox. For the full catalog and how to contribute your own, refer to {doc}`community-sandboxes`.
 
-The following is an example of a fully specified creation command:
-
-```console
-$ openshell sandbox create \
-    --name dev \
-    --provider my-claude \
-    --policy policy.yaml \
-    --upload \
-    -- claude
-```
-
-Additional `sandbox create` flags:
-
-| Flag | Purpose |
-|---|---|
-| `--no-keep` | Delete the sandbox automatically after the initial command exits |
-| `--forward <port>` | Forward a local port to the sandbox before running |
-| `--tty` / `--no-tty` | Force or disable pseudo-terminal allocation |
-| `--no-bootstrap` | Error if no gateway is available instead of auto-bootstrapping |
-| `--no-auto-providers` | Error if required providers are missing instead of prompting |
-
 ## Connect to a Sandbox
 
 Open an SSH session into a running sandbox:
@@ -203,7 +182,6 @@ Deleting a sandbox stops all processes, releases resources, and purges injected 
 
 ```console
 $ openshell sandbox delete my-sandbox
-$ openshell sandbox delete --all
 ```
 
 ## Next Steps


### PR DESCRIPTION
## Summary
- Rewrites quickstart install to use `curl | sh` one-liner as primary method, with `uv tool install -U openshell` as alternative; removes Python/uv from prerequisites
- Moves "Deploy a Gateway (Optional)" below "Create Your First OpenShell Sandbox" in quickstart
- Clarifies cloud gateways are for individual users behind a cloud VM, not shared team access
- Removes: advanced gateway start options, outlook provider type, simulation community sandbox, fully specified sandbox create example with flags table, and `sandbox delete --all` example

## Changes
| File | Change |
|------|--------|
| `docs/get-started/quickstart.md` | New install section (curl + uv), stripped prerequisites, reordered gateway/sandbox sections |
| `docs/sandboxes/index.md` | Updated Cloud gateway description |
| `docs/sandboxes/manage-sandboxes.md` | Removed fully specified create example, flags table, and `--all` delete |
| `docs/sandboxes/manage-gateways.md` | Removed Advanced Start Options section |
| `docs/sandboxes/manage-providers.md` | Removed `outlook` from provider types table |
| `docs/sandboxes/community-sandboxes.md` | Removed `simulation` from catalog table |