### PR TITLE
docs(providers): note that ANTHROPIC_API_KEY requires an API account, not a subscription

### DIFF
--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -62,7 +62,7 @@ If `ANTHROPIC_API_KEY` is set in your environment, the CLI picks it up automatic
 If not, you can configure it from inside the sandbox after it launches.
 
 <Note>
-`ANTHROPIC_API_KEY` is an API key from [console.anthropic.com](https://console.anthropic.com), not a Claude.ai subscription token. Claude Max and Pro subscription users must generate a separate API key.
+`ANTHROPIC_API_KEY` is an API key from [console.anthropic.com](https://console.anthropic.com), not a subscription token. Subscription users must generate a separate API key.
 </Note>
 </Tab>
 

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -60,6 +60,10 @@ The CLI prompts you to create a provider from local credentials.
 Type `yes` to continue.
 If `ANTHROPIC_API_KEY` is set in your environment, the CLI picks it up automatically.
 If not, you can configure it from inside the sandbox after it launches.
+
+<Note>
+`ANTHROPIC_API_KEY` is an API key from [console.anthropic.com](https://console.anthropic.com), not a Claude.ai subscription token. Claude Max and Pro subscription users must generate a separate API key.
+</Note>
 </Tab>
 
 <Tab title="OpenCode">

--- a/docs/sandboxes/manage-providers.mdx
+++ b/docs/sandboxes/manage-providers.mdx
@@ -246,10 +246,6 @@ The following provider types are supported.
 |---|---|---|
 | `anthropic` | `ANTHROPIC_API_KEY` | Anthropic API |
 | `claude` | `ANTHROPIC_API_KEY`, `CLAUDE_API_KEY` | Claude Code, Anthropic API |
-
-<Note>
-`ANTHROPIC_API_KEY` is an API key from [console.anthropic.com](https://console.anthropic.com), not a Claude.ai subscription token. Claude Max and Pro subscription users must generate a separate API key from the Anthropic Console.
-</Note>
 | `codex` | `OPENAI_API_KEY` | OpenAI Codex |
 | `copilot` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` | GitHub Copilot CLI |
 | `generic` | User-defined | Any service with custom credentials |
@@ -258,6 +254,10 @@ The following provider types are supported.
 | `nvidia` | `NVIDIA_API_KEY` | NVIDIA API Catalog |
 | `openai` | `OPENAI_API_KEY` | Any OpenAI-compatible endpoint. Set `--config OPENAI_BASE_URL` to point to the provider. Refer to [Inference Routing](/sandboxes/inference-routing). |
 | `opencode` | `OPENCODE_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY` | OpenCode |
+
+<Note>
+`ANTHROPIC_API_KEY` is an API key from [console.anthropic.com](https://console.anthropic.com), not a subscription token. Subscription users must generate a separate API key from the Anthropic Console.
+</Note>
 
 <Tip>
 Use the `generic` type for any service not listed above. You define the

--- a/docs/sandboxes/manage-providers.mdx
+++ b/docs/sandboxes/manage-providers.mdx
@@ -246,6 +246,10 @@ The following provider types are supported.
 |---|---|---|
 | `anthropic` | `ANTHROPIC_API_KEY` | Anthropic API |
 | `claude` | `ANTHROPIC_API_KEY`, `CLAUDE_API_KEY` | Claude Code, Anthropic API |
+
+<Note>
+`ANTHROPIC_API_KEY` is an API key from [console.anthropic.com](https://console.anthropic.com), not a Claude.ai subscription token. Claude Max and Pro subscription users must generate a separate API key from the Anthropic Console.
+</Note>
 | `codex` | `OPENAI_API_KEY` | OpenAI Codex |
 | `copilot` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` | GitHub Copilot CLI |
 | `generic` | User-defined | Any service with custom credentials |


### PR DESCRIPTION
Anthropic subscription users authenticate via OAuth, not an API key.

The provider types that inject `ANTHROPIC_API_KEY` reference [console.anthropic.com](https://console.anthropic.com), but the docs never mention this, leaving subscription users with a silent dead-end.

Adds a `<Note>` callout in two places:
- Provider type table in the manage-providers guide
- Quickstart guide where `ANTHROPIC_API_KEY` is first mentioned

Related Issue: Closes #620