### PR TITLE
fix(core): exclude vm-dev tag from git describe version glob

### DIFF
--- a/crates/openshell-core/build.rs
+++ b/crates/openshell-core/build.rs
@@ -63,8 +63,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///
 /// Returns `None` when git is unavailable or the repo has no matching tags.
 fn git_version() -> Option<String> {
+    // Match numeric release tags only (e.g. `v0.0.29`). The bare glob `v*`
+    // also matches non-release tags like `vm-dev` or `vm-prod`; when one of
+    // those lands on the same commit as a release tag, `git describe` picks
+    // it and the resulting version string collapses to `m-dev` after the
+    // leading `v` is stripped below. Requiring a digit after `v` excludes
+    // those development tags without losing any release tag.
     let output = std::process::Command::new("git")
-        .args(["describe", "--tags", "--long", "--match", "v*"])
+        .args(["describe", "--tags", "--long", "--match", "v[0-9]*"])
         .output()
         .ok()?;
 


### PR DESCRIPTION
## Summary
Exclude the `vm-dev` development tag from the `git describe` glob that derives the build-time version string. Currently `--match "v*"` catches it, producing a binary that reports itself as `m-dev`. Fixed by requiring a numeric segment after `v`.

## Related Issue
Closes #832

## Changes
- `crates/openshell-core/build.rs::git_version`: change `--match "v*"` to `--match "v[0-9]*"`. Leaves a short comment explaining *why* (the `vm-dev` collision) so the next reader doesn't think the glob is over-restrictive.

## Root Cause

`git describe --tags --long --match "v*"` matches every tag that starts with `v`, including `vm-dev` and `vm-prod`. On current main, `vm-dev` sits on or past the latest release tag in the commit graph, so git picks it:

```
$ git describe --tags --long --match 'v*'
vm-dev-0-g355d845
```

`git_version` then strips the leading `v` (line 77), producing `m-dev-0-g355d845`, which parses cleanly as `tag="m-dev"`, `commits=0` and is returned verbatim. The resulting binary reports:

```
$ openshell --version
openshell m-dev
```

The original issue logged this for v0.0.28; I reproduced it on v0.0.29 as well (installed via `uv tool install openshell==0.0.29 --force`, same `m-dev` output). See comment: https://github.com/NVIDIA/OpenShell/issues/832#issuecomment-4248984900

## Fix verification

On current repo HEAD:

```
# before
$ git describe --tags --long --match 'v*'
vm-dev-0-g355d845

# after
$ git describe --tags --long --match 'v[0-9]*'
v0.0.29-2-g355d845
```

The fixed glob walks past `vm-dev`/`vm-prod` and lands on the newest numeric release tag. All real release tags follow `v\d+\.\d+\.\d+`, so this loses no valid version — it only filters out the dev tags that the format string was never meant to interpret.

The `guess-next-dev` path on line 90 (`v0.0.29-2-gSHA` → `0.0.30-dev.2+g355d845`) now works as intended.

## Testing
- [x] `cargo check --package openshell-core` compiles clean
- [x] `cargo fmt --package openshell-core -- --check` clean
- [x] Demonstrated glob behavior change above with `git describe` directly — the fix is one glob character so unit tests aren't useful, but the before/after demonstration on real tags is
- [ ] `mise run pre-commit` — `mise` not installed in this environment; ran `cargo fmt --check` + `cargo check` for the affected crate by hand

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) — `fix(core): …`
- [x] Commit is signed off (DCO)
- [ ] Architecture docs updated — not applicable
