### PR TITLE
feat(docker): add BINARY_SOURCE selector for prebuilt Rust binaries

### DIFF
--- a/deploy/docker/Dockerfile.images
+++ b/deploy/docker/Dockerfile.images
@@ -22,6 +22,12 @@ ARG K9S_VERSION=v0.50.18
 ARG HELM_VERSION=v3.17.3
 ARG NVIDIA_CONTAINER_TOOLKIT_VERSION=1.18.2-1
 
+# OS-128 Phase 4: select binary source for final images. `build` (default)
+# compiles Rust inside the builder stages below; `prebuilt` consumes binaries
+# staged at deploy/docker/.build/prebuilt-binaries/<arch>/. Declared at global
+# scope so BuildKit can substitute it in `FROM *-binary-${BINARY_SOURCE}`.
+ARG BINARY_SOURCE=build
+
 # ---------------------------------------------------------------------------
 # Shared Rust build stages
 # ---------------------------------------------------------------------------
@@ -173,10 +179,39 @@ RUN --mount=type=cache,id=cargo-registry-${TARGETARCH},sharing=locked,target=/us
     mkdir -p /build/out && \
     cp "$(cross_output_dir release)/openshell-sandbox" /build/out/
 
+# ---------------------------------------------------------------------------
+# Binary source selector (OS-128 Phase 4)
+# ---------------------------------------------------------------------------
+# `BINARY_SOURCE` is declared at global scope above (near the other version
+# ARGs). `build` (default) routes through the Rust builder stages above;
+# `prebuilt` routes through the scratch stages below, which COPY from
+#   deploy/docker/.build/prebuilt-binaries/<arch>/openshell-{gateway,sandbox}
+# in the build context. Prebuilt-artifact production + end-to-end workflow
+# wiring land in later Phase 4 PRs; the `prebuilt` path is inert unless a
+# caller sets BINARY_SOURCE=prebuilt and stages the binaries.
+
+FROM gateway-builder AS gateway-binary-build
+# Inherits /build/out/openshell-gateway from the cargo build stage.
+
+FROM scratch AS gateway-binary-prebuilt
+ARG TARGETARCH
+COPY deploy/docker/.build/prebuilt-binaries/${TARGETARCH}/openshell-gateway /build/out/openshell-gateway
+
+FROM gateway-binary-${BINARY_SOURCE} AS gateway-binary
+
+FROM supervisor-builder AS supervisor-binary-build
+# Inherits /build/out/openshell-sandbox from the cargo build stage.
+
+FROM scratch AS supervisor-binary-prebuilt
+ARG TARGETARCH
+COPY deploy/docker/.build/prebuilt-binaries/${TARGETARCH}/openshell-sandbox /build/out/openshell-sandbox
+
+FROM supervisor-binary-${BINARY_SOURCE} AS supervisor-binary
+
 # Minimal extraction stage for fast-deploy: exports only the supervisor
 # binary (~20-40 MB) instead of the entire build environment (~968 MB).
 FROM scratch AS supervisor-output
-COPY --from=supervisor-builder /build/out/openshell-sandbox /openshell-sandbox
+COPY --from=supervisor-binary /build/out/openshell-sandbox /openshell-sandbox
 
 # ---------------------------------------------------------------------------
 # Final gateway image
@@ -192,7 +227,7 @@ RUN useradd --create-home --user-group openshell
 
 WORKDIR /app
 
-COPY --from=gateway-builder /build/out/openshell-gateway /usr/local/bin/
+COPY --from=gateway-binary /build/out/openshell-gateway /usr/local/bin/
 
 RUN mkdir -p /build/crates/openshell-server
 COPY --chmod=755 crates/openshell-server/migrations /build/crates/openshell-server/migrations
@@ -217,7 +252,7 @@ RUN useradd --create-home --user-group openshell
 
 WORKDIR /app
 
-COPY --from=supervisor-builder /build/out/openshell-sandbox /usr/local/bin/
+COPY --from=supervisor-binary /build/out/openshell-sandbox /usr/local/bin/
 
 USER openshell
 
@@ -287,7 +322,7 @@ COPY --from=nvidia-container-toolkit /usr/bin/nvidia-cdi-hook /usr/bin/
 COPY --from=nvidia-container-toolkit /usr/bin/nvidia-container-runtime /usr/bin/
 COPY --from=nvidia-container-toolkit /usr/bin/nvidia-ctk /usr/bin/
 COPY --from=nvidia-container-toolkit /etc/nvidia-container-runtime /etc/nvidia-container-runtime
-COPY --from=supervisor-builder /build/out/openshell-sandbox /opt/openshell/bin/openshell-sandbox
+COPY --from=supervisor-binary /build/out/openshell-sandbox /opt/openshell/bin/openshell-sandbox
 
 RUN mkdir -p /var/lib/rancher/k3s/server/manifests \
              /var/lib/rancher/k3s/server/static/charts \

--- a/deploy/docker/Dockerfile.images
+++ b/deploy/docker/Dockerfile.images
@@ -195,7 +195,9 @@ FROM gateway-builder AS gateway-binary-build
 
 FROM scratch AS gateway-binary-prebuilt
 ARG TARGETARCH
-COPY deploy/docker/.build/prebuilt-binaries/${TARGETARCH}/openshell-gateway /build/out/openshell-gateway
+# --chmod=755 preserves the executable bit through actions/upload-artifact +
+# download-artifact, which strip exec perms during the roundtrip.
+COPY --chmod=755 deploy/docker/.build/prebuilt-binaries/${TARGETARCH}/openshell-gateway /build/out/openshell-gateway
 
 FROM gateway-binary-${BINARY_SOURCE} AS gateway-binary
 
@@ -204,7 +206,9 @@ FROM supervisor-builder AS supervisor-binary-build
 
 FROM scratch AS supervisor-binary-prebuilt
 ARG TARGETARCH
-COPY deploy/docker/.build/prebuilt-binaries/${TARGETARCH}/openshell-sandbox /build/out/openshell-sandbox
+# --chmod=755 preserves the executable bit through actions/upload-artifact +
+# download-artifact, which strip exec perms during the roundtrip.
+COPY --chmod=755 deploy/docker/.build/prebuilt-binaries/${TARGETARCH}/openshell-sandbox /build/out/openshell-sandbox
 
 FROM supervisor-binary-${BINARY_SOURCE} AS supervisor-binary
 

--- a/tasks/scripts/docker-build-image.sh
+++ b/tasks/scripts/docker-build-image.sh
@@ -143,6 +143,25 @@ if [[ -n "${CI:-}" ]]; then
   CODEGEN_ARGS=(--build-arg "CARGO_CODEGEN_UNITS=1")
 fi
 
+# OS-128 Phase 4: opt in to consuming pre-built Rust binaries instead of
+# compiling inside Docker. Default path (`build`) is unchanged. When
+# USE_PREBUILT_BINARIES=true, the Dockerfile's BINARY_SOURCE=prebuilt stages
+# are selected, which COPY from deploy/docker/.build/prebuilt-binaries/<arch>/
+# in the build context. Callers must stage the binaries before invoking.
+BINARY_SOURCE_ARGS=()
+if [[ "${USE_PREBUILT_BINARIES:-}" == "true" ]]; then
+  case "${TARGET}" in
+    gateway|supervisor|cluster|supervisor-output)
+      if [[ ! -d deploy/docker/.build/prebuilt-binaries ]]; then
+        echo "Error: USE_PREBUILT_BINARIES=true but deploy/docker/.build/prebuilt-binaries/ does not exist" >&2
+        echo "  Stage binaries at deploy/docker/.build/prebuilt-binaries/<arch>/openshell-{gateway,sandbox}" >&2
+        exit 1
+      fi
+      BINARY_SOURCE_ARGS=(--build-arg "BINARY_SOURCE=prebuilt")
+      ;;
+  esac
+fi
+
 TAG_ARGS=()
 if [[ "${IS_FINAL_IMAGE}" == "1" ]]; then
   TAG_ARGS=(-t "${IMAGE_NAME}:${IMAGE_TAG}")
@@ -181,6 +200,7 @@ docker buildx build \
   ${VERSION_ARGS[@]+"${VERSION_ARGS[@]}"} \
   ${K3S_ARGS[@]+"${K3S_ARGS[@]}"} \
   ${CODEGEN_ARGS[@]+"${CODEGEN_ARGS[@]}"} \
+  ${BINARY_SOURCE_ARGS[@]+"${BINARY_SOURCE_ARGS[@]}"} \
   ${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"} \
   --build-arg "CARGO_TARGET_CACHE_SCOPE=${CARGO_TARGET_CACHE_SCOPE}" \
   -f "${DOCKERFILE}" \


### PR DESCRIPTION
## Summary

Add a `BINARY_SOURCE` selector to `deploy/docker/Dockerfile.images` so the three final images (`gateway`, `supervisor`, `cluster`) can consume pre-built Rust binaries from the build context instead of compiling inside Docker. Default stays `build` (unchanged behavior); `prebuilt` is opt-in and inert until later Phase 4 PRs wire in the producer + workflow.

## Related Issue

OS-49 runner migration, Phase 4 / OS-128. This is **PR 4b** of three:

- **PR 4a** (not yet opened) — per-arch native `cargo build` jobs publish `openshell-gateway` / `openshell-sandbox` artifacts. Data-blocked on Phase 2 dispatch results.
- **PR 4b** (this PR) — Dockerfile + script gain an opt-in path; default unchanged.
- **PR 4c** (later) — flip the default, delete the in-Docker Rust builder stages, add multi-arch manifest merge.

Full plan + gotchas live on [OS-128 as a Linear comment](https://linear.app/nvidia/issue/OS-128).

## Changes

- `deploy/docker/Dockerfile.images`:
  - `ARG BINARY_SOURCE=build` declared at global scope (required for BuildKit `FROM *-${ARG}` substitution).
  - Two new dual-source stages per binary:
    - `gateway-binary-build` (alias for `gateway-builder`) / `gateway-binary-prebuilt` (scratch + `COPY deploy/docker/.build/prebuilt-binaries/${TARGETARCH}/openshell-gateway /build/out/openshell-gateway`) → merged into `gateway-binary` via `FROM gateway-binary-${BINARY_SOURCE}`.
    - Same shape for `supervisor-binary`.
  - Four `COPY --from=*-builder` lines re-pointed at `*-binary`: `supervisor-output`, `gateway`, `supervisor`, `cluster`.
  - Key property: when `BINARY_SOURCE=prebuilt`, BuildKit skips the `rust-builder-*` / `rust-deps` / `*-builder` / `*-workspace` stages entirely — Docker becomes packaging-only. PR 4c just flips the default and deletes the now-unreferenced stages.
- `tasks/scripts/docker-build-image.sh`:
  - Reads `USE_PREBUILT_BINARIES` env var. When `true` and target is `gateway`/`supervisor`/`cluster`/`supervisor-output`, passes `--build-arg BINARY_SOURCE=prebuilt` plus a fail-early sanity check that `deploy/docker/.build/prebuilt-binaries/` exists.

## Testing

- [x] `mise run pre-commit` passes
- [x] `docker buildx build --call=check` on `gateway`, `supervisor`, `cluster` targets — lint-clean, no warnings.
- [x] `docker buildx build --call=check` with `BINARY_SOURCE=prebuilt` override — lint-clean.
- [x] `mise run build:docker:gateway` (default `BINARY_SOURCE=build`) — completed end-to-end, produced `openshell/gateway:dev` (115MB). `docker run openshell/gateway:dev --version` returns `openshell-gateway 0.0.0` (version-injection not exercised locally; CI path unchanged).
- [ ] `USE_PREBUILT_BINARIES=true mise run build:docker:gateway` end-to-end — **not exercised in this PR**. The `prebuilt` path is inert until PR 4a lands and stages the binaries. First real end-to-end test ships in PR 4a.
- [ ] E2E tests — N/A; Docker image shape unchanged on the default path.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] No caller behavior changes (default `BINARY_SOURCE=build` routes through the same `gateway-builder` / `supervisor-builder` stages as before)
- [ ] Architecture docs updated — N/A; plan lives on Linear OS-128 (as a comment; `create_document` MCP outage)