### PR TITLE
docs(helm): fix overlay values paths after ci/ reorganization

### DIFF
--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -24,6 +24,6 @@ The `dev` tags are intended for testing changes ahead of a release. Production d
 
 See [`values.yaml`](values.yaml) for configurable values. Selected overlays:
 
-- [`values-gateway.yaml`](values-gateway.yaml) — gateway-only configuration
-- [`values-cert-manager.yaml`](values-cert-manager.yaml) — cert-manager integration
-- [`values-keycloak.yaml`](values-keycloak.yaml) — Keycloak OIDC integration
+- [`ci/values-gateway.yaml`](ci/values-gateway.yaml) — gateway-only configuration
+- [`ci/values-cert-manager.yaml`](ci/values-cert-manager.yaml) — cert-manager integration
+- [`ci/values-keycloak.yaml`](ci/values-keycloak.yaml) — Keycloak OIDC integration


### PR DESCRIPTION
## Summary

PR #1223 moved the Helm chart values overlays into `deploy/helm/openshell/ci/` but the `README.md` still points to the old root-level paths. The three links in the Configuration section are broken.

## Related Issue

Follow-up to #1223.

## Changes

- Fix `values-gateway.yaml`, `values-cert-manager.yaml`, and `values-keycloak.yaml` links to `ci/values-*.yaml`.

## Testing

- Confirmed the files exist at `deploy/helm/openshell/ci/`.
- Confirmed no `values-*.yaml` files remain at the chart root.

## Checklist

- [x] No functional changes, link paths updated to match current filesystem layout