### PR TITLE
ci(helm): add OCI chart release workflow

### DIFF
--- a/.github/actions/release-helm-oci/action.yml
+++ b/.github/actions/release-helm-oci/action.yml
@@ -23,8 +23,10 @@ inputs:
   pin-sha:
     description: >
       Full commit SHA. When set on dev releases, a second chart is also pushed
-      as 0.0.0-dev.<short-sha> with appVersion set to this SHA, enabling exact
-      version pinning alongside the floating 0.0.0-dev tag.
+      as 0.0.0-dev.<sha> with appVersion set to the same SHA, enabling exact
+      version pinning alongside the floating 0.0.0-dev tag. Both chart version
+      and appVersion use the full SHA so the chart tag matches the image tag
+      pushed by docker-build.yml.
     required: false
     default: ""
 
@@ -92,10 +94,9 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        SHORT_SHA="${PIN_SHA:0:7}"
         SHA_CHART_DIR="${RUNNER_TEMP}/chart-build-sha"
         cp -a "${CHART_DIR}/." "${SHA_CHART_DIR}"
-        sed -i "s/^version:.*/version: 0.0.0-dev.${SHORT_SHA}/" "${SHA_CHART_DIR}/Chart.yaml"
+        sed -i "s/^version:.*/version: 0.0.0-dev.${PIN_SHA}/" "${SHA_CHART_DIR}/Chart.yaml"
         sed -i "s/^appVersion:.*/appVersion: \"${PIN_SHA}\"/" "${SHA_CHART_DIR}/Chart.yaml"
         helm package "${SHA_CHART_DIR}" --destination /tmp/sha-pin
         helm push /tmp/sha-pin/helm-chart-*.tgz oci://ghcr.io/nvidia/openshell

--- a/.github/actions/release-helm-oci/action.yml
+++ b/.github/actions/release-helm-oci/action.yml
@@ -4,7 +4,7 @@
 name: Release Helm OCI
 description: >
   Patch chart version/appVersion, refuse duplicate OCI versions on public
-  releases, package the chart, push to GHCR OCI, and tag as latest (public only).
+  releases, package the chart, and push to GHCR OCI.
 
 inputs:
   chart-version:
@@ -18,7 +18,7 @@ inputs:
       (e.g. 0.6.0 for tag releases, dev for dev).
     required: true
   release-kind:
-    description: "dev or public — controls duplicate guard and latest tagging."
+    description: "dev or public — controls the duplicate-version guard."
     required: true
   pin-sha:
     description: >
@@ -83,21 +83,6 @@ runs:
       run: |
         set -euo pipefail
         helm push /tmp/helm-chart-*.tgz oci://ghcr.io/nvidia/openshell
-
-    - name: Install oras
-      if: inputs.release-kind == 'public'
-      uses: oras-project/setup-oras@v1
-
-    - name: Tag chart as latest
-      if: inputs.release-kind == 'public'
-      env:
-        CHART_VERSION: ${{ steps.prep.outputs.chart_version }}
-      shell: bash
-      run: |
-        set -euo pipefail
-        oras copy \
-          ghcr.io/nvidia/openshell/helm-chart:"${CHART_VERSION}" \
-          ghcr.io/nvidia/openshell/helm-chart:latest
 
     - name: Push SHA-pinned chart
       if: inputs.pin-sha != ''

--- a/.github/actions/release-helm-oci/action.yml
+++ b/.github/actions/release-helm-oci/action.yml
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release Helm OCI
+description: >
+  Patch chart version/appVersion, refuse duplicate OCI versions on public
+  releases, package the chart, push to GHCR OCI, and tag as latest (public only).
+
+inputs:
+  chart-version:
+    description: >
+      Chart.yaml version and OCI tag — SemVer without leading v
+      (e.g. 0.6.0 for tag releases, 0.0.0-dev for dev).
+    required: true
+  app-version:
+    description: >
+      Chart.yaml appVersion and default image tag
+      (e.g. 0.6.0 for tag releases, dev for dev).
+    required: true
+  release-kind:
+    description: "dev or public — controls duplicate guard and latest tagging."
+    required: true
+  pin-sha:
+    description: >
+      Full commit SHA. When set on dev releases, a second chart is also pushed
+      as 0.0.0-dev.<short-sha> with appVersion set to this SHA, enabling exact
+      version pinning alongside the floating 0.0.0-dev tag.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Install Helm
+      uses: azure/setup-helm@v4
+
+    - name: Stage chart and patch version
+      id: prep
+      env:
+        CHART_VERSION: ${{ inputs.chart-version }}
+        APP_VERSION: ${{ inputs.app-version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        CHART_DIR="${RUNNER_TEMP}/chart-build"
+        cp -a deploy/helm/openshell/. "${CHART_DIR}"
+        sed -i "s/^version:.*/version: ${CHART_VERSION}/" "${CHART_DIR}/Chart.yaml"
+        sed -i "s/^appVersion:.*/appVersion: \"${APP_VERSION}\"/" "${CHART_DIR}/Chart.yaml"
+        echo "chart_dir=${CHART_DIR}" >> "$GITHUB_OUTPUT"
+        echo "chart_version=${CHART_VERSION}" >> "$GITHUB_OUTPUT"
+
+    - name: Refuse duplicate chart version
+      if: inputs.release-kind == 'public'
+      env:
+        CHART_VERSION: ${{ steps.prep.outputs.chart_version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        OCI_CHART="oci://ghcr.io/nvidia/openshell/helm-chart"
+        if helm show chart "${OCI_CHART}" --version "${CHART_VERSION}" >/dev/null 2>&1; then
+          echo "::error::Chart ${CHART_VERSION} is already published. Use a new tag or delete the existing package first."
+          exit 1
+        fi
+
+    - name: Package Helm chart
+      env:
+        CHART_DIR: ${{ steps.prep.outputs.chart_dir }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        helm package "${CHART_DIR}" --destination /tmp
+        ls /tmp/helm-chart-*.tgz
+
+    - name: Push Helm chart to GHCR OCI
+      shell: bash
+      run: |
+        set -euo pipefail
+        helm push /tmp/helm-chart-*.tgz oci://ghcr.io/nvidia/openshell
+
+    - name: Install oras
+      if: inputs.release-kind == 'public'
+      uses: oras-project/setup-oras@v1
+
+    - name: Tag chart as latest
+      if: inputs.release-kind == 'public'
+      env:
+        CHART_VERSION: ${{ steps.prep.outputs.chart_version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        oras copy \
+          ghcr.io/nvidia/openshell/helm-chart:"${CHART_VERSION}" \
+          ghcr.io/nvidia/openshell/helm-chart:latest
+
+    - name: Push SHA-pinned chart
+      if: inputs.pin-sha != ''
+      env:
+        PIN_SHA: ${{ inputs.pin-sha }}
+        CHART_DIR: ${{ steps.prep.outputs.chart_dir }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        SHORT_SHA="${PIN_SHA:0:7}"
+        SHA_CHART_DIR="${RUNNER_TEMP}/chart-build-sha"
+        cp -a "${CHART_DIR}/." "${SHA_CHART_DIR}"
+        sed -i "s/^version:.*/version: 0.0.0-dev.${SHORT_SHA}/" "${SHA_CHART_DIR}/Chart.yaml"
+        sed -i "s/^appVersion:.*/appVersion: \"${PIN_SHA}\"/" "${SHA_CHART_DIR}/Chart.yaml"
+        helm package "${SHA_CHART_DIR}" --destination /tmp/sha-pin
+        helm push /tmp/sha-pin/helm-chart-*.tgz oci://ghcr.io/nvidia/openshell

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -823,6 +823,23 @@ jobs:
             release/openshell-gateway-checksums-sha256.txt
             release/openshell-sandbox-checksums-sha256.txt
 
+  release-helm:
+    name: Release Helm Chart (OCI, dev)
+    needs: [tag-ghcr-dev]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/release-helm-oci
+        with:
+          chart-version: 0.0.0-dev
+          app-version: dev
+          release-kind: dev
+          pin-sha: ${{ github.sha }}
+
   trigger-wheel-publish:
     name: Trigger Wheel Publish
     needs: [compute-versions, release-dev]

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -815,6 +815,24 @@ jobs:
         working-directory: ./fern
         run: fern generate --docs
 
+  release-helm:
+    name: Release Helm Chart (OCI)
+    needs: [compute-versions, tag-ghcr-release]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: ./.github/actions/release-helm-oci
+        with:
+          chart-version: ${{ needs.compute-versions.outputs.semver }}
+          app-version: ${{ needs.compute-versions.outputs.semver }}
+          release-kind: public
+
   trigger-wheel-publish:
     name: Trigger Wheel Publish
     needs: [compute-versions, release]

--- a/README.md
+++ b/README.md
@@ -42,17 +42,10 @@ Both methods install the latest stable release by default. To install a specific
 Deploy the OpenShell gateway into a Kubernetes cluster from the OCI chart published to GHCR:
 
 ```bash
-# Tagged release — pin to a specific version
-helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart --version <version>
-
-# Floating dev tag — tracks the latest commit on main
-helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart --version 0.0.0-dev
-
-# Pinned dev — exact commit on main (full SHA)
-helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart --version 0.0.0-dev.<commit-sha>
+helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart
 ```
 
-See [`deploy/helm/openshell/values.yaml`](deploy/helm/openshell/values.yaml) for configurable values.
+See [`deploy/helm/openshell/README.md`](deploy/helm/openshell/README.md) for available versions, dev tag conventions, and configuration.
 
 ### Create a sandbox
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ uv tool install -U openshell
 
 Both methods install the latest stable release by default. To install a specific version, set `OPENSHELL_VERSION` (binary) or pin the version with `uv tool install openshell==<version>`. A [`dev` release](https://github.com/NVIDIA/OpenShell/releases/tag/dev) is also available that tracks the latest commit on `main`.
 
+**Helm chart:**
+
+> **Experimental** — the Kubernetes deployment path is under active development. Expect rough edges and breaking changes.
+
+Deploy the OpenShell gateway into a Kubernetes cluster from the OCI chart published to GHCR:
+
+```bash
+# Tagged release — pin to a specific version
+helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart --version <version>
+
+# Floating dev tag — tracks the latest commit on main
+helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart --version 0.0.0-dev
+
+# Pinned dev — exact commit on main (full SHA)
+helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart --version 0.0.0-dev.<commit-sha>
+```
+
+See [`deploy/helm/openshell/values.yaml`](deploy/helm/openshell/values.yaml) for configurable values.
+
 ### Create a sandbox
 
 ```bash

--- a/deploy/helm/openshell/Chart.yaml
+++ b/deploy/helm/openshell/Chart.yaml
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v2
-name: openshell
+# Chart name determines the OCI image name: ghcr.io/nvidia/openshell/helm-chart:<version>
+name: helm-chart
 description: runtime environment for autonomous agents
 type: application
-# Updated to the release version by CI. The appVersion doubles as the default
-# image tag (image.tag defaults to appVersion when empty), so a released chart
-# automatically pulls the matching gateway and supervisor images.
+# version and appVersion are patched to the release semver by CI before helm package.
+# appVersion doubles as the default image tag (image.tag defaults to appVersion when
+# empty), so a released chart automatically pulls the matching gateway and supervisor images.
 version: 0.0.0
 appVersion: "0.0.0"

--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -1,0 +1,29 @@
+# OpenShell Helm Chart
+
+> **Experimental** — the Kubernetes deployment path is under active development. Expect rough edges and breaking changes.
+
+This chart deploys the OpenShell gateway into a Kubernetes cluster. It is published as an OCI artifact to GHCR at `oci://ghcr.io/nvidia/openshell/helm-chart`.
+
+## Install
+
+```bash
+helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart --version <version>
+```
+
+## Available versions
+
+| Tag | Source | Notes |
+| --- | --- | --- |
+| `<semver>` (e.g. `0.6.0`) | Tagged GitHub release | Tracks the matching gateway and supervisor image versions. Recommended for production. |
+| `0.0.0-dev` | Latest commit on `main` | Floating tag, overwritten on every push. `appVersion` is `dev`, so images resolve to the `:dev` tag. |
+| `0.0.0-dev.<commit-sha>` | A specific commit on `main` | Per-commit pin. Chart version and `appVersion` both use the full 40-character commit SHA, which matches the image tag pushed by CI. |
+
+The `dev` tags are intended for testing changes ahead of a release. Production deployments should pin to a tagged release.
+
+## Configuration
+
+See [`values.yaml`](values.yaml) for configurable values. Selected overlays:
+
+- [`values-gateway.yaml`](values-gateway.yaml) — gateway-only configuration
+- [`values-cert-manager.yaml`](values-cert-manager.yaml) — cert-manager integration
+- [`values-keycloak.yaml`](values-keycloak.yaml) — Keycloak OIDC integration


### PR DESCRIPTION
## Summary
Publishes the OpenShell Helm chart to `ghcr.io/nvidia/openshell/helm-chart` as an OCI artifact on every release. Tagged releases push the versioned chart; main pushes overwrite a floating `:0.0.0-dev` tag and also publish a per-commit `:0.0.0-dev.<short-sha>` for exact pinning.

## Related Issue
N/A

## Changes
- Add `.github/actions/release-helm-oci` composite action: stages the chart, patches `version`/`appVersion`, refuses duplicate public versions, packages, and pushes to GHCR via `helm push`. Dev releases optionally push a SHA-pinned variant.
- Wire a `release-helm` job into `release-tag.yml` (public, depends on `compute-versions` + `tag-ghcr-release`) and `release-dev.yml` (dev, depends on `tag-ghcr-dev`, passes `pin-sha: ${{ github.sha }}`).
- Rename `Chart.yaml` `name` from `openshell` to `helm-chart` so the OCI artifact path matches `ghcr.io/nvidia/openshell/helm-chart`.

## Testing
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated — N/A (CI workflow only)
- [ ] E2E tests added/updated (if applicable) — N/A; will validate end-to-end on the next dev release run

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — N/A