### PR TITLE
docs(fern): Add Kata Containers tutorial & examples

### DIFF
--- a/docs/tutorials/index.mdx
+++ b/docs/tutorials/index.mdx
@@ -31,4 +31,9 @@ Route inference through Ollama using cloud-hosted or local models, and verify it
 
 Route inference to a local LM Studio server via the OpenAI or Anthropic compatible APIs.
 </Card>
+
+<Card title="Kata Containers" href="/tutorials/kata-containers">
+
+Run sandboxes inside Kata Container VMs on Kubernetes for hardware-level isolation on top of OpenShell policy enforcement.
+</Card>
 </Cards>

--- a/docs/tutorials/kata-containers.mdx
+++ b/docs/tutorials/kata-containers.mdx
@@ -1,0 +1,314 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Run Sandboxes in Kata Container VMs"
+sidebar-title: "Kata Containers"
+slug: "tutorials/kata-containers"
+description: "Deploy OpenShell sandboxes inside Kata Container VMs on Kubernetes for hardware-level isolation, with step-by-step instructions for Kata setup, gateway deployment, image building, and agent execution."
+keywords: "Generative AI, Cybersecurity, Tutorial, Kata Containers, Sandbox, VM, Kubernetes, Isolation"
+---
+
+Run OpenShell sandboxes inside Kata Container VMs on Kubernetes. Each sandbox pod runs in its own lightweight VM with a dedicated guest kernel, adding hardware-level isolation on top of OpenShell's Landlock, seccomp, and network namespace enforcement.
+
+After completing this tutorial you will have:
+
+- Kata Containers installed and verified on your Kubernetes cluster.
+- The OpenShell gateway deployed via Helm with the supervisor binary on every node.
+- A custom sandbox image with your AI agent baked in.
+- A running sandbox inside a Kata VM with network policy enforcement.
+
+## Prerequisites
+
+- A Kubernetes cluster (v1.26+) with admin access.
+- Nodes with hardware virtualization support (Intel VT-x / AMD-V).
+- `kubectl`, `helm` v3, and Docker installed locally.
+- OpenShell CLI installed. See the [Quickstart](/get-started/quickstart) if you have not installed it yet.
+
+## Architecture
+
+Three layers of isolation protect your infrastructure:
+
+1. **Kata VM** -- each sandbox pod runs inside a QEMU or Cloud Hypervisor microVM with its own guest kernel.
+2. **OpenShell sandbox** -- inside the VM, the supervisor enforces Landlock filesystem rules, seccomp-BPF syscall filters, and a dedicated network namespace.
+3. **Egress proxy and OPA** -- all outbound traffic passes through an HTTP CONNECT proxy that evaluates per-binary, per-endpoint network policy via an embedded OPA/Rego engine.
+
+<Steps toc={true}>
+
+## Install Kata Containers
+
+kata-deploy is a DaemonSet that installs Kata binaries and configures containerd on every node.
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+kubectl -n kube-system wait --for=condition=Ready pod -l name=kata-deploy --timeout=600s
+```
+
+Verify the RuntimeClass exists:
+
+```shell
+kubectl get runtimeclass
+```
+
+If `kata-containers` is not listed, create it manually. An example manifest is at [examples/kata-containers/kata-runtimeclass.yaml](https://github.com/NVIDIA/OpenShell/blob/main/examples/kata-containers/kata-runtimeclass.yaml):
+
+```shell
+kubectl apply -f examples/kata-containers/kata-runtimeclass.yaml
+```
+
+Confirm Kata works by running a test pod:
+
+```shell
+kubectl run kata-test --image=busybox --restart=Never \
+  --overrides='{"spec":{"runtimeClassName":"kata-containers"}}' \
+  -- uname -a
+kubectl wait --for=condition=Ready pod/kata-test --timeout=60s
+kubectl logs kata-test
+kubectl delete pod kata-test
+```
+
+If the kernel version differs from your host, Kata is working.
+
+## Deploy the Supervisor Binary
+
+The Kubernetes driver side-loads the `openshell-sandbox` supervisor from `/opt/openshell/bin/openshell-sandbox` on the node via a hostPath volume. For the built-in k3s cluster this is already present. For your own cluster, deploy the installer DaemonSet:
+
+```shell
+kubectl create namespace openshell
+kubectl apply -f examples/kata-containers/supervisor-daemonset.yaml
+```
+
+Wait for it to roll out:
+
+```shell
+kubectl -n openshell rollout status daemonset/openshell-supervisor-installer
+```
+
+## Deploy the Agent-Sandbox CRD
+
+Install the Sandbox Custom Resource Definition and its controller:
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/NVIDIA/OpenShell/main/deploy/kube/manifests/agent-sandbox.yaml
+kubectl get crd sandboxes.agents.x-k8s.io
+kubectl -n agent-sandbox-system get pods
+```
+
+## Create Secrets
+
+The gateway requires mTLS certificates and an SSH handshake secret. The simplest approach is to bootstrap a local gateway, extract the PKI material, then create Kubernetes secrets:
+
+```shell
+openshell gateway start
+GATEWAY_DIR=$(ls -d ~/.config/openshell/gateways/*/mtls | head -1)
+
+kubectl -n openshell create secret tls openshell-server-tls \
+  --cert="$GATEWAY_DIR/../server.crt" \
+  --key="$GATEWAY_DIR/../server.key"
+
+kubectl -n openshell create secret generic openshell-server-client-ca \
+  --from-file=ca.crt="$GATEWAY_DIR/ca.crt"
+
+kubectl -n openshell create secret tls openshell-client-tls \
+  --cert="$GATEWAY_DIR/client.crt" \
+  --key="$GATEWAY_DIR/client.key"
+
+kubectl -n openshell create secret generic openshell-ssh-handshake \
+  --from-literal=secret=$(openssl rand -hex 32)
+
+openshell gateway stop
+```
+
+## Install the Gateway via Helm
+
+```shell
+helm install openshell deploy/helm/openshell/ \
+  --namespace openshell \
+  --set server.sandboxNamespace=openshell \
+  --set server.sandboxImage=ghcr.io/nvidia/openshell-community/sandboxes/base:latest \
+  --set server.grpcEndpoint=https://openshell.openshell.svc.cluster.local:8080 \
+  --set server.sshGatewayHost=<YOUR_EXTERNAL_HOST> \
+  --set server.sshGatewayPort=30051
+```
+
+Replace `<YOUR_EXTERNAL_HOST>` with the externally reachable address of your cluster's NodePort or load balancer.
+
+Wait for the gateway:
+
+```shell
+kubectl -n openshell rollout status statefulset/openshell --timeout=300s
+```
+
+Register it with the CLI:
+
+```shell
+openshell gateway add --name kata-cluster --endpoint https://<YOUR_EXTERNAL_HOST>:30051
+```
+
+## Build a Sandbox Image
+
+Your image provides the agent and its dependencies. OpenShell replaces the entrypoint at runtime with its supervisor, so pass the agent start command after `--` on the CLI. Key requirements:
+
+- Standard Linux base image (not distroless or `FROM scratch`).
+- `iproute2` installed (required for network namespace isolation).
+- `iptables` installed (recommended for bypass detection).
+- A `sandbox` user with uid/gid 1000.
+
+Example for Claude Code (see [Dockerfile.claude-code](https://github.com/NVIDIA/OpenShell/blob/main/examples/kata-containers/Dockerfile.claude-code)):
+
+```dockerfile
+FROM node:22-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl iproute2 iptables git openssh-client ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @anthropic-ai/claude-code
+
+RUN groupadd -g 1000 sandbox && \
+    useradd -m -u 1000 -g sandbox -s /bin/bash sandbox
+
+WORKDIR /sandbox
+```
+
+Build and push to a registry your cluster can reach:
+
+```shell
+docker build -t myregistry.com/claude-sandbox:latest \
+  -f examples/kata-containers/Dockerfile.claude-code .
+docker push myregistry.com/claude-sandbox:latest
+```
+
+## Configure a Provider
+
+Providers inject API keys into sandboxes. Create one from your local environment:
+
+```shell
+export ANTHROPIC_API_KEY=sk-ant-...
+openshell provider create --name claude --type claude --from-existing
+openshell provider list
+```
+
+## Create a Sandbox with Kata
+
+The `runtime_class_name` field is fully supported in the gRPC API and Kubernetes driver but is not yet exposed as a CLI flag. Use the Python SDK script from the example:
+
+```shell
+uv run examples/kata-containers/create-kata-sandbox.py \
+  --name my-claude \
+  --image myregistry.com/claude-sandbox:latest \
+  --runtime-class kata-containers \
+  --provider claude
+```
+
+Or create via CLI and patch afterward:
+
+```shell
+openshell sandbox create --name my-claude \
+  --from myregistry.com/claude-sandbox:latest \
+  --provider claude \
+  --policy examples/kata-containers/policy-claude-code.yaml
+
+kubectl -n openshell patch sandbox my-claude --type=merge -p '{
+  "spec": {
+    "podTemplate": {
+      "spec": {
+        "runtimeClassName": "kata-containers"
+      }
+    }
+  }
+}'
+```
+
+## Apply a Network Policy
+
+Apply the Claude Code policy that allows Anthropic, GitHub, npm, and PyPI:
+
+```shell
+openshell policy set my-claude \
+  --policy examples/kata-containers/policy-claude-code.yaml \
+  --wait
+```
+
+Verify:
+
+```shell
+openshell policy get my-claude --full
+```
+
+## Connect and Run Your Agent
+
+```shell
+openshell sandbox connect my-claude
+```
+
+Inside the sandbox, start Claude Code:
+
+```shell
+claude
+```
+
+## Verify Kata Isolation
+
+Confirm the pod is running with the Kata runtime:
+
+```shell
+kubectl -n openshell get pods -l sandbox=my-claude \
+  -o jsonpath='{.items[0].spec.runtimeClassName}'
+```
+
+The output should be `kata-containers`.
+
+Check the guest kernel version (it should differ from the host):
+
+```shell
+openshell sandbox exec my-claude -- uname -r
+```
+
+Verify OpenShell sandbox isolation inside the VM:
+
+```shell
+openshell sandbox exec my-claude -- ip netns list
+openshell sandbox exec my-claude -- ss -tlnp | grep 3128
+openshell sandbox exec my-claude -- touch /usr/test-file
+```
+
+The network namespace should be listed, the proxy should be listening on port 3128, and writing to `/usr` should fail with "Permission denied".
+
+</Steps>
+
+## Kata-Specific Considerations
+
+### Guest Kernel Requirements
+
+The supervisor requires Landlock (ABI V2, kernel 5.19+), seccomp-BPF, network namespaces, veth, and iptables inside the VM. Most Kata guest kernels 5.15+ include these. If Landlock is unavailable, set `landlock.compatibility: best_effort` in the policy.
+
+### hostPath Volume Passthrough
+
+The supervisor binary is injected via a hostPath volume. Kata passes hostPath volumes into the VM via virtiofs or 9p. This works with standard Kata configurations. If your setup restricts host filesystem access, allow `/opt/openshell/bin` in the Kata `configuration.toml`.
+
+### Container Capabilities
+
+The OpenShell K8s driver automatically requests `SYS_ADMIN`, `NET_ADMIN`, `SYS_PTRACE`, and `SYSLOG`. Inside a Kata VM these capabilities are scoped to the guest kernel, not the host.
+
+### Performance
+
+Kata adds 2-5 seconds of VM boot time. Runtime overhead is minimal for IO-bound AI agent workloads. Account for the base VM memory overhead (128-256 MB) in pod resource requests.
+
+## Cleanup
+
+```shell
+openshell sandbox delete my-claude
+openshell provider delete claude
+kubectl delete -f examples/kata-containers/supervisor-daemonset.yaml
+helm uninstall openshell -n openshell
+kubectl delete -f https://raw.githubusercontent.com/NVIDIA/OpenShell/main/deploy/kube/manifests/agent-sandbox.yaml
+kubectl delete namespace openshell
+```
+
+## Next Steps
+
+- Explore the [example policies](https://github.com/NVIDIA/OpenShell/tree/main/examples/kata-containers) for minimal, L7, and full agent configurations.
+- Add more providers for multi-agent setups. See [Manage Providers](/sandboxes/manage-providers).
+- Configure [Inference Routing](/inference/about) to route model requests through local or remote LLM backends.
+- Review the [Policy Schema Reference](/reference/policy-schema) for the full YAML specification.

--- a/examples/kata-containers/Dockerfile.claude-code
+++ b/examples/kata-containers/Dockerfile.claude-code
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Sandbox image for Claude Code.
+# Build:  docker build -t claude-sandbox:latest -f Dockerfile.claude-code .
+# Usage:  openshell sandbox create --from claude-sandbox:latest -- claude
+
+FROM node:22-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl iproute2 iptables git openssh-client ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @anthropic-ai/claude-code
+
+RUN groupadd -g 1000 sandbox && \
+    useradd -m -u 1000 -g sandbox -s /bin/bash sandbox
+
+WORKDIR /sandbox

--- a/examples/kata-containers/Dockerfile.python-agent
+++ b/examples/kata-containers/Dockerfile.python-agent
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Sandbox image for Python-based AI agents (Hermes, custom agents, etc.).
+# Build:  docker build -t python-agent-sandbox:latest -f Dockerfile.python-agent .
+# Usage:  openshell sandbox create --from python-agent-sandbox:latest -- python -m my_agent
+
+FROM python:3.13-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl iproute2 iptables git openssh-client ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install your agent here.  Replace with your agent's package name.
+# RUN pip install --no-cache-dir hermes-ai
+
+RUN groupadd -g 1000 sandbox && \
+    useradd -m -u 1000 -g sandbox -s /bin/bash sandbox
+
+WORKDIR /sandbox

--- a/examples/kata-containers/README.md
+++ b/examples/kata-containers/README.md
@@ -1,0 +1,129 @@
+# Running AI Agents with Kata Containers
+
+Run OpenShell sandboxes inside Kata Container VMs for hardware-level
+isolation on Kubernetes.  This example covers Kata setup, custom sandbox
+images, policy authoring, and sandbox creation with `runtimeClassName`.
+
+## Prerequisites
+
+- A Kubernetes cluster (v1.26+) with admin access
+- Nodes with hardware virtualization (Intel VT-x / AMD-V)
+- `kubectl`, `helm` v3, and Docker on your local machine
+- OpenShell CLI installed (`curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh`)
+
+## What's in this example
+
+| File                          | Description                                                        |
+| ----------------------------- | ------------------------------------------------------------------ |
+| `Dockerfile.claude-code`      | Sandbox image for Claude Code (Node.js base)                       |
+| `Dockerfile.python-agent`     | Sandbox image for Python-based agents (Hermes, custom)             |
+| `policy-claude-code.yaml`     | Network policy: Anthropic API, GitHub, npm, PyPI                   |
+| `policy-minimal.yaml`         | Minimal policy: single API endpoint                                |
+| `policy-l7-github.yaml`       | L7 read-only policy for the GitHub REST API                        |
+| `supervisor-daemonset.yaml`   | DaemonSet that installs the supervisor binary on every node        |
+| `create-kata-sandbox.py`      | Python SDK script to create a sandbox with Kata runtime class      |
+| `kata-runtimeclass.yaml`      | RuntimeClass manifest for Kata                                     |
+
+## Quick start
+
+### 1. Install Kata Containers on your cluster
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+kubectl -n kube-system wait --for=condition=Ready pod -l name=kata-deploy --timeout=600s
+```
+
+Verify the RuntimeClass exists:
+
+```bash
+kubectl get runtimeclass
+```
+
+If `kata-containers` is missing:
+
+```bash
+kubectl apply -f examples/kata-containers/kata-runtimeclass.yaml
+```
+
+### 2. Deploy the supervisor binary to nodes
+
+```bash
+kubectl apply -f examples/kata-containers/supervisor-daemonset.yaml
+```
+
+### 3. Deploy the OpenShell gateway
+
+Follow the [Kata Containers tutorial](../../docs/tutorials/kata-containers.mdx)
+for full Helm-based gateway deployment, or use the built-in local gateway:
+
+```bash
+openshell gateway start
+```
+
+### 4. Create a provider
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+openshell provider create --name claude --type claude --from-existing
+```
+
+### 5. Create a Kata-isolated sandbox
+
+Using the Python SDK (the CLI does not yet expose `--runtime-class`):
+
+```bash
+uv run examples/kata-containers/create-kata-sandbox.py \
+  --name my-claude \
+  --image myregistry.com/claude-sandbox:latest \
+  --provider claude \
+  --runtime-class kata-containers
+```
+
+Or create via CLI without Kata and patch afterward:
+
+```bash
+openshell sandbox create --name my-claude \
+  --from examples/kata-containers/Dockerfile.claude-code \
+  --provider claude \
+  --policy examples/kata-containers/policy-claude-code.yaml
+
+kubectl -n openshell patch sandbox my-claude --type=merge -p '{
+  "spec": {
+    "podTemplate": {
+      "spec": {
+        "runtimeClassName": "kata-containers"
+      }
+    }
+  }
+}'
+```
+
+### 6. Connect and run your agent
+
+```bash
+openshell sandbox connect my-claude
+# Inside the sandbox:
+claude
+```
+
+### 7. Verify Kata isolation
+
+```bash
+# Guest kernel (should differ from host)
+openshell sandbox exec my-claude -- uname -r
+
+# Sandbox network namespace
+openshell sandbox exec my-claude -- ip netns list
+
+# Proxy is running
+openshell sandbox exec my-claude -- ss -tlnp | grep 3128
+```
+
+## Cleanup
+
+```bash
+openshell sandbox delete my-claude
+openshell provider delete claude
+kubectl delete -f examples/kata-containers/supervisor-daemonset.yaml
+```

--- a/examples/kata-containers/create-kata-sandbox.py
+++ b/examples/kata-containers/create-kata-sandbox.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Create an OpenShell sandbox with Kata Containers runtime class.
+
+The CLI does not yet expose a --runtime-class flag, but the gRPC API fully
+supports it.  This script uses the Python SDK to set runtime_class_name on
+the SandboxTemplate at creation time.
+
+Usage:
+    uv run examples/kata-containers/create-kata-sandbox.py \\
+        --name my-agent \\
+        --image myregistry.com/agent-sandbox:latest \\
+        --runtime-class kata-containers \\
+        --provider claude
+
+Requirements:
+    pip install openshell   # or: uv pip install openshell
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Create an OpenShell sandbox with a Kata Containers runtime class.",
+    )
+    parser.add_argument("--name", required=True, help="Sandbox name")
+    parser.add_argument(
+        "--image",
+        default="ghcr.io/nvidia/openshell-community/sandboxes/base:latest",
+        help="Container image for the sandbox",
+    )
+    parser.add_argument(
+        "--runtime-class",
+        default="kata-containers",
+        help="Kubernetes RuntimeClass name (default: kata-containers)",
+    )
+    parser.add_argument(
+        "--provider",
+        action="append",
+        default=[],
+        help="Provider name to attach (repeatable)",
+    )
+    parser.add_argument(
+        "--endpoint",
+        default=None,
+        help="Gateway gRPC endpoint (auto-detected from active cluster if omitted)",
+    )
+    args = parser.parse_args()
+
+    try:
+        from openshell._proto import openshell_pb2, openshell_pb2_grpc
+    except ImportError:
+        print(
+            "error: openshell package not installed. "
+            "Run: uv pip install openshell",
+            file=sys.stderr,
+        )
+        return 1
+
+    from openshell import SandboxClient
+
+    if args.endpoint:
+        client = SandboxClient(args.endpoint)
+    else:
+        client = SandboxClient.from_active_cluster()
+
+    template = openshell_pb2.SandboxTemplate(
+        image=args.image,
+        runtime_class_name=args.runtime_class,
+    )
+
+    request = openshell_pb2.CreateSandboxRequest(
+        name=args.name,
+        providers=args.provider,
+        template=template,
+    )
+
+    print(f"Creating sandbox '{args.name}' with runtime class '{args.runtime_class}'...")
+    response = client.stub.CreateSandbox(request)
+    print(f"Sandbox created: {response.name} (id: {response.id})")
+    print()
+    print("Connect with:")
+    print(f"    openshell sandbox connect {args.name}")
+    print()
+    print("Verify Kata isolation:")
+    print(f"    openshell sandbox exec {args.name} -- uname -r")
+    print(
+        f"    kubectl -n openshell get pods -l sandbox={args.name}"
+        " -o jsonpath='{.items[0].spec.runtimeClassName}'"
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/kata-containers/kata-runtimeclass.yaml
+++ b/examples/kata-containers/kata-runtimeclass.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# RuntimeClass for Kata Containers.
+# Apply only if kata-deploy did not create it automatically.
+#
+#   kubectl apply -f kata-runtimeclass.yaml
+#   kubectl get runtimeclass
+
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-containers
+handler: kata

--- a/examples/kata-containers/policy-claude-code.yaml
+++ b/examples/kata-containers/policy-claude-code.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Network policy for Claude Code: Anthropic API, GitHub, npm, and PyPI.
+
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /etc
+    - /proc
+    - /dev/urandom
+    - /app
+    - /var/log
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  anthropic:
+    name: anthropic-api
+    endpoints:
+      - host: "*.anthropic.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: full
+
+  github:
+    name: github
+    endpoints:
+      - host: "*.github.com"
+        port: 443
+      - host: "*.githubusercontent.com"
+        port: 443
+
+  npm:
+    name: npm-registry
+    endpoints:
+      - host: registry.npmjs.org
+        port: 443
+      - host: "*.npmjs.com"
+        port: 443
+
+  pypi:
+    name: pypi
+    endpoints:
+      - host: pypi.org
+        port: 443
+      - host: files.pythonhosted.org
+        port: 443

--- a/examples/kata-containers/policy-l7-github.yaml
+++ b/examples/kata-containers/policy-l7-github.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# L7 read-only policy for the GitHub REST API.
+# Allows GET requests to /repos/** but blocks POST, PUT, DELETE, etc.
+# The proxy terminates TLS to inspect individual HTTP requests.
+
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /etc
+    - /proc
+    - /dev/urandom
+    - /app
+    - /var/log
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  github_readonly:
+    name: github-read-only
+    endpoints:
+      - host: api.github.com
+        port: 443
+        protocol: rest
+        tls: terminate
+        enforcement: enforce
+        access: full
+        rules:
+          - allow:
+              method: GET
+              path: "/repos/**"
+          - allow:
+              method: GET
+              path: "/orgs/**"
+          - allow:
+              method: GET
+              path: "/users/**"
+    binaries:
+      - path: /usr/bin/curl

--- a/examples/kata-containers/policy-minimal.yaml
+++ b/examples/kata-containers/policy-minimal.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Minimal policy: allows only a single API endpoint.
+# All other outbound network traffic is blocked by default.
+
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /etc
+    - /proc
+    - /dev/urandom
+    - /app
+    - /var/log
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  anthropic:
+    name: anthropic-only
+    endpoints:
+      - host: api.anthropic.com
+        port: 443

--- a/examples/kata-containers/supervisor-daemonset.yaml
+++ b/examples/kata-containers/supervisor-daemonset.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# DaemonSet that installs the openshell-sandbox supervisor binary on every
+# node.  The Kubernetes driver side-loads this binary into sandbox pods via
+# a hostPath volume at /opt/openshell/bin/openshell-sandbox.
+#
+# For the built-in k3s cluster the binary is already in the cluster image.
+# Use this DaemonSet when deploying OpenShell onto an existing Kubernetes
+# cluster (EKS, GKE, AKS, bare-metal, etc.).
+#
+#   kubectl apply -f supervisor-daemonset.yaml
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: openshell-supervisor-installer
+  namespace: openshell
+  labels:
+    app.kubernetes.io/name: openshell-supervisor-installer
+    app.kubernetes.io/component: supervisor
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: openshell-supervisor-installer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: openshell-supervisor-installer
+    spec:
+      initContainers:
+        - name: install-supervisor
+          image: ghcr.io/nvidia/openshell/cluster:latest
+          command:
+            - cp
+            - /opt/openshell/bin/openshell-sandbox
+            - /host-bin/openshell-sandbox
+          volumeMounts:
+            - name: host-bin
+              mountPath: /host-bin
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+          resources:
+            requests:
+              cpu: 1m
+              memory: 4Mi
+            limits:
+              cpu: 1m
+              memory: 4Mi
+      volumes:
+        - name: host-bin
+          hostPath:
+            path: /opt/openshell/bin
+            type: DirectoryOrCreate


### PR DESCRIPTION
Introduce a new Kata Containers tutorial and add example artifacts to support running OpenShell sandboxes inside Kata VMs. Changes include: adding a Kata Containers card to the tutorials index, a full tutorial (docs/tutorials/kata-containers.mdx), example sandbox Dockerfiles for Claude and Python agents, a README for the examples, a Python SDK script to create sandboxes with a runtimeClass, a RuntimeClass manifest, several policy YAMLs (claude-code, minimal, L7 GitHub), and a DaemonSet to install the supervisor binary on cluster nodes. These additions provide step-by-step instructions, sample images, network policies, and deployment manifests for hardware-level VM isolation on Kubernetes.

## Summary
<!-- 1-3 sentences: what this PR does and why -->

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- What testing was done? -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
