### PR TITLE
fix(ci): patch CI container vulnerability toolchain

### DIFF
--- a/deploy/docker/Dockerfile.ci
+++ b/deploy/docker/Dockerfile.ci
@@ -10,6 +10,7 @@ FROM nvcr.io/nvidia/base/ubuntu:noble-20251013
 
 ARG DOCKER_VERSION=29.4.1
 ARG BUILDX_VERSION=v0.33.0
+ARG NPM_VERSION=11.13.0
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -65,7 +66,7 @@ RUN case "$TARGETARCH" in \
     | tar xz --strip-components=2 -C /usr/local/bin "gh_${GH_VERSION}_linux_${gh_arch}/bin/gh"
 
 # Install mise
-ARG MISE_VERSION=v2026.4.18
+ARG MISE_VERSION=v2026.4.20
 RUN curl https://mise.run | MISE_VERSION=$MISE_VERSION sh
 
 # Copy mise.toml and task includes, then install all tools via mise
@@ -76,6 +77,8 @@ RUN --mount=type=secret,id=MISE_GITHUB_TOKEN \
     export MISE_GITHUB_TOKEN="$(cat /run/secrets/MISE_GITHUB_TOKEN 2>/dev/null || true)" && \
     mise trust /opt/mise/mise.toml && \
     env -u RUSTC_WRAPPER mise install && \
+    mise reshim && \
+    npm install -g "npm@${NPM_VERSION}" && \
     mise reshim && \
     (/root/.cargo/bin/rustup component remove rust-docs || true) && \
     rm -rf /root/.rustup/toolchains/*/share/doc /root/.rustup/toolchains/*/share/man

--- a/mise.toml
+++ b/mise.toml
@@ -13,15 +13,15 @@ experimental = true
 python.precompiled_flavor = "install_only_stripped"
 
 [tools]
-python = "3.13.12"
+python = "3.13.13"
 rust = "stable"
-node = "24"
-kubectl = "1.35.1"
-uv = "0.10.2"
+node = "24.15.0"
+kubectl = "1.35.4"
+uv = "0.10.12"
 protoc = "29.6"
 helm = "4.1.4"
 "ubi:mozilla/sccache" = { version = "0.14.0", matching = "sccache-v" }
-"github:anchore/syft" = { version = "1.42.3" }
+"github:anchore/syft" = { version = "1.43.0" }
 "github:EmbarkStudios/cargo-about" = { version = "0.8.4", version_prefix = "" }
 zig = "0.14.1"
 "npm:markdownlint-cli2" = "0.22.0"

--- a/tasks/scripts/docker-build-ci.sh
+++ b/tasks/scripts/docker-build-ci.sh
@@ -18,9 +18,17 @@ elif [[ "${DOCKER_PLATFORM:-}" == *","* ]]; then
   OUTPUT_ARGS=(--push)
 fi
 
+SECRET_ARGS=()
+if [[ -n "${MISE_GITHUB_TOKEN:-}" ]]; then
+  SECRET_ARGS=(--secret id=MISE_GITHUB_TOKEN,env=MISE_GITHUB_TOKEN)
+elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  SECRET_ARGS=(--secret id=MISE_GITHUB_TOKEN,env=GITHUB_TOKEN)
+fi
+
 exec ce_build \
   ${DOCKER_BUILDER:+--builder ${DOCKER_BUILDER}} \
   ${DOCKER_PLATFORM:+--platform ${DOCKER_PLATFORM}} \
+  ${SECRET_ARGS[@]+"${SECRET_ARGS[@]}"} \
   -f deploy/docker/Dockerfile.ci \
   -t "openshell/ci:${IMAGE_TAG:-dev}" \
   --provenance=false \


### PR DESCRIPTION
## Summary

Patch the CI container toolchain versions that were responsible for the directly fixable findings in the 2026-04-24 container vulnerability report.

## Related Issue

closes OS-136, parent OS-134

## Changes

- Bump mise-managed Python, Node, kubectl, uv, and Syft versions.
- Refresh the CI image's mise installer.
- Install npm `11.13.0` in the CI image so bundled `picomatch` resolves to the patched version.
- Pass `MISE_GITHUB_TOKEN` or `GITHUB_TOKEN` into the CI image BuildKit secret mount during local Docker builds.

## Testing

- [x] `mise run build:docker:ci`
- [x] Verified rebuilt `openshell/ci:dev` versions: Python `3.13.13`, Node `24.15.0`, npm `11.13.0`, kubectl `1.35.4`, Syft `1.43.0`
- [x] Generated and rescanned CI SBOM with Syft/Grype
- [x] Confirmed the original CI Python, `picomatch`, `go-jose`, `go-getter`, and Syft-owned OTel findings are cleared
- [x] `cargo test -p openshell-prover` with `Z3_SYS_Z3_HEADER=/opt/homebrew/opt/z3/include/z3.h` and `Z3_LIBRARY_PATH_OVERRIDE=/opt/homebrew/opt/z3/lib`
- [x] `mise run pre-commit` reached and passed Python checks/tests, Rust check/lint/tests, Helm lint, and `git diff --check`
- [ ] `mise run pre-commit` fully passes locally

Local pre-commit still exits nonzero because existing ignored scratch files under `architecture/plans/567-*` are missing SPDX headers. The earlier Z3 linker issue is resolved by exporting the Homebrew Z3 environment variables above.

## Checklist

- [x] Follows Conventional Commits
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable)
