### PR TITLE
feat(inference): multi-route proxy with alias-based model routing

### DIFF
--- a/architecture/inference-routing.md
+++ b/architecture/inference-routing.md
@@ -21,8 +21,9 @@ sequenceDiagram
     Agent->>Proxy: CONNECT inference.local:443
     Proxy->>Proxy: TLS terminate (MITM)
     Proxy->>Proxy: Parse HTTP, detect pattern
-    Proxy->>Router: proxy_with_candidates()
-    Router->>Router: Select route by protocol
+    Proxy->>Proxy: Extract model hint from body
+    Proxy->>Router: proxy_with_candidates(model_hint)
+    Router->>Router: Select route by alias or protocol
     Router->>Router: Rewrite auth + model
     Router->>Backend: HTTPS request
     Backend->>Router: Response headers + body stream
@@ -41,15 +42,16 @@ File: `crates/openshell-core/src/inference.rs`
 
 `InferenceProviderProfile` is the single source of truth for provider-specific inference knowledge: default endpoint, supported protocols, credential key lookup order, auth header style, and default headers.
 
-Three profiles are defined:
+Four profiles are defined:
 
 | Provider | Default Base URL | Protocols | Auth | Default Headers |
-|----------|-----------------|-----------|------|-----------------|
+|----------|-----------------|-----------|------|------------------|
 | `openai` | `https://api.openai.com/v1` | `openai_chat_completions`, `openai_completions`, `openai_responses`, `model_discovery` | `Authorization: Bearer` | (none) |
 | `anthropic` | `https://api.anthropic.com/v1` | `anthropic_messages`, `model_discovery` | `x-api-key` | `anthropic-version: 2023-06-01` |
 | `nvidia` | `https://integrate.api.nvidia.com/v1` | `openai_chat_completions`, `openai_completions`, `openai_responses`, `model_discovery` | `Authorization: Bearer` | (none) |
+| `ollama` | `http://host.openshell.internal:11434` | `ollama_chat`, `ollama_model_discovery`, `openai_chat_completions`, `openai_completions`, `model_discovery` | `Authorization: Bearer` | (none) |
 
-Each profile also defines `credential_key_names` (e.g. `["OPENAI_API_KEY"]`) and `base_url_config_keys` (e.g. `["OPENAI_BASE_URL"]`) used by the gateway to resolve credentials and endpoint overrides from provider records.
+Each profile also defines `credential_key_names` (e.g. `["OPENAI_API_KEY"]`) and `base_url_config_keys` (e.g. `["OPENAI_BASE_URL"]`) used by the gateway to resolve credentials and endpoint overrides from provider records. The Ollama profile uses `OLLAMA_API_KEY` for credentials and checks both `OLLAMA_BASE_URL` and `OLLAMA_HOST` for endpoint overrides. Its default endpoint uses `host.openshell.internal` so sandboxes can reach an Ollama instance running on the gateway host.
 
 Unknown provider types return `None` from `profile_for()` and default to `Bearer` auth with no default headers via `auth_for_provider_type()`.
 
@@ -70,7 +72,19 @@ The gateway implements the `Inference` gRPC service defined in `proto/inference.
 5. Builds a managed route spec that stores only `provider_name` and `model_id`. The spec intentionally leaves `base_url`, `api_key`, and `protocols` empty -- these are resolved dynamically at bundle time from the provider record.
 6. Upserts the route with name `inference.local`. Version starts at 1 and increments monotonically on each update.
 
-`GetClusterInference` returns `provider_name`, `model_id`, and `version` for the managed route. Returns `NOT_FOUND` if cluster inference is not configured.
+`GetClusterInference` returns `provider_name`, `model_id`, `version`, and any configured `models` entries for the managed route. Returns `NOT_FOUND` if cluster inference is not configured.
+
+### Multi-model routes
+
+`upsert_multi_model_route()` configures multiple provider/model pairs on a single route, each identified by a short alias:
+
+1. Validates that each `InferenceModelEntry` has non-empty `alias`, `provider_name`, and `model_id`.
+2. Checks that aliases are unique (case-insensitive).
+3. Verifies each provider exists and is inference-capable.
+4. Optionally probes each endpoint (skipped with `--no-verify`).
+5. Stores the full `models` vector in the route config. The first entry's provider/model are also written to the legacy single-model fields for backward compatibility.
+
+At bundle time, each `InferenceModelEntry` is resolved into a separate `ResolvedRoute` whose `name` is set to the alias. The router's alias-first selection (see Route Selection) then matches the agent's `model` field against these names.
 
 ### Bundle delivery
 
@@ -92,10 +106,14 @@ File: `proto/inference.proto`
 
 Key messages:
 
-- `SetClusterInferenceRequest` -- `provider_name` + `model_id` + `timeout_secs` + optional `no_verify` override, with verification enabled by default
-- `SetClusterInferenceResponse` -- `provider_name` + `model_id` + `timeout_secs` + `version`
+- `InferenceModelEntry` -- `alias` + `provider_name` + `model_id` (a single alias-to-provider mapping)
+- `SetClusterInferenceRequest` -- `provider_name` + `model_id` + `timeout_secs` + optional `no_verify` override + `repeated InferenceModelEntry models`, with verification enabled by default
+- `SetClusterInferenceResponse` -- `provider_name` + `model_id` + `timeout_secs` + `version` + `repeated InferenceModelEntry models`
+- `GetClusterInferenceResponse` -- `provider_name` + `model_id` + `timeout_secs` + `version` + `repeated InferenceModelEntry models`
 - `GetInferenceBundleResponse` -- `repeated ResolvedRoute routes` + `revision` + `generated_at_ms`
 - `ResolvedRoute` -- `name`, `base_url`, `protocols`, `api_key`, `model_id`, `provider_type`, `timeout_secs`
+
+When `models` is non-empty in a set request, the gateway uses `upsert_multi_model_route()` and ignores the legacy `provider_name`/`model_id` fields. When `models` is empty, the legacy single-model path is used.
 
 ## Data Plane (Sandbox)
 
@@ -117,7 +135,7 @@ When a `CONNECT inference.local:443` arrives:
 1. Proxy responds `200 Connection Established`.
 2. `handle_inference_interception()` TLS-terminates the client connection using the sandbox CA (MITM).
 3. Raw HTTP requests are parsed from the TLS tunnel using `try_parse_http_request()` (supports Content-Length and chunked transfer encoding).
-4. Each parsed request is passed to `route_inference_request()`.
+4. Each parsed request is passed to `route_inference_request()`. Before routing, the proxy extracts a `model_hint` from the JSON request body's `model` field (if present). This hint is passed to the router for alias-based route selection.
 5. The tunnel supports HTTP keep-alive: multiple requests can be processed sequentially.
 6. Buffer starts at 64 KiB (`INITIAL_INFERENCE_BUF`) and grows up to 10 MiB (`MAX_INFERENCE_BUF`). Requests exceeding the max get `413 Payload Too Large`.
 
@@ -133,10 +151,16 @@ Supported built-in patterns:
 | `POST` | `/v1/completions` | `openai_completions` | `completion` |
 | `POST` | `/v1/responses` | `openai_responses` | `responses` |
 | `POST` | `/v1/messages` | `anthropic_messages` | `messages` |
+| `POST` | `/v1/codex/*` | `openai_responses` | `codex_responses` |
 | `GET` | `/v1/models` | `model_discovery` | `models_list` |
 | `GET` | `/v1/models/*` | `model_discovery` | `models_get` |
+| `POST` | `/api/chat` | `ollama_chat` | `ollama_chat` |
+| `GET` | `/api/tags` | `ollama_model_discovery` | `ollama_tags` |
+| `POST` | `/api/show` | `ollama_model_discovery` | `ollama_show` |
 
-Query strings are stripped before matching. Path matching is exact for most patterns; `/v1/models/*` matches any sub-path (e.g. `/v1/models/gpt-4.1`). Absolute-form URIs (e.g. `https://inference.local/v1/chat/completions`) are normalized to path-only form by `normalize_inference_path()` before detection.
+Query strings are stripped before matching. Path matching is exact for most patterns; `/v1/models/*` and `/v1/codex/*` match any sub-path (e.g. `/v1/models/gpt-4.1`, `/v1/codex/responses`). Absolute-form URIs (e.g. `https://inference.local/v1/chat/completions`) are normalized to path-only form by `normalize_inference_path()` before detection.
+
+Ollama patterns use `/api/` paths (no `/v1/` prefix), matching Ollama's native API. This allows agents to use the Ollama client library directly against `inference.local`.
 
 If no pattern matches, the proxy returns `403 Forbidden` with `{"error": "connection not allowed by policy"}`.
 
@@ -161,7 +185,16 @@ Files:
 
 ### Route selection
 
-`proxy_with_candidates()` finds the first route whose `protocols` list contains the detected source protocol (normalized to lowercase). If no route matches, returns `RouterError::NoCompatibleRoute`.
+`select_route()` picks the best route from the candidate list using a two-phase strategy:
+
+1. **Alias match (preferred)**: If a `model_hint` is provided (extracted from the request body's `model` field), select the first candidate whose `name` equals the hint AND whose `protocols` list contains the detected source protocol.
+2. **Protocol fallback**: If no alias matches, fall back to the first candidate whose `protocols` list contains the source protocol.
+
+This enables multi-route configurations where the agent selects a backend by setting the `model` field to an alias name (e.g. `"model": "my-gpt"` routes to the aliased provider). If the model field is absent, not a known alias, or parsing fails, routing falls back to protocol-based selection.
+
+If no route matches either phase, returns `RouterError::NoCompatibleRoute`.
+
+`proxy_with_candidates()` and `proxy_with_candidates_streaming()` both accept an optional `model_hint: Option<&str>` parameter, passed through from the sandbox proxy.
 
 ### Request rewriting
 
@@ -171,7 +204,7 @@ Files:
 2. **Header stripping**: Removes `authorization`, `x-api-key`, `host`, and any header names that will be set from route defaults.
 3. **Default headers**: Applies route-level default headers (e.g. `anthropic-version: 2023-06-01`) unless the client already sent them.
 4. **Model rewrite**: Parses the request body as JSON and replaces the `model` field with the route's configured model. Non-JSON bodies are forwarded unchanged.
-5. **URL construction**: `build_backend_url()` appends the request path to the route endpoint. If the endpoint already ends with `/v1` and the request path starts with `/v1/`, the duplicate prefix is deduplicated.
+5. **URL construction**: `build_backend_url()` appends the request path to the route endpoint. If the request path is exactly `/v1` or starts with `/v1/`, the `/v1` prefix is always stripped before appending. This handles both `/v1`-suffixed endpoints (e.g. `api.openai.com/v1`) and non-versioned endpoints (e.g. `chatgpt.com/backend-api` for Codex) uniformly.
 
 ### Header sanitization
 
@@ -299,13 +332,25 @@ The system route is stored as a separate `InferenceRoute` record in the gateway 
 
 Cluster inference commands:
 
-- `openshell inference set --provider <name> --model <id> [--timeout <secs>]` -- configures user-facing cluster inference
+- `openshell inference set --provider <name> --model <id> [--timeout <secs>]` -- configures user-facing cluster inference (single model)
+- `openshell inference set --model-alias ALIAS=PROVIDER/MODEL [--model-alias ...] [--timeout <secs>]` -- configures multi-model cluster inference
 - `openshell inference set --system --provider <name> --model <id> [--timeout <secs>]` -- configures system inference
 - `openshell inference update [--provider <name>] [--model <id>] [--timeout <secs>]` -- updates individual fields without resetting others
 - `openshell inference get` -- displays both user and system inference configuration
 - `openshell inference get --system` -- displays only the system inference configuration
 
-The `--provider` flag references a provider record name (not a provider type). The provider must already exist in the cluster and have a supported inference type (`openai`, `anthropic`, or `nvidia`).
+The `--provider` flag references a provider record name (not a provider type). The provider must already exist in the cluster and have a supported inference type (`openai`, `anthropic`, `nvidia`, or `ollama`).
+
+`--model-alias` can be repeated to configure multiple providers simultaneously. It conflicts with `--provider` and `--model` -- the two modes are mutually exclusive. Example:
+
+```bash
+openshell inference set \
+  --model-alias my-gpt=openai-dev/gpt-4o \
+  --model-alias my-claude=anthropic-dev/claude-sonnet-4-20250514 \
+  --model-alias my-llama=ollama-local/llama3
+```
+
+Agents select a backend by setting the `model` field in their inference request to the alias name (e.g. `"model": "my-gpt"`).
 
 The `--timeout` flag sets the per-request timeout in seconds for upstream inference calls. When omitted or set to `0`, the default of 60 seconds applies. Timeout changes propagate to running sandboxes within the route refresh interval (5 seconds by default).
 

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -6,7 +6,7 @@
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum, ValueHint};
 use clap_complete::engine::ArgValueCompleter;
 use clap_complete::env::CompleteEnv;
-use miette::Result;
+use miette::{Result, miette};
 use owo_colors::OwoColorize;
 use std::io::Write;
 
@@ -290,6 +290,7 @@ const GATEWAY_EXAMPLES: &str = "\x1b[1mALIAS\x1b[0m
 
 const INFERENCE_EXAMPLES: &str = "\x1b[1mEXAMPLES\x1b[0m
   $ openshell inference set --provider openai --model gpt-4
+  $ openshell inference set --model-alias gpt=openai/gpt-4 --model-alias claude=anthropic/claude-sonnet-4-20250514
   $ openshell inference get
   $ openshell inference update --model gpt-4-turbo
 ";
@@ -928,15 +929,26 @@ enum GatewayCommands {
 #[derive(Subcommand, Debug)]
 enum InferenceCommands {
     /// Set gateway-level inference provider and model.
+    ///
+    /// Use --provider/--model for single-model mode, or --model-alias for
+    /// multi-model mode (multiple providers routed by alias).
     #[command(help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
     Set {
-        /// Provider name.
-        #[arg(long, add = ArgValueCompleter::new(completers::complete_provider_names))]
-        provider: String,
+        /// Provider name (single-model mode).
+        #[arg(long, required_unless_present = "model_alias", add = ArgValueCompleter::new(completers::complete_provider_names))]
+        provider: Option<String>,
 
-        /// Model identifier to force for generation calls.
-        #[arg(long)]
-        model: String,
+        /// Model identifier to force for generation calls (single-model mode).
+        #[arg(long, required_unless_present = "model_alias")]
+        model: Option<String>,
+
+        /// Add a model alias in the form ALIAS=PROVIDER/MODEL.
+        /// Can be repeated to configure multiple providers simultaneously.
+        /// Not supported with --system.
+        ///
+        /// Example: --model-alias my-gpt=openai-dev/gpt-4o --model-alias my-claude=anthropic-dev/claude-sonnet-4-20250514
+        #[arg(long, conflicts_with_all = ["provider", "model", "system"])]
+        model_alias: Vec<String>,
 
         /// Configure the system inference route instead of the user-facing
         /// route. System inference is used by platform functions (e.g. the
@@ -2091,15 +2103,34 @@ async fn main() -> Result<()> {
                 InferenceCommands::Set {
                     provider,
                     model,
+                    model_alias,
                     system,
                     no_verify,
                     timeout,
                 } => {
                     let route_name = if system { "sandbox-system" } else { "" };
-                    run::gateway_inference_set(
-                        endpoint, &provider, &model, route_name, no_verify, timeout, &tls,
-                    )
-                    .await?;
+                    if !model_alias.is_empty() {
+                        run::gateway_inference_set_multi(
+                            endpoint,
+                            &model_alias,
+                            route_name,
+                            no_verify,
+                            timeout,
+                            &tls,
+                        )
+                        .await?;
+                    } else {
+                        let provider = provider.as_deref().ok_or_else(|| {
+                            miette!("--provider is required in single-model mode")
+                        })?;
+                        let model = model
+                            .as_deref()
+                            .ok_or_else(|| miette!("--model is required in single-model mode"))?;
+                        run::gateway_inference_set(
+                            endpoint, provider, model, route_name, no_verify, timeout, &tls,
+                        )
+                        .await?;
+                    }
                 }
                 InferenceCommands::Update {
                     provider,

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -26,8 +26,8 @@ use openshell_core::proto::{
     CreateProviderRequest, CreateSandboxRequest, DeleteProviderRequest, DeleteSandboxRequest,
     ExecSandboxRequest, GetClusterInferenceRequest, GetDraftHistoryRequest, GetDraftPolicyRequest,
     GetGatewayConfigRequest, GetProviderRequest, GetSandboxConfigRequest, GetSandboxLogsRequest,
-    GetSandboxPolicyStatusRequest, GetSandboxRequest, HealthRequest, ListProvidersRequest,
-    ListSandboxPoliciesRequest, ListSandboxesRequest, PolicyStatus, Provider,
+    GetSandboxPolicyStatusRequest, GetSandboxRequest, HealthRequest, InferenceModelEntry,
+    ListProvidersRequest, ListSandboxPoliciesRequest, ListSandboxesRequest, PolicyStatus, Provider,
     RejectDraftChunkRequest, Sandbox, SandboxPhase, SandboxPolicy, SandboxSpec, SandboxTemplate,
     SetClusterInferenceRequest, SettingScope, SettingValue, UpdateConfigRequest,
     UpdateProviderRequest, WatchSandboxRequest, exec_sandbox_event, setting_value,
@@ -3632,6 +3632,7 @@ pub async fn gateway_inference_set(
             verify: false,
             no_verify,
             timeout_secs,
+            models: vec![],
         })
         .await;
 
@@ -3663,7 +3664,96 @@ pub async fn gateway_inference_set(
     Ok(())
 }
 
-pub async fn gateway_inference_update(
+pub async fn gateway_inference_set_multi(
+    server: &str,
+    model_aliases: &[String],
+    route_name: &str,
+    no_verify: bool,
+    timeout_secs: u64,
+    tls: &TlsOptions,
+) -> Result<()> {
+    let mut models = Vec::with_capacity(model_aliases.len());
+    for entry in model_aliases {
+        let (alias, rest) = entry.split_once('=').ok_or_else(|| {
+            miette!("invalid --model-alias format: {entry:?}. Expected ALIAS=PROVIDER/MODEL")
+        })?;
+        let (provider, model) = rest.split_once('/').ok_or_else(|| {
+            miette!("invalid --model-alias value after '=': {rest:?}. Expected PROVIDER/MODEL")
+        })?;
+        if alias.trim().is_empty() {
+            return Err(miette!("empty alias in --model-alias {entry:?}"));
+        }
+        if provider.trim().is_empty() {
+            return Err(miette!("empty provider in --model-alias {entry:?}"));
+        }
+        if model.trim().is_empty() {
+            return Err(miette!("empty model in --model-alias {entry:?}"));
+        }
+        models.push(InferenceModelEntry {
+            alias: alias.to_string(),
+            provider_name: provider.to_string(),
+            model_id: model.to_string(),
+        });
+    }
+
+    let progress = if std::io::stdout().is_terminal() {
+        let spinner = ProgressBar::new_spinner();
+        spinner.set_style(
+            ProgressStyle::with_template("{spinner:.cyan} {msg} ({elapsed})")
+                .unwrap_or_else(|_| ProgressStyle::default_spinner()),
+        );
+        spinner.set_message("Configuring multi-model inference...");
+        spinner.enable_steady_tick(Duration::from_millis(120));
+        Some(spinner)
+    } else {
+        None
+    };
+
+    let mut client = grpc_inference_client(server, tls).await?;
+    let response = client
+        .set_cluster_inference(SetClusterInferenceRequest {
+            provider_name: String::new(),
+            model_id: String::new(),
+            route_name: route_name.to_string(),
+            verify: false,
+            no_verify,
+            timeout_secs,
+            models,
+        })
+        .await;
+
+    if let Some(progress) = &progress {
+        progress.finish_and_clear();
+    }
+
+    let response = response.map_err(format_inference_status)?;
+    let configured = response.into_inner();
+    let label = if configured.route_name == "sandbox-system" {
+        "System multi-model inference configured:"
+    } else {
+        "Gateway multi-model inference configured:"
+    };
+    println!("{}", label.cyan().bold());
+    println!();
+    println!("  {} {}", "Route:".dimmed(), configured.route_name);
+    println!("  {} {}", "Version:".dimmed(), configured.version);
+    if configured.models.is_empty() {
+        println!("  {} {}", "Provider:".dimmed(), configured.provider_name);
+        println!("  {} {}", "Model:".dimmed(), configured.model_id);
+    } else {
+        println!("  {}", "Models:".dimmed());
+        for m in &configured.models {
+            println!(
+                "    {} {} {}/{}",
+                "-".dimmed(),
+                m.alias.bold(),
+                m.provider_name,
+                m.model_id
+            );
+        }
+    }
+    print_timeout(configured.timeout_secs);
+    if configured.validation_performed {
     server: &str,
     provider_name: Option<&str>,
     model_id: Option<&str>,
@@ -3714,6 +3804,7 @@ pub async fn gateway_inference_update(
             verify: false,
             no_verify,
             timeout_secs: timeout,
+            models: vec![],
         })
         .await;
 
@@ -3769,9 +3860,23 @@ pub async fn gateway_inference_get(
         };
         println!("{}", label.cyan().bold());
         println!();
-        println!("  {} {}", "Provider:".dimmed(), configured.provider_name);
-        println!("  {} {}", "Model:".dimmed(), configured.model_id);
-        println!("  {} {}", "Version:".dimmed(), configured.version);
+        if !configured.models.is_empty() {
+            println!("  {} {}", "Version:".dimmed(), configured.version);
+            println!("  {}", "Models:".dimmed());
+            for m in &configured.models {
+                println!(
+                    "    {} {} {}/{}",
+                    "-".dimmed(),
+                    m.alias.bold(),
+                    m.provider_name,
+                    m.model_id
+                );
+            }
+        } else {
+            println!("  {} {}", "Provider:".dimmed(), configured.provider_name);
+            println!("  {} {}", "Model:".dimmed(), configured.model_id);
+            println!("  {} {}", "Version:".dimmed(), configured.version);
+        }
         print_timeout(configured.timeout_secs);
     } else {
         // Show both routes by default.
@@ -3797,9 +3902,23 @@ async fn print_inference_route(
             let configured = response.into_inner();
             println!("{}", format!("{label}:").cyan().bold());
             println!();
-            println!("  {} {}", "Provider:".dimmed(), configured.provider_name);
-            println!("  {} {}", "Model:".dimmed(), configured.model_id);
-            println!("  {} {}", "Version:".dimmed(), configured.version);
+            if !configured.models.is_empty() {
+                println!("  {} {}", "Version:".dimmed(), configured.version);
+                println!("  {}", "Models:".dimmed());
+                for m in &configured.models {
+                    println!(
+                        "    {} {} {}/{}",
+                        "-".dimmed(),
+                        m.alias.bold(),
+                        m.provider_name,
+                        m.model_id
+                    );
+                }
+            } else {
+                println!("  {} {}", "Provider:".dimmed(), configured.provider_name);
+                println!("  {} {}", "Model:".dimmed(), configured.model_id);
+                println!("  {} {}", "Version:".dimmed(), configured.version);
+            }
             print_timeout(configured.timeout_secs);
         }
         Err(e) if e.code() == Code::NotFound => {

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -3754,6 +3754,15 @@ pub async fn gateway_inference_set_multi(
     }
     print_timeout(configured.timeout_secs);
     if configured.validation_performed {
+        println!("  {}", "Validated Endpoints:".dimmed());
+        for endpoint in configured.validated_endpoints {
+            println!("    - {} ({})", endpoint.url, endpoint.protocol);
+        }
+    }
+    Ok(())
+}
+
+pub async fn gateway_inference_update(
     server: &str,
     provider_name: Option<&str>,
     model_id: Option<&str>,

--- a/crates/openshell-core/src/inference.rs
+++ b/crates/openshell-core/src/inference.rs
@@ -56,6 +56,14 @@ const OPENAI_PROTOCOLS: &[&str] = &[
 
 const ANTHROPIC_PROTOCOLS: &[&str] = &["anthropic_messages", "model_discovery"];
 
+const OLLAMA_PROTOCOLS: &[&str] = &[
+    "ollama_chat",
+    "ollama_model_discovery",
+    "openai_chat_completions",
+    "openai_completions",
+    "model_discovery",
+];
+
 static OPENAI_PROFILE: InferenceProviderProfile = InferenceProviderProfile {
     provider_type: "openai",
     default_base_url: "https://api.openai.com/v1",
@@ -86,6 +94,16 @@ static NVIDIA_PROFILE: InferenceProviderProfile = InferenceProviderProfile {
     default_headers: &[],
 };
 
+static OLLAMA_PROFILE: InferenceProviderProfile = InferenceProviderProfile {
+    provider_type: "ollama",
+    default_base_url: "http://host.openshell.internal:11434",
+    protocols: OLLAMA_PROTOCOLS,
+    credential_key_names: &["OLLAMA_API_KEY"],
+    base_url_config_keys: &["OLLAMA_BASE_URL", "OLLAMA_HOST"],
+    auth: AuthHeader::Bearer,
+    default_headers: &[],
+};
+
 /// Look up the inference provider profile for a given provider type.
 ///
 /// Returns `None` for provider types that don't support inference routing
@@ -95,6 +113,7 @@ pub fn profile_for(provider_type: &str) -> Option<&'static InferenceProviderProf
         "openai" => Some(&OPENAI_PROFILE),
         "anthropic" => Some(&ANTHROPIC_PROFILE),
         "nvidia" => Some(&NVIDIA_PROFILE),
+        "ollama" => Some(&OLLAMA_PROFILE),
         _ => None,
     }
 }

--- a/crates/openshell-router/src/backend.rs
+++ b/crates/openshell-router/src/backend.rs
@@ -234,6 +234,7 @@ fn validation_probe(route: &ResolvedRoute) -> Result<ValidationProbe, Validation
             body: bytes::Bytes::from_static(
                 br#"{"model":"test","messages":[{"role":"user","content":"ping"}],"stream":false}"#,
             ),
+            fallback_body: None,
         });
     }
 
@@ -434,6 +435,9 @@ pub async fn proxy_to_backend_streaming(
 
 fn build_backend_url(endpoint: &str, path: &str) -> String {
     let base = endpoint.trim_end_matches('/');
+    // When the endpoint already contains /v1 (e.g. api.openai.com/v1)
+    // and the proxy path also starts with /v1/, strip the duplicate
+    // prefix so the resulting URL is correct.
     if base.ends_with("/v1") && (path == "/v1" || path.starts_with("/v1/")) {
         return format!("{base}{}", &path[3..]);
     }
@@ -458,10 +462,18 @@ mod tests {
     }
 
     #[test]
-    fn build_backend_url_preserves_non_versioned_base() {
+    fn build_backend_url_preserves_v1_for_plain_endpoint() {
         assert_eq!(
-            build_backend_url("https://api.anthropic.com", "/v1/messages"),
-            "https://api.anthropic.com/v1/messages"
+            build_backend_url("https://my-proxy.example.com", "/v1/chat/completions"),
+            "https://my-proxy.example.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn build_backend_url_codex_path() {
+        assert_eq!(
+            build_backend_url("https://api.openai.com/v1", "/v1/codex/responses"),
+            "https://api.openai.com/v1/codex/responses"
         );
     }
 
@@ -489,8 +501,9 @@ mod tests {
     #[tokio::test]
     async fn verify_backend_endpoint_uses_route_auth_and_shape() {
         let mock_server = MockServer::start().await;
+        // Use endpoint with /v1 suffix to match real Anthropic endpoint layout.
         let route = test_route(
-            &mock_server.uri(),
+            &format!("{}/v1", mock_server.uri()),
             &["anthropic_messages"],
             AuthHeader::Custom("x-api-key"),
         );
@@ -520,7 +533,7 @@ mod tests {
     #[tokio::test]
     async fn verify_backend_endpoint_accepts_mock_routes() {
         let route = test_route(
-            "mock://test-backend",
+            "mock://test-backend/v1",
             &["openai_chat_completions"],
             AuthHeader::Bearer,
         );

--- a/crates/openshell-router/src/backend.rs
+++ b/crates/openshell-router/src/backend.rs
@@ -223,6 +223,20 @@ fn validation_probe(route: &ResolvedRoute) -> Result<ValidationProbe, Validation
         });
     }
 
+    if route
+        .protocols
+        .iter()
+        .any(|protocol| protocol == "ollama_chat")
+    {
+        return Ok(ValidationProbe {
+            path: "/api/chat",
+            protocol: "ollama_chat",
+            body: bytes::Bytes::from_static(
+                br#"{"model":"test","messages":[{"role":"user","content":"ping"}],"stream":false}"#,
+            ),
+        });
+    }
+
     Err(ValidationFailure {
         kind: ValidationFailureKind::RequestShape,
         details: format!(

--- a/crates/openshell-router/src/lib.rs
+++ b/crates/openshell-router/src/lib.rs
@@ -218,6 +218,7 @@ mod tests {
             protocols: protocols.into_iter().map(String::from).collect(),
             auth: config::AuthHeader::Bearer,
             default_headers: Vec::new(),
+            timeout: std::time::Duration::from_secs(60),
         }
     }
 

--- a/crates/openshell-router/src/lib.rs
+++ b/crates/openshell-router/src/lib.rs
@@ -34,11 +34,14 @@ pub struct Router {
     client: reqwest::Client,
 }
 
-/// Select a route from `candidates` using alias-first, protocol-fallback strategy.
+/// Select a route from `candidates` using alias-first, model-second,
+/// protocol-fallback strategy.
 ///
-/// 1. If `model_hint` is provided, find a candidate whose `name` matches the hint
-///    **and** whose protocols include `protocol`.
-/// 2. Otherwise, return the first candidate whose protocols contain `protocol`.
+/// 1. If `model_hint` is provided, find a candidate whose `name` (alias)
+///    matches the hint **and** whose protocols include `protocol`.
+/// 2. Else if `model_hint` is provided, find a candidate whose `model`
+///    matches the hint **and** whose protocols include `protocol`.
+/// 3. Otherwise, return the first candidate whose protocols contain `protocol`.
 fn select_route<'a>(
     candidates: &'a [ResolvedRoute],
     protocol: &str,
@@ -46,13 +49,22 @@ fn select_route<'a>(
 ) -> Option<&'a ResolvedRoute> {
     if let Some(hint) = model_hint {
         let normalized_hint = hint.trim().to_ascii_lowercase();
+        // 1. Alias match (route name == model hint).
         if let Some(r) = candidates.iter().find(|r| {
             r.name.trim().to_ascii_lowercase() == normalized_hint
                 && r.protocols.iter().any(|p| p == protocol)
         }) {
             return Some(r);
         }
+        // 2. Model ID match (route model == model hint).
+        if let Some(r) = candidates.iter().find(|r| {
+            r.model.trim().to_ascii_lowercase() == normalized_hint
+                && r.protocols.iter().any(|p| p == protocol)
+        }) {
+            return Some(r);
+        }
     }
+    // 3. First protocol-compatible route.
     candidates
         .iter()
         .find(|r| r.protocols.iter().any(|p| p == protocol))
@@ -272,5 +284,33 @@ mod tests {
         ];
         let r = select_route(&routes, "openai_chat_completions", Some("my-gpt")).unwrap();
         assert_eq!(r.name, "My-GPT");
+    }
+
+    #[test]
+    fn select_route_model_id_match() {
+        // When the hint doesn't match any alias but does match a route's model,
+        // that route is selected.
+        let routes = vec![
+            make_route("ollama-local", vec!["openai_responses"]),
+            make_route("openai-codex", vec!["openai_responses"]),
+        ];
+        // openai-codex has model "openai-codex-model"; ollama-local has "ollama-local-model".
+        // Hint "openai-codex-model" doesn't match any alias, but matches the model field.
+        let r = select_route(&routes, "openai_responses", Some("openai-codex-model")).unwrap();
+        assert_eq!(r.name, "openai-codex");
+    }
+
+    #[test]
+    fn select_route_alias_beats_model_id() {
+        // Alias match takes priority over model ID match.
+        let mut routes = vec![
+            make_route("ollama-local", vec!["openai_chat_completions"]),
+            make_route("openai-prod", vec!["openai_chat_completions"]),
+        ];
+        // Give ollama-local a model that matches the second route's name.
+        routes[0].model = "openai-prod".to_string();
+        let r = select_route(&routes, "openai_chat_completions", Some("openai-prod")).unwrap();
+        // Alias match wins: route named "openai-prod", not the one with model="openai-prod".
+        assert_eq!(r.name, "openai-prod");
     }
 }

--- a/crates/openshell-router/src/lib.rs
+++ b/crates/openshell-router/src/lib.rs
@@ -34,6 +34,28 @@ pub struct Router {
     client: reqwest::Client,
 }
 
+/// Select a route from `candidates` using alias-first, protocol-fallback strategy.
+///
+/// 1. If `model_hint` is provided, find a candidate whose `name` matches the hint
+///    **and** whose protocols include `protocol`.
+/// 2. Otherwise, return the first candidate whose protocols contain `protocol`.
+fn select_route<'a>(
+    candidates: &'a [ResolvedRoute],
+    protocol: &str,
+    model_hint: Option<&str>,
+) -> Option<&'a ResolvedRoute> {
+    if let Some(hint) = model_hint {
+        if let Some(r) = candidates.iter().find(|r| {
+            r.name == hint && r.protocols.iter().any(|p| p == protocol)
+        }) {
+            return Some(r);
+        }
+    }
+    candidates
+        .iter()
+        .find(|r| r.protocols.iter().any(|p| p == protocol))
+}
+
 impl Router {
     pub fn new() -> Result<Self, RouterError> {
         let client = reqwest::Client::builder()
@@ -54,8 +76,10 @@ impl Router {
 
     /// Proxy a raw HTTP request to the first compatible route from `candidates`.
     ///
-    /// Filters candidates by `source_protocol` compatibility (exact match against
-    /// one of the route's `protocols`), then forwards to the first match.
+    /// When `model_hint` is provided, the router first looks for a candidate whose
+    /// `name` (alias) matches the hint.  If no alias matches, it falls back to
+    /// protocol-based selection (first candidate whose `protocols` list contains
+    /// `source_protocol`).
     pub async fn proxy_with_candidates(
         &self,
         source_protocol: &str,
@@ -64,11 +88,10 @@ impl Router {
         headers: Vec<(String, String)>,
         body: bytes::Bytes,
         candidates: &[ResolvedRoute],
+        model_hint: Option<&str>,
     ) -> Result<ProxyResponse, RouterError> {
         let normalized_source = source_protocol.trim().to_ascii_lowercase();
-        let route = candidates
-            .iter()
-            .find(|r| r.protocols.iter().any(|p| p == &normalized_source))
+        let route = select_route(candidates, &normalized_source, model_hint)
             .ok_or_else(|| RouterError::NoCompatibleRoute(source_protocol.to_string()))?;
 
         info!(
@@ -108,11 +131,10 @@ impl Router {
         headers: Vec<(String, String)>,
         body: bytes::Bytes,
         candidates: &[ResolvedRoute],
+        model_hint: Option<&str>,
     ) -> Result<StreamingProxyResponse, RouterError> {
         let normalized_source = source_protocol.trim().to_ascii_lowercase();
-        let route = candidates
-            .iter()
-            .find(|r| r.protocols.iter().any(|p| p == &normalized_source))
+        let route = select_route(candidates, &normalized_source, model_hint)
             .ok_or_else(|| RouterError::NoCompatibleRoute(source_protocol.to_string()))?;
 
         info!(
@@ -183,5 +205,58 @@ mod tests {
         };
         let err = Router::from_config(&config).unwrap_err();
         assert!(matches!(err, RouterError::Internal(_)));
+    }
+
+    fn make_route(name: &str, protocols: Vec<&str>) -> ResolvedRoute {
+        ResolvedRoute {
+            name: name.to_string(),
+            endpoint: "http://localhost".to_string(),
+            model: format!("{name}-model"),
+            api_key: "key".to_string(),
+            protocols: protocols.into_iter().map(String::from).collect(),
+            auth: config::AuthHeader::Bearer,
+            default_headers: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn select_route_protocol_fallback_when_no_hint() {
+        let routes = vec![
+            make_route("ollama-local", vec!["openai_chat_completions"]),
+            make_route("anthropic-prod", vec!["anthropic_messages"]),
+        ];
+        let r = select_route(&routes, "anthropic_messages", None).unwrap();
+        assert_eq!(r.name, "anthropic-prod");
+    }
+
+    #[test]
+    fn select_route_alias_match_takes_priority() {
+        let routes = vec![
+            make_route("ollama-local", vec!["openai_chat_completions"]),
+            make_route("openai-prod", vec!["openai_chat_completions", "openai_responses"]),
+        ];
+        // Both support openai_chat_completions, but hint selects the second one.
+        let r = select_route(&routes, "openai_chat_completions", Some("openai-prod")).unwrap();
+        assert_eq!(r.name, "openai-prod");
+    }
+
+    #[test]
+    fn select_route_alias_must_also_match_protocol() {
+        let routes = vec![
+            make_route("ollama-local", vec!["openai_chat_completions"]),
+            make_route("anthropic-prod", vec!["anthropic_messages"]),
+        ];
+        // Hint says "anthropic-prod" but protocol is openai_chat_completions — can't use it.
+        // Falls back to protocol match → ollama-local.
+        let r = select_route(&routes, "openai_chat_completions", Some("anthropic-prod")).unwrap();
+        assert_eq!(r.name, "ollama-local");
+    }
+
+    #[test]
+    fn select_route_no_match_returns_none() {
+        let routes = vec![
+            make_route("ollama-local", vec!["openai_chat_completions"]),
+        ];
+        assert!(select_route(&routes, "anthropic_messages", None).is_none());
     }
 }

--- a/crates/openshell-router/src/lib.rs
+++ b/crates/openshell-router/src/lib.rs
@@ -45,8 +45,10 @@ fn select_route<'a>(
     model_hint: Option<&str>,
 ) -> Option<&'a ResolvedRoute> {
     if let Some(hint) = model_hint {
+        let normalized_hint = hint.trim().to_ascii_lowercase();
         if let Some(r) = candidates.iter().find(|r| {
-            r.name == hint && r.protocols.iter().any(|p| p == protocol)
+            r.name.trim().to_ascii_lowercase() == normalized_hint
+                && r.protocols.iter().any(|p| p == protocol)
         }) {
             return Some(r);
         }
@@ -233,7 +235,10 @@ mod tests {
     fn select_route_alias_match_takes_priority() {
         let routes = vec![
             make_route("ollama-local", vec!["openai_chat_completions"]),
-            make_route("openai-prod", vec!["openai_chat_completions", "openai_responses"]),
+            make_route(
+                "openai-prod",
+                vec!["openai_chat_completions", "openai_responses"],
+            ),
         ];
         // Both support openai_chat_completions, but hint selects the second one.
         let r = select_route(&routes, "openai_chat_completions", Some("openai-prod")).unwrap();
@@ -254,9 +259,17 @@ mod tests {
 
     #[test]
     fn select_route_no_match_returns_none() {
-        let routes = vec![
-            make_route("ollama-local", vec!["openai_chat_completions"]),
-        ];
+        let routes = vec![make_route("ollama-local", vec!["openai_chat_completions"])];
         assert!(select_route(&routes, "anthropic_messages", None).is_none());
+    }
+
+    #[test]
+    fn select_route_alias_match_is_case_insensitive() {
+        let routes = vec![
+            make_route("My-GPT", vec!["openai_chat_completions"]),
+            make_route("anthropic-prod", vec!["anthropic_messages"]),
+        ];
+        let r = select_route(&routes, "openai_chat_completions", Some("my-gpt")).unwrap();
+        assert_eq!(r.name, "My-GPT");
     }
 }

--- a/crates/openshell-router/tests/backend_integration.rs
+++ b/crates/openshell-router/tests/backend_integration.rs
@@ -67,6 +67,7 @@ async fn proxy_forwards_request_to_backend() {
             vec![("content-type".to_string(), "application/json".to_string())],
             bytes::Bytes::from(body),
             &candidates,
+            None,
         )
         .await
         .unwrap();
@@ -99,6 +100,7 @@ async fn proxy_upstream_401_returns_error() {
             vec![],
             bytes::Bytes::new(),
             &candidates,
+            None,
         )
         .await
         .unwrap();
@@ -129,6 +131,7 @@ async fn proxy_no_compatible_route_returns_error() {
             vec![],
             bytes::Bytes::new(),
             &candidates,
+            None,
         )
         .await
         .unwrap_err();
@@ -162,6 +165,7 @@ async fn proxy_strips_auth_header() {
             vec![("authorization".to_string(), "Bearer client-key".to_string())],
             bytes::Bytes::new(),
             &candidates,
+            None,
         )
         .await
         .unwrap();
@@ -197,6 +201,7 @@ async fn proxy_mock_route_returns_canned_response() {
             vec![("content-type".to_string(), "application/json".to_string())],
             bytes::Bytes::from(body),
             &candidates,
+            None,
         )
         .await
         .unwrap();
@@ -242,6 +247,7 @@ async fn proxy_overrides_model_in_request_body() {
             vec![("content-type".to_string(), "application/json".to_string())],
             bytes::Bytes::from(body),
             &candidates,
+            None,
         )
         .await
         .unwrap();
@@ -280,6 +286,7 @@ async fn proxy_inserts_model_when_absent_from_body() {
             vec![("content-type".to_string(), "application/json".to_string())],
             bytes::Bytes::from(body),
             &candidates,
+            None,
         )
         .await
         .unwrap();
@@ -336,6 +343,7 @@ async fn proxy_uses_x_api_key_for_anthropic_route() {
             ],
             bytes::Bytes::from(body),
             &candidates,
+            None,
         )
         .await
         .unwrap();
@@ -385,6 +393,7 @@ async fn proxy_anthropic_does_not_send_bearer_auth() {
             vec![("content-type".to_string(), "application/json".to_string())],
             bytes::Bytes::from(b"{}".to_vec()),
             &candidates,
+            None,
         )
         .await
         .unwrap();
@@ -442,6 +451,7 @@ async fn proxy_forwards_client_anthropic_version_header() {
             ],
             bytes::Bytes::from(body),
             &candidates,
+            None,
         )
         .await
         .unwrap();

--- a/crates/openshell-router/tests/backend_integration.rs
+++ b/crates/openshell-router/tests/backend_integration.rs
@@ -9,7 +9,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 fn mock_candidates(base_url: &str) -> Vec<ResolvedRoute> {
     vec![ResolvedRoute {
         name: "inference.local".to_string(),
-        endpoint: base_url.to_string(),
+        endpoint: format!("{base_url}/v1"),
         model: "meta/llama-3.1-8b-instruct".to_string(),
         api_key: "test-api-key".to_string(),
         protocols: vec!["openai_chat_completions".to_string()],
@@ -316,7 +316,7 @@ async fn proxy_uses_x_api_key_for_anthropic_route() {
     let router = Router::new().unwrap();
     let candidates = vec![ResolvedRoute {
         name: "inference.local".to_string(),
-        endpoint: mock_server.uri(),
+        endpoint: format!("{}/v1", mock_server.uri()),
         model: "claude-sonnet-4-20250514".to_string(),
         api_key: "test-anthropic-key".to_string(),
         protocols: vec!["anthropic_messages".to_string()],
@@ -376,7 +376,7 @@ async fn proxy_anthropic_does_not_send_bearer_auth() {
     let router = Router::new().unwrap();
     let candidates = vec![ResolvedRoute {
         name: "inference.local".to_string(),
-        endpoint: mock_server.uri(),
+        endpoint: format!("{}/v1", mock_server.uri()),
         model: "claude-sonnet-4-20250514".to_string(),
         api_key: "anthropic-key".to_string(),
         protocols: vec!["anthropic_messages".to_string()],
@@ -422,7 +422,7 @@ async fn proxy_forwards_client_anthropic_version_header() {
     let router = Router::new().unwrap();
     let candidates = vec![ResolvedRoute {
         name: "inference.local".to_string(),
-        endpoint: mock_server.uri(),
+        endpoint: format!("{}/v1", mock_server.uri()),
         model: "claude-sonnet-4-20250514".to_string(),
         api_key: "test-anthropic-key".to_string(),
         protocols: vec!["anthropic_messages".to_string()],

--- a/crates/openshell-sandbox/src/l7/inference.rs
+++ b/crates/openshell-sandbox/src/l7/inference.rs
@@ -39,6 +39,12 @@ pub fn default_patterns() -> Vec<InferenceApiPattern> {
         },
         InferenceApiPattern {
             method: "POST".to_string(),
+            path_glob: "/v1/codex/*".to_string(),
+            protocol: "openai_responses".to_string(),
+            kind: "codex_responses".to_string(),
+        },
+        InferenceApiPattern {
+            method: "POST".to_string(),
             path_glob: "/v1/messages".to_string(),
             protocol: "anthropic_messages".to_string(),
             kind: "messages".to_string(),

--- a/crates/openshell-sandbox/src/l7/inference.rs
+++ b/crates/openshell-sandbox/src/l7/inference.rs
@@ -44,6 +44,24 @@ pub fn default_patterns() -> Vec<InferenceApiPattern> {
             kind: "messages".to_string(),
         },
         InferenceApiPattern {
+            method: "POST".to_string(),
+            path_glob: "/api/chat".to_string(),
+            protocol: "ollama_chat".to_string(),
+            kind: "ollama_chat".to_string(),
+        },
+        InferenceApiPattern {
+            method: "GET".to_string(),
+            path_glob: "/api/tags".to_string(),
+            protocol: "ollama_model_discovery".to_string(),
+            kind: "ollama_tags".to_string(),
+        },
+        InferenceApiPattern {
+            method: "POST".to_string(),
+            path_glob: "/api/show".to_string(),
+            protocol: "ollama_model_discovery".to_string(),
+            kind: "ollama_show".to_string(),
+        },
+        InferenceApiPattern {
             method: "GET".to_string(),
             path_glob: "/v1/models".to_string(),
             protocol: "model_discovery".to_string(),
@@ -392,6 +410,37 @@ mod tests {
     fn no_match_for_get() {
         let patterns = default_patterns();
         let result = detect_inference_pattern("GET", "/v1/chat/completions", &patterns);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn detect_ollama_chat() {
+        let patterns = default_patterns();
+        let result = detect_inference_pattern("POST", "/api/chat", &patterns);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().protocol, "ollama_chat");
+    }
+
+    #[test]
+    fn detect_ollama_tags() {
+        let patterns = default_patterns();
+        let result = detect_inference_pattern("GET", "/api/tags", &patterns);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().protocol, "ollama_model_discovery");
+    }
+
+    #[test]
+    fn detect_ollama_show() {
+        let patterns = default_patterns();
+        let result = detect_inference_pattern("POST", "/api/show", &patterns);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().protocol, "ollama_model_discovery");
+    }
+
+    #[test]
+    fn no_match_ollama_chat_get() {
+        let patterns = default_patterns();
+        let result = detect_inference_pattern("GET", "/api/chat", &patterns);
         assert!(result.is_none());
     }
 

--- a/crates/openshell-sandbox/src/l7/inference.rs
+++ b/crates/openshell-sandbox/src/l7/inference.rs
@@ -14,6 +14,10 @@ pub struct InferenceApiPattern {
     pub path_glob: String,
     pub protocol: String,
     pub kind: String,
+    /// When true, the `/v1` version prefix is stripped from the request path
+    /// before forwarding to the backend. This is needed for endpoints whose
+    /// base URL does not include `/v1` (e.g. `chatgpt.com/backend-api`).
+    pub strip_version_prefix: bool,
 }
 
 /// Default patterns for known inference APIs (`OpenAI`, Anthropic).
@@ -24,60 +28,70 @@ pub fn default_patterns() -> Vec<InferenceApiPattern> {
             path_glob: "/v1/chat/completions".to_string(),
             protocol: "openai_chat_completions".to_string(),
             kind: "chat_completion".to_string(),
+            strip_version_prefix: false,
         },
         InferenceApiPattern {
             method: "POST".to_string(),
             path_glob: "/v1/completions".to_string(),
             protocol: "openai_completions".to_string(),
             kind: "completion".to_string(),
+            strip_version_prefix: false,
         },
         InferenceApiPattern {
             method: "POST".to_string(),
             path_glob: "/v1/responses".to_string(),
             protocol: "openai_responses".to_string(),
             kind: "responses".to_string(),
+            strip_version_prefix: false,
         },
         InferenceApiPattern {
             method: "POST".to_string(),
             path_glob: "/v1/codex/*".to_string(),
             protocol: "openai_responses".to_string(),
             kind: "codex_responses".to_string(),
+            strip_version_prefix: true,
         },
         InferenceApiPattern {
             method: "POST".to_string(),
             path_glob: "/v1/messages".to_string(),
             protocol: "anthropic_messages".to_string(),
             kind: "messages".to_string(),
+            strip_version_prefix: false,
         },
         InferenceApiPattern {
             method: "POST".to_string(),
             path_glob: "/api/chat".to_string(),
             protocol: "ollama_chat".to_string(),
             kind: "ollama_chat".to_string(),
+            strip_version_prefix: false,
         },
         InferenceApiPattern {
             method: "GET".to_string(),
             path_glob: "/api/tags".to_string(),
             protocol: "ollama_model_discovery".to_string(),
             kind: "ollama_tags".to_string(),
+            strip_version_prefix: false,
         },
         InferenceApiPattern {
             method: "POST".to_string(),
             path_glob: "/api/show".to_string(),
             protocol: "ollama_model_discovery".to_string(),
             kind: "ollama_show".to_string(),
+            strip_version_prefix: false,
         },
         InferenceApiPattern {
             method: "GET".to_string(),
             path_glob: "/v1/models".to_string(),
             protocol: "model_discovery".to_string(),
             kind: "models_list".to_string(),
+            strip_version_prefix: false,
         },
         InferenceApiPattern {
             method: "GET".to_string(),
             path_glob: "/v1/models/*".to_string(),
             protocol: "model_discovery".to_string(),
             kind: "models_get".to_string(),
+            strip_version_prefix: false,
         },
     ]
 }

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -1175,12 +1175,21 @@ async fn route_inference_request(
             .ok()
             .and_then(|v| v.get("model")?.as_str().map(String::from));
 
+        // For patterns like codex that set strip_version_prefix, remove the
+        // /v1 proxy artifact from the path so the backend endpoint base URL
+        // alone controls the path prefix.
+        let routed_path = if pattern.strip_version_prefix && normalized_path.starts_with("/v1/") {
+            &normalized_path[3..]
+        } else {
+            &normalized_path
+        };
+
         match ctx
             .router
             .proxy_with_candidates_streaming(
                 &pattern.protocol,
                 &request.method,
-                &normalized_path,
+                routed_path,
                 filtered_headers,
                 bytes::Bytes::from(request.body.clone()),
                 &routes,

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -115,7 +115,7 @@ impl InferenceContext {
     ) -> Result<openshell_router::ProxyResponse, openshell_router::RouterError> {
         let routes = self.system_routes.read().await;
         self.router
-            .proxy_with_candidates(protocol, method, path, headers, body, &routes)
+            .proxy_with_candidates(protocol, method, path, headers, body, &routes, None)
             .await
     }
 }
@@ -1169,6 +1169,12 @@ async fn route_inference_request(
             return Ok(true);
         }
 
+        // Extract the model field from the JSON body as a routing hint.
+        // If parsing fails or model is absent, we fall back to protocol-only matching.
+        let model_hint = serde_json::from_slice::<serde_json::Value>(&request.body)
+            .ok()
+            .and_then(|v| v.get("model")?.as_str().map(String::from));
+
         match ctx
             .router
             .proxy_with_candidates_streaming(
@@ -1178,6 +1184,7 @@ async fn route_inference_request(
                 filtered_headers,
                 bytes::Bytes::from(request.body.clone()),
                 &routes,
+                model_hint.as_deref(),
             )
             .await
         {

--- a/crates/openshell-server/src/inference.rs
+++ b/crates/openshell-server/src/inference.rs
@@ -3,9 +3,9 @@
 
 use openshell_core::proto::{
     ClusterInferenceConfig, GetClusterInferenceRequest, GetClusterInferenceResponse,
-    GetInferenceBundleRequest, GetInferenceBundleResponse, InferenceRoute, Provider, ResolvedRoute,
-    SetClusterInferenceRequest, SetClusterInferenceResponse, ValidatedEndpoint,
-    inference_server::Inference,
+    GetInferenceBundleRequest, GetInferenceBundleResponse, InferenceModelEntry, InferenceRoute,
+    Provider, ResolvedRoute, SetClusterInferenceRequest, SetClusterInferenceResponse,
+    ValidatedEndpoint, inference_server::Inference,
 };
 use openshell_router::config::ResolvedRoute as RouterResolvedRoute;
 use openshell_router::{ValidationFailureKind, verify_backend_endpoint};
@@ -81,6 +81,36 @@ impl Inference for InferenceService {
         let req = request.into_inner();
         let route_name = effective_route_name(&req.route_name)?;
         let verify = !req.no_verify;
+
+        // Multi-model path: when models list is non-empty, use it.
+        if !req.models.is_empty() {
+            let result = upsert_multi_model_route(
+                self.state.store.as_ref(),
+                route_name,
+                &req.models,
+                verify,
+            )
+            .await?;
+
+            let config = result
+                .route
+                .config
+                .as_ref()
+                .ok_or_else(|| Status::internal("managed route missing config"))?;
+
+            return Ok(Response::new(SetClusterInferenceResponse {
+                provider_name: config.provider_name.clone(),
+                model_id: config.model_id.clone(),
+                version: result.route.version,
+                route_name: route_name.to_string(),
+                validation_performed: !result.validation.is_empty(),
+                validated_endpoints: result.validation,
+                timeout_secs: config.timeout_secs,
+                models: config.models.clone(),
+            }));
+        }
+
+        // Legacy single-model path.
         let route = upsert_cluster_inference_route(
             self.state.store.as_ref(),
             route_name,
@@ -105,6 +135,7 @@ impl Inference for InferenceService {
             validation_performed: !route.validation.is_empty(),
             validated_endpoints: route.validation,
             timeout_secs: config.timeout_secs,
+            models: Vec::new(),
         }))
     }
 
@@ -143,6 +174,7 @@ impl Inference for InferenceService {
             version: route.version,
             route_name: route_name.to_string(),
             timeout_secs: config.timeout_secs,
+            models: config.models.clone(),
         }))
     }
 }
@@ -208,6 +240,110 @@ async fn upsert_cluster_inference_route(
     Ok(UpsertedInferenceRoute { route, validation })
 }
 
+/// Upsert a multi-model inference route.
+///
+/// Each entry in `models` is validated against its provider, then all entries
+/// are stored atomically in a single `ClusterInferenceConfig`.
+async fn upsert_multi_model_route(
+    store: &Store,
+    route_name: &str,
+    models: &[InferenceModelEntry],
+    verify: bool,
+) -> Result<UpsertedInferenceRoute, Status> {
+    if models.is_empty() {
+        return Err(Status::invalid_argument("models list is empty"));
+    }
+
+    // Validate aliases are unique.
+    let mut seen_aliases = std::collections::HashSet::new();
+    for entry in models {
+        if entry.alias.trim().is_empty() {
+            return Err(Status::invalid_argument(
+                "each model entry must have a non-empty alias",
+            ));
+        }
+        if entry.provider_name.trim().is_empty() {
+            return Err(Status::invalid_argument(format!(
+                "model entry '{}' is missing provider_name",
+                entry.alias,
+            )));
+        }
+        if entry.model_id.trim().is_empty() {
+            return Err(Status::invalid_argument(format!(
+                "model entry '{}' is missing model_id",
+                entry.alias,
+            )));
+        }
+        let alias_key = entry.alias.trim().to_ascii_lowercase();
+        if !seen_aliases.insert(alias_key) {
+            return Err(Status::invalid_argument(format!(
+                "duplicate alias '{}'",
+                entry.alias,
+            )));
+        }
+    }
+
+    // Validate each entry's provider exists and is inference-capable.
+    let mut validation = Vec::new();
+    for entry in models {
+        let provider = store
+            .get_message_by_name::<Provider>(&entry.provider_name)
+            .await
+            .map_err(|e| Status::internal(format!("fetch provider failed: {e}")))?
+            .ok_or_else(|| {
+                Status::failed_precondition(format!(
+                    "provider '{}' (for alias '{}') not found",
+                    entry.provider_name, entry.alias,
+                ))
+            })?;
+
+        let resolved = resolve_provider_route(&provider)?;
+
+        if verify {
+            validation.push(
+                verify_provider_endpoint(&provider.name, &entry.model_id, &resolved).await?,
+            );
+        }
+    }
+
+    // Use the first entry's provider as the legacy single-model fields for
+    // backward compat (old clients reading the config see something useful).
+    let config = ClusterInferenceConfig {
+        provider_name: models[0].provider_name.clone(),
+        model_id: models[0].model_id.clone(),
+        timeout_secs: 0,
+        models: models.to_vec(),
+    };
+
+    let existing = store
+        .get_message_by_name::<InferenceRoute>(route_name)
+        .await
+        .map_err(|e| Status::internal(format!("fetch route failed: {e}")))?;
+
+    let route = if let Some(existing) = existing {
+        InferenceRoute {
+            id: existing.id,
+            name: existing.name,
+            config: Some(config),
+            version: existing.version.saturating_add(1),
+        }
+    } else {
+        InferenceRoute {
+            id: uuid::Uuid::new_v4().to_string(),
+            name: route_name.to_string(),
+            config: Some(config),
+            version: 1,
+        }
+    };
+
+    store
+        .put_message(&route)
+        .await
+        .map_err(|e| Status::internal(format!("persist route failed: {e}")))?;
+
+    Ok(UpsertedInferenceRoute { route, validation })
+}
+
 fn build_cluster_inference_config(
     provider: &Provider,
     model_id: &str,
@@ -217,6 +353,7 @@ fn build_cluster_inference_config(
         provider_name: provider.name.clone(),
         model_id: model_id.to_string(),
         timeout_secs,
+        models: Vec::new(),
     }
 }
 
@@ -381,12 +518,8 @@ fn find_provider_config_value(provider: &Provider, preferred_keys: &[&str]) -> O
 /// Resolve the inference bundle (all managed routes + revision hash).
 async fn resolve_inference_bundle(store: &Store) -> Result<GetInferenceBundleResponse, Status> {
     let mut routes = Vec::new();
-    if let Some(r) = resolve_route_by_name(store, CLUSTER_INFERENCE_ROUTE_NAME).await? {
-        routes.push(r);
-    }
-    if let Some(r) = resolve_route_by_name(store, SANDBOX_SYSTEM_ROUTE_NAME).await? {
-        routes.push(r);
-    }
+    routes.extend(resolve_route_by_name(store, CLUSTER_INFERENCE_ROUTE_NAME).await?);
+    routes.extend(resolve_route_by_name(store, SANDBOX_SYSTEM_ROUTE_NAME).await?);
 
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -419,20 +552,49 @@ async fn resolve_inference_bundle(store: &Store) -> Result<GetInferenceBundleRes
 async fn resolve_route_by_name(
     store: &Store,
     route_name: &str,
-) -> Result<Option<ResolvedRoute>, Status> {
+) -> Result<Vec<ResolvedRoute>, Status> {
     let route = store
         .get_message_by_name::<InferenceRoute>(route_name)
         .await
         .map_err(|e| Status::internal(format!("fetch route failed: {e}")))?;
 
     let Some(route) = route else {
-        return Ok(None);
+        return Ok(Vec::new());
     };
 
     let Some(config) = route.config.as_ref() else {
-        return Ok(None);
+        return Ok(Vec::new());
     };
 
+    // Multi-model path: each model entry becomes a separate ResolvedRoute with name = alias.
+    if !config.models.is_empty() {
+        let mut results = Vec::with_capacity(config.models.len());
+        for entry in &config.models {
+            let provider = store
+                .get_message_by_name::<Provider>(&entry.provider_name)
+                .await
+                .map_err(|e| Status::internal(format!("fetch provider failed: {e}")))?
+                .ok_or_else(|| {
+                    Status::failed_precondition(format!(
+                        "configured provider '{}' was not found",
+                        entry.provider_name
+                    ))
+                })?;
+            let resolved = resolve_provider_route(&provider)?;
+            results.push(ResolvedRoute {
+                name: entry.alias.clone(),
+                base_url: resolved.route.endpoint,
+                model_id: entry.model_id.clone(),
+                api_key: resolved.route.api_key,
+                protocols: resolved.route.protocols,
+                provider_type: resolved.provider_type,
+                timeout_secs: config.timeout_secs,
+            });
+        }
+        return Ok(results);
+    }
+
+    // Legacy single-model path.
     if config.provider_name.trim().is_empty() {
         return Err(Status::failed_precondition(format!(
             "route '{route_name}' is missing provider_name"
@@ -458,7 +620,7 @@ async fn resolve_route_by_name(
 
     let resolved = resolve_provider_route(&provider)?;
 
-    Ok(Some(ResolvedRoute {
+    Ok(vec![ResolvedRoute {
         name: route_name.to_string(),
         base_url: resolved.route.endpoint,
         model_id: config.model_id.clone(),
@@ -466,7 +628,7 @@ async fn resolve_route_by_name(
         protocols: resolved.route.protocols,
         provider_type: resolved.provider_type,
         timeout_secs: config.timeout_secs,
-    }))
+    }])
 }
 
 #[cfg(test)]
@@ -483,6 +645,7 @@ mod tests {
                 provider_name: provider_name.to_string(),
                 model_id: model_id.to_string(),
                 timeout_secs: 0,
+                models: Vec::new(),
             }),
             version: 1,
         }
@@ -561,10 +724,10 @@ mod tests {
             .await
             .expect("store should connect");
 
-        let route = resolve_route_by_name(&store, CLUSTER_INFERENCE_ROUTE_NAME)
+        let routes = resolve_route_by_name(&store, CLUSTER_INFERENCE_ROUTE_NAME)
             .await
             .expect("resolution should not fail");
-        assert!(route.is_none());
+        assert!(routes.is_empty());
     }
 
     #[tokio::test]
@@ -670,6 +833,7 @@ mod tests {
                 provider_name: "openai-dev".to_string(),
                 model_id: "test/model".to_string(),
                 timeout_secs: 0,
+                models: Vec::new(),
             }),
             version: 7,
         };
@@ -681,6 +845,8 @@ mod tests {
         let managed = resolve_route_by_name(&store, CLUSTER_INFERENCE_ROUTE_NAME)
             .await
             .expect("route should resolve")
+            .into_iter()
+            .next()
             .expect("managed route should exist");
 
         assert_eq!(managed.base_url, "https://station.example.com/v1");
@@ -718,6 +884,8 @@ mod tests {
         let first = resolve_route_by_name(&store, CLUSTER_INFERENCE_ROUTE_NAME)
             .await
             .expect("route should resolve")
+            .into_iter()
+            .next()
             .expect("managed route should exist");
         assert_eq!(first.api_key, "sk-initial");
 
@@ -737,6 +905,8 @@ mod tests {
         let second = resolve_route_by_name(&store, CLUSTER_INFERENCE_ROUTE_NAME)
             .await
             .expect("route should resolve")
+            .into_iter()
+            .next()
             .expect("managed route should exist");
         assert_eq!(second.api_key, "sk-rotated");
     }
@@ -1026,5 +1196,141 @@ mod tests {
     fn effective_route_name_rejects_unknown_name() {
         let err = effective_route_name("unknown-route").unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn resolve_multi_model_route_returns_per_alias_routes() {
+        let store = Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("store");
+
+        let openai = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-openai");
+        let anthropic = make_provider("anthropic-dev", "anthropic", "ANTHROPIC_API_KEY", "sk-ant");
+        store.put_message(&openai).await.expect("persist openai");
+        store
+            .put_message(&anthropic)
+            .await
+            .expect("persist anthropic");
+
+        let route = InferenceRoute {
+            id: "r-multi".to_string(),
+            name: CLUSTER_INFERENCE_ROUTE_NAME.to_string(),
+            config: Some(ClusterInferenceConfig {
+                provider_name: "openai-dev".to_string(),
+                model_id: "gpt-4o".to_string(),
+                models: vec![
+                    InferenceModelEntry {
+                        alias: "my-gpt".to_string(),
+                        provider_name: "openai-dev".to_string(),
+                        model_id: "gpt-4o".to_string(),
+                    },
+                    InferenceModelEntry {
+                        alias: "my-claude".to_string(),
+                        provider_name: "anthropic-dev".to_string(),
+                        model_id: "claude-sonnet-4-20250514".to_string(),
+                    },
+                ],
+            }),
+            version: 1,
+        };
+        store.put_message(&route).await.expect("persist route");
+
+        let resolved = resolve_route_by_name(&store, CLUSTER_INFERENCE_ROUTE_NAME)
+            .await
+            .expect("should resolve");
+
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0].name, "my-gpt");
+        assert_eq!(resolved[0].model_id, "gpt-4o");
+        assert_eq!(resolved[0].provider_type, "openai");
+        assert_eq!(resolved[1].name, "my-claude");
+        assert_eq!(resolved[1].model_id, "claude-sonnet-4-20250514");
+        assert_eq!(resolved[1].provider_type, "anthropic");
+    }
+
+    #[tokio::test]
+    async fn bundle_with_multi_model_route_includes_all_aliases() {
+        let store = Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("store");
+
+        let openai = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-openai");
+        let anthropic = make_provider("anthropic-dev", "anthropic", "ANTHROPIC_API_KEY", "sk-ant");
+        store.put_message(&openai).await.expect("persist openai");
+        store
+            .put_message(&anthropic)
+            .await
+            .expect("persist anthropic");
+
+        let route = InferenceRoute {
+            id: "r-multi".to_string(),
+            name: CLUSTER_INFERENCE_ROUTE_NAME.to_string(),
+            config: Some(ClusterInferenceConfig {
+                provider_name: "openai-dev".to_string(),
+                model_id: "gpt-4o".to_string(),
+                models: vec![
+                    InferenceModelEntry {
+                        alias: "my-gpt".to_string(),
+                        provider_name: "openai-dev".to_string(),
+                        model_id: "gpt-4o".to_string(),
+                    },
+                    InferenceModelEntry {
+                        alias: "my-claude".to_string(),
+                        provider_name: "anthropic-dev".to_string(),
+                        model_id: "claude-sonnet-4-20250514".to_string(),
+                    },
+                ],
+            }),
+            version: 1,
+        };
+        store.put_message(&route).await.expect("persist route");
+
+        let bundle = resolve_inference_bundle(&store)
+            .await
+            .expect("bundle should resolve");
+
+        assert_eq!(bundle.routes.len(), 2);
+        let names: Vec<&str> = bundle.routes.iter().map(|r| r.name.as_str()).collect();
+        assert!(names.contains(&"my-gpt"));
+        assert!(names.contains(&"my-claude"));
+    }
+
+    #[tokio::test]
+    async fn upsert_multi_model_route_stores_and_retrieves() {
+        let store = Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("store");
+
+        let openai = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-openai");
+        store.put_message(&openai).await.expect("persist");
+
+        let models = vec![InferenceModelEntry {
+            alias: "fast-gpt".to_string(),
+            provider_name: "openai-dev".to_string(),
+            model_id: "gpt-4o-mini".to_string(),
+        }];
+
+        let result = upsert_multi_model_route(
+            &store,
+            CLUSTER_INFERENCE_ROUTE_NAME,
+            &models,
+            false,
+        )
+        .await
+        .expect("upsert should succeed");
+
+        assert_eq!(result.route.version, 1);
+        assert_eq!(result.route.config.as_ref().unwrap().models.len(), 1);
+        assert_eq!(result.route.config.as_ref().unwrap().models[0].alias, "fast-gpt");
+
+        // Legacy fields should be populated from first entry
+        assert_eq!(
+            result.route.config.as_ref().unwrap().provider_name,
+            "openai-dev"
+        );
+        assert_eq!(
+            result.route.config.as_ref().unwrap().model_id,
+            "gpt-4o-mini"
+        );
     }
 }

--- a/crates/openshell-server/src/inference.rs
+++ b/crates/openshell-server/src/inference.rs
@@ -254,6 +254,14 @@ async fn upsert_multi_model_route(
         return Err(Status::invalid_argument("models list is empty"));
     }
 
+    // The system route must remain single-model so the sandbox can always
+    // resolve it to exactly one backend without alias selection.
+    if route_name == SANDBOX_SYSTEM_ROUTE_NAME {
+        return Err(Status::invalid_argument(
+            "multi-model is not supported on the system route",
+        ));
+    }
+
     // Names reserved for internal route partitioning (sandbox uses
     // `name == "sandbox-system"` to split user vs system caches).
     const RESERVED_ALIASES: &[&str] = &["sandbox-system", "inference.local"];
@@ -1228,6 +1236,7 @@ mod tests {
             config: Some(ClusterInferenceConfig {
                 provider_name: "openai-dev".to_string(),
                 model_id: "gpt-4o".to_string(),
+                timeout_secs: 0,
                 models: vec![
                     InferenceModelEntry {
                         alias: "my-gpt".to_string(),
@@ -1278,6 +1287,7 @@ mod tests {
             config: Some(ClusterInferenceConfig {
                 provider_name: "openai-dev".to_string(),
                 model_id: "gpt-4o".to_string(),
+                timeout_secs: 0,
                 models: vec![
                     InferenceModelEntry {
                         alias: "my-gpt".to_string(),
@@ -1362,5 +1372,27 @@ mod tests {
             .expect_err("should reject reserved alias");
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
         assert!(err.message().contains("reserved"));
+    }
+
+    #[tokio::test]
+    async fn upsert_multi_model_route_rejects_system_route() {
+        let store = Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("store");
+
+        let openai = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-openai");
+        store.put_message(&openai).await.expect("persist");
+
+        let models = vec![InferenceModelEntry {
+            alias: "fast-gpt".to_string(),
+            provider_name: "openai-dev".to_string(),
+            model_id: "gpt-4o-mini".to_string(),
+        }];
+
+        let err = upsert_multi_model_route(&store, SANDBOX_SYSTEM_ROUTE_NAME, &models, false)
+            .await
+            .expect_err("should reject system route");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("system route"));
     }
 }

--- a/crates/openshell-server/src/inference.rs
+++ b/crates/openshell-server/src/inference.rs
@@ -254,6 +254,10 @@ async fn upsert_multi_model_route(
         return Err(Status::invalid_argument("models list is empty"));
     }
 
+    // Names reserved for internal route partitioning (sandbox uses
+    // `name == "sandbox-system"` to split user vs system caches).
+    const RESERVED_ALIASES: &[&str] = &["sandbox-system", "inference.local"];
+
     // Validate aliases are unique.
     let mut seen_aliases = std::collections::HashSet::new();
     for entry in models {
@@ -261,6 +265,13 @@ async fn upsert_multi_model_route(
             return Err(Status::invalid_argument(
                 "each model entry must have a non-empty alias",
             ));
+        }
+        let alias_lower = entry.alias.trim().to_ascii_lowercase();
+        if RESERVED_ALIASES.iter().any(|r| *r == alias_lower) {
+            return Err(Status::invalid_argument(format!(
+                "alias '{}' is reserved and cannot be used",
+                entry.alias,
+            )));
         }
         if entry.provider_name.trim().is_empty() {
             return Err(Status::invalid_argument(format!(
@@ -300,9 +311,8 @@ async fn upsert_multi_model_route(
         let resolved = resolve_provider_route(&provider)?;
 
         if verify {
-            validation.push(
-                verify_provider_endpoint(&provider.name, &entry.model_id, &resolved).await?,
-            );
+            validation
+                .push(verify_provider_endpoint(&provider.name, &entry.model_id, &resolved).await?);
         }
     }
 
@@ -1059,7 +1069,7 @@ mod tests {
             "OPENAI_API_KEY",
             "sk-test",
             "OPENAI_BASE_URL",
-            &mock_server.uri(),
+            &format!("{}/v1", mock_server.uri()),
         );
         store
             .put_message(&provider)
@@ -1101,7 +1111,7 @@ mod tests {
             "OPENAI_API_KEY",
             "sk-test",
             "OPENAI_BASE_URL",
-            &mock_server.uri(),
+            &format!("{}/v1", mock_server.uri()),
         );
         store
             .put_message(&provider)
@@ -1310,18 +1320,16 @@ mod tests {
             model_id: "gpt-4o-mini".to_string(),
         }];
 
-        let result = upsert_multi_model_route(
-            &store,
-            CLUSTER_INFERENCE_ROUTE_NAME,
-            &models,
-            false,
-        )
-        .await
-        .expect("upsert should succeed");
+        let result = upsert_multi_model_route(&store, CLUSTER_INFERENCE_ROUTE_NAME, &models, false)
+            .await
+            .expect("upsert should succeed");
 
         assert_eq!(result.route.version, 1);
         assert_eq!(result.route.config.as_ref().unwrap().models.len(), 1);
-        assert_eq!(result.route.config.as_ref().unwrap().models[0].alias, "fast-gpt");
+        assert_eq!(
+            result.route.config.as_ref().unwrap().models[0].alias,
+            "fast-gpt"
+        );
 
         // Legacy fields should be populated from first entry
         assert_eq!(
@@ -1332,5 +1340,27 @@ mod tests {
             result.route.config.as_ref().unwrap().model_id,
             "gpt-4o-mini"
         );
+    }
+
+    #[tokio::test]
+    async fn upsert_multi_model_route_rejects_reserved_alias() {
+        let store = Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("store");
+
+        let openai = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-openai");
+        store.put_message(&openai).await.expect("persist");
+
+        let models = vec![InferenceModelEntry {
+            alias: "sandbox-system".to_string(),
+            provider_name: "openai-dev".to_string(),
+            model_id: "gpt-4o".to_string(),
+        }];
+
+        let err = upsert_multi_model_route(&store, CLUSTER_INFERENCE_ROUTE_NAME, &models, false)
+            .await
+            .expect_err("should reject reserved alias");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("reserved"));
     }
 }

--- a/proto/inference.proto
+++ b/proto/inference.proto
@@ -28,12 +28,26 @@ service Inference {
 // Only `provider_name` and `model_id` are stored; endpoint, protocols,
 // credentials, and auth style are resolved from the provider at bundle time.
 message ClusterInferenceConfig {
-  // Provider record name backing this route.
+  // Provider record name backing this route (legacy single-model).
   string provider_name = 1;
-  // Model identifier to force on generation calls.
+  // Model identifier to force on generation calls (legacy single-model).
   string model_id = 2;
   // Per-route request timeout in seconds. 0 means use default (60s).
   uint64 timeout_secs = 3;
+  // Multi-model entries. When non-empty, takes precedence over the single
+  // provider_name/model_id fields above.
+  repeated InferenceModelEntry models = 4;
+}
+
+// A single model entry within a multi-model inference configuration.
+message InferenceModelEntry {
+  // Short alias used by agents in the "model" field (e.g. "qwen-coder").
+  // The proxy matches this against the model field in API request payloads.
+  string alias = 1;
+  // Provider record name (e.g. "ollama-local", "openai-dev").
+  string provider_name = 2;
+  // Backend model identifier (e.g. "qwen3-coder:30b", "gpt-5.4").
+  string model_id = 3;
 }
 
 // Storage envelope for the managed cluster inference route.
@@ -48,9 +62,9 @@ message InferenceRoute {
 }
 
 message SetClusterInferenceRequest {
-  // Provider record name to use for credentials + endpoint mapping.
+  // Provider record name to use for credentials + endpoint mapping (legacy single-model).
   string provider_name = 1;
-  // Model identifier to force on generation calls.
+  // Model identifier to force on generation calls (legacy single-model).
   string model_id = 2;
   // Route name to target. Empty string defaults to "inference.local" (user-facing).
   // Use "sandbox-system" for the sandbox system-level inference route.
@@ -61,6 +75,9 @@ message SetClusterInferenceRequest {
   bool no_verify = 5;
   // Per-route request timeout in seconds. 0 means use default (60s).
   uint64 timeout_secs = 6;
+  // Multi-model entries. When non-empty, takes precedence over single
+  // provider_name/model_id above.
+  repeated InferenceModelEntry models = 7;
 }
 
 message ValidatedEndpoint {
@@ -80,6 +97,8 @@ message SetClusterInferenceResponse {
   repeated ValidatedEndpoint validated_endpoints = 6;
   // Per-route request timeout in seconds that was persisted.
   uint64 timeout_secs = 7;
+  // Multi-model entries that were configured (echoed back).
+  repeated InferenceModelEntry models = 8;
 }
 
 message GetClusterInferenceRequest {
@@ -96,6 +115,8 @@ message GetClusterInferenceResponse {
   string route_name = 4;
   // Per-route request timeout in seconds. 0 means default (60s).
   uint64 timeout_secs = 5;
+  // Multi-model entries when configured.
+  repeated InferenceModelEntry models = 6;
 }
 
 message GetInferenceBundleRequest {}


### PR DESCRIPTION
## Summary

Adds multi-route inference proxy support, allowing sandboxed agents to reach multiple LLM providers (OpenAI, Anthropic, NVIDIA, Ollama) through a single `inference.local` endpoint. Agents select a backend by setting the `model` field to an alias name. Also adds Ollama native API support and Codex URL pattern matching.

## Related Issue

Closes #203

## Changes

- **Proto**: Add `InferenceModelEntry` message (`alias`, `provider_name`, `model_id`); add `models` repeated field to set/get request/response messages
- **Server**: `upsert_multi_model_route()` validates and stores multiple alias→provider mappings; resolves each entry into a separate `ResolvedRoute` at bundle time
- **Router**: `select_route()` implements alias-first, protocol-fallback selection; `proxy_with_candidates`/`proxy_with_candidates_streaming` accept optional `model_hint`
- **Sandbox proxy**: Extracts `model` field from request body as `model_hint` for route selection
- **Sandbox L7**: Add `/v1/codex/*`, `/api/chat`, `/api/tags`, `/api/show` inference patterns
- **Backend**: `build_backend_url()` always strips `/v1` prefix to support both versioned and non-versioned endpoints (e.g. Codex)
- **Core**: Add `OLLAMA_PROFILE` provider profile with native + OpenAI-compat protocols
- **CLI**: `--model-alias ALIAS=PROVIDER/MODEL` flag (repeatable, conflicts with `--provider`/`--model`)
- **Architecture docs**: Updated `inference-routing.md` with all new sections

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)