### PR TITLE
ci(vm): remove remaining EKS release assumptions

### DIFF
--- a/.github/workflows/driver-vm-macos.yml
+++ b/.github/workflows/driver-vm-macos.yml
@@ -66,9 +66,62 @@ jobs:
           path: runtime-artifacts/vm-runtime-darwin-aarch64.tar.zst
           retention-days: 1
 
+  build-supervisor-arm64:
+    name: Build Supervisor Bundle (arm64)
+    runs-on: linux-arm64-cpu8
+    timeout-minutes: 30
+    container:
+      image: ghcr.io/nvidia/openshell/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OPENSHELL_IMAGE_TAG: ${{ inputs['image-tag'] }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs['checkout-ref'] }}
+          fetch-depth: 0
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Install tools
+        run: mise install --locked
+
+      - name: Cache Rust target and registry
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: driver-vm-supervisor-arm64
+          cache-directories: .cache/sccache
+          cache-targets: "true"
+
+      - name: Install zstd
+        run: apt-get update && apt-get install -y --no-install-recommends zstd && rm -rf /var/lib/apt/lists/*
+
+      - name: Build bundled supervisor
+        run: |
+          set -euo pipefail
+          tasks/scripts/vm/build-supervisor-bundle.sh --arch aarch64
+
+      - name: sccache stats
+        if: always()
+        run: mise x -- sccache --show-stats
+
+      - name: Upload supervisor bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: driver-vm-supervisor-arm64
+          path: target/vm-runtime-compressed/openshell-sandbox.zst
+          retention-days: 1
+
   build-driver-vm-macos:
     name: Build Driver VM (macOS)
-    needs: [download-kernel-runtime]
+    needs: [download-kernel-runtime, build-supervisor-arm64]
     runs-on: linux-amd64-cpu8
     timeout-minutes: 60
     container:
@@ -81,7 +134,6 @@ jobs:
         - /var/run/docker.sock:/var/run/docker.sock
     env:
       MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SCCACHE_MEMCACHED_ENDPOINT: ${{ vars.SCCACHE_MEMCACHED_ENDPOINT }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -99,6 +151,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: ./.github/actions/setup-buildx
+        with:
+          driver: local
 
       - name: Install zstd
         run: apt-get update && apt-get install -y --no-install-recommends zstd && rm -rf /var/lib/apt/lists/*
@@ -132,20 +186,17 @@ jobs:
           echo "Staged macOS compressed runtime artifacts:"
           ls -lah "$COMPRESSED_DIR"
 
-      - name: Build bundled supervisor
+      - name: Download bundled supervisor
+        uses: actions/download-artifact@v4
+        with:
+          name: driver-vm-supervisor-arm64
+          path: target/vm-runtime-compressed-macos/
+
+      - name: Verify bundled supervisor
         run: |
           set -euo pipefail
-          docker buildx build \
-            --file deploy/docker/Dockerfile.images \
-            --platform linux/arm64 \
-            --build-arg OPENSHELL_CARGO_VERSION="${{ inputs['cargo-version'] }}" \
-            --build-arg OPENSHELL_IMAGE_TAG="${{ inputs['image-tag'] }}" \
-            --target supervisor-output \
-            --output type=local,dest=supervisor-out/ \
-            .
-
-          zstd -19 -T0 -f supervisor-out/openshell-sandbox \
-            -o "${PWD}/target/vm-runtime-compressed-macos/openshell-sandbox.zst"
+          test -f target/vm-runtime-compressed-macos/openshell-sandbox.zst
+          ls -lh target/vm-runtime-compressed-macos/openshell-sandbox.zst
 
       - name: Verify embedded driver inputs
         run: |

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -75,9 +75,9 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: build-amd64
+            runner: linux-amd64-cpu8
           - arch: arm64
-            runner: build-arm64
+            runner: linux-arm64-cpu8
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 10
     container:

--- a/.github/workflows/rpm-package.yml
+++ b/.github/workflows/rpm-package.yml
@@ -24,9 +24,9 @@ jobs:
       matrix:
         include:
           - arch: x86_64
-            runner: build-amd64
+            runner: linux-amd64-cpu8
           - arch: aarch64
-            runner: build-arm64
+            runner: linux-arm64-cpu8
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     container:


### PR DESCRIPTION
## Summary

Follow up #1186 by removing remaining EKS-specific assumptions from VM/release-adjacent workflows.

## Related Issue

Related to OS-49 (Linear). Follows #1186.

## Changes

- Move release-canary install-dev and RPM packaging jobs from old `build-amd64`/`build-arm64` labels to shared CPU runner labels.
- Build the macOS driver VM supervisor bundle in a separate arm64 job on shared runners and download it in the macOS packaging job.
- Use local Buildx for the macOS driver VM image build and remove the unused VM SCCACHE memcached environment path.

## Testing

- [x] Workflow YAML parses for changed workflow files
- [x] `git diff --check origin/main...HEAD`
- [x] Targeted grep verified old labels/remote BuildKit/sccache/supervisor-output paths are absent from changed workflows
- [ ] `mise run pre-commit` passes

`mise run pre-commit` was run on this branch and failed on pre-existing/unrelated local issues: markdownlint scans untracked `.codex-learning/*.md`, and Rust unit test `ssh::tests::launch_editor_returns_friendly_error_when_binary_missing` still fails. Rust check, clippy, fmt, Python checks/tests, Helm lint, license check, and Mermaid lint completed before the aggregate failure.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable: workflow-only follow-up to #1186)