### PR TITLE
fix(ci): add actions:write permission to release-auto-tag workflow

### DIFF
--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: release-auto-tag


### PR DESCRIPTION
## Summary

Add `actions: write` permission to the Release Auto-Tag workflow so the `GITHUB_TOKEN` can dispatch the Release Tag workflow via `gh workflow run`.

## Related Issue

Fixes failed run: https://github.com/NVIDIA/OpenShell/actions/runs/23149319067

## Changes

- Added `actions: write` to the `permissions` block in `.github/workflows/release-auto-tag.yml`

## Root Cause

The "Trigger Release Tag workflow" step calls `gh workflow run release-tag.yml`, which hits the GitHub API endpoint `POST /repos/{owner}/{repo}/actions/workflows/{id}/dispatches`. This endpoint requires the `actions: write` permission on the token. The workflow only had `contents: write`, resulting in:

```
HTTP 403: Resource not accessible by integration
```

## Note

The `v0.0.6` tag was already pushed successfully before the failure. After merging this fix, the Release Tag workflow should be manually triggered with `tag: v0.0.6` to complete that release.

## Testing

- [x] Verified the GitHub Actions [permissions documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) confirms `actions: write` is required for workflow dispatch

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)