### PR TITLE
fix(sandbox): harden seccomp, inference routing, and process limits

### DIFF
--- a/crates/openshell-sandbox/src/process.rs
+++ b/crates/openshell-sandbox/src/process.rs
@@ -49,6 +49,22 @@ pub(crate) fn harden_child_process() -> Result<()> {
         ));
     }
 
+    // Limit process creation to prevent fork bombs. 512 processes per UID is
+    // sufficient for typical agent workloads (shell, compilers, language servers)
+    // while preventing runaway forking. Set as a hard limit so the sandbox user
+    // cannot raise it after privilege drop.
+    let nproc_limit = libc::rlimit {
+        rlim_cur: 512,
+        rlim_max: 512,
+    };
+    let rc = unsafe { libc::setrlimit(libc::RLIMIT_NPROC, &nproc_limit) };
+    if rc != 0 {
+        return Err(miette::miette!(
+            "Failed to set RLIMIT_NPROC: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+
     #[cfg(target_os = "linux")]
     {
         let rc = unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0) };

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -27,6 +27,7 @@ use tracing::{debug, warn};
 
 const MAX_HEADER_BYTES: usize = 8192;
 const INFERENCE_LOCAL_HOST: &str = "inference.local";
+const INFERENCE_LOCAL_PORT: u16 = 443;
 
 /// Maximum total bytes for a streaming inference response body (32 MiB).
 const MAX_STREAMING_BODY: usize = 32 * 1024 * 1024;
@@ -354,7 +355,7 @@ async fn handle_tcp_connection(
     let (host, port) = parse_target(target)?;
     let host_lc = host.to_ascii_lowercase();
 
-    if host_lc == INFERENCE_LOCAL_HOST {
+    if host_lc == INFERENCE_LOCAL_HOST && port == INFERENCE_LOCAL_PORT {
         respond(&mut client, b"HTTP/1.1 200 Connection Established\r\n\r\n").await?;
         let outcome = handle_inference_interception(
             client,

--- a/crates/openshell-sandbox/src/sandbox/linux/seccomp.rs
+++ b/crates/openshell-sandbox/src/sandbox/linux/seccomp.rs
@@ -112,11 +112,11 @@ fn build_filter_rules(allow_inet: bool) -> Result<BTreeMap<i64, Vec<SeccompRule>
     let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
 
     // --- Socket domain blocks ---
-    let mut blocked_domains = vec![libc::AF_PACKET, libc::AF_BLUETOOTH, libc::AF_VSOCK];
+    let mut blocked_domains =
+        vec![libc::AF_PACKET, libc::AF_BLUETOOTH, libc::AF_VSOCK, libc::AF_NETLINK];
     if !allow_inet {
         blocked_domains.push(libc::AF_INET);
         blocked_domains.push(libc::AF_INET6);
-        blocked_domains.push(libc::AF_NETLINK);
     }
 
     for domain in blocked_domains {

--- a/crates/openshell-sandbox/src/sandbox/linux/seccomp.rs
+++ b/crates/openshell-sandbox/src/sandbox/linux/seccomp.rs
@@ -112,8 +112,12 @@ fn build_filter_rules(allow_inet: bool) -> Result<BTreeMap<i64, Vec<SeccompRule>
     let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
 
     // --- Socket domain blocks ---
-    let mut blocked_domains =
-        vec![libc::AF_PACKET, libc::AF_BLUETOOTH, libc::AF_VSOCK, libc::AF_NETLINK];
+    let mut blocked_domains = vec![
+        libc::AF_PACKET,
+        libc::AF_BLUETOOTH,
+        libc::AF_VSOCK,
+        libc::AF_NETLINK,
+    ];
     if !allow_inet {
         blocked_domains.push(libc::AF_INET);
         blocked_domains.push(libc::AF_INET6);


### PR DESCRIPTION
## Summary

Three defense-in-depth fixes for sandbox security controls, addressing findings from a 2026-04-16 security assessment. Each fix is a separate commit.

- **SEC-01 (OS-94):** Block AF_NETLINK in seccomp unconditionally — previously only blocked in `NetworkMode::Block`, now blocked in all modes alongside AF_PACKET/AF_BLUETOOTH/AF_VSOCK. Impact was informational (network namespace already scopes netlink to sandbox's own veth), but closes the gap.
- **SEC-02 (OS-95):** Scope `inference.local` pre-OPA interception to port 443 only — the hostname-only check at `proxy.rs:357` allowed any port to bypass OPA policy evaluation, including under deny-all. Non-443 ports now fall through to OPA.
- **SEC-03 (OS-96):** Enforce `RLIMIT_NPROC` (hard limit 512) in `harden_child_process()` — prevents fork bomb process exhaustion, most relevant for local dev mode where K8s pod cgroup `pids.max` is absent.

## Related Issues

Closes OS-93, OS-94, OS-95, OS-96

## Changes

- `crates/openshell-sandbox/src/sandbox/linux/seccomp.rs` — move AF_NETLINK to unconditional block list
- `crates/openshell-sandbox/src/proxy.rs` — add `INFERENCE_LOCAL_PORT` constant and port check to inference interception condition
- `crates/openshell-sandbox/src/process.rs` — add `RLIMIT_NPROC` hard limit of 512 before privilege drop

## Testing

- [x] `cargo check -p openshell-sandbox` — compiles clean (no new warnings)
- [ ] `mise run pre-commit` — lint and format
- [ ] `mise run test` — unit tests
- [ ] `mise run e2e` — end-to-end validation of deny-all + inference routing + fork limit