### PR TITLE
fix(ci): allowlist dependabot for DCO

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -38,7 +38,7 @@ jobs:
           path-to-signatures: "dco-signatures.json"
           path-to-document: "https://github.com/NVIDIA/OpenShell/blob/main/DCO"
           branch: "signatures"
-          allowlist: dependabot
+          allowlist: "dependabot[bot]"
           create-file-commit-message: "chore: create file to store dco signatures"
           signed-commit-message: "chore: $contributorName has signed the dco in #$pullRequestNo"
           custom-notsigned-prcomment: >-

--- a/CI.md
+++ b/CI.md
@@ -21,7 +21,7 @@ Both are required to merge once the corresponding `E2E Gate` checks are marked r
 
 copy-pr-bot decides whether to mirror a PR automatically based on whether the author is trusted. For org members and collaborators, "trusted" means **all commits in the PR are cryptographically signed**. Unsigned commits, even from an org member, force the bot to wait for a maintainer's `/ok to test <SHA>`.
 
-DCO sign-off (`-s` / `Signed-off-by`) is a separate requirement and does not count as commit signing.
+DCO sign-off (`-s` / `Signed-off-by`) is a separate requirement and does not count as commit signing. Dependabot-authored dependency update PRs are allowlisted in DCO Assistant because the bot cannot sign commits.
 
 ### One-time setup with an SSH key
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,7 +271,7 @@ chore(deps): bump tokio to 1.40
 
 ### DCO
 
-All contributions must include a `Signed-off-by` line in each commit message. This certifies you have the right to submit the work under the project license. See the [Developer Certificate of Origin](https://developercertificate.org/).
+All human contributions must include a `Signed-off-by` line in each commit message. This certifies you have the right to submit the work under the project license. See the [Developer Certificate of Origin](https://developercertificate.org/). Dependabot-authored dependency update PRs are allowlisted because the bot cannot sign commits.
 
 ```bash
 git commit -s -m "feat(sandbox): add new capability"


### PR DESCRIPTION
## Summary

Allow Dependabot-authored dependency update PRs to pass DCO Assistant by matching the actual bot commit author, `dependabot[bot]`.

## Related Issue

Relates to #1197

## Changes

- Update DCO Assistant allowlist from `dependabot` to `dependabot[bot]`
- Document the Dependabot DCO exception in CI and contributor docs

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)
