### PR TITLE
ci(os-132): remove stale remote buildx mode

### DIFF
--- a/.github/actions/setup-buildx/action.yml
+++ b/.github/actions/setup-buildx/action.yml
@@ -1,23 +1,11 @@
 name: Setup Docker Buildx
 description: >
-  Create a Docker Buildx builder. Two modes:
-    * driver=remote (default) — multi-arch builder against in-cluster BuildKit
-      pods. Requires EKS connectivity. Behaviour unchanged from prior versions.
-    * driver=local — single-node buildx on the local docker-container driver.
-      Pair with cache-to/cache-from=type=gha on build steps for persistence.
-      Works on nv-gha-runners; no EKS needed.
+  Create a Docker Buildx builder on the local docker-container driver. Pair
+  with cache-to/cache-from=type=gha on build steps for persistence. Works on
+  nv-gha-runners; no EKS BuildKit service is required.
   Cleanup is automatic when the job finishes (docker/setup-buildx-action default).
 
 inputs:
-  driver:
-    description: "buildx driver: 'remote' or 'local'"
-    default: remote
-  amd64-endpoint:
-    description: BuildKit endpoint for linux/amd64 (remote driver only)
-    default: tcp://buildkit-amd64.buildkit:1234
-  arm64-endpoint:
-    description: BuildKit endpoint for linux/arm64 (remote driver only)
-    default: tcp://buildkit-arm64.buildkit:1234
   name:
     description: Builder instance name
     default: openshell
@@ -34,21 +22,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up Docker Buildx (remote)
-      if: inputs.driver == 'remote'
-      uses: docker/setup-buildx-action@v3
-      with:
-        name: ${{ inputs.name }}
-        driver: remote
-        endpoint: ${{ inputs.amd64-endpoint }}
-        platforms: linux/amd64
-        append: |
-          - endpoint: ${{ inputs.arm64-endpoint }}
-            platforms: linux/arm64
-        buildkitd-config: ${{ inputs.buildkitd-config }}
-
     - name: Set up Docker Buildx (local)
-      if: inputs.driver == 'local'
       uses: docker/setup-buildx-action@v3
       with:
         name: ${{ inputs.name }}

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: ./.github/actions/setup-buildx
         with:
-          driver: local
           buildkitd-config: ${{ steps.buildkit.outputs.config }}
 
       - name: Build and push CI image

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -204,7 +204,6 @@ jobs:
       - name: Set up buildx (local driver)
         uses: ./.github/actions/setup-buildx
         with:
-          driver: local
           buildkitd-config: /etc/buildkit/buildkitd.toml
 
       - name: Download Rust binary artifact

--- a/.github/workflows/driver-vm-macos.yml
+++ b/.github/workflows/driver-vm-macos.yml
@@ -151,8 +151,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: ./.github/actions/setup-buildx
-        with:
-          driver: local
 
       - name: Install zstd
         run: apt-get update && apt-get install -y --no-install-recommends zstd && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -179,8 +179,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: ./.github/actions/setup-buildx
-        with:
-          driver: local
 
       - name: Mark workspace safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -349,8 +347,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: ./.github/actions/setup-buildx
-        with:
-          driver: local
 
       - name: Build macOS binary via Docker
         run: |
@@ -498,8 +494,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: ./.github/actions/setup-buildx
-        with:
-          driver: local
 
       - name: Build macOS binary via Docker
         run: |

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -210,8 +210,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: ./.github/actions/setup-buildx
-        with:
-          driver: local
 
       - name: Mark workspace safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -382,8 +380,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: ./.github/actions/setup-buildx
-        with:
-          driver: local
 
       - name: Build macOS binary via Docker
         run: |
@@ -617,8 +613,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: ./.github/actions/setup-buildx
-        with:
-          driver: local
 
       - name: Build macOS binary via Docker
         run: |


### PR DESCRIPTION
## Summary

Remove the stale remote BuildKit mode from the shared setup-buildx action now that all tracked callers use local Buildx on supported runners.

## Related Issue

OS-132 / OS-49 Phase 8

## Changes

- Removes the unused remote BuildKit action inputs and step from `.github/actions/setup-buildx/action.yml`.
- Drops redundant `driver: local` inputs from all current setup-buildx callers.
- Leaves `buildkitd-config` support in place for local builder registry mirror config.

## Testing

- [x] `git diff --check`
- [x] YAML syntax parse for changed workflow/action files
- [ ] `mise run pre-commit` passes

`mise run pre-commit` was attempted. It failed on unrelated local workspace issues: markdownlint errors in untracked `.codex-learning/*.md`, plus existing local Rust test failure `ssh::tests::launch_editor_returns_friendly_error_when_binary_missing`. Rust check, clippy, Python tests, Helm lint, license check, formatting checks, and Mermaid lint completed successfully before the markdown task failure was reported.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)