### PR TITLE
feat(vm): add vm life cycle extensions

### DIFF
--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -570,6 +570,37 @@ configure_hostname() {
     ts "hostname=${sandbox_hostname}"
 }
 
+run_openshell_init_dropins() {
+    # Run executable drop-ins from /opt/openshell/init.d in deterministic
+    # ASCII-sorted order. Drop-ins are *executed* in a child shell rather
+    # than sourced, so they cannot mutate parent shell state or exit the
+    # caller. They inherit `OPENSHELL_VM_INIT_PHASE`, `ROOT_PREFIX`, and
+    # any `OPENSHELL_VM_DATA_*` env vars set by lifecycle extensions.
+    local init_dir
+    init_dir="$(root_path /opt/openshell/init.d)"
+    [ -d "$init_dir" ] || return 0
+
+    export OPENSHELL_VM_INIT_PHASE="before-supervisor"
+    export ROOT_PREFIX="${ROOT_PREFIX:-}"
+
+    local dropin rc
+    while IFS= read -r dropin; do
+        [ -n "$dropin" ] || continue
+        [ -f "$dropin" ] || continue
+        [ -x "$dropin" ] || continue
+
+        ts "running OpenShell VM init drop-in ${dropin##*/}"
+        rc=0
+        set +e
+        "$dropin"
+        rc=$?
+        set -e
+        if [ "$rc" -ne 0 ]; then
+            ts "WARNING: OpenShell VM init drop-in ${dropin##*/} failed with exit code ${rc}"
+        fi
+    done < <(LC_ALL=C find "$init_dir" -mindepth 1 -maxdepth 1 -type f -print | LC_ALL=C sort)
+}
+
 run_post_overlay_setup() {
     # Source QEMU-injected environment variables if present. The file lives in
     # the overlay upperdir so the cached bootstrap rootfs remains immutable.
@@ -728,6 +759,8 @@ if [ -d /sandbox ]; then
         fi
     fi
 fi
+
+run_openshell_init_dropins
 
 rewrite_openshell_endpoint_if_needed
 

--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -576,29 +576,72 @@ run_openshell_init_dropins() {
     # than sourced, so they cannot mutate parent shell state or exit the
     # caller. They inherit `OPENSHELL_VM_INIT_PHASE`, `ROOT_PREFIX`, and
     # any `OPENSHELL_VM_DATA_*` env vars set by lifecycle extensions.
-    local init_dir
+    #
+    # Security: this runs as root before the supervisor enforces policy, so
+    # it executes *only* the drop-ins the VM driver explicitly injected this
+    # launch, as enumerated in the driver-authored manifest. Anything else
+    # found under init.d (e.g. files baked into a user-controlled guest
+    # image) is ignored. The manifest lives in the overlay upperdir, which
+    # the driver owns, so a guest image cannot forge or shadow it. A missing
+    # manifest is treated as "run nothing" (fail-closed).
+    local init_dir manifest
     init_dir="$(root_path /opt/openshell/init.d)"
-    [ -d "$init_dir" ] || return 0
+    manifest="$(root_path /opt/openshell/init.d.manifest)"
+
+    if [ ! -f "$manifest" ]; then
+        if [ -d "$init_dir" ]; then
+            ts "no OpenShell VM init drop-in manifest present; skipping init.d"
+        fi
+        return 0
+    fi
 
     export OPENSHELL_VM_INIT_PHASE="before-supervisor"
     export ROOT_PREFIX="${ROOT_PREFIX:-}"
 
-    local dropin rc
-    while IFS= read -r dropin; do
-        [ -n "$dropin" ] || continue
-        [ -f "$dropin" ] || continue
-        [ -x "$dropin" ] || continue
+    # Fail closed on any inconsistency: every drop-in below is trusted,
+    # required setup the driver injected on purpose, so we abort the boot
+    # rather than run a half-configured sandbox. Aborting exits this init
+    # non-zero; the VM helper then exits and the driver runs
+    # lifecycle-extension cleanup, so a failed init does not leak resources.
+    # The loop runs in the main shell (process substitution, not a pipe), so
+    # `exit` here terminates init as intended.
+    local name dropin rc
+    while IFS= read -r name; do
+        [ -n "$name" ] || continue
+        # Manifest entries are bare file names that the driver already
+        # validated. A separator or traversal here means the manifest was
+        # tampered with after the driver wrote it.
+        case "$name" in
+            */* | . | ..)
+                ts "FATAL: unsafe init drop-in manifest entry '${name}'"
+                exit 1
+                ;;
+        esac
 
-        ts "running OpenShell VM init drop-in ${dropin##*/}"
+        # The driver writes each entry's file and marks it 0755 in the same
+        # operation, so a missing or non-executable entry means the overlay
+        # was tampered with or provisioning is broken.
+        dropin="${init_dir}/${name}"
+        if [ ! -f "$dropin" ]; then
+            ts "FATAL: init drop-in '${name}' listed in manifest but not found"
+            exit 1
+        fi
+        if [ ! -x "$dropin" ]; then
+            ts "FATAL: init drop-in '${name}' is not executable"
+            exit 1
+        fi
+
+        ts "running OpenShell VM init drop-in ${name}"
         rc=0
         set +e
         "$dropin"
         rc=$?
         set -e
         if [ "$rc" -ne 0 ]; then
-            ts "WARNING: OpenShell VM init drop-in ${dropin##*/} failed with exit code ${rc}"
+            ts "FATAL: OpenShell VM init drop-in ${name} failed with exit code ${rc}"
+            exit 1
         fi
-    done < <(LC_ALL=C find "$init_dir" -mindepth 1 -maxdepth 1 -type f -print | LC_ALL=C sort)
+    done < <(LC_ALL=C sort -u "$manifest")
 }
 
 run_post_overlay_setup() {

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::extension::{LaunchAbortReason, VmLaunchPlan, VmLifecycleExtensions};
+use crate::extension::{
+    LaunchAbortReason, VmBackendFeature, VmGuestInitDropIn, VmLaunchPlan, VmLifecycleExtensions,
+    VmPersistedSandbox, extension_state_dir,
+};
 use crate::gpu::{
     GpuInventory, SubnetAllocator, allocate_vsock_cid, mac_from_sandbox_id, tap_device_name,
 };
@@ -103,6 +106,7 @@ const GUEST_TLS_CA_PATH: &str = "/opt/openshell/tls/ca.crt";
 const GUEST_TLS_CERT_PATH: &str = "/opt/openshell/tls/tls.crt";
 const GUEST_TLS_KEY_PATH: &str = "/opt/openshell/tls/tls.key";
 const GUEST_SANDBOX_TOKEN_PATH: &str = "/opt/openshell/auth/sandbox.jwt";
+const GUEST_INIT_DROPIN_DIR: &str = "/opt/openshell/init.d";
 const IMAGE_CACHE_ROOT_DIR: &str = "images";
 const IMAGE_CACHE_ROOTFS_IMAGE: &str = "rootfs.ext4";
 const OVERLAY_TEMPLATE_CACHE_DIR: &str = "overlay-templates";
@@ -313,6 +317,9 @@ impl VmDriver {
         config: VmDriverConfig,
         lifecycle_extensions: VmLifecycleExtensions,
     ) -> Result<Self, String> {
+        lifecycle_extensions
+            .validate()
+            .map_err(|err| err.message().to_string())?;
         if config.openshell_endpoint.trim().is_empty() {
             return Err("openshell endpoint is required".to_string());
         }
@@ -415,9 +422,6 @@ impl VmDriver {
             "vm driver: create_sandbox received"
         );
         validate_vm_sandbox(sandbox, self.config.gpu_enabled)?;
-        self.validate_extension_backend_requirements(
-            sandbox.spec.as_ref().is_some_and(|spec| spec.gpu),
-        )?;
 
         let state_dir = sandbox_state_dir(&self.config.state_dir, &sandbox.id)?;
         let image_ref = self.resolved_sandbox_image(sandbox).ok_or_else(|| {
@@ -465,6 +469,13 @@ impl VmDriver {
             let mut registry = self.registry.lock().await;
             registry.remove(&sandbox.id);
             return Err(Status::internal(format!("create state dir failed: {err}")));
+        }
+
+        if let Err(err) = self.ensure_extension_state_dirs(&state_dir).await {
+            let mut registry = self.registry.lock().await;
+            registry.remove(&sandbox.id);
+            let _ = tokio::fs::remove_dir_all(&state_dir).await;
+            return Err(err);
         }
 
         if let Err(err) = write_sandbox_request(&state_dir, sandbox).await {
@@ -571,7 +582,6 @@ impl VmDriver {
     ) -> Result<(), Status> {
         self.ensure_provisioning_active(&sandbox.id).await?;
         let is_gpu = sandbox.spec.as_ref().is_some_and(|spec| spec.gpu);
-        self.validate_extension_backend_requirements(is_gpu)?;
         self.publish_platform_event(
             sandbox.id.clone(),
             platform_event(
@@ -650,6 +660,65 @@ impl VmDriver {
                     return Err(err);
                 }
             };
+
+        if let Err(err) = self
+            .lifecycle_extensions
+            .configure_vm_launch(&sandbox, &state_dir, &mut plan)
+            .await
+        {
+            self.lifecycle_extensions
+                .after_vm_launch_failed(
+                    &sandbox,
+                    &state_dir,
+                    LaunchAbortReason::BeforeLaunchHookFailed,
+                )
+                .await;
+            self.release_gpu_and_subnet(&sandbox.id);
+            let message = format!(
+                "vm lifecycle extension rejected sandbox launch plan: {}",
+                err.message()
+            );
+            return Err(if err.is_resource_exhausted() {
+                Status::resource_exhausted(message)
+            } else {
+                Status::failed_precondition(message)
+            });
+        }
+
+        // Resolve and validate the backend from the requirements that
+        // `configure_vm_launch` extensions contributed. After this point the
+        // plan's backend, sizing, and host allocations (subnet, tap, vsock)
+        // are final; the `before_vm_launch` hook below may still mutate
+        // `plan.env` and `plan.guest_init_dropins` and may abort the launch,
+        // but it MUST NOT change `plan.backend`, `plan.required_backends`,
+        // or `plan.required_backend_features` -- those are enforced as a
+        // documented trait contract, not a runtime check.
+        if let Err(err) =
+            self.resolve_launch_plan_backend(&sandbox.id, is_gpu, gpu_bdf.clone(), &mut plan)
+        {
+            self.lifecycle_extensions
+                .after_vm_launch_failed(
+                    &sandbox,
+                    &state_dir,
+                    LaunchAbortReason::BeforeLaunchHookFailed,
+                )
+                .await;
+            self.release_gpu_and_subnet(&sandbox.id);
+            return Err(err);
+        }
+
+        if let Err(err) = Self::validate_launch_plan_backend(is_gpu, &plan) {
+            self.lifecycle_extensions
+                .after_vm_launch_failed(
+                    &sandbox,
+                    &state_dir,
+                    LaunchAbortReason::BeforeLaunchHookFailed,
+                )
+                .await;
+            self.release_gpu_and_subnet(&sandbox.id);
+            return Err(err);
+        }
+
         if plan.backend == VmBackend::Qemu
             && let Err(err) = self.mark_qemu_network_allocated(&sandbox.id).await
         {
@@ -681,13 +750,9 @@ impl VmDriver {
             });
         }
 
-        if let Err(err) = Self::validate_launch_plan_backend(is_gpu, &plan) {
+        if let Err(err) = inject_guest_init_dropins(&overlay_disk, &plan.guest_init_dropins) {
             self.lifecycle_extensions
-                .after_vm_launch_failed(
-                    &sandbox,
-                    &state_dir,
-                    LaunchAbortReason::BeforeLaunchHookFailed,
-                )
+                .after_vm_launch_failed(&sandbox, &state_dir, LaunchAbortReason::GuestPrepareFailed)
                 .await;
             self.release_gpu_and_subnet(&sandbox.id);
             return Err(err);
@@ -718,6 +783,9 @@ impl VmDriver {
         command.arg("--vm-console-output").arg(&console_output);
         command.arg("--vm-vcpus").arg(plan.vcpus.to_string());
         command.arg("--vm-mem-mib").arg(plan.mem_mib.to_string());
+        if let Some(kernel_image) = &plan.kernel_image {
+            command.arg("--vm-kernel-image").arg(kernel_image);
+        }
 
         if plan.backend == VmBackend::Qemu {
             command.arg("--vm-backend").arg("qemu");
@@ -831,6 +899,15 @@ impl VmDriver {
         );
         if let Some(snapshot) = snapshot_to_publish {
             self.publish_snapshot(snapshot);
+        }
+        if overlay_preparation == OverlayPreparation::PreserveExisting {
+            let persisted = VmPersistedSandbox {
+                sandbox: sandbox.clone(),
+                state_dir: state_dir.clone(),
+            };
+            self.lifecycle_extensions
+                .reconcile_after_restore(&persisted)
+                .await;
         }
         tokio::spawn({
             let driver = self.clone();
@@ -1056,6 +1133,36 @@ impl VmDriver {
             }
         };
 
+        if let Err(err) = self.ensure_extension_state_dirs(&state_dir).await {
+            warn!(
+                sandbox_id = %sandbox.id,
+                sandbox_name = %sandbox.name,
+                state_dir = %state_dir.display(),
+                error = %err.message(),
+                "vm driver: cannot restore persisted sandbox extension state"
+            );
+            return;
+        }
+
+        let persisted = VmPersistedSandbox {
+            sandbox: sandbox.clone(),
+            state_dir: state_dir.clone(),
+        };
+        if let Err(err) = self
+            .lifecycle_extensions
+            .reconcile_before_restore(&persisted)
+            .await
+        {
+            warn!(
+                sandbox_id = %sandbox.id,
+                sandbox_name = %sandbox.name,
+                state_dir = %state_dir.display(),
+                error = %err,
+                "vm driver: lifecycle extension rejected persisted sandbox restore"
+            );
+            return;
+        }
+
         let snapshot = sandbox_snapshot(&sandbox, provisioning_condition(), false);
         {
             let mut registry = self.registry.lock().await;
@@ -1141,27 +1248,165 @@ impl VmDriver {
         self.release_subnet(sandbox_id);
     }
 
-    #[allow(clippy::result_large_err)]
-    fn validate_extension_backend_requirements(&self, is_gpu: bool) -> Result<(), Status> {
-        if self.lifecycle_extensions.requires_qemu() && !is_gpu {
-            return Err(Status::failed_precondition(
-                "vm lifecycle extension requires QEMU, but non-GPU QEMU launch support requires concrete PCI device transport",
-            ));
+    async fn ensure_extension_state_dirs(&self, state_dir: &Path) -> Result<(), Status> {
+        for extension_name in self.lifecycle_extensions.names() {
+            let extension_dir = extension_state_dir(state_dir, &extension_name).map_err(|err| {
+                Status::failed_precondition(format!(
+                    "invalid VM lifecycle extension '{}': {}",
+                    extension_name,
+                    err.message()
+                ))
+            })?;
+            create_private_dir_all(&extension_dir)
+                .await
+                .map_err(|err| {
+                    Status::internal(format!(
+                        "create VM lifecycle extension state dir '{}' failed: {err}",
+                        extension_dir.display()
+                    ))
+                })?;
         }
         Ok(())
     }
 
     #[allow(clippy::result_large_err)]
+    fn resolve_launch_plan_backend(
+        &self,
+        sandbox_id: &str,
+        is_gpu: bool,
+        gpu_bdf: Option<String>,
+        plan: &mut VmLaunchPlan,
+    ) -> Result<(), Status> {
+        if plan.kernel_image.is_some() {
+            plan.require_backend_feature(VmBackendFeature::ExternalKernelImage);
+        }
+        if !plan.guest_init_dropins.is_empty() {
+            plan.require_backend_feature(VmBackendFeature::GuestInitDropins);
+        }
+
+        if plan.required_backends.contains(&VmBackend::Qemu)
+            || plan.backend == VmBackend::Qemu
+            || plan
+                .required_backend_features
+                .iter()
+                .any(|feature| feature.requires_qemu())
+        {
+            self.configure_qemu_launch_plan(sandbox_id, is_gpu, gpu_bdf, plan)?;
+        }
+
+        Ok(())
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn configure_qemu_launch_plan(
+        &self,
+        sandbox_id: &str,
+        is_gpu: bool,
+        gpu_bdf: Option<String>,
+        plan: &mut VmLaunchPlan,
+    ) -> Result<(), Status> {
+        plan.backend = VmBackend::Qemu;
+        if is_gpu {
+            plan.vcpus = self.config.gpu_vcpus;
+            plan.mem_mib = self.config.gpu_mem_mib;
+        }
+        if plan.gpu_bdf.is_none() {
+            plan.gpu_bdf = gpu_bdf;
+        }
+        if has_complete_qemu_network(plan) {
+            return Ok(());
+        }
+
+        let subnet = self
+            .subnet_allocator
+            .lock()
+            .map_err(|e| Status::internal(format!("subnet allocator lock poisoned: {e}")))?
+            .allocate(sandbox_id)
+            .map_err(Status::failed_precondition)?;
+        let mac = mac_from_sandbox_id(sandbox_id);
+        plan.tap_device = Some(tap_device_name(sandbox_id));
+        plan.guest_ip = Some(subnet.guest_ip.to_string());
+        plan.host_ip = Some(subnet.host_ip.to_string());
+        plan.vsock_cid = Some(allocate_vsock_cid());
+        plan.guest_mac = Some(format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+        ));
+        plan.gateway_port = gateway_port_from_endpoint(&self.config.openshell_endpoint);
+        Ok(())
+    }
+
+    #[allow(clippy::result_large_err)]
     fn validate_launch_plan_backend(is_gpu: bool, plan: &VmLaunchPlan) -> Result<(), Status> {
+        // NOTE: this guard exists because the non-GPU QEMU launch path
+        // (PCI device transport, VFIO root port wiring) has not landed
+        // yet. Until then, even though the resolver will happily promote
+        // a plan to QEMU when an extension requires `PciPassthrough` or
+        // `ExternalKernelImage`, the launch itself is blocked here so we
+        // don't spawn a QEMU instance with no concrete device backing.
+        // Remove this guard once the non-GPU QEMU launch path supports
+        // emitting `pcie-root-port` + `vfio-pci` for arbitrary device
+        // descriptors.
         if plan.backend == VmBackend::Qemu && !is_gpu {
-            return Err(Status::failed_precondition(
-                "vm lifecycle extension selected QEMU, but non-GPU QEMU launch support requires concrete PCI device transport",
-            ));
+            let offending_feature = plan
+                .required_backend_features
+                .iter()
+                .find(|feature| feature.requires_qemu())
+                .map_or("(explicit QEMU backend requirement)", |feature| {
+                    feature.as_str()
+                });
+            return Err(Status::failed_precondition(format!(
+                "vm lifecycle extension required '{offending_feature}', which resolves to the QEMU backend, \
+                 but non-GPU QEMU launch is not yet supported (pending PCI device transport)"
+            )));
         }
         if plan.backend != VmBackend::Qemu && is_gpu {
             return Err(Status::failed_precondition(
                 "GPU sandbox launch requires the QEMU backend",
             ));
+        }
+        if plan.required_backends.contains(&VmBackend::Libkrun)
+            && plan.required_backends.contains(&VmBackend::Qemu)
+        {
+            return Err(Status::failed_precondition(
+                "VM lifecycle extensions requested conflicting VM backends",
+            ));
+        }
+        if plan.required_backends.contains(&VmBackend::Libkrun)
+            && plan.backend != VmBackend::Libkrun
+        {
+            return Err(Status::failed_precondition(
+                "VM lifecycle extension requires the libkrun backend",
+            ));
+        }
+        if plan.required_backends.contains(&VmBackend::Qemu) && plan.backend != VmBackend::Qemu {
+            return Err(Status::failed_precondition(
+                "VM lifecycle extension requires the QEMU backend",
+            ));
+        }
+        if plan.backend != VmBackend::Qemu
+            && let Some(feature) = plan
+                .required_backend_features
+                .iter()
+                .find(|feature| feature.requires_qemu())
+        {
+            return Err(Status::failed_precondition(format!(
+                "VM backend feature '{}' requires a VM backend with PCI-style launch support",
+                feature.as_str()
+            )));
+        }
+        if plan.kernel_image.is_some() && plan.backend != VmBackend::Qemu {
+            return Err(Status::failed_precondition(
+                "selected kernel image requires a VM backend that supports external kernel images",
+            ));
+        }
+        if let Some(kernel_image) = &plan.kernel_image
+            && !kernel_image.is_file()
+        {
+            return Err(Status::failed_precondition(format!(
+                "selected kernel image does not exist: {}",
+                kernel_image.display()
+            )));
         }
         Ok(())
     }
@@ -1190,6 +1435,10 @@ impl VmDriver {
                 backend: VmBackend::Libkrun,
                 vcpus: self.config.vcpus,
                 mem_mib: self.config.mem_mib,
+                required_backends: Vec::new(),
+                required_backend_features: Vec::new(),
+                kernel_profile: None,
+                kernel_image: None,
                 gpu_bdf: None,
                 tap_device: None,
                 guest_ip: None,
@@ -1197,6 +1446,7 @@ impl VmDriver {
                 vsock_cid: None,
                 guest_mac: None,
                 gateway_port: None,
+                guest_init_dropins: Vec::new(),
                 env: Vec::new(),
             });
         }
@@ -1226,6 +1476,10 @@ impl VmDriver {
             backend: VmBackend::Qemu,
             vcpus,
             mem_mib,
+            required_backends: Vec::new(),
+            required_backend_features: Vec::new(),
+            kernel_profile: None,
+            kernel_image: None,
             gpu_bdf,
             tap_device: Some(tap),
             guest_ip: Some(subnet.guest_ip.to_string()),
@@ -1233,6 +1487,7 @@ impl VmDriver {
             vsock_cid: Some(vsock_cid),
             guest_mac: Some(mac_str),
             gateway_port,
+            guest_init_dropins: Vec::new(),
             env: Vec::new(),
         })
     }
@@ -3607,6 +3862,14 @@ fn gateway_port_from_endpoint(endpoint: &str) -> Option<u16> {
     Url::parse(endpoint).ok().and_then(|url| url.port())
 }
 
+fn has_complete_qemu_network(plan: &VmLaunchPlan) -> bool {
+    plan.tap_device.is_some()
+        && plan.guest_ip.is_some()
+        && plan.host_ip.is_some()
+        && plan.vsock_cid.is_some()
+        && plan.guest_mac.is_some()
+}
+
 fn guest_visible_openshell_endpoint_for_tap(endpoint: &str, host_ip: &str) -> String {
     let Ok(mut url) = Url::parse(endpoint) else {
         return endpoint.to_string();
@@ -4211,6 +4474,61 @@ fn inject_guest_sandbox_token(overlay_disk: &Path, token: &str) -> Result<(), St
     let token_path = overlay_upper_path(GUEST_SANDBOX_TOKEN_PATH);
     write_rootfs_image_file(overlay_disk, &token_path, format!("{token}\n").as_bytes())?;
     set_rootfs_image_file_mode(overlay_disk, &token_path, 0o600)
+}
+
+#[allow(clippy::result_large_err)]
+fn inject_guest_init_dropins(
+    overlay_disk: &Path,
+    dropins: &[VmGuestInitDropIn],
+) -> Result<(), Status> {
+    validate_guest_init_dropins(dropins).map_err(Status::failed_precondition)?;
+
+    // Drop-ins are *executed* in a child shell by run_openshell_init_dropins
+    // in the guest init script, not sourced into the parent. Mode 0o755 is
+    // required (the runner skips anything that is not `-x`) and is the
+    // contract drop-in authors should rely on.
+    for dropin in dropins {
+        let guest_path = overlay_upper_path(&format!("{GUEST_INIT_DROPIN_DIR}/{}", dropin.name));
+        write_rootfs_image_file(overlay_disk, &guest_path, &dropin.contents).map_err(|err| {
+            Status::internal(format!(
+                "write VM guest init drop-in '{}' failed: {err}",
+                dropin.name
+            ))
+        })?;
+        set_rootfs_image_file_mode(overlay_disk, &guest_path, 0o755).map_err(|err| {
+            Status::internal(format!(
+                "set VM guest init drop-in '{}' executable failed: {err}",
+                dropin.name
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn validate_guest_init_dropins(dropins: &[VmGuestInitDropIn]) -> Result<(), String> {
+    let mut names = HashSet::new();
+    for dropin in dropins {
+        validate_guest_init_dropin_name(&dropin.name)?;
+        if !names.insert(dropin.name.clone()) {
+            return Err(format!("duplicate VM guest init drop-in '{}'", dropin.name));
+        }
+    }
+    Ok(())
+}
+
+fn validate_guest_init_dropin_name(name: &str) -> Result<(), String> {
+    if name.is_empty() || name == "." || name == ".." {
+        return Err("VM guest init drop-in name is empty or reserved".to_string());
+    }
+    if !name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.')
+    {
+        return Err(format!(
+            "VM guest init drop-in name '{name}' must contain only ASCII letters, numbers, '.', '-', or '_'"
+        ));
+    }
+    Ok(())
 }
 
 fn overlay_upper_path(guest_path: &str) -> String {
@@ -5988,8 +6306,8 @@ mod tests {
     }
 
     use crate::extension::{
-        VmLaunchPlan, VmLifecycleError, VmLifecycleExtension, VmLifecycleExtensions,
-        VmLifecycleResult,
+        VmBackendFeature, VmLaunchPlan, VmLifecycleError, VmLifecycleExtension,
+        VmLifecycleExtensions, VmLifecycleResult,
     };
     use crate::runtime::VmBackend;
 
@@ -6028,8 +6346,15 @@ mod tests {
             &self.name
         }
 
-        fn required_backend(&self) -> Option<VmBackend> {
-            Some(VmBackend::Qemu)
+        async fn configure_vm_launch(
+            &self,
+            _sandbox: &Sandbox,
+            _state_dir: &Path,
+            plan: &mut VmLaunchPlan,
+        ) -> VmLifecycleResult<()> {
+            plan.require_backend(VmBackend::Qemu);
+            plan.require_backend_feature(VmBackendFeature::PciPassthrough);
+            Ok(())
         }
 
         async fn before_vm_launch(
@@ -6088,9 +6413,9 @@ mod tests {
     }
 
     #[test]
-    fn empty_registry_does_not_force_qemu() {
+    fn empty_registry_has_no_extension_descriptors() {
         let driver = test_driver_with_extensions(VmLifecycleExtensions::new());
-        assert!(!driver.lifecycle_extensions.requires_qemu());
+        assert!(driver.lifecycle_extensions.descriptors().is_empty());
     }
 
     #[test]
@@ -6113,23 +6438,117 @@ mod tests {
     }
 
     #[test]
-    fn extension_requiring_qemu_rejects_non_gpu_until_pci_transport() {
-        let mut extensions = VmLifecycleExtensions::new();
-        extensions.push(Arc::new(QemuRequiringExtension {
-            name: "test-ext".to_string(),
-        }));
-        let driver = test_driver_with_extensions(extensions);
-        assert!(driver.lifecycle_extensions.requires_qemu());
+    fn launch_plan_rejects_external_kernel_on_unsupported_backend() {
+        let mut plan = VmLaunchPlan {
+            backend: VmBackend::Libkrun,
+            vcpus: 2,
+            mem_mib: 2048,
+            required_backends: Vec::new(),
+            required_backend_features: Vec::new(),
+            kernel_profile: None,
+            kernel_image: Some(PathBuf::from("/tmp/openshell-test-kernel")),
+            gpu_bdf: None,
+            tap_device: None,
+            guest_ip: None,
+            host_ip: None,
+            vsock_cid: None,
+            guest_mac: None,
+            gateway_port: None,
+            guest_init_dropins: Vec::new(),
+            env: Vec::new(),
+        };
 
-        let err = driver
-            .validate_extension_backend_requirements(false)
-            .expect_err("non-GPU QEMU extension requests need concrete PCI transport");
+        let err = VmDriver::validate_launch_plan_backend(false, &plan)
+            .expect_err("external kernels require a compatible backend");
         assert_eq!(err.code(), Code::FailedPrecondition);
-        assert!(err.message().contains("concrete PCI device transport"));
+        assert!(err.message().contains("external kernel images"));
+
+        let base = unique_temp_dir();
+        std::fs::create_dir_all(&base).unwrap();
+        let kernel = base.join("vmlinux");
+        std::fs::write(&kernel, b"kernel").unwrap();
+        plan.backend = VmBackend::Qemu;
+        plan.kernel_image = Some(kernel);
+        VmDriver::validate_launch_plan_backend(true, &plan).expect("existing kernel is accepted");
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn backend_feature_requirements_select_qemu_launch_plan() {
+        let driver = test_driver_with_extensions(VmLifecycleExtensions::new());
+        let mut plan = driver
+            .build_vm_launch_plan("sandbox-vfio", false, false, None)
+            .expect("base plan should build");
+        plan.require_backend_feature(VmBackendFeature::PciPassthrough);
 
         driver
-            .validate_extension_backend_requirements(true)
-            .expect("GPU sandboxes already use the QEMU backend");
+            .resolve_launch_plan_backend("sandbox-vfio", false, None, &mut plan)
+            .expect("backend feature should resolve");
+
+        assert_eq!(plan.backend, VmBackend::Qemu);
+        assert!(plan.tap_device.is_some());
+        assert!(plan.guest_ip.is_some());
+        assert!(plan.host_ip.is_some());
+        assert!(plan.vsock_cid.is_some());
+        assert!(plan.guest_mac.is_some());
+
+        driver.release_subnet("sandbox-vfio");
+    }
+
+    #[test]
+    fn explicit_backend_requirement_selects_qemu_launch_plan() {
+        let driver = test_driver_with_extensions(VmLifecycleExtensions::new());
+        let mut plan = driver
+            .build_vm_launch_plan("sandbox-qemu", false, false, None)
+            .expect("base plan should build");
+        plan.require_backend(VmBackend::Qemu);
+
+        driver
+            .resolve_launch_plan_backend("sandbox-qemu", false, None, &mut plan)
+            .expect("backend requirement should resolve");
+
+        assert_eq!(plan.backend, VmBackend::Qemu);
+        assert!(plan.tap_device.is_some());
+        assert!(plan.guest_ip.is_some());
+        assert!(plan.host_ip.is_some());
+
+        driver.release_subnet("sandbox-qemu");
+    }
+
+    #[test]
+    fn guest_init_dropin_feature_does_not_force_qemu() {
+        let driver = test_driver_with_extensions(VmLifecycleExtensions::new());
+        let mut plan = driver
+            .build_vm_launch_plan("sandbox-init", false, false, None)
+            .expect("base plan should build");
+        plan.require_backend_feature(VmBackendFeature::GuestInitDropins);
+
+        driver
+            .resolve_launch_plan_backend("sandbox-init", false, None, &mut plan)
+            .expect("guest init feature should resolve");
+
+        assert_eq!(plan.backend, VmBackend::Libkrun);
+        assert!(plan.tap_device.is_none());
+    }
+
+    #[test]
+    fn guest_init_dropin_validation_rejects_unsafe_or_duplicate_names() {
+        validate_guest_init_dropins(&[VmGuestInitDropIn::new("50-vfio.sh", b"true\n".to_vec())])
+            .expect("safe drop-in name is accepted");
+
+        let err = validate_guest_init_dropins(&[VmGuestInitDropIn::new(
+            "../50-vfio.sh",
+            b"true\n".to_vec(),
+        )])
+        .expect_err("path traversal is rejected");
+        assert!(err.contains("must contain only ASCII"));
+
+        let err = validate_guest_init_dropins(&[
+            VmGuestInitDropIn::new("50-vfio.sh", b"true\n".to_vec()),
+            VmGuestInitDropIn::new("50-vfio.sh", b"true\n".to_vec()),
+        ])
+        .expect_err("duplicate drop-ins are rejected");
+        assert!(err.contains("duplicate"));
     }
 
     #[tokio::test]
@@ -6148,6 +6567,10 @@ mod tests {
             backend: VmBackend::Libkrun,
             vcpus: 2,
             mem_mib: 2048,
+            required_backends: Vec::new(),
+            required_backend_features: Vec::new(),
+            kernel_profile: None,
+            kernel_image: None,
             gpu_bdf: None,
             tap_device: None,
             guest_ip: None,
@@ -6155,6 +6578,7 @@ mod tests {
             vsock_cid: None,
             guest_mac: None,
             gateway_port: None,
+            guest_init_dropins: Vec::new(),
             env: Vec::new(),
         };
         let err = extensions
@@ -6167,6 +6591,10 @@ mod tests {
             backend: VmBackend::Qemu,
             vcpus: 2,
             mem_mib: 2048,
+            required_backends: Vec::new(),
+            required_backend_features: Vec::new(),
+            kernel_profile: None,
+            kernel_image: None,
             gpu_bdf: None,
             tap_device: Some("vmtap-x".to_string()),
             guest_ip: Some("10.0.0.2".to_string()),
@@ -6174,6 +6602,7 @@ mod tests {
             vsock_cid: Some(7),
             guest_mac: Some("02:00:00:00:00:01".to_string()),
             gateway_port: Some(8080),
+            guest_init_dropins: Vec::new(),
             env: Vec::new(),
         };
         extensions
@@ -6195,6 +6624,10 @@ mod tests {
             backend: VmBackend::Qemu,
             vcpus: 2,
             mem_mib: 2048,
+            required_backends: Vec::new(),
+            required_backend_features: Vec::new(),
+            kernel_profile: None,
+            kernel_image: None,
             gpu_bdf: None,
             tap_device: Some("vmtap-x".to_string()),
             guest_ip: Some("10.0.0.2".to_string()),
@@ -6202,6 +6635,7 @@ mod tests {
             vsock_cid: Some(7),
             guest_mac: Some("02:00:00:00:00:01".to_string()),
             gateway_port: Some(8080),
+            guest_init_dropins: Vec::new(),
             env: Vec::new(),
         };
         let err = extensions

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -107,6 +107,14 @@ const GUEST_TLS_CERT_PATH: &str = "/opt/openshell/tls/tls.crt";
 const GUEST_TLS_KEY_PATH: &str = "/opt/openshell/tls/tls.key";
 const GUEST_SANDBOX_TOKEN_PATH: &str = "/opt/openshell/auth/sandbox.jwt";
 const GUEST_INIT_DROPIN_DIR: &str = "/opt/openshell/init.d";
+/// Guest path of the driver-authored manifest enumerating which
+/// `init.d` drop-ins the guest init script is allowed to execute.
+///
+/// The guest runs *only* the entries listed here (fail-closed): anything
+/// else found under `init.d` — e.g. files baked into a user-controlled
+/// guest image — is ignored. The driver writes this file into the overlay
+/// upperdir on every launch, so the image cannot forge or shadow it.
+const GUEST_INIT_DROPIN_MANIFEST: &str = "/opt/openshell/init.d.manifest";
 const IMAGE_CACHE_ROOT_DIR: &str = "images";
 const IMAGE_CACHE_ROOTFS_IMAGE: &str = "rootfs.ext4";
 const OVERLAY_TEMPLATE_CACHE_DIR: &str = "overlay-templates";
@@ -2775,12 +2783,30 @@ impl VmDriver {
                     sandbox_id.clone(),
                     platform_event("vm", "Warning", "ProcessExited", message),
                 );
-                let (has_gpu, has_qemu_network) = {
+                let (has_gpu, has_qemu_network, cleanup_ctx) = {
                     let registry = self.registry.lock().await;
-                    registry.get(&sandbox_id).map_or((false, false), |record| {
-                        (record.gpu_bdf.is_some(), record.qemu_network_allocated)
-                    })
+                    registry
+                        .get(&sandbox_id)
+                        .map_or((false, false, None), |record| {
+                            (
+                                record.gpu_bdf.is_some(),
+                                record.qemu_network_allocated,
+                                Some((record.snapshot.clone(), record.state_dir.clone())),
+                            )
+                        })
                 };
+                // Give lifecycle extensions a chance to release host
+                // resources they allocated in `before_launch` (e.g. device
+                // bindings, OVS flows). The driver releases its own
+                // allocations just below; without this, extension-owned
+                // resources would leak whenever a VM helper exits without an
+                // explicit delete. Cleanup is best-effort and idempotent, so
+                // a later delete that also fires `after_delete` is safe.
+                if let Some((sandbox, state_dir)) = cleanup_ctx {
+                    self.lifecycle_extensions
+                        .after_launch_failed(&sandbox, &state_dir, LaunchAbortReason::ProcessExited)
+                        .await;
+                }
                 self.release_allocations(&sandbox_id, has_gpu, has_qemu_network);
                 return;
             }
@@ -4502,6 +4528,45 @@ fn inject_guest_init_dropins(
             ))
         })?;
     }
+
+    // Write the allow-list manifest the guest runner consults. We write it
+    // unconditionally — including an empty manifest when no drop-ins were
+    // injected — so the guest always fails closed: only names the driver
+    // explicitly injected this launch are eligible to run, and a guest
+    // image cannot smuggle in extra `init.d` entries.
+    write_guest_init_dropin_manifest(overlay_disk, dropins)?;
+    Ok(())
+}
+
+/// Render the drop-in allow-list as newline-separated, ASCII-sorted,
+/// de-duplicated names. Names are already validated to be path-safe by
+/// [`validate_guest_init_dropins`].
+fn render_guest_init_dropin_manifest(dropins: &[GuestInitDropin]) -> Vec<u8> {
+    let mut names: Vec<&str> = dropins.iter().map(|d| d.name.as_str()).collect();
+    names.sort_unstable();
+    names.dedup();
+    let mut body = names.join("\n");
+    if !body.is_empty() {
+        body.push('\n');
+    }
+    body.into_bytes()
+}
+
+#[allow(clippy::result_large_err)]
+fn write_guest_init_dropin_manifest(
+    overlay_disk: &Path,
+    dropins: &[GuestInitDropin],
+) -> Result<(), Status> {
+    let guest_path = overlay_upper_path(GUEST_INIT_DROPIN_MANIFEST);
+    let contents = render_guest_init_dropin_manifest(dropins);
+    write_rootfs_image_file(overlay_disk, &guest_path, &contents).map_err(|err| {
+        Status::internal(format!("write VM guest init drop-in manifest failed: {err}"))
+    })?;
+    set_rootfs_image_file_mode(overlay_disk, &guest_path, 0o644).map_err(|err| {
+        Status::internal(format!(
+            "set VM guest init drop-in manifest mode failed: {err}"
+        ))
+    })?;
     Ok(())
 }
 
@@ -6549,6 +6614,25 @@ mod tests {
         ])
         .expect_err("duplicate drop-ins are rejected");
         assert!(err.contains("duplicate"));
+    }
+
+    #[test]
+    fn guest_init_dropin_manifest_lists_only_injected_names_sorted() {
+        let manifest = render_guest_init_dropin_manifest(&[
+            GuestInitDropin::new("50-vfio.sh", b"true\n".to_vec()),
+            GuestInitDropin::new("10-nemo.sh", b"true\n".to_vec()),
+        ]);
+        assert_eq!(
+            String::from_utf8(manifest).unwrap(),
+            "10-nemo.sh\n50-vfio.sh\n"
+        );
+    }
+
+    #[test]
+    fn guest_init_dropin_manifest_is_empty_when_no_dropins() {
+        // An empty manifest is the fail-closed signal that nothing under
+        // init.d should run.
+        assert!(render_guest_init_dropin_manifest(&[]).is_empty());
     }
 
     #[tokio::test]

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::extension::{LaunchAbortReason, VmLaunchPlan, VmLifecycleExtensions};
 use crate::gpu::{
     GpuInventory, SubnetAllocator, allocate_vsock_cid, mac_from_sandbox_id, tap_device_name,
 };
@@ -9,6 +10,7 @@ use crate::rootfs::{
     extract_rootfs_archive_to, prepare_sandbox_rootfs_from_image_root, sandbox_guest_init_path,
     set_rootfs_image_file_mode, write_rootfs_image_file,
 };
+use crate::runtime::VmBackend;
 use bollard::Docker;
 use bollard::errors::Error as BollardError;
 use bollard::models::ContainerCreateBody;
@@ -280,6 +282,7 @@ struct SandboxRecord {
     process: Option<Arc<Mutex<VmProcess>>>,
     provisioning_task: Option<JoinHandle<()>>,
     gpu_bdf: Option<String>,
+    qemu_network_allocated: bool,
     deleting: bool,
 }
 
@@ -298,10 +301,18 @@ pub struct VmDriver {
     events: broadcast::Sender<WatchSandboxesEvent>,
     gpu_inventory: Option<Arc<std::sync::Mutex<GpuInventory>>>,
     subnet_allocator: Arc<std::sync::Mutex<SubnetAllocator>>,
+    lifecycle_extensions: Arc<VmLifecycleExtensions>,
 }
 
 impl VmDriver {
     pub async fn new(config: VmDriverConfig) -> Result<Self, String> {
+        Self::new_with_extensions(config, VmLifecycleExtensions::new()).await
+    }
+
+    pub async fn new_with_extensions(
+        config: VmDriverConfig,
+        lifecycle_extensions: VmLifecycleExtensions,
+    ) -> Result<Self, String> {
         if config.openshell_endpoint.trim().is_empty() {
             return Err("openshell endpoint is required".to_string());
         }
@@ -366,6 +377,7 @@ impl VmDriver {
             events,
             gpu_inventory,
             subnet_allocator,
+            lifecycle_extensions: Arc::new(lifecycle_extensions),
         };
         driver.restore_persisted_sandboxes().await;
         Ok(driver)
@@ -403,6 +415,9 @@ impl VmDriver {
             "vm driver: create_sandbox received"
         );
         validate_vm_sandbox(sandbox, self.config.gpu_enabled)?;
+        self.validate_extension_backend_requirements(
+            sandbox.spec.as_ref().is_some_and(|spec| spec.gpu),
+        )?;
 
         let state_dir = sandbox_state_dir(&self.config.state_dir, &sandbox.id)?;
         let image_ref = self.resolved_sandbox_image(sandbox).ok_or_else(|| {
@@ -431,6 +446,7 @@ impl VmDriver {
                     process: None,
                     provisioning_task: None,
                     gpu_bdf: None,
+                    qemu_network_allocated: false,
                     deleting: false,
                 },
             );
@@ -554,6 +570,8 @@ impl VmDriver {
         overlay_preparation: OverlayPreparation,
     ) -> Result<(), Status> {
         self.ensure_provisioning_active(&sandbox.id).await?;
+        let is_gpu = sandbox.spec.as_ref().is_some_and(|spec| spec.gpu);
+        self.validate_extension_backend_requirements(is_gpu)?;
         self.publish_platform_event(
             sandbox.id.clone(),
             platform_event(
@@ -615,11 +633,70 @@ impl VmDriver {
             )));
         }
 
-        let spec = sandbox.spec.as_ref();
-        let is_gpu = spec.is_some_and(|s| s.gpu);
-        let gpu_device = spec.map_or("", |s| s.gpu_device.as_str());
+        let gpu_device = sandbox.spec.as_ref().map_or("", |s| s.gpu_device.as_str());
         let gpu_bdf = if is_gpu {
             Some(self.assign_gpu_to_record(&sandbox.id, gpu_device).await?)
+        } else {
+            None
+        };
+
+        let needs_qemu = is_gpu;
+
+        let mut plan =
+            match self.build_vm_launch_plan(&sandbox.id, needs_qemu, is_gpu, gpu_bdf.clone()) {
+                Ok(plan) => plan,
+                Err(err) => {
+                    self.release_gpu_and_subnet(&sandbox.id);
+                    return Err(err);
+                }
+            };
+        if plan.backend == VmBackend::Qemu
+            && let Err(err) = self.mark_qemu_network_allocated(&sandbox.id).await
+        {
+            self.release_gpu_and_subnet(&sandbox.id);
+            return Err(err);
+        }
+
+        if let Err(err) = self
+            .lifecycle_extensions
+            .before_vm_launch(&sandbox, &state_dir, &mut plan)
+            .await
+        {
+            self.lifecycle_extensions
+                .after_vm_launch_failed(
+                    &sandbox,
+                    &state_dir,
+                    LaunchAbortReason::BeforeLaunchHookFailed,
+                )
+                .await;
+            self.release_gpu_and_subnet(&sandbox.id);
+            let message = format!(
+                "vm lifecycle extension rejected sandbox launch: {}",
+                err.message()
+            );
+            return Err(if err.is_resource_exhausted() {
+                Status::resource_exhausted(message)
+            } else {
+                Status::failed_precondition(message)
+            });
+        }
+
+        if let Err(err) = Self::validate_launch_plan_backend(is_gpu, &plan) {
+            self.lifecycle_extensions
+                .after_vm_launch_failed(
+                    &sandbox,
+                    &state_dir,
+                    LaunchAbortReason::BeforeLaunchHookFailed,
+                )
+                .await;
+            self.release_gpu_and_subnet(&sandbox.id);
+            return Err(err);
+        }
+
+        let endpoint_override = if plan.backend == VmBackend::Qemu {
+            plan.host_ip.as_deref().map(|host_ip| {
+                guest_visible_openshell_endpoint_for_tap(&self.config.openshell_endpoint, host_ip)
+            })
         } else {
             None
         };
@@ -639,66 +716,34 @@ impl VmDriver {
         command.arg("--vm-exec").arg(sandbox_guest_init_path());
         command.arg("--vm-workdir").arg("/");
         command.arg("--vm-console-output").arg(&console_output);
+        command.arg("--vm-vcpus").arg(plan.vcpus.to_string());
+        command.arg("--vm-mem-mib").arg(plan.mem_mib.to_string());
 
-        // Compute the endpoint override before building the env so
-        // there is a single OPENSHELL_ENDPOINT value in the env list.
-        let endpoint_override = if let Some(bdf) = gpu_bdf.as_ref() {
-            let subnet = match self
-                .subnet_allocator
-                .lock()
-                .map_err(|e| Status::internal(format!("subnet allocator lock poisoned: {e}")))
-                .and_then(|mut alloc| {
-                    alloc
-                        .allocate(&sandbox.id)
-                        .map_err(Status::failed_precondition)
-                }) {
-                Ok(s) => s,
-                Err(err) => {
-                    self.release_gpu_and_subnet(&sandbox.id);
-                    return Err(err);
-                }
-            };
-            let vsock_cid = allocate_vsock_cid();
-            let mac = mac_from_sandbox_id(&sandbox.id);
-            let mac_str = format!(
-                "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
-                mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
-            );
-            let tap = tap_device_name(&sandbox.id);
-
-            let tap_endpoint = guest_visible_openshell_endpoint_for_tap(
-                &self.config.openshell_endpoint,
-                &subnet.host_ip.to_string(),
-            );
-
+        if plan.backend == VmBackend::Qemu {
             command.arg("--vm-backend").arg("qemu");
-            command
-                .arg("--vm-vcpus")
-                .arg(self.config.gpu_vcpus.to_string());
-            command
-                .arg("--vm-mem-mib")
-                .arg(self.config.gpu_mem_mib.to_string());
-            command.arg("--vm-gpu-bdf").arg(bdf);
-            command.arg("--vm-tap-device").arg(&tap);
-            command
-                .arg("--vm-guest-ip")
-                .arg(subnet.guest_ip.to_string());
-            command.arg("--vm-host-ip").arg(subnet.host_ip.to_string());
-            command.arg("--vm-vsock-cid").arg(vsock_cid.to_string());
-            command.arg("--vm-guest-mac").arg(&mac_str);
-
-            if let Some(port) = gateway_port_from_endpoint(&self.config.openshell_endpoint) {
+            if let Some(bdf) = plan.gpu_bdf.as_deref() {
+                command.arg("--vm-gpu-bdf").arg(bdf);
+            }
+            if let Some(tap) = plan.tap_device.as_deref() {
+                command.arg("--vm-tap-device").arg(tap);
+            }
+            if let Some(guest_ip) = plan.guest_ip.as_deref() {
+                command.arg("--vm-guest-ip").arg(guest_ip);
+            }
+            if let Some(host_ip) = plan.host_ip.as_deref() {
+                command.arg("--vm-host-ip").arg(host_ip);
+            }
+            if let Some(vsock_cid) = plan.vsock_cid {
+                command.arg("--vm-vsock-cid").arg(vsock_cid.to_string());
+            }
+            if let Some(guest_mac) = plan.guest_mac.as_deref() {
+                command.arg("--vm-guest-mac").arg(guest_mac);
+            }
+            if let Some(port) = plan.gateway_port {
                 command.arg("--vm-gateway-port").arg(port.to_string());
             }
+        }
 
-            Some(tap_endpoint)
-        } else {
-            command.arg("--vm-vcpus").arg(self.config.vcpus.to_string());
-            command
-                .arg("--vm-mem-mib")
-                .arg(self.config.mem_mib.to_string());
-            None
-        };
         self.ensure_provisioning_active(&sandbox.id).await?;
 
         command
@@ -706,6 +751,9 @@ impl VmDriver {
             .arg(self.config.krun_log_level.to_string());
 
         for env in build_guest_environment(&sandbox, &self.config, endpoint_override.as_deref()) {
+            command.arg("--vm-env").arg(env);
+        }
+        for env in &plan.env {
             command.arg("--vm-env").arg(env);
         }
 
@@ -723,9 +771,14 @@ impl VmDriver {
                     error = %err,
                     "vm driver: launcher spawn failed"
                 );
-                if gpu_bdf.is_some() {
-                    self.release_gpu_and_subnet(&sandbox.id);
-                }
+                self.lifecycle_extensions
+                    .after_vm_launch_failed(
+                        &sandbox,
+                        &state_dir,
+                        LaunchAbortReason::LauncherSpawnFailed,
+                    )
+                    .await;
+                self.release_gpu_and_subnet(&sandbox.id);
                 return Err(Status::internal(format!(
                     "failed to launch vm helper '{}': {err}",
                     self.launcher_bin.display()
@@ -750,6 +803,7 @@ impl VmDriver {
                 Some(record) if !record.deleting => {
                     record.process = Some(process.clone());
                     record.gpu_bdf.clone_from(&gpu_bdf);
+                    record.qemu_network_allocated = plan.backend == VmBackend::Qemu;
                     record.provisioning_task = None;
                     snapshot_to_publish = Some(record.snapshot.clone());
                 }
@@ -814,7 +868,14 @@ impl VmDriver {
             return Ok(DeleteSandboxResponse { deleted: false });
         };
 
-        let (state_dir, process, gpu_bdf, provisioning_task) = {
+        let (
+            state_dir,
+            process,
+            gpu_bdf,
+            qemu_network_allocated,
+            provisioning_task,
+            sandbox_snapshot,
+        ) = {
             let mut registry = self.registry.lock().await;
             let Some(record) = registry.get_mut(&record_id) else {
                 return Ok(DeleteSandboxResponse { deleted: false });
@@ -824,7 +885,9 @@ impl VmDriver {
                 record.state_dir.clone(),
                 record.process.clone(),
                 record.gpu_bdf.clone(),
+                record.qemu_network_allocated,
                 record.provisioning_task.take(),
+                record.snapshot.clone(),
             )
         };
 
@@ -847,9 +910,11 @@ impl VmDriver {
                 .map_err(|err| Status::internal(format!("failed to stop vm: {err}")))?;
         }
 
-        if gpu_bdf.is_some() {
-            self.release_gpu_and_subnet(&record_id);
-        }
+        self.lifecycle_extensions
+            .after_sandbox_deleted(&sandbox_snapshot, &state_dir)
+            .await;
+
+        self.release_allocations(&record_id, gpu_bdf.is_some(), qemu_network_allocated);
 
         remove_sandbox_state_dir(&self.config.state_dir, &state_dir).await?;
 
@@ -1005,6 +1070,7 @@ impl VmDriver {
                     process: None,
                     provisioning_task: None,
                     gpu_bdf: None,
+                    qemu_network_allocated: false,
                     deleting: false,
                 },
             );
@@ -1047,15 +1113,128 @@ impl VmDriver {
         }
     }
 
-    fn release_gpu_and_subnet(&self, sandbox_id: &str) {
+    fn release_gpu(&self, sandbox_id: &str) {
         if let Some(inventory) = self.gpu_inventory.as_ref()
             && let Ok(mut inv) = inventory.lock()
         {
             inv.release(sandbox_id);
         }
+    }
+
+    fn release_subnet(&self, sandbox_id: &str) {
         if let Ok(mut alloc) = self.subnet_allocator.lock() {
             alloc.release(sandbox_id);
         }
+    }
+
+    fn release_allocations(&self, sandbox_id: &str, has_gpu: bool, has_qemu_network: bool) {
+        if has_gpu {
+            self.release_gpu(sandbox_id);
+        }
+        if has_qemu_network {
+            self.release_subnet(sandbox_id);
+        }
+    }
+
+    fn release_gpu_and_subnet(&self, sandbox_id: &str) {
+        self.release_gpu(sandbox_id);
+        self.release_subnet(sandbox_id);
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn validate_extension_backend_requirements(&self, is_gpu: bool) -> Result<(), Status> {
+        if self.lifecycle_extensions.requires_qemu() && !is_gpu {
+            return Err(Status::failed_precondition(
+                "vm lifecycle extension requires QEMU, but non-GPU QEMU launch support requires concrete PCI device transport",
+            ));
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn validate_launch_plan_backend(is_gpu: bool, plan: &VmLaunchPlan) -> Result<(), Status> {
+        if plan.backend == VmBackend::Qemu && !is_gpu {
+            return Err(Status::failed_precondition(
+                "vm lifecycle extension selected QEMU, but non-GPU QEMU launch support requires concrete PCI device transport",
+            ));
+        }
+        if plan.backend != VmBackend::Qemu && is_gpu {
+            return Err(Status::failed_precondition(
+                "GPU sandbox launch requires the QEMU backend",
+            ));
+        }
+        Ok(())
+    }
+
+    async fn mark_qemu_network_allocated(&self, sandbox_id: &str) -> Result<(), Status> {
+        let mut registry = self.registry.lock().await;
+        match registry.get_mut(sandbox_id) {
+            Some(record) if !record.deleting => {
+                record.qemu_network_allocated = true;
+                Ok(())
+            }
+            _ => Err(Status::cancelled("sandbox provisioning cancelled")),
+        }
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn build_vm_launch_plan(
+        &self,
+        sandbox_id: &str,
+        needs_qemu: bool,
+        is_gpu: bool,
+        gpu_bdf: Option<String>,
+    ) -> Result<VmLaunchPlan, Status> {
+        if !needs_qemu {
+            return Ok(VmLaunchPlan {
+                backend: VmBackend::Libkrun,
+                vcpus: self.config.vcpus,
+                mem_mib: self.config.mem_mib,
+                gpu_bdf: None,
+                tap_device: None,
+                guest_ip: None,
+                host_ip: None,
+                vsock_cid: None,
+                guest_mac: None,
+                gateway_port: None,
+                env: Vec::new(),
+            });
+        }
+
+        let subnet = self
+            .subnet_allocator
+            .lock()
+            .map_err(|e| Status::internal(format!("subnet allocator lock poisoned: {e}")))?
+            .allocate(sandbox_id)
+            .map_err(Status::failed_precondition)?;
+        let vsock_cid = allocate_vsock_cid();
+        let mac = mac_from_sandbox_id(sandbox_id);
+        let mac_str = format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+        );
+        let tap = tap_device_name(sandbox_id);
+        let gateway_port = gateway_port_from_endpoint(&self.config.openshell_endpoint);
+
+        let (vcpus, mem_mib) = if is_gpu {
+            (self.config.gpu_vcpus, self.config.gpu_mem_mib)
+        } else {
+            (self.config.vcpus, self.config.mem_mib)
+        };
+
+        Ok(VmLaunchPlan {
+            backend: VmBackend::Qemu,
+            vcpus,
+            mem_mib,
+            gpu_bdf,
+            tap_device: Some(tap),
+            guest_ip: Some(subnet.guest_ip.to_string()),
+            host_ip: Some(subnet.host_ip.to_string()),
+            vsock_cid: Some(vsock_cid),
+            guest_mac: Some(mac_str),
+            gateway_port,
+            env: Vec::new(),
+        })
     }
 
     async fn ensure_provisioning_active(&self, sandbox_id: &str) -> Result<(), Status> {
@@ -1121,6 +1300,7 @@ impl VmDriver {
             record.process = None;
             record.provisioning_task = None;
             record.gpu_bdf = None;
+            record.qemu_network_allocated = false;
             record.snapshot.status = Some(status_with_condition(
                 &record.snapshot,
                 error_condition(reason, message),
@@ -2340,16 +2520,13 @@ impl VmDriver {
                     sandbox_id.clone(),
                     platform_event("vm", "Warning", "ProcessExited", message),
                 );
-                let has_gpu = {
+                let (has_gpu, has_qemu_network) = {
                     let registry = self.registry.lock().await;
-                    registry
-                        .get(&sandbox_id)
-                        .and_then(|r| r.gpu_bdf.as_ref())
-                        .is_some()
+                    registry.get(&sandbox_id).map_or((false, false), |record| {
+                        (record.gpu_bdf.is_some(), record.qemu_network_allocated)
+                    })
                 };
-                if has_gpu {
-                    self.release_gpu_and_subnet(&sandbox_id);
-                }
+                self.release_allocations(&sandbox_id, has_gpu, has_qemu_network);
                 return;
             }
 
@@ -4785,6 +4962,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
+            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
         };
 
         assert_eq!(driver.capabilities().default_image, "openshell/sandbox:dev");
@@ -4806,6 +4984,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
+            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
         };
         let sandbox = Sandbox {
             spec: Some(SandboxSpec {
@@ -4840,6 +5019,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
+            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
         };
         let sandbox = Sandbox {
             spec: Some(SandboxSpec {
@@ -4868,6 +5048,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
+            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
         };
         let sandbox = Sandbox {
             spec: Some(SandboxSpec {
@@ -4897,6 +5078,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
+            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
         };
 
         assert_eq!(
@@ -4921,6 +5103,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
+            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
         };
 
         assert_eq!(
@@ -4942,6 +5125,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
+            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
         };
 
         assert_eq!(
@@ -5329,6 +5513,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
+            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
         };
 
         let state_file = sandbox_state_dir(&driver_state, "sandbox-123").unwrap();
@@ -5392,6 +5577,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
+            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
         };
 
         let state_dir = sandbox_state_dir(&driver_state, "sandbox-123").unwrap();
@@ -5410,6 +5596,7 @@ mod tests {
                     process: None,
                     provisioning_task: None,
                     gpu_bdf: None,
+                    qemu_network_allocated: false,
                     deleting: false,
                 },
             );
@@ -5446,6 +5633,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
+            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
         };
 
         let state_dir = sandbox_state_dir(&driver_state, "sandbox-123").unwrap();
@@ -5465,6 +5653,7 @@ mod tests {
                     process: None,
                     provisioning_task: None,
                     gpu_bdf: None,
+                    qemu_network_allocated: false,
                     deleting: false,
                 },
             );
@@ -5792,8 +5981,234 @@ mod tests {
                 process: Some(process),
                 provisioning_task: None,
                 gpu_bdf: None,
+                qemu_network_allocated: false,
                 deleting: false,
             },
         );
+    }
+
+    use crate::extension::{
+        VmLaunchPlan, VmLifecycleError, VmLifecycleExtension, VmLifecycleExtensions,
+        VmLifecycleResult,
+    };
+    use crate::runtime::VmBackend;
+
+    fn test_driver_with_extensions(extensions: VmLifecycleExtensions) -> VmDriver {
+        let (events, _) = broadcast::channel(WATCH_BUFFER);
+        VmDriver {
+            config: VmDriverConfig {
+                openshell_endpoint: "http://127.0.0.1:8080".to_string(),
+                vcpus: 2,
+                mem_mib: 2048,
+                gpu_vcpus: 8,
+                gpu_mem_mib: 16384,
+                ..Default::default()
+            },
+            launcher_bin: PathBuf::from("openshell-driver-vm"),
+            registry: Arc::new(Mutex::new(HashMap::new())),
+            image_cache_lock: Arc::new(Mutex::new(())),
+            events,
+            gpu_inventory: None,
+            subnet_allocator: Arc::new(std::sync::Mutex::new(SubnetAllocator::new(
+                Ipv4Addr::new(10, 0, 128, 0),
+                17,
+            ))),
+            lifecycle_extensions: Arc::new(extensions),
+        }
+    }
+
+    #[derive(Debug)]
+    struct QemuRequiringExtension {
+        name: String,
+    }
+
+    #[tonic::async_trait]
+    impl VmLifecycleExtension for QemuRequiringExtension {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn required_backend(&self) -> Option<VmBackend> {
+            Some(VmBackend::Qemu)
+        }
+
+        async fn before_vm_launch(
+            &self,
+            _sandbox: &Sandbox,
+            _state_dir: &Path,
+            plan: &mut VmLaunchPlan,
+        ) -> VmLifecycleResult<()> {
+            if plan.backend != VmBackend::Qemu {
+                return Err(VmLifecycleError::new(
+                    "qemu-requiring extension demands QEMU backend",
+                ));
+            }
+            plan.env.push("EXT_DECLARED_QEMU=1".to_string());
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct AlwaysFailsExtension;
+
+    #[tonic::async_trait]
+    impl VmLifecycleExtension for AlwaysFailsExtension {
+        fn name(&self) -> &'static str {
+            "always-fails"
+        }
+
+        async fn before_vm_launch(
+            &self,
+            _sandbox: &Sandbox,
+            _state_dir: &Path,
+            _plan: &mut VmLaunchPlan,
+        ) -> VmLifecycleResult<()> {
+            Err(VmLifecycleError::resource_exhausted("pool empty"))
+        }
+    }
+
+    #[test]
+    fn empty_registry_keeps_non_gpu_sandbox_on_libkrun() {
+        let driver = test_driver_with_extensions(VmLifecycleExtensions::new());
+
+        let plan = driver
+            .build_vm_launch_plan("sandbox-x", false, false, None)
+            .expect("plan should build");
+
+        assert_eq!(plan.backend, VmBackend::Libkrun);
+        assert_eq!(plan.vcpus, 2);
+        assert_eq!(plan.mem_mib, 2048);
+        assert!(plan.tap_device.is_none());
+        assert!(plan.guest_ip.is_none());
+        assert!(plan.host_ip.is_none());
+        assert!(plan.vsock_cid.is_none());
+        assert!(plan.guest_mac.is_none());
+        assert!(plan.gpu_bdf.is_none());
+        assert!(plan.env.is_empty());
+    }
+
+    #[test]
+    fn empty_registry_does_not_force_qemu() {
+        let driver = test_driver_with_extensions(VmLifecycleExtensions::new());
+        assert!(!driver.lifecycle_extensions.requires_qemu());
+    }
+
+    #[test]
+    fn gpu_sandbox_uses_qemu_backend_and_gpu_sizing() {
+        let driver = test_driver_with_extensions(VmLifecycleExtensions::new());
+
+        let plan = driver
+            .build_vm_launch_plan("sandbox-gpu", true, true, Some("0000:01:00.0".to_string()))
+            .expect("gpu plan should build");
+
+        assert_eq!(plan.backend, VmBackend::Qemu);
+        assert_eq!(plan.vcpus, 8);
+        assert_eq!(plan.mem_mib, 16384);
+        assert_eq!(plan.gpu_bdf.as_deref(), Some("0000:01:00.0"));
+        assert!(plan.tap_device.is_some());
+        assert!(plan.guest_ip.is_some());
+        assert!(plan.host_ip.is_some());
+        assert!(plan.vsock_cid.is_some());
+        assert!(plan.guest_mac.is_some());
+    }
+
+    #[test]
+    fn extension_requiring_qemu_rejects_non_gpu_until_pci_transport() {
+        let mut extensions = VmLifecycleExtensions::new();
+        extensions.push(Arc::new(QemuRequiringExtension {
+            name: "test-ext".to_string(),
+        }));
+        let driver = test_driver_with_extensions(extensions);
+        assert!(driver.lifecycle_extensions.requires_qemu());
+
+        let err = driver
+            .validate_extension_backend_requirements(false)
+            .expect_err("non-GPU QEMU extension requests need concrete PCI transport");
+        assert_eq!(err.code(), Code::FailedPrecondition);
+        assert!(err.message().contains("concrete PCI device transport"));
+
+        driver
+            .validate_extension_backend_requirements(true)
+            .expect("GPU sandboxes already use the QEMU backend");
+    }
+
+    #[tokio::test]
+    async fn extension_can_validate_backend_in_before_vm_launch() {
+        let extension = Arc::new(QemuRequiringExtension {
+            name: "validate".to_string(),
+        });
+        let extensions = VmLifecycleExtensions::with(vec![extension.clone()]);
+        let sandbox = Sandbox {
+            id: "sandbox-validate".to_string(),
+            name: "sandbox-validate".to_string(),
+            ..Default::default()
+        };
+
+        let mut libkrun_plan = VmLaunchPlan {
+            backend: VmBackend::Libkrun,
+            vcpus: 2,
+            mem_mib: 2048,
+            gpu_bdf: None,
+            tap_device: None,
+            guest_ip: None,
+            host_ip: None,
+            vsock_cid: None,
+            guest_mac: None,
+            gateway_port: None,
+            env: Vec::new(),
+        };
+        let err = extensions
+            .before_vm_launch(&sandbox, Path::new("/tmp/state"), &mut libkrun_plan)
+            .await
+            .expect_err("backend mismatch should fail validation");
+        assert!(err.message().contains("demands QEMU"));
+
+        let mut qemu_plan = VmLaunchPlan {
+            backend: VmBackend::Qemu,
+            vcpus: 2,
+            mem_mib: 2048,
+            gpu_bdf: None,
+            tap_device: Some("vmtap-x".to_string()),
+            guest_ip: Some("10.0.0.2".to_string()),
+            host_ip: Some("10.0.0.1".to_string()),
+            vsock_cid: Some(7),
+            guest_mac: Some("02:00:00:00:00:01".to_string()),
+            gateway_port: Some(8080),
+            env: Vec::new(),
+        };
+        extensions
+            .before_vm_launch(&sandbox, Path::new("/tmp/state"), &mut qemu_plan)
+            .await
+            .expect("QEMU backend should satisfy the extension");
+        assert!(qemu_plan.env.contains(&"EXT_DECLARED_QEMU=1".to_string()));
+    }
+
+    #[tokio::test]
+    async fn lifecycle_error_resource_exhausted_propagates() {
+        let extensions = VmLifecycleExtensions::with(vec![Arc::new(AlwaysFailsExtension)]);
+        let sandbox = Sandbox {
+            id: "sandbox-resource".to_string(),
+            name: "sandbox-resource".to_string(),
+            ..Default::default()
+        };
+        let mut plan = VmLaunchPlan {
+            backend: VmBackend::Qemu,
+            vcpus: 2,
+            mem_mib: 2048,
+            gpu_bdf: None,
+            tap_device: Some("vmtap-x".to_string()),
+            guest_ip: Some("10.0.0.2".to_string()),
+            host_ip: Some("10.0.0.1".to_string()),
+            vsock_cid: Some(7),
+            guest_mac: Some("02:00:00:00:00:01".to_string()),
+            gateway_port: Some(8080),
+            env: Vec::new(),
+        };
+        let err = extensions
+            .before_vm_launch(&sandbox, Path::new("/tmp/state"), &mut plan)
+            .await
+            .expect_err("scripted pool exhaustion should surface");
+        assert!(err.is_resource_exhausted());
+        assert_eq!(err.message(), "pool empty");
     }
 }

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::extension::{
-    LaunchAbortReason, VmBackendFeature, VmGuestInitDropIn, VmLaunchPlan, VmLifecycleExtensions,
-    VmPersistedSandbox, extension_state_dir,
+use crate::lifecycle::{
+    BackendFeature, GuestInitDropin, LaunchAbortReason, LaunchPlan, LifecycleExtensionRegistry,
+    RestoreContext, extension_state_dir,
 };
 use crate::gpu::{
     GpuInventory, SubnetAllocator, allocate_vsock_cid, mac_from_sandbox_id, tap_device_name,
@@ -305,17 +305,17 @@ pub struct VmDriver {
     events: broadcast::Sender<WatchSandboxesEvent>,
     gpu_inventory: Option<Arc<std::sync::Mutex<GpuInventory>>>,
     subnet_allocator: Arc<std::sync::Mutex<SubnetAllocator>>,
-    lifecycle_extensions: Arc<VmLifecycleExtensions>,
+    lifecycle_extensions: Arc<LifecycleExtensionRegistry>,
 }
 
 impl VmDriver {
     pub async fn new(config: VmDriverConfig) -> Result<Self, String> {
-        Self::new_with_extensions(config, VmLifecycleExtensions::new()).await
+        Self::new_with_extensions(config, LifecycleExtensionRegistry::new()).await
     }
 
     pub async fn new_with_extensions(
         config: VmDriverConfig,
-        lifecycle_extensions: VmLifecycleExtensions,
+        lifecycle_extensions: LifecycleExtensionRegistry,
     ) -> Result<Self, String> {
         lifecycle_extensions
             .validate()
@@ -663,11 +663,11 @@ impl VmDriver {
 
         if let Err(err) = self
             .lifecycle_extensions
-            .configure_vm_launch(&sandbox, &state_dir, &mut plan)
+            .configure_launch(&sandbox, &state_dir, &mut plan)
             .await
         {
             self.lifecycle_extensions
-                .after_vm_launch_failed(
+                .after_launch_failed(
                     &sandbox,
                     &state_dir,
                     LaunchAbortReason::BeforeLaunchHookFailed,
@@ -686,9 +686,9 @@ impl VmDriver {
         }
 
         // Resolve and validate the backend from the requirements that
-        // `configure_vm_launch` extensions contributed. After this point the
+        // `configure_launch` extensions contributed. After this point the
         // plan's backend, sizing, and host allocations (subnet, tap, vsock)
-        // are final; the `before_vm_launch` hook below may still mutate
+        // are final; the `before_launch` hook below may still mutate
         // `plan.env` and `plan.guest_init_dropins` and may abort the launch,
         // but it MUST NOT change `plan.backend`, `plan.required_backends`,
         // or `plan.required_backend_features` -- those are enforced as a
@@ -697,7 +697,7 @@ impl VmDriver {
             self.resolve_launch_plan_backend(&sandbox.id, is_gpu, gpu_bdf.clone(), &mut plan)
         {
             self.lifecycle_extensions
-                .after_vm_launch_failed(
+                .after_launch_failed(
                     &sandbox,
                     &state_dir,
                     LaunchAbortReason::BeforeLaunchHookFailed,
@@ -709,7 +709,7 @@ impl VmDriver {
 
         if let Err(err) = Self::validate_launch_plan_backend(is_gpu, &plan) {
             self.lifecycle_extensions
-                .after_vm_launch_failed(
+                .after_launch_failed(
                     &sandbox,
                     &state_dir,
                     LaunchAbortReason::BeforeLaunchHookFailed,
@@ -728,11 +728,11 @@ impl VmDriver {
 
         if let Err(err) = self
             .lifecycle_extensions
-            .before_vm_launch(&sandbox, &state_dir, &mut plan)
+            .before_launch(&sandbox, &state_dir, &mut plan)
             .await
         {
             self.lifecycle_extensions
-                .after_vm_launch_failed(
+                .after_launch_failed(
                     &sandbox,
                     &state_dir,
                     LaunchAbortReason::BeforeLaunchHookFailed,
@@ -752,7 +752,7 @@ impl VmDriver {
 
         if let Err(err) = inject_guest_init_dropins(&overlay_disk, &plan.guest_init_dropins) {
             self.lifecycle_extensions
-                .after_vm_launch_failed(&sandbox, &state_dir, LaunchAbortReason::GuestPrepareFailed)
+                .after_launch_failed(&sandbox, &state_dir, LaunchAbortReason::GuestPrepareFailed)
                 .await;
             self.release_gpu_and_subnet(&sandbox.id);
             return Err(err);
@@ -840,7 +840,7 @@ impl VmDriver {
                     "vm driver: launcher spawn failed"
                 );
                 self.lifecycle_extensions
-                    .after_vm_launch_failed(
+                    .after_launch_failed(
                         &sandbox,
                         &state_dir,
                         LaunchAbortReason::LauncherSpawnFailed,
@@ -901,12 +901,12 @@ impl VmDriver {
             self.publish_snapshot(snapshot);
         }
         if overlay_preparation == OverlayPreparation::PreserveExisting {
-            let persisted = VmPersistedSandbox {
+            let persisted = RestoreContext {
                 sandbox: sandbox.clone(),
                 state_dir: state_dir.clone(),
             };
             self.lifecycle_extensions
-                .reconcile_after_restore(&persisted)
+                .after_restore(&persisted)
                 .await;
         }
         tokio::spawn({
@@ -988,7 +988,7 @@ impl VmDriver {
         }
 
         self.lifecycle_extensions
-            .after_sandbox_deleted(&sandbox_snapshot, &state_dir)
+            .after_delete(&sandbox_snapshot, &state_dir)
             .await;
 
         self.release_allocations(&record_id, gpu_bdf.is_some(), qemu_network_allocated);
@@ -1144,13 +1144,13 @@ impl VmDriver {
             return;
         }
 
-        let persisted = VmPersistedSandbox {
+        let persisted = RestoreContext {
             sandbox: sandbox.clone(),
             state_dir: state_dir.clone(),
         };
         if let Err(err) = self
             .lifecycle_extensions
-            .reconcile_before_restore(&persisted)
+            .before_restore(&persisted)
             .await
         {
             warn!(
@@ -1275,13 +1275,13 @@ impl VmDriver {
         sandbox_id: &str,
         is_gpu: bool,
         gpu_bdf: Option<String>,
-        plan: &mut VmLaunchPlan,
+        plan: &mut LaunchPlan,
     ) -> Result<(), Status> {
         if plan.kernel_image.is_some() {
-            plan.require_backend_feature(VmBackendFeature::ExternalKernelImage);
+            plan.require_backend_feature(BackendFeature::ExternalKernelImage);
         }
         if !plan.guest_init_dropins.is_empty() {
-            plan.require_backend_feature(VmBackendFeature::GuestInitDropins);
+            plan.require_backend_feature(BackendFeature::GuestInitDropins);
         }
 
         if plan.required_backends.contains(&VmBackend::Qemu)
@@ -1303,7 +1303,7 @@ impl VmDriver {
         sandbox_id: &str,
         is_gpu: bool,
         gpu_bdf: Option<String>,
-        plan: &mut VmLaunchPlan,
+        plan: &mut LaunchPlan,
     ) -> Result<(), Status> {
         plan.backend = VmBackend::Qemu;
         if is_gpu {
@@ -1337,7 +1337,7 @@ impl VmDriver {
     }
 
     #[allow(clippy::result_large_err)]
-    fn validate_launch_plan_backend(is_gpu: bool, plan: &VmLaunchPlan) -> Result<(), Status> {
+    fn validate_launch_plan_backend(is_gpu: bool, plan: &LaunchPlan) -> Result<(), Status> {
         // NOTE: this guard exists because the non-GPU QEMU launch path
         // (PCI device transport, VFIO root port wiring) has not landed
         // yet. Until then, even though the resolver will happily promote
@@ -1429,9 +1429,9 @@ impl VmDriver {
         needs_qemu: bool,
         is_gpu: bool,
         gpu_bdf: Option<String>,
-    ) -> Result<VmLaunchPlan, Status> {
+    ) -> Result<LaunchPlan, Status> {
         if !needs_qemu {
-            return Ok(VmLaunchPlan {
+            return Ok(LaunchPlan {
                 backend: VmBackend::Libkrun,
                 vcpus: self.config.vcpus,
                 mem_mib: self.config.mem_mib,
@@ -1472,7 +1472,7 @@ impl VmDriver {
             (self.config.vcpus, self.config.mem_mib)
         };
 
-        Ok(VmLaunchPlan {
+        Ok(LaunchPlan {
             backend: VmBackend::Qemu,
             vcpus,
             mem_mib,
@@ -3862,7 +3862,7 @@ fn gateway_port_from_endpoint(endpoint: &str) -> Option<u16> {
     Url::parse(endpoint).ok().and_then(|url| url.port())
 }
 
-fn has_complete_qemu_network(plan: &VmLaunchPlan) -> bool {
+fn has_complete_qemu_network(plan: &LaunchPlan) -> bool {
     plan.tap_device.is_some()
         && plan.guest_ip.is_some()
         && plan.host_ip.is_some()
@@ -4479,7 +4479,7 @@ fn inject_guest_sandbox_token(overlay_disk: &Path, token: &str) -> Result<(), St
 #[allow(clippy::result_large_err)]
 fn inject_guest_init_dropins(
     overlay_disk: &Path,
-    dropins: &[VmGuestInitDropIn],
+    dropins: &[GuestInitDropin],
 ) -> Result<(), Status> {
     validate_guest_init_dropins(dropins).map_err(Status::failed_precondition)?;
 
@@ -4505,7 +4505,7 @@ fn inject_guest_init_dropins(
     Ok(())
 }
 
-fn validate_guest_init_dropins(dropins: &[VmGuestInitDropIn]) -> Result<(), String> {
+fn validate_guest_init_dropins(dropins: &[GuestInitDropin]) -> Result<(), String> {
     let mut names = HashSet::new();
     for dropin in dropins {
         validate_guest_init_dropin_name(&dropin.name)?;
@@ -5280,7 +5280,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
-            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
+            lifecycle_extensions: Arc::new(LifecycleExtensionRegistry::new()),
         };
 
         assert_eq!(driver.capabilities().default_image, "openshell/sandbox:dev");
@@ -5302,7 +5302,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
-            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
+            lifecycle_extensions: Arc::new(LifecycleExtensionRegistry::new()),
         };
         let sandbox = Sandbox {
             spec: Some(SandboxSpec {
@@ -5337,7 +5337,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
-            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
+            lifecycle_extensions: Arc::new(LifecycleExtensionRegistry::new()),
         };
         let sandbox = Sandbox {
             spec: Some(SandboxSpec {
@@ -5366,7 +5366,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
-            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
+            lifecycle_extensions: Arc::new(LifecycleExtensionRegistry::new()),
         };
         let sandbox = Sandbox {
             spec: Some(SandboxSpec {
@@ -5396,7 +5396,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
-            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
+            lifecycle_extensions: Arc::new(LifecycleExtensionRegistry::new()),
         };
 
         assert_eq!(
@@ -5421,7 +5421,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
-            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
+            lifecycle_extensions: Arc::new(LifecycleExtensionRegistry::new()),
         };
 
         assert_eq!(
@@ -5443,7 +5443,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
-            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
+            lifecycle_extensions: Arc::new(LifecycleExtensionRegistry::new()),
         };
 
         assert_eq!(
@@ -5831,7 +5831,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
-            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
+            lifecycle_extensions: Arc::new(LifecycleExtensionRegistry::new()),
         };
 
         let state_file = sandbox_state_dir(&driver_state, "sandbox-123").unwrap();
@@ -5895,7 +5895,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
-            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
+            lifecycle_extensions: Arc::new(LifecycleExtensionRegistry::new()),
         };
 
         let state_dir = sandbox_state_dir(&driver_state, "sandbox-123").unwrap();
@@ -5951,7 +5951,7 @@ mod tests {
                 Ipv4Addr::new(10, 0, 128, 0),
                 17,
             ))),
-            lifecycle_extensions: Arc::new(VmLifecycleExtensions::new()),
+            lifecycle_extensions: Arc::new(LifecycleExtensionRegistry::new()),
         };
 
         let state_dir = sandbox_state_dir(&driver_state, "sandbox-123").unwrap();
@@ -6305,13 +6305,13 @@ mod tests {
         );
     }
 
-    use crate::extension::{
-        VmBackendFeature, VmLaunchPlan, VmLifecycleError, VmLifecycleExtension,
-        VmLifecycleExtensions, VmLifecycleResult,
+    use crate::lifecycle::{
+        BackendFeature, LaunchPlan, LifecycleError, LifecycleExtension,
+        LifecycleExtensionRegistry, LifecycleResult,
     };
     use crate::runtime::VmBackend;
 
-    fn test_driver_with_extensions(extensions: VmLifecycleExtensions) -> VmDriver {
+    fn test_driver_with_extensions(extensions: LifecycleExtensionRegistry) -> VmDriver {
         let (events, _) = broadcast::channel(WATCH_BUFFER);
         VmDriver {
             config: VmDriverConfig {
@@ -6341,30 +6341,30 @@ mod tests {
     }
 
     #[tonic::async_trait]
-    impl VmLifecycleExtension for QemuRequiringExtension {
+    impl LifecycleExtension for QemuRequiringExtension {
         fn name(&self) -> &str {
             &self.name
         }
 
-        async fn configure_vm_launch(
+        async fn configure_launch(
             &self,
             _sandbox: &Sandbox,
             _state_dir: &Path,
-            plan: &mut VmLaunchPlan,
-        ) -> VmLifecycleResult<()> {
+            plan: &mut LaunchPlan,
+        ) -> LifecycleResult<()> {
             plan.require_backend(VmBackend::Qemu);
-            plan.require_backend_feature(VmBackendFeature::PciPassthrough);
+            plan.require_backend_feature(BackendFeature::PciPassthrough);
             Ok(())
         }
 
-        async fn before_vm_launch(
+        async fn before_launch(
             &self,
             _sandbox: &Sandbox,
             _state_dir: &Path,
-            plan: &mut VmLaunchPlan,
-        ) -> VmLifecycleResult<()> {
+            plan: &mut LaunchPlan,
+        ) -> LifecycleResult<()> {
             if plan.backend != VmBackend::Qemu {
-                return Err(VmLifecycleError::new(
+                return Err(LifecycleError::new(
                     "qemu-requiring extension demands QEMU backend",
                 ));
             }
@@ -6377,24 +6377,24 @@ mod tests {
     struct AlwaysFailsExtension;
 
     #[tonic::async_trait]
-    impl VmLifecycleExtension for AlwaysFailsExtension {
+    impl LifecycleExtension for AlwaysFailsExtension {
         fn name(&self) -> &'static str {
             "always-fails"
         }
 
-        async fn before_vm_launch(
+        async fn before_launch(
             &self,
             _sandbox: &Sandbox,
             _state_dir: &Path,
-            _plan: &mut VmLaunchPlan,
-        ) -> VmLifecycleResult<()> {
-            Err(VmLifecycleError::resource_exhausted("pool empty"))
+            _plan: &mut LaunchPlan,
+        ) -> LifecycleResult<()> {
+            Err(LifecycleError::resource_exhausted("pool empty"))
         }
     }
 
     #[test]
     fn empty_registry_keeps_non_gpu_sandbox_on_libkrun() {
-        let driver = test_driver_with_extensions(VmLifecycleExtensions::new());
+        let driver = test_driver_with_extensions(LifecycleExtensionRegistry::new());
 
         let plan = driver
             .build_vm_launch_plan("sandbox-x", false, false, None)
@@ -6414,13 +6414,13 @@ mod tests {
 
     #[test]
     fn empty_registry_has_no_extension_descriptors() {
-        let driver = test_driver_with_extensions(VmLifecycleExtensions::new());
+        let driver = test_driver_with_extensions(LifecycleExtensionRegistry::new());
         assert!(driver.lifecycle_extensions.descriptors().is_empty());
     }
 
     #[test]
     fn gpu_sandbox_uses_qemu_backend_and_gpu_sizing() {
-        let driver = test_driver_with_extensions(VmLifecycleExtensions::new());
+        let driver = test_driver_with_extensions(LifecycleExtensionRegistry::new());
 
         let plan = driver
             .build_vm_launch_plan("sandbox-gpu", true, true, Some("0000:01:00.0".to_string()))
@@ -6439,7 +6439,7 @@ mod tests {
 
     #[test]
     fn launch_plan_rejects_external_kernel_on_unsupported_backend() {
-        let mut plan = VmLaunchPlan {
+        let mut plan = LaunchPlan {
             backend: VmBackend::Libkrun,
             vcpus: 2,
             mem_mib: 2048,
@@ -6475,11 +6475,11 @@ mod tests {
 
     #[test]
     fn backend_feature_requirements_select_qemu_launch_plan() {
-        let driver = test_driver_with_extensions(VmLifecycleExtensions::new());
+        let driver = test_driver_with_extensions(LifecycleExtensionRegistry::new());
         let mut plan = driver
             .build_vm_launch_plan("sandbox-vfio", false, false, None)
             .expect("base plan should build");
-        plan.require_backend_feature(VmBackendFeature::PciPassthrough);
+        plan.require_backend_feature(BackendFeature::PciPassthrough);
 
         driver
             .resolve_launch_plan_backend("sandbox-vfio", false, None, &mut plan)
@@ -6497,7 +6497,7 @@ mod tests {
 
     #[test]
     fn explicit_backend_requirement_selects_qemu_launch_plan() {
-        let driver = test_driver_with_extensions(VmLifecycleExtensions::new());
+        let driver = test_driver_with_extensions(LifecycleExtensionRegistry::new());
         let mut plan = driver
             .build_vm_launch_plan("sandbox-qemu", false, false, None)
             .expect("base plan should build");
@@ -6517,11 +6517,11 @@ mod tests {
 
     #[test]
     fn guest_init_dropin_feature_does_not_force_qemu() {
-        let driver = test_driver_with_extensions(VmLifecycleExtensions::new());
+        let driver = test_driver_with_extensions(LifecycleExtensionRegistry::new());
         let mut plan = driver
             .build_vm_launch_plan("sandbox-init", false, false, None)
             .expect("base plan should build");
-        plan.require_backend_feature(VmBackendFeature::GuestInitDropins);
+        plan.require_backend_feature(BackendFeature::GuestInitDropins);
 
         driver
             .resolve_launch_plan_backend("sandbox-init", false, None, &mut plan)
@@ -6533,10 +6533,10 @@ mod tests {
 
     #[test]
     fn guest_init_dropin_validation_rejects_unsafe_or_duplicate_names() {
-        validate_guest_init_dropins(&[VmGuestInitDropIn::new("50-vfio.sh", b"true\n".to_vec())])
+        validate_guest_init_dropins(&[GuestInitDropin::new("50-vfio.sh", b"true\n".to_vec())])
             .expect("safe drop-in name is accepted");
 
-        let err = validate_guest_init_dropins(&[VmGuestInitDropIn::new(
+        let err = validate_guest_init_dropins(&[GuestInitDropin::new(
             "../50-vfio.sh",
             b"true\n".to_vec(),
         )])
@@ -6544,26 +6544,26 @@ mod tests {
         assert!(err.contains("must contain only ASCII"));
 
         let err = validate_guest_init_dropins(&[
-            VmGuestInitDropIn::new("50-vfio.sh", b"true\n".to_vec()),
-            VmGuestInitDropIn::new("50-vfio.sh", b"true\n".to_vec()),
+            GuestInitDropin::new("50-vfio.sh", b"true\n".to_vec()),
+            GuestInitDropin::new("50-vfio.sh", b"true\n".to_vec()),
         ])
         .expect_err("duplicate drop-ins are rejected");
         assert!(err.contains("duplicate"));
     }
 
     #[tokio::test]
-    async fn extension_can_validate_backend_in_before_vm_launch() {
+    async fn extension_can_validate_backend_in_before_launch() {
         let extension = Arc::new(QemuRequiringExtension {
             name: "validate".to_string(),
         });
-        let extensions = VmLifecycleExtensions::with(vec![extension.clone()]);
+        let extensions = LifecycleExtensionRegistry::with(vec![extension.clone()]);
         let sandbox = Sandbox {
             id: "sandbox-validate".to_string(),
             name: "sandbox-validate".to_string(),
             ..Default::default()
         };
 
-        let mut libkrun_plan = VmLaunchPlan {
+        let mut libkrun_plan = LaunchPlan {
             backend: VmBackend::Libkrun,
             vcpus: 2,
             mem_mib: 2048,
@@ -6582,12 +6582,12 @@ mod tests {
             env: Vec::new(),
         };
         let err = extensions
-            .before_vm_launch(&sandbox, Path::new("/tmp/state"), &mut libkrun_plan)
+            .before_launch(&sandbox, Path::new("/tmp/state"), &mut libkrun_plan)
             .await
             .expect_err("backend mismatch should fail validation");
         assert!(err.message().contains("demands QEMU"));
 
-        let mut qemu_plan = VmLaunchPlan {
+        let mut qemu_plan = LaunchPlan {
             backend: VmBackend::Qemu,
             vcpus: 2,
             mem_mib: 2048,
@@ -6606,7 +6606,7 @@ mod tests {
             env: Vec::new(),
         };
         extensions
-            .before_vm_launch(&sandbox, Path::new("/tmp/state"), &mut qemu_plan)
+            .before_launch(&sandbox, Path::new("/tmp/state"), &mut qemu_plan)
             .await
             .expect("QEMU backend should satisfy the extension");
         assert!(qemu_plan.env.contains(&"EXT_DECLARED_QEMU=1".to_string()));
@@ -6614,13 +6614,13 @@ mod tests {
 
     #[tokio::test]
     async fn lifecycle_error_resource_exhausted_propagates() {
-        let extensions = VmLifecycleExtensions::with(vec![Arc::new(AlwaysFailsExtension)]);
+        let extensions = LifecycleExtensionRegistry::with(vec![Arc::new(AlwaysFailsExtension)]);
         let sandbox = Sandbox {
             id: "sandbox-resource".to_string(),
             name: "sandbox-resource".to_string(),
             ..Default::default()
         };
-        let mut plan = VmLaunchPlan {
+        let mut plan = LaunchPlan {
             backend: VmBackend::Qemu,
             vcpus: 2,
             mem_mib: 2048,
@@ -6639,7 +6639,7 @@ mod tests {
             env: Vec::new(),
         };
         let err = extensions
-            .before_vm_launch(&sandbox, Path::new("/tmp/state"), &mut plan)
+            .before_launch(&sandbox, Path::new("/tmp/state"), &mut plan)
             .await
             .expect_err("scripted pool exhaustion should surface");
         assert!(err.is_resource_exhausted());

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::gpu::{
+    GpuInventory, SubnetAllocator, allocate_vsock_cid, mac_from_sandbox_id, tap_device_name,
+};
 use crate::lifecycle::{
     BackendFeature, GuestInitDropin, LaunchAbortReason, LaunchPlan, LifecycleExtensionRegistry,
     RestoreContext, extension_state_dir,
-};
-use crate::gpu::{
-    GpuInventory, SubnetAllocator, allocate_vsock_cid, mac_from_sandbox_id, tap_device_name,
 };
 use crate::rootfs::{
     clone_or_copy_sparse_file, create_ext4_image_from_dir_with_size, create_rootfs_image_from_dir,
@@ -919,9 +919,7 @@ impl VmDriver {
                 sandbox: sandbox.clone(),
                 state_dir: state_dir.clone(),
             };
-            self.lifecycle_extensions
-                .after_restore(&persisted)
-                .await;
+            self.lifecycle_extensions.after_restore(&persisted).await;
         }
         tokio::spawn({
             let driver = self.clone();
@@ -1162,11 +1160,7 @@ impl VmDriver {
             sandbox: sandbox.clone(),
             state_dir: state_dir.clone(),
         };
-        if let Err(err) = self
-            .lifecycle_extensions
-            .before_restore(&persisted)
-            .await
-        {
+        if let Err(err) = self.lifecycle_extensions.before_restore(&persisted).await {
             warn!(
                 sandbox_id = %sandbox.id,
                 sandbox_name = %sandbox.name,
@@ -4566,7 +4560,9 @@ fn write_guest_init_dropin_manifest(
     let guest_path = overlay_upper_path(GUEST_INIT_DROPIN_MANIFEST);
     let contents = render_guest_init_dropin_manifest(dropins);
     write_rootfs_image_file(overlay_disk, &guest_path, &contents).map_err(|err| {
-        Status::internal(format!("write VM guest init drop-in manifest failed: {err}"))
+        Status::internal(format!(
+            "write VM guest init drop-in manifest failed: {err}"
+        ))
     })?;
     set_rootfs_image_file_mode(overlay_disk, &guest_path, 0o644).map_err(|err| {
         Status::internal(format!(
@@ -6377,8 +6373,8 @@ mod tests {
     }
 
     use crate::lifecycle::{
-        BackendFeature, LaunchPlan, LifecycleError, LifecycleExtension,
-        LifecycleExtensionRegistry, LifecycleResult,
+        BackendFeature, LaunchPlan, LifecycleError, LifecycleExtension, LifecycleExtensionRegistry,
+        LifecycleResult,
     };
     use crate::runtime::VmBackend;
 

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -669,6 +669,19 @@ impl VmDriver {
                 }
             };
 
+        // `build_vm_launch_plan` already allocated the QEMU subnet, so record
+        // it as allocated now — before the cancellable `configure_launch` /
+        // `before_launch` hooks run. If a delete aborts provisioning while
+        // one of those hooks is awaiting, the aborted future never runs its
+        // own release path, and the delete cleanup is gated on this flag; if
+        // the flag were still unset the subnet would leak.
+        if plan.backend == VmBackend::Qemu
+            && let Err(err) = self.mark_qemu_network_allocated(&sandbox.id).await
+        {
+            self.release_gpu_and_subnet(&sandbox.id);
+            return Err(err);
+        }
+
         if let Err(err) = self
             .lifecycle_extensions
             .configure_launch(&sandbox, &state_dir, &mut plan)
@@ -723,13 +736,6 @@ impl VmDriver {
                     LaunchAbortReason::BeforeLaunchHookFailed,
                 )
                 .await;
-            self.release_gpu_and_subnet(&sandbox.id);
-            return Err(err);
-        }
-
-        if plan.backend == VmBackend::Qemu
-            && let Err(err) = self.mark_qemu_network_allocated(&sandbox.id).await
-        {
             self.release_gpu_and_subnet(&sandbox.id);
             return Err(err);
         }

--- a/crates/openshell-driver-vm/src/extension.rs
+++ b/crates/openshell-driver-vm/src/extension.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::Path;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use openshell_core::proto::compute::v1::DriverSandbox as Sandbox;
@@ -12,6 +13,7 @@ use crate::runtime::VmBackend;
 pub enum LaunchAbortReason {
     LauncherSpawnFailed,
     BeforeLaunchHookFailed,
+    GuestPrepareFailed,
 }
 
 #[derive(Debug, Clone)]
@@ -56,11 +58,148 @@ impl std::error::Error for VmLifecycleError {}
 
 pub type VmLifecycleResult<T> = Result<T, VmLifecycleError>;
 
+/// A capability an extension can require from the VM backend.
+///
+/// Extensions declare features they need (e.g. PCI passthrough or an
+/// external kernel image) and the VM driver resolves a concrete
+/// [`VmBackend`] that can satisfy them. The mapping from feature to
+/// backend lives in [`VmBackendFeature::requires_qemu`] for now; once a
+/// third backend exists this should evolve into a per-backend capability
+/// table that the resolver intersects against feature requirements.
+///
+/// # Current limitations
+///
+/// Until the non-GPU QEMU launch path (PCI device transport / VFIO root
+/// port wiring) lands, the driver still rejects launches where the
+/// resolved backend is QEMU but the sandbox has no GPU. As a result,
+/// declaring [`Self::PciPassthrough`] or [`Self::ExternalKernelImage`] on
+/// a non-GPU sandbox is accepted by [`VmLifecycleExtensions::validate`]
+/// at registration time but will fail provisioning with a
+/// `FailedPrecondition` status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VmBackendFeature {
+    /// Extension supplies its own kernel image via
+    /// [`VmLaunchPlan::kernel_image`]. Currently QEMU-only.
+    ExternalKernelImage,
+    /// Extension contributes guest init drop-ins via
+    /// [`VmLaunchPlan::guest_init_dropins`]. Supported by all backends.
+    GuestInitDropins,
+    /// Extension needs PCI device passthrough on the guest. Currently
+    /// QEMU-only and currently rejected for non-GPU sandboxes pending the
+    /// non-GPU QEMU launch path landing.
+    PciPassthrough,
+    /// Extension needs a host TAP device wired into the guest. Currently
+    /// QEMU-only (libkrun does not expose a TAP transport).
+    TapNetworking,
+}
+
+impl VmBackendFeature {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ExternalKernelImage => "external-kernel-image",
+            Self::GuestInitDropins => "guest-init-dropins",
+            Self::PciPassthrough => "pci-passthrough",
+            Self::TapNetworking => "tap-networking",
+        }
+    }
+
+    /// Returns true when satisfying this feature requires the QEMU backend
+    /// today. This is the simplest possible resolver and is expected to be
+    /// replaced with a per-backend capability table once a third backend
+    /// exists.
+    #[must_use]
+    pub fn requires_qemu(self) -> bool {
+        matches!(
+            self,
+            Self::ExternalKernelImage | Self::PciPassthrough | Self::TapNetworking
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct VmExtensionProvides {
+    pub kernel_profiles: Vec<String>,
+    pub guest_init_dropins: Vec<String>,
+    pub launch_features: Vec<String>,
+    pub host_resources: Vec<String>,
+}
+
+/// A registration-time description of what a lifecycle extension provides
+/// and requires.
+///
+/// `required_backends` and `required_backend_features` are merged into the
+/// launch plan unconditionally for every sandbox. An extension that wants
+/// conditional behavior (e.g. only contribute requirements when the
+/// sandbox spec asks for it) should leave the descriptor fields empty and
+/// call [`VmLaunchPlan::require_backend`] /
+/// [`VmLaunchPlan::require_backend_feature`] inside
+/// [`VmLifecycleExtension::configure_vm_launch`] instead.
+///
+/// A future PR will add a per-sandbox activation protocol so the driver
+/// can gate this merge on a sandbox spec field. Until that lands, the
+/// only knob is "declare in the descriptor (always merged) vs decide in
+/// the hook (per-sandbox)".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VmLifecycleExtensionDescriptor {
+    pub name: String,
+    pub provides: VmExtensionProvides,
+    pub required_backends: Vec<VmBackend>,
+    pub required_backend_features: Vec<VmBackendFeature>,
+}
+
+impl VmLifecycleExtensionDescriptor {
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            provides: VmExtensionProvides::default(),
+            required_backends: Vec::new(),
+            required_backend_features: Vec::new(),
+        }
+    }
+}
+
+/// A guest-side init drop-in injected into the sandbox's overlay disk.
+///
+/// Drop-ins land at `/opt/openshell/init.d/{name}` inside the guest with
+/// mode `0o755`. The guest's init script *executes* drop-ins in a child
+/// shell in deterministic ASCII-sorted order; it does not source them.
+/// Authors should:
+///
+/// - Begin the file with a `#!/bin/bash` (or equivalent) shebang.
+/// - Use the `00-`, `50-`, `99-` prefix convention to control ordering.
+/// - Treat the parent shell as immutable: env vars set in a drop-in do not
+///   propagate to the rest of init.
+///
+/// `name` must consist of ASCII letters, digits, `.`, `-`, or `_` (no
+/// path separators, no `.`/`..`); duplicates across a single launch plan
+/// are rejected by the driver.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VmGuestInitDropIn {
+    pub name: String,
+    pub contents: Vec<u8>,
+}
+
+impl VmGuestInitDropIn {
+    #[must_use]
+    pub fn new(name: impl Into<String>, contents: impl Into<Vec<u8>>) -> Self {
+        Self {
+            name: name.into(),
+            contents: contents.into(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct VmLaunchPlan {
     pub backend: VmBackend,
     pub vcpus: u8,
     pub mem_mib: u32,
+    pub required_backends: Vec<VmBackend>,
+    pub required_backend_features: Vec<VmBackendFeature>,
+    pub kernel_profile: Option<String>,
+    pub kernel_image: Option<PathBuf>,
     pub gpu_bdf: Option<String>,
     pub tap_device: Option<String>,
     pub guest_ip: Option<String>,
@@ -68,17 +207,112 @@ pub struct VmLaunchPlan {
     pub vsock_cid: Option<u32>,
     pub guest_mac: Option<String>,
     pub gateway_port: Option<u16>,
+    pub guest_init_dropins: Vec<VmGuestInitDropIn>,
     pub env: Vec<String>,
 }
 
+impl VmLaunchPlan {
+    pub fn require_backend(&mut self, backend: VmBackend) {
+        if !self.required_backends.contains(&backend) {
+            self.required_backends.push(backend);
+        }
+    }
+
+    pub fn require_backend_feature(&mut self, feature: VmBackendFeature) {
+        if !self.required_backend_features.contains(&feature) {
+            self.required_backend_features.push(feature);
+        }
+    }
+
+    pub fn require_backend_features(
+        &mut self,
+        features: impl IntoIterator<Item = VmBackendFeature>,
+    ) {
+        for feature in features {
+            self.require_backend_feature(feature);
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct VmPersistedSandbox {
+    pub sandbox: Sandbox,
+    pub state_dir: PathBuf,
+}
+
+/// Lifecycle hooks an extension can implement to participate in VM sandbox
+/// provisioning, launch failure, deletion, and post-restart reconciliation.
+///
+/// # Hook ordering during a successful launch
+///
+/// 1. [`configure_vm_launch`](Self::configure_vm_launch) — contribute backend
+///    requirements (via [`VmLaunchPlan::require_backend`] /
+///    [`VmLaunchPlan::require_backend_feature`]) and provisioning inputs
+///    (kernel profile, guest init drop-ins, etc.). Called before the driver
+///    has resolved the final backend.
+/// 2. Driver resolves [`VmLaunchPlan::backend`] from declared requirements
+///    and allocates backend-specific host resources (subnet, tap, vsock).
+/// 3. [`before_vm_launch`](Self::before_vm_launch) — perform host-side
+///    side effects with the resolved plan in hand, optionally append
+///    additional guest env via [`VmLaunchPlan::env`].
+/// 4. The driver spawns the VM launcher process.
+///
+/// On launch failure or sandbox deletion, the driver invokes
+/// [`after_vm_launch_failed`](Self::after_vm_launch_failed) or
+/// [`after_sandbox_deleted`](Self::after_sandbox_deleted) in **reverse
+/// registration order**, so cleanup mirrors setup.
 #[tonic::async_trait]
 pub trait VmLifecycleExtension: std::fmt::Debug + Send + Sync {
     fn name(&self) -> &str;
 
-    fn required_backend(&self) -> Option<VmBackend> {
-        None
+    fn descriptor(&self) -> VmLifecycleExtensionDescriptor {
+        VmLifecycleExtensionDescriptor::new(self.name())
     }
 
+    /// Contribute backend requirements and provisioning inputs to the plan
+    /// before the driver picks a backend.
+    ///
+    /// Use this hook to:
+    /// - Declare backend requirements with
+    ///   [`VmLaunchPlan::require_backend`] or
+    ///   [`VmLaunchPlan::require_backend_feature`].
+    /// - Set [`VmLaunchPlan::kernel_profile`] or
+    ///   [`VmLaunchPlan::kernel_image`].
+    /// - Append [`VmLaunchPlan::guest_init_dropins`] entries.
+    ///
+    /// At this point [`VmLaunchPlan::backend`] is the driver's tentative
+    /// choice and may still change during backend resolution. Do not perform
+    /// host-side side effects here — defer them to
+    /// [`before_vm_launch`](Self::before_vm_launch).
+    async fn configure_vm_launch(
+        &self,
+        _sandbox: &Sandbox,
+        _state_dir: &Path,
+        _plan: &mut VmLaunchPlan,
+    ) -> VmLifecycleResult<()> {
+        Ok(())
+    }
+
+    /// Perform host-side preparation with the resolved launch plan.
+    ///
+    /// At this point [`VmLaunchPlan::backend`],
+    /// [`VmLaunchPlan::required_backends`], and
+    /// [`VmLaunchPlan::required_backend_features`] are finalized and any
+    /// backend-specific host resources (subnet, tap, vsock) have been
+    /// allocated. This hook is the right place to bind PCI devices, set
+    /// up filesystem state, or otherwise prepare the host.
+    ///
+    /// Implementations MAY append entries to [`VmLaunchPlan::env`] to
+    /// inject additional guest environment variables, and MAY return an
+    /// error to abort the launch. Implementations MUST NOT change
+    /// [`VmLaunchPlan::backend`], [`VmLaunchPlan::required_backends`], or
+    /// [`VmLaunchPlan::required_backend_features`]; those changes are
+    /// ignored by the driver once `before_vm_launch` is reached.
+    ///
+    /// If this hook performs allocations that must be released on failure
+    /// or delete, implement
+    /// [`after_vm_launch_failed`](Self::after_vm_launch_failed) and
+    /// [`after_sandbox_deleted`](Self::after_sandbox_deleted) accordingly.
     async fn before_vm_launch(
         &self,
         _sandbox: &Sandbox,
@@ -88,6 +322,17 @@ pub trait VmLifecycleExtension: std::fmt::Debug + Send + Sync {
         Ok(())
     }
 
+    /// Release anything this extension allocated during
+    /// [`configure_vm_launch`](Self::configure_vm_launch) or
+    /// [`before_vm_launch`](Self::before_vm_launch) when the launcher
+    /// could not be started or aborted before it became healthy.
+    ///
+    /// Invoked in reverse registration order. Errors are logged but do not
+    /// propagate; do best-effort cleanup and return [`Ok`] when possible.
+    /// This hook is invoked on every launcher failure, including failures
+    /// that happen during a persisted-sandbox restore (in that case
+    /// [`reconcile_after_restore`](Self::reconcile_after_restore) is *not*
+    /// invoked).
     async fn after_vm_launch_failed(
         &self,
         _sandbox: &Sandbox,
@@ -97,10 +342,40 @@ pub trait VmLifecycleExtension: std::fmt::Debug + Send + Sync {
         Ok(())
     }
 
+    /// Release per-sandbox resources after a sandbox has been deleted.
+    ///
+    /// Invoked in reverse registration order. Errors are logged but do not
+    /// propagate.
     async fn after_sandbox_deleted(
         &self,
         _sandbox: &Sandbox,
         _state_dir: &Path,
+    ) -> VmLifecycleResult<()> {
+        Ok(())
+    }
+
+    /// Inspect or reconcile persisted extension state before the driver
+    /// attempts to restore a sandbox after a process restart.
+    ///
+    /// Returning an error causes the driver to skip restoring this
+    /// sandbox; the persisted state is left on disk for operator
+    /// inspection.
+    async fn reconcile_before_restore(
+        &self,
+        _sandbox: &VmPersistedSandbox,
+    ) -> VmLifecycleResult<()> {
+        Ok(())
+    }
+
+    /// Notify the extension that a persisted sandbox has been
+    /// successfully restored and its launcher is running again.
+    ///
+    /// Only invoked when restore succeeds. If the restore fails partway
+    /// through, [`after_vm_launch_failed`](Self::after_vm_launch_failed)
+    /// runs instead.
+    async fn reconcile_after_restore(
+        &self,
+        _sandbox: &VmPersistedSandbox,
     ) -> VmLifecycleResult<()> {
         Ok(())
     }
@@ -152,10 +427,78 @@ impl VmLifecycleExtensions {
     }
 
     #[must_use]
-    pub fn requires_qemu(&self) -> bool {
+    pub fn names(&self) -> Vec<String> {
         self.extensions
             .iter()
-            .any(|ext| ext.required_backend() == Some(VmBackend::Qemu))
+            .map(|ext| ext.name().to_string())
+            .collect()
+    }
+
+    #[must_use]
+    pub fn descriptors(&self) -> Vec<VmLifecycleExtensionDescriptor> {
+        self.extensions.iter().map(|ext| ext.descriptor()).collect()
+    }
+
+    pub fn validate(&self) -> VmLifecycleResult<()> {
+        let mut names = HashSet::new();
+        for ext in &self.extensions {
+            let descriptor = ext.descriptor();
+            validate_extension_name(ext.name())?;
+            validate_extension_name(&descriptor.name)?;
+            if descriptor.name != ext.name() {
+                return Err(VmLifecycleError::new(format!(
+                    "VM lifecycle extension '{}' descriptor name does not match '{}'",
+                    ext.name(),
+                    descriptor.name
+                )));
+            }
+            validate_descriptor_strings(&descriptor)?;
+            if !names.insert(descriptor.name.clone()) {
+                return Err(VmLifecycleError::new(format!(
+                    "duplicate VM lifecycle extension name: {}",
+                    descriptor.name
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn configure_vm_launch(
+        &self,
+        sandbox: &Sandbox,
+        state_dir: &Path,
+        plan: &mut VmLaunchPlan,
+    ) -> VmLifecycleResult<()> {
+        for ext in &self.extensions {
+            let descriptor = ext.descriptor();
+            for backend in descriptor.required_backends {
+                plan.require_backend(backend);
+            }
+            plan.require_backend_features(descriptor.required_backend_features);
+            // Snapshot fields where "last writer wins" could mask an
+            // extension conflict, so we can flag the conflict instead of
+            // silently dropping the earlier value.
+            let prev_kernel_profile = plan.kernel_profile.clone();
+            let prev_kernel_image = plan.kernel_image.clone();
+            ext.configure_vm_launch(sandbox, state_dir, plan).await?;
+            warn_on_singleton_overwrite(
+                ext.name(),
+                "kernel_profile",
+                prev_kernel_profile.as_deref(),
+                plan.kernel_profile.as_deref(),
+            );
+            warn_on_singleton_overwrite(
+                ext.name(),
+                "kernel_image",
+                prev_kernel_image
+                    .as_deref()
+                    .map(|p| p.display().to_string()),
+                plan.kernel_image
+                    .as_deref()
+                    .map(|p| p.display().to_string()),
+            );
+        }
+        Ok(())
     }
 
     pub async fn before_vm_launch(
@@ -176,7 +519,7 @@ impl VmLifecycleExtensions {
         state_dir: &Path,
         reason: LaunchAbortReason,
     ) {
-        for ext in &self.extensions {
+        for ext in self.extensions.iter().rev() {
             if let Err(err) = ext
                 .after_vm_launch_failed(sandbox, state_dir, reason.clone())
                 .await
@@ -192,7 +535,7 @@ impl VmLifecycleExtensions {
     }
 
     pub async fn after_sandbox_deleted(&self, sandbox: &Sandbox, state_dir: &Path) {
-        for ext in &self.extensions {
+        for ext in self.extensions.iter().rev() {
             if let Err(err) = ext.after_sandbox_deleted(sandbox, state_dir).await {
                 tracing::warn!(
                     extension = ext.name(),
@@ -203,6 +546,111 @@ impl VmLifecycleExtensions {
             }
         }
     }
+
+    pub async fn reconcile_before_restore(
+        &self,
+        sandbox: &VmPersistedSandbox,
+    ) -> VmLifecycleResult<()> {
+        for ext in &self.extensions {
+            ext.reconcile_before_restore(sandbox).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn reconcile_after_restore(&self, sandbox: &VmPersistedSandbox) {
+        for ext in &self.extensions {
+            if let Err(err) = ext.reconcile_after_restore(sandbox).await {
+                tracing::warn!(
+                    extension = ext.name(),
+                    sandbox_id = %sandbox.sandbox.id,
+                    error = %err,
+                    "vm driver: lifecycle extension reconcile_after_restore hook failed"
+                );
+            }
+        }
+    }
+}
+
+fn warn_on_singleton_overwrite<T>(
+    extension_name: &str,
+    field: &str,
+    prev: Option<T>,
+    next: Option<T>,
+) where
+    T: AsRef<str> + std::fmt::Display + PartialEq,
+{
+    let (Some(prev), Some(next)) = (prev, next) else {
+        return;
+    };
+    if prev == next {
+        return;
+    }
+    tracing::warn!(
+        extension = extension_name,
+        field,
+        previous = %prev,
+        next = %next,
+        "vm driver: lifecycle extension overwrote a singleton launch-plan field set by an earlier extension"
+    );
+}
+
+pub fn extension_state_dir(
+    sandbox_state_dir: &Path,
+    extension_name: &str,
+) -> VmLifecycleResult<PathBuf> {
+    validate_extension_name(extension_name)?;
+    Ok(sandbox_state_dir.join("extensions").join(extension_name))
+}
+
+fn validate_extension_name(name: &str) -> VmLifecycleResult<()> {
+    if name.is_empty() || name == "." || name == ".." {
+        return Err(VmLifecycleError::new(
+            "VM lifecycle extension name is empty or reserved",
+        ));
+    }
+    if !name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.')
+    {
+        return Err(VmLifecycleError::new(format!(
+            "VM lifecycle extension name '{name}' must contain only ASCII letters, numbers, '.', '-', or '_'"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_descriptor_strings(
+    descriptor: &VmLifecycleExtensionDescriptor,
+) -> VmLifecycleResult<()> {
+    for value in descriptor
+        .provides
+        .kernel_profiles
+        .iter()
+        .chain(descriptor.provides.guest_init_dropins.iter())
+        .chain(descriptor.provides.launch_features.iter())
+        .chain(descriptor.provides.host_resources.iter())
+    {
+        validate_extension_identifier(value).map_err(|err| {
+            VmLifecycleError::new(format!(
+                "VM lifecycle extension '{}' has invalid provided capability '{}': {err}",
+                descriptor.name, value
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn validate_extension_identifier(value: &str) -> Result<(), &'static str> {
+    if value.is_empty() || value == "." || value == ".." {
+        return Err("identifier is empty or reserved");
+    }
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.')
+    {
+        return Err("identifier must contain only ASCII letters, numbers, '.', '-', or '_'");
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -215,26 +663,35 @@ mod tests {
     #[derive(Debug)]
     struct RecordingExtension {
         name: String,
-        backend: Option<VmBackend>,
+        configure_should_fail: bool,
         before_should_fail: bool,
         calls: Mutex<Vec<String>>,
     }
 
     impl RecordingExtension {
-        fn new(name: &str, backend: Option<VmBackend>) -> Arc<Self> {
+        fn new(name: &str) -> Arc<Self> {
             Arc::new(Self {
                 name: name.to_string(),
-                backend,
+                configure_should_fail: false,
                 before_should_fail: false,
                 calls: Mutex::new(Vec::new()),
             })
         }
 
-        fn failing(name: &str, backend: Option<VmBackend>) -> Arc<Self> {
+        fn failing(name: &str) -> Arc<Self> {
             Arc::new(Self {
                 name: name.to_string(),
-                backend,
+                configure_should_fail: false,
                 before_should_fail: true,
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn configure_failing(name: &str) -> Arc<Self> {
+            Arc::new(Self {
+                name: name.to_string(),
+                configure_should_fail: true,
+                before_should_fail: false,
                 calls: Mutex::new(Vec::new()),
             })
         }
@@ -250,8 +707,42 @@ mod tests {
             &self.name
         }
 
-        fn required_backend(&self) -> Option<VmBackend> {
-            self.backend.clone()
+        fn descriptor(&self) -> VmLifecycleExtensionDescriptor {
+            VmLifecycleExtensionDescriptor {
+                name: self.name.clone(),
+                provides: VmExtensionProvides {
+                    kernel_profiles: vec![format!("profile-{}", self.name)],
+                    guest_init_dropins: vec![format!("50-{}.sh", self.name)],
+                    launch_features: vec!["guest-init-dropins".to_string()],
+                    host_resources: Vec::new(),
+                },
+                required_backends: Vec::new(),
+                required_backend_features: vec![VmBackendFeature::GuestInitDropins],
+            }
+        }
+
+        async fn configure_vm_launch(
+            &self,
+            _sandbox: &Sandbox,
+            _state_dir: &Path,
+            plan: &mut VmLaunchPlan,
+        ) -> VmLifecycleResult<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("{}:configure_vm_launch", self.name));
+            if self.configure_should_fail {
+                return Err(VmLifecycleError::new(format!(
+                    "{}: scripted configure_vm_launch failure",
+                    self.name
+                )));
+            }
+            plan.kernel_profile = Some(format!("profile-{}", self.name));
+            plan.guest_init_dropins.push(VmGuestInitDropIn::new(
+                format!("50-{}.sh", self.name),
+                b"#!/bin/sh\n".to_vec(),
+            ));
+            Ok(())
         }
 
         async fn before_vm_launch(
@@ -305,6 +796,10 @@ mod tests {
             backend,
             vcpus: 2,
             mem_mib: 2048,
+            required_backends: Vec::new(),
+            required_backend_features: Vec::new(),
+            kernel_profile: None,
+            kernel_image: None,
             gpu_bdf: None,
             tap_device: None,
             guest_ip: None,
@@ -312,6 +807,7 @@ mod tests {
             vsock_cid: None,
             guest_mac: None,
             gateway_port: None,
+            guest_init_dropins: Vec::new(),
             env: Vec::new(),
         }
     }
@@ -331,33 +827,66 @@ mod tests {
         extension.clone()
     }
 
-    #[test]
-    fn empty_registry_does_not_require_qemu() {
-        let registry = VmLifecycleExtensions::new();
-        assert!(registry.is_empty());
-        assert!(!registry.requires_qemu());
+    #[tokio::test]
+    async fn configure_vm_launch_runs_each_extension_in_order() {
+        let ext_a = RecordingExtension::new("a");
+        let ext_b = RecordingExtension::new("b");
+        let registry =
+            VmLifecycleExtensions::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
+        let mut plan = sample_plan(VmBackend::Qemu);
+        let sandbox = sample_sandbox();
+
+        registry
+            .configure_vm_launch(&sandbox, &PathBuf::from("/tmp/state"), &mut plan)
+            .await
+            .expect("configure_vm_launch succeeds");
+
+        assert_eq!(plan.kernel_profile.as_deref(), Some("profile-b"));
+        assert_eq!(
+            plan.guest_init_dropins
+                .iter()
+                .map(|dropin| dropin.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["50-a.sh", "50-b.sh"]
+        );
+        assert_eq!(ext_a.calls(), vec!["a:configure_vm_launch"]);
+        assert_eq!(ext_b.calls(), vec!["b:configure_vm_launch"]);
     }
 
-    #[test]
-    fn registry_requires_qemu_when_any_extension_declares_it() {
-        let mut registry = VmLifecycleExtensions::new();
-        registry.push(RecordingExtension::new("noop", None));
-        registry.push(RecordingExtension::new("vfio", Some(VmBackend::Qemu)));
-        assert!(registry.requires_qemu());
-    }
+    #[tokio::test]
+    async fn configure_vm_launch_short_circuits_on_first_failure() {
+        let ext_a = RecordingExtension::new("a");
+        let ext_fail = RecordingExtension::configure_failing("boom");
+        let ext_c = RecordingExtension::new("c");
+        let registry = VmLifecycleExtensions::with(vec![
+            as_extension(&ext_a),
+            as_extension(&ext_fail),
+            as_extension(&ext_c),
+        ]);
+        let mut plan = sample_plan(VmBackend::Libkrun);
+        let sandbox = sample_sandbox();
 
-    #[test]
-    fn registry_does_not_require_qemu_when_no_extension_declares_it() {
-        let mut registry = VmLifecycleExtensions::new();
-        registry.push(RecordingExtension::new("noop1", None));
-        registry.push(RecordingExtension::new("noop2", Some(VmBackend::Libkrun)));
-        assert!(!registry.requires_qemu());
+        let err = registry
+            .configure_vm_launch(&sandbox, &PathBuf::from("/tmp/state"), &mut plan)
+            .await
+            .expect_err("scripted failure should propagate");
+        assert!(
+            err.message()
+                .contains("scripted configure_vm_launch failure")
+        );
+
+        assert_eq!(ext_a.calls(), vec!["a:configure_vm_launch"]);
+        assert_eq!(ext_fail.calls(), vec!["boom:configure_vm_launch"]);
+        assert!(
+            ext_c.calls().is_empty(),
+            "extensions after the failure must not be invoked"
+        );
     }
 
     #[tokio::test]
     async fn before_vm_launch_runs_each_extension_in_order_and_collects_env() {
-        let ext_a = RecordingExtension::new("a", None);
-        let ext_b = RecordingExtension::new("b", Some(VmBackend::Qemu));
+        let ext_a = RecordingExtension::new("a");
+        let ext_b = RecordingExtension::new("b");
         let registry =
             VmLifecycleExtensions::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
         let mut plan = sample_plan(VmBackend::Qemu);
@@ -375,9 +904,9 @@ mod tests {
 
     #[tokio::test]
     async fn before_vm_launch_short_circuits_on_first_failure() {
-        let ext_a = RecordingExtension::new("a", None);
-        let ext_fail = RecordingExtension::failing("boom", None);
-        let ext_c = RecordingExtension::new("c", None);
+        let ext_a = RecordingExtension::new("a");
+        let ext_fail = RecordingExtension::failing("boom");
+        let ext_c = RecordingExtension::new("c");
         let registry = VmLifecycleExtensions::with(vec![
             as_extension(&ext_a),
             as_extension(&ext_fail),
@@ -401,9 +930,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn after_vm_launch_failed_runs_every_extension() {
-        let ext_a = RecordingExtension::new("a", None);
-        let ext_b = RecordingExtension::new("b", None);
+    async fn after_vm_launch_failed_runs_every_extension_in_reverse_order() {
+        let ext_a = RecordingExtension::new("a");
+        let ext_b = RecordingExtension::new("b");
         let registry =
             VmLifecycleExtensions::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
         let sandbox = sample_sandbox();
@@ -428,8 +957,8 @@ mod tests {
 
     #[tokio::test]
     async fn after_sandbox_deleted_runs_every_extension() {
-        let ext_a = RecordingExtension::new("a", None);
-        let ext_b = RecordingExtension::new("b", None);
+        let ext_a = RecordingExtension::new("a");
+        let ext_b = RecordingExtension::new("b");
         let registry =
             VmLifecycleExtensions::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
         let sandbox = sample_sandbox();
@@ -450,5 +979,51 @@ mod tests {
 
         let plain = VmLifecycleError::new("internal");
         assert!(!plain.is_resource_exhausted());
+    }
+
+    #[test]
+    fn extension_state_dir_rejects_path_unsafe_names() {
+        let base = PathBuf::from("/tmp/sandbox");
+        assert_eq!(
+            extension_state_dir(&base, "vfio").unwrap(),
+            base.join("extensions").join("vfio")
+        );
+        assert!(extension_state_dir(&base, "../vfio").is_err());
+        assert!(extension_state_dir(&base, "").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_extension_names() {
+        let registry = VmLifecycleExtensions::with(vec![
+            RecordingExtension::new("dup"),
+            RecordingExtension::new("dup"),
+        ]);
+        let err = registry
+            .validate()
+            .expect_err("duplicate names should fail");
+        assert!(err.message().contains("duplicate"));
+    }
+
+    #[test]
+    fn descriptor_tracks_provided_capabilities_and_requirements() {
+        let ext = RecordingExtension::new("vfio");
+        let registry = VmLifecycleExtensions::with(vec![ext]);
+
+        let descriptors = registry.descriptors();
+        assert_eq!(descriptors.len(), 1);
+        assert_eq!(descriptors[0].name, "vfio");
+        assert!(descriptors[0].required_backends.is_empty());
+        assert_eq!(
+            descriptors[0].required_backend_features,
+            vec![VmBackendFeature::GuestInitDropins]
+        );
+        assert_eq!(
+            descriptors[0].provides.kernel_profiles,
+            vec!["profile-vfio".to_string()]
+        );
+        assert_eq!(
+            descriptors[0].provides.guest_init_dropins,
+            vec!["50-vfio.sh".to_string()]
+        );
     }
 }

--- a/crates/openshell-driver-vm/src/extension.rs
+++ b/crates/openshell-driver-vm/src/extension.rs
@@ -1,0 +1,454 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+use std::sync::Arc;
+
+use openshell_core::proto::compute::v1::DriverSandbox as Sandbox;
+
+use crate::runtime::VmBackend;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LaunchAbortReason {
+    LauncherSpawnFailed,
+    BeforeLaunchHookFailed,
+}
+
+#[derive(Debug, Clone)]
+pub struct VmLifecycleError {
+    message: String,
+    resource_exhausted: bool,
+}
+
+impl VmLifecycleError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            resource_exhausted: false,
+        }
+    }
+
+    pub fn resource_exhausted(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            resource_exhausted: true,
+        }
+    }
+
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    #[must_use]
+    pub fn is_resource_exhausted(&self) -> bool {
+        self.resource_exhausted
+    }
+}
+
+impl std::fmt::Display for VmLifecycleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for VmLifecycleError {}
+
+pub type VmLifecycleResult<T> = Result<T, VmLifecycleError>;
+
+#[derive(Debug, Clone)]
+pub struct VmLaunchPlan {
+    pub backend: VmBackend,
+    pub vcpus: u8,
+    pub mem_mib: u32,
+    pub gpu_bdf: Option<String>,
+    pub tap_device: Option<String>,
+    pub guest_ip: Option<String>,
+    pub host_ip: Option<String>,
+    pub vsock_cid: Option<u32>,
+    pub guest_mac: Option<String>,
+    pub gateway_port: Option<u16>,
+    pub env: Vec<String>,
+}
+
+#[tonic::async_trait]
+pub trait VmLifecycleExtension: std::fmt::Debug + Send + Sync {
+    fn name(&self) -> &str;
+
+    fn required_backend(&self) -> Option<VmBackend> {
+        None
+    }
+
+    async fn before_vm_launch(
+        &self,
+        _sandbox: &Sandbox,
+        _state_dir: &Path,
+        _plan: &mut VmLaunchPlan,
+    ) -> VmLifecycleResult<()> {
+        Ok(())
+    }
+
+    async fn after_vm_launch_failed(
+        &self,
+        _sandbox: &Sandbox,
+        _state_dir: &Path,
+        _reason: LaunchAbortReason,
+    ) -> VmLifecycleResult<()> {
+        Ok(())
+    }
+
+    async fn after_sandbox_deleted(
+        &self,
+        _sandbox: &Sandbox,
+        _state_dir: &Path,
+    ) -> VmLifecycleResult<()> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct VmLifecycleExtensions {
+    extensions: Vec<Arc<dyn VmLifecycleExtension>>,
+}
+
+impl std::fmt::Debug for VmLifecycleExtensions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VmLifecycleExtensions")
+            .field(
+                "names",
+                &self
+                    .extensions
+                    .iter()
+                    .map(|ext| ext.name())
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
+impl VmLifecycleExtensions {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn with(extensions: Vec<Arc<dyn VmLifecycleExtension>>) -> Self {
+        Self { extensions }
+    }
+
+    pub fn push(&mut self, extension: Arc<dyn VmLifecycleExtension>) {
+        self.extensions.push(extension);
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.extensions.is_empty()
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.extensions.len()
+    }
+
+    #[must_use]
+    pub fn requires_qemu(&self) -> bool {
+        self.extensions
+            .iter()
+            .any(|ext| ext.required_backend() == Some(VmBackend::Qemu))
+    }
+
+    pub async fn before_vm_launch(
+        &self,
+        sandbox: &Sandbox,
+        state_dir: &Path,
+        plan: &mut VmLaunchPlan,
+    ) -> VmLifecycleResult<()> {
+        for ext in &self.extensions {
+            ext.before_vm_launch(sandbox, state_dir, plan).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn after_vm_launch_failed(
+        &self,
+        sandbox: &Sandbox,
+        state_dir: &Path,
+        reason: LaunchAbortReason,
+    ) {
+        for ext in &self.extensions {
+            if let Err(err) = ext
+                .after_vm_launch_failed(sandbox, state_dir, reason.clone())
+                .await
+            {
+                tracing::warn!(
+                    extension = ext.name(),
+                    sandbox_id = %sandbox.id,
+                    error = %err,
+                    "vm driver: lifecycle extension after_vm_launch_failed hook failed"
+                );
+            }
+        }
+    }
+
+    pub async fn after_sandbox_deleted(&self, sandbox: &Sandbox, state_dir: &Path) {
+        for ext in &self.extensions {
+            if let Err(err) = ext.after_sandbox_deleted(sandbox, state_dir).await {
+                tracing::warn!(
+                    extension = ext.name(),
+                    sandbox_id = %sandbox.id,
+                    error = %err,
+                    "vm driver: lifecycle extension after_sandbox_deleted hook failed"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct RecordingExtension {
+        name: String,
+        backend: Option<VmBackend>,
+        before_should_fail: bool,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl RecordingExtension {
+        fn new(name: &str, backend: Option<VmBackend>) -> Arc<Self> {
+            Arc::new(Self {
+                name: name.to_string(),
+                backend,
+                before_should_fail: false,
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn failing(name: &str, backend: Option<VmBackend>) -> Arc<Self> {
+            Arc::new(Self {
+                name: name.to_string(),
+                backend,
+                before_should_fail: true,
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[tonic::async_trait]
+    impl VmLifecycleExtension for RecordingExtension {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn required_backend(&self) -> Option<VmBackend> {
+            self.backend.clone()
+        }
+
+        async fn before_vm_launch(
+            &self,
+            _sandbox: &Sandbox,
+            _state_dir: &Path,
+            plan: &mut VmLaunchPlan,
+        ) -> VmLifecycleResult<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("{}:before_vm_launch", self.name));
+            if self.before_should_fail {
+                return Err(VmLifecycleError::new(format!(
+                    "{}: scripted before_vm_launch failure",
+                    self.name
+                )));
+            }
+            plan.env.push(format!("RECORDING_{}=1", self.name));
+            Ok(())
+        }
+
+        async fn after_vm_launch_failed(
+            &self,
+            _sandbox: &Sandbox,
+            _state_dir: &Path,
+            reason: LaunchAbortReason,
+        ) -> VmLifecycleResult<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("{}:after_vm_launch_failed:{:?}", self.name, reason));
+            Ok(())
+        }
+
+        async fn after_sandbox_deleted(
+            &self,
+            _sandbox: &Sandbox,
+            _state_dir: &Path,
+        ) -> VmLifecycleResult<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("{}:after_sandbox_deleted", self.name));
+            Ok(())
+        }
+    }
+
+    fn sample_plan(backend: VmBackend) -> VmLaunchPlan {
+        VmLaunchPlan {
+            backend,
+            vcpus: 2,
+            mem_mib: 2048,
+            gpu_bdf: None,
+            tap_device: None,
+            guest_ip: None,
+            host_ip: None,
+            vsock_cid: None,
+            guest_mac: None,
+            gateway_port: None,
+            env: Vec::new(),
+        }
+    }
+
+    fn sample_sandbox() -> Sandbox {
+        Sandbox {
+            id: "sandbox-123".to_string(),
+            name: "sandbox-123".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn as_extension<T>(extension: &Arc<T>) -> Arc<dyn VmLifecycleExtension>
+    where
+        T: VmLifecycleExtension + 'static,
+    {
+        extension.clone()
+    }
+
+    #[test]
+    fn empty_registry_does_not_require_qemu() {
+        let registry = VmLifecycleExtensions::new();
+        assert!(registry.is_empty());
+        assert!(!registry.requires_qemu());
+    }
+
+    #[test]
+    fn registry_requires_qemu_when_any_extension_declares_it() {
+        let mut registry = VmLifecycleExtensions::new();
+        registry.push(RecordingExtension::new("noop", None));
+        registry.push(RecordingExtension::new("vfio", Some(VmBackend::Qemu)));
+        assert!(registry.requires_qemu());
+    }
+
+    #[test]
+    fn registry_does_not_require_qemu_when_no_extension_declares_it() {
+        let mut registry = VmLifecycleExtensions::new();
+        registry.push(RecordingExtension::new("noop1", None));
+        registry.push(RecordingExtension::new("noop2", Some(VmBackend::Libkrun)));
+        assert!(!registry.requires_qemu());
+    }
+
+    #[tokio::test]
+    async fn before_vm_launch_runs_each_extension_in_order_and_collects_env() {
+        let ext_a = RecordingExtension::new("a", None);
+        let ext_b = RecordingExtension::new("b", Some(VmBackend::Qemu));
+        let registry =
+            VmLifecycleExtensions::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
+        let mut plan = sample_plan(VmBackend::Qemu);
+        let sandbox = sample_sandbox();
+
+        registry
+            .before_vm_launch(&sandbox, &PathBuf::from("/tmp/state"), &mut plan)
+            .await
+            .expect("before_vm_launch succeeds");
+
+        assert_eq!(plan.env, vec!["RECORDING_a=1", "RECORDING_b=1"]);
+        assert_eq!(ext_a.calls(), vec!["a:before_vm_launch"]);
+        assert_eq!(ext_b.calls(), vec!["b:before_vm_launch"]);
+    }
+
+    #[tokio::test]
+    async fn before_vm_launch_short_circuits_on_first_failure() {
+        let ext_a = RecordingExtension::new("a", None);
+        let ext_fail = RecordingExtension::failing("boom", None);
+        let ext_c = RecordingExtension::new("c", None);
+        let registry = VmLifecycleExtensions::with(vec![
+            as_extension(&ext_a),
+            as_extension(&ext_fail),
+            as_extension(&ext_c),
+        ]);
+        let mut plan = sample_plan(VmBackend::Libkrun);
+        let sandbox = sample_sandbox();
+
+        let err = registry
+            .before_vm_launch(&sandbox, &PathBuf::from("/tmp/state"), &mut plan)
+            .await
+            .expect_err("scripted failure should propagate");
+        assert!(err.message().contains("scripted before_vm_launch failure"));
+
+        assert_eq!(ext_a.calls(), vec!["a:before_vm_launch"]);
+        assert_eq!(ext_fail.calls(), vec!["boom:before_vm_launch"]);
+        assert!(
+            ext_c.calls().is_empty(),
+            "extensions after the failure must not be invoked"
+        );
+    }
+
+    #[tokio::test]
+    async fn after_vm_launch_failed_runs_every_extension() {
+        let ext_a = RecordingExtension::new("a", None);
+        let ext_b = RecordingExtension::new("b", None);
+        let registry =
+            VmLifecycleExtensions::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
+        let sandbox = sample_sandbox();
+
+        registry
+            .after_vm_launch_failed(
+                &sandbox,
+                &PathBuf::from("/tmp/state"),
+                LaunchAbortReason::LauncherSpawnFailed,
+            )
+            .await;
+
+        assert_eq!(
+            ext_a.calls(),
+            vec!["a:after_vm_launch_failed:LauncherSpawnFailed"]
+        );
+        assert_eq!(
+            ext_b.calls(),
+            vec!["b:after_vm_launch_failed:LauncherSpawnFailed"]
+        );
+    }
+
+    #[tokio::test]
+    async fn after_sandbox_deleted_runs_every_extension() {
+        let ext_a = RecordingExtension::new("a", None);
+        let ext_b = RecordingExtension::new("b", None);
+        let registry =
+            VmLifecycleExtensions::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
+        let sandbox = sample_sandbox();
+
+        registry
+            .after_sandbox_deleted(&sandbox, &PathBuf::from("/tmp/state"))
+            .await;
+
+        assert_eq!(ext_a.calls(), vec!["a:after_sandbox_deleted"]);
+        assert_eq!(ext_b.calls(), vec!["b:after_sandbox_deleted"]);
+    }
+
+    #[test]
+    fn resource_exhausted_flag_round_trips() {
+        let err = VmLifecycleError::resource_exhausted("pool empty");
+        assert!(err.is_resource_exhausted());
+        assert_eq!(err.message(), "pool empty");
+
+        let plain = VmLifecycleError::new("internal");
+        assert!(!plain.is_resource_exhausted());
+    }
+}

--- a/crates/openshell-driver-vm/src/extensions/mod.rs
+++ b/crates/openshell-driver-vm/src/extensions/mod.rs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Concrete implementations of [`crate::lifecycle::LifecycleExtension`].
+//!
+//! The framework itself — the trait, registry, launch plan, descriptor,
+//! and backend-feature resolver — lives in [`crate::lifecycle`]. This
+//! module is the conventional home for concrete extensions that
+//! implement the trait.
+//!
+//! # Conventions for a new extension
+//!
+//! - Each extension lives in its own submodule:
+//!   `crates/openshell-driver-vm/src/extensions/<name>/mod.rs`.
+//! - The submodule exposes a single public type
+//!   `<Name>Extension` (e.g. `VfioPassthroughExtension`) that
+//!   implements [`crate::lifecycle::LifecycleExtension`].
+//! - Helpers (pool allocators, guest env builders, on-disk state
+//!   layouts) live alongside the extension in private modules within
+//!   the same directory.
+//! - The extension's [`crate::lifecycle::LifecycleExtension::name`]
+//!   must match `<name>` (kebab-case ASCII). The driver creates
+//!   per-extension state at
+//!   `<sandbox_state_dir>/extensions/<name>/` for hooks to use.
+//! - Re-export the extension type from this `mod.rs` so callers can
+//!   write `use openshell_driver_vm::extensions::VfioPassthroughExtension;`.
+//!
+//! New extension types are wired into a running driver by registering
+//! them with [`crate::lifecycle::LifecycleExtensionRegistry`] and passing
+//! the registry to [`crate::VmDriver::new_with_extensions`].

--- a/crates/openshell-driver-vm/src/lib.rs
+++ b/crates/openshell-driver-vm/src/lib.rs
@@ -3,19 +3,19 @@
 
 pub mod driver;
 mod embedded_runtime;
-pub mod extension;
 mod ffi;
 pub mod gpu;
+pub mod lifecycle;
 mod nft_ruleset;
 pub mod procguard;
 mod rootfs;
 mod runtime;
 
 pub use driver::{VmDriver, VmDriverConfig};
-pub use extension::{
-    LaunchAbortReason, VmBackendFeature, VmExtensionProvides, VmGuestInitDropIn, VmLaunchPlan,
-    VmLifecycleError, VmLifecycleExtension, VmLifecycleExtensionDescriptor, VmLifecycleExtensions,
-    VmLifecycleResult, VmPersistedSandbox,
+pub use lifecycle::{
+    BackendFeature, ExtensionCapabilities, ExtensionDescriptor, GuestInitDropin, LaunchAbortReason,
+    LaunchPlan, LifecycleError, LifecycleExtension, LifecycleExtensionRegistry, LifecycleResult,
+    RestoreContext,
 };
 pub use runtime::{
     VM_RUNTIME_DIR_ENV, VmBackend, VmLaunchConfig, cleanup_stale_tap_interfaces,

--- a/crates/openshell-driver-vm/src/lib.rs
+++ b/crates/openshell-driver-vm/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod driver;
 mod embedded_runtime;
+pub mod extension;
 mod ffi;
 pub mod gpu;
 mod nft_ruleset;
@@ -11,6 +12,10 @@ mod rootfs;
 mod runtime;
 
 pub use driver::{VmDriver, VmDriverConfig};
+pub use extension::{
+    LaunchAbortReason, VmLaunchPlan, VmLifecycleError, VmLifecycleExtension, VmLifecycleExtensions,
+    VmLifecycleResult,
+};
 pub use runtime::{
     VM_RUNTIME_DIR_ENV, VmBackend, VmLaunchConfig, cleanup_stale_tap_interfaces,
     configured_runtime_dir, run_vm,

--- a/crates/openshell-driver-vm/src/lib.rs
+++ b/crates/openshell-driver-vm/src/lib.rs
@@ -13,8 +13,9 @@ mod runtime;
 
 pub use driver::{VmDriver, VmDriverConfig};
 pub use extension::{
-    LaunchAbortReason, VmLaunchPlan, VmLifecycleError, VmLifecycleExtension, VmLifecycleExtensions,
-    VmLifecycleResult,
+    LaunchAbortReason, VmBackendFeature, VmExtensionProvides, VmGuestInitDropIn, VmLaunchPlan,
+    VmLifecycleError, VmLifecycleExtension, VmLifecycleExtensionDescriptor, VmLifecycleExtensions,
+    VmLifecycleResult, VmPersistedSandbox,
 };
 pub use runtime::{
     VM_RUNTIME_DIR_ENV, VmBackend, VmLaunchConfig, cleanup_stale_tap_interfaces,

--- a/crates/openshell-driver-vm/src/lifecycle.rs
+++ b/crates/openshell-driver-vm/src/lifecycle.rs
@@ -17,12 +17,12 @@ pub enum LaunchAbortReason {
 }
 
 #[derive(Debug, Clone)]
-pub struct VmLifecycleError {
+pub struct LifecycleError {
     message: String,
     resource_exhausted: bool,
 }
 
-impl VmLifecycleError {
+impl LifecycleError {
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
@@ -48,22 +48,22 @@ impl VmLifecycleError {
     }
 }
 
-impl std::fmt::Display for VmLifecycleError {
+impl std::fmt::Display for LifecycleError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.message)
     }
 }
 
-impl std::error::Error for VmLifecycleError {}
+impl std::error::Error for LifecycleError {}
 
-pub type VmLifecycleResult<T> = Result<T, VmLifecycleError>;
+pub type LifecycleResult<T> = Result<T, LifecycleError>;
 
 /// A capability an extension can require from the VM backend.
 ///
 /// Extensions declare features they need (e.g. PCI passthrough or an
 /// external kernel image) and the VM driver resolves a concrete
 /// [`VmBackend`] that can satisfy them. The mapping from feature to
-/// backend lives in [`VmBackendFeature::requires_qemu`] for now; once a
+/// backend lives in [`BackendFeature::requires_qemu`] for now; once a
 /// third backend exists this should evolve into a per-backend capability
 /// table that the resolver intersects against feature requirements.
 ///
@@ -73,16 +73,16 @@ pub type VmLifecycleResult<T> = Result<T, VmLifecycleError>;
 /// port wiring) lands, the driver still rejects launches where the
 /// resolved backend is QEMU but the sandbox has no GPU. As a result,
 /// declaring [`Self::PciPassthrough`] or [`Self::ExternalKernelImage`] on
-/// a non-GPU sandbox is accepted by [`VmLifecycleExtensions::validate`]
+/// a non-GPU sandbox is accepted by [`LifecycleExtensionRegistry::validate`]
 /// at registration time but will fail provisioning with a
 /// `FailedPrecondition` status.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum VmBackendFeature {
+pub enum BackendFeature {
     /// Extension supplies its own kernel image via
-    /// [`VmLaunchPlan::kernel_image`]. Currently QEMU-only.
+    /// [`LaunchPlan::kernel_image`]. Currently QEMU-only.
     ExternalKernelImage,
     /// Extension contributes guest init drop-ins via
-    /// [`VmLaunchPlan::guest_init_dropins`]. Supported by all backends.
+    /// [`LaunchPlan::guest_init_dropins`]. Supported by all backends.
     GuestInitDropins,
     /// Extension needs PCI device passthrough on the guest. Currently
     /// QEMU-only and currently rejected for non-GPU sandboxes pending the
@@ -93,7 +93,7 @@ pub enum VmBackendFeature {
     TapNetworking,
 }
 
-impl VmBackendFeature {
+impl BackendFeature {
     #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
@@ -118,7 +118,7 @@ impl VmBackendFeature {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct VmExtensionProvides {
+pub struct ExtensionCapabilities {
     pub kernel_profiles: Vec<String>,
     pub guest_init_dropins: Vec<String>,
     pub launch_features: Vec<String>,
@@ -132,28 +132,28 @@ pub struct VmExtensionProvides {
 /// launch plan unconditionally for every sandbox. An extension that wants
 /// conditional behavior (e.g. only contribute requirements when the
 /// sandbox spec asks for it) should leave the descriptor fields empty and
-/// call [`VmLaunchPlan::require_backend`] /
-/// [`VmLaunchPlan::require_backend_feature`] inside
-/// [`VmLifecycleExtension::configure_vm_launch`] instead.
+/// call [`LaunchPlan::require_backend`] /
+/// [`LaunchPlan::require_backend_feature`] inside
+/// [`LifecycleExtension::configure_launch`] instead.
 ///
 /// A future PR will add a per-sandbox activation protocol so the driver
 /// can gate this merge on a sandbox spec field. Until that lands, the
 /// only knob is "declare in the descriptor (always merged) vs decide in
 /// the hook (per-sandbox)".
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VmLifecycleExtensionDescriptor {
+pub struct ExtensionDescriptor {
     pub name: String,
-    pub provides: VmExtensionProvides,
+    pub provides: ExtensionCapabilities,
     pub required_backends: Vec<VmBackend>,
-    pub required_backend_features: Vec<VmBackendFeature>,
+    pub required_backend_features: Vec<BackendFeature>,
 }
 
-impl VmLifecycleExtensionDescriptor {
+impl ExtensionDescriptor {
     #[must_use]
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
-            provides: VmExtensionProvides::default(),
+            provides: ExtensionCapabilities::default(),
             required_backends: Vec::new(),
             required_backend_features: Vec::new(),
         }
@@ -176,12 +176,12 @@ impl VmLifecycleExtensionDescriptor {
 /// path separators, no `.`/`..`); duplicates across a single launch plan
 /// are rejected by the driver.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VmGuestInitDropIn {
+pub struct GuestInitDropin {
     pub name: String,
     pub contents: Vec<u8>,
 }
 
-impl VmGuestInitDropIn {
+impl GuestInitDropin {
     #[must_use]
     pub fn new(name: impl Into<String>, contents: impl Into<Vec<u8>>) -> Self {
         Self {
@@ -192,12 +192,12 @@ impl VmGuestInitDropIn {
 }
 
 #[derive(Debug, Clone)]
-pub struct VmLaunchPlan {
+pub struct LaunchPlan {
     pub backend: VmBackend,
     pub vcpus: u8,
     pub mem_mib: u32,
     pub required_backends: Vec<VmBackend>,
-    pub required_backend_features: Vec<VmBackendFeature>,
+    pub required_backend_features: Vec<BackendFeature>,
     pub kernel_profile: Option<String>,
     pub kernel_image: Option<PathBuf>,
     pub gpu_bdf: Option<String>,
@@ -207,18 +207,18 @@ pub struct VmLaunchPlan {
     pub vsock_cid: Option<u32>,
     pub guest_mac: Option<String>,
     pub gateway_port: Option<u16>,
-    pub guest_init_dropins: Vec<VmGuestInitDropIn>,
+    pub guest_init_dropins: Vec<GuestInitDropin>,
     pub env: Vec<String>,
 }
 
-impl VmLaunchPlan {
+impl LaunchPlan {
     pub fn require_backend(&mut self, backend: VmBackend) {
         if !self.required_backends.contains(&backend) {
             self.required_backends.push(backend);
         }
     }
 
-    pub fn require_backend_feature(&mut self, feature: VmBackendFeature) {
+    pub fn require_backend_feature(&mut self, feature: BackendFeature) {
         if !self.required_backend_features.contains(&feature) {
             self.required_backend_features.push(feature);
         }
@@ -226,7 +226,7 @@ impl VmLaunchPlan {
 
     pub fn require_backend_features(
         &mut self,
-        features: impl IntoIterator<Item = VmBackendFeature>,
+        features: impl IntoIterator<Item = BackendFeature>,
     ) {
         for feature in features {
             self.require_backend_feature(feature);
@@ -235,7 +235,7 @@ impl VmLaunchPlan {
 }
 
 #[derive(Debug, Clone)]
-pub struct VmPersistedSandbox {
+pub struct RestoreContext {
     pub sandbox: Sandbox,
     pub state_dir: PathBuf,
 }
@@ -245,28 +245,28 @@ pub struct VmPersistedSandbox {
 ///
 /// # Hook ordering during a successful launch
 ///
-/// 1. [`configure_vm_launch`](Self::configure_vm_launch) — contribute backend
-///    requirements (via [`VmLaunchPlan::require_backend`] /
-///    [`VmLaunchPlan::require_backend_feature`]) and provisioning inputs
+/// 1. [`configure_launch`](Self::configure_launch) — contribute backend
+///    requirements (via [`LaunchPlan::require_backend`] /
+///    [`LaunchPlan::require_backend_feature`]) and provisioning inputs
 ///    (kernel profile, guest init drop-ins, etc.). Called before the driver
 ///    has resolved the final backend.
-/// 2. Driver resolves [`VmLaunchPlan::backend`] from declared requirements
+/// 2. Driver resolves [`LaunchPlan::backend`] from declared requirements
 ///    and allocates backend-specific host resources (subnet, tap, vsock).
-/// 3. [`before_vm_launch`](Self::before_vm_launch) — perform host-side
+/// 3. [`before_launch`](Self::before_launch) — perform host-side
 ///    side effects with the resolved plan in hand, optionally append
-///    additional guest env via [`VmLaunchPlan::env`].
+///    additional guest env via [`LaunchPlan::env`].
 /// 4. The driver spawns the VM launcher process.
 ///
 /// On launch failure or sandbox deletion, the driver invokes
-/// [`after_vm_launch_failed`](Self::after_vm_launch_failed) or
-/// [`after_sandbox_deleted`](Self::after_sandbox_deleted) in **reverse
+/// [`after_launch_failed`](Self::after_launch_failed) or
+/// [`after_delete`](Self::after_delete) in **reverse
 /// registration order**, so cleanup mirrors setup.
 #[tonic::async_trait]
-pub trait VmLifecycleExtension: std::fmt::Debug + Send + Sync {
+pub trait LifecycleExtension: std::fmt::Debug + Send + Sync {
     fn name(&self) -> &str;
 
-    fn descriptor(&self) -> VmLifecycleExtensionDescriptor {
-        VmLifecycleExtensionDescriptor::new(self.name())
+    fn descriptor(&self) -> ExtensionDescriptor {
+        ExtensionDescriptor::new(self.name())
     }
 
     /// Contribute backend requirements and provisioning inputs to the plan
@@ -274,71 +274,71 @@ pub trait VmLifecycleExtension: std::fmt::Debug + Send + Sync {
     ///
     /// Use this hook to:
     /// - Declare backend requirements with
-    ///   [`VmLaunchPlan::require_backend`] or
-    ///   [`VmLaunchPlan::require_backend_feature`].
-    /// - Set [`VmLaunchPlan::kernel_profile`] or
-    ///   [`VmLaunchPlan::kernel_image`].
-    /// - Append [`VmLaunchPlan::guest_init_dropins`] entries.
+    ///   [`LaunchPlan::require_backend`] or
+    ///   [`LaunchPlan::require_backend_feature`].
+    /// - Set [`LaunchPlan::kernel_profile`] or
+    ///   [`LaunchPlan::kernel_image`].
+    /// - Append [`LaunchPlan::guest_init_dropins`] entries.
     ///
-    /// At this point [`VmLaunchPlan::backend`] is the driver's tentative
+    /// At this point [`LaunchPlan::backend`] is the driver's tentative
     /// choice and may still change during backend resolution. Do not perform
     /// host-side side effects here — defer them to
-    /// [`before_vm_launch`](Self::before_vm_launch).
-    async fn configure_vm_launch(
+    /// [`before_launch`](Self::before_launch).
+    async fn configure_launch(
         &self,
         _sandbox: &Sandbox,
         _state_dir: &Path,
-        _plan: &mut VmLaunchPlan,
-    ) -> VmLifecycleResult<()> {
+        _plan: &mut LaunchPlan,
+    ) -> LifecycleResult<()> {
         Ok(())
     }
 
     /// Perform host-side preparation with the resolved launch plan.
     ///
-    /// At this point [`VmLaunchPlan::backend`],
-    /// [`VmLaunchPlan::required_backends`], and
-    /// [`VmLaunchPlan::required_backend_features`] are finalized and any
+    /// At this point [`LaunchPlan::backend`],
+    /// [`LaunchPlan::required_backends`], and
+    /// [`LaunchPlan::required_backend_features`] are finalized and any
     /// backend-specific host resources (subnet, tap, vsock) have been
     /// allocated. This hook is the right place to bind PCI devices, set
     /// up filesystem state, or otherwise prepare the host.
     ///
-    /// Implementations MAY append entries to [`VmLaunchPlan::env`] to
+    /// Implementations MAY append entries to [`LaunchPlan::env`] to
     /// inject additional guest environment variables, and MAY return an
     /// error to abort the launch. Implementations MUST NOT change
-    /// [`VmLaunchPlan::backend`], [`VmLaunchPlan::required_backends`], or
-    /// [`VmLaunchPlan::required_backend_features`]; those changes are
-    /// ignored by the driver once `before_vm_launch` is reached.
+    /// [`LaunchPlan::backend`], [`LaunchPlan::required_backends`], or
+    /// [`LaunchPlan::required_backend_features`]; those changes are
+    /// ignored by the driver once `before_launch` is reached.
     ///
     /// If this hook performs allocations that must be released on failure
     /// or delete, implement
-    /// [`after_vm_launch_failed`](Self::after_vm_launch_failed) and
-    /// [`after_sandbox_deleted`](Self::after_sandbox_deleted) accordingly.
-    async fn before_vm_launch(
+    /// [`after_launch_failed`](Self::after_launch_failed) and
+    /// [`after_delete`](Self::after_delete) accordingly.
+    async fn before_launch(
         &self,
         _sandbox: &Sandbox,
         _state_dir: &Path,
-        _plan: &mut VmLaunchPlan,
-    ) -> VmLifecycleResult<()> {
+        _plan: &mut LaunchPlan,
+    ) -> LifecycleResult<()> {
         Ok(())
     }
 
     /// Release anything this extension allocated during
-    /// [`configure_vm_launch`](Self::configure_vm_launch) or
-    /// [`before_vm_launch`](Self::before_vm_launch) when the launcher
+    /// [`configure_launch`](Self::configure_launch) or
+    /// [`before_launch`](Self::before_launch) when the launcher
     /// could not be started or aborted before it became healthy.
     ///
     /// Invoked in reverse registration order. Errors are logged but do not
     /// propagate; do best-effort cleanup and return [`Ok`] when possible.
     /// This hook is invoked on every launcher failure, including failures
     /// that happen during a persisted-sandbox restore (in that case
-    /// [`reconcile_after_restore`](Self::reconcile_after_restore) is *not*
+    /// [`after_restore`](Self::after_restore) is *not*
     /// invoked).
-    async fn after_vm_launch_failed(
+    async fn after_launch_failed(
         &self,
         _sandbox: &Sandbox,
         _state_dir: &Path,
         _reason: LaunchAbortReason,
-    ) -> VmLifecycleResult<()> {
+    ) -> LifecycleResult<()> {
         Ok(())
     }
 
@@ -346,11 +346,11 @@ pub trait VmLifecycleExtension: std::fmt::Debug + Send + Sync {
     ///
     /// Invoked in reverse registration order. Errors are logged but do not
     /// propagate.
-    async fn after_sandbox_deleted(
+    async fn after_delete(
         &self,
         _sandbox: &Sandbox,
         _state_dir: &Path,
-    ) -> VmLifecycleResult<()> {
+    ) -> LifecycleResult<()> {
         Ok(())
     }
 
@@ -360,10 +360,10 @@ pub trait VmLifecycleExtension: std::fmt::Debug + Send + Sync {
     /// Returning an error causes the driver to skip restoring this
     /// sandbox; the persisted state is left on disk for operator
     /// inspection.
-    async fn reconcile_before_restore(
+    async fn before_restore(
         &self,
-        _sandbox: &VmPersistedSandbox,
-    ) -> VmLifecycleResult<()> {
+        _sandbox: &RestoreContext,
+    ) -> LifecycleResult<()> {
         Ok(())
     }
 
@@ -371,24 +371,24 @@ pub trait VmLifecycleExtension: std::fmt::Debug + Send + Sync {
     /// successfully restored and its launcher is running again.
     ///
     /// Only invoked when restore succeeds. If the restore fails partway
-    /// through, [`after_vm_launch_failed`](Self::after_vm_launch_failed)
+    /// through, [`after_launch_failed`](Self::after_launch_failed)
     /// runs instead.
-    async fn reconcile_after_restore(
+    async fn after_restore(
         &self,
-        _sandbox: &VmPersistedSandbox,
-    ) -> VmLifecycleResult<()> {
+        _sandbox: &RestoreContext,
+    ) -> LifecycleResult<()> {
         Ok(())
     }
 }
 
 #[derive(Clone, Default)]
-pub struct VmLifecycleExtensions {
-    extensions: Vec<Arc<dyn VmLifecycleExtension>>,
+pub struct LifecycleExtensionRegistry {
+    extensions: Vec<Arc<dyn LifecycleExtension>>,
 }
 
-impl std::fmt::Debug for VmLifecycleExtensions {
+impl std::fmt::Debug for LifecycleExtensionRegistry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VmLifecycleExtensions")
+        f.debug_struct("LifecycleExtensionRegistry")
             .field(
                 "names",
                 &self
@@ -401,18 +401,18 @@ impl std::fmt::Debug for VmLifecycleExtensions {
     }
 }
 
-impl VmLifecycleExtensions {
+impl LifecycleExtensionRegistry {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     #[must_use]
-    pub fn with(extensions: Vec<Arc<dyn VmLifecycleExtension>>) -> Self {
+    pub fn with(extensions: Vec<Arc<dyn LifecycleExtension>>) -> Self {
         Self { extensions }
     }
 
-    pub fn push(&mut self, extension: Arc<dyn VmLifecycleExtension>) {
+    pub fn push(&mut self, extension: Arc<dyn LifecycleExtension>) {
         self.extensions.push(extension);
     }
 
@@ -435,27 +435,27 @@ impl VmLifecycleExtensions {
     }
 
     #[must_use]
-    pub fn descriptors(&self) -> Vec<VmLifecycleExtensionDescriptor> {
+    pub fn descriptors(&self) -> Vec<ExtensionDescriptor> {
         self.extensions.iter().map(|ext| ext.descriptor()).collect()
     }
 
-    pub fn validate(&self) -> VmLifecycleResult<()> {
+    pub fn validate(&self) -> LifecycleResult<()> {
         let mut names = HashSet::new();
         for ext in &self.extensions {
             let descriptor = ext.descriptor();
             validate_extension_name(ext.name())?;
             validate_extension_name(&descriptor.name)?;
             if descriptor.name != ext.name() {
-                return Err(VmLifecycleError::new(format!(
-                    "VM lifecycle extension '{}' descriptor name does not match '{}'",
+                return Err(LifecycleError::new(format!(
+                    "lifecycle extension '{}' descriptor name does not match '{}'",
                     ext.name(),
                     descriptor.name
                 )));
             }
             validate_descriptor_strings(&descriptor)?;
             if !names.insert(descriptor.name.clone()) {
-                return Err(VmLifecycleError::new(format!(
-                    "duplicate VM lifecycle extension name: {}",
+                return Err(LifecycleError::new(format!(
+                    "duplicate lifecycle extension name: {}",
                     descriptor.name
                 )));
             }
@@ -463,12 +463,12 @@ impl VmLifecycleExtensions {
         Ok(())
     }
 
-    pub async fn configure_vm_launch(
+    pub async fn configure_launch(
         &self,
         sandbox: &Sandbox,
         state_dir: &Path,
-        plan: &mut VmLaunchPlan,
-    ) -> VmLifecycleResult<()> {
+        plan: &mut LaunchPlan,
+    ) -> LifecycleResult<()> {
         for ext in &self.extensions {
             let descriptor = ext.descriptor();
             for backend in descriptor.required_backends {
@@ -480,7 +480,7 @@ impl VmLifecycleExtensions {
             // silently dropping the earlier value.
             let prev_kernel_profile = plan.kernel_profile.clone();
             let prev_kernel_image = plan.kernel_image.clone();
-            ext.configure_vm_launch(sandbox, state_dir, plan).await?;
+            ext.configure_launch(sandbox, state_dir, plan).await?;
             warn_on_singleton_overwrite(
                 ext.name(),
                 "kernel_profile",
@@ -501,19 +501,19 @@ impl VmLifecycleExtensions {
         Ok(())
     }
 
-    pub async fn before_vm_launch(
+    pub async fn before_launch(
         &self,
         sandbox: &Sandbox,
         state_dir: &Path,
-        plan: &mut VmLaunchPlan,
-    ) -> VmLifecycleResult<()> {
+        plan: &mut LaunchPlan,
+    ) -> LifecycleResult<()> {
         for ext in &self.extensions {
-            ext.before_vm_launch(sandbox, state_dir, plan).await?;
+            ext.before_launch(sandbox, state_dir, plan).await?;
         }
         Ok(())
     }
 
-    pub async fn after_vm_launch_failed(
+    pub async fn after_launch_failed(
         &self,
         sandbox: &Sandbox,
         state_dir: &Path,
@@ -521,50 +521,50 @@ impl VmLifecycleExtensions {
     ) {
         for ext in self.extensions.iter().rev() {
             if let Err(err) = ext
-                .after_vm_launch_failed(sandbox, state_dir, reason.clone())
+                .after_launch_failed(sandbox, state_dir, reason.clone())
                 .await
             {
                 tracing::warn!(
                     extension = ext.name(),
                     sandbox_id = %sandbox.id,
                     error = %err,
-                    "vm driver: lifecycle extension after_vm_launch_failed hook failed"
+                    "vm driver: lifecycle extension after_launch_failed hook failed"
                 );
             }
         }
     }
 
-    pub async fn after_sandbox_deleted(&self, sandbox: &Sandbox, state_dir: &Path) {
+    pub async fn after_delete(&self, sandbox: &Sandbox, state_dir: &Path) {
         for ext in self.extensions.iter().rev() {
-            if let Err(err) = ext.after_sandbox_deleted(sandbox, state_dir).await {
+            if let Err(err) = ext.after_delete(sandbox, state_dir).await {
                 tracing::warn!(
                     extension = ext.name(),
                     sandbox_id = %sandbox.id,
                     error = %err,
-                    "vm driver: lifecycle extension after_sandbox_deleted hook failed"
+                    "vm driver: lifecycle extension after_delete hook failed"
                 );
             }
         }
     }
 
-    pub async fn reconcile_before_restore(
+    pub async fn before_restore(
         &self,
-        sandbox: &VmPersistedSandbox,
-    ) -> VmLifecycleResult<()> {
+        sandbox: &RestoreContext,
+    ) -> LifecycleResult<()> {
         for ext in &self.extensions {
-            ext.reconcile_before_restore(sandbox).await?;
+            ext.before_restore(sandbox).await?;
         }
         Ok(())
     }
 
-    pub async fn reconcile_after_restore(&self, sandbox: &VmPersistedSandbox) {
+    pub async fn after_restore(&self, sandbox: &RestoreContext) {
         for ext in &self.extensions {
-            if let Err(err) = ext.reconcile_after_restore(sandbox).await {
+            if let Err(err) = ext.after_restore(sandbox).await {
                 tracing::warn!(
                     extension = ext.name(),
                     sandbox_id = %sandbox.sandbox.id,
                     error = %err,
-                    "vm driver: lifecycle extension reconcile_after_restore hook failed"
+                    "vm driver: lifecycle extension after_restore hook failed"
                 );
             }
         }
@@ -597,31 +597,31 @@ fn warn_on_singleton_overwrite<T>(
 pub fn extension_state_dir(
     sandbox_state_dir: &Path,
     extension_name: &str,
-) -> VmLifecycleResult<PathBuf> {
+) -> LifecycleResult<PathBuf> {
     validate_extension_name(extension_name)?;
     Ok(sandbox_state_dir.join("extensions").join(extension_name))
 }
 
-fn validate_extension_name(name: &str) -> VmLifecycleResult<()> {
+fn validate_extension_name(name: &str) -> LifecycleResult<()> {
     if name.is_empty() || name == "." || name == ".." {
-        return Err(VmLifecycleError::new(
-            "VM lifecycle extension name is empty or reserved",
+        return Err(LifecycleError::new(
+            "lifecycle extension name is empty or reserved",
         ));
     }
     if !name
         .chars()
         .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.')
     {
-        return Err(VmLifecycleError::new(format!(
-            "VM lifecycle extension name '{name}' must contain only ASCII letters, numbers, '.', '-', or '_'"
+        return Err(LifecycleError::new(format!(
+            "lifecycle extension name '{name}' must contain only ASCII letters, numbers, '.', '-', or '_'"
         )));
     }
     Ok(())
 }
 
 fn validate_descriptor_strings(
-    descriptor: &VmLifecycleExtensionDescriptor,
-) -> VmLifecycleResult<()> {
+    descriptor: &ExtensionDescriptor,
+) -> LifecycleResult<()> {
     for value in descriptor
         .provides
         .kernel_profiles
@@ -631,8 +631,8 @@ fn validate_descriptor_strings(
         .chain(descriptor.provides.host_resources.iter())
     {
         validate_extension_identifier(value).map_err(|err| {
-            VmLifecycleError::new(format!(
-                "VM lifecycle extension '{}' has invalid provided capability '{}': {err}",
+            LifecycleError::new(format!(
+                "lifecycle extension '{}' has invalid provided capability '{}': {err}",
                 descriptor.name, value
             ))
         })?;
@@ -702,62 +702,62 @@ mod tests {
     }
 
     #[tonic::async_trait]
-    impl VmLifecycleExtension for RecordingExtension {
+    impl LifecycleExtension for RecordingExtension {
         fn name(&self) -> &str {
             &self.name
         }
 
-        fn descriptor(&self) -> VmLifecycleExtensionDescriptor {
-            VmLifecycleExtensionDescriptor {
+        fn descriptor(&self) -> ExtensionDescriptor {
+            ExtensionDescriptor {
                 name: self.name.clone(),
-                provides: VmExtensionProvides {
+                provides: ExtensionCapabilities {
                     kernel_profiles: vec![format!("profile-{}", self.name)],
                     guest_init_dropins: vec![format!("50-{}.sh", self.name)],
                     launch_features: vec!["guest-init-dropins".to_string()],
                     host_resources: Vec::new(),
                 },
                 required_backends: Vec::new(),
-                required_backend_features: vec![VmBackendFeature::GuestInitDropins],
+                required_backend_features: vec![BackendFeature::GuestInitDropins],
             }
         }
 
-        async fn configure_vm_launch(
+        async fn configure_launch(
             &self,
             _sandbox: &Sandbox,
             _state_dir: &Path,
-            plan: &mut VmLaunchPlan,
-        ) -> VmLifecycleResult<()> {
+            plan: &mut LaunchPlan,
+        ) -> LifecycleResult<()> {
             self.calls
                 .lock()
                 .unwrap()
-                .push(format!("{}:configure_vm_launch", self.name));
+                .push(format!("{}:configure_launch", self.name));
             if self.configure_should_fail {
-                return Err(VmLifecycleError::new(format!(
-                    "{}: scripted configure_vm_launch failure",
+                return Err(LifecycleError::new(format!(
+                    "{}: scripted configure_launch failure",
                     self.name
                 )));
             }
             plan.kernel_profile = Some(format!("profile-{}", self.name));
-            plan.guest_init_dropins.push(VmGuestInitDropIn::new(
+            plan.guest_init_dropins.push(GuestInitDropin::new(
                 format!("50-{}.sh", self.name),
                 b"#!/bin/sh\n".to_vec(),
             ));
             Ok(())
         }
 
-        async fn before_vm_launch(
+        async fn before_launch(
             &self,
             _sandbox: &Sandbox,
             _state_dir: &Path,
-            plan: &mut VmLaunchPlan,
-        ) -> VmLifecycleResult<()> {
+            plan: &mut LaunchPlan,
+        ) -> LifecycleResult<()> {
             self.calls
                 .lock()
                 .unwrap()
-                .push(format!("{}:before_vm_launch", self.name));
+                .push(format!("{}:before_launch", self.name));
             if self.before_should_fail {
-                return Err(VmLifecycleError::new(format!(
-                    "{}: scripted before_vm_launch failure",
+                return Err(LifecycleError::new(format!(
+                    "{}: scripted before_launch failure",
                     self.name
                 )));
             }
@@ -765,34 +765,34 @@ mod tests {
             Ok(())
         }
 
-        async fn after_vm_launch_failed(
+        async fn after_launch_failed(
             &self,
             _sandbox: &Sandbox,
             _state_dir: &Path,
             reason: LaunchAbortReason,
-        ) -> VmLifecycleResult<()> {
+        ) -> LifecycleResult<()> {
             self.calls
                 .lock()
                 .unwrap()
-                .push(format!("{}:after_vm_launch_failed:{:?}", self.name, reason));
+                .push(format!("{}:after_launch_failed:{:?}", self.name, reason));
             Ok(())
         }
 
-        async fn after_sandbox_deleted(
+        async fn after_delete(
             &self,
             _sandbox: &Sandbox,
             _state_dir: &Path,
-        ) -> VmLifecycleResult<()> {
+        ) -> LifecycleResult<()> {
             self.calls
                 .lock()
                 .unwrap()
-                .push(format!("{}:after_sandbox_deleted", self.name));
+                .push(format!("{}:after_delete", self.name));
             Ok(())
         }
     }
 
-    fn sample_plan(backend: VmBackend) -> VmLaunchPlan {
-        VmLaunchPlan {
+    fn sample_plan(backend: VmBackend) -> LaunchPlan {
+        LaunchPlan {
             backend,
             vcpus: 2,
             mem_mib: 2048,
@@ -820,26 +820,26 @@ mod tests {
         }
     }
 
-    fn as_extension<T>(extension: &Arc<T>) -> Arc<dyn VmLifecycleExtension>
+    fn as_extension<T>(extension: &Arc<T>) -> Arc<dyn LifecycleExtension>
     where
-        T: VmLifecycleExtension + 'static,
+        T: LifecycleExtension + 'static,
     {
         extension.clone()
     }
 
     #[tokio::test]
-    async fn configure_vm_launch_runs_each_extension_in_order() {
+    async fn configure_launch_runs_each_extension_in_order() {
         let ext_a = RecordingExtension::new("a");
         let ext_b = RecordingExtension::new("b");
         let registry =
-            VmLifecycleExtensions::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
+            LifecycleExtensionRegistry::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
         let mut plan = sample_plan(VmBackend::Qemu);
         let sandbox = sample_sandbox();
 
         registry
-            .configure_vm_launch(&sandbox, &PathBuf::from("/tmp/state"), &mut plan)
+            .configure_launch(&sandbox, &PathBuf::from("/tmp/state"), &mut plan)
             .await
-            .expect("configure_vm_launch succeeds");
+            .expect("configure_launch succeeds");
 
         assert_eq!(plan.kernel_profile.as_deref(), Some("profile-b"));
         assert_eq!(
@@ -849,16 +849,16 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["50-a.sh", "50-b.sh"]
         );
-        assert_eq!(ext_a.calls(), vec!["a:configure_vm_launch"]);
-        assert_eq!(ext_b.calls(), vec!["b:configure_vm_launch"]);
+        assert_eq!(ext_a.calls(), vec!["a:configure_launch"]);
+        assert_eq!(ext_b.calls(), vec!["b:configure_launch"]);
     }
 
     #[tokio::test]
-    async fn configure_vm_launch_short_circuits_on_first_failure() {
+    async fn configure_launch_short_circuits_on_first_failure() {
         let ext_a = RecordingExtension::new("a");
         let ext_fail = RecordingExtension::configure_failing("boom");
         let ext_c = RecordingExtension::new("c");
-        let registry = VmLifecycleExtensions::with(vec![
+        let registry = LifecycleExtensionRegistry::with(vec![
             as_extension(&ext_a),
             as_extension(&ext_fail),
             as_extension(&ext_c),
@@ -867,16 +867,16 @@ mod tests {
         let sandbox = sample_sandbox();
 
         let err = registry
-            .configure_vm_launch(&sandbox, &PathBuf::from("/tmp/state"), &mut plan)
+            .configure_launch(&sandbox, &PathBuf::from("/tmp/state"), &mut plan)
             .await
             .expect_err("scripted failure should propagate");
         assert!(
             err.message()
-                .contains("scripted configure_vm_launch failure")
+                .contains("scripted configure_launch failure")
         );
 
-        assert_eq!(ext_a.calls(), vec!["a:configure_vm_launch"]);
-        assert_eq!(ext_fail.calls(), vec!["boom:configure_vm_launch"]);
+        assert_eq!(ext_a.calls(), vec!["a:configure_launch"]);
+        assert_eq!(ext_fail.calls(), vec!["boom:configure_launch"]);
         assert!(
             ext_c.calls().is_empty(),
             "extensions after the failure must not be invoked"
@@ -884,30 +884,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn before_vm_launch_runs_each_extension_in_order_and_collects_env() {
+    async fn before_launch_runs_each_extension_in_order_and_collects_env() {
         let ext_a = RecordingExtension::new("a");
         let ext_b = RecordingExtension::new("b");
         let registry =
-            VmLifecycleExtensions::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
+            LifecycleExtensionRegistry::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
         let mut plan = sample_plan(VmBackend::Qemu);
         let sandbox = sample_sandbox();
 
         registry
-            .before_vm_launch(&sandbox, &PathBuf::from("/tmp/state"), &mut plan)
+            .before_launch(&sandbox, &PathBuf::from("/tmp/state"), &mut plan)
             .await
-            .expect("before_vm_launch succeeds");
+            .expect("before_launch succeeds");
 
         assert_eq!(plan.env, vec!["RECORDING_a=1", "RECORDING_b=1"]);
-        assert_eq!(ext_a.calls(), vec!["a:before_vm_launch"]);
-        assert_eq!(ext_b.calls(), vec!["b:before_vm_launch"]);
+        assert_eq!(ext_a.calls(), vec!["a:before_launch"]);
+        assert_eq!(ext_b.calls(), vec!["b:before_launch"]);
     }
 
     #[tokio::test]
-    async fn before_vm_launch_short_circuits_on_first_failure() {
+    async fn before_launch_short_circuits_on_first_failure() {
         let ext_a = RecordingExtension::new("a");
         let ext_fail = RecordingExtension::failing("boom");
         let ext_c = RecordingExtension::new("c");
-        let registry = VmLifecycleExtensions::with(vec![
+        let registry = LifecycleExtensionRegistry::with(vec![
             as_extension(&ext_a),
             as_extension(&ext_fail),
             as_extension(&ext_c),
@@ -916,13 +916,13 @@ mod tests {
         let sandbox = sample_sandbox();
 
         let err = registry
-            .before_vm_launch(&sandbox, &PathBuf::from("/tmp/state"), &mut plan)
+            .before_launch(&sandbox, &PathBuf::from("/tmp/state"), &mut plan)
             .await
             .expect_err("scripted failure should propagate");
-        assert!(err.message().contains("scripted before_vm_launch failure"));
+        assert!(err.message().contains("scripted before_launch failure"));
 
-        assert_eq!(ext_a.calls(), vec!["a:before_vm_launch"]);
-        assert_eq!(ext_fail.calls(), vec!["boom:before_vm_launch"]);
+        assert_eq!(ext_a.calls(), vec!["a:before_launch"]);
+        assert_eq!(ext_fail.calls(), vec!["boom:before_launch"]);
         assert!(
             ext_c.calls().is_empty(),
             "extensions after the failure must not be invoked"
@@ -930,15 +930,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn after_vm_launch_failed_runs_every_extension_in_reverse_order() {
+    async fn after_launch_failed_runs_every_extension_in_reverse_order() {
         let ext_a = RecordingExtension::new("a");
         let ext_b = RecordingExtension::new("b");
         let registry =
-            VmLifecycleExtensions::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
+            LifecycleExtensionRegistry::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
         let sandbox = sample_sandbox();
 
         registry
-            .after_vm_launch_failed(
+            .after_launch_failed(
                 &sandbox,
                 &PathBuf::from("/tmp/state"),
                 LaunchAbortReason::LauncherSpawnFailed,
@@ -947,37 +947,37 @@ mod tests {
 
         assert_eq!(
             ext_a.calls(),
-            vec!["a:after_vm_launch_failed:LauncherSpawnFailed"]
+            vec!["a:after_launch_failed:LauncherSpawnFailed"]
         );
         assert_eq!(
             ext_b.calls(),
-            vec!["b:after_vm_launch_failed:LauncherSpawnFailed"]
+            vec!["b:after_launch_failed:LauncherSpawnFailed"]
         );
     }
 
     #[tokio::test]
-    async fn after_sandbox_deleted_runs_every_extension() {
+    async fn after_delete_runs_every_extension() {
         let ext_a = RecordingExtension::new("a");
         let ext_b = RecordingExtension::new("b");
         let registry =
-            VmLifecycleExtensions::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
+            LifecycleExtensionRegistry::with(vec![as_extension(&ext_a), as_extension(&ext_b)]);
         let sandbox = sample_sandbox();
 
         registry
-            .after_sandbox_deleted(&sandbox, &PathBuf::from("/tmp/state"))
+            .after_delete(&sandbox, &PathBuf::from("/tmp/state"))
             .await;
 
-        assert_eq!(ext_a.calls(), vec!["a:after_sandbox_deleted"]);
-        assert_eq!(ext_b.calls(), vec!["b:after_sandbox_deleted"]);
+        assert_eq!(ext_a.calls(), vec!["a:after_delete"]);
+        assert_eq!(ext_b.calls(), vec!["b:after_delete"]);
     }
 
     #[test]
     fn resource_exhausted_flag_round_trips() {
-        let err = VmLifecycleError::resource_exhausted("pool empty");
+        let err = LifecycleError::resource_exhausted("pool empty");
         assert!(err.is_resource_exhausted());
         assert_eq!(err.message(), "pool empty");
 
-        let plain = VmLifecycleError::new("internal");
+        let plain = LifecycleError::new("internal");
         assert!(!plain.is_resource_exhausted());
     }
 
@@ -994,7 +994,7 @@ mod tests {
 
     #[test]
     fn validate_rejects_duplicate_extension_names() {
-        let registry = VmLifecycleExtensions::with(vec![
+        let registry = LifecycleExtensionRegistry::with(vec![
             RecordingExtension::new("dup"),
             RecordingExtension::new("dup"),
         ]);
@@ -1007,7 +1007,7 @@ mod tests {
     #[test]
     fn descriptor_tracks_provided_capabilities_and_requirements() {
         let ext = RecordingExtension::new("vfio");
-        let registry = VmLifecycleExtensions::with(vec![ext]);
+        let registry = LifecycleExtensionRegistry::with(vec![ext]);
 
         let descriptors = registry.descriptors();
         assert_eq!(descriptors.len(), 1);
@@ -1015,7 +1015,7 @@ mod tests {
         assert!(descriptors[0].required_backends.is_empty());
         assert_eq!(
             descriptors[0].required_backend_features,
-            vec![VmBackendFeature::GuestInitDropins]
+            vec![BackendFeature::GuestInitDropins]
         );
         assert_eq!(
             descriptors[0].provides.kernel_profiles,

--- a/crates/openshell-driver-vm/src/lifecycle.rs
+++ b/crates/openshell-driver-vm/src/lifecycle.rs
@@ -247,10 +247,7 @@ impl LaunchPlan {
         }
     }
 
-    pub fn require_backend_features(
-        &mut self,
-        features: impl IntoIterator<Item = BackendFeature>,
-    ) {
+    pub fn require_backend_features(&mut self, features: impl IntoIterator<Item = BackendFeature>) {
         for feature in features {
             self.require_backend_feature(feature);
         }
@@ -412,11 +409,7 @@ pub trait LifecycleExtension: std::fmt::Debug + Send + Sync {
     ///
     /// Invoked in reverse registration order. Errors are logged but do not
     /// propagate.
-    async fn after_delete(
-        &self,
-        _sandbox: &Sandbox,
-        _state_dir: &Path,
-    ) -> LifecycleResult<()> {
+    async fn after_delete(&self, _sandbox: &Sandbox, _state_dir: &Path) -> LifecycleResult<()> {
         Ok(())
     }
 
@@ -426,10 +419,7 @@ pub trait LifecycleExtension: std::fmt::Debug + Send + Sync {
     /// Returning an error causes the driver to skip restoring this
     /// sandbox; the persisted state is left on disk for operator
     /// inspection.
-    async fn before_restore(
-        &self,
-        _sandbox: &RestoreContext,
-    ) -> LifecycleResult<()> {
+    async fn before_restore(&self, _sandbox: &RestoreContext) -> LifecycleResult<()> {
         Ok(())
     }
 
@@ -439,10 +429,7 @@ pub trait LifecycleExtension: std::fmt::Debug + Send + Sync {
     /// Only invoked when restore succeeds. If the restore fails partway
     /// through, [`after_launch_failed`](Self::after_launch_failed)
     /// runs instead.
-    async fn after_restore(
-        &self,
-        _sandbox: &RestoreContext,
-    ) -> LifecycleResult<()> {
+    async fn after_restore(&self, _sandbox: &RestoreContext) -> LifecycleResult<()> {
         Ok(())
     }
 }
@@ -558,9 +545,7 @@ impl LifecycleExtensionRegistry {
             .iter()
             .filter(|ext| match ext.activation() {
                 ExtensionActivation::Global => true,
-                ExtensionActivation::OnRequest { key } => {
-                    sandbox_requested_extension(sandbox, key)
-                }
+                ExtensionActivation::OnRequest { key } => sandbox_requested_extension(sandbox, key),
             })
             .collect()
     }
@@ -649,10 +634,7 @@ impl LifecycleExtensionRegistry {
         }
     }
 
-    pub async fn before_restore(
-        &self,
-        sandbox: &RestoreContext,
-    ) -> LifecycleResult<()> {
+    pub async fn before_restore(&self, sandbox: &RestoreContext) -> LifecycleResult<()> {
         for ext in self.active_for(&sandbox.sandbox) {
             ext.before_restore(sandbox).await?;
         }
@@ -752,9 +734,7 @@ fn validate_extension_name(name: &str) -> LifecycleResult<()> {
     Ok(())
 }
 
-fn validate_descriptor_strings(
-    descriptor: &ExtensionDescriptor,
-) -> LifecycleResult<()> {
+fn validate_descriptor_strings(descriptor: &ExtensionDescriptor) -> LifecycleResult<()> {
     for value in descriptor
         .provides
         .kernel_profiles
@@ -932,11 +912,7 @@ mod tests {
             Ok(())
         }
 
-        async fn after_delete(
-            &self,
-            _sandbox: &Sandbox,
-            _state_dir: &Path,
-        ) -> LifecycleResult<()> {
+        async fn after_delete(&self, _sandbox: &Sandbox, _state_dir: &Path) -> LifecycleResult<()> {
             self.calls
                 .lock()
                 .unwrap()
@@ -1040,10 +1016,7 @@ mod tests {
             .configure_launch(&sandbox, &PathBuf::from("/tmp/state"), &mut plan)
             .await
             .expect_err("scripted failure should propagate");
-        assert!(
-            err.message()
-                .contains("scripted configure_launch failure")
-        );
+        assert!(err.message().contains("scripted configure_launch failure"));
 
         assert_eq!(ext_a.calls(), vec!["a:configure_launch"]);
         assert_eq!(ext_fail.calls(), vec!["boom:configure_launch"]);

--- a/crates/openshell-driver-vm/src/lifecycle.rs
+++ b/crates/openshell-driver-vm/src/lifecycle.rs
@@ -6,14 +6,32 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use openshell_core::proto::compute::v1::DriverSandbox as Sandbox;
+use openshell_core::settings::parse_bool_like;
 
 use crate::runtime::VmBackend;
+
+/// Label-key prefix used to request a per-sandbox lifecycle extension.
+///
+/// A sandbox opts into an [`ExtensionActivation::OnRequest`] extension when
+/// its template carries a `{SANDBOX_EXTENSION_LABEL_PREFIX}{key}` label set
+/// to an enabled value. The label is policy-controlled (stamped by the
+/// gateway), so a guest cannot self-activate an extension. This contract
+/// lives with the lifecycle framework that consumes it rather than in the
+/// shared settings registry.
+pub const SANDBOX_EXTENSION_LABEL_PREFIX: &str = "openshell.io/extension.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LaunchAbortReason {
     LauncherSpawnFailed,
     BeforeLaunchHookFailed,
     GuestPrepareFailed,
+    /// The VM helper process exited on its own *after* the launcher was
+    /// spawned (e.g. a guest crash or the hypervisor dying), rather than the
+    /// driver aborting during setup. The driver releases its own per-launch
+    /// allocations when this happens, so extensions are given the same
+    /// opportunity to release host resources they allocated in
+    /// [`LifecycleExtension::before_launch`].
+    ProcessExited,
 }
 
 #[derive(Debug, Clone)]
@@ -136,10 +154,15 @@ pub struct ExtensionCapabilities {
 /// [`LaunchPlan::require_backend_feature`] inside
 /// [`LifecycleExtension::configure_launch`] instead.
 ///
-/// A future PR will add a per-sandbox activation protocol so the driver
-/// can gate this merge on a sandbox spec field. Until that lands, the
-/// only knob is "declare in the descriptor (always merged) vs decide in
-/// the hook (per-sandbox)".
+/// Whether the descriptor requirements are merged for *every* sandbox or
+/// only for sandboxes that opted in is controlled by the extension's
+/// [`LifecycleExtension::activation`]: a [`ExtensionActivation::Global`]
+/// extension always participates, while an
+/// [`ExtensionActivation::OnRequest`] extension only participates when the
+/// sandbox carries the matching request label (see
+/// [`ExtensionActivation`]). Within an active extension, the
+/// "declare in the descriptor (merged) vs decide in the hook" knob still
+/// applies for finer-grained, spec-dependent behavior.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExtensionDescriptor {
     pub name: String,
@@ -240,6 +263,29 @@ pub struct RestoreContext {
     pub state_dir: PathBuf,
 }
 
+/// When a registered lifecycle extension participates in a sandbox's
+/// lifecycle.
+///
+/// This gates *every* hook (configure/launch/cleanup/restore) for the
+/// extension, so an inactive extension is invisible to the sandbox: it
+/// contributes no descriptor requirements, runs no host-side side effects,
+/// and — crucially — its cleanup hooks are not invoked either (there is
+/// nothing to clean up because nothing ran).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtensionActivation {
+    /// The extension participates in every sandbox on this driver. This is
+    /// the default and matches the historical behavior where all registered
+    /// extensions ran unconditionally.
+    Global,
+    /// The extension participates only for sandboxes that explicitly
+    /// requested it via a `{SANDBOX_EXTENSION_LABEL_PREFIX}{key}` template
+    /// label set to an enabled value. The label is policy-controlled
+    /// (stamped by the gateway), so guests cannot self-activate an
+    /// extension. `key` must be a valid extension identifier (validated by
+    /// [`LifecycleExtensionRegistry::validate`]).
+    OnRequest { key: &'static str },
+}
+
 /// Lifecycle hooks an extension can implement to participate in VM sandbox
 /// provisioning, launch failure, deletion, and post-restart reconciliation.
 ///
@@ -264,6 +310,16 @@ pub struct RestoreContext {
 #[tonic::async_trait]
 pub trait LifecycleExtension: std::fmt::Debug + Send + Sync {
     fn name(&self) -> &str;
+
+    /// Declare when this extension participates in a sandbox's lifecycle.
+    ///
+    /// Defaults to [`ExtensionActivation::Global`] (runs for every sandbox).
+    /// Override and return [`ExtensionActivation::OnRequest`] for an opt-in
+    /// extension that should only run when the sandbox carries the matching
+    /// request label.
+    fn activation(&self) -> ExtensionActivation {
+        ExtensionActivation::Global
+    }
 
     fn descriptor(&self) -> ExtensionDescriptor {
         ExtensionDescriptor::new(self.name())
@@ -324,15 +380,25 @@ pub trait LifecycleExtension: std::fmt::Debug + Send + Sync {
 
     /// Release anything this extension allocated during
     /// [`configure_launch`](Self::configure_launch) or
-    /// [`before_launch`](Self::before_launch) when the launcher
-    /// could not be started or aborted before it became healthy.
+    /// [`before_launch`](Self::before_launch).
     ///
-    /// Invoked in reverse registration order. Errors are logged but do not
-    /// propagate; do best-effort cleanup and return [`Ok`] when possible.
-    /// This hook is invoked on every launcher failure, including failures
-    /// that happen during a persisted-sandbox restore (in that case
-    /// [`after_restore`](Self::after_restore) is *not*
-    /// invoked).
+    /// Invoked in reverse registration order with the reason in
+    /// [`LaunchAbortReason`]. This fires both when the launcher could not be
+    /// started / was aborted before it became healthy *and* when a
+    /// previously-running VM helper process exits on its own
+    /// ([`LaunchAbortReason::ProcessExited`]); in the latter case the driver
+    /// simultaneously releases its own per-launch allocations.
+    ///
+    /// Because [`LaunchAbortReason::ProcessExited`] cleanup runs while the
+    /// sandbox record still exists, this hook may later be followed by
+    /// [`after_delete`](Self::after_delete) for the same sandbox.
+    /// Implementations MUST therefore be idempotent: do best-effort cleanup,
+    /// treat already-released resources as success, and return [`Ok`] when
+    /// possible. Errors are logged but do not propagate.
+    ///
+    /// Invoked on every launcher failure, including failures that happen
+    /// during a persisted-sandbox restore (in that case
+    /// [`after_restore`](Self::after_restore) is *not* invoked).
     async fn after_launch_failed(
         &self,
         _sandbox: &Sandbox,
@@ -439,12 +505,31 @@ impl LifecycleExtensionRegistry {
         self.extensions.iter().map(|ext| ext.descriptor()).collect()
     }
 
+    /// Names of the extensions that are active for `sandbox`, in
+    /// registration order.
+    #[must_use]
+    pub fn active_names(&self, sandbox: &Sandbox) -> Vec<String> {
+        self.active_for(sandbox)
+            .into_iter()
+            .map(|ext| ext.name().to_string())
+            .collect()
+    }
+
     pub fn validate(&self) -> LifecycleResult<()> {
         let mut names = HashSet::new();
         for ext in &self.extensions {
             let descriptor = ext.descriptor();
             validate_extension_name(ext.name())?;
             validate_extension_name(&descriptor.name)?;
+            if let ExtensionActivation::OnRequest { key } = ext.activation() {
+                validate_extension_identifier(key).map_err(|err| {
+                    LifecycleError::new(format!(
+                        "lifecycle extension '{}' has invalid activation key '{}': {err}",
+                        ext.name(),
+                        key
+                    ))
+                })?;
+            }
             if descriptor.name != ext.name() {
                 return Err(LifecycleError::new(format!(
                     "lifecycle extension '{}' descriptor name does not match '{}'",
@@ -463,13 +548,30 @@ impl LifecycleExtensionRegistry {
         Ok(())
     }
 
+    /// Extensions active for `sandbox`, preserving registration order.
+    ///
+    /// [`ExtensionActivation::Global`] extensions are always included;
+    /// [`ExtensionActivation::OnRequest`] extensions are included only when
+    /// the sandbox carries the matching request label.
+    fn active_for<'a>(&'a self, sandbox: &Sandbox) -> Vec<&'a Arc<dyn LifecycleExtension>> {
+        self.extensions
+            .iter()
+            .filter(|ext| match ext.activation() {
+                ExtensionActivation::Global => true,
+                ExtensionActivation::OnRequest { key } => {
+                    sandbox_requested_extension(sandbox, key)
+                }
+            })
+            .collect()
+    }
+
     pub async fn configure_launch(
         &self,
         sandbox: &Sandbox,
         state_dir: &Path,
         plan: &mut LaunchPlan,
     ) -> LifecycleResult<()> {
-        for ext in &self.extensions {
+        for ext in self.active_for(sandbox) {
             let descriptor = ext.descriptor();
             for backend in descriptor.required_backends {
                 plan.require_backend(backend);
@@ -507,7 +609,7 @@ impl LifecycleExtensionRegistry {
         state_dir: &Path,
         plan: &mut LaunchPlan,
     ) -> LifecycleResult<()> {
-        for ext in &self.extensions {
+        for ext in self.active_for(sandbox) {
             ext.before_launch(sandbox, state_dir, plan).await?;
         }
         Ok(())
@@ -519,7 +621,7 @@ impl LifecycleExtensionRegistry {
         state_dir: &Path,
         reason: LaunchAbortReason,
     ) {
-        for ext in self.extensions.iter().rev() {
+        for ext in self.active_for(sandbox).into_iter().rev() {
             if let Err(err) = ext
                 .after_launch_failed(sandbox, state_dir, reason.clone())
                 .await
@@ -535,7 +637,7 @@ impl LifecycleExtensionRegistry {
     }
 
     pub async fn after_delete(&self, sandbox: &Sandbox, state_dir: &Path) {
-        for ext in self.extensions.iter().rev() {
+        for ext in self.active_for(sandbox).into_iter().rev() {
             if let Err(err) = ext.after_delete(sandbox, state_dir).await {
                 tracing::warn!(
                     extension = ext.name(),
@@ -551,14 +653,14 @@ impl LifecycleExtensionRegistry {
         &self,
         sandbox: &RestoreContext,
     ) -> LifecycleResult<()> {
-        for ext in &self.extensions {
+        for ext in self.active_for(&sandbox.sandbox) {
             ext.before_restore(sandbox).await?;
         }
         Ok(())
     }
 
     pub async fn after_restore(&self, sandbox: &RestoreContext) {
-        for ext in &self.extensions {
+        for ext in self.active_for(&sandbox.sandbox) {
             if let Err(err) = ext.after_restore(sandbox).await {
                 tracing::warn!(
                     extension = ext.name(),
@@ -569,6 +671,37 @@ impl LifecycleExtensionRegistry {
             }
         }
     }
+}
+
+/// Returns true when `sandbox` opted into the extension identified by
+/// `key` via a policy-stamped `{SANDBOX_EXTENSION_LABEL_PREFIX}{key}`
+/// template label set to an enabled value.
+fn sandbox_requested_extension(sandbox: &Sandbox, key: &str) -> bool {
+    let label_key = format!("{SANDBOX_EXTENSION_LABEL_PREFIX}{key}");
+    sandbox
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.template.as_ref())
+        .and_then(|template| template.labels.get(&label_key))
+        .is_some_and(|value| extension_label_enabled(value))
+}
+
+/// Interpret an extension request-label value. Accepts the explicit
+/// `enabled`/`requested` spellings as well as the common bool-like values
+/// understood by [`parse_bool_like`]; anything unrecognized is treated as
+/// "not requested" so a malformed label fails closed.
+fn extension_label_enabled(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    if matches!(
+        normalized.as_str(),
+        "enabled" | "enable" | "requested" | "request"
+    ) {
+        return true;
+    }
+    if matches!(normalized.as_str(), "disabled" | "disable") {
+        return false;
+    }
+    parse_bool_like(&normalized).unwrap_or(false)
 }
 
 fn warn_on_singleton_overwrite<T>(
@@ -655,8 +788,11 @@ fn validate_extension_identifier(value: &str) -> Result<(), &'static str> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::path::PathBuf;
     use std::sync::Mutex;
+
+    use openshell_core::proto::compute::v1::{DriverSandboxSpec, DriverSandboxTemplate};
 
     use super::*;
 
@@ -665,6 +801,7 @@ mod tests {
         name: String,
         configure_should_fail: bool,
         before_should_fail: bool,
+        activation: ExtensionActivation,
         calls: Mutex<Vec<String>>,
     }
 
@@ -674,6 +811,17 @@ mod tests {
                 name: name.to_string(),
                 configure_should_fail: false,
                 before_should_fail: false,
+                activation: ExtensionActivation::Global,
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn on_request(name: &str, key: &'static str) -> Arc<Self> {
+            Arc::new(Self {
+                name: name.to_string(),
+                configure_should_fail: false,
+                before_should_fail: false,
+                activation: ExtensionActivation::OnRequest { key },
                 calls: Mutex::new(Vec::new()),
             })
         }
@@ -683,6 +831,7 @@ mod tests {
                 name: name.to_string(),
                 configure_should_fail: false,
                 before_should_fail: true,
+                activation: ExtensionActivation::Global,
                 calls: Mutex::new(Vec::new()),
             })
         }
@@ -692,6 +841,7 @@ mod tests {
                 name: name.to_string(),
                 configure_should_fail: true,
                 before_should_fail: false,
+                activation: ExtensionActivation::Global,
                 calls: Mutex::new(Vec::new()),
             })
         }
@@ -705,6 +855,10 @@ mod tests {
     impl LifecycleExtension for RecordingExtension {
         fn name(&self) -> &str {
             &self.name
+        }
+
+        fn activation(&self) -> ExtensionActivation {
+            self.activation
         }
 
         fn descriptor(&self) -> ExtensionDescriptor {
@@ -820,6 +974,22 @@ mod tests {
         }
     }
 
+    fn sample_sandbox_with_extension(key: &str) -> Sandbox {
+        let label_key = format!("{SANDBOX_EXTENSION_LABEL_PREFIX}{key}");
+        Sandbox {
+            id: "sandbox-123".to_string(),
+            name: "sandbox-123".to_string(),
+            spec: Some(DriverSandboxSpec {
+                template: Some(DriverSandboxTemplate {
+                    labels: HashMap::from([(label_key, "enabled".to_string())]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
     fn as_extension<T>(extension: &Arc<T>) -> Arc<dyn LifecycleExtension>
     where
         T: LifecycleExtension + 'static,
@@ -881,6 +1051,70 @@ mod tests {
             ext_c.calls().is_empty(),
             "extensions after the failure must not be invoked"
         );
+    }
+
+    #[tokio::test]
+    async fn on_request_extension_only_runs_when_label_is_enabled() {
+        let ext_global = RecordingExtension::new("global");
+        let ext_requested = RecordingExtension::on_request("requested", "nemo-relay");
+        let registry = LifecycleExtensionRegistry::with(vec![
+            as_extension(&ext_global),
+            as_extension(&ext_requested),
+        ]);
+        let mut plan = sample_plan(VmBackend::Libkrun);
+
+        registry
+            .configure_launch(&sample_sandbox(), &PathBuf::from("/tmp/state"), &mut plan)
+            .await
+            .expect("configure_launch succeeds");
+
+        assert_eq!(ext_global.calls(), vec!["global:configure_launch"]);
+        assert!(
+            ext_requested.calls().is_empty(),
+            "on-request extension must stay inactive without the request label"
+        );
+
+        let mut requested_plan = sample_plan(VmBackend::Libkrun);
+        registry
+            .configure_launch(
+                &sample_sandbox_with_extension("nemo-relay"),
+                &PathBuf::from("/tmp/state"),
+                &mut requested_plan,
+            )
+            .await
+            .expect("configure_launch succeeds");
+
+        assert_eq!(
+            ext_requested.calls(),
+            vec!["requested:configure_launch"],
+            "on-request extension should run when the label is enabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn active_names_reflects_request_label() {
+        let registry = LifecycleExtensionRegistry::with(vec![
+            RecordingExtension::new("global"),
+            RecordingExtension::on_request("requested", "nemo-relay"),
+        ]);
+
+        assert_eq!(registry.active_names(&sample_sandbox()), vec!["global"]);
+        assert_eq!(
+            registry.active_names(&sample_sandbox_with_extension("nemo-relay")),
+            vec!["global", "requested"]
+        );
+    }
+
+    #[test]
+    fn validate_rejects_invalid_on_request_key() {
+        let registry = LifecycleExtensionRegistry::with(vec![RecordingExtension::on_request(
+            "bad-key",
+            "../escape",
+        )]);
+        let err = registry
+            .validate()
+            .expect_err("invalid activation key should fail validation");
+        assert!(err.message().contains("invalid activation key"));
     }
 
     #[tokio::test]

--- a/crates/openshell-driver-vm/src/main.rs
+++ b/crates/openshell-driver-vm/src/main.rs
@@ -36,6 +36,9 @@ struct Args {
     #[arg(long = "vm-image-disk", hide = true)]
     vm_image_disk: Option<PathBuf>,
 
+    #[arg(long = "vm-kernel-image", hide = true)]
+    vm_kernel_image: Option<PathBuf>,
+
     #[arg(long, hide = true)]
     vm_exec: Option<String>,
 
@@ -482,6 +485,7 @@ fn build_vm_launch_config(args: &Args) -> std::result::Result<VmLaunchConfig, St
         root_disk,
         overlay_disk,
         image_disk,
+        kernel_image: args.vm_kernel_image.clone(),
         vcpus: args.vm_vcpus,
         mem_mib: args.vm_mem_mib,
         exec_path,

--- a/crates/openshell-driver-vm/src/runtime.rs
+++ b/crates/openshell-driver-vm/src/runtime.rs
@@ -48,6 +48,7 @@ pub struct VmLaunchConfig {
     pub root_disk: PathBuf,
     pub overlay_disk: PathBuf,
     pub image_disk: Option<PathBuf>,
+    pub kernel_image: Option<PathBuf>,
     pub vcpus: u8,
     pub mem_mib: u32,
     pub exec_path: String,
@@ -126,12 +127,15 @@ fn run_qemu_vm(config: &VmLaunchConfig) -> Result<(), String> {
     let guest_env = qemu_guest_env_vars(config, host_dns_server());
     write_guest_env_file(&config.overlay_disk, &guest_env)?;
 
-    let runtime_dir = qemu_runtime_dir()?;
     let gw_port = config.gateway_port.unwrap_or(0);
     setup_tap_networking(tap_device, host_ip, gw_port)?;
     let mut tap_guard = TapGuard::new(tap_device.to_string(), host_ip.to_string(), gw_port);
 
-    let vmlinux = runtime_dir.join("vmlinux");
+    let vmlinux = if let Some(kernel_image) = &config.kernel_image {
+        kernel_image.clone()
+    } else {
+        qemu_runtime_dir()?.join("vmlinux")
+    };
     if !vmlinux.is_file() {
         return Err(format!("VM kernel not found: {}", vmlinux.display()));
     }
@@ -648,6 +652,12 @@ fn procguard_kill_children() {
 }
 
 fn run_libkrun_vm(config: &VmLaunchConfig) -> Result<(), String> {
+    if let Some(kernel_image) = &config.kernel_image {
+        return Err(format!(
+            "selected kernel image is not supported by this VM backend: {}",
+            kernel_image.display()
+        ));
+    }
     if !config.root_disk.is_file() {
         return Err(format!(
             "root disk image not found: {}",
@@ -1397,6 +1407,7 @@ mod tests {
             root_disk: PathBuf::from("/rootfs.ext4"),
             overlay_disk: PathBuf::from("/overlay.ext4"),
             image_disk: None,
+            kernel_image: None,
             vcpus: 2,
             mem_mib: 2048,
             exec_path: "/srv/openshell-vm-sandbox-init.sh".to_string(),


### PR DESCRIPTION
## Summary

Adds lifecycle extension points to the VM driver so future integrations can inspect and adjust VM launch plans around sandbox startup and cleanup. The default registry is empty, so existing VM sandbox behavior remains unchanged.

## Related Issue

Not linked

## Changes

- Added a VM lifecycle extension trait, registry, launch plan, and lifecycle error type.
- Wired VM provisioning to run lifecycle hooks before launcher spawn, on launch failure, and after sandbox deletion.
- Kept backend selection stable by rejecting non-GPU QEMU extension requirements until concrete PCI transport exists.
- Tracked QEMU network allocation separately from GPU assignment so cleanup does not depend on GPU state.
- Added unit coverage for lifecycle hook ordering, cleanup hooks, backend validation, and resource exhaustion handling.

## Testing

- [ ] `mise run pre-commit` passes (not run; `mise` is not available in this shell)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (not applicable)

Additional validation run:

- [x] `cargo fmt -p openshell-driver-vm`
- [x] `cargo test -p openshell-driver-vm lifecycle -- --nocapture`
- [x] `cargo test -p openshell-driver-vm qemu -- --nocapture`
- [x] `cargo clippy -p openshell-driver-vm --all-targets -- -D warnings`
- [x] `cargo test -p openshell-driver-vm`
- [x] `git diff --check`

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable)
