### PR TITLE
ci: add OS-49 phase 5 shadow workflows

### DIFF
--- a/.github/actions/pr-gate/action.yml
+++ b/.github/actions/pr-gate/action.yml
@@ -2,13 +2,15 @@ name: PR Gate
 description: >
   Resolve PR metadata for a `pull-request/<N>` push from copy-pr-bot and decide
   whether the workflow should run. Sets `should-run=true` only when the pushed
-  SHA still matches the PR head SHA and the PR carries the required label. For
-  non-`push` events (e.g. `workflow_dispatch`), always sets `should-run=true`.
+  SHA still matches the PR head SHA. If `required_label` is provided, the PR
+  must also carry that label. For non-`push` events (e.g. `workflow_dispatch`),
+  always sets `should-run=true`.
 
 inputs:
   required_label:
-    description: PR label required to enable the run (e.g. "test:e2e").
-    required: true
+    description: Optional PR label required to enable the run (e.g. "test:e2e").
+    required: false
+    default: ""
 
 outputs:
   should_run:
@@ -43,10 +45,14 @@ runs:
         fi
 
         head_sha="$(jq -r '.head.sha' <<< "$PR_INFO")"
-        has_label="$(jq -r --arg L "$REQUIRED_LABEL" '[.labels[].name] | index($L) != null' <<< "$PR_INFO")"
+        if [ -z "$REQUIRED_LABEL" ]; then
+          has_label=true
+        else
+          has_label="$(jq -r --arg L "$REQUIRED_LABEL" '[.labels[].name] | index($L) != null' <<< "$PR_INFO")"
+        fi
 
         # Only trust copied pull-request/* pushes that still match the PR head
-        # SHA and carry the required label.
+        # SHA and, when configured, carry the required label.
         if [ "$head_sha" = "$GITHUB_SHA_VALUE" ] && [ "$has_label" = "true" ]; then
           should_run=true
         else

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: ""
+      image-tag:
+        description: "Image tag base to build/push (defaults to the GitHub SHA)"
+        required: false
+        type: string
+        default: ""
 
 env:
   MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,6 +60,7 @@ jobs:
       binary_component: ${{ steps.resolve.outputs.binary_component }}
       binary_name: ${{ steps.resolve.outputs.binary_name }}
       artifact_prefix: ${{ steps.resolve.outputs.artifact_prefix }}
+      image_tag_base: ${{ steps.resolve.outputs.image_tag_base }}
     steps:
       - name: Resolve component and platform matrix
         id: resolve
@@ -76,6 +82,11 @@ jobs:
               exit 1
               ;;
           esac
+
+          image_tag_base="${{ inputs['image-tag'] }}"
+          if [[ -z "$image_tag_base" ]]; then
+            image_tag_base="$GITHUB_SHA"
+          fi
 
           platform_input="${{ inputs.platform }}"
           platform_input="${platform_input//[[:space:]]/}"
@@ -122,6 +133,7 @@ jobs:
             echo "binary_component=$binary_component"
             echo "binary_name=$binary_name"
             echo "artifact_prefix=rust-binary-${component}-${binary_component}"
+            echo "image_tag_base=$image_tag_base"
           } >> "$GITHUB_OUTPUT"
 
   rust-binary:
@@ -162,7 +174,7 @@ jobs:
         # inside the container so setup-buildx can read it.
         - /etc/buildkit:/etc/buildkit:ro
     env:
-      IMAGE_TAG: ${{ needs.resolve.outputs.platform_count == '1' && github.sha || format('{0}-{1}', github.sha, matrix.arch) }}
+      IMAGE_TAG: ${{ needs.resolve.outputs.platform_count == '1' && needs.resolve.outputs.image_tag_base || format('{0}-{1}', needs.resolve.outputs.image_tag_base, matrix.arch) }}
       IMAGE_REGISTRY: ghcr.io/nvidia/openshell
       DOCKER_PUSH: ${{ inputs.push && '1' || '0' }}
       DOCKER_PLATFORM: ${{ matrix.platform }}
@@ -264,9 +276,9 @@ jobs:
           image="ghcr.io/nvidia/openshell/${{ inputs.component }}"
           refs=()
           for arch in ${{ needs.resolve.outputs.arches }}; do
-            refs+=("${image}:${GITHUB_SHA}-${arch}")
+            refs+=("${image}:${{ needs.resolve.outputs.image_tag_base }}-${arch}")
           done
           docker buildx imagetools create \
             --prefer-index=false \
-            -t "${image}:${GITHUB_SHA}" \
+            -t "${image}:${{ needs.resolve.outputs.image_tag_base }}" \
             "${refs[@]}"

--- a/.github/workflows/shadow-branch-checks.yml
+++ b/.github/workflows/shadow-branch-checks.yml
@@ -1,0 +1,183 @@
+name: Shadow Branch Checks
+
+# OS-129 Phase 5: non-required branch-check coverage on supported shared CPU
+# runners. Pull request coverage uses copy-pr-bot's trusted pull-request/*
+# mirror branches; workflow_dispatch is for ad hoc bake runs.
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SCCACHE_GHA_ENABLED: "true"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr_metadata:
+    name: Resolve PR metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: gate
+        uses: ./.github/actions/pr-gate
+
+  mise-lockfile:
+    name: mise Lockfile
+    needs: pr_metadata
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    runs-on: linux-amd64-cpu8
+    container:
+      image: ghcr.io/nvidia/openshell/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Verify mise.lock is in sync with mise.toml
+        run: |
+          mise lock
+          if ! git diff --exit-code mise.lock; then
+            echo "::error::mise.lock is out of sync with mise.toml. Run 'mise lock' locally and commit the result." >&2
+            exit 1
+          fi
+
+  license-headers:
+    name: License Headers
+    needs: pr_metadata
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    runs-on: linux-amd64-cpu8
+    container:
+      image: ghcr.io/nvidia/openshell/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: mise install --locked
+
+      - name: Check license headers
+        run: mise run license:check
+
+  rust:
+    name: Rust (${{ matrix.runner }})
+    needs: pr_metadata
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [linux-amd64-cpu8, linux-arm64-cpu8]
+    runs-on: ${{ matrix.runner }}
+    env:
+      SCCACHE_GHA_VERSION: shadow-branch-checks-rust-${{ matrix.runner }}
+    container:
+      image: ghcr.io/nvidia/openshell/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: mise install --locked
+
+      - name: Configure GHA sccache backend
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Cache Rust target and registry
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: shadow-branch-checks-rust-${{ matrix.runner }}
+          cache-directories: .cache/sccache
+
+      - name: Format
+        run: mise run rust:format:check
+
+      - name: Lint
+        run: mise run rust:lint
+
+      - name: Test
+        run: mise run test:rust
+
+      - name: sccache stats
+        if: always()
+        run: |
+          set +e
+          stats_bin="${SCCACHE_PATH:-sccache}"
+          "$stats_bin" --show-stats
+          status=$?
+          if [[ $status -ne 0 ]]; then
+            echo "::warning::sccache stats unavailable (exit $status)"
+          fi
+          exit 0
+
+  python:
+    name: Python (${{ matrix.runner }})
+    needs: pr_metadata
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [linux-amd64-cpu8, linux-arm64-cpu8]
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ghcr.io/nvidia/openshell/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: mise install --locked
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Lint
+        run: mise run python:lint
+
+      - name: Test
+        run: mise run test:python
+
+  markdown:
+    name: Markdown
+    needs: pr_metadata
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    runs-on: linux-amd64-cpu8
+    container:
+      image: ghcr.io/nvidia/openshell/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: mise install --locked
+
+      - name: Lint
+        run: mise run markdown:lint

--- a/.github/workflows/shadow-branch-e2e.yml
+++ b/.github/workflows/shadow-branch-e2e.yml
@@ -1,0 +1,71 @@
+name: Shadow Branch E2E
+
+# OS-129 Phase 5: non-required Branch E2E coverage on supported shared CPU
+# runners. Trusted PR mirrors stay gated by the existing test:e2e label.
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr_metadata:
+    name: Resolve PR metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: gate
+        uses: ./.github/actions/pr-gate
+        with:
+          required_label: test:e2e
+
+  build-gateway:
+    needs: [pr_metadata]
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      component: gateway
+      platform: linux/arm64
+      image-tag: shadow-branch-e2e-${{ github.sha }}
+    secrets: inherit
+
+  build-cluster:
+    needs: [pr_metadata]
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      component: cluster
+      platform: linux/arm64
+      image-tag: shadow-branch-e2e-${{ github.sha }}
+    secrets: inherit
+
+  e2e:
+    needs: [pr_metadata, build-gateway, build-cluster]
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      image-tag: shadow-branch-e2e-${{ github.sha }}
+      runner: linux-arm64-cpu8
+    secrets: inherit

--- a/.github/workflows/shadow-ci-image.yml
+++ b/.github/workflows/shadow-ci-image.yml
@@ -1,0 +1,96 @@
+name: Shadow CI Image
+
+# OS-129 Phase 5: non-publishing CI image builds on supported shared CPU
+# runners. This builds each architecture natively with the local Buildx driver
+# instead of the EKS remote builder.
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+  workflow_dispatch:
+
+env:
+  CI_IMAGE: ghcr.io/nvidia/openshell/ci
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr_metadata:
+    name: Resolve PR metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: gate
+        uses: ./.github/actions/pr-gate
+
+  build-ci-image:
+    name: Build (${{ matrix.arch }})
+    needs: pr_metadata
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: linux-amd64-cpu8
+          - arch: arm64
+            platform: linux/arm64
+            runner: linux-arm64-cpu8
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve BuildKit config
+        id: buildkit
+        run: |
+          if [[ -r /etc/buildkit/buildkitd.toml ]]; then
+            echo "config=/etc/buildkit/buildkitd.toml" >> "$GITHUB_OUTPUT"
+          else
+            echo "config=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: ./.github/actions/setup-buildx
+        with:
+          driver: local
+          buildkitd-config: ${{ steps.buildkit.outputs.config }}
+
+      - name: Build CI image
+        env:
+          MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHADOW_IMAGE: ${{ env.CI_IMAGE }}:shadow-${{ github.sha }}-${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --builder openshell \
+            --platform "${{ matrix.platform }}" \
+            --secret id=MISE_GITHUB_TOKEN,env=MISE_GITHUB_TOKEN \
+            --cache-from "type=gha,scope=ci-image-${{ matrix.arch }}" \
+            --cache-to "type=gha,mode=max,scope=ci-image-${{ matrix.arch }}" \
+            --load \
+            -t "$SHADOW_IMAGE" \
+            -f deploy/docker/Dockerfile.ci \
+            .
+
+      - name: Smoke check CI image
+        env:
+          SHADOW_IMAGE: ${{ env.CI_IMAGE }}:shadow-${{ github.sha }}-${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          docker run --rm --platform "${{ matrix.platform }}" "$SHADOW_IMAGE" mise --version
+          docker run --rm --platform "${{ matrix.platform }}" "$SHADOW_IMAGE" gh --version
+          docker run --rm --platform "${{ matrix.platform }}" "$SHADOW_IMAGE" docker buildx version

--- a/.github/workflows/shadow-e2e-test.yml
+++ b/.github/workflows/shadow-e2e-test.yml
@@ -1,0 +1,72 @@
+name: Shadow E2E Test
+
+# OS-129 Phase 5: direct non-required coverage for the reusable e2e-test.yml
+# workflow on supported shared CPU runners. Trusted PR mirrors stay gated by
+# the existing test:e2e label.
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr_metadata:
+    name: Resolve PR metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: gate
+        uses: ./.github/actions/pr-gate
+        with:
+          required_label: test:e2e
+
+  build-gateway:
+    needs: [pr_metadata]
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      component: gateway
+      platform: linux/arm64
+      image-tag: shadow-e2e-test-${{ github.sha }}
+    secrets: inherit
+
+  build-cluster:
+    needs: [pr_metadata]
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      component: cluster
+      platform: linux/arm64
+      image-tag: shadow-e2e-test-${{ github.sha }}
+    secrets: inherit
+
+  e2e:
+    needs: [pr_metadata, build-gateway, build-cluster]
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      image-tag: shadow-e2e-test-${{ github.sha }}
+      runner: linux-arm64-cpu8
+    secrets: inherit

--- a/architecture/build-containers.md
+++ b/architecture/build-containers.md
@@ -23,7 +23,7 @@ The supervisor binary (`openshell-sandbox`) is built before the image build, sta
 
 ## Image Build Pipeline
 
-`deploy/docker/Dockerfile.images` no longer compiles Rust. CI calls `.github/workflows/shadow-rust-native-build.yml` through `workflow_call` to build `openshell-gateway` or `openshell-sandbox` natively on the target architecture. `.github/workflows/docker-build.yml` downloads the resulting artifact, stages it at `deploy/docker/.build/prebuilt-binaries/<arch>/`, builds the per-arch image with the local Buildx driver, and merges multi-arch pushes with `docker buildx imagetools create`.
+`deploy/docker/Dockerfile.images` no longer compiles Rust. CI calls `.github/workflows/shadow-rust-native-build.yml` through `workflow_call` to build `openshell-gateway` or `openshell-sandbox` natively on the target architecture. `.github/workflows/docker-build.yml` downloads the resulting artifact, stages it at `deploy/docker/.build/prebuilt-binaries/<arch>/`, builds the per-arch image with the local Buildx driver, and merges multi-arch pushes with `docker buildx imagetools create`. Callers normally publish the GitHub SHA tag, but shadow workflows can pass `image-tag` to publish isolated temporary tags for validation.
 
 Local Docker builds use `tasks/scripts/stage-prebuilt-binaries.sh` through `tasks/scripts/docker-build-image.sh` before invoking Docker, so clean checkouts do not need to create the staging directory manually.
 

--- a/architecture/ci-e2e.md
+++ b/architecture/ci-e2e.md
@@ -19,11 +19,18 @@ These three goals do not compose cleanly: the safety goal forces `push: pull-req
 | `.github/copy-pr-bot.yaml` | (config) | Tells copy-pr-bot to mirror trusted PRs into `pull-request/<N>` branches. Pre-existed. |
 | `.github/workflows/branch-e2e.yml` | `push: pull-request/[0-9]+` + `workflow_dispatch` | Runs non-GPU E2E on `build-arm64`. |
 | `.github/workflows/test-gpu.yml` | `push: pull-request/[0-9]+` + `workflow_dispatch` | Runs GPU E2E on self-hosted GPU runners. |
-| `.github/actions/pr-gate/action.yml` | (composite) | Resolves PR metadata for a `pull-request/<N>` push and decides whether the run should proceed. Used by the two workflows above. |
+| `.github/workflows/shadow-branch-e2e.yml`, `.github/workflows/shadow-e2e-test.yml` | `push: pull-request/[0-9]+` + `workflow_dispatch` | Non-required shared-runner E2E shadow coverage for OS-49 Phase 5. |
+| `.github/actions/pr-gate/action.yml` | (composite) | Resolves PR metadata for a `pull-request/<N>` push and decides whether the run should proceed. Label enforcement is optional, so non-required shadows can validate mirror metadata without introducing another PR label. |
 | `.github/workflows/e2e-gate.yml` | `pull_request` + `workflow_run` | Posts the required `E2E Gate` check on the PR. Re-evaluates after the gated workflow completes. |
 | `.github/workflows/e2e-gate-check.yml` | `workflow_call` | Reusable gate logic shared by E2E and GPU E2E. |
 | `.github/workflows/e2e-label-help.yml` | `pull_request_target: [labeled]` | Posts a PR comment when a `test:e2e*` label is applied, telling the maintainer the next manual step (re-run an existing run, or `/ok to test <SHA>` to refresh the mirror). Does *not* dispatch the workflow itself - see "Why we don't auto-dispatch" below. |
 | `.github/workflows/e2e-test.yml`, `e2e-gpu-test.yaml`, `docker-build.yml` | `workflow_call` | Reusable worker workflows. Unchanged by this design - called from the gated workflows and from release workflows. |
+
+## OS-49 shadow runner coverage
+
+OS-49 Phase 5 adds non-required shadow workflows for the non-release workflows being prepared for shared-runner cutover. They all use `workflow_dispatch` for manual bake runs and `push: pull-request/[0-9]+` for copy-pr-bot mirrored PRs.
+
+`shadow-branch-checks.yml` and `shadow-ci-image.yml` use `pr-gate` without a required label. That still verifies the mirror SHA matches the source PR head SHA, but does not require a new GitHub label for every ordinary CI shadow run. `shadow-branch-e2e.yml` and `shadow-e2e-test.yml` keep the existing `test:e2e` gate because they publish temporary images and run the expensive E2E suite.
 
 ## Trigger taxonomy
 

--- a/crates/openshell-vfio/src/lib.rs
+++ b/crates/openshell-vfio/src/lib.rs
@@ -845,7 +845,16 @@ pub fn reconcile_stale_bindings(sysfs: &SysfsRoot, state_path: &Path) -> Vec<Str
 mod tests {
     use super::*;
     use std::os::unix::fs::symlink;
+    use std::sync::{MutexGuard, PoisonError};
     use tempfile::TempDir;
+
+    static VFIO_ID_REFCOUNT_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn vfio_id_refcount_test_guard() -> MutexGuard<'static, ()> {
+        VFIO_ID_REFCOUNT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
 
     fn setup_mock_sysfs() -> (TempDir, SysfsRoot) {
         let tmp = TempDir::new().unwrap();
@@ -1133,6 +1142,7 @@ mod tests {
 
     #[test]
     fn test_register_vfio_new_id_writes_vendor_device() {
+        let _refcount_guard = vfio_id_refcount_test_guard();
         clear_vfio_id_refcount("10de 26b3");
         let (tmp, sysfs) = setup_mock_sysfs();
         create_pci_device(
@@ -1157,6 +1167,7 @@ mod tests {
 
     #[test]
     fn test_register_vfio_new_id_ignores_missing_new_id_file() {
+        let _refcount_guard = vfio_id_refcount_test_guard();
         clear_vfio_id_refcount("10de 26b4");
         let (tmp, sysfs) = setup_mock_sysfs();
         create_pci_device(
@@ -1177,6 +1188,7 @@ mod tests {
 
     #[test]
     fn test_deregister_vfio_new_id_writes_vendor_device() {
+        let _refcount_guard = vfio_id_refcount_test_guard();
         clear_vfio_id_refcount("10de 26b5");
         let (tmp, sysfs) = setup_mock_sysfs();
         create_pci_device(
@@ -1201,6 +1213,7 @@ mod tests {
 
     #[test]
     fn test_deregister_vfio_new_id_ignores_missing_remove_id_file() {
+        let _refcount_guard = vfio_id_refcount_test_guard();
         clear_vfio_id_refcount("10de 26b6");
         let (tmp, sysfs) = setup_mock_sysfs();
         create_pci_device(
@@ -1220,6 +1233,7 @@ mod tests {
 
     #[test]
     fn test_register_deregister_refcount() {
+        let _refcount_guard = vfio_id_refcount_test_guard();
         clear_vfio_id_refcount("10de 26b8");
         let (tmp, sysfs) = setup_mock_sysfs();
 
@@ -1298,6 +1312,8 @@ mod tests {
 
     #[test]
     fn test_prepare_gpu_skips_already_bound_companions() {
+        let _refcount_guard = vfio_id_refcount_test_guard();
+        clear_vfio_id_refcount("10de 2684");
         let (tmp, sysfs) = setup_mock_sysfs();
         create_pci_device(
             &sysfs,
@@ -1335,6 +1351,8 @@ mod tests {
 
     #[test]
     fn test_prepare_gpu_solo_iommu_group_no_companions() {
+        let _refcount_guard = vfio_id_refcount_test_guard();
+        clear_vfio_id_refcount("10de 2684");
         let (tmp, sysfs) = setup_mock_sysfs();
         create_pci_device(
             &sysfs,
@@ -1382,6 +1400,7 @@ mod tests {
 
     #[test]
     fn test_guard_drop_restores_companions() {
+        let _refcount_guard = vfio_id_refcount_test_guard();
         clear_vfio_id_refcount("10de 2684");
         let (tmp, sysfs) = setup_mock_sysfs();
         create_pci_device(
@@ -1452,6 +1471,8 @@ mod tests {
 
     #[test]
     fn test_guard_disarm_skips_restore() {
+        let _refcount_guard = vfio_id_refcount_test_guard();
+        clear_vfio_id_refcount("10de 2684");
         let (tmp, sysfs) = setup_mock_sysfs();
         create_pci_device(
             &sysfs,
@@ -1489,6 +1510,7 @@ mod tests {
 
     #[test]
     fn test_restore_gpu_deregisters_new_id_before_reprobe() {
+        let _refcount_guard = vfio_id_refcount_test_guard();
         clear_vfio_id_refcount("10de 26b7");
         let (tmp, sysfs) = setup_mock_sysfs();
         create_pci_device(
@@ -1529,6 +1551,7 @@ mod tests {
 
     #[test]
     fn test_reconcile_clears_stale_driver_override_when_not_on_vfio() {
+        let _refcount_guard = vfio_id_refcount_test_guard();
         clear_vfio_id_refcount("10de 2684");
         let (tmp, sysfs) = setup_mock_sysfs();
         create_pci_device(


### PR DESCRIPTION
## Summary

Add non-required OS-49 Phase 5 shadow workflows for branch checks, CI image builds, Branch E2E, and the reusable E2E test path on supported shared CPU runners.

## Related Issue

Related to OS-129 / OS-49.

## Changes

- Added `shadow-branch-checks.yml` on `linux-{amd64,arm64}-cpu8` with trusted PR mirror validation and GHA-backed sccache.
- Added `shadow-ci-image.yml` to build CI images natively per architecture with the local Buildx driver and no registry push.
- Added `shadow-branch-e2e.yml` and `shadow-e2e-test.yml` using the existing `test:e2e` gate and shared arm64 runner.
- Added an optional `image-tag` input to `docker-build.yml` so shadow E2E publishes isolated `shadow-*` tags.
- Made `pr-gate` usable for both label-gated E2E shadows and label-free copied-PR shadow workflows.
- Run the shadow `mise lock` check unconditionally so copied-PR push events cannot miss earlier `mise.toml` / `mise.lock` changes in the PR diff.
- Serialized VFIO refcount-map tests that mutate shared global state, fixing the parallel-test race found by the first shadow Branch Checks run.
- Removed path filtering from `shadow-ci-image.yml` so it always exercises copied PR pushes during the Phase 5 shadow bake.
- Documented the Phase 5 shadow trigger/gating model.

## Testing

- [x] `git diff --check` passes
- [x] Workflow YAML files parse locally with Ruby YAML loader
- [x] `mise x -- cargo test -p openshell-vfio --lib` passes
- [x] `mise run pre-commit` passes with sanitized PATH
- [x] GitHub Branch Checks pass on PR #1075
- [x] GitHub Shadow Branch Checks pass on PR #1075, including the unconditional `mise lock` path
- [x] GitHub Shadow CI Image passes on PR #1075
- [x] Shadow E2E/GPU metadata gates pass and correctly skip without `test:e2e` / `test:e2e-gpu` labels
- [ ] Full Docker image build run locally
- [ ] E2E tests run locally

Note: an initial `mise run pre-commit` with the default WSL/Windows-heavy PATH failed `ssh::tests::launch_editor_returns_friendly_error_when_binary_missing`; the isolated test and full pre-commit passed with Windows PATH entries removed.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)