### PR TITLE
fix(server): pre-register prometheus metrics at startup

### DIFF
--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -36,6 +36,7 @@ mod tls;
 pub mod tracing_bus;
 mod ws_tunnel;
 
+use metrics::{Unit, describe_counter, describe_gauge, describe_histogram, gauge};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use openshell_core::{ComputeDriverKind, Config, Error, Result};
 use std::collections::HashMap;
@@ -262,6 +263,38 @@ pub async fn run_server(
         let prometheus_handle = PrometheusBuilder::new()
             .install_recorder()
             .map_err(|e| Error::config(format!("failed to install metrics recorder: {e}")))?;
+        // Record server start time so /metrics is non-empty from the first scrape.
+        // Without this, metrics-exporter-prometheus returns an empty body until the first
+        // request flows through MultiplexedService, causing Prometheus gaps on restart.
+        describe_gauge!(
+            "openshell_server_start_time_seconds",
+            Unit::Seconds,
+            "Unix timestamp of when the gateway server started"
+        );
+        gauge!("openshell_server_start_time_seconds").set(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs_f64(),
+        );
+        describe_counter!(
+            "openshell_server_grpc_requests_total",
+            "Total number of gRPC requests handled"
+        );
+        describe_histogram!(
+            "openshell_server_grpc_request_duration_seconds",
+            Unit::Seconds,
+            "gRPC request duration in seconds"
+        );
+        describe_counter!(
+            "openshell_server_http_requests_total",
+            "Total number of HTTP requests handled"
+        );
+        describe_histogram!(
+            "openshell_server_http_request_duration_seconds",
+            Unit::Seconds,
+            "HTTP request duration in seconds"
+        );
         let metrics_listener = TcpListener::bind(metrics_bind_address).await.map_err(|e| {
             Error::transport(format!(
                 "failed to bind metrics port {metrics_bind_address}: {e}",

--- a/crates/openshell-server/tests/metrics_preregistration.rs
+++ b/crates/openshell-server/tests/metrics_preregistration.rs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use metrics::{Unit, describe_counter, describe_gauge, describe_histogram, gauge};
+use metrics_exporter_prometheus::PrometheusBuilder;
+
+/// Verify that /metrics is non-empty from the first scrape after startup.
+///
+/// metrics-exporter-prometheus only emits a metric once a value has been recorded;
+/// `describe_*` alone is not sufficient. The server records `openshell_server_start_time_seconds`
+/// immediately after `install_recorder()` so the body is never empty.
+#[test]
+fn metrics_are_non_empty_before_any_request() {
+    let handle = PrometheusBuilder::new()
+        .install_recorder()
+        .expect("failed to install prometheus recorder");
+
+    describe_gauge!(
+        "openshell_server_start_time_seconds",
+        Unit::Seconds,
+        "Unix timestamp of when the gateway server started"
+    );
+    gauge!("openshell_server_start_time_seconds").set(1_000_000.0_f64);
+
+    describe_counter!(
+        "openshell_server_grpc_requests_total",
+        "Total number of gRPC requests handled"
+    );
+    describe_histogram!(
+        "openshell_server_grpc_request_duration_seconds",
+        Unit::Seconds,
+        "gRPC request duration in seconds"
+    );
+    describe_counter!(
+        "openshell_server_http_requests_total",
+        "Total number of HTTP requests handled"
+    );
+    describe_histogram!(
+        "openshell_server_http_request_duration_seconds",
+        Unit::Seconds,
+        "HTTP request duration in seconds"
+    );
+
+    let output = handle.render();
+    assert!(
+        !output.is_empty(),
+        "/metrics body should be non-empty after startup gauge is set"
+    );
+    assert!(
+        output.contains("openshell_server_start_time_seconds"),
+        "/metrics body missing startup gauge"
+    );
+}


### PR DESCRIPTION
> **🏗️ build-from-issue-agent**

## Summary
Records `openshell_server_start_time_seconds` immediately after `install_recorder()` so `/metrics` returns a non-empty body from the first Prometheus scrape after pod restart. `describe_*` calls are also added for all four request metrics so their HELP/TYPE metadata renders correctly once traffic arrives.

## Related Issue
Closes #1119

## Changes
- `crates/openshell-server/src/lib.rs`: Added `gauge!("openshell_server_start_time_seconds")` with current Unix timestamp and `describe_counter!`/`describe_histogram!` for the four request metrics, immediately after `install_recorder()`.
- `crates/openshell-server/tests/metrics_preregistration.rs` (new): Integration test asserting `handle.render()` is non-empty and contains `openshell_server_start_time_seconds` before any request is made.

### Deviations from Plan
The approved plan proposed using only `describe_*` macros. Investigation revealed that `metrics-exporter-prometheus` 0.18 only emits a metric in `render()` once a value has been recorded — descriptions alone produce no output. The fix was updated to also record a `openshell_server_start_time_seconds` gauge at startup (a standard Prometheus pattern used by most exporters). The `describe_*` calls are retained for HELP/TYPE metadata on request metrics.

## Testing
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (N/A — no e2e/ changes)

**Tests added:**
- **Unit:** `crates/openshell-server/tests/metrics_preregistration.rs::metrics_are_non_empty_before_any_request` — verifies `handle.render()` is non-empty and contains the startup gauge before any request flows through `MultiplexedService`
- **Integration:** N/A
- **E2E:** N/A

## Checklist
- [x] Follows Conventional Commits
- [x] Architecture docs updated (if applicable)

**Documentation updated:**
- None required — no published docs reference metrics startup behavior