### PR TITLE
fix(server): downgrade expected connection teardown errors to debug

### DIFF
--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -32,7 +32,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use russh::ChannelMsg;
 use russh::client::AuthResult;
@@ -1001,7 +1001,7 @@ async fn bridge_forward_tcp_stream(
                 }
                 Ok(None) => break,
                 Err(err) => {
-                    warn!(sandbox_id = %sandbox_id_in, channel_id = %channel_id_in, error = %err, "ForwardTcp: inbound stream failed");
+                    debug!(sandbox_id = %sandbox_id_in, channel_id = %channel_id_in, error = %err, "ForwardTcp: inbound stream ended");
                     break;
                 }
             }

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -111,6 +111,15 @@ fn is_benign_tls_handshake_failure(error: &std::io::Error) -> bool {
     )
 }
 
+fn is_benign_connection_close(error: &(dyn std::error::Error + 'static)) -> bool {
+    let msg = error.to_string();
+    msg.contains("connection closed")
+        || msg.contains("connection reset")
+        || msg.contains("connection error")
+        || msg.contains("error reading a body from connection")
+        || msg.contains("broken pipe")
+}
+
 impl ServerState {
     /// Create new server state.
     #[must_use]
@@ -475,7 +484,11 @@ fn spawn_gateway_connection(
                     ) =>
                 {
                     if let Err(e) = service.serve_service_http(stream).await {
-                        error!(error = %e, client = %addr, listen = %listen_addr, "Plaintext service HTTP connection error");
+                        if is_benign_connection_close(e.as_ref()) {
+                            debug!(error = %e, client = %addr, listen = %listen_addr, "Plaintext service HTTP connection closed");
+                        } else {
+                            error!(error = %e, client = %addr, listen = %listen_addr, "Plaintext service HTTP connection error");
+                        }
                     }
                 }
                 Ok(ConnectionProtocol::PlainHttp) => {
@@ -485,7 +498,11 @@ fn spawn_gateway_connection(
                     match acceptor.inner().accept(stream).await {
                         Ok(tls_stream) => {
                             if let Err(e) = service.serve(tls_stream).await {
-                                error!(error = %e, client = %addr, "Connection error");
+                                if is_benign_connection_close(e.as_ref()) {
+                                    debug!(error = %e, client = %addr, "Connection closed");
+                                } else {
+                                    error!(error = %e, client = %addr, "Connection error");
+                                }
                             }
                         }
                         Err(e) => {
@@ -505,7 +522,11 @@ fn spawn_gateway_connection(
     } else {
         tokio::spawn(async move {
             if let Err(e) = service.serve(stream).await {
-                error!(error = %e, client = %addr, "Connection error");
+                if is_benign_connection_close(e.as_ref()) {
+                    debug!(error = %e, client = %addr, "Connection closed");
+                } else {
+                    error!(error = %e, client = %addr, "Connection error");
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary

h2 connection errors during sandbox deletion are expected — the supervisor gRPC stream is torn down when the sandbox is removed. Downgrade these from ERROR/WARN to DEBUG so they don't pollute gateway logs during normal operations.

## Related Issue

None — discovered during nftables migration e2e testing (#1335).

## Changes

- Add `is_benign_connection_close()` helper in `lib.rs` that matches expected h2/connection teardown error messages
- Downgrade connection error logs from `error!` to `debug!` for both TLS and plaintext paths when the error matches a benign connection close
- Downgrade `ForwardTcp: inbound stream failed` from `warn!` to `debug!` in `grpc/sandbox.rs` — stream teardown during sandbox deletion is expected

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [x] E2E tests added/updated — verified gateway logs no longer show ERROR/WARN during normal sandbox lifecycle (create → exec → delete)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)