### PR TITLE
fix(sandbox): block direct inet sockets in proxy mode

### DIFF
--- a/crates/openshell-sandbox/src/sandbox/linux/seccomp.rs
+++ b/crates/openshell-sandbox/src/sandbox/linux/seccomp.rs
@@ -18,8 +18,7 @@ pub fn apply(policy: &SandboxPolicy) -> Result<()> {
         return Ok(());
     }
 
-    let allow_inet = matches!(policy.network.mode, NetworkMode::Proxy);
-    let filter = build_filter(allow_inet)?;
+    let filter = build_filter()?;
 
     // Required before applying seccomp filters.
     let rc = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) };
@@ -34,15 +33,17 @@ pub fn apply(policy: &SandboxPolicy) -> Result<()> {
     Ok(())
 }
 
-fn build_filter(allow_inet: bool) -> Result<seccompiler::BpfProgram> {
+fn build_filter() -> Result<seccompiler::BpfProgram> {
     let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
 
-    let mut blocked_domains = vec![libc::AF_PACKET, libc::AF_BLUETOOTH, libc::AF_VSOCK];
-    if !allow_inet {
-        blocked_domains.push(libc::AF_INET);
-        blocked_domains.push(libc::AF_INET6);
-        blocked_domains.push(libc::AF_NETLINK);
-    }
+    let blocked_domains = vec![
+        libc::AF_PACKET,
+        libc::AF_BLUETOOTH,
+        libc::AF_VSOCK,
+        libc::AF_INET,
+        libc::AF_INET6,
+        libc::AF_NETLINK,
+    ];
 
     for domain in blocked_domains {
         debug!(domain, "Blocking socket domain via seccomp");


### PR DESCRIPTION
### Motivation
- The Linux seccomp setup previously treated `NetworkMode::Proxy` as allowing `AF_INET`/`AF_INET6` socket creation, which lets sandboxed processes open direct IPv4/IPv6 sockets and bypass the proxy allowlist enforcement.
- The intent is to enforce proxy-only egress in non-`Allow` modes, so seccomp must block inet socket domains whenever seccomp network filtering is active.

### Description
- Removed the proxy-dependent `allow_inet` branch and simplified `build_filter` to unconditionally include `AF_INET` and `AF_INET6` in the blocked socket domains when seccomp is applied in non-`Allow` modes. 
- Updated `apply` to call the new `build_filter()` signature and preserved the early return for `NetworkMode::Allow` so existing `Allow` behavior remains unchanged. 
- Change is localized to `crates/openshell-sandbox/src/sandbox/linux/seccomp.rs` and is scoped to the minimal set of edits required to remediate the bypass.

### Testing
- Ran `cargo fmt --all -- --check` which passed. 
- `mise run pre-commit` failed in this environment due to local tool resolution and `mise.toml` trust/remote resolution warnings. 
- `cargo test -p openshell-sandbox` and `cargo check -p openshell-sandbox --lib` were started but were long-running / blocked by heavy dependency compilation in this environment and could not be completed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7786a3fd0832096da201cb2faabb0)