### PR TITLE
fix(vm): make /sandbox chown non-fatal for virtiofs rootless hosts

### DIFF
--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -397,6 +397,11 @@ export USER=sandbox
 
 # Fix /sandbox ownership. The host-side CLI extracts OCI layers as a non-root
 # user (e.g. UID 501 on macOS), so /sandbox may be owned by the host UID.
+#
+# On macOS (Hypervisor.framework), guest root has real root privileges and
+# chown succeeds. On Linux non-root hosts with virtiofs, guest root maps to
+# the host user, so chown is denied — this is non-fatal because the
+# supervisor's own filesystem preparation handles the paths that matter.
 if [ -d /sandbox ]; then
     _sb_uid=$(id -u sandbox 2>/dev/null || true)
     _sb_gid=$(id -g sandbox 2>/dev/null || true)
@@ -404,7 +409,8 @@ if [ -d /sandbox ]; then
         _cur_uid=$(stat -c '%u' /sandbox 2>/dev/null || true)
         if [ -n "$_cur_uid" ] && [ "$_cur_uid" != "$_sb_uid" ]; then
             ts "fixing /sandbox ownership (was uid=${_cur_uid}, setting to sandbox=${_sb_uid}:${_sb_gid})"
-            chown -R "${_sb_uid}:${_sb_gid}" /sandbox
+            chown -R "${_sb_uid}:${_sb_gid}" /sandbox 2>/dev/null || \
+                ts "chown /sandbox denied (virtiofs rootless host), continuing"
         fi
     fi
 fi


### PR DESCRIPTION
## Summary

On Linux non-root hosts, virtiofs maps guest root to the host user, so `chown` inside the VM is denied. This causes the init script to abort under `set -e`, preventing the sandbox from starting. Make the chown best-effort so the VM boots successfully.

## Related Issue

The `/sandbox` ownership fix was added in #1176 for macOS hosts where guest root has real root privileges (Hypervisor.framework) and chown succeeds. This PR extends it to handle the Linux non-root case where chown is denied.

## Changes

- Make `chown -R /sandbox` non-fatal: suppress stderr and log a warning on failure instead of aborting
- Add comment explaining the macOS vs Linux virtiofs behavior difference

This is a pragmatic workaround — anything that would break due to the failed chown will still break, just later and with a clearer error rather than a cryptic boot failure. In practice the sandbox functions normally because the supervisor sets up its own working directories.

## Testing

- [x] `mise run pre-commit` passes
- [x] Verified on a Linux non-root host with the VM driver — sandbox boots successfully, console log shows `chown /sandbox denied (virtiofs rootless host), continuing`
- [x] Bypass detection e2e test passes on the VM driver with this fix

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)