### PR TITLE
fix(ci): update release canary install path

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -82,15 +82,13 @@ jobs:
             fi
           fi
 
-      - name: Install CLI from GitHub Release
+      - name: Install CLI from published install script
         run: |
           set -euo pipefail
-          ./install.sh
+          export OPENSHELL_VERSION="${{ steps.release.outputs.tag }}"
+          export OPENSHELL_INSTALL_DIR="${{ runner.temp }}/openshell-bin"
+          curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
           echo "$OPENSHELL_INSTALL_DIR" >> "$GITHUB_PATH"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENSHELL_VERSION: ${{ steps.release.outputs.tag }}
-          OPENSHELL_INSTALL_DIR: ${{ runner.temp }}/openshell-bin
 
       - name: Verify CLI installation
         run: |

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -364,37 +364,10 @@ jobs:
 
             ### Quick install
 
-            Requires the [GitHub CLI (`gh`)](https://cli.github.com) to be installed and authenticated.
-
             ```bash
-            sh -c 'ARCH=$(uname -m); OS=$(uname -s); \
-                case "${OS}-${ARCH}" in \
-                  Linux-x86_64)  ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;; \
-                  Linux-aarch64) ASSET="openshell-aarch64-unknown-linux-musl.tar.gz" ;; \
-                  Darwin-arm64)  ASSET="openshell-aarch64-apple-darwin.tar.gz" ;; \
-                  *) echo "Unsupported platform: ${OS}-${ARCH}" >&2; exit 1 ;; \
-                esac; \
-                gh release download ${{ env.RELEASE_TAG }} --repo NVIDIA/OpenShell --pattern "${ASSET}" -O - \
-                  | tar xz \
-                  && sudo install -m 755 openshell /usr/local/bin/openshell'
+            curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | OPENSHELL_VERSION=${{ env.RELEASE_TAG }} sh
             ```
 
-            ### Docker images
-
-            ```bash
-            docker pull ghcr.io/nvidia/openshell/gateway:${{ needs.compute-versions.outputs.semver }}
-            docker pull ghcr.io/nvidia/openshell/cluster:${{ needs.compute-versions.outputs.semver }}
-            ```
-
-            ### Assets
-
-            | File | Platform |
-            |------|----------|
-            | `openshell-x86_64-unknown-linux-musl.tar.gz` | Linux x86_64 |
-            | `openshell-aarch64-unknown-linux-musl.tar.gz` | Linux aarch64 / ARM64 |
-            | `openshell-aarch64-apple-darwin.tar.gz` | macOS Apple Silicon |
-            | `openshell-*.whl` | Python wheels |
-            | `openshell-checksums-sha256.txt` | SHA256 checksums for all archives |
           files: |
             release/openshell-x86_64-unknown-linux-musl.tar.gz
             release/openshell-aarch64-unknown-linux-musl.tar.gz


### PR DESCRIPTION
## Summary

Update the release canary workflow to use an explicit install directory and add it to the GitHub Actions PATH. This keeps canary validation working with the new `install.sh` default install location.

## Related Issue

N/A

## Changes

- set `OPENSHELL_INSTALL_DIR` to a temporary runner directory in the canary workflow
- append that directory to `GITHUB_PATH` after running `install.sh`
- verify the installed binary is discoverable before checking `openshell --version`

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)