### PR TITLE
feat(agents): add LSM compatibility checks to review and spike skills

### DIFF
--- a/.agents/skills/build-from-issue/SKILL.md
+++ b/.agents/skills/build-from-issue/SKILL.md
@@ -148,6 +148,7 @@ In the prompt, instruct the reviewer to:
    - **Medium**: Multiple files/components, some design decisions, but well-scoped
    - **High**: Cross-cutting changes, architectural decisions needed, significant unknowns
 8. Call out risks, unknowns, and decisions that need stakeholder input.
+9. Assess **LSM compatibility** — if the change touches process identity, `/proc` filesystem access, binary execution, or inter-process visibility, flag whether it will behave differently on hosts running SELinux (enforcing) or AppArmor. In particular, tests that fork+exec into system binaries will fail on SELinux-enforcing hosts due to cross-label `/proc/<pid>/exe` access restrictions.
 
 ### A2: Post the Plan Comment
 

--- a/.agents/skills/create-spike/SKILL.md
+++ b/.agents/skills/create-spike/SKILL.md
@@ -91,7 +91,9 @@ The prompt to the reviewer **must** instruct it to:
 
 9. **Check architecture docs** in the `architecture/` directory for relevant documentation about the affected subsystems.
 
-10. **Determine the issue type:** `feat`, `fix`, `refactor`, `chore`, `perf`, or `docs`.
+10. **Assess Linux Security Module (LSM) impact.** If the change involves process identity, `/proc` filesystem access, file labeling, binary execution, or inter-process visibility, call out whether it will behave differently on hosts running SELinux (enforcing) or AppArmor. For example: reading `/proc/<pid>/exe` across an SELinux domain boundary returns ENOENT, not EACCES. Tests that fork+exec into system binaries (different SELinux label) will fail on enforcing hosts. Flag any LSM-sensitive code paths and recommend mitigations.
+
+11. **Determine the issue type:** `feat`, `fix`, `refactor`, `chore`, `perf`, or `docs`.
 
 ### What makes a good investigation prompt
 

--- a/.claude/agents/principal-engineer-reviewer.md
+++ b/.claude/agents/principal-engineer-reviewer.md
@@ -146,6 +146,36 @@ applies to every PR — use judgment.
 - **Supply chain:** Do new dependencies introduce known vulnerabilities or
   unmaintained transitive dependencies?
 
+### Linux Security Module (LSM) compatibility
+
+OpenShell runs on hosts with SELinux or AppArmor in enforcing mode.
+Review changes that interact with the `/proc` filesystem, process
+identity, binary execution, or inter-process visibility for
+LSM-related issues:
+
+- **`/proc/<pid>/exe` across domain boundaries:** On SELinux-enforcing
+  hosts, readlink on `/proc/<pid>/exe` returns ENOENT (not EACCES) when
+  the target process has a different SELinux label than the caller.
+  This affects any code that resolves binary identity after fork+exec
+  into a differently-labeled binary (e.g., system binaries under
+  `bin_t` vs. build artifacts under `user_home_t`).
+
+- **Tests that fork+exec into system binaries:** Tests that fork a child
+  and exec into `/bin/sleep`, `/usr/bin/cat`, or similar will fail on
+  SELinux-enforcing hosts because the child transitions to a different
+  domain, making its `/proc` entries unreadable to the parent. Flag
+  these tests and recommend either using a same-label helper binary or
+  skipping on enforcing hosts with a TODO.
+
+- **File labeling and Landlock interaction:** New files created in
+  non-standard paths may inherit unexpected SELinux labels. Verify that
+  Landlock and SELinux policies do not conflict.
+
+- **Socket and IPC visibility:** SELinux can restrict `/proc/<pid>/fd`
+  and `/proc/<pid>/net` visibility across domain boundaries. Code that
+  scans these paths for socket ownership should handle access failures
+  gracefully.
+
 ## Principles
 
 - Don't nitpick style unless it harms readability. Trust `rustfmt` and the


### PR DESCRIPTION
## Summary
Teach the principal-engineer-reviewer agent, build-from-issue skill, and create-spike skill to assess Linux Security Module impact.  Code that touches /proc filesystem access, process identity, or binary execution can behave differently on SELinux-enforcing or AppArmor hosts — for example, readlink on /proc/<pid>/exe returns ENOENT across SELinux domain boundaries, breaking tests that fork+exec into system binaries.

## Related Issue

## Changes

## Testing
<!-- What testing was done? -->
- [x ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [ x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
