### PR TITLE
docs(kubernetes): add RBAC section to setup page

### DIFF
--- a/docs/kubernetes/setup.mdx
+++ b/docs/kubernetes/setup.mdx
@@ -152,6 +152,45 @@ helm upgrade --install openshell \
   --values my-values.yaml
 ```
 
+## RBAC
+
+The chart creates the following RBAC resources in the release namespace:
+
+| Resource | Scope | Name |
+|---|---|---|
+| ServiceAccount | Namespace | `openshell` |
+| ServiceAccount | Namespace | `openshell-sandbox` (for sandbox pods) |
+| Role + RoleBinding | Namespace | `openshell-sandbox` |
+| ClusterRole + ClusterRoleBinding | Cluster | `openshell-node-reader` |
+
+The namespaced Role covers sandbox lifecycle and identity:
+
+| API Group | Resource | Verbs |
+|---|---|---|
+| `agents.x-k8s.io` | `sandboxes`, `sandboxes/status` | create, delete, get, list, patch, update, watch |
+| `""` | `events` | get, list, watch |
+| `""` | `pods` | get |
+
+The ClusterRole grants node inspection and token validation:
+
+| API Group | Resource | Verbs |
+|---|---|---|
+| `authentication.k8s.io` | `tokenreviews` | create |
+| `""` | `nodes` | get, list, watch |
+
+To use an existing ServiceAccount instead of creating one, set `serviceAccount.create=false` and supply its name:
+
+```shell
+helm upgrade --install openshell \
+  oci://ghcr.io/nvidia/openshell/helm-chart \
+  --version <version> \
+  --namespace openshell \
+  --set serviceAccount.create=false \
+  --set serviceAccount.name=my-existing-sa
+```
+
+The ServiceAccount must already have the Role and ClusterRole bindings described above.
+
 ## Next Steps
 
 - To enable automatic certificate rotation with cert-manager, refer to [Managing Certificates](/kubernetes/managing-certificates).


### PR DESCRIPTION
Moves RBAC documentation inline into the setup page, per reviewer feedback on #1250. 

Reflects the current Helm chart templates accurately, including the `pods/get` permission added for sandbox identity and `tokenreviews/create` for projected token validation.

Closes #1018