### PR TITLE
fix(docker): set migrations dir permissions to 755 on COPY

### DIFF
--- a/deploy/docker/Dockerfile.images
+++ b/deploy/docker/Dockerfile.images
@@ -168,7 +168,7 @@ WORKDIR /app
 COPY --from=gateway-builder /build/out/openshell-server /usr/local/bin/
 
 RUN mkdir -p /build/crates/openshell-server
-COPY crates/openshell-server/migrations /build/crates/openshell-server/migrations
+COPY --chmod=755 crates/openshell-server/migrations /build/crates/openshell-server/migrations
 
 USER openshell
 EXPOSE 8080


### PR DESCRIPTION
## Summary

Docker COPY preserves build-host file permissions. On hosts with a restrictive umask (e.g. 0027), the migrations directory is copied as 750 root:root, making it unreadable by the openshell user at runtime and causing the server to crash with a permission denied error on startup. Using `--chmod=755` ensures the directory is always world-readable regardless of build host umask.

## Related Issue

N/A

## Changes

- Added `--chmod=755` to the `COPY` instruction for the migrations directory in `deploy/docker/Dockerfile.images`

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)