### PR TITLE
fix(ci): use env context instead of secrets in step-level if condition

### DIFF
--- a/.github/workflows/vouch-check.yml
+++ b/.github/workflows/vouch-check.yml
@@ -12,10 +12,12 @@ jobs:
   vouch-gate:
     if: github.repository_owner == 'NVIDIA'
     runs-on: ubuntu-latest
+    env:
+      ORG_READ_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
     steps:
       - name: Check org membership
         id: org-check
-        if: ${{ secrets.ORG_READ_TOKEN != '' }}
+        if: env.ORG_READ_TOKEN != ''
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.ORG_READ_TOKEN }}


### PR DESCRIPTION
## Summary

- The vouch-check workflow is broken on main — every run fails with `Unrecognized named-value: 'secrets'`
- The `secrets` context is not available in step-level `if` expressions in GitHub Actions, only in `with` and `env` blocks

## Changes

- Export `ORG_READ_TOKEN` to a job-level `env` var
- Check `env.ORG_READ_TOKEN != ''` in the step `if` instead of `secrets.ORG_READ_TOKEN != ''`

## Checklist

- [x] Follows Conventional Commits format
- [x] No new dependencies introduced