### PR TITLE
fix(e2e): isolate kubernetes user namespace test

### DIFF
--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -57,11 +57,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          run_id=$(gh api "repos/$GH_REPO/actions/workflows/e2e-gate.yml/runs?event=pull_request&head_sha=$HEAD_SHA" \
-            --jq '.workflow_runs | sort_by(.created_at) | reverse | .[0].id // empty')
-          if [ -z "$run_id" ]; then
+          latest=$(gh api "repos/$GH_REPO/actions/workflows/e2e-gate.yml/runs?event=pull_request&head_sha=$HEAD_SHA" \
+            --jq '.workflow_runs | sort_by(.created_at) | reverse | .[0] // empty')
+          if [ -z "$latest" ]; then
             echo "No pull_request-triggered E2E Gate run found for $HEAD_SHA — nothing to re-run."
             exit 0
           fi
+
+          run_id=$(jq -r '.id' <<< "$latest")
+          status=$(jq -r '.status' <<< "$latest")
+          if [ "$status" != "completed" ]; then
+            echo "E2E Gate run $run_id is already $status for $HEAD_SHA — no new re-run needed."
+            exit 0
+          fi
+
           echo "Re-running E2E Gate run $run_id so it re-evaluates and posts a fresh check on the PR."
-          gh api --method POST "repos/$GH_REPO/actions/runs/$run_id/rerun"
+          if ! output=$(gh api --method POST "repos/$GH_REPO/actions/runs/$run_id/rerun" 2>&1); then
+            if grep -q "This workflow is already running" <<< "$output"; then
+              echo "E2E Gate run $run_id is already running for $HEAD_SHA — no new re-run needed."
+              exit 0
+            fi
+            echo "$output" >&2
+            exit 1
+          fi

--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -57,33 +57,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for attempt in {1..60}; do
-            latest=$(gh api "repos/$GH_REPO/actions/workflows/e2e-gate.yml/runs?event=pull_request&head_sha=$HEAD_SHA" \
-              --jq '.workflow_runs | sort_by(.created_at) | reverse | .[0] // empty')
-            if [ -z "$latest" ]; then
-              echo "No pull_request-triggered E2E Gate run found for $HEAD_SHA — nothing to re-run."
-              exit 0
-            fi
-
-            run_id=$(jq -r '.id' <<< "$latest")
-            status=$(jq -r '.status' <<< "$latest")
-            if [ "$status" = "completed" ]; then
-              break
-            fi
-            if [ "$attempt" -eq 60 ]; then
-              echo "E2E Gate run $run_id is still $status for $HEAD_SHA — leaving the active run to update the PR check."
-              exit 0
-            fi
-            echo "E2E Gate run $run_id is $status for $HEAD_SHA; waiting before requesting a rerun."
-            sleep 2
-          done
-
-          echo "Re-running E2E Gate run $run_id so it re-evaluates and posts a fresh check on the PR."
-          if ! output=$(gh api --method POST "repos/$GH_REPO/actions/runs/$run_id/rerun" 2>&1); then
-            if grep -q "This workflow is already running" <<< "$output"; then
-              echo "E2E Gate run $run_id is already running for $HEAD_SHA — no new re-run needed."
-              exit 0
-            fi
-            echo "$output" >&2
-            exit 1
+          run_id=$(gh api "repos/$GH_REPO/actions/workflows/e2e-gate.yml/runs?event=pull_request&head_sha=$HEAD_SHA" \
+            --jq '.workflow_runs | sort_by(.created_at) | reverse | .[0].id // empty')
+          if [ -z "$run_id" ]; then
+            echo "No pull_request-triggered E2E Gate run found for $HEAD_SHA — nothing to re-run."
+            exit 0
           fi
+          echo "Re-running E2E Gate run $run_id so it re-evaluates and posts a fresh check on the PR."
+          gh api --method POST "repos/$GH_REPO/actions/runs/$run_id/rerun"

--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -57,19 +57,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          latest=$(gh api "repos/$GH_REPO/actions/workflows/e2e-gate.yml/runs?event=pull_request&head_sha=$HEAD_SHA" \
-            --jq '.workflow_runs | sort_by(.created_at) | reverse | .[0] // empty')
-          if [ -z "$latest" ]; then
-            echo "No pull_request-triggered E2E Gate run found for $HEAD_SHA — nothing to re-run."
-            exit 0
-          fi
+          for attempt in {1..60}; do
+            latest=$(gh api "repos/$GH_REPO/actions/workflows/e2e-gate.yml/runs?event=pull_request&head_sha=$HEAD_SHA" \
+              --jq '.workflow_runs | sort_by(.created_at) | reverse | .[0] // empty')
+            if [ -z "$latest" ]; then
+              echo "No pull_request-triggered E2E Gate run found for $HEAD_SHA — nothing to re-run."
+              exit 0
+            fi
 
-          run_id=$(jq -r '.id' <<< "$latest")
-          status=$(jq -r '.status' <<< "$latest")
-          if [ "$status" != "completed" ]; then
-            echo "E2E Gate run $run_id is already $status for $HEAD_SHA — no new re-run needed."
-            exit 0
-          fi
+            run_id=$(jq -r '.id' <<< "$latest")
+            status=$(jq -r '.status' <<< "$latest")
+            if [ "$status" = "completed" ]; then
+              break
+            fi
+            if [ "$attempt" -eq 60 ]; then
+              echo "E2E Gate run $run_id is still $status for $HEAD_SHA — leaving the active run to update the PR check."
+              exit 0
+            fi
+            echo "E2E Gate run $run_id is $status for $HEAD_SHA; waiting before requesting a rerun."
+            sleep 2
+          done
 
           echo "Re-running E2E Gate run $run_id so it re-evaluates and posts a fresh check on the PR."
           if ! output=$(gh api --method POST "repos/$GH_REPO/actions/runs/$run_id/rerun" 2>&1); then

--- a/e2e/rust/Cargo.toml
+++ b/e2e/rust/Cargo.toml
@@ -19,6 +19,7 @@ publish = false
 e2e = []
 e2e-docker = ["e2e"]
 e2e-docker-gpu = ["e2e-docker"]
+e2e-kubernetes = ["e2e"]
 
 [[test]]
 name = "custom_image"
@@ -39,6 +40,11 @@ required-features = ["e2e-docker"]
 name = "gateway_resume"
 path = "tests/gateway_resume.rs"
 required-features = ["e2e-docker"]
+
+[[test]]
+name = "user_namespaces"
+path = "tests/user_namespaces.rs"
+required-features = ["e2e-kubernetes"]
 
 [dependencies]
 tokio = { version = "1.43", features = ["full"] }


### PR DESCRIPTION
## Summary

Keep the Kubernetes-only user namespace e2e test out of the Docker and Podman e2e jobs by declaring it as an explicit Cargo test target gated by `e2e-kubernetes`.

The earlier `.github/workflows/e2e-gate.yml` changes were reverted; the net PR diff now only changes `e2e/rust/Cargo.toml`.

## Related Issue

N/A

## Changes

- Add an `e2e-kubernetes` feature for Kubernetes-specific Rust e2e tests.
- Add an explicit `user_namespaces` Rust e2e test target requiring `e2e-kubernetes`.
- Restore `.github/workflows/e2e-gate.yml` to match `main`.

## Testing

- [x] `cargo test --manifest-path e2e/rust/Cargo.toml --features e2e -- --list user_namespaces`
- [x] `cargo test --manifest-path e2e/rust/Cargo.toml --features e2e-docker -- --list user_namespaces`
- [x] `cargo test --manifest-path e2e/rust/Cargo.toml --features e2e-kubernetes --test user_namespaces -- --list`
- [x] `mise run pre-commit` passes
- [ ] E2E workflow rerun passes on GitHub

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)