### PR TITLE
fix: allow Anthropic token counting through inference router

### DIFF
--- a/architecture/inference-routing.md
+++ b/architecture/inference-routing.md
@@ -136,6 +136,7 @@ Supported built-in patterns:
 | `POST` | `/v1/completions` | `openai_completions` | `completion` |
 | `POST` | `/v1/responses` | `openai_responses` | `responses` |
 | `POST` | `/v1/messages` | `anthropic_messages` | `messages` |
+| `POST` | `/v1/messages/count_tokens` | `anthropic_messages` | `messages_count_tokens` |
 | `GET` | `/v1/models` | `model_discovery` | `models_list` |
 | `GET` | `/v1/models/*` | `model_discovery` | `models_get` |
 

--- a/crates/openshell-sandbox/src/l7/inference.rs
+++ b/crates/openshell-sandbox/src/l7/inference.rs
@@ -44,6 +44,12 @@ pub fn default_patterns() -> Vec<InferenceApiPattern> {
             kind: "messages".to_string(),
         },
         InferenceApiPattern {
+            method: "POST".to_string(),
+            path_glob: "/v1/messages/count_tokens".to_string(),
+            protocol: "anthropic_messages".to_string(),
+            kind: "messages_count_tokens".to_string(),
+        },
+        InferenceApiPattern {
             method: "GET".to_string(),
             path_glob: "/v1/models".to_string(),
             protocol: "model_discovery".to_string(),
@@ -405,6 +411,15 @@ mod tests {
         let result = detect_inference_pattern("POST", "/v1/messages", &patterns);
         assert!(result.is_some());
         assert_eq!(result.unwrap().protocol, "anthropic_messages");
+    }
+
+    #[test]
+    fn detect_anthropic_count_tokens() {
+        let patterns = default_patterns();
+        let result = detect_inference_pattern("POST", "/v1/messages/count_tokens", &patterns);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().protocol, "anthropic_messages");
+        assert_eq!(result.unwrap().kind, "messages_count_tokens");
     }
 
     #[test]

--- a/docs/inference/about.mdx
+++ b/docs/inference/about.mdx
@@ -53,6 +53,7 @@ Supported request patterns depend on the provider configured for `inference.loca
 | Pattern | Method | Path |
 |---|---|---|
 | Messages | `POST` | `/v1/messages` |
+| Token Counting | `POST` | `/v1/messages/count_tokens` |
 
 </Tab>
 


### PR DESCRIPTION
## Summary

- allow Anthropic-compatible `POST /v1/messages/count_tokens` requests through the `inference.local` classifier
- keep the token-counting request on the existing `anthropic_messages` protocol so it routes to the configured Anthropic-compatible backend
- document the supported token-counting path in the inference routing architecture docs and user docs

## Why

Claude SDK uses `/v1/messages/count_tokens` when talking to Anthropic-compatible endpoints. OpenShell already routed `/v1/messages`, but the sandbox classifier rejected the token-counting endpoint before normal route selection, so valid SDK traffic to `inference.local` failed even when the backend/provider configuration was otherwise correct.

## Validation

- `cargo test -p openshell-sandbox detect_anthropic_count_tokens`
