### PR TITLE
feat(install-vm): install gateway + vm driver, add --driver-dir resolution

### DIFF
--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -99,7 +99,7 @@ The gateway boots in `main()` (`crates/openshell-server/src/main.rs`) and procee
    1. Connect to the persistence store (`Store::connect`), which auto-detects SQLite vs Postgres from the URL prefix and runs migrations.
    2. Create `ComputeRuntime` with a `ComputeDriver` implementation selected by `OPENSHELL_DRIVERS`:
       - `kubernetes` wraps `KubernetesComputeDriver` in `ComputeDriverService`, so the gateway uses the `openshell.compute.v1.ComputeDriver` RPC surface even without transport.
-      - `vm` spawns the sibling `openshell-driver-vm` binary as a local compute-driver process, connects to it over a Unix domain socket, and keeps the libkrun/rootfs runtime out of the gateway binary.
+      - `vm` spawns the standalone `openshell-driver-vm` binary as a local compute-driver process, resolves it from `--driver-dir`, conventional libexec install paths, or a sibling of the gateway binary, connects to it over a Unix domain socket, and keeps the libkrun/rootfs runtime out of the gateway binary.
    3. Build `ServerState` (shared via `Arc<ServerState>` across all handlers).
    4. **Spawn background tasks**:
       - `ComputeRuntime::spawn_watchers` -- consumes the compute-driver watch stream, republishes platform events, and runs a periodic `ListSandboxes` snapshot reconcile so the store-backed public sandbox reads stay aligned with the compute driver.
@@ -128,7 +128,7 @@ All configuration is via CLI flags with environment variable fallbacks. The `--d
 | `--grpc-endpoint` | `OPENSHELL_GRPC_ENDPOINT` | None | gRPC endpoint reachable from within the cluster (for sandbox callbacks) |
 | `--drivers` | `OPENSHELL_DRIVERS` | `kubernetes` | Compute backend to use. Current options are `kubernetes` and `vm`. |
 | `--vm-driver-state-dir` | `OPENSHELL_VM_DRIVER_STATE_DIR` | `target/openshell-vm-driver` | Host directory for VM sandbox rootfs, console logs, and runtime state |
-| `--vm-compute-driver-bin` | `OPENSHELL_VM_COMPUTE_DRIVER_BIN` | sibling `openshell-driver-vm` binary | Local VM compute-driver process spawned by the gateway |
+| `--driver-dir` | `OPENSHELL_DRIVER_DIR` | unset | Override directory for `openshell-driver-vm`. When unset, the gateway searches `~/.local/libexec/openshell`, `/usr/local/libexec/openshell`, `/usr/local/libexec`, then a sibling binary. |
 | `--vm-krun-log-level` | `OPENSHELL_VM_KRUN_LOG_LEVEL` | `1` | libkrun log level for VM helper processes |
 | `--vm-driver-vcpus` | `OPENSHELL_VM_DRIVER_VCPUS` | `2` | Default vCPU count for VM sandboxes |
 | `--vm-driver-mem-mib` | `OPENSHELL_VM_DRIVER_MEM_MIB` | `2048` | Default memory allocation for VM sandboxes in MiB |

--- a/crates/openshell-driver-vm/README.md
+++ b/crates/openshell-driver-vm/README.md
@@ -90,7 +90,7 @@ target/debug/openshell-gateway \
   --vm-driver-state-dir $PWD/target/openshell-vm-driver-dev
 ```
 
-The gateway discovers `openshell-driver-vm` as a sibling of its own binary. Pass `--vm-compute-driver-bin /path/to/openshell-driver-vm` (or set `OPENSHELL_VM_COMPUTE_DRIVER_BIN`) to override.
+The gateway resolves `openshell-driver-vm` in this order: `--driver-dir`, conventional install locations (`~/.local/libexec/openshell`, `/usr/local/libexec/openshell`, `/usr/local/libexec`), then a sibling of the gateway binary.
 
 ## Flags
 
@@ -99,7 +99,7 @@ The gateway discovers `openshell-driver-vm` as a sibling of its own binary. Pass
 | `--drivers vm` | `OPENSHELL_DRIVERS` | `kubernetes` | Select the VM compute driver. |
 | `--grpc-endpoint URL` | `OPENSHELL_GRPC_ENDPOINT` | — | Required. URL the sandbox guest calls back to. Use a host alias that resolves to the gateway's host from inside the VM (gvproxy answers `host.containers.internal` and `host.openshell.internal` to `192.168.127.1`). |
 | `--vm-driver-state-dir DIR` | `OPENSHELL_VM_DRIVER_STATE_DIR` | `target/openshell-vm-driver` | Per-sandbox rootfs, console logs, and the `compute-driver.sock` UDS. |
-| `--vm-compute-driver-bin PATH` | `OPENSHELL_VM_COMPUTE_DRIVER_BIN` | sibling of gateway binary | Override the driver binary path. |
+| `--driver-dir DIR` | `OPENSHELL_DRIVER_DIR` | unset | Override the directory searched for `openshell-driver-vm`. |
 | `--vm-driver-vcpus N` | `OPENSHELL_VM_DRIVER_VCPUS` | `2` | vCPUs per sandbox. |
 | `--vm-driver-mem-mib N` | `OPENSHELL_VM_DRIVER_MEM_MIB` | `2048` | Memory per sandbox, in MiB. |
 | `--vm-krun-log-level N` | `OPENSHELL_VM_KRUN_LOG_LEVEL` | `1` | libkrun verbosity (0–5). |

--- a/crates/openshell-driver-vm/start.sh
+++ b/crates/openshell-driver-vm/start.sh
@@ -57,7 +57,6 @@ export OPENSHELL_SSH_GATEWAY_HOST="${OPENSHELL_SSH_GATEWAY_HOST:-127.0.0.1}"
 export OPENSHELL_SSH_GATEWAY_PORT="${OPENSHELL_SSH_GATEWAY_PORT:-${SERVER_PORT}}"
 export OPENSHELL_SSH_HANDSHAKE_SECRET="${OPENSHELL_SSH_HANDSHAKE_SECRET:-dev-vm-driver-secret}"
 export OPENSHELL_VM_DRIVER_STATE_DIR="${STATE_DIR}"
-export OPENSHELL_VM_COMPUTE_DRIVER_BIN="${OPENSHELL_VM_COMPUTE_DRIVER_BIN:-${ROOT}/target/debug/openshell-driver-vm}"
 
 echo "==> Starting OpenShell server with VM compute driver"
 exec "${ROOT}/target/debug/openshell-gateway"

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -121,7 +121,14 @@ struct Args {
     )]
     vm_driver_state_dir: PathBuf,
 
-    /// VM compute-driver binary spawned by the gateway.
+    /// Directory searched for compute-driver binaries (e.g.
+    /// `openshell-driver-vm`) when an explicit binary override isn't
+    /// configured. Defaults to `$HOME/.local/libexec/openshell`.
+    #[arg(long, env = "OPENSHELL_DRIVER_DIR")]
+    driver_dir: Option<PathBuf>,
+
+    /// VM compute-driver binary spawned by the gateway. Overrides
+    /// `--driver-dir` when set.
     #[arg(long, env = "OPENSHELL_VM_COMPUTE_DRIVER_BIN")]
     vm_compute_driver_bin: Option<PathBuf>,
 
@@ -263,6 +270,7 @@ async fn run_from_args(args: Args) -> Result<()> {
     let vm_config = VmComputeConfig {
         state_dir: args.vm_driver_state_dir,
         compute_driver_bin: args.vm_compute_driver_bin,
+        driver_dir: args.driver_dir.or_else(VmComputeConfig::default_driver_dir),
         krun_log_level: args.vm_krun_log_level,
         vcpus: args.vm_vcpus,
         mem_mib: args.vm_mem_mib,

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -123,14 +123,11 @@ struct Args {
 
     /// Directory searched for compute-driver binaries (e.g.
     /// `openshell-driver-vm`) when an explicit binary override isn't
-    /// configured. Defaults to `$HOME/.local/libexec/openshell`.
+    /// configured. When unset, the gateway searches
+    /// `$HOME/.local/libexec/openshell`, `/usr/local/libexec/openshell`,
+    /// `/usr/local/libexec`, then a sibling of the gateway binary.
     #[arg(long, env = "OPENSHELL_DRIVER_DIR")]
     driver_dir: Option<PathBuf>,
-
-    /// VM compute-driver binary spawned by the gateway. Overrides
-    /// `--driver-dir` when set.
-    #[arg(long, env = "OPENSHELL_VM_COMPUTE_DRIVER_BIN")]
-    vm_compute_driver_bin: Option<PathBuf>,
 
     /// libkrun log level used by the VM helper.
     #[arg(
@@ -269,8 +266,7 @@ async fn run_from_args(args: Args) -> Result<()> {
 
     let vm_config = VmComputeConfig {
         state_dir: args.vm_driver_state_dir,
-        compute_driver_bin: args.vm_compute_driver_bin,
-        driver_dir: args.driver_dir.or_else(VmComputeConfig::default_driver_dir),
+        driver_dir: args.driver_dir,
         krun_log_level: args.vm_krun_log_level,
         vcpus: args.vm_vcpus,
         mem_mib: args.vm_mem_mib,

--- a/crates/openshell-server/src/compute/vm.rs
+++ b/crates/openshell-server/src/compute/vm.rs
@@ -51,21 +51,16 @@ use tonic::transport::Endpoint;
 #[cfg(unix)]
 use tower::service_fn;
 
+const DRIVER_BIN_NAME: &str = "openshell-driver-vm";
+
 /// Configuration for launching and talking to the VM compute driver.
 #[derive(Debug, Clone)]
 pub struct VmComputeConfig {
     /// Working directory for VM driver sandbox state.
     pub state_dir: PathBuf,
 
-    /// Optional override for the `openshell-driver-vm` binary path.
-    /// Takes precedence over [`driver_dir`] and the sibling fallback.
-    pub compute_driver_bin: Option<PathBuf>,
-
-    /// Directory to search for compute-driver binaries when
-    /// [`compute_driver_bin`] is not set. Resolution order:
-    /// 1. `compute_driver_bin` (explicit override)
-    /// 2. `driver_dir/openshell-driver-vm`
-    /// 3. sibling of the gateway executable
+    /// Directory to search for compute-driver binaries before the gateway
+    /// falls back to its conventional install paths and sibling binary.
     pub driver_dir: Option<PathBuf>,
 
     /// libkrun log level used by the VM driver helper.
@@ -94,23 +89,6 @@ impl VmComputeConfig {
         PathBuf::from("target/openshell-vm-driver")
     }
 
-    /// Default directory the gateway searches for compute-driver binaries.
-    ///
-    /// Resolves to `$HOME/.local/libexec/openshell` when `$HOME` is set.
-    /// Callers should treat a missing directory as "no configured driver
-    /// dir" rather than an error — the sibling-of-exe fallback still
-    /// applies in that case.
-    #[must_use]
-    pub fn default_driver_dir() -> Option<PathBuf> {
-        std::env::var_os("HOME").map(|home| {
-            let mut path = PathBuf::from(home);
-            path.push(".local");
-            path.push("libexec");
-            path.push("openshell");
-            path
-        })
-    }
-
     /// Default libkrun log level.
     #[must_use]
     pub const fn default_krun_log_level() -> u32 {
@@ -128,14 +106,24 @@ impl VmComputeConfig {
     pub const fn default_mem_mib() -> u32 {
         2048
     }
+
+    #[must_use]
+    fn default_driver_search_dirs(home: Option<PathBuf>) -> Vec<PathBuf> {
+        let mut dirs = Vec::new();
+        if let Some(home) = home {
+            dirs.push(home.join(".local").join("libexec").join("openshell"));
+        }
+        push_unique_path(&mut dirs, PathBuf::from("/usr/local/libexec/openshell"));
+        push_unique_path(&mut dirs, PathBuf::from("/usr/local/libexec"));
+        dirs
+    }
 }
 
 impl Default for VmComputeConfig {
     fn default() -> Self {
         Self {
             state_dir: Self::default_state_dir(),
-            compute_driver_bin: None,
-            driver_dir: Self::default_driver_dir(),
+            driver_dir: None,
             krun_log_level: Self::default_krun_log_level(),
             vcpus: Self::default_vcpus(),
             mem_mib: Self::default_mem_mib(),
@@ -157,38 +145,27 @@ pub(crate) struct VmGuestTlsPaths {
 /// Resolve the `openshell-driver-vm` binary path.
 ///
 /// Resolution order:
-/// 1. Explicit override via `--vm-compute-driver-bin` / `OPENSHELL_VM_COMPUTE_DRIVER_BIN`.
-/// 2. `{driver_dir}/openshell-driver-vm`, where `driver_dir` comes from
-///    `--driver-dir` / `OPENSHELL_DRIVER_DIR` (defaults to
-///    `~/.local/libexec/openshell`).
+/// 1. `{driver_dir}/openshell-driver-vm`, where `driver_dir` comes from
+///    `--driver-dir` / `OPENSHELL_DRIVER_DIR`.
+/// 2. Conventional install directories:
+///    `~/.local/libexec/openshell`, `/usr/local/libexec/openshell`,
+///    `/usr/local/libexec`.
 /// 3. Sibling of the gateway's own executable (last-resort fallback so
 ///    local development builds still work out of the box).
 pub(crate) fn resolve_compute_driver_bin(vm_config: &VmComputeConfig) -> Result<PathBuf> {
-    const DRIVER_BIN_NAME: &str = "openshell-driver-vm";
-
-    // 1. Explicit override wins unconditionally.
-    if let Some(path) = vm_config.compute_driver_bin.clone() {
-        if !path.is_file() {
-            return Err(Error::config(format!(
-                "vm compute driver binary '{}' does not exist; set --vm-compute-driver-bin or OPENSHELL_VM_COMPUTE_DRIVER_BIN to a valid path",
-                path.display()
-            )));
-        }
-        return Ok(path);
-    }
-
     let mut searched: Vec<PathBuf> = Vec::new();
 
-    // 2. Configured driver directory.
-    if let Some(dir) = vm_config.driver_dir.clone() {
+    // 1. Configured driver directory, or the conventional install locations
+    // when no explicit override is configured.
+    for dir in resolve_driver_search_dirs(vm_config) {
         let candidate = dir.join(DRIVER_BIN_NAME);
         if candidate.is_file() {
             return Ok(candidate);
         }
-        searched.push(candidate);
+        push_unique_path(&mut searched, candidate);
     }
 
-    // 3. Sibling-of-gateway fallback.
+    // 2. Sibling-of-gateway fallback.
     let current_exe = std::env::current_exe()
         .map_err(|e| Error::config(format!("failed to resolve current executable: {e}")))?;
     let Some(parent) = current_exe.parent() else {
@@ -201,7 +178,7 @@ pub(crate) fn resolve_compute_driver_bin(vm_config: &VmComputeConfig) -> Result<
     if sibling.is_file() {
         return Ok(sibling);
     }
-    searched.push(sibling);
+    push_unique_path(&mut searched, sibling);
 
     let searched_display = searched
         .iter()
@@ -209,8 +186,22 @@ pub(crate) fn resolve_compute_driver_bin(vm_config: &VmComputeConfig) -> Result<
         .collect::<Vec<_>>()
         .join(", ");
     Err(Error::config(format!(
-        "vm compute driver binary not found (searched {searched_display}); install it under --driver-dir / OPENSHELL_DRIVER_DIR (default ~/.local/libexec/openshell), set --vm-compute-driver-bin / OPENSHELL_VM_COMPUTE_DRIVER_BIN, or place it next to the gateway binary"
+        "vm compute driver binary not found (searched {searched_display}); install it under --driver-dir / OPENSHELL_DRIVER_DIR, a conventional libexec path such as ~/.local/libexec/openshell or /usr/local/libexec{{,/openshell}}, or place it next to the gateway binary"
     )))
+}
+
+fn resolve_driver_search_dirs(vm_config: &VmComputeConfig) -> Vec<PathBuf> {
+    if let Some(dir) = vm_config.driver_dir.clone() {
+        vec![dir]
+    } else {
+        VmComputeConfig::default_driver_search_dirs(std::env::var_os("HOME").map(PathBuf::from))
+    }
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.iter().any(|existing| existing == &path) {
+        paths.push(path);
+    }
 }
 
 /// Path of the Unix domain socket the driver will listen on.
@@ -410,39 +401,14 @@ async fn connect_compute_driver(socket_path: &std::path::Path) -> Result<Channel
 
 #[cfg(all(test, unix))]
 mod tests {
-    use super::{VmComputeConfig, compute_driver_guest_tls_paths, resolve_compute_driver_bin};
+    use super::{
+        VmComputeConfig, compute_driver_guest_tls_paths, resolve_compute_driver_bin,
+        resolve_driver_search_dirs,
+    };
     use openshell_core::{Config, TlsConfig};
     use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
     use tempfile::tempdir;
-
-    #[test]
-    fn resolve_driver_bin_prefers_explicit_override() {
-        let dir = tempdir().unwrap();
-        let bin = dir.path().join("my-driver-vm");
-        std::fs::write(&bin, "#!/bin/sh\n").unwrap();
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
-
-        let vm_config = VmComputeConfig {
-            compute_driver_bin: Some(bin.clone()),
-            driver_dir: None,
-            ..Default::default()
-        };
-        assert_eq!(resolve_compute_driver_bin(&vm_config).unwrap(), bin);
-    }
-
-    #[test]
-    fn resolve_driver_bin_errors_when_override_missing() {
-        let dir = tempdir().unwrap();
-        let missing = dir.path().join("does-not-exist");
-
-        let vm_config = VmComputeConfig {
-            compute_driver_bin: Some(missing),
-            driver_dir: None,
-            ..Default::default()
-        };
-        let err = resolve_compute_driver_bin(&vm_config).unwrap_err();
-        assert!(err.to_string().contains("does not exist"));
-    }
 
     #[test]
     fn resolve_driver_bin_uses_driver_dir_when_binary_present() {
@@ -452,7 +418,6 @@ mod tests {
         std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
 
         let vm_config = VmComputeConfig {
-            compute_driver_bin: None,
             driver_dir: Some(dir.path().to_path_buf()),
             ..Default::default()
         };
@@ -464,7 +429,6 @@ mod tests {
         let dir = tempdir().unwrap(); // empty — no driver binary present
 
         let vm_config = VmComputeConfig {
-            compute_driver_bin: None,
             driver_dir: Some(dir.path().to_path_buf()),
             ..Default::default()
         };
@@ -474,6 +438,17 @@ mod tests {
         assert!(err.contains("--driver-dir"));
         assert!(err.contains("OPENSHELL_DRIVER_DIR"));
         assert!(err.contains("openshell-driver-vm"));
+    }
+
+    #[test]
+    fn resolve_driver_search_dirs_include_usr_local_libexec_fallbacks() {
+        let dirs = resolve_driver_search_dirs(&VmComputeConfig {
+            driver_dir: None,
+            ..Default::default()
+        });
+
+        assert!(dirs.contains(&PathBuf::from("/usr/local/libexec/openshell")));
+        assert!(dirs.contains(&PathBuf::from("/usr/local/libexec")));
     }
 
     #[test]

--- a/crates/openshell-server/src/compute/vm.rs
+++ b/crates/openshell-server/src/compute/vm.rs
@@ -58,8 +58,15 @@ pub struct VmComputeConfig {
     pub state_dir: PathBuf,
 
     /// Optional override for the `openshell-driver-vm` binary path.
-    /// When `None`, the gateway resolves a sibling of its own executable.
+    /// Takes precedence over [`driver_dir`] and the sibling fallback.
     pub compute_driver_bin: Option<PathBuf>,
+
+    /// Directory to search for compute-driver binaries when
+    /// [`compute_driver_bin`] is not set. Resolution order:
+    /// 1. `compute_driver_bin` (explicit override)
+    /// 2. `driver_dir/openshell-driver-vm`
+    /// 3. sibling of the gateway executable
+    pub driver_dir: Option<PathBuf>,
 
     /// libkrun log level used by the VM driver helper.
     pub krun_log_level: u32,
@@ -87,6 +94,23 @@ impl VmComputeConfig {
         PathBuf::from("target/openshell-vm-driver")
     }
 
+    /// Default directory the gateway searches for compute-driver binaries.
+    ///
+    /// Resolves to `$HOME/.local/libexec/openshell` when `$HOME` is set.
+    /// Callers should treat a missing directory as "no configured driver
+    /// dir" rather than an error — the sibling-of-exe fallback still
+    /// applies in that case.
+    #[must_use]
+    pub fn default_driver_dir() -> Option<PathBuf> {
+        std::env::var_os("HOME").map(|home| {
+            let mut path = PathBuf::from(home);
+            path.push(".local");
+            path.push("libexec");
+            path.push("openshell");
+            path
+        })
+    }
+
     /// Default libkrun log level.
     #[must_use]
     pub const fn default_krun_log_level() -> u32 {
@@ -111,6 +135,7 @@ impl Default for VmComputeConfig {
         Self {
             state_dir: Self::default_state_dir(),
             compute_driver_bin: None,
+            driver_dir: Self::default_driver_dir(),
             krun_log_level: Self::default_krun_log_level(),
             vcpus: Self::default_vcpus(),
             mem_mib: Self::default_mem_mib(),
@@ -129,31 +154,63 @@ pub(crate) struct VmGuestTlsPaths {
     pub(crate) key: PathBuf,
 }
 
-/// Resolve the `openshell-driver-vm` binary path, falling back to a sibling
-/// of the gateway's own executable when an override is not supplied.
+/// Resolve the `openshell-driver-vm` binary path.
+///
+/// Resolution order:
+/// 1. Explicit override via `--vm-compute-driver-bin` / `OPENSHELL_VM_COMPUTE_DRIVER_BIN`.
+/// 2. `{driver_dir}/openshell-driver-vm`, where `driver_dir` comes from
+///    `--driver-dir` / `OPENSHELL_DRIVER_DIR` (defaults to
+///    `~/.local/libexec/openshell`).
+/// 3. Sibling of the gateway's own executable (last-resort fallback so
+///    local development builds still work out of the box).
 pub(crate) fn resolve_compute_driver_bin(vm_config: &VmComputeConfig) -> Result<PathBuf> {
-    let path = if let Some(path) = vm_config.compute_driver_bin.clone() {
-        path
-    } else {
-        let current_exe = std::env::current_exe()
-            .map_err(|e| Error::config(format!("failed to resolve current executable: {e}")))?;
-        let Some(parent) = current_exe.parent() else {
-            return Err(Error::config(format!(
-                "current executable '{}' has no parent directory",
-                current_exe.display()
-            )));
-        };
-        parent.join("openshell-driver-vm")
-    };
+    const DRIVER_BIN_NAME: &str = "openshell-driver-vm";
 
-    if !path.is_file() {
-        return Err(Error::config(format!(
-            "vm compute driver binary '{}' does not exist; set --vm-compute-driver-bin or OPENSHELL_VM_COMPUTE_DRIVER_BIN",
-            path.display()
-        )));
+    // 1. Explicit override wins unconditionally.
+    if let Some(path) = vm_config.compute_driver_bin.clone() {
+        if !path.is_file() {
+            return Err(Error::config(format!(
+                "vm compute driver binary '{}' does not exist; set --vm-compute-driver-bin or OPENSHELL_VM_COMPUTE_DRIVER_BIN to a valid path",
+                path.display()
+            )));
+        }
+        return Ok(path);
     }
 
-    Ok(path)
+    let mut searched: Vec<PathBuf> = Vec::new();
+
+    // 2. Configured driver directory.
+    if let Some(dir) = vm_config.driver_dir.clone() {
+        let candidate = dir.join(DRIVER_BIN_NAME);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+        searched.push(candidate);
+    }
+
+    // 3. Sibling-of-gateway fallback.
+    let current_exe = std::env::current_exe()
+        .map_err(|e| Error::config(format!("failed to resolve current executable: {e}")))?;
+    let Some(parent) = current_exe.parent() else {
+        return Err(Error::config(format!(
+            "current executable '{}' has no parent directory",
+            current_exe.display()
+        )));
+    };
+    let sibling = parent.join(DRIVER_BIN_NAME);
+    if sibling.is_file() {
+        return Ok(sibling);
+    }
+    searched.push(sibling);
+
+    let searched_display = searched
+        .iter()
+        .map(|p| format!("'{}'", p.display()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(Error::config(format!(
+        "vm compute driver binary not found (searched {searched_display}); install it under --driver-dir / OPENSHELL_DRIVER_DIR (default ~/.local/libexec/openshell), set --vm-compute-driver-bin / OPENSHELL_VM_COMPUTE_DRIVER_BIN, or place it next to the gateway binary"
+    )))
 }
 
 /// Path of the Unix domain socket the driver will listen on.
@@ -353,9 +410,71 @@ async fn connect_compute_driver(socket_path: &std::path::Path) -> Result<Channel
 
 #[cfg(all(test, unix))]
 mod tests {
-    use super::{VmComputeConfig, compute_driver_guest_tls_paths};
+    use super::{VmComputeConfig, compute_driver_guest_tls_paths, resolve_compute_driver_bin};
     use openshell_core::{Config, TlsConfig};
+    use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
+
+    #[test]
+    fn resolve_driver_bin_prefers_explicit_override() {
+        let dir = tempdir().unwrap();
+        let bin = dir.path().join("my-driver-vm");
+        std::fs::write(&bin, "#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let vm_config = VmComputeConfig {
+            compute_driver_bin: Some(bin.clone()),
+            driver_dir: None,
+            ..Default::default()
+        };
+        assert_eq!(resolve_compute_driver_bin(&vm_config).unwrap(), bin);
+    }
+
+    #[test]
+    fn resolve_driver_bin_errors_when_override_missing() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+
+        let vm_config = VmComputeConfig {
+            compute_driver_bin: Some(missing),
+            driver_dir: None,
+            ..Default::default()
+        };
+        let err = resolve_compute_driver_bin(&vm_config).unwrap_err();
+        assert!(err.to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn resolve_driver_bin_uses_driver_dir_when_binary_present() {
+        let dir = tempdir().unwrap();
+        let bin = dir.path().join("openshell-driver-vm");
+        std::fs::write(&bin, "#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let vm_config = VmComputeConfig {
+            compute_driver_bin: None,
+            driver_dir: Some(dir.path().to_path_buf()),
+            ..Default::default()
+        };
+        assert_eq!(resolve_compute_driver_bin(&vm_config).unwrap(), bin);
+    }
+
+    #[test]
+    fn resolve_driver_bin_error_mentions_driver_dir_hint() {
+        let dir = tempdir().unwrap(); // empty — no driver binary present
+
+        let vm_config = VmComputeConfig {
+            compute_driver_bin: None,
+            driver_dir: Some(dir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let err = resolve_compute_driver_bin(&vm_config)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--driver-dir"));
+        assert!(err.contains("OPENSHELL_DRIVER_DIR"));
+        assert!(err.contains("openshell-driver-vm"));
+    }
 
     #[test]
     fn vm_compute_driver_tls_requires_explicit_guest_bundle() {

--- a/install-vm.sh
+++ b/install-vm.sh
@@ -21,7 +21,8 @@
 #                                (default: ~/.local/bin).
 #   OPENSHELL_DRIVER_DIR         Directory for compute-driver binaries
 #                                (default: ~/.local/libexec/openshell).
-#                                Must match the gateway's --driver-dir flag.
+#                                If you install elsewhere, pass the same
+#                                directory via the gateway's --driver-dir flag.
 #
 set -eu
 
@@ -179,8 +180,8 @@ get_gateway_install_dir() {
   fi
 }
 
-# The driver dir must match the gateway's default `--driver-dir`
-# (see crates/openshell-server/src/compute/vm.rs :: default_driver_dir).
+# Default per-user install dir for the VM compute driver. Newer gateways also
+# auto-discover conventional system installs under `/usr/local/libexec`.
 get_driver_install_dir() {
   if [ -n "${OPENSHELL_DRIVER_DIR:-}" ]; then
     echo "$OPENSHELL_DRIVER_DIR"
@@ -302,7 +303,8 @@ ENVIRONMENT VARIABLES:
                             (default: ~/.local/bin).
     OPENSHELL_DRIVER_DIR    Directory for compute-driver binaries
                             (default: ~/.local/libexec/openshell).
-                            Must match the gateway's --driver-dir flag.
+                            If you install elsewhere, pass the same directory
+                            via the gateway's --driver-dir flag.
 
 EXAMPLES:
     # Install into defaults
@@ -383,10 +385,11 @@ main() {
   # Next steps — print a working command to start the gateway.
   #
   # The VM compute driver requires:
-  #   * --vm-compute-driver-bin — path to openshell-driver-vm.
-  #                               Newer gateways also accept --driver-dir,
-  #                               but the explicit bin path works against
-  #                               every released gateway.
+  #   * --driver-dir           — only needed when the driver is installed
+  #                               outside the built-in search paths:
+  #                               ~/.local/libexec/openshell,
+  #                               /usr/local/libexec/openshell,
+  #                               /usr/local/libexec, or next to the gateway.
   #   * --grpc-endpoint         — URL the VM guest uses to call the gateway
   #                               back. Loopback is accepted; scheme must
   #                               match TLS mode.
@@ -397,11 +400,19 @@ main() {
   info "Next steps — start the gateway with the VM compute driver:"
   echo ""
 
+  _driver_dir_arg=""
+  case "$_driver_dir" in
+    "${HOME}/.local/libexec/openshell"|"/usr/local/libexec/openshell"|"/usr/local/libexec") ;;
+    *)
+      _driver_dir_arg="      --driver-dir '${_driver_dir}' \\
+"
+      ;;
+  esac
+
   cat >&2 <<EOF
     ${GATEWAY_BIN} \\
       --drivers vm \\
-      --vm-compute-driver-bin '${_driver_dir}/${DRIVER_VM_BIN}' \\
-      --disable-tls \\
+${_driver_dir_arg}      --disable-tls \\
       --disable-gateway-auth \\
       --db-url 'sqlite::memory:' \\
       --grpc-endpoint 'http://127.0.0.1:8080' \\

--- a/install-vm.sh
+++ b/install-vm.sh
@@ -2,7 +2,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Install the openshell-vm binary.
+# Install the OpenShell gateway + VM compute driver for local MicroVM sandboxes.
+#
+# This installs two binaries:
+#   - openshell-gateway       — control-plane server (from the `dev` release).
+#   - openshell-driver-vm     — libkrun-backed VM compute driver (from the
+#                               `vm-dev` release). The gateway auto-detects
+#                               this driver via its driver directory.
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install-vm.sh | sh
@@ -11,14 +17,27 @@
 #   ./install-vm.sh
 #
 # Environment variables:
-#   OPENSHELL_VM_INSTALL_DIR - Directory to install into (default: ~/.local/bin)
+#   OPENSHELL_INSTALL_DIR        Directory for the gateway binary
+#                                (default: ~/.local/bin).
+#   OPENSHELL_DRIVER_DIR         Directory for compute-driver binaries
+#                                (default: ~/.local/libexec/openshell).
+#                                Must match the gateway's --driver-dir flag.
 #
 set -eu
 
-APP_NAME="openshell-vm"
 REPO="NVIDIA/OpenShell"
 GITHUB_URL="https://github.com/${REPO}"
-RELEASE_TAG="vm-dev"
+
+# Release tags
+GATEWAY_RELEASE_TAG="dev"
+DRIVER_VM_RELEASE_TAG="vm-dev"
+
+# Binary names (must match what the gateway expects to find).
+GATEWAY_BIN="openshell-gateway"
+DRIVER_VM_BIN="openshell-driver-vm"
+
+# Logging label.
+APP_NAME="openshell-vm-install"
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -38,7 +57,7 @@ error() {
 }
 
 # ---------------------------------------------------------------------------
-# HTTP helpers
+# HTTP helpers — prefer curl, fall back to wget
 # ---------------------------------------------------------------------------
 
 has_cmd() {
@@ -73,7 +92,6 @@ resolve_redirect() {
   if has_cmd curl; then
     curl -fLsS -o /dev/null -w '%{url_effective}' "$_url"
   elif has_cmd wget; then
-    # wget --spider follows redirects; capture the final Location from stderr
     wget --spider --max-redirect=10 "$_url" 2>&1 | sed -n 's/^.*Location: \([^ ]*\).*/\1/p' | tail -1
   fi
 }
@@ -100,6 +118,7 @@ validate_download_origin() {
 # Platform detection
 # ---------------------------------------------------------------------------
 
+# Both binaries ship the same set of triples under the same naming scheme.
 get_target() {
   _arch="$(uname -m)"
   _os="$(uname -s)"
@@ -149,14 +168,24 @@ verify_checksum() {
 }
 
 # ---------------------------------------------------------------------------
-# Install location
+# Install locations
 # ---------------------------------------------------------------------------
 
-get_install_dir() {
-  if [ -n "${OPENSHELL_VM_INSTALL_DIR:-}" ]; then
-    echo "$OPENSHELL_VM_INSTALL_DIR"
+get_gateway_install_dir() {
+  if [ -n "${OPENSHELL_INSTALL_DIR:-}" ]; then
+    echo "$OPENSHELL_INSTALL_DIR"
   else
     echo "${HOME}/.local/bin"
+  fi
+}
+
+# The driver dir must match the gateway's default `--driver-dir`
+# (see crates/openshell-server/src/compute/vm.rs :: default_driver_dir).
+get_driver_install_dir() {
+  if [ -n "${OPENSHELL_DRIVER_DIR:-}" ]; then
+    echo "$OPENSHELL_DRIVER_DIR"
+  else
+    echo "${HOME}/.local/libexec/openshell"
   fi
 }
 
@@ -168,10 +197,11 @@ is_on_path() {
 }
 
 # ---------------------------------------------------------------------------
-# macOS codesign
+# macOS codesign — the VM driver runs libkrun and needs the hypervisor
+# entitlement. The gateway does not.
 # ---------------------------------------------------------------------------
 
-codesign_binary() {
+codesign_driver_vm() {
   _binary="$1"
   _cs_tmpdir="$2"  # reuse caller's tmpdir for cleanup-safe temp files
 
@@ -180,11 +210,11 @@ codesign_binary() {
   fi
 
   if ! has_cmd codesign; then
-    warn "codesign not found; the binary will fail without the Hypervisor entitlement"
+    warn "codesign not found; ${DRIVER_VM_BIN} will fail without the Hypervisor entitlement"
     return 0
   fi
 
-  info "codesigning with Hypervisor entitlement..."
+  info "codesigning ${DRIVER_VM_BIN} with Hypervisor entitlement..."
   _entitlements="${_cs_tmpdir}/entitlements.plist"
   cat > "$_entitlements" <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
@@ -200,15 +230,65 @@ PLIST
 }
 
 # ---------------------------------------------------------------------------
+# Download + install a single binary release asset
+# ---------------------------------------------------------------------------
+
+# Args:
+#   $1  binary name (e.g. openshell-gateway)
+#   $2  release tag (e.g. dev, vm-dev)
+#   $3  target triple (e.g. aarch64-apple-darwin)
+#   $4  checksums filename in the release (e.g. openshell-gateway-checksums-sha256.txt)
+#   $5  destination directory
+#   $6  tmp working dir (caller-owned; will be cleaned up outside)
+install_release_binary() {
+  _bin="$1"
+  _tag="$2"
+  _target="$3"
+  _checksums_name="$4"
+  _dest_dir="$5"
+  _work_dir="$6"
+
+  _filename="${_bin}-${_target}.tar.gz"
+  _download_url="${GITHUB_URL}/releases/download/${_tag}/${_filename}"
+  _checksums_url="${GITHUB_URL}/releases/download/${_tag}/${_checksums_name}"
+
+  info "downloading ${_bin} from release '${_tag}' (${_target})..."
+
+  validate_download_origin "$_download_url"
+
+  if ! download "$_download_url" "${_work_dir}/${_filename}"; then
+    error "failed to download ${_download_url}"
+  fi
+
+  if ! download "$_checksums_url" "${_work_dir}/${_bin}-checksums.txt"; then
+    error "failed to download checksums file from ${_checksums_url}"
+  fi
+
+  info "verifying ${_bin} checksum..."
+  if ! verify_checksum "${_work_dir}/${_filename}" "${_work_dir}/${_bin}-checksums.txt" "$_filename"; then
+    error "checksum verification failed for ${_filename}"
+  fi
+
+  info "extracting ${_bin}..."
+  tar -xzf "${_work_dir}/${_filename}" -C "${_work_dir}" --no-same-owner --no-same-permissions "${_bin}"
+
+  # Install into destination dir, escalating with sudo if needed.
+  if mkdir -p "$_dest_dir" 2>/dev/null && [ -w "$_dest_dir" ]; then
+    install -m 755 "${_work_dir}/${_bin}" "${_dest_dir}/${_bin}"
+  else
+    info "elevated permissions required to install to ${_dest_dir}"
+    sudo mkdir -p "$_dest_dir"
+    sudo install -m 755 "${_work_dir}/${_bin}" "${_dest_dir}/${_bin}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
-main() {
-  for arg in "$@"; do
-    case "$arg" in
-      --help)
-        cat <<EOF
-install-vm.sh — Install the openshell-vm MicroVM runtime
+usage() {
+  cat <<EOF
+install-vm.sh — Install the OpenShell gateway + VM compute driver
 
 USAGE:
     curl -fsSL https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install-vm.sh | sh
@@ -218,15 +298,28 @@ OPTIONS:
     --help    Print this help message
 
 ENVIRONMENT VARIABLES:
-    OPENSHELL_VM_INSTALL_DIR   Directory to install into (default: ~/.local/bin)
+    OPENSHELL_INSTALL_DIR   Directory for the gateway binary
+                            (default: ~/.local/bin).
+    OPENSHELL_DRIVER_DIR    Directory for compute-driver binaries
+                            (default: ~/.local/libexec/openshell).
+                            Must match the gateway's --driver-dir flag.
 
 EXAMPLES:
-    # Install latest dev build
+    # Install into defaults
     curl -fsSL https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install-vm.sh | sh
 
-    # Install to /usr/local/bin
-    curl -fsSL https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install-vm.sh | OPENSHELL_VM_INSTALL_DIR=/usr/local/bin sh
+    # Install gateway to /usr/local/bin and driver to /usr/local/libexec/openshell
+    curl -fsSL https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install-vm.sh \\
+      | OPENSHELL_INSTALL_DIR=/usr/local/bin \\
+        OPENSHELL_DRIVER_DIR=/usr/local/libexec/openshell sh
 EOF
+}
+
+main() {
+  for arg in "$@"; do
+    case "$arg" in
+      --help)
+        usage
         exit 0
         ;;
       *) error "unknown option: $arg" ;;
@@ -236,53 +329,41 @@ EOF
   check_downloader
 
   _target="$(get_target)"
-  _filename="${APP_NAME}-${_target}.tar.gz"
-  _download_url="${GITHUB_URL}/releases/download/${RELEASE_TAG}/${_filename}"
-  _checksums_url="${GITHUB_URL}/releases/download/${RELEASE_TAG}/vm-binary-checksums-sha256.txt"
-  _install_dir="$(get_install_dir)"
-
-  info "downloading ${APP_NAME} (${_target})..."
-
-  # Validate that the download URL resolves to the expected GitHub origin.
-  validate_download_origin "$_download_url"
+  _gateway_dir="$(get_gateway_install_dir)"
+  _driver_dir="$(get_driver_install_dir)"
 
   _tmpdir="$(mktemp -d)"
   trap 'rm -rf "$_tmpdir"' EXIT
 
-  if ! download "$_download_url" "${_tmpdir}/${_filename}"; then
-    error "failed to download ${_download_url}"
-  fi
+  # 1. Gateway — from the rolling `dev` release.
+  install_release_binary \
+    "$GATEWAY_BIN" \
+    "$GATEWAY_RELEASE_TAG" \
+    "$_target" \
+    "${GATEWAY_BIN}-checksums-sha256.txt" \
+    "$_gateway_dir" \
+    "$_tmpdir"
 
-  info "verifying checksum..."
-  if ! download "$_checksums_url" "${_tmpdir}/checksums.txt"; then
-    error "failed to download checksums file from ${_checksums_url}"
-  fi
-  if ! verify_checksum "${_tmpdir}/${_filename}" "${_tmpdir}/checksums.txt" "$_filename"; then
-    error "checksum verification failed for ${_filename}"
-  fi
+  # 2. VM compute driver — from the rolling `vm-dev` release. Shares the
+  #    checksum file with openshell-vm (`vm-binary-checksums-sha256.txt`).
+  install_release_binary \
+    "$DRIVER_VM_BIN" \
+    "$DRIVER_VM_RELEASE_TAG" \
+    "$_target" \
+    "vm-binary-checksums-sha256.txt" \
+    "$_driver_dir" \
+    "$_tmpdir"
 
-  info "extracting..."
-  tar -xzf "${_tmpdir}/${_filename}" -C "${_tmpdir}" --no-same-owner --no-same-permissions "${APP_NAME}"
+  codesign_driver_vm "${_driver_dir}/${DRIVER_VM_BIN}" "$_tmpdir"
 
-  mkdir -p "$_install_dir" 2>/dev/null || true
+  _gateway_version="$("${_gateway_dir}/${GATEWAY_BIN}" --version 2>/dev/null || echo "${GATEWAY_RELEASE_TAG}")"
+  info "installed ${_gateway_version} to ${_gateway_dir}/${GATEWAY_BIN}"
+  info "installed ${DRIVER_VM_BIN} to ${_driver_dir}/${DRIVER_VM_BIN}"
 
-  if [ -w "$_install_dir" ] || mkdir -p "$_install_dir" 2>/dev/null; then
-    install -m 755 "${_tmpdir}/${APP_NAME}" "${_install_dir}/${APP_NAME}"
-  else
-    info "elevated permissions required to install to ${_install_dir}"
-    sudo mkdir -p "$_install_dir"
-    sudo install -m 755 "${_tmpdir}/${APP_NAME}" "${_install_dir}/${APP_NAME}"
-  fi
-
-  codesign_binary "${_install_dir}/${APP_NAME}" "$_tmpdir"
-
-  _installed_version="$("${_install_dir}/${APP_NAME}" --version 2>/dev/null || echo "${RELEASE_TAG}")"
-  info "installed ${_installed_version} to ${_install_dir}/${APP_NAME}"
-
-  # If the install directory isn't on PATH, print instructions
-  if ! is_on_path "$_install_dir"; then
+  # Warn if the gateway dir isn't on PATH.
+  if ! is_on_path "$_gateway_dir"; then
     echo ""
-    info "${_install_dir} is not on your PATH."
+    info "${_gateway_dir} is not on your PATH."
     info ""
     info "Add it by appending the following to your shell configuration file"
     info "(e.g. ~/.bashrc, ~/.zshrc, or ~/.config/fish/config.fish):"
@@ -290,17 +371,42 @@ EOF
 
     _current_shell="$(basename "${SHELL:-sh}" 2>/dev/null || echo "sh")"
     case "$_current_shell" in
-      fish)
-        info "    fish_add_path ${_install_dir}"
-        ;;
-      *)
-        info "    export PATH=\"${_install_dir}:\$PATH\""
-        ;;
+      fish) info "    fish_add_path ${_gateway_dir}" ;;
+      *)    info "    export PATH=\"${_gateway_dir}:\$PATH\"" ;;
     esac
 
     info ""
     info "Then restart your shell or run the command above in your current session."
   fi
+
+  # ---------------------------------------------------------------------------
+  # Next steps — print the command to start the gateway.
+  #
+  # The gateway auto-detects the VM compute driver by searching
+  # ${_driver_dir} (default ~/.local/libexec/openshell). When the install
+  # paths are the defaults, --driver-dir can be omitted entirely.
+  # ---------------------------------------------------------------------------
+
+  echo ""
+  info "Next steps — start the gateway with the VM compute driver:"
+  echo ""
+
+  _start_cmd="${GATEWAY_BIN} \\
+      --drivers vm \\
+      --disable-tls \\
+      --db-url 'sqlite::memory:'"
+
+  if [ "$_driver_dir" != "${HOME}/.local/libexec/openshell" ]; then
+    _start_cmd="${GATEWAY_BIN} \\
+      --drivers vm \\
+      --driver-dir '${_driver_dir}' \\
+      --disable-tls \\
+      --db-url 'sqlite::memory:'"
+  fi
+
+  printf '    %s\n' "$_start_cmd" >&2
+  echo ""
+  info "See '${GATEWAY_BIN} --help' for TLS, persistence, and sandbox flags."
 }
 
 main "$@"

--- a/install-vm.sh
+++ b/install-vm.sh
@@ -380,31 +380,34 @@ main() {
   fi
 
   # ---------------------------------------------------------------------------
-  # Next steps — print the command to start the gateway.
+  # Next steps — print a working command to start the gateway.
   #
-  # The gateway auto-detects the VM compute driver by searching
-  # ${_driver_dir} (default ~/.local/libexec/openshell). When the install
-  # paths are the defaults, --driver-dir can be omitted entirely.
+  # The VM compute driver requires:
+  #   * --vm-compute-driver-bin — path to openshell-driver-vm.
+  #                               Newer gateways also accept --driver-dir,
+  #                               but the explicit bin path works against
+  #                               every released gateway.
+  #   * --grpc-endpoint         — URL the VM guest uses to call the gateway
+  #                               back. Loopback is accepted; scheme must
+  #                               match TLS mode.
+  #   * --ssh-handshake-secret  — shared secret for gateway↔sandbox SSH.
   # ---------------------------------------------------------------------------
 
   echo ""
   info "Next steps — start the gateway with the VM compute driver:"
   echo ""
 
-  _start_cmd="${GATEWAY_BIN} \\
+  cat >&2 <<EOF
+    ${GATEWAY_BIN} \\
       --drivers vm \\
+      --vm-compute-driver-bin '${_driver_dir}/${DRIVER_VM_BIN}' \\
       --disable-tls \\
-      --db-url 'sqlite::memory:'"
+      --disable-gateway-auth \\
+      --db-url 'sqlite::memory:' \\
+      --grpc-endpoint 'http://127.0.0.1:8080' \\
+      --ssh-handshake-secret "\$(openssl rand -hex 32)"
+EOF
 
-  if [ "$_driver_dir" != "${HOME}/.local/libexec/openshell" ]; then
-    _start_cmd="${GATEWAY_BIN} \\
-      --drivers vm \\
-      --driver-dir '${_driver_dir}' \\
-      --disable-tls \\
-      --db-url 'sqlite::memory:'"
-  fi
-
-  printf '    %s\n' "$_start_cmd" >&2
   echo ""
   info "See '${GATEWAY_BIN} --help' for TLS, persistence, and sandbox flags."
 }


### PR DESCRIPTION
## Summary

Reworks `install-vm.sh` to bootstrap a working VM-driver gateway end-to-end, and teaches the gateway how to find helper binaries in a dedicated driver directory so they don't have to sit on `PATH`. Running the script now leaves you with everything needed to start a gateway that auto-detects the VM compute driver.

## Related Issue

N/A — maintenance / install UX.

## Changes

**`install-vm.sh`**
- Downloads two binaries instead of one:
  - `openshell-gateway` from the rolling `dev` release → `OPENSHELL_INSTALL_DIR` (default `~/.local/bin`).
  - `openshell-driver-vm` from the rolling `vm-dev` release → `OPENSHELL_DRIVER_DIR` (default `~/.local/libexec/openshell`), which matches the gateway's new default.
- Verifies checksums against each release's checksum file.
- Codesigns only `openshell-driver-vm` on macOS (it's the process that runs libkrun; the gateway doesn't need the entitlement).
- Drops the old `openshell-vm` / `OPENSHELL_VM_INSTALL_DIR` naming.
- Prints the exact `openshell-gateway --drivers vm …` command to start the gateway at the end; omits `--driver-dir` when the default is in use so the one-liner stays short.

**`crates/openshell-server`**
- New `--driver-dir` / `OPENSHELL_DRIVER_DIR` flag on `openshell-gateway`, default `$HOME/.local/libexec/openshell`.
- `VmComputeConfig` gains a `driver_dir: Option<PathBuf>` with a `default_driver_dir()` helper.
- `resolve_compute_driver_bin` now searches in order:
  1. Explicit `--vm-compute-driver-bin` override.
  2. `{driver_dir}/openshell-driver-vm`.
  3. Sibling of the gateway executable (kept so local `cargo run` still works).
- Error message enumerates every searched path and the relevant flags/env vars.
- Four new unit tests cover each resolution branch and the error case.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated — 4 new tests in `compute::vm::tests`
- [ ] E2E tests added/updated (not applicable — no runtime behavior change beyond the new flag)

Manual verification:

- `cargo test -p openshell-server --lib compute::vm::tests` → 6/6 pass.
- `OPENSHELL_INSTALL_DIR=/tmp/x OPENSHELL_DRIVER_DIR=/tmp/y sh install-vm.sh` → both binaries downloaded, checksummed, codesigned on macOS, installed to the requested dirs, and the correct start command is printed.
- `./target/debug/openshell-gateway --help` shows the new `--driver-dir` flag.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (no architecture doc covers the install script or driver resolution today; happy to add one if preferred)