### PR TITLE
ci: add helm lint workflow triggered on helm chart changes

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Helm Lint
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+    paths:
+      - "deploy/helm/**"
+  workflow_dispatch:
+
+env:
+  MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr_metadata:
+    name: Resolve PR metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: gate
+        uses: ./.github/actions/pr-gate
+
+  helm-lint:
+    name: Helm Lint
+    needs: pr_metadata
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    runs-on: linux-amd64-cpu8
+    container:
+      image: ghcr.io/nvidia/openshell/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install tools
+        run: mise install --locked
+
+      - name: Lint Helm chart
+        run: mise run helm:lint

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Default values for OpenShell
-# ci-trigger
 
 replicaCount: 1
 

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Default values for OpenShell
+# ci-trigger
 
 replicaCount: 1
 


### PR DESCRIPTION
## Summary

- Adds a dedicated `helm-lint.yml` workflow that runs `mise run helm:lint` on PRs that touch `deploy/helm/**`
- Path filter on the trigger means the workflow is skipped entirely for unrelated PRs
- Uses the same `pr_metadata` gate and CI image as the other branch-checks workflows

## Related Issue

Stacked on #1159 (which introduces the `helm:lint` matrix task and the `ci/` values directory).

## Changes

- `.github/workflows/helm-lint.yml` — new workflow: triggers on `deploy/helm/**` path changes, runs `mise run helm:lint` in the CI container

## Testing

- [ ] Verify workflow triggers on a PR with helm chart changes
- [ ] Verify workflow is skipped on PRs with no helm chart changes

## Checklist

- [x] Follows conventional commits format
- [x] No secrets or credentials committed