### PR TITLE
refactor(proto): rename UpdateSettings to UpdateConfig for consistency with read path

### DIFF
--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -29,8 +29,8 @@ use openshell_core::proto::{
     GetSandboxPolicyStatusRequest, GetSandboxRequest, HealthRequest, ListProvidersRequest,
     ListSandboxPoliciesRequest, ListSandboxesRequest, PolicyStatus, Provider,
     RejectDraftChunkRequest, Sandbox, SandboxPhase, SandboxPolicy, SandboxSpec, SandboxTemplate,
-    SetClusterInferenceRequest, SettingScope, SettingValue, UpdateProviderRequest,
-    UpdateSettingsRequest, WatchSandboxRequest, setting_value,
+    SetClusterInferenceRequest, SettingScope, SettingValue, UpdateConfigRequest,
+    UpdateProviderRequest, WatchSandboxRequest, setting_value,
 };
 use openshell_core::settings::{self, SettingValueKind};
 use openshell_providers::{
@@ -3906,7 +3906,7 @@ pub async fn sandbox_policy_set_global(
 
     let mut client = grpc_client(server, tls).await?;
     let response = client
-        .update_settings(UpdateSettingsRequest {
+        .update_config(UpdateConfigRequest {
             name: String::new(),
             policy: Some(policy),
             setting_key: String::new(),
@@ -4105,7 +4105,7 @@ pub async fn gateway_setting_set(
 
     let mut client = grpc_client(server, tls).await?;
     let response = client
-        .update_settings(UpdateSettingsRequest {
+        .update_config(UpdateConfigRequest {
             name: String::new(),
             policy: None,
             setting_key: key.to_string(),
@@ -4138,7 +4138,7 @@ pub async fn sandbox_setting_set(
 
     let mut client = grpc_client(server, tls).await?;
     let response = client
-        .update_settings(UpdateSettingsRequest {
+        .update_config(UpdateConfigRequest {
             name: name.to_string(),
             policy: None,
             setting_key: key.to_string(),
@@ -4171,7 +4171,7 @@ pub async fn gateway_setting_delete(
 
     let mut client = grpc_client(server, tls).await?;
     let response = client
-        .update_settings(UpdateSettingsRequest {
+        .update_config(UpdateConfigRequest {
             name: String::new(),
             policy: None,
             setting_key: key.to_string(),
@@ -4204,7 +4204,7 @@ pub async fn sandbox_setting_delete(
 ) -> Result<()> {
     let mut client = grpc_client(server, tls).await?;
     let response = client
-        .update_settings(UpdateSettingsRequest {
+        .update_config(UpdateConfigRequest {
             name: name.to_string(),
             policy: None,
             setting_key: key.to_string(),
@@ -4261,7 +4261,7 @@ pub async fn sandbox_policy_set(
         .map_or(0, |r| r.version);
 
     let response = client
-        .update_settings(UpdateSettingsRequest {
+        .update_config(UpdateConfigRequest {
             name: name.to_string(),
             policy: Some(policy),
             setting_key: String::new(),

--- a/crates/openshell-cli/tests/ensure_providers_integration.rs
+++ b/crates/openshell-cli/tests/ensure_providers_integration.rs
@@ -319,10 +319,10 @@ impl OpenShell for TestOpenShell {
         )))
     }
 
-    async fn update_settings(
+    async fn update_config(
         &self,
-        _request: tonic::Request<openshell_core::proto::UpdateSettingsRequest>,
-    ) -> Result<Response<openshell_core::proto::UpdateSettingsResponse>, Status> {
+        _request: tonic::Request<openshell_core::proto::UpdateConfigRequest>,
+    ) -> Result<Response<openshell_core::proto::UpdateConfigResponse>, Status> {
         Err(Status::unimplemented("not implemented in test"))
     }
 

--- a/crates/openshell-cli/tests/mtls_integration.rs
+++ b/crates/openshell-cli/tests/mtls_integration.rs
@@ -221,10 +221,10 @@ impl OpenShell for TestOpenShell {
         )))
     }
 
-    async fn update_settings(
+    async fn update_config(
         &self,
-        _request: tonic::Request<openshell_core::proto::UpdateSettingsRequest>,
-    ) -> Result<Response<openshell_core::proto::UpdateSettingsResponse>, Status> {
+        _request: tonic::Request<openshell_core::proto::UpdateConfigRequest>,
+    ) -> Result<Response<openshell_core::proto::UpdateConfigResponse>, Status> {
         Err(Status::unimplemented("not implemented in test"))
     }
 

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -273,10 +273,10 @@ impl OpenShell for TestOpenShell {
         )))
     }
 
-    async fn update_settings(
+    async fn update_config(
         &self,
-        _request: tonic::Request<openshell_core::proto::UpdateSettingsRequest>,
-    ) -> Result<Response<openshell_core::proto::UpdateSettingsResponse>, Status> {
+        _request: tonic::Request<openshell_core::proto::UpdateConfigRequest>,
+    ) -> Result<Response<openshell_core::proto::UpdateConfigResponse>, Status> {
         Err(Status::unimplemented("not implemented in test"))
     }
 

--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -299,10 +299,10 @@ impl OpenShell for TestOpenShell {
         )))
     }
 
-    async fn update_settings(
+    async fn update_config(
         &self,
-        _request: tonic::Request<openshell_core::proto::UpdateSettingsRequest>,
-    ) -> Result<Response<openshell_core::proto::UpdateSettingsResponse>, Status> {
+        _request: tonic::Request<openshell_core::proto::UpdateConfigRequest>,
+    ) -> Result<Response<openshell_core::proto::UpdateConfigResponse>, Status> {
         Err(Status::unimplemented("not implemented in test"))
     }
 

--- a/crates/openshell-cli/tests/sandbox_name_fallback_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_name_fallback_integration.rs
@@ -231,10 +231,10 @@ impl OpenShell for TestOpenShell {
         )))
     }
 
-    async fn update_settings(
+    async fn update_config(
         &self,
-        _request: tonic::Request<openshell_core::proto::UpdateSettingsRequest>,
-    ) -> Result<Response<openshell_core::proto::UpdateSettingsResponse>, Status> {
+        _request: tonic::Request<openshell_core::proto::UpdateConfigRequest>,
+    ) -> Result<Response<openshell_core::proto::UpdateConfigResponse>, Status> {
         Err(Status::unimplemented("not implemented in test"))
     }
 

--- a/crates/openshell-sandbox/src/grpc_client.rs
+++ b/crates/openshell-sandbox/src/grpc_client.rs
@@ -11,7 +11,7 @@ use miette::{IntoDiagnostic, Result, WrapErr};
 use openshell_core::proto::{
     DenialSummary, GetInferenceBundleRequest, GetInferenceBundleResponse, GetSandboxConfigRequest,
     GetSandboxProviderEnvironmentRequest, PolicySource, PolicyStatus, ReportPolicyStatusRequest,
-    SandboxPolicy as ProtoSandboxPolicy, SubmitPolicyAnalysisRequest, UpdateSettingsRequest,
+    SandboxPolicy as ProtoSandboxPolicy, SubmitPolicyAnalysisRequest, UpdateConfigRequest,
     inference_client::InferenceClient, open_shell_client::OpenShellClient,
 };
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
@@ -126,7 +126,7 @@ async fn sync_policy_with_client(
     policy: &ProtoSandboxPolicy,
 ) -> Result<()> {
     client
-        .update_settings(UpdateSettingsRequest {
+        .update_config(UpdateConfigRequest {
             name: sandbox.to_string(),
             policy: Some(policy.clone()),
             setting_key: String::new(),

--- a/crates/openshell-server/src/grpc.rs
+++ b/crates/openshell-server/src/grpc.rs
@@ -30,7 +30,7 @@ use openshell_core::proto::{
     RevokeSshSessionRequest, RevokeSshSessionResponse, SandboxLogLine, SandboxPolicyRevision,
     SandboxResponse, SandboxStreamEvent, ServiceStatus, SettingScope, SettingValue, SshSession,
     SubmitPolicyAnalysisRequest, SubmitPolicyAnalysisResponse, UndoDraftChunkRequest,
-    UndoDraftChunkResponse, UpdateProviderRequest, UpdateSettingsRequest, UpdateSettingsResponse,
+    UndoDraftChunkResponse, UpdateConfigRequest, UpdateConfigResponse, UpdateProviderRequest,
     WatchSandboxRequest, open_shell_server::OpenShell,
 };
 use openshell_core::proto::{
@@ -1086,10 +1086,10 @@ impl OpenShell for OpenShellService {
     // Policy update handlers
     // -------------------------------------------------------------------
 
-    async fn update_settings(
+    async fn update_config(
         &self,
-        request: Request<UpdateSettingsRequest>,
-    ) -> Result<Response<UpdateSettingsResponse>, Status> {
+        request: Request<UpdateConfigRequest>,
+    ) -> Result<Response<UpdateConfigResponse>, Status> {
         let req = request.into_inner();
         let key = req.setting_key.trim();
         let has_policy = req.policy.is_some();
@@ -1158,7 +1158,7 @@ impl OpenShell for OpenShellService {
                             save_global_settings(self.state.store.as_ref(), &global_settings)
                                 .await?;
                         }
-                        return Ok(Response::new(UpdateSettingsResponse {
+                        return Ok(Response::new(UpdateConfigResponse {
                             version: u32::try_from(current.version).unwrap_or(0),
                             policy_hash: hash,
                             settings_revision: global_settings.revision,
@@ -1221,7 +1221,7 @@ impl OpenShell for OpenShellService {
                     save_global_settings(self.state.store.as_ref(), &global_settings).await?;
                 }
 
-                return Ok(Response::new(UpdateSettingsResponse {
+                return Ok(Response::new(UpdateConfigResponse {
                     version: u32::try_from(next_version).unwrap_or(0),
                     policy_hash: hash,
                     settings_revision: global_settings.revision,
@@ -1273,7 +1273,7 @@ impl OpenShell for OpenShellService {
                 save_global_settings(self.state.store.as_ref(), &global_settings).await?;
             }
 
-            return Ok(Response::new(UpdateSettingsResponse {
+            return Ok(Response::new(UpdateConfigResponse {
                 version: 0,
                 policy_hash: String::new(),
                 settings_revision: global_settings.revision,
@@ -1334,7 +1334,7 @@ impl OpenShell for OpenShellService {
                     .await?;
                 }
 
-                return Ok(Response::new(UpdateSettingsResponse {
+                return Ok(Response::new(UpdateConfigResponse {
                     version: 0,
                     policy_hash: String::new(),
                     settings_revision: sandbox_settings.revision,
@@ -1368,7 +1368,7 @@ impl OpenShell for OpenShellService {
                 .await?;
             }
 
-            return Ok(Response::new(UpdateSettingsResponse {
+            return Ok(Response::new(UpdateConfigResponse {
                 version: 0,
                 policy_hash: String::new(),
                 settings_revision: sandbox_settings.revision,
@@ -1424,7 +1424,7 @@ impl OpenShell for OpenShellService {
                 .map_err(|e| Status::internal(format!("backfill spec.policy failed: {e}")))?;
             info!(
                 sandbox_id = %sandbox_id,
-                "UpdateSettings: backfilled spec.policy from sandbox-discovered policy"
+                "UpdateConfig: backfilled spec.policy from sandbox-discovered policy"
             );
         }
 
@@ -1443,7 +1443,7 @@ impl OpenShell for OpenShellService {
         if let Some(ref current) = latest
             && current.policy_hash == hash
         {
-            return Ok(Response::new(UpdateSettingsResponse {
+            return Ok(Response::new(UpdateConfigResponse {
                 version: u32::try_from(current.version).unwrap_or(0),
                 policy_hash: hash,
                 settings_revision: 0,
@@ -1474,10 +1474,10 @@ impl OpenShell for OpenShellService {
             sandbox_id = %sandbox_id,
             version = next_version,
             policy_hash = %hash,
-            "UpdateSettings: new policy version persisted"
+            "UpdateConfig: new policy version persisted"
         );
 
-        Ok(Response::new(UpdateSettingsResponse {
+        Ok(Response::new(UpdateConfigResponse {
             version: u32::try_from(next_version).unwrap_or(0),
             policy_hash: hash,
             settings_revision: 0,
@@ -2474,7 +2474,7 @@ fn draft_chunk_record_to_proto(record: &DraftChunkRecord) -> Result<PolicyChunk,
 /// Merge a draft chunk's proposed rule into the current active sandbox policy.
 ///
 /// Returns `(new_version, policy_hash)`. This reuses the same persistence
-/// pattern as `update_settings`: compute hash, check for no-op,
+/// pattern as `update_config`: compute hash, check for no-op,
 /// persist a new revision, supersede older versions, and notify watchers.
 /// Maximum number of optimistic retry attempts for policy version conflicts.
 const MERGE_RETRY_LIMIT: usize = 5;
@@ -4908,7 +4908,7 @@ mod tests {
         };
         store.put_message(&sandbox).await.unwrap();
 
-        // Simulate what update_settings does when spec.policy is None:
+        // Simulate what update_config does when spec.policy is None:
         // backfill spec.policy with the new policy.
         let new_policy = ProtoSandboxPolicy {
             version: 1,

--- a/crates/openshell-server/tests/auth_endpoint_integration.rs
+++ b/crates/openshell-server/tests/auth_endpoint_integration.rs
@@ -549,10 +549,10 @@ impl openshell_core::proto::open_shell_server::OpenShell for TestOpenShell {
         ))
     }
 
-    async fn update_settings(
+    async fn update_config(
         &self,
-        _: tonic::Request<openshell_core::proto::UpdateSettingsRequest>,
-    ) -> Result<tonic::Response<openshell_core::proto::UpdateSettingsResponse>, tonic::Status> {
+        _: tonic::Request<openshell_core::proto::UpdateConfigRequest>,
+    ) -> Result<tonic::Response<openshell_core::proto::UpdateConfigResponse>, tonic::Status> {
         Err(tonic::Status::unimplemented("test"))
     }
 

--- a/crates/openshell-server/tests/edge_tunnel_auth.rs
+++ b/crates/openshell-server/tests/edge_tunnel_auth.rs
@@ -203,10 +203,10 @@ impl OpenShell for TestOpenShell {
         Ok(Response::new(ReceiverStream::new(rx)))
     }
 
-    async fn update_settings(
+    async fn update_config(
         &self,
-        _request: tonic::Request<openshell_core::proto::UpdateSettingsRequest>,
-    ) -> Result<Response<openshell_core::proto::UpdateSettingsResponse>, Status> {
+        _request: tonic::Request<openshell_core::proto::UpdateConfigRequest>,
+    ) -> Result<Response<openshell_core::proto::UpdateConfigResponse>, Status> {
         Err(Status::unimplemented("not implemented in test"))
     }
 

--- a/crates/openshell-server/tests/multiplex_integration.rs
+++ b/crates/openshell-server/tests/multiplex_integration.rs
@@ -171,10 +171,10 @@ impl OpenShell for TestOpenShell {
         Ok(Response::new(ReceiverStream::new(rx)))
     }
 
-    async fn update_settings(
+    async fn update_config(
         &self,
-        _request: tonic::Request<openshell_core::proto::UpdateSettingsRequest>,
-    ) -> Result<Response<openshell_core::proto::UpdateSettingsResponse>, Status> {
+        _request: tonic::Request<openshell_core::proto::UpdateConfigRequest>,
+    ) -> Result<Response<openshell_core::proto::UpdateConfigResponse>, Status> {
         Err(Status::unimplemented("not implemented in test"))
     }
 

--- a/crates/openshell-server/tests/multiplex_tls_integration.rs
+++ b/crates/openshell-server/tests/multiplex_tls_integration.rs
@@ -184,10 +184,10 @@ impl OpenShell for TestOpenShell {
         Ok(Response::new(ReceiverStream::new(rx)))
     }
 
-    async fn update_settings(
+    async fn update_config(
         &self,
-        _request: tonic::Request<openshell_core::proto::UpdateSettingsRequest>,
-    ) -> Result<Response<openshell_core::proto::UpdateSettingsResponse>, Status> {
+        _request: tonic::Request<openshell_core::proto::UpdateConfigRequest>,
+    ) -> Result<Response<openshell_core::proto::UpdateConfigResponse>, Status> {
         Err(Status::unimplemented("not implemented in test"))
     }
 

--- a/crates/openshell-server/tests/ws_tunnel_integration.rs
+++ b/crates/openshell-server/tests/ws_tunnel_integration.rs
@@ -197,10 +197,10 @@ impl OpenShell for TestOpenShell {
         Ok(Response::new(ReceiverStream::new(rx)))
     }
 
-    async fn update_settings(
+    async fn update_config(
         &self,
-        _request: tonic::Request<openshell_core::proto::UpdateSettingsRequest>,
-    ) -> Result<Response<openshell_core::proto::UpdateSettingsResponse>, Status> {
+        _request: tonic::Request<openshell_core::proto::UpdateConfigRequest>,
+    ) -> Result<Response<openshell_core::proto::UpdateConfigResponse>, Status> {
         Err(Status::unimplemented("not implemented in test"))
     }
 

--- a/crates/openshell-tui/src/lib.rs
+++ b/crates/openshell-tui/src/lib.rs
@@ -1923,7 +1923,7 @@ fn spawn_set_global_setting(app: &App, tx: mpsc::UnboundedSender<Event>) {
 
     tokio::spawn(async move {
         // Build the typed SettingValue from the validated input.
-        use openshell_core::proto::{SettingValue, UpdateSettingsRequest, setting_value};
+        use openshell_core::proto::{SettingValue, UpdateConfigRequest, setting_value};
 
         let value = match kind {
             openshell_core::settings::SettingValueKind::Bool => {
@@ -1951,7 +1951,7 @@ fn spawn_set_global_setting(app: &App, tx: mpsc::UnboundedSender<Event>) {
             }
         };
 
-        let req = UpdateSettingsRequest {
+        let req = UpdateConfigRequest {
             name: String::new(),
             policy: None,
             setting_key: key,
@@ -1960,8 +1960,7 @@ fn spawn_set_global_setting(app: &App, tx: mpsc::UnboundedSender<Event>) {
             global: true,
         };
 
-        let result =
-            tokio::time::timeout(Duration::from_secs(5), client.update_settings(req)).await;
+        let result = tokio::time::timeout(Duration::from_secs(5), client.update_config(req)).await;
 
         let event = match result {
             Ok(Ok(resp)) => Event::GlobalSettingSetResult(Ok(resp.into_inner().settings_revision)),
@@ -1984,9 +1983,9 @@ fn spawn_delete_global_setting(app: &App, tx: mpsc::UnboundedSender<Event>) {
     let mut client = app.client.clone();
 
     tokio::spawn(async move {
-        use openshell_core::proto::UpdateSettingsRequest;
+        use openshell_core::proto::UpdateConfigRequest;
 
-        let req = UpdateSettingsRequest {
+        let req = UpdateConfigRequest {
             name: String::new(),
             policy: None,
             setting_key: key,
@@ -1995,8 +1994,7 @@ fn spawn_delete_global_setting(app: &App, tx: mpsc::UnboundedSender<Event>) {
             global: true,
         };
 
-        let result =
-            tokio::time::timeout(Duration::from_secs(5), client.update_settings(req)).await;
+        let result = tokio::time::timeout(Duration::from_secs(5), client.update_config(req)).await;
 
         let event = match result {
             Ok(Ok(resp)) => {
@@ -2027,7 +2025,7 @@ fn spawn_set_sandbox_setting(app: &App, tx: mpsc::UnboundedSender<Event>) {
     let mut client = app.client.clone();
 
     tokio::spawn(async move {
-        use openshell_core::proto::{SettingValue, UpdateSettingsRequest, setting_value};
+        use openshell_core::proto::{SettingValue, UpdateConfigRequest, setting_value};
 
         let value = match kind {
             openshell_core::settings::SettingValueKind::Bool => {
@@ -2055,7 +2053,7 @@ fn spawn_set_sandbox_setting(app: &App, tx: mpsc::UnboundedSender<Event>) {
             }
         };
 
-        let req = UpdateSettingsRequest {
+        let req = UpdateConfigRequest {
             name,
             policy: None,
             setting_key: key,
@@ -2064,8 +2062,7 @@ fn spawn_set_sandbox_setting(app: &App, tx: mpsc::UnboundedSender<Event>) {
             global: false,
         };
 
-        let result =
-            tokio::time::timeout(Duration::from_secs(5), client.update_settings(req)).await;
+        let result = tokio::time::timeout(Duration::from_secs(5), client.update_config(req)).await;
 
         let event = match result {
             Ok(Ok(resp)) => Event::SandboxSettingSetResult(Ok(resp.into_inner().settings_revision)),
@@ -2092,9 +2089,9 @@ fn spawn_delete_sandbox_setting(app: &App, tx: mpsc::UnboundedSender<Event>) {
     let mut client = app.client.clone();
 
     tokio::spawn(async move {
-        use openshell_core::proto::UpdateSettingsRequest;
+        use openshell_core::proto::UpdateConfigRequest;
 
-        let req = UpdateSettingsRequest {
+        let req = UpdateConfigRequest {
             name,
             policy: None,
             setting_key: key,
@@ -2103,8 +2100,7 @@ fn spawn_delete_sandbox_setting(app: &App, tx: mpsc::UnboundedSender<Event>) {
             global: false,
         };
 
-        let result =
-            tokio::time::timeout(Duration::from_secs(5), client.update_settings(req)).await;
+        let result = tokio::time::timeout(Duration::from_secs(5), client.update_config(req)).await;
 
         let event = match result {
             Ok(Ok(resp)) => {

--- a/e2e/python/test_policy_validation.py
+++ b/e2e/python/test_policy_validation.py
@@ -126,7 +126,7 @@ def test_update_policy_rejects_immutable_fields(
     sandbox: Callable[..., Sandbox],
     sandbox_client: SandboxClient,
 ) -> None:
-    """UpdateSettings rejects removal of filesystem paths on a live sandbox.
+    """UpdateConfig rejects removal of filesystem paths on a live sandbox.
 
     Filesystem paths are enforced by Landlock at sandbox startup and cannot be
     removed after the fact. This test verifies that the server rejects updates
@@ -153,8 +153,8 @@ def test_update_policy_rejects_immutable_fields(
         )
 
         with pytest.raises(grpc.RpcError) as exc_info:
-            stub.UpdateSettings(
-                openshell_pb2.UpdateSettingsRequest(
+            stub.UpdateConfig(
+                openshell_pb2.UpdateConfigRequest(
                     name=sandbox_name,
                     policy=unsafe_policy,
                 )

--- a/e2e/python/test_sandbox_policy.py
+++ b/e2e/python/test_sandbox_policy.py
@@ -1156,8 +1156,8 @@ def test_live_policy_update_and_logs(
         initial_hash = status_resp.revision.policy_hash
 
         # --- LPU-2: Set the same policy -> no new version ---
-        update_resp = stub.UpdateSettings(
-            openshell_pb2.UpdateSettingsRequest(
+        update_resp = stub.UpdateConfig(
+            openshell_pb2.UpdateConfigRequest(
                 name=sandbox_name,
                 policy=policy_a,
             )
@@ -1169,8 +1169,8 @@ def test_live_policy_update_and_logs(
         assert update_resp.policy_hash == initial_hash
 
         # --- LPU-3: Push policy B -> new version ---
-        update_resp = stub.UpdateSettings(
-            openshell_pb2.UpdateSettingsRequest(
+        update_resp = stub.UpdateConfig(
+            openshell_pb2.UpdateConfigRequest(
                 name=sandbox_name,
                 policy=policy_b,
             )
@@ -1213,8 +1213,8 @@ def test_live_policy_update_and_logs(
         )
 
         # --- LPU-4: Push policy B again -> unchanged ---
-        update_resp = stub.UpdateSettings(
-            openshell_pb2.UpdateSettingsRequest(
+        update_resp = stub.UpdateConfig(
+            openshell_pb2.UpdateConfigRequest(
                 name=sandbox_name,
                 policy=policy_b,
             )
@@ -1306,8 +1306,8 @@ def test_live_policy_update_from_empty_network_policies(
         )
         initial_version = initial_status.revision.version
 
-        update_resp = stub.UpdateSettings(
-            openshell_pb2.UpdateSettingsRequest(
+        update_resp = stub.UpdateConfig(
+            openshell_pb2.UpdateConfigRequest(
                 name=sandbox_name,
                 policy=updated_policy,
             )

--- a/proto/openshell.proto
+++ b/proto/openshell.proto
@@ -61,8 +61,8 @@ service OpenShell {
       returns (openshell.sandbox.v1.GetGatewayConfigResponse);
 
   // Update settings or policy at sandbox or global scope.
-  rpc UpdateSettings(UpdateSettingsRequest)
-      returns (UpdateSettingsResponse);
+  rpc UpdateConfig(UpdateConfigRequest)
+      returns (UpdateConfigResponse);
 
   // Get the load status of a specific policy version.
   rpc GetSandboxPolicyStatus(GetSandboxPolicyStatusRequest)
@@ -440,7 +440,7 @@ message GetSandboxProviderEnvironmentResponse {
 // ---------------------------------------------------------------------------
 
 // Update sandbox policy request.
-message UpdateSettingsRequest {
+message UpdateConfigRequest {
   // Sandbox name (canonical lookup key). Required for sandbox-scoped updates.
   // Not required when `global=true`.
   string name = 1;
@@ -465,7 +465,7 @@ message UpdateSettingsRequest {
 }
 
 // Update sandbox policy response.
-message UpdateSettingsResponse {
+message UpdateConfigResponse {
   // Assigned policy version (monotonically increasing per sandbox).
   uint32 version = 1;
   // SHA-256 hash of the serialized policy payload.


### PR DESCRIPTION
## Summary

Renames the `UpdateSettings` RPC to `UpdateConfig` to match the read-side naming (`GetSandboxConfig`, `GetGatewayConfig`). The RPC handles both settings and policy mutations, so `UpdateConfig` is more accurate.

## Related Issue

Follow-up to #474 (PR review feedback)

## Changes

- Proto: `UpdateSettings` → `UpdateConfig`, `UpdateSettingsRequest/Response` → `UpdateConfigRequest/Response`
- Server: handler method `update_settings` → `update_config`
- CLI, TUI, sandbox, e2e (Rust + Python): all call sites and mock trait impls updated

Mechanical rename across 17 files, no behavioral changes.

## Testing

- [x] `cargo build` all affected crates
- [x] `cargo test -p openshell-server -p openshell-core` all passing
- [ ] E2E tests (running in CI)

## Checklist

- [x] Follows Conventional Commits
- [x] No behavioral changes