### PR TITLE
fix(cli): support plaintext gateway registration

### DIFF
--- a/architecture/gateway-deploy-connect.md
+++ b/architecture/gateway-deploy-connect.md
@@ -11,11 +11,11 @@ This document describes how the CLI resolves a gateway and communicates with it 
 When any CLI command needs to talk to the gateway, it resolves the target through a priority chain (`crates/openshell-cli/src/main.rs` -- `resolve_gateway()`):
 
 1. `--gateway-endpoint <URL>` flag (direct URL, reusing stored metadata when the gateway is known).
-2. `--cluster <NAME>` / `-g <NAME>` flag.
+2. `--gateway <NAME>` / `-g <NAME>` flag.
 3. `OPENSHELL_GATEWAY` environment variable.
 4. Active gateway from `~/.config/openshell/active_gateway`.
 
-Resolution loads `ClusterMetadata` from disk to get the `gateway_endpoint` URL and `auth_mode`. When `--gateway-endpoint` is used, the CLI still tries to match the URL to stored metadata so edge auth tokens and TLS bundles continue to resolve by cluster name.
+Resolution loads `GatewayMetadata` from disk to get the `gateway_endpoint` URL and `auth_mode`. When `--gateway-endpoint` is used, the CLI still tries to match the URL to stored metadata so edge auth tokens and TLS bundles continue to resolve by gateway name.
 
 ### Connection modes
 
@@ -36,7 +36,7 @@ graph TD
 
     MODE -->|"null / mtls"| MTLS
     MODE -->|"cloudflare_jwt"| EDGE
-    MODE -->|"plaintext endpoint"| PLAIN
+    MODE -->|"plaintext"| PLAIN
 
     MTLS -->|"TLS + client cert"| GW
     EDGE -->|"WSS tunnel + JWT"| GW
@@ -47,11 +47,11 @@ graph TD
 
 **File**: `crates/openshell-cli/src/tls.rs` -- `build_channel()`
 
-The default mode for self-deployed gateways. The CLI loads three PEM files from `~/.config/openshell/clusters/<name>/mtls/`:
+The default mode for self-deployed gateways. The CLI loads three PEM files from `~/.config/openshell/gateways/<name>/mtls/`:
 
 | File      | Purpose                                                        |
 | --------- | -------------------------------------------------------------- |
-| `ca.crt`  | Cluster CA certificate -- verifies the gateway's server cert   |
+| `ca.crt`  | Gateway CA certificate -- verifies the gateway's server cert   |
 | `tls.crt` | Client certificate -- proves the CLI's identity to the gateway |
 | `tls.key` | Client private key                                             |
 
@@ -81,11 +81,19 @@ For gateways behind an edge proxy (e.g., Cloudflare Access), the CLI routes traf
 3. The gateway's `ws_tunnel.rs` handler upgrades the WebSocket and bridges it to an in-memory `MultiplexService` instance.
 4. The gRPC channel connects to `http://127.0.0.1:<local_port>` (plaintext HTTP/2 over the tunnel).
 
-Authentication uses a browser-based flow: `gateway add` opens the user's browser to the gateway's `/auth/connect` endpoint, which reads the `CF_Authorization` cookie and relays it back to a localhost callback server. The token is stored at `~/.config/openshell/clusters/<name>/edge_token`.
+Authentication uses a browser-based flow: `gateway add` opens the user's browser to the gateway's `/auth/connect` endpoint, which reads the `CF_Authorization` cookie and relays it back to a localhost callback server. The token is stored at `~/.config/openshell/gateways/<name>/edge_token`.
 
 ### Plaintext connection
 
 When the gateway is deployed with `--plaintext`, TLS is disabled entirely. The CLI connects over plain HTTP/2. This mode is intended for gateways behind a trusted reverse proxy or tunnel that handles TLS termination.
+
+The CLI also treats an explicit `http://...` registration as plaintext mode:
+
+```shell
+openshell gateway add http://127.0.0.1:8080 --local
+```
+
+This stores `auth_mode = "plaintext"`, skips mTLS certificate extraction, and bypasses the edge browser-auth flow.
 
 ## File System Layout
 
@@ -93,12 +101,12 @@ All connection artifacts are stored under `$XDG_CONFIG_HOME/openshell/` (default
 
 ```
 openshell/
-  active_cluster                          # plain text: active cluster name
-  clusters/
-    <name>_metadata.json                  # ClusterMetadata JSON
+  active_gateway                          # plain text: active gateway name
+  gateways/
     <name>/
+      metadata.json                       # GatewayMetadata JSON
       mtls/                               # mTLS bundle (when TLS enabled)
-        ca.crt                            # cluster CA certificate
+        ca.crt                            # gateway CA certificate
         tls.crt                           # client certificate
         tls.key                           # client private key
       edge_token                          # Edge auth JWT (when auth_mode=cloudflare_jwt)
@@ -127,6 +135,6 @@ sequenceDiagram
     GW-->>Browser: Relay page (extracts token, POSTs to localhost)
     Browser->>CLI: POST token to localhost callback
     CLI->>CLI: Store edge_token
-    CLI->>CLI: save_active_cluster
+    CLI->>CLI: save_active_gateway
     CLI-->>U: Gateway added and set as active
 ```

--- a/crates/openshell-bootstrap/src/metadata.rs
+++ b/crates/openshell-bootstrap/src/metadata.rs
@@ -26,7 +26,8 @@ pub struct GatewayMetadata {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub resolved_host: Option<String>,
 
-    /// Auth mode: `None` or `"mtls"` = mTLS (default), `"cloudflare_jwt"` = CF JWT.
+    /// Auth mode: `None` or `"mtls"` = mTLS (default), `"plaintext"` = direct HTTP,
+    /// `"cloudflare_jwt"` = CF JWT.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_mode: Option<String>,
 
@@ -132,7 +133,7 @@ pub fn create_gateway_metadata_with_host(
         gateway_port: port,
         remote_host,
         resolved_host,
-        auth_mode: None,
+        auth_mode: disable_tls.then(|| "plaintext".to_string()),
         edge_team_domain: None,
         edge_auth_url: None,
     }
@@ -514,6 +515,7 @@ mod tests {
     fn local_gateway_metadata_with_tls_disabled() {
         let meta = create_gateway_metadata_with_host("test", None, 8080, None, true);
         assert_eq!(meta.gateway_endpoint, "http://127.0.0.1:8080");
+        assert_eq!(meta.auth_mode.as_deref(), Some("plaintext"));
     }
 
     #[test]
@@ -526,6 +528,7 @@ mod tests {
             true,
         );
         assert_eq!(meta.gateway_endpoint, "http://host.docker.internal:8080");
+        assert_eq!(meta.auth_mode.as_deref(), Some("plaintext"));
     }
 
     // ── GatewayMetadata::gateway_host() ──────────────────────────────
@@ -590,6 +593,7 @@ mod tests {
         assert!(meta.is_remote);
         assert!(meta.gateway_endpoint.starts_with("http://"));
         assert!(!meta.gateway_endpoint.starts_with("https://"));
+        assert_eq!(meta.auth_mode.as_deref(), Some("plaintext"));
     }
 
     // ── last-sandbox persistence ──────────────────────────────────────

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -857,8 +857,12 @@ enum GatewayCommands {
     ///
     /// Registers a gateway endpoint so it appears in `openshell gateway select`.
     ///
-    /// Without extra flags the gateway is treated as an edge-authenticated
-    /// (cloud) gateway and a browser is opened for authentication.
+    /// An `http://...` endpoint is treated as a direct plaintext gateway and
+    /// skips both mTLS certificate extraction and browser authentication.
+    ///
+    /// Without extra flags, an `https://...` endpoint is treated as an
+    /// edge-authenticated (cloud) gateway and a browser is opened for
+    /// authentication.
     ///
     /// Pass `--remote <ssh-dest>` to register a remote mTLS gateway whose
     /// Docker daemon is reachable over SSH. Pass `--local` to register a
@@ -870,7 +874,8 @@ enum GatewayCommands {
     /// for `--remote user@host` with the endpoint derived from the URL.
     #[command(help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
     Add {
-        /// Gateway endpoint URL (e.g., `https://10.0.0.5:8080` or `ssh://user@host:8080`).
+        /// Gateway endpoint URL (for example `http://127.0.0.1:8080`,
+        /// `https://10.0.0.5:8080`, or `ssh://user@host:8080`).
         endpoint: String,
 
         /// Gateway name (auto-derived from the endpoint hostname when omitted).
@@ -878,6 +883,7 @@ enum GatewayCommands {
         name: Option<String>,
 
         /// Register a remote mTLS gateway accessible via SSH.
+        /// With `http://...`, stores a remote plaintext registration instead.
         #[arg(long, conflicts_with = "local")]
         remote: Option<String>,
 
@@ -886,6 +892,7 @@ enum GatewayCommands {
         ssh_key: Option<String>,
 
         /// Register a local mTLS gateway running in Docker on this machine.
+        /// With `http://...`, stores a local plaintext registration instead.
         #[arg(long, conflicts_with = "remote")]
         local: bool,
     },

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -843,7 +843,61 @@ fn gateway_type_label(gateway: &GatewayMetadata) -> &'static str {
 }
 
 fn gateway_auth_label(gateway: &GatewayMetadata) -> &str {
-    gateway.auth_mode.as_deref().unwrap_or("unknown")
+    match gateway.auth_mode.as_deref() {
+        Some(auth_mode) => auth_mode,
+        None if gateway.gateway_endpoint.starts_with("http://") => "plaintext",
+        None => "mtls",
+    }
+}
+
+fn is_loopback_gateway_endpoint(endpoint: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(endpoint) else {
+        return false;
+    };
+
+    match parsed.host() {
+        Some(url::Host::Ipv4(addr)) => addr.is_loopback(),
+        Some(url::Host::Ipv6(addr)) => addr.is_loopback(),
+        Some(url::Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        None => false,
+    }
+}
+
+fn plaintext_gateway_is_remote(endpoint: &str, remote: Option<&str>, local: bool) -> bool {
+    if local {
+        return false;
+    }
+    if remote.is_some() {
+        return true;
+    }
+    !is_loopback_gateway_endpoint(endpoint)
+}
+
+fn plaintext_gateway_metadata(
+    name: &str,
+    endpoint: &str,
+    remote: Option<&str>,
+    local: bool,
+) -> GatewayMetadata {
+    let (remote_host, resolved_host) = if let Some(dest) = remote {
+        let ssh_host = extract_host_from_ssh_destination(dest);
+        let resolved = resolve_ssh_hostname(&ssh_host);
+        (Some(dest.to_string()), Some(resolved))
+    } else {
+        (None, None)
+    };
+
+    GatewayMetadata {
+        name: name.to_string(),
+        gateway_endpoint: endpoint.to_string(),
+        is_remote: plaintext_gateway_is_remote(endpoint, remote, local),
+        gateway_port: 0,
+        remote_host,
+        resolved_host,
+        auth_mode: Some("plaintext".to_string()),
+        edge_team_domain: None,
+        edge_auth_url: None,
+    }
 }
 
 fn gateway_select_with<F>(
@@ -889,8 +943,12 @@ where
 
 /// Register an existing gateway.
 ///
-/// Without extra flags the gateway is treated as an edge-authenticated (cloud)
-/// gateway and a browser is opened for authentication.
+/// An `http://...` endpoint is registered as a direct plaintext gateway with
+/// no mTLS extraction or browser authentication.
+///
+/// Without extra flags, an `https://...` endpoint is treated as an
+/// edge-authenticated (cloud) gateway and a browser is opened for
+/// authentication.
 ///
 /// Pass `remote` (SSH destination) to register a remote mTLS gateway, or
 /// `local = true` for a local mTLS gateway. In both cases the CLI extracts
@@ -983,6 +1041,26 @@ pub async fn gateway_add(
             name,
             name,
         ));
+    }
+
+    if endpoint.starts_with("http://") {
+        let metadata = plaintext_gateway_metadata(name, &endpoint, remote, local);
+        let gateway_type = gateway_type_label(&metadata);
+        let gateway_auth = gateway_auth_label(&metadata);
+
+        store_gateway_metadata(name, &metadata)?;
+        save_active_gateway(name)?;
+
+        eprintln!(
+            "{} Gateway '{}' added and set as active",
+            "✓".green().bold(),
+            name,
+        );
+        eprintln!("  {} {}", "Endpoint:".dimmed(), endpoint);
+        eprintln!("  {} {}", "Type:".dimmed(), gateway_type);
+        eprintln!("  {} {}", "Auth:".dimmed(), gateway_auth);
+
+        return Ok(());
     }
 
     if remote.is_some() || local {
@@ -5119,15 +5197,16 @@ fn format_timestamp_ms(ms: i64) -> String {
 mod tests {
     use super::{
         GatewayControlTarget, TlsOptions, format_gateway_select_header,
-        format_gateway_select_items, gateway_auth_label, gateway_select_with, gateway_type_label,
-        git_sync_files, http_health_check, image_requests_gpu, inferred_provider_type,
-        parse_cli_setting_value, parse_credential_pairs, provisioning_timeout_message,
-        ready_false_condition_message, resolve_gateway_control_target_from, sandbox_should_persist,
-        shell_escape, source_requests_gpu, validate_gateway_name, validate_ssh_host,
+        format_gateway_select_items, gateway_add, gateway_auth_label, gateway_select_with,
+        gateway_type_label, git_sync_files, http_health_check, image_requests_gpu,
+        inferred_provider_type, parse_cli_setting_value, parse_credential_pairs,
+        plaintext_gateway_is_remote, provisioning_timeout_message, ready_false_condition_message,
+        resolve_gateway_control_target_from, sandbox_should_persist, shell_escape,
+        source_requests_gpu, validate_gateway_name, validate_ssh_host,
     };
     use crate::TEST_ENV_LOCK;
     use hyper::StatusCode;
-    use openshell_bootstrap::{load_active_gateway, store_gateway_metadata};
+    use openshell_bootstrap::{load_active_gateway, load_gateway_metadata, store_gateway_metadata};
     use std::fs;
     use std::io::{Read, Write};
     use std::net::TcpListener;
@@ -5597,7 +5676,7 @@ mod tests {
         assert_eq!(gateway_type_label(&gateways[0]), "cloud");
         assert_eq!(gateway_type_label(&gateways[1]), "local");
         assert_eq!(gateway_auth_label(&gateways[0]), "cloudflare_jwt");
-        assert_eq!(gateway_auth_label(&gateways[1]), "unknown");
+        assert_eq!(gateway_auth_label(&gateways[1]), "plaintext");
         assert!(header.contains("NAME"));
         assert!(header.contains("ENDPOINT"));
         assert!(header.contains("TYPE"));
@@ -5607,8 +5686,102 @@ mod tests {
         assert!(items[0].contains("cloud"));
         assert!(items[0].contains("cloudflare_jwt"));
         assert!(items[1].contains("local"));
-        assert!(items[1].contains("unknown"));
+        assert!(items[1].contains("plaintext"));
         assert!(items[1].contains("http://127.0.0.1:8080"));
+    }
+
+    #[test]
+    fn gateway_auth_label_defaults_https_gateways_to_mtls() {
+        let gateway = GatewayMetadata {
+            name: "local".to_string(),
+            gateway_endpoint: "https://127.0.0.1:8080".to_string(),
+            is_remote: false,
+            gateway_port: 8080,
+            remote_host: None,
+            resolved_host: None,
+            auth_mode: None,
+            edge_team_domain: None,
+            edge_auth_url: None,
+        };
+
+        assert_eq!(gateway_auth_label(&gateway), "mtls");
+    }
+
+    #[test]
+    fn plaintext_gateway_locality_infers_loopback_endpoints_as_local() {
+        assert!(!plaintext_gateway_is_remote(
+            "http://127.0.0.1:8080",
+            None,
+            false,
+        ));
+        assert!(!plaintext_gateway_is_remote(
+            "http://localhost:8080",
+            None,
+            false,
+        ));
+        assert!(!plaintext_gateway_is_remote(
+            "http://[::1]:8080",
+            None,
+            false,
+        ));
+    }
+
+    #[test]
+    fn plaintext_gateway_locality_treats_non_loopback_endpoints_as_remote_without_local_flag() {
+        assert!(plaintext_gateway_is_remote(
+            "http://gateway.example.com:8080",
+            None,
+            false,
+        ));
+        assert!(plaintext_gateway_is_remote(
+            "http://10.0.0.5:8080",
+            None,
+            false,
+        ));
+    }
+
+    #[test]
+    fn gateway_add_registers_plaintext_loopback_gateway_without_local_flag() {
+        let tmpdir = tempfile::tempdir().expect("create tmpdir");
+        with_tmp_xdg(tmpdir.path(), || {
+            let runtime = tokio::runtime::Runtime::new().expect("create runtime");
+            runtime.block_on(async {
+                gateway_add("http://127.0.0.1:8080", None, None, None, false)
+                    .await
+                    .expect("register plaintext gateway");
+            });
+
+            let metadata = load_gateway_metadata("127.0.0.1").expect("load stored gateway");
+            assert_eq!(metadata.auth_mode.as_deref(), Some("plaintext"));
+            assert!(!metadata.is_remote);
+            assert_eq!(metadata.gateway_endpoint, "http://127.0.0.1:8080");
+            assert_eq!(load_active_gateway().as_deref(), Some("127.0.0.1"));
+        });
+    }
+
+    #[test]
+    fn gateway_add_respects_local_flag_for_plaintext_registrations() {
+        let tmpdir = tempfile::tempdir().expect("create tmpdir");
+        with_tmp_xdg(tmpdir.path(), || {
+            let runtime = tokio::runtime::Runtime::new().expect("create runtime");
+            runtime.block_on(async {
+                gateway_add(
+                    "http://gateway.example.com:8080",
+                    Some("dev-http"),
+                    None,
+                    None,
+                    true,
+                )
+                .await
+                .expect("register plaintext gateway");
+            });
+
+            let metadata = load_gateway_metadata("dev-http").expect("load stored gateway");
+            assert_eq!(metadata.auth_mode.as_deref(), Some("plaintext"));
+            assert!(!metadata.is_remote);
+            assert_eq!(metadata.gateway_endpoint, "http://gateway.example.com:8080");
+            assert_eq!(load_active_gateway().as_deref(), Some("dev-http"));
+        });
     }
 
     #[tokio::test]

--- a/crates/openshell-cli/src/tls.rs
+++ b/crates/openshell-cli/src/tls.rs
@@ -249,6 +249,15 @@ async fn edge_tunnel_addr(server: &str, token: &str) -> Result<SocketAddr> {
 }
 
 pub async fn build_channel(server: &str, tls: &TlsOptions) -> Result<Channel> {
+    if server.starts_with("http://") {
+        let endpoint = Endpoint::from_shared(server.to_string())
+            .into_diagnostic()?
+            .connect_timeout(Duration::from_secs(10))
+            .http2_keep_alive_interval(Duration::from_secs(10))
+            .keep_alive_while_idle(true);
+        return endpoint.connect().await.into_diagnostic();
+    }
+
     // When edge bearer auth is active and the server is HTTPS,
     // route traffic through a local WebSocket tunnel proxy instead.
     if tls.is_bearer_auth() && server.starts_with("https://") {

--- a/docs/reference/gateway-auth.mdx
+++ b/docs/reference/gateway-auth.mdx
@@ -7,7 +7,7 @@ keywords: "Generative AI, Cybersecurity, Gateway, Authentication, mTLS, Edge Aut
 position: 1
 ---
 
-This page describes how the CLI resolves a gateway, authenticates with it, and where credentials are stored. For how to deploy or register gateways, refer to [Manage Sandboxes](/sandboxes/manage-sandboxes).
+This page describes how the CLI resolves a gateway, authenticates with it, and where credentials are stored. For how to deploy or register gateways, refer to [Gateways](/sandboxes/manage-gateways).
 
 ## Gateway Resolution
 
@@ -26,7 +26,7 @@ The CLI uses one of three connection modes depending on the gateway's authentica
 
 ### mTLS (local and remote gateways)
 
-The default mode for self-deployed gateways. When you run `gateway start` or `gateway add --local` / `gateway add --remote`, the CLI extracts mTLS certificates from the running container and stores them locally. Every subsequent request presents a client certificate to prove identity.
+The default mode for self-deployed gateways. When you run `gateway start` or `gateway add https://... --local` / `gateway add https://... --remote`, the CLI extracts mTLS certificates from the running container and stores them locally. Every subsequent request presents a client certificate to prove identity.
 
 The CLI loads three PEM files from `~/.config/openshell/gateways/<name>/mtls/`:
 
@@ -71,6 +71,14 @@ This is transparent to the user. All CLI commands work the same regardless of wh
 ### Plaintext
 
 When a gateway is deployed with `--plaintext`, TLS is disabled entirely. The CLI connects over plain HTTP/2. This mode is intended for gateways behind a trusted reverse proxy or tunnel that handles TLS termination externally.
+
+Register a plaintext gateway with an explicit `http://` endpoint:
+
+```shell
+openshell gateway add http://127.0.0.1:8080 --local
+```
+
+This stores the gateway with `auth_mode = plaintext`, skips mTLS certificate extraction, and does not open the browser login flow.
 
 ## File Layout
 

--- a/docs/sandboxes/manage-gateways.mdx
+++ b/docs/sandboxes/manage-gateways.mdx
@@ -113,11 +113,19 @@ openshell gateway add ssh://user@remote-host:8080
 
 ### Local Gateway
 
-Register a gateway running locally that was started outside the CLI:
+Register a local mTLS gateway running outside the CLI:
 
 ```shell
 openshell gateway add https://127.0.0.1:8080 --local
 ```
+
+Register a local plaintext gateway with no auth:
+
+```shell
+openshell gateway add http://127.0.0.1:8080 --local
+```
+
+When the endpoint uses `http://`, the CLI stores a direct plaintext registration. It does not extract mTLS certificates and it does not open the browser auth flow.
 
 ## Manage Multiple Gateways
 

--- a/docs/sandboxes/manage-gateways.mdx
+++ b/docs/sandboxes/manage-gateways.mdx
@@ -113,7 +113,7 @@ openshell gateway add ssh://user@remote-host:8080
 
 ### Local Gateway
 
-Register a local mTLS gateway running outside the CLI:
+Register a local mTLS gateway:
 
 ```shell
 openshell gateway add https://127.0.0.1:8080 --local


### PR DESCRIPTION
## Summary

Support direct plaintext gateway registrations through `openshell gateway add` when the endpoint uses `http://...`.

## Related Issue

N/A

## Changes

- add a direct plaintext registration path for `http://...` gateway endpoints
- treat plaintext registrations as first-class metadata with `auth_mode = "plaintext"`
- connect direct `http://...` gateways over plaintext HTTP/2 without TLS material lookup
- document the new `openshell gateway add http://127.0.0.1:8080 --local` flow

## Testing

- [ ] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] `cargo test -p openshell-cli -p openshell-bootstrap --lib`

`mise run pre-commit` was run but failed in this environment because `openshell-cli` integration test `sandbox_create_keeps_sandbox_with_forwarding` expects port `8080` to be free, and an existing `openshell` process was already listening on that port.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
