### PR TITLE
ci(release): smoke test rpm artifacts on fedora

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -730,16 +730,16 @@ jobs:
             artifact_arch: arm64
             rpm_arch: aarch64
             target: aarch64-unknown-linux-gnu
-          - name: rhel9-rpm
+          - name: fedora-rpm
             runner: linux-amd64-cpu8
-            image: rockylinux:9
+            image: fedora:latest
             kind: rpm
             artifact_arch: amd64
             rpm_arch: x86_64
             target: x86_64-unknown-linux-gnu
-          - name: rhel9-rpm-aarch64
+          - name: fedora-rpm-aarch64
             runner: linux-arm64-cpu8
-            image: rockylinux:9
+            image: fedora:latest
             kind: rpm
             artifact_arch: arm64
             rpm_arch: aarch64


### PR DESCRIPTION
## Summary

Switch release-tag RPM smoke tests from Rocky Linux 9 to Fedora so the smoke environment matches the Fedora RPMs produced by the package workflow. Rename the matrix entries from rhel9-rpm to fedora-rpm so check names reflect the target distro.

The Rocky smoke jobs were failing before any OpenShell binary ran. The RPM package workflow builds in `fedora:latest`, which currently emits Fedora 44 RPMs with Python 3.14 metadata, including `python(abi) = 3.14` and `python3.14dist(...)` dependencies. Rocky Linux 9 does not provide those Fedora/Python 3.14 packages, so `dnf install ./package-input/*.rpm` failed with unresolved dependencies for `python3-openshell-0.0.48-1.fc44`.

## Related Issue

None. Follow-up from failed release run https://github.com/NVIDIA/OpenShell/actions/runs/26406903910/job/77734352602.

## Changes

- Use `fedora:latest` for release RPM smoke tests on x86_64 and aarch64.
- Rename RPM smoke jobs from `rhel9-rpm*` to `fedora-rpm*`.

## Testing

- [x] `mise run pre-commit` passes.
- [ ] Unit tests added/updated - not applicable; workflow-only change.
- [ ] E2E tests added/updated (if applicable) - not applicable.
- [x] YAML parsed with Ruby YAML load.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable) - not applicable.
