### PR TITLE
feat(ci): add shadow-shared-cpu-spike workflow for OS-49 Phase 2

### DIFF
--- a/.github/workflows/shadow-shared-cpu-spike.yml
+++ b/.github/workflows/shadow-shared-cpu-spike.yml
@@ -1,0 +1,57 @@
+name: Shadow — Shared CPU Spike
+
+# OS-49 Phase 2 / PR 1 — non-blocking spike. Runs `cargo check` on the
+# nv-gha-runners shared CPU pool (`linux-{amd64,arm64}-cpu8`) with a
+# GHA-backed sccache.
+#
+# Plan, decision thresholds, and results live in the Linear doc attached
+# to OS-126 ("OS-126 — Shared CPU spike plan & results"). Dispatch this
+# workflow 4–5 times after merge and record numbers there.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Wire sccache (already RUSTC_WRAPPER in mise.toml) to the GHA cache
+  # backend instead of the EKS memcached used by ARC.
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  rust-check:
+    name: cargo check (${{ matrix.runner }})
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [linux-amd64-cpu8, linux-arm64-cpu8]
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ghcr.io/nvidia/openshell/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: mise install
+
+      - name: Cache Rust target and registry
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: shadow-shared-cpu-spike-${{ matrix.runner }}
+          cache-directories: .cache/sccache
+
+      - name: cargo check
+        run: mise x -- cargo check --workspace --all-targets
+
+      - name: sccache stats
+        if: always()
+        run: mise x -- sccache --show-stats


### PR DESCRIPTION
## Summary

Add `shadow-shared-cpu-spike.yml` — a `workflow_dispatch` spike that runs `cargo check` on the `nv-gha-runners` shared CPU pool (`linux-{amd64,arm64}-cpu8`) with a GHA-backed sccache. Non-blocking; feeds three Phase 2 decisions once dispatched:

| Data point | Decision it drives | Threshold |
|---|---|---|
| Spike wall vs. ARC `branch-checks` wall p50 (4.0m, OS-125) | Phase 5/6 cut-over go/no-go | ≲1.2× |
| Warm-vs-cold delta + sccache hit rate | GHA sccache vs. EKS memcached (Phase 8) | hit rate ≳60% |
| Spike queue time | Runner-size selection (cpu8 vs. cpu16) | vs. ARC queue p95 15.4m |

Full method, thresholds, and results capture live in the Linear doc on OS-126.

## Related Issue

OS-49 runner migration, Phase 2 / OS-126. Plan doc: *OS-126 — Shared CPU spike plan & results* (attached to OS-126).

## Changes

- `.github/workflows/shadow-shared-cpu-spike.yml`: matrix over `linux-amd64-cpu8` / `linux-arm64-cpu8`, container `ghcr.io/nvidia/openshell/ci:latest` (same as `branch-checks.yml`), `mise install` + `Swatinem/rust-cache` + `mise x -- cargo check --workspace --all-targets`, `SCCACHE_GHA_ENABLED=true` to wire mise's existing `RUSTC_WRAPPER=sccache` to the GHA cache backend. Trigger: `workflow_dispatch` only.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated — N/A; new workflow, no Rust/Python changes
- [ ] E2E tests added/updated — N/A; spike is non-blocking and dispatch-only
- [ ] Dispatch validation — will run after merge, record into OS-126 Linear doc

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — N/A; plan lives in Linear OS-126