### PR TITLE
ci(rust): keep sccache stats non-blocking

### DIFF
--- a/.github/workflows/shadow-rust-native-build.yml
+++ b/.github/workflows/shadow-rust-native-build.yml
@@ -224,10 +224,6 @@ jobs:
           ldd --version
           ldd "$BIN" || true
 
-      - name: sccache stats
-        if: always()
-        run: mise x -- sccache --show-stats
-
       - name: Stage binary for prebuilt layout
         run: |
           set -euo pipefail
@@ -245,3 +241,15 @@ jobs:
           path: prebuilt-binaries/${{ inputs.arch }}/${{ steps.target.outputs.binary }}
           retention-days: ${{ inputs['retention-days'] }}
           if-no-files-found: error
+
+      - name: sccache stats
+        if: always()
+        run: |
+          set +e
+          stats_bin="${SCCACHE_PATH:-sccache}"
+          "$stats_bin" --show-stats
+          status=$?
+          if [[ $status -ne 0 ]]; then
+            echo "::warning::sccache stats unavailable (exit $status)"
+          fi
+          exit 0


### PR DESCRIPTION
## Summary

Prevent native Rust artifact jobs from failing when diagnostic sccache stats use a different client than the server started by mozilla-actions/sccache-action.

## Related Issue

Related to OS-49 / OS-128

## Changes

- Move native Rust `sccache stats` after artifact upload so diagnostics cannot block artifact staging.
- Use `SCCACHE_PATH` when the action provides it, falling back to `sccache`.
- Convert stats failures into GitHub Actions warnings.

## Testing

- [x] `git diff --check`
- [x] `mise run pre-commit`
- [x] `cargo test -p openshell-vfio tests::test_register_deregister_refcount -- --nocapture`
- [ ] Unit tests added/updated (not applicable)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable)