### PR TITLE
fix(ci): harden packit rpm source prep

### DIFF
--- a/.github/workflows/rpm-package.yml
+++ b/.github/workflows/rpm-package.yml
@@ -59,7 +59,16 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          find ~/rpmbuild/RPMS/ -name '*.rpm' -exec cp {} artifacts/ \;
+          for rpm_dir in "$HOME/rpmbuild/RPMS" "$PWD/${{ matrix.arch }}"; do
+            if [ -d "$rpm_dir" ]; then
+              find "$rpm_dir" -type f -name '*.rpm' -exec cp {} artifacts/ \;
+            fi
+          done
+          if ! compgen -G 'artifacts/*.rpm' > /dev/null; then
+            echo "::error::No RPM artifacts found"
+            find "$PWD" -maxdepth 3 -type f -name '*.rpm' -print
+            exit 1
+          fi
           echo "=== Built RPMs ==="
           ls -lah artifacts/
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,9 +26,10 @@ actions:
     # reflects any patching that Packit may have done (e.g. version bumps).
     - 'bash -c "VERSION=${PACKIT_PROJECT_VERSION} && TMPDIR=$(mktemp -d) && DIR=openshell-${VERSION} && mkdir -p ${TMPDIR}/${DIR} && git ls-files -z | xargs -0 tar cf - | tar xf - -C ${TMPDIR}/${DIR}/ && tar -czf openshell-${VERSION}.tar.gz -C ${TMPDIR} ${DIR} && rm -rf ${TMPDIR}"'
     # Step 2: Create vendored Cargo dependencies tarball for offline RPM build.
-    - 'bash -c "VERSION=${PACKIT_PROJECT_VERSION} && cargo vendor --quiet && tar -cJf openshell-${VERSION}-vendor.tar.xz vendor/ && rm -rf vendor/"'
-    # Step 3: Return BOTH archive names. Packit maps each line to Source0, Source1, etc.
-    - 'bash -c "echo openshell-${PACKIT_PROJECT_VERSION}.tar.gz && echo openshell-${PACKIT_PROJECT_VERSION}-vendor.tar.xz"'
+    - 'bash -c "VERSION=${PACKIT_PROJECT_VERSION} && CARGO_HTTP_TIMEOUT=600 CARGO_NET_RETRY=5 cargo vendor --locked --quiet && tar -cJf openshell-${VERSION}-vendor.tar.xz vendor/ && rm -rf vendor/"'
+    # Step 3: Return the primary archive name. Packit expects create-archive
+    # to print one path for Source0; Source1 is patched explicitly below.
+    - 'bash -c "echo openshell-${PACKIT_PROJECT_VERSION}.tar.gz"'
 
   fix-spec-file:
     # Update Source0 to the generated tarball name

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,8 +17,10 @@ srpm_build_deps:
 
 actions:
   get-current-version:
-    # Derive version from the latest upstream tag on the current branch.
-    - 'bash -c "git describe --tags --match ''v*'' --abbrev=0 HEAD | sed ''s/^v//''"'
+    # Derive version from the latest SemVer upstream tag on the current branch.
+    # Avoid operational tags such as vm-dev; Packit normalizes that to m.dev,
+    # which is not a valid Cargo package version.
+    - 'bash -c "git describe --tags --match ''v[0-9]*.[0-9]*.[0-9]*'' --abbrev=0 HEAD | sed ''s/^v//''"'
 
   create-archive:
     # Step 1: Create source tarball from git working tree.


### PR DESCRIPTION
## Summary

Fix the RPM Packit source-prep and artifact paths. The RPM package jobs now tolerate slow Cargo registry responses, avoid dev/vm-dev tags as package versions, return the correct Source0 archive path to Packit, and collect Packit local RPM outputs from the architecture-specific output directory.

## Related Issue

Fixes failing Release Dev RPM job: https://github.com/NVIDIA/OpenShell/actions/runs/25406306514/job/74518129270

## Changes

- Add Cargo HTTP timeout and retry settings to the Packit vendoring step.
- Run `cargo vendor --locked` so CI uses the committed lockfile.
- Return only the Source0 tarball from Packit create-archive; Source1 remains patched explicitly in fix-spec-file.
- Restrict Packit version discovery to SemVer release tags so operational tags like vm-dev do not become invalid Cargo versions.
- Collect local Packit RPM artifacts from `$PWD/${arch}` as well as legacy `~/rpmbuild/RPMS`, and fail with a clear error when no RPMs are copied.

## Testing

- [x] Rebased onto `origin/main` at `f17806ca`, which contains the shared `mise.lock` fix.
- [x] Confirmed `mise.lock` has no PR diff.
- [x] Confirmed `.github/workflows/release-canary.yml` has no PR diff.
- [x] `mise run pre-commit` passes.
- [x] YAML parse checks for `.packit.yaml` and `.github/workflows/rpm-package.yml`.
- [x] `git diff --check`.
- [x] Release Dev workflow succeeded on this branch before the final rebase: https://github.com/NVIDIA/OpenShell/actions/runs/25416029359
- [x] Reproduced and fixed Packit dev-tag version failure (`m.dev` Cargo version).
- [x] Reproduced and fixed Packit local artifact collection path failure.

## Checklist

- [x] Follows Conventional Commits.
- [x] Commits are signed off (DCO).
- [x] Architecture docs updated: not applicable; CI packaging config only.