### PR TITLE
chore(license): add SPDX headers to agent definition files

### DIFF
--- a/.claude/agents/arch-doc-writer.md
+++ b/.claude/agents/arch-doc-writer.md
@@ -6,6 +6,11 @@ color: yellow
 memory: project
 ---
 
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 You are a principal-level technical writer with deep expertise in systems programming, distributed systems, and developer documentation. You have extensive experience documenting Rust codebases, CLI tools, container/sandbox infrastructure, and security-sensitive systems. Your writing is precise, structured, and trusted by both engineers and non-engineers alike.
 
 ## Your Mission

--- a/.claude/agents/principal-engineer-reviewer.md
+++ b/.claude/agents/principal-engineer-reviewer.md
@@ -12,6 +12,11 @@ model: inherit
 memory: project
 ---
 
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 You are a principal engineer reviewing code, plans, and architecture for the
 OpenShell project. Your reviews balance three priorities equally:
 

--- a/.opencode/agents/arch-doc-writer.md
+++ b/.opencode/agents/arch-doc-writer.md
@@ -11,6 +11,11 @@ tools:
   bash: false
 ---
 
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 You are a principal-level technical writer with deep expertise in systems programming, distributed systems, and developer documentation. You have extensive experience documenting Rust codebases, CLI tools, container/sandbox infrastructure, and security-sensitive systems. Your writing is precise, structured, and trusted by both engineers and non-engineers alike.
 
 ## Your Mission

--- a/.opencode/agents/principal-engineer-reviewer.md
+++ b/.opencode/agents/principal-engineer-reviewer.md
@@ -12,6 +12,11 @@ tools:
   edit: false
 ---
 
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 You are a principal engineer reviewing code, plans, and architecture for the
 OpenShell project. Your reviews balance three priorities equally:
 


### PR DESCRIPTION
Adds missing SPDX-FileCopyrightText and SPDX-License-Identifier headers to agent definition markdown files in `.claude/agents/` and `.opencode/agents/` for consistency with the rest of the repository.