### PR TITLE
fix(sandbox): restore GPU procfs baseline

### DIFF
--- a/architecture/security-policy.md
+++ b/architecture/security-policy.md
@@ -21,6 +21,13 @@ For the field-by-field YAML reference, use
 Filesystem and process policy are startup-time controls. Network policy is
 dynamic and can be hot-reloaded when the new policy validates successfully.
 
+Before applying Landlock, the supervisor enriches baseline filesystem paths that
+the runtime needs. Missing baseline paths are skipped so one absent runtime path
+does not weaken the whole ruleset. When GPU devices are present, GPU baseline
+enrichment adds existing GPU device nodes as read-write paths and promotes
+`/proc` to read-write because CUDA workloads write thread metadata under
+`/proc/<pid>/task/<tid>/comm`.
+
 ## Network Decisions
 
 Ordinary network traffic follows this order:

--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -1556,7 +1556,7 @@ where
         }
     }
     for path in rw {
-        if fs.read_only.iter().any(|p| p == path) || fs.read_write.iter().any(|p| p == path) {
+        if fs.read_write.iter().any(|p| p == path) {
             continue;
         }
         if !path_exists(path) {
@@ -1564,6 +1564,18 @@ where
                 path,
                 "Baseline read-write path does not exist, skipping enrichment"
             );
+            continue;
+        }
+        if fs.read_only.iter().any(|p| p == path) {
+            if path == "/proc" {
+                info!(
+                    path,
+                    "Promoting /proc from read-only to read-write for GPU runtime compatibility"
+                );
+                fs.read_only.retain(|p| p != path);
+                fs.read_write.push(path.clone());
+                modified = true;
+            }
             continue;
         }
         fs.read_write.push(path.clone());
@@ -1769,7 +1781,7 @@ mod baseline_tests {
     }
 
     #[test]
-    fn proto_gpu_enrichment_adds_devices_without_network_policy() {
+    fn proto_gpu_enrichment_promotes_proc_without_network_policy() {
         let mut policy = openshell_policy::restrictive_default_policy();
         assert!(
             policy.network_policies.is_empty(),
@@ -1790,6 +1802,14 @@ mod baseline_tests {
         assert!(
             filesystem.read_write.contains(&"/dev/nvidia0".to_string()),
             "GPU enrichment should add enumerated device nodes without network policies"
+        );
+        assert!(
+            !filesystem.read_only.contains(&"/proc".to_string()),
+            "GPU enrichment should remove /proc from read_only"
+        );
+        assert!(
+            filesystem.read_write.contains(&"/proc".to_string()),
+            "GPU enrichment should promote /proc to read_write"
         );
     }
 

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -62,6 +62,8 @@ Raw streams are connection-scoped and outside L7 live-reload guarantees. This in
 
 When a sandbox runs in proxy mode (the default), OpenShell automatically adds baseline filesystem paths required for the sandbox child process to function: `/usr`, `/lib`, `/etc`, `/var/log` (read-only) and `/sandbox`, `/tmp` (read-write). Paths like `/app` are included in the baseline set but are only added if they exist in the container image.
 
+For GPU sandboxes, OpenShell also adds existing GPU device nodes as read-write paths. CUDA workloads require write access to procfs for thread metadata, so GPU baseline enrichment moves `/proc` from read-only to read-write when GPU devices are present.
+
 This filtering prevents a missing baseline path from degrading Landlock enforcement. Without it, a single missing path could cause the entire Landlock ruleset to fail, leaving the sandbox with no filesystem restrictions at all.
 
 User-specified paths in your policy YAML are not pre-filtered. If you list a path that does not exist:


### PR DESCRIPTION
## Summary

Restore CUDA GPU startup compatibility by promoting `/proc` from
`filesystem_policy.read_only` to `filesystem_policy.read_write` when `/proc`
is part of the active GPU runtime baseline.

This keeps the change intentionally narrow. The existing baseline enrichment
already places `/proc` in the GPU read-write baseline because CUDA writes
`/proc/<pid>/task/<tid>/comm` during initialization. The missing behavior was
that an existing read-only `/proc` entry caused enrichment to skip the
read-write baseline path. This PR restores that promotion and emits an
informational log message when it happens.

Broader handling for user-supplied policy conflicts and explicit baseline
conflict controls is left to follow-up work such as #1629.

## Related Issue

Fixes #1486

Related follow-up: #1629

## Changes

- Promote `/proc` from `read_only` to `read_write` when the GPU read-write
  baseline requires it.
- Preserve existing behavior for other read-only/read-write baseline conflicts.
- Emit an informational log when `/proc` is promoted for GPU runtime
  compatibility.
- Add a regression test covering GPU baseline enrichment without network
  policy.

## Testing

- [x] `mise exec -- cargo fmt --all`
- [x] `mise exec -- cargo test -p openshell-sandbox --lib baseline_tests -- --nocapture`
- [x] `mise run pre-commit` completed Helm lint, Rust format, Rust check, Rust clippy, markdown lint, and license checks; `python:proto` failed in the parallel run because `grpc_tools` was missing after `.venv` recreation.
- [x] `mise run python:proto`

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture/docs updated (not applicable for this minimal runtime fix)
