### PR TITLE
fix(sandbox): preserve encoded slash policy from proto

### DIFF
--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -1017,7 +1017,7 @@ flowchart LR
 | `L7Protocol` | `Rest`, `Sql` | Supported application protocols |
 | `TlsMode` | `Auto` (default), `Skip` | TLS handling strategy — `Auto` peeks first bytes and terminates if TLS is detected; `Skip` bypasses detection entirely |
 | `EnforcementMode` | `Audit`, `Enforce` | What to do on L7 deny (log-only vs block) |
-| `L7EndpointConfig` | `{ protocol, tls, enforcement }` | Per-endpoint L7 configuration |
+| `L7EndpointConfig` | `{ protocol, tls, enforcement, allow_encoded_slash }` | Per-endpoint L7 configuration |
 | `L7Decision` | `{ allowed, reason, matched_rule }` | Result of L7 evaluation |
 | `L7RequestInfo` | `{ action, target, query_params }` | HTTP method, path, and decoded query multimap for policy evaluation |
 

--- a/architecture/security-policy.md
+++ b/architecture/security-policy.md
@@ -475,6 +475,7 @@ Each endpoint defines a network destination and, optionally, L7 inspection behav
 | `access`       | `string`   | `""`            | Shorthand preset for common L7 rule sets. Mutually exclusive with `rules`.                                          |
 | `rules`        | `L7Rule[]` | `[]`            | Explicit L7 allow rules. Mutually exclusive with `access`.                                                          |
 | `allowed_ips`  | `string[]` | `[]`            | IP allowlist for SSRF override. Entries overlapping always-blocked ranges (loopback, link-local, unspecified) are rejected at load time. See [Private IP Access via `allowed_ips`](#private-ip-access-via-allowed_ips). |
+| `allow_encoded_slash` | `bool` | `false` | Preserves `%2F` inside L7 request path segments instead of rejecting the request. Required for endpoints such as npm scoped packages. |
 
 #### `NetworkBinary`
 
@@ -1462,7 +1463,7 @@ Evaluated on every CONNECT request and every forward proxy request. The same OPA
 | `network_action`          | Same input                                                                                                        | `"allow"` if endpoint + binary matched, `"deny"` otherwise                                    |
 | `deny_reason`             | Same input                                                                                                        | Human-readable string explaining why access was denied                                        |
 | `matched_network_policy`  | Same input                                                                                                        | Name of the matched policy (for audit logging)                                                |
-| `matched_endpoint_config` | Same input                                                                                                        | Raw endpoint object for L7 config extraction (returned if endpoint has `protocol` or `allowed_ips` field) |
+| `matched_endpoint_config` | Same input                                                                                                        | Raw endpoint object for L7 config extraction (returned if endpoint has `protocol`, `allowed_ips`, or explicit TLS config) |
 
 ### L7 Rules (per-request within tunnel)
 

--- a/crates/openshell-sandbox/src/opa.rs
+++ b/crates/openshell-sandbox/src/opa.rs
@@ -911,6 +911,9 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                             .collect();
                         ep["deny_rules"] = deny_rules.into();
                     }
+                    if e.allow_encoded_slash {
+                        ep["allow_encoded_slash"] = true.into();
+                    }
                     ep
                 })
                 .collect();
@@ -1944,6 +1947,63 @@ process:
         let l7 = crate::l7::parse_l7_config(&config).unwrap();
         assert_eq!(l7.protocol, crate::l7::L7Protocol::Rest);
         assert_eq!(l7.enforcement, crate::l7::EnforcementMode::Enforce);
+    }
+
+    #[test]
+    fn l7_endpoint_config_preserves_proto_allow_encoded_slash() {
+        let mut network_policies = std::collections::HashMap::new();
+        network_policies.insert(
+            "npm".to_string(),
+            NetworkPolicyRule {
+                name: "npm".to_string(),
+                endpoints: vec![NetworkEndpoint {
+                    host: "registry.npmjs.org".to_string(),
+                    port: 443,
+                    protocol: "rest".to_string(),
+                    enforcement: "enforce".to_string(),
+                    access: "read-only".to_string(),
+                    allow_encoded_slash: true,
+                    ..Default::default()
+                }],
+                binaries: vec![NetworkBinary {
+                    path: "/usr/bin/node".to_string(),
+                    ..Default::default()
+                }],
+            },
+        );
+        let proto = ProtoSandboxPolicy {
+            version: 1,
+            filesystem: Some(ProtoFs {
+                include_workdir: true,
+                read_only: vec![],
+                read_write: vec![],
+            }),
+            landlock: Some(openshell_core::proto::LandlockPolicy {
+                compatibility: "best_effort".to_string(),
+            }),
+            process: Some(ProtoProc {
+                run_as_user: "sandbox".to_string(),
+                run_as_group: "sandbox".to_string(),
+            }),
+            network_policies,
+        };
+
+        let engine = OpaEngine::from_proto(&proto).expect("engine from proto");
+        let input = NetworkInput {
+            host: "registry.npmjs.org".into(),
+            port: 443,
+            binary_path: PathBuf::from("/usr/bin/node"),
+            binary_sha256: "unused".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+        };
+
+        let config = engine
+            .query_endpoint_config(&input)
+            .unwrap()
+            .expect("endpoint config");
+        let l7 = crate::l7::parse_l7_config(&config).unwrap();
+        assert!(l7.allow_encoded_slash);
     }
 
     #[test]

--- a/docs/reference/policy-schema.mdx
+++ b/docs/reference/policy-schema.mdx
@@ -161,6 +161,7 @@ Each endpoint defines a reachable destination and optional inspection rules.
 | `rules` | list of rule objects | No | Fine-grained per-method, per-path allow rules. Mutually exclusive with `access`. |
 | `deny_rules` | list of deny rule objects | No | L7 deny rules that block specific requests even when allowed by `access` or `rules`. Deny rules take precedence over allow rules. |
 | `allowed_ips` | list of string | No | CIDR or IP allowlist for SSRF override. Entries overlapping loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), or unspecified (`0.0.0.0`) are rejected at load time. |
+| `allow_encoded_slash` | bool | No | When `true`, L7 request parsing preserves `%2F` inside path segments instead of rejecting it. Use this for registries and APIs such as npm scoped packages (`/@scope%2Fname`). Defaults to `false`. |
 
 #### Access Levels
 
@@ -262,6 +263,9 @@ network_policies:
     endpoints:
       - host: registry.npmjs.org
         port: 443
+        protocol: rest
+        access: read-only
+        allow_encoded_slash: true
     binaries:
       - path: /usr/bin/npm
       - path: /usr/bin/node


### PR DESCRIPTION
## Summary

Preserve `allow_encoded_slash` when sandbox proto policies are converted into OPA data so L7-inspected endpoints such as `registry.npmjs.org` can allow scoped npm package paths like `/@scope%2Fname`.

## Related Issue

None.

## Changes

- Copy `allow_encoded_slash` into endpoint OPA data during proto policy loading.
- Add a regression test for proto-loaded endpoint config extraction.
- Document `allow_encoded_slash` for npm registry policy examples and architecture references.

## Testing

- [ ] `mise run pre-commit` passes. Failed due unrelated pre-existing worktree changes and untracked `test-policy.yaml` license header; targeted checks below pass.
- [x] Unit tests added/updated: `cargo test -p openshell-sandbox allow_encoded_slash`
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [ ] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)