### PR TITLE
fix(gateway): update Podman supervisor build task name

### DIFF
--- a/tasks/scripts/gateway.sh
+++ b/tasks/scripts/gateway.sh
@@ -177,7 +177,7 @@ ensure_podman_supervisor_image() {
 
   echo "Building Podman supervisor sideload image (${supervisor_image})..."
   require_mise
-  CONTAINER_ENGINE=podman IMAGE_TAG=dev mise run build:docker:supervisor-sideload
+  CONTAINER_ENGINE=podman IMAGE_TAG=dev mise run build:docker:supervisor
 
   if ! podman image exists "${supervisor_image}" >/dev/null 2>&1; then
     echo "ERROR: expected supervisor image '${supervisor_image}' after build" >&2


### PR DESCRIPTION
## Summary

Fix the Podman path in the dev gateway script which references the removed `build:docker:supervisor-sideload` mise task, causing `mise run gateway` to fail when Podman is the detected compute driver.

## Related Issue

Broken by d8b84773 ("feat(rpm): add RPM packaging with Packit/COPR and GHA release publishing (#1126)"), which consolidated the sideload and standalone supervisor image builds into a single `build:docker:supervisor` task but did not update the gateway script.

## Changes

- Updated `tasks/scripts/gateway.sh` to reference `build:docker:supervisor` instead of the removed `build:docker:supervisor-sideload`

## Testing

- [x] `mise run pre-commit` passes (pre-existing `python:proto` failure on main, unrelated)
- [x] Manually verified `mise run gateway` succeeds with Podman driver
- [ ] Unit tests added/updated (N/A — script fix)
- [ ] E2E tests added/updated (N/A — script fix)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)