### PR TITLE
feat(server): serve health endpoints on separate unauthenticated port

### DIFF
--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -57,6 +57,10 @@ pub struct Config {
     #[serde(default = "default_bind_address")]
     pub bind_address: SocketAddr,
 
+    /// Address to bind the unauthenticated health endpoint to.
+    #[serde(default = "default_health_bind_address")]
+    pub health_bind_address: SocketAddr,
+
     /// Log level (trace, debug, info, warn, error).
     #[serde(default = "default_log_level")]
     pub log_level: String,
@@ -168,6 +172,7 @@ impl Config {
     pub fn new(tls: Option<TlsConfig>) -> Self {
         Self {
             bind_address: default_bind_address(),
+            health_bind_address: default_health_bind_address(),
             log_level: default_log_level(),
             tls,
             database_url: String::new(),
@@ -192,6 +197,12 @@ impl Config {
     #[must_use]
     pub const fn with_bind_address(mut self, addr: SocketAddr) -> Self {
         self.bind_address = addr;
+        self
+    }
+
+    #[must_use]
+    pub const fn with_health_bind_address(mut self, addr: SocketAddr) -> Self {
+        self.health_bind_address = addr;
         self
     }
 
@@ -313,6 +324,10 @@ impl Config {
 
 fn default_bind_address() -> SocketAddr {
     "0.0.0.0:8080".parse().expect("valid default address")
+}
+
+fn default_health_bind_address() -> SocketAddr {
+    "0.0.0.0:8081".parse().expect("valid default address")
 }
 
 fn default_log_level() -> String {

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -23,6 +23,10 @@ struct Args {
     #[arg(long, default_value_t = 8080, env = "OPENSHELL_SERVER_PORT")]
     port: u16,
 
+    /// Port for unauthenticated health endpoints (healthz, readyz).
+    #[arg(long, default_value_t = 8081, env = "OPENSHELL_HEALTH_PORT")]
+    health_port: u16,
+
     /// Log level (trace, debug, info, warn, error).
     #[arg(long, default_value = "info", env = "OPENSHELL_LOG_LEVEL")]
     log_level: String,
@@ -197,6 +201,14 @@ async fn run_from_args(args: Args) -> Result<()> {
     );
 
     let bind = SocketAddr::from(([0, 0, 0, 0], args.port));
+    let health_bind = SocketAddr::from(([0, 0, 0, 0], args.health_port));
+
+    if args.port == args.health_port {
+        return Err(miette::miette!(
+            "--port and --health-port must be different (both set to {})",
+            args.port
+        ));
+    }
 
     let tls = if args.disable_tls {
         None
@@ -224,6 +236,7 @@ async fn run_from_args(args: Args) -> Result<()> {
 
     let mut config = openshell_core::Config::new(tls)
         .with_bind_address(bind)
+        .with_health_bind_address(health_bind)
         .with_log_level(&args.log_level);
 
     config = config

--- a/crates/openshell-server/src/http.rs
+++ b/crates/openshell-server/src/http.rs
@@ -47,8 +47,7 @@ pub fn health_router() -> Router {
 
 /// Create the HTTP router.
 pub fn http_router(state: Arc<crate::ServerState>) -> Router {
-    health_router()
-        .merge(crate::ssh_tunnel::router(state.clone()))
+    crate::ssh_tunnel::router(state.clone())
         .merge(crate::ws_tunnel::router(state.clone()))
         .merge(crate::auth::router(state))
 }

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -176,6 +176,22 @@ pub async fn run_server(
 
     info!(address = %config.bind_address, "Server listening");
 
+    // Bind the unauthenticated health endpoint on a separate port.
+    let health_listener = TcpListener::bind(config.health_bind_address)
+        .await
+        .map_err(|e| {
+            Error::transport(format!(
+                "failed to bind health port {}: {e}",
+                config.health_bind_address
+            ))
+        })?;
+    info!(address = %config.health_bind_address, "Health server listening");
+    tokio::spawn(async move {
+        if let Err(e) = axum::serve(health_listener, health_router().into_make_service()).await {
+            error!("Health server error: {e}");
+        }
+    });
+
     // Build TLS acceptor when TLS is configured; otherwise serve plaintext.
     let tls_acceptor = if let Some(tls) = &config.tls {
         Some(TlsAcceptor::from_files(

--- a/deploy/docker/cluster-healthcheck.sh
+++ b/deploy/docker/cluster-healthcheck.sh
@@ -78,5 +78,7 @@ kubectl -n openshell get secret openshell-ssh-handshake >/dev/null 2>&1 || exit 
 # iptables rules for NodePort routing.  Without this check the health check
 # can pass before the port is routable, causing "Connection refused" on the
 # host-mapped port.
+# Use </dev/tcp (no echo) to avoid sending plaintext bytes into the TLS
+# listener, which would log InvalidContentType errors in the gateway.
 # ---------------------------------------------------------------------------
-timeout 2 bash -c 'echo >/dev/tcp/127.0.0.1/30051' 2>/dev/null || exit 1
+timeout 2 bash -c 'exec 3<>/dev/tcp/127.0.0.1/30051 && exec 3>&-' 2>/dev/null || exit 1

--- a/deploy/helm/openshell/templates/statefulset.yaml
+++ b/deploy/helm/openshell/templates/statefulset.yaml
@@ -49,6 +49,8 @@ spec:
           args:
             - --port
             - {{ .Values.service.port | quote }}
+            - --health-port
+            - {{ .Values.service.healthPort | quote }}
             - --log-level
             - {{ .Values.server.logLevel }}
             - --db-url
@@ -113,22 +115,28 @@ spec:
             - name: grpc
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            - name: health
+              containerPort: {{ .Values.service.healthPort }}
+              protocol: TCP
           startupProbe:
-            tcpSocket:
-              port: grpc
+            httpGet:
+              path: /healthz
+              port: health
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
             failureThreshold: {{ .Values.probes.startup.failureThreshold }}
           livenessProbe:
-            tcpSocket:
-              port: grpc
+            httpGet:
+              path: /healthz
+              port: health
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
           readinessProbe:
-            tcpSocket:
-              port: grpc
+            httpGet:
+              path: /readyz
+              port: health
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -37,6 +37,7 @@ service:
   type: NodePort
   port: 8080
   nodePort: 30051
+  healthPort: 8081
 
 # Pod restart behavior and health probe tuning.
 podLifecycle:


### PR DESCRIPTION
## Summary

Move `/health`, `/healthz`, and `/readyz` to a dedicated plaintext HTTP port (default 8081) so Kubernetes probes work without mTLS client certificates. Also fixes the Docker cluster healthcheck to avoid sending plaintext bytes into the TLS listener.

## Related Issue

Fixes #897

## Changes

- Add `health_bind_address` to `Config` with `--health-port` CLI arg (default 8081, env `OPENSHELL_HEALTH_PORT`)
- Spawn standalone `axum::serve` for `health_router` on the health port (plain HTTP, no TLS)
- Remove health routes from the main multiplexed HTTP router
- Add port-collision validation (`--port` vs `--health-port`)
- Update Helm statefulset: add `health` container port, switch all probes from `tcpSocket` to `httpGet` on health port
- Fix `cluster-healthcheck.sh` to open/close TCP without sending data, avoiding `InvalidContentType` TLS errors

## Testing

- [x] `cargo check -p openshell-core -p openshell-server` passes
- [x] `cargo test -p openshell-core -p openshell-server --lib` passes (223 tests)
- [x] Verified health server listens on 8081 in running cluster
- [x] Verified Kubernetes probes correctly target health port
- [x] Identified and fixed `cluster-healthcheck.sh` as source of remaining TLS errors
- [ ] E2E tests (`mise run e2e`)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)