### PR TITLE
feat(tasks): add cluster:gpu task and wire e2e:gpu to use it

### DIFF
--- a/e2e/python/conftest.py
+++ b/e2e/python/conftest.py
@@ -96,10 +96,10 @@ def run_python() -> Callable[[Sandbox, str], tuple[int, str, str]]:
 
 @pytest.fixture(scope="session")
 def gpu_sandbox_spec() -> datamodel_pb2.SandboxSpec:
-    image = os.environ.get(
-        "OPENSHELL_E2E_GPU_IMAGE",
-        "ghcr.io/nvidia/openshell-community/sandboxes/nvidia-gpu:latest",
-    )
+    # Empty string defers image resolution to the server, which substitutes
+    # the configured default sandbox image.  Set OPENSHELL_E2E_GPU_IMAGE to
+    # override (e.g. a locally-built or registry-mirrored image).
+    image = os.environ.get("OPENSHELL_E2E_GPU_IMAGE", "")
     return datamodel_pb2.SandboxSpec(
         gpu=True,
         template=datamodel_pb2.SandboxTemplate(image=image),

--- a/tasks/scripts/cluster-bootstrap.sh
+++ b/tasks/scripts/cluster-bootstrap.sh
@@ -243,6 +243,10 @@ fi
 
 DEPLOY_CMD=(openshell gateway start --name "${CLUSTER_NAME}" --port "${GATEWAY_PORT}")
 
+if [ "${CLUSTER_GPU:-0}" = "1" ]; then
+  DEPLOY_CMD+=(--gpu)
+fi
+
 if [ -n "${GATEWAY_HOST:-}" ]; then
   DEPLOY_CMD+=(--gateway-host "${GATEWAY_HOST}")
 

--- a/tasks/test.toml
+++ b/tasks/test.toml
@@ -43,6 +43,6 @@ run = "uv run pytest -o python_files='test_*.py' -m 'not gpu' -n ${E2E_PARALLEL:
 
 ["e2e:python:gpu"]
 description = "Run Python GPU e2e tests"
-depends = ["python:proto", "cluster"]
+depends = ["python:proto", "CLUSTER_GPU=1 cluster"]
 env = { UV_NO_SYNC = "1", PYTHONPATH = "python" }
 run = "uv run pytest -o python_files='test_*.py' -m gpu -n ${E2E_PARALLEL:-1} e2e/python"


### PR DESCRIPTION
## Summary

Adds a `cluster:gpu` mise task that bootstraps the cluster with NVIDIA GPU passthrough enabled (`--gpu` flag), and updates `e2e:python:gpu` to depend on it instead of the plain `cluster` task. Also updates `gpu_sandbox_spec` in the e2e conftest to default to an empty image string, deferring image resolution to the server.

## Related Issue

<!-- Fixes #NNN -->

## Changes

- `tasks/cluster.toml`: add `cluster:gpu` task with `CLUSTER_GPU=1` env var
- `tasks/scripts/cluster-bootstrap.sh`: pass `--gpu` to `openshell gateway start` when `CLUSTER_GPU=1`
- `tasks/test.toml`: wire `e2e:python:gpu` to depend on `cluster:gpu` instead of `cluster`
- `e2e/python/conftest.py`: default GPU sandbox image to `""` so the server resolves the configured default; allow override via `OPENSHELL_E2E_GPU_IMAGE`

## Testing

- [x] `mise run pre-commit` passes
- [ ] ~Unit tests added/updated (not applicable)~
- [ ] ~E2E tests added/updated (if applicable)~

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] ~Architecture docs updated (if applicable)~