### PR TITLE
fix(examples): repair multi-agent notepad uploads

### DIFF
--- a/e2e/rust/tests/upload_create.rs
+++ b/e2e/rust/tests/upload_create.rs
@@ -18,10 +18,10 @@ use std::fs;
 use openshell_e2e::harness::output::strip_ansi;
 use openshell_e2e::harness::sandbox::SandboxGuard;
 
-/// Create a sandbox with `--upload dir:/sandbox/data` and run a command that
-/// reads the uploaded files, verifying the content appears in stdout.
+/// Create a sandbox with `--upload dir:/sandbox/data` and verify directory
+/// uploads preserve the source basename at `/sandbox/data/<dirname>/...`.
 #[tokio::test]
-async fn create_with_upload_provides_files_to_command() {
+async fn create_with_upload_directory_preserves_source_basename() {
     let tmpdir = tempfile::tempdir().expect("create tmpdir");
 
     // Create a directory with files to upload.

--- a/examples/multi-agent-notepad/demo.sh
+++ b/examples/multi-agent-notepad/demo.sh
@@ -294,7 +294,7 @@ worker() {
     output_file="$(mktemp)"
     repo_path="runs/${RUN_ID}/notes/agent-${AGENT_INDEX}.md"
 
-    render_template /sandbox/prompts/worker.md "$slice" > "$prompt_file"
+    render_template /sandbox/payload/prompts/worker.md "$slice" > "$prompt_file"
     run_codex_to_file "$prompt_file" "$output_file"
     put_contents "$repo_path" "$output_file" "Add agent ${AGENT_INDEX} note for ${RUN_ID}"
     printf 'wrote %s\n' "$repo_path"
@@ -312,7 +312,7 @@ synthesis() {
         get_contents_file "runs/${RUN_ID}/notes/agent-${i}.md" "${notes_dir}/agent-${i}.md"
     done
 
-    render_template /sandbox/prompts/synthesis.md "" > "$prompt_file"
+    render_template /sandbox/payload/prompts/synthesis.md "" > "$prompt_file"
     {
         printf '\n\n## Worker Notes\n\n'
         for i in $(seq 1 "$AGENT_COUNT"); do
@@ -363,7 +363,7 @@ run_sandbox() {
         --policy "$POLICY_FILE" \
         --upload "${PAYLOAD_DIR}:/sandbox" \
         --no-tty \
-        -- bash /sandbox/demo-runner.sh "$@"
+        -- bash /sandbox/payload/demo-runner.sh "$@"
 }
 
 run_worker() {


### PR DESCRIPTION
## Summary

Fix the multi-agent notepad demo after the directory upload basename semantics change. The demo now invokes the uploaded runner and prompt files from `/sandbox/payload/...`, which is where `--upload <dir>:/sandbox` places the payload directory.

## Related Issue

Closes #1147

## Changes

- Updated worker and synthesis prompt paths to read from `/sandbox/payload/prompts/...`
- Updated the sandbox command to run `/sandbox/payload/demo-runner.sh`
- Renamed the existing upload e2e test to make the directory basename contract explicit

## Testing

- [x] `bash -n examples/multi-agent-notepad/demo.sh`
- [x] `cargo test -p openshell-e2e --features e2e create_with_upload_directory_preserves_source_basename --quiet` with `RUSTC_WRAPPER` unset
- [x] `mise run pre-commit` with `RUSTC_WRAPPER` unset

## Checklist

- [x] Follows Conventional Commits
- [x] Tests updated where useful
- [ ] Architecture docs updated (not applicable)