### PR TITLE
fix(bootstrap): stabilize release canary gateway startup

### DIFF
--- a/.agents/skills/debug-openshell-cluster/SKILL.md
+++ b/.agents/skills/debug-openshell-cluster/SKILL.md
@@ -198,6 +198,7 @@ openshell logs <sandbox-name>
 | Kubernetes gateway pod crash loops | Missing secret, bad DB URL, bad TLS config | `kubectl -n openshell logs statefulset/openshell` |
 | CLI TLS error | Local mTLS bundle does not match server cert/CA | Check `~/.config/openshell/gateways/<name>/mtls/` |
 | Image pull failure | Gateway or sandbox image cannot be pulled | Runtime events and image pull credentials |
+| `K8s namespace not ready` with `envoy-gateway-openshell.yaml: the server could not find the requested resource` | Optional Gateway API manifest was auto-applied without Envoy Gateway CRDs, or k3s Helm controller startup exceeded the namespace wait | Confirm the cluster image only bundles core manifests; apply `deploy/kube/manifests/envoy-gateway-openshell.yaml` manually only when `grpcRoute` is enabled |
 
 ## Reporting
 

--- a/crates/openshell-bootstrap/src/lib.rs
+++ b/crates/openshell-bootstrap/src/lib.rs
@@ -1189,7 +1189,9 @@ async fn wait_for_namespace(
 ) -> Result<()> {
     use miette::WrapErr;
 
-    let attempts = 60;
+    // Shared CPU runners can take several minutes to cold-start k3s, apply
+    // bundled manifests, and let the k3s Helm controller create the namespace.
+    let attempts = 150;
     let max_backoff = std::time::Duration::from_secs(2);
     let mut backoff = std::time::Duration::from_millis(200);
 

--- a/crates/openshell-cli/src/doctor_llm_prompt.md
+++ b/crates/openshell-cli/src/doctor_llm_prompt.md
@@ -225,7 +225,7 @@ openshell doctor exec -- kubectl -n openshell get secret openshell-client-tls -o
 
 Common mTLS issues:
 
-- **Secrets missing**: The `openshell` namespace may not have been created yet (Helm controller race). Bootstrap waits up to 2 minutes for the namespace.
+- **Secrets missing**: The `openshell` namespace may not have been created yet (Helm controller race). Bootstrap waits up to about 5 minutes for the namespace.
 - **mTLS mismatch after manual secret deletion**: Delete all three secrets and redeploy — bootstrap will regenerate and restart the workload.
 - **CLI can't connect after redeploy**: Check that `~/.config/openshell/gateways/<name>/mtls/` contains `ca.crt`, `tls.crt`, `tls.key` and that they were updated at deploy time.
 - **Local mTLS files missing**: The gateway was deployed but CLI credentials weren't persisted (e.g., interrupted deploy). Extract from the cluster secret as shown above.

--- a/deploy/docker/Dockerfile.images
+++ b/deploy/docker/Dockerfile.images
@@ -201,7 +201,13 @@ COPY deploy/docker/cluster-healthcheck.sh /usr/local/bin/cluster-healthcheck.sh
 RUN chmod +x /usr/local/bin/cluster-healthcheck.sh
 
 COPY deploy/docker/.build/charts/*.tgz /opt/openshell/charts/
-COPY deploy/kube/manifests/*.yaml /opt/openshell/manifests/
+# Only the core k3s auto-deploy manifests belong in the cluster image.
+# Gateway API routing is optional and requires Envoy Gateway CRDs, so
+# deploy/kube/manifests/envoy-gateway-openshell.yaml stays repo-local and is
+# applied manually by `mise run helm:gateway:apply` when grpcRoute is enabled.
+COPY deploy/kube/manifests/openshell-helmchart.yaml \
+     deploy/kube/manifests/agent-sandbox.yaml \
+     /opt/openshell/manifests/
 COPY deploy/kube/gpu-manifests/*.yaml /opt/openshell/gpu-manifests/
 
 ENTRYPOINT ["/usr/local/bin/cluster-entrypoint.sh"]


### PR DESCRIPTION
## Summary

Stabilize local gateway startup for Release Canary on shared runners. The canary was timing out while k3s was still applying the bundled HelmChart, and the cluster image was also auto-applying the optional Envoy GatewayClass manifest without Gateway API CRDs installed.

## Related Issue

Related to OS-49 (Linear). Follow-up to #1195.

## Changes

- Stop auto-bundling `envoy-gateway-openshell.yaml` into the default cluster image; it remains repo-local for `mise run helm:gateway:apply` when `grpcRoute` is enabled.
- Extend the bootstrap namespace wait from the previous roughly 2 minute window to about 5 minutes for shared-runner k3s cold starts.
- Update the doctor prompt and cluster debug skill with the new wait/signature.

## Testing

- [x] `git diff --check`
- [x] `mise x -- cargo test -p openshell-bootstrap`
- [ ] `mise run pre-commit` passes

`mise run pre-commit` was run and failed on pre-existing/unrelated local issues: markdownlint scans untracked `.codex-learning/*.md`, and Rust unit test `ssh::tests::launch_editor_returns_friendly_error_when_binary_missing` still fails. Rust check, clippy, fmt, Python checks/tests, Helm lint, license check, and Mermaid lint completed before the aggregate failure.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Cluster debug skill updated for bootstrap infrastructure changes