### PR TITLE
chore: pin mitchellh/vouch actions to SHA

### DIFF
--- a/.github/workflows/vouch-check.yml
+++ b/.github/workflows/vouch-check.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'NVIDIA'
     runs-on: ubuntu-latest
     steps:
-      - uses: mitchellh/vouch/action/check-pr@v1
+      - uses: mitchellh/vouch/action/check-pr@f44860978966ace98fb11aaaa20f2b27d7543e13 # v1
         with:
           pr-number: ${{ github.event.pull_request.number }}
           auto-close: true

--- a/.github/workflows/vouch-command.yml
+++ b/.github/workflows/vouch-command.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: mitchellh/vouch/action/manage-by-discussion@v1
+      - uses: mitchellh/vouch/action/manage-by-discussion@f44860978966ace98fb11aaaa20f2b27d7543e13 # v1
         with:
           discussion-number: ${{ github.event.discussion.number }}
           comment-node-id: ${{ github.event.comment.node_id }}


### PR DESCRIPTION
## Summary

Pin `mitchellh/vouch` actions to commit SHA to comply with enterprise action policy. Tag `@v1` references are blocked.

## Changes

- `vouch-check.yml` — pin `check-pr` to `f44860978966ace98fb11aaaa20f2b27d7543e13`
- `vouch-command.yml` — pin `manage-by-discussion` to `f44860978966ace98fb11aaaa20f2b27d7543e13`

## Testing

- [ ] `mise run pre-commit` passes
- [ ] Vouch check workflow runs successfully on test PR

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)