### PR TITLE
fix(cli): report no-op gateway destroy

### DIFF
--- a/crates/openshell-bootstrap/src/docker.rs
+++ b/crates/openshell-bootstrap/src/docker.rs
@@ -1227,6 +1227,55 @@ pub struct ExistingGatewayInfo {
     pub container_image: Option<String>,
 }
 
+fn has_managed_gateway_resources(
+    container_exists: bool,
+    volume_exists: bool,
+    network_exists: bool,
+) -> bool {
+    container_exists || volume_exists || network_exists
+}
+
+/// Check whether any managed gateway resources with the given name exist.
+///
+/// This is broader than `check_existing_gateway()`: destroy also needs to
+/// clean up the per-gateway Docker network, so a lone network still counts as
+/// an existing managed gateway resource set.
+pub async fn check_gateway_resources(docker: &Docker, name: &str) -> Result<bool> {
+    let container_name = container_name(name);
+    let volume_name = volume_name(name);
+    let network_name = network_name(name);
+
+    let volume_exists = match docker.inspect_volume(&volume_name).await {
+        Ok(_) => true,
+        Err(err) if is_not_found(&err) => false,
+        Err(err) => return Err(err).into_diagnostic(),
+    };
+
+    let container_exists = match docker
+        .inspect_container(&container_name, None::<InspectContainerOptions>)
+        .await
+    {
+        Ok(_) => true,
+        Err(err) if is_not_found(&err) => false,
+        Err(err) => return Err(err).into_diagnostic(),
+    };
+
+    let network_exists = match docker
+        .inspect_network(&network_name, None::<InspectNetworkOptions>)
+        .await
+    {
+        Ok(_) => true,
+        Err(err) if is_not_found(&err) => false,
+        Err(err) => return Err(err).into_diagnostic(),
+    };
+
+    Ok(has_managed_gateway_resources(
+        container_exists,
+        volume_exists,
+        network_exists,
+    ))
+}
+
 /// Check whether a gateway with the given name already exists.
 ///
 /// Returns `None` if no gateway resources exist, or `Some(info)` with
@@ -1447,5 +1496,13 @@ mod tests {
             "nvidia.com/gpu=1".to_string(),
         ];
         assert_eq!(resolve_gpu_device_ids(&multi, true), multi);
+    }
+
+    #[test]
+    fn managed_gateway_resources_require_any_resource() {
+        assert!(!has_managed_gateway_resources(false, false, false));
+        assert!(has_managed_gateway_resources(true, false, false));
+        assert!(has_managed_gateway_resources(false, true, false));
+        assert!(has_managed_gateway_resources(false, false, true));
     }
 }

--- a/crates/openshell-bootstrap/src/lib.rs
+++ b/crates/openshell-bootstrap/src/lib.rs
@@ -30,9 +30,9 @@ use crate::constants::{
     SSH_HANDSHAKE_SECRET_NAME, network_name, volume_name,
 };
 use crate::docker::{
-    check_existing_gateway, check_port_conflicts, cleanup_gateway_container,
-    destroy_gateway_resources, ensure_container, ensure_image, ensure_network, ensure_volume,
-    resolve_gpu_device_ids, start_container, stop_container,
+    check_existing_gateway, check_gateway_resources, check_port_conflicts,
+    cleanup_gateway_container, destroy_gateway_resources, ensure_container, ensure_image,
+    ensure_network, ensure_volume, resolve_gpu_device_ids, start_container, stop_container,
 };
 use crate::metadata::{
     create_gateway_metadata, create_gateway_metadata_with_host, local_gateway_host,
@@ -252,6 +252,23 @@ pub async fn check_existing_deployment(
         preflight.docker
     };
     check_existing_gateway(&docker, name).await
+}
+
+/// Check whether any managed gateway resources with the given name exist.
+///
+/// Unlike `check_existing_deployment`, this includes the per-gateway Docker
+/// network so destroy can distinguish a real cleanup from a no-op.
+pub async fn check_existing_gateway_resources(
+    name: &str,
+    remote: Option<&RemoteOptions>,
+) -> Result<bool> {
+    let docker = if let Some(remote_opts) = remote {
+        create_ssh_docker_client(remote_opts).await?
+    } else {
+        let preflight = check_docker_available().await?;
+        preflight.docker
+    };
+    check_gateway_resources(&docker, name).await
 }
 
 pub async fn deploy_gateway(options: DeployOptions) -> Result<GatewayHandle> {

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -1640,6 +1640,14 @@ pub async fn gateway_admin_destroy(
             let remote_opts = gateway_control_target_options(name, remote, ssh_key)?;
 
             eprintln!("• Destroying gateway {name}...");
+            if !openshell_bootstrap::check_existing_gateway_resources(name, remote_opts.as_ref())
+                .await?
+            {
+                cleanup_gateway_metadata(name);
+                eprintln!("• No gateway '{name}' found.");
+                return Ok(());
+            }
+
             let handle = openshell_bootstrap::gateway_handle(name, remote_opts.as_ref()).await?;
             handle.destroy().await?;
 

--- a/docs/sandboxes/manage-gateways.mdx
+++ b/docs/sandboxes/manage-gateways.mdx
@@ -180,6 +180,8 @@ Permanently destroy a gateway and all its state:
 openshell gateway destroy
 ```
 
+If no managed gateway resources exist for that name, OpenShell reports that there is nothing to destroy instead of claiming a successful removal.
+
 For cloud gateways, `gateway destroy` removes only the local registration. It does not affect the remote deployment.
 
 Target a specific gateway with `--name`:


### PR DESCRIPTION
## Summary

Report a no-op result when `openshell gateway destroy` is invoked for a managed gateway name that has no remaining Docker resources.

## Related Issue

Closes #898

## Changes

- added a managed gateway resource check that considers container, volume, and per-gateway network state before destroy output is chosen
- updated `gateway_admin_destroy` to print `No gateway '<name>' found.` for no-op destroys while still cleaning stale local metadata
- documented the new destroy behavior in the gateway management docs
- added a unit test covering the resource-existence helper

## Testing

- [ ] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] `env -u RUSTC_WRAPPER cargo test -p openshell-bootstrap managed_gateway_resources_require_any_resource`
- [x] `env -u RUSTC_WRAPPER cargo check -p openshell-cli --lib`
- `mise run pre-commit` was attempted but failed in this environment because `openshell-prover` test linking could not find `libz3` on macOS (`ld: library 'z3' not found`)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)