### PR TITLE
fix(vm): correct /sandbox ownership when rootfs is built by non-root host

### DIFF
--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -395,6 +395,20 @@ fi
 export HOME=/sandbox
 export USER=sandbox
 
+# Fix /sandbox ownership. The host-side CLI extracts OCI layers as a non-root
+# user (e.g. UID 501 on macOS), so /sandbox may be owned by the host UID.
+if [ -d /sandbox ]; then
+    _sb_uid=$(id -u sandbox 2>/dev/null || true)
+    _sb_gid=$(id -g sandbox 2>/dev/null || true)
+    if [ -n "$_sb_uid" ] && [ -n "$_sb_gid" ]; then
+        _cur_uid=$(stat -c '%u' /sandbox 2>/dev/null || true)
+        if [ -n "$_cur_uid" ] && [ "$_cur_uid" != "$_sb_uid" ]; then
+            ts "fixing /sandbox ownership (was uid=${_cur_uid}, setting to sandbox=${_sb_uid}:${_sb_gid})"
+            chown -R "${_sb_uid}:${_sb_gid}" /sandbox
+        fi
+    fi
+fi
+
 rewrite_openshell_endpoint_if_needed
 
 # Log supervisor connectivity state for debugging stuck-in-Provisioning issues


### PR DESCRIPTION
## Summary
Fix `/sandbox` home directory ownership in VM sandboxes when the host CLI runs as a non-root user (e.g. macOS UID 501). The sandbox user could not create files or directories in its own home because OCI layer extraction preserves the host user's UID instead of the in-guest sandbox user's UID.

## Related Issue
related to https://github.com/NVIDIA/OpenShell/pull/957

## Changes
- Add a conditional `chown -R` block to the VM init script (`openshell-vm-sandbox-init.sh`) that runs before the supervisor starts
- The block compares the current owner of `/sandbox` against the sandbox user's UID (resolved via `id -u sandbox`) and only runs `chown` when there is a mismatch
- No-op on systems where tar extraction already preserves correct ownership (e.g. Linux-as-root)


## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

### Manual verification

```bash
# Clear the rootfs cache so the updated init script is embedded
rm -rf target/openshell-vm-driver/images

# Rebuild
OPENSHELL_VM_RUNTIME_COMPRESSED_DIR=$PWD/target/vm-runtime-compressed cargo build

# Create a sandbox and verify
./target/debug/openshell sandbox create --from base
# Inside sandbox:
id                    # uid=998(sandbox)
ls -la ~              # should show sandbox:sandbox ownership
mkdir ~/hello         # should succeed
touch ~/testfile      # should succeed
```

without the patch I got

```
$ openshell  sandbox create --from base                                                                                                                                                                
  Created sandbox: perennial-pika

  sandbox@openshell-sandbox-vm:~$ id
  uid=998(sandbox) gid=998(sandbox) groups=998(sandbox)
  
  sandbox@openshell-sandbox-vm:~$ mkdir hello
  mkdir: cannot create directory 'hello': Permission denied
  
  sandbox@openshell-sandbox-vm:~$ ls -la
  total 8
  drwxr-xr-x 3 501 dialout  96 May  5 18:42 .agents
  -rw-r--r-- 1 501 dialout 174 Apr  3 23:12 .bashrc
  drwxr-xr-x 3 501 dialout  96 May  5 18:42 .claude
  -rw-r--r-- 1 501 dialout  32 Apr  3 23:12 .profile
  drwxr-xr-x 3 501 dialout  96 May  5 18:42 .uv
  drwxr-xr-x 9 501 dialout 288 May  5 18:42 .venv
  
  
  (501 is the user id on my mac)
  
```

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
