### PR TITLE
feat(helm): support custom CA for OIDC issuer TLS verification

### DIFF
--- a/deploy/helm/openshell/templates/statefulset.yaml
+++ b/deploy/helm/openshell/templates/statefulset.yaml
@@ -128,6 +128,10 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Values.server.oidc.issuer }}
+            {{- if .Values.server.oidc.caConfigMapName }}
+            - name: SSL_CERT_FILE
+              value: /etc/openshell-tls/oidc-ca/ca.crt
+            {{- end }}
             - name: OPENSHELL_OIDC_ISSUER
               value: {{ .Values.server.oidc.issuer | quote }}
             - name: OPENSHELL_OIDC_AUDIENCE
@@ -160,6 +164,11 @@ spec:
               readOnly: true
             - name: tls-client-ca
               mountPath: /etc/openshell-tls/client-ca
+              readOnly: true
+            {{- end }}
+            {{- if and .Values.server.oidc.issuer .Values.server.oidc.caConfigMapName }}
+            - name: oidc-ca
+              mountPath: /etc/openshell-tls/oidc-ca
               readOnly: true
             {{- end }}
           ports:
@@ -214,6 +223,11 @@ spec:
             {{- else }}
             secretName: {{ .Values.server.tls.clientCaSecretName }}
             {{- end }}
+        {{- end }}
+        {{- if and .Values.server.oidc.issuer .Values.server.oidc.caConfigMapName }}
+        - name: oidc-ca
+          configMap:
+            name: {{ .Values.server.oidc.caConfigMapName }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -160,6 +160,10 @@ server:
     userRole: ""
     # Dot-separated path to the scopes array in the JWT claims.
     scopesClaim: ""
+    # Name of a ConfigMap containing a CA certificate bundle (key: ca.crt)
+    # for verifying the OIDC issuer's TLS certificate. Required when the
+    # issuer uses a non-public CA (e.g. OpenShift ingress, private PKI).
+    caConfigMapName: ""
 
 # NetworkPolicy restricting SSH ingress on sandbox pods to the gateway only.
 networkPolicy:


### PR DESCRIPTION
## Summary

Add a `caConfigMapName` field to the OIDC Helm values so operators can mount a CA certificate bundle for verifying the OIDC issuer's TLS certificate. This is required when the issuer uses a non-public CA (e.g. OpenShift ingress, private PKI).

## Changes

- Added `server.oidc.caConfigMapName` value (default empty string)
- When set, mounts the referenced ConfigMap at `/etc/openshell-tls/oidc-ca` in the gateway container
- Sets `SSL_CERT_FILE=/etc/openshell-tls/oidc-ca/ca.crt` so the gateway trusts the custom CA

## Testing

- [x] `mise run pre-commit` passes
- [x] `helm lint` passes with default, cert-manager, and gateway value sets
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)