### PR TITLE
fix(docker): fall back to host arch for local builds

### DIFF
--- a/architecture/build.md
+++ b/architecture/build.md
@@ -31,10 +31,12 @@ Dockerfile compiles Rust — both copy a staged binary out of
 
 Binary staging is driven by `tasks/scripts/stage-prebuilt-binaries.sh`, which
 runs `cargo build` natively on a matching host or `cargo zigbuild` when
-cross-compiling. CI invokes the same staging step via the
-`rust-native-build.yml` workflow (per-architecture, per-component) and uploads
-the result as an artifact that the image build job downloads back into the
-staging directory before running Buildx.
+cross-compiling. Local Docker image tasks infer the target architecture from
+`DOCKER_PLATFORM` when set, otherwise from the container engine host metadata
+with the kernel architecture as the fallback. CI invokes the same staging step
+via the `rust-native-build.yml` workflow (per-architecture, per-component) and
+uploads the result as an artifact that the image build job downloads back into
+the staging directory before running Buildx.
 
 Runtime layout:
 

--- a/tasks/scripts/container-engine.sh
+++ b/tasks/scripts/container-engine.sh
@@ -168,16 +168,46 @@ ce_build() {
 }
 
 # ---------------------------------------------------------------------------
+# ce_normalize_arch — normalize common architecture names.
+#
+# Keeps container-engine helpers from silently drifting between Docker,
+# Podman, and kernel naming conventions.
+# ---------------------------------------------------------------------------
+ce_normalize_arch() {
+  case "$1" in
+    x86_64|amd64) echo "amd64" ;;
+    aarch64|arm64) echo "arm64" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# ce_host_arch — kernel architecture normalized for Docker platform names.
+# ---------------------------------------------------------------------------
+ce_host_arch() {
+  ce_normalize_arch "$(uname -m)"
+}
+
+# ---------------------------------------------------------------------------
 # ce_info_arch — host architecture reported by the container engine.
 #
 # Docker: docker info --format '{{.Architecture}}'
 # Podman: podman info --format '{{.Host.Arch}}'
+# Falls back to the kernel architecture when the daemon query is unavailable so
+# local builds do not accidentally target amd64 on arm64 hosts.
 # ---------------------------------------------------------------------------
 ce_info_arch() {
+  local arch=""
   if ce_is_docker; then
-    "${_CE_BIN}" info --format '{{.Architecture}}' 2>/dev/null || echo "amd64"
+    arch=$("${_CE_BIN}" info --format '{{.Architecture}}' 2>/dev/null || true)
   else
-    "${_CE_BIN}" info --format '{{.Host.Arch}}' 2>/dev/null || echo "amd64"
+    arch=$("${_CE_BIN}" info --format '{{.Host.Arch}}' 2>/dev/null || true)
+  fi
+
+  if [[ -n "${arch}" ]]; then
+    ce_normalize_arch "${arch}"
+  else
+    ce_host_arch
   fi
 }
 


### PR DESCRIPTION
## Summary

Fall back to the host architecture for local container builds when no explicit platform is configured. This was detected on a clean DGX Spark with Podman installed and Docker not runnable by the current user.

## Related Issue

None.

## Changes

- Added host architecture fallback in local container engine platform detection.
- Updated build documentation for local platform behavior.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated (not applicable)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)