### PR TITLE
fix(ci): use nv-gha-runners buildkit mirror to avoid Docker Hub rate limit

### DIFF
--- a/.github/actions/setup-buildx/action.yml
+++ b/.github/actions/setup-buildx/action.yml
@@ -44,3 +44,8 @@ runs:
         name: ${{ inputs.name }}
         driver: docker-container
         platforms: linux/amd64,linux/arm64
+        # Use the nv-gha-runners Docker Hub mirror to avoid unauthenticated
+        # pull rate limits on shared runners. The TOML is pre-populated on
+        # every nv-gha-runner. Per:
+        # https://docs.gha-runners.nvidia.com/platform/best-practices/#use-docker-cache-for-buildkit
+        buildkitd-config: /etc/buildkit/buildkitd.toml


### PR DESCRIPTION
## Summary

First dispatch of `shadow-docker-build` ([run 24908165293](https://github.com/NVIDIA/OpenShell/actions/runs/24908165293)) hit Docker Hub's unauthenticated pull rate limit on 3/6 jobs — classic "lucky pulls go through, unlucky ones hit the cap" pattern on shared-runner egress.

Per pimlock's pointer ([nv-gha-runners best-practices, *Use Docker Cache for BuildKit*](https://docs.gha-runners.nvidia.com/platform/best-practices/#use-docker-cache-for-buildkit)), the fix is one input to `docker/setup-buildx-action@v3`: `buildkitd-config: /etc/buildkit/buildkitd.toml`. That TOML is pre-populated on every nv-gha-runner and points Docker Hub traffic at an in-environment mirror.

## Related Issue

OS-49 runner migration, Phase 3 / [OS-127](https://linear.app/nvidia/issue/OS-127). Unblocks clean shadow dispatches on [PR 964's](https://github.com/NVIDIA/OpenShell/pull/964) shadow workflow.

## Changes

- `.github/actions/setup-buildx/action.yml`: add `buildkitd-config: /etc/buildkit/buildkitd.toml` to the `driver: local` branch only. Remote-driver path is unaffected (ARC BuildKit pods live inside EKS and don't egress to Docker Hub).

## Testing

- [x] `mise run pre-commit` — Rust / Python / license / helm all green. `markdown:lint:md` fails on 8 pre-existing MD040 errors in `architecture/podman-rootless-networking.md` from PR #904 — unrelated to this PR.
- [ ] Unit tests added/updated — N/A; composite action config.
- [ ] E2E tests — N/A.
- [ ] **Dispatch validation** — will re-dispatch `shadow-docker-build` after merge; expect all 6 matrix cells to succeed on image pulls.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — N/A.