### PR TITLE
refactor: deduplicate shared code across ocsf builders and driver crates

### DIFF
--- a/crates/openshell-core/src/driver_utils.rs
+++ b/crates/openshell-core/src/driver_utils.rs
@@ -3,7 +3,9 @@
 
 //! Utility helpers shared across compute-driver crates.
 
-use crate::proto::compute::v1::DriverSandbox;
+use std::path::PathBuf;
+
+use crate::proto::compute::v1::{DriverSandbox, GetCapabilitiesResponse};
 
 // ---------------------------------------------------------------------------
 // Sandbox container/pod label keys (openshell.ai/ namespace)
@@ -33,6 +35,50 @@ pub const LABEL_SANDBOX_NAMESPACE: &str = "openshell.ai/sandbox-namespace";
 /// start the sandboxed environment.  The value must be kept in sync with the
 /// path used when building the `openshell-sandbox` image layer.
 pub const SUPERVISOR_IMAGE_BINARY_PATH: &str = "/openshell-sandbox";
+
+/// Return the XDG state path for a driver's sandbox JWT token file.
+///
+/// The resulting path is `$XDG_STATE_HOME/openshell/<driver_subdir>[/<namespace>]/<sandbox_id>/sandbox.jwt`.
+///
+/// `driver_subdir` is driver-specific, e.g. `"docker-sandbox-tokens"` or
+/// `"podman-sandbox-tokens"`.  When `namespace` is `Some`, it is appended as
+/// an additional path component (with `/` and `\` replaced by `-`).
+///
+/// # Errors
+/// Returns an error if the XDG state directory cannot be resolved.
+pub fn sandbox_token_path(
+    driver_subdir: &str,
+    namespace: Option<&str>,
+    sandbox_id: &str,
+) -> miette::Result<PathBuf> {
+    let mut path = crate::paths::xdg_state_dir()?
+        .join("openshell")
+        .join(driver_subdir);
+    if let Some(ns) = namespace {
+        path = path.join(ns.replace(['/', '\\'], "-"));
+    }
+    Ok(path.join(sandbox_id).join("sandbox.jwt"))
+}
+
+/// Build a [`GetCapabilitiesResponse`] from the common driver capability fields.
+///
+/// Every compute driver constructs this response with the same fields. Shared
+/// here to avoid repeating the struct literal (and the always-zero `gpu_count`
+/// default) in each driver crate.
+pub fn build_capabilities_response(
+    driver_name: &str,
+    driver_version: impl Into<String>,
+    default_image: impl Into<String>,
+    supports_gpu: bool,
+) -> GetCapabilitiesResponse {
+    GetCapabilitiesResponse {
+        driver_name: driver_name.to_string(),
+        driver_version: driver_version.into(),
+        default_image: default_image.into(),
+        supports_gpu,
+        gpu_count: 0,
+    }
+}
 
 /// Return the effective log level for a sandbox.
 ///

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -320,13 +320,12 @@ impl DockerComputeDriver {
     }
 
     fn capabilities(&self) -> GetCapabilitiesResponse {
-        GetCapabilitiesResponse {
-            driver_name: "docker".to_string(),
-            driver_version: self.config.daemon_version.clone(),
-            default_image: self.config.default_image.clone(),
-            supports_gpu: self.config.supports_gpu,
-            gpu_count: 0,
-        }
+        openshell_core::driver_utils::build_capabilities_response(
+            "docker",
+            &self.config.daemon_version,
+            &self.config.default_image,
+            self.config.supports_gpu,
+        )
     }
 
     fn validate_sandbox(
@@ -962,17 +961,16 @@ fn sandbox_token_host_path_by_id(
     sandbox_id: &str,
     config: &DockerDriverRuntimeConfig,
 ) -> Result<PathBuf, Status> {
-    let base = openshell_core::paths::xdg_state_dir().map_err(|err| {
+    openshell_core::driver_utils::sandbox_token_path(
+        "docker-sandbox-tokens",
+        Some(&config.sandbox_namespace),
+        sandbox_id,
+    )
+    .map_err(|err| {
         Status::internal(format!(
             "resolve sandbox token state directory failed: {err}"
         ))
-    })?;
-    Ok(base
-        .join("openshell")
-        .join("docker-sandbox-tokens")
-        .join(config.sandbox_namespace.replace(['/', '\\'], "-"))
-        .join(sandbox_id)
-        .join("sandbox.jwt"))
+    })
 }
 
 async fn write_sandbox_token_file(

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -160,13 +160,12 @@ impl KubernetesComputeDriver {
     }
 
     pub async fn capabilities(&self) -> Result<GetCapabilitiesResponse, String> {
-        Ok(GetCapabilitiesResponse {
-            driver_name: "kubernetes".to_string(),
-            driver_version: openshell_core::VERSION.to_string(),
-            default_image: self.config.default_image.clone(),
-            supports_gpu: self.has_gpu_capacity().await.unwrap_or(false),
-            gpu_count: 0,
-        })
+        Ok(openshell_core::driver_utils::build_capabilities_response(
+            "kubernetes",
+            openshell_core::VERSION,
+            &self.config.default_image,
+            self.has_gpu_capacity().await.unwrap_or(false),
+        ))
     }
 
     pub fn default_image(&self) -> &str {

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -57,13 +57,8 @@ fn validated_container_name(sandbox_name: &str) -> Result<String, ComputeDriverE
 }
 
 fn sandbox_token_host_path(sandbox_id: &str) -> Result<PathBuf, ComputeDriverError> {
-    let base = openshell_core::paths::xdg_state_dir()
-        .map_err(|err| ComputeDriverError::Message(format!("resolve state dir failed: {err}")))?;
-    Ok(base
-        .join("openshell")
-        .join("podman-sandbox-tokens")
-        .join(sandbox_id)
-        .join("sandbox.jwt"))
+    openshell_core::driver_utils::sandbox_token_path("podman-sandbox-tokens", None, sandbox_id)
+        .map_err(|err| ComputeDriverError::Message(format!("resolve state dir failed: {err}")))
 }
 
 async fn write_sandbox_token_file(
@@ -257,14 +252,12 @@ impl PodmanComputeDriver {
 
     /// Report driver capabilities.
     pub fn capabilities(&self) -> Result<GetCapabilitiesResponse, ComputeDriverError> {
-        let supports_gpu = Self::has_gpu_capacity();
-        Ok(GetCapabilitiesResponse {
-            driver_name: "podman".to_string(),
-            driver_version: openshell_core::VERSION.to_string(),
-            default_image: self.config.default_image.clone(),
-            supports_gpu,
-            gpu_count: 0,
-        })
+        Ok(openshell_core::driver_utils::build_capabilities_response(
+            "podman",
+            openshell_core::VERSION,
+            &self.config.default_image,
+            Self::has_gpu_capacity(),
+        ))
     }
 
     #[must_use]

--- a/crates/openshell-ocsf/src/builders/base.rs
+++ b/crates/openshell-ocsf/src/builders/base.rs
@@ -32,21 +32,6 @@ impl<'a> BaseEventBuilder<'a> {
     }
 
     #[must_use]
-    pub fn severity(mut self, id: SeverityId) -> Self {
-        self.severity = id;
-        self
-    }
-    #[must_use]
-    pub fn status(mut self, id: StatusId) -> Self {
-        self.status = Some(id);
-        self
-    }
-    #[must_use]
-    pub fn message(mut self, msg: impl Into<String>) -> Self {
-        self.message = Some(msg.into());
-        self
-    }
-    #[must_use]
     pub fn activity_name(mut self, name: impl Into<String>) -> Self {
         self.activity_name = Some(name.into());
         self
@@ -72,21 +57,17 @@ impl<'a> BaseEventBuilder<'a> {
             self.severity,
             self.ctx.metadata(&["container", "host"]),
         );
-        if let Some(status) = self.status {
-            base.set_status(status);
-        }
-        if let Some(msg) = self.message {
-            base.set_message(msg);
-        }
-        base.set_device(self.ctx.device());
-        base.set_container(self.ctx.container());
         if !self.unmapped.is_empty() {
             base.unmapped = Some(serde_json::Value::Object(self.unmapped));
         }
+        self.ctx
+            .apply_common_fields(&mut base, self.status, self.message);
 
         OcsfEvent::Base(BaseEvent { base })
     }
 }
+
+impl_builder_setters!(BaseEventBuilder);
 
 #[cfg(test)]
 mod tests {

--- a/crates/openshell-ocsf/src/builders/config.rs
+++ b/crates/openshell-ocsf/src/builders/config.rs
@@ -37,22 +37,6 @@ impl<'a> ConfigStateChangeBuilder<'a> {
         }
     }
 
-    #[must_use]
-    pub fn severity(mut self, id: SeverityId) -> Self {
-        self.severity = id;
-        self
-    }
-    #[must_use]
-    pub fn status(mut self, id: StatusId) -> Self {
-        self.status = Some(id);
-        self
-    }
-    #[must_use]
-    pub fn message(mut self, msg: impl Into<String>) -> Self {
-        self.message = Some(msg.into());
-        self
-    }
-
     /// Set state with a custom label (OCSF `state_id` + display label).
     #[must_use]
     pub fn state(mut self, id: StateId, label: &str) -> Self {
@@ -92,17 +76,11 @@ impl<'a> ConfigStateChangeBuilder<'a> {
             self.ctx
                 .metadata(&["security_control", "container", "host"]),
         );
-        if let Some(status) = self.status {
-            base.set_status(status);
-        }
-        if let Some(msg) = self.message {
-            base.set_message(msg);
-        }
-        base.set_device(self.ctx.device());
-        base.set_container(self.ctx.container());
         if !self.unmapped.is_empty() {
             base.unmapped = Some(serde_json::Value::Object(self.unmapped));
         }
+        self.ctx
+            .apply_common_fields(&mut base, self.status, self.message);
 
         OcsfEvent::DeviceConfigStateChange(DeviceConfigStateChangeEvent {
             base,
@@ -113,6 +91,8 @@ impl<'a> ConfigStateChangeBuilder<'a> {
         })
     }
 }
+
+impl_builder_setters!(ConfigStateChangeBuilder);
 
 #[cfg(test)]
 mod tests {

--- a/crates/openshell-ocsf/src/builders/finding.rs
+++ b/crates/openshell-ocsf/src/builders/finding.rs
@@ -54,11 +54,6 @@ impl<'a> DetectionFindingBuilder<'a> {
         self
     }
     #[must_use]
-    pub fn severity(mut self, id: SeverityId) -> Self {
-        self.severity = id;
-        self
-    }
-    #[must_use]
     pub fn action(mut self, id: ActionId) -> Self {
         self.action = Some(id);
         self
@@ -86,11 +81,6 @@ impl<'a> DetectionFindingBuilder<'a> {
     #[must_use]
     pub fn risk_level(mut self, id: RiskLevelId) -> Self {
         self.risk_level = Some(id);
-        self
-    }
-    #[must_use]
-    pub fn message(mut self, msg: impl Into<String>) -> Self {
-        self.message = Some(msg.into());
         self
     }
     #[must_use]
@@ -147,11 +137,7 @@ impl<'a> DetectionFindingBuilder<'a> {
             self.severity,
             metadata,
         );
-        if let Some(msg) = self.message {
-            base.set_message(msg);
-        }
-        base.set_device(self.ctx.device());
-        base.set_container(self.ctx.container());
+        self.ctx.apply_common_fields(&mut base, None, self.message);
 
         OcsfEvent::DetectionFinding(DetectionFindingEvent {
             base,
@@ -177,6 +163,8 @@ impl<'a> DetectionFindingBuilder<'a> {
         })
     }
 }
+
+impl_builder_setters!(DetectionFindingBuilder, no_status);
 
 #[cfg(test)]
 mod tests {

--- a/crates/openshell-ocsf/src/builders/http.rs
+++ b/crates/openshell-ocsf/src/builders/http.rs
@@ -64,16 +64,6 @@ impl<'a> HttpActivityBuilder<'a> {
         self
     }
     #[must_use]
-    pub fn severity(mut self, id: SeverityId) -> Self {
-        self.severity = id;
-        self
-    }
-    #[must_use]
-    pub fn status(mut self, id: StatusId) -> Self {
-        self.status = Some(id);
-        self
-    }
-    #[must_use]
     pub fn http_request(mut self, req: HttpRequest) -> Self {
         self.http_request = Some(req);
         self
@@ -104,11 +94,6 @@ impl<'a> HttpActivityBuilder<'a> {
         self
     }
     #[must_use]
-    pub fn message(mut self, msg: impl Into<String>) -> Self {
-        self.message = Some(msg.into());
-        self
-    }
-    #[must_use]
     pub fn status_detail(mut self, detail: impl Into<String>) -> Self {
         self.status_detail = Some(detail.into());
         self
@@ -128,17 +113,11 @@ impl<'a> HttpActivityBuilder<'a> {
             self.ctx
                 .metadata(&["security_control", "network_proxy", "container", "host"]),
         );
-        if let Some(status) = self.status {
-            base.set_status(status);
-        }
-        if let Some(msg) = self.message {
-            base.set_message(msg);
-        }
         if let Some(detail) = self.status_detail {
             base.set_status_detail(detail);
         }
-        base.set_device(self.ctx.device());
-        base.set_container(self.ctx.container());
+        self.ctx
+            .apply_common_fields(&mut base, self.status, self.message);
 
         OcsfEvent::HttpActivity(HttpActivityEvent {
             base,
@@ -156,6 +135,8 @@ impl<'a> HttpActivityBuilder<'a> {
         })
     }
 }
+
+impl_builder_setters!(HttpActivityBuilder);
 
 #[cfg(test)]
 mod tests {

--- a/crates/openshell-ocsf/src/builders/lifecycle.rs
+++ b/crates/openshell-ocsf/src/builders/lifecycle.rs
@@ -35,21 +35,6 @@ impl<'a> AppLifecycleBuilder<'a> {
         self.activity = id;
         self
     }
-    #[must_use]
-    pub fn severity(mut self, id: SeverityId) -> Self {
-        self.severity = id;
-        self
-    }
-    #[must_use]
-    pub fn status(mut self, id: StatusId) -> Self {
-        self.status = Some(id);
-        self
-    }
-    #[must_use]
-    pub fn message(mut self, msg: impl Into<String>) -> Self {
-        self.message = Some(msg.into());
-        self
-    }
 
     #[must_use]
     pub fn build(self) -> OcsfEvent {
@@ -64,14 +49,8 @@ impl<'a> AppLifecycleBuilder<'a> {
             self.severity,
             self.ctx.metadata(&["container", "host"]),
         );
-        if let Some(status) = self.status {
-            base.set_status(status);
-        }
-        if let Some(msg) = self.message {
-            base.set_message(msg);
-        }
-        base.set_device(self.ctx.device());
-        base.set_container(self.ctx.container());
+        self.ctx
+            .apply_common_fields(&mut base, self.status, self.message);
 
         OcsfEvent::ApplicationLifecycle(ApplicationLifecycleEvent {
             base,
@@ -79,6 +58,8 @@ impl<'a> AppLifecycleBuilder<'a> {
         })
     }
 }
+
+impl_builder_setters!(AppLifecycleBuilder);
 
 #[cfg(test)]
 mod tests {

--- a/crates/openshell-ocsf/src/builders/mod.rs
+++ b/crates/openshell-ocsf/src/builders/mod.rs
@@ -6,6 +6,55 @@
 //! Each event class has a builder that takes a `SandboxContext` reference
 //! and provides chainable methods for setting event fields.
 
+/// Generate the shared `severity`, `status`, and `message` setter methods that
+/// appear identically on every OCSF event builder in this crate.
+///
+/// # Usage
+/// ```ignore
+/// impl_builder_setters!(MyBuilder);            // severity + status + message
+/// impl_builder_setters!(MyBuilder, no_status); // severity + message only
+/// ```
+macro_rules! impl_builder_setters {
+    ($builder:ident) => {
+        impl<'a> $builder<'a> {
+            /// Set the event severity.
+            #[must_use]
+            pub fn severity(mut self, id: $crate::enums::SeverityId) -> Self {
+                self.severity = id;
+                self
+            }
+            /// Set the overall event status.
+            #[must_use]
+            pub fn status(mut self, id: $crate::enums::StatusId) -> Self {
+                self.status = Some(id);
+                self
+            }
+            /// Set a human-readable event message.
+            #[must_use]
+            pub fn message(mut self, msg: impl Into<String>) -> Self {
+                self.message = Some(msg.into());
+                self
+            }
+        }
+    };
+    ($builder:ident, no_status) => {
+        impl<'a> $builder<'a> {
+            /// Set the event severity.
+            #[must_use]
+            pub fn severity(mut self, id: $crate::enums::SeverityId) -> Self {
+                self.severity = id;
+                self
+            }
+            /// Set a human-readable event message.
+            #[must_use]
+            pub fn message(mut self, msg: impl Into<String>) -> Self {
+                self.message = Some(msg.into());
+                self
+            }
+        }
+    };
+}
+
 mod base;
 mod config;
 mod finding;
@@ -27,6 +76,8 @@ pub use ssh::SshActivityBuilder;
 use std::net::IpAddr;
 
 use crate::OCSF_VERSION;
+use crate::enums::StatusId;
+use crate::events::base_event::BaseEventData;
 use crate::objects::{Container, Device, Endpoint, Image, Metadata, Product};
 
 /// Immutable context created once at sandbox startup.
@@ -86,6 +137,24 @@ impl SandboxContext {
     #[must_use]
     pub fn proxy_endpoint(&self) -> Endpoint {
         Endpoint::from_ip(self.proxy_ip, self.proxy_port)
+    }
+
+    /// Apply the fields common to every builder's `build()` method onto `base`:
+    /// optional status, optional message, device info, and container info.
+    pub fn apply_common_fields(
+        &self,
+        base: &mut BaseEventData,
+        status: Option<StatusId>,
+        message: Option<String>,
+    ) {
+        if let Some(s) = status {
+            base.set_status(s);
+        }
+        if let Some(m) = message {
+            base.set_message(m);
+        }
+        base.set_device(self.device());
+        base.set_container(self.container());
     }
 }
 

--- a/crates/openshell-ocsf/src/builders/network.rs
+++ b/crates/openshell-ocsf/src/builders/network.rs
@@ -78,16 +78,6 @@ impl<'a> NetworkActivityBuilder<'a> {
         self
     }
     #[must_use]
-    pub fn severity(mut self, id: SeverityId) -> Self {
-        self.severity = id;
-        self
-    }
-    #[must_use]
-    pub fn status(mut self, id: StatusId) -> Self {
-        self.status = Some(id);
-        self
-    }
-    #[must_use]
     pub fn src_endpoint_addr(mut self, ip: IpAddr, port: u16) -> Self {
         self.src_endpoint = Some(Endpoint::from_ip(ip, port));
         self
@@ -115,11 +105,6 @@ impl<'a> NetworkActivityBuilder<'a> {
     #[must_use]
     pub fn observation_point(mut self, id: u8) -> Self {
         self.observation_point_id = Some(id);
-        self
-    }
-    #[must_use]
-    pub fn message(mut self, msg: impl Into<String>) -> Self {
-        self.message = Some(msg.into());
         self
     }
     #[must_use]
@@ -166,20 +151,14 @@ impl<'a> NetworkActivityBuilder<'a> {
             metadata,
         );
 
-        if let Some(status) = self.status {
-            base.set_status(status);
-        }
-        if let Some(msg) = self.message {
-            base.set_message(msg);
-        }
         if let Some(detail) = self.status_detail {
             base.set_status_detail(detail);
         }
-        base.set_device(self.ctx.device());
-        base.set_container(self.ctx.container());
         if let Some(unmapped) = self.unmapped {
             base.unmapped = Some(serde_json::Value::Object(unmapped));
         }
+        self.ctx
+            .apply_common_fields(&mut base, self.status, self.message);
 
         OcsfEvent::NetworkActivity(NetworkActivityEvent {
             base,
@@ -196,6 +175,8 @@ impl<'a> NetworkActivityBuilder<'a> {
         })
     }
 }
+
+impl_builder_setters!(NetworkActivityBuilder);
 
 #[cfg(test)]
 mod tests {

--- a/crates/openshell-ocsf/src/builders/process.rs
+++ b/crates/openshell-ocsf/src/builders/process.rs
@@ -48,16 +48,6 @@ impl<'a> ProcessActivityBuilder<'a> {
         self
     }
     #[must_use]
-    pub fn severity(mut self, id: SeverityId) -> Self {
-        self.severity = id;
-        self
-    }
-    #[must_use]
-    pub fn status(mut self, id: StatusId) -> Self {
-        self.status = Some(id);
-        self
-    }
-    #[must_use]
     pub fn action(mut self, id: ActionId) -> Self {
         self.action = Some(id);
         self
@@ -87,11 +77,6 @@ impl<'a> ProcessActivityBuilder<'a> {
         self.exit_code = Some(code);
         self
     }
-    #[must_use]
-    pub fn message(mut self, msg: impl Into<String>) -> Self {
-        self.message = Some(msg.into());
-        self
-    }
 
     #[must_use]
     pub fn build(self) -> OcsfEvent {
@@ -107,14 +92,8 @@ impl<'a> ProcessActivityBuilder<'a> {
             self.ctx
                 .metadata(&["security_control", "container", "host"]),
         );
-        if let Some(status) = self.status {
-            base.set_status(status);
-        }
-        if let Some(msg) = self.message {
-            base.set_message(msg);
-        }
-        base.set_device(self.ctx.device());
-        base.set_container(self.ctx.container());
+        self.ctx
+            .apply_common_fields(&mut base, self.status, self.message);
 
         OcsfEvent::ProcessActivity(ProcessActivityEvent {
             base,
@@ -127,6 +106,8 @@ impl<'a> ProcessActivityBuilder<'a> {
         })
     }
 }
+
+impl_builder_setters!(ProcessActivityBuilder);
 
 #[cfg(test)]
 mod tests {

--- a/crates/openshell-ocsf/src/builders/ssh.rs
+++ b/crates/openshell-ocsf/src/builders/ssh.rs
@@ -64,16 +64,6 @@ impl<'a> SshActivityBuilder<'a> {
         self
     }
     #[must_use]
-    pub fn severity(mut self, id: SeverityId) -> Self {
-        self.severity = id;
-        self
-    }
-    #[must_use]
-    pub fn status(mut self, id: StatusId) -> Self {
-        self.status = Some(id);
-        self
-    }
-    #[must_use]
     pub fn src_endpoint_addr(mut self, ip: IpAddr, port: u16) -> Self {
         self.src_endpoint = Some(Endpoint::from_ip(ip, port));
         self
@@ -86,11 +76,6 @@ impl<'a> SshActivityBuilder<'a> {
     #[must_use]
     pub fn actor_process(mut self, process: Process) -> Self {
         self.actor = Some(Actor { process });
-        self
-    }
-    #[must_use]
-    pub fn message(mut self, msg: impl Into<String>) -> Self {
-        self.message = Some(msg.into());
         self
     }
 
@@ -122,14 +107,8 @@ impl<'a> SshActivityBuilder<'a> {
             self.ctx
                 .metadata(&["security_control", "container", "host"]),
         );
-        if let Some(status) = self.status {
-            base.set_status(status);
-        }
-        if let Some(msg) = self.message {
-            base.set_message(msg);
-        }
-        base.set_device(self.ctx.device());
-        base.set_container(self.ctx.container());
+        self.ctx
+            .apply_common_fields(&mut base, self.status, self.message);
 
         OcsfEvent::SshActivity(SshActivityEvent {
             base,
@@ -144,6 +123,8 @@ impl<'a> SshActivityBuilder<'a> {
         })
     }
 }
+
+impl_builder_setters!(SshActivityBuilder);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Eliminate several categories of repeated code identified across the OCSF builder layer and compute driver crates. No behavioral changes — pure structural deduplication.

## Related Issue

N/A

## Changes

**`openshell-ocsf` — OCSF builder deduplication (~90 lines removed)**
- Add `impl_builder_setters!` macro in `builders/mod.rs` that generates the identical `severity()`, `status()`, and `message()` setter methods present on all 7 OCSF event builders (two variants: with and without `status`)
- Add `SandboxContext::apply_common_fields()` to consolidate the four-line finalization pattern (`set_status`, `set_message`, `set_device`, `set_container`) repeated in every builder's `build()` method
- Update all 7 builder files to use the macro and helper

**`openshell-core` — two new shared driver utilities**
- `driver_utils::sandbox_token_path(driver_subdir, namespace, sandbox_id)` — centralizes the XDG state path construction for sandbox JWT token files previously duplicated between the Docker and Podman drivers
- `driver_utils::build_capabilities_response(name, version, image, gpu)` — centralizes the `GetCapabilitiesResponse` struct literal repeated across the Docker, Podman, and Kubernetes compute drivers

**`openshell-driver-docker`, `openshell-driver-podman`, `openshell-driver-kubernetes`**
- Token path functions and `capabilities()` methods now delegate to the shared helpers above

**Skipped** (differences were too significant to abstract cleanly): gRPC `ComputeDriverService` adapters (different error types and method signatures between k8s and podman), persistence store backends, test PKI helpers, provider boilerplate files.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [ ] Commits are signed off (DCO)