### PR TITLE
docs: document OPENSHELL_SSH_HANDSHAKE_SECRET in Getting Started

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,10 @@ cargo build -p openshell-prover --features bundled-z3
 # One-time trust
 mise trust
 
+# Podman and Kubernetes drivers require an SSH handshake secret.
+# Set any value for local development:
+export OPENSHELL_SSH_HANDSHAKE_SECRET=dev-secret
+
 # Run a standalone gateway for local development
 mise run gateway
 ```


### PR DESCRIPTION
## Summary

Add `OPENSHELL_SSH_HANDSHAKE_SECRET` to the Getting Started section in CONTRIBUTING.md. The Podman and Kubernetes compute drivers require this variable, but it was never documented in the dev setup instructions. Developers using Podman (the default when it's installed) hit an opaque configuration error on first run.

## Related Issue

Introduced by 2e0afeab ("feat(vm): derive guest rootfs from sandbox images (#957)"), which added the requirement but exempted only Docker and VM drivers.

## Changes

- Added an `export OPENSHELL_SSH_HANDSHAKE_SECRET=dev-secret` step to the Getting Started code block in CONTRIBUTING.md
- Included a comment explaining which drivers require the variable

## Testing

- [x] `mise run pre-commit` passes (pre-existing `python:proto` failure on main, unrelated)
- [ ] Unit tests added/updated (N/A — docs only)
- [ ] E2E tests added/updated (N/A — docs only)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)