### PR TITLE
fix(kube): add RBAC rule for sandbox finalizer updates

### DIFF
--- a/deploy/kube/manifests/agent-sandbox.yaml
+++ b/deploy/kube/manifests/agent-sandbox.yaml
@@ -4111,4 +4111,10 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - agents.x-k8s.io
+  resources:
+  - sandboxes/finalizers
+  verbs:
+  - update
 ---


### PR DESCRIPTION
## Summary

Adds a missing RBAC rule granting `update` on `sandboxes/finalizers` in the `agents.x-k8s.io` API group to the agent sandbox ClusterRole.

Without this change, I get the following in the `agent-sandbox-controller` log
```
2026-05-06T16:27:29Z    ERROR   Reconciler error        {"controller": "sandbox", "controllerGroup": "agents.x-k8s.io", "controllerKind": "Sandbox", "Sandbox": {"name":"civil-dolphin","namespace":"openshell"}, "namespace": "openshell", "name": "civil-dolphin", "reconcileID": "e6224e13-b5fc-4223-b6e9-c39cd512f4b9", "error": "persistentvolumeclaims \"workspace-civil-dolphin\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>\npods \"civil-dolphin\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>\nservices \"civil-dolphin\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}
```

## Changes

- Added `update` verb for `sandboxes/finalizers` resource in the `agents.x-k8s.io` API group to the ClusterRole in `deploy/kube/manifests/agent-sandbox.yaml`

## Testing

- [x] `mise run pre-commit` passes

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)