### PR TITLE
fix(server): add 10s timeout to TLS handshake

### DIFF
--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -206,18 +206,26 @@ pub async fn run_server(config: Config, tracing_log_bus: TracingLogBus) -> Resul
         if let Some(ref acceptor) = tls_acceptor {
             let tls_acceptor = acceptor.clone();
             tokio::spawn(async move {
-                match tls_acceptor.inner().accept(stream).await {
-                    Ok(tls_stream) => {
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(10),
+                    tls_acceptor.inner().accept(stream),
+                )
+                .await
+                {
+                    Ok(Ok(tls_stream)) => {
                         if let Err(e) = service.serve(tls_stream).await {
                             error!(error = %e, client = %addr, "Connection error");
                         }
                     }
-                    Err(e) => {
+                    Ok(Err(e)) => {
                         if is_benign_tls_handshake_failure(&e) {
                             debug!(error = %e, client = %addr, "TLS handshake closed early");
                         } else {
                             error!(error = %e, client = %addr, "TLS handshake failed");
                         }
+                    }
+                    Err(_) => {
+                        debug!(client = %addr, "TLS handshake timed out");
                     }
                 }
             });


### PR DESCRIPTION
## Summary
- Wraps the TLS `accept()` call with a 10-second `tokio::time::timeout` to prevent slowloris-style attacks
- Connections that fail to complete the TLS handshake within 10s are dropped with a debug log

## Related Issue
Production readiness audit finding (P1): no timeout on TLS handshake — a malicious client could hold a connection open indefinitely.

## Changes
- `crates/openshell-server/src/lib.rs`: Wrapped `tls_acceptor.inner().accept(stream)` with `tokio::time::timeout(Duration::from_secs(10), ...)`

## Testing
- `cargo check -p openshell-server` passes
- 10s is generous for legitimate clients while preventing indefinite hangs

## Checklist
- [x] Conventional commit format
- [x] No secrets committed
- [x] Scoped to the issue at hand