### PR TITLE
docs: fix tutorials card link on index page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -99,7 +99,7 @@ Install the CLI and create your first sandbox in two commands.
 <Badge intent="tip" minimal outlined>Tutorial</Badge>
 </Card>
 
-<Card title="Tutorials" href="/tutorials">
+<Card title="Tutorials" href="/get-started/tutorials">
 
 Hands-on walkthroughs from first sandbox to custom policies.
 


### PR DESCRIPTION
The Tutorials card on the home page was pointing to /tutorials instead of /get-started/tutorials. This was missed in #1137 which fixed the same link in other files.

Related Issue: Followup to #1137.

Changes: Fixed the href in docs/index.mdx line 102.

Testiny: Verify the Tutorials card on the home page navigates to the correct URL.

Checklist: Follows docs style guide. No broken links introduced.