### PR TITLE
fix(vm): scope rootfs cache by openshell version

### DIFF
--- a/crates/openshell-driver-vm/README.md
+++ b/crates/openshell-driver-vm/README.md
@@ -180,6 +180,9 @@ Linux-owned ext4 storage. The resulting disk is cached under
 sandboxes. Local Docker images are still exported as rootfs tar archives and
 prepared inside the bootstrap VM. Set `OPENSHELL_VM_IMAGE_PULL_CONCURRENCY` to
 tune registry layer download parallelism (default `4`, maximum `16`).
+Both caches are scoped by source image identity and OpenShell version, so an
+OpenShell upgrade builds a fresh guest rootfs instead of reusing one with an old
+embedded supervisor.
 
 Each sandbox gets its own sparse writable
 `<state-dir>/sandboxes/<id>/overlay.ext4`. Guest init mounts overlayfs as `/`

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -111,8 +111,8 @@ const GUEST_IMAGE_CONFIG_DIR: &str = "openshell-image";
 const GUEST_IMAGE_OCI_LAYOUT_DIR: &str = "oci";
 const GUEST_IMAGE_OCI_REF: &str = "openshell";
 const IMAGE_EXPORT_ROOTFS_ARCHIVE: &str = "source-rootfs.tar";
-const BOOTSTRAP_IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-bootstrap-rootfs-ext4-v2";
-const PREPARED_IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-prepared-rootfs-ext4-umoci-v2";
+const BOOTSTRAP_IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-bootstrap-rootfs-ext4-v3";
+const PREPARED_IMAGE_CACHE_LAYOUT_VERSION: &str = "sandbox-prepared-rootfs-ext4-umoci-v3";
 const IMAGE_IDENTITY_FILE: &str = "image-identity";
 const IMAGE_REFERENCE_FILE: &str = "image-reference";
 const IMAGE_PREP_INIT_MODE: &str = "image-prep";
@@ -3725,11 +3725,17 @@ fn write_oci_layout_for_manifest(
 }
 
 fn bootstrap_image_cache_identity(image_identity: &str) -> String {
-    format!("{BOOTSTRAP_IMAGE_CACHE_LAYOUT_VERSION}:{image_identity}")
+    format!(
+        "{BOOTSTRAP_IMAGE_CACHE_LAYOUT_VERSION}:openshell-{}:{image_identity}",
+        openshell_core::VERSION
+    )
 }
 
 fn prepared_image_cache_identity(image_identity: &str) -> String {
-    format!("{PREPARED_IMAGE_CACHE_LAYOUT_VERSION}:{image_identity}")
+    format!(
+        "{PREPARED_IMAGE_CACHE_LAYOUT_VERSION}:openshell-{}:{image_identity}",
+        openshell_core::VERSION
+    )
 }
 
 fn registry_layer_download_concurrency() -> usize {
@@ -5517,18 +5523,24 @@ mod tests {
     }
 
     #[test]
-    fn prepared_image_cache_identity_includes_rootfs_layout_version() {
+    fn prepared_image_cache_identity_includes_rootfs_layout_and_openshell_version() {
         assert_eq!(
             prepared_image_cache_identity("sha256:local-image"),
-            "sandbox-prepared-rootfs-ext4-umoci-v2:sha256:local-image"
+            format!(
+                "sandbox-prepared-rootfs-ext4-umoci-v3:openshell-{}:sha256:local-image",
+                openshell_core::VERSION
+            )
         );
     }
 
     #[test]
-    fn bootstrap_image_cache_identity_includes_rootfs_layout_version() {
+    fn bootstrap_image_cache_identity_includes_rootfs_layout_and_openshell_version() {
         assert_eq!(
             bootstrap_image_cache_identity("sha256:bootstrap-image"),
-            "sandbox-bootstrap-rootfs-ext4-v2:sha256:bootstrap-image"
+            format!(
+                "sandbox-bootstrap-rootfs-ext4-v3:openshell-{}:sha256:bootstrap-image",
+                openshell_core::VERSION
+            )
         );
     }
 


### PR DESCRIPTION
## Summary

Scope VM bootstrap and prepared rootfs cache identities by OpenShell version so upgraded gateways build fresh guest rootfs disks instead of reusing cached disks with older embedded supervisors.

## Related Issue

None.

## Changes

- Bump the VM bootstrap and prepared rootfs cache layout namespaces to v3.
- Include openshell_core::VERSION in both VM rootfs cache identities.
- Update cache identity unit tests and document the version-scoped cache invariant in the VM driver README.

## Testing

- [x] mise run pre-commit passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (not applicable)

Additional validation: mise run e2e:vm was attempted. It built a fresh v3 version-scoped rootfs cache, then failed at sandbox readiness with the existing VM supervisor callback reachability timeout: Waiting for VM supervisor with repeated NET:FAIL host.openshell.internal:<port>.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
