### PR TITLE
fix(sandbox): track PTY state per SSH channel to fix terminal resize

### DIFF
--- a/crates/openshell-sandbox/src/ssh.rs
+++ b/crates/openshell-sandbox/src/ssh.rs
@@ -269,6 +269,7 @@ fn hmac_sha256(key: &[u8], data: &[u8]) -> String {
 /// sender.  This allows `window_change_request` to resize the correct PTY when
 /// multiple channels are open simultaneously (e.g. parallel shells, shell +
 /// sftp, etc.).
+#[derive(Default)]
 struct ChannelState {
     input_sender: Option<mpsc::Sender<Vec<u8>>>,
     pty_master: Option<std::fs::File>,
@@ -323,10 +324,21 @@ impl russh::server::Handler for SshHandler {
 
     async fn channel_open_session(
         &mut self,
-        _channel: russh::Channel<russh::server::Msg>,
+        channel: russh::Channel<russh::server::Msg>,
         _session: &mut Session,
     ) -> Result<bool, Self::Error> {
+        self.channels
+            .insert(channel.id(), ChannelState::default());
         Ok(true)
+    }
+
+    async fn channel_close(
+        &mut self,
+        channel: ChannelId,
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        self.channels.remove(&channel);
+        Ok(())
     }
 
     async fn channel_open_direct_tcpip(
@@ -398,12 +410,8 @@ impl russh::server::Handler for SshHandler {
     ) -> Result<(), Self::Error> {
         let state = self
             .channels
-            .entry(channel)
-            .or_insert_with(|| ChannelState {
-                input_sender: None,
-                pty_master: None,
-                pty_request: None,
-            });
+            .get_mut(&channel)
+            .ok_or_else(|| anyhow::anyhow!("pty_request on unknown channel {channel:?}"))?;
         state.pty_request = Some(PtyRequest {
             term: term.to_string(),
             col_width,
@@ -496,12 +504,8 @@ impl russh::server::Handler for SshHandler {
             )?;
             let state = self
                 .channels
-                .entry(channel)
-                .or_insert_with(|| ChannelState {
-                    input_sender: None,
-                    pty_master: None,
-                    pty_request: None,
-                });
+                .get_mut(&channel)
+                .ok_or_else(|| anyhow::anyhow!("subsystem_request on unknown channel {channel:?}"))?;
             state.input_sender = Some(input_sender);
         } else {
             warn!(subsystem = name, "unsupported subsystem requested");
@@ -564,12 +568,8 @@ impl SshHandler {
     ) -> anyhow::Result<()> {
         let state = self
             .channels
-            .entry(channel)
-            .or_insert_with(|| ChannelState {
-                input_sender: None,
-                pty_master: None,
-                pty_request: None,
-            });
+            .get_mut(&channel)
+            .ok_or_else(|| anyhow::anyhow!("start_shell on unknown channel {channel:?}"))?;
         if let Some(pty) = state.pty_request.take() {
             // PTY was requested — allocate a real PTY (interactive shell or
             // exec that explicitly asked for a terminal).
@@ -1512,13 +1512,11 @@ mod tests {
 
         let mut state_a = ChannelState {
             input_sender: Some(tx_a),
-            pty_master: None,
-            pty_request: None,
+            ..Default::default()
         };
         let state_b = ChannelState {
             input_sender: Some(tx_b),
-            pty_master: None,
-            pty_request: None,
+            ..Default::default()
         };
 
         // Send data to channel A only.


### PR DESCRIPTION
## Summary

Resolves #543 — terminal resize (`window_change_request`) was broken when multiple SSH channels were open simultaneously.

- Replace the flat `pty_master`/`input_sender`/`pty_request` fields in `SshHandler` with a `HashMap<ChannelId, ChannelState>`, ensuring each channel tracks its own PTY resources independently
- Fix `set_winsize` to pass a reference (`&winsize`) to `ioctl`, correcting undefined behaviour on aarch64
- Add error logging when `set_winsize` fails, rather than silently discarding the result

## Root Cause

The previous implementation stored a single `pty_master` file descriptor at the handler level. When a client opened multiple channels (e.g. parallel shells, shell + SFTP), `window_change_request` would resize whichever PTY was stored last — not the one belonging to the requesting channel.

```mermaid
graph TD
    subgraph "Before (broken)"
        A[Channel 0 — resize 80×24] --> B[SshHandler.pty_master]
        C[Channel 1 — resize 120×50] --> B
        B --> D["ioctl(TIOCSWINSZ) on last-stored FD"]
    end

    subgraph "After (fixed)"
        E[Channel 0 — resize 80×24] --> F["channels[0].pty_master"]
        G[Channel 1 — resize 120×50] --> H["channels[1].pty_master"]
        F --> I["ioctl(TIOCSWINSZ) on channel 0 FD"]
        H --> J["ioctl(TIOCSWINSZ) on channel 1 FD"]
    end
```

## Changes

| File | Change |
|------|--------|
| `crates/openshell-sandbox/src/ssh.rs` | Introduce `ChannelState` struct; migrate all per-channel fields into `HashMap<ChannelId, ChannelState>`; update `pty_request_request`, `window_change_request`, `data`, `channel_eof`, `subsystem_request`, and `spawn_shell_or_exec` to look up channel state by ID |

## Test Plan

- [x] `cargo test -p openshell-sandbox` — 319 passed (1 pre-existing failure in `drop_privileges`, unrelated)
- [x] New test: `set_winsize_applies_to_correct_pty` — verifies two PTYs can be resized independently
- [x] New test: `channel_state_independent_input_senders` — verifies data routing and EOF isolation between channels

```mermaid
sequenceDiagram
    participant Client
    participant SshHandler
    participant Channel0
    participant Channel1

    Client->>SshHandler: pty_request(channel=0, 80×24)
    SshHandler->>Channel0: store PTY master + request

    Client->>SshHandler: pty_request(channel=1, 120×50)
    SshHandler->>Channel1: store PTY master + request

    Client->>SshHandler: window_change(channel=0, 132×43)
    SshHandler->>Channel0: ioctl(TIOCSWINSZ, 132×43)
    Note over Channel1: unaffected

    Client->>SshHandler: channel_eof(channel=0)
    SshHandler->>Channel0: drop input_sender
    Note over Channel1: still functional
```