### PR TITLE
fix(server): validate discovered sandbox policy against restrictive baseline

### DIFF
--- a/crates/openshell-server/src/grpc.rs
+++ b/crates/openshell-server/src/grpc.rs
@@ -1023,10 +1023,16 @@ impl OpenShell for OpenShellService {
             // Validate policy safety (no root, no path traversal, etc.).
             validate_policy_safety(&new_policy)?;
         } else {
-            // No baseline policy exists (sandbox created without one). The
-            // sandbox is syncing a locally-discovered or restrictive-default
-            // policy. Backfill spec.policy so future updates can validate
-            // against it.
+            // No baseline policy exists (sandbox created without one).
+            // Validate against the restrictive default before backfilling so
+            // untrusted sandbox images cannot inject a more permissive policy.
+            let restrictive_baseline = openshell_policy::restrictive_default_policy();
+            validate_static_fields_unchanged(&restrictive_baseline, &new_policy)?;
+            validate_network_mode_unchanged(&restrictive_baseline, &new_policy)?;
+            validate_policy_safety(&new_policy)?;
+
+            // Backfill spec.policy so future updates can validate against the
+            // same baseline that was accepted here.
             let mut sandbox = sandbox;
             if let Some(ref mut spec) = sandbox.spec {
                 spec.policy = Some(new_policy.clone());


### PR DESCRIPTION
### Motivation
- Prevent untrusted sandbox images from injecting a more permissive policy when the gateway omits a baseline, which could widen network/filesystem access and bypass the restrictive default.
- Ensure the server enforces the same static-field, network-mode, and safety constraints for a sandbox-discovered policy as it does for baseline-backed updates.

### Description
- In `crates/openshell-server/src/grpc.rs` `update_sandbox_policy`, when `spec.policy` is `None` the server now constructs a restrictive baseline via `openshell_policy::restrictive_default_policy()` and validates the incoming policy against it before accepting and backfilling `spec.policy`.
- The new path runs `validate_static_fields_unchanged`, `validate_network_mode_unchanged`, and `validate_policy_safety` against the restrictive baseline prior to persisting the discovered policy.
- This preserves the intended backfill behavior for legitimately restrictive policies while blocking permissive policies originating from container disk discovery.

### Testing
- Ran `cargo fmt --all -- --check`, which completed successfully.
- Attempted `mise run pre-commit`, which did not complete in this environment due to `mise` configuration/tool resolution warnings and no runnable tasks being detected.
- Attempted targeted unit tests (`cargo test -p openshell-server validate_network_mode_rejects_block_to_proxy` and `cargo test -p openshell-policy validate_sandbox_policy_accepts_default`), but native dependency builds were long-running and did not complete within the session; no test failures were observed from completed tooling steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b76bb0b1388320944aabcecf756ff9)