### PR TITLE
fix(cli): use OS trust store for reqwest TLS verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4541,6 +4541,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ serde_yml = "0.0.12"
 apollo-parser = "0.8.5"
 
 # HTTP client
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 
 # WebSocket
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }

--- a/crates/openshell-cli/src/tls.rs
+++ b/crates/openshell-cli/src/tls.rs
@@ -406,9 +406,12 @@ pub async fn build_channel(server: &str, tls: &TlsOptions) -> Result<Channel> {
                     .ca
                     .as_ref()
                     .and_then(|ca_path| std::fs::read(ca_path).ok())
-                    .map_or_else(ClientTlsConfig::new, |ca_pem| {
-                        ClientTlsConfig::new().ca_certificate(Certificate::from_pem(ca_pem))
-                    })
+                    .map_or_else(
+                        || ClientTlsConfig::new().with_enabled_roots(),
+                        |ca_pem| {
+                            ClientTlsConfig::new().ca_certificate(Certificate::from_pem(ca_pem))
+                        },
+                    )
             },
             |materials| build_tonic_tls_config(&materials),
         )


### PR DESCRIPTION
## Summary
- Switch reqwest from `rustls-tls` (bundled Mozilla webpki roots) to `rustls-tls-native-roots` (OS certificate store) so the CLI trusts the same CAs as the rest of the system
- Fixes OIDC discovery failures (`UnknownIssuer`) against Keycloak instances using certificates signed by internal CAs present in the system trust bundle
- Aligns reqwest with `tokio-tungstenite`, which already uses `rustls-tls-native-roots`

## Test plan
- [ ] Run `openshell gateway login` against a Keycloak instance with an internally-signed certificate
- [ ] Verify OIDC discovery succeeds without `UnknownIssuer` error
- [ ] Verify login still works against Keycloak instances with publicly-signed certificates