### PR TITLE
fix(install): register local gateway before probing listener

### DIFF
--- a/install-dev.sh
+++ b/install-dev.sh
@@ -416,9 +416,9 @@ start_user_gateway() {
   as_target_user systemctl --user restart openshell-gateway
   as_target_user systemctl --user is-active --quiet openshell-gateway
 
-  wait_for_local_gateway_listener
   info "registering local gateway as ${TARGET_USER}..."
   register_local_gateway
+  wait_for_local_gateway_listener
   wait_for_local_gateway_status
 }
 
@@ -661,9 +661,9 @@ install_macos_homebrew() {
     OPENSHELL_REGISTER_BIN="${_brew_prefix}/bin/openshell"
   fi
 
-  wait_for_local_gateway_listener
   info "registering local gateway as ${TARGET_USER}..."
   register_local_gateway
+  wait_for_local_gateway_listener
   wait_for_local_gateway_status
 }
 


### PR DESCRIPTION
## Summary

Move local gateway registration before the install script listener probe so fresh Homebrew and systemd installs import the package-managed mTLS bundle before the probe needs it.

## Related Issue

None.

## Changes

- Register the local gateway immediately after starting the package-managed service.
- Run the mTLS listener probe after registration so gateway add --local has created the CLI mTLS bundle.

## Testing

- [x] mise run pre-commit passes
- [ ] Unit tests added/updated (not applicable: installer ordering only)
- [ ] E2E tests added/updated (not applicable)
- [x] sh -n install-dev.sh passes

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable: installer script only)
