### PR TITLE
refactor(driver): trim compute capability response

### DIFF
--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -22,6 +22,10 @@ drive client provisioning UI, the driver attaches the shared
 clients to parse Kubernetes reasons, VM cache states, or other driver-local
 reason strings.
 
+The capability RPC reports driver identity, version, and the default sandbox
+image used by the gateway. GPU availability stays driver-local and is validated
+when a sandbox create request asks for GPU resources.
+
 ## Runtime Summary
 
 | Runtime | Best fit | Sandbox boundary | Notes |

--- a/crates/openshell-core/src/driver_utils.rs
+++ b/crates/openshell-core/src/driver_utils.rs
@@ -63,20 +63,16 @@ pub fn sandbox_token_path(
 /// Build a [`GetCapabilitiesResponse`] from the common driver capability fields.
 ///
 /// Every compute driver constructs this response with the same fields. Shared
-/// here to avoid repeating the struct literal (and the always-zero `gpu_count`
-/// default) in each driver crate.
+/// here to avoid repeating the struct literal in each driver crate.
 pub fn build_capabilities_response(
     driver_name: &str,
     driver_version: impl Into<String>,
     default_image: impl Into<String>,
-    supports_gpu: bool,
 ) -> GetCapabilitiesResponse {
     GetCapabilitiesResponse {
         driver_name: driver_name.to_string(),
         driver_version: driver_version.into(),
         default_image: default_image.into(),
-        supports_gpu,
-        gpu_count: 0,
     }
 }
 

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -353,7 +353,6 @@ impl DockerComputeDriver {
             "docker",
             &self.config.daemon_version,
             &self.config.default_image,
-            self.config.supports_gpu,
         )
     }
 

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -159,12 +159,11 @@ impl KubernetesComputeDriver {
         })
     }
 
-    pub async fn capabilities(&self) -> Result<GetCapabilitiesResponse, String> {
+    pub fn capabilities(&self) -> Result<GetCapabilitiesResponse, String> {
         Ok(openshell_core::driver_utils::build_capabilities_response(
             "kubernetes",
             openshell_core::VERSION,
             &self.config.default_image,
-            self.has_gpu_capacity().await.unwrap_or(false),
         ))
     }
 

--- a/crates/openshell-driver-kubernetes/src/grpc.rs
+++ b/crates/openshell-driver-kubernetes/src/grpc.rs
@@ -36,7 +36,6 @@ impl ComputeDriver for ComputeDriverService {
     ) -> Result<Response<GetCapabilitiesResponse>, Status> {
         self.driver
             .capabilities()
-            .await
             .map(Response::new)
             .map_err(Status::internal)
     }

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -257,7 +257,6 @@ impl PodmanComputeDriver {
             "podman",
             openshell_core::VERSION,
             &self.config.default_image,
-            Self::has_gpu_capacity(),
         ))
     }
 

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -373,17 +373,10 @@ impl VmDriver {
 
     #[must_use]
     pub fn capabilities(&self) -> GetCapabilitiesResponse {
-        let gpu_count = self
-            .gpu_inventory
-            .as_ref()
-            .and_then(|inv| inv.lock().ok())
-            .map_or(0, |inv| inv.gpu_count());
         GetCapabilitiesResponse {
             driver_name: DRIVER_NAME.to_string(),
             driver_version: openshell_core::VERSION.to_string(),
             default_image: self.config.default_image.clone(),
-            supports_gpu: self.gpu_inventory.is_some(),
-            gpu_count,
         }
     }
 

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -1650,8 +1650,6 @@ impl ComputeDriver for NoopTestDriver {
                 driver_name: "noop-test-driver".to_string(),
                 driver_version: "test".to_string(),
                 default_image: "openshell/sandbox:test".to_string(),
-                supports_gpu: false,
-                gpu_count: 0,
             },
         ))
     }
@@ -1799,8 +1797,6 @@ mod tests {
                 driver_name: "test-driver".to_string(),
                 driver_version: "test".to_string(),
                 default_image: "openshell/sandbox:test".to_string(),
-                supports_gpu: true,
-                gpu_count: 0,
             }))
         }
 

--- a/proto/compute_driver.proto
+++ b/proto/compute_driver.proto
@@ -45,16 +45,15 @@ service ComputeDriver {
 message GetCapabilitiesRequest {}
 
 message GetCapabilitiesResponse {
+  reserved 4, 5;
+  reserved "supports_gpu", "gpu_count";
+
   // Human-readable driver name.
   string driver_name = 1;
   // Driver implementation version string.
   string driver_version = 2;
   // Default sandbox image recommended by the driver.
   string default_image = 3;
-  // True when the driver can provision GPU-backed sandboxes.
-  bool supports_gpu = 4;
-  // Number of GPUs available for sandbox assignment.
-  uint32 gpu_count = 5;
 }
 
 // Driver-owned sandbox model used for create requests and platform observations.


### PR DESCRIPTION
## Summary

Remove unused GPU availability fields from the internal compute driver capability response. GPU admission remains driver-local and is still validated when a sandbox create request asks for GPU resources.

This intentionally breaks wire compatibility for the internal compute-driver capability message by deleting the removed fields without reserving their field numbers or names.

## Related Issue

None.

## Changes

- Removed the compute-driver capability proto fields for GPU support and GPU count without reserving their tags or names.
- Stopped populating GPU capability fields from Docker, Kubernetes, Podman, VM, and test drivers.
- Documented that the capability RPC reports driver identity, version, and default image only.
- Addressed clippy fallout from the now-sync Kubernetes capability path.

## Testing

- [x] `cargo check -p openshell-core -p openshell-driver-docker -p openshell-driver-kubernetes -p openshell-driver-podman -p openshell-driver-vm -p openshell-server`
- [x] `cargo test -p openshell-server -p openshell-driver-docker -p openshell-driver-kubernetes -p openshell-driver-podman -p openshell-driver-vm --no-run`
- [x] `mise run pre-commit` passes
- [x] Unit tests not applicable; no behavior change beyond removing unused capability fields
- [x] E2E tests not applicable; no sandbox runtime behavior change

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
