### PR TITLE
fix(skills): remove --assignee @me from gh pr/issue create commands

### DIFF
--- a/.agents/skills/build-from-issue/SKILL.md
+++ b/.agents/skills/build-from-issue/SKILL.md
@@ -478,7 +478,6 @@ Create the PR:
 ```bash
 gh pr create \
   --title "<type>(<scope>): <short description>" \
-  --assignee "@me" \
   --body "$(cat <<'EOF'
 > **🏗️ build-from-issue-agent**
 

--- a/.agents/skills/create-github-issue/SKILL.md
+++ b/.agents/skills/create-github-issue/SKILL.md
@@ -114,7 +114,6 @@ GitHub built-in issue types (`Bug`, `Feature`, `Task`) should come from the matc
 | `--title, -t`       | Issue title (required)             |
 | `--body, -b`        | Issue description                  |
 | `--label, -l`       | Add label (can use multiple times) |
-| `--assignee, -a`    | Assign to user                     |
 | `--milestone, -m`   | Add to milestone                   |
 | `--project, -p`     | Add to project                     |
 | `--web`             | Open in browser after creation     |

--- a/.agents/skills/create-github-pr/SKILL.md
+++ b/.agents/skills/create-github-pr/SKILL.md
@@ -99,22 +99,6 @@ gh pr create --title "PR title" --body "PR description"
 - `refactor(models): simplify deployment logic`
 - `chore(ci): update Python version in pipeline`
 
-## Required PR Fields
-
-Every PR **must** have:
-
-1. **Assignee** - Always assign to yourself
-
-## Assignee and Reviewer
-
-### Always Assign to Yourself
-
-**Every PR must be assigned to the user creating it.** Use the `--assignee` flag:
-
-```bash
-gh pr create --title "Title" --assignee "@me"
-```
-
 ### Link to an Issue
 
 Use `Closes #<issue-number>` in the body to auto-close the issue when merged:
@@ -122,7 +106,6 @@ Use `Closes #<issue-number>` in the body to auto-close the issue when merged:
 ```bash
 gh pr create \
   --title "Fix validation error for empty requests" \
-  --assignee "@me" \
   --body "Closes #123
 
 ## Summary
@@ -135,7 +118,7 @@ gh pr create \
 For work-in-progress that's not ready for review:
 
 ```bash
-gh pr create --draft --title "WIP: New feature" --assignee "@me"
+gh pr create --draft --title "WIP: New feature"
 ```
 
 ### With Labels
@@ -185,7 +168,6 @@ Populate the testing checklist based on what was actually run. Check boxes for s
 ```bash
 gh pr create \
   --title "feat(cli): add pagination to sandbox list" \
-  --assignee "@me" \
   --body "$(cat <<'EOF'
 ## Summary
 
@@ -222,7 +204,6 @@ EOF
 | ------------------- | ------------------------------------------ |
 | `--title, -t`       | PR title (use conventional commit format)  |
 | `--body, -b`        | PR description                             |
-| `--assignee, -a`    | Assign to user (use `@me` for yourself)    |
 | `--reviewer, -r`    | Request review from user                   |
 | `--draft`           | Create as draft (WIP)                      |
 | `--label, -l`       | Add label (can use multiple times)         |

--- a/.agents/skills/fix-security-issue/SKILL.md
+++ b/.agents/skills/fix-security-issue/SKILL.md
@@ -207,7 +207,6 @@ Create a PR that closes the security issue. Put the full fix summary in the PR d
 ```bash
 gh pr create \
   --title "fix(security): <short description>" \
-  --assignee "@me" \
   --label "topic:security" \
   --body "$(cat <<'EOF'
 > **🔧 security-fix-agent**


### PR DESCRIPTION
## Summary

Remove `--assignee @me` from agent skill templates.

Most contributors cannot assign PRs or issues to themselves due to repository settings. Remove the --assignee flag from skill templates to prevent gh CLI errors.

## Changes

- Removed `--assignee "@me"` from `build-from-issue` PR creation template
- Removed assignee documentation from `create-github-issue` options table
- Removed "Required PR Fields" and "Assignee and Reviewer" sections from `create-github-pr`
- Removed `--assignee` from all `gh pr create` examples in `create-github-pr`
- Removed `--assignee "@me"` from `fix-security-issue` PR creation template

## Testing

- [x] `mise run pre-commit` not required (documentation-only change)
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)