### PR TITLE
fix(installer): remove duplicate app name in install output

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -280,7 +280,7 @@ main() {
   fi
 
   _installed_version="$("${_install_dir}/${APP_NAME}" --version 2>/dev/null || echo "${_version}")"
-  info "installed ${APP_NAME} ${_installed_version} to ${_install_dir}/${APP_NAME}"
+  info "installed ${_installed_version} to ${_install_dir}/${APP_NAME}"
 
   # If the install directory isn't on PATH, print instructions
   if ! is_on_path "$_install_dir"; then


### PR DESCRIPTION
## Summary

Clean up the install success message so it does not repeat the app name when `--version` already includes it. This keeps the installer output easier to read and avoids awkward duplicated text.

## Related Issue

<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes

- Remove the extra `${APP_NAME}` prefix from the final install success log in `install.sh`
- Preserve the existing installed binary path and version lookup behavior

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)