### PR TITLE
fix(ci): simplify dev release install instructions to use install.sh

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to test (e.g. devel, v1.2.3)"
+        description: "Release tag to test (e.g. dev, v1.2.3)"
         required: true
         type: string
   workflow_run:
@@ -115,7 +115,7 @@ jobs:
           else
             WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
             if [ "$WORKFLOW_NAME" = "Release Dev" ]; then
-              echo "tag=devel" >> "$GITHUB_OUTPUT"
+              echo "tag=dev" >> "$GITHUB_OUTPUT"
             elif [ "$WORKFLOW_NAME" = "Release Tag" ]; then
               TAG="${{ github.event.workflow_run.head_branch }}"
               if [ -z "$TAG" ]; then

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -305,10 +305,10 @@ jobs:
           retention-days: 5
 
   # ---------------------------------------------------------------------------
-  # Create / update the devel GitHub Release with CLI binaries and wheels
+  # Create / update the dev GitHub Release with CLI binaries and wheels
   # ---------------------------------------------------------------------------
-  release-devel:
-    name: Release Devel
+  release-dev:
+    name: Release Dev
     needs: [build-cli-linux, build-cli-macos, build-python-wheels]
     runs-on: build-amd64
     timeout-minutes: 10
@@ -335,7 +335,7 @@ jobs:
           sha256sum *.tar.gz *.whl > openshell-checksums-sha256.txt
           cat openshell-checksums-sha256.txt
 
-      - name: Prune stale wheel assets from devel release
+      - name: Prune stale wheel assets from dev release
         uses: actions/github-script@v7
         env:
           WHEEL_VERSION: ${{ needs.build-python-wheels.outputs.wheel_version }}
@@ -349,20 +349,20 @@ jobs:
             core.info(`WHEEL_VERSION: ${wheelVersion}`);
             core.info(`CURRENT_PREFIX: ${currentPrefix}`);
 
-            // Fetch the devel release
+            // Fetch the dev release
             let release;
             try {
-              release = await github.rest.repos.getReleaseByTag({ owner, repo, tag: 'devel' });
+              release = await github.rest.repos.getReleaseByTag({ owner, repo, tag: 'dev' });
             } catch (err) {
               if (err.status === 404) {
-                core.info('No existing devel release found; skipping wheel pruning.');
+                core.info('No existing dev release found; skipping wheel pruning.');
                 return;
               }
               throw err;
             }
 
             const assets = release.data.assets;
-            core.info(`=== Current devel release assets (${assets.length} total) ===`);
+            core.info(`=== Current dev release assets (${assets.length} total) ===`);
             for (const a of assets) {
               core.info(`  ${String(a.id).padStart(12)}  ${a.name}`);
             }
@@ -382,19 +382,19 @@ jobs:
             }
             core.info(`Summary: kept=${kept}, deleted=${deleted}`);
 
-      - name: Move devel tag
+      - name: Move dev tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -fa devel -m "Latest Devel" "${GITHUB_SHA}"
-          git push --force origin devel
+          git tag -fa dev -m "Latest Dev" "${GITHUB_SHA}"
+          git push --force origin dev
 
       - name: Create / update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           name: OpenShell Development Build
           prerelease: true
-          tag_name: devel
+          tag_name: dev
           target_commitish: ${{ github.sha }}
           body: |
             This build is automatically published on every commit to main that passes CI.
@@ -404,7 +404,7 @@ jobs:
             ### Quick install
 
             ```
-            curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | OPENSHELL_VERSION=devel sh
+            curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | OPENSHELL_VERSION=dev sh
             ```
 
           files: |
@@ -416,7 +416,7 @@ jobs:
 
   trigger-wheel-publish:
     name: Trigger Wheel Publish
-    needs: [compute-versions, build-python-wheels, release-devel]
+    needs: [compute-versions, build-python-wheels, release-dev]
     runs-on: [self-hosted, nv]
     timeout-minutes: 10
     steps:
@@ -442,7 +442,7 @@ jobs:
             -F "variables[PIPELINE_ACTION]=publish_wheels" \
             -F "variables[GITHUB_REPOSITORY]=${GITHUB_REPOSITORY}" \
             -F "variables[COMMIT_SHA]=${GITHUB_SHA}" \
-            -F "variables[RELEASE_TAG]=devel" \
+            -F "variables[RELEASE_TAG]=dev" \
             -F "variables[RELEASE_VERSION]=${RELEASE_VERSION}" \
             -F "variables[RELEASE_KIND]=dev" \
             -F "variables[WHEEL_FILENAMES]=${WHEEL_FILENAMES}" \


### PR DESCRIPTION
## Summary

Replace the verbose, `gh`-CLI-dependent install instructions in the dev release notes with a single `curl | sh` one-liner using the published `install.sh` script. This also removes the per-platform asset table since the install script handles platform detection automatically.

## Related Issue

Follows up on #416 which published the install script in release workflows.

## Changes

- Replaced multi-line `gh release download` shell snippet with `curl | OPENSHELL_VERSION=devel sh` one-liner
- Removed the per-platform assets table (the install script handles this)
- Changed "automatically built" to "automatically published" for clarity

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)