### PR TITLE
fix(ci): enable e2e for fork PRs via pull_request_target

### DIFF
--- a/.github/workflows/branch-e2e.yml
+++ b/.github/workflows/branch-e2e.yml
@@ -1,7 +1,11 @@
 name: Branch E2E Checks
 
+# pull_request_target runs in the base repo context with write permissions,
+# enabling fork PRs to push docker images to GHCR and run e2e tests.
+# Security: the test:e2e label is a maintainer trust gate — only org members
+# can apply it, signalling that the PR code has been reviewed.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 
 permissions:
@@ -16,6 +20,7 @@ jobs:
       component: gateway
       platform: linux/arm64
       runner: build-arm64
+      ref: ${{ github.event.pull_request.head.sha }}
 
   build-cluster:
     if: contains(github.event.pull_request.labels.*.name, 'test:e2e')
@@ -24,10 +29,12 @@ jobs:
       component: cluster
       platform: linux/arm64
       runner: build-arm64
+      ref: ${{ github.event.pull_request.head.sha }}
 
   e2e:
     needs: [build-gateway, build-cluster]
     uses: ./.github/workflows/e2e-test.yml
     with:
-      image-tag: ${{ github.sha }}
+      image-tag: ${{ github.event.pull_request.head.sha }}
       runner: build-arm64
+      ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: ""
+      ref:
+        description: "Git ref to checkout (defaults to the triggering event ref)"
+        required: false
+        type: string
+        default: ""
 
 env:
   MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,7 +60,7 @@ jobs:
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock
     env:
-      IMAGE_TAG: ${{ github.sha }}
+      IMAGE_TAG: ${{ inputs.ref || github.sha }}
       IMAGE_REGISTRY: ghcr.io/nvidia/openshell
       DOCKER_PUSH: ${{ inputs.push && '1' || '0' }}
       DOCKER_PLATFORM: ${{ inputs.platform }}
@@ -63,6 +68,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref || '' }}
 
       - name: Mark workspace safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: "build-amd64"
+      ref:
+        description: "Git ref to checkout (defaults to the triggering event ref)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -40,6 +45,8 @@ jobs:
       OPENSHELL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin


### PR DESCRIPTION
## Summary

Enable full e2e test pipeline for fork PRs by switching to `pull_request_target` and adding `ref` input to reusable workflows.

## Related Issue

Observed on PR #672 — fork PRs can't push to GHCR due to read-only `GITHUB_TOKEN`.

## Why not local-build?

Attempted a single-job local-build approach (build images with `--load`, use local registry, no GHCR push). It failed because:
- `--network host` conflicts with Actions' auto-created container network
- `host.docker.internal` doesn't resolve in Linux CI containers
- The CI container can't configure the host Docker daemon's insecure registry list (it accesses Docker via socket mount, not daemon config)

## Changes

**`branch-e2e.yml`**: `pull_request` -> `pull_request_target`. Passes `github.event.pull_request.head.sha` as explicit ref to all child workflows. The `test:e2e` label requirement is the security gate.

**`docker-build.yml`**: New `ref` input overrides checkout ref and `IMAGE_TAG`. Defaults to empty (falls back to `github.sha`), so existing callers (`release-tag.yml`, `release-dev.yml`) are unaffected.

**`e2e-test.yml`**: New `ref` input for checkout.

### `github.sha` under `pull_request_target`

Under `pull_request_target`, `github.sha` is the base branch HEAD. Without the `ref` override, the workflow would build and test main instead of the PR. The explicit ref fixes this.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)