### PR TITLE
fix(ci): make buildkitd-config opt-in for setup-buildx

### DIFF
--- a/.github/actions/setup-buildx/action.yml
+++ b/.github/actions/setup-buildx/action.yml
@@ -21,6 +21,15 @@ inputs:
   name:
     description: Builder instance name
     default: openshell
+  buildkitd-config:
+    description: >
+      Path to a buildkitd.toml to configure the builder with (e.g. the
+      nv-gha-runners Docker Hub mirror at /etc/buildkit/buildkitd.toml).
+      Must be readable *from where this action runs* — in a containerized
+      job that means the caller must bind-mount the host path into the job
+      container (e.g. `volumes: [/etc/buildkit:/etc/buildkit:ro]`). Empty
+      disables the config (default).
+    default: ""
 
 runs:
   using: composite
@@ -36,6 +45,7 @@ runs:
         append: |
           - endpoint: ${{ inputs.arm64-endpoint }}
             platforms: linux/arm64
+        buildkitd-config: ${{ inputs.buildkitd-config }}
 
     - name: Set up Docker Buildx (local)
       if: inputs.driver == 'local'
@@ -44,8 +54,4 @@ runs:
         name: ${{ inputs.name }}
         driver: docker-container
         platforms: linux/amd64,linux/arm64
-        # Use the nv-gha-runners Docker Hub mirror to avoid unauthenticated
-        # pull rate limits on shared runners. The TOML is pre-populated on
-        # every nv-gha-runner. Per:
-        # https://docs.gha-runners.nvidia.com/platform/best-practices/#use-docker-cache-for-buildkit
-        buildkitd-config: /etc/buildkit/buildkitd.toml
+        buildkitd-config: ${{ inputs.buildkitd-config }}

--- a/.github/workflows/shadow-docker-build.yml
+++ b/.github/workflows/shadow-docker-build.yml
@@ -45,6 +45,11 @@ jobs:
       options: --privileged
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock
+        # Expose the nv-gha-runners buildkitd.toml (registry-mirror config)
+        # inside the container so docker/setup-buildx-action can read it.
+        # The file is pre-populated on every nv-gha-runner per:
+        # https://docs.gha-runners.nvidia.com/platform/best-practices/#use-docker-cache-for-buildkit
+        - /etc/buildkit:/etc/buildkit:ro
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -61,6 +66,10 @@ jobs:
         uses: ./.github/actions/setup-buildx
         with:
           driver: local
+          # Bind-mounted above via container.volumes; without that, the file
+          # is on the host but invisible to the action (which runs inside
+          # the ci:latest container).
+          buildkitd-config: /etc/buildkit/buildkitd.toml
 
       - name: Package Helm chart (cluster only)
         if: matrix.component == 'cluster'


### PR DESCRIPTION
## Summary

Hotfix for #966, which broke `shadow-docker-build.yml` on main. That PR hard-coded `buildkitd-config: /etc/buildkit/buildkitd.toml` inside the `driver: local` branch of the `setup-buildx` composite action. The only caller using that driver is `shadow-docker-build.yml`, which runs inside the `ghcr.io/nvidia/openshell/ci:latest` container — so the host-side TOML was invisible to `docker/setup-buildx-action` and every matrix job failed at "Set up buildx" (e.g. [run 24911395318](https://github.com/NVIDIA/OpenShell/actions/runs/24911395318)).

Remote-driver callers (`docker-build`, `release-dev`, `release-tag`, `release-vm-dev`, `ci-image`) were unaffected because the hard-coded line was only inside the local-driver branch.

## Changes

- `.github/actions/setup-buildx/action.yml`
  - Add `buildkitd-config` input (empty default).
  - Revert the hard-coded path; pass the input through to `docker/setup-buildx-action` in both the remote and local branches. Empty input is a no-op.
- `.github/workflows/shadow-docker-build.yml`
  - Bind-mount `/etc/buildkit:/etc/buildkit:ro` into the ci container so the action running inside it can read the TOML.
  - Pass `buildkitd-config: /etc/buildkit/buildkitd.toml` through the new input.

## Testing

- Diff reviewed; minimal surface area (20 added / 5 removed).
- Remote-driver callers: no behavior change (new input defaults empty → `docker/setup-buildx-action` receives an empty `buildkitd-config`, treated as no config).
- Local-driver caller (shadow-docker-build): verified the action will now be able to read `/etc/buildkit/buildkitd.toml` from inside the container via the bind mount; will confirm on the first push-to-main dispatch after merge.

## Related

- Reverts the behavioral breakage introduced by #966.
- Follow-up to OS-127 (Phase 3 shadow docker build).