### PR TITLE
fix(e2e): add /dev/urandom to provider test sandbox policy

### DIFF
--- a/e2e/python/test_sandbox_providers.py
+++ b/e2e/python/test_sandbox_providers.py
@@ -36,7 +36,7 @@ def _default_policy() -> sandbox_pb2.SandboxPolicy:
         version=1,
         filesystem=sandbox_pb2.FilesystemPolicy(
             include_workdir=True,
-            read_only=["/usr", "/lib", "/etc", "/app"],
+            read_only=["/usr", "/lib", "/etc", "/app", "/dev/urandom"],
             read_write=["/sandbox", "/tmp"],
         ),
         landlock=sandbox_pb2.LandlockPolicy(compatibility="best_effort"),


### PR DESCRIPTION
## Summary
Python runtime requires /dev/urandom access during initialization to seed the hash randomizer. The _default_policy() in provider tests was missing this path, causing exec_python tests to fail with: 'Fatal Python error: _Py_HashRandomization_Init: failed to get random numbers to initialize Python'.

Add /dev/urandom to read_only paths to match the policy used in test_sandbox_policy.py, allowing Python to initialize successfully.

## Related Issue

## Changes

## Testing
<!-- What testing was done? -->
- [x] `mise run e2e:python`

## Checklist
- [x ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
