### PR TITLE
fix(installer): stop forcing Homebrew VM driver

### DIFF
--- a/install-dev.sh
+++ b/install-dev.sh
@@ -400,18 +400,6 @@ patch_homebrew_formula() {
     mv "$_patched_file" "$_formula_file"
   fi
 
-  if ! grep -q 'OPENSHELL_DRIVERS:' "$_formula_file"; then
-    info "patching Homebrew formula to use VM driver..."
-    awk '
-      {
-        print
-        if ($0 ~ /^[[:space:]]*environment_variables\(/) {
-          print "      OPENSHELL_DRIVERS: \"vm\","
-        }
-      }
-    ' "$_formula_file" >"$_patched_file"
-    mv "$_patched_file" "$_formula_file"
-  fi
 }
 
 start_user_gateway() {


### PR DESCRIPTION
## Summary

Remove the installer-side Homebrew formula patch that reintroduced `OPENSHELL_DRIVERS: "vm"` after the generated release formula stopped setting a default driver.

## Related Issue

None.

## Changes

- Removed the `patch_homebrew_formula` branch that injected `OPENSHELL_DRIVERS: "vm"` into downloaded Homebrew formulas.
- Kept the idempotent `entitlements.atomic_write` compatibility patch for older release formulas.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)