### PR TITLE
docs: add macOS compiler troubleshooting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,25 @@ Project requirements:
 - Docker (running)
 - Z3 solver library (for the policy prover crate)
 
+### macOS build tools
+
+Install Apple Command Line Tools before building locally:
+
+```bash
+xcode-select --install
+```
+
+If Cargo fails while building `protobuf-src` with an error such as
+`fatal error: 'utility' file not found`, `fatal error: 'cstdlib' file not
+found`, or `A compiler with support for C++11 language features is required`,
+your Command Line Tools install may not expose the libc++ headers on the
+compiler's default include path. Reinstall Command Line Tools to correct the error:
+
+```bash
+sudo rm -rf /Library/Developer/CommandLineTools
+xcode-select --install
+```
+
 ### Z3 installation
 
 The `openshell-prover` crate links against the system Z3 library via pkg-config.


### PR DESCRIPTION
## Summary

Add macOS contributor troubleshooting for Command Line Tools installs that fail to expose libc++ headers during bundled protobuf builds.

This is an easy fix for a scary looking error, but let me know if you would recommend putting it in a different location than CONTRIBUTING.md.  I can't think of a good way to automatically unit test it because the error only shows up on a Mac that's had the Command Line Tools installed for a while, but I did test the fix myself.

## Related Issue

N/A

## Changes

- Document installing Apple Command Line Tools before local builds.
- Add a specific remediation path for protobuf-src C++ header and C++11 detection failures on macOS.

## Testing

- [x] mise run pre-commit passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)