### PR TITLE
docs(contributing): add bash shell setup example for mise

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,9 @@ After installing `mise`, activate it with `mise activate` or [add it to your she
 Shell setup examples:
 
 ```bash
+# Bash
+echo 'eval "$(~/.local/bin/mise activate bash)"' >> ~/.bashrc
+
 # Fish
 echo '~/.local/bin/mise activate fish | source' >> ~/.config/fish/config.fish
 


### PR DESCRIPTION
## Summary
  Adds the missing Bash shell setup example for mise activate in the CONTRIBUTING guide. Fish and Zsh were already documented but Bash was not.

## Related Issue
None, minor docs fix

## Changes
  Adds the missing Bash shell setup example for mise activate in the CONTRIBUTING guide. Fish and Zsh were already documented but Bash was not.

## Testing
mise setup correctly in a bash environment

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
