### PR TITLE
docs: fix provider command and PR template link

### DIFF
--- a/.agents/skills/create-github-pr/SKILL.md
+++ b/.agents/skills/create-github-pr/SKILL.md
@@ -137,7 +137,7 @@ gh pr create --base "release-1.0"
 
 ## PR Description Format
 
-PR descriptions must follow the project's [PR template](.github/PULL_REQUEST_TEMPLATE.md) structure:
+PR descriptions must follow the project's [PR template](../../../.github/PULL_REQUEST_TEMPLATE.md) structure:
 
 ```markdown
 ## Summary

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Docker-backed GPU sandboxes auto-select CDI when available and otherwise fall ba
 | `openshell sandbox create -- <agent>`                      | Create a sandbox and launch an agent.           |
 | `openshell sandbox connect [name]`                         | SSH into a running sandbox.                     |
 | `openshell sandbox list`                                   | List all sandboxes.                             |
-| `openshell provider create --type [type]] --from-existing` | Create a credential provider from env vars.     |
+| `openshell provider create --name <name> --type <type> --from-existing` | Create a credential provider from env vars.     |
 | `openshell policy set <name> --policy file.yaml`           | Apply or update a policy on a running sandbox.  |
 | `openshell policy get <name>`                              | Show the active policy.                         |
 | `openshell inference set --provider <p> --model <m>`       | Configure the `inference.local` endpoint.       |


### PR DESCRIPTION
## Summary
Fixes two small docs issues: the README provider-create command now matches the CLI, and the create-github-pr skill points to the repository PR template using a path that resolves from the nested skill directory.

## Related Issue
N/A

## Changes
- Correct the README `openshell provider create` example to include `--name` and remove the stray `]`.
- Fix the `create-github-pr` skill link to the repository PR template.

## Testing
Docs-only change; not run.
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
