### PR TITLE
fix(scripts): replace mapfile with bash 3.2-compatible read loop

### DIFF
--- a/tasks/scripts/docker-build-image.sh
+++ b/tasks/scripts/docker-build-image.sh
@@ -55,7 +55,8 @@ missing_prebuilt_paths() {
 	local binary
 	local path
 
-	mapfile -t arches < <(prebuilt_arches)
+	local arches=()
+	while IFS= read -r _a; do arches+=("$_a"); done < <(prebuilt_arches)
 	read -r -a binaries <<< "$(required_prebuilt_binaries "${target}")"
 
 	for arch in "${arches[@]}"; do
@@ -75,7 +76,8 @@ ensure_prebuilt_binaries() {
 
 	if [[ -z "${CI:-}" && "${PREBUILT_AUTO_STAGE:-1}" != "0" ]]; then
 		echo "Staging prebuilt Rust binaries for Docker target '${target}'..."
-		mapfile -t arches < <(prebuilt_arches)
+		local arches=()
+		while IFS= read -r _a; do arches+=("$_a"); done < <(prebuilt_arches)
 		for arch in "${arches[@]}"; do
 			PREBUILT_ARCH="${arch}" "${SCRIPT_DIR}/stage-prebuilt-binaries.sh" "${target}"
 		done

--- a/tasks/scripts/stage-prebuilt-binaries.sh
+++ b/tasks/scripts/stage-prebuilt-binaries.sh
@@ -203,7 +203,8 @@ trap restore_workspace_version EXIT
 
 patch_workspace_version
 
-mapfile -t arches < <(detect_arches)
+arches=()
+while IFS= read -r _a; do arches+=("$_a"); done < <(detect_arches)
 read -r -a components <<< "$(components_for_target "$target")"
 
 for arch in "${arches[@]}"; do


### PR DESCRIPTION

## Summary
Replace `mapfile -t` with a `while read` loop in `docker-build-image.sh` and `stage-prebuilt-binaries.sh` to ensure compatibility with **bash 3.2**, the default shell on macOS.

`mapfile` (also known as `readarray`) was introduced in bash 4.0. macOS ships with bash 3.2 due to the GPLv3 licensing change in bash 4+, so any script using `mapfile` fails on a stock macOS developer machine:

```
line XX: mapfile: command not found
```

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
All three call sites follow the same mechanical replacement:

```bash
# Before (requires bash 4.0+)
mapfile -t arches < <(prebuilt_arches)

# After (works on bash 3.2+)
local arches=()
while IFS= read -r _a; do arches+=("$_a"); done < <(prebuilt_arches)
```

| File | Location | Function |
|------|----------|----------|
| `tasks/scripts/docker-build-image.sh` | `missing_prebuilt_paths()` | Detects which prebuilt binaries are absent |
| `tasks/scripts/docker-build-image.sh` | `ensure_prebuilt_binaries()` | Stages prebuilt binaries before Docker build |
| `tasks/scripts/stage-prebuilt-binaries.sh` | top-level | Detects host architectures for cross-compilation |

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

### Manual Testing

- Run `tasks/scripts/stage-prebuilt-binaries.sh` on macOS (bash 3.2) and confirm it no longer errors on `mapfile`.
- Run `mise run docker:build` and verify prebuilt binary staging still works on both macOS and Linux.

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)


