### PR TITLE
feat(ci): add driver input to setup-buildx action

### DIFF
--- a/.github/actions/setup-buildx/action.yml
+++ b/.github/actions/setup-buildx/action.yml
@@ -1,15 +1,22 @@
 name: Setup Docker Buildx
 description: >
-  Create a multi-arch Docker Buildx builder using remote BuildKit nodes.
-  The builder is automatically removed when the job finishes (cleanup is
-  enabled by default in docker/setup-buildx-action).
+  Create a Docker Buildx builder. Two modes:
+    * driver=remote (default) — multi-arch builder against in-cluster BuildKit
+      pods. Requires EKS connectivity. Behaviour unchanged from prior versions.
+    * driver=local — single-node buildx on the local docker-container driver.
+      Pair with cache-to/cache-from=type=gha on build steps for persistence.
+      Works on nv-gha-runners; no EKS needed.
+  Cleanup is automatic when the job finishes (docker/setup-buildx-action default).
 
 inputs:
+  driver:
+    description: "buildx driver: 'remote' or 'local'"
+    default: remote
   amd64-endpoint:
-    description: BuildKit endpoint for linux/amd64
+    description: BuildKit endpoint for linux/amd64 (remote driver only)
     default: tcp://buildkit-amd64.buildkit:1234
   arm64-endpoint:
-    description: BuildKit endpoint for linux/arm64
+    description: BuildKit endpoint for linux/arm64 (remote driver only)
     default: tcp://buildkit-arm64.buildkit:1234
   name:
     description: Builder instance name
@@ -18,7 +25,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up Docker Buildx
+    - name: Set up Docker Buildx (remote)
+      if: inputs.driver == 'remote'
       uses: docker/setup-buildx-action@v3
       with:
         name: ${{ inputs.name }}
@@ -28,3 +36,11 @@ runs:
         append: |
           - endpoint: ${{ inputs.arm64-endpoint }}
             platforms: linux/arm64
+
+    - name: Set up Docker Buildx (local)
+      if: inputs.driver == 'local'
+      uses: docker/setup-buildx-action@v3
+      with:
+        name: ${{ inputs.name }}
+        driver: docker-container
+        platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

Add a `driver` input to `.github/actions/setup-buildx/action.yml`. Default stays `remote`, preserving current behavior for all 7 call sites. New `local` option selects the `docker-container` driver for callers that need buildx on nv-gha-runners (no EKS BuildKit). Pure-additive prep for the OS-127 Phase 3 shadow workflow.

## Related Issue

OS-49 runner migration, Phase 3 / OS-127. This is **PR 2 (prep)**. **PR 3** (shadow workflow using `driver: local` + GHA cache) follows once this lands.

## Changes

- `.github/actions/setup-buildx/action.yml`:
  - New `driver` input with `default: remote`.
  - Setup step split into two conditional steps:
    - `if: inputs.driver == 'remote'` — unchanged wiring to the in-cluster BuildKit endpoints (`tcp://buildkit-{amd64,arm64}.buildkit:1234`).
    - `if: inputs.driver == 'local'` — new, `docker/setup-buildx-action@v3` with `driver: docker-container`, no endpoints.
  - Existing inputs (`amd64-endpoint`, `arm64-endpoint`, `name`) unchanged; description clarified as remote-only.

No caller updated. Default resolution keeps all 7 existing callers (`ci-image.yml`, `docker-build.yml`, `release-tag.yml` ×3, `release-vm-dev.yml` ×2, `release-dev.yml` ×2) on the remote path.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated — N/A; composite GitHub Action
- [ ] E2E tests added/updated — N/A
- [x] Remote-driver path exercised by every Rust/Docker CI job on this PR (7 call sites)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — N/A; plan lives in Linear OS-127 (doc pending; MCP `create_document` is currently returning `Tool not found` — will attach the plan doc once it recovers or fall back to a Linear comment)