### PR TITLE
fix(e2e): add uv-managed python binary glob to forward proxy L7 test

### DIFF
--- a/e2e/rust/tests/forward_proxy_l7_bypass.rs
+++ b/e2e/rust/tests/forward_proxy_l7_bypass.rs
@@ -156,6 +156,7 @@ network_policies:
       - path: /usr/bin/curl
       - path: /usr/bin/python*
       - path: /usr/local/bin/python*
+      - path: /sandbox/.uv/python/*/bin/python*
 "#
     );
     file.write_all(policy.as_bytes())


### PR DESCRIPTION
## Summary

- Fixes the `forward_proxy_allows_l7_permitted_request` e2e test failure introduced by #666
- The base sandbox image installs Python via uv at `/sandbox/.uv/python/*/bin/python*`, but the proxy resolves binary identity via `/proc/PID/exe` (the real path, not the symlink at `/usr/local/bin/python3`)
- The test policy only listed `/usr/bin/python*` and `/usr/local/bin/python*`, so OPA denied at L4 before L7 evaluation could run

## Related Issue

Fixes e2e failure from #666

## Changes

- Added `/sandbox/.uv/python/*/bin/python*` to the binary allowlist in the forward proxy L7 bypass test policy

## Testing

- Verified locally: both `forward_proxy_allows_l7_permitted_request` and `forward_proxy_denies_l7_blocked_request` pass