### PR TITLE
test(sandbox): fix flaky arm64 procfs binary_path tests

### DIFF
--- a/crates/openshell-sandbox/src/procfs.rs
+++ b/crates/openshell-sandbox/src/procfs.rs
@@ -423,6 +423,28 @@ mod tests {
         }
     }
 
+    /// Retry `Command::spawn` on `ETXTBSY`. The kernel rejects `execve` when
+    /// `inode->i_writecount > 0`, and the release of that counter after the
+    /// writer fd is closed isn't synchronous with `close(2)` under contention —
+    /// so the very-next-instruction `execve` can still race it. Any other error
+    /// surfaces immediately.
+    #[cfg(target_os = "linux")]
+    fn spawn_retrying_on_etxtbsy(cmd: &mut std::process::Command) -> std::process::Child {
+        let mut attempts = 0;
+        loop {
+            match cmd.spawn() {
+                Ok(child) => return child,
+                Err(err)
+                    if err.kind() == std::io::ErrorKind::ExecutableFileBusy && attempts < 20 =>
+                {
+                    attempts += 1;
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                Err(err) => panic!("spawn failed after {attempts} ETXTBSY retries: {err}"),
+            }
+        }
+    }
+
     #[test]
     fn file_sha256_computes_correct_hash() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
@@ -481,10 +503,9 @@ mod tests {
         // child is still running. The child keeps the exec mapping via
         // `/proc/<pid>/exe`, but readlink will now return the tainted
         // "<path> (deleted)" string.
-        let mut child = std::process::Command::new(&exe_path)
-            .arg("5")
-            .spawn()
-            .unwrap();
+        let mut cmd = std::process::Command::new(&exe_path);
+        cmd.arg("5");
+        let mut child = spawn_retrying_on_etxtbsy(&mut cmd);
         let pid: i32 = child.id().cast_signed();
         wait_for_child_exec(pid, &exe_path);
         std::fs::remove_file(&exe_path).unwrap();
@@ -532,10 +553,9 @@ mod tests {
         std::fs::copy("/bin/sleep", &exe_path).unwrap();
         std::fs::set_permissions(&exe_path, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-        let mut child = std::process::Command::new(&exe_path)
-            .arg("5")
-            .spawn()
-            .unwrap();
+        let mut cmd = std::process::Command::new(&exe_path);
+        cmd.arg("5");
+        let mut child = spawn_retrying_on_etxtbsy(&mut cmd);
         let pid: i32 = child.id().cast_signed();
         wait_for_child_exec(pid, &exe_path);
 
@@ -576,10 +596,9 @@ mod tests {
         std::fs::copy("/bin/sleep", &exe_path).unwrap();
         std::fs::set_permissions(&exe_path, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-        let mut child = std::process::Command::new(&exe_path)
-            .arg("5")
-            .spawn()
-            .unwrap();
+        let mut cmd = std::process::Command::new(&exe_path);
+        cmd.arg("5");
+        let mut child = spawn_retrying_on_etxtbsy(&mut cmd);
         let pid: i32 = child.id().cast_signed();
         wait_for_child_exec(pid, &exe_path);
         std::fs::remove_file(&exe_path).unwrap();

--- a/crates/openshell-sandbox/src/procfs.rs
+++ b/crates/openshell-sandbox/src/procfs.rs
@@ -399,6 +399,30 @@ mod tests {
     use super::*;
     use std::io::Write;
 
+    /// Block until `/proc/<pid>/exe` points at `target`. `Command::spawn` returns
+    /// once the child is scheduled, not once it has completed `exec()`; on
+    /// contended runners the readlink can still show the parent (test harness)
+    /// binary for a brief window. Byte-level `starts_with` tolerates the kernel's
+    /// `" (deleted)"` suffix on unlinked executables.
+    #[cfg(target_os = "linux")]
+    fn wait_for_child_exec(pid: i32, target: &std::path::Path) {
+        use std::os::unix::ffi::OsStrExt as _;
+        let target_bytes = target.as_os_str().as_bytes();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            if let Ok(link) = std::fs::read_link(format!("/proc/{pid}/exe"))
+                && link.as_os_str().as_bytes().starts_with(target_bytes)
+            {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child pid {pid} did not exec into {target:?} within 2s"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
     #[test]
     fn file_sha256_computes_correct_hash() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
@@ -462,6 +486,7 @@ mod tests {
             .spawn()
             .unwrap();
         let pid: i32 = child.id().cast_signed();
+        wait_for_child_exec(pid, &exe_path);
         std::fs::remove_file(&exe_path).unwrap();
 
         // Sanity check: the raw readlink should contain " (deleted)".
@@ -512,6 +537,7 @@ mod tests {
             .spawn()
             .unwrap();
         let pid: i32 = child.id().cast_signed();
+        wait_for_child_exec(pid, &exe_path);
 
         // File is still linked — binary_path must return the path unchanged,
         // suffix and all.
@@ -537,9 +563,8 @@ mod tests {
     #[test]
     fn binary_path_strips_suffix_for_non_utf8_filename() {
         use std::ffi::OsString;
-        use std::io::Write;
         use std::os::unix::ffi::{OsStrExt, OsStringExt};
-        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+        use std::os::unix::fs::PermissionsExt;
 
         let tmp = tempfile::TempDir::new().unwrap();
         // 0xFF is not valid UTF-8. Build the filename on raw bytes.
@@ -548,27 +573,15 @@ mod tests {
         raw_name.extend_from_slice(b".bin");
         let exe_path = tmp.path().join(OsString::from_vec(raw_name));
 
-        // Write bytes explicitly (instead of `std::fs::copy`) with an
-        // explicit `sync_all()` + scope drop so the write fd is fully closed
-        // before we `exec()` the file. Otherwise concurrent tests can race
-        // the kernel into returning ETXTBSY on spawn.
-        let bytes = std::fs::read("/bin/sleep").expect("read /bin/sleep");
-        {
-            let mut f = std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .mode(0o755)
-                .open(&exe_path)
-                .expect("create non-UTF-8 target file");
-            f.write_all(&bytes).expect("write bytes");
-            f.sync_all().expect("sync_all before exec");
-        }
+        std::fs::copy("/bin/sleep", &exe_path).unwrap();
+        std::fs::set_permissions(&exe_path, std::fs::Permissions::from_mode(0o755)).unwrap();
 
         let mut child = std::process::Command::new(&exe_path)
             .arg("5")
             .spawn()
             .unwrap();
         let pid: i32 = child.id().cast_signed();
+        wait_for_child_exec(pid, &exe_path);
         std::fs::remove_file(&exe_path).unwrap();
 
         // Sanity: raw readlink ends with " (deleted)" and is not valid UTF-8.


### PR DESCRIPTION
## Summary

Failing tests: 
- https://github.com/NVIDIA/OpenShell/actions/runs/24590650130/job/71913920970
- https://github.com/NVIDIA/OpenShell/actions/runs/24482014190/job/71720540869#step:9:2560

Three `procfs::tests` tests flake on arm64 CI runners. Two independent test-side races, each needing its own mitigation:

1. **Fork/exec race** — `binary_path_strips_deleted_suffix` and `binary_path_preserves_live_deleted_basename` read `/proc/<child_pid>/exe` immediately after `Command::spawn()` returns. `spawn()` returns once the child is scheduled, not once it has completed `exec()`. Before `execve` lands, the child inherits the parent's `mm->exe_file`, so `/proc/<child>/exe` readlinks to the test harness binary. The target-path assertion then fails with the harness path on the left (`left: \"/__w/.../openshell_sandbox-f9dbf131daaba99d\"`, `right: \"/tmp/.../sleepy (deleted)\"`).
2. **ETXTBSY on spawn** — all three tests copy `/bin/sleep` to a temp path and then spawn it. The kernel rejects `execve` when `inode->i_writecount > 0`, and the release of that counter after the writer fd is closed isn't synchronous with `close(2)` under contention, so the very-next-instruction `execve` can still race it. This is independent of *how* the binary is written — CI has surfaced ETXTBSY in every test, not just the one that originally used `OpenOptions`.

## Changes

`crates/openshell-sandbox/src/procfs.rs`:

- **New `wait_for_child_exec(pid, target)` helper** (test-only, \`#[cfg(target_os = \"linux\")]\`). Polls \`/proc/<pid>/exe\` on a 10 ms interval with a 2 s deadline until the readlink's byte prefix matches \`target\`. Byte-level \`starts_with\` tolerates the kernel's \`\" (deleted)\"\` suffix on unlinked binaries and non-UTF-8 filenames.
- **New \`spawn_retrying_on_etxtbsy(cmd)\` helper** (test-only, \`#[cfg(target_os = \"linux\")]\`). Retries \`Command::spawn()\` up to 20 times with 50 ms backoff (~1 s budget) when \`err.kind() == ErrorKind::ExecutableFileBusy\`. Any other error surfaces immediately.
- Both helpers applied at every \`spawn()\` site in all three affected tests.
- \`binary_path_strips_suffix_for_non_utf8_filename\` also switches from the \`OpenOptions + sync_all\` pattern to \`std::fs::copy\` so all three tests set up their target binary the same way. With the retry in place the write path no longer matters for correctness — this is purely for consistency.

Production \`binary_path\` behaviour is unchanged.

## Related Issue

Blocking CI on #867.

## Testing

- [x] \`cargo test -p openshell-sandbox --lib\` green locally (macOS; Linux-only tests gated out).
- [x] \`cargo check -p openshell-sandbox --tests\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [ ] arm64 CI green on this PR (verifies the flake is actually addressed, not just papered over locally).

## Checklist

- [x] Conforms to Conventional Commits
- [x] No new secrets or credentials
- [x] Scope limited to the test harness