### PR TITLE
fix(docker): copy providers/ into rust-builder stage

### DIFF
--- a/deploy/docker/Dockerfile.images
+++ b/deploy/docker/Dockerfile.images
@@ -47,6 +47,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 COPY proto/ proto/
+COPY providers/ providers/
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/build/target \


### PR DESCRIPTION
## Summary
Source-built Docker images (`BUILD_FROM_SOURCE=1`, the path Skaffold dev uses) currently fail because the `rust-builder` stage in `deploy/docker/Dockerfile.images` does not copy the repo's `providers/` directory into the build context. The `openshell-providers` crate embeds provider profile YAML via `include_str!("../../../providers/*.yaml")`, so the build aborts with:

```
error: couldn't read `crates/openshell-providers/src/../../../providers/anthropic.yaml`: No such file or directory
```

This blocks `mise run helm:skaffold:dev` / `helm:skaffold:run` for anyone on `main`. One-line fix: add `COPY providers/ providers/` next to the other source-tree copies.

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
- `deploy/docker/Dockerfile.images`: copy `providers/` into the `rust-builder` stage so `include_str!` for provider profile YAML resolves.

## Testing
- [x] `mise run pre-commit` passes (no Rust changes; only the Dockerfile)
- [ ] `mise run helm:skaffold:run` against a local k3d cluster — verifying now on a downstream branch.

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — pure build-infra fix; no doc impact.