### PR TITLE
ci(release): enable scheduled nightly release auto-tag

### DIFF
--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -5,8 +5,8 @@ name: Release Auto-Tag
 
 on:
   workflow_dispatch: {}
-  # schedule:
-  #   - cron: "0 3 * * *" # 7 PM PT (03:00 UTC during PDT)
+  schedule:
+    - cron: "0 3 * * *" # 7 PM PT (03:00 UTC during PDT)
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Uncomments the `schedule` trigger in the `release-auto-tag` workflow so nightly releases run automatically at 7 PM PT (03:00 UTC).

## Changes

- Uncommented the `schedule` cron trigger in `.github/workflows/release-auto-tag.yml`
- Nightly auto-tag will now run daily at `0 3 * * *` (03:00 UTC / 7 PM PT during PDT)

## Testing

- [x] `mise run pre-commit` — N/A (YAML comment change only)
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)