### PR TITLE
fix(release): pin macOS gateway supervisor image tag

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -507,6 +507,7 @@ jobs:
           docker buildx build \
             --file deploy/docker/Dockerfile.gateway-macos \
             --build-arg OPENSHELL_CARGO_VERSION="${{ needs.compute-versions.outputs.cargo_version }}" \
+            --build-arg OPENSHELL_IMAGE_TAG="${{ github.sha }}" \
             --build-arg CARGO_TARGET_CACHE_SCOPE="${{ github.sha }}" \
             --target binary \
             --output type=local,dest=out/ \

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -626,6 +626,7 @@ jobs:
           docker buildx build \
             --file deploy/docker/Dockerfile.gateway-macos \
             --build-arg OPENSHELL_CARGO_VERSION="${{ needs.compute-versions.outputs.cargo_version }}" \
+            --build-arg OPENSHELL_IMAGE_TAG="${{ needs.compute-versions.outputs.source_sha }}" \
             --build-arg CARGO_TARGET_CACHE_SCOPE="${{ github.sha }}" \
             --target binary \
             --output type=local,dest=out/ \

--- a/deploy/docker/Dockerfile.gateway-macos
+++ b/deploy/docker/Dockerfile.gateway-macos
@@ -93,7 +93,10 @@ RUN touch crates/openshell-core/src/lib.rs \
     crates/openshell-core/build.rs \
     proto/*.proto
 
+# Declare version ARGs here (not earlier) so the git-hash-bearing values do not
+# invalidate the expensive dependency-build layers above on every commit.
 ARG OPENSHELL_CARGO_VERSION
+ARG OPENSHELL_IMAGE_TAG
 RUN --mount=type=cache,id=cargo-registry-gateway-macos,sharing=locked,target=/root/.cargo/registry \
     --mount=type=cache,id=cargo-git-gateway-macos,sharing=locked,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-target-gateway-macos-${CARGO_TARGET_CACHE_SCOPE},sharing=locked,target=/build/target \


### PR DESCRIPTION
## Summary

- Bake `OPENSHELL_IMAGE_TAG` into the macOS standalone gateway binary so the supervisor image lookup uses a valid Docker reference instead of falling through to a `CARGO_PKG_VERSION` that contains `+` build metadata.
- Patches both `release-dev.yml` and `release-tag.yml` plus `Dockerfile.gateway-macos`. PR #1259 covered the Linux gateway binary; this is the macOS counterpart.

## Diagnostics

A user-reported failure of `install-dev.sh` on Apple Silicon: the gateway service shows as "started" via `brew services list`, but the gateway is actually crash-looping.

```
$ launchctl print gui/$(id -u)/homebrew.mxcl.openshell | grep 'last exit\|runs'
        runs = 43
        last exit code = 1
```

The launchd error log:

```
$ tail /opt/homebrew/var/log/openshell/openshell-gateway.err.log
Error:   × execution error: failed to create compute runtime: configuration error:
  │ failed to inspect docker supervisor image 'ghcr.io/nvidia/openshell/
  │ supervisor:0.0.37-dev.147+g084c93b6a': Docker responded with status code
  │ 400: invalid reference format
```

The `+` is illegal in Docker image references (which only accept `[A-Za-z0-9_.-]` after the colon). The `+g…` is SemVer build metadata that should never reach an image tag.

## Root cause

`default_docker_supervisor_image_tag()` at `crates/openshell-driver-docker/src/lib.rs:92` resolves the supervisor tag at compile time in this order:

1. `option_env!("OPENSHELL_IMAGE_TAG")`
2. `option_env!("IMAGE_TAG")`
3. `env!("CARGO_PKG_VERSION")`

The dev release pipeline patches the workspace Cargo version to a git-derived string like `0.0.37-dev.147+g084c93b6a`. When `OPENSHELL_IMAGE_TAG` is not set at build time, the binary falls all the way through to that patched version and bakes the `+` into the default supervisor reference.

In `.github/workflows/release-dev.yml`:

- `build-cli-macos` (line 358–365): passes both `OPENSHELL_CARGO_VERSION` *and* `OPENSHELL_IMAGE_TAG=dev` ✅
- `build-gateway-binary-linux` (line 432): set via env after PR #1259 ✅
- `build-gateway-binary-macos` (line 504–513): missing `OPENSHELL_IMAGE_TAG` ❌

`release-tag.yml` had the same gap for tagged releases on macOS.

`Dockerfile.gateway-macos` also did not declare `ARG OPENSHELL_IMAGE_TAG`, so even with `--build-arg` the value was never visible to `cargo build`. The companion `Dockerfile.cli-macos` declares both ARGs near the final cargo step (after dependency layers are cached) — this PR mirrors that pattern.

## Changes

- `release-dev.yml`: pass `--build-arg OPENSHELL_IMAGE_TAG=${{ github.sha }}` to the macOS gateway buildx invocation, matching the Linux fix in #1259.
- `release-tag.yml`: pass `--build-arg OPENSHELL_IMAGE_TAG=${{ needs.compute-versions.outputs.source_sha }}`, matching the Linux fix in #1259.
- `Dockerfile.gateway-macos`: declare `ARG OPENSHELL_IMAGE_TAG` next to `ARG OPENSHELL_CARGO_VERSION`, after the dependency-build cache layers (matches the `cli-macos` Dockerfile, including the comment explaining the placement).

The supervisor image is published with `<github.sha>` / `<source_sha>` tags by `build-supervisor` -> `docker-build.yml` and re-tagged as `dev` / `latest` / `<semver>` by `tag-ghcr-{dev,release}`. Pinning the gateway binary to the SHA is consistent with the Linux fix and points to a tag that is guaranteed to exist before the release notes are published.

## Test plan

- [ ] `mise run pre-commit` passes locally (done before push).
- [ ] CI on this branch builds the macOS gateway binary without errors.
- [ ] After merge + dev re-release, run `install-dev.sh` on an Apple Silicon host:
  - `brew services info openshell` shows `Running: true`
  - `curl http://127.0.0.1:17670/health` returns 2xx
  - `/opt/homebrew/var/log/openshell/openshell-gateway.err.log` does not contain `invalid reference format`
- [ ] `openshell sandbox create` succeeds against the local gateway, confirming the supervisor image is pulled successfully.

## Workaround for users on the broken dev build

Until a new dev release is cut, set the runtime override (`OPENSHELL_DOCKER_SUPERVISOR_IMAGE`) in the launchd plist:

```sh
plutil -insert EnvironmentVariables.OPENSHELL_DOCKER_SUPERVISOR_IMAGE \
  -string "ghcr.io/nvidia/openshell/supervisor:dev" \
  ~/Library/LaunchAgents/homebrew.mxcl.openshell.plist
brew services restart openshell
```

Note: `brew services` regenerates the plist from the formula, so this needs to be re-applied after each `install-dev.sh` run.