### PR TITLE
fix(docker): set apparmor=unconfined on sandbox containers

### DIFF
--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -927,6 +927,13 @@ fn build_container_create_body(
                 "SYS_PTRACE".to_string(),
                 "SYSLOG".to_string(),
             ]),
+            // AppArmor's default Docker profile blocks mount(2) with MS_SHARED
+            // even when SYS_ADMIN is granted, which prevents ip-netns from
+            // creating network namespaces for proxy-mode isolation. The sandbox
+            // enforces its own isolation via seccomp, Landlock, and network
+            // namespaces, so the host AppArmor profile adds no meaningful
+            // defence here.
+            security_opt: Some(vec!["apparmor=unconfined".to_string()]),
             extra_hosts: Some(vec![
                 format!("{HOST_DOCKER_INTERNAL}:host-gateway"),
                 format!("{HOST_OPENSHELL_INTERNAL}:host-gateway"),


### PR DESCRIPTION
## Summary

Docker's default AppArmor profile blocks `mount(2)` with `MS_SHARED` even when `SYS_ADMIN` is granted, which prevents `ip netns add` from creating the network namespaces required for proxy-mode sandbox isolation. This fix adds `security_opt: apparmor=unconfined` to every sandbox container so network namespace creation succeeds.

## Related Issue

No tracking issue — discovered while running `mise run e2e:docker` and `mise run e2e:docker:gpu` on an AWS Ubuntu host with AppArmor enabled.

## Changes

- `crates/openshell-driver-docker/src/lib.rs`: add `security_opt: Some(vec!["apparmor=unconfined"])` to the `HostConfig` built by `build_container_create_body`

## Why this fails on some hosts but not others

AppArmor is Linux-only and not universally enabled. The failure is specific to environments that satisfy all three conditions:

1. **Linux host with AppArmor enabled** — macOS Docker Desktop, Windows WSL2 Docker, and many minimal cloud images ship without AppArmor, so `mount --make-shared` is not blocked there.
2. **Docker daemon using the built-in seccomp/AppArmor profile** — the default `docker-default` AppArmor profile restricts `mount(2)` with `MS_SHARED` regardless of which capabilities are granted. Hosts where Docker was installed without AppArmor support (`docker info` shows no `apparmor` security option) are unaffected.
3. **Kernel 5.x+ on Ubuntu/Debian** — confirmed on `6.17.0-1012-aws` (Amazon Linux / Ubuntu-derived AMI) with Docker 27.x. The same Docker version on a stock Debian image without AppArmor loaded passes `ip netns add` without this flag.

On the test machine (`6.17.0-1012-aws`, Docker with `apparmor` + `seccomp: builtin`):
```
# Without the fix — fails even as root inside the container
$ docker run --rm --cap-add SYS_ADMIN --cap-add NET_ADMIN --user 0 \
    ghcr.io/nvidia/openshell-community/sandboxes/base:latest \
    ip netns add test-ns
mount --make-shared /run/netns failed: Permission denied

# With apparmor=unconfined — succeeds
$ docker run --rm --cap-add SYS_ADMIN --cap-add NET_ADMIN --user 0 \
    --security-opt apparmor=unconfined \
    ghcr.io/nvidia/openshell-community/sandboxes/base:latest \
    ip netns add test-ns
# (exit 0)
```

Disabling AppArmor for the sandbox container is appropriate: the container already holds `SYS_ADMIN` (a very broad capability), and the sandbox enforces its own isolation layers — seccomp filters, Landlock filesystem restrictions, and the network namespace itself — making the host AppArmor profile redundant inside it.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [x] E2E tests added/updated (if applicable) — `mise run e2e:docker` and `mise run e2e:docker:gpu` both pass after this change (previously both timed out with `ContainerRestarting` due to the netns failure)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)