### PR TITLE
fix(server): default bind to loopback and restore bind-address option

### DIFF
--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -250,7 +250,7 @@ impl Config {
 }
 
 fn default_bind_address() -> SocketAddr {
-    "0.0.0.0:8080".parse().expect("valid default address")
+    "127.0.0.1:8080".parse().expect("valid default address")
 }
 
 fn default_log_level() -> String {

--- a/crates/openshell-server/src/main.rs
+++ b/crates/openshell-server/src/main.rs
@@ -5,7 +5,6 @@
 
 use clap::Parser;
 use miette::{IntoDiagnostic, Result};
-use std::net::SocketAddr;
 use std::path::PathBuf;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
@@ -18,9 +17,9 @@ use openshell_server::{run_server, tracing_bus::TracingLogBus};
 #[command(version = openshell_core::VERSION)]
 #[command(about = "OpenShell gRPC/HTTP server", long_about = None)]
 struct Args {
-    /// Port to bind the server to (all interfaces).
-    #[arg(long, default_value_t = 8080, env = "OPENSHELL_SERVER_PORT")]
-    port: u16,
+    /// Address to bind the server to. Defaults to loopback for safety.
+    #[arg(long, env = "OPENSHELL_SERVER_BIND", default_value = "127.0.0.1:8080")]
+    bind: std::net::SocketAddr,
 
     /// Log level (trace, debug, info, warn, error).
     #[arg(long, default_value = "info", env = "OPENSHELL_LOG_LEVEL")]
@@ -125,7 +124,6 @@ async fn main() -> Result<()> {
     );
 
     // Build configuration
-    let bind = SocketAddr::from(([0, 0, 0, 0], args.port));
 
     let tls = if args.disable_tls {
         None
@@ -152,7 +150,7 @@ async fn main() -> Result<()> {
     };
 
     let mut config = openshell_core::Config::new(tls)
-        .with_bind_address(bind)
+        .with_bind_address(args.bind)
         .with_log_level(&args.log_level);
 
     config = config


### PR DESCRIPTION
### Motivation

- The server previously defaulted to binding `0.0.0.0:8080`, exposing an unauthenticated gRPC control plane on all interfaces by default. 
- A minimal, safety-first change is required so that a default run is local-only while still allowing operators to opt into a different bind address when needed.

### Description

- Changed the core default bind address in `crates/openshell-core/src/config.rs` from `0.0.0.0:8080` to `127.0.0.1:8080` so the default server process listens on loopback only. 
- Updated the server CLI in `crates/openshell-server/src/main.rs` to accept a full socket address via `--bind` / `OPENSHELL_SERVER_BIND` (default `127.0.0.1:8080`) and to use `args.bind` for the configured bind address. 
- Preserved explicit override behavior so operators can still bind to `0.0.0.0` (or any other address) by passing `--bind 0.0.0.0:8080` when intentional.

### Testing

- Ran `cargo fmt --all -- --check` which completed successfully. 
- Started `cargo test -p openshell-server`, which began compilation of dependencies in this environment but did not complete within the session budget due to a long-running dependency build. 
- Attempted `mise run pre-commit` but the environment blocked full execution due to remote tool resolution/network constraints; this check was therefore not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b777a8e6688320b49a2bfa962cf2ee)