### PR TITLE
fix(ci): skip auto-tag when no new commits since latest tag

### DIFF
--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -34,6 +34,15 @@ jobs:
           fi
           echo "Latest tag: $latest"
 
+          # Skip if no new commits since the latest tag
+          commit_count=$(git rev-list "${latest}..HEAD" --count)
+          echo "Commits since $latest: $commit_count"
+          if [ "$commit_count" -eq 0 ]; then
+            echo "No new commits since $latest — skipping tag creation"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           major=$(echo "$latest" | sed 's/^v//' | cut -d. -f1)
           minor=$(echo "$latest" | sed 's/^v//' | cut -d. -f2)
           patch=$(echo "$latest" | sed 's/^v//' | cut -d. -f3)
@@ -48,11 +57,13 @@ jobs:
           echo "Next tag: $next"
 
       - name: Create and push tag
+        if: steps.version.outputs.skip != 'true'
         run: |
           git tag ${{ steps.version.outputs.next }}
           git push origin ${{ steps.version.outputs.next }}
 
       - name: Trigger Release Tag workflow
+        if: steps.version.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

Prevents the nightly `release-auto-tag` workflow from creating redundant patch tags when there are no new commits since the latest tag.

## Changes

- Added a `git rev-list` check after finding the latest tag to count commits between it and HEAD
- If the count is zero, sets a `skip` output and exits early
- Added `if: steps.version.outputs.skip != 'true'` guards on the "Create and push tag" and "Trigger Release Tag workflow" steps

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)