### PR TITLE
fix(k8s-driver): use dedicated kube client without read_timeout for watches

### DIFF
--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -102,6 +102,7 @@ const WORKSPACE_SENTINEL: &str = ".workspace-initialized";
 #[derive(Clone)]
 pub struct KubernetesComputeDriver {
     client: Client,
+    watch_client: Client,
     config: KubernetesComputeConfig,
 }
 
@@ -117,17 +118,30 @@ impl std::fmt::Debug for KubernetesComputeDriver {
 
 impl KubernetesComputeDriver {
     pub async fn new(config: KubernetesComputeConfig) -> Result<Self, KubeError> {
-        let mut kube_config = match kube::Config::incluster() {
+        let base_config = match kube::Config::incluster() {
             Ok(c) => c,
             Err(_) => kube::Config::infer()
                 .await
                 .map_err(kube::Error::InferConfig)?,
         };
+
+        let mut kube_config = base_config.clone();
         kube_config.connect_timeout = Some(Duration::from_secs(10));
         kube_config.read_timeout = Some(Duration::from_secs(30));
         kube_config.write_timeout = Some(Duration::from_secs(30));
         let client = Client::try_from(kube_config)?;
-        Ok(Self { client, config })
+
+        let mut watch_kube_config = base_config;
+        watch_kube_config.connect_timeout = Some(Duration::from_secs(10));
+        watch_kube_config.read_timeout = None;
+        watch_kube_config.write_timeout = Some(Duration::from_secs(30));
+        let watch_client = Client::try_from(watch_kube_config)?;
+
+        Ok(Self {
+            client,
+            watch_client,
+            config,
+        })
     }
 
     pub async fn capabilities(&self) -> Result<GetCapabilitiesResponse, String> {
@@ -153,6 +167,12 @@ impl KubernetesComputeDriver {
 
     pub const fn ssh_handshake_skew_secs(&self) -> u64 {
         self.config.ssh_handshake_skew_secs
+    }
+
+    fn watch_api(&self) -> Api<DynamicObject> {
+        let gvk = GroupVersionKind::gvk(SANDBOX_GROUP, SANDBOX_VERSION, SANDBOX_KIND);
+        let resource = ApiResource::from_gvk(&gvk);
+        Api::namespaced_with(self.watch_client.clone(), &self.config.namespace, &resource)
     }
 
     fn api(&self) -> Api<DynamicObject> {
@@ -392,8 +412,8 @@ impl KubernetesComputeDriver {
 
     pub async fn watch_sandboxes(&self) -> Result<WatchStream, String> {
         let namespace = self.config.namespace.clone();
-        let sandbox_api = self.api();
-        let event_api: Api<KubeEventObj> = Api::namespaced(self.client.clone(), &namespace);
+        let sandbox_api = self.watch_api();
+        let event_api: Api<KubeEventObj> = Api::namespaced(self.watch_client.clone(), &namespace);
         let mut sandbox_stream = watcher::watcher(sandbox_api, watcher::Config::default()).boxed();
         let mut event_stream = watcher::watcher(event_api, watcher::Config::default()).boxed();
         let (tx, rx) = mpsc::channel(256);


### PR DESCRIPTION
## Summary

The shared Kubernetes client's 30-second `read_timeout` was terminating long-lived watch streams during idle periods, causing a reconnect cycle every 30 seconds. This creates a dedicated `watch_client` with `read_timeout: None` for watch operations while preserving the timeout-protected client for CRUD operations.

Avoids these warnings in the openshell-server log
```
2026-04-21T14:54:28.803303Z  WARN openshell_server::compute: Compute driver watch stream errored error=status: Internal, message: "watch stream failed: Error reading events stream: ServiceError: error reading a body from connection", details: [], metadata: MetadataMap { headers: {} }
```

## Changes

- Add a `watch_client` field to `KubernetesComputeDriver` with `read_timeout: None`
- Add `watch_api()` helper that uses the watch client
- Update `watch_sandboxes` to use the watch client for both sandbox and event watchers
- CRUD operations (create, get, list, delete) continue using the original timeout-protected client

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo check -p openshell-driver-kubernetes` compiles clean
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)