### PR TITLE
fix(build): match only semver tags in git_version()

### DIFF
--- a/crates/openshell-core/build.rs
+++ b/crates/openshell-core/build.rs
@@ -64,7 +64,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// Returns `None` when git is unavailable or the repo has no matching tags.
 fn git_version() -> Option<String> {
     let output = std::process::Command::new("git")
-        .args(["describe", "--tags", "--long", "--match", "v*"])
+        .args(["describe", "--tags", "--long", "--match", "v[0-9]*"])
         .output()
         .ok()?;
 


### PR DESCRIPTION
## Summary

- Fix `git_version()` in `build.rs` to use `--match "v[0-9]*"` instead of `--match "v*"` so that non-version tags like `vm-dev` are excluded from `git describe` output

Closes #832

## Root cause

`git describe --tags --long --match "v*"` matches both `v0.0.28` and `vm-dev` since both start with `v`. When `vm-dev` is on a more recent commit, git picks it, resulting in the version string `m-dev` after the `v` prefix is stripped.

## Fix

Change the glob pattern from `v*` to `v[0-9]*` so only tags that start with `v` followed by a digit (i.e. semantic version tags like `v0.0.28`) are matched.

## Test plan

- [ ] Verify `git describe --tags --long --match "v[0-9]*"` skips `vm-dev` and returns the correct semver tag
- [ ] Build locally and confirm `openshell --version` shows the expected version