### PR TITLE
fix(ci): heading-level mismatch in agent dianostic regex

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -23,7 +23,7 @@ jobs:
             // The template placeholder starts with "Example:" — if that's still
             // there or the section is empty, the reporter didn't fill it in.
             const diagnosticMatch = body.match(
-              /## Agent Diagnostic\s*\n([\s\S]*?)(?=\n## |\n$)/
+              /### Agent Diagnostic\s*\n([\s\S]*?)(?=\n### |\n$)/
             );
 
             const hasSubstantiveDiagnostic = diagnosticMatch


### PR DESCRIPTION
## Summary

Fix a false-positive condition in the issue-triage workflow where all bug reports submitted via the GitHub form template were incorrectly flagged with `state:triage-needed`, even when fully compliant with the agent-first requirement.

## Related Issue

Fixes #603

## Changes

- Updated `.github/workflows/issue-triage.yml` to search for `### Agent Diagnostic` (H3) instead of `## Agent Diagnostic` (H2)
- GitHub form templates always render textarea field labels as H3 headings regardless of template configuration; the workflow regex was searching for H2, causing every form submission to be flagged as missing an agent diagnostic

## Testing

The workflow now correctly recognizes the Agent Diagnostic section in form-submitted issues and only applies `state:triage-needed` when the section is actually empty or contains only the placeholder text.

## Checklist

- [x] Follows Conventional Commits format
- [x] No breaking changes
- [x] Related issue is referenced