### PR TITLE
fix(net): catch IPv4-mapped blocked ranges in is_always_blocked_net

### DIFF
--- a/crates/openshell-core/src/net.rs
+++ b/crates/openshell-core/src/net.rs
@@ -103,12 +103,13 @@ pub fn is_always_blocked_net(net: ipnet::IpNet) -> bool {
             // containment checks below catch broader prefixes that only reach
             // into a blocked range further in — e.g. ::ffff:168.0.0.0/103
             // has a public network address but spans ::ffff:169.254.0.0.
-            if let Some(v4) = network.to_ipv4_mapped() {
-                if v4.is_loopback() || v4.is_link_local() || v4.is_unspecified() {
-                    return true;
-                }
+            if network
+                .to_ipv4_mapped()
+                .is_some_and(|v4| v4.is_loopback() || v4.is_link_local() || v4.is_unspecified())
+            {
+                return true;
             }
-            if v6net.contains(&Ipv4Addr::new(127, 0, 0, 1).to_ipv6_mapped())
+            if v6net.contains(&Ipv4Addr::LOCALHOST.to_ipv6_mapped())
                 || v6net.contains(&Ipv4Addr::new(169, 254, 0, 0).to_ipv6_mapped())
                 || v6net.contains(&Ipv4Addr::UNSPECIFIED.to_ipv6_mapped())
             {

--- a/crates/openshell-core/src/net.rs
+++ b/crates/openshell-core/src/net.rs
@@ -97,11 +97,22 @@ pub fn is_always_blocked_net(net: ipnet::IpNet) -> bool {
                 return true;
             }
 
-            // Check IPv4-mapped IPv6 (::ffff:127.0.0.1, ::ffff:169.254.x.x, etc.)
+            // Check IPv4-mapped IPv6 addresses. The network-address check covers
+            // ranges whose first address is already in a blocked range
+            // (e.g. ::ffff:127.0.0.1/128, ::ffff:169.254.0.1/128). The
+            // containment checks below catch broader prefixes that only reach
+            // into a blocked range further in — e.g. ::ffff:168.0.0.0/103
+            // has a public network address but spans ::ffff:169.254.0.0.
             if let Some(v4) = network.to_ipv4_mapped() {
                 if v4.is_loopback() || v4.is_link_local() || v4.is_unspecified() {
                     return true;
                 }
+            }
+            if v6net.contains(&Ipv4Addr::new(127, 0, 0, 1).to_ipv6_mapped())
+                || v6net.contains(&Ipv4Addr::new(169, 254, 0, 0).to_ipv6_mapped())
+                || v6net.contains(&Ipv4Addr::UNSPECIFIED.to_ipv6_mapped())
+            {
+                return true;
             }
 
             false
@@ -330,6 +341,42 @@ mod tests {
     fn test_always_blocked_net_v6_broad_containing_loopback() {
         let net: ipnet::IpNet = "::/0".parse().unwrap();
         assert!(is_always_blocked_net(net));
+    }
+
+    #[test]
+    fn test_always_blocked_net_v6_ipv4_mapped_loopback_single() {
+        let net: ipnet::IpNet = "::ffff:127.0.0.1/128".parse().unwrap();
+        assert!(is_always_blocked_net(net));
+    }
+
+    #[test]
+    fn test_always_blocked_net_v6_ipv4_mapped_link_local_single() {
+        let net: ipnet::IpNet = "::ffff:169.254.0.1/128".parse().unwrap();
+        assert!(is_always_blocked_net(net));
+    }
+
+    #[test]
+    fn test_always_blocked_net_v6_ipv4_mapped_broad_spans_link_local() {
+        // ::ffff:168.0.0.0/103 has a public network address (168.0.0.0) but
+        // the range covers 168.0.0.0–169.255.255.255, which includes the
+        // link-local block 169.254.0.0/16.
+        let net: ipnet::IpNet = "::ffff:168.0.0.0/103".parse().unwrap();
+        assert!(is_always_blocked_net(net));
+    }
+
+    #[test]
+    fn test_always_blocked_net_v6_ipv4_mapped_broad_spans_loopback() {
+        // ::ffff:64.0.0.0/98 has a public network address (64.0.0.0) but the
+        // range covers 64.0.0.0–127.255.255.255, which includes loopback.
+        let net: ipnet::IpNet = "::ffff:64.0.0.0/98".parse().unwrap();
+        assert!(is_always_blocked_net(net));
+    }
+
+    #[test]
+    fn test_always_blocked_net_v6_ipv4_mapped_allows_public() {
+        // ::ffff:8.8.8.8/128 is a public address — should not be blocked.
+        let net: ipnet::IpNet = "::ffff:8.8.8.8/128".parse().unwrap();
+        assert!(!is_always_blocked_net(net));
     }
 
     // -- is_internal_ip --


### PR DESCRIPTION
## Summary

`is_always_blocked_net` only checked whether the network address of an IPv6 prefix mapped to a blocked IPv4 address. That misses cases where the network address is public but the range extends into a blocked zone. For example, `::ffff:168.0.0.0/103` starts at `168.0.0.0` so the old check passes it, but the range covers up to `169.255.255.255` and includes `::ffff:169.254.0.0`. The result is that `parse_allowed_ips` accepts the CIDR at policy load time while every connection to it fails silently at runtime.

The fix adds containment checks for the three IPv4-mapped blocked representatives: loopback, link-local, and unspecified. The existing network-address check stays because it still handles `/128` entries whose first address is already in a blocked range.

## Related Issue

N/A

## Changes

- Add `v6net.contains()` checks for `::ffff:127.0.0.1`, `::ffff:169.254.0.0`, and `::ffff:0.0.0.0` after the network-address check in the IPv6 branch of `is_always_blocked_net`
- Use `Ipv4Addr::LOCALHOST` instead of `Ipv4Addr::new(127, 0, 0, 1)` and collapse nested `if let / if` into `is_some_and` to satisfy clippy
- Five new tests: single-host loopback and link-local mapped addresses, broad prefixes that span each blocked range from a public start, and a public `/128` that must not be blocked

## Testing

- [x] `cargo test -p openshell-core --lib net` passes (38 tests)
- [x] `cargo clippy -p openshell-core` passes, no new warnings
- [x] `cargo fmt --check -p openshell-core` passes
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)