### PR TITLE
fix(scripts): eliminate xargs subshell dependency in docker-cleanup.sh

### DIFF
--- a/scripts/docker-cleanup.sh
+++ b/scripts/docker-cleanup.sh
@@ -177,7 +177,12 @@ info "Removing stale tagged images..."
 
 # Collect image IDs that are directly used by running containers so we never
 # touch them regardless of tag matching.
-running_image_ids=$(ce ps -q 2>/dev/null | xargs -r ce inspect --format '{{.Image}}' 2>/dev/null | sort -u)
+container_ids=($(ce ps -q 2>/dev/null))
+if [[ ${#container_ids[@]} -gt 0 ]]; then
+  running_image_ids=$(ce inspect --format '{{.Image}}' "${container_ids[@]}" 2>/dev/null | sort -u)
+else
+  running_image_ids=""
+fi
 
 stale_images=()
 while IFS=$'\t' read -r repo tag id; do
@@ -215,9 +220,13 @@ echo
 info "Removing unused volumes..."
 
 # Identify volumes in use by running containers
-in_use_volumes=$(ce ps -q 2>/dev/null \
-  | xargs -r ce inspect --format '{{range .Mounts}}{{.Name}} {{end}}' 2>/dev/null \
-  | tr ' ' '\n' | sort -u | grep -v '^$' || true)
+container_ids=($(ce ps -q 2>/dev/null))
+if [[ ${#container_ids[@]} -gt 0 ]]; then
+  in_use_volumes=$(ce inspect --format '{{range .Mounts}}{{.Name}} {{end}}' "${container_ids[@]}" 2>/dev/null \
+    | tr ' ' '\n' | sort -u | grep -v '^$' || true)
+else
+  in_use_volumes=""
+fi
 
 unused_volumes=()
 while read -r vol; do


### PR DESCRIPTION
## Summary
Replace xargs usage with native docker/podman multi-argument inspect calls. The previous implementation failed because xargs spawns subshells that don't inherit the ce() function from container-engine.sh.

Instead of piping container IDs through xargs, collect them into an array and pass them directly to `ce inspect`, which accepts multiple IDs. This eliminates the subshell issue entirely and simplifies the code.

Fixes the docker:cleanup mise task that was failing with:
  xargs: ce: No such file or directory

## Related Issue

## Changes

## Testing
<!-- What testing was done? -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
