### PR TITLE
feat(ci): add shadow-rust-native-build workflow for OS-49 Phase 4 (PR 4a)

### DIFF
--- a/.github/workflows/shadow-rust-native-build.yml
+++ b/.github/workflows/shadow-rust-native-build.yml
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Shadow — Rust Native Build (openshell-gateway / openshell-sandbox)
+
+# OS-49 Phase 4 / PR 4a — non-blocking shadow that builds openshell-gateway
+# and openshell-sandbox natively per-arch on the nv-gha-runners shared CPU
+# pool (`linux-{amd64,arm64}-cpu8`) with a GHA-backed sccache, and uploads
+# the resulting binaries as artifacts. Reuses the pattern from PR #853's
+# release-dev.yml "Build standalone {gateway,supervisor} binaries" jobs.
+#
+# The artifacts match the layout PR 4c expects when consuming `BINARY_SOURCE=
+# prebuilt` (wired up in #945): one binary per (component, arch), staged to
+# `deploy/docker/.build/prebuilt-binaries/<arch>/openshell-{gateway,sandbox}`.
+#
+# Dispatch 4-5 times after merge to collect cold + warm numbers and compare
+# against the Rust portion of docker-build.yml's 17.5 m ARC baseline. Success
+# criteria, gotchas, and dependency graph live on the OS-128 Linear issue.
+
+on:
+  # workflow_dispatch only — keeps this shadow off main's required-check
+  # surface and avoids cluttering CI history with non-blocking failures
+  # while we're still collecting Phase 4 data. Dispatch from the Actions
+  # UI to collect cold/warm-cache numbers.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Route sccache (already RUSTC_WRAPPER in mise.toml) to the GHA cache
+  # backend instead of the EKS memcached used by ARC.
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  rust-native-build:
+    name: ${{ matrix.component }} (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [gateway, sandbox]
+        arch: [amd64, arm64]
+        include:
+          - component: gateway
+            crate: openshell-server
+            binary: openshell-gateway
+          - component: sandbox
+            crate: openshell-sandbox
+            binary: openshell-sandbox
+          - arch: amd64
+            runner: linux-amd64-cpu8
+            target: x86_64-unknown-linux-gnu
+          - arch: arm64
+            runner: linux-arm64-cpu8
+            target: aarch64-unknown-linux-gnu
+    runs-on: ${{ matrix.runner }}
+    env:
+      # Partition the GHA sccache cache per (component, arch). Without this,
+      # concurrent matrix jobs collide on the same cache key and later-starting
+      # writers hit 409 Conflict (PR #961 fix for shadow-shared-cpu-spike).
+      SCCACHE_GHA_VERSION: ${{ matrix.component }}-${{ matrix.arch }}
+    container:
+      image: ghcr.io/nvidia/openshell/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Install tools
+        run: mise install
+
+      - name: Configure GHA sccache backend
+        # Exposes ACTIONS_CACHE_URL / ACTIONS_RUNTIME_TOKEN so sccache (wrapped
+        # around rustc via mise's RUSTC_WRAPPER) can initialize the GHA cache.
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Cache Rust target and registry
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: shadow-rust-native-${{ matrix.component }}-${{ matrix.arch }}
+          cache-directories: .cache/sccache
+          cache-targets: "true"
+
+      - name: Compute cargo version
+        id: version
+        run: |
+          set -euo pipefail
+          echo "cargo_version=$(uv run python tasks/scripts/release.py get-version --cargo)" >> "$GITHUB_OUTPUT"
+
+      - name: Patch workspace version
+        if: steps.version.outputs.cargo_version != ''
+        run: |
+          set -euo pipefail
+          sed -i -E '/^\[workspace\.package\]/,/^\[/{s/^version[[:space:]]*=[[:space:]]*".*"/version = "'"${{ steps.version.outputs.cargo_version }}"'"/}' Cargo.toml
+
+      - name: Build ${{ matrix.binary }} (${{ matrix.target }})
+        # Matches docker-build.yml's default EXTRA_CARGO_FEATURES so the
+        # binary content is byte-comparable to what Dockerfile.images produces
+        # today (precondition for PR 4c's drop-in swap).
+        run: |
+          set -euo pipefail
+          mise x -- cargo build \
+            --release \
+            --target ${{ matrix.target }} \
+            -p ${{ matrix.crate }} \
+            --bin ${{ matrix.binary }} \
+            --features openshell-core/dev-settings
+
+      - name: Verify packaged binary
+        run: |
+          set -euo pipefail
+          BIN="target/${{ matrix.target }}/release/${{ matrix.binary }}"
+          OUTPUT="$("$BIN" --version)"
+          echo "$OUTPUT"
+          grep -q "^${{ matrix.binary }} " <<<"$OUTPUT"
+          # Record glibc linkage so drift from the Ubuntu noble runtime base
+          # image is visible in logs (not asserted — the runtime check lands
+          # when PR 4c builds images on top of these artifacts).
+          ldd --version | head -1
+          ldd "$BIN" | head -20 || true
+
+      - name: sccache stats
+        if: always()
+        run: mise x -- sccache --show-stats
+
+      - name: Stage binary for prebuilt layout
+        # Shape mirrors `deploy/docker/.build/prebuilt-binaries/<arch>/<bin>`
+        # so PR 4c can download the artifact directly into the build context.
+        run: |
+          set -euo pipefail
+          STAGE="prebuilt-binaries/${{ matrix.arch }}"
+          mkdir -p "$STAGE"
+          install -m 0755 "target/${{ matrix.target }}/release/${{ matrix.binary }}" "$STAGE/${{ matrix.binary }}"
+          ls -lh "$STAGE/"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-binary-${{ matrix.component }}-linux-${{ matrix.arch }}
+          path: prebuilt-binaries/${{ matrix.arch }}/${{ matrix.binary }}
+          retention-days: 5
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

OS-49 Phase 4 / PR 4a — non-blocking shadow workflow that builds `openshell-gateway` and `openshell-sandbox` natively per-arch on the `nv-gha-runners` shared CPU pool with a GHA-backed sccache, and uploads the resulting binaries as artifacts.

The artifacts are shaped exactly for the `BINARY_SOURCE=prebuilt` path that landed in #945 — one binary per `(component, arch)`, uploaded as `rust-binary-{gateway,sandbox}-linux-{amd64,arm64}`, staged inside the artifact at `prebuilt-binaries/<arch>/openshell-{gateway,sandbox}`. PR 4c will wire these into `docker-build.yml` via `actions/download-artifact`, flip the Dockerfile default to `BINARY_SOURCE=prebuilt`, and delete the Rust `RUN cargo build` stages.

## Related Issue

- [OS-128](https://linear.app/nvidia/issue/OS-128/os-49-phase-4-decouple-rust-from-docker) — Phase 4 parent
- Reuses the per-arch native build pattern from #853
- Follows the shadow convention from #934 (Phase 2) and #964 (Phase 3)

## Changes

- `.github/workflows/shadow-rust-native-build.yml` (new, 154 lines):
  - Matrix: `component={gateway,sandbox} × arch={amd64,arm64}` → 4 jobs, `fail-fast: false`.
  - Runners: `linux-{amd64,arm64}-cpu8` (Phase 2-validated).
  - Container: `ghcr.io/nvidia/openshell/ci:latest`.
  - sccache via `mozilla-actions/sccache-action` with `SCCACHE_GHA_VERSION` partitioned per `(component, arch)` to avoid the 409-Conflict collisions that PR #961 fixed for Phase 2.
  - Version injection: `uv run python tasks/scripts/release.py get-version --cargo` + `sed` on `[workspace.package]` in `Cargo.toml` (same as `docker-build.yml` and `release-dev.yml`).
  - Build: `cargo build --release --target <triple> -p <crate> --bin <binary> --features openshell-core/dev-settings` (matches `docker-build.yml`'s default `EXTRA_CARGO_FEATURES` so artifacts are interchangeable with the in-Docker build's output for PR 4c).
  - Verify step: `--version` grep + `ldd --version` + `ldd <bin>` diagnostics (so glibc drift from the Ubuntu noble runtime base image is visible in the logs).
  - Artifact upload with `if-no-files-found: error`, 5-day retention.

## Testing

- Static review: Cargo.toml `[workspace.package]` matches the sed pattern; `openshell-server` + `openshell-sandbox` both have `[[bin]]` entries matching `openshell-gateway` / `openshell-sandbox`; both depend on `openshell-core` directly so `--features openshell-core/dev-settings` propagates; `tasks/scripts/release.py get-version --cargo` exists.
- `license:check` passes.
- Dispatch plan after merge: 4-5 runs via `workflow_dispatch` to collect cold + warm wall times and sccache hit rates, recorded on OS-128.

## Checklist

- [x] Conventional commit format, signed-off.
- [x] License header present.
- [x] Trigger scoped to `workflow_dispatch` + push-to-main (non-blocking; required-check list untouched).
- [x] No changes to any existing workflow, action, or Cargo file.
- [ ] Decision thresholds will be recorded on OS-128 after dispatch runs.
- [ ] PR 4c (flip default + delete Rust build stages) opens once dispatch numbers land.

## Notes

Draft until the first dispatch completes and the wall-time / sccache-hit numbers look sane. Then ready for review.