### PR TITLE
feat(gpu): introduce GPU request spec

### DIFF
--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -82,7 +82,9 @@ users.
 Custom sandbox images must include the agent runtime and any system
 dependencies, but they should not need to include the gateway. GPU-capable
 images must include the user-space libraries required by the workload. The
-runtime still owns GPU device injection.
+runtime still owns GPU device injection. GPU requests can include explicit
+driver-native device IDs or a requested count; the gateway validates the public
+request shape and each runtime enforces the GPU allocation modes it supports.
 
 ## Deployment Shape
 

--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -45,6 +45,9 @@ through the driver configuration. The Helm chart defaults sandbox agents to
 `Unconfined` so runtime/default AppArmor profiles do not block supervisor
 network namespace setup on AppArmor-enabled nodes.
 
+GPU requests enter the driver layer through
+`SandboxSpec.resource_requirements.gpu`.
+
 VM runtime state paths are derived only from driver-validated sandbox IDs
 matching `[A-Za-z0-9._-]{1,128}`. The gateway-owned VM driver socket uses a
 private `run/` directory plus Unix peer UID/PID checks. Standalone

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -1217,8 +1217,12 @@ enum SandboxCommands {
         /// (for example "nvidia.com/gpu=0"); VM uses a PCI BDF or index.
         /// Specifying --gpu-device also requests GPU resources.
         /// When omitted with --gpu, the driver uses its default GPU selection.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "gpu_count")]
         gpu_device: Option<String>,
+
+        /// Request a specific number of GPUs. Mutually exclusive with --gpu-device.
+        #[arg(long, value_parser = clap::value_parser!(u32).range(1..), conflicts_with = "gpu_device")]
+        gpu_count: Option<u32>,
 
         /// CPU limit for the sandbox (for example: 500m, 1, 2.5).
         #[arg(long)]
@@ -2548,6 +2552,7 @@ async fn main() -> Result<()> {
                     editor,
                     gpu,
                     gpu_device,
+                    gpu_count,
                     cpu,
                     memory,
                     driver_config_json,
@@ -2629,6 +2634,7 @@ async fn main() -> Result<()> {
                         keep,
                         gpu,
                         gpu_device.as_deref(),
+                        gpu_count,
                         cpu.as_deref(),
                         memory.as_deref(),
                         driver_config_json.as_deref(),
@@ -4396,6 +4402,52 @@ mod tests {
             }
             other => panic!("expected SandboxCommands::Create, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn sandbox_create_gpu_count_parses_without_gpu_flag() {
+        let cli = Cli::try_parse_from(["openshell", "sandbox", "create", "--gpu-count", "2"])
+            .expect("sandbox create --gpu-count should parse");
+
+        match cli.command {
+            Some(Commands::Sandbox {
+                command: Some(SandboxCommands::Create { gpu, gpu_count, .. }),
+                ..
+            }) => {
+                assert!(!gpu);
+                assert_eq!(gpu_count, Some(2));
+            }
+            other => panic!("expected SandboxCommands::Create, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sandbox_create_gpu_count_rejects_zero() {
+        let result = Cli::try_parse_from(["openshell", "sandbox", "create", "--gpu-count", "0"]);
+
+        assert!(
+            result.is_err(),
+            "sandbox create --gpu-count 0 should be rejected"
+        );
+    }
+
+    #[test]
+    fn sandbox_create_gpu_count_conflicts_with_gpu_device() {
+        let result = Cli::try_parse_from([
+            "openshell",
+            "sandbox",
+            "create",
+            "--gpu",
+            "--gpu-device",
+            "nvidia.com/gpu=0",
+            "--gpu-count",
+            "2",
+        ]);
+
+        assert!(
+            result.is_err(),
+            "sandbox create should reject --gpu-count with --gpu-device"
+        );
     }
 
     #[test]

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -1215,8 +1215,9 @@ enum SandboxCommands {
 
         /// Target a driver-specific GPU device. Docker and Podman use CDI device IDs
         /// (for example "nvidia.com/gpu=0"); VM uses a PCI BDF or index.
-        /// Only valid with --gpu. When omitted with --gpu, the driver uses its default GPU selection.
-        #[arg(long, requires = "gpu")]
+        /// Specifying --gpu-device also requests GPU resources.
+        /// When omitted with --gpu, the driver uses its default GPU selection.
+        #[arg(long)]
         gpu_device: Option<String>,
 
         /// CPU limit for the sandbox (for example: 500m, 1, 2.5).
@@ -4366,6 +4367,32 @@ mod tests {
                 ..
             }) => {
                 assert_eq!(driver_config_json.as_deref(), Some(json));
+            }
+            other => panic!("expected SandboxCommands::Create, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sandbox_create_gpu_device_parses_without_gpu_flag() {
+        let cli = Cli::try_parse_from([
+            "openshell",
+            "sandbox",
+            "create",
+            "--gpu-device",
+            "nvidia.com/gpu=0",
+        ])
+        .expect("sandbox create --gpu-device should parse without --gpu");
+
+        match cli.command {
+            Some(Commands::Sandbox {
+                command:
+                    Some(SandboxCommands::Create {
+                        gpu, gpu_device, ..
+                    }),
+                ..
+            }) => {
+                assert!(!gpu);
+                assert_eq!(gpu_device.as_deref(), Some("nvidia.com/gpu=0"));
             }
             other => panic!("expected SandboxCommands::Create, got: {other:?}"),
         }

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -39,17 +39,18 @@ use openshell_core::proto::{
     GetClusterInferenceRequest, GetDraftHistoryRequest, GetDraftPolicyRequest,
     GetGatewayConfigRequest, GetProviderProfileRequest, GetProviderRefreshStatusRequest,
     GetProviderRequest, GetSandboxConfigRequest, GetSandboxLogsRequest,
-    GetSandboxPolicyStatusRequest, GetSandboxRequest, GetServiceRequest, HealthRequest,
-    ImportProviderProfilesRequest, LintProviderProfilesRequest, ListProviderProfilesRequest,
-    ListProvidersRequest, ListSandboxPoliciesRequest, ListSandboxProvidersRequest,
-    ListSandboxesRequest, ListServicesRequest, PlatformEvent, PolicySource, PolicyStatus, Provider,
-    ProviderCredentialRefreshStatus, ProviderCredentialRefreshStrategy, ProviderProfile,
-    ProviderProfileDiagnostic, ProviderProfileImportItem, RejectDraftChunkRequest,
-    RevokeSshSessionRequest, RotateProviderCredentialRequest, Sandbox, SandboxPhase, SandboxPolicy,
-    SandboxSpec, SandboxTemplate, ServiceEndpointResponse, SetClusterInferenceRequest,
-    SettingScope, SettingValue, TcpForwardFrame, TcpForwardInit, TcpRelayTarget,
-    UpdateConfigRequest, UpdateProviderRequest, WatchSandboxRequest, exec_sandbox_event,
-    setting_value, tcp_forward_init,
+    GetSandboxPolicyStatusRequest, GetSandboxRequest, GetServiceRequest, GpuRequestSpec,
+    HealthRequest, ImportProviderProfilesRequest, LintProviderProfilesRequest,
+    ListProviderProfilesRequest, ListProvidersRequest, ListSandboxPoliciesRequest,
+    ListSandboxProvidersRequest, ListSandboxesRequest, ListServicesRequest, PlatformEvent,
+    PolicySource, PolicyStatus, Provider, ProviderCredentialRefreshStatus,
+    ProviderCredentialRefreshStrategy, ProviderProfile, ProviderProfileDiagnostic,
+    ProviderProfileImportItem, RejectDraftChunkRequest, RevokeSshSessionRequest,
+    RotateProviderCredentialRequest, Sandbox, SandboxPhase, SandboxPolicy, SandboxSpec,
+    SandboxTemplate, ServiceEndpointResponse, SetClusterInferenceRequest, SettingScope,
+    SettingValue, TcpForwardFrame, TcpForwardInit, TcpRelayTarget, UpdateConfigRequest,
+    UpdateProviderRequest, WatchSandboxRequest, exec_sandbox_event, setting_value,
+    tcp_forward_init,
 };
 use openshell_core::settings::{self, SettingValueKind};
 use openshell_core::{ObjectId, ObjectName};
@@ -1745,6 +1746,7 @@ pub async fn sandbox_create(
     keep: bool,
     gpu: bool,
     gpu_device: Option<&str>,
+    gpu_count: Option<u32>,
     cpu: Option<&str>,
     memory: Option<&str>,
     driver_config_json: Option<&str>,
@@ -1801,6 +1803,7 @@ pub async fn sandbox_create(
     };
     let requested_gpu = gpu
         || gpu_device.is_some_and(|device_id| !device_id.is_empty())
+        || gpu_count.is_some()
         || image.as_deref().is_some_and(image_requests_gpu);
 
     let providers_v2_enabled = gateway_providers_v2_enabled(&mut client).await?;
@@ -1836,8 +1839,7 @@ pub async fn sandbox_create(
 
     let request = CreateSandboxRequest {
         spec: Some(SandboxSpec {
-            gpu: requested_gpu,
-            gpu_device: gpu_device.unwrap_or_default().to_string(),
+            gpu: gpu_request_from_cli(requested_gpu, gpu_device, gpu_count),
             policy,
             providers: configured_providers,
             template,
@@ -2270,6 +2272,20 @@ pub async fn sandbox_create(
             "sandbox provisioning stream ended before reaching terminal phase"
         )),
     }
+}
+
+fn gpu_request_from_cli(
+    requested_gpu: bool,
+    gpu_device: Option<&str>,
+    gpu_count: Option<u32>,
+) -> Option<GpuRequestSpec> {
+    requested_gpu.then(|| GpuRequestSpec {
+        device_id: gpu_device
+            .filter(|device_id| !device_id.is_empty())
+            .map(|device_id| vec![device_id.to_string()])
+            .unwrap_or_default(),
+        count: gpu_count,
+    })
 }
 
 /// Resolved source for the `--from` flag on `sandbox create`.
@@ -7521,8 +7537,9 @@ mod tests {
         dockerfile_sources_supported_for_gateway, format_endpoint, format_gateway_select_header,
         format_gateway_select_items, format_provider_attachment_table, gateway_add,
         gateway_auth_label, gateway_env_override_warning, gateway_select_with, gateway_type_label,
-        git_sync_files, http_health_check, image_requests_gpu, import_local_package_mtls_bundle,
-        inferred_provider_type, mtls_certs_exist_for_gateway, package_managed_tls_dirs,
+        git_sync_files, gpu_request_from_cli, http_health_check, image_requests_gpu,
+        import_local_package_mtls_bundle, inferred_provider_type, mtls_certs_exist_for_gateway,
+        package_managed_tls_dirs,
         parse_cli_setting_value, parse_credential_expiry_cli_value, parse_credential_expiry_pairs,
         parse_credential_pairs, parse_driver_config_json, plaintext_gateway_is_remote,
         progress_step_from_metadata, provider_profile_allows_refresh_bootstrap,
@@ -8055,6 +8072,46 @@ mod tests {
                 "did not expect GPU detection for {image}"
             );
         }
+    }
+
+    #[test]
+    fn gpu_request_from_cli_uses_presence_with_empty_device_ids_for_default_gpu() {
+        let request =
+            gpu_request_from_cli(true, None, None).expect("gpu request should be present");
+
+        assert!(request.device_id.is_empty());
+        assert_eq!(request.count, None);
+    }
+
+    #[test]
+    fn gpu_request_from_cli_maps_gpu_device_to_one_device_id() {
+        let request = gpu_request_from_cli(true, Some("0000:2d:00.0"), None)
+            .expect("gpu request should be present");
+
+        assert_eq!(request.device_id, vec!["0000:2d:00.0"]);
+        assert_eq!(request.count, None);
+    }
+
+    #[test]
+    fn gpu_request_from_cli_maps_gpu_count() {
+        let request = gpu_request_from_cli(true, None, Some(2)).expect("gpu request should exist");
+
+        assert!(request.device_id.is_empty());
+        assert_eq!(request.count, Some(2));
+    }
+
+    #[test]
+    fn gpu_request_from_cli_preserves_device_and_gpu_count_for_gateway_validation() {
+        let request = gpu_request_from_cli(true, Some("nvidia.com/gpu=0"), Some(2))
+            .expect("gpu request should exist");
+
+        assert_eq!(request.device_id, vec!["nvidia.com/gpu=0"]);
+        assert_eq!(request.count, Some(2));
+    }
+
+    #[test]
+    fn gpu_request_from_cli_omits_gpu_request_when_not_requested() {
+        assert!(gpu_request_from_cli(false, Some("0"), None).is_none());
     }
 
     #[test]

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -1799,7 +1799,9 @@ pub async fn sandbox_create(
         }
         None => None,
     };
-    let requested_gpu = gpu || image.as_deref().is_some_and(image_requests_gpu);
+    let requested_gpu = gpu
+        || gpu_device.is_some_and(|device_id| !device_id.is_empty())
+        || image.as_deref().is_some_and(image_requests_gpu);
 
     let providers_v2_enabled = gateway_providers_v2_enabled(&mut client).await?;
     let inferred_types: Vec<String> = if providers_v2_enabled {

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -39,18 +39,18 @@ use openshell_core::proto::{
     GetClusterInferenceRequest, GetDraftHistoryRequest, GetDraftPolicyRequest,
     GetGatewayConfigRequest, GetProviderProfileRequest, GetProviderRefreshStatusRequest,
     GetProviderRequest, GetSandboxConfigRequest, GetSandboxLogsRequest,
-    GetSandboxPolicyStatusRequest, GetSandboxRequest, GetServiceRequest, GpuRequestSpec,
+    GetSandboxPolicyStatusRequest, GetSandboxRequest, GetServiceRequest, GpuResourceRequirement,
     HealthRequest, ImportProviderProfilesRequest, LintProviderProfilesRequest,
     ListProviderProfilesRequest, ListProvidersRequest, ListSandboxPoliciesRequest,
     ListSandboxProvidersRequest, ListSandboxesRequest, ListServicesRequest, PlatformEvent,
     PolicySource, PolicyStatus, Provider, ProviderCredentialRefreshStatus,
     ProviderCredentialRefreshStrategy, ProviderProfile, ProviderProfileDiagnostic,
     ProviderProfileImportItem, RejectDraftChunkRequest, RevokeSshSessionRequest,
-    RotateProviderCredentialRequest, Sandbox, SandboxPhase, SandboxPolicy, SandboxSpec,
-    SandboxTemplate, ServiceEndpointResponse, SetClusterInferenceRequest, SettingScope,
-    SettingValue, TcpForwardFrame, TcpForwardInit, TcpRelayTarget, UpdateConfigRequest,
-    UpdateProviderRequest, WatchSandboxRequest, exec_sandbox_event, setting_value,
-    tcp_forward_init,
+    RotateProviderCredentialRequest, Sandbox, SandboxPhase, SandboxPolicy,
+    SandboxResourceRequirements, SandboxSpec, SandboxTemplate, ServiceEndpointResponse,
+    SetClusterInferenceRequest, SettingScope, SettingValue, TcpForwardFrame, TcpForwardInit,
+    TcpRelayTarget, UpdateConfigRequest, UpdateProviderRequest, WatchSandboxRequest,
+    exec_sandbox_event, setting_value, tcp_forward_init,
 };
 use openshell_core::settings::{self, SettingValueKind};
 use openshell_core::{ObjectId, ObjectName};
@@ -1801,11 +1801,6 @@ pub async fn sandbox_create(
         }
         None => None,
     };
-    let requested_gpu = gpu
-        || gpu_device.is_some_and(|device_id| !device_id.is_empty())
-        || gpu_count.is_some()
-        || image.as_deref().is_some_and(image_requests_gpu);
-
     let providers_v2_enabled = gateway_providers_v2_enabled(&mut client).await?;
     let inferred_types: Vec<String> = if providers_v2_enabled {
         Vec::new()
@@ -1825,6 +1820,11 @@ pub async fn sandbox_create(
     let driver_config = driver_config_json
         .map(parse_driver_config_json)
         .transpose()?;
+    let resource_requirements =
+        resource_requirements_from_cli(image.as_deref(), gpu, gpu_device, gpu_count);
+    let requested_gpu = resource_requirements
+        .as_ref()
+        .is_some_and(|requirements| requirements.gpu.is_some());
 
     let template = if image.is_some() || resource_limits.is_some() || driver_config.is_some() {
         Some(SandboxTemplate {
@@ -1839,7 +1839,7 @@ pub async fn sandbox_create(
 
     let request = CreateSandboxRequest {
         spec: Some(SandboxSpec {
-            gpu: gpu_request_from_cli(requested_gpu, gpu_device, gpu_count),
+            resource_requirements,
             policy,
             providers: configured_providers,
             template,
@@ -2274,17 +2274,26 @@ pub async fn sandbox_create(
     }
 }
 
-fn gpu_request_from_cli(
-    requested_gpu: bool,
+fn resource_requirements_from_cli(
+    image: Option<&str>,
+    gpu: bool,
     gpu_device: Option<&str>,
     gpu_count: Option<u32>,
-) -> Option<GpuRequestSpec> {
-    requested_gpu.then(|| GpuRequestSpec {
-        device_id: gpu_device
-            .filter(|device_id| !device_id.is_empty())
-            .map(|device_id| vec![device_id.to_string()])
-            .unwrap_or_default(),
-        count: gpu_count,
+) -> Option<SandboxResourceRequirements> {
+    let device_ids = gpu_device
+        .filter(|device_id| !device_id.is_empty())
+        .map(|device_id| vec![device_id.to_string()])
+        .unwrap_or_default();
+    let requested_gpu = gpu
+        || gpu_count.is_some()
+        || !device_ids.is_empty()
+        || image.is_some_and(image_requests_gpu);
+
+    requested_gpu.then_some(SandboxResourceRequirements {
+        gpu: Some(GpuResourceRequirement {
+            device_ids,
+            count: gpu_count,
+        }),
     })
 }
 
@@ -7537,15 +7546,14 @@ mod tests {
         dockerfile_sources_supported_for_gateway, format_endpoint, format_gateway_select_header,
         format_gateway_select_items, format_provider_attachment_table, gateway_add,
         gateway_auth_label, gateway_env_override_warning, gateway_select_with, gateway_type_label,
-        git_sync_files, gpu_request_from_cli, http_health_check, image_requests_gpu,
-        import_local_package_mtls_bundle, inferred_provider_type, mtls_certs_exist_for_gateway,
-        package_managed_tls_dirs,
+        git_sync_files, http_health_check, image_requests_gpu, import_local_package_mtls_bundle,
+        inferred_provider_type, mtls_certs_exist_for_gateway, package_managed_tls_dirs,
         parse_cli_setting_value, parse_credential_expiry_cli_value, parse_credential_expiry_pairs,
         parse_credential_pairs, parse_driver_config_json, plaintext_gateway_is_remote,
         progress_step_from_metadata, provider_profile_allows_refresh_bootstrap,
         provisioning_timeout_message, ready_false_condition_message, refresh_status_header,
-        refresh_status_row, resolve_from, sandbox_should_persist, sandbox_upload_plan,
-        service_expose_status_error, service_url_for_gateway,
+        refresh_status_row, resolve_from, resource_requirements_from_cli, sandbox_should_persist,
+        sandbox_upload_plan, service_expose_status_error, service_url_for_gateway,
     };
     use crate::TEST_ENV_LOCK;
     use hyper::StatusCode;
@@ -8075,43 +8083,64 @@ mod tests {
     }
 
     #[test]
-    fn gpu_request_from_cli_uses_presence_with_empty_device_ids_for_default_gpu() {
-        let request =
-            gpu_request_from_cli(true, None, None).expect("gpu request should be present");
+    fn resource_requirements_from_cli_uses_presence_for_default_gpu() {
+        let requirements = resource_requirements_from_cli(None, true, None, None)
+            .expect("resource requirements should be present");
+        let gpu = requirements.gpu.expect("GPU requirement should be present");
 
-        assert!(request.device_id.is_empty());
-        assert_eq!(request.count, None);
+        assert!(gpu.device_ids.is_empty());
+        assert_eq!(gpu.count, None);
     }
 
     #[test]
-    fn gpu_request_from_cli_maps_gpu_device_to_one_device_id() {
-        let request = gpu_request_from_cli(true, Some("0000:2d:00.0"), None)
-            .expect("gpu request should be present");
+    fn resource_requirements_from_cli_maps_gpu_device_to_one_device_id() {
+        let requirements = resource_requirements_from_cli(None, false, Some("0000:2d:00.0"), None)
+            .expect("resource requirements should be present");
+        let gpu = requirements.gpu.expect("GPU requirement should be present");
 
-        assert_eq!(request.device_id, vec!["0000:2d:00.0"]);
-        assert_eq!(request.count, None);
+        assert_eq!(gpu.device_ids, vec!["0000:2d:00.0"]);
+        assert_eq!(gpu.count, None);
     }
 
     #[test]
-    fn gpu_request_from_cli_maps_gpu_count() {
-        let request = gpu_request_from_cli(true, None, Some(2)).expect("gpu request should exist");
+    fn resource_requirements_from_cli_maps_gpu_count() {
+        let requirements = resource_requirements_from_cli(None, false, None, Some(2))
+            .expect("requirements should exist");
+        let gpu = requirements.gpu.expect("GPU requirement should be present");
 
-        assert!(request.device_id.is_empty());
-        assert_eq!(request.count, Some(2));
+        assert!(gpu.device_ids.is_empty());
+        assert_eq!(gpu.count, Some(2));
     }
 
     #[test]
-    fn gpu_request_from_cli_preserves_device_and_gpu_count_for_gateway_validation() {
-        let request = gpu_request_from_cli(true, Some("nvidia.com/gpu=0"), Some(2))
-            .expect("gpu request should exist");
+    fn resource_requirements_from_cli_preserves_device_and_gpu_count_for_gateway_validation() {
+        let requirements =
+            resource_requirements_from_cli(None, false, Some("nvidia.com/gpu=0"), Some(2))
+                .expect("requirements should exist");
+        let gpu = requirements.gpu.expect("GPU requirement should be present");
 
-        assert_eq!(request.device_id, vec!["nvidia.com/gpu=0"]);
-        assert_eq!(request.count, Some(2));
+        assert_eq!(gpu.device_ids, vec!["nvidia.com/gpu=0"]);
+        assert_eq!(gpu.count, Some(2));
     }
 
     #[test]
-    fn gpu_request_from_cli_omits_gpu_request_when_not_requested() {
-        assert!(gpu_request_from_cli(false, Some("0"), None).is_none());
+    fn resource_requirements_from_cli_omits_gpu_request_when_not_requested() {
+        assert!(resource_requirements_from_cli(None, false, None, None).is_none());
+    }
+
+    #[test]
+    fn resource_requirements_from_cli_infers_gpu_from_image() {
+        let requirements = resource_requirements_from_cli(
+            Some("ghcr.io/nvidia/openshell-community/sandboxes/nvidia-gpu:latest"),
+            false,
+            None,
+            None,
+        )
+        .expect("resource requirements should be present");
+        let gpu = requirements.gpu.expect("GPU requirement should be present");
+
+        assert!(gpu.device_ids.is_empty());
+        assert_eq!(gpu.count, None);
     }
 
     #[test]

--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -788,6 +788,7 @@ async fn sandbox_create_keeps_command_sessions_by_default() {
         None,
         None,
         None,
+        None,
         &[],
         None,
         None,
@@ -907,6 +908,7 @@ async fn sandbox_create_sends_driver_config_json() {
         None,
         None,
         None,
+        None,
         Some(r#"{"kubernetes":{"pod":{"priority_class_name":"batch-low"}}}"#),
         None,
         &[],
@@ -982,6 +984,7 @@ async fn sandbox_create_sends_gpu_device_request_without_gpu_flag() {
         None,
         None,
         None,
+        None,
         &[],
         None,
         None,
@@ -999,10 +1002,11 @@ async fn sandbox_create_sends_gpu_device_request_without_gpu_flag() {
     let gpu = requests[0]
         .spec
         .as_ref()
-        .and_then(|spec| spec.gpu.as_ref())
+        .and_then(|spec| spec.resource_requirements.as_ref())
+        .and_then(|requirements| requirements.gpu.as_ref())
         .expect("GPU request should be sent");
 
-    assert_eq!(gpu.device_id, vec!["nvidia.com/gpu=0"]);
+    assert_eq!(gpu.device_ids, vec!["nvidia.com/gpu=0"]);
     assert_eq!(gpu.count, None);
 }
 
@@ -1020,11 +1024,12 @@ async fn sandbox_create_sends_gpu_count_request() {
         Some("gpu-count"),
         None,
         "openshell",
-        None,
+        &[],
         true,
         false,
         None,
         Some(2),
+        None,
         None,
         None,
         None,
@@ -1045,10 +1050,11 @@ async fn sandbox_create_sends_gpu_count_request() {
     let gpu = requests[0]
         .spec
         .as_ref()
-        .and_then(|spec| spec.gpu.as_ref())
+        .and_then(|spec| spec.resource_requirements.as_ref())
+        .and_then(|requirements| requirements.gpu.as_ref())
         .expect("GPU request should be sent");
 
-    assert!(gpu.device_id.is_empty());
+    assert!(gpu.device_ids.is_empty());
     assert_eq!(gpu.count, Some(2));
 }
 
@@ -1070,6 +1076,7 @@ async fn sandbox_create_does_not_infer_command_providers_when_v2_enabled() {
         &[],
         true,
         false,
+        None,
         None,
         None,
         None,
@@ -1133,6 +1140,7 @@ async fn sandbox_create_returns_vm_error_without_waiting_for_timeout() {
         None,
         None,
         None,
+        None,
         &[],
         None,
         None,
@@ -1187,6 +1195,7 @@ async fn sandbox_create_keeps_waiting_while_vm_progress_arrives() {
         None,
         None,
         None,
+        None,
         &[],
         None,
         None,
@@ -1233,6 +1242,7 @@ async fn sandbox_create_times_out_when_only_logs_arrive() {
         None,
         None,
         None,
+        None,
         &[],
         None,
         None,
@@ -1270,6 +1280,7 @@ async fn sandbox_create_deletes_command_sessions_with_no_keep() {
         &[],
         false,
         false,
+        None,
         None,
         None,
         None,
@@ -1321,6 +1332,7 @@ async fn sandbox_create_deletes_shell_sessions_with_no_keep() {
         None,
         None,
         None,
+        None,
         &[],
         None,
         None,
@@ -1367,6 +1379,7 @@ async fn sandbox_create_keeps_sandbox_with_hidden_keep_flag() {
         None,
         None,
         None,
+        None,
         &[],
         None,
         None,
@@ -1408,6 +1421,7 @@ async fn sandbox_create_keeps_sandbox_with_forwarding() {
         &[],
         false,
         false,
+        None,
         None,
         None,
         None,

--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -827,6 +827,7 @@ async fn sandbox_create_sends_cpu_and_memory_limits_only() {
         true,
         false,
         None,
+        None,
         Some("500m"),
         Some("2Gi"),
         None,
@@ -995,13 +996,60 @@ async fn sandbox_create_sends_gpu_device_request_without_gpu_flag() {
     .expect("sandbox create should succeed");
 
     let requests = create_requests(&server).await;
-    let spec = requests[0]
+    let gpu = requests[0]
         .spec
         .as_ref()
-        .expect("sandbox spec should be sent");
+        .and_then(|spec| spec.gpu.as_ref())
+        .expect("GPU request should be sent");
 
-    assert!(spec.gpu);
-    assert_eq!(spec.gpu_device, "nvidia.com/gpu=0");
+    assert_eq!(gpu.device_id, vec!["nvidia.com/gpu=0"]);
+    assert_eq!(gpu.count, None);
+}
+
+#[tokio::test]
+async fn sandbox_create_sends_gpu_count_request() {
+    let server = run_server().await;
+    let fake_ssh_dir = tempfile::tempdir().unwrap();
+    let xdg_dir = tempfile::tempdir().unwrap();
+    let _env = test_env(&fake_ssh_dir, &xdg_dir);
+    let tls = test_tls(&server);
+    install_fake_ssh(&fake_ssh_dir);
+
+    run::sandbox_create(
+        &server.endpoint,
+        Some("gpu-count"),
+        None,
+        "openshell",
+        None,
+        true,
+        false,
+        None,
+        Some(2),
+        None,
+        None,
+        None,
+        &[],
+        None,
+        None,
+        &["echo".to_string(), "OK".to_string()],
+        Some(false),
+        Some(false),
+        &HashMap::new(),
+        "manual",
+        &tls,
+    )
+    .await
+    .expect("sandbox create should succeed");
+
+    let requests = create_requests(&server).await;
+    let gpu = requests[0]
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.gpu.as_ref())
+        .expect("GPU request should be sent");
+
+    assert!(gpu.device_id.is_empty());
+    assert_eq!(gpu.count, Some(2));
 }
 
 #[tokio::test]

--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -960,6 +960,51 @@ async fn sandbox_create_sends_driver_config_json() {
 }
 
 #[tokio::test]
+async fn sandbox_create_sends_gpu_device_request_without_gpu_flag() {
+    let server = run_server().await;
+    let fake_ssh_dir = tempfile::tempdir().unwrap();
+    let xdg_dir = tempfile::tempdir().unwrap();
+    let _env = test_env(&fake_ssh_dir, &xdg_dir);
+    let tls = test_tls(&server);
+    install_fake_ssh(&fake_ssh_dir);
+
+    run::sandbox_create(
+        &server.endpoint,
+        Some("gpu-device"),
+        None,
+        "openshell",
+        &[],
+        true,
+        false,
+        Some("nvidia.com/gpu=0"),
+        None,
+        None,
+        None,
+        None,
+        &[],
+        None,
+        None,
+        &["echo".to_string(), "OK".to_string()],
+        Some(false),
+        Some(false),
+        &HashMap::new(),
+        "manual",
+        &tls,
+    )
+    .await
+    .expect("sandbox create should succeed");
+
+    let requests = create_requests(&server).await;
+    let spec = requests[0]
+        .spec
+        .as_ref()
+        .expect("sandbox spec should be sent");
+
+    assert!(spec.gpu);
+    assert_eq!(spec.gpu_device, "nvidia.com/gpu=0");
+}
+
+#[tokio::test]
 async fn sandbox_create_does_not_infer_command_providers_when_v2_enabled() {
     let server = run_server().await;
     enable_providers_v2(&server).await;

--- a/crates/openshell-core/src/gpu.rs
+++ b/crates/openshell-core/src/gpu.rs
@@ -4,23 +4,26 @@
 //! Shared GPU request helpers.
 
 use crate::config::CDI_GPU_DEVICE_ALL;
-use crate::proto::compute::v1::{DriverSandboxSpec, GpuRequestSpec};
+use crate::proto::compute::v1::{DriverGpuResourceRequirement, DriverSandboxSpec};
 
-/// Extract the driver GPU request from a sandbox spec.
+/// Extract the driver GPU requirement from a sandbox spec.
 #[must_use]
-pub fn driver_gpu_request(spec: &DriverSandboxSpec) -> Option<&GpuRequestSpec> {
-    spec.gpu.as_ref()
+pub fn driver_gpu_requirement(spec: &DriverSandboxSpec) -> Option<&DriverGpuResourceRequirement> {
+    spec.resource_requirements
+        .as_ref()
+        .and_then(|requirements| requirements.gpu.as_ref())
 }
 
 /// Resolve a driver GPU request into CDI device identifiers.
 ///
 /// `None` means no GPU was requested. Presence with no explicit device IDs
-/// uses the CDI all-GPU request; otherwise the driver-native IDs pass through.
+/// uses the CDI all-GPU request, preserving the current default GPU behavior;
+/// otherwise the driver-native IDs pass through.
 #[must_use]
-pub fn cdi_gpu_device_ids(gpu: Option<&GpuRequestSpec>) -> Option<Vec<String>> {
+pub fn cdi_gpu_device_ids(gpu: Option<&DriverGpuResourceRequirement>) -> Option<Vec<String>> {
     match gpu {
-        Some(gpu) if gpu.device_id.is_empty() => Some(vec![CDI_GPU_DEVICE_ALL.to_string()]),
-        Some(gpu) => Some(gpu.device_id.clone()),
+        Some(gpu) if gpu.device_ids.is_empty() => Some(vec![CDI_GPU_DEVICE_ALL.to_string()]),
+        Some(gpu) => Some(gpu.device_ids.clone()),
         None => None,
     }
 }
@@ -36,8 +39,8 @@ mod tests {
 
     #[test]
     fn cdi_gpu_device_ids_defaults_empty_request_to_all_gpus() {
-        let request = GpuRequestSpec {
-            device_id: vec![],
+        let request = DriverGpuResourceRequirement {
+            device_ids: vec![],
             count: None,
         };
 
@@ -49,8 +52,8 @@ mod tests {
 
     #[test]
     fn cdi_gpu_device_ids_passes_single_device_id_through() {
-        let request = GpuRequestSpec {
-            device_id: vec!["nvidia.com/gpu=0".to_string()],
+        let request = DriverGpuResourceRequirement {
+            device_ids: vec!["nvidia.com/gpu=0".to_string()],
             count: None,
         };
 
@@ -62,8 +65,8 @@ mod tests {
 
     #[test]
     fn cdi_gpu_device_ids_passes_multiple_device_ids_through() {
-        let request = GpuRequestSpec {
-            device_id: vec![
+        let request = DriverGpuResourceRequirement {
+            device_ids: vec![
                 "nvidia.com/gpu=0".to_string(),
                 "nvidia.com/gpu=1".to_string(),
             ],

--- a/crates/openshell-core/src/gpu.rs
+++ b/crates/openshell-core/src/gpu.rs
@@ -4,21 +4,25 @@
 //! Shared GPU request helpers.
 
 use crate::config::CDI_GPU_DEVICE_ALL;
+use crate::proto::compute::v1::{DriverSandboxSpec, GpuRequestSpec};
 
-/// Resolve the existing GPU request fields into CDI device identifiers.
-///
-/// `None` means no GPU was requested. A GPU request with no explicit device
-/// ID uses the CDI all-GPU request; otherwise the driver-native ID passes
-/// through unchanged.
+/// Extract the driver GPU request from a sandbox spec.
 #[must_use]
-pub fn cdi_gpu_device_ids(gpu: bool, gpu_device: &str) -> Option<Vec<String>> {
-    gpu.then(|| {
-        if gpu_device.is_empty() {
-            vec![CDI_GPU_DEVICE_ALL.to_string()]
-        } else {
-            vec![gpu_device.to_string()]
-        }
-    })
+pub fn driver_gpu_request(spec: &DriverSandboxSpec) -> Option<&GpuRequestSpec> {
+    spec.gpu.as_ref()
+}
+
+/// Resolve a driver GPU request into CDI device identifiers.
+///
+/// `None` means no GPU was requested. Presence with no explicit device IDs
+/// uses the CDI all-GPU request; otherwise the driver-native IDs pass through.
+#[must_use]
+pub fn cdi_gpu_device_ids(gpu: Option<&GpuRequestSpec>) -> Option<Vec<String>> {
+    match gpu {
+        Some(gpu) if gpu.device_id.is_empty() => Some(vec![CDI_GPU_DEVICE_ALL.to_string()]),
+        Some(gpu) => Some(gpu.device_id.clone()),
+        None => None,
+    }
 }
 
 #[cfg(test)]
@@ -27,22 +31,51 @@ mod tests {
 
     #[test]
     fn cdi_gpu_device_ids_returns_none_when_absent() {
-        assert_eq!(cdi_gpu_device_ids(false, ""), None);
+        assert_eq!(cdi_gpu_device_ids(None), None);
     }
 
     #[test]
     fn cdi_gpu_device_ids_defaults_empty_request_to_all_gpus() {
+        let request = GpuRequestSpec {
+            device_id: vec![],
+            count: None,
+        };
+
         assert_eq!(
-            cdi_gpu_device_ids(true, ""),
+            cdi_gpu_device_ids(Some(&request)),
             Some(vec![CDI_GPU_DEVICE_ALL.to_string()])
         );
     }
 
     #[test]
-    fn cdi_gpu_device_ids_passes_explicit_device_id_through() {
+    fn cdi_gpu_device_ids_passes_single_device_id_through() {
+        let request = GpuRequestSpec {
+            device_id: vec!["nvidia.com/gpu=0".to_string()],
+            count: None,
+        };
+
         assert_eq!(
-            cdi_gpu_device_ids(true, "nvidia.com/gpu=0"),
+            cdi_gpu_device_ids(Some(&request)),
             Some(vec!["nvidia.com/gpu=0".to_string()])
+        );
+    }
+
+    #[test]
+    fn cdi_gpu_device_ids_passes_multiple_device_ids_through() {
+        let request = GpuRequestSpec {
+            device_id: vec![
+                "nvidia.com/gpu=0".to_string(),
+                "nvidia.com/gpu=1".to_string(),
+            ],
+            count: None,
+        };
+
+        assert_eq!(
+            cdi_gpu_device_ids(Some(&request)),
+            Some(vec![
+                "nvidia.com/gpu=0".to_string(),
+                "nvidia.com/gpu=1".to_string()
+            ])
         );
     }
 }

--- a/crates/openshell-driver-docker/README.md
+++ b/crates/openshell-driver-docker/README.md
@@ -32,7 +32,7 @@ contract:
 | `apparmor=unconfined` | Avoids Docker's default profile blocking required mount operations. |
 | `restart_policy = unless-stopped` | Keeps managed sandboxes resumable across daemon or gateway restarts. |
 | `PidsLimit` | Enforces the sandbox PID budget at the Docker cgroup layer. Set `[openshell.drivers.docker].sandbox_pids_limit = 0` to inherit the Docker/runtime default. |
-| CDI GPU request | Uses the sandbox `gpu_device` value when set; otherwise requests all NVIDIA GPUs when the sandbox spec asks for GPU support and daemon CDI support is detected. |
+| CDI GPU request | Uses explicit GPU request device IDs when set; otherwise requests all NVIDIA GPUs when the sandbox spec asks for GPU support and daemon CDI support is detected. Count-based GPU requests are rejected until Docker CDI selection can map counts to concrete devices. |
 
 The agent child process does not retain these supervisor privileges.
 

--- a/crates/openshell-driver-docker/README.md
+++ b/crates/openshell-driver-docker/README.md
@@ -32,7 +32,7 @@ contract:
 | `apparmor=unconfined` | Avoids Docker's default profile blocking required mount operations. |
 | `restart_policy = unless-stopped` | Keeps managed sandboxes resumable across daemon or gateway restarts. |
 | `PidsLimit` | Enforces the sandbox PID budget at the Docker cgroup layer. Set `[openshell.drivers.docker].sandbox_pids_limit = 0` to inherit the Docker/runtime default. |
-| CDI GPU request | Uses explicit GPU request device IDs when set; otherwise requests all NVIDIA GPUs when the sandbox spec asks for GPU support and daemon CDI support is detected. Count-based GPU requests are rejected until Docker CDI selection can map counts to concrete devices. |
+| CDI GPU request | Uses explicit `resource_requirements.gpu.device_ids` when set; otherwise requests all NVIDIA GPUs when `resource_requirements.gpu` is present and daemon CDI support is detected. Count-based GPU requests are rejected until Docker CDI selection can map counts to concrete devices. |
 
 The agent child process does not retain these supervisor privileges.
 

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -25,7 +25,7 @@ use openshell_core::driver_utils::{
     LABEL_MANAGED_BY, LABEL_MANAGED_BY_VALUE, LABEL_SANDBOX_ID, LABEL_SANDBOX_NAME,
     LABEL_SANDBOX_NAMESPACE, SUPERVISOR_IMAGE_BINARY_PATH, supervisor_image_should_refresh,
 };
-use openshell_core::gpu::cdi_gpu_device_ids;
+use openshell_core::gpu::{cdi_gpu_device_ids, driver_gpu_request};
 use openshell_core::progress::{
     PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX, PROGRESS_STEP_STARTING_SANDBOX,
     format_bytes, mark_progress_active, mark_progress_complete, mark_progress_detail,
@@ -34,11 +34,11 @@ use openshell_core::proto::compute::v1::{
     CreateSandboxRequest, CreateSandboxResponse, DeleteSandboxRequest, DeleteSandboxResponse,
     DriverCondition, DriverPlatformEvent, DriverSandbox, DriverSandboxStatus,
     DriverSandboxTemplate, GetCapabilitiesRequest, GetCapabilitiesResponse, GetSandboxRequest,
-    GetSandboxResponse, ListSandboxesRequest, ListSandboxesResponse, StopSandboxRequest,
-    StopSandboxResponse, ValidateSandboxCreateRequest, ValidateSandboxCreateResponse,
-    WatchSandboxesDeletedEvent, WatchSandboxesEvent, WatchSandboxesPlatformEvent,
-    WatchSandboxesRequest, WatchSandboxesSandboxEvent, compute_driver_server::ComputeDriver,
-    watch_sandboxes_event,
+    GetSandboxResponse, GpuRequestSpec, ListSandboxesRequest, ListSandboxesResponse,
+    StopSandboxRequest, StopSandboxResponse, ValidateSandboxCreateRequest,
+    ValidateSandboxCreateResponse, WatchSandboxesDeletedEvent, WatchSandboxesEvent,
+    WatchSandboxesPlatformEvent, WatchSandboxesRequest, WatchSandboxesSandboxEvent,
+    compute_driver_server::ComputeDriver, watch_sandboxes_event,
 };
 use openshell_core::{Config, Error, Result as CoreResult};
 use std::collections::HashMap;
@@ -375,7 +375,7 @@ impl DockerComputeDriver {
                 "docker sandboxes require a template image",
             ));
         }
-        Self::validate_gpu_request(spec.gpu, config.supports_gpu)?;
+        Self::validate_gpu_request(driver_gpu_request(spec), config.supports_gpu)?;
         if !template.agent_socket_path.trim().is_empty() {
             return Err(Status::failed_precondition(
                 "docker compute driver does not support template.agent_socket_path",
@@ -409,8 +409,16 @@ impl DockerComputeDriver {
         ))
     }
 
-    fn validate_gpu_request(gpu: bool, supports_gpu: bool) -> Result<(), Status> {
-        if gpu && !supports_gpu {
+    fn validate_gpu_request(
+        gpu: Option<&GpuRequestSpec>,
+        supports_gpu: bool,
+    ) -> Result<(), Status> {
+        if gpu.is_some_and(|gpu| gpu.count.is_some()) {
+            return Err(Status::invalid_argument(
+                "docker compute driver does not support GPU count requests",
+            ));
+        }
+        if gpu.is_some() && !supports_gpu {
             return Err(Status::failed_precondition(
                 "docker GPU sandboxes require Docker CDI support. Enable CDI on the Docker daemon, then restart the OpenShell gateway/server so GPU capability is detected.",
             ));
@@ -1713,8 +1721,8 @@ fn build_environment(sandbox: &DriverSandbox, config: &DockerDriverRuntimeConfig
         .collect()
 }
 
-fn docker_gpu_device_requests(gpu: bool, gpu_device: &str) -> Option<Vec<DeviceRequest>> {
-    cdi_gpu_device_ids(gpu, gpu_device).map(|device_ids| {
+fn docker_gpu_device_requests(gpu: Option<&GpuRequestSpec>) -> Option<Vec<DeviceRequest>> {
+    cdi_gpu_device_ids(gpu).map(|device_ids| {
         vec![DeviceRequest {
             driver: Some("cdi".to_string()),
             device_ids: Some(device_ids),
@@ -1765,7 +1773,7 @@ fn build_container_create_body(
             nano_cpus: resource_limits.nano_cpus,
             memory: resource_limits.memory_bytes,
             pids_limit: docker_pids_limit(config.sandbox_pids_limit)?,
-            device_requests: docker_gpu_device_requests(spec.gpu, &spec.gpu_device),
+            device_requests: docker_gpu_device_requests(driver_gpu_request(spec)),
             binds: Some(build_binds(sandbox, config)?),
             restart_policy: Some(RestartPolicy {
                 name: Some(RestartPolicyNameEnum::UNLESS_STOPPED),

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -25,16 +25,16 @@ use openshell_core::driver_utils::{
     LABEL_MANAGED_BY, LABEL_MANAGED_BY_VALUE, LABEL_SANDBOX_ID, LABEL_SANDBOX_NAME,
     LABEL_SANDBOX_NAMESPACE, SUPERVISOR_IMAGE_BINARY_PATH, supervisor_image_should_refresh,
 };
-use openshell_core::gpu::{cdi_gpu_device_ids, driver_gpu_request};
+use openshell_core::gpu::{cdi_gpu_device_ids, driver_gpu_requirement};
 use openshell_core::progress::{
     PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX, PROGRESS_STEP_STARTING_SANDBOX,
     format_bytes, mark_progress_active, mark_progress_complete, mark_progress_detail,
 };
 use openshell_core::proto::compute::v1::{
     CreateSandboxRequest, CreateSandboxResponse, DeleteSandboxRequest, DeleteSandboxResponse,
-    DriverCondition, DriverPlatformEvent, DriverSandbox, DriverSandboxStatus,
-    DriverSandboxTemplate, GetCapabilitiesRequest, GetCapabilitiesResponse, GetSandboxRequest,
-    GetSandboxResponse, GpuRequestSpec, ListSandboxesRequest, ListSandboxesResponse,
+    DriverCondition, DriverGpuResourceRequirement, DriverPlatformEvent, DriverSandbox,
+    DriverSandboxStatus, DriverSandboxTemplate, GetCapabilitiesRequest, GetCapabilitiesResponse,
+    GetSandboxRequest, GetSandboxResponse, ListSandboxesRequest, ListSandboxesResponse,
     StopSandboxRequest, StopSandboxResponse, ValidateSandboxCreateRequest,
     ValidateSandboxCreateResponse, WatchSandboxesDeletedEvent, WatchSandboxesEvent,
     WatchSandboxesPlatformEvent, WatchSandboxesRequest, WatchSandboxesSandboxEvent,
@@ -375,7 +375,7 @@ impl DockerComputeDriver {
                 "docker sandboxes require a template image",
             ));
         }
-        Self::validate_gpu_request(driver_gpu_request(spec), config.supports_gpu)?;
+        Self::validate_gpu_request(driver_gpu_requirement(spec), config.supports_gpu)?;
         if !template.agent_socket_path.trim().is_empty() {
             return Err(Status::failed_precondition(
                 "docker compute driver does not support template.agent_socket_path",
@@ -410,7 +410,7 @@ impl DockerComputeDriver {
     }
 
     fn validate_gpu_request(
-        gpu: Option<&GpuRequestSpec>,
+        gpu: Option<&DriverGpuResourceRequirement>,
         supports_gpu: bool,
     ) -> Result<(), Status> {
         if gpu.is_some_and(|gpu| gpu.count.is_some()) {
@@ -1721,7 +1721,9 @@ fn build_environment(sandbox: &DriverSandbox, config: &DockerDriverRuntimeConfig
         .collect()
 }
 
-fn docker_gpu_device_requests(gpu: Option<&GpuRequestSpec>) -> Option<Vec<DeviceRequest>> {
+fn docker_gpu_device_requests(
+    gpu: Option<&DriverGpuResourceRequirement>,
+) -> Option<Vec<DeviceRequest>> {
     cdi_gpu_device_ids(gpu).map(|device_ids| {
         vec![DeviceRequest {
             driver: Some("cdi".to_string()),
@@ -1773,7 +1775,7 @@ fn build_container_create_body(
             nano_cpus: resource_limits.nano_cpus,
             memory: resource_limits.memory_bytes,
             pids_limit: docker_pids_limit(config.sandbox_pids_limit)?,
-            device_requests: docker_gpu_device_requests(driver_gpu_request(spec)),
+            device_requests: docker_gpu_device_requests(driver_gpu_requirement(spec)),
             binds: Some(build_binds(sandbox, config)?),
             restart_policy: Some(RestartPolicy {
                 name: Some(RestartPolicyNameEnum::UNLESS_STOPPED),

--- a/crates/openshell-driver-docker/src/tests.rs
+++ b/crates/openshell-driver-docker/src/tests.rs
@@ -13,7 +13,7 @@ use openshell_core::progress::{
     PROGRESS_STEP_STARTING_SANDBOX,
 };
 use openshell_core::proto::compute::v1::{
-    DriverResourceRequirements, DriverSandboxSpec, DriverSandboxTemplate,
+    DriverResourceRequirements, DriverSandboxSpec, DriverSandboxTemplate, GpuRequestSpec,
 };
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -41,8 +41,7 @@ fn test_sandbox() -> DriverSandbox {
                 environment: HashMap::from([("TEMPLATE_ENV".to_string(), "template".to_string())]),
                 ..Default::default()
             }),
-            gpu: false,
-            gpu_device: String::new(),
+            gpu: None,
             sandbox_token: String::new(),
         }),
         status: None,
@@ -604,12 +603,31 @@ fn build_container_create_body_clears_inherited_cmd() {
 fn validate_sandbox_rejects_gpu_when_cdi_unavailable() {
     let config = runtime_config();
     let mut sandbox = test_sandbox();
-    sandbox.spec.as_mut().unwrap().gpu = true;
+    sandbox.spec.as_mut().unwrap().gpu = Some(GpuRequestSpec {
+        device_id: vec![],
+        count: None,
+    });
 
     let err = DockerComputeDriver::validate_sandbox(&sandbox, &config).unwrap_err();
 
     assert_eq!(err.code(), tonic::Code::FailedPrecondition);
     assert!(err.message().contains("Docker CDI"));
+}
+
+#[test]
+fn validate_sandbox_rejects_gpu_count() {
+    let mut config = runtime_config();
+    config.supports_gpu = true;
+    let mut sandbox = test_sandbox();
+    sandbox.spec.as_mut().unwrap().gpu = Some(GpuRequestSpec {
+        device_id: vec![],
+        count: Some(2),
+    });
+
+    let err = DockerComputeDriver::validate_sandbox(&sandbox, &config).unwrap_err();
+
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert!(err.message().contains("does not support GPU count"));
 }
 
 #[test]
@@ -639,7 +657,10 @@ fn build_container_create_body_maps_gpu_to_all_cdi_device() {
     let mut config = runtime_config();
     config.supports_gpu = true;
     let mut sandbox = test_sandbox();
-    sandbox.spec.as_mut().unwrap().gpu = true;
+    sandbox.spec.as_mut().unwrap().gpu = Some(GpuRequestSpec {
+        device_id: vec![],
+        count: None,
+    });
 
     let create_body = build_container_create_body(&sandbox, &config).unwrap();
     let request = create_body
@@ -657,13 +678,17 @@ fn build_container_create_body_maps_gpu_to_all_cdi_device() {
 }
 
 #[test]
-fn build_container_create_body_passes_explicit_cdi_device_id_through() {
+fn build_container_create_body_passes_explicit_cdi_device_ids_through() {
     let mut config = runtime_config();
     config.supports_gpu = true;
     let mut sandbox = test_sandbox();
-    let spec = sandbox.spec.as_mut().unwrap();
-    spec.gpu = true;
-    spec.gpu_device = "nvidia.com/gpu=0".to_string();
+    sandbox.spec.as_mut().unwrap().gpu = Some(GpuRequestSpec {
+        device_id: vec![
+            "nvidia.com/gpu=0".to_string(),
+            "nvidia.com/gpu=1".to_string(),
+        ],
+        count: None,
+    });
 
     let create_body = build_container_create_body(&sandbox, &config).unwrap();
     let request = create_body
@@ -676,7 +701,10 @@ fn build_container_create_body_passes_explicit_cdi_device_id_through() {
     assert_eq!(request.driver.as_deref(), Some("cdi"));
     assert_eq!(
         request.device_ids.as_ref().unwrap(),
-        &vec!["nvidia.com/gpu=0".to_string()]
+        &vec![
+            "nvidia.com/gpu=0".to_string(),
+            "nvidia.com/gpu=1".to_string()
+        ]
     );
 }
 

--- a/crates/openshell-driver-docker/src/tests.rs
+++ b/crates/openshell-driver-docker/src/tests.rs
@@ -13,7 +13,8 @@ use openshell_core::progress::{
     PROGRESS_STEP_STARTING_SANDBOX,
 };
 use openshell_core::proto::compute::v1::{
-    DriverResourceRequirements, DriverSandboxSpec, DriverSandboxTemplate, GpuRequestSpec,
+    DriverGpuResourceRequirement, DriverResourceRequirements, DriverSandboxResourceRequirements,
+    DriverSandboxSpec, DriverSandboxTemplate,
 };
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -22,6 +23,15 @@ use tempfile::TempDir;
 
 const TLS_MOUNT_DIR: &str = "/etc/openshell/tls/client";
 static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn gpu_resource_requirements(
+    device_ids: Vec<String>,
+    count: Option<u32>,
+) -> DriverSandboxResourceRequirements {
+    DriverSandboxResourceRequirements {
+        gpu: Some(DriverGpuResourceRequirement { device_ids, count }),
+    }
+}
 
 fn test_sandbox() -> DriverSandbox {
     // Mirrors the gateway-supplied request: the public `Sandbox` API no
@@ -41,8 +51,8 @@ fn test_sandbox() -> DriverSandbox {
                 environment: HashMap::from([("TEMPLATE_ENV".to_string(), "template".to_string())]),
                 ..Default::default()
             }),
-            gpu: None,
             sandbox_token: String::new(),
+            resource_requirements: None,
         }),
         status: None,
     }
@@ -603,10 +613,8 @@ fn build_container_create_body_clears_inherited_cmd() {
 fn validate_sandbox_rejects_gpu_when_cdi_unavailable() {
     let config = runtime_config();
     let mut sandbox = test_sandbox();
-    sandbox.spec.as_mut().unwrap().gpu = Some(GpuRequestSpec {
-        device_id: vec![],
-        count: None,
-    });
+    sandbox.spec.as_mut().unwrap().resource_requirements =
+        Some(gpu_resource_requirements(vec![], None));
 
     let err = DockerComputeDriver::validate_sandbox(&sandbox, &config).unwrap_err();
 
@@ -619,10 +627,8 @@ fn validate_sandbox_rejects_gpu_count() {
     let mut config = runtime_config();
     config.supports_gpu = true;
     let mut sandbox = test_sandbox();
-    sandbox.spec.as_mut().unwrap().gpu = Some(GpuRequestSpec {
-        device_id: vec![],
-        count: Some(2),
-    });
+    sandbox.spec.as_mut().unwrap().resource_requirements =
+        Some(gpu_resource_requirements(vec![], Some(2)));
 
     let err = DockerComputeDriver::validate_sandbox(&sandbox, &config).unwrap_err();
 
@@ -657,10 +663,8 @@ fn build_container_create_body_maps_gpu_to_all_cdi_device() {
     let mut config = runtime_config();
     config.supports_gpu = true;
     let mut sandbox = test_sandbox();
-    sandbox.spec.as_mut().unwrap().gpu = Some(GpuRequestSpec {
-        device_id: vec![],
-        count: None,
-    });
+    sandbox.spec.as_mut().unwrap().resource_requirements =
+        Some(gpu_resource_requirements(vec![], None));
 
     let create_body = build_container_create_body(&sandbox, &config).unwrap();
     let request = create_body
@@ -682,13 +686,13 @@ fn build_container_create_body_passes_explicit_cdi_device_ids_through() {
     let mut config = runtime_config();
     config.supports_gpu = true;
     let mut sandbox = test_sandbox();
-    sandbox.spec.as_mut().unwrap().gpu = Some(GpuRequestSpec {
-        device_id: vec![
+    sandbox.spec.as_mut().unwrap().resource_requirements = Some(gpu_resource_requirements(
+        vec![
             "nvidia.com/gpu=0".to_string(),
             "nvidia.com/gpu=1".to_string(),
         ],
-        count: None,
-    });
+        None,
+    ));
 
     let create_body = build_container_create_body(&sandbox, &config).unwrap();
     let request = create_body

--- a/crates/openshell-driver-kubernetes/README.md
+++ b/crates/openshell-driver-kubernetes/README.md
@@ -62,9 +62,9 @@ the supervisor's network namespace mount setup on AppArmor-enabled nodes.
 ## GPU Support
 
 When a sandbox requests GPU support, the driver checks node allocatable capacity
-for `nvidia.com/gpu` and requests one GPU resource in the workload spec. The
-sandbox image must provide the user-space libraries needed by the agent
-workload.
+for `nvidia.com/gpu` and sets the workload's `nvidia.com/gpu` resource limit.
+Requests without an explicit count use one GPU. The sandbox image must provide
+the user-space libraries needed by the agent workload.
 
 ## Driver Config POC
 

--- a/crates/openshell-driver-kubernetes/README.md
+++ b/crates/openshell-driver-kubernetes/README.md
@@ -61,9 +61,9 @@ the supervisor's network namespace mount setup on AppArmor-enabled nodes.
 
 ## GPU Support
 
-When a sandbox requests GPU support, the driver checks node allocatable capacity
-for `nvidia.com/gpu` and sets the workload's `nvidia.com/gpu` resource limit.
-Requests without an explicit count use one GPU. The sandbox image must provide
+When `resource_requirements.gpu` is present, the driver checks node allocatable
+capacity for `nvidia.com/gpu` and sets the workload's `nvidia.com/gpu` resource
+limit. The default is to request a single GPU. The sandbox image must provide
 the user-space libraries needed by the agent workload.
 
 ## Driver Config POC
@@ -96,6 +96,6 @@ Resource keys use native Kubernetes resource names and quantity strings. The
 POC parser renders the keys listed above and ignores unknown fields.
 `pod.runtime_class_name` maps to PodSpec `runtimeClassName` and overrides the
 driver's configured `default_runtime_class_name`; the typed public
-`SandboxTemplate.runtime_class_name` still takes precedence when set. Use the
-public `gpu` flag for the default GPU request and `driver_config` only for
-additional driver-owned resource details.
+`SandboxTemplate.runtime_class_name` still takes precedence when set. Use
+`resource_requirements.gpu` for the default GPU request and `driver_config` only
+for additional driver-owned resource details.

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -17,17 +17,18 @@ use kube::{Client, Error as KubeError};
 use openshell_core::driver_utils::{
     LABEL_MANAGED_BY, LABEL_MANAGED_BY_VALUE, LABEL_SANDBOX_ID, SUPERVISOR_IMAGE_BINARY_PATH,
 };
-use openshell_core::gpu::driver_gpu_request;
+use openshell_core::gpu::driver_gpu_requirement;
 use openshell_core::progress::{
     PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX, PROGRESS_STEP_STARTING_SANDBOX,
     format_bytes, mark_progress_active, mark_progress_complete, mark_progress_detail,
 };
 use openshell_core::proto::compute::v1::{
-    DriverCondition as SandboxCondition, DriverPlatformEvent as PlatformEvent,
-    DriverSandbox as Sandbox, DriverSandboxSpec as SandboxSpec,
-    DriverSandboxStatus as SandboxStatus, DriverSandboxTemplate as SandboxTemplate,
-    GetCapabilitiesResponse, GpuRequestSpec, WatchSandboxesDeletedEvent, WatchSandboxesEvent,
-    WatchSandboxesPlatformEvent, WatchSandboxesSandboxEvent, watch_sandboxes_event,
+    DriverCondition as SandboxCondition, DriverGpuResourceRequirement,
+    DriverPlatformEvent as PlatformEvent, DriverSandbox as Sandbox,
+    DriverSandboxSpec as SandboxSpec, DriverSandboxStatus as SandboxStatus,
+    DriverSandboxTemplate as SandboxTemplate, GetCapabilitiesResponse, WatchSandboxesDeletedEvent,
+    WatchSandboxesEvent, WatchSandboxesPlatformEvent, WatchSandboxesSandboxEvent,
+    watch_sandboxes_event,
 };
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -80,9 +81,23 @@ pub const SANDBOX_KIND: &str = "Sandbox";
 
 const GPU_RESOURCE_NAME: &str = "nvidia.com/gpu";
 const DEFAULT_GPU_COUNT: u32 = 1;
+const EXPLICIT_GPU_DEVICE_IDS_UNSUPPORTED_MESSAGE: &str =
+    "kubernetes compute driver does not support explicit GPU device IDs";
 
-fn gpu_has_explicit_device_ids(gpu: Option<&GpuRequestSpec>) -> bool {
-    gpu.is_some_and(|gpu| !gpu.device_id.is_empty())
+fn gpu_has_explicit_device_ids(gpu: Option<&DriverGpuResourceRequirement>) -> bool {
+    gpu.is_some_and(|gpu| !gpu.device_ids.is_empty())
+}
+
+#[allow(clippy::result_large_err)]
+fn validate_gpu_request_shape(
+    gpu: Option<&DriverGpuResourceRequirement>,
+) -> Result<(), tonic::Status> {
+    if gpu_has_explicit_device_ids(gpu) {
+        return Err(tonic::Status::invalid_argument(
+            EXPLICIT_GPU_DEVICE_IDS_UNSUPPORTED_MESSAGE,
+        ));
+    }
+    Ok(())
 }
 
 // This POC treats the selected Struct as a driver-local typed schema. Once the
@@ -250,19 +265,15 @@ impl KubernetesComputeDriver {
     }
 
     pub async fn validate_sandbox_create(&self, sandbox: &Sandbox) -> Result<(), tonic::Status> {
-        let gpu = sandbox.spec.as_ref().and_then(driver_gpu_request);
+        let gpu = sandbox.spec.as_ref().and_then(driver_gpu_requirement);
         self.validate_gpu_request(gpu).await
     }
 
     async fn validate_gpu_request(
         &self,
-        gpu: Option<&GpuRequestSpec>,
+        gpu: Option<&DriverGpuResourceRequirement>,
     ) -> Result<(), tonic::Status> {
-        if gpu_has_explicit_device_ids(gpu) {
-            return Err(tonic::Status::invalid_argument(
-                "kubernetes compute driver does not support explicit GPU device IDs",
-            ));
-        }
+        validate_gpu_request_shape(gpu)?;
         if gpu.is_some()
             && !self.has_gpu_capacity().await.map_err(|err| {
                 tonic::Status::internal(format!("check GPU node capacity failed: {err}"))
@@ -355,11 +366,11 @@ impl KubernetesComputeDriver {
     }
 
     pub async fn create_sandbox(&self, sandbox: &Sandbox) -> Result<(), KubernetesDriverError> {
-        if let Some(gpu) = sandbox.spec.as_ref().and_then(driver_gpu_request)
+        if let Some(gpu) = sandbox.spec.as_ref().and_then(driver_gpu_requirement)
             && gpu_has_explicit_device_ids(Some(gpu))
         {
             return Err(KubernetesDriverError::Precondition(
-                "kubernetes compute driver does not support explicit GPU device IDs".to_string(),
+                EXPLICIT_GPU_DEVICE_IDS_UNSUPPORTED_MESSAGE.to_string(),
             ));
         }
 
@@ -1192,7 +1203,7 @@ fn sandbox_to_k8s_spec(
                 "podTemplate".to_string(),
                 sandbox_template_to_k8s(
                     template,
-                    driver_gpu_request(spec),
+                    driver_gpu_requirement(spec),
                     &pod_env,
                     inject_workspace,
                     params,
@@ -1228,7 +1239,7 @@ fn sandbox_to_k8s_spec(
             "podTemplate".to_string(),
             sandbox_template_to_k8s(
                 &SandboxTemplate::default(),
-                spec.and_then(|s| s.gpu.as_ref()),
+                spec.and_then(driver_gpu_requirement),
                 &pod_env,
                 inject_workspace,
                 params,
@@ -1243,7 +1254,7 @@ fn sandbox_to_k8s_spec(
 
 fn sandbox_template_to_k8s(
     template: &SandboxTemplate,
-    gpu: Option<&GpuRequestSpec>,
+    gpu: Option<&DriverGpuResourceRequirement>,
     spec_environment: &std::collections::HashMap<String, String>,
     inject_workspace: bool,
     params: &SandboxPodParams<'_>,
@@ -1581,7 +1592,7 @@ fn app_armor_profile_to_k8s(profile: &AppArmorProfile) -> serde_json::Value {
 
 fn container_resources(
     template: &SandboxTemplate,
-    gpu: Option<&GpuRequestSpec>,
+    gpu: Option<&DriverGpuResourceRequirement>,
 ) -> Option<serde_json::Value> {
     // Start from the raw resources passthrough in platform_config (preserves
     // custom resource types like GPU limits that users set via the public API
@@ -1942,11 +1953,29 @@ mod tests {
         assert!(config.containers.agent.resources.limits.is_empty());
     }
 
-    fn gpu_request(count: Option<u32>) -> GpuRequestSpec {
-        GpuRequestSpec {
-            device_id: vec![],
+    fn gpu_request(count: Option<u32>) -> DriverGpuResourceRequirement {
+        DriverGpuResourceRequirement {
+            device_ids: vec![],
             count,
         }
+    }
+
+    fn default_gpu_request() -> DriverGpuResourceRequirement {
+        gpu_request(None)
+    }
+
+    #[test]
+    fn validate_gpu_request_shape_rejects_explicit_device_ids() {
+        let gpu = DriverGpuResourceRequirement {
+            device_ids: vec!["nvidia.com/gpu=0".to_string()],
+            count: None,
+        };
+
+        let err = validate_gpu_request_shape(Some(&gpu))
+            .expect_err("explicit GPU device IDs should be rejected");
+
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert_eq!(err.message(), EXPLICIT_GPU_DEVICE_IDS_UNSUPPORTED_MESSAGE);
     }
 
     #[test]
@@ -2260,7 +2289,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &SandboxTemplate::default(),
-                Some(&gpu_request(None)),
+                Some(&default_gpu_request()),
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2297,21 +2326,6 @@ mod tests {
     }
 
     #[test]
-    fn gpu_has_explicit_device_ids_only_when_ids_are_present() {
-        use openshell_core::proto::compute::v1::GpuRequestSpec;
-
-        assert!(!gpu_has_explicit_device_ids(None));
-        assert!(!gpu_has_explicit_device_ids(Some(&GpuRequestSpec {
-            device_id: vec![],
-            count: None,
-        })));
-        assert!(gpu_has_explicit_device_ids(Some(&GpuRequestSpec {
-            device_id: vec!["nvidia.com/gpu=0".to_string()],
-            count: None,
-        })));
-    }
-
-    #[test]
     fn gpu_sandbox_uses_template_runtime_class_name_when_set() {
         let template = SandboxTemplate {
             platform_config: Some(Struct {
@@ -2330,7 +2344,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &template,
-                Some(&gpu_request(None)),
+                Some(&default_gpu_request()),
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2385,7 +2399,7 @@ mod tests {
             };
             sandbox_template_to_k8s(
                 &template,
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2420,7 +2434,7 @@ mod tests {
             };
             sandbox_template_to_k8s(
                 &template,
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2448,7 +2462,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &template,
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2479,7 +2493,7 @@ mod tests {
             };
             sandbox_template_to_k8s(
                 &template,
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2516,7 +2530,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &template,
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2536,7 +2550,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &template,
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2564,7 +2578,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &template,
-                Some(&gpu_request(None)),
+                Some(&default_gpu_request()),
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2868,7 +2882,7 @@ mod tests {
         };
         let pod_template = sandbox_template_to_k8s(
             &SandboxTemplate::default(),
-            false,
+            None,
             &std::collections::HashMap::new(),
             true,
             &params,
@@ -2894,7 +2908,7 @@ mod tests {
         };
         let pod_template = sandbox_template_to_k8s(
             &SandboxTemplate::default(),
-            false,
+            None,
             &std::collections::HashMap::new(),
             true,
             &params,
@@ -3368,7 +3382,7 @@ mod tests {
 
         let pod_template = sandbox_template_to_k8s(
             &template,
-            false,
+            None,
             &std::collections::HashMap::new(),
             false,
             &SandboxPodParams::default(),

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -246,6 +246,10 @@ impl KubernetesComputeDriver {
 
     pub async fn validate_sandbox_create(&self, sandbox: &Sandbox) -> Result<(), tonic::Status> {
         let gpu_requested = sandbox.spec.as_ref().is_some_and(|spec| spec.gpu);
+        self.validate_gpu_request(gpu_requested).await
+    }
+
+    async fn validate_gpu_request(&self, gpu_requested: bool) -> Result<(), tonic::Status> {
         if gpu_requested
             && !self.has_gpu_capacity().await.map_err(|err| {
                 tonic::Status::internal(format!("check GPU node capacity failed: {err}"))

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -17,6 +17,7 @@ use kube::{Client, Error as KubeError};
 use openshell_core::driver_utils::{
     LABEL_MANAGED_BY, LABEL_MANAGED_BY_VALUE, LABEL_SANDBOX_ID, SUPERVISOR_IMAGE_BINARY_PATH,
 };
+use openshell_core::gpu::driver_gpu_request;
 use openshell_core::progress::{
     PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX, PROGRESS_STEP_STARTING_SANDBOX,
     format_bytes, mark_progress_active, mark_progress_complete, mark_progress_detail,
@@ -25,7 +26,7 @@ use openshell_core::proto::compute::v1::{
     DriverCondition as SandboxCondition, DriverPlatformEvent as PlatformEvent,
     DriverSandbox as Sandbox, DriverSandboxSpec as SandboxSpec,
     DriverSandboxStatus as SandboxStatus, DriverSandboxTemplate as SandboxTemplate,
-    GetCapabilitiesResponse, WatchSandboxesDeletedEvent, WatchSandboxesEvent,
+    GetCapabilitiesResponse, GpuRequestSpec, WatchSandboxesDeletedEvent, WatchSandboxesEvent,
     WatchSandboxesPlatformEvent, WatchSandboxesSandboxEvent, watch_sandboxes_event,
 };
 use serde::Deserialize;
@@ -78,7 +79,11 @@ const SANDBOX_VERSION: &str = "v1alpha1";
 pub const SANDBOX_KIND: &str = "Sandbox";
 
 const GPU_RESOURCE_NAME: &str = "nvidia.com/gpu";
-const GPU_RESOURCE_QUANTITY: &str = "1";
+const DEFAULT_GPU_COUNT: u32 = 1;
+
+fn gpu_has_explicit_device_ids(gpu: Option<&GpuRequestSpec>) -> bool {
+    gpu.is_some_and(|gpu| !gpu.device_id.is_empty())
+}
 
 // This POC treats the selected Struct as a driver-local typed schema. Once the
 // Kubernetes shape stabilizes, these serde structs may move to driver-local
@@ -245,12 +250,20 @@ impl KubernetesComputeDriver {
     }
 
     pub async fn validate_sandbox_create(&self, sandbox: &Sandbox) -> Result<(), tonic::Status> {
-        let gpu_requested = sandbox.spec.as_ref().is_some_and(|spec| spec.gpu);
-        self.validate_gpu_request(gpu_requested).await
+        let gpu = sandbox.spec.as_ref().and_then(driver_gpu_request);
+        self.validate_gpu_request(gpu).await
     }
 
-    async fn validate_gpu_request(&self, gpu_requested: bool) -> Result<(), tonic::Status> {
-        if gpu_requested
+    async fn validate_gpu_request(
+        &self,
+        gpu: Option<&GpuRequestSpec>,
+    ) -> Result<(), tonic::Status> {
+        if gpu_has_explicit_device_ids(gpu) {
+            return Err(tonic::Status::invalid_argument(
+                "kubernetes compute driver does not support explicit GPU device IDs",
+            ));
+        }
+        if gpu.is_some()
             && !self.has_gpu_capacity().await.map_err(|err| {
                 tonic::Status::internal(format!("check GPU node capacity failed: {err}"))
             })?
@@ -342,6 +355,14 @@ impl KubernetesComputeDriver {
     }
 
     pub async fn create_sandbox(&self, sandbox: &Sandbox) -> Result<(), KubernetesDriverError> {
+        if let Some(gpu) = sandbox.spec.as_ref().and_then(driver_gpu_request)
+            && gpu_has_explicit_device_ids(Some(gpu))
+        {
+            return Err(KubernetesDriverError::Precondition(
+                "kubernetes compute driver does not support explicit GPU device IDs".to_string(),
+            ));
+        }
+
         let name = sandbox.name.as_str();
         info!(
             sandbox_id = %sandbox.id,
@@ -1169,7 +1190,13 @@ fn sandbox_to_k8s_spec(
         if let Some(template) = spec.template.as_ref() {
             root.insert(
                 "podTemplate".to_string(),
-                sandbox_template_to_k8s(template, spec.gpu, &pod_env, inject_workspace, params),
+                sandbox_template_to_k8s(
+                    template,
+                    driver_gpu_request(spec),
+                    &pod_env,
+                    inject_workspace,
+                    params,
+                ),
             );
             if !template.agent_socket_path.is_empty() {
                 root.insert(
@@ -1201,7 +1228,7 @@ fn sandbox_to_k8s_spec(
             "podTemplate".to_string(),
             sandbox_template_to_k8s(
                 &SandboxTemplate::default(),
-                spec.is_some_and(|s| s.gpu),
+                spec.and_then(|s| s.gpu.as_ref()),
                 &pod_env,
                 inject_workspace,
                 params,
@@ -1216,7 +1243,7 @@ fn sandbox_to_k8s_spec(
 
 fn sandbox_template_to_k8s(
     template: &SandboxTemplate,
-    gpu: bool,
+    gpu: Option<&GpuRequestSpec>,
     spec_environment: &std::collections::HashMap<String, String>,
     inject_workspace: bool,
     params: &SandboxPodParams<'_>,
@@ -1282,7 +1309,7 @@ fn sandbox_template_to_k8s(
 
     if use_user_namespaces {
         spec.insert("hostUsers".to_string(), serde_json::json!(false));
-        if gpu {
+        if gpu.is_some() {
             warn!(
                 "GPU sandbox with user namespaces enabled — \
                  NVIDIA device plugin compatibility is unverified"
@@ -1552,7 +1579,10 @@ fn app_armor_profile_to_k8s(profile: &AppArmorProfile) -> serde_json::Value {
     value
 }
 
-fn container_resources(template: &SandboxTemplate, gpu: bool) -> Option<serde_json::Value> {
+fn container_resources(
+    template: &SandboxTemplate,
+    gpu: Option<&GpuRequestSpec>,
+) -> Option<serde_json::Value> {
     // Start from the raw resources passthrough in platform_config (preserves
     // custom resource types like GPU limits that users set via the public API
     // Struct), then overlay the typed DriverResourceRequirements on top.
@@ -1585,8 +1615,8 @@ fn container_resources(template: &SandboxTemplate, gpu: bool) -> Option<serde_js
         apply("requests", "memory", memory_request);
     }
 
-    if gpu {
-        apply_gpu_limit(&mut resources);
+    if let Some(gpu) = gpu {
+        apply_gpu_limit(&mut resources, gpu.count.unwrap_or(DEFAULT_GPU_COUNT));
     }
     if resources.as_object().is_some_and(serde_json::Map::is_empty) {
         None
@@ -1595,10 +1625,10 @@ fn container_resources(template: &SandboxTemplate, gpu: bool) -> Option<serde_js
     }
 }
 
-fn apply_gpu_limit(resources: &mut serde_json::Value) {
+fn apply_gpu_limit(resources: &mut serde_json::Value, count: u32) {
     let Some(resources_obj) = resources.as_object_mut() else {
         *resources = serde_json::json!({});
-        return apply_gpu_limit(resources);
+        return apply_gpu_limit(resources, count);
     };
 
     let limits = resources_obj
@@ -1606,12 +1636,12 @@ fn apply_gpu_limit(resources: &mut serde_json::Value) {
         .or_insert_with(|| serde_json::json!({}));
     let Some(limits_obj) = limits.as_object_mut() else {
         *limits = serde_json::json!({});
-        return apply_gpu_limit(resources);
+        return apply_gpu_limit(resources, count);
     };
 
     limits_obj.insert(
         GPU_RESOURCE_NAME.to_string(),
-        serde_json::json!(GPU_RESOURCE_QUANTITY),
+        serde_json::json!(count.to_string()),
     );
 }
 
@@ -1910,6 +1940,13 @@ mod tests {
         assert!(config.pod.node_selector.is_empty());
         assert!(config.containers.agent.resources.requests.is_empty());
         assert!(config.containers.agent.resources.limits.is_empty());
+    }
+
+    fn gpu_request(count: Option<u32>) -> GpuRequestSpec {
+        GpuRequestSpec {
+            device_id: vec![],
+            count,
+        }
     }
 
     #[test]
@@ -2223,7 +2260,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &SandboxTemplate::default(),
-                true,
+                Some(&gpu_request(None)),
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2236,8 +2273,42 @@ mod tests {
         );
         assert_eq!(
             pod_template["spec"]["containers"][0]["resources"]["limits"][GPU_RESOURCE_NAME],
-            serde_json::json!(GPU_RESOURCE_QUANTITY)
+            serde_json::json!(DEFAULT_GPU_COUNT.to_string())
         );
+    }
+
+    #[test]
+    fn gpu_sandbox_uses_requested_gpu_count() {
+        let pod_template = {
+            let params = SandboxPodParams::default();
+            sandbox_template_to_k8s(
+                &SandboxTemplate::default(),
+                Some(&gpu_request(Some(2))),
+                &std::collections::HashMap::new(),
+                true,
+                &params,
+            )
+        };
+
+        assert_eq!(
+            pod_template["spec"]["containers"][0]["resources"]["limits"][GPU_RESOURCE_NAME],
+            serde_json::json!("2")
+        );
+    }
+
+    #[test]
+    fn gpu_has_explicit_device_ids_only_when_ids_are_present() {
+        use openshell_core::proto::compute::v1::GpuRequestSpec;
+
+        assert!(!gpu_has_explicit_device_ids(None));
+        assert!(!gpu_has_explicit_device_ids(Some(&GpuRequestSpec {
+            device_id: vec![],
+            count: None,
+        })));
+        assert!(gpu_has_explicit_device_ids(Some(&GpuRequestSpec {
+            device_id: vec!["nvidia.com/gpu=0".to_string()],
+            count: None,
+        })));
     }
 
     #[test]
@@ -2259,7 +2330,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &template,
-                true,
+                Some(&gpu_request(None)),
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2291,7 +2362,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &template,
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2493,7 +2564,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &template,
-                true,
+                Some(&gpu_request(None)),
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2504,7 +2575,7 @@ mod tests {
         assert_eq!(limits["cpu"], serde_json::json!("2"));
         assert_eq!(
             limits[GPU_RESOURCE_NAME],
-            serde_json::json!(GPU_RESOURCE_QUANTITY)
+            serde_json::json!(DEFAULT_GPU_COUNT.to_string())
         );
     }
 
@@ -2524,7 +2595,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &template,
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2547,7 +2618,7 @@ mod tests {
             };
             sandbox_template_to_k8s(
                 &SandboxTemplate::default(),
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2572,7 +2643,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &SandboxTemplate::default(),
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2595,7 +2666,7 @@ mod tests {
             };
             sandbox_template_to_k8s(
                 &template,
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2734,7 +2805,7 @@ mod tests {
         };
         let pod_template = sandbox_template_to_k8s(
             &SandboxTemplate::default(),
-            false,
+            None,
             &std::collections::HashMap::new(),
             false, // user provided custom VCTs
             &params,
@@ -2772,7 +2843,7 @@ mod tests {
         };
         sandbox_template_to_k8s(
             &SandboxTemplate::default(),
-            false,
+            None,
             &std::collections::HashMap::new(),
             true,
             &params,
@@ -2896,7 +2967,7 @@ mod tests {
         let params = SandboxPodParams::default(); // cluster default is off
         let pod_template = sandbox_template_to_k8s(
             &template,
-            false,
+            None,
             &std::collections::HashMap::new(),
             true,
             &params,
@@ -2934,7 +3005,7 @@ mod tests {
         };
         let pod_template = sandbox_template_to_k8s(
             &template,
-            false,
+            None,
             &std::collections::HashMap::new(),
             true,
             &params,
@@ -2960,7 +3031,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &SandboxTemplate::default(),
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 true,
                 &params,
@@ -2982,7 +3053,7 @@ mod tests {
         };
         let pod_template = sandbox_template_to_k8s(
             &SandboxTemplate::default(),
-            false,
+            None,
             &std::collections::HashMap::new(),
             true,
             &params,
@@ -3004,7 +3075,7 @@ mod tests {
     fn sandbox_template_omits_empty_image_pull_secrets() {
         let pod_template = sandbox_template_to_k8s(
             &SandboxTemplate::default(),
-            false,
+            None,
             &std::collections::HashMap::new(),
             true,
             &SandboxPodParams::default(),
@@ -3029,7 +3100,7 @@ mod tests {
         };
         let pod_template = sandbox_template_to_k8s(
             &SandboxTemplate::default(),
-            false,
+            None,
             &std::collections::HashMap::new(),
             true,
             &params,
@@ -3058,7 +3129,7 @@ mod tests {
         };
         let pod_template = sandbox_template_to_k8s(
             &template,
-            false,
+            None,
             &std::collections::HashMap::new(),
             true,
             &params,
@@ -3186,7 +3257,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &template,
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 false,
                 &params,
@@ -3247,7 +3318,7 @@ mod tests {
             let params = SandboxPodParams::default();
             sandbox_template_to_k8s(
                 &template,
-                false,
+                None,
                 &std::collections::HashMap::new(),
                 false,
                 &params,

--- a/crates/openshell-driver-podman/README.md
+++ b/crates/openshell-driver-podman/README.md
@@ -46,7 +46,7 @@ The container spec in `container.rs` sets these security-critical fields:
 | `no_new_privileges` | `true` | Prevents privilege escalation after exec. |
 | `seccomp_profile_path` | `unconfined` | The supervisor installs its own policy-aware BPF filter. A container-level profile can block Landlock/seccomp syscalls during setup. |
 | `mounts` | Private tmpfs at `/run/netns` | Lets the supervisor create named network namespaces in rootless Podman. |
-| CDI GPU devices | Explicit GPU request device IDs when set, otherwise all NVIDIA GPUs | Exposes requested GPUs to GPU-enabled sandbox containers. Count-based GPU requests are rejected until Podman CDI selection can map counts to concrete devices. |
+| CDI GPU devices | Explicit `resource_requirements.gpu.device_ids` when set, otherwise all NVIDIA GPUs | Exposes requested GPUs to GPU-enabled sandbox containers. Count-based GPU requests are rejected until Podman CDI selection can map counts to concrete devices. |
 
 The restricted agent child does not retain these supervisor privileges.
 

--- a/crates/openshell-driver-podman/README.md
+++ b/crates/openshell-driver-podman/README.md
@@ -46,7 +46,7 @@ The container spec in `container.rs` sets these security-critical fields:
 | `no_new_privileges` | `true` | Prevents privilege escalation after exec. |
 | `seccomp_profile_path` | `unconfined` | The supervisor installs its own policy-aware BPF filter. A container-level profile can block Landlock/seccomp syscalls during setup. |
 | `mounts` | Private tmpfs at `/run/netns` | Lets the supervisor create named network namespaces in rootless Podman. |
-| CDI GPU devices | Sandbox `gpu_device` value when set, otherwise all NVIDIA GPUs | Exposes requested GPUs to GPU-enabled sandbox containers. |
+| CDI GPU devices | Explicit GPU request device IDs when set, otherwise all NVIDIA GPUs | Exposes requested GPUs to GPU-enabled sandbox containers. Count-based GPU requests are rejected until Podman CDI selection can map counts to concrete devices. |
 
 The restricted agent child does not retain these supervisor privileges.
 

--- a/crates/openshell-driver-podman/src/container.rs
+++ b/crates/openshell-driver-podman/src/container.rs
@@ -4,7 +4,7 @@
 //! Container spec construction for the Podman driver.
 
 use crate::config::PodmanComputeConfig;
-use openshell_core::gpu::cdi_gpu_device_ids;
+use openshell_core::gpu::{cdi_gpu_device_ids, driver_gpu_request};
 use openshell_core::proto::compute::v1::DriverSandbox;
 use serde::Serialize;
 use serde_json::Value;
@@ -379,8 +379,8 @@ fn podman_pids_limit(value: i64) -> Option<i64> {
 
 /// Build CDI GPU device list if GPU is requested.
 fn build_devices(sandbox: &DriverSandbox) -> Option<Vec<LinuxDevice>> {
-    let spec = sandbox.spec.as_ref()?;
-    cdi_gpu_device_ids(spec.gpu, &spec.gpu_device).map(|device_ids| {
+    let gpu = sandbox.spec.as_ref().and_then(driver_gpu_request);
+    cdi_gpu_device_ids(gpu).map(|device_ids| {
         device_ids
             .into_iter()
             .map(|path| LinuxDevice { path })
@@ -808,11 +808,14 @@ mod tests {
     #[test]
     fn container_spec_maps_empty_gpu_request_to_all_cdi_device() {
         use openshell_core::config::CDI_GPU_DEVICE_ALL;
-        use openshell_core::proto::compute::v1::DriverSandboxSpec;
+        use openshell_core::proto::compute::v1::{DriverSandboxSpec, GpuRequestSpec};
 
         let mut sandbox = test_sandbox("test-id", "test-name");
         sandbox.spec = Some(DriverSandboxSpec {
-            gpu: true,
+            gpu: Some(GpuRequestSpec {
+                device_id: vec![],
+                count: None,
+            }),
             ..Default::default()
         });
         let config = test_config();
@@ -826,12 +829,14 @@ mod tests {
 
     #[test]
     fn container_spec_passes_explicit_cdi_device_id_through() {
-        use openshell_core::proto::compute::v1::DriverSandboxSpec;
+        use openshell_core::proto::compute::v1::{DriverSandboxSpec, GpuRequestSpec};
 
         let mut sandbox = test_sandbox("test-id", "test-name");
         sandbox.spec = Some(DriverSandboxSpec {
-            gpu: true,
-            gpu_device: "nvidia.com/gpu=0".to_string(),
+            gpu: Some(GpuRequestSpec {
+                device_id: vec!["nvidia.com/gpu=0".to_string()],
+                count: None,
+            }),
             ..Default::default()
         });
         let config = test_config();

--- a/crates/openshell-driver-podman/src/container.rs
+++ b/crates/openshell-driver-podman/src/container.rs
@@ -4,7 +4,7 @@
 //! Container spec construction for the Podman driver.
 
 use crate::config::PodmanComputeConfig;
-use openshell_core::gpu::{cdi_gpu_device_ids, driver_gpu_request};
+use openshell_core::gpu::{cdi_gpu_device_ids, driver_gpu_requirement};
 use openshell_core::proto::compute::v1::DriverSandbox;
 use serde::Serialize;
 use serde_json::Value;
@@ -379,7 +379,7 @@ fn podman_pids_limit(value: i64) -> Option<i64> {
 
 /// Build CDI GPU device list if GPU is requested.
 fn build_devices(sandbox: &DriverSandbox) -> Option<Vec<LinuxDevice>> {
-    let gpu = sandbox.spec.as_ref().and_then(driver_gpu_request);
+    let gpu = sandbox.spec.as_ref().and_then(driver_gpu_requirement);
     cdi_gpu_device_ids(gpu).map(|device_ids| {
         device_ids
             .into_iter()
@@ -699,6 +699,13 @@ mod tests {
     static ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
         std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
 
+    fn default_gpu_request() -> openshell_core::proto::compute::v1::DriverGpuResourceRequirement {
+        openshell_core::proto::compute::v1::DriverGpuResourceRequirement {
+            device_ids: vec![],
+            count: None,
+        }
+    }
+
     #[test]
     fn parse_cpu_millicore() {
         assert_eq!(parse_cpu_to_microseconds("500m"), Some(50_000));
@@ -808,13 +815,14 @@ mod tests {
     #[test]
     fn container_spec_maps_empty_gpu_request_to_all_cdi_device() {
         use openshell_core::config::CDI_GPU_DEVICE_ALL;
-        use openshell_core::proto::compute::v1::{DriverSandboxSpec, GpuRequestSpec};
+        use openshell_core::proto::compute::v1::{
+            DriverSandboxResourceRequirements, DriverSandboxSpec,
+        };
 
         let mut sandbox = test_sandbox("test-id", "test-name");
         sandbox.spec = Some(DriverSandboxSpec {
-            gpu: Some(GpuRequestSpec {
-                device_id: vec![],
-                count: None,
+            resource_requirements: Some(DriverSandboxResourceRequirements {
+                gpu: Some(default_gpu_request()),
             }),
             ..Default::default()
         });
@@ -829,13 +837,17 @@ mod tests {
 
     #[test]
     fn container_spec_passes_explicit_cdi_device_id_through() {
-        use openshell_core::proto::compute::v1::{DriverSandboxSpec, GpuRequestSpec};
+        use openshell_core::proto::compute::v1::{
+            DriverGpuResourceRequirement, DriverSandboxResourceRequirements, DriverSandboxSpec,
+        };
 
         let mut sandbox = test_sandbox("test-id", "test-name");
         sandbox.spec = Some(DriverSandboxSpec {
-            gpu: Some(GpuRequestSpec {
-                device_id: vec!["nvidia.com/gpu=0".to_string()],
-                count: None,
+            resource_requirements: Some(DriverSandboxResourceRequirements {
+                gpu: Some(DriverGpuResourceRequirement {
+                    device_ids: vec!["nvidia.com/gpu=0".to_string()],
+                    count: None,
+                }),
             }),
             ..Default::default()
         });

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -11,8 +11,10 @@ use crate::watcher::{
 };
 use openshell_core::ComputeDriverError;
 use openshell_core::driver_utils::supervisor_image_should_refresh;
-use openshell_core::gpu::driver_gpu_request;
-use openshell_core::proto::compute::v1::{DriverSandbox, GetCapabilitiesResponse, GpuRequestSpec};
+use openshell_core::gpu::driver_gpu_requirement;
+use openshell_core::proto::compute::v1::{
+    DriverGpuResourceRequirement, DriverSandbox, GetCapabilitiesResponse,
+};
 use std::path::PathBuf;
 use std::time::Duration;
 use tracing::{info, warn};
@@ -282,11 +284,13 @@ impl PodmanComputeDriver {
         &self,
         sandbox: &DriverSandbox,
     ) -> Result<(), ComputeDriverError> {
-        let gpu = sandbox.spec.as_ref().and_then(driver_gpu_request);
+        let gpu = sandbox.spec.as_ref().and_then(driver_gpu_requirement);
         Self::validate_gpu_request(gpu)
     }
 
-    fn validate_gpu_request(gpu: Option<&GpuRequestSpec>) -> Result<(), ComputeDriverError> {
+    fn validate_gpu_request(
+        gpu: Option<&DriverGpuResourceRequirement>,
+    ) -> Result<(), ComputeDriverError> {
         if gpu.is_some_and(|gpu| gpu.count.is_some()) {
             return Err(ComputeDriverError::Precondition(
                 "podman compute driver does not support GPU count requests".to_string(),
@@ -660,8 +664,8 @@ mod tests {
 
     #[test]
     fn validate_gpu_request_rejects_count() {
-        let err = PodmanComputeDriver::validate_gpu_request(Some(&GpuRequestSpec {
-            device_id: vec![],
+        let err = PodmanComputeDriver::validate_gpu_request(Some(&DriverGpuResourceRequirement {
+            device_ids: vec![],
             count: Some(2),
         }))
         .expect_err("GPU count should be rejected");

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -11,7 +11,8 @@ use crate::watcher::{
 };
 use openshell_core::ComputeDriverError;
 use openshell_core::driver_utils::supervisor_image_should_refresh;
-use openshell_core::proto::compute::v1::{DriverSandbox, GetCapabilitiesResponse};
+use openshell_core::gpu::driver_gpu_request;
+use openshell_core::proto::compute::v1::{DriverSandbox, GetCapabilitiesResponse, GpuRequestSpec};
 use std::path::PathBuf;
 use std::time::Duration;
 use tracing::{info, warn};
@@ -281,12 +282,17 @@ impl PodmanComputeDriver {
         &self,
         sandbox: &DriverSandbox,
     ) -> Result<(), ComputeDriverError> {
-        let gpu_requested = sandbox.spec.as_ref().is_some_and(|s| s.gpu);
-        Self::validate_gpu_request(gpu_requested)
+        let gpu = sandbox.spec.as_ref().and_then(driver_gpu_request);
+        Self::validate_gpu_request(gpu)
     }
 
-    fn validate_gpu_request(gpu_requested: bool) -> Result<(), ComputeDriverError> {
-        if gpu_requested && !Self::has_gpu_capacity() {
+    fn validate_gpu_request(gpu: Option<&GpuRequestSpec>) -> Result<(), ComputeDriverError> {
+        if gpu.is_some_and(|gpu| gpu.count.is_some()) {
+            return Err(ComputeDriverError::Precondition(
+                "podman compute driver does not support GPU count requests".to_string(),
+            ));
+        }
+        if gpu.is_some() && !Self::has_gpu_capacity() {
             return Err(ComputeDriverError::Precondition(
                 "GPU sandbox requested, but no NVIDIA GPU devices are available.".to_string(),
             ));
@@ -306,6 +312,7 @@ impl PodmanComputeDriver {
                 "sandbox id is required".into(),
             ));
         }
+        self.validate_sandbox_create(sandbox)?;
 
         // Validate the composed container name early, before creating any
         // resources (volume), so we don't leave orphans when the name is
@@ -649,6 +656,19 @@ mod tests {
     fn podman_driver_error_from_not_found() {
         let err = ComputeDriverError::from(PodmanApiError::NotFound("gone".into()));
         assert!(matches!(err, ComputeDriverError::Message(_)));
+    }
+
+    #[test]
+    fn validate_gpu_request_rejects_count() {
+        let err = PodmanComputeDriver::validate_gpu_request(Some(&GpuRequestSpec {
+            device_id: vec![],
+            count: Some(2),
+        }))
+        .expect_err("GPU count should be rejected");
+
+        assert!(
+            matches!(err, ComputeDriverError::Precondition(message) if message.contains("does not support GPU count"))
+        );
     }
 
     // ── grpc_endpoint auto-detection ───────────────────────────────────

--- a/crates/openshell-driver-vm/README.md
+++ b/crates/openshell-driver-vm/README.md
@@ -52,8 +52,9 @@ sudo -E env "PATH=$PATH" mise run gateway:vm -- --gpu
 ```
 
 GPU passthrough uses VFIO and requires host support for IOMMU, root privileges
-for bind/unbind operations, and a compatible sandbox image. The public GPU
-overview lives in the repository `README.md`.
+for bind/unbind operations, and a compatible sandbox image. Sandbox GPU requests
+arrive as `resource_requirements.gpu`; the VM driver accepts the default request,
+one explicit device ID, or a count of one.
 
 Point the CLI at the gateway with one of:
 

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -2577,15 +2577,7 @@ fn validate_vm_sandbox(sandbox: &Sandbox, gpu_enabled: bool) -> Result<(), Statu
         .as_ref()
         .ok_or_else(|| Status::invalid_argument("sandbox spec is required"))?;
 
-    if spec.gpu && !gpu_enabled {
-        return Err(Status::failed_precondition(
-            "GPU support is not enabled on this driver; start with --gpu",
-        ));
-    }
-
-    if !spec.gpu && !spec.gpu_device.is_empty() {
-        return Err(Status::invalid_argument("gpu_device requires gpu=true"));
-    }
+    validate_gpu_request(spec.gpu, &spec.gpu_device, gpu_enabled)?;
 
     if let Some(template) = spec.template.as_ref() {
         if !template.agent_socket_path.is_empty() {
@@ -2624,6 +2616,20 @@ fn validate_sandbox_id(sandbox_id: &str) -> Result<(), Status> {
         return Err(Status::invalid_argument(
             "sandbox id must match [A-Za-z0-9._-]{1,128}",
         ));
+    }
+    Ok(())
+}
+
+#[allow(clippy::result_large_err)]
+fn validate_gpu_request(gpu: bool, gpu_device: &str, gpu_enabled: bool) -> Result<(), Status> {
+    if gpu && !gpu_enabled {
+        return Err(Status::failed_precondition(
+            "GPU support is not enabled on this driver; start with --gpu",
+        ));
+    }
+
+    if !gpu && !gpu_device.is_empty() {
+        return Err(Status::invalid_argument("gpu_device requires gpu=true"));
     }
     Ok(())
 }

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -24,20 +24,21 @@ use oci_client::manifest::{
 };
 use oci_client::secrets::RegistryAuth;
 use oci_client::{Reference, RegistryOperation};
-use openshell_core::gpu::driver_gpu_request;
+use openshell_core::gpu::driver_gpu_requirement;
 use openshell_core::progress::{
     PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX, PROGRESS_STEP_STARTING_SANDBOX,
     format_bytes, mark_progress_active, mark_progress_complete, mark_progress_detail,
 };
 use openshell_core::proto::compute::v1::{
     CreateSandboxRequest, CreateSandboxResponse, DeleteSandboxRequest, DeleteSandboxResponse,
-    DriverCondition as SandboxCondition, DriverPlatformEvent as PlatformEvent,
-    DriverSandbox as Sandbox, DriverSandboxStatus as SandboxStatus, GetCapabilitiesRequest,
-    GetCapabilitiesResponse, GetSandboxRequest, GetSandboxResponse, GpuRequestSpec,
-    ListSandboxesRequest, ListSandboxesResponse, StopSandboxRequest, StopSandboxResponse,
-    ValidateSandboxCreateRequest, ValidateSandboxCreateResponse, WatchSandboxesDeletedEvent,
-    WatchSandboxesEvent, WatchSandboxesPlatformEvent, WatchSandboxesRequest,
-    WatchSandboxesSandboxEvent, compute_driver_server::ComputeDriver, watch_sandboxes_event,
+    DriverCondition as SandboxCondition, DriverGpuResourceRequirement,
+    DriverPlatformEvent as PlatformEvent, DriverSandbox as Sandbox,
+    DriverSandboxStatus as SandboxStatus, GetCapabilitiesRequest, GetCapabilitiesResponse,
+    GetSandboxRequest, GetSandboxResponse, ListSandboxesRequest, ListSandboxesResponse,
+    StopSandboxRequest, StopSandboxResponse, ValidateSandboxCreateRequest,
+    ValidateSandboxCreateResponse, WatchSandboxesDeletedEvent, WatchSandboxesEvent,
+    WatchSandboxesPlatformEvent, WatchSandboxesRequest, WatchSandboxesSandboxEvent,
+    compute_driver_server::ComputeDriver, watch_sandboxes_event,
 };
 use openshell_vfio::SysfsRoot;
 use prost::Message;
@@ -619,7 +620,8 @@ impl VmDriver {
         let gpu_device = sandbox
             .spec
             .as_ref()
-            .and_then(|spec| requested_gpu_device(driver_gpu_request(spec)));
+            .and_then(driver_gpu_requirement)
+            .and_then(|gpu| requested_gpu_device(Some(gpu)));
         let gpu_bdf = if let Some(gpu_device) = gpu_device {
             Some(self.assign_gpu_to_record(&sandbox.id, gpu_device).await?)
         } else {
@@ -2579,7 +2581,7 @@ fn validate_vm_sandbox(sandbox: &Sandbox, gpu_enabled: bool) -> Result<(), Statu
         .as_ref()
         .ok_or_else(|| Status::invalid_argument("sandbox spec is required"))?;
 
-    validate_gpu_request(driver_gpu_request(spec), gpu_enabled)?;
+    validate_gpu_request(driver_gpu_requirement(spec), gpu_enabled)?;
 
     if let Some(template) = spec.template.as_ref() {
         if !template.agent_socket_path.is_empty() {
@@ -2622,26 +2624,33 @@ fn validate_sandbox_id(sandbox_id: &str) -> Result<(), Status> {
     Ok(())
 }
 
-fn requested_gpu_device(gpu: Option<&GpuRequestSpec>) -> Option<&str> {
+fn requested_gpu_device(gpu: Option<&DriverGpuResourceRequirement>) -> Option<&str> {
     let gpu = gpu?;
-    Some(gpu.device_id.first().map_or("", String::as_str))
+    Some(gpu.device_ids.first().map_or("", String::as_str))
 }
 
 #[allow(clippy::result_large_err)]
-fn validate_gpu_request(gpu: Option<&GpuRequestSpec>, gpu_enabled: bool) -> Result<(), Status> {
-    if gpu.is_some() && !gpu_enabled {
+fn validate_gpu_request(
+    gpu: Option<&DriverGpuResourceRequirement>,
+    gpu_enabled: bool,
+) -> Result<(), Status> {
+    let Some(gpu) = gpu else {
+        return Ok(());
+    };
+
+    if !gpu_enabled {
         return Err(Status::failed_precondition(
             "GPU support is not enabled on this driver; start with --gpu",
         ));
     }
 
-    if gpu.is_some_and(|gpu| gpu.count.is_some_and(|count| count > 1)) {
+    if gpu.count.is_some_and(|count| count > 1) {
         return Err(Status::invalid_argument(
             "vm compute driver supports at most one GPU",
         ));
     }
 
-    if gpu.is_some_and(|gpu| gpu.device_id.len() > 1) {
+    if gpu.device_ids.len() > 1 {
         return Err(Status::invalid_argument(
             "vm compute driver supports at most one GPU device ID",
         ));
@@ -4433,7 +4442,8 @@ mod tests {
         PROGRESS_COMPLETE_STEP_KEY,
     };
     use openshell_core::proto::compute::v1::{
-        DriverSandboxSpec as SandboxSpec, DriverSandboxTemplate as SandboxTemplate, GpuRequestSpec,
+        DriverGpuResourceRequirement, DriverSandboxResourceRequirements,
+        DriverSandboxSpec as SandboxSpec, DriverSandboxTemplate as SandboxTemplate,
     };
     use prost_types::{Struct, Value, value::Kind};
     use std::fs;
@@ -4444,6 +4454,15 @@ mod tests {
 
     static ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
         std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
+    fn gpu_resource_requirements(
+        device_ids: Vec<String>,
+        count: Option<u32>,
+    ) -> DriverSandboxResourceRequirements {
+        DriverSandboxResourceRequirements {
+            gpu: Some(DriverGpuResourceRequirement { device_ids, count }),
+        }
+    }
 
     #[test]
     fn vm_pulling_layer_event_adds_progress_detail_metadata() {
@@ -4512,10 +4531,7 @@ mod tests {
         let sandbox = Sandbox {
             id: "sandbox-123".to_string(),
             spec: Some(SandboxSpec {
-                gpu: Some(GpuRequestSpec {
-                    device_id: vec![],
-                    count: None,
-                }),
+                resource_requirements: Some(gpu_resource_requirements(vec![], None)),
                 ..Default::default()
             }),
             ..Default::default()
@@ -4531,10 +4547,7 @@ mod tests {
         let sandbox = Sandbox {
             id: "sandbox-123".to_string(),
             spec: Some(SandboxSpec {
-                gpu: Some(GpuRequestSpec {
-                    device_id: vec![],
-                    count: None,
-                }),
+                resource_requirements: Some(gpu_resource_requirements(vec![], None)),
                 ..Default::default()
             }),
             ..Default::default()
@@ -4547,10 +4560,7 @@ mod tests {
         let sandbox = Sandbox {
             id: "sandbox-123".to_string(),
             spec: Some(SandboxSpec {
-                gpu: Some(GpuRequestSpec {
-                    device_id: vec![],
-                    count: Some(1),
-                }),
+                resource_requirements: Some(gpu_resource_requirements(vec![], Some(1))),
                 ..Default::default()
             }),
             ..Default::default()
@@ -4563,10 +4573,7 @@ mod tests {
         let sandbox = Sandbox {
             id: "sandbox-123".to_string(),
             spec: Some(SandboxSpec {
-                gpu: Some(GpuRequestSpec {
-                    device_id: vec![],
-                    count: Some(2),
-                }),
+                resource_requirements: Some(gpu_resource_requirements(vec![], Some(2))),
                 ..Default::default()
             }),
             ..Default::default()
@@ -4582,10 +4589,10 @@ mod tests {
         let sandbox = Sandbox {
             id: "sandbox-123".to_string(),
             spec: Some(SandboxSpec {
-                gpu: Some(GpuRequestSpec {
-                    device_id: vec!["0000:2d:00.0".to_string(), "0000:3d:00.0".to_string()],
-                    count: None,
-                }),
+                resource_requirements: Some(gpu_resource_requirements(
+                    vec!["0000:2d:00.0".to_string(), "0000:3d:00.0".to_string()],
+                    None,
+                )),
                 ..Default::default()
             }),
             ..Default::default()
@@ -4603,8 +4610,8 @@ mod tests {
 
     #[test]
     fn requested_gpu_device_defaults_empty_request_to_inventory_choice() {
-        let gpu = GpuRequestSpec {
-            device_id: vec![],
+        let gpu = DriverGpuResourceRequirement {
+            device_ids: vec![],
             count: None,
         };
 
@@ -4613,8 +4620,8 @@ mod tests {
 
     #[test]
     fn requested_gpu_device_returns_first_explicit_device_id() {
-        let gpu = GpuRequestSpec {
-            device_id: vec!["0000:2d:00.0".to_string()],
+        let gpu = DriverGpuResourceRequirement {
+            device_ids: vec!["0000:2d:00.0".to_string()],
             count: None,
         };
 

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -615,10 +615,11 @@ impl VmDriver {
             )));
         }
 
-        let spec = sandbox.spec.as_ref();
-        let is_gpu = spec.is_some_and(|s| s.gpu);
-        let gpu_device = spec.map_or("", |s| s.gpu_device.as_str());
-        let gpu_bdf = if is_gpu {
+        let gpu_device = sandbox
+            .spec
+            .as_ref()
+            .and_then(|spec| requested_gpu_device(spec.gpu, &spec.gpu_device));
+        let gpu_bdf = if let Some(gpu_device) = gpu_device {
             Some(self.assign_gpu_to_record(&sandbox.id, gpu_device).await?)
         } else {
             None
@@ -2620,6 +2621,10 @@ fn validate_sandbox_id(sandbox_id: &str) -> Result<(), Status> {
     Ok(())
 }
 
+fn requested_gpu_device(gpu: bool, gpu_device: &str) -> Option<&str> {
+    gpu.then_some(gpu_device)
+}
+
 #[allow(clippy::result_large_err)]
 fn validate_gpu_request(gpu: bool, gpu_device: &str, gpu_enabled: bool) -> Result<(), Status> {
     if gpu && !gpu_enabled {
@@ -4536,6 +4541,24 @@ mod tests {
             .expect_err("gpu_device without gpu should be rejected");
         assert_eq!(err.code(), Code::InvalidArgument);
         assert!(err.message().contains("gpu_device requires gpu=true"));
+    }
+
+    #[test]
+    fn requested_gpu_device_returns_none_without_gpu_request() {
+        assert_eq!(requested_gpu_device(false, ""), None);
+    }
+
+    #[test]
+    fn requested_gpu_device_defaults_empty_request_to_inventory_choice() {
+        assert_eq!(requested_gpu_device(true, ""), Some(""));
+    }
+
+    #[test]
+    fn requested_gpu_device_returns_explicit_device_id() {
+        assert_eq!(
+            requested_gpu_device(true, "0000:2d:00.0"),
+            Some("0000:2d:00.0")
+        );
     }
 
     #[test]

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -24,6 +24,7 @@ use oci_client::manifest::{
 };
 use oci_client::secrets::RegistryAuth;
 use oci_client::{Reference, RegistryOperation};
+use openshell_core::gpu::driver_gpu_request;
 use openshell_core::progress::{
     PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX, PROGRESS_STEP_STARTING_SANDBOX,
     format_bytes, mark_progress_active, mark_progress_complete, mark_progress_detail,
@@ -32,11 +33,11 @@ use openshell_core::proto::compute::v1::{
     CreateSandboxRequest, CreateSandboxResponse, DeleteSandboxRequest, DeleteSandboxResponse,
     DriverCondition as SandboxCondition, DriverPlatformEvent as PlatformEvent,
     DriverSandbox as Sandbox, DriverSandboxStatus as SandboxStatus, GetCapabilitiesRequest,
-    GetCapabilitiesResponse, GetSandboxRequest, GetSandboxResponse, ListSandboxesRequest,
-    ListSandboxesResponse, StopSandboxRequest, StopSandboxResponse, ValidateSandboxCreateRequest,
-    ValidateSandboxCreateResponse, WatchSandboxesDeletedEvent, WatchSandboxesEvent,
-    WatchSandboxesPlatformEvent, WatchSandboxesRequest, WatchSandboxesSandboxEvent,
-    compute_driver_server::ComputeDriver, watch_sandboxes_event,
+    GetCapabilitiesResponse, GetSandboxRequest, GetSandboxResponse, GpuRequestSpec,
+    ListSandboxesRequest, ListSandboxesResponse, StopSandboxRequest, StopSandboxResponse,
+    ValidateSandboxCreateRequest, ValidateSandboxCreateResponse, WatchSandboxesDeletedEvent,
+    WatchSandboxesEvent, WatchSandboxesPlatformEvent, WatchSandboxesRequest,
+    WatchSandboxesSandboxEvent, compute_driver_server::ComputeDriver, watch_sandboxes_event,
 };
 use openshell_vfio::SysfsRoot;
 use prost::Message;
@@ -618,7 +619,7 @@ impl VmDriver {
         let gpu_device = sandbox
             .spec
             .as_ref()
-            .and_then(|spec| requested_gpu_device(spec.gpu, &spec.gpu_device));
+            .and_then(|spec| requested_gpu_device(driver_gpu_request(spec)));
         let gpu_bdf = if let Some(gpu_device) = gpu_device {
             Some(self.assign_gpu_to_record(&sandbox.id, gpu_device).await?)
         } else {
@@ -2578,7 +2579,7 @@ fn validate_vm_sandbox(sandbox: &Sandbox, gpu_enabled: bool) -> Result<(), Statu
         .as_ref()
         .ok_or_else(|| Status::invalid_argument("sandbox spec is required"))?;
 
-    validate_gpu_request(spec.gpu, &spec.gpu_device, gpu_enabled)?;
+    validate_gpu_request(driver_gpu_request(spec), gpu_enabled)?;
 
     if let Some(template) = spec.template.as_ref() {
         if !template.agent_socket_path.is_empty() {
@@ -2621,20 +2622,29 @@ fn validate_sandbox_id(sandbox_id: &str) -> Result<(), Status> {
     Ok(())
 }
 
-fn requested_gpu_device(gpu: bool, gpu_device: &str) -> Option<&str> {
-    gpu.then_some(gpu_device)
+fn requested_gpu_device(gpu: Option<&GpuRequestSpec>) -> Option<&str> {
+    let gpu = gpu?;
+    Some(gpu.device_id.first().map_or("", String::as_str))
 }
 
 #[allow(clippy::result_large_err)]
-fn validate_gpu_request(gpu: bool, gpu_device: &str, gpu_enabled: bool) -> Result<(), Status> {
-    if gpu && !gpu_enabled {
+fn validate_gpu_request(gpu: Option<&GpuRequestSpec>, gpu_enabled: bool) -> Result<(), Status> {
+    if gpu.is_some() && !gpu_enabled {
         return Err(Status::failed_precondition(
             "GPU support is not enabled on this driver; start with --gpu",
         ));
     }
 
-    if !gpu && !gpu_device.is_empty() {
-        return Err(Status::invalid_argument("gpu_device requires gpu=true"));
+    if gpu.is_some_and(|gpu| gpu.count.is_some_and(|count| count > 1)) {
+        return Err(Status::invalid_argument(
+            "vm compute driver supports at most one GPU",
+        ));
+    }
+
+    if gpu.is_some_and(|gpu| gpu.device_id.len() > 1) {
+        return Err(Status::invalid_argument(
+            "vm compute driver supports at most one GPU device ID",
+        ));
     }
     Ok(())
 }
@@ -4423,7 +4433,7 @@ mod tests {
         PROGRESS_COMPLETE_STEP_KEY,
     };
     use openshell_core::proto::compute::v1::{
-        DriverSandboxSpec as SandboxSpec, DriverSandboxTemplate as SandboxTemplate,
+        DriverSandboxSpec as SandboxSpec, DriverSandboxTemplate as SandboxTemplate, GpuRequestSpec,
     };
     use prost_types::{Struct, Value, value::Kind};
     use std::fs;
@@ -4502,7 +4512,10 @@ mod tests {
         let sandbox = Sandbox {
             id: "sandbox-123".to_string(),
             spec: Some(SandboxSpec {
-                gpu: true,
+                gpu: Some(GpuRequestSpec {
+                    device_id: vec![],
+                    count: None,
+                }),
                 ..Default::default()
             }),
             ..Default::default()
@@ -4518,7 +4531,10 @@ mod tests {
         let sandbox = Sandbox {
             id: "sandbox-123".to_string(),
             spec: Some(SandboxSpec {
-                gpu: true,
+                gpu: Some(GpuRequestSpec {
+                    device_id: vec![],
+                    count: None,
+                }),
                 ..Default::default()
             }),
             ..Default::default()
@@ -4527,38 +4543,82 @@ mod tests {
     }
 
     #[test]
-    fn validate_vm_sandbox_rejects_gpu_device_without_gpu() {
+    fn validate_vm_sandbox_accepts_gpu_count_one_when_enabled() {
         let sandbox = Sandbox {
             id: "sandbox-123".to_string(),
             spec: Some(SandboxSpec {
-                gpu: false,
-                gpu_device: "0000:2d:00.0".to_string(),
+                gpu: Some(GpuRequestSpec {
+                    device_id: vec![],
+                    count: Some(1),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        validate_vm_sandbox(&sandbox, true).expect("gpu count one should be accepted");
+    }
+
+    #[test]
+    fn validate_vm_sandbox_rejects_gpu_count_greater_than_one() {
+        let sandbox = Sandbox {
+            id: "sandbox-123".to_string(),
+            spec: Some(SandboxSpec {
+                gpu: Some(GpuRequestSpec {
+                    device_id: vec![],
+                    count: Some(2),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let err =
+            validate_vm_sandbox(&sandbox, true).expect_err("gpu count > 1 should be rejected");
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("at most one GPU"));
+    }
+
+    #[test]
+    fn validate_vm_sandbox_rejects_multiple_gpu_device_ids() {
+        let sandbox = Sandbox {
+            id: "sandbox-123".to_string(),
+            spec: Some(SandboxSpec {
+                gpu: Some(GpuRequestSpec {
+                    device_id: vec!["0000:2d:00.0".to_string(), "0000:3d:00.0".to_string()],
+                    count: None,
+                }),
                 ..Default::default()
             }),
             ..Default::default()
         };
         let err = validate_vm_sandbox(&sandbox, true)
-            .expect_err("gpu_device without gpu should be rejected");
+            .expect_err("multiple GPU device IDs should be rejected");
         assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("gpu_device requires gpu=true"));
+        assert!(err.message().contains("at most one GPU device ID"));
     }
 
     #[test]
     fn requested_gpu_device_returns_none_without_gpu_request() {
-        assert_eq!(requested_gpu_device(false, ""), None);
+        assert_eq!(requested_gpu_device(None), None);
     }
 
     #[test]
     fn requested_gpu_device_defaults_empty_request_to_inventory_choice() {
-        assert_eq!(requested_gpu_device(true, ""), Some(""));
+        let gpu = GpuRequestSpec {
+            device_id: vec![],
+            count: None,
+        };
+
+        assert_eq!(requested_gpu_device(Some(&gpu)), Some(""));
     }
 
     #[test]
-    fn requested_gpu_device_returns_explicit_device_id() {
-        assert_eq!(
-            requested_gpu_device(true, "0000:2d:00.0"),
-            Some("0000:2d:00.0")
-        );
+    fn requested_gpu_device_returns_first_explicit_device_id() {
+        let gpu = GpuRequestSpec {
+            device_id: vec!["0000:2d:00.0".to_string()],
+            count: None,
+        };
+
+        assert_eq!(requested_gpu_device(Some(&gpu)), Some("0000:2d:00.0"));
     }
 
     #[test]

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -19,10 +19,10 @@ use openshell_core::ComputeDriverKind;
 use openshell_core::proto::compute::v1::{
     CreateSandboxRequest, DeleteSandboxRequest, DriverCondition, DriverPlatformEvent,
     DriverResourceRequirements, DriverSandbox, DriverSandboxSpec, DriverSandboxStatus,
-    DriverSandboxTemplate, GetCapabilitiesRequest, GetSandboxRequest, ListSandboxesRequest,
-    ValidateSandboxCreateRequest, WatchSandboxesEvent, WatchSandboxesRequest,
-    compute_driver_client::ComputeDriverClient, compute_driver_server::ComputeDriver,
-    watch_sandboxes_event,
+    DriverSandboxTemplate, GetCapabilitiesRequest, GetSandboxRequest,
+    GpuRequestSpec as DriverGpuRequestSpec, ListSandboxesRequest, ValidateSandboxCreateRequest,
+    WatchSandboxesEvent, WatchSandboxesRequest, compute_driver_client::ComputeDriverClient,
+    compute_driver_server::ComputeDriver, watch_sandboxes_event,
 };
 use openshell_core::proto::{
     PlatformEvent, Sandbox, SandboxCondition, SandboxPhase, SandboxSpec, SandboxStatus,
@@ -1279,8 +1279,10 @@ fn driver_sandbox_spec_from_public(
             .as_ref()
             .map(|template| driver_sandbox_template_from_public(template, driver_kind))
             .transpose()?,
-        gpu: spec.gpu,
-        gpu_device: spec.gpu_device.clone(),
+        gpu: spec.gpu.as_ref().map(|gpu| DriverGpuRequestSpec {
+            device_id: gpu.device_id.clone(),
+            count: gpu.count,
+        }),
         sandbox_token: String::new(),
     })
 }
@@ -1661,7 +1663,7 @@ fn derive_phase(status: Option<&DriverSandboxStatus>) -> SandboxPhase {
 }
 
 fn rewrite_user_facing_conditions(status: &mut Option<SandboxStatus>, spec: Option<&SandboxSpec>) {
-    let gpu_requested = spec.is_some_and(|sandbox_spec| sandbox_spec.gpu);
+    let gpu_requested = spec.is_some_and(|sandbox_spec| sandbox_spec.gpu.is_some());
     if !gpu_requested {
         return;
     }
@@ -1824,6 +1826,7 @@ pub async fn new_test_runtime(store: Arc<Store>) -> ComputeRuntime {
 mod tests {
     use super::*;
     use futures::stream;
+    use openshell_core::proto::GpuRequestSpec;
     use openshell_core::proto::compute::v1::{
         CreateSandboxResponse, DeleteSandboxResponse, GetCapabilitiesResponse, GetSandboxRequest,
         GetSandboxResponse, StopSandboxRequest, StopSandboxResponse, ValidateSandboxCreateResponse,
@@ -1842,6 +1845,48 @@ mod tests {
         prost_types::Value {
             kind: Some(prost_types::value::Kind::NumberValue(value)),
         }
+    }
+
+    #[test]
+    fn driver_sandbox_spec_from_public_preserves_gpu_request_device_ids() {
+        let public = SandboxSpec {
+            gpu: Some(GpuRequestSpec {
+                device_id: vec!["nvidia.com/gpu=0".to_string()],
+                count: None,
+            }),
+            ..Default::default()
+        };
+
+        let driver = driver_sandbox_spec_from_public(&public);
+
+        assert_eq!(
+            driver
+                .gpu
+                .expect("driver GPU request should be present")
+                .device_id,
+            vec!["nvidia.com/gpu=0".to_string()]
+        );
+    }
+
+    #[test]
+    fn driver_sandbox_spec_from_public_preserves_gpu_count() {
+        let public = SandboxSpec {
+            gpu: Some(GpuRequestSpec {
+                device_id: vec![],
+                count: Some(2),
+            }),
+            ..Default::default()
+        };
+
+        let driver = driver_sandbox_spec_from_public(&public);
+
+        assert_eq!(
+            driver
+                .gpu
+                .expect("driver GPU request should be present")
+                .count,
+            Some(2)
+        );
     }
 
     fn struct_value(
@@ -2356,7 +2401,10 @@ mod tests {
         rewrite_user_facing_conditions(
             &mut status,
             Some(&SandboxSpec {
-                gpu: true,
+                gpu: Some(GpuRequestSpec {
+                    device_id: vec![],
+                    count: None,
+                }),
                 ..Default::default()
             }),
         );
@@ -2387,7 +2435,7 @@ mod tests {
         rewrite_user_facing_conditions(
             &mut status,
             Some(&SandboxSpec {
-                gpu: false,
+                gpu: None,
                 ..Default::default()
             }),
         );
@@ -2669,7 +2717,10 @@ mod tests {
 
         let sandbox = Sandbox {
             spec: Some(SandboxSpec {
-                gpu: true,
+                gpu: Some(GpuRequestSpec {
+                    device_id: vec![],
+                    count: None,
+                }),
                 ..Default::default()
             }),
             ..sandbox_record("sb-1", "sandbox-a", SandboxPhase::Provisioning)
@@ -2692,7 +2743,7 @@ mod tests {
             SandboxPhase::try_from(stored.phase()).unwrap(),
             SandboxPhase::Ready
         );
-        assert!(stored.spec.as_ref().is_some_and(|spec| spec.gpu));
+        assert!(stored.spec.as_ref().is_some_and(|spec| spec.gpu.is_some()));
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -17,12 +17,13 @@ use crate::tracing_bus::TracingLogBus;
 use futures::{Stream, StreamExt};
 use openshell_core::ComputeDriverKind;
 use openshell_core::proto::compute::v1::{
-    CreateSandboxRequest, DeleteSandboxRequest, DriverCondition, DriverPlatformEvent,
-    DriverResourceRequirements, DriverSandbox, DriverSandboxSpec, DriverSandboxStatus,
-    DriverSandboxTemplate, GetCapabilitiesRequest, GetSandboxRequest,
-    GpuRequestSpec as DriverGpuRequestSpec, ListSandboxesRequest, ValidateSandboxCreateRequest,
-    WatchSandboxesEvent, WatchSandboxesRequest, compute_driver_client::ComputeDriverClient,
-    compute_driver_server::ComputeDriver, watch_sandboxes_event,
+    CreateSandboxRequest, DeleteSandboxRequest, DriverCondition, DriverGpuResourceRequirement,
+    DriverPlatformEvent, DriverResourceRequirements, DriverSandbox,
+    DriverSandboxResourceRequirements, DriverSandboxSpec, DriverSandboxStatus,
+    DriverSandboxTemplate, GetCapabilitiesRequest, GetSandboxRequest, ListSandboxesRequest,
+    ValidateSandboxCreateRequest, WatchSandboxesEvent, WatchSandboxesRequest,
+    compute_driver_client::ComputeDriverClient, compute_driver_server::ComputeDriver,
+    watch_sandboxes_event,
 };
 use openshell_core::proto::{
     PlatformEvent, Sandbox, SandboxCondition, SandboxPhase, SandboxSpec, SandboxStatus,
@@ -1279,12 +1280,26 @@ fn driver_sandbox_spec_from_public(
             .as_ref()
             .map(|template| driver_sandbox_template_from_public(template, driver_kind))
             .transpose()?,
-        gpu: spec.gpu.as_ref().map(|gpu| DriverGpuRequestSpec {
-            device_id: gpu.device_id.clone(),
-            count: gpu.count,
-        }),
+        resource_requirements: spec
+            .resource_requirements
+            .as_ref()
+            .map(driver_resource_requirements_from_public),
         sandbox_token: String::new(),
     })
+}
+
+fn driver_resource_requirements_from_public(
+    requirements: &openshell_core::proto::SandboxResourceRequirements,
+) -> DriverSandboxResourceRequirements {
+    DriverSandboxResourceRequirements {
+        gpu: requirements
+            .gpu
+            .as_ref()
+            .map(|gpu| DriverGpuResourceRequirement {
+                device_ids: gpu.device_ids.clone(),
+                count: gpu.count,
+            }),
+    }
 }
 
 fn driver_sandbox_template_from_public(
@@ -1663,7 +1678,12 @@ fn derive_phase(status: Option<&DriverSandboxStatus>) -> SandboxPhase {
 }
 
 fn rewrite_user_facing_conditions(status: &mut Option<SandboxStatus>, spec: Option<&SandboxSpec>) {
-    let gpu_requested = spec.is_some_and(|sandbox_spec| sandbox_spec.gpu.is_some());
+    let gpu_requested = spec.is_some_and(|sandbox_spec| {
+        sandbox_spec
+            .resource_requirements
+            .as_ref()
+            .is_some_and(|requirements| requirements.gpu.is_some())
+    });
     if !gpu_requested {
         return;
     }
@@ -1826,11 +1846,11 @@ pub async fn new_test_runtime(store: Arc<Store>) -> ComputeRuntime {
 mod tests {
     use super::*;
     use futures::stream;
-    use openshell_core::proto::GpuRequestSpec;
     use openshell_core::proto::compute::v1::{
         CreateSandboxResponse, DeleteSandboxResponse, GetCapabilitiesResponse, GetSandboxRequest,
         GetSandboxResponse, StopSandboxRequest, StopSandboxResponse, ValidateSandboxCreateResponse,
     };
+    use openshell_core::proto::{GpuResourceRequirement, SandboxResourceRequirements};
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::{mpsc, oneshot};
@@ -1850,20 +1870,25 @@ mod tests {
     #[test]
     fn driver_sandbox_spec_from_public_preserves_gpu_request_device_ids() {
         let public = SandboxSpec {
-            gpu: Some(GpuRequestSpec {
-                device_id: vec!["nvidia.com/gpu=0".to_string()],
-                count: None,
+            resource_requirements: Some(SandboxResourceRequirements {
+                gpu: Some(GpuResourceRequirement {
+                    device_ids: vec!["nvidia.com/gpu=0".to_string()],
+                    count: None,
+                }),
             }),
             ..Default::default()
         };
 
-        let driver = driver_sandbox_spec_from_public(&public);
+        let driver = driver_sandbox_spec_from_public(&public, None)
+            .expect("public sandbox spec should convert to driver spec");
 
         assert_eq!(
             driver
+                .resource_requirements
+                .expect("driver resource requirements should be present")
                 .gpu
-                .expect("driver GPU request should be present")
-                .device_id,
+                .expect("driver GPU requirement should be present")
+                .device_ids,
             vec!["nvidia.com/gpu=0".to_string()]
         );
     }
@@ -1871,19 +1896,24 @@ mod tests {
     #[test]
     fn driver_sandbox_spec_from_public_preserves_gpu_count() {
         let public = SandboxSpec {
-            gpu: Some(GpuRequestSpec {
-                device_id: vec![],
-                count: Some(2),
+            resource_requirements: Some(SandboxResourceRequirements {
+                gpu: Some(GpuResourceRequirement {
+                    device_ids: vec![],
+                    count: Some(2),
+                }),
             }),
             ..Default::default()
         };
 
-        let driver = driver_sandbox_spec_from_public(&public);
+        let driver = driver_sandbox_spec_from_public(&public, None)
+            .expect("public sandbox spec should convert to driver spec");
 
         assert_eq!(
             driver
+                .resource_requirements
+                .expect("driver resource requirements should be present")
                 .gpu
-                .expect("driver GPU request should be present")
+                .expect("driver GPU requirement should be present")
                 .count,
             Some(2)
         );
@@ -2401,9 +2431,11 @@ mod tests {
         rewrite_user_facing_conditions(
             &mut status,
             Some(&SandboxSpec {
-                gpu: Some(GpuRequestSpec {
-                    device_id: vec![],
-                    count: None,
+                resource_requirements: Some(SandboxResourceRequirements {
+                    gpu: Some(GpuResourceRequirement {
+                        device_ids: vec![],
+                        count: None,
+                    }),
                 }),
                 ..Default::default()
             }),
@@ -2432,13 +2464,7 @@ mod tests {
             ..Default::default()
         });
 
-        rewrite_user_facing_conditions(
-            &mut status,
-            Some(&SandboxSpec {
-                gpu: None,
-                ..Default::default()
-            }),
-        );
+        rewrite_user_facing_conditions(&mut status, Some(&SandboxSpec::default()));
 
         assert_eq!(status.unwrap().conditions[0].message, original);
     }
@@ -2717,9 +2743,11 @@ mod tests {
 
         let sandbox = Sandbox {
             spec: Some(SandboxSpec {
-                gpu: Some(GpuRequestSpec {
-                    device_id: vec![],
-                    count: None,
+                resource_requirements: Some(SandboxResourceRequirements {
+                    gpu: Some(GpuResourceRequirement {
+                        device_ids: vec![],
+                        count: None,
+                    }),
                 }),
                 ..Default::default()
             }),
@@ -2743,7 +2771,11 @@ mod tests {
             SandboxPhase::try_from(stored.phase()).unwrap(),
             SandboxPhase::Ready
         );
-        assert!(stored.spec.as_ref().is_some_and(|spec| spec.gpu.is_some()));
+        assert!(stored.spec.as_ref().is_some_and(|spec| {
+            spec.resource_requirements
+                .as_ref()
+                .is_some_and(|requirements| requirements.gpu.is_some())
+        }));
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -100,7 +100,7 @@ fn emit_sandbox_create_telemetry(
     };
     openshell_core::telemetry::emit_sandbox_create(
         outcome,
-        spec.gpu,
+        spec.gpu.is_some(),
         spec.providers.len() as u64,
         spec.policy.is_some(),
         template_source,

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -100,7 +100,9 @@ fn emit_sandbox_create_telemetry(
     };
     openshell_core::telemetry::emit_sandbox_create(
         outcome,
-        spec.gpu.is_some(),
+        spec.resource_requirements
+            .as_ref()
+            .is_some_and(|requirements| requirements.gpu.is_some()),
         spec.providers.len() as u64,
         spec.policy.is_some(),
         template_source,

--- a/crates/openshell-server/src/grpc/validation.rs
+++ b/crates/openshell-server/src/grpc/validation.rs
@@ -131,9 +131,9 @@ pub(super) fn validate_sandbox_spec(
         validate_sandbox_template(tmpl)?;
     }
 
-    // --- spec.gpu ---
-    if let Some(ref gpu) = spec.gpu {
-        validate_gpu_request(gpu)?;
+    // --- spec.resource_requirements ---
+    if let Some(ref requirements) = spec.resource_requirements {
+        validate_resource_requirements(requirements)?;
     }
 
     // --- spec.policy serialized size ---
@@ -149,14 +149,27 @@ pub(super) fn validate_sandbox_spec(
     Ok(())
 }
 
-fn validate_gpu_request(gpu: &openshell_core::proto::GpuRequestSpec) -> Result<(), Status> {
-    if gpu.count.is_some() && !gpu.device_id.is_empty() {
+fn validate_resource_requirements(
+    requirements: &openshell_core::proto::SandboxResourceRequirements,
+) -> Result<(), Status> {
+    if let Some(ref gpu) = requirements.gpu {
+        validate_gpu_requirement(gpu)?;
+    }
+    Ok(())
+}
+
+fn validate_gpu_requirement(
+    gpu: &openshell_core::proto::GpuResourceRequirement,
+) -> Result<(), Status> {
+    if gpu.count.is_some() && !gpu.device_ids.is_empty() {
         return Err(Status::invalid_argument(
-            "gpu.count is mutually exclusive with gpu.device_id",
+            "resource_requirements.gpu.count is mutually exclusive with resource_requirements.gpu.device_ids",
         ));
     }
     if gpu.count == Some(0) {
-        return Err(Status::invalid_argument("gpu.count must be greater than 0"));
+        return Err(Status::invalid_argument(
+            "resource_requirements.gpu.count must be greater than 0",
+        ));
     }
     Ok(())
 }
@@ -697,7 +710,7 @@ pub(super) fn level_matches(log_level: &str, min_level: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openshell_core::proto::{GpuRequestSpec, SandboxSpec};
+    use openshell_core::proto::{GpuResourceRequirement, SandboxResourceRequirements, SandboxSpec};
     use std::collections::HashMap;
     use tonic::Code;
 
@@ -723,9 +736,11 @@ mod tests {
     #[test]
     fn validate_sandbox_spec_accepts_gpu_flag() {
         let spec = SandboxSpec {
-            gpu: Some(GpuRequestSpec {
-                device_id: vec![],
-                count: None,
+            resource_requirements: Some(SandboxResourceRequirements {
+                gpu: Some(GpuResourceRequirement {
+                    device_ids: vec![],
+                    count: None,
+                }),
             }),
             ..Default::default()
         };
@@ -735,9 +750,11 @@ mod tests {
     #[test]
     fn validate_sandbox_spec_accepts_gpu_count() {
         let spec = SandboxSpec {
-            gpu: Some(GpuRequestSpec {
-                device_id: vec![],
-                count: Some(2),
+            resource_requirements: Some(SandboxResourceRequirements {
+                gpu: Some(GpuResourceRequirement {
+                    device_ids: vec![],
+                    count: Some(2),
+                }),
             }),
             ..Default::default()
         };
@@ -747,9 +764,11 @@ mod tests {
     #[test]
     fn validate_sandbox_spec_rejects_zero_gpu_count() {
         let spec = SandboxSpec {
-            gpu: Some(GpuRequestSpec {
-                device_id: vec![],
-                count: Some(0),
+            resource_requirements: Some(SandboxResourceRequirements {
+                gpu: Some(GpuResourceRequirement {
+                    device_ids: vec![],
+                    count: Some(0),
+                }),
             }),
             ..Default::default()
         };
@@ -763,9 +782,11 @@ mod tests {
     #[test]
     fn validate_sandbox_spec_rejects_gpu_count_with_device_id() {
         let spec = SandboxSpec {
-            gpu: Some(GpuRequestSpec {
-                device_id: vec!["nvidia.com/gpu=0".to_string()],
-                count: Some(1),
+            resource_requirements: Some(SandboxResourceRequirements {
+                gpu: Some(GpuResourceRequirement {
+                    device_ids: vec!["nvidia.com/gpu=0".to_string()],
+                    count: Some(1),
+                }),
             }),
             ..Default::default()
         };

--- a/crates/openshell-server/src/grpc/validation.rs
+++ b/crates/openshell-server/src/grpc/validation.rs
@@ -131,6 +131,11 @@ pub(super) fn validate_sandbox_spec(
         validate_sandbox_template(tmpl)?;
     }
 
+    // --- spec.gpu ---
+    if let Some(ref gpu) = spec.gpu {
+        validate_gpu_request(gpu)?;
+    }
+
     // --- spec.policy serialized size ---
     if let Some(ref policy) = spec.policy {
         let size = policy.encoded_len();
@@ -141,6 +146,18 @@ pub(super) fn validate_sandbox_spec(
         }
     }
 
+    Ok(())
+}
+
+fn validate_gpu_request(gpu: &openshell_core::proto::GpuRequestSpec) -> Result<(), Status> {
+    if gpu.count.is_some() && !gpu.device_id.is_empty() {
+        return Err(Status::invalid_argument(
+            "gpu.count is mutually exclusive with gpu.device_id",
+        ));
+    }
+    if gpu.count == Some(0) {
+        return Err(Status::invalid_argument("gpu.count must be greater than 0"));
+    }
     Ok(())
 }
 
@@ -680,7 +697,7 @@ pub(super) fn level_matches(log_level: &str, min_level: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openshell_core::proto::SandboxSpec;
+    use openshell_core::proto::{GpuRequestSpec, SandboxSpec};
     use std::collections::HashMap;
     use tonic::Code;
 
@@ -706,10 +723,57 @@ mod tests {
     #[test]
     fn validate_sandbox_spec_accepts_gpu_flag() {
         let spec = SandboxSpec {
-            gpu: true,
+            gpu: Some(GpuRequestSpec {
+                device_id: vec![],
+                count: None,
+            }),
             ..Default::default()
         };
         assert!(validate_sandbox_spec("gpu-sandbox", &spec).is_ok());
+    }
+
+    #[test]
+    fn validate_sandbox_spec_accepts_gpu_count() {
+        let spec = SandboxSpec {
+            gpu: Some(GpuRequestSpec {
+                device_id: vec![],
+                count: Some(2),
+            }),
+            ..Default::default()
+        };
+        assert!(validate_sandbox_spec("gpu-count-sandbox", &spec).is_ok());
+    }
+
+    #[test]
+    fn validate_sandbox_spec_rejects_zero_gpu_count() {
+        let spec = SandboxSpec {
+            gpu: Some(GpuRequestSpec {
+                device_id: vec![],
+                count: Some(0),
+            }),
+            ..Default::default()
+        };
+
+        let err = validate_sandbox_spec("gpu-count-sandbox", &spec).unwrap_err();
+
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("count must be greater than 0"));
+    }
+
+    #[test]
+    fn validate_sandbox_spec_rejects_gpu_count_with_device_id() {
+        let spec = SandboxSpec {
+            gpu: Some(GpuRequestSpec {
+                device_id: vec!["nvidia.com/gpu=0".to_string()],
+                count: Some(1),
+            }),
+            ..Default::default()
+        };
+
+        let err = validate_sandbox_spec("gpu-count-sandbox", &spec).unwrap_err();
+
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("mutually exclusive"));
     }
 
     #[test]

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -70,9 +70,19 @@ To request GPU resources, add `--gpu`:
 openshell sandbox create --gpu -- claude
 ```
 
+Request a specific number of GPUs with `--gpu-count`:
+
+```shell
+openshell sandbox create --gpu-count 2 -- claude
+```
+
 For Docker-backed sandboxes, GPU injection uses Docker CDI. If you enable Docker
 CDI after the gateway starts, restart the gateway so OpenShell can detect the
 updated Docker daemon capability.
+
+Kubernetes gateways honor `--gpu-count` by setting the `nvidia.com/gpu` resource
+limit. Docker and Podman support explicit CDI device IDs through `--gpu-device`
+but do not support count-based selection yet. VM gateways accept only one GPU.
 
 ### Custom Containers
 

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -76,13 +76,26 @@ Request a specific number of GPUs with `--gpu-count`:
 openshell sandbox create --gpu-count 2 -- claude
 ```
 
+Request a specific GPU device with `--gpu-device`; this also requests GPU
+resources:
+
+```shell
+openshell sandbox create --gpu-device nvidia.com/gpu=0 -- claude
+```
+
+Support for `--gpu-count` and `--gpu-device` is driver-dependent:
+
+| Driver     | `--gpu` default request       | `--gpu-count`         | `--gpu-device`                             |
+| ---------- | ----------------------------- | --------------------- | ------------------------------------------ |
+| Docker     | All CDI GPU devices           | Not supported         | One CDI device ID, such as `nvidia.com/gpu=0` |
+| Podman     | All CDI GPU devices           | Not supported         | One CDI device ID, such as `nvidia.com/gpu=0` |
+| Kubernetes | One `nvidia.com/gpu` resource | Supported             | Not supported                              |
+| VM         | One GPU                       | Only `1` is supported | One PCI BDF or GPU index                   |
+
 For Docker-backed sandboxes, GPU injection uses Docker CDI. If you enable Docker
 CDI after the gateway starts, restart the gateway so OpenShell can detect the
-updated Docker daemon capability.
-
-Kubernetes gateways honor `--gpu-count` by setting the `nvidia.com/gpu` resource
-limit. Docker and Podman support explicit CDI device IDs through `--gpu-device`
-but do not support count-based selection yet. VM gateways accept only one GPU.
+updated Docker daemon capability. In the API, these flags populate
+`SandboxSpec.resource_requirements.gpu`.
 
 ### Custom Containers
 

--- a/proto/compute_driver.proto
+++ b/proto/compute_driver.proto
@@ -77,18 +77,16 @@ message DriverSandbox {
 
 // Driver-owned provisioning inputs required to create a sandbox.
 message DriverSandboxSpec {
+  reserved 10;
+
   // Log level exposed to processes running inside the sandbox.
   string log_level = 1;
   // Environment variables injected into the sandbox runtime.
   map<string, string> environment = 5;
   // Runtime template consumed by the driver during provisioning.
   DriverSandboxTemplate template = 6;
-  // Request NVIDIA GPU resources for this sandbox.
-  bool gpu = 9;
-  // Optional PCI BDF address (e.g. "0000:2d:00.0") or device index
-  // (e.g. "0", "1"). When empty with gpu=true, the driver assigns the
-  // first available GPU.
-  string gpu_device = 10;
+  // Request GPU resources for this sandbox. Presence indicates a GPU request.
+  GpuRequestSpec gpu = 9;
   // Gateway-minted JWT identifying this sandbox to the gateway. Set by
   // the gateway on create; the driver materialises it via its native
   // secret mechanism (Docker/Podman/VM bind-mount a per-sandbox file;
@@ -96,6 +94,15 @@ message DriverSandboxSpec {
   // ServiceAccount token bootstrap instead). Never echoed to the public
   // Sandbox proto.
   string sandbox_token = 11;
+}
+
+// Driver-native GPU request details.
+message GpuRequestSpec {
+  // Optional number of GPUs requested. Mutually exclusive with device_id.
+  optional uint32 count = 1;
+  // Optional driver-native device identifiers. Mutually exclusive with count.
+  // Empty means the driver chooses its default GPU assignment behavior.
+  repeated string device_id = 2;
 }
 
 // Driver-owned runtime template consumed by the compute platform.

--- a/proto/compute_driver.proto
+++ b/proto/compute_driver.proto
@@ -77,16 +77,14 @@ message DriverSandbox {
 
 // Driver-owned provisioning inputs required to create a sandbox.
 message DriverSandboxSpec {
-  reserved 10;
-
   // Log level exposed to processes running inside the sandbox.
   string log_level = 1;
   // Environment variables injected into the sandbox runtime.
   map<string, string> environment = 5;
   // Runtime template consumed by the driver during provisioning.
   DriverSandboxTemplate template = 6;
-  // Request GPU resources for this sandbox. Presence indicates a GPU request.
-  GpuRequestSpec gpu = 9;
+  // Portable resource requirements for this sandbox.
+  DriverSandboxResourceRequirements resource_requirements = 9;
   // Gateway-minted JWT identifying this sandbox to the gateway. Set by
   // the gateway on create; the driver materialises it via its native
   // secret mechanism (Docker/Podman/VM bind-mount a per-sandbox file;
@@ -96,13 +94,20 @@ message DriverSandboxSpec {
   string sandbox_token = 11;
 }
 
-// Driver-native GPU request details.
-message GpuRequestSpec {
-  // Optional number of GPUs requested. Mutually exclusive with device_id.
+// Driver-owned resource requirements for the sandbox workload.
+message DriverSandboxResourceRequirements {
+  // GPU requirement for the sandbox. Presence indicates a GPU request.
+  DriverGpuResourceRequirement gpu = 1;
+}
+
+// Driver-owned GPU resource requirement. Device identifiers are interpreted by
+// the selected compute driver and are an interim compatibility surface.
+message DriverGpuResourceRequirement {
+  // Optional number of GPUs requested. Mutually exclusive with device_ids.
   optional uint32 count = 1;
   // Optional driver-native device identifiers. Mutually exclusive with count.
   // Empty means the driver chooses its default GPU assignment behavior.
-  repeated string device_id = 2;
+  repeated string device_ids = 2;
 }
 
 // Driver-owned runtime template consumed by the compute platform.

--- a/proto/openshell.proto
+++ b/proto/openshell.proto
@@ -307,6 +307,9 @@ message Sandbox {
 
 // Desired sandbox configuration provided through the public API.
 message SandboxSpec {
+  reserved 10, 11;
+  reserved "gpu_device", "proposal_approval_mode";
+
   // Log level exposed to processes running inside the sandbox.
   string log_level = 1;
   // Environment variables injected into the sandbox runtime.
@@ -317,18 +320,18 @@ message SandboxSpec {
   openshell.sandbox.v1.SandboxPolicy policy = 7;
   // Provider names to attach to this sandbox.
   repeated string providers = 8;
-  // Request NVIDIA GPU resources for this sandbox.
-  bool gpu = 9;
-  // Optional PCI BDF address (e.g. "0000:2d:00.0") or device index
-  // (e.g. "0", "1"). When empty with gpu=true, the driver assigns the
-  // first available GPU.
-  string gpu_device = 10;
-  // Field 11 was `proposal_approval_mode`. The approval mode is now a
-  // runtime setting (gateway or sandbox scope) read via UpdateConfig /
-  // GetSandboxConfig, so it can be flipped on a running sandbox and
-  // managed fleet-wide.
-  reserved 11;
-  reserved "proposal_approval_mode";
+  // Request GPU resources for this sandbox. Presence indicates a GPU request.
+  GpuRequestSpec gpu = 9;
+}
+
+// Public GPU request details. Device identifiers are interpreted by the
+// selected compute driver.
+message GpuRequestSpec {
+  // Optional number of GPUs requested. Mutually exclusive with device_id.
+  optional uint32 count = 1;
+  // Optional driver-native device identifiers. Mutually exclusive with count.
+  // Empty means the driver chooses its default GPU assignment behavior.
+  repeated string device_id = 2;
 }
 
 // Public sandbox template mapped onto compute-driver template inputs.

--- a/proto/openshell.proto
+++ b/proto/openshell.proto
@@ -307,9 +307,6 @@ message Sandbox {
 
 // Desired sandbox configuration provided through the public API.
 message SandboxSpec {
-  reserved 10, 11;
-  reserved "gpu_device", "proposal_approval_mode";
-
   // Log level exposed to processes running inside the sandbox.
   string log_level = 1;
   // Environment variables injected into the sandbox runtime.
@@ -320,18 +317,24 @@ message SandboxSpec {
   openshell.sandbox.v1.SandboxPolicy policy = 7;
   // Provider names to attach to this sandbox.
   repeated string providers = 8;
-  // Request GPU resources for this sandbox. Presence indicates a GPU request.
-  GpuRequestSpec gpu = 9;
+  // Portable resource requirements for this sandbox.
+  SandboxResourceRequirements resource_requirements = 9;
 }
 
-// Public GPU request details. Device identifiers are interpreted by the
-// selected compute driver.
-message GpuRequestSpec {
-  // Optional number of GPUs requested. Mutually exclusive with device_id.
+// Public resource requirements for the sandbox workload.
+message SandboxResourceRequirements {
+  // GPU requirement for the sandbox. Presence indicates a GPU request.
+  GpuResourceRequirement gpu = 1;
+}
+
+// Public GPU resource requirement. Device identifiers are interpreted by the
+// selected compute driver and are an interim compatibility surface.
+message GpuResourceRequirement {
+  // Optional number of GPUs requested. Mutually exclusive with device_ids.
   optional uint32 count = 1;
   // Optional driver-native device identifiers. Mutually exclusive with count.
   // Empty means the driver chooses its default GPU assignment behavior.
-  repeated string device_id = 2;
+  repeated string device_ids = 2;
 }
 
 // Public sandbox template mapped onto compute-driver template inputs.


### PR DESCRIPTION
## Summary
Adds compact GPU resource requirements to the public and compute-driver protos, moving the API toward the resource-requirements shape proposed in #1360.

## Related Issue
Related to #1444 and #1360

Closes #1338

## Changes
- Replaces `SandboxSpec.gpu` with `SandboxSpec.resource_requirements.gpu`.
- Supports default GPU requests, GPU count requests, and interim driver-specific `device_ids`.
- Preserves driver behavior: Kubernetes honors counts, VM accepts one GPU, Docker/Podman reject count requests while using CDI device IDs.
- Updates CLI mapping, gateway validation/translation, tests, and docs.

## Testing
- [x] `mise run pre-commit`

## Checklist
- [x] Follows Conventional Commits
- [x] Docs updated

