### PR TITLE
fix(ci): skip helm plugin verification in CI image

### DIFF
--- a/deploy/docker/Dockerfile.ci
+++ b/deploy/docker/Dockerfile.ci
@@ -84,7 +84,7 @@ RUN --mount=type=secret,id=MISE_GITHUB_TOKEN \
     mise reshim && \
     (/root/.cargo/bin/rustup component remove rust-docs || true) && \
     rm -rf /root/.rustup/toolchains/*/share/doc /root/.rustup/toolchains/*/share/man && \
-    helm plugin install https://github.com/helm-unittest/helm-unittest
+    helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
 
 # Set working directory for CI jobs
 WORKDIR /builds


### PR DESCRIPTION
## Summary

Fix the Build CI Image workflow by installing the helm-unittest plugin with Helm source verification disabled. Helm now verifies plugin sources by default, and helm-unittest does not support that verification path.

## Related Issue

Fixes failing workflow run: https://github.com/NVIDIA/OpenShell/actions/runs/25939570007

## Changes

- Add `--verify=false` to the helm-unittest plugin install in `deploy/docker/Dockerfile.ci`
- Match the existing Helm test task behavior in `tasks/helm.toml`

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)