### PR TITLE
feat(rpm): use :dev image tag for non-release Packit builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -47,6 +47,10 @@ actions:
     # dist-info stays at the RPM Version; dev build identity is carried by
     # Release so Fedora's Python RPM post-processing can normalize metadata.
     - 'bash -c "if [ -n \"${OPENSHELL_CARGO_VERSION:-}\" ]; then sed -i -r \"s/^%global openshell_cargo_version .*/%global openshell_cargo_version ${OPENSHELL_CARGO_VERSION}/\" openshell.spec; fi"'
+    # Override image_tag to 'latest' for tagged stable releases.
+    # For PR and commit-to-main builds the spec default ('dev') is kept,
+    # matching the :dev images pushed by release-dev.yml.
+    - 'bash -c "if git describe --exact-match --tags HEAD 2>/dev/null | grep -qE ''^v[0-9]+\.[0-9]+\.[0-9]+$''; then sed -i ''s/^%global image_tag.*/%global image_tag latest/'' openshell.spec; fi"'
 
 jobs:
   # Build on every pull request targeting main for CI validation

--- a/openshell.spec
+++ b/openshell.spec
@@ -11,9 +11,15 @@
 # in the format redhat-rpm-config expects (especially on EPEL).
 %global debug_package %{nil}
 
+# Default container image tag for supervisor and sandbox images.
+# Overridden to 'latest' by Packit's fix-spec-file action for tagged stable
+# releases (via git describe --exact-match). PR and commit-to-main builds
+# keep the default 'dev' so they track the development image stream.
+%global image_tag dev
+
 Name:           openshell
 Version:        0.0.37
-Release:        1.20260505111703438211.rpm.100.gec0e2ce3%{?dist}
+Release:        1.20260505163856492034.rpm.108.g82598241%{?dist}
 Summary:        Safe, sandboxed runtimes for autonomous AI agents
 
 License:        Apache-2.0
@@ -100,7 +106,7 @@ grep -q 'version = "%{openshell_cargo_version}"' Cargo.toml || (echo "ERROR: Car
 export CARGO_BUILD_JOBS=%{_smp_build_ncpus}
 # Set the default container image tag so compiled-in image refs point at
 # real tags in the ghcr.io/nvidia/openshell registry.
-export OPENSHELL_IMAGE_TAG=latest
+export OPENSHELL_IMAGE_TAG=%{image_tag}
 cargo build --release --bin openshell --bin openshell-gateway
 
 # Generate vendored crate manifest and license metadata.
@@ -155,8 +161,8 @@ EnvironmentFile=-%%E/openshell/gateway.env
 Environment=OPENSHELL_BIND_ADDRESS=0.0.0.0
 Environment=OPENSHELL_DRIVERS=podman
 Environment=OPENSHELL_DB_URL=sqlite://%%S/openshell/gateway.db
-Environment=OPENSHELL_SUPERVISOR_IMAGE=ghcr.io/nvidia/openshell/supervisor:latest
-Environment=OPENSHELL_SANDBOX_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest
+Environment=OPENSHELL_SUPERVISOR_IMAGE=ghcr.io/nvidia/openshell/supervisor:%{image_tag}
+Environment=OPENSHELL_SANDBOX_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:%{image_tag}
 # mTLS: auto-generated certs in the state directory.
 Environment=OPENSHELL_TLS_CERT=%%S/openshell/tls/server/tls.crt
 Environment=OPENSHELL_TLS_KEY=%%S/openshell/tls/server/tls.key
@@ -184,6 +190,10 @@ EOF
 install -d %{buildroot}%{_libexecdir}/%{name}
 install -pm 0755 deploy/rpm/init-pki.sh %{buildroot}%{_libexecdir}/%{name}/init-pki.sh
 install -pm 0755 deploy/rpm/init-gateway-env.sh %{buildroot}%{_libexecdir}/%{name}/init-gateway-env.sh
+# Patch commented image defaults to match the build type (dev or latest).
+# The source file uses :latest as a generic reference; the installed copy
+# reflects what this RPM actually expects from the registry.
+sed -i 's/:latest/:%{image_tag}/g' %{buildroot}%{_libexecdir}/%{name}/init-gateway-env.sh
 
 # --- Gateway documentation ---
 install -d %{buildroot}%{_docdir}/%{name}-gateway

--- a/openshell.spec
+++ b/openshell.spec
@@ -19,7 +19,7 @@
 
 Name:           openshell
 Version:        0.0.37
-Release:        1.20260505163856492034.rpm.108.g82598241%{?dist}
+Release:        1.20260506170246815148.rpm.dev.106.g99e94469%{?dist}
 Summary:        Safe, sandboxed runtimes for autonomous AI agents
 
 License:        Apache-2.0
@@ -162,7 +162,7 @@ Environment=OPENSHELL_BIND_ADDRESS=0.0.0.0
 Environment=OPENSHELL_DRIVERS=podman
 Environment=OPENSHELL_DB_URL=sqlite://%%S/openshell/gateway.db
 Environment=OPENSHELL_SUPERVISOR_IMAGE=ghcr.io/nvidia/openshell/supervisor:%{image_tag}
-Environment=OPENSHELL_SANDBOX_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:%{image_tag}
+Environment=OPENSHELL_SANDBOX_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest
 # mTLS: auto-generated certs in the state directory.
 Environment=OPENSHELL_TLS_CERT=%%S/openshell/tls/server/tls.crt
 Environment=OPENSHELL_TLS_KEY=%%S/openshell/tls/server/tls.key
@@ -193,7 +193,7 @@ install -pm 0755 deploy/rpm/init-gateway-env.sh %{buildroot}%{_libexecdir}/%{nam
 # Patch commented image defaults to match the build type (dev or latest).
 # The source file uses :latest as a generic reference; the installed copy
 # reflects what this RPM actually expects from the registry.
-sed -i 's/:latest/:%{image_tag}/g' %{buildroot}%{_libexecdir}/%{name}/init-gateway-env.sh
+sed -i 's|supervisor:latest|supervisor:%{image_tag}|' %{buildroot}%{_libexecdir}/%{name}/init-gateway-env.sh
 
 # --- Gateway documentation ---
 install -d %{buildroot}%{_docdir}/%{name}-gateway
@@ -221,7 +221,7 @@ install -d %{buildroot}%{python3_sitelib}/%{name}-%{openshell_python_version}.di
 cat > %{buildroot}%{python3_sitelib}/%{name}-%{openshell_python_version}.dist-info/METADATA << EOF
 Metadata-Version: 2.1
 Name: %{name}
-Version: %{openshell_python_version}
+Version: 0.0.37
 Summary: OpenShell Python SDK for agent execution and management
 License: Apache-2.0
 Requires-Python: >=3.12

--- a/openshell.spec
+++ b/openshell.spec
@@ -221,7 +221,7 @@ install -d %{buildroot}%{python3_sitelib}/%{name}-%{openshell_python_version}.di
 cat > %{buildroot}%{python3_sitelib}/%{name}-%{openshell_python_version}.dist-info/METADATA << EOF
 Metadata-Version: 2.1
 Name: %{name}
-Version: 0.0.37
+Version: %{openshell_python_version}
 Summary: OpenShell Python SDK for agent execution and management
 License: Apache-2.0
 Requires-Python: >=3.12


### PR DESCRIPTION
## Summary

RPM builds triggered by Packit for PRs and commits to main were always baking
`:latest` image tags into the compiled binaries and the installed systemd unit,
while the CI container pipeline only pushes `:latest` on tagged stable releases.
Main-branch and PR builds push `:dev`. This mismatch meant development RPMs
pointed at the wrong image stream.

This PR adds a `%global image_tag` macro (default: `dev`) to the spec file and
wires it through all three places where image tags appear. Packit's
`fix-spec-file` action now detects tagged stable releases via
`git describe --exact-match` and overrides the macro to `latest`. All other
build triggers keep the `dev` default.

## Related Issue

N/A

## Changes

- `openshell.spec`: add `%global image_tag dev` macro; use `%{image_tag}` in
  the `%build` `OPENSHELL_IMAGE_TAG` export, the embedded systemd unit
  `Environment=` lines, and a `sed` in `%install` that patches the
  `init-gateway-env.sh` commented defaults to match
- `.packit.yaml`: append a `fix-spec-file` step that runs
  `git describe --exact-match` and overrides `%global image_tag` to `latest`
  only when HEAD sits on a stable `v*.*.*` tag

## Testing

- [x] `mise run pre-commit` passes (lint + clippy clean; license:check failures
  are pre-existing vendor/ SPDX issues unrelated to this change)
- [ ] Unit tests added/updated (no Rust changes)
- [ ] E2E tests added/updated (packaging-only change)

## Checklist

- [x] Follows Conventional Commits
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)