### PR TITLE
test(e2e): clarify backend-specific task names

### DIFF
--- a/.github/workflows/e2e-gpu-test.yaml
+++ b/.github/workflows/e2e-gpu-test.yaml
@@ -79,4 +79,4 @@ jobs:
         run: mise run --no-deps --skip-deps cluster
 
       - name: Run tests
-        run: mise run --no-deps --skip-deps e2e:python:gpu
+        run: mise run --no-deps --skip-deps e2e:k3s:gpu

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,9 +27,9 @@ jobs:
       matrix:
         include:
           - suite: python
-            cmd: "mise run --no-deps --skip-deps e2e:python"
+            cmd: "mise run --no-deps --skip-deps e2e:docker:python"
           - suite: rust
-            cmd: "mise run --no-deps --skip-deps e2e:rust"
+            cmd: "mise run --no-deps --skip-deps e2e:docker:rust"
     container:
       image: ghcr.io/nvidia/openshell/ci:latest
       credentials:

--- a/TESTING.md
+++ b/TESTING.md
@@ -4,7 +4,9 @@
 
 ```bash
 mise run test          # Rust + Python unit tests
-mise run e2e           # End-to-end tests (starts a Docker-backed gateway)
+mise run e2e           # Docker-backed end-to-end tests
+mise run e2e:docker    # Same as e2e, explicit Docker-backed suite
+mise run e2e:k3s:gpu   # GPU E2E against the OpenShell k3s-cluster gateway
 mise run ci            # Everything: lint, compile checks, and tests
 ```
 
@@ -96,6 +98,12 @@ def test_exec_returns_stdout(sandbox):
         assert "hello" in result.stdout
 ```
 
+Run Docker-backed Python e2e tests:
+
+```bash
+mise run e2e:docker:python
+```
+
 #### `Sandbox.exec_python`
 
 `exec_python` serializes a Python callable with `cloudpickle`, sends it to the
@@ -154,13 +162,32 @@ Tests:
 Run all CLI e2e tests:
 
 ```bash
-mise run e2e:rust
+mise run e2e:docker:rust
 ```
 
 Run a single test directly with cargo:
 
 ```bash
 cargo test --manifest-path e2e/rust/Cargo.toml --features e2e --test sync
+```
+
+Run a single Rust e2e test target with the Docker-backed gateway wrapper:
+
+```bash
+OPENSHELL_E2E_RUST_TEST=smoke mise run e2e:docker:rust
+OPENSHELL_E2E_RUST_TEST=sync mise run e2e:docker:rust
+```
+
+Run only the Docker-backed smoke test:
+
+```bash
+mise run e2e:docker:smoke
+```
+
+Run GPU E2E against the OpenShell k3s-cluster gateway:
+
+```bash
+mise run e2e:k3s:gpu
 ```
 
 The harness (`e2e/rust/src/harness/`) provides:
@@ -178,3 +205,4 @@ The harness (`e2e/rust/src/harness/`) provides:
 |---|---|
 | `OPENSHELL_GATEWAY` | Override active gateway name for E2E tests |
 | `OPENSHELL_GATEWAY_ENDPOINT` | Run E2E tests against an existing plaintext HTTP gateway endpoint |
+| `OPENSHELL_E2E_RUST_TEST` | Run one Rust E2E integration test target, for example `smoke` or `sync` |

--- a/e2e/rust/e2e-docker.sh
+++ b/e2e/rust/e2e-docker.sh
@@ -2,19 +2,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Run a Rust e2e test against a standalone gateway running the bundled Docker
-# compute driver. Set OPENSHELL_GATEWAY_ENDPOINT=http://host:port to reuse an
-# existing plaintext gateway instead of starting an ephemeral one.
+# Backward-compatible wrapper for the Docker Rust e2e smoke path.
+#
+# Prefer e2e-rust.sh with OPENSHELL_E2E_RUST_TEST for new task wiring.
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-E2E_TEST="${OPENSHELL_E2E_DOCKER_TEST:-smoke}"
 
-cargo build -p openshell-cli --features openshell-core/dev-settings
+export OPENSHELL_E2E_RUST_TEST="${OPENSHELL_E2E_RUST_TEST:-${OPENSHELL_E2E_DOCKER_TEST:-smoke}}"
 
-exec "${ROOT}/e2e/with-docker-gateway.sh" \
-  cargo test --manifest-path "${ROOT}/e2e/rust/Cargo.toml" \
-    --features e2e \
-    --test "${E2E_TEST}" \
-    -- --nocapture
+exec "${ROOT}/e2e/rust/e2e-rust.sh"

--- a/e2e/rust/e2e-rust.sh
+++ b/e2e/rust/e2e-rust.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run Rust e2e tests against a standalone gateway running the bundled Docker
+# compute driver. Set OPENSHELL_E2E_RUST_TEST to a Rust integration test target
+# such as "smoke" or "sync" to run only that file.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+E2E_TEST="${OPENSHELL_E2E_RUST_TEST:-}"
+
+cargo build -p openshell-cli --features openshell-core/dev-settings
+
+cargo_args=(
+  test
+  --manifest-path "${ROOT}/e2e/rust/Cargo.toml"
+  --features e2e
+)
+
+test_args=()
+
+if [ -n "${E2E_TEST}" ]; then
+  cargo_args+=(--test "${E2E_TEST}")
+  test_args+=(--nocapture)
+else
+  test_args+=(--skip docker_gpu_sandbox_runs_nvidia_smi)
+fi
+
+exec "${ROOT}/e2e/with-docker-gateway.sh" cargo "${cargo_args[@]}" -- "${test_args[@]}"

--- a/mise.lock
+++ b/mise.lock
@@ -300,6 +300,7 @@ url = "https://storage.googleapis.com/skaffold/releases/v2.19.0/skaffold-linux-a
 url = "https://storage.googleapis.com/skaffold/releases/v2.19.0/skaffold-linux-amd64"
 
 [tools.skaffold."platforms.macos-arm64"]
+checksum = "blake3:0e91ba4f1d53adfdf70868424b3678de1b4e194488652ba5ed1805eb7142f929"
 url = "https://storage.googleapis.com/skaffold/releases/v2.19.0/skaffold-darwin-arm64"
 
 [tools.skaffold."platforms.macos-x64"]

--- a/tasks/test.toml
+++ b/tasks/test.toml
@@ -8,12 +8,16 @@ description = "Run all tests (Rust + Python)"
 depends = ["test:rust", "test:python"]
 
 [e2e]
-description = "Run all end-to-end tests (Rust + Python)"
-depends = ["e2e:rust", "e2e:python"]
+description = "Run all Docker-backed end-to-end tests (Rust + Python)"
+depends = ["e2e:docker"]
 
 ["e2e:gpu"]
-description = "Run GPU end-to-end tests"
-depends = ["e2e:python:gpu"]
+description = "Alias for e2e:k3s:gpu"
+run = [
+  "echo 'warning: e2e:gpu is deprecated; use e2e:k3s:gpu' >&2",
+  "mise run e2e:k3s:gpu",
+]
+hide = true
 
 ["test:rust"]
 description = "Run Rust tests"
@@ -28,20 +32,31 @@ run = "uv run pytest python/"
 hide = true
 
 ["e2e:rust"]
-description = "Run Rust CLI e2e tests against a Docker-backed gateway"
+description = "Alias for e2e:docker:rust"
 run = [
-  "cargo build -p openshell-cli --features openshell-core/dev-settings",
-  "e2e/with-docker-gateway.sh cargo test --manifest-path e2e/rust/Cargo.toml --features e2e -- --skip docker_gpu_sandbox_runs_nvidia_smi",
+  "echo 'warning: e2e:rust is deprecated; use e2e:docker:rust' >&2",
+  "mise run e2e:docker:rust",
 ]
+hide = true
 
 ["e2e:python"]
-description = "Run Python e2e tests against a Docker-backed gateway (E2E_PARALLEL=N or 'auto'; default 5)"
-depends = ["python:proto"]
-env = { UV_NO_SYNC = "1", PYTHONPATH = "python" }
-run = "e2e/with-docker-gateway.sh uv run pytest -o python_files='test_*.py' -m 'not gpu' -n ${E2E_PARALLEL:-5} e2e/python"
+description = "Alias for e2e:docker:python"
+run = [
+  "echo 'warning: e2e:python is deprecated; use e2e:docker:python' >&2",
+  "mise run e2e:docker:python",
+]
+hide = true
 
 ["e2e:python:gpu"]
-description = "Run Python GPU e2e tests"
+description = "Alias for e2e:k3s:gpu"
+run = [
+  "echo 'warning: e2e:python:gpu is deprecated; use e2e:k3s:gpu' >&2",
+  "mise run e2e:k3s:gpu",
+]
+hide = true
+
+["e2e:k3s:gpu"]
+description = "Run GPU e2e tests against an OpenShell k3s-cluster gateway"
 depends = ["python:proto", "CLUSTER_GPU=1 cluster"]
 env = { UV_NO_SYNC = "1", PYTHONPATH = "python" }
 run = "uv run pytest -o python_files='test_*.py' -m gpu -n ${E2E_PARALLEL:-1} e2e/python"
@@ -56,10 +71,25 @@ description = "Start openshell-gateway with the VM compute driver and run the cl
 run = "e2e/rust/e2e-vm.sh"
 
 ["e2e:docker"]
+description = "Run all Docker-backed end-to-end tests (Rust + Python)"
+depends = ["e2e:docker:rust", "e2e:docker:python"]
+
+["e2e:docker:rust"]
+description = "Run Rust CLI e2e tests against a Docker-backed gateway"
+run = "e2e/rust/e2e-rust.sh"
+
+["e2e:docker:python"]
+description = "Run Python e2e tests against a Docker-backed gateway (E2E_PARALLEL=N or 'auto'; default 5)"
+depends = ["python:proto"]
+env = { UV_NO_SYNC = "1", PYTHONPATH = "python" }
+run = "e2e/with-docker-gateway.sh uv run pytest -o python_files='test_*.py' -m 'not gpu' -n ${E2E_PARALLEL:-5} e2e/python"
+
+["e2e:docker:smoke"]
 description = "Run smoke e2e against a standalone gateway with the Docker compute driver"
-run = "e2e/rust/e2e-docker.sh"
+env = { OPENSHELL_E2E_RUST_TEST = "smoke" }
+run = "e2e/rust/e2e-rust.sh"
 
 ["e2e:docker:gpu"]
 description = "Run GPU e2e against a standalone gateway with the Docker compute driver"
-env = { OPENSHELL_E2E_DOCKER_GPU = "1", OPENSHELL_E2E_DOCKER_TEST = "docker_gpu" }
-run = "e2e/rust/e2e-docker.sh"
+env = { OPENSHELL_E2E_DOCKER_GPU = "1", OPENSHELL_E2E_RUST_TEST = "docker_gpu" }
+run = "e2e/rust/e2e-rust.sh"


### PR DESCRIPTION
## Summary

Reorganize the E2E mise task names so their backend intent is explicit. This is a task naming and wiring cleanup only; it does not add new test coverage.

## Related Issue

N/A

## Changes

- Route the default `e2e` task through the explicit Docker-backed suite name.
- Move Docker-backed Rust and Python task entry points under `e2e:docker:*` names.
- Rename the k3s-cluster GPU task entry point to `e2e:k3s:gpu`.
- Keep the old mise task names as hidden warning wrappers that shell out to the new task names.
- Factor the Docker-backed Rust runner into `e2e/rust/e2e-rust.sh` and keep `e2e/rust/e2e-docker.sh` as a script-level compatibility wrapper.
- Update workflow commands and TESTING.md to use the clearer task names.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] `mise run --dry-run e2e:rust ::: e2e:gpu ::: e2e:docker:rust` verified deprecated wrapper ordering

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
