### PR TITLE
fix(ci): check author_association before API calls in vouch gate

### DIFF
--- a/.github/workflows/vouch-check.yml
+++ b/.github/workflows/vouch-check.yml
@@ -19,12 +19,24 @@ jobs:
           script: |
             const author = context.payload.pull_request.user.login;
             const authorType = context.payload.pull_request.user.type;
+            const authorAssociation = context.payload.pull_request.author_association;
 
             // Skip bots (dependabot, renovate, github-actions, etc.).
             if (authorType === 'Bot') {
               console.log(`${author} is a bot. Skipping vouch check.`);
               return;
             }
+
+            // Check author_association from the webhook payload. This is set by
+            // GitHub itself and doesn't require extra token permissions, so it
+            // works reliably for org members even when their membership is private.
+            const trustedAssociations = ['MEMBER', 'OWNER', 'COLLABORATOR'];
+            if (trustedAssociations.includes(authorAssociation)) {
+              console.log(`${author} has author_association=${authorAssociation}. Skipping vouch check.`);
+              return;
+            }
+
+            // Fallback: explicit API checks in case author_association is unexpected.
 
             // Check org membership — members bypass the vouch gate.
             try {
@@ -33,7 +45,7 @@ jobs:
                 username: author,
               });
               if (status === 204 || status === 302) {
-                console.log(`${author} is an org member. Skipping vouch check.`);
+                console.log(`${author} is an org member (API). Skipping vouch check.`);
                 return;
               }
             } catch (e) {
@@ -50,7 +62,7 @@ jobs:
                 username: author,
               });
               if (status === 204) {
-                console.log(`${author} is a collaborator. Skipping vouch check.`);
+                console.log(`${author} is a collaborator (API). Skipping vouch check.`);
                 return;
               }
             } catch (e) {


### PR DESCRIPTION
## Summary

- Fixes the vouch-check workflow incorrectly closing PRs from NVIDIA org members (e.g. #430)
- Adds an `author_association` check from the webhook payload as the primary bypass, before the API calls that fail due to insufficient `GITHUB_TOKEN` permissions

## Related Issue

Fixes the false positive that closed #430

## Changes

- `.github/workflows/vouch-check.yml`: Read `author_association` from `context.payload.pull_request` and skip the vouch gate for `MEMBER`, `OWNER`, and `COLLABORATOR` associations. The existing `orgs.checkMembershipForUser` and `repos.checkCollaborator` API calls are kept as fallbacks.

### Root cause

The `GITHUB_TOKEN` only has `contents: read` and `pull-requests: write` permissions. The `orgs.checkMembershipForUser` API requires `read:org` scope to see non-public org members — a scope `GITHUB_TOKEN` doesn't support. When a member has private org membership, the API returns 404, the catch block swallows it (since it specifically ignores 404s), and the workflow falls through to closing the PR.

`author_association` is set server-side by GitHub on every webhook event and correctly reports `MEMBER` for org members regardless of public/private visibility, with no extra token permissions needed.

## Testing

- [x] Verified in PR #430 logs that the org membership API silently returned 404 for `Kh4L` despite being an org member
- [x] Confirmed `Kh4L` has `authorAssociation: MEMBER` in the PR metadata via `gh pr view`

## Checklist

- [x] Follows Conventional Commits format
- [x] No new dependencies introduced