### PR TITLE
fix(cli): warn when env gateway overrides selection

### DIFF
--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -766,7 +766,21 @@ pub fn gateway_use(name: &str) -> Result<()> {
 
     save_active_gateway(name)?;
     eprintln!("{} Active gateway set to '{name}'", "✓".green().bold());
+    if let Some(warning) = gateway_env_override_warning(name) {
+        eprintln!("{} {warning}", "⚠".yellow().bold());
+    }
     Ok(())
+}
+
+fn gateway_env_override_warning(selected_name: &str) -> Option<String> {
+    let env_name = std::env::var("OPENSHELL_GATEWAY").ok()?;
+    if env_name.is_empty() || env_name == selected_name {
+        return None;
+    }
+
+    Some(format!(
+        "OPENSHELL_GATEWAY={env_name} is set and will override this selection.\n  Unset it or run: export OPENSHELL_GATEWAY={selected_name}"
+    ))
 }
 
 pub fn gateway_select(name: Option<&str>, gateway_flag: &Option<String>) -> Result<()> {
@@ -5971,8 +5985,8 @@ mod tests {
     use super::{
         GatewayControlTarget, TlsOptions, dockerfile_sources_supported_for_gateway,
         format_gateway_select_header, format_gateway_select_items, gateway_add, gateway_auth_label,
-        gateway_select_with, gateway_type_label, git_sync_files, http_health_check,
-        image_requests_gpu, inferred_provider_type, parse_cli_setting_value,
+        gateway_env_override_warning, gateway_select_with, gateway_type_label, git_sync_files,
+        http_health_check, image_requests_gpu, inferred_provider_type, parse_cli_setting_value,
         parse_credential_pairs, plaintext_gateway_is_remote, provisioning_timeout_message,
         ready_false_condition_message, resolve_from, resolve_gateway_control_target_from,
         sandbox_should_persist, shell_escape, source_requests_gpu, validate_gateway_name,
@@ -6512,6 +6526,35 @@ mod tests {
             assert_eq!(load_active_gateway().as_deref(), Some("alpha"));
             assert!(!prompted, "explicit gateway should skip prompting");
         });
+    }
+
+    #[test]
+    fn gateway_env_override_warning_mentions_masked_selection() {
+        let _guard = TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _env = EnvVarGuard::set("OPENSHELL_GATEWAY", "openshell");
+
+        let warning = gateway_env_override_warning("docker-dev").expect("env override should warn");
+
+        assert!(
+            warning.contains("OPENSHELL_GATEWAY=openshell"),
+            "warning should name the overriding env var: {warning}"
+        );
+        assert!(
+            warning.contains("export OPENSHELL_GATEWAY=docker-dev"),
+            "warning should suggest updating the env var: {warning}"
+        );
+    }
+
+    #[test]
+    fn gateway_env_override_warning_skips_matching_gateway() {
+        let _guard = TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _env = EnvVarGuard::set("OPENSHELL_GATEWAY", "docker-dev");
+
+        assert_eq!(gateway_env_override_warning("docker-dev"), None);
     }
 
     #[test]

--- a/docs/sandboxes/manage-gateways.mdx
+++ b/docs/sandboxes/manage-gateways.mdx
@@ -158,6 +158,8 @@ For direct mTLS endpoints, place the CLI client certificate bundle in the gatewa
 
 One gateway is always the active gateway. All CLI commands target it by default. `gateway add` sets the new gateway as active.
 
+The active gateway is the persisted default. The `-g` flag and the `OPENSHELL_GATEWAY` environment variable override it when commands resolve a gateway. If `OPENSHELL_GATEWAY` is set to a different gateway, `openshell gateway select <name>` still saves the new default and warns that the current shell will keep using the environment value until you unset or update it.
+
 List all registered gateways:
 
 ```shell


### PR DESCRIPTION
> **🏗️ build-from-issue-agent**

## Summary
Warn when `openshell gateway select <name>` saves a new active gateway while `OPENSHELL_GATEWAY` is set to a different name. The command still succeeds, but the warning explains that the current shell will continue resolving through the env var until it is unset or updated.

## Related Issue
Closes #1206

## Changes
- `crates/openshell-cli/src/run.rs`: adds env-override warning text after successful gateway selection and unit coverage for masked vs matching selection behavior.
- `docs/sandboxes/manage-gateways.mdx`: documents that `-g` and `OPENSHELL_GATEWAY` override the persisted active gateway, including the new warning behavior.

### Deviations from Plan
None — implemented as planned.

## Testing
- [x] `RUSTC_WRAPPER= cargo test -p openshell-cli gateway_env_override_warning` passes
- [x] `RUSTC_WRAPPER= mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] E2E tests not needed (no `e2e/` changes)

**Tests added:**
- **Unit:** `crates/openshell-cli/src/run.rs` covers warning generation when `OPENSHELL_GATEWAY` masks the selected gateway and no warning when it matches.
- **Integration:** N/A
- **E2E:** N/A

## Checklist
- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)

**Documentation updated:**
- `docs/sandboxes/manage-gateways.mdx`: gateway precedence and env override warning behavior.