### PR TITLE
docs: refresh user-facing docs for recent sandbox and inference changes

### DIFF
--- a/docs/about/architecture.mdx
+++ b/docs/about/architecture.mdx
@@ -35,7 +35,17 @@ Every outbound connection from agent code passes through the same decision path:
    - **Allow** - the destination and binary match a policy block. Traffic flows directly to the external service.
    - **Deny** - no policy block matched. The connection is blocked and logged.
 
-For REST endpoints with TLS termination enabled, the proxy also decrypts TLS and checks each HTTP request against per-method, per-path rules before allowing it through.
+For REST endpoints, the proxy auto-detects TLS on every tunnel by peeking the first bytes. When a TLS ClientHello is detected, the proxy terminates TLS transparently using a per-sandbox ephemeral CA and checks each HTTP request against per-method, per-path rules before allowing it through. Upstream connections trust both the Mozilla webpki root set and the system CA store inside the sandbox container (`/etc/ssl/certs/ca-certificates.crt`, `/etc/pki/tls/certs/ca-bundle.crt`, `/etc/ssl/ca-bundle.pem`, `/etc/ssl/cert.pem`). To trust a corporate or internal CA for upstream traffic, add the PEM file to the container's trust store during the image build.
+
+The older `tls: terminate` and `tls: passthrough` policy keys are deprecated. Leaving either in a policy emits a warning and has no effect. Use `tls: skip` on an endpoint if you need to disable TLS detection and termination for that destination.
+
+## Gateway Lifecycle
+
+OpenShell preserves sandbox state across gateway restarts. When you run `openshell gateway stop` and then `openshell gateway start`, running sandboxes resume from their saved state rather than being recreated. The gateway also persists the SSH handshake secret so open SSH sessions to sandboxes reconnect without re-authenticating.
+
+## Observability
+
+The sandbox emits operational decisions as OCSF v1.7.0 structured logs, covering network connections, HTTP requests, SSH sessions, process lifecycle events, detection findings, policy and configuration changes, and supervisor lifecycle. For the event classes and the JSONL export format, refer to [OCSF JSON Export](/observability/ocsf-json-export).
 
 ## Deployment Modes
 

--- a/docs/about/architecture.mdx
+++ b/docs/about/architecture.mdx
@@ -30,10 +30,15 @@ Every outbound connection from agent code passes through the same decision path:
 2. The proxy inside the sandbox intercepts the connection and identifies which binary opened it.
 3. If the target is `https://inference.local`, the proxy handles it as managed inference before policy evaluation. OpenShell strips sandbox-supplied credentials, injects the configured backend credentials, and forwards the request to the managed model endpoint.
 4. For every other destination, the proxy queries the policy engine with the destination, port, and calling binary.
-5. The policy engine returns one of the following decisions. Explicit deny takes precedence over allow.
-   - **Explicit Deny**: a deny rule, or a hardening rule such as server-side request forgery (SSRF) protection, a blocked control-plane port, or a Layer 7 (L7) deny, rejects the request even when an allow rule would otherwise permit it. The connection is blocked and logged.
-   - **Allow**: the destination and binary match a policy block, and no deny rule applies. Traffic flows directly to the external service.
-   - **Implicit Deny**: no policy block matched. The connection is blocked and logged.
+5. The policy engine returns one of the decisions in the following table.
+
+   The policy engine evaluates decisions in this order. Explicit deny takes precedence over allow, and allow takes precedence over implicit deny.
+
+   | Decision | When it applies | Outcome |
+   |---|---|---|
+   | **Explicit Deny** | A deny rule, or a hardening rule such as server-side request forgery (SSRF) protection, a blocked control-plane port, or a Layer 7 (L7) deny, rejects the request even when an allow rule would otherwise permit it. | The connection is blocked and logged. |
+   | **Allow** | The destination and binary match a policy block, and no deny rule applies. | Traffic flows directly to the external service. |
+   | **Implicit Deny** | No policy block matched. | The connection is blocked and logged. |
 
 For REST endpoints, the proxy auto-detects Transport Layer Security (TLS) by peeking the first bytes of each tunnel. When TLS is detected, the proxy terminates it transparently using a per-sandbox ephemeral certificate authority (CA) so each HTTP request can be checked against per-method, per-path rules before forwarding. To trust a corporate or internal CA for upstream traffic, add the PEM-encoded certificate to the sandbox container's trust store at image build time.
 

--- a/docs/about/architecture.mdx
+++ b/docs/about/architecture.mdx
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 title: "How OpenShell Works"
 sidebar-title: "How It Works"
-description: "OpenShell architecture overview covering the gateway, sandbox, policy engine, and privacy router."
+description: "OpenShell architecture overview covering the gateway, sandbox, and policy engine."
 keywords: "Generative AI, Cybersecurity, AI Agents, Sandboxing, Security, Architecture"
 position: 2
 ---
 
-OpenShell runs inside a Docker container. Each sandbox is an isolated environment managed through the gateway. Four components work together to keep agents secure.
+OpenShell runs inside a Docker container. Each sandbox is an isolated environment managed through the gateway. Three components work together to keep agents secure.
 
 ![OpenShell architecture diagram](/assets/images/architecture.svg)
 
@@ -21,7 +21,6 @@ The following table describes each component and its role in the system:
 | **Gateway** | Control-plane API that coordinates sandbox lifecycle and state, and acts as the auth boundary between clients and sandboxes. |
 | **Sandbox** | Isolated runtime that includes container supervision and policy-enforced egress routing. |
 | **Policy Engine** | Policy definition and enforcement layer for filesystem, network, process, and inference constraints. Defense in depth enforces policies from the application layer down to infrastructure and kernel layers. |
-| **Privacy Router** | Privacy-aware large language model (LLM) routing layer that keeps sensitive context on sandbox compute and routes to the configured backend. |
 
 ## How a Request Flows
 
@@ -31,9 +30,10 @@ Every outbound connection from agent code passes through the same decision path:
 2. The proxy inside the sandbox intercepts the connection and identifies which binary opened it.
 3. If the target is `https://inference.local`, the proxy handles it as managed inference before policy evaluation. OpenShell strips sandbox-supplied credentials, injects the configured backend credentials, and forwards the request to the managed model endpoint.
 4. For every other destination, the proxy queries the policy engine with the destination, port, and calling binary.
-5. The policy engine returns one of the following decisions.
-   - **Allow**: the destination and binary match a policy block. Traffic flows directly to the external service.
-   - **Deny**: no policy block matched, or a hardening rule, such as server-side request forgery (SSRF) protection, blocked control-plane port, or Layer 7 (L7) deny, explicitly rejects the request. The connection is blocked and logged.
+5. The policy engine returns one of the following decisions. Explicit deny takes precedence over allow.
+   - **Explicit Deny**: a deny rule, or a hardening rule such as server-side request forgery (SSRF) protection, a blocked control-plane port, or a Layer 7 (L7) deny, rejects the request even when an allow rule would otherwise permit it. The connection is blocked and logged.
+   - **Allow**: the destination and binary match a policy block, and no deny rule applies. Traffic flows directly to the external service.
+   - **Implicit Deny**: no policy block matched. The connection is blocked and logged.
 
 For REST endpoints, the proxy auto-detects Transport Layer Security (TLS) by peeking the first bytes of each tunnel. When TLS is detected, the proxy terminates it transparently using a per-sandbox ephemeral certificate authority (CA) so each HTTP request can be checked against per-method, per-path rules before forwarding. To trust a corporate or internal CA for upstream traffic, add the PEM-encoded certificate to the sandbox container's trust store at image build time.
 

--- a/docs/about/architecture.mdx
+++ b/docs/about/architecture.mdx
@@ -39,11 +39,11 @@ For REST endpoints, the proxy auto-detects Transport Layer Security (TLS) by pee
 
 ## Gateway Lifecycle
 
-OpenShell preserves sandbox state across gateway restarts. After `openshell gateway stop` and `openshell gateway start`, running sandboxes resume from their saved state and existing SSH sessions reconnect without re-authenticating.
+OpenShell preserves sandbox state across gateway restarts. After `openshell gateway stop` and `openshell gateway start`, running sandboxes resume from their saved state. Existing SSH sessions reconnect without re-authenticating.
 
 ## Observability
 
-The sandbox emits operational decisions as Open Cybersecurity Schema Framework (OCSF) v1.7.0 structured logs, covering network connections, HTTP requests, SSH sessions, process lifecycle, detection findings, and configuration changes. For event classes and the JSON Lines (JSONL) export format, refer to [OCSF JSON Export](/observability/ocsf-json-export).
+The sandbox emits operational decisions as Open Cybersecurity Schema Framework (OCSF) v1.7.0 structured logs. The events cover network connections, HTTP requests, SSH sessions, process lifecycle, detection findings, and configuration changes. For event classes and the JSON Lines (JSONL) export format, refer to [OCSF JSON Export](/observability/ocsf-json-export).
 
 ## Deployment Modes
 

--- a/docs/about/architecture.mdx
+++ b/docs/about/architecture.mdx
@@ -14,14 +14,14 @@ OpenShell runs inside a Docker container. Each sandbox is an isolated environmen
 
 ## Components
 
-The following table describes each component  and its role in the system:
+The following table describes each component and its role in the system:
 
 | Component | Role |
 |---|---|
-| **Gateway** | Control-plane API that coordinates sandbox lifecycle and state, acts as the auth boundary, and brokers requests across the platform. |
+| **Gateway** | Control-plane API that coordinates sandbox lifecycle and state, and acts as the auth boundary between clients and sandboxes. |
 | **Sandbox** | Isolated runtime that includes container supervision and policy-enforced egress routing. |
-| **Policy Engine** | Policy definition and enforcement layer for filesystem, network, and process constraints. Defense in depth enforces policies from the application layer down to infrastructure and kernel layers. |
-| **Privacy Router** | Privacy-aware LLM routing layer that keeps sensitive context on sandbox compute and routes based on cost and privacy policy. |
+| **Policy Engine** | Policy definition and enforcement layer for filesystem, network, process, and inference constraints. Defense in depth enforces policies from the application layer down to infrastructure and kernel layers. |
+| **Privacy Router** | Privacy-aware large language model (LLM) routing layer that keeps sensitive context on sandbox compute and routes to the configured backend. |
 
 ## How a Request Flows
 
@@ -31,25 +31,23 @@ Every outbound connection from agent code passes through the same decision path:
 2. The proxy inside the sandbox intercepts the connection and identifies which binary opened it.
 3. If the target is `https://inference.local`, the proxy handles it as managed inference before policy evaluation. OpenShell strips sandbox-supplied credentials, injects the configured backend credentials, and forwards the request to the managed model endpoint.
 4. For every other destination, the proxy queries the policy engine with the destination, port, and calling binary.
-5. The policy engine returns one of two decisions:
-   - **Allow** - the destination and binary match a policy block. Traffic flows directly to the external service.
-   - **Deny** - no policy block matched. The connection is blocked and logged.
+5. The policy engine returns one of the following decisions.
+   - **Allow**: the destination and binary match a policy block. Traffic flows directly to the external service.
+   - **Deny**: no policy block matched, or a hardening rule, such as server-side request forgery (SSRF) protection, blocked control-plane port, or Layer 7 (L7) deny, explicitly rejects the request. The connection is blocked and logged.
 
-For REST endpoints, the proxy auto-detects TLS on every tunnel by peeking the first bytes. When a TLS ClientHello is detected, the proxy terminates TLS transparently using a per-sandbox ephemeral CA and checks each HTTP request against per-method, per-path rules before allowing it through. Upstream connections trust both the Mozilla webpki root set and the system CA store inside the sandbox container (`/etc/ssl/certs/ca-certificates.crt`, `/etc/pki/tls/certs/ca-bundle.crt`, `/etc/ssl/ca-bundle.pem`, `/etc/ssl/cert.pem`). To trust a corporate or internal CA for upstream traffic, add the PEM file to the container's trust store during the image build.
-
-The older `tls: terminate` and `tls: passthrough` policy keys are deprecated. Leaving either in a policy emits a warning and has no effect. Use `tls: skip` on an endpoint if you need to disable TLS detection and termination for that destination.
+For REST endpoints, the proxy auto-detects Transport Layer Security (TLS) by peeking the first bytes of each tunnel. When TLS is detected, the proxy terminates it transparently using a per-sandbox ephemeral certificate authority (CA) so each HTTP request can be checked against per-method, per-path rules before forwarding. To trust a corporate or internal CA for upstream traffic, add the PEM-encoded certificate to the sandbox container's trust store at image build time.
 
 ## Gateway Lifecycle
 
-OpenShell preserves sandbox state across gateway restarts. When you run `openshell gateway stop` and then `openshell gateway start`, running sandboxes resume from their saved state rather than being recreated. The gateway also persists the SSH handshake secret so open SSH sessions to sandboxes reconnect without re-authenticating.
+OpenShell preserves sandbox state across gateway restarts. After `openshell gateway stop` and `openshell gateway start`, running sandboxes resume from their saved state and existing SSH sessions reconnect without re-authenticating.
 
 ## Observability
 
-The sandbox emits operational decisions as OCSF v1.7.0 structured logs, covering network connections, HTTP requests, SSH sessions, process lifecycle events, detection findings, policy and configuration changes, and supervisor lifecycle. For the event classes and the JSONL export format, refer to [OCSF JSON Export](/observability/ocsf-json-export).
+The sandbox emits operational decisions as Open Cybersecurity Schema Framework (OCSF) v1.7.0 structured logs, covering network connections, HTTP requests, SSH sessions, process lifecycle, detection findings, and configuration changes. For event classes and the JSON Lines (JSONL) export format, refer to [OCSF JSON Export](/observability/ocsf-json-export).
 
 ## Deployment Modes
 
-OpenShell can run locally, on a remote host, or behind a cloud proxy. The architecture is identical in all cases — only the Docker container location and authentication mode change.
+OpenShell can run locally, on a remote host, or behind a cloud proxy. The architecture is identical in all cases. Only the Docker container location and authentication mode change.
 
 | Mode | Description | Command |
 |---|---|---|

--- a/docs/about/architecture.mdx
+++ b/docs/about/architecture.mdx
@@ -30,9 +30,7 @@ Every outbound connection from agent code passes through the same decision path:
 2. The proxy inside the sandbox intercepts the connection and identifies which binary opened it.
 3. If the target is `https://inference.local`, the proxy handles it as managed inference before policy evaluation. OpenShell strips sandbox-supplied credentials, injects the configured backend credentials, and forwards the request to the managed model endpoint.
 4. For every other destination, the proxy queries the policy engine with the destination, port, and calling binary.
-5. The policy engine returns one of the decisions in the following table.
-
-   The policy engine evaluates decisions in this order. Explicit deny takes precedence over allow, and allow takes precedence over implicit deny.
+5. The policy engine returns one of the following decisions. Explicit deny takes precedence over allow, and allow takes precedence over implicit deny.
 
    | Decision | When it applies | Outcome |
    |---|---|---|

--- a/docs/inference/about.mdx
+++ b/docs/inference/about.mdx
@@ -18,7 +18,7 @@ The following table summarizes how OpenShell handles inference traffic.
 
 ## How `inference.local` Works
 
-When code inside a sandbox calls `https://inference.local`, the privacy router routes the request to the configured backend for that gateway. The configured model is applied to generation requests, provider credentials are supplied by OpenShell rather than by code inside the sandbox, and only approved inference headers are forwarded upstream. The router also tolerates long idle gaps between streamed chunks, so responses from reasoning models are not truncated during extended thinking pauses.
+When code inside a sandbox calls `https://inference.local`, the privacy router routes the request to the configured backend for that gateway. The configured model is applied to generation requests, provider credentials are supplied by OpenShell rather than by code inside the sandbox, and only approved inference headers are forwarded upstream.
 
 If code calls an external inference host directly, that traffic is evaluated only by `network_policies`.
 

--- a/docs/inference/about.mdx
+++ b/docs/inference/about.mdx
@@ -18,16 +18,17 @@ The following table summarizes how OpenShell handles inference traffic.
 
 ## How `inference.local` Works
 
-When code inside a sandbox calls `https://inference.local`, the privacy router routes the request to the configured backend for that gateway. The configured model is applied to generation requests, provider credentials are supplied by OpenShell rather than by code inside the sandbox, and only approved inference headers are forwarded upstream.
+When code inside a sandbox calls `https://inference.local`, the privacy router routes the request to the configured backend for that gateway. The configured model is applied to generation requests, provider credentials are supplied by OpenShell rather than by code inside the sandbox, and only approved inference headers are forwarded upstream. The router also tolerates long idle gaps between streamed chunks, so responses from reasoning models are not truncated during extended thinking pauses.
 
 If code calls an external inference host directly, that traffic is evaluated only by `network_policies`.
 
 | Property | Detail |
 |---|---|
-| Credentials | No sandbox API keys needed. Credentials come from the configured provider record. |
-| Header forwarding | `inference.local` forwards only approved inference headers. It strips caller auth and other unexpected headers before sending the request upstream. |
+| Credentials | No sandbox API keys needed. Credentials come from the configured provider record. The router strips caller-supplied `Authorization` before forwarding the request. |
+| Header forwarding | `inference.local` forwards only a per-provider header allowlist. OpenAI routes allow `openai-organization` and `x-model-id`. Anthropic routes allow `anthropic-version` and `anthropic-beta`. NVIDIA routes allow `x-model-id`. All other caller headers are stripped. |
 | Configuration | One provider and one model define sandbox inference for the active gateway. Every sandbox on that gateway sees the same `inference.local` backend. |
 | Provider support | NVIDIA, any OpenAI-compatible provider, and Anthropic all work through the same endpoint. |
+| Streaming reliability | The router tolerates idle gaps of up to 120 seconds between streamed chunks so long reasoning responses are not cut off mid-stream. |
 | Hot-refresh | OpenShell picks up provider credential changes and inference updates without recreating sandboxes. Changes propagate within about 5 seconds by default. |
 
 ## Supported API Patterns

--- a/docs/inference/configure.mdx
+++ b/docs/inference/configure.mdx
@@ -103,7 +103,7 @@ openshell inference set \
     --timeout 300
 ```
 
-The value is in seconds. When `--timeout` is omitted (or set to `0`), the default of 60 seconds applies.
+The value is in seconds. When `--timeout` is omitted (or set to `0`), the default of 60 seconds applies. Increase `--timeout` when you expect extended thinking phases so the full response completes before the request deadline.
 
 ## Verify the Active Config
 
@@ -154,7 +154,7 @@ response = client.chat.completions.create(
 )
 ```
 
-The client-supplied `model` and `api_key` values are not sent upstream. The privacy router injects the real credentials from the configured provider and rewrites the model before forwarding.
+The client-supplied `model` and `api_key` values are not sent upstream. The privacy router injects the real credentials from the configured provider and rewrites the model before forwarding. Caller-supplied `Authorization` and other non-allowlisted headers are stripped; only a per-provider header allowlist reaches the upstream endpoint. For the exact allowlist, refer to [About Inference Routing](/inference/about).
 
 Some SDKs require a non-empty API key even though `inference.local` does not use the sandbox-provided value. In those cases, pass any placeholder such as `test` or `unused`.
 

--- a/docs/observability/logging.mdx
+++ b/docs/observability/logging.mdx
@@ -124,6 +124,12 @@ A connection denied because the destination resolves to an always-blocked addres
 OCSF NET:OPEN [MED] DENIED /usr/bin/curl(1618) -> 169.254.169.254:80 [policy:- engine:ssrf] [reason:resolves to always-blocked address]
 ```
 
+An HTTP request to a non-default port. HTTP log URLs include the port whenever it differs from the scheme default (80 for `http`, 443 for `https`):
+
+```text
+OCSF HTTP:GET [INFO] ALLOWED GET http://api.internal.corp:8080/v1/status [policy:internal_api engine:opa]
+```
+
 Proxy and SSH servers ready:
 
 ```text
@@ -149,6 +155,67 @@ A policy reload after a settings change:
 OCSF CONFIG:DETECTED [INFO] Settings poll: config change detected [old_revision:2915564174587774909 new_revision:11008534403127604466 policy_changed:true]
 OCSF CONFIG:LOADED [INFO] Policy reloaded successfully [policy_hash:0cc0c2b525573c07]
 ```
+
+## Denial Reasons
+
+Denied `NET:` and `HTTP:` events carry a `[reason:...]` suffix that surfaces the decision detail from the event's `status_detail` field. The reason helps distinguish between policy misses, SSRF hardening, and L7 enforcement without inspecting the full OCSF JSONL record.
+
+Common reason phrases emitted by the sandbox include:
+
+| Reason | Meaning |
+|---|---|
+| `no matching policy` | OPA evaluated the request and no allow rule matched. |
+| `resolves to always-blocked address` | The destination resolved to loopback, link-local, or unspecified. These ranges are always blocked, even when listed in `allowed_ips`. |
+| `resolves to <ip> which is not in allowed_ips, connection rejected` | The destination resolved to an IP outside the policy's `allowed_ips` allowlist. |
+| `DNS resolution failed for <host>:<port>` | The proxy could not resolve the destination. |
+| `port <n> is a blocked control-plane port, connection rejected` | The destination port matches a control-plane port (etcd, Kubernetes API, kubelet) and is always blocked. |
+| `l7 deny` | An L7 policy rule denied the request. |
+
+Policy authors can use `allowed_ips` entries that are invalid or that overlap always-blocked ranges; those entries are rejected at policy-load time so denials at runtime report the underlying phrase rather than a generic failure.
+
+## Proxy Error Responses
+
+When the HTTP CONNECT proxy denies a request or cannot reach the upstream, it returns an HTTP error response with a JSON body. Clients can parse the body to surface actionable failure details instead of treating the status code alone.
+
+A denied CONNECT returns `403 Forbidden`:
+
+```json
+{
+  "error": "policy_denied",
+  "detail": "CONNECT api.example.com:443 not permitted by policy"
+}
+```
+
+An upstream that the proxy cannot reach returns `502 Bad Gateway`:
+
+```json
+{
+  "error": "upstream_unreachable",
+  "detail": "connection to api.example.com:443 failed"
+}
+```
+
+The `error` field is a short machine-readable code (`policy_denied`, `ssrf_denied`, `upstream_unreachable`). The `detail` field is a human-readable explanation suitable for display in an agent transcript.
+
+## Filesystem Sandbox Logs
+
+Landlock filesystem restrictions emit `CONFIG:` events at startup and whenever the sandbox has to skip a requested path.
+
+On startup, the probe reports the kernel's supported Landlock ABI version alongside the requested path counts:
+
+```text
+OCSF CONFIG:ENABLED [INFO] Landlock filesystem sandbox available [abi:v2 compat:BestEffort ro:4 rw:2]
+OCSF CONFIG:ENABLED [INFO] Applying Landlock filesystem sandbox [abi:V2 compat:BestEffort ro:4 rw:2]
+OCSF CONFIG:ENABLED [INFO] Landlock ruleset built [rules_applied:5 skipped:1]
+```
+
+When `landlock.compatibility` is `best_effort` and a requested path fails to open for reasons other than `NotFound` (for example, permission denied or a symlink loop), the sandbox continues without that path and emits a `[MED]` event so the degradation is not silent:
+
+```text
+OCSF CONFIG:OTHER [MED] Skipping inaccessible Landlock path (best-effort) [path:/opt/data error:Permission denied (os error 13)]
+```
+
+Set `landlock.compatibility` to `hard_requirement` in the policy to make these failures fatal instead of degraded.
 
 ## Log File Location
 

--- a/docs/observability/logging.mdx
+++ b/docs/observability/logging.mdx
@@ -171,7 +171,7 @@ Common reason phrases emitted by the sandbox include:
 | `port <n> is a blocked control-plane port, connection rejected` | The destination port matches a control-plane port (etcd, Kubernetes API, kubelet) and is always blocked. |
 | `l7 deny` | An L7 policy rule denied the request. |
 
-Policy authors can use `allowed_ips` entries that are invalid or that overlap always-blocked ranges; those entries are rejected at policy-load time so denials at runtime report the underlying phrase rather than a generic failure.
+Invalid `allowed_ips` entries and entries that overlap always-blocked ranges are rejected at policy-load time, so they never reach the runtime denial path. The phrases above come from the proxy's per-CONNECT `allowed_ips` and SSRF checks, not from policy validation.
 
 ## Proxy Error Responses
 

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -70,6 +70,38 @@ When `--editor` is used, OpenShell keeps the sandbox alive and installs an
 OpenShell-managed SSH include file instead of cluttering your main
 `~/.ssh/config` with generated host blocks.
 
+## Execute a Command in a Sandbox
+
+Run a one-shot command inside a running sandbox without opening an interactive shell:
+
+```shell
+openshell sandbox exec -n my-sandbox -- ls -la /workspace
+```
+
+Pipe stdin into the command:
+
+```shell
+echo "hello" | openshell sandbox exec -n my-sandbox -- cat
+```
+
+The command's exit code is propagated to the CLI, so `exec` works in scripts that check return codes.
+
+Run an interactive shell with a TTY:
+
+```shell
+openshell sandbox exec -n my-sandbox --tty -- /bin/bash
+```
+
+OpenShell allocates a TTY automatically when both stdin and stdout are terminals. Force the behavior with `--tty` or disable it with `--no-tty`.
+
+| Flag | Purpose |
+|---|---|
+| `-n`, `--name` | Sandbox to target. |
+| `--workdir` | Working directory for the command inside the sandbox. |
+| `--timeout` | Command timeout in seconds. `0` disables the timeout. |
+| `--tty` | Force TTY allocation. |
+| `--no-tty` | Disable TTY allocation even when attached to a terminal. |
+
 ## Monitor and Debug
 
 List all sandboxes:

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -145,12 +145,14 @@ Paths listed in `read_only` receive read-only access.
 Paths listed in `read_write` receive full access.
 All other paths are inaccessible.
 
+Landlock setup runs in two phases. The parent supervisor probes the kernel ABI and opens the configured path file descriptors before forking. The child then applies the ruleset with `restrict_self()` after privilege drop. At startup, OpenShell emits the selected ABI version and the applied read-only and read-write rule counts so you can confirm what the kernel accepted.
+
 | Aspect | Detail |
 |---|---|
-| Default | `compatibility: best_effort`. Uses the highest kernel ABI available. The system skips missing paths with a warning. If the kernel does not support Landlock, the sandbox continues without filesystem restrictions. |
+| Default | `compatibility: best_effort`. Uses the highest kernel ABI available. Missing paths are skipped. If the kernel does not support Landlock or any configured path cannot be opened, the sandbox continues without those restrictions and emits a High-severity OCSF `DetectionFinding`. |
 | What you can change | Set `compatibility: hard_requirement` to abort sandbox startup if Landlock is unavailable or any configured path cannot be opened. |
 | Risk if relaxed | On kernels without Landlock (pre-5.13), or when all paths fail to open, the sandbox runs without kernel-level filesystem restrictions. The agent can access any file the process user can access. |
-| Recommendation | Use `best_effort` for development. Use `hard_requirement` in environments where any gap in filesystem isolation is unacceptable. Run on Ubuntu 22.04+ or any kernel 5.13+ for Landlock support. |
+| Recommendation | Use `best_effort` for development. Use `hard_requirement` in environments where any gap in filesystem isolation is unacceptable. Treat High-severity Landlock findings as a signal to investigate the host kernel or the image. Run on Ubuntu 22.04+ or any kernel 5.13+ for Landlock support. |
 
 ### Read-Only vs Read-Write Paths
 
@@ -192,13 +194,15 @@ The sandbox process runs as a non-root user after explicit privilege dropping.
 
 ### Seccomp Filters
 
-A BPF seccomp filter restricts which socket domains the sandbox process can use.
+A BPF seccomp filter restricts which socket domains the sandbox process can use and blocks a denylist of syscalls that enable container escape, privilege escalation, or host observation. The sandbox sets `PR_SET_NO_NEW_PRIVS` before applying the filter.
 
 | Aspect | Detail |
 |---|---|
-| Default | The filter allows `AF_INET` and `AF_INET6` (for proxy communication) and blocks `AF_NETLINK`, `AF_PACKET`, `AF_BLUETOOTH`, and `AF_VSOCK` with `EPERM`. The sandbox sets `PR_SET_NO_NEW_PRIVS` before applying the filter. |
+| Socket domains | The filter allows `AF_INET` and `AF_INET6` (for proxy communication) and blocks `AF_NETLINK`, `AF_PACKET`, `AF_BLUETOOTH`, and `AF_VSOCK` with `EPERM`. |
+| Unconditional syscall blocks | `memfd_create`, `ptrace`, `bpf`, `process_vm_readv`, `process_vm_writev`, `pidfd_open`, `pidfd_getfd`, `pidfd_send_signal`, `io_uring_setup`, `mount`, `fsopen`, `fsconfig`, `fsmount`, `fspick`, `move_mount`, `open_tree`, `setns`, `umount2`, `pivot_root`, `userfaultfd`, `perf_event_open`. |
+| Conditional syscall blocks | `execveat` with `AT_EMPTY_PATH`, `unshare` and `clone` with `CLONE_NEWUSER`, and `seccomp(SECCOMP_SET_MODE_FILTER)` are denied with `EPERM`. |
 | What you can change | This is not a user-facing knob. OpenShell enforces it automatically. |
-| Risk if relaxed | `AF_NETLINK` allows manipulation of routing tables and firewall rules. `AF_PACKET` enables raw packet capture. `AF_VSOCK` enables VM socket communication. |
+| Risk if relaxed | The blocked syscalls support container escape (`mount`, `pivot_root`, `move_mount`, namespace creation), cross-process observation (`ptrace`, `process_vm_readv`, `pidfd_*`), raw kernel bypass (`bpf`, `io_uring_setup`, `perf_event_open`), and filter evasion (`seccomp`, `userfaultfd`). |
 | Recommendation | No action needed. OpenShell enforces this automatically. |
 
 ### Enforcement Application Order
@@ -224,6 +228,7 @@ The agent never receives the provider API key.
 | Aspect | Detail |
 |---|---|
 | Default | Always active. The proxy handles `inference.local` before OPA policy evaluation. The gateway injects credentials on the host side. |
+| Keep-alive isolation | If a sandbox reuses a keep-alive connection that previously carried a routed inference request for a subsequent non-inference request, the proxy denies the non-inference request with `connection not allowed by policy` and closes the connection. This prevents agents from reusing an inference-authorized connection for other destinations. |
 | What you can change | Configure inference routes with `openshell inference set`. |
 | Risk if bypassed | If an inference provider's host is added directly to `network_policies`, the agent could reach it with a stolen or hardcoded key, bypassing credential isolation. |
 | Recommendation | Do not add inference provider hosts to `network_policies`. Use OpenShell inference routing instead. |


### PR DESCRIPTION
## Summary

Catches up the published docs to the last ~4 weeks of user-facing changes across sandbox, inference routing, CLI, and observability. Scanned 87 commits since 2026-03-23, mapped user-facing commits to doc pages, and verified each edit against the code rather than commit messages alone.

## Related Issue

<!-- None; batched drift catch-up. -->

## Changes

- **`docs/about/architecture.mdx`**
  - System CA loading for upstream TLS alongside webpki-roots (#862, `3b21df1`).
  - `tls: skip` documented as the opt-out, deprecating `tls: terminate` / `tls: passthrough` (#544, `f37b69b`).
  - Gateway state persistence across `gateway stop` / `gateway start` (#739, `491c5d8`).
  - Persisted SSH handshake secret so sessions reconnect without re-auth (#488, `e837849`).
  - OCSF observability surface with link to the JSON export page (#720, `b7779bd`).
  - Follow-up trim: dropped implementation detail (CA bundle paths, deprecated-key migration note, SSH-secret internals), expanded Deny rule to include SSRF / blocked-port / L7 paths, added `inference` to Policy Engine constraint list, and expanded LLM / SSRF / L7 / TLS / CA / PEM / SSH / OCSF / JSONL on first use (`db243e5`).

- **`docs/inference/about.mdx`**
  - Per-provider header allowlist (#826, `25d2530`):
    - OpenAI: `openai-organization`, `x-model-id`.
    - Anthropic: `anthropic-version`, `anthropic-beta`.
    - NVIDIA: `x-model-id`.
  - Caller-supplied `Authorization` stripped before forwarding (#826, `25d2530`).
  - 120s streaming idle tolerance for reasoning-model pauses (#834, `355d845`).

- **`docs/inference/configure.mdx`**
  - Header-stripping cross-reference back to `/inference/about` (#826, `25d2530`).
  - Extended-thinking timeout guidance around the existing `--timeout` docs (#672, `36329a1`; #834, `355d845`).

- **`docs/sandboxes/manage-sandboxes.mdx`**
  - New "Execute a Command in a Sandbox" section for `openshell sandbox exec` (#752, `13262e1`):
    - Flag reference: `-n`, `--workdir`, `--timeout`, `--tty`, `--no-tty`.
    - TTY auto-detection when both stdin and stdout are terminals.
    - Exit-code propagation for use in scripts.

- **`docs/security/best-practices.mdx`**
  - Seccomp denylist expanded (#740, `8887d7c`):
    - Unconditional blocks: `mount`, `pivot_root`, `ptrace`, `bpf`, `pidfd_*`, `io_uring_setup`, `perf_event_open`, etc.
    - Conditional blocks: `execveat` with `AT_EMPTY_PATH`, `unshare` / `clone` with `CLONE_NEWUSER`, `seccomp(SECCOMP_SET_MODE_FILTER)`.
  - Core-dump hardening phrasing tightened (#821, `28db08e`).
  - Landlock two-phase probe and High-severity `landlock-unavailable` OCSF finding (#810, `29a3b1c`).
  - Inference keep-alive connection closure after a non-inference request (#819, `1cabd25`).

- **`docs/observability/logging.mdx`**
  - HTTP log URL port inclusion and proxy 403/502 JSON error body shape (#809, `09af1b6`).
  - `[reason:...]` denial suffix table with real reason phrases (#814, `2ca553a`).
  - Landlock `CONFIG:ENABLED` startup events (ABI, ro/rw counts) and `[MED]` `CONFIG:OTHER` per-path skip event (#599, `6828e14`).

## Testing

- [x] `mise run docs` passes (0 errors, 2 pre-existing warnings unrelated to these changes: upstream FDR 500 and a theme contrast-ratio check).
- [ ] `mise run pre-commit` — rust:lint fails locally on a `z3.h` not-found build-env issue unrelated to doc changes; CI will run the full check.
- [ ] Unit tests added/updated (N/A, docs only).
- [ ] E2E tests added/updated (N/A, docs only).

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) (`docs:`).
- [x] Commit signed off (DCO).
- [ ] Architecture docs updated (N/A beyond `docs/about/architecture.mdx`, which is included above).