### PR TITLE
docs(kubernetes): note that Sandbox volumeClaimTemplates is immutable

### DIFF
--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -125,3 +125,7 @@ For maintainer-level implementation details, refer to the [Kubernetes driver REA
 | `supervisor_sideload_method` | `supervisor.sideloadMethod` | How the supervisor binary is delivered into sandbox pods. Leave empty to auto-detect from cluster version. Set to `image-volume` to mount the supervisor OCI image directly as a volume (requires Kubernetes 1.33+ with the ImageVolume feature gate; GA in 1.36), or `init-container` to copy it through an init container on older clusters. |
 
 The Kubernetes driver creates namespaced `agents.x-k8s.io/v1alpha1` `Sandbox` resources from the Kubernetes SIG Apps [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) project. The Agent Sandbox controller turns those resources into sandbox pods and related storage.
+
+<Note>
+`Sandbox.spec.volumeClaimTemplates` is immutable after creation. To change storage configuration, delete the sandbox and create a new one with the updated spec.
+</Note>


### PR DESCRIPTION
Adds a `<Note>` to the Kubernetes compute driver reference clarifying that `Sandbox.spec.volumeClaimTemplates` is immutable after creation

Relates to kubernetes-sigs/agent-sandbox#727

`docs/reference/sandbox-compute-drivers.mdx`: one-sentence immutability note under the agent-sandbox paragraph
