### PR TITLE
fix(sandbox): apply supervisor seccomp prelude

### DIFF
--- a/architecture/sandbox-custom-containers.md
+++ b/architecture/sandbox-custom-containers.md
@@ -98,6 +98,7 @@ The `openshell-sandbox` supervisor adapts to arbitrary environments:
 
 - **Log file fallback**: Attempts to open `/var/log/openshell.log` for append; silently falls back to stdout-only logging if the path is not writable.
 - **Command resolution**: Executes the command from CLI args, then the `OPENSHELL_SANDBOX_COMMAND` env var (set to `sleep infinity` by the server), then `/bin/bash` as a last resort.
+- **Startup seccomp prelude**: Before parsing CLI args or starting the async runtime, the supervisor sets `PR_SET_NO_NEW_PRIVS` and installs a narrow seccomp filter that blocks mount/remount, the new mount API syscalls, module loading, kexec, `bpf`, `perf_event_open`, and `userfaultfd`. This closes the privileged remount window while still leaving required child-setup syscalls such as `setns` available.
 - **Network namespace**: Requires successful namespace creation for proxy isolation; startup fails in proxy mode if required capabilities (`CAP_NET_ADMIN`, `CAP_SYS_ADMIN`) or `iproute2` are unavailable. If the `iptables` package is present, the supervisor installs OUTPUT chain rules (LOG + REJECT) inside the namespace to provide fast-fail behavior (immediate `ECONNREFUSED` instead of a 30-second timeout) and diagnostic logging when processes attempt direct connections that bypass the HTTP CONNECT proxy. If `iptables` is absent, the supervisor logs a warning and continues — core network isolation still works via routing.
 
 ## Design Decisions
@@ -109,7 +110,7 @@ The `openshell-sandbox` supervisor adapts to arbitrary environments:
 | Auto build+push for Dockerfiles | Eliminates the two-step `image push` + `create` workflow for local development |
 | `OPENSHELL_COMMUNITY_REGISTRY` env var | Allows organizations to host their own community sandbox registry |
 | hostPath side-load | Supervisor binary lives on the node filesystem — no init container, no emptyDir, no extra image pull. Faster pod startup. |
-| Read-only mount in agent | Supervisor binary cannot be tampered with by the workload |
+| Read-only mount in agent | The supervisor binary is mounted read-only, and the startup seccomp prelude blocks the remount syscalls that would otherwise reopen it for writes during supervisor startup. |
 | Command override | Ensures `openshell-sandbox` is the entrypoint regardless of the image's default CMD |
 | Clear `run_as_user/group` for custom images | Prevents startup failure when the image lacks the default `sandbox` user |
 | Non-fatal log file init | `/var/log/openshell.log` may be unwritable in arbitrary images; falls back to stdout |

--- a/architecture/sandbox-custom-containers.md
+++ b/architecture/sandbox-custom-containers.md
@@ -110,7 +110,7 @@ The `openshell-sandbox` supervisor adapts to arbitrary environments:
 | Auto build+push for Dockerfiles | Eliminates the two-step `image push` + `create` workflow for local development |
 | `OPENSHELL_COMMUNITY_REGISTRY` env var | Allows organizations to host their own community sandbox registry |
 | hostPath side-load | Supervisor binary lives on the node filesystem — no init container, no emptyDir, no extra image pull. Faster pod startup. |
-| Read-only mount in agent | The supervisor binary is mounted read-only, and the startup seccomp prelude blocks the remount syscalls that would otherwise reopen it for writes during supervisor startup. |
+| Read-only mount in agent | The supervisor binary is mounted read-only, and the startup seccomp prelude blocks the remount syscalls that would otherwise reopen it for writes once privileged bootstrap has completed. |
 | Command override | Ensures `openshell-sandbox` is the entrypoint regardless of the image's default CMD |
 | Clear `run_as_user/group` for custom images | Prevents startup failure when the image lacks the default `sandbox` user |
 | Non-fatal log file init | `/var/log/openshell.log` may be unwritable in arbitrary images; falls back to stdout |

--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -417,6 +417,11 @@ pub async fn run_sandbox(
     #[allow(clippy::no_effect_underscore_binding)]
     let _netns: Option<()> = None;
 
+    // Install the supervisor seccomp prelude after privileged startup helpers
+    // (network namespace setup, iptables probes) complete, but before the SSH
+    // listener and workload process are exposed.
+    apply_supervisor_startup_hardening()?;
+
     // Shared PID: set after process spawn so the proxy can look up
     // the entrypoint process's /proc/net/tcp for identity binding.
     let entrypoint_pid = Arc::new(AtomicU32::new(0));

--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -97,6 +97,7 @@ use crate::proxy::ProxyHandle;
 use crate::sandbox::linux::netns::NetworkNamespace;
 use crate::secrets::SecretResolver;
 pub use process::{ProcessHandle, ProcessStatus};
+pub use sandbox::apply_supervisor_startup_hardening;
 
 /// Default interval (seconds) for re-fetching the inference route bundle from
 /// the gateway in cluster mode. Override at runtime with the

--- a/crates/openshell-sandbox/src/main.rs
+++ b/crates/openshell-sandbox/src/main.rs
@@ -7,14 +7,14 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use clap::Parser;
-use miette::Result;
+use miette::{IntoDiagnostic, Result};
 use openshell_ocsf::{OcsfJsonlLayer, OcsfShorthandLayer};
 use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::{Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
-use openshell_sandbox::run_sandbox;
+use openshell_sandbox::{apply_supervisor_startup_hardening, run_sandbox};
 
 /// OpenShell Sandbox - process isolation and monitoring.
 #[derive(Parser, Debug)]
@@ -96,8 +96,9 @@ struct Args {
     health_port: u16,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
+    apply_supervisor_startup_hardening()?;
+
     let args = Args::parse();
 
     // Try to open a rolling log file; fall back to stdout-only logging if it fails
@@ -118,116 +119,125 @@ async fn main() -> Result<()> {
     let stdout_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&args.log_level));
 
-    // Install rustls crypto provider before any TLS connections (including log push).
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .into_diagnostic()?;
 
-    // Set up optional log push layer (gRPC mode only).
-    let log_push_state = if let (Some(sandbox_id), Some(endpoint)) =
-        (&args.sandbox_id, &args.openshell_endpoint)
-    {
-        let (tx, handle) =
-            openshell_sandbox::log_push::spawn_log_push_task(endpoint.clone(), sandbox_id.clone());
-        let layer = openshell_sandbox::log_push::LogPushLayer::new(sandbox_id.clone(), tx);
-        Some((layer, handle))
-    } else {
-        None
-    };
-    let push_layer = log_push_state.as_ref().map(|(layer, _)| layer.clone());
-    let _log_push_handle = log_push_state.map(|(_, handle)| handle);
+    let exit_code = runtime.block_on(async move {
+        // Install rustls crypto provider before any TLS connections (including log push).
+        let _ = rustls::crypto::ring::default_provider().install_default();
 
-    // Shared flag: the sandbox poll loop toggles this when the
-    // `ocsf_json_enabled` setting changes. The JSONL layer checks it
-    // on each event and short-circuits when false.
-    let ocsf_enabled = Arc::new(AtomicBool::new(false));
+        // Set up optional log push layer (gRPC mode only).
+        let log_push_state = if let (Some(sandbox_id), Some(endpoint)) =
+            (&args.sandbox_id, &args.openshell_endpoint)
+        {
+            let (tx, handle) = openshell_sandbox::log_push::spawn_log_push_task(
+                endpoint.clone(),
+                sandbox_id.clone(),
+            );
+            let layer = openshell_sandbox::log_push::LogPushLayer::new(sandbox_id.clone(), tx);
+            Some((layer, handle))
+        } else {
+            None
+        };
+        let push_layer = log_push_state.as_ref().map(|(layer, _)| layer.clone());
+        let _log_push_handle = log_push_state.map(|(_, handle)| handle);
 
-    // Keep guards alive for the entire process. When a guard is dropped the
-    // non-blocking writer flushes remaining logs.
-    let (_file_guard, _jsonl_guard) = if let Some((file_writer, file_guard)) = file_logging {
-        let file_filter = EnvFilter::new("info");
+        // Shared flag: the sandbox poll loop toggles this when the
+        // `ocsf_json_enabled` setting changes. The JSONL layer checks it
+        // on each event and short-circuits when false.
+        let ocsf_enabled = Arc::new(AtomicBool::new(false));
 
-        // OCSF JSONL file: rolling appender matching the main log file
-        // (daily rotation, 3 files max). Created eagerly but gated by the
-        // enabled flag — no JSONL is written until ocsf_json_enabled is set.
-        let jsonl_logging = tracing_appender::rolling::RollingFileAppender::builder()
-            .rotation(tracing_appender::rolling::Rotation::DAILY)
-            .filename_prefix("openshell-ocsf")
-            .filename_suffix("log")
-            .max_log_files(3)
-            .build("/var/log")
-            .ok()
-            .map(|roller| {
-                let (writer, guard) = tracing_appender::non_blocking(roller);
-                let layer = OcsfJsonlLayer::new(writer).with_enabled_flag(ocsf_enabled.clone());
-                (layer, guard)
-            });
-        let (jsonl_layer, jsonl_guard) = match jsonl_logging {
-            Some((layer, guard)) => (Some(layer), Some(guard)),
-            None => (None, None),
+        // Keep guards alive for the entire process. When a guard is dropped the
+        // non-blocking writer flushes remaining logs.
+        let (_file_guard, _jsonl_guard) = if let Some((file_writer, file_guard)) = file_logging {
+            let file_filter = EnvFilter::new("info");
+
+            // OCSF JSONL file: rolling appender matching the main log file
+            // (daily rotation, 3 files max). Created eagerly but gated by the
+            // enabled flag — no JSONL is written until ocsf_json_enabled is set.
+            let jsonl_logging = tracing_appender::rolling::RollingFileAppender::builder()
+                .rotation(tracing_appender::rolling::Rotation::DAILY)
+                .filename_prefix("openshell-ocsf")
+                .filename_suffix("log")
+                .max_log_files(3)
+                .build("/var/log")
+                .ok()
+                .map(|roller| {
+                    let (writer, guard) = tracing_appender::non_blocking(roller);
+                    let layer = OcsfJsonlLayer::new(writer).with_enabled_flag(ocsf_enabled.clone());
+                    (layer, guard)
+                });
+            let (jsonl_layer, jsonl_guard) = match jsonl_logging {
+                Some((layer, guard)) => (Some(layer), Some(guard)),
+                None => (None, None),
+            };
+
+            tracing_subscriber::registry()
+                .with(
+                    OcsfShorthandLayer::new(std::io::stdout())
+                        .with_non_ocsf(true)
+                        .with_filter(stdout_filter),
+                )
+                .with(
+                    OcsfShorthandLayer::new(file_writer)
+                        .with_non_ocsf(true)
+                        .with_filter(file_filter),
+                )
+                .with(jsonl_layer.with_filter(LevelFilter::INFO))
+                .with(push_layer.clone())
+                .init();
+            (Some(file_guard), jsonl_guard)
+        } else {
+            tracing_subscriber::registry()
+                .with(
+                    OcsfShorthandLayer::new(std::io::stdout())
+                        .with_non_ocsf(true)
+                        .with_filter(stdout_filter),
+                )
+                .with(push_layer)
+                .init();
+            // Log the warning after the subscriber is initialized
+            warn!("Could not open /var/log for log rotation; using stdout-only logging");
+            (None, None)
         };
 
-        tracing_subscriber::registry()
-            .with(
-                OcsfShorthandLayer::new(std::io::stdout())
-                    .with_non_ocsf(true)
-                    .with_filter(stdout_filter),
-            )
-            .with(
-                OcsfShorthandLayer::new(file_writer)
-                    .with_non_ocsf(true)
-                    .with_filter(file_filter),
-            )
-            .with(jsonl_layer.with_filter(LevelFilter::INFO))
-            .with(push_layer.clone())
-            .init();
-        (Some(file_guard), jsonl_guard)
-    } else {
-        tracing_subscriber::registry()
-            .with(
-                OcsfShorthandLayer::new(std::io::stdout())
-                    .with_non_ocsf(true)
-                    .with_filter(stdout_filter),
-            )
-            .with(push_layer)
-            .init();
-        // Log the warning after the subscriber is initialized
-        warn!("Could not open /var/log for log rotation; using stdout-only logging");
-        (None, None)
-    };
+        // Get command - either from CLI args, environment variable, or default to /bin/bash
+        let command = if !args.command.is_empty() {
+            args.command
+        } else if let Ok(c) = std::env::var("OPENSHELL_SANDBOX_COMMAND") {
+            // Simple shell-like splitting on whitespace
+            c.split_whitespace().map(String::from).collect()
+        } else {
+            vec!["/bin/bash".to_string()]
+        };
 
-    // Get command - either from CLI args, environment variable, or default to /bin/bash
-    let command = if !args.command.is_empty() {
-        args.command
-    } else if let Ok(c) = std::env::var("OPENSHELL_SANDBOX_COMMAND") {
-        // Simple shell-like splitting on whitespace
-        c.split_whitespace().map(String::from).collect()
-    } else {
-        vec!["/bin/bash".to_string()]
-    };
+        info!(command = ?command, "Starting sandbox");
+        // Note: "Starting sandbox" stays as plain info!() since the OCSF context
+        // is not yet initialized at this point (run_sandbox hasn't been called).
+        // The shorthand layer will render it in fallback format.
 
-    info!(command = ?command, "Starting sandbox");
-    // Note: "Starting sandbox" stays as plain info!() since the OCSF context
-    // is not yet initialized at this point (run_sandbox hasn't been called).
-    // The shorthand layer will render it in fallback format.
-
-    let exit_code = run_sandbox(
-        command,
-        args.workdir,
-        args.timeout,
-        args.interactive,
-        args.sandbox_id,
-        args.sandbox,
-        args.openshell_endpoint,
-        args.policy_rules,
-        args.policy_data,
-        args.ssh_listen_addr,
-        args.ssh_handshake_secret,
-        args.ssh_handshake_skew_secs,
-        args.health_check,
-        args.health_port,
-        args.inference_routes,
-        ocsf_enabled,
-    )
-    .await?;
+        run_sandbox(
+            command,
+            args.workdir,
+            args.timeout,
+            args.interactive,
+            args.sandbox_id,
+            args.sandbox,
+            args.openshell_endpoint,
+            args.policy_rules,
+            args.policy_data,
+            args.ssh_listen_addr,
+            args.ssh_handshake_secret,
+            args.ssh_handshake_skew_secs,
+            args.health_check,
+            args.health_port,
+            args.inference_routes,
+            ocsf_enabled,
+        )
+        .await
+    })?;
 
     std::process::exit(exit_code);
 }

--- a/crates/openshell-sandbox/src/main.rs
+++ b/crates/openshell-sandbox/src/main.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::EnvFilter;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::{Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
-use openshell_sandbox::{apply_supervisor_startup_hardening, run_sandbox};
+use openshell_sandbox::run_sandbox;
 
 /// OpenShell Sandbox - process isolation and monitoring.
 #[derive(Parser, Debug)]
@@ -97,8 +97,6 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-    apply_supervisor_startup_hardening()?;
-
     let args = Args::parse();
 
     // Try to open a rolling log file; fall back to stdout-only logging if it fails

--- a/crates/openshell-sandbox/src/sandbox/linux/mod.rs
+++ b/crates/openshell-sandbox/src/sandbox/linux/mod.rs
@@ -43,6 +43,11 @@ pub fn enforce(prepared: PreparedSandbox) -> Result<()> {
     Ok(())
 }
 
+/// Apply the supervisor's early-startup hardening before runtime initialization.
+pub fn apply_supervisor_prelude() -> Result<()> {
+    seccomp::apply_supervisor_prelude()
+}
+
 /// Legacy single-phase apply. Kept for backward compatibility.
 /// New callers should use [`prepare`] + [`enforce`] for correct privilege ordering.
 pub fn apply(policy: &SandboxPolicy, workdir: Option<&str>) -> Result<()> {

--- a/crates/openshell-sandbox/src/sandbox/linux/mod.rs
+++ b/crates/openshell-sandbox/src/sandbox/linux/mod.rs
@@ -43,7 +43,7 @@ pub fn enforce(prepared: PreparedSandbox) -> Result<()> {
     Ok(())
 }
 
-/// Apply the supervisor's early-startup hardening before runtime initialization.
+/// Apply the supervisor seccomp prelude after privileged bootstrap completes.
 pub fn apply_supervisor_prelude() -> Result<()> {
     seccomp::apply_supervisor_prelude()
 }

--- a/crates/openshell-sandbox/src/sandbox/linux/seccomp.rs
+++ b/crates/openshell-sandbox/src/sandbox/linux/seccomp.rs
@@ -25,12 +25,70 @@ use tracing::debug;
 /// Value of `SECCOMP_SET_MODE_FILTER` (linux/seccomp.h).
 const SECCOMP_SET_MODE_FILTER: u64 = 1;
 
+/// Apply the supervisor's early-startup seccomp filter.
+///
+/// This prelude runs before the async runtime, logging, or argument parsing.
+/// It intentionally blocks only the privileged escape primitives that the
+/// supervisor does not need during normal startup.
+pub fn apply_supervisor_prelude() -> Result<()> {
+    let filter = build_supervisor_prelude_filter()?;
+    set_no_new_privs()?;
+    apply_filter(&filter).into_diagnostic()?;
+    Ok(())
+}
+
 pub fn apply(policy: &SandboxPolicy) -> Result<()> {
     let allow_inet = matches!(policy.network.mode, NetworkMode::Proxy | NetworkMode::Allow);
     let main_filter = build_filter(allow_inet)?;
     let clone3_filter = build_clone3_filter()?;
 
-    // Required before applying seccomp filters.
+    set_no_new_privs()?;
+    apply_runtime_filters(&main_filter, &clone3_filter)?;
+
+    Ok(())
+}
+
+fn build_filter(allow_inet: bool) -> Result<seccompiler::BpfProgram> {
+    let rules = build_filter_rules(allow_inet)?;
+    compile_filter(rules, SeccompAction::Errno(libc::EPERM as u32))
+}
+
+fn build_supervisor_prelude_filter() -> Result<seccompiler::BpfProgram> {
+    compile_filter(
+        build_supervisor_prelude_rules(),
+        SeccompAction::Errno(libc::EPERM as u32),
+    )
+}
+
+fn build_supervisor_prelude_rules() -> BTreeMap<i64, Vec<SeccompRule>> {
+    let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
+
+    for syscall in [
+        libc::SYS_mount,
+        libc::SYS_fsopen,
+        libc::SYS_fsconfig,
+        libc::SYS_fsmount,
+        libc::SYS_fspick,
+        libc::SYS_move_mount,
+        libc::SYS_open_tree,
+        libc::SYS_pivot_root,
+        libc::SYS_umount2,
+        libc::SYS_bpf,
+        libc::SYS_perf_event_open,
+        libc::SYS_userfaultfd,
+        libc::SYS_init_module,
+        libc::SYS_finit_module,
+        libc::SYS_delete_module,
+        libc::SYS_kexec_load,
+        libc::SYS_kexec_file_load,
+    ] {
+        rules.entry(syscall).or_default();
+    }
+
+    rules
+}
+
+fn set_no_new_privs() -> Result<()> {
     let rc = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) };
     if rc != 0 {
         return Err(miette::miette!(
@@ -39,25 +97,19 @@ pub fn apply(policy: &SandboxPolicy) -> Result<()> {
         ));
     }
 
-    apply_runtime_filters(&main_filter, &clone3_filter)?;
-
     Ok(())
 }
 
-fn build_filter(allow_inet: bool) -> Result<seccompiler::BpfProgram> {
-    let rules = build_filter_rules(allow_inet)?;
-
+fn compile_filter(
+    rules: BTreeMap<i64, Vec<SeccompRule>>,
+    blocked_action: SeccompAction,
+) -> Result<seccompiler::BpfProgram> {
     let arch = std::env::consts::ARCH
         .try_into()
         .map_err(|_| miette::miette!("Unsupported architecture for seccomp"))?;
 
-    let filter = SeccompFilter::new(
-        rules,
-        SeccompAction::Allow,
-        SeccompAction::Errno(libc::EPERM as u32),
-        arch,
-    )
-    .into_diagnostic()?;
+    let filter =
+        SeccompFilter::new(rules, SeccompAction::Allow, blocked_action, arch).into_diagnostic()?;
 
     filter.try_into().into_diagnostic()
 }
@@ -76,20 +128,7 @@ fn build_filter(allow_inet: bool) -> Result<seccompiler::BpfProgram> {
 fn build_clone3_filter() -> Result<seccompiler::BpfProgram> {
     let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
     rules.entry(libc::SYS_clone3).or_default();
-
-    let arch = std::env::consts::ARCH
-        .try_into()
-        .map_err(|_| miette::miette!("Unsupported architecture for seccomp"))?;
-
-    let filter = SeccompFilter::new(
-        rules,
-        SeccompAction::Allow,
-        SeccompAction::Errno(libc::ENOSYS as u32),
-        arch,
-    )
-    .into_diagnostic()?;
-
-    filter.try_into().into_diagnostic()
+    compile_filter(rules, SeccompAction::Errno(libc::ENOSYS as u32))
 }
 
 /// Install the sandbox seccomp filters in the required order.
@@ -262,6 +301,15 @@ mod tests {
     }
 
     #[test]
+    fn build_supervisor_prelude_filter_compiles() {
+        let filter = build_supervisor_prelude_filter();
+        assert!(
+            filter.is_ok(),
+            "build_supervisor_prelude_filter() should succeed"
+        );
+    }
+
+    #[test]
     fn add_masked_arg_rule_creates_entry() {
         let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
         let result = add_masked_arg_rule(&mut rules, libc::SYS_execveat, 4, 0x1000);
@@ -338,6 +386,57 @@ mod tests {
             assert!(
                 !filter_rules[&syscall].is_empty(),
                 "syscall {syscall} should have conditional rules"
+            );
+        }
+    }
+
+    #[test]
+    fn supervisor_prelude_blocks_expected_syscalls() {
+        let filter_rules = build_supervisor_prelude_rules();
+
+        for syscall in [
+            libc::SYS_mount,
+            libc::SYS_fsopen,
+            libc::SYS_fsconfig,
+            libc::SYS_fsmount,
+            libc::SYS_fspick,
+            libc::SYS_move_mount,
+            libc::SYS_open_tree,
+            libc::SYS_pivot_root,
+            libc::SYS_umount2,
+            libc::SYS_bpf,
+            libc::SYS_perf_event_open,
+            libc::SYS_userfaultfd,
+            libc::SYS_init_module,
+            libc::SYS_finit_module,
+            libc::SYS_delete_module,
+            libc::SYS_kexec_load,
+            libc::SYS_kexec_file_load,
+        ] {
+            assert!(
+                filter_rules.contains_key(&syscall),
+                "syscall {syscall} should be in the supervisor prelude rules"
+            );
+            assert!(
+                filter_rules[&syscall].is_empty(),
+                "syscall {syscall} should be unconditionally blocked in the supervisor prelude"
+            );
+        }
+    }
+
+    #[test]
+    fn supervisor_prelude_keeps_required_setup_syscalls_available() {
+        let filter_rules = build_supervisor_prelude_rules();
+
+        for syscall in [
+            libc::SYS_setns,
+            libc::SYS_clone,
+            libc::SYS_unshare,
+            libc::SYS_ptrace,
+        ] {
+            assert!(
+                !filter_rules.contains_key(&syscall),
+                "syscall {syscall} should remain available during supervisor startup"
             );
         }
     }
@@ -446,6 +545,46 @@ mod tests {
     fn behavioral_setns_blocked() {
         let filter = build_filter(true).unwrap();
         unsafe { assert_blocked_in_child(&filter, libc::SYS_setns, libc::EPERM) };
+    }
+
+    #[test]
+    fn behavioral_supervisor_prelude_mount_blocked() {
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0, "fork failed");
+        if pid == 0 {
+            unsafe {
+                if let Err(err) = apply_supervisor_prelude() {
+                    let msg = format!("failed to install supervisor prelude: {err}\n");
+                    libc::write(2, msg.as_ptr().cast(), msg.len());
+                    libc::_exit(1);
+                }
+                let ret = libc::syscall(
+                    libc::SYS_mount,
+                    std::ptr::null::<libc::c_char>(),
+                    std::ptr::null::<libc::c_char>(),
+                    std::ptr::null::<libc::c_char>(),
+                    0 as libc::c_ulong,
+                    std::ptr::null::<libc::c_void>(),
+                );
+                let errno = *libc::__errno_location();
+                if ret == -1 && errno == libc::EPERM {
+                    libc::_exit(0);
+                } else {
+                    let msg = format!(
+                        "mount: expected EPERM after supervisor prelude, got ret={ret} errno={errno}\n"
+                    );
+                    libc::write(2, msg.as_ptr().cast(), msg.len());
+                    libc::_exit(1);
+                }
+            }
+        }
+
+        let mut status: libc::c_int = 0;
+        unsafe { libc::waitpid(pid, &mut status, 0) };
+        assert!(
+            unsafe { libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0 },
+            "mount should be blocked by the supervisor prelude filter"
+        );
     }
 
     #[test]

--- a/crates/openshell-sandbox/src/sandbox/linux/seccomp.rs
+++ b/crates/openshell-sandbox/src/sandbox/linux/seccomp.rs
@@ -16,7 +16,7 @@ use crate::policy::{NetworkMode, SandboxPolicy};
 use miette::{IntoDiagnostic, Result};
 use seccompiler::{
     SeccompAction, SeccompCmpArgLen, SeccompCmpOp, SeccompCondition, SeccompFilter, SeccompRule,
-    apply_filter,
+    apply_filter, apply_filter_all_threads,
 };
 use std::collections::BTreeMap;
 use std::convert::TryInto;
@@ -25,15 +25,16 @@ use tracing::debug;
 /// Value of `SECCOMP_SET_MODE_FILTER` (linux/seccomp.h).
 const SECCOMP_SET_MODE_FILTER: u64 = 1;
 
-/// Apply the supervisor's early-startup seccomp filter.
+/// Apply the supervisor seccomp filter across the running process.
 ///
-/// This prelude runs before the async runtime, logging, or argument parsing.
-/// It intentionally blocks only the privileged escape primitives that the
-/// supervisor does not need during normal startup.
+/// This runs after privileged startup helpers complete and synchronizes the
+/// filter across all supervisor threads via TSYNC. It intentionally blocks
+/// only the privileged escape primitives that the long-lived supervisor no
+/// longer needs once bootstrap is complete.
 pub fn apply_supervisor_prelude() -> Result<()> {
     let filter = build_supervisor_prelude_filter()?;
     set_no_new_privs()?;
-    apply_filter(&filter).into_diagnostic()?;
+    apply_filter_all_threads(&filter).into_diagnostic()?;
     Ok(())
 }
 

--- a/crates/openshell-sandbox/src/sandbox/mod.rs
+++ b/crates/openshell-sandbox/src/sandbox/mod.rs
@@ -39,7 +39,7 @@ pub fn apply(policy: &SandboxPolicy, workdir: Option<&str>) -> Result<()> {
     }
 }
 
-/// Apply startup hardening for the supervisor process itself.
+/// Apply seccomp hardening for the long-lived supervisor process itself.
 #[cfg_attr(not(target_os = "linux"), allow(clippy::unnecessary_wraps))]
 pub fn apply_supervisor_startup_hardening() -> Result<()> {
     #[cfg(target_os = "linux")]

--- a/crates/openshell-sandbox/src/sandbox/mod.rs
+++ b/crates/openshell-sandbox/src/sandbox/mod.rs
@@ -38,3 +38,17 @@ pub fn apply(policy: &SandboxPolicy, workdir: Option<&str>) -> Result<()> {
         Ok(())
     }
 }
+
+/// Apply startup hardening for the supervisor process itself.
+#[cfg_attr(not(target_os = "linux"), allow(clippy::unnecessary_wraps))]
+pub fn apply_supervisor_startup_hardening() -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        linux::apply_supervisor_prelude()
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Ok(())
+    }
+}

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -194,12 +194,13 @@ The sandbox process runs as a non-root user after explicit privilege dropping.
 
 ### Seccomp Filters
 
-A BPF seccomp filter restricts which socket domains the sandbox process can use and blocks a denylist of syscalls that enable container escape, privilege escalation, or host observation. The sandbox sets `PR_SET_NO_NEW_PRIVS` before applying the filter.
+OpenShell applies seccomp in two phases. A narrow supervisor-startup prelude runs before CLI parsing and async runtime initialization, then the child process receives the broader runtime seccomp filter after privilege drop.
 
 | Aspect | Detail |
 |---|---|
+| Startup prelude | Before the supervisor initializes the runtime, it sets `PR_SET_NO_NEW_PRIVS` and blocks `mount`, the new mount API syscalls, `pivot_root`, `umount2`, `bpf`, `perf_event_open`, `userfaultfd`, module-loading syscalls, and kexec. This closes the privileged remount and kernel-surface window while leaving required setup syscalls such as `setns` available. |
 | Socket domains | The filter allows `AF_INET` and `AF_INET6` (for proxy communication) and blocks `AF_NETLINK`, `AF_PACKET`, `AF_BLUETOOTH`, and `AF_VSOCK` with `EPERM`. |
-| Unconditional syscall blocks | `memfd_create`, `ptrace`, `bpf`, `process_vm_readv`, `process_vm_writev`, `pidfd_open`, `pidfd_getfd`, `pidfd_send_signal`, `io_uring_setup`, `mount`, `fsopen`, `fsconfig`, `fsmount`, `fspick`, `move_mount`, `open_tree`, `setns`, `umount2`, `pivot_root`, `userfaultfd`, `perf_event_open`. |
+| Runtime unconditional syscall blocks | `memfd_create`, `ptrace`, `bpf`, `process_vm_readv`, `process_vm_writev`, `pidfd_open`, `pidfd_getfd`, `pidfd_send_signal`, `io_uring_setup`, `mount`, `fsopen`, `fsconfig`, `fsmount`, `fspick`, `move_mount`, `open_tree`, `setns`, `umount2`, `pivot_root`, `userfaultfd`, `perf_event_open`. |
 | Conditional syscall blocks | `execveat` with `AT_EMPTY_PATH`, `unshare` and `clone` with `CLONE_NEWUSER`, and `seccomp(SECCOMP_SET_MODE_FILTER)` are denied with `EPERM`. |
 | What you can change | This is not a user-facing knob. OpenShell enforces it automatically. |
 | Risk if relaxed | The blocked syscalls support container escape (`mount`, `pivot_root`, `move_mount`, namespace creation), cross-process observation (`ptrace`, `process_vm_readv`, `pidfd_*`), raw kernel bypass (`bpf`, `io_uring_setup`, `perf_event_open`), and filter evasion (`seccomp`, `userfaultfd`). |
@@ -208,13 +209,14 @@ A BPF seccomp filter restricts which socket domains the sandbox process can use 
 ### Enforcement Application Order
 
 The sandbox supervisor applies enforcement in a specific order during process startup.
-This ordering is intentional: privilege dropping needs `/etc/group` and `/etc/passwd`, which Landlock subsequently restricts.
+This ordering is intentional: the startup prelude must run before runtime initialization, and privilege dropping still needs `/etc/group` and `/etc/passwd`, which Landlock subsequently restricts.
 
-1. Network namespace entry (`setns`).
-2. Privilege drop (`initgroups` + `setgid` + `setuid`).
-3. Core-dump hardening (`RLIMIT_CORE=0`, plus `PR_SET_DUMPABLE=0` on Linux).
-4. Landlock filesystem restrictions.
-5. Seccomp socket domain filters.
+1. Supervisor startup prelude seccomp (`PR_SET_NO_NEW_PRIVS` plus the early syscall denylist).
+2. Network namespace entry (`setns`).
+3. Privilege drop (`initgroups` + `setgid` + `setuid`).
+4. Core-dump hardening (`RLIMIT_CORE=0`, plus `PR_SET_DUMPABLE=0` on Linux).
+5. Landlock filesystem restrictions.
+6. Runtime seccomp socket domain and syscall filters.
 
 ## Inference Controls
 

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -198,7 +198,7 @@ OpenShell applies seccomp in two phases. A narrow supervisor-startup prelude run
 
 | Aspect | Detail |
 |---|---|
-| Startup prelude | Before the supervisor initializes the runtime, it sets `PR_SET_NO_NEW_PRIVS` and blocks `mount`, the new mount API syscalls, `pivot_root`, `umount2`, `bpf`, `perf_event_open`, `userfaultfd`, module-loading syscalls, and kexec. This closes the privileged remount and kernel-surface window while leaving required setup syscalls such as `setns` available. |
+| Startup prelude | After privileged bootstrap helpers complete, the supervisor sets `PR_SET_NO_NEW_PRIVS` and synchronizes a seccomp filter across all runtime threads that blocks `mount`, the new mount API syscalls, `pivot_root`, `umount2`, `bpf`, `perf_event_open`, `userfaultfd`, module-loading syscalls, and kexec. This closes the long-lived privileged remount and kernel-surface window while leaving required setup syscalls such as `setns` available. |
 | Socket domains | The filter allows `AF_INET` and `AF_INET6` (for proxy communication) and blocks `AF_NETLINK`, `AF_PACKET`, `AF_BLUETOOTH`, and `AF_VSOCK` with `EPERM`. |
 | Runtime unconditional syscall blocks | `memfd_create`, `ptrace`, `bpf`, `process_vm_readv`, `process_vm_writev`, `pidfd_open`, `pidfd_getfd`, `pidfd_send_signal`, `io_uring_setup`, `mount`, `fsopen`, `fsconfig`, `fsmount`, `fspick`, `move_mount`, `open_tree`, `setns`, `umount2`, `pivot_root`, `userfaultfd`, `perf_event_open`. |
 | Conditional syscall blocks | `execveat` with `AT_EMPTY_PATH`, `unshare` and `clone` with `CLONE_NEWUSER`, and `seccomp(SECCOMP_SET_MODE_FILTER)` are denied with `EPERM`. |
@@ -209,14 +209,15 @@ OpenShell applies seccomp in two phases. A narrow supervisor-startup prelude run
 ### Enforcement Application Order
 
 The sandbox supervisor applies enforcement in a specific order during process startup.
-This ordering is intentional: the startup prelude must run before runtime initialization, and privilege dropping still needs `/etc/group` and `/etc/passwd`, which Landlock subsequently restricts.
+This ordering is intentional: named network-namespace setup still relies on privileged helpers, and privilege dropping still needs `/etc/group` and `/etc/passwd`, which Landlock subsequently restricts.
 
-1. Supervisor startup prelude seccomp (`PR_SET_NO_NEW_PRIVS` plus the early syscall denylist).
-2. Network namespace entry (`setns`).
-3. Privilege drop (`initgroups` + `setgid` + `setuid`).
-4. Core-dump hardening (`RLIMIT_CORE=0`, plus `PR_SET_DUMPABLE=0` on Linux).
-5. Landlock filesystem restrictions.
-6. Runtime seccomp socket domain and syscall filters.
+1. Privileged supervisor bootstrap helpers, including network-namespace setup and optional `iptables` probes.
+2. Supervisor startup prelude seccomp (`PR_SET_NO_NEW_PRIVS` plus the early syscall denylist) synchronized across runtime threads.
+3. Network namespace entry (`setns`) in child `pre_exec`.
+4. Privilege drop (`initgroups` + `setgid` + `setuid`).
+5. Core-dump hardening (`RLIMIT_CORE=0`, plus `PR_SET_DUMPABLE=0` on Linux).
+6. Landlock filesystem restrictions.
+7. Runtime seccomp socket domain and syscall filters.
 
 ## Inference Controls
 


### PR DESCRIPTION
## Summary

Apply a narrow seccomp prelude in `openshell-sandbox` before CLI parsing and async runtime initialization so the supervisor blocks privileged remount and kernel-surface syscalls at startup.

Update the sandbox docs to reflect the new two-phase seccomp model and startup enforcement order.

## Related Issue

closes OS-119

## Changes

- add a Linux supervisor-startup seccomp prelude and expose it through a public startup hardening hook
- replace `#[tokio::main]` with an explicit Tokio runtime so supervisor hardening runs before Clap, logging, and runtime setup
- add coverage for the new prelude rule set and document the updated startup hardening behavior

## Testing

Additional validation run:
- `cargo fmt --all`
- `cargo run -p openshell-sandbox -- --help`
- `mise run pre-commit` was run, but it does not pass in this local workspace for unrelated reasons:
  - missing SPDX headers in `architecture/plans/567-*`
  - missing local `z3` linker dependency while building `openshell-prover` tests
- Linux-target verification remains incomplete locally because `x86_64-linux-gnu-gcc` is not installed on this machine

- [ ] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
