### PR TITLE
build: restrict version tag glob to semver (v[0-9]*)

### DIFF
--- a/crates/openshell-core/build.rs
+++ b/crates/openshell-core/build.rs
@@ -64,7 +64,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// Returns `None` when git is unavailable or the repo has no matching tags.
 fn git_version() -> Option<String> {
     let output = std::process::Command::new("git")
-        .args(["describe", "--tags", "--long", "--match", "v*"])
+        .args(["describe", "--tags", "--long", "--match", "v[0-9]*"])
         .output()
         .ok()?;
 


### PR DESCRIPTION
## Summary

One-character fix to the tag glob used by `git_version()` in `crates/openshell-core/build.rs`.

```diff
-        .args(["describe", "--tags", "--long", "--match", "v*"])
+        .args(["describe", "--tags", "--long", "--match", "v[0-9]*"])
```

## Why

`git describe --tags --long --match \"v*\"` matches **any** tag starting with `v`, including non-release markers like `vm-dev`. When such a marker sits on a more recent commit than the last release, git picks it, and the downstream parser produces nonsense:

```
git describe ... → \"vm-dev-1-g463f65a\"
strip_prefix('v') → \"m-dev-1-g463f65a\"
splitn(3, '.') on \"m-dev\" → fails (no dots) → returns None
```

`git_version()` then returns `None`, the binary falls back to `CARGO_PKG_VERSION`, and the v0.0.28 release ships reporting its version as `m-dev` (per the diagnosis in the issue).

## Fix

`v[0-9]*` restricts matches to tags that begin with `v` followed by a digit, so `vm-dev` and similar markers are ignored and git correctly describes against `v0.0.28`.

## Test plan

- [x] `cargo check -p openshell-core` (local — passes; no logic change)
- Once merged and cut as a release, `openshell --version` should print `0.0.28` (or the current release tag) instead of `m-dev`.

Fixes #832