### PR TITLE
chore(mise): replace deprecated ubi: prefix by github: prefix

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -20,9 +20,9 @@ kubectl = "1.35.1"
 uv = "0.10.2"
 protoc = "29.6"
 helm = "4.1.4"
-"ubi:mozilla/sccache" = { version = "0.14.0", matching = "sccache-v" }
-"ubi:anchore/syft" = { version = "1.42.3", matching = "syft_" }
-"ubi:EmbarkStudios/cargo-about" = "0.8.4"
+"github:mozilla/sccache" = { version = "0.14.0" }
+"github:anchore/syft" = { version = "1.42.3" }
+"github:EmbarkStudios/cargo-about" = { version = "0.8.4", version_prefix = "" }
 zig = "0.14.1"
 
 [env]

--- a/mise.toml
+++ b/mise.toml
@@ -20,7 +20,7 @@ kubectl = "1.35.1"
 uv = "0.10.2"
 protoc = "29.6"
 helm = "4.1.4"
-"github:mozilla/sccache" = { version = "0.14.0" }
+"ubi:mozilla/sccache" = { version = "0.14.0", matching = "sccache-v" }
 "github:anchore/syft" = { version = "1.42.3" }
 "github:EmbarkStudios/cargo-about" = { version = "0.8.4", version_prefix = "" }
 zig = "0.14.1"


### PR DESCRIPTION
## Summary
Replace deprecated `ubi:` prefix by `github:` prefix [^1]

[^1]: https://mise.jdx.dev/dev-tools/backends/ubi.html

When executing the command `mise run vm:setup` I have an error message
```
mise ERROR Failed to install ubi:EmbarkStudios/cargo-about@0.8.4: HTTP request to https://api.github.com/repos/EmbarkStudios/cargo-about/releases/tags/v0.8.4 returned an error status
```
`ubi:` is assuming the tag has a v prefix but here the tag has not the prefix https://github.com/EmbarkStudios/cargo-about/releases/tag/0.8.4

I'm using `mise 2026.4.18 macos-arm64 (2026-04-19)`

## Related Issue
N/A <!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
- mise reports that ubi is deprecated and that github backend should be use instead
- using github: prefix allows to give the hint that the tag has not the 'v' prefix for EmbarkStudios/cargo-about

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
