### PR TITLE
fix(server): eliminate nested mutex acquisition in SSH tunnel handler

### DIFF
--- a/crates/openshell-server/src/ssh_tunnel.rs
+++ b/crates/openshell-server/src/ssh_tunnel.rs
@@ -123,22 +123,29 @@ async fn ssh_connect(
     }
 
     // Enforce per-sandbox concurrent connection limit.
-    {
+    let sandbox_over_limit = {
         let mut counts = state.ssh_connections_by_sandbox.lock().unwrap();
         let count = counts.entry(sandbox_id.clone()).or_insert(0);
         if *count >= MAX_CONNECTIONS_PER_SANDBOX {
-            // Roll back the per-token increment.
-            let mut token_counts = state.ssh_connections_by_token.lock().unwrap();
-            if let Some(c) = token_counts.get_mut(&token) {
-                *c = c.saturating_sub(1);
-                if *c == 0 {
-                    token_counts.remove(&token);
-                }
-            }
-            warn!(sandbox_id = %sandbox_id, "SSH tunnel: per-sandbox connection limit reached");
-            return StatusCode::TOO_MANY_REQUESTS.into_response();
+            true
+        } else {
+            *count += 1;
+            false
         }
-        *count += 1;
+    };
+    // Lock is released here before any rollback — avoids nested mutex acquisition.
+
+    if sandbox_over_limit {
+        // Roll back the per-token increment — no nested locks.
+        let mut token_counts = state.ssh_connections_by_token.lock().unwrap();
+        if let Some(c) = token_counts.get_mut(&token) {
+            *c = c.saturating_sub(1);
+            if *c == 0 {
+                token_counts.remove(&token);
+            }
+        }
+        warn!(sandbox_id = %sandbox_id, "SSH tunnel: per-sandbox connection limit reached");
+        return StatusCode::TOO_MANY_REQUESTS.into_response();
     }
 
     let handshake_secret = state.config.ssh_handshake_secret.clone();


### PR DESCRIPTION
## Summary
- Restructures the per-sandbox SSH connection limit check to release `ssh_connections_by_sandbox` before acquiring `ssh_connections_by_token` for rollback
- Eliminates a nested lock pattern (sandbox -> token) that risked deadlock if any other code path locked in reverse order

## Related Issue
Production readiness audit finding (P3): SSH connection dual-Mutex lock ordering could cause deadlocks.

## Changes
- `crates/openshell-server/src/ssh_tunnel.rs`: Split the per-sandbox limit check into two phases — check-and-release, then rollback separately

## Testing
- `cargo check -p openshell-server` passes
- `cargo clippy` clean (only pre-existing warnings)
- Audited `decrement_connection_count` helper — already acquires each mutex independently

## Checklist
- [x] Conventional commit format
- [x] No secrets committed
- [x] Scoped to the issue at hand