### PR TITLE
refactor: deduplicate repeated patterns across crates

### DIFF
--- a/crates/openshell-core/src/driver_utils.rs
+++ b/crates/openshell-core/src/driver_utils.rs
@@ -5,6 +5,28 @@
 
 use crate::proto::compute::v1::DriverSandbox;
 
+// ---------------------------------------------------------------------------
+// Sandbox container/pod label keys (openshell.ai/ namespace)
+// ---------------------------------------------------------------------------
+
+/// Container/pod label that identifies this resource as managed by `OpenShell`.
+/// Value should be `"openshell"`.
+pub const LABEL_MANAGED_BY: &str = "openshell.ai/managed-by";
+
+/// Expected value for [`LABEL_MANAGED_BY`].
+pub const LABEL_MANAGED_BY_VALUE: &str = "openshell";
+
+/// Container/pod label carrying the sandbox ID.
+pub const LABEL_SANDBOX_ID: &str = "openshell.ai/sandbox-id";
+
+/// Container/pod label carrying the sandbox name.
+pub const LABEL_SANDBOX_NAME: &str = "openshell.ai/sandbox-name";
+
+/// Container/pod label carrying the sandbox namespace.
+pub const LABEL_SANDBOX_NAMESPACE: &str = "openshell.ai/sandbox-namespace";
+
+// ---------------------------------------------------------------------------
+
 /// Path to the sandbox supervisor binary inside the container image.
 ///
 /// All compute drivers must launch this binary as the container entrypoint to

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -19,7 +19,10 @@ use bollard::query_parameters::{
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use openshell_core::config::{DEFAULT_DOCKER_NETWORK_NAME, DEFAULT_STOP_TIMEOUT_SECS};
-use openshell_core::driver_utils::SUPERVISOR_IMAGE_BINARY_PATH;
+use openshell_core::driver_utils::{
+    LABEL_MANAGED_BY, LABEL_MANAGED_BY_VALUE, LABEL_SANDBOX_ID, LABEL_SANDBOX_NAME,
+    LABEL_SANDBOX_NAMESPACE, SUPERVISOR_IMAGE_BINARY_PATH,
+};
 use openshell_core::gpu::cdi_gpu_device_ids;
 use openshell_core::proto::compute::v1::{
     CreateSandboxRequest, CreateSandboxResponse, DeleteSandboxRequest, DeleteSandboxResponse,
@@ -47,12 +50,6 @@ use url::Url;
 const WATCH_BUFFER: usize = 128;
 const WATCH_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const WATCH_POLL_MAX_BACKOFF: Duration = Duration::from_secs(30);
-
-const MANAGED_BY_LABEL_KEY: &str = "openshell.ai/managed-by";
-const MANAGED_BY_LABEL_VALUE: &str = "openshell";
-const SANDBOX_ID_LABEL_KEY: &str = "openshell.ai/sandbox-id";
-const SANDBOX_NAME_LABEL_KEY: &str = "openshell.ai/sandbox-name";
-const SANDBOX_NAMESPACE_LABEL_KEY: &str = "openshell.ai/sandbox-namespace";
 
 const SUPERVISOR_MOUNT_PATH: &str = "/opt/openshell/bin/openshell-sandbox";
 const TLS_CA_MOUNT_PATH: &str = "/etc/openshell/tls/client/ca.crt";
@@ -683,9 +680,9 @@ impl DockerComputeDriver {
     ) -> Result<Option<ContainerSummary>, Status> {
         let mut label_filter_values = Vec::new();
         if !sandbox_id.is_empty() {
-            label_filter_values.push(format!("{SANDBOX_ID_LABEL_KEY}={sandbox_id}"));
+            label_filter_values.push(format!("{LABEL_SANDBOX_ID}={sandbox_id}"));
         } else if !sandbox_name.is_empty() {
-            label_filter_values.push(format!("{SANDBOX_NAME_LABEL_KEY}={sandbox_name}"));
+            label_filter_values.push(format!("{LABEL_SANDBOX_NAME}={sandbox_name}"));
         }
 
         let filters =
@@ -706,15 +703,15 @@ impl DockerComputeDriver {
                 return false;
             };
             let namespace_matches = labels
-                .get(SANDBOX_NAMESPACE_LABEL_KEY)
+                .get(LABEL_SANDBOX_NAMESPACE)
                 .is_some_and(|value| value == &self.config.sandbox_namespace);
             let id_matches = sandbox_id.is_empty()
                 || labels
-                    .get(SANDBOX_ID_LABEL_KEY)
+                    .get(LABEL_SANDBOX_ID)
                     .is_some_and(|value| value == sandbox_id);
             let name_matches = sandbox_name.is_empty()
                 || labels
-                    .get(SANDBOX_NAME_LABEL_KEY)
+                    .get(LABEL_SANDBOX_NAME)
                     .is_some_and(|value| value == sandbox_name);
             namespace_matches && id_matches && name_matches
         }))
@@ -1015,17 +1012,17 @@ fn build_container_create_body(
     let resource_limits = docker_resource_limits(template)?;
     let mut labels = template.labels.clone();
     labels.insert(
-        MANAGED_BY_LABEL_KEY.to_string(),
-        MANAGED_BY_LABEL_VALUE.to_string(),
+        LABEL_MANAGED_BY.to_string(),
+        LABEL_MANAGED_BY_VALUE.to_string(),
     );
-    labels.insert(SANDBOX_ID_LABEL_KEY.to_string(), sandbox.id.clone());
-    labels.insert(SANDBOX_NAME_LABEL_KEY.to_string(), sandbox.name.clone());
+    labels.insert(LABEL_SANDBOX_ID.to_string(), sandbox.id.clone());
+    labels.insert(LABEL_SANDBOX_NAME.to_string(), sandbox.name.clone());
     // The list/get/find paths filter by `config.sandbox_namespace`, so use
     // the same value here. `DriverSandbox.namespace` is unset on the request
     // path (the gateway elides it), and using it would produce containers
     // that the driver itself cannot find afterwards.
     labels.insert(
-        SANDBOX_NAMESPACE_LABEL_KEY.to_string(),
+        LABEL_SANDBOX_NAMESPACE.to_string(),
         config.sandbox_namespace.clone(),
     );
 
@@ -1217,8 +1214,8 @@ async fn ensure_bridge_network(docker: &Docker, network_name: &str) -> CoreResul
             driver: Some(DOCKER_NETWORK_DRIVER.to_string()),
             attachable: Some(true),
             labels: Some(HashMap::from([(
-                MANAGED_BY_LABEL_KEY.to_string(),
-                MANAGED_BY_LABEL_VALUE.to_string(),
+                LABEL_MANAGED_BY.to_string(),
+                LABEL_MANAGED_BY_VALUE.to_string(),
             )])),
             ..Default::default()
         })
@@ -1397,10 +1394,10 @@ fn sandbox_from_container_summary(
     readiness: &dyn SupervisorReadiness,
 ) -> Option<DriverSandbox> {
     let labels = summary.labels.as_ref()?;
-    let id = labels.get(SANDBOX_ID_LABEL_KEY)?.clone();
-    let name = labels.get(SANDBOX_NAME_LABEL_KEY)?.clone();
+    let id = labels.get(LABEL_SANDBOX_ID)?.clone();
+    let name = labels.get(LABEL_SANDBOX_NAME)?.clone();
     let namespace = labels
-        .get(SANDBOX_NAMESPACE_LABEL_KEY)
+        .get(LABEL_SANDBOX_NAMESPACE)
         .cloned()
         .unwrap_or_default();
 
@@ -1573,8 +1570,8 @@ fn managed_container_label_filters(
     extra_values: impl IntoIterator<Item = String>,
 ) -> HashMap<String, Vec<String>> {
     let mut values = vec![
-        format!("{MANAGED_BY_LABEL_KEY}={MANAGED_BY_LABEL_VALUE}"),
-        format!("{SANDBOX_NAMESPACE_LABEL_KEY}={sandbox_namespace}"),
+        format!("{LABEL_MANAGED_BY}={LABEL_MANAGED_BY_VALUE}"),
+        format!("{LABEL_SANDBOX_NAMESPACE}={sandbox_namespace}"),
     ];
     values.extend(extra_values);
     label_filters(values)

--- a/crates/openshell-driver-docker/src/tests.rs
+++ b/crates/openshell-driver-docker/src/tests.rs
@@ -3,6 +3,10 @@
 
 use super::*;
 use openshell_core::config::{CDI_GPU_DEVICE_ALL, DEFAULT_SERVER_PORT};
+use openshell_core::driver_utils::{
+    LABEL_MANAGED_BY, LABEL_MANAGED_BY_VALUE, LABEL_SANDBOX_ID, LABEL_SANDBOX_NAME,
+    LABEL_SANDBOX_NAMESPACE,
+};
 use openshell_core::proto::compute::v1::{
     DriverResourceRequirements, DriverSandboxSpec, DriverSandboxTemplate,
 };
@@ -441,12 +445,12 @@ fn build_binds_uses_docker_tls_directory() {
 #[test]
 fn managed_container_label_filters_include_gateway_namespace() {
     let filters =
-        managed_container_label_filters("tenant-a", [format!("{SANDBOX_ID_LABEL_KEY}=sbx-123")]);
+        managed_container_label_filters("tenant-a", [format!("{LABEL_SANDBOX_ID}=sbx-123")]);
     let labels = filters.get("label").unwrap();
 
-    assert!(labels.contains(&format!("{MANAGED_BY_LABEL_KEY}={MANAGED_BY_LABEL_VALUE}")));
-    assert!(labels.contains(&format!("{SANDBOX_NAMESPACE_LABEL_KEY}=tenant-a")));
-    assert!(labels.contains(&format!("{SANDBOX_ID_LABEL_KEY}=sbx-123")));
+    assert!(labels.contains(&format!("{LABEL_MANAGED_BY}={LABEL_MANAGED_BY_VALUE}")));
+    assert!(labels.contains(&format!("{LABEL_SANDBOX_NAMESPACE}=tenant-a")));
+    assert!(labels.contains(&format!("{LABEL_SANDBOX_ID}=sbx-123")));
 }
 
 #[test]
@@ -462,7 +466,7 @@ fn build_container_create_body_clears_inherited_cmd() {
         create_body
             .labels
             .as_ref()
-            .and_then(|labels| labels.get(SANDBOX_NAMESPACE_LABEL_KEY)),
+            .and_then(|labels| labels.get(LABEL_SANDBOX_NAMESPACE)),
         Some(&"default".to_string())
     );
     let host_config = create_body.host_config.as_ref().unwrap();
@@ -606,7 +610,7 @@ fn build_container_create_body_uses_runtime_namespace_label() {
     let labels = create_body.labels.expect("labels are populated");
 
     assert_eq!(
-        labels.get(SANDBOX_NAMESPACE_LABEL_KEY),
+        labels.get(LABEL_SANDBOX_NAMESPACE),
         Some(&"tenant-a".to_string()),
         "namespace label must reflect the driver's runtime config"
     );
@@ -618,12 +622,9 @@ fn driver_status_keeps_running_sandboxes_provisioning_with_stable_message() {
         id: Some("cid".to_string()),
         names: Some(vec!["/openshell-demo".to_string()]),
         labels: Some(HashMap::from([
-            (SANDBOX_ID_LABEL_KEY.to_string(), "sbx-1".to_string()),
-            (SANDBOX_NAME_LABEL_KEY.to_string(), "demo".to_string()),
-            (
-                SANDBOX_NAMESPACE_LABEL_KEY.to_string(),
-                "default".to_string(),
-            ),
+            (LABEL_SANDBOX_ID.to_string(), "sbx-1".to_string()),
+            (LABEL_SANDBOX_NAME.to_string(), "demo".to_string()),
+            (LABEL_SANDBOX_NAMESPACE.to_string(), "default".to_string()),
         ])),
         state: Some(ContainerSummaryStateEnum::RUNNING),
         status: Some("Up 2 seconds".to_string()),
@@ -675,12 +676,9 @@ fn driver_status_marks_restarting_sandboxes_as_error() {
         id: Some("cid".to_string()),
         names: Some(vec!["/openshell-demo".to_string()]),
         labels: Some(HashMap::from([
-            (SANDBOX_ID_LABEL_KEY.to_string(), "sbx-1".to_string()),
-            (SANDBOX_NAME_LABEL_KEY.to_string(), "demo".to_string()),
-            (
-                SANDBOX_NAMESPACE_LABEL_KEY.to_string(),
-                "default".to_string(),
-            ),
+            (LABEL_SANDBOX_ID.to_string(), "sbx-1".to_string()),
+            (LABEL_SANDBOX_NAME.to_string(), "demo".to_string()),
+            (LABEL_SANDBOX_NAMESPACE.to_string(), "default".to_string()),
         ])),
         state: Some(ContainerSummaryStateEnum::RESTARTING),
         status: Some("Restarting (1) 2 seconds ago".to_string()),

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -13,7 +13,9 @@ use kube::core::gvk::GroupVersionKind;
 use kube::core::{DynamicObject, ObjectMeta};
 use kube::runtime::watcher::{self, Event};
 use kube::{Client, Error as KubeError};
-use openshell_core::driver_utils::SUPERVISOR_IMAGE_BINARY_PATH;
+use openshell_core::driver_utils::{
+    LABEL_MANAGED_BY, LABEL_MANAGED_BY_VALUE, LABEL_SANDBOX_ID, SUPERVISOR_IMAGE_BINARY_PATH,
+};
 use openshell_core::progress::{
     PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX, PROGRESS_STEP_STARTING_SANDBOX,
     mark_progress_active, mark_progress_complete, mark_progress_detail,
@@ -72,9 +74,7 @@ const KUBE_API_TIMEOUT: Duration = Duration::from_secs(30);
 const SANDBOX_GROUP: &str = "agents.x-k8s.io";
 const SANDBOX_VERSION: &str = "v1alpha1";
 pub const SANDBOX_KIND: &str = "Sandbox";
-const SANDBOX_ID_LABEL: &str = "openshell.ai/sandbox-id";
-const SANDBOX_MANAGED_LABEL: &str = "openshell.ai/managed-by";
-const SANDBOX_MANAGED_VALUE: &str = "openshell";
+
 const GPU_RESOURCE_NAME: &str = "nvidia.com/gpu";
 const GPU_RESOURCE_QUANTITY: &str = "1";
 
@@ -552,17 +552,17 @@ impl KubernetesComputeDriver {
 
 fn sandbox_labels(sandbox: &Sandbox) -> BTreeMap<String, String> {
     let mut labels = BTreeMap::new();
-    labels.insert(SANDBOX_ID_LABEL.to_string(), sandbox.id.clone());
+    labels.insert(LABEL_SANDBOX_ID.to_string(), sandbox.id.clone());
     labels.insert(
-        SANDBOX_MANAGED_LABEL.to_string(),
-        SANDBOX_MANAGED_VALUE.to_string(),
+        LABEL_MANAGED_BY.to_string(),
+        LABEL_MANAGED_BY_VALUE.to_string(),
     );
     labels
 }
 
 fn sandbox_id_from_object(obj: &DynamicObject) -> Result<String, String> {
     if let Some(labels) = obj.metadata.labels.as_ref()
-        && let Some(id) = labels.get(SANDBOX_ID_LABEL)
+        && let Some(id) = labels.get(LABEL_SANDBOX_ID)
     {
         return Ok(id.clone());
     }

--- a/crates/openshell-providers/src/providers/anthropic.rs
+++ b/crates/openshell-providers/src/providers/anthropic.rs
@@ -8,21 +8,8 @@ pub const SPEC: ProviderDiscoverySpec = ProviderDiscoverySpec {
     credential_env_vars: &["ANTHROPIC_API_KEY"],
 };
 
-#[cfg(test)]
-mod tests {
-    use super::SPEC;
-    use crate::discover_with_spec;
-    use crate::test_helpers::MockDiscoveryContext;
-
-    #[test]
-    fn discovers_anthropic_env_credentials() {
-        let ctx = MockDiscoveryContext::new().with_env("ANTHROPIC_API_KEY", "sk-ant-test");
-        let discovered = discover_with_spec(&SPEC, &ctx)
-            .expect("discovery")
-            .expect("provider");
-        assert_eq!(
-            discovered.credentials.get("ANTHROPIC_API_KEY"),
-            Some(&"sk-ant-test".to_string())
-        );
-    }
-}
+test_discovers_env_credential!(
+    discovers_anthropic_env_credentials,
+    "ANTHROPIC_API_KEY",
+    "sk-ant-test"
+);

--- a/crates/openshell-providers/src/providers/claude.rs
+++ b/crates/openshell-providers/src/providers/claude.rs
@@ -8,21 +8,8 @@ pub const SPEC: ProviderDiscoverySpec = ProviderDiscoverySpec {
     credential_env_vars: &["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"],
 };
 
-#[cfg(test)]
-mod tests {
-    use super::SPEC;
-    use crate::discover_with_spec;
-    use crate::test_helpers::MockDiscoveryContext;
-
-    #[test]
-    fn discovers_claude_env_credentials() {
-        let ctx = MockDiscoveryContext::new().with_env("ANTHROPIC_API_KEY", "test-key");
-        let discovered = discover_with_spec(&SPEC, &ctx)
-            .expect("discovery")
-            .expect("provider");
-        assert_eq!(
-            discovered.credentials.get("ANTHROPIC_API_KEY"),
-            Some(&"test-key".to_string())
-        );
-    }
-}
+test_discovers_env_credential!(
+    discovers_claude_env_credentials,
+    "ANTHROPIC_API_KEY",
+    "test-key"
+);

--- a/crates/openshell-providers/src/providers/codex.rs
+++ b/crates/openshell-providers/src/providers/codex.rs
@@ -8,21 +8,8 @@ pub const SPEC: ProviderDiscoverySpec = ProviderDiscoverySpec {
     credential_env_vars: &["OPENAI_API_KEY"],
 };
 
-#[cfg(test)]
-mod tests {
-    use super::SPEC;
-    use crate::discover_with_spec;
-    use crate::test_helpers::MockDiscoveryContext;
-
-    #[test]
-    fn discovers_codex_env_credentials() {
-        let ctx = MockDiscoveryContext::new().with_env("OPENAI_API_KEY", "openai-key");
-        let discovered = discover_with_spec(&SPEC, &ctx)
-            .expect("discovery")
-            .expect("provider");
-        assert_eq!(
-            discovered.credentials.get("OPENAI_API_KEY"),
-            Some(&"openai-key".to_string())
-        );
-    }
-}
+test_discovers_env_credential!(
+    discovers_codex_env_credentials,
+    "OPENAI_API_KEY",
+    "openai-key"
+);

--- a/crates/openshell-providers/src/providers/copilot.rs
+++ b/crates/openshell-providers/src/providers/copilot.rs
@@ -8,21 +8,8 @@ pub const SPEC: ProviderDiscoverySpec = ProviderDiscoverySpec {
     credential_env_vars: &["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"],
 };
 
-#[cfg(test)]
-mod tests {
-    use super::SPEC;
-    use crate::discover_with_spec;
-    use crate::test_helpers::MockDiscoveryContext;
-
-    #[test]
-    fn discovers_copilot_env_credentials() {
-        let ctx = MockDiscoveryContext::new().with_env("COPILOT_GITHUB_TOKEN", "ghp-copilot-token");
-        let discovered = discover_with_spec(&SPEC, &ctx)
-            .expect("discovery")
-            .expect("provider");
-        assert_eq!(
-            discovered.credentials.get("COPILOT_GITHUB_TOKEN"),
-            Some(&"ghp-copilot-token".to_string())
-        );
-    }
-}
+test_discovers_env_credential!(
+    discovers_copilot_env_credentials,
+    "COPILOT_GITHUB_TOKEN",
+    "ghp-copilot-token"
+);

--- a/crates/openshell-providers/src/providers/github.rs
+++ b/crates/openshell-providers/src/providers/github.rs
@@ -8,21 +8,4 @@ pub const SPEC: ProviderDiscoverySpec = ProviderDiscoverySpec {
     credential_env_vars: &["GITHUB_TOKEN", "GH_TOKEN"],
 };
 
-#[cfg(test)]
-mod tests {
-    use super::SPEC;
-    use crate::discover_with_spec;
-    use crate::test_helpers::MockDiscoveryContext;
-
-    #[test]
-    fn discovers_github_env_credentials() {
-        let ctx = MockDiscoveryContext::new().with_env("GH_TOKEN", "gh-token");
-        let discovered = discover_with_spec(&SPEC, &ctx)
-            .expect("discovery")
-            .expect("provider");
-        assert_eq!(
-            discovered.credentials.get("GH_TOKEN"),
-            Some(&"gh-token".to_string())
-        );
-    }
-}
+test_discovers_env_credential!(discovers_github_env_credentials, "GH_TOKEN", "gh-token");

--- a/crates/openshell-providers/src/providers/gitlab.rs
+++ b/crates/openshell-providers/src/providers/gitlab.rs
@@ -8,21 +8,4 @@ pub const SPEC: ProviderDiscoverySpec = ProviderDiscoverySpec {
     credential_env_vars: &["GITLAB_TOKEN", "GLAB_TOKEN", "CI_JOB_TOKEN"],
 };
 
-#[cfg(test)]
-mod tests {
-    use super::SPEC;
-    use crate::discover_with_spec;
-    use crate::test_helpers::MockDiscoveryContext;
-
-    #[test]
-    fn discovers_gitlab_env_credentials() {
-        let ctx = MockDiscoveryContext::new().with_env("GLAB_TOKEN", "glab-token");
-        let discovered = discover_with_spec(&SPEC, &ctx)
-            .expect("discovery")
-            .expect("provider");
-        assert_eq!(
-            discovered.credentials.get("GLAB_TOKEN"),
-            Some(&"glab-token".to_string())
-        );
-    }
-}
+test_discovers_env_credential!(discovers_gitlab_env_credentials, "GLAB_TOKEN", "glab-token");

--- a/crates/openshell-providers/src/providers/mod.rs
+++ b/crates/openshell-providers/src/providers/mod.rs
@@ -1,6 +1,35 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Generate a standard discovery smoke-test for a provider whose only test is
+/// checking that an env-var credential is picked up by `discover_with_spec`.
+///
+/// # Usage
+/// ```ignore
+/// test_discovers_env_credential!(discovers_openai_env_credentials, "OPENAI_API_KEY", "sk-test");
+/// ```
+macro_rules! test_discovers_env_credential {
+    ($test_name:ident, $env_var:expr, $env_value:expr) => {
+        #[cfg(test)]
+        mod tests {
+            use super::SPEC;
+            use crate::discover_with_spec;
+            use crate::test_helpers::MockDiscoveryContext;
+
+            #[test]
+            fn $test_name() {
+                let ctx = MockDiscoveryContext::new().with_env($env_var, $env_value);
+                let discovered = discover_with_spec(&SPEC, &ctx)
+                    .expect("discovery")
+                    .expect("provider");
+                assert_eq!(
+                    discovered.credentials.get($env_var),
+                    Some(&$env_value.to_string())
+                );
+            }
+        }
+    };
+}
 pub mod anthropic;
 pub mod claude;
 pub mod codex;

--- a/crates/openshell-providers/src/providers/nvidia.rs
+++ b/crates/openshell-providers/src/providers/nvidia.rs
@@ -8,21 +8,8 @@ pub const SPEC: ProviderDiscoverySpec = ProviderDiscoverySpec {
     credential_env_vars: &["NVIDIA_API_KEY"],
 };
 
-#[cfg(test)]
-mod tests {
-    use super::SPEC;
-    use crate::discover_with_spec;
-    use crate::test_helpers::MockDiscoveryContext;
-
-    #[test]
-    fn discovers_nvidia_env_credentials() {
-        let ctx = MockDiscoveryContext::new().with_env("NVIDIA_API_KEY", "nvapi-123");
-        let discovered = discover_with_spec(&SPEC, &ctx)
-            .expect("discovery")
-            .expect("provider");
-        assert_eq!(
-            discovered.credentials.get("NVIDIA_API_KEY"),
-            Some(&"nvapi-123".to_string())
-        );
-    }
-}
+test_discovers_env_credential!(
+    discovers_nvidia_env_credentials,
+    "NVIDIA_API_KEY",
+    "nvapi-123"
+);

--- a/crates/openshell-providers/src/providers/openai.rs
+++ b/crates/openshell-providers/src/providers/openai.rs
@@ -8,21 +8,8 @@ pub const SPEC: ProviderDiscoverySpec = ProviderDiscoverySpec {
     credential_env_vars: &["OPENAI_API_KEY"],
 };
 
-#[cfg(test)]
-mod tests {
-    use super::SPEC;
-    use crate::discover_with_spec;
-    use crate::test_helpers::MockDiscoveryContext;
-
-    #[test]
-    fn discovers_openai_env_credentials() {
-        let ctx = MockDiscoveryContext::new().with_env("OPENAI_API_KEY", "sk-openai-test");
-        let discovered = discover_with_spec(&SPEC, &ctx)
-            .expect("discovery")
-            .expect("provider");
-        assert_eq!(
-            discovered.credentials.get("OPENAI_API_KEY"),
-            Some(&"sk-openai-test".to_string())
-        );
-    }
-}
+test_discovers_env_credential!(
+    discovers_openai_env_credentials,
+    "OPENAI_API_KEY",
+    "sk-openai-test"
+);

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -2833,6 +2833,12 @@ mod tests {
     use std::sync::Arc;
     use tonic::Code;
 
+    async fn test_store() -> Store {
+        Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("in-memory SQLite store should connect")
+    }
+
     #[test]
     fn sandbox_caller_update_validation_allows_sandbox_policy_sync() {
         let req = UpdateConfigRequest {
@@ -2882,7 +2888,7 @@ mod tests {
     async fn sandbox_without_policy_stores_successfully() {
         use openshell_core::proto::{SandboxPhase, SandboxSpec};
 
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
 
         let sandbox = Sandbox {
             metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
@@ -3002,7 +3008,7 @@ mod tests {
 
     #[tokio::test]
     async fn provider_policy_layers_skip_unknown_provider_types() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         store
             .put_message(&test_provider("custom-provider", "custom"))
             .await
@@ -3017,7 +3023,7 @@ mod tests {
 
     #[tokio::test]
     async fn provider_policy_layers_skip_custom_profile_for_legacy_provider_type() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         store
             .put_message(&test_provider("custom-provider", "generic"))
             .await
@@ -3059,7 +3065,7 @@ mod tests {
     #[tokio::test]
     #[allow(deprecated)]
     async fn provider_policy_layers_include_custom_provider_profiles() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         store
             .put_message(&test_provider("work-custom", "custom-api"))
             .await
@@ -3122,7 +3128,7 @@ mod tests {
 
     #[tokio::test]
     async fn provider_policy_layers_normalize_custom_provider_type_ids() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         store
             .put_message(&test_provider("work-custom", " Custom-API "))
             .await
@@ -3164,7 +3170,7 @@ mod tests {
 
     #[tokio::test]
     async fn provider_policy_layers_include_known_provider_profiles() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         store
             .put_message(&test_provider("work-github", "github"))
             .await
@@ -3905,7 +3911,7 @@ mod tests {
     async fn sandbox_policy_backfill_on_update_when_no_baseline() {
         use openshell_core::proto::{FilesystemPolicy, LandlockPolicy, SandboxPhase, SandboxSpec};
 
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
 
         let sandbox = Sandbox {
             metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
@@ -4865,7 +4871,7 @@ mod tests {
     async fn merge_chunk_into_policy_adds_first_network_rule_to_empty_policy() {
         use openshell_core::proto::{NetworkBinary, NetworkEndpoint, NetworkPolicyRule};
 
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         let rule = NetworkPolicyRule {
             name: "google".to_string(),
             endpoints: vec![NetworkEndpoint {
@@ -4928,7 +4934,7 @@ mod tests {
             NetworkBinary, NetworkEndpoint, NetworkPolicyRule, SandboxPolicy,
         };
 
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         let sandbox_id = "sb-merge";
 
         let initial_policy = SandboxPolicy {
@@ -5029,7 +5035,7 @@ mod tests {
             NetworkBinary, NetworkEndpoint, NetworkPolicyRule, SandboxPolicy,
         };
 
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         let sandbox_id = "sb-new";
 
         let initial_policy = SandboxPolicy {
@@ -5116,7 +5122,7 @@ mod tests {
             L7Allow, L7DenyRule, L7Rule, NetworkEndpoint, NetworkPolicyRule, SandboxPolicy,
         };
 
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         let sandbox_id = "sb-concurrent-merge";
 
         let initial_policy = SandboxPolicy {
@@ -5687,9 +5693,7 @@ mod tests {
 
     #[tokio::test]
     async fn global_settings_load_returns_default_when_empty() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
         let settings = load_global_settings(&store).await.unwrap();
         assert!(settings.settings.is_empty());
         assert_eq!(settings.revision, 0);
@@ -5697,9 +5701,7 @@ mod tests {
 
     #[tokio::test]
     async fn sandbox_settings_load_returns_default_when_empty() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
         let settings = load_sandbox_settings(&store, "nonexistent").await.unwrap();
         assert!(settings.settings.is_empty());
         assert_eq!(settings.revision, 0);
@@ -5707,9 +5709,7 @@ mod tests {
 
     #[tokio::test]
     async fn global_settings_save_and_load_round_trip() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let mut settings = StoredSettings::default();
         settings.settings.insert(
@@ -5736,9 +5736,7 @@ mod tests {
 
     #[tokio::test]
     async fn sandbox_settings_save_and_load_round_trip() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let sandbox_name = "my-sandbox";
         let mut settings = StoredSettings::default();
@@ -5760,11 +5758,7 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_global_setting_mutations_are_serialized() {
-        let store = Arc::new(
-            Store::connect("sqlite::memory:?cache=shared")
-                .await
-                .unwrap(),
-        );
+        let store = Arc::new(test_store().await);
         let mutex = Arc::new(tokio::sync::Mutex::new(()));
 
         let n = 50;
@@ -5795,11 +5789,7 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_global_setting_mutations_without_lock_can_lose_writes() {
-        let store = Arc::new(
-            Store::connect("sqlite::memory:?cache=shared")
-                .await
-                .unwrap(),
-        );
+        let store = Arc::new(test_store().await);
 
         let n = 50;
         let mut handles = Vec::with_capacity(n);
@@ -5866,9 +5856,7 @@ mod tests {
 
     #[tokio::test]
     async fn conflict_guard_sandbox_set_blocked_when_global_exists() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let mut global = StoredSettings::default();
         global.settings.insert(
@@ -5885,9 +5873,7 @@ mod tests {
 
     #[tokio::test]
     async fn conflict_guard_sandbox_delete_blocked_when_global_exists() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let mut global = StoredSettings::default();
         global
@@ -5902,9 +5888,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_unlock_sandbox_set_succeeds_after_global_delete() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         // Create initial global settings
         let mut global = StoredSettings::default();
@@ -5966,7 +5950,7 @@ mod tests {
 
     #[tokio::test]
     async fn save_settings_detects_concurrent_modification() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
 
         // Create initial settings
         let mut settings = StoredSettings {

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -1445,6 +1445,12 @@ mod tests {
     use super::*;
     use crate::grpc::MAX_MAP_KEY_LEN;
     use crate::grpc::test_support::test_server_state;
+
+    async fn test_store() -> Store {
+        Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("in-memory SQLite store should connect")
+    }
     use openshell_core::proto::{
         DeleteProviderProfileRequest, GetProviderProfileRequest, ImportProviderProfilesRequest,
         L7Allow, L7Rule, LintProviderProfilesRequest, ListProviderProfilesRequest, NetworkBinary,
@@ -2612,9 +2618,7 @@ mod tests {
 
     #[tokio::test]
     async fn provider_crud_round_trip_and_semantics() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let created = provider_with_values("gitlab-local", "gitlab");
         let persisted = create_provider_record(&store, created.clone())
@@ -2706,9 +2710,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_provider_removes_scoped_refresh_states() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let provider = create_provider_record(
             &store,
@@ -2755,9 +2757,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_provider_rejects_attached_provider() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         create_provider_record(&store, provider_with_values("gitlab-local", "gitlab"))
             .await
@@ -2793,9 +2793,7 @@ mod tests {
 
     #[tokio::test]
     async fn provider_create_and_update_return_correct_resource_version() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         // Create provider and verify resource_version: 1 in response
         let created = provider_with_values("test-provider", "openai");
@@ -3081,9 +3079,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_provider_empty_maps_is_noop() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let created = provider_with_values("noop-test", "nvidia");
         let persisted = create_provider_record(&store, created).await.unwrap();
@@ -3130,9 +3126,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_provider_empty_value_deletes_key() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let created = provider_with_values("delete-key-test", "openai");
         create_provider_record(&store, created).await.unwrap();
@@ -3183,9 +3177,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_provider_empty_type_preserves_existing() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let created = provider_with_values("type-preserve-test", "anthropic");
         create_provider_record(&store, created).await.unwrap();
@@ -3214,9 +3206,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_provider_rejects_type_change() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let created = provider_with_values("type-change-test", "nvidia");
         create_provider_record(&store, created).await.unwrap();
@@ -3246,9 +3236,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_provider_validates_merged_result() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let created = provider_with_values("validate-merge-test", "gitlab");
         create_provider_record(&store, created).await.unwrap();
@@ -3278,14 +3266,14 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_provider_env_empty_list_returns_empty() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         let result = resolve_provider_environment(&store, &[]).await.unwrap();
         assert!(result.is_empty());
     }
 
     #[tokio::test]
     async fn resolve_provider_env_injects_credentials() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         let provider = Provider {
             metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
                 id: String::new(),
@@ -3320,7 +3308,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_provider_env_skips_expired_credentials_and_returns_expiry_metadata() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         let now_ms = crate::persistence::current_time_ms();
         let provider = Provider {
             metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
@@ -3360,7 +3348,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_provider_env_unknown_name_returns_error() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         let err = resolve_provider_environment(&store, &["nonexistent".to_string()])
             .await
             .unwrap_err();
@@ -3370,7 +3358,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_provider_env_skips_invalid_credential_keys() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         let provider = Provider {
             metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
                 id: String::new(),
@@ -3402,7 +3390,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_provider_env_multiple_providers_merge() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         create_provider_record(
             &store,
             Provider {
@@ -3457,7 +3445,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_provider_env_rejects_duplicate_credential_keys() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         create_provider_record(
             &store,
             Provider {
@@ -3514,7 +3502,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_provider_rejects_credential_key_collision_for_attached_sandbox() {
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         create_provider_record(
             &store,
             Provider {
@@ -3607,7 +3595,7 @@ mod tests {
     async fn handler_flow_resolves_credentials_from_sandbox_providers() {
         use openshell_core::proto::{Sandbox, SandboxPhase, SandboxSpec};
 
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
 
         create_provider_record(
             &store,
@@ -3667,7 +3655,7 @@ mod tests {
     async fn handler_flow_returns_empty_when_no_providers() {
         use openshell_core::proto::{Sandbox, SandboxPhase, SandboxSpec};
 
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
 
         let sandbox = Sandbox {
             metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
@@ -3701,14 +3689,14 @@ mod tests {
     async fn handler_flow_returns_none_for_unknown_sandbox() {
         use openshell_core::proto::Sandbox;
 
-        let store = Store::connect("sqlite::memory:").await.unwrap();
+        let store = test_store().await;
         let result = store.get_message::<Sandbox>("nonexistent").await.unwrap();
         assert!(result.is_none());
     }
 
     #[tokio::test]
     async fn update_provider_validates_before_write() {
-        let store = Arc::new(Store::connect("sqlite::memory:").await.unwrap());
+        let store = Arc::new(test_store().await);
 
         // Create a valid provider
         let provider = provider_with_values("test-validate-provider", "test-type");
@@ -3780,11 +3768,7 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_create_provider_rejects_duplicate() {
-        let store = Arc::new(
-            Store::connect("sqlite::memory:?cache=shared")
-                .await
-                .unwrap(),
-        );
+        let store = Arc::new(test_store().await);
 
         let provider = provider_with_values("test-concurrent-provider", "test-type");
 

--- a/crates/openshell-server/src/grpc/service.rs
+++ b/crates/openshell-server/src/grpc/service.rs
@@ -275,26 +275,8 @@ fn is_dns_label(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::grpc::test_support::test_server_state;
     use openshell_core::proto::SandboxPhase;
-
-    async fn test_server_state() -> Arc<ServerState> {
-        let store = Arc::new(
-            crate::persistence::Store::connect("sqlite::memory:?cache=shared")
-                .await
-                .unwrap(),
-        );
-        let compute = crate::compute::new_test_runtime(store.clone()).await;
-        Arc::new(ServerState::new(
-            openshell_core::Config::new(None).with_database_url("sqlite::memory:?cache=shared"),
-            store,
-            compute,
-            crate::sandbox_index::SandboxIndex::new(),
-            crate::sandbox_watch::SandboxWatchBus::new(),
-            crate::tracing_bus::TracingLogBus::new(),
-            Arc::new(crate::supervisor_session::SupervisorSessionRegistry::new()),
-            None,
-        ))
-    }
 
     async fn seed_sandbox(state: &Arc<ServerState>, name: &str) {
         state

--- a/crates/openshell-server/src/inference.rs
+++ b/crates/openshell-server/src/inference.rs
@@ -502,6 +502,12 @@ mod tests {
     use wiremock::matchers::{body_partial_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    async fn test_store() -> Store {
+        Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("in-memory SQLite store should connect")
+    }
+
     fn make_route(name: &str, provider_name: &str, model_id: &str) -> InferenceRoute {
         InferenceRoute {
             metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
@@ -552,9 +558,7 @@ mod tests {
 
     #[tokio::test]
     async fn upsert_cluster_route_creates_and_increments_version() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store should connect");
+        let store = test_store().await;
 
         let provider = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-test");
         store
@@ -593,9 +597,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_managed_route_returns_none_when_missing() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store should connect");
+        let store = test_store().await;
 
         let route = resolve_route_by_name(&store, CLUSTER_INFERENCE_ROUTE_NAME)
             .await
@@ -605,9 +607,7 @@ mod tests {
 
     #[tokio::test]
     async fn bundle_happy_path_returns_managed_route() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store");
+        let store = test_store().await;
 
         let provider = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-test");
         store
@@ -634,9 +634,7 @@ mod tests {
 
     #[tokio::test]
     async fn bundle_without_cluster_route_returns_empty_routes() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store");
+        let store = test_store().await;
 
         let resp = resolve_inference_bundle(&store)
             .await
@@ -646,9 +644,7 @@ mod tests {
 
     #[tokio::test]
     async fn bundle_revision_is_stable_for_same_route() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store");
+        let store = test_store().await;
 
         let provider = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-test");
         store
@@ -678,9 +674,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_managed_route_derives_from_provider() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store should connect");
+        let store = test_store().await;
 
         let provider = Provider {
             metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
@@ -746,9 +740,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_managed_route_reflects_provider_key_rotation() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store should connect");
+        let store = test_store().await;
 
         let provider = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-initial");
         store
@@ -790,9 +782,7 @@ mod tests {
 
     #[tokio::test]
     async fn upsert_system_route_creates_with_correct_name() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store");
+        let store = test_store().await;
 
         let provider = make_provider("anthropic-dev", "anthropic", "ANTHROPIC_API_KEY", "sk-ant");
         store.put_message(&provider).await.expect("persist");
@@ -816,9 +806,7 @@ mod tests {
 
     #[tokio::test]
     async fn bundle_includes_both_user_and_system_routes() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store");
+        let store = test_store().await;
 
         let openai = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-oai");
         store.put_message(&openai).await.expect("persist openai");
@@ -856,9 +844,7 @@ mod tests {
 
     #[tokio::test]
     async fn bundle_with_only_system_route() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store");
+        let store = test_store().await;
 
         let provider = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-test");
         store.put_message(&provider).await.expect("persist");
@@ -876,9 +862,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_returns_system_route_when_requested() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store");
+        let store = test_store().await;
 
         let provider = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-test");
         store.put_message(&provider).await.expect("persist");
@@ -907,9 +891,7 @@ mod tests {
 
     #[tokio::test]
     async fn upsert_cluster_route_verifies_endpoint_when_requested() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store");
+        let store = test_store().await;
         let mock_server = MockServer::start().await;
 
         Mock::given(method("POST"))
@@ -960,9 +942,7 @@ mod tests {
 
     #[tokio::test]
     async fn upsert_cluster_route_rejects_failed_validation() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store");
+        let store = test_store().await;
         let mock_server = MockServer::start().await;
 
         Mock::given(method("POST"))
@@ -1013,9 +993,7 @@ mod tests {
 
     #[tokio::test]
     async fn upsert_cluster_route_skips_validation_by_default() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store");
+        let store = test_store().await;
         let provider = make_provider_with_base_url(
             "openai-dev",
             "openai",
@@ -1076,9 +1054,7 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_upsert_route_create_uses_must_create() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store");
+        let store = test_store().await;
 
         let provider = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-test");
         store.put_message(&provider).await.expect("persist");
@@ -1147,9 +1123,7 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_upsert_route_update_uses_cas() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .expect("store");
+        let store = test_store().await;
 
         let provider = make_provider("openai-dev", "openai", "OPENAI_API_KEY", "sk-test");
         store.put_message(&provider).await.expect("persist");

--- a/crates/openshell-server/src/persistence/tests.rs
+++ b/crates/openshell-server/src/persistence/tests.rs
@@ -6,11 +6,15 @@ use crate::policy_store::PolicyStoreExt;
 use openshell_core::proto::{ObjectForTest, SandboxPolicy};
 use prost::Message;
 
+async fn test_store() -> Store {
+    Store::connect("sqlite::memory:?cache=shared")
+        .await
+        .expect("in-memory SQLite store should connect")
+}
+
 #[tokio::test]
 async fn sqlite_put_get_round_trip() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     store
         .put("sandbox", "abc", "my-sandbox", b"payload", None)
@@ -26,9 +30,7 @@ async fn sqlite_put_get_round_trip() {
 
 #[tokio::test]
 async fn sqlite_connect_runs_embedded_migrations() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     let records = store.list("sandbox", 10, 0).await.unwrap();
     assert!(records.is_empty());
@@ -213,9 +215,7 @@ async fn restrict_db_file_permissions_handles_real_sqlite_wal_files() {
 
 #[tokio::test]
 async fn sqlite_updates_timestamp() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     store
         .put("sandbox", "abc", "my-sandbox", b"payload", None)
@@ -236,9 +236,7 @@ async fn sqlite_updates_timestamp() {
 
 #[tokio::test]
 async fn sqlite_list_paging() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     for idx in 0..5 {
         let id = format!("id-{idx}");
@@ -258,9 +256,7 @@ async fn sqlite_list_paging() {
 
 #[tokio::test]
 async fn sqlite_delete_behavior() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     store
         .put("sandbox", "abc", "my-sandbox", b"payload", None)
@@ -276,9 +272,7 @@ async fn sqlite_delete_behavior() {
 
 #[tokio::test]
 async fn sqlite_protobuf_round_trip() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     let object = ObjectForTest {
         id: "abc".to_string(),
@@ -301,9 +295,7 @@ async fn sqlite_protobuf_round_trip() {
 
 #[tokio::test]
 async fn sqlite_get_by_name() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     store
         .put("sandbox", "id-1", "my-sandbox", b"payload", None)
@@ -325,9 +317,7 @@ async fn sqlite_get_by_name() {
 
 #[tokio::test]
 async fn sqlite_get_message_by_name() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     let object = ObjectForTest {
         id: "uid-1".to_string(),
@@ -355,9 +345,7 @@ async fn sqlite_get_message_by_name() {
 
 #[tokio::test]
 async fn sqlite_delete_by_name() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     store
         .put("sandbox", "id-1", "my-sandbox", b"payload", None)
@@ -376,9 +364,7 @@ async fn sqlite_delete_by_name() {
 
 #[tokio::test]
 async fn sqlite_name_unique_per_object_type() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     store
         .put("sandbox", "id-1", "shared-name", b"payload1", None)
@@ -408,9 +394,7 @@ async fn sqlite_name_unique_per_object_type() {
 
 #[tokio::test]
 async fn sqlite_id_globally_unique() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     store
         .put("sandbox", "same-id", "name-a", b"payload1", None)
@@ -458,9 +442,7 @@ impl ObjectType for ObjectForTest {
 
 #[tokio::test]
 async fn labels_round_trip() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     let labels = r#"{"env":"production","team":"platform"}"#;
     store
@@ -480,9 +462,7 @@ async fn labels_round_trip() {
 
 #[tokio::test]
 async fn label_selector_single_match() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     store
         .put("sandbox", "id-1", "s1", b"p1", Some(r#"{"env":"prod"}"#))
@@ -516,9 +496,7 @@ async fn label_selector_single_match() {
 
 #[tokio::test]
 async fn label_selector_multiple_labels() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     store
         .put(
@@ -562,9 +540,7 @@ async fn label_selector_multiple_labels() {
 
 #[tokio::test]
 async fn label_selector_no_match() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     store
         .put("sandbox", "id-1", "s1", b"p1", Some(r#"{"env":"prod"}"#))
@@ -581,9 +557,7 @@ async fn label_selector_no_match() {
 
 #[tokio::test]
 async fn label_selector_respects_paging() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     for idx in 0..5 {
         let id = format!("id-{idx}");
@@ -615,9 +589,7 @@ async fn label_selector_respects_paging() {
 
 #[tokio::test]
 async fn empty_labels_not_matched_by_selector() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     store
         .put("sandbox", "id-1", "s1", b"p1", None)
@@ -643,9 +615,7 @@ async fn empty_labels_not_matched_by_selector() {
 
 #[tokio::test]
 async fn policy_put_and_get_latest() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     let policy_v1 = SandboxPolicy::default().encode_to_vec();
     store
@@ -677,9 +647,7 @@ async fn policy_put_and_get_latest() {
 
 #[tokio::test]
 async fn policy_get_by_version() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     let policy_v1 = SandboxPolicy::default().encode_to_vec();
     let policy_v2 = SandboxPolicy {
@@ -718,9 +686,7 @@ async fn policy_get_by_version() {
 
 #[tokio::test]
 async fn policy_update_status_and_get_loaded() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     let payload = SandboxPolicy::default().encode_to_vec();
     store
@@ -751,9 +717,7 @@ async fn policy_update_status_and_get_loaded() {
 
 #[tokio::test]
 async fn policy_status_failed_with_error() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     let payload = SandboxPolicy::default().encode_to_vec();
     store
@@ -777,9 +741,7 @@ async fn policy_status_failed_with_error() {
 
 #[tokio::test]
 async fn policy_supersede_older() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     let payload = SandboxPolicy::default().encode_to_vec();
     store
@@ -832,9 +794,7 @@ async fn policy_supersede_older() {
 
 #[tokio::test]
 async fn policy_list_ordered_by_version_desc() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     let payload = SandboxPolicy::default().encode_to_vec();
     store
@@ -865,9 +825,7 @@ async fn policy_list_ordered_by_version_desc() {
 
 #[tokio::test]
 async fn policy_isolation_between_sandboxes() {
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     let policy_s1 = SandboxPolicy::default().encode_to_vec();
     let policy_s2 = SandboxPolicy {
@@ -971,9 +929,7 @@ fn parse_label_selector_handles_whitespace() {
 async fn cas_put_if_must_create_succeeds() {
     use super::WriteCondition;
 
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     let result = store
         .put_if(
@@ -998,9 +954,7 @@ async fn cas_put_if_must_create_succeeds() {
 async fn cas_put_if_must_create_fails_on_duplicate() {
     use super::{PersistenceError, WriteCondition};
 
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     // First insert succeeds
     store
@@ -1037,9 +991,7 @@ async fn cas_put_if_must_create_fails_on_duplicate() {
 async fn cas_put_if_match_version_succeeds() {
     use super::WriteCondition;
 
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     // Create initial object
     store
@@ -1078,9 +1030,7 @@ async fn cas_put_if_match_version_succeeds() {
 async fn cas_put_if_match_version_fails_on_mismatch() {
     use super::{PersistenceError, WriteCondition};
 
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     // Create initial object
     store
@@ -1124,9 +1074,7 @@ async fn cas_put_if_match_version_fails_on_mismatch() {
 async fn cas_delete_if_succeeds_with_correct_version() {
     use super::WriteCondition;
 
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     store
         .put_if(
@@ -1151,9 +1099,7 @@ async fn cas_delete_if_succeeds_with_correct_version() {
 async fn cas_delete_if_fails_with_wrong_version() {
     use super::{PersistenceError, WriteCondition};
 
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     store
         .put_if(
@@ -1184,9 +1130,7 @@ async fn cas_delete_if_fails_with_wrong_version() {
 async fn cas_resource_version_increments() {
     use super::WriteCondition;
 
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     // Create
     let r1 = store
@@ -1239,11 +1183,7 @@ async fn cas_concurrent_updates_one_succeeds() {
     use super::WriteCondition;
     use std::sync::Arc;
 
-    let store = Arc::new(
-        Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap(),
-    );
+    let store = Arc::new(test_store().await);
 
     // Create initial object
     store
@@ -1299,9 +1239,7 @@ async fn cas_concurrent_updates_one_succeeds() {
 async fn cas_update_message_cas_succeeds() {
     use openshell_core::proto::Sandbox;
 
-    let store = Store::connect("sqlite::memory:?cache=shared")
-        .await
-        .unwrap();
+    let store = test_store().await;
 
     // Create a sandbox
     let sandbox = Sandbox {
@@ -1342,11 +1280,7 @@ async fn cas_update_message_cas_conflicts_on_concurrent_updates() {
     use openshell_core::proto::Sandbox;
     use std::sync::Arc;
 
-    let store = Arc::new(
-        Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap(),
-    );
+    let store = Arc::new(test_store().await);
 
     // Create a sandbox
     let sandbox = Sandbox {

--- a/crates/openshell-server/src/provider_refresh.rs
+++ b/crates/openshell-server/src/provider_refresh.rs
@@ -786,6 +786,12 @@ mod tests {
     use wiremock::matchers::{body_string_contains, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    async fn test_store() -> Store {
+        Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("in-memory SQLite store should connect")
+    }
+
     #[test]
     fn refresh_state_name_preserves_distinct_credential_keys() {
         let provider_id = "provider-id";
@@ -846,9 +852,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
         let provider = provider("my-graph", "outlook");
         store.put_message(&provider).await.unwrap();
         let before_refresh_ms = crate::persistence::current_time_ms();
@@ -909,9 +913,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
         let mut provider_a = provider("existing-graph", "outlook");
         provider_a.credentials.insert(
             "MS_GRAPH_ACCESS_TOKEN".to_string(),
@@ -1002,9 +1004,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
         let provider = provider("my-delegated-graph", "outlook");
         store.put_message(&provider).await.unwrap();
         let state = new_refresh_state(
@@ -1083,9 +1083,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
         let provider = provider("my-drive", "google-drive");
         store.put_message(&provider).await.unwrap();
         let state = new_refresh_state(
@@ -1131,9 +1129,7 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_worker_skips_non_gateway_mintable_strategies() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
         let provider = provider("my-external", "outlook");
         store.put_message(&provider).await.unwrap();
         let state = new_refresh_state(

--- a/crates/openshell-server/src/ssh_sessions.rs
+++ b/crates/openshell-server/src/ssh_sessions.rs
@@ -83,6 +83,12 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    async fn test_store() -> Store {
+        Store::connect("sqlite::memory:?cache=shared")
+            .await
+            .expect("in-memory SQLite store should connect")
+    }
+
     fn make_session(id: &str, sandbox_id: &str, expires_at_ms: i64, revoked: bool) -> SshSession {
         SshSession {
             metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
@@ -105,9 +111,7 @@ mod tests {
 
     #[tokio::test]
     async fn reaper_deletes_expired_sessions() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let expired = make_session("expired1", "sbx1", now_ms() - 60_000, false);
         store.put_message(&expired).await.unwrap();
@@ -137,9 +141,7 @@ mod tests {
 
     #[tokio::test]
     async fn reaper_deletes_revoked_sessions() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let revoked = make_session("revoked1", "sbx1", 0, true);
         store.put_message(&revoked).await.unwrap();
@@ -169,9 +171,7 @@ mod tests {
 
     #[tokio::test]
     async fn reaper_preserves_zero_expiry_sessions() {
-        let store = Store::connect("sqlite::memory:?cache=shared")
-            .await
-            .unwrap();
+        let store = test_store().await;
 
         let no_expiry = make_session("noexpiry1", "sbx1", 0, false);
         store.put_message(&no_expiry).await.unwrap();

--- a/crates/openshell-server/src/supervisor_session.rs
+++ b/crates/openshell-server/src/supervisor_session.rs
@@ -786,6 +786,14 @@ mod tests {
     use crate::persistence::Store;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+    async fn test_store() -> Arc<Store> {
+        Arc::new(
+            Store::connect("sqlite::memory:?cache=shared")
+                .await
+                .expect("in-memory SQLite store should connect"),
+        )
+    }
+
     /// Returns a shutdown sender with its receiver immediately dropped. Tests
     /// that don't observe the shutdown signal can use this to satisfy the
     /// `register` signature without the receiver noise.
@@ -1200,11 +1208,7 @@ mod tests {
 
     #[tokio::test]
     async fn require_persisted_sandbox_rejects_missing_sandbox() {
-        let store = Arc::new(
-            Store::connect("sqlite::memory:?cache=shared")
-                .await
-                .unwrap(),
-        );
+        let store = test_store().await;
 
         let err = require_persisted_sandbox(&store, "missing")
             .await
@@ -1215,11 +1219,7 @@ mod tests {
 
     #[tokio::test]
     async fn require_persisted_sandbox_accepts_existing_sandbox() {
-        let store = Arc::new(
-            Store::connect("sqlite::memory:?cache=shared")
-                .await
-                .unwrap(),
-        );
+        let store = test_store().await;
         store
             .put_message(&sandbox_record("sbx-1", "sandbox-one"))
             .await

--- a/crates/openshell-server/tests/common/mod.rs
+++ b/crates/openshell-server/tests/common/mod.rs
@@ -557,3 +557,41 @@ pub async fn start_test_server(
 
     (addr, handle)
 }
+
+/// Rogue PKI bundle: client cert + key not signed by the server's CA.
+pub struct RoguePkiBundle {
+    pub client_cert_pem: String,
+    pub client_key_pem: String,
+}
+
+/// Generate a rogue CA and a client certificate signed by that CA.
+///
+/// Used to verify that the server rejects mTLS connections from clients whose
+/// certificate chain does not trace back to the trusted CA.
+pub fn generate_rogue_pki() -> RoguePkiBundle {
+    let mut rogue_ca_params =
+        CertificateParams::new(Vec::<String>::new()).expect("failed to create rogue CA params");
+    rogue_ca_params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    rogue_ca_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "rogue-ca");
+    let rogue_ca_key = KeyPair::generate().expect("failed to generate rogue CA key");
+    let rogue_ca_cert = rogue_ca_params
+        .self_signed(&rogue_ca_key)
+        .expect("failed to sign rogue CA cert");
+
+    let mut rogue_client_params =
+        CertificateParams::new(Vec::<String>::new()).expect("failed to create rogue client params");
+    rogue_client_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "rogue-client");
+    let rogue_client_key = KeyPair::generate().expect("failed to generate rogue client key");
+    let rogue_client_cert = rogue_client_params
+        .signed_by(&rogue_client_key, &rogue_ca_cert, &rogue_ca_key)
+        .expect("failed to sign rogue client cert");
+
+    RoguePkiBundle {
+        client_cert_pem: rogue_client_cert.pem(),
+        client_key_pem: rogue_client_key.serialize_pem(),
+    }
+}

--- a/crates/openshell-server/tests/edge_tunnel_auth.rs
+++ b/crates/openshell-server/tests/edge_tunnel_auth.rs
@@ -27,14 +27,15 @@
 mod common;
 
 use bytes::Bytes;
-use common::{PkiBundle, generate_pki, install_rustls_provider, start_test_server};
+use common::{
+    PkiBundle, generate_pki, generate_rogue_pki, install_rustls_provider, start_test_server,
+};
 use http_body_util::Empty;
 use hyper::{Request, StatusCode};
 use hyper_rustls::HttpsConnectorBuilder;
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 use openshell_core::proto::{HealthRequest, ServiceStatus, open_shell_client::OpenShellClient};
 use openshell_server::TlsAcceptor;
-use rcgen::{CertificateParams, IsCa, KeyPair};
 use rustls::RootCertStore;
 use rustls::pki_types::CertificateDer;
 use rustls_pemfile::certs;
@@ -321,32 +322,11 @@ async fn rogue_cert_rejected() {
     let (addr, server) = start_test_server(tls_acceptor).await;
 
     // Generate a rogue CA + client cert
-    let mut rogue_ca_params =
-        CertificateParams::new(Vec::<String>::new()).expect("failed to create rogue CA params");
-    rogue_ca_params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
-    rogue_ca_params
-        .distinguished_name
-        .push(rcgen::DnType::CommonName, "rogue-ca");
-    let rogue_ca_key = KeyPair::generate().expect("failed to generate rogue CA key");
-    let rogue_ca_cert = rogue_ca_params
-        .self_signed(&rogue_ca_key)
-        .expect("failed to sign rogue CA cert");
-
-    let mut rogue_client_params =
-        CertificateParams::new(Vec::<String>::new()).expect("failed to create rogue client params");
-    rogue_client_params
-        .distinguished_name
-        .push(rcgen::DnType::CommonName, "rogue-client");
-    let rogue_client_key = KeyPair::generate().expect("failed to generate rogue client key");
-    let rogue_client_cert = rogue_client_params
-        .signed_by(&rogue_client_key, &rogue_ca_cert, &rogue_ca_key)
-        .expect("failed to sign rogue client cert");
+    let rogue = generate_rogue_pki();
 
     let ca_cert = tonic::transport::Certificate::from_pem(pki.ca_cert_pem.clone());
-    let identity = tonic::transport::Identity::from_pem(
-        rogue_client_cert.pem(),
-        rogue_client_key.serialize_pem(),
-    );
+    let identity =
+        tonic::transport::Identity::from_pem(rogue.client_cert_pem, rogue.client_key_pem);
     let tls = ClientTlsConfig::new()
         .ca_certificate(ca_cert)
         .identity(identity)

--- a/crates/openshell-server/tests/multiplex_tls_integration.rs
+++ b/crates/openshell-server/tests/multiplex_tls_integration.rs
@@ -4,14 +4,15 @@
 mod common;
 
 use bytes::Bytes;
-use common::{PkiBundle, generate_pki, install_rustls_provider, start_test_server};
+use common::{
+    PkiBundle, generate_pki, generate_rogue_pki, install_rustls_provider, start_test_server,
+};
 use http_body_util::Empty;
 use hyper::Request;
 use hyper::StatusCode;
 use hyper_rustls::HttpsConnectorBuilder;
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 use openshell_core::proto::{HealthRequest, ServiceStatus, open_shell_client::OpenShellClient};
-use rcgen::{CertificateParams, IsCa, KeyPair};
 use rustls::RootCertStore;
 use rustls::pki_types::CertificateDer;
 use rustls_pemfile::certs;
@@ -240,33 +241,12 @@ async fn mtls_wrong_ca_client_cert_rejected() {
     let (addr, server) = start_test_server(tls_acceptor).await;
 
     // Generate a rogue CA + client cert not signed by the server's CA.
-    let mut rogue_ca_params =
-        CertificateParams::new(Vec::<String>::new()).expect("failed to create rogue CA params");
-    rogue_ca_params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
-    rogue_ca_params
-        .distinguished_name
-        .push(rcgen::DnType::CommonName, "rogue-ca");
-    let rogue_ca_key = KeyPair::generate().expect("failed to generate rogue CA key");
-    let rogue_ca_cert = rogue_ca_params
-        .self_signed(&rogue_ca_key)
-        .expect("failed to sign rogue CA cert");
-
-    let mut rogue_client_params =
-        CertificateParams::new(Vec::<String>::new()).expect("failed to create rogue client params");
-    rogue_client_params
-        .distinguished_name
-        .push(rcgen::DnType::CommonName, "rogue-client");
-    let rogue_client_key = KeyPair::generate().expect("failed to generate rogue client key");
-    let rogue_client_cert = rogue_client_params
-        .signed_by(&rogue_client_key, &rogue_ca_cert, &rogue_ca_key)
-        .expect("failed to sign rogue client cert");
+    let rogue = generate_rogue_pki();
 
     // Connect with rogue client cert -- server should reject it.
     let ca_cert = tonic::transport::Certificate::from_pem(pki.ca_cert_pem.clone());
-    let identity = tonic::transport::Identity::from_pem(
-        rogue_client_cert.pem(),
-        rogue_client_key.serialize_pem(),
-    );
+    let identity =
+        tonic::transport::Identity::from_pem(rogue.client_cert_pem, rogue.client_key_pem);
     let tls = ClientTlsConfig::new()
         .ca_certificate(ca_cert)
         .identity(identity)

--- a/crates/openshell-tui/src/ui/create_provider.rs
+++ b/crates/openshell-tui/src/ui/create_provider.rs
@@ -8,6 +8,8 @@ use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph};
 
 use crate::app::{App, CreateProviderPhase, ProviderKeyField};
 
+use super::centered_rect;
+
 /// Draw the create provider modal overlay.
 pub fn draw(frame: &mut Frame<'_>, app: &App, area: Rect) {
     let t = &app.theme;
@@ -742,24 +744,4 @@ fn draw_secret_field(
         Line::from(Span::styled(format!("  {masked}"), t.muted))
     };
     frame.render_widget(Paragraph::new(display), chunks[1]);
-}
-
-fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
-    let vert = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length((area.height.saturating_sub(height)) / 2),
-            Constraint::Length(height),
-            Constraint::Min(0),
-        ])
-        .split(area);
-    let horiz = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Length((area.width.saturating_sub(width)) / 2),
-            Constraint::Length(width),
-            Constraint::Min(0),
-        ])
-        .split(vert[1]);
-    horiz[1]
 }

--- a/crates/openshell-tui/src/ui/create_sandbox.rs
+++ b/crates/openshell-tui/src/ui/create_sandbox.rs
@@ -8,6 +8,8 @@ use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph};
 
 use crate::app::{App, CreateFormField, CreatePhase};
 
+use super::centered_rect;
+
 /// Draw the create sandbox modal overlay.
 pub fn draw(frame: &mut Frame<'_>, app: &App, area: Rect) {
     let Some(form) = &app.create_form else {
@@ -417,24 +419,4 @@ fn draw_text_field(
         Line::from(Span::styled(format!("  {value}"), t.text))
     };
     frame.render_widget(Paragraph::new(display), chunks[1]);
-}
-
-fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
-    let vert = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length((area.height.saturating_sub(height)) / 2),
-            Constraint::Length(height),
-            Constraint::Min(0),
-        ])
-        .split(area);
-    let horiz = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Length((area.width.saturating_sub(width)) / 2),
-            Constraint::Length(width),
-            Constraint::Min(0),
-        ])
-        .split(vert[1]);
-    horiz[1]
 }

--- a/crates/openshell-tui/src/ui/mod.rs
+++ b/crates/openshell-tui/src/ui/mod.rs
@@ -453,6 +453,28 @@ fn draw_command_bar(frame: &mut Frame<'_>, app: &App, area: Rect) {
     frame.render_widget(bar, area);
 }
 
+/// Center a popup rectangle within `area` using absolute width and height (in
+/// terminal columns/rows).
+pub fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let vert = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length((area.height.saturating_sub(height)) / 2),
+            Constraint::Length(height),
+            Constraint::Min(0),
+        ])
+        .split(area);
+    let horiz = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length((area.width.saturating_sub(width)) / 2),
+            Constraint::Length(width),
+            Constraint::Min(0),
+        ])
+        .split(vert[1]);
+    horiz[1]
+}
+
 /// Center a popup rectangle within `area` using percentage-based width and
 /// an absolute height (in rows).
 pub fn centered_popup(percent_x: u16, height: u16, area: Rect) -> Rect {

--- a/crates/openshell-tui/src/ui/sandbox_draft.rs
+++ b/crates/openshell-tui/src/ui/sandbox_draft.rs
@@ -6,10 +6,12 @@
 use crate::app::App;
 use openshell_core::proto::PolicyChunk;
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::layout::Rect;
 use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph, Wrap};
+
+use super::centered_rect;
 
 /// Draw the network rules panel (list view with highlight bar).
 pub fn draw(frame: &mut Frame<'_>, app: &mut App, area: Rect) {
@@ -440,24 +442,4 @@ fn format_short_time(epoch_ms: i64) -> String {
     let minutes = (time_of_day % 3600) / 60;
     let seconds = time_of_day % 60;
     format!("{hours:02}:{minutes:02}:{seconds:02}")
-}
-
-fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
-    let vert = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length((area.height.saturating_sub(height)) / 2),
-            Constraint::Length(height),
-            Constraint::Min(0),
-        ])
-        .split(area);
-    let horiz = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Length((area.width.saturating_sub(width)) / 2),
-            Constraint::Length(width),
-            Constraint::Min(0),
-        ])
-        .split(vert[1]);
-    horiz[1]
 }

--- a/crates/openshell-tui/src/ui/sandbox_logs.rs
+++ b/crates/openshell-tui/src/ui/sandbox_logs.rs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph, Wrap};
 
 use crate::app::{App, LogLine};
+
+use super::centered_rect;
 
 pub fn draw(frame: &mut Frame<'_>, app: &mut App, area: Rect) {
     let t = &app.theme;
@@ -200,26 +202,6 @@ pub fn draw_detail_popup(
             .wrap(Wrap { trim: false }),
         popup_area,
     );
-}
-
-fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
-    let vert = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length((area.height.saturating_sub(height)) / 2),
-            Constraint::Length(height),
-            Constraint::Min(0),
-        ])
-        .split(area);
-    let horiz = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Length((area.width.saturating_sub(width)) / 2),
-            Constraint::Length(width),
-            Constraint::Min(0),
-        ])
-        .split(vert[1]);
-    horiz[1]
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/openshell-tui/src/ui/splash.rs
+++ b/crates/openshell-tui/src/ui/splash.rs
@@ -11,6 +11,8 @@ use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph};
 
+use super::centered_rect;
+
 // ---------------------------------------------------------------------------
 // ANSI Shadow figlet art — OPEN (6 lines, 35 display cols)
 // ---------------------------------------------------------------------------
@@ -116,24 +118,4 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, theme: &crate::theme::Theme) {
     ]);
 
     frame.render_widget(footer, chunks[2]);
-}
-
-fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
-    let vert = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length((area.height.saturating_sub(height)) / 2),
-            Constraint::Length(height),
-            Constraint::Min(0),
-        ])
-        .split(area);
-    let horiz = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Length((area.width.saturating_sub(width)) / 2),
-            Constraint::Length(width),
-            Constraint::Min(0),
-        ])
-        .split(vert[1]);
-    horiz[1]
 }


### PR DESCRIPTION
## Summary

Remove ~280 lines of duplicated code across 30 files by extracting repeated patterns into shared helpers and a macro.

## Related Issue

N/A

## Changes

- **`centered_rect` (TUI):** 5 byte-for-byte identical 20-line layout helpers in `openshell-tui/src/ui/` consolidated into a single `pub fn centered_rect` in `mod.rs`
- **Server test helpers:** ~100 inline `Store::connect("sqlite::memory:?cache=shared").await.unwrap()` calls replaced with local `async fn test_store()` helpers per test module; duplicate `test_server_state()` in `grpc/service.rs` removed in favour of the shared `test_support` version
- **Rogue PKI:** identical 20-line rogue CA + client cert generation block duplicated in two integration tests extracted into `generate_rogue_pki()` + `RoguePkiBundle` in `tests/common/mod.rs`
- **Provider tests:** 8 identical 28-line `#[cfg(test)] mod tests { ... }` blocks replaced with a `macro_rules! test_discovers_env_credential!` invocation (macro defined in `providers/mod.rs`)
- **Label constants:** `openshell.ai/managed-by`, `openshell.ai/sandbox-id`, `openshell.ai/sandbox-name`, `openshell.ai/sandbox-namespace` constants centralised in `openshell-core::driver_utils`; duplicate private `const` definitions removed from `openshell-driver-docker` and `openshell-driver-kubernetes`

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [ ] Commits are signed off (DCO)