### PR TITLE
feat(examples): add A2A design review demo

### DIFF
--- a/docs/get-started/tutorials/a2a-design-review.mdx
+++ b/docs/get-started/tutorials/a2a-design-review.mdx
@@ -1,0 +1,122 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Run an A2A Agent Design Review"
+sidebar-title: "A2A Design Review"
+slug: "get-started/tutorials/a2a-design-review"
+description: "Run multiple A2A-compatible agents in isolated OpenShell sandboxes and use them to review a GitHub issue from different perspectives."
+keywords: "Generative AI, Cybersecurity, Tutorial, A2A, Agent2Agent, Multi-Agent, Sandbox, Policy"
+---
+
+This tutorial runs a small Agent2Agent (A2A) design-review mesh. Four remote agents review a GitHub issue from different perspectives, stream task updates, and return markdown artifacts. OpenShell runs each remote agent in its own sandbox so the agents can collaborate without sharing files, credentials, or unrelated network access.
+
+After completing this tutorial, you understand:
+
+- How A2A Agent Cards let a client agent discover remote agent capabilities.
+- How A2A message and streaming endpoints support iterative collaboration.
+- How OpenShell isolates each remote agent while still exposing its service through the gateway.
+- Why A2A's HTTP+JSON shape maps cleanly to OpenShell REST path enforcement.
+
+## Prerequisites
+
+- A working OpenShell installation. Complete the [Quickstart](/get-started/quickstart) before proceeding.
+- A running OpenShell gateway.
+- Node.js 18 or newer on your host machine.
+
+<Tip>
+You can run the protocol smoke without a gateway:
+
+```shell
+DEMO_LOCAL_ONLY=1 bash examples/a2a-design-review/demo.sh
+```
+
+The local smoke starts the same A2A agents on loopback and writes the same review artifact.
+</Tip>
+
+<Steps toc={true}>
+
+## Start the Gateway
+
+For local development, start the Docker-backed gateway:
+
+```shell
+mise run gateway:docker
+```
+
+Verify that the CLI can reach it:
+
+```shell
+openshell status
+```
+
+## Run the Demo
+
+From the repository root, run:
+
+```shell
+bash examples/a2a-design-review/demo.sh
+```
+
+The script creates one sandbox per remote A2A agent, uploads the agent server, and starts the HTTP service inside each sandbox. It then exposes each service through the gateway and runs the host-side orchestrator.
+
+The orchestrator fetches each Agent Card from:
+
+```text
+/.well-known/agent-card.json
+```
+
+Then it sends review work to:
+
+```text
+/message:stream
+```
+
+Each agent streams task state updates and returns a markdown artifact. Later agents receive the artifacts that earlier agents produced, so the review evolves over multiple rounds.
+
+## Review a Real Issue
+
+By default the demo uses an offline sample issue so it can run without GitHub API access. Point it at any public GitHub issue with `DEMO_ISSUE_URL`:
+
+```shell
+DEMO_ISSUE_URL=https://github.com/NVIDIA/OpenShell/issues/123 \
+  bash examples/a2a-design-review/demo.sh
+```
+
+To use the latest open issue from a repository:
+
+```shell
+DEMO_USE_SAMPLE_ISSUE=0 DEMO_REPO=NVIDIA/OpenShell \
+  bash examples/a2a-design-review/demo.sh
+```
+
+Set `GITHUB_TOKEN` or `GH_TOKEN` if you need higher API rate limits or private repository access. The token is used by the host-side orchestrator to fetch issue text; the remote worker agents do not receive it.
+
+## Inspect the Artifact
+
+The demo writes a markdown review under `examples/a2a-design-review/` by default. Set `DEMO_OUTPUT` to choose a different path:
+
+```shell
+DEMO_OUTPUT=/tmp/a2a-design-review.md \
+  bash examples/a2a-design-review/demo.sh
+```
+
+The artifact includes:
+
+- The issue title and URL.
+- The discovered A2A agents and their skills.
+- A round-by-round transcript of planner, security, implementation, and critic artifacts.
+
+## Understand the Boundary
+
+The worker sandbox policy grants no outbound network access. The workers receive A2A messages through OpenShell service routing and return artifacts on the same request path.
+
+For a production version, keep the A2A communication policy separate from tool and storage policies:
+
+- Allow only the A2A discovery, message, stream, and task paths between agents.
+- Attach GitHub or other tool providers only to agents that need them.
+- Scope write access to one repository path or API operation.
+- Treat Agent Cards, messages, artifacts, and task status as untrusted input before placing them into model context.
+
+A2A handles collaboration. OpenShell defines what each collaborator can actually call, know, and change.
+
+</Steps>

--- a/docs/get-started/tutorials/index.mdx
+++ b/docs/get-started/tutorials/index.mdx
@@ -22,6 +22,11 @@ Create a sandbox, observe default-deny networking, apply a read-only L7 policy, 
 Launch Claude Code in a sandbox, diagnose a policy denial, and iterate on a custom GitHub policy from outside the sandbox.
 </Card>
 
+<Card title="A2A Design Review" href="/get-started/tutorials/a2a-design-review">
+
+Run multiple A2A-compatible agents in isolated sandboxes and have them review a GitHub issue together.
+</Card>
+
 <Card title="Inference with Ollama" href="/get-started/tutorials/inference-ollama">
 
 Route inference through Ollama using cloud-hosted or local models, and verify it from a sandbox.

--- a/examples/a2a-design-review/README.md
+++ b/examples/a2a-design-review/README.md
@@ -1,0 +1,132 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# A2A Design Review Demo
+
+Run a small mesh of A2A-compatible agents that collaborate on a GitHub issue
+from different perspectives. Each remote agent exposes an Agent Card, streams
+task updates, and returns a markdown artifact. The orchestrator builds a
+round-by-round design review from those artifacts.
+
+This is the next step after the multi-agent GitHub notepad example:
+
+- The notepad demo uses GitHub files as durable shared coordination state.
+- This demo uses A2A messages, tasks, streams, and artifacts as the live
+  coordination layer.
+- OpenShell keeps each remote agent isolated and gives each agent only the
+  policy and credentials it needs.
+
+## What This Demo Shows
+
+The demo starts four A2A agents:
+
+| Agent | Role |
+|---|---|
+| Planner | Frames the issue and turns critique into the next plan. |
+| Security | Reviews credential flow, sandbox policy, prompt injection, and data exfiltration risk. |
+| Implementation | Maps the review into concrete implementation and validation steps. |
+| Critic | Challenges weak claims and synthesizes the strongest next artifact. |
+
+The agents run multiple rounds. Each agent receives the GitHub issue and the
+artifacts already produced by earlier agents, then streams its own task status
+and artifact back to the orchestrator.
+
+```text
+planner -> security -> implementation -> critic
+   ^                                      |
+   |------------- next round -------------|
+```
+
+## Why A2A Fits OpenShell
+
+A2A provides the collaboration protocol. OpenShell provides the boundary.
+
+The first version of this demo uses A2A's HTTP+JSON binding because it maps
+cleanly to OpenShell policy. A future sandboxed orchestrator can be allowed to
+fetch only:
+
+- `GET /.well-known/agent-card.json`
+- `POST /message:send`
+- `POST /message:stream`
+- selected task paths such as `GET /tasks/**`
+
+That gives users an understandable policy story: agents can talk to each other
+through A2A, but they do not inherit each other's filesystem, provider
+credentials, model credentials, or unrelated network access.
+
+## Files
+
+| File | Description |
+|---|---|
+| `demo.sh` | Starts the local smoke or OpenShell sandbox demo. |
+| `a2a-agent.mjs` | Minimal A2A HTTP+JSON remote agent with Agent Card discovery and SSE streaming. |
+| `orchestrator.mjs` | Host-side A2A client agent that drives multiple review rounds. |
+| `policy.yaml` | Restrictive OpenShell policy for remote worker agents. |
+| `sample-issue.json` | Offline issue fixture for the default smoke run. |
+
+## Quick Smoke Test
+
+Prerequisite: Node.js 18 or newer.
+
+Run the protocol flow locally without a gateway:
+
+```shell
+DEMO_LOCAL_ONLY=1 bash examples/a2a-design-review/demo.sh
+```
+
+The smoke test starts four local A2A servers, runs two collaboration rounds,
+and writes a markdown review artifact under `examples/a2a-design-review/`.
+
+## Run With OpenShell
+
+Start a gateway, then run the sandboxed version:
+
+```shell
+mise run gateway:docker
+bash examples/a2a-design-review/demo.sh
+```
+
+The script creates one OpenShell sandbox per remote A2A agent, exposes each
+agent's HTTP service through the gateway, discovers each Agent Card, and runs
+the design-review loop from the host.
+
+By default the demo uses `sample-issue.json` so it can run without GitHub API
+access. Point it at a real open issue by setting `DEMO_ISSUE_URL`:
+
+```shell
+DEMO_ISSUE_URL=https://github.com/NVIDIA/OpenShell/issues/123 \
+  bash examples/a2a-design-review/demo.sh
+```
+
+If you do not provide `DEMO_ISSUE_URL` and want the script to use the latest
+open issue from a repository, disable the sample fixture:
+
+```shell
+DEMO_USE_SAMPLE_ISSUE=0 DEMO_REPO=NVIDIA/OpenShell \
+  bash examples/a2a-design-review/demo.sh
+```
+
+Optional settings:
+
+```shell
+export DEMO_ROUNDS=3
+export DEMO_OUTPUT=/tmp/a2a-design-review.md
+export DEMO_KEEP_SANDBOXES=1
+```
+
+## Security Model
+
+The worker policy grants no outbound network access. The workers receive A2A
+messages through OpenShell service routing and return artifacts through the
+same request path.
+
+For a fuller version where the orchestrator also runs inside a sandbox, give
+the orchestrator a separate policy that allows only the remote A2A service
+URLs and the specific A2A REST paths it needs. If the final artifact should be
+written to GitHub, attach a separate GitHub provider and scope the policy to
+one repository path, as in the multi-agent notepad demo.
+
+Treat all A2A inputs as untrusted: Agent Cards, messages, artifacts, and task
+status can carry prompt-injection content. The orchestrator should summarize
+or sanitize remote artifacts before using them as model context in a
+production workflow.

--- a/examples/a2a-design-review/a2a-agent.mjs
+++ b/examples/a2a-design-review/a2a-agent.mjs
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import http from "node:http";
+import { randomUUID } from "node:crypto";
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 2) {
+  args.set(process.argv[i], process.argv[i + 1]);
+}
+
+const role = args.get("--role") ?? "planner";
+const host = args.get("--host") ?? "127.0.0.1";
+const port = Number(args.get("--port") ?? "8080");
+
+const ROLE_CONFIG = {
+  planner: {
+    name: "Planning Agent",
+    skill: "problem-framing",
+    description:
+      "Frames the issue, names assumptions, and turns prior critique into the next review plan.",
+    tags: ["planning", "triage", "scope"],
+  },
+  security: {
+    name: "Security Agent",
+    skill: "security-review",
+    description:
+      "Reviews credential flow, sandbox policy, prompt injection, and data-exfiltration risks.",
+    tags: ["security", "policy", "credentials"],
+  },
+  implementation: {
+    name: "Implementation Agent",
+    skill: "implementation-review",
+    description:
+      "Maps the issue and prior review notes to concrete implementation and testing steps.",
+    tags: ["implementation", "testing", "docs"],
+  },
+  critic: {
+    name: "Critic Agent",
+    skill: "synthesis-critique",
+    description:
+      "Challenges weak claims, asks for missing evidence, and synthesizes the strongest next artifact.",
+    tags: ["critique", "synthesis", "quality"],
+  },
+};
+
+const config = ROLE_CONFIG[role] ?? ROLE_CONFIG.planner;
+
+function requestBaseUrl(req) {
+  const proto = req.headers["x-forwarded-proto"] ?? "http";
+  const hostHeader = req.headers["x-forwarded-host"] ?? req.headers.host;
+  return `${proto}://${hostHeader}`;
+}
+
+function agentCard(req) {
+  const baseUrl = requestBaseUrl(req);
+  return {
+    name: config.name,
+    description: config.description,
+    provider: {
+      organization: "OpenShell example",
+      url: "https://github.com/NVIDIA/OpenShell",
+    },
+    version: "1.0.0",
+    capabilities: {
+      streaming: true,
+      pushNotifications: false,
+    },
+    defaultInputModes: ["text/plain", "application/json"],
+    defaultOutputModes: ["text/markdown", "application/json"],
+    skills: [
+      {
+        id: config.skill,
+        name: config.name,
+        description: config.description,
+        tags: config.tags,
+        examples: [
+          "Review this GitHub issue and prior agent notes.",
+          "Revise your recommendation based on the latest critique.",
+        ],
+        inputModes: ["text/plain", "application/json"],
+        outputModes: ["text/markdown", "application/json"],
+      },
+    ],
+    supportedInterfaces: [
+      {
+        protocolBinding: "HTTP+JSON",
+        protocolVersion: "1.0",
+        url: baseUrl,
+      },
+    ],
+  };
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      body += chunk;
+      if (body.length > 1024 * 1024) {
+        req.destroy(new Error("request body too large"));
+      }
+    });
+    req.on("end", () => resolve(body));
+    req.on("error", reject);
+  });
+}
+
+function parseRequest(body) {
+  const parsed = body ? JSON.parse(body) : {};
+  const textPart = parsed.message?.parts?.find((part) => typeof part.text === "string");
+  const dataPart = parsed.message?.parts?.find((part) => part.data && typeof part.data === "object");
+  const data = dataPart?.data ?? {};
+  if (textPart && !data.prompt) {
+    data.prompt = textPart.text;
+  }
+  return data;
+}
+
+function issueSummary(issue) {
+  const labels = Array.isArray(issue.labels) && issue.labels.length > 0 ? issue.labels.join(", ") : "none";
+  return `#${issue.number ?? "?"} ${issue.title ?? "Untitled issue"} (${labels})`;
+}
+
+function priorByRole(transcript, wantedRole) {
+  return transcript
+    .filter((entry) => entry.role === wantedRole)
+    .slice(-1)
+    .map((entry) => entry.artifact)
+    .join("\n");
+}
+
+function bullets(items) {
+  return items.map((item) => `- ${item}`).join("\n");
+}
+
+function reviewFor(input) {
+  const issue = input.issue ?? {};
+  const transcript = Array.isArray(input.transcript) ? input.transcript : [];
+  const round = Number(input.round ?? 1);
+  const latestPlan = priorByRole(transcript, "planner");
+  const latestSecurity = priorByRole(transcript, "security");
+  const latestImplementation = priorByRole(transcript, "implementation");
+  const latestCritic = priorByRole(transcript, "critic");
+  const body = `${issue.title ?? ""}\n${issue.body ?? ""}`.toLowerCase();
+  const mentionsPolicy = /policy|credential|token|secret|auth|permission|network|sandbox/.test(body);
+  const mentionsDocs = /doc|readme|tutorial|example|guide/.test(body);
+  const mentionsTest = /test|ci|e2e|regression|verify|coverage/.test(body);
+
+  if (role === "planner") {
+    const focus = [
+      "Identify the smallest useful deliverable that would close or de-risk the issue.",
+      mentionsPolicy
+        ? "Treat policy and credential boundaries as first-class acceptance criteria."
+        : "Check whether the issue needs a policy boundary or only product behavior.",
+      mentionsDocs
+        ? "Make the user-facing explanation part of the deliverable."
+        : "Decide whether documentation is needed based on user-visible behavior.",
+      latestCritic
+        ? "Resolve the critic's strongest objection before expanding scope."
+        : "Ask the other agents for concrete blockers, not broad opinions.",
+    ];
+    return `## ${config.name} Round ${round}\n\nIssue: ${issueSummary(issue)}\n\nPlan:\n${bullets(focus)}\n\nHandoff: Security should pressure-test privileges; Implementation should name files, commands, and validation steps.`;
+  }
+
+  if (role === "security") {
+    const risks = [
+      mentionsPolicy
+        ? "The issue touches policy or credentials, so the implementation should avoid broad host or path grants."
+        : "No explicit credential surface is obvious, but any agent workflow should still avoid inherited credentials.",
+      "Treat issue text, comments, Agent Cards, messages, artifacts, and task status as untrusted input.",
+      "Prefer scoped REST paths over raw TCP or opaque gRPC when OpenShell needs auditable enforcement.",
+      latestPlan
+        ? "The current plan is usable if it keeps privilege requests structured and reviewable."
+        : "The plan needs explicit boundaries before implementation starts.",
+    ];
+    return `## ${config.name} Round ${round}\n\nSecurity review:\n${bullets(risks)}\n\nPolicy note: Keep A2A communication limited to discovery plus message/task paths, and keep GitHub write access separate from inter-agent traffic.`;
+  }
+
+  if (role === "implementation") {
+    const steps = [
+      "Create the smallest reproducible path before adding a richer UI or more agent roles.",
+      "Use A2A Agent Cards for discovery and stream task updates so the collaboration is visible.",
+      mentionsTest
+        ? "Add a regression or smoke command because the issue already names verification risk."
+        : "Add a smoke command that exercises at least one full agent-to-agent round.",
+      mentionsDocs
+        ? "Update docs near the existing tutorial/example surface."
+        : "Document the run command and the security model in the example README.",
+      latestSecurity
+        ? "Incorporate the security review as acceptance criteria, not as post-hoc notes."
+        : "Block on a security pass before widening endpoint access.",
+    ];
+    return `## ${config.name} Round ${round}\n\nImplementation path:\n${bullets(steps)}\n\nValidation: Run the local A2A smoke first, then run the OpenShell sandbox demo when a gateway is available.`;
+  }
+
+  const concerns = [
+    latestPlan ? "The plan is concrete enough to review." : "The plan still needs a concrete deliverable.",
+    latestSecurity ? "The security pass names useful constraints." : "Missing security review.",
+    latestImplementation ? "The implementation pass names validation." : "Missing implementation details.",
+    "The final answer should separate protocol behavior from OpenShell enforcement so readers do not confuse A2A auth with sandbox policy.",
+  ];
+  return `## ${config.name} Round ${round}\n\nCritique:\n${bullets(concerns)}\n\nSynthesis: proceed if the next artifact shows the message flow, the allowed REST paths, and the different powers each sandboxed agent receives.`;
+}
+
+function taskResponse(input, artifactText, state = "TASK_STATE_COMPLETED") {
+  const taskId = input.taskId ?? randomUUID();
+  const contextId = input.contextId ?? randomUUID();
+  return {
+    task: {
+      id: taskId,
+      contextId,
+      status: {
+        state,
+        message: {
+          role: "ROLE_AGENT",
+          messageId: randomUUID(),
+          parts: [{ text: `${config.name} completed round ${input.round ?? 1}.` }],
+        },
+      },
+      artifacts: [
+        {
+          artifactId: randomUUID(),
+          name: `${role}-review-round-${input.round ?? 1}`,
+          parts: [{ text: artifactText, mediaType: "text/markdown" }],
+        },
+      ],
+    },
+  };
+}
+
+function sendJson(res, status, value, headers = {}) {
+  const body = JSON.stringify(value, null, 2);
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(body),
+    ...headers,
+  });
+  res.end(body);
+}
+
+async function handleMessage(req, res, stream) {
+  try {
+    const input = parseRequest(await readBody(req));
+    const artifactText = reviewFor(input);
+    if (!stream) {
+      sendJson(res, 200, taskResponse(input, artifactText));
+      return;
+    }
+
+    res.writeHead(200, {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+    const taskId = input.taskId ?? randomUUID();
+    const contextId = input.contextId ?? randomUUID();
+    const events = [
+      { task: { id: taskId, contextId, status: { state: "TASK_STATE_SUBMITTED" } } },
+      {
+        statusUpdate: {
+          taskId,
+          contextId,
+          status: {
+            state: "TASK_STATE_WORKING",
+            message: {
+              role: "ROLE_AGENT",
+              messageId: randomUUID(),
+              parts: [{ text: `${config.name} is reviewing prior artifacts.` }],
+            },
+          },
+        },
+      },
+      {
+        artifactUpdate: {
+          taskId,
+          contextId,
+          artifact: {
+            artifactId: randomUUID(),
+            name: `${role}-review-round-${input.round ?? 1}`,
+            parts: [{ text: artifactText, mediaType: "text/markdown" }],
+          },
+          lastChunk: true,
+        },
+      },
+      {
+        statusUpdate: {
+          taskId,
+          contextId,
+          status: { state: "TASK_STATE_COMPLETED" },
+          final: true,
+        },
+      },
+    ];
+    for (const event of events) {
+      res.write(`data: ${JSON.stringify(event)}\n\n`);
+      await new Promise((resolve) => setTimeout(resolve, 120));
+    }
+    res.end();
+  } catch (error) {
+    sendJson(res, 400, { error: String(error.message ?? error) });
+  }
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/.well-known/agent-card.json") {
+    sendJson(res, 200, agentCard(req), {
+      "cache-control": "max-age=30",
+      etag: `"${role}-1.0.0"`,
+    });
+    return;
+  }
+
+  if (req.method === "POST" && req.url === "/message:send") {
+    void handleMessage(req, res, false);
+    return;
+  }
+
+  if (req.method === "POST" && req.url === "/message:stream") {
+    void handleMessage(req, res, true);
+    return;
+  }
+
+  if (req.method === "GET" && req.url === "/health") {
+    sendJson(res, 200, { status: "ok", role });
+    return;
+  }
+
+  sendJson(res, 404, { error: "not found" });
+});
+
+server.listen(port, host, () => {
+  console.error(`${config.name} listening on http://${host}:${port}`);
+});

--- a/examples/a2a-design-review/demo.sh
+++ b/examples/a2a-design-review/demo.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPENSHELL_BIN="${OPENSHELL_BIN:-openshell}"
+DEMO_RUN_ID="${DEMO_RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
+DEMO_ROUNDS="${DEMO_ROUNDS:-2}"
+DEMO_LOCAL_ONLY="${DEMO_LOCAL_ONLY:-0}"
+DEMO_KEEP_SANDBOXES="${DEMO_KEEP_SANDBOXES:-0}"
+DEMO_REPO="${DEMO_REPO:-NVIDIA/OpenShell}"
+DEMO_OUTPUT="${DEMO_OUTPUT:-${SCRIPT_DIR}/design-review-${DEMO_RUN_ID}.md}"
+
+ROLES=(planner security implementation critic)
+LOCAL_PORTS=(18081 18082 18083 18084)
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/openshell-a2a-design-review.XXXXXX")"
+PAYLOAD_DIR="${TMP_DIR}/payload"
+LOG_DIR="${TMP_DIR}/logs"
+mkdir -p "$PAYLOAD_DIR" "$LOG_DIR"
+
+BOLD='\033[1m'
+CYAN='\033[36m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RED='\033[31m'
+RESET='\033[0m'
+
+PIDS=()
+SANDBOXES=()
+
+step() {
+    printf "\n${BOLD}${CYAN}==> %s${RESET}\n\n" "$1"
+}
+
+info() {
+    printf "  %b\n" "$*"
+}
+
+fail() {
+    printf "\n${RED}error:${RESET} %s\n" "$*" >&2
+    exit 1
+}
+
+cleanup() {
+    local status=$?
+    for pid in "${PIDS[@]:-}"; do
+        kill "$pid" >/dev/null 2>&1 || true
+    done
+
+    if [[ "$DEMO_LOCAL_ONLY" != "1" && "$DEMO_KEEP_SANDBOXES" != "1" ]]; then
+        for sandbox in "${SANDBOXES[@]:-}"; do
+            "$OPENSHELL_BIN" sandbox delete "$sandbox" >/dev/null 2>&1 || true
+        done
+    fi
+
+    if [[ $status -eq 0 ]]; then
+        rm -rf "$TMP_DIR"
+    else
+        printf "\n${YELLOW}Logs kept at: %s${RESET}\n" "$LOG_DIR"
+    fi
+}
+trap cleanup EXIT
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+prepare_payload() {
+    cp "${SCRIPT_DIR}/a2a-agent.mjs" "${PAYLOAD_DIR}/a2a-agent.mjs"
+}
+
+issue_args() {
+    if [[ -n "${DEMO_ISSUE_URL:-}" ]]; then
+        printf '%s\n' "--issue-url" "$DEMO_ISSUE_URL"
+    elif [[ "${DEMO_USE_SAMPLE_ISSUE:-1}" == "1" ]]; then
+        printf '%s\n' "--issue-file" "${SCRIPT_DIR}/sample-issue.json"
+    else
+        printf '%s\n' "--repo" "$DEMO_REPO"
+    fi
+}
+
+run_orchestrator() {
+    local -a agent_args=("$@")
+    local -a issue
+    mapfile -t issue < <(issue_args)
+
+    node "${SCRIPT_DIR}/orchestrator.mjs" \
+        "${issue[@]}" \
+        --rounds "$DEMO_ROUNDS" \
+        --output "$DEMO_OUTPUT" \
+        "${agent_args[@]}"
+}
+
+wait_for_http() {
+    local url="$1"
+    local label="$2"
+    for _ in $(seq 1 60); do
+        if curl -fsS "${url}/health" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    fail "${label} did not become healthy at ${url}"
+}
+
+run_local() {
+    local -a agent_args=()
+
+    step "Starting local A2A agents"
+    for i in "${!ROLES[@]}"; do
+        local role="${ROLES[$i]}"
+        local port="${LOCAL_PORTS[$i]}"
+        node "${SCRIPT_DIR}/a2a-agent.mjs" --role "$role" --host 127.0.0.1 --port "$port" \
+            >"${LOG_DIR}/${role}.log" 2>&1 &
+        PIDS+=("$!")
+        local url="http://127.0.0.1:${port}"
+        wait_for_http "$url" "$role"
+        agent_args+=(--agent "${role}=${url}")
+        info "${role} listening at ${url}"
+    done
+
+    step "Running A2A design review"
+    run_orchestrator "${agent_args[@]}"
+}
+
+wait_for_sandbox() {
+    local name="$1"
+    for _ in $(seq 1 90); do
+        if "$OPENSHELL_BIN" sandbox get "$name" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    fail "sandbox ${name} did not become visible"
+}
+
+expose_service() {
+    local name="$1"
+    local role="$2"
+    local output url
+
+    for _ in $(seq 1 60); do
+        if output="$(NO_COLOR=1 "$OPENSHELL_BIN" service expose "$name" 8080 "$role" 2>&1)"; then
+            url="$(printf '%s\n' "$output" | sed -n 's/^  URL: //p' | tail -1)"
+            [[ -n "$url" ]] || fail "service expose for ${name}/${role} did not print a URL"
+            printf '%s\n' "$url"
+            return 0
+        fi
+        sleep 1
+    done
+
+    printf '%s\n' "$output" >&2
+    fail "failed to expose ${role} service on ${name}"
+}
+
+run_openshell() {
+    local -a agent_args=()
+
+    require_command "$OPENSHELL_BIN"
+    require_command curl
+    "$OPENSHELL_BIN" status >/dev/null 2>&1 || fail "OpenShell gateway is not reachable; run: mise run gateway:docker"
+    "$OPENSHELL_BIN" sandbox list >/dev/null 2>&1 || fail "OpenShell sandbox API is not healthy; restart the gateway and confirm 'openshell sandbox list' works"
+
+    prepare_payload
+
+    step "Starting A2A agents in OpenShell sandboxes"
+    for role in "${ROLES[@]}"; do
+        local name="a2a-review-${DEMO_RUN_ID}-${role}"
+        SANDBOXES+=("$name")
+        "$OPENSHELL_BIN" sandbox delete "$name" >/dev/null 2>&1 || true
+        "$OPENSHELL_BIN" sandbox create \
+            --name "$name" \
+            --from base \
+            --policy "${SCRIPT_DIR}/policy.yaml" \
+            --upload "${PAYLOAD_DIR}:/sandbox" \
+            --no-tty \
+            -- node /sandbox/payload/a2a-agent.mjs --role "$role" --host 127.0.0.1 --port 8080 \
+            >"${LOG_DIR}/${role}.log" 2>&1 &
+        PIDS+=("$!")
+        wait_for_sandbox "$name"
+        info "started ${role} sandbox ${name}"
+    done
+
+    step "Exposing A2A services through the gateway"
+    for i in "${!ROLES[@]}"; do
+        local role="${ROLES[$i]}"
+        local name="${SANDBOXES[$i]}"
+        local url
+        url="$(expose_service "$name" "$role")"
+        wait_for_http "$url" "${role} service"
+        agent_args+=(--agent "${role}=${url}")
+        info "${role} Agent Card: ${url}/.well-known/agent-card.json"
+    done
+
+    step "Running A2A design review"
+    run_orchestrator "${agent_args[@]}"
+}
+
+main() {
+    require_command node
+
+    if [[ "$DEMO_LOCAL_ONLY" == "1" ]]; then
+        run_local
+    else
+        run_openshell
+    fi
+
+    printf "\n${BOLD}${GREEN}Demo complete.${RESET}\n"
+    printf "  Review artifact: %s\n" "$DEMO_OUTPUT"
+}
+
+main "$@"

--- a/examples/a2a-design-review/orchestrator.mjs
+++ b/examples/a2a-design-review/orchestrator.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+
+function parseArgs(argv) {
+  const out = { agents: [], rounds: 2 };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--agent") out.agents.push(argv[++i]);
+    else if (arg === "--issue-url") out.issueUrl = argv[++i];
+    else if (arg === "--issue-file") out.issueFile = argv[++i];
+    else if (arg === "--rounds") out.rounds = Number(argv[++i]);
+    else if (arg === "--output") out.output = argv[++i];
+    else if (arg === "--repo") out.repo = argv[++i];
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return out;
+}
+
+function parseIssueUrl(url) {
+  const match = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/([0-9]+)(?:[/?#].*)?$/.exec(url);
+  if (!match) {
+    throw new Error(`issue URL must look like https://github.com/OWNER/REPO/issues/123, got ${url}`);
+  }
+  return { owner: match[1], repo: match[2], number: match[3] };
+}
+
+async function githubJson(url) {
+  const headers = {
+    accept: "application/vnd.github+json",
+    "user-agent": "openshell-a2a-design-review-demo",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  } else if (process.env.GH_TOKEN) {
+    headers.authorization = `Bearer ${process.env.GH_TOKEN}`;
+  }
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`GitHub request failed ${response.status}: ${await response.text()}`);
+  }
+  return response.json();
+}
+
+async function loadIssue(args) {
+  if (args.issueFile) {
+    return JSON.parse(await fs.readFile(args.issueFile, "utf8"));
+  }
+
+  if (args.issueUrl) {
+    const { owner, repo, number } = parseIssueUrl(args.issueUrl);
+    const issue = await githubJson(`https://api.github.com/repos/${owner}/${repo}/issues/${number}`);
+    return normalizeIssue(issue);
+  }
+
+  const repo = args.repo ?? "NVIDIA/OpenShell";
+  const issues = await githubJson(`https://api.github.com/repos/${repo}/issues?state=open&per_page=1`);
+  const issue = issues.find((item) => !item.pull_request);
+  if (!issue) throw new Error(`no open issues found for ${repo}`);
+  return normalizeIssue(issue);
+}
+
+function normalizeIssue(issue) {
+  return {
+    number: issue.number,
+    title: issue.title,
+    body: issue.body ?? "",
+    url: issue.html_url ?? issue.url,
+    labels: (issue.labels ?? []).map((label) => (typeof label === "string" ? label : label.name)),
+  };
+}
+
+function parseAgentSpec(spec) {
+  const [role, ...rest] = spec.split("=");
+  const url = rest.join("=");
+  if (!role || !url) throw new Error(`--agent must be role=url, got ${spec}`);
+  return { role, url: url.replace(/\/$/, "") };
+}
+
+async function discover(agent) {
+  const response = await fetch(`${agent.url}/.well-known/agent-card.json`);
+  if (!response.ok) {
+    throw new Error(`failed to fetch Agent Card for ${agent.role}: ${response.status}`);
+  }
+  return { ...agent, card: await response.json() };
+}
+
+function messagePayload(issue, transcript, role, round) {
+  return {
+    message: {
+      role: "ROLE_USER",
+      messageId: randomUUID(),
+      parts: [
+        {
+          data: {
+            issue,
+            transcript,
+            role,
+            round,
+            prompt: `Round ${round}: review the issue from the ${role} perspective and build on prior artifacts.`,
+          },
+          mediaType: "application/json",
+        },
+      ],
+    },
+  };
+}
+
+function artifactTextFromEvent(event) {
+  const artifact = event.artifactUpdate?.artifact ?? event.task?.artifacts?.[0];
+  const part = artifact?.parts?.find((candidate) => typeof candidate.text === "string");
+  return part?.text ?? "";
+}
+
+async function callAgent(agent, issue, transcript, round) {
+  const response = await fetch(`${agent.url}/message:stream`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "text/event-stream",
+      "a2a-version": "1.0",
+    },
+    body: JSON.stringify(messagePayload(issue, transcript, agent.role, round)),
+  });
+  if (!response.ok) {
+    throw new Error(`${agent.role} returned ${response.status}: ${await response.text()}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let artifact = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const chunks = buffer.split("\n\n");
+    buffer = chunks.pop() ?? "";
+    for (const chunk of chunks) {
+      const line = chunk.split("\n").find((candidate) => candidate.startsWith("data: "));
+      if (!line) continue;
+      const event = JSON.parse(line.slice(6));
+      const status = event.statusUpdate?.status?.state ?? event.task?.status?.state;
+      if (status) console.log(`  ${agent.role}: ${status}`);
+      const text = artifactTextFromEvent(event);
+      if (text) artifact = text;
+    }
+  }
+  if (!artifact) {
+    throw new Error(`${agent.role} did not return an artifact`);
+  }
+  return artifact;
+}
+
+function finalReport(issue, agents, transcript) {
+  const agentRows = agents
+    .map((agent) => `- ${agent.role}: ${agent.card.name} (${agent.card.skills?.[0]?.id ?? "unknown skill"})`)
+    .join("\n");
+  const artifacts = transcript
+    .map((entry) => `\n### Round ${entry.round} - ${entry.role}\n\n${entry.artifact}`)
+    .join("\n");
+  return `# A2A Design Review\n\nIssue: [#${issue.number} ${issue.title}](${issue.url})\n\n## Agents\n\n${agentRows}\n\n## Transcript\n${artifacts}\n`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.agents.length === 0) {
+    throw new Error("provide at least one --agent role=url");
+  }
+
+  const issue = await loadIssue(args);
+  const agents = await Promise.all(args.agents.map((spec) => discover(parseAgentSpec(spec))));
+  const transcript = [];
+
+  console.log(`A2A design review for #${issue.number}: ${issue.title}`);
+  for (const agent of agents) {
+    console.log(`  discovered ${agent.role}: ${agent.card.name}`);
+  }
+
+  for (let round = 1; round <= args.rounds; round += 1) {
+    console.log(`\nRound ${round}`);
+    for (const agent of agents) {
+      const artifact = await callAgent(agent, issue, transcript, round);
+      transcript.push({ round, role: agent.role, artifact });
+      console.log(`  ${agent.role}: artifact accepted (${artifact.length} chars)`);
+    }
+  }
+
+  const report = finalReport(issue, agents, transcript);
+  if (args.output) {
+    await fs.writeFile(args.output, report);
+    console.log(`\nWrote ${args.output}`);
+  } else {
+    console.log(`\n${report}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(`error: ${error.message}`);
+  process.exit(1);
+});

--- a/examples/a2a-design-review/policy.yaml
+++ b/examples/a2a-design-review/policy.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only: [/usr, /lib, /proc, /dev/urandom, /app, /etc, /var/log]
+  read_write: [/sandbox, /tmp, /dev/null]
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+# The A2A worker agents in this demo do not need outbound network access.
+# They receive messages through OpenShell service routing and return artifacts
+# to the host-side client agent.
+network_policies: {}

--- a/examples/a2a-design-review/sample-issue.json
+++ b/examples/a2a-design-review/sample-issue.json
@@ -1,0 +1,7 @@
+{
+  "number": 42,
+  "title": "Add a safe agent-to-agent design review workflow",
+  "body": "We want a demo where multiple sandboxed agents collaborate on a GitHub issue using A2A. The demo should show Agent Card discovery, streaming task updates, scoped REST paths, credential isolation, and a clear final artifact. It should include a smoke test and documentation for users.",
+  "url": "https://github.com/NVIDIA/OpenShell/issues/42",
+  "labels": ["example", "area:policy", "agent-comms"]
+}


### PR DESCRIPTION
## Summary

Add a getting-started A2A design-review example where multiple isolated agents review a GitHub issue over Agent2Agent-style HTTP endpoints. The demo shows Agent Card discovery, streamed task updates, iterative artifacts, and the OpenShell boundary around worker agents.

## Related Issue

N/A

## Changes

- Added `examples/a2a-design-review/` with a minimal A2A HTTP agent, host orchestrator, OpenShell runner script, restrictive worker policy, and offline issue fixture.
- Added a getting-started tutorial page for running the A2A design review locally or through OpenShell service routing.
- Added the tutorial card to the tutorials index.

## Testing

- [x] `bash -n examples/a2a-design-review/demo.sh`
- [x] `node --check examples/a2a-design-review/a2a-agent.mjs && node --check examples/a2a-design-review/orchestrator.mjs`
- [x] `DEMO_LOCAL_ONLY=1 DEMO_OUTPUT=/tmp/a2a-design-review-final-smoke.md bash examples/a2a-design-review/demo.sh`
- [x] `git diff --check`
- [x] `uv run python scripts/update_license_headers.py --check <new/modified files>`
- [ ] `mise run pre-commit` passes

`mise run pre-commit` ran the full suite and the repo checks/tests completed successfully, but the task exited nonzero because of an unrelated pre-existing untracked `tmp.sh` file missing an SPDX header. I did not modify that file. The live OpenShell sandbox path could not be completed in this workspace because the currently running local gateway fails `openshell sandbox list` with a protobuf UTF-8 decode error after syncing main; the demo now preflights that condition and reports it clearly.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)