### PR TITLE
fix: use dedicated vouched branch for vouch system

### DIFF
--- a/.github/workflows/vouch-check.yml
+++ b/.github/workflows/vouch-check.yml
@@ -59,15 +59,15 @@ jobs:
               }
             }
 
-            // Check the VOUCHED.td file. Read from the default branch, NOT the
-            // PR branch — the PR author could add themselves in their fork.
+            // Check the VOUCHED.td file on the dedicated "vouched" branch.
+            // NOT the PR branch — the PR author could add themselves in their fork.
             let vouched = false;
             try {
               const { data } = await github.rest.repos.getContent({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 path: '.github/VOUCHED.td',
-                ref: context.payload.repository.default_branch,
+                ref: 'vouched',
               });
               const content = Buffer.from(data.content, 'base64').toString('utf-8');
               const usernames = content

--- a/.github/workflows/vouch-command.yml
+++ b/.github/workflows/vouch-command.yml
@@ -75,7 +75,33 @@ jobs:
             // --- Read VOUCHED.td ---
 
             const filePath = '.github/VOUCHED.td';
-            const branch = context.payload.repository.default_branch;
+            const branch = 'vouched';
+
+            // Ensure the "vouched" branch exists. If not, create it from main.
+            try {
+              await github.rest.repos.getBranch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch,
+              });
+            } catch (e) {
+              if (e.status === 404) {
+                console.log('Creating "vouched" branch from main.');
+                const { data: mainRef } = await github.rest.git.getRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `heads/${context.payload.repository.default_branch}`,
+                });
+                await github.rest.git.createRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: 'refs/heads/vouched',
+                  sha: mainRef.object.sha,
+                });
+              } else {
+                throw e;
+              }
+            }
 
             let currentContent = '';
             let sha = '';
@@ -89,7 +115,7 @@ jobs:
               currentContent = Buffer.from(data.content, 'base64').toString('utf-8');
               sha = data.sha;
             } catch (e) {
-              console.log(`Could not read VOUCHED.td: ${e.message}`);
+              console.log(`Could not read VOUCHED.td on "${branch}" branch: ${e.message}`);
               return;
             }
 


### PR DESCRIPTION
## Summary

Branch protection on main blocks direct commits from the vouch-command workflow. Switches to a dedicated `vouched` branch (same pattern as the `signatures` branch used by DCO).

## Changes

- `vouch-command.yml` — writes to `vouched` branch instead of main, auto-creates the branch from main on first vouch
- `vouch-check.yml` — reads VOUCHED.td from the `vouched` branch

## Testing

- [ ] `/vouch` command on a Vouch Request discussion
- [ ] Unvouched user opens a PR (should auto-close)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)