### PR TITLE
ci: add Podman e2e workflow and gate

### DIFF
--- a/.github/workflows/branch-e2e-podman.yml
+++ b/.github/workflows/branch-e2e-podman.yml
@@ -1,0 +1,36 @@
+name: Branch E2E Podman
+
+# Triggered by copy-pr-bot when a PR push arrives. Runs the rootless-Podman
+# smoke suite when the PR carries the `test:e2e-podman` label. The result is
+# checked by the E2E Gate (`e2e-gate.yml`) before merge.
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  pr_metadata:
+    name: Resolve PR metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: gate
+        uses: ./.github/actions/pr-gate
+        with:
+          required_label: test:e2e-podman
+
+  e2e-podman:
+    needs: [pr_metadata]
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/e2e-podman.yml

--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
   workflow_run:
-    workflows: ["Branch E2E Checks", "GPU Test"]
+    workflows: ["Branch E2E Checks", "GPU Test", "Branch E2E Podman"]
     types: [completed]
 
 permissions: {}
@@ -35,6 +35,18 @@ jobs:
     with:
       required_label: test:e2e-gpu
       workflow_file: test-gpu.yml
+
+  podman:
+    name: Podman E2E
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: read
+    uses: ./.github/workflows/e2e-gate-check.yml
+    with:
+      required_label: test:e2e-podman
+      workflow_file: branch-e2e-podman.yml
 
   # When the guarded workflow finishes, GitHub fires `workflow_run` in the
   # default-branch context — any check posted from here would land on `main`,

--- a/.github/workflows/e2e-podman.yml
+++ b/.github/workflows/e2e-podman.yml
@@ -1,0 +1,88 @@
+name: E2E Podman Test
+
+# Reusable workflow: start a rootless-Podman-backed gateway on the bare runner
+# (no Docker-in-Docker, no k3s) and run the Rust smoke suite against it.
+#
+# Unlike the k3s e2e, this runs directly on the runner host so that rootless
+# Podman user-namespaces are available. Binaries are compiled natively on the
+# runner; only the final scratch packaging step uses the container engine.
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: "GitHub Actions runner label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-podman:
+    name: "E2E (podman)"
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Enable rootless Podman socket
+        run: |
+          systemctl --user start podman.socket
+          podman info
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
+        with:
+          experimental: true
+
+      - name: Install tools
+        run: mise install --locked
+
+      - name: Cache Rust target and registry
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: rust-podman-e2e
+          cache-directories: .cache/sccache
+
+      - name: Install system build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libz3-dev \
+            openssh-client
+          sudo rm -rf /var/lib/apt/lists/*
+
+      # Build the sandbox binary (release) for the supervisor sideload image.
+      # No dev-settings needed — the sandbox doesn't use settings registry features.
+      - name: Build openshell-sandbox (release)
+        run: cargo build --release -p openshell-sandbox
+
+      # Stage the prebuilt binary where the Dockerfile expects it.
+      - name: Stage prebuilt supervisor binary
+        run: |
+          mkdir -p deploy/docker/.build/prebuilt-binaries/amd64/
+          cp target/release/openshell-sandbox deploy/docker/.build/prebuilt-binaries/amd64/
+
+      # Build the scratch image from the staged binary (skips cargo-in-Docker).
+      - name: Build supervisor sideload image
+        env:
+          USE_PREBUILT_BINARIES: "true"
+        run: mise run --no-deps --skip-deps build:docker:supervisor-sideload
+
+      # Pre-build gateway and CLI so the e2e script finds them and skips its
+      # own cargo build. Both need dev-settings for the settings management
+      # test fixtures. Debug profile matches what the e2e script expects.
+      - name: Build openshell-gateway and openshell-cli (debug, dev-settings)
+        run: cargo build -p openshell-server -p openshell-cli --features openshell-core/dev-settings
+
+      - name: Run Podman e2e smoke test
+        env:
+          MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mise run --no-deps --skip-deps e2e:podman
+
+      - name: sccache stats
+        if: always()
+        run: mise x -- sccache --show-stats


### PR DESCRIPTION
## Summary

Right now the podman support is pretty new, and we didn't add automatic CI runs for it. A lot of us would like to productize it more, so let's ensure we're gating CI changes.

I had my agent attempt to mirror the existing CI setup, but I'll be honest there are some things there I don't fully understand around the custom runners etc.

## Related Issue

None.

## Changes

Add a new CI flow.

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
