### PR TITLE
docs(helm): document supervisor.sideloadMethod and sandboxNamespace default

### DIFF
--- a/docs/kubernetes/setup.mdx
+++ b/docs/kubernetes/setup.mdx
@@ -131,11 +131,12 @@ The most commonly changed values are:
 | Value | Purpose |
 |---|---|
 | `image.repository` / `image.tag` | Gateway container image. Defaults to `ghcr.io/nvidia/openshell/gateway:latest`. |
-| `server.sandboxNamespace` | Namespace where sandbox pods are created. |
+| `server.sandboxNamespace` | Namespace where sandbox pods are created. Defaults to the Helm release namespace when left empty. |
 | `server.sandboxImage` | Default sandbox image used when a sandbox does not specify one. |
 | `server.grpcEndpoint` | Endpoint that sandbox supervisors use to call back to the gateway. Must be reachable from inside the cluster. |
 | `server.sshGatewayHost` / `server.sshGatewayPort` | Public host and port returned to CLI clients for SSH proxy connections. Required when the gateway is exposed externally. |
 | `server.disableTls` | Run the gateway over plaintext HTTP. Use only behind a trusted transport. |
+| `supervisor.sideloadMethod` | How the supervisor binary is delivered into sandbox pods. Leave empty to auto-detect based on cluster version: clusters running Kubernetes 1.35 or later use `image-volume` (ImageVolume GA in 1.36); older clusters use `init-container`. Set explicitly to `image-volume` on Kubernetes 1.33 or 1.34 with the ImageVolume feature gate enabled, or to `init-container` to force the legacy path on any version. |
 
 Use a values file for repeatable deployments:
 

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -98,10 +98,11 @@ For maintainer-level implementation details, refer to the [Kubernetes driver REA
 | Gateway option | Environment variable | Helm value | Description |
 |---|---|---|---|
 | `--drivers kubernetes` | `OPENSHELL_DRIVERS=kubernetes` | Not applicable | Select the Kubernetes compute driver. |
-| `--sandbox-namespace <namespace>` | `OPENSHELL_SANDBOX_NAMESPACE` | `server.sandboxNamespace` | Set the namespace for sandbox resources. |
+| `--sandbox-namespace <namespace>` | `OPENSHELL_SANDBOX_NAMESPACE` | `server.sandboxNamespace` | Set the namespace for sandbox resources. The Helm chart defaults to the release namespace when left empty. |
 | `--sandbox-image <image>` | `OPENSHELL_SANDBOX_IMAGE` | `server.sandboxImage` | Set the default sandbox image. |
 | `--sandbox-image-pull-policy <policy>` | `OPENSHELL_SANDBOX_IMAGE_PULL_POLICY` | `server.sandboxImagePullPolicy` | Set the Kubernetes image pull policy for sandbox pods. |
 | `--grpc-endpoint <url>` | `OPENSHELL_GRPC_ENDPOINT` | `server.grpcEndpoint` | Set the gateway callback endpoint reachable from sandbox pods. |
 | `--client-tls-secret-name <name>` | `OPENSHELL_CLIENT_TLS_SECRET_NAME` | `server.tls.clientTlsSecretName` | Mount sandbox client TLS materials from a Kubernetes secret. |
+| Not applicable | Not applicable | `supervisor.sideloadMethod` | How the supervisor binary is delivered into sandbox pods. Leave empty to auto-detect from cluster version. Set to `image-volume` to mount the supervisor OCI image directly as a volume (requires Kubernetes 1.33+ with the ImageVolume feature gate; GA in 1.36), or `init-container` to copy via an init container on older clusters. |
 
 The Kubernetes driver creates namespaced `agents.x-k8s.io/v1alpha1` `Sandbox` resources from the Kubernetes SIG Apps [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) project. The Agent Sandbox controller turns those resources into sandbox pods and related storage.


### PR DESCRIPTION
## Summary

- Add `supervisor.sideloadMethod` to the Kubernetes setup chart values table and the compute drivers reference table. The value controls how the supervisor binary is delivered into sandbox pods: `image-volume` mounts the supervisor OCI image directly (Kubernetes 1.33+ with ImageVolume feature gate; GA in 1.36), `init-container` copies via an init container and works on all versions. Leaving it empty enables auto-detection based on cluster version.
- Update the `server.sandboxNamespace` description in both pages to reflect that the Helm chart now derives the namespace from the release namespace by default when the value is left empty.

## Related Issue

Follows the ImageVolumeSource sideload PR and the sandboxNamespace default PR.

## Changes

- `docs/kubernetes/setup.mdx`: add `supervisor.sideloadMethod` row to the Configure Chart Values table; update `server.sandboxNamespace` description
- `docs/reference/sandbox-compute-drivers.mdx`: add `supervisor.sideloadMethod` row to the Kubernetes driver table; update `server.sandboxNamespace` description

## Testing

- [x] `mise run pre-commit` passes

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)