### PR TITLE
fix(sandbox): probe Landlock before build, skip on unsupported kernels

### DIFF
--- a/crates/openshell-sandbox/src/sandbox/linux/landlock.rs
+++ b/crates/openshell-sandbox/src/sandbox/linux/landlock.rs
@@ -119,6 +119,45 @@ pub fn prepare(policy: &SandboxPolicy, workdir: Option<&str>) -> Result<Option<P
         return Ok(None);
     }
 
+    let compatibility = &policy.landlock.compatibility;
+
+    // Probe first: kernels without Landlock (e.g. gVisor's sentry returns
+    // ENOSYS) would otherwise log misleading "Applying"+"Built" events.
+    let availability = probe_availability();
+    if !matches!(availability, LandlockAvailability::Available { .. }) {
+        match compatibility {
+            LandlockCompatibility::BestEffort => {
+                openshell_ocsf::ocsf_emit!(
+                    openshell_ocsf::DetectionFindingBuilder::new(crate::ocsf_ctx())
+                        .activity(openshell_ocsf::ActivityId::Open)
+                        .severity(openshell_ocsf::SeverityId::High)
+                        .confidence(openshell_ocsf::ConfidenceId::High)
+                        .is_alert(true)
+                        .finding_info(
+                            openshell_ocsf::FindingInfo::new(
+                                "landlock-unavailable",
+                                "Landlock Filesystem Sandbox Unavailable",
+                            )
+                            .with_desc(&format!(
+                                "Running WITHOUT filesystem restrictions: Landlock is {availability}. \
+                                 Set landlock.compatibility to 'hard_requirement' to make this fatal."
+                            )),
+                        )
+                        .message(format!(
+                            "Landlock filesystem sandbox unavailable: {availability}"
+                        ))
+                        .build()
+                );
+                return Ok(None);
+            }
+            LandlockCompatibility::HardRequirement => {
+                return Err(miette::miette!(
+                    "Landlock unavailable in hard_requirement mode: {availability}"
+                ));
+            }
+        }
+    }
+
     let total_paths = read_only.len() + read_write.len();
     let abi = ABI::V2;
     openshell_ocsf::ocsf_emit!(
@@ -134,8 +173,6 @@ pub fn prepare(policy: &SandboxPolicy, workdir: Option<&str>) -> Result<Option<P
             ))
             .build()
     );
-
-    let compatibility = &policy.landlock.compatibility;
 
     let result: Result<PreparedRuleset> = (|| {
         let access_all = AccessFs::from_all(abi);


### PR DESCRIPTION
## Summary

On kernels without Landlock (e.g. gVisor's sentry returns `ENOSYS` for syscall 444), the previous `best_effort` path in `landlock::prepare` still logged "Applying Landlock" + "Landlock ruleset built" OCSF events even though no enforcement was happening. This PR probes the kernel up-front and short-circuits with a single High-severity "Sandbox Unavailable" finding when Landlock isn't available, so the log stream no longer implies enforcement where there is none.

## Related Issue

No upstream-tracked issue. Surfaced while running OpenShell's supervisor under [Agent Substrate](https://github.com/agent-substrate/substrate)'s gVisor-backed actors — the sentry refuses Landlock syscalls and the existing best-effort path was producing self-contradictory log output (HIGH-severity "Sandbox Unavailable" finding alongside two INFO events implying the ruleset was applied).

## Changes

- `crates/openshell-sandbox/src/sandbox/linux/landlock.rs`: in `prepare()`, call `probe_availability()` at the top of the path-validation block (after the no-paths early return, before the "Applying Landlock" event). If the probe returns anything other than `Available { .. }`:
  - `BestEffort` → emit one High-severity `DetectionFinding` ("Landlock Filesystem Sandbox Unavailable") and return `Ok(None)`. No more "Applying" / "Built" events when there's nothing to apply.
  - `HardRequirement` → return `Err(...)` so the supervisor aborts.
- The existing `try_open_path` / `enforce` failure paths are untouched — those continue to handle per-path failures and `restrict_self()` failures respectively.

## Testing

Local Rust-side checks against the touched crate (`openshell-sandbox`):

- `cargo fmt --all -- --check` — clean
- `cargo check -p openshell-sandbox` — clean
- `cargo clippy -p openshell-sandbox --all-targets -- -D warnings` — clean
- `cargo test -p openshell-sandbox` — **786 passed, 0 failed, 1 ignored** (covers `landlock::tests` including `probe_availability_returns_a_result`, `try_open_path_*`, `classify_*`)

`mise run ci` was attempted but failed in my local environment on the `python:proto` task with `ModuleNotFoundError: No module named 'grpc_tools'` — Python dep not installed on my Mac, unrelated to this change. The Rust subtasks (`rust:check`, `rust:lint`, `test:rust`) were SIGTERM'd by mise when the parallel `python:proto` task failed; I ran them directly instead with the results above.

- [x] `mise run pre-commit` checks I could run pass (Rust fmt/check/clippy/test, helm:lint, markdown:lint)
- [ ] Unit tests added/updated — none new. The new branch is exercised by `probe_availability_returns_a_result` (covers the probe call site) plus the existing `BestEffort`/`HardRequirement` matchers; a deeper test would require refactoring `prepare()` to accept an injectable probe function, which felt out of scope for a 39-line log-shape fix.
- [ ] E2E tests added/updated — n/a, log-quality change with no enforcement semantics shift.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) — `fix(sandbox): probe Landlock before build, skip on unsupported kernels`
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — not applicable; no user-facing behavior change in enforcement semantics, only the log stream.
