### PR TITLE
fix(ci): pass wheel filenames as job output instead of re-downloading

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -96,6 +96,7 @@ jobs:
     timeout-minutes: 120
     outputs:
       wheel_version: ${{ needs.compute-versions.outputs.python_version }}
+      wheel_filenames: ${{ steps.filenames.outputs.wheel_filenames }}
     container:
       image: ghcr.io/nvidia/openshell/ci:latest
       credentials:
@@ -131,6 +132,13 @@ jobs:
           OPENSHELL_CARGO_VERSION="${{ needs.compute-versions.outputs.cargo_version }}" mise run python:build:multiarch
           OPENSHELL_CARGO_VERSION="${{ needs.compute-versions.outputs.cargo_version }}" mise run python:build:macos
           ls -la target/wheels/*.whl
+
+      - name: Capture wheel filenames
+        id: filenames
+        run: |
+          set -euo pipefail
+          WHEEL_FILENAMES=$(ls target/wheels/*.whl | xargs -n1 basename | paste -sd, -)
+          echo "wheel_filenames=${WHEEL_FILENAMES}" >> "$GITHUB_OUTPUT"
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4
@@ -428,31 +436,23 @@ jobs:
 
   trigger-wheel-publish:
     name: Trigger Wheel Publish
-    needs: [compute-versions, release-devel]
+    needs: [compute-versions, build-python-wheels, release-devel]
     runs-on: [self-hosted, nv]
     timeout-minutes: 10
     steps:
-      - name: Download wheel artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: python-wheels
-          path: release/
-
       - name: Trigger GitLab CI
         env:
           GITLAB_CI_TRIGGER_TOKEN: ${{ secrets.GITLAB_CI_TRIGGER_TOKEN }}
           GITLAB_CI_TRIGGER_URL: ${{ secrets.GITLAB_CI_TRIGGER_URL }}
           RELEASE_VERSION: ${{ needs.compute-versions.outputs.python_version }}
+          WHEEL_FILENAMES: ${{ needs.build-python-wheels.outputs.wheel_filenames }}
         run: |
           set -euo pipefail
-          shopt -s nullglob
-          wheel_files=(release/*.whl)
-          if (( ${#wheel_files[@]} == 0 )); then
-            echo "No wheel artifacts found in release/" >&2
+          if [ -z "${WHEEL_FILENAMES}" ]; then
+            echo "No wheel filenames provided by build job" >&2
             exit 1
           fi
 
-          WHEEL_FILENAMES=$(printf '%s\n' "${wheel_files[@]##*/}" | paste -sd, -)
           response=$(curl -X POST \
             --fail \
             --silent \

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -116,6 +116,7 @@ jobs:
     timeout-minutes: 120
     outputs:
       wheel_version: ${{ needs.compute-versions.outputs.python_version }}
+      wheel_filenames: ${{ steps.filenames.outputs.wheel_filenames }}
     container:
       image: ghcr.io/nvidia/openshell/ci:latest
       credentials:
@@ -152,6 +153,13 @@ jobs:
           OPENSHELL_CARGO_VERSION="${{ needs.compute-versions.outputs.cargo_version }}" mise run python:build:multiarch
           OPENSHELL_CARGO_VERSION="${{ needs.compute-versions.outputs.cargo_version }}" mise run python:build:macos
           ls -la target/wheels/*.whl
+
+      - name: Capture wheel filenames
+        id: filenames
+        run: |
+          set -euo pipefail
+          WHEEL_FILENAMES=$(ls target/wheels/*.whl | xargs -n1 basename | paste -sd, -)
+          echo "wheel_filenames=${WHEEL_FILENAMES}" >> "$GITHUB_OUTPUT"
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4
@@ -404,32 +412,24 @@ jobs:
 
   trigger-wheel-publish:
     name: Trigger Wheel Publish
-    needs: [compute-versions, release]
+    needs: [compute-versions, build-python-wheels, release]
     runs-on: [self-hosted, nv]
     timeout-minutes: 10
     steps:
-      - name: Download wheel artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: python-wheels
-          path: release/
-
       - name: Trigger GitLab CI
         env:
           GITLAB_CI_TRIGGER_TOKEN: ${{ secrets.GITLAB_CI_TRIGGER_TOKEN }}
           GITLAB_CI_TRIGGER_URL: ${{ secrets.GITLAB_CI_TRIGGER_URL }}
           RELEASE_VERSION: ${{ needs.compute-versions.outputs.python_version }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          WHEEL_FILENAMES: ${{ needs.build-python-wheels.outputs.wheel_filenames }}
         run: |
           set -euo pipefail
-          shopt -s nullglob
-          wheel_files=(release/*.whl)
-          if (( ${#wheel_files[@]} == 0 )); then
-            echo "No wheel artifacts found in release/" >&2
+          if [ -z "${WHEEL_FILENAMES}" ]; then
+            echo "No wheel filenames provided by build job" >&2
             exit 1
           fi
 
-          WHEEL_FILENAMES=$(printf '%s\n' "${wheel_files[@]##*/}" | paste -sd, -)
           response=$(curl -X POST \
             --fail \
             --silent \


### PR DESCRIPTION
## Summary

Passes wheel filenames as a job output from `build-python-wheels` to `trigger-wheel-publish` instead of re-downloading the artifact.

## Root Cause

The `trigger-wheel-publish` job runs on a persistent self-hosted runner (`agent-dev-kit-build-1`) with no `actions/checkout` step. It was downloading the wheel artifact into `release/` just to glob the filenames. Since `download-artifact` does not clean the destination directory, stale `.whl` files from every previous run accumulated there.

Confirmed on the runner instance:

```
/home/ubuntu/actions-runner/_work/OpenShell/OpenShell/release/
```

contained 120+ wheels spanning versions 0.0.5 through 0.0.10, while the actual artifact only contained 3 wheels (~5MB each).

## Fix

- Add a "Capture wheel filenames" step in `build-python-wheels` that writes the comma-separated basenames to `$GITHUB_OUTPUT`
- `trigger-wheel-publish` reads `needs.build-python-wheels.outputs.wheel_filenames` directly — no download, no filesystem, no accumulation possible
- The trigger job now only needs a shell and network access; it no longer touches the filesystem at all
