### PR TITLE
fix(grpc): allow credential rotation when legacy provider.type exceeds current limit

### DIFF
--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -16,7 +16,7 @@ use prost::Message;
 use tonic::Status;
 use tracing::warn;
 
-use super::validation::validate_provider_fields;
+use super::validation::{validate_provider_fields, validate_provider_mutable_fields};
 use super::{
     MAX_MAP_KEY_LEN, MAX_MAP_VALUE_LEN, MAX_PAGE_SIZE, MAX_PROVIDER_CONFIG_ENTRIES, clamp_limit,
 };
@@ -218,9 +218,14 @@ pub(super) async fn update_provider_record(
         provider.credential_expires_at_ms,
     );
 
-    // Validate BEFORE writing to prevent persisting invalid state
+    // Validate BEFORE writing to prevent persisting invalid state.
+    // Validate only the mutable fields (credentials/config) plus metadata and
+    // attached-sandbox invariants. The immutable name/type are carried forward
+    // from `existing` and re-running full `validate_provider_fields` here would
+    // strand legacy records whose stored type predates current limits. See
+    // #1347.
     super::validation::validate_object_metadata(candidate.metadata.as_ref(), "provider")?;
-    validate_provider_fields(&candidate)?;
+    validate_provider_mutable_fields(&candidate)?;
     validate_provider_update_against_attached_sandboxes(store, &candidate).await?;
 
     // Serialize labels for storage
@@ -1602,8 +1607,8 @@ fn telemetry_provider_profile(provider_type: &str) -> TelemetryProviderProfile {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::grpc::MAX_MAP_KEY_LEN;
     use crate::grpc::test_support::test_server_state;
+    use crate::grpc::{MAX_MAP_KEY_LEN, MAX_PROVIDER_TYPE_LEN};
     use crate::persistence::test_store;
     use openshell_core::proto::{
         DeleteProviderProfileRequest, GetProviderProfileRequest, ImportProviderProfilesRequest,
@@ -3555,6 +3560,52 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(err.code(), Code::InvalidArgument);
+    }
+
+    /// Regression for #1347: a credential rotation must not fail just because the
+    /// existing record's `type` field exceeds the current `MAX_PROVIDER_TYPE_LEN`.
+    /// The caller never touches `type`; re-validating it strands legacy records.
+    #[tokio::test]
+    async fn update_provider_allows_credential_rotation_on_legacy_oversized_type() {
+        let store = test_store().await;
+
+        let oversized_type = "x".repeat(MAX_PROVIDER_TYPE_LEN + 15);
+        let legacy = Provider {
+            metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                id: uuid::Uuid::new_v4().to_string(),
+                name: "legacy-oversized-type".to_string(),
+                created_at_ms: 0,
+                labels: HashMap::new(),
+                resource_version: 0,
+            }),
+            r#type: oversized_type.clone(),
+            credentials: std::iter::once(("API_TOKEN".to_string(), "old".to_string())).collect(),
+            config: HashMap::new(),
+            credential_expires_at_ms: HashMap::new(),
+        };
+        store.put_message(&legacy).await.unwrap();
+
+        let updated = update_provider_record(
+            &store,
+            Provider {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: String::new(),
+                    name: "legacy-oversized-type".to_string(),
+                    created_at_ms: 0,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                }),
+                r#type: String::new(),
+                credentials: std::iter::once(("API_TOKEN".to_string(), "new".to_string()))
+                    .collect(),
+                config: HashMap::new(),
+                credential_expires_at_ms: HashMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(updated.r#type, oversized_type);
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/grpc/validation.rs
+++ b/crates/openshell-server/src/grpc/validation.rs
@@ -239,7 +239,7 @@ pub(super) fn validate_string_map(
 // Provider field validation
 // ---------------------------------------------------------------------------
 
-/// Validate field sizes on a `Provider` before persisting.
+/// Validate field sizes on a `Provider` before persisting a new record.
 pub(super) fn validate_provider_fields(provider: &Provider) -> Result<(), Status> {
     let name_len = provider.metadata.as_ref().map_or(0, |m| m.name.len());
     if name_len > MAX_NAME_LEN {
@@ -253,6 +253,17 @@ pub(super) fn validate_provider_fields(provider: &Provider) -> Result<(), Status
             provider.r#type.len()
         )));
     }
+    validate_provider_mutable_fields(provider)
+}
+
+/// Validate field sizes on a `Provider` before persisting an update.
+///
+/// Skips the immutable `name` and `type` fields, which are carried forward from
+/// the existing record. Re-checking them would block credential rotation on any
+/// legacy record whose stored `name`/`type` predates current limits (or was
+/// written by a path that bypassed validation), even though the caller never
+/// touches those fields. See #1347.
+pub(super) fn validate_provider_mutable_fields(provider: &Provider) -> Result<(), Status> {
     validate_string_map(
         &provider.credentials,
         MAX_PROVIDER_CREDENTIALS_ENTRIES,


### PR DESCRIPTION
## Summary

`openshell provider update <name> --credential ...` re-validates the immutable `type` field on every call, stranding any legacy record whose stored type exceeds the current `MAX_PROVIDER_TYPE_LEN` (64). Split provider validation into create-time and update-time variants so the update path only validates fields the caller is mutating (`credentials`, `config`); immutable name/type are carried forward from the existing record without re-checking length.

## Related Issue

Closes #1347.

Reported by @KodeDaemon in the NVIDIA Discord community after upgrading NemoClaw 0.0.38 to 0.0.39:

```
Error:   × status: InvalidArgument, message: "provider.type exceeds maximum length (79 > 64)"
```

`openshell provider list` confirmed an existing inference provider had a 79-character `type` value. NemoClaw's onboard re-runs `openshell provider update inference --credential ...` on every upgrade, and that path failed because `update_provider_record` rebuilt the merged Provider from `existing.r#type` and ran the full `validate_provider_fields` over it, even though the caller only touches credentials. The CLI's `provider update` sends `r#type: ""`, so the existing value was preserved without modification, but the validator still measured it.

Two ways legacy data ends up oversized: (1) records that predate `validate_provider_fields` (added by #145, later split out in #777); (2) write paths that bypass `normalize_provider_type`, e.g. the TUI form at [crates/openshell-tui/src/lib.rs:1563](crates/openshell-tui/src/lib.rs#L1563) which forwards `r#type` to the request directly. Either way, the only escape was `provider delete` + recreate, which loses any `provider.config` entries the caller never sees.

## Changes

- `crates/openshell-server/src/grpc/validation.rs`: `validate_provider_fields` keeps the full create-time check (name + type + credentials + config), now delegating the map checks to a new helper. `validate_provider_mutable_fields` validates only `credentials` and `config`; used by the update path.
- `crates/openshell-server/src/grpc/provider.rs`: `update_provider_record` calls `validate_provider_mutable_fields` instead of `validate_provider_fields`. Immutable name/type carried forward from `existing` are trusted because they passed validation when stored.

## Testing

- [x] `cargo test -p openshell-server --lib grpc::provider` (32 passed including new regression)
- [x] `cargo test -p openshell-server --lib grpc::validation` (76 passed)
- [x] `cargo clippy -p openshell-server --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable) — pure server-side validation change, covered by unit tests against the same store the gRPC handler uses

New regression `update_provider_allows_credential_rotation_on_legacy_oversized_type` inserts a Provider with a 79-character type directly via `store.put_message` (bypassing gRPC validation, simulating a legacy record), then calls `update_provider_record` to rotate a credential and asserts both that the update succeeds and the original 79-character type is preserved on the stored record. Existing `update_provider_validates_merged_result` continues to assert that an oversized incoming credential key is still rejected, so incoming-mutation validation is unchanged.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — no architectural change; behavior change is a one-line swap in the update handler with the rationale captured in the new helper's doc comment

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>
