### PR TITLE
fix(scripts): use portable lowercase in normalize_bool for Bash 3.2

### DIFF
--- a/tasks/scripts/gateway-vm.sh
+++ b/tasks/scripts/gateway-vm.sh
@@ -58,7 +58,9 @@ normalize_arch() {
 }
 
 normalize_bool() {
-  case "${1,,}" in
+  local val
+  val="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "${val}" in
     1|true|yes|on) echo "true" ;;
     0|false|no|off) echo "false" ;;
     *)

--- a/tasks/scripts/package-snap.sh
+++ b/tasks/scripts/package-snap.sh
@@ -59,7 +59,9 @@ infer_snap_arch() {
 }
 
 normalize_bool() {
-	case "${1,,}" in
+	local val
+	val="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+	case "${val}" in
 	1 | true | yes | on) echo "1" ;;
 	0 | false | no | off) echo "0" ;;
 	*)


### PR DESCRIPTION
## Summary
- Fix `normalize_bool()` in `gateway-vm.sh` and `package-snap.sh` to use portable lowercase via `printf`/`tr` instead of Bash 4+ `${1,,}` syntax
- macOS ships Bash 3.2 which does not support `${1,,}`, causing `mise run gateway:vm` to fail immediately with `bad substitution`
- Matches the existing portable pattern already used in `gateway.sh`

## Related Issue
fixes https://github.com/NVIDIA/OpenShell/issues/1485

## Changes
- `tasks/scripts/gateway-vm.sh`: Replace `case "${1,,}"` with a local variable lowered via `tr '[:upper:]' '[:lower:]'`
- `tasks/scripts/package-snap.sh`: Same fix

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
