### PR TITLE
fix(openshell-sandbox): reject symlink and non-dir read_write paths

### DIFF
--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -1122,6 +1122,7 @@ fn validate_sandbox_user(policy: &SandboxPolicy) -> Result<()> {
 #[cfg(unix)]
 fn prepare_filesystem(policy: &SandboxPolicy) -> Result<()> {
     use nix::unistd::{Group, User, chown};
+    use std::fs;
 
     let user_name = match policy.process.run_as_user.as_deref() {
         Some(name) if !name.is_empty() => Some(name),
@@ -1164,7 +1165,21 @@ fn prepare_filesystem(policy: &SandboxPolicy) -> Result<()> {
     for path in &policy.filesystem.read_write {
         if !path.exists() {
             debug!(path = %path.display(), "Creating read_write directory");
-            std::fs::create_dir_all(path).into_diagnostic()?;
+            fs::create_dir_all(path).into_diagnostic()?;
+        }
+
+        let metadata = fs::symlink_metadata(path).into_diagnostic()?;
+        if metadata.file_type().is_symlink() {
+            return Err(miette::miette!(
+                "Refusing to set ownership on symlinked read_write path: {}",
+                path.display()
+            ));
+        }
+        if !metadata.is_dir() {
+            return Err(miette::miette!(
+                "read_write path is not a directory: {}",
+                path.display()
+            ));
         }
 
         debug!(path = %path.display(), ?uid, ?gid, "Setting ownership on read_write directory");
@@ -1659,6 +1674,62 @@ filesystem_policy:
         let proto = openshell_policy::restrictive_default_policy();
         let local_policy = SandboxPolicy::try_from(proto).expect("conversion should succeed");
         assert!(matches!(local_policy.network.mode, NetworkMode::Proxy));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_filesystem_rejects_symlink_read_write_path() {
+        use std::os::unix::fs as unix_fs;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        let symlink = dir.path().join("rw-link");
+        unix_fs::symlink(&target, &symlink).unwrap();
+
+        let policy = SandboxPolicy {
+            version: 1,
+            filesystem: policy::FilesystemPolicy {
+                read_only: Vec::new(),
+                read_write: vec![symlink],
+                include_workdir: true,
+            },
+            network: policy::NetworkPolicy::default(),
+            landlock: policy::LandlockPolicy::default(),
+            process: policy::ProcessPolicy {
+                run_as_user: Some("root".to_string()),
+                run_as_group: Some("root".to_string()),
+            },
+        };
+
+        let err = prepare_filesystem(&policy).unwrap_err().to_string();
+        assert!(err.contains("symlinked read_write path"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_filesystem_rejects_non_directory_read_write_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("rw-file");
+        std::fs::write(&file_path, "not a directory").unwrap();
+
+        let policy = SandboxPolicy {
+            version: 1,
+            filesystem: policy::FilesystemPolicy {
+                read_only: Vec::new(),
+                read_write: vec![file_path],
+                include_workdir: true,
+            },
+            network: policy::NetworkPolicy::default(),
+            landlock: policy::LandlockPolicy::default(),
+            process: policy::ProcessPolicy {
+                run_as_user: Some("root".to_string()),
+                run_as_group: Some("root".to_string()),
+            },
+        };
+
+        let err = prepare_filesystem(&policy).unwrap_err().to_string();
+        assert!(err.contains("not a directory"));
     }
 
     // ---- Route refresh interval + revision tests ----


### PR DESCRIPTION
### Motivation
- The supervisor previously created and `chown`ed every path in `policy.filesystem.read_write` while running as root, which follows symlinks and can change ownership of arbitrary targets. 
- That behavior enables a malicious image to pre-create a symlink and escalate privileges by making sensitive root-owned paths writable by the sandbox user. 
- The intent is to harden filesystem preparation so only legitimate directories declared by policy are prepared for the sandbox process.

### Description
- In `crates/openshell-sandbox/src/lib.rs` `prepare_filesystem` now uses `std::fs::symlink_metadata` to inspect `read_write` entries before calling `chown` and retains `std::fs::create_dir_all` behavior for missing paths.  
- The function returns an error if a `read_write` path is a symlink to prevent following and modifying arbitrary targets.  
- The function returns an error if a `read_write` path exists but is not a directory to avoid unexpected ownership changes on files.  
- Added unit tests that assert the function rejects a symlinked `read_write` path and rejects a non-directory `read_write` path, and kept behavior unchanged for valid directories.

### Testing
- Ran targeted unit tests with `cargo test -p openshell-sandbox prepare_filesystem_rejects_ --lib`, and both new tests passed.  
- `cargo test -p openshell-sandbox prepare_filesystem_rejects_symlink_read_write_path --lib` and `cargo test -p openshell-sandbox prepare_filesystem_rejects_non_directory_read_write_path --lib` succeeded.  
- `mise run pre-commit` and `mise run test` were attempted but failed in this environment due to external tool resolution/network issues (tooling warnings from `mise`), not due to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b779c80a608320ae0bac3dce338f4e)