### PR TITLE
fix(gpu): add WSL2 GPU support via CDI mode

### DIFF
--- a/deploy/docker/cluster-entrypoint.sh
+++ b/deploy/docker/cluster-entrypoint.sh
@@ -350,7 +350,32 @@ if [ "${GPU_ENABLED:-}" = "true" ]; then
             mkdir -p /var/run/cdi
             nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml 2>&1 || true
 
-            # 2. Patch CDI spec: add libdxcore.so mount (nvidia-ctk misses it)
+            # 2. Add per-GPU device entries (UUID and index) to CDI spec.
+            #    nvidia-ctk only generates name=all, but the device plugin
+            #    assigns GPUs by UUID which must resolve as a CDI device.
+            if [ -f /var/run/cdi/nvidia.yaml ] && command -v nvidia-smi >/dev/null 2>&1; then
+                idx=0
+                nvidia-smi --query-gpu=gpu_uuid --format=csv,noheader 2>/dev/null | while read -r uuid; do
+                    uuid=$(echo "$uuid" | tr -d ' ')
+                    [ -z "$uuid" ] && continue
+                    sed -i "/- name: all/a\\
+    - name: $uuid\\
+      containerEdits:\\
+        deviceNodes:\\
+            - path: /dev/dxg\\
+    - name: \"$idx\"\\
+      containerEdits:\\
+        deviceNodes:\\
+            - path: /dev/dxg" /var/run/cdi/nvidia.yaml
+                    idx=$((idx + 1))
+                done
+                # nvidia-ctk cdi generate uses cdiVersion 0.3.0 but the
+                # installed CDI library requires >= 0.5.0
+                sed -i 's/cdiVersion: 0\.3\.0/cdiVersion: 0.5.0/' /var/run/cdi/nvidia.yaml
+                echo "CDI spec: added per-GPU UUID and index device entries"
+            fi
+
+            # 4. Patch CDI spec: add libdxcore.so mount (nvidia-ctk misses it)
             DXCORE_PATH=$(find /usr/lib -name "libdxcore.so" 2>/dev/null | head -1)
             if [ -n "$DXCORE_PATH" ] && [ -f /var/run/cdi/nvidia.yaml ]; then
                 DXCORE_DIR=$(dirname "$DXCORE_PATH")
@@ -372,14 +397,14 @@ if [ "${GPU_ENABLED:-}" = "true" ]; then
             fi
         fi
 
-        # 3. Switch nvidia container runtime to CDI mode
+        # 5. Switch nvidia container runtime to CDI mode
         NVIDIA_RUNTIME_CONFIG="/etc/nvidia-container-runtime/config.toml"
         if [ -f "$NVIDIA_RUNTIME_CONFIG" ]; then
             sed -i 's/mode = "auto"/mode = "cdi"/' "$NVIDIA_RUNTIME_CONFIG"
             echo "nvidia-container-runtime switched to CDI mode"
         fi
 
-        # 4. Create a k3s manifest to label the node with NVIDIA PCI vendor
+        # 6. Create a k3s manifest to label the node with NVIDIA PCI vendor
         #    (NFD can't detect it on WSL2 since PCI topology is virtualised)
         cat > "$K3S_MANIFESTS/wsl2-gpu-node-label.yaml" <<'WSLEOF'
 apiVersion: batch/v1


### PR DESCRIPTION
## Summary

- Detect WSL2 at gateway startup (`/dev/dxg` present) and automatically configure CDI-based GPU injection
- Fixes the complete nvidia-device-plugin failure chain on WSL2: NFD can't see PCI, NVML can't init without `libdxcore.so`, CDI spec missing per-GPU UUID entries
- All changes are in `cluster-entrypoint.sh` — no Rust, Dockerfile, or manifest changes needed

## What it does

When `GPU_ENABLED=true` and `/dev/dxg` exists (WSL2), the entrypoint:

1. Generates CDI spec via `nvidia-ctk cdi generate` (auto-detects WSL mode)
2. Adds per-GPU UUID and index device entries (nvidia-ctk only generates `name=all`, but the device plugin assigns GPUs by UUID)
3. Bumps CDI spec version from 0.3.0 to 0.5.0 (library minimum)
4. Patches the spec to include `libdxcore.so` (upstream nvidia-ctk bug — NVIDIA/nvidia-container-toolkit#1739)
5. Switches nvidia-container-runtime from `auto` to `cdi` mode
6. Deploys a k3s Job to label the node with `pci-10de.present=true` (NFD can't detect NVIDIA PCI on WSL2's virtualised bus)

On non-WSL2 hosts, the new code path is never entered (`/dev/dxg` doesn't exist).

## Testing

Verified on:
- **Hardware**: Framework 16 laptop, AMD CPU, NVIDIA RTX 5070 (8GB VRAM) + 96GB DDR5 shared
- **OS**: WSL2 (Linux 6.6.87.2-microsoft-standard-WSL2)
- **Driver**: NVIDIA 595.71, CUDA 13.2
- **Result**: `nvidia-device-plugin` 1/1 Running, `nvidia.com/gpu: 1` advertised, `nvidia-smi` works inside sandbox pods, full NemoClaw onboard + sandbox creation + local inference (ollama nemotron 70B) working end-to-end

## Related

- Closes #404
- Upstream bug: NVIDIA/nvidia-container-toolkit#1739 (`nvidia-ctk cdi generate` misses `libdxcore.so` on WSL2)
- Related to #398 (CDI migration) — WSL2 is a concrete platform where legacy injection is broken and CDI is the only viable path

## Agent Investigation

Diagnosed using `openshell doctor` commands. Full diagnostic chain documented in #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)