### PR TITLE
feat(e2e): enable mTLS for Podman compute driver

### DIFF
--- a/e2e/rust/e2e-podman.sh
+++ b/e2e/rust/e2e-podman.sh
@@ -4,7 +4,7 @@
 
 # Run the Rust e2e suite against a standalone gateway running the bundled Podman
 # compute driver. Set OPENSHELL_GATEWAY_ENDPOINT=http://host:port to reuse an
-# existing plaintext gateway instead of starting an ephemeral one.
+# existing gateway instead of starting an ephemeral one.
 
 set -euo pipefail
 

--- a/e2e/support/gateway-common.sh
+++ b/e2e/support/gateway-common.sh
@@ -35,48 +35,19 @@ e2e_pick_port() {
 }
 
 e2e_generate_pki() {
-  local pki_dir=$1
-  local host_alias=$2  # e.g. host.docker.internal or host.containers.internal
+  local gateway_bin=$1
+  local pki_dir=$2
+  shift 2
+  # Remaining args are extra --server-san values (e.g. host.containers.internal).
+  # host.docker.internal and localhost are already in the default SAN list.
 
-  mkdir -p "${pki_dir}"
+  local san_args=()
+  san_args+=(--server-san host.openshell.internal)
+  for san in "$@"; do
+    san_args+=(--server-san "${san}")
+  done
 
-  cat > "${pki_dir}/openssl.cnf" <<EOF
-[req]
-distinguished_name = dn
-prompt = no
-[dn]
-CN = openshell-server
-[san_server]
-subjectAltName = @alt_server
-[alt_server]
-DNS.1 = localhost
-DNS.2 = host.openshell.internal
-DNS.3 = ${host_alias}
-IP.1 = 127.0.0.1
-IP.2 = ::1
-[san_client]
-subjectAltName = DNS:openshell-client
-EOF
-
-  openssl req -x509 -newkey rsa:2048 -nodes -days 30 \
-    -keyout "${pki_dir}/ca.key" -out "${pki_dir}/ca.crt" \
-    -subj "/CN=openshell-e2e-ca" >/dev/null 2>&1
-
-  openssl req -newkey rsa:2048 -nodes \
-    -keyout "${pki_dir}/server.key" -out "${pki_dir}/server.csr" \
-    -config "${pki_dir}/openssl.cnf" >/dev/null 2>&1
-  openssl x509 -req -in "${pki_dir}/server.csr" \
-    -CA "${pki_dir}/ca.crt" -CAkey "${pki_dir}/ca.key" -CAcreateserial \
-    -out "${pki_dir}/server.crt" -days 30 \
-    -extfile "${pki_dir}/openssl.cnf" -extensions san_server >/dev/null 2>&1
-
-  openssl req -newkey rsa:2048 -nodes \
-    -keyout "${pki_dir}/client.key" -out "${pki_dir}/client.csr" \
-    -subj "/CN=openshell-client" >/dev/null 2>&1
-  openssl x509 -req -in "${pki_dir}/client.csr" \
-    -CA "${pki_dir}/ca.crt" -CAkey "${pki_dir}/ca.key" -CAcreateserial \
-    -out "${pki_dir}/client.crt" -days 30 \
-    -extfile "${pki_dir}/openssl.cnf" -extensions san_client >/dev/null 2>&1
+  "${gateway_bin}" generate-certs --output-dir "${pki_dir}" "${san_args[@]}"
 }
 
 e2e_register_plaintext_gateway() {
@@ -108,9 +79,9 @@ e2e_register_mtls_gateway() {
   local gateway_config_dir="${config_home}/openshell/gateways/${name}"
 
   mkdir -p "${gateway_config_dir}/mtls"
-  cp "${pki_dir}/ca.crt"     "${gateway_config_dir}/mtls/ca.crt"
-  cp "${pki_dir}/client.crt" "${gateway_config_dir}/mtls/tls.crt"
-  cp "${pki_dir}/client.key" "${gateway_config_dir}/mtls/tls.key"
+  cp "${pki_dir}/ca.crt"         "${gateway_config_dir}/mtls/ca.crt"
+  cp "${pki_dir}/client/tls.crt" "${gateway_config_dir}/mtls/tls.crt"
+  cp "${pki_dir}/client/tls.key" "${gateway_config_dir}/mtls/tls.key"
   cat >"${gateway_config_dir}/metadata.json" <<EOF
 {
   "name": "${name}",

--- a/e2e/support/gateway-common.sh
+++ b/e2e/support/gateway-common.sh
@@ -34,6 +34,51 @@ e2e_pick_port() {
   python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()'
 }
 
+e2e_generate_pki() {
+  local pki_dir=$1
+  local host_alias=$2  # e.g. host.docker.internal or host.containers.internal
+
+  mkdir -p "${pki_dir}"
+
+  cat > "${pki_dir}/openssl.cnf" <<EOF
+[req]
+distinguished_name = dn
+prompt = no
+[dn]
+CN = openshell-server
+[san_server]
+subjectAltName = @alt_server
+[alt_server]
+DNS.1 = localhost
+DNS.2 = host.openshell.internal
+DNS.3 = ${host_alias}
+IP.1 = 127.0.0.1
+IP.2 = ::1
+[san_client]
+subjectAltName = DNS:openshell-client
+EOF
+
+  openssl req -x509 -newkey rsa:2048 -nodes -days 30 \
+    -keyout "${pki_dir}/ca.key" -out "${pki_dir}/ca.crt" \
+    -subj "/CN=openshell-e2e-ca" >/dev/null 2>&1
+
+  openssl req -newkey rsa:2048 -nodes \
+    -keyout "${pki_dir}/server.key" -out "${pki_dir}/server.csr" \
+    -config "${pki_dir}/openssl.cnf" >/dev/null 2>&1
+  openssl x509 -req -in "${pki_dir}/server.csr" \
+    -CA "${pki_dir}/ca.crt" -CAkey "${pki_dir}/ca.key" -CAcreateserial \
+    -out "${pki_dir}/server.crt" -days 30 \
+    -extfile "${pki_dir}/openssl.cnf" -extensions san_server >/dev/null 2>&1
+
+  openssl req -newkey rsa:2048 -nodes \
+    -keyout "${pki_dir}/client.key" -out "${pki_dir}/client.csr" \
+    -subj "/CN=openshell-client" >/dev/null 2>&1
+  openssl x509 -req -in "${pki_dir}/client.csr" \
+    -CA "${pki_dir}/ca.crt" -CAkey "${pki_dir}/ca.key" -CAcreateserial \
+    -out "${pki_dir}/client.crt" -days 30 \
+    -extfile "${pki_dir}/openssl.cnf" -extensions san_client >/dev/null 2>&1
+}
+
 e2e_register_plaintext_gateway() {
   local config_home=$1
   local name=$2

--- a/e2e/with-docker-gateway.sh
+++ b/e2e/with-docker-gateway.sh
@@ -234,10 +234,6 @@ if ! docker info >/dev/null 2>&1; then
   echo "ERROR: docker daemon is not reachable (docker info failed)" >&2
   exit 2
 fi
-if ! command -v openssl >/dev/null 2>&1; then
-  echo "ERROR: openssl is required to generate ephemeral PKI" >&2
-  exit 2
-fi
 if [ "${GPU_MODE}" = "1" ]; then
   DOCKER_CDI_SPEC_DIRS="$(docker info --format '{{json .CDISpecDirs}}' 2>/dev/null || true)"
   if [ -z "${DOCKER_CDI_SPEC_DIRS}" ] \
@@ -390,7 +386,7 @@ if ! docker image inspect "${SANDBOX_IMAGE}" >/dev/null 2>&1; then
 fi
 
 PKI_DIR="${WORKDIR}/pki"
-e2e_generate_pki "${PKI_DIR}" "host.docker.internal"
+e2e_generate_pki "${GATEWAY_BIN}" "${PKI_DIR}"
 
 HOST_PORT=$(e2e_pick_port)
 STATE_DIR="${WORKDIR}/state"
@@ -439,8 +435,8 @@ GATEWAY_CONFIG="${STATE_DIR}/gateway.toml"
   printf 'default_image = %s\n'        "$(toml_string "${SANDBOX_IMAGE}")"
   printf 'image_pull_policy = "IfNotPresent"\n'
   printf 'guest_tls_ca = %s\n'         "$(toml_string "${PKI_DIR}/ca.crt")"
-  printf 'guest_tls_cert = %s\n'       "$(toml_string "${PKI_DIR}/client.crt")"
-  printf 'guest_tls_key = %s\n'        "$(toml_string "${PKI_DIR}/client.key")"
+  printf 'guest_tls_cert = %s\n'       "$(toml_string "${PKI_DIR}/client/tls.crt")"
+  printf 'guest_tls_key = %s\n'        "$(toml_string "${PKI_DIR}/client/tls.key")"
   # DOCKER_SUPERVISOR_ARGS holds either ("--docker-supervisor-bin" "<path>")
   # or ("--docker-supervisor-image" "<image>"); both map to TOML keys on
   # the docker driver config.
@@ -464,8 +460,8 @@ GATEWAY_ARGS=(
   --bind-address 0.0.0.0
   --port "${HOST_PORT}"
   --drivers docker
-  --tls-cert "${PKI_DIR}/server.crt"
-  --tls-key "${PKI_DIR}/server.key"
+  --tls-cert "${PKI_DIR}/server/tls.crt"
+  --tls-key "${PKI_DIR}/server/tls.key"
   --tls-client-ca "${PKI_DIR}/ca.crt"
   --db-url "sqlite:${STATE_DIR}/gateway.db?mode=rwc"
 )

--- a/e2e/with-docker-gateway.sh
+++ b/e2e/with-docker-gateway.sh
@@ -390,41 +390,7 @@ if ! docker image inspect "${SANDBOX_IMAGE}" >/dev/null 2>&1; then
 fi
 
 PKI_DIR="${WORKDIR}/pki"
-mkdir -p "${PKI_DIR}"
-cd "${PKI_DIR}"
-
-cat > openssl.cnf <<'EOF'
-[req]
-distinguished_name = dn
-prompt = no
-[dn]
-CN = openshell-server
-[san_server]
-subjectAltName = @alt_server
-[alt_server]
-DNS.1 = localhost
-DNS.2 = host.openshell.internal
-DNS.3 = host.docker.internal
-IP.1 = 127.0.0.1
-IP.2 = ::1
-[san_client]
-subjectAltName = DNS:openshell-client
-EOF
-
-openssl req -x509 -newkey rsa:2048 -nodes -days 30 \
-  -keyout ca.key -out ca.crt -subj "/CN=openshell-e2e-ca" >/dev/null 2>&1
-
-openssl req -newkey rsa:2048 -nodes -keyout server.key -out server.csr \
-  -config openssl.cnf >/dev/null 2>&1
-openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
-  -out server.crt -days 30 -extfile openssl.cnf -extensions san_server >/dev/null 2>&1
-
-openssl req -newkey rsa:2048 -nodes -keyout client.key -out client.csr \
-  -subj "/CN=openshell-client" >/dev/null 2>&1
-openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
-  -out client.crt -days 30 -extfile openssl.cnf -extensions san_client >/dev/null 2>&1
-
-cd "${ROOT}"
+e2e_generate_pki "${PKI_DIR}" "host.docker.internal"
 
 HOST_PORT=$(e2e_pick_port)
 STATE_DIR="${WORKDIR}/state"

--- a/e2e/with-podman-gateway.sh
+++ b/e2e/with-podman-gateway.sh
@@ -313,10 +313,6 @@ if ! podman_cmd info >/dev/null 2>&1; then
   echo "       Start it with 'podman machine start' on macOS, or the user service on Linux." >&2
   exit 2
 fi
-if ! command -v openssl >/dev/null 2>&1; then
-  echo "ERROR: openssl is required to generate ephemeral PKI" >&2
-  exit 2
-fi
 ensure_podman_api_socket
 
 e2e_build_gateway_binaries "${ROOT}" TARGET_DIR GATEWAY_BIN CLI_BIN
@@ -333,7 +329,7 @@ if ! podman_cmd image exists "${SANDBOX_IMAGE}" 2>/dev/null; then
 fi
 
 PKI_DIR="${WORKDIR}/pki"
-e2e_generate_pki "${PKI_DIR}" "host.containers.internal"
+e2e_generate_pki "${GATEWAY_BIN}" "${PKI_DIR}" "host.containers.internal"
 
 HOST_PORT=$(e2e_pick_port)
 HEALTH_PORT=$(e2e_pick_port)
@@ -374,8 +370,8 @@ GATEWAY_CONFIG="${STATE_DIR}/gateway.toml"
   printf 'image_pull_policy = "missing"\n'
   printf 'supervisor_image = %s\n' "$(toml_string "${SUPERVISOR_IMAGE}")"
   printf 'guest_tls_ca = %s\n'     "$(toml_string "${PKI_DIR}/ca.crt")"
-  printf 'guest_tls_cert = %s\n'   "$(toml_string "${PKI_DIR}/client.crt")"
-  printf 'guest_tls_key = %s\n'    "$(toml_string "${PKI_DIR}/client.key")"
+  printf 'guest_tls_cert = %s\n'   "$(toml_string "${PKI_DIR}/client/tls.crt")"
+  printf 'guest_tls_key = %s\n'    "$(toml_string "${PKI_DIR}/client/tls.key")"
   # The in-process Podman driver reads `socket_path` from TOML only — the
   # OPENSHELL_PODMAN_SOCKET env var is honoured by the standalone driver
   # binary, not the in-process driver used here. Pin the socket to the one
@@ -392,8 +388,8 @@ GATEWAY_ARGS=(
   --port "${HOST_PORT}"
   --health-port "${HEALTH_PORT}"
   --drivers podman
-  --tls-cert "${PKI_DIR}/server.crt"
-  --tls-key "${PKI_DIR}/server.key"
+  --tls-cert "${PKI_DIR}/server/tls.crt"
+  --tls-key "${PKI_DIR}/server/tls.key"
   --tls-client-ca "${PKI_DIR}/ca.crt"
   --db-url "sqlite:${STATE_DIR}/gateway.db?mode=rwc"
   --log-level info

--- a/e2e/with-podman-gateway.sh
+++ b/e2e/with-podman-gateway.sh
@@ -333,41 +333,7 @@ if ! podman_cmd image exists "${SANDBOX_IMAGE}" 2>/dev/null; then
 fi
 
 PKI_DIR="${WORKDIR}/pki"
-mkdir -p "${PKI_DIR}"
-cd "${PKI_DIR}"
-
-cat > openssl.cnf <<'EOF'
-[req]
-distinguished_name = dn
-prompt = no
-[dn]
-CN = openshell-server
-[san_server]
-subjectAltName = @alt_server
-[alt_server]
-DNS.1 = localhost
-DNS.2 = host.openshell.internal
-DNS.3 = host.containers.internal
-IP.1 = 127.0.0.1
-IP.2 = ::1
-[san_client]
-subjectAltName = DNS:openshell-client
-EOF
-
-openssl req -x509 -newkey rsa:2048 -nodes -days 30 \
-  -keyout ca.key -out ca.crt -subj "/CN=openshell-e2e-ca" >/dev/null 2>&1
-
-openssl req -newkey rsa:2048 -nodes -keyout server.key -out server.csr \
-  -config openssl.cnf >/dev/null 2>&1
-openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
-  -out server.crt -days 30 -extfile openssl.cnf -extensions san_server >/dev/null 2>&1
-
-openssl req -newkey rsa:2048 -nodes -keyout client.key -out client.csr \
-  -subj "/CN=openshell-client" >/dev/null 2>&1
-openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
-  -out client.crt -days 30 -extfile openssl.cnf -extensions san_client >/dev/null 2>&1
-
-cd "${ROOT}"
+e2e_generate_pki "${PKI_DIR}" "host.containers.internal"
 
 HOST_PORT=$(e2e_pick_port)
 HEALTH_PORT=$(e2e_pick_port)

--- a/e2e/with-podman-gateway.sh
+++ b/e2e/with-podman-gateway.sh
@@ -11,8 +11,8 @@
 #   - OPENSHELL_GATEWAY_ENDPOINT=http://host:port:
 #       Use the existing plaintext gateway endpoint and run the command.
 #
-# Podman e2e currently uses plaintext gateway traffic. The Podman driver does
-# not yet inject gateway mTLS client materials into sandbox containers.
+# HTTPS endpoint-only mode is intentionally unsupported here. Use a named
+# gateway config when mTLS materials are needed.
 
 set -euo pipefail
 
@@ -277,12 +277,12 @@ if [ -n "${OPENSHELL_GATEWAY_ENDPOINT:-}" ]; then
   case "${OPENSHELL_GATEWAY_ENDPOINT}" in
     http://*) ;;
     https://*)
-      echo "ERROR: OPENSHELL_GATEWAY_ENDPOINT endpoint mode is HTTP-only for Podman e2e." >&2
-      echo "       Podman e2e does not yet support sandbox mTLS client material injection." >&2
+      echo "ERROR: OPENSHELL_GATEWAY_ENDPOINT endpoint mode is HTTP-only for e2e." >&2
+      echo "       Register a named gateway with mTLS config instead of using a raw HTTPS endpoint." >&2
       exit 2
       ;;
     *)
-      echo "ERROR: OPENSHELL_GATEWAY_ENDPOINT must start with http:// for Podman e2e endpoint mode." >&2
+      echo "ERROR: OPENSHELL_GATEWAY_ENDPOINT must start with http:// for e2e endpoint mode." >&2
       exit 2
       ;;
   esac
@@ -313,6 +313,10 @@ if ! podman_cmd info >/dev/null 2>&1; then
   echo "       Start it with 'podman machine start' on macOS, or the user service on Linux." >&2
   exit 2
 fi
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "ERROR: openssl is required to generate ephemeral PKI" >&2
+  exit 2
+fi
 ensure_podman_api_socket
 
 e2e_build_gateway_binaries "${ROOT}" TARGET_DIR GATEWAY_BIN CLI_BIN
@@ -327,6 +331,43 @@ if ! podman_cmd image exists "${SANDBOX_IMAGE}" 2>/dev/null; then
   echo "Pulling ${SANDBOX_IMAGE}..."
   podman_cmd pull "${SANDBOX_IMAGE}"
 fi
+
+PKI_DIR="${WORKDIR}/pki"
+mkdir -p "${PKI_DIR}"
+cd "${PKI_DIR}"
+
+cat > openssl.cnf <<'EOF'
+[req]
+distinguished_name = dn
+prompt = no
+[dn]
+CN = openshell-server
+[san_server]
+subjectAltName = @alt_server
+[alt_server]
+DNS.1 = localhost
+DNS.2 = host.openshell.internal
+DNS.3 = host.containers.internal
+IP.1 = 127.0.0.1
+IP.2 = ::1
+[san_client]
+subjectAltName = DNS:openshell-client
+EOF
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 30 \
+  -keyout ca.key -out ca.crt -subj "/CN=openshell-e2e-ca" >/dev/null 2>&1
+
+openssl req -newkey rsa:2048 -nodes -keyout server.key -out server.csr \
+  -config openssl.cnf >/dev/null 2>&1
+openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
+  -out server.crt -days 30 -extfile openssl.cnf -extensions san_server >/dev/null 2>&1
+
+openssl req -newkey rsa:2048 -nodes -keyout client.key -out client.csr \
+  -subj "/CN=openshell-client" >/dev/null 2>&1
+openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
+  -out client.crt -days 30 -extfile openssl.cnf -extensions san_client >/dev/null 2>&1
+
+cd "${ROOT}"
 
 HOST_PORT=$(e2e_pick_port)
 HEALTH_PORT=$(e2e_pick_port)
@@ -366,6 +407,9 @@ GATEWAY_CONFIG="${STATE_DIR}/gateway.toml"
   printf 'default_image = %s\n'  "$(toml_string "${SANDBOX_IMAGE}")"
   printf 'image_pull_policy = "missing"\n'
   printf 'supervisor_image = %s\n' "$(toml_string "${SUPERVISOR_IMAGE}")"
+  printf 'guest_tls_ca = %s\n'     "$(toml_string "${PKI_DIR}/ca.crt")"
+  printf 'guest_tls_cert = %s\n'   "$(toml_string "${PKI_DIR}/client.crt")"
+  printf 'guest_tls_key = %s\n'    "$(toml_string "${PKI_DIR}/client.key")"
   # The in-process Podman driver reads `socket_path` from TOML only — the
   # OPENSHELL_PODMAN_SOCKET env var is honoured by the standalone driver
   # binary, not the in-process driver used here. Pin the socket to the one
@@ -382,7 +426,9 @@ GATEWAY_ARGS=(
   --port "${HOST_PORT}"
   --health-port "${HEALTH_PORT}"
   --drivers podman
-  --disable-tls
+  --tls-cert "${PKI_DIR}/server.crt"
+  --tls-key "${PKI_DIR}/server.key"
+  --tls-client-ca "${PKI_DIR}/ca.crt"
   --db-url "sqlite:${STATE_DIR}/gateway.db?mode=rwc"
   --log-level info
 )
@@ -401,12 +447,13 @@ GATEWAY_PID=$!
 printf '%s\n' "${GATEWAY_PID}" >"${GATEWAY_PID_FILE}"
 
 GATEWAY_NAME="openshell-e2e-podman-${HOST_PORT}"
-CLI_GATEWAY_ENDPOINT="http://127.0.0.1:${HOST_PORT}"
-e2e_register_plaintext_gateway \
+CLI_GATEWAY_ENDPOINT="https://127.0.0.1:${HOST_PORT}"
+e2e_register_mtls_gateway \
   "${XDG_CONFIG_HOME}" \
   "${GATEWAY_NAME}" \
   "${CLI_GATEWAY_ENDPOINT}" \
-  "${HOST_PORT}"
+  "${HOST_PORT}" \
+  "${PKI_DIR}"
 
 export OPENSHELL_GATEWAY="${GATEWAY_NAME}"
 export OPENSHELL_PROVISION_TIMEOUT="${OPENSHELL_PROVISION_TIMEOUT:-300}"


### PR DESCRIPTION
## Summary

Enable mTLS in the Podman e2e test harness. The Podman driver already had full mTLS support in its Rust code (cert bind-mounts, env vars, config validation, unit tests) — the gap was entirely in the e2e harness, which explicitly blocked HTTPS and ran plaintext-only gateways. This PR wires up ephemeral PKI generation, TLS gateway flags, and mTLS registration, then extracts the shared PKI logic into `gateway-common.sh` to eliminate duplication with the Docker script.

## Related Issue

Closes #1428

## Changes

- `e2e/with-podman-gateway.sh`: Add openssl preflight, generate ephemeral PKI with `host.containers.internal` SAN, add `guest_tls_*` to TOML config, replace `--disable-tls` with `--tls-cert/--tls-key/--tls-client-ca`, switch to `https://` and `e2e_register_mtls_gateway`, update error messages to match Docker wording
- `e2e/support/gateway-common.sh`: Extract `e2e_generate_pki(pki_dir, host_alias)` shared helper — parameterizes the host-gateway SAN and uses absolute paths (eliminates the `cd`/`cd` pattern)
- `e2e/with-docker-gateway.sh`: Replace inline PKI generation with `e2e_generate_pki` call
- `e2e/rust/e2e-podman.sh`: Remove "plaintext" from comment

## Testing

- [x] `mise run pre-commit` passes (pre-existing markdown lint failure in unrelated gitignored file)
- [x] `mise run test:rust` — all unit tests pass
- [x] `mise run e2e:podman` — all 57 e2e tests pass over mTLS (run twice: once after initial implementation, once after PKI extraction refactor)
- [ ] `mise run e2e:docker` — not run locally (Docker script change is a pure refactor extracting existing code into a shared function; no behavioral change)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)