### PR TITLE
perf(sandbox): streaming SHA256 and spawn_blocking for identity resolution

### DIFF
--- a/crates/openshell-sandbox/src/identity.rs
+++ b/crates/openshell-sandbox/src/identity.rs
@@ -17,6 +17,24 @@ use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
+fn perf_log(msg: &str) {
+    use std::io::Write;
+    for path in &["/var/log/openshell-perf.log", "/tmp/openshell-perf.log"] {
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default();
+            let _ = writeln!(f, "[{:.3}] {}", now.as_secs_f64(), msg);
+            return;
+        }
+    }
+    eprintln!("PERF_LOG_FALLBACK: {msg}");
+}
+
 #[derive(Clone)]
 struct FileFingerprint {
     len: u64,
@@ -100,6 +118,7 @@ impl BinaryIdentityCache {
     where
         F: FnMut(&Path) -> Result<String>,
     {
+        let start = std::time::Instant::now();
         let metadata = std::fs::metadata(path)
             .map_err(|error| miette::miette!("Failed to stat {}: {error}", path.display()))?;
         let fingerprint = FileFingerprint::from_metadata(&metadata);
@@ -114,10 +133,24 @@ impl BinaryIdentityCache {
         if let Some(cached_binary) = &cached
             && cached_binary.fingerprint == fingerprint
         {
+            perf_log(&format!(
+                "      verify_or_cache: {}ms CACHE HIT path={}",
+                start.elapsed().as_millis(), path.display()
+            ));
             return Ok(cached_binary.hash.clone());
         }
 
+        perf_log(&format!(
+            "      verify_or_cache: CACHE MISS size={} path={}",
+            metadata.len(), path.display()
+        ));
+
+        let hash_start = std::time::Instant::now();
         let current_hash = hash_file(path)?;
+        perf_log(&format!(
+            "      verify_or_cache SHA256: {}ms path={}",
+            hash_start.elapsed().as_millis(), path.display()
+        ));
 
         let mut hashes = self
             .hashes
@@ -142,6 +175,11 @@ impl BinaryIdentityCache {
                 fingerprint,
             },
         );
+
+        perf_log(&format!(
+            "      verify_or_cache TOTAL (cold): {}ms path={}",
+            start.elapsed().as_millis(), path.display()
+        ));
 
         Ok(current_hash)
     }

--- a/crates/openshell-sandbox/src/procfs.rs
+++ b/crates/openshell-sandbox/src/procfs.rs
@@ -11,6 +11,24 @@ use std::path::Path;
 #[cfg(target_os = "linux")]
 use std::path::PathBuf;
 
+fn perf_log(msg: &str) {
+    use std::io::Write;
+    for path in &["/var/log/openshell-perf.log", "/tmp/openshell-perf.log"] {
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default();
+            let _ = writeln!(f, "[{:.3}] {}", now.as_secs_f64(), msg);
+            return;
+        }
+    }
+    eprintln!("PERF_LOG_FALLBACK: {msg}");
+}
+
 /// Read the binary path of a process via `/proc/{pid}/exe` symlink.
 ///
 /// Returns the canonical path to the executable that the process is running.
@@ -48,9 +66,33 @@ pub fn resolve_tcp_peer_binary(entrypoint_pid: u32, peer_port: u16) -> Result<Pa
 /// Needed for the ancestor walk: we must know the PID to walk `/proc/<pid>/status` PPid chain.
 #[cfg(target_os = "linux")]
 pub fn resolve_tcp_peer_identity(entrypoint_pid: u32, peer_port: u16) -> Result<(PathBuf, u32)> {
+    let start = std::time::Instant::now();
+
+    let phase = std::time::Instant::now();
     let inode = parse_proc_net_tcp(entrypoint_pid, peer_port)?;
+    perf_log(&format!(
+        "    parse_proc_net_tcp: {}ms inode={}",
+        phase.elapsed().as_millis(), inode
+    ));
+
+    let phase = std::time::Instant::now();
     let pid = find_pid_by_socket_inode(inode, entrypoint_pid)?;
+    perf_log(&format!(
+        "    find_pid_by_socket_inode: {}ms pid={}",
+        phase.elapsed().as_millis(), pid
+    ));
+
+    let phase = std::time::Instant::now();
     let path = binary_path(pid.cast_signed())?;
+    perf_log(&format!(
+        "    binary_path: {}ms path={}",
+        phase.elapsed().as_millis(), path.display()
+    ));
+
+    perf_log(&format!(
+        "    resolve_tcp_peer_identity TOTAL: {}ms",
+        start.elapsed().as_millis()
+    ));
     Ok((path, pid))
 }
 
@@ -227,18 +269,32 @@ fn parse_proc_net_tcp(pid: u32, peer_port: u16) -> Result<u64> {
 /// `/proc/<pid>/fd/` for processes running as a different user.
 #[cfg(target_os = "linux")]
 fn find_pid_by_socket_inode(inode: u64, entrypoint_pid: u32) -> Result<u32> {
+    let start = std::time::Instant::now();
     let target = format!("socket:[{inode}]");
 
-    // First: scan descendants of the entrypoint process (targeted, most likely to succeed)
+    let phase = std::time::Instant::now();
     let descendants = collect_descendant_pids(entrypoint_pid);
+    perf_log(&format!(
+        "      collect_descendant_pids: {}ms count={}",
+        phase.elapsed().as_millis(), descendants.len()
+    ));
+
+    let phase = std::time::Instant::now();
     for &pid in &descendants {
         if let Some(found) = check_pid_fds(pid, &target) {
+            perf_log(&format!(
+                "      find_pid_by_socket_inode: {}ms found_pid={} scan=descendants",
+                start.elapsed().as_millis(), found
+            ));
             return Ok(found);
         }
     }
+    perf_log(&format!(
+        "      descendant_fd_scan (not found): {}ms",
+        phase.elapsed().as_millis()
+    ));
 
-    // Fallback: scan all of /proc in case the process isn't in the tree
-    // (e.g., if /proc/<pid>/task/<tid>/children wasn't available)
+    let phase = std::time::Instant::now();
     if let Ok(proc_dir) = std::fs::read_dir("/proc") {
         for entry in proc_dir.flatten() {
             let name = entry.file_name();
@@ -246,15 +302,22 @@ fn find_pid_by_socket_inode(inode: u64, entrypoint_pid: u32) -> Result<u32> {
                 Ok(p) => p,
                 Err(_) => continue,
             };
-            // Skip PIDs we already checked
             if descendants.contains(&pid) {
                 continue;
             }
             if let Some(found) = check_pid_fds(pid, &target) {
+                perf_log(&format!(
+                    "      find_pid_by_socket_inode: {}ms found_pid={} scan=full_proc",
+                    start.elapsed().as_millis(), found
+                ));
                 return Ok(found);
             }
         }
     }
+    perf_log(&format!(
+        "      full_proc_scan (not found): {}ms",
+        phase.elapsed().as_millis()
+    ));
 
     Err(miette::miette!(
         "No process found owning socket inode {} \
@@ -318,9 +381,28 @@ fn collect_descendant_pids(root_pid: u32) -> Vec<u32> {
 /// same hash, or the request is denied.
 pub fn file_sha256(path: &Path) -> Result<String> {
     use sha2::{Digest, Sha256};
+    use std::io::Read;
 
-    let bytes = std::fs::read(path).into_diagnostic()?;
-    let hash = Sha256::digest(&bytes);
+    let start = std::time::Instant::now();
+    let mut file = std::fs::File::open(path)
+        .map_err(|e| miette::miette!("Failed to open {}: {e}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 65536];
+    let mut total_read = 0u64;
+    loop {
+        let n = file.read(&mut buf).into_diagnostic()?;
+        if n == 0 {
+            break;
+        }
+        total_read += n as u64;
+        hasher.update(&buf[..n]);
+    }
+
+    let hash = hasher.finalize();
+    perf_log(&format!(
+        "        file_sha256: {}ms size={} path={}",
+        start.elapsed().as_millis(), total_read, path.display()
+    ));
     Ok(hex::encode(hash))
 }
 

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -20,6 +20,24 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
+fn perf_log(msg: &str) {
+    use std::io::Write;
+    for path in &["/var/log/openshell-perf.log", "/tmp/openshell-perf.log"] {
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default();
+            let _ = writeln!(f, "[{:.3}] {}", now.as_secs_f64(), msg);
+            return;
+        }
+    }
+    eprintln!("PERF_LOG_FALLBACK: {msg}");
+}
+
 const MAX_HEADER_BYTES: usize = 8192;
 const INFERENCE_LOCAL_HOST: &str = "inference.local";
 
@@ -336,15 +354,32 @@ async fn handle_tcp_connection(
     let peer_addr = client.peer_addr().into_diagnostic()?;
     let local_addr = client.local_addr().into_diagnostic()?;
 
-    // Evaluate OPA policy with process-identity binding
-    let decision = evaluate_opa_tcp(
-        peer_addr,
-        &opa_engine,
-        &identity_cache,
-        &entrypoint_pid,
-        &host_lc,
-        port,
-    );
+    let connect_start = std::time::Instant::now();
+    perf_log(&format!("handle_tcp_connection START host={host_lc} port={port}"));
+
+    // Evaluate OPA policy with process-identity binding.
+    // Wrapped in spawn_blocking because identity resolution does heavy sync I/O:
+    // /proc scanning + SHA256 hashing of binaries (e.g. node at 124MB).
+    let opa_clone = opa_engine.clone();
+    let cache_clone = identity_cache.clone();
+    let pid_clone = entrypoint_pid.clone();
+    let host_clone = host_lc.clone();
+    let decision = tokio::task::spawn_blocking(move || {
+        evaluate_opa_tcp(
+            peer_addr,
+            &opa_clone,
+            &cache_clone,
+            &pid_clone,
+            &host_clone,
+            port,
+        )
+    })
+    .await
+    .map_err(|e| miette::miette!("identity resolution task panicked: {e}"))?;
+    perf_log(&format!(
+        "handle_tcp_connection evaluate_opa_tcp: {}ms",
+        connect_start.elapsed().as_millis()
+    ));
 
     // Extract action string and matched policy for logging
     let (matched_policy, deny_reason) = match &decision.action {
@@ -421,6 +456,7 @@ async fn handle_tcp_connection(
     let raw_allowed_ips = query_allowed_ips(&opa_engine, &decision, &host_lc, port);
 
     // Defense-in-depth: resolve DNS and reject connections to internal IPs.
+    let dns_connect_start = std::time::Instant::now();
     let mut upstream = if !raw_allowed_ips.is_empty() {
         // allowed_ips mode: validate resolved IPs against CIDR allowlist.
         // Loopback and link-local are still always blocked.
@@ -496,6 +532,11 @@ async fn handle_tcp_connection(
             }
         }
     };
+
+    perf_log(&format!(
+        "handle_tcp_connection dns_resolve_and_tcp_connect: {}ms host={host_lc}",
+        dns_connect_start.elapsed().as_millis()
+    ));
 
     respond(&mut client, b"HTTP/1.1 200 Connection Established\r\n\r\n").await?;
 
@@ -701,7 +742,11 @@ fn evaluate_opa_tcp(
         );
     }
 
+    let total_start = std::time::Instant::now();
     let peer_port = peer_addr.port();
+    perf_log(&format!("evaluate_opa_tcp START host={host} port={port}"));
+
+    let phase_start = std::time::Instant::now();
     let (bin_path, binary_pid) = match crate::procfs::resolve_tcp_peer_identity(pid, peer_port) {
         Ok(r) => r,
         Err(e) => {
@@ -714,8 +759,14 @@ fn evaluate_opa_tcp(
             );
         }
     };
+    perf_log(&format!(
+        "  resolve_tcp_peer_identity: {}ms binary={} pid={}",
+        phase_start.elapsed().as_millis(),
+        bin_path.display(),
+        binary_pid
+    ));
 
-    // TOFU verify the immediate binary
+    let phase_start = std::time::Instant::now();
     let bin_hash = match identity_cache.verify_or_cache(&bin_path) {
         Ok(h) => h,
         Err(e) => {
@@ -728,12 +779,23 @@ fn evaluate_opa_tcp(
             );
         }
     };
+    perf_log(&format!(
+        "  tofu_verify_binary: {}ms binary={}",
+        phase_start.elapsed().as_millis(),
+        bin_path.display()
+    ));
 
-    // Walk the process tree upward to collect ancestor binaries
+    let phase_start = std::time::Instant::now();
     let ancestors = crate::procfs::collect_ancestor_binaries(binary_pid, pid);
+    perf_log(&format!(
+        "  collect_ancestor_binaries: {}ms count={}",
+        phase_start.elapsed().as_millis(),
+        ancestors.len()
+    ));
 
-    // TOFU verify each ancestor binary
+    let phase_start = std::time::Instant::now();
     for ancestor in &ancestors {
+        let ancestor_start = std::time::Instant::now();
         if let Err(e) = identity_cache.verify_or_cache(ancestor) {
             return deny(
                 format!(
@@ -746,14 +808,27 @@ fn evaluate_opa_tcp(
                 vec![],
             );
         }
+        perf_log(&format!(
+            "    tofu_verify_ancestor: {}ms ancestor={}",
+            ancestor_start.elapsed().as_millis(),
+            ancestor.display()
+        ));
     }
+    perf_log(&format!(
+        "  tofu_verify_all_ancestors: {}ms",
+        phase_start.elapsed().as_millis()
+    ));
 
-    // Collect cmdline paths for script-based binary detection.
-    // Excludes exe paths already captured in bin_path/ancestors to avoid duplicates.
+    let phase_start = std::time::Instant::now();
     let mut exclude = ancestors.clone();
     exclude.push(bin_path.clone());
     let cmdline_paths = crate::procfs::collect_cmdline_paths(binary_pid, pid, &exclude);
+    perf_log(&format!(
+        "  collect_cmdline_paths: {}ms",
+        phase_start.elapsed().as_millis()
+    ));
 
+    let phase_start = std::time::Instant::now();
     let input = NetworkInput {
         host: host.to_string(),
         port,
@@ -763,7 +838,7 @@ fn evaluate_opa_tcp(
         cmdline_paths: cmdline_paths.clone(),
     };
 
-    match engine.evaluate_network_action(&input) {
+    let result = match engine.evaluate_network_action(&input) {
         Ok(action) => ConnectDecision {
             action,
             binary: Some(bin_path),
@@ -778,7 +853,16 @@ fn evaluate_opa_tcp(
             ancestors,
             cmdline_paths,
         ),
-    }
+    };
+    perf_log(&format!(
+        "  opa_evaluate_network_action: {}ms",
+        phase_start.elapsed().as_millis()
+    ));
+    perf_log(&format!(
+        "evaluate_opa_tcp TOTAL: {}ms host={host} port={port}",
+        total_start.elapsed().as_millis()
+    ));
+    result
 }
 
 /// Non-Linux stub: OPA identity binding requires /proc.
@@ -1600,14 +1684,22 @@ async fn handle_forward_proxy(
     let peer_addr = client.peer_addr().into_diagnostic()?;
     let local_addr = client.local_addr().into_diagnostic()?;
 
-    let decision = evaluate_opa_tcp(
-        peer_addr,
-        &opa_engine,
-        &identity_cache,
-        &entrypoint_pid,
-        &host_lc,
-        port,
-    );
+    let opa_clone = opa_engine.clone();
+    let cache_clone = identity_cache.clone();
+    let pid_clone = entrypoint_pid.clone();
+    let host_clone = host_lc.clone();
+    let decision = tokio::task::spawn_blocking(move || {
+        evaluate_opa_tcp(
+            peer_addr,
+            &opa_clone,
+            &cache_clone,
+            &pid_clone,
+            &host_clone,
+            port,
+        )
+    })
+    .await
+    .map_err(|e| miette::miette!("identity resolution task panicked: {e}"))?;
 
     // Build log context
     let binary_str = decision


### PR DESCRIPTION
## Summary

The proxy's TOFU (Trust-On-First-Use) identity resolution performs synchronous `/proc` scanning and SHA256 hashing of binaries on every cold-cache network request. For large binaries like Node.js (~124 MB), this blocks the async Tokio runtime for nearly a second — stalling all concurrent connections — and allocates the entire file contents in memory just to hash them.

This PR fixes both issues:

- **Streaming SHA256**: Replace `std::fs::read()` + `Sha256::digest()` (which loads the full binary into RAM) with a 64 KB buffered streaming read+hash loop. For a 124 MB binary this eliminates a 124 MB heap allocation per cold-cache check.
- **`spawn_blocking` wrapper**: Wrap the entire `evaluate_opa_tcp()` call in `tokio::task::spawn_blocking()` in both `handle_tcp_connection` and `handle_forward_proxy`. The identity resolution does heavy synchronous I/O (`/proc` scanning, file hashing) that must not run on the async executor.
- **Profiling instrumentation**: Add a lightweight file-based `perf_log()` helper that writes timestamped phase timings to `/var/log/openshell-perf.log` (or `/tmp`), providing visibility into proxy latency without depending on the `tracing` pipeline.

## Context

Commit `f88aecf` ("avoid repeated TOFU rehashing for unchanged binaries") added fingerprint-based caching that made the **warm path** fast (0 ms TOFU, 11 ms total `evaluate_opa_tcp`). However:

1. The **cold path** still reads the entire binary into memory before hashing — a 124 MB allocation for Node.js.
2. The hashing and `/proc` I/O run synchronously on the Tokio runtime, blocking all other connections during the ~1 s cold-cache window.

## Profiling Data (Node.js binary, 124 MB)

| Phase | Cold cache | Warm cache |
|-------|-----------|------------|
| `file_sha256` | ~890 ms | 0 ms (fingerprint hit) |
| `evaluate_opa_tcp` total | 1002 ms | 11 ms |
| OPA evaluation | 1 ms | 1 ms |
| DNS + TCP connect | 166–437 ms | 166–437 ms |

## Files Changed

- `crates/openshell-sandbox/src/procfs.rs` — streaming SHA256 in `file_sha256()`, phase timing in `resolve_tcp_peer_identity()` and `find_pid_by_socket_inode()`
- `crates/openshell-sandbox/src/proxy.rs` — `spawn_blocking` wrapper around `evaluate_opa_tcp()` in both call sites, phase timing throughout
- `crates/openshell-sandbox/src/identity.rs` — phase timing in `verify_or_cache()`

## Test Plan

- [x] `cargo build --release` succeeds (cross-compiled for `x86_64-unknown-linux-gnu`)
- [x] Deployed to live NemoClaw sandbox and verified with `curl` and `node` requests through the proxy
- [x] Cold-cache: ~1 s total (dominated by SHA256 of 124 MB binary, now non-blocking)
- [x] Warm-cache: 11 ms total (fingerprint cache hit, unchanged from baseline)
- [x] No functional regressions — policy allow/deny decisions unchanged
- [ ] `cargo test -p openshell-sandbox` (existing identity and procfs tests)


Made with [Cursor](https://cursor.com)