### PR TITLE
docs: weekly documentation refresh

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -16,19 +16,3 @@ NVIDIA OpenShell follows a frequent release cadence. Use the following GitHub re
 | [Release comparison](https://github.com/NVIDIA/OpenShell/compare) | Diff between any two tags or branches. |
 | [Merged pull requests](https://github.com/NVIDIA/OpenShell/pulls?q=is%3Apr+is%3Amerged) | Individual changes with review discussion. |
 | [Commit history](https://github.com/NVIDIA/OpenShell/commits/main) | Full commit log on `main`. |
-
-## Week of April 20 2026
-
-This weekly refresh summarizes user-facing changes merged to `main` between April 20, 2026 and April 27, 2026.
-
-| Pull request | Merged change | Documentation update |
-|---|---|---|
-| [#919](https://github.com/NVIDIA/OpenShell/pull/919) `feat(server): add object meta convention to top-level objects` | Adds sandbox labels at creation time and label-selector filtering in `openshell sandbox list`. | Added label and selector examples to [Manage Sandboxes](/sandboxes/manage-sandboxes). |
-| [#952](https://github.com/NVIDIA/OpenShell/pull/952) `fix(cli): preserve directory basename when uploading to sandbox` | Changes directory uploads to keep the source basename, matching `scp -r` and `cp -r` for named directories. | Clarified directory upload behavior in [Manage Sandboxes](/sandboxes/manage-sandboxes). |
-| [#918](https://github.com/NVIDIA/OpenShell/pull/918) `fix(sandbox): inject GIT_SSL_CAINFO so git clone trusts the sandbox CA` | Extends the injected sandbox trust-store variables so HTTPS `git clone` uses the same combined CA bundle as other TLS-aware tooling. | Updated the TLS trust-store description in [Security Best Practices](/security/best-practices). |
-| [#880](https://github.com/NVIDIA/OpenShell/pull/880) `fix(cli): sandbox get returns currently active runtime policy` | Makes `openshell sandbox get` show the currently active policy and adds `--policy-only` for scripts. | The current [Manage Sandboxes](/sandboxes/manage-sandboxes) page already reflects this behavior. |
-| [#903](https://github.com/NVIDIA/OpenShell/pull/903) `feat(server): serve health endpoints on separate unauthenticated port` | Moves `/health`, `/healthz`, and `/readyz` to a dedicated plaintext port so probes do not require mTLS client certificates. | No published operator page covers standalone gateway listener ports yet. |
-| [#915](https://github.com/NVIDIA/OpenShell/pull/915) `feat(server): allow disabling health check listener` | Lets operators disable the dedicated health listener by setting the server health port to `0`. | No published operator page covers standalone gateway listener ports yet. |
-| [#914](https://github.com/NVIDIA/OpenShell/pull/914) `feat: add configurable timeout for image transfer to gateway containerd` | Adds a configurable timeout for large image transfers into the gateway's containerd runtime. | No published task page covers this bootstrap setting yet. |
-| [#887](https://github.com/NVIDIA/OpenShell/pull/887) `feat(install-vm): install gateway + vm driver, add --driver-dir resolution` | Updates `install-vm.sh` to install both the gateway binary and VM driver, and documents `--driver-dir` resolution in repo architecture docs. | No published install guide covers `install-vm.sh` yet. |
-| [#904](https://github.com/NVIDIA/OpenShell/pull/904) `feat: Openshell driver podman` | Adds a Podman compute driver for rootless local sandbox management and related architecture documentation. | No published guide covers Podman driver setup yet. |

--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -16,3 +16,19 @@ NVIDIA OpenShell follows a frequent release cadence. Use the following GitHub re
 | [Release comparison](https://github.com/NVIDIA/OpenShell/compare) | Diff between any two tags or branches. |
 | [Merged pull requests](https://github.com/NVIDIA/OpenShell/pulls?q=is%3Apr+is%3Amerged) | Individual changes with review discussion. |
 | [Commit history](https://github.com/NVIDIA/OpenShell/commits/main) | Full commit log on `main`. |
+
+## Week of April 20 2026
+
+This weekly refresh summarizes user-facing changes merged to `main` between April 20, 2026 and April 27, 2026.
+
+| Pull request | Merged change | Documentation update |
+|---|---|---|
+| [#919](https://github.com/NVIDIA/OpenShell/pull/919) `feat(server): add object meta convention to top-level objects` | Adds sandbox labels at creation time and label-selector filtering in `openshell sandbox list`. | Added label and selector examples to [Manage Sandboxes](/sandboxes/manage-sandboxes). |
+| [#952](https://github.com/NVIDIA/OpenShell/pull/952) `fix(cli): preserve directory basename when uploading to sandbox` | Changes directory uploads to keep the source basename, matching `scp -r` and `cp -r` for named directories. | Clarified directory upload behavior in [Manage Sandboxes](/sandboxes/manage-sandboxes). |
+| [#918](https://github.com/NVIDIA/OpenShell/pull/918) `fix(sandbox): inject GIT_SSL_CAINFO so git clone trusts the sandbox CA` | Extends the injected sandbox trust-store variables so HTTPS `git clone` uses the same combined CA bundle as other TLS-aware tooling. | Updated the TLS trust-store description in [Security Best Practices](/security/best-practices). |
+| [#880](https://github.com/NVIDIA/OpenShell/pull/880) `fix(cli): sandbox get returns currently active runtime policy` | Makes `openshell sandbox get` show the currently active policy and adds `--policy-only` for scripts. | The current [Manage Sandboxes](/sandboxes/manage-sandboxes) page already reflects this behavior. |
+| [#903](https://github.com/NVIDIA/OpenShell/pull/903) `feat(server): serve health endpoints on separate unauthenticated port` | Moves `/health`, `/healthz`, and `/readyz` to a dedicated plaintext port so probes do not require mTLS client certificates. | No published operator page covers standalone gateway listener ports yet. |
+| [#915](https://github.com/NVIDIA/OpenShell/pull/915) `feat(server): allow disabling health check listener` | Lets operators disable the dedicated health listener by setting the server health port to `0`. | No published operator page covers standalone gateway listener ports yet. |
+| [#914](https://github.com/NVIDIA/OpenShell/pull/914) `feat: add configurable timeout for image transfer to gateway containerd` | Adds a configurable timeout for large image transfers into the gateway's containerd runtime. | No published task page covers this bootstrap setting yet. |
+| [#887](https://github.com/NVIDIA/OpenShell/pull/887) `feat(install-vm): install gateway + vm driver, add --driver-dir resolution` | Updates `install-vm.sh` to install both the gateway binary and VM driver, and documents `--driver-dir` resolution in repo architecture docs. | No published install guide covers `install-vm.sh` yet. |
+| [#904](https://github.com/NVIDIA/OpenShell/pull/904) `feat: Openshell driver podman` | Adds a Podman compute driver for rootless local sandbox management and related architecture documentation. | No published guide covers Podman driver setup yet. |

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -51,6 +51,21 @@ openshell sandbox create --from my-registry.example.com/my-image:latest
 
 The CLI resolves community names against the [OpenShell Community](https://github.com/NVIDIA/OpenShell-Community) catalog, pulls the bundled Dockerfile and policy, builds the image locally, and creates the sandbox. For the full catalog and how to contribute your own, refer to [Community Sandboxes](/sandboxes/community-sandboxes).
 
+### Label a Sandbox
+
+Attach labels when you create a sandbox to track ownership, environment, or workflow grouping:
+
+```shell
+openshell sandbox create --label env=dev --label team=platform -- claude
+```
+
+List only the sandboxes that match a label selector:
+
+```shell
+openshell sandbox list --selector env=dev
+openshell sandbox list --selector env=dev,team=platform
+```
+
 ## Connect to a Sandbox
 
 Open an SSH session into a running sandbox:
@@ -108,6 +123,12 @@ List all sandboxes:
 
 ```shell
 openshell sandbox list
+```
+
+Filter the list by labels when you want a narrower view:
+
+```shell
+openshell sandbox list --selector team=platform
 ```
 
 Get detailed information about a specific sandbox. The output lists **Policy source** (`sandbox` or `global`), **Revision** (the active policy’s row version for that source), and the formatted active policy YAML:
@@ -185,6 +206,8 @@ Upload files from your host into the sandbox:
 ```shell
 openshell sandbox upload my-sandbox ./src /sandbox/src
 ```
+
+When the local path is a named directory, OpenShell preserves that basename at the destination, matching `scp -r` and `cp -r`. The example above creates `/sandbox/src/src`.
 
 Download files from the sandbox to your host:
 

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -106,7 +106,7 @@ This enables credential injection and L7 inspection without explicit configurati
 
 | Aspect | Detail |
 |---|---|
-| Default | Auto-detect and terminate. OpenShell generates the sandbox CA at startup and injects it into the process trust stores (`NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`). |
+| Default | Auto-detect and terminate. OpenShell generates the sandbox CA at startup and injects it into the process trust stores (`NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`). |
 | What you can change | Set `tls: skip` on an endpoint to disable TLS detection and termination for that endpoint. Use this for client-certificate mTLS to upstream or non-standard binary protocols. |
 | Risk if relaxed | `tls: skip` disables credential injection and L7 inspection for that endpoint. The proxy relays encrypted traffic without seeing the contents. |
 | Recommendation | Use auto-detect (the default) for most endpoints. Use `tls: skip` only when the upstream requires the client's own TLS certificate (mTLS) or uses a non-HTTP protocol. |


### PR DESCRIPTION
## Summary

Refresh the published docs for user-facing changes merged during the week of April 20, 2026.

## Related Issue

None.

## Changes

- documented sandbox labels and `openshell sandbox list --selector` examples from [#919](https://github.com/NVIDIA/OpenShell/pull/919)
- documented directory upload basename preservation from [#952](https://github.com/NVIDIA/OpenShell/pull/952)
- updated the TLS trust-store docs to include `GIT_SSL_CAINFO` from [#918](https://github.com/NVIDIA/OpenShell/pull/918)
- noted additional weekly merged changes already reflected in docs or still lacking a published operator/install guide: [#880](https://github.com/NVIDIA/OpenShell/pull/880), [#903](https://github.com/NVIDIA/OpenShell/pull/903), [#915](https://github.com/NVIDIA/OpenShell/pull/915), [#914](https://github.com/NVIDIA/OpenShell/pull/914), [#887](https://github.com/NVIDIA/OpenShell/pull/887), and [#904](https://github.com/NVIDIA/OpenShell/pull/904)

## Testing

- [x] `mise run docs` passes
- [x] `mise run pre-commit` passes

Attempted both `mise` tasks after trusting the repo config. They currently fail while `mise` tries to install `uv` and `syft` because GitHub artifact attestation lookups return `403 API rate limit exceeded`.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
