### PR TITLE
fix(scripts): handle docker cleanup when no containers are running

### DIFF
--- a/scripts/docker-cleanup.sh
+++ b/scripts/docker-cleanup.sh
@@ -217,7 +217,7 @@ info "Removing unused volumes..."
 # Identify volumes in use by running containers
 in_use_volumes=$(ce ps -q 2>/dev/null \
   | xargs -r ce inspect --format '{{range .Mounts}}{{.Name}} {{end}}' 2>/dev/null \
-  | tr ' ' '\n' | sort -u | grep -v '^$')
+  | tr ' ' '\n' | sort -u | grep -v '^$' || true)
 
 unused_volumes=()
 while read -r vol; do


### PR DESCRIPTION
## Summary
The docker-cleanup.sh script failed when no containers were running because grep -v returned exit code 1 on empty input, causing the script to abort due to set -euo pipefail.

Add || true to the volume detection pipeline so the script succeeds when there are no running containers (in_use_volumes will be empty, which is the correct behavior).

## Related Issue

## Changes

## Testing
<!-- What testing was done? -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
