### PR TITLE
chore(ci): enable Dependabot for GitHub Actions with 48h cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 2


### PR DESCRIPTION
## Summary

Enable Dependabot to keep GitHub Actions dependencies up to date automatically. Uses a daily schedule with a 48-hour cooldown to avoid chasing yanked or short-lived releases.

## Related Issue

N/A

## Changes

- Add `.github/dependabot.yml` with a `github-actions` ecosystem entry, daily schedule, and `cooldown.default-days: 2`

## Testing

- [x] `mise run pre-commit` passes (lint, format, license headers, markdown)
- [ ] Unit tests added/updated — not applicable
- [ ] E2E tests added/updated — not applicable

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — not applicable

Made with [Cursor](https://cursor.com)