### PR TITLE
refactor(core): eliminate duplicate utilities across crates

### DIFF
--- a/crates/openshell-cli/tests/ensure_providers_integration.rs
+++ b/crates/openshell-cli/tests/ensure_providers_integration.rs
@@ -5,6 +5,11 @@
 //! `--provider` names are auto-created when they match a known provider type,
 //! pass through when they already exist, and error for unrecognised names.
 
+mod helpers;
+
+use helpers::{
+    EnvVarGuard, build_ca, build_client_cert, build_server_cert, install_rustls_provider,
+};
 use openshell_cli::run;
 use openshell_cli::tls::TlsOptions;
 use openshell_core::proto::open_shell_server::{OpenShell, OpenShellServer};
@@ -23,9 +28,6 @@ use openshell_core::proto::{
     SupervisorMessage, UpdateProviderRequest, WatchSandboxRequest,
 };
 use openshell_core::{ObjectId, ObjectName};
-use rcgen::{
-    BasicConstraints, Certificate, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyPair,
-};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -34,60 +36,6 @@ use tokio::sync::{Mutex, mpsc};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::{Certificate as TlsCertificate, Identity, Server, ServerTlsConfig};
 use tonic::{Response, Status};
-
-// ── EnvVarGuard ──────────────────────────────────────────────────────
-
-// Serialise tests that mutate environment variables so concurrent
-// threads don't clobber each other.
-static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-struct SavedVar {
-    key: &'static str,
-    original: Option<String>,
-}
-
-/// Holds the global env lock and restores all modified variables on drop.
-struct EnvVarGuard {
-    vars: Vec<SavedVar>,
-    _lock: std::sync::MutexGuard<'static, ()>,
-}
-
-#[allow(unsafe_code)]
-impl EnvVarGuard {
-    /// Acquire the lock and set one or more environment variables.
-    fn set(pairs: &[(&'static str, &str)]) -> Self {
-        let lock = ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut vars = Vec::with_capacity(pairs.len());
-        for &(key, value) in pairs {
-            let original = std::env::var(key).ok();
-            unsafe {
-                std::env::set_var(key, value);
-            }
-            vars.push(SavedVar { key, original });
-        }
-        Self { vars, _lock: lock }
-    }
-}
-
-#[allow(unsafe_code)]
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        for var in &self.vars {
-            if let Some(value) = &var.original {
-                unsafe {
-                    std::env::set_var(var.key, value);
-                }
-            } else {
-                unsafe {
-                    std::env::remove_var(var.key);
-                }
-            }
-        }
-        // _lock drops here, releasing the mutex
-    }
-}
 
 // ── mock OpenShell server ─────────────────────────────────────────────
 
@@ -557,36 +505,6 @@ impl OpenShell for TestOpenShell {
     ) -> Result<Response<Self::ForwardTcpStream>, Status> {
         Err(Status::unimplemented("not implemented in test"))
     }
-}
-
-// ── TLS helpers ──────────────────────────────────────────────────────
-
-fn install_rustls_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
-
-fn build_ca() -> (Certificate, KeyPair) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
-    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-    let cert = params.self_signed(&key_pair).unwrap();
-    (cert, key_pair)
-}
-
-fn build_server_cert(ca: &Certificate, ca_key: &KeyPair) -> (String, String) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(vec!["localhost".to_string()]).unwrap();
-    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
-    let cert = params.signed_by(&key_pair, ca, ca_key).unwrap();
-    (cert.pem(), key_pair.serialize_pem())
-}
-
-fn build_client_cert(ca: &Certificate, ca_key: &KeyPair) -> (String, String) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
-    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
-    let cert = params.signed_by(&key_pair, ca, ca_key).unwrap();
-    (cert.pem(), key_pair.serialize_pem())
 }
 
 // ── test server fixture ──────────────────────────────────────────────

--- a/crates/openshell-cli/tests/helpers/mod.rs
+++ b/crates/openshell-cli/tests/helpers/mod.rs
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared helpers for CLI integration tests.
+//!
+//! Include this module from a test file with:
+//! ```ignore
+//! mod helpers;
+//! ```
+
+use rcgen::{
+    BasicConstraints, Certificate, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyPair,
+};
+
+// ── EnvVarGuard ──────────────────────────────────────────────────────────────
+
+/// Global mutex that serialises tests which mutate environment variables so
+/// concurrent threads don't clobber each other's state.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+struct SavedVar {
+    key: &'static str,
+    original: Option<String>,
+}
+
+/// RAII guard that acquires `ENV_LOCK` and restores all modified environment
+/// variables on drop.
+pub struct EnvVarGuard {
+    vars: Vec<SavedVar>,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+#[allow(dead_code, unsafe_code)]
+impl EnvVarGuard {
+    /// Acquire the global env-var lock and atomically set one or more
+    /// environment variables.  All variables are restored to their prior
+    /// state (or removed) when the guard is dropped.
+    pub fn set(pairs: &[(&'static str, &str)]) -> Self {
+        let lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut vars = Vec::with_capacity(pairs.len());
+        for &(key, value) in pairs {
+            let original = std::env::var(key).ok();
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            vars.push(SavedVar { key, original });
+        }
+        Self { vars, _lock: lock }
+    }
+}
+
+#[allow(unsafe_code)]
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        for var in &self.vars {
+            if let Some(value) = &var.original {
+                unsafe {
+                    std::env::set_var(var.key, value);
+                }
+            } else {
+                unsafe {
+                    std::env::remove_var(var.key);
+                }
+            }
+        }
+        // _lock drops here, releasing the mutex
+    }
+}
+
+// ── TLS helpers ──────────────────────────────────────────────────────────────
+
+/// Install the `rustls` ring crypto provider as the process default.
+///
+/// Safe to call multiple times — subsequent calls are no-ops.
+#[allow(dead_code)]
+pub fn install_rustls_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+/// Generate a self-signed CA certificate and its key pair.
+#[allow(dead_code)]
+pub fn build_ca() -> (Certificate, KeyPair) {
+    let key_pair = KeyPair::generate().unwrap();
+    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let cert = params.self_signed(&key_pair).unwrap();
+    (cert, key_pair)
+}
+
+/// Generate a server certificate signed by `ca`, valid for `localhost`.
+///
+/// Returns `(cert_pem, key_pem)`.
+#[allow(dead_code)]
+pub fn build_server_cert(ca: &Certificate, ca_key: &KeyPair) -> (String, String) {
+    let key_pair = KeyPair::generate().unwrap();
+    let mut params = CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+    let cert = params.signed_by(&key_pair, ca, ca_key).unwrap();
+    (cert.pem(), key_pair.serialize_pem())
+}
+
+/// Generate a client authentication certificate signed by `ca`.
+///
+/// Returns `(cert_pem, key_pem)`.
+#[allow(dead_code)]
+pub fn build_client_cert(ca: &Certificate, ca_key: &KeyPair) -> (String, String) {
+    let key_pair = KeyPair::generate().unwrap();
+    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
+    let cert = params.signed_by(&key_pair, ca, ca_key).unwrap();
+    (cert.pem(), key_pair.serialize_pem())
+}

--- a/crates/openshell-cli/tests/mtls_integration.rs
+++ b/crates/openshell-cli/tests/mtls_integration.rs
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod helpers;
+
+use helpers::{
+    EnvVarGuard, build_ca, build_client_cert, build_server_cert, install_rustls_provider,
+};
 use openshell_cli::tls::{TlsOptions, grpc_client};
 use openshell_core::proto::{
     CreateProviderRequest, CreateSshSessionRequest, CreateSshSessionResponse,
@@ -10,9 +15,6 @@ use openshell_core::proto::{
     UpdateProviderRequest,
     open_shell_server::{OpenShell, OpenShellServer},
 };
-use rcgen::{
-    BasicConstraints, Certificate, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyPair,
-};
 use tempfile::tempdir;
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
@@ -21,41 +23,6 @@ use tonic::{
     Response, Status,
     transport::{Certificate as TlsCertificate, Identity, Server, ServerTlsConfig},
 };
-
-struct EnvVarGuard {
-    key: &'static str,
-    original: Option<String>,
-}
-
-#[allow(unsafe_code)]
-impl EnvVarGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        let original = std::env::var(key).ok();
-        unsafe {
-            std::env::set_var(key, value);
-        }
-        Self { key, original }
-    }
-}
-
-#[allow(unsafe_code)]
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        if let Some(value) = &self.original {
-            unsafe {
-                std::env::set_var(self.key, value);
-            }
-        } else {
-            unsafe {
-                std::env::remove_var(self.key);
-            }
-        }
-    }
-}
-
-fn install_rustls_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
 
 #[derive(Clone, Default)]
 struct TestOpenShell;
@@ -450,34 +417,6 @@ impl OpenShell for TestOpenShell {
     }
 }
 
-fn build_ca() -> (Certificate, KeyPair) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
-    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-    let cert = params.self_signed(&key_pair).unwrap();
-    (cert, key_pair)
-}
-
-fn build_server_cert(ca: &Certificate, ca_key: &KeyPair) -> (String, String) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(vec!["localhost".to_string()]).unwrap();
-    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
-    let cert = params.signed_by(&key_pair, ca, ca_key).unwrap();
-    let cert_pem = cert.pem();
-    let key_pem = key_pair.serialize_pem();
-    (cert_pem, key_pem)
-}
-
-fn build_client_cert(ca: &Certificate, ca_key: &KeyPair) -> (String, String) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
-    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
-    let cert = params.signed_by(&key_pair, ca, ca_key).unwrap();
-    let cert_pem = cert.pem();
-    let key_pem = key_pair.serialize_pem();
-    (cert_pem, key_pem)
-}
-
 async fn run_server(
     server_cert: String,
     server_key: String,
@@ -544,7 +483,8 @@ async fn cli_requires_client_cert_for_https() {
     let dir = tempdir().unwrap();
     // Point XDG_CONFIG_HOME at the isolated temp dir so that default_tls_dir
     // cannot discover real client certs from the developer's machine.
-    let _xdg_env = EnvVarGuard::set("XDG_CONFIG_HOME", &dir.path().to_string_lossy());
+    let xdg_path = dir.path().to_string_lossy();
+    let _xdg_env = EnvVarGuard::set(&[("XDG_CONFIG_HOME", &xdg_path)]);
     let ca_path = dir.path().join("ca.crt");
     std::fs::write(&ca_path, ca_cert).unwrap();
 

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod helpers;
+
+use helpers::{
+    EnvVarGuard, build_ca, build_client_cert, build_server_cert, install_rustls_provider,
+};
 use openshell_cli::run;
 use openshell_cli::tls::TlsOptions;
 use openshell_core::proto::open_shell_server::{OpenShell, OpenShellServer};
@@ -19,9 +24,6 @@ use openshell_core::proto::{
     SupervisorMessage, UpdateProviderRequest, WatchSandboxRequest,
 };
 use openshell_core::{ObjectId, ObjectName};
-use rcgen::{
-    BasicConstraints, Certificate, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyPair,
-};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -30,37 +32,6 @@ use tokio::sync::{Mutex, mpsc};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::{Certificate as TlsCertificate, Identity, Server, ServerTlsConfig};
 use tonic::{Response, Status};
-
-struct EnvVarGuard {
-    key: &'static str,
-    original: Option<String>,
-}
-
-#[allow(unsafe_code)]
-impl EnvVarGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        let original = std::env::var(key).ok();
-        unsafe {
-            std::env::set_var(key, value);
-        }
-        Self { key, original }
-    }
-}
-
-#[allow(unsafe_code)]
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        if let Some(value) = &self.original {
-            unsafe {
-                std::env::set_var(self.key, value);
-            }
-        } else {
-            unsafe {
-                std::env::remove_var(self.key);
-            }
-        }
-    }
-}
 
 #[derive(Clone, Default)]
 struct ProviderState {
@@ -668,34 +639,6 @@ impl OpenShell for TestOpenShell {
     }
 }
 
-fn install_rustls_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
-
-fn build_ca() -> (Certificate, KeyPair) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
-    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-    let cert = params.self_signed(&key_pair).unwrap();
-    (cert, key_pair)
-}
-
-fn build_server_cert(ca: &Certificate, ca_key: &KeyPair) -> (String, String) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(vec!["localhost".to_string()]).unwrap();
-    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
-    let cert = params.signed_by(&key_pair, ca, ca_key).unwrap();
-    (cert.pem(), key_pair.serialize_pem())
-}
-
-fn build_client_cert(ca: &Certificate, ca_key: &KeyPair) -> (String, String) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
-    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
-    let cert = params.signed_by(&key_pair, ca, ca_key).unwrap();
-    (cert.pem(), key_pair.serialize_pem())
-}
-
 /// Test fixture: TLS-enabled server with matching client certs.
 struct TestServer {
     endpoint: String,
@@ -1146,7 +1089,7 @@ async fn provider_create_rejects_key_only_credentials_without_local_env_value() 
 #[tokio::test]
 async fn provider_create_supports_generic_type_and_env_lookup_credentials() {
     let ts = run_server().await;
-    let _guard = EnvVarGuard::set("NAV_GENERIC_TEST_KEY", "generic-value");
+    let _guard = EnvVarGuard::set(&[("NAV_GENERIC_TEST_KEY", "generic-value")]);
 
     run::provider_create(
         &ts.endpoint,
@@ -1204,7 +1147,7 @@ async fn provider_create_rejects_combined_from_existing_and_credentials() {
 #[tokio::test]
 async fn provider_create_rejects_empty_env_var_for_key_only_credential() {
     let ts = run_server().await;
-    let _guard = EnvVarGuard::set("NAV_EMPTY_ENV_KEY", "");
+    let _guard = EnvVarGuard::set(&[("NAV_EMPTY_ENV_KEY", "")]);
 
     let err = run::provider_create(
         &ts.endpoint,
@@ -1228,7 +1171,7 @@ async fn provider_create_rejects_empty_env_var_for_key_only_credential() {
 #[tokio::test]
 async fn provider_create_supports_nvidia_type_with_nvidia_api_key() {
     let ts = run_server().await;
-    let _guard = EnvVarGuard::set("NVIDIA_API_KEY", "nvapi-live-test");
+    let _guard = EnvVarGuard::set(&[("NVIDIA_API_KEY", "nvapi-live-test")]);
 
     run::provider_create(
         &ts.endpoint,

--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod helpers;
+
+use helpers::{
+    EnvVarGuard, build_ca, build_client_cert, build_server_cert, install_rustls_provider,
+};
 use openshell_bootstrap::load_last_sandbox;
 use openshell_cli::run;
 use openshell_cli::tls::TlsOptions;
@@ -20,9 +25,6 @@ use openshell_core::proto::{
     ServiceStatus, SupervisorMessage, UpdateProviderRequest, WatchSandboxRequest,
     sandbox_stream_event,
 };
-use rcgen::{
-    BasicConstraints, Certificate, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyPair,
-};
 use std::collections::HashMap;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -33,53 +35,6 @@ use tokio::sync::{Mutex, mpsc};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::{Certificate as TlsCertificate, Identity, Server, ServerTlsConfig};
 use tonic::{Response, Status};
-
-static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-struct SavedVar {
-    key: &'static str,
-    original: Option<String>,
-}
-
-struct EnvVarGuard {
-    vars: Vec<SavedVar>,
-    _lock: std::sync::MutexGuard<'static, ()>,
-}
-
-#[allow(unsafe_code)]
-impl EnvVarGuard {
-    fn set(pairs: &[(&'static str, String)]) -> Self {
-        let lock = ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut vars = Vec::with_capacity(pairs.len());
-        for (key, value) in pairs {
-            let original = std::env::var(key).ok();
-            unsafe {
-                std::env::set_var(key, value);
-            }
-            vars.push(SavedVar { key, original });
-        }
-        Self { vars, _lock: lock }
-    }
-}
-
-#[allow(unsafe_code)]
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        for var in &self.vars {
-            if let Some(value) = &var.original {
-                unsafe {
-                    std::env::set_var(var.key, value);
-                }
-            } else {
-                unsafe {
-                    std::env::remove_var(var.key);
-                }
-            }
-        }
-    }
-}
 
 #[derive(Clone, Default)]
 struct SandboxState {
@@ -536,34 +491,6 @@ impl OpenShell for TestOpenShell {
     }
 }
 
-fn install_rustls_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
-
-fn build_ca() -> (Certificate, KeyPair) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
-    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-    let cert = params.self_signed(&key_pair).unwrap();
-    (cert, key_pair)
-}
-
-fn build_server_cert(ca: &Certificate, ca_key: &KeyPair) -> (String, String) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(vec!["localhost".to_string()]).unwrap();
-    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
-    let cert = params.signed_by(&key_pair, ca, ca_key).unwrap();
-    (cert.pem(), key_pair.serialize_pem())
-}
-
-fn build_client_cert(ca: &Certificate, ca_key: &KeyPair) -> (String, String) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
-    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
-    let cert = params.signed_by(&key_pair, ca, ca_key).unwrap();
-    (cert.pem(), key_pair.serialize_pem())
-}
-
 struct TestServer {
     endpoint: String,
     tls: TlsOptions,
@@ -636,15 +563,9 @@ fn test_env(fake_ssh_dir: &TempDir, xdg_dir: &TempDir) -> EnvVarGuard {
         fake_ssh_dir.path().display(),
         std::env::var("PATH").unwrap_or_default()
     );
+    let xdg = xdg_dir.path().to_str().unwrap().to_string();
 
-    EnvVarGuard::set(&[
-        ("PATH", path),
-        (
-            "XDG_CONFIG_HOME",
-            xdg_dir.path().to_str().unwrap().to_string(),
-        ),
-        ("HOME", xdg_dir.path().to_str().unwrap().to_string()),
-    ])
+    EnvVarGuard::set(&[("PATH", &path), ("XDG_CONFIG_HOME", &xdg), ("HOME", &xdg)])
 }
 
 async fn deleted_names(server: &TestServer) -> Vec<Vec<String>> {

--- a/crates/openshell-cli/tests/sandbox_name_fallback_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_name_fallback_integration.rs
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod helpers;
+
+use helpers::{
+    EnvVarGuard, build_ca, build_client_cert, build_server_cert, install_rustls_provider,
+};
 use openshell_bootstrap::{load_last_sandbox, save_last_sandbox};
 use openshell_cli::run;
 use openshell_cli::tls::TlsOptions;
@@ -19,9 +24,6 @@ use openshell_core::proto::{
     SandboxStreamEvent, ServiceStatus, SupervisorMessage, UpdateProviderRequest,
     WatchSandboxRequest,
 };
-use rcgen::{
-    BasicConstraints, Certificate, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyPair,
-};
 use std::sync::Arc;
 use tempfile::TempDir;
 use tokio::net::TcpListener;
@@ -29,50 +31,6 @@ use tokio::sync::{Mutex, mpsc};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::{Certificate as TlsCertificate, Identity, Server, ServerTlsConfig};
 use tonic::{Response, Status};
-
-// Serialise tests that mutate XDG_CONFIG_HOME so concurrent threads
-// don't clobber each other's environment.
-static XDG_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-struct EnvVarGuard {
-    key: &'static str,
-    original: Option<String>,
-    _xdg_lock: std::sync::MutexGuard<'static, ()>,
-}
-
-#[allow(unsafe_code)]
-impl EnvVarGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        let lock = XDG_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let original = std::env::var(key).ok();
-        unsafe {
-            std::env::set_var(key, value);
-        }
-        Self {
-            key,
-            original,
-            _xdg_lock: lock,
-        }
-    }
-}
-
-#[allow(unsafe_code)]
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        if let Some(value) = &self.original {
-            unsafe {
-                std::env::set_var(self.key, value);
-            }
-        } else {
-            unsafe {
-                std::env::remove_var(self.key);
-            }
-        }
-        // _xdg_lock drops here, releasing the mutex
-    }
-}
 
 // ── mock OpenShell server ─────────────────────────────────────────────
 
@@ -471,36 +429,6 @@ impl OpenShell for TestOpenShell {
     }
 }
 
-// ── helpers ───────────────────────────────────────────────────────────
-
-fn install_rustls_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
-
-fn build_ca() -> (Certificate, KeyPair) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
-    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-    let cert = params.self_signed(&key_pair).unwrap();
-    (cert, key_pair)
-}
-
-fn build_server_cert(ca: &Certificate, ca_key: &KeyPair) -> (String, String) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(vec!["localhost".to_string()]).unwrap();
-    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
-    let cert = params.signed_by(&key_pair, ca, ca_key).unwrap();
-    (cert.pem(), key_pair.serialize_pem())
-}
-
-fn build_client_cert(ca: &Certificate, ca_key: &KeyPair) -> (String, String) {
-    let key_pair = KeyPair::generate().unwrap();
-    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
-    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
-    let cert = params.signed_by(&key_pair, ca, ca_key).unwrap();
-    (cert.pem(), key_pair.serialize_pem())
-}
-
 struct TestServer {
     endpoint: String,
     tls: TlsOptions,
@@ -597,7 +525,7 @@ async fn sandbox_get_policy_only_round_trip() {
 async fn sandbox_get_with_persisted_last_sandbox() {
     let ts = run_server().await;
     let xdg_dir = tempfile::tempdir().unwrap();
-    let _guard = EnvVarGuard::set("XDG_CONFIG_HOME", xdg_dir.path().to_str().unwrap());
+    let _guard = EnvVarGuard::set(&[("XDG_CONFIG_HOME", xdg_dir.path().to_str().unwrap())]);
 
     // Persist a last-used sandbox for "integration-cluster".
     save_last_sandbox("integration-cluster", "persisted-sb")
@@ -626,7 +554,7 @@ async fn sandbox_get_with_persisted_last_sandbox() {
 async fn explicit_name_takes_precedence_over_persisted() {
     let ts = run_server().await;
     let xdg_dir = tempfile::tempdir().unwrap();
-    let _guard = EnvVarGuard::set("XDG_CONFIG_HOME", xdg_dir.path().to_str().unwrap());
+    let _guard = EnvVarGuard::set(&[("XDG_CONFIG_HOME", xdg_dir.path().to_str().unwrap())]);
 
     // Persist one name, but supply a different one explicitly.
     save_last_sandbox("my-cluster", "old-sandbox").expect("save should succeed");

--- a/crates/openshell-core/src/driver_utils.rs
+++ b/crates/openshell-core/src/driver_utils.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Utility helpers shared across compute-driver crates.
+
+use crate::proto::compute::v1::DriverSandbox;
+
+/// Return the effective log level for a sandbox.
+///
+/// Uses the level from the sandbox spec when non-empty, falling back to
+/// `default_level` otherwise.
+pub fn sandbox_log_level(sandbox: &DriverSandbox, default_level: &str) -> String {
+    sandbox
+        .spec
+        .as_ref()
+        .map(|spec| spec.log_level.as_str())
+        .filter(|level| !level.is_empty())
+        .unwrap_or(default_level)
+        .to_string()
+}

--- a/crates/openshell-core/src/error.rs
+++ b/crates/openshell-core/src/error.rs
@@ -120,3 +120,13 @@ pub enum ComputeDriverError {
     #[error("{0}")]
     Message(String),
 }
+
+impl From<ComputeDriverError> for tonic::Status {
+    fn from(err: ComputeDriverError) -> Self {
+        match err {
+            ComputeDriverError::AlreadyExists => Self::already_exists("sandbox already exists"),
+            ComputeDriverError::Precondition(m) => Self::failed_precondition(m),
+            ComputeDriverError::Message(m) => Self::internal(m),
+        }
+    }
+}

--- a/crates/openshell-core/src/lib.rs
+++ b/crates/openshell-core/src/lib.rs
@@ -10,6 +10,7 @@
 //! - Build version metadata
 
 pub mod config;
+pub mod driver_utils;
 pub mod error;
 pub mod forward;
 pub mod gpu;
@@ -19,7 +20,9 @@ pub mod metadata;
 pub mod net;
 pub mod paths;
 pub mod proto;
+pub mod sandbox_env;
 pub mod settings;
+pub mod time;
 
 pub use config::{ComputeDriverKind, Config, OidcConfig, TlsConfig};
 pub use error::{ComputeDriverError, Error, Result};

--- a/crates/openshell-core/src/sandbox_env.rs
+++ b/crates/openshell-core/src/sandbox_env.rs
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Environment-variable names used to configure the sandbox supervisor.
+//!
+//! These constants are the shared protocol between the compute drivers (which
+//! set the variables when launching a sandbox container/VM) and the sandbox
+//! supervisor process (which reads them on startup).  Using constants here
+//! prevents typos from producing silently broken sandboxes.
+
+/// Name of the sandbox (used for policy sync and identification).
+pub const SANDBOX: &str = "OPENSHELL_SANDBOX";
+
+/// gRPC endpoint of the `OpenShell` gateway that the sandbox reports to.
+pub const ENDPOINT: &str = "OPENSHELL_ENDPOINT";
+
+/// Unique identifier of the sandbox being supervised.
+pub const SANDBOX_ID: &str = "OPENSHELL_SANDBOX_ID";
+
+/// Filesystem path to the UNIX socket used for the in-sandbox SSH server.
+pub const SSH_SOCKET_PATH: &str = "OPENSHELL_SSH_SOCKET_PATH";
+
+/// Shared secret used for HMAC-based SSH handshake authentication.
+pub const SSH_HANDSHAKE_SECRET: &str = "OPENSHELL_SSH_HANDSHAKE_SECRET";
+
+/// Allowed clock-skew tolerance in seconds for the SSH handshake.
+pub const SSH_HANDSHAKE_SKEW_SECS: &str = "OPENSHELL_SSH_HANDSHAKE_SKEW_SECS";
+
+/// Log level for the sandbox supervisor (e.g. `"debug"`, `"info"`, `"warn"`).
+pub const LOG_LEVEL: &str = "OPENSHELL_LOG_LEVEL";
+
+/// Shell command to run inside the sandbox.
+pub const SANDBOX_COMMAND: &str = "OPENSHELL_SANDBOX_COMMAND";
+
+/// Path to the CA certificate for mTLS communication with the gateway.
+pub const TLS_CA: &str = "OPENSHELL_TLS_CA";
+
+/// Path to the client certificate for mTLS communication with the gateway.
+pub const TLS_CERT: &str = "OPENSHELL_TLS_CERT";
+
+/// Path to the private key for mTLS communication with the gateway.
+pub const TLS_KEY: &str = "OPENSHELL_TLS_KEY";

--- a/crates/openshell-core/src/time.rs
+++ b/crates/openshell-core/src/time.rs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Time utilities shared across `OpenShell` crates.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Return the current Unix timestamp in milliseconds, saturating to [`i64::MAX`]
+/// on overflow.  Returns `0` if the system clock is before the Unix epoch.
+///
+/// Prefer this over local implementations of the same pattern.
+pub fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+}

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -894,7 +894,7 @@ fn build_environment(sandbox: &DriverSandbox, config: &DockerDriverRuntimeConfig
         ("TERM".to_string(), "xterm".to_string()),
         (
             "OPENSHELL_LOG_LEVEL".to_string(),
-            sandbox_log_level(sandbox, &config.log_level),
+            openshell_core::driver_utils::sandbox_log_level(sandbox, &config.log_level),
         ),
     ]);
 
@@ -906,17 +906,23 @@ fn build_environment(sandbox: &DriverSandbox, config: &DockerDriverRuntimeConfig
     }
 
     environment.insert(
-        "OPENSHELL_ENDPOINT".to_string(),
+        openshell_core::sandbox_env::ENDPOINT.to_string(),
         config.grpc_endpoint.clone(),
     );
-    environment.insert("OPENSHELL_SANDBOX_ID".to_string(), sandbox.id.clone());
-    environment.insert("OPENSHELL_SANDBOX".to_string(), sandbox.name.clone());
     environment.insert(
-        "OPENSHELL_SSH_SOCKET_PATH".to_string(),
+        openshell_core::sandbox_env::SANDBOX_ID.to_string(),
+        sandbox.id.clone(),
+    );
+    environment.insert(
+        openshell_core::sandbox_env::SANDBOX.to_string(),
+        sandbox.name.clone(),
+    );
+    environment.insert(
+        openshell_core::sandbox_env::SSH_SOCKET_PATH.to_string(),
         config.ssh_socket_path.clone(),
     );
     environment.insert(
-        "OPENSHELL_SANDBOX_COMMAND".to_string(),
+        openshell_core::sandbox_env::SANDBOX_COMMAND.to_string(),
         SANDBOX_COMMAND.to_string(),
     );
     // The root supervisor executes namespace helpers during bootstrap; keep
@@ -924,15 +930,15 @@ fn build_environment(sandbox: &DriverSandbox, config: &DockerDriverRuntimeConfig
     environment.insert("PATH".to_string(), SUPERVISOR_PATH.to_string());
     if config.guest_tls.is_some() {
         environment.insert(
-            "OPENSHELL_TLS_CA".to_string(),
+            openshell_core::sandbox_env::TLS_CA.to_string(),
             TLS_CA_MOUNT_PATH.to_string(),
         );
         environment.insert(
-            "OPENSHELL_TLS_CERT".to_string(),
+            openshell_core::sandbox_env::TLS_CERT.to_string(),
             TLS_CERT_MOUNT_PATH.to_string(),
         );
         environment.insert(
-            "OPENSHELL_TLS_KEY".to_string(),
+            openshell_core::sandbox_env::TLS_KEY.to_string(),
             TLS_KEY_MOUNT_PATH.to_string(),
         );
     }
@@ -1045,16 +1051,6 @@ fn require_sandbox_identifier(sandbox_id: &str, sandbox_name: &str) -> Result<()
         ));
     }
     Ok(())
-}
-
-fn sandbox_log_level(sandbox: &DriverSandbox, default_level: &str) -> String {
-    sandbox
-        .spec
-        .as_ref()
-        .map(|spec| spec.log_level.as_str())
-        .filter(|level| !level.is_empty())
-        .unwrap_or(default_level)
-        .to_string()
 }
 
 fn docker_container_openshell_endpoint(endpoint: &str, host: &str, port: u16) -> String {

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -47,6 +47,16 @@ impl KubernetesDriverError {
     }
 }
 
+impl From<KubernetesDriverError> for openshell_core::ComputeDriverError {
+    fn from(err: KubernetesDriverError) -> Self {
+        match err {
+            KubernetesDriverError::AlreadyExists => Self::AlreadyExists,
+            KubernetesDriverError::Precondition(m) => Self::Precondition(m),
+            KubernetesDriverError::Message(m) => Self::Message(m),
+        }
+    }
+}
+
 /// Timeout for individual Kubernetes API calls (create, delete, get).
 /// This prevents gRPC handlers from blocking indefinitely when the k8s
 /// API server is unreachable or slow.
@@ -984,7 +994,10 @@ struct SandboxPodParams<'a> {
 fn spec_pod_env(spec: Option<&SandboxSpec>) -> std::collections::HashMap<String, String> {
     let mut env = spec.map_or_else(Default::default, |s| s.environment.clone());
     if let Some(s) = spec.filter(|s| !s.log_level.is_empty()) {
-        env.insert("OPENSHELL_LOG_LEVEL".to_string(), s.log_level.clone());
+        env.insert(
+            openshell_core::sandbox_env::LOG_LEVEL.to_string(),
+            s.log_level.clone(),
+        );
     }
     env
 }
@@ -1339,31 +1352,47 @@ fn apply_required_env(
     ssh_handshake_skew_secs: u64,
     tls_enabled: bool,
 ) {
-    upsert_env(env, "OPENSHELL_SANDBOX_ID", sandbox_id);
-    upsert_env(env, "OPENSHELL_SANDBOX", sandbox_name);
-    upsert_env(env, "OPENSHELL_ENDPOINT", grpc_endpoint);
-    upsert_env(env, "OPENSHELL_SANDBOX_COMMAND", "sleep infinity");
-    if !ssh_socket_path.is_empty() {
-        upsert_env(env, "OPENSHELL_SSH_SOCKET_PATH", ssh_socket_path);
-    }
-    upsert_env(env, "OPENSHELL_SSH_HANDSHAKE_SECRET", ssh_handshake_secret);
+    upsert_env(env, openshell_core::sandbox_env::SANDBOX_ID, sandbox_id);
+    upsert_env(env, openshell_core::sandbox_env::SANDBOX, sandbox_name);
+    upsert_env(env, openshell_core::sandbox_env::ENDPOINT, grpc_endpoint);
     upsert_env(
         env,
-        "OPENSHELL_SSH_HANDSHAKE_SKEW_SECS",
+        openshell_core::sandbox_env::SANDBOX_COMMAND,
+        "sleep infinity",
+    );
+    if !ssh_socket_path.is_empty() {
+        upsert_env(
+            env,
+            openshell_core::sandbox_env::SSH_SOCKET_PATH,
+            ssh_socket_path,
+        );
+    }
+    upsert_env(
+        env,
+        openshell_core::sandbox_env::SSH_HANDSHAKE_SECRET,
+        ssh_handshake_secret,
+    );
+    upsert_env(
+        env,
+        openshell_core::sandbox_env::SSH_HANDSHAKE_SKEW_SECS,
         &ssh_handshake_skew_secs.to_string(),
     );
     // TLS cert paths for sandbox-to-server mTLS. Only set when TLS is enabled
     // and the client TLS secret is mounted into the sandbox pod.
     if tls_enabled {
-        upsert_env(env, "OPENSHELL_TLS_CA", "/etc/openshell-tls/client/ca.crt");
         upsert_env(
             env,
-            "OPENSHELL_TLS_CERT",
+            openshell_core::sandbox_env::TLS_CA,
+            "/etc/openshell-tls/client/ca.crt",
+        );
+        upsert_env(
+            env,
+            openshell_core::sandbox_env::TLS_CERT,
             "/etc/openshell-tls/client/tls.crt",
         );
         upsert_env(
             env,
-            "OPENSHELL_TLS_KEY",
+            openshell_core::sandbox_env::TLS_KEY,
             "/etc/openshell-tls/client/tls.key",
         );
     }

--- a/crates/openshell-driver-kubernetes/src/grpc.rs
+++ b/crates/openshell-driver-kubernetes/src/grpc.rs
@@ -14,7 +14,7 @@ use openshell_core::proto::compute::v1::{
 use std::pin::Pin;
 use tonic::{Request, Response, Status};
 
-use crate::{KubernetesComputeDriver, KubernetesDriverError};
+use crate::KubernetesComputeDriver;
 
 #[derive(Debug, Clone)]
 pub struct ComputeDriverService {
@@ -103,7 +103,7 @@ impl ComputeDriver for ComputeDriverService {
         self.driver
             .create_sandbox(&sandbox)
             .await
-            .map_err(status_from_driver_error)?;
+            .map_err(|e| Status::from(openshell_core::ComputeDriverError::from(e)))?;
         Ok(Response::new(CreateSandboxResponse {}))
     }
 
@@ -146,23 +146,18 @@ impl ComputeDriver for ComputeDriverService {
     }
 }
 
-fn status_from_driver_error(err: KubernetesDriverError) -> Status {
-    match err {
-        KubernetesDriverError::AlreadyExists => Status::already_exists("sandbox already exists"),
-        KubernetesDriverError::Precondition(message) => Status::failed_precondition(message),
-        KubernetesDriverError::Message(message) => Status::internal(message),
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::KubernetesDriverError;
+    use openshell_core::ComputeDriverError;
+    use tonic::Status;
 
     #[test]
     fn precondition_driver_errors_map_to_failed_precondition_status() {
-        let status = status_from_driver_error(KubernetesDriverError::Precondition(
+        let status: Status = ComputeDriverError::from(KubernetesDriverError::Precondition(
             "sandbox agent pod IP is not available".to_string(),
-        ));
+        ))
+        .into();
 
         assert_eq!(status.code(), tonic::Code::FailedPrecondition);
         assert_eq!(status.message(), "sandbox agent pod IP is not available");
@@ -170,7 +165,7 @@ mod tests {
 
     #[test]
     fn already_exists_driver_errors_map_to_already_exists_status() {
-        let status = status_from_driver_error(KubernetesDriverError::AlreadyExists);
+        let status: Status = ComputeDriverError::from(KubernetesDriverError::AlreadyExists).into();
 
         assert_eq!(status.code(), tonic::Code::AlreadyExists);
         assert_eq!(status.message(), "sandbox already exists");

--- a/crates/openshell-driver-podman/src/container.rs
+++ b/crates/openshell-driver-podman/src/container.rs
@@ -252,7 +252,10 @@ fn build_env(
     // 1. User-supplied environment (lowest priority).
     if let Some(s) = spec {
         if !s.log_level.is_empty() {
-            env.insert("OPENSHELL_LOG_LEVEL".into(), s.log_level.clone());
+            env.insert(
+                openshell_core::sandbox_env::LOG_LEVEL.into(),
+                s.log_level.clone(),
+            );
         }
         for (k, v) in &s.environment {
             env.insert(k.clone(), v.clone());
@@ -265,30 +268,51 @@ fn build_env(
     }
 
     // 2. Required driver vars (highest priority -- always overwrite).
-    env.insert("OPENSHELL_SANDBOX".into(), sandbox.name.clone());
-    env.insert("OPENSHELL_SANDBOX_ID".into(), sandbox.id.clone());
-    env.insert("OPENSHELL_ENDPOINT".into(), config.grpc_endpoint.clone());
     env.insert(
-        "OPENSHELL_SSH_SOCKET_PATH".into(),
+        openshell_core::sandbox_env::SANDBOX.into(),
+        sandbox.name.clone(),
+    );
+    env.insert(
+        openshell_core::sandbox_env::SANDBOX_ID.into(),
+        sandbox.id.clone(),
+    );
+    env.insert(
+        openshell_core::sandbox_env::ENDPOINT.into(),
+        config.grpc_endpoint.clone(),
+    );
+    env.insert(
+        openshell_core::sandbox_env::SSH_SOCKET_PATH.into(),
         config.sandbox_ssh_socket_path.clone(),
     );
     // NOTE: The SSH handshake secret is injected via a Podman secret
     // (see the "secrets" field below) rather than a plaintext env var.
     // This prevents exposure through `podman inspect`.
     env.insert(
-        "OPENSHELL_SSH_HANDSHAKE_SKEW_SECS".into(),
+        openshell_core::sandbox_env::SSH_HANDSHAKE_SKEW_SECS.into(),
         config.ssh_handshake_skew_secs.to_string(),
     );
     env.insert("OPENSHELL_CONTAINER_IMAGE".into(), image.to_string());
-    env.insert("OPENSHELL_SANDBOX_COMMAND".into(), "sleep infinity".into());
+    env.insert(
+        openshell_core::sandbox_env::SANDBOX_COMMAND.into(),
+        "sleep infinity".into(),
+    );
 
     // 3. TLS client cert paths (when mTLS is enabled). These point to
     //    the container-side mount paths where the cert files are
     //    bind-mounted from the host.
     if config.tls_enabled() {
-        env.insert("OPENSHELL_TLS_CA".into(), TLS_CA_MOUNT_PATH.into());
-        env.insert("OPENSHELL_TLS_CERT".into(), TLS_CERT_MOUNT_PATH.into());
-        env.insert("OPENSHELL_TLS_KEY".into(), TLS_KEY_MOUNT_PATH.into());
+        env.insert(
+            openshell_core::sandbox_env::TLS_CA.into(),
+            TLS_CA_MOUNT_PATH.into(),
+        );
+        env.insert(
+            openshell_core::sandbox_env::TLS_CERT.into(),
+            TLS_CERT_MOUNT_PATH.into(),
+        );
+        env.insert(
+            openshell_core::sandbox_env::TLS_KEY.into(),
+            TLS_KEY_MOUNT_PATH.into(),
+        );
     }
 
     env
@@ -498,7 +522,7 @@ pub fn build_container_spec(sandbox: &DriverSandbox, config: &PodmanComputeConfi
         // The secret is created by the driver before the container
         // (see `PodmanComputeDriver::create_sandbox`).
         secret_env: BTreeMap::from([(
-            "OPENSHELL_SSH_HANDSHAKE_SECRET".into(),
+            openshell_core::sandbox_env::SSH_HANDSHAKE_SECRET.into(),
             secret_name(&sandbox.id),
         )]),
         stop_timeout: config.stop_timeout_secs,
@@ -855,7 +879,9 @@ mod tests {
 
         let env_map = spec["env"].as_object().expect("env should be an object");
         assert_eq!(
-            env_map.get("OPENSHELL_SANDBOX").and_then(|v| v.as_str()),
+            env_map
+                .get(openshell_core::sandbox_env::SANDBOX)
+                .and_then(|v| v.as_str()),
             Some("my-sandbox"),
         );
     }

--- a/crates/openshell-driver-podman/src/grpc.rs
+++ b/crates/openshell-driver-podman/src/grpc.rs
@@ -15,7 +15,6 @@ use std::pin::Pin;
 use tonic::{Request, Response, Status};
 
 use crate::PodmanComputeDriver;
-use openshell_core::ComputeDriverError;
 
 #[derive(Debug, Clone)]
 pub struct ComputeDriverService {
@@ -38,7 +37,7 @@ impl ComputeDriver for ComputeDriverService {
         self.driver
             .capabilities()
             .map(Response::new)
-            .map_err(status_from_driver_error)
+            .map_err(Status::from)
     }
 
     async fn validate_sandbox_create(
@@ -51,7 +50,7 @@ impl ComputeDriver for ComputeDriverService {
             .ok_or_else(|| Status::invalid_argument("sandbox is required"))?;
         self.driver
             .validate_sandbox_create(&sandbox)
-            .map_err(status_from_driver_error)?;
+            .map_err(Status::from)?;
         Ok(Response::new(ValidateSandboxCreateResponse {}))
     }
 
@@ -68,7 +67,7 @@ impl ComputeDriver for ComputeDriverService {
             .driver
             .get_sandbox(&request.sandbox_name)
             .await
-            .map_err(status_from_driver_error)?
+            .map_err(Status::from)?
             .ok_or_else(|| Status::not_found("sandbox not found"))?;
 
         if !request.sandbox_id.is_empty() && request.sandbox_id != sandbox.id {
@@ -86,11 +85,7 @@ impl ComputeDriver for ComputeDriverService {
         &self,
         _request: Request<ListSandboxesRequest>,
     ) -> Result<Response<ListSandboxesResponse>, Status> {
-        let sandboxes = self
-            .driver
-            .list_sandboxes()
-            .await
-            .map_err(status_from_driver_error)?;
+        let sandboxes = self.driver.list_sandboxes().await.map_err(Status::from)?;
         Ok(Response::new(ListSandboxesResponse { sandboxes }))
     }
 
@@ -105,7 +100,7 @@ impl ComputeDriver for ComputeDriverService {
         self.driver
             .create_sandbox(&sandbox)
             .await
-            .map_err(status_from_driver_error)?;
+            .map_err(Status::from)?;
         Ok(Response::new(CreateSandboxResponse {}))
     }
 
@@ -120,7 +115,7 @@ impl ComputeDriver for ComputeDriverService {
         self.driver
             .stop_sandbox(&request.sandbox_name)
             .await
-            .map_err(status_from_driver_error)?;
+            .map_err(Status::from)?;
         Ok(Response::new(StopSandboxResponse {}))
     }
 
@@ -139,7 +134,7 @@ impl ComputeDriver for ComputeDriverService {
             .driver
             .delete_sandbox(&request.sandbox_id, &request.sandbox_name)
             .await
-            .map_err(status_from_driver_error)?;
+            .map_err(Status::from)?;
         Ok(Response::new(DeleteSandboxResponse { deleted }))
     }
 
@@ -150,21 +145,9 @@ impl ComputeDriver for ComputeDriverService {
         &self,
         _request: Request<WatchSandboxesRequest>,
     ) -> Result<Response<Self::WatchSandboxesStream>, Status> {
-        let stream = self
-            .driver
-            .watch_sandboxes()
-            .await
-            .map_err(status_from_driver_error)?;
+        let stream = self.driver.watch_sandboxes().await.map_err(Status::from)?;
         let stream = stream.map(|item| item.map_err(|err| Status::internal(err.to_string())));
         Ok(Response::new(Box::pin(stream)))
-    }
-}
-
-fn status_from_driver_error(err: ComputeDriverError) -> Status {
-    match err {
-        ComputeDriverError::AlreadyExists => Status::already_exists("sandbox already exists"),
-        ComputeDriverError::Precondition(message) => Status::failed_precondition(message),
-        ComputeDriverError::Message(message) => Status::internal(message),
     }
 }
 
@@ -179,6 +162,7 @@ mod tests {
     use hyper::service::service_fn;
     use hyper::{Response as HyperResponse, StatusCode};
     use hyper_util::rt::TokioIo;
+    use openshell_core::ComputeDriverError;
     use std::collections::VecDeque;
     use std::convert::Infallible;
     use std::path::PathBuf;
@@ -187,9 +171,8 @@ mod tests {
 
     #[test]
     fn precondition_driver_errors_map_to_failed_precondition_status() {
-        let status = status_from_driver_error(ComputeDriverError::Precondition(
-            "sandbox container is not running".to_string(),
-        ));
+        let status: Status =
+            ComputeDriverError::Precondition("sandbox container is not running".to_string()).into();
 
         assert_eq!(status.code(), tonic::Code::FailedPrecondition);
         assert_eq!(status.message(), "sandbox container is not running");
@@ -197,7 +180,7 @@ mod tests {
 
     #[test]
     fn already_exists_driver_errors_map_to_already_exists_status() {
-        let status = status_from_driver_error(ComputeDriverError::AlreadyExists);
+        let status: Status = ComputeDriverError::AlreadyExists.into();
         assert_eq!(status.code(), tonic::Code::AlreadyExists);
     }
 

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -2201,38 +2201,47 @@ fn build_guest_environment(
             "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string(),
         ),
         ("TERM".to_string(), "xterm".to_string()),
-        ("OPENSHELL_ENDPOINT".to_string(), openshell_endpoint),
-        ("OPENSHELL_SANDBOX_ID".to_string(), sandbox.id.clone()),
-        ("OPENSHELL_SANDBOX".to_string(), sandbox.name.clone()),
         (
-            "OPENSHELL_SSH_SOCKET_PATH".to_string(),
+            openshell_core::sandbox_env::ENDPOINT.to_string(),
+            openshell_endpoint,
+        ),
+        (
+            openshell_core::sandbox_env::SANDBOX_ID.to_string(),
+            sandbox.id.clone(),
+        ),
+        (
+            openshell_core::sandbox_env::SANDBOX.to_string(),
+            sandbox.name.clone(),
+        ),
+        (
+            openshell_core::sandbox_env::SSH_SOCKET_PATH.to_string(),
             GUEST_SSH_SOCKET_PATH.to_string(),
         ),
         (
-            "OPENSHELL_SANDBOX_COMMAND".to_string(),
+            openshell_core::sandbox_env::SANDBOX_COMMAND.to_string(),
             "tail -f /dev/null".to_string(),
         ),
         (
-            "OPENSHELL_LOG_LEVEL".to_string(),
-            sandbox_log_level(sandbox, &config.log_level),
+            openshell_core::sandbox_env::LOG_LEVEL.to_string(),
+            openshell_core::driver_utils::sandbox_log_level(sandbox, &config.log_level),
         ),
         (
-            "OPENSHELL_SSH_HANDSHAKE_SECRET".to_string(),
+            openshell_core::sandbox_env::SSH_HANDSHAKE_SECRET.to_string(),
             config.ssh_handshake_secret.clone(),
         ),
     ]);
     if config.requires_tls_materials() {
         environment.extend(HashMap::from([
             (
-                "OPENSHELL_TLS_CA".to_string(),
+                openshell_core::sandbox_env::TLS_CA.to_string(),
                 GUEST_TLS_CA_PATH.to_string(),
             ),
             (
-                "OPENSHELL_TLS_CERT".to_string(),
+                openshell_core::sandbox_env::TLS_CERT.to_string(),
                 GUEST_TLS_CERT_PATH.to_string(),
             ),
             (
-                "OPENSHELL_TLS_KEY".to_string(),
+                openshell_core::sandbox_env::TLS_KEY.to_string(),
                 GUEST_TLS_KEY_PATH.to_string(),
             ),
         ]));
@@ -2245,16 +2254,6 @@ fn build_guest_environment(
         .into_iter()
         .map(|(key, value)| format!("{key}={value}"))
         .collect()
-}
-
-fn sandbox_log_level(sandbox: &Sandbox, default_level: &str) -> String {
-    sandbox
-        .spec
-        .as_ref()
-        .map(|spec| spec.log_level.as_str())
-        .filter(|level| !level.is_empty())
-        .unwrap_or(default_level)
-        .to_string()
 }
 
 fn sandboxes_root_dir(root: &Path) -> PathBuf {
@@ -2363,7 +2362,7 @@ fn sanitize_image_identity(image_identity: &str) -> String {
 
 fn unique_image_cache_suffix() -> String {
     let counter = IMAGE_CACHE_BUILD_COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("{}-{counter}", current_time_ms())
+    format!("{}-{counter}", openshell_core::time::now_ms())
 }
 
 async fn write_sandbox_image_metadata(
@@ -2492,21 +2491,13 @@ fn error_condition(reason: &str, message: &str) -> SandboxCondition {
 
 fn platform_event(source: &str, event_type: &str, reason: &str, message: String) -> PlatformEvent {
     PlatformEvent {
-        timestamp_ms: current_time_ms(),
+        timestamp_ms: openshell_core::time::now_ms(),
         source: source.to_string(),
         r#type: event_type.to_string(),
         reason: reason.to_string(),
         message,
         metadata: HashMap::new(),
     }
-}
-
-fn current_time_ms() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |duration| {
-            i64::try_from(duration.as_millis()).unwrap_or(i64::MAX)
-        })
 }
 
 #[cfg(test)]

--- a/crates/openshell-sandbox/src/denial_aggregator.rs
+++ b/crates/openshell-sandbox/src/denial_aggregator.rs
@@ -11,7 +11,6 @@
 
 use std::collections::HashMap;
 use std::future::Future;
-use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tracing::debug;
 
@@ -124,7 +123,7 @@ impl DenialAggregator {
     /// Ingest a single denial event, merging into existing summary or creating
     /// a new one.
     fn ingest(&mut self, event: DenialEvent) {
-        let now_ms = current_time_ms();
+        let now_ms = openshell_core::time::now_ms();
         let key = (event.host.clone(), event.port, event.binary.clone());
 
         let entry = self
@@ -216,10 +215,4 @@ pub struct FlushableL7Sample {
     pub method: String,
     pub path: String,
     pub count: u32,
-}
-
-fn current_time_ms() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
 }

--- a/crates/openshell-sandbox/src/grpc_client.rs
+++ b/crates/openshell-sandbox/src/grpc_client.rs
@@ -44,13 +44,13 @@ async fn connect_channel(endpoint: &str) -> Result<Channel> {
     let tls_enabled = endpoint.starts_with("https://");
 
     if tls_enabled {
-        let ca_path = std::env::var("OPENSHELL_TLS_CA")
+        let ca_path = std::env::var(openshell_core::sandbox_env::TLS_CA)
             .into_diagnostic()
             .wrap_err("OPENSHELL_TLS_CA is required")?;
-        let cert_path = std::env::var("OPENSHELL_TLS_CERT")
+        let cert_path = std::env::var(openshell_core::sandbox_env::TLS_CERT)
             .into_diagnostic()
             .wrap_err("OPENSHELL_TLS_CERT is required")?;
-        let key_path = std::env::var("OPENSHELL_TLS_KEY")
+        let key_path = std::env::var(openshell_core::sandbox_env::TLS_KEY)
             .into_diagnostic()
             .wrap_err("OPENSHELL_TLS_KEY is required")?;
 
@@ -111,7 +111,7 @@ type AuthenticatedInferenceClient =
     InferenceClient<InterceptedService<Channel, SandboxSecretInterceptor>>;
 
 fn sandbox_secret_interceptor() -> SandboxSecretInterceptor {
-    let secret = std::env::var("OPENSHELL_SSH_HANDSHAKE_SECRET")
+    let secret = std::env::var(openshell_core::sandbox_env::SSH_HANDSHAKE_SECRET)
         .ok()
         .and_then(|s| s.parse().ok());
     SandboxSecretInterceptor { secret }

--- a/crates/openshell-sandbox/src/log_push.rs
+++ b/crates/openshell-sandbox/src/log_push.rs
@@ -9,7 +9,6 @@
 
 use crate::grpc_client::CachedOpenShellClient;
 use openshell_core::proto::{PushSandboxLogsRequest, SandboxLogLine};
-use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tracing::{Event, Subscriber};
 use tracing_subscriber::Layer;
@@ -67,7 +66,7 @@ impl<S: Subscriber> Layer<S> for LogPushLayer {
             visitor.into_parts(meta.name())
         };
 
-        let ts = current_time_ms().unwrap_or(0);
+        let ts = openshell_core::time::now_ms();
 
         let is_ocsf = meta.target() == openshell_ocsf::OCSF_TARGET;
 
@@ -297,9 +296,4 @@ impl tracing::field::Visit for LogVisitor {
                 .push((field.name().to_string(), format!("{value:?}")));
         }
     }
-}
-
-fn current_time_ms() -> Option<i64> {
-    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?;
-    i64::try_from(now.as_millis()).ok()
 }

--- a/crates/openshell-sandbox/src/main.rs
+++ b/crates/openshell-sandbox/src/main.rs
@@ -50,17 +50,17 @@ struct Args {
 
     /// Sandbox ID for fetching policy via gRPC from `OpenShell` server.
     /// Requires --openshell-endpoint to be set.
-    #[arg(long, env = "OPENSHELL_SANDBOX_ID")]
+    #[arg(long, env = openshell_core::sandbox_env::SANDBOX_ID)]
     sandbox_id: Option<String>,
 
     /// Sandbox (used for policy sync when the sandbox discovers policy
     /// from disk or falls back to the restrictive default).
-    #[arg(long, env = "OPENSHELL_SANDBOX")]
+    #[arg(long, env = openshell_core::sandbox_env::SANDBOX)]
     sandbox: Option<String>,
 
     /// `OpenShell` server gRPC endpoint for fetching policy.
     /// Required when using --sandbox-id.
-    #[arg(long, env = "OPENSHELL_ENDPOINT")]
+    #[arg(long, env = openshell_core::sandbox_env::ENDPOINT)]
     openshell_endpoint: Option<String>,
 
     /// Path to Rego policy file for OPA-based network access control.
@@ -74,21 +74,21 @@ struct Args {
     policy_data: Option<String>,
 
     /// Log level (trace, debug, info, warn, error).
-    #[arg(long, default_value = "warn", env = "OPENSHELL_LOG_LEVEL")]
+    #[arg(long, default_value = "warn", env = openshell_core::sandbox_env::LOG_LEVEL)]
     log_level: String,
 
     /// Filesystem path to the Unix socket the embedded SSH daemon binds.
     /// The supervisor bridges `RelayStream` traffic from the gateway onto
     /// this socket; nothing else should connect to it.
-    #[arg(long, env = "OPENSHELL_SSH_SOCKET_PATH")]
+    #[arg(long, env = openshell_core::sandbox_env::SSH_SOCKET_PATH)]
     ssh_socket_path: Option<String>,
 
     /// Shared secret for gateway-to-sandbox SSH handshake.
-    #[arg(long, env = "OPENSHELL_SSH_HANDSHAKE_SECRET")]
+    #[arg(long, env = openshell_core::sandbox_env::SSH_HANDSHAKE_SECRET)]
     ssh_handshake_secret: Option<String>,
 
     /// Allowed clock skew for SSH handshake validation.
-    #[arg(long, env = "OPENSHELL_SSH_HANDSHAKE_SKEW_SECS", default_value = "300")]
+    #[arg(long, env = openshell_core::sandbox_env::SSH_HANDSHAKE_SKEW_SECS, default_value = "300")]
     ssh_handshake_skew_secs: u64,
 
     /// Path to YAML inference routes for standalone routing.
@@ -265,7 +265,7 @@ fn main() -> Result<()> {
         // Get command - either from CLI args, environment variable, or default to /bin/bash
         let command = if !args.command.is_empty() {
             args.command
-        } else if let Ok(c) = std::env::var("OPENSHELL_SANDBOX_COMMAND") {
+        } else if let Ok(c) = std::env::var(openshell_core::sandbox_env::SANDBOX_COMMAND) {
             // Simple shell-like splitting on whitespace
             c.split_whitespace().map(String::from).collect()
         } else {

--- a/crates/openshell-sandbox/src/process.rs
+++ b/crates/openshell-sandbox/src/process.rs
@@ -159,7 +159,7 @@ impl ProcessHandle {
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .kill_on_drop(true)
-            .env("OPENSHELL_SANDBOX", "1");
+            .env(openshell_core::sandbox_env::SANDBOX, "1");
 
         scrub_sensitive_env(&mut cmd);
         inject_provider_env(&mut cmd, provider_env);
@@ -286,7 +286,7 @@ impl ProcessHandle {
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .kill_on_drop(true)
-            .env("OPENSHELL_SANDBOX", "1");
+            .env(openshell_core::sandbox_env::SANDBOX, "1");
 
         scrub_sensitive_env(&mut cmd);
         inject_provider_env(&mut cmd, provider_env);

--- a/crates/openshell-sandbox/src/ssh.rs
+++ b/crates/openshell-sandbox/src/ssh.rs
@@ -680,7 +680,7 @@ fn apply_child_env(
     let path = std::env::var("PATH").unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".into());
 
     cmd.env_clear()
-        .env("OPENSHELL_SANDBOX", "1")
+        .env(openshell_core::sandbox_env::SANDBOX, "1")
         .env("HOME", session_home)
         .env("USER", session_user)
         .env("SHELL", "/bin/bash")

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -717,7 +717,7 @@ impl ComputeRuntime {
     }
 
     async fn reconcile_store_with_backend(&self, grace_period: Duration) -> Result<(), String> {
-        let sweep_started_at_ms = current_time_ms();
+        let sweep_started_at_ms = openshell_core::time::now_ms();
         let backend_sandboxes = self
             .driver
             .list_sandboxes(Request::new(ListSandboxesRequest {}))
@@ -822,8 +822,7 @@ impl ComputeRuntime {
         let session_connected = self.supervisor_sessions.has_session(&incoming.id);
         let mut phase = derive_phase(incoming.status.as_ref());
         let mut sandbox = existing.unwrap_or_else(|| {
-            use crate::persistence::current_time_ms;
-            let now_ms = current_time_ms().unwrap_or(0);
+            let now_ms = openshell_core::time::now_ms();
             Sandbox {
                 metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
                     id: incoming.id.clone(),
@@ -1066,7 +1065,7 @@ impl ComputeRuntime {
         }
 
         let sandbox = decode_sandbox_record(&current_record)?;
-        let age_ms = current_time_ms().saturating_sub(current_record.created_at_ms);
+        let age_ms = openshell_core::time::now_ms().saturating_sub(current_record.created_at_ms);
         if age_ms < grace_ms {
             return Ok(());
         }
@@ -1361,15 +1360,6 @@ fn compute_error_from_status(status: Status) -> ComputeError {
         Code::FailedPrecondition => ComputeError::Precondition(status.message().to_string()),
         _ => ComputeError::Message(status.message().to_string()),
     }
-}
-
-fn current_time_ms() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis()
-        .try_into()
-        .unwrap_or(i64::MAX)
 }
 
 fn decode_sandbox_record(record: &ObjectRecord) -> Result<Sandbox, String> {

--- a/crates/openshell-server/src/grpc/mod.rs
+++ b/crates/openshell-server/src/grpc/mod.rs
@@ -120,9 +120,8 @@ enum StoredSettingValue {
 // Utility
 // ---------------------------------------------------------------------------
 
-fn current_time_ms() -> Result<i64, std::time::SystemTimeError> {
-    let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)?;
-    Ok(i64::try_from(now.as_millis()).unwrap_or(i64::MAX))
+fn current_time_ms() -> i64 {
+    openshell_core::time::now_ms()
 }
 
 /// Validate that object metadata is present and contains required fields.

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -1196,7 +1196,7 @@ pub(super) async fn handle_report_policy_status(
     };
 
     let loaded_at_ms = if status_str == "loaded" {
-        Some(current_time_ms().map_err(|e| Status::internal(format!("timestamp error: {e}")))?)
+        Some(current_time_ms())
     } else {
         None
     };
@@ -1372,8 +1372,7 @@ pub(super) async fn handle_submit_policy_analysis(
             continue;
         }
 
-        let now_ms =
-            current_time_ms().map_err(|e| Status::internal(format!("timestamp error: {e}")))?;
+        let now_ms = current_time_ms();
         let proposed_rule_bytes = chunk
             .proposed_rule
             .as_ref()
@@ -1569,8 +1568,7 @@ pub(super) async fn handle_approve_draft_chunk(
         merge_chunk_into_policy(state.store.as_ref(), &sandbox_id, &chunk).await?;
     let chunk_summary = summarize_draft_chunk_rule(&chunk)?;
 
-    let now_ms =
-        current_time_ms().map_err(|e| Status::internal(format!("timestamp error: {e}")))?;
+    let now_ms = current_time_ms();
     state
         .store
         .update_draft_chunk_status(&req.chunk_id, "approved", Some(now_ms), None)
@@ -1669,8 +1667,7 @@ pub(super) async fn handle_reject_draft_chunk(
         );
     }
 
-    let now_ms =
-        current_time_ms().map_err(|e| Status::internal(format!("timestamp error: {e}")))?;
+    let now_ms = current_time_ms();
     // Persist the reviewer's free-form `reason` into the chunk's
     // `rejection_reason` field so the in-sandbox agent can read it back via
     // GetDraftPolicy / policy.local and revise the proposal.
@@ -1759,8 +1756,7 @@ pub(super) async fn handle_approve_all_draft_chunks(
         last_hash = hash;
         let chunk_summary = summarize_draft_chunk_rule(chunk)?;
 
-        let now_ms =
-            current_time_ms().map_err(|e| Status::internal(format!("timestamp error: {e}")))?;
+        let now_ms = current_time_ms();
         state
             .store
             .update_draft_chunk_status(&chunk.id, "approved", Some(now_ms), None)

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -37,8 +37,7 @@ pub(super) async fn create_provider_record(
 
     // Initialize metadata if not present
     if provider.metadata.is_none() {
-        let now_ms = current_time_ms()
-            .map_err(|e| Status::internal(format!("failed to get current time: {e}")))?;
+        let now_ms = current_time_ms();
         provider.metadata = Some(openshell_core::proto::datamodel::v1::ObjectMeta {
             id: uuid::Uuid::new_v4().to_string(),
             name: generate_name(),
@@ -649,7 +648,7 @@ async fn profile_conflict_diagnostics(
 
 fn stored_provider_profile(profile: ProviderProfile) -> StoredProviderProfile {
     use crate::persistence::current_time_ms;
-    let now_ms = current_time_ms().unwrap_or_default();
+    let now_ms = current_time_ms();
     StoredProviderProfile {
         metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
             id: uuid::Uuid::new_v4().to_string(),

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -101,8 +101,7 @@ pub(super) async fn handle_create_sandbox(
         request.name.clone()
     };
 
-    let now_ms = current_time_ms()
-        .map_err(|e| Status::internal(format!("failed to get current time: {e}")))?;
+    let now_ms = current_time_ms();
 
     let sandbox = Sandbox {
         metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
@@ -862,8 +861,7 @@ async fn validate_ssh_forward_token(
     }
 
     if session.expires_at_ms > 0 {
-        let now_ms = current_time_ms()
-            .map_err(|e| Status::internal(format!("timestamp generation failed: {e}")))?;
+        let now_ms = current_time_ms();
         if now_ms > session.expires_at_ms {
             return Err(Status::unauthenticated("SSH session token expired"));
         }
@@ -1063,8 +1061,7 @@ pub(super) async fn handle_create_ssh_session(
     }
 
     let token = uuid::Uuid::new_v4().to_string();
-    let now_ms = current_time_ms()
-        .map_err(|e| Status::internal(format!("timestamp generation failed: {e}")))?;
+    let now_ms = current_time_ms();
     let expires_at_ms = if state.config.ssh_session_ttl_secs > 0 {
         now_ms + (state.config.ssh_session_ttl_secs as i64 * 1000)
     } else {

--- a/crates/openshell-server/src/grpc/service.rs
+++ b/crates/openshell-server/src/grpc/service.rs
@@ -39,8 +39,7 @@ pub(super) async fn handle_expose_service(
         .map_err(|e| Status::internal(format!("fetch sandbox failed: {e}")))?
         .ok_or_else(|| Status::not_found("sandbox not found"))?;
 
-    let now =
-        super::current_time_ms().map_err(|e| Status::internal(format!("clock error: {e}")))?;
+    let now = super::current_time_ms();
     let key = service_routing::endpoint_key(&req.sandbox, &req.service);
     let (id, created_at_ms, created) = match state
         .store

--- a/crates/openshell-server/src/inference.rs
+++ b/crates/openshell-server/src/inference.rs
@@ -174,8 +174,7 @@ async fn upsert_cluster_inference_route(
         .await
         .map_err(|e| Status::internal(format!("fetch route failed: {e}")))?;
 
-    let now_ms =
-        current_time_ms().map_err(|e| Status::internal(format!("get current time: {e}")))?;
+    let now_ms = current_time_ms();
 
     let route = if let Some(existing) = existing {
         InferenceRoute {

--- a/crates/openshell-server/src/persistence/mod.rs
+++ b/crates/openshell-server/src/persistence/mod.rs
@@ -14,7 +14,6 @@ use openshell_core::{Error as CoreError, Result as CoreResult};
 use prost::Message;
 use rand::Rng;
 use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
 pub use postgres::PostgresStore;
@@ -283,12 +282,8 @@ impl Store {
     }
 }
 
-pub fn current_time_ms() -> PersistenceResult<i64> {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|e| PersistenceError::Database(format!("time error: {e}")))?;
-    i64::try_from(now.as_millis())
-        .map_err(|e| PersistenceError::Database(format!("time conversion error: {e}")))
+pub fn current_time_ms() -> i64 {
+    openshell_core::time::now_ms()
 }
 
 fn map_db_error(error: &sqlx::Error) -> PersistenceError {

--- a/crates/openshell-server/src/persistence/postgres.rs
+++ b/crates/openshell-server/src/persistence/postgres.rs
@@ -48,7 +48,7 @@ impl PostgresStore {
         payload: &[u8],
         labels: Option<&str>,
     ) -> PersistenceResult<()> {
-        let now_ms = current_time_ms()?;
+        let now_ms = current_time_ms();
         let labels_jsonb: Option<serde_json::Value> = labels
             .map(serde_json::from_str)
             .transpose()
@@ -205,7 +205,7 @@ LIMIT $3 OFFSET $4
         payload: &[u8],
         hash: &str,
     ) -> PersistenceResult<()> {
-        let now_ms = current_time_ms()?;
+        let now_ms = current_time_ms();
         let record = PolicyRecord {
             id: id.to_string(),
             sandbox_id: sandbox_id.to_string(),
@@ -348,7 +348,7 @@ LIMIT $3 OFFSET $4
         record.load_error = load_error.map(ToOwned::to_owned);
         record.loaded_at_ms = loaded_at_ms;
         let payload = policy_payload_from_record(&record)?;
-        let now_ms = current_time_ms()?;
+        let now_ms = current_time_ms();
 
         let result = sqlx::query(
             r"
@@ -374,7 +374,7 @@ WHERE object_type = $1 AND scope = $2 AND version = $3
         sandbox_id: &str,
         before_version: i64,
     ) -> PersistenceResult<u64> {
-        let now_ms = current_time_ms()?;
+        let now_ms = current_time_ms();
         let result = sqlx::query(
             r"
 UPDATE objects
@@ -499,7 +499,7 @@ ORDER BY created_at_ms DESC
 
         record.status = status.to_string();
         record.decided_at_ms = decided_at_ms;
-        record.last_seen_ms = current_time_ms()?;
+        record.last_seen_ms = current_time_ms();
         if let Some(reason) = rejection_reason {
             record.rejection_reason = reason.to_string();
         }
@@ -537,7 +537,7 @@ WHERE object_type = $1 AND id = $2
         }
 
         record.proposed_rule = proposed_rule.to_vec();
-        record.last_seen_ms = current_time_ms()?;
+        record.last_seen_ms = current_time_ms();
         let payload = draft_chunk_payload_from_record(&record)?;
 
         let result = sqlx::query(

--- a/crates/openshell-server/src/persistence/sqlite.rs
+++ b/crates/openshell-server/src/persistence/sqlite.rs
@@ -74,7 +74,7 @@ impl SqliteStore {
         payload: &[u8],
         labels: Option<&str>,
     ) -> PersistenceResult<()> {
-        let now_ms = current_time_ms()?;
+        let now_ms = current_time_ms();
 
         sqlx::query(
             r#"
@@ -231,7 +231,7 @@ LIMIT ?2 OFFSET ?3
         payload: &[u8],
         hash: &str,
     ) -> PersistenceResult<()> {
-        let now_ms = current_time_ms()?;
+        let now_ms = current_time_ms();
         let record = PolicyRecord {
             id: id.to_string(),
             sandbox_id: sandbox_id.to_string(),
@@ -374,7 +374,7 @@ LIMIT ?3 OFFSET ?4
         record.load_error = load_error.map(ToOwned::to_owned);
         record.loaded_at_ms = loaded_at_ms;
         let payload = policy_payload_from_record(&record)?;
-        let now_ms = current_time_ms()?;
+        let now_ms = current_time_ms();
 
         let result = sqlx::query(
             r#"
@@ -400,7 +400,7 @@ WHERE "object_type" = ?1 AND "scope" = ?2 AND "version" = ?3
         sandbox_id: &str,
         before_version: i64,
     ) -> PersistenceResult<u64> {
-        let now_ms = current_time_ms()?;
+        let now_ms = current_time_ms();
         let result = sqlx::query(
             r#"
 UPDATE "objects"
@@ -526,7 +526,7 @@ ORDER BY "created_at_ms" DESC
 
         record.status = status.to_string();
         record.decided_at_ms = decided_at_ms;
-        record.last_seen_ms = current_time_ms()?;
+        record.last_seen_ms = current_time_ms();
         if let Some(reason) = rejection_reason {
             record.rejection_reason = reason.to_string();
         }
@@ -564,7 +564,7 @@ WHERE "object_type" = ?1 AND "id" = ?2
         }
 
         record.proposed_rule = proposed_rule.to_vec();
-        record.last_seen_ms = current_time_ms()?;
+        record.last_seen_ms = current_time_ms();
         let payload = draft_chunk_payload_from_record(&record)?;
 
         let result = sqlx::query(

--- a/crates/openshell-server/src/tracing_bus.rs
+++ b/crates/openshell-server/src/tracing_bus.rs
@@ -5,7 +5,6 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use openshell_core::proto::{SandboxLogLine, SandboxStreamEvent};
 use openshell_ocsf::OCSF_TARGET;
@@ -150,7 +149,7 @@ where
         let msg = visitor.message.unwrap_or_else(|| meta.name().to_string());
         let level = display_level(meta.target(), &meta.level().to_string());
 
-        let ts = current_time_ms().unwrap_or(0);
+        let ts = openshell_core::time::now_ms();
         let log = SandboxLogLine {
             sandbox_id: sandbox_id.clone(),
             timestamp_ms: ts,
@@ -191,11 +190,6 @@ impl tracing::field::Visit for LogVisitor {
             _ => {}
         }
     }
-}
-
-fn current_time_ms() -> Option<i64> {
-    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?;
-    i64::try_from(now.as_millis()).ok()
 }
 
 fn display_level(target: &str, level: &str) -> String {


### PR DESCRIPTION
## Summary

Removes five categories of duplicated code that had been copy-pasted across the codebase, replacing each with a single canonical implementation. Also adds `OPENSHELL_SANDBOX` to the `sandbox_env` module so all drivers and the sandbox supervisor reference it via a typed constant rather than string literals.

## Related Issue

N/A (internal refactoring)

## Changes

- **`openshell_core::time::now_ms()`** — replaces 7 independent `current_time_ms()` implementations (sandbox denial aggregator, log pusher, server tracing bus, grpc handlers, compute reconciler, persistence layer, vm driver). Persistence and grpc wrappers simplified from `Result`/`Option` returns to plain `i64`.

- **`openshell_core::sandbox_env` constants** — typed constants for all `OPENSHELL_*` environment variable names replace identical string literals in the docker, vm, podman, and kubernetes drivers and the sandbox supervisor. Prevents silent typo bugs. Includes `OPENSHELL_SANDBOX` added in response to review feedback.

- **`openshell_core::driver_utils::sandbox_log_level()`** — replaces identical copy in docker and vm drivers.

- **`From<ComputeDriverError> for tonic::Status`** and **`From<KubernetesDriverError> for ComputeDriverError`** — eliminates the duplicate `status_from_driver_error` function that existed independently in `kubernetes/grpc.rs` and `podman/grpc.rs`.

- **`tests/helpers/mod.rs`** — shared CLI integration test helpers (`EnvVarGuard`, `build_ca`, `build_server_cert`, `build_client_cert`, `install_rustls_provider`) extracted from 5 independent copies. The consolidated `EnvVarGuard` uses a global mutex to safely serialize env-var mutations.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated (`cargo test` — 800+ tests, all green)
- [ ] E2E tests added/updated (not applicable — no behavior changes)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)