### PR TITLE
fix(scripts): use TMPDIR-aware mktemp template in shell scripts

### DIFF
--- a/tasks/scripts/helm-k3s-local.sh
+++ b/tasks/scripts/helm-k3s-local.sh
@@ -117,7 +117,7 @@ k3d_cluster_exists() {
 merge_kubeconfig() {
   require_kubectl
   local tmp k3d_cfg merged_dir
-  tmp="$(mktemp)"
+  tmp="$(mktemp "${TMPDIR:-/tmp}/openshell-kubeconfig.XXXXXX")"
   k3d kubeconfig get "${CLUSTER_NAME}" >"${tmp}"
 
   if [[ -s "${KUBECONFIG_TARGET}" ]]; then

--- a/tasks/scripts/stage-prebuilt-binaries.sh
+++ b/tasks/scripts/stage-prebuilt-binaries.sh
@@ -121,7 +121,7 @@ patch_workspace_version() {
   fi
 
   cargo_toml="${ROOT}/Cargo.toml"
-  cargo_toml_backup="$(mktemp)"
+  cargo_toml_backup="$(mktemp "${TMPDIR:-/tmp}/openshell-cargo.XXXXXX")"
   cp "$cargo_toml" "$cargo_toml_backup"
   restore_cargo_toml=1
   sed -i -E '/^\[workspace\.package\]/,/^\[/{s/^version[[:space:]]*=[[:space:]]*".*"/version = "'"${OPENSHELL_CARGO_VERSION}"'"/}' "$cargo_toml"


### PR DESCRIPTION
Replaces bare `mktemp` calls with `mktemp "${TMPDIR:-/tmp}/openshell-*.XXXXXX"` in 2 scripts

Consistent with the pattern already used on line 227 of `helm-k3s-local.sh`
