### PR TITLE
fix(server): add ConnectSupervisor and RelayStream to SANDBOX_METHODS

### DIFF
--- a/crates/openshell-server/src/auth/oidc.rs
+++ b/crates/openshell-server/src/auth/oidc.rs
@@ -51,6 +51,8 @@ const SANDBOX_METHODS: &[&str] = &[
     "/openshell.v1.OpenShell/SubmitPolicyAnalysis",
     "/openshell.sandbox.v1.SandboxService/GetSandboxConfig",
     "/openshell.inference.v1.Inference/GetInferenceBundle",
+    "/openshell.v1.OpenShell/ConnectSupervisor",
+    "/openshell.v1.OpenShell/RelayStream",
 ];
 
 /// Methods that accept either an OIDC Bearer token (CLI users, full scope)
@@ -469,6 +471,10 @@ mod tests {
         assert!(is_sandbox_method(
             "/openshell.inference.v1.Inference/GetInferenceBundle"
         ));
+        assert!(is_sandbox_method(
+            "/openshell.v1.OpenShell/ConnectSupervisor"
+        ));
+        assert!(is_sandbox_method("/openshell.v1.OpenShell/RelayStream"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add `ConnectSupervisor` and `RelayStream` to the `SANDBOX_METHODS` exemption list so the supervisor relay works when OIDC is enabled without mTLS.

When the gateway is configured with OIDC authentication and TLS disabled (`disable_tls = true`), the supervisor's `ConnectSupervisor` and `RelayStream` gRPC calls are rejected because they require an OIDC Bearer token that the supervisor does not (by design) carry. This causes `sandbox connect` to fail with `supervisor session not connected`.

The supervisor authenticates via mTLS in TLS-enabled deployments (line 339 in `multiplex.rs` bypasses all OIDC checks). In OIDC-only deployments, the existing `SANDBOX_METHODS` list exempts other supervisor RPCs (`PushSandboxLogs`, `GetSandboxProviderEnvironment`, etc.) but was missing these two relay RPCs.

## Related Issue

Fixes #1470

## Changes

- Added `/openshell.v1.OpenShell/ConnectSupervisor` to `SANDBOX_METHODS` in `crates/openshell-server/src/auth/oidc.rs`
- Added `/openshell.v1.OpenShell/RelayStream` to `SANDBOX_METHODS`
- Added test assertions for both RPCs in `sandbox_rpcs_are_sandbox_methods`

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo test -p openshell-server -- sandbox_rpcs` passes (1 test, including new assertions)
- [x] `cargo test -p openshell-server` passes (all 10 tests: 6 unit + 4 integration)
- [x] `cargo clippy -p openshell-server --no-deps` clean
- [x] Verified on OpenShift cluster: gateway 0.0.44, Helm chart 0.0.44, Keycloak OIDC, LoadBalancer service. Without fix: supervisor connects repeatedly, SSH relay times out. With OIDC removed (workaround): sandbox connect works end-to-end.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable, no architectural change)