### PR TITLE
chore(ci): label non-maintainer issues for triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,17 +8,18 @@ permissions:
   issues: write
 
 jobs:
-  label-maintainer-issues:
+  label-non-maintainer-issues:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'NVIDIA'
     steps:
-      - name: Check maintainer permissions
-        id: maintainer
+      - name: Check contributor permissions
+        id: contributor
         uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
             const author = context.payload.issue.user.login;
+            const maintainerPermissions = ['admin', 'maintain', 'write'];
 
             try {
               const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -27,25 +28,24 @@ jobs:
                 username: author,
               });
 
-              if (['admin', 'maintain', 'write'].includes(data.permission)) {
+              if (maintainerPermissions.includes(data.permission)) {
                 console.log(`${author} has maintainer permissions: ${data.permission}.`);
-                return 'true';
+                return 'false';
               }
 
-              console.log(`${author} does not have maintainer permissions: ${data.permission}.`);
+              console.log(`${author} is not a maintainer; permission is ${data.permission}.`);
+              return 'true';
             } catch (e) {
               if (e.status === 404) {
-                console.log(`${author} is not a repository collaborator.`);
-                return 'false';
+                console.log(`${author} is not a repository collaborator; labeling for triage.`);
+                return 'true';
               }
 
               throw e;
             }
 
-            return 'false';
-
       - name: Add triage label
-        if: steps.maintainer.outputs.result == 'true'
+        if: steps.contributor.outputs.result == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -54,42 +54,4 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               labels: ['state:triage-needed'],
-            });
-
-  check-agent-diagnostic:
-    runs-on: ubuntu-latest
-    # Only run on bug reports (title starts with "bug:")
-    if: startsWith(github.event.issue.title, 'bug:')
-    steps:
-      - name: Check for agent diagnostic section
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const body = context.payload.issue.body || '';
-
-            // Check if the Agent Diagnostic section has substantive content.
-            // GitHub issue forms render textarea labels as h3 headings, but
-            // issues created through gh or API clients often use h2 headings.
-            const diagnosticMatch = body.match(
-              /^#{2,4}\s+Agent Diagnostic[s]?\s*\n([\s\S]*?)(?=\n#{2,4}\s+|$)/im
-            );
-
-            const diagnosticText = diagnosticMatch?.[1].trim() || '';
-            const hasSubstantiveDiagnostic = diagnosticText.length > 0
-              && !diagnosticText.toLowerCase().startsWith('example:')
-              && !['n/a', 'none', 'no', 'not applicable'].includes(diagnosticText.toLowerCase());
-
-            if (hasSubstantiveDiagnostic) {
-              console.log('Agent diagnostic section found with content. Passing.');
-              return;
-            }
-
-            console.log('Agent diagnostic section missing or placeholder. Flagging.');
-
-            // Add state:triage-needed label
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['state:triage-needed']
             });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Skills connect into pipelines. Individual skill files don't describe these relat
 - **Policy iteration:** `openshell-cli` → `generate-sandbox-policy`
 
 Workflow state labels use the `state:*` prefix, and security work uses `topic:security`. GitHub issue templates assign built-in issue types where applicable, and agent-created issues should use issue types or manual follow-up rather than type labels.
-New issues opened by repository collaborators with `write`, `maintain`, or `admin` permission are automatically labeled `state:triage-needed` by the issue triage workflow.
+New issues opened by users without `write`, `maintain`, or `admin` repository permission are automatically labeled `state:triage-needed` by the issue triage workflow.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Fix the issue triage workflow so `state:triage-needed` is applied to issues from non-maintainers, not maintainers. The rule is now explicit: users with `write`, `maintain`, or `admin` repository permission are trusted and skipped; everyone else is labeled for triage.

## Related Issue

Refs #1119 as the observed false-positive maintainer case.

## Changes

- Invert the contributor permission check so only authors without `write`, `maintain`, or `admin` permission get `state:triage-needed`.
- Remove the older bug-diagnostic label path so maintainer-authored bug issues cannot be labeled by a second job.
- Update `CONTRIBUTING.md` to document the non-maintainer rule.

## Testing

- [x] `mise run pre-commit` passes
- [x] `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/issue-triage.yml')"` passes
- [x] `git diff --check` passes
- [x] Verified `TaylorMutch` has `admin` permission, which the new workflow skips
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)