### PR TITLE
fix(helm): derive grpcEndpoint from chart context

### DIFF
--- a/deploy/helm/openshell/templates/_helpers.tpl
+++ b/deploy/helm/openshell/templates/_helpers.tpl
@@ -81,3 +81,19 @@ Namespaced Issuer (selfSigned) for cert-manager CA bootstrap.
 {{- define "openshell.issuerSelfSigned" -}}
 {{- printf "%s-selfsigned" (include "openshell.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{/*
+gRPC endpoint sandbox pods use to call back into the gateway. An explicit
+.Values.server.grpcEndpoint is used verbatim. Otherwise it is derived from
+the in-cluster Service DNS, release namespace, service port, and disableTls
+flag — so the default value works for any release name or namespace without
+override.
+*/}}
+{{- define "openshell.grpcEndpoint" -}}
+{{- if .Values.server.grpcEndpoint -}}
+{{- .Values.server.grpcEndpoint -}}
+{{- else -}}
+{{- $scheme := ternary "http" "https" (default false .Values.server.disableTls) -}}
+{{- printf "%s://%s.%s.svc.cluster.local:%d" $scheme (include "openshell.fullname" .) .Release.Namespace (int .Values.service.port) -}}
+{{- end -}}
+{{- end }}

--- a/deploy/helm/openshell/templates/statefulset.yaml
+++ b/deploy/helm/openshell/templates/statefulset.yaml
@@ -77,7 +77,7 @@ spec:
               value: {{ .Values.supervisor.image.pullPolicy | quote }}
             {{- end }}
             - name: OPENSHELL_GRPC_ENDPOINT
-              value: {{ if .Values.server.disableTls }}{{ .Values.server.grpcEndpoint | replace "https://" "http://" | quote }}{{ else }}{{ .Values.server.grpcEndpoint | quote }}{{ end }}
+              value: {{ include "openshell.grpcEndpoint" . | quote }}
             {{- if .Values.server.sshGatewayHost }}
             - name: OPENSHELL_SSH_GATEWAY_HOST
               value: {{ .Values.server.sshGatewayHost | quote }}

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -86,8 +86,12 @@ server:
   # (Always for :latest, IfNotPresent otherwise).  Set to "Always" for dev
   # clusters so new images are picked up without manual eviction.
   sandboxImagePullPolicy: ""
-  # gRPC endpoint for sandboxes to callback to OpenShell (must be reachable from pods)
-  grpcEndpoint: "https://openshell.openshell.svc.cluster.local:8080"
+  # gRPC endpoint sandboxes call back into the gateway. Leave empty to derive
+  # it from the chart fullname, release namespace, service port, and
+  # disableTls flag (i.e. <scheme>://<fullname>.<namespace>.svc.cluster.local:<port>).
+  # Override only when sandboxes must reach the gateway via a different
+  # hostname (e.g. an external ingress or a host alias).
+  grpcEndpoint: ""
   # Public host/port returned to CLI clients for SSH proxy CONNECT requests.
   # For local clusters the default 127.0.0.1:8080 is correct; for remote
   # clusters these should be set to the externally reachable host and port.

--- a/deploy/kube/manifests/openshell-helmchart.yaml
+++ b/deploy/kube/manifests/openshell-helmchart.yaml
@@ -35,7 +35,6 @@ spec:
       dbUrl: __DB_URL__
       sshGatewayHost: __SSH_GATEWAY_HOST__
       sshGatewayPort: __SSH_GATEWAY_PORT__
-      grpcEndpoint: "https://openshell.openshell.svc.cluster.local:8080"
       hostGatewayIP: __HOST_GATEWAY_IP__
       disableGatewayAuth: __DISABLE_GATEWAY_AUTH__
       disableTls: __DISABLE_TLS__

--- a/examples/gateway-deploy-connect.md
+++ b/examples/gateway-deploy-connect.md
@@ -16,8 +16,7 @@ kubectl create namespace openshell
 helm upgrade --install openshell deploy/helm/openshell \
   --namespace openshell \
   --set server.disableTls=true \
-  --set service.type=ClusterIP \
-  --set server.grpcEndpoint=http://openshell.openshell.svc.cluster.local:8080
+  --set service.type=ClusterIP
 ```
 
 For local evaluation, forward the service and register the forwarded endpoint:

--- a/tasks/scripts/helm-k3s-local.sh
+++ b/tasks/scripts/helm-k3s-local.sh
@@ -20,6 +20,9 @@ ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 _branch="$(git -C "${ROOT}" rev-parse --abbrev-ref HEAD 2>/dev/null)" || _branch=""
 _suffix="$(printf '%s' "${_branch##*/}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/-*$//')"
 CLUSTER_NAME="${HELM_K3S_CLUSTER_NAME:-openshell-dev${_suffix:+-${_suffix}}}"
+# k3d caps cluster names at 32 chars; validated in cmd_create so the operator
+# gets an actionable hint instead of a deep-stack k3d validation error.
+K3D_CLUSTER_NAME_MAX=32
 # Host port forwarded to port 80 via the k3d load balancer.
 # Used by Envoy Gateway's LoadBalancer service (values-gateway.yaml).
 HOST_LB_PORT="${HELM_K3S_LB_HOST_PORT:-8080}"
@@ -153,6 +156,15 @@ cmd_create() {
   require_supported_os
   require_docker
   require_k3d
+
+  if (( ${#CLUSTER_NAME} > K3D_CLUSTER_NAME_MAX )); then
+    cat >&2 <<EOF
+error: derived cluster name '${CLUSTER_NAME}' is ${#CLUSTER_NAME} chars; k3d caps at ${K3D_CLUSTER_NAME_MAX}.
+Set HELM_K3S_CLUSTER_NAME to a shorter name, e.g.:
+  HELM_K3S_CLUSTER_NAME=openshell-dev-${_suffix:0:$(( K3D_CLUSTER_NAME_MAX - 14 ))} mise run helm:k3s:create
+EOF
+    exit 1
+  fi
 
   local lb_port_map="${HOST_LB_PORT}:80@loadbalancer"
 


### PR DESCRIPTION
## Summary

`server.grpcEndpoint` was hardcoded in `values.yaml` to `https://openshell.openshell.svc.cluster.local:8080`, which only matched the in-cluster Service DNS for releases named `openshell` in namespace `openshell`. The chart now derives the endpoint from chart context, so the default works for any release name, namespace, or service port without an override. An explicit `server.grpcEndpoint` is used verbatim.

Also bails out early in `helm-k3s-local.sh` when the branch-derived k3d cluster name exceeds k3d's 32-char cap, with a copy-pasteable override hint.

## Related Issue

n/a

## Changes

- New `openshell.grpcEndpoint` helper in `_helpers.tpl` builds `<scheme>://<fullname>.<namespace>.svc.cluster.local:<service.port>` from chart context, picking the scheme from `server.disableTls`. An explicit `server.grpcEndpoint` is passed through verbatim.
- `templates/statefulset.yaml` consumes the helper for `OPENSHELL_GRPC_ENDPOINT`.
- `values.yaml` defaults `server.grpcEndpoint` to empty with a comment explaining auto-derivation.
- `deploy/kube/manifests/openshell-helmchart.yaml` drops the redundant hardcoded value.
- `examples/gateway-deploy-connect.md` drops the now-unnecessary `--set server.grpcEndpoint=...` flag.
- `tasks/scripts/helm-k3s-local.sh` validates the cluster name length in `cmd_create` before calling docker/k3d.

## Testing

- [x] `mise run pre-commit` passes
- [x] `helm template` rendered correctly across: default mTLS, plaintext (`disableTls=true`), custom release name + namespace, explicit override (verbatim), explicit override with `disableTls=true` (still verbatim)
- [x] Deployed via `mise run helm:skaffold:run` against a local k3d cluster — pod healthy, resolved env `OPENSHELL_GRPC_ENDPOINT=http://openshell.openshell.svc.cluster.local:8080`
- [x] Created and deleted a sandbox via port-forward — supervisor callback used the chart-derived endpoint successfully
- [x] `helm-k3s-local.sh create` with a long branch suffix exits early with the suggested `HELM_K3S_CLUSTER_NAME=...` override; `status`, `--help`, `start`, `stop`, `delete` are unaffected

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)