### PR TITLE
chore(ci): drop push-to-main trigger from shadow-docker-build

### DIFF
--- a/.github/workflows/shadow-docker-build.yml
+++ b/.github/workflows/shadow-docker-build.yml
@@ -12,8 +12,10 @@ name: Shadow — Docker Build (local driver + GHA cache)
 # manually 4–5 times after merge to collect cold + warm numbers.
 
 on:
-  push:
-    branches: [main]
+  # workflow_dispatch only — keeps this shadow off main's required-check
+  # surface and avoids cluttering CI history with non-blocking failures
+  # while we're still collecting Phase 3 data. Dispatch from the Actions
+  # UI to collect cold/warm-cache numbers.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Per pimlock's review on [#973](https://github.com/NVIDIA/OpenShell/pull/973): shadow workflows shouldn't auto-run on main pushes while we're still collecting Phase 3 data, so non-blocking failures don't clutter the CI run history. Switching `shadow-docker-build.yml` to `workflow_dispatch` only — same change applied to `shadow-rust-native-build.yml` directly on [#973](https://github.com/NVIDIA/OpenShell/pull/973).

We keep manual dispatch for measurement runs. The auto-baseline-on-merge pattern was redundant once we had a stable cluster (7 green Phase 3 runs already in OS-127, range 6m32s–7m6s).

## Related Issue

- [OS-127](https://linear.app/nvidia/issue/OS-127/os-49-phase-3-docker-builds-without-eks-buildkit) — Phase 3
- Companion change to [#973](https://github.com/NVIDIA/OpenShell/pull/973) which applies the same change to `shadow-rust-native-build.yml`.

## Changes

- `.github/workflows/shadow-docker-build.yml`: drop `push: branches: [main]`; keep `workflow_dispatch`.

## Testing

- 4-line YAML edit; no behavior change for `workflow_dispatch` runs.
- After merge, the workflow will only run on manual dispatch — verified via the same convention used by `shadow-shared-cpu-spike.yml` (Phase 2).

## Checklist

- [x] Conventional commit format, signed-off.
- [x] No changes to existing actions or any other workflow.
- [x] Phase 3 data already meets exit criteria; future data collection via dispatch.