### PR TITLE
fix(server): preserve credential key names in redacted provider responses

### DIFF
--- a/crates/openshell-server/src/grpc.rs
+++ b/crates/openshell-server/src/grpc.rs
@@ -3997,11 +3997,14 @@ fn hmac_sha256(key: &[u8], data: &[u8]) -> String {
 // Provider CRUD
 // ---------------------------------------------------------------------------
 
-/// Strip credential values from a provider before returning it in a gRPC
-/// response.  Internal server paths (inference routing, sandbox env injection)
-/// read credentials from the store directly and are unaffected.
+/// Redact credential values from a provider before returning it in a gRPC
+/// response.  Key names are preserved so callers can display credential counts
+/// and key listings.  Internal server paths (inference routing, sandbox env
+/// injection) read credentials from the store directly and are unaffected.
 fn redact_provider_credentials(mut provider: Provider) -> Provider {
-    provider.credentials.clear();
+    for value in provider.credentials.values_mut() {
+        *value = "REDACTED".to_string();
+    }
     provider
 }
 
@@ -4472,10 +4475,16 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(updated.id, provider_id);
-        // Credentials are redacted in responses.
-        assert!(
-            updated.credentials.is_empty(),
-            "credentials must be redacted in gRPC responses"
+        // Credential keys are preserved but values are redacted in responses.
+        assert_eq!(updated.credentials.len(), 2);
+        assert_eq!(
+            updated.credentials.get("API_TOKEN"),
+            Some(&"REDACTED".to_string()),
+            "credential values must be redacted in gRPC responses"
+        );
+        assert_eq!(
+            updated.credentials.get("SECONDARY"),
+            Some(&"REDACTED".to_string()),
         );
         // Verify the store still has full credentials.
         let stored: Provider = store
@@ -4581,8 +4590,12 @@ mod tests {
 
         assert_eq!(updated.id, persisted.id);
         assert_eq!(updated.r#type, "nvidia");
-        // Credentials are redacted in responses.
-        assert!(updated.credentials.is_empty());
+        // Credential keys are preserved but values are redacted in responses.
+        assert_eq!(updated.credentials.len(), 2);
+        assert_eq!(
+            updated.credentials.get("API_TOKEN"),
+            Some(&"REDACTED".to_string())
+        );
         assert_eq!(updated.config.len(), 2);
         assert_eq!(
             updated.config.get("endpoint"),
@@ -4621,8 +4634,13 @@ mod tests {
         .await
         .unwrap();
 
-        // Credentials are redacted in responses.
-        assert!(updated.credentials.is_empty());
+        // Credential keys are preserved but values are redacted; SECONDARY was deleted.
+        assert_eq!(updated.credentials.len(), 1);
+        assert_eq!(
+            updated.credentials.get("API_TOKEN"),
+            Some(&"REDACTED".to_string())
+        );
+        assert!(updated.credentials.get("SECONDARY").is_none());
         assert_eq!(updated.config.len(), 1);
         assert_eq!(
             updated.config.get("endpoint"),


### PR DESCRIPTION
## Summary

Fix `provider list` and `provider get` showing 0 credential keys by replacing `HashMap::clear()` with value-only redaction in `redact_provider_credentials`.

## Related Issue

Refs #350

## Changes

- `redact_provider_credentials` now iterates `values_mut()` and replaces each value with `"REDACTED"` instead of calling `credentials.clear()`
- Credential key names and counts are preserved in gRPC responses while secret values remain hidden
- Updated three unit tests to assert redacted values (`"REDACTED"`) instead of empty maps

## Root Cause

Commit `2d3e6432` (part of security hardening PR #548) added `redact_provider_credentials` with `credentials.clear()` to prevent credential values from leaking over the API. This correctly hid secrets but also destroyed key names and the key count, causing `provider list` to show `CREDENTIAL_KEYS: 0` and `provider get` to show `<none>` for credential keys.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests updated to verify redacted values
- [x] Verified on live cluster: `openshell provider list` now shows correct credential count

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)