### PR TITLE
fix(cli): add missing Copilot variant to CliProviderType enum

### DIFF
--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -597,6 +597,7 @@ enum CliProviderType {
     Claude,
     Opencode,
     Codex,
+    Copilot,
     Generic,
     Openai,
     Anthropic,
@@ -627,6 +628,7 @@ impl CliProviderType {
             Self::Claude => "claude",
             Self::Opencode => "opencode",
             Self::Codex => "codex",
+            Self::Copilot => "copilot",
             Self::Generic => "generic",
             Self::Openai => "openai",
             Self::Anthropic => "anthropic",
@@ -3136,5 +3138,30 @@ mod tests {
             }
             other => panic!("expected settings delete command, got: {other:?}"),
         }
+    }
+
+    /// Ensure every provider registered in `ProviderRegistry` has a
+    /// corresponding `CliProviderType` variant (and vice-versa).
+    /// This test would have caught the missing `Copilot` variant from #707.
+    #[test]
+    fn cli_provider_types_match_registry() {
+        let registry = openshell_providers::ProviderRegistry::new();
+        let registry_types: std::collections::BTreeSet<&str> =
+            registry.known_types().into_iter().collect();
+
+        let cli_types: std::collections::BTreeSet<&str> =
+            <CliProviderType as ValueEnum>::value_variants()
+                .iter()
+                .map(CliProviderType::as_str)
+                .collect();
+
+        assert_eq!(
+            cli_types,
+            registry_types,
+            "CliProviderType variants must match ProviderRegistry.known_types(). \
+             CLI-only: {:?}, Registry-only: {:?}",
+            cli_types.difference(&registry_types).collect::<Vec<_>>(),
+            registry_types.difference(&cli_types).collect::<Vec<_>>(),
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds the missing `Copilot` variant to the `CliProviderType` enum and its `as_str()` match arm, fixing `--provider copilot` CLI argument parsing.
- Adds a parity test (`cli_provider_types_match_registry`) that asserts `CliProviderType` variants match `ProviderRegistry::known_types()`, preventing this class of drift in the future.

## Related Issue

Closes #707

## Changes

- `crates/openshell-cli/src/main.rs`: Added `Copilot` variant to `CliProviderType` enum and `"copilot"` arm to `as_str()`.
- `crates/openshell-cli/src/main.rs` (tests): Added `cli_provider_types_match_registry` test that iterates all `CliProviderType` variants via `ValueEnum::value_variants()` and compares against `ProviderRegistry::known_types()`.

## Testing

- `cargo test -p openshell-cli --bin openshell cli_provider_types_match_registry` passes.
- `cargo fmt --check` and `cargo clippy` clean on changed file.

## Checklist

- [x] Conventional commit format
- [x] Pre-commit checks pass
- [x] Tests added for regression prevention