### PR TITLE
docs: replace generic Index link text with actual page titles

### DIFF
--- a/docs/get-started/tutorials/inference-ollama.mdx
+++ b/docs/get-started/tutorials/inference-ollama.mdx
@@ -206,6 +206,6 @@ openshell provider get ollama
 
 ## Next Steps
 
-- To learn more about managed inference, refer to [Index](/inference/about).
+- To learn more about managed inference, refer to [About Inference Routing](/inference/about).
 - To configure a different self-hosted backend, refer to [Configure](/inference/configure).
 - To explore more community sandboxes, refer to [Community Sandboxes](/sandboxes/community-sandboxes).

--- a/docs/get-started/tutorials/local-inference-lmstudio.mdx
+++ b/docs/get-started/tutorials/local-inference-lmstudio.mdx
@@ -210,5 +210,5 @@ openshell provider get lmstudio-anthropic
 ## Next Steps
 
 - To learn more about using the LM Studio CLI, refer to [LM Studio docs](https://lmstudio.ai/docs/cli)
-- To learn more about managed inference, refer to [Index](/inference/about).
+- To learn more about managed inference, refer to [About Inference Routing](/inference/about).
 - To configure a different self-hosted backend, refer to [Configure](/inference/configure).

--- a/docs/inference/configure.mdx
+++ b/docs/inference/configure.mdx
@@ -189,7 +189,7 @@ A successful response confirms the privacy router can reach the configured backe
 
 Explore related topics:
 
-- To understand the inference routing flow and supported API patterns, refer to [Index](/inference/about).
+- To understand the inference routing flow and supported API patterns, refer to [About Inference Routing](/inference/about).
 - To follow a complete Ollama-based local setup, refer to [Inference Ollama](/get-started/tutorials/inference-ollama).
 - To follow a complete LM Studio-based local setup, refer to [Local Inference Lmstudio](/get-started/tutorials/local-inference-lmstudio).
 - To control external endpoints, refer to [Policies](/sandboxes/policies).

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -589,6 +589,6 @@ GraphQL field names are application-specific, so treat these as starting shapes 
 
 Explore related topics:
 
-- To learn about network access rules and sandbox isolation layers, refer to [Index](/sandboxes/about).
+- To learn about network access rules and sandbox isolation layers, refer to [About Gateways and Sandboxes](/sandboxes/about).
 - To view the full field-by-field YAML definition, refer to the [Policy Schema Reference](/reference/policy-schema).
 - To review the default policy breakdown, refer to [Default Policy](/reference/default-policy).


### PR DESCRIPTION
## Summary

Four cross-reference links across the docs used the label `Index` instead of the destination page's title, making the link text ambiguous and unhelpful to readers.

- `docs/sandboxes/policies.mdx` → `[Index](/sandboxes/about)` → `[About Gateways and Sandboxes](/sandboxes/about)`
- `docs/inference/configure.mdx` → `[Index](/inference/about)` → `[About Inference Routing](/inference/about)`
- `docs/get-started/tutorials/inference-ollama.mdx` → same fix
- `docs/get-started/tutorials/local-inference-lmstudio.mdx` → same fix

## Related Issue

N/A — caught during a routine docs audit.

## Changes

4 files, 4 one-line link-text corrections. No content, URL, or structure changes.

## Testing

- [ ] Verify each link navigates to the correct destination page in the docs site preview.

## Checklist

- [x] Follows docs style guide (active voice, no filler text)
- [x] No broken links introduced
- [x] No duplicate body H1