### PR TITLE
docs(helm): add agent sandbox prerequisite to Helm README

### DIFF
--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -4,6 +4,14 @@
 
 This chart deploys the OpenShell gateway into a Kubernetes cluster. It is published as an OCI artifact to GHCR at `oci://ghcr.io/nvidia/openshell/helm-chart`.
 
+## Prerequisites
+
+The Kubernetes Agent Sandbox CRDs and controller must be installed on the cluster before deploying OpenShell. Install them with:
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.4.3/manifest.yaml
+```
+
 ## Install on Kubernetes
 
 ```bash

--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -9,7 +9,7 @@ This chart deploys the OpenShell gateway into a Kubernetes cluster. It is publis
 The Kubernetes Agent Sandbox CRDs and controller must be installed on the cluster before deploying OpenShell. Install them with:
 
 ```bash
-kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.4.3/manifest.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/manifest.yaml
 ```
 
 ## Install on Kubernetes


### PR DESCRIPTION
## Summary

Add a Prerequisites section to the Helm chart README requiring the Kubernetes Agent Sandbox CRDs and controller to be installed before deploying OpenShell.

## Changes

- Added "Prerequisites" section to `deploy/helm/openshell/README.md`
- Includes `kubectl apply` command for latest Agent Sandbox manifest

## Checklist

- [x] No code changes (docs only)
- [x] Follows docs style guide (active voice, minimal formatting)