### PR TITLE
Missed input parameter to init OpenClaw container

### DIFF
--- a/examples/openclaw.md
+++ b/examples/openclaw.md
@@ -3,7 +3,7 @@
 ## Quick start
 
 ```sh
-openshell sandbox create --forward 18789 -- openclaw-start
+openshell sandbox create --forward 18789 --from openclaw -- openclaw-start
 ```
 
 `openclaw-start` is a helper script pre-installed in the sandbox that runs the
@@ -25,7 +25,7 @@ Note: you will need use the auth token present in the bootstrapping process to c
 ### Create the sandbox
 
 ```sh
-openshell sandbox create --forward 18789
+openshell sandbox create --forward 18789 --from openclaw
 ```
 
 Inside the sandbox, run the onboarding wizard and start the gateway:


### PR DESCRIPTION
## Summary
Missed _--from openclaw_ input parameter.
Without this input sandbox container didn't install "openclaw" by default

### Current MD sample
```
$ openshell sandbox create --forward 18789  -- openclaw-start
                                                                                                                       Created sandbox: eager-dragonfly                                                                                                                                                                                                                ✓ Forwarding port 18789 to sandbox eager-dragonfly in the background

  Access at: http://127.0.0.1:18789/
  Stop with: openshell forward stop 18789 eager-dragonfly
**/bin/bash: line 1: openclaw-start: command not found**
```

### Fixed MD Sample
```
$ openshell sandbox create --forward 18789 --from openclaw  -- openclaw-start
                                                                                                                       Created sandbox: muscular-doe                                                                                                                                                                                                                   ✓ Forwarding port 18789 to sandbox muscular-doe in the background

  Access at: http://127.0.0.1:18789/
  Stop with: openshell forward stop 18789 muscular-doe
(node:44) [UNDICI-EHPA] Warning: EnvHttpProxyAgent is experimental, expect them to change at any time.
(Use `node --trace-warnings ...` to show where the warning was created)
(node:52) [UNDICI-EHPA] Warning: EnvHttpProxyAgent is experimental, expect them to change at any time.
(Use `node --trace-warnings ...` to show where the warning was created)

🦞 OpenClaw 2026.3.11 (29dc654) — Alexa, but with taste.

```

## Related Issue
No related issue

## Changes
Add input parameter to documentation

## Checklist
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ X ] Architecture docs updated (if applicable)
