### PR TITLE
fix(ci): prune stale devel wheel assets

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -422,6 +422,31 @@ jobs:
           git tag -fa devel -m "Latest Devel" "${GITHUB_SHA}"
           git push --force origin devel
 
+      - name: Prune stale wheel assets from devel release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WHEEL_VERSION: ${{ needs.build-python-wheels.outputs.wheel_version }}
+        run: |
+          set -euo pipefail
+          CURRENT_PREFIX="openshell-${WHEEL_VERSION}-"
+
+          if ! gh release view devel --repo "${GITHUB_REPOSITORY}" --json assets > /dev/null 2>&1; then
+            echo "No existing devel release found; skipping wheel pruning."
+            exit 0
+          fi
+
+          gh release view devel --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets[].name' \
+            | while read -r asset; do
+                case "$asset" in
+                  *.whl)
+                    if [[ "$asset" != "${CURRENT_PREFIX}"* ]]; then
+                      echo "Deleting stale wheel asset: $asset"
+                      gh release delete-asset devel "$asset" --repo "${GITHUB_REPOSITORY}" --yes
+                    fi
+                    ;;
+                esac
+              done
+
       - name: Create / update GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary
Prune old wheel assets from the rolling `devel` GitHub release before uploading the latest build.
Keep wheel assets for the version currently being published so reruns stay safe and only older versions are removed.

## Related Issue
N/A

## Changes
- add a `release-dev.yml` step that inspects the existing `devel` release before upload
- delete only `*.whl` assets whose filenames do not match the current wheel version
- skip pruning when the `devel` release does not exist yet

## Testing
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Parsed `.github/workflows/release-dev.yml` with Ruby YAML

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)