### PR TITLE
fix(ci): restore protobuf and helm build checks

### DIFF
--- a/.github/workflows/rpm-package.yml
+++ b/.github/workflows/rpm-package.yml
@@ -51,6 +51,7 @@ jobs:
             packit rpm-build \
             rust cargo gcc gcc-c++ make cmake pkg-config \
             clang-devel z3-devel systemd-rpm-macros \
+            protobuf-compiler protobuf-devel \
             pandoc python3-devel git-core \
             cargo-rpm-macros
 

--- a/crates/openshell-core/build.rs
+++ b/crates/openshell-core/build.rs
@@ -34,12 +34,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     proto_files.sort();
 
     // Requires `protoc`. Local and CI builds get it from mise; Docker build
-    // images install protobuf-compiler. Those protoc distributions also
-    // provide the well-known type includes used by imports such as
-    // google/protobuf/struct.proto.
+    // images and RPM builds install protobuf packages. Some distro protoc
+    // packages split the well-known type includes into a separate development
+    // package and do not search that directory automatically, so pass it
+    // explicitly when it is present.
     let mut prost_config = prost_build::Config::new();
     if let Some(protoc) = resolve_protoc_from_mise() {
         prost_config.protoc_executable(protoc);
+    }
+    for include_dir in well_known_proto_include_dirs() {
+        println!(
+            "cargo:rerun-if-changed={}",
+            include_dir.join("google/protobuf/struct.proto").display()
+        );
+        prost_config.protoc_arg(format!("--proto_path={}", include_dir.display()));
     }
     tonic_build::configure()
         .build_server(true)
@@ -54,8 +62,45 @@ fn resolve_protoc_from_mise() -> Option<PathBuf> {
         return None;
     }
 
+    let protoc = mise_tool_root("protoc")?.join("bin").join("protoc");
+    protoc.is_file().then_some(protoc)
+}
+
+fn well_known_proto_include_dirs() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(path) = env::var_os("PROTOC_INCLUDE") {
+        candidates.push(PathBuf::from(path));
+    }
+    if let Some(path) = env::var_os("PROTOC")
+        && let Some(root) = Path::new(&path).parent().and_then(Path::parent)
+    {
+        candidates.push(root.join("include"));
+    }
+    if let Some(root) = mise_tool_root("protoc") {
+        candidates.push(root.join("include"));
+    }
+
+    candidates.extend([
+        PathBuf::from("/usr/include"),
+        PathBuf::from("/usr/local/include"),
+        PathBuf::from("/opt/homebrew/include"),
+    ]);
+
+    let mut dirs = Vec::new();
+    for candidate in candidates {
+        if candidate.join("google/protobuf/struct.proto").is_file()
+            && !dirs.iter().any(|dir| dir == &candidate)
+        {
+            dirs.push(candidate);
+        }
+    }
+    dirs
+}
+
+fn mise_tool_root(tool: &str) -> Option<PathBuf> {
     let output = std::process::Command::new("mise")
-        .args(["where", "protoc"])
+        .args(["where", tool])
         .output()
         .ok()?;
     if !output.status.success() {
@@ -63,8 +108,7 @@ fn resolve_protoc_from_mise() -> Option<PathBuf> {
     }
 
     let root = String::from_utf8(output.stdout).ok()?;
-    let protoc = PathBuf::from(root.trim()).join("bin").join("protoc");
-    protoc.is_file().then_some(protoc)
+    Some(PathBuf::from(root.trim()))
 }
 
 fn command_exists(command: &str) -> bool {

--- a/deploy/docker/Dockerfile.ci
+++ b/deploy/docker/Dockerfile.ci
@@ -84,7 +84,7 @@ RUN --mount=type=secret,id=MISE_GITHUB_TOKEN \
     mise reshim && \
     (/root/.cargo/bin/rustup component remove rust-docs || true) && \
     rm -rf /root/.rustup/toolchains/*/share/doc /root/.rustup/toolchains/*/share/man && \
-    helm plugin install https://github.com/helm-unittest/helm-unittest
+    helm plugin install --verify=false https://github.com/helm-unittest/helm-unittest
 
 # Set working directory for CI jobs
 WORKDIR /builds

--- a/deploy/docker/Dockerfile.cli-macos
+++ b/deploy/docker/Dockerfile.cli-macos
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     curl \
     libclang-dev \
+    libprotobuf-dev \
     pkg-config \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*

--- a/deploy/docker/Dockerfile.driver-vm-macos
+++ b/deploy/docker/Dockerfile.driver-vm-macos
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     clang \
     cmake \
     curl \
+    libprotobuf-dev \
     pkg-config \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*

--- a/deploy/docker/Dockerfile.gateway-macos
+++ b/deploy/docker/Dockerfile.gateway-macos
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     curl \
     libclang-dev \
+    libprotobuf-dev \
     pkg-config \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*

--- a/deploy/docker/Dockerfile.python-wheels
+++ b/deploy/docker/Dockerfile.python-wheels
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libc6-dev \
     libclang-dev \
+    libprotobuf-dev \
     pkg-config \
     protobuf-compiler \
     libssl-dev \

--- a/deploy/docker/Dockerfile.python-wheels-macos
+++ b/deploy/docker/Dockerfile.python-wheels-macos
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     libclang-dev \
     libssl-dev \
+    libprotobuf-dev \
     pkg-config \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*

--- a/openshell.spec
+++ b/openshell.spec
@@ -43,6 +43,8 @@ BuildRequires:  make
 BuildRequires:  cmake
 BuildRequires:  pkg-config
 BuildRequires:  clang-devel
+BuildRequires:  protobuf-compiler
+BuildRequires:  protobuf-devel
 BuildRequires:  z3-devel
 BuildRequires:  systemd-rpm-macros
 


### PR DESCRIPTION
## Summary

Restore failing main build checks by making protobuf codegen find well-known proto includes after removing `protobuf-src`, adding matching protobuf packages to macOS Docker and RPM build environments, and disabling Helm v4 plugin verification for the helm-unittest plugin install in the CI image.

## Related Issue

Related to #1387

## Changes

- Add explicit well-known protobuf include detection to `openshell-core` build codegen.
- Install protobuf development headers in macOS/Python Docker build images.
- Add protobuf compiler/devel dependencies to RPM workflow and spec.
- Pass `--verify=false` for the Helm unittest plugin install in the CI image.

## Testing

- [x] `cargo fmt --check`
- [x] `RUSTC_WRAPPER= cargo check -p openshell-core`
- [x] `RUSTC_WRAPPER= cargo clippy -p openshell-core --all-targets -- -D warnings`
- [x] `mise x -- helm plugin install --help | rg -n "verify"`
- [x] `git diff --check`
- [x] `mise run pre-commit`

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)