### PR TITLE
ci(canary): keep helm jwt secret generation enabled

### DIFF
--- a/.agents/skills/test-release-canary/SKILL.md
+++ b/.agents/skills/test-release-canary/SKILL.md
@@ -83,7 +83,6 @@ helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart \
   --version 0.0.0-dev \
   --namespace openshell --create-namespace \
   --set server.disableTls=true \
-  --set pkiInitJob.enabled=false \
   --wait --timeout 5m
 
 kubectl wait --namespace openshell \
@@ -95,6 +94,10 @@ kubectl port-forward --namespace openshell svc/openshell 8080:8080 &
 openshell gateway add http://127.0.0.1:8080 --local --name kind
 openshell status
 ```
+
+Keep `pkiInitJob.enabled=true` (the chart default), even when
+`server.disableTls=true`. The hook also generates the sandbox JWT signing
+secret that the gateway pod always mounts.
 
 Swap `0.0.0-dev` for `0.0.0-dev.<sha>` to pin to a specific dev build. Tear down with `kind delete cluster --name release-canary-local`.
 

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -99,7 +99,6 @@ jobs:
             --version 0.0.0-dev \
             --namespace "$RELEASE_NAMESPACE" --create-namespace \
             --set server.disableTls=true \
-            --set pkiInitJob.enabled=false \
             --wait --timeout 5m
 
       - name: Verify gateway pod is Ready


### PR DESCRIPTION
## Summary

Fix the Release Canary Kubernetes Helm job by keeping the chart's PKI/JWT init hook enabled. TLS remains disabled for the canary, but the gateway pod still mounts the sandbox JWT signing secret generated by that hook.

## Related Issue

N/A

Related failed run: https://github.com/NVIDIA/OpenShell/actions/runs/26263108448

## Changes

- Remove the `--set pkiInitJob.enabled=false` override from the Release Canary Helm install.
- Update the `test-release-canary` skill's local kind reproduction notes to keep the hook enabled when TLS is disabled.

## Testing

- [x] `git diff --check`
- [ ] `mise run pre-commit` passes
  - Skipped at maintainer request for this workflow-only fix.
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
  - Not applicable; this updates the release canary workflow itself.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
