### PR TITLE
fix(ci): expose GHA sccache env in shadow-shared-cpu-spike

### DIFF
--- a/.github/workflows/shadow-shared-cpu-spike.yml
+++ b/.github/workflows/shadow-shared-cpu-spike.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Install tools
         run: mise install
 
+      - name: Configure GHA sccache backend
+        # Exposes ACTIONS_CACHE_URL / ACTIONS_RUNTIME_TOKEN to subsequent steps
+        # so sccache (wrapped around rustc via RUSTC_WRAPPER in mise.toml) can
+        # initialize the GHA cache. Without this, sccache fails at startup with
+        # "cache url for ghac not found". The action also installs its own
+        # sccache binary; harmless since mise's sccache remains on PATH.
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
       - name: Cache Rust target and registry
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:


### PR DESCRIPTION
## Summary

First dispatch of the OS-126 shadow workflow failed at sccache startup ([run 24861024186](https://github.com/NVIDIA/OpenShell/actions/runs/24861024186)):

```
sccache: error: Server startup failed: create gha cache failed: ConfigInvalid (permanent):
cache url for ghac not found, maybe not in github action environment?
```

Root cause: `SCCACHE_GHA_ENABLED=true` alone isn't sufficient — sccache also needs `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` exported to the step's env. These are not auto-exposed by GitHub Actions; they have to be set by a cache-adjacent action. `Swatinem/rust-cache` uses them internally but doesn't persist them to subsequent step env.

Fix: add `mozilla-actions/sccache-action@v0.0.9` before the cargo step. Its side effect is exporting the required env vars. The action also installs its own sccache binary, but mise's sccache (set as `RUSTC_WRAPPER` in `mise.toml`) stays on PATH — only the env vars matter.

## Related Issue

OS-49 runner migration, Phase 2 / OS-126. Unblocks the first real dispatch so we can start filling the [OS-126 results table](https://linear.app/nvidia/document/os-126-shared-cpu-spike-plan-and-results-c6f854dc6255).

## Changes

- `.github/workflows/shadow-shared-cpu-spike.yml`: new `Configure GHA sccache backend` step (8 lines) pinned to v0.0.9 commit SHA `7d986dd9`. Placed between `Install tools` and `Cache Rust target and registry` so env vars are ready before any cargo/rustc invocation.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated — N/A; workflow config change
- [ ] E2E tests added/updated — N/A
- [ ] End-to-end workflow run — re-dispatch planned immediately after merge, expect cargo check to reach cargo-compile rather than fail at sccache init. That's the real verification; no way to simulate locally.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Action pinned to commit SHA with version comment
- [ ] Architecture docs updated — N/A; plan lives in Linear OS-126