### PR TITLE
feat(sandbox): add Kubernetes user namespace isolation 

### DIFF
--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -297,6 +297,14 @@ pub struct Config {
     /// allowing them to reach services running on the Docker host.
     #[serde(default)]
     pub host_gateway_ip: String,
+
+    /// Enable Kubernetes user namespace isolation (`hostUsers: false`) for
+    /// sandbox pods.  When enabled, container UID 0 maps to an unprivileged
+    /// host UID and capabilities become namespaced. Requires Kubernetes 1.33+
+    /// with user namespace support available (beta through 1.35, GA in 1.36+),
+    /// plus a supporting container runtime and Linux 5.12+.
+    #[serde(default)]
+    pub enable_user_namespaces: bool,
 }
 
 /// TLS configuration.
@@ -410,6 +418,7 @@ impl Config {
             ssh_session_ttl_secs: default_ssh_session_ttl_secs(),
             client_tls_secret_name: String::new(),
             host_gateway_ip: String::new(),
+            enable_user_namespaces: false,
         }
     }
 

--- a/crates/openshell-driver-kubernetes/src/config.rs
+++ b/crates/openshell-driver-kubernetes/src/config.rs
@@ -19,4 +19,5 @@ pub struct KubernetesComputeConfig {
     pub ssh_handshake_skew_secs: u64,
     pub client_tls_secret_name: String,
     pub host_gateway_ip: String,
+    pub enable_user_namespaces: bool,
 }

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -308,21 +308,22 @@ impl KubernetesComputeDriver {
             labels: Some(sandbox_labels(sandbox)),
             ..Default::default()
         };
-        obj.data = sandbox_to_k8s_spec(
-            sandbox.spec.as_ref(),
-            &self.config.default_image,
-            &self.config.image_pull_policy,
-            &self.config.supervisor_image,
-            &self.config.supervisor_image_pull_policy,
-            &sandbox.id,
-            &sandbox.name,
-            &self.config.grpc_endpoint,
-            self.ssh_socket_path(),
-            self.ssh_handshake_secret(),
-            self.ssh_handshake_skew_secs(),
-            &self.config.client_tls_secret_name,
-            &self.config.host_gateway_ip,
-        );
+        let params = SandboxPodParams {
+            default_image: &self.config.default_image,
+            image_pull_policy: &self.config.image_pull_policy,
+            supervisor_image: &self.config.supervisor_image,
+            supervisor_image_pull_policy: &self.config.supervisor_image_pull_policy,
+            sandbox_id: &sandbox.id,
+            sandbox_name: &sandbox.name,
+            grpc_endpoint: &self.config.grpc_endpoint,
+            ssh_socket_path: self.ssh_socket_path(),
+            ssh_handshake_secret: self.ssh_handshake_secret(),
+            ssh_handshake_skew_secs: self.ssh_handshake_skew_secs(),
+            client_tls_secret_name: &self.config.client_tls_secret_name,
+            host_gateway_ip: &self.config.host_gateway_ip,
+            enable_user_namespaces: self.config.enable_user_namespaces,
+        };
+        obj.data = sandbox_to_k8s_spec(sandbox.spec.as_ref(), &params);
         let api = self.api();
 
         match tokio::time::timeout(KUBE_API_TIMEOUT, api.create(&PostParams::default(), &obj)).await
@@ -926,21 +927,27 @@ fn default_workspace_volume_claim_templates() -> serde_json::Value {
     }])
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Parameters shared by `sandbox_to_k8s_spec` and `sandbox_template_to_k8s`.
+#[derive(Default)]
+struct SandboxPodParams<'a> {
+    default_image: &'a str,
+    image_pull_policy: &'a str,
+    supervisor_image: &'a str,
+    supervisor_image_pull_policy: &'a str,
+    sandbox_id: &'a str,
+    sandbox_name: &'a str,
+    grpc_endpoint: &'a str,
+    ssh_socket_path: &'a str,
+    ssh_handshake_secret: &'a str,
+    ssh_handshake_skew_secs: u64,
+    client_tls_secret_name: &'a str,
+    host_gateway_ip: &'a str,
+    enable_user_namespaces: bool,
+}
+
 fn sandbox_to_k8s_spec(
     spec: Option<&SandboxSpec>,
-    default_image: &str,
-    image_pull_policy: &str,
-    supervisor_image: &str,
-    supervisor_image_pull_policy: &str,
-    sandbox_id: &str,
-    sandbox_name: &str,
-    grpc_endpoint: &str,
-    ssh_socket_path: &str,
-    ssh_handshake_secret: &str,
-    ssh_handshake_skew_secs: u64,
-    client_tls_secret_name: &str,
-    host_gateway_ip: &str,
+    params: &SandboxPodParams<'_>,
 ) -> serde_json::Value {
     let mut root = serde_json::Map::new();
 
@@ -971,20 +978,9 @@ fn sandbox_to_k8s_spec(
                 sandbox_template_to_k8s(
                     template,
                     spec.gpu,
-                    default_image,
-                    image_pull_policy,
-                    supervisor_image,
-                    supervisor_image_pull_policy,
-                    sandbox_id,
-                    sandbox_name,
-                    grpc_endpoint,
-                    ssh_socket_path,
-                    ssh_handshake_secret,
-                    ssh_handshake_skew_secs,
                     &spec.environment,
-                    client_tls_secret_name,
-                    host_gateway_ip,
                     inject_workspace,
+                    params,
                 ),
             );
             if !template.agent_socket_path.is_empty() {
@@ -1019,20 +1015,9 @@ fn sandbox_to_k8s_spec(
             sandbox_template_to_k8s(
                 &SandboxTemplate::default(),
                 spec.as_ref().is_some_and(|s| s.gpu),
-                default_image,
-                image_pull_policy,
-                supervisor_image,
-                supervisor_image_pull_policy,
-                sandbox_id,
-                sandbox_name,
-                grpc_endpoint,
-                ssh_socket_path,
-                ssh_handshake_secret,
-                ssh_handshake_skew_secs,
                 spec_env,
-                client_tls_secret_name,
-                host_gateway_ip,
                 inject_workspace,
+                params,
             ),
         );
     }
@@ -1042,24 +1027,12 @@ fn sandbox_to_k8s_spec(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 fn sandbox_template_to_k8s(
     template: &SandboxTemplate,
     gpu: bool,
-    default_image: &str,
-    image_pull_policy: &str,
-    supervisor_image: &str,
-    supervisor_image_pull_policy: &str,
-    sandbox_id: &str,
-    sandbox_name: &str,
-    grpc_endpoint: &str,
-    ssh_socket_path: &str,
-    ssh_handshake_secret: &str,
-    ssh_handshake_skew_secs: u64,
     spec_environment: &std::collections::HashMap<String, String>,
-    client_tls_secret_name: &str,
-    host_gateway_ip: &str,
     inject_workspace: bool,
+    params: &SandboxPodParams<'_>,
 ) -> serde_json::Value {
     let mut metadata = serde_json::Map::new();
     if !template.labels.is_empty() {
@@ -1077,20 +1050,34 @@ fn sandbox_template_to_k8s(
         );
     }
 
+    // Per-sandbox platform_config.host_users overrides the cluster-wide default.
+    let use_user_namespaces = platform_config_bool(template, "host_users")
+        .map_or(params.enable_user_namespaces, |host_users| !host_users);
+
+    if use_user_namespaces {
+        spec.insert("hostUsers".to_string(), serde_json::json!(false));
+        if gpu {
+            warn!(
+                "GPU sandbox with user namespaces enabled — \
+                 NVIDIA device plugin compatibility is unverified"
+            );
+        }
+    }
+
     let mut container = serde_json::Map::new();
     container.insert("name".to_string(), serde_json::json!("agent"));
     // Use template image if provided, otherwise fall back to default
     let image = if template.image.is_empty() {
-        default_image
+        params.default_image
     } else {
         &template.image
     };
     if !image.is_empty() {
         container.insert("image".to_string(), serde_json::json!(image));
-        if !image_pull_policy.is_empty() {
+        if !params.image_pull_policy.is_empty() {
             container.insert(
                 "imagePullPolicy".to_string(),
-                serde_json::json!(image_pull_policy),
+                serde_json::json!(params.image_pull_policy),
             );
         }
     }
@@ -1100,34 +1087,36 @@ fn sandbox_template_to_k8s(
         None,
         &template.environment,
         spec_environment,
-        sandbox_id,
-        sandbox_name,
-        grpc_endpoint,
-        ssh_socket_path,
-        ssh_handshake_secret,
-        ssh_handshake_skew_secs,
-        !client_tls_secret_name.is_empty(),
+        params.sandbox_id,
+        params.sandbox_name,
+        params.grpc_endpoint,
+        params.ssh_socket_path,
+        params.ssh_handshake_secret,
+        params.ssh_handshake_skew_secs,
+        !params.client_tls_secret_name.is_empty(),
     );
 
     container.insert("env".to_string(), serde_json::Value::Array(env));
 
-    // The sandbox process needs SYS_ADMIN (for seccomp filter installation and
-    // network namespace creation), NET_ADMIN (for network namespace veth setup),
-    // SYS_PTRACE (for the CONNECT proxy to read /proc/<pid>/fd/ of sandbox-user
-    // processes to resolve binary identity for network policy enforcement),
-    // and SYSLOG (for reading /dev/kmsg to surface bypass detection diagnostics).
-    // This mirrors the capabilities used by `mise run sandbox`.
+    let mut capabilities: Vec<&str> = vec!["SYS_ADMIN", "NET_ADMIN", "SYS_PTRACE", "SYSLOG"];
+    if use_user_namespaces {
+        // In a user namespace the bounding set is reset. SETUID/SETGID are
+        // needed for the supervisor to drop privileges to the sandbox user.
+        // DAC_READ_SEARCH is needed for cross-UID /proc/<pid>/fd/ access
+        // for process identity resolution in network policy enforcement.
+        capabilities.extend(["SETUID", "SETGID", "DAC_READ_SEARCH"]);
+    }
     container.insert(
         "securityContext".to_string(),
         serde_json::json!({
             "capabilities": {
-                "add": ["SYS_ADMIN", "NET_ADMIN", "SYS_PTRACE", "SYSLOG"]
+                "add": capabilities
             }
         }),
     );
 
     // Mount client TLS secret for mTLS to the server.
-    if !client_tls_secret_name.is_empty() {
+    if !params.client_tls_secret_name.is_empty() {
         container.insert(
             "volumeMounts".to_string(),
             serde_json::json!([{
@@ -1148,22 +1137,22 @@ fn sandbox_template_to_k8s(
 
     // Add TLS secret volume.  Mode 0400 (owner-read) prevents the
     // unprivileged sandbox user from reading the mTLS private key.
-    if !client_tls_secret_name.is_empty() {
+    if !params.client_tls_secret_name.is_empty() {
         spec.insert(
             "volumes".to_string(),
             serde_json::json!([{
                 "name": "openshell-client-tls",
-                "secret": { "secretName": client_tls_secret_name, "defaultMode": 256 }
+                "secret": { "secretName": params.client_tls_secret_name, "defaultMode": 256 }
             }]),
         );
     }
 
     // Add hostAliases so sandbox pods can reach the Docker host.
-    if !host_gateway_ip.is_empty() {
+    if !params.host_gateway_ip.is_empty() {
         spec.insert(
             "hostAliases".to_string(),
             serde_json::json!([{
-                "ip": host_gateway_ip,
+                "ip": params.host_gateway_ip,
                 "hostnames": ["host.docker.internal", "host.openshell.internal"]
             }]),
         );
@@ -1179,13 +1168,17 @@ fn sandbox_template_to_k8s(
 
     // Side-load the supervisor binary via an init container that copies it
     // from the supervisor image into a shared emptyDir volume.
-    apply_supervisor_sideload(&mut result, supervisor_image, supervisor_image_pull_policy);
+    apply_supervisor_sideload(
+        &mut result,
+        params.supervisor_image,
+        params.supervisor_image_pull_policy,
+    );
 
     // Inject workspace persistence (init container + PVC volume mount) so
     // that /sandbox data survives pod rescheduling.  Skipped when the user
     // provides custom volumeClaimTemplates to avoid conflicts.
     if inject_workspace {
-        apply_workspace_persistence(&mut result, image, image_pull_policy);
+        apply_workspace_persistence(&mut result, image, params.image_pull_policy);
     }
 
     result
@@ -1342,6 +1335,15 @@ fn platform_config_string(template: &SandboxTemplate, key: &str) -> Option<Strin
     let value = config.fields.get(key)?;
     match value.kind.as_ref() {
         Some(prost_types::value::Kind::StringValue(s)) if !s.is_empty() => Some(s.clone()),
+        _ => None,
+    }
+}
+
+fn platform_config_bool(template: &SandboxTemplate, key: &str) -> Option<bool> {
+    let config = template.platform_config.as_ref()?;
+    let value = config.fields.get(key)?;
+    match value.kind.as_ref() {
+        Some(prost_types::value::Kind::BoolValue(b)) => Some(*b),
         _ => None,
     }
 }
@@ -1645,24 +1647,16 @@ mod tests {
 
     #[test]
     fn gpu_sandbox_adds_runtime_class_and_gpu_limit() {
-        let pod_template = sandbox_template_to_k8s(
-            &SandboxTemplate::default(),
-            true,
-            "openshell/sandbox:latest",
-            "",
-            "openshell/supervisor:latest",
-            "",
-            "sandbox-id",
-            "sandbox-name",
-            "https://gateway.example.com",
-            "0.0.0.0:2222",
-            "secret",
-            300,
-            &std::collections::HashMap::new(),
-            "",
-            "",
-            true,
-        );
+        let pod_template = {
+            let params = SandboxPodParams::default();
+            sandbox_template_to_k8s(
+                &SandboxTemplate::default(),
+                true,
+                &std::collections::HashMap::new(),
+                true,
+                &params,
+            )
+        };
 
         assert_eq!(
             pod_template["spec"]["runtimeClassName"],
@@ -1689,24 +1683,16 @@ mod tests {
             ..SandboxTemplate::default()
         };
 
-        let pod_template = sandbox_template_to_k8s(
-            &template,
-            true,
-            "openshell/sandbox:latest",
-            "",
-            "openshell/supervisor:latest",
-            "",
-            "sandbox-id",
-            "sandbox-name",
-            "https://gateway.example.com",
-            "0.0.0.0:2222",
-            "secret",
-            300,
-            &std::collections::HashMap::new(),
-            "",
-            "",
-            true,
-        );
+        let pod_template = {
+            let params = SandboxPodParams::default();
+            sandbox_template_to_k8s(
+                &template,
+                true,
+                &std::collections::HashMap::new(),
+                true,
+                &params,
+            )
+        };
 
         assert_eq!(
             pod_template["spec"]["runtimeClassName"],
@@ -1729,24 +1715,16 @@ mod tests {
             ..SandboxTemplate::default()
         };
 
-        let pod_template = sandbox_template_to_k8s(
-            &template,
-            false,
-            "openshell/sandbox:latest",
-            "",
-            "openshell/supervisor:latest",
-            "",
-            "sandbox-id",
-            "sandbox-name",
-            "https://gateway.example.com",
-            "0.0.0.0:2222",
-            "secret",
-            300,
-            &std::collections::HashMap::new(),
-            "",
-            "",
-            true,
-        );
+        let pod_template = {
+            let params = SandboxPodParams::default();
+            sandbox_template_to_k8s(
+                &template,
+                false,
+                &std::collections::HashMap::new(),
+                true,
+                &params,
+            )
+        };
 
         assert_eq!(
             pod_template["spec"]["runtimeClassName"],
@@ -1765,24 +1743,16 @@ mod tests {
             ..SandboxTemplate::default()
         };
 
-        let pod_template = sandbox_template_to_k8s(
-            &template,
-            true,
-            "openshell/sandbox:latest",
-            "",
-            "openshell/supervisor:latest",
-            "",
-            "sandbox-id",
-            "sandbox-name",
-            "https://gateway.example.com",
-            "0.0.0.0:2222",
-            "secret",
-            300,
-            &std::collections::HashMap::new(),
-            "",
-            "",
-            true,
-        );
+        let pod_template = {
+            let params = SandboxPodParams::default();
+            sandbox_template_to_k8s(
+                &template,
+                true,
+                &std::collections::HashMap::new(),
+                true,
+                &params,
+            )
+        };
 
         let limits = &pod_template["spec"]["containers"][0]["resources"]["limits"];
         assert_eq!(limits["cpu"], serde_json::json!("2"));
@@ -1794,24 +1764,19 @@ mod tests {
 
     #[test]
     fn host_aliases_injected_when_gateway_ip_set() {
-        let pod_template = sandbox_template_to_k8s(
-            &SandboxTemplate::default(),
-            false,
-            "openshell/sandbox:latest",
-            "",
-            "openshell/supervisor:latest",
-            "",
-            "sandbox-id",
-            "sandbox-name",
-            "https://gateway.example.com",
-            "0.0.0.0:2222",
-            "secret",
-            300,
-            &std::collections::HashMap::new(),
-            "",
-            "172.17.0.1",
-            true,
-        );
+        let pod_template = {
+            let params = SandboxPodParams {
+                host_gateway_ip: "172.17.0.1",
+                ..Default::default()
+            };
+            sandbox_template_to_k8s(
+                &SandboxTemplate::default(),
+                false,
+                &std::collections::HashMap::new(),
+                true,
+                &params,
+            )
+        };
 
         let host_aliases = pod_template["spec"]["hostAliases"]
             .as_array()
@@ -1827,24 +1792,16 @@ mod tests {
 
     #[test]
     fn host_aliases_not_injected_when_gateway_ip_empty() {
-        let pod_template = sandbox_template_to_k8s(
-            &SandboxTemplate::default(),
-            false,
-            "openshell/sandbox:latest",
-            "",
-            "openshell/supervisor:latest",
-            "",
-            "sandbox-id",
-            "sandbox-name",
-            "https://gateway.example.com",
-            "0.0.0.0:2222",
-            "secret",
-            300,
-            &std::collections::HashMap::new(),
-            "",
-            "",
-            true,
-        );
+        let pod_template = {
+            let params = SandboxPodParams::default();
+            sandbox_template_to_k8s(
+                &SandboxTemplate::default(),
+                false,
+                &std::collections::HashMap::new(),
+                true,
+                &params,
+            )
+        };
 
         assert!(
             pod_template["spec"]["hostAliases"].is_null(),
@@ -1855,24 +1812,19 @@ mod tests {
     #[test]
     fn tls_secret_volume_uses_restrictive_default_mode() {
         let template = SandboxTemplate::default();
-        let pod_template = sandbox_template_to_k8s(
-            &template,
-            false,
-            "openshell/sandbox:latest",
-            "",
-            "openshell/supervisor:latest",
-            "",
-            "sandbox-id",
-            "sandbox-name",
-            "https://gateway.example.com",
-            "0.0.0.0:2222",
-            "secret",
-            300,
-            &std::collections::HashMap::new(),
-            "my-tls-secret",
-            "",
-            true,
-        );
+        let pod_template = {
+            let params = SandboxPodParams {
+                client_tls_secret_name: "my-tls-secret",
+                ..Default::default()
+            };
+            sandbox_template_to_k8s(
+                &template,
+                false,
+                &std::collections::HashMap::new(),
+                true,
+                &params,
+            )
+        };
 
         let volumes = pod_template["spec"]["volumes"]
             .as_array()
@@ -2000,23 +1952,13 @@ mod tests {
 
     #[test]
     fn workspace_persistence_skipped_when_inject_workspace_false() {
+        let params = SandboxPodParams::default();
         let pod_template = sandbox_template_to_k8s(
             &SandboxTemplate::default(),
             false,
-            "openshell/sandbox:latest",
-            "",
-            "openshell/supervisor:latest",
-            "",
-            "sandbox-id",
-            "sandbox-name",
-            "https://gateway.example.com",
-            "0.0.0.0:2222",
-            "secret",
-            300,
             &std::collections::HashMap::new(),
-            "",
-            "",
             false, // user provided custom VCTs
+            &params,
         );
 
         // Only the supervisor init container should be present — no workspace init container
@@ -2038,5 +1980,176 @@ mod tests {
             !has_workspace_mount,
             "workspace mount must NOT be present when inject_workspace is false"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // User namespace tests
+    // -----------------------------------------------------------------------
+
+    fn default_template_to_k8s(enable_user_namespaces: bool) -> serde_json::Value {
+        let params = SandboxPodParams {
+            enable_user_namespaces,
+            ..Default::default()
+        };
+        sandbox_template_to_k8s(
+            &SandboxTemplate::default(),
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &params,
+        )
+    }
+
+    #[test]
+    fn user_namespaces_disabled_by_default() {
+        let pod_template = default_template_to_k8s(false);
+        assert!(
+            pod_template["spec"]["hostUsers"].is_null(),
+            "hostUsers must not be set when user namespaces are disabled"
+        );
+        let caps = pod_template["spec"]["containers"][0]["securityContext"]["capabilities"]["add"]
+            .as_array()
+            .unwrap();
+        assert_eq!(caps.len(), 4);
+        assert!(!caps.contains(&serde_json::json!("SETUID")));
+    }
+
+    #[test]
+    fn user_namespaces_enabled_by_cluster_default() {
+        let pod_template = default_template_to_k8s(true);
+        assert_eq!(
+            pod_template["spec"]["hostUsers"],
+            serde_json::json!(false),
+            "hostUsers must be false when user namespaces are enabled"
+        );
+    }
+
+    #[test]
+    fn user_namespaces_adds_extra_capabilities() {
+        let pod_template = default_template_to_k8s(true);
+        let caps = pod_template["spec"]["containers"][0]["securityContext"]["capabilities"]["add"]
+            .as_array()
+            .unwrap();
+        assert!(caps.contains(&serde_json::json!("SYS_ADMIN")));
+        assert!(caps.contains(&serde_json::json!("NET_ADMIN")));
+        assert!(caps.contains(&serde_json::json!("SYS_PTRACE")));
+        assert!(caps.contains(&serde_json::json!("SYSLOG")));
+        assert!(caps.contains(&serde_json::json!("SETUID")));
+        assert!(caps.contains(&serde_json::json!("SETGID")));
+        assert!(caps.contains(&serde_json::json!("DAC_READ_SEARCH")));
+        assert_eq!(caps.len(), 7);
+    }
+
+    #[test]
+    fn user_namespaces_per_sandbox_override_enables() {
+        let template = SandboxTemplate {
+            platform_config: Some(Struct {
+                fields: std::iter::once((
+                    "host_users".to_string(),
+                    Value {
+                        kind: Some(Kind::BoolValue(false)),
+                    },
+                ))
+                .collect(),
+            }),
+            ..SandboxTemplate::default()
+        };
+
+        let params = SandboxPodParams::default(); // cluster default is off
+        let pod_template = sandbox_template_to_k8s(
+            &template,
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &params,
+        );
+
+        assert_eq!(
+            pod_template["spec"]["hostUsers"],
+            serde_json::json!(false),
+            "per-sandbox host_users: false must enable user namespaces"
+        );
+        let caps = pod_template["spec"]["containers"][0]["securityContext"]["capabilities"]["add"]
+            .as_array()
+            .unwrap();
+        assert!(caps.contains(&serde_json::json!("SETUID")));
+    }
+
+    #[test]
+    fn user_namespaces_per_sandbox_override_disables() {
+        let template = SandboxTemplate {
+            platform_config: Some(Struct {
+                fields: std::iter::once((
+                    "host_users".to_string(),
+                    Value {
+                        kind: Some(Kind::BoolValue(true)),
+                    },
+                ))
+                .collect(),
+            }),
+            ..SandboxTemplate::default()
+        };
+
+        let params = SandboxPodParams {
+            enable_user_namespaces: true, // cluster default is on
+            ..Default::default()
+        };
+        let pod_template = sandbox_template_to_k8s(
+            &template,
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &params,
+        );
+
+        assert!(
+            pod_template["spec"]["hostUsers"].is_null(),
+            "per-sandbox host_users: true must disable user namespaces even when cluster default is on"
+        );
+        let caps = pod_template["spec"]["containers"][0]["securityContext"]["capabilities"]["add"]
+            .as_array()
+            .unwrap();
+        assert_eq!(
+            caps.len(),
+            4,
+            "extra capabilities must not be added when user namespaces are disabled"
+        );
+    }
+
+    #[test]
+    fn platform_config_bool_extracts_value() {
+        let template = SandboxTemplate {
+            platform_config: Some(Struct {
+                fields: std::iter::once((
+                    "my_bool".to_string(),
+                    Value {
+                        kind: Some(Kind::BoolValue(true)),
+                    },
+                ))
+                .collect(),
+            }),
+            ..SandboxTemplate::default()
+        };
+
+        assert_eq!(platform_config_bool(&template, "my_bool"), Some(true));
+        assert_eq!(platform_config_bool(&template, "missing"), None);
+    }
+
+    #[test]
+    fn platform_config_bool_returns_none_for_non_bool() {
+        let template = SandboxTemplate {
+            platform_config: Some(Struct {
+                fields: std::iter::once((
+                    "a_string".to_string(),
+                    Value {
+                        kind: Some(Kind::StringValue("hello".to_string())),
+                    },
+                ))
+                .collect(),
+            }),
+            ..SandboxTemplate::default()
+        };
+
+        assert_eq!(platform_config_bool(&template, "a_string"), None);
     }
 }

--- a/crates/openshell-driver-kubernetes/src/main.rs
+++ b/crates/openshell-driver-kubernetes/src/main.rs
@@ -63,6 +63,9 @@ struct Args {
 
     #[arg(long, env = "OPENSHELL_SUPERVISOR_IMAGE_PULL_POLICY")]
     supervisor_image_pull_policy: Option<String>,
+
+    #[arg(long, env = "OPENSHELL_ENABLE_USER_NAMESPACES")]
+    enable_user_namespaces: bool,
 }
 
 #[tokio::main]
@@ -88,6 +91,7 @@ async fn main() -> Result<()> {
         ssh_handshake_skew_secs: args.ssh_handshake_skew_secs,
         client_tls_secret_name: args.client_tls_secret_name.unwrap_or_default(),
         host_gateway_ip: args.host_gateway_ip.unwrap_or_default(),
+        enable_user_namespaces: args.enable_user_namespaces,
     })
     .await
     .into_diagnostic()?;

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -220,6 +220,11 @@ struct Args {
     )]
     docker_network_name: String,
 
+    /// Enable Kubernetes user namespace isolation (hostUsers: false) for
+    /// sandbox pods.
+    #[arg(long, env = "OPENSHELL_ENABLE_USER_NAMESPACES")]
+    enable_user_namespaces: bool,
+
     /// Disable TLS entirely — listen on plaintext HTTP.
     /// Use this when the gateway sits behind a reverse proxy or tunnel
     /// (e.g. Cloudflare Tunnel) that terminates TLS at the edge.
@@ -403,6 +408,8 @@ async fn run_from_args(args: Args) -> Result<()> {
             scopes_claim: args.oidc_scopes_claim,
         });
     }
+
+    config.enable_user_namespaces = args.enable_user_namespaces;
 
     let vm_config = VmComputeConfig {
         state_dir: args.vm_driver_state_dir,

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -1230,6 +1230,19 @@ fn build_platform_config(template: &SandboxTemplate) -> Option<prost_types::Stru
         );
     }
 
+    // Invert: the public API uses `user_namespaces: true` (positive sense)
+    // while the K8s driver expects `host_users: false` (K8s convention).
+    // The driver inverts this back via `!host_users` to resolve the final
+    // pod-level `hostUsers` field.
+    if let Some(user_ns) = template.user_namespaces {
+        fields.insert(
+            "host_users".to_string(),
+            Value {
+                kind: Some(Kind::BoolValue(!user_ns)),
+            },
+        );
+    }
+
     // Pass through any resource fields that do not map to the typed
     // DriverResourceRequirements so platform-specific drivers can still see
     // custom resources such as GPU limits.
@@ -2690,6 +2703,48 @@ mod tests {
         assert_eq!(
             SandboxPhase::try_from(stored.phase).unwrap(),
             SandboxPhase::Ready
+        );
+    }
+
+    #[test]
+    fn build_platform_config_inverts_user_namespaces_to_host_users() {
+        use prost_types::value::Kind;
+
+        // user_namespaces: true  → host_users: false
+        let mut template = SandboxTemplate {
+            user_namespaces: Some(true),
+            ..SandboxTemplate::default()
+        };
+        let config = build_platform_config(&template).expect("config should be Some");
+        let host_users = config
+            .fields
+            .get("host_users")
+            .expect("host_users must exist");
+        assert_eq!(
+            host_users.kind,
+            Some(Kind::BoolValue(false)),
+            "user_namespaces: true must produce host_users: false"
+        );
+
+        // user_namespaces: false → host_users: true
+        template.user_namespaces = Some(false);
+        let config = build_platform_config(&template).expect("config should be Some");
+        let host_users = config
+            .fields
+            .get("host_users")
+            .expect("host_users must exist");
+        assert_eq!(
+            host_users.kind,
+            Some(Kind::BoolValue(true)),
+            "user_namespaces: false must produce host_users: true"
+        );
+
+        // user_namespaces: None → host_users absent
+        template.user_namespaces = None;
+        let config = build_platform_config(&template);
+        assert!(
+            config.is_none() || !config.as_ref().unwrap().fields.contains_key("host_users"),
+            "unset user_namespaces must not produce host_users"
         );
     }
 }

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -487,17 +487,12 @@ async fn build_compute_runtime(
                     supervisor_image,
                     supervisor_image_pull_policy,
                     grpc_endpoint: config.grpc_endpoint.clone(),
-                    // Filesystem path to the supervisor's Unix-socket SSH daemon.
-                    // The path lives in a root-only directory so only the
-                    // supervisor can connect; the gateway reaches it through the
-                    // RelayStream bridge, not directly. Override via
-                    // `sandbox_ssh_socket_path` in the config for deployments
-                    // where multiple supervisors share a filesystem.
                     ssh_socket_path: config.sandbox_ssh_socket_path.clone(),
                     ssh_handshake_secret: config.ssh_handshake_secret.clone(),
                     ssh_handshake_skew_secs: config.ssh_handshake_skew_secs,
                     client_tls_secret_name: config.client_tls_secret_name.clone(),
                     host_gateway_ip: config.host_gateway_ip.clone(),
+                    enable_user_namespaces: config.enable_user_namespaces,
                 },
                 store,
                 sandbox_index,

--- a/deploy/helm/openshell/templates/statefulset.yaml
+++ b/deploy/helm/openshell/templates/statefulset.yaml
@@ -90,6 +90,10 @@ spec:
             - name: OPENSHELL_HOST_GATEWAY_IP
               value: {{ .Values.server.hostGatewayIP | quote }}
             {{- end }}
+            {{- if .Values.server.enableUserNamespaces }}
+            - name: OPENSHELL_ENABLE_USER_NAMESPACES
+              value: "true"
+            {{- end }}
             - name: OPENSHELL_SSH_HANDSHAKE_SECRET
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -104,6 +104,12 @@ server:
   # to this IP, allowing them to reach services running on the Docker host.
   # Auto-detected by the cluster entrypoint script.
   hostGatewayIP: ""
+  # Enable Kubernetes user namespace isolation (hostUsers: false) for sandbox
+  # pods. Requires Kubernetes 1.33+ with user namespace support available
+  # (beta through 1.35, GA in 1.36+), plus a supporting container runtime and
+  # Linux 5.12+. When enabled, container UID 0 maps to an unprivileged host
+  # UID and capabilities become namespaced.
+  enableUserNamespaces: false
   # Disable gateway authentication (mTLS client certificate requirement).
   # Set to true when the gateway sits behind a reverse proxy (e.g.
   # Cloudflare Tunnel) that terminates TLS.

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -63,6 +63,20 @@ Even if a process ignores proxy environment variables, it can only reach the pro
 | Risk if bypassed | Without network namespace isolation, a process could connect directly to the internet, bypassing all policy enforcement. |
 | Recommendation | No action needed. OpenShell enforces this automatically. |
 
+### User Namespace Isolation
+
+Kubernetes user namespaces (`hostUsers: false`) map container UID 0 to an unprivileged host UID.
+Capabilities like `CAP_SYS_ADMIN` become namespaced — they grant power over container-local resources only, not the host.
+This provides defense-in-depth: even if a container escape vulnerability exists, the attacker lands as an unprivileged host user.
+
+| Aspect | Detail |
+|---|---|
+| Default | Disabled. Set `server.enableUserNamespaces: true` in the Helm values or `OPENSHELL_ENABLE_USER_NAMESPACES=true` as an environment variable to enable cluster-wide. |
+| What you can change | Enable cluster-wide via Helm or environment variable. Override per-sandbox via the `user_namespaces` field on `SandboxTemplate` in the API. |
+| Prerequisites | Kubernetes 1.33+ with user namespace support available (beta through 1.35, GA in 1.36+), a container runtime that supports user namespaces (containerd 2.0+, CRI-O 1.25+), and Linux 5.12+ for ID-mapped mounts. |
+| Risk if enabled with GPU | NVIDIA device plugin compatibility with user namespaces is unverified. OpenShell logs a warning when both GPU and user namespaces are active on the same sandbox. |
+| Recommendation | Enable on non-GPU clusters running Kubernetes with user namespace support available (1.33+ beta, 1.36+ GA) for stronger host isolation. Test GPU workloads separately before enabling on GPU clusters. |
+
 ### Binary Identity Binding
 
 The proxy identifies which binary initiated each connection by reading `/proc/<pid>/exe` (the kernel-trusted executable path).

--- a/e2e/rust/tests/user_namespaces.rs
+++ b/e2e/rust/tests/user_namespaces.rs
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "e2e")]
+
+//! E2E test: verify Kubernetes user namespace pod spec generation.
+//!
+//! Enables `OPENSHELL_ENABLE_USER_NAMESPACES` on the gateway, triggers sandbox
+//! creation, and inspects the resulting pod spec to confirm:
+//!   1. `spec.hostUsers` is `false`
+//!   2. The container security context includes the extra capabilities
+//!      (SETUID, SETGID, DAC_READ_SEARCH) required for user namespace operation
+//!
+//! The sandbox pod may fail to start in Docker-in-Docker dev clusters where the
+//! filesystem does not support ID-mapped mounts. The test inspects the pod spec
+//! regardless of runtime success.
+
+use std::process::Stdio;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use openshell_e2e::harness::binary::openshell_cmd;
+use tokio::process::Child;
+
+async fn kubectl(args: &[&str]) -> Result<String, String> {
+    let output = tokio::process::Command::new("docker")
+        .args(["exec", "openshell-cluster-openshell", "kubectl"])
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| format!("failed to run kubectl: {e}"))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    if !output.status.success() {
+        return Err(format!("kubectl {args:?} failed: {stdout}{stderr}"));
+    }
+    Ok(stdout)
+}
+
+async fn set_user_namespaces(enable: bool) -> Result<(), String> {
+    let env_arg = if enable {
+        "OPENSHELL_ENABLE_USER_NAMESPACES=true"
+    } else {
+        "OPENSHELL_ENABLE_USER_NAMESPACES-"
+    };
+
+    kubectl(&[
+        "set", "env", "statefulset/openshell",
+        "-n", "openshell", env_arg,
+    ]).await?;
+
+    kubectl(&[
+        "rollout", "status", "statefulset/openshell",
+        "-n", "openshell", "--timeout=120s",
+    ]).await?;
+
+    // Give the gateway time to fully initialize after rollout.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    Ok(())
+}
+
+async fn delete_sandbox(name: &str) {
+    let _ = kubectl(&["delete", "sandbox", name, "-n", "openshell"]).await;
+}
+
+fn unique_sandbox_name() -> String {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    format!("userns-e2e-{suffix}")
+}
+
+async fn stop_child(child: &mut Child) {
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+}
+
+async fn wait_for_sandbox(name: &str, timeout_secs: u64) -> Result<(), String> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(n) = kubectl(&[
+            "get", "sandbox", name, "-n", "openshell",
+            "-o", "jsonpath={.metadata.name}",
+        ]).await {
+            if !n.trim().is_empty() {
+                return Ok(());
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+    Err(format!("sandbox {name} did not appear within {timeout_secs}s"))
+}
+
+/// Find a sandbox pod by its sandbox CRD name. The CRD controller creates a
+/// pod with the same name as the Sandbox resource.
+async fn wait_for_sandbox_pod(name: &str, timeout_secs: u64) -> Result<(), String> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(n) = kubectl(&[
+            "get", "pod", name, "-n", "openshell",
+            "-o", "jsonpath={.metadata.name}",
+        ]).await {
+            if !n.trim().is_empty() {
+                return Ok(());
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+    Err(format!("sandbox pod {name} did not appear within {timeout_secs}s"))
+}
+
+#[tokio::test]
+async fn sandbox_pod_spec_has_user_namespace_fields() {
+    // Enable user namespaces on the gateway.
+    set_user_namespaces(true)
+        .await
+        .expect("failed to enable user namespaces on gateway");
+
+    let sandbox_name = unique_sandbox_name();
+
+    // Start sandbox creation in the background. The pod may never become
+    // ready in DinD environments, so we spawn the CLI and inspect the pod
+    // spec independently.
+    let mut cmd = openshell_cmd();
+    cmd.arg("sandbox").arg("create")
+        .arg("--name").arg(&sandbox_name)
+        .arg("--").arg("sleep").arg("infinity");
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("failed to spawn openshell create");
+
+    if let Err(e) = wait_for_sandbox(&sandbox_name, 60).await {
+        stop_child(&mut child).await;
+        delete_sandbox(&sandbox_name).await;
+        set_user_namespaces(false).await.ok();
+        panic!("{e}");
+    }
+
+    // Wait for the pod to be created (the CRD controller creates it).
+    if let Err(e) = wait_for_sandbox_pod(&sandbox_name, 60).await {
+        stop_child(&mut child).await;
+        delete_sandbox(&sandbox_name).await;
+        set_user_namespaces(false).await.ok();
+        panic!("{e}");
+    }
+
+    // Inspect the pod spec for hostUsers.
+    let host_users = kubectl(&[
+        "get", "pod", &sandbox_name, "-n", "openshell",
+        "-o", "jsonpath={.spec.hostUsers}",
+    ]).await;
+
+    // Inspect capabilities on the agent container.
+    let caps = kubectl(&[
+        "get", "pod", &sandbox_name, "-n", "openshell",
+        "-o", "jsonpath={.spec.containers[?(@.name=='agent')].securityContext.capabilities.add}",
+    ]).await;
+
+    // Clean up.
+    stop_child(&mut child).await;
+    delete_sandbox(&sandbox_name).await;
+    set_user_namespaces(false).await.ok();
+
+    // Assert hostUsers is false.
+    let host_users_val = host_users.expect("failed to get hostUsers from pod spec");
+    assert_eq!(
+        host_users_val.trim(), "false",
+        "sandbox pod must have spec.hostUsers=false when user namespaces are enabled"
+    );
+
+    // Assert extra capabilities are present.
+    let caps_val = caps.expect("failed to get capabilities from pod spec");
+    for cap in ["SETUID", "SETGID", "DAC_READ_SEARCH"] {
+        assert!(
+            caps_val.contains(cap),
+            "sandbox pod must include {cap} in capabilities when user namespaces are enabled, got: {caps_val}"
+        );
+    }
+    for cap in ["SYS_ADMIN", "NET_ADMIN", "SYS_PTRACE", "SYSLOG"] {
+        assert!(
+            caps_val.contains(cap),
+            "sandbox pod must include {cap} in capabilities, got: {caps_val}"
+        );
+    }
+}

--- a/proto/openshell.proto
+++ b/proto/openshell.proto
@@ -248,6 +248,12 @@ message SandboxTemplate {
   google.protobuf.Struct resources = 7;
   // Optional platform-specific volume claim templates.
   google.protobuf.Struct volume_claim_templates = 9;
+  // Enable Kubernetes user namespace isolation (hostUsers: false).
+  // When true, container UID 0 maps to a non-root host UID and capabilities
+  // become namespaced. Requires Kubernetes 1.33+ with user namespace support
+  // available (beta through 1.35, GA in 1.36+) and a supporting runtime.
+  // When unset, the cluster-wide default is used.
+  optional bool user_namespaces = 10;
 }
 
 // User-facing sandbox status derived by the gateway from compute-driver observations.


### PR DESCRIPTION
## Summary
Add opt-in Kubernetes user namespace isolation  for sandbox pods. When enabled, container UID 0 maps to an unprivileged host UID and capabilities become namespaced, providing defense-in-depth against container escape vulnerabilities.

- Two-layer configuration: cluster-wide default via `OPENSHELL_ENABLE_USER_NAMESPACES` / Helm `server.enableUserNamespaces` (default off), with per-sandbox override via `SandboxTemplate.user_namespaces` in the API
- Extended capability set (`SETUID`, `SETGID`, `DAC_READ_SEARCH`) when user namespaces are active, matching the Podman driver's approach
- GPU + user namespaces warning (compatibility unverified)
- Supervisor hostPath type changed from `DirectoryOrCreate` to `Directory`
- Architecture docs, security best practices, and OCP testing guide
- Unit tests for pod spec generation and server-side inversion


## Related Issue
Fixes #982 

## Changes
**Proto & config (3 files):**
- `proto/openshell.proto` — add `optional bool user_namespaces` to `SandboxTemplate`
- `crates/openshell-core/src/config.rs` — add `enable_user_namespaces` to `Config`
- `crates/openshell-driver-kubernetes/src/config.rs` — add field to `KubernetesComputeConfig`

**Server & driver wiring (4 files):**
- `crates/openshell-server/src/cli.rs` — add `--enable-user-namespaces` CLI arg
- `crates/openshell-server/src/lib.rs` — pass config to K8s driver
- `crates/openshell-server/src/compute/mod.rs` — translate `user_namespaces` → `host_users` in `build_platform_config`
- `crates/openshell-driver-kubernetes/src/main.rs` — add CLI arg for standalone driver

**K8s driver (1 file):**
- `crates/openshell-driver-kubernetes/src/driver.rs` — add `platform_config_bool` helper, set `spec.hostUsers: false`, extend capabilities conditionally, change hostPath type to `Directory`, GPU warning, unit tests

**Helm (2 files):**
- `deploy/helm/openshell/values.yaml` — add `enableUserNamespaces: false`
- `deploy/helm/openshell/templates/statefulset.yaml` — wire env var

**Docs (4 files):**
- `docs/security/best-practices.mdx` — add User Namespace Isolation section
- `architecture/kubernetes-user-namespaces.md` — design doc with DinD limitation and Helm deployment guide
- `architecture/kubernetes-user-namespaces-ocp-testing.md` — step-by-step OCP reproduction guide

**Tests (1 file):**
- `e2e/rust/tests/user_namespaces.rs` — e2e pod spec verification


## Testing
- `cargo test -p openshell-driver-kubernetes` — 26 tests pass (8 new for user namespaces)
- `cargo test -p openshell-server --lib` — server-side inversion test passes
- `mise run e2e` — 31/32 pass (1 pre-existing flaky failure unrelated to this change)
- E2e `user_namespaces` test passes against `mise run cluster` (verifies pod spec)
- End-to-end validated on OCP 4.22 (K8s 1.35.3, CRI-O 1.35, RHEL CoreOS, kernel 5.14): full SSH tunnel with non-identity UID mapping (`0 → 3285581824`)
- End-to-end validated on native K8s v1.37 (CRI-O 1.36, Fedora, kernel 6.19): UID mapping confirmed (`0 → 2437873664`)
- Confirmed DinD limitation: pod spec correct but `MOUNT_ATTR_IDMAP` fails on nested overlayfs (documented)


## Checklist
- [x] Follows conventional commits
- [x] Unit tests added
- [x] E2E test added
- [x] Architecture docs updated
- [x] User-facing docs updated (`docs/security/best-practices.mdx`)
- [x] Helm chart updated
- [x] Feature defaults to off (no breaking changes)
- [x] Validated on a real cluster (OCP 4.22)

## Open Items
- [ ] Further testing with gpus

