### PR TITLE
ci: add snap build and publish pipeline

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -7,6 +7,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: read
   contents: read
 
 defaults:
@@ -70,6 +71,44 @@ jobs:
       - name: Install and check status
         run: |
           curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/${{ github.event.workflow_run.head_sha || github.sha }}/install.sh | sh
+          openshell status
+
+  ubuntu-snap:
+    name: Ubuntu Snap
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Install snapd
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y snapd
+          sudo systemctl start snapd
+
+      - name: Install Docker snap
+        run: |
+          sudo snap install docker
+
+      - name: Download snap from release-dev artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: snap-linux-amd64
+          path: release/
+
+      - name: Install snap (dangerous — from release, not store)
+        run: |
+          sudo snap install ./release/*.snap --dangerous
+
+      - name: Connect interfaces
+        run: |
+          sudo snap connect openshell:docker docker:docker-daemon
+          sudo snap connect openshell:log-observe
+          sudo snap connect openshell:system-observe
+          sudo snap connect openshell:ssh-keys
+
+      - name: Check status
+        run: |
           openshell status
 
   kubernetes:

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -647,6 +647,17 @@ jobs:
       checkout-ref: ${{ github.sha }}
     secrets: inherit
 
+  build-snap:
+    name: Build Snap
+    needs: [compute-versions]
+    uses: ./.github/workflows/snap-package.yml
+    with:
+      checkout-ref: ${{ github.sha }}
+      upload-channel: latest/edge
+      github-environment: latest/edge
+    secrets:
+      publish-credentials: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+
   build-rpm:
     name: Build RPM Packages
     needs: [compute-versions, build-cli-linux, build-gateway-binary-linux]
@@ -697,7 +708,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release-dev:
     name: Release Dev
-    needs: [compute-versions, build-cli-linux, build-cli-macos, build-gateway-binary-linux, build-gateway-binary-macos, build-supervisor-binary-linux, build-python-wheels-linux, build-python-wheel-macos, build-driver-vm-linux, build-driver-vm-macos, build-deb, build-rpm, smoke-linux-dev-artifacts]
+    needs: [compute-versions, build-cli-linux, build-cli-macos, build-gateway-binary-linux, build-gateway-binary-macos, build-supervisor-binary-linux, build-python-wheels-linux, build-python-wheel-macos, build-driver-vm-linux, build-driver-vm-macos, build-deb, build-rpm, build-snap, smoke-linux-dev-artifacts]
     runs-on: linux-amd64-cpu8
     timeout-minutes: 10
     permissions:
@@ -756,6 +767,13 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: rpm-linux-*
+          path: release/
+          merge-multiple: true
+
+      - name: Download snap artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: snap-linux-*
           path: release/
           merge-multiple: true
 
@@ -914,6 +932,7 @@ jobs:
             release/openshell-dev-amd64.deb
             release/openshell-dev-arm64.deb
             release/openshell-*.rpm
+            release/*.snap
             release/openshell-gateway-x86_64-unknown-linux-gnu.tar.gz
             release/openshell-gateway-aarch64-unknown-linux-gnu.tar.gz
             release/openshell-gateway-aarch64-apple-darwin.tar.gz

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -683,6 +683,17 @@ jobs:
       checkout-ref: ${{ inputs.tag || github.ref }}
     secrets: inherit
 
+  build-snap:
+    name: Build Snap
+    needs: [compute-versions]
+    uses: ./.github/workflows/snap-package.yml
+    with:
+      checkout-ref: ${{ inputs.tag || github.ref }}
+      upload-channel: latest/stable
+      github-environment: latest/stable
+    secrets:
+      publish-credentials: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+
   build-rpm:
     name: Build RPM Packages
     needs: [compute-versions, build-cli-linux, build-gateway-binary-linux]
@@ -807,7 +818,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Release
-    needs: [compute-versions, build-cli-linux, build-cli-macos, build-gateway-binary-linux, build-gateway-binary-macos, build-supervisor-binary-linux, build-python-wheels-linux, build-python-wheel-macos, tag-ghcr-release, build-driver-vm-linux, build-driver-vm-macos, build-deb, build-rpm, smoke-linux-release-artifacts]
+    needs: [compute-versions, build-cli-linux, build-cli-macos, build-gateway-binary-linux, build-gateway-binary-macos, build-supervisor-binary-linux, build-python-wheels-linux, build-python-wheel-macos, tag-ghcr-release, build-driver-vm-linux, build-driver-vm-macos, build-deb, build-rpm, build-snap, smoke-linux-release-artifacts]
     runs-on: linux-amd64-cpu8
     timeout-minutes: 10
     permissions:
@@ -868,6 +879,13 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: rpm-linux-*
+          path: release/
+          merge-multiple: true
+
+      - name: Download snap artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: snap-linux-*
           path: release/
           merge-multiple: true
 
@@ -966,6 +984,7 @@ jobs:
             release/openshell-aarch64-apple-darwin.tar.gz
             release/openshell_*.deb
             release/openshell-*.rpm
+            release/*.snap
             release/openshell-gateway-x86_64-unknown-linux-gnu.tar.gz
             release/openshell-gateway-aarch64-unknown-linux-gnu.tar.gz
             release/openshell-gateway-aarch64-apple-darwin.tar.gz

--- a/.github/workflows/snap-package.yml
+++ b/.github/workflows/snap-package.yml
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Snap Package
+
+on:
+  workflow_call:
+    inputs:
+      checkout-ref:
+        required: true
+        type: string
+      upload-channel:
+        required: true
+        type: string
+        description: "Snap Store channel to upload to (e.g., latest/edge, latest/candidate, latest/stable)"
+      github-environment:
+        required: true
+        type: string
+        description: "GitHub deployment environment for approval gates (e.g., latest/edge, latest/stable)"
+
+    secrets:
+      publish-credentials:
+        required: true
+        description: "Snap Store credentials (SNAPCRAFT_STORE_CREDENTIALS)"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-snap:
+    name: Build Snap (Linux ${{ matrix.arch }})
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: linux-amd64-cpu8
+          - arch: arm64
+            runner: linux-arm64-cpu8
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    environment: ${{ inputs.github-environment }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.checkout-ref }}
+          fetch-depth: 0
+
+      - name: Install snapd
+        run: |
+          set -euo pipefail
+          if ! command -v snapd >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y snapd
+          fi
+          sudo systemctl enable --now snapd.socket
+          sudo systemctl start snapd
+          sudo snap wait system seed.loaded
+
+      - name: Install LXD
+        run: |
+          set -euo pipefail
+          sudo snap install lxd
+          sudo usermod -aG lxd $USER
+          sudo lxd init --auto
+
+      - name: Install snapcraft
+        run: |
+          set -euo pipefail
+          sudo snap install snapcraft --classic
+
+      - name: Build snap
+        run: |
+          set -euo pipefail
+          snapcraft pack -v
+
+      - name: Capture snap filename
+        id: capture
+        run: |
+          set -euo pipefail
+          SNAP_FILE=$(ls -1 *.snap 2>/dev/null | head -1)
+          if [ -z "$SNAP_FILE" ]; then
+            echo "ERROR: No .snap file found after snapcraft pack"
+            exit 1
+          fi
+          echo "snap-file=${SNAP_FILE}" >> $GITHUB_OUTPUT
+          echo "Built snap: ${SNAP_FILE}"
+
+      - name: Upload snap artifact (${{ matrix.arch }})
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: snap-linux-${{ matrix.arch }}
+          path: |
+            ${{ steps.capture.outputs.snap-file }}
+            *.comp
+          retention-days: 5
+
+      - name: Upload snap to Snap Store
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.publish-credentials }}
+        run: |
+          set -euo pipefail
+          SNAP_FILE="${{ steps.capture.outputs.snap-file }}"
+          SNAP_NAME="${SNAP_FILE%.snap}"
+          SNAP_NAME="${SNAP_NAME%%_*}"
+
+          COMPONENT_ARGS=()
+          shopt -s nullglob
+          for comp in "${SNAP_NAME}"+*.comp; do
+            echo "Adding component: $comp"
+            COMPONENT_ARGS+=(--component "$comp")
+          done
+
+          echo "Uploading $SNAP_FILE to ${{ inputs.upload-channel }}"
+          snapcraft upload --release "${{ inputs.upload-channel }}" "$SNAP_FILE" "${COMPONENT_ARGS[@]}"

--- a/.github/workflows/snap-package.yml
+++ b/.github/workflows/snap-package.yml
@@ -68,6 +68,7 @@ jobs:
           sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
           sudo usermod -aG lxd $USER
           sudo lxd init --auto
+          sudo lxd waitready
 
       - name: Install snapcraft
         run: |

--- a/.github/workflows/snap-package.yml
+++ b/.github/workflows/snap-package.yml
@@ -64,6 +64,8 @@ jobs:
         run: |
           set -euo pipefail
           sudo snap install lxd
+          sudo iptables -P FORWARD ACCEPT
+          sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
           sudo usermod -aG lxd $USER
           sudo lxd init --auto
 

--- a/.github/workflows/snap-package.yml
+++ b/.github/workflows/snap-package.yml
@@ -79,6 +79,14 @@ jobs:
           set -euo pipefail
           snapcraft pack -v
 
+      - name: Upload snapcraft logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: snapcraft-logs
+          path: "~/.local/state/snapcraft/log/snapcraft-*.log"
+          retention-days: 7
+
       - name: Capture snap filename
         id: capture
         run: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,8 +12,7 @@ description: |
   LLM inference routing.
 
 base: core24
-# TODO: this prevents publishing a snap to latest/stable.
-grade: devel
+grade: stable
 confinement: strict
 license: Apache-2.0
 website: https://docs.nvidia.com/openshell/latest/index.html


### PR DESCRIPTION
## Summary
Add GitHub snap build, test (when spread support is merged) and publishing pipeline.

## Related Issue
N/A

## Changes
This branch is an adaptation of my https://github.com/zyga/hello-rust project that was developed for allowing GitHub based projects to use the snap store without having to grant individual developers collaborator status on the snap.

The main entrypoing is 

## Testing
<!-- What testing was done? -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- I smoke tested this on my fork (except for publishing for real)

## Checklist
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
