### PR TITLE
fix(sandbox): prevent overread request smuggling in L7 REST parser

### DIFF
--- a/crates/openshell-sandbox/src/l7/rest.rs
+++ b/crates/openshell-sandbox/src/l7/rest.rs
@@ -53,7 +53,6 @@ impl L7Provider for RestProvider {
 /// Parse one HTTP/1.1 request from the stream.
 async fn parse_http_request<C: AsyncRead + Unpin>(client: &mut C) -> Result<Option<L7Request>> {
     let mut buf = Vec::with_capacity(4096);
-    let mut tmp = [0u8; 1024];
 
     loop {
         if buf.len() > MAX_HEADER_BYTES {
@@ -62,8 +61,11 @@ async fn parse_http_request<C: AsyncRead + Unpin>(client: &mut C) -> Result<Opti
             ));
         }
 
-        let n = match client.read(&mut tmp).await {
-            Ok(n) => n,
+        let n = match client.read_u8().await {
+            Ok(byte) => {
+                buf.push(byte);
+                1
+            }
             Err(e) if buf.is_empty() && is_benign_close(&e) => return Ok(None),
             Err(e) => return Err(miette::miette!("{e}")),
         };
@@ -76,10 +78,9 @@ async fn parse_http_request<C: AsyncRead + Unpin>(client: &mut C) -> Result<Opti
                 buf.len()
             ));
         }
-        buf.extend_from_slice(&tmp[..n]);
 
         // Check for end of headers
-        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+        if buf.ends_with(b"\r\n\r\n") {
             break;
         }
     }
@@ -109,7 +110,7 @@ async fn parse_http_request<C: AsyncRead + Unpin>(client: &mut C) -> Result<Opti
     Ok(Some(L7Request {
         action: method,
         target: path,
-        raw_header: buf, // includes header bytes + any overflow body bytes
+        raw_header: buf,
         body_length,
     }))
 }
@@ -618,6 +619,38 @@ mod tests {
             BodyLength::None => {}
             other => panic!("Expected None, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn parse_http_request_does_not_overread_next_request() {
+        let (mut client, mut writer) = tokio::io::duplex(4096);
+
+        tokio::spawn(async move {
+            writer
+                .write_all(
+                    b"GET /allowed HTTP/1.1\r\nHost: example.com\r\n\r\nPOST /blocked HTTP/1.1\r\nHost: example.com\r\nContent-Length: 0\r\n\r\n",
+                )
+                .await
+                .unwrap();
+        });
+
+        let first = parse_http_request(&mut client)
+            .await
+            .expect("first request should parse")
+            .expect("expected first request");
+        assert_eq!(first.action, "GET");
+        assert_eq!(first.target, "/allowed");
+        assert_eq!(
+            first.raw_header,
+            b"GET /allowed HTTP/1.1\r\nHost: example.com\r\n\r\n"
+        );
+
+        let second = parse_http_request(&mut client)
+            .await
+            .expect("second request should parse")
+            .expect("expected second request");
+        assert_eq!(second.action, "POST");
+        assert_eq!(second.target, "/blocked");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- The HTTP/1.1 parser could return a `raw_header` that included bytes read past the header terminator (`\r\n\r\n`), and the relay path forwarded those overflow bytes upstream before additional L7 parsing, enabling request smuggling/pipelining to bypass per-request policy checks.

### Description

- Change `parse_http_request` to read one byte at a time (`read_u8`) and stop exactly when the buffer `ends_with(b"\r\n\r\n")`, ensuring `raw_header` contains only the current request header block.
- Remove the previous multi-byte temporary buffer read path and the behavior that returned overflow bytes inside `raw_header`.
- Adjust header-end detection to use `ends_with` and retain the existing `parse_body_length` framing logic.
- Add a regression test `parse_http_request_does_not_overread_next_request` that writes two requests in one write and verifies they are parsed as two separate requests with no overflow included in the first `raw_header`.

### Testing

- Added unit/regression test: `parse_http_request_does_not_overread_next_request` (async `tokio::test`) to verify the parser does not consume bytes belonging to a subsequent pipelined request; the test was added to `crates/openshell-sandbox/src/l7/rest.rs`.
- Attempted `mise run pre-commit` in the environment, but it could not complete due to remote tooling/version resolution failures in this sandbox.
- Attempted `cargo test` for the crate but could not run because `cargo` is not available in the execution environment, so the new test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b76fdc4e488320a848f68a3ed7d7d1)