### PR TITLE
docs: fix OpenCode capitalization in provider types table

### DIFF
--- a/docs/sandboxes/manage-providers.mdx
+++ b/docs/sandboxes/manage-providers.mdx
@@ -181,7 +181,7 @@ The following provider types are supported.
 | `gitlab` | `GITLAB_TOKEN`, `GLAB_TOKEN`, `CI_JOB_TOKEN` | GitLab API, `glab` CLI |
 | `nvidia` | `NVIDIA_API_KEY` | NVIDIA API Catalog |
 | `openai` | `OPENAI_API_KEY` | Any OpenAI-compatible endpoint. Set `--config OPENAI_BASE_URL` to point to the provider. Refer to [Configure](/inference/configure). |
-| `opencode` | `OPENCODE_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY` | opencode tool |
+| `opencode` | `OPENCODE_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY` | OpenCode |
 
 <Tip>
 Use the `generic` type for any service not listed above. You define the


### PR DESCRIPTION
The Typical Use column in the Supported Provider Types table had opencode in lowercase. Every other place in the docs uses OpenCode as the brand name.

Related Issue: No issue. Small consistency fix spotted while reviewing the docs.

Changes: Fixed the capitalization in docs/sandboxes/manage-providers.mdx line 184.

Testing: Verify the provider types table shows OpenCode with correct capitalization.

Checklist: Follows docs style guide. No broken links introduced.