### PR TITLE
fix(server): return already_exists for duplicate sandbox names

### DIFF
--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -2045,7 +2045,16 @@ pub async fn sandbox_create(
         name: name.unwrap_or_default().to_string(),
     };
 
-    let response = client.create_sandbox(request).await.into_diagnostic()?;
+    let response = match client.create_sandbox(request).await {
+        Ok(resp) => resp,
+        Err(status) if status.code() == Code::AlreadyExists => {
+            return Err(miette::miette!(
+                "{}\n\nhint: delete it first with: openshell sandbox delete <name>\n      or use a different name",
+                status.message()
+            ));
+        }
+        Err(status) => return Err(status).into_diagnostic(),
+    };
     let sandbox = response
         .into_inner()
         .sandbox

--- a/crates/openshell-server/src/grpc.rs
+++ b/crates/openshell-server/src/grpc.rs
@@ -244,6 +244,20 @@ impl OpenShell for OpenShellService {
             ..Default::default()
         };
 
+        // Reject duplicate names early, before touching the index or store.
+        // This mirrors the provider-creation pattern (see `create_provider`).
+        let existing = self
+            .state
+            .store
+            .get_message_by_name::<Sandbox>(&name)
+            .await
+            .map_err(|e| Status::internal(format!("fetch sandbox failed: {e}")))?;
+        if existing.is_some() {
+            return Err(Status::already_exists(format!(
+                "sandbox '{name}' already exists"
+            )));
+        }
+
         // Persist to the store FIRST so the sandbox watcher always finds
         // the record with `spec` populated.  If we created the k8s
         // resource first, the watcher could race us and write a fallback

--- a/e2e/python/test_inference_routing.py
+++ b/e2e/python/test_inference_routing.py
@@ -95,11 +95,6 @@ def _upsert_managed_inference(
             except grpc.RpcError as create_exc:
                 if create_exc.code() == grpc.StatusCode.ALREADY_EXISTS:
                     continue
-                if (
-                    create_exc.code() == grpc.StatusCode.INTERNAL
-                    and "UNIQUE constraint failed" in (create_exc.details() or "")
-                ):
-                    continue
                 raise
     else:
         raise RuntimeError("failed to upsert managed e2e provider after retries")


### PR DESCRIPTION
## Summary

Return a proper `AlreadyExists` gRPC status when creating a sandbox with a duplicate name, instead of leaking a raw SQLite `UNIQUE constraint failed` error as an `Internal` status.

## Related Issue

Closes #691

## Changes

- **`crates/openshell-server/src/grpc.rs`**: Added a `get_message_by_name::<Sandbox>` pre-check before `put_message` in `create_sandbox`, following the identical pattern used by `create_provider`. Returns `Status::already_exists("sandbox '<name>' already exists")` when a duplicate is found.
- **`crates/openshell-cli/src/run.rs`**: Handle `AlreadyExists` status in the sandbox create path to show a user-friendly message with a hint to delete or rename.
- **`e2e/python/test_inference_routing.py`**: Removed the workaround that matched `INTERNAL` status with `"UNIQUE constraint failed"` in the error string—now only `ALREADY_EXISTS` is needed.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests pass (`cargo test --workspace`)
- [ ] E2E tests added/updated (not applicable—existing e2e coverage was simplified, not expanded)

## Checklist

- [x] Follows Conventional Commits
- [ ] Architecture docs updated (not applicable)