### PR TITLE
docs(providers): add Groq to the supported providers table

### DIFF
--- a/docs/sandboxes/manage-providers.md
+++ b/docs/sandboxes/manage-providers.md
@@ -155,6 +155,7 @@ The following providers have been tested with `inference.local`. Any provider th
 | Baseten | `baseten` | `openai` | `https://inference.baseten.co/v1` | `OPENAI_API_KEY` |
 | Bitdeer AI | `bitdeer` | `openai` | `https://api-inference.bitdeer.ai/v1` | `OPENAI_API_KEY` |
 | Deepinfra | `deepinfra` | `openai` | `https://api.deepinfra.com/v1/openai` | `OPENAI_API_KEY` |
+| Groq | `groq` | `openai` | `https://api.groq.com/openai/v1` | `OPENAI_API_KEY` |
 | Ollama (local) | `ollama` | `openai` | `http://host.openshell.internal:11434/v1` | `OPENAI_API_KEY` |
 | LM Studio (local) | `lmstudio` | `openai` | `http://host.openshell.internal:1234/v1` | `OPENAI_API_KEY` |
 


### PR DESCRIPTION
## Summary
Add Groq to the supported inference providers table in the documentation.

## Related Issue
This discussion https://github.com/NVIDIA/OpenShell/discussions/499

## Testing
- `mise run pre-commit`
- `mise run docs:serve`
<img width="1175" height="787" alt="image" src="https://github.com/user-attachments/assets/e77d003e-1bee-498d-9223-44001a656771" />


## Checklist
- [x] Docs updated
- [x] Tests pass