### PR TITLE
feat(helm): support Secret-backed db URL for Postgres

### DIFF
--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -52,6 +52,7 @@ See [`values.yaml`](values.yaml) for configurable values. Selected overlays:
 - [`ci/values-gateway.yaml`](ci/values-gateway.yaml) — gateway-only configuration
 - [`ci/values-cert-manager.yaml`](ci/values-cert-manager.yaml) — cert-manager integration
 - [`ci/values-keycloak.yaml`](ci/values-keycloak.yaml) — Keycloak OIDC integration
+- [`ci/values-postgres.yaml`](ci/values-postgres.yaml) — Postgres persistence via a Secret-backed DB URL
 
 ## PKI bootstrap
 

--- a/deploy/helm/openshell/ci/values-postgres.yaml
+++ b/deploy/helm/openshell/ci/values-postgres.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Postgres persistence overlay.
+#
+# Sources the gateway's database URL from a Kubernetes Secret so the password
+# never lives in values.yaml or Helm release history.
+#
+# 1. Create the Secret in the release namespace, out-of-band:
+#
+#      kubectl create secret generic openshell-db \
+#        --namespace openshell \
+#        --from-literal=url='postgres://openshell:CHANGEME@postgres.openshell.svc.cluster.local:5432/openshell?sslmode=require'
+#
+#    Both `postgres://` and `postgresql://` schemes are accepted. The gateway
+#    runs the embedded migrations on first connect.
+#
+# 2. Layer this file on top of values.yaml when deploying:
+#
+#      helm upgrade --install openshell . \
+#        -f values.yaml -f ci/values-postgres.yaml
+#
+# When `server.dbUrlSecretRef.name` is set, the chart drops the `--db-url`
+# CLI flag and the gateway reads OPENSHELL_DB_URL from the referenced Secret.
+# The plaintext `server.dbUrl` value is ignored. The chart still provisions
+# the `/var/openshell` PVC, but it is unused when persistence is Postgres.
+
+server:
+  dbUrlSecretRef:
+    name: openshell-db
+    key: url

--- a/deploy/helm/openshell/templates/statefulset.yaml
+++ b/deploy/helm/openshell/templates/statefulset.yaml
@@ -59,9 +59,18 @@ spec:
             {{- end }}
             - --log-level
             - {{ .Values.server.logLevel }}
+            {{- if not .Values.server.dbUrlSecretRef.name }}
             - --db-url
             - {{ .Values.server.dbUrl | quote }}
+            {{- end }}
           env:
+            {{- if .Values.server.dbUrlSecretRef.name }}
+            - name: OPENSHELL_DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.server.dbUrlSecretRef.name | quote }}
+                  key: {{ .Values.server.dbUrlSecretRef.key | quote }}
+            {{- end }}
             - name: OPENSHELL_SANDBOX_NAMESPACE
               value: {{ include "openshell.sandboxNamespace" . | quote }}
             - name: OPENSHELL_SANDBOX_IMAGE

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -90,6 +90,14 @@ server:
   # namespace (.Release.Namespace) when left empty.
   sandboxNamespace: ""
   dbUrl: "sqlite:/var/openshell/openshell.db"
+  # Source the database URL from a Kubernetes Secret instead of `dbUrl`. When
+  # `name` is set, the gateway reads OPENSHELL_DB_URL from this Secret and the
+  # plaintext `dbUrl` value above is ignored. Use this for Postgres so the
+  # password never lives in values.yaml or Helm release history.
+  # See ci/values-postgres.yaml for a worked example.
+  dbUrlSecretRef:
+    name: ""
+    key: "url"
   sandboxImage: "ghcr.io/nvidia/openshell-community/sandboxes/base:latest"
   # Kubernetes imagePullPolicy for sandbox pods.  Empty = Kubernetes default
   # (Always for :latest, IfNotPresent otherwise).  Set to "Always" for dev


### PR DESCRIPTION
## Summary
Add a Secret-backed `OPENSHELL_DB_URL` path to the Helm chart so operators can point the gateway at Postgres without putting the password in `values.yaml` or Helm release history.

## Related Issue
N/A

## Changes
- `values.yaml`: new `server.dbUrlSecretRef` (`name` + `key`); empty `name` preserves the existing SQLite default.
- `templates/statefulset.yaml`: when `dbUrlSecretRef.name` is set, drop the `--db-url` CLI flag and inject `OPENSHELL_DB_URL` via `secretKeyRef`.
- `ci/values-postgres.yaml`: new overlay documenting the out-of-band Secret recipe and the `helm upgrade -f` command.
- `README.md`: list the new overlay alongside cert-manager / Keycloak.

## Testing
- [x] \`mise run pre-commit\` passes
- [x] \`helm template\` with defaults still emits \`--db-url "sqlite:/var/openshell/openshell.db"\` and no DB env var.
- [x] \`helm template -f values.yaml -f ci/values-postgres.yaml\` drops \`--db-url\` and emits an \`OPENSHELL_DB_URL\` env entry sourced from \`openshell-db\`.
- [ ] End-to-end Postgres install against a real cluster (not yet run).

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable — chart-only change)