### PR TITLE
fix(vm): use bash 3.2-safe empty array expansion in supervisor build

### DIFF
--- a/tasks/scripts/vm/build-supervisor-bundle.sh
+++ b/tasks/scripts/vm/build-supervisor-bundle.sh
@@ -134,11 +134,11 @@ run_supervisor_build() {
     fi
 
     if command -v cargo-zigbuild >/dev/null 2>&1; then
-        "${cargo_prefix[@]}" cargo zigbuild --release -p openshell-sandbox --target "${RUST_TARGET}" \
+        ${cargo_prefix[@]+"${cargo_prefix[@]}"} cargo zigbuild --release -p openshell-sandbox --target "${RUST_TARGET}" \
             --manifest-path "${ROOT}/Cargo.toml"
     else
         echo "    cargo-zigbuild not found, falling back to cargo build..."
-        "${cargo_prefix[@]}" cargo build --release -p openshell-sandbox --target "${RUST_TARGET}" \
+        ${cargo_prefix[@]+"${cargo_prefix[@]}"} cargo build --release -p openshell-sandbox --target "${RUST_TARGET}" \
             --manifest-path "${ROOT}/Cargo.toml"
     fi
 }


### PR DESCRIPTION
## Summary
Fix `mise run vm:supervisor` silently failing on macOS. Bash 3.2 (the macOS default) treats empty array expansion (`"${arr[@]}"`) as an unbound variable error under `set -u`. Unlike `set -e`, this error bypasses `if`-constructs and kills the shell immediately with no output. The fix uses the `${arr[@]+"${arr[@]}"}` idiom, which is safe on both bash 3.2 and 4+.

## Related Issue
https://github.com/NVIDIA/OpenShell/discussions/635

## Changes
- Replace `"${cargo_prefix[@]}"` with `${cargo_prefix[@]+"${cargo_prefix[@]}"}` on both `cargo zigbuild` and `cargo build` invocation lines in `tasks/scripts/vm/build-supervisor-bundle.sh`


## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
