### PR TITLE
fix(server): harden sandbox TLS secret volume permissions

### DIFF
--- a/crates/openshell-server/src/sandbox/mod.rs
+++ b/crates/openshell-server/src/sandbox/mod.rs
@@ -969,12 +969,17 @@ fn sandbox_template_to_k8s(
     );
 
     // Add TLS secret volume.
+    // Use mode 0400 (owner-read only) so unprivileged processes in the
+    // sandbox cannot read the client private key material.
     if !client_tls_secret_name.is_empty() {
         spec.insert(
             "volumes".to_string(),
             serde_json::json!([{
                 "name": "openshell-client-tls",
-                "secret": { "secretName": client_tls_secret_name }
+                "secret": {
+                    "secretName": client_tls_secret_name,
+                    "defaultMode": 256
+                }
             }]),
         );
     }
@@ -1047,6 +1052,8 @@ fn inject_pod_template(
     }
 
     // Inject TLS volume at the pod spec level.
+    // Use mode 0400 (owner-read only) so unprivileged processes in the
+    // sandbox cannot read the client private key material.
     if !client_tls_secret_name.is_empty() {
         let volumes = spec
             .entry("volumes")
@@ -1054,7 +1061,10 @@ fn inject_pod_template(
         if let Some(volumes_arr) = volumes.as_array_mut() {
             volumes_arr.push(serde_json::json!({
                 "name": "openshell-client-tls",
-                "secret": { "secretName": client_tls_secret_name }
+                "secret": {
+                    "secretName": client_tls_secret_name,
+                    "defaultMode": 256
+                }
             }));
         }
     }
@@ -2010,6 +2020,40 @@ mod tests {
         assert!(
             pod_template["spec"]["hostAliases"].is_null(),
             "hostAliases should not be present when host_gateway_ip is empty"
+        );
+    }
+
+    #[test]
+    fn tls_secret_volume_uses_owner_read_only_mode() {
+        let pod_template = sandbox_template_to_k8s(
+            &SandboxTemplate::default(),
+            false,
+            "openshell/sandbox:latest",
+            "",
+            "sandbox-id",
+            "sandbox-name",
+            "https://gateway.example.com",
+            "0.0.0.0:2222",
+            "secret",
+            300,
+            &std::collections::HashMap::new(),
+            "openshell-client-tls",
+            "",
+        );
+
+        let volumes = pod_template["spec"]["volumes"]
+            .as_array()
+            .expect("volumes should exist");
+        let tls_volume = volumes
+            .iter()
+            .find(|v| v["name"] == "openshell-client-tls")
+            .expect("openshell-client-tls volume should exist");
+
+        assert_eq!(tls_volume["secret"]["secretName"], "openshell-client-tls");
+        assert_eq!(
+            tls_volume["secret"]["defaultMode"],
+            serde_json::json!(256),
+            "TLS secret defaultMode should be 0400 (decimal 256)"
         );
     }
 


### PR DESCRIPTION
### Motivation
- Prevent sandboxed agent processes from reading the shared mTLS client private key and impersonating the control-plane client by reducing file permission exposure of the mounted TLS secret.

### Description
- Set Kubernetes secret `defaultMode` to `0400` (`256` decimal) for the sandbox TLS secret volume in both the default pod template path and the custom pod-template injection path in `crates/openshell-server/src/sandbox/mod.rs`.
- Preserve the existing mount path and environment variable wiring that points sandbox code to `/etc/openshell-tls/client/*` so runtime behavior remains unchanged.
- Add a unit regression test `tls_secret_volume_uses_owner_read_only_mode` asserting the injected TLS secret uses `defaultMode: 256`.
- Run `cargo fmt --all` to keep formatting consistent.

### Testing
- Ran `cargo test -p openshell-server tls_` which executed the added unit test plus related TLS tests and integration cases, and all ran successfully (unit tests passed and integration TLS tests succeeded).
- Ran `cargo fmt --all` which completed without changes/errors.
- Attempted `mise run pre-commit` but it failed in this environment due to external tool/version resolution and network/trust issues, so pre-commit automation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b77066c9e08320b19c97f2063d721e)