### PR TITLE
fix(vm): preserve guest TLS hostname

### DIFF
--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -17,11 +17,11 @@ BOOT_START=$(date +%s%3N 2>/dev/null || date +%s)
 #                     gvproxy's TCP/UDP/ICMP forwarder. Use this address
 #                     (or any of the host.* hostnames below) to reach a
 #                     service the host is listening on.
-# The host.containers.internal / host.docker.internal DNS records served
-# by gvproxy's embedded resolver point at 192.168.127.254. We mirror that
-# in /etc/hosts so the supervisor can reach the gateway even when
-# gvproxy's DNS is not in resolv.conf (e.g. DHCP failed and we fell
-# back to 8.8.8.8).
+# The host.openshell.internal / host.containers.internal /
+# host.docker.internal DNS records served by gvproxy's embedded resolver
+# point at 192.168.127.254. We mirror that in /etc/hosts so the supervisor
+# can reach the gateway even when gvproxy's DNS is not in resolv.conf
+# (e.g. DHCP failed and we fell back to 8.8.8.8).
 GVPROXY_GATEWAY_IP="192.168.127.1"
 GVPROXY_HOST_LOOPBACK_IP="192.168.127.254"
 GATEWAY_IP="$GVPROXY_GATEWAY_IP"
@@ -419,7 +419,12 @@ rewrite_openshell_endpoint_if_needed() {
     if [ "${GATEWAY_IP}" != "${GVPROXY_GATEWAY_IP}" ]; then
         fallback_ip="$GATEWAY_IP"
     fi
-    for candidate in host.openshell.internal host.containers.internal host.docker.internal "$fallback_ip"; do
+    local candidates="host.openshell.internal host.containers.internal host.docker.internal"
+    if [ "$scheme" != "https" ]; then
+        candidates="${candidates} ${fallback_ip}"
+    fi
+
+    for candidate in $candidates; do
         if [ "$candidate" = "$host" ]; then
             continue
         fi
@@ -434,6 +439,11 @@ rewrite_openshell_endpoint_if_needed() {
             return 0
         fi
     done
+
+    if [ "$scheme" = "https" ]; then
+        ts "WARNING: could not preflight HTTPS OpenShell endpoint ${host}:${port}; preserving hostname for TLS verification"
+        return 0
+    fi
 
     ts "WARNING: could not reach OpenShell endpoint ${host}:${port}"
 }

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -91,11 +91,11 @@ const OPENSHELL_HOST_GATEWAY_ALIAS: &str = "host.openshell.internal";
 ///     resolves even when gvproxy's DNS is not in resolv.conf;
 ///   * keeping a recognisable hostname makes log messages clearer than a bare
 ///     192.168.127.254 reference;
-///   * `host.docker.internal` works the same way for Docker-flavoured tooling.
+///   * package-managed gateway certificates include this SAN for guest mTLS.
 ///
 /// Both names ultimately route through the gvproxy NAT path on
 /// `GVPROXY_HOST_LOOPBACK_IP` — they do **not** go through the gateway IP.
-const GVPROXY_HOST_LOOPBACK_ALIAS: &str = "host.containers.internal";
+const GVPROXY_HOST_LOOPBACK_ALIAS: &str = OPENSHELL_HOST_GATEWAY_ALIAS;
 const GUEST_SSH_SOCKET_PATH: &str = "/run/openshell/ssh.sock";
 const GUEST_TLS_CA_PATH: &str = "/opt/openshell/tls/ca.crt";
 const GUEST_TLS_CERT_PATH: &str = "/opt/openshell/tls/tls.crt";
@@ -3392,7 +3392,7 @@ fn merged_environment(sandbox: &Sandbox) -> HashMap<String, String> {
 /// not the host's. Inside the guest we need a name that gvproxy will translate
 /// into the host's loopback address.
 ///
-/// We rewrite to `host.containers.internal`, which gvproxy's embedded DNS resolves
+/// We rewrite to `host.openshell.internal`, which gvproxy's embedded DNS resolves
 /// to the host-loopback IP `192.168.127.254`. gvproxy installs a default NAT entry
 /// rewriting that destination to the host's `127.0.0.1` and dialing out from the
 /// host process, so any port the host is listening on becomes reachable. The

--- a/crates/openshell-driver-vm/src/rootfs.rs
+++ b/crates/openshell-driver-vm/src/rootfs.rs
@@ -379,6 +379,7 @@ fn prepare_sandbox_rootfs(rootfs: &Path) -> Result<(), String> {
         .map_err(|e| format!("write sandbox rootfs marker: {e}"))?;
     ensure_sandbox_guest_user(rootfs)?;
     create_sandbox_mountpoint(&rootfs.join("sandbox"))?;
+    create_sandbox_mountpoint(&rootfs.join("image-cache"))?;
     create_sandbox_mountpoint(&rootfs.join("lower"))?;
     create_sandbox_mountpoint(&rootfs.join("overlay"))?;
     create_sandbox_mountpoint(&rootfs.join("newroot"))?;
@@ -941,6 +942,7 @@ mod tests {
         assert!(rootfs.join("srv/openshell-vm-sandbox-init.sh").is_file());
         assert!(rootfs.join("opt/openshell/bin/umoci").is_file());
         assert!(rootfs.join("sandbox").is_dir());
+        assert!(rootfs.join("image-cache").is_dir());
         assert!(rootfs.join("lower").is_dir());
         assert!(rootfs.join("overlay").is_dir());
         assert!(rootfs.join("newroot").is_dir());

--- a/e2e/rust/e2e-vm.sh
+++ b/e2e/rust/e2e-vm.sh
@@ -68,6 +68,11 @@ SANDBOX_PROVISION_TIMEOUT=180
 
 # ── Build prerequisites ──────────────────────────────────────────────
 
+if [ -n "${RUSTC_WRAPPER:-}" ] && [ "${OPENSHELL_E2E_VM_ALLOW_RUSTC_WRAPPER:-0}" != "1" ]; then
+  echo "==> Building without RUSTC_WRAPPER=${RUSTC_WRAPPER} (set OPENSHELL_E2E_VM_ALLOW_RUSTC_WRAPPER=1 to keep it)"
+  unset RUSTC_WRAPPER
+fi
+
 mkdir -p "${COMPRESSED_DIR}"
 
 if ! find "${COMPRESSED_DIR}" -maxdepth 1 -name 'libkrun*.zst' | grep -q .; then

--- a/e2e/rust/e2e-vm.sh
+++ b/e2e/rust/e2e-vm.sh
@@ -28,10 +28,10 @@
 #      `openshell` CLI with the embedded runtime.
 #   3. On macOS, codesigns the VM driver (libkrun needs the
 #      `com.apple.security.hypervisor` entitlement).
-#   4. Starts the gateway with `--drivers vm --disable-tls
-#      --disable-gateway-auth --db-url sqlite:<run-state>/gateway.db` on a random
-#      free port, waits for `Server listening`, then runs the selected
-#      Rust e2e test (`smoke` by default).
+#   4. Writes a per-run gateway config with `[openshell.drivers.vm]`
+#      settings, starts the gateway with `--config <run-state>/gateway.toml`
+#      on a random free port, waits for `Server listening`, then runs the
+#      selected Rust e2e test (`smoke` by default).
 #   5. Tears the gateway down and (on failure) preserves the gateway
 #      log and every VM serial console log for post-mortem.
 #
@@ -50,7 +50,7 @@ DRIVER_BIN="${ROOT}/target/debug/openshell-driver-vm"
 E2E_TEST="${OPENSHELL_E2E_VM_TEST:-smoke}"
 E2E_FEATURES="${OPENSHELL_E2E_VM_FEATURES:-e2e-vm}"
 
-# The VM driver places `compute-driver.sock` under --vm-driver-state-dir.
+# The VM driver places `compute-driver.sock` under `[openshell.drivers.vm].state_dir`.
 # AF_UNIX SUN_LEN is 104 bytes on macOS (108 on Linux), so paths anchored
 # in the workspace's `target/` blow the limit on typical developer
 # machines — e.g. a ~100-char `~/.superset/worktrees/.../target/...`
@@ -116,6 +116,7 @@ mkdir -p "${RUN_STATE_DIR}"
 GATEWAY_LOG="$(mktemp /tmp/openshell-gateway-e2e.XXXXXX)"
 GATEWAY_PID_FILE="${RUN_STATE_DIR}/gateway.pid"
 GATEWAY_ARGS_FILE="${RUN_STATE_DIR}/gateway.args"
+GATEWAY_CONFIG="${RUN_STATE_DIR}/gateway.toml"
 GATEWAY_DB="${RUN_STATE_DIR}/gateway.db"
 
 # ── Cleanup (trap) ───────────────────────────────────────────────────
@@ -172,28 +173,35 @@ trap cleanup EXIT
 
 echo "==> Starting openshell-gateway on 127.0.0.1:${HOST_PORT} (state: ${RUN_STATE_DIR})"
 
-# Pin --driver-dir to the workspace `target/debug/` so we always pick up
+# Pin `driver_dir` to the workspace `target/debug/` so we always pick up
 # the driver we just cargo-built. Without this, the gateway's
 # `resolve_compute_driver_bin` fallback prefers
 # `~/.local/libexec/openshell/openshell-driver-vm` when present,
 # which silently shadows development builds — a subtle source of
 # stale-binary bugs in e2e runs.
-# --grpc-endpoint is the URL the VM driver passes into each guest as
+# `grpc_endpoint` is the URL the VM driver passes into each guest as
 # OPENSHELL_ENDPOINT. The supervisor inside the VM dials this address.
 # Use `host.containers.internal` rather than `127.0.0.1` so gvproxy's
 # host-loopback proxy carries the connection — gvproxy's bare gateway IP
 # (192.168.127.1) does NOT forward arbitrary host ports. The driver also
 # rewrites loopback URLs to this hostname as a safety net, so this matches
 # what the guest will actually see and aligns with `tasks/scripts/gateway-vm.sh`.
+cat >"${GATEWAY_CONFIG}" <<EOF
+[openshell]
+version = 1
+
+[openshell.drivers.vm]
+grpc_endpoint = "http://host.containers.internal:${HOST_PORT}"
+driver_dir = "${ROOT}/target/debug"
+state_dir = "${RUN_STATE_DIR}"
+EOF
+
 GATEWAY_ARGS=(
+  --config "${GATEWAY_CONFIG}"
   --drivers vm
   --disable-tls
-  --disable-gateway-auth
   --db-url "sqlite:${GATEWAY_DB}?mode=rwc"
   --port "${HOST_PORT}"
-  --grpc-endpoint "http://host.containers.internal:${HOST_PORT}"
-  --driver-dir "${ROOT}/target/debug"
-  --vm-driver-state-dir "${RUN_STATE_DIR}"
 )
 e2e_write_gateway_args_file "${GATEWAY_ARGS_FILE}" "${GATEWAY_ARGS[@]}"
 

--- a/e2e/rust/e2e-vm.sh
+++ b/e2e/rust/e2e-vm.sh
@@ -181,17 +181,16 @@ echo "==> Starting openshell-gateway on 127.0.0.1:${HOST_PORT} (state: ${RUN_STA
 # stale-binary bugs in e2e runs.
 # `grpc_endpoint` is the URL the VM driver passes into each guest as
 # OPENSHELL_ENDPOINT. The supervisor inside the VM dials this address.
-# Use `host.containers.internal` rather than `127.0.0.1` so gvproxy's
-# host-loopback proxy carries the connection — gvproxy's bare gateway IP
-# (192.168.127.1) does NOT forward arbitrary host ports. The driver also
-# rewrites loopback URLs to this hostname as a safety net, so this matches
-# what the guest will actually see and aligns with `tasks/scripts/gateway-vm.sh`.
+# Use `host.openshell.internal` rather than `127.0.0.1` so gvproxy's
+# host-loopback proxy carries the connection while keeping the endpoint aligned
+# with package-managed gateway certificates. gvproxy's bare gateway IP
+# (192.168.127.1) does NOT forward arbitrary host ports.
 cat >"${GATEWAY_CONFIG}" <<EOF
 [openshell]
 version = 1
 
 [openshell.drivers.vm]
-grpc_endpoint = "http://host.containers.internal:${HOST_PORT}"
+grpc_endpoint = "http://host.openshell.internal:${HOST_PORT}"
 driver_dir = "${ROOT}/target/debug"
 state_dir = "${RUN_STATE_DIR}"
 EOF

--- a/e2e/rust/e2e-vm.sh
+++ b/e2e/rust/e2e-vm.sh
@@ -194,6 +194,11 @@ cat >"${GATEWAY_CONFIG}" <<EOF
 [openshell]
 version = 1
 
+[openshell.gateway]
+bind_address = "127.0.0.1:${HOST_PORT}"
+compute_drivers = ["vm"]
+disable_tls = true
+
 [openshell.drivers.vm]
 grpc_endpoint = "http://host.openshell.internal:${HOST_PORT}"
 driver_dir = "${ROOT}/target/debug"
@@ -202,10 +207,7 @@ EOF
 
 GATEWAY_ARGS=(
   --config "${GATEWAY_CONFIG}"
-  --drivers vm
-  --disable-tls
   --db-url "sqlite:${GATEWAY_DB}?mode=rwc"
-  --port "${HOST_PORT}"
 )
 e2e_write_gateway_args_file "${GATEWAY_ARGS_FILE}" "${GATEWAY_ARGS[@]}"
 


### PR DESCRIPTION
## Summary
Fix VM sandbox provisioning for package-managed local mTLS gateways by adding the missing `/image-cache` mountpoint and keeping guest callbacks on the certificate-valid `host.openshell.internal` alias.

## Related Issue
None

## Changes
- Create `/image-cache` when preparing sandbox VM rootfs images.
- Use `host.openshell.internal` as the VM host-loopback alias for loopback gateway endpoints.
- Keep HTTPS gateway callbacks on host aliases instead of falling back to a bare gvproxy IP when endpoint preflight fails.

## Testing
- `mise run pre-commit` (failed only on existing ignored markdown plan docs: `architecture/plans/issue-981-sandboxprofile-feedback.md`, `architecture/plans/issue-994-gateway-ingress-response.md`; Rust tests in the run passed)
- `env RUSTC_WRAPPER= cargo test -p openshell-driver-vm`
- `git diff --check`
- Local Homebrew VM smoke test: `/opt/homebrew/bin/openshell sandbox create --no-keep --no-tty -- true`

## Checklist
- [x] Follows Conventional Commits
- [x] Commit includes Signed-off-by
- [x] Unit tests pass
- [ ] E2E tests updated