### PR TITLE
chore(mise): use install_only_stripped precompiled Python flavor

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,7 @@ redactions = ["*_TOKEN", "*_PASSWORD"]
 
 [settings]
 experimental = true
+python.precompiled_flavor = "install_only_stripped"
 
 [tools]
 python = "3.13.12"


### PR DESCRIPTION
## Summary

Set mise Python precompiled flavor to `install_only_stripped` to use smaller, stripped Python builds.

Fixes

```
drew@spark-e157 ~/d/OpenShell (start-openshell-vm)> mise install
python@3.13.12                extract cpython-3.13.12+20260324-aarch64-unknown-linux-gnu-freethreaded-install_only_stripped.tar.gz                                                                                           ◜
mise ERROR Failed to install core:python@3.13.12: Python installation is missing a `lib` directory
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
mise WARN  missing: python@3.13.12
```

This is already the default for python installs.

## Related Issue

N/A

## Changes

- Set `python.precompiled_flavor = "install_only_stripped"` in `mise.toml`

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)