### PR TITLE
feat(router): warn when client-supplied model is rewritten

### DIFF
--- a/crates/openshell-router/src/backend.rs
+++ b/crates/openshell-router/src/backend.rs
@@ -5,6 +5,7 @@ use crate::RouterError;
 use crate::config::{AuthHeader, ResolvedRoute};
 use crate::mock;
 use std::collections::HashSet;
+use tracing::warn;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatedEndpoint {
@@ -190,9 +191,22 @@ fn prepare_backend_request(
 
     // Set the "model" field in the JSON body to the route's configured model so the
     // backend receives the correct model ID regardless of what the client sent.
+    // When the caller supplied a non-empty model that differs from the configured
+    // route, emit a warning so the rewrite is visible to operators and silent
+    // model-typo / stale-reference bugs do not get masked by the rewrite.
     let body = match serde_json::from_slice::<serde_json::Value>(&body) {
         Ok(mut json) => {
             if let Some(obj) = json.as_object_mut() {
+                if let Some(serde_json::Value::String(client_model)) = obj.get("model") {
+                    if !client_model.is_empty() && client_model != &route.model {
+                        warn!(
+                            client_model = %client_model,
+                            route_model = %route.model,
+                            endpoint = %route.endpoint,
+                            "router is rewriting client-supplied model to the configured route model",
+                        );
+                    }
+                }
                 obj.insert(
                     "model".to_string(),
                     serde_json::Value::String(route.model.clone()),


### PR DESCRIPTION
## Summary
The privacy router silently overwrites the client-supplied `model` with `route.model`, masking caller-side typos and stale references. Emit a `warn`-level tracing event when the supplied model differs from the configured route model. The rewrite itself is preserved.

## Related Issue
Fixes NVIDIA/NemoClaw#994

## Changes
- `crates/openshell-router/src/backend.rs` — warn with `client_model`, `route_model`, and `endpoint` when the caller's non-empty `model` differs from `route.model`.

## Testing
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
