### PR TITLE
fix(bootstrap): support cgroup v1 hosts by disabling kubelet failCgroupV1 check

### DIFF
--- a/deploy/docker/cluster-entrypoint.sh
+++ b/deploy/docker/cluster-entrypoint.sh
@@ -482,10 +482,25 @@ fi
 # Pre-creating the directory eliminates this failure mode.
 mkdir -p /run/flannel
 
+# ---------------------------------------------------------------------------
+# Detect cgroup version and set kubelet compatibility flags
+# ---------------------------------------------------------------------------
+# Kubernetes 1.35+ (k3s v1.35.x) rejects cgroup v1 by default. Hosts running
+# older distros (e.g. Rocky Linux 8, CentOS 7/8, Ubuntu 18.04) still use
+# cgroup v1. When we detect cgroup v1, pass --kubelet-arg=fail-cgroupv1=false
+# so kubelet warns instead of refusing to start. This flag can be removed once
+# cgroup v1 support is no longer needed.
+EXTRA_KUBELET_ARGS=""
+if [ ! -f /sys/fs/cgroup/cgroup.controllers ]; then
+    echo "Detected cgroup v1 — adding kubelet compatibility flag (fail-cgroupv1=false)"
+    EXTRA_KUBELET_ARGS="--kubelet-arg=fail-cgroupv1=false"
+fi
+
 # Docker Desktop can briefly start the container before its bridge default route
 # is fully installed. k3s exits immediately in that state, so wait briefly for
 # routing to settle first.
 wait_for_default_route
 
 # Execute k3s with explicit resolv-conf.
-exec /bin/k3s "$@" --resolv-conf="$RESOLV_CONF"
+# shellcheck disable=SC2086
+exec /bin/k3s "$@" --resolv-conf="$RESOLV_CONF" $EXTRA_KUBELET_ARGS


### PR DESCRIPTION
## Summary

Fix gateway startup failure on Linux hosts that use cgroup v1 (e.g. Rocky Linux 8, CentOS 7/8, Ubuntu 18.04). Kubernetes 1.35 (bundled in k3s v1.35.2) rejects cgroup v1 by default, causing kubelet to exit immediately with `kubelet is configured to not run on a host using cgroup v1`.

## Related Issue

Reported by a user running Rocky Linux 8 with Docker 29.3.0. The prior fix in #329 (commit a458ca6) addressed a different cgroup issue (private cgroupns on Docker Desktop preventing access to cgroup v2 controllers) and did not resolve the cgroup v1 rejection.

## Changes

- Detect cgroup v1 at container startup by checking for the absence of `/sys/fs/cgroup/cgroup.controllers` (which only exists on cgroup v2 unified hierarchy)
- When cgroup v1 is detected, pass `--kubelet-arg=fail-cgroupv1=false` to k3s so kubelet logs a deprecation warning instead of refusing to start
- The detection is reliable because the container runs with `cgroupns_mode: host`, so `/sys/fs/cgroup` reflects the host's cgroup filesystem

## Testing

- [x] `mise run pre-commit` passes
- [ ] Manual testing on a cgroup v1 host (Rocky Linux 8) needed
- [ ] Unit tests added/updated — N/A (shell script change, no testable Rust code)
- [ ] E2E tests added/updated — N/A

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — N/A