### PR TITLE
fix(sandbox): strip query string from L7 path matching

### DIFF
--- a/docs/reference/policy-schema.md
+++ b/docs/reference/policy-schema.md
@@ -198,6 +198,12 @@ Used when `access` is not set. Each rule explicitly allows a method and path com
 | `allow.path` | string | Yes | URL path pattern. Supports `*` and `**` glob syntax. |
 | `allow.query` | map | No | Query parameter matchers keyed by decoded param name. Matcher value can be a glob string (`tag: "foo-*"`) or an object with `any` (`tag: { any: ["foo-*", "bar-*"] }`). |
 
+**Path matching behavior:**
+
+- Path rules match only the path component of the request URI (everything before `?`).
+- Query strings are not evaluated by path rules. A rule with `path: /api/v1/download` matches both `/api/v1/download` and `/api/v1/download?slug=my-skill&version=1.0`.
+- Glob patterns use `/` as the segment delimiter. `*` matches within a single segment, `**` matches across segments.
+
 Example with rules:
 
 ```yaml


### PR DESCRIPTION
## Summary

Fix L7 policy path matching to ignore query strings, so exact path rules like `path: /api/v1/download` correctly match requests with query parameters (e.g., `/api/v1/download?slug=foo&version=1.0`).

## Related Issue

Refs: https://github.com/NVIDIA/OpenShell/discussions/607

## Changes

- Add `query` field to `L7Request` and `L7RequestInfo` structs to hold the query string separately from the path
- Split request target into path and query components during HTTP parsing in `parse_http_request`
- Pass query string to Rego input for future query parameter filtering support (Part 2)
- Add `l7_query` field to L7_REQUEST log output for observability
- Add unit tests for query string splitting in HTTP parser
- Add OPA engine tests for path matching with query parameters
- Document path matching behavior in policy-schema.md reference

## Testing

Smoke tested locally with httpbin.org:

| Test | Request | Expected | Result |
|------|---------|----------|--------|
| 1 | `GET /get` | ALLOW | ✓ |
| 2 | `GET /get?foo=bar&baz=qux` | ALLOW | ✓ |
| 3 | `GET /headers` | ALLOW | ✓ |
| 4 | `GET /anything` | DENY | ✓ |
| 5 | `GET /anything?test=1` | DENY | ✓ |

- [x] `mise run pre-commit` passes (excluding pre-existing license issues)
- [x] Unit tests added/updated (7 new tests)
- [ ] E2E tests added/updated (not applicable - behavior change is backwards compatible)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (policy-schema.md)