### PR TITLE
feat(policy): add GraphQL L7 inspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apollo-parser"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947e21ff51879f8a40d7519dfe619268de2afba4042a8a43878276de3cb910f0"
+dependencies = [
+ "memchr",
+ "rowan",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,7 +455,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.117",
 ]
@@ -877,6 +888,12 @@ dependencies = [
  "pastey",
  "rand 0.9.4",
 ]
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpufeatures"
@@ -3548,6 +3565,7 @@ name = "openshell-sandbox"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "apollo-parser",
  "base64 0.22.1",
  "bytes",
  "clap",
@@ -3570,6 +3588,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "seccompiler",
+ "serde",
  "serde_json",
  "serde_yml",
  "sha2 0.10.9",
@@ -4267,7 +4286,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -4288,7 +4307,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4622,6 +4641,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4752,6 +4783,12 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -5810,6 +5847,12 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3570,6 +3570,7 @@ dependencies = [
  "bytes",
  "clap",
  "futures",
+ "glob",
  "hex",
  "hmac",
  "ipnet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apollo-parser"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947e21ff51879f8a40d7519dfe619268de2afba4042a8a43878276de3cb910f0"
+dependencies = [
+ "memchr",
+ "rowan",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,7 +455,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.117",
 ]
@@ -840,6 +851,12 @@ dependencies = [
  "pastey",
  "rand 0.9.4",
 ]
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpufeatures"
@@ -3291,6 +3308,7 @@ name = "openshell-sandbox"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "apollo-parser",
  "base64 0.22.1",
  "bytes",
  "clap",
@@ -3313,6 +3331,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "seccompiler",
+ "serde",
  "serde_json",
  "serde_yml",
  "sha2 0.10.9",
@@ -4009,7 +4028,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -4029,7 +4048,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4322,6 +4341,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,6 +4483,12 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -5442,6 +5479,12 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ nix = { version = "0.29", features = ["signal", "process", "user", "fs", "term"]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yml = "0.0.12"
+apollo-parser = "0.8.5"
 
 # HTTP client
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -1032,7 +1032,7 @@ flowchart LR
 | `L7Protocol` | `Rest`, `Graphql`, `Sql` | Supported application protocols |
 | `TlsMode` | `Auto` (default), `Skip` | TLS handling strategy — `Auto` peeks first bytes and terminates if TLS is detected; `Skip` bypasses detection entirely |
 | `EnforcementMode` | `Audit`, `Enforce` | What to do on L7 deny (log-only vs block) |
-| `L7EndpointConfig` | `{ protocol, tls, enforcement, allow_encoded_slash, graphql_max_body_bytes }` | Per-endpoint L7 configuration |
+| `L7EndpointConfig` | `{ protocol, path, tls, enforcement, allow_encoded_slash, graphql_max_body_bytes }` | Per-endpoint L7 configuration, including optional path scoping for shared host:port APIs |
 | `L7Decision` | `{ allowed, reason, matched_rule }` | Result of L7 evaluation |
 | `L7RequestInfo` | `{ action, target, query_params, graphql }` | HTTP method, path, decoded query multimap, and optional GraphQL classification for policy evaluation |
 

--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -29,6 +29,7 @@ All paths are relative to `crates/openshell-sandbox/src/`.
 | `bypass_monitor.rs` | Background `/dev/kmsg` reader for iptables bypass detection events |
 | `sandbox/linux/netns.rs` | Network namespace creation, veth pair setup, bypass detection iptables rules, cleanup on drop |
 | `l7/mod.rs` | L7 types (`L7Protocol`, `TlsMode`, `EnforcementMode`, `L7EndpointConfig`), config parsing, validation, access preset expansion, deprecated `tls` value handling |
+| `l7/graphql.rs` | GraphQL-over-HTTP request classifier, body buffering, operation/root-field extraction, and persisted-query metadata handling |
 | `l7/inference.rs` | Inference API pattern detection (`detect_inference_pattern()`), HTTP request/response parsing and formatting for intercepted inference connections |
 | `l7/tls.rs` | Ephemeral CA generation (`SandboxCa`), per-hostname leaf cert cache (`CertCache`), TLS termination/connection helpers, `looks_like_tls()` auto-detection |
 | `l7/relay.rs` | Protocol-aware bidirectional relay with per-request OPA evaluation, credential-injection-only passthrough relay |
@@ -1028,12 +1029,12 @@ flowchart LR
 
 | Type | Definition | Purpose |
 |------|-----------|---------|
-| `L7Protocol` | `Rest`, `Sql` | Supported application protocols |
+| `L7Protocol` | `Rest`, `Graphql`, `Sql` | Supported application protocols |
 | `TlsMode` | `Auto` (default), `Skip` | TLS handling strategy — `Auto` peeks first bytes and terminates if TLS is detected; `Skip` bypasses detection entirely |
 | `EnforcementMode` | `Audit`, `Enforce` | What to do on L7 deny (log-only vs block) |
-| `L7EndpointConfig` | `{ protocol, tls, enforcement, allow_encoded_slash }` | Per-endpoint L7 configuration |
+| `L7EndpointConfig` | `{ protocol, tls, enforcement, allow_encoded_slash, graphql_max_body_bytes }` | Per-endpoint L7 configuration |
 | `L7Decision` | `{ allowed, reason, matched_rule }` | Result of L7 evaluation |
-| `L7RequestInfo` | `{ action, target, query_params }` | HTTP method, path, and decoded query multimap for policy evaluation |
+| `L7RequestInfo` | `{ action, target, query_params, graphql }` | HTTP method, path, decoded query multimap, and optional GraphQL classification for policy evaluation |
 
 ### Access presets
 
@@ -1041,9 +1042,9 @@ Policy data supports shorthand `access` presets that expand into explicit `rules
 
 | Preset | Expands to |
 |--------|-----------|
-| `read-only` | `GET **`, `HEAD **`, `OPTIONS **` |
-| `read-write` | `GET **`, `HEAD **`, `OPTIONS **`, `POST **`, `PUT **`, `PATCH **` |
-| `full` | `* **` (all methods, all paths) |
+| `read-only` | REST: `GET **`, `HEAD **`, `OPTIONS **`; GraphQL: `query` |
+| `read-write` | REST: `GET **`, `HEAD **`, `OPTIONS **`, `POST **`, `PUT **`, `PATCH **`; GraphQL: `query`, `mutation` |
+| `full` | REST: `* **`; GraphQL: `operation_type: "*"` |
 
 Expansion happens in `expand_access_presets()` before the Rego engine loads the data. The `rules` and `access` fields are mutually exclusive (validated at startup).
 
@@ -1055,14 +1056,17 @@ Expansion happens in `expand_access_presets()` before the Rego engine loads the 
 
 - `rules` and `access` both specified on same endpoint
 - `protocol` specified without `rules` or `access`
+- unknown `protocol`
 - `protocol: sql` with `enforcement: enforce` (SQL parsing not available in v1)
 - Empty `rules` array (would deny all traffic)
+- invalid GraphQL operation types, persisted-query mode, body limit, or rule shape
 
 **Warnings** (logged):
 
 - `tls: terminate` or `tls: passthrough` on any endpoint (deprecated — TLS termination is now automatic; use `tls: skip` to disable)
 - `tls: skip` with L7 rules on port 443 (L7 inspection cannot work on encrypted traffic)
 - Unknown HTTP method in rules
+- GraphQL-specific fields on non-GraphQL endpoints
 
 ### TLS termination (auto-detect)
 
@@ -1237,13 +1241,21 @@ Implements `L7Provider` for HTTP/1.1:
 
 - **`looks_like_http()`**: Protocol detection via first-byte peek -- checks for standard HTTP method prefixes (GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS, CONNECT, TRACE).
 
+### GraphQL protocol classifier
+
+**File:** `crates/openshell-sandbox/src/l7/graphql.rs`
+
+GraphQL inspection reuses the HTTP parser, then buffers the request body up to `graphql_max_body_bytes` for classification. It supports `GET` and `POST` GraphQL-over-HTTP envelopes, JSON batches, named operations, root fragment expansion, Apollo persisted-query hashes, and saved-query IDs (`id`, `documentId`, `queryId`). The classifier emits `GraphqlRequestInfo` with operation type, optional operation name, root fields, and persisted-query identifiers.
+
+Hash-only or saved-query-only requests cannot be parsed into operation fields. They are denied unless the endpoint sets `persisted_queries: allow_registered` and provides a trusted `graphql_persisted_queries` entry for the hash or ID. Batch requests are fail-closed: any malformed, denied, or unregistered operation denies the whole HTTP request.
+
 ### Per-request L7 evaluation
 
 `relay_with_inspection()` in `crates/openshell-sandbox/src/l7/relay.rs` is the main relay loop:
 
 1. Parse one HTTP request from client via the provider. Parser and path-canonicalization failures close the connection and emit a denied OCSF network event with the rejection reason in `status_detail`.
 2. Resolve credential placeholders in the request target via `rewrite_target_for_eval()`. OPA receives the redacted path (`[CREDENTIAL]` markers); the resolved path goes only to upstream. If resolution fails, return HTTP 500 and close the connection.
-3. Build L7 input JSON with `request.method`, the **redacted** `request.path`, `request.query_params`, plus the CONNECT-level context (host, port, binary, ancestors, cmdline)
+3. Build L7 input JSON with `request.method`, the **redacted** `request.path`, `request.query_params`, optional `request.graphql`, plus the CONNECT-level context (host, port, binary, ancestors, cmdline)
 4. Evaluate `data.openshell.sandbox.allow_request` and `data.openshell.sandbox.request_deny_reason`
 5. Log the L7 decision (tagged `L7_REQUEST`) using the redacted target — real credential values never appear in logs
 6. If allowed (or audit mode): relay request to upstream via `relay_http_request_with_resolver()` (which rewrites all remaining credential placeholders in headers, query parameters, path segments, and Basic auth tokens) and relay the response back to client, then loop

--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -29,6 +29,7 @@ All paths are relative to `crates/openshell-sandbox/src/`.
 | `bypass_monitor.rs` | Background `/dev/kmsg` reader for iptables bypass detection events |
 | `sandbox/linux/netns.rs` | Network namespace creation, veth pair setup, bypass detection iptables rules, cleanup on drop |
 | `l7/mod.rs` | L7 types (`L7Protocol`, `TlsMode`, `EnforcementMode`, `L7EndpointConfig`), config parsing, validation, access preset expansion, deprecated `tls` value handling |
+| `l7/graphql.rs` | GraphQL-over-HTTP request classifier, body buffering, operation/root-field extraction, and persisted-query metadata handling |
 | `l7/inference.rs` | Inference API pattern detection (`detect_inference_pattern()`), HTTP request/response parsing and formatting for intercepted inference connections |
 | `l7/tls.rs` | Ephemeral CA generation (`SandboxCa`), per-hostname leaf cert cache (`CertCache`), TLS termination/connection helpers, `looks_like_tls()` auto-detection |
 | `l7/relay.rs` | Protocol-aware bidirectional relay with per-request OPA evaluation, credential-injection-only passthrough relay |
@@ -1014,12 +1015,12 @@ flowchart LR
 
 | Type | Definition | Purpose |
 |------|-----------|---------|
-| `L7Protocol` | `Rest`, `Sql` | Supported application protocols |
+| `L7Protocol` | `Rest`, `Graphql`, `Sql` | Supported application protocols |
 | `TlsMode` | `Auto` (default), `Skip` | TLS handling strategy — `Auto` peeks first bytes and terminates if TLS is detected; `Skip` bypasses detection entirely |
 | `EnforcementMode` | `Audit`, `Enforce` | What to do on L7 deny (log-only vs block) |
-| `L7EndpointConfig` | `{ protocol, tls, enforcement, allow_encoded_slash }` | Per-endpoint L7 configuration |
+| `L7EndpointConfig` | `{ protocol, tls, enforcement, allow_encoded_slash, graphql_max_body_bytes }` | Per-endpoint L7 configuration |
 | `L7Decision` | `{ allowed, reason, matched_rule }` | Result of L7 evaluation |
-| `L7RequestInfo` | `{ action, target, query_params }` | HTTP method, path, and decoded query multimap for policy evaluation |
+| `L7RequestInfo` | `{ action, target, query_params, graphql }` | HTTP method, path, decoded query multimap, and optional GraphQL classification for policy evaluation |
 
 ### Access presets
 
@@ -1027,9 +1028,9 @@ Policy data supports shorthand `access` presets that expand into explicit `rules
 
 | Preset | Expands to |
 |--------|-----------|
-| `read-only` | `GET **`, `HEAD **`, `OPTIONS **` |
-| `read-write` | `GET **`, `HEAD **`, `OPTIONS **`, `POST **`, `PUT **`, `PATCH **` |
-| `full` | `* **` (all methods, all paths) |
+| `read-only` | REST: `GET **`, `HEAD **`, `OPTIONS **`; GraphQL: `query` |
+| `read-write` | REST: `GET **`, `HEAD **`, `OPTIONS **`, `POST **`, `PUT **`, `PATCH **`; GraphQL: `query`, `mutation` |
+| `full` | REST: `* **`; GraphQL: `operation_type: "*"` |
 
 Expansion happens in `expand_access_presets()` before the Rego engine loads the data. The `rules` and `access` fields are mutually exclusive (validated at startup).
 
@@ -1041,14 +1042,17 @@ Expansion happens in `expand_access_presets()` before the Rego engine loads the 
 
 - `rules` and `access` both specified on same endpoint
 - `protocol` specified without `rules` or `access`
+- unknown `protocol`
 - `protocol: sql` with `enforcement: enforce` (SQL parsing not available in v1)
 - Empty `rules` array (would deny all traffic)
+- invalid GraphQL operation types, persisted-query mode, body limit, or rule shape
 
 **Warnings** (logged):
 
 - `tls: terminate` or `tls: passthrough` on any endpoint (deprecated — TLS termination is now automatic; use `tls: skip` to disable)
 - `tls: skip` with L7 rules on port 443 (L7 inspection cannot work on encrypted traffic)
 - Unknown HTTP method in rules
+- GraphQL-specific fields on non-GraphQL endpoints
 
 ### TLS termination (auto-detect)
 
@@ -1223,13 +1227,21 @@ Implements `L7Provider` for HTTP/1.1:
 
 - **`looks_like_http()`**: Protocol detection via first-byte peek -- checks for standard HTTP method prefixes (GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS, CONNECT, TRACE).
 
+### GraphQL protocol classifier
+
+**File:** `crates/openshell-sandbox/src/l7/graphql.rs`
+
+GraphQL inspection reuses the HTTP parser, then buffers the request body up to `graphql_max_body_bytes` for classification. It supports `GET` and `POST` GraphQL-over-HTTP envelopes, JSON batches, named operations, root fragment expansion, Apollo persisted-query hashes, and saved-query IDs (`id`, `documentId`, `queryId`). The classifier emits `GraphqlRequestInfo` with operation type, optional operation name, root fields, and persisted-query identifiers.
+
+Hash-only or saved-query-only requests cannot be parsed into operation fields. They are denied unless the endpoint sets `persisted_queries: allow_registered` and provides a trusted `graphql_persisted_queries` entry for the hash or ID. Batch requests are fail-closed: any malformed, denied, or unregistered operation denies the whole HTTP request.
+
 ### Per-request L7 evaluation
 
 `relay_with_inspection()` in `crates/openshell-sandbox/src/l7/relay.rs` is the main relay loop:
 
 1. Parse one HTTP request from client via the provider. Parser and path-canonicalization failures close the connection and emit a denied OCSF network event with the rejection reason in `status_detail`.
 2. Resolve credential placeholders in the request target via `rewrite_target_for_eval()`. OPA receives the redacted path (`[CREDENTIAL]` markers); the resolved path goes only to upstream. If resolution fails, return HTTP 500 and close the connection.
-3. Build L7 input JSON with `request.method`, the **redacted** `request.path`, `request.query_params`, plus the CONNECT-level context (host, port, binary, ancestors, cmdline)
+3. Build L7 input JSON with `request.method`, the **redacted** `request.path`, `request.query_params`, optional `request.graphql`, plus the CONNECT-level context (host, port, binary, ancestors, cmdline)
 4. Evaluate `data.openshell.sandbox.allow_request` and `data.openshell.sandbox.request_deny_reason`
 5. Log the L7 decision (tagged `L7_REQUEST`) using the redacted target — real credential values never appear in logs
 6. If allowed (or audit mode): relay request to upstream via `relay_http_request_with_resolver()` (which rewrites all remaining credential placeholders in headers, query parameters, path segments, and Basic auth tokens) and relay the response back to client, then loop

--- a/architecture/security-policy.md
+++ b/architecture/security-policy.md
@@ -476,6 +476,9 @@ Each endpoint defines a network destination and, optionally, L7 inspection behav
 | `rules`        | `L7Rule[]` | `[]`            | Explicit L7 allow rules. Mutually exclusive with `access`.                                                          |
 | `allowed_ips`  | `string[]` | `[]`            | IP allowlist for SSRF override. Entries overlapping always-blocked ranges (loopback, link-local, unspecified) are rejected at load time. See [Private IP Access via `allowed_ips`](#private-ip-access-via-allowed_ips). |
 | `allow_encoded_slash` | `bool` | `false` | Preserves `%2F` inside L7 request path segments instead of rejecting the request. Required for endpoints such as npm scoped packages. |
+| `persisted_queries` | `string` | `"deny"` | GraphQL hash-only/saved-query behavior. Use `"allow_registered"` only with `graphql_persisted_queries`. |
+| `graphql_persisted_queries` | `map` | `{}` | Trusted GraphQL persisted-query registry keyed by hash or service-specific ID. Values contain `operation_type`, optional `operation_name`, and optional root `fields`. |
+| `graphql_max_body_bytes` | `integer` | `65536` | Maximum GraphQL request body size buffered for inspection. Larger GraphQL bodies are rejected before policy evaluation. |
 
 #### `NetworkBinary`
 
@@ -507,6 +510,13 @@ rules:
       query:
         labels:
           any: ["bug*", "p1*"]
+  - allow:
+      operation_type: query
+      fields: [viewer, repository]
+  - allow:
+      operation_type: mutation
+      operation_name: Issue*
+      fields: [createIssue]
 ```
 
 #### `L7Allow`
@@ -517,18 +527,23 @@ rules:
 | `path`    | `string` | URL path glob pattern: `**` matches everything, otherwise `glob.match` with `/` delimiter.                                   |
 | `command` | `string` | SQL command: `SELECT`, `INSERT`, `UPDATE`, `DELETE`, or `*` (any). Case-insensitive matching. For `protocol: sql` endpoints. |
 | `query`   | `map`    | Optional REST query rules keyed by decoded query param name. Value is either a glob string (for example, `tag: "foo-*"`) or `{ any: ["foo-*", "bar-*"] }`. |
+| `operation_type` | `string` | GraphQL operation type: `query`, `mutation`, `subscription`, or `*`. Required for `protocol: graphql` allow rules. |
+| `operation_name` | `string` | Optional GraphQL operation-name glob. Omit to match any operation name. |
+| `fields` | `string[]` | Optional GraphQL root-field globs. For allow rules, every selected root field must match one configured glob. For deny rules, any matching root field blocks the request. |
 
-Method and command fields use `*` as wildcard for "any". Path patterns use `**` for "match everything" and standard glob patterns with `/` as a delimiter otherwise. Query matching is case-sensitive and evaluates decoded values; when duplicate keys are present in the request, every value for that key must match the configured matcher. See `sandbox-policy.rego` -- `method_matches()`, `path_matches()`, `command_matches()`, `query_params_match()`.
+Method, command, and GraphQL operation type fields use `*` as wildcard for "any". Path patterns use `**` for "match everything" and standard glob patterns with `/` as a delimiter otherwise. Query matching is case-sensitive and evaluates decoded values; when duplicate keys are present in the request, every value for that key must match the configured matcher. GraphQL field and operation-name matching also uses glob patterns. See `sandbox-policy.rego` -- `method_matches()`, `path_matches()`, `command_matches()`, `query_params_match()`, and `graphql_*`.
+
+GraphQL inspection supports `GET` and `POST` GraphQL-over-HTTP envelopes, JSON batches, named-operation selection, fragments at the operation root, Apollo persisted-query hashes, and service-specific saved-query IDs (`id`, `documentId`, or `queryId`). Hash-only or saved-query-only requests have no parseable document, so they are denied unless `persisted_queries: allow_registered` is set and the hash or ID appears in `graphql_persisted_queries`. If a batch contains any denied, malformed, or unregistered operation, the whole request is denied.
 
 #### Access Presets
 
 The `access` field provides shorthand for common rule sets. During preprocessing, presets are expanded into explicit `rules` arrays before Rego evaluation.
 
-| Preset       | Expands To                                                         | Description                              |
-| ------------ | ------------------------------------------------------------------ | ---------------------------------------- |
-| `read-only`  | `GET/**`, `HEAD/**`, `OPTIONS/**`                                  | Safe read-only HTTP methods on all paths |
-| `read-write` | `GET/**`, `HEAD/**`, `OPTIONS/**`, `POST/**`, `PUT/**`, `PATCH/**` | Read and write but not delete            |
-| `full`       | `*/**`                                                             | All methods, all paths                   |
+| Preset       | REST expansion                                                     | GraphQL expansion              | Description                              |
+| ------------ | ------------------------------------------------------------------ | ------------------------------ | ---------------------------------------- |
+| `read-only`  | `GET/**`, `HEAD/**`, `OPTIONS/**`                                  | `operation_type: query`        | Safe read-only access                    |
+| `read-write` | `GET/**`, `HEAD/**`, `OPTIONS/**`, `POST/**`, `PUT/**`, `PATCH/**` | `query`, `mutation`            | Read and write but not delete for REST   |
+| `full`       | `*/**`                                                             | `operation_type: "*"`          | All supported actions                    |
 
 See `crates/openshell-sandbox/src/l7/mod.rs` -- `expand_access_presets()`.
 
@@ -719,9 +734,10 @@ flowchart LR
 | -------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `protocol` absent or empty | **L4 (transport)**               | The proxy performs a raw `copy_bidirectional` after the CONNECT handshake. No application-layer inspection occurs. Only the host:port and binary identity are checked.   |
 | `protocol: rest`           | **L7 (application)**             | The proxy parses each HTTP/1.1 request within the tunnel, evaluates method+path against the endpoint's `rules`, and either forwards or denies each request individually. |
+| `protocol: graphql`        | **L7 (application)**             | The proxy parses GraphQL-over-HTTP requests, classifies operation type, operation name, root fields, and persisted-query identifiers, then evaluates GraphQL allow and deny rules. |
 | `protocol: sql`            | **L7 (application, audit-only)** | Reserved for SQL protocol inspection. Currently falls through to passthrough with a warning. `enforcement: enforce` is rejected at validation time for SQL endpoints.    |
 
-This is the single most important behavioral trigger in the policy language. An endpoint with no `protocol` field passes traffic opaquely after the L4 (CONNECT) check. Adding `protocol: rest` activates per-request HTTP parsing and policy evaluation inside the proxy.
+This is the single most important behavioral trigger in the policy language. An endpoint with no `protocol` field passes traffic opaquely after the L4 (CONNECT) check. Adding `protocol: rest` or `protocol: graphql` activates per-request HTTP parsing and policy evaluation inside the proxy.
 
 **Implementation path**: After L4 CONNECT is allowed, the proxy calls `query_l7_route_snapshot()` which evaluates the Rego rule `data.openshell.sandbox.matched_endpoint_config` and records the policy generation. If an endpoint `protocol` config is returned, the proxy enters `relay_with_inspection()` instead of `copy_bidirectional()`. See `crates/openshell-sandbox/src/proxy.rs` -- `handle_tcp_connection()`.
 
@@ -1476,10 +1492,10 @@ Evaluated on every CONNECT request and every forward proxy request. The same OPA
 
 ### L7 Rules (per-request within tunnel)
 
-| Rule                  | Signature                                                                       | Returns                                                        |
-| --------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `allow_request`       | `input.network.*`, `input.exec.*`, `input.request.method`, `input.request.path` | `true` if the request matches any rule in the matched endpoint |
-| `request_deny_reason` | Same input                                                                      | Human-readable deny message                                    |
+| Rule                  | Signature                                                                                                  | Returns                                                        |
+| --------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `allow_request`       | `input.network.*`, `input.exec.*`, `input.request.method`, `input.request.path`, optional `request.graphql` | `true` if the request matches the matched endpoint's L7 rules |
+| `request_deny_reason` | Same input                                                                                                 | Human-readable deny message                                    |
 
 See `sandbox-policy.rego` for the full Rego implementation.
 

--- a/architecture/security-policy.md
+++ b/architecture/security-policy.md
@@ -469,6 +469,7 @@ Each endpoint defines a network destination and, optionally, L7 inspection behav
 | `host`         | `string`   | _(required)_    | Hostname or glob pattern to match (case-insensitive). Supports wildcards (`*.example.com`). Optional when `allowed_ips` is set (see [Hostless Endpoints](#hostless-endpoints-allowed_ips-without-host)). See [Host Wildcards](#host-wildcards). |
 | `port`         | `integer`  | _(required)_    | TCP port to match. Mutually exclusive with `ports` — if both are set, `ports` takes precedence. See [Multi-Port Endpoints](#multi-port-endpoints). |
 | `ports`        | `integer[]`| `[]`            | Multiple TCP ports to match. When non-empty, the endpoint covers all listed ports. Backwards compatible with `port`. See [Multi-Port Endpoints](#multi-port-endpoints). |
+| `path`         | `string`   | `""`            | Optional HTTP path glob for L7 endpoint selection when multiple protocols share a host:port, such as `/repos/**` and `/graphql`. Empty matches all paths. |
 | `protocol`     | `string`   | `""`            | Application protocol for L7 inspection. See [Behavioral Trigger: L7 Inspection](#behavioral-trigger-l7-inspection). |
 | `tls`          | `string`   | `""` (auto)      | TLS handling mode. Absent or empty: auto-detect and terminate TLS if detected. `"skip"`: bypass TLS detection entirely. `"terminate"` and `"passthrough"` are deprecated (treated as auto). See [Behavioral Trigger: TLS Handling](#behavioral-trigger-tls-handling). |
 | `enforcement`  | `string`   | `"audit"`       | L7 enforcement mode: `"enforce"` or `"audit"`                                                                       |
@@ -739,7 +740,7 @@ flowchart LR
 
 This is the single most important behavioral trigger in the policy language. An endpoint with no `protocol` field passes traffic opaquely after the L4 (CONNECT) check. Adding `protocol: rest` or `protocol: graphql` activates per-request HTTP parsing and policy evaluation inside the proxy.
 
-**Implementation path**: After L4 CONNECT is allowed, the proxy calls `query_l7_route_snapshot()` which evaluates the Rego rule `data.openshell.sandbox.matched_endpoint_config` and records the policy generation. If an endpoint `protocol` config is returned, the proxy enters `relay_with_inspection()` instead of `copy_bidirectional()`. See `crates/openshell-sandbox/src/proxy.rs` -- `handle_tcp_connection()`.
+**Implementation path**: After L4 CONNECT is allowed, the proxy calls `query_l7_route_snapshot()` which evaluates the Rego rule `data.openshell.sandbox._matching_endpoint_configs` and records the policy generation. If one or more endpoint `protocol` configs are returned, the proxy enters path-aware L7 route selection instead of `copy_bidirectional()`. See `crates/openshell-sandbox/src/proxy.rs` -- `handle_tcp_connection()`.
 
 For L7-inspected CONNECT tunnels, the proxy binds endpoint config and the per-tunnel policy engine clone to the policy generation observed at tunnel setup. If a live policy reload advances the generation, the relay closes the existing keep-alive tunnel before forwarding another request. HTTP passthrough tunnels without endpoint `protocol` use the same generation guard for parsed requests even though they do not evaluate L7 OPA rules. Clients should reconnect so the next request is evaluated under the current policy.
 

--- a/architecture/security-policy.md
+++ b/architecture/security-policy.md
@@ -476,6 +476,9 @@ Each endpoint defines a network destination and, optionally, L7 inspection behav
 | `rules`        | `L7Rule[]` | `[]`            | Explicit L7 allow rules. Mutually exclusive with `access`.                                                          |
 | `allowed_ips`  | `string[]` | `[]`            | IP allowlist for SSRF override. Entries overlapping always-blocked ranges (loopback, link-local, unspecified) are rejected at load time. See [Private IP Access via `allowed_ips`](#private-ip-access-via-allowed_ips). |
 | `allow_encoded_slash` | `bool` | `false` | Preserves `%2F` inside L7 request path segments instead of rejecting the request. Required for endpoints such as npm scoped packages. |
+| `persisted_queries` | `string` | `"deny"` | GraphQL hash-only/saved-query behavior. Use `"allow_registered"` only with `graphql_persisted_queries`. |
+| `graphql_persisted_queries` | `map` | `{}` | Trusted GraphQL persisted-query registry keyed by hash or service-specific ID. Values contain `operation_type`, optional `operation_name`, and optional root `fields`. |
+| `graphql_max_body_bytes` | `integer` | `65536` | Maximum GraphQL request body size buffered for inspection. Larger GraphQL bodies are rejected before policy evaluation. |
 
 #### `NetworkBinary`
 
@@ -507,6 +510,13 @@ rules:
       query:
         labels:
           any: ["bug*", "p1*"]
+  - allow:
+      operation_type: query
+      fields: [viewer, repository]
+  - allow:
+      operation_type: mutation
+      operation_name: Issue*
+      fields: [createIssue]
 ```
 
 #### `L7Allow`
@@ -517,18 +527,23 @@ rules:
 | `path`    | `string` | URL path glob pattern: `**` matches everything, otherwise `glob.match` with `/` delimiter.                                   |
 | `command` | `string` | SQL command: `SELECT`, `INSERT`, `UPDATE`, `DELETE`, or `*` (any). Case-insensitive matching. For `protocol: sql` endpoints. |
 | `query`   | `map`    | Optional REST query rules keyed by decoded query param name. Value is either a glob string (for example, `tag: "foo-*"`) or `{ any: ["foo-*", "bar-*"] }`. |
+| `operation_type` | `string` | GraphQL operation type: `query`, `mutation`, `subscription`, or `*`. Required for `protocol: graphql` allow rules. |
+| `operation_name` | `string` | Optional GraphQL operation-name glob. Omit to match any operation name. |
+| `fields` | `string[]` | Optional GraphQL root-field globs. For allow rules, every selected root field must match one configured glob. For deny rules, any matching root field blocks the request. |
 
-Method and command fields use `*` as wildcard for "any". Path patterns use `**` for "match everything" and standard glob patterns with `/` as a delimiter otherwise. Query matching is case-sensitive and evaluates decoded values; when duplicate keys are present in the request, every value for that key must match the configured matcher. See `sandbox-policy.rego` -- `method_matches()`, `path_matches()`, `command_matches()`, `query_params_match()`.
+Method, command, and GraphQL operation type fields use `*` as wildcard for "any". Path patterns use `**` for "match everything" and standard glob patterns with `/` as a delimiter otherwise. Query matching is case-sensitive and evaluates decoded values; when duplicate keys are present in the request, every value for that key must match the configured matcher. GraphQL field and operation-name matching also uses glob patterns. See `sandbox-policy.rego` -- `method_matches()`, `path_matches()`, `command_matches()`, `query_params_match()`, and `graphql_*`.
+
+GraphQL inspection supports `GET` and `POST` GraphQL-over-HTTP envelopes, JSON batches, named-operation selection, fragments at the operation root, Apollo persisted-query hashes, and service-specific saved-query IDs (`id`, `documentId`, or `queryId`). Hash-only or saved-query-only requests have no parseable document, so they are denied unless `persisted_queries: allow_registered` is set and the hash or ID appears in `graphql_persisted_queries`. If a batch contains any denied, malformed, or unregistered operation, the whole request is denied.
 
 #### Access Presets
 
 The `access` field provides shorthand for common rule sets. During preprocessing, presets are expanded into explicit `rules` arrays before Rego evaluation.
 
-| Preset       | Expands To                                                         | Description                              |
-| ------------ | ------------------------------------------------------------------ | ---------------------------------------- |
-| `read-only`  | `GET/**`, `HEAD/**`, `OPTIONS/**`                                  | Safe read-only HTTP methods on all paths |
-| `read-write` | `GET/**`, `HEAD/**`, `OPTIONS/**`, `POST/**`, `PUT/**`, `PATCH/**` | Read and write but not delete            |
-| `full`       | `*/**`                                                             | All methods, all paths                   |
+| Preset       | REST expansion                                                     | GraphQL expansion              | Description                              |
+| ------------ | ------------------------------------------------------------------ | ------------------------------ | ---------------------------------------- |
+| `read-only`  | `GET/**`, `HEAD/**`, `OPTIONS/**`                                  | `operation_type: query`        | Safe read-only access                    |
+| `read-write` | `GET/**`, `HEAD/**`, `OPTIONS/**`, `POST/**`, `PUT/**`, `PATCH/**` | `query`, `mutation`            | Read and write but not delete for REST   |
+| `full`       | `*/**`                                                             | `operation_type: "*"`          | All supported actions                    |
 
 See `crates/openshell-sandbox/src/l7/mod.rs` -- `expand_access_presets()`.
 
@@ -719,9 +734,10 @@ flowchart LR
 | -------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `protocol` absent or empty | **L4 (transport)**               | The proxy performs a raw `copy_bidirectional` after the CONNECT handshake. No application-layer inspection occurs. Only the host:port and binary identity are checked.   |
 | `protocol: rest`           | **L7 (application)**             | The proxy parses each HTTP/1.1 request within the tunnel, evaluates method+path against the endpoint's `rules`, and either forwards or denies each request individually. |
+| `protocol: graphql`        | **L7 (application)**             | The proxy parses GraphQL-over-HTTP requests, classifies operation type, operation name, root fields, and persisted-query identifiers, then evaluates GraphQL allow and deny rules. |
 | `protocol: sql`            | **L7 (application, audit-only)** | Reserved for SQL protocol inspection. Currently falls through to passthrough with a warning. `enforcement: enforce` is rejected at validation time for SQL endpoints.    |
 
-This is the single most important behavioral trigger in the policy language. An endpoint with no `protocol` field passes traffic opaquely after the L4 (CONNECT) check. Adding `protocol: rest` activates per-request HTTP parsing and policy evaluation inside the proxy.
+This is the single most important behavioral trigger in the policy language. An endpoint with no `protocol` field passes traffic opaquely after the L4 (CONNECT) check. Adding `protocol: rest` or `protocol: graphql` activates per-request HTTP parsing and policy evaluation inside the proxy.
 
 **Implementation path**: After L4 CONNECT is allowed, the proxy calls `query_l7_config()` which evaluates the Rego rule `data.openshell.sandbox.matched_endpoint_config`. This rule only matches endpoints that have a `protocol` field set (see `sandbox-policy.rego` line `ep.protocol`). If a config is returned, the proxy enters `relay_with_inspection()` instead of `copy_bidirectional()`. See `crates/openshell-sandbox/src/proxy.rs` -- `handle_tcp_connection()`.
 
@@ -1467,10 +1483,10 @@ Evaluated on every CONNECT request and every forward proxy request. The same OPA
 
 ### L7 Rules (per-request within tunnel)
 
-| Rule                  | Signature                                                                       | Returns                                                        |
-| --------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `allow_request`       | `input.network.*`, `input.exec.*`, `input.request.method`, `input.request.path` | `true` if the request matches any rule in the matched endpoint |
-| `request_deny_reason` | Same input                                                                      | Human-readable deny message                                    |
+| Rule                  | Signature                                                                                                  | Returns                                                        |
+| --------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `allow_request`       | `input.network.*`, `input.exec.*`, `input.request.method`, `input.request.path`, optional `request.graphql` | `true` if the request matches the matched endpoint's L7 rules |
+| `request_deny_reason` | Same input                                                                                                 | Human-readable deny message                                    |
 
 See `sandbox-policy.rego` for the full Rego implementation.
 

--- a/crates/openshell-cli/src/policy_update.rs
+++ b/crates/openshell-cli/src/policy_update.rs
@@ -168,6 +168,9 @@ fn group_allow_rules(specs: &[String]) -> Result<BTreeMap<(String, u32), Vec<L7R
                     path: parsed.path,
                     command: String::new(),
                     query: HashMap::default(),
+                    operation_type: String::new(),
+                    operation_name: String::new(),
+                    fields: Vec::new(),
                 }),
             });
     }
@@ -186,6 +189,9 @@ fn group_deny_rules(specs: &[String]) -> Result<BTreeMap<(String, u32), Vec<L7De
                 path: parsed.path,
                 command: String::new(),
                 query: HashMap::default(),
+                operation_type: String::new(),
+                operation_name: String::new(),
+                fields: Vec::new(),
             });
     }
     Ok(grouped)

--- a/crates/openshell-policy/src/lib.rs
+++ b/crates/openshell-policy/src/lib.rs
@@ -17,8 +17,9 @@ use std::path::Path;
 
 use miette::{IntoDiagnostic, Result, WrapErr};
 use openshell_core::proto::{
-    FilesystemPolicy, L7Allow, L7DenyRule, L7QueryMatcher, L7Rule, LandlockPolicy, NetworkBinary,
-    NetworkEndpoint, NetworkPolicyRule, ProcessPolicy, SandboxPolicy,
+    FilesystemPolicy, GraphqlOperation, L7Allow, L7DenyRule, L7QueryMatcher, L7Rule,
+    LandlockPolicy, NetworkBinary, NetworkEndpoint, NetworkPolicyRule, ProcessPolicy,
+    SandboxPolicy,
 };
 use serde::{Deserialize, Serialize};
 
@@ -115,12 +116,35 @@ struct NetworkEndpointDef {
     /// Defaults to false (strict).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     allow_encoded_slash: bool,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    persisted_queries: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    graphql_persisted_queries: BTreeMap<String, GraphqlOperationDef>,
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    graphql_max_body_bytes: u32,
 }
 
 // Signature dictated by serde's `skip_serializing_if`, which requires `&T`.
 #[allow(clippy::trivially_copy_pass_by_ref)]
 fn is_zero(v: &u16) -> bool {
     *v == 0
+}
+
+// Signature dictated by serde's `skip_serializing_if`, which requires `&T`.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_zero_u32(v: &u32) -> bool {
+    *v == 0
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GraphqlOperationDef {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    operation_type: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    operation_name: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    fields: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -140,6 +164,12 @@ struct L7AllowDef {
     command: String,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     query: BTreeMap<String, QueryMatcherDef>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    operation_type: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    operation_name: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    fields: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -167,6 +197,12 @@ struct L7DenyRuleDef {
     command: String,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     query: BTreeMap<String, QueryMatcherDef>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    operation_type: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    operation_name: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    fields: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -223,6 +259,9 @@ fn to_proto(raw: PolicyFile) -> SandboxPolicy {
                                         method: r.allow.method,
                                         path: r.allow.path,
                                         command: r.allow.command,
+                                        operation_type: r.allow.operation_type,
+                                        operation_name: r.allow.operation_name,
+                                        fields: r.allow.fields,
                                         query: r
                                             .allow
                                             .query
@@ -251,6 +290,9 @@ fn to_proto(raw: PolicyFile) -> SandboxPolicy {
                                     method: d.method,
                                     path: d.path,
                                     command: d.command,
+                                    operation_type: d.operation_type,
+                                    operation_name: d.operation_name,
+                                    fields: d.fields,
                                     query: d
                                         .query
                                         .into_iter()
@@ -270,6 +312,22 @@ fn to_proto(raw: PolicyFile) -> SandboxPolicy {
                                 })
                                 .collect(),
                             allow_encoded_slash: e.allow_encoded_slash,
+                            persisted_queries: e.persisted_queries,
+                            graphql_persisted_queries: e
+                                .graphql_persisted_queries
+                                .into_iter()
+                                .map(|(key, op)| {
+                                    (
+                                        key,
+                                        GraphqlOperation {
+                                            operation_type: op.operation_type,
+                                            operation_name: op.operation_name,
+                                            fields: op.fields,
+                                        },
+                                    )
+                                })
+                                .collect(),
+                            graphql_max_body_bytes: e.graphql_max_body_bytes,
                         }
                     })
                     .collect(),
@@ -367,6 +425,9 @@ fn from_proto(policy: &SandboxPolicy) -> PolicyFile {
                                             method: a.method,
                                             path: a.path,
                                             command: a.command,
+                                            operation_type: a.operation_type,
+                                            operation_name: a.operation_name,
+                                            fields: a.fields,
                                             query: a
                                                 .query
                                                 .into_iter()
@@ -393,6 +454,9 @@ fn from_proto(policy: &SandboxPolicy) -> PolicyFile {
                                     method: d.method.clone(),
                                     path: d.path.clone(),
                                     command: d.command.clone(),
+                                    operation_type: d.operation_type.clone(),
+                                    operation_name: d.operation_name.clone(),
+                                    fields: d.fields.clone(),
                                     query: d
                                         .query
                                         .iter()
@@ -410,6 +474,22 @@ fn from_proto(policy: &SandboxPolicy) -> PolicyFile {
                                 })
                                 .collect(),
                             allow_encoded_slash: e.allow_encoded_slash,
+                            persisted_queries: e.persisted_queries.clone(),
+                            graphql_persisted_queries: e
+                                .graphql_persisted_queries
+                                .iter()
+                                .map(|(key, op)| {
+                                    (
+                                        key.clone(),
+                                        GraphqlOperationDef {
+                                            operation_type: op.operation_type.clone(),
+                                            operation_name: op.operation_name.clone(),
+                                            fields: op.fields.clone(),
+                                        },
+                                    )
+                                })
+                                .collect(),
+                            graphql_max_body_bytes: e.graphql_max_body_bytes,
                         }
                     })
                     .collect(),
@@ -1489,6 +1569,57 @@ network_policies:
         let proto = parse_sandbox_policy(yaml).expect("parse failed");
         let deny = &proto.network_policies["test"].endpoints[0].deny_rules[0];
         assert_eq!(deny.query["type"].any, vec!["admin-*", "root-*"]);
+    }
+
+    #[test]
+    fn round_trip_preserves_graphql_policy_fields() {
+        let yaml = r"
+version: 1
+network_policies:
+  github_graphql:
+    name: github_graphql
+    endpoints:
+      - host: api.github.com
+        port: 443
+        protocol: graphql
+        enforcement: enforce
+        persisted_queries: allow_registered
+        graphql_max_body_bytes: 131072
+        graphql_persisted_queries:
+          abc123:
+            operation_type: query
+            operation_name: Viewer
+            fields: [viewer]
+        rules:
+          - allow:
+              operation_type: query
+              fields: [viewer, repository]
+          - allow:
+              operation_type: mutation
+              operation_name: Issue*
+              fields: [createIssue]
+        deny_rules:
+          - operation_type: mutation
+            fields: [deleteRepository]
+    binaries:
+      - path: /usr/bin/curl
+";
+        let proto1 = parse_sandbox_policy(yaml).expect("parse failed");
+        let yaml_out = serialize_sandbox_policy(&proto1).expect("serialize failed");
+        let proto2 = parse_sandbox_policy(&yaml_out).expect("re-parse failed");
+
+        let ep = &proto2.network_policies["github_graphql"].endpoints[0];
+        assert_eq!(ep.protocol, "graphql");
+        assert_eq!(ep.persisted_queries, "allow_registered");
+        assert_eq!(ep.graphql_max_body_bytes, 131_072);
+        assert_eq!(
+            ep.graphql_persisted_queries["abc123"].operation_type,
+            "query"
+        );
+        assert_eq!(ep.rules[0].allow.as_ref().unwrap().operation_type, "query");
+        assert_eq!(ep.rules[1].allow.as_ref().unwrap().operation_name, "Issue*");
+        assert_eq!(ep.deny_rules[0].operation_type, "mutation");
+        assert_eq!(ep.deny_rules[0].fields, vec!["deleteRepository"]);
     }
 
     #[test]

--- a/crates/openshell-policy/src/lib.rs
+++ b/crates/openshell-policy/src/lib.rs
@@ -89,6 +89,8 @@ struct NetworkPolicyRuleDef {
 struct NetworkEndpointDef {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     host: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    path: String,
     /// Single port (backwards compat). Mutually exclusive with `ports`.
     /// Uses `u16` to reject invalid values >65535 at parse time.
     #[serde(default, skip_serializing_if = "is_zero")]
@@ -245,6 +247,7 @@ fn to_proto(raw: PolicyFile) -> SandboxPolicy {
                         };
                         NetworkEndpoint {
                             host: e.host,
+                            path: e.path,
                             port: normalized_ports.first().copied().unwrap_or(0),
                             ports: normalized_ports,
                             protocol: e.protocol,
@@ -409,6 +412,7 @@ fn from_proto(policy: &SandboxPolicy) -> PolicyFile {
                         };
                         NetworkEndpointDef {
                             host: e.host.clone(),
+                            path: e.path.clone(),
                             port,
                             ports,
                             protocol: e.protocol.clone(),
@@ -1390,6 +1394,34 @@ network_policies:
         let ep = &policy.network_policies["test"].endpoints[0];
         assert_eq!(ep.ports, vec![443]);
         assert_eq!(ep.port, 443);
+    }
+
+    #[test]
+    fn round_trip_preserves_endpoint_path() {
+        let yaml = r#"
+version: 1
+network_policies:
+  test:
+    name: test
+    endpoints:
+      - host: api.example.com
+        port: 443
+        path: "/graphql"
+        protocol: graphql
+        rules:
+          - allow:
+              operation_type: query
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let proto1 = parse_sandbox_policy(yaml).expect("parse failed");
+        let yaml_out = serialize_sandbox_policy(&proto1).expect("serialize failed");
+        let proto2 = parse_sandbox_policy(&yaml_out).expect("re-parse failed");
+
+        let ep1 = &proto1.network_policies["test"].endpoints[0];
+        let ep2 = &proto2.network_policies["test"].endpoints[0];
+        assert_eq!(ep1.path, "/graphql");
+        assert_eq!(ep1.path, ep2.path);
     }
 
     #[test]

--- a/crates/openshell-policy/src/merge.rs
+++ b/crates/openshell-policy/src/merge.rs
@@ -389,6 +389,9 @@ fn merge_endpoint(
     if existing.host.is_empty() {
         existing.host.clone_from(&incoming.host);
     }
+    if existing.path.is_empty() {
+        existing.path.clone_from(&incoming.path);
+    }
 
     merge_endpoint_ports(existing, incoming);
     let existing_protocol = existing.protocol.clone();
@@ -506,6 +509,9 @@ fn rules_share_endpoint(
 
 fn endpoints_overlap(left: &NetworkEndpoint, right: &NetworkEndpoint) -> bool {
     if !left.host.eq_ignore_ascii_case(&right.host) {
+        return false;
+    }
+    if left.path != right.path {
         return false;
     }
 

--- a/crates/openshell-policy/src/merge.rs
+++ b/crates/openshell-policy/src/merge.rs
@@ -627,6 +627,9 @@ fn expand_access_preset(access: &str) -> Option<Vec<L7Rule>> {
                     path: "**".to_string(),
                     command: String::new(),
                     query: HashMap::default(),
+                    operation_type: String::new(),
+                    operation_name: String::new(),
+                    fields: Vec::new(),
                 }),
             })
             .collect(),
@@ -797,6 +800,9 @@ mod tests {
                 path: path.to_string(),
                 command: String::new(),
                 query: HashMap::new(),
+                operation_type: String::new(),
+                operation_name: String::new(),
+                fields: Vec::new(),
             }),
         }
     }

--- a/crates/openshell-sandbox/Cargo.toml
+++ b/crates/openshell-sandbox/Cargo.toml
@@ -67,6 +67,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
 apollo-parser = { workspace = true }
+glob = { workspace = true }
 
 # Logging
 tracing = { workspace = true }

--- a/crates/openshell-sandbox/Cargo.toml
+++ b/crates/openshell-sandbox/Cargo.toml
@@ -63,8 +63,10 @@ base64 = { workspace = true }
 ipnet = "2"
 
 # Serialization
+serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
+apollo-parser = { workspace = true }
 
 # Logging
 tracing = { workspace = true }

--- a/crates/openshell-sandbox/data/sandbox-policy.rego
+++ b/crates/openshell-sandbox/data/sandbox-policy.rego
@@ -179,7 +179,7 @@ default allow_request = false
 _policy_allows_l7(policy) if {
 	some ep
 	ep := policy.endpoints[_]
-	endpoint_matches_request(ep, input.network)
+	endpoint_matches_l7_request(ep, input.network, input.request)
 	request_allowed_for_endpoint(input.request, ep)
 }
 
@@ -207,7 +207,7 @@ default deny_request = false
 _policy_denies_l7(policy) if {
 	some ep
 	ep := policy.endpoints[_]
-	endpoint_matches_request(ep, input.network)
+	endpoint_matches_l7_request(ep, input.network, input.request)
 	request_denied_for_endpoint(input.request, ep)
 }
 
@@ -248,6 +248,16 @@ request_denied_for_endpoint(request, endpoint) if {
 	deny_rule.operation_type
 	op := request.graphql.operations[_]
 	graphql_deny_rule_matches_operation(op, deny_rule, endpoint)
+}
+
+# A GraphQL endpoint path is authoritative once it matches. If the parsed
+# GraphQL request is malformed, hash-only without a trusted registry entry, or
+# contains an operation outside the GraphQL allow rules, a broader REST rule on
+# the same host:port must not allow it through.
+request_denied_for_endpoint(request, endpoint) if {
+	endpoint.protocol == "graphql"
+	is_object(request.graphql)
+	not graphql_request_allowed(request, endpoint)
 }
 
 # Deny query matching: fail-closed semantics.
@@ -314,7 +324,7 @@ request_deny_reason := reason if {
 	input.request
 	deny_request
 	graphql_request_has_operations(input.request)
-	reason := "GraphQL operation blocked by deny rule"
+	reason := "GraphQL operation blocked by endpoint policy"
 }
 
 request_deny_reason := reason if {
@@ -630,6 +640,21 @@ endpoint_matches_request(ep, network) if {
 	object.get(ep, "host", "") == ""
 	count(object.get(ep, "allowed_ips", [])) > 0
 	ep.ports[_] == network.port
+}
+
+endpoint_matches_l7_request(ep, network, request) if {
+	endpoint_matches_request(ep, network)
+	endpoint_path_matches_request(ep, request)
+}
+
+endpoint_path_matches_request(ep, request) if {
+	object.get(ep, "path", "") == ""
+}
+
+endpoint_path_matches_request(ep, request) if {
+	path := object.get(ep, "path", "")
+	path != ""
+	path_matches(request.path, path)
 }
 
 # An endpoint has extended config if it specifies L7 protocol, allowed_ips,

--- a/crates/openshell-sandbox/data/sandbox-policy.rego
+++ b/crates/openshell-sandbox/data/sandbox-policy.rego
@@ -239,6 +239,17 @@ request_denied_for_endpoint(request, endpoint) if {
 	command_matches(request.command, deny_rule.command)
 }
 
+# --- L7 deny rule matching: GraphQL operation ---
+
+request_denied_for_endpoint(request, endpoint) if {
+	graphql_request_has_operations(request)
+	some deny_rule
+	deny_rule := endpoint.deny_rules[_]
+	deny_rule.operation_type
+	op := request.graphql.operations[_]
+	graphql_deny_rule_matches_operation(op, deny_rule, endpoint)
+}
+
 # Deny query matching: fail-closed semantics.
 # If no query rules on the deny rule, match unconditionally (any query params).
 # If query rules present, trigger the deny if ANY value for a configured key
@@ -288,7 +299,37 @@ deny_any_value_matches(values, matcher) if {
 
 request_deny_reason := reason if {
 	input.request
+	graphql_request_error(input.request)
+	reason := sprintf("GraphQL request rejected: %s", [input.request.graphql.error])
+}
+
+request_deny_reason := reason if {
+	input.request
+	not graphql_request_error(input.request)
+	graphql_request_has_unregistered_persisted_query(input.request, matched_endpoint_config)
+	reason := "GraphQL persisted query is not registered"
+}
+
+request_deny_reason := reason if {
+	input.request
 	deny_request
+	graphql_request_has_operations(input.request)
+	reason := "GraphQL operation blocked by deny rule"
+}
+
+request_deny_reason := reason if {
+	input.request
+	not deny_request
+	not allow_request
+	graphql_request_has_operations(input.request)
+	not graphql_request_has_unregistered_persisted_query(input.request, matched_endpoint_config)
+	reason := "GraphQL operation not permitted by policy"
+}
+
+request_deny_reason := reason if {
+	input.request
+	deny_request
+	not graphql_request_has_operations(input.request)
 	reason := sprintf("%s %s blocked by deny rule", [input.request.method, input.request.path])
 }
 
@@ -296,6 +337,7 @@ request_deny_reason := reason if {
 	input.request
 	not deny_request
 	not allow_request
+	not graphql_request_has_operations(input.request)
 	reason := sprintf("%s %s not permitted by policy", [input.request.method, input.request.path])
 }
 
@@ -317,6 +359,149 @@ request_allowed_for_endpoint(request, endpoint) if {
 	rule := endpoint.rules[_]
 	rule.allow.command
 	command_matches(request.command, rule.allow.command)
+}
+
+# --- L7 rule matching: GraphQL operation ---
+
+request_allowed_for_endpoint(request, endpoint) if {
+	graphql_request_allowed(request, endpoint)
+}
+
+graphql_request_allowed(request, endpoint) if {
+	graphql_request_has_operations(request)
+	not graphql_request_error(request)
+	not graphql_request_has_unregistered_persisted_query(request, endpoint)
+	not graphql_request_has_unallowed_operation(request, endpoint)
+}
+
+graphql_request_has_operations(request) if {
+	is_object(request.graphql)
+	operations := object.get(request.graphql, "operations", [])
+	count(operations) > 0
+}
+
+graphql_request_error(request) if {
+	is_object(request.graphql)
+	error := object.get(request.graphql, "error", "")
+	error != ""
+}
+
+graphql_request_has_unallowed_operation(request, endpoint) if {
+	op := request.graphql.operations[_]
+	not graphql_operation_allowed(op, endpoint)
+}
+
+graphql_operation_allowed(op, endpoint) if {
+	rule := endpoint.rules[_]
+	rule.allow.operation_type
+	graphql_allow_rule_matches_operation(op, rule.allow, endpoint)
+}
+
+graphql_request_has_unregistered_persisted_query(request, endpoint) if {
+	op := request.graphql.operations[_]
+	graphql_operation_needs_registry(op)
+	not graphql_registered_operation(op, endpoint)
+}
+
+graphql_operation_needs_registry(op) if {
+	object.get(op, "persisted_query", false) == true
+	object.get(op, "operation_type", "") == ""
+}
+
+graphql_registered_operation(op, endpoint) if {
+	object.get(endpoint, "persisted_queries", "deny") == "allow_registered"
+	id := graphql_operation_registry_key(op)
+	endpoint.graphql_persisted_queries[id]
+}
+
+graphql_operation_registry_key(op) := key if {
+	key := object.get(op, "persisted_query_hash", "")
+	key != ""
+}
+
+graphql_operation_registry_key(op) := key if {
+	object.get(op, "persisted_query_hash", "") == ""
+	key := object.get(op, "persisted_query_id", "")
+	key != ""
+}
+
+graphql_effective_operation(op, endpoint) := registered if {
+	graphql_operation_needs_registry(op)
+	key := graphql_operation_registry_key(op)
+	registered := endpoint.graphql_persisted_queries[key]
+}
+
+graphql_effective_operation(op, _) := op if {
+	not graphql_operation_needs_registry(op)
+}
+
+graphql_allow_rule_matches_operation(op, rule, endpoint) if {
+	effective := graphql_effective_operation(op, endpoint)
+	graphql_operation_type_matches(effective, rule)
+	graphql_operation_name_matches(effective, rule)
+	graphql_allow_fields_match(effective, rule)
+}
+
+graphql_deny_rule_matches_operation(op, rule, endpoint) if {
+	effective := graphql_effective_operation(op, endpoint)
+	graphql_operation_type_matches(effective, rule)
+	graphql_operation_name_matches(effective, rule)
+	graphql_deny_fields_match(effective, rule)
+}
+
+graphql_operation_type_matches(_, rule) if {
+	object.get(rule, "operation_type", "") == "*"
+}
+
+graphql_operation_type_matches(op, rule) if {
+	expected := object.get(rule, "operation_type", "")
+	expected != ""
+	expected != "*"
+	lower(object.get(op, "operation_type", "")) == lower(expected)
+}
+
+graphql_operation_name_matches(_, rule) if {
+	object.get(rule, "operation_name", "") == ""
+}
+
+graphql_operation_name_matches(op, rule) if {
+	pattern := object.get(rule, "operation_name", "")
+	pattern != ""
+	name := object.get(op, "operation_name", "")
+	glob.match(pattern, [], name)
+}
+
+# Allow-side field constraints are intentionally all-selected-fields semantics:
+# if a rule declares fields, every root field selected by the operation must
+# match one of the rule patterns. This prevents mixed-operation requests from
+# allowing an unlisted field because one safe field also appeared.
+graphql_allow_fields_match(_, rule) if {
+	count(object.get(rule, "fields", [])) == 0
+}
+
+graphql_allow_fields_match(op, rule) if {
+	count(object.get(rule, "fields", [])) > 0
+	count(object.get(op, "fields", [])) > 0
+	not graphql_operation_has_unmatched_field(op, rule)
+}
+
+graphql_operation_has_unmatched_field(op, rule) if {
+	field := object.get(op, "fields", [])[_]
+	not graphql_field_matches_any(field, object.get(rule, "fields", []))
+}
+
+graphql_deny_fields_match(_, rule) if {
+	count(object.get(rule, "fields", [])) == 0
+}
+
+graphql_deny_fields_match(op, rule) if {
+	field := object.get(op, "fields", [])[_]
+	graphql_field_matches_any(field, object.get(rule, "fields", []))
+}
+
+graphql_field_matches_any(field, patterns) if {
+	pattern := patterns[_]
+	glob.match(pattern, [], field)
 }
 
 # Wildcard "*" matches any method; otherwise case-insensitive exact match.

--- a/crates/openshell-sandbox/data/sandbox-policy.rego
+++ b/crates/openshell-sandbox/data/sandbox-policy.rego
@@ -324,6 +324,7 @@ request_deny_reason := reason if {
 	input.request
 	deny_request
 	graphql_request_has_operations(input.request)
+	not graphql_request_has_unregistered_persisted_query(input.request, matched_endpoint_config)
 	reason := "GraphQL operation blocked by endpoint policy"
 }
 

--- a/crates/openshell-sandbox/src/l7/graphql.rs
+++ b/crates/openshell-sandbox/src/l7/graphql.rs
@@ -1,0 +1,562 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! GraphQL-over-HTTP L7 inspection.
+
+use crate::l7::provider::{BodyLength, L7Provider, L7Request};
+use apollo_parser::Parser;
+use apollo_parser::cst;
+use miette::{IntoDiagnostic, Result, miette};
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
+
+pub const DEFAULT_MAX_BODY_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct GraphqlRequestInfo {
+    pub operations: Vec<GraphqlOperationInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct GraphqlOperationInfo {
+    pub operation_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation_name: Option<String>,
+    pub fields: Vec<String>,
+    pub persisted_query: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persisted_query_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persisted_query_id: Option<String>,
+}
+
+pub struct GraphqlHttpRequest {
+    pub request: L7Request,
+    pub info: GraphqlRequestInfo,
+}
+
+pub async fn parse_graphql_http_request<C: AsyncRead + AsyncWrite + Unpin + Send>(
+    client: &mut C,
+    max_body_bytes: usize,
+    canonicalize_options: crate::l7::path::CanonicalizeOptions,
+) -> Result<Option<GraphqlHttpRequest>> {
+    let provider = crate::l7::rest::RestProvider::with_options(canonicalize_options);
+    let Some(mut request) = provider.parse_request(client).await? else {
+        return Ok(None);
+    };
+
+    let header_str = header_str(&request)?;
+    reject_unsupported_headers(header_str)?;
+    let body = read_body_for_inspection(client, &mut request, max_body_bytes).await?;
+    let info = classify_request(&request, &body);
+
+    Ok(Some(GraphqlHttpRequest { request, info }))
+}
+
+pub fn classify_request(request: &L7Request, body: &[u8]) -> GraphqlRequestInfo {
+    match classify_request_inner(request, body) {
+        Ok(operations) => GraphqlRequestInfo {
+            operations,
+            error: None,
+        },
+        Err(err) => GraphqlRequestInfo {
+            operations: Vec::new(),
+            error: Some(err),
+        },
+    }
+}
+
+fn classify_request_inner(
+    request: &L7Request,
+    body: &[u8],
+) -> std::result::Result<Vec<GraphqlOperationInfo>, String> {
+    match request.action.to_ascii_uppercase().as_str() {
+        "GET" => classify_get(request),
+        "POST" => classify_post(body),
+        method => Err(format!("unsupported GraphQL HTTP method {method}")),
+    }
+}
+
+fn classify_get(request: &L7Request) -> std::result::Result<Vec<GraphqlOperationInfo>, String> {
+    let query = first_query_value(&request.query_params, "query");
+    let operation_name = first_query_value(&request.query_params, "operationName");
+    let extensions = first_query_value(&request.query_params, "extensions")
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok());
+    let id = first_query_value(&request.query_params, "id")
+        .or_else(|| first_query_value(&request.query_params, "documentId"))
+        .or_else(|| first_query_value(&request.query_params, "queryId"));
+
+    classify_envelope(
+        query.as_deref(),
+        operation_name.as_deref(),
+        extensions.as_ref(),
+        id,
+    )
+}
+
+fn classify_post(body: &[u8]) -> std::result::Result<Vec<GraphqlOperationInfo>, String> {
+    if body.is_empty() {
+        return Err("GraphQL POST body is empty".to_string());
+    }
+    let value: Value = serde_json::from_slice(body)
+        .map_err(|err| format!("GraphQL request body is not valid JSON: {err}"))?;
+
+    match value {
+        Value::Array(items) => {
+            if items.is_empty() {
+                return Err("GraphQL batch request is empty".to_string());
+            }
+            let mut operations = Vec::new();
+            for item in items {
+                operations.extend(classify_json_envelope(&item)?);
+            }
+            Ok(operations)
+        }
+        Value::Object(_) => classify_json_envelope(&value),
+        _ => Err("GraphQL JSON envelope must be an object or array".to_string()),
+    }
+}
+
+fn classify_json_envelope(value: &Value) -> std::result::Result<Vec<GraphqlOperationInfo>, String> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| "GraphQL batch item must be an object".to_string())?;
+    let query = obj.get("query").and_then(Value::as_str);
+    let operation_name = obj.get("operationName").and_then(Value::as_str);
+    let extensions = obj.get("extensions");
+    let id = obj
+        .get("id")
+        .or_else(|| obj.get("documentId"))
+        .or_else(|| obj.get("queryId"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+
+    classify_envelope(query, operation_name, extensions, id)
+}
+
+fn classify_envelope(
+    query: Option<&str>,
+    operation_name: Option<&str>,
+    extensions: Option<&Value>,
+    persisted_id: Option<String>,
+) -> std::result::Result<Vec<GraphqlOperationInfo>, String> {
+    let persisted_hash = persisted_query_hash(extensions);
+    let query = query.filter(|q| !q.trim().is_empty());
+
+    if let Some(query) = query {
+        let mut operation = classify_document(query, operation_name)?;
+        if let Some(hash) = persisted_hash {
+            operation.persisted_query = true;
+            operation.persisted_query_hash = Some(hash);
+        }
+        if let Some(id) = persisted_id {
+            operation.persisted_query = true;
+            operation.persisted_query_id = Some(id);
+        }
+        return Ok(vec![operation]);
+    }
+
+    if persisted_hash.is_some() || persisted_id.is_some() {
+        return Ok(vec![GraphqlOperationInfo {
+            operation_type: String::new(),
+            operation_name: operation_name.map(ToString::to_string),
+            fields: Vec::new(),
+            persisted_query: true,
+            persisted_query_hash: persisted_hash,
+            persisted_query_id: persisted_id,
+        }]);
+    }
+
+    Err("GraphQL request has no query document or persisted query identifier".to_string())
+}
+
+fn classify_document(
+    query: &str,
+    operation_name: Option<&str>,
+) -> std::result::Result<GraphqlOperationInfo, String> {
+    let parser = Parser::new(query).recursion_limit(128).token_limit(20_000);
+    let cst = parser.parse();
+    let mut parse_errors = cst.errors();
+    if let Some(err) = parse_errors.next() {
+        return Err(format!("GraphQL document parse error: {err}"));
+    }
+
+    let document = cst.document();
+    let mut operations = Vec::new();
+    let mut fragments = HashMap::new();
+
+    for definition in document.definitions() {
+        match definition {
+            cst::Definition::OperationDefinition(operation) => operations.push(operation),
+            cst::Definition::FragmentDefinition(fragment) => {
+                if let Some(name) = fragment.fragment_name().and_then(|n| n.name()) {
+                    fragments.insert(name.text().to_string(), fragment);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if operations.is_empty() {
+        return Err("GraphQL document contains no executable operation".to_string());
+    }
+
+    let selected = if let Some(expected_name) = operation_name.filter(|name| !name.is_empty()) {
+        operations
+            .into_iter()
+            .find(|op| {
+                op.name()
+                    .is_some_and(|name| name.text().as_ref() == expected_name)
+            })
+            .ok_or_else(|| format!("GraphQL operationName {expected_name:?} was not found"))?
+    } else if operations.len() == 1 {
+        operations.remove(0)
+    } else {
+        return Err("GraphQL document has multiple operations but no operationName".to_string());
+    };
+
+    let operation_type = operation_type(&selected);
+    let operation_name = selected.name().map(|name| name.text().to_string());
+    let selection_set = selected
+        .selection_set()
+        .ok_or_else(|| "GraphQL operation has no selection set".to_string())?;
+    let mut fields = HashSet::new();
+    let mut visited_fragments = HashSet::new();
+    collect_root_fields(
+        selection_set,
+        &fragments,
+        &mut visited_fragments,
+        &mut fields,
+    );
+    let mut fields: Vec<_> = fields.into_iter().collect();
+    fields.sort();
+
+    Ok(GraphqlOperationInfo {
+        operation_type,
+        operation_name,
+        fields,
+        persisted_query: false,
+        persisted_query_hash: None,
+        persisted_query_id: None,
+    })
+}
+
+fn operation_type(operation: &cst::OperationDefinition) -> String {
+    let Some(operation_type) = operation.operation_type() else {
+        return "query".to_string();
+    };
+    if operation_type.mutation_token().is_some() {
+        "mutation".to_string()
+    } else if operation_type.subscription_token().is_some() {
+        "subscription".to_string()
+    } else {
+        "query".to_string()
+    }
+}
+
+fn collect_root_fields(
+    selection_set: cst::SelectionSet,
+    fragments: &HashMap<String, cst::FragmentDefinition>,
+    visited_fragments: &mut HashSet<String>,
+    fields: &mut HashSet<String>,
+) {
+    for selection in selection_set.selections() {
+        match selection {
+            cst::Selection::Field(field) => {
+                if let Some(name) = field.name() {
+                    fields.insert(name.text().to_string());
+                }
+            }
+            cst::Selection::InlineFragment(fragment) => {
+                if let Some(selection_set) = fragment.selection_set() {
+                    collect_root_fields(selection_set, fragments, visited_fragments, fields);
+                }
+            }
+            cst::Selection::FragmentSpread(spread) => {
+                let Some(name) = spread.fragment_name().and_then(|n| n.name()) else {
+                    continue;
+                };
+                let name = name.text().to_string();
+                if !visited_fragments.insert(name.clone()) {
+                    continue;
+                }
+                if let Some(fragment) = fragments.get(&name)
+                    && let Some(selection_set) = fragment.selection_set()
+                {
+                    collect_root_fields(selection_set, fragments, visited_fragments, fields);
+                }
+            }
+        }
+    }
+}
+
+fn persisted_query_hash(extensions: Option<&Value>) -> Option<String> {
+    extensions?
+        .get("persistedQuery")?
+        .get("sha256Hash")?
+        .as_str()
+        .filter(|hash| !hash.is_empty())
+        .map(ToString::to_string)
+}
+
+fn first_query_value(params: &HashMap<String, Vec<String>>, key: &str) -> Option<String> {
+    params
+        .get(key)
+        .and_then(|values| values.first())
+        .filter(|value| !value.is_empty())
+        .cloned()
+}
+
+async fn read_body_for_inspection<C: AsyncRead + Unpin>(
+    client: &mut C,
+    request: &mut L7Request,
+    max_body_bytes: usize,
+) -> Result<Vec<u8>> {
+    let header_end = request
+        .raw_header
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map_or(request.raw_header.len(), |p| p + 4);
+    let overflow = request.raw_header[header_end..].to_vec();
+
+    match request.body_length {
+        BodyLength::None => Ok(Vec::new()),
+        BodyLength::ContentLength(len) => {
+            let len = usize::try_from(len)
+                .map_err(|_| miette!("GraphQL request body length exceeds platform limit"))?;
+            if len > max_body_bytes {
+                return Err(miette!(
+                    "GraphQL request body exceeds {max_body_bytes} byte inspection limit"
+                ));
+            }
+            if overflow.len() > len {
+                return Err(miette!(
+                    "GraphQL request contains more body bytes than Content-Length"
+                ));
+            }
+            let remaining = len - overflow.len();
+            let mut body = overflow;
+            if remaining > 0 {
+                let start = body.len();
+                body.resize(len, 0);
+                client
+                    .read_exact(&mut body[start..])
+                    .await
+                    .into_diagnostic()?;
+            }
+            request.raw_header.truncate(header_end);
+            request.raw_header.extend_from_slice(&body);
+            Ok(body)
+        }
+        BodyLength::Chunked => {
+            read_chunked_body_for_inspection(client, request, header_end, overflow, max_body_bytes)
+                .await
+        }
+    }
+}
+
+async fn read_chunked_body_for_inspection<C: AsyncRead + Unpin>(
+    client: &mut C,
+    request: &mut L7Request,
+    header_end: usize,
+    overflow: Vec<u8>,
+    max_body_bytes: usize,
+) -> Result<Vec<u8>> {
+    let mut raw = overflow;
+    let mut decoded = Vec::new();
+    let mut pos = 0usize;
+
+    loop {
+        let size_line_end = loop {
+            if let Some(end) = find_crlf(&raw, pos) {
+                break end;
+            }
+            read_more(client, &mut raw, max_body_bytes).await?;
+        };
+        let size_line = std::str::from_utf8(&raw[pos..size_line_end])
+            .into_diagnostic()
+            .map_err(|_| miette!("Invalid UTF-8 in GraphQL chunk-size line"))?;
+        let size_token = size_line
+            .split(';')
+            .next()
+            .map(str::trim)
+            .unwrap_or_default();
+        let chunk_size = usize::from_str_radix(size_token, 16)
+            .into_diagnostic()
+            .map_err(|_| miette!("Invalid GraphQL chunk size token: {size_token:?}"))?;
+        pos = size_line_end + 2;
+
+        if decoded.len().saturating_add(chunk_size) > max_body_bytes {
+            return Err(miette!(
+                "GraphQL request body exceeds {max_body_bytes} byte inspection limit"
+            ));
+        }
+
+        let chunk_end = pos
+            .checked_add(chunk_size)
+            .ok_or_else(|| miette!("GraphQL chunk size overflow"))?;
+        let chunk_with_crlf_end = chunk_end
+            .checked_add(2)
+            .ok_or_else(|| miette!("GraphQL chunk size overflow"))?;
+        while raw.len() < chunk_with_crlf_end {
+            read_more(client, &mut raw, max_body_bytes).await?;
+        }
+        decoded.extend_from_slice(&raw[pos..chunk_end]);
+        if raw.get(chunk_end..chunk_with_crlf_end) != Some(&b"\r\n"[..]) {
+            return Err(miette!("GraphQL chunk payload missing terminating CRLF"));
+        }
+        pos = chunk_with_crlf_end;
+
+        if chunk_size == 0 {
+            loop {
+                let trailer_end = loop {
+                    if let Some(end) = find_crlf(&raw, pos) {
+                        break end;
+                    }
+                    read_more(client, &mut raw, max_body_bytes).await?;
+                };
+                let trailer_line = &raw[pos..trailer_end];
+                pos = trailer_end + 2;
+                if trailer_line.is_empty() {
+                    request.raw_header.truncate(header_end);
+                    request.raw_header.extend_from_slice(&raw[..pos]);
+                    return Ok(decoded);
+                }
+            }
+        }
+    }
+}
+
+async fn read_more<C: AsyncRead + Unpin>(
+    client: &mut C,
+    raw: &mut Vec<u8>,
+    max_body_bytes: usize,
+) -> Result<()> {
+    if raw.len() > max_body_bytes.saturating_mul(2).max(max_body_bytes) {
+        return Err(miette!(
+            "GraphQL chunked request body exceeds inspection framing limit"
+        ));
+    }
+    let mut buf = [0u8; 8192];
+    let n = client.read(&mut buf).await.into_diagnostic()?;
+    if n == 0 {
+        return Err(miette!("GraphQL chunked body ended before terminator"));
+    }
+    raw.extend_from_slice(&buf[..n]);
+    Ok(())
+}
+
+fn find_crlf(buf: &[u8], start: usize) -> Option<usize> {
+    buf.get(start..)?
+        .windows(2)
+        .position(|w| w == b"\r\n")
+        .map(|p| start + p)
+}
+
+fn header_str(request: &L7Request) -> Result<&str> {
+    let header_end = request
+        .raw_header
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map_or(request.raw_header.len(), |p| p + 4);
+    std::str::from_utf8(&request.raw_header[..header_end])
+        .map_err(|_| miette!("GraphQL HTTP headers contain invalid UTF-8"))
+}
+
+fn reject_unsupported_headers(headers: &str) -> Result<()> {
+    for line in headers.lines().skip(1) {
+        let lower = line.to_ascii_lowercase();
+        if lower.starts_with("content-encoding:") {
+            let encoding = lower.split_once(':').map_or("", |(_, v)| v.trim());
+            if !encoding.is_empty() && encoding != "identity" {
+                return Err(miette!(
+                    "GraphQL request content-encoding {encoding:?} is not supported"
+                ));
+            }
+        }
+        if lower.starts_with("content-type:") {
+            let content_type = lower.split_once(':').map_or("", |(_, v)| v.trim());
+            if content_type.starts_with("multipart/") {
+                return Err(miette!("GraphQL multipart requests are not supported"));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(method: &str, target: &str) -> L7Request {
+        L7Request {
+            action: method.to_string(),
+            target: target.to_string(),
+            query_params: crate::l7::rest::parse_target_query(target).unwrap().1,
+            raw_header: format!("{method} {target} HTTP/1.1\r\nHost: example.com\r\n\r\n")
+                .into_bytes(),
+            body_length: BodyLength::None,
+        }
+    }
+
+    #[test]
+    fn classifies_simple_query() {
+        let req = request("POST", "/graphql");
+        let info = classify_request(&req, br#"{"query":"query Viewer { viewer { login } }"}"#);
+        assert_eq!(info.error, None);
+        assert_eq!(info.operations[0].operation_type, "query");
+        assert_eq!(info.operations[0].fields, vec!["viewer"]);
+    }
+
+    #[test]
+    fn classifies_mutation_field_not_alias() {
+        let req = request("POST", "/graphql");
+        let info = classify_request(
+            &req,
+            br#"{"query":"mutation M { safeAlias: volumeDelete(volumeId:\"x\") { id } }","operationName":"M"}"#,
+        );
+        assert_eq!(info.error, None);
+        assert_eq!(info.operations[0].operation_type, "mutation");
+        assert_eq!(info.operations[0].operation_name.as_deref(), Some("M"));
+        assert_eq!(info.operations[0].fields, vec!["volumeDelete"]);
+    }
+
+    #[test]
+    fn expands_root_fragments() {
+        let req = request("POST", "/graphql");
+        let info = classify_request(
+            &req,
+            br#"{"query":"query Q { ...RootFields } fragment RootFields on Query { viewer repository(owner:\"o\", name:\"r\") { id } }"}"#,
+        );
+        assert_eq!(info.error, None);
+        assert_eq!(info.operations[0].fields, vec!["repository", "viewer"]);
+    }
+
+    #[test]
+    fn multiple_operations_without_name_errors() {
+        let req = request("POST", "/graphql");
+        let info = classify_request(
+            &req,
+            br#"{"query":"query A { viewer { login } } query B { rateLimit { limit } }"}"#,
+        );
+        assert!(info.error.unwrap().contains("multiple operations"));
+    }
+
+    #[test]
+    fn detects_hash_only_apollo_persisted_query() {
+        let req = request("POST", "/graphql");
+        let info = classify_request(
+            &req,
+            br#"{"operationName":"Viewer","extensions":{"persistedQuery":{"version":1,"sha256Hash":"abc123"}}}"#,
+        );
+        assert_eq!(info.error, None);
+        let op = &info.operations[0];
+        assert!(op.persisted_query);
+        assert_eq!(op.operation_name.as_deref(), Some("Viewer"));
+        assert_eq!(op.persisted_query_hash.as_deref(), Some("abc123"));
+    }
+}

--- a/crates/openshell-sandbox/src/l7/graphql.rs
+++ b/crates/openshell-sandbox/src/l7/graphql.rs
@@ -384,10 +384,53 @@ async fn read_body_for_inspection<C: AsyncRead + Unpin>(
             Ok(body)
         }
         BodyLength::Chunked => {
-            read_chunked_body_for_inspection(client, request, header_end, overflow, max_body_bytes)
-                .await
+            let body = read_chunked_body_for_inspection(
+                client,
+                request,
+                header_end,
+                overflow,
+                max_body_bytes,
+            )
+            .await?;
+            normalize_chunked_request_to_content_length(request, header_end, &body)?;
+            Ok(body)
         }
     }
+}
+
+fn normalize_chunked_request_to_content_length(
+    request: &mut L7Request,
+    header_end: usize,
+    body: &[u8],
+) -> Result<()> {
+    let header_str = std::str::from_utf8(&request.raw_header[..header_end])
+        .map_err(|_| miette!("GraphQL HTTP headers contain invalid UTF-8"))?;
+    let header_str = header_str
+        .strip_suffix("\r\n\r\n")
+        .ok_or_else(|| miette!("GraphQL HTTP headers missing terminator"))?;
+
+    let mut normalized = Vec::with_capacity(header_str.len() + body.len() + 32);
+    for (idx, line) in header_str.split("\r\n").enumerate() {
+        if idx > 0 {
+            let name = line
+                .split_once(':')
+                .map(|(name, _)| name.trim().to_ascii_lowercase());
+            if matches!(
+                name.as_deref(),
+                Some("transfer-encoding" | "content-length" | "trailer")
+            ) {
+                continue;
+            }
+        }
+        normalized.extend_from_slice(line.as_bytes());
+        normalized.extend_from_slice(b"\r\n");
+    }
+    normalized.extend_from_slice(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes());
+    normalized.extend_from_slice(body);
+
+    request.raw_header = normalized;
+    request.body_length = BodyLength::ContentLength(body.len() as u64);
+    Ok(())
 }
 
 async fn read_chunked_body_for_inspection<C: AsyncRead + Unpin>(
@@ -427,21 +470,6 @@ async fn read_chunked_body_for_inspection<C: AsyncRead + Unpin>(
             ));
         }
 
-        let chunk_end = pos
-            .checked_add(chunk_size)
-            .ok_or_else(|| miette!("GraphQL chunk size overflow"))?;
-        let chunk_with_crlf_end = chunk_end
-            .checked_add(2)
-            .ok_or_else(|| miette!("GraphQL chunk size overflow"))?;
-        while raw.len() < chunk_with_crlf_end {
-            read_more(client, &mut raw, max_body_bytes).await?;
-        }
-        decoded.extend_from_slice(&raw[pos..chunk_end]);
-        if raw.get(chunk_end..chunk_with_crlf_end) != Some(&b"\r\n"[..]) {
-            return Err(miette!("GraphQL chunk payload missing terminating CRLF"));
-        }
-        pos = chunk_with_crlf_end;
-
         if chunk_size == 0 {
             loop {
                 let trailer_end = loop {
@@ -459,6 +487,21 @@ async fn read_chunked_body_for_inspection<C: AsyncRead + Unpin>(
                 }
             }
         }
+
+        let chunk_end = pos
+            .checked_add(chunk_size)
+            .ok_or_else(|| miette!("GraphQL chunk size overflow"))?;
+        let chunk_with_crlf_end = chunk_end
+            .checked_add(2)
+            .ok_or_else(|| miette!("GraphQL chunk size overflow"))?;
+        while raw.len() < chunk_with_crlf_end {
+            read_more(client, &mut raw, max_body_bytes).await?;
+        }
+        decoded.extend_from_slice(&raw[pos..chunk_end]);
+        if raw.get(chunk_end..chunk_with_crlf_end) != Some(&b"\r\n"[..]) {
+            return Err(miette!("GraphQL chunk payload missing terminating CRLF"));
+        }
+        pos = chunk_with_crlf_end;
     }
 }
 
@@ -616,5 +659,41 @@ mod tests {
                 .is_some_and(|err| err.contains("must not be combined")),
             "expected ambiguous persisted-query id error, got {info:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn chunked_graphql_post_is_normalized_after_inspection() {
+        let body = br#"{"query":"query Viewer { viewer { login } }"}"#;
+        let mut raw_header =
+            b"POST /graphql HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\nTrailer: X-Sig\r\nX-Test: yes\r\n\r\n"
+                .to_vec();
+        raw_header.extend_from_slice(format!("{:x}\r\n", body.len()).as_bytes());
+        raw_header.extend_from_slice(body);
+        raw_header.extend_from_slice(b"\r\n0\r\nX-Sig: ignored\r\n\r\n");
+
+        let mut req = L7Request {
+            action: "POST".to_string(),
+            target: "/graphql".to_string(),
+            query_params: HashMap::new(),
+            raw_header,
+            body_length: BodyLength::Chunked,
+        };
+        let mut client = tokio::io::empty();
+
+        let info = inspect_graphql_request(&mut client, &mut req, DEFAULT_MAX_BODY_BYTES)
+            .await
+            .expect("chunked body should inspect");
+
+        assert_eq!(info.error, None);
+        assert!(matches!(
+            req.body_length,
+            BodyLength::ContentLength(len) if len == body.len() as u64
+        ));
+        let forwarded = String::from_utf8_lossy(&req.raw_header);
+        assert!(forwarded.contains(&format!("Content-Length: {}", body.len())));
+        assert!(forwarded.contains("X-Test: yes\r\n"));
+        assert!(!forwarded.to_ascii_lowercase().contains("transfer-encoding"));
+        assert!(!forwarded.to_ascii_lowercase().contains("trailer:"));
+        assert!(req.raw_header.ends_with(body));
     }
 }

--- a/crates/openshell-sandbox/src/l7/graphql.rs
+++ b/crates/openshell-sandbox/src/l7/graphql.rs
@@ -90,13 +90,11 @@ fn classify_request_inner(
 }
 
 fn classify_get(request: &L7Request) -> std::result::Result<Vec<GraphqlOperationInfo>, String> {
-    let query = first_query_value(&request.query_params, "query");
-    let operation_name = first_query_value(&request.query_params, "operationName");
-    let extensions = first_query_value(&request.query_params, "extensions")
+    let query = unique_query_value(&request.query_params, "query")?;
+    let operation_name = unique_query_value(&request.query_params, "operationName")?;
+    let extensions = unique_query_value(&request.query_params, "extensions")?
         .and_then(|raw| serde_json::from_str::<Value>(&raw).ok());
-    let id = first_query_value(&request.query_params, "id")
-        .or_else(|| first_query_value(&request.query_params, "documentId"))
-        .or_else(|| first_query_value(&request.query_params, "queryId"));
+    let id = unique_persisted_query_id(&request.query_params)?;
 
     classify_envelope(
         query.as_deref(),
@@ -311,12 +309,37 @@ fn persisted_query_hash(extensions: Option<&Value>) -> Option<String> {
         .map(ToString::to_string)
 }
 
-fn first_query_value(params: &HashMap<String, Vec<String>>, key: &str) -> Option<String> {
-    params
-        .get(key)
-        .and_then(|values| values.first())
-        .filter(|value| !value.is_empty())
-        .cloned()
+fn unique_query_value(
+    params: &HashMap<String, Vec<String>>,
+    key: &str,
+) -> std::result::Result<Option<String>, String> {
+    let Some(values) = params.get(key) else {
+        return Ok(None);
+    };
+    if values.len() > 1 {
+        return Err(format!(
+            "GraphQL GET parameter {key:?} must not appear more than once"
+        ));
+    }
+    Ok(values.first().filter(|value| !value.is_empty()).cloned())
+}
+
+fn unique_persisted_query_id(
+    params: &HashMap<String, Vec<String>>,
+) -> std::result::Result<Option<String>, String> {
+    let mut selected: Option<(String, String)> = None;
+    for key in ["id", "documentId", "queryId"] {
+        let Some(value) = unique_query_value(params, key)? else {
+            continue;
+        };
+        if let Some((existing_key, _)) = selected {
+            return Err(format!(
+                "GraphQL GET persisted-query id parameters {existing_key:?} and {key:?} must not be combined"
+            ));
+        }
+        selected = Some((key.to_string(), value));
+    }
+    Ok(selected.map(|(_, value)| value))
 }
 
 async fn read_body_for_inspection<C: AsyncRead + Unpin>(
@@ -566,5 +589,32 @@ mod tests {
         assert!(op.persisted_query);
         assert_eq!(op.operation_name.as_deref(), Some("Viewer"));
         assert_eq!(op.persisted_query_hash.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn graphql_get_rejects_duplicate_query_parameter() {
+        let req = request(
+            "GET",
+            "/graphql?query=query+Viewer+%7B+viewer+%7B+login+%7D+%7D&query=mutation+Delete+%7B+volumeDelete(volumeId%3A%22x%22)+%7B+id+%7D+%7D",
+        );
+        let info = classify_request(&req, b"");
+        assert!(
+            info.error
+                .as_deref()
+                .is_some_and(|err| err.contains("must not appear more than once")),
+            "expected duplicate control parameter error, got {info:?}"
+        );
+    }
+
+    #[test]
+    fn graphql_get_rejects_ambiguous_persisted_query_ids() {
+        let req = request("GET", "/graphql?id=one&queryId=two");
+        let info = classify_request(&req, b"");
+        assert!(
+            info.error
+                .as_deref()
+                .is_some_and(|err| err.contains("must not be combined")),
+            "expected ambiguous persisted-query id error, got {info:?}"
+        );
     }
 }

--- a/crates/openshell-sandbox/src/l7/graphql.rs
+++ b/crates/openshell-sandbox/src/l7/graphql.rs
@@ -696,4 +696,113 @@ mod tests {
         assert!(!forwarded.to_ascii_lowercase().contains("trailer:"));
         assert!(req.raw_header.ends_with(body));
     }
+
+    #[tokio::test]
+    async fn absolute_form_chunked_graphql_post_classifies_after_inspection() {
+        let body = br#"{"query":"query Viewer { viewer { login } }"}"#;
+        let mut raw_header =
+            b"POST http://example.com/graphql HTTP/1.1\r\nHost: example.com\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n"
+                .to_vec();
+        raw_header.extend_from_slice(format!("{:x}\r\n", body.len()).as_bytes());
+        raw_header.extend_from_slice(body);
+        raw_header.extend_from_slice(b"\r\n0\r\n\r\n");
+
+        let mut req = L7Request {
+            action: "POST".to_string(),
+            target: "/graphql".to_string(),
+            query_params: HashMap::new(),
+            raw_header,
+            body_length: BodyLength::Chunked,
+        };
+        let mut client = tokio::io::empty();
+
+        let info = inspect_graphql_request(&mut client, &mut req, DEFAULT_MAX_BODY_BYTES)
+            .await
+            .expect("absolute-form chunked body should inspect");
+
+        assert_eq!(info.error, None);
+        assert_eq!(info.operations[0].operation_type, "query");
+        assert_eq!(info.operations[0].fields, vec!["viewer"]);
+    }
+
+    #[tokio::test]
+    async fn absolute_form_chunked_graphql_post_is_allowed_by_field_policy() {
+        let body = br#"{"query":"query Viewer { viewer { login } }"}"#;
+        let mut raw_header =
+            b"POST http://host.openshell.internal:8080/graphql HTTP/1.1\r\nHost: host.openshell.internal:8080\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n"
+                .to_vec();
+        raw_header.extend_from_slice(format!("{:x}\r\n", body.len()).as_bytes());
+        raw_header.extend_from_slice(body);
+        raw_header.extend_from_slice(b"\r\n0\r\n\r\n");
+
+        let mut req = L7Request {
+            action: "POST".to_string(),
+            target: "/graphql".to_string(),
+            query_params: HashMap::new(),
+            raw_header,
+            body_length: BodyLength::Chunked,
+        };
+        let mut client = tokio::io::empty();
+        let info = inspect_graphql_request(&mut client, &mut req, DEFAULT_MAX_BODY_BYTES)
+            .await
+            .expect("chunked body should inspect");
+
+        let data = r"
+network_policies:
+  test_graphql_l7:
+    name: test_graphql_l7
+    endpoints:
+      - host: host.openshell.internal
+        port: 8080
+        protocol: graphql
+        enforcement: enforce
+        persisted_queries: allow_registered
+        graphql_persisted_queries:
+          abc123:
+            operation_type: query
+            operation_name: Viewer
+            fields: [viewer]
+        rules:
+          - allow:
+              operation_type: query
+              fields: [viewer]
+          - allow:
+              operation_type: mutation
+              fields: [createIssue]
+        deny_rules:
+          - operation_type: mutation
+            fields: [deleteRepository]
+    binaries:
+      - { path: /usr/bin/python3 }
+";
+        let engine = crate::opa::OpaEngine::from_strings(
+            include_str!("../../data/sandbox-policy.rego"),
+            data,
+        )
+        .expect("policy should load");
+        let ctx = crate::l7::relay::L7EvalContext {
+            host: "host.openshell.internal".to_string(),
+            port: 8080,
+            policy_name: "test_graphql_l7".to_string(),
+            binary_path: "/usr/bin/python3".to_string(),
+            ancestors: Vec::new(),
+            cmdline_paths: Vec::new(),
+            secret_resolver: None,
+        };
+        let request_info = crate::l7::L7RequestInfo {
+            action: req.action,
+            target: req.target,
+            query_params: req.query_params,
+            graphql: Some(info),
+        };
+
+        let (allowed, reason) = crate::l7::relay::evaluate_l7_request(
+            &std::sync::Mutex::new(engine.clone_engine_for_tunnel().unwrap()),
+            &ctx,
+            &request_info,
+        )
+        .expect("evaluation should complete");
+
+        assert!(allowed, "expected query to be allowed, got {reason}");
+    }
 }

--- a/crates/openshell-sandbox/src/l7/graphql.rs
+++ b/crates/openshell-sandbox/src/l7/graphql.rs
@@ -796,12 +796,12 @@ network_policies:
             graphql: Some(info),
         };
 
-        let (allowed, reason) = crate::l7::relay::evaluate_l7_request(
-            &std::sync::Mutex::new(engine.clone_engine_for_tunnel().unwrap()),
-            &ctx,
-            &request_info,
-        )
-        .expect("evaluation should complete");
+        let tunnel_engine = engine
+            .clone_engine_for_tunnel(engine.current_generation())
+            .expect("tunnel engine should clone");
+        let (allowed, reason) =
+            crate::l7::relay::evaluate_l7_request(&tunnel_engine, &ctx, &request_info)
+                .expect("evaluation should complete");
 
         assert!(allowed, "expected query to be allowed, got {reason}");
     }

--- a/crates/openshell-sandbox/src/l7/graphql.rs
+++ b/crates/openshell-sandbox/src/l7/graphql.rs
@@ -49,12 +49,20 @@ pub async fn parse_graphql_http_request<C: AsyncRead + AsyncWrite + Unpin + Send
         return Ok(None);
     };
 
-    let header_str = header_str(&request)?;
-    reject_unsupported_headers(header_str)?;
-    let body = read_body_for_inspection(client, &mut request, max_body_bytes).await?;
-    let info = classify_request(&request, &body);
+    let info = inspect_graphql_request(client, &mut request, max_body_bytes).await?;
 
     Ok(Some(GraphqlHttpRequest { request, info }))
+}
+
+pub(crate) async fn inspect_graphql_request<C: AsyncRead + Unpin>(
+    client: &mut C,
+    request: &mut L7Request,
+    max_body_bytes: usize,
+) -> Result<GraphqlRequestInfo> {
+    let header_str = header_str(request)?;
+    reject_unsupported_headers(header_str)?;
+    let body = read_body_for_inspection(client, request, max_body_bytes).await?;
+    Ok(classify_request(request, &body))
 }
 
 pub fn classify_request(request: &L7Request, body: &[u8]) -> GraphqlRequestInfo {

--- a/crates/openshell-sandbox/src/l7/mod.rs
+++ b/crates/openshell-sandbox/src/l7/mod.rs
@@ -61,6 +61,9 @@ pub enum EnforcementMode {
 #[derive(Debug, Clone)]
 pub struct L7EndpointConfig {
     pub protocol: L7Protocol,
+    /// Optional endpoint-level HTTP path glob used to select between L7
+    /// protocols that share the same host:port.
+    pub path: String,
     pub tls: TlsMode,
     pub enforcement: EnforcementMode,
     /// Maximum GraphQL request body bytes to buffer for inspection.
@@ -142,11 +145,39 @@ pub fn parse_l7_config(val: &regorus::Value) -> Option<L7EndpointConfig> {
 
     Some(L7EndpointConfig {
         protocol,
+        path: get_object_str(val, "path").unwrap_or_default(),
         tls,
         enforcement,
         graphql_max_body_bytes,
         allow_encoded_slash,
     })
+}
+
+impl L7EndpointConfig {
+    pub fn matches_path(&self, path: &str) -> bool {
+        endpoint_path_matches(&self.path, path)
+    }
+
+    pub fn path_specificity(&self) -> usize {
+        if self.path.is_empty() {
+            0
+        } else {
+            self.path.chars().filter(|c| *c != '*').count()
+        }
+    }
+}
+
+pub fn endpoint_path_matches(pattern: &str, path: &str) -> bool {
+    if pattern.is_empty() || pattern == "**" || pattern == "/**" {
+        return true;
+    }
+    if pattern == path {
+        return true;
+    }
+    if let Some(prefix) = pattern.strip_suffix("/**") {
+        return path == prefix || path.starts_with(&format!("{prefix}/"));
+    }
+    glob::Pattern::new(pattern).is_ok_and(|glob| glob.matches(path))
 }
 
 /// Parse the `tls` field from an endpoint config, independent of L7 protocol.
@@ -352,6 +383,7 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                 .and_then(|v| v.as_array())
                 .is_some_and(|a| !a.is_empty());
             let host = ep.get("host").and_then(|v| v.as_str()).unwrap_or("");
+            let endpoint_path = ep.get("path").and_then(|v| v.as_str()).unwrap_or("");
 
             // Read ports from either "ports" array or scalar "port".
             let ports: Vec<u64> = ep.get("ports").and_then(|v| v.as_array()).map_or_else(
@@ -365,6 +397,17 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                 |arr| arr.iter().filter_map(serde_json::Value::as_u64).collect(),
             );
             let loc = format!("{name}.endpoints[{i}]");
+
+            if !endpoint_path.is_empty() {
+                if !endpoint_path.starts_with('/') && endpoint_path != "**" {
+                    errors.push(format!(
+                        "{loc}: endpoint path must start with '/' or be '**', got '{endpoint_path}'"
+                    ));
+                }
+                if let Some(warning) = check_glob_syntax(endpoint_path) {
+                    warnings.push(format!("{loc}.path: {warning}"));
+                }
+            }
 
             // Validate host wildcard patterns.
             if host.contains('*') {

--- a/crates/openshell-sandbox/src/l7/mod.rs
+++ b/crates/openshell-sandbox/src/l7/mod.rs
@@ -8,6 +8,7 @@
 //! doing a raw `copy_bidirectional`. Each request within the tunnel is parsed,
 //! evaluated against OPA policy, and either forwarded or denied.
 
+pub mod graphql;
 pub mod inference;
 pub mod path;
 pub mod provider;
@@ -19,6 +20,7 @@ pub mod tls;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum L7Protocol {
     Rest,
+    Graphql,
     Sql,
 }
 
@@ -26,6 +28,7 @@ impl L7Protocol {
     pub fn parse(s: &str) -> Option<Self> {
         match s.to_ascii_lowercase().as_str() {
             "rest" => Some(Self::Rest),
+            "graphql" => Some(Self::Graphql),
             "sql" => Some(Self::Sql),
             _ => None,
         }
@@ -60,6 +63,8 @@ pub struct L7EndpointConfig {
     pub protocol: L7Protocol,
     pub tls: TlsMode,
     pub enforcement: EnforcementMode,
+    /// Maximum GraphQL request body bytes to buffer for inspection.
+    pub graphql_max_body_bytes: usize,
     /// When true, percent-encoded `/` (`%2F`) is preserved in path segments
     /// rather than rejected at the parser. Needed by upstreams like GitLab
     /// that embed `%2F` in namespaced project paths. Defaults to false.
@@ -83,6 +88,8 @@ pub struct L7RequestInfo {
     pub target: String,
     /// Decoded query parameter multimap for REST requests.
     pub query_params: std::collections::HashMap<String, Vec<String>>,
+    /// Parsed GraphQL operation metadata for GraphQL endpoints.
+    pub graphql: Option<graphql::GraphqlRequestInfo>,
 }
 
 /// Parse an L7 endpoint config from a regorus Value (returned by Rego query).
@@ -128,11 +135,16 @@ pub fn parse_l7_config(val: &regorus::Value) -> Option<L7EndpointConfig> {
     };
 
     let allow_encoded_slash = get_object_bool(val, "allow_encoded_slash").unwrap_or(false);
+    let graphql_max_body_bytes = get_object_u64(val, "graphql_max_body_bytes")
+        .and_then(|v| usize::try_from(v).ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(graphql::DEFAULT_MAX_BODY_BYTES);
 
     Some(L7EndpointConfig {
         protocol,
         tls,
         enforcement,
+        graphql_max_body_bytes,
         allow_encoded_slash,
     })
 }
@@ -156,6 +168,17 @@ fn get_object_bool(val: &regorus::Value, key: &str) -> Option<bool> {
     match val {
         regorus::Value::Object(map) => match map.get(&key_val) {
             Some(regorus::Value::Bool(b)) => Some(*b),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn get_object_u64(val: &regorus::Value, key: &str) -> Option<u64> {
+    let key_val = regorus::Value::String(key.into());
+    match val {
+        regorus::Value::Object(map) => match map.get(&key_val) {
+            Some(regorus::Value::Number(n)) => n.as_u64(),
             _ => None,
         },
         _ => None,
@@ -218,6 +241,85 @@ fn check_glob_syntax(pattern: &str) -> Option<String> {
     }
 
     None
+}
+
+fn validate_graphql_operation_type(
+    errors: &mut Vec<String>,
+    loc: &str,
+    value: Option<&str>,
+    required: bool,
+) {
+    let Some(value) = value.filter(|v| !v.is_empty()) else {
+        if required {
+            errors.push(format!(
+                "{loc}.operation_type: required for GraphQL L7 rules"
+            ));
+        }
+        return;
+    };
+
+    let valid = ["query", "mutation", "subscription", "*"];
+    if !valid.contains(&value.to_ascii_lowercase().as_str()) {
+        errors.push(format!(
+            "{loc}.operation_type: expected query, mutation, subscription, or *, got '{value}'"
+        ));
+    }
+}
+
+fn validate_graphql_fields(
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    loc: &str,
+    fields: Option<&serde_json::Value>,
+) {
+    let Some(fields) = fields else {
+        return;
+    };
+    let Some(items) = fields.as_array() else {
+        errors.push(format!(
+            "{loc}.fields: expected array of GraphQL root field globs"
+        ));
+        return;
+    };
+    if items.is_empty() {
+        errors.push(format!(
+            "{loc}.fields: list must not be empty; omit fields to match all root fields"
+        ));
+        return;
+    }
+    for item in items {
+        let Some(field) = item.as_str() else {
+            errors.push(format!("{loc}.fields: all values must be strings"));
+            continue;
+        };
+        if field.is_empty() {
+            errors.push(format!("{loc}.fields: field glob must not be empty"));
+        } else if let Some(warning) = check_glob_syntax(field) {
+            warnings.push(format!("{loc}.fields: {warning}"));
+        }
+    }
+}
+
+fn validate_graphql_rule(
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    loc: &str,
+    rule: &serde_json::Value,
+    required: bool,
+) {
+    validate_graphql_operation_type(
+        errors,
+        loc,
+        rule.get("operation_type").and_then(|v| v.as_str()),
+        required,
+    );
+    if let Some(name) = rule.get("operation_name").and_then(|v| v.as_str())
+        && !name.is_empty()
+        && let Some(warning) = check_glob_syntax(name)
+    {
+        warnings.push(format!("{loc}.operation_name: {warning}"));
+    }
+    validate_graphql_fields(errors, warnings, loc, rule.get("fields"));
 }
 
 /// Validate L7 policy configuration in the loaded OPA data.
@@ -313,6 +415,57 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                 errors.push(format!(
                     "{loc}: protocol requires rules or access to define allowed traffic"
                 ));
+            }
+
+            if !protocol.is_empty() && L7Protocol::parse(protocol).is_none() {
+                errors.push(format!(
+                    "{loc}: unknown protocol '{protocol}' (expected rest, graphql, or sql)"
+                ));
+            }
+
+            if let Some(mode) = ep.get("persisted_queries").and_then(|v| v.as_str())
+                && !mode.is_empty()
+                && mode != "deny"
+                && mode != "allow_registered"
+            {
+                errors.push(format!(
+                    "{loc}: persisted_queries must be 'deny' or 'allow_registered', got '{mode}'"
+                ));
+            }
+
+            if ep.get("graphql_max_body_bytes").is_some() {
+                let valid_max = ep
+                    .get("graphql_max_body_bytes")
+                    .and_then(serde_json::Value::as_u64)
+                    .is_some_and(|v| v > 0);
+                if !valid_max {
+                    errors.push(format!(
+                        "{loc}: graphql_max_body_bytes must be a positive integer"
+                    ));
+                }
+            }
+
+            if protocol != "graphql"
+                && (ep.get("persisted_queries").is_some()
+                    || ep.get("graphql_persisted_queries").is_some()
+                    || ep.get("graphql_max_body_bytes").is_some())
+            {
+                warnings.push(format!(
+                    "{loc}: GraphQL-specific endpoint fields are ignored unless protocol is graphql"
+                ));
+            }
+
+            if let Some(registry_value) = ep.get("graphql_persisted_queries") {
+                let Some(registry) = registry_value.as_object() else {
+                    errors.push(format!(
+                        "{loc}: graphql_persisted_queries must be a map keyed by hash or saved-query id"
+                    ));
+                    continue;
+                };
+                for (key, op) in registry {
+                    let registry_loc = format!("{loc}.graphql_persisted_queries[{key}]");
+                    validate_graphql_rule(&mut errors, &mut warnings, &registry_loc, op, true);
+                }
             }
 
             // Deprecated tls values: warn but don't error
@@ -504,6 +657,23 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                             warnings
                                 .push(format!("{deny_loc}: command is for SQL protocol, not REST"));
                         }
+
+                        if protocol == "graphql" {
+                            validate_graphql_rule(
+                                &mut errors,
+                                &mut warnings,
+                                &deny_loc,
+                                deny_rule,
+                                true,
+                            );
+                        } else if deny_rule.get("operation_type").is_some()
+                            || deny_rule.get("operation_name").is_some()
+                            || deny_rule.get("fields").is_some()
+                        {
+                            warnings.push(format!(
+                                "{deny_loc}: GraphQL rule fields are ignored unless protocol is graphql"
+                            ));
+                        }
                     }
                 }
             }
@@ -644,6 +814,17 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                     }
                 }
             }
+
+            if has_rules
+                && protocol == "graphql"
+                && let Some(rules) = ep.get("rules").and_then(|v| v.as_array())
+            {
+                for (rule_idx, rule) in rules.iter().enumerate() {
+                    let allow = rule.get("allow").unwrap_or(rule);
+                    let rule_loc = format!("{loc}.rules[{rule_idx}].allow");
+                    validate_graphql_rule(&mut errors, &mut warnings, &rule_loc, allow, true);
+                }
+            }
         }
     }
 
@@ -686,22 +867,35 @@ pub fn expand_access_presets(data: &mut serde_json::Value) {
                 continue;
             }
 
-            let rules = match access.as_str() {
-                "read-only" => vec![
-                    rule_json("GET", "**"),
-                    rule_json("HEAD", "**"),
-                    rule_json("OPTIONS", "**"),
-                ],
-                "read-write" => vec![
-                    rule_json("GET", "**"),
-                    rule_json("HEAD", "**"),
-                    rule_json("OPTIONS", "**"),
-                    rule_json("POST", "**"),
-                    rule_json("PUT", "**"),
-                    rule_json("PATCH", "**"),
-                ],
-                "full" => vec![rule_json("*", "**")],
-                _ => continue,
+            let protocol = ep
+                .get("protocol")
+                .and_then(|v| v.as_str())
+                .unwrap_or("rest");
+            let rules = if protocol == "graphql" {
+                match access.as_str() {
+                    "read-only" => vec![graphql_rule_json("query")],
+                    "read-write" => vec![graphql_rule_json("query"), graphql_rule_json("mutation")],
+                    "full" => vec![graphql_rule_json("*")],
+                    _ => continue,
+                }
+            } else {
+                match access.as_str() {
+                    "read-only" => vec![
+                        rule_json("GET", "**"),
+                        rule_json("HEAD", "**"),
+                        rule_json("OPTIONS", "**"),
+                    ],
+                    "read-write" => vec![
+                        rule_json("GET", "**"),
+                        rule_json("HEAD", "**"),
+                        rule_json("OPTIONS", "**"),
+                        rule_json("POST", "**"),
+                        rule_json("PUT", "**"),
+                        rule_json("PATCH", "**"),
+                    ],
+                    "full" => vec![rule_json("*", "**")],
+                    _ => continue,
+                }
             };
 
             ep.as_object_mut()
@@ -716,6 +910,14 @@ fn rule_json(method: &str, path: &str) -> serde_json::Value {
         "allow": {
             "method": method,
             "path": path
+        }
+    })
+}
+
+fn graphql_rule_json(operation_type: &str) -> serde_json::Value {
+    serde_json::json!({
+        "allow": {
+            "operation_type": operation_type
         }
     })
 }
@@ -974,6 +1176,81 @@ mod tests {
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0]["allow"]["method"].as_str().unwrap(), "*");
         assert_eq!(rules[0]["allow"]["path"].as_str().unwrap(), "**");
+    }
+
+    #[test]
+    fn expand_graphql_readonly_preset() {
+        let mut data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "api.example.com",
+                        "port": 443,
+                        "protocol": "graphql",
+                        "access": "read-only"
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        expand_access_presets(&mut data);
+        let rules = data["network_policies"]["test"]["endpoints"][0]["rules"]
+            .as_array()
+            .unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(
+            rules[0]["allow"]["operation_type"].as_str().unwrap(),
+            "query"
+        );
+    }
+
+    #[test]
+    fn validate_graphql_rule_requires_operation_type() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "api.example.com",
+                        "port": 443,
+                        "protocol": "graphql",
+                        "rules": [{
+                            "allow": {
+                                "fields": ["viewer"]
+                            }
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|e| e.contains("operation_type")),
+            "GraphQL rules should require operation_type: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_graphql_persisted_query_mode() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "api.example.com",
+                        "port": 443,
+                        "protocol": "graphql",
+                        "access": "full",
+                        "persisted_queries": "allow_all"
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|e| e.contains("persisted_queries")),
+            "invalid persisted query mode should be rejected: {errors:?}"
+        );
     }
 
     #[test]

--- a/crates/openshell-sandbox/src/l7/relay.rs
+++ b/crates/openshell-sandbox/src/l7/relay.rs
@@ -125,6 +125,247 @@ where
     }
 }
 
+/// Run HTTP L7 inspection with per-request protocol selection.
+///
+/// This is used when multiple L7 endpoints share a host:port, for example a
+/// REST API under `/repos/**` and a GraphQL API under `/graphql`.
+pub async fn relay_with_route_selection<C, U>(
+    configs: &[L7EndpointConfig],
+    engine: TunnelPolicyEngine,
+    client: &mut C,
+    upstream: &mut U,
+    ctx: &L7EvalContext,
+) -> Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin + Send,
+    U: AsyncRead + AsyncWrite + Unpin + Send,
+{
+    let provider =
+        crate::l7::rest::RestProvider::with_options(crate::l7::path::CanonicalizeOptions {
+            allow_encoded_slash: configs.iter().any(|config| config.allow_encoded_slash),
+            ..Default::default()
+        });
+
+    loop {
+        if close_if_stale(engine.generation_guard(), ctx) {
+            return Ok(());
+        }
+
+        let mut req = match provider.parse_request(client).await {
+            Ok(Some(req)) => req,
+            Ok(None) => return Ok(()),
+            Err(e) => {
+                if is_benign_connection_error(&e) {
+                    debug!(
+                        host = %ctx.host,
+                        port = ctx.port,
+                        error = %e,
+                        "L7 route-selected connection closed"
+                    );
+                } else {
+                    let detail =
+                        parse_rejection_detail(&e.to_string(), ParseRejectionMode::L7Endpoint);
+                    emit_parse_rejection(ctx, &detail, "l7");
+                }
+                return Ok(());
+            }
+        };
+
+        let Some(config) = select_l7_config_for_path(configs, &req.target) else {
+            crate::l7::rest::RestProvider::default()
+                .deny(
+                    &req,
+                    &ctx.policy_name,
+                    "no L7 endpoint path matched request",
+                    client,
+                )
+                .await?;
+            return Ok(());
+        };
+
+        let graphql_info = if config.protocol == L7Protocol::Graphql {
+            match crate::l7::graphql::inspect_graphql_request(
+                client,
+                &mut req,
+                config.graphql_max_body_bytes,
+            )
+            .await
+            {
+                Ok(info) => Some(info),
+                Err(e) => {
+                    if is_benign_connection_error(&e) {
+                        debug!(
+                            host = %ctx.host,
+                            port = ctx.port,
+                            error = %e,
+                            "GraphQL L7 connection closed"
+                        );
+                    } else {
+                        let detail =
+                            parse_rejection_detail(&e.to_string(), ParseRejectionMode::L7Endpoint);
+                        emit_parse_rejection(ctx, &detail, "l7-graphql");
+                    }
+                    return Ok(());
+                }
+            }
+        } else {
+            None
+        };
+
+        if close_if_stale(engine.generation_guard(), ctx) {
+            return Ok(());
+        }
+
+        let (eval_target, redacted_target) = if let Some(ref resolver) = ctx.secret_resolver {
+            match secrets::rewrite_target_for_eval(&req.target, resolver) {
+                Ok(result) => (result.resolved, result.redacted),
+                Err(e) => {
+                    warn!(
+                        host = %ctx.host,
+                        port = ctx.port,
+                        error = %e,
+                        "credential resolution failed in request target, rejecting"
+                    );
+                    let response = b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                    client.write_all(response).await.into_diagnostic()?;
+                    client.flush().await.into_diagnostic()?;
+                    return Ok(());
+                }
+            }
+        } else {
+            (req.target.clone(), req.target.clone())
+        };
+
+        let request_info = L7RequestInfo {
+            action: req.action.clone(),
+            target: redacted_target.clone(),
+            query_params: req.query_params.clone(),
+            graphql: graphql_info.clone(),
+        };
+
+        let parse_error_reason = graphql_info
+            .as_ref()
+            .and_then(|info| info.error.as_deref())
+            .map(|error| format!("GraphQL request rejected: {error}"));
+        let force_deny = parse_error_reason.is_some();
+        let (allowed, reason) = if let Some(reason) = parse_error_reason {
+            (false, reason)
+        } else {
+            evaluate_l7_request(&engine, ctx, &request_info)?
+        };
+
+        if close_if_stale(engine.generation_guard(), ctx) {
+            return Ok(());
+        }
+
+        let decision_str = match (allowed, config.enforcement) {
+            (_, _) if force_deny => "deny",
+            (true, _) => "allow",
+            (false, EnforcementMode::Audit) => "audit",
+            (false, EnforcementMode::Enforce) => "deny",
+        };
+        let engine_type = if config.protocol == L7Protocol::Graphql {
+            "l7-graphql"
+        } else {
+            "l7"
+        };
+        emit_l7_request_log(
+            ctx,
+            &request_info,
+            &redacted_target,
+            decision_str,
+            engine_type,
+            &reason,
+            graphql_info.as_ref(),
+        );
+
+        let _ = &eval_target;
+
+        if allowed || (config.enforcement == EnforcementMode::Audit && !force_deny) {
+            let outcome = crate::l7::rest::relay_http_request_with_resolver_guarded(
+                &req,
+                client,
+                upstream,
+                ctx.secret_resolver.as_deref(),
+                Some(engine.generation_guard()),
+            )
+            .await?;
+            match outcome {
+                RelayOutcome::Reusable => {}
+                RelayOutcome::Consumed => return Ok(()),
+                RelayOutcome::Upgraded { overflow } => {
+                    return handle_upgrade(client, upstream, overflow, &ctx.host, ctx.port).await;
+                }
+            }
+        } else {
+            crate::l7::rest::RestProvider::default()
+                .deny_with_redacted_target(
+                    &req,
+                    &ctx.policy_name,
+                    &reason,
+                    client,
+                    Some(&redacted_target),
+                )
+                .await?;
+            return Ok(());
+        }
+    }
+}
+
+fn select_l7_config_for_path<'a>(
+    configs: &'a [L7EndpointConfig],
+    path: &str,
+) -> Option<&'a L7EndpointConfig> {
+    configs
+        .iter()
+        .filter(|config| config.matches_path(path))
+        .max_by_key(|config| config.path_specificity())
+}
+
+fn emit_l7_request_log(
+    ctx: &L7EvalContext,
+    request_info: &L7RequestInfo,
+    redacted_target: &str,
+    decision_str: &str,
+    engine_type: &str,
+    reason: &str,
+    graphql_info: Option<&crate::l7::graphql::GraphqlRequestInfo>,
+) {
+    let (action_id, disposition_id, severity) = match decision_str {
+        "deny" => (ActionId::Denied, DispositionId::Blocked, SeverityId::Medium),
+        "allow" | "audit" => (
+            ActionId::Allowed,
+            DispositionId::Allowed,
+            SeverityId::Informational,
+        ),
+        _ => (
+            ActionId::Other,
+            DispositionId::Other,
+            SeverityId::Informational,
+        ),
+    };
+    let summary = graphql_info
+        .map(|info| format!(" {}", graphql_log_summary(info)))
+        .unwrap_or_default();
+    let event = HttpActivityBuilder::new(crate::ocsf_ctx())
+        .activity(ActivityId::Other)
+        .action(action_id)
+        .disposition(disposition_id)
+        .severity(severity)
+        .http_request(HttpRequest::new(
+            &request_info.action,
+            OcsfUrl::new("http", &ctx.host, redacted_target, ctx.port),
+        ))
+        .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+        .firewall_rule(&ctx.policy_name, engine_type)
+        .message(format!(
+            "L7_REQUEST {decision_str} {} {}:{}{}{} reason={}",
+            request_info.action, ctx.host, ctx.port, redacted_target, summary, reason,
+        ))
+        .build();
+    ocsf_emit!(event);
+}
+
 /// Handle an upgraded connection (101 Switching Protocols).
 ///
 /// Forwards any overflow bytes from the upgrade response to the client, then

--- a/crates/openshell-sandbox/src/l7/relay.rs
+++ b/crates/openshell-sandbox/src/l7/relay.rs
@@ -102,6 +102,7 @@ where
 {
     match config.protocol {
         L7Protocol::Rest => relay_rest(config, &engine, client, upstream, ctx).await,
+        L7Protocol::Graphql => relay_graphql(config, &engine, client, upstream, ctx).await,
         L7Protocol::Sql => {
             if close_if_stale(engine.generation_guard(), ctx) {
                 return Ok(());
@@ -241,6 +242,7 @@ where
             action: req.action.clone(),
             target: redacted_target.clone(),
             query_params: req.query_params.clone(),
+            graphql: None,
         };
 
         // Evaluate L7 policy via Rego (using redacted target)
@@ -374,6 +376,199 @@ fn close_if_stale(guard: &PolicyGenerationGuard, ctx: &L7EvalContext) -> bool {
     true
 }
 
+async fn relay_graphql<C, U>(
+    config: &L7EndpointConfig,
+    engine: &TunnelPolicyEngine,
+    client: &mut C,
+    upstream: &mut U,
+    ctx: &L7EvalContext,
+) -> Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin + Send,
+    U: AsyncRead + AsyncWrite + Unpin + Send,
+{
+    loop {
+        if close_if_stale(engine.generation_guard(), ctx) {
+            return Ok(());
+        }
+
+        let parsed = match crate::l7::graphql::parse_graphql_http_request(
+            client,
+            config.graphql_max_body_bytes,
+            crate::l7::path::CanonicalizeOptions {
+                allow_encoded_slash: config.allow_encoded_slash,
+                ..Default::default()
+            },
+        )
+        .await
+        {
+            Ok(Some(parsed)) => parsed,
+            Ok(None) => return Ok(()),
+            Err(e) => {
+                if is_benign_connection_error(&e) {
+                    debug!(
+                        host = %ctx.host,
+                        port = ctx.port,
+                        error = %e,
+                        "GraphQL L7 connection closed"
+                    );
+                } else {
+                    let detail =
+                        parse_rejection_detail(&e.to_string(), ParseRejectionMode::L7Endpoint);
+                    emit_parse_rejection(ctx, &detail, "l7-graphql");
+                }
+                return Ok(());
+            }
+        };
+
+        let req = parsed.request;
+        let graphql_info = parsed.info;
+
+        if close_if_stale(engine.generation_guard(), ctx) {
+            return Ok(());
+        }
+
+        let (eval_target, redacted_target) = if let Some(ref resolver) = ctx.secret_resolver {
+            match secrets::rewrite_target_for_eval(&req.target, resolver) {
+                Ok(result) => (result.resolved, result.redacted),
+                Err(e) => {
+                    warn!(
+                        host = %ctx.host,
+                        port = ctx.port,
+                        error = %e,
+                        "credential resolution failed in GraphQL request target, rejecting"
+                    );
+                    let response = b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                    client.write_all(response).await.into_diagnostic()?;
+                    client.flush().await.into_diagnostic()?;
+                    return Ok(());
+                }
+            }
+        } else {
+            (req.target.clone(), req.target.clone())
+        };
+
+        let request_info = L7RequestInfo {
+            action: req.action.clone(),
+            target: redacted_target.clone(),
+            query_params: req.query_params.clone(),
+            graphql: Some(graphql_info.clone()),
+        };
+
+        let (allowed, reason) = evaluate_l7_request(engine, ctx, &request_info)?;
+
+        if close_if_stale(engine.generation_guard(), ctx) {
+            return Ok(());
+        }
+
+        let decision_str = match (allowed, config.enforcement) {
+            (true, _) => "allow",
+            (false, EnforcementMode::Audit) => "audit",
+            (false, EnforcementMode::Enforce) => "deny",
+        };
+
+        {
+            let (action_id, disposition_id, severity) = match decision_str {
+                "deny" => (ActionId::Denied, DispositionId::Blocked, SeverityId::Medium),
+                "allow" | "audit" => (
+                    ActionId::Allowed,
+                    DispositionId::Allowed,
+                    SeverityId::Informational,
+                ),
+                _ => (
+                    ActionId::Other,
+                    DispositionId::Other,
+                    SeverityId::Informational,
+                ),
+            };
+            let gql_summary = graphql_log_summary(&graphql_info);
+            let event = HttpActivityBuilder::new(crate::ocsf_ctx())
+                .activity(ActivityId::Other)
+                .action(action_id)
+                .disposition(disposition_id)
+                .severity(severity)
+                .http_request(HttpRequest::new(
+                    &request_info.action,
+                    OcsfUrl::new("http", &ctx.host, &redacted_target, ctx.port),
+                ))
+                .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+                .firewall_rule(&ctx.policy_name, "l7-graphql")
+                .message(format!(
+                    "GRAPHQL_L7_REQUEST {decision_str} {} {}:{}{} {gql_summary} reason={}",
+                    request_info.action, ctx.host, ctx.port, redacted_target, reason,
+                ))
+                .build();
+            ocsf_emit!(event);
+        }
+
+        let _ = &eval_target;
+
+        if allowed || config.enforcement == EnforcementMode::Audit {
+            let outcome = crate::l7::rest::relay_http_request_with_resolver_guarded(
+                &req,
+                client,
+                upstream,
+                ctx.secret_resolver.as_deref(),
+                Some(engine.generation_guard()),
+            )
+            .await?;
+            match outcome {
+                RelayOutcome::Reusable => {}
+                RelayOutcome::Consumed => {
+                    debug!(
+                        host = %ctx.host,
+                        port = ctx.port,
+                        "Upstream connection not reusable, closing GraphQL L7 relay"
+                    );
+                    return Ok(());
+                }
+                RelayOutcome::Upgraded { overflow } => {
+                    return handle_upgrade(client, upstream, overflow, &ctx.host, ctx.port).await;
+                }
+            }
+        } else {
+            crate::l7::rest::RestProvider::default()
+                .deny_with_redacted_target(
+                    &req,
+                    &ctx.policy_name,
+                    &reason,
+                    client,
+                    Some(&redacted_target),
+                )
+                .await?;
+            return Ok(());
+        }
+    }
+}
+
+fn graphql_log_summary(info: &crate::l7::graphql::GraphqlRequestInfo) -> String {
+    if let Some(error) = &info.error {
+        return format!("graphql_error={error:?}");
+    }
+    let ops: Vec<String> = info
+        .operations
+        .iter()
+        .map(|op| {
+            let name = op.operation_name.as_deref().unwrap_or("-");
+            let fields = if op.fields.is_empty() {
+                "-".to_string()
+            } else {
+                op.fields.join(",")
+            };
+            let persisted = op
+                .persisted_query_hash
+                .as_deref()
+                .or(op.persisted_query_id.as_deref())
+                .unwrap_or("-");
+            format!(
+                "type={} name={} fields={} persisted={}",
+                op.operation_type, name, fields, persisted
+            )
+        })
+        .collect();
+    format!("graphql_ops={}", ops.join(";"))
+}
+
 /// Check if a miette error represents a benign connection close.
 ///
 /// TLS handshake EOF, missing `close_notify`, connection resets, and broken
@@ -422,6 +617,7 @@ pub fn evaluate_l7_request(
             "method": request.action,
             "path": request.target,
             "query_params": request.query_params.clone(),
+            "graphql": request.graphql.clone(),
         }
     });
 

--- a/crates/openshell-sandbox/src/l7/relay.rs
+++ b/crates/openshell-sandbox/src/l7/relay.rs
@@ -455,13 +455,27 @@ where
             graphql: Some(graphql_info.clone()),
         };
 
-        let (allowed, reason) = evaluate_l7_request(engine, ctx, &request_info)?;
+        // Malformed or ambiguous GraphQL requests, such as duplicated GET
+        // control parameters, are rejected before policy evaluation. This
+        // keeps parser-differential cases fail-closed even if the endpoint is
+        // otherwise in audit mode.
+        let parse_error_reason = graphql_info
+            .error
+            .as_deref()
+            .map(|error| format!("GraphQL request rejected: {error}"));
+        let force_deny = parse_error_reason.is_some();
+        let (allowed, reason) = if let Some(reason) = parse_error_reason {
+            (false, reason)
+        } else {
+            evaluate_l7_request(engine, ctx, &request_info)?
+        };
 
         if close_if_stale(engine.generation_guard(), ctx) {
             return Ok(());
         }
 
         let decision_str = match (allowed, config.enforcement) {
+            (_, _) if force_deny => "deny",
             (true, _) => "allow",
             (false, EnforcementMode::Audit) => "audit",
             (false, EnforcementMode::Enforce) => "deny",
@@ -503,7 +517,7 @@ where
 
         let _ = &eval_target;
 
-        if allowed || config.enforcement == EnforcementMode::Audit {
+        if allowed || (config.enforcement == EnforcementMode::Audit && !force_deny) {
             let outcome = crate::l7::rest::relay_http_request_with_resolver_guarded(
                 &req,
                 client,

--- a/crates/openshell-sandbox/src/l7/relay.rs
+++ b/crates/openshell-sandbox/src/l7/relay.rs
@@ -101,6 +101,7 @@ where
 {
     match config.protocol {
         L7Protocol::Rest => relay_rest(config, &engine, client, upstream, ctx).await,
+        L7Protocol::Graphql => relay_graphql(config, &engine, client, upstream, ctx).await,
         L7Protocol::Sql => {
             // SQL provider is Phase 3 — fall through to passthrough with warning
             {
@@ -229,6 +230,7 @@ where
             action: req.action.clone(),
             target: redacted_target.clone(),
             query_params: req.query_params.clone(),
+            graphql: None,
         };
 
         // Evaluate L7 policy via Rego (using redacted target)
@@ -331,6 +333,185 @@ where
     }
 }
 
+async fn relay_graphql<C, U>(
+    config: &L7EndpointConfig,
+    engine: &Mutex<regorus::Engine>,
+    client: &mut C,
+    upstream: &mut U,
+    ctx: &L7EvalContext,
+) -> Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin + Send,
+    U: AsyncRead + AsyncWrite + Unpin + Send,
+{
+    loop {
+        let parsed = match crate::l7::graphql::parse_graphql_http_request(
+            client,
+            config.graphql_max_body_bytes,
+            crate::l7::path::CanonicalizeOptions {
+                allow_encoded_slash: config.allow_encoded_slash,
+                ..Default::default()
+            },
+        )
+        .await
+        {
+            Ok(Some(parsed)) => parsed,
+            Ok(None) => return Ok(()),
+            Err(e) => {
+                if is_benign_connection_error(&e) {
+                    debug!(
+                        host = %ctx.host,
+                        port = ctx.port,
+                        error = %e,
+                        "GraphQL L7 connection closed"
+                    );
+                } else {
+                    let detail =
+                        parse_rejection_detail(&e.to_string(), ParseRejectionMode::L7Endpoint);
+                    emit_parse_rejection(ctx, &detail, "l7-graphql");
+                }
+                return Ok(());
+            }
+        };
+
+        let req = parsed.request;
+        let graphql_info = parsed.info;
+
+        let (eval_target, redacted_target) = if let Some(ref resolver) = ctx.secret_resolver {
+            match secrets::rewrite_target_for_eval(&req.target, resolver) {
+                Ok(result) => (result.resolved, result.redacted),
+                Err(e) => {
+                    warn!(
+                        host = %ctx.host,
+                        port = ctx.port,
+                        error = %e,
+                        "credential resolution failed in GraphQL request target, rejecting"
+                    );
+                    let response = b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                    client.write_all(response).await.into_diagnostic()?;
+                    client.flush().await.into_diagnostic()?;
+                    return Ok(());
+                }
+            }
+        } else {
+            (req.target.clone(), req.target.clone())
+        };
+
+        let request_info = L7RequestInfo {
+            action: req.action.clone(),
+            target: redacted_target.clone(),
+            query_params: req.query_params.clone(),
+            graphql: Some(graphql_info.clone()),
+        };
+
+        let (allowed, reason) = evaluate_l7_request(engine, ctx, &request_info)?;
+        let decision_str = match (allowed, config.enforcement) {
+            (true, _) => "allow",
+            (false, EnforcementMode::Audit) => "audit",
+            (false, EnforcementMode::Enforce) => "deny",
+        };
+
+        {
+            let (action_id, disposition_id, severity) = match decision_str {
+                "deny" => (ActionId::Denied, DispositionId::Blocked, SeverityId::Medium),
+                "allow" | "audit" => (
+                    ActionId::Allowed,
+                    DispositionId::Allowed,
+                    SeverityId::Informational,
+                ),
+                _ => (
+                    ActionId::Other,
+                    DispositionId::Other,
+                    SeverityId::Informational,
+                ),
+            };
+            let gql_summary = graphql_log_summary(&graphql_info);
+            let event = HttpActivityBuilder::new(crate::ocsf_ctx())
+                .activity(ActivityId::Other)
+                .action(action_id)
+                .disposition(disposition_id)
+                .severity(severity)
+                .http_request(HttpRequest::new(
+                    &request_info.action,
+                    OcsfUrl::new("http", &ctx.host, &redacted_target, ctx.port),
+                ))
+                .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+                .firewall_rule(&ctx.policy_name, "l7-graphql")
+                .message(format!(
+                    "GRAPHQL_L7_REQUEST {decision_str} {} {}:{}{} {gql_summary} reason={}",
+                    request_info.action, ctx.host, ctx.port, redacted_target, reason,
+                ))
+                .build();
+            ocsf_emit!(event);
+        }
+
+        let _ = &eval_target;
+
+        if allowed || config.enforcement == EnforcementMode::Audit {
+            let outcome = crate::l7::rest::relay_http_request_with_resolver(
+                &req,
+                client,
+                upstream,
+                ctx.secret_resolver.as_deref(),
+            )
+            .await?;
+            match outcome {
+                RelayOutcome::Reusable => {}
+                RelayOutcome::Consumed => {
+                    debug!(
+                        host = %ctx.host,
+                        port = ctx.port,
+                        "Upstream connection not reusable, closing GraphQL L7 relay"
+                    );
+                    return Ok(());
+                }
+                RelayOutcome::Upgraded { overflow } => {
+                    return handle_upgrade(client, upstream, overflow, &ctx.host, ctx.port).await;
+                }
+            }
+        } else {
+            crate::l7::rest::RestProvider::default()
+                .deny_with_redacted_target(
+                    &req,
+                    &ctx.policy_name,
+                    &reason,
+                    client,
+                    Some(&redacted_target),
+                )
+                .await?;
+            return Ok(());
+        }
+    }
+}
+
+fn graphql_log_summary(info: &crate::l7::graphql::GraphqlRequestInfo) -> String {
+    if let Some(error) = &info.error {
+        return format!("graphql_error={error:?}");
+    }
+    let ops: Vec<String> = info
+        .operations
+        .iter()
+        .map(|op| {
+            let name = op.operation_name.as_deref().unwrap_or("-");
+            let fields = if op.fields.is_empty() {
+                "-".to_string()
+            } else {
+                op.fields.join(",")
+            };
+            let persisted = op
+                .persisted_query_hash
+                .as_deref()
+                .or(op.persisted_query_id.as_deref())
+                .unwrap_or("-");
+            format!(
+                "type={} name={} fields={} persisted={}",
+                op.operation_type, name, fields, persisted
+            )
+        })
+        .collect();
+    format!("graphql_ops={}", ops.join(";"))
+}
+
 /// Check if a miette error represents a benign connection close.
 ///
 /// TLS handshake EOF, missing `close_notify`, connection resets, and broken
@@ -371,6 +552,7 @@ pub fn evaluate_l7_request(
             "method": request.action,
             "path": request.target,
             "query_params": request.query_params.clone(),
+            "graphql": request.graphql.clone(),
         }
     });
 

--- a/crates/openshell-sandbox/src/mechanistic_mapper.rs
+++ b/crates/openshell-sandbox/src/mechanistic_mapper.rs
@@ -352,6 +352,9 @@ fn build_l7_rules(samples: &HashMap<(String, String), u32>) -> Vec<L7Rule> {
                 path: generalised,
                 command: String::new(),
                 query: HashMap::new(),
+                operation_type: String::new(),
+                operation_name: String::new(),
+                fields: Vec::new(),
             }),
         });
     }

--- a/crates/openshell-sandbox/src/opa.rs
+++ b/crates/openshell-sandbox/src/opa.rs
@@ -2080,6 +2080,30 @@ process:
     }
 
     #[test]
+    fn l7_graphql_unregistered_hash_only_query_has_deny_reason() {
+        let engine = l7_engine();
+        let input = l7_graphql_input(
+            "api.graphql.com",
+            serde_json::json!([{
+                "operation_type": "",
+                "operation_name": "Viewer",
+                "fields": [],
+                "persisted_query": true,
+                "persisted_query_hash": "missing"
+            }]),
+        );
+        let mut eng = engine.engine.lock().unwrap();
+        eng.set_input_json(&input.to_string()).unwrap();
+        let val = eng
+            .eval_rule("data.openshell.sandbox.request_deny_reason".into())
+            .unwrap();
+        assert_eq!(
+            val,
+            regorus::Value::String("GraphQL persisted query is not registered".into())
+        );
+    }
+
+    #[test]
     fn l7_graphql_parse_error_denied() {
         let engine = l7_engine();
         let input = l7_graphql_error_input("api.graphql.com", "GraphQL document parse error");

--- a/crates/openshell-sandbox/src/opa.rs
+++ b/crates/openshell-sandbox/src/opa.rs
@@ -491,6 +491,15 @@ impl OpaEngine {
         &self,
         input: &NetworkInput,
     ) -> Result<(Option<regorus::Value>, u64)> {
+        let (configs, generation) = self.query_endpoint_configs_with_generation(input)?;
+        Ok((configs.into_iter().next(), generation))
+    }
+
+    /// Query all matching endpoint configs and return the policy generation used for the query.
+    pub fn query_endpoint_configs_with_generation(
+        &self,
+        input: &NetworkInput,
+    ) -> Result<(Vec<regorus::Value>, u64)> {
         let ancestor_strs: Vec<String> = input
             .ancestors
             .iter()
@@ -524,13 +533,13 @@ impl OpaEngine {
             .map_err(|e| miette::miette!("{e}"))?;
 
         let val = engine
-            .eval_rule("data.openshell.sandbox.matched_endpoint_config".into())
+            .eval_rule("data.openshell.sandbox._matching_endpoint_configs".into())
             .map_err(|e| miette::miette!("{e}"))?;
 
-        if val == regorus::Value::Undefined {
-            Ok((None, generation))
-        } else {
-            Ok((Some(val), generation))
+        match val {
+            regorus::Value::Undefined => Ok((Vec::new(), generation)),
+            regorus::Value::Array(values) => Ok((values.to_vec(), generation)),
+            other => Ok((vec![other], generation)),
         }
     }
 
@@ -939,6 +948,9 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                         vec![]
                     };
                     let mut ep = serde_json::json!({"host": e.host, "ports": ports});
+                    if !e.path.is_empty() {
+                        ep["path"] = e.path.clone().into();
+                    }
                     if !e.protocol.is_empty() {
                         ep["protocol"] = e.protocol.clone().into();
                     }
@@ -2096,6 +2108,62 @@ process:
             }]),
         );
         assert!(!eval_l7(&engine, &mutation));
+    }
+
+    #[test]
+    fn l7_endpoint_path_scopes_rest_and_graphql_on_same_host() {
+        let data = r#"
+network_policies:
+  mixed_api:
+    name: mixed_api
+    endpoints:
+      - host: api.github.test
+        port: 443
+        path: "/repos/**"
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow:
+              method: "*"
+              path: "/**"
+      - host: api.github.test
+        port: 443
+        path: "/graphql"
+        protocol: graphql
+        enforcement: enforce
+        rules:
+          - allow:
+              operation_type: query
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
+
+        let rest_write = l7_input("api.github.test", 443, "POST", "/repos/org/repo/issues");
+        assert!(eval_l7(&engine, &rest_write));
+
+        let graphql_query = l7_graphql_input(
+            "api.github.test",
+            serde_json::json!([{
+                "operation_type": "query",
+                "fields": ["viewer"],
+                "persisted_query": false
+            }]),
+        );
+        assert!(eval_l7(&engine, &graphql_query));
+
+        let graphql_mutation = l7_graphql_input(
+            "api.github.test",
+            serde_json::json!([{
+                "operation_type": "mutation",
+                "fields": ["deleteRepository"],
+                "persisted_query": false
+            }]),
+        );
+        assert!(
+            !eval_l7(&engine, &graphql_mutation),
+            "REST rules on the same host must not allow a GraphQL mutation"
+        );
     }
 
     #[test]

--- a/crates/openshell-sandbox/src/opa.rs
+++ b/crates/openshell-sandbox/src/opa.rs
@@ -961,7 +961,14 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                                     "method": a.map_or("", |a| &a.method),
                                     "path": a.map_or("", |a| &a.path),
                                     "command": a.map_or("", |a| &a.command),
+                                    "operation_type": a.map_or("", |a| &a.operation_type),
+                                    "operation_name": a.map_or("", |a| &a.operation_name),
                                 });
+                                if let Some(a) = a
+                                    && !a.fields.is_empty()
+                                {
+                                    allow["fields"] = a.fields.clone().into();
+                                }
                                 let query: serde_json::Map<String, serde_json::Value> = a
                                     .map(|allow| {
                                         allow
@@ -1008,6 +1015,15 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                                 if !d.command.is_empty() {
                                     deny["command"] = d.command.clone().into();
                                 }
+                                if !d.operation_type.is_empty() {
+                                    deny["operation_type"] = d.operation_type.clone().into();
+                                }
+                                if !d.operation_name.is_empty() {
+                                    deny["operation_name"] = d.operation_name.clone().into();
+                                }
+                                if !d.fields.is_empty() {
+                                    deny["fields"] = d.fields.clone().into();
+                                }
                                 let query: serde_json::Map<String, serde_json::Value> = d
                                     .query
                                     .iter()
@@ -1032,6 +1048,29 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                     }
                     if e.allow_encoded_slash {
                         ep["allow_encoded_slash"] = true.into();
+                    }
+                    if !e.persisted_queries.is_empty() {
+                        ep["persisted_queries"] = e.persisted_queries.clone().into();
+                    }
+                    if !e.graphql_persisted_queries.is_empty() {
+                        let persisted: serde_json::Map<String, serde_json::Value> = e
+                            .graphql_persisted_queries
+                            .iter()
+                            .map(|(key, op)| {
+                                (
+                                    key.clone(),
+                                    serde_json::json!({
+                                        "operation_type": op.operation_type,
+                                        "operation_name": op.operation_name,
+                                        "fields": op.fields,
+                                    }),
+                                )
+                            })
+                            .collect();
+                        ep["graphql_persisted_queries"] = persisted.into();
+                    }
+                    if e.graphql_max_body_bytes > 0 {
+                        ep["graphql_max_body_bytes"] = e.graphql_max_body_bytes.into();
                     }
                     ep
                 })
@@ -1724,6 +1763,42 @@ network_policies:
                   any: ["foo-*", "bar-*"]
     binaries:
       - { path: /usr/bin/curl }
+  graphql_api:
+    name: graphql_api
+    endpoints:
+      - host: api.graphql.com
+        port: 443
+        protocol: graphql
+        enforcement: enforce
+        persisted_queries: allow_registered
+        graphql_persisted_queries:
+          abc123:
+            operation_type: query
+            operation_name: Viewer
+            fields: [viewer]
+        rules:
+          - allow:
+              operation_type: query
+              fields: [viewer, repository]
+          - allow:
+              operation_type: mutation
+              operation_name: Issue*
+              fields: [createIssue, deleteRepository]
+        deny_rules:
+          - operation_type: mutation
+            fields: [deleteRepository]
+    binaries:
+      - { path: /usr/bin/curl }
+  graphql_readonly:
+    name: graphql_readonly
+    endpoints:
+      - host: gql.readonly.com
+        port: 443
+        protocol: graphql
+        enforcement: enforce
+        access: read-only
+    binaries:
+      - { path: /usr/bin/curl }
   l4_only:
     name: l4_only
     endpoints:
@@ -1767,6 +1842,45 @@ process:
                 "method": method,
                 "path": path,
                 "query_params": query_params
+            }
+        })
+    }
+
+    fn l7_graphql_input(host: &str, operations: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "network": { "host": host, "port": 443 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "POST",
+                "path": "/graphql",
+                "query_params": {},
+                "graphql": {
+                    "operations": operations
+                }
+            }
+        })
+    }
+
+    fn l7_graphql_error_input(host: &str, error: &str) -> serde_json::Value {
+        serde_json::json!({
+            "network": { "host": host, "port": 443 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "POST",
+                "path": "/graphql",
+                "query_params": {},
+                "graphql": {
+                    "operations": [],
+                    "error": error
+                }
             }
         })
     }
@@ -1853,6 +1967,135 @@ process:
                 "{method} should be allowed with full preset"
             );
         }
+    }
+
+    #[test]
+    fn l7_graphql_query_allowed_by_field_rule() {
+        let engine = l7_engine();
+        let input = l7_graphql_input(
+            "api.graphql.com",
+            serde_json::json!([{
+                "operation_type": "query",
+                "operation_name": "RepoLookup",
+                "fields": ["repository"],
+                "persisted_query": false
+            }]),
+        );
+        assert!(eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_unlisted_field_denied() {
+        let engine = l7_engine();
+        let input = l7_graphql_input(
+            "api.graphql.com",
+            serde_json::json!([{
+                "operation_type": "query",
+                "fields": ["viewer", "adminAuditLog"],
+                "persisted_query": false
+            }]),
+        );
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_batch_denied_if_any_operation_unallowed() {
+        let engine = l7_engine();
+        let input = l7_graphql_input(
+            "api.graphql.com",
+            serde_json::json!([
+                {
+                    "operation_type": "query",
+                    "fields": ["viewer"],
+                    "persisted_query": false
+                },
+                {
+                    "operation_type": "mutation",
+                    "operation_name": "DeleteRepo",
+                    "fields": ["deleteRepository"],
+                    "persisted_query": false
+                }
+            ]),
+        );
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_deny_rule_takes_precedence() {
+        let engine = l7_engine();
+        let input = l7_graphql_input(
+            "api.graphql.com",
+            serde_json::json!([{
+                "operation_type": "mutation",
+                "operation_name": "IssueDelete",
+                "fields": ["deleteRepository"],
+                "persisted_query": false
+            }]),
+        );
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_registered_hash_only_query_allowed() {
+        let engine = l7_engine();
+        let input = l7_graphql_input(
+            "api.graphql.com",
+            serde_json::json!([{
+                "operation_type": "",
+                "operation_name": "Viewer",
+                "fields": [],
+                "persisted_query": true,
+                "persisted_query_hash": "abc123"
+            }]),
+        );
+        assert!(eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_unregistered_hash_only_query_denied() {
+        let engine = l7_engine();
+        let input = l7_graphql_input(
+            "api.graphql.com",
+            serde_json::json!([{
+                "operation_type": "",
+                "operation_name": "Viewer",
+                "fields": [],
+                "persisted_query": true,
+                "persisted_query_hash": "missing"
+            }]),
+        );
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_parse_error_denied() {
+        let engine = l7_engine();
+        let input = l7_graphql_error_input("api.graphql.com", "GraphQL document parse error");
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_readonly_access_allows_query_and_denies_mutation() {
+        let engine = l7_engine();
+        let query = l7_graphql_input(
+            "gql.readonly.com",
+            serde_json::json!([{
+                "operation_type": "query",
+                "fields": ["viewer"],
+                "persisted_query": false
+            }]),
+        );
+        assert!(eval_l7(&engine, &query));
+
+        let mutation = l7_graphql_input(
+            "gql.readonly.com",
+            serde_json::json!([{
+                "operation_type": "mutation",
+                "fields": ["createIssue"],
+                "persisted_query": false
+            }]),
+        );
+        assert!(!eval_l7(&engine, &mutation));
     }
 
     #[test]
@@ -1956,6 +2199,9 @@ process:
                             path: "/download".to_string(),
                             command: String::new(),
                             query,
+                            operation_type: String::new(),
+                            operation_name: String::new(),
+                            fields: Vec::new(),
                         }),
                     }],
                     ..Default::default()

--- a/crates/openshell-sandbox/src/opa.rs
+++ b/crates/openshell-sandbox/src/opa.rs
@@ -842,7 +842,14 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                                     "method": a.map_or("", |a| &a.method),
                                     "path": a.map_or("", |a| &a.path),
                                     "command": a.map_or("", |a| &a.command),
+                                    "operation_type": a.map_or("", |a| &a.operation_type),
+                                    "operation_name": a.map_or("", |a| &a.operation_name),
                                 });
+                                if let Some(a) = a
+                                    && !a.fields.is_empty()
+                                {
+                                    allow["fields"] = a.fields.clone().into();
+                                }
                                 let query: serde_json::Map<String, serde_json::Value> = a
                                     .map(|allow| {
                                         allow
@@ -889,6 +896,15 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                                 if !d.command.is_empty() {
                                     deny["command"] = d.command.clone().into();
                                 }
+                                if !d.operation_type.is_empty() {
+                                    deny["operation_type"] = d.operation_type.clone().into();
+                                }
+                                if !d.operation_name.is_empty() {
+                                    deny["operation_name"] = d.operation_name.clone().into();
+                                }
+                                if !d.fields.is_empty() {
+                                    deny["fields"] = d.fields.clone().into();
+                                }
                                 let query: serde_json::Map<String, serde_json::Value> = d
                                     .query
                                     .iter()
@@ -913,6 +929,29 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                     }
                     if e.allow_encoded_slash {
                         ep["allow_encoded_slash"] = true.into();
+                    }
+                    if !e.persisted_queries.is_empty() {
+                        ep["persisted_queries"] = e.persisted_queries.clone().into();
+                    }
+                    if !e.graphql_persisted_queries.is_empty() {
+                        let persisted: serde_json::Map<String, serde_json::Value> = e
+                            .graphql_persisted_queries
+                            .iter()
+                            .map(|(key, op)| {
+                                (
+                                    key.clone(),
+                                    serde_json::json!({
+                                        "operation_type": op.operation_type,
+                                        "operation_name": op.operation_name,
+                                        "fields": op.fields,
+                                    }),
+                                )
+                            })
+                            .collect();
+                        ep["graphql_persisted_queries"] = persisted.into();
+                    }
+                    if e.graphql_max_body_bytes > 0 {
+                        ep["graphql_max_body_bytes"] = e.graphql_max_body_bytes.into();
                     }
                     ep
                 })
@@ -1605,6 +1644,42 @@ network_policies:
                   any: ["foo-*", "bar-*"]
     binaries:
       - { path: /usr/bin/curl }
+  graphql_api:
+    name: graphql_api
+    endpoints:
+      - host: api.graphql.com
+        port: 443
+        protocol: graphql
+        enforcement: enforce
+        persisted_queries: allow_registered
+        graphql_persisted_queries:
+          abc123:
+            operation_type: query
+            operation_name: Viewer
+            fields: [viewer]
+        rules:
+          - allow:
+              operation_type: query
+              fields: [viewer, repository]
+          - allow:
+              operation_type: mutation
+              operation_name: Issue*
+              fields: [createIssue, deleteRepository]
+        deny_rules:
+          - operation_type: mutation
+            fields: [deleteRepository]
+    binaries:
+      - { path: /usr/bin/curl }
+  graphql_readonly:
+    name: graphql_readonly
+    endpoints:
+      - host: gql.readonly.com
+        port: 443
+        protocol: graphql
+        enforcement: enforce
+        access: read-only
+    binaries:
+      - { path: /usr/bin/curl }
   l4_only:
     name: l4_only
     endpoints:
@@ -1648,6 +1723,45 @@ process:
                 "method": method,
                 "path": path,
                 "query_params": query_params
+            }
+        })
+    }
+
+    fn l7_graphql_input(host: &str, operations: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "network": { "host": host, "port": 443 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "POST",
+                "path": "/graphql",
+                "query_params": {},
+                "graphql": {
+                    "operations": operations
+                }
+            }
+        })
+    }
+
+    fn l7_graphql_error_input(host: &str, error: &str) -> serde_json::Value {
+        serde_json::json!({
+            "network": { "host": host, "port": 443 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "POST",
+                "path": "/graphql",
+                "query_params": {},
+                "graphql": {
+                    "operations": [],
+                    "error": error
+                }
             }
         })
     }
@@ -1734,6 +1848,135 @@ process:
                 "{method} should be allowed with full preset"
             );
         }
+    }
+
+    #[test]
+    fn l7_graphql_query_allowed_by_field_rule() {
+        let engine = l7_engine();
+        let input = l7_graphql_input(
+            "api.graphql.com",
+            serde_json::json!([{
+                "operation_type": "query",
+                "operation_name": "RepoLookup",
+                "fields": ["repository"],
+                "persisted_query": false
+            }]),
+        );
+        assert!(eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_unlisted_field_denied() {
+        let engine = l7_engine();
+        let input = l7_graphql_input(
+            "api.graphql.com",
+            serde_json::json!([{
+                "operation_type": "query",
+                "fields": ["viewer", "adminAuditLog"],
+                "persisted_query": false
+            }]),
+        );
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_batch_denied_if_any_operation_unallowed() {
+        let engine = l7_engine();
+        let input = l7_graphql_input(
+            "api.graphql.com",
+            serde_json::json!([
+                {
+                    "operation_type": "query",
+                    "fields": ["viewer"],
+                    "persisted_query": false
+                },
+                {
+                    "operation_type": "mutation",
+                    "operation_name": "DeleteRepo",
+                    "fields": ["deleteRepository"],
+                    "persisted_query": false
+                }
+            ]),
+        );
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_deny_rule_takes_precedence() {
+        let engine = l7_engine();
+        let input = l7_graphql_input(
+            "api.graphql.com",
+            serde_json::json!([{
+                "operation_type": "mutation",
+                "operation_name": "IssueDelete",
+                "fields": ["deleteRepository"],
+                "persisted_query": false
+            }]),
+        );
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_registered_hash_only_query_allowed() {
+        let engine = l7_engine();
+        let input = l7_graphql_input(
+            "api.graphql.com",
+            serde_json::json!([{
+                "operation_type": "",
+                "operation_name": "Viewer",
+                "fields": [],
+                "persisted_query": true,
+                "persisted_query_hash": "abc123"
+            }]),
+        );
+        assert!(eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_unregistered_hash_only_query_denied() {
+        let engine = l7_engine();
+        let input = l7_graphql_input(
+            "api.graphql.com",
+            serde_json::json!([{
+                "operation_type": "",
+                "operation_name": "Viewer",
+                "fields": [],
+                "persisted_query": true,
+                "persisted_query_hash": "missing"
+            }]),
+        );
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_parse_error_denied() {
+        let engine = l7_engine();
+        let input = l7_graphql_error_input("api.graphql.com", "GraphQL document parse error");
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_graphql_readonly_access_allows_query_and_denies_mutation() {
+        let engine = l7_engine();
+        let query = l7_graphql_input(
+            "gql.readonly.com",
+            serde_json::json!([{
+                "operation_type": "query",
+                "fields": ["viewer"],
+                "persisted_query": false
+            }]),
+        );
+        assert!(eval_l7(&engine, &query));
+
+        let mutation = l7_graphql_input(
+            "gql.readonly.com",
+            serde_json::json!([{
+                "operation_type": "mutation",
+                "fields": ["createIssue"],
+                "persisted_query": false
+            }]),
+        );
+        assert!(!eval_l7(&engine, &mutation));
     }
 
     #[test]
@@ -1837,6 +2080,9 @@ process:
                             path: "/download".to_string(),
                             command: String::new(),
                             query,
+                            operation_type: String::new(),
+                            operation_name: String::new(),
+                            fields: Vec::new(),
                         }),
                     }],
                     ..Default::default()

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -2652,6 +2652,7 @@ async fn handle_forward_proxy(
             action: method.to_string(),
             target: path.clone(),
             query_params,
+            graphql: None,
         };
 
         let (allowed, reason) =

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -680,7 +680,7 @@ async fn handle_tcp_connection(
     // so log consumers can distinguish L4-only decisions from tunnel lifecycle events.
     let connect_msg = if l7_route
         .as_ref()
-        .is_some_and(|route| route.config.is_some())
+        .is_some_and(|route| !route.configs.is_empty())
     {
         "CONNECT_L7"
     } else {
@@ -766,24 +766,39 @@ async fn handle_tcp_connection(
                     crate::l7::tls::tls_connect_upstream(upstream, &host_lc, tls.upstream_config())
                         .await?;
 
-                if let Some(l7_config) = l7_route.as_ref().and_then(|route| route.config.as_ref()) {
+                if let Some(route) = l7_route.as_ref().filter(|route| !route.configs.is_empty()) {
                     // L7 inspection on terminated TLS traffic.
-                    let tunnel_engine =
-                        match opa_engine.clone_engine_for_tunnel(l7_config.generation) {
-                            Ok(engine) => engine,
-                            Err(e) => {
-                                emit_l7_tunnel_close_after_policy_change(&host_lc, port, e);
-                                return Ok(());
-                            }
-                        };
-                    crate::l7::relay::relay_with_inspection(
-                        &l7_config.config,
-                        tunnel_engine,
-                        &mut tls_client,
-                        &mut tls_upstream,
-                        &ctx,
-                    )
-                    .await
+                    let tunnel_engine = match opa_engine.clone_engine_for_tunnel(route.generation) {
+                        Ok(engine) => engine,
+                        Err(e) => {
+                            emit_l7_tunnel_close_after_policy_change(&host_lc, port, e);
+                            return Ok(());
+                        }
+                    };
+                    if route.configs.len() == 1 {
+                        crate::l7::relay::relay_with_inspection(
+                            &route.configs[0].config,
+                            tunnel_engine,
+                            &mut tls_client,
+                            &mut tls_upstream,
+                            &ctx,
+                        )
+                        .await
+                    } else {
+                        let configs: Vec<crate::l7::L7EndpointConfig> = route
+                            .configs
+                            .iter()
+                            .map(|snapshot| snapshot.config.clone())
+                            .collect();
+                        crate::l7::relay::relay_with_route_selection(
+                            &configs,
+                            tunnel_engine,
+                            &mut tls_client,
+                            &mut tls_upstream,
+                            &ctx,
+                        )
+                        .await
+                    }
                 } else {
                     // No L7 config — relay with credential injection only.
                     let generation = l7_route
@@ -843,23 +858,39 @@ async fn handle_tcp_connection(
         }
     } else if is_http {
         // Plaintext HTTP detected.
-        if let Some(l7_config) = l7_route.as_ref().and_then(|route| route.config.as_ref()) {
-            let tunnel_engine = match opa_engine.clone_engine_for_tunnel(l7_config.generation) {
+        if let Some(route) = l7_route.as_ref().filter(|route| !route.configs.is_empty()) {
+            let tunnel_engine = match opa_engine.clone_engine_for_tunnel(route.generation) {
                 Ok(engine) => engine,
                 Err(e) => {
                     emit_l7_tunnel_close_after_policy_change(&host_lc, port, e);
                     return Ok(());
                 }
             };
-            if let Err(e) = crate::l7::relay::relay_with_inspection(
-                &l7_config.config,
-                tunnel_engine,
-                &mut client,
-                &mut upstream,
-                &ctx,
-            )
-            .await
-            {
+            let relay_result = if route.configs.len() == 1 {
+                crate::l7::relay::relay_with_inspection(
+                    &route.configs[0].config,
+                    tunnel_engine,
+                    &mut client,
+                    &mut upstream,
+                    &ctx,
+                )
+                .await
+            } else {
+                let configs: Vec<crate::l7::L7EndpointConfig> = route
+                    .configs
+                    .iter()
+                    .map(|snapshot| snapshot.config.clone())
+                    .collect();
+                crate::l7::relay::relay_with_route_selection(
+                    &configs,
+                    tunnel_engine,
+                    &mut client,
+                    &mut upstream,
+                    &ctx,
+                )
+                .await
+            };
+            if let Err(e) = relay_result {
                 if is_benign_relay_error(&e) {
                     debug!(host = %host_lc, port = port, error = %e, "L7 connection closed");
                 } else {
@@ -1619,12 +1650,11 @@ async fn write_all(writer: &mut (impl tokio::io::AsyncWrite + Unpin), data: &[u8
 #[derive(Debug, Clone)]
 struct L7ConfigSnapshot {
     config: crate::l7::L7EndpointConfig,
-    generation: u64,
 }
 
 #[derive(Debug, Clone)]
 struct L7RouteSnapshot {
-    config: Option<L7ConfigSnapshot>,
+    configs: Vec<L7ConfigSnapshot>,
     generation: u64,
 }
 
@@ -1671,14 +1701,13 @@ fn query_l7_route_snapshot(
         cmdline_paths: decision.cmdline_paths.clone(),
     };
 
-    match engine.query_endpoint_config_with_generation(&input) {
-        Ok((Some(val), generation)) => Some(L7RouteSnapshot {
-            config: crate::l7::parse_l7_config(&val)
-                .map(|config| L7ConfigSnapshot { config, generation }),
-            generation,
-        }),
-        Ok((None, generation)) => Some(L7RouteSnapshot {
-            config: None,
+    match engine.query_endpoint_configs_with_generation(&input) {
+        Ok((vals, generation)) => Some(L7RouteSnapshot {
+            configs: vals
+                .into_iter()
+                .filter_map(|val| crate::l7::parse_l7_config(&val))
+                .map(|config| L7ConfigSnapshot { config })
+                .collect(),
             generation,
         }),
         Err(e) => {
@@ -1693,6 +1722,16 @@ fn query_l7_route_snapshot(
             None
         }
     }
+}
+
+fn select_l7_config_for_path<'a>(
+    configs: &'a [L7ConfigSnapshot],
+    path: &str,
+) -> Option<&'a L7ConfigSnapshot> {
+    configs
+        .iter()
+        .filter(|snapshot| snapshot.config.matches_path(path))
+        .max_by_key(|snapshot| snapshot.config.path_specificity())
 }
 
 /// Query the TLS mode for an endpoint, independent of L7 config.
@@ -2540,16 +2579,16 @@ async fn handle_forward_proxy(
     //     L7 policy.  The forward proxy handles exactly one request per
     //     connection (Connection: close), so a single evaluation suffices.
     if let Some(route) = query_l7_route_snapshot(&opa_engine, &decision, &host_lc, port)
-        && let Some(l7_config) = route.config
+        && !route.configs.is_empty()
     {
-        if l7_config.generation != forward_generation_guard.captured_generation() {
+        if route.generation != forward_generation_guard.captured_generation() {
             emit_l7_tunnel_close_after_policy_change(
                 &host_lc,
                 port,
                 miette::miette!(
                     "policy changed before forward L7 evaluation [expected_generation:{} current_generation:{}]",
                     forward_generation_guard.captured_generation(),
-                    l7_config.generation,
+                    route.generation,
                 ),
             );
             respond(
@@ -2564,7 +2603,7 @@ async fn handle_forward_proxy(
             .await?;
             return Ok(());
         }
-        let tunnel_engine = match opa_engine.clone_engine_for_tunnel(l7_config.generation) {
+        let tunnel_engine = match opa_engine.clone_engine_for_tunnel(route.generation) {
             Ok(engine) => engine,
             Err(e) => {
                 emit_l7_tunnel_close_after_policy_change(&host_lc, port, e);
@@ -2612,7 +2651,10 @@ async fn handle_forward_proxy(
         // while the upstream re-normalizes the raw input and dispatches on a
         // potentially different path.
         let canonicalize_options = crate::l7::path::CanonicalizeOptions {
-            allow_encoded_slash: l7_config.config.allow_encoded_slash,
+            allow_encoded_slash: route
+                .configs
+                .iter()
+                .any(|snapshot| snapshot.config.allow_encoded_slash),
             ..Default::default()
         };
         let query_params =
@@ -2656,7 +2698,20 @@ async fn handle_forward_proxy(
                     return Ok(());
                 }
             };
-        let graphql = if l7_config.protocol == crate::l7::L7Protocol::Graphql {
+        let Some(l7_config) = select_l7_config_for_path(&route.configs, &path) else {
+            respond(
+                client,
+                &build_json_error_response(
+                    403,
+                    "Forbidden",
+                    "policy_denied",
+                    &format!("{method} {host_lc}:{port}{path} did not match an L7 endpoint path"),
+                ),
+            )
+            .await?;
+            return Ok(());
+        };
+        let graphql = if l7_config.config.protocol == crate::l7::L7Protocol::Graphql {
             let header_end = forward_request_bytes
                 .windows(4)
                 .position(|w| w == b"\r\n\r\n")
@@ -2674,7 +2729,7 @@ async fn handle_forward_proxy(
             let info = match crate::l7::graphql::inspect_graphql_request(
                 client,
                 &mut graphql_request,
-                l7_config.graphql_max_body_bytes,
+                l7_config.config.graphql_max_body_bytes,
             )
             .await
             {
@@ -2713,21 +2768,32 @@ async fn handle_forward_proxy(
             graphql,
         };
 
-        let (allowed, reason) =
-            crate::l7::relay::evaluate_l7_request(&tunnel_engine, &l7_ctx, &request_info)
-                .unwrap_or_else(|e| {
-                    let event = NetworkActivityBuilder::new(crate::ocsf_ctx())
-                        .activity(ActivityId::Fail)
-                        .severity(SeverityId::Low)
-                        .status(StatusId::Failure)
-                        .dst_endpoint(Endpoint::from_domain(&host_lc, port))
-                        .message(format!("L7 eval failed, denying request: {e}"))
-                        .build();
-                    ocsf_emit!(event);
-                    (false, format!("L7 evaluation error: {e}"))
-                });
+        let parse_error_reason = request_info
+            .graphql
+            .as_ref()
+            .and_then(|info| info.error.as_deref())
+            .map(|error| format!("GraphQL request rejected: {error}"));
+        let force_deny = parse_error_reason.is_some();
+        let (allowed, reason) = parse_error_reason.map_or_else(
+            || {
+                crate::l7::relay::evaluate_l7_request(&tunnel_engine, &l7_ctx, &request_info)
+                    .unwrap_or_else(|e| {
+                        let event = NetworkActivityBuilder::new(crate::ocsf_ctx())
+                            .activity(ActivityId::Fail)
+                            .severity(SeverityId::Low)
+                            .status(StatusId::Failure)
+                            .dst_endpoint(Endpoint::from_domain(&host_lc, port))
+                            .message(format!("L7 eval failed, denying request: {e}"))
+                            .build();
+                        ocsf_emit!(event);
+                        (false, format!("L7 evaluation error: {e}"))
+                    })
+            },
+            |reason| (false, reason),
+        );
 
         let decision_str = match (allowed, l7_config.config.enforcement) {
+            (_, _) if force_deny => "deny",
             (true, _) => "allow",
             (false, crate::l7::EnforcementMode::Audit) => "audit",
             (false, crate::l7::EnforcementMode::Enforce) => "deny",
@@ -2747,12 +2813,12 @@ async fn handle_forward_proxy(
                     SeverityId::Informational,
                 ),
             };
-            let engine_type = if l7_config.protocol == crate::l7::L7Protocol::Graphql {
+            let engine_type = if l7_config.config.protocol == crate::l7::L7Protocol::Graphql {
                 "l7-graphql"
             } else {
                 "l7"
             };
-            let message_prefix = if l7_config.protocol == crate::l7::L7Protocol::Graphql {
+            let message_prefix = if l7_config.config.protocol == crate::l7::L7Protocol::Graphql {
                 "FORWARD_GRAPHQL_L7"
             } else {
                 "FORWARD_L7"
@@ -2780,8 +2846,8 @@ async fn handle_forward_proxy(
             ocsf_emit!(event);
         }
 
-        let effectively_denied =
-            !allowed && l7_config.config.enforcement == crate::l7::EnforcementMode::Enforce;
+        let effectively_denied = force_deny
+            || (!allowed && l7_config.config.enforcement == crate::l7::EnforcementMode::Enforce);
 
         if effectively_denied {
             emit_denial_simple(
@@ -3183,6 +3249,40 @@ fn is_benign_relay_error(err: &miette::Report) -> bool {
 mod tests {
     use super::*;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+    #[test]
+    fn l7_route_selection_prefers_path_specific_graphql_endpoint() {
+        let configs = vec![
+            L7ConfigSnapshot {
+                config: crate::l7::L7EndpointConfig {
+                    protocol: crate::l7::L7Protocol::Rest,
+                    path: "/**".to_string(),
+                    tls: crate::l7::TlsMode::Auto,
+                    enforcement: crate::l7::EnforcementMode::Enforce,
+                    graphql_max_body_bytes: crate::l7::graphql::DEFAULT_MAX_BODY_BYTES,
+                    allow_encoded_slash: false,
+                },
+            },
+            L7ConfigSnapshot {
+                config: crate::l7::L7EndpointConfig {
+                    protocol: crate::l7::L7Protocol::Graphql,
+                    path: "/graphql".to_string(),
+                    tls: crate::l7::TlsMode::Auto,
+                    enforcement: crate::l7::EnforcementMode::Enforce,
+                    graphql_max_body_bytes: crate::l7::graphql::DEFAULT_MAX_BODY_BYTES,
+                    allow_encoded_slash: false,
+                },
+            },
+        ];
+
+        let selected =
+            select_l7_config_for_path(&configs, "/graphql").expect("expected path-specific route");
+        assert_eq!(selected.config.protocol, crate::l7::L7Protocol::Graphql);
+
+        let selected =
+            select_l7_config_for_path(&configs, "/repos/org/repo").expect("expected REST route");
+        assert_eq!(selected.config.protocol, crate::l7::L7Protocol::Rest);
+    }
 
     // -- is_internal_ip: IPv4 --
 

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -2533,6 +2533,7 @@ async fn handle_forward_proxy(
             return Ok(());
         }
     };
+    let mut forward_request_bytes = buf[..used].to_vec();
 
     // 4b. If the endpoint has L7 config, evaluate the request against
     //     L7 policy.  The forward proxy handles exactly one request per
@@ -2648,11 +2649,61 @@ async fn handle_forward_proxy(
                     return Ok(());
                 }
             };
+        let graphql = if l7_config.protocol == crate::l7::L7Protocol::Graphql {
+            let header_end = forward_request_bytes
+                .windows(4)
+                .position(|w| w == b"\r\n\r\n")
+                .map_or(forward_request_bytes.len(), |p| p + 4);
+            let header_str = std::str::from_utf8(&forward_request_bytes[..header_end])
+                .map_err(|_| miette::miette!("Forward GraphQL headers contain invalid UTF-8"))?;
+            let body_length = crate::l7::rest::parse_body_length(header_str)?;
+            let mut graphql_request = crate::l7::provider::L7Request {
+                action: method.to_string(),
+                target: path.clone(),
+                query_params: query_params.clone(),
+                raw_header: forward_request_bytes,
+                body_length,
+            };
+            let info = match crate::l7::graphql::inspect_graphql_request(
+                client,
+                &mut graphql_request,
+                l7_config.graphql_max_body_bytes,
+            )
+            .await
+            {
+                Ok(info) => info,
+                Err(e) => {
+                    let event = NetworkActivityBuilder::new(crate::ocsf_ctx())
+                        .activity(ActivityId::Fail)
+                        .severity(SeverityId::Medium)
+                        .status(StatusId::Failure)
+                        .dst_endpoint(Endpoint::from_domain(&host_lc, port))
+                        .message(format!("FORWARD_GRAPHQL_L7 request rejected: {e}"))
+                        .build();
+                    ocsf_emit!(event);
+                    respond(
+                        client,
+                        &build_json_error_response(
+                            400,
+                            "Bad Request",
+                            "invalid_graphql_request",
+                            &format!("GraphQL request rejected before policy evaluation: {e}"),
+                        ),
+                    )
+                    .await?;
+                    return Ok(());
+                }
+            };
+            forward_request_bytes = graphql_request.raw_header;
+            Some(info)
+        } else {
+            None
+        };
         let request_info = crate::l7::L7RequestInfo {
             action: method.to_string(),
             target: path.clone(),
             query_params,
-            graphql: None,
+            graphql,
         };
 
         let (allowed, reason) =
@@ -2689,6 +2740,16 @@ async fn handle_forward_proxy(
                     SeverityId::Informational,
                 ),
             };
+            let engine_type = if l7_config.protocol == crate::l7::L7Protocol::Graphql {
+                "l7-graphql"
+            } else {
+                "l7"
+            };
+            let message_prefix = if l7_config.protocol == crate::l7::L7Protocol::Graphql {
+                "FORWARD_GRAPHQL_L7"
+            } else {
+                "FORWARD_L7"
+            };
             let event = HttpActivityBuilder::new(crate::ocsf_ctx())
                 .activity(ActivityId::Other)
                 .action(action_id)
@@ -2704,9 +2765,9 @@ async fn handle_forward_proxy(
                     Process::from_bypass(&binary_str, &pid_str, &ancestors_str)
                         .with_cmd_line(&cmdline_str),
                 )
-                .firewall_rule(policy_str, "l7")
+                .firewall_rule(policy_str, engine_type)
                 .message(format!(
-                    "FORWARD_L7 {decision_str} {method} {host_lc}:{port}{path} reason={reason}"
+                    "{message_prefix} {decision_str} {method} {host_lc}:{port}{path} reason={reason}"
                 ))
                 .build();
             ocsf_emit!(event);
@@ -2992,7 +3053,12 @@ async fn handle_forward_proxy(
     }
 
     // 9. Rewrite request and forward to upstream
-    let rewritten = match rewrite_forward_request(buf, used, &path, secret_resolver.as_deref()) {
+    let rewritten = match rewrite_forward_request(
+        &forward_request_bytes,
+        forward_request_bytes.len(),
+        &path,
+        secret_resolver.as_deref(),
+    ) {
         Ok(bytes) => bytes,
         Err(e) => {
             warn!(

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -2534,6 +2534,7 @@ async fn handle_forward_proxy(
         }
     };
     let mut forward_request_bytes = buf[..used].to_vec();
+    let mut upstream_target = path.clone();
 
     // 4b. If the endpoint has L7 config, evaluate the request against
     //     L7 policy.  The forward proxy handles exactly one request per
@@ -2617,6 +2618,12 @@ async fn handle_forward_proxy(
         let query_params =
             match crate::l7::path::canonicalize_request_target(&path, &canonicalize_options) {
                 Ok((canon, query)) => {
+                    upstream_target = match query.as_deref() {
+                        Some(raw_query) if !raw_query.is_empty() => {
+                            format!("{}?{raw_query}", canon.path)
+                        }
+                        _ => canon.path.clone(),
+                    };
                     let params = query
                         .as_deref()
                         .map_or_else(std::collections::HashMap::new, |q| {
@@ -3056,7 +3063,7 @@ async fn handle_forward_proxy(
     let rewritten = match rewrite_forward_request(
         &forward_request_bytes,
         forward_request_bytes.len(),
-        &path,
+        &upstream_target,
         secret_resolver.as_deref(),
     ) {
         Ok(bytes) => bytes,
@@ -4166,6 +4173,30 @@ mod tests {
         assert!(
             !rewritten_str.contains(".."),
             "outbound bytes must not leak the pre-canonical form, got: {rewritten_str:?}"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_forward_request_preserves_canonical_query_on_the_wire() {
+        let raw = b"GET http://host/public/../graphql?query=query+Viewer+%7B+viewer+%7B+login+%7D+%7D HTTP/1.1\r\nHost: host\r\n\r\n";
+        let (canon, raw_query) = crate::l7::path::canonicalize_request_target(
+            "/public/../graphql?query=query+Viewer+%7B+viewer+%7B+login+%7D+%7D",
+            &crate::l7::path::CanonicalizeOptions::default(),
+        )
+        .expect("canonicalization should preserve query separately");
+        let upstream_target = match raw_query.as_deref() {
+            Some(raw_query) if !raw_query.is_empty() => format!("{}?{raw_query}", canon.path),
+            _ => canon.path,
+        };
+
+        let rewritten = rewrite_forward_request(raw, raw.len(), &upstream_target, None)
+            .expect("rewrite_forward_request should succeed");
+        let rewritten_str = String::from_utf8_lossy(&rewritten);
+        assert!(
+            rewritten_str.starts_with(
+                "GET /graphql?query=query+Viewer+%7B+viewer+%7B+login+%7D+%7D HTTP/1.1\r\n"
+            ),
+            "outbound request line must preserve canonical query, got: {rewritten_str:?}"
         );
     }
 

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -2799,7 +2799,7 @@ async fn handle_forward_proxy(
                     403,
                     "Forbidden",
                     "policy_denied",
-                    &format!("{method} {host_lc}:{port}{path} denied by L7 policy"),
+                    &format!("{method} {host_lc}:{port}{path} denied by L7 policy: {reason}"),
                 ),
             )
             .await?;

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -2513,6 +2513,7 @@ async fn handle_forward_proxy(
             action: method.to_string(),
             target: path.clone(),
             query_params,
+            graphql: None,
         };
 
         let (allowed, reason) =

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -3154,6 +3154,9 @@ mod tests {
                     path: "/repos/*/issues".to_string(),
                     command: String::new(),
                     query: HashMap::new(),
+                    operation_type: String::new(),
+                    operation_name: String::new(),
+                    fields: Vec::new(),
                 }),
             }],
         };
@@ -3484,6 +3487,9 @@ mod tests {
                     path: "/repos/*/issues".to_string(),
                     command: String::new(),
                     query: HashMap::new(),
+                    operation_type: String::new(),
+                    operation_name: String::new(),
+                    fields: Vec::new(),
                 }),
             }],
         }];

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -3076,6 +3076,9 @@ mod tests {
                     path: "/repos/*/issues".to_string(),
                     command: String::new(),
                     query: HashMap::new(),
+                    operation_type: String::new(),
+                    operation_name: String::new(),
+                    fields: Vec::new(),
                 }),
             }],
         };
@@ -3406,6 +3409,9 @@ mod tests {
                     path: "/repos/*/issues".to_string(),
                     command: String::new(),
                     query: HashMap::new(),
+                    operation_type: String::new(),
+                    operation_name: String::new(),
+                    fields: Vec::new(),
                 }),
             }],
         }];

--- a/docs/get-started/tutorials/github-sandbox.mdx
+++ b/docs/get-started/tutorials/github-sandbox.mdx
@@ -247,17 +247,29 @@ network_policies:
     endpoints:
       - host: api.github.com
         port: 443
+        path: "/repos/<org>/<repo>/**"
         protocol: rest
         enforcement: enforce
         rules:
-          # GraphQL API (used by gh CLI)
-          - allow:
-              method: POST
-              path: "/graphql"
           # Full read-write access to the repository
           - allow:
               method: "*"
               path: "/repos/<org>/<repo>/**"
+      - host: api.github.com
+        port: 443
+        path: "/graphql"
+        protocol: graphql
+        enforcement: enforce
+        rules:
+          # GitHub GraphQL API (used by gh CLI)
+          - allow:
+              operation_type: query
+          - allow:
+              operation_type: mutation
+              fields: [createIssue, updateIssue, addComment]
+        deny_rules:
+          - operation_type: mutation
+            fields: [deleteRepository, deleteRef, updateBranchProtectionRule]
     binaries:
       - { path: /usr/local/bin/claude }
       - { path: /usr/local/bin/opencode }

--- a/docs/reference/policy-schema.mdx
+++ b/docs/reference/policy-schema.mdx
@@ -157,8 +157,8 @@ Each endpoint defines a reachable destination and optional inspection rules.
 | `protocol` | string | No | Set to `rest` for HTTP method/path inspection or `graphql` for GraphQL operation inspection. Omit for TCP passthrough. |
 | `tls` | string | No | TLS handling mode. The proxy auto-detects TLS by peeking the first bytes of each connection and terminates it for inspected HTTPS traffic, so this field is optional in most cases. Set to `skip` to disable auto-detection for edge cases such as client-certificate mTLS or non-standard protocols. The values `terminate` and `passthrough` are deprecated and log a warning; they are still accepted for backward compatibility but have no effect on behavior. |
 | `enforcement` | string | No | `enforce` actively blocks disallowed requests. `audit` logs violations but allows traffic through. |
-| `access` | string | No | HTTP access level. One of `read-only`, `read-write`, or `full`. Mutually exclusive with `rules`. |
-| `rules` | list of rule objects | No | Fine-grained per-method, per-path allow rules. Mutually exclusive with `access`. |
+| `access` | string | No | Access preset. One of `read-only`, `read-write`, or `full`. Mutually exclusive with `rules`. |
+| `rules` | list of rule objects | No | Fine-grained protocol-specific allow rules. Mutually exclusive with `access`. |
 | `deny_rules` | list of deny rule objects | No | L7 deny rules that block specific requests even when allowed by `access` or `rules`. Deny rules take precedence over allow rules. |
 | `allowed_ips` | list of string | No | CIDR or IP allowlist for SSRF override. Entries overlapping loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), or unspecified (`0.0.0.0`) are rejected at load time. |
 | `allow_encoded_slash` | bool | No | When `true`, L7 request parsing preserves `%2F` inside path segments instead of rejecting it. Use this for registries and APIs such as npm scoped packages (`/@scope%2Fname`). Defaults to `false`. |
@@ -176,20 +176,21 @@ The `access` field accepts one of the following values:
 | `read-only` | `GET`, `HEAD`, `OPTIONS`. | `query` operations. |
 | `read-write` | `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT`, `PATCH`. | `query` and `mutation` operations. |
 
-#### Rule Object
+#### Allow Rule Objects
 
-Used when `access` is not set. Each rule explicitly allows a method and path combination.
+Used when `access` is not set. Each entry in `rules` contains an `allow` object. The tables below list the fields inside that `allow` object.
+
+##### REST Allow Rule (`protocol: rest`)
+
+REST allow rules match HTTP requests by method, path, and optional query parameters.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `allow.method` | string | Yes | HTTP method to allow (for example, `GET`, `POST`). |
-| `allow.path` | string | Yes | URL path pattern. Supports `*` and `**` glob syntax. |
-| `allow.query` | map | No | Query parameter matchers keyed by decoded param name. Matcher value can be a glob string (`tag: "foo-*"`) or an object with `any` (`tag: { any: ["foo-*", "bar-*"] }`). |
-| `allow.operation_type` | string | Yes for GraphQL | GraphQL operation type: `query`, `mutation`, `subscription`, or `*`. |
-| `allow.operation_name` | string | No | GraphQL operation-name glob. Omit to match any operation name. |
-| `allow.fields` | list of string | No | GraphQL root-field globs. Every selected root field must match one configured glob. Omit to match all root fields. |
+| `method` | string | Yes | HTTP method to allow (for example, `GET`, `POST`). `*` matches any method. |
+| `path` | string | Yes | URL path pattern. Supports `*` and `**` glob syntax. |
+| `query` | map | No | Query parameter matchers keyed by decoded param name. Matcher value can be a glob string (`tag: "foo-*"`) or an object with `any` (`tag: { any: ["foo-*", "bar-*"] }`). |
 
-Example with rules:
+Example REST allow rules:
 
 ```yaml showLineNumbers={false}
 rules:
@@ -206,24 +207,44 @@ rules:
           any: ["v1.*", "v2.*"]
 ```
 
-#### Deny Rule Object
+##### GraphQL Allow Rule (`protocol: graphql`)
 
-Blocks specific operations on endpoints that otherwise have broad access. Each deny rule
-matches a method and path (and optionally query parameters or SQL commands). Deny rules are
-evaluated after allow rules and take precedence -- if a request matches any deny rule, it is
-blocked regardless of what the allow rules or access preset permit.
+GraphQL allow rules match parsed GraphQL operations by operation type, optional operation name, and optional root fields.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `method` | string | No | HTTP method to deny (for example, `POST`, `DELETE`). `*` matches any method. |
-| `path` | string | No | URL path pattern. Same glob syntax as allow rules. |
-| `command` | string | No | SQL command to deny (`SELECT`, `INSERT`, etc.). For `protocol: sql` only. |
-| `query` | map | No | Query parameter matchers. Same syntax as allow rule `query`. |
-| `operation_type` | string | No | GraphQL operation type to deny: `query`, `mutation`, `subscription`, or `*`. |
-| `operation_name` | string | No | GraphQL operation-name glob. |
-| `fields` | list of string | No | GraphQL root-field globs. Any matching root field blocks the request. |
+| `operation_type` | string | Yes | GraphQL operation type: `query`, `mutation`, `subscription`, or `*`. |
+| `operation_name` | string | No | GraphQL operation-name glob. Omit to match any operation name. |
+| `fields` | list of string | No | GraphQL root-field globs. Every selected root field must match one configured glob. Omit to match all root fields. |
 
-Example -- grant read-write access to GitHub but block admin operations:
+Example GraphQL allow rules:
+
+```yaml showLineNumbers={false}
+rules:
+  - allow:
+      operation_type: query
+      fields: [viewer, repository]
+  - allow:
+      operation_type: mutation
+      operation_name: Issue*
+      fields: [createIssue]
+```
+
+#### Deny Rule Objects
+
+Blocks specific operations on endpoints that otherwise have broad access. Deny rules are evaluated after allow rules and take precedence: if a request matches any deny rule, it is blocked regardless of what the allow rules or access preset permit.
+
+##### REST Deny Rule (`protocol: rest`)
+
+REST deny rules use the same field names as REST allow rules, but they appear directly under each `deny_rules` entry instead of under an `allow` wrapper.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `method` | string | Yes | HTTP method to deny (for example, `POST`, `DELETE`). `*` matches any method. |
+| `path` | string | Yes | URL path pattern. Same glob syntax as allow rules. Use `**` to match any path. |
+| `query` | map | No | Query parameter matchers. Same syntax as allow rule `query`. |
+
+Example REST deny rules:
 
 ```yaml showLineNumbers={false}
 endpoints:
@@ -239,6 +260,32 @@ endpoints:
         path: "/repos/*/branches/*/protection"
       - method: "*"
         path: "/repos/*/rulesets"
+```
+
+##### GraphQL Deny Rule (`protocol: graphql`)
+
+GraphQL deny rules use the same field names as GraphQL allow rules, but they appear directly under each `deny_rules` entry instead of under an `allow` wrapper.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `operation_type` | string | Yes | GraphQL operation type to deny: `query`, `mutation`, `subscription`, or `*`. |
+| `operation_name` | string | No | GraphQL operation-name glob. |
+| `fields` | list of string | No | GraphQL root-field globs. Any matching root field blocks the request. Omit to deny every operation that matches `operation_type` and `operation_name`. |
+
+Example GraphQL deny rules:
+
+```yaml showLineNumbers={false}
+endpoints:
+  - host: api.github.com
+    port: 443
+    protocol: graphql
+    enforcement: enforce
+    access: read-write
+    deny_rules:
+      - operation_type: mutation
+        fields: [deleteRepository]
+      - operation_type: mutation
+        operation_name: Admin*
 ```
 
 ### Binary Object

--- a/docs/reference/policy-schema.mdx
+++ b/docs/reference/policy-schema.mdx
@@ -154,6 +154,7 @@ Each endpoint defines a reachable destination and optional inspection rules.
 |---|---|---|---|
 | `host` | string | Yes | Hostname or IP address. Supports wildcards: `*.example.com` matches any subdomain. |
 | `port` | integer | Yes | TCP port number. |
+| `path` | string | No | Optional HTTP path glob used to select between L7 endpoints that share the same host and port. Empty means all paths. Use this when REST and GraphQL live under the same host, such as `/repos/**` and `/graphql`. |
 | `protocol` | string | No | Set to `rest` for HTTP method/path inspection or `graphql` for GraphQL operation inspection. Omit for TCP passthrough. |
 | `tls` | string | No | TLS handling mode. The proxy auto-detects TLS by peeking the first bytes of each connection and terminates it for inspected HTTPS traffic, so this field is optional in most cases. Set to `skip` to disable auto-detection for edge cases such as client-certificate mTLS or non-standard protocols. The values `terminate` and `passthrough` are deprecated and log a warning; they are still accepted for backward compatibility but have no effect on behavior. |
 | `enforcement` | string | No | `enforce` actively blocks disallowed requests. `audit` logs violations but allows traffic through. |

--- a/docs/reference/policy-schema.mdx
+++ b/docs/reference/policy-schema.mdx
@@ -154,24 +154,27 @@ Each endpoint defines a reachable destination and optional inspection rules.
 |---|---|---|---|
 | `host` | string | Yes | Hostname or IP address. Supports wildcards: `*.example.com` matches any subdomain. |
 | `port` | integer | Yes | TCP port number. |
-| `protocol` | string | No | Set to `rest` to enable HTTP request inspection. Omit for TCP passthrough. |
-| `tls` | string | No | TLS handling mode. The proxy auto-detects TLS by peeking the first bytes of each connection and terminates it when `protocol` is `rest`, so this field is optional in most cases. Set to `skip` to disable auto-detection for edge cases such as client-certificate mTLS or non-standard protocols. The values `terminate` and `passthrough` are deprecated and log a warning; they are still accepted for backward compatibility but have no effect on behavior. |
+| `protocol` | string | No | Set to `rest` for HTTP method/path inspection or `graphql` for GraphQL operation inspection. Omit for TCP passthrough. |
+| `tls` | string | No | TLS handling mode. The proxy auto-detects TLS by peeking the first bytes of each connection and terminates it for inspected HTTPS traffic, so this field is optional in most cases. Set to `skip` to disable auto-detection for edge cases such as client-certificate mTLS or non-standard protocols. The values `terminate` and `passthrough` are deprecated and log a warning; they are still accepted for backward compatibility but have no effect on behavior. |
 | `enforcement` | string | No | `enforce` actively blocks disallowed requests. `audit` logs violations but allows traffic through. |
 | `access` | string | No | HTTP access level. One of `read-only`, `read-write`, or `full`. Mutually exclusive with `rules`. |
 | `rules` | list of rule objects | No | Fine-grained per-method, per-path allow rules. Mutually exclusive with `access`. |
 | `deny_rules` | list of deny rule objects | No | L7 deny rules that block specific requests even when allowed by `access` or `rules`. Deny rules take precedence over allow rules. |
 | `allowed_ips` | list of string | No | CIDR or IP allowlist for SSRF override. Entries overlapping loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), or unspecified (`0.0.0.0`) are rejected at load time. |
 | `allow_encoded_slash` | bool | No | When `true`, L7 request parsing preserves `%2F` inside path segments instead of rejecting it. Use this for registries and APIs such as npm scoped packages (`/@scope%2Fname`). Defaults to `false`. |
+| `persisted_queries` | string | No | GraphQL hash-only behavior. Default is `deny`; use `allow_registered` only with `graphql_persisted_queries`. |
+| `graphql_persisted_queries` | map | No | Trusted GraphQL persisted-query registry keyed by hash or saved-query ID. Values contain `operation_type`, optional `operation_name`, and optional root `fields`. |
+| `graphql_max_body_bytes` | integer | No | Maximum GraphQL request body bytes buffered for inspection. Defaults to `65536`. |
 
 #### Access Levels
 
 The `access` field accepts one of the following values:
 
-| Value | Allowed HTTP Methods |
-|---|---|
-| `full` | All methods and paths. |
-| `read-only` | `GET`, `HEAD`, `OPTIONS`. |
-| `read-write` | `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT`, `PATCH`. |
+| Value | REST expansion | GraphQL expansion |
+|---|---|---|
+| `full` | All methods and paths. | All operation types. |
+| `read-only` | `GET`, `HEAD`, `OPTIONS`. | `query` operations. |
+| `read-write` | `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT`, `PATCH`. | `query` and `mutation` operations. |
 
 #### Rule Object
 
@@ -182,6 +185,9 @@ Used when `access` is not set. Each rule explicitly allows a method and path com
 | `allow.method` | string | Yes | HTTP method to allow (for example, `GET`, `POST`). |
 | `allow.path` | string | Yes | URL path pattern. Supports `*` and `**` glob syntax. |
 | `allow.query` | map | No | Query parameter matchers keyed by decoded param name. Matcher value can be a glob string (`tag: "foo-*"`) or an object with `any` (`tag: { any: ["foo-*", "bar-*"] }`). |
+| `allow.operation_type` | string | Yes for GraphQL | GraphQL operation type: `query`, `mutation`, `subscription`, or `*`. |
+| `allow.operation_name` | string | No | GraphQL operation-name glob. Omit to match any operation name. |
+| `allow.fields` | list of string | No | GraphQL root-field globs. Every selected root field must match one configured glob. Omit to match all root fields. |
 
 Example with rules:
 
@@ -213,6 +219,9 @@ blocked regardless of what the allow rules or access preset permit.
 | `path` | string | No | URL path pattern. Same glob syntax as allow rules. |
 | `command` | string | No | SQL command to deny (`SELECT`, `INSERT`, etc.). For `protocol: sql` only. |
 | `query` | map | No | Query parameter matchers. Same syntax as allow rule `query`. |
+| `operation_type` | string | No | GraphQL operation type to deny: `query`, `mutation`, `subscription`, or `*`. |
+| `operation_name` | string | No | GraphQL operation-name glob. |
+| `fields` | list of string | No | GraphQL root-field globs. Any matching root field blocks the request. |
 
 Example -- grant read-write access to GitHub but block admin operations:
 

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -222,8 +222,8 @@ Each segment has a fixed meaning:
 |---|---|---|
 | `host` | Yes | Destination hostname. |
 | `port` | Yes | Destination port, `1` through `65535`. |
-| `access` | No | Access preset for L7 endpoints: `read-only`, `read-write`, or `full`. REST and GraphQL endpoints expand presets differently. |
-| `protocol` | No | L7 inspection mode: `rest`, `graphql`, or `sql`. `sql` is audit-only and not a recommended workflow today. |
+| `access` | No | Access preset for L7 endpoints: `read-only`, `read-write`, or `full`. Incremental updates currently expand presets for REST-shaped access. |
+| `protocol` | No | L7 inspection mode: `rest` or `sql`. `sql` is audit-only and not a recommended workflow today. |
 | `enforcement` | No | Enforcement mode for inspected traffic: `enforce` or `audit`. |
 
 Examples:
@@ -232,14 +232,12 @@ Examples:
 |---|---|
 | `pypi.org:443` | Add a plain L4 endpoint. The proxy allows the TCP stream and does not inspect HTTP requests. |
 | `api.github.com:443:read-only:rest:enforce` | Add a REST endpoint with the `read-only` preset expanded by the policy engine into GET, HEAD, and OPTIONS access. |
-| `api.github.com:443:read-only:graphql:enforce` | Add a GraphQL endpoint with the `read-only` preset expanded into query-only access. |
 
-If you set `protocol: rest` or `protocol: graphql`, you also need an allow shape. With incremental updates, that means you should provide an `access` preset on `--add-endpoint`, then use `--add-allow` or `--add-deny` to refine REST endpoints later.
+If you set `protocol: rest`, you also need an allow shape. With incremental updates, that means you should provide an `access` preset on `--add-endpoint`, then use `--add-allow` or `--add-deny` to refine REST endpoints later.
 
 For example:
 
 - `api.github.com:443:read-only:rest` is valid.
-- `api.github.com:443:read-only:graphql` is valid.
 - `api.github.com:443::rest` is invalid. It does not mean "allow all traffic." An L7 endpoint with `protocol` but no `access` or `rules` is rejected when the policy loads.
 
 When you pass multiple `--add-endpoint` flags in one command, every `--binary` value applies to every added endpoint in that command. If different endpoints need different binaries, use separate `policy update` commands.
@@ -429,7 +427,7 @@ openshell policy update <name> --add-allow 'api.github.com:443:GET:/repos/**' --
 
 ## Examples
 
-Add these blocks to the `network_policies` section of your sandbox policy. Apply with `openshell policy update` for incremental additions or `openshell policy set <name> --policy <file> --wait` for full replacement.
+Add these blocks to the `network_policies` section of your sandbox policy. Apply simple endpoints and REST rule additions with `openshell policy update`, or apply any complete YAML block with `openshell policy set <name> --policy <file> --wait`.
 Use **Simple endpoint** for host-level allowlists and **Granular rules** for method/path control.
 
 <Tabs>
@@ -529,6 +527,8 @@ REST rules can also constrain query parameter values:
 ### GraphQL matching
 
 GraphQL endpoints use `protocol: graphql`. The proxy parses GraphQL-over-HTTP `GET` and `POST` requests, classifies each operation, and evaluates rules against the operation type, optional operation name, and selected root fields.
+
+GraphQL endpoint policies currently require full policy YAML applied with `openshell policy set`; the incremental `openshell policy update --add-endpoint` parser does not accept `graphql` as a protocol.
 
 ```yaml showLineNumbers={false}
   github_graphql:

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -451,7 +451,7 @@ Endpoints without `protocol` use TCP passthrough, where the proxy allows the str
 </Tab>
 
 <Tab title="Granular rules">
-Allow Claude and the GitHub CLI to reach `api.github.com` with per-path rules: read-only (GET, HEAD, OPTIONS) and GraphQL (POST) for all paths; full write access for `alpha-repo`; and create/edit issues only for `bravo-repo`. Replace `<org_name>` with your GitHub org or username.
+Allow Claude and the GitHub CLI to reach `api.github.com` with separate REST and GraphQL endpoint scopes: read-only REST for general API paths, GraphQL operation inspection on `/graphql`, full REST write access for `alpha-repo`, and create/edit issues only for `bravo-repo`. Replace `<org_name>` with your GitHub org or username.
 
 <Tip>
 For an end-to-end walkthrough that combines this policy with a GitHub credential provider and sandbox creation, refer to [GitHub Sandbox](/get-started/tutorials/github-sandbox).
@@ -464,6 +464,7 @@ For an end-to-end walkthrough that combines this policy with a GitHub credential
     endpoints:
       - host: api.github.com
         port: 443
+        path: "/**"
         protocol: rest
         enforcement: enforce
         rules:
@@ -477,9 +478,6 @@ For an end-to-end walkthrough that combines this policy with a GitHub credential
               method: OPTIONS
               path: "/**"
           - allow:
-              method: POST
-              path: "/graphql"
-          - allow:
               method: "*"
               path: "/repos/<org_name>/alpha-repo/**"
           - allow:
@@ -488,12 +486,26 @@ For an end-to-end walkthrough that combines this policy with a GitHub credential
           - allow:
               method: PATCH
               path: "/repos/<org_name>/bravo-repo/issues/*"
+      - host: api.github.com
+        port: 443
+        path: "/graphql"
+        protocol: graphql
+        enforcement: enforce
+        rules:
+          - allow:
+              operation_type: query
+          - allow:
+              operation_type: mutation
+              fields: [createIssue, updateIssue, addComment]
+        deny_rules:
+          - operation_type: mutation
+            fields: [deleteRepository, deleteRef, updateBranchProtectionRule]
     binaries:
       - { path: /usr/local/bin/claude }
       - { path: /usr/bin/gh }
 ```
 
-Endpoints with `protocol: rest` enable HTTP request inspection. The proxy auto-detects TLS on HTTPS endpoints, terminates it, and checks each HTTP request against the `rules` list.
+Endpoints with `protocol: rest` enable HTTP request inspection. Endpoints with `protocol: graphql` parse GraphQL-over-HTTP payloads before evaluating rules. The endpoint-level `path` field lets both protocols share `api.github.com:443` without treating GraphQL payloads as plain REST `POST /graphql` requests.
 </Tab>
 
 </Tabs>
@@ -536,6 +548,7 @@ GraphQL endpoint policies currently require full policy YAML applied with `opens
     endpoints:
       - host: api.github.com
         port: 443
+        path: "/graphql"
         protocol: graphql
         enforcement: enforce
         rules:

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -222,8 +222,8 @@ Each segment has a fixed meaning:
 |---|---|---|
 | `host` | Yes | Destination hostname. |
 | `port` | Yes | Destination port, `1` through `65535`. |
-| `access` | No | Access preset for REST endpoints: `read-only`, `read-write`, or `full`. |
-| `protocol` | No | L7 inspection mode: `rest` or `sql`. In practice, incremental updates are designed around `rest`. `sql` is audit-only and not a recommended workflow today. |
+| `access` | No | Access preset for L7 endpoints: `read-only`, `read-write`, or `full`. REST and GraphQL endpoints expand presets differently. |
+| `protocol` | No | L7 inspection mode: `rest`, `graphql`, or `sql`. `sql` is audit-only and not a recommended workflow today. |
 | `enforcement` | No | Enforcement mode for inspected traffic: `enforce` or `audit`. |
 
 Examples:
@@ -232,13 +232,15 @@ Examples:
 |---|---|
 | `pypi.org:443` | Add a plain L4 endpoint. The proxy allows the TCP stream and does not inspect HTTP requests. |
 | `api.github.com:443:read-only:rest:enforce` | Add a REST endpoint with the `read-only` preset expanded by the policy engine into GET, HEAD, and OPTIONS access. |
+| `api.github.com:443:read-only:graphql:enforce` | Add a GraphQL endpoint with the `read-only` preset expanded into query-only access. |
 
-If you set `protocol: rest`, you also need an allow shape. With incremental updates, that means you should provide an `access` preset on `--add-endpoint`, then use `--add-allow` or `--add-deny` to refine it later.
+If you set `protocol: rest` or `protocol: graphql`, you also need an allow shape. With incremental updates, that means you should provide an `access` preset on `--add-endpoint`, then use `--add-allow` or `--add-deny` to refine REST endpoints later.
 
 For example:
 
 - `api.github.com:443:read-only:rest` is valid.
-- `api.github.com:443::rest` is invalid. It does not mean "allow all traffic." A REST endpoint with `protocol` but no `access` or `rules` is rejected when the policy loads.
+- `api.github.com:443:read-only:graphql` is valid.
+- `api.github.com:443::rest` is invalid. It does not mean "allow all traffic." An L7 endpoint with `protocol` but no `access` or `rules` is rejected when the policy loads.
 
 When you pass multiple `--add-endpoint` flags in one command, every `--binary` value applies to every added endpoint in that command. If different endpoints need different binaries, use separate `policy update` commands.
 
@@ -523,6 +525,52 @@ REST rules can also constrain query parameter values:
 ```
 
 `query` matchers are case-sensitive and run on decoded values. If a request has duplicate keys (for example, `tag=a&tag=b`), every value for that key must match the configured glob(s).
+
+### GraphQL matching
+
+GraphQL endpoints use `protocol: graphql`. The proxy parses GraphQL-over-HTTP `GET` and `POST` requests, classifies each operation, and evaluates rules against the operation type, optional operation name, and selected root fields.
+
+```yaml showLineNumbers={false}
+  github_graphql:
+    name: github_graphql
+    endpoints:
+      - host: api.github.com
+        port: 443
+        protocol: graphql
+        enforcement: enforce
+        rules:
+          - allow:
+              operation_type: query
+              fields: [viewer, repository]
+          - allow:
+              operation_type: mutation
+              operation_name: Issue*
+              fields: [createIssue]
+        deny_rules:
+          - operation_type: mutation
+            fields: [deleteRepository]
+    binaries:
+      - { path: /usr/bin/gh }
+```
+
+For allow rules, every selected root field in an operation must match one of the configured `fields` globs. For deny rules, one matching root field blocks the request. Batched GraphQL requests are fail-closed: if any operation is malformed, denied, or unregistered, the whole HTTP request is denied.
+
+Hash-only persisted queries cannot be classified from the request alone. OpenShell denies them unless the endpoint uses `persisted_queries: allow_registered` and provides a trusted `graphql_persisted_queries` entry keyed by hash or saved-query ID.
+
+### GraphQL service policy shapes
+
+GraphQL field names are application-specific, so treat these as starting shapes to review against the actual app schema:
+
+| Service | Endpoint shape | Starting policy |
+|---|---|---|
+| Railway | `backboard.railway.app/graphql/v2` | Allow `query`; allow only reviewed deployment mutations; deny `volumeDelete`, `projectDelete`, `*Delete`, `*Destroy`. |
+| GitHub | `api.github.com/graphql` | Allow `query`; optionally allow low-risk mutations such as reactions; deny broad destructive/admin roots like `deleteRef`, `deleteRepository`, `updateBranchProtectionRule`, and `delete*`. |
+| GitLab | `/api/graphql` | Prefer read-only token scopes where possible; allow `query`; deny mutations by default or allow only reviewed workflow roots. |
+| Shopify Admin | `*.myshopify.com/admin/api/**/graphql.json` | Allow `query`; allow app-specific mutations only; deny `*Delete`, `bulkOperationRunMutation`, and high-impact inventory/order/customer roots unless approved. |
+| monday.com | `api.monday.com/v2` | Allow board/item reads; allow tightly scoped create/update mutations only where needed; deny delete/archive roots. |
+| Salesforce GraphQL | Salesforce GraphQL endpoint | Allow `query`; deny record create/update/delete mutations unless the sandbox is intended to modify CRM data. |
+| Hygraph | Project content API endpoint | Allow content reads; deny generated destructive content roots such as `delete*`, `deleteMany*`, `unpublish*`, and batch mutations unless a publishing workflow requires them. |
+| Atlassian GraphQL Gateway | `api.atlassian.com/graphql` | Allow reads by default; require explicit mutation allowlists because the gateway spans Jira, Confluence, Bitbucket, and admin surfaces. |
 
 ## Next Steps
 

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -220,8 +220,8 @@ Each segment has a fixed meaning:
 |---|---|---|
 | `host` | Yes | Destination hostname. |
 | `port` | Yes | Destination port, `1` through `65535`. |
-| `access` | No | Access preset for L7 endpoints: `read-only`, `read-write`, or `full`. REST and GraphQL endpoints expand presets differently. |
-| `protocol` | No | L7 inspection mode: `rest`, `graphql`, or `sql`. `sql` is audit-only and not a recommended workflow today. |
+| `access` | No | Access preset for L7 endpoints: `read-only`, `read-write`, or `full`. Incremental updates currently expand presets for REST-shaped access. |
+| `protocol` | No | L7 inspection mode: `rest` or `sql`. `sql` is audit-only and not a recommended workflow today. |
 | `enforcement` | No | Enforcement mode for inspected traffic: `enforce` or `audit`. |
 
 Examples:
@@ -230,14 +230,12 @@ Examples:
 |---|---|
 | `pypi.org:443` | Add a plain L4 endpoint. The proxy allows the TCP stream and does not inspect HTTP requests. |
 | `api.github.com:443:read-only:rest:enforce` | Add a REST endpoint with the `read-only` preset expanded by the policy engine into GET, HEAD, and OPTIONS access. |
-| `api.github.com:443:read-only:graphql:enforce` | Add a GraphQL endpoint with the `read-only` preset expanded into query-only access. |
 
-If you set `protocol: rest` or `protocol: graphql`, you also need an allow shape. With incremental updates, that means you should provide an `access` preset on `--add-endpoint`, then use `--add-allow` or `--add-deny` to refine REST endpoints later.
+If you set `protocol: rest`, you also need an allow shape. With incremental updates, that means you should provide an `access` preset on `--add-endpoint`, then use `--add-allow` or `--add-deny` to refine REST endpoints later.
 
 For example:
 
 - `api.github.com:443:read-only:rest` is valid.
-- `api.github.com:443:read-only:graphql` is valid.
 - `api.github.com:443::rest` is invalid. It does not mean "allow all traffic." An L7 endpoint with `protocol` but no `access` or `rules` is rejected when the policy loads.
 
 When you pass multiple `--add-endpoint` flags in one command, every `--binary` value applies to every added endpoint in that command. If different endpoints need different binaries, use separate `policy update` commands.
@@ -427,7 +425,7 @@ openshell policy update <name> --add-allow 'api.github.com:443:GET:/repos/**' --
 
 ## Examples
 
-Add these blocks to the `network_policies` section of your sandbox policy. Apply with `openshell policy update` for incremental additions or `openshell policy set <name> --policy <file> --wait` for full replacement.
+Add these blocks to the `network_policies` section of your sandbox policy. Apply simple endpoints and REST rule additions with `openshell policy update`, or apply any complete YAML block with `openshell policy set <name> --policy <file> --wait`.
 Use **Simple endpoint** for host-level allowlists and **Granular rules** for method/path control.
 
 <Tabs>
@@ -527,6 +525,8 @@ REST rules can also constrain query parameter values:
 ### GraphQL matching
 
 GraphQL endpoints use `protocol: graphql`. The proxy parses GraphQL-over-HTTP `GET` and `POST` requests, classifies each operation, and evaluates rules against the operation type, optional operation name, and selected root fields.
+
+GraphQL endpoint policies currently require full policy YAML applied with `openshell policy set`; the incremental `openshell policy update --add-endpoint` parser does not accept `graphql` as a protocol.
 
 ```yaml showLineNumbers={false}
   github_graphql:

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -220,8 +220,8 @@ Each segment has a fixed meaning:
 |---|---|---|
 | `host` | Yes | Destination hostname. |
 | `port` | Yes | Destination port, `1` through `65535`. |
-| `access` | No | Access preset for REST endpoints: `read-only`, `read-write`, or `full`. |
-| `protocol` | No | L7 inspection mode: `rest` or `sql`. In practice, incremental updates are designed around `rest`. `sql` is audit-only and not a recommended workflow today. |
+| `access` | No | Access preset for L7 endpoints: `read-only`, `read-write`, or `full`. REST and GraphQL endpoints expand presets differently. |
+| `protocol` | No | L7 inspection mode: `rest`, `graphql`, or `sql`. `sql` is audit-only and not a recommended workflow today. |
 | `enforcement` | No | Enforcement mode for inspected traffic: `enforce` or `audit`. |
 
 Examples:
@@ -230,13 +230,15 @@ Examples:
 |---|---|
 | `pypi.org:443` | Add a plain L4 endpoint. The proxy allows the TCP stream and does not inspect HTTP requests. |
 | `api.github.com:443:read-only:rest:enforce` | Add a REST endpoint with the `read-only` preset expanded by the policy engine into GET, HEAD, and OPTIONS access. |
+| `api.github.com:443:read-only:graphql:enforce` | Add a GraphQL endpoint with the `read-only` preset expanded into query-only access. |
 
-If you set `protocol: rest`, you also need an allow shape. With incremental updates, that means you should provide an `access` preset on `--add-endpoint`, then use `--add-allow` or `--add-deny` to refine it later.
+If you set `protocol: rest` or `protocol: graphql`, you also need an allow shape. With incremental updates, that means you should provide an `access` preset on `--add-endpoint`, then use `--add-allow` or `--add-deny` to refine REST endpoints later.
 
 For example:
 
 - `api.github.com:443:read-only:rest` is valid.
-- `api.github.com:443::rest` is invalid. It does not mean "allow all traffic." A REST endpoint with `protocol` but no `access` or `rules` is rejected when the policy loads.
+- `api.github.com:443:read-only:graphql` is valid.
+- `api.github.com:443::rest` is invalid. It does not mean "allow all traffic." An L7 endpoint with `protocol` but no `access` or `rules` is rejected when the policy loads.
 
 When you pass multiple `--add-endpoint` flags in one command, every `--binary` value applies to every added endpoint in that command. If different endpoints need different binaries, use separate `policy update` commands.
 
@@ -521,6 +523,52 @@ REST rules can also constrain query parameter values:
 ```
 
 `query` matchers are case-sensitive and run on decoded values. If a request has duplicate keys (for example, `tag=a&tag=b`), every value for that key must match the configured glob(s).
+
+### GraphQL matching
+
+GraphQL endpoints use `protocol: graphql`. The proxy parses GraphQL-over-HTTP `GET` and `POST` requests, classifies each operation, and evaluates rules against the operation type, optional operation name, and selected root fields.
+
+```yaml showLineNumbers={false}
+  github_graphql:
+    name: github_graphql
+    endpoints:
+      - host: api.github.com
+        port: 443
+        protocol: graphql
+        enforcement: enforce
+        rules:
+          - allow:
+              operation_type: query
+              fields: [viewer, repository]
+          - allow:
+              operation_type: mutation
+              operation_name: Issue*
+              fields: [createIssue]
+        deny_rules:
+          - operation_type: mutation
+            fields: [deleteRepository]
+    binaries:
+      - { path: /usr/bin/gh }
+```
+
+For allow rules, every selected root field in an operation must match one of the configured `fields` globs. For deny rules, one matching root field blocks the request. Batched GraphQL requests are fail-closed: if any operation is malformed, denied, or unregistered, the whole HTTP request is denied.
+
+Hash-only persisted queries cannot be classified from the request alone. OpenShell denies them unless the endpoint uses `persisted_queries: allow_registered` and provides a trusted `graphql_persisted_queries` entry keyed by hash or saved-query ID.
+
+### GraphQL service policy shapes
+
+GraphQL field names are application-specific, so treat these as starting shapes to review against the actual app schema:
+
+| Service | Endpoint shape | Starting policy |
+|---|---|---|
+| Railway | `backboard.railway.app/graphql/v2` | Allow `query`; allow only reviewed deployment mutations; deny `volumeDelete`, `projectDelete`, `*Delete`, `*Destroy`. |
+| GitHub | `api.github.com/graphql` | Allow `query`; optionally allow low-risk mutations such as reactions; deny broad destructive/admin roots like `deleteRef`, `deleteRepository`, `updateBranchProtectionRule`, and `delete*`. |
+| GitLab | `/api/graphql` | Prefer read-only token scopes where possible; allow `query`; deny mutations by default or allow only reviewed workflow roots. |
+| Shopify Admin | `*.myshopify.com/admin/api/**/graphql.json` | Allow `query`; allow app-specific mutations only; deny `*Delete`, `bulkOperationRunMutation`, and high-impact inventory/order/customer roots unless approved. |
+| monday.com | `api.monday.com/v2` | Allow board/item reads; allow tightly scoped create/update mutations only where needed; deny delete/archive roots. |
+| Salesforce GraphQL | Salesforce GraphQL endpoint | Allow `query`; deny record create/update/delete mutations unless the sandbox is intended to modify CRM data. |
+| Hygraph | Project content API endpoint | Allow content reads; deny generated destructive content roots such as `delete*`, `deleteMany*`, `unpublish*`, and batch mutations unless a publishing workflow requires them. |
+| Atlassian GraphQL Gateway | `api.atlassian.com/graphql` | Allow reads by default; require explicit mutation allowlists because the gateway spans Jira, Confluence, Bitbucket, and admin surfaces. |
 
 ## Next Steps
 

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -83,13 +83,13 @@ The `protocol` field on an endpoint controls whether the proxy inspects individu
 | Aspect | Detail |
 |---|---|
 | Default | Endpoints without a `protocol` field use L4-only enforcement: the proxy checks host, port, and binary, then relays the TCP stream without inspecting payloads. |
-| What you can change | Add `protocol: rest` to enable per-request HTTP inspection. Pair it with `rules` (fine-grained method and path control) or `access` presets (`full`, `read-only`, `read-write`). |
-| Risk if relaxed | L4-only endpoints allow the agent to send any data through the tunnel after the initial connection is permitted. The proxy cannot see HTTP methods, paths, or bodies. Adding `access: full` with `protocol: rest` enables inspection but permits all methods and paths, providing observability without restriction. |
-| Recommendation | Use `protocol: rest` with specific `rules` for APIs where you want method and path control. Use `access: read-only` for read-only endpoints. Omit `protocol` for non-HTTP protocols (WebSocket, gRPC streaming). |
+| What you can change | Add `protocol: rest` to enable per-request HTTP method/path inspection, or `protocol: graphql` to inspect GraphQL operation type, operation name, and root fields. Pair either protocol with `rules` or access presets (`full`, `read-only`, `read-write`). |
+| Risk if relaxed | L4-only endpoints allow the agent to send any data through the tunnel after the initial connection is permitted. The proxy cannot see HTTP methods, paths, or GraphQL operations. Adding `access: full` with L7 inspection enables observability but permits all inspected actions. |
+| Recommendation | Use `protocol: rest` with specific `rules` for APIs where intent is encoded in method and path. Use `protocol: graphql` for GraphQL APIs where destructive operations are body-encoded. Prefer `access: read-only` or explicit allowlists, and deny hash-only persisted queries unless you maintain a trusted registry. Omit `protocol` for non-HTTP protocols (WebSocket, gRPC streaming). |
 
 ### Enforcement Mode (`audit` vs `enforce`)
 
-When `protocol: rest` is active, the `enforcement` field controls whether the proxy blocks or logs rule violations.
+When L7 inspection is active, the `enforcement` field controls whether the proxy blocks or logs rule violations.
 
 | Aspect | Detail |
 |---|---|

--- a/e2e/rust/tests/forward_proxy_graphql_l7.rs
+++ b/e2e/rust/tests/forward_proxy_graphql_l7.rs
@@ -317,7 +317,6 @@ def forward_chunked_status(query):
             f"\r\n"
         ).encode() + chunk
         sock.sendall(request)
-        sock.shutdown(socket.SHUT_WR)
         response, body = read_response(sock)
         DETAILS["forward_chunked_query_allowed_detail"] = body.decode(errors="replace")
         return int(response.split()[1])

--- a/e2e/rust/tests/forward_proxy_graphql_l7.rs
+++ b/e2e/rust/tests/forward_proxy_graphql_l7.rs
@@ -33,7 +33,10 @@ impl DockerServer {
 
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
-        self.send_response(200)
+        if self.path == "/" or self.path.startswith("/graphql?"):
+            self.send_response(200)
+        else:
+            self.send_response(418)
         self.end_headers()
         self.wfile.write(b'{"ok":true}')
     def do_POST(self):
@@ -150,6 +153,12 @@ network_policies:
         port: {port}
         protocol: graphql
         enforcement: enforce
+        persisted_queries: allow_registered
+        graphql_persisted_queries:
+          abc123:
+            operation_type: query
+            operation_name: Viewer
+            fields: [viewer]
         allowed_ips:
           - "172.0.0.0/8"
         rules:
@@ -221,6 +230,79 @@ def forward_status(query):
         error.read()
         return error.code
 
+def forward_get_status(query):
+    encoded = urllib.parse.urlencode({{"query": query}})
+    request = urllib.request.Request(
+        f"http://{{HOST}}:{{PORT}}/graphql?{{encoded}}",
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            response.read()
+            return response.status
+    except urllib.error.HTTPError as error:
+        error.read()
+        return error.code
+
+def forward_duplicate_get_status():
+    safe = urllib.parse.quote_plus(QUERY_VIEWER)
+    unsafe = urllib.parse.quote_plus(MUTATION_DELETE)
+    request = urllib.request.Request(
+        f"http://{{HOST}}:{{PORT}}/graphql?query={{safe}}&query={{unsafe}}",
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            response.read()
+            return response.status
+    except urllib.error.HTTPError as error:
+        error.read()
+        return error.code
+
+def forward_persisted_get_status(hash_value):
+    extensions = json.dumps({{"persistedQuery": {{"version": 1, "sha256Hash": hash_value}}}})
+    encoded = urllib.parse.urlencode({{"operationName": "Viewer", "extensions": extensions}})
+    request = urllib.request.Request(
+        f"http://{{HOST}}:{{PORT}}/graphql?{{encoded}}",
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            response.read()
+            return response.status
+    except urllib.error.HTTPError as error:
+        error.read()
+        return error.code
+
+def proxy_parts():
+    proxy_url = (
+        os.environ.get("HTTPS_PROXY")
+        or os.environ.get("https_proxy")
+        or os.environ.get("HTTP_PROXY")
+        or os.environ.get("http_proxy")
+    )
+    parsed = urllib.parse.urlparse(proxy_url)
+    return parsed.hostname, parsed.port or 80
+
+def forward_chunked_status(query):
+    proxy_host, proxy_port = proxy_parts()
+    target = f"{{HOST}}:{{PORT}}"
+    body = json.dumps({{"query": query}}).encode()
+    chunk = f"{{len(body):x}}\r\n".encode() + body + b"\r\n0\r\n\r\n"
+
+    with socket.create_connection((proxy_host, proxy_port), timeout=15) as sock:
+        request = (
+            f"POST http://{{target}}/graphql HTTP/1.1\r\n"
+            f"Host: {{target}}\r\n"
+            f"Content-Type: application/json\r\n"
+            f"Transfer-Encoding: chunked\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+        ).encode() + chunk
+        sock.sendall(request)
+        response = read_until(sock, b"\r\n\r\n")
+        return int(response.split()[1])
+
 def read_until(sock, marker):
     data = b""
     while marker not in data:
@@ -231,18 +313,11 @@ def read_until(sock, marker):
     return data
 
 def connect_status(query):
-    proxy_url = (
-        os.environ.get("HTTPS_PROXY")
-        or os.environ.get("https_proxy")
-        or os.environ.get("HTTP_PROXY")
-        or os.environ.get("http_proxy")
-    )
-    parsed = urllib.parse.urlparse(proxy_url)
-    proxy_port = parsed.port or 80
+    proxy_host, proxy_port = proxy_parts()
     target = f"{{HOST}}:{{PORT}}"
     body = json.dumps({{"query": query}}).encode()
 
-    with socket.create_connection((parsed.hostname, proxy_port), timeout=15) as sock:
+    with socket.create_connection((proxy_host, proxy_port), timeout=15) as sock:
         sock.sendall(
             f"CONNECT {{target}} HTTP/1.1\r\nHost: {{target}}\r\n\r\n".encode()
         )
@@ -262,12 +337,119 @@ def connect_status(query):
         response = read_until(sock, b"\r\n\r\n")
         return int(response.split()[1])
 
+def connect_get_status(query):
+    proxy_host, proxy_port = proxy_parts()
+    target = f"{{HOST}}:{{PORT}}"
+    encoded = urllib.parse.urlencode({{"query": query}})
+
+    with socket.create_connection((proxy_host, proxy_port), timeout=15) as sock:
+        sock.sendall(
+            f"CONNECT {{target}} HTTP/1.1\r\nHost: {{target}}\r\n\r\n".encode()
+        )
+        connect_response = read_until(sock, b"\r\n\r\n")
+        if not connect_response.startswith(b"HTTP/1.1 200"):
+            return int(connect_response.split()[1])
+
+        request = (
+            f"GET /graphql?{{encoded}} HTTP/1.1\r\n"
+            f"Host: {{target}}\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+        ).encode()
+        sock.sendall(request)
+        response = read_until(sock, b"\r\n\r\n")
+        return int(response.split()[1])
+
+def connect_duplicate_get_status():
+    proxy_host, proxy_port = proxy_parts()
+    target = f"{{HOST}}:{{PORT}}"
+    safe = urllib.parse.quote_plus(QUERY_VIEWER)
+    unsafe = urllib.parse.quote_plus(MUTATION_DELETE)
+
+    with socket.create_connection((proxy_host, proxy_port), timeout=15) as sock:
+        sock.sendall(
+            f"CONNECT {{target}} HTTP/1.1\r\nHost: {{target}}\r\n\r\n".encode()
+        )
+        connect_response = read_until(sock, b"\r\n\r\n")
+        if not connect_response.startswith(b"HTTP/1.1 200"):
+            return int(connect_response.split()[1])
+
+        request = (
+            f"GET /graphql?query={{safe}}&query={{unsafe}} HTTP/1.1\r\n"
+            f"Host: {{target}}\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+        ).encode()
+        sock.sendall(request)
+        response = read_until(sock, b"\r\n\r\n")
+        return int(response.split()[1])
+
+def connect_persisted_get_status(hash_value):
+    proxy_host, proxy_port = proxy_parts()
+    target = f"{{HOST}}:{{PORT}}"
+    extensions = json.dumps({{"persistedQuery": {{"version": 1, "sha256Hash": hash_value}}}})
+    encoded = urllib.parse.urlencode({{"operationName": "Viewer", "extensions": extensions}})
+
+    with socket.create_connection((proxy_host, proxy_port), timeout=15) as sock:
+        sock.sendall(
+            f"CONNECT {{target}} HTTP/1.1\r\nHost: {{target}}\r\n\r\n".encode()
+        )
+        connect_response = read_until(sock, b"\r\n\r\n")
+        if not connect_response.startswith(b"HTTP/1.1 200"):
+            return int(connect_response.split()[1])
+
+        request = (
+            f"GET /graphql?{{encoded}} HTTP/1.1\r\n"
+            f"Host: {{target}}\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+        ).encode()
+        sock.sendall(request)
+        response = read_until(sock, b"\r\n\r\n")
+        return int(response.split()[1])
+
+def connect_chunked_status(query):
+    proxy_host, proxy_port = proxy_parts()
+    target = f"{{HOST}}:{{PORT}}"
+    body = json.dumps({{"query": query}}).encode()
+    chunk = f"{{len(body):x}}\r\n".encode() + body + b"\r\n0\r\n\r\n"
+
+    with socket.create_connection((proxy_host, proxy_port), timeout=15) as sock:
+        sock.sendall(
+            f"CONNECT {{target}} HTTP/1.1\r\nHost: {{target}}\r\n\r\n".encode()
+        )
+        connect_response = read_until(sock, b"\r\n\r\n")
+        if not connect_response.startswith(b"HTTP/1.1 200"):
+            return int(connect_response.split()[1])
+
+        request = (
+            f"POST /graphql HTTP/1.1\r\n"
+            f"Host: {{target}}\r\n"
+            f"Content-Type: application/json\r\n"
+            f"Transfer-Encoding: chunked\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+        ).encode() + chunk
+        sock.sendall(request)
+        response = read_until(sock, b"\r\n\r\n")
+        return int(response.split()[1])
+
 results = {{
     "forward_query_allowed": forward_status(QUERY_VIEWER),
+    "forward_get_query_allowed": forward_get_status(QUERY_VIEWER),
+    "forward_duplicate_get_denied": forward_duplicate_get_status(),
+    "forward_persisted_get_allowed": forward_persisted_get_status("abc123"),
+    "forward_unregistered_persisted_get_denied": forward_persisted_get_status("missing"),
+    "forward_chunked_query_allowed": forward_chunked_status(QUERY_VIEWER),
     "forward_unlisted_field_denied": forward_status(QUERY_REPOSITORY),
     "forward_mutation_allowed": forward_status(MUTATION_CREATE),
     "forward_deny_rule_denied": forward_status(MUTATION_DELETE),
     "connect_query_allowed": connect_status(QUERY_VIEWER),
+    "connect_get_query_allowed": connect_get_status(QUERY_VIEWER),
+    "connect_duplicate_get_denied": connect_duplicate_get_status(),
+    "connect_persisted_get_allowed": connect_persisted_get_status("abc123"),
+    "connect_unregistered_persisted_get_denied": connect_persisted_get_status("missing"),
+    "connect_chunked_query_allowed": connect_chunked_status(QUERY_VIEWER),
     "connect_unlisted_field_denied": connect_status(QUERY_REPOSITORY),
     "connect_mutation_allowed": connect_status(MUTATION_CREATE),
     "connect_deny_rule_denied": connect_status(MUTATION_DELETE),
@@ -290,10 +472,20 @@ print(json.dumps(results, sort_keys=True))
 
     for (key, expected) in [
         ("forward_query_allowed", 200),
+        ("forward_get_query_allowed", 200),
+        ("forward_duplicate_get_denied", 403),
+        ("forward_persisted_get_allowed", 200),
+        ("forward_unregistered_persisted_get_denied", 403),
+        ("forward_chunked_query_allowed", 200),
         ("forward_unlisted_field_denied", 403),
         ("forward_mutation_allowed", 200),
         ("forward_deny_rule_denied", 403),
         ("connect_query_allowed", 200),
+        ("connect_get_query_allowed", 200),
+        ("connect_duplicate_get_denied", 403),
+        ("connect_persisted_get_allowed", 200),
+        ("connect_unregistered_persisted_get_denied", 403),
+        ("connect_chunked_query_allowed", 200),
         ("connect_unlisted_field_denied", 403),
         ("connect_mutation_allowed", 200),
         ("connect_deny_rule_denied", 403),

--- a/e2e/rust/tests/forward_proxy_graphql_l7.rs
+++ b/e2e/rust/tests/forward_proxy_graphql_l7.rs
@@ -315,6 +315,7 @@ def forward_chunked_status(query):
             f"\r\n"
         ).encode() + chunk
         sock.sendall(request)
+        sock.shutdown(socket.SHUT_WR)
         response = read_until(sock, b"\r\n\r\n")
         return int(response.split()[1])
 
@@ -446,6 +447,7 @@ def connect_chunked_status(query):
             f"\r\n"
         ).encode() + chunk
         sock.sendall(request)
+        sock.shutdown(socket.SHUT_WR)
         response = read_until(sock, b"\r\n\r\n")
         return int(response.split()[1])
 

--- a/e2e/rust/tests/forward_proxy_graphql_l7.rs
+++ b/e2e/rust/tests/forward_proxy_graphql_l7.rs
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! E2E tests for GraphQL L7 inspection across both proxy entry points.
+//!
+//! The upstream server deliberately does not implement GraphQL. `OpenShell`
+//! parses and enforces GraphQL before forwarding, so any HTTP server that
+//! accepts POST /graphql is enough to prove allowed requests reach upstream
+//! and denied requests are stopped by the sandbox proxy.
+
+#![cfg(feature = "e2e")]
+
+use std::io::Write;
+use std::process::Command;
+use std::time::Duration;
+
+use openshell_e2e::harness::port::find_free_port;
+use openshell_e2e::harness::sandbox::SandboxGuard;
+use tempfile::NamedTempFile;
+use tokio::time::{interval, timeout};
+
+const TEST_SERVER_IMAGE: &str = "public.ecr.aws/docker/library/python:3.13-alpine";
+
+struct DockerServer {
+    port: u16,
+    container_id: String,
+}
+
+impl DockerServer {
+    async fn start() -> Result<Self, String> {
+        let port = find_free_port();
+        let script = r#"from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'{"ok":true}')
+    def do_POST(self):
+        _ = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"ok":true}')
+    def log_message(self, format, *args):
+        pass
+
+HTTPServer(("0.0.0.0", 8000), Handler).serve_forever()
+"#;
+
+        let output = Command::new("docker")
+            .args([
+                "run",
+                "--detach",
+                "--rm",
+                "-p",
+                &format!("{port}:8000"),
+                TEST_SERVER_IMAGE,
+                "python3",
+                "-c",
+                script,
+            ])
+            .output()
+            .map_err(|e| format!("start docker test server: {e}"))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        if !output.status.success() {
+            return Err(format!(
+                "docker run failed (exit {:?}):\n{stderr}",
+                output.status.code()
+            ));
+        }
+
+        let server = Self {
+            port,
+            container_id: stdout,
+        };
+        server.wait_until_ready().await?;
+        Ok(server)
+    }
+
+    async fn wait_until_ready(&self) -> Result<(), String> {
+        let container_id = self.container_id.clone();
+        timeout(Duration::from_secs(60), async move {
+            let mut tick = interval(Duration::from_millis(500));
+            loop {
+                tick.tick().await;
+                let output = Command::new("docker")
+                    .args([
+                        "exec",
+                        &container_id,
+                        "python3",
+                        "-c",
+                        "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000', timeout=1).read()",
+                    ])
+                    .output()
+                    .ok();
+                if output.is_some_and(|o| o.status.success()) {
+                    return;
+                }
+            }
+        })
+        .await
+        .map_err(|_| "docker test server did not become ready within 60s".to_string())
+    }
+}
+
+impl Drop for DockerServer {
+    fn drop(&mut self) {
+        let _ = Command::new("docker")
+            .args(["rm", "-f", &self.container_id])
+            .output();
+    }
+}
+
+fn write_graphql_policy(port: u16) -> Result<NamedTempFile, String> {
+    let mut file = NamedTempFile::new().map_err(|e| format!("create temp policy file: {e}"))?;
+    let policy = format!(
+        r#"version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /proc
+    - /dev/urandom
+    - /app
+    - /etc
+    - /var/log
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  test_graphql_l7:
+    name: test_graphql_l7
+    endpoints:
+      - host: host.openshell.internal
+        port: {port}
+        protocol: graphql
+        enforcement: enforce
+        allowed_ips:
+          - "172.0.0.0/8"
+        rules:
+          - allow:
+              operation_type: query
+              fields: [viewer]
+          - allow:
+              operation_type: mutation
+              fields: [createIssue]
+        deny_rules:
+          - operation_type: mutation
+            fields: [deleteRepository]
+    binaries:
+      - path: /usr/bin/python*
+      - path: /usr/local/bin/python*
+      - path: /sandbox/.uv/python/*/bin/python*
+"#
+    );
+    file.write_all(policy.as_bytes())
+        .map_err(|e| format!("write temp policy file: {e}"))?;
+    file.flush()
+        .map_err(|e| format!("flush temp policy file: {e}"))?;
+    Ok(file)
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn graphql_l7_enforces_allow_and_deny_rules_on_forward_and_connect_paths() {
+    let server = DockerServer::start()
+        .await
+        .expect("start docker test server");
+    let policy = write_graphql_policy(server.port).expect("write custom policy");
+    let policy_path = policy
+        .path()
+        .to_str()
+        .expect("temp policy path should be utf-8")
+        .to_string();
+
+    let script = format!(
+        r#"
+import json
+import os
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
+
+HOST = "host.openshell.internal"
+PORT = {port}
+
+QUERY_VIEWER = "query Viewer {{ viewer {{ login }} }}"
+QUERY_REPOSITORY = "query Repo {{ repository(owner:\"o\", name:\"r\") {{ id }} }}"
+MUTATION_CREATE = "mutation Create {{ createIssue(input:{{repositoryId:\"r\", title:\"t\", body:\"b\"}}) {{ issue {{ id }} }} }}"
+MUTATION_DELETE = "mutation Delete {{ deleteRepository(input:{{repositoryId:\"r\"}}) {{ clientMutationId }} }}"
+
+def forward_status(query):
+    body = json.dumps({{"query": query}}).encode()
+    request = urllib.request.Request(
+        f"http://{{HOST}}:{{PORT}}/graphql",
+        data=body,
+        headers={{"Content-Type": "application/json"}},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            response.read()
+            return response.status
+    except urllib.error.HTTPError as error:
+        error.read()
+        return error.code
+
+def read_until(sock, marker):
+    data = b""
+    while marker not in data:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+    return data
+
+def connect_status(query):
+    proxy_url = (
+        os.environ.get("HTTPS_PROXY")
+        or os.environ.get("https_proxy")
+        or os.environ.get("HTTP_PROXY")
+        or os.environ.get("http_proxy")
+    )
+    parsed = urllib.parse.urlparse(proxy_url)
+    proxy_port = parsed.port or 80
+    target = f"{{HOST}}:{{PORT}}"
+    body = json.dumps({{"query": query}}).encode()
+
+    with socket.create_connection((parsed.hostname, proxy_port), timeout=15) as sock:
+        sock.sendall(
+            f"CONNECT {{target}} HTTP/1.1\r\nHost: {{target}}\r\n\r\n".encode()
+        )
+        connect_response = read_until(sock, b"\r\n\r\n")
+        if not connect_response.startswith(b"HTTP/1.1 200"):
+            return int(connect_response.split()[1])
+
+        request = (
+            f"POST /graphql HTTP/1.1\r\n"
+            f"Host: {{target}}\r\n"
+            f"Content-Type: application/json\r\n"
+            f"Content-Length: {{len(body)}}\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+        ).encode() + body
+        sock.sendall(request)
+        response = read_until(sock, b"\r\n\r\n")
+        return int(response.split()[1])
+
+results = {{
+    "forward_query_allowed": forward_status(QUERY_VIEWER),
+    "forward_unlisted_field_denied": forward_status(QUERY_REPOSITORY),
+    "forward_mutation_allowed": forward_status(MUTATION_CREATE),
+    "forward_deny_rule_denied": forward_status(MUTATION_DELETE),
+    "connect_query_allowed": connect_status(QUERY_VIEWER),
+    "connect_unlisted_field_denied": connect_status(QUERY_REPOSITORY),
+    "connect_mutation_allowed": connect_status(MUTATION_CREATE),
+    "connect_deny_rule_denied": connect_status(MUTATION_DELETE),
+}}
+print(json.dumps(results, sort_keys=True))
+"#,
+        port = server.port,
+    );
+
+    let guard = SandboxGuard::create(&[
+        "--policy",
+        &policy_path,
+        "--",
+        "python3",
+        "-c",
+        &script,
+    ])
+    .await
+    .expect("sandbox create");
+
+    for (key, expected) in [
+        ("forward_query_allowed", 200),
+        ("forward_unlisted_field_denied", 403),
+        ("forward_mutation_allowed", 200),
+        ("forward_deny_rule_denied", 403),
+        ("connect_query_allowed", 200),
+        ("connect_unlisted_field_denied", 403),
+        ("connect_mutation_allowed", 200),
+        ("connect_deny_rule_denied", 403),
+    ] {
+        let expected_fragment = format!(r#""{key}": {expected}"#);
+        assert!(
+            guard.create_output.contains(&expected_fragment),
+            "expected {key}={expected}, got:\n{}",
+            guard.create_output
+        );
+    }
+}

--- a/e2e/rust/tests/forward_proxy_graphql_l7.rs
+++ b/e2e/rust/tests/forward_proxy_graphql_l7.rs
@@ -289,18 +289,19 @@ def forward_persisted_get_status(hash_value):
         error.read()
         return error.code
 
-def proxy_parts():
-    proxy_url = (
-        os.environ.get("HTTPS_PROXY")
-        or os.environ.get("https_proxy")
-        or os.environ.get("HTTP_PROXY")
-        or os.environ.get("http_proxy")
-    )
+def proxy_parts(*names):
+    proxy_url = next((os.environ.get(name) for name in names if os.environ.get(name)), None)
     parsed = urllib.parse.urlparse(proxy_url)
     return parsed.hostname, parsed.port or 80
 
+def forward_proxy_parts():
+    return proxy_parts("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy")
+
+def connect_proxy_parts():
+    return proxy_parts("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy")
+
 def forward_chunked_status(query):
-    proxy_host, proxy_port = proxy_parts()
+    proxy_host, proxy_port = forward_proxy_parts()
     target = f"{{HOST}}:{{PORT}}"
     body = json.dumps({{"query": query}}).encode()
     chunk = f"{{len(body):x}}\r\n".encode() + body + b"\r\n0\r\n\r\n"
@@ -329,7 +330,7 @@ def read_until(sock, marker):
     return data
 
 def connect_status(query):
-    proxy_host, proxy_port = proxy_parts()
+    proxy_host, proxy_port = connect_proxy_parts()
     target = f"{{HOST}}:{{PORT}}"
     body = json.dumps({{"query": query}}).encode()
 
@@ -355,7 +356,7 @@ def connect_status(query):
         return int(response.split()[1])
 
 def connect_get_status(query):
-    proxy_host, proxy_port = proxy_parts()
+    proxy_host, proxy_port = connect_proxy_parts()
     target = f"{{HOST}}:{{PORT}}"
     encoded = urllib.parse.urlencode({{"query": query}})
 
@@ -379,7 +380,7 @@ def connect_get_status(query):
         return int(response.split()[1])
 
 def connect_duplicate_get_status():
-    proxy_host, proxy_port = proxy_parts()
+    proxy_host, proxy_port = connect_proxy_parts()
     target = f"{{HOST}}:{{PORT}}"
     safe = urllib.parse.quote_plus(QUERY_VIEWER)
     unsafe = urllib.parse.quote_plus(MUTATION_DELETE)
@@ -404,7 +405,7 @@ def connect_duplicate_get_status():
         return int(response.split()[1])
 
 def connect_persisted_get_status(hash_value):
-    proxy_host, proxy_port = proxy_parts()
+    proxy_host, proxy_port = connect_proxy_parts()
     target = f"{{HOST}}:{{PORT}}"
     extensions = json.dumps({{"persistedQuery": {{"version": 1, "sha256Hash": hash_value}}}})
     encoded = urllib.parse.urlencode({{"operationName": "Viewer", "extensions": extensions}})
@@ -429,7 +430,7 @@ def connect_persisted_get_status(hash_value):
         return int(response.split()[1])
 
 def connect_chunked_status(query):
-    proxy_host, proxy_port = proxy_parts()
+    proxy_host, proxy_port = connect_proxy_parts()
     target = f"{{HOST}}:{{PORT}}"
     body = json.dumps({{"query": query}}).encode()
     chunk = f"{{len(body):x}}\r\n".encode() + body + b"\r\n0\r\n\r\n"

--- a/e2e/rust/tests/forward_proxy_graphql_l7.rs
+++ b/e2e/rust/tests/forward_proxy_graphql_l7.rs
@@ -32,6 +32,18 @@ impl DockerServer {
         let script = r#"from http.server import BaseHTTPRequestHandler, HTTPServer
 
 class Handler(BaseHTTPRequestHandler):
+    def read_chunked(self):
+        while True:
+            size_line = self.rfile.readline()
+            if not size_line:
+                return
+            size = int(size_line.split(b";", 1)[0].strip(), 16)
+            if size == 0:
+                while self.rfile.readline().strip():
+                    pass
+                return
+            self.rfile.read(size)
+            self.rfile.read(2)
     def do_GET(self):
         if self.path == "/" or self.path.startswith("/graphql?"):
             self.send_response(200)
@@ -40,7 +52,10 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(b'{"ok":true}')
     def do_POST(self):
-        _ = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+        if self.headers.get("Transfer-Encoding", "").lower() == "chunked":
+            self.read_chunked()
+        else:
+            _ = self.rfile.read(int(self.headers.get("Content-Length", "0")))
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.end_headers()

--- a/e2e/rust/tests/forward_proxy_graphql_l7.rs
+++ b/e2e/rust/tests/forward_proxy_graphql_l7.rs
@@ -223,6 +223,7 @@ import urllib.request
 
 HOST = "host.openshell.internal"
 PORT = {port}
+DETAILS = {{}}
 
 QUERY_VIEWER = "query Viewer {{ viewer {{ login }} }}"
 QUERY_REPOSITORY = "query Repo {{ repository(owner:\"o\", name:\"r\") {{ id }} }}"
@@ -317,7 +318,8 @@ def forward_chunked_status(query):
         ).encode() + chunk
         sock.sendall(request)
         sock.shutdown(socket.SHUT_WR)
-        response = read_until(sock, b"\r\n\r\n")
+        response, body = read_response(sock)
+        DETAILS["forward_chunked_query_allowed_detail"] = body.decode(errors="replace")
         return int(response.split()[1])
 
 def read_until(sock, marker):
@@ -328,6 +330,21 @@ def read_until(sock, marker):
             break
         data += chunk
     return data
+
+def read_response(sock):
+    response = read_until(sock, b"\r\n\r\n")
+    headers, _, body = response.partition(b"\r\n\r\n")
+    content_length = 0
+    for line in headers.split(b"\r\n")[1:]:
+        if line.lower().startswith(b"content-length:"):
+            content_length = int(line.split(b":", 1)[1].strip())
+            break
+    while len(body) < content_length:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        body += chunk
+    return response, body
 
 def connect_status(query):
     proxy_host, proxy_port = connect_proxy_parts()
@@ -476,6 +493,7 @@ results = {{
     "connect_mutation_allowed": connect_status(MUTATION_CREATE),
     "connect_deny_rule_denied": connect_status(MUTATION_DELETE),
 }}
+results.update(DETAILS)
 print(json.dumps(results, sort_keys=True))
 "#,
         port = server.port,

--- a/e2e/rust/tests/forward_proxy_graphql_l7.rs
+++ b/e2e/rust/tests/forward_proxy_graphql_l7.rs
@@ -350,6 +350,7 @@ def connect_status(query):
             f"\r\n"
         ).encode() + body
         sock.sendall(request)
+        sock.shutdown(socket.SHUT_WR)
         response = read_until(sock, b"\r\n\r\n")
         return int(response.split()[1])
 
@@ -373,6 +374,7 @@ def connect_get_status(query):
             f"\r\n"
         ).encode()
         sock.sendall(request)
+        sock.shutdown(socket.SHUT_WR)
         response = read_until(sock, b"\r\n\r\n")
         return int(response.split()[1])
 
@@ -397,6 +399,7 @@ def connect_duplicate_get_status():
             f"\r\n"
         ).encode()
         sock.sendall(request)
+        sock.shutdown(socket.SHUT_WR)
         response = read_until(sock, b"\r\n\r\n")
         return int(response.split()[1])
 
@@ -421,6 +424,7 @@ def connect_persisted_get_status(hash_value):
             f"\r\n"
         ).encode()
         sock.sendall(request)
+        sock.shutdown(socket.SHUT_WR)
         response = read_until(sock, b"\r\n\r\n")
         return int(response.split()[1])
 

--- a/proto/sandbox.proto
+++ b/proto/sandbox.proto
@@ -70,7 +70,7 @@ message NetworkEndpoint {
   // Single port (backwards compat). Use `ports` for multiple ports.
   // Mutually exclusive with `ports` — if both are set, `ports` takes precedence.
   uint32 port = 2;
-  // Application protocol for L7 inspection: "rest", "sql", or "" (L4-only).
+  // Application protocol for L7 inspection: "rest", "graphql", "sql", or "" (L4-only).
   string protocol = 3;
   // TLS handling: "terminate" or "passthrough" (default).
   string tls = 4;
@@ -102,6 +102,25 @@ message NetworkEndpoint {
   // upstreams like GitLab that embed %2F in namespaced resource paths.
   // Defaults to false (strict).
   bool allow_encoded_slash = 11;
+  // GraphQL persisted-query behavior for hash-only/saved-query requests:
+  // "deny" (default) or "allow_registered".
+  string persisted_queries = 12;
+  // Trusted GraphQL persisted-query registry keyed by hash or service-specific ID.
+  // Only used when persisted_queries is "allow_registered".
+  map<string, GraphqlOperation> graphql_persisted_queries = 13;
+  // Maximum GraphQL request body bytes to buffer for inspection.
+  // Defaults to 65536 when unset.
+  uint32 graphql_max_body_bytes = 14;
+}
+
+// Trusted GraphQL operation classification.
+message GraphqlOperation {
+  // Operation type: "query", "mutation", or "subscription".
+  string operation_type = 1;
+  // Operation name, if known.
+  string operation_name = 2;
+  // Root field names selected by the operation.
+  repeated string fields = 3;
 }
 
 // An L7 deny rule that blocks specific requests.
@@ -117,6 +136,13 @@ message L7DenyRule {
   // Query parameter matcher map (REST).
   // Same semantics as L7Allow.query.
   map<string, L7QueryMatcher> query = 4;
+  // GraphQL operation type: "query", "mutation", "subscription", or "*" for any.
+  string operation_type = 5;
+  // GraphQL operation name glob. "*" matches any operation name.
+  string operation_name = 6;
+  // GraphQL root field globs. Deny rules match when any selected root field
+  // matches any configured glob.
+  repeated string fields = 7;
 }
 
 // An L7 policy rule (allow-only).
@@ -136,6 +162,13 @@ message L7Allow {
   // Key is the decoded query parameter name (case-sensitive).
   // Value supports either a single glob (`glob`) or a list (`any`).
   map<string, L7QueryMatcher> query = 4;
+  // GraphQL operation type: "query", "mutation", "subscription", or "*" for any.
+  string operation_type = 5;
+  // GraphQL operation name glob. "*" matches any operation name.
+  string operation_name = 6;
+  // GraphQL root field globs. Allow rules match only when every selected root
+  // field matches one of the configured globs. Omit to match all fields.
+  repeated string fields = 7;
 }
 
 // Query value matcher for one query parameter key.

--- a/proto/sandbox.proto
+++ b/proto/sandbox.proto
@@ -111,6 +111,11 @@ message NetworkEndpoint {
   // Maximum GraphQL request body bytes to buffer for inspection.
   // Defaults to 65536 when unset.
   uint32 graphql_max_body_bytes = 14;
+  // Optional HTTP path glob that scopes this L7 endpoint on shared host:port APIs.
+  // Example: use path "/graphql" for protocol "graphql" and "/repos/**" for
+  // protocol "rest" when both surfaces live under api.example.com:443.
+  // Empty means all paths.
+  string path = 15;
 }
 
 // Trusted GraphQL operation classification.


### PR DESCRIPTION
> **🏗️ build-from-issue-agent**

## Summary
Adds GraphQL-aware L7 inspection for GraphQL-over-HTTP endpoints. The sandbox can classify operation type, operation name, root fields, and persisted-query identifiers before evaluating OPA policy.

## Related Issue
Closes #1022

## Changes
- `proto/sandbox.proto`, `crates/openshell-policy`, `crates/openshell-sandbox/src/opa.rs`: add GraphQL policy fields, persisted-query registry fields, YAML/proto round trips, and OPA serialization.
- `crates/openshell-sandbox/src/l7/graphql.rs`, `crates/openshell-sandbox/src/l7/relay.rs`: add GraphQL request parsing, bounded body buffering, batched operation classification, deny handling, and OCSF logging.
- `crates/openshell-sandbox/data/sandbox-policy.rego`: enforce GraphQL allow/deny rules with deny precedence, all-operation batch checks, field glob matching, and trusted hash-only persisted-query handling.
- L7 endpoint selection is path-aware, so REST and GraphQL endpoints can share the same host and port without treating GraphQL as a generic REST `POST`.
- `e2e/rust/tests/forward_proxy_graphql_l7.rs`: cover forward-proxy and CONNECT-proxy GraphQL enforcement, duplicate GET control params, persisted queries, and chunked request bodies.
- `architecture/` and `docs/`: document policy syntax, real-world service policy shapes, and saved/hash-only query behavior.

### Railway-Style Destructive Mutation UX
The Railway accident class was a direct GraphQL mutation against `https://backboard.railway.app/graphql/v2` such as:

```shell
curl -X POST https://backboard.railway.app/graphql/v2 \
  -H "Authorization: Bearer $RAILWAY_TOKEN" \
  -d '{"query":"mutation { volumeDelete(volumeId: \"vol_123\") }"}'
```

A policy can make that failure mode explicit by allowing only known read operations and denying destructive root mutation fields before the request leaves the sandbox:

```yaml
network_policies:
  railway_guardrails:
    endpoints:
      - host: backboard.railway.app
        port: 443
        path: /graphql/v2
        protocol: graphql
        enforcement: enforce
        rules:
          - allow:
              operation_type: query
              fields:
                - viewer
                - project
                - projects
                - environment
                - service
                - deployment
          - allow:
              operation_type: mutation
              fields:
                - deploymentRedeploy
                - deploymentCancel
        deny_rules:
          - operation_type: mutation
            fields:
              - volumeDelete
              - serviceDelete
              - projectDelete
              - environmentDelete
              - databaseDelete
    binaries:
      - path: /usr/bin/curl
      - path: /usr/local/bin/python*
      - path: /sandbox/.uv/python/*/bin/python*
```

The important reviewer-facing behavior is that policy authors do not need to identify every possible mutation name. They can combine narrow allow rules with explicit high-risk deny rules, and deny rules take precedence if a batch mixes safe reads with a destructive mutation.

### Real-World Network Policy Shapes
These examples are intentionally service-specific. GraphQL is not a universal verb model like REST, so the useful policy unit is the app schema's root fields plus any trusted saved-query registry. The new endpoint `path` selector is what lets a policy distinguish `/graphql` from REST routes on the same host.

GitHub mixed REST and GraphQL shape on `api.github.com`:

```yaml
network_policies:
  github_api_guardrails:
    endpoints:
      - host: api.github.com
        port: 443
        path: /repos/NVIDIA/OpenShell/**
        protocol: rest
        enforcement: enforce
        rules:
          - allow:
              methods: [GET]
              path: /repos/NVIDIA/OpenShell/**
          - allow:
              methods: [POST]
              path: /repos/NVIDIA/OpenShell/issues/*/comments
        deny_rules:
          - methods: [DELETE, PATCH, PUT]
            path: /repos/NVIDIA/OpenShell/**
      - host: api.github.com
        port: 443
        path: /graphql
        protocol: graphql
        enforcement: enforce
        rules:
          - allow:
              operation_type: query
              fields:
                - viewer
                - repository
                - organization
                - search
                - rateLimit
                - node
                - nodes
        deny_rules:
          - operation_type: mutation
            fields:
              - deleteRepository
              - deleteRef
              - updateBranchProtectionRule
              - createDeployment
              - mergePullRequest
    binaries:
      - path: /usr/bin/gh
      - path: /usr/local/bin/gh
      - path: /usr/bin/python*
      - path: /usr/local/bin/python*
```

Railway destructive-operation guardrail shape:

```yaml
network_policies:
  railway_graphql_guardrails:
    endpoints:
      - host: backboard.railway.app
        port: 443
        path: /graphql/v2
        protocol: graphql
        enforcement: enforce
        rules:
          - allow:
              operation_type: query
              fields: [viewer, project, projects, environment, service, deployment]
          - allow:
              operation_type: mutation
              fields: [deploymentRedeploy, deploymentCancel]
        deny_rules:
          - operation_type: mutation
            fields: [volumeDelete, serviceDelete, projectDelete, environmentDelete, databaseDelete]
    binaries:
      - path: /usr/bin/curl
      - path: /usr/bin/python*
      - path: /usr/local/bin/python*
```

Shopify Admin GraphQL read-first shape:

```yaml
network_policies:
  shopify_admin_graphql_review:
    endpoints:
      - host: my-store.myshopify.com
        port: 443
        path: /admin/api/*/graphql.json
        protocol: graphql
        enforcement: enforce
        rules:
          - allow:
              operation_type: query
              fields:
                - shop
                - products
                - product
                - orders
                - order
                - customers
                - customer
        deny_rules:
          - operation_type: mutation
            fields:
              - '*Delete'
              - bulkOperationRunMutation
              - inventoryAdjustQuantities
              - orderCancel
              - refundCreate
    binaries:
      - path: /usr/bin/node
      - path: /usr/local/bin/node
      - path: /usr/bin/python*
      - path: /usr/local/bin/python*
```

Hash-only / saved-query shape with a trusted registry:

```yaml
network_policies:
  railway_registered_graphql:
    endpoints:
      - host: backboard.railway.app
        port: 443
        path: /graphql/v2
        protocol: graphql
        enforcement: enforce
        persisted_queries: allow_registered
        graphql_persisted_queries:
          railwayProjectReadV1:
            operation_type: query
            operation_name: Project
            fields: [project]
          abc123trustedhash:
            operation_type: query
            operation_name: Viewer
            fields: [viewer]
        rules:
          - allow:
              operation_type: query
              fields: [project, projects, environment, service, viewer]
        deny_rules:
          - operation_type: mutation
            fields: [volumeDelete, serviceDelete, projectDelete, environmentDelete]
    binaries:
      - path: /usr/bin/python*
      - path: /usr/local/bin/python*
```

Behavior to review:
- Full-document GraphQL requests are classified from the HTTP body or GET query string.
- When a host has both REST and GraphQL L7 endpoints, OpenShell selects the most specific matching endpoint path before applying protocol-specific policy.
- For GitHub, `POST https://api.github.com/graphql` is evaluated by the `/graphql` GraphQL endpoint; `GET https://api.github.com/repos/NVIDIA/OpenShell/issues` is evaluated by the `/repos/NVIDIA/OpenShell/**` REST endpoint.
- Duplicate GraphQL GET control params are rejected fail-closed.
- Hash-only or saved-query-only requests are denied unless `persisted_queries: allow_registered` is set and the hash or saved-query ID appears in `graphql_persisted_queries`.
- Registered persisted queries are evaluated as the registered operation metadata, not as an opaque allow-all bypass.
- Batched requests are fail-closed: one malformed, denied, destructive, or unregistered operation denies the whole HTTP request.

### Deviations from Plan
- Implemented operation type, operation name, root fields, and persisted-query registry together rather than splitting Phase 1/Phase 2.
- Added endpoint `path` matching so `protocol: rest` and `protocol: graphql` can coexist under the same host and port.

## Testing
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated

**Tests added:**
- **Unit:** GraphQL classifier tests in `crates/openshell-sandbox/src/l7/graphql.rs`; policy validation/access preset tests in `crates/openshell-sandbox/src/l7/mod.rs`; GraphQL OPA allow/deny/persisted-query tests in `crates/openshell-sandbox/src/opa.rs`; YAML/proto round-trip test in `crates/openshell-policy/src/lib.rs`.
- **Integration:** N/A.
- **E2E:** `e2e/rust/tests/forward_proxy_graphql_l7.rs` covers GraphQL L7 enforcement over both forward-proxy and CONNECT-proxy paths, including duplicate GET control params, persisted-query registry behavior, and chunked bodies.

## Checklist
- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)

**Documentation updated:**
- `architecture/sandbox.md`: GraphQL classifier, endpoint `path`, and L7 flow updates.
- `architecture/security-policy.md`: GraphQL schema, endpoint `path`, and enforcement behavior.
- `docs/reference/policy-schema.mdx`: policy schema fields, including endpoint `path`.
- `docs/sandboxes/policies.mdx`: user policy examples, service shapes, and mixed REST/GraphQL host examples.
- `docs/get-started/tutorials/github-sandbox.mdx`: GitHub REST and GraphQL endpoints split by path.
- `docs/security/best-practices.mdx`: GraphQL L7 recommendations.
