### PR TITLE
feat(vm): boot sandboxes from ext4 root disks

### DIFF
--- a/.github/workflows/driver-vm-linux.yml
+++ b/.github/workflows/driver-vm-linux.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Verify embedded driver inputs
         run: |
           set -euo pipefail
-          for file in libkrun.so.zst libkrunfw.so.5.zst gvproxy.zst openshell-sandbox.zst; do
+          for file in libkrun.so.zst libkrunfw.so.5.zst gvproxy.zst umoci.zst openshell-sandbox.zst; do
             test -s "target/vm-runtime-compressed/${file}"
           done
 

--- a/.github/workflows/driver-vm-macos.yml
+++ b/.github/workflows/driver-vm-macos.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Verify embedded driver inputs
         run: |
           set -euo pipefail
-          for file in libkrun.dylib.zst libkrunfw.5.dylib.zst gvproxy.zst openshell-sandbox.zst; do
+          for file in libkrun.dylib.zst libkrunfw.5.dylib.zst gvproxy.zst umoci.zst openshell-sandbox.zst; do
             test -s "target/vm-runtime-compressed-macos/${file}"
           done
 

--- a/.github/workflows/release-vm-kernel.yml
+++ b/.github/workflows/release-vm-kernel.yml
@@ -237,9 +237,9 @@ jobs:
 
             ### Kernel Runtime Artifacts
 
-            Pre-built kernel runtime (libkrunfw + libkrun + gvproxy) for embedding into
-            the `openshell-driver-vm` binary. These are rebuilt on demand when the kernel
-            config or pinned dependency versions change.
+            Pre-built kernel runtime (libkrunfw + libkrun + gvproxy + umoci) for embedding
+            into the `openshell-driver-vm` binary. These are rebuilt on demand when the
+            kernel config or pinned dependency versions change.
 
             | Platform | Artifact |
             |----------|----------|

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,14 +1,24 @@
 {
   "globs": [
-    "**/*.md",
-    "**/*.mdx"
+    "*.md",
+    "architecture/**/*.md",
+    "crates/**/*.md",
+    "deploy/**/*.md",
+    "docs/**/*.md",
+    "docs/**/*.mdx",
+    "e2e/**/*.md",
+    "examples/**/*.md",
+    "rfc/**/*.md"
   ],
-  "gitignore": true,
+  "gitignore": false,
   "ignores": [
     ".agents/**",
     ".claude/**",
     ".opencode/**",
     ".github/**",
+    "**/node_modules/**",
+    "target/**",
+    ".pytest_cache/**",
     "THIRD-PARTY-NOTICES/**",
     "CLAUDE.md",
     // Man page sources use pandoc markdown with multiple H1 sections

--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -23,7 +23,7 @@ Each runtime receives a sandbox spec from the gateway and is responsible for:
 | Docker | Local development with Docker available. | Container plus nested sandbox namespace. | Uses host networking so loopback gateway endpoints work from the supervisor. |
 | Podman | Rootless or single-machine deployments. | Container plus nested sandbox namespace. | Uses the Podman REST API, OCI image volumes, and CDI GPU devices when available. |
 | Kubernetes | Cluster deployment through Helm. | Pod plus nested sandbox namespace. | Uses Kubernetes API objects, service accounts, secrets, PVC-backed workspace storage, and GPU resources. |
-| VM | Experimental microVM isolation. | Per-sandbox libkrun VM. | Gateway spawns `openshell-driver-vm` as a subprocess over a private, state-local Unix socket. |
+| VM | Experimental microVM isolation. | Per-sandbox libkrun VM. | Gateway spawns `openshell-driver-vm` as a subprocess over a private, state-local Unix socket. The VM driver caches a prepared `rootfs.ext4` per source image and copies it per sandbox, so guest ownership metadata lives inside the ext4 filesystem instead of host directory entries. |
 
 Per-sandbox CPU and memory values currently enter the driver layer through
 template resource limits. Docker and Podman apply them as runtime limits.

--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -23,7 +23,7 @@ Each runtime receives a sandbox spec from the gateway and is responsible for:
 | Docker | Local development with Docker available. | Container plus nested sandbox namespace. | Uses host networking so loopback gateway endpoints work from the supervisor. |
 | Podman | Rootless or single-machine deployments. | Container plus nested sandbox namespace. | Uses the Podman REST API, OCI image volumes, and CDI GPU devices when available. |
 | Kubernetes | Cluster deployment through Helm. | Pod plus nested sandbox namespace. | Uses Kubernetes API objects, service accounts, secrets, PVC-backed workspace storage, and GPU resources. |
-| VM | Experimental microVM isolation. | Per-sandbox libkrun VM. | Gateway spawns `openshell-driver-vm` as a subprocess over a private, state-local Unix socket. The VM driver caches a prepared `rootfs.ext4` per source image and copies it per sandbox, so guest ownership metadata lives inside the ext4 filesystem instead of host directory entries. |
+| VM | Experimental microVM isolation. | Per-sandbox libkrun VM. | Gateway spawns `openshell-driver-vm` as a subprocess over a private, state-local Unix socket. The VM driver caches a prepared `rootfs.ext4` per source image, boots it read-only, and gives each sandbox a writable `overlay.ext4` for merged-root changes and runtime material. |
 
 Per-sandbox CPU and memory values currently enter the driver layer through
 template resource limits. Docker and Podman apply them as runtime limits.

--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -29,7 +29,7 @@ reason strings.
 | Docker | Local development with Docker available. | Container plus nested sandbox namespace. | Uses host networking so loopback gateway endpoints work from the supervisor. |
 | Podman | Rootless or single-machine deployments. | Container plus nested sandbox namespace. | Uses the Podman REST API, OCI image volumes, and CDI GPU devices when available. |
 | Kubernetes | Cluster deployment through Helm. | Pod plus nested sandbox namespace. | Uses Kubernetes API objects, service accounts, secrets, PVC-backed workspace storage, and GPU resources. |
-| VM | Experimental microVM isolation. | Per-sandbox libkrun VM. | Gateway spawns `openshell-driver-vm` as a subprocess over a private, state-local Unix socket. The VM driver caches a prepared `rootfs.ext4` per source image, boots it read-only, and gives each sandbox a writable `overlay.ext4` for merged-root changes and runtime material. |
+| VM | Experimental microVM isolation. | Per-sandbox libkrun VM. | Gateway spawns `openshell-driver-vm` as a subprocess over a private, state-local Unix socket. The VM driver boots a cached bootstrap `rootfs.ext4`, prepares requested OCI images inside a bootstrap VM with `umoci`, attaches the prepared image disk read-only, and gives each sandbox a writable `overlay.ext4` for merged-root changes and runtime material. |
 
 Per-sandbox CPU and memory values currently enter the driver layer through
 template resource limits. Docker and Podman apply them as runtime limits.

--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -16,6 +16,12 @@ Each runtime receives a sandbox spec from the gateway and is responsible for:
 - Reporting lifecycle and platform events back to the gateway.
 - Cleaning up runtime-owned resources.
 
+Drivers own runtime-specific platform event interpretation. When an event should
+drive client provisioning UI, the driver attaches the shared
+`openshell.progress.*` metadata defined in `openshell-core` instead of requiring
+clients to parse Kubernetes reasons, VM cache states, or other driver-local
+reason strings.
+
 ## Runtime Summary
 
 | Runtime | Best fit | Sandbox boundary | Notes |

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -23,6 +23,11 @@ use openshell_bootstrap::{
     remove_gateway_metadata, resolve_ssh_hostname, save_active_gateway, save_last_sandbox,
     store_gateway_metadata,
 };
+use openshell_core::progress::{
+    PROGRESS_ACTIVE_DETAIL_KEY, PROGRESS_ACTIVE_STEP_KEY, PROGRESS_COMPLETE_LABEL_KEY,
+    PROGRESS_COMPLETE_STEP_KEY, PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX,
+    PROGRESS_STEP_STARTING_SANDBOX,
+};
 use openshell_core::proto::ProviderProfileCategory;
 use openshell_core::proto::{
     ApproveAllDraftChunksRequest, ApproveDraftChunkRequest, AttachSandboxProviderRequest,
@@ -35,7 +40,7 @@ use openshell_core::proto::{
     GetSandboxRequest, GetServiceRequest, HealthRequest, ImportProviderProfilesRequest,
     LintProviderProfilesRequest, ListProviderProfilesRequest, ListProvidersRequest,
     ListSandboxPoliciesRequest, ListSandboxProvidersRequest, ListSandboxesRequest,
-    ListServicesRequest, PolicySource, PolicyStatus, Provider, ProviderProfile,
+    ListServicesRequest, PlatformEvent, PolicySource, PolicyStatus, Provider, ProviderProfile,
     ProviderProfileDiagnostic, ProviderProfileImportItem, RejectDraftChunkRequest,
     RevokeSshSessionRequest, Sandbox, SandboxPhase, SandboxPolicy, SandboxSpec, SandboxTemplate,
     ServiceEndpointResponse, SetClusterInferenceRequest, SettingScope, SettingValue,
@@ -196,26 +201,6 @@ impl ProvisioningStep {
     }
 }
 
-/// Kubernetes event reason codes we care about.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum KubeEventReason {
-    Scheduled,
-    Pulling,
-    Pulled,
-    Started,
-}
-
-/// Map a Kubernetes event reason string to an enum.
-fn parse_kube_event_reason(reason: &str) -> Option<KubeEventReason> {
-    match reason {
-        "Scheduled" => Some(KubeEventReason::Scheduled),
-        "Pulling" => Some(KubeEventReason::Pulling),
-        "Pulled" => Some(KubeEventReason::Pulled),
-        "Started" => Some(KubeEventReason::Started),
-        _ => None,
-    }
-}
-
 /// Live-updating display showing a provisioning step checklist with spinner.
 ///
 /// Completed steps are printed as static `✓ Step` lines.  The current
@@ -270,14 +255,6 @@ impl ProvisioningDisplay {
             active_detail: String::new(),
             step_start: now,
         }
-    }
-
-    /// Record a completed provisioning step.
-    ///
-    /// The step is printed as a static `✓` line and the spinner advances
-    /// to the next expected state.
-    fn complete_step(&mut self, step: ProvisioningStep) {
-        self.complete_step_with_label(step, step.completed_label());
     }
 
     /// Record a completed provisioning step with a custom label.
@@ -382,34 +359,80 @@ fn format_timestamp(d: Duration) -> String {
     format!("[{secs:.1}s]")
 }
 
-/// Extract image size in bytes from a Kubernetes Pulled event message.
-/// Example: "Successfully pulled image ... Image size: 620405524 bytes."
-fn extract_image_size(message: &str) -> Option<u64> {
-    let size_prefix = "Image size: ";
-    let start = message.find(size_prefix)? + size_prefix.len();
-    let rest = &message[start..];
-    let end = rest.find(' ')?;
-    rest[..end].parse().ok()
+fn progress_step_from_metadata(value: &str) -> Option<ProvisioningStep> {
+    match value {
+        PROGRESS_STEP_REQUESTING_SANDBOX => Some(ProvisioningStep::RequestingSandbox),
+        PROGRESS_STEP_PULLING_IMAGE => Some(ProvisioningStep::PullingSandboxImage),
+        PROGRESS_STEP_STARTING_SANDBOX => Some(ProvisioningStep::StartingSandbox),
+        _ => None,
+    }
 }
 
-/// Format bytes as a human-readable string (e.g., "620 MB").
-fn format_bytes(bytes: u64) -> String {
-    const KB: u64 = 1024;
-    const MB: u64 = 1024 * KB;
-    const GB: u64 = 1024 * MB;
+fn noninteractive_active_label(step: ProvisioningStep) -> String {
+    step.active_label().trim_end_matches('.').to_string()
+}
 
-    if bytes >= GB {
-        // GB-scale precision loss is acceptable for a human-readable label.
-        #[allow(clippy::cast_precision_loss)]
-        let gb = bytes as f64 / GB as f64;
-        format!("{gb:.1} GB")
-    } else if bytes >= MB {
-        format!("{} MB", bytes / MB)
-    } else if bytes >= KB {
-        format!("{} KB", bytes / KB)
-    } else {
-        format!("{bytes} B")
+fn handle_platform_progress_event(
+    event: &PlatformEvent,
+    display: &mut Option<ProvisioningDisplay>,
+    provision_start: Instant,
+) -> bool {
+    let completed_step = event
+        .metadata
+        .get(PROGRESS_COMPLETE_STEP_KEY)
+        .and_then(|step| progress_step_from_metadata(step));
+    let active_step = event
+        .metadata
+        .get(PROGRESS_ACTIVE_STEP_KEY)
+        .and_then(|step| progress_step_from_metadata(step));
+    let active_detail = event
+        .metadata
+        .get(PROGRESS_ACTIVE_DETAIL_KEY)
+        .filter(|detail| !detail.is_empty());
+
+    let handled = completed_step.is_some() || active_step.is_some() || active_detail.is_some();
+    if !handled {
+        return false;
     }
+
+    if let Some(step) = completed_step {
+        let label = event
+            .metadata
+            .get(PROGRESS_COMPLETE_LABEL_KEY)
+            .map_or_else(|| step.completed_label(), String::as_str);
+        if let Some(d) = display.as_mut() {
+            d.complete_step_with_label(step, label);
+        } else {
+            let ts = format_timestamp(provision_start.elapsed());
+            println!("{} {}", ts.dimmed(), label);
+        }
+    }
+
+    if let Some(step) = active_step
+        && let Some(d) = display.as_mut()
+    {
+        d.set_active_step(step);
+    }
+
+    if let Some(detail) = active_detail {
+        if let Some(d) = display.as_mut() {
+            d.set_active_detail(detail);
+        } else {
+            let ts = format_timestamp(provision_start.elapsed());
+            if let Some(step) = active_step {
+                println!(
+                    "{} {} {}",
+                    ts.dimmed(),
+                    noninteractive_active_label(step),
+                    detail
+                );
+            } else {
+                println!("{} {}", ts.dimmed(), detail);
+            }
+        }
+    }
+
+    true
 }
 
 fn print_sandbox_header(sandbox: &Sandbox, display: Option<&ProvisioningDisplay>) {
@@ -1720,7 +1743,7 @@ pub async fn sandbox_create(
             follow_logs: true,
             follow_events: true,
             log_tail_lines: 200,
-            event_tail: 0,
+            event_tail: 50,
             stop_on_terminal: false,
             log_since_ms: 0,
             log_sources: vec!["gateway".to_string()],
@@ -1735,7 +1758,6 @@ pub async fn sandbox_create(
     let mut last_condition_message = ready_false_condition_message(sandbox.status.as_ref());
     // Track whether we have seen a non-Ready phase during the watch.
     let mut saw_non_ready = SandboxPhase::try_from(sandbox.phase) != Ok(SandboxPhase::Ready);
-    let start_time = Instant::now();
     let provision_timeout = Duration::from_secs(
         std::env::var("OPENSHELL_PROVISION_TIMEOUT")
             .ok()
@@ -1746,10 +1768,10 @@ pub async fn sandbox_create(
     let mut saw_gateway_ready = false;
 
     loop {
-        // Compute remaining time so the timeout fires even when the stream
-        // produces no events (e.g. server-side producer died).
-        let remaining = provision_timeout.saturating_sub(start_time.elapsed());
-        let maybe_item = tokio::time::timeout(remaining, stream.next()).await;
+        // Timeout only when provisioning goes idle. VM first-create can spend
+        // longer than the default timeout pulling and preparing large images,
+        // but progress events should keep the CLI alive.
+        let maybe_item = tokio::time::timeout(provision_timeout, stream.next()).await;
 
         let item = match maybe_item {
             Ok(Some(item)) => item,
@@ -1795,6 +1817,7 @@ pub async fn sandbox_create(
                                 format!("{}: {}", condition.reason, condition.message);
                         }
                     }
+                    break;
                 }
 
                 // Only accept Ready as terminal after we've observed a
@@ -1813,76 +1836,11 @@ pub async fn sandbox_create(
                 }
             }
             Some(openshell_core::proto::sandbox_stream_event::Payload::Event(ev)) => {
-                // Map Kubernetes events to provisioning steps.
-                // We simplify the display to: Sandbox allocated -> Pulling image -> Ready
-                if let Some(reason) = parse_kube_event_reason(&ev.reason) {
-                    match reason {
-                        KubeEventReason::Scheduled => {
-                            if let Some(d) = display.as_mut() {
-                                d.complete_step_with_label(
-                                    ProvisioningStep::RequestingSandbox,
-                                    "Sandbox allocated",
-                                );
-                                d.set_active_step(ProvisioningStep::PullingSandboxImage);
-                            } else {
-                                let ts = format_timestamp(provision_start.elapsed());
-                                println!("{} Sandbox allocated", ts.dimmed());
-                            }
-                        }
-                        KubeEventReason::Pulling => {
-                            // Extract image name from the event message.
-                            let image_name = ev
-                                .message
-                                .strip_prefix("Pulling image ")
-                                .map_or("", |s| s.trim_matches('"'));
-                            if let Some(d) = display.as_mut() {
-                                d.set_active("Pulling image...");
-                                if !image_name.is_empty() {
-                                    d.set_active_detail(image_name);
-                                }
-                            } else {
-                                let ts = format_timestamp(provision_start.elapsed());
-                                if image_name.is_empty() {
-                                    println!("{} Pulling image...", ts.dimmed());
-                                } else {
-                                    println!("{} Pulling image {image_name}", ts.dimmed());
-                                }
-                            }
-                        }
-                        KubeEventReason::Pulled => {
-                            // Extract image size from message like:
-                            // "Successfully pulled image ... Image size: 620405524 bytes."
-                            let size_label = extract_image_size(&ev.message)
-                                .map(format_bytes)
-                                .unwrap_or_default();
-                            let label = if size_label.is_empty() {
-                                "Image pulled".to_string()
-                            } else {
-                                format!("Image pulled ({size_label})")
-                            };
-                            if let Some(d) = display.as_mut() {
-                                d.complete_step_with_label(
-                                    ProvisioningStep::PullingSandboxImage,
-                                    &label,
-                                );
-                                d.set_active_step(ProvisioningStep::StartingSandbox);
-                            } else {
-                                let ts = format_timestamp(provision_start.elapsed());
-                                println!("{} {}", ts.dimmed(), label);
-                            }
-                        }
-                        KubeEventReason::Started => {
-                            // Only complete StartingSandbox if we've already completed
-                            // PullingSandboxImage (meaning the container is starting).
-                            if let Some(d) = display.as_mut()
-                                && d.completed_steps
-                                    .contains(&ProvisioningStep::PullingSandboxImage)
-                            {
-                                d.complete_step(ProvisioningStep::StartingSandbox);
-                            }
-                        }
-                    }
-                } else if let Some(d) = display.as_mut() {
+                if handle_platform_progress_event(&ev, &mut display, provision_start) {
+                    continue;
+                }
+
+                if let Some(d) = display.as_mut() {
                     // Unknown events: show as detail on the current spinner.
                     if !ev.message.is_empty() {
                         d.set_active_detail(&ev.message);
@@ -6264,15 +6222,15 @@ fn format_timestamp_ms(ms: i64) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        TlsOptions, build_sandbox_resource_limits, dockerfile_sources_supported_for_gateway,
-        format_endpoint, format_gateway_select_header, format_gateway_select_items,
-        format_provider_attachment_table, gateway_add, gateway_auth_label,
-        gateway_env_override_warning, gateway_select_with, gateway_type_label, git_sync_files,
-        http_health_check, image_requests_gpu, import_local_package_mtls_bundle,
+        ProvisioningStep, TlsOptions, build_sandbox_resource_limits,
+        dockerfile_sources_supported_for_gateway, format_endpoint, format_gateway_select_header,
+        format_gateway_select_items, format_provider_attachment_table, gateway_add,
+        gateway_auth_label, gateway_env_override_warning, gateway_select_with, gateway_type_label,
+        git_sync_files, http_health_check, image_requests_gpu, import_local_package_mtls_bundle,
         inferred_provider_type, package_managed_tls_dirs, parse_cli_setting_value,
-        parse_credential_pairs, plaintext_gateway_is_remote, provisioning_timeout_message,
-        ready_false_condition_message, resolve_from, sandbox_should_persist,
-        service_expose_status_error, service_url_for_gateway,
+        parse_credential_pairs, plaintext_gateway_is_remote, progress_step_from_metadata,
+        provisioning_timeout_message, ready_false_condition_message, resolve_from,
+        sandbox_should_persist, service_expose_status_error, service_url_for_gateway,
     };
     use crate::TEST_ENV_LOCK;
     use hyper::StatusCode;
@@ -6286,6 +6244,10 @@ mod tests {
     use tonic::Status;
 
     use openshell_bootstrap::GatewayMetadata;
+    use openshell_core::progress::{
+        PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX,
+        PROGRESS_STEP_STARTING_SANDBOX,
+    };
     use openshell_core::proto::{
         Provider, SandboxCondition, SandboxStatus, datamodel::v1::ObjectMeta,
     };
@@ -6423,6 +6385,23 @@ mod tests {
         assert!(output.contains("custom-api"));
         assert!(output.contains('2'));
         assert!(output.contains('1'));
+    }
+
+    #[test]
+    fn progress_step_metadata_values_map_to_cli_steps() {
+        assert_eq!(
+            progress_step_from_metadata(PROGRESS_STEP_REQUESTING_SANDBOX),
+            Some(ProvisioningStep::RequestingSandbox)
+        );
+        assert_eq!(
+            progress_step_from_metadata(PROGRESS_STEP_PULLING_IMAGE),
+            Some(ProvisioningStep::PullingSandboxImage)
+        );
+        assert_eq!(
+            progress_step_from_metadata(PROGRESS_STEP_STARTING_SANDBOX),
+            Some(ProvisioningStep::StartingSandbox)
+        );
+        assert_eq!(progress_step_from_metadata("driver-private-step"), None);
     }
 
     #[cfg(feature = "dev-settings")]

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -435,6 +435,32 @@ fn handle_platform_progress_event(
     true
 }
 
+fn is_provisioning_progress_event(event: &PlatformEvent) -> bool {
+    if event.metadata.contains_key(PROGRESS_COMPLETE_STEP_KEY)
+        || event.metadata.contains_key(PROGRESS_ACTIVE_STEP_KEY)
+        || event.metadata.contains_key(PROGRESS_ACTIVE_DETAIL_KEY)
+    {
+        return true;
+    }
+
+    event.source == "vm"
+        && matches!(
+            event.reason.as_str(),
+            "PullingLayer"
+                | "ResolvingImage"
+                | "AuthenticatingRegistry"
+                | "FetchingManifest"
+                | "CacheHit"
+                | "CacheMiss"
+                | "WaitingForImageCacheLock"
+                | "ExportingRootfs"
+                | "PreparingRootfs"
+                | "CreatingRootDisk"
+                | "PreparingOverlay"
+                | "Started"
+        )
+}
+
 fn print_sandbox_header(sandbox: &Sandbox, display: Option<&ProvisioningDisplay>) {
     let lines = [
         String::new(),
@@ -1764,14 +1790,30 @@ pub async fn sandbox_create(
             .and_then(|v| v.parse().ok())
             .unwrap_or(300),
     );
+    let mut provisioning_idle_deadline = Instant::now() + provision_timeout;
     // Track whether we saw the gateway become ready (from log messages).
     let mut saw_gateway_ready = false;
 
     loop {
         // Timeout only when provisioning goes idle. VM first-create can spend
         // longer than the default timeout pulling and preparing large images,
-        // but progress events should keep the CLI alive.
-        let maybe_item = tokio::time::timeout(provision_timeout, stream.next()).await;
+        // but only recognized progress events extend the idle deadline. Logs
+        // and generic status churn must not keep a stuck sandbox alive forever.
+        let remaining = provisioning_idle_deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            let timeout_message = provisioning_timeout_message(
+                provision_timeout.as_secs(),
+                requested_gpu,
+                last_condition_message.as_deref(),
+            );
+            if let Some(d) = display.as_mut() {
+                d.finish_error(&timeout_message);
+            }
+            println!();
+            return Err(miette::miette!(timeout_message));
+        }
+
+        let maybe_item = tokio::time::timeout(remaining, stream.next()).await;
 
         let item = match maybe_item {
             Ok(Some(item)) => item,
@@ -1836,8 +1878,15 @@ pub async fn sandbox_create(
                 }
             }
             Some(openshell_core::proto::sandbox_stream_event::Payload::Event(ev)) => {
+                let extends_timeout = is_provisioning_progress_event(&ev);
                 if handle_platform_progress_event(&ev, &mut display, provision_start) {
+                    if extends_timeout {
+                        provisioning_idle_deadline = Instant::now() + provision_timeout;
+                    }
                     continue;
+                }
+                if extends_timeout {
+                    provisioning_idle_deadline = Instant::now() + provision_timeout;
                 }
 
                 if let Some(d) = display.as_mut() {

--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -21,14 +21,20 @@ use openshell_core::proto::{
     GetSandboxProviderEnvironmentResponse, GetSandboxRequest, HealthRequest, HealthResponse,
     ListProvidersRequest, ListProvidersResponse, ListSandboxProvidersRequest,
     ListSandboxProvidersResponse, ListSandboxesRequest, ListSandboxesResponse, PlatformEvent,
-    ProviderResponse, RevokeSshSessionRequest, RevokeSshSessionResponse, Sandbox, SandboxPhase,
-    SandboxResponse, SandboxStreamEvent, ServiceStatus, SupervisorMessage, UpdateProviderRequest,
-    WatchSandboxRequest, sandbox_stream_event,
+    ProviderResponse, RevokeSshSessionRequest, RevokeSshSessionResponse, Sandbox,
+    SandboxCondition, SandboxPhase, SandboxResponse, SandboxStatus, SandboxStreamEvent,
+    ServiceStatus, SupervisorMessage, UpdateProviderRequest, WatchSandboxRequest,
+    sandbox_stream_event,
+};
+use rcgen::{
+    BasicConstraints, Certificate, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyPair,
 };
 use std::collections::HashMap;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, mpsc};
@@ -40,6 +46,8 @@ use tonic::{Response, Status};
 struct SandboxState {
     deleted_names: Arc<Mutex<Vec<Vec<String>>>>,
     create_requests: Arc<Mutex<Vec<CreateSandboxRequest>>>,
+    vm_error_after_started: Arc<AtomicBool>,
+    vm_slow_progress_before_ready: Arc<AtomicBool>,
 }
 
 #[derive(Clone, Default)]
@@ -304,6 +312,11 @@ impl OpenShell for TestOpenShell {
     ) -> Result<Response<Self::WatchSandboxStream>, Status> {
         let sandbox_id = request.into_inner().id;
         let (tx, rx) = mpsc::channel(4);
+        let vm_error_after_started = self.state.vm_error_after_started.load(Ordering::SeqCst);
+        let vm_slow_progress_before_ready = self
+            .state
+            .vm_slow_progress_before_ready
+            .load(Ordering::SeqCst);
 
         tokio::spawn(async move {
             let provisioning = Sandbox {
@@ -316,6 +329,23 @@ impl OpenShell for TestOpenShell {
                 phase: SandboxPhase::Provisioning as i32,
                 ..Sandbox::default()
             };
+            let error = Sandbox {
+                phase: SandboxPhase::Error as i32,
+                status: Some(SandboxStatus {
+                    sandbox_name: sandbox_id.trim_start_matches("id-").to_string(),
+                    agent_pod: String::new(),
+                    agent_fd: String::new(),
+                    sandbox_fd: String::new(),
+                    conditions: vec![SandboxCondition {
+                        r#type: "Ready".to_string(),
+                        status: "False".to_string(),
+                        reason: "ProcessExited".to_string(),
+                        message: "VM process exited with status 0".to_string(),
+                        last_transition_time: String::new(),
+                    }],
+                }),
+                ..provisioning.clone()
+            };
             let ready = Sandbox {
                 phase: SandboxPhase::Ready as i32,
                 ..provisioning.clone()
@@ -326,6 +356,56 @@ impl OpenShell for TestOpenShell {
                     payload: Some(sandbox_stream_event::Payload::Sandbox(provisioning)),
                 }))
                 .await;
+            if vm_error_after_started {
+                let _ = tx
+                    .send(Ok(SandboxStreamEvent {
+                        payload: Some(sandbox_stream_event::Payload::Event(PlatformEvent {
+                            source: "vm".to_string(),
+                            reason: "Started".to_string(),
+                            message: "Started VM launcher".to_string(),
+                            ..PlatformEvent::default()
+                        })),
+                    }))
+                    .await;
+                let _ = tx
+                    .send(Ok(SandboxStreamEvent {
+                        payload: Some(sandbox_stream_event::Payload::Sandbox(error)),
+                    }))
+                    .await;
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                return;
+            }
+            if vm_slow_progress_before_ready {
+                tokio::time::sleep(Duration::from_millis(600)).await;
+                let _ = tx
+                    .send(Ok(SandboxStreamEvent {
+                        payload: Some(sandbox_stream_event::Payload::Event(PlatformEvent {
+                            source: "vm".to_string(),
+                            reason: "PreparingRootfs".to_string(),
+                            message: "Preparing rootfs".to_string(),
+                            ..PlatformEvent::default()
+                        })),
+                    }))
+                    .await;
+                tokio::time::sleep(Duration::from_millis(600)).await;
+                let _ = tx
+                    .send(Ok(SandboxStreamEvent {
+                        payload: Some(sandbox_stream_event::Payload::Event(PlatformEvent {
+                            source: "vm".to_string(),
+                            reason: "CreatingRootDisk".to_string(),
+                            message: "Formatting root disk".to_string(),
+                            ..PlatformEvent::default()
+                        })),
+                    }))
+                    .await;
+                tokio::time::sleep(Duration::from_millis(600)).await;
+                let _ = tx
+                    .send(Ok(SandboxStreamEvent {
+                        payload: Some(sandbox_stream_event::Payload::Sandbox(ready)),
+                    }))
+                    .await;
+                return;
+            }
             let _ = tx
                 .send(Ok(SandboxStreamEvent {
                     payload: Some(sandbox_stream_event::Payload::Event(PlatformEvent {
@@ -567,6 +647,14 @@ fn install_fake_ssh(dir: &TempDir) -> std::path::PathBuf {
 }
 
 fn test_env(fake_ssh_dir: &TempDir, xdg_dir: &TempDir) -> EnvVarGuard {
+    test_env_with(fake_ssh_dir, xdg_dir, &[])
+}
+
+fn test_env_with(
+    fake_ssh_dir: &TempDir,
+    xdg_dir: &TempDir,
+    extra: &[(&'static str, String)],
+) -> EnvVarGuard {
     let path = format!(
         "{}:{}",
         fake_ssh_dir.path().display(),
@@ -574,7 +662,18 @@ fn test_env(fake_ssh_dir: &TempDir, xdg_dir: &TempDir) -> EnvVarGuard {
     );
     let xdg = xdg_dir.path().to_str().unwrap().to_string();
 
-    EnvVarGuard::set(&[("PATH", &path), ("XDG_CONFIG_HOME", &xdg), ("HOME", &xdg)])
+    let mut owned_pairs = vec![
+        ("PATH", path),
+        ("XDG_CONFIG_HOME", xdg.clone()),
+        ("HOME", xdg),
+    ];
+    owned_pairs.extend(extra.iter().cloned());
+    let pairs = owned_pairs
+        .iter()
+        .map(|(key, value)| (*key, value.as_str()))
+        .collect::<Vec<_>>();
+
+    EnvVarGuard::set(&pairs)
 }
 
 async fn deleted_names(server: &TestServer) -> Vec<Vec<String>> {
@@ -606,6 +705,7 @@ async fn sandbox_create_keeps_command_sessions_by_default() {
         None,
         true,
         false,
+        None,
         None,
         None,
         None,
@@ -703,6 +803,102 @@ async fn sandbox_create_sends_cpu_and_memory_limits_only() {
         Some("2Gi")
     );
     assert!(!resources.fields.contains_key("requests"));
+}
+
+#[tokio::test]
+async fn sandbox_create_returns_vm_error_without_waiting_for_timeout() {
+    let server = run_server().await;
+    server
+        .openshell
+        .state
+        .vm_error_after_started
+        .store(true, Ordering::SeqCst);
+    let fake_ssh_dir = tempfile::tempdir().unwrap();
+    let xdg_dir = tempfile::tempdir().unwrap();
+    let _env = test_env_with(
+        &fake_ssh_dir,
+        &xdg_dir,
+        &[("OPENSHELL_PROVISION_TIMEOUT", "1".to_string())],
+    );
+    let tls = test_tls(&server);
+    install_fake_ssh(&fake_ssh_dir);
+
+    let started_at = Instant::now();
+    let err = run::sandbox_create(
+        &server.endpoint,
+        Some("vm-error"),
+        None,
+        "openshell",
+        None,
+        true,
+        false,
+        None,
+        None,
+        None,
+        None,
+        &[],
+        None,
+        None,
+        &["echo".to_string(), "OK".to_string()],
+        Some(false),
+        Some(false),
+        &HashMap::new(),
+        &tls,
+    )
+    .await
+    .expect_err("sandbox create should fail on terminal VM error");
+
+    assert!(
+        started_at.elapsed() < Duration::from_secs(2),
+        "terminal VM errors should not wait for the provisioning timeout"
+    );
+    let rendered = err.to_string();
+    assert!(rendered.contains("sandbox entered error phase while provisioning"));
+    assert!(rendered.contains("ProcessExited: VM process exited with status 0"));
+    assert!(!rendered.contains("timed out"));
+}
+
+#[tokio::test]
+async fn sandbox_create_keeps_waiting_while_vm_progress_arrives() {
+    let server = run_server().await;
+    server
+        .openshell
+        .state
+        .vm_slow_progress_before_ready
+        .store(true, Ordering::SeqCst);
+    let fake_ssh_dir = tempfile::tempdir().unwrap();
+    let xdg_dir = tempfile::tempdir().unwrap();
+    let _env = test_env_with(
+        &fake_ssh_dir,
+        &xdg_dir,
+        &[("OPENSHELL_PROVISION_TIMEOUT", "1".to_string())],
+    );
+    let tls = test_tls(&server);
+    install_fake_ssh(&fake_ssh_dir);
+
+    run::sandbox_create(
+        &server.endpoint,
+        Some("vm-slow-progress"),
+        None,
+        "openshell",
+        None,
+        true,
+        false,
+        None,
+        None,
+        None,
+        None,
+        &[],
+        None,
+        None,
+        &["echo".to_string(), "OK".to_string()],
+        Some(false),
+        Some(false),
+        &HashMap::new(),
+        &tls,
+    )
+    .await
+    .expect("sandbox create should not time out while VM progress is active");
 }
 
 #[tokio::test]

--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -26,9 +26,6 @@ use openshell_core::proto::{
     ServiceStatus, SupervisorMessage, UpdateProviderRequest, WatchSandboxRequest,
     sandbox_stream_event,
 };
-use rcgen::{
-    BasicConstraints, Certificate, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyPair,
-};
 use std::collections::HashMap;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -705,7 +702,6 @@ async fn sandbox_create_keeps_command_sessions_by_default() {
         None,
         true,
         false,
-        None,
         None,
         None,
         None,

--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -21,8 +21,8 @@ use openshell_core::proto::{
     GetSandboxProviderEnvironmentResponse, GetSandboxRequest, HealthRequest, HealthResponse,
     ListProvidersRequest, ListProvidersResponse, ListSandboxProvidersRequest,
     ListSandboxProvidersResponse, ListSandboxesRequest, ListSandboxesResponse, PlatformEvent,
-    ProviderResponse, RevokeSshSessionRequest, RevokeSshSessionResponse, Sandbox,
-    SandboxCondition, SandboxPhase, SandboxResponse, SandboxStatus, SandboxStreamEvent,
+    ProviderResponse, RevokeSshSessionRequest, RevokeSshSessionResponse, Sandbox, SandboxCondition,
+    SandboxLogLine, SandboxPhase, SandboxResponse, SandboxStatus, SandboxStreamEvent,
     ServiceStatus, SupervisorMessage, UpdateProviderRequest, WatchSandboxRequest,
     sandbox_stream_event,
 };
@@ -45,6 +45,7 @@ struct SandboxState {
     create_requests: Arc<Mutex<Vec<CreateSandboxRequest>>>,
     vm_error_after_started: Arc<AtomicBool>,
     vm_slow_progress_before_ready: Arc<AtomicBool>,
+    vm_log_churn_before_ready: Arc<AtomicBool>,
 }
 
 #[derive(Clone, Default)]
@@ -314,6 +315,7 @@ impl OpenShell for TestOpenShell {
             .state
             .vm_slow_progress_before_ready
             .load(Ordering::SeqCst);
+        let vm_log_churn_before_ready = self.state.vm_log_churn_before_ready.load(Ordering::SeqCst);
 
         tokio::spawn(async move {
             let provisioning = Sandbox {
@@ -370,6 +372,30 @@ impl OpenShell for TestOpenShell {
                     }))
                     .await;
                 tokio::time::sleep(Duration::from_secs(5)).await;
+                return;
+            }
+            if vm_log_churn_before_ready {
+                for message in ["still booting", "still booting again"] {
+                    tokio::time::sleep(Duration::from_millis(600)).await;
+                    let _ = tx
+                        .send(Ok(SandboxStreamEvent {
+                            payload: Some(sandbox_stream_event::Payload::Log(SandboxLogLine {
+                                sandbox_id: sandbox_id.clone(),
+                                timestamp_ms: 0,
+                                level: "INFO".to_string(),
+                                target: "test".to_string(),
+                                message: message.to_string(),
+                                source: "gateway".to_string(),
+                                fields: HashMap::new(),
+                            })),
+                        }))
+                        .await;
+                }
+                let _ = tx
+                    .send(Ok(SandboxStreamEvent {
+                        payload: Some(sandbox_stream_event::Payload::Sandbox(ready)),
+                    }))
+                    .await;
                 return;
             }
             if vm_slow_progress_before_ready {
@@ -895,6 +921,56 @@ async fn sandbox_create_keeps_waiting_while_vm_progress_arrives() {
     )
     .await
     .expect("sandbox create should not time out while VM progress is active");
+}
+
+#[tokio::test]
+async fn sandbox_create_times_out_when_only_logs_arrive() {
+    let server = run_server().await;
+    server
+        .openshell
+        .state
+        .vm_log_churn_before_ready
+        .store(true, Ordering::SeqCst);
+    let fake_ssh_dir = tempfile::tempdir().unwrap();
+    let xdg_dir = tempfile::tempdir().unwrap();
+    let _env = test_env_with(
+        &fake_ssh_dir,
+        &xdg_dir,
+        &[("OPENSHELL_PROVISION_TIMEOUT", "1".to_string())],
+    );
+    let tls = test_tls(&server);
+    install_fake_ssh(&fake_ssh_dir);
+
+    let started_at = Instant::now();
+    let err = run::sandbox_create(
+        &server.endpoint,
+        Some("vm-log-churn"),
+        None,
+        "openshell",
+        None,
+        true,
+        false,
+        None,
+        None,
+        None,
+        None,
+        &[],
+        None,
+        None,
+        &["echo".to_string(), "OK".to_string()],
+        Some(false),
+        Some(false),
+        &HashMap::new(),
+        &tls,
+    )
+    .await
+    .expect_err("sandbox create should time out when only logs arrive");
+
+    assert!(
+        started_at.elapsed() < Duration::from_secs(2),
+        "logs should not extend the provisioning timeout"
+    );
+    assert!(err.to_string().contains("sandbox provisioning timed out"));
 }
 
 #[tokio::test]

--- a/crates/openshell-core/src/lib.rs
+++ b/crates/openshell-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod inference;
 pub mod metadata;
 pub mod net;
 pub mod paths;
+pub mod progress;
 pub mod proto;
 pub mod sandbox_env;
 pub mod settings;

--- a/crates/openshell-core/src/progress.rs
+++ b/crates/openshell-core/src/progress.rs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared metadata keys for driver-provided sandbox provisioning progress.
+
+use std::collections::HashMap;
+use std::hash::BuildHasher;
+
+pub const PROGRESS_COMPLETE_STEP_KEY: &str = "openshell.progress.complete_step";
+pub const PROGRESS_COMPLETE_LABEL_KEY: &str = "openshell.progress.complete_label";
+pub const PROGRESS_ACTIVE_STEP_KEY: &str = "openshell.progress.active_step";
+pub const PROGRESS_ACTIVE_DETAIL_KEY: &str = "openshell.progress.active_detail";
+
+pub const PROGRESS_STEP_REQUESTING_SANDBOX: &str = "requesting_sandbox";
+pub const PROGRESS_STEP_PULLING_IMAGE: &str = "pulling_image";
+pub const PROGRESS_STEP_STARTING_SANDBOX: &str = "starting_sandbox";
+
+pub fn mark_progress_complete<S: BuildHasher>(
+    metadata: &mut HashMap<String, String, S>,
+    step: &'static str,
+    label: impl Into<String>,
+) {
+    metadata.insert(PROGRESS_COMPLETE_STEP_KEY.to_string(), step.to_string());
+    metadata.insert(PROGRESS_COMPLETE_LABEL_KEY.to_string(), label.into());
+}
+
+pub fn mark_progress_active<S: BuildHasher>(
+    metadata: &mut HashMap<String, String, S>,
+    step: &'static str,
+) {
+    metadata.insert(PROGRESS_ACTIVE_STEP_KEY.to_string(), step.to_string());
+}
+
+pub fn mark_progress_detail<S: BuildHasher>(
+    metadata: &mut HashMap<String, String, S>,
+    detail: impl Into<String>,
+) {
+    metadata.insert(PROGRESS_ACTIVE_DETAIL_KEY.to_string(), detail.into());
+}

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -1633,32 +1633,6 @@ mod tests {
     }
 
     #[test]
-    fn apply_required_env_always_injects_ssh_handshake_secret() {
-        let mut env = Vec::new();
-        apply_required_env(
-            &mut env,
-            "sandbox-1",
-            "my-sandbox",
-            "https://endpoint:8080",
-            "0.0.0.0:2222",
-            "my-secret-value",
-            300,
-            true,
-        );
-
-        let secret_entry = env
-            .iter()
-            .find(|e| {
-                e.get("name").and_then(|v| v.as_str()) == Some("OPENSHELL_SSH_HANDSHAKE_SECRET")
-            })
-            .expect("OPENSHELL_SSH_HANDSHAKE_SECRET must be present in env");
-        assert_eq!(
-            secret_entry.get("value").and_then(|v| v.as_str()),
-            Some("my-secret-value")
-        );
-    }
-
-    #[test]
     fn supervisor_sideload_injects_run_as_user_zero() {
         let mut pod_template = serde_json::json!({
             "spec": {

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -11,6 +11,10 @@ use kube::core::gvk::GroupVersionKind;
 use kube::core::{DynamicObject, ObjectMeta};
 use kube::runtime::watcher::{self, Event};
 use kube::{Client, Error as KubeError};
+use openshell_core::progress::{
+    PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX, PROGRESS_STEP_STARTING_SANDBOX,
+    mark_progress_active, mark_progress_complete, mark_progress_detail,
+};
 use openshell_core::proto::compute::v1::{
     DriverCondition as SandboxCondition, DriverPlatformEvent as PlatformEvent,
     DriverSandbox as Sandbox, DriverSandboxSpec as SandboxSpec,
@@ -646,6 +650,11 @@ fn map_kube_event_to_platform(
     if let Some(count) = obj.count {
         metadata.insert("count".to_string(), count.to_string());
     }
+    attach_kube_progress_metadata(
+        &mut metadata,
+        obj.reason.as_deref().unwrap_or_default(),
+        obj.message.as_deref().unwrap_or_default(),
+    );
 
     Some((
         sandbox_id,
@@ -658,6 +667,76 @@ fn map_kube_event_to_platform(
             metadata,
         },
     ))
+}
+
+fn attach_kube_progress_metadata(
+    metadata: &mut std::collections::HashMap<String, String>,
+    reason: &str,
+    message: &str,
+) {
+    match reason {
+        "Scheduled" => {
+            mark_progress_complete(
+                metadata,
+                PROGRESS_STEP_REQUESTING_SANDBOX,
+                "Sandbox allocated",
+            );
+            mark_progress_active(metadata, PROGRESS_STEP_PULLING_IMAGE);
+        }
+        "Pulling" => {
+            mark_progress_active(metadata, PROGRESS_STEP_PULLING_IMAGE);
+            if let Some(image) = pulling_image_from_kube_message(message) {
+                mark_progress_detail(metadata, image);
+            }
+        }
+        "Pulled" => {
+            let label = pulled_image_label(message);
+            mark_progress_complete(metadata, PROGRESS_STEP_PULLING_IMAGE, label);
+            mark_progress_active(metadata, PROGRESS_STEP_STARTING_SANDBOX);
+        }
+        _ => {}
+    }
+}
+
+fn pulling_image_from_kube_message(message: &str) -> Option<String> {
+    let image = message
+        .strip_prefix("Pulling image ")
+        .map(str::trim)
+        .map(|value| value.trim_matches('"'))?;
+    (!image.is_empty()).then(|| image.to_string())
+}
+
+fn pulled_image_label(message: &str) -> String {
+    extract_image_size(message).map_or_else(
+        || "Image pulled".to_string(),
+        |bytes| format!("Image pulled ({})", format_bytes(bytes)),
+    )
+}
+
+fn extract_image_size(message: &str) -> Option<u64> {
+    let size_prefix = "Image size: ";
+    let start = message.find(size_prefix)? + size_prefix.len();
+    let rest = &message[start..];
+    let end = rest.find(' ')?;
+    rest[..end].parse().ok()
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * KB;
+    const GB: u64 = 1024 * MB;
+
+    if bytes >= GB {
+        #[allow(clippy::cast_precision_loss)]
+        let gb = bytes as f64 / GB as f64;
+        format!("{gb:.1} GB")
+    } else if bytes >= MB {
+        format!("{} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("{} KB", bytes / KB)
+    } else {
+        format!("{bytes} B")
+    }
 }
 
 /// Path where the supervisor binary is mounted inside the agent container.
@@ -1501,7 +1580,83 @@ fn condition_from_value(value: &serde_json::Value) -> Option<SandboxCondition> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openshell_core::progress::{
+        PROGRESS_ACTIVE_DETAIL_KEY, PROGRESS_ACTIVE_STEP_KEY, PROGRESS_COMPLETE_LABEL_KEY,
+        PROGRESS_COMPLETE_STEP_KEY,
+    };
     use prost_types::{Struct, Value, value::Kind};
+
+    #[test]
+    fn kube_pulling_event_adds_image_progress_metadata() {
+        let mut metadata = std::collections::HashMap::new();
+
+        attach_kube_progress_metadata(
+            &mut metadata,
+            "Pulling",
+            "Pulling image \"ghcr.io/acme/sandbox:latest\"",
+        );
+
+        assert_eq!(
+            metadata.get(PROGRESS_ACTIVE_STEP_KEY).map(String::as_str),
+            Some(PROGRESS_STEP_PULLING_IMAGE)
+        );
+        assert_eq!(
+            metadata.get(PROGRESS_ACTIVE_DETAIL_KEY).map(String::as_str),
+            Some("ghcr.io/acme/sandbox:latest")
+        );
+    }
+
+    #[test]
+    fn kube_pulled_event_adds_completed_image_progress_metadata() {
+        let mut metadata = std::collections::HashMap::new();
+
+        attach_kube_progress_metadata(
+            &mut metadata,
+            "Pulled",
+            "Successfully pulled image \"ghcr.io/acme/sandbox:latest\". Image size: 44040192 bytes.",
+        );
+
+        assert_eq!(
+            metadata.get(PROGRESS_COMPLETE_STEP_KEY).map(String::as_str),
+            Some(PROGRESS_STEP_PULLING_IMAGE)
+        );
+        assert_eq!(
+            metadata
+                .get(PROGRESS_COMPLETE_LABEL_KEY)
+                .map(String::as_str),
+            Some("Image pulled (42 MB)")
+        );
+        assert_eq!(
+            metadata.get(PROGRESS_ACTIVE_STEP_KEY).map(String::as_str),
+            Some(PROGRESS_STEP_STARTING_SANDBOX)
+        );
+    }
+
+    #[test]
+    fn apply_required_env_always_injects_ssh_handshake_secret() {
+        let mut env = Vec::new();
+        apply_required_env(
+            &mut env,
+            "sandbox-1",
+            "my-sandbox",
+            "https://endpoint:8080",
+            "0.0.0.0:2222",
+            "my-secret-value",
+            300,
+            true,
+        );
+
+        let secret_entry = env
+            .iter()
+            .find(|e| {
+                e.get("name").and_then(|v| v.as_str()) == Some("OPENSHELL_SSH_HANDSHAKE_SECRET")
+            })
+            .expect("OPENSHELL_SSH_HANDSHAKE_SECRET must be present in env");
+        assert_eq!(
+            secret_entry.get("value").and_then(|v| v.as_str()),
+            Some("my-secret-value")
+        );
+    }
 
     #[test]
     fn supervisor_sideload_injects_run_as_user_zero() {

--- a/crates/openshell-driver-vm/README.md
+++ b/crates/openshell-driver-vm/README.md
@@ -2,7 +2,7 @@
 
 > Status: Experimental. The VM compute driver is under active development and the interface still has VM-specific plumbing that will be generalized.
 
-Standalone libkrun-backed [`ComputeDriver`](../../proto/compute_driver.proto) for OpenShell. The gateway spawns this binary as a subprocess, talks to it over a Unix domain socket with the `openshell.compute.v1.ComputeDriver` gRPC surface, and lets it manage per-sandbox microVMs. The runtime (libkrun + libkrunfw + gvproxy) and the sandbox supervisor are embedded directly in the binary; each sandbox guest rootfs is derived from a configured container image at create time.
+Standalone libkrun-backed [`ComputeDriver`](../../proto/compute_driver.proto) for OpenShell. The gateway spawns this binary as a subprocess, talks to it over a Unix domain socket with the `openshell.compute.v1.ComputeDriver` gRPC surface, and lets it manage per-sandbox microVMs. The runtime (libkrun + libkrunfw + gvproxy) and the sandbox supervisor are embedded directly in the binary; each sandbox boots from a copied ext4 root disk derived from the configured container image.
 
 ## How it fits together
 
@@ -42,7 +42,7 @@ By default `mise run gateway:vm`:
 - Listens on plaintext HTTP at `127.0.0.1:18081`.
 - Registers the CLI gateway `vm-dev` by writing `~/.config/openshell/gateways/vm-dev/metadata.json`. It does not modify the workspace `.env`.
 - Persists the gateway SQLite DB under `.cache/gateway-vm/gateway.db`.
-- Places the VM driver state (per-sandbox rootfs plus `run/compute-driver.sock`) under `/tmp/openshell-vm-driver-$USER-vm-dev/` so the AF_UNIX socket path stays under macOS `SUN_LEN`.
+- Places the VM driver state (per-sandbox `rootfs.ext4`, image cache, and `run/compute-driver.sock`) under `/tmp/openshell-vm-driver-$USER-vm-dev/` so the AF_UNIX socket path stays under macOS `SUN_LEN`.
 - Writes `.cache/gateway-vm/gateway.toml` with `[openshell.drivers.vm].driver_dir = "$PWD/target/debug"` so the freshly built `openshell-driver-vm` is used instead of an older installed copy from `~/.local/libexec/openshell`, `/usr/libexec/openshell`, or `/usr/local/libexec`.
 
 For GPU passthrough (VFIO), pass `-- --gpu` and run with root privileges:
@@ -131,7 +131,20 @@ The gateway resolves `openshell-driver-vm` in this order: `[openshell.drivers.vm
 
 ## Gateway And Driver Configuration
 
-Select the VM driver with `--drivers vm` or `OPENSHELL_DRIVERS=vm`. Configure VM-specific settings in `[openshell.drivers.vm]`: `grpc_endpoint`, `state_dir`, `driver_dir`, `vcpus`, `mem_mib`, `krun_log_level`, and `guest_tls_*`.
+Select the VM driver with `--drivers vm`, `OPENSHELL_DRIVERS=vm`, or `compute_drivers = ["vm"]` in `[openshell.gateway]`. Configure VM-specific settings in `[openshell.drivers.vm]`.
+
+| Configuration key | Default | Purpose |
+|---|---|---|
+| `grpc_endpoint` | empty | Required. URL the sandbox guest dials to reach the gateway. Use `http://host.containers.internal:<port>` (or `host.docker.internal` / `host.openshell.internal`) so traffic flows through gvproxy's host-loopback NAT (HostIP `192.168.127.254` → host `127.0.0.1`). Loopback URLs like `http://127.0.0.1:<port>` are rewritten automatically by the driver. The bare gateway IP (`192.168.127.1`) only carries gvproxy's own services and will not reach host-bound ports. |
+| `state_dir` | `target/openshell-vm-driver` | Per-sandbox root disk images, console logs, image cache, and private `run/compute-driver.sock` UDS. |
+| `driver_dir` | unset | Override the directory searched for `openshell-driver-vm`. |
+| `default_image` | OpenShell base image | Sandbox image used when a create request omits one. |
+| `vcpus` | `2` | vCPUs per sandbox. |
+| `mem_mib` | `2048` | Memory per sandbox, in MiB. |
+| `krun_log_level` | `1` | libkrun verbosity (0-5). |
+| `guest_tls_ca` | unset | CA cert for the guest's mTLS client bundle. Required when `grpc_endpoint` uses `https://`. |
+| `guest_tls_cert` | unset | Guest client certificate. |
+| `guest_tls_key` | unset | Guest client private key. |
 
 See [`openshell-gateway --help`](../openshell-server/src/cli.rs) for the gateway process flag surface.
 
@@ -145,7 +158,15 @@ The gateway is auto-registered by `mise run gateway:vm`. In another terminal:
 ./scripts/bin/openshell sandbox connect demo
 ```
 
-First sandbox takes 10–30 seconds to boot (image fetch/prepare/cache + libkrun + guest init). If `--from` is omitted, the VM driver uses the gateway's configured default sandbox image. Without either `--from` or `--sandbox-image`, VM sandbox creation fails. Subsequent creates reuse the prepared sandbox rootfs.
+First sandbox takes 10–30 seconds to boot (image fetch/prepare/cache + libkrun + guest init). If `--from` is omitted, the VM driver uses the gateway's configured default sandbox image. Without either `--from` or `--sandbox-image`, VM sandbox creation fails. Subsequent creates reuse the prepared image cache and copy its sparse root disk into the sandbox state directory before boot.
+
+During rootfs preparation the VM driver exports or pulls the selected OCI image,
+applies the OpenShell guest mutations, formats a sparse `rootfs.ext4`, and
+caches it under `<state-dir>/images/<cache-id>/rootfs.ext4`. Each sandbox gets
+its own copied `rootfs.ext4` under `<state-dir>/sandboxes/<id>/`. The host owns
+only the image file; guest ownership such as `/sandbox` UID/GID metadata lives
+inside the ext4 filesystem and is corrected by guest init before the supervisor
+starts.
 
 ## Logs and debugging
 
@@ -162,6 +183,7 @@ The VM guest's serial console is appended to `<state-dir>/<sandbox-id>/console.l
 
 - macOS on Apple Silicon, or Linux on aarch64/x86_64 with KVM
 - Rust toolchain
+- e2fsprogs (`mke2fs` or `mkfs.ext4`, plus `debugfs`) for root disk image creation and per-sandbox file injection
 - Guest-supervisor cross-compile toolchain (needed on macOS, and on Linux when host arch ≠ guest arch):
   - Matching rustup target: `rustup target add aarch64-unknown-linux-gnu` (or `x86_64-unknown-linux-gnu` for an amd64 guest)
   - `cargo install --locked cargo-zigbuild` and `brew install zig` (or distro equivalent). `vm:supervisor` uses `cargo zigbuild` to cross-compile the in-VM `openshell-sandbox` supervisor binary.

--- a/crates/openshell-driver-vm/README.md
+++ b/crates/openshell-driver-vm/README.md
@@ -2,7 +2,7 @@
 
 > Status: Experimental. The VM compute driver is under active development and the interface still has VM-specific plumbing that will be generalized.
 
-Standalone libkrun-backed [`ComputeDriver`](../../proto/compute_driver.proto) for OpenShell. The gateway spawns this binary as a subprocess, talks to it over a Unix domain socket with the `openshell.compute.v1.ComputeDriver` gRPC surface, and lets it manage per-sandbox microVMs. The runtime (libkrun + libkrunfw + gvproxy) and the sandbox supervisor are embedded directly in the binary; each sandbox boots from a cached immutable ext4 root disk derived from the configured container image plus a per-sandbox writable overlay disk.
+Standalone libkrun-backed [`ComputeDriver`](../../proto/compute_driver.proto) for OpenShell. The gateway spawns this binary as a subprocess, talks to it over a Unix domain socket with the `openshell.compute.v1.ComputeDriver` gRPC surface, and lets it manage per-sandbox microVMs. The runtime (libkrun + libkrunfw + gvproxy), guest OCI unpacker, and sandbox supervisor are embedded directly in the binary; each sandbox boots from a cached immutable bootstrap ext4 root disk plus a per-sandbox writable overlay disk. When the requested sandbox image differs from the bootstrap image, the driver prepares a read-only image ext4 disk inside a bootstrap VM and mounts that unpacked rootfs as the sandbox lowerdir.
 
 ## How it fits together
 
@@ -35,7 +35,7 @@ Sandbox guests execute `/opt/openshell/bin/openshell-sandbox` as PID 1 inside th
 mise run gateway:vm
 ```
 
-First run takes a few minutes while `mise run vm:setup` stages libkrun/libkrunfw/gvproxy and `mise run vm:supervisor` builds the bundled guest supervisor. Subsequent runs are cached.
+First run takes a few minutes while `mise run vm:setup` stages libkrun/libkrunfw/gvproxy/umoci and `mise run vm:supervisor` builds the bundled guest supervisor. Subsequent runs are cached.
 
 By default `mise run gateway:vm`:
 
@@ -75,6 +75,9 @@ mise run gateway:vm
 
 # custom sandbox image
 OPENSHELL_SANDBOX_IMAGE=ghcr.io/example/sandbox:latest mise run gateway:vm
+
+# custom bootstrap image for the VM runtime used to prepare/boot target images
+OPENSHELL_VM_BOOTSTRAP_IMAGE=ghcr.io/example/bootstrap:latest mise run gateway:vm
 ```
 
 Teardown:
@@ -139,6 +142,7 @@ Select the VM driver with `--drivers vm`, `OPENSHELL_DRIVERS=vm`, or `compute_dr
 | `state_dir` | `target/openshell-vm-driver` | Per-sandbox overlay disks, console logs, image cache, and private `run/compute-driver.sock` UDS. |
 | `driver_dir` | unset | Override the directory searched for `openshell-driver-vm`. |
 | `default_image` | OpenShell base image | Sandbox image used when a create request omits one. |
+| `bootstrap_image` | unset | VM runtime image used as the immutable bootstrap root disk. Defaults to the sandbox image when unset. |
 | `vcpus` | `2` | vCPUs per sandbox. |
 | `mem_mib` | `2048` | Memory per sandbox, in MiB. |
 | `overlay_disk_mib` | `4096` | Sparse writable overlay disk size per sandbox, in MiB. |
@@ -166,16 +170,24 @@ background. The driver publishes platform events for image resolution, cache
 hits/misses, layer pulls, rootfs preparation, overlay creation, and VM launcher
 startup so the CLI can show progress through the existing sandbox watch stream.
 
-During rootfs preparation the VM driver exports or pulls the selected OCI image,
-applies the OpenShell guest mutations, formats a sparse `rootfs.ext4`, and
-caches it under `<state-dir>/images/<cache-id>/rootfs.ext4`. Registry layers are
-downloaded, verified, and extracted concurrently, then applied in image order. Set
-`OPENSHELL_VM_IMAGE_PULL_CONCURRENCY` to tune registry layer download
-parallelism (default `4`, maximum `16`). Each sandbox boots that cached base
-disk read-only and gets its own sparse writable
-`<state-dir>/sandboxes/<id>/overlay.ext4`. Guest init mounts overlayfs as `/`,
-so writes to `/sandbox` and other mutable paths land in the overlay while the
-cached root image remains unchanged.
+The VM driver keeps two image caches. The bootstrap cache is a controlled
+`rootfs.ext4` used to boot the guest init and OpenShell supervisor. The prepared
+image cache is used when the requested sandbox image differs from the bootstrap
+image: the host downloads registry layers into a valid OCI layout, attaches that
+payload to a temporary bootstrap VM, and guest init runs `umoci raw unpack` onto
+Linux-owned ext4 storage. The resulting disk is cached under
+`<state-dir>/images/<cache-id>/rootfs.ext4` and attached read-only to later
+sandboxes. Local Docker images are still exported as rootfs tar archives and
+prepared inside the bootstrap VM. Set `OPENSHELL_VM_IMAGE_PULL_CONCURRENCY` to
+tune registry layer download parallelism (default `4`, maximum `16`).
+
+Each sandbox gets its own sparse writable
+`<state-dir>/sandboxes/<id>/overlay.ext4`. Guest init mounts overlayfs as `/`
+with the prepared image rootfs as lowerdir when present, otherwise the bootstrap
+rootfs is used directly. Writes to `/sandbox` and other mutable paths land in
+the overlay while cached image disks remain unchanged. The overlay disk must be
+large enough to hold the compressed payload, unpacked rootfs, and sandbox writes
+during the first prepare.
 
 ## Logs and debugging
 

--- a/crates/openshell-driver-vm/README.md
+++ b/crates/openshell-driver-vm/README.md
@@ -161,10 +161,18 @@ The gateway is auto-registered by `mise run gateway:vm`. In another terminal:
 
 First sandbox takes 10–30 seconds to boot (image fetch/prepare/cache + libkrun + guest init). If `--from` is omitted, the VM driver uses the gateway's configured default sandbox image. Without either `--from` or `--sandbox-image`, VM sandbox creation fails. Subsequent creates reuse the prepared image cache and create only a sparse per-sandbox `overlay.ext4` before boot.
 
+`CreateSandbox` accepts the sandbox quickly and continues VM provisioning in the
+background. The driver publishes platform events for image resolution, cache
+hits/misses, layer pulls, rootfs preparation, overlay creation, and VM launcher
+startup so the CLI can show progress through the existing sandbox watch stream.
+
 During rootfs preparation the VM driver exports or pulls the selected OCI image,
 applies the OpenShell guest mutations, formats a sparse `rootfs.ext4`, and
-caches it under `<state-dir>/images/<cache-id>/rootfs.ext4`. Each sandbox boots
-that cached base disk read-only and gets its own sparse writable
+caches it under `<state-dir>/images/<cache-id>/rootfs.ext4`. Registry layers are
+downloaded, verified, and extracted concurrently, then applied in image order. Set
+`OPENSHELL_VM_IMAGE_PULL_CONCURRENCY` to tune registry layer download
+parallelism (default `4`, maximum `16`). Each sandbox boots that cached base
+disk read-only and gets its own sparse writable
 `<state-dir>/sandboxes/<id>/overlay.ext4`. Guest init mounts overlayfs as `/`,
 so writes to `/sandbox` and other mutable paths land in the overlay while the
 cached root image remains unchanged.

--- a/crates/openshell-driver-vm/README.md
+++ b/crates/openshell-driver-vm/README.md
@@ -2,7 +2,7 @@
 
 > Status: Experimental. The VM compute driver is under active development and the interface still has VM-specific plumbing that will be generalized.
 
-Standalone libkrun-backed [`ComputeDriver`](../../proto/compute_driver.proto) for OpenShell. The gateway spawns this binary as a subprocess, talks to it over a Unix domain socket with the `openshell.compute.v1.ComputeDriver` gRPC surface, and lets it manage per-sandbox microVMs. The runtime (libkrun + libkrunfw + gvproxy) and the sandbox supervisor are embedded directly in the binary; each sandbox boots from a copied ext4 root disk derived from the configured container image.
+Standalone libkrun-backed [`ComputeDriver`](../../proto/compute_driver.proto) for OpenShell. The gateway spawns this binary as a subprocess, talks to it over a Unix domain socket with the `openshell.compute.v1.ComputeDriver` gRPC surface, and lets it manage per-sandbox microVMs. The runtime (libkrun + libkrunfw + gvproxy) and the sandbox supervisor are embedded directly in the binary; each sandbox boots from a cached immutable ext4 root disk derived from the configured container image plus a per-sandbox writable overlay disk.
 
 ## How it fits together
 
@@ -42,7 +42,7 @@ By default `mise run gateway:vm`:
 - Listens on plaintext HTTP at `127.0.0.1:18081`.
 - Registers the CLI gateway `vm-dev` by writing `~/.config/openshell/gateways/vm-dev/metadata.json`. It does not modify the workspace `.env`.
 - Persists the gateway SQLite DB under `.cache/gateway-vm/gateway.db`.
-- Places the VM driver state (per-sandbox `rootfs.ext4`, image cache, and `run/compute-driver.sock`) under `/tmp/openshell-vm-driver-$USER-vm-dev/` so the AF_UNIX socket path stays under macOS `SUN_LEN`.
+- Places the VM driver state (per-sandbox `overlay.ext4`, image cache, and `run/compute-driver.sock`) under `/tmp/openshell-vm-driver-$USER-vm-dev/` so the AF_UNIX socket path stays under macOS `SUN_LEN`.
 - Writes `.cache/gateway-vm/gateway.toml` with `[openshell.drivers.vm].driver_dir = "$PWD/target/debug"` so the freshly built `openshell-driver-vm` is used instead of an older installed copy from `~/.local/libexec/openshell`, `/usr/libexec/openshell`, or `/usr/local/libexec`.
 
 For GPU passthrough (VFIO), pass `-- --gpu` and run with root privileges:
@@ -136,11 +136,12 @@ Select the VM driver with `--drivers vm`, `OPENSHELL_DRIVERS=vm`, or `compute_dr
 | Configuration key | Default | Purpose |
 |---|---|---|
 | `grpc_endpoint` | empty | Required. URL the sandbox guest dials to reach the gateway. Use `http://host.containers.internal:<port>` (or `host.docker.internal` / `host.openshell.internal`) so traffic flows through gvproxy's host-loopback NAT (HostIP `192.168.127.254` → host `127.0.0.1`). Loopback URLs like `http://127.0.0.1:<port>` are rewritten automatically by the driver. The bare gateway IP (`192.168.127.1`) only carries gvproxy's own services and will not reach host-bound ports. |
-| `state_dir` | `target/openshell-vm-driver` | Per-sandbox root disk images, console logs, image cache, and private `run/compute-driver.sock` UDS. |
+| `state_dir` | `target/openshell-vm-driver` | Per-sandbox overlay disks, console logs, image cache, and private `run/compute-driver.sock` UDS. |
 | `driver_dir` | unset | Override the directory searched for `openshell-driver-vm`. |
 | `default_image` | OpenShell base image | Sandbox image used when a create request omits one. |
 | `vcpus` | `2` | vCPUs per sandbox. |
 | `mem_mib` | `2048` | Memory per sandbox, in MiB. |
+| `overlay_disk_mib` | `4096` | Sparse writable overlay disk size per sandbox, in MiB. |
 | `krun_log_level` | `1` | libkrun verbosity (0-5). |
 | `guest_tls_ca` | unset | CA cert for the guest's mTLS client bundle. Required when `grpc_endpoint` uses `https://`. |
 | `guest_tls_cert` | unset | Guest client certificate. |
@@ -158,15 +159,15 @@ The gateway is auto-registered by `mise run gateway:vm`. In another terminal:
 ./scripts/bin/openshell sandbox connect demo
 ```
 
-First sandbox takes 10–30 seconds to boot (image fetch/prepare/cache + libkrun + guest init). If `--from` is omitted, the VM driver uses the gateway's configured default sandbox image. Without either `--from` or `--sandbox-image`, VM sandbox creation fails. Subsequent creates reuse the prepared image cache and copy its sparse root disk into the sandbox state directory before boot.
+First sandbox takes 10–30 seconds to boot (image fetch/prepare/cache + libkrun + guest init). If `--from` is omitted, the VM driver uses the gateway's configured default sandbox image. Without either `--from` or `--sandbox-image`, VM sandbox creation fails. Subsequent creates reuse the prepared image cache and create only a sparse per-sandbox `overlay.ext4` before boot.
 
 During rootfs preparation the VM driver exports or pulls the selected OCI image,
 applies the OpenShell guest mutations, formats a sparse `rootfs.ext4`, and
-caches it under `<state-dir>/images/<cache-id>/rootfs.ext4`. Each sandbox gets
-its own copied `rootfs.ext4` under `<state-dir>/sandboxes/<id>/`. The host owns
-only the image file; guest ownership such as `/sandbox` UID/GID metadata lives
-inside the ext4 filesystem and is corrected by guest init before the supervisor
-starts.
+caches it under `<state-dir>/images/<cache-id>/rootfs.ext4`. Each sandbox boots
+that cached base disk read-only and gets its own sparse writable
+`<state-dir>/sandboxes/<id>/overlay.ext4`. Guest init mounts overlayfs as `/`,
+so writes to `/sandbox` and other mutable paths land in the overlay while the
+cached root image remains unchanged.
 
 ## Logs and debugging
 
@@ -183,7 +184,7 @@ The VM guest's serial console is appended to `<state-dir>/<sandbox-id>/console.l
 
 - macOS on Apple Silicon, or Linux on aarch64/x86_64 with KVM
 - Rust toolchain
-- e2fsprogs (`mke2fs` or `mkfs.ext4`, plus `debugfs`) for root disk image creation and per-sandbox file injection
+- e2fsprogs (`mke2fs` or `mkfs.ext4`, plus `debugfs`) for root and overlay disk image creation and QEMU environment injection
 - Guest-supervisor cross-compile toolchain (needed on macOS, and on Linux when host arch ≠ guest arch):
   - Matching rustup target: `rustup target add aarch64-unknown-linux-gnu` (or `x86_64-unknown-linux-gnu` for an amd64 guest)
   - `cargo install --locked cargo-zigbuild` and `brew install zig` (or distro equivalent). `vm:supervisor` uses `cargo zigbuild` to cross-compile the in-VM `openshell-sandbox` supervisor binary.

--- a/crates/openshell-driver-vm/build.rs
+++ b/crates/openshell-driver-vm/build.rs
@@ -21,6 +21,7 @@ fn main() {
             "libkrunfw.5.dylib.zst",
             "gvproxy.zst",
             "openshell-sandbox.zst",
+            "umoci.zst",
         ] {
             println!("cargo:rerun-if-changed={dir}/{name}");
         }
@@ -35,7 +36,10 @@ fn main() {
         "linux" => ("libkrun.so", "libkrunfw.so.5"),
         _ => {
             println!("cargo:warning=VM runtime not available for {target_os}-{target_arch}");
-            generate_stub_resources(&out_dir, &["libkrun", "libkrunfw", "openshell-sandbox.zst"]);
+            generate_stub_resources(
+                &out_dir,
+                &["libkrun", "libkrunfw", "openshell-sandbox.zst", "umoci.zst"],
+            );
             return;
         }
     };
@@ -52,6 +56,7 @@ fn main() {
                 &format!("{libkrunfw_name}.zst"),
                 "gvproxy.zst",
                 "openshell-sandbox.zst",
+                "umoci.zst",
             ],
         );
         return;
@@ -70,6 +75,7 @@ fn main() {
                 &format!("{libkrunfw_name}.zst"),
                 "gvproxy.zst",
                 "openshell-sandbox.zst",
+                "umoci.zst",
             ],
         );
         return;
@@ -86,6 +92,7 @@ fn main() {
             "openshell-sandbox.zst".to_string(),
             "openshell-sandbox.zst".to_string(),
         ),
+        ("umoci.zst".to_string(), "umoci.zst".to_string()),
     ];
 
     let mut all_found = true;
@@ -128,6 +135,7 @@ fn main() {
                 &format!("{libkrunfw_name}.zst"),
                 "gvproxy.zst",
                 "openshell-sandbox.zst",
+                "umoci.zst",
             ],
         );
     }

--- a/crates/openshell-driver-vm/runtime/README.md
+++ b/crates/openshell-driver-vm/runtime/README.md
@@ -11,8 +11,8 @@ runtime/
     openshell.kconfig
 ```
 
-`openshell-driver-vm` embeds libkrun, libkrunfw, gvproxy, and the bundled
-`openshell-sandbox` supervisor.
+`openshell-driver-vm` embeds libkrun, libkrunfw, gvproxy, umoci for guest-side
+OCI image unpacking, and the bundled `openshell-sandbox` supervisor.
 
 ## Why
 
@@ -27,7 +27,7 @@ VM sandboxes can run the same supervisor enforcement path as other backends.
 |---|---|---|
 | `tasks/scripts/vm/build-libkrun.sh` | Linux | Builds libkrunfw and libkrun from source with the custom kernel config |
 | `tasks/scripts/vm/build-libkrun-macos.sh` | macOS | Builds portable libkrunfw and libkrun from a prebuilt `kernel.c` |
-| `tasks/scripts/vm/package-vm-runtime.sh` | Any | Packages `vm-runtime-<platform>.tar.zst` with libraries, gvproxy, and provenance |
+| `tasks/scripts/vm/package-vm-runtime.sh` | Any | Packages `vm-runtime-<platform>.tar.zst` with libraries, gvproxy, umoci, and provenance |
 | `tasks/scripts/vm/download-kernel-runtime.sh` | Any | Downloads runtime tarballs from the `vm-runtime` release and stages compressed files |
 
 ## Local Flow
@@ -62,8 +62,9 @@ publish the driver binary next to `openshell-gateway`.
 ## Provenance
 
 `package-vm-runtime.sh` writes `provenance.json` into each runtime tarball with
-the platform, libkrunfw commit, kernel version, GitHub SHA, and build time. The
-driver logs this metadata when it extracts and loads a runtime bundle.
+the platform, libkrunfw commit, kernel version, gvproxy and umoci versions,
+GitHub SHA, and build time. The driver logs this metadata when it extracts and
+loads a runtime bundle.
 
 The release workflow also publishes GitHub artifact attestations for each
 runtime tarball. Verify a downloaded runtime with:

--- a/crates/openshell-driver-vm/runtime/kernel/openshell.kconfig
+++ b/crates/openshell-driver-vm/runtime/kernel/openshell.kconfig
@@ -8,6 +8,13 @@
 #
 # See also: check-vm-capabilities.sh for runtime verification.
 
+# ── Root disk transport and filesystem ─────────────────────────────────
+CONFIG_BLOCK=y
+CONFIG_BLK_DEV=y
+CONFIG_VIRTIO_BLK=y
+CONFIG_EXT4_FS=y
+CONFIG_EXT4_USE_FOR_EXT2=y
+
 # ── Network Namespaces (required for pod isolation) ─────────────────────
 CONFIG_NET_NS=y
 CONFIG_NAMESPACES=y

--- a/crates/openshell-driver-vm/runtime/pins.env
+++ b/crates/openshell-driver-vm/runtime/pins.env
@@ -33,6 +33,10 @@ COMMUNITY_SANDBOX_IMAGE="${COMMUNITY_SANDBOX_IMAGE:-ghcr.io/nvidia/openshell-com
 # Repo: https://github.com/containers/gvisor-tap-vsock
 GVPROXY_VERSION="${GVPROXY_VERSION:-v0.8.8}"
 
+# ── umoci (guest OCI unpacker) ──────────────────────────────────────────
+# Repo: https://github.com/opencontainers/umoci
+UMOCI_VERSION="${UMOCI_VERSION:-v0.6.0}"
+
 # ── libkrunfw upstream (commit-pinned) ─────────────────────────────────
 # Repo: https://github.com/containers/libkrunfw
 # Pinned: 2026-03-27 (main branch HEAD at time of pinning)

--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -239,7 +239,8 @@ setup_gpu() {
         return 1
     fi
 
-    # Stage GSP firmware from virtiofs to tmpfs to avoid slow FUSE reads
+    # Stage GSP firmware to tmpfs so module loading reads it from a stable
+    # early-boot path.
     if [ -d /lib/firmware/nvidia ]; then
         ts "staging GPU firmware to tmpfs"
         mkdir -p /run/firmware/nvidia
@@ -273,6 +274,15 @@ setup_gpu() {
     fi
 }
 
+setup_sandbox_workdir() {
+    mkdir -p /sandbox
+    if ! chown -R sandbox:sandbox /sandbox 2>/dev/null; then
+        chown -R 10001:10001 /sandbox
+    fi
+    chmod 0755 /sandbox
+    ts "prepared /sandbox ownership"
+}
+
 mount -t proc proc /proc 2>/dev/null &
 mount -t sysfs sysfs /sys 2>/dev/null &
 mount -t tmpfs tmpfs /tmp 2>/dev/null &
@@ -285,6 +295,8 @@ mount -t devpts devpts /dev/pts 2>/dev/null &
 mount -t tmpfs tmpfs /dev/shm 2>/dev/null &
 mount -t cgroup2 cgroup2 /sys/fs/cgroup 2>/dev/null &
 wait
+
+setup_sandbox_workdir
 
 hostname openshell-sandbox-vm 2>/dev/null || true
 ip link set lo up 2>/dev/null || true

--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -25,6 +25,7 @@ BOOT_START=$(date +%s%3N 2>/dev/null || date +%s)
 GVPROXY_GATEWAY_IP="192.168.127.1"
 GVPROXY_HOST_LOOPBACK_IP="192.168.127.254"
 GATEWAY_IP="$GVPROXY_GATEWAY_IP"
+SANDBOX_OWNER_NORMALIZED_MARKER="/opt/openshell/.sandbox-owner-normalized"
 
 GPU_ENABLED="${GPU_ENABLED:-false}"
 VM_NET_IP="${VM_NET_IP:-}"
@@ -62,8 +63,17 @@ root_path() {
 }
 
 sandbox_owner() {
+    sandbox_owner_from_passwd "$(root_path /etc/passwd)"
+}
+
+sandbox_owner_for_root() {
+    local root="$1"
+    sandbox_owner_from_passwd "$root/etc/passwd"
+}
+
+sandbox_owner_from_passwd() {
     local passwd_path name uid gid rest
-    passwd_path="$(root_path /etc/passwd)"
+    passwd_path="$1"
     if [ -f "$passwd_path" ]; then
         while IFS=: read -r name _ uid gid rest; do
             _="${rest:-}"
@@ -117,8 +127,19 @@ ensure_target_runtime() {
     if ! grep -q '^sandbox:' "$image_root/etc/shadow" 2>/dev/null; then
         printf 'sandbox:!:20123:0:99999:7:::\n' >> "$image_root/etc/shadow"
     fi
-    chown 10001:10001 "$image_root/sandbox" 2>/dev/null || true
+    local owner
+    local owner_normalized=0
+    owner="$(sandbox_owner_for_root "$image_root")"
+    if chown -R "$owner" "$image_root/sandbox" 2>/dev/null; then
+        owner_normalized=1
+    elif chown -R 10001:10001 "$image_root/sandbox" 2>/dev/null; then
+        owner_normalized=1
+    fi
     chmod 0755 "$image_root/sandbox"
+    if [ "$owner_normalized" -eq 1 ]; then
+        mkdir -p "$image_root/opt/openshell"
+        printf '1\n' > "$image_root${SANDBOX_OWNER_NORMALIZED_MARKER}"
+    fi
 }
 
 prepare_guest_image_rootfs() {
@@ -502,11 +523,16 @@ setup_gpu() {
 setup_sandbox_workdir() {
     local sandbox_dir
     local owner
+    local current_owner
     sandbox_dir="$(root_path /sandbox)"
     owner="$(sandbox_owner)"
     mkdir -p "$sandbox_dir"
-    if ! chown -R "$owner" "$sandbox_dir" 2>/dev/null; then
-        chown -R 10001:10001 "$sandbox_dir"
+    current_owner="$(stat -c '%u:%g' "$sandbox_dir" 2>/dev/null || true)"
+    if [ "$current_owner" != "$owner" ] \
+        || [ ! -f "$(root_path "$SANDBOX_OWNER_NORMALIZED_MARKER")" ]; then
+        if ! chown -R "$owner" "$sandbox_dir" 2>/dev/null; then
+            chown -R 10001:10001 "$sandbox_dir"
+        fi
     fi
     chmod 0755 "$sandbox_dir"
     ts "prepared /sandbox ownership (${owner})"

--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -41,27 +41,166 @@ ts() {
 mount_initial_fs() {
     mount -t proc proc /proc 2>/dev/null || true
     mount -t sysfs sysfs /sys 2>/dev/null || true
+    mount -t tmpfs tmpfs /tmp 2>/dev/null || true
     mount -t tmpfs tmpfs /run 2>/dev/null || true
     mount -t devtmpfs devtmpfs /dev 2>/dev/null || true
 }
 
-move_mount_if_possible() {
+bind_mount_into_newroot() {
     local source="$1"
     local target="/newroot${source}"
 
     mkdir -p "$target" 2>/dev/null || true
-    mount --move "$source" "$target" 2>/dev/null || true
+    mount --rbind "$source" "$target" 2>/dev/null \
+        || mount --bind "$source" "$target" 2>/dev/null \
+        || true
 }
 
-exec_chroot_overlay_root() {
+root_path() {
+    local path="$1"
+    printf '%s%s\n' "${ROOT_PREFIX:-}" "$path"
+}
+
+sandbox_owner() {
+    local passwd_path name uid gid rest
+    passwd_path="$(root_path /etc/passwd)"
+    if [ -f "$passwd_path" ]; then
+        while IFS=: read -r name _ uid gid rest; do
+            _="${rest:-}"
+            if [ "$name" = "sandbox" ] \
+                && [[ "$uid" =~ ^[0-9]+$ ]] \
+                && [[ "$gid" =~ ^[0-9]+$ ]]; then
+                printf '%s:%s\n' "$uid" "$gid"
+                return
+            fi
+        done < "$passwd_path"
+    fi
+
+    printf '10001:10001\n'
+}
+
+source_overlay_env_if_present() {
+    local env_file="/overlay/upper/srv/openshell-env.sh"
+    if [ -f "$env_file" ]; then
+        # shellcheck source=/dev/null
+        source "$env_file"
+    fi
+}
+
+ensure_target_runtime() {
+    local image_root="$1"
+
+    mkdir -p \
+        "$image_root/srv" \
+        "$image_root/opt/openshell/bin" \
+        "$image_root/sandbox" \
+        "$image_root/etc"
+
+    cp /srv/openshell-vm-sandbox-init.sh "$image_root/srv/openshell-vm-sandbox-init.sh"
+    chmod 0755 "$image_root/srv/openshell-vm-sandbox-init.sh"
+
+    if [ -x /opt/openshell/bin/openshell-sandbox ]; then
+        cp /opt/openshell/bin/openshell-sandbox "$image_root/opt/openshell/bin/openshell-sandbox"
+        chmod 0755 "$image_root/opt/openshell/bin/openshell-sandbox"
+    fi
+
+    touch "$image_root/etc/passwd" "$image_root/etc/group" "$image_root/etc/shadow" "$image_root/etc/gshadow"
+    if ! grep -q '^sandbox:' "$image_root/etc/group" 2>/dev/null; then
+        printf 'sandbox:x:10001:\n' >> "$image_root/etc/group"
+    fi
+    if ! grep -q '^sandbox:' "$image_root/etc/gshadow" 2>/dev/null; then
+        printf 'sandbox:!::\n' >> "$image_root/etc/gshadow"
+    fi
+    if ! grep -q '^sandbox:' "$image_root/etc/passwd" 2>/dev/null; then
+        printf 'sandbox:x:10001:10001:OpenShell Sandbox:/sandbox:/bin/sh\n' >> "$image_root/etc/passwd"
+    fi
+    if ! grep -q '^sandbox:' "$image_root/etc/shadow" 2>/dev/null; then
+        printf 'sandbox:!:20123:0:99999:7:::\n' >> "$image_root/etc/shadow"
+    fi
+    chown 10001:10001 "$image_root/sandbox" 2>/dev/null || true
+    chmod 0755 "$image_root/sandbox"
+}
+
+prepare_guest_image_rootfs() {
+    local payload_dir="/overlay/config/openshell-image"
+    local image_root="/overlay/image-rootfs"
+    local partial_root="/overlay/image-rootfs.partial"
+    local source
+
+    [ -d "$payload_dir" ] || return 0
+
+    source="$(cat "$payload_dir/source" 2>/dev/null || true)"
+    ts "preparing sandbox image rootfs in guest (${source:-unknown})"
+
+    rm -rf "$image_root" "$partial_root"
+
+    case "$source" in
+        local-docker)
+            mkdir -p "$image_root"
+            tar -xpf "$payload_dir/source-rootfs.tar" -C "$image_root"
+            ;;
+        oci-layout)
+            if [ ! -x /opt/openshell/bin/umoci ]; then
+                ts "FATAL: umoci not found in VM bootstrap image"
+                exit 1
+            fi
+            /opt/openshell/bin/umoci raw unpack \
+                --image "$payload_dir/oci:openshell" \
+                "$partial_root"
+            if [ ! -d "$partial_root/rootfs" ]; then
+                ts "FATAL: umoci unpack did not produce rootfs directory"
+                exit 1
+            fi
+            mv "$partial_root/rootfs" "$image_root"
+            rm -rf "$partial_root"
+            ;;
+        *)
+            ts "FATAL: unknown guest image payload source: ${source:-missing}"
+            exit 1
+            ;;
+    esac
+
+    ensure_target_runtime "$image_root"
+    if [ -f "$payload_dir/identity" ]; then
+        cp "$payload_dir/identity" "$image_root/.openshell-rootfs-variant"
+    fi
+    rm -rf "$payload_dir"
+}
+
+exec_supervisor_in_newroot() {
     local chroot_bin
+    local bootstrap="/.openshell-bootstrap"
+    local supervisor="${bootstrap}/opt/openshell/bin/openshell-sandbox"
+    local loader
+    local lib_path
+
     for chroot_bin in /usr/sbin/chroot /usr/bin/chroot /sbin/chroot /bin/chroot; do
-        if [ -x "$chroot_bin" ]; then
-            exec "$chroot_bin" /newroot /srv/openshell-vm-sandbox-init.sh --post-overlay
+        [ -x "$chroot_bin" ] || continue
+
+        if [ -x "/newroot${supervisor}" ]; then
+            for loader in \
+                "${bootstrap}/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2" \
+                "${bootstrap}/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2" \
+                "${bootstrap}/lib64/ld-linux-x86-64.so.2" \
+                "${bootstrap}/lib/ld-linux-x86-64.so.2" \
+                "${bootstrap}/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1" \
+                "${bootstrap}/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1" \
+                "${bootstrap}/lib/ld-linux-aarch64.so.1" \
+                "${bootstrap}/lib64/ld-linux-aarch64.so.1"; do
+                if [ -x "/newroot${loader}" ]; then
+                    lib_path="${bootstrap}/lib:${bootstrap}/lib64:${bootstrap}/usr/lib:${bootstrap}/usr/lib64:${bootstrap}/lib/aarch64-linux-gnu:${bootstrap}/lib/x86_64-linux-gnu:${bootstrap}/usr/lib/aarch64-linux-gnu:${bootstrap}/usr/lib/x86_64-linux-gnu"
+                    exec "$chroot_bin" /newroot "$loader" --library-path "$lib_path" "$supervisor" --workdir /sandbox
+                fi
+            done
+            exec "$chroot_bin" /newroot "$supervisor" --workdir /sandbox
+        fi
+
+        if [ -x /newroot/opt/openshell/bin/openshell-sandbox ]; then
+            exec "$chroot_bin" /newroot /opt/openshell/bin/openshell-sandbox --workdir /sandbox
         fi
     done
 
-    ts "FATAL: chroot not found in guest rootfs"
+    ts "FATAL: unable to exec openshell-sandbox in guest rootfs"
     exit 1
 }
 
@@ -74,36 +213,56 @@ setup_overlay_root() {
         exit 1
     fi
 
+    mkdir -p /overlay /lower /newroot
     mount -o remount,ro / 2>/dev/null || true
+    mount -t ext4 -o rw /dev/vdb /overlay
+    mkdir -p /overlay/upper /overlay/work
+    source_overlay_env_if_present
+
+    if [ "${OPENSHELL_VM_INIT_MODE:-sandbox}" = "image-prep" ]; then
+        prepare_guest_image_rootfs
+        sync
+        ts "image-prep complete"
+        exit 0
+    fi
+
     mount --bind / /lower
     mount -o remount,bind,ro /lower 2>/dev/null || true
 
-    mount -t ext4 -o rw /dev/vdb /overlay
-    mkdir -p /overlay/upper /overlay/work
+    local lower_root="/lower"
+    if [ -b /dev/vdc ]; then
+        mkdir -p /image-cache
+        mount -t ext4 -o ro /dev/vdc /image-cache
+        if [ -d /image-cache/image-rootfs ]; then
+            lower_root="/image-cache/image-rootfs"
+            ts "using prepared image rootfs lowerdir"
+        else
+            ts "FATAL: prepared image disk missing /image-rootfs"
+            exit 1
+        fi
+    fi
+
     mount -t overlay overlay \
-        -o lowerdir=/lower,upperdir=/overlay/upper,workdir=/overlay/work \
+        -o lowerdir="$lower_root",upperdir=/overlay/upper,workdir=/overlay/work \
         /newroot
+    mkdir -p /newroot/.openshell-bootstrap
+    mount --bind /lower /newroot/.openshell-bootstrap
 
-    move_mount_if_possible /proc
-    move_mount_if_possible /sys
-    move_mount_if_possible /dev
-    move_mount_if_possible /run
+    # GPU setup runs against the bootstrap runtime and its mounted /dev, /proc,
+    # and /run before those filesystems are mirrored into the target root.
+    if [ "${GPU_ENABLED}" = "true" ]; then
+        setup_gpu || ts "WARNING: GPU init failed; continuing without GPU"
+    fi
 
-    exec_chroot_overlay_root
+    bind_mount_into_newroot /proc
+    bind_mount_into_newroot /sys
+    bind_mount_into_newroot /tmp
+    bind_mount_into_newroot /dev
+    bind_mount_into_newroot /run
+
+    ROOT_PREFIX="/newroot"
+    run_post_overlay_setup
 }
-
-if [ "${1:-}" != "--post-overlay" ]; then
-    setup_overlay_root
-fi
-
-shift || true
-
-# Source QEMU-injected environment variables if present. The file lives in the
-# overlay upperdir so the cached base rootfs remains immutable.
-if [ -f /srv/openshell-env.sh ]; then
-    # shellcheck source=/dev/null
-    source /srv/openshell-env.sh
-fi
 
 parse_endpoint() {
     local endpoint="$1"
@@ -171,13 +330,18 @@ ensure_host_gateway_aliases() {
     # gateway IP only listens on gvproxy's own service ports (DNS:53, DHCP,
     # HTTP API:80). Pinning host.containers.internal to the gateway IP
     # silently breaks guest→host port reachability for arbitrary ports.
-    local hosts_tmp="/tmp/openshell-hosts.$$"
+    local hosts_tmp
+    local hosts_path
     local host_aliases="host.openshell.internal host.containers.internal host.docker.internal"
     local gateway_aliases="gateway.containers.internal"
     local filter='(^|[[:space:]])(host\.openshell\.internal|host\.containers\.internal|host\.docker\.internal|gateway\.containers\.internal)([[:space:]]|$)'
+    hosts_path="$(root_path /etc/hosts)"
+    hosts_tmp="$(root_path "/tmp/openshell-hosts.$$.tmp")"
 
-    if [ -f /etc/hosts ]; then
-        grep -vE "$filter" /etc/hosts > "$hosts_tmp" || true
+    mkdir -p "$(dirname "$hosts_path")" 2>/dev/null || true
+    mkdir -p "$(dirname "$hosts_tmp")" 2>/dev/null || true
+    if [ -f "$hosts_path" ]; then
+        grep -vE "$filter" "$hosts_path" > "$hosts_tmp" || true
     else
         : > "$hosts_tmp"
     fi
@@ -194,7 +358,7 @@ ensure_host_gateway_aliases() {
         # TAP networking: gateway and host are both reachable at GATEWAY_IP.
         printf '%s %s %s\n' "$GATEWAY_IP" "$host_aliases" "$gateway_aliases" >> "$hosts_tmp"
     fi
-    cat "$hosts_tmp" > /etc/hosts
+    cat "$hosts_tmp" > "$hosts_path"
     rm -f "$hosts_tmp"
 }
 
@@ -336,12 +500,16 @@ setup_gpu() {
 }
 
 setup_sandbox_workdir() {
-    mkdir -p /sandbox
-    if ! chown -R sandbox:sandbox /sandbox 2>/dev/null; then
-        chown -R 10001:10001 /sandbox
+    local sandbox_dir
+    local owner
+    sandbox_dir="$(root_path /sandbox)"
+    owner="$(sandbox_owner)"
+    mkdir -p "$sandbox_dir"
+    if ! chown -R "$owner" "$sandbox_dir" 2>/dev/null; then
+        chown -R 10001:10001 "$sandbox_dir"
     fi
-    chmod 0755 /sandbox
-    ts "prepared /sandbox ownership"
+    chmod 0755 "$sandbox_dir"
+    ts "prepared /sandbox ownership (${owner})"
 }
 
 configure_hostname() {
@@ -354,32 +522,39 @@ configure_hostname() {
     fi
 
     hostname "$sandbox_hostname" 2>/dev/null || true
-    printf '%s\n' "$sandbox_hostname" >/etc/hostname 2>/dev/null || true
+    printf '%s\n' "$sandbox_hostname" >"$(root_path /etc/hostname)" 2>/dev/null || true
     ts "hostname=${sandbox_hostname}"
 }
 
-mount -t proc proc /proc 2>/dev/null &
-mount -t sysfs sysfs /sys 2>/dev/null &
-mount -t tmpfs tmpfs /tmp 2>/dev/null &
-mount -t tmpfs tmpfs /run 2>/dev/null &
-mount -t devtmpfs devtmpfs /dev 2>/dev/null &
-wait
+run_post_overlay_setup() {
+    # Source QEMU-injected environment variables if present. The file lives in
+    # the overlay upperdir so the cached bootstrap rootfs remains immutable.
+    local env_file
+    env_file="$(root_path /srv/openshell-env.sh)"
+    if [ -f "$env_file" ]; then
+        # shellcheck source=/dev/null
+        source "$env_file"
+    fi
 
-mkdir -p /dev/pts /dev/shm /sys/fs/cgroup
-mount -t devpts devpts /dev/pts 2>/dev/null &
-mount -t tmpfs tmpfs /dev/shm 2>/dev/null &
-mount -t cgroup2 cgroup2 /sys/fs/cgroup 2>/dev/null &
-wait
+    if [ -z "${ROOT_PREFIX:-}" ]; then
+        mount -t proc proc /proc 2>/dev/null &
+        mount -t sysfs sysfs /sys 2>/dev/null &
+        mount -t tmpfs tmpfs /tmp 2>/dev/null &
+        mount -t tmpfs tmpfs /run 2>/dev/null &
+        mount -t devtmpfs devtmpfs /dev 2>/dev/null &
+        wait
+    fi
 
-setup_sandbox_workdir
+    mkdir -p "$(root_path /dev/pts)" "$(root_path /dev/shm)" "$(root_path /sys/fs/cgroup)"
+    mount -t devpts devpts "$(root_path /dev/pts)" 2>/dev/null &
+    mount -t tmpfs tmpfs "$(root_path /dev/shm)" 2>/dev/null &
+    mount -t cgroup2 cgroup2 "$(root_path /sys/fs/cgroup)" 2>/dev/null &
+    wait
 
-configure_hostname
-ip link set lo up 2>/dev/null || true
+    setup_sandbox_workdir
 
-# GPU initialization (before networking so nvidia-smi output is visible early)
-if [ "${GPU_ENABLED}" = "true" ]; then
-    setup_gpu || ts "WARNING: GPU init failed; continuing without GPU"
-fi
+    configure_hostname
+    ip link set lo up 2>/dev/null || true
 
 # Networking: use TAP static config if VM_NET_IP is set (QEMU path),
 # otherwise fall back to gvproxy DHCP on eth0 (libkrun path).
@@ -422,10 +597,10 @@ if [ -n "${VM_NET_IP}" ] && [ -n "${VM_NET_GW}" ]; then
     fi
 
     if [ -n "${VM_NET_DNS}" ]; then
-        echo "nameserver ${VM_NET_DNS}" > /etc/resolv.conf
-    elif [ ! -s /etc/resolv.conf ]; then
-        echo "nameserver 8.8.8.8" > /etc/resolv.conf
-        echo "nameserver 8.8.4.4" >> /etc/resolv.conf
+        echo "nameserver ${VM_NET_DNS}" > "$(root_path /etc/resolv.conf)"
+    elif [ ! -s "$(root_path /etc/resolv.conf)" ]; then
+        echo "nameserver 8.8.8.8" > "$(root_path /etc/resolv.conf)"
+        echo "nameserver 8.8.4.4" >> "$(root_path /etc/resolv.conf)"
     fi
 
     ensure_host_gateway_aliases
@@ -434,10 +609,9 @@ elif ip link show eth0 >/dev/null 2>&1; then
     ip link set eth0 up 2>/dev/null || true
 
     if command -v udhcpc >/dev/null 2>&1; then
-        UDHCPC_SCRIPT="/usr/share/udhcpc/default.script"
-        if [ ! -f "$UDHCPC_SCRIPT" ]; then
-            UDHCPC_SCRIPT="/run/openshell-udhcpc.script"
-            cat > "$UDHCPC_SCRIPT" <<'DHCP_SCRIPT'
+        UDHCPC_SCRIPT="$(root_path /run/openshell-udhcpc.script)"
+        mkdir -p "$(dirname "$UDHCPC_SCRIPT")"
+        cat > "$UDHCPC_SCRIPT" <<'DHCP_SCRIPT'
 #!/bin/sh
 case "$1" in
     bound|renew)
@@ -447,18 +621,20 @@ case "$1" in
             ip route add default via "$router" dev "$interface"
         fi
         if [ -n "$dns" ]; then
-            : > /etc/resolv.conf
+            resolv_conf="${OPENSHELL_RESOLV_CONF:-/etc/resolv.conf}"
+            mkdir -p "$(dirname "$resolv_conf")" 2>/dev/null || true
+            : > "$resolv_conf" 2>/dev/null || true
             for d in $dns; do
-                echo "nameserver $d" >> /etc/resolv.conf
+                echo "nameserver $d" >> "$resolv_conf" 2>/dev/null || true
             done
         fi
         ;;
 esac
 DHCP_SCRIPT
-            chmod +x "$UDHCPC_SCRIPT"
-        fi
+        chmod +x "$UDHCPC_SCRIPT"
 
-        if ! udhcpc -i eth0 -f -q -n -T 1 -t 3 -A 1 -s "$UDHCPC_SCRIPT" 2>&1; then
+        if ! OPENSHELL_RESOLV_CONF="$(root_path /etc/resolv.conf)" \
+            udhcpc -i eth0 -f -q -n -T 1 -t 3 -A 1 -s "$UDHCPC_SCRIPT" 2>&1; then
             ts "WARNING: DHCP failed, falling back to static config"
             ip addr add 192.168.127.2/24 dev eth0 2>/dev/null || true
             ip route add default via "$GVPROXY_GATEWAY_IP" 2>/dev/null || true
@@ -469,9 +645,9 @@ DHCP_SCRIPT
         ip route add default via "$GVPROXY_GATEWAY_IP" 2>/dev/null || true
     fi
 
-    if [ ! -s /etc/resolv.conf ]; then
-        echo "nameserver 8.8.8.8" > /etc/resolv.conf
-        echo "nameserver 8.8.4.4" >> /etc/resolv.conf
+    if [ ! -s "$(root_path /etc/resolv.conf)" ]; then
+        echo "nameserver 8.8.8.8" > "$(root_path /etc/resolv.conf)"
+        echo "nameserver 8.8.4.4" >> "$(root_path /etc/resolv.conf)"
     fi
 
     ensure_host_gateway_aliases
@@ -523,4 +699,15 @@ if [ -n "${OPENSHELL_SANDBOX_ID:-}" ]; then
 fi
 
 ts "starting openshell-sandbox supervisor"
+if [ "${ROOT_PREFIX:-}" = "/newroot" ]; then
+    exec_supervisor_in_newroot
+fi
 exec /opt/openshell/bin/openshell-sandbox --workdir /sandbox
+}
+
+if [ "${1:-}" != "--post-overlay" ]; then
+    setup_overlay_root
+fi
+
+shift || true
+run_post_overlay_setup

--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -9,12 +9,6 @@
 
 set -euo pipefail
 
-# Source QEMU-injected environment variables if present.
-if [ -f /srv/openshell-env.sh ]; then
-    # shellcheck source=/dev/null
-    source /srv/openshell-env.sh
-fi
-
 BOOT_START=$(date +%s%3N 2>/dev/null || date +%s)
 # gvisor-tap-vsock subnet layout:
 #   192.168.127.1   — gateway: gvproxy's DNS / DHCP / HTTP API. Does NOT
@@ -43,6 +37,73 @@ ts() {
     local elapsed=$((now - BOOT_START))
     printf "[%d.%03ds] %s\n" $((elapsed / 1000)) $((elapsed % 1000)) "$*"
 }
+
+mount_initial_fs() {
+    mount -t proc proc /proc 2>/dev/null || true
+    mount -t sysfs sysfs /sys 2>/dev/null || true
+    mount -t tmpfs tmpfs /run 2>/dev/null || true
+    mount -t devtmpfs devtmpfs /dev 2>/dev/null || true
+}
+
+move_mount_if_possible() {
+    local source="$1"
+    local target="/newroot${source}"
+
+    mkdir -p "$target" 2>/dev/null || true
+    mount --move "$source" "$target" 2>/dev/null || true
+}
+
+exec_chroot_overlay_root() {
+    local chroot_bin
+    for chroot_bin in /usr/sbin/chroot /usr/bin/chroot /sbin/chroot /bin/chroot; do
+        if [ -x "$chroot_bin" ]; then
+            exec "$chroot_bin" /newroot /srv/openshell-vm-sandbox-init.sh --post-overlay
+        fi
+    done
+
+    ts "FATAL: chroot not found in guest rootfs"
+    exit 1
+}
+
+setup_overlay_root() {
+    ts "setting up writable overlay root"
+    mount_initial_fs
+
+    if [ ! -b /dev/vdb ]; then
+        ts "FATAL: writable overlay disk /dev/vdb not found"
+        exit 1
+    fi
+
+    mount -o remount,ro / 2>/dev/null || true
+    mount --bind / /lower
+    mount -o remount,bind,ro /lower 2>/dev/null || true
+
+    mount -t ext4 -o rw /dev/vdb /overlay
+    mkdir -p /overlay/upper /overlay/work
+    mount -t overlay overlay \
+        -o lowerdir=/lower,upperdir=/overlay/upper,workdir=/overlay/work \
+        /newroot
+
+    move_mount_if_possible /proc
+    move_mount_if_possible /sys
+    move_mount_if_possible /dev
+    move_mount_if_possible /run
+
+    exec_chroot_overlay_root
+}
+
+if [ "${1:-}" != "--post-overlay" ]; then
+    setup_overlay_root
+fi
+
+shift || true
+
+# Source QEMU-injected environment variables if present. The file lives in the
+# overlay upperdir so the cached base rootfs remains immutable.
+if [ -f /srv/openshell-env.sh ]; then
+    # shellcheck source=/dev/null
+    source /srv/openshell-env.sh
+fi
 
 parse_endpoint() {
     local endpoint="$1"

--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -234,7 +234,7 @@ setup_overlay_root() {
         exit 1
     fi
 
-    mkdir -p /overlay /lower /newroot
+    mkdir -p /overlay /lower /newroot /image-cache
     mount -o remount,ro / 2>/dev/null || true
     mount -t ext4 -o rw /dev/vdb /overlay
     mkdir -p /overlay/upper /overlay/work
@@ -252,7 +252,6 @@ setup_overlay_root() {
 
     local lower_root="/lower"
     if [ -b /dev/vdc ]; then
-        mkdir -p /image-cache
         mount -t ext4 -o ro /dev/vdc /image-cache
         if [ -d /image-cache/image-rootfs ]; then
             lower_root="/image-cache/image-rootfs"

--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -351,14 +351,19 @@ ensure_host_gateway_aliases() {
     # gateway IP only listens on gvproxy's own service ports (DNS:53, DHCP,
     # HTTP API:80). Pinning host.containers.internal to the gateway IP
     # silently breaks guest→host port reachability for arbitrary ports.
-    local hosts_tmp
-    local hosts_path
     local host_aliases="host.openshell.internal host.containers.internal host.docker.internal"
     local gateway_aliases="gateway.containers.internal"
     local filter='(^|[[:space:]])(host\.openshell\.internal|host\.containers\.internal|host\.docker\.internal|gateway\.containers\.internal)([[:space:]]|$)'
-    hosts_path="$(root_path /etc/hosts)"
-    hosts_tmp="$(root_path "/tmp/openshell-hosts.$$.tmp")"
 
+    write_host_gateway_aliases "$(root_path /etc/hosts)" "$(root_path "/tmp/openshell-hosts.$$.tmp")" || true
+    if [ -n "${ROOT_PREFIX:-}" ]; then
+        write_host_gateway_aliases "/etc/hosts" "/tmp/openshell-hosts.$$.tmp" || true
+    fi
+}
+
+write_host_gateway_aliases() {
+    local hosts_path="$1"
+    local hosts_tmp="$2"
     mkdir -p "$(dirname "$hosts_path")" 2>/dev/null || true
     mkdir -p "$(dirname "$hosts_tmp")" 2>/dev/null || true
     if [ -f "$hosts_path" ]; then
@@ -379,7 +384,11 @@ ensure_host_gateway_aliases() {
         # TAP networking: gateway and host are both reachable at GATEWAY_IP.
         printf '%s %s %s\n' "$GATEWAY_IP" "$host_aliases" "$gateway_aliases" >> "$hosts_tmp"
     fi
-    cat "$hosts_tmp" > "$hosts_path"
+    if ! cat "$hosts_tmp" > "$hosts_path" 2>/dev/null; then
+        rm -f "$hosts_tmp"
+        ts "WARNING: could not update ${hosts_path}"
+        return 1
+    fi
     rm -f "$hosts_tmp"
 }
 

--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -344,6 +344,20 @@ setup_sandbox_workdir() {
     ts "prepared /sandbox ownership"
 }
 
+configure_hostname() {
+    local sandbox_hostname="${OPENSHELL_SANDBOX:-openshell-sandbox-vm}"
+    sandbox_hostname="$(printf '%s' "$sandbox_hostname" | tr -c 'A-Za-z0-9.-' '-')"
+    sandbox_hostname="$(printf '%s' "$sandbox_hostname" | sed 's/^[.-][.-]*//; s/[.-][.-]*$//')"
+    sandbox_hostname="$(printf '%.63s' "$sandbox_hostname")"
+    if [ -z "$sandbox_hostname" ]; then
+        sandbox_hostname="openshell-sandbox-vm"
+    fi
+
+    hostname "$sandbox_hostname" 2>/dev/null || true
+    printf '%s\n' "$sandbox_hostname" >/etc/hostname 2>/dev/null || true
+    ts "hostname=${sandbox_hostname}"
+}
+
 mount -t proc proc /proc 2>/dev/null &
 mount -t sysfs sysfs /sys 2>/dev/null &
 mount -t tmpfs tmpfs /tmp 2>/dev/null &
@@ -359,7 +373,7 @@ wait
 
 setup_sandbox_workdir
 
-hostname openshell-sandbox-vm 2>/dev/null || true
+configure_hostname
 ip link set lo up 2>/dev/null || true
 
 # GPU initialization (before networking so nvidia-smi output is visible early)

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -5,8 +5,9 @@ use crate::gpu::{
     GpuInventory, SubnetAllocator, allocate_vsock_cid, mac_from_sandbox_id, tap_device_name,
 };
 use crate::rootfs::{
-    create_rootfs_archive_from_dir, extract_rootfs_archive_to,
-    prepare_sandbox_rootfs_from_image_root, sandbox_guest_init_path,
+    copy_rootfs_image_to, create_rootfs_image_from_dir, extract_rootfs_archive_to,
+    prepare_sandbox_rootfs_from_image_root, sandbox_guest_init_path, set_rootfs_image_file_mode,
+    write_rootfs_image_file,
 };
 use bollard::Docker;
 use bollard::errors::Error as BollardError;
@@ -37,7 +38,6 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Read;
 use std::net::Ipv4Addr;
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
 use std::pin::Pin;
 use std::process::Stdio;
@@ -84,13 +84,13 @@ const OPENSHELL_HOST_GATEWAY_ALIAS: &str = "host.openshell.internal";
 /// `GVPROXY_HOST_LOOPBACK_IP` — they do **not** go through the gateway IP.
 const GVPROXY_HOST_LOOPBACK_ALIAS: &str = "host.containers.internal";
 const GUEST_SSH_SOCKET_PATH: &str = "/run/openshell/ssh.sock";
-const GUEST_TLS_DIR: &str = "/opt/openshell/tls";
 const GUEST_TLS_CA_PATH: &str = "/opt/openshell/tls/ca.crt";
 const GUEST_TLS_CERT_PATH: &str = "/opt/openshell/tls/tls.crt";
 const GUEST_TLS_KEY_PATH: &str = "/opt/openshell/tls/tls.key";
 const IMAGE_CACHE_ROOT_DIR: &str = "images";
-const IMAGE_CACHE_ROOTFS_ARCHIVE: &str = "rootfs.tar";
+const IMAGE_CACHE_ROOTFS_IMAGE: &str = "rootfs.ext4";
 const IMAGE_EXPORT_ROOTFS_ARCHIVE: &str = "source-rootfs.tar";
+const IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-rootfs-ext4-v1";
 const IMAGE_IDENTITY_FILE: &str = "image-identity";
 const IMAGE_REFERENCE_FILE: &str = "image-reference";
 static IMAGE_CACHE_BUILD_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -359,7 +359,7 @@ impl VmDriver {
         let gpu_device = spec.map_or("", |s| s.gpu_device.as_str());
 
         let state_dir = sandbox_state_dir(&self.config.state_dir, &sandbox.id)?;
-        let rootfs = state_dir.join("rootfs");
+        let root_disk = state_dir.join(IMAGE_CACHE_ROOTFS_IMAGE);
         let image_ref = self.resolved_sandbox_image(sandbox).ok_or_else(|| {
             Status::failed_precondition(
                 "vm sandboxes require template.image or a configured default sandbox image",
@@ -369,7 +369,7 @@ impl VmDriver {
             sandbox_id = %sandbox.id,
             image_ref = %image_ref,
             state_dir = %state_dir.display(),
-            "vm driver: resolved image ref, preparing rootfs"
+            "vm driver: resolved image ref, preparing root disk"
         );
 
         tokio::fs::create_dir_all(&state_dir)
@@ -394,14 +394,14 @@ impl VmDriver {
         );
 
         let image_identity = match self
-            .prepare_runtime_rootfs(&sandbox.id, &image_ref, &rootfs)
+            .prepare_runtime_rootfs(&sandbox.id, &image_ref, &root_disk)
             .await
         {
             Ok(image_identity) => {
                 info!(
                     sandbox_id = %sandbox.id,
                     image_identity = %image_identity,
-                    "vm driver: rootfs prepared"
+                    "vm driver: root disk prepared"
                 );
                 image_identity
             }
@@ -409,14 +409,14 @@ impl VmDriver {
                 warn!(
                     sandbox_id = %sandbox.id,
                     error = %err.message(),
-                    "vm driver: rootfs preparation failed"
+                    "vm driver: root disk preparation failed"
                 );
                 let _ = tokio::fs::remove_dir_all(&state_dir).await;
                 return Err(err);
             }
         };
         if let Some(tls_paths) = tls_paths.as_ref()
-            && let Err(err) = prepare_guest_tls_materials(&rootfs, tls_paths).await
+            && let Err(err) = prepare_guest_tls_materials(&root_disk, tls_paths).await
         {
             let _ = tokio::fs::remove_dir_all(&state_dir).await;
             return Err(Status::internal(format!(
@@ -470,7 +470,7 @@ impl VmDriver {
         command.stdout(Stdio::inherit());
         command.stderr(Stdio::inherit());
         command.arg("--internal-run-vm");
-        command.arg("--vm-rootfs").arg(&rootfs);
+        command.arg("--vm-root-disk").arg(&root_disk);
         command.arg("--vm-exec").arg(sandbox_guest_init_path());
         command.arg("--vm-workdir").arg("/");
         command.arg("--vm-console-output").arg(&console_output);
@@ -729,17 +729,17 @@ impl VmDriver {
         &self,
         sandbox_id: &str,
         image_ref: &str,
-        rootfs: &Path,
+        root_disk: &Path,
     ) -> Result<String, Status> {
         let image_identity = self
-            .ensure_cached_image_rootfs_archive(sandbox_id, image_ref)
+            .ensure_cached_image_rootfs_image(sandbox_id, image_ref)
             .await?;
-        let archive_path = image_cache_rootfs_archive(&self.config.state_dir, &image_identity);
-        let rootfs_dest = rootfs.to_path_buf();
-        tokio::task::spawn_blocking(move || extract_rootfs_archive_to(&archive_path, &rootfs_dest))
+        let cached_image = image_cache_rootfs_image(&self.config.state_dir, &image_identity);
+        let root_disk_dest = root_disk.to_path_buf();
+        tokio::task::spawn_blocking(move || copy_rootfs_image_to(&cached_image, &root_disk_dest))
             .await
-            .map_err(|err| Status::internal(format!("sandbox rootfs extraction panicked: {err}")))?
-            .map_err(|err| Status::internal(format!("extract sandbox rootfs failed: {err}")))?;
+            .map_err(|err| Status::internal(format!("sandbox root disk copy panicked: {err}")))?
+            .map_err(|err| Status::internal(format!("copy sandbox root disk failed: {err}")))?;
 
         Ok(image_identity)
     }
@@ -753,7 +753,7 @@ impl VmDriver {
             })
     }
 
-    async fn ensure_cached_image_rootfs_archive(
+    async fn ensure_cached_image_rootfs_image(
         &self,
         sandbox_id: &str,
         image_ref: &str,
@@ -762,7 +762,7 @@ impl VmDriver {
             self.resolve_local_container_image(image_ref).await?
         {
             return self
-                .ensure_cached_local_image_rootfs_archive(
+                .ensure_cached_local_image_rootfs_image(
                     sandbox_id,
                     image_ref,
                     &engine,
@@ -771,7 +771,7 @@ impl VmDriver {
                 .await;
         }
 
-        info!(image_ref = %image_ref, "vm driver: ensuring cached image rootfs archive (registry)");
+        info!(image_ref = %image_ref, "vm driver: ensuring cached root disk image (registry)");
         let reference = parse_registry_reference(image_ref)?;
         let client = registry_client();
         let auth = registry_auth(image_ref)?;
@@ -785,7 +785,7 @@ impl VmDriver {
                 ))
             })?;
         info!(image_ref = %image_ref, "vm driver: fetching manifest digest");
-        let image_identity = client
+        let source_image_identity = client
             .fetch_manifest_digest(&reference, &auth)
             .await
             .map_err(|err| {
@@ -795,10 +795,11 @@ impl VmDriver {
             })?;
         info!(
             image_ref = %image_ref,
-            image_identity = %image_identity,
+            image_identity = %source_image_identity,
             "vm driver: manifest digest resolved"
         );
-        let archive_path = image_cache_rootfs_archive(&self.config.state_dir, &image_identity);
+        let image_identity = prepared_image_cache_identity(&source_image_identity);
+        let image_path = image_cache_rootfs_image(&self.config.state_dir, &image_identity);
 
         // Mirror the K8s `Pulling` event so the CLI flips to the
         // image-pull spinner with the image name as detail. We emit it
@@ -814,37 +815,37 @@ impl VmDriver {
             ),
         );
 
-        if tokio::fs::metadata(&archive_path).await.is_ok() {
+        if tokio::fs::metadata(&image_path).await.is_ok() {
             info!(
                 image_identity = %image_identity,
-                archive_path = %archive_path.display(),
-                "vm driver: image rootfs archive cache hit (no build needed)"
+                image_path = %image_path.display(),
+                "vm driver: root disk image cache hit (no build needed)"
             );
-            self.publish_pulled_event(sandbox_id, image_ref, &archive_path)
+            self.publish_pulled_event(sandbox_id, image_ref, &image_path)
                 .await;
             return Ok(image_identity);
         }
 
         info!(
             image_identity = %image_identity,
-            "vm driver: image rootfs archive cache miss, acquiring build lock"
+            "vm driver: root disk image cache miss, acquiring build lock"
         );
         let _cache_guard = self.image_cache_lock.lock().await;
         info!(
             image_identity = %image_identity,
             "vm driver: build lock acquired"
         );
-        if tokio::fs::metadata(&archive_path).await.is_ok() {
+        if tokio::fs::metadata(&image_path).await.is_ok() {
             info!(
                 image_identity = %image_identity,
-                "vm driver: image rootfs archive cache hit after lock (built by another task)"
+                "vm driver: root disk image cache hit after lock (built by another task)"
             );
-            self.publish_pulled_event(sandbox_id, image_ref, &archive_path)
+            self.publish_pulled_event(sandbox_id, image_ref, &image_path)
                 .await;
             return Ok(image_identity);
         }
 
-        self.build_cached_registry_image_rootfs_archive(
+        self.build_cached_registry_image_rootfs_image(
             sandbox_id,
             &client,
             &reference,
@@ -853,7 +854,7 @@ impl VmDriver {
             &image_identity,
         )
         .await?;
-        self.publish_pulled_event(sandbox_id, image_ref, &archive_path)
+        self.publish_pulled_event(sandbox_id, image_ref, &image_path)
             .await;
         Ok(image_identity)
     }
@@ -931,14 +932,15 @@ impl VmDriver {
         }
     }
 
-    async fn ensure_cached_local_image_rootfs_archive(
+    async fn ensure_cached_local_image_rootfs_image(
         &self,
         sandbox_id: &str,
         image_ref: &str,
         docker: &Docker,
         image_identity: &str,
     ) -> Result<String, Status> {
-        let archive_path = image_cache_rootfs_archive(&self.config.state_dir, image_identity);
+        let cache_identity = prepared_image_cache_identity(image_identity);
+        let image_path = image_cache_rootfs_image(&self.config.state_dir, &cache_identity);
 
         self.publish_platform_event(
             sandbox_id.to_string(),
@@ -950,38 +952,38 @@ impl VmDriver {
             ),
         );
 
-        if tokio::fs::metadata(&archive_path).await.is_ok() {
-            self.publish_pulled_event(sandbox_id, image_ref, &archive_path)
+        if tokio::fs::metadata(&image_path).await.is_ok() {
+            self.publish_pulled_event(sandbox_id, image_ref, &image_path)
                 .await;
-            return Ok(image_identity.to_string());
+            return Ok(cache_identity);
         }
 
         let _cache_guard = self.image_cache_lock.lock().await;
-        if tokio::fs::metadata(&archive_path).await.is_ok() {
-            self.publish_pulled_event(sandbox_id, image_ref, &archive_path)
+        if tokio::fs::metadata(&image_path).await.is_ok() {
+            self.publish_pulled_event(sandbox_id, image_ref, &image_path)
                 .await;
-            return Ok(image_identity.to_string());
+            return Ok(cache_identity);
         }
 
-        self.build_cached_local_image_rootfs_archive(docker, image_ref, image_identity)
+        self.build_cached_local_image_rootfs_image(docker, image_ref, &cache_identity)
             .await?;
-        self.publish_pulled_event(sandbox_id, image_ref, &archive_path)
+        self.publish_pulled_event(sandbox_id, image_ref, &image_path)
             .await;
-        Ok(image_identity.to_string())
+        Ok(cache_identity)
     }
 
-    async fn build_cached_local_image_rootfs_archive(
+    async fn build_cached_local_image_rootfs_image(
         &self,
         docker: &Docker,
         image_ref: &str,
         image_identity: &str,
     ) -> Result<(), Status> {
         let cache_dir = image_cache_dir(&self.config.state_dir, image_identity);
-        let archive_path = image_cache_rootfs_archive(&self.config.state_dir, image_identity);
+        let image_path = image_cache_rootfs_image(&self.config.state_dir, image_identity);
         let staging_dir = image_cache_staging_dir(&self.config.state_dir, image_identity);
         let exported_rootfs = staging_dir.join(IMAGE_EXPORT_ROOTFS_ARCHIVE);
         let prepared_rootfs = staging_dir.join("rootfs");
-        let prepared_archive = staging_dir.join(IMAGE_CACHE_ROOTFS_ARCHIVE);
+        let prepared_image = staging_dir.join(IMAGE_CACHE_ROOTFS_IMAGE);
 
         tokio::fs::create_dir_all(image_cache_root_dir(&self.config.state_dir))
             .await
@@ -1016,14 +1018,14 @@ impl VmDriver {
         let image_identity_owned = image_identity.to_string();
         let exported_rootfs_for_build = exported_rootfs.clone();
         let prepared_rootfs_for_build = prepared_rootfs.clone();
-        let prepared_archive_for_build = prepared_archive.clone();
+        let prepared_image_for_build = prepared_image.clone();
         let build_result = tokio::task::spawn_blocking(move || {
-            prepare_exported_rootfs_archive(
+            prepare_exported_rootfs_image(
                 &image_ref_owned,
                 &image_identity_owned,
                 &exported_rootfs_for_build,
                 &prepared_rootfs_for_build,
-                &prepared_archive_for_build,
+                &prepared_image_for_build,
             )
         })
         .await
@@ -1034,19 +1036,19 @@ impl VmDriver {
             return Err(Status::failed_precondition(err));
         }
 
-        if tokio::fs::metadata(&archive_path).await.is_ok() {
+        if tokio::fs::metadata(&image_path).await.is_ok() {
             let _ = tokio::fs::remove_dir_all(&staging_dir).await;
             return Ok(());
         }
 
-        tokio::fs::rename(&prepared_archive, &archive_path)
+        tokio::fs::rename(&prepared_image, &image_path)
             .await
-            .map_err(|err| Status::internal(format!("store cached image rootfs failed: {err}")))?;
+            .map_err(|err| Status::internal(format!("store cached rootfs image failed: {err}")))?;
         let _ = tokio::fs::remove_dir_all(&staging_dir).await;
         Ok(())
     }
 
-    async fn build_cached_registry_image_rootfs_archive(
+    async fn build_cached_registry_image_rootfs_image(
         &self,
         sandbox_id: &str,
         client: &OciClient,
@@ -1056,10 +1058,10 @@ impl VmDriver {
         image_identity: &str,
     ) -> Result<(), Status> {
         let cache_dir = image_cache_dir(&self.config.state_dir, image_identity);
-        let archive_path = image_cache_rootfs_archive(&self.config.state_dir, image_identity);
+        let image_path = image_cache_rootfs_image(&self.config.state_dir, image_identity);
         let staging_dir = image_cache_staging_dir(&self.config.state_dir, image_identity);
         let prepared_rootfs = staging_dir.join("rootfs");
-        let prepared_archive = staging_dir.join(IMAGE_CACHE_ROOTFS_ARCHIVE);
+        let prepared_image = staging_dir.join(IMAGE_CACHE_ROOTFS_IMAGE);
 
         tokio::fs::create_dir_all(image_cache_root_dir(&self.config.state_dir))
             .await
@@ -1110,13 +1112,13 @@ impl VmDriver {
         }
         info!(
             image_ref = %image_ref,
-            "vm driver: image layers pulled, preparing rootfs archive"
+            "vm driver: image layers pulled, preparing rootfs image"
         );
 
         let image_ref_owned = image_ref.to_string();
         let image_identity_owned = image_identity.to_string();
         let prepared_rootfs_for_build = prepared_rootfs.clone();
-        let prepared_archive_for_build = prepared_archive.clone();
+        let prepared_image_for_build = prepared_image.clone();
         let build_result = tokio::task::spawn_blocking(move || {
             prepare_sandbox_rootfs_from_image_root(
                 &prepared_rootfs_for_build,
@@ -1125,7 +1127,7 @@ impl VmDriver {
             .map_err(|err| {
                 format!("vm sandbox image '{image_ref_owned}' is not base-compatible: {err}")
             })?;
-            create_rootfs_archive_from_dir(&prepared_rootfs_for_build, &prepared_archive_for_build)
+            create_rootfs_image_from_dir(&prepared_rootfs_for_build, &prepared_image_for_build)
         })
         .await
         .map_err(|err| Status::internal(format!("image rootfs preparation panicked: {err}")))?;
@@ -1134,28 +1136,28 @@ impl VmDriver {
             warn!(
                 image_ref = %image_ref,
                 error = %err,
-                "vm driver: rootfs archive build failed"
+                "vm driver: rootfs image build failed"
             );
             let _ = tokio::fs::remove_dir_all(&staging_dir).await;
             return Err(Status::failed_precondition(err));
         }
 
-        if tokio::fs::metadata(&archive_path).await.is_ok() {
+        if tokio::fs::metadata(&image_path).await.is_ok() {
             info!(
                 image_identity = %image_identity,
-                "vm driver: another task wrote archive while we were building, discarding ours"
+                "vm driver: another task wrote image while we were building, discarding ours"
             );
             let _ = tokio::fs::remove_dir_all(&staging_dir).await;
             return Ok(());
         }
 
-        tokio::fs::rename(&prepared_archive, &archive_path)
+        tokio::fs::rename(&prepared_image, &image_path)
             .await
-            .map_err(|err| Status::internal(format!("store cached image rootfs failed: {err}")))?;
+            .map_err(|err| Status::internal(format!("store cached rootfs image failed: {err}")))?;
         info!(
             image_identity = %image_identity,
-            archive_path = %archive_path.display(),
-            "vm driver: image rootfs archive committed to cache"
+            image_path = %image_path.display(),
+            "vm driver: root disk image committed to cache"
         );
         let _ = tokio::fs::remove_dir_all(&staging_dir).await;
         Ok(())
@@ -1670,17 +1672,17 @@ async fn export_local_image_rootfs_to_path(
     }
 }
 
-fn prepare_exported_rootfs_archive(
+fn prepare_exported_rootfs_image(
     image_ref: &str,
     image_identity: &str,
     exported_rootfs: &Path,
     prepared_rootfs: &Path,
-    prepared_archive: &Path,
+    prepared_image: &Path,
 ) -> Result<(), String> {
     extract_rootfs_archive_to(exported_rootfs, prepared_rootfs)?;
     prepare_sandbox_rootfs_from_image_root(prepared_rootfs, image_identity)
         .map_err(|err| format!("vm sandbox image '{image_ref}' is not base-compatible: {err}"))?;
-    create_rootfs_archive_from_dir(prepared_rootfs, prepared_archive)
+    create_rootfs_image_from_dir(prepared_rootfs, prepared_image)
 }
 
 fn registry_client() -> OciClient {
@@ -1844,8 +1846,8 @@ impl VmDriver {
     /// Emit a `Pulled` platform event with a message that mirrors the
     /// kubelet's `Successfully pulled image ... Image size: N bytes.`
     /// format so the CLI's `extract_image_size` parser works unchanged.
-    async fn publish_pulled_event(&self, sandbox_id: &str, image_ref: &str, archive_path: &Path) {
-        let size_suffix = tokio::fs::metadata(archive_path).await.map_or_else(
+    async fn publish_pulled_event(&self, sandbox_id: &str, image_ref: &str, image_path: &Path) {
+        let size_suffix = tokio::fs::metadata(image_path).await.map_or_else(
             |_| String::new(),
             |meta| format!(" Image size: {} bytes.", meta.len()),
         );
@@ -2373,8 +2375,8 @@ fn image_cache_dir(root: &Path, image_identity: &str) -> PathBuf {
     image_cache_root_dir(root).join(sanitize_image_identity(image_identity))
 }
 
-fn image_cache_rootfs_archive(root: &Path, image_identity: &str) -> PathBuf {
-    image_cache_dir(root, image_identity).join(IMAGE_CACHE_ROOTFS_ARCHIVE)
+fn image_cache_rootfs_image(root: &Path, image_identity: &str) -> PathBuf {
+    image_cache_dir(root, image_identity).join(IMAGE_CACHE_ROOTFS_IMAGE)
 }
 
 fn image_cache_staging_dir(root: &Path, image_identity: &str) -> PathBuf {
@@ -2383,6 +2385,10 @@ fn image_cache_staging_dir(root: &Path, image_identity: &str) -> PathBuf {
         sanitize_image_identity(image_identity),
         unique_image_cache_suffix()
     ))
+}
+
+fn prepared_image_cache_identity(image_identity: &str) -> String {
+    format!("{IMAGE_CACHE_LAYOUT_VERSION}:{image_identity}")
 }
 
 fn sanitize_image_identity(image_identity: &str) -> String {
@@ -2423,26 +2429,28 @@ async fn write_sandbox_image_metadata(
 }
 
 async fn prepare_guest_tls_materials(
-    rootfs: &Path,
+    root_disk: &Path,
     paths: &VmDriverTlsPaths,
-) -> Result<(), std::io::Error> {
-    let guest_tls_dir = rootfs.join(GUEST_TLS_DIR.trim_start_matches('/'));
-    tokio::fs::create_dir_all(&guest_tls_dir).await?;
+) -> Result<(), String> {
+    let ca = tokio::fs::read(&paths.ca)
+        .await
+        .map_err(|err| format!("read {}: {err}", paths.ca.display()))?;
+    let cert = tokio::fs::read(&paths.cert)
+        .await
+        .map_err(|err| format!("read {}: {err}", paths.cert.display()))?;
+    let key = tokio::fs::read(&paths.key)
+        .await
+        .map_err(|err| format!("read {}: {err}", paths.key.display()))?;
+    let root_disk = root_disk.to_path_buf();
 
-    copy_guest_tls_material(&paths.ca, &guest_tls_dir.join("ca.crt"), 0o644).await?;
-    copy_guest_tls_material(&paths.cert, &guest_tls_dir.join("tls.crt"), 0o644).await?;
-    copy_guest_tls_material(&paths.key, &guest_tls_dir.join("tls.key"), 0o600).await?;
-    Ok(())
-}
-
-async fn copy_guest_tls_material(
-    source: &Path,
-    dest: &Path,
-    mode: u32,
-) -> Result<(), std::io::Error> {
-    tokio::fs::copy(source, dest).await?;
-    tokio::fs::set_permissions(dest, fs::Permissions::from_mode(mode)).await?;
-    Ok(())
+    tokio::task::spawn_blocking(move || {
+        write_rootfs_image_file(&root_disk, GUEST_TLS_CA_PATH, &ca)?;
+        write_rootfs_image_file(&root_disk, GUEST_TLS_CERT_PATH, &cert)?;
+        write_rootfs_image_file(&root_disk, GUEST_TLS_KEY_PATH, &key)?;
+        set_rootfs_image_file_mode(&root_disk, GUEST_TLS_KEY_PATH, 0o100_600)
+    })
+    .await
+    .map_err(|err| format!("guest TLS material injection panicked: {err}"))?
 }
 
 async fn terminate_vm_process(child: &mut Child) -> Result<(), std::io::Error> {
@@ -3228,54 +3236,11 @@ mod tests {
     }
 
     #[test]
-    fn prepare_exported_rootfs_archive_rewrites_docker_exported_rootfs() {
-        let base = unique_temp_dir();
-        let source_rootfs = base.join("source-rootfs");
-        let exported_rootfs = base.join("exported-rootfs.tar");
-        let prepared_rootfs = base.join("prepared-rootfs");
-        let prepared_archive = base.join("prepared-rootfs.tar");
-        let extracted = base.join("extracted");
-
-        for path in [
-            "bin/bash",
-            "bin/mount",
-            "bin/sed",
-            "sbin/ip",
-            "opt/openshell/bin/openshell-sandbox",
-        ] {
-            let path = source_rootfs.join(path);
-            fs::create_dir_all(path.parent().unwrap()).unwrap();
-            fs::write(path, "").unwrap();
-        }
-
-        create_rootfs_archive_from_dir(&source_rootfs, &exported_rootfs).unwrap();
-        prepare_exported_rootfs_archive(
-            "openshell/sandbox-from:123",
-            "sha256:local-image",
-            &exported_rootfs,
-            &prepared_rootfs,
-            &prepared_archive,
-        )
-        .unwrap();
-        extract_rootfs_archive_to(&prepared_archive, &extracted).unwrap();
-
-        assert!(extracted.join("srv/openshell-vm-sandbox-init.sh").is_file());
-        assert!(
-            extracted
-                .join("opt/openshell/bin/openshell-sandbox")
-                .is_file()
-        );
+    fn prepared_image_cache_identity_includes_rootfs_layout_version() {
         assert_eq!(
-            fs::read_to_string(extracted.join("opt/openshell/.rootfs-type")).unwrap(),
-            "sandbox\n"
+            prepared_image_cache_identity("sha256:local-image"),
+            format!("{IMAGE_CACHE_LAYOUT_VERSION}:sha256:local-image")
         );
-        assert!(
-            fs::read_to_string(extracted.join(".openshell-rootfs-variant"))
-                .unwrap()
-                .contains("sha256:local-image")
-        );
-
-        let _ = fs::remove_dir_all(base);
     }
 
     #[test]
@@ -3287,50 +3252,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prepare_guest_tls_materials_copies_bundle_into_rootfs() {
+    async fn prepare_guest_tls_materials_reports_missing_input() {
         let base = unique_temp_dir();
-        let source_dir = base.join("source");
-        let rootfs = base.join("rootfs");
-        std::fs::create_dir_all(&source_dir).unwrap();
-        std::fs::create_dir_all(&rootfs).unwrap();
+        let source_dir = base.join("missing-source");
 
-        let ca = source_dir.join("ca.crt");
-        let cert = source_dir.join("tls.crt");
-        let key = source_dir.join("tls.key");
-        std::fs::write(&ca, "ca").unwrap();
-        std::fs::write(&cert, "cert").unwrap();
-        std::fs::write(&key, "key").unwrap();
-
-        prepare_guest_tls_materials(
-            &rootfs,
+        let err = prepare_guest_tls_materials(
+            &base.join("rootfs.ext4"),
             &VmDriverTlsPaths {
-                ca: ca.clone(),
-                cert: cert.clone(),
-                key: key.clone(),
+                ca: source_dir.join("ca.crt"),
+                cert: source_dir.join("tls.crt"),
+                key: source_dir.join("tls.key"),
             },
         )
         .await
-        .unwrap();
+        .expect_err("missing TLS materials should fail before image injection");
 
-        let guest_dir = rootfs.join(GUEST_TLS_DIR.trim_start_matches('/'));
-        assert_eq!(
-            std::fs::read_to_string(guest_dir.join("ca.crt")).unwrap(),
-            "ca"
-        );
-        assert_eq!(
-            std::fs::read_to_string(guest_dir.join("tls.crt")).unwrap(),
-            "cert"
-        );
-        assert_eq!(
-            std::fs::read_to_string(guest_dir.join("tls.key")).unwrap(),
-            "key"
-        );
-        let key_mode = std::fs::metadata(guest_dir.join("tls.key"))
-            .unwrap()
-            .permissions()
-            .mode()
-            & 0o777;
-        assert_eq!(key_mode, 0o600);
+        assert!(err.contains("ca.crt"));
 
         let _ = std::fs::remove_dir_all(base);
     }

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -5,8 +5,9 @@ use crate::gpu::{
     GpuInventory, SubnetAllocator, allocate_vsock_cid, mac_from_sandbox_id, tap_device_name,
 };
 use crate::rootfs::{
-    create_ext4_image_from_dir_with_size, create_rootfs_image_from_dir, extract_rootfs_archive_to,
-    prepare_sandbox_rootfs_from_image_root, sandbox_guest_init_path,
+    clone_or_copy_sparse_file, create_ext4_image_from_dir_with_size, create_rootfs_image_from_dir,
+    extract_rootfs_archive_to, prepare_sandbox_rootfs_from_image_root, sandbox_guest_init_path,
+    set_rootfs_image_file_mode, write_rootfs_image_file,
 };
 use bollard::Docker;
 use bollard::errors::Error as BollardError;
@@ -98,6 +99,8 @@ const GUEST_TLS_CERT_PATH: &str = "/opt/openshell/tls/tls.crt";
 const GUEST_TLS_KEY_PATH: &str = "/opt/openshell/tls/tls.key";
 const IMAGE_CACHE_ROOT_DIR: &str = "images";
 const IMAGE_CACHE_ROOTFS_IMAGE: &str = "rootfs.ext4";
+const OVERLAY_TEMPLATE_CACHE_DIR: &str = "overlay-templates";
+const OVERLAY_TEMPLATE_CACHE_LAYOUT_VERSION: &str = "sandbox-overlay-ext4-v1";
 const SANDBOX_OVERLAY_IMAGE: &str = "overlay.ext4";
 const GUEST_IMAGE_CONFIG_DIR: &str = "openshell-image";
 const GUEST_IMAGE_OCI_LAYOUT_DIR: &str = "oci";
@@ -1013,8 +1016,23 @@ impl VmDriver {
                 )
             })?;
 
+        let template_path = overlay_template_image(&self.config.state_dir, overlay_size_bytes);
+        if !overlay_template_image_ready(&template_path, overlay_size_bytes).await? {
+            let _cache_guard = self.image_cache_lock.lock().await;
+            let template_path = template_path.clone();
+            tokio::task::spawn_blocking(move || {
+                ensure_sandbox_overlay_template_image(&template_path, overlay_size_bytes)
+            })
+            .await
+            .map_err(|err| format!("overlay template preparation panicked: {err}"))??;
+        }
+
         tokio::task::spawn_blocking(move || {
-            create_sandbox_overlay_image(&overlay_disk, overlay_size_bytes, tls_materials.as_ref())
+            create_sandbox_overlay_image_from_template(
+                &template_path,
+                &overlay_disk,
+                tls_materials.as_ref(),
+            )
         })
         .await
         .map_err(|err| format!("overlay image preparation panicked: {err}"))?
@@ -3301,6 +3319,13 @@ fn sandbox_overlay_image(state_dir: &Path) -> PathBuf {
     state_dir.join(SANDBOX_OVERLAY_IMAGE)
 }
 
+fn overlay_template_image(root: &Path, size_bytes: u64) -> PathBuf {
+    image_cache_root_dir(root)
+        .join(OVERLAY_TEMPLATE_CACHE_DIR)
+        .join(OVERLAY_TEMPLATE_CACHE_LAYOUT_VERSION)
+        .join(format!("{size_bytes}.ext4"))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SandboxRuntimeDiskPaths {
     overlay_disk: PathBuf,
@@ -3541,11 +3566,66 @@ async fn read_guest_tls_materials(paths: &VmDriverTlsPaths) -> Result<GuestTlsMa
     Ok(GuestTlsMaterials { ca, cert, key })
 }
 
-fn create_sandbox_overlay_image(
-    overlay_disk: &Path,
+async fn overlay_template_image_ready(path: &Path, size_bytes: u64) -> Result<bool, String> {
+    match tokio::fs::metadata(path).await {
+        Ok(metadata) => Ok(metadata.is_file() && metadata.len() == size_bytes),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(format!("stat overlay template {}: {err}", path.display())),
+    }
+}
+
+fn ensure_sandbox_overlay_template_image(
+    template_path: &Path,
     size_bytes: u64,
-    tls_materials: Option<&GuestTlsMaterials>,
 ) -> Result<(), String> {
+    if let Ok(metadata) = fs::metadata(template_path)
+        && metadata.is_file()
+        && metadata.len() == size_bytes
+    {
+        return Ok(());
+    }
+
+    let parent = template_path.parent().ok_or_else(|| {
+        format!(
+            "overlay template path has no parent: {}",
+            template_path.display()
+        )
+    })?;
+    fs::create_dir_all(parent).map_err(|err| {
+        format!(
+            "create overlay template cache dir {}: {err}",
+            parent.display()
+        )
+    })?;
+
+    let staging_image = parent.join(format!(
+        ".{}.staging-{}-{}",
+        template_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("overlay-template.ext4"),
+        std::process::id(),
+        openshell_core::time::now_ms()
+    ));
+
+    let result = (|| {
+        create_empty_sandbox_overlay_image(&staging_image, size_bytes)?;
+        fs::rename(&staging_image, template_path).map_err(|err| {
+            format!(
+                "move overlay template {} to {}: {err}",
+                staging_image.display(),
+                template_path.display()
+            )
+        })
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&staging_image);
+    }
+    result
+}
+
+fn create_empty_sandbox_overlay_image(overlay_disk: &Path, size_bytes: u64) -> Result<(), String> {
     let staging_dir = overlay_staging_dir(overlay_disk);
     if staging_dir.exists() {
         fs::remove_dir_all(&staging_dir)
@@ -3560,15 +3640,46 @@ fn create_sandbox_overlay_image(
         fs::create_dir_all(staging_dir.join("config"))
             .map_err(|err| format!("create overlay config dir: {err}"))?;
 
-        if let Some(tls) = tls_materials {
-            stage_guest_tls_materials(&staging_dir, tls)?;
-        }
-
         create_ext4_image_from_dir_with_size(&staging_dir, overlay_disk, size_bytes)
     })();
 
     let _ = fs::remove_dir_all(&staging_dir);
     result
+}
+
+fn create_sandbox_overlay_image_from_template(
+    template_path: &Path,
+    overlay_disk: &Path,
+    tls_materials: Option<&GuestTlsMaterials>,
+) -> Result<(), String> {
+    clone_or_copy_sparse_file(template_path, overlay_disk)?;
+    if let Some(tls) = tls_materials {
+        inject_guest_tls_materials(overlay_disk, tls)?;
+    }
+    Ok(())
+}
+
+fn inject_guest_tls_materials(
+    overlay_disk: &Path,
+    materials: &GuestTlsMaterials,
+) -> Result<(), String> {
+    write_rootfs_image_file(
+        overlay_disk,
+        &overlay_upper_path(GUEST_TLS_CA_PATH),
+        &materials.ca,
+    )?;
+    write_rootfs_image_file(
+        overlay_disk,
+        &overlay_upper_path(GUEST_TLS_CERT_PATH),
+        &materials.cert,
+    )?;
+    let key_path = overlay_upper_path(GUEST_TLS_KEY_PATH);
+    write_rootfs_image_file(overlay_disk, &key_path, &materials.key)?;
+    set_rootfs_image_file_mode(overlay_disk, &key_path, 0o600)
+}
+
+fn overlay_upper_path(guest_path: &str) -> String {
+    format!("/upper/{}", guest_path.trim_start_matches('/'))
 }
 
 fn create_image_prep_disk(
@@ -3704,6 +3815,7 @@ fn dir_size_bytes(path: &Path) -> Result<u64, String> {
     Ok(total)
 }
 
+#[cfg(test)]
 fn stage_guest_tls_materials(
     staging_dir: &Path,
     materials: &GuestTlsMaterials,
@@ -3896,7 +4008,7 @@ fn attach_vm_progress_metadata(event: &mut PlatformEvent) {
         "PreparingRootfs" => mark_progress_detail(&mut event.metadata, "Preparing rootfs"),
         "CreatingRootDisk" => mark_progress_detail(&mut event.metadata, "Formatting root disk"),
         "PreparingOverlay" => mark_progress_detail(&mut event.metadata, "Preparing overlay disk"),
-        "Started" => mark_progress_detail(&mut event.metadata, "VM launcher started"),
+        "Started" => mark_progress_detail(&mut event.metadata, "Waiting for VM supervisor"),
         _ => {}
     }
 }
@@ -4196,6 +4308,28 @@ mod tests {
         let disks = sandbox_runtime_disk_paths(&state_dir);
 
         assert_eq!(disks.overlay_disk, state_dir.join(SANDBOX_OVERLAY_IMAGE));
+    }
+
+    #[test]
+    fn overlay_template_image_is_keyed_by_size_and_layout() {
+        let path = overlay_template_image(Path::new("/tmp/openshell-vm"), 4 * 1024 * 1024);
+
+        assert_eq!(
+            path,
+            Path::new("/tmp/openshell-vm")
+                .join(IMAGE_CACHE_ROOT_DIR)
+                .join(OVERLAY_TEMPLATE_CACHE_DIR)
+                .join(OVERLAY_TEMPLATE_CACHE_LAYOUT_VERSION)
+                .join("4194304.ext4")
+        );
+    }
+
+    #[test]
+    fn overlay_upper_path_targets_overlay_upperdir() {
+        assert_eq!(
+            overlay_upper_path(GUEST_TLS_KEY_PATH),
+            "/upper/opt/openshell/tls/tls.key"
+        );
     }
 
     #[test]

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -106,8 +106,8 @@ const GUEST_IMAGE_CONFIG_DIR: &str = "openshell-image";
 const GUEST_IMAGE_OCI_LAYOUT_DIR: &str = "oci";
 const GUEST_IMAGE_OCI_REF: &str = "openshell";
 const IMAGE_EXPORT_ROOTFS_ARCHIVE: &str = "source-rootfs.tar";
-const BOOTSTRAP_IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-bootstrap-rootfs-ext4-v1";
-const PREPARED_IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-prepared-rootfs-ext4-umoci-v1";
+const BOOTSTRAP_IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-bootstrap-rootfs-ext4-v2";
+const PREPARED_IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-prepared-rootfs-ext4-umoci-v2";
 const IMAGE_IDENTITY_FILE: &str = "image-identity";
 const IMAGE_REFERENCE_FILE: &str = "image-reference";
 const IMAGE_PREP_INIT_MODE: &str = "image-prep";
@@ -4978,7 +4978,7 @@ mod tests {
     fn prepared_image_cache_identity_includes_rootfs_layout_version() {
         assert_eq!(
             prepared_image_cache_identity("sha256:local-image"),
-            "sandbox-prepared-rootfs-ext4-umoci-v1:sha256:local-image"
+            "sandbox-prepared-rootfs-ext4-umoci-v2:sha256:local-image"
         );
     }
 
@@ -4986,7 +4986,7 @@ mod tests {
     fn bootstrap_image_cache_identity_includes_rootfs_layout_version() {
         assert_eq!(
             bootstrap_image_cache_identity("sha256:bootstrap-image"),
-            "sandbox-bootstrap-rootfs-ext4-v1:sha256:bootstrap-image"
+            "sandbox-bootstrap-rootfs-ext4-v2:sha256:bootstrap-image"
         );
     }
 

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -18,7 +18,9 @@ use nix::errno::Errno;
 use nix::sys::signal::{Signal, kill};
 use nix::unistd::Pid;
 use oci_client::client::{Client as OciClient, ClientConfig};
-use oci_client::manifest::{ImageIndexEntry, OciDescriptor};
+use oci_client::manifest::{
+    ImageIndexEntry, OCI_IMAGE_MEDIA_TYPE, OciDescriptor, OciImageManifest,
+};
 use oci_client::secrets::RegistryAuth;
 use oci_client::{Reference, RegistryOperation};
 use openshell_core::progress::{
@@ -97,10 +99,15 @@ const GUEST_TLS_KEY_PATH: &str = "/opt/openshell/tls/tls.key";
 const IMAGE_CACHE_ROOT_DIR: &str = "images";
 const IMAGE_CACHE_ROOTFS_IMAGE: &str = "rootfs.ext4";
 const SANDBOX_OVERLAY_IMAGE: &str = "overlay.ext4";
+const GUEST_IMAGE_CONFIG_DIR: &str = "openshell-image";
+const GUEST_IMAGE_OCI_LAYOUT_DIR: &str = "oci";
+const GUEST_IMAGE_OCI_REF: &str = "openshell";
 const IMAGE_EXPORT_ROOTFS_ARCHIVE: &str = "source-rootfs.tar";
-const IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-rootfs-ext4-overlay-v2";
+const BOOTSTRAP_IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-bootstrap-rootfs-ext4-v1";
+const PREPARED_IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-prepared-rootfs-ext4-umoci-v1";
 const IMAGE_IDENTITY_FILE: &str = "image-identity";
 const IMAGE_REFERENCE_FILE: &str = "image-reference";
+const IMAGE_PREP_INIT_MODE: &str = "image-prep";
 static IMAGE_CACHE_BUILD_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
@@ -111,11 +118,39 @@ struct VmDriverTlsPaths {
 }
 
 #[derive(Debug, Clone)]
+struct RuntimeImagePlan {
+    root_disk: PathBuf,
+    image_disk: Option<PathBuf>,
+    image_identity: String,
+    bootstrap_image_identity: String,
+}
+
+#[derive(Debug, Clone)]
+struct PreparedImageDisk {
+    image_identity: String,
+    disk_path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+struct GuestImagePayload {
+    image_ref: String,
+    image_identity: String,
+    source: GuestImagePayloadSource,
+}
+
+#[derive(Debug, Clone)]
+enum GuestImagePayloadSource {
+    RegistryOciLayout { layout_dir: PathBuf },
+    LocalDocker { rootfs_archive: PathBuf },
+}
+
+#[derive(Debug, Clone)]
 pub struct VmDriverConfig {
     pub openshell_endpoint: String,
     pub state_dir: PathBuf,
     pub launcher_bin: Option<PathBuf>,
     pub default_image: String,
+    pub bootstrap_image: String,
     pub log_level: String,
     pub krun_log_level: u32,
     pub vcpus: u8,
@@ -136,6 +171,7 @@ impl Default for VmDriverConfig {
             state_dir: PathBuf::from("target/openshell-vm-driver"),
             launcher_bin: None,
             default_image: String::new(),
+            bootstrap_image: String::new(),
             log_level: "info".to_string(),
             krun_log_level: 1,
             vcpus: DEFAULT_VCPUS,
@@ -490,16 +526,19 @@ impl VmDriver {
             ),
         );
 
-        let image_identity = self.prepare_runtime_rootfs(&sandbox.id, &image_ref).await?;
+        let image_plan = self.prepare_runtime_images(&sandbox.id, &image_ref).await?;
+        let image_identity = image_plan.image_identity.clone();
         self.ensure_provisioning_active(&sandbox.id).await?;
         info!(
             sandbox_id = %sandbox.id,
             image_identity = %image_identity,
-            "vm driver: cached root disk resolved"
+            bootstrap_image_identity = %image_plan.bootstrap_image_identity,
+            image_disk = image_plan.image_disk.as_ref().map(|path| path.display().to_string()).unwrap_or_default(),
+            "vm driver: sandbox root disk plan resolved"
         );
-        let disk_paths =
-            sandbox_runtime_disk_paths(&self.config.state_dir, &state_dir, &image_identity);
-        let root_disk = disk_paths.root_disk;
+        let disk_paths = sandbox_runtime_disk_paths(&state_dir);
+        let root_disk = image_plan.root_disk;
+        let image_disk = image_plan.image_disk;
         let overlay_disk = disk_paths.overlay_disk;
 
         self.publish_platform_event(
@@ -576,6 +615,9 @@ impl VmDriver {
         command.arg("--internal-run-vm");
         command.arg("--vm-root-disk").arg(&root_disk);
         command.arg("--vm-overlay-disk").arg(&overlay_disk);
+        if let Some(image_disk) = &image_disk {
+            command.arg("--vm-image-disk").arg(image_disk);
+        }
         command.arg("--vm-exec").arg(sandbox_guest_init_path());
         command.arg("--vm-workdir").arg("/");
         command.arg("--vm-console-output").arg(&console_output);
@@ -907,13 +949,47 @@ impl VmDriver {
         }
     }
 
-    async fn prepare_runtime_rootfs(
+    async fn prepare_runtime_images(
         &self,
         sandbox_id: &str,
         image_ref: &str,
-    ) -> Result<String, Status> {
-        self.ensure_cached_image_rootfs_image(sandbox_id, image_ref)
-            .await
+    ) -> Result<RuntimeImagePlan, Status> {
+        let bootstrap_image_ref = self.bootstrap_image_ref(image_ref);
+        let bootstrap_image_identity = self
+            .ensure_cached_bootstrap_rootfs_image(sandbox_id, &bootstrap_image_ref)
+            .await?;
+        let root_disk = image_cache_rootfs_image(&self.config.state_dir, &bootstrap_image_identity);
+
+        if image_ref.trim() == bootstrap_image_ref.trim() {
+            return Ok(RuntimeImagePlan {
+                root_disk,
+                image_disk: None,
+                image_identity: bootstrap_image_identity.clone(),
+                bootstrap_image_identity,
+            });
+        }
+
+        let prepared = self
+            .ensure_prepared_image_disk(sandbox_id, image_ref, &root_disk)
+            .await?;
+        Ok(RuntimeImagePlan {
+            root_disk,
+            image_disk: Some(prepared.disk_path),
+            image_identity: prepared.image_identity,
+            bootstrap_image_identity,
+        })
+    }
+
+    fn bootstrap_image_ref(&self, sandbox_image_ref: &str) -> String {
+        let configured = self.config.bootstrap_image.trim();
+        if !configured.is_empty() {
+            return configured.to_string();
+        }
+        let default = self.config.default_image.trim();
+        if !default.is_empty() {
+            return default.to_string();
+        }
+        sandbox_image_ref.to_string()
     }
 
     async fn prepare_runtime_overlay(
@@ -953,7 +1029,7 @@ impl VmDriver {
             })
     }
 
-    async fn ensure_cached_image_rootfs_image(
+    async fn ensure_cached_bootstrap_rootfs_image(
         &self,
         sandbox_id: &str,
         image_ref: &str,
@@ -1016,7 +1092,7 @@ impl VmDriver {
             image_identity = %source_image_identity,
             "vm driver: manifest digest resolved"
         );
-        let image_identity = prepared_image_cache_identity(&source_image_identity);
+        let image_identity = bootstrap_image_cache_identity(&source_image_identity);
         let image_path = image_cache_rootfs_image(&self.config.state_dir, &image_identity);
 
         // Emit a driver progress hint for cache hits too and immediately
@@ -1197,7 +1273,7 @@ impl VmDriver {
         docker: &Docker,
         image_identity: &str,
     ) -> Result<String, Status> {
-        let cache_identity = prepared_image_cache_identity(image_identity);
+        let cache_identity = bootstrap_image_cache_identity(image_identity);
         let image_path = image_cache_rootfs_image(&self.config.state_dir, &cache_identity);
 
         self.publish_platform_event(
@@ -1270,6 +1346,432 @@ impl VmDriver {
         self.publish_pulled_event(sandbox_id, image_ref, &image_path)
             .await;
         Ok(cache_identity)
+    }
+
+    async fn ensure_prepared_image_disk(
+        &self,
+        sandbox_id: &str,
+        image_ref: &str,
+        bootstrap_root_disk: &Path,
+    ) -> Result<PreparedImageDisk, Status> {
+        if let Some((docker, image_identity)) =
+            self.resolve_local_container_image(image_ref).await?
+        {
+            return self
+                .ensure_prepared_local_image_disk(
+                    sandbox_id,
+                    image_ref,
+                    &docker,
+                    &image_identity,
+                    bootstrap_root_disk,
+                )
+                .await;
+        }
+
+        self.ensure_prepared_registry_image_disk(sandbox_id, image_ref, bootstrap_root_disk)
+            .await
+    }
+
+    async fn ensure_prepared_local_image_disk(
+        &self,
+        sandbox_id: &str,
+        image_ref: &str,
+        docker: &Docker,
+        image_identity: &str,
+        bootstrap_root_disk: &Path,
+    ) -> Result<PreparedImageDisk, Status> {
+        let cache_identity = prepared_image_cache_identity(image_identity);
+        let image_path = image_cache_rootfs_image(&self.config.state_dir, &cache_identity);
+
+        if tokio::fs::metadata(&image_path).await.is_ok() {
+            self.publish_prepared_cache_hit(sandbox_id, image_ref, "local_docker", &cache_identity);
+            return Ok(PreparedImageDisk {
+                image_identity: cache_identity,
+                disk_path: image_path,
+            });
+        }
+
+        self.publish_prepared_cache_miss(sandbox_id, image_ref, "local_docker", &cache_identity);
+        let _cache_guard = self.image_cache_lock.lock().await;
+        if tokio::fs::metadata(&image_path).await.is_ok() {
+            self.publish_prepared_cache_hit(sandbox_id, image_ref, "local_docker", &cache_identity);
+            return Ok(PreparedImageDisk {
+                image_identity: cache_identity,
+                disk_path: image_path,
+            });
+        }
+
+        let staging_dir = image_cache_staging_dir(&self.config.state_dir, &cache_identity);
+        let rootfs_archive = staging_dir.join(IMAGE_EXPORT_ROOTFS_ARCHIVE);
+        self.reset_image_staging_dir(&staging_dir).await?;
+
+        self.publish_vm_progress(
+            sandbox_id,
+            "ExportingRootfs",
+            format!("Exporting rootfs from local image \"{image_ref}\""),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), "local_docker".to_string()),
+                ("image_identity".to_string(), cache_identity.clone()),
+            ]),
+        );
+        if let Err(err) =
+            export_local_image_rootfs_to_path(docker, image_ref, &rootfs_archive).await
+        {
+            let _ = tokio::fs::remove_dir_all(&staging_dir).await;
+            return Err(err);
+        }
+
+        let payload = GuestImagePayload {
+            image_ref: image_ref.to_string(),
+            image_identity: cache_identity.clone(),
+            source: GuestImagePayloadSource::LocalDocker { rootfs_archive },
+        };
+        self.build_prepared_image_disk(
+            sandbox_id,
+            image_ref,
+            "local_docker",
+            &cache_identity,
+            bootstrap_root_disk,
+            &staging_dir,
+            &payload,
+        )
+        .await?;
+
+        Ok(PreparedImageDisk {
+            image_identity: cache_identity,
+            disk_path: image_path,
+        })
+    }
+
+    async fn ensure_prepared_registry_image_disk(
+        &self,
+        sandbox_id: &str,
+        image_ref: &str,
+        bootstrap_root_disk: &Path,
+    ) -> Result<PreparedImageDisk, Status> {
+        let reference = parse_registry_reference(image_ref)?;
+        let client = registry_client();
+        let auth = registry_auth(image_ref)?;
+
+        self.publish_vm_progress(
+            sandbox_id,
+            "AuthenticatingRegistry",
+            format!("Authenticating registry access for image \"{image_ref}\""),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), "registry".to_string()),
+            ]),
+        );
+        client
+            .auth(&reference, &auth, RegistryOperation::Pull)
+            .await
+            .map_err(|err| {
+                Status::failed_precondition(format!(
+                    "failed to authenticate registry access for vm sandbox image '{image_ref}': {err}"
+                ))
+            })?;
+
+        self.publish_vm_progress(
+            sandbox_id,
+            "FetchingManifest",
+            format!("Fetching manifest for image \"{image_ref}\""),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), "registry".to_string()),
+            ]),
+        );
+        let source_image_identity = client
+            .fetch_manifest_digest(&reference, &auth)
+            .await
+            .map_err(|err| {
+                Status::failed_precondition(format!(
+                    "failed to resolve vm sandbox image '{image_ref}': {err}"
+                ))
+            })?;
+        let cache_identity = prepared_image_cache_identity(&source_image_identity);
+        let image_path = image_cache_rootfs_image(&self.config.state_dir, &cache_identity);
+
+        if tokio::fs::metadata(&image_path).await.is_ok() {
+            self.publish_prepared_cache_hit(sandbox_id, image_ref, "registry", &cache_identity);
+            return Ok(PreparedImageDisk {
+                image_identity: cache_identity,
+                disk_path: image_path,
+            });
+        }
+
+        self.publish_prepared_cache_miss(sandbox_id, image_ref, "registry", &cache_identity);
+        let _cache_guard = self.image_cache_lock.lock().await;
+        if tokio::fs::metadata(&image_path).await.is_ok() {
+            self.publish_prepared_cache_hit(sandbox_id, image_ref, "registry", &cache_identity);
+            return Ok(PreparedImageDisk {
+                image_identity: cache_identity,
+                disk_path: image_path,
+            });
+        }
+
+        let staging_dir = image_cache_staging_dir(&self.config.state_dir, &cache_identity);
+        self.reset_image_staging_dir(&staging_dir).await?;
+        let layout_dir = staging_dir.join(GUEST_IMAGE_OCI_LAYOUT_DIR);
+
+        let (manifest, _) = client
+            .pull_image_manifest(&reference, &auth)
+            .await
+            .map_err(|err| {
+                Status::failed_precondition(format!(
+                    "failed to pull vm sandbox image manifest '{image_ref}': {err}"
+                ))
+            })?;
+        tokio::fs::create_dir_all(oci_layout_blobs_dir(&layout_dir))
+            .await
+            .map_err(|err| Status::internal(format!("create guest OCI layout failed: {err}")))?;
+
+        download_registry_descriptor_blob_file(
+            &client,
+            &reference,
+            image_ref,
+            &layout_dir,
+            &manifest.config,
+            "config",
+        )
+        .await?;
+
+        let total_layers = manifest.layers.len();
+        let total_bytes: i64 = manifest.layers.iter().map(|layer| layer.size.max(0)).sum();
+        futures::stream::iter(manifest.layers.iter().cloned().enumerate())
+            .map(|(index, layer)| {
+                let client = client.clone();
+                let reference = reference.clone();
+                let layout_dir = layout_dir.clone();
+                async move {
+                    self.publish_registry_layer_progress(
+                        sandbox_id,
+                        image_ref,
+                        &layer,
+                        index,
+                        total_layers,
+                        total_bytes,
+                    );
+                    download_registry_descriptor_blob_file(
+                        &client,
+                        &reference,
+                        image_ref,
+                        &layout_dir,
+                        &layer,
+                        &format!("layer {}", index + 1),
+                    )
+                    .await
+                }
+            })
+            .buffer_unordered(registry_layer_download_concurrency())
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        write_oci_layout_for_manifest(&layout_dir, GUEST_IMAGE_OCI_REF, &manifest)
+            .map_err(|err| Status::internal(format!("write OCI layout failed: {err}")))?;
+
+        let payload = GuestImagePayload {
+            image_ref: image_ref.to_string(),
+            image_identity: cache_identity.clone(),
+            source: GuestImagePayloadSource::RegistryOciLayout { layout_dir },
+        };
+        self.build_prepared_image_disk(
+            sandbox_id,
+            image_ref,
+            "registry",
+            &cache_identity,
+            bootstrap_root_disk,
+            &staging_dir,
+            &payload,
+        )
+        .await?;
+
+        Ok(PreparedImageDisk {
+            image_identity: cache_identity,
+            disk_path: image_path,
+        })
+    }
+
+    async fn reset_image_staging_dir(&self, staging_dir: &Path) -> Result<(), Status> {
+        tokio::fs::create_dir_all(image_cache_root_dir(&self.config.state_dir))
+            .await
+            .map_err(|err| Status::internal(format!("create image cache dir failed: {err}")))?;
+        if tokio::fs::metadata(staging_dir).await.is_ok() {
+            tokio::fs::remove_dir_all(staging_dir)
+                .await
+                .map_err(|err| {
+                    Status::internal(format!(
+                        "remove stale image cache staging dir failed: {err}"
+                    ))
+                })?;
+        }
+        tokio::fs::create_dir_all(staging_dir).await.map_err(|err| {
+            Status::internal(format!("create image cache staging dir failed: {err}"))
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn build_prepared_image_disk(
+        &self,
+        sandbox_id: &str,
+        image_ref: &str,
+        image_source: &str,
+        image_identity: &str,
+        bootstrap_root_disk: &Path,
+        staging_dir: &Path,
+        payload: &GuestImagePayload,
+    ) -> Result<(), Status> {
+        let cache_dir = image_cache_dir(&self.config.state_dir, image_identity);
+        let image_path = image_cache_rootfs_image(&self.config.state_dir, image_identity);
+        let prepared_image = staging_dir.join(IMAGE_CACHE_ROOTFS_IMAGE);
+        tokio::fs::create_dir_all(&cache_dir).await.map_err(|err| {
+            Status::internal(format!("create prepared image cache dir failed: {err}"))
+        })?;
+
+        let payload_for_size = payload.clone();
+        let min_size = self
+            .config
+            .overlay_disk_mib
+            .checked_mul(1024 * 1024)
+            .ok_or_else(|| Status::internal("prepared image disk size overflow"))?;
+        let image_size = tokio::task::spawn_blocking(move || {
+            prepared_image_disk_size_bytes(&payload_for_size, min_size)
+        })
+        .await
+        .map_err(|err| {
+            Status::internal(format!("prepared image size calculation panicked: {err}"))
+        })?
+        .map_err(Status::internal)?;
+
+        let payload_for_disk = payload.clone();
+        let prepared_image_for_disk = prepared_image.clone();
+        self.publish_vm_progress(
+            sandbox_id,
+            "CreatingRootDisk",
+            "Formatting prepared VM image disk".to_string(),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), image_source.to_string()),
+                ("image_identity".to_string(), image_identity.to_string()),
+            ]),
+        );
+        tokio::task::spawn_blocking(move || {
+            create_image_prep_disk(&prepared_image_for_disk, image_size, &payload_for_disk)
+        })
+        .await
+        .map_err(|err| Status::internal(format!("prepared image disk build panicked: {err}")))?
+        .map_err(Status::failed_precondition)?;
+
+        self.publish_vm_progress(
+            sandbox_id,
+            "PreparingRootfs",
+            format!("Preparing VM image rootfs for \"{image_ref}\""),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), image_source.to_string()),
+                ("image_identity".to_string(), image_identity.to_string()),
+            ]),
+        );
+        if let Err(err) = self
+            .run_image_prep_vm(bootstrap_root_disk, &prepared_image, staging_dir)
+            .await
+        {
+            let _ = tokio::fs::remove_dir_all(staging_dir).await;
+            return Err(err);
+        }
+
+        if tokio::fs::metadata(&image_path).await.is_ok() {
+            let _ = tokio::fs::remove_dir_all(staging_dir).await;
+            return Ok(());
+        }
+        tokio::fs::rename(&prepared_image, &image_path)
+            .await
+            .map_err(|err| Status::internal(format!("store prepared image disk failed: {err}")))?;
+        let _ = tokio::fs::remove_dir_all(staging_dir).await;
+        Ok(())
+    }
+
+    async fn run_image_prep_vm(
+        &self,
+        bootstrap_root_disk: &Path,
+        prep_disk: &Path,
+        run_dir: &Path,
+    ) -> Result<(), Status> {
+        let console_output = run_dir.join("image-prep-console.log");
+        let mut command = Command::new(&self.launcher_bin);
+        command.stdin(Stdio::null());
+        command.stdout(Stdio::inherit());
+        command.stderr(Stdio::inherit());
+        command.arg("--internal-run-vm");
+        command.arg("--vm-root-disk").arg(bootstrap_root_disk);
+        command.arg("--vm-overlay-disk").arg(prep_disk);
+        command.arg("--vm-exec").arg(sandbox_guest_init_path());
+        command.arg("--vm-workdir").arg("/");
+        command.arg("--vm-console-output").arg(&console_output);
+        command.arg("--vm-vcpus").arg(self.config.vcpus.to_string());
+        command
+            .arg("--vm-mem-mib")
+            .arg(self.config.mem_mib.to_string());
+        command
+            .arg("--vm-krun-log-level")
+            .arg(self.config.krun_log_level.to_string());
+        command
+            .arg("--vm-env")
+            .arg(format!("OPENSHELL_VM_INIT_MODE={IMAGE_PREP_INIT_MODE}"));
+
+        let status = command
+            .status()
+            .await
+            .map_err(|err| Status::internal(format!("failed to run image-prep vm: {err}")))?;
+        if status.success() {
+            return Ok(());
+        }
+        let console = tokio::fs::read_to_string(&console_output)
+            .await
+            .unwrap_or_default();
+        Err(Status::failed_precondition(format!(
+            "image-prep vm exited with status {status}: {console}"
+        )))
+    }
+
+    fn publish_prepared_cache_hit(
+        &self,
+        sandbox_id: &str,
+        image_ref: &str,
+        image_source: &str,
+        image_identity: &str,
+    ) {
+        self.publish_vm_progress(
+            sandbox_id,
+            "CacheHit",
+            format!("Using cached prepared VM image disk for \"{image_ref}\""),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), image_source.to_string()),
+                ("cache_hit".to_string(), "true".to_string()),
+                ("image_identity".to_string(), image_identity.to_string()),
+            ]),
+        );
+    }
+
+    fn publish_prepared_cache_miss(
+        &self,
+        sandbox_id: &str,
+        image_ref: &str,
+        image_source: &str,
+        image_identity: &str,
+    ) {
+        self.publish_vm_progress(
+            sandbox_id,
+            "CacheMiss",
+            format!("Preparing VM image disk cache for \"{image_ref}\""),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), image_source.to_string()),
+                ("cache_hit".to_string(), "false".to_string()),
+                ("image_identity".to_string(), image_identity.to_string()),
+            ]),
+        );
     }
 
     async fn build_cached_local_image_rootfs_image(
@@ -2364,6 +2866,53 @@ async fn apply_registry_layer_blob(
     })
 }
 
+async fn download_registry_descriptor_blob_file(
+    client: &OciClient,
+    reference: &Reference,
+    image_ref: &str,
+    layout_dir: &Path,
+    descriptor: &OciDescriptor,
+    kind: &str,
+) -> Result<(), Status> {
+    let blob_path = oci_layout_blob_path(layout_dir, &descriptor.digest)
+        .map_err(|err| Status::failed_precondition(format!("invalid {kind} digest: {err}")))?;
+    if let Some(parent) = blob_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|err| Status::internal(format!("create OCI blob dir failed: {err}")))?;
+    }
+
+    let mut file = tokio::fs::File::create(&blob_path)
+        .await
+        .map_err(|err| Status::internal(format!("create OCI {kind} blob failed: {err}")))?;
+    client
+        .pull_blob(reference, descriptor, &mut file)
+        .await
+        .map_err(|err| {
+            Status::failed_precondition(format!(
+                "failed to download {kind} '{}' for vm sandbox image '{image_ref}': {err}",
+                descriptor.digest
+            ))
+        })?;
+    file.flush()
+        .await
+        .map_err(|err| Status::internal(format!("flush OCI {kind} blob failed: {err}")))?;
+
+    let blob_path_for_digest = blob_path.clone();
+    let expected_digest = descriptor.digest.clone();
+    tokio::task::spawn_blocking(move || {
+        verify_descriptor_digest(&blob_path_for_digest, &expected_digest)
+    })
+    .await
+    .map_err(|err| Status::internal(format!("OCI {kind} digest verification panicked: {err}")))?
+    .map_err(|err| {
+        Status::failed_precondition(format!(
+            "vm sandbox image {kind} verification failed for '{}': {err}",
+            descriptor.digest
+        ))
+    })
+}
+
 fn verify_descriptor_digest(path: &Path, expected_digest: &str) -> Result<(), String> {
     let expected = expected_digest
         .strip_prefix("sha256:")
@@ -2393,6 +2942,12 @@ fn compute_file_sha256_hex(path: &Path) -> Result<String, String> {
         hasher.update(&buffer[..read]);
     }
     Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn compute_bytes_sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
 }
 
 fn extract_layer_blob_to_dir(
@@ -2748,17 +3303,11 @@ fn sandbox_overlay_image(state_dir: &Path) -> PathBuf {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SandboxRuntimeDiskPaths {
-    root_disk: PathBuf,
     overlay_disk: PathBuf,
 }
 
-fn sandbox_runtime_disk_paths(
-    driver_state_root: &Path,
-    state_dir: &Path,
-    image_identity: &str,
-) -> SandboxRuntimeDiskPaths {
+fn sandbox_runtime_disk_paths(state_dir: &Path) -> SandboxRuntimeDiskPaths {
     SandboxRuntimeDiskPaths {
-        root_disk: image_cache_rootfs_image(driver_state_root, image_identity),
         overlay_disk: sandbox_overlay_image(state_dir),
     }
 }
@@ -2844,8 +3393,81 @@ fn image_cache_staging_dir(root: &Path, image_identity: &str) -> PathBuf {
     ))
 }
 
+fn oci_layout_blobs_dir(layout_dir: &Path) -> PathBuf {
+    layout_dir.join("blobs").join("sha256")
+}
+
+fn oci_layout_blob_path(layout_dir: &Path, digest: &str) -> Result<PathBuf, String> {
+    let hex = sha256_digest_hex(digest)?;
+    Ok(oci_layout_blobs_dir(layout_dir).join(hex))
+}
+
+fn sha256_digest_hex(digest: &str) -> Result<&str, String> {
+    let Some((algorithm, hex)) = digest.split_once(':') else {
+        return Err(format!("digest '{digest}' is missing an algorithm"));
+    };
+    if algorithm != "sha256" {
+        return Err(format!("unsupported digest algorithm '{algorithm}'"));
+    }
+    if hex.is_empty() || !hex.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return Err(format!("digest '{digest}' is not a valid sha256 digest"));
+    }
+    Ok(hex)
+}
+
+fn write_oci_layout_for_manifest(
+    layout_dir: &Path,
+    ref_name: &str,
+    manifest: &OciImageManifest,
+) -> Result<(), String> {
+    fs::create_dir_all(oci_layout_blobs_dir(layout_dir))
+        .map_err(|err| format!("create OCI layout blobs dir failed: {err}"))?;
+
+    fs::write(
+        layout_dir.join("oci-layout"),
+        br#"{"imageLayoutVersion":"1.0.0"}"#,
+    )
+    .map_err(|err| format!("write OCI layout marker failed: {err}"))?;
+
+    let manifest_bytes = serde_json::to_vec(manifest)
+        .map_err(|err| format!("serialize OCI manifest failed: {err}"))?;
+    let manifest_digest = format!("sha256:{}", compute_bytes_sha256_hex(&manifest_bytes));
+    let manifest_blob = oci_layout_blob_path(layout_dir, &manifest_digest)
+        .map_err(|err| format!("compute OCI manifest blob path failed: {err}"))?;
+    fs::write(&manifest_blob, &manifest_bytes)
+        .map_err(|err| format!("write OCI manifest blob failed: {err}"))?;
+
+    let media_type = manifest
+        .media_type
+        .clone()
+        .unwrap_or_else(|| OCI_IMAGE_MEDIA_TYPE.to_string());
+    let index = serde_json::json!({
+        "schemaVersion": 2,
+        "manifests": [
+            {
+                "mediaType": media_type,
+                "digest": manifest_digest,
+                "size": manifest_bytes.len(),
+                "annotations": {
+                    "org.opencontainers.image.ref.name": ref_name
+                }
+            }
+        ]
+    });
+    let index_bytes = serde_json::to_vec_pretty(&index)
+        .map_err(|err| format!("serialize OCI index failed: {err}"))?;
+    fs::write(layout_dir.join("index.json"), index_bytes)
+        .map_err(|err| format!("write OCI index failed: {err}"))?;
+
+    Ok(())
+}
+
+fn bootstrap_image_cache_identity(image_identity: &str) -> String {
+    format!("{BOOTSTRAP_IMAGE_CACHE_LAYOUT_VERSION}:{image_identity}")
+}
+
 fn prepared_image_cache_identity(image_identity: &str) -> String {
-    format!("{IMAGE_CACHE_LAYOUT_VERSION}:{image_identity}")
+    format!("{PREPARED_IMAGE_CACHE_LAYOUT_VERSION}:{image_identity}")
 }
 
 fn registry_layer_download_concurrency() -> usize {
@@ -2947,6 +3569,139 @@ fn create_sandbox_overlay_image(
 
     let _ = fs::remove_dir_all(&staging_dir);
     result
+}
+
+fn create_image_prep_disk(
+    image_path: &Path,
+    size_bytes: u64,
+    payload: &GuestImagePayload,
+) -> Result<(), String> {
+    let staging_dir = overlay_staging_dir(image_path);
+    if staging_dir.exists() {
+        fs::remove_dir_all(&staging_dir)
+            .map_err(|err| format!("remove stale image-prep staging dir: {err}"))?;
+    }
+
+    let result = (|| {
+        fs::create_dir_all(staging_dir.join("upper").join("srv"))
+            .map_err(|err| format!("create image-prep env dir: {err}"))?;
+        fs::create_dir_all(staging_dir.join("work"))
+            .map_err(|err| format!("create image-prep work dir: {err}"))?;
+        fs::create_dir_all(staging_dir.join("config"))
+            .map_err(|err| format!("create image-prep config dir: {err}"))?;
+        stage_guest_image_payload(&staging_dir, payload)?;
+        create_ext4_image_from_dir_with_size(&staging_dir, image_path, size_bytes)
+    })();
+
+    let _ = fs::remove_dir_all(&staging_dir);
+    result
+}
+
+fn stage_guest_image_payload(
+    staging_dir: &Path,
+    payload: &GuestImagePayload,
+) -> Result<(), String> {
+    let image_dir = staging_dir.join("config").join(GUEST_IMAGE_CONFIG_DIR);
+    fs::create_dir_all(&image_dir).map_err(|err| {
+        format!(
+            "create guest image config dir {}: {err}",
+            image_dir.display()
+        )
+    })?;
+    fs::write(image_dir.join("ref"), payload.image_ref.as_bytes())
+        .map_err(|err| format!("write guest image ref: {err}"))?;
+    fs::write(
+        image_dir.join("identity"),
+        payload.image_identity.as_bytes(),
+    )
+    .map_err(|err| format!("write guest image identity: {err}"))?;
+
+    match &payload.source {
+        GuestImagePayloadSource::RegistryOciLayout { layout_dir } => {
+            fs::write(image_dir.join("source"), b"oci-layout")
+                .map_err(|err| format!("write guest image source: {err}"))?;
+            copy_dir_recursive(layout_dir, &image_dir.join(GUEST_IMAGE_OCI_LAYOUT_DIR))?;
+        }
+        GuestImagePayloadSource::LocalDocker { rootfs_archive } => {
+            fs::write(image_dir.join("source"), b"local-docker")
+                .map_err(|err| format!("write guest image source: {err}"))?;
+            let dest = image_dir.join(IMAGE_EXPORT_ROOTFS_ARCHIVE);
+            fs::copy(rootfs_archive, &dest).map_err(|err| {
+                format!(
+                    "copy guest image rootfs archive {} to {}: {err}",
+                    rootfs_archive.display(),
+                    dest.display()
+                )
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+fn copy_dir_recursive(source: &Path, dest: &Path) -> Result<(), String> {
+    fs::create_dir_all(dest).map_err(|err| format!("create {}: {err}", dest.display()))?;
+    for entry in fs::read_dir(source).map_err(|err| format!("read {}: {err}", source.display()))? {
+        let entry = entry.map_err(|err| format!("read {}: {err}", source.display()))?;
+        let source_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+        let metadata = fs::symlink_metadata(&source_path)
+            .map_err(|err| format!("stat {}: {err}", source_path.display()))?;
+        if metadata.file_type().is_dir() {
+            copy_dir_recursive(&source_path, &dest_path)?;
+        } else if metadata.file_type().is_file() {
+            if let Some(parent) = dest_path.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|err| format!("create {}: {err}", parent.display()))?;
+            }
+            fs::copy(&source_path, &dest_path).map_err(|err| {
+                format!(
+                    "copy {} to {}: {err}",
+                    source_path.display(),
+                    dest_path.display()
+                )
+            })?;
+        } else {
+            return Err(format!(
+                "unsupported payload entry type at {}",
+                source_path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn prepared_image_disk_size_bytes(
+    payload: &GuestImagePayload,
+    minimum_size_bytes: u64,
+) -> Result<u64, String> {
+    let payload_size = match &payload.source {
+        GuestImagePayloadSource::RegistryOciLayout { layout_dir } => dir_size_bytes(layout_dir)?,
+        GuestImagePayloadSource::LocalDocker { rootfs_archive } => fs::metadata(rootfs_archive)
+            .map_err(|err| format!("stat {}: {err}", rootfs_archive.display()))?
+            .len(),
+    };
+    let requested = payload_size
+        .saturating_mul(3)
+        .saturating_add(512 * 1024 * 1024);
+    Ok(minimum_size_bytes.max(requested))
+}
+
+fn dir_size_bytes(path: &Path) -> Result<u64, String> {
+    let metadata =
+        fs::symlink_metadata(path).map_err(|err| format!("stat {}: {err}", path.display()))?;
+    if metadata.file_type().is_file() {
+        return Ok(metadata.len());
+    }
+    if metadata.file_type().is_symlink() {
+        return Ok(0);
+    }
+    let mut total = 0_u64;
+    for entry in fs::read_dir(path).map_err(|err| format!("read {}: {err}", path.display()))? {
+        let entry = entry.map_err(|err| format!("read {}: {err}", path.display()))?;
+        total = total.saturating_add(dir_size_bytes(&entry.path())?);
+    }
+    Ok(total)
 }
 
 fn stage_guest_tls_materials(
@@ -3434,19 +4189,13 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_runtime_disk_paths_use_cached_root_and_per_sandbox_overlay() {
+    fn sandbox_runtime_disk_paths_use_per_sandbox_overlay() {
         let driver_state = Path::new("/tmp/openshell-vm");
         let state_dir = driver_state.join("sandboxes").join("sandbox-123");
-        let image_identity = prepared_image_cache_identity("sha256:abc");
 
-        let disks = sandbox_runtime_disk_paths(driver_state, &state_dir, &image_identity);
+        let disks = sandbox_runtime_disk_paths(&state_dir);
 
-        assert_eq!(
-            disks.root_disk,
-            image_cache_rootfs_image(driver_state, &image_identity)
-        );
         assert_eq!(disks.overlay_disk, state_dir.join(SANDBOX_OVERLAY_IMAGE));
-        assert_ne!(disks.root_disk.parent(), Some(state_dir.as_path()));
     }
 
     #[test]
@@ -3558,6 +4307,76 @@ mod tests {
         };
 
         assert!(driver.resolved_sandbox_image(&sandbox).is_none());
+    }
+
+    #[test]
+    fn bootstrap_image_ref_prefers_explicit_bootstrap_image() {
+        let driver = VmDriver {
+            config: VmDriverConfig {
+                default_image: "openshell/sandbox:default".to_string(),
+                bootstrap_image: "openshell/sandbox-bootstrap:latest".to_string(),
+                ..Default::default()
+            },
+            launcher_bin: PathBuf::from("/tmp/openshell-driver-vm"),
+            registry: Arc::new(Mutex::new(HashMap::new())),
+            image_cache_lock: Arc::new(Mutex::new(())),
+            events: broadcast::channel(WATCH_BUFFER).0,
+            gpu_inventory: None,
+            subnet_allocator: Arc::new(std::sync::Mutex::new(SubnetAllocator::new(
+                Ipv4Addr::new(10, 0, 128, 0),
+                17,
+            ))),
+        };
+
+        assert_eq!(
+            driver.bootstrap_image_ref("ghcr.io/example/app:latest"),
+            "openshell/sandbox-bootstrap:latest"
+        );
+    }
+
+    #[test]
+    fn bootstrap_image_ref_falls_back_to_default_image() {
+        let driver = VmDriver {
+            config: VmDriverConfig {
+                default_image: "openshell/sandbox:default".to_string(),
+                ..Default::default()
+            },
+            launcher_bin: PathBuf::from("/tmp/openshell-driver-vm"),
+            registry: Arc::new(Mutex::new(HashMap::new())),
+            image_cache_lock: Arc::new(Mutex::new(())),
+            events: broadcast::channel(WATCH_BUFFER).0,
+            gpu_inventory: None,
+            subnet_allocator: Arc::new(std::sync::Mutex::new(SubnetAllocator::new(
+                Ipv4Addr::new(10, 0, 128, 0),
+                17,
+            ))),
+        };
+
+        assert_eq!(
+            driver.bootstrap_image_ref("ghcr.io/example/app:latest"),
+            "openshell/sandbox:default"
+        );
+    }
+
+    #[test]
+    fn bootstrap_image_ref_falls_back_to_requested_image() {
+        let driver = VmDriver {
+            config: VmDriverConfig::default(),
+            launcher_bin: PathBuf::from("/tmp/openshell-driver-vm"),
+            registry: Arc::new(Mutex::new(HashMap::new())),
+            image_cache_lock: Arc::new(Mutex::new(())),
+            events: broadcast::channel(WATCH_BUFFER).0,
+            gpu_inventory: None,
+            subnet_allocator: Arc::new(std::sync::Mutex::new(SubnetAllocator::new(
+                Ipv4Addr::new(10, 0, 128, 0),
+                17,
+            ))),
+        };
+
+        assert_eq!(
+            driver.bootstrap_image_ref("ghcr.io/example/app:latest"),
+            "ghcr.io/example/app:latest"
+        );
     }
 
     #[test]
@@ -4025,8 +4844,65 @@ mod tests {
     fn prepared_image_cache_identity_includes_rootfs_layout_version() {
         assert_eq!(
             prepared_image_cache_identity("sha256:local-image"),
-            "sandbox-rootfs-ext4-overlay-v2:sha256:local-image"
+            "sandbox-prepared-rootfs-ext4-umoci-v1:sha256:local-image"
         );
+    }
+
+    #[test]
+    fn bootstrap_image_cache_identity_includes_rootfs_layout_version() {
+        assert_eq!(
+            bootstrap_image_cache_identity("sha256:bootstrap-image"),
+            "sandbox-bootstrap-rootfs-ext4-v1:sha256:bootstrap-image"
+        );
+    }
+
+    #[test]
+    fn stage_guest_image_payload_copies_registry_oci_layout() {
+        let base = unique_temp_dir();
+        let staging_dir = base.join("staging");
+        let layout_dir = base.join("layout");
+        let blob_dir = layout_dir.join("blobs").join("sha256");
+        fs::create_dir_all(&blob_dir).unwrap();
+        fs::write(
+            layout_dir.join("oci-layout"),
+            r#"{"imageLayoutVersion":"1.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(layout_dir.join("index.json"), "{}").unwrap();
+        fs::write(blob_dir.join("abc"), "blob").unwrap();
+
+        stage_guest_image_payload(
+            &staging_dir,
+            &GuestImagePayload {
+                image_ref: "ghcr.io/example/app:latest".to_string(),
+                image_identity: prepared_image_cache_identity("sha256:abc"),
+                source: GuestImagePayloadSource::RegistryOciLayout { layout_dir },
+            },
+        )
+        .unwrap();
+
+        let image_dir = staging_dir.join("config").join(GUEST_IMAGE_CONFIG_DIR);
+        assert_eq!(
+            fs::read_to_string(image_dir.join("source")).unwrap(),
+            "oci-layout"
+        );
+        assert_eq!(
+            fs::read_to_string(image_dir.join("ref")).unwrap(),
+            "ghcr.io/example/app:latest"
+        );
+        assert_eq!(
+            fs::read_to_string(
+                image_dir
+                    .join(GUEST_IMAGE_OCI_LAYOUT_DIR)
+                    .join("blobs")
+                    .join("sha256")
+                    .join("abc")
+            )
+            .unwrap(),
+            "blob"
+        );
+
+        let _ = std::fs::remove_dir_all(base);
     }
 
     #[test]

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -13,7 +13,7 @@ use bollard::errors::Error as BollardError;
 use bollard::models::ContainerCreateBody;
 use bollard::query_parameters::{CreateContainerOptionsBuilder, RemoveContainerOptionsBuilder};
 use flate2::read::GzDecoder;
-use futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt, TryStreamExt};
 use nix::errno::Errno;
 use nix::sys::signal::{Signal, kill};
 use nix::unistd::Pid;
@@ -21,6 +21,10 @@ use oci_client::client::{Client as OciClient, ClientConfig};
 use oci_client::manifest::{ImageIndexEntry, OciDescriptor};
 use oci_client::secrets::RegistryAuth;
 use oci_client::{Reference, RegistryOperation};
+use openshell_core::progress::{
+    PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX, PROGRESS_STEP_STARTING_SANDBOX,
+    mark_progress_active, mark_progress_complete, mark_progress_detail,
+};
 use openshell_core::proto::compute::v1::{
     CreateSandboxRequest, CreateSandboxResponse, DeleteSandboxRequest, DeleteSandboxResponse,
     DriverCondition as SandboxCondition, DriverPlatformEvent as PlatformEvent,
@@ -46,6 +50,7 @@ use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, Command};
 use tokio::sync::{Mutex, broadcast, mpsc};
+use tokio::task::JoinHandle;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 use tracing::{info, warn};
@@ -56,6 +61,8 @@ const WATCH_BUFFER: usize = 256;
 const DEFAULT_VCPUS: u8 = 2;
 const DEFAULT_MEM_MIB: u32 = 2048;
 const DEFAULT_OVERLAY_DISK_MIB: u64 = 4096;
+const DEFAULT_REGISTRY_LAYER_DOWNLOAD_CONCURRENCY: usize = 4;
+const MAX_REGISTRY_LAYER_DOWNLOAD_CONCURRENCY: usize = 16;
 /// gvproxy host-loopback IP — gvproxy's TCP/UDP/ICMP forwarder NAT-rewrites
 /// this destination to the host's `127.0.0.1` and dials out from the host
 /// process. This is the only address that transparently reaches host-bound
@@ -91,7 +98,7 @@ const IMAGE_CACHE_ROOT_DIR: &str = "images";
 const IMAGE_CACHE_ROOTFS_IMAGE: &str = "rootfs.ext4";
 const SANDBOX_OVERLAY_IMAGE: &str = "overlay.ext4";
 const IMAGE_EXPORT_ROOTFS_ARCHIVE: &str = "source-rootfs.tar";
-const IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-rootfs-ext4-overlay-v1";
+const IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-rootfs-ext4-overlay-v2";
 const IMAGE_IDENTITY_FILE: &str = "image-identity";
 const IMAGE_REFERENCE_FILE: &str = "image-reference";
 static IMAGE_CACHE_BUILD_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -223,12 +230,13 @@ struct VmProcess {
     deleting: bool,
 }
 
-#[derive(Debug)]
 struct SandboxRecord {
     snapshot: Sandbox,
     state_dir: PathBuf,
-    process: Arc<Mutex<VmProcess>>,
+    process: Option<Arc<Mutex<VmProcess>>>,
+    provisioning_task: Option<JoinHandle<()>>,
     gpu_bdf: Option<String>,
+    deleting: bool,
 }
 
 #[derive(Clone)]
@@ -353,14 +361,6 @@ impl VmDriver {
         );
         validate_vm_sandbox(sandbox, self.config.gpu_enabled)?;
 
-        if self.registry.lock().await.contains_key(&sandbox.id) {
-            return Err(Status::already_exists("sandbox already exists"));
-        }
-
-        let spec = sandbox.spec.as_ref();
-        let is_gpu = spec.is_some_and(|s| s.gpu);
-        let gpu_device = spec.map_or("", |s| s.gpu_device.as_str());
-
         let state_dir = sandbox_state_dir(&self.config.state_dir, &sandbox.id)?;
         let image_ref = self.resolved_sandbox_image(sandbox).ok_or_else(|| {
             Status::failed_precondition(
@@ -382,9 +382,27 @@ impl VmDriver {
             .config
             .tls_paths()
             .map_err(Status::failed_precondition)?;
-        // Mirror the K8s `Scheduled` event so the CLI can complete the
-        // "Requesting sandbox" step and switch the spinner over to the
-        // image-pull phase before we block on the registry.
+
+        let snapshot = sandbox_snapshot(sandbox, provisioning_condition(), false);
+        {
+            let mut registry = self.registry.lock().await;
+            if registry.contains_key(&sandbox.id) {
+                let _ = tokio::fs::remove_dir_all(&state_dir).await;
+                return Err(Status::already_exists("sandbox already exists"));
+            }
+            registry.insert(
+                sandbox.id.clone(),
+                SandboxRecord {
+                    snapshot: snapshot.clone(),
+                    state_dir: state_dir.clone(),
+                    process: None,
+                    provisioning_task: None,
+                    gpu_bdf: None,
+                    deleting: false,
+                },
+            );
+        }
+
         self.publish_platform_event(
             sandbox.id.clone(),
             platform_event(
@@ -394,50 +412,126 @@ impl VmDriver {
                 format!("Sandbox accepted by vm driver to image \"{image_ref}\""),
             ),
         );
+        self.publish_snapshot(snapshot);
 
-        let image_identity = match self.prepare_runtime_rootfs(&sandbox.id, &image_ref).await {
-            Ok(image_identity) => {
-                info!(
-                    sandbox_id = %sandbox.id,
-                    image_identity = %image_identity,
-                    "vm driver: cached root disk resolved"
-                );
-                image_identity
+        let driver = self.clone();
+        let sandbox_for_task = sandbox.clone();
+        let sandbox_id = sandbox.id.clone();
+        let image_ref_for_task = image_ref.clone();
+        let state_dir_for_task = state_dir.clone();
+        let task = tokio::spawn(async move {
+            driver
+                .provision_sandbox(
+                    sandbox_for_task,
+                    image_ref_for_task,
+                    state_dir_for_task,
+                    tls_paths,
+                )
+                .await;
+        });
+
+        let mut registry = self.registry.lock().await;
+        if let Some(record) = registry.get_mut(&sandbox_id) {
+            if record.deleting {
+                task.abort();
+            } else {
+                record.provisioning_task = Some(task);
             }
-            Err(err) => {
-                warn!(
-                    sandbox_id = %sandbox.id,
-                    error = %err.message(),
-                    "vm driver: root disk preparation failed"
-                );
+        } else {
+            task.abort();
+        }
+
+        Ok(CreateSandboxResponse {})
+    }
+
+    async fn provision_sandbox(
+        &self,
+        sandbox: Sandbox,
+        image_ref: String,
+        state_dir: PathBuf,
+        tls_paths: Option<VmDriverTlsPaths>,
+    ) {
+        let sandbox_id = sandbox.id.clone();
+        if let Err(err) = self
+            .provision_sandbox_inner(sandbox, image_ref, state_dir.clone(), tls_paths)
+            .await
+        {
+            if err.code() == tonic::Code::Cancelled {
                 let _ = tokio::fs::remove_dir_all(&state_dir).await;
-                return Err(err);
+                return;
             }
-        };
+
+            warn!(
+                sandbox_id = %sandbox_id,
+                error = %err.message(),
+                "vm driver: sandbox provisioning failed"
+            );
+            self.fail_provisioning(&sandbox_id, &state_dir, "ProvisioningFailed", err.message())
+                .await;
+        }
+    }
+
+    #[allow(clippy::result_large_err)]
+    async fn provision_sandbox_inner(
+        &self,
+        sandbox: Sandbox,
+        image_ref: String,
+        state_dir: PathBuf,
+        tls_paths: Option<VmDriverTlsPaths>,
+    ) -> Result<(), Status> {
+        self.ensure_provisioning_active(&sandbox.id).await?;
+        self.publish_platform_event(
+            sandbox.id.clone(),
+            platform_event(
+                "vm",
+                "Normal",
+                "ResolvingImage",
+                format!("Resolving VM sandbox image \"{image_ref}\""),
+            ),
+        );
+
+        let image_identity = self.prepare_runtime_rootfs(&sandbox.id, &image_ref).await?;
+        self.ensure_provisioning_active(&sandbox.id).await?;
+        info!(
+            sandbox_id = %sandbox.id,
+            image_identity = %image_identity,
+            "vm driver: cached root disk resolved"
+        );
         let disk_paths =
             sandbox_runtime_disk_paths(&self.config.state_dir, &state_dir, &image_identity);
         let root_disk = disk_paths.root_disk;
         let overlay_disk = disk_paths.overlay_disk;
 
+        self.publish_platform_event(
+            sandbox.id.clone(),
+            platform_event(
+                "vm",
+                "Normal",
+                "PreparingOverlay",
+                "Preparing writable VM overlay disk".to_string(),
+            ),
+        );
         if let Err(err) = self
             .prepare_runtime_overlay(&overlay_disk, tls_paths.as_ref())
             .await
         {
-            let _ = tokio::fs::remove_dir_all(&state_dir).await;
             return Err(Status::internal(format!(
                 "prepare guest overlay disk failed: {err}"
             )));
         }
+        self.ensure_provisioning_active(&sandbox.id).await?;
 
         if let Err(err) =
             write_sandbox_image_metadata(&state_dir, &image_ref, &image_identity).await
         {
-            let _ = tokio::fs::remove_dir_all(&state_dir).await;
             return Err(Status::internal(format!(
                 "write sandbox image metadata failed: {err}"
             )));
         }
 
+        let spec = sandbox.spec.as_ref();
+        let is_gpu = spec.is_some_and(|s| s.gpu);
+        let gpu_device = spec.map_or("", |s| s.gpu_device.as_str());
         let gpu_bdf = if is_gpu {
             let inventory = self
                 .gpu_inventory
@@ -461,13 +555,18 @@ impl VmDriver {
                     Some(assignment.bdf)
                 }
                 Err(err) => {
-                    let _ = tokio::fs::remove_dir_all(&state_dir).await;
                     return Err(err);
                 }
             }
         } else {
             None
         };
+        if let Some(bdf) = gpu_bdf.as_ref()
+            && !self.record_gpu_assignment(&sandbox.id, bdf.clone()).await
+        {
+            self.release_gpu_and_subnet(&sandbox.id);
+            return Err(Status::cancelled("sandbox provisioning cancelled"));
+        }
 
         let console_output = state_dir.join("rootfs-console.log");
         let mut command = Command::new(&self.launcher_bin);
@@ -496,7 +595,6 @@ impl VmDriver {
                 Ok(s) => s,
                 Err(err) => {
                     self.release_gpu_and_subnet(&sandbox.id);
-                    let _ = tokio::fs::remove_dir_all(&state_dir).await;
                     return Err(err);
                 }
             };
@@ -541,12 +639,13 @@ impl VmDriver {
                 .arg(self.config.mem_mib.to_string());
             None
         };
+        self.ensure_provisioning_active(&sandbox.id).await?;
 
         command
             .arg("--vm-krun-log-level")
             .arg(self.config.krun_log_level.to_string());
 
-        for env in build_guest_environment(sandbox, &self.config, endpoint_override.as_deref()) {
+        for env in build_guest_environment(&sandbox, &self.config, endpoint_override.as_deref()) {
             command.arg("--vm-env").arg(env);
         }
 
@@ -567,7 +666,6 @@ impl VmDriver {
                 if gpu_bdf.is_some() {
                     self.release_gpu_and_subnet(&sandbox.id);
                 }
-                let _ = tokio::fs::remove_dir_all(&state_dir).await;
                 return Err(Status::internal(format!(
                     "failed to launch vm helper '{}': {err}",
                     self.launcher_bin.display()
@@ -577,35 +675,49 @@ impl VmDriver {
         info!(
             sandbox_id = %sandbox.id,
             launcher_pid = child.id().unwrap_or(0),
-            "vm driver: launcher spawned"
+                "vm driver: launcher spawned"
         );
-        // Mirror the K8s `Started` event so the CLI can complete the
-        // "Starting sandbox" step. The supervisor-ready transition still
-        // promotes the sandbox to `Ready` separately.
-        self.publish_platform_event(
-            sandbox.id.clone(),
-            platform_event("vm", "Normal", "Started", "Started VM launcher".to_string()),
-        );
-        let snapshot = sandbox_snapshot(sandbox, provisioning_condition(), false);
         let process = Arc::new(Mutex::new(VmProcess {
             child,
             deleting: false,
         }));
 
+        let mut process_to_stop = None;
+        let mut snapshot_to_publish = None;
         {
             let mut registry = self.registry.lock().await;
-            registry.insert(
-                sandbox.id.clone(),
-                SandboxRecord {
-                    snapshot: snapshot.clone(),
-                    state_dir: state_dir.clone(),
-                    process: process.clone(),
-                    gpu_bdf: gpu_bdf.clone(),
-                },
-            );
+            match registry.get_mut(&sandbox.id) {
+                Some(record) if !record.deleting => {
+                    record.process = Some(process.clone());
+                    record.gpu_bdf.clone_from(&gpu_bdf);
+                    record.provisioning_task = None;
+                    snapshot_to_publish = Some(record.snapshot.clone());
+                }
+                _ => {
+                    process_to_stop = Some(process.clone());
+                }
+            }
         }
 
-        self.publish_snapshot(snapshot.clone());
+        if let Some(process) = process_to_stop {
+            {
+                let mut process = process.lock().await;
+                process.deleting = true;
+                terminate_vm_process(&mut process.child)
+                    .await
+                    .map_err(|err| Status::internal(format!("failed to stop vm: {err}")))?;
+            }
+            self.release_gpu_and_subnet(&sandbox.id);
+            return Err(Status::cancelled("sandbox provisioning cancelled"));
+        }
+
+        self.publish_platform_event(
+            sandbox.id.clone(),
+            platform_event("vm", "Normal", "Started", "Started VM launcher".to_string()),
+        );
+        if let Some(snapshot) = snapshot_to_publish {
+            self.publish_snapshot(snapshot);
+        }
         tokio::spawn({
             let driver = self.clone();
             let sandbox_id = sandbox.id.clone();
@@ -614,7 +726,7 @@ impl VmDriver {
             }
         });
 
-        Ok(CreateSandboxResponse {})
+        Ok(())
     }
 
     pub async fn delete_sandbox(
@@ -626,35 +738,34 @@ impl VmDriver {
             validate_sandbox_id(sandbox_id)?;
         }
 
-        let record = {
+        let record_id = {
             let registry = self.registry.lock().await;
-            if let Some((id, record)) = registry.get_key_value(sandbox_id) {
-                Some((
-                    id.clone(),
-                    record.state_dir.clone(),
-                    record.process.clone(),
-                    record.gpu_bdf.clone(),
-                ))
+            if let Some((id, _record)) = registry.get_key_value(sandbox_id) {
+                Some(id.clone())
             } else {
-                let matched_id = registry
+                registry
                     .iter()
                     .find(|(_, record)| record.snapshot.name == sandbox_name)
-                    .map(|(id, _)| id.clone());
-                matched_id.and_then(|id| {
-                    registry.get(&id).map(|record| {
-                        (
-                            id,
-                            record.state_dir.clone(),
-                            record.process.clone(),
-                            record.gpu_bdf.clone(),
-                        )
-                    })
-                })
+                    .map(|(id, _)| id.clone())
             }
         };
 
-        let Some((record_id, state_dir, process, gpu_bdf)) = record else {
+        let Some(record_id) = record_id else {
             return Ok(DeleteSandboxResponse { deleted: false });
+        };
+
+        let (state_dir, process, gpu_bdf, provisioning_task) = {
+            let mut registry = self.registry.lock().await;
+            let Some(record) = registry.get_mut(&record_id) else {
+                return Ok(DeleteSandboxResponse { deleted: false });
+            };
+            record.deleting = true;
+            (
+                record.state_dir.clone(),
+                record.process.clone(),
+                record.gpu_bdf.clone(),
+                record.provisioning_task.take(),
+            )
         };
 
         if let Some(snapshot) = self
@@ -664,7 +775,11 @@ impl VmDriver {
             self.publish_snapshot(snapshot);
         }
 
-        {
+        if let Some(task) = provisioning_task {
+            task.abort();
+        }
+
+        if let Some(process) = process {
             let mut process = process.lock().await;
             process.deleting = true;
             terminate_vm_process(&mut process.child)
@@ -728,6 +843,67 @@ impl VmDriver {
         }
         if let Ok(mut alloc) = self.subnet_allocator.lock() {
             alloc.release(sandbox_id);
+        }
+    }
+
+    async fn ensure_provisioning_active(&self, sandbox_id: &str) -> Result<(), Status> {
+        let registry = self.registry.lock().await;
+        match registry.get(sandbox_id) {
+            Some(record) if !record.deleting => Ok(()),
+            _ => Err(Status::cancelled("sandbox provisioning cancelled")),
+        }
+    }
+
+    async fn record_gpu_assignment(&self, sandbox_id: &str, bdf: String) -> bool {
+        let mut registry = self.registry.lock().await;
+        match registry.get_mut(sandbox_id) {
+            Some(record) if !record.deleting => {
+                record.gpu_bdf = Some(bdf);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    async fn fail_provisioning(
+        &self,
+        sandbox_id: &str,
+        state_dir: &Path,
+        reason: &str,
+        message: &str,
+    ) {
+        self.release_gpu_and_subnet(sandbox_id);
+        let snapshot = {
+            let mut registry = self.registry.lock().await;
+            let Some(record) = registry.get_mut(sandbox_id) else {
+                return;
+            };
+            if record.deleting {
+                return;
+            }
+            record.process = None;
+            record.provisioning_task = None;
+            record.gpu_bdf = None;
+            record.snapshot.status = Some(status_with_condition(
+                &record.snapshot,
+                error_condition(reason, message),
+                false,
+            ));
+            Some(record.snapshot.clone())
+        };
+
+        let _ = tokio::fs::remove_dir_all(state_dir).await;
+        self.publish_platform_event(
+            sandbox_id.to_string(),
+            platform_event(
+                "vm",
+                "Warning",
+                reason,
+                format!("VM provisioning failed: {message}"),
+            ),
+        );
+        if let Some(snapshot) = snapshot {
+            self.publish_snapshot(snapshot);
         }
     }
 
@@ -800,6 +976,15 @@ impl VmDriver {
         let client = registry_client();
         let auth = registry_auth(image_ref)?;
         info!(image_ref = %image_ref, "vm driver: authenticating with registry");
+        self.publish_vm_progress(
+            sandbox_id,
+            "AuthenticatingRegistry",
+            format!("Authenticating registry access for image \"{image_ref}\""),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), "registry".to_string()),
+            ]),
+        );
         client
             .auth(&reference, &auth, RegistryOperation::Pull)
             .await
@@ -809,6 +994,15 @@ impl VmDriver {
                 ))
             })?;
         info!(image_ref = %image_ref, "vm driver: fetching manifest digest");
+        self.publish_vm_progress(
+            sandbox_id,
+            "FetchingManifest",
+            format!("Fetching manifest for image \"{image_ref}\""),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), "registry".to_string()),
+            ]),
+        );
         let source_image_identity = client
             .fetch_manifest_digest(&reference, &auth)
             .await
@@ -825,10 +1019,8 @@ impl VmDriver {
         let image_identity = prepared_image_cache_identity(&source_image_identity);
         let image_path = image_cache_rootfs_image(&self.config.state_dir, &image_identity);
 
-        // Mirror the K8s `Pulling` event so the CLI flips to the
-        // image-pull spinner with the image name as detail. We emit it
-        // for cache hits too and immediately follow with `Pulled` so the
-        // spinner step still advances cleanly.
+        // Emit a driver progress hint for cache hits too and immediately
+        // follow with `Pulled` so the image step still advances cleanly.
         self.publish_platform_event(
             sandbox_id.to_string(),
             platform_event(
@@ -845,6 +1037,17 @@ impl VmDriver {
                 image_path = %image_path.display(),
                 "vm driver: root disk image cache hit (no build needed)"
             );
+            self.publish_vm_progress(
+                sandbox_id,
+                "CacheHit",
+                format!("Using cached VM root disk for image \"{image_ref}\""),
+                HashMap::from([
+                    ("image_ref".to_string(), image_ref.to_string()),
+                    ("image_source".to_string(), "registry".to_string()),
+                    ("cache_hit".to_string(), "true".to_string()),
+                    ("image_identity".to_string(), image_identity.clone()),
+                ]),
+            );
             self.publish_pulled_event(sandbox_id, image_ref, &image_path)
                 .await;
             return Ok(image_identity);
@@ -853,6 +1056,26 @@ impl VmDriver {
         info!(
             image_identity = %image_identity,
             "vm driver: root disk image cache miss, acquiring build lock"
+        );
+        self.publish_vm_progress(
+            sandbox_id,
+            "CacheMiss",
+            format!("Preparing VM root disk cache for image \"{image_ref}\""),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), "registry".to_string()),
+                ("cache_hit".to_string(), "false".to_string()),
+                ("image_identity".to_string(), image_identity.clone()),
+            ]),
+        );
+        self.publish_vm_progress(
+            sandbox_id,
+            "WaitingForImageCacheLock",
+            "Waiting for VM image cache build lock".to_string(),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_identity".to_string(), image_identity.clone()),
+            ]),
         );
         let _cache_guard = self.image_cache_lock.lock().await;
         info!(
@@ -863,6 +1086,17 @@ impl VmDriver {
             info!(
                 image_identity = %image_identity,
                 "vm driver: root disk image cache hit after lock (built by another task)"
+            );
+            self.publish_vm_progress(
+                sandbox_id,
+                "CacheHit",
+                format!("Using cached VM root disk for image \"{image_ref}\""),
+                HashMap::from([
+                    ("image_ref".to_string(), image_ref.to_string()),
+                    ("image_source".to_string(), "registry".to_string()),
+                    ("cache_hit".to_string(), "true".to_string()),
+                    ("image_identity".to_string(), image_identity.clone()),
+                ]),
             );
             self.publish_pulled_event(sandbox_id, image_ref, &image_path)
                 .await;
@@ -977,19 +1211,61 @@ impl VmDriver {
         );
 
         if tokio::fs::metadata(&image_path).await.is_ok() {
+            self.publish_vm_progress(
+                sandbox_id,
+                "CacheHit",
+                format!("Using cached VM root disk for local image \"{image_ref}\""),
+                HashMap::from([
+                    ("image_ref".to_string(), image_ref.to_string()),
+                    ("image_source".to_string(), "local_docker".to_string()),
+                    ("cache_hit".to_string(), "true".to_string()),
+                    ("image_identity".to_string(), cache_identity.clone()),
+                ]),
+            );
             self.publish_pulled_event(sandbox_id, image_ref, &image_path)
                 .await;
             return Ok(cache_identity);
         }
 
+        self.publish_vm_progress(
+            sandbox_id,
+            "CacheMiss",
+            format!("Preparing VM root disk cache for local image \"{image_ref}\""),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), "local_docker".to_string()),
+                ("cache_hit".to_string(), "false".to_string()),
+                ("image_identity".to_string(), cache_identity.clone()),
+            ]),
+        );
+        self.publish_vm_progress(
+            sandbox_id,
+            "WaitingForImageCacheLock",
+            "Waiting for VM image cache build lock".to_string(),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_identity".to_string(), cache_identity.clone()),
+            ]),
+        );
         let _cache_guard = self.image_cache_lock.lock().await;
         if tokio::fs::metadata(&image_path).await.is_ok() {
+            self.publish_vm_progress(
+                sandbox_id,
+                "CacheHit",
+                format!("Using cached VM root disk for local image \"{image_ref}\""),
+                HashMap::from([
+                    ("image_ref".to_string(), image_ref.to_string()),
+                    ("image_source".to_string(), "local_docker".to_string()),
+                    ("cache_hit".to_string(), "true".to_string()),
+                    ("image_identity".to_string(), cache_identity.clone()),
+                ]),
+            );
             self.publish_pulled_event(sandbox_id, image_ref, &image_path)
                 .await;
             return Ok(cache_identity);
         }
 
-        self.build_cached_local_image_rootfs_image(docker, image_ref, &cache_identity)
+        self.build_cached_local_image_rootfs_image(sandbox_id, docker, image_ref, &cache_identity)
             .await?;
         self.publish_pulled_event(sandbox_id, image_ref, &image_path)
             .await;
@@ -998,6 +1274,7 @@ impl VmDriver {
 
     async fn build_cached_local_image_rootfs_image(
         &self,
+        sandbox_id: &str,
         docker: &Docker,
         image_ref: &str,
         image_identity: &str,
@@ -1031,6 +1308,16 @@ impl VmDriver {
                 Status::internal(format!("create image cache staging dir failed: {err}"))
             })?;
 
+        self.publish_vm_progress(
+            sandbox_id,
+            "ExportingRootfs",
+            format!("Exporting rootfs from local image \"{image_ref}\""),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), "local_docker".to_string()),
+                ("image_identity".to_string(), image_identity.to_string()),
+            ]),
+        );
         if let Err(err) =
             export_local_image_rootfs_to_path(docker, image_ref, &exported_rootfs).await
         {
@@ -1042,18 +1329,51 @@ impl VmDriver {
         let image_identity_owned = image_identity.to_string();
         let exported_rootfs_for_build = exported_rootfs.clone();
         let prepared_rootfs_for_build = prepared_rootfs.clone();
-        let prepared_image_for_build = prepared_image.clone();
-        let build_result = tokio::task::spawn_blocking(move || {
-            prepare_exported_rootfs_image(
-                &image_ref_owned,
-                &image_identity_owned,
-                &exported_rootfs_for_build,
+        self.publish_vm_progress(
+            sandbox_id,
+            "PreparingRootfs",
+            format!("Preparing VM rootfs for local image \"{image_ref}\""),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), "local_docker".to_string()),
+                ("image_identity".to_string(), image_identity.to_string()),
+            ]),
+        );
+        let prepare_result = tokio::task::spawn_blocking(move || {
+            extract_rootfs_archive_to(&exported_rootfs_for_build, &prepared_rootfs_for_build)?;
+            prepare_sandbox_rootfs_from_image_root(
                 &prepared_rootfs_for_build,
-                &prepared_image_for_build,
+                &image_identity_owned,
             )
+            .map_err(|err| {
+                format!("vm sandbox image '{image_ref_owned}' is not base-compatible: {err}")
+            })
         })
         .await
         .map_err(|err| Status::internal(format!("local image preparation panicked: {err}")))?;
+
+        if let Err(err) = prepare_result {
+            let _ = tokio::fs::remove_dir_all(&staging_dir).await;
+            return Err(Status::failed_precondition(err));
+        }
+
+        self.publish_vm_progress(
+            sandbox_id,
+            "CreatingRootDisk",
+            "Formatting VM root disk image".to_string(),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), "local_docker".to_string()),
+                ("image_identity".to_string(), image_identity.to_string()),
+            ]),
+        );
+        let prepared_rootfs_for_build = prepared_rootfs.clone();
+        let prepared_image_for_build = prepared_image.clone();
+        let build_result = tokio::task::spawn_blocking(move || {
+            create_rootfs_image_from_dir(&prepared_rootfs_for_build, &prepared_image_for_build)
+        })
+        .await
+        .map_err(|err| Status::internal(format!("rootfs image build panicked: {err}")))?;
 
         if let Err(err) = build_result {
             let _ = tokio::fs::remove_dir_all(&staging_dir).await;
@@ -1142,19 +1462,55 @@ impl VmDriver {
         let image_ref_owned = image_ref.to_string();
         let image_identity_owned = image_identity.to_string();
         let prepared_rootfs_for_build = prepared_rootfs.clone();
-        let prepared_image_for_build = prepared_image.clone();
-        let build_result = tokio::task::spawn_blocking(move || {
+        self.publish_vm_progress(
+            sandbox_id,
+            "PreparingRootfs",
+            format!("Preparing VM rootfs for image \"{image_ref}\""),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), "registry".to_string()),
+                ("image_identity".to_string(), image_identity.to_string()),
+            ]),
+        );
+        let prepare_result = tokio::task::spawn_blocking(move || {
             prepare_sandbox_rootfs_from_image_root(
                 &prepared_rootfs_for_build,
                 &image_identity_owned,
             )
             .map_err(|err| {
                 format!("vm sandbox image '{image_ref_owned}' is not base-compatible: {err}")
-            })?;
-            create_rootfs_image_from_dir(&prepared_rootfs_for_build, &prepared_image_for_build)
+            })
         })
         .await
         .map_err(|err| Status::internal(format!("image rootfs preparation panicked: {err}")))?;
+
+        if let Err(err) = prepare_result {
+            warn!(
+                image_ref = %image_ref,
+                error = %err,
+                "vm driver: rootfs preparation failed"
+            );
+            let _ = tokio::fs::remove_dir_all(&staging_dir).await;
+            return Err(Status::failed_precondition(err));
+        }
+
+        self.publish_vm_progress(
+            sandbox_id,
+            "CreatingRootDisk",
+            "Formatting VM root disk image".to_string(),
+            HashMap::from([
+                ("image_ref".to_string(), image_ref.to_string()),
+                ("image_source".to_string(), "registry".to_string()),
+                ("image_identity".to_string(), image_identity.to_string()),
+            ]),
+        );
+        let prepared_rootfs_for_build = prepared_rootfs.clone();
+        let prepared_image_for_build = prepared_image.clone();
+        let build_result = tokio::task::spawn_blocking(move || {
+            create_rootfs_image_from_dir(&prepared_rootfs_for_build, &prepared_image_for_build)
+        })
+        .await
+        .map_err(|err| Status::internal(format!("image rootfs build panicked: {err}")))?;
 
         if let Err(err) = build_result {
             warn!(
@@ -1203,7 +1559,10 @@ impl VmDriver {
                 let Some(record) = registry.get(&sandbox_id) else {
                     return;
                 };
-                record.process.clone()
+                let Some(process) = record.process.as_ref() else {
+                    return;
+                };
+                process.clone()
             };
 
             let exit_status = {
@@ -1313,6 +1672,19 @@ impl VmDriver {
                 },
             )),
         });
+    }
+
+    fn publish_vm_progress(
+        &self,
+        sandbox_id: &str,
+        reason: &str,
+        message: String,
+        metadata: HashMap<String, String>,
+    ) {
+        let mut event = platform_event("vm", "Normal", reason, message);
+        event.metadata = metadata;
+        attach_vm_progress_metadata(&mut event);
+        self.publish_platform_event(sandbox_id.to_string(), event);
     }
 }
 
@@ -1696,19 +2068,6 @@ async fn export_local_image_rootfs_to_path(
     }
 }
 
-fn prepare_exported_rootfs_image(
-    image_ref: &str,
-    image_identity: &str,
-    exported_rootfs: &Path,
-    prepared_rootfs: &Path,
-    prepared_image: &Path,
-) -> Result<(), String> {
-    extract_rootfs_archive_to(exported_rootfs, prepared_rootfs)?;
-    prepare_sandbox_rootfs_from_image_root(prepared_rootfs, image_identity)
-        .map_err(|err| format!("vm sandbox image '{image_ref}' is not base-compatible: {err}"))?;
-    create_rootfs_image_from_dir(prepared_rootfs, prepared_image)
-}
-
 fn registry_client() -> OciClient {
     OciClient::new(ClientConfig {
         platform_resolver: Some(Box::new(linux_platform_resolver)),
@@ -1826,76 +2185,105 @@ impl VmDriver {
 
         let total_layers = manifest.layers.len();
         let total_bytes: i64 = manifest.layers.iter().map(|layer| layer.size.max(0)).sum();
-        for (index, layer) in manifest.layers.iter().enumerate() {
-            // Emit a per-layer progress event so the CLI can show
-            // "Layer 3/8 (12.4 MB)" as detail under the spinner.
-            let mut metadata = HashMap::new();
-            metadata.insert("layer_index".to_string(), (index + 1).to_string());
-            metadata.insert("layer_total".to_string(), total_layers.to_string());
-            metadata.insert("layer_digest".to_string(), layer.digest.clone());
-            metadata.insert("layer_size_bytes".to_string(), layer.size.to_string());
-            metadata.insert("image_ref".to_string(), image_ref.to_string());
-            if total_bytes > 0 {
-                metadata.insert("image_size_bytes".to_string(), total_bytes.to_string());
-            }
-            let mut event = platform_event(
-                "vm",
-                "Normal",
-                "PullingLayer",
-                format!(
-                    "Pulling layer {}/{} ({} bytes) for image \"{image_ref}\"",
-                    index + 1,
+        let mut layers = futures::stream::iter(manifest.layers.iter().cloned().enumerate())
+            .map(|(index, layer)| async move {
+                self.publish_registry_layer_progress(
+                    sandbox_id,
+                    image_ref,
+                    &layer,
+                    index,
                     total_layers,
-                    layer.size
-                ),
-            );
-            event.metadata = metadata;
-            self.publish_platform_event(sandbox_id.to_string(), event);
-
-            pull_registry_layer(
-                client,
-                reference,
-                image_ref,
-                staging_dir,
-                rootfs,
-                layer,
-                index,
-            )
+                    total_bytes,
+                );
+                download_registry_layer_blob(
+                    client,
+                    reference,
+                    image_ref,
+                    staging_dir,
+                    layer,
+                    index,
+                )
+                .await
+            })
+            .buffer_unordered(registry_layer_download_concurrency())
+            .try_collect::<Vec<_>>()
             .await?;
+        layers.sort_by_key(|layer| layer.index);
+
+        for layer in &layers {
+            apply_registry_layer_blob(image_ref, rootfs, layer).await?;
         }
 
         Ok(())
     }
 
-    /// Emit a `Pulled` platform event with a message that mirrors the
-    /// kubelet's `Successfully pulled image ... Image size: N bytes.`
-    /// format so the CLI's `extract_image_size` parser works unchanged.
+    fn publish_registry_layer_progress(
+        &self,
+        sandbox_id: &str,
+        image_ref: &str,
+        layer: &OciDescriptor,
+        index: usize,
+        total_layers: usize,
+        total_bytes: i64,
+    ) {
+        let mut metadata = HashMap::new();
+        metadata.insert("layer_index".to_string(), (index + 1).to_string());
+        metadata.insert("layer_total".to_string(), total_layers.to_string());
+        metadata.insert("layer_digest".to_string(), layer.digest.clone());
+        metadata.insert("layer_size_bytes".to_string(), layer.size.to_string());
+        metadata.insert("image_ref".to_string(), image_ref.to_string());
+        if total_bytes > 0 {
+            metadata.insert("image_size_bytes".to_string(), total_bytes.to_string());
+        }
+        let mut event = platform_event(
+            "vm",
+            "Normal",
+            "PullingLayer",
+            format!(
+                "Pulling layer {}/{} ({} bytes) for image \"{image_ref}\"",
+                index + 1,
+                total_layers,
+                layer.size
+            ),
+        );
+        event.metadata = metadata;
+        attach_vm_progress_metadata(&mut event);
+        self.publish_platform_event(sandbox_id.to_string(), event);
+    }
+
+    /// Emit a `Pulled` platform event with progress metadata for the CLI.
     async fn publish_pulled_event(&self, sandbox_id: &str, image_ref: &str, image_path: &Path) {
+        let mut metadata = HashMap::from([("image_ref".to_string(), image_ref.to_string())]);
         let size_suffix = tokio::fs::metadata(image_path).await.map_or_else(
             |_| String::new(),
-            |meta| format!(" Image size: {} bytes.", meta.len()),
+            |meta| {
+                metadata.insert("image_size_bytes".to_string(), meta.len().to_string());
+                format!(" Image size: {} bytes.", meta.len())
+            },
         );
-        self.publish_platform_event(
-            sandbox_id.to_string(),
-            platform_event(
-                "vm",
-                "Normal",
-                "Pulled",
-                format!("Successfully pulled image \"{image_ref}\".{size_suffix}"),
-            ),
+        self.publish_vm_progress(
+            sandbox_id,
+            "Pulled",
+            format!("Successfully pulled image \"{image_ref}\".{size_suffix}"),
+            metadata,
         );
     }
 }
 
-async fn pull_registry_layer(
+struct DownloadedRegistryLayer {
+    index: usize,
+    digest: String,
+    layer_root: PathBuf,
+}
+
+async fn download_registry_layer_blob(
     client: &OciClient,
     reference: &Reference,
     image_ref: &str,
     staging_dir: &Path,
-    rootfs: &Path,
-    layer: &OciDescriptor,
+    layer: OciDescriptor,
     index: usize,
-) -> Result<(), Status> {
+) -> Result<DownloadedRegistryLayer, Status> {
     let digest_component = sanitize_image_identity(&layer.digest);
     let blob_path = staging_dir
         .join("layers")
@@ -1908,7 +2296,7 @@ async fn pull_registry_layer(
         .await
         .map_err(|err| Status::internal(format!("create layer blob failed: {err}")))?;
     client
-        .pull_blob(reference, layer, &mut file)
+        .pull_blob(reference, &layer, &mut file)
         .await
         .map_err(|err| {
             Status::failed_precondition(format!(
@@ -1936,14 +2324,38 @@ async fn pull_registry_layer(
 
     let blob_path_for_unpack = blob_path.clone();
     let layer_root_for_unpack = layer_root.clone();
-    let rootfs_for_unpack = rootfs.to_path_buf();
     let media_type = layer.media_type.clone();
     tokio::task::spawn_blocking(move || {
-        extract_layer_blob_to_dir(&blob_path_for_unpack, &media_type, &layer_root_for_unpack)?;
-        apply_layer_dir_to_rootfs(&layer_root_for_unpack, &rootfs_for_unpack)
+        extract_layer_blob_to_dir(&blob_path_for_unpack, &media_type, &layer_root_for_unpack)
     })
     .await
     .map_err(|err| Status::internal(format!("layer extraction panicked: {err}")))?
+    .map_err(|err| {
+        Status::failed_precondition(format!(
+            "failed to extract layer '{}' for vm sandbox image '{image_ref}': {err}",
+            layer.digest
+        ))
+    })?;
+
+    Ok(DownloadedRegistryLayer {
+        index,
+        digest: layer.digest,
+        layer_root,
+    })
+}
+
+async fn apply_registry_layer_blob(
+    image_ref: &str,
+    rootfs: &Path,
+    layer: &DownloadedRegistryLayer,
+) -> Result<(), Status> {
+    let layer_root_for_unpack = layer.layer_root.clone();
+    let rootfs_for_unpack = rootfs.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        apply_layer_dir_to_rootfs(&layer_root_for_unpack, &rootfs_for_unpack)
+    })
+    .await
+    .map_err(|err| Status::internal(format!("layer application panicked: {err}")))?
     .map_err(|err| {
         Status::failed_precondition(format!(
             "failed to apply layer '{}' for vm sandbox image '{image_ref}': {err}",
@@ -2436,6 +2848,20 @@ fn prepared_image_cache_identity(image_identity: &str) -> String {
     format!("{IMAGE_CACHE_LAYOUT_VERSION}:{image_identity}")
 }
 
+fn registry_layer_download_concurrency() -> usize {
+    let value = std::env::var("OPENSHELL_VM_IMAGE_PULL_CONCURRENCY").ok();
+    registry_layer_download_concurrency_value(value.as_deref())
+}
+
+fn registry_layer_download_concurrency_value(value: Option<&str>) -> usize {
+    value
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .map_or(DEFAULT_REGISTRY_LAYER_DOWNLOAD_CONCURRENCY, |value| {
+            value.min(MAX_REGISTRY_LAYER_DOWNLOAD_CONCURRENCY)
+        })
+}
+
 fn sanitize_image_identity(image_identity: &str) -> String {
     image_identity
         .chars()
@@ -2568,7 +2994,7 @@ fn overlay_staging_dir(overlay_disk: &Path) -> PathBuf {
     parent.join(format!(
         ".openshell-overlay-staging-{}-{}",
         std::process::id(),
-        current_time_ms()
+        openshell_core::time::now_ms()
     ))
 }
 
@@ -2655,13 +3081,118 @@ fn error_condition(reason: &str, message: &str) -> SandboxCondition {
 }
 
 fn platform_event(source: &str, event_type: &str, reason: &str, message: String) -> PlatformEvent {
-    PlatformEvent {
+    let mut event = PlatformEvent {
         timestamp_ms: openshell_core::time::now_ms(),
         source: source.to_string(),
         r#type: event_type.to_string(),
         reason: reason.to_string(),
         message,
         metadata: HashMap::new(),
+    };
+    attach_vm_progress_metadata(&mut event);
+    event
+}
+
+fn attach_vm_progress_metadata(event: &mut PlatformEvent) {
+    if event.source != "vm" {
+        return;
+    }
+
+    match event.reason.as_str() {
+        "Scheduled" => {
+            mark_progress_complete(
+                &mut event.metadata,
+                PROGRESS_STEP_REQUESTING_SANDBOX,
+                "Sandbox allocated",
+            );
+            mark_progress_active(&mut event.metadata, PROGRESS_STEP_PULLING_IMAGE);
+        }
+        "Pulling" => {
+            mark_progress_active(&mut event.metadata, PROGRESS_STEP_PULLING_IMAGE);
+            if let Some(image_ref) = event.metadata.get("image_ref").cloned() {
+                mark_progress_detail(&mut event.metadata, image_ref);
+            } else if let Some(image_ref) = pulling_image_from_message(&event.message) {
+                mark_progress_detail(&mut event.metadata, image_ref);
+            }
+        }
+        "Pulled" => {
+            let label = pulled_label(event);
+            mark_progress_complete(&mut event.metadata, PROGRESS_STEP_PULLING_IMAGE, label);
+            mark_progress_active(&mut event.metadata, PROGRESS_STEP_STARTING_SANDBOX);
+        }
+        "PullingLayer" => {
+            if let Some(detail) = pulling_layer_detail(&event.metadata) {
+                mark_progress_detail(&mut event.metadata, detail);
+            }
+        }
+        "ResolvingImage" => mark_progress_detail(&mut event.metadata, "Resolving image"),
+        "AuthenticatingRegistry" => {
+            mark_progress_detail(&mut event.metadata, "Authenticating registry");
+        }
+        "FetchingManifest" => mark_progress_detail(&mut event.metadata, "Fetching image manifest"),
+        "CacheHit" => mark_progress_detail(&mut event.metadata, "Using cached root disk"),
+        "CacheMiss" => mark_progress_detail(&mut event.metadata, "Preparing image cache"),
+        "WaitingForImageCacheLock" => {
+            mark_progress_detail(&mut event.metadata, "Waiting for image cache lock");
+        }
+        "ExportingRootfs" => {
+            mark_progress_detail(&mut event.metadata, "Exporting local image rootfs");
+        }
+        "PreparingRootfs" => mark_progress_detail(&mut event.metadata, "Preparing rootfs"),
+        "CreatingRootDisk" => mark_progress_detail(&mut event.metadata, "Formatting root disk"),
+        "PreparingOverlay" => mark_progress_detail(&mut event.metadata, "Preparing overlay disk"),
+        "Started" => mark_progress_detail(&mut event.metadata, "VM launcher started"),
+        _ => {}
+    }
+}
+
+fn pulling_image_from_message(message: &str) -> Option<String> {
+    let image = message
+        .strip_prefix("Pulling image ")
+        .map(str::trim)
+        .map(|value| value.trim_matches('"'))?;
+    (!image.is_empty()).then(|| image.to_string())
+}
+
+fn pulled_label(event: &PlatformEvent) -> String {
+    event
+        .metadata
+        .get("image_size_bytes")
+        .and_then(|value| value.parse::<u64>().ok())
+        .map_or_else(
+            || "Image pulled".to_string(),
+            |bytes| format!("Image pulled ({})", format_bytes(bytes)),
+        )
+}
+
+fn pulling_layer_detail(metadata: &HashMap<String, String>) -> Option<String> {
+    let index = metadata.get("layer_index")?;
+    let total = metadata.get("layer_total")?;
+    let size = metadata
+        .get("layer_size_bytes")
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(format_bytes);
+    Some(size.map_or_else(
+        || format!("Layer {index}/{total}"),
+        |size| format!("Layer {index}/{total} ({size})"),
+    ))
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * KB;
+    const GB: u64 = 1024 * MB;
+
+    if bytes >= GB {
+        #[allow(clippy::cast_precision_loss)]
+        let gb = bytes as f64 / GB as f64;
+        format!("{gb:.1} GB")
+    } else if bytes >= MB {
+        format!("{} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("{} KB", bytes / KB)
+    } else {
+        format!("{bytes} B")
     }
 }
 
@@ -2669,6 +3200,10 @@ fn platform_event(source: &str, event_type: &str, reason: &str, message: String)
 mod tests {
     use super::*;
     use crate::gpu::{SubnetAllocator, allocate_vsock_cid, mac_from_sandbox_id, tap_device_name};
+    use openshell_core::progress::{
+        PROGRESS_ACTIVE_DETAIL_KEY, PROGRESS_ACTIVE_STEP_KEY, PROGRESS_COMPLETE_LABEL_KEY,
+        PROGRESS_COMPLETE_STEP_KEY,
+    };
     use openshell_core::proto::compute::v1::{
         DriverSandboxSpec as SandboxSpec, DriverSandboxTemplate as SandboxTemplate,
     };
@@ -2678,6 +3213,68 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
     use tonic::Code;
+
+    #[test]
+    fn vm_pulling_layer_event_adds_progress_detail_metadata() {
+        let mut event = platform_event(
+            "vm",
+            "Normal",
+            "PullingLayer",
+            "Pulling layer 3/8 for image".to_string(),
+        );
+        event.metadata = HashMap::from([
+            ("layer_index".to_string(), "3".to_string()),
+            ("layer_total".to_string(), "8".to_string()),
+            ("layer_size_bytes".to_string(), "44040192".to_string()),
+        ]);
+
+        attach_vm_progress_metadata(&mut event);
+
+        assert_eq!(
+            event
+                .metadata
+                .get(PROGRESS_ACTIVE_DETAIL_KEY)
+                .map(String::as_str),
+            Some("Layer 3/8 (42 MB)")
+        );
+    }
+
+    #[test]
+    fn vm_pulled_event_adds_completed_image_progress_metadata() {
+        let mut event = platform_event(
+            "vm",
+            "Normal",
+            "Pulled",
+            "Successfully pulled image".to_string(),
+        );
+        event
+            .metadata
+            .insert("image_size_bytes".to_string(), "44040192".to_string());
+
+        attach_vm_progress_metadata(&mut event);
+
+        assert_eq!(
+            event
+                .metadata
+                .get(PROGRESS_COMPLETE_STEP_KEY)
+                .map(String::as_str),
+            Some(PROGRESS_STEP_PULLING_IMAGE)
+        );
+        assert_eq!(
+            event
+                .metadata
+                .get(PROGRESS_COMPLETE_LABEL_KEY)
+                .map(String::as_str),
+            Some("Image pulled (42 MB)")
+        );
+        assert_eq!(
+            event
+                .metadata
+                .get(PROGRESS_ACTIVE_STEP_KEY)
+                .map(String::as_str),
+            Some(PROGRESS_STEP_STARTING_SANDBOX)
+        );
+    }
 
     #[test]
     fn validate_vm_sandbox_rejects_gpu_when_not_enabled() {
@@ -2992,7 +3589,7 @@ mod tests {
         };
         let sandbox = Sandbox {
             id: "sandbox-123".to_string(),
-            name: "sandbox-123".to_string(),
+            name: "breezy-rhinoceros".to_string(),
             spec: Some(SandboxSpec::default()),
             ..Default::default()
         };
@@ -3003,6 +3600,7 @@ mod tests {
             "OPENSHELL_ENDPOINT=http://{GVPROXY_HOST_LOOPBACK_ALIAS}:8080/"
         )));
         assert!(env.contains(&"OPENSHELL_SANDBOX_ID=sandbox-123".to_string()));
+        assert!(env.contains(&"OPENSHELL_SANDBOX=breezy-rhinoceros".to_string()));
         assert!(env.contains(&format!(
             "OPENSHELL_SSH_SOCKET_PATH={GUEST_SSH_SOCKET_PATH}"
         )));
@@ -3291,10 +3889,10 @@ mod tests {
             let mut registry = driver.registry.lock().await;
             let record = registry.get_mut("sandbox-123").unwrap();
             record.state_dir = retry_state_dir;
-            record.process = Arc::new(Mutex::new(VmProcess {
+            record.process = Some(Arc::new(Mutex::new(VmProcess {
                 child: spawn_exited_child(),
                 deleting: false,
-            }));
+            })));
         }
 
         let response = driver
@@ -3303,6 +3901,59 @@ mod tests {
             .expect("delete retry should succeed once cleanup works");
         assert!(response.deleted);
         assert!(!driver.registry.lock().await.contains_key("sandbox-123"));
+
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[tokio::test]
+    async fn delete_sandbox_cleans_provisioning_record_without_process() {
+        let base = unique_temp_dir();
+        let driver_state = base.join("driver-state");
+        let (events, _) = broadcast::channel(WATCH_BUFFER);
+        let driver = VmDriver {
+            config: VmDriverConfig {
+                state_dir: driver_state.clone(),
+                ..Default::default()
+            },
+            launcher_bin: PathBuf::from("openshell-driver-vm"),
+            registry: Arc::new(Mutex::new(HashMap::new())),
+            image_cache_lock: Arc::new(Mutex::new(())),
+            events,
+            gpu_inventory: None,
+            subnet_allocator: Arc::new(std::sync::Mutex::new(SubnetAllocator::new(
+                Ipv4Addr::new(10, 0, 128, 0),
+                17,
+            ))),
+        };
+
+        let state_dir = sandbox_state_dir(&driver_state, "sandbox-123").unwrap();
+        std::fs::create_dir_all(&state_dir).unwrap();
+        {
+            let mut registry = driver.registry.lock().await;
+            registry.insert(
+                "sandbox-123".to_string(),
+                SandboxRecord {
+                    snapshot: Sandbox {
+                        id: "sandbox-123".to_string(),
+                        name: "sandbox-123".to_string(),
+                        ..Default::default()
+                    },
+                    state_dir: state_dir.clone(),
+                    process: None,
+                    provisioning_task: None,
+                    gpu_bdf: None,
+                    deleting: false,
+                },
+            );
+        }
+
+        let response = driver
+            .delete_sandbox("sandbox-123", "sandbox-123")
+            .await
+            .expect("delete should handle accepted-but-not-started sandboxes");
+        assert!(response.deleted);
+        assert!(!driver.registry.lock().await.contains_key("sandbox-123"));
+        assert!(!state_dir.exists());
 
         let _ = std::fs::remove_dir_all(base);
     }
@@ -3374,7 +4025,24 @@ mod tests {
     fn prepared_image_cache_identity_includes_rootfs_layout_version() {
         assert_eq!(
             prepared_image_cache_identity("sha256:local-image"),
-            format!("{IMAGE_CACHE_LAYOUT_VERSION}:sha256:local-image")
+            "sandbox-rootfs-ext4-overlay-v2:sha256:local-image"
+        );
+    }
+
+    #[test]
+    fn registry_layer_download_concurrency_is_bounded() {
+        assert_eq!(
+            registry_layer_download_concurrency_value(None),
+            DEFAULT_REGISTRY_LAYER_DOWNLOAD_CONCURRENCY
+        );
+        assert_eq!(
+            registry_layer_download_concurrency_value(Some("0")),
+            DEFAULT_REGISTRY_LAYER_DOWNLOAD_CONCURRENCY
+        );
+        assert_eq!(registry_layer_download_concurrency_value(Some("8")), 8);
+        assert_eq!(
+            registry_layer_download_concurrency_value(Some("999")),
+            MAX_REGISTRY_LAYER_DOWNLOAD_CONCURRENCY
         );
     }
 
@@ -3529,8 +4197,10 @@ mod tests {
             SandboxRecord {
                 snapshot: sandbox,
                 state_dir,
-                process,
+                process: Some(process),
+                provisioning_task: None,
                 gpu_bdf: None,
+                deleting: false,
             },
         );
     }

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -413,20 +413,10 @@ impl VmDriver {
             "vm driver: resolved image ref, preparing disks"
         );
 
-        tokio::fs::create_dir_all(&state_dir)
-            .await
-            .map_err(|err| Status::internal(format!("create state dir failed: {err}")))?;
-
-        let tls_paths = self
-            .config
-            .tls_paths()
-            .map_err(Status::failed_precondition)?;
-
         let snapshot = sandbox_snapshot(sandbox, provisioning_condition(), false);
         {
             let mut registry = self.registry.lock().await;
             if registry.contains_key(&sandbox.id) {
-                let _ = tokio::fs::remove_dir_all(&state_dir).await;
                 return Err(Status::already_exists("sandbox already exists"));
             }
             registry.insert(
@@ -440,6 +430,21 @@ impl VmDriver {
                     deleting: false,
                 },
             );
+        }
+
+        let tls_paths = match self.config.tls_paths() {
+            Ok(paths) => paths,
+            Err(err) => {
+                let mut registry = self.registry.lock().await;
+                registry.remove(&sandbox.id);
+                return Err(Status::failed_precondition(err));
+            }
+        };
+
+        if let Err(err) = tokio::fs::create_dir_all(&state_dir).await {
+            let mut registry = self.registry.lock().await;
+            registry.remove(&sandbox.id);
+            return Err(Status::internal(format!("create state dir failed: {err}")));
         }
 
         self.publish_platform_event(
@@ -612,6 +617,7 @@ impl VmDriver {
 
         let console_output = state_dir.join("rootfs-console.log");
         let mut command = Command::new(&self.launcher_bin);
+        command.kill_on_drop(true);
         command.stdin(Stdio::null());
         command.stdout(Stdio::inherit());
         command.stderr(Stdio::inherit());
@@ -1717,6 +1723,7 @@ impl VmDriver {
     ) -> Result<(), Status> {
         let console_output = run_dir.join("image-prep-console.log");
         let mut command = Command::new(&self.launcher_bin);
+        command.kill_on_drop(true);
         command.stdin(Stdio::null());
         command.stdout(Stdio::inherit());
         command.stderr(Stdio::inherit());
@@ -1737,10 +1744,13 @@ impl VmDriver {
             .arg("--vm-env")
             .arg(format!("OPENSHELL_VM_INIT_MODE={IMAGE_PREP_INIT_MODE}"));
 
-        let status = command
-            .status()
-            .await
+        let mut child = command
+            .spawn()
             .map_err(|err| Status::internal(format!("failed to run image-prep vm: {err}")))?;
+        let status = child
+            .wait()
+            .await
+            .map_err(|err| Status::internal(format!("failed to wait for image-prep vm: {err}")))?;
         if status.success() {
             return Ok(());
         }
@@ -4907,6 +4917,67 @@ mod tests {
         assert!(response.deleted);
         assert!(!driver.registry.lock().await.contains_key("sandbox-123"));
         assert!(!state_dir.exists());
+
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[tokio::test]
+    async fn duplicate_create_keeps_existing_state_dir() {
+        let base = unique_temp_dir();
+        let driver_state = base.join("driver-state");
+        let (events, _) = broadcast::channel(WATCH_BUFFER);
+        let driver = VmDriver {
+            config: VmDriverConfig {
+                state_dir: driver_state.clone(),
+                default_image: "ghcr.io/example/sandbox:latest".to_string(),
+                ..Default::default()
+            },
+            launcher_bin: PathBuf::from("openshell-driver-vm"),
+            registry: Arc::new(Mutex::new(HashMap::new())),
+            image_cache_lock: Arc::new(Mutex::new(())),
+            events,
+            gpu_inventory: None,
+            subnet_allocator: Arc::new(std::sync::Mutex::new(SubnetAllocator::new(
+                Ipv4Addr::new(10, 0, 128, 0),
+                17,
+            ))),
+        };
+
+        let state_dir = sandbox_state_dir(&driver_state, "sandbox-123").unwrap();
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::write(state_dir.join("overlay.ext4"), b"live overlay").unwrap();
+        {
+            let mut registry = driver.registry.lock().await;
+            registry.insert(
+                "sandbox-123".to_string(),
+                SandboxRecord {
+                    snapshot: Sandbox {
+                        id: "sandbox-123".to_string(),
+                        name: "sandbox-123".to_string(),
+                        ..Default::default()
+                    },
+                    state_dir: state_dir.clone(),
+                    process: None,
+                    provisioning_task: None,
+                    gpu_bdf: None,
+                    deleting: false,
+                },
+            );
+        }
+
+        let err = driver
+            .create_sandbox(&Sandbox {
+                id: "sandbox-123".to_string(),
+                name: "sandbox-123".to_string(),
+                spec: Some(SandboxSpec::default()),
+                ..Default::default()
+            })
+            .await
+            .expect_err("duplicate create should fail");
+
+        assert_eq!(err.code(), Code::AlreadyExists);
+        assert!(state_dir.join("overlay.ext4").exists());
+        assert!(driver.registry.lock().await.contains_key("sandbox-123"));
 
         let _ = std::fs::remove_dir_all(base);
     }

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -5,9 +5,8 @@ use crate::gpu::{
     GpuInventory, SubnetAllocator, allocate_vsock_cid, mac_from_sandbox_id, tap_device_name,
 };
 use crate::rootfs::{
-    copy_rootfs_image_to, create_rootfs_image_from_dir, extract_rootfs_archive_to,
-    prepare_sandbox_rootfs_from_image_root, sandbox_guest_init_path, set_rootfs_image_file_mode,
-    write_rootfs_image_file,
+    create_ext4_image_from_dir_with_size, create_rootfs_image_from_dir, extract_rootfs_archive_to,
+    prepare_sandbox_rootfs_from_image_root, sandbox_guest_init_path,
 };
 use bollard::Docker;
 use bollard::errors::Error as BollardError;
@@ -56,6 +55,7 @@ const DRIVER_NAME: &str = "openshell-driver-vm";
 const WATCH_BUFFER: usize = 256;
 const DEFAULT_VCPUS: u8 = 2;
 const DEFAULT_MEM_MIB: u32 = 2048;
+const DEFAULT_OVERLAY_DISK_MIB: u64 = 4096;
 /// gvproxy host-loopback IP — gvproxy's TCP/UDP/ICMP forwarder NAT-rewrites
 /// this destination to the host's `127.0.0.1` and dials out from the host
 /// process. This is the only address that transparently reaches host-bound
@@ -89,8 +89,9 @@ const GUEST_TLS_CERT_PATH: &str = "/opt/openshell/tls/tls.crt";
 const GUEST_TLS_KEY_PATH: &str = "/opt/openshell/tls/tls.key";
 const IMAGE_CACHE_ROOT_DIR: &str = "images";
 const IMAGE_CACHE_ROOTFS_IMAGE: &str = "rootfs.ext4";
+const SANDBOX_OVERLAY_IMAGE: &str = "overlay.ext4";
 const IMAGE_EXPORT_ROOTFS_ARCHIVE: &str = "source-rootfs.tar";
-const IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-rootfs-ext4-v1";
+const IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-rootfs-ext4-overlay-v1";
 const IMAGE_IDENTITY_FILE: &str = "image-identity";
 const IMAGE_REFERENCE_FILE: &str = "image-reference";
 static IMAGE_CACHE_BUILD_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -112,6 +113,7 @@ pub struct VmDriverConfig {
     pub krun_log_level: u32,
     pub vcpus: u8,
     pub mem_mib: u32,
+    pub overlay_disk_mib: u64,
     pub guest_tls_ca: Option<PathBuf>,
     pub guest_tls_cert: Option<PathBuf>,
     pub guest_tls_key: Option<PathBuf>,
@@ -131,6 +133,7 @@ impl Default for VmDriverConfig {
             krun_log_level: 1,
             vcpus: DEFAULT_VCPUS,
             mem_mib: DEFAULT_MEM_MIB,
+            overlay_disk_mib: DEFAULT_OVERLAY_DISK_MIB,
             guest_tls_ca: None,
             guest_tls_cert: None,
             guest_tls_key: None,
@@ -359,7 +362,6 @@ impl VmDriver {
         let gpu_device = spec.map_or("", |s| s.gpu_device.as_str());
 
         let state_dir = sandbox_state_dir(&self.config.state_dir, &sandbox.id)?;
-        let root_disk = state_dir.join(IMAGE_CACHE_ROOTFS_IMAGE);
         let image_ref = self.resolved_sandbox_image(sandbox).ok_or_else(|| {
             Status::failed_precondition(
                 "vm sandboxes require template.image or a configured default sandbox image",
@@ -369,7 +371,7 @@ impl VmDriver {
             sandbox_id = %sandbox.id,
             image_ref = %image_ref,
             state_dir = %state_dir.display(),
-            "vm driver: resolved image ref, preparing root disk"
+            "vm driver: resolved image ref, preparing disks"
         );
 
         tokio::fs::create_dir_all(&state_dir)
@@ -393,15 +395,12 @@ impl VmDriver {
             ),
         );
 
-        let image_identity = match self
-            .prepare_runtime_rootfs(&sandbox.id, &image_ref, &root_disk)
-            .await
-        {
+        let image_identity = match self.prepare_runtime_rootfs(&sandbox.id, &image_ref).await {
             Ok(image_identity) => {
                 info!(
                     sandbox_id = %sandbox.id,
                     image_identity = %image_identity,
-                    "vm driver: root disk prepared"
+                    "vm driver: cached root disk resolved"
                 );
                 image_identity
             }
@@ -415,12 +414,18 @@ impl VmDriver {
                 return Err(err);
             }
         };
-        if let Some(tls_paths) = tls_paths.as_ref()
-            && let Err(err) = prepare_guest_tls_materials(&root_disk, tls_paths).await
+        let disk_paths =
+            sandbox_runtime_disk_paths(&self.config.state_dir, &state_dir, &image_identity);
+        let root_disk = disk_paths.root_disk;
+        let overlay_disk = disk_paths.overlay_disk;
+
+        if let Err(err) = self
+            .prepare_runtime_overlay(&overlay_disk, tls_paths.as_ref())
+            .await
         {
             let _ = tokio::fs::remove_dir_all(&state_dir).await;
             return Err(Status::internal(format!(
-                "prepare guest TLS materials failed: {err}"
+                "prepare guest overlay disk failed: {err}"
             )));
         }
 
@@ -471,6 +476,7 @@ impl VmDriver {
         command.stderr(Stdio::inherit());
         command.arg("--internal-run-vm");
         command.arg("--vm-root-disk").arg(&root_disk);
+        command.arg("--vm-overlay-disk").arg(&overlay_disk);
         command.arg("--vm-exec").arg(sandbox_guest_init_path());
         command.arg("--vm-workdir").arg("/");
         command.arg("--vm-console-output").arg(&console_output);
@@ -729,19 +735,37 @@ impl VmDriver {
         &self,
         sandbox_id: &str,
         image_ref: &str,
-        root_disk: &Path,
     ) -> Result<String, Status> {
-        let image_identity = self
-            .ensure_cached_image_rootfs_image(sandbox_id, image_ref)
-            .await?;
-        let cached_image = image_cache_rootfs_image(&self.config.state_dir, &image_identity);
-        let root_disk_dest = root_disk.to_path_buf();
-        tokio::task::spawn_blocking(move || copy_rootfs_image_to(&cached_image, &root_disk_dest))
+        self.ensure_cached_image_rootfs_image(sandbox_id, image_ref)
             .await
-            .map_err(|err| Status::internal(format!("sandbox root disk copy panicked: {err}")))?
-            .map_err(|err| Status::internal(format!("copy sandbox root disk failed: {err}")))?;
+    }
 
-        Ok(image_identity)
+    async fn prepare_runtime_overlay(
+        &self,
+        overlay_disk: &Path,
+        tls_paths: Option<&VmDriverTlsPaths>,
+    ) -> Result<(), String> {
+        let tls_materials = match tls_paths {
+            Some(paths) => Some(read_guest_tls_materials(paths).await?),
+            None => None,
+        };
+        let overlay_disk = overlay_disk.to_path_buf();
+        let overlay_size_bytes = self
+            .config
+            .overlay_disk_mib
+            .checked_mul(1024 * 1024)
+            .ok_or_else(|| {
+                format!(
+                    "overlay disk size {} MiB is too large",
+                    self.config.overlay_disk_mib
+                )
+            })?;
+
+        tokio::task::spawn_blocking(move || {
+            create_sandbox_overlay_image(&overlay_disk, overlay_size_bytes, tls_materials.as_ref())
+        })
+        .await
+        .map_err(|err| format!("overlay image preparation panicked: {err}"))?
     }
 
     fn resolved_sandbox_image(&self, sandbox: &Sandbox) -> Option<String> {
@@ -2306,6 +2330,27 @@ fn sandbox_state_dir(root: &Path, sandbox_id: &str) -> Result<PathBuf, Status> {
     Ok(sandboxes_root_dir(root).join(sandbox_id))
 }
 
+fn sandbox_overlay_image(state_dir: &Path) -> PathBuf {
+    state_dir.join(SANDBOX_OVERLAY_IMAGE)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SandboxRuntimeDiskPaths {
+    root_disk: PathBuf,
+    overlay_disk: PathBuf,
+}
+
+fn sandbox_runtime_disk_paths(
+    driver_state_root: &Path,
+    state_dir: &Path,
+    image_identity: &str,
+) -> SandboxRuntimeDiskPaths {
+    SandboxRuntimeDiskPaths {
+        root_disk: image_cache_rootfs_image(driver_state_root, image_identity),
+        overlay_disk: sandbox_overlay_image(state_dir),
+    }
+}
+
 #[allow(clippy::result_large_err)]
 fn validate_sandbox_state_dir(root: &Path, state_dir: &Path) -> Result<(), Status> {
     let sandboxes_root = sandboxes_root_dir(root);
@@ -2428,10 +2473,14 @@ async fn write_sandbox_image_metadata(
     Ok(())
 }
 
-async fn prepare_guest_tls_materials(
-    root_disk: &Path,
-    paths: &VmDriverTlsPaths,
-) -> Result<(), String> {
+#[derive(Debug, Clone)]
+struct GuestTlsMaterials {
+    ca: Vec<u8>,
+    cert: Vec<u8>,
+    key: Vec<u8>,
+}
+
+async fn read_guest_tls_materials(paths: &VmDriverTlsPaths) -> Result<GuestTlsMaterials, String> {
     let ca = tokio::fs::read(&paths.ca)
         .await
         .map_err(|err| format!("read {}: {err}", paths.ca.display()))?;
@@ -2441,16 +2490,86 @@ async fn prepare_guest_tls_materials(
     let key = tokio::fs::read(&paths.key)
         .await
         .map_err(|err| format!("read {}: {err}", paths.key.display()))?;
-    let root_disk = root_disk.to_path_buf();
+    Ok(GuestTlsMaterials { ca, cert, key })
+}
 
-    tokio::task::spawn_blocking(move || {
-        write_rootfs_image_file(&root_disk, GUEST_TLS_CA_PATH, &ca)?;
-        write_rootfs_image_file(&root_disk, GUEST_TLS_CERT_PATH, &cert)?;
-        write_rootfs_image_file(&root_disk, GUEST_TLS_KEY_PATH, &key)?;
-        set_rootfs_image_file_mode(&root_disk, GUEST_TLS_KEY_PATH, 0o100_600)
-    })
-    .await
-    .map_err(|err| format!("guest TLS material injection panicked: {err}"))?
+fn create_sandbox_overlay_image(
+    overlay_disk: &Path,
+    size_bytes: u64,
+    tls_materials: Option<&GuestTlsMaterials>,
+) -> Result<(), String> {
+    let staging_dir = overlay_staging_dir(overlay_disk);
+    if staging_dir.exists() {
+        fs::remove_dir_all(&staging_dir)
+            .map_err(|err| format!("remove stale overlay staging dir: {err}"))?;
+    }
+
+    let result = (|| {
+        fs::create_dir_all(staging_dir.join("upper"))
+            .map_err(|err| format!("create overlay upper dir: {err}"))?;
+        fs::create_dir_all(staging_dir.join("work"))
+            .map_err(|err| format!("create overlay work dir: {err}"))?;
+        fs::create_dir_all(staging_dir.join("config"))
+            .map_err(|err| format!("create overlay config dir: {err}"))?;
+
+        if let Some(tls) = tls_materials {
+            stage_guest_tls_materials(&staging_dir, tls)?;
+        }
+
+        create_ext4_image_from_dir_with_size(&staging_dir, overlay_disk, size_bytes)
+    })();
+
+    let _ = fs::remove_dir_all(&staging_dir);
+    result
+}
+
+fn stage_guest_tls_materials(
+    staging_dir: &Path,
+    materials: &GuestTlsMaterials,
+) -> Result<(), String> {
+    let tls_dir = staging_dir
+        .join("upper")
+        .join(GUEST_TLS_CA_PATH.trim_start_matches('/'))
+        .parent()
+        .ok_or_else(|| "guest TLS CA path has no parent".to_string())?
+        .to_path_buf();
+    fs::create_dir_all(&tls_dir)
+        .map_err(|err| format!("create guest TLS dir {}: {err}", tls_dir.display()))?;
+
+    let ca_path = staging_dir
+        .join("upper")
+        .join(GUEST_TLS_CA_PATH.trim_start_matches('/'));
+    let cert_path = staging_dir
+        .join("upper")
+        .join(GUEST_TLS_CERT_PATH.trim_start_matches('/'));
+    let key_path = staging_dir
+        .join("upper")
+        .join(GUEST_TLS_KEY_PATH.trim_start_matches('/'));
+    fs::write(&ca_path, &materials.ca)
+        .map_err(|err| format!("write guest TLS CA {}: {err}", ca_path.display()))?;
+    fs::write(&cert_path, &materials.cert)
+        .map_err(|err| format!("write guest TLS cert {}: {err}", cert_path.display()))?;
+    fs::write(&key_path, &materials.key)
+        .map_err(|err| format!("write guest TLS key {}: {err}", key_path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        fs::set_permissions(&key_path, fs::Permissions::from_mode(0o600))
+            .map_err(|err| format!("chmod guest TLS key {}: {err}", key_path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn overlay_staging_dir(overlay_disk: &Path) -> PathBuf {
+    let parent = overlay_disk.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(format!(
+        ".openshell-overlay-staging-{}-{}",
+        std::process::id(),
+        current_time_ms()
+    ))
 }
 
 async fn terminate_vm_process(child: &mut Child) -> Result<(), std::io::Error> {
@@ -2715,6 +2834,22 @@ mod tests {
         let err = sandbox_state_dir(Path::new("/tmp/openshell-vm"), "../escape")
             .expect_err("path traversal should be rejected");
         assert_eq!(err.code(), Code::InvalidArgument);
+    }
+
+    #[test]
+    fn sandbox_runtime_disk_paths_use_cached_root_and_per_sandbox_overlay() {
+        let driver_state = Path::new("/tmp/openshell-vm");
+        let state_dir = driver_state.join("sandboxes").join("sandbox-123");
+        let image_identity = prepared_image_cache_identity("sha256:abc");
+
+        let disks = sandbox_runtime_disk_paths(driver_state, &state_dir, &image_identity);
+
+        assert_eq!(
+            disks.root_disk,
+            image_cache_rootfs_image(driver_state, &image_identity)
+        );
+        assert_eq!(disks.overlay_disk, state_dir.join(SANDBOX_OVERLAY_IMAGE));
+        assert_ne!(disks.root_disk.parent(), Some(state_dir.as_path()));
     }
 
     #[test]
@@ -3252,22 +3387,61 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prepare_guest_tls_materials_reports_missing_input() {
+    async fn read_guest_tls_materials_reports_missing_input() {
         let base = unique_temp_dir();
         let source_dir = base.join("missing-source");
 
-        let err = prepare_guest_tls_materials(
-            &base.join("rootfs.ext4"),
-            &VmDriverTlsPaths {
-                ca: source_dir.join("ca.crt"),
-                cert: source_dir.join("tls.crt"),
-                key: source_dir.join("tls.key"),
-            },
-        )
+        let err = read_guest_tls_materials(&VmDriverTlsPaths {
+            ca: source_dir.join("ca.crt"),
+            cert: source_dir.join("tls.crt"),
+            key: source_dir.join("tls.key"),
+        })
         .await
         .expect_err("missing TLS materials should fail before image injection");
 
         assert!(err.contains("ca.crt"));
+
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stage_guest_tls_materials_places_files_in_overlay_upper_with_private_key_mode() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let base = unique_temp_dir();
+        let materials = GuestTlsMaterials {
+            ca: b"ca".to_vec(),
+            cert: b"cert".to_vec(),
+            key: b"key".to_vec(),
+        };
+
+        stage_guest_tls_materials(&base, &materials).expect("stage TLS materials");
+
+        assert_eq!(
+            fs::read(
+                base.join("upper")
+                    .join(GUEST_TLS_CA_PATH.trim_start_matches('/'))
+            )
+            .unwrap(),
+            b"ca"
+        );
+        assert_eq!(
+            fs::read(
+                base.join("upper")
+                    .join(GUEST_TLS_CERT_PATH.trim_start_matches('/'))
+            )
+            .unwrap(),
+            b"cert"
+        );
+        let key_path = base
+            .join("upper")
+            .join(GUEST_TLS_KEY_PATH.trim_start_matches('/'));
+        assert_eq!(fs::read(&key_path).unwrap(), b"key");
+        assert_eq!(
+            fs::metadata(&key_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
 
         let _ = std::fs::remove_dir_all(base);
     }

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -580,40 +580,10 @@ impl VmDriver {
         let is_gpu = spec.is_some_and(|s| s.gpu);
         let gpu_device = spec.map_or("", |s| s.gpu_device.as_str());
         let gpu_bdf = if is_gpu {
-            let inventory = self
-                .gpu_inventory
-                .as_ref()
-                .ok_or_else(|| Status::internal("GPU inventory not initialized"))?;
-            match inventory
-                .lock()
-                .map_err(|e| Status::internal(format!("GPU inventory lock poisoned: {e}")))
-                .and_then(|mut inv| {
-                    inv.assign(&sandbox.id, gpu_device)
-                        .map_err(Status::failed_precondition)
-                }) {
-                Ok(assignment) => {
-                    tracing::info!(
-                        sandbox_id = %sandbox.id,
-                        bdf = %assignment.bdf,
-                        gpu_name = %assignment.name,
-                        iommu_group = assignment.iommu_group,
-                        "assigned GPU to sandbox"
-                    );
-                    Some(assignment.bdf)
-                }
-                Err(err) => {
-                    return Err(err);
-                }
-            }
+            Some(self.assign_gpu_to_record(&sandbox.id, gpu_device).await?)
         } else {
             None
         };
-        if let Some(bdf) = gpu_bdf.as_ref()
-            && !self.record_gpu_assignment(&sandbox.id, bdf.clone()).await
-        {
-            self.release_gpu_and_subnet(&sandbox.id);
-            return Err(Status::cancelled("sandbox provisioning cancelled"));
-        }
 
         let console_output = state_dir.join("rootfs-console.log");
         let mut command = Command::new(&self.launcher_bin);
@@ -905,15 +875,39 @@ impl VmDriver {
         }
     }
 
-    async fn record_gpu_assignment(&self, sandbox_id: &str, bdf: String) -> bool {
+    async fn assign_gpu_to_record(
+        &self,
+        sandbox_id: &str,
+        gpu_device: &str,
+    ) -> Result<String, Status> {
         let mut registry = self.registry.lock().await;
         match registry.get_mut(sandbox_id) {
-            Some(record) if !record.deleting => {
-                record.gpu_bdf = Some(bdf);
-                true
-            }
-            _ => false,
+            Some(record) if !record.deleting => {}
+            _ => return Err(Status::cancelled("sandbox provisioning cancelled")),
         }
+
+        let inventory = self
+            .gpu_inventory
+            .as_ref()
+            .ok_or_else(|| Status::internal("GPU inventory not initialized"))?;
+        let assignment = inventory
+            .lock()
+            .map_err(|e| Status::internal(format!("GPU inventory lock poisoned: {e}")))?
+            .assign(sandbox_id, gpu_device)
+            .map_err(Status::failed_precondition)?;
+
+        let record = registry
+            .get_mut(sandbox_id)
+            .expect("sandbox record exists while registry lock is held");
+        record.gpu_bdf = Some(assignment.bdf.clone());
+        tracing::info!(
+            sandbox_id = %sandbox_id,
+            bdf = %assignment.bdf,
+            gpu_name = %assignment.name,
+            iommu_group = assignment.iommu_group,
+            "assigned GPU to sandbox"
+        );
+        Ok(assignment.bdf)
     }
 
     async fn fail_provisioning(

--- a/crates/openshell-driver-vm/src/ffi.rs
+++ b/crates/openshell-driver-vm/src/ffi.rs
@@ -29,7 +29,18 @@ type KrunInitLog =
 type KrunCreateCtx = unsafe extern "C" fn() -> i32;
 type KrunFreeCtx = unsafe extern "C" fn(ctx_id: u32) -> i32;
 type KrunSetVmConfig = unsafe extern "C" fn(ctx_id: u32, num_vcpus: u8, ram_mib: u32) -> i32;
-type KrunSetRoot = unsafe extern "C" fn(ctx_id: u32, root_path: *const c_char) -> i32;
+type KrunAddDisk = unsafe extern "C" fn(
+    ctx_id: u32,
+    block_id: *const c_char,
+    disk_path: *const c_char,
+    read_only: bool,
+) -> i32;
+type KrunSetRootDiskRemount = unsafe extern "C" fn(
+    ctx_id: u32,
+    device: *const c_char,
+    fstype: *const c_char,
+    options: *const c_char,
+) -> i32;
 type KrunSetWorkdir = unsafe extern "C" fn(ctx_id: u32, workdir_path: *const c_char) -> i32;
 type KrunSetExec = unsafe extern "C" fn(
     ctx_id: u32,
@@ -67,7 +78,8 @@ pub struct LibKrun {
     pub krun_create_ctx: KrunCreateCtx,
     pub krun_free_ctx: KrunFreeCtx,
     pub krun_set_vm_config: KrunSetVmConfig,
-    pub krun_set_root: KrunSetRoot,
+    pub krun_add_disk: KrunAddDisk,
+    pub krun_set_root_disk_remount: KrunSetRootDiskRemount,
     pub krun_set_workdir: KrunSetWorkdir,
     pub krun_set_exec: KrunSetExec,
     pub krun_set_console_output: KrunSetConsoleOutput,
@@ -119,7 +131,12 @@ impl LibKrun {
             krun_create_ctx: load_symbol(library, b"krun_create_ctx\0", &libkrun_path)?,
             krun_free_ctx: load_symbol(library, b"krun_free_ctx\0", &libkrun_path)?,
             krun_set_vm_config: load_symbol(library, b"krun_set_vm_config\0", &libkrun_path)?,
-            krun_set_root: load_symbol(library, b"krun_set_root\0", &libkrun_path)?,
+            krun_add_disk: load_symbol(library, b"krun_add_disk\0", &libkrun_path)?,
+            krun_set_root_disk_remount: load_symbol(
+                library,
+                b"krun_set_root_disk_remount\0",
+                &libkrun_path,
+            )?,
             krun_set_workdir: load_symbol(library, b"krun_set_workdir\0", &libkrun_path)?,
             krun_set_exec: load_symbol(library, b"krun_set_exec\0", &libkrun_path)?,
             krun_set_console_output: load_symbol(

--- a/crates/openshell-driver-vm/src/main.rs
+++ b/crates/openshell-driver-vm/src/main.rs
@@ -30,6 +30,9 @@ struct Args {
     #[arg(long = "vm-root-disk", hide = true, alias = "vm-rootfs")]
     vm_root_disk: Option<PathBuf>,
 
+    #[arg(long = "vm-overlay-disk", hide = true)]
+    vm_overlay_disk: Option<PathBuf>,
+
     #[arg(long, hide = true)]
     vm_exec: Option<String>,
 
@@ -107,6 +110,9 @@ struct Args {
 
     #[arg(long, env = "OPENSHELL_VM_DRIVER_MEM_MIB", default_value_t = 2048)]
     mem_mib: u32,
+
+    #[arg(long, env = "OPENSHELL_VM_OVERLAY_DISK_MIB", default_value_t = 4096)]
+    overlay_disk_mib: u64,
 
     #[arg(long, env = "OPENSHELL_VM_GPU")]
     gpu: bool,
@@ -191,6 +197,7 @@ async fn main() -> Result<()> {
         krun_log_level: args.krun_log_level,
         vcpus: args.vcpus,
         mem_mib: args.mem_mib,
+        overlay_disk_mib: args.overlay_disk_mib,
         guest_tls_ca: args.guest_tls_ca.clone(),
         guest_tls_cert: args.guest_tls_cert.clone(),
         guest_tls_key: args.guest_tls_key.clone(),
@@ -444,6 +451,10 @@ fn build_vm_launch_config(args: &Args) -> std::result::Result<VmLaunchConfig, St
         .vm_root_disk
         .clone()
         .ok_or_else(|| "--vm-root-disk is required in internal VM mode".to_string())?;
+    let overlay_disk = args
+        .vm_overlay_disk
+        .clone()
+        .ok_or_else(|| "--vm-overlay-disk is required in internal VM mode".to_string())?;
     let exec_path = args
         .vm_exec
         .clone()
@@ -461,6 +472,7 @@ fn build_vm_launch_config(args: &Args) -> std::result::Result<VmLaunchConfig, St
 
     Ok(VmLaunchConfig {
         root_disk,
+        overlay_disk,
         vcpus: args.vm_vcpus,
         mem_mib: args.vm_mem_mib,
         exec_path,

--- a/crates/openshell-driver-vm/src/main.rs
+++ b/crates/openshell-driver-vm/src/main.rs
@@ -33,6 +33,9 @@ struct Args {
     #[arg(long = "vm-overlay-disk", hide = true)]
     vm_overlay_disk: Option<PathBuf>,
 
+    #[arg(long = "vm-image-disk", hide = true)]
+    vm_image_disk: Option<PathBuf>,
+
     #[arg(long, hide = true)]
     vm_exec: Option<String>,
 
@@ -85,6 +88,9 @@ struct Args {
 
     #[arg(long, env = "OPENSHELL_SANDBOX_IMAGE", default_value = "")]
     default_image: String,
+
+    #[arg(long, env = "OPENSHELL_VM_BOOTSTRAP_IMAGE", default_value = "")]
+    bootstrap_image: String,
 
     #[arg(
         long,
@@ -193,6 +199,7 @@ async fn main() -> Result<()> {
         state_dir: args.state_dir.clone(),
         launcher_bin: None,
         default_image: args.default_image.clone(),
+        bootstrap_image: args.bootstrap_image.clone(),
         log_level: args.log_level.clone(),
         krun_log_level: args.krun_log_level,
         vcpus: args.vcpus,
@@ -455,6 +462,7 @@ fn build_vm_launch_config(args: &Args) -> std::result::Result<VmLaunchConfig, St
         .vm_overlay_disk
         .clone()
         .ok_or_else(|| "--vm-overlay-disk is required in internal VM mode".to_string())?;
+    let image_disk = args.vm_image_disk.clone();
     let exec_path = args
         .vm_exec
         .clone()
@@ -473,6 +481,7 @@ fn build_vm_launch_config(args: &Args) -> std::result::Result<VmLaunchConfig, St
     Ok(VmLaunchConfig {
         root_disk,
         overlay_disk,
+        image_disk,
         vcpus: args.vm_vcpus,
         mem_mib: args.vm_mem_mib,
         exec_path,

--- a/crates/openshell-driver-vm/src/main.rs
+++ b/crates/openshell-driver-vm/src/main.rs
@@ -27,8 +27,8 @@ struct Args {
     #[arg(long, hide = true, default_value_t = false)]
     internal_run_vm: bool,
 
-    #[arg(long, hide = true)]
-    vm_rootfs: Option<PathBuf>,
+    #[arg(long = "vm-root-disk", hide = true, alias = "vm-rootfs")]
+    vm_root_disk: Option<PathBuf>,
 
     #[arg(long, hide = true)]
     vm_exec: Option<String>,
@@ -440,10 +440,10 @@ impl Stream for AuthenticatedUnixIncoming {
 }
 
 fn build_vm_launch_config(args: &Args) -> std::result::Result<VmLaunchConfig, String> {
-    let rootfs = args
-        .vm_rootfs
+    let root_disk = args
+        .vm_root_disk
         .clone()
-        .ok_or_else(|| "--vm-rootfs is required in internal VM mode".to_string())?;
+        .ok_or_else(|| "--vm-root-disk is required in internal VM mode".to_string())?;
     let exec_path = args
         .vm_exec
         .clone()
@@ -460,7 +460,7 @@ fn build_vm_launch_config(args: &Args) -> std::result::Result<VmLaunchConfig, St
     };
 
     Ok(VmLaunchConfig {
-        rootfs,
+        root_disk,
         vcpus: args.vm_vcpus,
         mem_mib: args.vm_mem_mib,
         exec_path,

--- a/crates/openshell-driver-vm/src/rootfs.rs
+++ b/crates/openshell-driver-vm/src/rootfs.rs
@@ -3,13 +3,20 @@
 
 use std::fs;
 use std::fs::File;
-use std::io::{BufWriter, Cursor};
-use std::path::Path;
+#[cfg(test)]
+use std::io::BufWriter;
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 const SUPERVISOR: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/openshell-sandbox.zst"));
 const ROOTFS_VARIANT_MARKER: &str = ".openshell-rootfs-variant";
 const SANDBOX_GUEST_INIT_PATH: &str = "/srv/openshell-vm-sandbox-init.sh";
 const SANDBOX_SUPERVISOR_PATH: &str = "/opt/openshell/bin/openshell-sandbox";
+const ROOTFS_IMAGE_MIN_SIZE_BYTES: u64 = 512 * 1024 * 1024;
+const ROOTFS_IMAGE_MIN_HEADROOM_BYTES: u64 = 256 * 1024 * 1024;
+static INJECTION_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub const fn sandbox_guest_init_path() -> &'static str {
     SANDBOX_GUEST_INIT_PATH
@@ -44,6 +51,7 @@ pub fn extract_rootfs_archive_to(archive_path: &Path, dest: &Path) -> Result<(),
         .map_err(|e| format!("extract rootfs tarball into {}: {e}", dest.display()))
 }
 
+#[cfg(test)]
 pub fn create_rootfs_archive_from_dir(source: &Path, archive_path: &Path) -> Result<(), String> {
     if let Some(parent) = archive_path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
@@ -65,6 +73,104 @@ pub fn create_rootfs_archive_from_dir(source: &Path, archive_path: &Path) -> Res
         .map_err(|e| format!("finalize {}: {e}", archive_path.display()))
 }
 
+pub fn create_rootfs_image_from_dir(source: &Path, image_path: &Path) -> Result<(), String> {
+    if let Some(parent) = image_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    if image_path.exists() {
+        fs::remove_file(image_path)
+            .map_err(|e| format!("remove old rootfs image {}: {e}", image_path.display()))?;
+    }
+
+    let image_size = rootfs_image_size_bytes(source)?;
+    let image = File::create(image_path)
+        .map_err(|e| format!("create rootfs image {}: {e}", image_path.display()))?;
+    image
+        .set_len(image_size)
+        .map_err(|e| format!("size rootfs image {}: {e}", image_path.display()))?;
+    drop(image);
+
+    if let Err(err) = format_ext4_image_from_dir(source, image_path) {
+        let _ = fs::remove_file(image_path);
+        return Err(err);
+    }
+
+    Ok(())
+}
+
+pub fn copy_rootfs_image_to(source: &Path, dest: &Path) -> Result<(), String> {
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    if dest.exists() {
+        fs::remove_file(dest)
+            .map_err(|e| format!("remove old rootfs image {}: {e}", dest.display()))?;
+    }
+
+    let mut input = File::open(source)
+        .map_err(|e| format!("open cached rootfs image {}: {e}", source.display()))?;
+    let mut output =
+        File::create(dest).map_err(|e| format!("create rootfs image {}: {e}", dest.display()))?;
+    let mut buf = vec![0; 1024 * 1024];
+    let mut total = 0_u64;
+
+    loop {
+        let len = input
+            .read(&mut buf)
+            .map_err(|e| format!("read rootfs image {}: {e}", source.display()))?;
+        if len == 0 {
+            break;
+        }
+        total += len as u64;
+        if buf[..len].iter().all(|byte| *byte == 0) {
+            let offset = i64::try_from(len).map_err(|e| {
+                format!(
+                    "convert sparse rootfs image seek offset for {}: {e}",
+                    dest.display()
+                )
+            })?;
+            output
+                .seek(SeekFrom::Current(offset))
+                .map_err(|e| format!("seek sparse rootfs image {}: {e}", dest.display()))?;
+        } else {
+            output
+                .write_all(&buf[..len])
+                .map_err(|e| format!("write rootfs image {}: {e}", dest.display()))?;
+        }
+    }
+
+    output
+        .set_len(total)
+        .map_err(|e| format!("finalize rootfs image {}: {e}", dest.display()))
+}
+
+pub fn write_rootfs_image_file(
+    image_path: &Path,
+    guest_path: &str,
+    contents: &[u8],
+) -> Result<(), String> {
+    ensure_rootfs_image_parent_dirs(image_path, guest_path);
+
+    let tmp_path = temporary_injection_path(image_path);
+    fs::write(&tmp_path, contents).map_err(|e| format!("write {}: {e}", tmp_path.display()))?;
+    let _ = run_debugfs(image_path, &format!("rm {guest_path}"));
+    let result = run_debugfs(
+        image_path,
+        &format!("write {} {}", tmp_path.display(), guest_path),
+    );
+    let _ = fs::remove_file(&tmp_path);
+    result
+}
+
+pub fn set_rootfs_image_file_mode(
+    image_path: &Path,
+    guest_path: &str,
+    mode: u32,
+) -> Result<(), String> {
+    run_debugfs(image_path, &format!("sif {guest_path} mode {mode:o}"))
+}
+
+#[cfg(test)]
 fn append_rootfs_tree_to_archive(
     builder: &mut tar::Builder<BufWriter<File>>,
     source: &Path,
@@ -119,6 +225,7 @@ fn append_rootfs_tree_to_archive(
     Ok(())
 }
 
+#[cfg(test)]
 fn append_symlink_to_archive(
     builder: &mut tar::Builder<BufWriter<File>>,
     source_path: &Path,
@@ -165,6 +272,7 @@ fn prepare_sandbox_rootfs(rootfs: &Path) -> Result<(), String> {
     fs::write(opt_dir.join(".rootfs-type"), "sandbox\n")
         .map_err(|e| format!("write sandbox rootfs marker: {e}"))?;
     ensure_sandbox_guest_user(rootfs)?;
+    create_sandbox_mountpoint(&rootfs.join("sandbox"))?;
 
     Ok(())
 }
@@ -180,6 +288,159 @@ pub fn validate_sandbox_rootfs(rootfs: &Path) -> Result<(), String> {
     )?;
     require_any_rootfs_path(rootfs, &["/bin/sed", "/usr/bin/sed"])?;
     Ok(())
+}
+
+fn create_sandbox_mountpoint(path: &Path) -> Result<(), String> {
+    fs::create_dir_all(path).map_err(|e| format!("create {}: {e}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+            .map_err(|e| format!("chmod {}: {e}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn rootfs_image_size_bytes(source: &Path) -> Result<u64, String> {
+    let used = directory_size_bytes(source)?;
+    let headroom = (used / 4).max(ROOTFS_IMAGE_MIN_HEADROOM_BYTES);
+    let size = (used + headroom).max(ROOTFS_IMAGE_MIN_SIZE_BYTES);
+    Ok(round_up_to_mib(size))
+}
+
+fn directory_size_bytes(path: &Path) -> Result<u64, String> {
+    let metadata =
+        fs::symlink_metadata(path).map_err(|e| format!("stat {}: {e}", path.display()))?;
+    if metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        return Ok(metadata.len());
+    }
+    if !metadata.file_type().is_dir() {
+        return Ok(0);
+    }
+
+    let mut size = 4096;
+    for entry in fs::read_dir(path).map_err(|e| format!("read {}: {e}", path.display()))? {
+        let entry = entry.map_err(|e| format!("read {}: {e}", path.display()))?;
+        size += directory_size_bytes(&entry.path())?;
+    }
+    Ok(size)
+}
+
+fn round_up_to_mib(bytes: u64) -> u64 {
+    const MIB: u64 = 1024 * 1024;
+    bytes.div_ceil(MIB) * MIB
+}
+
+fn format_ext4_image_from_dir(source: &Path, image_path: &Path) -> Result<(), String> {
+    let mut last_error = None;
+    for tool in ["mke2fs", "mkfs.ext4"] {
+        for candidate in e2fs_tool_candidates(tool) {
+            let label = candidate.display().to_string();
+            let output = Command::new(&candidate)
+                .arg("-q")
+                .arg("-F")
+                .arg("-t")
+                .arg("ext4")
+                .arg("-E")
+                .arg("root_owner=0:0")
+                .arg("-d")
+                .arg(source)
+                .arg(image_path)
+                .output();
+            match output {
+                Ok(output) if output.status.success() => return Ok(()),
+                Ok(output) => {
+                    last_error = Some(format!(
+                        "{label} failed with status {}\nstdout: {}\nstderr: {}",
+                        output.status,
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr)
+                    ));
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    last_error = Some(format!("{label} not found"));
+                }
+                Err(err) => {
+                    last_error = Some(format!("run {label}: {err}"));
+                }
+            }
+        }
+    }
+    Err(format!(
+        "failed to create ext4 rootfs image from {}: {}. Install e2fsprogs (mke2fs/mkfs.ext4) and retry",
+        source.display(),
+        last_error.unwrap_or_else(|| "no ext4 formatter found".to_string())
+    ))
+}
+
+fn ensure_rootfs_image_parent_dirs(image_path: &Path, guest_path: &str) {
+    let Some(parent) = Path::new(guest_path).parent() else {
+        return;
+    };
+    let mut current = String::new();
+    for component in parent.components() {
+        let part = component.as_os_str().to_string_lossy();
+        if part == "/" || part.is_empty() {
+            continue;
+        }
+        current.push('/');
+        current.push_str(&part);
+        let _ = run_debugfs(image_path, &format!("mkdir {current}"));
+    }
+}
+
+fn run_debugfs(image_path: &Path, command: &str) -> Result<(), String> {
+    let mut last_error = None;
+    for candidate in e2fs_tool_candidates("debugfs") {
+        let label = candidate.display().to_string();
+        let output = Command::new(&candidate)
+            .arg("-w")
+            .arg("-R")
+            .arg(command)
+            .arg(image_path)
+            .output();
+        match output {
+            Ok(output) if output.status.success() => return Ok(()),
+            Ok(output) => {
+                last_error = Some(format!(
+                    "{label} failed with status {}\nstdout: {}\nstderr: {}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                last_error = Some(format!("{label} not found"));
+            }
+            Err(err) => {
+                last_error = Some(format!("run {label}: {err}"));
+            }
+        }
+    }
+    Err(format!(
+        "debugfs command '{command}' failed for {}: {}. Install e2fsprogs (debugfs) and retry",
+        image_path.display(),
+        last_error.unwrap_or_else(|| "debugfs not found".to_string())
+    ))
+}
+
+fn e2fs_tool_candidates(tool: &str) -> Vec<PathBuf> {
+    let mut candidates = vec![PathBuf::from(tool)];
+    for root in ["/opt/homebrew/opt/e2fsprogs", "/usr/local/opt/e2fsprogs"] {
+        candidates.push(Path::new(root).join("sbin").join(tool));
+        candidates.push(Path::new(root).join("bin").join(tool));
+    }
+    candidates
+}
+
+fn temporary_injection_path(image_path: &Path) -> PathBuf {
+    let n = INJECTION_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let parent = image_path.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(format!(
+        ".openshell-rootfs-inject-{}-{n}",
+        std::process::id()
+    ))
 }
 
 fn ensure_sandbox_guest_user(rootfs: &Path) -> Result<(), String> {
@@ -343,7 +604,13 @@ mod tests {
         validate_sandbox_rootfs(&rootfs).expect("validate sandbox rootfs");
 
         assert!(rootfs.join("srv/openshell-vm-sandbox-init.sh").is_file());
-        assert!(!rootfs.join("sandbox").exists());
+        assert!(rootfs.join("sandbox").is_dir());
+        assert!(
+            fs::read_dir(rootfs.join("sandbox"))
+                .expect("read sandbox")
+                .next()
+                .is_none()
+        );
         assert!(
             fs::read_to_string(rootfs.join("etc/passwd"))
                 .expect("read passwd")
@@ -363,7 +630,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_sandbox_rootfs_preserves_image_workdir_contents() {
+    fn prepare_sandbox_rootfs_preserves_image_workdir_contents_in_rootfs() {
         let dir = unique_temp_dir();
         let rootfs = dir.join("rootfs");
 
@@ -378,6 +645,7 @@ mod tests {
 
         prepare_sandbox_rootfs(&rootfs).expect("prepare sandbox rootfs");
 
+        assert!(rootfs.join("sandbox").is_dir());
         assert_eq!(
             fs::read_to_string(rootfs.join("sandbox/app.py")).expect("read app"),
             "print('hello')\n"

--- a/crates/openshell-driver-vm/src/rootfs.rs
+++ b/crates/openshell-driver-vm/src/rootfs.rs
@@ -159,10 +159,21 @@ pub fn write_rootfs_image_file(
 
     let tmp_path = temporary_injection_path(image_path);
     fs::write(&tmp_path, contents).map_err(|e| format!("write {}: {e}", tmp_path.display()))?;
-    let _ = run_debugfs(image_path, &format!("rm {guest_path}"));
+    let Some(quoted_guest_path) = debugfs_quote_absolute_path(guest_path) else {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(format!("invalid debugfs guest path '{guest_path}'"));
+    };
+    let Some(quoted_tmp_path) = debugfs_quote_argument(&tmp_path.to_string_lossy()) else {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(format!(
+            "invalid debugfs injection path '{}'",
+            tmp_path.display()
+        ));
+    };
+    let _ = run_debugfs(image_path, &format!("rm {quoted_guest_path}"));
     let result = run_debugfs(
         image_path,
-        &format!("write {} {}", tmp_path.display(), guest_path),
+        &format!("write {quoted_tmp_path} {quoted_guest_path}"),
     );
     let _ = fs::remove_file(&tmp_path);
     result
@@ -174,9 +185,12 @@ pub fn set_rootfs_image_file_mode(
     mode: u32,
 ) -> Result<(), String> {
     let regular_file_mode = 0o100_000 | (mode & 0o7777);
+    let Some(quoted_guest_path) = debugfs_quote_absolute_path(guest_path) else {
+        return Err(format!("invalid debugfs guest path '{guest_path}'"));
+    };
     run_debugfs(
         image_path,
-        &format!("set_inode_field {guest_path} mode 0{regular_file_mode:o}"),
+        &format!("set_inode_field {quoted_guest_path} mode 0{regular_file_mode:o}"),
     )
 }
 
@@ -539,7 +553,7 @@ fn collect_sandbox_owner_commands(
         return Ok(true);
     }
 
-    let Some(quoted_guest_path) = debugfs_quote_path(guest_path) else {
+    let Some(quoted_guest_path) = debugfs_quote_absolute_path(guest_path) else {
         return Ok(false);
     };
     commands.push(format!("set_inode_field {quoted_guest_path} uid {uid}"));
@@ -579,14 +593,22 @@ fn collect_sandbox_owner_commands(
     Ok(true)
 }
 
-fn debugfs_quote_path(path: &str) -> Option<String> {
+fn debugfs_quote_absolute_path(path: &str) -> Option<String> {
     if path.is_empty() || !path.starts_with('/') {
         return None;
     }
 
-    let mut quoted = String::with_capacity(path.len() + 2);
+    debugfs_quote_argument(path)
+}
+
+fn debugfs_quote_argument(argument: &str) -> Option<String> {
+    if argument.is_empty() {
+        return None;
+    }
+
+    let mut quoted = String::with_capacity(argument.len() + 2);
     quoted.push('"');
-    for ch in path.chars() {
+    for ch in argument.chars() {
         match ch {
             '\0' | '\n' | '\r' => return None,
             '\\' => quoted.push_str("\\\\"),
@@ -1082,6 +1104,19 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn debugfs_quote_argument_quotes_source_paths_with_spaces() {
+        assert_eq!(
+            debugfs_quote_argument("/tmp/openshell state/.openshell-rootfs-inject-123-0"),
+            Some("\"/tmp/openshell state/.openshell-rootfs-inject-123-0\"".to_string())
+        );
+        assert_eq!(
+            debugfs_quote_argument("/tmp/path/with\\backslash/and\"quote"),
+            Some("\"/tmp/path/with\\\\backslash/and\\\"quote\"".to_string())
+        );
+        assert_eq!(debugfs_quote_argument("/tmp/bad\npath"), None);
     }
 
     fn unique_temp_dir() -> PathBuf {

--- a/crates/openshell-driver-vm/src/rootfs.rs
+++ b/crates/openshell-driver-vm/src/rootfs.rs
@@ -16,6 +16,7 @@ const ROOTFS_VARIANT_MARKER: &str = ".openshell-rootfs-variant";
 const SANDBOX_GUEST_INIT_PATH: &str = "/srv/openshell-vm-sandbox-init.sh";
 const SANDBOX_SUPERVISOR_PATH: &str = "/opt/openshell/bin/openshell-sandbox";
 const SANDBOX_UMOCI_PATH: &str = "/opt/openshell/bin/umoci";
+const SANDBOX_OWNER_NORMALIZED_MARKER: &str = "/opt/openshell/.sandbox-owner-normalized";
 const ROOTFS_IMAGE_MIN_SIZE_BYTES: u64 = 512 * 1024 * 1024;
 const ROOTFS_IMAGE_MIN_HEADROOM_BYTES: u64 = 256 * 1024 * 1024;
 const EXT4_IMAGE_MIN_HEADROOM_BYTES: u64 = 16 * 1024 * 1024;
@@ -78,7 +79,12 @@ pub fn create_rootfs_archive_from_dir(source: &Path, archive_path: &Path) -> Res
 
 pub fn create_rootfs_image_from_dir(source: &Path, image_path: &Path) -> Result<(), String> {
     let image_size = rootfs_image_size_bytes(source)?;
-    create_ext4_image_from_dir_with_size(source, image_path, image_size)
+    create_ext4_image_from_dir_with_size(source, image_path, image_size)?;
+    if let Err(err) = normalize_sandbox_owner_in_rootfs_image(source, image_path) {
+        let _ = fs::remove_file(image_path);
+        return Err(err);
+    }
+    Ok(())
 }
 
 pub fn create_ext4_image_from_dir_with_size(
@@ -494,6 +500,182 @@ fn ensure_rootfs_image_parent_dirs(image_path: &Path, guest_path: &str) {
     }
 }
 
+fn normalize_sandbox_owner_in_rootfs_image(source: &Path, image_path: &Path) -> Result<(), String> {
+    let sandbox_dir = source.join("sandbox");
+    if !sandbox_dir.exists() {
+        return Ok(());
+    }
+
+    let Some((uid, gid)) = sandbox_guest_user_ids(source)? else {
+        return Ok(());
+    };
+
+    let mut commands = Vec::new();
+    if !collect_sandbox_owner_commands(&sandbox_dir, "/sandbox", uid, gid, &mut commands)? {
+        return Ok(());
+    }
+    if commands.is_empty() {
+        return Ok(());
+    }
+
+    run_debugfs_batch(image_path, &commands)?;
+    write_rootfs_image_file(image_path, SANDBOX_OWNER_NORMALIZED_MARKER, b"1\n")
+}
+
+fn collect_sandbox_owner_commands(
+    source_path: &Path,
+    guest_path: &str,
+    uid: u32,
+    gid: u32,
+    commands: &mut Vec<String>,
+) -> Result<bool, String> {
+    let metadata = fs::symlink_metadata(source_path).map_err(|e| {
+        format!(
+            "stat {} for rootfs ownership normalization: {e}",
+            source_path.display()
+        )
+    })?;
+    if metadata.file_type().is_symlink() {
+        return Ok(true);
+    }
+
+    let Some(quoted_guest_path) = debugfs_quote_path(guest_path) else {
+        return Ok(false);
+    };
+    commands.push(format!("set_inode_field {quoted_guest_path} uid {uid}"));
+    commands.push(format!("set_inode_field {quoted_guest_path} gid {gid}"));
+
+    if !metadata.is_dir() {
+        return Ok(true);
+    }
+
+    let mut entries = fs::read_dir(source_path)
+        .map_err(|e| {
+            format!(
+                "read {} for rootfs ownership normalization: {e}",
+                source_path.display()
+            )
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            format!(
+                "read {} entry for rootfs ownership normalization: {e}",
+                source_path.display()
+            )
+        })?;
+    entries.sort_by_key(fs::DirEntry::file_name);
+
+    for entry in entries {
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            return Ok(false);
+        };
+        let child_guest_path = format!("{guest_path}/{file_name}");
+        if !collect_sandbox_owner_commands(&entry.path(), &child_guest_path, uid, gid, commands)? {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+fn debugfs_quote_path(path: &str) -> Option<String> {
+    if path.is_empty() || !path.starts_with('/') {
+        return None;
+    }
+
+    let mut quoted = String::with_capacity(path.len() + 2);
+    quoted.push('"');
+    for ch in path.chars() {
+        match ch {
+            '\0' | '\n' | '\r' => return None,
+            '\\' => quoted.push_str("\\\\"),
+            '"' => quoted.push_str("\\\""),
+            _ => quoted.push(ch),
+        }
+    }
+    quoted.push('"');
+    Some(quoted)
+}
+
+fn sandbox_guest_user_ids(rootfs: &Path) -> Result<Option<(u32, u32)>, String> {
+    let passwd_path = rootfs.join("etc/passwd");
+    if !passwd_path.exists() {
+        return Ok(None);
+    }
+
+    let passwd = fs::read_to_string(&passwd_path)
+        .map_err(|e| format!("read {}: {e}", passwd_path.display()))?;
+    for line in passwd.lines() {
+        let mut parts = line.split(':');
+        if parts.next() != Some("sandbox") {
+            continue;
+        }
+        let _password = parts.next();
+        let uid = parts
+            .next()
+            .ok_or_else(|| format!("sandbox entry in {} is missing uid", passwd_path.display()))?
+            .parse::<u32>()
+            .map_err(|e| format!("sandbox uid in {} is invalid: {e}", passwd_path.display()))?;
+        let gid = parts
+            .next()
+            .ok_or_else(|| format!("sandbox entry in {} is missing gid", passwd_path.display()))?
+            .parse::<u32>()
+            .map_err(|e| format!("sandbox gid in {} is invalid: {e}", passwd_path.display()))?;
+        return Ok(Some((uid, gid)));
+    }
+
+    Ok(None)
+}
+
+fn run_debugfs_batch(image_path: &Path, commands: &[String]) -> Result<(), String> {
+    let command_path = temporary_injection_path(image_path);
+    let mut contents = commands.join("\n");
+    contents.push('\n');
+    fs::write(&command_path, contents)
+        .map_err(|e| format!("write {}: {e}", command_path.display()))?;
+
+    let result = run_debugfs_batch_file(image_path, &command_path);
+    let _ = fs::remove_file(&command_path);
+    result
+}
+
+fn run_debugfs_batch_file(image_path: &Path, command_path: &Path) -> Result<(), String> {
+    let mut last_error = None;
+    for candidate in e2fs_tool_candidates("debugfs") {
+        let label = candidate.display().to_string();
+        let output = Command::new(&candidate)
+            .arg("-w")
+            .arg("-f")
+            .arg(command_path)
+            .arg(image_path)
+            .output();
+        match output {
+            Ok(output) if output.status.success() => return Ok(()),
+            Ok(output) => {
+                last_error = Some(format!(
+                    "{label} failed with status {}\nstdout: {}\nstderr: {}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                last_error = Some(format!("{label} not found"));
+            }
+            Err(err) => {
+                last_error = Some(format!("run {label}: {err}"));
+            }
+        }
+    }
+    Err(format!(
+        "debugfs batch {} failed for {}: {}. Install e2fsprogs (debugfs) and retry",
+        command_path.display(),
+        image_path.display(),
+        last_error.unwrap_or_else(|| "debugfs not found".to_string())
+    ))
+}
+
 fn run_debugfs(image_path: &Path, command: &str) -> Result<(), String> {
     let mut last_error = None;
     for candidate in e2fs_tool_candidates("debugfs") {
@@ -850,6 +1032,54 @@ mod tests {
         let mut tail = [0_u8; 4];
         dest_file.read_exact(&mut tail).expect("read tail");
         assert_eq!(&tail, b"tail");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sandbox_guest_user_ids_reads_existing_sandbox_user() {
+        let dir = unique_temp_dir();
+        let rootfs = dir.join("rootfs");
+        fs::create_dir_all(rootfs.join("etc")).expect("create etc");
+        fs::write(
+            rootfs.join("etc/passwd"),
+            "root:x:0:0:root:/root:/bin/bash\nsandbox:x:998:997:Sandbox:/sandbox:/bin/sh\n",
+        )
+        .expect("write passwd");
+
+        assert_eq!(
+            sandbox_guest_user_ids(&rootfs).expect("read sandbox user"),
+            Some((998, 997))
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn collect_sandbox_owner_commands_quotes_guest_paths() {
+        let dir = unique_temp_dir();
+        let sandbox_dir = dir.join("sandbox");
+        fs::create_dir_all(sandbox_dir.join("dir with space")).expect("create sandbox tree");
+        fs::write(sandbox_dir.join("dir with space/file.txt"), "hello\n").expect("write file");
+
+        let mut commands = Vec::new();
+        assert!(
+            collect_sandbox_owner_commands(&sandbox_dir, "/sandbox", 998, 997, &mut commands)
+                .expect("collect commands")
+        );
+
+        assert!(commands.contains(&"set_inode_field \"/sandbox\" uid 998".to_string()));
+        assert!(commands.contains(&"set_inode_field \"/sandbox\" gid 997".to_string()));
+        assert!(
+            commands.contains(
+                &"set_inode_field \"/sandbox/dir with space/file.txt\" uid 998".to_string()
+            )
+        );
+        assert!(
+            commands.contains(
+                &"set_inode_field \"/sandbox/dir with space/file.txt\" gid 997".to_string()
+            )
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/crates/openshell-driver-vm/src/rootfs.rs
+++ b/crates/openshell-driver-vm/src/rootfs.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::fs::File;
 #[cfg(test)]
 use std::io::BufWriter;
-use std::io::Cursor;
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -119,6 +119,31 @@ pub fn create_ext4_image_from_dir_with_size(
     Ok(())
 }
 
+pub fn clone_or_copy_sparse_file(source: &Path, dest: &Path) -> Result<(), String> {
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    if dest.exists() {
+        fs::remove_file(dest).map_err(|e| format!("remove old file {}: {e}", dest.display()))?;
+    }
+
+    let clone_error = match try_clone_file(source, dest) {
+        Ok(()) => return Ok(()),
+        Err(err) => {
+            let _ = fs::remove_file(dest);
+            err
+        }
+    };
+
+    copy_sparse_file(source, dest).map_err(|copy_error| {
+        format!(
+            "clone {} to {} failed ({clone_error}); sparse copy failed: {copy_error}",
+            source.display(),
+            dest.display()
+        )
+    })
+}
+
 pub fn write_rootfs_image_file(
     image_path: &Path,
     guest_path: &str,
@@ -135,6 +160,99 @@ pub fn write_rootfs_image_file(
     );
     let _ = fs::remove_file(&tmp_path);
     result
+}
+
+pub fn set_rootfs_image_file_mode(
+    image_path: &Path,
+    guest_path: &str,
+    mode: u32,
+) -> Result<(), String> {
+    let regular_file_mode = 0o100_000 | (mode & 0o7777);
+    run_debugfs(
+        image_path,
+        &format!("set_inode_field {guest_path} mode 0{regular_file_mode:o}"),
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn try_clone_file(source: &Path, dest: &Path) -> Result<(), String> {
+    let output = Command::new("cp")
+        .arg("-c")
+        .arg(source)
+        .arg(dest)
+        .output()
+        .map_err(|e| format!("run cp -c: {e}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(format!(
+        "cp -c failed with status {}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn try_clone_file(source: &Path, dest: &Path) -> Result<(), String> {
+    let output = Command::new("cp")
+        .arg("--reflink=auto")
+        .arg("--sparse=always")
+        .arg(source)
+        .arg(dest)
+        .output()
+        .map_err(|e| format!("run cp --reflink=auto: {e}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(format!(
+        "cp --reflink=auto --sparse=always failed with status {}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    ))
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn try_clone_file(_source: &Path, _dest: &Path) -> Result<(), String> {
+    Err("no platform clone command available".to_string())
+}
+
+fn copy_sparse_file(source: &Path, dest: &Path) -> Result<(), String> {
+    const BUFFER_SIZE: usize = 1024 * 1024;
+
+    let mut source_file =
+        File::open(source).map_err(|e| format!("open {}: {e}", source.display()))?;
+    let mut dest_file =
+        File::create(dest).map_err(|e| format!("create {}: {e}", dest.display()))?;
+    let mut buffer = vec![0_u8; BUFFER_SIZE];
+    let mut size = 0_u64;
+
+    loop {
+        let read = source_file
+            .read(&mut buffer)
+            .map_err(|e| format!("read {}: {e}", source.display()))?;
+        if read == 0 {
+            break;
+        }
+
+        if buffer[..read].iter().all(|byte| *byte == 0) {
+            let skip =
+                i64::try_from(read).map_err(|_| format!("sparse copy chunk too large: {read}"))?;
+            dest_file
+                .seek(SeekFrom::Current(skip))
+                .map_err(|e| format!("seek {}: {e}", dest.display()))?;
+        } else {
+            dest_file
+                .write_all(&buffer[..read])
+                .map_err(|e| format!("write {}: {e}", dest.display()))?;
+        }
+        size += read as u64;
+    }
+
+    dest_file
+        .set_len(size)
+        .map_err(|e| format!("size {}: {e}", dest.display()))
 }
 
 #[cfg(test)]
@@ -694,6 +812,44 @@ mod tests {
             fs::read_link(&extracted_link).expect("read extracted symlink"),
             PathBuf::from("/proc/self/mounts")
         );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn clone_or_copy_sparse_file_preserves_size_and_contents() {
+        let dir = unique_temp_dir();
+        fs::create_dir_all(&dir).expect("create temp dir");
+        let source = dir.join("source.bin");
+        let dest = dir.join("dest.bin");
+
+        let mut source_file = File::create(&source).expect("create source");
+        source_file.write_all(b"head").expect("write head");
+        source_file
+            .seek(SeekFrom::Start(1024 * 1024 + 7))
+            .expect("seek source");
+        source_file.write_all(b"tail").expect("write tail");
+        source_file
+            .set_len(2 * 1024 * 1024 + 3)
+            .expect("size source");
+        drop(source_file);
+
+        clone_or_copy_sparse_file(&source, &dest).expect("copy sparse file");
+
+        assert_eq!(
+            fs::metadata(&dest).expect("stat dest").len(),
+            2 * 1024 * 1024 + 3
+        );
+        let mut dest_file = File::open(&dest).expect("open dest");
+        let mut head = [0_u8; 4];
+        dest_file.read_exact(&mut head).expect("read head");
+        assert_eq!(&head, b"head");
+        dest_file
+            .seek(SeekFrom::Start(1024 * 1024 + 7))
+            .expect("seek dest");
+        let mut tail = [0_u8; 4];
+        dest_file.read_exact(&mut tail).expect("read tail");
+        assert_eq!(&tail, b"tail");
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/crates/openshell-driver-vm/src/rootfs.rs
+++ b/crates/openshell-driver-vm/src/rootfs.rs
@@ -11,9 +11,11 @@ use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 const SUPERVISOR: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/openshell-sandbox.zst"));
+const UMOCI: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/umoci.zst"));
 const ROOTFS_VARIANT_MARKER: &str = ".openshell-rootfs-variant";
 const SANDBOX_GUEST_INIT_PATH: &str = "/srv/openshell-vm-sandbox-init.sh";
 const SANDBOX_SUPERVISOR_PATH: &str = "/opt/openshell/bin/openshell-sandbox";
+const SANDBOX_UMOCI_PATH: &str = "/opt/openshell/bin/umoci";
 const ROOTFS_IMAGE_MIN_SIZE_BYTES: u64 = 512 * 1024 * 1024;
 const ROOTFS_IMAGE_MIN_HEADROOM_BYTES: u64 = 256 * 1024 * 1024;
 const EXT4_IMAGE_MIN_HEADROOM_BYTES: u64 = 16 * 1024 * 1024;
@@ -231,6 +233,7 @@ fn prepare_sandbox_rootfs(rootfs: &Path) -> Result<(), String> {
     }
 
     ensure_supervisor_binary(rootfs)?;
+    ensure_umoci_binary(rootfs)?;
 
     let opt_dir = rootfs.join("opt/openshell");
     fs::create_dir_all(&opt_dir).map_err(|e| format!("create {}: {e}", opt_dir.display()))?;
@@ -247,7 +250,8 @@ fn prepare_sandbox_rootfs(rootfs: &Path) -> Result<(), String> {
 
 pub fn validate_sandbox_rootfs(rootfs: &Path) -> Result<(), String> {
     require_rootfs_path(rootfs, SANDBOX_GUEST_INIT_PATH)?;
-    require_rootfs_path(rootfs, "/opt/openshell/bin/openshell-sandbox")?;
+    require_rootfs_path(rootfs, SANDBOX_SUPERVISOR_PATH)?;
+    require_rootfs_path(rootfs, SANDBOX_UMOCI_PATH)?;
     require_any_rootfs_path(rootfs, &["/bin/bash"])?;
     require_any_rootfs_path(rootfs, &["/bin/mount", "/usr/bin/mount"])?;
     require_any_rootfs_path(
@@ -508,6 +512,36 @@ fn ensure_supervisor_binary(rootfs: &Path) -> Result<(), String> {
     Ok(())
 }
 
+fn ensure_umoci_binary(rootfs: &Path) -> Result<(), String> {
+    let path = rootfs.join(SANDBOX_UMOCI_PATH.trim_start_matches('/'));
+    if UMOCI.is_empty() {
+        if !path.exists() {
+            return Err(
+                "umoci not embedded. Build openshell-driver-vm with OPENSHELL_VM_RUNTIME_COMPRESSED_DIR set and run `mise run vm:setup` first"
+                    .to_string(),
+            );
+        }
+    } else {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+        }
+
+        let umoci =
+            zstd::decode_all(Cursor::new(UMOCI)).map_err(|e| format!("decompress umoci: {e}"))?;
+        fs::write(&path, umoci).map_err(|e| format!("write {}: {e}", path.display()))?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+            .map_err(|e| format!("chmod {}: {e}", path.display()))?;
+    }
+
+    Ok(())
+}
+
 fn require_rootfs_path(rootfs: &Path, relative: &str) -> Result<(), String> {
     let candidate = rootfs.join(relative.trim_start_matches('/'));
     if candidate.exists() {
@@ -563,11 +597,7 @@ mod tests {
         fs::create_dir_all(rootfs.join("etc")).expect("create etc");
         fs::create_dir_all(rootfs.join("opt/openshell/bin")).expect("create openshell bin");
         fs::write(rootfs.join("opt/openshell/.initialized"), b"yes").expect("write initialized");
-        fs::write(
-            rootfs.join("opt/openshell/bin/openshell-sandbox"),
-            b"sandbox",
-        )
-        .expect("write openshell-sandbox");
+        write_fake_runtime_binaries(&rootfs);
         fs::write(
             rootfs.join("etc/passwd"),
             "root:x:0:0:root:/root:/bin/bash\n",
@@ -587,6 +617,7 @@ mod tests {
         validate_sandbox_rootfs(&rootfs).expect("validate sandbox rootfs");
 
         assert!(rootfs.join("srv/openshell-vm-sandbox-init.sh").is_file());
+        assert!(rootfs.join("opt/openshell/bin/umoci").is_file());
         assert!(rootfs.join("sandbox").is_dir());
         assert!(rootfs.join("lower").is_dir());
         assert!(rootfs.join("overlay").is_dir());
@@ -621,11 +652,7 @@ mod tests {
         let rootfs = dir.join("rootfs");
 
         fs::create_dir_all(rootfs.join("opt/openshell/bin")).expect("create openshell bin");
-        fs::write(
-            rootfs.join("opt/openshell/bin/openshell-sandbox"),
-            b"sandbox",
-        )
-        .expect("write openshell-sandbox");
+        write_fake_runtime_binaries(&rootfs);
         fs::create_dir_all(rootfs.join("sandbox")).expect("create sandbox workdir");
         fs::write(rootfs.join("sandbox/app.py"), "print('hello')\n").expect("write app");
 
@@ -682,5 +709,14 @@ mod tests {
             "openshell-driver-vm-rootfs-test-{}-{nanos}-{suffix}",
             std::process::id()
         ))
+    }
+
+    fn write_fake_runtime_binaries(rootfs: &Path) {
+        fs::write(
+            rootfs.join("opt/openshell/bin/openshell-sandbox"),
+            b"sandbox",
+        )
+        .expect("write openshell-sandbox");
+        fs::write(rootfs.join("opt/openshell/bin/umoci"), b"umoci").expect("write umoci");
     }
 }

--- a/crates/openshell-driver-vm/src/rootfs.rs
+++ b/crates/openshell-driver-vm/src/rootfs.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::fs::File;
 #[cfg(test)]
 use std::io::BufWriter;
-use std::io::{Cursor, Read, Seek, SeekFrom, Write};
+use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -16,6 +16,7 @@ const SANDBOX_GUEST_INIT_PATH: &str = "/srv/openshell-vm-sandbox-init.sh";
 const SANDBOX_SUPERVISOR_PATH: &str = "/opt/openshell/bin/openshell-sandbox";
 const ROOTFS_IMAGE_MIN_SIZE_BYTES: u64 = 512 * 1024 * 1024;
 const ROOTFS_IMAGE_MIN_HEADROOM_BYTES: u64 = 256 * 1024 * 1024;
+const EXT4_IMAGE_MIN_HEADROOM_BYTES: u64 = 16 * 1024 * 1024;
 static INJECTION_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub const fn sandbox_guest_init_path() -> &'static str {
@@ -74,6 +75,15 @@ pub fn create_rootfs_archive_from_dir(source: &Path, archive_path: &Path) -> Res
 }
 
 pub fn create_rootfs_image_from_dir(source: &Path, image_path: &Path) -> Result<(), String> {
+    let image_size = rootfs_image_size_bytes(source)?;
+    create_ext4_image_from_dir_with_size(source, image_path, image_size)
+}
+
+pub fn create_ext4_image_from_dir_with_size(
+    source: &Path,
+    image_path: &Path,
+    image_size: u64,
+) -> Result<(), String> {
     if let Some(parent) = image_path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
     }
@@ -82,7 +92,16 @@ pub fn create_rootfs_image_from_dir(source: &Path, image_path: &Path) -> Result<
             .map_err(|e| format!("remove old rootfs image {}: {e}", image_path.display()))?;
     }
 
-    let image_size = rootfs_image_size_bytes(source)?;
+    let required_size = ext4_image_min_size_bytes(source)?;
+    if image_size < required_size {
+        return Err(format!(
+            "ext4 image size {} bytes is too small for {} (requires at least {} bytes)",
+            image_size,
+            source.display(),
+            required_size
+        ));
+    }
+
     let image = File::create(image_path)
         .map_err(|e| format!("create rootfs image {}: {e}", image_path.display()))?;
     image
@@ -96,52 +115,6 @@ pub fn create_rootfs_image_from_dir(source: &Path, image_path: &Path) -> Result<
     }
 
     Ok(())
-}
-
-pub fn copy_rootfs_image_to(source: &Path, dest: &Path) -> Result<(), String> {
-    if let Some(parent) = dest.parent() {
-        fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
-    }
-    if dest.exists() {
-        fs::remove_file(dest)
-            .map_err(|e| format!("remove old rootfs image {}: {e}", dest.display()))?;
-    }
-
-    let mut input = File::open(source)
-        .map_err(|e| format!("open cached rootfs image {}: {e}", source.display()))?;
-    let mut output =
-        File::create(dest).map_err(|e| format!("create rootfs image {}: {e}", dest.display()))?;
-    let mut buf = vec![0; 1024 * 1024];
-    let mut total = 0_u64;
-
-    loop {
-        let len = input
-            .read(&mut buf)
-            .map_err(|e| format!("read rootfs image {}: {e}", source.display()))?;
-        if len == 0 {
-            break;
-        }
-        total += len as u64;
-        if buf[..len].iter().all(|byte| *byte == 0) {
-            let offset = i64::try_from(len).map_err(|e| {
-                format!(
-                    "convert sparse rootfs image seek offset for {}: {e}",
-                    dest.display()
-                )
-            })?;
-            output
-                .seek(SeekFrom::Current(offset))
-                .map_err(|e| format!("seek sparse rootfs image {}: {e}", dest.display()))?;
-        } else {
-            output
-                .write_all(&buf[..len])
-                .map_err(|e| format!("write rootfs image {}: {e}", dest.display()))?;
-        }
-    }
-
-    output
-        .set_len(total)
-        .map_err(|e| format!("finalize rootfs image {}: {e}", dest.display()))
 }
 
 pub fn write_rootfs_image_file(
@@ -160,14 +133,6 @@ pub fn write_rootfs_image_file(
     );
     let _ = fs::remove_file(&tmp_path);
     result
-}
-
-pub fn set_rootfs_image_file_mode(
-    image_path: &Path,
-    guest_path: &str,
-    mode: u32,
-) -> Result<(), String> {
-    run_debugfs(image_path, &format!("sif {guest_path} mode {mode:o}"))
 }
 
 #[cfg(test)]
@@ -273,6 +238,9 @@ fn prepare_sandbox_rootfs(rootfs: &Path) -> Result<(), String> {
         .map_err(|e| format!("write sandbox rootfs marker: {e}"))?;
     ensure_sandbox_guest_user(rootfs)?;
     create_sandbox_mountpoint(&rootfs.join("sandbox"))?;
+    create_sandbox_mountpoint(&rootfs.join("lower"))?;
+    create_sandbox_mountpoint(&rootfs.join("overlay"))?;
+    create_sandbox_mountpoint(&rootfs.join("newroot"))?;
 
     Ok(())
 }
@@ -282,6 +250,15 @@ pub fn validate_sandbox_rootfs(rootfs: &Path) -> Result<(), String> {
     require_rootfs_path(rootfs, "/opt/openshell/bin/openshell-sandbox")?;
     require_any_rootfs_path(rootfs, &["/bin/bash"])?;
     require_any_rootfs_path(rootfs, &["/bin/mount", "/usr/bin/mount"])?;
+    require_any_rootfs_path(
+        rootfs,
+        &[
+            "/usr/sbin/chroot",
+            "/usr/bin/chroot",
+            "/sbin/chroot",
+            "/bin/chroot",
+        ],
+    )?;
     require_any_rootfs_path(
         rootfs,
         &["/sbin/ip", "/usr/sbin/ip", "/bin/ip", "/usr/bin/ip"],
@@ -307,6 +284,11 @@ fn rootfs_image_size_bytes(source: &Path) -> Result<u64, String> {
     let headroom = (used / 4).max(ROOTFS_IMAGE_MIN_HEADROOM_BYTES);
     let size = (used + headroom).max(ROOTFS_IMAGE_MIN_SIZE_BYTES);
     Ok(round_up_to_mib(size))
+}
+
+fn ext4_image_min_size_bytes(source: &Path) -> Result<u64, String> {
+    let used = directory_size_bytes(source)?;
+    Ok(round_up_to_mib(used + EXT4_IMAGE_MIN_HEADROOM_BYTES))
 }
 
 fn directory_size_bytes(path: &Path) -> Result<u64, String> {
@@ -597,6 +579,7 @@ mod tests {
         fs::create_dir_all(rootfs.join("sbin")).expect("create sbin");
         fs::write(rootfs.join("bin/bash"), b"bash").expect("write bash");
         fs::write(rootfs.join("bin/mount"), b"mount").expect("write mount");
+        fs::write(rootfs.join("bin/chroot"), b"chroot").expect("write chroot");
         fs::write(rootfs.join("bin/sed"), b"sed").expect("write sed");
         fs::write(rootfs.join("sbin/ip"), b"ip").expect("write ip");
 
@@ -605,6 +588,9 @@ mod tests {
 
         assert!(rootfs.join("srv/openshell-vm-sandbox-init.sh").is_file());
         assert!(rootfs.join("sandbox").is_dir());
+        assert!(rootfs.join("lower").is_dir());
+        assert!(rootfs.join("overlay").is_dir());
+        assert!(rootfs.join("newroot").is_dir());
         assert!(
             fs::read_dir(rootfs.join("sandbox"))
                 .expect("read sandbox")

--- a/crates/openshell-driver-vm/src/runtime.rs
+++ b/crates/openshell-driver-vm/src/runtime.rs
@@ -10,7 +10,7 @@ use std::ptr;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::time::{Duration, Instant};
 
-use crate::{embedded_runtime, ffi, procguard};
+use crate::{embedded_runtime, ffi, procguard, rootfs};
 
 pub const VM_RUNTIME_DIR_ENV: &str = "OPENSHELL_VM_RUNTIME_DIR";
 
@@ -18,7 +18,7 @@ pub const VM_RUNTIME_DIR_ENV: &str = "OPENSHELL_VM_RUNTIME_DIR";
 /// Used by the SIGTERM/SIGINT handler to forward signals to the VM.
 static CHILD_PID: AtomicI32 = AtomicI32::new(0);
 
-/// PID of the helper process (gvproxy for libkrun, virtiofsd for QEMU).
+/// PID of the helper process (gvproxy for libkrun; zero for QEMU).
 /// Zero when not running. Used by the SIGTERM/SIGINT handler and
 /// procguard cleanup callback to ensure the helper doesn't outlive the
 /// launcher (especially on macOS where `PR_SET_PDEATHSIG` is absent).
@@ -45,7 +45,7 @@ const COMPAT_NET_FEATURES: u32 = NET_FEATURE_CSUM
     | NET_FEATURE_HOST_UFO;
 
 pub struct VmLaunchConfig {
-    pub rootfs: PathBuf,
+    pub root_disk: PathBuf,
     pub vcpus: u8,
     pub mem_mib: u32,
     pub exec_path: String,
@@ -96,10 +96,10 @@ fn run_qemu_vm(config: &VmLaunchConfig) -> Result<(), String> {
         .as_deref()
         .ok_or("host_ip is required for QEMU backend")?;
 
-    if !config.rootfs.is_dir() {
+    if !config.root_disk.is_file() {
         return Err(format!(
-            "rootfs directory not found: {}",
-            config.rootfs.display()
+            "root disk image not found: {}",
+            config.root_disk.display()
         ));
     }
 
@@ -111,69 +111,12 @@ fn run_qemu_vm(config: &VmLaunchConfig) -> Result<(), String> {
     check_kvm_access()?;
 
     let guest_env = qemu_guest_env_vars(config, host_dns_server());
-    write_guest_env_file(&config.rootfs, &guest_env)?;
-
-    let rootfs_str = config.rootfs.to_str().ok_or("rootfs path not UTF-8")?;
-    let sandbox_dir = config.rootfs.parent().unwrap_or(&config.rootfs);
-    let sock_prefix = tap_device.trim_start_matches("vmtap-");
-    let virtiofsd_sock_dir = PathBuf::from(format!("/tmp/ovm-qemu-{sock_prefix}"));
-    std::fs::create_dir_all(&virtiofsd_sock_dir)
-        .map_err(|e| format!("create virtiofsd sock dir: {e}"))?;
-    let virtiofsd_sock = virtiofsd_sock_dir.join("virtiofsd.sock");
-    let shm_path = format!("/dev/shm/ovm-qemu-{sock_prefix}");
-
-    std::fs::create_dir_all(&shm_path).map_err(|e| format!("create shm dir: {e}"))?;
+    write_guest_env_file(&config.root_disk, &guest_env)?;
 
     let runtime_dir = qemu_runtime_dir()?;
-
     let gw_port = config.gateway_port.unwrap_or(0);
     setup_tap_networking(tap_device, host_ip, gw_port)?;
     let mut tap_guard = TapGuard::new(tap_device.to_string(), host_ip.to_string(), gw_port);
-
-    let virtiofsd_log = sandbox_dir.join("virtiofsd.log");
-    let virtiofsd_log_file =
-        std::fs::File::create(&virtiofsd_log).map_err(|e| format!("create virtiofsd log: {e}"))?;
-
-    let virtiofsd_bin = {
-        let runtime_virtiofsd = runtime_dir.join("virtiofsd");
-        if runtime_virtiofsd.is_file() {
-            runtime_virtiofsd
-        } else {
-            PathBuf::from("virtiofsd")
-        }
-    };
-
-    let mut virtiofsd_cmd = StdCommand::new(&virtiofsd_bin);
-    virtiofsd_cmd
-        .arg("--socket-path")
-        .arg(&virtiofsd_sock)
-        .arg("--shared-dir")
-        .arg(rootfs_str)
-        .arg("--cache=auto")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(virtiofsd_log_file);
-
-    #[cfg(target_os = "linux")]
-    {
-        use nix::sys::signal::Signal;
-        use std::os::unix::process::CommandExt as _;
-        unsafe {
-            virtiofsd_cmd.pre_exec(|| {
-                nix::sys::prctl::set_pdeathsig(Signal::SIGKILL)
-                    .map_err(|err| std::io::Error::other(format!("pdeathsig: {err}")))
-            });
-        }
-    }
-
-    let virtiofsd_child = virtiofsd_cmd
-        .spawn()
-        .map_err(|e| format!("failed to start virtiofsd: {e}"))?;
-    let virtiofsd_pid = virtiofsd_child.id().cast_signed();
-    GVPROXY_PID.store(virtiofsd_pid, Ordering::Relaxed);
-    let mut virtiofsd_guard = GvproxyGuard::new(virtiofsd_child);
-
-    wait_for_path(&virtiofsd_sock, Duration::from_secs(5), "virtiofsd socket")?;
 
     let vmlinux = runtime_dir.join("vmlinux");
     if !vmlinux.is_file() {
@@ -198,20 +141,13 @@ fn run_qemu_vm(config: &VmLaunchConfig) -> Result<(), String> {
         .arg(&vmlinux)
         .arg("-append")
         .arg(&kernel_cmdline)
-        .arg("-chardev")
+        .arg("-drive")
         .arg(format!(
-            "socket,id=virtiofs,path={}",
-            virtiofsd_sock.display()
+            "file={},if=none,format=raw,id=rootfs",
+            config.root_disk.display()
         ))
         .arg("-device")
-        .arg("vhost-user-fs-pci,chardev=virtiofs,tag=rootfs")
-        .arg("-object")
-        .arg(format!(
-            "memory-backend-memfd,id=mem,size={}M,share=on",
-            config.mem_mib
-        ))
-        .arg("-numa")
-        .arg("node,memdev=mem")
+        .arg("virtio-blk-pci,drive=rootfs")
         .arg("-netdev")
         .arg(format!(
             "tap,id=net0,ifname={tap_device},script=no,downscript=no"
@@ -263,15 +199,8 @@ fn run_qemu_vm(config: &VmLaunchConfig) -> Result<(), String> {
         .map_err(|e| format!("failed to wait for QEMU: {e}"))?;
 
     CHILD_PID.store(0, Ordering::Relaxed);
-    unsafe {
-        libc::kill(virtiofsd_pid, libc::SIGTERM);
-    }
-    virtiofsd_guard.disarm();
-    GVPROXY_PID.store(0, Ordering::Relaxed);
     teardown_tap_networking(tap_device, host_ip, gw_port);
     tap_guard.disarm();
-    let _ = std::fs::remove_dir_all(&shm_path);
-    let _ = std::fs::remove_dir_all(&virtiofsd_sock_dir);
 
     if status.success() {
         Ok(())
@@ -280,12 +209,11 @@ fn run_qemu_vm(config: &VmLaunchConfig) -> Result<(), String> {
     }
 }
 
-/// Write environment variables into the rootfs so the guest init script
-/// can source them. virtiofs shares the host rootfs directory into the guest.
-fn write_guest_env_file(rootfs: &Path, env_vars: &[String]) -> Result<(), String> {
-    let srv_dir = rootfs.join("srv");
-    std::fs::create_dir_all(&srv_dir).map_err(|e| format!("create /srv in rootfs: {e}"))?;
-    let env_file = srv_dir.join("openshell-env.sh");
+/// Write environment variables into the root disk so the guest init script can
+/// source them. QEMU does not provide a `krun_set_exec` equivalent, so the
+/// launcher injects this small per-sandbox file into the copied root image
+/// before boot.
+fn write_guest_env_file(root_disk: &Path, env_vars: &[String]) -> Result<(), String> {
     let mut content = String::new();
     for var in env_vars {
         if let Some((key, value)) = var.split_once('=') {
@@ -293,8 +221,7 @@ fn write_guest_env_file(rootfs: &Path, env_vars: &[String]) -> Result<(), String
             let _ = writeln!(content, "export {key}=\"{}\"", shell_escape(value));
         }
     }
-    std::fs::write(&env_file, &content).map_err(|e| format!("write guest env file: {e}"))?;
-    Ok(())
+    rootfs::write_rootfs_image_file(root_disk, "/srv/openshell-env.sh", content.as_bytes())
 }
 
 fn qemu_guest_env_vars(config: &VmLaunchConfig, dns_server: Option<String>) -> Vec<String> {
@@ -331,8 +258,8 @@ fn shell_escape(s: &str) -> String {
 fn build_kernel_cmdline(config: &VmLaunchConfig) -> String {
     let mut parts = vec![
         "console=ttyS0".to_string(),
-        "root=rootfs".to_string(),
-        "rootfstype=virtiofs".to_string(),
+        "root=/dev/vda".to_string(),
+        "rootfstype=ext4".to_string(),
         "rw".to_string(),
         "panic=-1".to_string(),
         format!("init={}", config.exec_path),
@@ -674,10 +601,10 @@ fn procguard_kill_children() {
 }
 
 fn run_libkrun_vm(config: &VmLaunchConfig) -> Result<(), String> {
-    if !config.rootfs.is_dir() {
+    if !config.root_disk.is_file() {
         return Err(format!(
-            "rootfs directory not found: {}",
-            config.rootfs.display()
+            "root disk image not found: {}",
+            config.root_disk.display()
         ));
     }
 
@@ -702,7 +629,7 @@ fn run_libkrun_vm(config: &VmLaunchConfig) -> Result<(), String> {
 
     let vm = VmContext::create(&runtime_dir, config.log_level)?;
     vm.set_vm_config(config.vcpus, config.mem_mib)?;
-    vm.set_root(&config.rootfs)?;
+    vm.set_root_disk(&config.root_disk)?;
     vm.set_workdir(&config.workdir)?;
 
     // Run gvproxy strictly as the guest's virtual NIC / DHCP / router.
@@ -749,12 +676,12 @@ fn run_libkrun_vm(config: &VmLaunchConfig) -> Result<(), String> {
             ));
         }
 
-        let sock_base = gvproxy_socket_base(&config.rootfs)?;
+        let sock_base = gvproxy_socket_base(&config.root_disk)?;
         let net_sock = sock_base.with_extension("v");
         let _ = std::fs::remove_file(&net_sock);
         let _ = std::fs::remove_file(sock_base.with_extension("v-krun.sock"));
 
-        let run_dir = config.rootfs.parent().unwrap_or(&config.rootfs);
+        let run_dir = config.root_disk.parent().unwrap_or(&config.root_disk);
         let gvproxy_log = run_dir.join("gvproxy.log");
         let gvproxy_log_file = std::fs::File::create(&gvproxy_log)
             .map_err(|e| format!("create gvproxy log {}: {e}", gvproxy_log.display()))?;
@@ -1013,11 +940,37 @@ impl VmContext {
         )
     }
 
-    fn set_root(&self, rootfs: &Path) -> Result<(), String> {
-        let rootfs_c = path_to_cstring(rootfs)?;
+    fn set_root_disk(&self, root_disk: &Path) -> Result<(), String> {
+        let root_disk_c = path_to_cstring(root_disk)?;
+        let block_id_c = CString::new("root").map_err(|e| format!("invalid block id: {e}"))?;
         check(
-            unsafe { (self.krun.krun_set_root)(self.ctx_id, rootfs_c.as_ptr()) },
-            "krun_set_root",
+            unsafe {
+                (self.krun.krun_add_disk)(
+                    self.ctx_id,
+                    block_id_c.as_ptr(),
+                    root_disk_c.as_ptr(),
+                    false,
+                )
+            },
+            "krun_add_disk",
+        )?;
+
+        let device_c =
+            CString::new("/dev/vda").map_err(|e| format!("invalid root disk device: {e}"))?;
+        let fstype_c =
+            CString::new("ext4").map_err(|e| format!("invalid root disk fstype: {e}"))?;
+        let options_c =
+            CString::new("rw").map_err(|e| format!("invalid root disk options: {e}"))?;
+        check(
+            unsafe {
+                (self.krun.krun_set_root_disk_remount)(
+                    self.ctx_id,
+                    device_c.as_ptr(),
+                    fstype_c.as_ptr(),
+                    options_c.as_ptr(),
+                )
+            },
+            "krun_set_root_disk_remount",
         )
     }
 
@@ -1234,8 +1187,8 @@ fn secure_socket_base(subdir: &str) -> Result<PathBuf, String> {
     Ok(dir)
 }
 
-fn gvproxy_socket_base(rootfs: &Path) -> Result<PathBuf, String> {
-    Ok(secure_socket_base("osd-gv")?.join(hash_path_id(rootfs)))
+fn gvproxy_socket_base(root_disk: &Path) -> Result<PathBuf, String> {
+    Ok(secure_socket_base("osd-gv")?.join(hash_path_id(root_disk)))
 }
 
 fn install_signal_forwarding(pid: i32) {
@@ -1342,7 +1295,7 @@ mod tests {
 
     fn qemu_config() -> VmLaunchConfig {
         VmLaunchConfig {
-            rootfs: PathBuf::from("/rootfs"),
+            root_disk: PathBuf::from("/rootfs.ext4"),
             vcpus: 2,
             mem_mib: 2048,
             exec_path: "/srv/openshell-vm-sandbox-init.sh".to_string(),
@@ -1377,6 +1330,8 @@ mod tests {
     fn kernel_cmdline_keeps_guest_init_metadata_out_of_proc_cmdline() {
         let cmdline = build_kernel_cmdline(&qemu_config());
 
+        assert!(cmdline.contains("root=/dev/vda"));
+        assert!(cmdline.contains("rootfstype=ext4"));
         assert!(cmdline.contains("ip=10.0.128.2::10.0.128.1:255.255.255.252:sandbox::off"));
         assert!(cmdline.contains("firmware_class.path=/lib/firmware"));
         assert!(!cmdline.contains("VM_NET_IP="));

--- a/crates/openshell-driver-vm/src/runtime.rs
+++ b/crates/openshell-driver-vm/src/runtime.rs
@@ -46,6 +46,7 @@ const COMPAT_NET_FEATURES: u32 = NET_FEATURE_CSUM
 
 pub struct VmLaunchConfig {
     pub root_disk: PathBuf,
+    pub overlay_disk: PathBuf,
     pub vcpus: u8,
     pub mem_mib: u32,
     pub exec_path: String,
@@ -102,6 +103,12 @@ fn run_qemu_vm(config: &VmLaunchConfig) -> Result<(), String> {
             config.root_disk.display()
         ));
     }
+    if !config.overlay_disk.is_file() {
+        return Err(format!(
+            "overlay disk image not found: {}",
+            config.overlay_disk.display()
+        ));
+    }
 
     if let Err(err) = procguard::die_with_parent_cleanup(procguard_kill_children) {
         return Err(format!("procguard arm failed: {err}"));
@@ -111,7 +118,7 @@ fn run_qemu_vm(config: &VmLaunchConfig) -> Result<(), String> {
     check_kvm_access()?;
 
     let guest_env = qemu_guest_env_vars(config, host_dns_server());
-    write_guest_env_file(&config.root_disk, &guest_env)?;
+    write_guest_env_file(&config.overlay_disk, &guest_env)?;
 
     let runtime_dir = qemu_runtime_dir()?;
     let gw_port = config.gateway_port.unwrap_or(0);
@@ -141,13 +148,7 @@ fn run_qemu_vm(config: &VmLaunchConfig) -> Result<(), String> {
         .arg(&vmlinux)
         .arg("-append")
         .arg(&kernel_cmdline)
-        .arg("-drive")
-        .arg(format!(
-            "file={},if=none,format=raw,id=rootfs",
-            config.root_disk.display()
-        ))
-        .arg("-device")
-        .arg("virtio-blk-pci,drive=rootfs")
+        .args(qemu_disk_args(config))
         .arg("-netdev")
         .arg(format!(
             "tap,id=net0,ifname={tap_device},script=no,downscript=no"
@@ -209,11 +210,30 @@ fn run_qemu_vm(config: &VmLaunchConfig) -> Result<(), String> {
     }
 }
 
-/// Write environment variables into the root disk so the guest init script can
-/// source them. QEMU does not provide a `krun_set_exec` equivalent, so the
-/// launcher injects this small per-sandbox file into the copied root image
-/// before boot.
-fn write_guest_env_file(root_disk: &Path, env_vars: &[String]) -> Result<(), String> {
+fn qemu_disk_args(config: &VmLaunchConfig) -> Vec<String> {
+    vec![
+        "-drive".to_string(),
+        format!(
+            "file={},if=none,format=raw,id=rootfs,readonly=on",
+            config.root_disk.display()
+        ),
+        "-device".to_string(),
+        "virtio-blk-pci,drive=rootfs".to_string(),
+        "-drive".to_string(),
+        format!(
+            "file={},if=none,format=raw,id=overlay",
+            config.overlay_disk.display()
+        ),
+        "-device".to_string(),
+        "virtio-blk-pci,drive=overlay".to_string(),
+    ]
+}
+
+/// Write environment variables into the overlay disk so the guest init script
+/// can source them after the overlay root is mounted. QEMU does not provide a
+/// `krun_set_exec` equivalent, so the launcher injects this small per-sandbox
+/// file into the overlay upperdir before boot.
+fn write_guest_env_file(overlay_disk: &Path, env_vars: &[String]) -> Result<(), String> {
     let mut content = String::new();
     for var in env_vars {
         if let Some((key, value)) = var.split_once('=') {
@@ -221,7 +241,11 @@ fn write_guest_env_file(root_disk: &Path, env_vars: &[String]) -> Result<(), Str
             let _ = writeln!(content, "export {key}=\"{}\"", shell_escape(value));
         }
     }
-    rootfs::write_rootfs_image_file(root_disk, "/srv/openshell-env.sh", content.as_bytes())
+    rootfs::write_rootfs_image_file(
+        overlay_disk,
+        "/upper/srv/openshell-env.sh",
+        content.as_bytes(),
+    )
 }
 
 fn qemu_guest_env_vars(config: &VmLaunchConfig, dns_server: Option<String>) -> Vec<String> {
@@ -260,7 +284,7 @@ fn build_kernel_cmdline(config: &VmLaunchConfig) -> String {
         "console=ttyS0".to_string(),
         "root=/dev/vda".to_string(),
         "rootfstype=ext4".to_string(),
-        "rw".to_string(),
+        "ro".to_string(),
         "panic=-1".to_string(),
         format!("init={}", config.exec_path),
     ];
@@ -607,6 +631,12 @@ fn run_libkrun_vm(config: &VmLaunchConfig) -> Result<(), String> {
             config.root_disk.display()
         ));
     }
+    if !config.overlay_disk.is_file() {
+        return Err(format!(
+            "overlay disk image not found: {}",
+            config.overlay_disk.display()
+        ));
+    }
 
     // Arm procguard first, BEFORE we spawn gvproxy or fork libkrun, so
     // that the launcher can't be orphaned during setup. The cleanup
@@ -629,7 +659,7 @@ fn run_libkrun_vm(config: &VmLaunchConfig) -> Result<(), String> {
 
     let vm = VmContext::create(&runtime_dir, config.log_level)?;
     vm.set_vm_config(config.vcpus, config.mem_mib)?;
-    vm.set_root_disk(&config.root_disk)?;
+    vm.set_disks(&config.root_disk, &config.overlay_disk)?;
     vm.set_workdir(&config.workdir)?;
 
     // Run gvproxy strictly as the guest's virtual NIC / DHCP / router.
@@ -940,7 +970,7 @@ impl VmContext {
         )
     }
 
-    fn set_root_disk(&self, root_disk: &Path) -> Result<(), String> {
+    fn set_disks(&self, root_disk: &Path, overlay_disk: &Path) -> Result<(), String> {
         let root_disk_c = path_to_cstring(root_disk)?;
         let block_id_c = CString::new("root").map_err(|e| format!("invalid block id: {e}"))?;
         check(
@@ -949,6 +979,21 @@ impl VmContext {
                     self.ctx_id,
                     block_id_c.as_ptr(),
                     root_disk_c.as_ptr(),
+                    true,
+                )
+            },
+            "krun_add_disk",
+        )?;
+
+        let overlay_disk_c = path_to_cstring(overlay_disk)?;
+        let overlay_block_id_c =
+            CString::new("overlay").map_err(|e| format!("invalid block id: {e}"))?;
+        check(
+            unsafe {
+                (self.krun.krun_add_disk)(
+                    self.ctx_id,
+                    overlay_block_id_c.as_ptr(),
+                    overlay_disk_c.as_ptr(),
                     false,
                 )
             },
@@ -960,7 +1005,7 @@ impl VmContext {
         let fstype_c =
             CString::new("ext4").map_err(|e| format!("invalid root disk fstype: {e}"))?;
         let options_c =
-            CString::new("rw").map_err(|e| format!("invalid root disk options: {e}"))?;
+            CString::new("ro").map_err(|e| format!("invalid root disk options: {e}"))?;
         check(
             unsafe {
                 (self.krun.krun_set_root_disk_remount)(
@@ -1296,6 +1341,7 @@ mod tests {
     fn qemu_config() -> VmLaunchConfig {
         VmLaunchConfig {
             root_disk: PathBuf::from("/rootfs.ext4"),
+            overlay_disk: PathBuf::from("/overlay.ext4"),
             vcpus: 2,
             mem_mib: 2048,
             exec_path: "/srv/openshell-vm-sandbox-init.sh".to_string(),
@@ -1332,11 +1378,32 @@ mod tests {
 
         assert!(cmdline.contains("root=/dev/vda"));
         assert!(cmdline.contains("rootfstype=ext4"));
+        assert!(cmdline.contains(" ro"));
         assert!(cmdline.contains("ip=10.0.128.2::10.0.128.1:255.255.255.252:sandbox::off"));
         assert!(cmdline.contains("firmware_class.path=/lib/firmware"));
         assert!(!cmdline.contains("VM_NET_IP="));
         assert!(!cmdline.contains("VM_NET_GW="));
         assert!(!cmdline.contains("VM_NET_DNS="));
         assert!(!cmdline.contains("GPU_ENABLED="));
+    }
+
+    #[test]
+    fn qemu_disk_args_attach_base_readonly_and_overlay_readwrite() {
+        let args = qemu_disk_args(&qemu_config());
+
+        assert!(args.contains(&"-drive".to_string()));
+        assert!(
+            args.contains(
+                &"file=/rootfs.ext4,if=none,format=raw,id=rootfs,readonly=on".to_string()
+            )
+        );
+        assert!(args.contains(&"virtio-blk-pci,drive=rootfs".to_string()));
+        assert!(args.contains(&"file=/overlay.ext4,if=none,format=raw,id=overlay".to_string()));
+        assert!(
+            !args
+                .iter()
+                .any(|arg| arg.contains("id=overlay,readonly=on"))
+        );
+        assert!(args.contains(&"virtio-blk-pci,drive=overlay".to_string()));
     }
 }

--- a/crates/openshell-driver-vm/src/runtime.rs
+++ b/crates/openshell-driver-vm/src/runtime.rs
@@ -47,6 +47,7 @@ const COMPAT_NET_FEATURES: u32 = NET_FEATURE_CSUM
 pub struct VmLaunchConfig {
     pub root_disk: PathBuf,
     pub overlay_disk: PathBuf,
+    pub image_disk: Option<PathBuf>,
     pub vcpus: u8,
     pub mem_mib: u32,
     pub exec_path: String,
@@ -108,6 +109,11 @@ fn run_qemu_vm(config: &VmLaunchConfig) -> Result<(), String> {
             "overlay disk image not found: {}",
             config.overlay_disk.display()
         ));
+    }
+    if let Some(image_disk) = &config.image_disk
+        && !image_disk.is_file()
+    {
+        return Err(format!("image disk not found: {}", image_disk.display()));
     }
 
     if let Err(err) = procguard::die_with_parent_cleanup(procguard_kill_children) {
@@ -211,7 +217,7 @@ fn run_qemu_vm(config: &VmLaunchConfig) -> Result<(), String> {
 }
 
 fn qemu_disk_args(config: &VmLaunchConfig) -> Vec<String> {
-    vec![
+    let mut args = vec![
         "-drive".to_string(),
         format!(
             "file={},if=none,format=raw,id=rootfs,readonly=on",
@@ -226,7 +232,19 @@ fn qemu_disk_args(config: &VmLaunchConfig) -> Vec<String> {
         ),
         "-device".to_string(),
         "virtio-blk-pci,drive=overlay".to_string(),
-    ]
+    ];
+    if let Some(image_disk) = &config.image_disk {
+        args.extend([
+            "-drive".to_string(),
+            format!(
+                "file={},if=none,format=raw,id=image,readonly=on",
+                image_disk.display()
+            ),
+            "-device".to_string(),
+            "virtio-blk-pci,drive=image".to_string(),
+        ]);
+    }
+    args
 }
 
 /// Write environment variables into the overlay disk so the guest init script
@@ -637,6 +655,11 @@ fn run_libkrun_vm(config: &VmLaunchConfig) -> Result<(), String> {
             config.overlay_disk.display()
         ));
     }
+    if let Some(image_disk) = &config.image_disk
+        && !image_disk.is_file()
+    {
+        return Err(format!("image disk not found: {}", image_disk.display()));
+    }
 
     // Arm procguard first, BEFORE we spawn gvproxy or fork libkrun, so
     // that the launcher can't be orphaned during setup. The cleanup
@@ -659,7 +682,11 @@ fn run_libkrun_vm(config: &VmLaunchConfig) -> Result<(), String> {
 
     let vm = VmContext::create(&runtime_dir, config.log_level)?;
     vm.set_vm_config(config.vcpus, config.mem_mib)?;
-    vm.set_disks(&config.root_disk, &config.overlay_disk)?;
+    vm.set_disks(
+        &config.root_disk,
+        &config.overlay_disk,
+        config.image_disk.as_deref(),
+    )?;
     vm.set_workdir(&config.workdir)?;
 
     // Run gvproxy strictly as the guest's virtual NIC / DHCP / router.
@@ -706,12 +733,12 @@ fn run_libkrun_vm(config: &VmLaunchConfig) -> Result<(), String> {
             ));
         }
 
-        let sock_base = gvproxy_socket_base(&config.root_disk)?;
+        let sock_base = gvproxy_socket_base(&config.overlay_disk)?;
         let net_sock = sock_base.with_extension("v");
         let _ = std::fs::remove_file(&net_sock);
         let _ = std::fs::remove_file(sock_base.with_extension("v-krun.sock"));
 
-        let run_dir = config.root_disk.parent().unwrap_or(&config.root_disk);
+        let run_dir = config.overlay_disk.parent().unwrap_or(&config.overlay_disk);
         let gvproxy_log = run_dir.join("gvproxy.log");
         let gvproxy_log_file = std::fs::File::create(&gvproxy_log)
             .map_err(|e| format!("create gvproxy log {}: {e}", gvproxy_log.display()))?;
@@ -970,7 +997,12 @@ impl VmContext {
         )
     }
 
-    fn set_disks(&self, root_disk: &Path, overlay_disk: &Path) -> Result<(), String> {
+    fn set_disks(
+        &self,
+        root_disk: &Path,
+        overlay_disk: &Path,
+        image_disk: Option<&Path>,
+    ) -> Result<(), String> {
         let root_disk_c = path_to_cstring(root_disk)?;
         let block_id_c = CString::new("root").map_err(|e| format!("invalid block id: {e}"))?;
         check(
@@ -999,6 +1031,23 @@ impl VmContext {
             },
             "krun_add_disk",
         )?;
+
+        if let Some(image_disk) = image_disk {
+            let image_disk_c = path_to_cstring(image_disk)?;
+            let image_block_id_c =
+                CString::new("image").map_err(|e| format!("invalid image block id: {e}"))?;
+            check(
+                unsafe {
+                    (self.krun.krun_add_disk)(
+                        self.ctx_id,
+                        image_block_id_c.as_ptr(),
+                        image_disk_c.as_ptr(),
+                        true,
+                    )
+                },
+                "krun_add_disk",
+            )?;
+        }
 
         let device_c =
             CString::new("/dev/vda").map_err(|e| format!("invalid root disk device: {e}"))?;
@@ -1232,8 +1281,8 @@ fn secure_socket_base(subdir: &str) -> Result<PathBuf, String> {
     Ok(dir)
 }
 
-fn gvproxy_socket_base(root_disk: &Path) -> Result<PathBuf, String> {
-    Ok(secure_socket_base("osd-gv")?.join(hash_path_id(root_disk)))
+fn gvproxy_socket_base(overlay_disk: &Path) -> Result<PathBuf, String> {
+    Ok(secure_socket_base("osd-gv")?.join(hash_path_id(overlay_disk)))
 }
 
 fn install_signal_forwarding(pid: i32) {
@@ -1342,6 +1391,7 @@ mod tests {
         VmLaunchConfig {
             root_disk: PathBuf::from("/rootfs.ext4"),
             overlay_disk: PathBuf::from("/overlay.ext4"),
+            image_disk: None,
             vcpus: 2,
             mem_mib: 2048,
             exec_path: "/srv/openshell-vm-sandbox-init.sh".to_string(),
@@ -1405,5 +1455,30 @@ mod tests {
                 .any(|arg| arg.contains("id=overlay,readonly=on"))
         );
         assert!(args.contains(&"virtio-blk-pci,drive=overlay".to_string()));
+    }
+
+    #[test]
+    fn qemu_disk_args_attach_prepared_image_readonly_when_present() {
+        let mut config = qemu_config();
+        config.image_disk = Some(PathBuf::from("/image-rootfs.ext4"));
+
+        let args = qemu_disk_args(&config);
+
+        assert!(args.contains(
+            &"file=/image-rootfs.ext4,if=none,format=raw,id=image,readonly=on".to_string()
+        ));
+        assert!(args.contains(&"virtio-blk-pci,drive=image".to_string()));
+    }
+
+    #[test]
+    fn gvproxy_socket_base_is_per_sandbox_overlay_path() {
+        let first =
+            gvproxy_socket_base(Path::new("/tmp/openshell-vm/sandboxes/first/overlay.ext4"))
+                .expect("first socket base");
+        let second =
+            gvproxy_socket_base(Path::new("/tmp/openshell-vm/sandboxes/second/overlay.ext4"))
+                .expect("second socket base");
+
+        assert_ne!(first, second);
     }
 }

--- a/crates/openshell-sandbox/src/l7/mod.rs
+++ b/crates/openshell-sandbox/src/l7/mod.rs
@@ -535,6 +535,10 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                     errors.push(format!(
                         "{loc}: host wildcard '{host}' matches all hosts; use specific patterns like '*.example.com'"
                     ));
+                } else if !host.starts_with("*.") && !host.starts_with("**.") {
+                    errors.push(format!(
+                        "{loc}: host wildcard must start with '*.' or '**.' (e.g., '*.example.com'), got '{host}'"
+                    ));
                 } else {
                     // Reject TLD wildcards like *.com (2 labels) — they are
                     // accepted by the policy engine but silently fail at the
@@ -1789,26 +1793,22 @@ mod tests {
     }
 
     #[test]
-    fn validate_intra_label_wildcard_host_valid_no_error() {
+    fn validate_wildcard_host_no_star_dot_error() {
         let data = serde_json::json!({
             "network_policies": {
                 "test": {
                     "endpoints": [{
-                        "host": "*-aiplatform.googleapis.com",
+                        "host": "*com",
                         "port": 443
                     }],
                     "binaries": []
                 }
             }
         });
-        let (errors, warnings) = validate_l7_policies(&data);
+        let (errors, _warnings) = validate_l7_policies(&data);
         assert!(
-            errors.is_empty(),
-            "Scoped intra-label host wildcard should be valid, got errors: {errors:?}"
-        );
-        assert!(
-            warnings.is_empty(),
-            "Scoped intra-label host wildcard should not warn, got warnings: {warnings:?}"
+            errors.iter().any(|e| e.contains("must start with")),
+            "Malformed wildcard should be rejected, got errors: {errors:?}"
         );
     }
 
@@ -1829,26 +1829,6 @@ mod tests {
         assert!(
             errors.iter().any(|e| e.contains("TLD wildcard")),
             "*.com should be rejected as TLD wildcard, got errors: {errors:?}"
-        );
-    }
-
-    #[test]
-    fn validate_intra_label_tld_wildcard_rejected() {
-        let data = serde_json::json!({
-            "network_policies": {
-                "test": {
-                    "endpoints": [{
-                        "host": "example.*",
-                        "port": 443
-                    }],
-                    "binaries": []
-                }
-            }
-        });
-        let (errors, _warnings) = validate_l7_policies(&data);
-        assert!(
-            errors.iter().any(|e| e.contains("TLD wildcard")),
-            "example.* should be rejected as TLD wildcard, got errors: {errors:?}"
         );
     }
 

--- a/crates/openshell-sandbox/src/l7/mod.rs
+++ b/crates/openshell-sandbox/src/l7/mod.rs
@@ -535,10 +535,6 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                     errors.push(format!(
                         "{loc}: host wildcard '{host}' matches all hosts; use specific patterns like '*.example.com'"
                     ));
-                } else if !host.starts_with("*.") && !host.starts_with("**.") {
-                    errors.push(format!(
-                        "{loc}: host wildcard must start with '*.' or '**.' (e.g., '*.example.com'), got '{host}'"
-                    ));
                 } else {
                     // Reject TLD wildcards like *.com (2 labels) — they are
                     // accepted by the policy engine but silently fail at the
@@ -1793,22 +1789,26 @@ mod tests {
     }
 
     #[test]
-    fn validate_wildcard_host_no_star_dot_error() {
+    fn validate_intra_label_wildcard_host_valid_no_error() {
         let data = serde_json::json!({
             "network_policies": {
                 "test": {
                     "endpoints": [{
-                        "host": "*com",
+                        "host": "*-aiplatform.googleapis.com",
                         "port": 443
                     }],
                     "binaries": []
                 }
             }
         });
-        let (errors, _warnings) = validate_l7_policies(&data);
+        let (errors, warnings) = validate_l7_policies(&data);
         assert!(
-            errors.iter().any(|e| e.contains("must start with")),
-            "Malformed wildcard should be rejected, got errors: {errors:?}"
+            errors.is_empty(),
+            "Scoped intra-label host wildcard should be valid, got errors: {errors:?}"
+        );
+        assert!(
+            warnings.is_empty(),
+            "Scoped intra-label host wildcard should not warn, got warnings: {warnings:?}"
         );
     }
 
@@ -1829,6 +1829,26 @@ mod tests {
         assert!(
             errors.iter().any(|e| e.contains("TLD wildcard")),
             "*.com should be rejected as TLD wildcard, got errors: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_intra_label_tld_wildcard_rejected() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "example.*",
+                        "port": 443
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|e| e.contains("TLD wildcard")),
+            "example.* should be rejected as TLD wildcard, got errors: {errors:?}"
         );
     }
 

--- a/crates/openshell-sandbox/src/opa.rs
+++ b/crates/openshell-sandbox/src/opa.rs
@@ -3884,6 +3884,34 @@ network_policies:
     }
 
     #[test]
+    fn wildcard_host_matches_intra_label_suffix() {
+        let data = r#"
+network_policies:
+  wildcard:
+    name: wildcard
+    endpoints:
+      - { host: "*-aiplatform.googleapis.com", port: 443 }
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
+        let input = NetworkInput {
+            host: "us-central1-aiplatform.googleapis.com".into(),
+            port: 443,
+            binary_path: PathBuf::from("/usr/bin/curl"),
+            binary_sha256: "unused".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+        };
+        let decision = engine.evaluate_network(&input).unwrap();
+        assert!(
+            decision.allowed,
+            "*-aiplatform.googleapis.com should match us-central1-aiplatform.googleapis.com: {}",
+            decision.reason
+        );
+    }
+
+    #[test]
     fn wildcard_host_rejects_deep_subdomain() {
         // * should match single DNS label only (does not cross .)
         let data = r#"

--- a/crates/openshell-sandbox/src/opa.rs
+++ b/crates/openshell-sandbox/src/opa.rs
@@ -3884,34 +3884,6 @@ network_policies:
     }
 
     #[test]
-    fn wildcard_host_matches_intra_label_suffix() {
-        let data = r#"
-network_policies:
-  wildcard:
-    name: wildcard
-    endpoints:
-      - { host: "*-aiplatform.googleapis.com", port: 443 }
-    binaries:
-      - { path: /usr/bin/curl }
-"#;
-        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
-        let input = NetworkInput {
-            host: "us-central1-aiplatform.googleapis.com".into(),
-            port: 443,
-            binary_path: PathBuf::from("/usr/bin/curl"),
-            binary_sha256: "unused".into(),
-            ancestors: vec![],
-            cmdline_paths: vec![],
-        };
-        let decision = engine.evaluate_network(&input).unwrap();
-        assert!(
-            decision.allowed,
-            "*-aiplatform.googleapis.com should match us-central1-aiplatform.googleapis.com: {}",
-            decision.reason
-        );
-    }
-
-    #[test]
     fn wildcard_host_rejects_deep_subdomain() {
         // * should match single DNS label only (does not cross .)
         let data = r#"

--- a/crates/openshell-server/src/compute/vm.rs
+++ b/crates/openshell-server/src/compute/vm.rs
@@ -85,6 +85,9 @@ pub struct VmComputeConfig {
     /// Default memory allocation for VM sandboxes, in MiB.
     pub mem_mib: u32,
 
+    /// Writable overlay disk size for each VM sandbox, in MiB.
+    pub overlay_disk_mib: u64,
+
     /// Host-side CA certificate for the guest's mTLS client bundle.
     pub guest_tls_ca: Option<PathBuf>,
 
@@ -120,6 +123,12 @@ impl VmComputeConfig {
         2048
     }
 
+    /// Default writable overlay disk size, in MiB.
+    #[must_use]
+    pub const fn default_overlay_disk_mib() -> u64 {
+        4096
+    }
+
     #[must_use]
     fn default_driver_search_dirs(home: Option<PathBuf>) -> Vec<PathBuf> {
         let mut dirs = Vec::new();
@@ -143,6 +152,7 @@ impl Default for VmComputeConfig {
             krun_log_level: Self::default_krun_log_level(),
             vcpus: Self::default_vcpus(),
             mem_mib: Self::default_mem_mib(),
+            overlay_disk_mib: Self::default_overlay_disk_mib(),
             guest_tls_ca: None,
             guest_tls_cert: None,
             guest_tls_key: None,
@@ -457,6 +467,9 @@ pub async fn spawn(
         .arg(vm_config.krun_log_level.to_string());
     command.arg("--vcpus").arg(vm_config.vcpus.to_string());
     command.arg("--mem-mib").arg(vm_config.mem_mib.to_string());
+    command
+        .arg("--overlay-disk-mib")
+        .arg(vm_config.overlay_disk_mib.to_string());
     if let Some(tls) = guest_tls_paths {
         command.arg("--guest-tls-ca").arg(tls.ca);
         command.arg("--guest-tls-cert").arg(tls.cert);

--- a/crates/openshell-server/src/compute/vm.rs
+++ b/crates/openshell-server/src/compute/vm.rs
@@ -280,11 +280,15 @@ fn prepare_vm_state_dir(state_dir: &Path, expected_uid: u32) -> Result<()> {
     })?;
     let metadata = checked_directory_metadata(state_dir, expected_uid, "vm driver state dir")?;
     let mode = metadata.permissions().mode() & 0o777;
-    if mode & 0o022 != 0 {
-        return Err(Error::execution(format!(
-            "vm driver state dir '{}' must not be group/world-writable (mode {mode:03o})",
-            state_dir.display()
-        )));
+    if mode != 0o700 {
+        std::fs::set_permissions(state_dir, std::fs::Permissions::from_mode(0o700)).map_err(
+            |err| {
+                Error::execution(format!(
+                    "failed to restrict vm driver state dir '{}': {err}",
+                    state_dir.display()
+                ))
+            },
+        )?;
     }
     Ok(())
 }
@@ -720,7 +724,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_compute_driver_socket_path_rejects_writable_state_dir() {
+    fn prepare_compute_driver_socket_path_restricts_existing_state_dir() {
         let dir = tempdir().unwrap();
         let vm_config = VmComputeConfig {
             state_dir: dir.path().join("state"),
@@ -731,10 +735,14 @@ mod tests {
             .unwrap();
         let socket_path = compute_driver_socket_path(&vm_config);
 
-        let err = prepare_compute_driver_socket_path(&vm_config, &socket_path)
-            .expect_err("world-writable state dir should be rejected")
-            .to_string();
-        assert!(err.contains("must not be group/world-writable"));
+        prepare_compute_driver_socket_path(&vm_config, &socket_path).unwrap();
+
+        let mode = std::fs::metadata(vm_config.state_dir)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700);
     }
 
     #[test]

--- a/crates/openshell-server/src/compute/vm.rs
+++ b/crates/openshell-server/src/compute/vm.rs
@@ -76,6 +76,9 @@ pub struct VmComputeConfig {
     /// Gateway gRPC endpoint the sandbox guest connects back to.
     pub grpc_endpoint: String,
 
+    /// Bootstrap image used to boot and prepare VM sandbox target images.
+    pub bootstrap_image: String,
+
     /// libkrun log level used by the VM driver helper.
     pub krun_log_level: u32,
 
@@ -149,6 +152,7 @@ impl Default for VmComputeConfig {
             driver_dir: None,
             default_image: default_sandbox_image(),
             grpc_endpoint: String::new(),
+            bootstrap_image: String::new(),
             krun_log_level: Self::default_krun_log_level(),
             vcpus: Self::default_vcpus(),
             mem_mib: Self::default_mem_mib(),
@@ -461,6 +465,11 @@ pub async fn spawn(
     command.arg("--state-dir").arg(&vm_config.state_dir);
     if !vm_config.default_image.trim().is_empty() {
         command.arg("--default-image").arg(&vm_config.default_image);
+    }
+    if !vm_config.bootstrap_image.trim().is_empty() {
+        command
+            .arg("--bootstrap-image")
+            .arg(&vm_config.bootstrap_image);
     }
     command
         .arg("--krun-log-level")

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -414,6 +414,7 @@ pub(super) async fn handle_watch_sandbox(
     let log_since_ms = req.log_since_ms;
     let log_sources = req.log_sources;
     let log_min_level = req.log_min_level;
+    let event_tail = req.event_tail;
 
     let (tx, rx) = mpsc::channel::<Result<SandboxStreamEvent, Status>>(256);
     let state = state.clone();
@@ -518,7 +519,7 @@ pub(super) async fn handle_watch_sandbox(
             for evt in state
                 .tracing_log_bus
                 .platform_event_bus
-                .tail(&sandbox_id, 50)
+                .tail(&sandbox_id, event_tail as usize)
             {
                 if tx.send(Ok(evt)).await.is_err() {
                     return;

--- a/docs/reference/policy-schema.mdx
+++ b/docs/reference/policy-schema.mdx
@@ -152,7 +152,7 @@ Each endpoint defines a reachable destination and optional inspection rules.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `host` | string | Yes | Hostname or IP address. Supports DNS-label wildcards such as `*.example.com` and scoped label globs such as `*-aiplatform.googleapis.com`. Bare wildcards and TLD wildcards such as `*.com` are rejected. |
+| `host` | string | Yes | Hostname or IP address. Supports wildcards: `*.example.com` matches any subdomain. |
 | `port` | integer | Yes | TCP port number. |
 | `path` | string | No | Optional HTTP path glob used to select between L7 endpoints that share the same host and port. Empty means all paths. Use this when REST and GraphQL live under the same host, such as `/repos/**` and `/graphql`. |
 | `protocol` | string | No | Set to `rest` for HTTP method/path inspection, `websocket` for RFC 6455 upgrade and client text-message inspection, or `graphql` for GraphQL-over-HTTP operation inspection. WebSocket endpoints can also use GraphQL operation rules for GraphQL-over-WebSocket traffic. Omit for TCP passthrough. |

--- a/docs/reference/policy-schema.mdx
+++ b/docs/reference/policy-schema.mdx
@@ -152,7 +152,7 @@ Each endpoint defines a reachable destination and optional inspection rules.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `host` | string | Yes | Hostname or IP address. Supports wildcards: `*.example.com` matches any subdomain. |
+| `host` | string | Yes | Hostname or IP address. Supports DNS-label wildcards such as `*.example.com` and scoped label globs such as `*-aiplatform.googleapis.com`. Bare wildcards and TLD wildcards such as `*.com` are rejected. |
 | `port` | integer | Yes | TCP port number. |
 | `path` | string | No | Optional HTTP path glob used to select between L7 endpoints that share the same host and port. Empty means all paths. Use this when REST and GraphQL live under the same host, such as `/repos/**` and `/graphql`. |
 | `protocol` | string | No | Set to `rest` for HTTP method/path inspection, `websocket` for RFC 6455 upgrade and client text-message inspection, or `graphql` for GraphQL-over-HTTP operation inspection. WebSocket endpoints can also use GraphQL operation rules for GraphQL-over-WebSocket traffic. Omit for TCP passthrough. |

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -65,9 +65,9 @@ MicroVM-backed sandboxes run inside VM-backed isolation instead of a container b
 
 The gateway uses the VM compute driver to create VM-backed sandboxes. MicroVM requires host virtualization support. It uses [libkrun](https://github.com/containers/libkrun) with Apple's [Hypervisor framework](https://developer.apple.com/documentation/hypervisor) on macOS, KVM on Linux, and [QEMU](https://www.qemu.org/) for GPU-backed sandboxes on Linux.
 
-The VM driver prepares an immutable ext4 root disk image from the selected sandbox image and caches it by image identity. Each sandbox boots that cached base disk read-only and receives its own writable `overlay.ext4` disk for `/`, including `/sandbox` writes and runtime TLS material. The overlay persists for the sandbox lifetime and is deleted with the sandbox state directory.
+The VM driver boots a cached immutable bootstrap ext4 root disk. When the requested sandbox image differs from the bootstrap image, the driver stages the registry image as an OCI layout, unpacks it inside a bootstrap VM with `umoci`, and caches the prepared image disk by image identity. Each sandbox receives that prepared disk read-only plus its own writable `overlay.ext4` disk for `/`, including `/sandbox` writes and runtime TLS material. The overlay persists for the sandbox lifetime and is deleted with the sandbox state directory.
 
-VM sandbox creation follows the same progress model as Kubernetes-backed sandboxes. The gateway accepts the sandbox, then the VM driver publishes watch events while it resolves the image, prepares or reuses the root disk cache, creates the writable overlay, and starts the VM launcher.
+VM sandbox creation follows the same progress model as Kubernetes-backed sandboxes. The gateway accepts the sandbox, then the VM driver publishes watch events while it resolves the image, prepares or reuses the bootstrap and prepared image caches, creates the writable overlay, and starts the VM launcher.
 
 For maintainer-level implementation details, refer to the [VM driver README](https://github.com/NVIDIA/OpenShell/blob/main/crates/openshell-driver-vm/README.md).
 
@@ -83,7 +83,7 @@ openshell-gateway --drivers vm
 
 For a service, set `OPENSHELL_DRIVERS=vm` in the service environment file and restart the service. Homebrew creates `$(brew --prefix)/var/openshell/gateway.env` with a commented `OPENSHELL_DRIVERS=vm` entry. Debian and RPM user services read `~/.config/openshell/gateway.env`.
 
-Select VM with `--drivers vm` or `OPENSHELL_DRIVERS=vm`. Configure VM driver values such as `grpc_endpoint`, `driver_dir`, `state_dir`, `vcpus`, `mem_mib`, `overlay_disk_mib`, `krun_log_level`, and `guest_tls_*` in `[openshell.drivers.vm]`. The VM `state_dir` stores overlay disks, console logs, runtime state, image-rootfs cache, and the private `run/compute-driver.sock` socket.
+Select VM with `--drivers vm` or `OPENSHELL_DRIVERS=vm`. Configure VM driver values such as `grpc_endpoint`, `driver_dir`, `state_dir`, `default_image`, `bootstrap_image`, `vcpus`, `mem_mib`, `overlay_disk_mib`, `krun_log_level`, and `guest_tls_*` in `[openshell.drivers.vm]`. The VM `state_dir` stores overlay disks, console logs, runtime state, image-rootfs cache, and the private `run/compute-driver.sock` socket.
 
 The gateway starts `openshell-driver-vm` over a private Unix socket and passes its process ID so the driver can reject unexpected local clients. The driver's standalone TCP listener is disabled unless `--allow-unauthenticated-tcp` is set for local development.
 

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -65,6 +65,8 @@ MicroVM-backed sandboxes run inside VM-backed isolation instead of a container b
 
 The gateway uses the VM compute driver to create VM-backed sandboxes. MicroVM requires host virtualization support. It uses [libkrun](https://github.com/containers/libkrun) with Apple's [Hypervisor framework](https://developer.apple.com/documentation/hypervisor) on macOS, KVM on Linux, and [QEMU](https://www.qemu.org/) for GPU-backed sandboxes on Linux.
 
+The VM driver prepares an ext4 root disk image from the selected sandbox image and boots each sandbox from its own copy. Host state owns the disk image file; guest UID/GID ownership, including `/sandbox`, lives inside the ext4 filesystem metadata.
+
 For maintainer-level implementation details, refer to the [VM driver README](https://github.com/NVIDIA/OpenShell/blob/main/crates/openshell-driver-vm/README.md).
 
 ### Enable the VM Driver

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -67,6 +67,8 @@ The gateway uses the VM compute driver to create VM-backed sandboxes. MicroVM re
 
 The VM driver prepares an immutable ext4 root disk image from the selected sandbox image and caches it by image identity. Each sandbox boots that cached base disk read-only and receives its own writable `overlay.ext4` disk for `/`, including `/sandbox` writes and runtime TLS material. The overlay persists for the sandbox lifetime and is deleted with the sandbox state directory.
 
+VM sandbox creation follows the same progress model as Kubernetes-backed sandboxes. The gateway accepts the sandbox, then the VM driver publishes watch events while it resolves the image, prepares or reuses the root disk cache, creates the writable overlay, and starts the VM launcher.
+
 For maintainer-level implementation details, refer to the [VM driver README](https://github.com/NVIDIA/OpenShell/blob/main/crates/openshell-driver-vm/README.md).
 
 ### Enable the VM Driver

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -65,7 +65,7 @@ MicroVM-backed sandboxes run inside VM-backed isolation instead of a container b
 
 The gateway uses the VM compute driver to create VM-backed sandboxes. MicroVM requires host virtualization support. It uses [libkrun](https://github.com/containers/libkrun) with Apple's [Hypervisor framework](https://developer.apple.com/documentation/hypervisor) on macOS, KVM on Linux, and [QEMU](https://www.qemu.org/) for GPU-backed sandboxes on Linux.
 
-The VM driver prepares an ext4 root disk image from the selected sandbox image and boots each sandbox from its own copy. Host state owns the disk image file; guest UID/GID ownership, including `/sandbox`, lives inside the ext4 filesystem metadata.
+The VM driver prepares an immutable ext4 root disk image from the selected sandbox image and caches it by image identity. Each sandbox boots that cached base disk read-only and receives its own writable `overlay.ext4` disk for `/`, including `/sandbox` writes and runtime TLS material. The overlay persists for the sandbox lifetime and is deleted with the sandbox state directory.
 
 For maintainer-level implementation details, refer to the [VM driver README](https://github.com/NVIDIA/OpenShell/blob/main/crates/openshell-driver-vm/README.md).
 
@@ -81,7 +81,7 @@ openshell-gateway --drivers vm
 
 For a service, set `OPENSHELL_DRIVERS=vm` in the service environment file and restart the service. Homebrew creates `$(brew --prefix)/var/openshell/gateway.env` with a commented `OPENSHELL_DRIVERS=vm` entry. Debian and RPM user services read `~/.config/openshell/gateway.env`.
 
-Select VM with `--drivers vm` or `OPENSHELL_DRIVERS=vm`. Configure VM driver values such as `grpc_endpoint`, `driver_dir`, `state_dir`, `vcpus`, `mem_mib`, `krun_log_level`, and `guest_tls_*` in `[openshell.drivers.vm]`.
+Select VM with `--drivers vm` or `OPENSHELL_DRIVERS=vm`. Configure VM driver values such as `grpc_endpoint`, `driver_dir`, `state_dir`, `vcpus`, `mem_mib`, `overlay_disk_mib`, `krun_log_level`, and `guest_tls_*` in `[openshell.drivers.vm]`. The VM `state_dir` stores overlay disks, console logs, runtime state, image-rootfs cache, and the private `run/compute-driver.sock` socket.
 
 The gateway starts `openshell-driver-vm` over a private Unix socket and passes its process ID so the driver can reject unexpected local clients. The driver's standalone TCP listener is disabled unless `--allow-unauthenticated-tcp` is set for local development.
 

--- a/e2e/rust/e2e-vm.sh
+++ b/e2e/rust/e2e-vm.sh
@@ -104,7 +104,7 @@ s.close()')"
 
 # Per-run state dir so concurrent e2e runs don't collide on the UDS or
 # sandbox state. The VM driver creates `<state_dir>/compute-driver.sock`
-# and `<state_dir>/sandboxes/<id>/rootfs.ext4` under here. Keep the
+# and `<state_dir>/sandboxes/<id>/overlay.ext4` under here. Keep the
 # basename short — see the SUN_LEN comment above.
 RUN_STATE_DIR="${STATE_DIR_ROOT}/os-vm-e2e-${HOST_PORT}-$$"
 mkdir -p "${RUN_STATE_DIR}"
@@ -215,11 +215,12 @@ echo "==> Gateway ready after ${elapsed}s"
 # metadata lookup needed when TLS is disabled.
 
 export OPENSHELL_GATEWAY_ENDPOINT="http://127.0.0.1:${HOST_PORT}"
+export OPENSHELL_E2E_EXPECT_VM_OVERLAY=1
 
-# The VM driver creates each sandbox VM from a copied ext4 root disk, and the
-# guest's sandbox supervisor then initializes policy, netns, Landlock, and sshd.
-# On a cold host this is ~15s after image preparation; allow 180s for slower CI
-# runners.
+# The VM driver creates each sandbox VM from a cached read-only ext4 root disk
+# plus a writable overlay disk. The guest's sandbox supervisor then initializes
+# policy, netns, Landlock, and sshd. On a cold host this is ~15s after image
+# preparation; allow 180s for slower CI runners.
 export OPENSHELL_PROVISION_TIMEOUT="${SANDBOX_PROVISION_TIMEOUT}"
 
 echo "==> Running e2e smoke test (endpoint: ${OPENSHELL_GATEWAY_ENDPOINT})"

--- a/e2e/rust/e2e-vm.sh
+++ b/e2e/rust/e2e-vm.sh
@@ -56,9 +56,9 @@ DRIVER_BIN="${ROOT}/target/debug/openshell-driver-vm"
 STATE_DIR_ROOT="/tmp"
 
 # Smoke test timeouts. First boot extracts the embedded libkrun runtime
-# (~60-90MB of zstd per architecture) and prepares a sandbox rootfs from the
-# configured image. The guest then starts the sandbox supervisor directly; a
-# cold microVM is typically ready within ~15s after image preparation.
+# (~60-90MB of zstd per architecture) and prepares an ext4 root disk from the
+# configured image. The guest then starts the sandbox supervisor directly; a cold
+# microVM is typically ready within ~15s after image preparation.
 GATEWAY_READY_TIMEOUT=60
 SANDBOX_PROVISION_TIMEOUT=180
 
@@ -104,7 +104,7 @@ s.close()')"
 
 # Per-run state dir so concurrent e2e runs don't collide on the UDS or
 # sandbox state. The VM driver creates `<state_dir>/compute-driver.sock`
-# and `<state_dir>/sandboxes/<id>/rootfs/` under here. Keep the
+# and `<state_dir>/sandboxes/<id>/rootfs.ext4` under here. Keep the
 # basename short — see the SUN_LEN comment above.
 RUN_STATE_DIR="${STATE_DIR_ROOT}/os-vm-e2e-${HOST_PORT}-$$"
 mkdir -p "${RUN_STATE_DIR}"
@@ -147,7 +147,7 @@ cleanup() {
 
   rm -f "${GATEWAY_LOG}" 2>/dev/null || true
   # Only wipe the per-run state dir on success. On failure, leave it for
-  # post-mortem (serial console logs, gvproxy logs, rootfs dumps).
+  # post-mortem (serial console logs, gvproxy logs, root disk images).
   if [ "${exit_code}" -eq 0 ]; then
     rm -rf "${RUN_STATE_DIR}" 2>/dev/null || true
   else
@@ -216,10 +216,10 @@ echo "==> Gateway ready after ${elapsed}s"
 
 export OPENSHELL_GATEWAY_ENDPOINT="http://127.0.0.1:${HOST_PORT}"
 
-# The VM driver creates each sandbox VM from scratch — the embedded
-# rootfs is extracted per sandbox, and the guest's sandbox supervisor
-# then initializes policy, netns, Landlock, and sshd. On a cold host
-# this is ~15s; allow 180s for slower CI runners.
+# The VM driver creates each sandbox VM from a copied ext4 root disk, and the
+# guest's sandbox supervisor then initializes policy, netns, Landlock, and sshd.
+# On a cold host this is ~15s after image preparation; allow 180s for slower CI
+# runners.
 export OPENSHELL_PROVISION_TIMEOUT="${SANDBOX_PROVISION_TIMEOUT}"
 
 echo "==> Running e2e smoke test (endpoint: ${OPENSHELL_GATEWAY_ENDPOINT})"

--- a/e2e/rust/tests/smoke.rs
+++ b/e2e/rust/tests/smoke.rs
@@ -68,6 +68,10 @@ async fn gateway_smoke() {
         sb.create_output,
     );
 
+    if std::env::var_os("OPENSHELL_E2E_EXPECT_VM_OVERLAY").is_some() {
+        assert_vm_overlay_root(&sb.name).await;
+    }
+
     // ── 3. Verify the sandbox appeared in the list ───────────────────
     let mut list_cmd = openshell_cmd();
     list_cmd
@@ -94,4 +98,42 @@ async fn gateway_smoke() {
 
     // ── 4. Cleanup ───────────────────────────────────────────────────
     sb.cleanup().await;
+}
+
+async fn assert_vm_overlay_root(sandbox_name: &str) {
+    let script = concat!(
+        "set -eu; ",
+        "test \"$(stat -f -c %T /)\" = \"overlayfs\"; ",
+        "printf \"overlay-write\\n\" > /sandbox/overlay-check; ",
+        "test \"$(cat /sandbox/overlay-check)\" = \"overlay-write\"; ",
+        "if [ -e /opt/openshell/tls/tls.key ]; then ",
+        "test \"$(stat -c %a /opt/openshell/tls/tls.key)\" = \"600\"; ",
+        "fi; ",
+        "echo vm-overlay-ok",
+    );
+
+    let mut exec_cmd = openshell_cmd();
+    exec_cmd
+        .args(["sandbox", "exec", "--name", sandbox_name, "--no-tty", "--"])
+        .arg("sh")
+        .arg("-lc")
+        .arg(script)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let output = exec_cmd
+        .output()
+        .await
+        .expect("failed to run VM overlay assertion");
+    let combined = strip_ansi(&format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    ));
+
+    assert!(
+        output.status.success() && combined.contains("vm-overlay-ok"),
+        "VM overlay assertion failed (status {:?}):\n{combined}",
+        output.status.code(),
+    );
 }

--- a/tasks/scripts/gateway-vm.sh
+++ b/tasks/scripts/gateway-vm.sh
@@ -307,6 +307,7 @@ fi
 
 mkdir -p "${STATE_DIR}"
 mkdir -p "${VM_DRIVER_STATE_DIR}"
+chmod 700 "${VM_DRIVER_STATE_DIR}"
 CONFIG_PATH="${STATE_DIR}/gateway.toml"
 cat >"${CONFIG_PATH}" <<EOF
 [openshell]

--- a/tasks/scripts/gateway-vm.sh
+++ b/tasks/scripts/gateway-vm.sh
@@ -38,6 +38,7 @@ GATEWAY_NAME="${OPENSHELL_VM_GATEWAY_NAME:-vm-dev}"
 STATE_DIR="${OPENSHELL_VM_GATEWAY_STATE_DIR:-${ROOT}/.cache/gateway-vm}"
 SANDBOX_NAMESPACE="${OPENSHELL_SANDBOX_NAMESPACE:-vm-dev}"
 SANDBOX_IMAGE="${OPENSHELL_SANDBOX_IMAGE:-${COMMUNITY_SANDBOX_IMAGE:-ghcr.io/nvidia/openshell-community/sandboxes/base:latest}}"
+VM_BOOTSTRAP_IMAGE="${OPENSHELL_VM_BOOTSTRAP_IMAGE:-}"
 SANDBOX_IMAGE_PULL_POLICY="${OPENSHELL_SANDBOX_IMAGE_PULL_POLICY:-IfNotPresent}"
 LOG_LEVEL="${OPENSHELL_LOG_LEVEL:-info}"
 GATEWAY_BIN="${ROOT}/target/debug/openshell-gateway"
@@ -272,7 +273,8 @@ DISABLE_TLS="$(normalize_bool "${OPENSHELL_DISABLE_TLS:-true}")"
 # Build prerequisites: VM runtime artifacts + bundled supervisor.
 if [ ! -d "${COMPRESSED_DIR}" ] \
     || ! find "${COMPRESSED_DIR}" -maxdepth 1 -name 'libkrun*.zst' | grep -q . \
-    || [ ! -f "${COMPRESSED_DIR}/gvproxy.zst" ]; then
+    || [ ! -f "${COMPRESSED_DIR}/gvproxy.zst" ] \
+    || [ ! -f "${COMPRESSED_DIR}/umoci.zst" ]; then
   echo "==> Preparing embedded VM runtime (mise run vm:setup)"
   mise run vm:setup
 fi
@@ -316,6 +318,7 @@ disable_tls = ${DISABLE_TLS}
 
 [openshell.drivers.vm]
 default_image = "${SANDBOX_IMAGE}"
+bootstrap_image = "${VM_BOOTSTRAP_IMAGE}"
 grpc_endpoint = "${GRPC_ENDPOINT}"
 driver_dir = "${DRIVER_DIR}"
 state_dir = "${VM_DRIVER_STATE_DIR}"

--- a/tasks/scripts/vm/_lib.sh
+++ b/tasks/scripts/vm/_lib.sh
@@ -30,6 +30,50 @@ detect_platform() {
     esac
 }
 
+# ── Runtime dependency downloads ────────────────────────────────────────
+
+# Download a Linux guest umoci binary for the requested architecture.
+# Usage: download_umoci_binary <output> <version> <guest_arch>
+download_umoci_binary() {
+    local output="$1"
+    local version="$2"
+    local guest_arch="$3"
+    local suffix
+
+    case "$guest_arch" in
+        arm64|aarch64) suffix="arm64" ;;
+        amd64|x86_64)  suffix="amd64" ;;
+        *)
+            echo "Error: Unsupported guest architecture for umoci: ${guest_arch}" >&2
+            return 1
+            ;;
+    esac
+
+    local base_url="https://github.com/opencontainers/umoci/releases/download/${version}"
+    local candidates=("umoci.linux.${suffix}" "umoci.${suffix}")
+    local error_log last_error asset
+    error_log="$(mktemp)"
+    last_error=""
+
+    echo "    Downloading umoci ${version} for linux/${suffix}..."
+    for asset in "${candidates[@]}"; do
+        if curl -fsSL -o "$output" "${base_url}/${asset}" 2>"$error_log"; then
+            chmod +x "$output"
+            rm -f "$error_log"
+            return 0
+        fi
+        last_error="$(cat "$error_log")"
+        rm -f "$output"
+    done
+
+    rm -f "$error_log"
+    echo "Error: failed to download umoci ${version} for linux/${suffix}" >&2
+    if [ -n "$last_error" ]; then
+        echo "$last_error" >&2
+    fi
+    return 1
+}
+
 # ── Compression helpers ─────────────────────────────────────────────────
 
 # Compress a single file with zstd level 19, reporting sizes.

--- a/tasks/scripts/vm/compress-vm-runtime.sh
+++ b/tasks/scripts/vm/compress-vm-runtime.sh
@@ -61,21 +61,7 @@ mkdir -p "$OUTPUT_DIR"
 download_umoci_for_guest() {
     local output="$1"
     local guest_arch="$2"
-    local suffix
-
-    case "$guest_arch" in
-        arm64|aarch64) suffix="arm64" ;;
-        amd64|x86_64)  suffix="amd64" ;;
-        *)
-            echo "Error: Unsupported guest architecture for umoci: ${guest_arch}" >&2
-            exit 1
-            ;;
-    esac
-
-    echo "    Downloading umoci ${UMOCI_VERSION} for ${suffix}..."
-    curl -fsSL -o "$output" \
-        "https://github.com/opencontainers/umoci/releases/download/${UMOCI_VERSION}/umoci.${suffix}"
-    chmod +x "$output"
+    download_umoci_binary "$output" "${UMOCI_VERSION}" "$guest_arch"
 }
 
 # ── Fast path: compressed artifacts already present (e.g. from vm:setup) ──

--- a/tasks/scripts/vm/compress-vm-runtime.sh
+++ b/tasks/scripts/vm/compress-vm-runtime.sh
@@ -4,9 +4,9 @@
 
 # Gather VM runtime artifacts from local sources and compress for embedding.
 #
-# This script collects libkrun, libkrunfw, and gvproxy from local sources
-# (Homebrew on macOS, built from source on Linux) and compresses them with
-# zstd for embedding into the openshell-driver-vm binary.
+# This script collects libkrun, libkrunfw, gvproxy, and the guest OCI unpacker
+# from local sources or pinned releases and compresses them with zstd for
+# embedding into the openshell-driver-vm binary.
 #
 # Usage:
 #   ./compress-vm-runtime.sh
@@ -26,9 +26,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/_lib.sh"
 ROOT="$(vm_lib_root)"
 
-# Source pins for gvproxy version.
+# Source pins for runtime tool versions.
 source "${ROOT}/crates/openshell-driver-vm/runtime/pins.env" 2>/dev/null || true
 GVPROXY_VERSION="${GVPROXY_VERSION:-v0.8.8}"
+UMOCI_VERSION="${UMOCI_VERSION:-v0.6.0}"
 
 # ── macOS dylib portability helpers ─────────────────────────────────────
 
@@ -57,6 +58,26 @@ OUTPUT_DIR="${OPENSHELL_VM_RUNTIME_COMPRESSED_DIR:-${ROOT}/target/vm-runtime-com
 
 mkdir -p "$OUTPUT_DIR"
 
+download_umoci_for_guest() {
+    local output="$1"
+    local guest_arch="$2"
+    local suffix
+
+    case "$guest_arch" in
+        arm64|aarch64) suffix="arm64" ;;
+        amd64|x86_64)  suffix="amd64" ;;
+        *)
+            echo "Error: Unsupported guest architecture for umoci: ${guest_arch}" >&2
+            exit 1
+            ;;
+    esac
+
+    echo "    Downloading umoci ${UMOCI_VERSION} for ${suffix}..."
+    curl -fsSL -o "$output" \
+        "https://github.com/opencontainers/umoci/releases/download/${UMOCI_VERSION}/umoci.${suffix}"
+    chmod +x "$output"
+}
+
 # ── Fast path: compressed artifacts already present (e.g. from vm:setup) ──
 
 _check_compressed_artifacts() {
@@ -65,12 +86,12 @@ _check_compressed_artifacts() {
     platform="$(uname -s)-$(uname -m)"
     case "$platform" in
         Darwin-arm64)
-            for f in libkrun.dylib.zst libkrunfw.5.dylib.zst gvproxy.zst; do
+            for f in libkrun.dylib.zst libkrunfw.5.dylib.zst gvproxy.zst umoci.zst; do
                 [ -f "${dir}/${f}" ] || return 1
             done
             ;;
         Linux-*)
-            for f in libkrun.so.zst libkrunfw.so.5.zst gvproxy.zst; do
+            for f in libkrun.so.zst libkrunfw.so.5.zst gvproxy.zst umoci.zst; do
                 [ -f "${dir}/${f}" ] || return 1
             done
             ;;
@@ -211,6 +232,7 @@ case "$(uname -s)-$(uname -m)" in
       echo "Error: gvproxy not found. Install Podman Desktop or run: brew install gvproxy" >&2
       exit 1
     fi
+    download_umoci_for_guest "$WORK_DIR/umoci" "arm64"
     ;;
     
   Linux-*)
@@ -256,6 +278,7 @@ case "$(uname -s)-$(uname -m)" in
         "https://github.com/containers/gvisor-tap-vsock/releases/download/${GVPROXY_VERSION}/gvproxy-linux-${GVPROXY_ARCH}"
       chmod +x "$WORK_DIR/gvproxy"
     fi
+    download_umoci_for_guest "$WORK_DIR/umoci" "$ARCH"
     ;;
     
   *)

--- a/tasks/scripts/vm/download-kernel-runtime.sh
+++ b/tasks/scripts/vm/download-kernel-runtime.sh
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Download pre-built VM kernel runtime artifacts from the vm-runtime GitHub Release
-# and stage them for the openshell-driver-vm cargo build.
+# Download pre-built VM kernel runtime artifacts from the vm-runtime GitHub
+# Release and stage them for the openshell-driver-vm cargo build.
 #
 # This script is used by driver release CI and can also be used locally
 # to avoid building libkrun/libkrunfw from source.
@@ -23,10 +23,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/_lib.sh"
 ROOT="$(vm_lib_root)"
+source "${ROOT}/crates/openshell-driver-vm/runtime/pins.env" 2>/dev/null || true
 
 RELEASE_TAG="${VM_RUNTIME_RELEASE_TAG:-vm-runtime}"
 REPO="${GITHUB_REPOSITORY:-NVIDIA/OpenShell}"
 OUTPUT_DIR="${OPENSHELL_VM_RUNTIME_COMPRESSED_DIR:-${ROOT}/target/vm-runtime-compressed}"
+UMOCI_VERSION="${UMOCI_VERSION:-v0.6.0}"
 
 # ── Auto-detect platform (detect_platform from _lib.sh) ─────────────────
 
@@ -108,6 +110,21 @@ rm -rf "$EXTRACT_DIR"
 mkdir -p "$EXTRACT_DIR"
 
 zstd -d "${DOWNLOAD_DIR}/${TARBALL_NAME}" --stdout | tar -xf - -C "$EXTRACT_DIR"
+
+if [ ! -f "${EXTRACT_DIR}/umoci" ]; then
+    case "$PLATFORM" in
+        linux-aarch64|darwin-aarch64) UMOCI_SUFFIX="arm64" ;;
+        linux-x86_64)                 UMOCI_SUFFIX="amd64" ;;
+        *)
+            echo "Error: Unsupported platform for umoci guest binary: ${PLATFORM}" >&2
+            exit 1
+            ;;
+    esac
+    echo "    Runtime tarball has no umoci; downloading ${UMOCI_VERSION} for ${UMOCI_SUFFIX}"
+    curl -fsSL -o "${EXTRACT_DIR}/umoci" \
+        "https://github.com/opencontainers/umoci/releases/download/${UMOCI_VERSION}/umoci.${UMOCI_SUFFIX}"
+    chmod +x "${EXTRACT_DIR}/umoci"
+fi
 
 echo "    Extracted files:"
 ls -lah "$EXTRACT_DIR"

--- a/tasks/scripts/vm/download-kernel-runtime.sh
+++ b/tasks/scripts/vm/download-kernel-runtime.sh
@@ -112,18 +112,17 @@ mkdir -p "$EXTRACT_DIR"
 zstd -d "${DOWNLOAD_DIR}/${TARBALL_NAME}" --stdout | tar -xf - -C "$EXTRACT_DIR"
 
 if [ ! -f "${EXTRACT_DIR}/umoci" ]; then
+    UMOCI_GUEST_ARCH=""
     case "$PLATFORM" in
-        linux-aarch64|darwin-aarch64) UMOCI_SUFFIX="arm64" ;;
-        linux-x86_64)                 UMOCI_SUFFIX="amd64" ;;
+        linux-aarch64|darwin-aarch64) UMOCI_GUEST_ARCH="arm64" ;;
+        linux-x86_64)                 UMOCI_GUEST_ARCH="amd64" ;;
         *)
             echo "Error: Unsupported platform for umoci guest binary: ${PLATFORM}" >&2
             exit 1
             ;;
     esac
-    echo "    Runtime tarball has no umoci; downloading ${UMOCI_VERSION} for ${UMOCI_SUFFIX}"
-    curl -fsSL -o "${EXTRACT_DIR}/umoci" \
-        "https://github.com/opencontainers/umoci/releases/download/${UMOCI_VERSION}/umoci.${UMOCI_SUFFIX}"
-    chmod +x "${EXTRACT_DIR}/umoci"
+    echo "    Runtime tarball has no umoci"
+    download_umoci_binary "${EXTRACT_DIR}/umoci" "${UMOCI_VERSION}" "${UMOCI_GUEST_ARCH}"
 fi
 
 echo "    Extracted files:"

--- a/tasks/scripts/vm/package-vm-runtime.sh
+++ b/tasks/scripts/vm/package-vm-runtime.sh
@@ -122,14 +122,13 @@ chmod +x "${PACKAGE_DIR}/gvproxy"
 # ── Download umoci for the Linux guest ───────────────────────────────────
 
 echo "==> Downloading umoci ${UMOCI_VERSION} for ${PLATFORM} guest..."
+UMOCI_GUEST_ARCH=""
 case "$PLATFORM" in
-    linux-aarch64|darwin-aarch64) UMOCI_SUFFIX="arm64" ;;
-    linux-x86_64)                 UMOCI_SUFFIX="amd64" ;;
+    linux-aarch64|darwin-aarch64) UMOCI_GUEST_ARCH="arm64" ;;
+    linux-x86_64)                 UMOCI_GUEST_ARCH="amd64" ;;
 esac
 
-curl -fsSL -o "${PACKAGE_DIR}/umoci" \
-    "https://github.com/opencontainers/umoci/releases/download/${UMOCI_VERSION}/umoci.${UMOCI_SUFFIX}"
-chmod +x "${PACKAGE_DIR}/umoci"
+download_umoci_binary "${PACKAGE_DIR}/umoci" "${UMOCI_VERSION}" "${UMOCI_GUEST_ARCH}"
 
 # ── Write provenance metadata ───────────────────────────────────────────
 

--- a/tasks/scripts/vm/package-vm-runtime.sh
+++ b/tasks/scripts/vm/package-vm-runtime.sh
@@ -4,9 +4,10 @@
 
 # Package VM runtime artifacts into a release tarball.
 #
-# Used by CI (release-vm-kernel.yml) to bundle libkrun, libkrunfw, and gvproxy
-# into a platform-specific tarball for the vm-runtime GitHub Release. Handles
-# gvproxy download, provenance metadata generation, and tarball creation.
+# Used by CI (release-vm-kernel.yml) to bundle libkrun, libkrunfw, gvproxy,
+# and the guest OCI unpacker into a platform-specific tarball for the
+# vm-runtime GitHub Release. Handles tool downloads, provenance metadata
+# generation, and tarball creation.
 #
 # Usage:
 #   ./package-vm-runtime.sh --platform <PLATFORM> --build-dir <DIR> --output <FILE>
@@ -28,9 +29,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/_lib.sh"
 ROOT="$(vm_lib_root)"
 
-# Source pins for gvproxy version.
+# Source pins for runtime tool versions.
 source "${ROOT}/crates/openshell-driver-vm/runtime/pins.env" 2>/dev/null || true
 GVPROXY_VERSION="${GVPROXY_VERSION:-v0.8.8}"
+UMOCI_VERSION="${UMOCI_VERSION:-v0.6.0}"
 
 PLATFORM=""
 BUILD_DIR=""
@@ -117,6 +119,18 @@ curl -fsSL -o "${PACKAGE_DIR}/gvproxy" \
     "https://github.com/containers/gvisor-tap-vsock/releases/download/${GVPROXY_VERSION}/gvproxy-${GVPROXY_SUFFIX}"
 chmod +x "${PACKAGE_DIR}/gvproxy"
 
+# ── Download umoci for the Linux guest ───────────────────────────────────
+
+echo "==> Downloading umoci ${UMOCI_VERSION} for ${PLATFORM} guest..."
+case "$PLATFORM" in
+    linux-aarch64|darwin-aarch64) UMOCI_SUFFIX="arm64" ;;
+    linux-x86_64)                 UMOCI_SUFFIX="amd64" ;;
+esac
+
+curl -fsSL -o "${PACKAGE_DIR}/umoci" \
+    "https://github.com/opencontainers/umoci/releases/download/${UMOCI_VERSION}/umoci.${UMOCI_SUFFIX}"
+chmod +x "${PACKAGE_DIR}/umoci"
+
 # ── Write provenance metadata ───────────────────────────────────────────
 
 echo "==> Writing provenance metadata..."
@@ -149,9 +163,11 @@ jq -n \
     --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg kfw_commit "$LIBKRUNFW_COMMIT" \
     --arg kver "$KERNEL_VERSION" \
+    --arg gvproxy "$GVPROXY_VERSION" \
+    --arg umoci "$UMOCI_VERSION" \
     --arg sha "${GITHUB_SHA:-unknown}" \
     --arg run "${GITHUB_RUN_ID:-unknown}" \
-    '{artifact: $artifact, platform: $platform, build_timestamp: $ts, libkrunfw_commit: $kfw_commit, kernel_version: $kver, github_sha: $sha, github_run_id: $run}' \
+    '{artifact: $artifact, platform: $platform, build_timestamp: $ts, libkrunfw_commit: $kfw_commit, kernel_version: $kver, gvproxy_version: $gvproxy, umoci_version: $umoci, github_sha: $sha, github_run_id: $run}' \
     > "${PACKAGE_DIR}/provenance.json"
 
 # ── Create tarball ──────────────────────────────────────────────────────

--- a/tasks/scripts/vm/vm-setup.sh
+++ b/tasks/scripts/vm/vm-setup.sh
@@ -4,8 +4,9 @@
 
 # One-time setup for the openshell-driver-vm runtime.
 #
-# Downloads pre-built runtime artifacts (libkrun, libkrunfw, gvproxy) from the
-# vm-runtime GitHub Release, or builds them from source when --from-source is set.
+# Downloads pre-built runtime artifacts (libkrun, libkrunfw, gvproxy, umoci)
+# from the vm-runtime GitHub Release, or builds them from source when
+# --from-source is set.
 # After obtaining the runtime, compresses the artifacts for embedding into the
 # openshell-driver-vm binary.
 #
@@ -34,7 +35,7 @@ while [[ $# -gt 0 ]]; do
         --help|-h)
             echo "Usage: $0 [--from-source]"
             echo ""
-            echo "Set up the openshell-driver-vm runtime (libkrun, libkrunfw, gvproxy)."
+            echo "Set up the openshell-driver-vm runtime (libkrun, libkrunfw, gvproxy, umoci)."
             echo ""
             echo "Options:"
             echo "  --from-source   Build runtime from source instead of downloading (~15-45min)"
@@ -100,7 +101,7 @@ OUTPUT_DIR="${OPENSHELL_VM_RUNTIME_COMPRESSED_DIR:-${ROOT}/target/vm-runtime-com
 missing=0
 case "$PLATFORM" in
     darwin-aarch64)
-        for f in libkrun.dylib.zst libkrunfw.5.dylib.zst gvproxy.zst; do
+        for f in libkrun.dylib.zst libkrunfw.5.dylib.zst gvproxy.zst umoci.zst; do
             if [ ! -f "${OUTPUT_DIR}/${f}" ]; then
                 echo "ERROR: Missing ${OUTPUT_DIR}/${f}" >&2
                 missing=1
@@ -108,7 +109,7 @@ case "$PLATFORM" in
         done
         ;;
     linux-aarch64|linux-x86_64)
-        for f in libkrun.so.zst libkrunfw.so.5.zst gvproxy.zst; do
+        for f in libkrun.so.zst libkrunfw.so.5.zst gvproxy.zst umoci.zst; do
             if [ ! -f "${OUTPUT_DIR}/${f}" ]; then
                 echo "ERROR: Missing ${OUTPUT_DIR}/${f}" >&2
                 missing=1


### PR DESCRIPTION

## Summary

Boot VM sandboxes from per-sandbox ext4 root disk images instead of exposing a prepared host rootfs directory to the guest.

## Related Issue

N/A

## Changes

- Cache prepared VM root filesystems as `rootfs.ext4` images keyed by source image identity and rootfs layout version.
- Copy the cached root disk per sandbox and launch libkrun/QEMU with that disk as the guest root filesystem.
- Move guest environment and TLS injection into the ext4 image, keep guest `/sandbox` ownership inside guest filesystem metadata, and update VM docs/e2e notes.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)
- [x] `mise run e2e:vm` passes

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
