### PR TITLE
[WIP] feat(sandbox): opt-in best-effort bootstrap via OPENSHELL_BEST_EFFORT_FAILURES

### DIFF
--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -111,6 +111,34 @@ pub(crate) fn agent_proposals_enabled() -> bool {
         .is_some_and(|flag| flag.load(Ordering::Relaxed))
 }
 
+/// Operator-opt-in to best-effort bootstrap. When the
+/// `OPENSHELL_BEST_EFFORT_FAILURES` environment variable is set (to any
+/// value), the sandbox tolerates failures from optional hardening
+/// subsystems (network namespace, seccomp) instead of aborting. Intended
+/// for gVisor-on-Kubernetes deployments where the runtime degrades these
+/// syscalls. Default is strict (any failure aborts).
+fn best_effort_failures() -> bool {
+    static FLAG: OnceLock<bool> = OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("OPENSHELL_BEST_EFFORT_FAILURES").is_some())
+}
+
+/// Dispatch a sandbox bootstrap failure: abort by default, warn-and-continue
+/// when the operator has opted into best-effort mode via
+/// [`best_effort_failures`].
+pub(crate) fn handle_bootstrap_failure(subsystem: &str, err: miette::Report) -> Result<()> {
+    if best_effort_failures() {
+        warn!(
+            subsystem,
+            error = %err,
+            "Sandbox bootstrap subsystem unavailable; continuing in best-effort mode \
+             (operator opted in via OPENSHELL_BEST_EFFORT_FAILURES)"
+        );
+        Ok(())
+    } else {
+        Err(err)
+    }
+}
+
 /// Test-only helpers shared across sibling test modules.
 #[cfg(test)]
 pub(crate) mod test_helpers {
@@ -547,11 +575,15 @@ pub async fn run_sandbox(
                 Some(ns)
             }
             Err(e) => {
-                return Err(miette::miette!(
-                    "Network namespace creation failed and proxy mode requires isolation. \
-                     Ensure CAP_NET_ADMIN and CAP_SYS_ADMIN are available and iproute2 is installed. \
-                     Error: {e}"
-                ));
+                handle_bootstrap_failure(
+                    "network-namespace",
+                    miette::miette!(
+                        "Network namespace creation failed and proxy mode requires isolation. \
+                         Ensure CAP_NET_ADMIN and CAP_SYS_ADMIN are available and iproute2 is installed. \
+                         Error: {e}"
+                    ),
+                )?;
+                None
             }
         }
     } else {
@@ -566,7 +598,9 @@ pub async fn run_sandbox(
     // Install the supervisor seccomp prelude after privileged startup helpers
     // (network namespace setup, nftables probes) complete, but before the SSH
     // listener and workload process are exposed.
-    apply_supervisor_startup_hardening()?;
+    if let Err(e) = apply_supervisor_startup_hardening() {
+        handle_bootstrap_failure("supervisor-seccomp", e)?;
+    }
 
     // Shared PID: set after process spawn so the proxy can look up
     // the entrypoint process's /proc/net/tcp for identity binding.

--- a/crates/openshell-sandbox/src/process.rs
+++ b/crates/openshell-sandbox/src/process.rs
@@ -477,6 +477,14 @@ pub fn drop_privileges(policy: &SandboxPolicy) -> Result<()> {
             .ok_or_else(|| miette::miette!("Failed to resolve user primary group"))?
     };
 
+    // Idempotent fast-path: if the process is already running as the target
+    // uid/gid (e.g. the container entrypoint dropped privileges before exec),
+    // there is nothing to do. Skipping avoids initgroups(3), which requires
+    // CAP_SETGID and would fail otherwise.
+    if nix::unistd::geteuid() == user.uid && nix::unistd::getegid() == group.gid {
+        return Ok(());
+    }
+
     if user_name.is_some() {
         let user_cstr =
             CString::new(user.name.clone()).map_err(|_| miette::miette!("Invalid user name"))?;

--- a/crates/openshell-sandbox/src/sandbox/linux/mod.rs
+++ b/crates/openshell-sandbox/src/sandbox/linux/mod.rs
@@ -40,7 +40,9 @@ pub fn enforce(prepared: PreparedSandbox) -> Result<()> {
     if let Some(ruleset) = prepared.landlock {
         landlock::enforce(ruleset)?;
     }
-    seccomp::apply(&prepared.policy)?;
+    if let Err(e) = seccomp::apply(&prepared.policy) {
+        crate::handle_bootstrap_failure("workload-seccomp", e)?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Add an `OPENSHELL_BEST_EFFORT_FAILURES` env var that lets the supervisor tolerate bootstrap-syscall failures from outer-sandbox runtimes (gVisor, Firecracker, Kata). Default stays strict — standalone deployments are unaffected.

## Related Issue

None — proposed as a small, opt-in change to unblock outer-sandbox integrations.

## Changes

- **`crates/openshell-sandbox/src/lib.rs`** — add `best_effort_failures()` env-var probe and `handle_bootstrap_failure()` helper. Route the netns-create and supervisor-seccomp call sites through the helper.
- **`crates/openshell-sandbox/src/sandbox/linux/mod.rs`** — route the workload seccomp call site through the helper.
- **`crates/openshell-sandbox/src/process.rs`** — make `drop_privileges` idempotent: skip `initgroups`/`setresgid`/`setresuid` when the process is already at the resolved target uid/gid.

Net diff: **3 files, +51 / −7.**

## Testing

- [x] `cargo fmt --all -- --check` clean on the touched files.
- [x] `cargo test -p openshell-sandbox --lib` — 777 tests pass.
- [x] `cargo clippy -p openshell-sandbox --lib --tests -- -D warnings` — zero new warnings introduced (pre-existing warnings on `main` unchanged).
- [x] End-to-end against gVisor-managed actors on a kind cluster — supervisor boots, OPA + OCSF pipelines work, sandbox behaviour unchanged when the env var is unset.
- [ ] `mise run pre-commit` — to be re-verified by CI after copy-pr-bot mirrors.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) — `feat(sandbox): …`
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — not applicable; new behaviour is fully opt-in via a documented env var, no existing user-visible contract changes.

## Motivation

Integrating the OpenShell supervisor with NVIDIA Agent Substrate (gVisor + checkpoint/restore via `runsc`). With this gate the stock supervisor binary boots cleanly inside that runtime; without it a fork is required.
