### PR TITLE
docs: replace --sync with --upload . in sync-files example

### DIFF
--- a/examples/sync-files.md
+++ b/examples/sync-files.md
@@ -39,20 +39,19 @@ openshell sandbox download my-sandbox /sandbox/results
 
 ## Sync on create
 
-Push all git-tracked files into a new sandbox automatically:
+Push all files in the current directory into a new sandbox automatically:
 
 ```bash
-openshell sandbox create --sync -- python main.py
+openshell sandbox create --upload . -- python main.py
 ```
 
-This collects tracked and untracked (non-ignored) files via
-`git ls-files` and streams them into `/sandbox` before the command runs.
+This uploads the current directory into `/sandbox` before the command runs.
 
 ## Workflow: iterate on code in a sandbox
 
 ```bash
-# Create a sandbox and sync your repo
-openshell sandbox create --name dev --sync
+# Create a sandbox and upload your repo
+openshell sandbox create --name dev --upload .
 
 # Make local changes, then push them
 openshell sandbox upload dev ./src /sandbox/src


### PR DESCRIPTION
## Summary

- Fixes the missing `--sync` flag in `examples/sync-files.md`
- Replaces it with `--upload .` which is the correct flag
- Updates the workflow snippet to match

## Related Issue

Fixes #1339

## Changes

- `examples/sync-files.md`: replaced two `--sync` references with `--upload .` and updated the description text around them

## Testing

Documentation change only. No code changes.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Follows the docs style guide
- [x] No duplicate H1
- [x] Active voice