### PR TITLE
chore(ci): label mon maintainer issues for triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,6 +8,63 @@ permissions:
   issues: write
 
 jobs:
+  label-mon-maintainer-issues:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'NVIDIA'
+    env:
+      ORG_READ_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
+    steps:
+      - name: Require org read token
+        if: env.ORG_READ_TOKEN == ''
+        run: |
+          echo "::error::ORG_READ_TOKEN is required to check mon-maintainers membership."
+          exit 1
+
+      - name: Check mon-maintainers membership
+        id: mon-maintainer
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ORG_READ_TOKEN }}
+          result-encoding: string
+          script: |
+            const author = context.payload.issue.user.login;
+
+            try {
+              const { data } = await github.rest.teams.getMembershipForUserInOrg({
+                org: context.repo.owner,
+                team_slug: 'mon-maintainers',
+                username: author,
+              });
+
+              if (data.state === 'active') {
+                console.log(`${author} is an active mon-maintainers member.`);
+                return 'true';
+              }
+
+              console.log(`${author} has mon-maintainers membership state: ${data.state}`);
+            } catch (e) {
+              if (e.status === 404) {
+                console.log(`${author} is not a mon-maintainers member.`);
+                return 'false';
+              }
+
+              throw e;
+            }
+
+            return 'false';
+
+      - name: Add triage label
+        if: steps.mon-maintainer.outputs.result == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['state:triage-needed'],
+            });
+
   check-agent-diagnostic:
     runs-on: ubuntu-latest
     # Only run on bug reports (title starts with "bug:")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,7 @@ Skills connect into pipelines. Individual skill files don't describe these relat
 - **Policy iteration:** `openshell-cli` → `generate-sandbox-policy`
 
 Workflow state labels use the `state:*` prefix, and security work uses `topic:security`. GitHub issue templates assign built-in issue types where applicable, and agent-created issues should use issue types or manual follow-up rather than type labels.
+New issues opened by members of the `mon-maintainers` GitHub team are automatically labeled `state:triage-needed` by the issue triage workflow.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Automatically label newly opened issues from active `mon-maintainers` team members with `state:triage-needed` so they enter the standard triage queue.

## Related Issue

None.

## Changes

- Added an issue triage workflow job that checks `mon-maintainers` membership with `ORG_READ_TOKEN`.
- Added `state:triage-needed` when the issue author is an active team member.
- Documented the automatic labeling behavior in `CONTRIBUTING.md`.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)