### PR TITLE
docs(arch): update Kubernetes supervisor delivery to reflect init-container pattern

### DIFF
--- a/architecture/build-containers.md
+++ b/architecture/build-containers.md
@@ -38,7 +38,7 @@ The `openshell-sandbox` supervisor is delivered by the selected compute driver:
 
 | Driver | Supervisor delivery |
 |---|---|
-| Kubernetes | Sandbox pod image or Kubernetes driver pod template configuration. |
+| Kubernetes | Init container copies the supervisor binary from the supervisor image into an `emptyDir` volume shared with the sandbox container. Configured via `supervisor_image` / `supervisor_image_pull_policy` in `KubernetesComputeConfig`. |
 | Docker | Local supervisor binary or supervisor image extraction configured by the gateway. |
 | Podman | Read-only OCI image volume from the `supervisor-output` image. |
 | VM | Embedded in the VM runtime rootfs. |

--- a/architecture/podman-driver.md
+++ b/architecture/podman-driver.md
@@ -84,7 +84,7 @@ All capabilities are only available to the supervisor process. Sandbox child pro
 
 ## Supervisor Sideloading
 
-The supervisor binary is delivered to sandbox containers via Podman's OCI image volume mechanism, distinct from both the Kubernetes hostPath approach and the VM's embedded rootfs.
+The supervisor binary is delivered to sandbox containers via Podman's OCI image volume mechanism, distinct from the Kubernetes init-container approach (which copies the binary into an `emptyDir` volume) and the VM's embedded rootfs.
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
## Summary

PR #1154 replaced the Kubernetes hostPath volume approach for supervisor binary injection with an init container + `emptyDir` pattern. Two architecture docs were not updated to reflect this change:

- `architecture/build-containers.md`: Kubernetes row in the supervisor delivery table described the old approach ("Sandbox pod image or Kubernetes driver pod template configuration").
- `architecture/podman-driver.md`: Compared Podman's OCI image volume mechanism against "the Kubernetes hostPath approach", which no longer applies.

## Related Issue

Follows #1154.

## Changes

- `architecture/build-containers.md`: Updated the Kubernetes supervisor delivery row to describe the init container + `emptyDir` pattern and reference `supervisor_image` / `supervisor_image_pull_policy`.
- `architecture/podman-driver.md`: Replaced the reference to "Kubernetes hostPath approach" with "Kubernetes init-container approach".

## Testing

Documentation change only. No code changes.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)