### PR TITLE
fix(ci): grant actions:read and contents:read to E2E label helper

### DIFF
--- a/.github/workflows/e2e-label-help.yml
+++ b/.github/workflows/e2e-label-help.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      actions: read
+      contents: read
     steps:
       - name: Post comment
         env:

--- a/.github/workflows/e2e-label-help.yml
+++ b/.github/workflows/e2e-label-help.yml
@@ -56,11 +56,12 @@ jobs:
             run_id=$(gh api "repos/$GH_REPO/actions/workflows/$workflow_file/runs?head_sha=$PR_HEAD_SHA&event=push" \
               --jq '.workflow_runs | sort_by(.created_at) | reverse | .[0].id // empty')
             if [ -n "$run_id" ]; then
-              run_link="[the existing run](https://github.com/$GH_REPO/actions/runs/$run_id)"
+              instructions="Open [the existing run](https://github.com/$GH_REPO/actions/runs/$run_id) and click **Re-run all jobs** to execute with the label set."
             else
-              run_link="[$workflow_name](https://github.com/$GH_REPO/actions/workflows/$workflow_file)"
+              workflow_link="[$workflow_name](https://github.com/$GH_REPO/actions/workflows/$workflow_file)"
+              instructions="Open $workflow_link, find the run for commit \`$short_pr\`, and click **Re-run all jobs** to execute with the label set."
             fi
-            body="Label \`$LABEL_NAME\` applied for \`$short_pr\`. Open $run_link and click **Re-run all jobs** to execute with the label set. The \`E2E Gate\` check on this PR will flip green automatically once the run finishes."
+            body="Label \`$LABEL_NAME\` applied for \`$short_pr\`. $instructions The \`E2E Gate\` check on this PR will flip green automatically once the run finishes."
           fi
 
           gh pr comment "$PR_NUMBER" --body "$body"

--- a/CI.md
+++ b/CI.md
@@ -63,7 +63,7 @@ Prerequisites:
 Flow:
 
 1. Open the PR. copy-pr-bot mirrors it to `pull-request/<N>` automatically.
-2. The first push of `pull-request/<N>` runs `Branch E2E Checks`, but it skips the build/E2E jobs because no label is set yet. The PR's `E2E Gate` check stays neutral (no label, no requirement).
+2. The first push of `pull-request/<N>` runs `Branch E2E Checks`, but it skips the build/E2E jobs because no label is set yet. The PR's `E2E Gate` check passes as a no-op (no label, no requirement).
 3. A maintainer applies `test:e2e` and/or `test:e2e-gpu`. `E2E Label Help` posts a comment with a link to the existing `Branch E2E Checks` run.
 4. The maintainer opens that link and clicks **Re-run all jobs**. This time `pr_metadata` sees the label and the build/E2E jobs run.
 5. When the run finishes, the `E2E Gate` check on the PR flips to green automatically.

--- a/architecture/ci-e2e.md
+++ b/architecture/ci-e2e.md
@@ -150,7 +150,7 @@ Every workflow declares `permissions: {}` at the top. Per-job grants are the min
 | `e2e-gate.yml` | `e2e`, `gpu` (`workflow_call`) | inherits via the called workflow |
 | | `rerun-on-completion` | `actions: write` |
 | `e2e-gate-check.yml` | `check` | `contents: read`, `pull-requests: read`, `actions: read` |
-| `e2e-label-help.yml` | `hint` | `pull-requests: write` |
+| `e2e-label-help.yml` | `hint` | `pull-requests: write`, `actions: read`, `contents: read` |
 
 The reusable worker workflows (`e2e-test.yml`, `e2e-gpu-test.yaml`, `docker-build.yml`) declare their own internal permissions; the calling job grants are an upper bound for them.
 


### PR DESCRIPTION
## Summary

The `E2E Label Help` workflow's `gh api` calls silently failed permission checks. The job had only `pull-requests: write`, but it also calls:

- `gh api repos/<repo>/branches/<ref>` (needs `contents: read`)
- `gh api repos/<repo>/actions/workflows/<file>/runs` (needs `actions: read`)

Without those, the workflow-runs lookup returned empty and the helper fell back to linking the all-runs page for the workflow instead of the specific run for the PR head SHA. Posting comments still worked because that uses `pull-requests: write`.

Spotted while testing #990 by re-applying `test:e2e` to this PR and observing the comment linked to the workflow's all-runs page rather than the run for this PR's SHA. The same `gh api .../runs?head_sha=<sha>` call returns the run when run locally with a PAT.

Also includes a tiny CI.md wording tweak from the original test commit ("stays neutral" → "passes as a no-op", since the gate's no-label path exits 0 / green, not neutral).

## Changes

- `.github/workflows/e2e-label-help.yml` - add `actions: read` and `contents: read` to the `hint` job.
- `architecture/ci-e2e.md` - update the permissions table to match.
- `CI.md` - clarify gate-with-no-label state.

## Testing

`pull_request_target` workflow files are loaded from the base branch (main), so the fix only takes effect after this PR merges. Verification on a future PR:

- [ ] Apply `test:e2e`, confirm the `E2E Label Help` comment links to the specific `Branch E2E Checks` run for the PR head SHA, not the workflow's all-runs page.
- [ ] Apply `test:e2e` before copy-pr-bot mirrors the PR, confirm the comment instead tells the maintainer to run `/ok to test <SHA>`.

## Checklist

- [x] Conventional commit message
- [x] DCO sign-off
- [x] Commits signed