### PR TITLE
fix(cli): sandbox get returns currently active runtime policy

### DIFF
--- a/.agents/skills/openshell-cli/cli-reference.md
+++ b/.agents/skills/openshell-cli/cli-reference.md
@@ -183,6 +183,10 @@ Create a sandbox, wait for readiness, then connect or execute the trailing comma
 
 Show sandbox details (id, name, namespace, phase, policy).
 
+| Flag | Description |
+|------|-------------|
+| `--policy-only` | Print only the active policy YAML to stdout (effective sandbox or global policy via the gateway; use for scripts and piping) |
+
 ### `openshell sandbox list`
 
 List sandboxes in a table.

--- a/.agents/skills/openshell-cli/cli-reference.md
+++ b/.agents/skills/openshell-cli/cli-reference.md
@@ -181,11 +181,11 @@ Create a sandbox, wait for readiness, then connect or execute the trailing comma
 
 ### `openshell sandbox get <name>`
 
-Show sandbox details (id, name, namespace, phase, policy).
+Show sandbox details (id, name, namespace, phase) and the **active** policy from the gateway (same source whether policy is sandbox-scoped or global). Metadata includes **Policy source** (`sandbox` or `global`) and **Revision** (global policy row when source is global, otherwise sandbox policy row).
 
 | Flag | Description |
 |------|-------------|
-| `--policy-only` | Print only the active policy YAML to stdout (effective sandbox or global policy via the gateway; use for scripts and piping) |
+| `--policy-only` | Print only the active policy YAML to stdout (same policy as above; use for scripts and piping) |
 
 ### `openshell sandbox list`
 

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -1208,6 +1208,10 @@ enum SandboxCommands {
         /// Sandbox name (defaults to last-used sandbox).
         #[arg(add = ArgValueCompleter::new(completers::complete_sandbox_names))]
         name: Option<String>,
+
+        /// Print only the active policy YAML (effective sandbox or global policy).
+        #[arg(long)]
+        policy_only: bool,
     },
 
     /// List sandboxes.
@@ -2461,9 +2465,12 @@ async fn main() -> Result<()> {
                         | SandboxCommands::Download { .. } => {
                             unreachable!()
                         }
-                        SandboxCommands::Get { name } => {
+                        SandboxCommands::Get {
+                            name,
+                            policy_only,
+                        } => {
                             let name = resolve_sandbox_name(name, &ctx.name)?;
-                            run::sandbox_get(endpoint, &name, &tls).await?;
+                            run::sandbox_get(endpoint, &name, policy_only, &tls).await?;
                         }
                         SandboxCommands::List {
                             limit,

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -2465,10 +2465,7 @@ async fn main() -> Result<()> {
                         | SandboxCommands::Download { .. } => {
                             unreachable!()
                         }
-                        SandboxCommands::Get {
-                            name,
-                            policy_only,
-                        } => {
+                        SandboxCommands::Get { name, policy_only } => {
                             let name = resolve_sandbox_name(name, &ctx.name)?;
                             run::sandbox_get(endpoint, &name, policy_only, &tls).await?;
                         }

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -1209,7 +1209,7 @@ enum SandboxCommands {
         #[arg(add = ArgValueCompleter::new(completers::complete_sandbox_names))]
         name: Option<String>,
 
-        /// Print only the active policy YAML (effective sandbox or global policy).
+        /// Print only the active policy YAML (same policy as the default view; stdout only).
         #[arg(long)]
         policy_only: bool,
     },

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -2734,7 +2734,16 @@ pub async fn sandbox_sync_command(
 }
 
 /// Fetch a sandbox by name.
-pub async fn sandbox_get(server: &str, name: &str, tls: &TlsOptions) -> Result<()> {
+///
+/// With `policy_only`, prints only the active policy YAML from [`GetSandboxConfig`]
+/// (effective policy whether it is sandbox-scoped or global). Otherwise prints
+/// sandbox metadata and the creation-time `spec.policy` when present.
+pub async fn sandbox_get(
+    server: &str,
+    name: &str,
+    policy_only: bool,
+    tls: &TlsOptions,
+) -> Result<()> {
     let mut client = grpc_client(server, tls).await?;
 
     let response = client
@@ -2747,6 +2756,26 @@ pub async fn sandbox_get(server: &str, name: &str, tls: &TlsOptions) -> Result<(
         .into_inner()
         .sandbox
         .ok_or_else(|| miette::miette!("sandbox missing from response"))?;
+
+    if policy_only {
+        let config = client
+            .get_sandbox_config(GetSandboxConfigRequest {
+                sandbox_id: sandbox.id.clone(),
+            })
+            .await
+            .into_diagnostic()?
+            .into_inner();
+
+        let Some(ref policy) = config.policy else {
+            return Err(miette::miette!(
+                "no active policy configured for this sandbox"
+            ));
+        };
+        let yaml_str = openshell_policy::serialize_sandbox_policy(policy)
+            .wrap_err("failed to serialize policy to YAML")?;
+        print!("{yaml_str}");
+        return Ok(());
+    }
 
     println!("{}", "Sandbox:".cyan().bold());
     println!();

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -2788,7 +2788,11 @@ pub async fn sandbox_get(
     println!(
         "  {} {}",
         "Policy source:".dimmed(),
-        if policy_from_global { "global" } else { "sandbox" }
+        if policy_from_global {
+            "global"
+        } else {
+            "sandbox"
+        }
     );
     let revision = if policy_from_global {
         if config.global_policy_version > 0 {

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -2735,9 +2735,9 @@ pub async fn sandbox_sync_command(
 
 /// Fetch a sandbox by name.
 ///
-/// With `policy_only`, prints only the active policy YAML from [`GetSandboxConfig`]
-/// (effective policy whether it is sandbox-scoped or global). Otherwise prints
-/// sandbox metadata and the creation-time `spec.policy` when present.
+/// Policy always comes from [`GetSandboxConfig`] (effective active policy, sandbox
+/// or global). With `policy_only`, prints only that YAML to stdout; otherwise
+/// prints sandbox metadata and the same policy with formatted YAML.
 pub async fn sandbox_get(
     server: &str,
     name: &str,
@@ -2757,15 +2757,15 @@ pub async fn sandbox_get(
         .sandbox
         .ok_or_else(|| miette::miette!("sandbox missing from response"))?;
 
-    if policy_only {
-        let config = client
-            .get_sandbox_config(GetSandboxConfigRequest {
-                sandbox_id: sandbox.id.clone(),
-            })
-            .await
-            .into_diagnostic()?
-            .into_inner();
+    let config = client
+        .get_sandbox_config(GetSandboxConfigRequest {
+            sandbox_id: sandbox.id.clone(),
+        })
+        .await
+        .into_diagnostic()?
+        .into_inner();
 
+    if policy_only {
         let Some(ref policy) = config.policy else {
             return Err(miette::miette!(
                 "no active policy configured for this sandbox"
@@ -2784,9 +2784,30 @@ pub async fn sandbox_get(
     println!("  {} {}", "Namespace:".dimmed(), sandbox.namespace);
     println!("  {} {}", "Phase:".dimmed(), phase_name(sandbox.phase));
 
-    if let Some(spec) = &sandbox.spec
-        && let Some(policy) = &spec.policy
-    {
+    let policy_from_global = config.policy_source == PolicySource::Global as i32;
+    println!(
+        "  {} {}",
+        "Policy source:".dimmed(),
+        if policy_from_global { "global" } else { "sandbox" }
+    );
+    let revision = if policy_from_global {
+        if config.global_policy_version > 0 {
+            Some(config.global_policy_version)
+        } else if config.version > 0 {
+            Some(config.version)
+        } else {
+            None
+        }
+    } else if config.version > 0 {
+        Some(config.version)
+    } else {
+        None
+    };
+    if let Some(rev) = revision {
+        println!("  {} {}", "Revision:".dimmed(), rev);
+    }
+
+    if let Some(ref policy) = config.policy {
         println!();
         print_sandbox_policy(policy);
     }

--- a/crates/openshell-cli/tests/sandbox_name_fallback_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_name_fallback_integration.rs
@@ -12,7 +12,8 @@ use openshell_core::proto::{
     GetProviderRequest, GetSandboxConfigRequest, GetSandboxConfigResponse,
     GetSandboxProviderEnvironmentRequest, GetSandboxProviderEnvironmentResponse, GetSandboxRequest,
     HealthRequest, HealthResponse, ListProvidersRequest, ListProvidersResponse,
-    ListSandboxesRequest, ListSandboxesResponse, ProviderResponse, Sandbox, SandboxResponse,
+    ListSandboxesRequest, ListSandboxesResponse, ProviderResponse, Sandbox, SandboxPolicy,
+    SandboxResponse,
     SandboxStreamEvent, ServiceStatus, UpdateProviderRequest, WatchSandboxRequest,
 };
 use rcgen::{
@@ -134,9 +135,20 @@ impl OpenShell for TestOpenShell {
 
     async fn get_sandbox_config(
         &self,
-        _request: tonic::Request<GetSandboxConfigRequest>,
+        request: tonic::Request<GetSandboxConfigRequest>,
     ) -> Result<Response<GetSandboxConfigResponse>, Status> {
-        Ok(Response::new(GetSandboxConfigResponse::default()))
+        let req = request.into_inner();
+        assert_eq!(
+            req.sandbox_id, "test-id",
+            "sandbox_get --policy-only should pass the id from GetSandbox"
+        );
+        Ok(Response::new(GetSandboxConfigResponse {
+            policy: Some(SandboxPolicy {
+                version: 1,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
     }
 
     async fn get_gateway_config(
@@ -432,7 +444,7 @@ async fn run_server() -> TestServer {
 async fn sandbox_get_sends_correct_name() {
     let ts = run_server().await;
 
-    run::sandbox_get(&ts.endpoint, "my-sandbox", &ts.tls)
+    run::sandbox_get(&ts.endpoint, "my-sandbox", false, &ts.tls)
         .await
         .expect("sandbox_get should succeed");
 
@@ -442,6 +454,19 @@ async fn sandbox_get_sends_correct_name() {
         Some("my-sandbox"),
         "mock should have recorded the requested sandbox name"
     );
+}
+
+/// `sandbox_get` with `policy_only` calls `GetSandboxConfig` and prints YAML from the response.
+#[tokio::test]
+async fn sandbox_get_policy_only_round_trip() {
+    let ts = run_server().await;
+
+    run::sandbox_get(&ts.endpoint, "my-sandbox", true, &ts.tls)
+        .await
+        .expect("sandbox_get with policy_only should succeed");
+
+    let recorded = ts.openshell.state.last_get_name.lock().await.clone();
+    assert_eq!(recorded.as_deref(), Some("my-sandbox"));
 }
 
 /// End-to-end: save a last-used sandbox, load it back, then call `sandbox_get`
@@ -462,7 +487,7 @@ async fn sandbox_get_with_persisted_last_sandbox() {
     assert_eq!(resolved, "persisted-sb");
 
     // Call sandbox_get with the resolved name.
-    run::sandbox_get(&ts.endpoint, &resolved, &ts.tls)
+    run::sandbox_get(&ts.endpoint, &resolved, false, &ts.tls)
         .await
         .expect("sandbox_get should succeed");
 
@@ -484,7 +509,7 @@ async fn explicit_name_takes_precedence_over_persisted() {
     // Persist one name, but supply a different one explicitly.
     save_last_sandbox("my-cluster", "old-sandbox").expect("save should succeed");
 
-    run::sandbox_get(&ts.endpoint, "explicit-sandbox", &ts.tls)
+    run::sandbox_get(&ts.endpoint, "explicit-sandbox", false, &ts.tls)
         .await
         .expect("sandbox_get should succeed");
 

--- a/crates/openshell-cli/tests/sandbox_name_fallback_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_name_fallback_integration.rs
@@ -13,8 +13,7 @@ use openshell_core::proto::{
     GetSandboxProviderEnvironmentRequest, GetSandboxProviderEnvironmentResponse, GetSandboxRequest,
     HealthRequest, HealthResponse, ListProvidersRequest, ListProvidersResponse,
     ListSandboxesRequest, ListSandboxesResponse, ProviderResponse, Sandbox, SandboxPolicy,
-    SandboxResponse,
-    SandboxStreamEvent, ServiceStatus, UpdateProviderRequest, WatchSandboxRequest,
+    SandboxResponse, SandboxStreamEvent, ServiceStatus, UpdateProviderRequest, WatchSandboxRequest,
 };
 use rcgen::{
     BasicConstraints, Certificate, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyPair,

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -110,13 +110,13 @@ List all sandboxes:
 openshell sandbox list
 ```
 
-Get detailed information about a specific sandbox:
+Get detailed information about a specific sandbox. The output lists **Policy source** (`sandbox` or `global`), **Revision** (the active policy’s row version for that source), and the formatted active policy YAML:
 
 ```shell
 openshell sandbox get my-sandbox
 ```
 
-Print only the active policy YAML (effective sandbox or global policy) for scripting:
+Print only that policy YAML for scripting (same effective policy, no metadata):
 
 ```shell
 openshell sandbox get my-sandbox --policy-only

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -116,6 +116,12 @@ Get detailed information about a specific sandbox:
 openshell sandbox get my-sandbox
 ```
 
+Print only the active policy YAML (effective sandbox or global policy) for scripting:
+
+```shell
+openshell sandbox get my-sandbox --policy-only
+```
+
 Stream sandbox logs to monitor agent activity and diagnose policy decisions:
 
 ```shell


### PR DESCRIPTION
## Summary

Fixes the root cause described in #837: `openshell sandbox get` now fetches the **effective runtime policy** via `GetSandboxConfig` for all output modes — including hot-reloaded updates and gateway-global overrides. The base output also surfaces the **policy source** (sandbox or global) and **revision number**, so callers no longer need to stitch together `sandbox get` and `policy get --full` output.

A `--policy-only` flag is also added for scripting workflows:

```shell
openshell sandbox get my-sandbox --policy-only > current.yaml
# edit current.yaml, then:
openshell policy set my-sandbox --policy current.yaml --wait
```

## Related Issue

Fixes https://github.com/NVIDIA/OpenShell/issues/837

## Changes

- `sandbox get` now always calls `GetSandboxConfig` to retrieve the active runtime policy (replaces creation-time spec lookup)
- Base output now includes **Policy source** (sandbox/global) and **Revision** fields
- Added `--policy-only` flag to `openshell sandbox get`; when set, prints only the active policy YAML to stdout
- Added `sandbox_get_policy_only_round_trip` integration test; updated `get_sandbox_config` mock to return a real `SandboxPolicy`
- Updated CLI reference docs and `docs/sandboxes/manage-sandboxes.mdx` with the new flag and updated output

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated (`sandbox_get_policy_only_round_trip`)
- [x] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)