### PR TITLE
fix(e2e): use high UID range to avoid host user conflicts

### DIFF
--- a/e2e/rust/tests/custom_image.rs
+++ b/e2e/rust/tests/custom_image.rs
@@ -22,8 +22,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends iproute2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Create the sandbox user/group so the supervisor can switch to it.
-RUN groupadd -g 1000 sandbox && \
-    useradd -m -u 1000 -g sandbox sandbox
+# Use a high UID range to avoid conflicts with host users when running without
+# user namespace remapping (UID in container = UID on host).
+RUN groupadd -g 1000660000 sandbox && \
+    useradd -m -u 1000660000 -g sandbox sandbox
 
 # Write a marker file so we can verify this is our custom image.
 RUN echo "custom-image-e2e-marker" > /opt/marker.txt

--- a/examples/bring-your-own-container/Dockerfile
+++ b/examples/bring-your-own-container/Dockerfile
@@ -14,9 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl iproute2 iptables \
     && rm -rf /var/lib/apt/lists/*
 
-# Create the sandbox user (uid/gid 1000) for non-root execution.
-RUN groupadd -g 1000 sandbox && \
-    useradd -m -u 1000 -g sandbox sandbox
+# Create the sandbox user for non-root execution.
+# Use a high UID range to avoid conflicts with host users when running without
+# user namespace remapping (UID in container = UID on host).
+RUN groupadd -g 1000660000 sandbox && \
+    useradd -m -u 1000660000 -g sandbox sandbox
 
 WORKDIR /sandbox
 COPY app.py .

--- a/examples/bring-your-own-container/README.md
+++ b/examples/bring-your-own-container/README.md
@@ -59,7 +59,9 @@ key requirements are:
 - **Pass your start command explicitly** — use `-- <command>` on the CLI.
   The image's `CMD` / `ENTRYPOINT` is replaced by the sandbox supervisor
   at runtime.
-- **Create a `sandbox` user** (uid/gid 1000) for non-root execution.
+- **Create a `sandbox` user** (uid/gid 1000660000) for non-root execution.
+  Use a high UID (1000000000+) to avoid conflicts with host users when running
+  without user namespace remapping.
 - **Install `iproute2`** for full network namespace isolation.
 - **Use a standard Linux base image** — distroless and `FROM scratch`
   images are not supported.


### PR DESCRIPTION
## Summary
Change sandbox user UID from 1000 to 1000660000 in custom image examples and E2E tests.

Using a high UID range (1000000000+) prevents conflicts with host users when running without user namespace remapping, where container UIDs map directly to host UIDs.

This resolves fork failures caused by RLIMIT_NPROC enforcement when the host user already has many threads running.

## Related Issue

## Changes

## Testing
<!-- What testing was done? -->
- [x ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [x ] E2E tests added/updated (if applicable)

## Checklist
- [ x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
