### PR TITLE
fix(server): respect OPENSHELL_PODMAN_SOCKET env var in embedded driver

### DIFF
--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -46,6 +46,7 @@ use openshell_core::{ComputeDriverKind, Config, Error, Result};
 use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::net::{TcpListener, TcpStream};
@@ -628,6 +629,9 @@ async fn build_compute_runtime(
         ComputeDriverKind::Podman => {
             let mut podman = podman_config_from_file(file)?;
             podman.gateway_port = config.bind_address.port();
+            if let Ok(p) = std::env::var("OPENSHELL_PODMAN_SOCKET") {
+                podman.socket_path = PathBuf::from(p);
+            }
             apply_podman_local_tls_defaults(config, &mut podman)?;
 
             ComputeRuntime::new_podman(


### PR DESCRIPTION
## Summary

When the Podman driver runs embedded in the gateway (the common deployment path), `OPENSHELL_PODMAN_SOCKET` was ignored. The env var was only wired up via clap in the standalone `openshell-driver-podman` binary. This applies it as a post-deserialization override in the gateway, matching the existing `OPENSHELL_K8S_WORKSPACE_DEFAULT_STORAGE_SIZE` pattern.

## Related Issue

Closes #1446

## Changes

- Apply `OPENSHELL_PODMAN_SOCKET` env var override after TOML config deserialization in `build_compute_runtime()`, consistent with how `OPENSHELL_K8S_WORKSPACE_DEFAULT_STORAGE_SIZE` is handled for the Kubernetes driver

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo test -p openshell-server` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)