### PR TITLE
fix(secret): Add custom derive Debug for SecretResolver to prevent secret leakage with {:?}

### DIFF
--- a/crates/openshell-sandbox/src/secrets.rs
+++ b/crates/openshell-sandbox/src/secrets.rs
@@ -82,9 +82,24 @@ pub struct RewriteTargetResult {
 // SecretResolver
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct SecretResolver {
     by_placeholder: HashMap<String, String>,
+}
+
+// Manual `Debug` impl: the auto-derived `Debug` would format the
+// `by_placeholder` map, exposing both placeholder keys (which reveal which
+// provider env var names are configured) and the resolved secret values
+// themselves. Any accidental `{:?}` in a tracing call, or a
+// derived `Debug` on a containing struct, would write secrets to logs.
+//
+// We expose only the count of registered placeholders without leaking anything.
+impl fmt::Debug for SecretResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecretResolver")
+            .field("placeholders", &self.by_placeholder.len())
+            .finish_non_exhaustive() // Use to show that the struct is not empty
+    }
 }
 
 impl SecretResolver {
@@ -1912,6 +1927,66 @@ mod tests {
 
         assert_eq!(result.resolved, "/v1/chat/completions?format=json");
         assert_eq!(result.redacted, "/v1/chat/completions?format=json");
+    }
+
+    #[test]
+    fn debug_format_does_not_leak_secret_values() {
+        let (_, resolver) = SecretResolver::from_provider_env(
+            [
+                (
+                    "ANTHROPIC_API_KEY".to_string(),
+                    "sk-very-secret-value-12345".to_string(),
+                ),
+                ("DB_PASSWORD".to_string(), "very-secret-value".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let resolver = resolver.expect("resolver");
+
+        let plain = format!("{resolver:?}");
+        let pretty = format!("{resolver:#?}");
+
+        for output in [&plain, &pretty] {
+            assert!(
+                !output.contains("sk-very-secret-value-12345"),
+                "secret value leaked via Debug: {output}"
+            );
+            assert!(
+                !output.contains("very-secret-value"),
+                "secret value leaked via Debug: {output}"
+            );
+            assert!(
+                !output.contains("ANTHROPIC_API_KEY"),
+                "placeholder key (env var name) leaked via Debug: {output}"
+            );
+            assert!(
+                !output.contains("DB_PASSWORD"),
+                "placeholder key (env var name) leaked via Debug: {output}"
+            );
+            assert!(
+                !output.contains(PLACEHOLDER_PREFIX),
+                "placeholder prefix leaked via Debug: {output}"
+            );
+            assert!(
+                output.contains("SecretResolver"),
+                "Debug output should still identify the type: {output}"
+            );
+        }
+
+        assert!(
+            plain.contains('2'),
+            "Debug output should expose the placeholder count: {plain}"
+        );
+    }
+
+    #[test]
+    fn debug_format_of_empty_resolver_is_safe() {
+        let resolver = SecretResolver::default();
+        let output = format!("{resolver:?}");
+        assert!(output.contains("SecretResolver"));
+        assert!(output.contains('0'));
+        assert!(!output.contains(PLACEHOLDER_PREFIX));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`SecretResolver` previously used `#[derive(Debug, ...)]`, which expands the internal `HashMap<String, String>` and prints both the placeholder keys (`openshell:resolve:env:<ENV_VAR>:<revision>`) and the resolved secret values. Any accidental `{:?}` in a `tracing` call — or a derived `Debug` on a struct that owns a `SecretResolver` — would write provider credentials to logs. This PR replaces the auto-derived impl with a hand-rolled one that exposes only the count of registered placeholders.

## Related Issue

closes OS-72

## Changes

- Drop `Debug` from the `#[derive(...)]` on `SecretResolver` in `crates/openshell-sandbox/src/secrets.rs`.
- Add a manual `fmt::Debug` impl that prints `SecretResolver { placeholders: <n>, .. }` via `finish_non_exhaustive()` — no keys, no values, ever.
- Add unit tests:
  - `debug_format_does_not_leak_secret_values` checks both `{:?}` and `{:#?}` of a populated resolver and asserts that secret values, placeholder keys (provider env-var names), and the `openshell:resolve:env:` token are all absent — while the placeholder count is still present.
  - `debug_format_of_empty_resolver_is_safe` covers the empty case.

## Design Note: Why Only the Count

I deliberately picked the most defensive `Debug` shape — just the number of registered placeholders, nothing else.

OpenShell logs may be shipped through channels I do not control end-to-end: unencrypted transports, third-party aggregators, long-term storage on operator machines. Any `Debug` output has to be treated as potentially externalized. Under that threat model:

- Leaking the secret **values** is obviously unacceptable.
- Leaking the placeholder **keys** (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DB_PASSWORD`) is still a real information disclosure — it tells an attacker which providers are configured and which credentials are worth phishing or stealing elsewhere.
- Leaking only the **count** reveals essentially nothing about the nature of the secrets stored or in use, while keeping `Debug` useful enough to identify the struct in traces.

Alternatives considered and rejected:

- Printing redacted keys (`ANTHROPIC_API_KEY=***`) — still leaks which providers are in play.
- Hashing keys — same disclosure surface in practice (small, enumerable set of provider env-var names).
- Removing `Debug` entirely — would break derived `Debug` on every struct that owns a `SecretResolver`, which is the path of least resistance for the very leakage I am trying to prevent.

## Testing

- [x] `mise run pre-commit` passes (run inside the dev VM — NixOS host can't run the mise toolchain directly)
- [x] Unit tests added (`debug_format_does_not_leak_secret_values`, `debug_format_of_empty_resolver_is_safe`)
- [ ] E2E tests added/updated (not applicable — formatting-only change, no behavioral surface)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable — internal struct formatting)