### PR TITLE
test(e2e): fix rust upload path assertions

### DIFF
--- a/e2e/rust/tests/sync.rs
+++ b/e2e/rust/tests/sync.rs
@@ -58,7 +58,7 @@ async fn sandbox_file_upload_download_round_trip() {
 
     let download_str = download_dir.to_str().expect("download path is UTF-8");
     guard
-        .download("/sandbox/uploaded", download_str)
+        .download("/sandbox/uploaded/upload", download_str)
         .await
         .expect("download directory");
 
@@ -108,7 +108,7 @@ async fn sandbox_file_upload_download_round_trip() {
 
     let large_down_str = large_down.to_str().expect("large_down path is UTF-8");
     guard
-        .download("/sandbox/large_test", large_down_str)
+        .download("/sandbox/large_test/large_upload", large_down_str)
         .await
         .expect("download large file");
 
@@ -257,7 +257,7 @@ async fn upload_respects_gitignore_by_default() {
     let download_str = download_dir.to_str().expect("verify path is UTF-8");
 
     guard
-        .download("/sandbox/filtered", download_str)
+        .download("/sandbox/filtered/repo", download_str)
         .await
         .expect("download filtered upload");
 

--- a/e2e/rust/tests/upload_create.rs
+++ b/e2e/rust/tests/upload_create.rs
@@ -31,13 +31,14 @@ async fn create_with_upload_provides_files_to_command() {
     fs::write(upload_dir.join("src/main.py"), "print('hello')").expect("write main.py");
 
     let upload_str = upload_dir.to_str().expect("upload path is UTF-8");
+    let remote_marker = "/sandbox/data/project/marker.txt";
 
     // The command reads the marker file — if upload worked, its content
     // appears in the output.
     let mut guard = SandboxGuard::create_with_upload(
         upload_str,
         "/sandbox/data",
-        &["cat", "/sandbox/data/marker.txt"],
+        &["cat", remote_marker],
     )
     .await
     .expect("sandbox create --upload");


### PR DESCRIPTION
## Summary

Update the Rust e2e upload tests to match the new basename-preserving directory upload semantics introduced in #952. This fixes the `e2e / E2E (rust)` regression from run 24874464695.

## Related Issue

Regression from #952
Failed workflow: https://github.com/NVIDIA/OpenShell/actions/runs/24874464695/job/72828948289

## Changes

- Update `upload_create` to read directory uploads from `/sandbox/data/project/...`
- Update `sync` round-trip expectations for directory downloads after upload
- Update the `.gitignore` filtered upload test to verify the nested repo directory

## Testing

- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)
- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= CARGO_BUILD_JOBS=1 cargo test --manifest-path e2e/rust/Cargo.toml --features e2e --test sync --no-run`
- `RUSTC_WRAPPER= CARGO_BUILD_JOBS=1 cargo test --manifest-path e2e/rust/Cargo.toml --features e2e --test upload_create --no-run`
- `mise run pre-commit` currently fails locally in `rust:check` because `sccache` hits `Too many open files`

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
