### PR TITLE
test(e2e): fix gitignore upload assertion path

### DIFF
--- a/e2e/rust/tests/sync.rs
+++ b/e2e/rust/tests/sync.rs
@@ -257,7 +257,7 @@ async fn upload_respects_gitignore_by_default() {
     let download_str = download_dir.to_str().expect("verify path is UTF-8");
 
     guard
-        .download("/sandbox/filtered/repo", download_str)
+        .download("/sandbox/filtered", download_str)
         .await
         .expect("download filtered upload");
 


### PR DESCRIPTION
## Summary

Fix the Rust E2E gitignore upload assertion path after #960 changed it to expect an extra source-directory wrapper.

## Related Issue

Follow-up to #960.

## Changes

- Download `/sandbox/filtered` for gitignore-filtered directory uploads.
- Preserve the wrapped-directory assertions for non-filtered uploads from #960.

## Testing

- [ ] `mise run pre-commit` passes
- [x] `env -u RUSTC_WRAPPER cargo test --manifest-path e2e/rust/Cargo.toml --test sync upload_respects_gitignore_by_default --no-run`
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)