### PR TITLE
feat(sandbox): add --helpers-config for pre-workload privileged helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caps"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1ddba47aba30b6a889298ad0109c3b8dcb0e8fc993b459daa7067d46f865e0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3329,6 +3338,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bytes",
+ "caps",
  "clap",
  "futures",
  "hex",
@@ -3349,6 +3359,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "seccompiler",
+ "serde",
  "serde_json",
  "serde_yml",
  "sha2 0.10.9",

--- a/architecture/supervisor-helpers.md
+++ b/architecture/supervisor-helpers.md
@@ -1,0 +1,180 @@
+# Supervisor Helpers
+
+Supervisor helpers are privileged processes the sandbox supervisor launches
+before the workload. They run in the supervisor's own execution context —
+without the per-workload seccomp filter, `PR_SET_NO_NEW_PRIVS`, or Landlock —
+with operator-declared ambient capabilities. The workload itself is sandboxed
+exactly as before.
+
+This page documents the shipped v0 primitive. A broader design with Landlock
+integration, workload rendezvous, lifecycle semantics, and OCSF stdio is
+tracked in `architecture/plans/supervisor-helpers.md`.
+
+## Motivation
+
+The supervisor already runs as pid 1 of the sandbox pod with a full permitted
+capability set and `NoNewPrivs=0`. Some sandbox deployments need a small,
+audited daemon running alongside the workload that holds capabilities the
+workload must not — a capability broker, a privileged IPC bridge, or a
+pre-seccomp helper. Before this feature, the only options were:
+
+- **File capabilities on a helper binary.** Dead on arrival: workloads are
+  spawned with `NoNewPrivs=1`, which causes the kernel to drop file caps at
+  `execve`. Even if a helper is launched from an unrelated path, it's hard
+  to keep it out of the workload's privilege-drop envelope.
+- **Hardcoded special cases in the supervisor.** The DNS proxy at pid ~618
+  already runs this way — spawned by the supervisor before seccomp applies —
+  but it's baked into the supervisor binary. There's no way for a deployment
+  to register its own helper without patching the supervisor.
+
+Supervisor helpers turn the DNS-proxy-shaped pattern into a public, declarative
+API: one JSON config, any number of operator-audited daemons.
+
+## Surface
+
+One new flag on `openshell-sandbox`:
+
+```
+--helpers-config <path>    [env: OPENSHELL_HELPERS_CONFIG]
+```
+
+When absent, behavior is unchanged from previous versions. When present, the
+supervisor loads the JSON file, validates it, and spawns every listed helper
+before starting the workload.
+
+### Config schema
+
+```json
+{
+  "helpers": [
+    {
+      "name": "example-broker",
+      "command": ["/opt/example/bin/broker", "--socket", "/var/run/example.sock"],
+      "env": {
+        "RUST_LOG": "info"
+      },
+      "ambient_caps": ["CAP_SETUID", "CAP_SETGID", "CAP_NET_ADMIN"]
+    }
+  ]
+}
+```
+
+| Field | Required | Meaning |
+|---|---|---|
+| `name` | yes | Human-readable name used in logs and OCSF events. Must be unique. |
+| `command` | yes | Full argv. `command[0]` must be an absolute path — the supervisor does not consult `$PATH`. |
+| `env` | no | Environment variables merged on top of the supervisor's environment after `OPENSHELL_SSH_HANDSHAKE_SECRET` is scrubbed. |
+| `ambient_caps` | no | Capabilities raised into the helper's ambient set before `execve`. Names accept `CAP_FOO` or `FOO`, case-insensitive. |
+
+Validation rejects: empty `name`, duplicate names, empty `command`, non-absolute
+`command[0]`, unknown capability names.
+
+## Runtime semantics
+
+For each helper in declaration order:
+
+1. The supervisor forks.
+2. In the child's `pre_exec`, for each declared capability, the supervisor
+   calls `capset(2)` to add it to the inheritable set, then
+   `prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, cap, 0, 0)`. After `execve`
+   the ambient set becomes part of the helper's permitted and effective sets.
+3. The child `execve`s `command[0]` with the declared argv and merged env.
+4. The supervisor emits an OCSF `AppLifecycle` event with `activity=Start`.
+
+Helpers do **not** get:
+
+- the per-workload seccomp filter (from `sandbox::linux::seccomp::apply`),
+- `PR_SET_NO_NEW_PRIVS`,
+- Landlock (from `sandbox::linux::landlock::apply`),
+- `drop_privileges` (the helper keeps the supervisor's uid — typically 0).
+
+This is intentional. A helper's containment is bounded by the pod's
+securityContext (bounding set and capabilities granted to the supervisor) and
+by whatever restrictions the helper binary applies to itself. The operator
+vouches for the helper binary shipped in the image and for the capabilities
+declared here.
+
+### Interaction with the supervisor seccomp prelude
+
+The supervisor installs its own seccomp prelude mid-startup via
+`apply_supervisor_startup_hardening` (introduced in #891). Helpers are
+spawned *before* that prelude is applied, so helpers themselves are not
+subject to it. The prelude only blocks long-lived supervisor escape
+primitives — `mount`, the new mount API (`fsopen`/`fsconfig`/`fsmount`/
+`fspick`/`move_mount`/`open_tree`), `umount2`, `pivot_root`, `bpf`,
+`perf_event_open`, `userfaultfd`, and module/kexec loaders. Notably it does
+not touch `capset`, `prctl`, `clone`, or `execve`, so the helper spawn path
+(`capset` for the inheritable set plus `prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, ...)`
+in the pre-exec child, then `execve`) is unaffected.
+
+Helpers are spawned with `kill_on_drop(true)`. When the supervisor exits
+(for any reason), tokio sends `SIGKILL` to the helper. No structured
+shutdown in v0.
+
+## Security model
+
+The trust boundary is **the supervisor**, and the same trust boundary that
+already exists today. A compromised supervisor was always catastrophic;
+giving it the ability to fork a declared set of other root-capable processes
+from a config file does not expand that blast radius.
+
+What *does* change:
+
+- The operator is now responsible for auditing each helper binary and each
+  capability it receives. The `--helpers-config` path and its contents are
+  part of the image's attack surface.
+- Helpers and the workload share the pod's filesystem. In v0 there is no
+  Landlock isolation between them — any cap-less helper could read
+  workload-writable paths, and vice versa. Deployments that need file-level
+  isolation should either wait for the RFC's Landlock support or implement
+  it inside the helper binary.
+- `ambient_caps` is clamped to the supervisor's permitted set, which in turn
+  is clamped to the pod's bounding set. Requesting a cap the bounding set
+  doesn't include fails at `capset(2)` with `EPERM` and the supervisor exits
+  before the workload starts.
+
+The SSH handshake secret (`OPENSHELL_SSH_HANDSHAKE_SECRET`) is scrubbed from
+the helper's inherited environment, matching what the workload sees.
+
+## Interactions
+
+- **DNS proxy.** The DNS proxy's existing hardcoded path is unchanged.
+  Nothing in this feature removes or modifies it. A future follow-up may
+  migrate it onto supervisor helpers.
+- **Policy.** Helpers are outside the policy surface: OPA rules, network
+  policy, and Landlock config apply to the workload, not to helpers. A
+  helper talking through the policy-enforced proxy must do so the same way
+  any process does — by speaking HTTP to the proxy.
+- **OCSF.** Helper start emits `AppLifecycleBuilder { activity: Start,
+  severity: Informational, status: Success }`. Structured helper stdout/stderr
+  is deferred; plain tracing is used.
+
+## What the v0 does *not* include
+
+These are explicitly out of scope for this landing and are tracked in
+`architecture/plans/supervisor-helpers.md`:
+
+- Per-helper Landlock (`readOnly`, `readWrite`, `readExec`).
+- A `shareWithWorkload` rendezvous field that lets the workload `connect()`
+  to a helper-owned socket without gaining `unlink()`/replace rights.
+- Structured restart policy (`Never`, `OnFailure`, `Always`).
+- `readinessFd` convention (fd 3 write-one-byte) for "helper is live" gating.
+- Helper stdio routing into the OCSF JSONL log stream.
+- Per-helper cgroup resource limits.
+- `runAsUser`/`runAsGroup` with the `PR_SET_KEEPCAPS` + `setuid` + ambient
+  dance to let helpers drop to non-root while retaining requested caps.
+
+Each of those is additive on the existing schema — no breaking change to
+the v0 config format.
+
+## Implementation
+
+| Path | Role |
+|---|---|
+| `crates/openshell-sandbox/src/helpers.rs` | `HelpersConfig`, `HelperSpec`, `spawn_helpers`, cap-raising `pre_exec` hook. |
+| `crates/openshell-sandbox/src/lib.rs` | `run_sandbox` takes `helpers_config: Option<String>` and calls `spawn_helpers` after OCSF init, before policy load. |
+| `crates/openshell-sandbox/src/main.rs` | `--helpers-config` clap flag bound to `OPENSHELL_HELPERS_CONFIG`. |
+
+Dependencies: [`caps`](https://crates.io/crates/caps) for the capability
+set manipulation — thin wrapper over `capset(2)` + `PR_CAP_AMBIENT`. `serde`
+is already a workspace dependency.

--- a/crates/openshell-sandbox/Cargo.toml
+++ b/crates/openshell-sandbox/Cargo.toml
@@ -63,6 +63,7 @@ base64 = { workspace = true }
 ipnet = "2"
 
 # Serialization
+serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
 
@@ -81,6 +82,10 @@ libc = "0.2"
 landlock = "0.4"
 seccompiler = "0.5"
 uuid = { version = "1", features = ["v4"] }
+# Supervisor-helper ambient-capability plumbing. Used by src/helpers.rs to
+# move caps into the inheritable + ambient sets of the pre-exec child so the
+# helper process receives them after execve.
+caps = "0.5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/openshell-sandbox/src/helpers.rs
+++ b/crates/openshell-sandbox/src/helpers.rs
@@ -115,9 +115,30 @@ fn validate(config: &HelpersConfig) -> Result<()> {
 /// Spawn every helper in the config, in declaration order. Returns a handle
 /// per spawned helper.
 ///
+/// Before the first helper spawns, install iptables OUTPUT rules in the
+/// supervisor's netns that REJECT helper-originated egress that doesn't
+/// route through the policy proxy. See `install_capture_rules` for the
+/// rule set and exemption rationale.
+///
 /// # Errors
-/// Propagates the first helper that fails to spawn.
+/// Propagates the first helper that fails to spawn. Failure to install
+/// capture rules is logged but non-fatal — helpers still spawn so the
+/// supervisor can boot, but the trust model is degraded (operators get
+/// an OCSF event flagging the missing capture).
 pub fn spawn_helpers(config: &HelpersConfig) -> Result<Vec<HelperHandle>> {
+    if !config.helpers.is_empty() {
+        if let Err(e) = install_capture_rules() {
+            // Don't fail the spawn — degraded mode is better than no helpers.
+            // The OCSF event raised inside `install_capture_rules` already
+            // tells operators capture is off; tracing here is for completeness.
+            tracing::warn!(
+                error = %e,
+                "supervisor netns capture rules failed to install; \
+                 helpers will run with un-captured egress"
+            );
+        }
+    }
+
     let mut handles = Vec::with_capacity(config.helpers.len());
     for spec in &config.helpers {
         let handle = spawn_helper(spec)?;
@@ -220,6 +241,236 @@ fn raise_ambient(caps_list: &[caps::Capability]) -> std::io::Result<()> {
         caps::raise(None, CapSet::Ambient, *cap)
             .map_err(|e| std::io::Error::other(format!("raise ambient {cap:?}: {e}")))?;
     }
+    Ok(())
+}
+
+// ── Supervisor-netns iptables capture ───────────────────────────────────────
+//
+// Helpers share the supervisor's network namespace by design — that's how
+// the mediator UDS, OpenClaw gateway, and other operator-declared daemons
+// reach services the workload sandbox couldn't reach itself. The downside:
+// before this module, the supervisor netns had no iptables rules at all, so
+// any helper-spawned process whose HTTP client ignores `HTTPS_PROXY` (e.g.
+// Node's built-in `https.request`, which OpenClaw's `web_fetch` tool uses
+// internally) could egress directly to any host the pod can reach, with no
+// policy check and no audit trail.
+//
+// This module installs a small set of rules in the supervisor netns OUTPUT
+// chain that LOG+REJECT helper-originated direct egress while exempting:
+//   - the supervisor's own outbound traffic (gRPC to control plane, log
+//     push, the policy proxy's upstream forwarding) via `--uid-owner 0`
+//   - traffic destined for the policy proxy itself (the legitimate
+//     proxy-aware path)
+//   - loopback and reply packets
+//
+// A helper that drops privileges (e.g. `nemoclaw-start` → `gosu gateway` →
+// UID 999, or `mediator-runner` → setresuid → UID 998) and then attempts a
+// direct outbound TCP connection lands in the catch-all REJECT and gets a
+// fast `ECONNREFUSED` plus an `openshell:helper-bypass:` LOG entry that
+// `bypass_monitor` parses into an OCSF DetectionFinding.
+//
+// Known limitations of this v0 design:
+//   1. A helper running as root before its own privilege drop is exempted
+//      by the UID 0 rule — same brief window as for the supervisor's own
+//      bootstrap traffic. For sclaw's helpers this is bounded to the few
+//      seconds between exec and gosu/runner; documented in the helpers RFC.
+//   2. The proxy hostname/IP is hard-coded here to match
+//      `sandbox::linux::netns::{SUBNET_PREFIX, HOST_IP_SUFFIX}` because at
+//      `spawn_helpers` time the policy hasn't been loaded yet and the
+//      runtime proxy bind address isn't available. A v1 refactor that
+//      moves helper spawn after policy load would replace the constant
+//      with the runtime address.
+
+/// Hard-coded supervisor-side proxy IP. Must match
+/// `sandbox::linux::netns::SUBNET_PREFIX` (`10.200.0`) +
+/// `HOST_IP_SUFFIX` (`1`). Hard-coding here because helpers spawn before
+/// the policy is loaded and the actual proxy bind address is set.
+#[cfg(target_os = "linux")]
+const PROXY_IP: &str = "10.200.0.1";
+
+/// Hard-coded proxy port. Matches the default in `lib.rs` and `proxy.rs`.
+/// Same v0 limitation as `PROXY_IP` above.
+#[cfg(target_os = "linux")]
+const PROXY_PORT: u16 = 3128;
+
+/// Well-known iptables paths. Mirrors `sandbox::linux::netns`'s probe set;
+/// duplicated here so we can stay independent of the netns module's
+/// internal API.
+#[cfg(target_os = "linux")]
+const IPTABLES_SEARCH_PATHS: &[&str] =
+    &["/usr/sbin/iptables", "/sbin/iptables", "/usr/bin/iptables"];
+
+#[cfg(target_os = "linux")]
+fn find_iptables() -> Option<String> {
+    IPTABLES_SEARCH_PATHS
+        .iter()
+        .find(|p| std::path::Path::new(p).exists())
+        .map(|s| (*s).to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn run_iptables(iptables_cmd: &str, args: &[&str]) -> Result<()> {
+    let output = std::process::Command::new(iptables_cmd)
+        .args(args)
+        .output()
+        .into_diagnostic()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(miette::miette!(
+            "{iptables_cmd} {} failed: {}",
+            args.join(" "),
+            stderr.trim()
+        ));
+    }
+    Ok(())
+}
+
+/// Install OUTPUT-chain rules in the supervisor's netns to capture helper
+/// egress. Idempotent: re-running appends duplicate ACCEPT/REJECT rules,
+/// which is harmless but cosmetically noisy; in practice this runs once
+/// per supervisor lifetime.
+///
+/// Degrades gracefully when iptables is missing — emits an OCSF event so
+/// operators see the missing capture, returns `Ok(())` to let helpers
+/// still spawn.
+#[cfg(target_os = "linux")]
+fn install_capture_rules() -> Result<()> {
+    let iptables = match find_iptables() {
+        Some(path) => path,
+        None => {
+            ocsf_emit!(
+                openshell_ocsf::ConfigStateChangeBuilder::new(crate::ocsf_ctx())
+                    .severity(openshell_ocsf::SeverityId::Medium)
+                    .status(openshell_ocsf::StatusId::Failure)
+                    .state(openshell_ocsf::StateId::Disabled, "degraded")
+                    .message(
+                        "iptables not found; supervisor-netns helper capture rules \
+                         will not be installed — helpers may egress without policy \
+                         enforcement"
+                    )
+                    .build()
+            );
+            return Ok(());
+        }
+    };
+
+    let proxy_port_str = PROXY_PORT.to_string();
+    let proxy_dst = format!("{PROXY_IP}/32");
+
+    // Rule 1: ACCEPT loopback. Mediator UDS, gateway UI, etc. depend on it.
+    run_iptables(
+        &iptables,
+        &["-A", "OUTPUT", "-o", "lo", "-j", "ACCEPT"],
+    )?;
+
+    // Rule 2: ACCEPT reply packets for connections we already permitted.
+    run_iptables(
+        &iptables,
+        &[
+            "-A", "OUTPUT",
+            "-m", "conntrack",
+            "--ctstate", "ESTABLISHED,RELATED",
+            "-j", "ACCEPT",
+        ],
+    )?;
+
+    // Rule 3: ACCEPT to the policy proxy. Helpers that respect HTTPS_PROXY
+    // land here; the proxy then enforces the binary + host allowlist.
+    run_iptables(
+        &iptables,
+        &[
+            "-A", "OUTPUT",
+            "-d", &proxy_dst,
+            "-p", "tcp",
+            "--dport", &proxy_port_str,
+            "-j", "ACCEPT",
+        ],
+    )?;
+
+    // Rule 4: ACCEPT supervisor's own outbound. UID 0 covers the gRPC
+    // control-plane connection, log push, and the policy proxy's own
+    // upstream forwarding (which would otherwise loop). Helpers that
+    // haven't dropped privileges yet are also covered here — see the
+    // module-level comment for the bounded-window caveat.
+    run_iptables(
+        &iptables,
+        &[
+            "-A", "OUTPUT",
+            "-m", "owner",
+            "--uid-owner", "0",
+            "-j", "ACCEPT",
+        ],
+    )?;
+
+    // Rule 4b: ACCEPT DNS (UDP/TCP port 53) from any helper UID. Unlike
+    // ordinary application traffic — which is expected to flow through
+    // the policy proxy — DNS is consulted by the helpers themselves
+    // when they call iptables/getaddrinfo with hostnames (e.g. the
+    // mediator daemon resolving the per-policy http_allowlist before
+    // installing per-worker iptables rules). Without this exception,
+    // those resolutions hit Rule 6 (REJECT), iptables fails with
+    // "host/network not found / exit 2", and `fork_with_policy`
+    // breaks even though the operator-approved policy is otherwise
+    // valid. Allowing port-53 egress from helpers is a narrow widening
+    // of the bypass surface (DNS exfil only), well-justified by the
+    // requirement that hostname-based allowlists actually work.
+    for proto in &["udp", "tcp"] {
+        run_iptables(
+            &iptables,
+            &[
+                "-A", "OUTPUT",
+                "-p", proto,
+                "--dport", "53",
+                "-j", "ACCEPT",
+            ],
+        )?;
+    }
+
+    // Rule 5: LOG bypass attempts so bypass_monitor can surface them as
+    // OCSF DetectionFindings. The prefix matches the existing convention
+    // used by the workload-netns LOG rules in `sandbox::linux::netns`.
+    let log_prefix = "openshell:helper-bypass:";
+    if let Err(e) = run_iptables(
+        &iptables,
+        &[
+            "-A", "OUTPUT",
+            "-j", "LOG",
+            "--log-prefix", log_prefix,
+            "--log-level", "warning",
+        ],
+    ) {
+        // LOG is non-essential — REJECT below still catches the bypass.
+        // Some kernels lack `xt_LOG`; downgrade to a warning and continue.
+        tracing::warn!(error = %e, "could not install LOG rule for helper bypass");
+    }
+
+    // Rule 6: REJECT everything else with ECONNREFUSED so callers fast-fail
+    // instead of hanging on a 30s connect timeout.
+    run_iptables(
+        &iptables,
+        &[
+            "-A", "OUTPUT",
+            "-j", "REJECT",
+            "--reject-with", "icmp-port-unreachable",
+        ],
+    )?;
+
+    ocsf_emit!(
+        openshell_ocsf::ConfigStateChangeBuilder::new(crate::ocsf_ctx())
+            .severity(openshell_ocsf::SeverityId::Informational)
+            .status(openshell_ocsf::StatusId::Success)
+            .state(openshell_ocsf::StateId::Enabled, "installed")
+            .message(format!(
+                "Supervisor netns capture rules installed [proxy:{PROXY_IP}:{PROXY_PORT}]"
+            ))
+            .build()
+    );
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn install_capture_rules() -> Result<()> {
     Ok(())
 }
 

--- a/crates/openshell-sandbox/src/helpers.rs
+++ b/crates/openshell-sandbox/src/helpers.rs
@@ -1,0 +1,296 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Supervisor helpers — privileged processes spawned before the workload.
+//!
+//! A helper is a short, operator-audited daemon that the workload will talk
+//! to via an approved Landlock path (typically a UDS). Helpers are spawned
+//! directly by the supervisor *before* the workload and *without* the
+//! per-workload sandbox: no seccomp filter, no `PR_SET_NO_NEW_PRIVS`, no
+//! Landlock, no privilege drop. They inherit ambient capabilities declared
+//! in the helpers config file, so daemons that need `CAP_SETUID`,
+//! `CAP_NET_ADMIN`, etc. to set up per-request isolation (e.g. a capability
+//! broker) can run alongside the sandboxed workload.
+//!
+//! The supervisor is the trust boundary. The operator vouches for each
+//! helper binary shipped in the image and for the declared capabilities in
+//! the config. The workload process is still sandboxed exactly as before.
+//!
+//! See `architecture/plans/supervisor-helpers.md` for the RFC that will
+//! supersede this v0.
+
+use miette::{IntoDiagnostic, Result};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+use tokio::process::Child;
+use tracing::info;
+
+#[cfg(target_os = "linux")]
+use std::process::Stdio;
+#[cfg(target_os = "linux")]
+use tokio::process::Command;
+
+#[cfg(target_os = "linux")]
+use openshell_ocsf::{ActivityId, AppLifecycleBuilder, SeverityId, StatusId, ocsf_emit};
+
+#[cfg(target_os = "linux")]
+const SSH_HANDSHAKE_SECRET_ENV: &str = "OPENSHELL_SSH_HANDSHAKE_SECRET";
+
+/// Root config document loaded from `--helpers-config <path>` or
+/// `OPENSHELL_HELPERS_CONFIG`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct HelpersConfig {
+    #[serde(default)]
+    pub helpers: Vec<HelperSpec>,
+}
+
+/// One supervisor helper. v0 schema — future RFC iterations will add Landlock,
+/// restart policy, readiness fd, stdio routing, cgroup limits.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HelperSpec {
+    /// Human-readable name used in logs and OCSF events.
+    pub name: String,
+    /// Full argv. `command[0]` must be an absolute path; the supervisor does
+    /// not consult `$PATH`.
+    pub command: Vec<String>,
+    /// Environment variables merged on top of the supervisor's environment.
+    /// Supervisor-private values (e.g. the SSH handshake secret) are scrubbed
+    /// from the inherited environment before these overrides apply.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// Capabilities raised into the helper's ambient set. Names accept either
+    /// `CAP_FOO` or `FOO` (case-insensitive). Each listed cap must exist in
+    /// the supervisor's permitted set (which, in the default pod spec, is
+    /// the full bounding set).
+    #[serde(default)]
+    pub ambient_caps: Vec<String>,
+}
+
+/// Runtime handle for a spawned helper.
+pub struct HelperHandle {
+    pub name: String,
+    pub pid: u32,
+    pub child: Child,
+}
+
+/// Load and validate a helpers config from disk.
+///
+/// # Errors
+/// Returns an error if the file cannot be read, parsed, or fails validation.
+pub fn load_helpers_config(path: &Path) -> Result<HelpersConfig> {
+    let bytes = std::fs::read(path)
+        .into_diagnostic()
+        .map_err(|e| miette::miette!("reading helpers config {}: {e}", path.display()))?;
+    let config: HelpersConfig = serde_json::from_slice(&bytes)
+        .into_diagnostic()
+        .map_err(|e| miette::miette!("parsing helpers config {}: {e}", path.display()))?;
+    validate(&config)?;
+    Ok(config)
+}
+
+fn validate(config: &HelpersConfig) -> Result<()> {
+    let mut seen = std::collections::HashSet::new();
+    for helper in &config.helpers {
+        if helper.name.is_empty() {
+            return Err(miette::miette!("helper with empty name"));
+        }
+        if !seen.insert(helper.name.clone()) {
+            return Err(miette::miette!("duplicate helper name {:?}", helper.name));
+        }
+        let argv0 = helper
+            .command
+            .first()
+            .ok_or_else(|| miette::miette!("helper {:?} has empty command", helper.name))?;
+        if !argv0.starts_with('/') {
+            return Err(miette::miette!(
+                "helper {:?}: command[0] must be an absolute path, got {argv0:?}",
+                helper.name
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Spawn every helper in the config, in declaration order. Returns a handle
+/// per spawned helper.
+///
+/// # Errors
+/// Propagates the first helper that fails to spawn.
+pub fn spawn_helpers(config: &HelpersConfig) -> Result<Vec<HelperHandle>> {
+    let mut handles = Vec::with_capacity(config.helpers.len());
+    for spec in &config.helpers {
+        let handle = spawn_helper(spec)?;
+        info!(
+            name = %handle.name,
+            pid = handle.pid,
+            caps = ?spec.ambient_caps,
+            "Supervisor helper started"
+        );
+        handles.push(handle);
+    }
+    Ok(handles)
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_helper(spec: &HelperSpec) -> Result<HelperHandle> {
+    let caps_list = parse_caps(&spec.ambient_caps)?;
+
+    let (program, args) = spec
+        .command
+        .split_first()
+        .ok_or_else(|| miette::miette!("empty command"))?;
+
+    let mut cmd = Command::new(program);
+    cmd.args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .env_remove(SSH_HANDSHAKE_SECRET_ENV)
+        .env("OPENSHELL_SUPERVISOR_HELPER", &spec.name)
+        .kill_on_drop(true);
+    for (k, v) in &spec.env {
+        cmd.env(k, v);
+    }
+
+    // SAFETY: pre_exec runs after fork, before exec, in the child. The
+    // syscalls we make (capset via the `caps` crate, prctl) are
+    // async-signal-safe.
+    let caps_for_child = caps_list.clone();
+    #[allow(unsafe_code)]
+    unsafe {
+        cmd.pre_exec(move || raise_ambient(&caps_for_child).map_err(std::io::Error::other));
+    }
+
+    let child = cmd.spawn().into_diagnostic()?;
+    let pid = child.id().unwrap_or(0);
+
+    // OCSF's unified ActivityId maps `Reset = 3` to "Start" in lifecycle context
+    // (see lifecycle_label in openshell-ocsf/src/enums/activity.rs).
+    ocsf_emit!(
+        AppLifecycleBuilder::new(crate::ocsf_ctx())
+            .activity(ActivityId::Reset)
+            .severity(SeverityId::Informational)
+            .status(StatusId::Success)
+            .message(format!(
+                "supervisor helper {} started (pid {pid})",
+                spec.name
+            ))
+            .build()
+    );
+
+    Ok(HelperHandle {
+        name: spec.name.clone(),
+        pid,
+        child,
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn spawn_helper(_spec: &HelperSpec) -> Result<HelperHandle> {
+    Err(miette::miette!("supervisor helpers are Linux-only"))
+}
+
+#[cfg(target_os = "linux")]
+fn parse_caps(names: &[String]) -> Result<Vec<caps::Capability>> {
+    names
+        .iter()
+        .map(|n| {
+            let canon = n
+                .strip_prefix("CAP_")
+                .or_else(|| n.strip_prefix("cap_"))
+                .unwrap_or(n)
+                .to_ascii_uppercase();
+            let full = format!("CAP_{canon}");
+            full.parse::<caps::Capability>()
+                .map_err(|_| miette::miette!("unknown capability name {n:?}"))
+        })
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn raise_ambient(caps_list: &[caps::Capability]) -> std::io::Result<()> {
+    use caps::CapSet;
+    for cap in caps_list {
+        // Ambient requires the cap to be in both permitted and inheritable.
+        // The supervisor runs with a full permitted set in the default pod
+        // spec, but inheritable is empty by default — add it first.
+        caps::raise(None, CapSet::Inheritable, *cap)
+            .map_err(|e| std::io::Error::other(format!("raise inheritable {cap:?}: {e}")))?;
+        caps::raise(None, CapSet::Ambient, *cap)
+            .map_err(|e| std::io::Error::other(format!("raise ambient {cap:?}: {e}")))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(name: &str, cmd: &str) -> HelperSpec {
+        HelperSpec {
+            name: name.into(),
+            command: vec![cmd.into()],
+            env: HashMap::new(),
+            ambient_caps: vec![],
+        }
+    }
+
+    #[test]
+    fn rejects_relative_command() {
+        let config = HelpersConfig {
+            helpers: vec![spec("h", "relative")],
+        };
+        assert!(validate(&config).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        let config = HelpersConfig {
+            helpers: vec![spec("", "/bin/true")],
+        };
+        assert!(validate(&config).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_names() {
+        let config = HelpersConfig {
+            helpers: vec![spec("dup", "/bin/true"), spec("dup", "/bin/true")],
+        };
+        assert!(validate(&config).is_err());
+    }
+
+    #[test]
+    fn accepts_minimal_valid_config() {
+        let config = HelpersConfig {
+            helpers: vec![spec("h", "/bin/true")],
+        };
+        assert!(validate(&config).is_ok());
+    }
+
+    #[test]
+    fn parses_json_config() {
+        let json =
+            r#"{"helpers":[{"name":"m","command":["/bin/true"],"ambient_caps":["CAP_SETUID"]}]}"#;
+        let config: HelpersConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.helpers.len(), 1);
+        assert_eq!(config.helpers[0].name, "m");
+        assert_eq!(config.helpers[0].ambient_caps, vec!["CAP_SETUID"]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_caps_accepts_both_forms() {
+        let parsed = parse_caps(&["CAP_SETUID".into(), "setgid".into()]).unwrap();
+        assert_eq!(
+            parsed,
+            vec![caps::Capability::CAP_SETUID, caps::Capability::CAP_SETGID]
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_caps_rejects_unknown() {
+        assert!(parse_caps(&["CAP_NOPE".into()]).is_err());
+    }
+}

--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -9,6 +9,7 @@ pub mod bypass_monitor;
 mod child_env;
 pub mod denial_aggregator;
 mod grpc_client;
+pub mod helpers;
 mod identity;
 pub mod l7;
 pub mod log_push;
@@ -217,6 +218,7 @@ pub async fn run_sandbox(
     _health_check: bool,
     _health_port: u16,
     inference_routes: Option<String>,
+    helpers_config: Option<String>,
     ocsf_enabled: Arc<std::sync::atomic::AtomicBool>,
 ) -> Result<i32> {
     let (program, args) = command
@@ -248,6 +250,31 @@ pub async fn run_sandbox(
             debug!("OCSF context already initialized, keeping existing");
         }
     }
+
+    // Start supervisor helpers before anything else. Helpers run in the
+    // supervisor's full-capability, no-seccomp, no-NoNewPrivs context with
+    // operator-declared ambient caps — intended for small audited daemons
+    // (e.g. capability brokers) that the sandboxed workload will connect to
+    // via an approved Landlock path. We hold the handles for the lifetime
+    // of `run_sandbox` so that `kill_on_drop` reaps them on shutdown.
+    let _helper_handles = if let Some(path) = helpers_config.as_deref() {
+        let config = helpers::load_helpers_config(std::path::Path::new(path))?;
+        let handles = helpers::spawn_helpers(&config)?;
+        ocsf_emit!(
+            ConfigStateChangeBuilder::new(ocsf_ctx())
+                .severity(SeverityId::Informational)
+                .status(StatusId::Success)
+                .state(StateId::Enabled, "loaded")
+                .message(format!(
+                    "Supervisor helpers started [count:{}]",
+                    handles.len()
+                ))
+                .build()
+        );
+        handles
+    } else {
+        Vec::new()
+    };
 
     // Load policy and initialize OPA engine
     let openshell_endpoint_for_proxy = openshell_endpoint.clone();

--- a/crates/openshell-sandbox/src/main.rs
+++ b/crates/openshell-sandbox/src/main.rs
@@ -96,6 +96,14 @@ struct Args {
     /// Port for health check endpoint.
     #[arg(long, default_value = "8080")]
     health_port: u16,
+
+    /// Path to a JSON helpers config. Each listed helper is spawned before the
+    /// workload with its declared ambient capabilities, bypassing seccomp and
+    /// `PR_SET_NO_NEW_PRIVS`. Intended for small, audited daemons (capability
+    /// brokers, privileged bridges) that the workload will connect to via an
+    /// approved Landlock path.
+    #[arg(long, env = "OPENSHELL_HELPERS_CONFIG")]
+    helpers_config: Option<String>,
 }
 
 fn main() -> Result<()> {
@@ -234,6 +242,7 @@ fn main() -> Result<()> {
             args.health_check,
             args.health_port,
             args.inference_routes,
+            args.helpers_config,
             ocsf_enabled,
         )
         .await

--- a/docs/sandboxes/supervisor-helpers.mdx
+++ b/docs/sandboxes/supervisor-helpers.mdx
@@ -1,0 +1,105 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Supervisor Helpers"
+sidebar-title: "Supervisor Helpers"
+description: "Declare privileged helper processes that run alongside the sandboxed workload."
+keywords: "OpenShell, Sandbox, Linux Capabilities, Privileged Helper, Capability Broker"
+position: 7
+---
+
+Supervisor helpers are small, operator-audited daemons that run inside the sandbox pod alongside the workload. They are spawned by the supervisor before the workload and are not subject to the per-workload seccomp filter, `PR_SET_NO_NEW_PRIVS`, or Landlock. Use them for capabilities the workload must not hold directly — for example, a capability broker that sets up per-request isolation, or a privileged bridge to a local control socket.
+
+The workload itself remains sandboxed exactly as before. The trust boundary is the supervisor, and the operator vouches for each helper binary shipped in the image.
+
+## When to Use a Helper
+
+Consider a helper when a daemon needs a Linux capability that the workload is not allowed to hold. A workload with `PR_SET_NO_NEW_PRIVS` set cannot gain capabilities via file caps at `execve`, so the supervisor must hand capabilities to the helper directly. Typical use cases:
+
+- A capability broker that creates per-request user namespaces on behalf of the workload.
+- A privileged IPC bridge holding `CAP_NET_ADMIN` for traffic shaping.
+- A pre-seccomp setup daemon that mediates access to a resource the workload cannot open itself.
+
+If the workload can do the job itself inside its own policy surface, it should.
+
+## Declare Helpers
+
+Write a JSON config and pass its path on startup:
+
+```shell
+openshell-sandbox --helpers-config /etc/openshell/helpers.json -- my-workload
+```
+
+The flag is also bound to `OPENSHELL_HELPERS_CONFIG`.
+
+### Config Schema
+
+```json
+{
+  "helpers": [
+    {
+      "name": "example-broker",
+      "command": ["/opt/example/bin/broker", "--socket", "/var/run/example.sock"],
+      "env": {
+        "RUST_LOG": "info"
+      },
+      "ambient_caps": ["CAP_SETUID", "CAP_SETGID", "CAP_NET_ADMIN"]
+    }
+  ]
+}
+```
+
+| Field | Required | Meaning |
+|---|---|---|
+| `name` | yes | Human-readable name used in logs and OCSF events. Must be unique. |
+| `command` | yes | Full argv. `command[0]` must be an absolute path; the supervisor does not consult `$PATH`. |
+| `env` | no | Environment variables merged on top of the supervisor's environment. |
+| `ambient_caps` | no | Capabilities raised into the helper's ambient set before `execve`. Names accept `CAP_FOO` or `FOO`, case-insensitive. |
+
+Validation rejects empty names, duplicate names, empty commands, non-absolute `command[0]`, and unknown capability names. A helper that requests a capability outside the pod's bounding set fails at `capset(2)` with `EPERM` and the supervisor exits before the workload starts.
+
+## Runtime Behavior
+
+For each helper, in declaration order, the supervisor forks, raises the declared capabilities into the child's inheritable and ambient sets, and `execve`s the command. After `execve` the ambient set becomes part of the helper's permitted and effective sets.
+
+Helpers are spawned with `kill_on_drop(true)`. When the supervisor exits for any reason, the helper receives `SIGKILL`. The v0 release does not include structured shutdown, restart policy, or readiness gating.
+
+### What Helpers Do Not Get
+
+Helpers intentionally bypass the workload sandbox. They do not receive:
+
+- The per-workload seccomp filter.
+- `PR_SET_NO_NEW_PRIVS`.
+- Landlock filesystem restrictions.
+- The privilege drop applied to the workload (a helper keeps the supervisor's uid — typically 0).
+
+Helper containment is bounded by the pod's `securityContext` — the bounding set and the capabilities granted to the supervisor — plus whatever restrictions the helper binary applies to itself.
+
+## Security Model
+
+The trust boundary is the supervisor. A compromised supervisor was always catastrophic; letting it fork a declared set of other root-capable processes from a config file does not expand that blast radius. What does change is operator responsibility:
+
+- The `--helpers-config` path and its contents are part of the image's attack surface. Audit every helper binary and every capability it receives.
+- Helpers and the workload share the pod's filesystem. The v0 release does not offer per-helper Landlock isolation — a cap-less helper could read workload-writable paths, and vice versa. Helpers that need file-level isolation should apply it themselves.
+- The SSH handshake secret (`OPENSHELL_SSH_HANDSHAKE_SECRET`) is scrubbed from the helper's inherited environment.
+
+## Observability
+
+Each helper start emits an OCSF `AppLifecycle` event with `activity=Start`, `severity=Informational`, `status=Success`, and a message containing the helper name and pid. Structured helper stdout routing is deferred to a later release.
+
+## Interactions
+
+- **Policy.** Helpers sit outside the policy surface. OPA rules, network policy, and Landlock apply to the workload, not to helpers. A helper that needs to reach the policy-enforced proxy must speak HTTP to it like any other process.
+- **DNS proxy.** The existing hardcoded DNS proxy is unchanged. Future work may migrate it onto supervisor helpers.
+
+## Out of Scope for v0
+
+The following are additive on the v0 schema and tracked for future iterations:
+
+- Per-helper Landlock (`readOnly`, `readWrite`, `readExec`).
+- Workload rendezvous for connect-only access to a helper-owned socket.
+- Structured restart policy.
+- Readiness file descriptor convention for "helper is live" gating.
+- Helper stdio routing into the OCSF JSONL stream.
+- Per-helper cgroup resource limits.
+- Dropping the helper to a non-root uid while retaining requested capabilities.


### PR DESCRIPTION
## Summary

Add supervisor helpers v0: declarative long-lived helper processes that the sandbox supervisor starts before the workload and keeps alive for the sandbox lifetime.

Helpers run as supervisor children, outside the per-workload sandbox path, so they can use operator-declared ambient capabilities that the workload cannot retain after `PR_SET_NO_NEW_PRIVS`, Landlock, seccomp, and privilege drop are applied. The workload sandboxing behavior is unchanged; helpers are an additive, opt-in supervisor feature loaded through `--helpers-config <path>` or `OPENSHELL_HELPERS_CONFIG`.

This complements #775. The boot hook covers one-shot initialization. Supervisor helpers cover long-lived sidecar daemons with explicit capability grants.

## Related Issue

Related to #775.

## Motivation

Some sandbox deployments need a privileged daemon inside the pod that the sandboxed workload can reach through an approved Landlock path, usually a Unix domain socket.

Examples:

- Capability brokers that perform per-request UID or network namespace setup for the workload and need capabilities such as `CAP_SETUID`, `CAP_SETGID`, and `CAP_NET_ADMIN`.
- Local infrastructure daemons, such as an inference gateway, that should run beside the sandboxed workload while sharing the pod environment.

The existing mechanisms do not fit this shape. The Kubernetes driver overrides `ENTRYPOINT`; a sidecar pod does not share the sandbox network namespace; and file capabilities are stripped from the workload path by `PR_SET_NO_NEW_PRIVS`.

Spawning audited helpers from the supervisor before the workload starts keeps the privilege boundary explicit. The supervisor is already in the trusted computing base, and each helper binary plus its requested capabilities are declared in operator-controlled config.

## API

```json
{
  "helpers": [
    {
      "name": "capability-broker",
      "command": ["/usr/local/libexec/broker", "--arg"],
      "env": { "RUN_UID": "998" },
      "ambient_caps": ["CAP_SETUID", "CAP_SETGID", "CAP_NET_ADMIN"]
    }
  ]
}
```

- `name`: unique helper name used in logs and OCSF `AppLifecycle` events.
- `command[0]`: absolute executable path. No `$PATH` lookup is performed.
- `env`: merged on top of the supervisor environment. `OPENSHELL_SSH_HANDSHAKE_SECRET` is scrubbed before merge, and `OPENSHELL_SUPERVISOR_HELPER=<name>` is always injected.
- `ambient_caps`: capabilities raised through the `caps` crate in the child pre-exec path. Each requested capability must already be in the supervisor's permitted set.

Helpers start in declaration order before the workload. Process handles are retained for the lifetime of `run_sandbox` with `kill_on_drop(true)` so supervisor shutdown reaps helper processes.

## Changes

- Added `crates/openshell-sandbox/src/helpers.rs` with `HelpersConfig`, `HelperSpec`, `load_helpers_config`, and `spawn_helpers`.
- Added Linux helper spawning with ambient capability raising through the `caps` crate.
- Added validation for empty names, duplicate names, empty commands, relative executable paths, and unknown capability names.
- Wired helper startup into `run_sandbox` before policy load and retained helper handles for the sandbox lifetime.
- Added an OCSF `ConfigStateChange` event when helper config is loaded.
- Added `--helpers-config` and `OPENSHELL_HELPERS_CONFIG`.
- Added the `caps` dependency.

## Testing

- [x] `mise run pre-commit`
- [x] Unit tests for helper config validation and capability parsing
- [x] Manual live k3s validation with two helpers: a capability broker using `CAP_SETUID`, `CAP_SETGID`, and `CAP_NET_ADMIN`, plus a sidecar daemon
- [ ] Dedicated helper E2E coverage

Manual validation confirmed that helpers spawn before the workload, OCSF `AppLifecycle[Reset]` events emit, and `kill_on_drop` reaps helper processes on supervisor shutdown.

Helper-originated CONNECT peer attribution exposed a separate `procfs::parse_proc_net_tcp` bug. That fix is staged in the follow-up branch.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
