### PR TITLE
fix(cluster): declare openshell namespace via k3s auto-manifest

### DIFF
--- a/architecture/gateway-single-node.md
+++ b/architecture/gateway-single-node.md
@@ -242,7 +242,7 @@ Layers added:
 4. Kubernetes manifests: `deploy/kube/manifests/*.yaml` -> `/opt/openshell/manifests/`
 
 Bundled manifests include:
-
+- `openshell-namespace.yaml` (declares the `openshell` namespace so it exists as soon as the k3s API is ready, before Helm reconciliation — see [Manifest injection](#manifest-injection))
 - `openshell-helmchart.yaml` (OpenShell Helm chart auto-deploy)
 - `envoy-gateway-helmchart.yaml` (Envoy Gateway for Gateway API)
 - `agent-sandbox.yaml`
@@ -272,6 +272,8 @@ Writes `/etc/rancher/k3s/registries.yaml` from `REGISTRY_HOST`, `REGISTRY_ENDPOI
 ### Manifest injection
 
 Copies bundled manifests from `/opt/openshell/manifests/` to `/var/lib/rancher/k3s/server/manifests/`. This is needed because the volume mount on `/var/lib/rancher/k3s` overwrites any files baked into that path at image build time.
+
+`openshell-namespace.yaml` is a standalone `kind: Namespace` manifest that k3s applies as soon as its API server is ready — before the Helm controller reconciles `openshell-helmchart.yaml`. `reconcile_pki` in `crates/openshell-bootstrap` waits up to ~115s for the namespace before reading or writing PKI secrets; declaring it here decouples that wait from Helm controller latency on slow networks or cold boots. `createNamespace: true` on the HelmChart is retained as an idempotent fallback — Helm's `--create-namespace` coexists with pre-existing namespaces without error.
 
 ### Image configuration overrides
 

--- a/crates/openshell-bootstrap/src/lib.rs
+++ b/crates/openshell-bootstrap/src/lib.rs
@@ -1217,4 +1217,28 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn openshell_namespace_manifest_is_present_and_well_formed() {
+        // Guards `wait_for_namespace("openshell")` against silent regressions
+        // in the auto-applied manifest that k3s uses to create the namespace
+        // before Helm reconciles the openshell chart.
+        const MANIFEST: &str =
+            include_str!("../../../deploy/kube/manifests/openshell-namespace.yaml");
+        assert!(
+            MANIFEST.contains("apiVersion: v1"),
+            "manifest must target core/v1:
+{MANIFEST}"
+        );
+        assert!(
+            MANIFEST.contains("kind: Namespace"),
+            "manifest must declare kind: Namespace:
+{MANIFEST}"
+        );
+        assert!(
+            MANIFEST.contains("name: openshell"),
+            "manifest must name the openshell namespace:
+{MANIFEST}"
+        );
+    }
 }

--- a/crates/openshell-vm/scripts/build-rootfs.sh
+++ b/crates/openshell-vm/scripts/build-rootfs.sh
@@ -439,7 +439,7 @@ MANIFEST_DEST="${ROOTFS_DIR}/opt/openshell/manifests"
 echo "==> Injecting Kubernetes manifests..."
 mkdir -p "${MANIFEST_DEST}"
 
-for manifest in openshell-helmchart.yaml agent-sandbox.yaml; do
+for manifest in openshell-namespace.yaml openshell-helmchart.yaml agent-sandbox.yaml; do
     if [ -f "${MANIFEST_SRC}/${manifest}" ]; then
         cp "${MANIFEST_SRC}/${manifest}" "${MANIFEST_DEST}/"
         echo "    ${manifest}"

--- a/deploy/kube/manifests/openshell-namespace.yaml
+++ b/deploy/kube/manifests/openshell-namespace.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Explicit Namespace manifest for the OpenShell control plane.
+#
+# k3s auto-applies every YAML in /var/lib/rancher/k3s/server/manifests/ as
+# soon as its API server is ready, before the Helm controller reconciles
+# the HelmChart CR. Declaring the namespace here guarantees it exists
+# within seconds of cluster startup and decouples PKI bootstrap
+# (wait_for_namespace in openshell-bootstrap) from Helm controller
+# reconciliation latency — which on slow networks or cold boots can
+# exceed the 115-second wait budget.
+#
+# The companion openshell-helmchart.yaml retains `createNamespace: true`
+# as an idempotent fallback; pre-existing namespaces coexist with Helm's
+# --create-namespace flag without error.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshell

--- a/e2e/rust/tests/namespace_bootstrap.rs
+++ b/e2e/rust/tests/namespace_bootstrap.rs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "e2e")]
+
+//! Regression test for the openshell namespace auto-create.
+//!
+//! `reconcile_pki` waits up to ~115s for `namespace/openshell` before the
+//! PKI phase can read or write secrets. The namespace is declared by a
+//! standalone manifest at `deploy/kube/manifests/openshell-namespace.yaml`
+//! that k3s auto-applies before the Helm controller reconciles the
+//! openshell chart — without it, slow networks or cold boots race the
+//! Helm controller and `wait_for_namespace` times out.
+//!
+//! This test runs against a healthy gateway and asserts the namespace is
+//! present in the cluster. Closes NVIDIA/NemoClaw#1974.
+
+use std::process::{Command, Stdio};
+
+use openshell_e2e::harness::output::strip_ansi;
+
+/// Resolve the gateway name from `OPENSHELL_GATEWAY`, falling back to the
+/// CI default of `"openshell"` — same convention as `gateway_resume`.
+fn gateway_name() -> String {
+    std::env::var("OPENSHELL_GATEWAY").unwrap_or_else(|_| "openshell".to_string())
+}
+
+/// Docker container name for the e2e gateway.
+fn container_name() -> String {
+    format!("openshell-cluster-{}", gateway_name())
+}
+
+/// Run `kubectl` against the gateway's embedded k3s cluster via
+/// `docker exec` and return (stdout, stderr, exit-code).
+fn kubectl_in_cluster(args: &str) -> (String, String, i32) {
+    let cname = container_name();
+    let output = Command::new("docker")
+        .args([
+            "exec",
+            &cname,
+            "sh",
+            "-c",
+            &format!("KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl {args}"),
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn docker exec kubectl");
+
+    (
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+#[tokio::test]
+async fn openshell_namespace_exists_after_cluster_start() {
+    let (stdout, stderr, code) = kubectl_in_cluster("get namespace openshell -o name");
+    assert_eq!(
+        code, 0,
+        "`kubectl get namespace openshell` must succeed after gateway start. \
+         stdout=<{}> stderr=<{}>",
+        strip_ansi(&stdout),
+        strip_ansi(&stderr),
+    );
+    assert_eq!(
+        stdout.trim(),
+        "namespace/openshell",
+        "unexpected kubectl output: <{}>",
+        strip_ansi(&stdout),
+    );
+}
+
+#[tokio::test]
+async fn openshell_namespace_is_active() {
+    // A Namespace can exist in the `Terminating` phase during cluster
+    // tear-down — assert we see the healthy `Active` phase, not just
+    // bare existence. This also rejects an empty-phase response that a
+    // transient API error could produce.
+    let (stdout, stderr, code) =
+        kubectl_in_cluster("get namespace openshell -o jsonpath={.status.phase}");
+    assert_eq!(
+        code, 0,
+        "jsonpath query for openshell namespace phase must succeed. \
+         stdout=<{}> stderr=<{}>",
+        strip_ansi(&stdout),
+        strip_ansi(&stderr),
+    );
+    assert_eq!(
+        stdout.trim(),
+        "Active",
+        "openshell namespace must be in Active phase, got: <{}>",
+        strip_ansi(&stdout),
+    );
+}


### PR DESCRIPTION
## Summary

`reconcile_pki` calls `wait_for_namespace("openshell")` with a ~115 s budget before the PKI phase can read or write secrets. Today the namespace is created only by the k3s Helm controller reconciling `openshell-helmchart.yaml` with `createNamespace: true`. On slow networks, cold boots, or stalled chart downloads the Helm controller can exceed that budget, causing the gateway to fail with:

```
Error: × K8s namespace not ready
╰─▶ timed out waiting for namespace 'openshell' to exist: Error from server
    (NotFound): namespaces "openshell" not found
```

Declaring the namespace as a standalone auto-applied manifest makes k3s create it within seconds of the API server becoming ready — decoupled from Helm controller latency.

## Related Issue

Closes NVIDIA/NemoClaw#1974

## Changes

- Add [`deploy/kube/manifests/openshell-namespace.yaml`](https://github.com/NVIDIA/OpenShell/blob/fix/k8s-namespace-race-1974/deploy/kube/manifests/openshell-namespace.yaml) — a minimal `kind: Namespace` manifest with SPDX header. k3s auto-applies everything in `/var/lib/rancher/k3s/server/manifests/` on startup, before Helm reconciliation.
- Update [`crates/openshell-vm/scripts/build-rootfs.sh`](https://github.com/NVIDIA/OpenShell/blob/fix/k8s-namespace-race-1974/crates/openshell-vm/scripts/build-rootfs.sh#L357) to include the new file in its explicit manifest copy list. The docker path in `cluster-entrypoint.sh` uses a `*.yaml` glob and picks it up automatically.
- Unit test in [`crates/openshell-bootstrap/src/lib.rs`](https://github.com/NVIDIA/OpenShell/blob/fix/k8s-namespace-race-1974/crates/openshell-bootstrap/src/lib.rs) — compile-time embeds the manifest via `include_str!` and asserts `apiVersion`, `kind`, and `metadata.name`. Fails the build if the file is deleted/renamed; fails the test if any of the three fields `wait_for_namespace` depends on drift.
- E2E test [`e2e/rust/tests/namespace_bootstrap.rs`](https://github.com/NVIDIA/OpenShell/blob/fix/k8s-namespace-race-1974/e2e/rust/tests/namespace_bootstrap.rs) — against a healthy gateway, asserts `kubectl get namespace openshell` returns `namespace/openshell` and that `status.phase == Active`. The phase check rejects a `Terminating` namespace from a tear-down or an empty response from a transient API error.
- [`architecture/gateway-single-node.md`](https://github.com/NVIDIA/OpenShell/blob/fix/k8s-namespace-race-1974/architecture/gateway-single-node.md) — lists the new manifest in the bundled-manifests section and explains why it exists independently of the HelmChart CR.
- `createNamespace: true` on the HelmChart is retained as an idempotent fallback — Helm's `--create-namespace` coexists with pre-existing namespaces without error.

## Testing

- [x] `cargo test -p openshell-bootstrap --lib` — 109 passed / 0 failed, including the new `openshell_namespace_manifest_is_present_and_well_formed`
- [x] `cargo check --tests --features e2e` (in `e2e/rust/`) — new e2e suite compiles cleanly
- [x] **Live e2e against `rancher/k3s:v1.29.8-k3s1`** — dropped the new manifest into `/var/lib/rancher/k3s/server/manifests/` on a running k3s container. k3s applied it within 6 ms (`ApplyingManifest` → `AppliedManifest` per the addon controller events), and `kubectl get namespace openshell -o name` returned `namespace/openshell` with `status.phase == Active`. This mirrors exactly what `cluster-entrypoint.sh`'s `cp "$manifest" "$K3S_MANIFESTS/"` step does, using a stock k3s image.
- [x] `mise run license:check` — SPDX headers present on all new files
- [x] `mise run helm:lint` — no regression on the openshell chart
- [x] `mise run docs` — architecture + Fern docs validate
- [x] `bash -n crates/openshell-vm/scripts/build-rootfs.sh` — syntax OK
- [x] YAML parses and matches `apiVersion: v1` / `kind: Namespace` / `metadata.name: openshell`

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated ([`gateway-single-node.md`](https://github.com/NVIDIA/OpenShell/blob/fix/k8s-namespace-race-1974/architecture/gateway-single-node.md))