### PR TITLE
feat(nix): add Nix flake for building, developing, and containerizing OpenShell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,9 @@ mise.local.toml
 # Ignore plans for now
 architecture/plans
 
+# Nix build output
+result
+
 # Claude
 .claude/settings.local.json.claude/worktrees/
 .claude/worktrees/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774286934,
+        "narHash": "sha256-9lflLKorBdcLw7fRTKnnCaW3pCu40ppmU0vrID2pG+o=",
+        "path": "/home/das/Downloads/n/nixpkgs",
+        "type": "path"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,93 @@
+# Quick start:
+#
+#   nix build                          Build all 3 binaries (openshell, openshell-server, openshell-sandbox)
+#   nix run                            Run openshell (default binary)
+#   nix run -- --help                  Show CLI help
+#   nix run -- --version               Show version
+#   nix develop                        Enter the dev shell (rustc, cargo, clippy, protoc, kubectl, helm, ...)
+#   nix develop -c cargo build         Run a single command inside the dev shell
+#   nix develop -c rustc --version     Check Rust version available in the dev shell
+#
+# Container:
+#
+#   nix build .#container              Build the OCI container image (creates ./result symlink)
+#   docker load < result               Load it into Docker
+#   docker run --rm openshell:0.0.0    Run container (default entrypoint shows help)
+#   docker run --rm -it --entrypoint /bin/bash openshell:0.0.0   Interactive shell
+#   docker image inspect openshell:0.0.0 --format='{{.Size}}'    Check uncompressed size
+#
+# Testing:
+#
+#   nix run .#container-test           Run 15 container smoke tests (requires Docker)
+#   nix flake check                    Run all checks (builds package + dev shell)
+#
+# Formatting:
+#
+#   nix fmt                            Format all Nix files
+#   nix fmt -- --check flake.nix nix/*.nix   Check formatting without modifying
+#
+{
+  description = "OpenShell — safe, sandboxed runtimes for autonomous AI agents";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # Pure data — no pkgs needed
+        constants = import ./nix/constants.nix;
+
+        # Source filters
+        sources = pkgs.callPackage ./nix/source-filter.nix { inherit constants; };
+
+        # OpenShell package (all workspace binaries)
+        openshell = pkgs.callPackage ./nix/package.nix {
+          inherit constants sources;
+        };
+
+        # OCI container image
+        container = pkgs.callPackage ./nix/container.nix {
+          inherit constants openshell;
+        };
+
+        # Container smoke-test script
+        container-test = pkgs.callPackage ./nix/container-test.nix {
+          inherit constants container;
+          docker = pkgs.docker-client;
+        };
+
+      in
+      {
+        packages = {
+          default = openshell;
+          inherit
+            openshell
+            container
+            container-test
+            ;
+        };
+
+        devShells.default = pkgs.callPackage ./nix/shell.nix {
+          inherit openshell;
+        };
+
+        formatter = pkgs.nixfmt;
+
+        checks = {
+          inherit openshell;
+          shell = self.devShells.${system}.default;
+        };
+      }
+    );
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,290 @@
+# OpenShell Nix Infrastructure
+
+Modular Nix flake for building, developing, and containerizing OpenShell.
+
+## What is Nix?
+
+[Nix](https://nixos.org) is a package manager that provides **reproducible, isolated**
+environments. It tracks all dependencies and pins exact versions so every developer
+gets the same toolchain. Nix packages live in `/nix/store/` and do not interfere
+with your system packages.
+
+## Quick Start
+
+### 1. Install Nix
+
+If you don't have Nix installed, grab it from <https://nixos.org/download/>.
+
+**Multi-user install** (recommended):
+
+```bash
+bash <(curl -L https://nixos.org/nix/install) --daemon
+```
+
+**Single-user install** (no root required):
+
+```bash
+bash <(curl -L https://nixos.org/nix/install) --no-daemon
+```
+
+### 2. Enable Flakes
+
+OpenShell uses Nix **flakes**, which are still marked "experimental" in Nix.
+
+**Per-command** (no config changes needed):
+
+```bash
+nix --extra-experimental-features 'nix-command flakes' develop
+```
+
+**Permanently** (recommended):
+
+```bash
+test -d /etc/nix || sudo mkdir /etc/nix
+echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
+```
+
+### 3. Build and Develop
+
+```bash
+# Enter dev shell with all build/lint/test tools
+nix develop
+
+# Build OpenShell (all 3 binaries: openshell, openshell-server, openshell-sandbox)
+nix build
+
+# Run the CLI
+nix run -- --version
+
+# Build OCI container image
+nix build .#container
+
+# Smoke-test the container (requires Docker daemon)
+nix run .#container-test
+
+# Format Nix files
+nix fmt
+```
+
+### First Run
+
+On the first run, Nix downloads and builds all dependencies. This can take
+5-15 minutes (protobuf-src compiles from C++ source). Subsequent runs reuse
+the cache in `/nix/store/` and are nearly instant.
+
+## Container Usage
+
+### Build and Load
+
+```bash
+nix build .#container
+docker load < result
+```
+
+### Run
+
+```bash
+# Default entrypoint shows help
+docker run --rm openshell:0.0.0
+
+# Interactive shell
+docker run --rm -it --entrypoint /bin/bash openshell:0.0.0
+```
+
+### Image Size
+
+| Metric | Size |
+|--------|------|
+| Compressed tarball (`result`) | ~48 MiB |
+| Uncompressed (Docker) | ~131 MiB |
+
+The image uses `dockerTools.buildLayeredImage` with 80 max layers. It is
+small because it only contains Rust static binaries, bash, coreutils, and
+CA certificates — no Python, Node.js, or other runtimes.
+
+### Smoke Test
+
+```bash
+# Build, load, and run structural checks (requires Docker daemon)
+nix run .#container-test
+```
+
+The test runs 15 structural checks. See [Tested Results](#tested-results) for the full list.
+
+## Architecture
+
+```text
+flake.nix                    # Coordinator — imports from ./nix/
+  |
+  +-- nix/constants.nix      # Pure data: version, user config, exclude patterns
+  +-- nix/source-filter.nix  # Filtered sources for reproducible builds
+  +-- nix/package.nix        # rustPlatform.buildRustPackage (workspace)
+  +-- nix/shell.nix          # Dev shell (mkShell + inputsFrom)
+  +-- nix/container.nix      # OCI image (dockerTools.buildLayeredImage)
+  +-- nix/container-test.nix # Container smoke tests (writeShellApplication)
+```
+
+### Module Dependencies
+
+```text
+constants.nix --+---> source-filter.nix ---> package.nix --+---> container.nix
+                |                                          |
+                +---> (all modules read constants)         +---> shell.nix
+```
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `constants.nix` | Shared config: version, user, exclude patterns |
+| `source-filter.nix` | `lib.cleanSourceWith` filter for Rust build files |
+| `package.nix` | `rustPlatform.buildRustPackage` for the whole workspace |
+| `shell.nix` | Dev shell via `mkShell` with `inputsFrom` |
+| `container.nix` | OCI image via `dockerTools.buildLayeredImage` |
+| `container-test.nix` | Container smoke tests via `writeShellApplication` |
+
+## Tested Results
+
+All outputs verified on Linux x86_64 (2026-03-23):
+
+| Command | Result |
+|---------|--------|
+| `nix build` | 3 binaries built in ~5 min (`openshell`, `openshell-server`, `openshell-sandbox`) |
+| `nix run -- --version` | `openshell 0.0.0` |
+| `nix develop -c rustc --version` | `rustc 1.94.0` with clippy, rustfmt, protoc, kubectl, helm, etc. |
+| `nix build .#container` | 48 MiB compressed tarball, 131 MiB uncompressed |
+| `docker load < result` | `Loaded image: openshell:0.0.0` |
+| `nix run .#container-test` | **15/15 checks passed** |
+| `nix fmt -- --check` | All Nix files formatted |
+
+### Container Smoke Test Checks (15/15)
+
+- `openshell`, `openshell-server`, `openshell-sandbox`, `bash` on PATH
+- `--version` works for all 3 binaries
+- Runs as uid 65532, gid 65532
+- `/etc/passwd` and `/etc/group` exist
+- Home directory exists and is writable
+- CA certs available at `/etc/ssl/certs/ca-bundle.crt`
+- Entrypoint contains `openshell`
+
+## Key Design Decisions
+
+- **`rustPlatform.buildRustPackage`** with `cargoLock.lockFile` — no manual hash updates
+- **Single package builds all 3 binaries** — workspace-wide `cargo build`
+- **`protobuf-src` compiles protoc from source** — needs `cmake` + C++ compiler (from `stdenv`)
+- **Minimal container** — Rust binaries are statically linked with rustls; only bash, coreutils, cacert needed
+- **Non-root container user** — uid/gid 65532
+- **Git version fallback** — `build.rs` gracefully falls back to `CARGO_PKG_VERSION` in Nix sandbox
+
+## Sandboxing: OpenShell vs Nix
+
+OpenShell and Nix both sandbox Linux processes using overlapping kernel primitives,
+but they solve fundamentally different problems. Nix isolates *builds* to guarantee
+reproducibility. OpenShell isolates *running AI agents* to enforce security policy
+at runtime. Neither subsumes the other.
+
+### What They Share
+
+Both systems use:
+
+- **Linux namespaces** — mount, PID, network, user (Nix uses all six; OpenShell uses mount, PID, network, and user)
+- **seccomp** — syscall filtering to reduce kernel attack surface
+- **Privilege dropping** — both run sandboxed processes as non-root
+- **Mount isolation** — restricted filesystem views via bind mounts and pivot_root (Nix) or mount namespaces (OpenShell)
+
+### Comparison
+
+| Dimension | Nix | OpenShell |
+|-----------|-----|-----------|
+| **Goal** | Reproducible builds — same inputs always produce same outputs | Runtime agent isolation — enforce what a running process can reach |
+| **When it runs** | Build time only | Runtime (long-lived agent sessions) |
+| **Network model** | Binary: full access (fixed-output derivations) or no access (normal builds) | Per-host, per-port, per-path policy via OPA/Rego; HTTP CONNECT proxy for egress |
+| **Filesystem model** | Curated `/nix/store` paths bind-mounted read-only; no access outside the closure | Landlock LSM restricts filesystem paths per-agent; policy-driven |
+| **Namespace usage** | 6 namespaces (mount, PID, network, user, UTS, IPC) + pivot_root + chroot | Mount, PID, network, user namespaces + Landlock + seccomp |
+| **Policy engine** | Hardcoded in C++ (`libstore/unix/build/`) | OPA/Rego policies, hot-reloadable at runtime (`openshell-policy` crate) |
+| **L7 inspection** | None | Optional TLS MITM via `openshell-sandbox` for HTTP request/response inspection |
+| **Process identity** | None beyond builder UID mapping | Per-process identity binding tracked across sandbox lifetime |
+| **Platform support** | Linux, macOS (Seatbelt), FreeBSD | Linux only |
+| **Infrastructure** | Just the Nix daemon | Kubernetes cluster, gRPC control plane, mTLS PKI |
+| **Maturity** | ~20 years, battle-tested across NixOS and CI farms | Young project, under active development |
+
+### Where Nix Is Stronger
+
+- **Simplicity.** The sandbox is binary: either the build has network access or it
+  does not. There is no policy language to learn, no proxy to configure, no MITM
+  certificates to manage.
+- **Cross-platform.** Nix sandboxes builds on Linux (namespaces), macOS (Seatbelt/sandbox-exec),
+  and FreeBSD. OpenShell's sandbox is Linux-only due to Landlock and seccompiler dependencies.
+- **Battle-tested.** Nix's sandbox has been hardened over ~20 years across thousands of
+  packages and CI systems. Edge cases around builder UID mapping, `/dev` access, and
+  store path isolation are well-understood.
+- **Zero infrastructure.** A single `nix-daemon` process is all you need. No cluster,
+  no control plane, no certificate authority.
+
+### Where OpenShell Is Stronger
+
+- **Granular network policy.** OpenShell can allow `api.example.com:443` on `GET /v1/models`
+  while blocking everything else. Nix's fixed-output derivations get unrestricted network
+  access — there is no middle ground.
+- **Runtime enforcement.** Policies apply to long-running agent processes, not just builds.
+  OpenShell can revoke access mid-session without restarting the sandbox.
+- **L7 visibility.** The HTTP CONNECT proxy in `openshell-sandbox` can inspect request
+  and response bodies, enabling content-based policy decisions. Nix has no equivalent.
+- **Hot-reloadable policies.** OPA/Rego policies can be updated without restarting the
+  sandbox. Nix's sandbox rules are compiled into the daemon.
+- **Process identity tracking.** OpenShell binds identity to individual processes within
+  a sandbox, enabling per-agent audit trails. Nix tracks builds, not individual processes.
+
+### Where Nix Is Weaker
+
+- **No granular network control.** Fixed-output derivations bypass the sandbox entirely
+  for network access. A compromised `fetchurl` derivation can reach any host.
+- **Build-time only.** Nix cannot enforce policy on running services or long-lived
+  processes. Once a build completes, the sandbox is gone.
+- **macOS sandbox is aging.** Nix's macOS sandbox uses Apple's `sandbox-exec` / Seatbelt
+  API, which Apple has deprecated. Future macOS releases may break it.
+
+### Where OpenShell Is Weaker
+
+- **Linux-only.** The `openshell-sandbox` crate depends on Landlock (Linux 5.13+) and
+  seccompiler. No macOS or FreeBSD support.
+- **Complexity.** The full stack involves OPA policy evaluation, an HTTP CONNECT proxy,
+  TOFU certificate pinning, optional TLS MITM, and a Kubernetes control plane. More
+  moving parts means more ways to misconfigure.
+- **Infrastructure requirements.** OpenShell needs a Kubernetes cluster, gRPC gateway,
+  and mTLS PKI. Nix needs a daemon.
+- **Young project.** OpenShell's sandbox has not been through the years of edge-case
+  hardening that Nix's has. Expect rough edges.
+
+### Summary
+
+Nix's sandbox is simple, cross-platform, and proven — ideal for hermetic builds where
+binary network access control is sufficient. OpenShell's sandbox trades that simplicity
+for granular, policy-driven runtime isolation — necessary when AI agents need controlled
+access to external services during execution, not just during builds.
+
+## Troubleshooting
+
+**"error: experimental Nix feature 'flakes' is disabled"**
+
+Enable flakes per-command or permanently (see above).
+
+**First build is slow (5-15 minutes)**
+
+Expected. Nix is compiling protobuf-src from C++ source plus all Rust dependencies.
+After the first build, everything is cached in `/nix/store/`.
+
+**Build fails on macOS**
+
+`openshell-sandbox` uses Linux-only crates (`landlock`, `seccompiler`). The workspace
+build may fail on macOS. Use Linux or restrict the build to specific crates.
+
+**"hash mismatch" or cargo lock errors**
+
+Make sure `Cargo.lock` is committed and up to date. Run `cargo update` if needed,
+then try `nix build` again.
+
+**Container test fails with "Cannot connect to the Docker daemon"**
+
+The `container-test` target requires a running Docker daemon. Make sure Docker
+is installed and your user is in the `docker` group.

--- a/nix/constants.nix
+++ b/nix/constants.nix
@@ -1,0 +1,34 @@
+# Shared configuration for all OpenShell Nix modules.
+# Pure data — no nixpkgs dependency.
+{
+  openshellVersion = "0.0.0";
+
+  # Container user (non-root)
+  user = {
+    name = "openshell";
+    group = "openshell";
+    uid = 65532;
+    gid = 65532;
+    home = "/home/openshell";
+    shell = "/bin/bash";
+  };
+
+  # Patterns excluded from the project source derivation (projectSrc).
+  # Only build artifacts and non-Rust files that don't affect the build.
+  excludePatterns = [
+    ".git"
+    "target"
+    "node_modules"
+    "__pycache__"
+    "nix"
+    "python"
+    "deploy"
+    "docs"
+    "e2e"
+    ".agents"
+    "architecture"
+    ".github"
+    ".vscode"
+    "result"
+  ];
+}

--- a/nix/container-test.nix
+++ b/nix/container-test.nix
@@ -1,0 +1,128 @@
+# Smoke-test script for the OpenShell OCI container.
+# Loads the image into Docker, runs structural checks, and reports results.
+#
+# Usage: nix run .#container-test
+{
+  writeShellApplication,
+  docker,
+  coreutils,
+  gawk,
+  constants,
+  container,
+}:
+
+writeShellApplication {
+  name = "openshell-container-test";
+
+  runtimeInputs = [
+    docker
+    coreutils
+    gawk
+  ];
+
+  text = ''
+    set -euo pipefail
+
+    IMAGE="openshell:${constants.openshellVersion}"
+    CONTAINER=""
+    PASS=0
+    FAIL=0
+
+    cleanup() {
+      if [ -n "$CONTAINER" ]; then
+        docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+      fi
+    }
+    trap cleanup EXIT
+
+    check() {
+      local desc="$1"; shift
+      if "$@" >/dev/null 2>&1; then
+        echo "  PASS  $desc"
+        PASS=$((PASS + 1))
+      else
+        echo "  FAIL  $desc"
+        FAIL=$((FAIL + 1))
+      fi
+    }
+
+    check_output() {
+      local desc="$1" expected="$2"; shift 2
+      local output
+      output=$("$@" 2>&1) || true
+      if echo "$output" | grep -qF "$expected"; then
+        echo "  PASS  $desc"
+        PASS=$((PASS + 1))
+      else
+        echo "  FAIL  $desc (expected '$expected', got '$output')"
+        FAIL=$((FAIL + 1))
+      fi
+    }
+
+    run_in() {
+      docker exec "$CONTAINER" bash -c "$1"
+    }
+
+    # ── Load image ──────────────────────────────────────────────
+    echo "Loading container image..."
+    docker load < ${container}
+
+    # ── Report image size ───────────────────────────────────────
+    echo ""
+    echo "=== Image Size ==="
+    docker image inspect "$IMAGE" --format='{{.Size}}' \
+      | awk '{ printf "  Uncompressed: %.0f MiB\n", $1/1024/1024 }'
+    TARBALL_SIZE=$(stat -c%s ${container})
+    echo "  Compressed tarball: $((TARBALL_SIZE / 1024 / 1024)) MiB"
+    echo ""
+
+    # ── Start container ─────────────────────────────────────────
+    echo "Starting container..."
+    CONTAINER=$(docker create --name openshell-nix-test --entrypoint /bin/bash "$IMAGE" -c "sleep 300")
+    docker start "$CONTAINER"
+
+    echo ""
+    echo "=== Structural Checks ==="
+
+    # Binaries present
+    check "openshell is on PATH"         run_in "command -v openshell"
+    check "openshell-server is on PATH"  run_in "command -v openshell-server"
+    check "openshell-sandbox is on PATH" run_in "command -v openshell-sandbox"
+    check "bash is on PATH"             run_in "command -v bash"
+
+    # Version output
+    check "openshell --version works"         run_in "openshell --version"
+    check "openshell-server --version works"  run_in "openshell-server --version"
+    check "openshell-sandbox --version works" run_in "openshell-sandbox --version"
+
+    # User/permissions
+    check_output "runs as uid ${toString constants.user.uid}" "${toString constants.user.uid}" run_in "id -u"
+    check_output "runs as gid ${toString constants.user.gid}" "${toString constants.user.gid}" run_in "id -g"
+
+    # passwd/group
+    check "/etc/passwd exists" run_in "test -f /etc/passwd"
+    check "/etc/group exists"  run_in "test -f /etc/group"
+
+    # Home directory
+    check "home dir exists"    run_in "test -d ${constants.user.home}"
+    check "home dir writable"  run_in "touch ${constants.user.home}/test && rm ${constants.user.home}/test"
+
+    # SSL certs
+    check "CA certs available" run_in "test -f /etc/ssl/certs/ca-bundle.crt"
+
+    # Entrypoint
+    check_output "entrypoint contains openshell" "openshell" \
+      docker inspect "$IMAGE" --format '{{join .Config.Entrypoint " "}}'
+
+    # ── Summary ─────────────────────────────────────────────────
+    echo ""
+    TOTAL=$((PASS + FAIL))
+    echo "=== Results: $PASS/$TOTAL passed ==="
+    if [ "$FAIL" -gt 0 ]; then
+      echo "FAILED: $FAIL check(s) did not pass."
+      exit 1
+    else
+      echo "All checks passed."
+    fi
+  '';
+}

--- a/nix/container.nix
+++ b/nix/container.nix
@@ -1,0 +1,72 @@
+# OCI container image via dockerTools.buildLayeredImage.
+# Minimal image: Rust binaries + bash + coreutils + CA certs.
+{
+  lib,
+  dockerTools,
+  writeTextFile,
+  bash,
+  coreutils,
+  cacert,
+  constants,
+  openshell,
+}:
+
+let
+  # Generate /etc/passwd and /etc/group entries
+  passwdEntry = ''
+    root:x:0:0:root:/root:/bin/bash
+    ${constants.user.name}:x:${toString constants.user.uid}:${toString constants.user.gid}:${constants.user.name}:${constants.user.home}:${constants.user.shell}
+  '';
+
+  groupEntry = ''
+    root:x:0:
+    ${constants.user.group}:x:${toString constants.user.gid}:
+  '';
+
+  passwd = writeTextFile {
+    name = "passwd";
+    text = passwdEntry;
+  };
+  group = writeTextFile {
+    name = "group";
+    text = groupEntry;
+  };
+
+in
+dockerTools.buildLayeredImage {
+  name = "openshell";
+  tag = constants.openshellVersion;
+  maxLayers = 80;
+
+  contents = [
+    bash
+    coreutils
+    cacert
+    openshell
+  ];
+
+  fakeRootCommands = ''
+    # /etc entries
+    mkdir -p ./etc
+    cp ${passwd} ./etc/passwd
+    cp ${group}  ./etc/group
+
+    # Home directory for non-root user
+    mkdir -p .${constants.user.home}
+    chown -R ${toString constants.user.uid}:${toString constants.user.gid} .${constants.user.home}
+  '';
+
+  config = {
+    Entrypoint = [
+      "${openshell}/bin/openshell"
+      "--help"
+    ];
+    Cmd = [ ];
+    User = "${toString constants.user.uid}:${toString constants.user.gid}";
+    WorkingDir = constants.user.home;
+    Env = [
+      "PATH=/usr/local/bin:/usr/bin:/bin:${lib.makeBinPath [ openshell ]}"
+      "SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt"
+    ];
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,41 @@
+# OpenShell workspace build — produces openshell, openshell-server, openshell-sandbox.
+{
+  lib,
+  rustPlatform,
+  cmake,
+  pkg-config,
+  constants,
+  sources,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "openshell";
+  version = constants.openshellVersion;
+  src = sources.projectSrc;
+
+  cargoLock.lockFile = sources.projectSrc + "/Cargo.lock";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  cargoBuildFlags = [ "--workspace" ];
+
+  # Tests require network access and a running cluster
+  doCheck = false;
+
+  postInstall = ''
+    # Verify all expected binaries were built
+    for bin in openshell openshell-server openshell-sandbox; do
+      test -x "$out/bin/$bin" || (echo "ERROR: $bin not found in $out/bin" && exit 1)
+    done
+  '';
+
+  meta = {
+    description = "OpenShell — safe, sandboxed runtimes for autonomous AI agents";
+    homepage = "https://github.com/NVIDIA/OpenShell";
+    license = lib.licenses.asl20;
+    mainProgram = "openshell";
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,72 @@
+# Dev shell with all build, lint, and test tools.
+{
+  mkShell,
+  rustc,
+  cargo,
+  clippy,
+  rustfmt,
+  cmake,
+  pkg-config,
+  protobuf,
+  git,
+  curl,
+  kubectl,
+  kubernetes-helm,
+  shellcheck,
+  shfmt,
+  hadolint,
+  ruff,
+  cargo-about,
+  syft,
+  openshell,
+}:
+
+mkShell {
+  # Inherit build dependencies from the openshell package
+  inputsFrom = [ openshell ];
+
+  packages = [
+    # Rust toolchain
+    rustc
+    cargo
+    clippy
+    rustfmt
+
+    # Build tools
+    cmake
+    pkg-config
+    protobuf
+
+    # Core
+    git
+    curl
+
+    # Kubernetes
+    kubectl
+    kubernetes-helm
+
+    # Linters / formatters
+    shellcheck
+    shfmt
+    hadolint
+    ruff
+
+    # Compliance
+    cargo-about
+    syft
+  ];
+
+  shellHook = ''
+    echo "OpenShell dev shell"
+    echo "  rustc:  $(rustc --version)"
+    echo "  cargo:  $(cargo --version)"
+    echo "  protoc: $(protoc --version)"
+    echo ""
+    echo "Quick start:"
+    echo "  cargo build              — build workspace"
+    echo "  cargo clippy             — lint"
+    echo "  cargo test               — run tests"
+    echo "  nix build                — reproducible build"
+    echo "  nix build .#container    — build OCI container"
+  '';
+}

--- a/nix/source-filter.nix
+++ b/nix/source-filter.nix
@@ -1,0 +1,26 @@
+# Reusable source filtering for OpenShell builds.
+# Keeps derivations from rebuilding when unrelated files change.
+{ lib, constants }:
+
+let
+  root = ./..;
+
+  # Filter that excludes patterns listed in constants.excludePatterns
+  excludeFilter =
+    path: _type:
+    let
+      baseName = baseNameOf (toString path);
+    in
+    !builtins.elem baseName constants.excludePatterns;
+
+  # Full project source minus excluded directories
+  projectSrc = lib.cleanSourceWith {
+    src = root;
+    filter = excludeFilter;
+    name = "openshell-source";
+  };
+
+in
+{
+  inherit projectSrc;
+}


### PR DESCRIPTION
## Summary

Hi there! This PR adds Nix flake support so that people on NixOS (and anyone using Nix) can build, develop, and containerize OpenShell directly.

We recently raised https://github.com/NVIDIA/NemoClaw/pull/727 which integrates OpenShell into NemoClaw — but in that repo we had to pull in the OpenShell container image rather than building it more directly. With this PR merged, NemoClaw (and other Nix-based projects) could build and use OpenShell as a native Nix dependency instead.

We'd love for this to be useful to the community. Feedback very welcome!

## What's Included

- `flake.nix` coordinates modular Nix files under `./nix/`
- Builds all 3 binaries (`openshell`, `openshell-server`, `openshell-sandbox`)
- Dev shell provides `rustc`, `cargo`, `clippy`, `rustfmt`, `protoc`, `kubectl`, `helm`
- OCI container image via `dockerTools` (~48 MiB compressed, ~131 MiB uncompressed, non-root)
- 15 container smoke tests via `nix run .#container-test`
- Source filtering for reproducible builds without `.git` or `target/`
- [README](nix/README.md) covers usage, architecture, tested results, and an honest sandboxing comparison between Nix and OpenShell
- `.gitignore` updated for `/result` symlink

## Quick Start

```bash
nix build                    # Build all 3 binaries
nix run -- --version         # Run openshell
nix develop                  # Enter dev shell
nix build .#container        # Build OCI container image
nix run .#container-test     # Run 15 smoke tests
```

Full details in [`nix/README.md`](nix/README.md).

## Related

- https://github.com/NVIDIA/NemoClaw/pull/727 — NemoClaw Nix integration (currently uses the OpenShell container; this PR would let it build OpenShell directly)

## Testing

- [x] `nix build` produces all 3 binaries
- [x] `nix run -- --version` outputs `openshell 0.0.0`
- [x] `nix develop -c rustc --version` confirms `rustc 1.94.0`
- [x] `nix build .#container` produces ~48 MiB compressed / ~131 MiB uncompressed image
- [x] `nix run .#container-test` passes 15/15 structural checks
- [x] `nix fmt -- --check` passes on all Nix files