### PR TITLE
docs: add missing --from openclaw parameter to OpenClaw example

### DIFF
--- a/examples/openclaw.md
+++ b/examples/openclaw.md
@@ -3,7 +3,7 @@
 ## Quick start
 
 ```sh
-openshell sandbox create --forward 18789 -- openclaw-start
+openshell sandbox create --forward 18789 --from openclaw -- openclaw-start
 ```
 
 `openclaw-start` is a helper script pre-installed in the sandbox that runs the
@@ -25,7 +25,7 @@ Note: you will need use the auth token present in the bootstrapping process to c
 ### Create the sandbox
 
 ```sh
-openshell sandbox create --forward 18789
+openshell sandbox create --forward 18789 --from openclaw
 ```
 
 Inside the sandbox, run the onboarding wizard and start the gateway:


### PR DESCRIPTION
## Summary
- Adds the missing `--from openclaw` parameter to sandbox create commands in the OpenClaw example docs
- Without this parameter, the sandbox doesn't install OpenClaw and `openclaw-start` fails with `command not found`

Re-creation of #645 (credit to @vcorrea-ppc for identifying the issue).

## Related Issue
No related issue

## Changes
Added `--from openclaw` to both sandbox create commands in `examples/openclaw.md`:
- Quick start one-liner
- Step-by-step alternative

## Testing
Documentation-only change — verified the corrected commands match the working invocation.

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)