### PR TITLE
fix(sandbox): accept ENOENT in drop_privileges identity lookup tests

### DIFF
--- a/crates/openshell-sandbox/src/process.rs
+++ b/crates/openshell-sandbox/src/process.rs
@@ -614,6 +614,17 @@ mod tests {
         }
     }
 
+    /// Unknown names may yield `Ok(None)` (`… not found …`) or `Err` when NSS fails first
+    /// (e.g. `ENOENT: No such file or directory`).
+    fn assert_unknown_identity_lookup_failed(msg: &str) {
+        assert!(
+            msg.contains("not found")
+                || msg.contains("ENOENT")
+                || msg.contains("No such file or directory"),
+            "expected unknown user/group lookup failure (…not found… or ENOENT): {msg}"
+        );
+    }
+
     #[test]
     fn drop_privileges_noop_when_no_user_or_group() {
         let policy = policy_with_process(ProcessPolicy {
@@ -696,10 +707,7 @@ mod tests {
         let result = drop_privileges(&policy);
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
-        assert!(
-            msg.contains("not found"),
-            "expected 'not found' in error: {msg}"
-        );
+        assert_unknown_identity_lookup_failed(&msg);
     }
 
     #[test]
@@ -712,10 +720,7 @@ mod tests {
         let result = drop_privileges(&policy);
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
-        assert!(
-            msg.contains("not found"),
-            "expected 'not found' in error: {msg}"
-        );
+        assert_unknown_identity_lookup_failed(&msg);
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

`drop_privileges` unknown-user / unknown-group tests asserted on the literal substring `"not found"`. On environments where NSS fails before producing a definitive unknown-name result, `User::from_name` / `Group::from_name` return `Err(ENOENT: No such file or directory)` instead of `Ok(None)`, so the test wording miss-matches and the tests fail spuriously.

Accept either form so the tests stay meaningful regardless of the host's NSS configuration.

## Related Issue

N/A

## Changes

- Added an `assert_unknown_identity_lookup_failed` helper in `crates/openshell-sandbox/src/process.rs` tests that accepts `not found`, `ENOENT`, or `No such file or directory`.
- Updated `drop_privileges_*_unknown_*` tests to use the helper.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests pass on environments where NSS returns `Ok(None)` and where it returns `Err(ENOENT)`
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable — test-only change)