### PR TITLE
fix(server): add database pool acquire, idle, and lifetime timeouts

### DIFF
--- a/crates/openshell-server/src/persistence/postgres.rs
+++ b/crates/openshell-server/src/persistence/postgres.rs
@@ -18,6 +18,9 @@ impl PostgresStore {
     pub async fn connect(url: &str) -> Result<Self> {
         let pool = PgPoolOptions::new()
             .max_connections(10)
+            .acquire_timeout(std::time::Duration::from_secs(5))
+            .idle_timeout(std::time::Duration::from_secs(300))
+            .max_lifetime(std::time::Duration::from_secs(1800))
             .connect(url)
             .await
             .map_err(|e| map_db_error(&e))?;

--- a/crates/openshell-server/src/persistence/sqlite.rs
+++ b/crates/openshell-server/src/persistence/sqlite.rs
@@ -30,6 +30,9 @@ impl SqliteStore {
         let pool = SqlitePoolOptions::new()
             .max_connections(max_connections)
             .min_connections(max_connections)
+            .acquire_timeout(std::time::Duration::from_secs(5))
+            .idle_timeout(std::time::Duration::from_secs(300))
+            .max_lifetime(std::time::Duration::from_secs(1800))
             .connect_with(options)
             .await
             .map_err(|e| map_db_error(&e))?;


### PR DESCRIPTION
## Summary
- Adds `acquire_timeout(5s)`, `idle_timeout(5m)`, and `max_lifetime(30m)` to both PostgreSQL and SQLite connection pools
- Prevents indefinite hangs when the database is unreachable or pool is exhausted
- Forces periodic connection recycling to avoid stale connections

## Related Issue
Production readiness audit finding (P0): database pool has no timeout configuration — can hang indefinitely on acquire.

## Changes
- `crates/openshell-server/src/persistence/postgres.rs`: Added three timeout settings to `PgPoolOptions`
- `crates/openshell-server/src/persistence/sqlite.rs`: Added matching timeout settings to `SqlitePoolOptions`

## Testing
- `cargo check -p openshell-server` passes
- Timeout values are conservative defaults that work for both dev and production

## Checklist
- [x] Conventional commit format
- [x] No secrets committed
- [x] Scoped to the issue at hand