### PR TITLE
docs(helm): add install instructions for OpenShift

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart
 
 See [`deploy/helm/openshell/README.md`](deploy/helm/openshell/README.md) for available versions, dev tag conventions, and configuration.
 
+For deploying OpenShell on OpenShift, see [`deploy/helm/openshell/README.md#install-on-openshift`](deploy/helm/openshell/README.md#install-on-openshift).
+
 ### Create a sandbox
 
 ```bash

--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -4,10 +4,27 @@
 
 This chart deploys the OpenShell gateway into a Kubernetes cluster. It is published as an OCI artifact to GHCR at `oci://ghcr.io/nvidia/openshell/helm-chart`.
 
-## Install
+## Install on Kubernetes
 
 ```bash
 helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart --version <version>
+```
+
+## Install on OpenShift
+
+```bash
+# Precreate the openshell namespace so we can create the SCC cluster role
+oc create ns openshell
+
+# Sandboxes are deployed into the openshell namespace and use the default service account for now
+oc adm policy add-scc-to-user privileged -z default -n openshell
+
+# Deploy openshell with overrides to allow SCC assignment of fsGroup and runAsUser for the gateway
+helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart --version <version> -n openshell \
+	--set pkiInitJob.enabled=false \
+	--set server.disableTls=true \
+	--set podSecurityContext.fsGroup=null \
+	--set securityContext.runAsUser=null
 ```
 
 ## Available versions


### PR DESCRIPTION
## Summary

Add OpenShift installation instructions to the Helm chart README, enabling users to deploy OpenShell on OpenShift clusters.

## Changes

- Added OpenShift-specific installation steps to `deploy/helm/openshell/README.md`
- Updated main project README with OpenShift reference

## Testing

- [ ] `mise run pre-commit` passes

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)