### PR TITLE
fix(ci): use ORG_READ_TOKEN for org membership check in vouch gate

### DIFF
--- a/.github/workflows/vouch-check.yml
+++ b/.github/workflows/vouch-check.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Check if contributor is vouched
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.ORG_READ_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const author = context.payload.pull_request.user.login;
             const authorType = context.payload.pull_request.user.type;
@@ -26,27 +27,40 @@ jobs:
               return;
             }
 
-            // Fetch author_association via the REST API. The webhook payload
-            // field (context.payload.pull_request.author_association) is
-            // unreliable under pull_request_target — it can be absent or stale.
-            // The pulls.get endpoint only needs pull-requests permission, which
-            // we already have, and reliably returns MEMBER for org members even
-            // when their membership is private.
-            const trustedAssociations = ['MEMBER', 'OWNER', 'COLLABORATOR'];
+            // Check org membership. Requires a token with read:org scope
+            // (ORG_READ_TOKEN secret). The default GITHUB_TOKEN cannot see org
+            // membership, so author_association and orgs.checkMembershipForUser
+            // both return NONE/404 for private members.
             try {
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
+              const { status } = await github.rest.orgs.checkMembershipForUser({
+                org: context.repo.owner,
+                username: author,
               });
-              const association = pr.author_association;
-              console.log(`${author}: author_association=${association}`);
-              if (trustedAssociations.includes(association)) {
-                console.log(`${author} has author_association=${association}. Skipping vouch check.`);
+              if (status === 204 || status === 302) {
+                console.log(`${author} is an org member. Skipping vouch check.`);
                 return;
               }
             } catch (e) {
-              console.log(`Failed to fetch PR author_association: ${e.message}`);
+              if (e.status !== 404) {
+                console.log(`Org membership check error (status=${e.status}): ${e.message}`);
+              }
+            }
+
+            // Check collaborator status — direct collaborators bypass.
+            try {
+              const { status } = await github.rest.repos.checkCollaborator({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: author,
+              });
+              if (status === 204) {
+                console.log(`${author} is a repo collaborator. Skipping vouch check.`);
+                return;
+              }
+            } catch (e) {
+              if (e.status !== 404) {
+                console.log(`Collaborator check error (status=${e.status}): ${e.message}`);
+              }
             }
 
             // Check the VOUCHED.td file on the dedicated "vouched" branch.


### PR DESCRIPTION
## Summary

- The `GITHUB_TOKEN` fundamentally cannot determine org membership — `read:org` is not a configurable scope for it. Both `author_association` (via REST API) and `orgs.checkMembershipForUser` return `NONE`/404 for org members when called with the repo-scoped token.
- Uses an `ORG_READ_TOKEN` secret when available, falling back to `GITHUB_TOKEN`
- Also added `Kh4L` to `VOUCHED.td` on the `vouched` branch as an interim workaround so #431 can be reopened now

## Related Issue

Follow-up to #442 and #444. Fixes the false positive closing of #430 / #431.

## Changes

- `.github/workflows/vouch-check.yml`:
  - Pass `ORG_READ_TOKEN` (with `GITHUB_TOKEN` fallback) via `github-token` to `actions/github-script`
  - Restore `orgs.checkMembershipForUser` and `repos.checkCollaborator` checks — they work correctly with a token that has `read:org`
  - Add status codes to error logs for easier debugging

## Setup Required

Create a fine-grained PAT (or classic PAT) with **Organization > Members > Read** (`read:org`) permission, then add it as a repo secret named `ORG_READ_TOKEN`.

Until that secret exists, the workflow falls back to `GITHUB_TOKEN` and org members will need to be in `VOUCHED.td` to bypass the gate.

## Testing

- Confirmed via logs that `GITHUB_TOKEN` returns `author_association=NONE` for org member Kh4L (run 23254861242)
- Confirmed via local `gh api` (with `read:org` token) that the same endpoint returns `MEMBER`
- `Kh4L` added to `VOUCHED.td` for immediate unblocking

## Checklist

- [x] Follows Conventional Commits format
- [x] No new dependencies introduced