### PR TITLE
fix(e2e): stabilize wildcard host DNS test

### DIFF
--- a/e2e/python/test_sandbox_policy.py
+++ b/e2e/python/test_sandbox_policy.py
@@ -30,6 +30,10 @@ _BASE_PROCESS = sandbox_pb2.ProcessPolicy(run_as_user="sandbox", run_as_group="s
 # Standard proxy address inside the sandbox network namespace
 _PROXY_HOST = "10.200.0.1"
 _PROXY_PORT = 3128
+# sslip.io keeps the wildcard test on deterministic public DNS. Vendor-owned
+# telemetry subdomains can be NXDOMAIN or resolve to private ranges in CI.
+_PUBLIC_WILDCARD_SUFFIX = "1.1.1.1.sslip.io"
+_PUBLIC_WILDCARD_PATTERN = f"*.{_PUBLIC_WILDCARD_SUFFIX}"
 
 
 def _base_policy(
@@ -1835,22 +1839,25 @@ def test_single_port_backwards_compat(
 # Host wildcard tests
 # =============================================================================
 #
-# HW-1: Wildcard *.anthropic.com matches subdomains
-# HW-2: Wildcard *.anthropic.com does NOT match anthropic.com (bare domain)
-# HW-3: Wildcard *.anthropic.com does NOT match deep.sub.anthropic.com
+# HW-1: Wildcard host pattern matches subdomains
+# HW-2: Wildcard host pattern does NOT match the bare domain
+# HW-3: Wildcard host pattern does NOT match deep subdomains
 # =============================================================================
 
 
 def test_host_wildcard_matches_subdomain(
     sandbox: Callable[..., Sandbox],
 ) -> None:
-    """HW-1: *.anthropic.com matches api.anthropic.com."""
+    """HW-1: host wildcard matches single-label subdomains."""
     policy = _base_policy(
         network_policies={
             "wildcard": sandbox_pb2.NetworkPolicyRule(
                 name="wildcard",
                 endpoints=[
-                    sandbox_pb2.NetworkEndpoint(host="*.anthropic.com", port=443),
+                    sandbox_pb2.NetworkEndpoint(
+                        host=_PUBLIC_WILDCARD_PATTERN,
+                        port=443,
+                    ),
                 ],
                 binaries=[sandbox_pb2.NetworkBinary(path="/**")],
             ),
@@ -1858,38 +1865,44 @@ def test_host_wildcard_matches_subdomain(
     )
     spec = datamodel_pb2.SandboxSpec(policy=policy)
     with sandbox(spec=spec, delete_on_exit=True) as sb:
-        # api.anthropic.com -> matches *.anthropic.com
-        result = sb.exec_python(_proxy_connect(), args=("api.anthropic.com", 443))
+        first_subdomain = f"alpha.{_PUBLIC_WILDCARD_SUFFIX}"
+        result = sb.exec_python(_proxy_connect(), args=(first_subdomain, 443))
         assert result.exit_code == 0, result.stderr
         assert "200" in result.stdout, (
-            f"*.anthropic.com should match api.anthropic.com: {result.stdout}"
+            f"{_PUBLIC_WILDCARD_PATTERN} should match {first_subdomain}: "
+            f"{result.stdout}"
         )
 
-        # statsig.anthropic.com -> also matches *.anthropic.com
-        result = sb.exec_python(_proxy_connect(), args=("statsig.anthropic.com", 443))
+        second_subdomain = f"beta.{_PUBLIC_WILDCARD_SUFFIX}"
+        result = sb.exec_python(_proxy_connect(), args=(second_subdomain, 443))
         assert result.exit_code == 0, result.stderr
         assert "200" in result.stdout, (
-            f"*.anthropic.com should match statsig.anthropic.com: {result.stdout}"
+            f"{_PUBLIC_WILDCARD_PATTERN} should match {second_subdomain}: "
+            f"{result.stdout}"
         )
 
-        # example.com -> does NOT match *.anthropic.com
+        # example.com -> does NOT match the wildcard pattern
         result = sb.exec_python(_proxy_connect(), args=("example.com", 443))
         assert result.exit_code == 0, result.stderr
         assert "403" in result.stdout, (
-            f"*.anthropic.com should NOT match example.com: {result.stdout}"
+            f"{_PUBLIC_WILDCARD_PATTERN} should NOT match example.com: "
+            f"{result.stdout}"
         )
 
 
 def test_host_wildcard_rejects_bare_domain(
     sandbox: Callable[..., Sandbox],
 ) -> None:
-    """HW-2: *.anthropic.com does NOT match anthropic.com (requires a subdomain)."""
+    """HW-2: host wildcard does NOT match the bare domain."""
     policy = _base_policy(
         network_policies={
             "wildcard": sandbox_pb2.NetworkPolicyRule(
                 name="wildcard",
                 endpoints=[
-                    sandbox_pb2.NetworkEndpoint(host="*.anthropic.com", port=443),
+                    sandbox_pb2.NetworkEndpoint(
+                        host=_PUBLIC_WILDCARD_PATTERN,
+                        port=443,
+                    ),
                 ],
                 binaries=[sandbox_pb2.NetworkBinary(path="/**")],
             ),
@@ -1897,17 +1910,18 @@ def test_host_wildcard_rejects_bare_domain(
     )
     spec = datamodel_pb2.SandboxSpec(policy=policy)
     with sandbox(spec=spec, delete_on_exit=True) as sb:
-        result = sb.exec_python(_proxy_connect(), args=("anthropic.com", 443))
+        result = sb.exec_python(_proxy_connect(), args=(_PUBLIC_WILDCARD_SUFFIX, 443))
         assert result.exit_code == 0, result.stderr
         assert "403" in result.stdout, (
-            f"*.anthropic.com should NOT match bare anthropic.com: {result.stdout}"
+            f"{_PUBLIC_WILDCARD_PATTERN} should NOT match bare "
+            f"{_PUBLIC_WILDCARD_SUFFIX}: {result.stdout}"
         )
 
 
 def test_host_wildcard_rejects_deep_subdomain(
     sandbox: Callable[..., Sandbox],
 ) -> None:
-    """HW-3: *.anthropic.com does NOT match deep.sub.anthropic.com.
+    """HW-3: host wildcard does NOT match a deep subdomain.
 
     Single * matches one DNS label only (does not cross . boundaries).
     """
@@ -1916,7 +1930,10 @@ def test_host_wildcard_rejects_deep_subdomain(
             "wildcard": sandbox_pb2.NetworkPolicyRule(
                 name="wildcard",
                 endpoints=[
-                    sandbox_pb2.NetworkEndpoint(host="*.anthropic.com", port=443),
+                    sandbox_pb2.NetworkEndpoint(
+                        host=_PUBLIC_WILDCARD_PATTERN,
+                        port=443,
+                    ),
                 ],
                 binaries=[sandbox_pb2.NetworkBinary(path="/**")],
             ),
@@ -1924,10 +1941,12 @@ def test_host_wildcard_rejects_deep_subdomain(
     )
     spec = datamodel_pb2.SandboxSpec(policy=policy)
     with sandbox(spec=spec, delete_on_exit=True) as sb:
-        result = sb.exec_python(_proxy_connect(), args=("deep.sub.anthropic.com", 443))
+        deep_subdomain = f"deep.sub.{_PUBLIC_WILDCARD_SUFFIX}"
+        result = sb.exec_python(_proxy_connect(), args=(deep_subdomain, 443))
         assert result.exit_code == 0, result.stderr
         assert "403" in result.stdout, (
-            f"*.anthropic.com should NOT match deep.sub.anthropic.com: {result.stdout}"
+            f"{_PUBLIC_WILDCARD_PATTERN} should NOT match {deep_subdomain}: "
+            f"{result.stdout}"
         )
 
 


### PR DESCRIPTION
## Summary

Stabilize the Python e2e wildcard-host policy test by replacing the Anthropic telemetry subdomain with deterministic public `sslip.io` hostnames. The previous `statsig.anthropic.com` target can be NXDOMAIN or resolve to private ranges in CI, causing the SSRF guard to correctly return `403` before the wildcard match assertion can pass.

## Related Issue

N/A

## Changes

- Added shared wildcard test constants backed by `1.1.1.1.sslip.io`.
- Updated host wildcard positive and negative cases to use deterministic public DNS instead of vendor telemetry DNS.
- Kept the test coverage focused on single-label wildcard matching, bare-domain rejection, and deep-subdomain rejection.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated - not applicable; test-only e2e stabilization
- [x] E2E tests added/updated - updated the Python e2e wildcard-host coverage, not run locally because no active `OPENSHELL_GATEWAY` was configured

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) - not applicable; test-only change