### PR TITLE
feat(ci): add shadow-docker-build workflow for OS-49 Phase 3

### DIFF
--- a/.github/workflows/shadow-docker-build.yml
+++ b/.github/workflows/shadow-docker-build.yml
@@ -1,0 +1,89 @@
+name: Shadow — Docker Build (local driver + GHA cache)
+
+# OS-49 Phase 3 / PR 3 — non-blocking shadow of docker-build.yml.
+#
+# Exercises buildx's local (docker-container) driver plus GHA-cache
+# (type=gha, scoped per component+arch) so Docker builds no longer depend on
+# the in-cluster BuildKit pods. Per-arch matrix on nv-gha-runners; each job
+# builds a single platform natively (no QEMU). No multi-arch manifest
+# merging — that folds into the real cut-over in Phase 6.
+#
+# Plan, decision thresholds, and results: OS-127 Linear issue. Dispatch
+# manually 4–5 times after merge to collect cold + warm numbers.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  shadow-build:
+    name: shadow ${{ matrix.component }} (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [gateway, supervisor, cluster]
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: linux-amd64-cpu8
+          - arch: arm64
+            runner: linux-arm64-cpu8
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ghcr.io/nvidia/openshell/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --privileged
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Install tools
+        run: mise install
+
+      - name: Set up buildx (local driver)
+        uses: ./.github/actions/setup-buildx
+        with:
+          driver: local
+
+      - name: Package Helm chart (cluster only)
+        if: matrix.component == 'cluster'
+        run: |
+          mkdir -p deploy/docker/.build/charts
+          helm package deploy/helm/openshell -d deploy/docker/.build/charts/
+
+      - name: Build ${{ matrix.component }} (${{ matrix.arch }})
+        # Matches docker-build.yml's default EXTRA_CARGO_FEATURES so CI image
+        # content is comparable. No --push: the shadow measures build/cache
+        # mechanics, not publish behavior. Multi-arch manifests are Phase 6.
+        run: |
+          docker buildx build \
+            --builder openshell \
+            --platform linux/${{ matrix.arch }} \
+            --cache-from type=gha,scope=${{ matrix.component }}-${{ matrix.arch }} \
+            --cache-to   type=gha,mode=max,scope=${{ matrix.component }}-${{ matrix.arch }} \
+            --build-arg EXTRA_CARGO_FEATURES=openshell-core/dev-settings \
+            --load \
+            --file deploy/docker/Dockerfile.images \
+            --target ${{ matrix.component }} \
+            .
+
+      - name: buildx du
+        if: always()
+        run: docker buildx du --builder openshell || true


### PR DESCRIPTION
## Summary

Add `.github/workflows/shadow-docker-build.yml` — a dispatch-driven shadow of `docker-build.yml` using buildx's **local driver** (via the recently-merged `setup-buildx` `driver: local`) and **GHA cache** (`type=gha`, scoped per `(component, arch)`). Proves Docker builds can run on `nv-gha-runners` without reaching back to the in-cluster EKS BuildKit pods. Non-blocking; `push: main` + `workflow_dispatch` only.

## Related Issue

OS-49 runner migration, Phase 3 / OS-127. This is **PR 3** of the two-PR phase; PR 2 (setup-buildx driver input) already merged in [#941](https://github.com/NVIDIA/OpenShell/pull/941).

Plan and decision thresholds live in [OS-127](https://linear.app/nvidia/issue/OS-127) as an attached comment (Linear MCP `create_document` remains out of service).

## Changes

- `.github/workflows/shadow-docker-build.yml`: new workflow.
  - **Matrix:** `{gateway, supervisor, cluster} × {amd64, arm64}` = 6 jobs.
  - **Runner:** `linux-{amd64,arm64}-cpu8` (native per arch, no QEMU).
  - **Container:** `ghcr.io/nvidia/openshell/ci:latest` with `--privileged` + docker-socket mount — mirrors `docker-build.yml`.
  - **Buildx:** `./.github/actions/setup-buildx` with `driver: local`.
  - **Cluster helm prep:** `helm package deploy/helm/openshell -d deploy/docker/.build/charts/` before the build (only on `matrix.component == 'cluster'`).
  - **Build:** `docker buildx build --platform linux/<arch> --cache-from/--cache-to type=gha,scope=<component>-<arch>,mode=max --build-arg EXTRA_CARGO_FEATURES=openshell-core/dev-settings --load --file deploy/docker/Dockerfile.images --target <component>`.
  - **Post-step:** `docker buildx du` for cache-size visibility.

## Deliberate divergences from `docker-build.yml`

All per the OS-127 plan:

- **Does not call `docker-build.yml` as a reusable workflow.** Phase 6 folds the driver input into the reusable workflow; the shadow is self-contained.
- **No multi-arch manifest merge.** Per-arch images land separately; manifest stitching enters in Phase 6.
- **No `--push`.** Shadow measures build + cache mechanics, not publish.
- **No `OPENSHELL_CARGO_VERSION` injection.** Binary will report `0.0.0`; wall-time unaffected.
- **No `SCCACHE_MEMCACHED_ENDPOINT`.** Won't resolve off-EKS anyway; Dockerfile falls back to local disk cache.

## Risk note: `--privileged` on shared runners

`nv-gha-runners` may or may not permit `--privileged` containers — this hasn't been confirmed. Per the OS-127 plan, the first dispatch is the test. If rejected, the job fails at container-start with an explicit policy error — clean failure, not partial execution. Phase 3 redesign would then consider non-DinD alternatives (`docker-container` driver in a sidecar, for instance). Same `--privileged` pattern that `docker-build.yml` on ARC uses daily.

## Testing

- [ ] `mise run pre-commit` — ⚠️ **exit 1, but failure is pre-existing on `main`**, unrelated to this PR. 8 `MD040` errors in `architecture/podman-rootless-networking.md` (from PR #904's podman driver doc, landed today). Worth a separate tiny fix PR.
- [ ] Unit tests added/updated — N/A; workflow config change.
- [ ] E2E tests added/updated — N/A.
- [ ] **Dispatch validation** — planned immediately post-merge (`gh workflow run shadow-docker-build.yml --ref main`). First dispatch doubles as the `--privileged`-policy test.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — N/A; plan lives on OS-127 (Linear comment due to MCP `create_document` outage).