### PR TITLE
fix(sandbox): skip non-existent paths instead of abandoning Landlock ruleset

### DIFF
--- a/crates/openshell-sandbox/src/sandbox/linux/landlock.rs
+++ b/crates/openshell-sandbox/src/sandbox/linux/landlock.rs
@@ -51,23 +51,49 @@ pub fn apply(policy: &SandboxPolicy, workdir: Option<&str>) -> Result<()> {
         let mut ruleset = ruleset.create().into_diagnostic()?;
 
         for path in read_only {
-            debug!(path = %path.display(), "Landlock allow read-only");
-            ruleset = ruleset
-                .add_rule(PathBeneath::new(
-                    PathFd::new(path).into_diagnostic()?,
-                    access_read,
-                ))
-                .into_diagnostic()?;
+            match PathFd::new(&path) {
+                Ok(path_fd) => {
+                    debug!(
+                        path = %path.display(),
+                        "Landlock allow read-only"
+                    );
+                    ruleset = ruleset
+                        .add_rule(PathBeneath::new(
+                            path_fd, access_read,
+                        ))
+                        .into_diagnostic()?;
+                }
+                Err(err) => {
+                    warn!(
+                        path = %path.display(),
+                        error = %err,
+                        "Skipping non-existent read-only path"
+                    );
+                }
+            }
         }
 
         for path in read_write {
-            debug!(path = %path.display(), "Landlock allow read-write");
-            ruleset = ruleset
-                .add_rule(PathBeneath::new(
-                    PathFd::new(path).into_diagnostic()?,
-                    access_all,
-                ))
-                .into_diagnostic()?;
+            match PathFd::new(&path) {
+                Ok(path_fd) => {
+                    debug!(
+                        path = %path.display(),
+                        "Landlock allow read-write"
+                    );
+                    ruleset = ruleset
+                        .add_rule(PathBeneath::new(
+                            path_fd, access_all,
+                        ))
+                        .into_diagnostic()?;
+                }
+                Err(err) => {
+                    warn!(
+                        path = %path.display(),
+                        error = %err,
+                        "Skipping non-existent read-write path"
+                    );
+                }
+            }
         }
 
         ruleset.restrict_self().into_diagnostic()?;


### PR DESCRIPTION
## Summary
When a single path in the filesystem policy did not exist (e.g., `/app` in container images without that directory), `PathFd::new()` failed and the `?` operator propagated the error to abandon the entire Landlock ruleset. Under the default `best_effort` compatibility mode, this silently disabled **all** filesystem restrictions for the sandbox.

This is a critical security degradation: one missing optional path causes the entire filesystem sandbox to be dropped, leaving the container with zero filesystem isolation.

### Fix
Replace the `?` operator on `PathFd::new()` with per-path `match` statements that:
- **Warn** and skip individual non-existent paths
- **Continue** building the ruleset from remaining valid paths
- **Preserve** filesystem isolation even when optional paths are missing

The existing error handling for ruleset creation and `restrict_self()` is unchanged. Only `PathFd::new()` failures are handled per-path.

## Test plan
- [ ] Sandbox with all valid paths: Landlock applied normally (no regression)
- [ ] Sandbox with one missing path (e.g., `/app`): warning logged, remaining paths still enforced
- [ ] Sandbox with all paths missing: existing `best_effort` degradation behavior unchanged
- [ ] `hard_requirement` mode with missing path: still returns error (unchanged)
- [ ] `cargo test` passes

Closes #664

I have read the DCO document and I hereby sign the DCO.