### PR TITLE
test(snap): add spread integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,5 +219,8 @@ rfc.md
 *.snap
 *.comp
 
+# Spread reuse files
+.spread-reuse.*.yaml
+
 # Markdown/mermaid lint tooling deps
 scripts/lint-mermaid/node_modules/

--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+default_sandbox_image=ghcr.io/nvidia/openshell-community/sandboxes/base:latest
+
+define UBUNTU_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- snap wait system seed.loaded
+- snap install docker
+- snap run docker pull $(default_sandbox_image)
+endef
+
+define DEBIAN_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- systemctl enable --now snapd.socket snapd.service snapd.apparmor.service
+- snap wait system seed.loaded
+- snap install docker
+- snap run docker pull $(default_sandbox_image)
+packages:
+- snapd
+endef
+
+define FEDORA_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- dnf install -y snapd
+- systemctl enable --now snapd.socket
+- snap wait system seed.loaded
+- sudo ln -s /var/lib/snapd/snap /snap
+- snap install docker
+- snap run docker pull $(default_sandbox_image)
+endef
+
+define CENTOS_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- yum install -y epel-release
+- yum install -y snapd
+- systemctl enable --now snapd.socket snapd.service
+- snap wait system seed.loaded
+- sudo ln -s /var/lib/snapd/snap /snap
+- snap install docker
+- snap run docker pull $(default_sandbox_image)
+endef

--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -3,19 +3,24 @@
 
 default_sandbox_image=ghcr.io/nvidia/openshell-community/sandboxes/base:latest
 
+define install_and_setup_docker
+- addgroup --system docker
+- snap install docker
+- while [ ! -S /run/docker.sock ]; do sleep 3; done
+- "snap run docker pull $(default_sandbox_image)"
+endef
+
 define UBUNTU_CLOUD_INIT_USER_DATA_TEMPLATE
 $(CLOUD_INIT_USER_DATA_TEMPLATE)
 - snap wait system seed.loaded
-- snap install docker
-- snap run docker pull $(default_sandbox_image)
+$(install_and_setup_docker)
 endef
 
 define DEBIAN_CLOUD_INIT_USER_DATA_TEMPLATE
 $(CLOUD_INIT_USER_DATA_TEMPLATE)
 - systemctl enable --now snapd.socket snapd.service snapd.apparmor.service
 - snap wait system seed.loaded
-- snap install docker
-- snap run docker pull $(default_sandbox_image)
+$(install_and_setup_docker)
 packages:
 - snapd
 endef
@@ -26,8 +31,7 @@ $(CLOUD_INIT_USER_DATA_TEMPLATE)
 - systemctl enable --now snapd.socket
 - snap wait system seed.loaded
 - sudo ln -s /var/lib/snapd/snap /snap
-- snap install docker
-- snap run docker pull $(default_sandbox_image)
+$(install_and_setup_docker)
 endef
 
 define CENTOS_CLOUD_INIT_USER_DATA_TEMPLATE
@@ -37,6 +41,5 @@ $(CLOUD_INIT_USER_DATA_TEMPLATE)
 - systemctl enable --now snapd.socket snapd.service
 - snap wait system seed.loaded
 - sudo ln -s /var/lib/snapd/snap /snap
-- snap install docker
-- snap run docker pull $(default_sandbox_image)
+$(install_and_setup_docker)
 endef

--- a/.image-garden/.gitignore
+++ b/.image-garden/.gitignore
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+*.img
+*.iso
+*.lock
+*.log
+*.meta-data
+*.qcow2
+*.run
+*.user-data

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+project: openshell
+
+backends:
+    garden:
+        type: adhoc
+        allocate: |
+            if [ -n "${SPREAD_HOST_PATH-}" ]; then
+                PATH="${SPREAD_HOST_PATH}"
+            fi
+            exec image-garden allocate --spread "$SPREAD_SYSTEM"."$(uname -m)"
+        discard: |
+            if [ -n "${SPREAD_HOST_PATH-}" ]; then
+                PATH="${SPREAD_HOST_PATH}"
+            fi
+            image-garden discard "$SPREAD_SYSTEM_ADDRESS"
+        systems:
+            - ubuntu-cloud-24.04:
+                  username: ubuntu
+                  password: ubuntu
+            - ubuntu-cloud-26.04:
+                  username: ubuntu
+                  password: ubuntu
+            - debian-cloud-13:
+                  username: debian
+                  password: debian
+            - fedora-cloud-44:
+                  username: fedora
+                  password: fedora
+            - centos-cloud-10:
+                  username: centos
+                  password: centos
+
+exclude:
+    - ".cache/*"
+    - ".image-garden/*"
+    - "target/*"
+
+path: /root/openshell
+
+prepare: |
+    # Install the openshell snap that was copied into the test environment.
+    snap install $(ls ./openshell_*.snap | sort -r | head -n 1) --dangerous
+
+    # Connect snap interfaces. When installing from the store this
+    # is auto-connected by the snap declaration assertion, but locally
+    # we need to do it manually.
+    snap connect openshell:docker docker:docker-daemon
+    snap connect openshell:log-observe
+    snap connect openshell:system-observe
+    snap connect openshell:ssh-keys
+
+    # Add the local gateway to user configuration.
+    openshell gateway add http://127.0.0.1:17670 --local --name snap-docker
+    openshell gateway select snap-docker
+    openshell status
+
+debug-each: |
+    echo "Kernel and architecture:"
+    uname -a
+
+    echo "OS release info:"
+    cat /etc/os-release
+
+    echo "Installed snaps:"
+    snap list
+
+    set +e
+
+    echo "Snap connections of the openshell snap:"
+    snap connections openshell
+
+    echo "Openshell version:"
+    snap run openshell --version
+
+suites:
+    tests/:
+        summary: Smoke tests for OpenShell snap

--- a/spread.yaml
+++ b/spread.yaml
@@ -29,9 +29,6 @@ backends:
             - fedora-cloud-44:
                   username: fedora
                   password: fedora
-            - centos-cloud-10:
-                  username: centos
-                  password: centos
 
 exclude:
     - ".cache/*"

--- a/tests/smoke/task.yaml
+++ b/tests/smoke/task.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+summary: Smoke test for creating a sandbox
+details: |
+    This test verifies that the openshell snap is properly installed
+    and that the openshell command is available and functional.
+    A test sandbox is created on the selected gateway. A hello world program is
+    then invoked in the sandbox.
+
+prepare: |
+    snap run openshell sandbox list | MATCH "No sandboxes found."
+
+execute: |
+    snap run openshell sandbox create -- echo "Hello, OpenShell!" | MATCH "Hello, OpenShell!"
+    snap run openshell sandbox list | MATCH ".*Ready"
+
+restore: |
+    snap run openshell sandbox delete --all | MATCH ".*Deleted.*"
+    snap run openshell sandbox list | MATCH "No sandboxes found."


### PR DESCRIPTION
## Summary
Add `spread` smoke test suite for the snap package.

## Related Issue
N/A

## Changes
- Add spread.yaml using image-garded ad-hoc backend (using qemu internally)
- Add .image-garden.mk with one-time init logic for each system image
- Add spread tests/ directory with one smoke test that creates a sandbox

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)

Please let me know if I should update architecture docs. The next step after this is to wire this all to GitHub to gate snap publishing on the smoke test passing.