### PR TITLE
fix(build): install binaries built in part build tree

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -77,11 +77,11 @@ parts:
       cargo build --release --locked -p openshell-server --bin openshell-gateway
       cargo build --release --locked -p openshell-sandbox --bin openshell-sandbox
 
-      install -D -m 0755 "$CRAFT_PROJECT_DIR/target/release/openshell" \
+      install -D -m 0755 "$CRAFT_PART_BUILD/target/release/openshell" \
         "$CRAFT_PART_INSTALL/bin/openshell"
-      install -D -m 0755 "$CRAFT_PROJECT_DIR/target/release/openshell-gateway" \
+      install -D -m 0755 "$CRAFT_PART_BUILD/target/release/openshell-gateway" \
         "$CRAFT_PART_INSTALL/bin/openshell-gateway"
-      install -D -m 0755 "$CRAFT_PROJECT_DIR/target/release/openshell-sandbox" \
+      install -D -m 0755 "$CRAFT_PART_BUILD/target/release/openshell-sandbox" \
         "$CRAFT_PART_INSTALL/bin/openshell-sandbox"
       install -D -m 0755 "$CRAFT_PROJECT_DIR/deploy/snap/bin/openshell-gateway-wrapper" \
         "$CRAFT_PART_INSTALL/bin/openshell-gateway-wrapper"


### PR DESCRIPTION
## Summary
Fixes the snap build from a pristine tree

## Related Issue
N/A

## Changes
The snapcraft built recipe now installs binaries that were built in the part instead of those that came with the workspace tree on the host. 

## Testing
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
