### PR TITLE
fix(gpu): add WSL2 GPU support via CDI mode

### DIFF
--- a/deploy/docker/cluster-entrypoint.sh
+++ b/deploy/docker/cluster-entrypoint.sh
@@ -345,55 +345,93 @@ if [ "${GPU_ENABLED:-}" = "true" ]; then
     if [ -c /dev/dxg ]; then
         echo "WSL2 detected (/dev/dxg present) — configuring CDI mode for GPU"
 
-        # 1. Generate CDI spec (nvidia-ctk auto-detects WSL mode)
-        if command -v nvidia-ctk >/dev/null 2>&1; then
+        # 1. Build a complete CDI spec from scratch.
+        #    nvidia-ctk cdi generate has two WSL2 bugs:
+        #      a) only creates name=all but the device plugin assigns by UUID
+        #      b) misses libdxcore.so (the NVML-to-DXG bridge library)
+        #    Writing the spec directly avoids fragile sed patching of YAML.
+        if command -v nvidia-ctk >/dev/null 2>&1 && command -v nvidia-smi >/dev/null 2>&1; then
             mkdir -p /var/run/cdi
-            nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml 2>&1 || true
 
-            # 2. Add per-GPU device entries (UUID and index) to CDI spec.
-            #    nvidia-ctk only generates name=all, but the device plugin
-            #    assigns GPUs by UUID which must resolve as a CDI device.
-            if [ -f /var/run/cdi/nvidia.yaml ] && command -v nvidia-smi >/dev/null 2>&1; then
-                idx=0
-                nvidia-smi --query-gpu=gpu_uuid --format=csv,noheader 2>/dev/null | while read -r uuid; do
-                    uuid=$(echo "$uuid" | tr -d ' ')
-                    [ -z "$uuid" ] && continue
-                    sed -i "/- name: all/a\\
-    - name: $uuid\\
-      containerEdits:\\
-        deviceNodes:\\
-            - path: /dev/dxg\\
-    - name: \"$idx\"\\
-      containerEdits:\\
-        deviceNodes:\\
-            - path: /dev/dxg" /var/run/cdi/nvidia.yaml
-                    idx=$((idx + 1))
-                done
-                # nvidia-ctk cdi generate uses cdiVersion 0.3.0 but the
-                # installed CDI library requires >= 0.5.0
-                sed -i 's/cdiVersion: 0\.3\.0/cdiVersion: 0.5.0/' /var/run/cdi/nvidia.yaml
-                echo "CDI spec: added per-GPU UUID and index device entries"
-            fi
-
-            # 4. Patch CDI spec: add libdxcore.so mount (nvidia-ctk misses it)
+            GPU_UUID=$(nvidia-smi --query-gpu=gpu_uuid --format=csv,noheader 2>/dev/null | tr -d ' ' | head -1)
             DXCORE_PATH=$(find /usr/lib -name "libdxcore.so" 2>/dev/null | head -1)
-            if [ -n "$DXCORE_PATH" ] && [ -f /var/run/cdi/nvidia.yaml ]; then
-                DXCORE_DIR=$(dirname "$DXCORE_PATH")
-                # Insert libdxcore mount after the mounts: key
-                sed -i "/^    mounts:/a\\
-        - hostPath: $DXCORE_PATH\\
-          containerPath: $DXCORE_PATH\\
-          options:\\
-            - ro\\
-            - nosuid\\
-            - nodev\\
-            - rbind\\
-            - rprivate" /var/run/cdi/nvidia.yaml
-                # Add ldcache folder for libdxcore directory
-                sed -i "s|update-ldcache|update-ldcache\n            - --folder\n            - $DXCORE_DIR|" /var/run/cdi/nvidia.yaml
-                echo "CDI spec patched with libdxcore.so from $DXCORE_PATH"
+            DXCORE_DIR=$(dirname "$DXCORE_PATH" 2>/dev/null || echo "/usr/lib/x86_64-linux-gnu")
+            DRIVER_DIR=$(ls -d /usr/lib/wsl/drivers/nv*.inf_amd64_* 2>/dev/null | head -1)
+
+            if [ -n "$DRIVER_DIR" ] && [ -n "$GPU_UUID" ]; then
+                cat > /var/run/cdi/nvidia.yaml <<CDIEOF
+---
+cdiVersion: "0.5.0"
+kind: nvidia.com/gpu
+devices:
+    - name: all
+      containerEdits:
+        deviceNodes:
+            - path: /dev/dxg
+    - name: "${GPU_UUID}"
+      containerEdits:
+        deviceNodes:
+            - path: /dev/dxg
+    - name: "0"
+      containerEdits:
+        deviceNodes:
+            - path: /dev/dxg
+containerEdits:
+    env:
+        - NVIDIA_VISIBLE_DEVICES=void
+    hooks:
+        - hookName: createContainer
+          path: /usr/bin/nvidia-cdi-hook
+          args:
+            - nvidia-cdi-hook
+            - create-symlinks
+            - --link
+            - ${DRIVER_DIR}/nvidia-smi::/usr/bin/nvidia-smi
+          env:
+            - NVIDIA_CTK_DEBUG=false
+        - hookName: createContainer
+          path: /usr/bin/nvidia-cdi-hook
+          args:
+            - nvidia-cdi-hook
+            - update-ldcache
+            - --folder
+            - ${DRIVER_DIR}
+            - --folder
+            - ${DXCORE_DIR}
+          env:
+            - NVIDIA_CTK_DEBUG=false
+    mounts:
+        - hostPath: ${DXCORE_PATH}
+          containerPath: ${DXCORE_PATH}
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/libcuda.so.1.1
+          containerPath: ${DRIVER_DIR}/libcuda.so.1.1
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/libcuda_loader.so
+          containerPath: ${DRIVER_DIR}/libcuda_loader.so
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/libnvdxgdmal.so.1
+          containerPath: ${DRIVER_DIR}/libnvdxgdmal.so.1
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/libnvidia-ml.so.1
+          containerPath: ${DRIVER_DIR}/libnvidia-ml.so.1
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/libnvidia-ml_loader.so
+          containerPath: ${DRIVER_DIR}/libnvidia-ml_loader.so
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/libnvidia-ptxjitcompiler.so.1
+          containerPath: ${DRIVER_DIR}/libnvidia-ptxjitcompiler.so.1
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/nvcubins.bin
+          containerPath: ${DRIVER_DIR}/nvcubins.bin
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/nvidia-smi
+          containerPath: ${DRIVER_DIR}/nvidia-smi
+          options: [ro, nosuid, nodev, rbind, rprivate]
+CDIEOF
+                echo "CDI spec written (GPU: $GPU_UUID, driver: $DRIVER_DIR, dxcore: $DXCORE_PATH)"
             else
-                echo "Warning: libdxcore.so not found — NVML may fail inside pods"
+                echo "Warning: could not detect GPU UUID or WSL driver store — CDI spec not written"
             fi
         fi
 


### PR DESCRIPTION
This is a newly created issue to effectively re-open #411 as my vouched user.
It's probably a less than ideal technique and needs cleanup if it were to be used, it's also semi-tested-and-untested as my llm created this after manually patching containers etc.

 Tested on a Frame.work 16" with AMD AI 7 350 CPU (+GPU), w/ NVIDIA RTX 5070 (8GB VRAM) + 96GB DDR5 unified/shared RAM.

See the original issue in NVidia/NemoClaw https://github.com/NVIDIA/NemoClaw/issues/208#issuecomment-4078271080

> ## Summary
> * Detect WSL2 at gateway startup (`/dev/dxg` present) and automatically configure CDI-based GPU injection
> * Fixes the complete nvidia-device-plugin failure chain on WSL2: NFD can't see PCI, NVML can't init without `libdxcore.so`, CDI spec missing per-GPU UUID entries
> * All changes are in `cluster-entrypoint.sh` — no Rust, Dockerfile, or manifest changes needed
> 
> ## What it does
> When `GPU_ENABLED=true` and `/dev/dxg` exists (WSL2), the entrypoint:
> 
> 1. Generates CDI spec via `nvidia-ctk cdi generate` (auto-detects WSL mode)
> 2. Adds per-GPU UUID and index device entries (nvidia-ctk only generates `name=all`, but the device plugin assigns GPUs by UUID)
> 3. Bumps CDI spec version from 0.3.0 to 0.5.0 (library minimum)
> 4. Patches the spec to include `libdxcore.so` (upstream nvidia-ctk bug — [nvidia-ctk cdi generate: libdxcore.so not found on WSL2 despite being present nvidia-container-toolkit#1739](https://github.com/NVIDIA/nvidia-container-toolkit/issues/1739))
> 5. Switches nvidia-container-runtime from `auto` to `cdi` mode
> 6. Deploys a k3s Job to label the node with `pci-10de.present=true` (NFD can't detect NVIDIA PCI on WSL2's virtualised bus)
> 
> On non-WSL2 hosts, the new code path is never entered (`/dev/dxg` doesn't exist).
> 
> ## Testing
> Verified on:
> 
> * **Hardware**: Framework 16 laptop, AMD CPU, NVIDIA RTX 5070 (8GB VRAM) + 96GB DDR5 shared
> * **OS**: WSL2 (Linux 6.6.87.2-microsoft-standard-WSL2)
> * **Driver**: NVIDIA 595.71, CUDA 13.2
> * **Result**: `nvidia-device-plugin` 1/1 Running, `nvidia.com/gpu: 1` advertised, `nvidia-smi` works inside sandbox pods, full NemoClaw onboard + sandbox creation + local inference (ollama nemotron 70B) working end-to-end
> 
> ## Related
> * Closes [bug: GPU passthrough fails on WSL2 — NVML init fails without CDI mode and libdxcore.so #404](https://github.com/NVIDIA/OpenShell/issues/404)
> * Upstream bug: [nvidia-ctk cdi generate: libdxcore.so not found on WSL2 despite being present nvidia-container-toolkit#1739](https://github.com/NVIDIA/nvidia-container-toolkit/issues/1739) (`nvidia-ctk cdi generate` misses `libdxcore.so` on WSL2)
> * Related to [feat: Use CDI for GPU injection instead of nvidia-container-cli #398](https://github.com/NVIDIA/OpenShell/issues/398) (CDI migration) — WSL2 is a concrete platform where legacy injection is broken and CDI is the only viable path
> 
> ## Agent Investigation
> Diagnosed using `openshell doctor` commands. Full diagnostic chain documented in #404.
> 
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)