### PR TITLE
fix(sandbox): enforce non-root fallback when process user unset

### DIFF
--- a/crates/openshell-sandbox/src/process.rs
+++ b/crates/openshell-sandbox/src/process.rs
@@ -351,17 +351,25 @@ impl Drop for ProcessHandle {
 
 #[cfg(unix)]
 pub fn drop_privileges(policy: &SandboxPolicy) -> Result<()> {
-    let user_name = match policy.process.run_as_user.as_deref() {
+    let mut user_name = match policy.process.run_as_user.as_deref() {
         Some(name) if !name.is_empty() => Some(name),
         _ => None,
     };
-    let group_name = match policy.process.run_as_group.as_deref() {
+    let mut group_name = match policy.process.run_as_group.as_deref() {
         Some(name) if !name.is_empty() => Some(name),
         _ => None,
     };
 
     if user_name.is_none() && group_name.is_none() {
-        return Ok(());
+        // The supervisor process requires elevated capabilities to configure
+        // sandbox isolation, but child workloads must never retain those
+        // capabilities by running as root.
+        if nix::unistd::geteuid().is_root() {
+            user_name = Some("sandbox");
+            group_name = Some("sandbox");
+        } else {
+            return Ok(());
+        }
     }
 
     let user = if let Some(name) = user_name {
@@ -522,7 +530,17 @@ mod tests {
             run_as_user: None,
             run_as_group: None,
         });
-        assert!(drop_privileges(&policy).is_ok());
+
+        let result = drop_privileges(&policy);
+        if nix::unistd::geteuid().is_root() {
+            let msg = format!("{}", result.unwrap_err());
+            assert!(
+                msg.contains("Sandbox user not found: sandbox"),
+                "expected sandbox fallback resolution failure when running as root: {msg}"
+            );
+        } else {
+            assert!(result.is_ok());
+        }
     }
 
     #[test]
@@ -531,7 +549,17 @@ mod tests {
             run_as_user: Some(String::new()),
             run_as_group: Some(String::new()),
         });
-        assert!(drop_privileges(&policy).is_ok());
+
+        let result = drop_privileges(&policy);
+        if nix::unistd::geteuid().is_root() {
+            let msg = format!("{}", result.unwrap_err());
+            assert!(
+                msg.contains("Sandbox user not found: sandbox"),
+                "expected sandbox fallback resolution failure when running as root: {msg}"
+            );
+        } else {
+            assert!(result.is_ok());
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent child workloads from retaining powerful capabilities when a sandbox policy omits `run_as_user`/`run_as_group` and the container runs as root. 
- Address an isolation regression where sandbox pod templates add `SYS_ADMIN`/`NET_ADMIN` and privilege dropping could be a no-op if the process identity is unset.

### Description
- Changed `drop_privileges` in `crates/openshell-sandbox/src/process.rs` to treat an unset process identity as a security-sensitive case by falling back to `sandbox:sandbox` when running as root, instead of returning early. 
- Preserved existing behavior for non-root runtimes so that omission remains a no-op when not root. 
- Updated unit tests in the same file to account for root vs non-root semantics for the two no-user/no-group cases. 
- The change is minimal and scoped to privilege-drop fallback logic and associated tests.

### Testing
- Updated unit tests in `crates/openshell-sandbox/src/process.rs` were added/adjusted to cover the new fallback semantics for `drop_privileges`.
- Ran `cargo fmt --check` which succeeded. 
- Attempted `cargo check -p openshell-sandbox --lib`, but full CI/build was not completed within the interactive environment limits. 
- `mise run pre-commit` was attempted but failed due to environment/tool resolution and trust issues in this run (not a code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b777daa2d88320b5cf39c586057618)