### PR TITLE
fix(inference): route codex requests to non-versioned backends

### DIFF
--- a/crates/openshell-router/src/backend.rs
+++ b/crates/openshell-router/src/backend.rs
@@ -518,6 +518,10 @@ fn build_backend_url(endpoint: &str, path: &str) -> String {
         return format!("{base}{}", &path[3..]);
     }
 
+    if path == "/v1/codex" || path.starts_with("/v1/codex/") {
+        return format!("{base}{}", &path[3..]);
+    }
+
     format!("{base}{path}")
 }
 
@@ -550,6 +554,14 @@ mod tests {
         assert_eq!(
             build_backend_url("https://api.openai.com/v1", "/v1"),
             "https://api.openai.com/v1"
+        );
+    }
+
+    #[test]
+    fn build_backend_url_strips_v1_for_codex_backend() {
+        assert_eq!(
+            build_backend_url("https://chatgpt.com/backend-api", "/v1/codex/responses"),
+            "https://chatgpt.com/backend-api/codex/responses"
         );
     }
 

--- a/crates/openshell-router/tests/backend_integration.rs
+++ b/crates/openshell-router/tests/backend_integration.rs
@@ -109,6 +109,51 @@ async fn proxy_upstream_401_returns_error() {
 }
 
 #[tokio::test]
+async fn proxy_strips_v1_before_forwarding_codex_to_non_versioned_base() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/codex/responses"))
+        .and(bearer_token("test-api-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+        .mount(&mock_server)
+        .await;
+
+    let router = Router::new().unwrap();
+    let candidates = vec![ResolvedRoute {
+        name: "inference.local".to_string(),
+        endpoint: mock_server.uri(),
+        model: "gpt-5.4".to_string(),
+        api_key: "test-api-key".to_string(),
+        protocols: vec!["openai_responses".to_string()],
+        auth: AuthHeader::Bearer,
+        default_headers: Vec::new(),
+        passthrough_headers: Vec::new(),
+        timeout: openshell_router::config::DEFAULT_ROUTE_TIMEOUT,
+    }];
+
+    let body = serde_json::to_vec(&serde_json::json!({
+        "model": "gpt-5.4",
+        "input": "Hello"
+    }))
+    .unwrap();
+
+    let response = router
+        .proxy_with_candidates(
+            "openai_responses",
+            "POST",
+            "/v1/codex/responses",
+            vec![("content-type".to_string(), "application/json".to_string())],
+            bytes::Bytes::from(body),
+            &candidates,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status, 200);
+}
+
+#[tokio::test]
 async fn proxy_no_compatible_route_returns_error() {
     let router = Router::new().unwrap();
     let candidates = vec![ResolvedRoute {

--- a/crates/openshell-sandbox/src/l7/inference.rs
+++ b/crates/openshell-sandbox/src/l7/inference.rs
@@ -39,6 +39,12 @@ pub fn default_patterns() -> Vec<InferenceApiPattern> {
         },
         InferenceApiPattern {
             method: "POST".to_string(),
+            path_glob: "/v1/codex/*".to_string(),
+            protocol: "openai_responses".to_string(),
+            kind: "codex_responses".to_string(),
+        },
+        InferenceApiPattern {
+            method: "POST".to_string(),
             path_glob: "/v1/messages".to_string(),
             protocol: "anthropic_messages".to_string(),
             kind: "messages".to_string(),
@@ -395,6 +401,14 @@ mod tests {
     fn detect_openai_responses() {
         let patterns = default_patterns();
         let result = detect_inference_pattern("POST", "/v1/responses", &patterns);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().protocol, "openai_responses");
+    }
+
+    #[test]
+    fn detect_codex_responses() {
+        let patterns = default_patterns();
+        let result = detect_inference_pattern("POST", "/v1/codex/responses", &patterns);
         assert!(result.is_some());
         assert_eq!(result.unwrap().protocol, "openai_responses");
     }

--- a/docs/inference/about.mdx
+++ b/docs/inference/about.mdx
@@ -43,6 +43,7 @@ Supported request patterns depend on the provider configured for `inference.loca
 | Chat Completions | `POST` | `/v1/chat/completions` |
 | Completions | `POST` | `/v1/completions` |
 | Responses | `POST` | `/v1/responses` |
+| OpenAI OAuth Codex | `POST` | `/v1/codex/*` |
 | Model Discovery | `GET` | `/v1/models` |
 | Model Discovery | `GET` | `/v1/models/*` |
 

--- a/docs/inference/configure.mdx
+++ b/docs/inference/configure.mdx
@@ -158,6 +158,8 @@ The client-supplied `model` and `api_key` values are not sent upstream. The priv
 
 Some SDKs require a non-empty API key even though `inference.local` does not use the sandbox-provided value. In those cases, pass any placeholder such as `test` or `unused`.
 
+OpenAI OAuth Codex clients can also use the local endpoint. If the Codex client appends `/codex/responses` to the configured base URL, set the base URL to `https://inference.local/v1`. OpenShell matches `/v1/codex/*` and forwards those requests to upstream backends that do not expose a `/v1` prefix.
+
 Use this endpoint when inference should stay local to the host for privacy and security reasons. External providers that should be reached directly belong in `network_policies` instead.
 
 When the upstream runs on the same machine as the gateway, bind it to `0.0.0.0` and point the provider at `host.openshell.internal` or the host's LAN IP. `127.0.0.1` and `localhost` usually fail because the request originates from the gateway or sandbox runtime, not from your shell.

--- a/examples/local-inference/README.md
+++ b/examples/local-inference/README.md
@@ -163,4 +163,5 @@ In cluster mode, use `openshell cluster inference set` instead.
 | `POST /v1/chat/completions` | `openai_chat_completions` | Chat completion |
 | `POST /v1/completions` | `openai_completions` | Text completion |
 | `POST /v1/responses` | `openai_responses` | Responses API |
+| `POST /v1/codex/*` | `openai_responses` | OpenAI OAuth Codex responses |
 | `POST /v1/messages` | `anthropic_messages` | Anthropic messages |


### PR DESCRIPTION
## Summary

This is the separate OpenAI Codex OAuth follow-up requested in #618. It adds Codex-specific matching for `/v1/codex/*` requests and rewrites only that Codex path when forwarding to non-versioned upstream backends such as `chatgpt.com/backend-api`. Multi-model routing and Ollama support from #618 are intentionally not included.

## Related Issue

Follow-up to #618.

This specifically matches the review request there to split out just the Codex path fix into a narrowly scoped PR.

## Changes

- add sandbox inference matching for `POST /v1/codex/*` as `openai_responses`
- rewrite forwarded OpenAI Codex OAuth requests from `/v1/codex/...` to `/codex/...` for non-versioned upstream bases
- preserve existing behavior for non-Codex `/v1/*` routes
- add focused router unit and integration coverage for the Codex path handling
- update user-facing inference docs and examples to document OpenAI Codex OAuth support through `https://inference.local/v1`

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

Manual / focused testing:
- manually tested from a fresh OpenShell setup
- verified with curl requests to `https://inference.local/v1` within the sandbox
- verified OpenClaw OpenAI OAuth Codex through `https://inference.local/v1`
- confirmed Codex requests are forwarded to non-versioned upstreams without the extra `/v1` prefix
- `cargo test -p openshell-router --lib verify_`
- `cargo test -p openshell-cli --test sandbox_create_lifecycle_integration sandbox_create_keeps_sandbox_with_forwarding -- --exact --nocapture`
- `mise run docs`

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)