### PR TITLE
docs: fix broken link and capitalise GitHub correctly

### DIFF
--- a/docs/get-started/tutorials/first-network-policy.mdx
+++ b/docs/get-started/tutorials/first-network-policy.mdx
@@ -218,4 +218,4 @@ bash examples/sandbox-policy-quickstart/demo.sh
 
 ## Next Steps
 
-- To walk through a full policy iteration with Claude Code, including diagnosing denials and applying fixes from outside the sandbox, refer to [Github Sandbox](/tutorials/github-sandbox).
+- To walk through a full policy iteration with Claude Code, including diagnosing denials and applying fixes from outside the sandbox, refer to [GitHub Sandbox](/tutorials/github-sandbox).

--- a/docs/get-started/tutorials/github-sandbox.mdx
+++ b/docs/get-started/tutorials/github-sandbox.mdx
@@ -348,4 +348,4 @@ The following resources cover related topics in greater depth:
 
 - To add per-repository access levels (read-write vs read-only) or restrict to specific API methods, refer to the [Policy Schema Reference](/reference/policy-schema).
 - To learn the full policy iteration workflow (pull, edit, push, verify), refer to [Policies](/sandboxes/policies).
-- To inject credentials automatically instead of pasting tokens, refer to [Manage Providers](/sandboxes/manage-providers
+- To inject credentials automatically instead of pasting tokens, refer to [Manage Providers](/sandboxes/manage-providers)

--- a/docs/sandboxes/manage-providers.mdx
+++ b/docs/sandboxes/manage-providers.mdx
@@ -156,7 +156,7 @@ The following provider types are supported.
 | `claude` | `ANTHROPIC_API_KEY`, `CLAUDE_API_KEY` | Claude Code, Anthropic API |
 | `codex` | `OPENAI_API_KEY` | OpenAI Codex |
 | `generic` | User-defined | Any service with custom credentials |
-| `github` | `GITHUB_TOKEN`, `GH_TOKEN` | GitHub API, `gh` CLI — refer to [Github Sandbox](/tutorials/github-sandbox) |
+| `github` | `GITHUB_TOKEN`, `GH_TOKEN` | GitHub API, `gh` CLI — refer to [GitHub Sandbox](/tutorials/github-sandbox) |
 | `gitlab` | `GITLAB_TOKEN`, `GLAB_TOKEN`, `CI_JOB_TOKEN` | GitLab API, `glab` CLI |
 | `nvidia` | `NVIDIA_API_KEY` | NVIDIA API Catalog |
 | `openai` | `OPENAI_API_KEY` | Any OpenAI-compatible endpoint. Set `--config OPENAI_BASE_URL` to point to the provider. Refer to [Configure](/inference/configure). |

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -235,7 +235,7 @@ openshell sandbox delete my-sandbox
 
 ## Next Steps
 
-- To follow a complete end-to-end example, refer to the [Github Sandbox](/tutorials/github-sandbox) tutorial.
+- To follow a complete end-to-end example, refer to the [GitHub Sandbox](/tutorials/github-sandbox) tutorial.
 - To supply API keys or tokens, refer to [Manage Providers](/sandboxes/manage-providers).
 - To control what the agent can access, refer to [Policies](/sandboxes/policies).
 - To use a pre-built environment, refer to the [Community Sandboxes](/sandboxes/community-sandboxes) catalog.

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -454,7 +454,7 @@ Endpoints without `protocol` use TCP passthrough, where the proxy allows the str
 Allow Claude and the GitHub CLI to reach `api.github.com` with per-path rules: read-only (GET, HEAD, OPTIONS) and GraphQL (POST) for all paths; full write access for `alpha-repo`; and create/edit issues only for `bravo-repo`. Replace `<org_name>` with your GitHub org or username.
 
 <Tip>
-For an end-to-end walkthrough that combines this policy with a GitHub credential provider and sandbox creation, refer to [Github Sandbox](/tutorials/github-sandbox).
+For an end-to-end walkthrough that combines this policy with a GitHub credential provider and sandbox creation, refer to [GitHub Sandbox](/tutorials/github-sandbox).
 
 </Tip>
 


### PR DESCRIPTION
Summary

- Fix missing closing parenthesis on the Manage Providers link in `github-sandbox.mdx` (line 351)
- Correct four instances of `Github` → `GitHub` across the docs

Related Issue: No issue.

Changes

| File | Change |
|---|---|
| `docs/get-started/tutorials/github-sandbox.mdx` | Add missing `)` to close the Manage Providers link |
| `docs/sandboxes/manage-sandboxes.mdx` | `Github` → `GitHub` |
| `docs/sandboxes/manage-providers.mdx` | `Github` → `GitHub` |
| `docs/sandboxes/policies.mdx` | `Github` → `GitHub` |
| `docs/get-started/tutorials/first-network-policy.mdx` | `Github` → `GitHub` |

Testing

- [x] No code changes: docs only
- [x] Verified existing Fern redirects cover the `/tutorials/` paths, so link destinations are unchanged

Checklist

- [x] Follows the docs style guide (active voice, no filler)
- [x] No Rust or config changes
- [x] Conventional commit message used