### PR TITLE
fix(driver-vm): preflight supervisor cross-compile toolchain in start.sh

### DIFF
--- a/crates/openshell-driver-vm/README.md
+++ b/crates/openshell-driver-vm/README.md
@@ -157,6 +157,9 @@ The VM guest's serial console is appended to `<state-dir>/<sandbox-id>/console.l
 
 - macOS on Apple Silicon, or Linux on aarch64/x86_64 with KVM
 - Rust toolchain
+- Guest-supervisor cross-compile toolchain (needed on macOS, and on Linux when host arch ≠ guest arch):
+  - Matching rustup target: `rustup target add aarch64-unknown-linux-gnu` (or `x86_64-unknown-linux-gnu` for an amd64 guest)
+  - `cargo install --locked cargo-zigbuild` and `brew install zig` (or distro equivalent). `build-rootfs.sh` uses `cargo zigbuild` to cross-compile the in-VM `openshell-sandbox` supervisor binary.
 - [mise](https://mise.jdx.dev/) task runner
 - Docker (needed by `mise run vm:rootfs` to build the base rootfs)
 - `gh` CLI (used by `mise run vm:setup` to download pre-built runtime artifacts)

--- a/crates/openshell-driver-vm/start.sh
+++ b/crates/openshell-driver-vm/start.sh
@@ -41,7 +41,40 @@ normalize_bool() {
     esac
 }
 
+check_supervisor_cross_toolchain() {
+    # The sandbox supervisor inside the guest is always Linux. On non-Linux
+    # hosts (macOS) and on Linux hosts with a different arch than the guest,
+    # we cross-compile via cargo-zigbuild and need the matching rustup target.
+    local host_os host_arch guest_arch rust_target
+    host_os="$(uname -s)"
+    host_arch="$(uname -m)"
+    guest_arch="${GUEST_ARCH:-${host_arch}}"
+    case "${guest_arch}" in
+        arm64|aarch64) rust_target="aarch64-unknown-linux-gnu" ;;
+        x86_64|amd64)  rust_target="x86_64-unknown-linux-gnu" ;;
+        *) return 0 ;;
+    esac
+    if [ "${host_os}" = "Linux" ] && [ "${host_arch}" = "${guest_arch}" ]; then
+        return 0
+    fi
+    local missing=0
+    if ! command -v cargo-zigbuild >/dev/null 2>&1; then
+        echo "ERROR: cargo-zigbuild not found (required to cross-compile the guest supervisor)." >&2
+        echo "       Install: cargo install --locked cargo-zigbuild && brew install zig" >&2
+        missing=1
+    fi
+    if ! rustup target list --installed 2>/dev/null | grep -qx "${rust_target}"; then
+        echo "ERROR: Rust target '${rust_target}' not installed." >&2
+        echo "       Install: rustup target add ${rust_target}" >&2
+        missing=1
+    fi
+    if [ "${missing}" -ne 0 ]; then
+        exit 1
+    fi
+}
+
 if [ ! -f "${COMPRESSED_DIR}/rootfs.tar.zst" ]; then
+    check_supervisor_cross_toolchain
     echo "==> Building base VM rootfs tarball"
     mise run vm:rootfs -- --base
 fi

--- a/crates/openshell-vm/README.md
+++ b/crates/openshell-vm/README.md
@@ -18,6 +18,9 @@ mise run vm
 
 - **macOS (Apple Silicon)** or **Linux (aarch64 or x86_64 with KVM)**
 - Rust toolchain
+- Guest-supervisor cross-compile toolchain (needed on macOS, and on Linux when host arch ≠ guest arch):
+  - Matching rustup target: `rustup target add aarch64-unknown-linux-gnu` (or `x86_64-unknown-linux-gnu` for an amd64 guest)
+  - `cargo install --locked cargo-zigbuild` and `brew install zig` (or distro equivalent). `build-rootfs.sh` uses `cargo zigbuild` to cross-compile the in-VM `openshell-sandbox` supervisor binary.
 - [mise](https://mise.jdx.dev/) task runner
 - Docker (for rootfs builds)
 - `gh` CLI (for downloading pre-built runtime)

--- a/crates/openshell-vm/scripts/build-rootfs.sh
+++ b/crates/openshell-vm/scripts/build-rootfs.sh
@@ -365,16 +365,29 @@ SUPERVISOR_TARGET="${RUST_TARGET}"
 SUPERVISOR_BIN="${PROJECT_ROOT}/target/${SUPERVISOR_TARGET}/release/openshell-sandbox"
 
 echo "==> Building openshell-sandbox supervisor binary (${SUPERVISOR_TARGET})..."
-if command -v cargo-zigbuild >/dev/null 2>&1; then
-    cargo zigbuild --release -p openshell-sandbox --target "${SUPERVISOR_TARGET}" \
-        --manifest-path "${PROJECT_ROOT}/Cargo.toml" 2>&1 | tail -5
+SUPERVISOR_BUILD_LOG="$(mktemp -t openshell-supervisor-build.XXXXXX.log)"
+run_supervisor_build() {
+    if command -v cargo-zigbuild >/dev/null 2>&1; then
+        cargo zigbuild --release -p openshell-sandbox --target "${SUPERVISOR_TARGET}" \
+            --manifest-path "${PROJECT_ROOT}/Cargo.toml"
+    else
+        # Fallback: use plain cargo build when cargo-zigbuild is not available.
+        # This works for native builds (e.g. building x86_64 on x86_64) but
+        # will fail for true cross-compilation without a cross toolchain.
+        echo "    cargo-zigbuild not found, falling back to cargo build..."
+        cargo build --release -p openshell-sandbox --target "${SUPERVISOR_TARGET}" \
+            --manifest-path "${PROJECT_ROOT}/Cargo.toml"
+    fi
+}
+if run_supervisor_build >"${SUPERVISOR_BUILD_LOG}" 2>&1; then
+    tail -5 "${SUPERVISOR_BUILD_LOG}"
+    rm -f "${SUPERVISOR_BUILD_LOG}"
 else
-    # Fallback: use plain cargo build when cargo-zigbuild is not available.
-    # This works for native builds (e.g. building x86_64 on x86_64) but
-    # will fail for true cross-compilation without a cross toolchain.
-    echo "    cargo-zigbuild not found, falling back to cargo build..."
-    cargo build --release -p openshell-sandbox --target "${SUPERVISOR_TARGET}" \
-        --manifest-path "${PROJECT_ROOT}/Cargo.toml" 2>&1 | tail -5
+    status=$?
+    echo "ERROR: supervisor build failed. Full output:" >&2
+    cat "${SUPERVISOR_BUILD_LOG}" >&2
+    echo "    (log saved at ${SUPERVISOR_BUILD_LOG})" >&2
+    exit "${status}"
 fi
 
 if [ ! -f "${SUPERVISOR_BIN}" ]; then


### PR DESCRIPTION
## Summary

- `crates/openshell-driver-vm/start.sh` cross-compiles the in-guest `openshell-sandbox` supervisor via `cargo-zigbuild`. When either the matching `<arch>-unknown-linux-gnu` rustup target or `cargo-zigbuild` itself was missing, the visible failure was a wall of "could not compile libc/zeroize/..." summaries with no hint about the root cause — `build-rootfs.sh` was piping the real cargo output through `tail -5`, truncating the rustup-suggested fix.
- Add a preflight check in `start.sh` that verifies the cross-compile toolchain before the expensive docker + rootfs build kicks off, and prints exact install commands when something is missing. Check is scoped to cases where cross-compilation is actually needed (macOS host, or Linux host where host arch ≠ guest arch).
- Change `build-rootfs.sh` to tee cargo/zigbuild output to a tempfile: tail on success to keep logs tidy, dump the whole log to stderr on failure so the real error surfaces.
- Update `openshell-driver-vm` and `openshell-vm` README Prerequisites to call out `rustup target add <arch>-unknown-linux-gnu` and `cargo install --locked cargo-zigbuild` + `zig`.

## Related Issue

N/A — developer-experience fix surfaced while debugging `start.sh` locally.

## Changes

- `crates/openshell-driver-vm/start.sh` — new `check_supervisor_cross_toolchain()` function, invoked before `mise run vm:rootfs`.
- `crates/openshell-vm/scripts/build-rootfs.sh` — capture full cargo output to a log; tail-on-success, cat-on-failure.
- `crates/openshell-driver-vm/README.md`, `crates/openshell-vm/README.md` — document the cross-compile toolchain in Prerequisites.

## Testing

- [x] `bash -n` parses cleanly under both macOS `/bin/bash` (3.2) and Homebrew `bash` (5.x).
- [x] Removed `aarch64-unknown-linux-gnu` via `rustup target remove`, re-ran `start.sh`; preflight fires with actionable error and non-zero exit before any docker activity.
- [x] With the target re-installed, full flow continues past the check unchanged.
- [ ] Not exercised: `x86_64-unknown-linux-gnu` path (no amd64 Mac available). Same code path, just the target string differs.

## Checklist

- [x] Conventional commit format (`fix(driver-vm): ...`)
- [x] No secrets / credentials committed
- [x] Changes scoped to the issue (no unrelated edits bundled in)
- [x] Docs updated alongside the behavior change