### PR TITLE
fix(install): support normalized dev deb assets

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - 'install.sh'
+      - 'install-dev.sh'
       - 'e2e/install/**'
       - '.github/workflows/test-install.yml'
   push:
     branches: [main]
     paths:
       - 'install.sh'
+      - 'install-dev.sh'
       - 'e2e/install/**'
       - '.github/workflows/test-install.yml'
   workflow_dispatch:
@@ -49,3 +51,13 @@ jobs:
 
       - name: Run tests (${{ matrix.shell }})
         run: ${{ matrix.run }}
+
+  test-install-dev:
+    name: install-dev.sh lookup
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run install-dev.sh lookup tests
+        run: sh e2e/install/install_dev_lookup_test.sh

--- a/e2e/install/install_dev_lookup_test.sh
+++ b/e2e/install/install_dev_lookup_test.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# POSIX sh tests for install-dev.sh release asset lookup.
+#
+set -eu
+
+. "$(dirname "$0")/helpers.sh"
+
+INSTALL_DEV_SCRIPT="$REPO_ROOT/install-dev.sh"
+
+_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$_TMPDIR"' EXIT
+
+_FUNCTIONS="${_TMPDIR}/install-dev-functions.sh"
+awk '$0 == "main \"$@\"" { next } { print }' "$INSTALL_DEV_SCRIPT" > "$_FUNCTIONS"
+. "$_FUNCTIONS"
+
+write_checksums() {
+  _path="$1"
+  shift
+
+  : > "$_path"
+  for _line in "$@"; do
+    printf '%s\n' "$_line" >> "$_path"
+  done
+}
+
+assert_deb_asset() {
+  _label="$1"
+  _arch="$2"
+  _expected="$3"
+  shift 3
+
+  _checksums="${_TMPDIR}/${_label}.checksums"
+  write_checksums "$_checksums" "$@"
+
+  _actual="$(find_deb_asset "$_checksums" "$_arch")"
+  if [ "$_actual" = "$_expected" ]; then
+    pass "$_label"
+  else
+    fail "$_label" "expected '${_expected}', got '${_actual}'"
+  fi
+}
+
+assert_no_deb_asset() {
+  _label="$1"
+  _arch="$2"
+  shift 2
+
+  _checksums="${_TMPDIR}/${_label}.checksums"
+  write_checksums "$_checksums" "$@"
+
+  _actual="$(find_deb_asset "$_checksums" "$_arch")"
+  if [ -z "$_actual" ]; then
+    pass "$_label"
+  else
+    fail "$_label" "expected no match, got '${_actual}'"
+  fi
+}
+
+printf '=== install-dev.sh asset lookup tests ===\n\n'
+
+assert_deb_asset \
+  "selects normalized amd64 dev asset" \
+  "amd64" \
+  "openshell-dev-amd64.deb" \
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  openshell-dev-amd64.deb" \
+  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  openshell-dev-arm64.deb"
+
+assert_deb_asset \
+  "selects normalized arm64 dev asset with binary marker" \
+  "arm64" \
+  "openshell-dev-arm64.deb" \
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *openshell-dev-amd64.deb" \
+  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb *openshell-dev-arm64.deb"
+
+assert_deb_asset \
+  "keeps legacy Debian package fallback" \
+  "amd64" \
+  "openshell_0.1.0~dev_amd64.deb" \
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  openshell_0.1.0~dev_amd64.deb"
+
+assert_deb_asset \
+  "prefers normalized dev asset over legacy fallback" \
+  "arm64" \
+  "openshell-dev-arm64.deb" \
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  openshell_0.1.0~dev_arm64.deb" \
+  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  openshell-dev-arm64.deb"
+
+assert_no_deb_asset \
+  "ignores mismatched architecture" \
+  "amd64" \
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  openshell-dev-arm64.deb"
+
+print_summary

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -165,10 +165,22 @@ find_deb_asset() {
   _arch="$2"
 
   awk -v arch="$_arch" '
-    $2 ~ "^\\*?openshell_.*_" arch "\\.deb$" {
-      sub("^\\*", "", $2)
-      print $2
+    {
+      name = $2
+      sub("^\\*", "", name)
+    }
+    name == "openshell-dev-" arch ".deb" {
+      print name
+      found = 1
       exit
+    }
+    legacy == "" && name ~ "^openshell_.*_" arch "\\.deb$" {
+      legacy = name
+    }
+    END {
+      if (!found && legacy != "") {
+        print legacy
+      }
     }
   ' "$_checksums"
 }


### PR DESCRIPTION
## Summary

Fix `install-dev.sh` so the dev Debian installer can find the normalized dev release assets published by Release Dev.

## Related Issue

Related to OS-49.

## Changes

- Prefer `openshell-dev-<arch>.deb` entries from `openshell-checksums-sha256.txt`.
- Keep the previous `openshell_..._<arch>.deb` lookup as a fallback for compatibility.
- Add a focused POSIX shell lookup test for normalized names, binary checksum markers, legacy fallback, preference order, and architecture mismatch.
- Include `install-dev.sh` in the install-script workflow path filters and run the new lookup test there.

## Testing

- [x] `sh -n install-dev.sh`
- [x] `sh -n e2e/install/install_dev_lookup_test.sh`
- [x] `sh e2e/install/install_dev_lookup_test.sh`
- [x] `git diff --check`
- [ ] `mise run pre-commit` passes

`mise run pre-commit` was attempted locally. It did not pass due to unrelated existing workspace issues: markdownlint picked up untracked `.codex-learning/*.md` files, and `test:rust` failed in `ssh::tests::launch_editor_returns_friendly_error_when_binary_missing`. The targeted installer checks passed.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)