### PR TITLE
ci(e2e): load single-arch images into kind

### DIFF
--- a/.github/workflows/e2e-kubernetes-test.yml
+++ b/.github/workflows/e2e-kubernetes-test.yml
@@ -84,8 +84,10 @@ jobs:
           set -euo pipefail
           for component in gateway supervisor; do
             image="ghcr.io/nvidia/openshell/${component}:${{ inputs.image-tag }}"
+            archive="${RUNNER_TEMP:-/tmp}/openshell-${component}-linux-amd64.tar"
             docker pull --platform linux/amd64 "$image"
-            kind load docker-image "$image" --name "$KIND_CLUSTER_NAME"
+            docker image save --platform linux/amd64 --output "$archive" "$image"
+            kind load image-archive "$archive" --name "$KIND_CLUSTER_NAME"
           done
 
       - name: Run Kubernetes E2E (Rust smoke)


### PR DESCRIPTION
## Summary

Load Kubernetes E2E images into kind from explicit single-platform archives. This avoids the `kind load docker-image` path importing a multi-arch tag with `ctr --all-platforms --digests` after only the `linux/amd64` image content was pulled locally.

## Related Issue

N/A

Related to the Kubernetes E2E failure observed on PR #1516:
https://github.com/NVIDIA/OpenShell/actions/runs/26269734764/job/77321344877

## Changes

- Keep pulling the gateway and supervisor images as `linux/amd64`.
- Save each image as a `linux/amd64` Docker archive.
- Load those archives into the kind node with `kind load image-archive`.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
  - Requested with the `test:e2e` label.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
