### PR TITLE
fix(packaging): let gateway auto-detect package driver

### DIFF
--- a/crates/openshell-driver-vm/README.md
+++ b/crates/openshell-driver-vm/README.md
@@ -182,13 +182,17 @@ The VM guest's serial console is appended to `<state-dir>/<sandbox-id>/console.l
 
 On Linux amd64 and arm64, `install-dev.sh` installs the Debian package from the
 selected `OPENSHELL_VERSION` release tag. That package includes
-`openshell-gateway` and `openshell-driver-vm`.
+`openshell-gateway` and `openshell-driver-vm`, but leaves
+`OPENSHELL_DRIVERS` unset so the gateway uses its normal runtime
+auto-detection. Set `OPENSHELL_DRIVERS=vm` to force the VM driver.
 
 On Apple Silicon macOS, `install-dev.sh` stages the generated `openshell.rb`
 formula from the selected release in the `nvidia/openshell` Homebrew tap.
 Homebrew installs `openshell`, `openshell-gateway`, and
 `openshell-driver-vm`, ad-hoc signs the driver with the Hypervisor entitlement
-in `post_install`, and owns the `brew services` gateway lifecycle.
+in `post_install`, and owns the `brew services` gateway lifecycle. The service
+also leaves `OPENSHELL_DRIVERS` unset so driver choice remains automatic unless
+the user explicitly overrides it.
 
 ## Relationship to `openshell-vm`
 

--- a/deploy/deb/openshell-gateway.service
+++ b/deploy/deb/openshell-gateway.service
@@ -12,7 +12,6 @@ Environment=OPENSHELL_SERVER_PORT=17670
 Environment=OPENSHELL_DISABLE_TLS=true
 Environment=OPENSHELL_DISABLE_GATEWAY_AUTH=true
 Environment=OPENSHELL_DB_URL=sqlite:%S/openshell/gateway/openshell.db
-Environment=OPENSHELL_DRIVERS=vm
 Environment=OPENSHELL_GRPC_ENDPOINT=http://127.0.0.1:17670
 Environment=OPENSHELL_SSH_GATEWAY_HOST=127.0.0.1
 Environment=OPENSHELL_SSH_GATEWAY_PORT=17670

--- a/python/openshell/release_formula_test.py
+++ b/python/openshell/release_formula_test.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 
 
-def test_generate_homebrew_formula_uses_tagged_macos_driver_asset(
+def test_generate_homebrew_formula_uses_tagged_macos_driver_asset_without_default_driver(
     tmp_path: Path,
 ) -> None:
     release_dir = tmp_path / "release"
@@ -51,6 +51,7 @@ def test_generate_homebrew_formula_uses_tagged_macos_driver_asset(
         "v0.0.10/openshell-driver-vm-aarch64-apple-darwin.tar.gz"
     ) in formula
     assert 'sha256 "' + "b" * 64 + '"' in formula
+    assert "OPENSHELL_DRIVERS" not in formula
     assert 'OPENSHELL_DRIVER_DIR: "#{opt_libexec}"' in formula
     assert "entitlements.atomic_write" in formula
     assert "brew services restart openshell" in formula

--- a/tasks/scripts/release.py
+++ b/tasks/scripts/release.py
@@ -293,7 +293,6 @@ class Openshell < Formula
       OPENSHELL_DISABLE_TLS: "true",
       OPENSHELL_DISABLE_GATEWAY_AUTH: "true",
       OPENSHELL_DB_URL: "sqlite:#{{var}}/openshell/gateway/openshell.db",
-      OPENSHELL_DRIVERS: "vm",
       OPENSHELL_GRPC_ENDPOINT: "http://127.0.0.1:{LOCAL_GATEWAY_PORT}",
       OPENSHELL_SSH_GATEWAY_HOST: "127.0.0.1",
       OPENSHELL_SSH_GATEWAY_PORT: "{LOCAL_GATEWAY_PORT}",


### PR DESCRIPTION
## Summary

Unset the packaged Debian and Homebrew `OPENSHELL_DRIVERS=vm` defaults so `openshell-gateway` uses its normal runtime auto-detection. The VM driver helper remains installed and discoverable for users who explicitly select `OPENSHELL_DRIVERS=vm`.

## Related Issue

None.

## Changes

- Remove `OPENSHELL_DRIVERS=vm` from the Debian user service.
- Remove `OPENSHELL_DRIVERS: "vm"` from generated Homebrew service environment variables.
- Update the Homebrew formula test and VM driver docs to reflect automatic driver selection.

## Testing

- [x] `uv run pytest python/openshell/release_formula_test.py` passes
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)