### PR TITLE
fix(ci): run wheel pruning before moving devel tag

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -327,13 +327,6 @@ jobs:
           sha256sum *.tar.gz *.whl > openshell-checksums-sha256.txt
           cat openshell-checksums-sha256.txt
 
-      - name: Move devel tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -fa devel -m "Latest Devel" "${GITHUB_SHA}"
-          git push --force origin devel
-
       - name: Prune stale wheel assets from devel release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -358,6 +351,13 @@ jobs:
                     ;;
                 esac
               done
+
+      - name: Move devel tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -fa devel -m "Latest Devel" "${GITHUB_SHA}"
+          git push --force origin devel
 
       - name: Create / update GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

Previous run showing "no release": https://github.com/NVIDIA/OpenShell/actions/runs/23126625930/job/67171875390#step:7:26

Fix the devel wheel pruning step that was silently skipping because it ran after `git push --force origin devel`.
The force-push disassociates the release from the tag momentarily, causing `gh release view devel` to 404.

Move the prune step before the tag move so it runs while the old devel release is still intact.

## Related Issue
Follow-up to #332 -- the prune step landed but wasn't effective due to step ordering.

## Changes
- Move "Prune stale wheel assets from devel release" step before "Move devel tag" step

## Testing
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Parsed `.github/workflows/release-dev.yml` with Ruby YAML

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)