### PR TITLE
fix(sandbox): deny ambiguous socket ownership

### DIFF
--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -585,7 +585,7 @@ The proxy port defaults to `3128` unless the policy specifies a different `http_
 1. Opens `/dev/kmsg` in read mode and seeks to end (skips historical messages)
 2. Reads lines via `BufReader`, filtering for the namespace-specific prefix `openshell:bypass:{namespace_name}:`
 3. Parses iptables LOG format via `parse_kmsg_line()`, extracting `DST`, `DPT`, `SPT`, `PROTO`, and `UID` fields
-4. Resolves process identity for TCP events via `procfs::resolve_tcp_peer_identity()` (best-effort — requires a valid entrypoint PID and non-zero source port)
+4. Resolves process identity for TCP events via multi-owner socket inode lookup (best-effort — requires a valid entrypoint PID and non-zero source port). If multiple processes hold the same socket with different executable identities, the event is marked ambiguous instead of attributing it to one PID.
 5. Emits a structured `tracing::warn!()` event with the tag `BYPASS_DETECT`
 6. Sends a `DenialEvent` to the denial aggregator channel (if available)
 
@@ -1265,21 +1265,25 @@ The TOFU model means:
 
 The proxy resolves which binary is making each network request by inspecting `/proc`.
 
-**`resolve_tcp_peer_identity(entrypoint_pid, peer_port) -> (PathBuf, u32)`**
+**`resolve_tcp_peer_socket_owners(entrypoint_pid, peer_port) -> TcpPeerSocketOwners`**
 
 ```mermaid
 flowchart TD
     A["Parse /proc/{entrypoint}/net/tcp + tcp6"] --> B[Find ESTABLISHED socket with matching local port]
     B --> C[Extract socket inode]
-    C --> D["BFS collect descendants of entrypoint via /proc/{pid}/task/{tid}/children"]
-    D --> E["Scan /proc/{pid}/fd/* for socket:[inode] symlink"]
-    E --> F{Found?}
-    F -- Yes --> G["Read /proc/{pid}/exe -> binary path"]
-    F -- No --> H["Fallback: scan all /proc PIDs"]
-    H --> G
+    C --> D["BFS collect descendants of entrypoint via /proc/{pid}/task/{tid}/children, deduping PIDs"]
+    D --> E["Scan every descendant /proc/{pid}/fd/* for socket:[inode] symlink"]
+    E --> F["Fallback: scan all /proc PIDs not already checked"]
+    F --> G["Return all socket owner PIDs with source/depth metadata"]
+    G --> H["Read /proc/{pid}/exe, TOFU-check each owner and ancestor"]
+    H --> I{All owners same policy identity?}
+    I -- Yes --> J["Evaluate OPA once with the shared identity"]
+    I -- No --> K["Deny as ambiguous shared socket ownership"]
 ```
 
 Both IPv4 (`/proc/{pid}/net/tcp`) and IPv6 (`/proc/{pid}/net/tcp6`) tables are checked because some clients (notably gRPC C-core) use `AF_INET6` sockets with IPv4-mapped addresses.
+
+Multiple processes can hold the same socket inode after `fork()` or fd inheritance across `execve()`. The proxy treats that as ambiguous unless all socket owners resolve to the same policy identity: binary path, TOFU hash, ancestor chain, and cmdline-derived absolute paths. Ambiguous ownership is denied before OPA evaluation so a trusted co-owner cannot accidentally authorize traffic for a different process.
 
 **`collect_ancestor_binaries(pid, stop_pid) -> Vec<PathBuf>`**: Walk the PPid chain via `/proc/{pid}/status`, collecting `binary_path()` for each ancestor. Stops at PID 1, `stop_pid` (entrypoint), or after 64 levels (safety limit). Does not include `pid` itself.
 

--- a/crates/openshell-sandbox/src/bypass_monitor.rs
+++ b/crates/openshell-sandbox/src/bypass_monitor.rs
@@ -300,9 +300,59 @@ fn resolve_process_identity(entrypoint_pid: u32, src_port: u16) -> (String, Stri
     {
         use crate::procfs;
 
-        match procfs::resolve_tcp_peer_identity(entrypoint_pid, src_port) {
-            Ok((binary_path, pid)) => {
-                let ancestors = procfs::collect_ancestor_binaries(pid, entrypoint_pid);
+        match procfs::resolve_tcp_peer_socket_owners(entrypoint_pid, src_port) {
+            Ok(socket_owners) => {
+                let mut identities = Vec::new();
+                for owner in &socket_owners.owners {
+                    let Ok(binary_path) = procfs::binary_path(owner.pid.cast_signed()) else {
+                        continue;
+                    };
+                    let ancestors = procfs::collect_ancestor_binaries(owner.pid, entrypoint_pid);
+                    identities.push((owner.pid, binary_path, ancestors));
+                }
+
+                if identities.is_empty() {
+                    return ("-".to_string(), "-".to_string(), "-".to_string());
+                }
+
+                identities.sort_by_key(|(pid, _, _)| *pid);
+                let first_identity = (identities[0].1.clone(), identities[0].2.clone());
+                let ambiguous = identities
+                    .iter()
+                    .skip(1)
+                    .any(|(_, binary_path, ancestors)| {
+                        binary_path != &first_identity.0 || ancestors != &first_identity.1
+                    });
+
+                if ambiguous {
+                    let pids = identities
+                        .iter()
+                        .map(|(pid, _, _)| pid.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let owner_summary = identities
+                        .iter()
+                        .map(|(pid, binary_path, ancestors)| {
+                            let ancestors_str = if ancestors.is_empty() {
+                                "-".to_string()
+                            } else {
+                                ancestors
+                                    .iter()
+                                    .map(|p| p.display().to_string())
+                                    .collect::<Vec<_>>()
+                                    .join(" -> ")
+                            };
+                            format!(
+                                "pid={pid} binary={} ancestors=[{ancestors_str}]",
+                                binary_path.display()
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    return ("ambiguous".to_string(), pids, owner_summary);
+                }
+
+                let (pid, binary_path, ancestors) = identities.remove(0);
                 let ancestors_str = if ancestors.is_empty() {
                     "-".to_string()
                 } else {
@@ -443,6 +493,80 @@ mod tests {
             uid: None,
         };
         assert!(hint_for_event(&event).contains("UDP"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_process_identity_surfaces_ambiguous_shared_socket() {
+        use std::ffi::CString;
+        use std::net::{TcpListener, TcpStream};
+        use std::os::fd::AsRawFd;
+        use std::time::{Duration, Instant};
+
+        if !std::path::Path::new("/bin/sleep").exists() {
+            eprintln!("skipping: /bin/sleep not available");
+            return;
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let listener_port = listener.local_addr().unwrap().port();
+        let stream = TcpStream::connect(("127.0.0.1", listener_port)).expect("connect");
+        let peer_port = stream.local_addr().unwrap().port();
+        let (_accepted, _) = listener.accept().expect("accept");
+
+        let fd = stream.as_raw_fd();
+        unsafe {
+            let flags = libc::fcntl(fd, libc::F_GETFD);
+            assert!(flags >= 0, "F_GETFD failed");
+            assert_eq!(
+                libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC),
+                0,
+                "F_SETFD failed"
+            );
+        }
+
+        let sleep_path = CString::new("/bin/sleep").unwrap();
+        let arg0 = CString::new("sleep").unwrap();
+        let arg1 = CString::new("30").unwrap();
+        let child_pid = unsafe { libc::fork() };
+        assert!(child_pid >= 0, "fork failed");
+        if child_pid == 0 {
+            unsafe {
+                libc::execl(
+                    sleep_path.as_ptr(),
+                    arg0.as_ptr(),
+                    arg1.as_ptr(),
+                    std::ptr::null::<libc::c_char>(),
+                );
+                libc::_exit(127);
+            }
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if let Ok(link) = std::fs::read_link(format!("/proc/{child_pid}/exe"))
+                && link.to_string_lossy().contains("sleep")
+            {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "child pid {child_pid} did not exec into sleep within 2s"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        let (binary, pid, ancestors) = resolve_process_identity(std::process::id(), peer_port);
+
+        unsafe {
+            libc::kill(child_pid, libc::SIGKILL);
+            libc::waitpid(child_pid, std::ptr::null_mut(), 0);
+        }
+
+        assert_eq!(binary, "ambiguous");
+        assert!(pid.contains(&std::process::id().to_string()));
+        assert!(pid.contains(&child_pid.to_string()));
+        assert!(ancestors.contains("binary="));
     }
 
     #[test]

--- a/crates/openshell-sandbox/src/procfs.rs
+++ b/crates/openshell-sandbox/src/procfs.rs
@@ -7,10 +7,45 @@
 //! for process-identity binding in the OPA proxy policy engine.
 
 use miette::Result;
+#[cfg(target_os = "linux")]
+use std::collections::HashSet;
 use std::path::Path;
 #[cfg(target_os = "linux")]
 use std::path::PathBuf;
 use tracing::debug;
+
+/// Where a socket owner was discovered while scanning `/proc`.
+#[cfg(target_os = "linux")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SocketOwnerSource {
+    /// Owner was found in the entrypoint process tree at the given BFS depth.
+    Descendant { depth: usize },
+    /// Owner was found by scanning all of `/proc` after the descendant scan.
+    ProcFallback,
+}
+
+/// A process with an fd pointing at a target socket inode.
+#[cfg(target_os = "linux")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SocketOwner {
+    pub pid: u32,
+    pub source: SocketOwnerSource,
+}
+
+/// All process owners for a TCP peer socket.
+#[cfg(target_os = "linux")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TcpPeerSocketOwners {
+    pub inode: u64,
+    pub owners: Vec<SocketOwner>,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DescendantPid {
+    pid: u32,
+    depth: usize,
+}
 
 /// Read the binary path of a process via `/proc/{pid}/exe` symlink.
 ///
@@ -85,9 +120,44 @@ pub fn binary_path(pid: i32) -> Result<PathBuf> {
 /// that socket, and finally reads `/proc/<pid>/exe` to get the binary path.
 #[cfg(target_os = "linux")]
 pub fn resolve_tcp_peer_binary(entrypoint_pid: u32, peer_port: u16) -> Result<PathBuf> {
+    let owner = resolve_single_tcp_peer_owner(entrypoint_pid, peer_port)?;
+    binary_path(owner.pid.cast_signed())
+}
+
+/// Resolve all process owners for the TCP peer inside a sandbox network namespace.
+///
+/// Multiple processes can legitimately hold the same socket inode after `fork()`
+/// or fd passing. Callers that make security decisions must evaluate the full
+/// owner set instead of selecting the first PID returned by `/proc` traversal.
+#[cfg(target_os = "linux")]
+pub fn resolve_tcp_peer_socket_owners(
+    entrypoint_pid: u32,
+    peer_port: u16,
+) -> Result<TcpPeerSocketOwners> {
     let inode = parse_proc_net_tcp(entrypoint_pid, peer_port)?;
-    let pid = find_pid_by_socket_inode(inode, entrypoint_pid)?;
-    binary_path(pid.cast_signed())
+    let owners = find_socket_inode_owners(inode, entrypoint_pid)?;
+    Ok(TcpPeerSocketOwners { inode, owners })
+}
+
+/// Resolve exactly one owner for the TCP peer, failing closed on ambiguity.
+#[cfg(target_os = "linux")]
+fn resolve_single_tcp_peer_owner(entrypoint_pid: u32, peer_port: u16) -> Result<SocketOwner> {
+    let socket_owners = resolve_tcp_peer_socket_owners(entrypoint_pid, peer_port)?;
+    match socket_owners.owners.as_slice() {
+        [owner] => Ok(owner.clone()),
+        owners => {
+            let mut pids: Vec<u32> = owners.iter().map(|owner| owner.pid).collect();
+            pids.sort_unstable();
+            Err(miette::miette!(
+                "Ambiguous socket ownership for inode {}: PIDs [{}] all hold the same socket",
+                socket_owners.inode,
+                pids.iter()
+                    .map(u32::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))
+        }
+    }
 }
 
 /// Like `resolve_tcp_peer_binary`, but also returns the PID that owns the socket.
@@ -95,10 +165,9 @@ pub fn resolve_tcp_peer_binary(entrypoint_pid: u32, peer_port: u16) -> Result<Pa
 /// Needed for the ancestor walk: we must know the PID to walk `/proc/<pid>/status` PPid chain.
 #[cfg(target_os = "linux")]
 pub fn resolve_tcp_peer_identity(entrypoint_pid: u32, peer_port: u16) -> Result<(PathBuf, u32)> {
-    let inode = parse_proc_net_tcp(entrypoint_pid, peer_port)?;
-    let pid = find_pid_by_socket_inode(inode, entrypoint_pid)?;
-    let path = binary_path(pid.cast_signed())?;
-    Ok((path, pid))
+    let owner = resolve_single_tcp_peer_owner(entrypoint_pid, peer_port)?;
+    let path = binary_path(owner.pid.cast_signed())?;
+    Ok((path, owner.pid))
 }
 
 /// Read the `PPid` (parent PID) from `/proc/<pid>/status`.
@@ -267,40 +336,59 @@ fn parse_proc_net_tcp(pid: u32, peer_port: u16) -> Result<u64> {
     ))
 }
 
-/// Scan process tree to find which PID owns a given socket inode.
+/// Scan `/proc` to find every PID that owns a given socket inode.
 ///
 /// First scans descendants of `entrypoint_pid` (most likely owners), then falls
 /// back to scanning all of `/proc`. Requires `CAP_SYS_PTRACE` to read
 /// `/proc/<pid>/fd/` for processes running as a different user.
 #[cfg(target_os = "linux")]
-fn find_pid_by_socket_inode(inode: u64, entrypoint_pid: u32) -> Result<u32> {
+fn find_socket_inode_owners(inode: u64, entrypoint_pid: u32) -> Result<Vec<SocketOwner>> {
     let target = format!("socket:[{inode}]");
+    let mut owners = Vec::new();
+    let mut checked = HashSet::new();
 
     // First: scan descendants of the entrypoint process
-    let descendants = collect_descendant_pids(entrypoint_pid);
+    let descendants = collect_descendant_pids_with_depth(entrypoint_pid);
 
-    for &pid in &descendants {
-        if let Some(found) = check_pid_fds(pid, &target) {
-            return Ok(found);
+    for descendant in &descendants {
+        checked.insert(descendant.pid);
+        if check_pid_fds(descendant.pid, &target) {
+            owners.push(SocketOwner {
+                pid: descendant.pid,
+                source: SocketOwnerSource::Descendant {
+                    depth: descendant.depth,
+                },
+            });
         }
     }
 
     // Fallback: scan all of /proc in case the process isn't in the tree
     if let Ok(proc_dir) = std::fs::read_dir("/proc") {
+        let mut proc_pids = Vec::new();
         for entry in proc_dir.flatten() {
             let name = entry.file_name();
-            let pid: u32 = match name.to_string_lossy().parse() {
-                Ok(p) => p,
-                Err(_) => continue,
-            };
-            // Skip PIDs we already checked
-            if descendants.contains(&pid) {
-                continue;
-            }
-            if let Some(found) = check_pid_fds(pid, &target) {
-                return Ok(found);
+            if let Ok(pid) = name.to_string_lossy().parse::<u32>() {
+                proc_pids.push(pid);
             }
         }
+        proc_pids.sort_unstable();
+
+        for pid in proc_pids {
+            if checked.contains(&pid) {
+                continue;
+            }
+            checked.insert(pid);
+            if check_pid_fds(pid, &target) {
+                owners.push(SocketOwner {
+                    pid,
+                    source: SocketOwnerSource::ProcFallback,
+                });
+            }
+        }
+    }
+
+    if !owners.is_empty() {
+        return Ok(owners);
     }
 
     Err(miette::miette!(
@@ -316,17 +404,19 @@ fn find_pid_by_socket_inode(inode: u64, entrypoint_pid: u32) -> Result<u32> {
 
 /// Check if a PID has an fd pointing to the given socket target string.
 #[cfg(target_os = "linux")]
-fn check_pid_fds(pid: u32, target: &str) -> Option<u32> {
+fn check_pid_fds(pid: u32, target: &str) -> bool {
     let fd_dir = format!("/proc/{pid}/fd");
-    let fds = std::fs::read_dir(&fd_dir).ok()?;
+    let Some(fds) = std::fs::read_dir(&fd_dir).ok() else {
+        return false;
+    };
     for fd_entry in fds.flatten() {
         if let Ok(link) = std::fs::read_link(fd_entry.path())
             && link.to_string_lossy() == target
         {
-            return Some(pid);
+            return true;
         }
     }
-    None
+    false
 }
 
 /// Collect all descendant PIDs of a root process using `/proc/<pid>/task/<tid>/children`.
@@ -335,18 +425,37 @@ fn check_pid_fds(pid: u32, target: &str) -> Option<u32> {
 /// is not available (requires `CONFIG_PROC_CHILDREN`), returns only the root PID.
 #[cfg(target_os = "linux")]
 fn collect_descendant_pids(root_pid: u32) -> Vec<u32> {
-    let mut pids = vec![root_pid];
+    collect_descendant_pids_with_depth(root_pid)
+        .into_iter()
+        .map(|descendant| descendant.pid)
+        .collect()
+}
+
+/// Collect descendant PIDs with BFS depth, deduping children reported by multiple tasks.
+#[cfg(target_os = "linux")]
+fn collect_descendant_pids_with_depth(root_pid: u32) -> Vec<DescendantPid> {
+    let mut pids = vec![DescendantPid {
+        pid: root_pid,
+        depth: 0,
+    }];
+    let mut seen = HashSet::from([root_pid]);
     let mut i = 0;
     while i < pids.len() {
-        let pid = pids[i];
+        let pid = pids[i].pid;
+        let child_depth = pids[i].depth + 1;
         let task_dir = format!("/proc/{pid}/task");
         if let Ok(tasks) = std::fs::read_dir(&task_dir) {
             for task_entry in tasks.flatten() {
                 let children_path = task_entry.path().join("children");
                 if let Ok(children_str) = std::fs::read_to_string(&children_path) {
                     for child in children_str.split_whitespace() {
-                        if let Ok(child_pid) = child.parse::<u32>() {
-                            pids.push(child_pid);
+                        if let Ok(child_pid) = child.parse::<u32>()
+                            && seen.insert(child_pid)
+                        {
+                            pids.push(DescendantPid {
+                                pid: child_pid,
+                                depth: child_depth,
+                            });
                         }
                     }
                 }
@@ -636,6 +745,75 @@ mod tests {
         let pid = std::process::id();
         let pids = collect_descendant_pids(pid);
         assert!(pids.contains(&pid));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn collect_descendants_dedupes_pids() {
+        let pid = std::process::id();
+        let pids = collect_descendant_pids(pid);
+        let unique = pids
+            .iter()
+            .copied()
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(pids.len(), unique.len());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_tcp_peer_socket_owners_returns_all_forked_socket_holders() {
+        use std::net::{TcpListener, TcpStream};
+        use std::time::{Duration, Instant};
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let listener_port = listener.local_addr().unwrap().port();
+        let stream = TcpStream::connect(("127.0.0.1", listener_port)).expect("connect");
+        let peer_port = stream.local_addr().unwrap().port();
+        let (_accepted, _) = listener.accept().expect("accept");
+
+        let child_pid = unsafe { libc::fork() };
+        assert!(child_pid >= 0, "fork failed");
+        if child_pid == 0 {
+            unsafe {
+                libc::sleep(30);
+                libc::_exit(0);
+            }
+        }
+
+        let child_pid_u32 = child_pid as u32;
+        let entrypoint_pid = std::process::id();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let owners = loop {
+            let owners = resolve_tcp_peer_socket_owners(entrypoint_pid, peer_port)
+                .expect("resolve socket owners");
+            let owner_pids = owners
+                .owners
+                .iter()
+                .map(|owner| owner.pid)
+                .collect::<std::collections::HashSet<_>>();
+            if owner_pids.contains(&entrypoint_pid) && owner_pids.contains(&child_pid_u32) {
+                break owners;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for forked child to appear as a socket owner; got {:?}",
+                owner_pids
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        };
+
+        unsafe {
+            libc::kill(child_pid, libc::SIGKILL);
+            libc::waitpid(child_pid, std::ptr::null_mut(), 0);
+        }
+
+        let owner_pids = owners
+            .owners
+            .iter()
+            .map(|owner| owner.pid)
+            .collect::<std::collections::HashSet<_>>();
+        assert!(owner_pids.contains(&entrypoint_pid));
+        assert!(owner_pids.contains(&child_pid_u32));
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -907,6 +907,27 @@ struct ResolvedIdentity {
     bin_hash: String,
 }
 
+#[cfg(target_os = "linux")]
+#[derive(Debug, Eq, PartialEq)]
+struct PolicyIdentityKey {
+    bin_path: PathBuf,
+    ancestors: Vec<PathBuf>,
+    cmdline_paths: Vec<PathBuf>,
+    bin_hash: String,
+}
+
+#[cfg(target_os = "linux")]
+impl ResolvedIdentity {
+    fn policy_key(&self) -> PolicyIdentityKey {
+        PolicyIdentityKey {
+            bin_path: self.bin_path.clone(),
+            ancestors: self.ancestors.clone(),
+            cmdline_paths: self.cmdline_paths.clone(),
+            bin_hash: self.bin_hash.clone(),
+        }
+    }
+}
+
 /// Error from [`resolve_process_identity`]. Carries the deny reason and
 /// whatever partial identity data was resolved before the failure so the
 /// caller can include it in the [`ConnectDecision`] and OCSF event.
@@ -918,12 +939,64 @@ struct IdentityError {
     ancestors: Vec<PathBuf>,
 }
 
+#[cfg(target_os = "linux")]
+fn resolve_owner_identity(
+    owner_pid: u32,
+    entrypoint_pid: u32,
+    identity_cache: &BinaryIdentityCache,
+) -> std::result::Result<ResolvedIdentity, IdentityError> {
+    let bin_path =
+        crate::procfs::binary_path(owner_pid.cast_signed()).map_err(|e| IdentityError {
+            reason: format!("failed to resolve peer binary for PID {owner_pid}: {e}"),
+            binary: None,
+            binary_pid: Some(owner_pid),
+            ancestors: vec![],
+        })?;
+
+    let bin_hash = identity_cache
+        .verify_or_cache(&bin_path)
+        .map_err(|e| IdentityError {
+            reason: format!("binary integrity check failed: {e}"),
+            binary: Some(bin_path.clone()),
+            binary_pid: Some(owner_pid),
+            ancestors: vec![],
+        })?;
+
+    let ancestors = crate::procfs::collect_ancestor_binaries(owner_pid, entrypoint_pid);
+
+    for ancestor in &ancestors {
+        identity_cache
+            .verify_or_cache(ancestor)
+            .map_err(|e| IdentityError {
+                reason: format!(
+                    "ancestor integrity check failed for {}: {e}",
+                    ancestor.display()
+                ),
+                binary: Some(bin_path.clone()),
+                binary_pid: Some(owner_pid),
+                ancestors: ancestors.clone(),
+            })?;
+    }
+
+    let mut exclude = ancestors.clone();
+    exclude.push(bin_path.clone());
+    let cmdline_paths = crate::procfs::collect_cmdline_paths(owner_pid, entrypoint_pid, &exclude);
+
+    Ok(ResolvedIdentity {
+        bin_path,
+        binary_pid: owner_pid,
+        ancestors,
+        cmdline_paths,
+        bin_hash,
+    })
+}
+
 /// Resolve the identity of the process owning a TCP peer connection.
 ///
 /// Walks `/proc/<entrypoint_pid>/net/tcp` to find the socket inode, locates
-/// the owning PID, reads `/proc/<pid>/exe`, TOFU-verifies the binary hash,
-/// walks the ancestor chain verifying each one, and collects cmdline-derived
-/// absolute paths for script detection.
+/// every owning PID, reads `/proc/<pid>/exe`, TOFU-verifies each binary hash,
+/// walks each ancestor chain verifying every ancestor, and collects
+/// cmdline-derived absolute paths for script detection.
 ///
 /// This is the identity-resolution block of [`evaluate_opa_tcp`] extracted
 /// into a standalone helper so it can be exercised by Linux-only regression
@@ -937,52 +1010,66 @@ fn resolve_process_identity(
     peer_port: u16,
     identity_cache: &BinaryIdentityCache,
 ) -> std::result::Result<ResolvedIdentity, IdentityError> {
-    let (bin_path, binary_pid) =
-        crate::procfs::resolve_tcp_peer_identity(entrypoint_pid, peer_port).map_err(|e| {
-            IdentityError {
-                reason: format!("failed to resolve peer binary: {e}"),
-                binary: None,
-                binary_pid: None,
-                ancestors: vec![],
-            }
-        })?;
-
-    let bin_hash = identity_cache
-        .verify_or_cache(&bin_path)
+    let socket_owners = crate::procfs::resolve_tcp_peer_socket_owners(entrypoint_pid, peer_port)
         .map_err(|e| IdentityError {
-            reason: format!("binary integrity check failed: {e}"),
-            binary: Some(bin_path.clone()),
-            binary_pid: Some(binary_pid),
+            reason: format!("failed to resolve peer binary: {e}"),
+            binary: None,
+            binary_pid: None,
             ancestors: vec![],
         })?;
 
-    let ancestors = crate::procfs::collect_ancestor_binaries(binary_pid, entrypoint_pid);
-
-    for ancestor in &ancestors {
-        identity_cache
-            .verify_or_cache(ancestor)
-            .map_err(|e| IdentityError {
-                reason: format!(
-                    "ancestor integrity check failed for {}: {e}",
-                    ancestor.display()
-                ),
-                binary: Some(bin_path.clone()),
-                binary_pid: Some(binary_pid),
-                ancestors: ancestors.clone(),
-            })?;
+    let mut identities = Vec::with_capacity(socket_owners.owners.len());
+    for owner in &socket_owners.owners {
+        identities.push(resolve_owner_identity(
+            owner.pid,
+            entrypoint_pid,
+            identity_cache,
+        )?);
     }
 
-    let mut exclude = ancestors.clone();
-    exclude.push(bin_path.clone());
-    let cmdline_paths = crate::procfs::collect_cmdline_paths(binary_pid, entrypoint_pid, &exclude);
+    let Some(first_identity) = identities.first() else {
+        return Err(IdentityError {
+            reason: format!(
+                "failed to resolve peer binary: no process found owning socket inode {}",
+                socket_owners.inode
+            ),
+            binary: None,
+            binary_pid: None,
+            ancestors: vec![],
+        });
+    };
 
-    Ok(ResolvedIdentity {
-        bin_path,
-        binary_pid,
-        ancestors,
-        cmdline_paths,
-        bin_hash,
-    })
+    let first_key = first_identity.policy_key();
+    if identities
+        .iter()
+        .skip(1)
+        .any(|identity| identity.policy_key() != first_key)
+    {
+        let mut pids: Vec<u32> = identities
+            .iter()
+            .map(|identity| identity.binary_pid)
+            .collect();
+        pids.sort_unstable();
+        return Err(IdentityError {
+            reason: format!(
+                "ambiguous shared socket ownership: inode {} is held by PIDs [{}] with different policy identities",
+                socket_owners.inode,
+                pids.iter()
+                    .map(u32::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            binary: None,
+            binary_pid: None,
+            ancestors: vec![],
+        });
+    }
+
+    let mut identity = identities.swap_remove(0);
+    if let Some(lowest_pid) = socket_owners.owners.iter().map(|owner| owner.pid).min() {
+        identity.binary_pid = lowest_pid;
+    }
+    Ok(identity)
 }
 
 /// Evaluate OPA policy for a TCP connection with identity binding via /proc/net/tcp.
@@ -4266,6 +4353,101 @@ mod tests {
                         path.display()
                     );
                 }
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_process_identity_denies_fork_exec_shared_socket_ambiguity() {
+        use crate::identity::BinaryIdentityCache;
+        use std::ffi::CString;
+        use std::net::{TcpListener, TcpStream};
+        use std::os::fd::AsRawFd;
+        use std::time::{Duration, Instant};
+
+        if !std::path::Path::new("/bin/sleep").exists() {
+            eprintln!("skipping: /bin/sleep not available");
+            return;
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let listener_port = listener.local_addr().unwrap().port();
+        let stream = TcpStream::connect(("127.0.0.1", listener_port)).expect("connect");
+        let peer_port = stream.local_addr().unwrap().port();
+        let (_accepted, _) = listener.accept().expect("accept");
+
+        let fd = stream.as_raw_fd();
+        unsafe {
+            let flags = libc::fcntl(fd, libc::F_GETFD);
+            assert!(flags >= 0, "F_GETFD failed");
+            assert_eq!(
+                libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC),
+                0,
+                "F_SETFD failed"
+            );
+        }
+
+        let sleep_path = CString::new("/bin/sleep").unwrap();
+        let arg0 = CString::new("sleep").unwrap();
+        let arg1 = CString::new("30").unwrap();
+        let child_pid = unsafe { libc::fork() };
+        assert!(child_pid >= 0, "fork failed");
+        if child_pid == 0 {
+            unsafe {
+                libc::execl(
+                    sleep_path.as_ptr(),
+                    arg0.as_ptr(),
+                    arg1.as_ptr(),
+                    std::ptr::null::<libc::c_char>(),
+                );
+                libc::_exit(127);
+            }
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if let Ok(link) = std::fs::read_link(format!("/proc/{child_pid}/exe"))
+                && link.to_string_lossy().contains("sleep")
+            {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "child pid {child_pid} did not exec into sleep within 2s"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        let cache = BinaryIdentityCache::new();
+        let result = resolve_process_identity(std::process::id(), peer_port, &cache);
+
+        unsafe {
+            libc::kill(child_pid, libc::SIGKILL);
+            libc::waitpid(child_pid, std::ptr::null_mut(), 0);
+        }
+
+        match result {
+            Ok(identity) => panic!(
+                "resolve_process_identity unexpectedly succeeded for shared socket owned by PID {}",
+                identity.binary_pid
+            ),
+            Err(err) => {
+                assert!(
+                    err.reason.contains("ambiguous shared socket ownership"),
+                    "expected ambiguous socket ownership error, got: {}",
+                    err.reason
+                );
+                assert!(
+                    err.reason.contains(&std::process::id().to_string()),
+                    "error should include parent PID; got: {}",
+                    err.reason
+                );
+                assert!(
+                    err.reason.contains(&child_pid.to_string()),
+                    "error should include child PID; got: {}",
+                    err.reason
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary

Deny ambiguous shared socket ownership in sandbox identity resolution so a socket inode shared across fork/exec cannot be authorized using the wrong process identity.

## Related Issue

closes OS-133

## Changes

- Replaced first-match socket inode attribution with multi-owner `/proc` resolution that dedupes descendant and fallback scans.
- TOFU-verifies every socket owner and denies before OPA when co-owners resolve to different policy identities.
- Updates bypass monitor reporting to surface ambiguous socket owners instead of collapsing to one PID.
- Documents the new fail-closed multi-owner identity model in `architecture/sandbox.md`.

## Testing

- [ ] `mise run pre-commit` passes
  - Attempted locally; blocked in the Rust test lane by unrelated local `openshell-prover` link failure: `ld: library 'z3' not found`.
- [x] `env -u RUSTC_WRAPPER cargo test -p openshell-sandbox` passes on macOS (`535 passed; 1 ignored`).
- [x] `env -u RUSTC_WRAPPER cargo test -p openshell-sandbox procfs` passes on macOS; Linux-only regression tests are cfg-filtered locally and should run in Linux CI.
- [x] `env -u RUSTC_WRAPPER cargo test -p openshell-sandbox resolve_process_identity` passes on macOS; Linux-only regression tests are cfg-filtered locally and should run in Linux CI.
- [ ] E2E tests added/updated (not applicable; unit/integration coverage added for identity resolution behavior).

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
