### PR TITLE
docs(arch): index ci-e2e in architecture README

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -302,3 +302,4 @@ This opens an interactive SSH session into the sandbox, with all provider creden
 | [System Architecture](system-architecture.md) | Top-level system architecture diagram with all deployable components and communication flows. |
 | [Gateway Settings Channel](gateway-settings.md) | Runtime settings channel: two-tier key-value configuration, global policy override, settings registry, CLI/TUI commands. |
 | [TUI](tui.md) | Terminal user interface for sandbox interaction. |
+| [E2E CI Architecture](ci-e2e.md) | Workflows, triggers, and the label-driven E2E gate for self-hosted runners. |


### PR DESCRIPTION
## Summary

Adds the new `architecture/ci-e2e.md` doc to the index table in `architecture/README.md`. Trivial follow-up to #975.

This PR doubles as a test for the new `E2E Label Dispatch` workflow that landed with #975 - apply `test:e2e` here to confirm the dispatcher picks up the label, finds a fresh `pull-request/<N>` mirror, runs `branch-e2e.yml`, and posts a confirmation comment.

## Related Issue

Follow-up to #975.

## Changes

- `architecture/README.md` - one new row in the index table.

## Testing

- [ ] Apply `test:e2e` after copy-pr-bot mirrors the PR. Expect: `E2E Label Dispatch` workflow runs, posts a "Dispatched..." comment, `Branch E2E Checks` runs against `pull-request/<N>`, `E2E Gate / E2E` flips to green after the gated workflow finishes.

## Checklist

- [x] Conventional commit message
- [x] DCO sign-off
- [x] Commit signed