### PR TITLE
docs: add supervisor image Helm values to manage-gateways reference

### DIFF
--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -47,11 +47,28 @@ The `dev` tags are intended for testing changes ahead of a release. Production d
 
 ## Configuration
 
-See [`values.yaml`](values.yaml) for configurable values. Selected overlays:
+See [`values.yaml`](values.yaml) for the full list of configurable values. Selected overlays:
 
 - [`ci/values-gateway.yaml`](ci/values-gateway.yaml) — gateway-only configuration
 - [`ci/values-cert-manager.yaml`](ci/values-cert-manager.yaml) — cert-manager integration
 - [`ci/values-keycloak.yaml`](ci/values-keycloak.yaml) — Keycloak OIDC integration
+
+Commonly configured values:
+
+| Value | Purpose |
+|---|---|
+| `image.repository` / `image.tag` | Gateway image. Defaults to `ghcr.io/nvidia/openshell/gateway`. |
+| `service.type` | Kubernetes service type. Use `ClusterIP`, `NodePort`, or your platform default. |
+| `server.dbUrl` | Gateway database URL. Defaults to SQLite on the chart-managed persistent volume. |
+| `server.sandboxNamespace` | Namespace where sandbox resources are created. |
+| `server.sandboxImage` | Default sandbox image used when a sandbox does not specify one. |
+| `server.grpcEndpoint` | Endpoint that sandbox supervisors use to call back to the gateway. |
+| `server.sshGatewayHost` / `server.sshGatewayPort` | Public host and port returned to CLI clients for SSH proxy connections. |
+| `server.disableTls` | Run the gateway over plaintext HTTP. Use only behind a trusted transport. |
+| `server.tls.*` | Secret names for server and client mTLS materials. |
+| `supervisor.image.repository` | Repository for the supervisor init container image. Defaults to `ghcr.io/nvidia/openshell/supervisor`. |
+| `supervisor.image.tag` | Tag for the supervisor image. Defaults to the chart's `appVersion` so the supervisor and gateway stay in sync. |
+| `supervisor.image.pullPolicy` | Pull policy for the supervisor image. Defaults to the Kubernetes cluster default when unset. |
 
 ## PKI bootstrap
 


### PR DESCRIPTION
## Summary

The supervisor init container was introduced in #1154 but the three \`supervisor.image.*\` Helm values were not documented.

After #1231 removed the Helm deployment section from \`manage-gateways.mdx\`, the natural home for chart configuration is \`deploy/helm/openshell/README.md\`. This PR adds a configuration reference table there, which is where \`docs/about/installation.mdx\` directs Kubernetes users for chart configuration details.

Added values:

- \`supervisor.image.repository\`
- \`supervisor.image.tag\`
- \`supervisor.image.pullPolicy\`

The table also restores the other commonly configured values that were lost when \`manage-gateways.mdx\` was consolidated.

## Related Issue

Follows #1154. Rebased after #1231.

## Changes

- \`deploy/helm/openshell/README.md\`: added a configuration reference table with all commonly used Helm values, including the three \`supervisor.image.*\` entries.

## Testing

Documentation change only. No code changes.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Follows the docs style guide
- [x] No duplicate H1
- [x] Active voice