### PR TITLE
perf: enable thin LTO in release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ missing_fields_in_debug = "allow"  # Manual Debug impls often intentionally omit
 
 [profile.release]
 strip = true
+lto = "thin"
 
 [profile.dev]
 # Faster compile times for dev builds


### PR DESCRIPTION
## Summary
- Adds `lto = "thin"` to the workspace release profile for better cross-crate optimization
- Thin LTO provides most of the binary size and performance benefits of full LTO with significantly faster link times

## Related Issue
Production readiness audit finding (P3): release profile has `strip = true` but no LTO.

## Changes
- `Cargo.toml` (workspace root): Added `lto = "thin"` to `[profile.release]`

## Testing
- `cargo check` passes
- Thin LTO is a well-established Rust optimization that requires no code changes

## Checklist
- [x] Conventional commit format
- [x] No secrets committed
- [x] Scoped to the issue at hand