### PR TITLE
chore(ci): relax agent diagnostic gate

### DIFF
--- a/.agents/skills/triage-issue/SKILL.md
+++ b/.agents/skills/triage-issue/SKILL.md
@@ -85,19 +85,7 @@ Check whether the issue body contains a substantive agent diagnostic section. Lo
    ```bash
    gh issue edit <id> --add-label "state:triage-needed"
    ```
-2. Post a comment with the triage marker:
-   ```
-   > **📋 triage-agent**
-   >
-   > This issue was opened without an agent investigation.
-   >
-   > OpenShell is an agent-first project - before we triage this, please point your coding agent at the repo and have it investigate. Your agent can load skills like `debug-openshell-cluster` (for cluster issues), `debug-inference` (for inference setup issues), `openshell-cli` (for usage questions), or `generate-sandbox-policy` (for policy help).
-   >
-   > See [CONTRIBUTING.md](https://github.com/NVIDIA/OpenShell/blob/main/CONTRIBUTING.md#before-you-open-an-issue) for the full workflow.
-   >
-   > **Classification:** needs-more-info (agent diagnostic required)
-   ```
-3. Stop. Do not proceed with diagnosis until the reporter provides diagnostics.
+2. Do not post a standalone redirect comment. Report the missing diagnostic to the operator and stop unless a human explicitly asks you to continue triage anyway.
 
 **If the diagnostic section is substantive**, proceed to Step 4.
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -20,15 +20,16 @@ jobs:
             const body = context.payload.issue.body || '';
 
             // Check if the Agent Diagnostic section has substantive content.
-            // The template placeholder starts with "Example:" — if that's still
-            // there or the section is empty, the reporter didn't fill it in.
+            // GitHub issue forms render textarea labels as h3 headings, but
+            // issues created through gh or API clients often use h2 headings.
             const diagnosticMatch = body.match(
-              /### Agent Diagnostic\s*\n([\s\S]*?)(?=\n### |\n$)/
+              /^#{2,4}\s+Agent Diagnostic[s]?\s*\n([\s\S]*?)(?=\n#{2,4}\s+|$)/im
             );
 
-            const hasSubstantiveDiagnostic = diagnosticMatch
-              && diagnosticMatch[1].trim().length > 0
-              && !diagnosticMatch[1].trim().startsWith('Example:');
+            const diagnosticText = diagnosticMatch?.[1].trim() || '';
+            const hasSubstantiveDiagnostic = diagnosticText.length > 0
+              && !diagnosticText.toLowerCase().startsWith('example:')
+              && !['n/a', 'none', 'no', 'not applicable'].includes(diagnosticText.toLowerCase());
 
             if (hasSubstantiveDiagnostic) {
               console.log('Agent diagnostic section found with content. Passing.');
@@ -43,18 +44,4 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               labels: ['state:triage-needed']
-            });
-
-            // Post redirect comment
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: [
-                'This issue appears to have been opened without an agent investigation.',
-                '',
-                'OpenShell is an agent-first project - please point your coding agent at the repo and have it diagnose this before we triage. Your agent can load skills like `debug-openshell-cluster`, `debug-inference`, `openshell-cli`, and `generate-sandbox-policy`.',
-                '',
-                'See [CONTRIBUTING.md](https://github.com/NVIDIA/OpenShell/blob/main/CONTRIBUTING.md#before-you-open-an-issue) for the full workflow.',
-              ].join('\n')
             });


### PR DESCRIPTION
## Summary

Relax the issue triage diagnostic gate so it accepts agent diagnostic sections created by GitHub issue forms or by `gh`/API clients, and stop posting the noisy redirect comment when diagnostics are missing.

## Related Issue

Related to #967

## Changes

- Accept `##`, `###`, and `#### Agent Diagnostic(s)` headings in the issue triage workflow.
- Keep placeholder/empty diagnostic detection for truly incomplete bug reports.
- Remove the automatic public redirect comment from both the workflow and triage skill instructions.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated (not applicable; workflow/agent instruction change)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable)