### PR TITLE
docs: document --drivers flag and compute driver auto-detection

### DIFF
--- a/docs/sandboxes/manage-gateways.mdx
+++ b/docs/sandboxes/manage-gateways.mdx
@@ -160,6 +160,7 @@ openshell gateway info --name my-remote-cluster
 
 | Flag | Purpose |
 |---|---|
+| `--drivers` | Compute driver to use: `kubernetes`, `docker`, `podman`, or `vm`. When omitted, the gateway auto-detects the driver based on the runtime environment, checking in priority order: Kubernetes → Podman → Docker. The `vm` driver is never auto-detected and must be set explicitly. |
 | `--gpu` | Enable NVIDIA GPU passthrough. Requires NVIDIA drivers and the Container Toolkit on the host. OpenShell auto-selects CDI when enabled on the daemon and falls back to Docker's NVIDIA GPU request path (`--gpus all`) otherwise. |
 | `--plaintext` | Listen on HTTP instead of mTLS. Use behind a TLS-terminating reverse proxy. |
 | `--disable-gateway-auth` | Skip mTLS client certificate checks. Use when a reverse proxy cannot forward client certs. |


### PR DESCRIPTION
- Add `--drivers` row to the Advanced Start Options table in `manage-gateways.mdx`
- Documents the auto-detection priority order (Kubernetes → Podman → Docker) and the fact that `vm` must be set explicitly

 Related Issue: Follows up on #1088, which added auto-detection but left the architecture docs checkbox unchecked.

| File | Change |
|---|---|
| `docs/sandboxes/manage-gateways.mdx` | Add one table row documenting `--drivers` and auto-detection behaviour |

Testing

- [x] Docs only — no code changes
- [x] Verified flag name and detection priority against `crates/openshell-server/src/cli.rs` (line 67–82) and `crates/openshell-core/src/config.rs`

Checklist

- [x] Follows the docs style guide (active voice, no filler)
- [x] Conventional commit message used
- [x] DCO sign-off included