### PR TITLE
sec(l7): reject duplicate Content-Length headers to prevent request smuggling (CWE-444)

### DIFF
--- a/crates/openshell-sandbox/src/l7/inference.rs
+++ b/crates/openshell-sandbox/src/l7/inference.rs
@@ -96,6 +96,8 @@ pub enum ParseResult {
     Complete(ParsedHttpRequest, usize),
     /// Headers are incomplete — caller should read more data.
     Incomplete,
+    /// The request is malformed and must be rejected (e.g., duplicate Content-Length).
+    Invalid(String),
 }
 
 /// Try to parse an HTTP/1.1 request from raw bytes.
@@ -125,6 +127,7 @@ pub fn try_parse_http_request(buf: &[u8]) -> ParseResult {
 
     let mut headers = Vec::new();
     let mut content_length: usize = 0;
+    let mut has_content_length = false;
     let mut is_chunked = false;
     for line in lines {
         if line.is_empty() {
@@ -134,7 +137,14 @@ pub fn try_parse_http_request(buf: &[u8]) -> ParseResult {
             let name = name.trim().to_string();
             let value = value.trim().to_string();
             if name.eq_ignore_ascii_case("content-length") {
-                content_length = value.parse().unwrap_or(0);
+                let new_len: usize = value.parse().unwrap_or(0);
+                if has_content_length && new_len != content_length {
+                    return ParseResult::Invalid(format!(
+                        "duplicate Content-Length headers with differing values ({content_length} vs {new_len})"
+                    ));
+                }
+                content_length = new_len;
+                has_content_length = true;
             }
             if name.eq_ignore_ascii_case("transfer-encoding")
                 && value

--- a/crates/openshell-sandbox/src/l7/rest.rs
+++ b/crates/openshell-sandbox/src/l7/rest.rs
@@ -250,6 +250,13 @@ fn parse_body_length(headers: &str) -> Result<BodyLength> {
             && let Some(val) = lower.split_once(':').map(|(_, v)| v.trim())
             && let Ok(len) = val.parse::<u64>()
         {
+            if let Some(prev) = cl_value {
+                if prev != len {
+                    return Err(miette!(
+                        "Request contains multiple Content-Length headers with differing values ({prev} vs {len})"
+                    ));
+                }
+            }
             cl_value = Some(len);
         }
     }

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -943,6 +943,11 @@ async fn handle_inference_interception(
                     buf.resize((buf.len() * 2).min(MAX_INFERENCE_BUF), 0);
                 }
             }
+            ParseResult::Invalid(reason) => {
+                let response = format_http_response(400, &[], reason.as_bytes());
+                write_all(&mut tls_client, &response).await?;
+                return Ok(InferenceOutcome::Denied { reason });
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Both `parse_body_length()` in `rest.rs` and `try_parse_http_request()` in `inference.rs` silently accepted multiple `Content-Length` headers, overwriting with the last value
- Per RFC 7230 Section 3.3.3, differing Content-Length values must be rejected to prevent HTTP request smuggling (CWE-444)
- **rest.rs**: Detect duplicate CL headers with differing values and return `Err` before forwarding
- **inference.rs**: Add `ParseResult::Invalid` variant; detect duplicate CL headers and return `Invalid`
- **proxy.rs**: Handle `ParseResult::Invalid` by sending HTTP 400 and denying the connection

## Test plan
- [ ] Send a request with a single Content-Length header — verify it passes through normally
- [ ] Send a request with two identical Content-Length headers (e.g., `Content-Length: 10` twice) — verify it is accepted (idempotent duplicate is OK per RFC)
- [ ] Send a request with two differing Content-Length headers (e.g., `Content-Length: 0` and `Content-Length: 50`) — verify it is rejected with HTTP 400
- [ ] Existing CL+TE rejection test still passes
- [ ] Run `cargo test` for the crate

Closes #637