### PR TITLE
fix(docker): propagate OPENSHELL_IMAGE_TAG to cross-compile Dockerfiles

### DIFF
--- a/deploy/docker/Dockerfile.cli-macos
+++ b/deploy/docker/Dockerfile.cli-macos
@@ -103,9 +103,10 @@ RUN touch crates/openshell-cli/src/main.rs \
     crates/openshell-core/build.rs \
     proto/*.proto
 
-# Declare version ARG here (not earlier) so the git-hash-bearing value does not
+# Declare version ARGs here (not earlier) so the git-hash-bearing values do not
 # invalidate the expensive dependency-build layers above on every commit.
 ARG OPENSHELL_CARGO_VERSION
+ARG OPENSHELL_IMAGE_TAG
 RUN --mount=type=cache,id=cargo-registry-cli-macos,sharing=locked,target=/root/.cargo/registry \
     --mount=type=cache,id=cargo-git-cli-macos,sharing=locked,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-target-cli-macos-${CARGO_TARGET_CACHE_SCOPE},sharing=locked,target=/build/target \

--- a/deploy/docker/Dockerfile.python-wheels
+++ b/deploy/docker/Dockerfile.python-wheels
@@ -84,9 +84,10 @@ RUN touch crates/openshell-cli/src/main.rs \
     crates/openshell-core/build.rs \
     proto/*.proto
 
-# Declare version ARG here (not earlier) so the git-hash-bearing value does not
+# Declare version ARGs here (not earlier) so the git-hash-bearing values do not
 # invalidate the expensive dependency-build layers above on every commit.
 ARG OPENSHELL_CARGO_VERSION
+ARG OPENSHELL_IMAGE_TAG
 RUN --mount=type=cache,id=cargo-registry-python-wheels-${TARGETARCH},sharing=locked,target=/root/.cargo/registry \
     --mount=type=cache,id=cargo-git-python-wheels-${TARGETARCH},sharing=locked,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-target-python-wheels-${TARGETARCH}-${CARGO_TARGET_CACHE_SCOPE},sharing=locked,target=/build/target \

--- a/deploy/docker/Dockerfile.python-wheels-macos
+++ b/deploy/docker/Dockerfile.python-wheels-macos
@@ -91,9 +91,10 @@ RUN touch crates/openshell-cli/src/main.rs \
     crates/openshell-core/build.rs \
     proto/*.proto
 
-# Declare version ARG here (not earlier) so the git-hash-bearing value does not
+# Declare version ARGs here (not earlier) so the git-hash-bearing values do not
 # invalidate the expensive dependency-build layers above on every commit.
 ARG OPENSHELL_CARGO_VERSION
+ARG OPENSHELL_IMAGE_TAG
 RUN --mount=type=cache,id=cargo-registry-python-wheels-macos-${TARGETARCH},sharing=locked,target=/root/.cargo/registry \
     --mount=type=cache,id=cargo-git-python-wheels-macos-${TARGETARCH},sharing=locked,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-target-python-wheels-macos-${TARGETARCH}-${CARGO_TARGET_CACHE_SCOPE},sharing=locked,target=/build/target \


### PR DESCRIPTION
## Summary

Stable release binaries built via Docker cross-compilation (macOS CLI, Linux/macOS Python wheels) were baking `DEFAULT_IMAGE_TAG = "dev"` instead of the release semver. This caused these binaries to pull `dev`-tagged Docker images instead of the version-pinned stable images.

## Related Issue

N/A (discovered via investigation)

## Changes

- Added `ARG OPENSHELL_IMAGE_TAG` to `Dockerfile.cli-macos`, `Dockerfile.python-wheels`, and `Dockerfile.python-wheels-macos`
- The CI workflows and build scripts already pass `OPENSHELL_IMAGE_TAG` as a `--build-arg`, but without the `ARG` declaration in the Dockerfile, Docker silently drops it
- Rust's `option_env!("OPENSHELL_IMAGE_TAG")` reads the env at compile time; without the `ARG`, it gets `None` and falls back to `"dev"`

### Root Cause

`crates/openshell-bootstrap/src/image.rs` defines:
```rust
pub const DEFAULT_IMAGE_TAG: &str = match option_env!("OPENSHELL_IMAGE_TAG") {
    Some(tag) => tag,
    None => "dev",
};
```

Docker `ARG` values are available as env vars during `RUN` commands, but only if declared. The three affected Dockerfiles declared `ARG OPENSHELL_CARGO_VERSION` (for version patching) but not `ARG OPENSHELL_IMAGE_TAG` (for image tag baking).

### Affected Artifacts

| Build artifact | Was affected? | Build method |
|---|---|---|
| Linux CLI binary | No | Direct `cargo build` in CI container with env var set |
| macOS CLI binary | **Yes** | `Dockerfile.cli-macos` (missing `ARG`) |
| Linux Python wheels | **Yes** | `Dockerfile.python-wheels` (missing `ARG`) |
| macOS Python wheels | **Yes** | `Dockerfile.python-wheels-macos` (missing `ARG`) |

## Testing

- [x] `mise run pre-commit` passes (one unrelated test failure due to local port conflict)
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

The fix is a Dockerfile-only change with no runtime code changes. Verification requires a tagged release build to confirm the baked-in tag is correct.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)