### PR TITLE
feat(ci): add helm-unittest mise task and CI step

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -55,3 +55,6 @@ jobs:
 
       - name: Lint Helm chart
         run: mise run helm:lint
+
+      - name: Run Helm chart unit tests
+        run: mise run helm:test

--- a/deploy/docker/Dockerfile.ci
+++ b/deploy/docker/Dockerfile.ci
@@ -83,7 +83,8 @@ RUN --mount=type=secret,id=MISE_GITHUB_TOKEN \
     npm install -g "npm@${NPM_VERSION}" && \
     mise reshim && \
     (/root/.cargo/bin/rustup component remove rust-docs || true) && \
-    rm -rf /root/.rustup/toolchains/*/share/doc /root/.rustup/toolchains/*/share/man
+    rm -rf /root/.rustup/toolchains/*/share/doc /root/.rustup/toolchains/*/share/man && \
+    helm plugin install https://github.com/helm-unittest/helm-unittest
 
 # Set working directory for CI jobs
 WORKDIR /builds

--- a/tasks/helm.toml
+++ b/tasks/helm.toml
@@ -19,6 +19,16 @@ run = """
   echo "All variants passed."
 """
 
+["helm:test"]
+description = "Run Helm chart unit tests"
+run = """
+  set -e
+  if ! helm plugin list | grep -q unittest; then
+    helm plugin install https://github.com/helm-unittest/helm-unittest
+  fi
+  helm unittest deploy/helm/openshell
+"""
+
 ["helm:skaffold:dev"]
 description = "Run skaffold dev for deploy/helm/openshell (iterative deploy)"
 dir = "deploy/helm/openshell"


### PR DESCRIPTION
## Summary

- Adds a `helm:test` mise task that installs the helm-unittest plugin if needed and runs chart tests
- Adds a CI step to the Helm Lint workflow so tests run on every chart change

## Related Issue

Closes #1281

## Changes

- `tasks/helm.toml`: new `helm:test` task
- `.github/workflows/helm-lint.yml`: new step that runs `helm:test` after lint

## Testing

Run locally with:

```shell
mise run helm:test
```

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)