### PR TITLE
ci(docs): publish versioned Fern docs on release

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1004,7 +1004,9 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         working-directory: ./fern
-        run: fern generate --docs
+        run: |
+          fern generate --docs
+          fern generate --docs --version "$RELEASE_TAG"
 
   release-helm:
     name: Release Helm Chart (OCI)


### PR DESCRIPTION
After each release, `fern generate --docs` publishes to `latest`. 
This PR adds a second call that also publishes a version-tagged snapshot so users on older installs can find docs that match their version.

Related Issue: Closes #1296

Testing

Workflow-only change. The `fern generate --docs --version` flag creates a new version entry on the Fern site using the tag as the slug. Requires `FERN_TOKEN` to verify end-to-end; the existing `fern check` step in `branch-docs.yml` validates the config locally.
