### PR TITLE
docs(openshift): add manual JWT signing secret step

### DIFF
--- a/docs/kubernetes/openshift.mdx
+++ b/docs/kubernetes/openshift.mdx
@@ -40,6 +40,24 @@ Sandbox pods run under the `openshell-sandbox` service account in the `openshell
 oc adm policy add-scc-to-user privileged -z openshell-sandbox -n openshell
 ```
 
+## Create the JWT signing secret
+
+The PKI init job is disabled (see next step), so the JWT signing keys it would normally create must be provisioned manually:
+
+```shell
+openssl genpkey -algorithm Ed25519 -out /tmp/signing.pem
+openssl pkey -in /tmp/signing.pem -pubout -out /tmp/public.pem
+openssl rand -hex 16 > /tmp/kid
+
+oc create secret generic openshell-jwt-keys \
+  -n openshell \
+  --from-file=signing.pem=/tmp/signing.pem \
+  --from-file=public.pem=/tmp/public.pem \
+  --from-file=kid=/tmp/kid
+
+rm /tmp/signing.pem /tmp/public.pem /tmp/kid
+```
+
 ## Install the chart with OpenShift overrides
 
 ```shell


### PR DESCRIPTION
## Summary

- Adds a missing step to the OpenShift install guide: manually creating the `openshell-jwt-keys` secret before installing the chart.
- When `pkiInitJob.enabled=false`, the PKI init job that normally generates this secret is skipped, leaving the gateway pod stuck in `ContainerCreating` with `MountVolume.SetUp failed for volume "sandbox-jwt" : secret "openshell-jwt-keys" not found`.

## Test plan

- [x] Followed the updated steps on an OpenShift 4.x cluster — gateway pod starts successfully after creating the secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)