### PR TITLE
fix(gateway): bootstrap gateway env files for macOS installs

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -22,7 +22,8 @@ jobs:
     steps:
       - name: Ensure VM driver
         run: |
-          launchctl setenv OPENSHELL_DRIVERS vm
+          mkdir -p "${HOME}/.config/openshell"
+          printf 'OPENSHELL_DRIVERS=vm\n' > "${HOME}/.config/openshell/gateway.env"
 
       - name: Install and check status
         run: |

--- a/architecture/build.md
+++ b/architecture/build.md
@@ -53,7 +53,12 @@ versions.
 The Homebrew service keeps gateway TLS under the Homebrew state directory but
 mirrors Docker sandbox client TLS into `$HOME/.local/state/openshell/homebrew/tls`
 at service start, because Docker Desktop bind mounts must use paths visible to
-the macOS user's shared home directory.
+the macOS user's shared home directory. The Homebrew wrapper also sources
+`$HOME/.config/openshell/gateway.env` before starting the gateway so local
+driver selection, the generated sandbox RPC secret, and other gateway overrides
+follow the same operator-facing file convention as the Linux packages. The
+wrapper calls `openshell-gateway init-env --output ... --driver vm` first, which
+creates or repairs the env file without replacing an existing driver choice.
 
 Local image work should use `mise` tasks rather than direct Docker commands so
 the same staging and tagging assumptions are used locally and in CI.

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -4,14 +4,17 @@
 //! Shared CLI entrypoint for the gateway binaries.
 
 use clap::{ArgAction, Command, CommandFactory, FromArgMatches, Parser};
-use miette::{IntoDiagnostic, Result};
+use miette::{Context, IntoDiagnostic, Result};
 use openshell_core::ComputeDriverKind;
 use openshell_core::config::{
     DEFAULT_DOCKER_NETWORK_NAME, DEFAULT_SERVER_PORT, DEFAULT_SSH_HANDSHAKE_SKEW_SECS,
     DEFAULT_SSH_PORT,
 };
+use rand::Rng;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::net::{IpAddr, SocketAddr};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
@@ -39,6 +42,20 @@ struct Cli {
 enum Commands {
     /// Generate mTLS PKI and write Kubernetes Secrets (Helm pre-install hook).
     GenerateCerts(certgen::CertgenArgs),
+
+    /// Create or repair a gateway environment file with generated local secrets.
+    InitEnv(InitEnvArgs),
+}
+
+#[derive(clap::Args, Debug)]
+struct InitEnvArgs {
+    /// Environment file to create or repair.
+    #[arg(long, value_name = "PATH")]
+    output: PathBuf,
+
+    /// Compute driver to write when `OPENSHELL_DRIVERS` is absent.
+    #[arg(long, value_parser = parse_compute_driver)]
+    driver: Option<ComputeDriverKind>,
 }
 
 #[derive(clap::Args, Debug)]
@@ -333,8 +350,137 @@ pub async fn run_cli() -> Result<()> {
 
     match cli.command {
         Some(Commands::GenerateCerts(args)) => certgen::run(args).await,
+        Some(Commands::InitEnv(args)) => run_init_env(args),
         None => Box::pin(run_from_args(cli.run)).await,
     }
+}
+
+fn run_init_env(args: InitEnvArgs) -> Result<()> {
+    let result = init_gateway_env(&args.output, args.driver)?;
+    info!(
+        path = %args.output.display(),
+        created = result.created,
+        added_secret = result.added_secret,
+        added_driver = result.added_driver,
+        "gateway environment initialized"
+    );
+    Ok(())
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct InitEnvResult {
+    created: bool,
+    added_secret: bool,
+    added_driver: bool,
+}
+
+fn init_gateway_env(path: &Path, driver: Option<ComputeDriverKind>) -> Result<InitEnvResult> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("create parent directory for {}", path.display()))?;
+    }
+
+    let mut result = InitEnvResult::default();
+    let mut contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            result.created = true;
+            gateway_env_header().to_string()
+        }
+        Err(err) => {
+            return Err(err)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("read {}", path.display()));
+        }
+    };
+
+    if !env_file_has_key(&contents, "OPENSHELL_SSH_HANDSHAKE_SECRET") {
+        ensure_trailing_newline(&mut contents);
+        contents.push_str("# Shared secret for gateway-to-sandbox RPC authentication.\n");
+        contents
+            .push_str("# Auto-generated on first bootstrap. To regenerate: openssl rand -hex 32\n");
+        contents.push_str("OPENSHELL_SSH_HANDSHAKE_SECRET=");
+        contents.push_str(&generate_secret_hex());
+        contents.push('\n');
+        result.added_secret = true;
+    }
+
+    if let Some(driver) = driver
+        && !env_file_has_key(&contents, "OPENSHELL_DRIVERS")
+    {
+        ensure_trailing_newline(&mut contents);
+        contents.push_str("# Compute driver selected for this local gateway.\n");
+        contents.push_str("OPENSHELL_DRIVERS=");
+        contents.push_str(driver.as_str());
+        contents.push('\n');
+        result.added_driver = true;
+    }
+
+    if result.created || result.added_secret || result.added_driver {
+        write_gateway_env(path, &contents)?;
+    }
+
+    Ok(result)
+}
+
+fn gateway_env_header() -> &'static str {
+    "# OpenShell Gateway Environment Configuration\n\
+# Generated on first bootstrap. Edit freely; this file is not overwritten.\n\
+# Run 'openshell-gateway --help' for the full list of options.\n\n"
+}
+
+fn env_file_has_key(contents: &str, key: &str) -> bool {
+    let prefix = format!("{key}=");
+    contents
+        .lines()
+        .map(str::trim_start)
+        .any(|line| line.starts_with(&prefix))
+}
+
+fn ensure_trailing_newline(contents: &mut String) {
+    if !contents.is_empty() && !contents.ends_with('\n') {
+        contents.push('\n');
+    }
+}
+
+fn generate_secret_hex() -> String {
+    let mut rng = rand::rng();
+    let secret: [u8; 32] = rng.random();
+    hex::encode(secret)
+}
+
+fn write_gateway_env(path: &Path, contents: &str) -> Result<()> {
+    let mut options = OpenOptions::new();
+    options.create(true).write(true).truncate(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = options
+        .open(path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("open {}", path.display()))?;
+    file.write_all(contents.as_bytes())
+        .into_diagnostic()
+        .wrap_err_with(|| format!("write {}", path.display()))?;
+    file.sync_all()
+        .into_diagnostic()
+        .wrap_err_with(|| format!("sync {}", path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let permissions = fs::Permissions::from_mode(0o600);
+        fs::set_permissions(path, permissions)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("set permissions on {}", path.display()))?;
+    }
+
+    Ok(())
 }
 
 async fn run_from_args(args: RunArgs) -> Result<()> {
@@ -494,8 +640,9 @@ fn parse_compute_driver(value: &str) -> std::result::Result<ComputeDriverKind, S
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, command};
+    use super::{Cli, ComputeDriverKind, command, init_gateway_env};
     use clap::Parser;
+    use std::fs;
     use std::net::{IpAddr, Ipv4Addr};
     use std::sync::{LazyLock, Mutex};
 
@@ -699,6 +846,72 @@ mod tests {
             cli.command,
             Some(super::Commands::GenerateCerts(_))
         ));
+    }
+
+    #[test]
+    fn init_env_subcommand_parses_without_db_url() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _g = EnvVarGuard::remove("OPENSHELL_DB_URL");
+
+        let cli = Cli::try_parse_from([
+            "openshell-gateway",
+            "init-env",
+            "--output",
+            "/tmp/openshell-gateway.env",
+            "--driver",
+            "vm",
+        ])
+        .expect("init-env should parse without --db-url");
+
+        assert!(matches!(cli.command, Some(super::Commands::InitEnv(_))));
+    }
+
+    #[test]
+    fn init_gateway_env_creates_secret_and_default_driver() {
+        let temp = tempfile::tempdir().unwrap();
+        let env_path = temp.path().join("gateway.env");
+
+        let result = init_gateway_env(&env_path, Some(ComputeDriverKind::Vm)).unwrap();
+        let contents = fs::read_to_string(&env_path).unwrap();
+
+        assert!(result.created);
+        assert!(result.added_secret);
+        assert!(result.added_driver);
+        assert!(contents.contains("OPENSHELL_SSH_HANDSHAKE_SECRET="));
+        assert!(contents.contains("OPENSHELL_DRIVERS=vm"));
+    }
+
+    #[test]
+    fn init_gateway_env_repairs_partial_file_without_overriding_driver() {
+        let temp = tempfile::tempdir().unwrap();
+        let env_path = temp.path().join("gateway.env");
+        fs::write(&env_path, "OPENSHELL_DRIVERS=podman\n").unwrap();
+
+        let result = init_gateway_env(&env_path, Some(ComputeDriverKind::Vm)).unwrap();
+        let contents = fs::read_to_string(&env_path).unwrap();
+
+        assert!(!result.created);
+        assert!(result.added_secret);
+        assert!(!result.added_driver);
+        assert!(contents.contains("OPENSHELL_DRIVERS=podman"));
+        assert!(!contents.contains("OPENSHELL_DRIVERS=vm"));
+        assert!(contents.contains("OPENSHELL_SSH_HANDSHAKE_SECRET="));
+    }
+
+    #[test]
+    fn init_gateway_env_preserves_complete_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let env_path = temp.path().join("gateway.env");
+        let original = "OPENSHELL_DRIVERS=docker\nOPENSHELL_SSH_HANDSHAKE_SECRET=existing\n";
+        fs::write(&env_path, original).unwrap();
+
+        let result = init_gateway_env(&env_path, Some(ComputeDriverKind::Vm)).unwrap();
+        let contents = fs::read_to_string(&env_path).unwrap();
+
+        assert_eq!(result, super::InitEnvResult::default());
+        assert_eq!(contents, original);
     }
 
     #[test]

--- a/deploy/deb/openshell-gateway.service
+++ b/deploy/deb/openshell-gateway.service
@@ -27,6 +27,7 @@ Environment=OPENSHELL_PODMAN_TLS_CA=%S/openshell/tls/ca.crt
 Environment=OPENSHELL_PODMAN_TLS_CERT=%S/openshell/tls/client/tls.crt
 Environment=OPENSHELL_PODMAN_TLS_KEY=%S/openshell/tls/client/tls.key
 EnvironmentFile=-%h/.config/openshell/gateway.env
+ExecStartPre=/usr/bin/openshell-gateway init-env --output %h/.config/openshell/gateway.env
 ExecStartPre=/usr/bin/openshell-gateway generate-certs --output-dir %S/openshell/tls --server-san host.openshell.internal
 ExecStart=/usr/bin/openshell-gateway
 Restart=on-failure

--- a/deploy/man/openshell-gateway.8.md
+++ b/deploy/man/openshell-gateway.8.md
@@ -14,6 +14,10 @@ openshell-gateway - OpenShell gateway server daemon
 
 **openshell-gateway** \[*OPTIONS*\]
 
+**openshell-gateway** **init-env** **--output** *PATH* \[**--driver** *DRIVER*\]
+
+**openshell-gateway** **generate-certs** \[*OPTIONS*\]
+
 # DESCRIPTION
 
 **openshell-gateway** is the control-plane server for OpenShell. It
@@ -124,6 +128,17 @@ gRPC and HTTP, secured by mutual TLS (mTLS) by default.
 :   gRPC endpoint for sandbox callbacks. Should be reachable from
     within sandbox containers.
     Environment: **OPENSHELL_GRPC_ENDPOINT**.
+
+# SUBCOMMANDS
+
+**init-env** **--output** *PATH* \[**--driver** *DRIVER*\]
+:   Create or repair a gateway environment file. The command creates
+    parent directories, adds **OPENSHELL_SSH_HANDSHAKE_SECRET** when
+    missing, and writes **OPENSHELL_DRIVERS** only when **--driver** is
+    provided and the file does not already contain a driver choice.
+
+**generate-certs**
+:   Generate local mTLS materials or Kubernetes TLS Secrets.
 
 # SYSTEMD INTEGRATION
 

--- a/deploy/man/openshell-gateway.env.5.md
+++ b/deploy/man/openshell-gateway.env.5.md
@@ -14,9 +14,10 @@ openshell-gateway.env - OpenShell gateway environment configuration
 
 The **openshell-gateway.env** file contains environment variables that
 configure the OpenShell gateway server when running as a systemd user
-service. It is generated automatically on first start by
-**init-gateway-env.sh** and is not overwritten on subsequent starts or
-package upgrades.
+service. Package-managed services generate or repair it automatically on
+first start. Newer packages use **openshell-gateway init-env**; RPM
+packages may also use **init-gateway-env.sh**. The file is not
+overwritten on subsequent starts or package upgrades.
 
 The file uses the standard systemd **EnvironmentFile** format: one
 **KEY=VALUE** pair per line. Lines beginning with **#** are comments.
@@ -43,7 +44,8 @@ the SSH handshake secret).
 **OPENSHELL_SSH_HANDSHAKE_SECRET**
 :   Shared HMAC secret for gateway-to-sandbox SSH handshake
     authentication. Auto-generated as a 32-byte hex string on first
-    start. To regenerate: **openssl rand -hex 32**.
+    start. To regenerate: **openssl rand -hex 32**. The value is a
+    symmetric sandbox RPC secret, not an SSH public/private key pair.
 
 ## Gateway
 

--- a/docs/about/installation.mdx
+++ b/docs/about/installation.mdx
@@ -38,7 +38,30 @@ For detailed driver behavior, refer to [Sandbox Compute Drivers](/reference/sand
 
 On macOS, the install script uses Homebrew. The Homebrew package installs the `openshell` CLI, the gateway binary, and a Homebrew-managed gateway service.
 
-The Homebrew service listens on `https://127.0.0.1:17670` and generates a local mTLS bundle on install. The CLI reads the client bundle from `~/.config/openshell/gateways/openshell/mtls/`.
+The Homebrew service listens on `https://127.0.0.1:17670` and generates a local mTLS bundle on install. The CLI reads the client bundle from `~/.config/openshell/gateways/openshell/mtls/`. The service also runs `openshell-gateway init-env` before startup to create or repair `~/.config/openshell/gateway.env` with local generated secrets and a default `OPENSHELL_DRIVERS=vm` entry when you have not selected a driver.
+
+To force a different local driver, edit `OPENSHELL_DRIVERS` in `~/.config/openshell/gateway.env` and restart the service:
+
+```shell
+env_file="${HOME}/.config/openshell/gateway.env"
+openshell-gateway init-env --output "${env_file}" --driver vm
+if grep -q '^OPENSHELL_DRIVERS=' "${env_file}"; then
+  perl -0pi -e 's/^OPENSHELL_DRIVERS=.*/OPENSHELL_DRIVERS=docker/m' "${env_file}"
+else
+  printf 'OPENSHELL_DRIVERS=docker\n' >> "${env_file}"
+fi
+brew services restart openshell
+```
+
+Use `OPENSHELL_DRIVERS=podman` instead if you run a local Podman service.
+
+To repair an existing env file without changing your selected driver, run:
+
+```shell
+env_file="${HOME}/.config/openshell/gateway.env"
+openshell-gateway init-env --output "${env_file}" --driver vm
+brew services restart openshell
+```
 
 The installer starts the service for you. Use Homebrew service commands when you need to inspect, restart, or stop the gateway service:
 

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -28,7 +28,7 @@ Run the install script:
 curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
 ```
 
-The install script uses Homebrew, RPM, or a Debian package based on your machine. It starts the local gateway server after installation.
+The install script uses Homebrew, RPM, or a Debian package based on your machine. It starts the local gateway server after installation. On macOS, the Homebrew service bootstraps `~/.config/openshell/gateway.env` automatically and defaults to the local MicroVM driver when no driver is configured.
 
 If you prefer [uv](https://docs.astral.sh/uv/):
 

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -24,6 +24,21 @@ You can also set the driver with `OPENSHELL_DRIVERS`. Supported values are `dock
 
 When `--drivers` and `OPENSHELL_DRIVERS` are unset, the gateway auto-detects Kubernetes, then Podman, then Docker by CLI availability or a local Unix socket. The VM driver is never auto-detected; configure it explicitly with `--drivers vm`.
 
+For Homebrew-managed gateways on macOS, the service runs `openshell-gateway init-env` before startup. This creates or repairs `~/.config/openshell/gateway.env`, adds the generated sandbox RPC secret when missing, and writes `OPENSHELL_DRIVERS=vm` only when no driver is already configured. To use Docker or Podman, edit the driver entry and restart:
+
+```shell
+env_file="${HOME}/.config/openshell/gateway.env"
+openshell-gateway init-env --output "${env_file}" --driver vm
+if grep -q '^OPENSHELL_DRIVERS=' "${env_file}"; then
+  perl -0pi -e 's/^OPENSHELL_DRIVERS=.*/OPENSHELL_DRIVERS=docker/m' "${env_file}"
+else
+  printf 'OPENSHELL_DRIVERS=docker\n' >> "${env_file}"
+fi
+brew services restart openshell
+```
+
+Use `OPENSHELL_DRIVERS=podman` instead if you run a local Podman service.
+
 Common gateway options:
 
 | Option | Environment variable | Description |

--- a/install.sh
+++ b/install.sh
@@ -581,6 +581,46 @@ patch_homebrew_formula() {
     mv "$_patched_file" "$_formula_file"
   fi
 
+  if ! grep -q '.config/openshell/gateway.env' "$_formula_file"; then
+    info "patching Homebrew formula to read ~/.config/openshell/gateway.env..."
+    awk '
+      { print }
+      /HOME must be set for Docker TLS bind mounts/ { in_home_block = 1 }
+      in_home_block && /^[[:space:]]*fi$/ {
+        print ""
+        print "      gateway_env=\"${HOME}/.config/openshell/gateway.env\""
+        print "      \"#{opt_bin}/openshell-gateway\" init-env --output \"${gateway_env}\" --driver vm"
+        print "      if [ -f \"${gateway_env}\" ]; then"
+        print "        set -a"
+        print "        . \"${gateway_env}\""
+        print "        set +a"
+        print "      fi"
+        in_home_block = 0
+      }
+    ' "$_formula_file" >"$_patched_file"
+    mv "$_patched_file" "$_formula_file"
+  fi
+
+  if ! grep -q 'init-env --output' "$_formula_file"; then
+    info "patching Homebrew formula to bootstrap gateway.env with openshell-gateway init-env..."
+    awk '
+      BEGIN { inserted = 0; skipping = 0 }
+      /^[[:space:]]*if \[ ! -f "\$\{gateway_env\}" \]; then$/ { skipping = 1; next }
+      skipping && /^[[:space:]]*fi$/ { skipping = 0; next }
+      /^[[:space:]]*if ! grep -q '\''\^OPENSHELL_SSH_HANDSHAKE_SECRET='\'' "\$\{gateway_env\}"; then$/ { skipping = 1; next }
+      skipping { next }
+      /^[[:space:]]*gateway_env="\$\{HOME\}\/\.config\/openshell\/gateway\.env"$/ {
+        print
+        print "      \"#{opt_bin}/openshell-gateway\" init-env --output \"${gateway_env}\" --driver vm"
+        inserted = 1
+        next
+      }
+      { print }
+      END { if (!inserted) exit 1 }
+    ' "$_formula_file" >"$_patched_file"
+    mv "$_patched_file" "$_formula_file"
+  fi
+
 }
 
 start_user_gateway() {

--- a/python/openshell/release_formula_test.py
+++ b/python/openshell/release_formula_test.py
@@ -60,6 +60,11 @@ def test_generate_homebrew_formula_uses_tagged_macos_driver_asset_without_defaul
     assert (
         'docker_tls_dir="${OPENSHELL_DOCKER_TLS_DIR:-${HOME}/.local/state/openshell/homebrew/tls}"'
     ) in formula
+    assert 'gateway_env="${HOME}/.config/openshell/gateway.env"' in formula
+    assert (
+        '"#{opt_bin}/openshell-gateway" init-env --output "${gateway_env}" --driver vm'
+    ) in formula
+    assert '. "${gateway_env}"' in formula
     assert 'export OPENSHELL_DOCKER_TLS_CA="${docker_tls_dir}/ca.crt"' in formula
     assert 'OPENSHELL_DOCKER_TLS_CA: "#{var}/openshell/tls/ca.crt"' not in formula
     assert "entitlements.atomic_write" in formula

--- a/tasks/scripts/release.py
+++ b/tasks/scripts/release.py
@@ -289,6 +289,14 @@ class Openshell < Formula
         exit 1
       fi
 
+      gateway_env="${{HOME}}/.config/openshell/gateway.env"
+      "#{{opt_bin}}/openshell-gateway" init-env --output "${{gateway_env}}" --driver vm
+      if [ -f "${{gateway_env}}" ]; then
+        set -a
+        . "${{gateway_env}}"
+        set +a
+      fi
+
       docker_tls_dir="${{OPENSHELL_DOCKER_TLS_DIR:-${{HOME}}/.local/state/openshell/homebrew/tls}}"
       mkdir -p "${{docker_tls_dir}}/client"
       chmod 700 "${{docker_tls_dir}}" "${{docker_tls_dir}}/client"


### PR DESCRIPTION
## Summary

Improve macOS gateway bootstrapping so Homebrew installs create and source a gateway environment file automatically instead of failing on missing `OPENSHELL_DRIVERS` or `OPENSHELL_SSH_HANDSHAKE_SECRET`.

## Related Issue

None.

## Changes

- Add `openshell-gateway init-env` to create or repair a gateway env file with a generated SSH handshake secret and optional default compute driver.
- Update Homebrew formula generation and `install.sh` patching so macOS services initialize and source `~/.config/openshell/gateway.env`.
- Default macOS Homebrew installs to the `vm` compute driver only when no driver is already configured, preserving user-selected drivers such as `podman` or `docker`.
- Update Debian service startup to repair the gateway env file before certificate generation.
- Document the SSH handshake secret, driver configuration, Homebrew behavior, and repair flow in installation, quickstart, compute driver, architecture, and manpage docs.
- Update release canary and formula tests to exercise the generated env-file path.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (not applicable; packaging/docs bootstrap path)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)