### PR TITLE
feat(cli): add openshell gateway list subcommand

### DIFF
--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -1031,6 +1031,13 @@ enum GatewayCommands {
         #[arg(long, env = "OPENSHELL_GATEWAY", add = ArgValueCompleter::new(completers::complete_gateway_names))]
         name: Option<String>,
     },
+
+    /// List registered gateways.
+    ///
+    /// Prints a table of all registered gateways with their endpoint, type,
+    /// and authentication mode. The active gateway is marked with `*`.
+    #[command(help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
+    List,
 }
 
 // -----------------------------------------------------------------------
@@ -1955,6 +1962,9 @@ async fn main() -> Result<()> {
                     .or_else(|| resolve_gateway_name(&cli.gateway))
                     .unwrap_or_else(|| "openshell".to_string());
                 run::gateway_admin_info(&name)?;
+            }
+            GatewayCommands::List => {
+                run::gateway_list(&cli.gateway)?;
             }
         },
 

--- a/docs/sandboxes/manage-gateways.mdx
+++ b/docs/sandboxes/manage-gateways.mdx
@@ -161,7 +161,7 @@ One gateway is always the active gateway. All CLI commands target it by default.
 List all registered gateways:
 
 ```shell
-openshell gateway select
+openshell gateway list
 ```
 
 Switch the active gateway:


### PR DESCRIPTION
## Summary

Wires up `openshell gateway list` as a first-class subcommand. Resolves
the dead reference at `crates/openshell-bootstrap/src/errors.rs:248`,
where the port-conflict recovery hint already pointed users at this
command.

## Related Issue

Closes #1173

## Changes

- `crates/openshell-cli/src/main.rs`: add `GatewayCommands::List` variant
  and dispatch to the existing `run::gateway_list(&cli.gateway)`.
- `docs/sandboxes/manage-gateways.mdx`: replace the `gateway select`
  workaround with `gateway list` in the "List all registered gateways"
  example.

## Testing

Manual: `openshell gateway list` renders the same table as `gateway select`
(no arg), and `openshell gateway --help` shows the new subcommand.

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)