### PR TITLE
fix(ci): rename mise --no-prepare to --no-deps

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -93,4 +93,4 @@ jobs:
           # Enable dev-settings feature for test settings (dummy_bool, dummy_int)
           # used by e2e tests.
           EXTRA_CARGO_FEATURES: openshell-core/dev-settings
-        run: mise run --no-prepare build:docker:${{ inputs.component }}
+        run: mise run --no-deps build:docker:${{ inputs.component }}

--- a/.github/workflows/e2e-gpu-test.yaml
+++ b/.github/workflows/e2e-gpu-test.yaml
@@ -64,7 +64,7 @@ jobs:
         run: docker pull ghcr.io/nvidia/openshell/cluster:${{ inputs.image-tag }}
 
       - name: Install Python dependencies and generate protobuf stubs
-        run: uv sync --frozen && mise run --no-prepare python:proto
+        run: uv sync --frozen && mise run --no-deps python:proto
 
       - name: Bootstrap GPU cluster
         env:
@@ -76,7 +76,7 @@ jobs:
           SKIP_IMAGE_PUSH: "1"
           SKIP_CLUSTER_IMAGE_BUILD: "1"
           OPENSHELL_CLUSTER_IMAGE: ghcr.io/nvidia/openshell/cluster:${{ inputs.image-tag }}
-        run: mise run --no-prepare --skip-deps cluster
+        run: mise run --no-deps --skip-deps cluster
 
       - name: Run tests
-        run: mise run --no-prepare --skip-deps e2e:python:gpu
+        run: mise run --no-deps --skip-deps e2e:python:gpu

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -29,11 +29,11 @@ jobs:
           - suite: python
             cluster: e2e-python
             port: "8080"
-            cmd: "mise run --no-prepare --skip-deps e2e:python"
+            cmd: "mise run --no-deps --skip-deps e2e:python"
           - suite: rust
             cluster: e2e-rust
             port: "8081"
-            cmd: "mise run --no-prepare --skip-deps e2e:rust"
+            cmd: "mise run --no-deps --skip-deps e2e:rust"
           - suite: gateway-resume
             cluster: e2e-resume
             port: "8082"
@@ -66,7 +66,7 @@ jobs:
 
       - name: Install Python dependencies and generate protobuf stubs
         if: matrix.suite == 'python'
-        run: uv sync --frozen && mise run --no-prepare python:proto
+        run: uv sync --frozen && mise run --no-deps python:proto
 
       - name: Build Rust CLI
         if: matrix.suite != 'python'
@@ -84,7 +84,7 @@ jobs:
           SKIP_IMAGE_PUSH: "1"
           SKIP_CLUSTER_IMAGE_BUILD: "1"
           OPENSHELL_CLUSTER_IMAGE: ghcr.io/nvidia/openshell/cluster:${{ inputs.image-tag }}
-        run: mise run --no-prepare --skip-deps cluster
+        run: mise run --no-deps --skip-deps cluster
 
       - name: Run tests
         run: ${{ matrix.cmd }}


### PR DESCRIPTION
## Summary

- mise 2026.4.18 (bumped in #923) renamed the `--no-prepare` flag to `--no-deps`, which broke CI invocations still using the old name.
- Update all workflow `mise run` calls to use `--no-deps`.

## Related Issue

Follow-up to #923.

## Changes

- `.github/workflows/docker-build.yml`: `--no-prepare` → `--no-deps`
- `.github/workflows/e2e-test.yml`: same rename across python/rust/cluster steps
- `.github/workflows/e2e-gpu-test.yaml`: same rename across python-proto/cluster/gpu-e2e steps

## Testing

- [ ] CI workflows run green on this branch

## Checklist

- [x] Conventional commit format
- [x] No unrelated changes