### PR TITLE
ci: extend artifact attestations to all release binaries

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -797,13 +797,14 @@ jobs:
             --output release/openshell.rb
           cat release/openshell.rb
 
-      - name: Attest VM driver artifacts
+      - name: Attest release artifacts
         uses: actions/attest@v4
         with:
           subject-path: |
-            release/openshell-driver-vm-x86_64-unknown-linux-gnu.tar.gz
-            release/openshell-driver-vm-aarch64-unknown-linux-gnu.tar.gz
-            release/openshell-driver-vm-aarch64-apple-darwin.tar.gz
+            release/*.tar.gz
+            release/*.deb
+            release/*.rpm
+            release/*.whl
 
       - name: Prune removed VM checksum asset
         uses: actions/github-script@v9


### PR DESCRIPTION
## Summary

- The VM driver artifacts were already attested in the release workflow.
- This extends the attest step to cover CLI, gateway, supervisor, deb, rpm, and wheel artifacts using glob patterns instead of explicit file lists.
- All release binaries can now be verified with `gh attestation verify`.

## Related Issue

Closes #1364

## Changes

Replaced the VM-only `actions/attest@v4` step with a single step that covers all release artifact types via globs. No new permissions needed as `id-token: write` and `attestations: write` were already set on the job.

## Testing

- Attestation behavior is validated at release time by the workflow itself.
- The glob patterns match exactly the files produced by the build jobs and downloaded into the `release/` directory.

## Checklist

- [x] Follows Conventional Commits format
- [x] Signed-off-by included
- [x] No unrelated changes