### PR TITLE
ci(release): skip python rpm in gateway smoke test

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -799,7 +799,7 @@ jobs:
         if: matrix.kind == 'rpm'
         run: |
           set -euo pipefail
-          dnf install -y ./package-input/*.rpm
+          dnf install -y ./package-input/openshell-[0-9]*.rpm ./package-input/openshell-gateway-*.rpm
           openshell-gateway --version
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Update the Fedora RPM smoke test to install only the CLI and gateway RPMs before running `openshell-gateway --version`. The previous `*.rpm` glob also installed the optional Python SDK RPM, which is not needed for this gateway smoke check.

Fedora fixed the earlier Rocky-specific Python ABI issue, but the smoke still failed because `python3-openshell-0.0.48-1.fc44` requires `python3.14dist(grpcio) >= 1.60` and `python3.14dist(protobuf) >= 4.25`, which Fedora 44 does not provide. Since this smoke validates the gateway package path, skipping the Python subpackage avoids blocking the release on unrelated SDK RPM dependencies.

## Related Issue

None. Follow-up from failed release run https://github.com/NVIDIA/OpenShell/actions/runs/26415139181/job/77759471779.

## Changes

- Replace `./package-input/*.rpm` with explicit CLI and gateway RPM globs in the release-tag RPM smoke step.
- Leave `python3-openshell` out of the gateway smoke install path.

## Testing

- [x] `mise run pre-commit` passes.
- [ ] Unit tests added/updated - not applicable; workflow-only change.
- [ ] E2E tests added/updated (if applicable) - not applicable.
- [x] YAML parsed with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-tag.yml'); puts 'ok'"`.
- [x] Local Fedora x86_64 smoke passed against run `26415139181` artifacts: `docker run --rm --platform linux/amd64 -v ... fedora:latest bash -lc 'set -euo pipefail; dnf install -y /work/package-input/openshell-[0-9]*.rpm /work/package-input/openshell-gateway-*.rpm; openshell-gateway --version'` returned `openshell-gateway 0.0.48`.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable) - not applicable.
