### PR TITLE
docs(helm): replace hard tabs with spaces in README OpenShift block

### DIFF
--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -29,10 +29,10 @@ oc adm policy add-scc-to-user privileged -z default -n openshell
 
 # Deploy openshell with overrides to allow SCC assignment of fsGroup and runAsUser for the gateway
 helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart --version <version> -n openshell \
-	--set pkiInitJob.enabled=false \
-	--set server.disableTls=true \
-	--set podSecurityContext.fsGroup=null \
-	--set securityContext.runAsUser=null
+  --set pkiInitJob.enabled=false \
+  --set server.disableTls=true \
+  --set podSecurityContext.fsGroup=null \
+  --set securityContext.runAsUser=null
 ```
 
 ## Available versions


### PR DESCRIPTION
## Summary

Replace the four hard-tab indents in the OpenShift install snippet with two-space indents so `markdownlint` (MD010/no-hard-tabs) passes. Introduced by #1249; currently failing pre-commit on every branch off main.

## Related Issue

N/A — drive-by fix.

## Changes

- `deploy/helm/openshell/README.md` lines 32-35: tab → two spaces.

## Testing

- [x] `mise run markdown:lint:md` passes (0 errors)
- [ ] Unit tests added/updated — N/A (docs only)
- [ ] E2E tests added/updated — N/A

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — N/A