### PR TITLE
fix(ci): partition GHA sccache cache per arch in shadow spike

### DIFF
--- a/.github/workflows/shadow-shared-cpu-spike.yml
+++ b/.github/workflows/shadow-shared-cpu-spike.yml
@@ -31,6 +31,14 @@ jobs:
       matrix:
         runner: [linux-amd64-cpu8, linux-arm64-cpu8]
     runs-on: ${{ matrix.runner }}
+    env:
+      # Partition the GHA sccache cache per-arch. Without this, matrix jobs
+      # collide on the same cache key, and the later-starting job's writes
+      # fail with 409 Conflict while the earlier one's writes land — leaving
+      # subsequent runs with asymmetric and mostly-empty caches.
+      # (Run 1 on 2026-04-24 showed amd64 with 0/1062 writes succeeding
+      # while arm64 got 575/1064.)
+      SCCACHE_GHA_VERSION: ${{ matrix.runner }}
     container:
       image: ghcr.io/nvidia/openshell/ci:latest
       credentials:


### PR DESCRIPTION
## Summary

Run 1 of `shadow-shared-cpu-spike` on 2026-04-24 ([run 24890968200](https://github.com/NVIDIA/OpenShell/actions/runs/24890968200)) succeeded on wall time but exposed a cache-key collision: both matrix jobs wrote to the same GHA cache key because we didn't partition by arch. arm64 started first and landed **575/1064** writes; amd64 started ~60s later and every one of its **1062** writes failed (409 Conflict on keys already claimed by arm64).

Fix: add job-level `SCCACHE_GHA_VERSION: \${{ matrix.runner }}` so each arch gets its own cache namespace. One-liner (plus comment).

## Related Issue

OS-49 runner migration, Phase 2 / OS-126. Unblocks the real warm-cache behavior on Run 2-4 dispatches.

## Changes

- `.github/workflows/shadow-shared-cpu-spike.yml`: new job-level \`env.SCCACHE_GHA_VERSION\` keyed to \`\${{ matrix.runner }}\`. Workflow-level \`env\` can't reference \`matrix.*\`, hence the job-level placement.

## Testing

- [x] \`mise run pre-commit\` passes
- [ ] Unit tests added/updated — N/A; workflow config change
- [ ] E2E tests added/updated — N/A
- [ ] End-to-end dispatch — redispatch planned immediately after merge; expect both arches to land writes independently and show symmetric cache-hit numbers on the next warm run

## Context — Run 1 data (cache-side is void, wall/queue are good)

| Metric | arm64 | amd64 | ARC baseline (branch-checks) |
|---|---|---|---|
| Queue time | 29s | 85s | p95 15.4m |
| Wall time (cold) | 3m45s | 3m03s | p50 4.0m |
| Cache writes | 575 / 1064 | **0 / 1062** | n/a |
| Cache hit rate | 0% (cold) | 0% (cold) | n/a |

Wall time comfortably below the exit-criterion threshold even on cold cache — the real question left is whether warm cache holds up, which this PR unblocks.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — N/A; plan lives in Linear OS-126