### PR TITLE
fix(install): make checksum verification mandatory and validate redirect origin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -92,9 +92,9 @@ download() {
   _output="$2"
 
   if has_cmd curl; then
-    curl -fLsS --retry 3 -o "$_output" "$_url"
+    curl -fLsS --retry 3 --max-redirs 5 -o "$_output" "$_url"
   elif has_cmd wget; then
-    wget -q --tries=3 -O "$_output" "$_url"
+    wget -q --tries=3 --max-redirect=5 -O "$_output" "$_url"
   fi
 }
 
@@ -196,7 +196,7 @@ verify_checksum() {
     error "neither 'shasum' nor 'sha256sum' found; cannot verify download integrity"
   fi
 
-  _vc_expected="$(grep "$_vc_filename" "$_vc_checksums" | awk '{print $1}')"
+  _vc_expected="$(grep -F "$_vc_filename" "$_vc_checksums" | awk '{print $1}')"
 
   if [ -z "$_vc_expected" ]; then
     error "no checksum entry found for $_vc_filename in checksums file"


### PR DESCRIPTION
## Summary

Make all checksum verification paths in `install.sh` hard failures instead of silent warnings, and validate the redirect URL origin when resolving the latest release.

## Related Issue

Closes #590
Closes #638

## Changes

- **Mandatory checksums file download**: Failing to download the checksums file is now a fatal error instead of a warning that skips verification
- **Mandatory hash tool**: If neither `shasum` nor `sha256sum` is available, the script aborts instead of silently skipping verification
- **Mandatory checksum entry**: If the checksums file doesn't contain an entry for the downloaded filename, the script aborts instead of skipping
- **Redirect origin validation**: After following the GitHub `releases/latest` redirect, the resolved URL is validated against `https://github.com/NVIDIA/OpenShell/releases/*` to prevent MITM/DNS hijack attacks where an attacker could serve both a malicious binary and a matching checksums file

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)