### PR TITLE
fix(ci): pin tag release reusable workflows

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: ""
+      checkout-ref:
+        description: "Git ref to check out for build inputs (defaults to the workflow SHA)"
+        required: false
+        type: string
+        default: ""
 
 env:
   MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -150,6 +155,7 @@ jobs:
       component: ${{ needs.resolve.outputs.binary_component }}
       arch: ${{ matrix.arch }}
       cargo-version: ${{ inputs['cargo-version'] }}
+      checkout-ref: ${{ inputs['checkout-ref'] }}
       features: openshell-core/dev-settings
       artifact-name: ${{ needs.resolve.outputs.artifact_prefix }}-linux-${{ matrix.arch }}
     secrets: inherit
@@ -181,6 +187,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ inputs['checkout-ref'] || github.sha }}
           fetch-depth: 0
 
       - name: Mark workspace safe for git

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: "linux-amd64-cpu8"
+      checkout-ref:
+        description: "Git ref to check out for test inputs (defaults to the workflow SHA)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -54,6 +59,8 @@ jobs:
       OPENSHELL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs['checkout-ref'] || github.sha }}
 
       - name: Install OS test dependencies
         if: matrix.apt_packages != ''

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -45,6 +45,8 @@ jobs:
       rpm_release: ${{ steps.v.outputs.rpm_release }}
       # Semver without 'v' prefix (e.g. 0.6.0), used for image tags and release body
       semver: ${{ steps.v.outputs.semver }}
+      # Commit resolved from RELEASE_TAG, used for image tags and downstream metadata
+      source_sha: ${{ steps.v.outputs.source_sha }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -67,6 +69,7 @@ jobs:
           echo "rpm_version=$(uv run python tasks/scripts/release.py get-version --rpm-version)" >> "$GITHUB_OUTPUT"
           echo "rpm_release=$(uv run python tasks/scripts/release.py get-version --rpm-release)" >> "$GITHUB_OUTPUT"
           echo "semver=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   build-gateway:
     needs: [compute-versions]
@@ -74,6 +77,8 @@ jobs:
     with:
       component: gateway
       cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
+      image-tag: ${{ needs.compute-versions.outputs.source_sha }}
+      checkout-ref: ${{ inputs.tag || github.ref }}
 
   build-supervisor:
     needs: [compute-versions]
@@ -81,6 +86,8 @@ jobs:
     with:
       component: supervisor
       cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
+      image-tag: ${{ needs.compute-versions.outputs.source_sha }}
+      checkout-ref: ${{ inputs.tag || github.ref }}
 
   build-cluster:
     needs: [compute-versions]
@@ -88,12 +95,15 @@ jobs:
     with:
       component: cluster
       cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
+      image-tag: ${{ needs.compute-versions.outputs.source_sha }}
+      checkout-ref: ${{ inputs.tag || github.ref }}
 
   e2e:
-    needs: [build-gateway, build-supervisor, build-cluster]
+    needs: [compute-versions, build-gateway, build-supervisor, build-cluster]
     uses: ./.github/workflows/e2e-test.yml
     with:
-      image-tag: ${{ github.sha }}
+      image-tag: ${{ needs.compute-versions.outputs.source_sha }}
+      checkout-ref: ${{ inputs.tag || github.ref }}
       runner: linux-arm64-cpu8
 
   tag-ghcr-release:
@@ -110,16 +120,17 @@ jobs:
           set -euo pipefail
           REGISTRY="ghcr.io/nvidia/openshell"
           VERSION="${{ needs.compute-versions.outputs.semver }}"
+          SOURCE_TAG="${{ needs.compute-versions.outputs.source_sha }}"
           for component in gateway supervisor cluster; do
-            echo "Tagging ${REGISTRY}/${component}:${{ github.sha }} as ${VERSION} and latest..."
+            echo "Tagging ${REGISTRY}/${component}:${SOURCE_TAG} as ${VERSION} and latest..."
             docker buildx imagetools create \
               --prefer-index=false \
               -t "${REGISTRY}/${component}:${VERSION}" \
-              "${REGISTRY}/${component}:${{ github.sha }}"
+              "${REGISTRY}/${component}:${SOURCE_TAG}"
             docker buildx imagetools create \
               --prefer-index=false \
               -t "${REGISTRY}/${component}:latest" \
-              "${REGISTRY}/${component}:${{ github.sha }}"
+              "${REGISTRY}/${component}:${SOURCE_TAG}"
           done
 
   build-python-wheels-linux:
@@ -918,6 +929,7 @@ jobs:
         env:
           GITLAB_CI_TRIGGER_TOKEN: ${{ secrets.GITLAB_CI_TRIGGER_TOKEN }}
           GITLAB_CI_TRIGGER_URL: ${{ secrets.GITLAB_CI_TRIGGER_URL }}
+          COMMIT_SHA: ${{ needs.compute-versions.outputs.source_sha }}
           RELEASE_VERSION: ${{ needs.compute-versions.outputs.python_version }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
           WHEEL_FILENAMES: ${{ needs.release.outputs.wheel_filenames }}
@@ -936,7 +948,7 @@ jobs:
             -F "ref=main" \
             -F "variables[PIPELINE_ACTION]=publish_wheels" \
             -F "variables[GITHUB_REPOSITORY]=${GITHUB_REPOSITORY}" \
-            -F "variables[COMMIT_SHA]=${GITHUB_SHA}" \
+            -F "variables[COMMIT_SHA]=${COMMIT_SHA}" \
             -F "variables[RELEASE_TAG]=${RELEASE_TAG}" \
             -F "variables[RELEASE_VERSION]=${RELEASE_VERSION}" \
             -F "variables[RELEASE_KIND]=stable" \

--- a/.github/workflows/shadow-rust-native-build.yml
+++ b/.github/workflows/shadow-rust-native-build.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: ""
+      checkout-ref:
+        description: "Git ref to check out for build inputs (defaults to the workflow SHA)"
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       component:
@@ -72,6 +77,11 @@ on:
         default: 5
       artifact-name:
         description: "Artifact name override"
+        required: false
+        type: string
+        default: ""
+      checkout-ref:
+        description: "Git ref to check out for build inputs (defaults to the workflow SHA)"
         required: false
         type: string
         default: ""
@@ -113,6 +123,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ inputs['checkout-ref'] || github.sha }}
           fetch-depth: 0
 
       - name: Mark workspace safe for git


### PR DESCRIPTION
## Summary

Pin tag release Docker and e2e reusable workflows to the resolved release tag commit so manually dispatched tag releases do not build or test the dispatch ref.

## Related Issue

None

## Changes

- Resolve the release tag commit once in release-tag.yml and expose it as source_sha.
- Pass checkout-ref and source_sha through Docker build and e2e reusable workflows.
- Use source_sha for GHCR release retagging and downstream wheel publish metadata.

## Testing

- [x] mise run pre-commit passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)