### PR TITLE
fix(sandbox): invalidate stale l7 tunnels after reload

### DIFF
--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -292,18 +292,22 @@ The proxy calls `evaluate_network_action()` (not `evaluate_network()`) as its ma
 
 ### L7 endpoint config query
 
-After L4 allows a connection, `query_endpoint_config(input)` evaluates `data.openshell.sandbox.matched_endpoint_config` to get the full endpoint object. If the endpoint has a `protocol` field, `l7::parse_l7_config()` extracts the L7 config for protocol-aware inspection.
+After L4 allows a connection, `query_endpoint_config_with_generation(input)` evaluates `data.openshell.sandbox.matched_endpoint_config` to get the full endpoint object and the policy generation used for the query. If the endpoint has a `protocol` field, `l7::parse_l7_config()` extracts the L7 config for protocol-aware inspection.
 
 ### Engine cloning for L7
 
-`clone_engine_for_tunnel()` clones the inner `regorus::Engine`. With the `arc` feature, this shares compiled policy via `Arc` and only duplicates interpreter state (microseconds). The cloned engine is wrapped in its own `std::sync::Mutex` and used by the L7 relay without contention on the main engine.
+`clone_engine_for_tunnel(expected_generation)` clones the inner `regorus::Engine` only if the current policy generation still matches the endpoint config generation captured above. With the `arc` feature, this shares compiled policy via `Arc` and only duplicates interpreter state (microseconds). The cloned engine is wrapped in a generation-bound `TunnelPolicyEngine` and used by the L7 relay without contention on the main engine.
+
+The L7 relay checks the captured generation before parsing, evaluating, and forwarding each request. If a policy reload has advanced the shared generation, the relay closes the tunnel before forwarding more bytes. This applies live policy changes to the next L7 request on a keep-alive tunnel and avoids pairing stale endpoint config with a newer policy engine. HTTP passthrough tunnels without endpoint `protocol` are also generation-bound so credential-injection-only keep-alive tunnels close after a reload before forwarding another request.
+
+Raw streams are connection-scoped and outside the L7 live-reload guarantee. This includes `tls: skip`, binary/non-HTTP CONNECT tunnels, SQL audit fallback passthrough, HTTP upgrades such as WebSocket after `101 Switching Protocols`, and already-forwarded long-lived response bodies such as SSE. Policy reloads affect the next connection or the next parsed HTTP request; they do not interrupt raw byte streams that have already moved outside the request parser.
 
 ### Hot reload
 
 Two reload methods exist:
 
 - **`reload(policy, data_yaml)`**: Builds a new engine from raw Rego + YAML strings and atomically replaces the inner engine. Used in tests and by the file-mode path.
-- **`reload_from_proto(proto)`**: Builds a new engine through the same validated pipeline as `from_proto()` -- proto-to-JSON conversion, L7 validation, access preset expansion -- then atomically swaps the inner `regorus::Engine`. On success, all subsequent `evaluate_network_action()` and `query_endpoint_config()` calls use the new policy. On failure (e.g., L7 validation errors), the previous engine is untouched (last-known-good behavior). This is the method used by the policy poll loop for live reloads in gRPC mode.
+- **`reload_from_proto(proto)`**: Builds a new engine through the same validated pipeline as `from_proto()` -- proto-to-JSON conversion, L7 validation, access preset expansion -- then atomically swaps the inner `regorus::Engine`. On success, all subsequent `evaluate_network_action()` and `query_endpoint_config()` calls use the new policy, and the engine generation increments so active L7 tunnels close before forwarding another request under stale state. On failure (e.g., L7 validation errors), the previous engine and generation are untouched (last-known-good behavior). This is the method used by the policy poll loop for live reloads in gRPC mode.
 
 Both methods hold the `Mutex` only for the final swap (`*engine = new_engine`), so evaluation is blocked for only the duration of a pointer-sized assignment.
 
@@ -962,7 +966,7 @@ flowchart TD
 
 After a CONNECT is allowed, the SSRF check passes, and the upstream TCP connection is established, the proxy determines how to handle the tunnel traffic. TLS detection is automatic — the proxy peeks the first bytes of the client stream to decide.
 
-1. **Query L7 config**: `query_l7_config()` asks the OPA engine for `matched_endpoint_config`. If the endpoint has a `protocol` field, parse it into `L7EndpointConfig`.
+1. **Query L7 route**: `query_l7_route_snapshot()` asks the OPA engine for `matched_endpoint_config` and the current policy generation. If the endpoint has a `protocol` field, parse it into a generation-bound `L7ConfigSnapshot`. If the endpoint has no `protocol`, retain the generation for HTTP passthrough keep-alive tunnels.
 
 2. **Check for `tls: skip`**: If the endpoint has `tls: skip`, bypass all auto-detection and relay raw bytes via `copy_bidirectional()`. This is the escape hatch for client-cert mTLS or non-standard protocols.
 
@@ -970,15 +974,15 @@ After a CONNECT is allowed, the SSRF check passes, and the upstream TCP connecti
 
 4. **TLS detected** (`is_tls = true`):
    - Terminate TLS unconditionally via `tls_terminate_client()` + `tls_connect_upstream()`. This happens for all HTTPS endpoints, not just those with L7 config.
-   - If L7 config is present: clone the OPA engine (`clone_engine_for_tunnel()`), run `relay_with_inspection()` for per-request policy evaluation.
-   - If no L7 config: run `relay_passthrough_with_credentials()` — parses HTTP minimally to inject credentials (via `SecretResolver`) and log requests, but does not evaluate L7 OPA rules. This enables credential injection on all HTTPS endpoints without requiring `protocol` in the policy.
+   - If L7 config is present: clone the OPA engine for the captured generation (`clone_engine_for_tunnel(generation)`), run `relay_with_inspection()` for per-request policy evaluation. If the generation changed between config lookup and clone, close the tunnel before inspection.
+   - If no L7 config: run `relay_passthrough_with_credentials()` — parses HTTP minimally to inject credentials (via `SecretResolver`) and log requests, but does not evaluate L7 OPA rules. The passthrough relay is bound to the policy generation captured at connection setup and closes before forwarding another request after a reload. This enables credential injection on all HTTPS endpoints without requiring `protocol` in the policy.
    - If TLS state is not configured: fall back to raw `copy_bidirectional()` with a warning.
 
 5. **Plaintext HTTP detected** (`is_http = true`, `is_tls = false`):
-   - If L7 config present: clone OPA engine, run `relay_with_inspection()` directly on the plaintext streams.
-   - If no L7 config: run `relay_passthrough_with_credentials()` for credential injection and observability.
+   - If L7 config present: clone the OPA engine for the captured generation, run `relay_with_inspection()` directly on the plaintext streams.
+   - If no L7 config: run `relay_passthrough_with_credentials()` for credential injection and observability, with the same per-request generation guard.
 
-6. **Neither TLS nor HTTP**: Raw `copy_bidirectional()` tunnel (binary protocols, SSH-over-CONNECT, etc.).
+6. **Neither TLS nor HTTP**: Raw `copy_bidirectional()` tunnel (binary protocols, SSH-over-CONNECT, etc.). These raw streams are connection-scoped and continue until either side closes; live policy reload does not interrupt them.
 
 ```mermaid
 flowchart TD
@@ -1002,7 +1006,7 @@ flowchart TD
 
 **Files:** `crates/openshell-sandbox/src/l7/`
 
-The L7 subsystem inspects application-layer traffic within CONNECT tunnels. Instead of raw `copy_bidirectional`, each request is parsed, evaluated against OPA rules, and either forwarded or blocked.
+The L7 subsystem inspects application-layer traffic within CONNECT tunnels. Instead of raw `copy_bidirectional`, each request is parsed, evaluated against OPA rules, and either forwarded or blocked. The relay uses a generation-bound policy snapshot; after a successful policy reload, an existing L7 keep-alive tunnel closes before forwarding another request. Once an HTTP request has upgraded into a raw stream, or when a response body is a long-lived stream, that stream is connection-scoped and is not interrupted by L7 live reload.
 
 ### Architecture
 
@@ -1244,6 +1248,8 @@ Implements `L7Provider` for HTTP/1.1:
 5. Log the L7 decision (tagged `L7_REQUEST`) using the redacted target — real credential values never appear in logs
 6. If allowed (or audit mode): relay request to upstream via `relay_http_request_with_resolver()` (which rewrites all remaining credential placeholders in headers, query parameters, path segments, and Basic auth tokens) and relay the response back to client, then loop
 7. If denied in enforce mode: send 403 (using redacted target in the response body) and close the connection
+
+Before parsing, before evaluation, and before forwarding each request, the relay checks whether its captured policy generation still matches the shared engine generation. If not, it emits a denied OCSF network event and closes the tunnel without forwarding the request.
 
 ## Process Identity
 

--- a/architecture/security-policy.md
+++ b/architecture/security-policy.md
@@ -203,7 +203,7 @@ The poll loop:
 2. Fetches the current policy via `GetSandboxSettings`, which returns the latest version, its policy payload, and a SHA-256 hash.
 3. Compares the returned version against the locally tracked `current_version`. If the server version is not greater, the loop sleeps and retries.
 4. On a new version, calls `OpaEngine::reload_from_proto()` which builds a complete new `regorus::Engine` through the same validated pipeline as the initial load (proto-to-JSON conversion, L7 validation, access preset expansion).
-5. If the new engine builds successfully, it atomically replaces the inner `Mutex<regorus::Engine>`. If it fails, the previous engine is untouched.
+5. If the new engine builds successfully, it atomically replaces the inner `Mutex<regorus::Engine>` and increments the policy generation. Active L7 keep-alive tunnels close before forwarding another request after they observe the new generation. If reload fails, the previous engine and generation are untouched.
 6. Reports success or failure back to the server via `ReportPolicyStatus`.
 
 See `crates/openshell-sandbox/src/grpc_client.rs` -- `CachedOpenShellClient`.
@@ -723,7 +723,11 @@ flowchart LR
 
 This is the single most important behavioral trigger in the policy language. An endpoint with no `protocol` field passes traffic opaquely after the L4 (CONNECT) check. Adding `protocol: rest` activates per-request HTTP parsing and policy evaluation inside the proxy.
 
-**Implementation path**: After L4 CONNECT is allowed, the proxy calls `query_l7_config()` which evaluates the Rego rule `data.openshell.sandbox.matched_endpoint_config`. This rule only matches endpoints that have a `protocol` field set (see `sandbox-policy.rego` line `ep.protocol`). If a config is returned, the proxy enters `relay_with_inspection()` instead of `copy_bidirectional()`. See `crates/openshell-sandbox/src/proxy.rs` -- `handle_tcp_connection()`.
+**Implementation path**: After L4 CONNECT is allowed, the proxy calls `query_l7_route_snapshot()` which evaluates the Rego rule `data.openshell.sandbox.matched_endpoint_config` and records the policy generation. If an endpoint `protocol` config is returned, the proxy enters `relay_with_inspection()` instead of `copy_bidirectional()`. See `crates/openshell-sandbox/src/proxy.rs` -- `handle_tcp_connection()`.
+
+For L7-inspected CONNECT tunnels, the proxy binds endpoint config and the per-tunnel policy engine clone to the policy generation observed at tunnel setup. If a live policy reload advances the generation, the relay closes the existing keep-alive tunnel before forwarding another request. HTTP passthrough tunnels without endpoint `protocol` use the same generation guard for parsed requests even though they do not evaluate L7 OPA rules. Clients should reconnect so the next request is evaluated under the current policy.
+
+Raw streams are connection-scoped and outside L7 live-reload guarantees. This includes endpoints with `tls: skip`, non-HTTP CONNECT payloads, SQL audit fallback passthrough, HTTP upgrades after `101 Switching Protocols`, and already-forwarded streaming response bodies such as SSE. A policy reload applies to the next connection or next parsed HTTP request; it does not terminate raw bytes already relayed outside the HTTP request parser.
 
 **Validation requirement**: When `protocol` is set, either `rules` or `access` must also be present. An endpoint with `protocol` but no rules/access is rejected at validation time because it would deny all traffic (no allow rules means nothing matches). See `crates/openshell-sandbox/src/l7/mod.rs` -- `validate_l7_policies()`.
 
@@ -758,9 +762,9 @@ If any condition fails, the proxy returns `403 Forbidden`.
 5. Resolves DNS and validates all IPs are private and within `allowed_ips`
 6. Connects to upstream
 7. Rewrites the request: absolute-form → origin-form (`GET /path HTTP/1.1`), strips hop-by-hop headers, adds `Via: 1.1 openshell-sandbox` and `Connection: close`
-8. Forwards the rewritten request, then relays bidirectionally using `tokio::io::copy_bidirectional` (supports chunked transfer, SSE streams, and other long-lived responses with no idle timeout)
+8. Relays the rewritten request and response through the shared guarded HTTP relay. This reuses the same request body framing, CL/TE rejection, credential rewrite fail-closed behavior, unsolicited `101` blocking, and policy-generation checks as CONNECT L7 HTTP.
 
-**V1 simplifications**: Forward proxy v1 injects `Connection: close` (no keep-alive). Every forward proxy connection handles exactly one request-response exchange. When an endpoint has L7 rules configured, the forward proxy evaluates the single request's method and path against L7 policy before forwarding.
+**V1 simplifications**: Forward proxy v1 injects `Connection: close` (no keep-alive). Every forward proxy connection handles exactly one request-response exchange. The request is bound to the policy generation used for the L4 allow decision and is checked again before upstream connect and request forwarding. When an endpoint has L7 rules configured, the forward proxy also evaluates the single request's method and path against L7 policy before forwarding.
 
 **Implementation**: See `crates/openshell-sandbox/src/proxy.rs` -- `handle_forward_proxy()`, `parse_proxy_uri()`, `rewrite_forward_request()`.
 
@@ -785,7 +789,7 @@ flowchart TD
     K -- No --> L["403 Forbidden"]
     K -- Yes --> M["TCP connect to upstream"]
     M --> N["Rewrite request to origin-form<br/>Add Via + Connection: close"]
-    N --> O["Forward request + copy_bidirectional"]
+    N --> O["Guarded HTTP relay"]
 ```
 
 #### Example: Forward Proxy Policy
@@ -836,7 +840,7 @@ TLS termination is automatic. The proxy peeks the first bytes of every CONNECT t
 
 **Certificate caching**: Per-hostname leaf certificates are cached (up to 256 entries, then the entire cache is cleared). See `crates/openshell-sandbox/src/l7/tls.rs` -- `CertCache`.
 
-**Credential injection**: When TLS is auto-terminated but no L7 policy is configured (no `protocol` field), the proxy enters a passthrough relay that rewrites credential placeholders in HTTP headers (via `SecretResolver`) and logs requests for observability, but does not evaluate L7 OPA rules. This means credential injection works on all HTTPS endpoints automatically.
+**Credential injection**: When TLS is auto-terminated but no L7 policy is configured (no `protocol` field), the proxy enters a passthrough relay that rewrites credential placeholders in HTTP headers (via `SecretResolver`) and logs requests for observability, but does not evaluate L7 OPA rules. The relay still closes parsed keep-alive HTTP tunnels after policy generation changes before forwarding another request. This means credential injection works on all HTTPS endpoints automatically.
 
 **Validation warnings**:
 
@@ -972,9 +976,11 @@ sequenceDiagram
     OPA-->>Proxy: allowed=true, matched_policy="api_policy"
     Proxy-->>Client: 200 Connection Established
 
-    Note over Proxy: Query L7 config for matched endpoint
-    Proxy->>OPA: query_endpoint_config(host, port, binary)
-    OPA-->>Proxy: {protocol: rest, enforcement: enforce}
+    Note over Proxy: Query L7 config and generation for matched endpoint
+    Proxy->>OPA: query_endpoint_config_with_generation(host, port, binary)
+    OPA-->>Proxy: {protocol: rest, enforcement: enforce}, generation=N
+    Proxy->>OPA: clone_engine_for_tunnel(generation=N)
+    OPA-->>Proxy: generation-bound tunnel evaluator
 
     Note over Proxy: Auto-detect TLS (peek first bytes)
     Note over Proxy: TLS ClientHello detected → terminate
@@ -988,9 +994,12 @@ sequenceDiagram
 
     loop Per HTTP request in tunnel
         Client->>Proxy: GET /repos/myorg/foo HTTP/1.1
+        Note over Proxy: Close if policy generation changed
         Note over Proxy: Parse HTTP request line + headers
+        Note over Proxy: Close if policy generation changed
         Proxy->>OPA: allow_request(method=GET, path=/repos/myorg/foo)
         OPA-->>Proxy: allowed=true
+        Note over Proxy: Close if policy generation changed
         Proxy->>Upstream: GET /repos/myorg/foo HTTP/1.1
         Upstream-->>Proxy: 200 OK (response body)
         Proxy-->>Client: 200 OK (response body)

--- a/crates/openshell-sandbox/src/l7/relay.rs
+++ b/crates/openshell-sandbox/src/l7/relay.rs
@@ -9,13 +9,14 @@
 
 use crate::l7::provider::{L7Provider, RelayOutcome};
 use crate::l7::{EnforcementMode, L7EndpointConfig, L7Protocol, L7RequestInfo};
+use crate::opa::{PolicyGenerationGuard, TunnelPolicyEngine};
 use crate::secrets::{self, SecretResolver};
 use miette::{IntoDiagnostic, Result, miette};
 use openshell_ocsf::{
     ActionId, ActivityId, DispositionId, Endpoint, HttpActivityBuilder, HttpRequest,
     NetworkActivityBuilder, SeverityId, StatusId, Url as OcsfUrl, ocsf_emit,
 };
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tracing::{debug, warn};
 
@@ -90,7 +91,7 @@ fn emit_parse_rejection(ctx: &L7EvalContext, detail: &str, engine_type: &str) {
 /// caller peeks on the raw `TcpStream` before calling this.
 pub async fn relay_with_inspection<C, U>(
     config: &L7EndpointConfig,
-    engine: Mutex<regorus::Engine>,
+    engine: TunnelPolicyEngine,
     client: &mut C,
     upstream: &mut U,
     ctx: &L7EvalContext,
@@ -102,6 +103,9 @@ where
     match config.protocol {
         L7Protocol::Rest => relay_rest(config, &engine, client, upstream, ctx).await,
         L7Protocol::Sql => {
+            if close_if_stale(engine.generation_guard(), ctx) {
+                return Ok(());
+            }
             // SQL provider is Phase 3 — fall through to passthrough with warning
             {
                 let event = NetworkActivityBuilder::new(crate::ocsf_ctx())
@@ -126,7 +130,7 @@ where
 /// switches to raw bidirectional TCP copy for the upgraded protocol (WebSocket,
 /// HTTP/2, etc.). L7 policy enforcement does not apply after the upgrade —
 /// the initial HTTP request was already evaluated.
-async fn handle_upgrade<C, U>(
+pub(crate) async fn handle_upgrade<C, U>(
     client: &mut C,
     upstream: &mut U,
     overflow: Vec<u8>,
@@ -163,7 +167,7 @@ where
 /// REST relay loop: parse request -> evaluate -> allow/deny -> relay response -> repeat.
 async fn relay_rest<C, U>(
     config: &L7EndpointConfig,
-    engine: &Mutex<regorus::Engine>,
+    engine: &TunnelPolicyEngine,
     client: &mut C,
     upstream: &mut U,
     ctx: &L7EvalContext,
@@ -181,6 +185,10 @@ where
             ..Default::default()
         });
     loop {
+        if close_if_stale(engine.generation_guard(), ctx) {
+            return Ok(());
+        }
+
         // Parse one HTTP request from client
         let req = match provider.parse_request(client).await {
             Ok(Some(req)) => req,
@@ -201,6 +209,10 @@ where
                 return Ok(()); // Close connection on parse error
             }
         };
+
+        if close_if_stale(engine.generation_guard(), ctx) {
+            return Ok(());
+        }
 
         // Rewrite credential placeholders in the request target BEFORE OPA
         // evaluation. OPA sees the redacted path; the resolved path goes only
@@ -233,6 +245,10 @@ where
 
         // Evaluate L7 policy via Rego (using redacted target)
         let (allowed, reason) = evaluate_l7_request(engine, ctx, &request_info)?;
+
+        if close_if_stale(engine.generation_guard(), ctx) {
+            return Ok(());
+        }
 
         // Check if this is an upgrade request for logging purposes.
         let header_end = req
@@ -294,11 +310,12 @@ where
 
         if allowed || config.enforcement == EnforcementMode::Audit {
             // Forward request to upstream and relay response
-            let outcome = crate::l7::rest::relay_http_request_with_resolver(
+            let outcome = crate::l7::rest::relay_http_request_with_resolver_guarded(
                 &req,
                 client,
                 upstream,
                 ctx.secret_resolver.as_deref(),
+                Some(engine.generation_guard()),
             )
             .await?;
             match outcome {
@@ -331,6 +348,32 @@ where
     }
 }
 
+fn close_if_stale(guard: &PolicyGenerationGuard, ctx: &L7EvalContext) -> bool {
+    if !guard.is_stale() {
+        return false;
+    }
+
+    ocsf_emit!(
+        NetworkActivityBuilder::new(crate::ocsf_ctx())
+            .activity(ActivityId::Open)
+            .action(ActionId::Denied)
+            .disposition(DispositionId::Blocked)
+            .severity(SeverityId::Medium)
+            .status(StatusId::Failure)
+            .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+            .firewall_rule(&ctx.policy_name, "l7")
+            .message(format!(
+                "L7 tunnel closed after policy reload [host:{} port:{} captured_generation:{} current_generation:{}]",
+                ctx.host,
+                ctx.port,
+                guard.captured_generation(),
+                guard.current_generation(),
+            ))
+            .build()
+    );
+    true
+}
+
 /// Check if a miette error represents a benign connection close.
 ///
 /// TLS handshake EOF, missing `close_notify`, connection resets, and broken
@@ -353,10 +396,18 @@ fn is_benign_connection_error(err: &miette::Report) -> bool {
 ///
 /// Returns `(allowed, deny_reason)`.
 pub fn evaluate_l7_request(
-    engine: &Mutex<regorus::Engine>,
+    engine: &TunnelPolicyEngine,
     ctx: &L7EvalContext,
     request: &L7RequestInfo,
 ) -> Result<(bool, String)> {
+    if engine.is_stale() {
+        return Err(miette!(
+            "L7 tunnel policy generation is stale [captured_generation:{} current_generation:{}]",
+            engine.captured_generation(),
+            engine.current_generation(),
+        ));
+    }
+
     let input_json = serde_json::json!({
         "network": {
             "host": ctx.host,
@@ -375,6 +426,7 @@ pub fn evaluate_l7_request(
     });
 
     let mut engine = engine
+        .engine()
         .lock()
         .map_err(|_| miette!("OPA engine lock poisoned"))?;
 
@@ -412,6 +464,7 @@ pub async fn relay_passthrough_with_credentials<C, U>(
     client: &mut C,
     upstream: &mut U,
     ctx: &L7EvalContext,
+    generation_guard: &PolicyGenerationGuard,
 ) -> Result<()>
 where
     C: AsyncRead + AsyncWrite + Unpin + Send,
@@ -426,6 +479,10 @@ where
     let resolver = ctx.secret_resolver.as_deref();
 
     loop {
+        if close_if_stale(generation_guard, ctx) {
+            return Ok(());
+        }
+
         // Read next request from client.
         let req = match provider.parse_request(client).await {
             Ok(Some(req)) => req,
@@ -440,6 +497,10 @@ where
                 return Ok(());
             }
         };
+
+        if close_if_stale(generation_guard, ctx) {
+            return Ok(());
+        }
 
         request_count += 1;
 
@@ -489,9 +550,14 @@ where
         // Forward request with credential rewriting and relay the response.
         // relay_http_request_with_resolver handles both directions: it sends
         // the request upstream and reads the response back to the client.
-        let outcome =
-            crate::l7::rest::relay_http_request_with_resolver(&req, client, upstream, resolver)
-                .await?;
+        let outcome = crate::l7::rest::relay_http_request_with_resolver_guarded(
+            &req,
+            client,
+            upstream,
+            resolver,
+            Some(generation_guard),
+        )
+        .await?;
 
         match outcome {
             RelayOutcome::Reusable => {} // continue loop
@@ -515,6 +581,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::opa::{NetworkInput, OpaEngine};
+    use std::path::PathBuf;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    const TEST_POLICY: &str = include_str!("../../data/sandbox-policy.rego");
 
     #[test]
     fn parse_rejection_detail_adds_l7_hint_for_encoded_slash() {
@@ -546,6 +617,223 @@ mod tests {
         assert_eq!(
             parse_rejection_detail(error, ParseRejectionMode::L7Endpoint),
             error
+        );
+    }
+
+    #[tokio::test]
+    async fn l7_relay_closes_keep_alive_tunnel_after_policy_generation_change() {
+        let initial_data = r#"
+network_policies:
+  rest_api:
+    name: rest_api
+    endpoints:
+      - host: api.example.test
+        port: 8080
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow:
+              method: POST
+              path: "/write"
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let reloaded_data = r#"
+network_policies:
+  rest_api:
+    name: rest_api
+    endpoints:
+      - host: api.example.test
+        port: 8080
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow:
+              method: GET
+              path: "/write"
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, initial_data).unwrap();
+        let input = NetworkInput {
+            host: "api.example.test".into(),
+            port: 8080,
+            binary_path: PathBuf::from("/usr/bin/curl"),
+            binary_sha256: "unused".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+        };
+        let (endpoint_config, generation) = engine
+            .query_endpoint_config_with_generation(&input)
+            .unwrap();
+        let config = crate::l7::parse_l7_config(&endpoint_config.unwrap()).unwrap();
+        let tunnel_engine = engine.clone_engine_for_tunnel(generation).unwrap();
+        let ctx = L7EvalContext {
+            host: "api.example.test".into(),
+            port: 8080,
+            policy_name: "rest_api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+        };
+
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_with_inspection(
+                &config,
+                tunnel_engine,
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+            )
+            .await
+        });
+
+        app.write_all(
+            b"POST /write HTTP/1.1\r\nHost: api.example.test\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        let mut first_upstream = [0u8; 512];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upstream.read(&mut first_upstream),
+        )
+        .await
+        .expect("first request should reach upstream")
+        .unwrap();
+        let first_upstream = String::from_utf8_lossy(&first_upstream[..n]);
+        assert!(first_upstream.starts_with("POST /write HTTP/1.1"));
+
+        upstream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nOK")
+            .await
+            .unwrap();
+
+        let mut first_response = [0u8; 512];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            app.read(&mut first_response),
+        )
+        .await
+        .expect("first response should reach client")
+        .unwrap();
+        let first_response = String::from_utf8_lossy(&first_response[..n]);
+        assert!(first_response.contains("200 OK"));
+
+        engine.reload(TEST_POLICY, reloaded_data).unwrap();
+        app.write_all(
+            b"POST /write HTTP/1.1\r\nHost: api.example.test\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should close stale tunnel")
+            .unwrap()
+            .unwrap();
+
+        let mut second_upstream = [0u8; 128];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upstream.read(&mut second_upstream),
+        )
+        .await
+        .expect("upstream side should close")
+        .unwrap();
+        assert_eq!(n, 0, "stale request must not be forwarded upstream");
+    }
+
+    #[tokio::test]
+    async fn passthrough_relay_closes_keep_alive_tunnel_after_policy_generation_change() {
+        let policy_data = "network_policies: {}\n";
+        let engine = OpaEngine::from_strings(TEST_POLICY, policy_data).unwrap();
+        let generation_guard = engine
+            .generation_guard(engine.current_generation())
+            .unwrap();
+        let ctx = L7EvalContext {
+            host: "api.example.test".into(),
+            port: 8080,
+            policy_name: "rest_api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+        };
+
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_passthrough_with_credentials(
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+                &generation_guard,
+            )
+            .await
+        });
+
+        app.write_all(
+            b"GET /first HTTP/1.1\r\nHost: api.example.test\r\nConnection: keep-alive\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        let mut first_upstream = [0u8; 512];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upstream.read(&mut first_upstream),
+        )
+        .await
+        .expect("first passthrough request should reach upstream")
+        .unwrap();
+        let first_upstream = String::from_utf8_lossy(&first_upstream[..n]);
+        assert!(first_upstream.starts_with("GET /first HTTP/1.1"));
+
+        upstream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nOK")
+            .await
+            .unwrap();
+
+        let mut first_response = [0u8; 512];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            app.read(&mut first_response),
+        )
+        .await
+        .expect("first passthrough response should reach client")
+        .unwrap();
+        let first_response = String::from_utf8_lossy(&first_response[..n]);
+        assert!(first_response.contains("200 OK"));
+
+        engine.reload(TEST_POLICY, policy_data).unwrap();
+        app.write_all(
+            b"GET /second HTTP/1.1\r\nHost: api.example.test\r\nConnection: keep-alive\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("passthrough relay should close stale tunnel")
+            .unwrap()
+            .unwrap();
+
+        let mut second_upstream = [0u8; 128];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upstream.read(&mut second_upstream),
+        )
+        .await
+        .expect("upstream side should close")
+        .unwrap();
+        assert_eq!(
+            n, 0,
+            "stale passthrough request must not be forwarded upstream"
         );
     }
 }

--- a/crates/openshell-sandbox/src/l7/rest.rs
+++ b/crates/openshell-sandbox/src/l7/rest.rs
@@ -8,6 +8,7 @@
 //! and chunked transfer encoding for body framing.
 
 use crate::l7::provider::{BodyLength, L7Provider, L7Request, RelayOutcome};
+use crate::opa::PolicyGenerationGuard;
 use crate::secrets::rewrite_http_header_block;
 use miette::{IntoDiagnostic, Result, miette};
 use std::collections::HashMap;
@@ -340,6 +341,20 @@ where
     C: AsyncRead + AsyncWrite + Unpin,
     U: AsyncRead + AsyncWrite + Unpin,
 {
+    relay_http_request_with_resolver_guarded(req, client, upstream, resolver, None).await
+}
+
+pub(crate) async fn relay_http_request_with_resolver_guarded<C, U>(
+    req: &L7Request,
+    client: &mut C,
+    upstream: &mut U,
+    resolver: Option<&crate::secrets::SecretResolver>,
+    generation_guard: Option<&PolicyGenerationGuard>,
+) -> Result<RelayOutcome>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+    U: AsyncRead + AsyncWrite + Unpin,
+{
     let header_end = req
         .raw_header
         .windows(4)
@@ -349,6 +364,10 @@ where
     let rewrite_result = rewrite_http_header_block(&req.raw_header[..header_end], resolver)
         .map_err(|e| miette!("credential injection failed: {e}"))?;
 
+    if let Some(guard) = generation_guard {
+        guard.ensure_current()?;
+    }
+
     upstream
         .write_all(&rewrite_result.rewritten)
         .await
@@ -356,6 +375,9 @@ where
 
     let overflow = &req.raw_header[header_end..];
     if !overflow.is_empty() {
+        if let Some(guard) = generation_guard {
+            guard.ensure_current()?;
+        }
         upstream.write_all(overflow).await.into_diagnostic()?;
     }
     let overflow_len = overflow.len() as u64;
@@ -364,11 +386,17 @@ where
         BodyLength::ContentLength(len) => {
             let remaining = len.saturating_sub(overflow_len);
             if remaining > 0 {
-                relay_fixed(client, upstream, remaining).await?;
+                relay_fixed(client, upstream, remaining, generation_guard).await?;
             }
         }
         BodyLength::Chunked => {
-            relay_chunked(client, upstream, &req.raw_header[header_end..]).await?;
+            relay_chunked(
+                client,
+                upstream,
+                &req.raw_header[header_end..],
+                generation_guard,
+            )
+            .await?;
         }
         BodyLength::None => {}
     }
@@ -460,7 +488,7 @@ async fn send_deny_response<C: AsyncWrite + Unpin>(
 /// Per RFC 7230 Section 3.3.3, rejects requests containing both
 /// `Content-Length` and `Transfer-Encoding` headers to prevent request
 /// smuggling via CL/TE ambiguity.
-fn parse_body_length(headers: &str) -> Result<BodyLength> {
+pub(crate) fn parse_body_length(headers: &str) -> Result<BodyLength> {
     let mut has_te_chunked = false;
     let mut cl_value: Option<u64> = None;
 
@@ -504,7 +532,12 @@ fn parse_body_length(headers: &str) -> Result<BodyLength> {
 }
 
 /// Relay exactly `len` bytes from reader to writer.
-async fn relay_fixed<R, W>(reader: &mut R, writer: &mut W, len: u64) -> Result<()>
+async fn relay_fixed<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    len: u64,
+    generation_guard: Option<&PolicyGenerationGuard>,
+) -> Result<()>
 where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
@@ -521,6 +554,9 @@ where
                 "Connection closed with {remaining} bytes remaining"
             ));
         }
+        if let Some(guard) = generation_guard {
+            guard.ensure_current()?;
+        }
         writer.write_all(&buf[..n]).await.into_diagnostic()?;
         remaining -= n as u64;
     }
@@ -536,7 +572,12 @@ where
 /// `already_forwarded` are overflow bytes that were already written to the
 /// writer during header parsing. They are seeded into the parser buffer so
 /// termination can still be detected when boundaries span reads.
-async fn relay_chunked<R, W>(reader: &mut R, writer: &mut W, already_forwarded: &[u8]) -> Result<()>
+async fn relay_chunked<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    already_forwarded: &[u8],
+    generation_guard: Option<&PolicyGenerationGuard>,
+) -> Result<()>
 where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
@@ -559,6 +600,9 @@ where
             let n = reader.read(&mut read_buf).await.into_diagnostic()?;
             if n == 0 {
                 return Err(miette!("Chunked body ended before chunk-size line"));
+            }
+            if let Some(guard) = generation_guard {
+                guard.ensure_current()?;
             }
             writer.write_all(&read_buf[..n]).await.into_diagnostic()?;
             parse_buf.extend_from_slice(&read_buf[..n]);
@@ -588,6 +632,9 @@ where
                     let n = reader.read(&mut read_buf).await.into_diagnostic()?;
                     if n == 0 {
                         return Err(miette!("Chunked body ended before trailer terminator"));
+                    }
+                    if let Some(guard) = generation_guard {
+                        guard.ensure_current()?;
                     }
                     writer.write_all(&read_buf[..n]).await.into_diagnostic()?;
                     parse_buf.extend_from_slice(&read_buf[..n]);
@@ -621,6 +668,9 @@ where
             let n = reader.read(&mut read_buf).await.into_diagnostic()?;
             if n == 0 {
                 return Err(miette!("Chunked body ended mid-chunk"));
+            }
+            if let Some(guard) = generation_guard {
+                guard.ensure_current()?;
             }
             writer.write_all(&read_buf[..n]).await.into_diagnostic()?;
             parse_buf.extend_from_slice(&read_buf[..n]);
@@ -794,11 +844,11 @@ where
         BodyLength::ContentLength(len) => {
             let remaining = len.saturating_sub(overflow_len);
             if remaining > 0 {
-                relay_fixed(upstream, client, remaining).await?;
+                relay_fixed(upstream, client, remaining, None).await?;
             }
         }
         BodyLength::Chunked => {
-            relay_chunked(upstream, client, &buf[header_end..]).await?;
+            relay_chunked(upstream, client, &buf[header_end..], None).await?;
         }
         BodyLength::None => unreachable!(),
     }
@@ -945,8 +995,11 @@ fn is_benign_close(err: &std::io::Error) -> bool {
 )]
 mod tests {
     use super::*;
+    use crate::opa::OpaEngine;
     use crate::secrets::SecretResolver;
     use base64::Engine as _;
+
+    const TEST_POLICY: &str = include_str!("../../data/sandbox-policy.rego");
 
     #[test]
     fn parse_content_length() {
@@ -1967,6 +2020,47 @@ mod tests {
         );
 
         upstream_task.await.expect("upstream task should complete");
+    }
+
+    #[tokio::test]
+    async fn relay_request_guard_blocks_stale_generation_before_upstream_write() {
+        let policy_data = "network_policies: {}\n";
+        let engine = OpaEngine::from_strings(TEST_POLICY, policy_data).unwrap();
+        let guard = engine
+            .generation_guard(engine.current_generation())
+            .unwrap();
+        engine.reload(TEST_POLICY, policy_data).unwrap();
+
+        let req = L7Request {
+            action: "GET".to_string(),
+            target: "/api".to_string(),
+            query_params: HashMap::new(),
+            raw_header: b"GET /api HTTP/1.1\r\nHost: example.com\r\n\r\n".to_vec(),
+            body_length: BodyLength::None,
+        };
+        let (mut proxy_to_upstream, mut upstream_side) = tokio::io::duplex(8192);
+        let (mut _app_side, mut proxy_to_client) = tokio::io::duplex(8192);
+
+        let result = relay_http_request_with_resolver_guarded(
+            &req,
+            &mut proxy_to_client,
+            &mut proxy_to_upstream,
+            None,
+            Some(&guard),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "stale generation must stop relay before upstream write"
+        );
+
+        drop(proxy_to_upstream);
+        let mut forwarded = Vec::new();
+        upstream_side.read_to_end(&mut forwarded).await.unwrap();
+        assert!(
+            forwarded.is_empty(),
+            "stale request bytes must not reach upstream"
+        );
     }
 
     #[test]

--- a/crates/openshell-sandbox/src/opa.rs
+++ b/crates/openshell-sandbox/src/opa.rs
@@ -11,7 +11,10 @@ use crate::policy::{FilesystemPolicy, LandlockCompatibility, LandlockPolicy, Pro
 use miette::Result;
 use openshell_core::proto::SandboxPolicy as ProtoSandboxPolicy;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
 
 /// Baked-in rego rules for OPA policy evaluation.
 /// These rules define the network access decision logic and static config
@@ -64,6 +67,68 @@ pub struct SandboxConfig {
 /// (one eval per CONNECT request).
 pub struct OpaEngine {
     engine: Mutex<regorus::Engine>,
+    generation: Arc<AtomicU64>,
+}
+
+/// Generation guard captured when an HTTP tunnel or request path starts.
+#[derive(Clone)]
+pub struct PolicyGenerationGuard {
+    captured_generation: u64,
+    current_generation: Arc<AtomicU64>,
+}
+
+impl PolicyGenerationGuard {
+    pub fn captured_generation(&self) -> u64 {
+        self.captured_generation
+    }
+
+    pub fn current_generation(&self) -> u64 {
+        self.current_generation.load(Ordering::Acquire)
+    }
+
+    pub fn is_stale(&self) -> bool {
+        self.current_generation() != self.captured_generation
+    }
+
+    pub fn ensure_current(&self) -> Result<()> {
+        if self.is_stale() {
+            return Err(miette::miette!(
+                "policy generation is stale [captured_generation:{} current_generation:{}]",
+                self.captured_generation(),
+                self.current_generation(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Per-tunnel L7 policy evaluator bound to the engine generation captured when
+/// the tunnel was established.
+pub struct TunnelPolicyEngine {
+    engine: Mutex<regorus::Engine>,
+    generation_guard: PolicyGenerationGuard,
+}
+
+impl TunnelPolicyEngine {
+    pub fn captured_generation(&self) -> u64 {
+        self.generation_guard.captured_generation()
+    }
+
+    pub fn current_generation(&self) -> u64 {
+        self.generation_guard.current_generation()
+    }
+
+    pub fn is_stale(&self) -> bool {
+        self.generation_guard.is_stale()
+    }
+
+    pub fn generation_guard(&self) -> &PolicyGenerationGuard {
+        &self.generation_guard
+    }
+
+    pub(crate) fn engine(&self) -> &Mutex<regorus::Engine> {
+        &self.engine
+    }
 }
 
 impl OpaEngine {
@@ -84,6 +149,7 @@ impl OpaEngine {
             .map_err(|e| miette::miette!("{e}"))?;
         Ok(Self {
             engine: Mutex::new(engine),
+            generation: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -101,6 +167,7 @@ impl OpaEngine {
             .map_err(|e| miette::miette!("{e}"))?;
         Ok(Self {
             engine: Mutex::new(engine),
+            generation: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -162,6 +229,7 @@ impl OpaEngine {
             .map_err(|e| miette::miette!("{e}"))?;
         Ok(Self {
             engine: Mutex::new(engine),
+            generation: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -233,6 +301,14 @@ impl OpaEngine {
     /// Uses the OPA `network_action` rule which returns one of:
     /// `"allow"` or `"deny"`.
     pub fn evaluate_network_action(&self, input: &NetworkInput) -> Result<NetworkAction> {
+        Ok(self.evaluate_network_action_with_generation(input)?.0)
+    }
+
+    /// Evaluate network action and return the policy generation used for the evaluation.
+    pub fn evaluate_network_action_with_generation(
+        &self,
+        input: &NetworkInput,
+    ) -> Result<(NetworkAction, u64)> {
         let ancestor_strs: Vec<String> = input
             .ancestors
             .iter()
@@ -259,6 +335,7 @@ impl OpaEngine {
             .engine
             .lock()
             .map_err(|_| miette::miette!("OPA engine lock poisoned"))?;
+        let generation = self.current_generation();
 
         engine
             .set_input_json(&input_json.to_string())
@@ -279,13 +356,13 @@ impl OpaEngine {
         };
 
         if action_str == "allow" {
-            Ok(NetworkAction::Allow { matched_policy })
+            Ok((NetworkAction::Allow { matched_policy }, generation))
         } else {
             let reason_val = engine
                 .eval_rule("data.openshell.sandbox.deny_reason".into())
                 .map_err(|e| miette::miette!("{e}"))?;
             let reason = value_to_string(&reason_val);
-            Ok(NetworkAction::Deny { reason })
+            Ok((NetworkAction::Deny { reason }, generation))
         }
     }
 
@@ -306,6 +383,7 @@ impl OpaEngine {
             .lock()
             .map_err(|_| miette::miette!("OPA engine lock poisoned"))?;
         *engine = new_engine;
+        self.generation.fetch_add(1, Ordering::AcqRel);
         Ok(())
     }
 
@@ -340,7 +418,27 @@ impl OpaEngine {
             .lock()
             .map_err(|_| miette::miette!("OPA engine lock poisoned"))?;
         *engine = new_engine;
+        self.generation.fetch_add(1, Ordering::AcqRel);
         Ok(())
+    }
+
+    /// Current policy generation. Successful reloads increment this value.
+    pub fn current_generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    /// Return a guard for a previously captured policy generation.
+    pub fn generation_guard(&self, expected_generation: u64) -> Result<PolicyGenerationGuard> {
+        let generation = self.current_generation();
+        if generation != expected_generation {
+            return Err(miette::miette!(
+                "policy changed before HTTP relay started [expected_generation:{expected_generation} current_generation:{generation}]"
+            ));
+        }
+        Ok(PolicyGenerationGuard {
+            captured_generation: generation,
+            current_generation: Arc::clone(&self.generation),
+        })
     }
 
     /// Query static sandbox configuration from the OPA data module.
@@ -385,6 +483,14 @@ impl OpaEngine {
     /// to get the full endpoint object for the matched policy. Returns the raw
     /// `regorus::Value` which can be parsed by `l7::parse_l7_config()`.
     pub fn query_endpoint_config(&self, input: &NetworkInput) -> Result<Option<regorus::Value>> {
+        Ok(self.query_endpoint_config_with_generation(input)?.0)
+    }
+
+    /// Query L7 endpoint config and return the policy generation used for the query.
+    pub fn query_endpoint_config_with_generation(
+        &self,
+        input: &NetworkInput,
+    ) -> Result<(Option<regorus::Value>, u64)> {
         let ancestor_strs: Vec<String> = input
             .ancestors
             .iter()
@@ -411,6 +517,7 @@ impl OpaEngine {
             .engine
             .lock()
             .map_err(|_| miette::miette!("OPA engine lock poisoned"))?;
+        let generation = self.current_generation();
 
         engine
             .set_input_json(&input_json.to_string())
@@ -421,9 +528,9 @@ impl OpaEngine {
             .map_err(|e| miette::miette!("{e}"))?;
 
         if val == regorus::Value::Undefined {
-            Ok(None)
+            Ok((None, generation))
         } else {
-            Ok(Some(val))
+            Ok((Some(val), generation))
         }
     }
 
@@ -445,12 +552,24 @@ impl OpaEngine {
     /// With the `arc` feature enabled, this shares compiled policy via Arc
     /// and only duplicates interpreter state (~microseconds). The cloned
     /// engine can be used without Mutex contention.
-    pub fn clone_engine_for_tunnel(&self) -> Result<regorus::Engine> {
+    pub fn clone_engine_for_tunnel(&self, expected_generation: u64) -> Result<TunnelPolicyEngine> {
         let engine = self
             .engine
             .lock()
             .map_err(|_| miette::miette!("OPA engine lock poisoned"))?;
-        Ok(engine.clone())
+        let generation = self.current_generation();
+        if generation != expected_generation {
+            return Err(miette::miette!(
+                "policy changed before L7 tunnel started [expected_generation:{expected_generation} current_generation:{generation}]"
+            ));
+        }
+        Ok(TunnelPolicyEngine {
+            engine: Mutex::new(engine.clone()),
+            generation_guard: PolicyGenerationGuard {
+                captured_generation: generation,
+                current_generation: Arc::clone(&self.generation),
+            },
+        })
     }
 }
 
@@ -2027,15 +2146,96 @@ process:
     #[test]
     fn l7_clone_engine_for_tunnel() {
         let engine = l7_engine();
-        let cloned = engine.clone_engine_for_tunnel().unwrap();
+        let cloned = engine
+            .clone_engine_for_tunnel(engine.current_generation())
+            .unwrap();
         // Verify the cloned engine can evaluate
         let input_json = l7_input("api.example.com", 8080, "GET", "/repos/myorg/foo");
-        let mut eng = cloned;
+        let mut eng = cloned.engine().lock().unwrap();
         eng.set_input_json(&input_json.to_string()).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
         assert_eq!(val, regorus::Value::from(true));
+    }
+
+    #[test]
+    fn policy_generation_starts_at_zero_and_increments_on_successful_reload() {
+        let engine = l7_engine();
+        assert_eq!(engine.current_generation(), 0);
+
+        engine.reload(TEST_POLICY, L7_TEST_DATA).unwrap();
+
+        assert_eq!(engine.current_generation(), 1);
+    }
+
+    #[test]
+    fn policy_generation_does_not_increment_on_failed_reload() {
+        let engine = l7_engine();
+        engine.reload(TEST_POLICY, L7_TEST_DATA).unwrap();
+        assert_eq!(engine.current_generation(), 1);
+
+        let invalid_l7_data = r#"
+network_policies:
+  bad_api:
+    name: bad_api
+    endpoints:
+      - host: api.example.com
+        port: 8080
+        protocol: invalid-protocol
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        assert!(engine.reload(TEST_POLICY, invalid_l7_data).is_err());
+        assert_eq!(engine.current_generation(), 1);
+
+        let input_json = l7_input("api.example.com", 8080, "GET", "/repos/myorg/foo");
+        let cloned = engine
+            .clone_engine_for_tunnel(engine.current_generation())
+            .unwrap();
+        let mut eng = cloned.engine().lock().unwrap();
+        eng.set_input_json(&input_json.to_string()).unwrap();
+        let val = eng
+            .eval_rule("data.openshell.sandbox.allow_request".into())
+            .unwrap();
+        assert_eq!(val, regorus::Value::from(true));
+    }
+
+    #[test]
+    fn endpoint_config_generation_matches_query_generation() {
+        let engine = l7_engine();
+        let input = NetworkInput {
+            host: "api.example.com".into(),
+            port: 8080,
+            binary_path: PathBuf::from("/usr/bin/curl"),
+            binary_sha256: "unused".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+        };
+
+        let (config, generation) = engine
+            .query_endpoint_config_with_generation(&input)
+            .unwrap();
+        assert!(config.is_some());
+        assert_eq!(generation, engine.current_generation());
+
+        engine.reload(TEST_POLICY, L7_TEST_DATA).unwrap();
+
+        let (config, generation) = engine
+            .query_endpoint_config_with_generation(&input)
+            .unwrap();
+        assert!(config.is_some());
+        assert_eq!(generation, engine.current_generation());
+        assert_eq!(generation, 1);
+    }
+
+    #[test]
+    fn tunnel_clone_rejects_stale_generation() {
+        let engine = l7_engine();
+        let captured_generation = engine.current_generation();
+        engine.reload(TEST_POLICY, L7_TEST_DATA).unwrap();
+
+        assert!(engine.clone_engine_for_tunnel(captured_generation).is_err());
     }
 
     // ========================================================================

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -6,7 +6,7 @@
 use crate::denial_aggregator::DenialEvent;
 use crate::identity::BinaryIdentityCache;
 use crate::l7::tls::ProxyTlsState;
-use crate::opa::{NetworkAction, OpaEngine};
+use crate::opa::{NetworkAction, OpaEngine, PolicyGenerationGuard};
 use crate::policy::ProxyPolicy;
 use crate::secrets::{SecretResolver, rewrite_header_line};
 use miette::{IntoDiagnostic, Result};
@@ -19,7 +19,9 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{
+    AsyncRead as TokioAsyncRead, AsyncReadExt, AsyncWrite as TokioAsyncWrite, AsyncWriteExt,
+};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -42,6 +44,8 @@ const CHUNK_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1
 /// Result of a proxy CONNECT policy decision.
 struct ConnectDecision {
     action: NetworkAction,
+    /// Policy generation used for the L4 network decision.
+    generation: u64,
     /// Resolved binary path.
     binary: Option<PathBuf>,
     /// PID owning the socket.
@@ -668,12 +672,16 @@ async fn handle_tcp_connection(
 
     respond(&mut client, b"HTTP/1.1 200 Connection Established\r\n\r\n").await?;
 
-    // Check if endpoint has L7 config for protocol-aware inspection
-    let l7_config = query_l7_config(&opa_engine, &decision, &host_lc, port);
+    // Check if endpoint has L7 config for protocol-aware inspection, and
+    // retain the generation for HTTP passthrough keep-alive tunnels.
+    let l7_route = query_l7_route_snapshot(&opa_engine, &decision, &host_lc, port);
 
     // Log the allowed CONNECT — use CONNECT_L7 when L7 inspection follows,
     // so log consumers can distinguish L4-only decisions from tunnel lifecycle events.
-    let connect_msg = if l7_config.is_some() {
+    let connect_msg = if l7_route
+        .as_ref()
+        .is_some_and(|route| route.config.is_some())
+    {
         "CONNECT_L7"
     } else {
         "CONNECT"
@@ -758,24 +766,19 @@ async fn handle_tcp_connection(
                     crate::l7::tls::tls_connect_upstream(upstream, &host_lc, tls.upstream_config())
                         .await?;
 
-                if let Some(ref l7_config) = l7_config {
+                if let Some(l7_config) = l7_route.as_ref().and_then(|route| route.config.as_ref()) {
                     // L7 inspection on terminated TLS traffic.
-                    let tunnel_engine = opa_engine.clone_engine_for_tunnel().unwrap_or_else(|e| {
-                        let event = NetworkActivityBuilder::new(crate::ocsf_ctx())
-                            .activity(ActivityId::Fail)
-                            .severity(SeverityId::Low)
-                            .status(StatusId::Failure)
-                            .dst_endpoint(Endpoint::from_domain(&host_lc, port))
-                            .message(format!(
-                                "Failed to clone OPA engine for L7, falling back to relay-only: {e}"
-                            ))
-                            .build();
-                        ocsf_emit!(event);
-                        regorus::Engine::new()
-                    });
+                    let tunnel_engine =
+                        match opa_engine.clone_engine_for_tunnel(l7_config.generation) {
+                            Ok(engine) => engine,
+                            Err(e) => {
+                                emit_l7_tunnel_close_after_policy_change(&host_lc, port, e);
+                                return Ok(());
+                            }
+                        };
                     crate::l7::relay::relay_with_inspection(
-                        l7_config,
-                        std::sync::Mutex::new(tunnel_engine),
+                        &l7_config.config,
+                        tunnel_engine,
                         &mut tls_client,
                         &mut tls_upstream,
                         &ctx,
@@ -783,10 +786,21 @@ async fn handle_tcp_connection(
                     .await
                 } else {
                     // No L7 config — relay with credential injection only.
+                    let generation = l7_route
+                        .as_ref()
+                        .map_or(decision.generation, |route| route.generation);
+                    let generation_guard = match opa_engine.generation_guard(generation) {
+                        Ok(guard) => guard,
+                        Err(e) => {
+                            emit_l7_tunnel_close_after_policy_change(&host_lc, port, e);
+                            return Ok(());
+                        }
+                    };
                     crate::l7::relay::relay_passthrough_with_credentials(
                         &mut tls_client,
                         &mut tls_upstream,
                         &ctx,
+                        &generation_guard,
                     )
                     .await
                 }
@@ -829,23 +843,17 @@ async fn handle_tcp_connection(
         }
     } else if is_http {
         // Plaintext HTTP detected.
-        if let Some(ref l7_config) = l7_config {
-            let tunnel_engine = opa_engine.clone_engine_for_tunnel().unwrap_or_else(|e| {
-                let event = NetworkActivityBuilder::new(crate::ocsf_ctx())
-                    .activity(ActivityId::Fail)
-                    .severity(SeverityId::Low)
-                    .status(StatusId::Failure)
-                    .dst_endpoint(Endpoint::from_domain(&host_lc, port))
-                    .message(format!(
-                        "Failed to clone OPA engine for L7, falling back to relay-only: {e}"
-                    ))
-                    .build();
-                ocsf_emit!(event);
-                regorus::Engine::new()
-            });
+        if let Some(l7_config) = l7_route.as_ref().and_then(|route| route.config.as_ref()) {
+            let tunnel_engine = match opa_engine.clone_engine_for_tunnel(l7_config.generation) {
+                Ok(engine) => engine,
+                Err(e) => {
+                    emit_l7_tunnel_close_after_policy_change(&host_lc, port, e);
+                    return Ok(());
+                }
+            };
             if let Err(e) = crate::l7::relay::relay_with_inspection(
-                l7_config,
-                std::sync::Mutex::new(tunnel_engine),
+                &l7_config.config,
+                tunnel_engine,
                 &mut client,
                 &mut upstream,
                 &ctx,
@@ -867,10 +875,21 @@ async fn handle_tcp_connection(
             }
         } else {
             // Plaintext HTTP, no L7 config — relay with credential injection.
+            let generation = l7_route
+                .as_ref()
+                .map_or(decision.generation, |route| route.generation);
+            let generation_guard = match opa_engine.generation_guard(generation) {
+                Ok(guard) => guard,
+                Err(e) => {
+                    emit_l7_tunnel_close_after_policy_change(&host_lc, port, e);
+                    return Ok(());
+                }
+            };
             if let Err(e) = crate::l7::relay::relay_passthrough_with_credentials(
                 &mut client,
                 &mut upstream,
                 &ctx,
+                &generation_guard,
             )
             .await
             {
@@ -1103,6 +1122,7 @@ fn evaluate_opa_tcp(
      -> ConnectDecision {
         ConnectDecision {
             action: NetworkAction::Deny { reason },
+            generation: engine.current_generation(),
             binary,
             binary_pid,
             ancestors,
@@ -1154,9 +1174,10 @@ fn evaluate_opa_tcp(
         cmdline_paths: cmdline_paths.clone(),
     };
 
-    let result = match engine.evaluate_network_action(&input) {
-        Ok(action) => ConnectDecision {
+    let result = match engine.evaluate_network_action_with_generation(&input) {
+        Ok((action, generation)) => ConnectDecision {
             action,
+            generation,
             binary: Some(bin_path),
             binary_pid: Some(binary_pid),
             ancestors,
@@ -1191,6 +1212,7 @@ fn evaluate_opa_tcp(
         action: NetworkAction::Deny {
             reason: "identity binding unavailable on this platform".into(),
         },
+        generation: _engine.current_generation(),
         binary: None,
         binary_pid: None,
         ancestors: vec![],
@@ -1594,16 +1616,43 @@ async fn write_all(writer: &mut (impl tokio::io::AsyncWrite + Unpin), data: &[u8
     Ok(())
 }
 
+#[derive(Debug, Clone)]
+struct L7ConfigSnapshot {
+    config: crate::l7::L7EndpointConfig,
+    generation: u64,
+}
+
+#[derive(Debug, Clone)]
+struct L7RouteSnapshot {
+    config: Option<L7ConfigSnapshot>,
+    generation: u64,
+}
+
+fn emit_l7_tunnel_close_after_policy_change(host: &str, port: u16, error: miette::Report) {
+    let event = NetworkActivityBuilder::new(crate::ocsf_ctx())
+        .activity(ActivityId::Open)
+        .action(ActionId::Denied)
+        .disposition(DispositionId::Blocked)
+        .severity(SeverityId::Medium)
+        .status(StatusId::Failure)
+        .dst_endpoint(Endpoint::from_domain(host, port))
+        .message(format!(
+            "L7 tunnel closed before inspection because policy changed: {error}"
+        ))
+        .build();
+    ocsf_emit!(event);
+}
+
 /// Query L7 endpoint config from the OPA engine for a matched CONNECT decision.
 ///
 /// Returns `Some(L7EndpointConfig)` if the matched endpoint has L7 config (protocol field),
 /// `None` for L4-only endpoints.
-fn query_l7_config(
+fn query_l7_route_snapshot(
     engine: &OpaEngine,
     decision: &ConnectDecision,
     host: &str,
     port: u16,
-) -> Option<crate::l7::L7EndpointConfig> {
+) -> Option<L7RouteSnapshot> {
     // Only query if action is Allow (not Deny)
     let has_policy = match &decision.action {
         NetworkAction::Allow { matched_policy } => matched_policy.is_some(),
@@ -1622,9 +1671,16 @@ fn query_l7_config(
         cmdline_paths: decision.cmdline_paths.clone(),
     };
 
-    match engine.query_endpoint_config(&input) {
-        Ok(Some(val)) => crate::l7::parse_l7_config(&val),
-        Ok(None) => None,
+    match engine.query_endpoint_config_with_generation(&input) {
+        Ok((Some(val), generation)) => Some(L7RouteSnapshot {
+            config: crate::l7::parse_l7_config(&val)
+                .map(|config| L7ConfigSnapshot { config, generation }),
+            generation,
+        }),
+        Ok((None, generation)) => Some(L7RouteSnapshot {
+            config: None,
+            generation,
+        }),
         Err(e) => {
             let event = NetworkActivityBuilder::new(crate::ocsf_ctx())
                 .activity(ActivityId::Fail)
@@ -2258,12 +2314,49 @@ fn rewrite_forward_request(
     Ok(output)
 }
 
+async fn relay_rewritten_forward_request<C, U>(
+    method: &str,
+    path: &str,
+    rewritten: Vec<u8>,
+    client: &mut C,
+    upstream: &mut U,
+    generation_guard: &PolicyGenerationGuard,
+) -> Result<crate::l7::provider::RelayOutcome>
+where
+    C: TokioAsyncRead + TokioAsyncWrite + Unpin,
+    U: TokioAsyncRead + TokioAsyncWrite + Unpin,
+{
+    let header_end = rewritten
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map_or(rewritten.len(), |p| p + 4);
+    let header_str = String::from_utf8_lossy(&rewritten[..header_end]);
+    let body_length = crate::l7::rest::parse_body_length(&header_str)?;
+    let (_, query_params) = crate::l7::rest::parse_target_query(path)?;
+    let req = crate::l7::provider::L7Request {
+        action: method.to_string(),
+        target: path.to_string(),
+        query_params,
+        raw_header: rewritten,
+        body_length,
+    };
+
+    crate::l7::rest::relay_http_request_with_resolver_guarded(
+        &req,
+        client,
+        upstream,
+        None,
+        Some(generation_guard),
+    )
+    .await
+}
+
 /// Handle a plain HTTP forward proxy request (non-CONNECT).
 ///
 /// Public IPs are allowed through when the endpoint passes OPA evaluation.
 /// Private IPs require explicit `allowed_ips` on the endpoint config (SSRF
 /// override). Rewrites the absolute-form request to origin-form, connects
-/// upstream, and relays the response using `copy_bidirectional` for streaming.
+/// upstream, and relays the request/response using the guarded HTTP relay.
 // Many distinct, non-related context parameters are required for forward proxy
 // dispatch; bundling them into a struct would just shift the noise into call sites.
 #[allow(clippy::too_many_arguments)]
@@ -2423,23 +2516,69 @@ async fn handle_forward_proxy(
     };
     let policy_str = matched_policy.as_deref().unwrap_or("-");
     let sandbox_entrypoint_pid = entrypoint_pid.load(Ordering::Acquire);
+    let forward_generation_guard = match opa_engine.generation_guard(decision.generation) {
+        Ok(guard) => guard,
+        Err(e) => {
+            emit_l7_tunnel_close_after_policy_change(&host_lc, port, e);
+            respond(
+                client,
+                &build_json_error_response(
+                    403,
+                    "Forbidden",
+                    "policy_denied",
+                    &format!("{method} {host_lc}:{port}{path} not permitted by policy"),
+                ),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
 
     // 4b. If the endpoint has L7 config, evaluate the request against
     //     L7 policy.  The forward proxy handles exactly one request per
     //     connection (Connection: close), so a single evaluation suffices.
-    if let Some(l7_config) = query_l7_config(&opa_engine, &decision, &host_lc, port) {
-        let tunnel_engine = opa_engine.clone_engine_for_tunnel().unwrap_or_else(|e| {
-            let event = NetworkActivityBuilder::new(crate::ocsf_ctx())
-                .activity(ActivityId::Fail)
-                .severity(SeverityId::Low)
-                .status(StatusId::Failure)
-                .dst_endpoint(Endpoint::from_domain(&host_lc, port))
-                .message(format!("Failed to clone OPA engine for forward L7: {e}"))
-                .build();
-            ocsf_emit!(event);
-            regorus::Engine::new()
-        });
-        let engine_mutex = std::sync::Mutex::new(tunnel_engine);
+    if let Some(route) = query_l7_route_snapshot(&opa_engine, &decision, &host_lc, port)
+        && let Some(l7_config) = route.config
+    {
+        if l7_config.generation != forward_generation_guard.captured_generation() {
+            emit_l7_tunnel_close_after_policy_change(
+                &host_lc,
+                port,
+                miette::miette!(
+                    "policy changed before forward L7 evaluation [expected_generation:{} current_generation:{}]",
+                    forward_generation_guard.captured_generation(),
+                    l7_config.generation,
+                ),
+            );
+            respond(
+                client,
+                &build_json_error_response(
+                    403,
+                    "Forbidden",
+                    "policy_denied",
+                    &format!("{method} {host_lc}:{port}{path} not permitted by policy"),
+                ),
+            )
+            .await?;
+            return Ok(());
+        }
+        let tunnel_engine = match opa_engine.clone_engine_for_tunnel(l7_config.generation) {
+            Ok(engine) => engine,
+            Err(e) => {
+                emit_l7_tunnel_close_after_policy_change(&host_lc, port, e);
+                respond(
+                    client,
+                    &build_json_error_response(
+                        403,
+                        "Forbidden",
+                        "policy_denied",
+                        &format!("{method} {host_lc}:{port}{path} not permitted by policy"),
+                    ),
+                )
+                .await?;
+                return Ok(());
+            }
+        };
 
         let l7_ctx = crate::l7::relay::L7EvalContext {
             host: host_lc.clone(),
@@ -2471,7 +2610,7 @@ async fn handle_forward_proxy(
         // while the upstream re-normalizes the raw input and dispatches on a
         // potentially different path.
         let canonicalize_options = crate::l7::path::CanonicalizeOptions {
-            allow_encoded_slash: l7_config.allow_encoded_slash,
+            allow_encoded_slash: l7_config.config.allow_encoded_slash,
             ..Default::default()
         };
         let query_params =
@@ -2516,7 +2655,7 @@ async fn handle_forward_proxy(
         };
 
         let (allowed, reason) =
-            crate::l7::relay::evaluate_l7_request(&engine_mutex, &l7_ctx, &request_info)
+            crate::l7::relay::evaluate_l7_request(&tunnel_engine, &l7_ctx, &request_info)
                 .unwrap_or_else(|e| {
                     let event = NetworkActivityBuilder::new(crate::ocsf_ctx())
                         .activity(ActivityId::Fail)
@@ -2529,7 +2668,7 @@ async fn handle_forward_proxy(
                     (false, format!("L7 evaluation error: {e}"))
                 });
 
-        let decision_str = match (allowed, l7_config.enforcement) {
+        let decision_str = match (allowed, l7_config.config.enforcement) {
             (true, _) => "allow",
             (false, crate::l7::EnforcementMode::Audit) => "audit",
             (false, crate::l7::EnforcementMode::Enforce) => "deny",
@@ -2573,7 +2712,7 @@ async fn handle_forward_proxy(
         }
 
         let effectively_denied =
-            !allowed && l7_config.enforcement == crate::l7::EnforcementMode::Enforce;
+            !allowed && l7_config.config.enforcement == crate::l7::EnforcementMode::Enforce;
 
         if effectively_denied {
             emit_denial_simple(
@@ -2775,6 +2914,21 @@ async fn handle_forward_proxy(
             }
         };
 
+    if let Err(e) = forward_generation_guard.ensure_current() {
+        emit_l7_tunnel_close_after_policy_change(&host_lc, port, e);
+        respond(
+            client,
+            &build_json_error_response(
+                403,
+                "Forbidden",
+                "policy_denied",
+                &format!("{method} {host_lc}:{port}{path} not permitted by policy"),
+            ),
+        )
+        .await?;
+        return Ok(());
+    }
+
     // 6. Connect upstream
     let mut upstream = match TcpStream::connect(addrs.as_slice()).await {
         Ok(s) => s,
@@ -2859,12 +3013,32 @@ async fn handle_forward_proxy(
             return Ok(());
         }
     };
-    upstream.write_all(&rewritten).await.into_diagnostic()?;
-
-    // 8. Relay remaining traffic bidirectionally (supports streaming)
-    let _ = tokio::io::copy_bidirectional(client, &mut upstream)
-        .await
-        .into_diagnostic()?;
+    if let Err(e) = forward_generation_guard.ensure_current() {
+        emit_l7_tunnel_close_after_policy_change(&host_lc, port, e);
+        respond(
+            client,
+            &build_json_error_response(
+                403,
+                "Forbidden",
+                "policy_denied",
+                &format!("{method} {host_lc}:{port}{path} not permitted by policy"),
+            ),
+        )
+        .await?;
+        return Ok(());
+    }
+    let outcome = relay_rewritten_forward_request(
+        method,
+        &path,
+        rewritten,
+        client,
+        &mut upstream,
+        &forward_generation_guard,
+    )
+    .await?;
+    if let crate::l7::provider::RelayOutcome::Upgraded { overflow } = outcome {
+        crate::l7::relay::handle_upgrade(client, &mut upstream, overflow, &host_lc, port).await?;
+    }
 
     Ok(())
 }
@@ -3941,6 +4115,80 @@ mod tests {
         let result_str = String::from_utf8_lossy(&result);
         assert!(result_str.contains("Authorization: Bearer sk-test"));
         assert!(!result_str.contains("openshell:resolve:env:ANTHROPIC_API_KEY"));
+    }
+
+    #[tokio::test]
+    async fn test_forward_relay_guard_blocks_stale_generation_before_upstream_write() {
+        let policy = include_str!("../data/sandbox-policy.rego");
+        let policy_data = "network_policies: {}\n";
+        let engine = OpaEngine::from_strings(policy, policy_data).unwrap();
+        let guard = engine
+            .generation_guard(engine.current_generation())
+            .unwrap();
+        engine.reload(policy, policy_data).unwrap();
+
+        let raw = b"GET http://host/api HTTP/1.1\r\nHost: host\r\n\r\n";
+        let rewritten =
+            rewrite_forward_request(raw, raw.len(), "/api", None).expect("rewrite should succeed");
+        let (mut proxy_to_upstream, mut upstream_side) = tokio::io::duplex(8192);
+        let (mut _app_side, mut proxy_to_client) = tokio::io::duplex(8192);
+
+        let result = relay_rewritten_forward_request(
+            "GET",
+            "/api",
+            rewritten,
+            &mut proxy_to_client,
+            &mut proxy_to_upstream,
+            &guard,
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "stale generation must stop forward relay before upstream write"
+        );
+
+        drop(proxy_to_upstream);
+        let mut forwarded = Vec::new();
+        upstream_side.read_to_end(&mut forwarded).await.unwrap();
+        assert!(
+            forwarded.is_empty(),
+            "stale forward request bytes must not reach upstream"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_forward_relay_rejects_cl_te_smuggling_before_upstream_write() {
+        let policy = include_str!("../data/sandbox-policy.rego");
+        let policy_data = "network_policies: {}\n";
+        let engine = OpaEngine::from_strings(policy, policy_data).unwrap();
+        let guard = engine
+            .generation_guard(engine.current_generation())
+            .unwrap();
+
+        let raw = b"POST http://host/api HTTP/1.1\r\nHost: host\r\nContent-Length: 4\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n";
+        let rewritten =
+            rewrite_forward_request(raw, raw.len(), "/api", None).expect("rewrite should succeed");
+        let (mut proxy_to_upstream, mut upstream_side) = tokio::io::duplex(8192);
+        let (mut _app_side, mut proxy_to_client) = tokio::io::duplex(8192);
+
+        let result = relay_rewritten_forward_request(
+            "POST",
+            "/api",
+            rewritten,
+            &mut proxy_to_client,
+            &mut proxy_to_upstream,
+            &guard,
+        )
+        .await;
+        assert!(result.is_err(), "forward relay must reject CL/TE ambiguity");
+
+        drop(proxy_to_upstream);
+        let mut forwarded = Vec::new();
+        upstream_side.read_to_end(&mut forwarded).await.unwrap();
+        assert!(
+            forwarded.is_empty(),
+            "smuggled forward request bytes must not reach upstream"
+        );
     }
 
     // --- Forward proxy SSRF defence tests ---

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -48,6 +48,8 @@ network_policies:
 
 Static sections are locked at sandbox creation. Changing them requires destroying and recreating the sandbox.
 Dynamic sections can be updated on a running sandbox with `openshell policy update` for incremental merges or `openshell policy set` for full replacement, and take effect without restarting.
+When a hot reload changes rules on an active HTTP L7 endpoint, existing keep-alive tunnels are closed before forwarding another parsed request. Credential-injection-only HTTP passthrough tunnels use the same reload boundary. Most HTTP clients reconnect automatically, and the next request is evaluated against the current policy.
+Raw streams are connection-scoped and outside L7 live-reload guarantees. This includes `tls: skip`, non-HTTP TCP payloads, HTTP upgrades such as WebSocket, and long-lived response streams such as SSE. A reload applies to the next connection or next parsed HTTP request; it does not interrupt an already-forwarded raw stream.
 
 | Section | Type | Description |
 |---|---|---|
@@ -445,7 +447,7 @@ Allow `pip install` and `uv pip install` to reach PyPI:
       - { path: /usr/local/bin/uv }
 ```
 
-Endpoints without `protocol` use TCP passthrough, where the proxy allows the stream without inspecting payloads.
+Endpoints without `protocol` use TCP passthrough, where the proxy allows the stream without inspecting payloads. If the stream is HTTP and TLS is auto-terminated, the proxy can still rewrite configured credential placeholders and closes keep-alive passthrough tunnels on policy reload before forwarding another request.
 </Tab>
 
 <Tab title="Granular rules">


### PR DESCRIPTION
## Summary

Close active L7 keep-alive tunnels when the sandbox policy engine reloads to a newer generation. This prevents subsequent requests on an existing inspected tunnel from being evaluated or forwarded with stale per-tunnel policy state.

## Related Issue

N/A

## Changes

- Added policy generation tracking to the sandbox OPA engine and generation-bound L7 tunnel snapshots.
- Captured L7 endpoint config and policy generation together before starting inspected CONNECT tunnels.
- Closed stale L7 tunnels before parsing, evaluating, or forwarding another request after policy reload.
- Added regression coverage for generation changes and stale keep-alive tunnel closure.
- Updated architecture and policy docs for the new L7 reload behavior.

## Testing

- [ ] `mise run pre-commit` passes
  - Blocked locally because `mise.toml` is not trusted in this checkout.
- [x] Unit tests added/updated
  - `cargo check -p openshell-sandbox`
  - `cargo test -p openshell-sandbox`
- [ ] E2E tests added/updated (if applicable)
  - Not applicable; this is covered by focused sandbox unit/integration-style tests.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
