### PR TITLE
fix(ci): E2E gate must verify work actually ran, not just top-level success

### DIFF
--- a/.github/workflows/e2e-gate-check.yml
+++ b/.github/workflows/e2e-gate-check.yml
@@ -84,18 +84,30 @@ jobs:
             exit 1
           fi
 
+          run_id=$(jq -r '.id' <<< "$latest")
           status=$(jq -r '.status' <<< "$latest")
           conclusion=$(jq -r '.conclusion' <<< "$latest")
-
-          if [ "$conclusion" = "success" ]; then
-            echo "$WORKFLOW_FILE succeeded for $HEAD_SHA."
-            exit 0
-          fi
 
           if [ "$status" != "completed" ]; then
             echo "::error::$WORKFLOW_FILE is $status for $HEAD_SHA. This gate will re-evaluate on completion."
             exit 1
           fi
 
-          echo "::error::$WORKFLOW_FILE concluded as $conclusion for $HEAD_SHA."
-          exit 1
+          if [ "$conclusion" != "success" ]; then
+            echo "::error::$WORKFLOW_FILE concluded as $conclusion for $HEAD_SHA."
+            exit 1
+          fi
+
+          # Top-level success isn't enough: if `pr_metadata` gated downstream
+          # jobs out (label wasn't set at run time), only the gate job itself
+          # concludes `success` and the workflow still reports `success`.
+          # Require at least one non-gate job to have succeeded as proof the
+          # label was present when the workflow ran.
+          real_success=$(gh api "repos/$GH_REPO/actions/runs/$run_id/jobs" --jq '[.jobs[] | select(.conclusion == "success" and .name != "Resolve PR metadata")] | length')
+          if [ "$real_success" -lt 1 ]; then
+            echo "::error::$WORKFLOW_FILE run $run_id only ran the metadata gate — $REQUIRED_LABEL was not set when the workflow last executed. Re-run $WORKFLOW_FILE so the gate re-evaluates with the label present."
+            exit 1
+          fi
+
+          echo "$WORKFLOW_FILE run $run_id executed and succeeded for $HEAD_SHA ($real_success non-gate job(s) passed)."
+          exit 0


### PR DESCRIPTION
## Summary

Closes gap in `E2E Gate` discovered while testing #922 in PR #924: labeling a PR **after** `Branch E2E Checks` already ran (with the label absent) kept the gate green, because the gate only checked the workflow's top-level `conclusion`.

When `pr_metadata` returns `should_run=false`, every downstream job (`build-gateway`, `build-cluster`, the E2E matrix) is `skipped` — so the workflow top-level concludes `success` even though nothing was actually tested. The gate was treating that as a pass.

## Change

In `.github/workflows/e2e-gate-check.yml`, after verifying top-level success, also query the run's jobs and require at least one job **other than** `Resolve PR metadata` to have concluded `success`. If only the gate job succeeded, the gate fails with an actionable message.

Using "at least one non-gate success" instead of "zero skipped jobs" so legitimate conditional skips in future jobs don't break the gate.

## Testing

- [x] Manually confirmed via `gh api .../actions/runs/<id>/jobs` against the existing no-label run on PR #924 that the job list shows `Resolve PR metadata=success` and the three downstream jobs as `skipped` — the new check correctly counts `real_success=0` and would fail.
- [ ] Merging this will re-fire `E2E Gate` on #924 via the `workflow_run` trigger; expected flip from green → red because `test:e2e` is labeled there but the underlying `Branch E2E Checks` run only executed the gate.

## Checklist

- [x] Conventional Commits
- [x] DCO sign-off