### PR TITLE
feat(sandbox): inject DENO_CERT into sandbox child environment

### DIFF
--- a/crates/openshell-sandbox/src/child_env.rs
+++ b/crates/openshell-sandbox/src/child_env.rs
@@ -24,11 +24,12 @@ pub fn proxy_env_vars(proxy_url: &str) -> [(&'static str, String); 9] {
 pub fn tls_env_vars(
     ca_cert_path: &Path,
     combined_bundle_path: &Path,
-) -> [(&'static str, String); 5] {
+) -> [(&'static str, String); 6] {
     let ca_cert_path = ca_cert_path.display().to_string();
     let combined_bundle_path = combined_bundle_path.display().to_string();
     [
-        ("NODE_EXTRA_CA_CERTS", ca_cert_path),
+        ("NODE_EXTRA_CA_CERTS", ca_cert_path.clone()),
+        ("DENO_CERT", ca_cert_path),
         ("SSL_CERT_FILE", combined_bundle_path.clone()),
         ("REQUESTS_CA_BUNDLE", combined_bundle_path.clone()),
         ("CURL_CA_BUNDLE", combined_bundle_path.clone()),
@@ -81,6 +82,7 @@ mod tests {
         let stdout = String::from_utf8(output.stdout).expect("utf8");
 
         assert!(stdout.contains("NODE_EXTRA_CA_CERTS=/etc/openshell-tls/openshell-ca.pem"));
+        assert!(stdout.contains("DENO_CERT=/etc/openshell-tls/openshell-ca.pem"));
         assert!(stdout.contains("SSL_CERT_FILE=/etc/openshell-tls/ca-bundle.pem"));
         assert!(stdout.contains("REQUESTS_CA_BUNDLE=/etc/openshell-tls/ca-bundle.pem"));
         assert!(stdout.contains("CURL_CA_BUNDLE=/etc/openshell-tls/ca-bundle.pem"));

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -120,7 +120,7 @@ This enables credential injection and L7 inspection without explicit configurati
 
 | Aspect | Detail |
 |---|---|
-| Default | Auto-detect and terminate. OpenShell generates the sandbox CA at startup and injects it into the process trust stores (`NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`). |
+| Default | Auto-detect and terminate. OpenShell generates the sandbox CA at startup and injects it into the process trust stores (`NODE_EXTRA_CA_CERTS`, `DENO_CERT`, `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`). |
 | What you can change | Set `tls: skip` on an endpoint to disable TLS detection and termination for that endpoint. Use this for client-certificate mTLS to upstream or non-standard binary protocols. |
 | Risk if relaxed | `tls: skip` disables credential injection and L7 inspection for that endpoint. The proxy relays encrypted traffic without seeing the contents. |
 | Recommendation | Use auto-detect (the default) for most endpoints. Use `tls: skip` only when the upstream requires the client's own TLS certificate (mTLS) or uses a non-HTTP protocol. |


### PR DESCRIPTION
## Summary

Inject `DENO_CERT` into the sandbox child environment alongside the existing trust-store env vars so Deno-based agents can TLS-verify connections to services signed by OpenShell's per-sandbox ephemeral CA.

## Related Issue

Tracks: [brevdev/dex-ui#5](https://github.com/brevdev/dex-ui/issues/5) (dex-ui-side tracking ticket; the fix belongs here)

## Changes

- `crates/openshell-sandbox/src/child_env.rs::tls_env_vars` — add `("DENO_CERT", ca_cert_path)` to the array, bumping its length from 5 to 6.
  - Points `DENO_CERT` at the **standalone OpenShell CA cert path**, not the combined system+sandbox bundle. Per Deno's [docs](https://docs.deno.com/runtime/reference/cli/#environment-variables), `DENO_CERT` is **additive** (merged with the system trust roots), same shape as `NODE_EXTRA_CA_CERTS` — the combined-bundle path would double-count system CAs.
- `docs/security/best-practices.mdx` — list `DENO_CERT` in the auto-detect TLS row.
- Test assertion updated.

The three callers in `process.rs` and `ssh.rs` iterate the array, so the size bump is type-only — no caller changes needed.

## Testing

- [x] `cargo test -p openshell-sandbox --lib child_env` — 3/3 green, including the updated `apply_tls_env_sets_node_and_bundle_paths` assertion.
- [x] `cargo fmt --check -p openshell-sandbox` clean.
- [x] `cargo clippy -p openshell-sandbox --lib --tests -- -D warnings` clean.
- [ ] `mise run pre-commit` — failed locally on an unrelated `z3.h` missing system dep for a different crate (Z3 SMT solver bindings); the workspace-wide pre-commit needs Z3 installed on the host. CI should pick it up.

## Checklist

- [x] Follows Conventional Commits
- [x] Commit signed off (DCO)
- [ ] Architecture docs updated *(no `architecture/` page enumerates these env vars; the user-facing list lives in `docs/security/best-practices.mdx`, which is updated)*