### PR TITLE
fix(ci): include provider profiles in macos docker builds

### DIFF
--- a/deploy/docker/Dockerfile.cli-macos
+++ b/deploy/docker/Dockerfile.cli-macos
@@ -102,6 +102,7 @@ RUN --mount=type=cache,id=cargo-registry-cli-macos,sharing=locked,target=/root/.
 # Stage 2: real build
 # ---------------------------------------------------------------------------
 COPY crates/ crates/
+COPY providers/ providers/
 
 # Touch source files to ensure they're rebuilt (not the cached dummy).
 RUN touch crates/openshell-cli/src/main.rs \

--- a/deploy/docker/Dockerfile.gateway-macos
+++ b/deploy/docker/Dockerfile.gateway-macos
@@ -80,6 +80,7 @@ RUN --mount=type=cache,id=cargo-registry-gateway-macos,sharing=locked,target=/ro
     cargo build --release --target aarch64-apple-darwin -p openshell-server 2>/dev/null || true
 
 COPY crates/ crates/
+COPY providers/ providers/
 
 RUN touch crates/openshell-core/src/lib.rs \
     crates/openshell-driver-kubernetes/src/lib.rs \

--- a/deploy/docker/Dockerfile.python-wheels-macos
+++ b/deploy/docker/Dockerfile.python-wheels-macos
@@ -91,6 +91,7 @@ RUN --mount=type=cache,id=cargo-registry-python-wheels-macos-${TARGETARCH},shari
 
 # Copy actual source code and Python packaging files.
 COPY crates/ crates/
+COPY providers/ providers/
 COPY pyproject.toml README.md ./
 COPY python/ python/
 


### PR DESCRIPTION
## Summary

Fix macOS Docker-based builds after provider profiles moved to top-level `providers/*.yaml`. The affected Dockerfiles now copy `providers/` into the real build stage so `openshell-providers` can resolve its `include_str!` profile YAMLs.

## Related Issue

Fixes the failing Release Dev job from #1037: https://github.com/NVIDIA/OpenShell/actions/runs/25353137217/job/74336899201

## Changes

- `deploy/docker/Dockerfile.gateway-macos`: copy top-level provider profile YAMLs before compiling the gateway binary.
- `deploy/docker/Dockerfile.cli-macos`: copy provider profile YAMLs for the CLI macOS build.
- `deploy/docker/Dockerfile.python-wheels-macos`: copy provider profile YAMLs for macOS wheel builds.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

No new unit tests were added because this is a Docker build-context fix. The failing path is covered by CI's macOS Docker build jobs.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)