### PR TITLE
fix(docker): enable dev-settings feature by default in local builds

### DIFF
--- a/tasks/scripts/docker-build-image.sh
+++ b/tasks/scripts/docker-build-image.sh
@@ -159,8 +159,12 @@ else
   exit 1
 fi
 
+# Default to dev-settings so local builds include test-only settings
+# (dummy_bool, dummy_int) that e2e tests depend on, matching CI behaviour.
+EXTRA_CARGO_FEATURES="${EXTRA_CARGO_FEATURES:-openshell-core/dev-settings}"
+
 FEATURE_ARGS=()
-if [[ -n "${EXTRA_CARGO_FEATURES:-}" ]]; then
+if [[ -n "${EXTRA_CARGO_FEATURES}" ]]; then
   FEATURE_ARGS=(--build-arg "EXTRA_CARGO_FEATURES=${EXTRA_CARGO_FEATURES}")
 fi
 


### PR DESCRIPTION
## Summary

Local image builds (`mise run cluster`, `mise run docker:build:*`) were missing the `dev-settings` feature flag, causing e2e tests to fail with `unknown setting key 'dummy_bool'`. CI sets `EXTRA_CARGO_FEATURES=openshell-core/dev-settings` explicitly in `docker-build.yml`, but the local build path never did.

## Related Issue

No issue — discovered while running e2e tests locally after #474 landed.

## Changes

- `tasks/scripts/docker-build-image.sh`: Default `EXTRA_CARGO_FEATURES` to `openshell-core/dev-settings` when not already set by the caller. This matches CI behavior and ensures test-only settings (`dummy_bool`, `dummy_int`) are compiled into local builds.

The variable can still be overridden (`EXTRA_CARGO_FEATURES=foo mise run cluster`) or cleared (`EXTRA_CARGO_FEATURES="" mise run cluster`) if needed.

## Testing

- [x] Verified the script change applies the default correctly
- [ ] E2E tests require a cluster rebuild to validate end-to-end

## Checklist

- [x] Follows Conventional Commits
- [ ] Architecture docs updated (if applicable)