### PR TITLE
feat(server): allow disabling health check listener

### DIFF
--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -58,8 +58,10 @@ pub struct Config {
     pub bind_address: SocketAddr,
 
     /// Address to bind the unauthenticated health endpoint to.
-    #[serde(default = "default_health_bind_address")]
-    pub health_bind_address: SocketAddr,
+    ///
+    /// When `None`, the dedicated health listener is disabled.
+    #[serde(default)]
+    pub health_bind_address: Option<SocketAddr>,
 
     /// Log level (trace, debug, info, warn, error).
     #[serde(default = "default_log_level")]
@@ -180,7 +182,7 @@ impl Config {
     pub fn new(tls: Option<TlsConfig>) -> Self {
         Self {
             bind_address: default_bind_address(),
-            health_bind_address: default_health_bind_address(),
+            health_bind_address: None,
             log_level: default_log_level(),
             tls,
             database_url: String::new(),
@@ -210,7 +212,7 @@ impl Config {
 
     #[must_use]
     pub const fn with_health_bind_address(mut self, addr: SocketAddr) -> Self {
-        self.health_bind_address = addr;
+        self.health_bind_address = Some(addr);
         self
     }
 
@@ -327,10 +329,6 @@ fn default_bind_address() -> SocketAddr {
     "0.0.0.0:8080".parse().expect("valid default address")
 }
 
-fn default_health_bind_address() -> SocketAddr {
-    "0.0.0.0:8081".parse().expect("valid default address")
-}
-
 fn default_log_level() -> String {
     "info".to_string()
 }
@@ -370,6 +368,7 @@ const fn default_ssh_session_ttl_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{ComputeDriverKind, Config};
+    use std::net::SocketAddr;
 
     #[test]
     fn compute_driver_kind_parses_supported_values() {
@@ -399,5 +398,18 @@ mod tests {
             Config::new(None).compute_drivers,
             vec![ComputeDriverKind::Kubernetes]
         );
+    }
+
+    #[test]
+    fn config_new_disables_health_bind_by_default() {
+        let cfg = Config::new(None);
+        assert!(cfg.health_bind_address.is_none());
+    }
+
+    #[test]
+    fn config_with_health_bind_address_sets_address() {
+        let addr: SocketAddr = "0.0.0.0:9090".parse().expect("valid address");
+        let cfg = Config::new(None).with_health_bind_address(addr);
+        assert_eq!(cfg.health_bind_address, Some(addr));
     }
 }

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -24,7 +24,8 @@ struct Args {
     port: u16,
 
     /// Port for unauthenticated health endpoints (healthz, readyz).
-    #[arg(long, default_value_t = 8081, env = "OPENSHELL_HEALTH_PORT")]
+    /// Set to 0 to disable the dedicated health listener.
+    #[arg(long, default_value_t = 0, env = "OPENSHELL_HEALTH_PORT")]
     health_port: u16,
 
     /// Log level (trace, debug, info, warn, error).
@@ -201,15 +202,6 @@ async fn run_from_args(args: Args) -> Result<()> {
     );
 
     let bind = SocketAddr::from(([0, 0, 0, 0], args.port));
-    let health_bind = SocketAddr::from(([0, 0, 0, 0], args.health_port));
-
-    if args.port == args.health_port {
-        return Err(miette::miette!(
-            "--port and --health-port must be different (both set to {})",
-            args.port
-        ));
-    }
-
     let tls = if args.disable_tls {
         None
     } else {
@@ -236,8 +228,18 @@ async fn run_from_args(args: Args) -> Result<()> {
 
     let mut config = openshell_core::Config::new(tls)
         .with_bind_address(bind)
-        .with_health_bind_address(health_bind)
         .with_log_level(&args.log_level);
+
+    if args.health_port != 0 {
+        if args.port == args.health_port {
+            return Err(miette::miette!(
+                "--port and --health-port must be different (both set to {})",
+                args.port
+            ));
+        }
+        let health_bind = SocketAddr::from(([0, 0, 0, 0], args.health_port));
+        config = config.with_health_bind_address(health_bind);
+    }
 
     config = config
         .with_database_url(args.db_url)

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -182,21 +182,24 @@ pub async fn run_server(
 
     info!(address = %config.bind_address, "Server listening");
 
-    // Bind the unauthenticated health endpoint on a separate port.
-    let health_listener = TcpListener::bind(config.health_bind_address)
-        .await
-        .map_err(|e| {
+    // Bind the unauthenticated health endpoint on a separate port when configured.
+    if let Some(health_bind_address) = config.health_bind_address {
+        let health_listener = TcpListener::bind(health_bind_address).await.map_err(|e| {
             Error::transport(format!(
                 "failed to bind health port {}: {e}",
-                config.health_bind_address
+                health_bind_address
             ))
         })?;
-    info!(address = %config.health_bind_address, "Health server listening");
-    tokio::spawn(async move {
-        if let Err(e) = axum::serve(health_listener, health_router().into_make_service()).await {
-            error!("Health server error: {e}");
-        }
-    });
+        info!(address = %health_bind_address, "Health server listening");
+        tokio::spawn(async move {
+            if let Err(e) = axum::serve(health_listener, health_router().into_make_service()).await
+            {
+                error!("Health server error: {e}");
+            }
+        });
+    } else {
+        info!("Health server disabled");
+    }
 
     // Build TLS acceptor when TLS is configured; otherwise serve plaintext.
     let tls_acceptor = if let Some(tls) = &config.tls {


### PR DESCRIPTION
## Summary

Allow the dedicated health endpoint listener to be disabled by setting `--health-port 0` (or `OPENSHELL_HEALTH_PORT=0`). Previously, the health port defaulted to `8081` and could not be turned off. This is useful for deployments that don't need a separate unauthenticated health port, or don't need to enable health checks.

## Related Issue

<!-- No issue tracked -->

## Changes

- `Config.health_bind_address` changed from `SocketAddr` to `Option<SocketAddr>`; `None` means disabled
- Removed `default_health_bind_address()` — default is now `None` (disabled)
- CLI `--health-port` defaults to `0`; any non-zero value enables the listener (port collision check still applies)
- Server skips binding the health listener when `health_bind_address` is `None`, logs `"Health server disabled"`
- Added unit tests for the new `Config` default and the `with_health_bind_address` builder

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)