### PR TITLE
fix(python): raise SandboxError instead of FileNotFoundError or KeyError

### DIFF
--- a/python/openshell/sandbox.py
+++ b/python/openshell/sandbox.py
@@ -153,7 +153,12 @@ class SandboxClient:
             / cluster_name
             / "metadata.json"
         )
-        metadata = json.loads(metadata_path.read_text())
+        try:
+            metadata = json.loads(metadata_path.read_text())
+        except FileNotFoundError:
+            raise SandboxError(f"gateway '{cluster_name}' not found")
+        if "gateway_endpoint" not in metadata:
+            raise SandboxError(f"gateway '{cluster_name}' metadata missing endpoint")
         parsed = urlparse(metadata["gateway_endpoint"])
         host = parsed.hostname or "127.0.0.1"
         port = parsed.port or (443 if parsed.scheme == "https" else 80)
@@ -613,7 +618,10 @@ def _resolve_active_cluster() -> str:
     if env_gateway:
         return env_gateway
     active_file = _xdg_config_home() / "openshell" / "active_gateway"
-    value = active_file.read_text().strip()
+    try:
+        value = active_file.read_text().strip()
+    except FileNotFoundError:
+        raise SandboxError("no active gateway configured")
     if value == "":
         raise SandboxError("no active gateway configured")
     return value

--- a/python/openshell/sandbox.py
+++ b/python/openshell/sandbox.py
@@ -156,7 +156,7 @@ class SandboxClient:
         try:
             metadata = json.loads(metadata_path.read_text())
         except FileNotFoundError:
-            raise SandboxError(f"gateway '{cluster_name}' not found")
+            raise SandboxError(f"gateway '{cluster_name}' not found") from None
         if "gateway_endpoint" not in metadata:
             raise SandboxError(f"gateway '{cluster_name}' metadata missing endpoint")
         parsed = urlparse(metadata["gateway_endpoint"])
@@ -621,7 +621,7 @@ def _resolve_active_cluster() -> str:
     try:
         value = active_file.read_text().strip()
     except FileNotFoundError:
-        raise SandboxError("no active gateway configured")
+        raise SandboxError("no active gateway configured") from None
     if value == "":
         raise SandboxError("no active gateway configured")
     return value


### PR DESCRIPTION
`_resolve_active_cluster`: wraps `read_text()` in a `try/except FileNotFoundError` so a missing active gateway file raises `SandboxError` with a clear message instead of a raw Python exception

`from_active_cluster`: same fix for `metadata.json` not found, plus an explicit check for the missing `gateway_endpoint` key

All other error paths in the file already raise `SandboxError`. 

These 2 were inconsistent.
