### PR TITLE
fix(deps): add missing cargo-zigbuild dependency for macOS cross-compilation

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -24,6 +24,7 @@ helm = "4.1.4"
 "github:anchore/syft" = { version = "1.42.3" }
 "github:EmbarkStudios/cargo-about" = { version = "0.8.4", version_prefix = "" }
 zig = "0.14.1"
+"cargo:cargo-zigbuild" = { version = "0.22.3", os = ["macos"] }
 "npm:markdownlint-cli2" = "0.22.0"
 
 [env]


### PR DESCRIPTION
## Summary
Add the missing `cargo-zigbuild` dependency to `mise.toml` so that macOS cross-compilation works out of the box. Without this, it fails on `mise run vm:rootfs --base` step

## Related Issue
https://github.com/NVIDIA/OpenShell/discussions/917

## Changes
- Add cargo:cargo-zigbuild v0.22.3 to mise.toml, scoped to macOS only (os = ["macos"])

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
