### PR TITLE
test(persistence): make CAS conflict test deterministic

### DIFF
--- a/crates/openshell-server/src/persistence/tests.rs
+++ b/crates/openshell-server/src/persistence/tests.rs
@@ -1341,7 +1341,6 @@ async fn cas_update_message_cas_succeeds() {
 async fn cas_update_message_cas_conflicts_on_concurrent_updates() {
     use openshell_core::proto::Sandbox;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicU32, Ordering};
 
     let store = Arc::new(
         Store::connect("sqlite::memory:?cache=shared")
@@ -1366,26 +1365,18 @@ async fn cas_update_message_cas_conflicts_on_concurrent_updates() {
 
     store.put_message(&sandbox).await.unwrap();
 
-    // Track how many updates succeed
-    let success_count = Arc::new(AtomicU32::new(0));
-
     // Spawn 5 concurrent CAS updates using the same observed version. Passing an
     // explicit version makes this deterministic: later tasks cannot re-read the
     // latest committed version and legitimately succeed.
     let mut handles = vec![];
     for i in 0..5 {
         let store = Arc::clone(&store);
-        let success_count = Arc::clone(&success_count);
         let handle = tokio::spawn(async move {
-            let result = store
+            store
                 .update_message_cas::<Sandbox, _>("test-id", 1, |s| {
                     s.current_policy_version = i;
                 })
-                .await;
-            if result.is_ok() {
-                success_count.fetch_add(1, Ordering::SeqCst);
-            }
-            result
+                .await
         });
         handles.push(handle);
     }
@@ -1396,7 +1387,7 @@ async fn cas_update_message_cas_conflicts_on_concurrent_updates() {
         .map(|r| r.unwrap())
         .collect();
 
-    // Only one should succeed; others fail with Conflict due to single-attempt CAS
+    // Only one should succeed; others fail with Conflict due to single-attempt CAS.
     let successes = results.iter().filter(|r| r.is_ok()).count();
     let conflicts = results
         .iter()
@@ -1404,7 +1395,6 @@ async fn cas_update_message_cas_conflicts_on_concurrent_updates() {
         .count();
     assert_eq!(successes, 1, "exactly one concurrent update should succeed");
     assert_eq!(conflicts, 4, "four updates should fail with Conflict");
-    assert_eq!(success_count.load(Ordering::SeqCst), 1);
 
     // Final version should be 2 (initial 1 + 1 successful update)
     let final_sandbox = store

--- a/crates/openshell-server/src/persistence/tests.rs
+++ b/crates/openshell-server/src/persistence/tests.rs
@@ -1369,14 +1369,16 @@ async fn cas_update_message_cas_conflicts_on_concurrent_updates() {
     // Track how many updates succeed
     let success_count = Arc::new(AtomicU32::new(0));
 
-    // Spawn 5 concurrent CAS updates (using expected_version = 0 to use current)
+    // Spawn 5 concurrent CAS updates using the same observed version. Passing an
+    // explicit version makes this deterministic: later tasks cannot re-read the
+    // latest committed version and legitimately succeed.
     let mut handles = vec![];
     for i in 0..5 {
         let store = Arc::clone(&store);
         let success_count = Arc::clone(&success_count);
         let handle = tokio::spawn(async move {
             let result = store
-                .update_message_cas::<Sandbox, _>("test-id", 0, |s| {
+                .update_message_cas::<Sandbox, _>("test-id", 1, |s| {
                     s.current_policy_version = i;
                 })
                 .await;


### PR DESCRIPTION
## Summary

Make the flaky `cas_update_message_cas_conflicts_on_concurrent_updates` test assert the intended stale-version CAS behavior deterministically.

The test was failing because it passed `expected_version = 0`, which has special sentinel behavior in `update_message_cas`: each caller first reads the current resource version and then attempts a single CAS write against that version. Under concurrent scheduling, a second task can start after the first update commits, read the new version, and legitimately succeed. That produced failures like `left: 2, right: 1` even though CAS itself was working correctly.

The right fix is to have every spawned task use the same observed initial resource version (`1`). That makes the test exercise the actual invariant it claims to verify: when multiple writers race with the same expected resource version, exactly one write should win and the rest should return `PersistenceError::Conflict`.

Example of failure: https://github.com/NVIDIA/OpenShell/actions/runs/26104406128/job/76764142461?pr=1436#step:10:2991

## Related Issue

None.

## Changes

- Change the concurrent message CAS test from sentinel `expected_version = 0` to explicit `expected_version = 1`.
- Update the test comment to document why the explicit version is required for deterministic conflict testing.
- Remove the `success_count` atomic counter because it duplicated the success count already derived from the joined task results.

## Testing

- [x] `cargo test -p openshell-server persistence::tests::cas_update_message_cas_conflicts_on_concurrent_updates` passes
- [x] Targeted CAS test passed 20 repeated runs
- [x] `cargo fmt --check` passes
- [x] `mise run pre-commit` passes

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)