### PR TITLE
test(e2e): default GPU probe image

### DIFF
--- a/e2e/rust/tests/gpu_device_selection.rs
+++ b/e2e/rust/tests/gpu_device_selection.rs
@@ -21,6 +21,7 @@ const SANDBOX_CREATE_TIMEOUT: Duration = Duration::from_secs(600);
 const CDI_GPU_DEVICE_ALL: &str = "nvidia.com/gpu=all";
 const CDI_GPU_DEVICE_PREFIX: &str = "nvidia.com/gpu=";
 const GPU_PROBE_IMAGE_ENV: &str = "OPENSHELL_E2E_GPU_PROBE_IMAGE";
+const DEFAULT_GPU_PROBE_IMAGE: &str = "nvcr.io/nvidia/base/ubuntu:noble-20251013";
 
 fn gpu_lines(output: &str) -> Vec<String> {
     strip_ansi(output)
@@ -36,13 +37,7 @@ fn gpu_probe_image() -> String {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| {
-            panic!(
-                "{GPU_PROBE_IMAGE_ENV} must be set to a container image that supports \
-                 NVIDIA Container Toolkit CDI injection (set by \
-                 .github/workflows/e2e-gpu-test.yaml in CI)"
-            )
-        })
+        .unwrap_or_else(|| DEFAULT_GPU_PROBE_IMAGE.to_string())
 }
 
 fn object_string<'a>(object: &'a Map<String, Value>, key: &str) -> Option<&'a str> {


### PR DESCRIPTION
## Summary

Default the GPU e2e probe image to the same NVIDIA base image used by CI. This keeps local `mise run e2e:docker:gpu` aligned with CI while preserving `OPENSHELL_E2E_GPU_PROBE_IMAGE` as an override.

## Related Issue

None.

## Changes

- Added `nvcr.io/nvidia/base/ubuntu:noble-20251013` as the default GPU probe image.
- Removed the panic that required `OPENSHELL_E2E_GPU_PROBE_IMAGE` to be set for local GPU e2e runs.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated (not applicable; E2E-only change)
- [x] E2E tests added/updated (if applicable)

Ran on `e2e-default-gpu-probe-image` after rebasing onto latest `main`:

- `mise run e2e:docker:gpu` — 7 passed, 0 failed
- `mise run pre-commit` — passed

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
