### PR TITLE
feat(cli): add --gateway-insecure flag to skip TLS certificate verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,6 +3384,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite 0.26.2",
  "tonic",
+ "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/crates/openshell-cli/Cargo.toml
+++ b/crates/openshell-cli/Cargo.toml
@@ -44,10 +44,11 @@ bytes = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
-hyper-rustls = { version = "0.27", default-features = false, features = ["native-tokio", "http1", "tls12", "logging", "ring", "webpki-tokio"] }
+hyper-rustls = { version = "0.27", default-features = false, features = ["native-tokio", "http1", "http2", "tls12", "logging", "ring", "webpki-tokio"] }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
 tokio-rustls = { workspace = true }
+tower = { workspace = true }
 reqwest = { workspace = true }
 
 # Error handling

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -379,6 +379,15 @@ struct Cli {
     )]
     gateway_endpoint: Option<String>,
 
+    /// Skip TLS certificate verification for gateway connections.
+    #[arg(
+        long,
+        global = true,
+        env = "OPENSHELL_GATEWAY_INSECURE",
+        help_heading = "GATEWAY FLAGS"
+    )]
+    gateway_insecure: bool,
+
     /// Increase verbosity (-v, -vv, -vvv).
     #[arg(short, long, action = clap::ArgAction::Count, global = true, help_heading = "GLOBAL FLAGS")]
     verbose: u8,
@@ -1796,7 +1805,8 @@ async fn main() -> Result<()> {
     CompleteEnv::with_factory(Cli::command).complete();
 
     let cli = Cli::parse();
-    let tls = TlsOptions::default();
+    let mut tls = TlsOptions::default();
+    tls.gateway_insecure = cli.gateway_insecure;
 
     // Set up logging based on verbosity
     let log_level = match cli.verbose {

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -5,7 +5,8 @@
 
 use crate::policy_update::build_policy_update_plan;
 use crate::tls::{
-    TlsOptions, build_rustls_config, grpc_client, grpc_inference_client, require_tls_materials,
+    TlsOptions, build_insecure_rustls_config, build_rustls_config, grpc_client,
+    grpc_inference_client, require_tls_materials,
 };
 use bytes::Bytes;
 use dialoguer::{Confirm, Select, theme::ColorfulTheme};
@@ -1509,7 +1510,14 @@ async fn http_health_check(server: &str, tls: &TlsOptions) -> Result<Option<Stat
     let uri: hyper::Uri = format!("{base}/healthz").parse().into_diagnostic()?;
 
     let scheme = uri.scheme_str().unwrap_or("https");
-    let https = if scheme.eq_ignore_ascii_case("http") || tls.is_bearer_auth() {
+    let https = if tls.gateway_insecure && scheme.eq_ignore_ascii_case("https") {
+        let insecure_config = build_insecure_rustls_config()?;
+        HttpsConnectorBuilder::new()
+            .with_tls_config(insecure_config)
+            .https_or_http()
+            .enable_http1()
+            .build()
+    } else if scheme.eq_ignore_ascii_case("http") || tls.is_bearer_auth() {
         HttpsConnectorBuilder::new()
             .with_native_roots()
             .into_diagnostic()?

--- a/crates/openshell-cli/src/tls.rs
+++ b/crates/openshell-cli/src/tls.rs
@@ -6,9 +6,11 @@ use openshell_core::proto::inference_client::InferenceClient;
 use openshell_core::proto::open_shell_client::OpenShellClient;
 use rustls::{
     RootCertStore,
-    pki_types::{CertificateDer, PrivateKeyDer},
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime},
 };
 use std::collections::HashMap;
+use std::future::Future;
 use std::io::Cursor;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -37,6 +39,8 @@ pub struct TlsOptions {
     /// OIDC bearer token — when set, injects `authorization: Bearer <token>`
     /// on every gRPC request. Takes precedence over `edge_token`.
     pub oidc_token: Option<String>,
+    /// Skip TLS certificate verification for gateway connections.
+    pub gateway_insecure: bool,
 }
 
 impl TlsOptions {
@@ -48,6 +52,7 @@ impl TlsOptions {
             gateway_name: None,
             edge_token: None,
             oidc_token: None,
+            gateway_insecure: false,
         }
     }
 
@@ -224,6 +229,86 @@ pub fn build_tonic_tls_config(materials: &TlsMaterials) -> ClientTlsConfig {
         .identity(identity)
 }
 
+#[derive(Debug)]
+struct InsecureServerCertVerifier;
+
+impl ServerCertVerifier for InsecureServerCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+#[derive(Clone)]
+struct InsecureTlsConnector {
+    tls_connector: tokio_rustls::TlsConnector,
+}
+
+impl tower::Service<hyper::Uri> for InsecureTlsConnector {
+    type Response = hyper_util::rt::TokioIo<tokio_rustls::client::TlsStream<tokio::net::TcpStream>>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+    type Future =
+        std::pin::Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, uri: hyper::Uri) -> Self::Future {
+        let tls_connector = self.tls_connector.clone();
+        Box::pin(async move {
+            let host = uri.host().unwrap_or("localhost").to_string();
+            let port = uri.port_u16().unwrap_or(443);
+            let addr = format!("{host}:{port}");
+            let tcp = tokio::net::TcpStream::connect(addr).await?;
+            let server_name = ServerName::try_from(host)?;
+            let tls_stream = tls_connector.connect(server_name, tcp).await?;
+            Ok(hyper_util::rt::TokioIo::new(tls_stream))
+        })
+    }
+}
+
+pub fn build_insecure_rustls_config() -> Result<rustls::ClientConfig> {
+    let config = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(std::sync::Arc::new(InsecureServerCertVerifier))
+        .with_no_client_auth();
+    Ok(config)
+}
+
 /// Tunnel proxy addresses keyed by upstream endpoint + token.
 ///
 /// Each distinct edge-authenticated gateway gets its own local proxy instead of
@@ -280,6 +365,25 @@ pub async fn build_channel(server: &str, tls: &TlsOptions) -> Result<Channel> {
             .http2_keep_alive_interval(Duration::from_secs(10))
             .keep_alive_while_idle(true);
         return endpoint.connect().await.into_diagnostic();
+    }
+
+    if tls.gateway_insecure && server.starts_with("https://") {
+        tracing::warn!("TLS certificate verification is disabled — do not use in production");
+        let rustls_config = build_insecure_rustls_config()?;
+        let tls_connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(rustls_config));
+        let connector = InsecureTlsConnector { tls_connector };
+        // Use http:// so tonic does not layer its own TLS on top — our
+        // connector performs TLS with the insecure config.
+        let http_uri = server.replacen("https://", "http://", 1);
+        let endpoint = Endpoint::from_shared(http_uri)
+            .into_diagnostic()?
+            .connect_timeout(Duration::from_secs(10))
+            .http2_keep_alive_interval(Duration::from_secs(10))
+            .keep_alive_while_idle(true);
+        return endpoint
+            .connect_with_connector(connector)
+            .await
+            .into_diagnostic();
     }
 
     let mut endpoint = Endpoint::from_shared(server.to_string())

--- a/crates/openshell-cli/tests/mtls_integration.rs
+++ b/crates/openshell-cli/tests/mtls_integration.rs
@@ -464,3 +464,44 @@ async fn cli_requires_client_cert_for_https() {
     let result = grpc_client(&endpoint, &tls).await;
     assert!(result.is_err());
 }
+
+async fn run_server_no_client_auth(
+    server_cert: String,
+    server_key: String,
+) -> std::net::SocketAddr {
+    let identity = Identity::from_pem(server_cert, server_key);
+    let tls = ServerTlsConfig::new().identity(identity);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpListenerStream::new(listener);
+    tokio::spawn(async move {
+        Server::builder()
+            .tls_config(tls)
+            .unwrap()
+            .add_service(OpenShellServer::new(TestOpenShell))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    addr
+}
+
+#[tokio::test]
+async fn cli_connects_with_gateway_insecure() {
+    install_rustls_provider();
+
+    let (ca, ca_key) = build_ca();
+    let (server_cert, server_key) = build_server_cert(&ca, &ca_key);
+
+    let addr = run_server_no_client_auth(server_cert, server_key).await;
+
+    let mut tls = TlsOptions::default();
+    tls.gateway_insecure = true;
+
+    let endpoint = format!("https://localhost:{}", addr.port());
+    let mut client = grpc_client(&endpoint, &tls).await.unwrap();
+    let response = client.health(HealthRequest {}).await.unwrap();
+    assert_eq!(response.get_ref().status, ServiceStatus::Healthy as i32);
+}


### PR DESCRIPTION
## Summary

Add `--gateway-insecure` flag and `OPENSHELL_GATEWAY_INSECURE` environment variable to skip TLS certificate verification when connecting to gateways. Useful for development environments with self-signed certificates.

## Related Issue

N/A

## Changes

- Added `--gateway-insecure` global CLI flag with `OPENSHELL_GATEWAY_INSECURE` env var support
- Added `gateway_insecure` field to `TlsOptions` struct
- Implemented `InsecureServerCertVerifier` that bypasses TLS certificate validation
- Implemented `InsecureTlsConnector` using `tower::Service` for custom TLS handling
- Updated `build_channel()` and `http_health_check()` to use insecure TLS when flag is set
- Added integration test `cli_connects_with_gateway_insecure`
- Enabled `http2` feature on `hyper-rustls` for HTTP/2 support
- Added `tower` dependency

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated (integration test added)
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)