### PR TITLE
rfc-0002: policy management

### DIFF
--- a/rfc/0002-agent-driven-policy-management/README.md
+++ b/rfc/0002-agent-driven-policy-management/README.md
@@ -7,7 +7,7 @@ links:
   - https://github.com/NVIDIA/OpenShell/blob/main/architecture/policy-advisor.md
 ---
 
-# RFC 0001 - Agent-Driven Policy Management
+# RFC 0002 - Agent-Driven Policy Management
 
 <!--
 See rfc/README.md for the full RFC process and state definitions.


### PR DESCRIPTION
## Summary

Move the agent-driven policy management RFC into the directory-based RFC layout and renumber it to RFC 0002.

## Related Issue

Refs #1062

## Changes

- Renamed `rfc/0001-agent-driven-policy-management.md` to `rfc/0002-agent-driven-policy-management/README.md`
- Updated the document title from RFC 0001 to RFC 0002

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [ ] Commits are signed off (DCO)
