### PR TITLE
fix(sandbox): default missing process identity before privilege checks

### DIFF
--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -169,7 +169,7 @@ pub async fn run_sandbox(
     // Load policy and initialize OPA engine
     let openshell_endpoint_for_proxy = openshell_endpoint.clone();
     let sandbox_name_for_agg = sandbox.clone();
-    let (policy, opa_engine) = load_policy(
+    let (mut policy, opa_engine) = load_policy(
         sandbox_id.clone(),
         sandbox,
         openshell_endpoint.clone(),
@@ -181,7 +181,7 @@ pub async fn run_sandbox(
     // Validate that the required "sandbox" user exists in this image.
     // All sandbox images must include this user for privilege dropping.
     #[cfg(unix)]
-    validate_sandbox_user(&policy)?;
+    validate_sandbox_user(&mut policy)?;
 
     // Fetch provider environment variables from the server.
     // This is done after loading the policy so the sandbox can still start
@@ -1089,8 +1089,28 @@ fn discover_policy_from_path(path: &std::path::Path) -> openshell_core::proto::S
 /// inspect `/etc/passwd`. If the user is missing, the sandbox fails fast
 /// with a clear error instead of silently running child processes as root.
 #[cfg(unix)]
-fn validate_sandbox_user(policy: &SandboxPolicy) -> Result<()> {
+fn validate_sandbox_user(policy: &mut SandboxPolicy) -> Result<()> {
     use nix::unistd::User;
+
+    // Default missing/empty process identity to `sandbox` so privilege
+    // dropping cannot be skipped.
+    if policy
+        .process
+        .run_as_user
+        .as_deref()
+        .map_or(true, str::is_empty)
+    {
+        policy.process.run_as_user = Some("sandbox".to_string());
+    }
+
+    if policy
+        .process
+        .run_as_group
+        .as_deref()
+        .map_or(true, str::is_empty)
+    {
+        policy.process.run_as_group = Some("sandbox".to_string());
+    }
 
     let user_name = policy.process.run_as_user.as_deref().unwrap_or("sandbox");
 
@@ -1327,6 +1347,7 @@ async fn run_policy_poll_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::policy::{FilesystemPolicy, LandlockPolicy, ProcessPolicy};
     use temp_env::with_vars;
 
     static ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
@@ -1650,6 +1671,44 @@ filesystem_policy:
         let proc = policy.process.unwrap();
         assert_eq!(proc.run_as_user, "sandbox");
         assert_eq!(proc.run_as_group, "sandbox");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_sandbox_user_fills_missing_process_identity() {
+        let mut policy = SandboxPolicy {
+            version: 1,
+            filesystem: FilesystemPolicy::default(),
+            network: NetworkPolicy::default(),
+            landlock: LandlockPolicy::default(),
+            process: ProcessPolicy {
+                run_as_user: None,
+                run_as_group: None,
+            },
+        };
+
+        let _ = validate_sandbox_user(&mut policy);
+        assert_eq!(policy.process.run_as_user.as_deref(), Some("sandbox"));
+        assert_eq!(policy.process.run_as_group.as_deref(), Some("sandbox"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_sandbox_user_fills_empty_process_identity() {
+        let mut policy = SandboxPolicy {
+            version: 1,
+            filesystem: FilesystemPolicy::default(),
+            network: NetworkPolicy::default(),
+            landlock: LandlockPolicy::default(),
+            process: ProcessPolicy {
+                run_as_user: Some(String::new()),
+                run_as_group: Some(String::new()),
+            },
+        };
+
+        let _ = validate_sandbox_user(&mut policy);
+        assert_eq!(policy.process.run_as_user.as_deref(), Some("sandbox"));
+        assert_eq!(policy.process.run_as_group.as_deref(), Some("sandbox"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- A regression allowed policies with missing or empty `run_as_user`/`run_as_group` to skip privilege dropping and run sandboxed children as root, weakening isolation.
- The runtime must ensure the process identity is normalized before any privilege-drop or filesystem ownership operations so a missing identity cannot bypass security checks.

### Description
- Change `run_sandbox` to retain a mutable `policy` returned from `load_policy` and pass a mutable reference into `validate_sandbox_user` so normalization happens at startup (`crates/openshell-sandbox/src/lib.rs`).
- Update `validate_sandbox_user` signature to accept `&mut SandboxPolicy` and fill missing or empty `process.run_as_user` and `process.run_as_group` with the literal string `"sandbox"` before verifying the account exists in the image (`crates/openshell-sandbox/src/lib.rs`).
- Add two regression unit tests that assert missing and empty process identity fields are populated to `sandbox` by the validation function (`validate_sandbox_user_fills_missing_process_identity` and `validate_sandbox_user_fills_empty_process_identity` in `crates/openshell-sandbox/src/lib.rs`).
- Keep existing behavior of failing fast if the `sandbox` account is absent, preserving the preexisting safety check while preventing noop privilege drops.

### Testing
- Ran the unit tests in the sandbox crate targeting the new checks with `cargo test -p openshell-sandbox` and verified the new tests `validate_sandbox_user_fills_missing_process_identity` and `validate_sandbox_user_fills_empty_process_identity` passed.
- Ran `cargo fmt --all --check` which succeeded in this environment.
- Attempted `mise run pre-commit` but it could not complete in this environment due to external tool metadata resolution and task discovery failures (environment/network limitation), so pre-commit hooks were not validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b76b9d907883209e814eaa5877ffd3)