### PR TITLE
fix(installer): repair dev install package and service setup

### DIFF
--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -6,7 +6,9 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::net::SocketAddr;
-use std::path::PathBuf;
+#[cfg(unix)]
+use std::os::unix::fs::FileTypeExt;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
 
@@ -108,8 +110,8 @@ pub fn detect_driver() -> Option<ComputeDriverKind> {
         return Some(ComputeDriverKind::Podman);
     }
 
-    // Docker: check if docker binary is available
-    if is_binary_available("docker") {
+    // Docker: check if the CLI is available or a local Docker socket exists.
+    if is_docker_available() {
         return Some(ComputeDriverKind::Docker);
     }
 
@@ -122,6 +124,55 @@ fn is_binary_available(name: &str) -> bool {
         .arg("--version")
         .output()
         .is_ok_and(|output| output.status.success())
+}
+
+fn is_docker_available() -> bool {
+    is_binary_available("docker") || docker_socket_available()
+}
+
+fn docker_socket_available() -> bool {
+    docker_socket_candidates()
+        .iter()
+        .any(|path| is_unix_socket(path))
+}
+
+fn docker_socket_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Ok(host) = std::env::var("DOCKER_HOST")
+        && let Some(path) = docker_host_unix_socket_path(&host)
+    {
+        candidates.push(path);
+    }
+
+    candidates.push(PathBuf::from("/var/run/docker.sock"));
+
+    if let Some(home) = std::env::var_os("HOME") {
+        candidates.push(PathBuf::from(home).join(".docker/run/docker.sock"));
+    }
+
+    if let Some(runtime_dir) = std::env::var_os("XDG_RUNTIME_DIR") {
+        candidates.push(PathBuf::from(runtime_dir).join("docker.sock"));
+    }
+
+    candidates
+}
+
+fn docker_host_unix_socket_path(host: &str) -> Option<PathBuf> {
+    let path = host.trim().strip_prefix("unix://")?;
+    (!path.is_empty()).then(|| PathBuf::from(path))
+}
+
+#[cfg(unix)]
+fn is_unix_socket(path: &Path) -> bool {
+    path.metadata()
+        .is_ok_and(|metadata| metadata.file_type().is_socket())
+}
+
+#[cfg(not(unix))]
+fn is_unix_socket(path: &Path) -> bool {
+    let _ = path;
+    false
 }
 
 /// Server configuration.
@@ -563,8 +614,13 @@ const fn default_ssh_session_ttl_secs() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{ComputeDriverKind, Config, detect_driver};
+    use super::{
+        ComputeDriverKind, Config, detect_driver, docker_host_unix_socket_path, is_unix_socket,
+    };
     use std::net::SocketAddr;
+    #[cfg(unix)]
+    use std::os::unix::net::UnixListener;
+    use std::path::PathBuf;
 
     #[test]
     fn compute_driver_kind_parses_supported_values() {
@@ -614,10 +670,34 @@ mod tests {
     #[test]
     fn detect_driver_returns_none_without_k8s_env_or_binaries() {
         // When KUBERNETES_SERVICE_HOST is not set and no docker/podman binaries
-        // are available, detect_driver should return None.
+        // or Docker socket are available, detect_driver should return None.
         // This test may pass or fail depending on the test environment,
         // but it documents the expected behavior.
         let _ = detect_driver(); // Returns Some or None based on environment
+    }
+
+    #[test]
+    fn docker_host_unix_socket_path_parses_unix_hosts() {
+        assert_eq!(
+            docker_host_unix_socket_path("unix:///var/run/docker.sock"),
+            Some(PathBuf::from("/var/run/docker.sock"))
+        );
+        assert_eq!(docker_host_unix_socket_path("tcp://127.0.0.1:2375"), None);
+        assert_eq!(docker_host_unix_socket_path("unix://"), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn is_unix_socket_detects_socket_files() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let socket_path = temp_dir.path().join("docker.sock");
+        let _listener = UnixListener::bind(&socket_path).expect("bind unix socket");
+
+        assert!(is_unix_socket(&socket_path));
+
+        let regular_file = temp_dir.path().join("not-a-socket");
+        std::fs::write(&regular_file, b"not a socket").expect("write regular file");
+        assert!(!is_unix_socket(&regular_file));
     }
 
     #[test]

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -67,8 +67,8 @@ struct Args {
     /// `kubernetes,podman`. The configuration format is future-proofed for
     /// multiple drivers, but the gateway currently requires exactly one.
     /// When unset, the gateway auto-detects the driver based on the runtime
-    /// environment (Kubernetes → Podman → Docker). VM is never auto-detected
-    /// and requires explicit configuration.
+    /// environment (Kubernetes → Podman → Docker CLI or socket). VM is never
+    /// auto-detected and requires explicit configuration.
     #[arg(
         long,
         alias = "driver",

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -22,7 +22,7 @@ openshell-gateway --drivers docker
 
 You can also set the driver with `OPENSHELL_DRIVERS`. Supported values are `docker`, `podman`, `kubernetes`, and `vm`.
 
-When `--drivers` and `OPENSHELL_DRIVERS` are unset, the gateway auto-detects Kubernetes, then Podman, then Docker. The VM driver is never auto-detected; configure it explicitly with `--drivers vm`.
+When `--drivers` and `OPENSHELL_DRIVERS` are unset, the gateway auto-detects Kubernetes, then Podman, then Docker by CLI availability or a local Unix socket. The VM driver is never auto-detected; configure it explicitly with `--drivers vm`.
 
 Common gateway options:
 

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -227,10 +227,26 @@ find_deb_asset() {
   _arch="$2"
 
   awk -v arch="$_arch" '
-    $2 ~ "^\\*?openshell_.*_" arch "\\.deb$" {
-      sub("^\\*", "", $2)
-      print $2
-      exit
+    {
+      name = $2
+      sub("^\\*", "", name)
+
+      if (name == "openshell-dev-" arch ".deb") {
+        selected = name
+        found = 1
+        exit
+      }
+
+      if (fallback == "" && name ~ "^openshell_.*_" arch "\\.deb$") {
+        fallback = name
+      }
+    }
+    END {
+      if (found) {
+        print selected
+      } else if (fallback != "") {
+        print fallback
+      }
     }
   ' "$_checksums"
 }


### PR DESCRIPTION
## Summary

Fix dev installer regressions for Linux Debian package lookup and macOS Homebrew gateway startup.

## Related Issue

N/A

## Changes

- Accept `openshell-dev-<arch>.deb` entries in dev release checksums while retaining support for versioned `openshell_<version>_<arch>.deb` names.
- Patch downloaded dev Homebrew formulas to generate and pass an `OPENSHELL_SSH_HANDSHAKE_SECRET`.
- Give the Homebrew service a launchd-friendly `PATH` so gateway auto-detection can resolve Kubernetes, Podman, or Docker without setting a default driver.
- Allow an explicit Homebrew driver override through `OPENSHELL_DRIVERS` without baking in a default.
- Update generated Homebrew formula output and install docs for gateway driver auto-detection.
- Fix hard tabs in the Helm README that were failing the Markdown branch check.

## Testing

- [x] `sh -n install-dev.sh`
- [x] `shellcheck install-dev.sh`
- [x] `uv run pytest python/openshell/release_formula_test.py`
- [x] `markdownlint-cli2 deploy/helm/openshell/README.md docs/about/installation.mdx`
- [x] Generated Homebrew formula parses with `ruby -c`
- [x] `mise run pre-commit`

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
