### PR TITLE
fix(server): prevent deleting providers still referenced by sandboxes…

### DIFF
--- a/crates/openshell-server/src/grpc.rs
+++ b/crates/openshell-server/src/grpc.rs
@@ -3290,6 +3290,15 @@ async fn delete_provider_record(
         return Err(Status::invalid_argument("name is required"));
     }
 
+    // Early-out: if the provider doesn't exist, nothing to delete.
+    let exists = store
+        .get_by_name(Provider::object_type(), name)
+        .await
+        .map_err(|e| Status::internal(format!("check provider failed: {e}")))?;
+    if exists.is_none() {
+        return Ok(false);
+    }
+
     // Check if any sandbox references this provider.
     let sandbox_records = store
         .list(Sandbox::object_type(), u32::MAX, 0)
@@ -3341,7 +3350,8 @@ async fn delete_provider_record(
             ));
         }
         return Err(Status::failed_precondition(format!(
-            "cannot delete provider '{}': still referenced by {}",
+            "cannot delete provider '{}': still referenced by {}. \
+             Remove or update these references before deleting the provider.",
             name,
             details.join(" and ")
         )));


### PR DESCRIPTION
Block provider deletion when the provider is still referenced by any sandbox (spec.providers) or inference route (inference.local, sandbox-system). Returns FAILED_PRECONDITION with an actionable error message listing the referencing resources.

Closes #157

## Summary
<!-- 1-3 sentences: what this PR does and why -->

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- What testing was done? -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
