### PR TITLE
fix(ci): bump ci-image tooling versions to clear vendored CVEs

### DIFF
--- a/deploy/docker/Dockerfile.ci
+++ b/deploy/docker/Dockerfile.ci
@@ -8,8 +8,8 @@
 
 FROM nvcr.io/nvidia/base/ubuntu:noble-20251013
 
-ARG DOCKER_VERSION=29.3.1
-ARG BUILDX_VERSION=v0.32.1
+ARG DOCKER_VERSION=29.4.1
+ARG BUILDX_VERSION=v0.33.0
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -55,7 +55,7 @@ RUN case "$TARGETARCH" in \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
 
 # Install GitHub CLI used by install.sh and CI jobs
-ARG GH_VERSION=2.74.1
+ARG GH_VERSION=2.91.0
 RUN case "$TARGETARCH" in \
       amd64) gh_arch=amd64 ;; \
       arm64) gh_arch=arm64 ;; \
@@ -65,7 +65,7 @@ RUN case "$TARGETARCH" in \
     | tar xz --strip-components=2 -C /usr/local/bin "gh_${GH_VERSION}_linux_${gh_arch}/bin/gh"
 
 # Install mise
-ARG MISE_VERSION=v2026.3.13
+ARG MISE_VERSION=v2026.4.18
 RUN curl https://mise.run | MISE_VERSION=$MISE_VERSION sh
 
 # Copy mise.toml and task includes, then install all tools via mise


### PR DESCRIPTION
## Summary
Bumps Docker CLI, buildx, gh, and mise pins in `Dockerfile.ci` to clear High-severity container findings in `ghcr.io/nvidia/openshell/ci`. Source: nSpect Security Tracker (NSPECT-4VVR-UWWE).

## Related Issue
No tracking issue — direct remediation from the nSpect tracker; security vulns are not filed as GitHub issues per `SECURITY.md`.

## Changes
- `DOCKER_VERSION`  29.3.1 → 29.4.1
- `BUILDX_VERSION`  v0.32.1 → v0.33.0 (bundles buildkit v0.29.0, above the 0.28.1 fix target)
- `GH_VERSION`      2.74.1 → 2.91.0
- `MISE_VERSION`    v2026.3.13 → v2026.4.18

Findings addressed (vendored Go modules inside these binaries):

| CVE / GHSA | Package | From → fix |
|---|---|---|
| GHSA-p77j-4mvh-x3m3 | google.golang.org/grpc | v1.78.0 → 1.79.3 |
| GHSA-4c29-8rgm-jvjj | github.com/moby/buildkit | v0.28.0 → 0.28.1 (we ship 0.29.0) |
| GHSA-4vrq-3vrq-g6gg | github.com/moby/buildkit | v0.28.0 → 0.28.1 (we ship 0.29.0) |
| GHSA-9h8m-3fm2-qjrq | go.opentelemetry.io/otel/sdk | v1.38.0 → 1.40.0 |
| GHSA-92mm-2pjq-r785 | github.com/hashicorp/go-getter | v1.8.5 → 1.8.6 |
| GHSA-78h2-9frx-2jm8 | github.com/go-jose/go-jose/v4 | v4.1.3 → 4.1.4 |
| GHSA-4qg8-fj49-pxjh | github.com/sigstore/timestamp-authority | v1.2.7 → 2.0.3 |
| GHSA-x744-4wpc-v9h2 | github.com/docker/docker | v28.5.2 → — (via docker 29.4.1) |

Final vendored versions will be verified post-merge via nSpect OSS scan.

## Testing
- [ ] CI image rebuild (workflow triggered by changes to `Dockerfile.ci`)
- [ ] E2E on rebuilt image
- [ ] nSpect re-scan to confirm findings cleared

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — N/A (tool version pins)