### PR TITLE
fix(ci): eliminate image-tag race between concurrent workflows

### DIFF
--- a/.github/workflows/branch-e2e.yml
+++ b/.github/workflows/branch-e2e.yml
@@ -34,6 +34,7 @@ jobs:
     with:
       component: gateway
       platform: linux/arm64
+      publish-manifest: false
 
   build-supervisor:
     needs: [pr_metadata]
@@ -45,6 +46,7 @@ jobs:
     with:
       component: supervisor
       platform: linux/arm64
+      publish-manifest: false
 
   e2e:
     needs: [pr_metadata, build-gateway, build-supervisor]
@@ -54,5 +56,5 @@ jobs:
       packages: read
     uses: ./.github/workflows/e2e-test.yml
     with:
-      image-tag: ${{ github.sha }}
+      image-tag: ${{ github.sha }}-arm64
       runner: linux-arm64-cpu8

--- a/.github/workflows/branch-kubernetes-e2e.yml
+++ b/.github/workflows/branch-kubernetes-e2e.yml
@@ -38,6 +38,7 @@ jobs:
     with:
       component: gateway
       platform: linux/amd64
+      publish-manifest: false
 
   build-supervisor:
     needs: [pr_metadata]
@@ -49,6 +50,7 @@ jobs:
     with:
       component: supervisor
       platform: linux/amd64
+      publish-manifest: false
 
   kubernetes-e2e:
     name: Kubernetes E2E (Rust smoke)
@@ -106,16 +108,15 @@ jobs:
           kind get kubeconfig --name "$KIND_CLUSTER_NAME" > "$GITHUB_WORKSPACE/kubeconfig"
           chmod 600 "$GITHUB_WORKSPACE/kubeconfig"
 
-      # Pre-pull and side-load: kind nodes don't have ghcr credentials, and
-      # tagging IMAGE_TAG to a SHA means the chart's IfNotPresent pull policy
-      # is satisfied once the image is loaded into the node's containerd.
       - name: Load gateway and supervisor images into kind
         run: |
           set -euo pipefail
           for component in gateway supervisor; do
-            image="ghcr.io/nvidia/openshell/${component}:${{ github.sha }}"
-            docker pull "$image"
-            kind load docker-image "$image" --name "$KIND_CLUSTER_NAME"
+            src="ghcr.io/nvidia/openshell/${component}:${{ github.sha }}-amd64"
+            bare="ghcr.io/nvidia/openshell/${component}:${{ github.sha }}"
+            docker pull "$src"
+            docker tag "$src" "$bare"
+            kind load docker-image "$bare" --name "$KIND_CLUSTER_NAME"
           done
 
       - name: Run Kubernetes E2E (Rust smoke)

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -42,6 +42,11 @@ on:
         required: false
         type: string
         default: ""
+      publish-manifest:
+        description: "Push the bare-SHA manifest. Set false for single-arch branch workflows."
+        required: false
+        type: boolean
+        default: true
 
 env:
   MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -181,7 +186,7 @@ jobs:
         # inside the container so setup-buildx can read it.
         - /etc/buildkit:/etc/buildkit:ro
     env:
-      IMAGE_TAG: ${{ needs.resolve.outputs.platform_count == '1' && needs.resolve.outputs.image_tag_base || format('{0}-{1}', needs.resolve.outputs.image_tag_base, matrix.arch) }}
+      IMAGE_TAG: ${{ format('{0}-{1}', needs.resolve.outputs.image_tag_base, matrix.arch) }}
       IMAGE_REGISTRY: ghcr.io/nvidia/openshell
       DOCKER_PUSH: ${{ inputs.push && '1' || '0' }}
       DOCKER_PLATFORM: ${{ matrix.platform }}
@@ -257,7 +262,7 @@ jobs:
   merge:
     name: Merge ${{ inputs.component }} manifest
     needs: [resolve, build]
-    if: ${{ inputs.push && needs.resolve.outputs.platform_count != '1' }}
+    if: ${{ inputs.push && inputs['publish-manifest'] }}
     runs-on: linux-amd64-cpu8
     timeout-minutes: 10
     container:


### PR DESCRIPTION
## Summary

- Always append arch suffix to `IMAGE_TAG` in `docker-build.yml` so each workflow writes to its own registry slot
- Run the merge step unconditionally when pushing so the bare `:SHA` tag is always a deterministic manifest list
- Update `branch-kubernetes-e2e.yml` to pull the `amd64`-suffixed tag directly

## Related Issue

Fixes #1343

## Changes

Three concurrent workflows (Branch Kubernetes E2E, Branch E2E Checks, GPU Test) were all writing to the same bare `:SHA` tag. The merge step was gated on `platform_count != 1`, so single-arch builds collapsed onto the bare tag and raced with each other. `kind load` then failed when it found a manifest list but only had one arch locally.

The fix removes the conditional collapse so every build writes to `:SHA-<arch>`, and the merge step always assembles the bare `:SHA` tag as a proper manifest list.

## Testing

- CI-only change, validated by reading the workflow logic
- No code changes, no Rust

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)