### PR TITLE
fix(sandbox): emit tracing on stderr to avoid corrupting SSH-exec stdout

### DIFF
--- a/crates/openshell-sandbox/src/main.rs
+++ b/crates/openshell-sandbox/src/main.rs
@@ -101,7 +101,7 @@ struct Args {
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    // Try to open a rolling log file; fall back to stdout-only logging if it fails
+    // Try to open a rolling log file; fall back to stderr-only logging if it fails
     // (e.g., /var/log is not writable in custom workload images).
     // Rotates daily, keeps the 3 most recent files to bound disk usage.
     let file_logging = tracing_appender::rolling::RollingFileAppender::builder()
@@ -176,7 +176,16 @@ fn main() -> Result<()> {
 
             tracing_subscriber::registry()
                 .with(
-                    OcsfShorthandLayer::new(std::io::stdout())
+                    // Tracing must target stderr, not stdout. The pre_exec hook
+                    // that applies Landlock inherits this subscriber and runs
+                    // in the SSH-exec child process after fd 1 has been remapped
+                    // to the SSH channel's stdout pipe. Any WARN emitted during
+                    // pre_exec (e.g. the "Landlock unavailable" DetectionFinding
+                    // on hosts whose kernel lacks Landlock, such as Darwin's
+                    // Docker Linux VM) otherwise interleaves with the command's
+                    // stdout — which corrupts the tar archive produced by
+                    // `openshell sandbox download`.
+                    OcsfShorthandLayer::new(std::io::stderr())
                         .with_non_ocsf(true)
                         .with_filter(stdout_filter),
                 )
@@ -192,14 +201,16 @@ fn main() -> Result<()> {
         } else {
             tracing_subscriber::registry()
                 .with(
-                    OcsfShorthandLayer::new(std::io::stdout())
+                    // See comment above: stderr prevents pre_exec tracing from
+                    // polluting the SSH exec channel's stdout.
+                    OcsfShorthandLayer::new(std::io::stderr())
                         .with_non_ocsf(true)
                         .with_filter(stdout_filter),
                 )
                 .with(push_layer)
                 .init();
             // Log the warning after the subscriber is initialized
-            warn!("Could not open /var/log for log rotation; using stdout-only logging");
+            warn!("Could not open /var/log for log rotation; using stderr-only logging");
             (None, None)
         };
 


### PR DESCRIPTION
## Summary

`openshell sandbox download` is currently unreliable on any host whose kernel lacks Landlock support — notably Darwin running Docker Desktop / OrbStack, and stripped Linux kernels. The tar archive returned by `download` is intermittently corrupted, producing errors like:

```
numeric field did not have utf-8 text: ILABLE �
```

The `ILABLE` bytes are the `ava**ILABLE**` fragment of a `WARN openshell_sandbox::sandbox::linux::landlock: Landlock filesystem sandbox is UNAVAILABLE…` message leaking into the tar byte stream.

## Root cause

In `crates/openshell-sandbox/src/main.rs`, the `OcsfShorthandLayer` tracing subscriber is configured to write to `std::io::stdout()` (both in the file-logging path and the fallback path when `/var/log` isn't writable).

The `pre_exec` hook that applies Landlock inherits this subscriber and runs in the SSH-exec **child** process after SSH has remapped `fd 1` to the channel's stdout pipe. On kernels without Landlock, `landlock::apply` enters its best-effort fallback and emits a WARN-level `DetectionFinding`. That WARN text interleaves with the command's stdout — which corrupts any binary stream flowing through it, including `tar czf -` used internally by `openshell sandbox download`.

Linux CI hosts expose Landlock, so `landlock::apply` succeeds silently, no WARN is emitted, no stdout pollution occurs, and the bug doesn't reproduce there. It only manifests on Landlock-less kernels — which is every Darwin developer machine running Docker Desktop.

## Fix

Redirect both `OcsfShorthandLayer` instances to `std::io::stderr()`. Tracing now flows to SSH's separate stderr channel and the exec stdout stream stays clean. No behavior change for cases where tracing already worked correctly.

Also updates the fallback log message (`using stdout-only logging` → `using stderr-only logging`) and the nearby code comment to match.

## Evidence

From a failing `openshell sandbox download` run on Darwin (captured by a downstream consumer):

```json
{"stream": "stdout", "line": "...WARN openshell_sandbox::sandbox::linux::landlock: Landlock filesystem sandbox is UNAVAILABLE..."}
{"stream": "warning", "line": "Failed to download output '/sandbox/artifacts' (rc=1): ... numeric field did not have utf-8 text: ILABLE � when getting cksum for 2026-... WARN openshell_sandbox::sandbox::linux::landlock..."}
```

The tar checksum error and the WARN fragment appear on the same line because the WARN was physically spliced into the tar byte stream.

After the fix: tar archive is clean, `download` succeeds, `outputs/` artifacts sync correctly end-to-end on Darwin.

## Validation

- [x] `cargo check -p openshell-sandbox` — clean
- [x] `cargo clippy -p openshell-sandbox` — no new warnings
- [x] Downstream Darwin validation — patched binary applied via `docker cp` to a running cluster container, `openshell sandbox download` tar archives now arrive intact, binary artifacts (PDF) extract correctly
