### PR TITLE
fix(docker): restore apt cleanup chaining in cluster image

### DIFF
--- a/deploy/docker/Dockerfile.images
+++ b/deploy/docker/Dockerfile.images
@@ -213,7 +213,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        "nvidia-container-toolkit-base=${NVIDIA_CONTAINER_TOOLKIT_VERSION}" \
+        "nvidia-container-toolkit-base=${NVIDIA_CONTAINER_TOOLKIT_VERSION}" && \
     rm -rf /var/lib/apt/lists/*
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Restore the missing `&&` before `rm -rf /var/lib/apt/lists/*` in the cluster image's NVIDIA toolkit install step. Without it, `rm -rf` is parsed as extra `apt-get install` arguments and the cluster image build fails in CI.

## Related Issue

Fixes the build failure introduced after #503 merged.

## Changes

- add the missing shell chaining operator in `deploy/docker/Dockerfile.images`
- keep the cluster image package list unchanged; this only fixes the broken `RUN` command

## Testing

- [ ] `mise run pre-commit` passes
- [ ] Local cluster image build passes

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)