### PR TITLE
fix(vm): collapse nested if blocks in container engine connect

### DIFF
--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -1522,25 +1522,23 @@ fn parse_registry_reference(image_ref: &str) -> Result<Reference, Status> {
 /// `DOCKER_HOST`). If Docker is unavailable, falls back to the Podman
 /// socket, which exposes a Docker-compatible API.
 async fn connect_local_container_engine() -> Option<Docker> {
-    if let Ok(docker) = Docker::connect_with_local_defaults() {
-        if docker.ping().await.is_ok() {
-            return Some(docker);
-        }
+    if let Ok(docker) = Docker::connect_with_local_defaults()
+        && docker.ping().await.is_ok()
+    {
+        return Some(docker);
     }
 
     let podman_socket = podman_socket_path();
-    if podman_socket.exists() {
-        if let Ok(docker) =
+    if podman_socket.exists()
+        && let Ok(docker) =
             Docker::connect_with_unix(podman_socket.to_str()?, 120, bollard::API_DEFAULT_VERSION)
-        {
-            if docker.ping().await.is_ok() {
-                info!(
-                    socket = %podman_socket.display(),
-                    "vm driver: connected to Podman (Docker-compatible API)"
-                );
-                return Some(docker);
-            }
-        }
+        && docker.ping().await.is_ok()
+    {
+        info!(
+            socket = %podman_socket.display(),
+            "vm driver: connected to Podman (Docker-compatible API)"
+        );
+        return Some(docker);
     }
 
     None


### PR DESCRIPTION
## Summary
- `mise run pre-commit` fails on `main` because clippy's `collapsible_if` lint fires on `connect_local_container_engine` in `crates/openshell-driver-vm/src/driver.rs`.
- Rewrote both nested `if let Ok(..) { if ping().is_ok() { .. } }` blocks as let-chains so `mise run rust:lint` (with `-D warnings`) passes again.

## Related Issue
N/A — restoring green pre-commit on main.

## Changes
- `crates/openshell-driver-vm/src/driver.rs`: collapse the Docker default and Podman socket fallback `if` blocks using `&&` let-chains.

## Root Cause
Introduced by 44e843ed (\"feat(vm): fall back to Podman socket when Docker is unavailable\", #1370), which added the nested Docker/Podman connect-then-ping pattern. Clippy's `collapsible_if` lint flags it and the workspace runs with `-D warnings`.

## Testing
- [x] `cargo clippy -p openshell-driver-vm --all-targets -- -D warnings`
- [x] `mise run pre-commit`

## Checklist
- [x] Conventional Commits
- [x] No unrelated changes
- [x] Lint passes