### PR TITLE
feat: switch gateway image to distroless base

### DIFF
--- a/deploy/docker/Dockerfile.images
+++ b/deploy/docker/Dockerfile.images
@@ -227,23 +227,30 @@ FROM scratch AS supervisor-output
 COPY --from=supervisor-binary /build/out/openshell-sandbox /openshell-sandbox
 
 # ---------------------------------------------------------------------------
-# Final gateway image
+# Passwd stage – inject an openshell user (UID 1000) into distroless.
+# Distroless has no shell or useradd, so we craft the entry externally and
+# COPY it into the final image.
 # ---------------------------------------------------------------------------
-FROM nvcr.io/nvidia/base/ubuntu:noble-20251013 AS gateway
+FROM gcr.io/distroless/cc-debian13 AS gateway-base
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates && \
-    apt-get install -y --only-upgrade gpgv && \
-    rm -rf /var/lib/apt/lists/*
+# Copy the minimal /etc/passwd and /etc/group from the distroless base image,
+# so we preserve any existing users/groups and only add the openshell user.
+FROM debian:trixie-slim AS gateway-passwd
+COPY --from=gateway-base /etc/passwd /etc/passwd
+COPY --from=gateway-base /etc/group /etc/group
+RUN echo 'openshell:x:1000:1000::/home/openshell:/sbin/nologin' >> /etc/passwd && \
+    echo 'openshell:x:1000:' >> /etc/group && \
+    mkdir -p /home/openshell && chown 1000:1000 /home/openshell
 
-RUN useradd --create-home --user-group openshell
+FROM gateway-base AS gateway
+
+COPY --from=gateway-passwd /etc/passwd /etc/passwd
+COPY --from=gateway-passwd /etc/group /etc/group
+COPY --from=gateway-passwd --chown=1000:1000 /home/openshell /home/openshell
 
 WORKDIR /app
 
 COPY --from=gateway-binary /build/out/openshell-gateway /usr/local/bin/
-
-RUN mkdir -p /build/crates/openshell-server
-COPY --chmod=755 crates/openshell-server/migrations /build/crates/openshell-server/migrations
 
 USER openshell
 EXPOSE 8080


### PR DESCRIPTION
## Summary
Replace the Ubuntu-based gateway image with gcr.io/distroless/cc-debian13 to minimize attack surface and image size. In addition removes the migration scripts as those are embedded into the gateway binary.

Let me know what do you think about this change and if you are willing to accept such contribution.

## Related Issue
I did not find an issue about this, however I can open one if you advise so.

## Changes

- Base ubuntu image is replaced with distroless/cc-debian13 (suitable for Rust binaries)
- Copying of migration scripts was removed as those are embedded into the binary [ref](https://github.com/NVIDIA/OpenShell/blob/597580542492717091d47d23acccbbba9527d5cf/crates/openshell-server/src/persistence/postgres.rs#L11)
- The user ID was preserved to be 1000, however the distroless images come with a built in `nonroot` user. IMO it is a matter of preference so I kept the original `openshell` user. If agreed, I can switch to distroless's `nonroot` user.

## Testing
<!-- What testing was done? -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated - not applicable
- [ ] E2E tests added/updated (if applicable) - not applicable
- [x] Ran `mise run cluster` and `mise run sandbox`. Verified that the gateway works as expected.

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
