### PR TITLE
fix(podman): use podman machine socket path on macOS

### DIFF
--- a/architecture/podman-driver.md
+++ b/architecture/podman-driver.md
@@ -217,7 +217,7 @@ If the container is already gone during inspect or remove, the driver still perf
 
 | Environment Variable | CLI Flag | Default | Description |
 |---------------------|----------|---------|-------------|
-| `OPENSHELL_PODMAN_SOCKET` | `--podman-socket` | `$XDG_RUNTIME_DIR/podman/podman.sock` | Podman API Unix socket path |
+| `OPENSHELL_PODMAN_SOCKET` | `--podman-socket` | `$XDG_RUNTIME_DIR/podman/podman.sock` (Linux), `$HOME/.local/share/containers/podman/machine/podman.sock` (macOS) | Podman API Unix socket path |
 | `OPENSHELL_SANDBOX_IMAGE` | `--sandbox-image` | (from gateway config) | Default OCI image for sandboxes |
 | `OPENSHELL_SANDBOX_IMAGE_PULL_POLICY` | `--sandbox-image-pull-policy` | `missing` | Pull policy: `always`, `missing`, `never`, `newer` |
 | `OPENSHELL_GRPC_ENDPOINT` | `--grpc-endpoint` | Auto-detected via `host.containers.internal` | Gateway gRPC endpoint for sandbox callbacks |

--- a/crates/openshell-driver-podman/src/config.rs
+++ b/crates/openshell-driver-podman/src/config.rs
@@ -64,7 +64,8 @@ impl FromStr for ImagePullPolicy {
 #[derive(Clone)]
 pub struct PodmanComputeConfig {
     /// Path to the Podman API Unix socket.
-    /// Default: `$XDG_RUNTIME_DIR/podman/podman.sock`
+    /// Default: `$XDG_RUNTIME_DIR/podman/podman.sock` (Linux),
+    /// `$HOME/.local/share/containers/podman/machine/podman.sock` (macOS).
     pub socket_path: PathBuf,
     /// Default OCI image for sandboxes.
     pub default_image: String,
@@ -106,18 +107,26 @@ pub struct PodmanComputeConfig {
 impl PodmanComputeConfig {
     /// Resolve the default socket path from the environment.
     ///
-    /// Uses `$XDG_RUNTIME_DIR` when available (set by `pam_systemd`/logind),
-    /// otherwise falls back to the real UID via `getuid()` — matching how the
-    /// Podman CLI itself resolves the rootless socket path.
+    /// - **macOS**: `$HOME/.local/share/containers/podman/machine/podman.sock`
+    ///   (the symlink created by `podman machine` pointing to the VM API socket).
+    /// - **Linux**: `$XDG_RUNTIME_DIR/podman/podman.sock` when set (by
+    ///   `pam_systemd`/logind), otherwise `/run/user/{uid}/podman/podman.sock`
+    ///   using the real UID via `getuid()`.
     #[must_use]
     pub fn default_socket_path() -> PathBuf {
-        if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
-            PathBuf::from(xdg).join("podman/podman.sock")
-        } else {
-            // Use the real UID from the kernel — reliable in containers,
-            // systemd services, CI, and after su/sudo.
-            let uid = nix::unistd::getuid();
-            PathBuf::from(format!("/run/user/{uid}/podman/podman.sock"))
+        #[cfg(target_os = "macos")]
+        {
+            let home = std::env::var("HOME").expect("HOME must be set on macOS");
+            PathBuf::from(home).join(".local/share/containers/podman/machine/podman.sock")
+        }
+        #[cfg(target_os = "linux")]
+        {
+            if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
+                PathBuf::from(xdg).join("podman/podman.sock")
+            } else {
+                let uid = nix::unistd::getuid();
+                PathBuf::from(format!("/run/user/{uid}/podman/podman.sock"))
+            }
         }
     }
 }
@@ -172,6 +181,7 @@ mod tests {
         std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn default_socket_path_respects_xdg_runtime_dir() {
         let _guard = ENV_LOCK
             .lock()
@@ -183,6 +193,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn default_socket_path_falls_back_to_uid() {
         let _guard = ENV_LOCK
             .lock()
@@ -193,6 +204,21 @@ mod tests {
             assert_eq!(
                 path,
                 PathBuf::from(format!("/run/user/{uid}/podman/podman.sock"))
+            );
+        });
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn default_socket_path_uses_podman_machine_on_macos() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        temp_env::with_vars([("HOME", Some("/Users/testuser"))], || {
+            let path = PodmanComputeConfig::default_socket_path();
+            assert_eq!(
+                path,
+                PathBuf::from("/Users/testuser/.local/share/containers/podman/machine/podman.sock")
             );
         });
     }

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -58,11 +58,19 @@ impl PodmanComputeDriver {
     /// Create a new driver, verifying the Podman socket is reachable.
     pub async fn new(mut config: PodmanComputeConfig) -> Result<Self, PodmanApiError> {
         if !config.socket_path.exists() {
-            warn!(
-                path = %config.socket_path.display(),
-                "Podman socket not found; is the Podman service running? \
-                 Set OPENSHELL_PODMAN_SOCKET or XDG_RUNTIME_DIR to override."
-            );
+            if cfg!(target_os = "macos") {
+                warn!(
+                    path = %config.socket_path.display(),
+                    "Podman socket not found; is podman machine running? \
+                     Try `podman machine start` or set OPENSHELL_PODMAN_SOCKET to override."
+                );
+            } else {
+                warn!(
+                    path = %config.socket_path.display(),
+                    "Podman socket not found; is the Podman service running? \
+                     Set OPENSHELL_PODMAN_SOCKET or XDG_RUNTIME_DIR to override."
+                );
+            }
         }
 
         let client = PodmanClient::new(config.socket_path.clone());


### PR DESCRIPTION
## Summary
Fix the default Podman socket path on macOS. The driver assumed Linux conventions (`$XDG_RUNTIME_DIR` or `/run/user/{uid}/`), which do not exist on macOS. On macOS, Podman runs inside a VM via `podman machine` and exposes the API socket at `$HOME/.local/share/containers/podman/machine/podman.sock`.

## Related Issue
N/A

## Changes
- Use `#[cfg(target_os = "macos")]` / `#[cfg(target_os = "linux")]` in `default_socket_path()` to return the correct platform-specific path
- On macOS: default to `$HOME/.local/share/containers/podman/machine/podman.sock`
- On Linux: preserve existing `$XDG_RUNTIME_DIR` / `/run/user/{uid}/` logic
- Update the "socket not found" warning in `driver.rs` to suggest `podman machine start` on macOS
- Add macOS-specific unit test, gate Linux tests with `#[cfg(target_os = "linux")]`
- Update `architecture/podman-driver.md` configuration table with both platform defaults

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
