### PR TITLE
fix(images): remove image-specific owner and mode set for gateway binary

### DIFF
--- a/deploy/docker/Dockerfile.gateway
+++ b/deploy/docker/Dockerfile.gateway
@@ -26,13 +26,7 @@ ARG TARGETARCH
 
 WORKDIR /app
 
-# --chmod=0550 preserves the executable bit through actions/upload-artifact +
-# download-artifact (which strip exec perms during the roundtrip) without
-# granting world-execute. --chown=nvs:nvs matches the image's only defined
-# non-root user (`nvs:1000`, the NVIDIA distroless convention) and aligns
-# with the Helm chart's `securityContext.runAsUser: 1000`, which overrides
-# the Dockerfile's USER at runtime.
-COPY --chown=nvs:nvs --chmod=0550 deploy/docker/.build/prebuilt-binaries/${TARGETARCH}/openshell-gateway /usr/local/bin/openshell-gateway
+COPY deploy/docker/.build/prebuilt-binaries/${TARGETARCH}/openshell-gateway /usr/local/bin/openshell-gateway
 
 USER nvs:nvs
 EXPOSE 8080


### PR DESCRIPTION
## Summary

Remove the `--chown=nvs:nvs --chmod=0550` flags from the gateway Dockerfile `COPY` instruction.

If the user overrides the user ID in the helm values or the UID can't be controlled, as is the case with OpenShift, this will break.  This preserves the original 0755 mode and, since it is world executable, there is no need to `chown`.

## Changes

- Removed `--chown=nvs:nvs --chmod=0550` from the gateway binary `COPY` instruction in `deploy/docker/Dockerfile.gateway`
- Removed the associated explanatory comment block

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)