### PR TITLE
fix(sandbox): allow HEAD where GET is permitted in L7 policy

### DIFF
--- a/crates/openshell-sandbox/data/sandbox-policy.rego
+++ b/crates/openshell-sandbox/data/sandbox-policy.rego
@@ -526,11 +526,17 @@ graphql_field_matches_any(field, patterns) if {
 }
 
 # Wildcard "*" matches any method; otherwise case-insensitive exact match.
+# RFC 9110 §9.3.2: HEAD is semantically identical to GET except no response body.
 method_matches(_, "*") if true
 
 method_matches(actual, expected) if {
 	expected != "*"
 	upper(actual) == upper(expected)
+}
+
+method_matches(actual, expected) if {
+	upper(actual) == "HEAD"
+	upper(expected) == "GET"
 }
 
 # Path matching: "**" matches everything; otherwise glob.match with "/" delimiter.

--- a/crates/openshell-sandbox/src/opa.rs
+++ b/crates/openshell-sandbox/src/opa.rs
@@ -4817,7 +4817,7 @@ network_policies:
     fn l7_head_denied_when_only_post_allowed() {
         let engine = OpaEngine::from_strings(
             TEST_POLICY,
-            "network_policies:\n  p:\n    name: p\n    endpoints:\n      - host: h.test\n        port: 80\n        protocol: rest\n        enforcement: enforce\n        rules:\n          - allow: {method: POST, path: \"/\"}\n    binaries:\n      - {path: /bin/sh}\n",
+            "network_policies:\n  p:\n    name: p\n    endpoints:\n      - host: h.test\n        port: 80\n        protocol: rest\n        enforcement: enforce\n        rules:\n          - allow: {method: POST, path: \"/\"}\n    binaries:\n      - {path: /usr/bin/curl}\n",
         )
         .unwrap();
         let input = l7_input("h.test", 80, "HEAD", "/");
@@ -4828,6 +4828,18 @@ network_policies:
     fn l7_options_not_implicitly_allowed_by_get() {
         let engine = l7_engine();
         let input = l7_input("api.example.com", 8080, "OPTIONS", "/repos/myorg/foo");
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_head_blocked_by_deny_rule_targeting_get() {
+        // deny_rules use method_matches() too; a deny on GET must also block HEAD.
+        let engine = OpaEngine::from_strings(
+            TEST_POLICY,
+            "network_policies:\n  p:\n    name: p\n    endpoints:\n      - host: h.test\n        port: 80\n        protocol: rest\n        enforcement: enforce\n        access: full\n        deny_rules:\n          - method: GET\n            path: \"/protected\"\n    binaries:\n      - {path: /usr/bin/curl}\n",
+        )
+        .unwrap();
+        let input = l7_input("h.test", 80, "HEAD", "/protected");
         assert!(!eval_l7(&engine, &input));
     }
 }

--- a/crates/openshell-sandbox/src/opa.rs
+++ b/crates/openshell-sandbox/src/opa.rs
@@ -4805,4 +4805,29 @@ network_policies:
             decision.reason
         );
     }
+
+    #[test]
+    fn l7_head_allowed_where_get_is_allowed() {
+        let engine = l7_engine();
+        let input = l7_input("api.example.com", 8080, "HEAD", "/repos/myorg/foo");
+        assert!(eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_head_denied_when_only_post_allowed() {
+        let engine = OpaEngine::from_strings(
+            TEST_POLICY,
+            "network_policies:\n  p:\n    name: p\n    endpoints:\n      - host: h.test\n        port: 80\n        protocol: rest\n        enforcement: enforce\n        rules:\n          - allow: {method: POST, path: \"/\"}\n    binaries:\n      - {path: /bin/sh}\n",
+        )
+        .unwrap();
+        let input = l7_input("h.test", 80, "HEAD", "/");
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_options_not_implicitly_allowed_by_get() {
+        let engine = l7_engine();
+        let input = l7_input("api.example.com", 8080, "OPTIONS", "/repos/myorg/foo");
+        assert!(!eval_l7(&engine, &input));
+    }
 }


### PR DESCRIPTION
## Summary

`method_matches` in `sandbox-policy.rego` did exact case-insensitive matching with no HEAD/GET equivalence. A rule permitting `GET` on a path rejected `HEAD` on the same path with a 403, breaking package managers (uv, pip, cargo sparse index, npm) that probe with HEAD before fetching.

RFC 9110 §9.3.2 defines HEAD as identical to GET except the server omits the response body.

## Related Issue

Fixes #1357

## Changes

- Added a `method_matches` clause in `sandbox-policy.rego` that allows HEAD wherever GET is explicitly permitted
- Added 3 tests: HEAD allowed where GET is allowed, HEAD denied where only POST is allowed, OPTIONS not implicitly allowed by GET

## Testing

- [ ] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

All 128 `opa::tests` pass.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)