### PR TITLE
feat(tui): add OIDC authentication support

### DIFF
--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -2700,7 +2700,11 @@ async fn main() -> Result<()> {
             let mut tls = tls.with_gateway_name(&ctx.name);
             apply_auth(&mut tls, &ctx.name);
             let channel = openshell_cli::tls::build_channel(&ctx.endpoint, &tls).await?;
-            openshell_tui::run(channel, &ctx.name, &ctx.endpoint, theme).await?;
+            let interceptor = openshell_core::auth::EdgeAuthInterceptor::new(
+                tls.oidc_token.as_deref(),
+                tls.edge_token.as_deref(),
+            )?;
+            openshell_tui::run(channel, interceptor, &ctx.name, &ctx.endpoint, theme).await?;
         }
         Some(Commands::Completions { shell }) => {
             let exe = std::env::current_exe()

--- a/crates/openshell-cli/src/tls.rs
+++ b/crates/openshell-cli/src/tls.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use miette::{IntoDiagnostic, Result, WrapErr};
+use openshell_core::auth::EdgeAuthInterceptor;
 use openshell_core::proto::inference_client::InferenceClient;
 use openshell_core::proto::open_shell_client::OpenShellClient;
 use rustls::{
@@ -435,85 +436,16 @@ pub async fn build_channel(server: &str, tls: &TlsOptions) -> Result<Channel> {
 /// Otherwise, standard mTLS is used (interceptor is a no-op).
 pub async fn grpc_client(server: &str, tls: &TlsOptions) -> Result<GrpcClient> {
     let channel = build_channel(server, tls).await?;
-    let interceptor = EdgeAuthInterceptor::maybe_from(tls)?;
+    let interceptor = interceptor_from_tls(tls)?;
     Ok(OpenShellClient::with_interceptor(channel, interceptor))
 }
 
-/// Interceptor that injects authentication headers into every outgoing gRPC request.
-///
-/// Supports OIDC Bearer tokens (standard `authorization` header) and
-/// Cloudflare Access tokens (custom headers). When no token is set, acts
-/// as a no-op. OIDC takes precedence over edge tokens.
-#[derive(Clone)]
-#[allow(clippy::struct_field_names)]
-pub struct EdgeAuthInterceptor {
-    /// Standard `authorization: Bearer <token>` for OIDC.
-    bearer_value: Option<tonic::metadata::MetadataValue<tonic::metadata::Ascii>>,
-    /// CF-specific `Cf-Access-Jwt-Assertion` header.
-    header_value: Option<tonic::metadata::MetadataValue<tonic::metadata::Ascii>>,
-    /// CF-specific `Cookie: CF_Authorization=<token>` header.
-    cookie_value: Option<tonic::metadata::MetadataValue<tonic::metadata::Ascii>>,
-}
-
-impl EdgeAuthInterceptor {
-    /// Create an interceptor from [`TlsOptions`].  Returns a no-op interceptor
-    /// when no auth token is configured.
-    pub fn maybe_from(tls: &TlsOptions) -> Result<Self> {
-        // OIDC bearer token takes precedence.
-        if let Some(ref token) = tls.oidc_token {
-            let bearer: tonic::metadata::MetadataValue<tonic::metadata::Ascii> =
-                format!("Bearer {token}")
-                    .parse()
-                    .map_err(|_| miette::miette!("invalid OIDC token value"))?;
-            return Ok(Self {
-                bearer_value: Some(bearer),
-                header_value: None,
-                cookie_value: None,
-            });
-        }
-
-        let (header_value, cookie_value) = match tls.edge_token.as_deref() {
-            Some(t) => {
-                let hv: tonic::metadata::MetadataValue<tonic::metadata::Ascii> = t
-                    .parse()
-                    .map_err(|_| miette::miette!("invalid edge token value"))?;
-                let cv: tonic::metadata::MetadataValue<tonic::metadata::Ascii> =
-                    format!("CF_Authorization={t}")
-                        .parse()
-                        .map_err(|_| miette::miette!("invalid edge token value for cookie"))?;
-                (Some(hv), Some(cv))
-            }
-            None => (None, None),
-        };
-        Ok(Self {
-            bearer_value: None,
-            header_value,
-            cookie_value,
-        })
-    }
-}
-
-impl tonic::service::Interceptor for EdgeAuthInterceptor {
-    fn call(
-        &mut self,
-        mut req: tonic::Request<()>,
-    ) -> std::result::Result<tonic::Request<()>, tonic::Status> {
-        if let Some(ref val) = self.bearer_value {
-            req.metadata_mut().insert("authorization", val.clone());
-        }
-        if let Some(ref val) = self.header_value {
-            req.metadata_mut()
-                .insert("cf-access-jwt-assertion", val.clone());
-        }
-        if let Some(ref val) = self.cookie_value {
-            req.metadata_mut().insert("cookie", val.clone());
-        }
-        Ok(req)
-    }
+fn interceptor_from_tls(tls: &TlsOptions) -> Result<EdgeAuthInterceptor> {
+    EdgeAuthInterceptor::new(tls.oidc_token.as_deref(), tls.edge_token.as_deref())
 }
 
 pub async fn grpc_inference_client(server: &str, tls: &TlsOptions) -> Result<GrpcInferenceClient> {
     let channel = build_channel(server, tls).await?;
-    let interceptor = EdgeAuthInterceptor::maybe_from(tls)?;
+    let interceptor = interceptor_from_tls(tls)?;
     Ok(InferenceClient::with_interceptor(channel, interceptor))
 }

--- a/crates/openshell-core/src/auth.rs
+++ b/crates/openshell-core/src/auth.rs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! gRPC authentication interceptor shared by CLI and TUI.
+
+use miette::Result;
+
+/// Interceptor that injects authentication headers into every outgoing gRPC request.
+///
+/// Supports OIDC Bearer tokens (standard `authorization` header) and
+/// Cloudflare Access tokens (custom headers). When no token is set, acts
+/// as a no-op. OIDC takes precedence over edge tokens.
+#[derive(Clone)]
+#[allow(clippy::struct_field_names)]
+pub struct EdgeAuthInterceptor {
+    bearer_value: Option<tonic::metadata::MetadataValue<tonic::metadata::Ascii>>,
+    header_value: Option<tonic::metadata::MetadataValue<tonic::metadata::Ascii>>,
+    cookie_value: Option<tonic::metadata::MetadataValue<tonic::metadata::Ascii>>,
+}
+
+impl EdgeAuthInterceptor {
+    /// Create an interceptor from optional token strings.
+    ///
+    /// OIDC bearer token takes precedence over edge token. Returns a no-op
+    /// interceptor when neither token is provided.
+    pub fn new(oidc_token: Option<&str>, edge_token: Option<&str>) -> Result<Self> {
+        if let Some(token) = oidc_token {
+            let bearer: tonic::metadata::MetadataValue<tonic::metadata::Ascii> =
+                format!("Bearer {token}")
+                    .parse()
+                    .map_err(|_| miette::miette!("invalid OIDC token value"))?;
+            return Ok(Self {
+                bearer_value: Some(bearer),
+                header_value: None,
+                cookie_value: None,
+            });
+        }
+
+        let (header_value, cookie_value) = match edge_token {
+            Some(t) => {
+                let hv: tonic::metadata::MetadataValue<tonic::metadata::Ascii> = t
+                    .parse()
+                    .map_err(|_| miette::miette!("invalid edge token value"))?;
+                let cv: tonic::metadata::MetadataValue<tonic::metadata::Ascii> =
+                    format!("CF_Authorization={t}")
+                        .parse()
+                        .map_err(|_| miette::miette!("invalid edge token value for cookie"))?;
+                (Some(hv), Some(cv))
+            }
+            None => (None, None),
+        };
+        Ok(Self {
+            bearer_value: None,
+            header_value,
+            cookie_value,
+        })
+    }
+
+    /// No-op interceptor that passes requests through without modification.
+    pub fn noop() -> Self {
+        Self {
+            bearer_value: None,
+            header_value: None,
+            cookie_value: None,
+        }
+    }
+}
+
+impl tonic::service::Interceptor for EdgeAuthInterceptor {
+    fn call(
+        &mut self,
+        mut req: tonic::Request<()>,
+    ) -> std::result::Result<tonic::Request<()>, tonic::Status> {
+        if let Some(ref val) = self.bearer_value {
+            req.metadata_mut().insert("authorization", val.clone());
+        }
+        if let Some(ref val) = self.header_value {
+            req.metadata_mut()
+                .insert("cf-access-jwt-assertion", val.clone());
+        }
+        if let Some(ref val) = self.cookie_value {
+            req.metadata_mut().insert("cookie", val.clone());
+        }
+        Ok(req)
+    }
+}

--- a/crates/openshell-core/src/lib.rs
+++ b/crates/openshell-core/src/lib.rs
@@ -9,6 +9,7 @@
 //! - Common error types
 //! - Build version metadata
 
+pub mod auth;
 pub mod config;
 pub mod driver_utils;
 pub mod error;

--- a/crates/openshell-tui/src/app.rs
+++ b/crates/openshell-tui/src/app.rs
@@ -5,9 +5,11 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use openshell_core::auth::EdgeAuthInterceptor;
 use openshell_core::proto::open_shell_client::OpenShellClient;
 use openshell_core::proto::setting_value;
 use openshell_core::settings::{self, SettingValueKind};
+use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 
 // ---------------------------------------------------------------------------
@@ -413,7 +415,7 @@ pub struct App {
     // Active gateway connection
     pub gateway_name: String,
     pub endpoint: String,
-    pub client: OpenShellClient<Channel>,
+    pub client: OpenShellClient<InterceptedService<Channel, EdgeAuthInterceptor>>,
     pub status_text: String,
 
     // Gateway list
@@ -580,7 +582,7 @@ pub fn format_labels(labels: &HashMap<String, String>) -> String {
 impl App {
     #[allow(clippy::large_types_passed_by_value)] // Theme is Copy; one-shot ctor
     pub fn new(
-        client: OpenShellClient<Channel>,
+        client: OpenShellClient<InterceptedService<Channel, EdgeAuthInterceptor>>,
         gateway_name: String,
         endpoint: String,
         theme: crate::theme::Theme,

--- a/crates/openshell-tui/src/lib.rs
+++ b/crates/openshell-tui/src/lib.rs
@@ -18,6 +18,7 @@ use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
 use miette::{IntoDiagnostic, Result};
+use openshell_core::auth::EdgeAuthInterceptor;
 use openshell_core::metadata::{ObjectId, ObjectLabels, ObjectName};
 use openshell_core::proto::open_shell_client::OpenShellClient;
 use ratatui::Terminal;
@@ -41,6 +42,7 @@ pub use theme::ThemeMode;
 /// background, `Dark`/`Light` forces a specific palette.
 pub async fn run(
     channel: Channel,
+    interceptor: EdgeAuthInterceptor,
     gateway_name: &str,
     endpoint: &str,
     theme_mode: ThemeMode,
@@ -50,7 +52,7 @@ pub async fn run(
     // after our own enable_raw_mode() would conflict.
     let detected_theme = theme::detect(theme_mode);
 
-    let client = OpenShellClient::new(channel);
+    let client = OpenShellClient::with_interceptor(channel, interceptor);
     let mut app = App::new(
         client,
         gateway_name.to_string(),
@@ -491,8 +493,8 @@ async fn handle_gateway_switch(app: &mut App) {
     };
 
     match connect_to_gateway(&name, &endpoint).await {
-        Ok(channel) => {
-            app.client = OpenShellClient::new(channel);
+        Ok((channel, interceptor)) => {
+            app.client = OpenShellClient::with_interceptor(channel, interceptor);
             app.gateway_name = name;
             app.endpoint = endpoint;
             app.reset_sandbox_state();
@@ -505,8 +507,76 @@ async fn handle_gateway_switch(app: &mut App) {
     }
 }
 
-/// Build a gRPC channel to a gateway using its mTLS certs on disk.
-async fn connect_to_gateway(name: &str, endpoint: &str) -> Result<Channel> {
+/// Build a gRPC channel and auth interceptor for a gateway.
+///
+/// Checks gateway metadata for the auth mode and loads the appropriate
+/// credentials (mTLS certs or OIDC bearer token).
+async fn connect_to_gateway(name: &str, endpoint: &str) -> Result<(Channel, EdgeAuthInterceptor)> {
+    let meta = openshell_bootstrap::get_gateway_metadata(name);
+
+    if meta.as_ref().and_then(|m| m.auth_mode.as_deref()) == Some("oidc") {
+        let bundle = openshell_bootstrap::oidc_token::load_oidc_token(name).ok_or_else(|| {
+            miette::miette!(
+                "No OIDC token for gateway '{name}'.\n\
+                     Authenticate with: openshell gateway login"
+            )
+        })?;
+        if openshell_bootstrap::oidc_token::is_token_expired(&bundle) {
+            miette::bail!(
+                "OIDC token for gateway '{name}' has expired.\n\
+                 Re-authenticate with: openshell gateway login"
+            );
+        }
+        let interceptor = EdgeAuthInterceptor::new(Some(&bundle.access_token), None)?;
+        let channel = build_oidc_channel(name, endpoint).await?;
+        Ok((channel, interceptor))
+    } else {
+        let channel = build_mtls_channel(name, endpoint).await?;
+        Ok((channel, EdgeAuthInterceptor::noop()))
+    }
+}
+
+/// Build an HTTPS channel for OIDC-authenticated gateways.
+///
+/// Tries mTLS client certs for the transport layer when available (the server
+/// may still require them alongside the bearer token), falls back to CA-only
+/// or system roots.
+async fn build_oidc_channel(name: &str, endpoint: &str) -> Result<Channel> {
+    let mtls_dir = gateway_mtls_dir(name);
+
+    let tls_config = mtls_dir.as_ref().map_or_else(
+        || ClientTlsConfig::new().with_enabled_roots(),
+        |dir| {
+            let ca = std::fs::read(dir.join("ca.crt")).ok();
+            let cert = std::fs::read(dir.join("tls.crt")).ok();
+            let key = std::fs::read(dir.join("tls.key")).ok();
+
+            match (ca, cert, key) {
+                (Some(ca), Some(cert), Some(key)) => ClientTlsConfig::new()
+                    .ca_certificate(Certificate::from_pem(ca))
+                    .identity(Identity::from_pem(cert, key)),
+                (Some(ca), _, _) => {
+                    ClientTlsConfig::new().ca_certificate(Certificate::from_pem(ca))
+                }
+                _ => ClientTlsConfig::new().with_enabled_roots(),
+            }
+        },
+    );
+
+    Endpoint::from_shared(endpoint.to_string())
+        .into_diagnostic()?
+        .connect_timeout(Duration::from_secs(10))
+        .http2_keep_alive_interval(Duration::from_secs(10))
+        .keep_alive_while_idle(true)
+        .tls_config(tls_config)
+        .into_diagnostic()?
+        .connect()
+        .await
+        .into_diagnostic()
+}
+
+/// Build a gRPC channel using mTLS client certificates.
+async fn build_mtls_channel(name: &str, endpoint: &str) -> Result<Channel> {
     let mtls_dir = gateway_mtls_dir(name)
         .ok_or_else(|| miette::miette!("cannot determine config directory for gateway {name}"))?;
 
@@ -524,7 +594,7 @@ async fn connect_to_gateway(name: &str, endpoint: &str) -> Result<Channel> {
         .ca_certificate(Certificate::from_pem(ca))
         .identity(Identity::from_pem(cert, key));
 
-    let channel = Endpoint::from_shared(endpoint.to_string())
+    Endpoint::from_shared(endpoint.to_string())
         .into_diagnostic()?
         .connect_timeout(Duration::from_secs(10))
         .http2_keep_alive_interval(Duration::from_secs(10))
@@ -533,9 +603,7 @@ async fn connect_to_gateway(name: &str, endpoint: &str) -> Result<Channel> {
         .into_diagnostic()?
         .connect()
         .await
-        .into_diagnostic()?;
-
-    Ok(channel)
+        .into_diagnostic()
 }
 
 /// Resolve the mTLS cert directory for a gateway.
@@ -1385,7 +1453,9 @@ fn spawn_create_sandbox(app: &mut App, tx: mpsc::UnboundedSender<Event>) {
 /// This is called from within the create-sandbox task so the pacman animation
 /// keeps running while forwards are being established.
 async fn start_port_forwards(
-    client: &mut OpenShellClient<Channel>,
+    client: &mut OpenShellClient<
+        tonic::service::interceptor::InterceptedService<Channel, EdgeAuthInterceptor>,
+    >,
     endpoint: &str,
     gateway_name: &str,
     sandbox_name: &str,


### PR DESCRIPTION
## Summary

Currently, when logged into a gateway configured with OIDC authn, `openshell term` fails with `missing authorization header`.

Add OIDC authentication support to the `openshell term` TUI. Previously the TUI only worked with mTLS-authenticated gateways — OIDC gateways would silently fail because no bearer token was injected into gRPC requests.

- Move `EdgeAuthInterceptor` from `openshell-cli` to `openshell-core` to avoid a circular dependency (CLI depends on TUI)
- TUI now checks gateway metadata for auth mode and loads stored OIDC tokens on both startup and gateway switch
- Expired tokens surface a clear error directing users to `openshell gateway login`

## Related Issue

N/A

## Changes

- **`crates/openshell-core/src/auth.rs`** (new): `EdgeAuthInterceptor` with `new()` and `noop()` constructors
- **`crates/openshell-cli/src/tls.rs`**: Remove interceptor definition, import from `openshell_core::auth`
- **`crates/openshell-cli/src/main.rs`**: Build interceptor and pass to `openshell_tui::run()`
- **`crates/openshell-tui/src/app.rs`**: Change client type to `OpenShellClient<InterceptedService<Channel, EdgeAuthInterceptor>>`
- **`crates/openshell-tui/src/lib.rs`**: `run()` accepts interceptor; `connect_to_gateway()` dispatches on auth mode; new `build_oidc_channel()` and `build_mtls_channel()` helpers

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual: `openshell term` with mTLS gateway (no regression)
- [x] Manual: `openshell term` with OIDC gateway
- [x] Manual: gateway switching between mTLS and OIDC gateways

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)