### PR TITLE
fix(sandbox): allow Anthropic token counting through inference router

### DIFF
--- a/architecture/inference-routing.md
+++ b/architecture/inference-routing.md
@@ -136,6 +136,7 @@ Supported built-in patterns:
 | `POST` | `/v1/completions` | `openai_completions` | `completion` |
 | `POST` | `/v1/responses` | `openai_responses` | `responses` |
 | `POST` | `/v1/messages` | `anthropic_messages` | `messages` |
+| `POST` | `/v1/messages/count_tokens` | `anthropic_messages` | `messages_count_tokens` |
 | `GET` | `/v1/models` | `model_discovery` | `models_list` |
 | `GET` | `/v1/models/*` | `model_discovery` | `models_get` |
 

--- a/crates/openshell-sandbox/src/l7/inference.rs
+++ b/crates/openshell-sandbox/src/l7/inference.rs
@@ -44,6 +44,12 @@ pub fn default_patterns() -> Vec<InferenceApiPattern> {
             kind: "messages".to_string(),
         },
         InferenceApiPattern {
+            method: "POST".to_string(),
+            path_glob: "/v1/messages/count_tokens".to_string(),
+            protocol: "anthropic_messages".to_string(),
+            kind: "messages_count_tokens".to_string(),
+        },
+        InferenceApiPattern {
             method: "GET".to_string(),
             path_glob: "/v1/models".to_string(),
             protocol: "model_discovery".to_string(),
@@ -405,6 +411,15 @@ mod tests {
         let result = detect_inference_pattern("POST", "/v1/messages", &patterns);
         assert!(result.is_some());
         assert_eq!(result.unwrap().protocol, "anthropic_messages");
+    }
+
+    #[test]
+    fn detect_anthropic_count_tokens() {
+        let patterns = default_patterns();
+        let result = detect_inference_pattern("POST", "/v1/messages/count_tokens", &patterns);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().protocol, "anthropic_messages");
+        assert_eq!(result.unwrap().kind, "messages_count_tokens");
     }
 
     #[test]

--- a/docs/inference/about.mdx
+++ b/docs/inference/about.mdx
@@ -53,6 +53,7 @@ Supported request patterns depend on the provider configured for `inference.loca
 | Pattern | Method | Path |
 |---|---|---|
 | Messages | `POST` | `/v1/messages` |
+| Token Counting | `POST` | `/v1/messages/count_tokens` |
 
 </Tab>
 


### PR DESCRIPTION
## Summary

Allow Anthropic-compatible `POST /v1/messages/count_tokens` requests through the `inference.local` classifier so the Claude SDK's pre-flight token-count call reaches the configured Anthropic-compatible backend instead of being rejected by the sandbox inference router.

## Related Issue

Vouch request: #1224. Supersedes #1100 (same fix; scoped commit title and template-aligned body).

## Changes

- Add a `POST /v1/messages/count_tokens` entry to `default_patterns()` in `crates/openshell-sandbox/src/l7/inference.rs`, mapped to the existing `anthropic_messages` protocol with kind `messages_count_tokens`.
- Add unit test `detect_anthropic_count_tokens` covering the new pattern.
- Document the supported route in `architecture/inference-routing.md` and `docs/inference/about.mdx`.

## Testing

- [ ] `mise run pre-commit` passes
- [x] Unit tests added/updated — `detect_anthropic_count_tokens` in `crates/openshell-sandbox/src/l7/inference.rs`
- [ ] E2E tests added/updated (if applicable) — not applicable; pure pattern-matcher table addition with unit-test coverage

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) — title is `fix(sandbox): ...`
- [x] Commits are signed off (DCO) — `Signed-off-by: Matej Kosec <mkosec@nvidia.com>`
- [x] Architecture docs updated (if applicable) — `architecture/inference-routing.md` row added; `docs/inference/about.mdx` user-facing route table updated