### PR TITLE
fix(install): make checksum verification mandatory

### DIFF
--- a/e2e/install/sh_test.sh
+++ b/e2e/install/sh_test.sh
@@ -71,13 +71,15 @@ test_guidance_mentions_restart() {
 test_skip_checksum_env() {
   printf 'TEST: OPENSHELL_NO_VERIFY=1 skips checksum verification\n'
 
-  _skip_dir="$(mktemp -d)/bin"
+  _skip_base="$(mktemp -d)"
+  _skip_dir="${_skip_base}/bin"
   _skip_output="$(OPENSHELL_NO_VERIFY=1 \
     OPENSHELL_INSTALL_DIR="$_skip_dir" \
     SHELL="/bin/sh" \
     PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
     sh "$INSTALL_SCRIPT" 2>&1)" || {
     fail "install succeeds with OPENSHELL_NO_VERIFY=1" "exit code: $?"
+    rm -rf "$_skip_base"
     return 1
   }
 
@@ -89,6 +91,7 @@ test_skip_checksum_env() {
   else
     fail "binary installed with checksum skip" "not found at $_skip_dir/openshell"
   fi
+  rm -rf "$_skip_base"
 }
 
 test_no_env_scripts_created() {

--- a/install.sh
+++ b/install.sh
@@ -227,7 +227,12 @@ is_on_path() {
 # ---------------------------------------------------------------------------
 
 main() {
-  _skip_checksum="${OPENSHELL_NO_VERIFY:-0}"
+  # Normalise OPENSHELL_NO_VERIFY to "1" or "0".
+  # Accept common truthy values: 1, true, yes, y (case-insensitive).
+  case "$(printf '%s' "${OPENSHELL_NO_VERIFY:-}" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|y) _skip_checksum=1 ;;
+    *)            _skip_checksum=0 ;;
+  esac
 
   # Parse CLI flags
   for arg in "$@"; do


### PR DESCRIPTION
## Summary

Makes SHA-256 checksum verification mandatory in `install.sh` instead of silently skipping it when tools or files are unavailable. Adds an explicit opt-out (`--no-verify-checksum` / `OPENSHELL_NO_VERIFY=1`) for environments where verification is not feasible.

## Related Issue

Closes #590

## Changes

**`install.sh`**

1. **`verify_checksum()`**: `warn` → `error` when `sha256sum`/`shasum` is unavailable (line 200) or when no checksum entry exists for the archive (line 192). Previously both cases returned 0, allowing an unverified binary to be installed.

2. **`main()`**: `warn` → `error` when the checksums file cannot be downloaded (line 276). Previously the installer continued without any verification.

3. **New flag**: `--no-verify-checksum` CLI flag and `OPENSHELL_NO_VERIFY=1` env var to explicitly opt out. Error messages reference the env var so users know how to proceed if verification cannot be performed.

4. **`usage()`**: Documents the new flag, env var, and adds an example.

## Testing

- [x] `shellcheck install.sh` — zero warnings
- [x] `sh -n install.sh` — syntax valid
- [x] Existing e2e tests (`e2e/install/{sh,bash,zsh}_test.sh`) unaffected — they use real releases with checksums available
- [x] CI passes on fork: https://github.com/areporeporepo/OpenShell-1/pull/1

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] No secrets or credentials committed
- [x] Changes scoped to the issue at hand