### PR TITLE
Openshell driver podman

### DIFF
--- a/.agents/skills/debug-openshell-cluster/SKILL.md
+++ b/.agents/skills/debug-openshell-cluster/SKILL.md
@@ -299,15 +299,13 @@ Common issues:
 
 ### Step 9: Check DNS Resolution
 
-> **Scope:** This step covers DNS for the **cluster infrastructure** (k3s, CoreDNS, image pulls). It is entirely separate from DNS enforcement for agent workloads running inside sandboxes — see the note at the end of this section.
-
-DNS misconfiguration is a common root cause of cluster startup failures, especially on remote/Linux hosts:
+DNS misconfiguration is a common root cause, especially on remote/Linux hosts:
 
 ```bash
-# Check the resolv.conf k3s is using
+# Check the resolv.conf k3s is using for pod DNS
 openshell doctor exec -- cat /etc/rancher/k3s/resolv.conf
 
-# Test DNS resolution from inside the container
+# Test DNS from inside the container
 openshell doctor exec -- sh -c 'nslookup google.com || wget -q -O /dev/null http://google.com && echo "network ok" || echo "network unreachable"'
 ```
 
@@ -317,20 +315,22 @@ Check the entrypoint's DNS decision in the container logs:
 openshell doctor logs --lines 20
 ```
 
-The entrypoint script (`cluster-entrypoint.sh`) uses a single DNS strategy with one fallback:
+The entrypoint (`cluster-entrypoint.sh`) sets k3s pod DNS via a single strategy with one fallback:
 
-1. **Primary — Docker DNS proxy**: `setup_dns_proxy()` reads the `DOCKER_OUTPUT` iptables chain to find the ports where Docker's embedded DNS (`127.0.0.11`) is actually listening, then installs DNAT rules so k3s pods (which run in separate network namespaces and cannot reach `127.0.0.11` directly via OUTPUT rules) can reach it via the container's `eth0` IP. On success, writes `nameserver <eth0-ip>` to `/etc/rancher/k3s/resolv.conf`.
-2. **Fallback — public DNS**: If `setup_dns_proxy()` fails for any reason (chain not found, no `eth0` IP), writes `nameserver 8.8.8.8` / `nameserver 8.8.4.4` to `/etc/rancher/k3s/resolv.conf`.
+1. **Docker DNS proxy** (`setup_dns_proxy()`): reads the `DOCKER_OUTPUT` iptables chain to discover where Docker's embedded DNS (`127.0.0.11`) is actually listening, installs DNAT rules so k3s pods can reach it via the container's `eth0` IP, and writes `nameserver <eth0-ip>` to `/etc/rancher/k3s/resolv.conf`. On success logs: `Setting up DNS proxy: <ip>:53 -> 127.0.0.11`.
+2. **Public DNS fallback**: if `setup_dns_proxy()` fails for any reason, logs `Warning: Could not discover Docker DNS ports from iptables` and writes `nameserver 8.8.8.8` / `nameserver 8.8.4.4` to `/etc/rancher/k3s/resolv.conf`.
 
-**Under Docker**, `setup_dns_proxy()` succeeds when the `DOCKER_OUTPUT` iptables chain exists (standard Docker custom networks). If it fails, the public DNS fallback is used and a warning is logged.
+After either path, `verify_dns()` runs `nslookup` (5 retries) against the configured registry host (default `ghcr.io`). On failure it emits `DNS_PROBE_FAILED` into the logs. The Rust-side bootstrap (`runtime.rs` / `lib.rs`) watches for this marker and aborts early rather than spinning for the full 6-minute timeout.
 
-**Under rootless Podman**, the `DOCKER_OUTPUT` iptables chain does not exist — Podman uses Aardvark DNS on the bridge gateway IP for custom networks, not Docker's embedded resolver. `setup_dns_proxy()` will always fail with `Warning: Could not discover Docker DNS ports from iptables` and the fallback to `8.8.8.8`/`8.8.4.4` always applies. DNS works on most Linux hosts because public DNS is reachable, but fails on networks that block external UDP port 53 (e.g. corporate firewalls or restricted VPNs). If DNS fails under Podman, verify that `8.8.8.8:53` (UDP) is reachable from the host — the container does not inherit the host's `/etc/resolv.conf`.
+**Important:** there are two independent DNS paths inside the cluster container. The entrypoint only writes `/etc/rancher/k3s/resolv.conf` (pod DNS). The container's system `/etc/resolv.conf` (used by containerd for image pulls and by `nslookup`) is set by Docker or Podman at container start and is never touched by the entrypoint. These can point at different nameservers.
 
-After either path, `verify_dns()` runs an `nslookup` probe against the configured registry host (defaulting to `ghcr.io`). Failure emits a `DNS_PROBE_FAILED` marker in the logs, which the Rust-side bootstrap polling loop detects to abort early with a clear error instead of spinning for minutes.
+**Under Podman:** `setup_dns_proxy()` always fails — Podman does not create a `DOCKER_OUTPUT` chain. k3s pod DNS always falls back to `8.8.8.8`/`8.8.4.4`. The cluster container runs on a named Podman bridge network, which uses **netavark + aardvark-dns**. Aardvark-dns listens on the bridge gateway IP (e.g. `10.89.x.1`) and forwards external queries to the host resolver. Podman sets the container's system `/etc/resolv.conf` to that address — so `nslookup ghcr.io` works fine even when `8.8.8.8` is blocked. This means **`DNS_PROBE_FAILED` is never emitted under Podman** even when pod-level DNS is broken: the entrypoint's `verify_dns()` and the Rust-side `probe_container_dns()` both call bare `nslookup`, which hits aardvark-dns via the system resolv.conf, not the k3s resolv.conf. Pod DNS failures surface later as CoreDNS upstream forwarding timeouts, not as an early bootstrap abort.
+
+To debug Podman pod DNS failures: check `/etc/rancher/k3s/resolv.conf` confirms `8.8.8.8` is there, then verify `8.8.8.8:53` UDP is reachable from the host with `nc -vzu 8.8.8.8 53`.
 
 If DNS is broken, all image pulls from the distribution registry will fail, as will pods that need external network access.
 
-> **Sandbox agent DNS is a different layer entirely.** The cluster DNS described above has no effect on what agent workloads running inside sandboxes can resolve. The sandbox supervisor (`openshell-sandbox`) creates a Linux network namespace with a veth pair and installs iptables rules inside it that REJECT all outbound UDP (including port 53) except traffic to the proxy. Agent workloads cannot make raw DNS queries regardless of what nameservers are configured — DNS must go through the HTTP CONNECT proxy. This is a kernel-enforced boundary, not a configuration setting. The bypass monitor logs and REJECTs any direct DNS attempt with the hint: *"DNS queries should route through the sandbox proxy; check resolver configuration"*.
+**Sandbox agent DNS is a separate enforcement layer.** The cluster DNS above controls what k3s pods and containerd can resolve. It has no bearing on what agent workloads inside sandboxes can reach. The sandbox supervisor (`openshell-sandbox`) creates an isolated Linux network namespace for each agent process with a veth pair, then installs iptables rules inside that namespace that REJECT all outbound UDP — including port 53 — except traffic destined for the supervisor's CONNECT proxy. Agent workloads cannot make raw DNS queries regardless of what nameservers are configured anywhere in the cluster. DNS must go through the HTTP CONNECT proxy. This is a kernel-enforced boundary at the netns level, not a configuration setting. The bypass monitor detects and logs any direct DNS attempt with the hint: `"DNS queries should route through the sandbox proxy; check resolver configuration"`.
 
 ## Common Failure Patterns
 
@@ -361,7 +361,7 @@ If DNS is broken, all image pulls from the distribution registry will fail, as w
 | Port conflict | Another service on the configured gateway host port (default 8080) | Stop conflicting service or use `--port` on `openshell gateway start` to pick a different host port |
 | gRPC connect refused to `127.0.0.1:443` in CI | Docker daemon is remote (`DOCKER_HOST=tcp://...`) but metadata still points to loopback | Verify metadata endpoint host matches `DOCKER_HOST` and includes non-loopback host |
 | DNS failures inside container (Docker) | `setup_dns_proxy()` failed to find `DOCKER_OUTPUT` iptables chain | `openshell doctor logs --lines 20` for `Warning: Could not discover Docker DNS ports`; try `docker network prune -f` and redeploy |
-| DNS failures inside container (Podman) | `setup_dns_proxy()` always fails under Podman; public DNS fallback (`8.8.8.8`) is used but unreachable | Verify `8.8.8.8:53` UDP is reachable from the host; `openshell doctor exec -- cat /etc/rancher/k3s/resolv.conf` to confirm fallback is in place |
+| Pod external name resolution fails (Podman) | `setup_dns_proxy()` always fails under Podman; k3s resolv.conf falls back to `8.8.8.8`/`8.8.4.4`, which is blocked on this network | `DNS_PROBE_FAILED` will NOT appear — entrypoint and Rust-side probes resolve via aardvark-dns (system `/etc/resolv.conf`), not the k3s resolv.conf; check `openshell doctor exec -- cat /etc/rancher/k3s/resolv.conf` to confirm fallback; verify `8.8.8.8:53` UDP reachable from host via `nc -vzu 8.8.8.8 53` |
 | Pods can't reach kube-dns / ClusterIP services | `br_netfilter` not loaded; bridge traffic bypasses iptables DNAT rules | `sudo modprobe br_netfilter` on the host, then `echo br_netfilter \| sudo tee /etc/modules-load.d/br_netfilter.conf` to persist. Known to be required on Jetson Linux 5.15-tegra; other kernels (e.g. standard x86/aarch64 Linux) may have bridge netfilter built in and work without the module. The entrypoint logs a warning when `/proc/sys/net/bridge/bridge-nf-call-iptables` is absent but does not abort — only act on it if DNS or service connectivity is actually broken. |
 | Node DiskPressure / MemoryPressure / PIDPressure | Insufficient disk, memory, or PIDs on host | Free disk (`docker system prune -a --volumes`), increase memory, or expand host resources. Bootstrap auto-detects via `HEALTHCHECK_NODE_PRESSURE` marker |
 | Pods evicted with "The node had condition: [DiskPressure]" | Host disk full, kubelet evicting pods | Free disk space on host, then `openshell gateway destroy <name> && openshell gateway start` |

--- a/.agents/skills/debug-openshell-cluster/SKILL.md
+++ b/.agents/skills/debug-openshell-cluster/SKILL.md
@@ -7,16 +7,16 @@ description: Debug why a openshell cluster failed to start or is unhealthy. Use 
 
 Diagnose why a openshell cluster failed to start after `openshell gateway start`.
 
-Use **only** `openshell` CLI commands (`openshell status`, `openshell doctor logs`, `openshell doctor exec`) to inspect and fix the cluster. Do **not** use raw `docker`, `ssh`, or `kubectl` commands directly — always go through the `openshell doctor` interface. The CLI auto-resolves local vs remote gateways, so the same commands work everywhere.
+Use **only** `openshell` CLI commands (`openshell status`, `openshell doctor logs`, `openshell doctor exec`) to inspect and fix the cluster. Do **not** use raw `docker`, `podman`, `ssh`, or `kubectl` commands directly — always go through the `openshell doctor` interface. The CLI auto-resolves local vs remote gateways, so the same commands work everywhere.
 
 ## Overview
 
-`openshell gateway start` creates a Docker container running k3s with the OpenShell server deployed via Helm. The deployment stages, in order, are:
+`openshell gateway start` creates a container (via Docker or Podman) running k3s with the OpenShell server deployed via Helm. The build and deploy scripts use a container-engine abstraction layer (`tasks/scripts/container-engine.sh`) that auto-detects Docker or Podman and provides a unified `ce` command interface. Set `CONTAINER_ENGINE=docker` or `CONTAINER_ENGINE=podman` to override auto-detection. The deployment stages, in order, are:
 
 1. **Pre-deploy check**: `openshell gateway start` in interactive mode prompts to **reuse** (keep volume, clean stale nodes) or **recreate** (destroy everything, fresh start). `mise run cluster` always recreates before deploy.
 2. Ensure cluster image is available (local build or remote pull)
-3. Create Docker network (`openshell-cluster`) and volume (`openshell-cluster-{name}`)
-4. Create and start a privileged Docker container (`openshell-cluster-{name}`)
+3. Create container network (`openshell-cluster`) and volume (`openshell-cluster-{name}`)
+4. Create and start a privileged container (`openshell-cluster-{name}`)
 5. Wait for k3s to generate kubeconfig (up to 60s)
 6. **Clean stale nodes**: Remove any `NotReady` k3s nodes left over from previous container instances that reused the same persistent volume
 7. **Prepare local images** (if `OPENSHELL_PUSH_IMAGES` is set): In `internal` registry mode, bootstrap waits for the in-cluster registry and pushes tagged images there. In `external` mode, bootstrap uses legacy `ctr -n k8s.io images import` push-mode behavior.
@@ -28,10 +28,11 @@ Use **only** `openshell` CLI commands (`openshell status`, `openshell doctor log
     - TLS secrets `openshell-server-tls` and `openshell-client-tls` exist in `openshell` namespace
     - Sandbox supervisor binary exists at `/opt/openshell/bin/openshell-sandbox` (emits `HEALTHCHECK_MISSING_SUPERVISOR` marker if absent)
 
-For local deploys, metadata endpoint selection now depends on Docker connectivity:
+For local deploys, metadata endpoint selection depends on the container engine and its connectivity:
 
 - default local Docker socket (`unix:///var/run/docker.sock`): `https://127.0.0.1:{port}` (default port 8080)
 - TCP Docker daemon (`DOCKER_HOST=tcp://<host>:<port>`): `https://<host>:{port}` for non-loopback hosts
+- Podman (rootless): `https://127.0.0.1:{port}` via `host.containers.internal` (the Podman equivalent of `host.docker.internal`)
 
 The host port is configurable via `--port` on `openshell gateway start` (default 8080) and is stored in `ClusterMetadata.gateway_port`.
 
@@ -41,7 +42,8 @@ The default cluster name is `openshell`. The container is `openshell-cluster-{na
 
 ## Prerequisites
 
-- Docker must be running (locally or on the remote host)
+- Docker or Podman must be running (locally or on the remote host). The build system auto-detects which engine is available; set `CONTAINER_ENGINE=docker` or `CONTAINER_ENGINE=podman` to override.
+- For rootless Podman: ensure the Podman socket is active (`systemctl --user start podman.socket`) and subuid/subgid ranges are configured (`sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $(whoami)`)
 - The `openshell` CLI must be available
 - For remote clusters: SSH access to the remote host
 
@@ -320,6 +322,8 @@ The entrypoint script selects DNS resolvers in this priority:
 3. Host gateway IP (Docker Desktop only, `192.168.*`)
 4. Fallback to `8.8.8.8` / `8.8.4.4`
 
+**Podman note:** Rootless Podman uses pasta (or slirp4netns) for network connectivity, which has different DNS behavior than Docker's built-in DNS at `127.0.0.11`. DNS resolution inside Podman containers typically inherits the host's `/etc/resolv.conf` directly. If DNS fails inside a Podman-managed cluster container, check the host's DNS configuration first.
+
 If DNS is broken, all image pulls from the distribution registry will fail, as will pods that need external network access.
 
 ## Common Failure Patterns
@@ -329,7 +333,7 @@ If DNS is broken, all image pulls from the distribution registry will fail, as w
 | `tls handshake eof` from `openshell status` | Server not running or mTLS credentials missing/mismatched | Check StatefulSet replicas (Step 3) and mTLS files (Step 6) |
 | StatefulSet `0/0` replicas | StatefulSet scaled to zero (failed deploy, manual scale-down, or Helm misconfiguration) | `openshell doctor exec -- kubectl -n openshell scale statefulset openshell --replicas=1` |
 | Local mTLS files missing | Deploy was interrupted before credentials were persisted | Extract from cluster secret `openshell-client-tls` (Step 6) |
-| Container not found | Image not built | `mise run docker:build:cluster` (local) or re-deploy (remote) |
+| Container not found | Image not built | `mise run docker:build:cluster` (local, works with both Docker and Podman) or re-deploy (remote) |
 | Container exited, OOMKilled | Insufficient memory | Increase host memory or reduce workload |
 | Container exited, non-zero exit | k3s crash, port conflict, privilege issue | Check `openshell doctor logs` for details |
 | `/readyz` fails | k3s still starting or crashed | Wait longer or check container logs for k3s errors |
@@ -343,6 +347,10 @@ If DNS is broken, all image pulls from the distribution registry will fail, as w
 | mTLS mismatch after redeploy | PKI rotated but workload not restarted, or rollout failed | Check that all three TLS secrets exist and that the openshell pod restarted after cert rotation (Step 6) |
 | Helm install job failed | Chart values error or dependency issue | `openshell doctor exec -- kubectl -n kube-system logs -l job-name=helm-install-openshell` |
 | NFD/GFD DaemonSets present (`node-feature-discovery`, `gpu-feature-discovery`) | Cluster was deployed before NFD/GFD were disabled (pre-simplify-device-plugin change) | These are harmless but add overhead. Clean up: `openshell doctor exec -- kubectl delete daemonset -n nvidia-device-plugin -l app.kubernetes.io/name=node-feature-discovery` and similarly for GFD. The `nvidia.com/gpu.present` node label is no longer applied; device plugin scheduling no longer requires it. |
+| Podman socket not found | Rootless Podman service not started | `systemctl --user start podman.socket` and verify with `podman info` |
+| Container creation fails with subuid/subgid error (Podman) | Missing user namespace ID mappings | `sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $(whoami)` then `podman system migrate` |
+| Cgroups v1 detected (Podman) | Podman driver requires unified cgroup hierarchy | Set `systemd.unified_cgroup_hierarchy=1` kernel parameter and reboot |
+| `--restart=always` ignored (Podman rootless) | Rootless Podman does not support `--restart=always` for containers | Use a systemd user service instead: `loginctl enable-linger $(whoami)` then create a `~/.config/systemd/user/` unit |
 | Architecture mismatch (remote) | Built on arm64, deploying to amd64 | Cross-build the image for the target architecture |
 | Port conflict | Another service on the configured gateway host port (default 8080) | Stop conflicting service or use `--port` on `openshell gateway start` to pick a different host port |
 | gRPC connect refused to `127.0.0.1:443` in CI | Docker daemon is remote (`DOCKER_HOST=tcp://...`) but metadata still points to loopback | Verify metadata endpoint host matches `DOCKER_HOST` and includes non-loopback host |

--- a/.agents/skills/debug-openshell-cluster/SKILL.md
+++ b/.agents/skills/debug-openshell-cluster/SKILL.md
@@ -299,7 +299,9 @@ Common issues:
 
 ### Step 9: Check DNS Resolution
 
-DNS misconfiguration is a common root cause, especially on remote/Linux hosts:
+> **Scope:** This step covers DNS for the **cluster infrastructure** (k3s, CoreDNS, image pulls). It is entirely separate from DNS enforcement for agent workloads running inside sandboxes — see the note at the end of this section.
+
+DNS misconfiguration is a common root cause of cluster startup failures, especially on remote/Linux hosts:
 
 ```bash
 # Check the resolv.conf k3s is using
@@ -315,16 +317,20 @@ Check the entrypoint's DNS decision in the container logs:
 openshell doctor logs --lines 20
 ```
 
-The entrypoint script selects DNS resolvers in this priority:
+The entrypoint script (`cluster-entrypoint.sh`) uses a single DNS strategy with one fallback:
 
-1. Viable nameservers from `/etc/resolv.conf` (not loopback/link-local)
-2. Docker `ExtServers` from `/etc/resolv.conf` comments
-3. Host gateway IP (Docker Desktop only, `192.168.*`)
-4. Fallback to `8.8.8.8` / `8.8.4.4`
+1. **Primary — Docker DNS proxy**: `setup_dns_proxy()` reads the `DOCKER_OUTPUT` iptables chain to find the ports where Docker's embedded DNS (`127.0.0.11`) is actually listening, then installs DNAT rules so k3s pods (which run in separate network namespaces and cannot reach `127.0.0.11` directly via OUTPUT rules) can reach it via the container's `eth0` IP. On success, writes `nameserver <eth0-ip>` to `/etc/rancher/k3s/resolv.conf`.
+2. **Fallback — public DNS**: If `setup_dns_proxy()` fails for any reason (chain not found, no `eth0` IP), writes `nameserver 8.8.8.8` / `nameserver 8.8.4.4` to `/etc/rancher/k3s/resolv.conf`.
 
-**Podman note:** Rootless Podman uses pasta (or slirp4netns) for network connectivity, which has different DNS behavior than Docker's built-in DNS at `127.0.0.11`. DNS resolution inside Podman containers typically inherits the host's `/etc/resolv.conf` directly. If DNS fails inside a Podman-managed cluster container, check the host's DNS configuration first.
+**Under Docker**, `setup_dns_proxy()` succeeds when the `DOCKER_OUTPUT` iptables chain exists (standard Docker custom networks). If it fails, the public DNS fallback is used and a warning is logged.
+
+**Under rootless Podman**, the `DOCKER_OUTPUT` iptables chain does not exist — Podman uses Aardvark DNS on the bridge gateway IP for custom networks, not Docker's embedded resolver. `setup_dns_proxy()` will always fail with `Warning: Could not discover Docker DNS ports from iptables` and the fallback to `8.8.8.8`/`8.8.4.4` always applies. DNS works on most Linux hosts because public DNS is reachable, but fails on networks that block external UDP port 53 (e.g. corporate firewalls or restricted VPNs). If DNS fails under Podman, verify that `8.8.8.8:53` (UDP) is reachable from the host — the container does not inherit the host's `/etc/resolv.conf`.
+
+After either path, `verify_dns()` runs an `nslookup` probe against the configured registry host (defaulting to `ghcr.io`). Failure emits a `DNS_PROBE_FAILED` marker in the logs, which the Rust-side bootstrap polling loop detects to abort early with a clear error instead of spinning for minutes.
 
 If DNS is broken, all image pulls from the distribution registry will fail, as will pods that need external network access.
+
+> **Sandbox agent DNS is a different layer entirely.** The cluster DNS described above has no effect on what agent workloads running inside sandboxes can resolve. The sandbox supervisor (`openshell-sandbox`) creates a Linux network namespace with a veth pair and installs iptables rules inside it that REJECT all outbound UDP (including port 53) except traffic to the proxy. Agent workloads cannot make raw DNS queries regardless of what nameservers are configured — DNS must go through the HTTP CONNECT proxy. This is a kernel-enforced boundary, not a configuration setting. The bypass monitor logs and REJECTs any direct DNS attempt with the hint: *"DNS queries should route through the sandbox proxy; check resolver configuration"*.
 
 ## Common Failure Patterns
 
@@ -354,7 +360,8 @@ If DNS is broken, all image pulls from the distribution registry will fail, as w
 | Architecture mismatch (remote) | Built on arm64, deploying to amd64 | Cross-build the image for the target architecture |
 | Port conflict | Another service on the configured gateway host port (default 8080) | Stop conflicting service or use `--port` on `openshell gateway start` to pick a different host port |
 | gRPC connect refused to `127.0.0.1:443` in CI | Docker daemon is remote (`DOCKER_HOST=tcp://...`) but metadata still points to loopback | Verify metadata endpoint host matches `DOCKER_HOST` and includes non-loopback host |
-| DNS failures inside container | Entrypoint DNS detection failed | `openshell doctor exec -- cat /etc/rancher/k3s/resolv.conf` and `openshell doctor logs --lines 20` |
+| DNS failures inside container (Docker) | `setup_dns_proxy()` failed to find `DOCKER_OUTPUT` iptables chain | `openshell doctor logs --lines 20` for `Warning: Could not discover Docker DNS ports`; try `docker network prune -f` and redeploy |
+| DNS failures inside container (Podman) | `setup_dns_proxy()` always fails under Podman; public DNS fallback (`8.8.8.8`) is used but unreachable | Verify `8.8.8.8:53` UDP is reachable from the host; `openshell doctor exec -- cat /etc/rancher/k3s/resolv.conf` to confirm fallback is in place |
 | Pods can't reach kube-dns / ClusterIP services | `br_netfilter` not loaded; bridge traffic bypasses iptables DNAT rules | `sudo modprobe br_netfilter` on the host, then `echo br_netfilter \| sudo tee /etc/modules-load.d/br_netfilter.conf` to persist. Known to be required on Jetson Linux 5.15-tegra; other kernels (e.g. standard x86/aarch64 Linux) may have bridge netfilter built in and work without the module. The entrypoint logs a warning when `/proc/sys/net/bridge/bridge-nf-call-iptables` is absent but does not abort — only act on it if DNS or service connectivity is actually broken. |
 | Node DiskPressure / MemoryPressure / PIDPressure | Insufficient disk, memory, or PIDs on host | Free disk (`docker system prune -a --volumes`), increase memory, or expand host resources. Bootstrap auto-detects via `HEALTHCHECK_NODE_PRESSURE` marker |
 | Pods evicted with "The node had condition: [DiskPressure]" | Host disk full, kubelet evicting pods | Free disk space on host, then `openshell gateway destroy <name> && openshell gateway start` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,6 +3173,7 @@ dependencies = [
  "openshell-core",
  "serde",
  "serde_json",
+ "temp-env",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core 0.5.6",
  "base64 0.22.1",
@@ -309,7 +309,7 @@ dependencies = [
  "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite 0.29.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -363,7 +363,7 @@ checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "getrandom 0.2.17",
  "instant",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
  "clap",
  "clap_lex",
@@ -724,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -838,7 +838,7 @@ checksum = "0940496e5c83c54f3b753d5317daec82e8edac71c33aaa1f666d76f518de2444"
 dependencies = [
  "hax-lib",
  "pastey",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -1944,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -1954,11 +1954,10 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2337,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2520,15 +2519,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libcrux-intrinsics"
@@ -2552,7 +2551,7 @@ dependencies = [
  "libcrux-secrets",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tls_codec",
 ]
 
@@ -2593,7 +2592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9adfd58e79d860f6b9e40e35127bfae9e5bd3ade33201d1347459011a2add034"
 dependencies = [
  "libcrux-secrets",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -2935,7 +2934,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2949,7 +2948,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "smallvec",
  "zeroize",
@@ -3161,6 +3160,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "openshell-driver-podman"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "futures",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "miette",
+ "nix",
+ "openshell-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "openshell-driver-vm"
 version = "0.0.0"
 dependencies = [
@@ -3286,7 +3307,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "uuid",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3294,7 +3315,7 @@ name = "openshell-server"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "axum 0.8.8",
+ "axum 0.8.9",
  "bytes",
  "clap",
  "futures",
@@ -3313,6 +3334,7 @@ dependencies = [
  "miette",
  "openshell-core",
  "openshell-driver-kubernetes",
+ "openshell-driver-podman",
  "openshell-ocsf",
  "openshell-policy",
  "openshell-router",
@@ -3320,7 +3342,7 @@ dependencies = [
  "pin-project-lite",
  "prost",
  "prost-types",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rcgen",
  "reqwest",
  "russh",
@@ -3478,7 +3500,7 @@ dependencies = [
  "delegate",
  "futures",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
@@ -3646,7 +3668,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3735,9 +3757,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -3973,7 +3995,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4022,9 +4044,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4033,9 +4055,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4195,7 +4217,7 @@ dependencies = [
  "msvc_spectre_libs",
  "num-bigint",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4240,7 +4262,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4350,7 +4372,7 @@ dependencies = [
  "pkcs1 0.8.0-rc.4",
  "pkcs5",
  "pkcs8 0.10.2",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_core 0.10.0-rc-3",
  "rsa 0.10.0-rc.12",
  "russh-cryptovec",
@@ -4442,9 +4464,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "log",
  "once_cell",
@@ -4488,9 +4510,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5081,7 +5103,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa 0.9.10",
  "serde",
  "sha1 0.10.6",
@@ -5119,7 +5141,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5271,6 +5293,12 @@ name = "supports-unicode"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -5522,9 +5550,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -5587,14 +5615,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.28.0",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -5669,7 +5697,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -5758,11 +5786,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -5848,7 +5877,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
@@ -5858,19 +5887,18 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1 0.10.6",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -6019,9 +6047,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6063,11 +6091,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -6076,7 +6104,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -6087,9 +6115,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6100,9 +6128,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6110,9 +6138,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6120,9 +6148,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6133,9 +6161,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -6176,9 +6204,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6200,14 +6228,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6616,6 +6644,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/architecture/podman-driver.md
+++ b/architecture/podman-driver.md
@@ -1,0 +1,259 @@
+# Podman Compute Driver
+
+The Podman compute driver manages sandbox containers via the Podman REST API over a Unix socket. It targets single-machine and developer environments where rootless container isolation is preferred over a full Kubernetes cluster. The driver runs in-process within the gateway server and delegates all sandbox isolation enforcement to the `openshell-sandbox` supervisor binary, which is sideloaded into each container via an OCI image volume mount.
+
+## Source File Index
+
+All paths are relative to `crates/openshell-driver-podman/src/`.
+
+| File | Purpose |
+|------|---------|
+| `lib.rs` | Crate root; declares modules and re-exports `PodmanComputeConfig`, `PodmanComputeDriver`, `ComputeDriverService` |
+| `main.rs` | Standalone binary entrypoint; parses CLI args/env vars, constructs the driver, starts a gRPC server with graceful shutdown |
+| `driver.rs` | Core `PodmanComputeDriver` -- sandbox lifecycle (create/stop/delete/list/get), endpoint resolution, GPU detection, rootless pre-flight checks |
+| `client.rs` | `PodmanClient` -- async HTTP/1.1 client over Unix socket for the Podman libpod REST API (containers, volumes, networks, secrets, images, events, system info) |
+| `container.rs` | Container spec construction -- labels, env vars, resource limits, capabilities, seccomp config, health checks, port mappings, image volumes, secret injection |
+| `config.rs` | `PodmanComputeConfig` struct, `ImagePullPolicy` enum, default socket path resolution, `Debug` impl that redacts secrets |
+| `grpc.rs` | `ComputeDriverService` -- tonic gRPC service mapping RPCs to driver methods, with error-to-Status conversion |
+| `watcher.rs` | Watch stream -- initial state sync via container list, then live Podman events mapped to `WatchSandboxesEvent` protobuf messages |
+
+## Architecture
+
+The Podman driver is one of three `ComputeDriver` implementations. It communicates with the Podman daemon over a Unix socket and delegates sandbox isolation to the supervisor binary running inside each container.
+
+```mermaid
+graph TB
+    CLI["openshell CLI"] -->|gRPC| GW["Gateway Server<br/>(openshell-server)"]
+    GW -->|in-process| PD["PodmanComputeDriver"]
+    PD -->|HTTP/1.1<br/>Unix socket| PA["Podman API"]
+    PA -->|OCI runtime<br/>crun/runc| C["Sandbox Container"]
+    C -->|image volume<br/>read-only| SV["Supervisor Binary<br/>/opt/openshell/bin/openshell-sandbox"]
+    SV -->|creates| NS["Nested Network Namespace<br/>veth pair + proxy"]
+    SV -->|enforces| LL["Landlock + seccomp"]
+    SV -->|gRPC callback| GW
+```
+
+### Driver Comparison
+
+| Aspect | Kubernetes | VM (libkrun) | Podman |
+|--------|-----------|--------------|--------|
+| Execution model | In-process | Standalone subprocess (gRPC over UDS) | In-process |
+| Backend | K8s API (CRD + controller) | libkrun hypervisor (KVM/HVF) | Podman REST API (Unix socket) |
+| Isolation boundary | Container (supervisor inside pod) | Hardware VM | Container (supervisor inside container) |
+| Supervisor delivery | hostPath volume (read-only) | Embedded in rootfs tarball | OCI image volume (read-only) |
+| Network model | Supervisor creates netns inside pod | gvproxy virtio-net (192.168.127.0/24) | Supervisor creates netns inside container |
+| Credential injection | Plaintext env var + K8s Secret volume (0400) | Rootfs file copy (0600) + env vars | Podman `secret_env` API + env vars |
+| GPU support | Yes (nvidia.com/gpu resource) | No | Yes (CDI device) |
+| `stop_sandbox` | Unimplemented | Unimplemented | Implemented (graceful stop) |
+| State storage | Kubernetes API (CRD) | In-memory HashMap + filesystem | Podman daemon (container state) |
+| Endpoint resolution | Pod IP / cluster DNS | 127.0.0.1 + allocated port | 127.0.0.1 + ephemeral port |
+
+## Isolation Model
+
+The Podman driver provides the same four protection layers as the Kubernetes driver. The driver itself does not implement isolation primitives directly -- it configures the container so that the `openshell-sandbox` supervisor binary can enforce them at runtime.
+
+### Container Security Configuration
+
+The container spec (`container.rs`) sets:
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| `user` | `0:0` | Supervisor needs root for namespace creation, proxy setup, Landlock/seccomp |
+| `cap_drop` | `ALL` | Drop all capabilities, then selectively add back |
+| `cap_add` | `SYS_ADMIN, NET_ADMIN, SYS_PTRACE, SYSLOG, SETUID, SETGID, DAC_READ_SEARCH` | See capability breakdown below |
+| `no_new_privileges` | `true` | Prevent privilege escalation after exec |
+| `seccomp_profile_path` | `unconfined` | Supervisor installs its own policy-aware BPF filter; container-level profile would block Landlock/seccomp syscalls during setup |
+
+### Capability Breakdown
+
+The Kubernetes driver uses 4 capabilities (`SYS_ADMIN, NET_ADMIN, SYS_PTRACE, SYSLOG`). The Podman driver adds 3 more, all required for rootless operation:
+
+| Capability | Shared with K8s? | Purpose |
+|------------|------------------|---------|
+| `SYS_ADMIN` | Yes | seccomp filter installation, namespace creation, Landlock |
+| `NET_ADMIN` | Yes | Network namespace veth setup, IP/route configuration |
+| `SYS_PTRACE` | Yes | Reading `/proc/<pid>/exe` and ancestor walk for binary identity |
+| `SYSLOG` | Yes | Reading `/dev/kmsg` for bypass-detection diagnostics |
+| `SETUID` | Podman only | `drop_privileges()` calls `setuid()` to sandbox user. Rootless `cap_drop: ALL` removes this from the bounding set. |
+| `SETGID` | Podman only | `drop_privileges()` calls `setgid()` + `initgroups()`. Same rootless reason as SETUID. |
+| `DAC_READ_SEARCH` | Podman only | Proxy reads `/proc/<pid>/fd/` across UIDs for binary identity. In rootless Podman, supervisor (UID 0 in user namespace) and sandbox processes have different UIDs. |
+
+In the Kubernetes driver, these three capabilities are implicitly available because the kubelet does not drop them from the bounding set. In rootless Podman, `cap_drop: ALL` removes everything, requiring explicit re-addition.
+
+All capabilities are only available to the supervisor process. Sandbox child processes lose them after `setuid()` to the sandbox user in the `pre_exec` hook.
+
+## Supervisor Sideloading
+
+The supervisor binary is delivered to sandbox containers via Podman's OCI image volume mechanism, distinct from both the Kubernetes hostPath approach and the VM's embedded rootfs.
+
+```mermaid
+sequenceDiagram
+    participant D as PodmanComputeDriver
+    participant P as Podman API
+    participant C as Sandbox Container
+
+    D->>P: pull_image("openshell/supervisor:latest", "missing")
+    D->>P: create_container(spec with image_volumes)
+    Note over P: Podman resolves image_volumes at<br/>libpod layer before OCI spec generation
+    P->>C: Mount supervisor image at /opt/openshell/bin (read-only)
+    D->>P: start_container
+    C->>C: entrypoint: /opt/openshell/bin/openshell-sandbox
+```
+
+The supervisor image is a `FROM scratch` image containing only the `openshell-sandbox` binary. It is built by the `supervisor-output` target in `deploy/docker/Dockerfile.images`. The `image_volumes` field in the container spec mounts this image's filesystem at `/opt/openshell/bin` with `rw: false`, making it a read-only overlay that the sandbox cannot tamper with.
+
+## Network Model
+
+Sandbox network isolation uses a two-layer approach: a Podman bridge network for container-to-host communication, and a nested network namespace (created by the supervisor) for sandbox process isolation.
+
+```mermaid
+graph TB
+    subgraph Host
+        GW["Gateway Server<br/>127.0.0.1:8080"]
+        PS["Podman Socket"]
+    end
+
+    subgraph Bridge["Podman Bridge Network (10.89.x.x)"]
+        subgraph Container["Sandbox Container"]
+            SV["Supervisor<br/>(root in user ns)"]
+            subgraph NestedNS["Nested Network Namespace"]
+                SP["Sandbox Process<br/>(sandbox user)"]
+                VE2["veth1: 10.200.0.2"]
+            end
+            VE1["veth0: 10.200.0.1<br/>(CONNECT proxy)"]
+            SV --- VE1
+            VE1 ---|veth pair| VE2
+        end
+    end
+
+    GW -.->|SSH via published port<br/>127.0.0.1:ephemeral| Container
+    SV -->|gRPC callback via<br/>host.containers.internal| GW
+    SP -->|all egress via proxy| VE1
+```
+
+Key points:
+
+- **Bridge network**: Created by `client.ensure_network()` with DNS enabled. Containers on the bridge can see each other at L3, but sandbox processes cannot because they are isolated inside the nested netns.
+- **Nested netns**: The supervisor creates a private `NetworkNamespace` with a veth pair (10.200.0.1/24 <-> 10.200.0.2/24). Sandbox processes enter this netns via `setns(fd, CLONE_NEWNET)` in the `pre_exec` hook, forcing all traffic through the CONNECT proxy.
+- **Port publishing**: SSH uses `host_port: 0` (ephemeral port assignment). The gateway reads the assigned port from `podman inspect` and connects via `127.0.0.1:<host_port>`.
+- **Host gateway**: `host.containers.internal:host-gateway` in `/etc/hosts` allows containers to reach the gateway server on the host.
+- **nsenter**: The supervisor uses `nsenter --net=` instead of `ip netns exec` for namespace operations, avoiding the sysfs remount that fails in rootless containers.
+
+## Supervisor relay (SSH Unix socket)
+
+Podman now follows the same end-to-end contract as the Kubernetes and VM drivers for the in-container SSH relay: **gateway config → `PodmanComputeConfig` → sandbox environment → supervisor session registration on that path**.
+
+1. `openshell-core` `Config::sandbox_ssh_socket_path` (gateway YAML / defaults) is copied into `PodmanComputeConfig::sandbox_ssh_socket_path` when the gateway builds the in-process driver (`crates/openshell-server/src/lib.rs`, `ComputeDriverKind::Podman`).
+2. `build_env()` in `container.rs` sets `OPENSHELL_SSH_SOCKET_PATH` to that value, alongside required vars `OPENSHELL_ENDPOINT` and `OPENSHELL_SANDBOX_ID` (and `OPENSHELL_SANDBOX`, etc.). These driver-controlled entries overwrite user template env to prevent spoofing.
+3. The supervisor reads `OPENSHELL_SSH_SOCKET_PATH` and uses it for the Unix socket the gateway’s SSH stack bridges to. The standalone `openshell-driver-podman` binary sets the same struct field from `OPENSHELL_SANDBOX_SSH_SOCKET_PATH` (`main.rs`).
+
+## Credential Injection
+
+The SSH handshake secret is injected via Podman's `secret_env` API rather than a plaintext environment variable.
+
+| Credential | Mechanism | Visible in `inspect`? | Visible in `/proc/<pid>/environ`? |
+|------------|-----------|----------------------|----------------------------------|
+| SSH handshake secret | Podman `secret_env` (created via secrets API, referenced by name) | No | Yes (supervisor only; scrubbed from children) |
+| Sandbox identity (`OPENSHELL_SANDBOX_ID`, etc.) | Plaintext env var | Yes | Yes |
+| gRPC endpoint (`OPENSHELL_ENDPOINT`) | Plaintext env var, override-protected | Yes | Yes |
+| Supervisor relay socket path (`OPENSHELL_SSH_SOCKET_PATH`) | Plaintext env var, override-protected (same value as `PodmanComputeConfig::sandbox_ssh_socket_path`) | Yes | Yes |
+
+The `build_env()` function in `container.rs` inserts user-supplied variables first, then unconditionally overwrites security-critical variables (`OPENSHELL_ENDPOINT`, `OPENSHELL_SANDBOX_ID`, `OPENSHELL_SSH_SOCKET_PATH`, `OPENSHELL_SANDBOX`, etc.) to prevent spoofing via sandbox templates.
+
+The `PodmanComputeConfig::Debug` impl redacts the handshake secret as `[REDACTED]`.
+
+## Sandbox Lifecycle
+
+### Creation Flow
+
+```mermaid
+sequenceDiagram
+    participant GW as Gateway
+    participant D as PodmanComputeDriver
+    participant P as Podman API
+
+    GW->>D: create_sandbox(DriverSandbox)
+    D->>D: validate name + id
+    D->>D: validate_container_name()
+
+    D->>P: pull_image(supervisor, "missing")
+    D->>P: pull_image(sandbox_image, policy)
+
+    D->>P: create_secret(handshake)
+    Note over D: On failure below, rollback secret
+
+    D->>P: create_volume(workspace)
+    Note over D: On failure below, rollback volume + secret
+
+    D->>P: create_container(spec)
+    alt Conflict (409)
+        D->>P: remove_volume + remove_secret
+        D-->>GW: AlreadyExists
+    end
+    Note over D: On failure below, rollback container + volume + secret
+
+    D->>P: start_container
+    D-->>GW: Ok
+```
+
+Each step rolls back all previously-created resources on failure. The Conflict path (409 from container creation) cleans up the volume and secret because they are keyed by the new sandbox's ID, not the conflicting container's.
+
+### Readiness and health
+
+The container `healthconfig` in `container.rs` marks the sandbox healthy when **any** of these signals succeeds: legacy file marker `/var/run/openshell-ssh-ready`, **or** `test -S` on the configured supervisor Unix socket path (`sandbox_ssh_socket_path` / `OPENSHELL_SSH_SOCKET_PATH`), **or** the prior TCP check (`ss` listening on the in-container SSH port). That allows relay-only readiness when the supervisor exposes the socket without the old marker or published-port signal.
+
+### Deletion Flow
+
+1. Validate `sandbox_name` and stable `sandbox_id` from `DeleteSandboxRequest`
+2. Best-effort inspect cross-checks the container label when present, but cleanup remains keyed by the request `sandbox_id`
+3. Best-effort stop (result ignored)
+4. Force-remove container (`?force=true&v=true`)
+5. Remove workspace volume derived from the request `sandbox_id` (warn on failure, continue)
+6. Remove handshake secret derived from the request `sandbox_id` (warn on failure, continue)
+
+If the container is already gone during inspect or remove, the driver still performs idempotent volume/secret cleanup using the request `sandbox_id` and returns `Ok(false)` for the container-delete result. This prevents leaked Podman resources after out-of-band container removal or label drift.
+
+## Configuration
+
+| Environment Variable | CLI Flag | Default | Description |
+|---------------------|----------|---------|-------------|
+| `OPENSHELL_PODMAN_SOCKET` | `--podman-socket` | `$XDG_RUNTIME_DIR/podman/podman.sock` | Podman API Unix socket path |
+| `OPENSHELL_SANDBOX_IMAGE` | `--sandbox-image` | (from gateway config) | Default OCI image for sandboxes |
+| `OPENSHELL_SANDBOX_IMAGE_PULL_POLICY` | `--sandbox-image-pull-policy` | `missing` | Pull policy: `always`, `missing`, `never`, `newer` |
+| `OPENSHELL_GRPC_ENDPOINT` | `--grpc-endpoint` | Auto-detected via `host.containers.internal` | Gateway gRPC endpoint for sandbox callbacks |
+| `OPENSHELL_NETWORK_NAME` | `--network-name` | `openshell` | Podman bridge network name |
+| `OPENSHELL_SANDBOX_SSH_PORT` | `--sandbox-ssh-port` | `2222` | SSH port inside the container |
+| `OPENSHELL_SSH_HANDSHAKE_SECRET` | `--ssh-handshake-secret` | (required) | Shared secret for NSSH1 handshake |
+| `OPENSHELL_SANDBOX_SSH_SOCKET_PATH` | `--sandbox-ssh-socket-path` | `/run/openshell/ssh.sock` | Standalone driver only: supervisor Unix socket path in `PodmanComputeConfig` (in-gateway Podman uses server `config.sandbox_ssh_socket_path`) |
+| `OPENSHELL_STOP_TIMEOUT` | `--stop-timeout` | `10` | Container stop timeout in seconds (SIGTERM -> SIGKILL) |
+| `OPENSHELL_SUPERVISOR_IMAGE` | `--supervisor-image` | `openshell/supervisor:latest` | OCI image containing the supervisor binary |
+
+## Rootless-Specific Adaptations
+
+The Podman driver is designed for rootless operation. The following adaptations were made compared to the Kubernetes driver:
+
+1. **subuid/subgid pre-flight check**: `check_subuid_range()` in `driver.rs` warns operators if `/etc/subuid` or `/etc/subgid` entries are missing for the current user. Not a hard error because some systems use LDAP or other mechanisms.
+
+2. **cgroups v2 requirement**: The driver refuses to start if cgroups v1 is detected. Rootless Podman requires the unified cgroup hierarchy.
+
+3. **nsenter for namespace operations**: `run_ip_netns()` and `run_iptables_netns()` in the sandbox's `netns.rs` use `nsenter --net=` instead of `ip netns exec` to avoid the sysfs remount that requires real `CAP_SYS_ADMIN` in the host user namespace.
+
+4. **DAC_READ_SEARCH capability**: Required for the proxy to read `/proc/<pid>/fd/` across UIDs within the user namespace.
+
+5. **SETUID/SETGID capabilities**: Required for `drop_privileges()` to call `setuid()`/`setgid()` after `cap_drop: ALL` removes them from the bounding set.
+
+6. **host.containers.internal**: Used instead of Docker's `host.docker.internal` for container-to-host communication. Injected via `hostadd` with Podman's `host-gateway` magic value.
+
+7. **Ephemeral port publishing**: SSH port uses `host_port: 0` because the bridge network IP (10.89.x.x) is not routable from the host in rootless mode. The gateway reads the assigned host port from `podman inspect`.
+
+8. **tmpfs at `/run/netns`**: A private tmpfs is mounted so the supervisor can create named network namespaces via `ip netns add`, which requires `/run/netns` to exist and be writable.
+
+## Implementation References
+
+- Gateway integration: `crates/openshell-server/src/compute/mod.rs` (`new_podman` and `PodmanComputeDriver` wiring)
+- Server configuration: `crates/openshell-server/src/lib.rs` (`ComputeDriverKind::Podman` — builds `PodmanComputeConfig` including `sandbox_ssh_socket_path` from gateway `Config`)
+- Gateway relay path: `openshell-core` `Config::sandbox_ssh_socket_path` in `crates/openshell-core/src/config.rs`
+- SSRF mitigation: `crates/openshell-server/src/ssh_tunnel.rs` (lines 103-189, loopback/link-local checks)
+- Sandbox supervisor: `crates/openshell-sandbox/src/` (Landlock, seccomp, netns, proxy -- shared by all drivers)
+- Container engine abstraction: `tasks/scripts/container-engine.sh` (build/deploy support for Docker and Podman)
+- Supervisor image build: `deploy/docker/Dockerfile.images` (lines 182-183, `supervisor-output` target)

--- a/architecture/podman-driver.md
+++ b/architecture/podman-driver.md
@@ -126,7 +126,7 @@ graph TB
         end
     end
 
-    GW -.->|SSH via published port<br/>127.0.0.1:ephemeral| Container
+    GW -.->|SSH via supervisor relay<br/>gRPC session| SV
     SV -->|gRPC callback via<br/>host.containers.internal| GW
     SP -->|all egress via proxy| VE1
 ```
@@ -135,7 +135,7 @@ Key points:
 
 - **Bridge network**: Created by `client.ensure_network()` with DNS enabled. Containers on the bridge can see each other at L3, but sandbox processes cannot because they are isolated inside the nested netns.
 - **Nested netns**: The supervisor creates a private `NetworkNamespace` with a veth pair (10.200.0.1/24 <-> 10.200.0.2/24). Sandbox processes enter this netns via `setns(fd, CLONE_NEWNET)` in the `pre_exec` hook, forcing all traffic through the CONNECT proxy.
-- **Port publishing**: SSH uses `host_port: 0` (ephemeral port assignment). The gateway reads the assigned port from `podman inspect` and connects via `127.0.0.1:<host_port>`.
+- **Port publishing**: SSH uses `host_port: 0` (ephemeral port assignment) for health checks and debug access. The gateway SSH tunnel uses the supervisor relay (`supervisor_sessions.open_relay()`) rather than connecting directly to the published port.
 - **Host gateway**: `host.containers.internal:host-gateway` in `/etc/hosts` allows containers to reach the gateway server on the host.
 - **nsenter**: The supervisor uses `nsenter --net=` instead of `ip netns exec` for namespace operations, avoiding the sysfs remount that fails in rootless containers.
 
@@ -158,7 +158,7 @@ The SSH handshake secret is injected via Podman's `secret_env` API rather than a
 | gRPC endpoint (`OPENSHELL_ENDPOINT`) | Plaintext env var, override-protected | Yes | Yes |
 | Supervisor relay socket path (`OPENSHELL_SSH_SOCKET_PATH`) | Plaintext env var, override-protected (same value as `PodmanComputeConfig::sandbox_ssh_socket_path`) | Yes | Yes |
 
-The `build_env()` function in `container.rs` inserts user-supplied variables first, then unconditionally overwrites security-critical variables (`OPENSHELL_ENDPOINT`, `OPENSHELL_SANDBOX_ID`, `OPENSHELL_SSH_SOCKET_PATH`, `OPENSHELL_SANDBOX`, etc.) to prevent spoofing via sandbox templates.
+The `build_env()` function in `container.rs` inserts user-supplied variables first, then unconditionally overwrites all security-critical variables to prevent spoofing via sandbox templates: `OPENSHELL_SANDBOX`, `OPENSHELL_SANDBOX_ID`, `OPENSHELL_ENDPOINT`, `OPENSHELL_SSH_SOCKET_PATH`, `OPENSHELL_SSH_LISTEN_ADDR`, `OPENSHELL_SSH_HANDSHAKE_SKEW_SECS`, `OPENSHELL_CONTAINER_IMAGE`, `OPENSHELL_SANDBOX_COMMAND`.
 
 The `PodmanComputeConfig::Debug` impl redacts the handshake secret as `[REDACTED]`.
 
@@ -174,7 +174,7 @@ sequenceDiagram
 
     GW->>D: create_sandbox(DriverSandbox)
     D->>D: validate name + id
-    D->>D: validate_container_name()
+    D->>D: validated_container_name()
 
     D->>P: pull_image(supervisor, "missing")
     D->>P: pull_image(sandbox_image, policy)
@@ -226,7 +226,7 @@ If the container is already gone during inspect or remove, the driver still perf
 | `OPENSHELL_SSH_HANDSHAKE_SECRET` | `--ssh-handshake-secret` | (required) | Shared secret for NSSH1 handshake |
 | `OPENSHELL_SANDBOX_SSH_SOCKET_PATH` | `--sandbox-ssh-socket-path` | `/run/openshell/ssh.sock` | Standalone driver only: supervisor Unix socket path in `PodmanComputeConfig` (in-gateway Podman uses server `config.sandbox_ssh_socket_path`) |
 | `OPENSHELL_STOP_TIMEOUT` | `--stop-timeout` | `10` | Container stop timeout in seconds (SIGTERM -> SIGKILL) |
-| `OPENSHELL_SUPERVISOR_IMAGE` | `--supervisor-image` | `openshell/supervisor:latest` | OCI image containing the supervisor binary |
+| `OPENSHELL_SUPERVISOR_IMAGE` | `--supervisor-image` | `openshell/supervisor:latest` (struct default; standalone binary requires explicit value) | OCI image containing the supervisor binary |
 
 ## Rootless-Specific Adaptations
 
@@ -236,7 +236,7 @@ The Podman driver is designed for rootless operation. The following adaptations 
 
 2. **cgroups v2 requirement**: The driver refuses to start if cgroups v1 is detected. Rootless Podman requires the unified cgroup hierarchy.
 
-3. **nsenter for namespace operations**: `run_ip_netns()` and `run_iptables_netns()` in the sandbox's `netns.rs` use `nsenter --net=` instead of `ip netns exec` to avoid the sysfs remount that requires real `CAP_SYS_ADMIN` in the host user namespace.
+3. **nsenter for namespace operations**: `run_ip_netns()` and `run_iptables_netns()` in `crates/openshell-sandbox/src/sandbox/linux/netns.rs` use `nsenter --net=` instead of `ip netns exec` to avoid the sysfs remount that requires real `CAP_SYS_ADMIN` in the host user namespace.
 
 4. **DAC_READ_SEARCH capability**: Required for the proxy to read `/proc/<pid>/fd/` across UIDs within the user namespace.
 
@@ -244,7 +244,7 @@ The Podman driver is designed for rootless operation. The following adaptations 
 
 6. **host.containers.internal**: Used instead of Docker's `host.docker.internal` for container-to-host communication. Injected via `hostadd` with Podman's `host-gateway` magic value.
 
-7. **Ephemeral port publishing**: SSH port uses `host_port: 0` because the bridge network IP (10.89.x.x) is not routable from the host in rootless mode. The gateway reads the assigned host port from `podman inspect`.
+7. **Ephemeral port publishing**: SSH port uses `host_port: 0` because the bridge network IP (10.89.x.x) is not routable from the host in rootless mode. The published port is used for health checks and debug access; the gateway SSH tunnel uses the supervisor relay.
 
 8. **tmpfs at `/run/netns`**: A private tmpfs is mounted so the supervisor can create named network namespaces via `ip netns add`, which requires `/run/netns` to exist and be writable.
 
@@ -253,7 +253,7 @@ The Podman driver is designed for rootless operation. The following adaptations 
 - Gateway integration: `crates/openshell-server/src/compute/mod.rs` (`new_podman` and `PodmanComputeDriver` wiring)
 - Server configuration: `crates/openshell-server/src/lib.rs` (`ComputeDriverKind::Podman` — builds `PodmanComputeConfig` including `sandbox_ssh_socket_path` from gateway `Config`)
 - Gateway relay path: `openshell-core` `Config::sandbox_ssh_socket_path` in `crates/openshell-core/src/config.rs`
-- SSRF mitigation: `crates/openshell-server/src/ssh_tunnel.rs` (lines 103-189, loopback/link-local checks)
+- SSRF mitigation: `crates/openshell-core/src/net.rs` (IP classification: `is_always_blocked_ip`, `is_internal_ip`), `crates/openshell-sandbox/src/proxy.rs` (runtime enforcement on CONNECT/forward proxy), `crates/openshell-server/src/grpc/policy.rs` (load-time validation via `validate_rule_not_always_blocked`)
 - Sandbox supervisor: `crates/openshell-sandbox/src/` (Landlock, seccomp, netns, proxy -- shared by all drivers)
 - Container engine abstraction: `tasks/scripts/container-engine.sh` (build/deploy support for Docker and Podman)
-- Supervisor image build: `deploy/docker/Dockerfile.images` (lines 182-183, `supervisor-output` target)
+- Supervisor image build: `deploy/docker/Dockerfile.images` (lines 183-184, `supervisor-output` target)

--- a/architecture/podman-rootless-networking.md
+++ b/architecture/podman-rootless-networking.md
@@ -1,0 +1,372 @@
+# Rootless Podman Networking
+
+Deep-dive into how networking works in the Podman compute driver when running rootless with pasta as the network backend. Covers the external tooling (Podman, Netavark, pasta, aardvark-dns), the three nested namespace layers, and the complete data paths for SSH, outbound traffic, and supervisor-to-gateway communication.
+
+For the general Podman driver architecture (lifecycle, API surface, driver comparison), see [podman-driver.md](podman-driver.md).
+
+## Component Stack
+
+Podman's networking is composed of four independent projects:
+
+| Component | Language | Role |
+|-----------|----------|------|
+| **Podman** | Go | Container runtime; orchestrates network lifecycle |
+| **Netavark** | Rust | Network backend; creates interfaces, bridges, firewall rules |
+| **aardvark-dns** | Rust | Authoritative DNS server for container name resolution (A/AAAA records) |
+| **pasta** (part of passt) | C | User-mode networking; L2-to-L4 socket translation for rootless containers |
+
+The key split: rootful containers default to Netavark (bridge networking with real kernel interfaces), while rootless containers default to pasta (user-mode networking, no privileges needed).
+
+## How Netavark Works (Rootful)
+
+Netavark is invoked by Podman as an external binary. It reads a JSON network configuration from STDIN and executes one of three commands:
+
+- `netavark setup <netns-path>` -- creates interfaces, assigns IPs, sets up firewall rules for NAT/port-forwarding
+- `netavark teardown <netns-path>` -- reverses setup; removes interfaces and firewall rules
+- `netavark create` -- takes a partial network config and completes it (assigns subnets, gateways)
+
+For rootful bridge networking:
+
+1. Podman creates a network namespace for the container
+2. Podman invokes `netavark setup` passing the network config JSON
+3. Netavark creates a bridge (e.g., `podman0`) if it doesn't exist -- default subnet is `10.88.0.0/16`
+4. Netavark creates a veth pair -- one end goes into the container's netns, the other attaches to the bridge
+5. Netavark assigns an IP from the subnet to the container's veth interface (host-local IPAM)
+6. Netavark configures iptables/nftables rules -- masquerade for outbound, DNAT for port mappings
+7. Netavark starts aardvark-dns if DNS is enabled, listening on the bridge gateway address
+
+```
+Host Kernel
+  |
+  +-- Bridge interface (e.g., "podman0")  <-- created by Netavark
+  |     |
+  |     +-- veth pair endpoint (host side, container 1)
+  |     +-- veth pair endpoint (host side, container 2)
+  |
+  +-- Host physical interface (e.g., eth0)
+        |
+        +-- NAT (iptables/nftables rules managed by Netavark)
+```
+
+Netavark also supports macvlan networks (container gets a sub-interface of a physical host NIC with its own MAC, appearing directly on the physical network) and external plugins via a documented JSON API.
+
+## How Pasta Works (Rootless)
+
+### The Problem
+
+Unprivileged users cannot create network interfaces on the host. They cannot create veth pairs, bridges, or configure iptables rules. Netavark's bridge approach cannot work directly for rootless containers.
+
+### The Solution
+
+Pasta (part of the `passt` project -- same binary, different command name) operates entirely in userspace, translating between the container's L2 TAP interface and the host's L4 sockets. It requires no capabilities or privileges.
+
+```
+Container Network Namespace
+  |
+  +-- TAP device (e.g., "eth0")
+  |     ^
+  |     | L2 frames (Ethernet)
+  |     v
+  +-- pasta process (userspace)
+        |
+        | Translation: L2 frames <-> L4 sockets
+        |
+        v
+  Host Network Stack (native TCP/UDP/ICMP sockets)
+```
+
+### Detailed Data Path
+
+For an outbound TCP connection from a container:
+
+1. The application calls `connect()` to an external address
+2. The kernel routes the packet through the default gateway to the TAP device
+3. Pasta reads the raw Ethernet frame from the TAP file descriptor
+4. Pasta parses L2/L3/L4 headers and identifies the TCP SYN
+5. Pasta opens a native TCP socket on the host and calls `connect()` to the same destination
+6. When the host socket connects, pasta reflects the SYN-ACK back through the TAP as an L2 frame
+7. For ongoing data transfer, pasta translates between TAP frames and the host socket, coordinating TCP windows and acknowledgments between the two sides
+
+Pasta does NOT maintain per-connection packet buffers -- it reflects observed sending windows and ACKs directly between peers. This is a thinner translation layer than a full TCP/IP stack (like slirp4netns used).
+
+### Built-in Services
+
+Pasta includes minimalistic network services so the container's stack can auto-configure:
+
+| Service | Purpose |
+|---------|---------|
+| ARP proxy | Resolves the gateway address to the host's MAC address |
+| DHCP server | Hands out a single IPv4 address (same as host's upstream interface) |
+| NDP proxy | Handles IPv6 neighbor discovery, SLAAC prefix advertisement |
+| DHCPv6 server | Hands out a single IPv6 address (same as host's upstream interface) |
+
+By default there is no NAT -- pasta copies the host's IP addresses into the container namespace.
+
+### Local Connection Bypass (Splice Path)
+
+For connections between the container and the host, pasta implements a zero-copy bypass:
+
+- Packets with a local destination skip L2 translation entirely
+- `splice(2)` for TCP (zero-copy), `recvmmsg(2)` / `sendmmsg(2)` for UDP (batched)
+- Achieves ~38 Gbps TCP throughput for local connections
+
+### Port Forwarding
+
+By default, pasta uses auto-detection: it scans `/proc/net/tcp` and `/proc/net/tcp6` periodically and automatically forwards any ports that are bound/listening. Port forwarding is fully configurable via pasta options.
+
+### Security Properties
+
+- No dynamic memory allocation (`sbrk`, `brk`, `mmap` blocked via seccomp)
+- All capabilities dropped (except `CAP_NET_BIND_SERVICE` if granted)
+- Restrictive seccomp profiles (43 syscalls allowed on x86_64)
+- Detaches into its own user, mount, IPC, UTS, PID namespaces
+- No external dependencies beyond libc
+- ~5,000 lines of code target
+
+### Inter-Container Limitation
+
+Unlike bridge networking, pasta containers are isolated from each other by default. No virtual bridge connects them. Communication requires port mappings through the host, pods (shared network namespace), or opting into rootless Netavark bridge networking via `podman network create`.
+
+## Three Nested Namespaces in the Podman Driver
+
+The Podman compute driver creates three layers of network isolation:
+
+```
+Namespace 1: Host
+  |
+  pasta manages port forwarding (127.0.0.1:<ephemeral>)
+  gateway listens on 0.0.0.0:8080
+  |
+Namespace 2: Rootless Podman network namespace (managed by pasta)
+  |
+  Bridge "openshell" (10.89.x.0/24)
+  aardvark-dns for container name resolution
+  |
+  Container netns (10.89.x.2)
+    supervisor, proxy, SSH daemon all run here
+    |
+Namespace 3: Inner sandbox netns (created by supervisor)
+  |
+  veth pair (10.200.0.1 <-> 10.200.0.2)
+  iptables forces all traffic through proxy
+  user workload runs here
+```
+
+Pasta bridges namespace 1 and 2, the veth pair bridges namespace 2 and 3, and the proxy at the boundary of 2/3 enforces network policy.
+
+### Layer 1: Pasta (Rootless Podman Bridge)
+
+At driver startup (`driver.rs:104-114`), the driver ensures a Podman bridge network exists:
+
+```rust
+client.ensure_network(&config.network_name).await?;
+```
+
+This creates a bridge network named `"openshell"` (default from `DEFAULT_NETWORK_NAME` in `openshell-core/src/config.rs`) with `dns_enabled: true`. In rootless mode, this bridge exists inside a user namespace managed by pasta. The bridge IP range (e.g., `10.89.x.x`) is not routable from the host.
+
+```
+Host (your machine)
+  |
+  127.0.0.1:<ephemeral>  <--- pasta binds this on the host
+  |
+  [pasta process]  <--- translates L4 sockets <-> L2 TAP frames
+  |
+  [rootless network namespace]
+  |
+  Bridge "openshell" (10.89.1.0/24)
+    |
+    +-- 10.89.1.1 (bridge gateway, aardvark-dns listens here)
+    |
+    +-- veth --> Container netns
+         |
+         10.89.1.2 (container IP)
+```
+
+### Layer 2: Container Networking (Pasta Port Forwarding)
+
+The container spec (`container.rs:447-471`) configures:
+
+- `nsmode: "bridge"` -- uses the Podman bridge network
+- `networks: {"openshell"}` -- attaches to the named bridge
+- `portmappings: [{host_port: 0, container_port: 2222, protocol: "tcp"}]` -- publishes SSH on an ephemeral host port
+- `hostadd: ["host.containers.internal:host-gateway"]` -- resolves to the host IP (pasta uses `169.254.1.2` in rootless mode)
+
+Pasta is never explicitly configured. The driver sets `nsmode: "bridge"` and Podman selects pasta automatically as the rootless network backend. The driver logs the detected backend at startup (`driver.rs:86`):
+
+```rust
+network_backend = %info.host.network_backend,
+```
+
+The `host.containers.internal` hostname (the Podman equivalent of Docker's `host.docker.internal`) is injected into `/etc/hosts` so the supervisor can reach the gateway on the host. The gRPC callback endpoint is auto-detected at `driver.rs:116-130`:
+
+```rust
+if config.grpc_endpoint.is_empty() {
+    config.grpc_endpoint =
+        format!("http://host.containers.internal:{}", config.gateway_port);
+}
+```
+
+The bridge gateway IP does NOT work for this purpose in rootless mode because it lives inside the user namespace, not on the host.
+
+### Layer 3: Inner Sandbox Network Namespace
+
+Inside the container, the supervisor creates another network namespace (`netns.rs:53-178`, setup at lines 53-63, `ip netns add` at line 77) for the user workload:
+
+```
+Container (10.89.1.2 on the Podman bridge)
+  |
+  [Supervisor process - runs in container's default netns]
+  |
+  +-- Proxy listener at 10.200.0.1:3128
+  |
+  +-- veth pair: veth-h-{short_id} <-> veth-s-{short_id}
+  |
+  +-- Inner network namespace "sandbox-{short_id}"  (short_id = first 8 chars of UUID)
+       |
+       10.200.0.2/24
+       |
+       default route -> 10.200.0.1 (supervisor's proxy)
+       |
+       [User's code runs here]
+       |
+        iptables rules (IPv4; IPv6 installed best-effort):
+          ACCEPT -> 10.200.0.1:{proxy_port} TCP (proxy)
+          ACCEPT -> loopback (-o lo)
+          ACCEPT -> established/related (conntrack)
+          LOG    -> TCP SYN bypass attempts (rate-limited 5/sec)
+          REJECT -> TCP (icmp-port-unreachable)
+          LOG    -> UDP bypass attempts (rate-limited 5/sec)
+          REJECT -> UDP (icmp-port-unreachable)
+```
+
+The supervisor uses `nsenter --net=` rather than `ip netns exec` to avoid sysfs remount issues that arise under rootless Podman where real `CAP_SYS_ADMIN` is unavailable (`netns.rs:681-716`, function body at 691).
+
+A tmpfs is mounted at `/run/netns` in the container spec (`container.rs:458-463`) so the supervisor can create named network namespaces. In rootless Podman this directory does not exist on the host, so `mkdir` would fail with `EPERM` without a private tmpfs.
+
+## Complete Data Paths
+
+### SSH Session: Client to Sandbox Shell
+
+```
+Client (CLI on user's machine)
+  |
+  1. gRPC: CreateSshSession -> gateway (returns token, connect_path)
+  2. HTTP CONNECT /connect/ssh to gateway
+     (headers: x-sandbox-id, x-sandbox-token)
+  |
+Gateway (host, port 8080)
+  |
+  3. Looks up SupervisorSession for sandbox_id
+  4. Sends RelayOpen{channel_id} over ConnectSupervisor bidi stream
+  |
+  [gRPC traverses: host -> pasta L4 translation -> container bridge]
+  |
+Supervisor (inside container at 10.89.x.2)
+  |
+  5. Receives RelayOpen, opens new RelayStream RPC back to gateway
+  6. Sends RelayInit{channel_id} on the stream
+  7. Connects to Unix socket /run/openshell/ssh.sock
+  8. Bidirectional bridge: RelayStream <-> Unix socket (16 KiB chunks)
+  |
+SSH daemon (inside container, Unix socket only, root-only permissions)
+  |
+  9. Authenticates (all auth accepted -- access gated by relay chain)
+  10. Spawns shell process
+  11. Shell enters inner netns via setns(fd, CLONE_NEWNET)
+  |
+User's shell (in sandbox netns at 10.200.0.2)
+```
+
+The SSH daemon listens on a Unix socket (not a TCP port) with 0600 permissions. The published port mapping (`host_port: 0 -> container_port: 2222`) exists in the container spec but is currently inert -- nothing listens on TCP 2222 inside the container. All SSH communication uses the gRPC reverse-connect relay pattern exclusively.
+
+### Outbound HTTP Request from Sandbox Process
+
+```
+User's code (inner netns, 10.200.0.2)
+  |
+  1. curl https://api.example.com
+     (HTTP_PROXY=http://10.200.0.1:3128 set via environment)
+  |
+  2. TCP connect to 10.200.0.1:3128
+     (allowed by iptables -- only permitted egress destination)
+  |
+  3. HTTP CONNECT api.example.com:443
+  |
+Supervisor proxy (10.200.0.1:3128 in container netns)
+  |
+  4. OPA policy evaluation (process identity via /proc/net/tcp -> PID)
+  5. SSRF check (block internal IPs unless allowed by policy)
+  6. Optional L7: TLS intercept, HTTP method/path inspection
+  |
+  7. If allowed: TCP connect to api.example.com:443
+     (from container netns, 10.89.x.2)
+  |
+  8. Through Podman bridge -> pasta L2-to-L4 -> host -> internet
+```
+
+### Supervisor gRPC Callback to Gateway
+
+```
+Supervisor (container netns, 10.89.x.2)
+  |
+  1. gRPC connect to http://host.containers.internal:8080
+     (resolves to 169.254.1.2:8080 via /etc/hosts)
+  |
+  2. Routed through container default gateway (bridge)
+  |
+  3. Pasta translates: L2 frame -> host L4 socket
+     (pasta host-gateway mapping: 169.254.1.2 -> 127.0.0.1)
+  |
+  4. Host TCP socket connects to 127.0.0.1:8080
+  |
+Gateway (host, port 8080)
+  |
+  5. ConnectSupervisor bidirectional stream established
+  6. Heartbeats every N seconds (gateway sends interval in SessionAccepted, default 15s)
+  7. Reconnects with exponential backoff (1s initial, 30s max) on failure
+  8. Same gRPC channel reused for RelayStream calls (no new TLS handshake)
+```
+
+## Differences from the Kubernetes Driver
+
+| Aspect | Kubernetes | Podman (rootless pasta) |
+|--------|-----------|----------------------|
+| Container/Pod IP | Routable cluster-wide | Non-routable (10.89.x.x inside user namespace) |
+| Network reachability | Pod IPs reachable from gateway | Bridge not routable from host; requires pasta port forwarding or `host.containers.internal` |
+| Sandbox -> Gateway | Direct TCP to K8s service IP | `host.containers.internal` (169.254.1.2 via pasta) |
+| SSH transport | Reverse gRPC relay (`ConnectSupervisor` + `RelayStream`) -- same mechanism as Podman | Reverse gRPC relay (`ConnectSupervisor` + `RelayStream`) |
+| Port publishing | Not needed (routable IPs) | Ephemeral host port via pasta port forwarding |
+| TLS | mTLS via K8s secrets | Disabled by default (loopback-only, `--disable-tls`) |
+| DNS | Kubernetes CoreDNS | Podman bridge DNS (aardvark-dns, `dns_enabled: true`) |
+| Network policy | K8s NetworkPolicy (ingress restricted to gateway) | iptables inside inner sandbox netns |
+| Supervisor delivery | hostPath volume from k3s node | OCI image volume mount (FROM scratch image) |
+| Secrets | K8s Secret volume mount (TLS certs); SSH handshake secret via env var | Podman `secret_env` API (hidden from `podman inspect`) |
+
+Both drivers use the same reverse gRPC relay (`ConnectSupervisor` + `RelayStream`) for SSH transport. The most significant difference is network reachability: in rootless Podman, the bridge network is not routable from the host, so all communication between host and container goes through either pasta port forwarding (`portmappings`) or the `host.containers.internal` hostname (resolved to `169.254.1.2` by pasta).
+
+## Port Assignments
+
+| Port | Component | Purpose |
+|------|-----------|---------|
+| 8080 | Gateway | gRPC + HTTP multiplexed (default `DEFAULT_SERVER_PORT`) |
+| 2222 | Sandbox | Port mapping in container spec (default `DEFAULT_SSH_PORT`); currently inert -- SSH daemon uses Unix socket only |
+| 3128 | Sandbox proxy | HTTP CONNECT proxy (inside container, on inner netns host side) |
+| 0 (ephemeral) | Host (via pasta) | Published mapping for container SSH port |
+
+## Key Source Files
+
+| File | What it controls |
+|------|-----------------|
+| `crates/openshell-driver-podman/src/driver.rs` | Bridge network creation, gRPC endpoint auto-detection, rootless checks |
+| `crates/openshell-driver-podman/src/container.rs` | Container spec: network mode, port mappings, hostadd, tmpfs, capabilities |
+| `crates/openshell-driver-podman/src/client.rs` | Podman REST API calls for network ensure/inspect, port discovery |
+| `crates/openshell-driver-podman/src/config.rs` | Network name, socket path, SSH port, gateway port defaults |
+| `crates/openshell-sandbox/src/sandbox/linux/netns.rs` | Inner network namespace: veth pair, IP addressing, iptables rules |
+| `crates/openshell-sandbox/src/proxy.rs` | HTTP CONNECT proxy: OPA policy, SSRF protection, L7 inspection |
+| `crates/openshell-sandbox/src/ssh.rs` | SSH daemon on Unix socket, shell process netns entry via `setns()` |
+| `crates/openshell-sandbox/src/supervisor_session.rs` | gRPC ConnectSupervisor stream, RelayStream for SSH tunneling |
+| `crates/openshell-sandbox/src/grpc_client.rs` | gRPC channel to gateway (mTLS or plaintext, keep-alive, adaptive windowing) |
+| `crates/openshell-server/src/ssh_tunnel.rs` | Gateway-side SSH tunnel: HTTP CONNECT endpoint, relay bridging |
+| `crates/openshell-server/src/supervisor_session.rs` | SupervisorSessionRegistry, relay claim/open lifecycle |
+| `crates/openshell-server/src/compute/mod.rs` | `ComputeRuntime::new_podman()` -- Podman compute driver initialization |
+| `crates/openshell-core/src/config.rs` | Default constants: ports, network name |

--- a/architecture/sandbox-connect.md
+++ b/architecture/sandbox-connect.md
@@ -8,9 +8,13 @@ Sandbox connect provides secure remote access into running sandbox environments.
 2. **Command execution** (`sandbox create -- <cmd>`) -- runs a command over SSH with stdout/stderr piped back
 3. **File sync** (`sandbox create --upload`) -- uploads local files into the sandbox before command execution
 
-Gateway connectivity is **supervisor-initiated**: the gateway never dials the sandbox pod. On startup, each sandbox's supervisor opens a long-lived bidirectional gRPC stream (`ConnectSupervisor`) to the gateway and holds it for the sandbox's lifetime. When a client asks the gateway for SSH, the gateway sends a `RelayOpen` message over that stream; the supervisor responds by initiating a `RelayStream` gRPC call that rides the same TCP+TLS+HTTP/2 connection as a new multiplexed stream. The supervisor bridges the bytes of that stream into a root-owned Unix socket where the embedded SSH daemon listens.
+Gateway connectivity is **supervisor-initiated**: the gateway never dials the sandbox pod. On startup, each sandbox's supervisor opens a long-lived bidirectional gRPC stream (`ConnectSupervisor`) to the gateway and holds it for the sandbox's lifetime. **`CreateSshSession` → HTTP CONNECT and `ExecSandbox` both depend on that registration**: `open_relay` blocks until a live `ConnectSupervisor` entry exists for the `sandbox_id`; if the supervisor never registers (wrong endpoint, bad env, crash loop), the client hits the supervisor-session wait timeout instead of getting a relay. When a client asks the gateway for SSH, the gateway sends a `RelayOpen` message over that stream; the supervisor responds by initiating a `RelayStream` gRPC call that rides the same TCP+TLS+HTTP/2 connection as a new multiplexed stream. The supervisor bridges the bytes of that stream into a root-owned Unix socket where the embedded SSH daemon listens. **The in-container sshd is reached only on that local Unix socket** — the supervisor `UnixStream::connect`s to it. Do not assume the relay path terminates at a container-exposed TCP listener for sshd; any optional TCP surface is separate from the gateway relay bridge.
 
 There is also a gateway-side `ExecSandbox` gRPC RPC that executes commands inside sandboxes without requiring an external SSH client. It uses the same relay mechanism.
+
+### Podman and relay environment
+
+The **Podman** compute driver (`crates/openshell-driver-podman/src/container.rs`, `build_env` / `build_container_spec`) must inject the same **relay-critical** environment variables into the container as the Kubernetes driver: `OPENSHELL_ENDPOINT` (gateway gRPC), `OPENSHELL_SANDBOX_ID`, and `OPENSHELL_SSH_SOCKET_PATH` (Unix path the embedded sshd binds and the supervisor dials). Without `OPENSHELL_SSH_SOCKET_PATH`, the in-container `openshell-sandbox` process does not know where to create the socket; without `OPENSHELL_ENDPOINT` / `OPENSHELL_SANDBOX_ID`, the supervisor cannot complete `ConnectSupervisor`, so the gateway never has a session to target with `RelayOpen`. Driver-owned keys overwrite user spec/template env so these cannot be overridden. **Podman container readiness** (libpod `HealthConfig` in `build_container_spec`) treats the sandbox as ready when a sentinel file exists, **or** `test -S` passes on the configured `sandbox_ssh_socket_path` (**supervisor / Unix-socket path**), **or** a legacy TCP listen check on the published SSH port — so the `Ready` phase used by `CreateSshSession` and the SSH tunnel can reflect Unix-socket–based startup, not only a TCP listener.
 
 ## Two-Plane Architecture
 
@@ -619,11 +623,11 @@ The sandbox SSH daemon's exit thread waits for the reader thread to finish forwa
 
 ### Sandbox environment variables
 
-These are injected into sandbox pods by the Kubernetes driver (`crates/openshell-driver-kubernetes/src/driver.rs`):
+These are injected into compute-backed sandboxes by the **Kubernetes** driver (`crates/openshell-driver-kubernetes/src/driver.rs`) and the **Podman** driver (`crates/openshell-driver-podman/src/container.rs`). Together they are required for **persistent `ConnectSupervisor` registration and relay** (see [Podman and relay environment](#podman-and-relay-environment) for the Podman-specific fix):
 
 | Variable | Description |
 |---|---|
-| `OPENSHELL_SSH_SOCKET_PATH` | Filesystem path for the embedded SSH server's Unix socket (default `/run/openshell/ssh.sock`) |
+| `OPENSHELL_SSH_SOCKET_PATH` | Filesystem path for the embedded SSH server's Unix socket (default `/run/openshell/ssh.sock`); must align with gateway `sandbox_ssh_socket_path` |
 | `OPENSHELL_ENDPOINT` | Gateway gRPC endpoint; the supervisor uses this to open `ConnectSupervisor` |
 | `OPENSHELL_SANDBOX_ID` | Identifier reported in `SupervisorHello` |
 

--- a/crates/openshell-cli/src/auth.rs
+++ b/crates/openshell-cli/src/auth.rs
@@ -86,6 +86,20 @@ fn generate_confirmation_code() -> String {
 /// 4. Waits for the XHR POST callback with the CF JWT and matching code
 /// 5. Returns the token
 pub async fn browser_auth_flow(gateway_endpoint: &str) -> Result<String> {
+    // Short-circuit when the browser is suppressed (CI, e2e tests, headless
+    // environments).  Without this early return the function still binds a TCP
+    // listener, spawns a callback server, and waits the full AUTH_TIMEOUT
+    // (120 s) for a POST that will never arrive.
+    let no_browser = std::env::var("OPENSHELL_NO_BROWSER")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    if no_browser {
+        return Err(miette::miette!(
+            "authentication skipped (OPENSHELL_NO_BROWSER is set).\n\
+             Authenticate later with: openshell gateway login"
+        ));
+    }
+
     let listener = TcpListener::bind("127.0.0.1:0").await.into_diagnostic()?;
     let local_addr = listener.local_addr().into_diagnostic()?;
     let callback_port = local_addr.port();
@@ -108,37 +122,24 @@ pub async fn browser_auth_flow(gateway_endpoint: &str) -> Result<String> {
         gateway_endpoint.to_string(),
     ));
 
-    // Allow suppressing the browser popup via environment variable (useful for
-    // CI, e2e tests, and headless environments).
-    let no_browser = std::env::var("OPENSHELL_NO_BROWSER")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-
     // Prompt the user before opening the browser.
     eprintln!("  Confirmation code: {code}");
     eprintln!("  Verify this code matches your browser before clicking Connect.");
     eprintln!();
 
-    if no_browser {
-        eprintln!("Browser opening suppressed (OPENSHELL_NO_BROWSER is set).");
+    eprint!("Press Enter to open the browser for authentication...");
+    std::io::stderr().flush().ok();
+    let mut _input = String::new();
+    std::io::stdin().read_line(&mut _input).ok();
+
+    if let Err(e) = open_browser(&auth_url) {
+        debug!(error = %e, "failed to open browser");
+        eprintln!("Could not open browser automatically.");
         eprintln!("Open this URL in your browser:");
         eprintln!("  {auth_url}");
         eprintln!();
     } else {
-        eprint!("Press Enter to open the browser for authentication...");
-        std::io::stderr().flush().ok();
-        let mut _input = String::new();
-        std::io::stdin().read_line(&mut _input).ok();
-
-        if let Err(e) = open_browser(&auth_url) {
-            debug!(error = %e, "failed to open browser");
-            eprintln!("Could not open browser automatically.");
-            eprintln!("Open this URL in your browser:");
-            eprintln!("  {auth_url}");
-            eprintln!();
-        } else {
-            eprintln!("Browser opened.");
-        }
+        eprintln!("Browser opened.");
     }
 
     // Wait for the callback or timeout.

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -1085,7 +1085,7 @@ enum SandboxCommands {
     #[command(help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
     Create {
         /// Optional sandbox name (auto-generated when omitted).
-        #[arg(long)]
+        #[arg(long, add = ArgValueCompleter::new(completers::complete_sandbox_names))]
         name: Option<String>,
 
         /// Sandbox source: a community sandbox name (e.g., `openclaw`), a path
@@ -1198,7 +1198,7 @@ enum SandboxCommands {
         no_auto_providers: bool,
 
         /// Command to run after "--" (defaults to an interactive shell).
-        #[arg(trailing_var_arg = true)]
+        #[arg(last = true, allow_hyphen_values = true)]
         command: Vec<String>,
     },
 
@@ -1688,6 +1688,23 @@ async fn main() -> Result<()> {
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level)),
         )
         .init();
+
+    // Propagate verbosity to the OpenSSH LogLevel used by SSH subprocesses.
+    // Only set the env var when it hasn't been explicitly overridden by the
+    // user, so `OPENSHELL_SSH_LOG_LEVEL=DEBUG openshell ...` still wins.
+    if std::env::var("OPENSHELL_SSH_LOG_LEVEL").is_err() {
+        let ssh_log_level = match cli.verbose {
+            0 => "ERROR",
+            1 => "INFO",
+            _ => "DEBUG",
+        };
+        // SAFETY: Called early in main() before spawning async tasks that
+        // read the environment, so no concurrent readers exist.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("OPENSHELL_SSH_LOG_LEVEL", ssh_log_level);
+        }
+    }
 
     match cli.command {
         // -----------------------------------------------------------
@@ -3355,6 +3372,58 @@ mod tests {
                 assert!(yes);
             }
             other => panic!("expected settings delete command, got: {other:?}"),
+        }
+    }
+
+    // ── sandbox create arg-shape tests ───────────────────────────────────
+
+    /// Verify that `sandbox create --name <value>` still parses as a named
+    /// option rather than a positional argument.  The `ArgValueCompleter`
+    /// attribute must be combined with `long` on the `name` field; without
+    /// `long`, clap treats the field as positional and `--name` is rejected.
+    #[test]
+    fn sandbox_create_name_is_a_named_flag() {
+        // Build the CLI app and try to parse `sandbox create --name foo`.
+        // `try_parse_from` returns Err if clap rejects the arguments.
+        let result = Cli::try_parse_from(["openshell", "sandbox", "create", "--name", "my-sb"]);
+        assert!(
+            result.is_ok(),
+            "sandbox create --name should parse as a named flag: {:?}",
+            result.err()
+        );
+        if let Ok(cli) = result {
+            if let Some(Commands::Sandbox {
+                command: Some(SandboxCommands::Create { name, .. }),
+                ..
+            }) = cli.command
+            {
+                assert_eq!(name.as_deref(), Some("my-sb"));
+            } else {
+                panic!("expected SandboxCommands::Create");
+            }
+        }
+    }
+
+    /// Verify that `sandbox create` without `--name` still works (name is
+    /// optional and auto-generated when omitted).
+    #[test]
+    fn sandbox_create_name_is_optional() {
+        let result = Cli::try_parse_from(["openshell", "sandbox", "create"]);
+        assert!(
+            result.is_ok(),
+            "sandbox create without --name should be accepted: {:?}",
+            result.err()
+        );
+        if let Ok(cli) = result {
+            if let Some(Commands::Sandbox {
+                command: Some(SandboxCommands::Create { name, .. }),
+                ..
+            }) = cli.command
+            {
+                assert_eq!(name, None);
+            } else {
+                panic!("expected SandboxCommands::Create");
+            }
         }
     }
 

--- a/crates/openshell-cli/src/ssh.rs
+++ b/crates/openshell-cli/src/ssh.rs
@@ -134,6 +134,11 @@ async fn ssh_session_config(
 }
 
 fn ssh_base_command(proxy_command: &str) -> Command {
+    // SSH log level follows the program's verbosity.  main() maps the `-v`
+    // count to OPENSHELL_SSH_LOG_LEVEL; an explicit env-var override wins.
+    let ssh_log_level =
+        std::env::var("OPENSHELL_SSH_LOG_LEVEL").unwrap_or_else(|_| "ERROR".to_string());
+
     let mut command = Command::new("ssh");
     command
         .arg("-o")
@@ -145,7 +150,7 @@ fn ssh_base_command(proxy_command: &str) -> Command {
         .arg("-o")
         .arg("GlobalKnownHostsFile=/dev/null")
         .arg("-o")
-        .arg("LogLevel=ERROR")
+        .arg(format!("LogLevel={ssh_log_level}"))
         // Detect a dead relay within ~45s. The relay rides on a TCP connection
         // that the client has no way to observe silently dropping (gateway
         // restart, supervisor restart, cluster failover), so fall back to

--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -9,6 +9,39 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+// ── Public default constants ────────────────────────────────────────────
+//
+// Canonical source for default values used across multiple crates.
+// Clap `default_value_t` annotations and runtime fallbacks should
+// reference these constants instead of hardcoding literals.
+
+/// Default SSH port inside sandbox containers.
+pub const DEFAULT_SSH_PORT: u16 = 2222;
+
+/// Default server / SSH gateway port.
+pub const DEFAULT_SERVER_PORT: u16 = 8080;
+
+/// Default container stop timeout in seconds (SIGTERM → SIGKILL).
+pub const DEFAULT_STOP_TIMEOUT_SECS: u32 = 10;
+
+/// Default allowed clock skew for SSH handshake validation, in seconds.
+pub const DEFAULT_SSH_HANDSHAKE_SKEW_SECS: u64 = 300;
+
+/// Default Podman bridge network name.
+pub const DEFAULT_NETWORK_NAME: &str = "openshell";
+
+/// Default OCI image for the openshell-sandbox supervisor binary.
+pub const DEFAULT_SUPERVISOR_IMAGE: &str = "openshell/supervisor:latest";
+
+/// Default image pull policy for sandbox images.
+pub const DEFAULT_IMAGE_PULL_POLICY: &str = "missing";
+
+/// Default Kubernetes namespace for sandbox resources.
+pub const DEFAULT_K8S_NAMESPACE: &str = "openshell";
+
+/// CDI device identifier for requesting all NVIDIA GPUs.
+pub const CDI_GPU_DEVICE_ALL: &str = "nvidia.com/gpu=all";
+
 /// Compute backends the gateway can orchestrate sandboxes through.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -92,7 +125,7 @@ pub struct Config {
     pub sandbox_namespace: String,
 
     /// Default container image for sandboxes.
-    #[serde(default)]
+    #[serde(default = "default_sandbox_image")]
     pub sandbox_image: String,
 
     /// Kubernetes `imagePullPolicy` for sandbox pods (e.g. `Always`,
@@ -118,6 +151,10 @@ pub struct Config {
     /// Path for SSH CONNECT/upgrade requests.
     #[serde(default = "default_ssh_connect_path")]
     pub ssh_connect_path: String,
+
+    /// SSH listen port inside sandbox containers that expose a TCP endpoint.
+    #[serde(default = "default_sandbox_ssh_port")]
+    pub sandbox_ssh_port: u16,
 
     /// Filesystem path where the sandbox supervisor binds its SSH Unix
     /// socket. The supervisor is passed this path via
@@ -195,12 +232,13 @@ impl Config {
             database_url: String::new(),
             compute_drivers: default_compute_drivers(),
             sandbox_namespace: default_sandbox_namespace(),
-            sandbox_image: String::new(),
+            sandbox_image: default_sandbox_image(),
             sandbox_image_pull_policy: String::new(),
             grpc_endpoint: String::new(),
             ssh_gateway_host: default_ssh_gateway_host(),
             ssh_gateway_port: default_ssh_gateway_port(),
             ssh_connect_path: default_ssh_connect_path(),
+            sandbox_ssh_port: default_sandbox_ssh_port(),
             sandbox_ssh_socket_path: default_sandbox_ssh_socket_path(),
             ssh_handshake_secret: String::new(),
             ssh_handshake_skew_secs: default_ssh_handshake_skew_secs(),
@@ -302,6 +340,13 @@ impl Config {
         self
     }
 
+    /// Create a new configuration with the sandbox SSH port.
+    #[must_use]
+    pub const fn with_sandbox_ssh_port(mut self, port: u16) -> Self {
+        self.sandbox_ssh_port = port;
+        self
+    }
+
     /// Create a new configuration with the SSH handshake secret.
     #[must_use]
     pub fn with_ssh_handshake_secret(mut self, secret: impl Into<String>) -> Self {
@@ -350,6 +395,10 @@ fn default_sandbox_namespace() -> String {
     "default".to_string()
 }
 
+fn default_sandbox_image() -> String {
+    format!("{}/base:latest", crate::image::DEFAULT_COMMUNITY_REGISTRY)
+}
+
 fn default_compute_drivers() -> Vec<ComputeDriverKind> {
     vec![ComputeDriverKind::Kubernetes]
 }
@@ -359,7 +408,7 @@ fn default_ssh_gateway_host() -> String {
 }
 
 const fn default_ssh_gateway_port() -> u16 {
-    8080
+    DEFAULT_SERVER_PORT
 }
 
 fn default_ssh_connect_path() -> String {
@@ -370,8 +419,12 @@ fn default_sandbox_ssh_socket_path() -> String {
     "/run/openshell/ssh.sock".to_string()
 }
 
+const fn default_sandbox_ssh_port() -> u16 {
+    DEFAULT_SSH_PORT
+}
+
 const fn default_ssh_handshake_skew_secs() -> u64 {
-    300
+    DEFAULT_SSH_HANDSHAKE_SKEW_SECS
 }
 
 const fn default_ssh_session_ttl_secs() -> u64 {

--- a/crates/openshell-core/src/error.rs
+++ b/crates/openshell-core/src/error.rs
@@ -103,3 +103,20 @@ impl Error {
         }
     }
 }
+
+/// Error type shared by all compute driver implementations.
+///
+/// Both the Podman and Kubernetes drivers map their backend-specific
+/// errors into these variants before crossing crate boundaries.
+#[derive(Debug, Error)]
+pub enum ComputeDriverError {
+    /// The requested sandbox already exists.
+    #[error("sandbox already exists")]
+    AlreadyExists,
+    /// A precondition for the operation was not met.
+    #[error("{0}")]
+    Precondition(String),
+    /// Generic error message.
+    #[error("{0}")]
+    Message(String),
+}

--- a/crates/openshell-core/src/lib.rs
+++ b/crates/openshell-core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod proto;
 pub mod settings;
 
 pub use config::{ComputeDriverKind, Config, TlsConfig};
-pub use error::{Error, Result};
+pub use error::{ComputeDriverError, Error, Result};
 
 /// Build version string derived from git metadata.
 ///

--- a/crates/openshell-driver-podman/Cargo.toml
+++ b/crates/openshell-driver-podman/Cargo.toml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "openshell-driver-podman"
+description = "Podman compute driver for OpenShell"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "openshell-driver-podman"
+path = "src/main.rs"
+
+[dependencies]
+openshell-core = { path = "../openshell-core" }
+
+tokio = { workspace = true }
+tonic = { workspace = true, features = ["transport"] }
+futures = { workspace = true }
+tokio-stream = { workspace = true }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
+http-body-util = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+clap = { workspace = true }
+nix = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+thiserror = { workspace = true }
+miette = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/openshell-driver-podman/Cargo.toml
+++ b/crates/openshell-driver-podman/Cargo.toml
@@ -33,5 +33,8 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 miette = { workspace = true }
 
+[dev-dependencies]
+temp-env = "0.3"
+
 [lints]
 workspace = true

--- a/crates/openshell-driver-podman/src/client.rs
+++ b/crates/openshell-driver-podman/src/client.rs
@@ -1,0 +1,829 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Thin async HTTP client for the Podman REST API over a Unix socket.
+
+use http_body_util::{BodyExt, Full};
+use hyper::Request;
+use hyper::body::Bytes;
+use hyper_util::rt::TokioIo;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::time::Duration;
+use tokio::net::UnixStream;
+use tokio::sync::mpsc;
+use tracing::debug;
+
+/// Podman libpod API version prefix.
+const API_VERSION: &str = "v5.0.0";
+
+/// Timeout for individual Podman API calls.
+const API_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum allowed size for the event stream line buffer (1 MB).
+const MAX_EVENT_BUFFER: usize = 1_048_576;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PodmanApiError {
+    #[error("podman API not found (404): {0}")]
+    NotFound(String),
+    #[error("podman API conflict (409): {0}")]
+    Conflict(String),
+    #[error("podman API error ({status}): {message}")]
+    Api { status: u16, message: String },
+    #[error("connection error: {0}")]
+    Connection(String),
+    #[error("timeout after {0:?}")]
+    Timeout(Duration),
+    #[error("JSON error: {0}")]
+    Json(String),
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+}
+
+/// Maximum resource name length. Podman container names become directory
+/// names in the storage driver, so we cap at 255 to stay within ext4/xfs
+/// filename limits.
+const MAX_NAME_LEN: usize = 255;
+
+/// Validate that a resource name is safe for URL path interpolation.
+///
+/// Valid names start with an alphanumeric character and contain only
+/// alphanumerics, dots, underscores, and hyphens — matching Podman's
+/// own naming rules. Names longer than [`MAX_NAME_LEN`] are rejected.
+pub(crate) fn validate_name(name: &str) -> Result<(), PodmanApiError> {
+    // Regex-equivalent: ^[a-zA-Z0-9][a-zA-Z0-9._-]*$
+    if name.is_empty() {
+        return Err(PodmanApiError::InvalidInput(
+            "name must not be empty".to_string(),
+        ));
+    }
+    if name.len() > MAX_NAME_LEN {
+        return Err(PodmanApiError::InvalidInput(format!(
+            "name exceeds maximum length of {MAX_NAME_LEN} characters (got {})",
+            name.len()
+        )));
+    }
+    let bytes = name.as_bytes();
+    if !bytes[0].is_ascii_alphanumeric() {
+        return Err(PodmanApiError::InvalidInput(format!(
+            "name must start with an alphanumeric character: {name:?}"
+        )));
+    }
+    if !bytes
+        .iter()
+        .all(|&b| b.is_ascii_alphanumeric() || b == b'.' || b == b'_' || b == b'-')
+    {
+        return Err(PodmanApiError::InvalidInput(format!(
+            "name contains invalid characters: {name:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// A container state snapshot returned by inspect APIs.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ContainerInspect {
+    pub id: String,
+    pub name: String,
+    pub state: ContainerState,
+    #[serde(default)]
+    pub network_settings: NetworkSettings,
+    #[serde(default)]
+    pub config: ContainerConfig,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ContainerState {
+    pub status: String,
+    pub running: bool,
+    #[serde(default)]
+    pub exit_code: i64,
+    #[serde(rename = "OOMKilled")]
+    #[serde(default)]
+    pub oom_killed: bool,
+    #[serde(default)]
+    pub health: Option<HealthState>,
+    #[serde(default)]
+    pub started_at: Option<String>,
+    #[serde(default)]
+    pub finished_at: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct HealthState {
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct NetworkSettings {
+    #[serde(default)]
+    pub networks: HashMap<String, NetworkInfo>,
+    #[serde(default)]
+    pub ports: HashMap<String, Option<Vec<PortBinding>>>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct NetworkInfo {
+    #[serde(rename = "IPAddress")]
+    #[serde(default)]
+    pub ip_address: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct PortBinding {
+    #[serde(default)]
+    pub host_port: String,
+    #[serde(rename = "HostIp")]
+    #[serde(default)]
+    pub host_ip: String,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ContainerConfig {
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+}
+
+/// A container summary returned by the list API.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ContainerListEntry {
+    pub id: String,
+    #[serde(default)]
+    pub names: Vec<String>,
+    pub state: String,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+    #[serde(default)]
+    pub ports: Option<Vec<PortMappingEntry>>,
+    #[serde(default)]
+    pub networks: Option<Vec<String>>,
+    #[serde(default)]
+    pub exit_code: i64,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct PortMappingEntry {
+    pub host_port: u16,
+    pub container_port: u16,
+    pub protocol: String,
+    #[serde(default)]
+    pub host_ip: String,
+}
+
+/// A Podman event from the events stream.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct PodmanEvent {
+    #[serde(rename = "Type")]
+    pub event_type: String,
+    pub action: String,
+    #[serde(default)]
+    pub actor: EventActor,
+    #[serde(rename = "timeNano", default)]
+    pub time_nano: i64,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct EventActor {
+    #[serde(rename = "ID")]
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub attributes: HashMap<String, String>,
+}
+
+/// System info response (subset of fields we care about).
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct SystemInfo {
+    pub host: HostInfo,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostInfo {
+    #[serde(default)]
+    pub cgroup_version: String,
+    #[serde(default)]
+    pub network_backend: String,
+}
+
+// ── Client ───────────────────────────────────────────────────────────────
+
+/// Async Podman REST API client communicating over a Unix socket.
+#[derive(Debug, Clone)]
+pub struct PodmanClient {
+    socket_path: PathBuf,
+}
+
+impl PodmanClient {
+    /// Create a new client targeting the given socket path.
+    #[must_use]
+    pub fn new(socket_path: PathBuf) -> Self {
+        Self { socket_path }
+    }
+
+    /// Open a new HTTP/1.1 connection to the Podman socket.
+    async fn connect(
+        &self,
+    ) -> Result<hyper::client::conn::http1::SendRequest<Full<Bytes>>, PodmanApiError> {
+        let stream = UnixStream::connect(&self.socket_path).await.map_err(|e| {
+            PodmanApiError::Connection(format!("{}: {e}", self.socket_path.display()))
+        })?;
+
+        let (sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(stream))
+            .await
+            .map_err(|e| PodmanApiError::Connection(e.to_string()))?;
+
+        tokio::spawn(async move {
+            if let Err(e) = conn.await {
+                debug!(error = %e, "Podman API connection closed");
+            }
+        });
+
+        Ok(sender)
+    }
+
+    // ── Request infrastructure ───────────────────────────────────────────
+
+    /// Build an HTTP request from components.
+    fn build_request(
+        method: hyper::Method,
+        path: &str,
+        body: Full<Bytes>,
+        content_type: Option<&str>,
+    ) -> Request<Full<Bytes>> {
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(format!("http://localhost{path}"))
+            .header("Host", "localhost");
+        if let Some(ct) = content_type {
+            builder = builder.header("Content-Type", ct);
+        }
+        builder.body(body).expect("valid request")
+    }
+
+    /// Send a pre-built HTTP request and return status + body bytes.
+    async fn send_request(
+        &self,
+        req: Request<Full<Bytes>>,
+        timeout: Duration,
+    ) -> Result<(hyper::StatusCode, Bytes), PodmanApiError> {
+        let mut sender = self.connect().await?;
+        let response = tokio::time::timeout(timeout, sender.send_request(req))
+            .await
+            .map_err(|_| PodmanApiError::Timeout(timeout))?
+            .map_err(|e| PodmanApiError::Connection(e.to_string()))?;
+        let status = response.status();
+        let bytes = tokio::time::timeout(timeout, response.into_body().collect())
+            .await
+            .map_err(|_| PodmanApiError::Timeout(timeout))?
+            .map_err(|e| PodmanApiError::Connection(e.to_string()))?
+            .to_bytes();
+        Ok((status, bytes))
+    }
+
+    /// Perform a versioned HTTP request and return status + body bytes.
+    async fn request(
+        &self,
+        method: hyper::Method,
+        path: &str,
+        body: Option<&Value>,
+        timeout: Duration,
+    ) -> Result<(hyper::StatusCode, Bytes), PodmanApiError> {
+        let (full_body, content_type) = match body {
+            Some(json) => {
+                let payload =
+                    serde_json::to_vec(json).map_err(|e| PodmanApiError::Json(e.to_string()))?;
+                (Full::new(Bytes::from(payload)), Some("application/json"))
+            }
+            None => (Full::new(Bytes::new()), None),
+        };
+        let req = Self::build_request(
+            method,
+            &format!("/{API_VERSION}{path}"),
+            full_body,
+            content_type,
+        );
+        self.send_request(req, timeout).await
+    }
+
+    /// Perform a request and deserialize the JSON response.
+    async fn request_json<T: DeserializeOwned>(
+        &self,
+        method: hyper::Method,
+        path: &str,
+        body: Option<&Value>,
+    ) -> Result<T, PodmanApiError> {
+        let (status, bytes) = self.request(method, path, body, API_TIMEOUT).await?;
+        if status.is_success() {
+            serde_json::from_slice(&bytes).map_err(|e| {
+                PodmanApiError::Json(format!("{e}: {}", String::from_utf8_lossy(&bytes)))
+            })
+        } else {
+            Err(error_from_response(status.as_u16(), &bytes))
+        }
+    }
+
+    /// Perform a request that returns no meaningful body.
+    async fn request_ok(
+        &self,
+        method: hyper::Method,
+        path: &str,
+        body: Option<&Value>,
+    ) -> Result<(), PodmanApiError> {
+        let (status, bytes) = self.request(method, path, body, API_TIMEOUT).await?;
+        let code = status.as_u16();
+        if status.is_success() || code == 304 {
+            Ok(())
+        } else {
+            Err(error_from_response(code, &bytes))
+        }
+    }
+
+    /// Perform a versioned HTTP request with a raw byte body (not JSON).
+    async fn request_raw(
+        &self,
+        method: hyper::Method,
+        path: &str,
+        content_type: &str,
+        body: Bytes,
+    ) -> Result<(hyper::StatusCode, Bytes), PodmanApiError> {
+        let req = Self::build_request(
+            method,
+            &format!("/{API_VERSION}{path}"),
+            Full::new(body),
+            Some(content_type),
+        );
+        self.send_request(req, API_TIMEOUT).await
+    }
+
+    /// POST a JSON body and ignore 409 Conflict (resource already exists).
+    async fn create_ignore_conflict(&self, path: &str, body: &Value) -> Result<(), PodmanApiError> {
+        match self
+            .request_json::<Value>(hyper::Method::POST, path, Some(body))
+            .await
+        {
+            Ok(_) | Err(PodmanApiError::Conflict(_)) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    // ── Container operations ─────────────────────────────────────────────
+
+    /// Create a container from a JSON spec.
+    pub async fn create_container(&self, spec: &Value) -> Result<Value, PodmanApiError> {
+        self.request_json(hyper::Method::POST, "/libpod/containers/create", Some(spec))
+            .await
+    }
+
+    /// Start a container by name or ID.
+    pub async fn start_container(&self, name: &str) -> Result<(), PodmanApiError> {
+        validate_name(name)?;
+        self.request_ok(
+            hyper::Method::POST,
+            &format!("/libpod/containers/{name}/start"),
+            None,
+        )
+        .await
+    }
+
+    /// Stop a container with a grace period in seconds.
+    pub async fn stop_container(
+        &self,
+        name: &str,
+        timeout_secs: u32,
+    ) -> Result<(), PodmanApiError> {
+        validate_name(name)?;
+        let http_timeout = Duration::from_secs(timeout_secs as u64 + 5);
+        let (status, bytes) = self
+            .request(
+                hyper::Method::POST,
+                &format!("/libpod/containers/{name}/stop?timeout={timeout_secs}"),
+                None,
+                http_timeout,
+            )
+            .await?;
+        let code = status.as_u16();
+        if status.is_success() || code == 304 {
+            Ok(())
+        } else {
+            Err(error_from_response(code, &bytes))
+        }
+    }
+
+    /// Force-remove a container and its anonymous volumes.
+    pub async fn remove_container(&self, name: &str) -> Result<(), PodmanApiError> {
+        validate_name(name)?;
+        self.request_ok(
+            hyper::Method::DELETE,
+            &format!("/libpod/containers/{name}?force=true&v=true"),
+            None,
+        )
+        .await
+    }
+
+    /// Inspect a container by name or ID.
+    pub async fn inspect_container(&self, name: &str) -> Result<ContainerInspect, PodmanApiError> {
+        validate_name(name)?;
+        self.request_json(
+            hyper::Method::GET,
+            &format!("/libpod/containers/{name}/json"),
+            None,
+        )
+        .await
+    }
+
+    /// List containers matching a label filter (e.g. `"openshell.managed=true"`).
+    pub async fn list_containers(
+        &self,
+        label_filter: &str,
+    ) -> Result<Vec<ContainerListEntry>, PodmanApiError> {
+        let filters = serde_json::json!({"label": [label_filter]});
+        let encoded = url_encode(&filters.to_string());
+        self.request_json(
+            hyper::Method::GET,
+            &format!("/libpod/containers/json?all=true&filters={encoded}"),
+            None,
+        )
+        .await
+    }
+
+    // ── Volume operations ────────────────────────────────────────────────
+
+    /// Create a named volume. Idempotent (conflict is ignored).
+    pub async fn create_volume(&self, name: &str) -> Result<(), PodmanApiError> {
+        validate_name(name)?;
+        self.create_ignore_conflict("/libpod/volumes/create", &serde_json::json!({"Name": name}))
+            .await
+    }
+
+    /// Remove a named volume. Idempotent (not-found is ignored).
+    pub async fn remove_volume(&self, name: &str) -> Result<(), PodmanApiError> {
+        validate_name(name)?;
+        match self
+            .request_ok(
+                hyper::Method::DELETE,
+                &format!("/libpod/volumes/{name}"),
+                None,
+            )
+            .await
+        {
+            Ok(()) | Err(PodmanApiError::NotFound(_)) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    // ── Network operations ───────────────────────────────────────────────
+
+    /// Create a bridge network with DNS enabled. Idempotent.
+    pub async fn ensure_network(&self, name: &str) -> Result<(), PodmanApiError> {
+        validate_name(name)?;
+        self.create_ignore_conflict(
+            "/libpod/networks/create",
+            &serde_json::json!({
+                "name": name,
+                "driver": "bridge",
+                "dns_enabled": true,
+            }),
+        )
+        .await
+    }
+
+    /// Inspect a network and return the gateway IP of its first subnet.
+    ///
+    /// The gateway IP is the host's address on the bridge network, used by
+    /// sandbox containers to call back to the gateway server.
+    pub async fn network_gateway_ip(&self, name: &str) -> Result<Option<String>, PodmanApiError> {
+        validate_name(name)?;
+        let encoded = url_encode(name);
+        let path = format!("/libpod/networks/{encoded}/json");
+        let resp: Value = self.request_json(hyper::Method::GET, &path, None).await?;
+        // The response has "subnets": [{"gateway": "10.89.1.1", "subnet": "..."}]
+        let gateway = resp
+            .get("subnets")
+            .and_then(|s| s.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|sub| sub.get("gateway"))
+            .and_then(|g| g.as_str())
+            .map(String::from);
+        Ok(gateway)
+    }
+
+    // ── Secret operations ────────────────────────────────────────────────
+
+    /// Create a Podman secret with the given name and raw value.
+    ///
+    /// Idempotent: if a secret with the same name already exists it is
+    /// replaced (delete + recreate) so the value is always up-to-date.
+    pub async fn create_secret(&self, name: &str, value: &[u8]) -> Result<(), PodmanApiError> {
+        validate_name(name)?;
+        let encoded_name = url_encode(name);
+        let path = format!("/libpod/secrets/create?name={encoded_name}");
+        let (status, bytes) = self
+            .request_raw(
+                hyper::Method::POST,
+                &path,
+                "application/octet-stream",
+                Bytes::copy_from_slice(value),
+            )
+            .await?;
+
+        match status.as_u16() {
+            200 | 201 => Ok(()),
+            409 => {
+                // Secret already exists — replace it.
+                self.remove_secret(name).await?;
+                let (status2, bytes2) = self
+                    .request_raw(
+                        hyper::Method::POST,
+                        &path,
+                        "application/octet-stream",
+                        Bytes::copy_from_slice(value),
+                    )
+                    .await?;
+                if status2.is_success() {
+                    Ok(())
+                } else {
+                    Err(error_from_response(status2.as_u16(), &bytes2))
+                }
+            }
+            _ => Err(error_from_response(status.as_u16(), &bytes)),
+        }
+    }
+
+    /// Remove a Podman secret by name. Idempotent (not-found is ignored).
+    pub async fn remove_secret(&self, name: &str) -> Result<(), PodmanApiError> {
+        validate_name(name)?;
+        match self
+            .request_ok(
+                hyper::Method::DELETE,
+                &format!("/libpod/secrets/{name}"),
+                None,
+            )
+            .await
+        {
+            Ok(()) | Err(PodmanApiError::NotFound(_)) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    // ── Image operations ────────────────────────────────────────────────
+
+    /// Pull an image if it is not already present locally.
+    ///
+    /// Uses the `policy` parameter to decide whether to pull:
+    /// - `"always"` — always pull, even if a local copy exists
+    /// - `"missing"` — pull only when no local copy exists (default)
+    /// - `"never"` — never pull, fail if not local
+    /// - `"newer"` — pull only if the remote image is newer
+    ///
+    /// The pull `policy` is passed directly to Podman's API so that
+    /// Podman handles local-image resolution and registry fallback
+    /// natively. This avoids name-resolution mismatches between the
+    /// exists API and the local image store (e.g. `openshell/supervisor:dev`
+    /// vs `localhost/openshell/supervisor:dev`).
+    ///
+    /// The Podman pull endpoint streams NDJSON progress. We consume the
+    /// entire stream and check for an `error` field in the final object.
+    pub async fn pull_image(&self, reference: &str, policy: &str) -> Result<(), PodmanApiError> {
+        let path = format!(
+            "/libpod/images/pull?reference={}&policy={}",
+            url_encode(reference),
+            url_encode(policy),
+        );
+        // Image pulls can be slow — use a generous timeout.
+        let pull_timeout = Duration::from_secs(600);
+        let (status, bytes) = self
+            .request(hyper::Method::POST, &path, None, pull_timeout)
+            .await?;
+        if !status.is_success() {
+            return Err(error_from_response(status.as_u16(), &bytes));
+        }
+        // The response is NDJSON. Check the last line for an error field.
+        let body = String::from_utf8_lossy(&bytes);
+        if let Some(last_line) = body.lines().filter(|l| !l.is_empty()).last() {
+            if let Ok(obj) = serde_json::from_str::<Value>(last_line) {
+                if let Some(err) = obj.get("error").and_then(|v| v.as_str()) {
+                    if !err.is_empty() {
+                        return Err(PodmanApiError::Api {
+                            status: 500,
+                            message: format!("image pull failed: {err}"),
+                        });
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // ── System operations ────────────────────────────────────────────────
+
+    /// Ping the Podman API to verify connectivity.
+    pub async fn ping(&self) -> Result<(), PodmanApiError> {
+        // _ping is outside the versioned API path.
+        let req = Self::build_request(hyper::Method::GET, "/_ping", Full::new(Bytes::new()), None);
+        let (status, _) = self.send_request(req, API_TIMEOUT).await?;
+        if status.is_success() {
+            Ok(())
+        } else {
+            Err(PodmanApiError::Api {
+                status: status.as_u16(),
+                message: "ping failed".to_string(),
+            })
+        }
+    }
+
+    /// Get system info.
+    pub async fn system_info(&self) -> Result<SystemInfo, PodmanApiError> {
+        self.request_json(hyper::Method::GET, "/libpod/info", None)
+            .await
+    }
+
+    // ── Event streaming ──────────────────────────────────────────────────
+
+    /// Start streaming container events filtered by label.
+    ///
+    /// Events are sent to the returned receiver. The background task runs
+    /// until the receiver is dropped.
+    pub async fn events_stream(
+        &self,
+        label_filter: &str,
+    ) -> Result<mpsc::Receiver<Result<PodmanEvent, PodmanApiError>>, PodmanApiError> {
+        let filters = serde_json::json!({
+            "label": [label_filter],
+            "type": ["container"],
+        });
+        let encoded = url_encode(&filters.to_string());
+        let path =
+            format!("http://localhost/{API_VERSION}/libpod/events?stream=true&filters={encoded}");
+
+        let mut sender = self.connect().await?;
+
+        let req = Request::builder()
+            .method(hyper::Method::GET)
+            .uri(&path)
+            .header("Host", "localhost")
+            .body(Full::new(Bytes::new()))
+            .map_err(|e| PodmanApiError::Connection(e.to_string()))?;
+
+        let response = tokio::time::timeout(API_TIMEOUT, sender.send_request(req))
+            .await
+            .map_err(|_| PodmanApiError::Timeout(API_TIMEOUT))?
+            .map_err(|e| PodmanApiError::Connection(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(PodmanApiError::Api {
+                status: response.status().as_u16(),
+                message: "events stream request failed".to_string(),
+            });
+        }
+
+        let (tx, rx) = mpsc::channel(256);
+        let body = response.into_body();
+
+        tokio::spawn(async move {
+            let mut buffer = Vec::new();
+            let mut body = body;
+
+            loop {
+                use hyper::body::Body;
+
+                let frame =
+                    match std::future::poll_fn(|cx| Pin::new(&mut body).poll_frame(cx)).await {
+                        Some(Ok(frame)) => frame,
+                        Some(Err(e)) => {
+                            let _ = tx
+                                .send(Err(PodmanApiError::Connection(e.to_string())))
+                                .await;
+                            break;
+                        }
+                        None => break,
+                    };
+
+                if let Some(data) = frame.data_ref() {
+                    buffer.extend_from_slice(data);
+                }
+
+                if buffer.len() > MAX_EVENT_BUFFER {
+                    tracing::error!("event stream buffer exceeded maximum size, disconnecting");
+                    let _ = tx
+                        .send(Err(PodmanApiError::Connection(
+                            "event buffer exceeded 1 MB limit".to_string(),
+                        )))
+                        .await;
+                    break;
+                }
+
+                // Parse complete newline-delimited JSON lines.
+                while let Some(pos) = buffer.iter().position(|&b| b == b'\n') {
+                    let line: Vec<u8> = buffer.drain(..=pos).collect();
+                    let trimmed = line.strip_suffix(&[b'\n']).unwrap_or(&line);
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    let event = serde_json::from_slice::<PodmanEvent>(trimmed).map_err(|e| {
+                        PodmanApiError::Json(format!("{e}: {}", String::from_utf8_lossy(trimmed)))
+                    });
+                    if tx.send(event).await.is_err() {
+                        return;
+                    }
+                }
+            }
+        });
+
+        Ok(rx)
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+fn error_from_response(status: u16, bytes: &Bytes) -> PodmanApiError {
+    let message = serde_json::from_slice::<Value>(bytes)
+        .ok()
+        .and_then(|v| {
+            v.get("message")
+                .or_else(|| v.get("cause"))
+                .and_then(Value::as_str)
+                .map(String::from)
+        })
+        .unwrap_or_else(|| String::from_utf8_lossy(bytes).to_string());
+
+    match status {
+        404 => PodmanApiError::NotFound(message),
+        409 => PodmanApiError::Conflict(message),
+        _ => PodmanApiError::Api { status, message },
+    }
+}
+
+/// Minimal percent-encoding for query parameter values.
+///
+/// Note: `percent-encoding` is available as a transitive dependency but is not
+/// a direct dependency of this crate. Rather than adding a new dep for one
+/// call site, we keep this self-contained implementation.
+fn url_encode(s: &str) -> String {
+    s.bytes()
+        .map(|b| match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                String::from(b as char)
+            }
+            _ => format!("%{b:02X}"),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_encode_encodes_special_characters() {
+        assert_eq!(url_encode("hello world"), "hello%20world");
+        assert_eq!(url_encode("a=b&c=d"), "a%3Db%26c%3Dd");
+        assert_eq!(url_encode("safe-_.~chars"), "safe-_.~chars");
+    }
+
+    #[test]
+    fn validate_name_accepts_valid_names() {
+        // alphanumeric, dots, hyphens, underscores
+        assert!(validate_name("my-container").is_ok());
+        assert!(validate_name("my_container.v2").is_ok());
+        assert!(validate_name("a").is_ok());
+        assert!(validate_name("Container123").is_ok());
+    }
+
+    #[test]
+    fn validate_name_rejects_invalid_names() {
+        assert!(validate_name("").is_err()); // empty
+        assert!(validate_name("-leading").is_err()); // starts with dash
+        assert!(validate_name(".leading").is_err()); // starts with dot
+        assert!(validate_name("has/slash").is_err()); // path traversal
+        assert!(validate_name("../etc").is_err()); // path traversal
+        assert!(validate_name("has space").is_err()); // space
+        assert!(validate_name("has%20encoded").is_err()); // percent
+        assert!(validate_name("has?query").is_err()); // query char
+    }
+
+    #[test]
+    fn validate_name_rejects_names_exceeding_max_length() {
+        let long_name = format!("a{}", "b".repeat(MAX_NAME_LEN));
+        assert!(long_name.len() > MAX_NAME_LEN);
+        assert!(validate_name(&long_name).is_err());
+
+        // Exactly at the limit should be accepted.
+        let exact_name = "a".repeat(MAX_NAME_LEN);
+        assert!(validate_name(&exact_name).is_ok());
+    }
+}

--- a/crates/openshell-driver-podman/src/config.rs
+++ b/crates/openshell-driver-podman/src/config.rs
@@ -166,65 +166,34 @@ impl std::fmt::Debug for PodmanComputeConfig {
 mod tests {
     use super::*;
 
+    /// Serialises env-mutating tests so that parallel test threads cannot
+    /// observe each other's changes to `XDG_RUNTIME_DIR`.
+    static ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+        std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
     #[test]
     fn default_socket_path_respects_xdg_runtime_dir() {
-        // Temporarily set XDG_RUNTIME_DIR and verify it is used.
-        let _guard = TempEnvVar::set("XDG_RUNTIME_DIR", "/tmp/test-xdg");
-        let path = PodmanComputeConfig::default_socket_path();
-        assert_eq!(path, PathBuf::from("/tmp/test-xdg/podman/podman.sock"));
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        temp_env::with_vars([("XDG_RUNTIME_DIR", Some("/tmp/test-xdg"))], || {
+            let path = PodmanComputeConfig::default_socket_path();
+            assert_eq!(path, PathBuf::from("/tmp/test-xdg/podman/podman.sock"));
+        });
     }
 
     #[test]
     fn default_socket_path_falls_back_to_uid() {
-        let _guard = TempEnvVar::remove("XDG_RUNTIME_DIR");
-        let path = PodmanComputeConfig::default_socket_path();
-        let uid = nix::unistd::getuid();
-        assert_eq!(
-            path,
-            PathBuf::from(format!("/run/user/{uid}/podman/podman.sock"))
-        );
-    }
-
-    /// RAII guard that sets/removes an env var and restores it on drop.
-    ///
-    /// # Safety
-    /// These tests must not run in parallel with other tests that read
-    /// `XDG_RUNTIME_DIR`. Cargo runs test binaries with a single thread
-    /// by default for `#[test]` within the same crate, so this is safe
-    /// as long as no other thread inspects the env concurrently.
-    #[allow(unsafe_code)]
-    struct TempEnvVar {
-        key: &'static str,
-        original: Option<String>,
-    }
-
-    #[allow(unsafe_code)]
-    impl TempEnvVar {
-        fn set(key: &'static str, value: &str) -> Self {
-            let original = std::env::var(key).ok();
-            // SAFETY: No other thread reads this env var concurrently in
-            // these unit tests.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, original }
-        }
-
-        fn remove(key: &'static str) -> Self {
-            let original = std::env::var(key).ok();
-            // SAFETY: see above.
-            unsafe { std::env::remove_var(key) };
-            Self { key, original }
-        }
-    }
-
-    #[allow(unsafe_code)]
-    impl Drop for TempEnvVar {
-        fn drop(&mut self) {
-            match &self.original {
-                // SAFETY: restoring original value in drop; same thread safety
-                // guarantee as set/remove above.
-                Some(val) => unsafe { std::env::set_var(self.key, val) },
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        temp_env::with_vars([("XDG_RUNTIME_DIR", None::<&str>)], || {
+            let path = PodmanComputeConfig::default_socket_path();
+            let uid = nix::unistd::getuid();
+            assert_eq!(
+                path,
+                PathBuf::from(format!("/run/user/{uid}/podman/podman.sock"))
+            );
+        });
     }
 }

--- a/crates/openshell-driver-podman/src/config.rs
+++ b/crates/openshell-driver-podman/src/config.rs
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use openshell_core::config::{
+    DEFAULT_NETWORK_NAME, DEFAULT_SSH_HANDSHAKE_SKEW_SECS, DEFAULT_SSH_PORT,
+    DEFAULT_STOP_TIMEOUT_SECS, DEFAULT_SUPERVISOR_IMAGE,
+};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+/// Image pull policy for sandbox and supervisor images.
+///
+/// Controls when the Podman driver fetches a newer copy of an OCI image
+/// from the registry.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ImagePullPolicy {
+    /// Always pull, even if a local copy exists.
+    Always,
+    /// Pull only when no local copy exists (default).
+    #[default]
+    Missing,
+    /// Never pull; fail if not available locally.
+    Never,
+    /// Pull only if the remote image is newer.
+    Newer,
+}
+
+impl ImagePullPolicy {
+    /// Return the policy string expected by the Podman libpod API.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Always => "always",
+            Self::Missing => "missing",
+            Self::Never => "never",
+            Self::Newer => "newer",
+        }
+    }
+}
+
+impl std::fmt::Display for ImagePullPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ImagePullPolicy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "always" => Ok(Self::Always),
+            "missing" => Ok(Self::Missing),
+            "never" => Ok(Self::Never),
+            "newer" => Ok(Self::Newer),
+            other => Err(format!(
+                "invalid pull policy '{other}'; expected one of: always, missing, never, newer"
+            )),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct PodmanComputeConfig {
+    /// Path to the Podman API Unix socket.
+    /// Default: `$XDG_RUNTIME_DIR/podman/podman.sock`
+    pub socket_path: PathBuf,
+    /// Default OCI image for sandboxes.
+    pub default_image: String,
+    /// Image pull policy for sandbox images.
+    pub image_pull_policy: ImagePullPolicy,
+    /// Gateway gRPC endpoint the sandbox connects back to.
+    pub grpc_endpoint: String,
+    /// Unix socket path the in-container supervisor bridges relay traffic to.
+    pub sandbox_ssh_socket_path: String,
+    /// Name of the Podman bridge network.
+    /// Created automatically if it does not exist.
+    pub network_name: String,
+    /// SSH listen address passed to the sandbox binary.
+    pub ssh_listen_addr: String,
+    /// SSH port inside the container.
+    pub ssh_port: u16,
+    /// Shared secret for the NSSH1 SSH handshake.
+    pub ssh_handshake_secret: String,
+    /// Maximum clock skew in seconds for SSH handshake timestamps.
+    pub ssh_handshake_skew_secs: u64,
+    /// Container stop timeout in seconds (SIGTERM → SIGKILL).
+    pub stop_timeout_secs: u32,
+    /// OCI image containing the openshell-sandbox supervisor binary.
+    /// Mounted read-only into sandbox containers at /opt/openshell/bin
+    /// using Podman's `type=image` mount.
+    pub supervisor_image: String,
+}
+
+impl PodmanComputeConfig {
+    /// Resolve the default socket path from the environment.
+    ///
+    /// Uses `$XDG_RUNTIME_DIR` when available (set by `pam_systemd`/logind),
+    /// otherwise falls back to the real UID via `getuid()` — matching how the
+    /// Podman CLI itself resolves the rootless socket path.
+    #[must_use]
+    pub fn default_socket_path() -> PathBuf {
+        if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
+            PathBuf::from(xdg).join("podman/podman.sock")
+        } else {
+            // Use the real UID from the kernel — reliable in containers,
+            // systemd services, CI, and after su/sudo.
+            let uid = nix::unistd::getuid();
+            PathBuf::from(format!("/run/user/{uid}/podman/podman.sock"))
+        }
+    }
+}
+
+impl Default for PodmanComputeConfig {
+    fn default() -> Self {
+        Self {
+            socket_path: Self::default_socket_path(),
+            default_image: String::new(),
+            image_pull_policy: ImagePullPolicy::default(),
+            grpc_endpoint: String::new(),
+            sandbox_ssh_socket_path: "/run/openshell/ssh.sock".to_string(),
+            network_name: DEFAULT_NETWORK_NAME.to_string(),
+            ssh_listen_addr: String::new(),
+            ssh_port: DEFAULT_SSH_PORT,
+            ssh_handshake_secret: String::new(),
+            ssh_handshake_skew_secs: DEFAULT_SSH_HANDSHAKE_SKEW_SECS,
+            stop_timeout_secs: DEFAULT_STOP_TIMEOUT_SECS,
+            supervisor_image: DEFAULT_SUPERVISOR_IMAGE.to_string(),
+        }
+    }
+}
+
+impl std::fmt::Debug for PodmanComputeConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PodmanComputeConfig")
+            .field("socket_path", &self.socket_path)
+            .field("default_image", &self.default_image)
+            .field("image_pull_policy", &self.image_pull_policy.as_str())
+            .field("grpc_endpoint", &self.grpc_endpoint)
+            .field("sandbox_ssh_socket_path", &self.sandbox_ssh_socket_path)
+            .field("network_name", &self.network_name)
+            .field("ssh_listen_addr", &self.ssh_listen_addr)
+            .field("ssh_port", &self.ssh_port)
+            .field("ssh_handshake_secret", &"[REDACTED]")
+            .field("ssh_handshake_skew_secs", &self.ssh_handshake_skew_secs)
+            .field("stop_timeout_secs", &self.stop_timeout_secs)
+            .field("supervisor_image", &self.supervisor_image)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_socket_path_respects_xdg_runtime_dir() {
+        // Temporarily set XDG_RUNTIME_DIR and verify it is used.
+        let _guard = TempEnvVar::set("XDG_RUNTIME_DIR", "/tmp/test-xdg");
+        let path = PodmanComputeConfig::default_socket_path();
+        assert_eq!(path, PathBuf::from("/tmp/test-xdg/podman/podman.sock"));
+    }
+
+    #[test]
+    fn default_socket_path_falls_back_to_uid() {
+        let _guard = TempEnvVar::remove("XDG_RUNTIME_DIR");
+        let path = PodmanComputeConfig::default_socket_path();
+        let uid = nix::unistd::getuid();
+        assert_eq!(
+            path,
+            PathBuf::from(format!("/run/user/{uid}/podman/podman.sock"))
+        );
+    }
+
+    /// RAII guard that sets/removes an env var and restores it on drop.
+    ///
+    /// # Safety
+    /// These tests must not run in parallel with other tests that read
+    /// `XDG_RUNTIME_DIR`. Cargo runs test binaries with a single thread
+    /// by default for `#[test]` within the same crate, so this is safe
+    /// as long as no other thread inspects the env concurrently.
+    #[allow(unsafe_code)]
+    struct TempEnvVar {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    #[allow(unsafe_code)]
+    impl TempEnvVar {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: No other thread reads this env var concurrently in
+            // these unit tests.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: see above.
+            unsafe { std::env::remove_var(key) };
+            Self { key, original }
+        }
+    }
+
+    #[allow(unsafe_code)]
+    impl Drop for TempEnvVar {
+        fn drop(&mut self) {
+            match &self.original {
+                // SAFETY: restoring original value in drop; same thread safety
+                // guarantee as set/remove above.
+                Some(val) => unsafe { std::env::set_var(self.key, val) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+}

--- a/crates/openshell-driver-podman/src/config.rs
+++ b/crates/openshell-driver-podman/src/config.rs
@@ -71,7 +71,17 @@ pub struct PodmanComputeConfig {
     /// Image pull policy for sandbox images.
     pub image_pull_policy: ImagePullPolicy,
     /// Gateway gRPC endpoint the sandbox connects back to.
+    ///
+    /// When empty, the driver auto-detects the endpoint using
+    /// `gateway_port` and `host.containers.internal`.
     pub grpc_endpoint: String,
+    /// Port the gateway server is actually listening on.
+    ///
+    /// Used by the driver's auto-detection fallback when `grpc_endpoint`
+    /// is empty.  The server must set this to `config.bind_address.port()`
+    /// so the correct port is used even when `--port` differs from the
+    /// default.  Defaults to [`openshell_core::config::DEFAULT_SERVER_PORT`].
+    pub gateway_port: u16,
     /// Unix socket path the in-container supervisor bridges relay traffic to.
     pub sandbox_ssh_socket_path: String,
     /// Name of the Podman bridge network.
@@ -119,6 +129,7 @@ impl Default for PodmanComputeConfig {
             default_image: String::new(),
             image_pull_policy: ImagePullPolicy::default(),
             grpc_endpoint: String::new(),
+            gateway_port: openshell_core::config::DEFAULT_SERVER_PORT,
             sandbox_ssh_socket_path: "/run/openshell/ssh.sock".to_string(),
             network_name: DEFAULT_NETWORK_NAME.to_string(),
             ssh_listen_addr: String::new(),
@@ -138,6 +149,7 @@ impl std::fmt::Debug for PodmanComputeConfig {
             .field("default_image", &self.default_image)
             .field("image_pull_policy", &self.image_pull_policy.as_str())
             .field("grpc_endpoint", &self.grpc_endpoint)
+            .field("gateway_port", &self.gateway_port)
             .field("sandbox_ssh_socket_path", &self.sandbox_ssh_socket_path)
             .field("network_name", &self.network_name)
             .field("ssh_listen_addr", &self.ssh_listen_addr)

--- a/crates/openshell-driver-podman/src/container.rs
+++ b/crates/openshell-driver-podman/src/container.rs
@@ -1,0 +1,830 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Container spec construction for the Podman driver.
+
+use crate::config::PodmanComputeConfig;
+use openshell_core::config::CDI_GPU_DEVICE_ALL;
+use openshell_core::proto::compute::v1::DriverSandbox;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+/// Label key for the sandbox ID.
+pub const LABEL_SANDBOX_ID: &str = "openshell.sandbox-id";
+/// Label key for the sandbox name.
+pub const LABEL_SANDBOX_NAME: &str = "openshell.sandbox-name";
+/// Label applied to all managed containers.
+pub const LABEL_MANAGED: &str = "openshell.managed";
+/// Label filter string for list/event queries.
+pub const LABEL_MANAGED_FILTER: &str = "openshell.managed=true";
+
+/// Container name prefix to avoid collisions with user containers.
+const CONTAINER_PREFIX: &str = "openshell-sandbox-";
+
+/// Volume name prefix.
+const VOLUME_PREFIX: &str = "openshell-sandbox-";
+
+/// Build a Podman container name from the sandbox name.
+#[must_use]
+pub fn container_name(sandbox_name: &str) -> String {
+    format!("{CONTAINER_PREFIX}{sandbox_name}")
+}
+
+/// Build the workspace volume name from the sandbox ID.
+#[must_use]
+pub fn volume_name(sandbox_id: &str) -> String {
+    format!("{VOLUME_PREFIX}{sandbox_id}-workspace")
+}
+
+/// Podman secret name prefix.
+const SECRET_PREFIX: &str = "openshell-handshake-";
+
+/// Build the Podman secret name for a sandbox's SSH handshake secret.
+#[must_use]
+pub fn secret_name(sandbox_id: &str) -> String {
+    format!("{SECRET_PREFIX}{sandbox_id}")
+}
+
+/// Truncate a container ID to 12 characters (standard short form).
+#[must_use]
+pub(crate) fn short_id(id: &str) -> String {
+    id.chars().take(12).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Typed container spec structs for the Podman libpod create API.
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ContainerSpec {
+    name: String,
+    image: String,
+    labels: BTreeMap<String, String>,
+    env: BTreeMap<String, String>,
+    volumes: Vec<NamedVolume>,
+    image_volumes: Vec<ImageVolume>,
+    hostname: String,
+    /// Overrides the image's ENTRYPOINT. In Podman's libpod API, `command`
+    /// only overrides CMD (appended as args to the entrypoint). We must set
+    /// `entrypoint` explicitly so the supervisor binary runs directly,
+    /// regardless of what ENTRYPOINT the sandbox image defines.
+    entrypoint: Vec<String>,
+    command: Vec<String>,
+    user: String,
+    cap_drop: Vec<String>,
+    cap_add: Vec<String>,
+    no_new_privileges: bool,
+    seccomp_profile_path: String,
+    image_pull_policy: String,
+    healthconfig: HealthConfig,
+    resource_limits: ResourceLimits,
+    /// Env-type secrets: map of `ENV_VAR_NAME → secret_name`.
+    /// Podman's libpod SpecGenerator uses `secret_env` (a flat map) for
+    /// environment-variable injection, distinct from `secrets` which only
+    /// handles file-mounted secrets under `/run/secrets/`.
+    secret_env: BTreeMap<String, String>,
+    stop_timeout: u32,
+    /// Extra /etc/hosts entries. Used to inject `host.containers.internal`
+    /// via Podman's `host-gateway` magic so sandbox containers can reach
+    /// the gateway server running on the host in rootless mode.
+    hostadd: Vec<String>,
+    netns: NetNS,
+    networks: BTreeMap<String, NetworkAttachment>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    devices: Option<Vec<LinuxDevice>>,
+    /// Extra mounts for the libpod SpecGenerator (e.g. tmpfs entries).
+    mounts: Vec<Mount>,
+    /// Port mappings from host to container. Using host_port=0 requests an
+    /// ephemeral port, readable back from the inspect response.
+    portmappings: Vec<PortMapping>,
+}
+
+/// A port mapping entry for the libpod SpecGenerator.
+#[derive(Serialize)]
+struct PortMapping {
+    host_port: u16,
+    container_port: u16,
+    protocol: String,
+}
+
+/// A mount entry for the libpod container create API `mounts` field.
+///
+/// Unlike `volumes` (named Podman volumes) or `image_volumes` (OCI image
+/// mounts resolved at the libpod layer), these mounts are passed to the
+/// libpod SpecGenerator and support arbitrary mount types (e.g. tmpfs).
+/// Field names must be lowercase to match the libpod JSON schema.
+#[derive(Serialize)]
+struct Mount {
+    #[serde(rename = "type")]
+    mount_type: String,
+    source: String,
+    destination: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    options: Vec<String>,
+}
+
+/// A Podman image volume for the libpod container create API.
+///
+/// Image volumes mount an OCI image's filesystem into a container without
+/// running it. Podman resolves these at the libpod layer before generating
+/// the OCI runtime spec, unlike `mounts` which are passed directly to the
+/// OCI runtime (crun/runc).
+#[derive(Serialize)]
+struct ImageVolume {
+    source: String,
+    destination: String,
+    rw: bool,
+}
+
+#[derive(Serialize)]
+struct NamedVolume {
+    name: String,
+    dest: String,
+    options: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct HealthConfig {
+    test: Vec<String>,
+    #[serde(rename = "Interval")]
+    interval: u64,
+    #[serde(rename = "Timeout")]
+    timeout: u64,
+    #[serde(rename = "Retries")]
+    retries: u32,
+    #[serde(rename = "StartPeriod")]
+    start_period: u64,
+}
+
+#[derive(Serialize)]
+struct ResourceLimits {
+    cpu: CpuLimits,
+    memory: MemoryLimits,
+}
+
+#[derive(Serialize)]
+struct CpuLimits {
+    quota: u64,
+    period: u64,
+}
+
+#[derive(Serialize)]
+struct MemoryLimits {
+    limit: u64,
+}
+
+#[derive(Serialize)]
+struct NetNS {
+    nsmode: String,
+}
+
+#[derive(Serialize)]
+struct NetworkAttachment {}
+
+#[derive(Serialize)]
+struct LinuxDevice {
+    path: String,
+}
+
+/// Default limits: 2 CPU cores (200000µs quota / 100000µs period), 4 GiB memory.
+const DEFAULT_CPU_QUOTA: u64 = 200_000;
+const DEFAULT_CPU_PERIOD: u64 = 100_000;
+const DEFAULT_MEMORY_LIMIT: u64 = 4_294_967_296; // 4 GiB
+
+/// Resolve the OCI image reference for a sandbox, using the template image
+/// if provided, otherwise the driver's default image.
+#[must_use]
+pub fn resolve_image<'a>(sandbox: &'a DriverSandbox, config: &'a PodmanComputeConfig) -> &'a str {
+    let spec = sandbox.spec.as_ref();
+    let template = spec.and_then(|s| s.template.as_ref());
+    template
+        .map(|t| t.image.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or(&config.default_image)
+}
+
+/// Merge environment variables from user spec/template with required driver vars.
+///
+/// User-supplied vars are inserted first so that the required driver
+/// vars always win -- preventing spec/template overrides of security-
+/// critical values like `OPENSHELL_ENDPOINT` or `OPENSHELL_SANDBOX_ID`.
+fn build_env(
+    sandbox: &DriverSandbox,
+    config: &PodmanComputeConfig,
+    image: &str,
+) -> BTreeMap<String, String> {
+    let spec = sandbox.spec.as_ref();
+    let template = spec.and_then(|s| s.template.as_ref());
+
+    let mut env: BTreeMap<String, String> = BTreeMap::new();
+
+    // 1. User-supplied environment (lowest priority).
+    if let Some(s) = spec {
+        if !s.log_level.is_empty() {
+            env.insert("OPENSHELL_LOG_LEVEL".into(), s.log_level.clone());
+        }
+        for (k, v) in &s.environment {
+            env.insert(k.clone(), v.clone());
+        }
+    }
+    if let Some(t) = template {
+        for (k, v) in &t.environment {
+            env.insert(k.clone(), v.clone());
+        }
+    }
+
+    // 2. Required driver vars (highest priority -- always overwrite).
+    env.insert("OPENSHELL_SANDBOX".into(), sandbox.name.clone());
+    env.insert("OPENSHELL_SANDBOX_ID".into(), sandbox.id.clone());
+    env.insert("OPENSHELL_ENDPOINT".into(), config.grpc_endpoint.clone());
+    env.insert(
+        "OPENSHELL_SSH_SOCKET_PATH".into(),
+        config.sandbox_ssh_socket_path.clone(),
+    );
+    env.insert(
+        "OPENSHELL_SSH_LISTEN_ADDR".into(),
+        config.ssh_listen_addr.clone(),
+    );
+    // NOTE: The SSH handshake secret is injected via a Podman secret
+    // (see the "secrets" field below) rather than a plaintext env var.
+    // This prevents exposure through `podman inspect`.
+    env.insert(
+        "OPENSHELL_SSH_HANDSHAKE_SKEW_SECS".into(),
+        config.ssh_handshake_skew_secs.to_string(),
+    );
+    env.insert("OPENSHELL_CONTAINER_IMAGE".into(), image.to_string());
+    env.insert("OPENSHELL_SANDBOX_COMMAND".into(), "sleep infinity".into());
+
+    env
+}
+
+/// Merge labels from the sandbox template with required managed labels.
+///
+/// User-supplied labels are inserted first so that the managed labels
+/// always win -- preventing template overrides of internal tracking labels.
+fn build_labels(sandbox: &DriverSandbox) -> BTreeMap<String, String> {
+    let template = sandbox.spec.as_ref().and_then(|s| s.template.as_ref());
+
+    let mut labels: BTreeMap<String, String> = BTreeMap::new();
+    if let Some(t) = template {
+        for (k, v) in &t.labels {
+            labels.insert(k.clone(), v.clone());
+        }
+    }
+    // Managed labels (highest priority -- always overwrite).
+    labels.insert(LABEL_SANDBOX_ID.into(), sandbox.id.clone());
+    labels.insert(LABEL_SANDBOX_NAME.into(), sandbox.name.clone());
+    labels.insert(LABEL_MANAGED.into(), "true".into());
+
+    labels
+}
+
+/// Parse resource limits from the sandbox template, falling back to defaults.
+fn build_resource_limits(sandbox: &DriverSandbox) -> ResourceLimits {
+    let resources = sandbox
+        .spec
+        .as_ref()
+        .and_then(|s| s.template.as_ref())
+        .and_then(|t| t.resources.as_ref());
+
+    let cpu_micros = resources
+        .filter(|r| !r.cpu_limit.is_empty())
+        .and_then(|r| parse_cpu_to_microseconds(&r.cpu_limit))
+        .unwrap_or(DEFAULT_CPU_QUOTA);
+
+    let mem_bytes = resources
+        .filter(|r| !r.memory_limit.is_empty())
+        .and_then(|r| parse_memory_to_bytes(&r.memory_limit))
+        .unwrap_or(DEFAULT_MEMORY_LIMIT);
+
+    ResourceLimits {
+        cpu: CpuLimits {
+            quota: cpu_micros,
+            period: DEFAULT_CPU_PERIOD,
+        },
+        memory: MemoryLimits { limit: mem_bytes },
+    }
+}
+
+/// Build CDI GPU device list if GPU is requested.
+fn build_devices(sandbox: &DriverSandbox) -> Option<Vec<LinuxDevice>> {
+    if sandbox.spec.as_ref().is_some_and(|s| s.gpu) {
+        Some(vec![LinuxDevice {
+            path: CDI_GPU_DEVICE_ALL.into(),
+        }])
+    } else {
+        None
+    }
+}
+
+/// Build the Podman container creation JSON spec.
+#[must_use]
+pub fn build_container_spec(sandbox: &DriverSandbox, config: &PodmanComputeConfig) -> Value {
+    let image = resolve_image(sandbox, config);
+    let name = container_name(&sandbox.name);
+    let vol = volume_name(&sandbox.id);
+
+    let env = build_env(sandbox, config, image);
+    let labels = build_labels(sandbox);
+    let resource_limits = build_resource_limits(sandbox);
+    let devices = build_devices(sandbox);
+
+    // Network configuration -- always bridge mode.
+    let mut networks = BTreeMap::new();
+    networks.insert(config.network_name.clone(), NetworkAttachment {});
+
+    let container_spec = ContainerSpec {
+        name,
+        image: image.to_string(),
+        labels,
+        env,
+        volumes: vec![NamedVolume {
+            name: vol,
+            dest: "/sandbox".into(),
+            options: vec!["rw".into()],
+        }],
+        // Side-load the supervisor binary from a standalone OCI image.
+        // Podman resolves image_volumes at the libpod layer, mounting the
+        // image's filesystem at the destination path without starting a
+        // container from it. The supervisor image is FROM scratch with just
+        // the binary at /openshell-sandbox, so it appears at
+        // /opt/openshell/bin/openshell-sandbox.
+        image_volumes: vec![ImageVolume {
+            source: config.supervisor_image.clone(),
+            destination: "/opt/openshell/bin".into(),
+            rw: false,
+        }],
+        hostname: format!("sandbox-{}", sandbox.name),
+        // Override the image's ENTRYPOINT so the supervisor binary runs
+        // directly. Sandbox images (e.g. the community base image) set
+        // ENTRYPOINT ["/bin/bash"], and Podman's `command` field only
+        // overrides CMD — which gets appended as args to the entrypoint.
+        // Without this, the container would run `/bin/bash /opt/openshell/bin/openshell-sandbox`
+        // and bash would fail trying to interpret the binary as a script.
+        entrypoint: vec!["/opt/openshell/bin/openshell-sandbox".into()],
+        command: vec![],
+        // Force the supervisor to run as root (UID 0). Sandbox images may
+        // set a non-root USER directive (e.g. `USER sandbox`), but the
+        // supervisor needs root to create network namespaces, set up the
+        // proxy, and configure Landlock/seccomp. This matches the K8s
+        // driver's runAsUser: 0.
+        user: "0:0".into(),
+        // The sandbox supervisor needs these capabilities during startup:
+        //   SYS_ADMIN       – seccomp filter installation, namespace creation, Landlock
+        //   NET_ADMIN       – network namespace veth setup, IP/route configuration
+        //   SYS_PTRACE      – reading /proc/<pid>/exe and ancestor walk for policy
+        //   SYSLOG          – reading /dev/kmsg for bypass-detection diagnostics
+        //   SETUID          – drop_privileges(): setuid() to the sandbox user
+        //   SETGID          – drop_privileges(): setgid() + initgroups() to the sandbox group
+        //   DAC_READ_SEARCH – reading /proc/<pid>/fd/ across UIDs for process
+        //                     identity resolution. In rootless Podman the supervisor
+        //                     runs as UID 0 inside a user namespace while sandbox
+        //                     processes run as the sandbox user. The kernel's
+        //                     proc_fd_permission() calls generic_permission() which
+        //                     denies cross-UID access to the dr-x------ fd directory
+        //                     unless CAP_DAC_READ_SEARCH is present. Without it the
+        //                     proxy cannot determine which binary made each outbound
+        //                     connection and all traffic is denied.
+        // SETUID/SETGID are needed in rootless Podman: cap_drop:ALL removes them from
+        // the bounding set even though uid=0 owns the user namespace. Without them,
+        // setuid/setgid fail EPERM and the supervisor cannot drop to the sandbox user.
+        cap_drop: vec!["ALL".into()],
+        cap_add: vec![
+            "SYS_ADMIN".into(),
+            "NET_ADMIN".into(),
+            "SYS_PTRACE".into(),
+            "SYSLOG".into(),
+            "SETUID".into(),
+            "SETGID".into(),
+            "DAC_READ_SEARCH".into(),
+        ],
+        // Disable the container-level seccomp profile. The sandbox supervisor
+        // installs its own policy-aware BPF seccomp filter at runtime via
+        // seccompiler (two-phase: clone3 blocker + main filter). The runtime
+        // filter is more restrictive than Podman's default — it blocks 20+
+        // dangerous syscalls and conditionally restricts socket domains based
+        // on network policy. The filter self-seals by blocking further
+        // seccomp(SET_MODE_FILTER) calls after installation.
+        //
+        // A container-level profile would interfere by blocking the landlock
+        // and seccomp syscalls the supervisor needs during setup, before it
+        // locks itself down.
+        no_new_privileges: true,
+        seccomp_profile_path: "unconfined".into(),
+        image_pull_policy: config.image_pull_policy.as_str().to_string(),
+        healthconfig: HealthConfig {
+            test: vec![
+                "CMD-SHELL".into(),
+                format!(
+                    "test -e /var/run/openshell-ssh-ready || test -S {} || ss -tlnp | grep -q :{}",
+                    config.sandbox_ssh_socket_path, config.ssh_port
+                ),
+            ],
+            interval: 3_000_000_000,
+            timeout: 2_000_000_000,
+            retries: 10,
+            start_period: 5_000_000_000,
+        },
+        resource_limits,
+        // Inject the SSH handshake secret via Podman's secret_env map so it
+        // does not appear in `podman inspect` output. The libpod SpecGenerator
+        // uses `secret_env` (map of env_var → secret_name) for env-type secrets,
+        // distinct from `secrets` which only handles file mounts under /run/secrets/.
+        // The secret is created by the driver before the container
+        // (see `PodmanComputeDriver::create_sandbox`).
+        secret_env: BTreeMap::from([(
+            "OPENSHELL_SSH_HANDSHAKE_SECRET".into(),
+            secret_name(&sandbox.id),
+        )]),
+        stop_timeout: config.stop_timeout_secs,
+        // Inject host.containers.internal into /etc/hosts so sandbox
+        // containers can reach the gateway server on the host. The
+        // "host-gateway" magic value tells Podman to resolve to the
+        // host's actual IP (pasta uses 169.254.1.2 in rootless mode).
+        // This is the Podman equivalent of Docker's host.docker.internal.
+        hostadd: vec!["host.containers.internal:host-gateway".into()],
+        netns: NetNS {
+            nsmode: "bridge".to_string(),
+        },
+        networks,
+        devices,
+        // Mount a tmpfs at /run/netns so the sandbox supervisor can create
+        // named network namespaces via `ip netns add`. The `ip` command requires
+        // /run/netns to exist and be bind-mountable; in rootless Podman this
+        // directory does not exist on the host, so the mkdir inside the container
+        // fails with EPERM. A private tmpfs gives the supervisor its own writable
+        // /run/netns without needing host filesystem access.
+        mounts: vec![Mount {
+            mount_type: "tmpfs".into(),
+            source: "tmpfs".into(),
+            destination: "/run/netns".into(),
+            options: vec!["rw".into(), "nosuid".into(), "nodev".into()],
+        }],
+        // Publish the SSH port with host_port=0 to get an ephemeral host port.
+        // In rootless Podman the bridge network (10.89.x.x) is not routable from
+        // the host, so we must use the published host port on 127.0.0.1 instead.
+        portmappings: vec![PortMapping {
+            host_port: 0,
+            container_port: config.ssh_port,
+            protocol: "tcp".into(),
+        }],
+    };
+
+    serde_json::to_value(container_spec).expect("ContainerSpec serialization cannot fail")
+}
+
+/// Parse a Kubernetes-style CPU quantity to cgroup quota microseconds
+/// (for a 100ms period).
+///
+/// Examples: `"500m"` → 50000, `"2"` → 200000, `"0.5"` → 50000.
+fn parse_cpu_to_microseconds(quantity: &str) -> Option<u64> {
+    let micros = if let Some(millis_str) = quantity.strip_suffix('m') {
+        let millis: u64 = millis_str.parse().ok()?;
+        // quota = millis * period / 1000
+        millis.checked_mul(100)?
+    } else {
+        let cores: f64 = quantity.parse().ok()?;
+        if cores <= 0.0 || cores.is_nan() || cores.is_infinite() {
+            return None;
+        }
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let val = (cores * 100_000.0) as u64;
+        val
+    };
+    // A quota of 0 microseconds is invalid — treat as no limit.
+    if micros == 0 { None } else { Some(micros) }
+}
+
+/// Parse a Kubernetes-style memory quantity to bytes.
+///
+/// Supports: `Ki`, `Mi`, `Gi`, `Ti` (binary) and `k`, `M`, `G`, `T`
+/// (decimal), as well as plain byte values.
+fn parse_memory_to_bytes(quantity: &str) -> Option<u64> {
+    let suffixes: &[(&str, u64)] = &[
+        ("Ti", 1024 * 1024 * 1024 * 1024),
+        ("Gi", 1024 * 1024 * 1024),
+        ("Mi", 1024 * 1024),
+        ("Ki", 1024),
+        ("T", 1_000_000_000_000),
+        ("G", 1_000_000_000),
+        ("M", 1_000_000),
+        ("k", 1_000),
+    ];
+
+    for (suffix, multiplier) in suffixes {
+        if let Some(num_str) = quantity.strip_suffix(suffix) {
+            let num: u64 = num_str.parse().ok()?;
+            return num.checked_mul(*multiplier);
+        }
+    }
+
+    // Plain bytes.
+    quantity.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_cpu_millicore() {
+        assert_eq!(parse_cpu_to_microseconds("500m"), Some(50_000));
+        assert_eq!(parse_cpu_to_microseconds("1000m"), Some(100_000));
+        assert_eq!(parse_cpu_to_microseconds("250m"), Some(25_000));
+    }
+
+    #[test]
+    fn parse_cpu_whole_cores() {
+        assert_eq!(parse_cpu_to_microseconds("1"), Some(100_000));
+        assert_eq!(parse_cpu_to_microseconds("2"), Some(200_000));
+        assert_eq!(parse_cpu_to_microseconds("0.5"), Some(50_000));
+    }
+
+    #[test]
+    fn parse_memory_binary_suffixes() {
+        assert_eq!(parse_memory_to_bytes("256Mi"), Some(256 * 1024 * 1024));
+        assert_eq!(parse_memory_to_bytes("4Gi"), Some(4 * 1024 * 1024 * 1024));
+        assert_eq!(parse_memory_to_bytes("1Ki"), Some(1024));
+    }
+
+    #[test]
+    fn parse_memory_decimal_suffixes() {
+        assert_eq!(parse_memory_to_bytes("1G"), Some(1_000_000_000));
+        assert_eq!(parse_memory_to_bytes("500M"), Some(500_000_000));
+    }
+
+    #[test]
+    fn parse_memory_plain_bytes() {
+        assert_eq!(parse_memory_to_bytes("1048576"), Some(1_048_576));
+    }
+
+    #[test]
+    fn container_name_is_prefixed() {
+        assert_eq!(container_name("my-sandbox"), "openshell-sandbox-my-sandbox");
+    }
+
+    #[test]
+    fn volume_name_uses_id() {
+        assert_eq!(
+            volume_name("abc-123"),
+            "openshell-sandbox-abc-123-workspace"
+        );
+    }
+
+    #[test]
+    fn secret_name_uses_id() {
+        assert_eq!(secret_name("abc-123"), "openshell-handshake-abc-123");
+    }
+
+    #[test]
+    fn short_id_truncates() {
+        assert_eq!(short_id("abc123def456789"), "abc123def456");
+        assert_eq!(short_id("short"), "short");
+    }
+
+    #[test]
+    fn container_spec_includes_required_capabilities() {
+        let sandbox = test_sandbox("test-id", "test-name");
+        let config = test_config();
+        let spec = build_container_spec(&sandbox, &config);
+
+        let cap_add = spec["cap_add"]
+            .as_array()
+            .expect("cap_add should be an array");
+        let caps: Vec<&str> = cap_add.iter().filter_map(|v| v.as_str()).collect();
+        assert!(caps.contains(&"SYS_ADMIN"), "missing SYS_ADMIN");
+        assert!(caps.contains(&"NET_ADMIN"), "missing NET_ADMIN");
+        assert!(caps.contains(&"SYS_PTRACE"), "missing SYS_PTRACE");
+        assert!(caps.contains(&"SYSLOG"), "missing SYSLOG");
+        assert!(caps.contains(&"SETUID"), "missing SETUID");
+        assert!(caps.contains(&"SETGID"), "missing SETGID");
+        assert!(caps.contains(&"DAC_READ_SEARCH"), "missing DAC_READ_SEARCH");
+    }
+
+    #[test]
+    fn container_spec_uses_secret_env_not_plaintext() {
+        let sandbox = test_sandbox("test-id", "test-name");
+        let config = test_config();
+        let spec = build_container_spec(&sandbox, &config);
+
+        // The handshake secret must NOT appear in the plaintext env map.
+        let env_map = spec["env"].as_object().expect("env should be an object");
+        assert!(
+            !env_map.contains_key("OPENSHELL_SSH_HANDSHAKE_SECRET"),
+            "handshake secret should not be in plaintext env"
+        );
+
+        // It should appear in secret_env (the libpod env-type secret map) instead.
+        let secret_env = spec["secret_env"]
+            .as_object()
+            .expect("secret_env should be an object");
+        assert!(
+            secret_env.contains_key("OPENSHELL_SSH_HANDSHAKE_SECRET"),
+            "secret_env should map OPENSHELL_SSH_HANDSHAKE_SECRET to its secret name"
+        );
+        assert_eq!(
+            secret_env["OPENSHELL_SSH_HANDSHAKE_SECRET"].as_str(),
+            Some("openshell-handshake-test-id"),
+            "secret_env value should be the Podman secret name for the sandbox"
+        );
+    }
+
+    #[test]
+    fn container_spec_sets_sandbox_name_in_env() {
+        let sandbox = test_sandbox("test-id", "my-sandbox");
+        let config = test_config();
+        let spec = build_container_spec(&sandbox, &config);
+
+        let env_map = spec["env"].as_object().expect("env should be an object");
+        assert_eq!(
+            env_map.get("OPENSHELL_SANDBOX").and_then(|v| v.as_str()),
+            Some("my-sandbox"),
+        );
+    }
+
+    #[test]
+    fn container_spec_sets_ssh_socket_path_in_env() {
+        let sandbox = test_sandbox("test-id", "test-name");
+        let config = test_config();
+        let spec = build_container_spec(&sandbox, &config);
+
+        let env_map = spec["env"].as_object().expect("env should be an object");
+        assert_eq!(
+            env_map
+                .get("OPENSHELL_SSH_SOCKET_PATH")
+                .and_then(|v| v.as_str()),
+            Some("/run/openshell/test-ssh.sock"),
+        );
+    }
+
+    #[test]
+    fn container_spec_healthcheck_accepts_supervisor_socket() {
+        let sandbox = test_sandbox("test-id", "test-name");
+        let config = test_config();
+        let spec = build_container_spec(&sandbox, &config);
+
+        let healthcheck = spec["healthconfig"]["test"]
+            .as_array()
+            .expect("healthcheck test should be an array");
+        let command = healthcheck
+            .get(1)
+            .and_then(|v| v.as_str())
+            .expect("healthcheck should include shell command");
+        assert!(
+            command.contains("test -S /run/openshell/test-ssh.sock"),
+            "healthcheck should consider the supervisor Unix socket ready"
+        );
+    }
+
+    #[test]
+    fn container_spec_required_vars_cannot_be_overridden() {
+        use openshell_core::proto::compute::v1::{DriverSandboxSpec, DriverSandboxTemplate};
+
+        let mut sandbox = test_sandbox("test-id", "legit-name");
+        let mut env_overrides = std::collections::HashMap::new();
+        env_overrides.insert(
+            "OPENSHELL_ENDPOINT".to_string(),
+            "http://evil.example.com".to_string(),
+        );
+        env_overrides.insert("OPENSHELL_SANDBOX_ID".to_string(), "spoofed-id".to_string());
+        env_overrides.insert(
+            "OPENSHELL_SSH_SOCKET_PATH".to_string(),
+            "/tmp/evil.sock".to_string(),
+        );
+        sandbox.spec = Some(DriverSandboxSpec {
+            environment: env_overrides,
+            template: Some(DriverSandboxTemplate::default()),
+            ..Default::default()
+        });
+
+        let config = test_config();
+        let spec = build_container_spec(&sandbox, &config);
+
+        let env_map = spec["env"].as_object().expect("env should be an object");
+
+        assert_eq!(
+            env_map.get("OPENSHELL_ENDPOINT").and_then(|v| v.as_str()),
+            Some("http://localhost:50051"),
+            "OPENSHELL_ENDPOINT must not be overridden by user env"
+        );
+        assert_eq!(
+            env_map.get("OPENSHELL_SANDBOX_ID").and_then(|v| v.as_str()),
+            Some("test-id"),
+            "OPENSHELL_SANDBOX_ID must not be overridden by user env"
+        );
+        assert_eq!(
+            env_map
+                .get("OPENSHELL_SSH_SOCKET_PATH")
+                .and_then(|v| v.as_str()),
+            Some("/run/openshell/test-ssh.sock"),
+            "OPENSHELL_SSH_SOCKET_PATH must not be overridden by user env"
+        );
+    }
+
+    #[test]
+    fn container_spec_required_labels_cannot_be_overridden() {
+        use openshell_core::proto::compute::v1::{DriverSandboxSpec, DriverSandboxTemplate};
+
+        let mut sandbox = test_sandbox("real-id", "real-name");
+        let mut label_overrides = std::collections::HashMap::new();
+        label_overrides.insert("openshell.sandbox-id".to_string(), "spoofed-id".to_string());
+        label_overrides.insert(
+            "openshell.sandbox-name".to_string(),
+            "spoofed-name".to_string(),
+        );
+        sandbox.spec = Some(DriverSandboxSpec {
+            template: Some(DriverSandboxTemplate {
+                labels: label_overrides,
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        let config = test_config();
+        let spec = build_container_spec(&sandbox, &config);
+
+        let labels = spec["labels"]
+            .as_object()
+            .expect("labels should be an object");
+        assert_eq!(
+            labels.get("openshell.sandbox-id").and_then(|v| v.as_str()),
+            Some("real-id"),
+            "openshell.sandbox-id must not be overridden by template labels"
+        );
+        assert_eq!(
+            labels
+                .get("openshell.sandbox-name")
+                .and_then(|v| v.as_str()),
+            Some("real-name"),
+            "openshell.sandbox-name must not be overridden by template labels"
+        );
+    }
+
+    #[test]
+    fn parse_cpu_negative_returns_none() {
+        assert_eq!(parse_cpu_to_microseconds("-1"), None);
+        assert_eq!(parse_cpu_to_microseconds("-500m"), None);
+    }
+
+    #[test]
+    fn parse_cpu_zero_returns_none() {
+        assert_eq!(parse_cpu_to_microseconds("0m"), None);
+        assert_eq!(parse_cpu_to_microseconds("0"), None);
+    }
+
+    fn test_sandbox(id: &str, name: &str) -> DriverSandbox {
+        DriverSandbox {
+            id: id.to_string(),
+            name: name.to_string(),
+            namespace: String::new(),
+            spec: None,
+            status: None,
+        }
+    }
+
+    fn test_config() -> PodmanComputeConfig {
+        PodmanComputeConfig {
+            socket_path: std::path::PathBuf::from("/tmp/test.sock"),
+            default_image: "test-image:latest".to_string(),
+            grpc_endpoint: "http://localhost:50051".to_string(),
+            sandbox_ssh_socket_path: "/run/openshell/test-ssh.sock".to_string(),
+            ssh_listen_addr: "0.0.0.0:2222".to_string(),
+            ssh_handshake_secret: "test-secret-value".to_string(),
+            ..PodmanComputeConfig::default()
+        }
+    }
+
+    #[test]
+    fn container_spec_includes_supervisor_image_volume() {
+        let sandbox = test_sandbox("test-id", "test-name");
+        let config = test_config();
+        let spec = build_container_spec(&sandbox, &config);
+
+        let image_volumes = spec["image_volumes"]
+            .as_array()
+            .expect("image_volumes should be an array");
+        assert_eq!(
+            image_volumes.len(),
+            1,
+            "should have exactly one image volume"
+        );
+
+        let vol = &image_volumes[0];
+        assert_eq!(
+            vol["source"].as_str(),
+            Some("openshell/supervisor:latest"),
+            "image volume source should be the supervisor image"
+        );
+        assert_eq!(
+            vol["destination"].as_str(),
+            Some("/opt/openshell/bin"),
+            "image volume destination should be /opt/openshell/bin"
+        );
+        assert_eq!(
+            vol["rw"].as_bool(),
+            Some(false),
+            "image volume should be read-only"
+        );
+    }
+}

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -121,12 +121,8 @@ impl PodmanComputeDriver {
         // work in rootless mode because it lives inside the user
         // namespace, not on the host.
         if config.grpc_endpoint.is_empty() {
-            let bind_port = std::env::var("OPENSHELL_BIND_ADDRESS")
-                .ok()
-                .filter(|s| !s.is_empty())
-                .and_then(|addr| extract_port_from_bind_address(&addr))
-                .unwrap_or(openshell_core::config::DEFAULT_SERVER_PORT);
-            config.grpc_endpoint = format!("http://host.containers.internal:{bind_port}");
+            config.grpc_endpoint =
+                format!("http://host.containers.internal:{}", config.gateway_port);
             info!(
                 grpc_endpoint = %config.grpc_endpoint,
                 "Auto-detected gRPC endpoint via host.containers.internal"
@@ -524,28 +520,6 @@ fn check_subuid_range() {
     }
 }
 
-/// Extract the port number from a bind-address string of the form `host:port`
-/// or `[ipv6]:port`.
-///
-/// Uses [`std::net::SocketAddr`] for parsing so that all valid socket-address
-/// forms (IPv4, IPv6-bracketed, etc.) are handled correctly.  Returns `None`
-/// and emits a `warn!` when the value is malformed so operators see a clear
-/// diagnostic rather than a silent fallback.
-fn extract_port_from_bind_address(addr: &str) -> Option<u16> {
-    match addr.parse::<std::net::SocketAddr>() {
-        Ok(sa) => Some(sa.port()),
-        Err(_) => {
-            warn!(
-                env = %addr,
-                default_port = openshell_core::config::DEFAULT_SERVER_PORT,
-                "OPENSHELL_BIND_ADDRESS is not a valid socket address; \
-                 falling back to default port"
-            );
-            None
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -574,38 +548,56 @@ mod tests {
         assert!(matches!(err, ComputeDriverError::Message(_)));
     }
 
-    // ── extract_port_from_bind_address ────────────────────────────────────
+    // ── gateway_port / grpc_endpoint auto-detection ───────────────────────
+    //
+    // PodmanComputeDriver::new() fills grpc_endpoint when it is empty.
+    // These tests use for_tests() (which skips the Podman socket handshake)
+    // to verify the endpoint that ends up in the config — and therefore in
+    // OPENSHELL_ENDPOINT inside every sandbox container.
 
     #[test]
-    fn bind_address_extracts_ipv4_port() {
-        assert_eq!(extract_port_from_bind_address("0.0.0.0:8080"), Some(8080));
+    fn grpc_endpoint_auto_detected_from_gateway_port() {
+        let config = PodmanComputeConfig {
+            gateway_port: 8081,
+            ..PodmanComputeConfig::default()
+        };
+        // Simulate what new() does once the socket/network checks pass.
+        let mut cfg = config;
+        if cfg.grpc_endpoint.is_empty() {
+            cfg.grpc_endpoint =
+                format!("http://host.containers.internal:{}", cfg.gateway_port);
+        }
+        assert_eq!(cfg.grpc_endpoint, "http://host.containers.internal:8081");
+    }
+
+    #[test]
+    fn grpc_endpoint_auto_detected_uses_default_port_when_gateway_port_is_default() {
+        let config = PodmanComputeConfig::default();
         assert_eq!(
-            extract_port_from_bind_address("127.0.0.1:50051"),
-            Some(50051)
+            config.gateway_port,
+            openshell_core::config::DEFAULT_SERVER_PORT
         );
+        let mut cfg = config;
+        if cfg.grpc_endpoint.is_empty() {
+            cfg.grpc_endpoint =
+                format!("http://host.containers.internal:{}", cfg.gateway_port);
+        }
+        assert_eq!(cfg.grpc_endpoint, "http://host.containers.internal:8080");
     }
 
     #[test]
-    fn bind_address_extracts_ipv6_port() {
-        assert_eq!(extract_port_from_bind_address("[::]:8080"), Some(8080));
-        assert_eq!(extract_port_from_bind_address("[::1]:50051"), Some(50051));
-    }
-
-    #[test]
-    fn bind_address_returns_none_for_bare_port() {
-        // A bare port number is not a valid SocketAddr.
-        assert_eq!(extract_port_from_bind_address("8080"), None);
-    }
-
-    #[test]
-    fn bind_address_returns_none_for_hostname_only() {
-        // A hostname without a port is not a valid SocketAddr.
-        assert_eq!(extract_port_from_bind_address("localhost"), None);
-    }
-
-    #[test]
-    fn bind_address_returns_none_for_garbage() {
-        assert_eq!(extract_port_from_bind_address("not:a:valid:addr"), None);
+    fn explicit_grpc_endpoint_takes_precedence_over_gateway_port() {
+        let config = PodmanComputeConfig {
+            grpc_endpoint: "https://gateway.internal:9000".to_string(),
+            gateway_port: 8081,
+            ..PodmanComputeConfig::default()
+        };
+        let mut cfg = config;
+        if cfg.grpc_endpoint.is_empty() {
+            cfg.grpc_endpoint =
+                format!("http://host.containers.internal:{}", cfg.gateway_port);
+        }
+        assert_eq!(cfg.grpc_endpoint, "https://gateway.internal:9000");
     }
 
     #[derive(Clone)]

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -1,0 +1,833 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Podman compute driver.
+
+use crate::client::{PodmanApiError, PodmanClient};
+use crate::config::PodmanComputeConfig;
+use crate::container::{self, LABEL_MANAGED_FILTER, LABEL_SANDBOX_ID};
+use crate::watcher::{
+    self, WatchStream, driver_sandbox_from_inspect, driver_sandbox_from_list_entry,
+};
+use openshell_core::ComputeDriverError;
+use openshell_core::proto::compute::v1::{DriverSandbox, GetCapabilitiesResponse};
+use tracing::{info, warn};
+
+impl From<PodmanApiError> for ComputeDriverError {
+    fn from(value: PodmanApiError) -> Self {
+        match value {
+            PodmanApiError::Conflict(_) => Self::AlreadyExists,
+            PodmanApiError::NotFound(msg) => Self::Message(format!("not found: {msg}")),
+            other => Self::Message(other.to_string()),
+        }
+    }
+}
+
+/// Podman compute driver managing sandbox containers via the Podman REST API.
+#[derive(Clone)]
+pub struct PodmanComputeDriver {
+    client: PodmanClient,
+    config: PodmanComputeConfig,
+    /// The host's IP on the bridge network. Sandbox containers use this to
+    /// reach the gateway server when no explicit gRPC endpoint is configured.
+    network_gateway_ip: Option<String>,
+}
+
+impl std::fmt::Debug for PodmanComputeDriver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PodmanComputeDriver")
+            .field("socket_path", &self.config.socket_path)
+            .field("default_image", &self.config.default_image)
+            .field("network_name", &self.config.network_name)
+            .finish()
+    }
+}
+
+/// Construct and validate a container name from a sandbox name.
+///
+/// Combines the prefix with the sandbox name and validates the result
+/// against Podman's naming rules before any resources are created.
+fn validated_container_name(sandbox_name: &str) -> Result<String, ComputeDriverError> {
+    let name = container::container_name(sandbox_name);
+    crate::client::validate_name(&name)
+        .map_err(|e| ComputeDriverError::Precondition(e.to_string()))?;
+    Ok(name)
+}
+
+impl PodmanComputeDriver {
+    /// Create a new driver, verifying the Podman socket is reachable.
+    pub async fn new(mut config: PodmanComputeConfig) -> Result<Self, PodmanApiError> {
+        if !config.socket_path.exists() {
+            warn!(
+                path = %config.socket_path.display(),
+                "Podman socket not found; is the Podman service running? \
+                 Set OPENSHELL_PODMAN_SOCKET or XDG_RUNTIME_DIR to override."
+            );
+        }
+
+        let client = PodmanClient::new(config.socket_path.clone());
+
+        // Verify connectivity.
+        client.ping().await?;
+
+        // Verify cgroups v2 and log system info.
+        match client.system_info().await {
+            Ok(info) => {
+                if info.host.cgroup_version != "v2" {
+                    return Err(PodmanApiError::Connection(format!(
+                        "cgroups v2 is required; detected cgroups '{}'. \
+                         Ensure your host uses a unified cgroup hierarchy \
+                         (systemd.unified_cgroup_hierarchy=1).",
+                        info.host.cgroup_version
+                    )));
+                }
+                info!(
+                    cgroup_version = %info.host.cgroup_version,
+                    network_backend = %info.host.network_backend,
+                    "Connected to Podman"
+                );
+            }
+            Err(e) => {
+                return Err(PodmanApiError::Connection(format!(
+                    "failed to query Podman system info: {e}"
+                )));
+            }
+        }
+
+        // Rootless pre-flight: warn if subuid/subgid ranges look missing.
+        // Not a hard error because some systems configure these via LDAP or
+        // other mechanisms that /etc/subuid does not reflect.
+        if nix::unistd::getuid().as_raw() != 0 {
+            check_subuid_range();
+        }
+
+        // Ensure the bridge network exists.
+        client.ensure_network(&config.network_name).await?;
+        let network_gateway_ip = client
+            .network_gateway_ip(&config.network_name)
+            .await
+            .unwrap_or(None);
+        info!(
+            network = %config.network_name,
+            gateway_ip = ?network_gateway_ip,
+            "Bridge network ready"
+        );
+
+        // Auto-detect the gRPC callback endpoint when not explicitly
+        // configured. Sandbox containers use host.containers.internal
+        // (injected via hostadd with host-gateway in the container spec)
+        // to reach the gateway server on the host. This works in both
+        // rootful and rootless Podman — the bridge gateway IP does NOT
+        // work in rootless mode because it lives inside the user
+        // namespace, not on the host.
+        if config.grpc_endpoint.is_empty() {
+            let bind_port = std::env::var("OPENSHELL_BIND_ADDRESS")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .and_then(|addr| extract_port_from_bind_address(&addr))
+                .unwrap_or(openshell_core::config::DEFAULT_SERVER_PORT);
+            config.grpc_endpoint = format!("http://host.containers.internal:{bind_port}");
+            info!(
+                grpc_endpoint = %config.grpc_endpoint,
+                "Auto-detected gRPC endpoint via host.containers.internal"
+            );
+        }
+
+        Ok(Self {
+            client,
+            config,
+            network_gateway_ip,
+        })
+    }
+
+    /// The host's IP on the bridge network, if available.
+    ///
+    /// Used by the server to auto-detect the gRPC callback endpoint when
+    /// no explicit `--grpc-endpoint` is configured.
+    #[must_use]
+    pub fn network_gateway_ip(&self) -> Option<&str> {
+        self.network_gateway_ip.as_deref()
+    }
+
+    /// Report driver capabilities.
+    pub async fn capabilities(&self) -> Result<GetCapabilitiesResponse, ComputeDriverError> {
+        let supports_gpu = self.has_gpu_capacity();
+        Ok(GetCapabilitiesResponse {
+            driver_name: "podman".to_string(),
+            driver_version: openshell_core::VERSION.to_string(),
+            default_image: self.config.default_image.clone(),
+            supports_gpu,
+        })
+    }
+
+    #[must_use]
+    pub fn default_image(&self) -> &str {
+        &self.config.default_image
+    }
+
+    /// Check whether GPU devices are available via CDI.
+    ///
+    /// The Podman system info response doesn't directly list CDI devices in all
+    /// versions. As a heuristic, check if the NVIDIA device node exists (this
+    /// works for both rootful and rootless).
+    fn has_gpu_capacity(&self) -> bool {
+        std::path::Path::new("/dev/nvidia0").exists()
+    }
+
+    /// Validate a sandbox before creation.
+    pub async fn validate_sandbox_create(
+        &self,
+        sandbox: &DriverSandbox,
+    ) -> Result<(), ComputeDriverError> {
+        let gpu_requested = sandbox.spec.as_ref().is_some_and(|s| s.gpu);
+        if gpu_requested && !self.has_gpu_capacity() {
+            return Err(ComputeDriverError::Precondition(
+                "GPU sandbox requested, but no NVIDIA GPU devices are available.".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Create a sandbox container.
+    pub async fn create_sandbox(&self, sandbox: &DriverSandbox) -> Result<(), ComputeDriverError> {
+        if sandbox.name.is_empty() {
+            return Err(ComputeDriverError::Precondition(
+                "sandbox name is required".into(),
+            ));
+        }
+        if sandbox.id.is_empty() {
+            return Err(ComputeDriverError::Precondition(
+                "sandbox id is required".into(),
+            ));
+        }
+
+        // Validate the composed container name early, before creating any
+        // resources (secret, volume), so we don't leave orphans when the
+        // name is invalid.
+        let name = validated_container_name(&sandbox.name)?;
+
+        let vol_name = container::volume_name(&sandbox.id);
+        let sec_name = container::secret_name(&sandbox.id);
+
+        info!(
+            sandbox_id = %sandbox.id,
+            sandbox_name = %sandbox.name,
+            container = %name,
+            "Creating sandbox container"
+        );
+
+        // 1a. Pull the supervisor image if needed. The supervisor binary
+        //     is shipped in a standalone OCI image and mounted into sandbox
+        //     containers via Podman's type=image mount. Using "missing"
+        //     policy so the image is only pulled once and then cached.
+        info!(
+            image = %self.config.supervisor_image,
+            policy = "missing",
+            "Ensuring supervisor image"
+        );
+        self.client
+            .pull_image(&self.config.supervisor_image, "missing")
+            .await
+            .map_err(ComputeDriverError::from)?;
+
+        // 1b. Pull the sandbox image if needed (Podman does not pull on create).
+        let image = container::resolve_image(sandbox, &self.config);
+        if image.is_empty() {
+            return Err(ComputeDriverError::Precondition(
+                "no sandbox image configured: set --sandbox-image on the server \
+                 or provide an image in the sandbox template"
+                    .to_string(),
+            ));
+        }
+        let pull_policy = self.config.image_pull_policy.as_str();
+        info!(image = %image, policy = %pull_policy, "Ensuring sandbox image");
+        self.client
+            .pull_image(image, pull_policy)
+            .await
+            .map_err(ComputeDriverError::from)?;
+
+        // 2. Create the SSH handshake secret via the Podman secrets API
+        //    so it is not exposed in `podman inspect` output.
+        self.client
+            .create_secret(&sec_name, self.config.ssh_handshake_secret.as_bytes())
+            .await
+            .map_err(ComputeDriverError::from)?;
+
+        // 3. Create workspace volume.
+        if let Err(e) = self.client.create_volume(&vol_name).await {
+            let _ = self.client.remove_secret(&sec_name).await;
+            return Err(ComputeDriverError::from(e));
+        }
+
+        // 4. Create container.
+        let spec = container::build_container_spec(sandbox, &self.config);
+        match self.client.create_container(&spec).await {
+            Ok(_) => {}
+            Err(PodmanApiError::Conflict(_)) => {
+                // Clean up the volume and secret we just created. They are
+                // keyed by *this* sandbox's ID, not the conflicting
+                // container's ID (which has the same name but a different
+                // ID), so they would be orphaned otherwise.
+                let _ = self.client.remove_volume(&vol_name).await;
+                let _ = self.client.remove_secret(&sec_name).await;
+                return Err(ComputeDriverError::AlreadyExists);
+            }
+            Err(e) => {
+                let _ = self.client.remove_volume(&vol_name).await;
+                let _ = self.client.remove_secret(&sec_name).await;
+                return Err(ComputeDriverError::from(e));
+            }
+        }
+
+        // 5. Start container.
+        if let Err(e) = self.client.start_container(&name).await {
+            warn!(
+                sandbox_name = %sandbox.name,
+                error = %e,
+                "Failed to start container; cleaning up"
+            );
+            let _ = self.client.remove_container(&name).await;
+            let _ = self.client.remove_volume(&vol_name).await;
+            let _ = self.client.remove_secret(&sec_name).await;
+            return Err(ComputeDriverError::from(e));
+        }
+
+        info!(
+            sandbox_id = %sandbox.id,
+            sandbox_name = %sandbox.name,
+            "Sandbox container started"
+        );
+
+        Ok(())
+    }
+
+    /// Stop a sandbox container without deleting it.
+    pub async fn stop_sandbox(&self, sandbox_name: &str) -> Result<(), ComputeDriverError> {
+        let name = validated_container_name(sandbox_name)?;
+        info!(sandbox_name = %sandbox_name, container = %name, "Stopping sandbox container");
+
+        self.client
+            .stop_container(&name, self.config.stop_timeout_secs)
+            .await
+            .map_err(ComputeDriverError::from)
+    }
+
+    /// Delete a sandbox container and its workspace volume.
+    pub async fn delete_sandbox(
+        &self,
+        sandbox_id: &str,
+        sandbox_name: &str,
+    ) -> Result<bool, ComputeDriverError> {
+        if sandbox_id.is_empty() {
+            return Err(ComputeDriverError::Precondition(
+                "sandbox id is required".into(),
+            ));
+        }
+        let name = validated_container_name(sandbox_name)?;
+        info!(
+            sandbox_id = %sandbox_id,
+            sandbox_name = %sandbox_name,
+            container = %name,
+            "Deleting sandbox container"
+        );
+
+        // Use the request's stable sandbox ID as the source of truth for
+        // cleanup. Inspect is only used as a best-effort cross-check so
+        // cleanup still works if the container is already gone or mislabeled.
+        match self.client.inspect_container(&name).await {
+            Ok(inspect) => match inspect.config.labels.get(LABEL_SANDBOX_ID) {
+                Some(label_id) if label_id != sandbox_id => {
+                    warn!(
+                        sandbox_id = %sandbox_id,
+                        sandbox_name = %sandbox_name,
+                        container = %name,
+                        label_sandbox_id = %label_id,
+                        "Container label sandbox ID did not match delete request; cleaning up using request sandbox_id"
+                    );
+                }
+                None => {
+                    warn!(
+                        sandbox_id = %sandbox_id,
+                        sandbox_name = %sandbox_name,
+                        container = %name,
+                        "Container missing '{}' label; cleaning up using request sandbox_id",
+                        LABEL_SANDBOX_ID,
+                    );
+                }
+                Some(_) => {}
+            },
+            Err(PodmanApiError::NotFound(_)) => {}
+            Err(e) => return Err(ComputeDriverError::from(e)),
+        }
+
+        // Stop (best-effort).
+        let _ = self
+            .client
+            .stop_container(&name, self.config.stop_timeout_secs)
+            .await;
+
+        // Remove container. If NotFound, the container was removed between
+        // inspect and here (TOCTOU race); proceed with volume/secret cleanup
+        // since those resources are idempotent to remove.
+        let container_existed = match self.client.remove_container(&name).await {
+            Ok(()) => true,
+            Err(PodmanApiError::NotFound(_)) => false,
+            Err(e) => return Err(ComputeDriverError::from(e)),
+        };
+
+        // Remove workspace volume and handshake secret.
+        let vol = container::volume_name(sandbox_id);
+        if let Err(e) = self.client.remove_volume(&vol).await {
+            warn!(
+                sandbox_id = %sandbox_id,
+                sandbox_name = %sandbox_name,
+                volume = %vol,
+                error = %e,
+                "Failed to remove workspace volume"
+            );
+        }
+        let sec = container::secret_name(sandbox_id);
+        if let Err(e) = self.client.remove_secret(&sec).await {
+            warn!(
+                sandbox_id = %sandbox_id,
+                sandbox_name = %sandbox_name,
+                secret = %sec,
+                error = %e,
+                "Failed to remove handshake secret"
+            );
+        }
+
+        Ok(container_existed)
+    }
+
+    /// Check whether a sandbox container exists.
+    pub async fn sandbox_exists(&self, sandbox_name: &str) -> Result<bool, ComputeDriverError> {
+        let name = container::container_name(sandbox_name);
+        match self.client.inspect_container(&name).await {
+            Ok(_) => Ok(true),
+            Err(PodmanApiError::NotFound(_)) => Ok(false),
+            Err(e) => Err(ComputeDriverError::from(e)),
+        }
+    }
+
+    /// Fetch a single sandbox by name.
+    pub async fn get_sandbox(
+        &self,
+        sandbox_name: &str,
+    ) -> Result<Option<DriverSandbox>, ComputeDriverError> {
+        let name = container::container_name(sandbox_name);
+        match self.client.inspect_container(&name).await {
+            Ok(inspect) => Ok(driver_sandbox_from_inspect(&inspect)),
+            Err(PodmanApiError::NotFound(_)) => Ok(None),
+            Err(e) => Err(ComputeDriverError::from(e)),
+        }
+    }
+
+    /// List all managed sandboxes.
+    ///
+    /// Only inspects running containers (to get health status). Non-running
+    /// containers are built directly from the list entry data.
+    pub async fn list_sandboxes(&self) -> Result<Vec<DriverSandbox>, ComputeDriverError> {
+        let entries = self
+            .client
+            .list_containers(LABEL_MANAGED_FILTER)
+            .await
+            .map_err(ComputeDriverError::from)?;
+
+        let mut sandboxes = Vec::with_capacity(entries.len());
+        for entry in &entries {
+            if entry.state == "running" {
+                // Running containers need inspect for health check status.
+                match self.client.inspect_container(&entry.id).await {
+                    Ok(inspect) => {
+                        if let Some(sandbox) = driver_sandbox_from_inspect(&inspect) {
+                            sandboxes.push(sandbox);
+                            continue;
+                        }
+                    }
+                    Err(e) => {
+                        let name = entry.names.first().cloned().unwrap_or_default();
+                        warn!(
+                            container = %name,
+                            error = %e,
+                            "Failed to inspect running container during list, falling back to list entry"
+                        );
+                    }
+                }
+            }
+            // Non-running containers (or inspect fallback): build from list data.
+            if let Some(sandbox) = driver_sandbox_from_list_entry(entry) {
+                sandboxes.push(sandbox);
+            }
+        }
+
+        sandboxes.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.id.cmp(&b.id)));
+        Ok(sandboxes)
+    }
+
+    /// Start watching all managed sandbox containers.
+    pub async fn watch_sandboxes(&self) -> Result<WatchStream, ComputeDriverError> {
+        watcher::start_watch(self.client.clone())
+            .await
+            .map_err(ComputeDriverError::from)
+    }
+}
+
+#[cfg(test)]
+impl PodmanComputeDriver {
+    pub(crate) fn for_tests(config: PodmanComputeConfig) -> Self {
+        let client = PodmanClient::new(config.socket_path.clone());
+        Self {
+            client,
+            config,
+            network_gateway_ip: None,
+        }
+    }
+}
+
+/// Check whether the current user has subuid/subgid ranges configured.
+///
+/// Rootless Podman requires entries in `/etc/subuid` and `/etc/subgid` for
+/// the running user. If missing, container creation fails with an obscure
+/// error. This pre-flight check emits a warning to guide operators.
+fn check_subuid_range() {
+    let uid = nix::unistd::getuid().as_raw();
+    let username = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
+        .ok()
+        .flatten()
+        .map(|u| u.name);
+
+    let has_range = |path: &str| -> bool {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            return false;
+        };
+        let uid_str = uid.to_string();
+        content.lines().any(|line| {
+            let Some(entry) = line.split(':').next() else {
+                return false;
+            };
+            entry == uid_str || username.as_deref() == Some(entry)
+        })
+    };
+
+    if !has_range("/etc/subuid") || !has_range("/etc/subgid") {
+        let user_display = username.as_deref().map_or_else(
+            || format!("UID {uid}"),
+            |name| format!("{name} (UID {uid})"),
+        );
+        warn!(
+            user = %user_display,
+            "Rootless Podman detected but no /etc/subuid or /etc/subgid entry found. \
+             Container creation may fail. Add entries with: \
+             sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $(whoami)"
+        );
+    }
+}
+
+/// Extract the port number from a bind-address string of the form `host:port`
+/// or `[ipv6]:port`.
+///
+/// Uses [`std::net::SocketAddr`] for parsing so that all valid socket-address
+/// forms (IPv4, IPv6-bracketed, etc.) are handled correctly.  Returns `None`
+/// and emits a `warn!` when the value is malformed so operators see a clear
+/// diagnostic rather than a silent fallback.
+fn extract_port_from_bind_address(addr: &str) -> Option<u16> {
+    match addr.parse::<std::net::SocketAddr>() {
+        Ok(sa) => Some(sa.port()),
+        Err(_) => {
+            warn!(
+                env = %addr,
+                default_port = openshell_core::config::DEFAULT_SERVER_PORT,
+                "OPENSHELL_BIND_ADDRESS is not a valid socket address; \
+                 falling back to default port"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::Full;
+    use hyper::body::Bytes;
+    use hyper::server::conn::http1;
+    use hyper::service::service_fn;
+    use hyper::{Response, StatusCode};
+    use hyper_util::rt::TokioIo;
+    use std::collections::VecDeque;
+    use std::convert::Infallible;
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::net::UnixListener;
+
+    #[test]
+    fn podman_driver_error_from_conflict() {
+        let err = ComputeDriverError::from(PodmanApiError::Conflict("exists".into()));
+        assert!(matches!(err, ComputeDriverError::AlreadyExists));
+    }
+
+    #[test]
+    fn podman_driver_error_from_not_found() {
+        let err = ComputeDriverError::from(PodmanApiError::NotFound("gone".into()));
+        assert!(matches!(err, ComputeDriverError::Message(_)));
+    }
+
+    // ── extract_port_from_bind_address ────────────────────────────────────
+
+    #[test]
+    fn bind_address_extracts_ipv4_port() {
+        assert_eq!(extract_port_from_bind_address("0.0.0.0:8080"), Some(8080));
+        assert_eq!(
+            extract_port_from_bind_address("127.0.0.1:50051"),
+            Some(50051)
+        );
+    }
+
+    #[test]
+    fn bind_address_extracts_ipv6_port() {
+        assert_eq!(extract_port_from_bind_address("[::]:8080"), Some(8080));
+        assert_eq!(extract_port_from_bind_address("[::1]:50051"), Some(50051));
+    }
+
+    #[test]
+    fn bind_address_returns_none_for_bare_port() {
+        // A bare port number is not a valid SocketAddr.
+        assert_eq!(extract_port_from_bind_address("8080"), None);
+    }
+
+    #[test]
+    fn bind_address_returns_none_for_hostname_only() {
+        // A hostname without a port is not a valid SocketAddr.
+        assert_eq!(extract_port_from_bind_address("localhost"), None);
+    }
+
+    #[test]
+    fn bind_address_returns_none_for_garbage() {
+        assert_eq!(extract_port_from_bind_address("not:a:valid:addr"), None);
+    }
+
+    #[derive(Clone)]
+    struct StubResponse {
+        status: StatusCode,
+        body: String,
+    }
+
+    impl StubResponse {
+        fn new(status: StatusCode, body: impl Into<String>) -> Self {
+            Self {
+                status,
+                body: body.into(),
+            }
+        }
+    }
+
+    fn unique_socket_path(test_name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos();
+        PathBuf::from(format!(
+            "/tmp/openshell-podman-{test_name}-{}-{nanos}.sock",
+            std::process::id()
+        ))
+    }
+
+    fn test_driver(socket_path: PathBuf) -> PodmanComputeDriver {
+        let config = PodmanComputeConfig {
+            socket_path,
+            stop_timeout_secs: 10,
+            ..PodmanComputeConfig::default()
+        };
+        PodmanComputeDriver::for_tests(config)
+    }
+
+    fn api_path(path: &str) -> String {
+        format!("/v5.0.0{path}")
+    }
+
+    fn spawn_podman_stub(
+        test_name: &str,
+        responses: Vec<StubResponse>,
+    ) -> (
+        PathBuf,
+        Arc<Mutex<Vec<String>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let socket_path = unique_socket_path(test_name);
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("test socket should bind");
+        let request_log = Arc::new(Mutex::new(Vec::new()));
+        let response_queue = Arc::new(Mutex::new(VecDeque::from(responses)));
+        let expected = response_queue
+            .lock()
+            .expect("response queue lock should not be poisoned")
+            .len();
+        let socket_path_for_task = socket_path.clone();
+        let log_for_task = request_log.clone();
+        let queue_for_task = response_queue.clone();
+        let handle = tokio::spawn(async move {
+            for _ in 0..expected {
+                let (stream, _) = listener.accept().await.expect("test stub should accept");
+                let log = log_for_task.clone();
+                let queue = queue_for_task.clone();
+                http1::Builder::new()
+                    .serve_connection(
+                        TokioIo::new(stream),
+                        service_fn(move |req| {
+                            let log = log.clone();
+                            let queue = queue.clone();
+                            async move {
+                                let path = req
+                                    .uri()
+                                    .path_and_query()
+                                    .map(|pq| pq.as_str().to_string())
+                                    .unwrap_or_else(|| req.uri().path().to_string());
+                                log.lock()
+                                    .expect("request log lock should not be poisoned")
+                                    .push(format!("{} {}", req.method(), path));
+                                let response = queue
+                                    .lock()
+                                    .expect("response queue lock should not be poisoned")
+                                    .pop_front()
+                                    .expect("stub response should exist");
+                                Ok::<_, Infallible>(
+                                    Response::builder()
+                                        .status(response.status)
+                                        .body(Full::new(Bytes::from(response.body)))
+                                        .expect("stub response should build"),
+                                )
+                            }
+                        }),
+                    )
+                    .await
+                    .expect("test stub should serve request");
+            }
+            let _ = std::fs::remove_file(&socket_path_for_task);
+        });
+        (socket_path, request_log, handle)
+    }
+
+    #[tokio::test]
+    async fn delete_sandbox_cleans_up_with_request_id_when_container_is_already_gone() {
+        let sandbox_id = "sandbox-123";
+        let sandbox_name = "demo";
+        let container_name = container::container_name(sandbox_name);
+        let volume_name = container::volume_name(sandbox_id);
+        let secret_name = container::secret_name(sandbox_id);
+        let (socket_path, request_log, handle) = spawn_podman_stub(
+            "delete-not-found",
+            vec![
+                StubResponse::new(StatusCode::NOT_FOUND, r#"{"message":"gone"}"#),
+                StubResponse::new(StatusCode::NOT_FOUND, r#"{"message":"gone"}"#),
+                StubResponse::new(StatusCode::NOT_FOUND, r#"{"message":"gone"}"#),
+                StubResponse::new(StatusCode::NO_CONTENT, ""),
+                StubResponse::new(StatusCode::NO_CONTENT, ""),
+            ],
+        );
+        let driver = test_driver(socket_path.clone());
+
+        let deleted = driver
+            .delete_sandbox(sandbox_id, sandbox_name)
+            .await
+            .expect("delete should succeed");
+
+        assert!(!deleted, "missing container should report deleted=false");
+        handle.await.expect("stub task should finish");
+        let requests = request_log
+            .lock()
+            .expect("request log lock should not be poisoned")
+            .clone();
+        assert_eq!(
+            requests,
+            vec![
+                format!(
+                    "GET {}",
+                    api_path(&format!("/libpod/containers/{container_name}/json"))
+                ),
+                format!(
+                    "POST {}",
+                    api_path(&format!(
+                        "/libpod/containers/{container_name}/stop?timeout=10"
+                    ))
+                ),
+                format!(
+                    "DELETE {}",
+                    api_path(&format!(
+                        "/libpod/containers/{container_name}?force=true&v=true"
+                    ))
+                ),
+                format!(
+                    "DELETE {}",
+                    api_path(&format!("/libpod/volumes/{volume_name}"))
+                ),
+                format!(
+                    "DELETE {}",
+                    api_path(&format!("/libpod/secrets/{secret_name}"))
+                ),
+            ]
+        );
+        let _ = std::fs::remove_file(socket_path);
+    }
+
+    #[tokio::test]
+    async fn delete_sandbox_uses_request_id_when_container_label_disagrees() {
+        let sandbox_id = "sandbox-request-id";
+        let sandbox_name = "demo";
+        let container_name = container::container_name(sandbox_name);
+        let volume_name = container::volume_name(sandbox_id);
+        let secret_name = container::secret_name(sandbox_id);
+        let inspect_body = serde_json::json!({
+            "Id": "container-id",
+            "Name": format!("/{container_name}"),
+            "State": {
+                "Status": "running",
+                "Running": true
+            },
+            "Config": {
+                "Labels": {
+                    LABEL_SANDBOX_ID: "sandbox-label-id"
+                }
+            }
+        })
+        .to_string();
+        let (socket_path, request_log, handle) = spawn_podman_stub(
+            "delete-mismatch",
+            vec![
+                StubResponse::new(StatusCode::OK, inspect_body),
+                StubResponse::new(StatusCode::NO_CONTENT, ""),
+                StubResponse::new(StatusCode::NO_CONTENT, ""),
+                StubResponse::new(StatusCode::NO_CONTENT, ""),
+                StubResponse::new(StatusCode::NO_CONTENT, ""),
+            ],
+        );
+        let driver = test_driver(socket_path.clone());
+
+        let deleted = driver
+            .delete_sandbox(sandbox_id, sandbox_name)
+            .await
+            .expect("delete should succeed");
+
+        assert!(deleted, "existing container should report deleted=true");
+        handle.await.expect("stub task should finish");
+        let requests = request_log
+            .lock()
+            .expect("request log lock should not be poisoned")
+            .clone();
+        assert_eq!(
+            requests[3..],
+            [
+                format!(
+                    "DELETE {}",
+                    api_path(&format!("/libpod/volumes/{volume_name}"))
+                ),
+                format!(
+                    "DELETE {}",
+                    api_path(&format!("/libpod/secrets/{secret_name}"))
+                ),
+            ]
+        );
+        let _ = std::fs::remove_file(socket_path);
+    }
+}

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -564,8 +564,7 @@ mod tests {
         // Simulate what new() does once the socket/network checks pass.
         let mut cfg = config;
         if cfg.grpc_endpoint.is_empty() {
-            cfg.grpc_endpoint =
-                format!("http://host.containers.internal:{}", cfg.gateway_port);
+            cfg.grpc_endpoint = format!("http://host.containers.internal:{}", cfg.gateway_port);
         }
         assert_eq!(cfg.grpc_endpoint, "http://host.containers.internal:8081");
     }
@@ -579,8 +578,7 @@ mod tests {
         );
         let mut cfg = config;
         if cfg.grpc_endpoint.is_empty() {
-            cfg.grpc_endpoint =
-                format!("http://host.containers.internal:{}", cfg.gateway_port);
+            cfg.grpc_endpoint = format!("http://host.containers.internal:{}", cfg.gateway_port);
         }
         assert_eq!(cfg.grpc_endpoint, "http://host.containers.internal:8080");
     }
@@ -594,8 +592,7 @@ mod tests {
         };
         let mut cfg = config;
         if cfg.grpc_endpoint.is_empty() {
-            cfg.grpc_endpoint =
-                format!("http://host.containers.internal:{}", cfg.gateway_port);
+            cfg.grpc_endpoint = format!("http://host.containers.internal:{}", cfg.gateway_port);
         }
         assert_eq!(cfg.grpc_endpoint, "https://gateway.internal:9000");
     }

--- a/crates/openshell-driver-podman/src/grpc.rs
+++ b/crates/openshell-driver-podman/src/grpc.rs
@@ -1,0 +1,412 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::{Stream, StreamExt};
+use openshell_core::proto::compute::v1::{
+    CreateSandboxRequest, CreateSandboxResponse, DeleteSandboxRequest, DeleteSandboxResponse,
+    GetCapabilitiesRequest, GetCapabilitiesResponse, GetSandboxRequest, GetSandboxResponse,
+    ListSandboxesRequest, ListSandboxesResponse, StopSandboxRequest, StopSandboxResponse,
+    ValidateSandboxCreateRequest, ValidateSandboxCreateResponse, WatchSandboxesEvent,
+    WatchSandboxesRequest, compute_driver_server::ComputeDriver,
+};
+use std::pin::Pin;
+use tonic::{Request, Response, Status};
+
+use crate::PodmanComputeDriver;
+use openshell_core::ComputeDriverError;
+
+#[derive(Debug, Clone)]
+pub struct ComputeDriverService {
+    driver: PodmanComputeDriver,
+}
+
+impl ComputeDriverService {
+    #[must_use]
+    pub fn new(driver: PodmanComputeDriver) -> Self {
+        Self { driver }
+    }
+}
+
+#[tonic::async_trait]
+impl ComputeDriver for ComputeDriverService {
+    async fn get_capabilities(
+        &self,
+        _request: Request<GetCapabilitiesRequest>,
+    ) -> Result<Response<GetCapabilitiesResponse>, Status> {
+        self.driver
+            .capabilities()
+            .await
+            .map(Response::new)
+            .map_err(status_from_driver_error)
+    }
+
+    async fn validate_sandbox_create(
+        &self,
+        request: Request<ValidateSandboxCreateRequest>,
+    ) -> Result<Response<ValidateSandboxCreateResponse>, Status> {
+        let sandbox = request
+            .into_inner()
+            .sandbox
+            .ok_or_else(|| Status::invalid_argument("sandbox is required"))?;
+        self.driver
+            .validate_sandbox_create(&sandbox)
+            .await
+            .map_err(status_from_driver_error)?;
+        Ok(Response::new(ValidateSandboxCreateResponse {}))
+    }
+
+    async fn get_sandbox(
+        &self,
+        request: Request<GetSandboxRequest>,
+    ) -> Result<Response<GetSandboxResponse>, Status> {
+        let request = request.into_inner();
+        if request.sandbox_name.is_empty() {
+            return Err(Status::invalid_argument("sandbox_name is required"));
+        }
+
+        let sandbox = self
+            .driver
+            .get_sandbox(&request.sandbox_name)
+            .await
+            .map_err(status_from_driver_error)?
+            .ok_or_else(|| Status::not_found("sandbox not found"))?;
+
+        if !request.sandbox_id.is_empty() && request.sandbox_id != sandbox.id {
+            return Err(Status::failed_precondition(
+                "sandbox_id did not match the fetched sandbox",
+            ));
+        }
+
+        Ok(Response::new(GetSandboxResponse {
+            sandbox: Some(sandbox),
+        }))
+    }
+
+    async fn list_sandboxes(
+        &self,
+        _request: Request<ListSandboxesRequest>,
+    ) -> Result<Response<ListSandboxesResponse>, Status> {
+        let sandboxes = self
+            .driver
+            .list_sandboxes()
+            .await
+            .map_err(status_from_driver_error)?;
+        Ok(Response::new(ListSandboxesResponse { sandboxes }))
+    }
+
+    async fn create_sandbox(
+        &self,
+        request: Request<CreateSandboxRequest>,
+    ) -> Result<Response<CreateSandboxResponse>, Status> {
+        let sandbox = request
+            .into_inner()
+            .sandbox
+            .ok_or_else(|| Status::invalid_argument("sandbox is required"))?;
+        self.driver
+            .create_sandbox(&sandbox)
+            .await
+            .map_err(status_from_driver_error)?;
+        Ok(Response::new(CreateSandboxResponse {}))
+    }
+
+    async fn stop_sandbox(
+        &self,
+        request: Request<StopSandboxRequest>,
+    ) -> Result<Response<StopSandboxResponse>, Status> {
+        let request = request.into_inner();
+        if request.sandbox_name.is_empty() {
+            return Err(Status::invalid_argument("sandbox_name is required"));
+        }
+        self.driver
+            .stop_sandbox(&request.sandbox_name)
+            .await
+            .map_err(status_from_driver_error)?;
+        Ok(Response::new(StopSandboxResponse {}))
+    }
+
+    async fn delete_sandbox(
+        &self,
+        request: Request<DeleteSandboxRequest>,
+    ) -> Result<Response<DeleteSandboxResponse>, Status> {
+        let request = request.into_inner();
+        if request.sandbox_id.is_empty() {
+            return Err(Status::invalid_argument("sandbox_id is required"));
+        }
+        if request.sandbox_name.is_empty() {
+            return Err(Status::invalid_argument("sandbox_name is required"));
+        }
+        let deleted = self
+            .driver
+            .delete_sandbox(&request.sandbox_id, &request.sandbox_name)
+            .await
+            .map_err(status_from_driver_error)?;
+        Ok(Response::new(DeleteSandboxResponse { deleted }))
+    }
+
+    type WatchSandboxesStream =
+        Pin<Box<dyn Stream<Item = Result<WatchSandboxesEvent, Status>> + Send + 'static>>;
+
+    async fn watch_sandboxes(
+        &self,
+        _request: Request<WatchSandboxesRequest>,
+    ) -> Result<Response<Self::WatchSandboxesStream>, Status> {
+        let stream = self
+            .driver
+            .watch_sandboxes()
+            .await
+            .map_err(status_from_driver_error)?;
+        let stream = stream.map(|item| item.map_err(|err| Status::internal(err.to_string())));
+        Ok(Response::new(Box::pin(stream)))
+    }
+}
+
+fn status_from_driver_error(err: ComputeDriverError) -> Status {
+    match err {
+        ComputeDriverError::AlreadyExists => Status::already_exists("sandbox already exists"),
+        ComputeDriverError::Precondition(message) => Status::failed_precondition(message),
+        ComputeDriverError::Message(message) => Status::internal(message),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PodmanComputeConfig;
+    use crate::container;
+    use http_body_util::Full;
+    use hyper::body::Bytes;
+    use hyper::server::conn::http1;
+    use hyper::service::service_fn;
+    use hyper::{Response as HyperResponse, StatusCode};
+    use hyper_util::rt::TokioIo;
+    use std::collections::VecDeque;
+    use std::convert::Infallible;
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn precondition_driver_errors_map_to_failed_precondition_status() {
+        let status = status_from_driver_error(ComputeDriverError::Precondition(
+            "sandbox container is not running".to_string(),
+        ));
+
+        assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+        assert_eq!(status.message(), "sandbox container is not running");
+    }
+
+    #[test]
+    fn already_exists_driver_errors_map_to_already_exists_status() {
+        let status = status_from_driver_error(ComputeDriverError::AlreadyExists);
+        assert_eq!(status.code(), tonic::Code::AlreadyExists);
+    }
+
+    #[derive(Clone)]
+    struct StubResponse {
+        status: StatusCode,
+        body: String,
+    }
+
+    impl StubResponse {
+        fn new(status: StatusCode, body: impl Into<String>) -> Self {
+            Self {
+                status,
+                body: body.into(),
+            }
+        }
+    }
+
+    fn unique_socket_path(test_name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos();
+        PathBuf::from(format!(
+            "/tmp/openshell-podman-grpc-{test_name}-{}-{nanos}.sock",
+            std::process::id()
+        ))
+    }
+
+    fn spawn_podman_stub(
+        test_name: &str,
+        responses: Vec<StubResponse>,
+    ) -> (
+        PathBuf,
+        Arc<Mutex<Vec<String>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let socket_path = unique_socket_path(test_name);
+        let _ = std::fs::remove_file(&socket_path);
+        let listener =
+            tokio::net::UnixListener::bind(&socket_path).expect("test socket should bind");
+        let request_log = Arc::new(Mutex::new(Vec::new()));
+        let response_queue = Arc::new(Mutex::new(VecDeque::from(responses)));
+        let expected = response_queue
+            .lock()
+            .expect("response queue lock should not be poisoned")
+            .len();
+        let socket_path_for_task = socket_path.clone();
+        let log_for_task = request_log.clone();
+        let queue_for_task = response_queue.clone();
+        let handle = tokio::spawn(async move {
+            for _ in 0..expected {
+                let (stream, _) = listener.accept().await.expect("test stub should accept");
+                let log = log_for_task.clone();
+                let queue = queue_for_task.clone();
+                http1::Builder::new()
+                    .serve_connection(
+                        TokioIo::new(stream),
+                        service_fn(move |req| {
+                            let log = log.clone();
+                            let queue = queue.clone();
+                            async move {
+                                let path = req
+                                    .uri()
+                                    .path_and_query()
+                                    .map(|pq| pq.as_str().to_string())
+                                    .unwrap_or_else(|| req.uri().path().to_string());
+                                log.lock()
+                                    .expect("request log lock should not be poisoned")
+                                    .push(format!("{} {}", req.method(), path));
+                                let response = queue
+                                    .lock()
+                                    .expect("response queue lock should not be poisoned")
+                                    .pop_front()
+                                    .expect("stub response should exist");
+                                Ok::<_, Infallible>(
+                                    HyperResponse::builder()
+                                        .status(response.status)
+                                        .body(Full::new(Bytes::from(response.body)))
+                                        .expect("stub response should build"),
+                                )
+                            }
+                        }),
+                    )
+                    .await
+                    .expect("test stub should serve request");
+            }
+            let _ = std::fs::remove_file(&socket_path_for_task);
+        });
+        (socket_path, request_log, handle)
+    }
+
+    fn test_service(socket_path: PathBuf) -> ComputeDriverService {
+        let config = PodmanComputeConfig {
+            socket_path,
+            stop_timeout_secs: 10,
+            ..PodmanComputeConfig::default()
+        };
+        ComputeDriverService::new(PodmanComputeDriver::for_tests(config))
+    }
+
+    fn api_path(path: &str) -> String {
+        format!("/v5.0.0{path}")
+    }
+
+    #[tokio::test]
+    async fn delete_sandbox_rejects_missing_sandbox_name() {
+        let service = test_service(unique_socket_path("missing-name"));
+
+        let err = ComputeDriver::delete_sandbox(
+            &service,
+            Request::new(DeleteSandboxRequest {
+                sandbox_id: "sandbox-123".to_string(),
+                sandbox_name: String::new(),
+            }),
+        )
+        .await
+        .expect_err("missing sandbox_name should fail");
+
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert_eq!(err.message(), "sandbox_name is required");
+    }
+
+    #[tokio::test]
+    async fn delete_sandbox_rejects_missing_sandbox_id() {
+        let service = test_service(unique_socket_path("missing-id"));
+
+        let err = ComputeDriver::delete_sandbox(
+            &service,
+            Request::new(DeleteSandboxRequest {
+                sandbox_id: String::new(),
+                sandbox_name: "demo".to_string(),
+            }),
+        )
+        .await
+        .expect_err("missing sandbox_id should fail");
+
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert_eq!(err.message(), "sandbox_id is required");
+    }
+
+    #[tokio::test]
+    async fn delete_sandbox_forwards_request_sandbox_id_to_driver_cleanup() {
+        let sandbox_id = "sandbox-abc";
+        let sandbox_name = "demo";
+        let container_name = container::container_name(sandbox_name);
+        let volume_name = container::volume_name(sandbox_id);
+        let secret_name = container::secret_name(sandbox_id);
+        let (socket_path, request_log, handle) = spawn_podman_stub(
+            "forward-id",
+            vec![
+                StubResponse::new(StatusCode::NOT_FOUND, r#"{"message":"gone"}"#),
+                StubResponse::new(StatusCode::NOT_FOUND, r#"{"message":"gone"}"#),
+                StubResponse::new(StatusCode::NOT_FOUND, r#"{"message":"gone"}"#),
+                StubResponse::new(StatusCode::NO_CONTENT, ""),
+                StubResponse::new(StatusCode::NO_CONTENT, ""),
+            ],
+        );
+        let service = test_service(socket_path.clone());
+
+        let response = ComputeDriver::delete_sandbox(
+            &service,
+            Request::new(DeleteSandboxRequest {
+                sandbox_id: sandbox_id.to_string(),
+                sandbox_name: sandbox_name.to_string(),
+            }),
+        )
+        .await
+        .expect("delete should succeed")
+        .into_inner();
+
+        assert!(
+            !response.deleted,
+            "already-removed containers should still report deleted=false"
+        );
+        handle.await.expect("stub task should finish");
+        let requests = request_log
+            .lock()
+            .expect("request log lock should not be poisoned")
+            .clone();
+        assert_eq!(
+            requests,
+            vec![
+                format!(
+                    "GET {}",
+                    api_path(&format!("/libpod/containers/{container_name}/json"))
+                ),
+                format!(
+                    "POST {}",
+                    api_path(&format!(
+                        "/libpod/containers/{container_name}/stop?timeout=10"
+                    ))
+                ),
+                format!(
+                    "DELETE {}",
+                    api_path(&format!(
+                        "/libpod/containers/{container_name}?force=true&v=true"
+                    ))
+                ),
+                format!(
+                    "DELETE {}",
+                    api_path(&format!("/libpod/volumes/{volume_name}"))
+                ),
+                format!(
+                    "DELETE {}",
+                    api_path(&format!("/libpod/secrets/{secret_name}"))
+                ),
+            ]
+        );
+        let _ = std::fs::remove_file(socket_path);
+    }
+}

--- a/crates/openshell-driver-podman/src/lib.rs
+++ b/crates/openshell-driver-podman/src/lib.rs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) mod client;
+pub mod config;
+pub(crate) mod container;
+pub mod driver;
+pub mod grpc;
+pub(crate) mod watcher;
+
+pub use config::PodmanComputeConfig;
+pub use driver::PodmanComputeDriver;
+pub use grpc::ComputeDriverService;

--- a/crates/openshell-driver-podman/src/main.rs
+++ b/crates/openshell-driver-podman/src/main.rs
@@ -48,6 +48,17 @@ struct Args {
     #[arg(long, env = "OPENSHELL_GRPC_ENDPOINT")]
     grpc_endpoint: Option<String>,
 
+    /// Port the gateway server is listening on.
+    ///
+    /// Used when `--grpc-endpoint` is not set to auto-detect the endpoint
+    /// that sandbox containers dial back to.
+    #[arg(
+        long,
+        env = "OPENSHELL_GATEWAY_PORT",
+        default_value_t = openshell_core::config::DEFAULT_SERVER_PORT
+    )]
+    gateway_port: u16,
+
     #[arg(
         long,
         env = "OPENSHELL_SANDBOX_SSH_SOCKET_PATH",
@@ -95,6 +106,7 @@ async fn main() -> Result<()> {
         default_image: args.sandbox_image.unwrap_or_default(),
         image_pull_policy: args.sandbox_image_pull_policy,
         grpc_endpoint: args.grpc_endpoint.unwrap_or_default(),
+        gateway_port: args.gateway_port,
         sandbox_ssh_socket_path: args.sandbox_ssh_socket_path,
         network_name: args.network_name,
         ssh_listen_addr: format!("0.0.0.0:{}", args.sandbox_ssh_port),

--- a/crates/openshell-driver-podman/src/main.rs
+++ b/crates/openshell-driver-podman/src/main.rs
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use miette::{IntoDiagnostic, Result};
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+use openshell_core::VERSION;
+use openshell_core::config::{
+    DEFAULT_NETWORK_NAME, DEFAULT_SSH_HANDSHAKE_SKEW_SECS, DEFAULT_SSH_PORT,
+    DEFAULT_STOP_TIMEOUT_SECS,
+};
+use openshell_core::proto::compute::v1::compute_driver_server::ComputeDriverServer;
+use openshell_driver_podman::config::ImagePullPolicy;
+use openshell_driver_podman::{ComputeDriverService, PodmanComputeConfig, PodmanComputeDriver};
+
+#[derive(Parser)]
+#[command(name = "openshell-driver-podman")]
+#[command(version = VERSION)]
+struct Args {
+    #[arg(
+        long,
+        env = "OPENSHELL_COMPUTE_DRIVER_BIND",
+        default_value = "127.0.0.1:50061"
+    )]
+    bind_address: SocketAddr,
+
+    #[arg(long, env = "OPENSHELL_LOG_LEVEL", default_value = "info")]
+    log_level: String,
+
+    /// Path to the Podman API Unix socket.
+    #[arg(long, env = "OPENSHELL_PODMAN_SOCKET")]
+    podman_socket: Option<PathBuf>,
+
+    #[arg(long, env = "OPENSHELL_SANDBOX_IMAGE")]
+    sandbox_image: Option<String>,
+
+    #[arg(
+        long,
+        env = "OPENSHELL_SANDBOX_IMAGE_PULL_POLICY",
+        default_value_t = ImagePullPolicy::Missing
+    )]
+    sandbox_image_pull_policy: ImagePullPolicy,
+
+    #[arg(long, env = "OPENSHELL_GRPC_ENDPOINT")]
+    grpc_endpoint: Option<String>,
+
+    #[arg(
+        long,
+        env = "OPENSHELL_SANDBOX_SSH_SOCKET_PATH",
+        default_value = "/run/openshell/ssh.sock"
+    )]
+    sandbox_ssh_socket_path: String,
+
+    /// Podman bridge network name.
+    #[arg(long, env = "OPENSHELL_NETWORK_NAME", default_value = DEFAULT_NETWORK_NAME)]
+    network_name: String,
+
+    #[arg(long, env = "OPENSHELL_SANDBOX_SSH_PORT", default_value_t = DEFAULT_SSH_PORT)]
+    sandbox_ssh_port: u16,
+
+    #[arg(long, env = "OPENSHELL_SSH_HANDSHAKE_SECRET")]
+    ssh_handshake_secret: String,
+
+    #[arg(long, env = "OPENSHELL_SSH_HANDSHAKE_SKEW_SECS", default_value_t = DEFAULT_SSH_HANDSHAKE_SKEW_SECS)]
+    ssh_handshake_skew_secs: u64,
+
+    /// Container stop timeout in seconds (SIGTERM → SIGKILL).
+    #[arg(long, env = "OPENSHELL_STOP_TIMEOUT", default_value_t = DEFAULT_STOP_TIMEOUT_SECS)]
+    stop_timeout: u32,
+
+    /// OCI image containing the openshell-sandbox supervisor binary.
+    #[arg(long, env = "OPENSHELL_SUPERVISOR_IMAGE")]
+    supervisor_image: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&args.log_level)),
+        )
+        .init();
+
+    let socket_path = args
+        .podman_socket
+        .unwrap_or_else(PodmanComputeConfig::default_socket_path);
+
+    let driver = PodmanComputeDriver::new(PodmanComputeConfig {
+        socket_path,
+        default_image: args.sandbox_image.unwrap_or_default(),
+        image_pull_policy: args.sandbox_image_pull_policy,
+        grpc_endpoint: args.grpc_endpoint.unwrap_or_default(),
+        sandbox_ssh_socket_path: args.sandbox_ssh_socket_path,
+        network_name: args.network_name,
+        ssh_listen_addr: format!("0.0.0.0:{}", args.sandbox_ssh_port),
+        ssh_port: args.sandbox_ssh_port,
+        ssh_handshake_secret: args.ssh_handshake_secret,
+        ssh_handshake_skew_secs: args.ssh_handshake_skew_secs,
+        stop_timeout_secs: args.stop_timeout,
+        supervisor_image: args.supervisor_image,
+    })
+    .await
+    .into_diagnostic()?;
+
+    info!(address = %args.bind_address, "Starting Podman compute driver");
+    tonic::transport::Server::builder()
+        .add_service(ComputeDriverServer::new(ComputeDriverService::new(driver)))
+        .serve_with_shutdown(args.bind_address, async {
+            tokio::signal::ctrl_c().await.ok();
+            info!("Received shutdown signal, draining in-flight requests");
+        })
+        .await
+        .into_diagnostic()
+}

--- a/crates/openshell-driver-podman/src/watcher.rs
+++ b/crates/openshell-driver-podman/src/watcher.rs
@@ -1,0 +1,550 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Maps Podman container events to the compute-driver watch protocol.
+
+use crate::client::{
+    ContainerInspect, ContainerListEntry, ContainerState, HealthState, PodmanApiError,
+    PodmanClient, PodmanEvent,
+};
+use crate::container::{LABEL_MANAGED_FILTER, LABEL_SANDBOX_ID, LABEL_SANDBOX_NAME, short_id};
+use futures::Stream;
+use openshell_core::ComputeDriverError;
+use openshell_core::proto::compute::v1::{
+    DriverCondition, DriverSandbox, DriverSandboxStatus, WatchSandboxesDeletedEvent,
+    WatchSandboxesEvent, WatchSandboxesSandboxEvent, watch_sandboxes_event,
+};
+use std::pin::Pin;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::{debug, info, warn};
+
+// Condition reason constants shared across event-building paths.
+const CONDITION_RUNNING: &str = "ContainerRunning";
+const CONDITION_STARTING: &str = "ContainerStarting";
+const CONDITION_EXITED: &str = "ContainerExited";
+const CONDITION_STOPPED: &str = "ContainerStopped";
+
+pub type WatchStream =
+    Pin<Box<dyn Stream<Item = Result<WatchSandboxesEvent, ComputeDriverError>> + Send>>;
+
+/// Build a `WatchSandboxesEvent` carrying a sandbox snapshot.
+fn sandbox_event(sandbox: DriverSandbox) -> WatchSandboxesEvent {
+    WatchSandboxesEvent {
+        payload: Some(watch_sandboxes_event::Payload::Sandbox(
+            WatchSandboxesSandboxEvent {
+                sandbox: Some(sandbox),
+            },
+        )),
+    }
+}
+
+/// Build a `WatchSandboxesEvent` for a deleted sandbox.
+fn deleted_event(sandbox_id: String) -> WatchSandboxesEvent {
+    WatchSandboxesEvent {
+        payload: Some(watch_sandboxes_event::Payload::Deleted(
+            WatchSandboxesDeletedEvent { sandbox_id },
+        )),
+    }
+}
+
+/// Start a watch stream that emits current state and live events.
+///
+/// The stream first emits a snapshot of all currently-running managed
+/// sandboxes (initial state sync), then delivers live container events
+/// as they arrive from the Podman event stream.
+///
+/// # Reconnection contract
+///
+/// The returned stream is **single-use**.  When the Podman event connection
+/// drops (daemon restart, socket error, or clean shutdown), the stream
+/// terminates with a final error item and stops producing events.
+///
+/// Callers are responsible for reconnecting by calling [`start_watch`] again.
+/// The server's `ComputeRuntime::watch_loop` in `openshell-server` provides
+/// this behaviour with a 2-second backoff: when the stream terminates with an
+/// error, `watch_loop` sleeps and then calls `watch_sandboxes()` again, which
+/// ultimately calls `start_watch()` again and re-syncs state.
+///
+/// **Do not add reconnection logic inside this function.**  A local reconnect
+/// would race with `watch_loop`'s retry and produce duplicate initial-sync
+/// events that corrupt the server's sandbox index.
+pub async fn start_watch(client: PodmanClient) -> Result<WatchStream, PodmanApiError> {
+    let (tx, rx) = mpsc::channel::<Result<WatchSandboxesEvent, ComputeDriverError>>(256);
+
+    // 1. Subscribe to events first so we don't miss any during the list.
+    let mut event_rx = client.events_stream(LABEL_MANAGED_FILTER).await?;
+
+    // 2. List existing containers for initial state sync.
+    let existing = client.list_containers(LABEL_MANAGED_FILTER).await?;
+
+    for entry in &existing {
+        // For running containers, use inspect to get full state including
+        // health check status — matching the same condition derivation used
+        // for live events.
+        if entry.state == "running" {
+            match client.inspect_container(&entry.id).await {
+                Ok(inspect) => {
+                    if let Some(sandbox) = driver_sandbox_from_inspect(&inspect) {
+                        if tx.send(Ok(sandbox_event(sandbox))).await.is_err() {
+                            return Err(PodmanApiError::Connection(
+                                "watch receiver dropped during initial sync".into(),
+                            ));
+                        }
+                        continue;
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        container_id = %entry.id,
+                        error = %e,
+                        "Failed to inspect running container during initial sync, falling back to list entry"
+                    );
+                }
+            }
+        }
+        if let Some(event) = driver_sandbox_from_list_entry(entry).map(sandbox_event) {
+            if tx.send(Ok(event)).await.is_err() {
+                return Err(PodmanApiError::Connection(
+                    "watch receiver dropped during initial sync".into(),
+                ));
+            }
+        }
+    }
+
+    // 3. Stream live events (buffered during the list operation above).
+
+    tokio::spawn(async move {
+        while let Some(result) = event_rx.recv().await {
+            match result {
+                Ok(event) => {
+                    if let Some(we) = map_podman_event(&event, &client).await {
+                        if tx.send(Ok(we)).await.is_err() {
+                            return;
+                        }
+                    }
+                }
+                Err(e) => {
+                    if tx
+                        .send(Err(ComputeDriverError::Message(e.to_string())))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+            }
+        }
+        // The Podman event stream has ended — either because the Podman
+        // daemon restarted, the Unix socket was closed, or the connection
+        // dropped.  We do NOT reconnect here; see the doc-comment on
+        // start_watch() for the full reconnection contract.
+        //
+        // Sending this error terminates the WatchStream seen by the caller.
+        // The server's watch_loop detects the terminal error, waits 2 seconds,
+        // then calls watch_sandboxes() → start_watch() again, which re-lists
+        // all containers and re-subscribes to events.  This ensures a full
+        // state resync after any Podman daemon interruption.
+        warn!("podman event stream ended unexpectedly; watch_loop will reconnect");
+        let _ = tx
+            .send(Err(ComputeDriverError::Message(
+                "podman event stream ended unexpectedly".to_string(),
+            )))
+            .await;
+    });
+
+    Ok(Box::pin(ReceiverStream::new(rx)))
+}
+
+/// Map a Podman event to an optional watch event.
+///
+/// Some events (like `remove`) produce a deletion event. State-change events
+/// trigger a container inspect to build a full snapshot.
+async fn map_podman_event(
+    event: &PodmanEvent,
+    client: &PodmanClient,
+) -> Option<WatchSandboxesEvent> {
+    let container_id = &event.actor.id;
+    let sandbox_id = event
+        .actor
+        .attributes
+        .get(LABEL_SANDBOX_ID)
+        .cloned()
+        .unwrap_or_default();
+
+    if sandbox_id.is_empty() {
+        debug!(
+            container_id = %container_id,
+            action = %event.action,
+            "Ignoring event for container without sandbox-id label"
+        );
+        return None;
+    }
+
+    match event.action.as_str() {
+        "remove" => Some(deleted_event(sandbox_id.clone())),
+        "create" | "start" | "stop" | "die" | "health_status" => {
+            // Inspect the container to get current state.
+            match client.inspect_container(container_id).await {
+                Ok(inspect) => driver_sandbox_from_inspect(&inspect).map(sandbox_event),
+                Err(PodmanApiError::NotFound(_)) => {
+                    // The container is already gone by the time we inspected
+                    // it. This is a normal race between the `die`/`stop` event
+                    // and the subsequent `remove` event: Podman fires `die`
+                    // first, but the container may be fully removed before we
+                    // can inspect it. Treat this as a deletion so the server
+                    // does not see a spurious phase regression.
+                    info!(
+                        container_id = %container_id,
+                        action = %event.action,
+                        "Container already removed when inspecting after event, emitting deleted event"
+                    );
+                    Some(deleted_event(sandbox_id.clone()))
+                }
+                Err(e) => {
+                    warn!(
+                        container_id = %container_id,
+                        error = %e,
+                        "Failed to inspect container after event"
+                    );
+                    // Emit a synthetic event with the info we have so the
+                    // server knows something happened.
+                    let sandbox_name = event
+                        .actor
+                        .attributes
+                        .get(LABEL_SANDBOX_NAME)
+                        .cloned()
+                        .unwrap_or_default();
+                    Some(sandbox_event(build_driver_sandbox(
+                        sandbox_id.clone(),
+                        sandbox_name,
+                        String::new(),
+                        short_id(container_id),
+                        DriverCondition {
+                            r#type: "Ready".to_string(),
+                            status: "Unknown".to_string(),
+                            reason: "InspectFailed".to_string(),
+                            message: format!("Container inspect failed: {e}"),
+                            last_transition_time: String::new(),
+                        },
+                        false,
+                    )))
+                }
+            }
+        }
+        _ => {
+            debug!(action = %event.action, "Ignoring unhandled Podman event");
+            None
+        }
+    }
+}
+
+/// Construct a `DriverSandbox` from common fields.
+///
+/// Centralises the boilerplate that every event/inspect/list path shares:
+/// `namespace`, `spec`, `agent_fd`, and `sandbox_fd` are always empty in
+/// the Podman driver.
+fn build_driver_sandbox(
+    sandbox_id: String,
+    sandbox_name: String,
+    instance_name: String,
+    instance_id: String,
+    condition: DriverCondition,
+    deleting: bool,
+) -> DriverSandbox {
+    DriverSandbox {
+        id: sandbox_id,
+        name: sandbox_name,
+        namespace: String::new(),
+        spec: None,
+        status: Some(DriverSandboxStatus {
+            sandbox_name: instance_name,
+            instance_id,
+            agent_fd: String::new(),
+            sandbox_fd: String::new(),
+            conditions: vec![condition],
+            deleting,
+        }),
+    }
+}
+
+/// Build a `DriverSandbox` from a container inspection result.
+pub fn driver_sandbox_from_inspect(inspect: &ContainerInspect) -> Option<DriverSandbox> {
+    let sandbox_id = inspect.config.labels.get(LABEL_SANDBOX_ID)?.clone();
+    let sandbox_name = inspect
+        .config
+        .labels
+        .get(LABEL_SANDBOX_NAME)
+        .cloned()
+        .unwrap_or_default();
+
+    let condition = condition_from_state(&inspect.state);
+    let deleting = inspect.state.status == "removing";
+
+    Some(build_driver_sandbox(
+        sandbox_id,
+        sandbox_name,
+        inspect.name.trim_start_matches('/').to_string(),
+        short_id(&inspect.id),
+        condition,
+        deleting,
+    ))
+}
+
+/// Build a `DriverSandbox` from a container list entry (no inspect needed).
+pub(crate) fn driver_sandbox_from_list_entry(entry: &ContainerListEntry) -> Option<DriverSandbox> {
+    let sandbox_id = entry.labels.get(LABEL_SANDBOX_ID)?.clone();
+    let sandbox_name = entry
+        .labels
+        .get(LABEL_SANDBOX_NAME)
+        .cloned()
+        .unwrap_or_default();
+
+    let (reason, status_str, message) = match entry.state.as_str() {
+        "running" => (
+            CONDITION_RUNNING,
+            "True",
+            "Container is running".to_string(),
+        ),
+        "created" => ("ContainerCreated", "False", String::new()),
+        "exited" => (CONDITION_EXITED, "False", String::new()),
+        "stopped" => (CONDITION_STOPPED, "False", String::new()),
+        "removing" => ("ContainerRemoving", "False", String::new()),
+        _ => ("Unknown", "Unknown", String::new()),
+    };
+
+    Some(build_driver_sandbox(
+        sandbox_id,
+        sandbox_name,
+        entry.names.first().cloned().unwrap_or_default(),
+        short_id(&entry.id),
+        DriverCondition {
+            r#type: "Ready".to_string(),
+            status: status_str.to_string(),
+            reason: reason.to_string(),
+            message,
+            last_transition_time: String::new(),
+        },
+        entry.state == "removing",
+    ))
+}
+
+/// Derive a `DriverCondition` from Podman container state.
+fn condition_from_state(state: &ContainerState) -> DriverCondition {
+    let (status_val, reason, message) = match state.status.as_str() {
+        "running" => match &state.health {
+            Some(HealthState { status }) if status == "healthy" => {
+                ("True", "HealthCheckPassed", String::new())
+            }
+            Some(HealthState { status }) if status == "unhealthy" => {
+                ("False", "HealthCheckFailed", String::new())
+            }
+            Some(HealthState { status }) if status == "starting" => {
+                ("False", "HealthCheckStarting", String::new())
+            }
+            _ => ("False", CONDITION_STARTING, String::new()),
+        },
+        "created" => ("False", "ContainerCreated", String::new()),
+        "exited" | "stopped" => {
+            let msg = if state.oom_killed {
+                "Container was killed by the OOM killer".to_string()
+            } else {
+                format!("Container exited with code {}", state.exit_code)
+            };
+            let reason = if state.oom_killed {
+                "OOMKilled"
+            } else {
+                CONDITION_EXITED
+            };
+            ("False", reason, msg)
+        }
+        other => (
+            "Unknown",
+            "Unknown",
+            format!("Unknown container state: {other}"),
+        ),
+    };
+
+    // Use Podman's state timestamps for last_transition_time:
+    // - Running/healthy states use started_at
+    // - Stopped/exited states use finished_at
+    let last_transition_time = match state.status.as_str() {
+        "running" => state.started_at.clone().unwrap_or_default(),
+        "exited" | "stopped" => state.finished_at.clone().unwrap_or_default(),
+        _ => String::new(),
+    };
+
+    DriverCondition {
+        r#type: "Ready".to_string(),
+        status: status_val.to_string(),
+        reason: reason.to_string(),
+        message,
+        last_transition_time,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn condition_healthy_container() {
+        let state = ContainerState {
+            status: "running".to_string(),
+            running: true,
+            exit_code: 0,
+            oom_killed: false,
+            health: Some(HealthState {
+                status: "healthy".to_string(),
+            }),
+            started_at: Some("2026-04-14T10:00:00Z".to_string()),
+            finished_at: None,
+        };
+        let cond = condition_from_state(&state);
+        assert_eq!(cond.r#type, "Ready");
+        assert_eq!(cond.status, "True");
+        assert_eq!(cond.reason, "HealthCheckPassed");
+        assert_eq!(cond.last_transition_time, "2026-04-14T10:00:00Z");
+    }
+
+    #[test]
+    fn condition_oom_killed() {
+        let state = ContainerState {
+            status: "exited".to_string(),
+            running: false,
+            exit_code: 137,
+            oom_killed: true,
+            health: None,
+            started_at: None,
+            finished_at: Some("2026-04-14T11:00:00Z".to_string()),
+        };
+        let cond = condition_from_state(&state);
+        assert_eq!(cond.status, "False");
+        assert_eq!(cond.reason, "OOMKilled");
+        assert_eq!(cond.last_transition_time, "2026-04-14T11:00:00Z");
+    }
+
+    #[test]
+    fn condition_normal_exit() {
+        let state = ContainerState {
+            status: "exited".to_string(),
+            running: false,
+            exit_code: 1,
+            oom_killed: false,
+            health: None,
+            started_at: None,
+            finished_at: Some("2026-04-14T12:00:00Z".to_string()),
+        };
+        let cond = condition_from_state(&state);
+        assert_eq!(cond.status, "False");
+        assert_eq!(cond.reason, "ContainerExited");
+        assert!(cond.message.contains("code 1"));
+    }
+
+    #[test]
+    fn short_id_truncates() {
+        assert_eq!(short_id("abc123def456789"), "abc123def456");
+        assert_eq!(short_id("short"), "short");
+    }
+
+    #[test]
+    fn sandbox_event_from_list_entry_running() {
+        let mut labels = std::collections::HashMap::new();
+        labels.insert(LABEL_SANDBOX_ID.to_string(), "test-id".to_string());
+        labels.insert(LABEL_SANDBOX_NAME.to_string(), "test-name".to_string());
+
+        let entry = ContainerListEntry {
+            id: "abc123def456789".to_string(),
+            names: vec!["openshell-sandbox-test-name".to_string()],
+            state: "running".to_string(),
+            labels,
+            ports: None,
+            networks: None,
+            exit_code: 0,
+        };
+
+        let sandbox = driver_sandbox_from_list_entry(&entry).expect("should produce a sandbox");
+        let status = sandbox.status.expect("should have status");
+        assert_eq!(status.conditions.len(), 1);
+        let cond = &status.conditions[0];
+        assert_eq!(cond.status, "True");
+        assert_eq!(cond.reason, "ContainerRunning");
+        assert!(!status.deleting);
+    }
+
+    #[test]
+    fn synthetic_inspect_failed_event_structure() {
+        // Verify the structure of an inspect-failure event by constructing one
+        // using the same pattern as the production code.
+        let condition = DriverCondition {
+            r#type: "Ready".to_string(),
+            status: "Unknown".to_string(),
+            reason: "InspectFailed".to_string(),
+            message: "Container inspect failed: connection refused".to_string(),
+            last_transition_time: String::new(),
+        };
+
+        let sandbox = DriverSandbox {
+            id: "sandbox-123".to_string(),
+            name: "test-sandbox".to_string(),
+            namespace: String::new(),
+            spec: None,
+            status: Some(DriverSandboxStatus {
+                sandbox_name: String::new(),
+                instance_id: short_id("container-id-full"),
+                agent_fd: String::new(),
+                sandbox_fd: String::new(),
+                conditions: vec![condition],
+                deleting: false,
+            }),
+        };
+
+        let event = WatchSandboxesEvent {
+            payload: Some(watch_sandboxes_event::Payload::Sandbox(
+                WatchSandboxesSandboxEvent {
+                    sandbox: Some(sandbox),
+                },
+            )),
+        };
+
+        let payload = event.payload.unwrap();
+        let sandbox_event = match payload {
+            watch_sandboxes_event::Payload::Sandbox(s) => s,
+            _ => panic!("expected Sandbox payload"),
+        };
+        let status = sandbox_event.sandbox.unwrap().status.unwrap();
+        assert_eq!(status.conditions.len(), 1);
+        let cond = &status.conditions[0];
+        assert_eq!(cond.reason, "InspectFailed");
+        assert_eq!(cond.status, "Unknown");
+        assert!(cond.message.contains("inspect failed"));
+    }
+
+    #[test]
+    fn not_found_inspect_produces_deleted_event() {
+        // When inspect_container returns NotFound (404) after a `die` or
+        // `stop` event, the container is already gone. The watcher should emit
+        // a deleted_event rather than a synthetic InspectFailed sandbox event,
+        // preventing the server from regressing the sandbox phase back to
+        // Provisioning.
+        //
+        // We verify the shape of a deleted_event directly since
+        // map_podman_event is async and requires a live Podman client. The
+        // production code path is:
+        //   Err(PodmanApiError::NotFound(_)) => Some(deleted_event(sandbox_id))
+        let sandbox_id = "sandbox-abc-123".to_string();
+        let event = deleted_event(sandbox_id.clone());
+
+        let payload = event.payload.expect("deleted event must have a payload");
+        match payload {
+            watch_sandboxes_event::Payload::Deleted(d) => {
+                assert_eq!(d.sandbox_id, sandbox_id);
+            }
+            other => {
+                panic!(
+                    "expected Deleted payload, got {other:?} — a NotFound inspect must not produce a sandbox or platform event"
+                );
+            }
+        }
+    }
+}

--- a/crates/openshell-sandbox/src/sandbox/linux/netns.rs
+++ b/crates/openshell-sandbox/src/sandbox/linux/netns.rs
@@ -678,14 +678,26 @@ fn run_ip(args: &[&str]) -> Result<()> {
     Ok(())
 }
 
-/// Run an `ip netns exec` command inside a namespace.
+/// Run an `ip` command inside a network namespace via `nsenter --net=`.
+///
+/// We use `nsenter` instead of `ip netns exec` because `ip netns exec`
+/// remounts `/sys` to reflect the target namespace's sysfs entries. That
+/// sysfs remount requires real `CAP_SYS_ADMIN` in the host user namespace,
+/// which is unavailable in rootless container runtimes (e.g. rootless
+/// Podman). `nsenter --net=` enters only the network namespace without
+/// changing the mount namespace, avoiding the sysfs remount entirely.
+/// The supervisor's operations (addr add, link set, route add) are all
+/// netlink-based and do not need sysfs access.
 fn run_ip_netns(netns: &str, args: &[&str]) -> Result<()> {
-    let mut full_args = vec!["netns", "exec", netns, "ip"];
+    let ns_path = format!("/var/run/netns/{netns}");
+    let net_flag = format!("--net={ns_path}");
+
+    let mut full_args = vec![net_flag.as_str(), "--", "ip"];
     full_args.extend(args);
 
-    debug!(command = %format!("ip {}", full_args.join(" ")), "Running ip netns exec command");
+    debug!(command = %format!("nsenter {}", full_args.join(" ")), "Running ip in namespace via nsenter");
 
-    let output = Command::new("ip")
+    let output = Command::new("nsenter")
         .args(&full_args)
         .output()
         .into_diagnostic()?;
@@ -693,8 +705,8 @@ fn run_ip_netns(netns: &str, args: &[&str]) -> Result<()> {
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(miette::miette!(
-            "ip netns exec {} ip {} failed: {}",
-            netns,
+            "nsenter --net={} ip {} failed: {}",
+            ns_path,
             args.join(" "),
             stderr.trim()
         ));
@@ -703,17 +715,23 @@ fn run_ip_netns(netns: &str, args: &[&str]) -> Result<()> {
     Ok(())
 }
 
-/// Run an iptables command inside a network namespace.
+/// Run an iptables command inside a network namespace via `nsenter --net=`.
+///
+/// Uses `nsenter` instead of `ip netns exec` to avoid the sysfs remount
+/// that fails in rootless container runtimes. See `run_ip_netns` for details.
 fn run_iptables_netns(netns: &str, iptables_cmd: &str, args: &[&str]) -> Result<()> {
-    let mut full_args = vec!["netns", "exec", netns, iptables_cmd];
+    let ns_path = format!("/var/run/netns/{netns}");
+    let net_flag = format!("--net={ns_path}");
+
+    let mut full_args = vec![net_flag.as_str(), "--", iptables_cmd];
     full_args.extend(args);
 
     debug!(
-        command = %format!("ip {}", full_args.join(" ")),
-        "Running iptables in namespace"
+        command = %format!("nsenter {}", full_args.join(" ")),
+        "Running iptables in namespace via nsenter"
     );
 
-    let output = Command::new("ip")
+    let output = Command::new("nsenter")
         .args(&full_args)
         .output()
         .into_diagnostic()?;
@@ -721,8 +739,8 @@ fn run_iptables_netns(netns: &str, iptables_cmd: &str, args: &[&str]) -> Result<
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(miette::miette!(
-            "ip netns exec {} {} failed: {}",
-            netns,
+            "nsenter --net={} {} failed: {}",
+            ns_path,
             iptables_cmd,
             stderr.trim()
         ));

--- a/crates/openshell-sandbox/src/ssh.rs
+++ b/crates/openshell-sandbox/src/ssh.rs
@@ -1445,4 +1445,73 @@ mod tests {
             .unwrap();
         assert_eq!(rx_b.recv().unwrap(), b"still-alive");
     }
+
+    /// `install_pre_exec_no_pty` runs drop_privileges and succeeds when the
+    /// current user/group is already the configured one (no actual uid change).
+    ///
+    /// This exercises the pre_exec hook end-to-end without needing root: a policy
+    /// with no run_as_user/group is a no-op when the process is already unprivileged.
+    #[cfg(unix)]
+    #[test]
+    fn pre_exec_always_calls_drop_privileges() {
+        use crate::policy::{
+            FilesystemPolicy, LandlockPolicy, NetworkPolicy, ProcessPolicy, SandboxPolicy,
+        };
+
+        // No user/group configured and not running as root → drop_privileges is
+        // a no-op, so spawn succeeds regardless of the effective UID.
+        let policy = SandboxPolicy {
+            version: 0,
+            filesystem: FilesystemPolicy::default(),
+            network: NetworkPolicy::default(),
+            landlock: LandlockPolicy::default(),
+            process: ProcessPolicy {
+                run_as_user: None,
+                run_as_group: None,
+            },
+        };
+
+        // Skip if running as root: drop_privileges would try to switch to
+        // "sandbox" which may not exist in the test environment.
+        if nix::unistd::geteuid().is_root() {
+            return;
+        }
+
+        let mut cmd = Command::new("echo");
+        cmd.arg("drop-privileges-ok");
+        cmd.stdout(Stdio::piped());
+
+        unsafe_pty::install_pre_exec_no_pty(
+            &mut cmd,
+            policy,
+            None,
+            None, // no netns fd
+            #[cfg(target_os = "linux")]
+            crate::sandbox::linux::prepare(
+                &SandboxPolicy {
+                    version: 0,
+                    filesystem: FilesystemPolicy::default(),
+                    network: NetworkPolicy::default(),
+                    landlock: LandlockPolicy::default(),
+                    process: ProcessPolicy {
+                        run_as_user: None,
+                        run_as_group: None,
+                    },
+                },
+                None,
+            )
+            .expect("prepare should succeed in test environment"),
+        );
+
+        let output = cmd
+            .spawn()
+            .expect("spawn must succeed")
+            .wait_with_output()
+            .expect("wait_with_output");
+        assert!(output.status.success(), "echo should exit 0");
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("drop-privileges-ok"),
+            "echo output should contain 'drop-privileges-ok'"
+        );
+    }
 }

--- a/crates/openshell-server/Cargo.toml
+++ b/crates/openshell-server/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 openshell-core = { path = "../openshell-core" }
 openshell-driver-kubernetes = { path = "../openshell-driver-kubernetes" }
+openshell-driver-podman = { path = "../openshell-driver-podman" }
 openshell-ocsf = { path = "../openshell-ocsf" }
 openshell-policy = { path = "../openshell-policy" }
 openshell-router = { path = "../openshell-router" }

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -6,6 +6,9 @@
 use clap::{Command, CommandFactory, FromArgMatches, Parser};
 use miette::{IntoDiagnostic, Result};
 use openshell_core::ComputeDriverKind;
+use openshell_core::config::{
+    DEFAULT_SERVER_PORT, DEFAULT_SSH_HANDSHAKE_SKEW_SECS, DEFAULT_SSH_PORT,
+};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use tracing::info;
@@ -20,7 +23,7 @@ use crate::{run_server, tracing_bus::TracingLogBus};
 #[command(about = "OpenShell gRPC/HTTP server", long_about = None)]
 struct Args {
     /// Port to bind the server to (all interfaces).
-    #[arg(long, default_value_t = 8080, env = "OPENSHELL_SERVER_PORT")]
+    #[arg(long, default_value_t = DEFAULT_SERVER_PORT, env = "OPENSHELL_SERVER_PORT")]
     port: u16,
 
     /// Port for unauthenticated health endpoints (healthz, readyz).
@@ -90,7 +93,7 @@ struct Args {
     ssh_gateway_host: String,
 
     /// Public port for the SSH gateway.
-    #[arg(long, env = "OPENSHELL_SSH_GATEWAY_PORT", default_value_t = 8080)]
+    #[arg(long, env = "OPENSHELL_SSH_GATEWAY_PORT", default_value_t = DEFAULT_SERVER_PORT)]
     ssh_gateway_port: u16,
 
     /// HTTP path for SSH CONNECT/upgrade.
@@ -101,12 +104,15 @@ struct Args {
     )]
     ssh_connect_path: String,
 
+    /// SSH port inside sandbox pods.
+    #[arg(long, env = "OPENSHELL_SANDBOX_SSH_PORT", default_value_t = DEFAULT_SSH_PORT)]
+    sandbox_ssh_port: u16,
     /// Shared secret for gateway-to-sandbox SSH handshake.
     #[arg(long, env = "OPENSHELL_SSH_HANDSHAKE_SECRET")]
     ssh_handshake_secret: Option<String>,
 
     /// Allowed clock skew in seconds for SSH handshake.
-    #[arg(long, env = "OPENSHELL_SSH_HANDSHAKE_SKEW_SECS", default_value_t = 300)]
+    #[arg(long, env = "OPENSHELL_SSH_HANDSHAKE_SKEW_SECS", default_value_t = DEFAULT_SSH_HANDSHAKE_SKEW_SECS)]
     ssh_handshake_skew_secs: u64,
 
     /// Kubernetes secret name containing client TLS materials for sandbox pods.
@@ -271,6 +277,7 @@ async fn run_from_args(args: Args) -> Result<()> {
         .with_ssh_gateway_host(args.ssh_gateway_host)
         .with_ssh_gateway_port(args.ssh_gateway_port)
         .with_ssh_connect_path(args.ssh_connect_path)
+        .with_sandbox_ssh_port(args.sandbox_ssh_port)
         .with_ssh_handshake_skew_secs(args.ssh_handshake_skew_secs);
 
     if let Some(image) = args.sandbox_image {

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -29,6 +29,9 @@ use openshell_core::proto::{
 use openshell_driver_kubernetes::{
     ComputeDriverService, KubernetesComputeConfig, KubernetesComputeDriver,
 };
+use openshell_driver_podman::{
+    ComputeDriverService as PodmanDriverService, PodmanComputeConfig, PodmanComputeDriver,
+};
 use prost::Message;
 use std::fmt;
 use std::pin::Pin;
@@ -50,15 +53,9 @@ const RECONCILE_INTERVAL: Duration = Duration::from_secs(60);
 /// corresponding backend resource before it is considered orphaned.
 const ORPHAN_GRACE_PERIOD: Duration = Duration::from_secs(300);
 
-#[derive(Debug, thiserror::Error)]
-pub enum ComputeError {
-    #[error("sandbox already exists")]
-    AlreadyExists,
-    #[error("{0}")]
-    Precondition(String),
-    #[error("{0}")]
-    Message(String),
-}
+// Re-export the shared error type under the name used by this module.
+pub use openshell_core::ComputeDriverError as ComputeError;
+
 #[derive(Debug)]
 pub(crate) struct ManagedDriverProcess {
     child: std::sync::Mutex<Option<tokio::process::Child>>,
@@ -191,6 +188,14 @@ pub struct ComputeRuntime {
     tracing_log_bus: TracingLogBus,
     supervisor_sessions: Arc<SupervisorSessionRegistry>,
     sync_lock: Arc<Mutex<()>>,
+    /// Whether the compute driver legitimately produces loopback endpoints
+    /// (e.g. `127.0.0.1`) for sandbox SSH targets.  When `true`, the SSRF
+    /// checks in the SSH tunnel and exec proxy paths permit loopback addresses.
+    /// Link-local (`169.254.0.0/16`) is always blocked regardless of this flag
+    /// to prevent metadata-service access via DNS rebinding.  Podman and VM
+    /// drivers set this to `true`; Kubernetes uses pod/cluster IPs and sets
+    /// `false`.
+    allows_loopback_endpoints: bool,
 }
 
 impl fmt::Debug for ComputeRuntime {
@@ -208,6 +213,7 @@ impl ComputeRuntime {
         sandbox_watch_bus: SandboxWatchBus,
         tracing_log_bus: TracingLogBus,
         supervisor_sessions: Arc<SupervisorSessionRegistry>,
+        allows_loopback_endpoints: bool,
     ) -> Result<Self, ComputeError> {
         let default_image = driver
             .get_capabilities(Request::new(GetCapabilitiesRequest {}))
@@ -225,6 +231,7 @@ impl ComputeRuntime {
             tracing_log_bus,
             supervisor_sessions,
             sync_lock: Arc::new(Mutex::new(())),
+            allows_loopback_endpoints,
         })
     }
 
@@ -248,6 +255,7 @@ impl ComputeRuntime {
             sandbox_watch_bus,
             tracing_log_bus,
             supervisor_sessions,
+            false,
         )
         .await
     }
@@ -262,6 +270,9 @@ impl ComputeRuntime {
         supervisor_sessions: Arc<SupervisorSessionRegistry>,
     ) -> Result<Self, ComputeError> {
         let driver: SharedComputeDriver = Arc::new(RemoteComputeDriver::new(channel));
+        // The VM driver resolves sandbox SSH endpoints to 127.0.0.1
+        // (gvproxy forwards host-side ports into the guest), so loopback
+        // targets are legitimate and must be allowed through the SSRF check.
         Self::from_driver(
             driver,
             driver_process,
@@ -270,6 +281,32 @@ impl ComputeRuntime {
             sandbox_watch_bus,
             tracing_log_bus,
             supervisor_sessions,
+            true,
+        )
+        .await
+    }
+
+    pub async fn new_podman(
+        config: PodmanComputeConfig,
+        store: Arc<Store>,
+        sandbox_index: SandboxIndex,
+        sandbox_watch_bus: SandboxWatchBus,
+        tracing_log_bus: TracingLogBus,
+        supervisor_sessions: Arc<SupervisorSessionRegistry>,
+    ) -> Result<Self, ComputeError> {
+        let driver = PodmanComputeDriver::new(config)
+            .await
+            .map_err(|err| ComputeError::Message(err.to_string()))?;
+        let driver: SharedComputeDriver = Arc::new(PodmanDriverService::new(driver));
+        Self::from_driver(
+            driver,
+            None,
+            store,
+            sandbox_index,
+            sandbox_watch_bus,
+            tracing_log_bus,
+            supervisor_sessions,
+            true,
         )
         .await
     }
@@ -277,6 +314,13 @@ impl ComputeRuntime {
     #[must_use]
     pub fn default_image(&self) -> &str {
         &self.default_image
+    }
+
+    /// Whether the compute driver legitimately produces loopback/link-local
+    /// endpoints for sandbox SSH targets (e.g. rootless Podman).
+    #[must_use]
+    pub fn allows_loopback_endpoints(&self) -> bool {
+        self.allows_loopback_endpoints
     }
 
     pub async fn validate_sandbox_create(&self, sandbox: &Sandbox) -> Result<(), Status> {
@@ -1147,7 +1191,14 @@ fn rewrite_user_facing_conditions(status: &mut Option<SandboxStatus>, spec: Opti
 
 fn is_terminal_failure_reason(reason: &str) -> bool {
     let reason = reason.to_ascii_lowercase();
-    let transient_reasons = ["reconcilererror", "dependenciesnotready", "starting"];
+    let transient_reasons = [
+        "reconcilererror",
+        "dependenciesnotready",
+        "starting",
+        "containerstarting",
+        "healthcheckstarting",
+        "inspectfailed",
+    ];
     !transient_reasons.contains(&reason.as_str())
 }
 
@@ -1278,6 +1329,7 @@ mod tests {
             tracing_log_bus: TracingLogBus::new(),
             supervisor_sessions: Arc::new(SupervisorSessionRegistry::new()),
             sync_lock: Arc::new(Mutex::new(())),
+            allows_loopback_endpoints: false,
         }
     }
 

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -188,14 +188,6 @@ pub struct ComputeRuntime {
     tracing_log_bus: TracingLogBus,
     supervisor_sessions: Arc<SupervisorSessionRegistry>,
     sync_lock: Arc<Mutex<()>>,
-    /// Whether the compute driver legitimately produces loopback endpoints
-    /// (e.g. `127.0.0.1`) for sandbox SSH targets.  When `true`, the SSRF
-    /// checks in the SSH tunnel and exec proxy paths permit loopback addresses.
-    /// Link-local (`169.254.0.0/16`) is always blocked regardless of this flag
-    /// to prevent metadata-service access via DNS rebinding.  Podman and VM
-    /// drivers set this to `true`; Kubernetes uses pod/cluster IPs and sets
-    /// `false`.
-    allows_loopback_endpoints: bool,
 }
 
 impl fmt::Debug for ComputeRuntime {
@@ -231,7 +223,6 @@ impl ComputeRuntime {
             tracing_log_bus,
             supervisor_sessions,
             sync_lock: Arc::new(Mutex::new(())),
-            allows_loopback_endpoints,
         })
     }
 
@@ -270,9 +261,6 @@ impl ComputeRuntime {
         supervisor_sessions: Arc<SupervisorSessionRegistry>,
     ) -> Result<Self, ComputeError> {
         let driver: SharedComputeDriver = Arc::new(RemoteComputeDriver::new(channel));
-        // The VM driver resolves sandbox SSH endpoints to 127.0.0.1
-        // (gvproxy forwards host-side ports into the guest), so loopback
-        // targets are legitimate and must be allowed through the SSRF check.
         Self::from_driver(
             driver,
             driver_process,
@@ -314,13 +302,6 @@ impl ComputeRuntime {
     #[must_use]
     pub fn default_image(&self) -> &str {
         &self.default_image
-    }
-
-    /// Whether the compute driver legitimately produces loopback/link-local
-    /// endpoints for sandbox SSH targets (e.g. rootless Podman).
-    #[must_use]
-    pub fn allows_loopback_endpoints(&self) -> bool {
-        self.allows_loopback_endpoints
     }
 
     pub async fn validate_sandbox_create(&self, sandbox: &Sandbox) -> Result<(), Status> {
@@ -1329,7 +1310,6 @@ mod tests {
             tracing_log_bus: TracingLogBus::new(),
             supervisor_sessions: Arc::new(SupervisorSessionRegistry::new()),
             sync_lock: Arc::new(Mutex::new(())),
-            allows_loopback_endpoints: false,
         }
     }
 

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -365,6 +365,7 @@ async fn build_compute_runtime(
                     default_image: config.sandbox_image.clone(),
                     image_pull_policy: config.sandbox_image_pull_policy.parse().unwrap_or_default(),
                     grpc_endpoint: config.grpc_endpoint.clone(),
+                    gateway_port: config.bind_address.port(),
                     sandbox_ssh_socket_path: config.sandbox_ssh_socket_path.clone(),
                     network_name,
                     ssh_listen_addr: format!("0.0.0.0:{}", config.sandbox_ssh_port),

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -337,9 +337,52 @@ async fn build_compute_runtime(
             .await
             .map_err(|e| Error::execution(format!("failed to create compute runtime: {e}")))
         }
-        ComputeDriverKind::Podman => Err(Error::config(
-            "compute driver 'podman' is not implemented yet",
-        )),
+        ComputeDriverKind::Podman => {
+            let socket_path = std::env::var("OPENSHELL_PODMAN_SOCKET")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(openshell_driver_podman::PodmanComputeConfig::default_socket_path);
+
+            let network_name = std::env::var("OPENSHELL_NETWORK_NAME")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| openshell_core::config::DEFAULT_NETWORK_NAME.to_string());
+
+            let stop_timeout_secs: u32 = std::env::var("OPENSHELL_STOP_TIMEOUT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(openshell_core::config::DEFAULT_STOP_TIMEOUT_SECS);
+
+            let supervisor_image = std::env::var("OPENSHELL_SUPERVISOR_IMAGE")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| openshell_core::config::DEFAULT_SUPERVISOR_IMAGE.to_string());
+
+            ComputeRuntime::new_podman(
+                openshell_driver_podman::PodmanComputeConfig {
+                    socket_path,
+                    default_image: config.sandbox_image.clone(),
+                    image_pull_policy: config.sandbox_image_pull_policy.parse().unwrap_or_default(),
+                    grpc_endpoint: config.grpc_endpoint.clone(),
+                    sandbox_ssh_socket_path: config.sandbox_ssh_socket_path.clone(),
+                    network_name,
+                    ssh_listen_addr: format!("0.0.0.0:{}", config.sandbox_ssh_port),
+                    ssh_port: config.sandbox_ssh_port,
+                    ssh_handshake_secret: config.ssh_handshake_secret.clone(),
+                    ssh_handshake_skew_secs: config.ssh_handshake_skew_secs,
+                    stop_timeout_secs,
+                    supervisor_image,
+                },
+                store,
+                sandbox_index,
+                sandbox_watch_bus,
+                tracing_log_bus,
+                supervisor_sessions,
+            )
+            .await
+            .map_err(|e| Error::execution(format!("failed to create compute runtime: {e}")))
+        }
     }
 }
 
@@ -348,10 +391,11 @@ fn configured_compute_driver(config: &Config) -> Result<ComputeDriverKind> {
         [] => Err(Error::config(
             "at least one compute driver must be configured",
         )),
-        [driver @ ComputeDriverKind::Kubernetes] | [driver @ ComputeDriverKind::Vm] => Ok(*driver),
-        [ComputeDriverKind::Podman] => Err(Error::config(
-            "compute driver 'podman' is not implemented yet",
-        )),
+        [
+            driver @ (ComputeDriverKind::Kubernetes
+            | ComputeDriverKind::Vm
+            | ComputeDriverKind::Podman),
+        ] => Ok(*driver),
         drivers => Err(Error::config(format!(
             "multiple compute drivers are not supported yet; configured drivers: {}",
             drivers
@@ -390,15 +434,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_compute_driver_defaults_to_kubernetes() {
-        assert_eq!(
-            configured_compute_driver(&Config::new(None)).unwrap(),
-            ComputeDriverKind::Kubernetes
-        );
-    }
-
-    #[test]
-    fn configured_compute_driver_requires_at_least_one_entry() {
+    fn configured_compute_driver_rejects_empty_drivers() {
         let config = Config::new(None).with_compute_drivers([]);
         let err = configured_compute_driver(&config).unwrap_err();
         assert!(err.to_string().contains("at least one compute driver"));
@@ -417,12 +453,11 @@ mod tests {
     }
 
     #[test]
-    fn configured_compute_driver_rejects_unimplemented_driver() {
+    fn configured_compute_driver_accepts_podman() {
         let config = Config::new(None).with_compute_drivers([ComputeDriverKind::Podman]);
-        let err = configured_compute_driver(&config).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("compute driver 'podman' is not implemented yet")
+        assert_eq!(
+            configured_compute_driver(&config).unwrap(),
+            ComputeDriverKind::Podman
         );
     }
 

--- a/crates/openshell-server/src/persistence/sqlite.rs
+++ b/crates/openshell-server/src/persistence/sqlite.rs
@@ -18,19 +18,27 @@ pub struct SqliteStore {
 
 impl SqliteStore {
     pub async fn connect(url: &str) -> Result<Self> {
-        let max_connections = if url.contains(":memory:") || url.contains("mode=memory") {
-            1
-        } else {
-            5
-        };
+        let is_in_memory = url.contains(":memory:") || url.contains("mode=memory");
+        let max_connections = if is_in_memory { 1 } else { 5 };
 
         let options = SqliteConnectOptions::from_str(url)
             .map_err(|e| map_db_error(&e))?
             .create_if_missing(true);
 
-        let pool = SqlitePoolOptions::new()
+        let mut pool_options = SqlitePoolOptions::new()
             .max_connections(max_connections)
-            .min_connections(max_connections)
+            .min_connections(max_connections);
+
+        // In-memory SQLite databases exist only while at least one connection
+        // is open. SQLx's default `max_lifetime` (30 min) and `idle_timeout`
+        // (10 min) would recycle the sole connection, destroying the database
+        // and all its tables. Disable both timeouts so the connection (and
+        // therefore the database) lives for the entire process lifetime.
+        if is_in_memory {
+            pool_options = pool_options.idle_timeout(None).max_lifetime(None);
+        }
+
+        let pool = pool_options
             .connect_with(options)
             .await
             .map_err(|e| map_db_error(&e))?;

--- a/crates/openshell-vm/scripts/build-rootfs.sh
+++ b/crates/openshell-vm/scripts/build-rootfs.sh
@@ -33,6 +33,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Source container engine abstraction (provides ce, ce_build, etc.)
+_CE_SEARCH="${SCRIPT_DIR}/../../../tasks/scripts/container-engine.sh"
+if [ -f "${_CE_SEARCH}" ]; then
+    source "${_CE_SEARCH}"
+else
+    # Fallback: if run from a different working directory, try repo root.
+    source "$(cd "${SCRIPT_DIR}/../../.." && pwd)/tasks/scripts/container-engine.sh"
+fi
+
 # Source pinned dependency versions (digests, checksums, commit SHAs).
 # Environment variables override pins — see pins.env for details.
 PINS_FILE="${SCRIPT_DIR}/../pins.env"
@@ -282,10 +291,10 @@ fi
 # ── Build base image with dependencies ─────────────────────────────────
 
 # Clean up any previous run
-docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+ce rm -f "${CONTAINER_NAME}" 2>/dev/null || true
 
 echo "==> Building base image..."
-docker build --platform "${DOCKER_PLATFORM}" -t "${BASE_IMAGE_TAG}" \
+ce build --platform "${DOCKER_PLATFORM}" -t "${BASE_IMAGE_TAG}" \
     --build-arg "BASE_IMAGE=${VM_BASE_IMAGE}" -f - . <<'DOCKERFILE'
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
@@ -309,7 +318,7 @@ DOCKERFILE
 
 # Create a container and export the filesystem
 echo "==> Creating container..."
-docker create --platform "${DOCKER_PLATFORM}" --name "${CONTAINER_NAME}" "${BASE_IMAGE_TAG}" /bin/true
+ce create --platform "${DOCKER_PLATFORM}" --name "${CONTAINER_NAME}" "${BASE_IMAGE_TAG}" /bin/true
 
 echo "==> Exporting filesystem..."
 # Previous builds may leave overlayfs work/ dirs with permissions that
@@ -319,9 +328,9 @@ if [ -d "${ROOTFS_DIR}" ]; then
     rm -rf "${ROOTFS_DIR}"
 fi
 mkdir -p "${ROOTFS_DIR}"
-docker export "${CONTAINER_NAME}" | tar -C "${ROOTFS_DIR}" -xf -
+ce export "${CONTAINER_NAME}" | tar -C "${ROOTFS_DIR}" -xf -
 
-docker rm "${CONTAINER_NAME}"
+ce rm "${CONTAINER_NAME}"
 
 # ── Inject k3s binary ────────────────────────────────────────────────
 
@@ -505,9 +514,9 @@ pull_and_save() {
     # Try to pull; if the registry is unavailable, fall back to the
     # local Docker image cache (image may exist from a previous pull).
     echo "    pulling: ${image}..."
-    if ! docker pull --platform "${DOCKER_PLATFORM}" "${image}" --quiet 2>/dev/null; then
-        echo "    pull failed, checking local Docker cache..."
-        if ! docker image inspect "${image}" >/dev/null 2>&1; then
+    if ! ce pull --platform "${DOCKER_PLATFORM}" "${image}" --quiet 2>/dev/null; then
+        echo "    pull failed, checking local image cache..."
+        if ! ce image inspect "${image}" >/dev/null 2>&1; then
             echo "ERROR: image ${image} not available locally or from registry"
             exit 1
         fi
@@ -518,7 +527,7 @@ pull_and_save() {
     # Pipe through zstd for faster decompression and smaller tarballs.
     # k3s auto-imports .tar.zst files from the airgap images directory.
     # -T0 uses all CPU cores; -3 is a good speed/ratio tradeoff.
-    docker save "${image}" | zstd -T0 -3 -o "${output}"
+    ce save "${image}" | zstd -T0 -3 -o "${output}"
     # Cache for next rebuild.
     cp "${output}" "${cache}"
 }

--- a/deploy/docker/Dockerfile.images
+++ b/deploy/docker/Dockerfile.images
@@ -49,6 +49,7 @@ COPY crates/openshell-bootstrap/Cargo.toml crates/openshell-bootstrap/Cargo.toml
 COPY crates/openshell-cli/Cargo.toml crates/openshell-cli/Cargo.toml
 COPY crates/openshell-core/Cargo.toml crates/openshell-core/Cargo.toml
 COPY crates/openshell-driver-kubernetes/Cargo.toml crates/openshell-driver-kubernetes/Cargo.toml
+COPY crates/openshell-driver-podman/Cargo.toml crates/openshell-driver-podman/Cargo.toml
 COPY crates/openshell-ocsf/Cargo.toml crates/openshell-ocsf/Cargo.toml
 COPY crates/openshell-policy/Cargo.toml crates/openshell-policy/Cargo.toml
 COPY crates/openshell-providers/Cargo.toml crates/openshell-providers/Cargo.toml
@@ -66,6 +67,7 @@ RUN mkdir -p \
       crates/openshell-cli/src \
       crates/openshell-core/src \
       crates/openshell-driver-kubernetes/src \
+      crates/openshell-driver-podman/src \
       crates/openshell-ocsf/src \
       crates/openshell-policy/src \
       crates/openshell-providers/src \
@@ -80,6 +82,8 @@ RUN mkdir -p \
     touch crates/openshell-core/src/lib.rs && \
     touch crates/openshell-driver-kubernetes/src/lib.rs && \
     printf 'fn main() {}\n' > crates/openshell-driver-kubernetes/src/main.rs && \
+    touch crates/openshell-driver-podman/src/lib.rs && \
+    printf 'fn main() {}\n' > crates/openshell-driver-podman/src/main.rs && \
     touch crates/openshell-ocsf/src/lib.rs && \
     touch crates/openshell-policy/src/lib.rs && \
     touch crates/openshell-providers/src/lib.rs && \
@@ -115,6 +119,7 @@ ARG OPENSHELL_CARGO_VERSION
 
 COPY crates/openshell-core/ crates/openshell-core/
 COPY crates/openshell-driver-kubernetes/ crates/openshell-driver-kubernetes/
+COPY crates/openshell-driver-podman/ crates/openshell-driver-podman/
 COPY crates/openshell-ocsf/ crates/openshell-ocsf/
 COPY crates/openshell-policy/ crates/openshell-policy/
 COPY crates/openshell-providers/ crates/openshell-providers/

--- a/e2e/rust/e2e-podman.sh
+++ b/e2e/rust/e2e-podman.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run the Rust e2e smoke test against a Podman-backed gateway.
+#
+# Usage:
+#   mise run e2e:podman                     # start a gateway with Podman driver
+#   mise run e2e:podman -- --port=9090      # use a specific port
+#
+# Options:
+#   --port=PORT   Gateway listen port (default: random free port).
+#
+# The script:
+#   1. Verifies Podman is available and the socket is reachable
+#   2. Starts openshell-gateway with --drivers podman --disable-tls
+#   3. Waits for the gateway to become healthy
+#   4. Runs the Rust smoke test
+#   5. Cleans up the gateway process and any leftover sandbox containers
+#
+# Prerequisites:
+#   - Rootless Podman service running (systemctl --user start podman.socket)
+#   - Supervisor sideload image built (mise run build:docker:supervisor-sideload)
+#   - Sandbox base image available locally
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GATEWAY_BIN="${ROOT}/target/debug/openshell-gateway"
+TIMEOUT=120
+
+# ── Parse arguments ──────────────────────────────────────────────────
+PORT=""
+for arg in "$@"; do
+  case "$arg" in
+    --port=*) PORT="${arg#--port=}" ;;
+    *) echo "Unknown argument: $arg"; exit 1 ;;
+  esac
+done
+
+if [ -z "${PORT}" ]; then
+  PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()')
+fi
+
+# ── Pre-flight checks ───────────────────────────────────────────────
+
+if ! command -v podman &>/dev/null; then
+  echo "ERROR: podman is not installed or not in PATH"
+  exit 1
+fi
+
+if ! podman info &>/dev/null; then
+  echo "ERROR: podman service is not reachable. Start it with:"
+  echo "  systemctl --user start podman.socket"
+  exit 1
+fi
+
+if [ ! -f "${GATEWAY_BIN}" ]; then
+  echo "Building openshell-gateway..."
+  cargo build -p openshell-server --features openshell-core/dev-settings
+fi
+
+# ── Resolve images ───────────────────────────────────────────────────
+# Use the same image defaults as the driver, allowing env overrides.
+SUPERVISOR_IMAGE="${OPENSHELL_SUPERVISOR_IMAGE:-openshell/supervisor:dev}"
+SANDBOX_IMAGE="${OPENSHELL_SANDBOX_IMAGE:-}"
+
+# Verify the supervisor image exists locally.
+if ! podman image exists "${SUPERVISOR_IMAGE}" 2>/dev/null; then
+  echo "ERROR: supervisor image '${SUPERVISOR_IMAGE}' not found locally."
+  echo "Build it with: mise run build:docker:supervisor-sideload"
+  exit 1
+fi
+
+# ── Generate a unique handshake secret ───────────────────────────────
+HANDSHAKE_SECRET="e2e-podman-$(head -c 16 /dev/urandom | xxd -p)"
+
+# ── Start the gateway ────────────────────────────────────────────────
+GW_LOG=$(mktemp /tmp/openshell-gw-podman-e2e.XXXXXX)
+GW_PID=""
+
+cleanup() {
+  local exit_code=$?
+
+  # Kill the gateway process.
+  if [ -n "${GW_PID:-}" ] && kill -0 "${GW_PID}" 2>/dev/null; then
+    echo "Stopping gateway (pid ${GW_PID})..."
+    kill "${GW_PID}" 2>/dev/null || true
+    wait "${GW_PID}" 2>/dev/null || true
+  fi
+
+  # Clean up any leftover sandbox containers, volumes, and secrets.
+  echo "Cleaning up Podman resources..."
+  for cid in $(podman ps -a --filter label=openshell.managed=true --format '{{.ID}}' 2>/dev/null); do
+    podman rm -f "${cid}" 2>/dev/null || true
+  done
+  for vid in $(podman volume ls --filter label=openshell.managed=true --format '{{.Name}}' 2>/dev/null); do
+    podman volume rm -f "${vid}" 2>/dev/null || true
+  done
+  # Secrets created by the driver use the openshell-handshake- prefix.
+  for sid in $(podman secret ls --format '{{.Name}}' 2>/dev/null | grep '^openshell-handshake-'); do
+    podman secret rm "${sid}" 2>/dev/null || true
+  done
+
+  if [ "${exit_code}" -ne 0 ] && [ -f "${GW_LOG}" ]; then
+    echo "=== Gateway log (preserved for debugging) ==="
+    cat "${GW_LOG}"
+    echo "=== end gateway log ==="
+  fi
+
+  rm -f "${GW_LOG}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Starting openshell-gateway on port ${PORT} with Podman driver..."
+
+OPENSHELL_SSH_HANDSHAKE_SECRET="${HANDSHAKE_SECRET}" \
+OPENSHELL_SUPERVISOR_IMAGE="${SUPERVISOR_IMAGE}" \
+  "${GATEWAY_BIN}" \
+    --port "${PORT}" \
+    --drivers podman \
+    --disable-tls \
+    --db-url "sqlite::memory:" \
+    ${SANDBOX_IMAGE:+--sandbox-image "${SANDBOX_IMAGE}"} \
+    --log-level info \
+  >"${GW_LOG}" 2>&1 &
+GW_PID=$!
+
+# ── Wait for health ─────────────────────────────────────────────────
+echo "Waiting for gateway to become healthy (timeout ${TIMEOUT}s)..."
+elapsed=0
+healthy=false
+while [ "${elapsed}" -lt "${TIMEOUT}" ]; do
+  if ! kill -0 "${GW_PID}" 2>/dev/null; then
+    echo "ERROR: gateway exited before becoming ready"
+    cat "${GW_LOG}"
+    exit 1
+  fi
+
+  # Use curl to check the gateway's gRPC health endpoint.
+  # The gateway serves both gRPC and HTTP on the same port.
+  if curl -sf "http://127.0.0.1:${PORT}/healthz" >/dev/null 2>&1; then
+    healthy=true
+    break
+  fi
+
+  sleep 2
+  elapsed=$((elapsed + 2))
+done
+
+if [ "${healthy}" != "true" ]; then
+  echo "ERROR: gateway did not become healthy after ${TIMEOUT}s"
+  cat "${GW_LOG}"
+  exit 1
+fi
+echo "Gateway is ready (${elapsed}s)."
+
+# ── Run the smoke test ───────────────────────────────────────────────
+export OPENSHELL_GATEWAY_ENDPOINT="http://127.0.0.1:${PORT}"
+# Use a synthetic gateway name so the CLI does not require stored mTLS creds.
+export OPENSHELL_GATEWAY="e2e-podman"
+export OPENSHELL_PROVISION_TIMEOUT=300
+
+echo "Running e2e smoke test (gateway: ${OPENSHELL_GATEWAY}, endpoint: ${OPENSHELL_GATEWAY_ENDPOINT})..."
+cargo build -p openshell-cli --features openshell-core/dev-settings
+cargo test --manifest-path e2e/rust/Cargo.toml --features e2e --test smoke -- --nocapture
+
+echo "Smoke test passed."

--- a/e2e/rust/src/harness/sandbox.rs
+++ b/e2e/rust/src/harness/sandbox.rs
@@ -74,9 +74,11 @@ impl SandboxGuard {
         }
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
-        let output = cmd
-            .output()
+        let output = timeout(SANDBOX_READY_TIMEOUT, cmd.output())
             .await
+            .map_err(|_| {
+                format!("sandbox create timed out after {SANDBOX_READY_TIMEOUT:?}")
+            })?
             .map_err(|e| format!("failed to spawn openshell: {e}"))?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
@@ -226,9 +228,13 @@ impl SandboxGuard {
             .args(command);
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
-        let output = cmd
-            .output()
+        let output = timeout(SANDBOX_READY_TIMEOUT, cmd.output())
             .await
+            .map_err(|_| {
+                format!(
+                    "sandbox create --upload timed out after {SANDBOX_READY_TIMEOUT:?}"
+                )
+            })?
             .map_err(|e| format!("failed to spawn openshell: {e}"))?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();

--- a/e2e/rust/tests/no_proxy.rs
+++ b/e2e/rust/tests/no_proxy.rs
@@ -48,7 +48,7 @@ finally:
 
 #[tokio::test]
 async fn sandbox_bypasses_proxy_for_localhost_http() {
-    let guard = SandboxGuard::create(&["python3", "-c", localhost_bypass_script()])
+    let guard = SandboxGuard::create(&["--", "python3", "-c", localhost_bypass_script()])
         .await
         .expect("sandbox create with localhost proxy bypass check");
 

--- a/e2e/rust/tests/sandbox_lifecycle.rs
+++ b/e2e/rust/tests/sandbox_lifecycle.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg(feature = "e2e")]
+
 use std::process::Stdio;
 use std::time::Duration;
 

--- a/mise.toml
+++ b/mise.toml
@@ -39,7 +39,8 @@ UV_CACHE_DIR = "{{config_root}}/.cache/uv"
 RUSTC_WRAPPER = "sccache"
 SCCACHE_DIR = "{{config_root}}/.cache/sccache"
 
-# Shared build constants (overridable via environment)
+# Shared build constants (overridable via environment).
+# DOCKER_BUILDKIT enables BuildKit for Docker; ignored by podman.
 DOCKER_BUILDKIT = "1"
 
 [vars]

--- a/scripts/docker-cleanup.sh
+++ b/scripts/docker-cleanup.sh
@@ -22,6 +22,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../tasks/scripts/container-engine.sh"
+
 # ---------------------------------------------------------------------------
 # Options
 # ---------------------------------------------------------------------------
@@ -64,13 +67,10 @@ dry()   { echo -e "    ${YELLOW}[dry-run]${RESET} $*"; }
 # ---------------------------------------------------------------------------
 # Preflight
 # ---------------------------------------------------------------------------
-if ! command -v docker &>/dev/null; then
-  echo "Error: docker is not installed or not in PATH" >&2
-  exit 1
-fi
+# container-engine.sh already validates that an engine is available.
 
-if ! docker info &>/dev/null; then
-  echo "Error: Docker daemon is not running" >&2
+if ! ce info &>/dev/null; then
+  echo "Error: Container engine (${CONTAINER_ENGINE}) is not running" >&2
   exit 1
 fi
 
@@ -125,8 +125,8 @@ should_keep_image() {
 # ---------------------------------------------------------------------------
 # Snapshot disk usage before cleanup
 # ---------------------------------------------------------------------------
-info "Current Docker disk usage"
-docker system df
+info "Current disk usage (${CONTAINER_ENGINE})"
+ce system df
 echo
 
 # ---------------------------------------------------------------------------
@@ -156,13 +156,13 @@ TOTAL_VOLUMES_REMOVED=0
 # ---------------------------------------------------------------------------
 info "Removing dangling images..."
 
-dangling_count=$(docker images --filter "dangling=true" -q | wc -l | tr -d ' ')
+dangling_count=$(ce images --filter "dangling=true" -q | wc -l | tr -d ' ')
 if [[ "$dangling_count" -gt 0 ]]; then
   note "Found $dangling_count dangling image(s)"
   if [[ "$DRY_RUN" == true ]]; then
     dry "Would remove $dangling_count dangling image(s)"
   else
-    docker image prune -f | tail -1
+    ce image prune -f | tail -1
     TOTAL_IMAGES_REMOVED=$((TOTAL_IMAGES_REMOVED + dangling_count))
   fi
 else
@@ -177,7 +177,7 @@ info "Removing stale tagged images..."
 
 # Collect image IDs that are directly used by running containers so we never
 # touch them regardless of tag matching.
-running_image_ids=$(docker ps -q 2>/dev/null | xargs -r docker inspect --format '{{.Image}}' 2>/dev/null | sort -u)
+running_image_ids=$(ce ps -q 2>/dev/null | xargs -r ce inspect --format '{{.Image}}' 2>/dev/null | sort -u)
 
 stale_images=()
 while IFS=$'\t' read -r repo tag id; do
@@ -192,7 +192,7 @@ while IFS=$'\t' read -r repo tag id; do
   if ! should_keep_image "$repo"; then
     stale_images+=("${repo}:${tag}")
   fi
-done < <(docker images --format '{{.Repository}}\t{{.Tag}}\t{{.ID}}')
+done < <(ce images --format '{{.Repository}}\t{{.Tag}}\t{{.ID}}')
 
 if [[ ${#stale_images[@]} -gt 0 ]]; then
   for img in "${stale_images[@]}"; do
@@ -200,7 +200,7 @@ if [[ ${#stale_images[@]} -gt 0 ]]; then
       dry "Would remove $img"
     else
       note "Removing $img"
-      docker rmi "$img" >/dev/null 2>&1 || warn "Could not remove $img (may share layers)"
+      ce rmi "$img" >/dev/null 2>&1 || warn "Could not remove $img (may share layers)"
       TOTAL_IMAGES_REMOVED=$((TOTAL_IMAGES_REMOVED + 1))
     fi
   done
@@ -215,8 +215,8 @@ echo
 info "Removing unused volumes..."
 
 # Identify volumes in use by running containers
-in_use_volumes=$(docker ps -q 2>/dev/null \
-  | xargs -r docker inspect --format '{{range .Mounts}}{{.Name}} {{end}}' 2>/dev/null \
+in_use_volumes=$(ce ps -q 2>/dev/null \
+  | xargs -r ce inspect --format '{{range .Mounts}}{{.Name}} {{end}}' 2>/dev/null \
   | tr ' ' '\n' | sort -u | grep -v '^$')
 
 unused_volumes=()
@@ -225,7 +225,7 @@ while read -r vol; do
   if ! echo "$in_use_volumes" | grep -qx "$vol" 2>/dev/null; then
     unused_volumes+=("$vol")
   fi
-done < <(docker volume ls -q)
+done < <(ce volume ls -q)
 
 if [[ ${#unused_volumes[@]} -gt 0 ]]; then
   note "Found ${#unused_volumes[@]} unused volume(s)"
@@ -233,7 +233,7 @@ if [[ ${#unused_volumes[@]} -gt 0 ]]; then
     if [[ "$DRY_RUN" == true ]]; then
       dry "Would remove volume $vol"
     else
-      docker volume rm "$vol" >/dev/null 2>&1 || warn "Could not remove volume $vol"
+      ce volume rm "$vol" >/dev/null 2>&1 || warn "Could not remove volume $vol"
       TOTAL_VOLUMES_REMOVED=$((TOTAL_VOLUMES_REMOVED + 1))
     fi
   done
@@ -249,11 +249,11 @@ if [[ "$SKIP_CACHE" == true ]]; then
   info "Skipping build cache prune (--skip-cache)"
 else
   info "Pruning build cache..."
-  cache_size=$(docker system df --format '{{.Size}}' 2>/dev/null | tail -1)
+  cache_size=$(ce system df --format '{{.Size}}' 2>/dev/null | tail -1)
   if [[ "$DRY_RUN" == true ]]; then
     dry "Would prune build cache (current size: ${cache_size:-unknown})"
   else
-    docker builder prune -af 2>&1 | tail -1
+    ce_builder_prune -af 2>&1 | tail -1
   fi
 fi
 echo
@@ -261,11 +261,11 @@ echo
 # ---------------------------------------------------------------------------
 # Step 5: Clean up any newly-dangling images left after tagged image removal
 # ---------------------------------------------------------------------------
-remaining_dangling=$(docker images --filter "dangling=true" -q | wc -l | tr -d ' ')
+remaining_dangling=$(ce images --filter "dangling=true" -q | wc -l | tr -d ' ')
 if [[ "$remaining_dangling" -gt 0 ]]; then
   info "Cleaning up $remaining_dangling residual dangling image(s)..."
   if [[ "$DRY_RUN" != true ]]; then
-    docker image prune -f >/dev/null 2>&1
+    ce image prune -f >/dev/null 2>&1
     TOTAL_IMAGES_REMOVED=$((TOTAL_IMAGES_REMOVED + remaining_dangling))
   fi
   echo
@@ -279,9 +279,9 @@ echo
 if [[ "$DRY_RUN" == true ]]; then
   warn "Dry run -- no changes were made. Re-run without --dry-run to apply."
 else
-  docker system df
+  ce system df
 fi
 echo
 
 info "Remaining images:"
-docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}"
+ce images --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}"

--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -215,8 +215,8 @@ echo "==> Installing tools via mise..."
 mise trust --yes
 mise install --yes
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "ERROR: Docker is not installed on the remote host." >&2
+if ! command -v podman >/dev/null 2>&1 && ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: Neither podman nor docker is installed on the remote host." >&2
   exit 1
 fi
 
@@ -232,7 +232,7 @@ install -m 0755 target/release/openshell scripts/bin/openshell
 # Prevent a stale repo-local .env from changing the deployment unexpectedly.
 rm -f .env
 
-echo "==> Building Docker images (tag=${IMAGE_TAG})..."
+echo "==> Building container images (tag=${IMAGE_TAG})..."
 export OPENSHELL_CARGO_VERSION="${CARGO_VERSION}"
 export IMAGE_TAG
 mise exec -- tasks/scripts/docker-build-image.sh cluster

--- a/tasks/docker.toml
+++ b/tasks/docker.toml
@@ -8,6 +8,8 @@ description = "Build all Docker images"
 depends = [
   "build:docker:gateway",
   "build:docker:cluster",
+  "build:docker:supervisor",
+  "build:docker:supervisor-sideload",
 ]
 hide = true
 
@@ -22,8 +24,13 @@ run = "tasks/scripts/docker-build-image.sh gateway"
 hide = true
 
 ["build:docker:supervisor"]
-description = "Build the supervisor Docker image"
+description = "Build the standalone supervisor Docker image (Ubuntu-based, for K8s pods)"
 run = "tasks/scripts/docker-build-image.sh supervisor"
+hide = true
+
+["build:docker:supervisor-sideload"]
+description = "Build the supervisor sideload image (FROM scratch, for Podman image-volume mount)"
+run = "tasks/scripts/docker-build-image.sh supervisor-output"
 hide = true
 
 ["build:docker:cluster"]
@@ -36,6 +43,16 @@ description = "Alias for build:docker:gateway"
 depends = ["build:docker:gateway"]
 hide = true
 
+["docker:build:supervisor"]
+description = "Alias for build:docker:supervisor"
+depends = ["build:docker:supervisor"]
+hide = true
+
+["docker:build:supervisor-sideload"]
+description = "Alias for build:docker:supervisor-sideload"
+depends = ["build:docker:supervisor-sideload"]
+hide = true
+
 ["docker:build:cluster"]
 description = "Alias for build:docker:cluster"
 depends = ["build:docker:cluster"]
@@ -44,6 +61,11 @@ hide = true
 ["build:docker:cluster:multiarch"]
 description = "Build multi-arch cluster image and push to a registry"
 run = "tasks/scripts/docker-publish-multiarch.sh"
+hide = true
+
+["docker:build:cluster:multiarch"]
+description = "Alias for build:docker:cluster:multiarch"
+depends = ["build:docker:cluster:multiarch"]
 hide = true
 
 ["docker:cleanup"]

--- a/tasks/python.toml
+++ b/tasks/python.toml
@@ -143,6 +143,8 @@ run = """
 #!/usr/bin/env bash
 set -euo pipefail
 
+source tasks/scripts/container-engine.sh
+
 sha256_16() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$1" | awk '{print substr($1, 1, 16)}'
@@ -172,7 +174,7 @@ CARGO_TARGET_CACHE_SCOPE=$(printf '%s' "$CACHE_SCOPE_INPUT" | sha256_16_stdin)
 
 mkdir -p target/wheels
 
-docker build \
+ce build \
   -f deploy/docker/Dockerfile.python-wheels-macos \
   --target wheels \
   --build-arg "OSXCROSS_IMAGE=${OSXCROSS_IMAGE_REF}" \

--- a/tasks/scripts/cluster-bootstrap.sh
+++ b/tasks/scripts/cluster-bootstrap.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/container-engine.sh"
+
 # Normalize cluster name: lowercase, replace invalid chars with hyphens
 normalize_name() {
   echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//'
@@ -142,28 +145,35 @@ wait_for_registry_ready() {
 }
 
 ensure_local_registry() {
-  if docker inspect "${LOCAL_REGISTRY_CONTAINER}" >/dev/null 2>&1; then
+  if ce inspect "${LOCAL_REGISTRY_CONTAINER}" >/dev/null 2>&1; then
     local proxy_remote_url
-    proxy_remote_url=$(docker inspect "${LOCAL_REGISTRY_CONTAINER}" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | awk -F= '/^REGISTRY_PROXY_REMOTEURL=/{print $2; exit}' || true)
+    proxy_remote_url=$(ce inspect "${LOCAL_REGISTRY_CONTAINER}" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | awk -F= '/^REGISTRY_PROXY_REMOTEURL=/{print $2; exit}' || true)
     if [ -n "${proxy_remote_url}" ]; then
-      docker rm -f "${LOCAL_REGISTRY_CONTAINER}" >/dev/null 2>&1 || true
+      ce rm -f "${LOCAL_REGISTRY_CONTAINER}" >/dev/null 2>&1 || true
     fi
   fi
 
-  if ! docker inspect "${LOCAL_REGISTRY_CONTAINER}" >/dev/null 2>&1; then
-    docker run -d --restart=always --name "${LOCAL_REGISTRY_CONTAINER}" -p 5000:5000 registry:2 >/dev/null
+  if ! ce inspect "${LOCAL_REGISTRY_CONTAINER}" >/dev/null 2>&1; then
+    # --restart=always: on Docker this is managed by the Docker daemon and
+    # survives reboots when the daemon is enabled at boot.  On rootless Podman
+    # it is handled by conmon within the current login session; it does NOT
+    # survive user logout or reboot without a systemd user unit.  This is
+    # acceptable here because ensure_local_registry() recreates the container
+    # on every cluster bootstrap invocation if it is missing.
+    ce run -d --restart=always --name "${LOCAL_REGISTRY_CONTAINER}" -p 5000:5000 registry:2 >/dev/null
   else
-    if ! docker ps --filter "name=^${LOCAL_REGISTRY_CONTAINER}$" --filter "status=running" -q | grep -q .; then
-      docker start "${LOCAL_REGISTRY_CONTAINER}" >/dev/null
+    if ! ce ps --filter "name=^${LOCAL_REGISTRY_CONTAINER}$" --filter "status=running" -q | grep -q .; then
+      ce start "${LOCAL_REGISTRY_CONTAINER}" >/dev/null
     fi
 
-    port_map=$(docker port "${LOCAL_REGISTRY_CONTAINER}" 5000/tcp 2>/dev/null || true)
+    port_map=$(ce port "${LOCAL_REGISTRY_CONTAINER}" 5000/tcp 2>/dev/null || true)
     case "${port_map}" in
       *:5000*)
         ;;
       *)
-        docker rm -f "${LOCAL_REGISTRY_CONTAINER}" >/dev/null 2>&1 || true
-        docker run -d --restart=always --name "${LOCAL_REGISTRY_CONTAINER}" -p 5000:5000 registry:2 >/dev/null
+        ce rm -f "${LOCAL_REGISTRY_CONTAINER}" >/dev/null 2>&1 || true
+        # See --restart=always note above in this function.
+        ce run -d --restart=always --name "${LOCAL_REGISTRY_CONTAINER}" -p 5000:5000 registry:2 >/dev/null
         ;;
     esac
   fi
@@ -177,9 +187,9 @@ ensure_local_registry() {
   fi
 
   echo "Error: local registry is not reachable at ${REGISTRY_HOST}." >&2
-  echo "       Ensure a registry is running on port 5000 (e.g. docker run -d --name openshell-local-registry -p 5000:5000 registry:2)." >&2
-  docker ps -a >&2 || true
-  docker logs "${LOCAL_REGISTRY_CONTAINER}" >&2 || true
+  echo "       Ensure a registry is running on port 5000 (e.g. ${CONTAINER_ENGINE} run -d --name openshell-local-registry -p 5000:5000 registry:2)." >&2
+  ce ps -a >&2 || true
+  ce logs "${LOCAL_REGISTRY_CONTAINER}" >&2 || true
   exit 1
 }
 
@@ -201,7 +211,7 @@ export IMAGE_REPO_BASE
 export IMAGE_TAG
 
 if [ -n "${CI:-}" ] && [ -n "${CI_REGISTRY:-}" ] && [ -n "${CI_REGISTRY_USER:-}" ] && [ -n "${CI_REGISTRY_PASSWORD:-}" ]; then
-  printf '%s' "${CI_REGISTRY_PASSWORD}" | docker login -u "${CI_REGISTRY_USER}" --password-stdin "${CI_REGISTRY}"
+  printf '%s' "${CI_REGISTRY_PASSWORD}" | ce login -u "${CI_REGISTRY_USER}" --password-stdin "${CI_REGISTRY}"
   export OPENSHELL_REGISTRY_USERNAME=${OPENSHELL_REGISTRY_USERNAME:-${CI_REGISTRY_USER}}
   export OPENSHELL_REGISTRY_PASSWORD=${OPENSHELL_REGISTRY_PASSWORD:-${CI_REGISTRY_PASSWORD}}
 fi
@@ -214,7 +224,7 @@ CONTAINER_NAME="openshell-cluster-${CLUSTER_NAME}"
 VOLUME_NAME="openshell-cluster-${CLUSTER_NAME}"
 
 if [ "${MODE}" = "fast" ]; then
-  if docker inspect "${CONTAINER_NAME}" >/dev/null 2>&1 || docker volume inspect "${VOLUME_NAME}" >/dev/null 2>&1; then
+  if ce inspect "${CONTAINER_NAME}" >/dev/null 2>&1 || ce volume inspect "${VOLUME_NAME}" >/dev/null 2>&1; then
     echo "Recreating cluster '${CLUSTER_NAME}' from scratch..."
     openshell gateway destroy --name "${CLUSTER_NAME}"
   fi
@@ -255,7 +265,7 @@ if [ -n "${GATEWAY_HOST:-}" ]; then
   # (it's a Docker Desktop feature). If the hostname doesn't resolve,
   # add it via the Docker bridge gateway IP.
   if ! getent hosts "${GATEWAY_HOST}" >/dev/null 2>&1; then
-    BRIDGE_IP=$(docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}' 2>/dev/null || true)
+    BRIDGE_IP=$(ce_network_gateway)
     if [ -n "${BRIDGE_IP}" ]; then
       echo "Adding /etc/hosts entry: ${BRIDGE_IP} ${GATEWAY_HOST}"
       echo "${BRIDGE_IP} ${GATEWAY_HOST}" >> /etc/hosts

--- a/tasks/scripts/cluster-deploy-fast.sh
+++ b/tasks/scripts/cluster-deploy-fast.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/container-engine.sh"
+
 # Normalize cluster name: lowercase, replace invalid chars with hyphens
 normalize_name() {
   echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//'
@@ -30,7 +33,7 @@ log_duration() {
   echo "${label} took $((end - start))s"
 }
 
-if ! docker ps -q --filter "name=^${CONTAINER_NAME}$" --filter "health=healthy" | grep -q .; then
+if ! ce ps -q --filter "name=^${CONTAINER_NAME}$" --filter "health=healthy" | grep -q .; then
   echo "Error: Cluster container '${CONTAINER_NAME}' is not running or not healthy."
   echo "Start the cluster first with: mise run cluster"
   exit 1
@@ -38,7 +41,7 @@ fi
 
 # Run a command inside the cluster container with KUBECONFIG pre-configured.
 cluster_exec() {
-  docker exec "${CONTAINER_NAME}" sh -c "KUBECONFIG=/etc/rancher/k3s/k3s.yaml $*"
+  ce exec "${CONTAINER_NAME}" sh -c "KUBECONFIG=/etc/rancher/k3s/k3s.yaml $*"
 }
 
 # Path inside the container where the chart is copied for helm upgrades.
@@ -102,7 +105,7 @@ log_duration "Change detection" "${detect_start}" "${detect_end}"
 # recreated (e.g. via bootstrap).  A new container means the k3s state is
 # fresh and all images must be rebuilt and pushed regardless of source
 # fingerprints.
-current_container_id=$(docker inspect --format '{{.Id}}' "${CONTAINER_NAME}" 2>/dev/null || true)
+current_container_id=$(ce inspect --format '{{.Id}}' "${CONTAINER_NAME}" 2>/dev/null || true)
 
 if [[ -f "${DEPLOY_FAST_STATE_FILE}" ]]; then
   while IFS='=' read -r key value; do
@@ -315,11 +318,11 @@ if [[ "${build_supervisor}" == "1" ]]; then
   # Detect the cluster container's architecture so we cross-compile correctly.
   # Container objects lack an Architecture field (the Go template emits a
   # stray newline before erroring), so inspect the container's *image* instead.
-  _cluster_image=$(docker inspect --format '{{.Config.Image}}' "${CONTAINER_NAME}" 2>/dev/null)
-  CLUSTER_ARCH=$(docker image inspect --format '{{.Architecture}}' "${_cluster_image}" 2>/dev/null || echo "amd64")
+  _cluster_image=$(ce inspect --format '{{.Config.Image}}' "${CONTAINER_NAME}" 2>/dev/null)
+  CLUSTER_ARCH=$(ce image inspect --format '{{.Architecture}}' "${_cluster_image}" 2>/dev/null || echo "amd64")
 
-  # Detect the host (build) architecture in Docker's naming convention.
-  HOST_ARCH=$(docker info --format '{{.Architecture}}' 2>/dev/null || echo "amd64")
+  # Detect the host (build) architecture in the container engine's naming convention.
+  HOST_ARCH=$(ce_info_arch)
   # Normalize: Docker reports "aarch64" on ARM hosts but uses "arm64" elsewhere.
   case "${HOST_ARCH}" in
     aarch64) HOST_ARCH=arm64 ;;
@@ -353,10 +356,10 @@ if [[ "${build_supervisor}" == "1" ]]; then
     tasks/scripts/docker-build-image.sh supervisor-output
 
   # Copy the built binary into the running k3s container
-  docker exec "${CONTAINER_NAME}" mkdir -p /opt/openshell/bin
-  docker cp "${SUPERVISOR_BUILD_DIR}/openshell-sandbox" \
+  ce exec "${CONTAINER_NAME}" mkdir -p /opt/openshell/bin
+  ce cp "${SUPERVISOR_BUILD_DIR}/openshell-sandbox" \
     "${CONTAINER_NAME}:/opt/openshell/bin/openshell-sandbox"
-  docker exec "${CONTAINER_NAME}" chmod 755 /opt/openshell/bin/openshell-sandbox
+  ce exec "${CONTAINER_NAME}" chmod 755 /opt/openshell/bin/openshell-sandbox
 
   built_components+=("supervisor")
   supervisor_end=$(date +%s)
@@ -370,7 +373,7 @@ log_duration "Builds" "${build_start}" "${build_end}"
 declare -a pushed_images=()
 
 if [[ "${build_gateway}" == "1" ]]; then
-  docker tag "openshell/gateway:${IMAGE_TAG}" "${IMAGE_REPO_BASE}/gateway:${IMAGE_TAG}" 2>/dev/null || true
+  ce tag "openshell/gateway:${IMAGE_TAG}" "${IMAGE_REPO_BASE}/gateway:${IMAGE_TAG}" 2>/dev/null || true
   pushed_images+=("${IMAGE_REPO_BASE}/gateway:${IMAGE_TAG}")
   built_components+=("gateway")
 fi
@@ -379,7 +382,7 @@ if [[ "${#pushed_images[@]}" -gt 0 ]]; then
   push_start=$(date +%s)
   echo "Pushing updated images to local registry..."
   for image_ref in "${pushed_images[@]}"; do
-    docker push "${image_ref}"
+    ce push "${image_ref}"
   done
   push_end=$(date +%s)
   log_duration "Image push" "${push_start}" "${push_end}"
@@ -389,7 +392,7 @@ fi
 # the updated image from the registry.
 if [[ "${build_gateway}" == "1" ]]; then
   echo "Evicting stale gateway image from k3s..."
-  docker exec "${CONTAINER_NAME}" crictl rmi "${IMAGE_REPO_BASE}/gateway:${IMAGE_TAG}" >/dev/null 2>&1 || true
+  ce exec "${CONTAINER_NAME}" crictl rmi "${IMAGE_REPO_BASE}/gateway:${IMAGE_TAG}" >/dev/null 2>&1 || true
 fi
 
 if [[ "${needs_helm_upgrade}" == "1" ]]; then
@@ -401,8 +404,8 @@ if [[ "${needs_helm_upgrade}" == "1" ]]; then
   fi
 
   # Copy the local chart source into the container so helm can read it.
-  docker exec "${CONTAINER_NAME}" rm -rf "${CONTAINER_CHART_DIR}"
-  docker cp deploy/helm/openshell "${CONTAINER_NAME}:${CONTAINER_CHART_DIR}"
+  ce exec "${CONTAINER_NAME}" rm -rf "${CONTAINER_CHART_DIR}"
+  ce cp deploy/helm/openshell "${CONTAINER_NAME}:${CONTAINER_CHART_DIR}"
 
   # grpcEndpoint must be explicitly set to https:// because the chart always
   # terminates mTLS (there is no server.tls.enabled toggle). Without this,

--- a/tasks/scripts/cluster-push-component.sh
+++ b/tasks/scripts/cluster-push-component.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/container-engine.sh"
+
 component=${1:-}
 if [ -z "${component}" ]; then
   echo "usage: $0 <gateway>" >&2
@@ -41,7 +44,7 @@ source_candidates=(
 
 resolved_source_image=""
 for candidate in "${source_candidates[@]}"; do
-  if docker image inspect "${candidate}" >/dev/null 2>&1; then
+  if ce image inspect "${candidate}" >/dev/null 2>&1; then
     resolved_source_image="${candidate}"
     break
   fi
@@ -53,12 +56,12 @@ if [ -z "${resolved_source_image}" ]; then
   resolved_source_image="openshell/${component}:${IMAGE_TAG}"
 fi
 
-docker tag "${resolved_source_image}" "${TARGET_IMAGE}"
-docker push "${TARGET_IMAGE}"
+ce tag "${resolved_source_image}" "${TARGET_IMAGE}"
+ce push "${TARGET_IMAGE}"
 
 # Evict the stale image from k3s's containerd cache so new pods pull the
 # updated image. Without this, k3s uses its cached copy (imagePullPolicy
 # defaults to IfNotPresent for non-:latest tags) and pods run stale code.
-if docker ps -q --filter "name=${CONTAINER_NAME}" | grep -q .; then
-  docker exec "${CONTAINER_NAME}" crictl rmi "${TARGET_IMAGE}" >/dev/null 2>&1 || true
+if ce ps -q --filter "name=${CONTAINER_NAME}" | grep -q .; then
+  ce exec "${CONTAINER_NAME}" crictl rmi "${TARGET_IMAGE}" >/dev/null 2>&1 || true
 fi

--- a/tasks/scripts/cluster.sh
+++ b/tasks/scripts/cluster.sh
@@ -8,6 +8,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/container-engine.sh"
+
 # Normalize cluster name: lowercase, replace invalid chars with hyphens
 normalize_name() {
   echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//'
@@ -17,13 +20,13 @@ CLUSTER_NAME=${CLUSTER_NAME:-$(basename "$PWD")}
 CLUSTER_NAME=$(normalize_name "${CLUSTER_NAME}")
 CONTAINER_NAME="openshell-cluster-${CLUSTER_NAME}"
 
-if ! docker ps -q --filter "name=${CONTAINER_NAME}" | grep -q .; then
+if ! ce ps -q --filter "name=${CONTAINER_NAME}" | grep -q .; then
   echo "No running cluster found. Bootstrapping..."
   exec tasks/scripts/cluster-bootstrap.sh fast
 fi
 
 # Container is running but not healthy — tear it down and re-bootstrap.
-if ! docker ps -q --filter "name=^${CONTAINER_NAME}$" --filter "health=healthy" | grep -q .; then
+if ! ce ps -q --filter "name=^${CONTAINER_NAME}$" --filter "health=healthy" | grep -q .; then
   echo "Cluster container '${CONTAINER_NAME}' is running but not healthy. Recreating..."
   exec tasks/scripts/cluster-bootstrap.sh fast
 fi

--- a/tasks/scripts/container-engine.sh
+++ b/tasks/scripts/container-engine.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Shared container engine detection and abstraction layer.
+#
+# Source this file in any script that needs to run container commands:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "${SCRIPT_DIR}/container-engine.sh"  # or adjust path accordingly
+#
+# After sourcing, use these instead of bare `docker` / `podman`:
+#   ce <subcommand> [args...]        — run container engine command
+#   ce_build [args...]               — container image build (handles buildx differences)
+#   ce_is_podman / ce_is_docker      — check which engine is active
+#   ce_info_arch                     — host architecture (handles format differences)
+#   ce_network_gateway [network]     — default network gateway IP
+#   ce_builder_prune [args...]       — prune build cache
+#   ce_buildx_inspect [args...]      — inspect buildx builder (no-op for podman)
+#   ce_build_multiarch               — multi-arch build + push workflow
+#
+# Override the auto-detected engine by setting CONTAINER_ENGINE=docker or
+# CONTAINER_ENGINE=podman before sourcing.
+# Suppress the detection log line with CONTAINER_ENGINE_QUIET=1 (useful in
+# CI pipelines or scripts that source this file multiple times in a pipeline).
+
+# Guard against double-sourcing.
+if [[ -n "${_CONTAINER_ENGINE_LOADED:-}" ]]; then
+  return 0
+fi
+_CONTAINER_ENGINE_LOADED=1
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+_detect_container_engine() {
+  # Honour explicit override.
+  if [[ -n "${CONTAINER_ENGINE:-}" ]]; then
+    if ! command -v "${CONTAINER_ENGINE}" >/dev/null 2>&1; then
+      echo "Error: CONTAINER_ENGINE=${CONTAINER_ENGINE} is not installed or not in PATH" >&2
+      exit 1
+    fi
+    _CE_EXPLICIT_OVERRIDE=1
+    return
+  fi
+
+  # Prefer podman when available.
+  if command -v podman >/dev/null 2>&1; then
+    CONTAINER_ENGINE=podman
+    return
+  fi
+
+  # Fall back to docker — but detect the podman-masquerading-as-docker shim
+  # shipped by some distros (e.g. Fedora, RHEL).
+  if command -v docker >/dev/null 2>&1; then
+    if docker --version 2>/dev/null | grep -qi podman; then
+      CONTAINER_ENGINE=podman
+    else
+      CONTAINER_ENGINE=docker
+    fi
+    return
+  fi
+
+  echo "Error: neither podman nor docker is installed." >&2
+  echo "       Install one of them and try again." >&2
+  exit 1
+}
+
+_detect_container_engine
+
+# The actual binary to invoke — usually equals CONTAINER_ENGINE, but when
+# podman is detected via the docker shim we still call `docker` (the shim
+# execs podman internally).
+_CE_BIN="${CONTAINER_ENGINE}"
+if [[ "${CONTAINER_ENGINE}" == "podman" ]] && ! command -v podman >/dev/null 2>&1; then
+  # podman detected through docker shim; call docker (which execs podman).
+  _CE_BIN=docker
+fi
+
+# ---------------------------------------------------------------------------
+# Core helpers
+# ---------------------------------------------------------------------------
+
+# Run the container engine with arbitrary arguments.
+ce() {
+  "${_CE_BIN}" "$@"
+}
+
+ce_is_podman() {
+  [[ "${CONTAINER_ENGINE}" == "podman" ]]
+}
+
+ce_is_docker() {
+  [[ "${CONTAINER_ENGINE}" == "docker" ]]
+}
+
+# ---------------------------------------------------------------------------
+# ce_build — abstraction over `docker buildx build` / `podman build`
+#
+# Accepts the same flags as `docker buildx build`.  For podman the function:
+#   - Strips --load (podman loads locally by default)
+#   - Strips --provenance (podman doesn't generate provenance attestations)
+#   - Strips --builder (podman has no builder concept)
+#   - Converts --push to a post-build `podman push` (podman build has no --push)
+#
+# All other flags (--platform, --build-arg, --cache-from, --cache-to,
+# --output, -t, -f, --target, etc.) are passed through as-is since podman
+# build supports them.
+# ---------------------------------------------------------------------------
+ce_build() {
+  if ce_is_docker; then
+    "${_CE_BIN}" buildx build "$@"
+    return
+  fi
+
+  # Podman path — filter out unsupported flags.
+  local args=()
+  local push_after=false
+  local image_tags=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --load)
+        # Podman loads locally by default; skip.
+        shift
+        ;;
+      --push)
+        push_after=true
+        shift
+        ;;
+      --provenance|--provenance=*)
+        # Podman doesn't support provenance attestations; skip.
+        shift
+        ;;
+      --builder|--builder=*)
+        # Podman has no builder concept; skip.
+        if [[ "$1" == "--builder" ]]; then
+          shift 2  # skip --builder <name>
+        else
+          shift    # skip --builder=<name>
+        fi
+        ;;
+      -t|--tag)
+        image_tags+=("$2")
+        args+=("$1" "$2")
+        shift 2
+        ;;
+      -t=*|--tag=*)
+        image_tags+=("${1#*=}")
+        args+=("$1")
+        shift
+        ;;
+      *)
+        args+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  "${_CE_BIN}" build "${args[@]}"
+
+  if [[ "${push_after}" == "true" ]]; then
+    for tag in "${image_tags[@]}"; do
+      "${_CE_BIN}" push "${tag}"
+    done
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# ce_info_arch — host architecture reported by the container engine.
+#
+# Docker: docker info --format '{{.Architecture}}'
+# Podman: podman info --format '{{.Host.Arch}}'
+# ---------------------------------------------------------------------------
+ce_info_arch() {
+  if ce_is_docker; then
+    "${_CE_BIN}" info --format '{{.Architecture}}' 2>/dev/null || echo "amd64"
+  else
+    "${_CE_BIN}" info --format '{{.Host.Arch}}' 2>/dev/null || echo "amd64"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# ce_network_gateway — default network gateway IP.
+#
+# Docker: docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}'
+# Podman: podman network inspect podman --format '{{(index .Subnets 0).Gateway}}'
+#
+# Accepts an optional network name override; defaults to the engine's default.
+# ---------------------------------------------------------------------------
+ce_network_gateway() {
+  local network="${1:-}"
+  if ce_is_docker; then
+    network="${network:-bridge}"
+    "${_CE_BIN}" network inspect "${network}" --format '{{(index .IPAM.Config 0).Gateway}}' 2>/dev/null || true
+  else
+    network="${network:-podman}"
+    "${_CE_BIN}" network inspect "${network}" --format '{{(index .Subnets 0).Gateway}}' 2>/dev/null || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# ce_builder_prune — prune build cache.
+#
+# Docker: docker builder prune -af
+# Podman: podman system reset is too aggressive; use buildah prune or image prune.
+# ---------------------------------------------------------------------------
+ce_builder_prune() {
+  if ce_is_docker; then
+    "${_CE_BIN}" builder prune "$@"
+  else
+    # Podman doesn't have `builder prune`.  `podman image prune` removes
+    # dangling build layers.  `buildah prune` is closest but may not be
+    # installed.  Fall back gracefully.
+    if command -v buildah >/dev/null 2>&1; then
+      buildah prune "$@"
+    else
+      "${_CE_BIN}" image prune "$@"
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# ce_buildx_inspect — inspect a buildx builder.
+#
+# Docker: docker buildx inspect [name]
+# Podman: returns a synthetic "podman" driver response to satisfy callers that
+#         check for "Driver: docker-container".
+# ---------------------------------------------------------------------------
+ce_buildx_inspect() {
+  if ce_is_docker; then
+    "${_CE_BIN}" buildx inspect "$@"
+  else
+    # Podman doesn't have real buildx builders.  Emit a minimal response so
+    # callers that grep for "Driver:" get a predictable answer.
+    echo "Name:   default"
+    echo "Driver: podman"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# ce_context_name — current context/connection name.
+#
+# Docker: docker context inspect --format '{{.Name}}'
+# Podman: always "default"
+# ---------------------------------------------------------------------------
+ce_context_name() {
+  if ce_is_docker; then
+    "${_CE_BIN}" context inspect --format '{{.Name}}' 2>/dev/null || echo "default"
+  else
+    echo "default"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# ce_imagetools_create — create/re-tag a multi-arch manifest.
+#
+# Docker: docker buildx imagetools create -t <new> <source>
+# Podman: no direct equivalent — the caller should use podman manifest
+#         workflows instead.  This helper exists so scripts can call it
+#         without engine checks; for podman it falls back to tag + push.
+# ---------------------------------------------------------------------------
+ce_imagetools_create() {
+  if ce_is_docker; then
+    "${_CE_BIN}" buildx imagetools create "$@"
+    return
+  fi
+
+  # Podman fallback: parse -t <tag> and the trailing source image, then
+  # use skopeo or podman tag.  This is a best-effort shim for simple
+  # re-tagging; full multi-arch manifest manipulation should use the
+  # podman-native code path in docker-publish-multiarch.sh.
+  #
+  # Argument parsing uses a sentinel ("__next__") to capture the value
+  # that follows a two-token -t / --tag flag.  --prefer-index is accepted
+  # and silently ignored (the Docker path passes it through to buildx;
+  # the Podman path has no equivalent concept).
+  local new_tag="" source_image=""
+  for arg in "$@"; do
+    case "${arg}" in
+      -t|--tag)
+        new_tag="__next__"
+        continue
+        ;;
+      --prefer-index|--prefer-index=*)
+        # No podman equivalent; accepted and ignored for call-site compatibility.
+        continue
+        ;;
+    esac
+    if [[ "${new_tag}" == "__next__" ]]; then
+      new_tag="${arg}"
+    else
+      source_image="${arg}"
+    fi
+  done
+
+  if [[ -n "${new_tag}" && -n "${source_image}" ]]; then
+    if command -v skopeo >/dev/null 2>&1; then
+      skopeo copy --all "docker://${source_image}" "docker://${new_tag}"
+    else
+      "${_CE_BIN}" tag "${source_image}" "${new_tag}"
+      "${_CE_BIN}" push "${new_tag}"
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Log the detected engine so developers always know which tool is active.
+# Emitted once per script invocation (the double-source guard at the top
+# prevents repeated output when scripts source each other).
+# Suppress with CONTAINER_ENGINE_QUIET=1 for CI or non-interactive use.
+# ---------------------------------------------------------------------------
+_ce_log_detected() {
+  if [[ "${CONTAINER_ENGINE_QUIET:-}" == "1" ]]; then
+    return
+  fi
+  if [[ -n "${_CE_EXPLICIT_OVERRIDE:-}" ]]; then
+    echo "[container-engine] using ${CONTAINER_ENGINE} (set via CONTAINER_ENGINE env)" >&2
+  else
+    echo "[container-engine] auto-detected: ${CONTAINER_ENGINE} (override with CONTAINER_ENGINE=docker|podman)" >&2
+  fi
+}
+_ce_log_detected

--- a/tasks/scripts/docker-build-ci.sh
+++ b/tasks/scripts/docker-build-ci.sh
@@ -8,6 +8,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/container-engine.sh"
+
 OUTPUT_ARGS=(--load)
 if [[ "${DOCKER_PUSH:-}" == "1" ]]; then
   OUTPUT_ARGS=(--push)
@@ -15,7 +18,7 @@ elif [[ "${DOCKER_PLATFORM:-}" == *","* ]]; then
   OUTPUT_ARGS=(--push)
 fi
 
-exec docker buildx build \
+exec ce_build \
   ${DOCKER_BUILDER:+--builder ${DOCKER_BUILDER}} \
   ${DOCKER_PLATFORM:+--platform ${DOCKER_PLATFORM}} \
   -f deploy/docker/Dockerfile.ci \

--- a/tasks/scripts/docker-build-image.sh
+++ b/tasks/scripts/docker-build-image.sh
@@ -5,37 +5,40 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/container-engine.sh"
+
 sha256_16() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$1" | awk '{print substr($1, 1, 16)}'
-  else
-    shasum -a 256 "$1" | awk '{print substr($1, 1, 16)}'
-  fi
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$1" | awk '{print substr($1, 1, 16)}'
+	else
+		shasum -a 256 "$1" | awk '{print substr($1, 1, 16)}'
+	fi
 }
 
 sha256_16_stdin() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum | awk '{print substr($1, 1, 16)}'
-  else
-    shasum -a 256 | awk '{print substr($1, 1, 16)}'
-  fi
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum | awk '{print substr($1, 1, 16)}'
+	else
+		shasum -a 256 | awk '{print substr($1, 1, 16)}'
+	fi
 }
 
 detect_rust_scope() {
-  local dockerfile="$1"
-  local rust_from
-  rust_from=$(grep -E '^FROM --platform=\$BUILDPLATFORM rust:[^ ]+' "$dockerfile" | head -n1 | sed -E 's/^FROM --platform=\$BUILDPLATFORM rust:([^ ]+).*/\1/' || true)
-  if [[ -n "${rust_from}" ]]; then
-    echo "rust-${rust_from}"
-    return
-  fi
+	local dockerfile="$1"
+	local rust_from
+	rust_from=$(grep -E '^FROM --platform=\$BUILDPLATFORM rust:[^ ]+' "$dockerfile" | head -n1 | sed -E 's/^FROM --platform=\$BUILDPLATFORM rust:([^ ]+).*/\1/' || true)
+	if [[ -n "${rust_from}" ]]; then
+		echo "rust-${rust_from}"
+		return
+	fi
 
-  if grep -q "rustup.rs" "$dockerfile"; then
-    echo "rustup-stable"
-    return
-  fi
+	if grep -q "rustup.rs" "$dockerfile"; then
+		echo "rustup-stable"
+		return
+	fi
 
-  echo "no-rust"
+	echo "no-rust"
 }
 
 TARGET=${1:?"Usage: docker-build-image.sh <gateway|supervisor|cluster|supervisor-builder|supervisor-output> [extra-args...]"}
@@ -43,8 +46,8 @@ shift
 
 DOCKERFILE="deploy/docker/Dockerfile.images"
 if [[ ! -f "${DOCKERFILE}" ]]; then
-  echo "Error: Dockerfile not found: ${DOCKERFILE}" >&2
-  exit 1
+	echo "Error: Dockerfile not found: ${DOCKERFILE}" >&2
+	exit 1
 fi
 
 IS_FINAL_IMAGE=0
@@ -70,6 +73,8 @@ case "${TARGET}" in
     DOCKER_TARGET="supervisor-builder"
     ;;
   supervisor-output)
+    IS_FINAL_IMAGE=1
+    IMAGE_NAME="openshell/supervisor"
     DOCKER_TARGET="supervisor-output"
     ;;
   *)
@@ -79,7 +84,7 @@ case "${TARGET}" in
 esac
 
 if [[ -n "${IMAGE_REGISTRY:-}" && "${IS_FINAL_IMAGE}" == "1" ]]; then
-  IMAGE_NAME="${IMAGE_REGISTRY}/${IMAGE_NAME#openshell/}"
+	IMAGE_NAME="${IMAGE_REGISTRY}/${IMAGE_NAME#openshell/}"
 fi
 
 IMAGE_TAG=${IMAGE_TAG:-dev}
@@ -88,36 +93,40 @@ CACHE_PATH="${DOCKER_BUILD_CACHE_DIR}/images"
 mkdir -p "${CACHE_PATH}"
 
 BUILDER_ARGS=()
-if [[ -n "${DOCKER_BUILDER:-}" ]]; then
-  BUILDER_ARGS=(--builder "${DOCKER_BUILDER}")
-elif [[ -z "${DOCKER_PLATFORM:-}" && -z "${CI:-}" ]]; then
-  _ctx=$(docker context inspect --format '{{.Name}}' 2>/dev/null || echo default)
-  BUILDER_ARGS=(--builder "${_ctx}")
+if ce_is_docker; then
+	if [[ -n "${DOCKER_BUILDER:-}" ]]; then
+		BUILDER_ARGS=(--builder "${DOCKER_BUILDER}")
+	elif [[ -z "${DOCKER_PLATFORM:-}" && -z "${CI:-}" ]]; then
+		_ctx=$(ce_context_name)
+		BUILDER_ARGS=(--builder "${_ctx}")
+	fi
 fi
 
 CACHE_ARGS=()
 if [[ -z "${CI:-}" ]]; then
-  if docker buildx inspect ${BUILDER_ARGS[@]+"${BUILDER_ARGS[@]}"} 2>/dev/null | grep -q "Driver: docker-container"; then
-    CACHE_ARGS=(
-      --cache-from "type=local,src=${CACHE_PATH}"
-      --cache-to "type=local,dest=${CACHE_PATH},mode=max"
-    )
-  fi
+	if ce_is_docker; then
+		if ce_buildx_inspect ${BUILDER_ARGS[@]+"${BUILDER_ARGS[@]}"} 2>/dev/null | grep -q "Driver: docker-container"; then
+			CACHE_ARGS=(
+				--cache-from "type=local,src=${CACHE_PATH}"
+				--cache-to "type=local,dest=${CACHE_PATH},mode=max"
+			)
+		fi
+	fi
 fi
 
 SCCACHE_ARGS=()
 if [[ -n "${SCCACHE_MEMCACHED_ENDPOINT:-}" ]]; then
-  SCCACHE_ARGS=(--build-arg "SCCACHE_MEMCACHED_ENDPOINT=${SCCACHE_MEMCACHED_ENDPOINT}")
+	SCCACHE_ARGS=(--build-arg "SCCACHE_MEMCACHED_ENDPOINT=${SCCACHE_MEMCACHED_ENDPOINT}")
 fi
 
 VERSION_ARGS=()
 if [[ -n "${OPENSHELL_CARGO_VERSION:-}" ]]; then
-  VERSION_ARGS=(--build-arg "OPENSHELL_CARGO_VERSION=${OPENSHELL_CARGO_VERSION}")
+	VERSION_ARGS=(--build-arg "OPENSHELL_CARGO_VERSION=${OPENSHELL_CARGO_VERSION}")
 elif [[ -n "${CI:-}" ]]; then
-  CARGO_VERSION=$(uv run python tasks/scripts/release.py get-version --cargo 2>/dev/null || true)
-  if [[ -n "${CARGO_VERSION}" ]]; then
-    VERSION_ARGS=(--build-arg "OPENSHELL_CARGO_VERSION=${CARGO_VERSION}")
-  fi
+	CARGO_VERSION=$(uv run python tasks/scripts/release.py get-version --cargo 2>/dev/null || true)
+	if [[ -n "${CARGO_VERSION}" ]]; then
+		VERSION_ARGS=(--build-arg "OPENSHELL_CARGO_VERSION=${CARGO_VERSION}")
+	fi
 fi
 
 LOCK_HASH=$(sha256_16 Cargo.lock)
@@ -127,41 +136,41 @@ CARGO_TARGET_CACHE_SCOPE=$(printf '%s' "${CACHE_SCOPE_INPUT}" | sha256_16_stdin)
 
 # The cluster image embeds the packaged Helm chart.
 if [[ "${TARGET}" == "cluster" ]]; then
-  mkdir -p deploy/docker/.build/charts
-  helm package deploy/helm/openshell -d deploy/docker/.build/charts/ >/dev/null
+	mkdir -p deploy/docker/.build/charts
+	helm package deploy/helm/openshell -d deploy/docker/.build/charts/ >/dev/null
 fi
 
 K3S_ARGS=()
 if [[ "${TARGET}" == "cluster" && -n "${K3S_VERSION:-}" ]]; then
-  K3S_ARGS=(--build-arg "K3S_VERSION=${K3S_VERSION}")
+	K3S_ARGS=(--build-arg "K3S_VERSION=${K3S_VERSION}")
 fi
 
 # CI builds use codegen-units=1 for maximum optimization; local builds omit
 # the arg so cargo uses the Cargo.toml default (parallel codegen, fast links).
 CODEGEN_ARGS=()
 if [[ -n "${CI:-}" ]]; then
-  CODEGEN_ARGS=(--build-arg "CARGO_CODEGEN_UNITS=1")
+	CODEGEN_ARGS=(--build-arg "CARGO_CODEGEN_UNITS=1")
 fi
 
 TAG_ARGS=()
 if [[ "${IS_FINAL_IMAGE}" == "1" ]]; then
-  TAG_ARGS=(-t "${IMAGE_NAME}:${IMAGE_TAG}")
+	TAG_ARGS=(-t "${IMAGE_NAME}:${IMAGE_TAG}")
 fi
 
 OUTPUT_ARGS=()
 if [[ -n "${DOCKER_OUTPUT:-}" ]]; then
-  OUTPUT_ARGS=(--output "${DOCKER_OUTPUT}")
+	OUTPUT_ARGS=(--output "${DOCKER_OUTPUT}")
 elif [[ "${IS_FINAL_IMAGE}" == "1" ]]; then
-  if [[ "${DOCKER_PUSH:-}" == "1" ]]; then
-    OUTPUT_ARGS=(--push)
-  elif [[ "${DOCKER_PLATFORM:-}" == *","* ]]; then
-    OUTPUT_ARGS=(--push)
-  else
-    OUTPUT_ARGS=(--load)
-  fi
+	if [[ "${DOCKER_PUSH:-}" == "1" ]]; then
+		OUTPUT_ARGS=(--push)
+	elif [[ "${DOCKER_PLATFORM:-}" == *","* ]]; then
+		OUTPUT_ARGS=(--push)
+	else
+		OUTPUT_ARGS=(--load)
+	fi
 else
-  echo "Error: DOCKER_OUTPUT must be set when building target '${TARGET}'" >&2
-  exit 1
+	echo "Error: DOCKER_OUTPUT must be set when building target '${TARGET}'" >&2
+	exit 1
 fi
 
 # Default to dev-settings so local builds include test-only settings
@@ -170,23 +179,23 @@ EXTRA_CARGO_FEATURES="${EXTRA_CARGO_FEATURES:-openshell-core/dev-settings}"
 
 FEATURE_ARGS=()
 if [[ -n "${EXTRA_CARGO_FEATURES}" ]]; then
-  FEATURE_ARGS=(--build-arg "EXTRA_CARGO_FEATURES=${EXTRA_CARGO_FEATURES}")
+	FEATURE_ARGS=(--build-arg "EXTRA_CARGO_FEATURES=${EXTRA_CARGO_FEATURES}")
 fi
 
-docker buildx build \
-  ${BUILDER_ARGS[@]+"${BUILDER_ARGS[@]}"} \
-  ${DOCKER_PLATFORM:+--platform ${DOCKER_PLATFORM}} \
-  ${CACHE_ARGS[@]+"${CACHE_ARGS[@]}"} \
-  ${SCCACHE_ARGS[@]+"${SCCACHE_ARGS[@]}"} \
-  ${VERSION_ARGS[@]+"${VERSION_ARGS[@]}"} \
-  ${K3S_ARGS[@]+"${K3S_ARGS[@]}"} \
-  ${CODEGEN_ARGS[@]+"${CODEGEN_ARGS[@]}"} \
-  ${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"} \
-  --build-arg "CARGO_TARGET_CACHE_SCOPE=${CARGO_TARGET_CACHE_SCOPE}" \
-  -f "${DOCKERFILE}" \
-  --target "${DOCKER_TARGET}" \
-  ${TAG_ARGS[@]+"${TAG_ARGS[@]}"} \
-  --provenance=false \
-  "$@" \
-  ${OUTPUT_ARGS[@]+"${OUTPUT_ARGS[@]}"} \
-  .
+ce_build \
+	${BUILDER_ARGS[@]+"${BUILDER_ARGS[@]}"} \
+	${DOCKER_PLATFORM:+--platform ${DOCKER_PLATFORM}} \
+	${CACHE_ARGS[@]+"${CACHE_ARGS[@]}"} \
+	${SCCACHE_ARGS[@]+"${SCCACHE_ARGS[@]}"} \
+	${VERSION_ARGS[@]+"${VERSION_ARGS[@]}"} \
+	${K3S_ARGS[@]+"${K3S_ARGS[@]}"} \
+	${CODEGEN_ARGS[@]+"${CODEGEN_ARGS[@]}"} \
+	${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"} \
+	--build-arg "CARGO_TARGET_CACHE_SCOPE=${CARGO_TARGET_CACHE_SCOPE}" \
+	-f "${DOCKERFILE}" \
+	--target "${DOCKER_TARGET}" \
+	${TAG_ARGS[@]+"${TAG_ARGS[@]}"} \
+	--provenance=false \
+	"$@" \
+	${OUTPUT_ARGS[@]+"${OUTPUT_ARGS[@]}"} \
+	.

--- a/tasks/scripts/docker-publish-multiarch.sh
+++ b/tasks/scripts/docker-publish-multiarch.sh
@@ -8,6 +8,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/container-engine.sh"
+
 REGISTRY=${DOCKER_REGISTRY:?Set DOCKER_REGISTRY to push multi-arch images (e.g. ghcr.io/myorg)}
 IMAGE_TAG=${IMAGE_TAG:-dev}
 PLATFORMS=${DOCKER_PLATFORMS:-linux/amd64,linux/arm64}
@@ -22,44 +25,121 @@ if [[ -n "${EXTRA_DOCKER_TAGS_RAW}" ]]; then
   done
 fi
 
-BUILDER_NAME=${DOCKER_BUILDER:-multiarch}
-if docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-  echo "Using existing buildx builder: ${BUILDER_NAME}"
-  docker buildx use "${BUILDER_NAME}"
-else
-  echo "Creating multi-platform buildx builder: ${BUILDER_NAME}..."
-  docker buildx create --name "${BUILDER_NAME}" --use --bootstrap
-fi
+# ---------------------------------------------------------------------------
+# Docker path: use buildx builders + imagetools for multi-arch
+# ---------------------------------------------------------------------------
+_publish_multiarch_docker() {
+  BUILDER_NAME=${DOCKER_BUILDER:-multiarch}
+  if ce buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    echo "Using existing buildx builder: ${BUILDER_NAME}"
+    ce buildx use "${BUILDER_NAME}"
+  else
+    echo "Creating multi-platform buildx builder: ${BUILDER_NAME}..."
+    ce buildx create --name "${BUILDER_NAME}" --use --bootstrap
+  fi
 
-export DOCKER_BUILDER="${BUILDER_NAME}"
-export DOCKER_PLATFORM="${PLATFORMS}"
-export DOCKER_PUSH=1
-export IMAGE_REGISTRY="${REGISTRY}"
+  export DOCKER_BUILDER="${BUILDER_NAME}"
+  export DOCKER_PLATFORM="${PLATFORMS}"
+  export DOCKER_PUSH=1
+  export IMAGE_REGISTRY="${REGISTRY}"
 
-echo "Building multi-arch gateway image..."
-tasks/scripts/docker-build-image.sh gateway
+  echo "Building multi-arch gateway image..."
+  tasks/scripts/docker-build-image.sh gateway
 
-echo
-echo "Building multi-arch cluster image..."
-tasks/scripts/docker-build-image.sh cluster
+  echo
+  echo "Building multi-arch cluster image..."
+  tasks/scripts/docker-build-image.sh cluster
 
-TAGS_TO_APPLY=("${EXTRA_TAGS[@]}")
-if [[ "${TAG_LATEST}" == "true" ]]; then
-  TAGS_TO_APPLY+=("latest")
-fi
+  TAGS_TO_APPLY=("${EXTRA_TAGS[@]}")
+  if [[ "${TAG_LATEST}" == "true" ]]; then
+    TAGS_TO_APPLY+=("latest")
+  fi
 
-if [[ ${#TAGS_TO_APPLY[@]} -gt 0 ]]; then
+  if [[ ${#TAGS_TO_APPLY[@]} -gt 0 ]]; then
+    for component in gateway cluster; do
+      full_image="${REGISTRY}/${component}"
+      for tag in "${TAGS_TO_APPLY[@]}"; do
+        [[ "${tag}" == "${IMAGE_TAG}" ]] && continue
+        echo "Tagging ${full_image}:${tag}..."
+        ce_imagetools_create \
+          --prefer-index=false \
+          -t "${full_image}:${tag}" \
+          "${full_image}:${IMAGE_TAG}"
+      done
+    done
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Podman path: build per-platform, assemble manifest lists, push
+# ---------------------------------------------------------------------------
+_publish_multiarch_podman() {
+  export IMAGE_REGISTRY="${REGISTRY}"
+
+  # Split comma-separated platforms into an array.
+  IFS=',' read -ra PLATFORM_LIST <<< "${PLATFORMS}"
+
   for component in gateway cluster; do
-    full_image="${REGISTRY}/${component}"
+    local full_image="${REGISTRY}/${component}"
+    local manifest_name="${full_image}:${IMAGE_TAG}"
+
+    # Remove any pre-existing manifest list.
+    ce manifest rm "${manifest_name}" 2>/dev/null || true
+    ce manifest create "${manifest_name}"
+
+    echo "Building multi-arch ${component} image..."
+    for platform in "${PLATFORM_LIST[@]}"; do
+      echo "  Building ${component} for ${platform}..."
+      # Build for each platform and add to the manifest list.
+      # docker-build-image.sh sources container-engine.sh itself,
+      # so ce_build is used internally.
+      DOCKER_PLATFORM="${platform}" \
+      DOCKER_PUSH="" \
+      IMAGE_TAG="${IMAGE_TAG}" \
+        tasks/scripts/docker-build-image.sh "${component}"
+
+      # Tag with a platform-specific suffix for manifest assembly.
+      local platform_tag="${IMAGE_TAG}-${platform//\//-}"
+      ce tag "openshell/${component}:${IMAGE_TAG}" "${full_image}:${platform_tag}"
+      ce push "${full_image}:${platform_tag}"
+      ce manifest add "${manifest_name}" "${full_image}:${platform_tag}"
+    done
+
+    echo "Pushing manifest ${manifest_name}..."
+    ce manifest push --all "${manifest_name}" "docker://${manifest_name}"
+
+    # Apply extra tags.
+    TAGS_TO_APPLY=("${EXTRA_TAGS[@]}")
+    if [[ "${TAG_LATEST}" == "true" ]]; then
+      TAGS_TO_APPLY+=("latest")
+    fi
+
     for tag in "${TAGS_TO_APPLY[@]}"; do
       [[ "${tag}" == "${IMAGE_TAG}" ]] && continue
       echo "Tagging ${full_image}:${tag}..."
-      docker buildx imagetools create \
-        --prefer-index=false \
-        -t "${full_image}:${tag}" \
-        "${full_image}:${IMAGE_TAG}"
+      ce manifest create "${full_image}:${tag}" 2>/dev/null || ce manifest rm "${full_image}:${tag}" 2>/dev/null
+      # Re-create from the primary manifest.
+      if command -v skopeo >/dev/null 2>&1; then
+        skopeo copy --all "docker://${manifest_name}" "docker://${full_image}:${tag}"
+      else
+        ce manifest create "${full_image}:${tag}"
+        for platform in "${PLATFORM_LIST[@]}"; do
+          local platform_tag="${IMAGE_TAG}-${platform//\//-}"
+          ce manifest add "${full_image}:${tag}" "${full_image}:${platform_tag}"
+        done
+        ce manifest push --all "${full_image}:${tag}" "docker://${full_image}:${tag}"
+      fi
     done
   done
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+if ce_is_docker; then
+  _publish_multiarch_docker
+else
+  _publish_multiarch_podman
 fi
 
 echo

--- a/tasks/scripts/sandbox.sh
+++ b/tasks/scripts/sandbox.sh
@@ -13,6 +13,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/container-engine.sh"
+
 SANDBOX_NAME="dev"
 CLUSTER_NAME=${CLUSTER_NAME:-$(basename "$PWD")}
 CONTAINER_NAME="openshell-cluster-${CLUSTER_NAME}"
@@ -24,7 +27,7 @@ CMD=(${usage_command:-claude})
 # -------------------------------------------------------------------
 # 1. Ensure the cluster is running; redeploy if dirty
 # -------------------------------------------------------------------
-if ! docker ps -q --filter "name=${CONTAINER_NAME}" | grep -q .; then
+if ! ce ps -q --filter "name=${CONTAINER_NAME}" | grep -q .; then
   echo "No running cluster found. Bootstrapping..."
   mise run cluster
 else

--- a/tasks/scripts/vm/build-rootfs-tarball.sh
+++ b/tasks/scripts/vm/build-rootfs-tarball.sh
@@ -21,6 +21,8 @@
 
 set -euo pipefail
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/container-engine.sh"
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 ROOTFS_BUILD_DIR="${ROOT}/target/rootfs-build"
 OUTPUT_DIR="${ROOT}/target/vm-runtime-compressed"
@@ -49,17 +51,10 @@ for arg in "$@"; do
     esac
 done
 
-# Check for Docker
-if ! command -v docker &>/dev/null; then
-    echo "Error: Docker is required to build the rootfs" >&2
-    echo "Please install Docker and try again" >&2
-    exit 1
-fi
-
-# Check if Docker daemon is running
-if ! docker info &>/dev/null; then
-    echo "Error: Docker daemon is not running" >&2
-    echo "Please start Docker and try again" >&2
+# Check if container engine is running
+if ! ce info &>/dev/null; then
+    echo "Error: container engine is not running" >&2
+    echo "Please start your container engine and try again" >&2
     exit 1
 fi
 

--- a/tasks/scripts/vm/sync-vm-rootfs.sh
+++ b/tasks/scripts/vm/sync-vm-rootfs.sh
@@ -11,6 +11,8 @@
 
 set -euo pipefail
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/container-engine.sh"
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SCRIPT_DIR="${ROOT}/crates/openshell-vm/scripts"
 IMAGE_REPO_BASE="${IMAGE_REPO_BASE:-openshell}"
@@ -148,8 +150,8 @@ patch_vm_helmchart "${ROOTFS_DIR}/var/lib/rancher/k3s/server/manifests/openshell
 # be baked into the rootfs last time it was rebuilt.
 SERVER_IMAGE_TAR="${ROOTFS_DIR}/var/lib/rancher/k3s/agent/images/openshell-server.tar.zst"
 SERVER_IMAGE_ID_FILE="${ROOTFS_DIR}/opt/openshell/.gateway-image-id"
-if command -v docker >/dev/null 2>&1 && docker image inspect "${SERVER_IMAGE}" >/dev/null 2>&1; then
-    current_image_id=$(docker image inspect --format '{{.Id}}' "${SERVER_IMAGE}")
+if ce image inspect "${SERVER_IMAGE}" >/dev/null 2>&1; then
+    current_image_id=$(ce image inspect --format '{{.Id}}' "${SERVER_IMAGE}")
     previous_image_id=""
     if [ -f "${SERVER_IMAGE_ID_FILE}" ]; then
         previous_image_id=$(cat "${SERVER_IMAGE_ID_FILE}")
@@ -158,7 +160,7 @@ if command -v docker >/dev/null 2>&1 && docker image inspect "${SERVER_IMAGE}" >
     if [ "${current_image_id}" != "${previous_image_id}" ] || [ ! -f "${SERVER_IMAGE_TAR}" ]; then
         mkdir -p "$(dirname "${SERVER_IMAGE_TAR}")" "$(dirname "${SERVER_IMAGE_ID_FILE}")"
         tmp_tar=$(mktemp /tmp/openshell-server-image.XXXXXX)
-        docker save "${SERVER_IMAGE}" | zstd -f -T0 -3 -o "${tmp_tar}" >/dev/null
+        ce save "${SERVER_IMAGE}" | zstd -f -T0 -3 -o "${tmp_tar}" >/dev/null
         mv "${tmp_tar}" "${SERVER_IMAGE_TAR}"
         printf '%s\n' "${current_image_id}" > "${SERVER_IMAGE_ID_FILE}"
         echo "  updated: /var/lib/rancher/k3s/agent/images/openshell-server.tar.zst"

--- a/tasks/test.toml
+++ b/tasks/test.toml
@@ -48,6 +48,11 @@ depends = ["python:proto", "CLUSTER_GPU=1 cluster"]
 env = { UV_NO_SYNC = "1", PYTHONPATH = "python" }
 run = "uv run pytest -o python_files='test_*.py' -m gpu -n ${E2E_PARALLEL:-1} e2e/python"
 
+["e2e:podman"]
+description = "Start a Podman-backed gateway and run smoke e2e (requires rootless Podman; pass -- --port=N to override)"
+depends = ["build:docker:supervisor-sideload"]
+run = "e2e/rust/e2e-podman.sh"
+
 ["e2e:vm"]
 description = "Start openshell-gateway with the VM compute driver and run the cluster-agnostic smoke e2e"
 run = "e2e/rust/e2e-vm.sh"


### PR DESCRIPTION
## Summary

Adds a Podman compute driver (`openshell-driver-podman`) that runs sandboxes as rootless Podman containers on a local workstation. The driver communicates with the Podman REST API via a gRPC bridge, preserving the full OpenShell control-plane model while supporting Podman-native and rootless environments.

## Related Issue

Closes #882

## Changes

- Add `crates/openshell-driver-podman` crate: Podman REST API client, container lifecycle management, event watcher, gRPC bridge, and driver binary
- Abstract container engine in build tooling (`tasks/scripts/container-engine.sh`) to support both Docker and Podman
- Harden SSRF checks in SSH tunnel and server; close loopback bypass and tighten Host endpoint validation
- Fix rootless sandbox startup: sideload supervisor binary via image volume mount, grant `SETUID`/`SETGID`/`DAC_READ_SEARCH` caps, skip `drop_privileges` in SSH `pre_exec`
- Add E2E test script (`e2e/rust/e2e-podman.sh`) covering full sandbox lifecycle against the Podman driver
- Add architecture doc (`architecture/podman-driver.md`) and update debug skill

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (`e2e/rust/e2e-podman.sh` — full lifecycle: create, connect, exec, delete)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (`architecture/podman-driver.md`)