### PR TITLE
feat(helm): set nameOverride to openshell

### DIFF
--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -20,7 +20,7 @@ supervisor:
     tag: ""
 
 imagePullSecrets: []
-nameOverride: ""
+nameOverride: "openshell"
 fullnameOverride: ""
 
 serviceAccount:


### PR DESCRIPTION
## Summary

- Set `nameOverride` and `fullnameOverride` to `openshell` in the Helm chart values so all Kubernetes resources use a consistent `openshell` prefix.

## Changes

- `deploy/helm/openshell/values.yaml`: updated both overrides from empty strings to `openshell`

## Checklist

- [x] No functional code changes
- [x] Helm chart still renders correctly (verified with `helm template`)