### PR TITLE
docs: add Debian package install option to quickstart

### DIFF
--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -31,6 +31,14 @@ If you prefer [uv](https://docs.astral.sh/uv/):
 uv tool install -U openshell
 ```
 
+On Debian and Ubuntu, download the `.deb` package from the [GitHub releases page](https://github.com/NVIDIA/OpenShell/releases) and install it:
+
+```shell
+sudo dpkg -i openshell_<version>_amd64.deb
+```
+
+The package includes the CLI, the gateway binary, and the VM compute driver.
+
 After installing the CLI, run `openshell --help` in your terminal to see the full CLI reference, including all commands and flags.
 
 <Tip>


### PR DESCRIPTION
The Debian package was added in #1069 but the quickstart page only showed the curl script and uv install options. This adds a third option for Debian and Ubuntu users.

Related Issue: Follows from #1069.

Added a Debian install section to the Install the OpenShell CLI part of the quickstart page. It links to the GitHub releases page and shows the dpkg install command.

Documentation change only.

Checklist

- [x] Follows the docs style guide
- [x] No duplicate H1
- [x] Active voice
- [x] Shell fence for copyable command