### PR TITLE
chore(helm): add missing SPDX header to gateway-config template

### DIFF
--- a/deploy/helm/openshell/templates/gateway-config.yaml
+++ b/deploy/helm/openshell/templates/gateway-config.yaml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 {{/*
 ConfigMap holding the gateway TOML config file (RFC 0003).
 

--- a/scripts/update_license_headers.py
+++ b/scripts/update_license_headers.py
@@ -55,7 +55,6 @@ EXCLUDE_DIRS: set[str] = {
     ".git",
     ".cache",
     "python/openshell/_proto",
-    "deploy/helm/openshell/templates",
 }
 
 # Individual filenames to skip.


### PR DESCRIPTION
Adds the missing SPDX copyright and license header to `deploy/helm/openshell/templates/gateway-config.yaml`

Every other file in `deploy/helm/openshell/templates/` already has this header. This was the only file missing it.
