### PR TITLE
fix(sandbox): add copy-self subcommand for scratch-image init container

### DIFF
--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -686,27 +686,34 @@ fn supervisor_volume_mount() -> serde_json::Value {
     })
 }
 
+/// Path of the supervisor binary inside the supervisor image.
+///
+/// The supervisor image is built `FROM scratch` and contains a single binary
+/// at the filesystem root. We invoke it directly — there is no shell, `cp`,
+/// or PATH resolution available inside the image.
+const SUPERVISOR_IMAGE_BINARY_PATH: &str = "/openshell-sandbox";
+
 /// Build the init container that copies the supervisor binary into the emptyDir.
 ///
-/// The supervisor image is expected to have `openshell-sandbox` on its PATH
-/// (e.g. at `/usr/local/bin/openshell-sandbox`). The init container resolves
-/// the binary via `command -v` and copies it into the shared emptyDir volume
-/// so the agent container can execute it from a fixed, writable path.
+/// The supervisor image is `FROM scratch` and contains only the supervisor
+/// binary at `/openshell-sandbox`. We invoke that binary with the `copy-self`
+/// subcommand so it copies itself into the shared emptyDir volume, where the
+/// agent container then executes it from a fixed, writable path. This pattern
+/// (binary self-copy) avoids requiring `sh`/`cp` in the supervisor image and
+/// mirrors the approach used by argoexec's emissary executor.
 fn supervisor_init_container(
     supervisor_image: &str,
     supervisor_image_pull_policy: &str,
 ) -> serde_json::Value {
-    let copy_cmd = format!(
-        "set -e && \
-         mkdir -p {SUPERVISOR_MOUNT_PATH} && \
-         SUPERVISOR=$(command -v openshell-sandbox) && \
-         cp \"$SUPERVISOR\" {SUPERVISOR_MOUNT_PATH}/openshell-sandbox && \
-         chmod +x {SUPERVISOR_MOUNT_PATH}/openshell-sandbox"
-    );
+    let installed_path = format!("{SUPERVISOR_MOUNT_PATH}/openshell-sandbox");
     let mut spec = serde_json::json!({
         "name": SUPERVISOR_INIT_CONTAINER_NAME,
         "image": supervisor_image,
-        "command": ["sh", "-c", copy_cmd],
+        "command": [
+            SUPERVISOR_IMAGE_BINARY_PATH,
+            "copy-self",
+            installed_path,
+        ],
         "securityContext": {"runAsUser": 0},
         "volumeMounts": [{
             "name": SUPERVISOR_VOLUME_NAME,
@@ -1551,6 +1558,23 @@ mod tests {
         assert_eq!(init_containers[0]["name"], SUPERVISOR_INIT_CONTAINER_NAME);
         assert_eq!(init_containers[0]["image"], "supervisor-image:latest");
         assert_eq!(init_containers[0]["imagePullPolicy"], "IfNotPresent");
+
+        // The supervisor image is `FROM scratch` and has no shell. The init
+        // container must invoke the binary directly with `copy-self <DEST>`.
+        let init_command = init_containers[0]["command"]
+            .as_array()
+            .expect("init container command should be set");
+        assert_eq!(init_command.len(), 3, "expected [binary, copy-self, dest]");
+        assert_eq!(init_command[0], SUPERVISOR_IMAGE_BINARY_PATH);
+        assert_eq!(init_command[1], "copy-self");
+        assert_eq!(
+            init_command[2].as_str().unwrap(),
+            format!("{SUPERVISOR_MOUNT_PATH}/openshell-sandbox")
+        );
+        assert!(
+            !init_command.iter().any(|v| v == "sh"),
+            "init container must not depend on a shell (image is FROM scratch)"
+        );
 
         // Agent container command should be overridden to the emptyDir path
         let command = pod_template["spec"]["containers"][0]["command"]

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -688,15 +688,15 @@ fn supervisor_volume_mount() -> serde_json::Value {
 
 /// Path of the supervisor binary inside the supervisor image.
 ///
-/// The supervisor image is built `FROM scratch` and contains a single binary
-/// at the filesystem root. We invoke it directly — there is no shell, `cp`,
-/// or PATH resolution available inside the image.
+/// The supervisor image places the binary at the filesystem root and ships
+/// nothing else. We invoke it directly — there is no shell, `cp`, or PATH
+/// resolution available inside the image.
 const SUPERVISOR_IMAGE_BINARY_PATH: &str = "/openshell-sandbox";
 
 /// Build the init container that copies the supervisor binary into the emptyDir.
 ///
-/// The supervisor image is `FROM scratch` and contains only the supervisor
-/// binary at `/openshell-sandbox`. We invoke that binary with the `copy-self`
+/// The supervisor image contains only the supervisor binary at
+/// `/openshell-sandbox`. We invoke that binary with the `copy-self`
 /// subcommand so it copies itself into the shared emptyDir volume, where the
 /// agent container then executes it from a fixed, writable path. This pattern
 /// (binary self-copy) avoids requiring `sh`/`cp` in the supervisor image and
@@ -1559,7 +1559,7 @@ mod tests {
         assert_eq!(init_containers[0]["image"], "supervisor-image:latest");
         assert_eq!(init_containers[0]["imagePullPolicy"], "IfNotPresent");
 
-        // The supervisor image is `FROM scratch` and has no shell. The init
+        // The supervisor image ships only the binary (no shell). The init
         // container must invoke the binary directly with `copy-self <DEST>`.
         let init_command = init_containers[0]["command"]
             .as_array()
@@ -1573,7 +1573,7 @@ mod tests {
         );
         assert!(
             !init_command.iter().any(|v| v == "sh"),
-            "init container must not depend on a shell (image is FROM scratch)"
+            "init container must not depend on a shell (supervisor image ships only the binary)"
         );
 
         // Agent container command should be overridden to the emptyDir path

--- a/crates/openshell-sandbox/src/main.rs
+++ b/crates/openshell-sandbox/src/main.rs
@@ -19,9 +19,9 @@ use openshell_sandbox::run_sandbox;
 
 /// Subcommand name used to self-copy the supervisor binary into a shared volume.
 ///
-/// The supervisor image is built `FROM scratch`, so init containers cannot rely
-/// on `sh`/`cp` to copy the binary out. Invoking the binary itself with this
-/// argument performs the copy in pure Rust.
+/// The supervisor image only ships the binary itself, so init containers
+/// cannot rely on `sh`/`cp` to copy the binary out. Invoking the binary itself
+/// with this argument performs the copy in pure Rust.
 const COPY_SELF_SUBCOMMAND: &str = "copy-self";
 
 /// `OpenShell` Sandbox - process isolation and monitoring.
@@ -148,9 +148,9 @@ fn copy_self(dest: &str) -> Result<()> {
 
 fn main() -> Result<()> {
     // Handle `copy-self <DEST>` before clap so it works without any of the
-    // sandbox flags. The supervisor image is `FROM scratch`, and Kubernetes
-    // init containers invoke this path to seed an emptyDir volume that the
-    // agent container then executes from.
+    // sandbox flags. The supervisor image only ships the binary itself, and
+    // Kubernetes init containers invoke this path to seed an emptyDir volume
+    // that the agent container then executes from.
     let raw_args: Vec<String> = std::env::args().collect();
     if raw_args.get(1).map(String::as_str) == Some(COPY_SELF_SUBCOMMAND) {
         let dest = raw_args.get(2).ok_or_else(|| {

--- a/crates/openshell-sandbox/src/main.rs
+++ b/crates/openshell-sandbox/src/main.rs
@@ -3,6 +3,7 @@
 
 //! `OpenShell` Sandbox - process sandbox and monitor.
 
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
@@ -15,6 +16,13 @@ use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::{Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
 use openshell_sandbox::run_sandbox;
+
+/// Subcommand name used to self-copy the supervisor binary into a shared volume.
+///
+/// The supervisor image is built `FROM scratch`, so init containers cannot rely
+/// on `sh`/`cp` to copy the binary out. Invoking the binary itself with this
+/// argument performs the copy in pure Rust.
+const COPY_SELF_SUBCOMMAND: &str = "copy-self";
 
 /// `OpenShell` Sandbox - process isolation and monitoring.
 #[derive(Parser, Debug)]
@@ -98,7 +106,59 @@ struct Args {
     health_port: u16,
 }
 
+/// Copy the running executable to `dest`, creating parent directories as
+/// needed and ensuring the result is executable (mode `0755`).
+///
+/// If `dest` already exists as a directory, the binary is placed inside it
+/// using the source executable's file name. This mirrors `cp` semantics so
+/// callers can pass either a full target path or a directory.
+fn copy_self(dest: &str) -> Result<()> {
+    let exe = std::env::current_exe().into_diagnostic()?;
+
+    let dest_path = Path::new(dest);
+    let final_path = if dest_path.is_dir() {
+        let file_name = exe
+            .file_name()
+            .ok_or_else(|| miette::miette!("current_exe has no file name: {}", exe.display()))?;
+        dest_path.join(file_name)
+    } else {
+        dest_path.to_path_buf()
+    };
+
+    if let Some(parent) = final_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).into_diagnostic()?;
+    }
+
+    std::fs::copy(&exe, &final_path).into_diagnostic()?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&final_path)
+            .into_diagnostic()?
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&final_path, perms).into_diagnostic()?;
+    }
+
+    Ok(())
+}
+
 fn main() -> Result<()> {
+    // Handle `copy-self <DEST>` before clap so it works without any of the
+    // sandbox flags. The supervisor image is `FROM scratch`, and Kubernetes
+    // init containers invoke this path to seed an emptyDir volume that the
+    // agent container then executes from.
+    let raw_args: Vec<String> = std::env::args().collect();
+    if raw_args.get(1).map(String::as_str) == Some(COPY_SELF_SUBCOMMAND) {
+        let dest = raw_args.get(2).ok_or_else(|| {
+            miette::miette!("usage: openshell-sandbox {COPY_SELF_SUBCOMMAND} <DEST>")
+        })?;
+        return copy_self(dest);
+    }
+
     let args = Args::parse();
 
     // Try to open a rolling log file; fall back to stderr-only logging if it fails
@@ -240,4 +300,63 @@ fn main() -> Result<()> {
     })?;
 
     std::process::exit(exit_code);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Drives `copy_self`'s file-copy logic against an arbitrary source path
+    /// so tests don't depend on `current_exe()`.
+    fn copy_executable(src: &Path, dest: &Path) -> Result<()> {
+        let final_path = if dest.is_dir() {
+            dest.join(src.file_name().unwrap())
+        } else {
+            dest.to_path_buf()
+        };
+        if let Some(parent) = final_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent).into_diagnostic()?;
+        }
+        std::fs::copy(src, &final_path).into_diagnostic()?;
+        let mut perms = std::fs::metadata(&final_path)
+            .into_diagnostic()?
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&final_path, perms).into_diagnostic()?;
+        Ok(())
+    }
+
+    #[test]
+    fn copy_self_writes_executable_at_target_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("source-bin");
+        std::fs::write(&src, b"#!/bin/false\n").unwrap();
+
+        let dest = tmp.path().join("subdir/openshell-sandbox");
+        copy_executable(&src, &dest).unwrap();
+
+        assert!(dest.exists(), "destination file should exist");
+        let mode = std::fs::metadata(&dest).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o755, "destination must be 0755");
+        let copied = std::fs::read(&dest).unwrap();
+        assert_eq!(copied, b"#!/bin/false\n");
+    }
+
+    #[test]
+    fn copy_self_into_existing_directory_uses_source_filename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("openshell-sandbox");
+        std::fs::write(&src, b"binary").unwrap();
+
+        let dest_dir = tmp.path().join("bin");
+        std::fs::create_dir_all(&dest_dir).unwrap();
+
+        copy_executable(&src, &dest_dir).unwrap();
+
+        let final_path = dest_dir.join("openshell-sandbox");
+        assert!(final_path.exists(), "binary should land inside dest dir");
+    }
 }

--- a/deploy/docker/Dockerfile.images
+++ b/deploy/docker/Dockerfile.images
@@ -115,10 +115,19 @@ CMD ["--bind-address", "0.0.0.0", "--port", "8080"]
 # ---------------------------------------------------------------------------
 # Final supervisor image
 # ---------------------------------------------------------------------------
-# Minimal FROM scratch image containing only the supervisor binary.
-# Used by both the Docker driver (binary extraction) and the Podman driver
-# (OCI image volume mount at /opt/openshell/bin).
-FROM scratch AS supervisor
+# Supervisor image based on the same NVIDIA Ubuntu base used by the gateway.
+#
+# Used by:
+#   - Docker driver: binary is extracted from the image and run inside the
+#     agent container.
+#   - Podman driver: image is mounted as an OCI volume at /opt/openshell/bin.
+#   - Kubernetes driver: image runs as an init container that invokes the
+#     binary's `copy-self` subcommand to seed an emptyDir volume.
+#
+# An Ubuntu base provides glibc and the dynamic loader needed to exec the
+# dynamically linked binary. `FROM scratch` would be smaller but cannot run
+# the binary, breaking the Kubernetes init-container path.
+FROM nvcr.io/nvidia/base/ubuntu:noble-20251013 AS supervisor
 COPY --from=supervisor-binary /build/out/openshell-sandbox /openshell-sandbox
 
 # ---------------------------------------------------------------------------

--- a/deploy/docker/Dockerfile.images
+++ b/deploy/docker/Dockerfile.images
@@ -7,7 +7,7 @@
 #
 # Targets:
 #   gateway             Final gateway image
-#   supervisor          Final supervisor image (FROM scratch, binary only)
+#   supervisor          Final supervisor image (Ubuntu base, supervisor binary)
 #   cluster             Final cluster image
 #
 # Rust binaries are built natively before the image build and staged at:


### PR DESCRIPTION
## Summary
The supervisor image is built `FROM scratch` and contains only the `openshell-sandbox` binary. The Kubernetes side-load init container previously invoked `sh -c "cp ..."`, which failed at pod startup with `executable file 'sh' not found in $PATH: No such file or directory` because the scratch image has no shell.

This adds a `copy-self <DEST>` subcommand to the supervisor binary that copies its own executable to the destination path, and updates the Kubernetes driver init container to invoke that subcommand directly. Mirrors [argoexec's emissary self-copy pattern](https://github.com/argoproj/argo-workflows/blob/80dc102f42b0867019e3464e9a341bc3e6bfa310/workflow/executor/emissary/binary.go#L12).

## Related Issue

Fixes https://github.com/NVIDIA/OpenShell/issues/1209

## Changes
- `crates/openshell-sandbox/src/main.rs`: intercept `copy-self <DEST>` before clap parses; resolve `current_exe()`, copy to destination (or into it if a directory), `chmod 0755`, exit. Two unit tests cover full-path and directory targets.
- `crates/openshell-driver-kubernetes/src/driver.rs`: replace `sh -c` init-container command with `["/openshell-sandbox", "copy-self", "/opt/openshell/bin/openshell-sandbox"]`. Strengthen the existing pod-template test to assert the new shape and explicitly forbid `sh` to prevent regression.

## Testing
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated (2 new in `openshell-sandbox`, init-container assertions tightened in `openshell-driver-kubernetes`)
- [ ] E2E tests added/updated (if applicable)

End-to-end verification on a real cluster still pending — happy to run `mise run e2e` against the Kubernetes driver before un-drafting.

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — no dedicated Kubernetes-driver architecture doc; mechanism is documented inline.