### PR TITLE
feat: AEGIS/MXC integration foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,11 +3330,14 @@ dependencies = [
  "futures",
  "miette",
  "openshell-core",
+ "p256",
  "rcgen",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -3407,6 +3410,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "openshell-driver-appcontainer"
+version = "0.0.0"
+
+[[package]]
 name = "openshell-driver-docker"
 version = "0.0.0"
 dependencies = [
@@ -3422,6 +3429,10 @@ dependencies = [
  "tracing",
  "url",
 ]
+
+[[package]]
+name = "openshell-driver-isolation-session"
+version = "0.0.0"
 
 [[package]]
 name = "openshell-driver-kubernetes"
@@ -3496,6 +3507,18 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "zstd",
+]
+
+[[package]]
+name = "openshell-mxc-bridge"
+version = "0.0.0"
+dependencies = [
+ "base64 0.22.1",
+ "openshell-core",
+ "openshell-policy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4511,6 +4534,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rand 0.9.4",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,12 @@
 
 [workspace]
 resolver = "2"
-members = ["crates/*"]
+members = [
+    "crates/*",
+    "crates/openshell-driver-appcontainer",
+    "crates/openshell-driver-isolation-session",
+    "crates/openshell-mxc-bridge",
+]
 
 [workspace.package]
 version = "0.0.0"
@@ -113,6 +118,11 @@ uuid = { version = "1.10", features = ["v4"] }
 
 # SMT solver (uses system libz3; enable z3/bundled via the prover's bundled-z3 feature for local dev without system z3)
 z3 = "0.19"
+
+# Windows interop (declared at workspace level for AEGIS/MXC crates; consumed only by Windows-targeted crates)
+windows = { version = "0.58", features = ["Win32_Foundation"] }
+windows-sys = { version = "0.59" }
+widestring = "1.1"
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ sha2 = "0.10"
 rand = "0.9"
 jsonwebtoken = "9"
 getrandom = "0.3"
+p256 = { version = "0.13", features = ["ecdsa", "pem", "pkcs8"] }
 
 # Filesystem embedding
 include_dir = "0.7"

--- a/architecture/aegis-governance.md
+++ b/architecture/aegis-governance.md
@@ -1,0 +1,216 @@
+# AEGIS Governance
+
+## Purpose
+
+AEGIS is a per-tool-call decision gate built into the OpenShell gateway. Before
+an agent runtime invokes a tool, it asks the gateway whether that specific
+action is allowed in this context. The gateway evaluates a Rego policy corpus,
+returns an `allow`, `deny`, or `ask` decision, and on `allow` mints a
+short-lived **execution envelope** (timeout, filesystem deny list, network
+on/off) bound to that one call. Compute drivers verify a signed ticket carrying
+the envelope and compose it with the sandbox's baseline policy before spawning
+the tool process. The gateway is the single trust authority: it owns auth,
+policy storage, OCSF audit, and the ECDSA private key that signs tickets.
+
+## Three-layer policy mental model
+
+OpenShell now expresses three policy surfaces. They have different lifetimes,
+different formats, and different enforcement points.
+
+```
+SandboxPolicy (YAML)        EnvelopePolicy (decision-bound)        ContainerConfig (JSON)
+       │                              │                                     │
+   per-sandbox                   per-tool-call                       per-spawn (Windows)
+   baseline cap                  decision result                     translated MXC payload
+       │                              │                                     │
+       └────────────► effective = baseline ∩ envelope ────────────► driver → wxc-exec
+                       (most-restrictive-wins composition)
+```
+
+| Layer | Format | Lifetime | Authority | Enforcement |
+|---|---|---|---|---|
+| `SandboxPolicy` | YAML, proto-defined | Per-sandbox lifetime | Gateway-stored, supervisor-loaded | Linux: Landlock + supervisor proxy. Windows: input to MXC `ContainerConfig`. |
+| `EnvelopePolicy` | Proto, decision-bound | Single tool call | Gateway Rego corpus | Driver verifies, intersects with baseline, applies on spawn. |
+| MXC `ContainerConfig` | JSON, transport shape | Single `wxc-exec` invocation | Translated by `openshell-mxc-bridge` | `wxc-exec.exe` reads from `--config-base64`. |
+
+Composition is **envelope ∩ baseline (most-restrictive-wins)**. The envelope
+cannot widen what baseline forbids. The translator is one-way: Rego decides,
+the bridge serializes, MXC enforces. There is no path back from
+`ContainerConfig` to Rego.
+
+## Trust boundaries
+
+AEGIS introduces three trust tiers. The gateway holds authority; everything
+downstream verifies.
+
+| Boundary | Holds | Trusts |
+|---|---|---|
+| Gateway | ECDSA P-256 private key, Rego corpus, auth tables, OCSF sink | Itself; OIDC/mTLS-authenticated callers |
+| Driver (`appcontainer`, `isolation-session`) | Cached gateway public key, `policy_hash` | Tickets it can verify offline against the cached pubkey |
+| Sandboxed process | Nothing | Untrusted; bounded by `ContainerConfig` |
+
+The v1 anti-replay floor is the ticket nonce plus `expires_at`. The driver
+maintains a bounded nonce-seen set and rejects reuse. Binding tickets to a
+caller PID is deferred to v1.5 — operators who need it today should keep
+`expires_at` short.
+
+## Decision flow
+
+A single tool call traverses three processes. The agent runtime's pre-tool
+hook pipes a JSON payload to a hidden CLI subprocess; the subprocess relays it
+to the gateway over loopback gRPC; the gateway returns a signed ticket; the
+runtime hands the ticket to the driver on `CreateSandbox`.
+
+```mermaid
+sequenceDiagram
+    participant Hook as Agent runtime hook
+    participant CLI as openshell aegis decide
+    participant GW as Gateway (AEGIS subsystem)
+    participant DRV as Compute driver
+    participant WXC as wxc-exec.exe
+
+    Hook->>CLI: tool-call JSON on stdin
+    CLI->>GW: IssueAegisTicket (mTLS / OIDC)
+    GW->>GW: regorus eval Rego corpus
+    GW->>GW: mint ExecutionTicket, ECDSA sign
+    GW-->>CLI: SignedTicket (or deny)
+    CLI-->>Hook: runtime-shaped response
+    Hook->>DRV: CreateSandbox(spec, signed_ticket)
+    DRV->>DRV: verify signature, check nonce/expiry/policy_hash
+    DRV->>DRV: compose envelope ∩ baseline → ContainerConfig
+    DRV->>WXC: spawn with --config-base64 <…>
+```
+
+If verification fails — bad signature, expired ticket, replayed nonce, or a
+`policy_hash` the driver does not have a cached pubkey for — the driver
+refuses to spawn and dual-emits a `DetectionFinding`. If the gateway returns
+`deny` or `ask`, the runtime never reaches the driver.
+
+Decisions are stateless on the gateway side except for the bounded
+nonce-seen set used to detect replay. Each driver maintains its own nonce
+cache keyed by gateway identity, so a ticket minted for one driver instance
+cannot be redeemed against another.
+
+## Wire shape
+
+`ExecutionTicket` is a canonical-JSON document; `SignedTicket` carries it with
+an ECDSA P-256 signature and an optional inline SPKI public key.
+
+```rust
+struct ExecutionTicket {
+    tool_name, tool_call_id, args_hash, cwd, envelope,
+    policy_hash, issued_at, expires_at, nonce,
+}
+struct SignedTicket { ticket, signature, public_key }
+```
+
+The full field list, RPC surface (`IssueAegisTicket`, `VerifyAegisTicket`), and
+`CreateSandboxRequest.signed_ticket` extension live in `proto/sandbox.proto`,
+`proto/openshell.proto`, and `proto/compute_driver.proto`. The signed-ticket
+contract is documented end-to-end in
+[RFC 0004](../rfc/0004-aegis-governance/README.md). Driver-side details
+(verify path, nonce cache, bridge invocation) belong in the driver crate
+READMEs.
+
+The gateway publishes its public key to three locations so drivers can verify
+offline:
+
+- `%TEMP%\aegis-pubkey.pem` (per-user staging path)
+- `%ProgramData%\aegis\aegis-public.pem` (machine-wide)
+- `GET /.well-known/aegis-public.pem` over mTLS (multi-host deployments)
+
+Probe order matches the upstream `mxc-aegis` SDK so AEGIS-aware tools that
+already exist on the host work without rewiring.
+
+## Linux/Windows feature matrix
+
+The Linux stack predates AEGIS and continues to work unchanged. The Windows
+drivers ship with a narrower enforcement surface; per-tool-call envelopes
+partially compensate for the missing supervisor and L7 proxy.
+
+| Feature | Linux (existing) | Windows (v1) |
+|---|---|---|
+| Filesystem isolation | Landlock | `wxc-exec` `ContainerConfig` |
+| Network egress filtering | netfilter + L7 policy proxy | `ContainerConfig.allowedHosts` |
+| Inference routing | `inference.local` supervisor proxy | Not in v1 |
+| Provider credential injection | Sandbox supervisor | Not in v1 |
+| Per-tool-call governance | New (via AEGIS) | New (via AEGIS) |
+| Audit | OCSF JSONL | OCSF JSONL |
+
+Windows v1 has no in-sandbox supervisor, so anything the Linux supervisor does
+between the gateway and the agent process — credential injection, inference
+interception, L7 inspection — is unavailable. Operators who need those
+controls on Windows in v1 should rely on tighter envelopes (short
+`expires_at`, restrictive `allowedHosts`) and accept that the only egress
+filter is L4.
+
+## OCSF events
+
+AEGIS reuses existing OCSF builders rather than introducing a new event class.
+Drivers and the gateway emit through the same JSONL sink operators already
+ingest.
+
+| Event | Builder | Severity |
+|---|---|---|
+| Decision: allow | `ConfigStateChangeBuilder` | Informational |
+| Decision: deny | `ConfigStateChangeBuilder` + `DetectionFindingBuilder` | Medium |
+| Ticket signature verify failure | `DetectionFindingBuilder` | High |
+| Ticket replay (nonce reused) | `DetectionFindingBuilder` | High |
+| Sandbox process start / stop | `ProcessActivityBuilder` | Informational / Low on non-zero exit |
+| Rego corpus reload | `ConfigStateChangeBuilder` | Informational |
+| Gateway keypair generated / rotated | `ConfigStateChangeBuilder` | Informational |
+
+Security findings (verify failure, replay, deny) dual-emit: one domain event
+plus one `DetectionFindingBuilder` for the same incident. Both the gateway's
+AEGIS subsystem and the new Windows drivers initialize their own
+`OnceLock<SandboxContext>` so the OCSF context is populated before the first
+event fires.
+
+## Operational notes
+
+- **Pubkey rotation.** Default cadence is per-gateway-restart: each cold start
+  generates a fresh ECDSA P-256 keypair, publishes it to the well-known paths,
+  and emits a `ConfigStateChange` event. Operators can force rotation through
+  the CLI without restarting. Drivers cache the pubkey alongside `policy_hash`
+  so a stale pubkey + fresh policy combination fails closed.
+- **Rego corpus distribution.** v1 ships only the **gateway tier** of the
+  three-tier composition (gateway / machine / user-or-repo). Operators load
+  one corpus into the gateway; drivers receive only the resulting envelope.
+  Machine-tier and user-tier corpora are forward-looking; the wire shape and
+  storage namespace are left open in `architecture/security-policy.md`.
+- **Capability handshake.** On startup, each Windows driver invokes
+  `wxc-exec.exe --capabilities` and validates the schema version against the
+  range its bundled `openshell-mxc-bridge` understands (currently `0.5.0-alpha`
+  and `0.6.0-dev`). Mismatch fails loudly with an actionable error before any
+  sandbox is created. The pinned `wxc-exec` version and SHA live in
+  `mise.toml`; staging is owned by `openshell-bootstrap`.
+- **Decision latency.** Rego eval runs in-process via regorus, with a target
+  budget of ~50–100 ms warm. The decision path is synchronous; a slow corpus
+  slows every tool call routed through AEGIS.
+
+## Cross-references
+
+- [Gateway](gateway.md) — auth, multiplex, persistence. Gateway also issues
+  AEGIS execution tickets.
+- [Compute Runtimes](compute-runtimes.md) — driver pattern, supervisor
+  delivery. The new AppContainer and IsolationSession drivers verify signed
+  tickets before spawning.
+- [Security Policy](security-policy.md) — baseline policy model, OCSF logging.
+  AEGIS adds a per-tool-call envelope that composes with baseline and
+  introduces a new privilege-escalation surface (the Rego corpus).
+- [RFC 0004](../rfc/0004-aegis-governance/README.md) — full design rationale,
+  alternatives considered, and open questions.
+
+## Out of scope
+
+- Stateful `IsolationSession` reuse across tool calls (matches MXC's deferred
+  stateful API).
+- L7 inference proxy and provider-credential injection on Windows in v1; both
+  remain Linux-only.
+- Replacing `SandboxPolicy` YAML with Rego. Baseline policy keeps its job;
+  Rego only answers per-tool-call decisions.
+- macOS, WSLC, and NanVix MXC backends.
+- PID-binding of tickets. The v1 anti-replay floor is nonce + `expires_at`.
+- Re-implementing the historical AEGIS named-pipe contract. Third-party
+  AEGIS consumers cannot drop in unmodified; the trade-off is a single
+  trust authority in the gateway.

--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -24,6 +24,8 @@ Each runtime receives a sandbox spec from the gateway and is responsible for:
 | Podman | Rootless or single-machine deployments. | Container plus nested sandbox namespace. | Uses the Podman REST API, OCI image volumes, and CDI GPU devices when available. |
 | Kubernetes | Cluster deployment through Helm. | Pod plus nested sandbox namespace. | Uses Kubernetes API objects, service accounts, secrets, PVC-backed workspace storage, and GPU resources. |
 | VM | Experimental microVM isolation. | Per-sandbox libkrun VM. | Gateway spawns `openshell-driver-vm` as a subprocess over a private, state-local Unix socket. |
+| AppContainer | Windows per-tool-call isolation. | `wxc-exec.exe` AppContainer runner. | Verifies AEGIS signed tickets before spawn — see [aegis-governance.md](aegis-governance.md). |
+| IsolationSession | Windows stronger isolation profile. | `wxc-exec.exe` IsolationSession runner. | Verifies AEGIS signed tickets before spawn — see [aegis-governance.md](aegis-governance.md). |
 
 VM runtime state paths are derived only from driver-validated sandbox IDs
 matching `[A-Za-z0-9._-]{1,128}`. The gateway-owned VM driver socket uses a

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -58,6 +58,9 @@ The gateway API is organized around platform objects and operational streams:
 | Inference | Set gateway-level model/provider config and resolve sandbox route bundles. |
 | Observability | Push sandbox logs, stream sandbox status and logs to clients. |
 
+The gateway also issues AEGIS execution tickets — see
+[aegis-governance.md](aegis-governance.md).
+
 Domain objects use shared metadata: stable server-generated IDs, human-readable
 names, creation timestamps, and labels. Crate-level details live in
 `crates/openshell-core/README.md`.

--- a/architecture/security-policy.md
+++ b/architecture/security-policy.md
@@ -65,6 +65,21 @@ before the child process starts.
 Gateway-global policy can override sandbox-scoped policy. Use it sparingly
 because it changes the effective access model for every sandbox on the gateway.
 
+## Per-tool-call envelopes (AEGIS)
+
+The gateway can also evaluate a Rego corpus per tool call and return an
+**EnvelopePolicy** that the compute driver composes with the baseline
+`SandboxPolicy` (most-restrictive-wins). This is a separate decision surface
+from the static baseline: it answers "may this specific call run, with these
+args, in this cwd?" before the tool process spawns. Full design lives in
+[aegis-governance.md](aegis-governance.md).
+
+The Rego corpus is a new privilege-escalation surface. An admin who controls
+the corpus controls every envelope the gateway issues, and therefore the
+effective access for every tool call routed through AEGIS. v1 ships only the
+gateway tier of the planned three-tier composition; treat the corpus with the
+same care as the gateway's TLS material and provider credentials.
+
 ## Policy Advisor
 
 The policy advisor pipeline turns observed denials into draft policy

--- a/crates/openshell-bootstrap/Cargo.toml
+++ b/crates/openshell-bootstrap/Cargo.toml
@@ -15,15 +15,19 @@ bollard = "0.20"
 bytes = { workspace = true }
 futures = { workspace = true }
 miette = { workspace = true }
+p256 = { workspace = true }
 rcgen = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 tar = "0.4"
 tempfile = "3"
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/openshell-bootstrap/src/aegis_keys.rs
+++ b/crates/openshell-bootstrap/src/aegis_keys.rs
@@ -145,11 +145,10 @@ pub fn load_or_generate(storage_dir: &Path) -> Result<AegisKeyMaterial, AegisKey
             path: private_path.clone(),
             source: e,
         })?;
-        let secret =
-            SecretKey::from_pkcs8_pem(&pem).map_err(|e| AegisKeyError::KeyParse {
-                path: private_path.clone(),
-                source: e,
-            })?;
+        let secret = SecretKey::from_pkcs8_pem(&pem).map_err(|e| AegisKeyError::KeyParse {
+            path: private_path.clone(),
+            source: e,
+        })?;
         let material = AegisKeyMaterial::from_secret(&secret)?;
         // Re-write the public key in case it was deleted out-of-band.
         write_public_key(storage_dir, &material)?;
@@ -236,10 +235,7 @@ fn generate_and_persist(storage_dir: &Path) -> Result<AegisKeyMaterial, AegisKey
     Ok(material)
 }
 
-fn write_public_key(
-    storage_dir: &Path,
-    material: &AegisKeyMaterial,
-) -> Result<(), AegisKeyError> {
+fn write_public_key(storage_dir: &Path, material: &AegisKeyMaterial) -> Result<(), AegisKeyError> {
     let public_path = storage_dir.join(PUBLIC_KEY_FILENAME);
     fs::write(&public_path, material.public_key_pem.as_bytes()).map_err(|e| AegisKeyError::Io {
         path: public_path,

--- a/crates/openshell-bootstrap/src/aegis_keys.rs
+++ b/crates/openshell-bootstrap/src/aegis_keys.rs
@@ -1,0 +1,295 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! AEGIS gateway ECDSA P-256 keypair lifecycle.
+//!
+//! This module owns the gateway's signing key for AEGIS execution tickets
+//! (see `rfc/0004-aegis-governance`). It generates, persists, loads, rotates,
+//! and publishes the public key to well-known paths that the mxc-aegis SDK
+//! and AppContainer/IsolationSession drivers probe in priority order.
+//!
+//! ## Storage layout
+//!
+//! - `<storage_dir>/aegis-private.pem` — PKCS#8 PEM, owner-only (`0o600` on
+//!   Unix; best-effort owner-only on Windows — see TODO below).
+//! - `<storage_dir>/aegis-public.pem`  — SPKI PEM.
+//!
+//! ## Public-key publish locations
+//!
+//! Per RFC 0004 §"Wire shape", the SDK probes (Windows-only):
+//!
+//! - `%TEMP%\aegis-pubkey.pem`
+//! - `%ProgramData%\aegis\aegis-public.pem`
+//!
+//! On Linux/macOS we publish to `$XDG_RUNTIME_DIR/aegis-pubkey.pem`
+//! (or `$TMPDIR`/`/tmp` fallback) for parity, but this is **not** the
+//! primary surface in v1 — the gateway's `GET /.well-known/aegis-public.pem`
+//! over mTLS is the canonical cross-host distribution path.
+//!
+//! ## OCSF
+//!
+//! This module emits `tracing::info!` on generation and rotation. The OCSF
+//! wiring task layers `ConfigStateChangeBuilder` events on top of these
+//! call sites — do not emit OCSF events from here directly.
+
+use openshell_core::paths::{ensure_parent_dir_restricted, set_file_owner_only};
+use p256::{
+    SecretKey,
+    pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey, LineEnding},
+};
+use sha2::{Digest, Sha256};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+use thiserror::Error;
+use tracing::info;
+
+/// Filename for the persisted private key under `<storage_dir>`.
+const PRIVATE_KEY_FILENAME: &str = "aegis-private.pem";
+/// Filename for the persisted public key under `<storage_dir>`.
+const PUBLIC_KEY_FILENAME: &str = "aegis-public.pem";
+
+/// Filename used at the SDK's `%TEMP%` probe location.
+const PUBLISH_TEMP_FILENAME: &str = "aegis-pubkey.pem";
+/// Filename used at the SDK's `%ProgramData%\aegis` probe location.
+const PUBLISH_PROGRAMDATA_FILENAME: &str = "aegis-public.pem";
+/// Subdirectory created under `%ProgramData%` to host the published key.
+const PROGRAMDATA_SUBDIR: &str = "aegis";
+
+/// PEM-encoded PKCS#8 private key + SPKI public key, plus convenience
+/// fields used by ticket signing and pubkey distribution.
+#[derive(Clone)]
+pub struct AegisKeyMaterial {
+    /// PKCS#8 PEM-encoded ECDSA P-256 private key.
+    pub private_key_pem: String,
+    /// SPKI PEM-encoded ECDSA P-256 public key.
+    pub public_key_pem: String,
+    /// Raw SPKI DER bytes of the public key (the form embedded in
+    /// `SignedTicket.public_key` per RFC 0004).
+    pub public_key_spki_der: Vec<u8>,
+    /// SHA-256 fingerprint of the SPKI DER. Stable identifier for logs
+    /// and OCSF events; safe to expose externally.
+    pub fingerprint_sha256: [u8; 32],
+}
+
+/// Errors produced by the keypair lifecycle API.
+#[derive(Debug, Error)]
+pub enum AegisKeyError {
+    #[error("aegis keys I/O error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to parse stored aegis private key at {path}: {source}")]
+    KeyParse {
+        path: PathBuf,
+        #[source]
+        source: p256::pkcs8::Error,
+    },
+
+    #[error("failed to generate aegis ECDSA P-256 keypair: {0}")]
+    KeyGenerate(String),
+
+    #[error("failed to encode aegis key material: {0}")]
+    KeyEncode(String),
+
+    #[error("failed to publish aegis public key to {path}: {source}")]
+    PublishPath {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl AegisKeyMaterial {
+    /// Build material from a `SecretKey`, computing PEM/DER/fingerprint.
+    fn from_secret(secret: &SecretKey) -> Result<Self, AegisKeyError> {
+        let private_key_pem = secret
+            .to_pkcs8_pem(LineEnding::LF)
+            .map_err(|e| AegisKeyError::KeyEncode(format!("pkcs8 pem: {e}")))?
+            .to_string();
+
+        let public_key = secret.public_key();
+        let public_key_pem = public_key
+            .to_public_key_pem(LineEnding::LF)
+            .map_err(|e| AegisKeyError::KeyEncode(format!("spki pem: {e}")))?;
+        let public_key_spki_der = public_key
+            .to_public_key_der()
+            .map_err(|e| AegisKeyError::KeyEncode(format!("spki der: {e}")))?
+            .as_bytes()
+            .to_vec();
+
+        let fingerprint_sha256 = Sha256::digest(&public_key_spki_der).into();
+
+        Ok(Self {
+            private_key_pem,
+            public_key_pem,
+            public_key_spki_der,
+            fingerprint_sha256,
+        })
+    }
+}
+
+/// Load the persisted gateway keypair from `storage_dir`, or generate and
+/// persist a new one if the private key file does not exist.
+///
+/// Idempotent: a second call returns identical material.
+pub fn load_or_generate(storage_dir: &Path) -> Result<AegisKeyMaterial, AegisKeyError> {
+    let private_path = storage_dir.join(PRIVATE_KEY_FILENAME);
+
+    if private_path.exists() {
+        let pem = fs::read_to_string(&private_path).map_err(|e| AegisKeyError::Io {
+            path: private_path.clone(),
+            source: e,
+        })?;
+        let secret =
+            SecretKey::from_pkcs8_pem(&pem).map_err(|e| AegisKeyError::KeyParse {
+                path: private_path.clone(),
+                source: e,
+            })?;
+        let material = AegisKeyMaterial::from_secret(&secret)?;
+        // Re-write the public key in case it was deleted out-of-band.
+        write_public_key(storage_dir, &material)?;
+        return Ok(material);
+    }
+
+    let material = generate_and_persist(storage_dir)?;
+    info!(
+        fingerprint = %hex_fingerprint(&material.fingerprint_sha256),
+        "generated new aegis ECDSA P-256 keypair"
+    );
+    Ok(material)
+}
+
+/// Force a new keypair, replacing any existing one under `storage_dir`.
+///
+/// Always returns material distinct from the previous on-disk state.
+pub fn rotate(storage_dir: &Path) -> Result<AegisKeyMaterial, AegisKeyError> {
+    let material = generate_and_persist(storage_dir)?;
+    info!(
+        fingerprint = %hex_fingerprint(&material.fingerprint_sha256),
+        "rotated aegis ECDSA P-256 keypair"
+    );
+    Ok(material)
+}
+
+/// Publish the public key PEM to the well-known probe paths used by the
+/// mxc-aegis SDK. Returns the list of paths actually written.
+///
+/// Failure to write to a probe path is returned as `PublishPath`; the caller
+/// decides whether to treat it as fatal (the gateway is still functional
+/// without local publish — drivers can fall back to the gateway's
+/// `/.well-known/aegis-public.pem` endpoint).
+pub fn publish_public_key(material: &AegisKeyMaterial) -> Result<Vec<PathBuf>, AegisKeyError> {
+    let mut written = Vec::new();
+    for path in publish_paths() {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent).map_err(|e| AegisKeyError::PublishPath {
+                path: parent.to_path_buf(),
+                source: e,
+            })?;
+        }
+        fs::write(&path, &material.public_key_pem).map_err(|e| AegisKeyError::PublishPath {
+            path: path.clone(),
+            source: e,
+        })?;
+        written.push(path);
+    }
+    Ok(written)
+}
+
+// --- internals ---------------------------------------------------------
+
+fn generate_and_persist(storage_dir: &Path) -> Result<AegisKeyMaterial, AegisKeyError> {
+    fs::create_dir_all(storage_dir).map_err(|e| AegisKeyError::Io {
+        path: storage_dir.to_path_buf(),
+        source: e,
+    })?;
+
+    let secret = SecretKey::random(&mut rand_core_compat::OsRng);
+    let material = AegisKeyMaterial::from_secret(&secret)?;
+
+    let private_path = storage_dir.join(PRIVATE_KEY_FILENAME);
+    ensure_parent_dir_restricted(&private_path)
+        .map_err(|e| AegisKeyError::KeyEncode(format!("ensure parent dir: {e:?}")))?;
+    fs::write(&private_path, material.private_key_pem.as_bytes()).map_err(|e| {
+        AegisKeyError::Io {
+            path: private_path.clone(),
+            source: e,
+        }
+    })?;
+    // Best-effort restrictive permissions. On Unix this sets 0o600.
+    // TODO(windows): set an owner-only DACL via the `windows` crate so the
+    // private key isn't world-readable on shared hosts. For now the file
+    // inherits the parent directory ACL; combined with a restricted
+    // %ProgramData%\openshell parent directory this is adequate for v1.
+    set_file_owner_only(&private_path)
+        .map_err(|e| AegisKeyError::KeyEncode(format!("set owner-only perms: {e:?}")))?;
+
+    write_public_key(storage_dir, &material)?;
+
+    Ok(material)
+}
+
+fn write_public_key(
+    storage_dir: &Path,
+    material: &AegisKeyMaterial,
+) -> Result<(), AegisKeyError> {
+    let public_path = storage_dir.join(PUBLIC_KEY_FILENAME);
+    fs::write(&public_path, material.public_key_pem.as_bytes()).map_err(|e| AegisKeyError::Io {
+        path: public_path,
+        source: e,
+    })
+}
+
+fn hex_fingerprint(bytes: &[u8; 32]) -> String {
+    let mut s = String::with_capacity(64);
+    for b in bytes {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+// --- publish paths -----------------------------------------------------
+
+#[cfg(windows)]
+fn publish_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(temp) = std::env::var_os("TEMP") {
+        paths.push(PathBuf::from(temp).join(PUBLISH_TEMP_FILENAME));
+    }
+    if let Some(pd) = std::env::var_os("ProgramData") {
+        paths.push(
+            PathBuf::from(pd)
+                .join(PROGRAMDATA_SUBDIR)
+                .join(PUBLISH_PROGRAMDATA_FILENAME),
+        );
+    }
+    paths
+}
+
+// On Linux/macOS we publish to a per-user runtime location for parity with
+// the Windows SDK probe order. v1 does not use this surface as the primary
+// distribution path — drivers on POSIX hosts use the gateway's
+// `/.well-known/aegis-public.pem` endpoint over mTLS instead.
+#[cfg(not(windows))]
+fn publish_paths() -> Vec<PathBuf> {
+    let dir = std::env::var_os("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("TMPDIR").map(PathBuf::from))
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
+    vec![dir.join(PUBLISH_TEMP_FILENAME)]
+}
+
+// `p256` 0.13 uses the `rand_core` 0.6 trait surface, which is re-exported
+// from the crate itself. We avoid taking a direct `rand_core` dep by using
+// the re-export.
+mod rand_core_compat {
+    pub use p256::elliptic_curve::rand_core::OsRng;
+}

--- a/crates/openshell-bootstrap/src/lib.rs
+++ b/crates/openshell-bootstrap/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod aegis_keys;
 pub mod build;
 pub mod edge_token;
 pub mod oidc_token;

--- a/crates/openshell-bootstrap/tests/aegis_keys.rs
+++ b/crates/openshell-bootstrap/tests/aegis_keys.rs
@@ -60,12 +60,12 @@ fn sign_and_verify_round_trip() {
     let dir = TempDir::new().unwrap();
     let material = load_or_generate(dir.path()).expect("generate");
 
-    let signing_secret = p256::SecretKey::from_pkcs8_pem(&material.private_key_pem)
-        .expect("parse private key");
+    let signing_secret =
+        p256::SecretKey::from_pkcs8_pem(&material.private_key_pem).expect("parse private key");
     let signing_key = SigningKey::from(signing_secret);
 
-    let verifying_public = p256::PublicKey::from_public_key_pem(&material.public_key_pem)
-        .expect("parse public key");
+    let verifying_public =
+        p256::PublicKey::from_public_key_pem(&material.public_key_pem).expect("parse public key");
     let verifying_key = VerifyingKey::from(verifying_public);
 
     let message = b"aegis ticket round-trip canary";

--- a/crates/openshell-bootstrap/tests/aegis_keys.rs
+++ b/crates/openshell-bootstrap/tests/aegis_keys.rs
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the AEGIS gateway keypair lifecycle.
+
+use openshell_bootstrap::aegis_keys::{load_or_generate, publish_public_key, rotate};
+use p256::ecdsa::{
+    Signature, SigningKey, VerifyingKey,
+    signature::{Signer, Verifier},
+};
+use p256::pkcs8::{DecodePrivateKey, DecodePublicKey};
+use tempfile::TempDir;
+
+#[test]
+fn load_or_generate_creates_new_keys_when_storage_is_empty() {
+    let dir = TempDir::new().unwrap();
+    let material = load_or_generate(dir.path()).expect("generate");
+
+    assert!(material.private_key_pem.contains("BEGIN PRIVATE KEY"));
+    assert!(material.public_key_pem.contains("BEGIN PUBLIC KEY"));
+    assert!(!material.public_key_spki_der.is_empty());
+    assert_eq!(material.fingerprint_sha256.len(), 32);
+
+    assert!(dir.path().join("aegis-private.pem").exists());
+    assert!(dir.path().join("aegis-public.pem").exists());
+}
+
+#[test]
+fn load_or_generate_is_idempotent() {
+    let dir = TempDir::new().unwrap();
+    let first = load_or_generate(dir.path()).expect("first");
+    let second = load_or_generate(dir.path()).expect("second");
+
+    assert_eq!(first.private_key_pem, second.private_key_pem);
+    assert_eq!(first.public_key_pem, second.public_key_pem);
+    assert_eq!(first.public_key_spki_der, second.public_key_spki_der);
+    assert_eq!(first.fingerprint_sha256, second.fingerprint_sha256);
+}
+
+#[test]
+fn rotate_replaces_existing_keypair() {
+    let dir = TempDir::new().unwrap();
+    let original = load_or_generate(dir.path()).expect("initial");
+    let rotated = rotate(dir.path()).expect("rotate");
+
+    assert_ne!(
+        original.fingerprint_sha256, rotated.fingerprint_sha256,
+        "rotated keypair should have a different fingerprint"
+    );
+    assert_ne!(original.private_key_pem, rotated.private_key_pem);
+    assert_ne!(original.public_key_pem, rotated.public_key_pem);
+
+    // After rotation, load_or_generate should return the rotated material.
+    let reloaded = load_or_generate(dir.path()).expect("reload");
+    assert_eq!(reloaded.fingerprint_sha256, rotated.fingerprint_sha256);
+}
+
+#[test]
+fn sign_and_verify_round_trip() {
+    let dir = TempDir::new().unwrap();
+    let material = load_or_generate(dir.path()).expect("generate");
+
+    let signing_secret = p256::SecretKey::from_pkcs8_pem(&material.private_key_pem)
+        .expect("parse private key");
+    let signing_key = SigningKey::from(signing_secret);
+
+    let verifying_public = p256::PublicKey::from_public_key_pem(&material.public_key_pem)
+        .expect("parse public key");
+    let verifying_key = VerifyingKey::from(verifying_public);
+
+    let message = b"aegis ticket round-trip canary";
+    let signature: Signature = signing_key.sign(message);
+
+    verifying_key
+        .verify(message, &signature)
+        .expect("signature should verify against derived public key");
+
+    // Tampered message must not verify.
+    let tampered = b"aegis ticket round-trip canary!";
+    assert!(verifying_key.verify(tampered, &signature).is_err());
+}
+
+#[test]
+fn publish_public_key_writes_at_least_one_path() {
+    let dir = TempDir::new().unwrap();
+    let material = load_or_generate(dir.path()).expect("generate");
+
+    // Steer the publish targets into the tempdir so we don't pollute the
+    // host's %TEMP% / %ProgramData% / $XDG_RUNTIME_DIR.
+    let publish_root = dir.path().join("publish");
+    std::fs::create_dir_all(&publish_root).unwrap();
+
+    // Set every env var the publisher reads on any platform; the cfg in
+    // the module decides which subset is consulted.
+    let prev_tmp = std::env::var_os("TEMP");
+    let prev_pd = std::env::var_os("ProgramData");
+    let prev_xdg = std::env::var_os("XDG_RUNTIME_DIR");
+    let prev_tmpdir = std::env::var_os("TMPDIR");
+
+    // SAFETY: these env mutations are only safe because the test process
+    // serializes within a single test binary; cargo runs integration
+    // tests in separate processes per file. The publish test owns this
+    // file so no other test mutates these vars concurrently.
+    unsafe {
+        std::env::set_var("TEMP", &publish_root);
+        std::env::set_var("ProgramData", &publish_root);
+        std::env::set_var("XDG_RUNTIME_DIR", &publish_root);
+        std::env::set_var("TMPDIR", &publish_root);
+    }
+
+    let written = publish_public_key(&material).expect("publish");
+    assert!(!written.is_empty(), "expected at least one published path");
+    for path in &written {
+        let content = std::fs::read_to_string(path).expect("read published pubkey");
+        assert_eq!(content, material.public_key_pem);
+    }
+
+    unsafe {
+        match prev_tmp {
+            Some(v) => std::env::set_var("TEMP", v),
+            None => std::env::remove_var("TEMP"),
+        }
+        match prev_pd {
+            Some(v) => std::env::set_var("ProgramData", v),
+            None => std::env::remove_var("ProgramData"),
+        }
+        match prev_xdg {
+            Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+            None => std::env::remove_var("XDG_RUNTIME_DIR"),
+        }
+        match prev_tmpdir {
+            Some(v) => std::env::set_var("TMPDIR", v),
+            None => std::env::remove_var("TMPDIR"),
+        }
+    }
+}

--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -51,6 +51,18 @@ pub const DEFAULT_K8S_NAMESPACE: &str = "openshell";
 /// CDI device identifier for requesting all NVIDIA GPUs.
 pub const CDI_GPU_DEVICE_ALL: &str = "nvidia.com/gpu=all";
 
+/// Default install path of the `wxc-exec.exe` helper used by the Windows
+/// AppContainer / Isolation Session compute drivers.
+///
+/// The bootstrap-wxc task is responsible for placing the binary here. The
+/// drivers consult this path when [`WXC_EXEC_ENV_VAR`] is unset.
+#[cfg(target_os = "windows")]
+pub const WXC_EXEC_DEFAULT_PATH_PROGRAMFILES: &str = r"C:\Program Files\OpenShell\wxc-exec.exe";
+
+/// Environment variable that overrides the discovered path to `wxc-exec.exe`.
+#[cfg(target_os = "windows")]
+pub const WXC_EXEC_ENV_VAR: &str = "OPENSHELL_WXC_EXEC";
+
 /// Compute backends the gateway can orchestrate sandboxes through.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -59,6 +71,14 @@ pub enum ComputeDriverKind {
     Vm,
     Docker,
     Podman,
+    /// Windows AppContainer-backed sandbox compute driver. Wired by the
+    /// `wxc-exec` helper installed via the bootstrap-wxc task.
+    #[serde(rename = "appcontainer")]
+    AppContainer,
+    /// Windows Isolation Session-backed sandbox compute driver. Wired by the
+    /// `wxc-exec` helper installed via the bootstrap-wxc task.
+    #[serde(rename = "isolation-session")]
+    IsolationSession,
 }
 
 impl ComputeDriverKind {
@@ -69,6 +89,8 @@ impl ComputeDriverKind {
             Self::Vm => "vm",
             Self::Docker => "docker",
             Self::Podman => "podman",
+            Self::AppContainer => "appcontainer",
+            Self::IsolationSession => "isolation-session",
         }
     }
 }
@@ -88,8 +110,10 @@ impl FromStr for ComputeDriverKind {
             "vm" => Ok(Self::Vm),
             "docker" => Ok(Self::Docker),
             "podman" => Ok(Self::Podman),
+            "appcontainer" => Ok(Self::AppContainer),
+            "isolation-session" => Ok(Self::IsolationSession),
             other => Err(format!(
-                "unsupported compute driver '{other}'. expected one of: kubernetes, vm, docker, podman"
+                "unsupported compute driver '{other}'. expected one of: kubernetes, vm, docker, podman, appcontainer, isolation-session"
             )),
         }
     }
@@ -744,12 +768,50 @@ mod tests {
             "docker".parse::<ComputeDriverKind>().unwrap(),
             ComputeDriverKind::Docker
         );
+        assert_eq!(
+            "appcontainer".parse::<ComputeDriverKind>().unwrap(),
+            ComputeDriverKind::AppContainer
+        );
+        assert_eq!(
+            "isolation-session".parse::<ComputeDriverKind>().unwrap(),
+            ComputeDriverKind::IsolationSession
+        );
     }
 
     #[test]
     fn compute_driver_kind_rejects_unknown_values() {
         let err = "firecracker".parse::<ComputeDriverKind>().unwrap_err();
         assert!(err.contains("unsupported compute driver 'firecracker'"));
+    }
+
+    #[test]
+    fn compute_driver_kind_display_round_trips() {
+        for kind in [
+            ComputeDriverKind::Kubernetes,
+            ComputeDriverKind::Vm,
+            ComputeDriverKind::Docker,
+            ComputeDriverKind::Podman,
+            ComputeDriverKind::AppContainer,
+            ComputeDriverKind::IsolationSession,
+        ] {
+            let rendered = kind.to_string();
+            assert_eq!(rendered, kind.as_str());
+            let parsed: ComputeDriverKind = rendered.parse().unwrap();
+            assert_eq!(parsed, kind);
+        }
+    }
+
+    #[test]
+    fn compute_driver_kind_serde_round_trips_new_variants() {
+        let appcontainer = serde_json::to_string(&ComputeDriverKind::AppContainer).unwrap();
+        assert_eq!(appcontainer, "\"appcontainer\"");
+        let parsed: ComputeDriverKind = serde_json::from_str(&appcontainer).unwrap();
+        assert_eq!(parsed, ComputeDriverKind::AppContainer);
+
+        let isolation = serde_json::to_string(&ComputeDriverKind::IsolationSession).unwrap();
+        assert_eq!(isolation, "\"isolation-session\"");
+        let parsed: ComputeDriverKind = serde_json::from_str(&isolation).unwrap();
+        assert_eq!(parsed, ComputeDriverKind::IsolationSession);
     }
 
     #[test]

--- a/crates/openshell-driver-appcontainer/Cargo.toml
+++ b/crates/openshell-driver-appcontainer/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "openshell-driver-appcontainer"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+path = "src/lib.rs"

--- a/crates/openshell-driver-appcontainer/src/lib.rs
+++ b/crates/openshell-driver-appcontainer/src/lib.rs
@@ -1,0 +1,1 @@
+// Scaffolding placeholder — populated by RFC 0004 (AEGIS governance) workers.

--- a/crates/openshell-driver-isolation-session/Cargo.toml
+++ b/crates/openshell-driver-isolation-session/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "openshell-driver-isolation-session"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+path = "src/lib.rs"

--- a/crates/openshell-driver-isolation-session/src/lib.rs
+++ b/crates/openshell-driver-isolation-session/src/lib.rs
@@ -1,0 +1,1 @@
+// Scaffolding placeholder — populated by RFC 0004 (AEGIS governance) workers.

--- a/crates/openshell-mxc-bridge/Cargo.toml
+++ b/crates/openshell-mxc-bridge/Cargo.toml
@@ -1,8 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "openshell-mxc-bridge"
+description = "Translate OpenShell SandboxPolicy + EnvelopePolicy into MXC ContainerConfig and build wxc-exec invocations"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [lib]
 path = "src/lib.rs"
+
+[dependencies]
+openshell-core = { path = "../openshell-core" }
+openshell-policy = { path = "../openshell-policy" }
+
+base64 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/openshell-mxc-bridge/Cargo.toml
+++ b/crates/openshell-mxc-bridge/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "openshell-mxc-bridge"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+path = "src/lib.rs"

--- a/crates/openshell-mxc-bridge/src/invoke.rs
+++ b/crates/openshell-mxc-bridge/src/invoke.rs
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `wxc-exec` (Windows) / `lxc-exec` (Linux) invocation contract.
+//!
+//! This module is a *builder* — it computes the program path, argument list,
+//! and base64-encoded config payload that the upstream `mxc-aegis` SDK
+//! passes to `pty.spawn` (`sandbox.ts:287–308`). It does **not** spawn a
+//! process. Driver crates own the actual `Command::spawn`.
+//!
+//! The contract is intentionally tiny:
+//!
+//! ```text
+//! wxc-exec.exe --config-base64 <b64> [--debug] [--experimental]
+//! ```
+//!
+//! `--experimental` is required for the `0.6.0-dev` IsolationSession
+//! schema and is added automatically when [`Schema::DevIsolationSession`]
+//! is selected.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use base64::Engine as _;
+
+/// CLI flag for the base64-encoded config payload.
+pub const CONFIG_BASE64_FLAG: &str = "--config-base64";
+
+/// CLI flag enabling verbose runner-side logging.
+pub const DEBUG_FLAG: &str = "--debug";
+
+/// CLI flag enabling experimental MXC features (e.g. IsolationSession).
+pub const EXPERIMENTAL_FLAG: &str = "--experimental";
+
+/// Target MXC config schema. Drives both the JSON shape and the runner
+/// invocation flags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum Schema {
+    /// Stable `0.5.0-alpha` schema. AppContainer (Windows process container)
+    /// or LXC (Linux). No `--experimental` required.
+    #[default]
+    AlphaProcess,
+    /// Dev `0.6.0-dev` schema. IsolationSession backend. Requires
+    /// `--experimental` to be passed to `wxc-exec`.
+    DevIsolationSession,
+}
+
+impl Schema {
+    /// Whether this schema requires the `--experimental` flag.
+    #[must_use]
+    pub const fn requires_experimental(self) -> bool {
+        matches!(self, Self::DevIsolationSession)
+    }
+}
+
+/// Computed `wxc-exec` invocation. The driver crate is expected to feed
+/// these into `tokio::process::Command::new(invocation.program).args(&invocation.args)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WxcInvocation {
+    /// Resolved path to `wxc-exec` (Windows) or `lxc-exec` (Linux).
+    pub program: PathBuf,
+    /// Argument list, in order. Includes `--config-base64 <b64>` plus any
+    /// flag toggles requested by the caller or implied by the schema.
+    pub args: Vec<OsString>,
+}
+
+/// Encode a JSON config payload as base64, matching the SDK's
+/// `Buffer.from(JSON.stringify(config), 'utf-8').toString('base64')`.
+#[must_use]
+pub fn encode_config_base64(config_json: &str) -> String {
+    base64::engine::general_purpose::STANDARD.encode(config_json.as_bytes())
+}
+
+/// Build a [`WxcInvocation`] for the given runner path, schema, config JSON,
+/// and debug toggle.
+///
+/// `--experimental` is appended automatically when `schema.requires_experimental()`
+/// returns true.
+#[must_use]
+pub fn build_invocation(
+    wxc_exec_path: &Path,
+    schema: Schema,
+    config_json: &str,
+    debug: bool,
+) -> WxcInvocation {
+    let mut args: Vec<OsString> = Vec::with_capacity(5);
+    args.push(OsString::from(CONFIG_BASE64_FLAG));
+    args.push(OsString::from(encode_config_base64(config_json)));
+
+    if debug {
+        args.push(OsString::from(DEBUG_FLAG));
+    }
+    if schema.requires_experimental() {
+        args.push(OsString::from(EXPERIMENTAL_FLAG));
+    }
+
+    WxcInvocation {
+        program: wxc_exec_path.to_path_buf(),
+        args,
+    }
+}
+
+/// Advisory classification of a `wxc-exec` exit code.
+///
+/// ASSUMPTION: the upstream MXC runner does **not** publish a stable exit
+/// code taxonomy. Inspecting `mxc/src/wxc/src/main.rs` shows it
+/// passes through the wrapped script's exit code on success and emits `1`
+/// for runner-internal failures (config parse error, unsupported backend,
+/// etc.). The two cases collide on `1` and are only fully disambiguated by
+/// the JSON error envelope written to stderr. Drivers should treat this
+/// classification as a hint and parse stderr for definitive diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WxcExitClass {
+    /// Script (and runner) exited cleanly.
+    Success,
+    /// Either the script exited with a non-zero status, or the runner
+    /// itself failed before the script could be launched. Disambiguate via
+    /// the stderr error envelope.
+    ScriptOrLauncherFailure(i32),
+    /// Process was killed by a signal (Unix) — exposed for callers that
+    /// inspect `ExitStatus::signal()` separately. The runner itself never
+    /// emits this.
+    Signalled(i32),
+}
+
+/// Map an exit-status code into a [`WxcExitClass`].
+#[must_use]
+pub const fn classify_exit_code(code: i32) -> WxcExitClass {
+    if code == 0 {
+        WxcExitClass::Success
+    } else {
+        WxcExitClass::ScriptOrLauncherFailure(code)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alpha_schema_does_not_add_experimental() {
+        let path = PathBuf::from("/opt/mxc/wxc-exec");
+        let inv = build_invocation(&path, Schema::AlphaProcess, "{}", false);
+        assert_eq!(inv.program, path);
+        assert_eq!(inv.args[0], OsString::from(CONFIG_BASE64_FLAG));
+        assert!(!inv.args.iter().any(|a| a == EXPERIMENTAL_FLAG));
+        assert!(!inv.args.iter().any(|a| a == DEBUG_FLAG));
+    }
+
+    #[test]
+    fn dev_schema_adds_experimental() {
+        let path = PathBuf::from("/opt/mxc/wxc-exec");
+        let inv = build_invocation(&path, Schema::DevIsolationSession, "{}", false);
+        assert!(inv.args.iter().any(|a| a == EXPERIMENTAL_FLAG));
+    }
+
+    #[test]
+    fn debug_flag_is_threaded_through() {
+        let path = PathBuf::from("/opt/mxc/wxc-exec");
+        let inv = build_invocation(&path, Schema::AlphaProcess, "{}", true);
+        assert!(inv.args.iter().any(|a| a == DEBUG_FLAG));
+    }
+
+    #[test]
+    fn config_is_base64_encoded() {
+        let path = PathBuf::from("/opt/mxc/wxc-exec");
+        let inv = build_invocation(&path, Schema::AlphaProcess, r#"{"version":"0.5.0-alpha"}"#, false);
+        let b64 = inv.args[1].to_string_lossy().into_owned();
+        let decoded =
+            base64::engine::general_purpose::STANDARD.decode(b64.as_bytes()).expect("decodes");
+        assert_eq!(decoded, br#"{"version":"0.5.0-alpha"}"#);
+    }
+
+    #[test]
+    fn exit_classification() {
+        assert_eq!(classify_exit_code(0), WxcExitClass::Success);
+        assert_eq!(
+            classify_exit_code(1),
+            WxcExitClass::ScriptOrLauncherFailure(1),
+        );
+        assert_eq!(
+            classify_exit_code(42),
+            WxcExitClass::ScriptOrLauncherFailure(42),
+        );
+    }
+}

--- a/crates/openshell-mxc-bridge/src/invoke.rs
+++ b/crates/openshell-mxc-bridge/src/invoke.rs
@@ -164,10 +164,16 @@ mod tests {
     #[test]
     fn config_is_base64_encoded() {
         let path = PathBuf::from("/opt/mxc/wxc-exec");
-        let inv = build_invocation(&path, Schema::AlphaProcess, r#"{"version":"0.5.0-alpha"}"#, false);
+        let inv = build_invocation(
+            &path,
+            Schema::AlphaProcess,
+            r#"{"version":"0.5.0-alpha"}"#,
+            false,
+        );
         let b64 = inv.args[1].to_string_lossy().into_owned();
-        let decoded =
-            base64::engine::general_purpose::STANDARD.decode(b64.as_bytes()).expect("decodes");
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(b64.as_bytes())
+            .expect("decodes");
         assert_eq!(decoded, br#"{"version":"0.5.0-alpha"}"#);
     }
 

--- a/crates/openshell-mxc-bridge/src/lib.rs
+++ b/crates/openshell-mxc-bridge/src/lib.rs
@@ -1,1 +1,34 @@
-// Scaffolding placeholder — populated by RFC 0004 (AEGIS governance) workers.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bridge between OpenShell policy types and the Microsoft MXC sandbox runner.
+//!
+//! This crate is pure — it does no I/O. It holds two responsibilities:
+//!
+//! 1. Translate an OpenShell baseline [`SandboxPolicy`](openshell_core::proto::SandboxPolicy)
+//!    plus an optional per-task
+//!    [`EnvelopePolicy`](openshell_policy::EnvelopePolicy) into an MXC
+//!    `ContainerConfig` JSON document, supporting **both** the stable
+//!    `0.5.0-alpha` (AppContainer) and dev `0.6.0-dev` (IsolationSession)
+//!    schemas via [`Schema`].
+//! 2. Build the `wxc-exec` invocation contract — base64-encoded config,
+//!    `--config-base64` / `--debug` / `--experimental` arg layout, and
+//!    advisory exit-code classification — without spawning a process. Driver
+//!    crates own the actual `Command::spawn`.
+//!
+//! See `rfc/0004-aegis-governance` and the Phase 2 spike (Findings 3b/3c)
+//! for context.
+
+mod invoke;
+pub mod schema_alpha;
+pub mod schema_dev;
+mod translate;
+
+pub use invoke::{
+    CONFIG_BASE64_FLAG, DEBUG_FLAG, EXPERIMENTAL_FLAG, Schema, WxcExitClass, WxcInvocation,
+    build_invocation, classify_exit_code, encode_config_base64,
+};
+pub use translate::{
+    ContainerConfig, TranslateError, TranslateOptions, UiPolicy, translate, translate_alpha,
+    translate_dev,
+};

--- a/crates/openshell-mxc-bridge/src/lib.rs
+++ b/crates/openshell-mxc-bridge/src/lib.rs
@@ -1,0 +1,1 @@
+// Scaffolding placeholder — populated by RFC 0004 (AEGIS governance) workers.

--- a/crates/openshell-mxc-bridge/src/schema_alpha.rs
+++ b/crates/openshell-mxc-bridge/src/schema_alpha.rs
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! MXC `ContainerConfig` types for schema version `0.5.0-alpha`.
+//!
+//! Mirrors the wire shape produced by the upstream `mxc-aegis` SDK
+//! (`sdk/src/types.ts`). Field naming is `camelCase` over JSON; field
+//! presence (`Option`/`skip_serializing_if`) matches the SDK's behaviour.
+//!
+//! This file intentionally tracks the SDK shape — not the MXC config schema
+//! reference — because the SDK is what `wxc-exec` actually consumes for
+//! AppContainer (Windows process container) workloads. Notably the SDK uses
+//! `appContainer` while the schema doc lists `processContainer` for the
+//! older `0.4.0-alpha` schema (renamed in `0.5.0-alpha`).
+
+use serde::{Deserialize, Serialize};
+
+/// Schema version string emitted in the JSON `version` field.
+pub const SCHEMA_VERSION: &str = "0.5.0-alpha";
+
+/// Top-level MXC AppContainer container configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ContainerConfig {
+    /// Schema version (semver). Always [`SCHEMA_VERSION`] for this module.
+    pub version: String,
+
+    /// Externally assigned container identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_id: Option<String>,
+
+    /// Container lifecycle settings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle: Option<LifecycleConfig>,
+
+    /// Process execution settings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process: Option<ProcessConfig>,
+
+    /// AppContainer (Windows process container) settings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_container: Option<AppContainerConfig>,
+
+    /// Filesystem access policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filesystem: Option<FilesystemConfig>,
+
+    /// Network access policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<NetworkConfig>,
+
+    /// Cross-platform UI configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ui: Option<UiConfig>,
+}
+
+/// Container lifecycle settings shared across MXC backends.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LifecycleConfig {
+    /// Destroy the container after execution completes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destroy_on_exit: Option<bool>,
+    /// Retain filesystem and network policies after execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preserve_policy: Option<bool>,
+}
+
+/// Process execution settings.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProcessConfig {
+    /// Complete command line to execute. Required by the runner; the
+    /// translator emits the empty string and expects callers to fill it.
+    pub command_line: String,
+    /// Working directory.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    /// Environment variables as `KEY=VALUE` strings.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<String>,
+    /// Execution timeout in milliseconds. `0` (or omitted) means no timeout.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<u32>,
+}
+
+/// Filesystem access policy.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct FilesystemConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub readwrite_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub readonly_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub denied_paths: Vec<String>,
+}
+
+/// Network enforcement mode (Windows-specific in upstream).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum EnforcementMode {
+    Capabilities,
+    Firewall,
+    Both,
+}
+
+/// Default network policy.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DefaultNetworkPolicy {
+    Allow,
+    Block,
+}
+
+/// Network access policy.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enforcement_mode: Option<EnforcementMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_policy: Option<DefaultNetworkPolicy>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_hosts: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blocked_hosts: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proxy: Option<Proxy>,
+}
+
+/// Proxy configuration (Windows only — translator returns an error if
+/// requested for a Linux target, mirroring the upstream SDK).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum Proxy {
+    BuiltinTestServer { builtin_test_server: bool },
+    Localhost { localhost: u16 },
+    Url { url: String },
+}
+
+/// AppContainer (Windows) configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AppContainerConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub least_privilege: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ui: Option<BaseProcessUiConfig>,
+}
+
+/// UI isolation level for the AppContainer process.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum UiIsolation {
+    Desktop,
+    Handles,
+    Atoms,
+    Container,
+}
+
+/// Windows-only AppContainer UI settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BaseProcessUiConfig {
+    pub isolation: UiIsolation,
+    pub desktop_system_control: bool,
+    pub system_settings: String,
+    pub ime: bool,
+}
+
+impl Default for BaseProcessUiConfig {
+    fn default() -> Self {
+        Self {
+            isolation: UiIsolation::Container,
+            desktop_system_control: false,
+            system_settings: "none".to_owned(),
+            ime: false,
+        }
+    }
+}
+
+/// Clipboard access policy.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ClipboardPolicy {
+    None,
+    Read,
+    Write,
+    All,
+}
+
+impl Default for ClipboardPolicy {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// Cross-platform UI configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiConfig {
+    pub disable: bool,
+    pub clipboard: ClipboardPolicy,
+    pub injection: bool,
+}
+
+impl Default for UiConfig {
+    fn default() -> Self {
+        // Mirrors the upstream SDK default: most-restrictive.
+        Self {
+            disable: true,
+            clipboard: ClipboardPolicy::None,
+            injection: false,
+        }
+    }
+}

--- a/crates/openshell-mxc-bridge/src/schema_dev.rs
+++ b/crates/openshell-mxc-bridge/src/schema_dev.rs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! MXC `ContainerConfig` types for schema version `0.6.0-dev`.
+//!
+//! This dev schema is **only** used by the IsolationSession backend. It
+//! reuses most of the alpha schema but carries an additional
+//! `containment = "isolation_session"` discriminant and an
+//! `experimental.isolation_session.configurationId` field. The `wxc-exec`
+//! invocation **must** include `--experimental` for any config that targets
+//! this backend (see [`crate::Schema::DevIsolationSession`]).
+//!
+//! The shape here is reverse-engineered from the Phase 2 spike
+//! (`Finding 3c`); the upstream SDK does not export a strongly typed
+//! IsolationSession config. Field names are educated guesses where the
+//! spike is silent — flagged below with `ASSUMPTION:` comments.
+
+use serde::{Deserialize, Serialize};
+
+pub use crate::schema_alpha::{
+    ClipboardPolicy, DefaultNetworkPolicy, EnforcementMode, FilesystemConfig, LifecycleConfig,
+    NetworkConfig, ProcessConfig, Proxy, UiConfig,
+};
+
+/// Schema version string emitted in the JSON `version` field.
+pub const SCHEMA_VERSION: &str = "0.6.0-dev";
+
+/// Containment discriminant. Currently only `IsolationSession` is meaningful
+/// on the dev schema path; alpha-style backends should use the alpha module.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Containment {
+    IsolationSession,
+}
+
+/// Top-level MXC IsolationSession container configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ContainerConfig {
+    /// Schema version (semver). Always [`SCHEMA_VERSION`].
+    pub version: String,
+
+    /// Externally assigned container identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_id: Option<String>,
+
+    /// Always `IsolationSession` for this schema; emitted as
+    /// `"isolation_session"` in JSON.
+    pub containment: Containment,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle: Option<LifecycleConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process: Option<ProcessConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filesystem: Option<FilesystemConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<NetworkConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ui: Option<UiConfig>,
+
+    /// Experimental configuration. Required for IsolationSession.
+    pub experimental: Experimental,
+}
+
+/// Experimental config block. Only the IsolationSession sub-section is
+/// modelled here; other experimental backends (WSLC, seatbelt) are out of
+/// scope for this crate.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Experimental {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub isolation_session: Option<IsolationSessionConfig>,
+}
+
+/// IsolationSession-specific settings.
+///
+/// ASSUMPTION: only `configurationId` is documented in the spike. Additional
+/// fields (e.g. profile selectors, broker overrides) will be added when the
+/// dev schema firms up.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IsolationSessionConfig {
+    /// Opaque identifier for the IsolationSession runner's pre-registered
+    /// configuration entry. Required by the IsolationBroker on the host.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configuration_id: Option<String>,
+}

--- a/crates/openshell-mxc-bridge/src/translate.rs
+++ b/crates/openshell-mxc-bridge/src/translate.rs
@@ -149,10 +149,12 @@ pub fn translate(
     opts: &TranslateOptions,
 ) -> Result<ContainerConfig, TranslateError> {
     match opts.schema {
-        Schema::AlphaProcess => translate_alpha(policy, envelope, opts)
-            .map(|cfg| ContainerConfig::Alpha(Box::new(cfg))),
-        Schema::DevIsolationSession => translate_dev(policy, envelope, opts)
-            .map(|cfg| ContainerConfig::Dev(Box::new(cfg))),
+        Schema::AlphaProcess => {
+            translate_alpha(policy, envelope, opts).map(|cfg| ContainerConfig::Alpha(Box::new(cfg)))
+        }
+        Schema::DevIsolationSession => {
+            translate_dev(policy, envelope, opts).map(|cfg| ContainerConfig::Dev(Box::new(cfg)))
+        }
     }
 }
 
@@ -369,14 +371,15 @@ fn build_network(
 }
 
 fn build_ui(opts: &TranslateOptions) -> schema_alpha::UiConfig {
-    opts.ui.as_ref().map_or_else(
-        schema_alpha::UiConfig::default,
-        |u| schema_alpha::UiConfig {
-            disable: !u.allow_windows,
-            clipboard: u.clipboard,
-            injection: u.allow_input_injection,
-        },
-    )
+    opts.ui
+        .as_ref()
+        .map_or_else(schema_alpha::UiConfig::default, |u| {
+            schema_alpha::UiConfig {
+                disable: !u.allow_windows,
+                clipboard: u.clipboard,
+                injection: u.allow_input_injection,
+            }
+        })
 }
 
 fn build_app_container(

--- a/crates/openshell-mxc-bridge/src/translate.rs
+++ b/crates/openshell-mxc-bridge/src/translate.rs
@@ -1,0 +1,406 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pure translation from OpenShell policy types to MXC `ContainerConfig`.
+//!
+//! Mirrors the upstream `mxc-aegis` SDK's `createConfigFromPolicy()`
+//! (`sdk/src/sandbox.ts:143–206`) with the OpenShell type system as the
+//! input shape (proto [`SandboxPolicy`] baseline +
+//! [`EnvelopePolicy`] per-task envelope) and either the alpha or dev MXC
+//! schema as the output shape.
+//!
+//! Composition rule: when an envelope is supplied, it is composed against
+//! the baseline via [`openshell_policy::compose_envelope`] and the resulting
+//! `EffectiveEnvelope` drives the path/network/timeout fields. When no
+//! envelope is supplied, the baseline alone determines those fields and a
+//! best-effort default of "deny everything not explicitly allowed" is used.
+//!
+//! No I/O. No filesystem reads. No process spawns. Driver crates own
+//! execution; this module just builds the JSON.
+
+use std::collections::BTreeSet;
+
+use openshell_core::proto::SandboxPolicy;
+use openshell_policy::{EffectiveEnvelope, EnvelopePolicy, compose_envelope};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::invoke::Schema;
+use crate::{schema_alpha, schema_dev};
+
+/// Output container configuration. Wraps the per-schema strongly typed
+/// configs so callers can serialise either variant uniformly via
+/// [`ContainerConfig::to_json`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum ContainerConfig {
+    Alpha(Box<schema_alpha::ContainerConfig>),
+    Dev(Box<schema_dev::ContainerConfig>),
+}
+
+impl ContainerConfig {
+    /// Serialise to a compact JSON string suitable for `--config-base64`.
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
+
+    /// Schema discriminant for this config.
+    #[must_use]
+    pub const fn schema(&self) -> Schema {
+        match self {
+            Self::Alpha(_) => Schema::AlphaProcess,
+            Self::Dev(_) => Schema::DevIsolationSession,
+        }
+    }
+
+    /// Borrow the alpha variant if this is an alpha config.
+    #[must_use]
+    pub fn as_alpha(&self) -> Option<&schema_alpha::ContainerConfig> {
+        match self {
+            Self::Alpha(cfg) => Some(cfg.as_ref()),
+            Self::Dev(_) => None,
+        }
+    }
+
+    /// Borrow the dev variant if this is a dev config.
+    #[must_use]
+    pub fn as_dev(&self) -> Option<&schema_dev::ContainerConfig> {
+        match self {
+            Self::Dev(cfg) => Some(cfg.as_ref()),
+            Self::Alpha(_) => None,
+        }
+    }
+}
+
+/// Translation options that don't fit the policy/envelope inputs.
+#[derive(Debug, Clone, Default)]
+pub struct TranslateOptions {
+    /// Target schema (alpha AppContainer vs. dev IsolationSession).
+    pub schema: Schema,
+    /// Container identifier to embed in `containerId`. Callers are
+    /// expected to provide one — this crate is pure and will not generate
+    /// random identifiers (driver crates own that policy).
+    pub container_id: Option<String>,
+    /// AppContainer profile name (alpha schema only). When `None` the
+    /// `appContainer.name` field is set to `container_id` if available,
+    /// matching the SDK's `containerName` parameter.
+    pub app_container_name: Option<String>,
+    /// Pre-registered configuration identifier for the IsolationSession
+    /// broker (dev schema only). When `None`, the experimental block omits
+    /// the field.
+    pub isolation_session_configuration_id: Option<String>,
+    /// Whether the deployment target is Linux. The upstream SDK rejects
+    /// `proxy` on Linux; this crate honours that rule.
+    pub is_linux_target: bool,
+    /// Optional baseline override for the SDK's `clearPolicyOnExit` flag.
+    /// `None` (the common case) preserves the SDK default of `true`,
+    /// producing `lifecycle.preservePolicy = false`.
+    pub clear_policy_on_exit: Option<bool>,
+    /// Optional UI policy. Defaults to most-restrictive when `None`.
+    pub ui: Option<UiPolicy>,
+    /// Optional proxy configuration. Mirrors the SDK's `network.proxy`.
+    pub proxy: Option<schema_alpha::Proxy>,
+}
+
+/// Cross-platform UI policy (mirrors the SDK's `SandboxPolicy.ui`).
+///
+/// OpenShell's proto `SandboxPolicy` has no UI surface; callers wishing to
+/// loosen the most-restrictive default must supply this explicitly.
+#[derive(Debug, Clone, Default)]
+pub struct UiPolicy {
+    /// Whether the sandbox may create visible windows.
+    pub allow_windows: bool,
+    /// Clipboard access level.
+    pub clipboard: schema_alpha::ClipboardPolicy,
+    /// Whether the sandbox may inject keyboard/mouse input.
+    pub allow_input_injection: bool,
+}
+
+/// Errors returned by [`translate`].
+#[derive(Debug, Error)]
+pub enum TranslateError {
+    /// `allowedHosts` / `blockedHosts` were configured but the envelope
+    /// disabled outbound network access. Mirrors the upstream SDK rule.
+    #[error(
+        "allowedHosts/blockedHosts require outbound network access (envelope.network_enabled = true)"
+    )]
+    HostsRequireOutbound,
+
+    /// Proxy configuration is not supported on Linux.
+    #[error("proxy configuration is not supported on Linux")]
+    ProxyOnLinux,
+
+    /// The selected schema does not support a feature requested via options
+    /// (e.g. AppContainer-specific naming on the dev schema).
+    #[error("invalid option for schema {schema:?}: {message}")]
+    InvalidOptionForSchema { schema: Schema, message: String },
+}
+
+/// Translate baseline policy + optional envelope into a `ContainerConfig`
+/// matching `opts.schema`.
+///
+/// # Errors
+///
+/// Returns a [`TranslateError`] when validation rules are violated; see
+/// the variants for the specific conditions.
+pub fn translate(
+    policy: &SandboxPolicy,
+    envelope: Option<&EnvelopePolicy>,
+    opts: &TranslateOptions,
+) -> Result<ContainerConfig, TranslateError> {
+    match opts.schema {
+        Schema::AlphaProcess => translate_alpha(policy, envelope, opts)
+            .map(|cfg| ContainerConfig::Alpha(Box::new(cfg))),
+        Schema::DevIsolationSession => translate_dev(policy, envelope, opts)
+            .map(|cfg| ContainerConfig::Dev(Box::new(cfg))),
+    }
+}
+
+/// Translate to a `0.5.0-alpha` AppContainer config.
+///
+/// # Errors
+///
+/// See [`translate`].
+pub fn translate_alpha(
+    policy: &SandboxPolicy,
+    envelope: Option<&EnvelopePolicy>,
+    opts: &TranslateOptions,
+) -> Result<schema_alpha::ContainerConfig, TranslateError> {
+    let composed = compose_or_baseline(policy, envelope);
+    let allowed_hosts = collect_allowed_hosts(policy);
+
+    validate_network(&composed, &allowed_hosts, opts)?;
+
+    let lifecycle = build_lifecycle(opts);
+    let process = build_process(&composed);
+    let filesystem = build_filesystem(&composed);
+    let network = build_network(&composed, allowed_hosts, opts.proxy.clone());
+    let ui = Some(build_ui(opts));
+
+    let app_container = Some(build_app_container(
+        opts,
+        composed.network_enabled,
+        composed.allow_local_network,
+    ));
+
+    // Mirror upstream: when network is configured, force enforcementMode = "both".
+    let network = network.map(|mut n| {
+        n.enforcement_mode = Some(schema_alpha::EnforcementMode::Both);
+        n
+    });
+
+    Ok(schema_alpha::ContainerConfig {
+        version: schema_alpha::SCHEMA_VERSION.to_owned(),
+        container_id: opts.container_id.clone(),
+        lifecycle: Some(lifecycle),
+        process: Some(process),
+        app_container,
+        filesystem: Some(filesystem),
+        network,
+        ui,
+    })
+}
+
+/// Translate to a `0.6.0-dev` IsolationSession config.
+///
+/// # Errors
+///
+/// See [`translate`].
+pub fn translate_dev(
+    policy: &SandboxPolicy,
+    envelope: Option<&EnvelopePolicy>,
+    opts: &TranslateOptions,
+) -> Result<schema_dev::ContainerConfig, TranslateError> {
+    if opts.app_container_name.is_some() {
+        return Err(TranslateError::InvalidOptionForSchema {
+            schema: Schema::DevIsolationSession,
+            message: "app_container_name has no effect on the IsolationSession schema".to_owned(),
+        });
+    }
+
+    let composed = compose_or_baseline(policy, envelope);
+    let allowed_hosts = collect_allowed_hosts(policy);
+
+    validate_network(&composed, &allowed_hosts, opts)?;
+
+    let lifecycle = build_lifecycle(opts);
+    let process = build_process(&composed);
+    let filesystem = build_filesystem(&composed);
+    let network = build_network(&composed, allowed_hosts, opts.proxy.clone());
+    let ui = Some(build_ui(opts));
+
+    let experimental = schema_dev::Experimental {
+        isolation_session: Some(schema_dev::IsolationSessionConfig {
+            configuration_id: opts.isolation_session_configuration_id.clone(),
+        }),
+    };
+
+    Ok(schema_dev::ContainerConfig {
+        version: schema_dev::SCHEMA_VERSION.to_owned(),
+        container_id: opts.container_id.clone(),
+        containment: schema_dev::Containment::IsolationSession,
+        lifecycle: Some(lifecycle),
+        process: Some(process),
+        filesystem: Some(filesystem),
+        network,
+        ui,
+        experimental,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn compose_or_baseline(
+    policy: &SandboxPolicy,
+    envelope: Option<&EnvelopePolicy>,
+) -> EffectiveEnvelope {
+    if let Some(env) = envelope {
+        return compose_envelope(policy, env);
+    }
+
+    // No envelope: derive a baseline-only "effective" view. Path lists come
+    // straight from the baseline filesystem block; network is allowed only
+    // when the baseline carries at least one named network policy (matches
+    // the heuristic in `compose_envelope`).
+    let (read_only, read_write) = policy.filesystem.as_ref().map_or_else(
+        || (Vec::new(), Vec::new()),
+        |fs| (fs.read_only.clone(), fs.read_write.clone()),
+    );
+    let baseline_allows_network = !policy.network_policies.is_empty();
+
+    EffectiveEnvelope {
+        readwrite_paths: read_write,
+        readonly_paths: read_only,
+        denied_paths: Vec::new(),
+        network_enabled: baseline_allows_network,
+        // ASSUMPTION: baseline can't currently express local-network access;
+        // default to false to match the most-restrictive policy posture
+        // unless the envelope says otherwise.
+        allow_local_network: false,
+        timeout_ms: 0,
+        sandbox_profile: String::new(),
+    }
+}
+
+fn collect_allowed_hosts(policy: &SandboxPolicy) -> Vec<String> {
+    let mut hosts: BTreeSet<&str> = BTreeSet::new();
+    for rule in policy.network_policies.values() {
+        for endpoint in &rule.endpoints {
+            if !endpoint.host.is_empty() {
+                hosts.insert(endpoint.host.as_str());
+            }
+        }
+    }
+    hosts.into_iter().map(str::to_owned).collect()
+}
+
+fn validate_network(
+    composed: &EffectiveEnvelope,
+    allowed_hosts: &[String],
+    opts: &TranslateOptions,
+) -> Result<(), TranslateError> {
+    if !composed.network_enabled && !allowed_hosts.is_empty() {
+        return Err(TranslateError::HostsRequireOutbound);
+    }
+
+    if opts.proxy.is_some() && opts.is_linux_target {
+        return Err(TranslateError::ProxyOnLinux);
+    }
+
+    Ok(())
+}
+
+fn build_lifecycle(opts: &TranslateOptions) -> schema_alpha::LifecycleConfig {
+    // SDK default: clearPolicyOnExit = true → preservePolicy = false.
+    let clear_policy = opts.clear_policy_on_exit.unwrap_or(true);
+    schema_alpha::LifecycleConfig {
+        destroy_on_exit: Some(true),
+        preserve_policy: Some(!clear_policy),
+    }
+}
+
+fn build_process(composed: &EffectiveEnvelope) -> schema_alpha::ProcessConfig {
+    schema_alpha::ProcessConfig {
+        // Driver crates fill commandLine before invoking wxc-exec.
+        command_line: String::new(),
+        cwd: None,
+        env: Vec::new(),
+        timeout: if composed.timeout_ms == 0 {
+            None
+        } else {
+            Some(composed.timeout_ms)
+        },
+    }
+}
+
+fn build_filesystem(composed: &EffectiveEnvelope) -> schema_alpha::FilesystemConfig {
+    schema_alpha::FilesystemConfig {
+        readwrite_paths: composed.readwrite_paths.clone(),
+        readonly_paths: composed.readonly_paths.clone(),
+        denied_paths: composed.denied_paths.clone(),
+    }
+}
+
+fn build_network(
+    composed: &EffectiveEnvelope,
+    allowed_hosts: Vec<String>,
+    proxy: Option<schema_alpha::Proxy>,
+) -> Option<schema_alpha::NetworkConfig> {
+    // Match the SDK: only emit a network block when the baseline has
+    // *something* network-shaped to say. Either outbound is enabled, hosts
+    // are listed, or a proxy is configured.
+    if !composed.network_enabled && allowed_hosts.is_empty() && proxy.is_none() {
+        return None;
+    }
+
+    Some(schema_alpha::NetworkConfig {
+        enforcement_mode: None, // alpha-translator overwrites to Both below
+        default_policy: Some(if composed.network_enabled {
+            schema_alpha::DefaultNetworkPolicy::Allow
+        } else {
+            schema_alpha::DefaultNetworkPolicy::Block
+        }),
+        allowed_hosts,
+        blocked_hosts: Vec::new(),
+        proxy,
+    })
+}
+
+fn build_ui(opts: &TranslateOptions) -> schema_alpha::UiConfig {
+    opts.ui.as_ref().map_or_else(
+        schema_alpha::UiConfig::default,
+        |u| schema_alpha::UiConfig {
+            disable: !u.allow_windows,
+            clipboard: u.clipboard,
+            injection: u.allow_input_injection,
+        },
+    )
+}
+
+fn build_app_container(
+    opts: &TranslateOptions,
+    network_enabled: bool,
+    allow_local_network: bool,
+) -> schema_alpha::AppContainerConfig {
+    let mut capabilities: Vec<String> = Vec::new();
+    if network_enabled {
+        capabilities.push("internetClient".to_owned());
+    }
+    if allow_local_network {
+        capabilities.push("privateNetworkClientServer".to_owned());
+    }
+
+    let name = opts
+        .app_container_name
+        .clone()
+        .or_else(|| opts.container_id.clone());
+
+    schema_alpha::AppContainerConfig {
+        name,
+        least_privilege: Some(false),
+        capabilities,
+        ui: Some(schema_alpha::BaseProcessUiConfig::default()),
+    }
+}

--- a/crates/openshell-mxc-bridge/tests/translate.rs
+++ b/crates/openshell-mxc-bridge/tests/translate.rs
@@ -1,0 +1,349 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the policy → MXC `ContainerConfig` translator.
+//!
+//! These cover the validation rules ported verbatim from
+//! `mxc-aegis/sdk/src/sandbox.ts:143–206` plus the OpenShell-specific
+//! envelope composition behaviour.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use openshell_core::proto::{
+    FilesystemPolicy, NetworkEndpoint, NetworkPolicyRule, SandboxPolicy,
+};
+use openshell_mxc_bridge::schema_alpha::{
+    ClipboardPolicy, DefaultNetworkPolicy, EnforcementMode, Proxy, UiConfig,
+};
+use openshell_mxc_bridge::{
+    Schema, TranslateError, TranslateOptions, build_invocation, schema_dev, translate,
+    translate_alpha, translate_dev,
+};
+use openshell_policy::EnvelopePolicy;
+
+fn baseline_with_fs(read_only: Vec<&str>, read_write: Vec<&str>) -> SandboxPolicy {
+    SandboxPolicy {
+        version: 1,
+        filesystem: Some(FilesystemPolicy {
+            include_workdir: false,
+            read_only: read_only.into_iter().map(str::to_owned).collect(),
+            read_write: read_write.into_iter().map(str::to_owned).collect(),
+        }),
+        landlock: None,
+        process: None,
+        network_policies: HashMap::new(),
+    }
+}
+
+fn baseline_with_network(host: &str) -> SandboxPolicy {
+    let mut policy = baseline_with_fs(vec![], vec![]);
+    policy.network_policies.insert(
+        "rule".to_owned(),
+        NetworkPolicyRule {
+            name: "rule".to_owned(),
+            endpoints: vec![NetworkEndpoint {
+                host: host.to_owned(),
+                port: 443,
+                ..NetworkEndpoint::default()
+            }],
+            binaries: vec![],
+        },
+    );
+    policy
+}
+
+#[test]
+fn round_trip_minimal_policy_alpha_schema() {
+    let baseline = baseline_with_fs(vec!["/usr"], vec!["/tmp"]);
+    let envelope = EnvelopePolicy {
+        readwrite_paths: vec!["/tmp".to_owned()],
+        readonly_paths: vec!["/usr".to_owned()],
+        ..EnvelopePolicy::default()
+    };
+    let opts = TranslateOptions {
+        schema: Schema::AlphaProcess,
+        container_id: Some("box-1".to_owned()),
+        ..TranslateOptions::default()
+    };
+
+    let cfg = translate(&baseline, Some(&envelope), &opts).expect("translates");
+    let alpha = cfg.as_alpha().expect("alpha variant");
+
+    assert_eq!(alpha.version, "0.5.0-alpha");
+    assert_eq!(alpha.container_id.as_deref(), Some("box-1"));
+    assert_eq!(
+        alpha.filesystem.as_ref().expect("fs").readwrite_paths,
+        vec!["/tmp".to_owned()]
+    );
+    assert!(
+        alpha
+            .filesystem
+            .as_ref()
+            .expect("fs")
+            .readonly_paths
+            .contains(&"/usr".to_owned())
+    );
+
+    // No baseline network rule + envelope.network_enabled=false => no network block.
+    assert!(alpha.network.is_none());
+
+    // AppContainer block always present, with no network capabilities.
+    let app = alpha.app_container.as_ref().expect("appContainer");
+    assert!(app.capabilities.is_empty());
+    assert_eq!(app.name.as_deref(), Some("box-1"));
+
+    // Default lifecycle: clearPolicyOnExit=true => preservePolicy=false.
+    let lc = alpha.lifecycle.as_ref().expect("lifecycle");
+    assert_eq!(lc.preserve_policy, Some(false));
+    assert_eq!(lc.destroy_on_exit, Some(true));
+
+    // Default UI = most-restrictive.
+    let ui = alpha.ui.as_ref().expect("ui");
+    assert!(ui.disable);
+    assert!(matches!(ui.clipboard, ClipboardPolicy::None));
+    assert!(!ui.injection);
+
+    // Round-trips through JSON.
+    let json = cfg.to_json().expect("serialises");
+    assert!(json.contains("\"version\":\"0.5.0-alpha\""));
+    assert!(json.contains("\"appContainer\""));
+}
+
+#[test]
+fn allowed_hosts_without_outbound_returns_error() {
+    let baseline = baseline_with_network("api.example.com");
+    let envelope = EnvelopePolicy {
+        network_enabled: false,
+        ..EnvelopePolicy::default()
+    };
+    let opts = TranslateOptions {
+        schema: Schema::AlphaProcess,
+        ..TranslateOptions::default()
+    };
+
+    let err = translate_alpha(&baseline, Some(&envelope), &opts).unwrap_err();
+    assert!(matches!(err, TranslateError::HostsRequireOutbound));
+}
+
+#[test]
+fn baseline_network_with_envelope_outbound_allowed() {
+    let baseline = baseline_with_network("api.example.com");
+    let envelope = EnvelopePolicy {
+        network_enabled: true,
+        ..EnvelopePolicy::default()
+    };
+    let opts = TranslateOptions {
+        schema: Schema::AlphaProcess,
+        container_id: Some("box".to_owned()),
+        ..TranslateOptions::default()
+    };
+
+    let cfg = translate_alpha(&baseline, Some(&envelope), &opts).expect("translates");
+    let net = cfg.network.expect("network block");
+    assert!(matches!(net.default_policy, Some(DefaultNetworkPolicy::Allow)));
+    assert!(matches!(net.enforcement_mode, Some(EnforcementMode::Both)));
+    assert_eq!(net.allowed_hosts, vec!["api.example.com".to_owned()]);
+
+    let app = cfg.app_container.expect("appContainer");
+    assert!(app.capabilities.iter().any(|c| c == "internetClient"));
+    assert!(!app.capabilities.iter().any(|c| c == "privateNetworkClientServer"));
+}
+
+#[test]
+fn allow_local_network_adds_private_network_capability() {
+    let baseline = baseline_with_network("api.example.com");
+    let envelope = EnvelopePolicy {
+        network_enabled: true,
+        allow_local_network: true,
+        ..EnvelopePolicy::default()
+    };
+    let opts = TranslateOptions {
+        schema: Schema::AlphaProcess,
+        ..TranslateOptions::default()
+    };
+
+    let cfg = translate_alpha(&baseline, Some(&envelope), &opts).expect("translates");
+    let app = cfg.app_container.expect("appContainer");
+    assert!(app.capabilities.iter().any(|c| c == "internetClient"));
+    assert!(app.capabilities.iter().any(|c| c == "privateNetworkClientServer"));
+}
+
+#[test]
+fn proxy_on_linux_target_rejected() {
+    let baseline = baseline_with_fs(vec![], vec![]);
+    let opts = TranslateOptions {
+        schema: Schema::AlphaProcess,
+        is_linux_target: true,
+        proxy: Some(Proxy::Localhost { localhost: 8080 }),
+        ..TranslateOptions::default()
+    };
+
+    let err = translate_alpha(&baseline, None, &opts).unwrap_err();
+    assert!(matches!(err, TranslateError::ProxyOnLinux));
+}
+
+#[test]
+fn proxy_on_windows_target_passes_through() {
+    let baseline = baseline_with_fs(vec![], vec![]);
+    let opts = TranslateOptions {
+        schema: Schema::AlphaProcess,
+        is_linux_target: false,
+        proxy: Some(Proxy::Localhost { localhost: 9090 }),
+        ..TranslateOptions::default()
+    };
+
+    let cfg = translate_alpha(&baseline, None, &opts).expect("translates");
+    let net = cfg.network.expect("network block (proxy forces it)");
+    assert!(matches!(net.proxy, Some(Proxy::Localhost { localhost: 9090 })));
+}
+
+#[test]
+fn clear_policy_on_exit_explicit_false_preserves_policy() {
+    let baseline = baseline_with_fs(vec![], vec![]);
+    let opts = TranslateOptions {
+        schema: Schema::AlphaProcess,
+        clear_policy_on_exit: Some(false),
+        ..TranslateOptions::default()
+    };
+
+    let cfg = translate_alpha(&baseline, None, &opts).expect("translates");
+    assert_eq!(cfg.lifecycle.expect("lifecycle").preserve_policy, Some(true));
+}
+
+#[test]
+fn clear_policy_on_exit_default_true_clears_policy() {
+    let baseline = baseline_with_fs(vec![], vec![]);
+    let opts = TranslateOptions {
+        schema: Schema::AlphaProcess,
+        clear_policy_on_exit: None,
+        ..TranslateOptions::default()
+    };
+
+    let cfg = translate_alpha(&baseline, None, &opts).expect("translates");
+    assert_eq!(cfg.lifecycle.expect("lifecycle").preserve_policy, Some(false));
+}
+
+#[test]
+fn timeout_propagates_from_envelope() {
+    let baseline = baseline_with_fs(vec![], vec![]);
+    let envelope = EnvelopePolicy {
+        timeout_ms: 5_000,
+        ..EnvelopePolicy::default()
+    };
+    let opts = TranslateOptions {
+        schema: Schema::AlphaProcess,
+        ..TranslateOptions::default()
+    };
+
+    let cfg = translate_alpha(&baseline, Some(&envelope), &opts).expect("translates");
+    assert_eq!(cfg.process.expect("process").timeout, Some(5_000));
+}
+
+#[test]
+fn ui_policy_overrides_default() {
+    let baseline = baseline_with_fs(vec![], vec![]);
+    let opts = TranslateOptions {
+        schema: Schema::AlphaProcess,
+        ui: Some(openshell_mxc_bridge::UiPolicy {
+            allow_windows: true,
+            clipboard: ClipboardPolicy::Read,
+            allow_input_injection: true,
+        }),
+        ..TranslateOptions::default()
+    };
+
+    let cfg = translate_alpha(&baseline, None, &opts).expect("translates");
+    let ui: UiConfig = cfg.ui.expect("ui");
+    assert!(!ui.disable);
+    assert!(matches!(ui.clipboard, ClipboardPolicy::Read));
+    assert!(ui.injection);
+}
+
+#[test]
+fn dev_schema_sets_isolation_session_containment() {
+    let baseline = baseline_with_fs(vec!["/usr"], vec!["/tmp"]);
+    let opts = TranslateOptions {
+        schema: Schema::DevIsolationSession,
+        container_id: Some("iso-1".to_owned()),
+        isolation_session_configuration_id: Some("profile-prod".to_owned()),
+        ..TranslateOptions::default()
+    };
+
+    let cfg = translate_dev(&baseline, None, &opts).expect("translates");
+    assert_eq!(cfg.version, "0.6.0-dev");
+    assert!(matches!(cfg.containment, schema_dev::Containment::IsolationSession));
+    let iso = cfg
+        .experimental
+        .isolation_session
+        .as_ref()
+        .expect("iso config");
+    assert_eq!(iso.configuration_id.as_deref(), Some("profile-prod"));
+
+    let wrapped = translate(&baseline, None, &opts).expect("wrapped translates");
+    let json = wrapped.to_json().expect("serialises");
+    assert!(json.contains("\"containment\":\"isolation_session\""));
+    assert!(json.contains("\"experimental\""));
+    assert!(json.contains("\"configurationId\":\"profile-prod\""));
+}
+
+#[test]
+fn dev_schema_rejects_app_container_name_option() {
+    let baseline = baseline_with_fs(vec![], vec![]);
+    let opts = TranslateOptions {
+        schema: Schema::DevIsolationSession,
+        app_container_name: Some("nope".to_owned()),
+        ..TranslateOptions::default()
+    };
+
+    let err = translate(&baseline, None, &opts).unwrap_err();
+    assert!(matches!(err, TranslateError::InvalidOptionForSchema { .. }));
+}
+
+#[test]
+fn dev_schema_dispatches_experimental_flag_via_invoke() {
+    let baseline = baseline_with_fs(vec![], vec![]);
+    let opts = TranslateOptions {
+        schema: Schema::DevIsolationSession,
+        ..TranslateOptions::default()
+    };
+    let cfg = translate(&baseline, None, &opts).expect("translates");
+    let json = cfg.to_json().expect("serialises");
+
+    let inv = build_invocation(&PathBuf::from("wxc-exec.exe"), cfg.schema(), &json, false);
+    assert!(inv.args.iter().any(|a| a == "--experimental"));
+}
+
+#[test]
+fn alpha_schema_does_not_add_experimental_via_invoke() {
+    let baseline = baseline_with_fs(vec![], vec![]);
+    let opts = TranslateOptions {
+        schema: Schema::AlphaProcess,
+        ..TranslateOptions::default()
+    };
+    let cfg = translate(&baseline, None, &opts).expect("translates");
+    let json = cfg.to_json().expect("serialises");
+
+    let inv = build_invocation(&PathBuf::from("wxc-exec.exe"), cfg.schema(), &json, false);
+    assert!(!inv.args.iter().any(|a| a == "--experimental"));
+}
+
+#[test]
+fn envelope_intersects_baseline_paths() {
+    let baseline = baseline_with_fs(vec!["/usr", "/etc"], vec!["/tmp", "/sandbox"]);
+    let envelope = EnvelopePolicy {
+        readwrite_paths: vec!["/tmp".to_owned(), "/forbidden".to_owned()],
+        readonly_paths: vec!["/etc".to_owned()],
+        ..EnvelopePolicy::default()
+    };
+    let opts = TranslateOptions {
+        schema: Schema::AlphaProcess,
+        ..TranslateOptions::default()
+    };
+
+    let cfg = translate_alpha(&baseline, Some(&envelope), &opts).expect("translates");
+    let fs = cfg.filesystem.expect("filesystem");
+    assert_eq!(fs.readwrite_paths, vec!["/tmp".to_owned()]);
+    assert!(fs.readonly_paths.iter().any(|p| p == "/etc"));
+    assert!(!fs.readonly_paths.iter().any(|p| p == "/forbidden"));
+}

--- a/crates/openshell-mxc-bridge/tests/translate.rs
+++ b/crates/openshell-mxc-bridge/tests/translate.rs
@@ -10,9 +10,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use openshell_core::proto::{
-    FilesystemPolicy, NetworkEndpoint, NetworkPolicyRule, SandboxPolicy,
-};
+use openshell_core::proto::{FilesystemPolicy, NetworkEndpoint, NetworkPolicyRule, SandboxPolicy};
 use openshell_mxc_bridge::schema_alpha::{
     ClipboardPolicy, DefaultNetworkPolicy, EnforcementMode, Proxy, UiConfig,
 };
@@ -141,13 +139,20 @@ fn baseline_network_with_envelope_outbound_allowed() {
 
     let cfg = translate_alpha(&baseline, Some(&envelope), &opts).expect("translates");
     let net = cfg.network.expect("network block");
-    assert!(matches!(net.default_policy, Some(DefaultNetworkPolicy::Allow)));
+    assert!(matches!(
+        net.default_policy,
+        Some(DefaultNetworkPolicy::Allow)
+    ));
     assert!(matches!(net.enforcement_mode, Some(EnforcementMode::Both)));
     assert_eq!(net.allowed_hosts, vec!["api.example.com".to_owned()]);
 
     let app = cfg.app_container.expect("appContainer");
     assert!(app.capabilities.iter().any(|c| c == "internetClient"));
-    assert!(!app.capabilities.iter().any(|c| c == "privateNetworkClientServer"));
+    assert!(
+        !app.capabilities
+            .iter()
+            .any(|c| c == "privateNetworkClientServer")
+    );
 }
 
 #[test]
@@ -166,7 +171,11 @@ fn allow_local_network_adds_private_network_capability() {
     let cfg = translate_alpha(&baseline, Some(&envelope), &opts).expect("translates");
     let app = cfg.app_container.expect("appContainer");
     assert!(app.capabilities.iter().any(|c| c == "internetClient"));
-    assert!(app.capabilities.iter().any(|c| c == "privateNetworkClientServer"));
+    assert!(
+        app.capabilities
+            .iter()
+            .any(|c| c == "privateNetworkClientServer")
+    );
 }
 
 #[test]
@@ -195,7 +204,10 @@ fn proxy_on_windows_target_passes_through() {
 
     let cfg = translate_alpha(&baseline, None, &opts).expect("translates");
     let net = cfg.network.expect("network block (proxy forces it)");
-    assert!(matches!(net.proxy, Some(Proxy::Localhost { localhost: 9090 })));
+    assert!(matches!(
+        net.proxy,
+        Some(Proxy::Localhost { localhost: 9090 })
+    ));
 }
 
 #[test]
@@ -208,7 +220,10 @@ fn clear_policy_on_exit_explicit_false_preserves_policy() {
     };
 
     let cfg = translate_alpha(&baseline, None, &opts).expect("translates");
-    assert_eq!(cfg.lifecycle.expect("lifecycle").preserve_policy, Some(true));
+    assert_eq!(
+        cfg.lifecycle.expect("lifecycle").preserve_policy,
+        Some(true)
+    );
 }
 
 #[test]
@@ -221,7 +236,10 @@ fn clear_policy_on_exit_default_true_clears_policy() {
     };
 
     let cfg = translate_alpha(&baseline, None, &opts).expect("translates");
-    assert_eq!(cfg.lifecycle.expect("lifecycle").preserve_policy, Some(false));
+    assert_eq!(
+        cfg.lifecycle.expect("lifecycle").preserve_policy,
+        Some(false)
+    );
 }
 
 #[test]
@@ -272,7 +290,10 @@ fn dev_schema_sets_isolation_session_containment() {
 
     let cfg = translate_dev(&baseline, None, &opts).expect("translates");
     assert_eq!(cfg.version, "0.6.0-dev");
-    assert!(matches!(cfg.containment, schema_dev::Containment::IsolationSession));
+    assert!(matches!(
+        cfg.containment,
+        schema_dev::Containment::IsolationSession
+    ));
     let iso = cfg
         .experimental
         .isolation_session

--- a/crates/openshell-policy/src/envelope.rs
+++ b/crates/openshell-policy/src/envelope.rs
@@ -1,0 +1,410 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-task envelope policy and composition with the baseline `SandboxPolicy`.
+//!
+//! An [`EnvelopePolicy`] is a per-task constraint surface authored by the
+//! gateway/orchestrator on top of the operator-controlled baseline
+//! [`SandboxPolicy`]. The resulting [`EffectiveEnvelope`] is the
+//! most-restrictive intersection of the two: an envelope can only ever
+//! *narrow* what the baseline allows, never broaden it.
+//!
+//! See `rfc/0004-aegis-governance` §"Policy composition" and §"Wire shape".
+//
+// TODO(aegis-proto): once the `EnvelopePolicy` proto message lands (tracked by
+// the proto-aegis task), re-export the prost-generated type from here instead
+// of carrying a duplicate definition.
+
+use std::collections::BTreeSet;
+
+use openshell_core::proto::SandboxPolicy;
+use serde::{Deserialize, Serialize};
+
+/// Per-task envelope policy.
+///
+/// Field shape mirrors the planned `EnvelopePolicy` proto message. All fields
+/// are optional in spirit: empty vectors mean "no constraint contributed by
+/// the envelope on this axis" only for `denied_paths`; for the path allow
+/// lists an empty vector means "envelope grants nothing on this axis", which
+/// is the most-restrictive floor.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EnvelopePolicy {
+    /// Paths the task may read and write.
+    pub readwrite_paths: Vec<String>,
+    /// Paths the task may read.
+    pub readonly_paths: Vec<String>,
+    /// Paths the task must not access. Unioned with the baseline's deny list.
+    pub denied_paths: Vec<String>,
+    /// Whether the task may use the network at all.
+    pub network_enabled: bool,
+    /// Whether the task may reach loopback / link-local destinations.
+    pub allow_local_network: bool,
+    /// Maximum task wall-clock time in milliseconds. `0` means "unlimited".
+    pub timeout_ms: u32,
+    /// Named sandbox profile (capability bundle) requested by the task. Empty
+    /// string means "no profile pinned by the envelope".
+    pub sandbox_profile: String,
+}
+
+/// The result of composing an [`EnvelopePolicy`] against a [`SandboxPolicy`].
+///
+/// Returned by [`compose`]. This is a separate type from [`EnvelopePolicy`] so
+/// that composition is type-safe: an effective envelope cannot accidentally be
+/// fed back into composition as if it were a fresh per-task envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveEnvelope {
+    pub readwrite_paths: Vec<String>,
+    pub readonly_paths: Vec<String>,
+    pub denied_paths: Vec<String>,
+    pub network_enabled: bool,
+    pub allow_local_network: bool,
+    pub timeout_ms: u32,
+    pub sandbox_profile: String,
+}
+
+/// Compose a baseline [`SandboxPolicy`] with a per-task [`EnvelopePolicy`],
+/// producing the most-restrictive intersection.
+///
+/// Composition rules (see RFC 0004 §"Policy composition"):
+///
+/// * `readwrite_paths` = `envelope.readwrite_paths` ∩
+///   `baseline.filesystem.read_write`
+/// * `readonly_paths` = (`envelope.readonly_paths` ∪
+///   `envelope.readwrite_paths`) ∩ `baseline.filesystem.read_only`
+/// * `denied_paths` = `envelope.denied_paths` ∪ baseline deny list
+/// * `network_enabled` = `envelope.network_enabled` ∧ `baseline_allows_network`
+/// * `allow_local_network` = `envelope.allow_local_network` ∧
+///   `baseline_allows_local_network`
+/// * `timeout_ms` = `min(envelope.timeout_ms, baseline.max_timeout_ms)` where
+///   `0` is treated as "unlimited"; the result is `0` only when both inputs
+///   are `0`.
+/// * `sandbox_profile`: the envelope must request the same profile the
+///   baseline pins, or the empty string. Otherwise the envelope is rejected
+///   by clearing the field — callers should treat an empty profile in the
+///   effective envelope as "no capability bundle granted".
+///
+/// Outputs are deterministic: path vectors are sorted and deduplicated.
+#[must_use]
+pub fn compose(baseline: &SandboxPolicy, envelope: &EnvelopePolicy) -> EffectiveEnvelope {
+    // Baseline filesystem allow lists. The proto `SandboxPolicy` carries
+    // these inside the optional `filesystem` submessage with field names
+    // `read_write` / `read_only`. They are the closest equivalents to the
+    // RFC's `allowed_writable_paths` / `allowed_readable_paths`.
+    let baseline_rw: BTreeSet<&str> = baseline
+        .filesystem
+        .as_ref()
+        .map(|fs| fs.read_write.iter().map(String::as_str).collect())
+        .unwrap_or_default();
+    let baseline_ro: BTreeSet<&str> = baseline
+        .filesystem
+        .as_ref()
+        .map(|fs| fs.read_only.iter().map(String::as_str).collect())
+        .unwrap_or_default();
+
+    // TODO(aegis-baseline): the current `SandboxPolicy` proto has no explicit
+    // `denied_paths` field. Treat the baseline contribution to the deny list
+    // as empty until the proto grows one (tracked in RFC 0004).
+    let baseline_denied: BTreeSet<&str> = BTreeSet::new();
+
+    // Intersect envelope read-write against baseline read-write.
+    let env_rw: BTreeSet<&str> = envelope.readwrite_paths.iter().map(String::as_str).collect();
+    let readwrite_paths = sorted_intersection(&env_rw, &baseline_rw);
+
+    // Read-only effective set: union envelope ro + envelope rw, intersect
+    // with baseline ro. Anything the envelope wants writable must also be at
+    // least readable on the baseline — but we surface that requirement via
+    // the read-only allow list, not by hoisting writable entries into it.
+    let mut env_ro_union: BTreeSet<&str> =
+        envelope.readonly_paths.iter().map(String::as_str).collect();
+    env_ro_union.extend(envelope.readwrite_paths.iter().map(String::as_str));
+    let readonly_paths = sorted_intersection(&env_ro_union, &baseline_ro);
+
+    // Denied paths are a union — anything either side denies stays denied.
+    let mut denied_set: BTreeSet<&str> =
+        envelope.denied_paths.iter().map(String::as_str).collect();
+    denied_set.extend(baseline_denied.iter().copied());
+    let denied_paths: Vec<String> = denied_set.into_iter().map(str::to_owned).collect();
+
+    // TODO(aegis-baseline): the current `SandboxPolicy` proto has no explicit
+    // `allows_network` flag. Approximate it as "baseline grants network iff
+    // it ships at least one network policy rule"; an empty `network_policies`
+    // map is interpreted as "no network allowed" (matches
+    // `restrictive_default_policy()`).
+    let baseline_allows_network = !baseline.network_policies.is_empty();
+    let network_enabled = envelope.network_enabled && baseline_allows_network;
+
+    // TODO(aegis-baseline): the current `SandboxPolicy` proto has no explicit
+    // `allows_local_network` flag. Default the baseline contribution to
+    // `true` (most-permissive on this axis) so the envelope's value wins
+    // until the baseline can actually constrain it.
+    let baseline_allows_local_network = true;
+    let allow_local_network = envelope.allow_local_network && baseline_allows_local_network;
+
+    // TODO(aegis-baseline): the current `SandboxPolicy` proto has no explicit
+    // `max_timeout_ms`. Default the baseline contribution to `0` (unlimited);
+    // the envelope's timeout will dominate until the proto grows one.
+    let baseline_max_timeout_ms: u32 = 0;
+    let timeout_ms = min_timeout(envelope.timeout_ms, baseline_max_timeout_ms);
+
+    // TODO(aegis-baseline): the current `SandboxPolicy` proto has no explicit
+    // `sandbox_profile` pin. Default the baseline contribution to `""` (no
+    // pin) so any envelope-requested profile passes through. When the proto
+    // gains a pinned profile, `sandbox_profile` becomes: empty if the
+    // envelope's request differs from the pin and is non-empty; otherwise
+    // the envelope's value.
+    let baseline_sandbox_profile: &str = "";
+    let sandbox_profile = compose_profile(&envelope.sandbox_profile, baseline_sandbox_profile);
+
+    EffectiveEnvelope {
+        readwrite_paths,
+        readonly_paths,
+        denied_paths,
+        network_enabled,
+        allow_local_network,
+        timeout_ms,
+        sandbox_profile,
+    }
+}
+
+fn sorted_intersection(a: &BTreeSet<&str>, b: &BTreeSet<&str>) -> Vec<String> {
+    a.intersection(b).map(|s| (*s).to_owned()).collect()
+}
+
+fn min_timeout(envelope_ms: u32, baseline_ms: u32) -> u32 {
+    match (envelope_ms, baseline_ms) {
+        (0, 0) => 0,
+        (0, b) => b,
+        (e, 0) => e,
+        (e, b) => e.min(b),
+    }
+}
+
+fn compose_profile(envelope_profile: &str, baseline_profile: &str) -> String {
+    if baseline_profile.is_empty() {
+        envelope_profile.to_owned()
+    } else if envelope_profile.is_empty() || envelope_profile == baseline_profile {
+        baseline_profile.to_owned()
+    } else {
+        // Envelope asks for a different profile than the baseline pins —
+        // reject by yielding "no profile granted".
+        String::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use openshell_core::proto::{
+        FilesystemPolicy, NetworkEndpoint, NetworkPolicyRule, SandboxPolicy,
+    };
+
+    use super::*;
+
+    fn baseline_with_fs(read_only: Vec<&str>, read_write: Vec<&str>) -> SandboxPolicy {
+        SandboxPolicy {
+            version: 1,
+            filesystem: Some(FilesystemPolicy {
+                include_workdir: false,
+                read_only: read_only.into_iter().map(str::to_owned).collect(),
+                read_write: read_write.into_iter().map(str::to_owned).collect(),
+            }),
+            landlock: None,
+            process: None,
+            network_policies: HashMap::new(),
+        }
+    }
+
+    fn baseline_with_network() -> SandboxPolicy {
+        let mut policy = baseline_with_fs(vec!["/usr"], vec!["/tmp"]);
+        policy.network_policies.insert(
+            "allow_all".to_owned(),
+            NetworkPolicyRule {
+                name: "allow_all".to_owned(),
+                endpoints: vec![NetworkEndpoint {
+                    host: "example.com".to_owned(),
+                    port: 443,
+                    ..NetworkEndpoint::default()
+                }],
+                binaries: vec![],
+            },
+        );
+        policy
+    }
+
+    #[test]
+    fn empty_envelope_against_permissive_baseline_is_fully_restrictive() {
+        let baseline = baseline_with_fs(
+            vec!["/usr", "/etc", "/var/log"],
+            vec!["/tmp", "/sandbox"],
+        );
+        let envelope = EnvelopePolicy::default();
+
+        let effective = compose(&baseline, &envelope);
+
+        assert!(effective.readwrite_paths.is_empty());
+        assert!(effective.readonly_paths.is_empty());
+        assert!(effective.denied_paths.is_empty());
+        assert!(!effective.network_enabled);
+        assert!(!effective.allow_local_network);
+        assert_eq!(effective.timeout_ms, 0);
+        assert!(effective.sandbox_profile.is_empty());
+    }
+
+    #[test]
+    fn envelope_writable_path_not_in_baseline_is_excluded() {
+        let baseline = baseline_with_fs(vec!["/usr"], vec!["/tmp"]);
+        let envelope = EnvelopePolicy {
+            readwrite_paths: vec!["/tmp".to_owned(), "/forbidden".to_owned()],
+            ..EnvelopePolicy::default()
+        };
+
+        let effective = compose(&baseline, &envelope);
+
+        assert_eq!(effective.readwrite_paths, vec!["/tmp".to_owned()]);
+        assert!(!effective.readwrite_paths.contains(&"/forbidden".to_owned()));
+    }
+
+    #[test]
+    fn denied_paths_are_unioned_with_baseline() {
+        // Baseline currently contributes no deny entries (see compose() TODO),
+        // so the union is exactly the envelope's deny list — but the result
+        // must still be sorted + deduped.
+        let baseline = baseline_with_fs(vec![], vec![]);
+        let envelope = EnvelopePolicy {
+            denied_paths: vec![
+                "/secrets".to_owned(),
+                "/etc/shadow".to_owned(),
+                "/secrets".to_owned(),
+            ],
+            ..EnvelopePolicy::default()
+        };
+
+        let effective = compose(&baseline, &envelope);
+
+        assert_eq!(
+            effective.denied_paths,
+            vec!["/etc/shadow".to_owned(), "/secrets".to_owned()],
+        );
+    }
+
+    #[test]
+    fn envelope_wants_network_but_baseline_blocks_it() {
+        let baseline = baseline_with_fs(vec![], vec![]); // no network_policies
+        let envelope = EnvelopePolicy {
+            network_enabled: true,
+            allow_local_network: true,
+            ..EnvelopePolicy::default()
+        };
+
+        let effective = compose(&baseline, &envelope);
+
+        assert!(!effective.network_enabled);
+        // allow_local_network currently passes through (see TODO in compose()).
+        assert!(effective.allow_local_network);
+    }
+
+    #[test]
+    fn envelope_and_baseline_both_allow_network() {
+        let baseline = baseline_with_network();
+        let envelope = EnvelopePolicy {
+            network_enabled: true,
+            ..EnvelopePolicy::default()
+        };
+
+        let effective = compose(&baseline, &envelope);
+
+        assert!(effective.network_enabled);
+    }
+
+    #[test]
+    fn timeout_min_selection_when_both_nonzero() {
+        assert_eq!(min_timeout(5_000, 10_000), 5_000);
+        assert_eq!(min_timeout(10_000, 5_000), 5_000);
+    }
+
+    #[test]
+    fn timeout_zero_is_unlimited() {
+        assert_eq!(min_timeout(0, 0), 0);
+        assert_eq!(min_timeout(0, 7_500), 7_500);
+        assert_eq!(min_timeout(7_500, 0), 7_500);
+    }
+
+    #[test]
+    fn readonly_includes_envelope_writable_when_baseline_allows_reading_it() {
+        let baseline = baseline_with_fs(vec!["/usr", "/tmp"], vec!["/tmp"]);
+        let envelope = EnvelopePolicy {
+            readwrite_paths: vec!["/tmp".to_owned()],
+            readonly_paths: vec!["/usr".to_owned()],
+            ..EnvelopePolicy::default()
+        };
+
+        let effective = compose(&baseline, &envelope);
+
+        assert_eq!(effective.readwrite_paths, vec!["/tmp".to_owned()]);
+        assert_eq!(
+            effective.readonly_paths,
+            vec!["/tmp".to_owned(), "/usr".to_owned()],
+        );
+    }
+
+    #[test]
+    fn outputs_are_sorted_and_deduplicated() {
+        let baseline = baseline_with_fs(
+            vec!["/a", "/b", "/c"],
+            vec!["/x", "/y", "/z"],
+        );
+        let envelope = EnvelopePolicy {
+            readwrite_paths: vec!["/z".to_owned(), "/x".to_owned(), "/x".to_owned()],
+            readonly_paths: vec!["/c".to_owned(), "/a".to_owned()],
+            ..EnvelopePolicy::default()
+        };
+
+        let effective = compose(&baseline, &envelope);
+
+        assert_eq!(effective.readwrite_paths, vec!["/x".to_owned(), "/z".to_owned()]);
+        // readonly = (envelope.readonly ∪ envelope.readwrite) ∩ baseline.read_only
+        // baseline.read_only is {/a,/b,/c}, so the intersection is {/a,/c}.
+        assert_eq!(effective.readonly_paths, vec!["/a".to_owned(), "/c".to_owned()]);
+    }
+
+    #[test]
+    fn compose_is_deterministic() {
+        let baseline = baseline_with_fs(vec!["/a", "/b"], vec!["/x", "/y"]);
+        let envelope = EnvelopePolicy {
+            readwrite_paths: vec!["/y".to_owned(), "/x".to_owned()],
+            readonly_paths: vec!["/b".to_owned(), "/a".to_owned()],
+            denied_paths: vec!["/two".to_owned(), "/one".to_owned()],
+            ..EnvelopePolicy::default()
+        };
+
+        let first = compose(&baseline, &envelope);
+        let second = compose(&baseline, &envelope);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn sandbox_profile_passes_through_when_baseline_unpinned() {
+        let baseline = baseline_with_fs(vec![], vec![]);
+        let envelope = EnvelopePolicy {
+            sandbox_profile: "minimal".to_owned(),
+            ..EnvelopePolicy::default()
+        };
+
+        let effective = compose(&baseline, &envelope);
+        assert_eq!(effective.sandbox_profile, "minimal");
+    }
+
+    #[test]
+    fn compose_profile_helper() {
+        // Baseline unpinned -> envelope wins.
+        assert_eq!(compose_profile("minimal", ""), "minimal");
+        assert_eq!(compose_profile("", ""), "");
+        // Baseline pinned, envelope empty -> baseline wins.
+        assert_eq!(compose_profile("", "strict"), "strict");
+        // Baseline pinned, envelope agrees -> baseline.
+        assert_eq!(compose_profile("strict", "strict"), "strict");
+        // Baseline pinned, envelope disagrees -> rejected.
+        assert_eq!(compose_profile("loose", "strict"), "");
+    }
+}

--- a/crates/openshell-policy/src/envelope.rs
+++ b/crates/openshell-policy/src/envelope.rs
@@ -107,7 +107,11 @@ pub fn compose(baseline: &SandboxPolicy, envelope: &EnvelopePolicy) -> Effective
     let baseline_denied: BTreeSet<&str> = BTreeSet::new();
 
     // Intersect envelope read-write against baseline read-write.
-    let env_rw: BTreeSet<&str> = envelope.readwrite_paths.iter().map(String::as_str).collect();
+    let env_rw: BTreeSet<&str> = envelope
+        .readwrite_paths
+        .iter()
+        .map(String::as_str)
+        .collect();
     let readwrite_paths = sorted_intersection(&env_rw, &baseline_rw);
 
     // Read-only effective set: union envelope ro + envelope rw, intersect
@@ -120,8 +124,7 @@ pub fn compose(baseline: &SandboxPolicy, envelope: &EnvelopePolicy) -> Effective
     let readonly_paths = sorted_intersection(&env_ro_union, &baseline_ro);
 
     // Denied paths are a union — anything either side denies stays denied.
-    let mut denied_set: BTreeSet<&str> =
-        envelope.denied_paths.iter().map(String::as_str).collect();
+    let mut denied_set: BTreeSet<&str> = envelope.denied_paths.iter().map(String::as_str).collect();
     denied_set.extend(baseline_denied.iter().copied());
     let denied_paths: Vec<String> = denied_set.into_iter().map(str::to_owned).collect();
 
@@ -234,10 +237,7 @@ mod tests {
 
     #[test]
     fn empty_envelope_against_permissive_baseline_is_fully_restrictive() {
-        let baseline = baseline_with_fs(
-            vec!["/usr", "/etc", "/var/log"],
-            vec!["/tmp", "/sandbox"],
-        );
+        let baseline = baseline_with_fs(vec!["/usr", "/etc", "/var/log"], vec!["/tmp", "/sandbox"]);
         let envelope = EnvelopePolicy::default();
 
         let effective = compose(&baseline, &envelope);
@@ -350,10 +350,7 @@ mod tests {
 
     #[test]
     fn outputs_are_sorted_and_deduplicated() {
-        let baseline = baseline_with_fs(
-            vec!["/a", "/b", "/c"],
-            vec!["/x", "/y", "/z"],
-        );
+        let baseline = baseline_with_fs(vec!["/a", "/b", "/c"], vec!["/x", "/y", "/z"]);
         let envelope = EnvelopePolicy {
             readwrite_paths: vec!["/z".to_owned(), "/x".to_owned(), "/x".to_owned()],
             readonly_paths: vec!["/c".to_owned(), "/a".to_owned()],
@@ -362,10 +359,16 @@ mod tests {
 
         let effective = compose(&baseline, &envelope);
 
-        assert_eq!(effective.readwrite_paths, vec!["/x".to_owned(), "/z".to_owned()]);
+        assert_eq!(
+            effective.readwrite_paths,
+            vec!["/x".to_owned(), "/z".to_owned()]
+        );
         // readonly = (envelope.readonly ∪ envelope.readwrite) ∩ baseline.read_only
         // baseline.read_only is {/a,/b,/c}, so the intersection is {/a,/c}.
-        assert_eq!(effective.readonly_paths, vec!["/a".to_owned(), "/c".to_owned()]);
+        assert_eq!(
+            effective.readonly_paths,
+            vec!["/a".to_owned(), "/c".to_owned()]
+        );
     }
 
     #[test]

--- a/crates/openshell-policy/src/lib.rs
+++ b/crates/openshell-policy/src/lib.rs
@@ -10,6 +10,7 @@
 //! these types, ensuring round-trip fidelity.
 
 mod compose;
+mod envelope;
 mod merge;
 
 use std::collections::{BTreeMap, HashMap};
@@ -25,6 +26,7 @@ use openshell_core::proto::{
 use serde::{Deserialize, Serialize};
 
 pub use compose::{ProviderPolicyLayer, compose_effective_policy, provider_rule_name};
+pub use envelope::{EffectiveEnvelope, EnvelopePolicy, compose as compose_envelope};
 pub use merge::{
     PolicyMergeError, PolicyMergeOp, PolicyMergeResult, PolicyMergeWarning, generated_rule_name,
     merge_policy, policy_covers_rule,

--- a/crates/openshell-sandbox/Cargo.toml
+++ b/crates/openshell-sandbox/Cargo.toml
@@ -41,7 +41,7 @@ russh = "0.57"
 rand_core = "0.6"
 
 # OPA policy evaluation (no default features — full-opa pulls in opa-runtime which requires git in build)
-regorus = { version = "0.9", default-features = false, features = ["std", "arc", "glob", "yaml"] }
+regorus = { version = "0.9", default-features = false, features = ["std", "arc", "glob", "yaml", "regex"] }
 
 # TLS
 tokio-rustls = { workspace = true }

--- a/crates/openshell-server/src/auth/oidc.rs
+++ b/crates/openshell-server/src/auth/oidc.rs
@@ -49,6 +49,7 @@ const SANDBOX_SECRET_METHODS: &[&str] = &[
     "/openshell.v1.OpenShell/SubmitPolicyAnalysis",
     "/openshell.sandbox.v1.SandboxService/GetSandboxConfig",
     "/openshell.inference.v1.Inference/GetInferenceBundle",
+    "/openshell.v1.OpenShell/VerifyAegisTicket",
 ];
 
 /// Methods that accept either OIDC Bearer token (CLI users) or sandbox
@@ -526,6 +527,23 @@ mod tests {
     fn sandbox_secret_missing_header() {
         let headers = http::HeaderMap::new();
         assert!(validate_sandbox_secret(&headers, "test-secret").is_err());
+    }
+
+    #[test]
+    fn aegis_verify_uses_sandbox_secret() {
+        assert!(is_sandbox_secret_method(
+            "/openshell.v1.OpenShell/VerifyAegisTicket"
+        ));
+        assert!(!is_unauthenticated_method(
+            "/openshell.v1.OpenShell/VerifyAegisTicket"
+        ));
+    }
+
+    #[test]
+    fn aegis_issue_requires_oidc_default() {
+        let path = "/openshell.v1.OpenShell/IssueAegisTicket";
+        assert!(!is_sandbox_secret_method(path));
+        assert!(!is_unauthenticated_method(path));
     }
 
     #[test]

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -694,6 +694,15 @@ async fn build_compute_runtime(
             .await
             .map_err(|e| Error::execution(format!("failed to create compute runtime: {e}")))
         }
+        // TODO(server-compute): wire AppContainer / IsolationSession Windows
+        // compute drivers. Until then, `configured_compute_driver` accepts
+        // these variants but `build_compute_runtime` rejects them with an
+        // explicit error so misconfigurations surface clearly.
+        ComputeDriverKind::AppContainer | ComputeDriverKind::IsolationSession => {
+            Err(Error::config(format!(
+                "compute driver `{driver}` is not yet wired into the gateway"
+            )))
+        }
     }
 }
 
@@ -709,7 +718,9 @@ fn configured_compute_driver(config: &Config) -> Result<ComputeDriverKind> {
             driver @ (ComputeDriverKind::Kubernetes
             | ComputeDriverKind::Vm
             | ComputeDriverKind::Docker
-            | ComputeDriverKind::Podman),
+            | ComputeDriverKind::Podman
+            | ComputeDriverKind::AppContainer
+            | ComputeDriverKind::IsolationSession),
         ] => Ok(*driver),
         drivers => Err(Error::config(format!(
             "multiple compute drivers are not supported yet; configured drivers: {}",

--- a/proto/compute_driver.proto
+++ b/proto/compute_driver.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 package openshell.compute.v1;
 
 import "google/protobuf/struct.proto";
+import "sandbox.proto";
 
 // Internal compute-driver contract used by the gateway.
 //
@@ -215,6 +216,10 @@ message ListSandboxesResponse {
 message CreateSandboxRequest {
   // Sandbox configuration to provision on the compute platform.
   DriverSandbox sandbox = 1;
+  // Optional AEGIS-issued ticket scoping this sandbox's execution envelope.
+  // When present, the driver verifies the ticket and enforces its envelope
+  // for the upcoming command execution.
+  optional openshell.sandbox.v1.SignedTicket signed_ticket = 2;
 }
 
 message CreateSandboxResponse {}

--- a/proto/openshell.proto
+++ b/proto/openshell.proto
@@ -203,6 +203,15 @@ service OpenShell {
 
   // Get decision history for a sandbox's draft policy.
   rpc GetDraftHistory(GetDraftHistoryRequest) returns (GetDraftHistoryResponse);
+
+  // Evaluate AEGIS policy for a tool call and, when allowed, issue a
+  // signed ExecutionTicket the agent runtime can hand to the driver.
+  rpc IssueAegisTicket(openshell.sandbox.v1.IssueAegisTicketRequest)
+      returns (openshell.sandbox.v1.IssueAegisTicketResponse);
+
+  // Verify an existing signed AEGIS ticket without redeeming it.
+  rpc VerifyAegisTicket(openshell.sandbox.v1.VerifyAegisTicketRequest)
+      returns (openshell.sandbox.v1.VerifyAegisTicketResponse);
 }
 
 // Health check request.

--- a/proto/sandbox.proto
+++ b/proto/sandbox.proto
@@ -269,3 +269,116 @@ message GetSandboxConfigResponse {
   // Changes when attached provider names or attached provider records change.
   uint64 provider_env_revision = 8;
 }
+
+// AEGIS execution-envelope policy bound to a single tool call.
+//
+// EnvelopePolicy is the constrained subset of `SandboxPolicy` that the AEGIS
+// gateway adapter computes per tool call and embeds inside an `ExecutionTicket`.
+// Drivers consume this envelope to scope filesystem, network, and timeout
+// constraints for the upcoming command execution.
+message EnvelopePolicy {
+  // Filesystem paths the tool call may read and write.
+  repeated string readwrite_paths = 1;
+  // Filesystem paths the tool call may read only.
+  repeated string readonly_paths = 2;
+  // Filesystem paths the tool call must not access.
+  repeated string denied_paths = 3;
+  // True when network egress is permitted for this tool call.
+  bool network_enabled = 4;
+  // True when loopback / private-range network access is permitted.
+  bool allow_local_network = 5;
+  // Maximum wall-clock execution time in milliseconds before the driver
+  // terminates the tool call. Zero means "use driver default".
+  uint32 timeout_ms = 6;
+  // Driver-specific sandbox profile name (e.g. AppContainer profile).
+  string sandbox_profile = 7;
+}
+
+// AEGIS execution ticket: the signed authorization bound to one tool call.
+//
+// The ticket is canonically serialized as JSON, base64-encoded, and embedded
+// in a `SignedTicket` together with an ECDSA P-256 signature. Drivers verify
+// the signature offline against the gateway's published public key before
+// honoring the envelope.
+message ExecutionTicket {
+  // Ticket schema version.
+  uint32 version = 1;
+  // Tool name reported by the agent runtime (e.g. "shell", "edit_file").
+  string tool_name = 2;
+  // Runtime-supplied tool-call identifier used to correlate ticket issuance,
+  // verification, and audit events for the same logical call.
+  string tool_call_id = 3;
+  // Sandbox session identifier the tool call belongs to.
+  string session_id = 4;
+  // Hash of the canonicalized tool arguments at issuance time.
+  string args_hash = 5;
+  // Working directory the tool call will run in.
+  string cwd = 6;
+  // Constrained execution envelope the driver must enforce.
+  EnvelopePolicy envelope = 7;
+  // Hash of the policy revision used to derive this ticket.
+  string policy_hash = 8;
+  // Issuance timestamp (milliseconds since epoch).
+  uint64 issued_at = 9;
+  // Expiration timestamp (milliseconds since epoch).
+  uint64 expires_at = 10;
+  // Single-use nonce that prevents ticket replay.
+  string nonce = 11;
+}
+
+// Wire form of an AEGIS execution ticket carrying its signature.
+message SignedTicket {
+  // Base64 of the canonical JSON encoding of `ExecutionTicket`.
+  string ticket = 1;
+  // Base64 of the ECDSA P-256 signature over the canonical ticket bytes.
+  string signature = 2;
+  // Base64 of the SPKI-encoded public key. Empty means the driver should
+  // resolve the gateway's well-known public key path.
+  string public_key = 3;
+}
+
+// AEGIS policy decision attached to an issuance response.
+message AegisDecisionRecord {
+  // Decision verdict: "allow", "deny", or "ask".
+  string decision = 1;
+  // Human-readable reason for the decision.
+  string reason = 2;
+  // Name of the Rego rule that produced the decision.
+  string rule_name = 3;
+  // Ticket the gateway would issue if the decision is "allow".
+  ExecutionTicket ticket = 4;
+}
+
+// Request to evaluate AEGIS policy and (when allowed) issue a signed ticket.
+message IssueAegisTicketRequest {
+  // Adapter scope the runtime payload follows (e.g. "copilot", "claude").
+  string scope = 1;
+  // Raw runtime hook payload. The gateway adapter normalizes this into an
+  // ActionRequest before policy evaluation.
+  bytes runtime_payload = 2;
+}
+
+// Response carrying the AEGIS decision and, when allowed, a signed ticket.
+message IssueAegisTicketResponse {
+  // Decision record describing the verdict and matched rule.
+  AegisDecisionRecord decision = 1;
+  // Signed ticket. Only populated when `decision.decision` is "allow".
+  SignedTicket signed_ticket = 2;
+}
+
+// Request to verify an existing signed AEGIS ticket.
+message VerifyAegisTicketRequest {
+  // Ticket whose signature, expiry, and nonce state must be validated.
+  SignedTicket signed_ticket = 1;
+}
+
+// Response describing whether a signed AEGIS ticket is valid.
+message VerifyAegisTicketResponse {
+  // True when the ticket signature, expiry, and nonce checks all pass.
+  bool valid = 1;
+  // Human-readable reason when `valid` is false.
+  string reason = 2;
+  // Decoded ticket payload, populated whenever the wire format parsed
+  // successfully (even if `valid` is false).
+  ExecutionTicket ticket = 3;
+}


### PR DESCRIPTION
## Summary

Lays the foundation for AEGIS (governance/ticketing) and MXC (Multi-eXecution Container bridge) integration into OpenShell. This PR is **scaffolding only** — no runtime code paths invoke the new types yet. Subsequent PRs will wire the proto RPCs through the gateway and translate AEGIS envelopes into enforced sandbox policy at runtime.

## Related Issue

None — internal foundation work. No tracking issue exists yet; this PR establishes the surface area for future issues to reference.

## Changes

- **Workspace plumbing** — scaffold `openshell-mxc-bridge` crate; enable `regorus` + `regex` workspace deps for upcoming Rego policy evaluation.
- **Proto** — add `IssueAegisTicket`/`VerifyAegisTicket` RPCs, `EnvelopePolicy`, and `SignedTicket` messages to `openshell.v1.OpenShell`.
- **Policy** (`openshell-policy`) — `EnvelopePolicy` type with most-restrictive composition against a baseline policy (intersection semantics for read/write paths).
- **Core** (`openshell-core`) — `ComputeDriverKind` variants for `AppContainer` and `IsolationSession`.
- **Bootstrap** (`openshell-bootstrap`) — `aegis_keys` module providing ECDSA P-256 keypair lifecycle (generate/load/persist) for ticket signing.
- **Server auth** (`openshell-server`) — classify `VerifyAegisTicket` as sandbox-secret authenticated; `IssueAegisTicket` continues to require OIDC bearer auth.
- **MXC bridge** (`openshell-mxc-bridge`) — translator between AEGIS envelope schema and MXC `wxc-exec` invocation contract.
- **Architecture docs** — new `architecture/aegis-governance.md` overview; cross-references from existing subsystem docs.
- **Style** — rustfmt fixup commit at the tip (formatting drift from per-worker isolated builds).

## Testing

- [x] Unit tests added for each new module (envelope composition, ticket key lifecycle, MXC translation, auth classification).
- [ ] `mise run pre-commit` — **not run locally** (Windows ARM64 host: `mise install` fails because `skaffold@2.19.0` ships no win-arm64 binary; `mise.toml` `lockfile_platforms` excludes Windows). Will be validated by GitHub Actions.
- [ ] `mise run test` / `mise run ci` — **not run locally** (this codebase does not build on Windows ARM64: `aws-lc-sys` chacha-armv8 link step requires an assembler not present, and `protobuf-src` requires `sh`). Will be validated by GitHub Actions.
- [x] `cargo fmt --check` — clean (rustfmt fixup committed).
- [ ] E2E tests — N/A (no runtime code paths added).

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (new `architecture/aegis-governance.md`)
- [x] No AI co-author trailers (per `AGENTS.md`)

## Notes for reviewers

- This is intentionally inert plumbing. None of the new RPCs are wired into the dispatch surface yet — `VerifyAegisTicket`/`IssueAegisTicket` will return Unimplemented until a follow-up PR connects them.
- The `EnvelopePolicy::compose` semantics are most-restrictive: the effective read/write set is the intersection of the envelope's request and the baseline's permissions. Worth a careful read since this is the security boundary.
- Opening as **draft** to let GitHub Actions perform the actual lint/build/test validation that couldn't run on the author's host. Will move to ready-for-review once CI is green.
