### PR TITLE
fix(cli): sandbox upload overwrites files instead of creating directories

### DIFF
--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -1085,8 +1085,8 @@ enum SandboxCommands {
         /// Upload local files into the sandbox before running.
         ///
         /// Format: `<LOCAL_PATH>[:<SANDBOX_PATH>]`.
-        /// When `SANDBOX_PATH` is omitted, files are uploaded to the container
-        /// working directory (`/sandbox`).
+        /// When `SANDBOX_PATH` is omitted, files are uploaded to the container's
+        /// working directory.
         /// `.gitignore` rules are applied by default; use `--no-git-ignore` to
         /// upload everything.
         #[arg(long, value_hint = ValueHint::AnyPath, help_heading = "UPLOAD FLAGS")]
@@ -1247,7 +1247,7 @@ enum SandboxCommands {
         #[arg(value_hint = ValueHint::AnyPath)]
         local_path: String,
 
-        /// Destination path in the sandbox (defaults to `/sandbox`).
+        /// Destination path in the sandbox (defaults to the container's working directory).
         dest: Option<String>,
 
         /// Disable `.gitignore` filtering (uploads everything).
@@ -2211,7 +2211,7 @@ async fn main() -> Result<()> {
                     let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
                     let mut tls = tls.with_gateway_name(&ctx.name);
                     apply_edge_auth(&mut tls, &ctx.name);
-                    let sandbox_dest = dest.as_deref().unwrap_or("/sandbox");
+                    let sandbox_dest = dest.as_deref();
                     let local = std::path::Path::new(&local_path);
                     if !local.exists() {
                         return Err(miette::miette!(
@@ -2219,7 +2219,8 @@ async fn main() -> Result<()> {
                             local.display()
                         ));
                     }
-                    eprintln!("Uploading {} -> sandbox:{}", local.display(), sandbox_dest);
+                    let dest_display = sandbox_dest.unwrap_or("~");
+                    eprintln!("Uploading {} -> sandbox:{}", local.display(), dest_display);
                     if !no_git_ignore && let Ok((base_dir, files)) = run::git_sync_files(local) {
                         run::sandbox_sync_up_files(
                             &ctx.endpoint,

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -2300,8 +2300,12 @@ pub async fn sandbox_create(
             drop(client);
 
             if let Some((local_path, sandbox_path, git_ignore)) = upload {
-                let dest = sandbox_path.as_deref().unwrap_or("/sandbox");
-                eprintln!("  {} Uploading files to {dest}...", "\u{2022}".dimmed(),);
+                let dest = sandbox_path.as_deref();
+                let dest_display = dest.unwrap_or("~");
+                eprintln!(
+                    "  {} Uploading files to {dest_display}...",
+                    "\u{2022}".dimmed(),
+                );
                 let local = Path::new(local_path);
                 if *git_ignore && let Ok((base_dir, files)) = git_sync_files(local) {
                     sandbox_sync_up_files(
@@ -2619,7 +2623,6 @@ pub async fn sandbox_sync_command(
 ) -> Result<()> {
     match (up, down) {
         (Some(local_path), None) => {
-            let sandbox_dest = dest.unwrap_or("/sandbox");
             let local = Path::new(local_path);
             if !local.exists() {
                 return Err(miette::miette!(
@@ -2627,8 +2630,9 @@ pub async fn sandbox_sync_command(
                     local.display()
                 ));
             }
-            eprintln!("Syncing {} -> sandbox:{}", local.display(), sandbox_dest);
-            sandbox_sync_up(server, name, local, sandbox_dest, tls).await?;
+            let dest_display = dest.unwrap_or("~");
+            eprintln!("Syncing {} -> sandbox:{}", local.display(), dest_display);
+            sandbox_sync_up(server, name, local, dest, tls).await?;
             eprintln!("{} Sync complete", "✓".green().bold());
         }
         (None, Some(sandbox_path)) => {

--- a/crates/openshell-cli/src/ssh.rs
+++ b/crates/openshell-cli/src/ssh.rs
@@ -465,14 +465,25 @@ enum UploadSource {
 /// Core tar-over-SSH upload: streams a tar archive into `dest_dir` on the
 /// sandbox.  Callers are responsible for splitting the destination path so
 /// that `dest_dir` is always a directory.
+///
+/// When `dest_dir` is `None`, the sandbox user's home directory (`$HOME`) is
+/// used as the extraction target.  This avoids hard-coding any particular
+/// path and works for custom container images with non-default `WORKDIR`.
 async fn ssh_tar_upload(
     server: &str,
     name: &str,
-    dest_dir: &str,
+    dest_dir: Option<&str>,
     source: UploadSource,
     tls: &TlsOptions,
 ) -> Result<()> {
     let session = ssh_session_config(server, name, tls).await?;
+
+    // When no explicit destination is given, use the unescaped `$HOME` shell
+    // variable so the remote shell resolves it at runtime.
+    let escaped_dest = match dest_dir {
+        Some(d) => shell_escape(d),
+        None => "$HOME".to_string(),
+    };
 
     let mut ssh = ssh_base_command(&session.proxy_command);
     ssh.arg("-T")
@@ -480,9 +491,7 @@ async fn ssh_tar_upload(
         .arg("RequestTTY=no")
         .arg("sandbox")
         .arg(format!(
-            "mkdir -p {} && cat | tar xf - -C {}",
-            shell_escape(dest_dir),
-            shell_escape(dest_dir)
+            "mkdir -p {escaped_dest} && cat | tar xf - -C {escaped_dest}",
         ))
         .stdin(Stdio::piped())
         .stdout(Stdio::inherit())
@@ -571,13 +580,14 @@ fn split_sandbox_path(path: &str) -> (&str, &str) {
 /// Push a list of files from a local directory into a sandbox using tar-over-SSH.
 ///
 /// Files are streamed as a tar archive to `ssh ... tar xf - -C <dest>` on
-/// the sandbox side.
+/// the sandbox side.  When `dest` is `None`, files are uploaded to the
+/// sandbox user's home directory.
 pub async fn sandbox_sync_up_files(
     server: &str,
     name: &str,
     base_dir: &Path,
     files: &[String],
-    dest: &str,
+    dest: Option<&str>,
     tls: &TlsOptions,
 ) -> Result<()> {
     if files.is_empty() {
@@ -598,36 +608,44 @@ pub async fn sandbox_sync_up_files(
 
 /// Push a local path (file or directory) into a sandbox using tar-over-SSH.
 ///
-/// When uploading a single file to a destination that does not end with `/`,
-/// the destination is treated as a file path: the parent directory is created
-/// and the file is written with the destination's basename.  This matches
-/// `cp` / `scp` semantics and avoids creating a directory at the destination
-/// path.
+/// When `sandbox_path` is `None`, files are uploaded to the sandbox user's
+/// home directory.  When uploading a single file to an explicit destination
+/// that does not end with `/`, the destination is treated as a file path:
+/// the parent directory is created and the file is written with the
+/// destination's basename.  This matches `cp` / `scp` semantics.
 pub async fn sandbox_sync_up(
     server: &str,
     name: &str,
     local_path: &Path,
-    sandbox_path: &str,
+    sandbox_path: Option<&str>,
     tls: &TlsOptions,
 ) -> Result<()> {
-    // When uploading a single file to a path that looks like a file (does not
-    // end with '/'), split into parent directory + target basename so that
+    // When an explicit destination is given and looks like a file path (does
+    // not end with '/'), split into parent directory + target basename so that
     // `mkdir -p` creates the parent and tar extracts the file with the right
-    // name.  For directories or paths ending in '/', keep the original
-    // behavior where sandbox_path is the extraction directory.
-    if local_path.is_file() && !sandbox_path.ends_with('/') {
-        let (parent, target_name) = split_sandbox_path(sandbox_path);
-        return ssh_tar_upload(
-            server,
-            name,
-            parent,
-            UploadSource::SinglePath {
-                local_path: local_path.to_path_buf(),
-                tar_name: target_name.into(),
-            },
-            tls,
-        )
-        .await;
+    // name.
+    //
+    // Exception: if splitting would yield "/" as the parent (e.g. the user
+    // passed "/sandbox"), fall through to directory semantics instead.  The
+    // sandbox user cannot write to "/" and the intent is almost certainly
+    // "put the file inside /sandbox", not "create a file named sandbox in /".
+    if let Some(path) = sandbox_path {
+        if local_path.is_file() && !path.ends_with('/') {
+            let (parent, target_name) = split_sandbox_path(path);
+            if parent != "/" {
+                return ssh_tar_upload(
+                    server,
+                    name,
+                    Some(parent),
+                    UploadSource::SinglePath {
+                        local_path: local_path.to_path_buf(),
+                        tar_name: target_name.into(),
+                    },
+                    tls,
+                )
+                .await;
+            }
+        }
     }
 
     let tar_name = if local_path.is_file() {


### PR DESCRIPTION
## Summary

Fix `openshell sandbox upload` creating a directory at the destination path instead of overwriting an existing file. Consolidates duplicated SSH/tar upload boilerplate into a shared helper.

## Related Issue

Closes #667

## Changes

- **Bug fix**: When uploading a single file to a path that doesn't end with `/`, split the sandbox destination into parent directory + basename. The remote command now runs `mkdir -p <parent>` (not `mkdir -p <dest>`), and the tar entry uses the target basename so the file lands at the correct path with `cp`/`scp` semantics.
- **Refactor**: Extracted `ssh_tar_upload` helper and `UploadSource` enum to consolidate ~40 lines of duplicated SSH session setup, command construction, tar streaming, and exit-status checking from `sandbox_sync_up` and `sandbox_sync_up_files`.
- Added `split_sandbox_path` helper to split a remote path into `(parent, basename)`.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests pass (`mise run test` — all 1046 tests green)
- [ ] E2E tests added/updated (requires running cluster)

## Checklist

- [x] Follows Conventional Commits
- [ ] Architecture docs updated (if applicable)