### PR TITLE
fix(helm): derive sandboxNamespace from Release.Namespace instead of hardcoding

### DIFF
--- a/deploy/helm/openshell/templates/_helpers.tpl
+++ b/deploy/helm/openshell/templates/_helpers.tpl
@@ -83,6 +83,15 @@ Namespaced Issuer (selfSigned) for cert-manager CA bootstrap.
 {{- end }}
 
 {{/*
+Namespace where sandbox pods are created. An explicit
+.Values.server.sandboxNamespace is used verbatim. Otherwise it defaults to
+.Release.Namespace so `helm install -n my-ns` works without extra overrides.
+*/}}
+{{- define "openshell.sandboxNamespace" -}}
+{{- .Values.server.sandboxNamespace | default .Release.Namespace -}}
+{{- end }}
+
+{{/*
 gRPC endpoint sandbox pods use to call back into the gateway. An explicit
 .Values.server.grpcEndpoint is used verbatim. Otherwise it is derived from
 the in-cluster Service DNS, release namespace, service port, and disableTls

--- a/deploy/helm/openshell/templates/networkpolicy.yaml
+++ b/deploy/helm/openshell/templates/networkpolicy.yaml
@@ -11,7 +11,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "openshell.fullname" . }}-sandbox-ssh
-  namespace: {{ .Values.server.sandboxNamespace }}
+  namespace: {{ include "openshell.sandboxNamespace" . }}
   labels:
     {{- include "openshell.labels" . | nindent 4 }}
 spec:

--- a/deploy/helm/openshell/templates/statefulset.yaml
+++ b/deploy/helm/openshell/templates/statefulset.yaml
@@ -63,7 +63,7 @@ spec:
             - {{ .Values.server.dbUrl | quote }}
           env:
             - name: OPENSHELL_SANDBOX_NAMESPACE
-              value: {{ .Values.server.sandboxNamespace | quote }}
+              value: {{ include "openshell.sandboxNamespace" . | quote }}
             - name: OPENSHELL_SANDBOX_IMAGE
               value: {{ .Values.server.sandboxImage | quote }}
             {{- if .Values.server.sandboxImagePullPolicy }}

--- a/deploy/helm/openshell/tests/sandbox_namespace_test.yaml
+++ b/deploy/helm/openshell/tests/sandbox_namespace_test.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: sandboxNamespace defaulting
+templates:
+  - templates/statefulset.yaml
+  - templates/networkpolicy.yaml
+release:
+  name: openshell
+  namespace: my-namespace
+
+tests:
+  - it: defaults OPENSHELL_SANDBOX_NAMESPACE to release namespace
+    template: templates/statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OPENSHELL_SANDBOX_NAMESPACE
+            value: "my-namespace"
+
+  - it: uses explicit sandboxNamespace when set
+    template: templates/statefulset.yaml
+    set:
+      server.sandboxNamespace: other-ns
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OPENSHELL_SANDBOX_NAMESPACE
+            value: "other-ns"
+
+  - it: defaults NetworkPolicy namespace to release namespace
+    template: templates/networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: my-namespace
+
+  - it: uses explicit sandboxNamespace for NetworkPolicy
+    template: templates/networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      server.sandboxNamespace: other-ns
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: other-ns

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -79,7 +79,9 @@ affinity: {}
 # Server configuration
 server:
   logLevel: info
-  sandboxNamespace: openshell
+  # Namespace where sandbox pods are created. Defaults to the Helm release
+  # namespace (.Release.Namespace) when left empty.
+  sandboxNamespace: ""
   dbUrl: "sqlite:/var/openshell/openshell.db"
   sandboxImage: "ghcr.io/nvidia/openshell-community/sandboxes/base:latest"
   # Kubernetes imagePullPolicy for sandbox pods.  Empty = Kubernetes default


### PR DESCRIPTION
## Summary

The Helm chart's `server.sandboxNamespace` was hardcoded to `openshell` in `values.yaml`, requiring manual override for any non-`openshell` namespace deployment. This PR defaults it to `""` and derives the namespace from `.Release.Namespace` via a helper, following the same pattern used for `grpcEndpoint` in #1241.

## Related Issue

Closes #1278

## Changes

- **`values.yaml`**: Changed `sandboxNamespace` default from `openshell` to `""` with a comment explaining the fallback behavior
- **`templates/_helpers.tpl`**: Added `openshell.sandboxNamespace` helper that uses the explicit value when set, otherwise falls back to `.Release.Namespace`
- **`templates/statefulset.yaml`**: Uses `include "openshell.sandboxNamespace"` instead of direct `.Values` reference for the `OPENSHELL_SANDBOX_NAMESPACE` env var
- **`templates/networkpolicy.yaml`**: Same change for the NetworkPolicy namespace field
- **`tests/sandbox_namespace_test.yaml`**: Added 4 helm-unittest cases covering default and explicit override for both templates

## Testing

- [x] `helm template` verified: `-n custom-namespace` correctly resolves to `custom-namespace` in both statefulset env var and networkpolicy namespace
- [x] `helm template` verified: `--set server.sandboxNamespace=other-ns` override still works
- [x] `helm unittest` passes all 4 test cases
- [ ] `mise run pre-commit` passes
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)