### PR TITLE
chore(ci): label maintainer issues by repo permission

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,43 +8,34 @@ permissions:
   issues: write
 
 jobs:
-  label-mon-maintainer-issues:
+  label-maintainer-issues:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'NVIDIA'
-    env:
-      ORG_READ_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
     steps:
-      - name: Require org read token
-        if: env.ORG_READ_TOKEN == ''
-        run: |
-          echo "::error::ORG_READ_TOKEN is required to check mon-maintainers membership."
-          exit 1
-
-      - name: Check mon-maintainers membership
-        id: mon-maintainer
+      - name: Check maintainer permissions
+        id: maintainer
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.ORG_READ_TOKEN }}
           result-encoding: string
           script: |
             const author = context.payload.issue.user.login;
 
             try {
-              const { data } = await github.rest.teams.getMembershipForUserInOrg({
-                org: context.repo.owner,
-                team_slug: 'mon-maintainers',
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
                 username: author,
               });
 
-              if (data.state === 'active') {
-                console.log(`${author} is an active mon-maintainers member.`);
+              if (['admin', 'maintain', 'write'].includes(data.permission)) {
+                console.log(`${author} has maintainer permissions: ${data.permission}.`);
                 return 'true';
               }
 
-              console.log(`${author} has mon-maintainers membership state: ${data.state}`);
+              console.log(`${author} does not have maintainer permissions: ${data.permission}.`);
             } catch (e) {
               if (e.status === 404) {
-                console.log(`${author} is not a mon-maintainers member.`);
+                console.log(`${author} is not a repository collaborator.`);
                 return 'false';
               }
 
@@ -54,7 +45,7 @@ jobs:
             return 'false';
 
       - name: Add triage label
-        if: steps.mon-maintainer.outputs.result == 'true'
+        if: steps.maintainer.outputs.result == 'true'
         uses: actions/github-script@v7
         with:
           script: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Skills connect into pipelines. Individual skill files don't describe these relat
 - **Policy iteration:** `openshell-cli` → `generate-sandbox-policy`
 
 Workflow state labels use the `state:*` prefix, and security work uses `topic:security`. GitHub issue templates assign built-in issue types where applicable, and agent-created issues should use issue types or manual follow-up rather than type labels.
-New issues opened by members of the `mon-maintainers` GitHub team are automatically labeled `state:triage-needed` by the issue triage workflow.
+New issues opened by repository collaborators with `write`, `maintain`, or `admin` permission are automatically labeled `state:triage-needed` by the issue triage workflow.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Fix the issue triage workflow so maintainer-authored issues are detected by repository permission instead of membership in the `mon-maintainers` team. This matches the existing maintainer check used by the vouch command workflow and covers maintainers like `drew`, who has `admin` permission but is not returned as a `mon-maintainers` team member.

## Related Issue

Refs #1113 as the observed failure case; this PR does not close the issue itself.

## Changes

- Replaced the `mon-maintainers` team membership lookup with `repos.getCollaboratorPermissionLevel`.
- Treat `write`, `maintain`, and `admin` as maintainer permissions for automatic `state:triage-needed` labeling.
- Updated `CONTRIBUTING.md` to document the permission-based behavior.

## Testing

- [x] `mise run pre-commit` passes
- [x] Verified `gh api repos/NVIDIA/OpenShell/collaborators/drew/permission` returns `admin`
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)