### PR TITLE
fix(ci): skip docs preview deploy for fork PRs

### DIFF
--- a/.github/workflows/docs-preview-pr.yml
+++ b/.github/workflows/docs-preview-pr.yml
@@ -49,6 +49,7 @@ jobs:
                   find _build -name .buildinfo -exec rm {} \;
 
             - name: Deploy preview
+              if: github.event.pull_request.head.repo.full_name == github.repository
               uses: rossjrw/pr-preview-action@v1
               with:
                   source-dir: ./_build/docs/


### PR DESCRIPTION
## Summary

- Skip the gh-pages preview deploy step for fork PRs to prevent 403 failures
- Docs build still runs for fork PRs, validating changes compile cleanly

## Related Issue

Observed on PR #672 — the `preview` check fails for all fork PRs that touch `docs/` because the `GITHUB_TOKEN` from `pull_request` events on forks is read-only and cannot push to `gh-pages`.

## Changes

One-line condition added to the deploy step in `.github/workflows/docs-preview-pr.yml`:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

Fork PRs still get the docs build check (validates Sphinx compilation), but the gh-pages preview deployment is skipped since the token lacks write access to the base repo.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)