### PR TITLE
feat(bootstrap): fall back to anonymous pull when registry credentials are rejected

### DIFF
--- a/crates/openshell-bootstrap/src/docker.rs
+++ b/crates/openshell-bootstrap/src/docker.rs
@@ -21,6 +21,7 @@ use bollard::query_parameters::{
 use futures::StreamExt;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use std::collections::HashMap;
+use tracing::debug;
 
 const REGISTRY_NAMESPACE_DEFAULT: &str = "openshell";
 
@@ -436,10 +437,36 @@ pub async fn ensure_image(
         ..Default::default()
     };
 
-    let mut stream = docker.create_image(Some(options), None, credentials);
+    // Attempt the pull with credentials (if any), falling back to an
+    // anonymous pull when the registry rejects the credentials. This
+    // handles public ghcr.io repos where sending a token the caller
+    // doesn't have access with causes a 401/403, but an unauthenticated
+    // pull would succeed.
+    let has_credentials = credentials.is_some();
+    let mut stream = docker.create_image(Some(options.clone()), None, credentials);
+    let mut auth_failed = false;
     while let Some(result) = stream.next().await {
-        result.into_diagnostic()?;
+        match result {
+            Ok(_info) => {}
+            Err(err) if has_credentials && image::is_auth_failure(&err) => {
+                debug!(
+                    "Registry credentials rejected for {}, retrying as anonymous pull",
+                    repo
+                );
+                auth_failed = true;
+                break;
+            }
+            Err(err) => return Err(err).into_diagnostic(),
+        }
     }
+
+    if auth_failed {
+        let mut stream = docker.create_image(Some(options), None, None);
+        while let Some(result) = stream.next().await {
+            result.into_diagnostic()?;
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/openshell-bootstrap/src/errors.rs
+++ b/crates/openshell-bootstrap/src/errors.rs
@@ -240,8 +240,9 @@ fn diagnose_port_conflict(_gateway_name: &str) -> GatewayFailureDiagnosis {
 fn diagnose_image_pull_auth_failure(_gateway_name: &str) -> GatewayFailureDiagnosis {
     GatewayFailureDiagnosis {
         summary: "Registry authentication failed".to_string(),
-        explanation: "Could not authenticate with the container registry. The image may not \
-            exist, or you may not have permission to access it."
+        explanation: "Could not authenticate with the container registry and anonymous \
+            pull also failed. The image may not exist, the repository may be private, \
+            or there may be a network issue preventing access."
             .to_string(),
         recovery_steps: vec![
             RecoveryStep::with_command(

--- a/crates/openshell-bootstrap/src/image.rs
+++ b/crates/openshell-bootstrap/src/image.rs
@@ -6,6 +6,7 @@
 use crate::docker::{HostPlatform, get_host_platform};
 use bollard::Docker;
 use bollard::auth::DockerCredentials;
+use bollard::errors::Error as BollardError;
 use bollard::query_parameters::{CreateImageOptions, TagImageOptionsBuilder};
 use futures::StreamExt;
 use miette::{IntoDiagnostic, Result, WrapErr};
@@ -222,15 +223,11 @@ pub async fn pull_remote_image(
         ..Default::default()
     };
 
-    let mut stream = remote.create_image(Some(options), None, credentials);
-    while let Some(result) = stream.next().await {
-        let info = result
-            .into_diagnostic()
-            .wrap_err("failed to pull image on remote host")?;
+    // Attempt the pull with credentials, falling back to anonymous on auth failure.
+    let result = consume_pull_stream(remote, options.clone(), credentials, |info| {
         if let Some(ref status) = info.status {
             debug!("Remote pull: {}", status);
         }
-        // Report layer progress
         if let Some(ref status) = info.status
             && let Some(ref detail) = info.progress_detail
             && let (Some(current), Some(total)) = (detail.current, detail.total)
@@ -238,6 +235,38 @@ pub async fn pull_remote_image(
             let current_mb = current / (1024 * 1024);
             let total_mb = total / (1024 * 1024);
             on_progress(format!("[progress] {status}: {current_mb}/{total_mb} MB"));
+        }
+    })
+    .await;
+
+    match result {
+        Ok(()) => {}
+        Err(err) if is_auth_failure(&err) => {
+            debug!(
+                "Registry credentials rejected for {}, retrying as anonymous pull",
+                registry_image
+            );
+            consume_pull_stream(remote, options, None, |info| {
+                if let Some(ref status) = info.status {
+                    debug!("Remote pull (anonymous): {}", status);
+                }
+                if let Some(ref status) = info.status
+                    && let Some(ref detail) = info.progress_detail
+                    && let (Some(current), Some(total)) = (detail.current, detail.total)
+                {
+                    let current_mb = current / (1024 * 1024);
+                    let total_mb = total / (1024 * 1024);
+                    on_progress(format!("[progress] {status}: {current_mb}/{total_mb} MB"));
+                }
+            })
+            .await
+            .into_diagnostic()
+            .wrap_err("failed to pull image on remote host (anonymous fallback)")?;
+        }
+        Err(err) => {
+            return Err(err)
+                .into_diagnostic()
+                .wrap_err("failed to pull image on remote host");
         }
     }
 
@@ -302,6 +331,50 @@ pub async fn pull_remote_image(
 pub(crate) fn is_local_image_ref(image_ref: &str) -> bool {
     let (repo, _tag) = parse_image_ref(image_ref);
     !repo.contains('/')
+}
+
+/// Check whether a bollard error indicates an authentication/authorization failure.
+///
+/// These errors occur when credentials are rejected by the registry. For public
+/// repos on ghcr.io, retrying without credentials (anonymous pull) may succeed.
+pub(crate) fn is_auth_failure(err: &BollardError) -> bool {
+    match err {
+        BollardError::DockerResponseServerError {
+            status_code: 401 | 403,
+            ..
+        } => true,
+        BollardError::DockerResponseServerError { message, .. } => {
+            let msg = message.to_lowercase();
+            msg.contains("pull access denied")
+                || msg.contains("unauthorized")
+                || msg.contains("denied: access forbidden")
+        }
+        BollardError::DockerStreamError { error } => {
+            let msg = error.to_lowercase();
+            msg.contains("pull access denied")
+                || msg.contains("unauthorized")
+                || msg.contains("denied: access forbidden")
+        }
+        _ => false,
+    }
+}
+
+/// Consume a `create_image` pull stream to completion.
+///
+/// Returns `Ok(())` on success, or the first [`BollardError`] on failure.
+/// The `on_info` callback is invoked for each progress chunk.
+async fn consume_pull_stream(
+    docker: &Docker,
+    options: CreateImageOptions,
+    credentials: Option<DockerCredentials>,
+    mut on_info: impl FnMut(&bollard::models::CreateImageInfo),
+) -> std::result::Result<(), BollardError> {
+    let mut stream = docker.create_image(Some(options), None, credentials);
+    while let Some(result) = stream.next().await {
+        let info = result?;
+        on_info(&info);
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -398,5 +471,59 @@ mod tests {
             DEFAULT_IMAGE_REPO_BASE.starts_with(DEFAULT_REGISTRY),
             "repo base should start with the registry host"
         );
+    }
+
+    #[test]
+    fn is_auth_failure_status_401() {
+        let err = BollardError::DockerResponseServerError {
+            status_code: 401,
+            message: "Unauthorized".to_string(),
+        };
+        assert!(is_auth_failure(&err));
+    }
+
+    #[test]
+    fn is_auth_failure_status_403() {
+        let err = BollardError::DockerResponseServerError {
+            status_code: 403,
+            message: "Forbidden".to_string(),
+        };
+        assert!(is_auth_failure(&err));
+    }
+
+    #[test]
+    fn is_auth_failure_pull_access_denied_message() {
+        let err = BollardError::DockerResponseServerError {
+            status_code: 500,
+            message: "pull access denied for ghcr.io/foo/bar, repository does not exist"
+                .to_string(),
+        };
+        assert!(is_auth_failure(&err));
+    }
+
+    #[test]
+    fn is_auth_failure_stream_error() {
+        let err = BollardError::DockerStreamError {
+            error: "unauthorized: unauthenticated: User cannot be authenticated".to_string(),
+        };
+        assert!(is_auth_failure(&err));
+    }
+
+    #[test]
+    fn is_auth_failure_not_found_is_false() {
+        let err = BollardError::DockerResponseServerError {
+            status_code: 404,
+            message: "Not found".to_string(),
+        };
+        assert!(!is_auth_failure(&err));
+    }
+
+    #[test]
+    fn is_auth_failure_generic_500_is_false() {
+        let err = BollardError::DockerResponseServerError {
+            status_code: 500,
+            message: "internal server error".to_string(),
+        };
+        assert!(!is_auth_failure(&err));
     }
 }

--- a/deploy/docker/Dockerfile.cluster
+++ b/deploy/docker/Dockerfile.cluster
@@ -175,9 +175,11 @@ FROM nvcr.io/nvidia/base/ubuntu:noble-20251013
 # - mount/umount: needed by kubelet for volume mounts (provided by mount package)
 # - ca-certificates: TLS verification for registry pulls
 # - conntrack: k3s/kube-proxy uses conntrack for connection tracking
+# - curl: used by entrypoint to validate registry credentials
 # - dnsutils: nslookup used by entrypoint/healthcheck for DNS probe
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    curl \
     iptables \
     mount \
     dnsutils \

--- a/deploy/docker/cluster-entrypoint.sh
+++ b/deploy/docker/cluster-entrypoint.sh
@@ -208,8 +208,26 @@ REGEOF
 REGEOF
     fi
 
+    # Helper: test whether registry credentials are accepted by attempting
+    # a token exchange via the OCI distribution auth endpoint.  Returns 0
+    # when credentials work, non-zero otherwise.  This lets us skip writing
+    # auth config for registries where the token is rejected — containerd
+    # will then fall back to anonymous pulls, which succeeds for public repos.
+    test_registry_credentials() {
+        local host="$1" user="$2" pass="$3"
+        # ghcr.io uses token-based auth; we test with an arbitrary scope.
+        curl -sf -o /dev/null -u "${user}:${pass}" \
+            "https://${host}/token?service=${host}&scope=repository:nvidia/openshell/cluster:pull" \
+            2>/dev/null
+    }
+
+    # Track whether the configs: YAML block has been started so subsequent
+    # registry entries can be appended without duplicating the key.
+    CONFIGS_STARTED=false
+
     if [ -n "${REGISTRY_USERNAME:-}" ] && [ -n "${REGISTRY_PASSWORD:-}" ]; then
-        cat >> "$REGISTRIES_YAML" <<REGEOF
+        if test_registry_credentials "${REGISTRY_HOST}" "${REGISTRY_USERNAME}" "${REGISTRY_PASSWORD}"; then
+            cat >> "$REGISTRIES_YAML" <<REGEOF
 
 configs:
   "${REGISTRY_HOST}":
@@ -217,23 +235,27 @@ configs:
       username: ${REGISTRY_USERNAME}
       password: ${REGISTRY_PASSWORD}
 REGEOF
+            CONFIGS_STARTED=true
+        else
+            echo "Registry credentials rejected for ${REGISTRY_HOST}, skipping auth config (anonymous pulls)"
+        fi
     fi
 
     # Add auth for the community registry when it differs from the
     # primary registry (community sandbox images live there).
     if [ -n "${COMMUNITY_REGISTRY_HOST:-}" ] && [ "${COMMUNITY_REGISTRY_HOST}" != "${REGISTRY_HOST}" ] \
        && [ -n "${COMMUNITY_REGISTRY_USERNAME:-}" ] && [ -n "${COMMUNITY_REGISTRY_PASSWORD:-}" ]; then
-        # Append to existing configs block or start a new one.
-        if [ -n "${REGISTRY_USERNAME:-}" ] && [ -n "${REGISTRY_PASSWORD:-}" ]; then
-            # configs: block already started above — just append the entry.
-            cat >> "$REGISTRIES_YAML" <<REGEOF
+        if test_registry_credentials "${COMMUNITY_REGISTRY_HOST}" "${COMMUNITY_REGISTRY_USERNAME}" "${COMMUNITY_REGISTRY_PASSWORD}"; then
+            if [ "$CONFIGS_STARTED" = "true" ]; then
+                # configs: block already started above — just append the entry.
+                cat >> "$REGISTRIES_YAML" <<REGEOF
   "${COMMUNITY_REGISTRY_HOST}":
     auth:
       username: ${COMMUNITY_REGISTRY_USERNAME}
       password: ${COMMUNITY_REGISTRY_PASSWORD}
 REGEOF
-        else
-            cat >> "$REGISTRIES_YAML" <<REGEOF
+            else
+                cat >> "$REGISTRIES_YAML" <<REGEOF
 
 configs:
   "${COMMUNITY_REGISTRY_HOST}":
@@ -241,6 +263,9 @@ configs:
       username: ${COMMUNITY_REGISTRY_USERNAME}
       password: ${COMMUNITY_REGISTRY_PASSWORD}
 REGEOF
+            fi
+        else
+            echo "Community registry credentials rejected for ${COMMUNITY_REGISTRY_HOST}, skipping auth config (anonymous pulls)"
         fi
     fi
 else


### PR DESCRIPTION
## Summary

When pulling container images from ghcr.io, credentials are always sent. If the token lacks access to a specific repo (e.g., a public repo the caller's PAT cannot read), the pull fails with 401/403 even though an unauthenticated pull would succeed. This PR adds fallback-to-anonymous logic across all three image pull paths.

## Changes

- **`crates/openshell-bootstrap/src/image.rs`**: Added `is_auth_failure()` helper that detects auth errors by HTTP status (401/403) and message patterns. Added `consume_pull_stream()` helper for reusable stream consumption. Modified `pull_remote_image()` to retry anonymously on auth failure. Added 6 unit tests.
- **`crates/openshell-bootstrap/src/docker.rs`**: Modified `ensure_image()` to detect auth failure mid-stream, break out, and retry with `None` credentials.
- **`deploy/docker/cluster-entrypoint.sh`**: Added `test_registry_credentials()` shell function that validates credentials against the GHCR token endpoint via curl before writing auth config to `registries.yaml`. Skips auth block when credentials are rejected so containerd falls back to anonymous pulls.
- **`deploy/docker/Dockerfile.cluster`**: Added `curl` to runtime stage dependencies for the credential validation test.
- **`crates/openshell-bootstrap/src/errors.rs`**: Updated `diagnose_image_pull_auth_failure` to mention that anonymous fallback was also attempted.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated (6 new `is_auth_failure` tests)
- [ ] E2E tests added/updated (manual testing needed: deploy with invalid token against public GHCR image)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)