### PR TITLE
fix(sandbox): remove double response relay in passthrough credential path

### DIFF
--- a/crates/openshell-sandbox/src/l7/relay.rs
+++ b/crates/openshell-sandbox/src/l7/relay.rs
@@ -275,16 +275,14 @@ where
             "HTTP_REQUEST",
         );
 
-        // Forward request with credential rewriting.
-        let keep_alive =
+        // Forward request with credential rewriting and relay the response.
+        // relay_http_request_with_resolver handles both directions: it sends
+        // the request upstream and reads the response back to the client.
+        let reusable =
             crate::l7::rest::relay_http_request_with_resolver(&req, client, upstream, resolver)
                 .await?;
 
-        // Relay response back to client.
-        let reusable =
-            crate::l7::rest::relay_response_to_client(upstream, client, &req.action).await?;
-
-        if !keep_alive || !reusable {
+        if !reusable {
             break;
         }
     }


### PR DESCRIPTION
## Summary

- Fixes a deadlock in `relay_passthrough_with_credentials` that caused all HTTP/1.1 keep-alive clients (e.g. `npm install`) to hang indefinitely when proxied through the sandbox without L7 rules configured.

## Related Issue

None — discovered during live debugging of `npm install` hanging inside a sandbox.

## Changes

`relay_passthrough_with_credentials` called `relay_http_request_with_resolver` (which internally relays the upstream response back to the client via `relay_response` at `rest.rs:194`) and then immediately called `relay_response_to_client` a second time. The second call blocked forever waiting for a response that would never arrive because the upstream was waiting for the next request — deadlocking every CONNECT tunnel after its first request/response pair.

The fix removes the duplicate `relay_response_to_client` call and uses the reusable flag already returned by `relay_http_request_with_resolver`. This matches how `relay_rest` (the L7-inspection path) already works correctly.

The now-unused `relay_response_to_client` function becomes dead code (confirmed by compiler warning).

## Testing

- All 99 existing L7 unit tests pass (`cargo test -p openshell-sandbox --lib l7`)
- Verified manually: `npm install -g openclaw@latest` completes successfully in a sandbox after the fix
- Compiler confirms `relay_response_to_client` is now unused, proving it was only called from the buggy site

## Checklist

- [x] Tests pass locally
- [x] No unrelated changes
- [x] Commit message follows Conventional Commits