### PR TITLE
fix(security): bump container dependencies to remediate 10 CVEs

### DIFF
--- a/deploy/docker/Dockerfile.ci
+++ b/deploy/docker/Dockerfile.ci
@@ -8,7 +8,7 @@
 
 FROM nvcr.io/nvidia/base/ubuntu:noble-20251013
 
-ARG DOCKER_VERSION=29.3.0
+ARG DOCKER_VERSION=29.3.1
 ARG BUILDX_VERSION=v0.32.1
 ARG TARGETARCH
 
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xz-utils \
     jq \
     rsync \
+    && apt-get install -y --only-upgrade gpgv python3 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Docker CLI and buildx plugin used by CI jobs

--- a/deploy/docker/Dockerfile.images
+++ b/deploy/docker/Dockerfile.images
@@ -15,8 +15,8 @@
 # Pin by tag AND manifest-list digest to prevent silent upstream republishes
 # from breaking the build. Update both when bumping k3s versions.
 # To refresh: docker buildx imagetools inspect rancher/k3s:<tag> | head -3
-ARG K3S_VERSION=v1.35.2-k3s1
-ARG K3S_DIGEST=sha256:c3184157c3048112bab0c3e17405991da486cb3413511eba23f7650efd70776b
+ARG K3S_VERSION=v1.35.3-k3s1
+ARG K3S_DIGEST=sha256:4607083d3cac07e1ccde7317297271d13ed5f60f35a78f33fcef84858a9f1d69
 ARG K9S_VERSION=v0.50.18
 ARG HELM_VERSION=v3.17.3
 ARG NVIDIA_CONTAINER_TOOLKIT_VERSION=1.18.2-1
@@ -165,7 +165,9 @@ COPY --from=supervisor-builder /build/out/openshell-sandbox /openshell-sandbox
 FROM nvcr.io/nvidia/base/ubuntu:noble-20251013 AS gateway
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates && rm -rf /var/lib/apt/lists/*
+    ca-certificates && \
+    apt-get install -y --only-upgrade gpgv && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --user-group openshell
 
@@ -230,6 +232,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iptables \
     mount \
     dnsutils \
+    && apt-get install -y --only-upgrade gpgv \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=k3s /bin/ /bin/

--- a/mise.toml
+++ b/mise.toml
@@ -20,7 +20,7 @@ uv = "0.10.2"
 protoc = "29.6"
 helm = "4.1.1"
 "ubi:mozilla/sccache" = { version = "0.14.0", matching = "sccache-v" }
-"ubi:anchore/syft" = { version = "1.42.2", matching = "syft_" }
+"ubi:anchore/syft" = { version = "1.42.3", matching = "syft_" }
 "ubi:EmbarkStudios/cargo-about" = "0.8.4"
 
 [env]


### PR DESCRIPTION
## Summary

Bump third-party dependencies in container images to remediate 10 vulnerabilities (1 Critical, 9 High) identified in the April 1, 2026 Security Tracker.

## Related Issue

Closes #735

## Changes

### P0: k3s v1.35.2-k3s1 -> v1.35.3-k3s1 (7 CVEs in cluster image)
Bumps containerd to v2.2.2-k3s1, runc to v1.4.1, and Go to 1.25.7. Addresses:
- **GHSA-p77j-4mvh-x3m3** (Critical) -- gRPC-Go authorization bypass
- **GHSA-pwhc-rpq9-4c8w** -- containerd local privilege escalation
- **GHSA-p436-gjf2-799p** -- Docker CLI uncontrolled search path
- **GHSA-9h8m-3fm2-qjrq** -- OpenTelemetry Go SDK PATH hijacking
- **GHSA-6v2p-p543-phr9** -- golang.org/x/oauth2 input validation
- **GHSA-6g7g-w4f8-9c9x** -- buger/jsonparser DoS
- **CVE-2024-36623** -- moby streamformatter race condition

### P1: Explicit system package upgrades (2 CVEs across all images)
No newer NVIDIA base image (`noble-20251013`) is available. Added `apt-get install --only-upgrade gpgv` to gateway, cluster, and CI Dockerfiles, and `python3` upgrade to CI:
- **CVE-2025-68973** -- GnuPG out-of-bounds write in gpgv
- **CVE-2026-4519** -- Python webbrowser.open() CLI option injection

### P2: Docker CLI 29.3.0 -> 29.3.1 (2 CVEs in CI image)
Updates Go runtime to 1.25.8 and containerd to v2.2.2:
- **GHSA-p436-gjf2-799p** -- Docker CLI uncontrolled search path
- **GHSA-p77j-4mvh-x3m3** -- gRPC-Go authorization bypass (via Go dep)

### P3: syft 1.42.2 -> 1.42.3 (CI tooling)
Bumps buger/jsonparser to v1.1.2 within the syft binary, addressing scanner findings for **GHSA-6g7g-w4f8-9c9x** in CI image.

## Testing

- [ ] `mise run pre-commit` passes
- [ ] Rebuild all images: `mise run build:docker`
- [ ] Run full CI suite: `mise run ci`
- [ ] Run e2e tests: `mise run e2e`
- [ ] Rescan all images with grype/trivy to confirm 0 remaining findings

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)