### PR TITLE
refactor(sandbox): remove dead relay_response_to_client wrapper

### DIFF
--- a/crates/openshell-sandbox/src/l7/rest.rs
+++ b/crates/openshell-sandbox/src/l7/rest.rs
@@ -234,8 +234,6 @@ fn rewrite_request_line_target(
     Ok(out)
 }
 
-// Used only in tests; kept as a `pub(crate)` helper for clarity.
-#[allow(dead_code)]
 pub(crate) fn parse_target_query(target: &str) -> Result<(String, HashMap<String, Vec<String>>)> {
     match target.split_once('?') {
         Some((path, query)) => Ok((path.to_string(), parse_query_params(query)?)),
@@ -695,28 +693,6 @@ fn find_crlf(buf: &[u8], start: usize) -> Option<usize> {
         .windows(2)
         .position(|w| w == b"\r\n")
         .map(|offset| start + offset)
-}
-
-/// Read and relay a full HTTP response (headers + body) from upstream to client.
-///
-/// Returns a [`RelayOutcome`] indicating whether the connection is reusable,
-/// consumed, or has been upgraded (101 Switching Protocols).
-///
-/// Note: callers that receive `Upgraded` are responsible for switching to
-/// raw bidirectional relay and forwarding the overflow bytes.
-// Public helper retained as part of the relay API surface; internal callers
-// currently use `relay_response` directly.
-#[allow(dead_code)]
-pub(crate) async fn relay_response_to_client<U, C>(
-    upstream: &mut U,
-    client: &mut C,
-    request_method: &str,
-) -> Result<RelayOutcome>
-where
-    U: AsyncRead + Unpin,
-    C: AsyncWrite + Unpin,
-{
-    relay_response(request_method, upstream, client).await
 }
 
 async fn relay_response<U, C>(


### PR DESCRIPTION
`relay_response_to_client` in `crates/openshell-sandbox/src/l7/rest.rs` was a thin wrapper around the private `relay_response` function with no callers. Every call site inside the crate uses `relay_response` directly. The two lines above `parse_target_query` were also removed: the comment claiming it is test-only is incorrect since `proxy.rs` calls it from production code, and the `#[allow(dead_code)]` was there only to suppress the warning caused by that wrong comment.

This is a Rust codebase. The language was confirmed via the `.rs` file extensions, `Cargo.toml`, and the `cargo check` and `cargo test` toolchain.

Changes

- `crates/openshell-sandbox/src/l7/rest.rs`: removed `relay_response_to_client` and the misleading annotations above `parse_target_query`

Testing

- `cargo check -p openshell-sandbox` passed with no errors
- `cargo test -p openshell-sandbox` ran 551 unit tests and all integration tests with 0 failures

Checklist

- [x] Follows conventional commit format
- [x] No new logic introduced
- [x] No secrets or credentials in the diff
- [x] Scoped to dead code removal only