### PR TITLE
docs: add missing provider types to supported providers table

### DIFF
--- a/docs/sandboxes/manage-providers.mdx
+++ b/docs/sandboxes/manage-providers.mdx
@@ -172,14 +172,17 @@ The following provider types are supported.
 
 | Type | Environment Variables Injected | Typical Use |
 |---|---|---|
+| `anthropic` | `ANTHROPIC_API_KEY` | Anthropic API |
 | `claude` | `ANTHROPIC_API_KEY`, `CLAUDE_API_KEY` | Claude Code, Anthropic API |
 | `codex` | `OPENAI_API_KEY` | OpenAI Codex |
+| `copilot` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` | GitHub Copilot CLI |
 | `generic` | User-defined | Any service with custom credentials |
 | `github` | `GITHUB_TOKEN`, `GH_TOKEN` | GitHub API, `gh` CLI — refer to [GitHub Sandbox](/get-started/tutorials/github-sandbox) |
 | `gitlab` | `GITLAB_TOKEN`, `GLAB_TOKEN`, `CI_JOB_TOKEN` | GitLab API, `glab` CLI |
 | `nvidia` | `NVIDIA_API_KEY` | NVIDIA API Catalog |
 | `openai` | `OPENAI_API_KEY` | Any OpenAI-compatible endpoint. Set `--config OPENAI_BASE_URL` to point to the provider. Refer to [Configure](/inference/configure). |
 | `opencode` | `OPENCODE_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY` | opencode tool |
+| `outlook` | None | Microsoft Outlook. Use `--credential` to provide credentials. |
 
 <Tip>
 Use the `generic` type for any service not listed above. You define the

--- a/docs/sandboxes/manage-providers.mdx
+++ b/docs/sandboxes/manage-providers.mdx
@@ -182,7 +182,6 @@ The following provider types are supported.
 | `nvidia` | `NVIDIA_API_KEY` | NVIDIA API Catalog |
 | `openai` | `OPENAI_API_KEY` | Any OpenAI-compatible endpoint. Set `--config OPENAI_BASE_URL` to point to the provider. Refer to [Configure](/inference/configure). |
 | `opencode` | `OPENCODE_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY` | opencode tool |
-| `outlook` | None | Microsoft Outlook. Use `--credential` to provide credentials. |
 
 <Tip>
 Use the `generic` type for any service not listed above. You define the


### PR DESCRIPTION
3 provider types exist in the CLI but were not listed in the Supported Provider Types table on the Providers page.

- `anthropic`: injects `ANTHROPIC_API_KEY`
- `copilot`: injects `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`
- `outlook`: no auto-discovery, requires `--credential`

Changes: Added three rows to the table in `docs/sandboxes/manage-providers.mdx`.

Testing: No code changes. Verified against the provider source files in `crates/openshell-providers/src/providers/`.

Checklist

- [x] Matches existing table format
- [x] Verified against source code
- [x] No unrelated changes