### PR TITLE
feat(openshell-driver-vm): build sandbox supervisor through Cargo bindeps

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,3 +6,6 @@
 # the header lives in /usr/include/z3/ rather than /usr/include/. The extra -I
 # is harmless on systems where the path doesn't exist.
 BINDGEN_EXTRA_CLANG_ARGS = "-I/usr/include/z3"
+
+[unstable]
+bindeps = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,6 +3550,7 @@ dependencies = [
  "nix",
  "oci-client",
  "openshell-core",
+ "openshell-sandbox",
  "openshell-vfio",
  "polling",
  "prost",

--- a/crates/openshell-driver-vm/Cargo.toml
+++ b/crates/openshell-driver-vm/Cargo.toml
@@ -54,17 +54,20 @@ zstd = "0.13"
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly"))'.dependencies]
 polling = "3.11"
 
+[features]
+sandbox-bindeps = ["dep:openshell-sandbox"]
+
 [build-dependencies]
 zstd = "0.13"
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.build-dependencies]
-openshell-sandbox = { path = "../openshell-sandbox", artifact = "bin:openshell-sandbox", target = "x86_64-unknown-linux-gnu" }
+openshell-sandbox = { path = "../openshell-sandbox", artifact = "bin:openshell-sandbox", target = "x86_64-unknown-linux-gnu", optional = true }
 
 [target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.build-dependencies]
-openshell-sandbox = { path = "../openshell-sandbox", artifact = "bin:openshell-sandbox", target = "aarch64-unknown-linux-gnu" }
+openshell-sandbox = { path = "../openshell-sandbox", artifact = "bin:openshell-sandbox", target = "aarch64-unknown-linux-gnu", optional = true }
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
-openshell-sandbox = { path = "../openshell-sandbox", artifact = "bin:openshell-sandbox", target = "aarch64-unknown-linux-gnu" }
+openshell-sandbox = { path = "../openshell-sandbox", artifact = "bin:openshell-sandbox", target = "aarch64-unknown-linux-gnu", optional = true }
 
 
 [lints]

--- a/crates/openshell-driver-vm/Cargo.toml
+++ b/crates/openshell-driver-vm/Cargo.toml
@@ -54,5 +54,15 @@ zstd = "0.13"
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly"))'.dependencies]
 polling = "3.11"
 
+[target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.build-dependencies]
+openshell-sandbox = { path = "../openshell-sandbox", artifact = "bin:openshell-sandbox", target = "x86_64-unknown-linux-gnu" }
+
+[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.build-dependencies]
+openshell-sandbox = { path = "../openshell-sandbox", artifact = "bin:openshell-sandbox", target = "aarch64-unknown-linux-gnu" }
+
+[target.'cfg(target_os = "macos")'.build-dependencies]
+openshell-sandbox = { path = "../openshell-sandbox", artifact = "bin:openshell-sandbox", target = "aarch64-unknown-linux-gnu" }
+
+
 [lints]
 workspace = true

--- a/crates/openshell-driver-vm/Cargo.toml
+++ b/crates/openshell-driver-vm/Cargo.toml
@@ -54,6 +54,9 @@ zstd = "0.13"
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly"))'.dependencies]
 polling = "3.11"
 
+[build-dependencies]
+zstd = "0.13"
+
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.build-dependencies]
 openshell-sandbox = { path = "../openshell-sandbox", artifact = "bin:openshell-sandbox", target = "x86_64-unknown-linux-gnu" }
 

--- a/crates/openshell-driver-vm/build.rs
+++ b/crates/openshell-driver-vm/build.rs
@@ -45,32 +45,39 @@ fn main() {
         }
     };
 
-    let supervisor_path = env::var_os("CARGO_BIN_FILE_OPENSHELL_SANDBOX")
-        .or_else(|| env::var_os("CARGO_BIN_FILE_OPENSHELL_SANDBOX_openshell-sandbox"))
-        .expect("CARGO_BIN_FILE_OPENSHELL_SANDBOX not set");
-    let supervisor_path = PathBuf::from(supervisor_path);
-    println!("cargo:rerun-if-changed={}", supervisor_path.display());
+    let supervisor_artifact = env::var_os("CARGO_BIN_FILE_OPENSHELL_SANDBOX")
+        .or_else(|| env::var_os("CARGO_BIN_FILE_OPENSHELL_SANDBOX_openshell-sandbox"));
+    let supervisor_embedded = supervisor_artifact.is_some();
+    if let Some(supervisor_path) = supervisor_artifact {
+        let supervisor_path = PathBuf::from(supervisor_path);
+        println!("cargo:rerun-if-changed={}", supervisor_path.display());
 
-    let mut supervisor = File::open(&supervisor_path)
-        .unwrap_or_else(|e| panic!("Failed to open {}: {e}", supervisor_path.display()));
-    let dst_path = out_dir.join("openshell-sandbox.zst");
-    let mut dst = File::create(&dst_path)
-        .unwrap_or_else(|e| panic!("Failed to create {}: {e}", dst_path.display()));
-    zstd::stream::copy_encode(&mut supervisor, &mut dst, 1).unwrap_or_else(|e| {
-        panic!(
-            "Failed to compress {} to {}: {e}",
-            supervisor_path.display(),
-            dst_path.display()
-        )
-    });
-    let size = fs::metadata(&dst_path).map_or(0, |m| m.len());
-    println!("cargo:warning=Embedded openshell-sandbox.zst: {size} bytes");
+        let mut supervisor = File::open(&supervisor_path)
+            .unwrap_or_else(|e| panic!("Failed to open {}: {e}", supervisor_path.display()));
+        let dst_path = out_dir.join("openshell-sandbox.zst");
+        let mut dst = File::create(&dst_path)
+            .unwrap_or_else(|e| panic!("Failed to create {}: {e}", dst_path.display()));
+        zstd::stream::copy_encode(&mut supervisor, &mut dst, 1).unwrap_or_else(|e| {
+            panic!(
+                "Failed to compress {} to {}: {e}",
+                supervisor_path.display(),
+                dst_path.display()
+            )
+        });
+        let size = fs::metadata(&dst_path).map_or(0, |m| m.len());
+        println!("cargo:warning=Embedded openshell-sandbox.zst: {size} bytes");
+    }
+    let setup_hint = if supervisor_embedded {
+        "Run: mise run vm:setup"
+    } else {
+        "Run: mise run vm:setup && mise run vm:supervisor"
+    };
 
     let compressed_dir = if let Ok(dir) = env::var("OPENSHELL_VM_RUNTIME_COMPRESSED_DIR") {
         PathBuf::from(dir)
     } else {
         println!("cargo:warning=OPENSHELL_VM_RUNTIME_COMPRESSED_DIR not set");
-        println!("cargo:warning=Run: mise run vm:setup && mise run vm:supervisor");
+        println!("cargo:warning={setup_hint}");
         generate_stub_resources(
             &out_dir,
             &[
@@ -89,7 +96,7 @@ fn main() {
             "cargo:warning=Compressed runtime dir not found: {}",
             compressed_dir.display()
         );
-        println!("cargo:warning=Run: mise run vm:setup && mise run vm:supervisor");
+        println!("cargo:warning={setup_hint}");
         generate_stub_resources(
             &out_dir,
             &[
@@ -110,11 +117,19 @@ fn main() {
             format!("{libkrunfw_name}.zst"),
         ),
         ("gvproxy.zst".to_string(), "gvproxy.zst".to_string()),
+        (
+            "openshell-sandbox.zst".to_string(),
+            "openshell-sandbox.zst".to_string(),
+        ),
         ("umoci.zst".to_string(), "umoci.zst".to_string()),
     ];
 
     let mut all_found = true;
     for (src_name, dst_name) in &files {
+        if supervisor_embedded && src_name == "openshell-sandbox.zst" {
+            continue;
+        }
+
         let src_path = compressed_dir.join(src_name);
         let dst_path = out_dir.join(dst_name);
 
@@ -143,9 +158,7 @@ fn main() {
     }
 
     if !all_found {
-        println!(
-            "cargo:warning=Some artifacts missing. Run: mise run vm:setup && mise run vm:supervisor"
-        );
+        println!("cargo:warning=Some artifacts missing. {setup_hint}");
         generate_stub_resources(
             &out_dir,
             &[

--- a/crates/openshell-driver-vm/build.rs
+++ b/crates/openshell-driver-vm/build.rs
@@ -6,6 +6,7 @@
 //! This crate embeds the sandbox supervisor plus the minimal libkrun runtime
 //! artifacts it needs to boot VMs without a separate VM runtime binary.
 
+use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
@@ -43,6 +44,27 @@ fn main() {
             return;
         }
     };
+
+    let supervisor_path = env::var_os("CARGO_BIN_FILE_OPENSHELL_SANDBOX")
+        .or_else(|| env::var_os("CARGO_BIN_FILE_OPENSHELL_SANDBOX_openshell-sandbox"))
+        .expect("CARGO_BIN_FILE_OPENSHELL_SANDBOX not set");
+    let supervisor_path = PathBuf::from(supervisor_path);
+    println!("cargo:rerun-if-changed={}", supervisor_path.display());
+
+    let mut supervisor = File::open(&supervisor_path)
+        .unwrap_or_else(|e| panic!("Failed to open {}: {e}", supervisor_path.display()));
+    let dst_path = out_dir.join("openshell-sandbox.zst");
+    let mut dst = File::create(&dst_path)
+        .unwrap_or_else(|e| panic!("Failed to create {}: {e}", dst_path.display()));
+    zstd::stream::copy_encode(&mut supervisor, &mut dst, 1).unwrap_or_else(|e| {
+        panic!(
+            "Failed to compress {} to {}: {e}",
+            supervisor_path.display(),
+            dst_path.display()
+        )
+    });
+    let size = fs::metadata(&dst_path).map_or(0, |m| m.len());
+    println!("cargo:warning=Embedded openshell-sandbox.zst: {size} bytes");
 
     let compressed_dir = if let Ok(dir) = env::var("OPENSHELL_VM_RUNTIME_COMPRESSED_DIR") {
         PathBuf::from(dir)
@@ -88,10 +110,6 @@ fn main() {
             format!("{libkrunfw_name}.zst"),
         ),
         ("gvproxy.zst".to_string(), "gvproxy.zst".to_string()),
-        (
-            "openshell-sandbox.zst".to_string(),
-            "openshell-sandbox.zst".to_string(),
-        ),
         ("umoci.zst".to_string(), "umoci.zst".to_string()),
     ];
 

--- a/mise.lock
+++ b/mise.lock
@@ -202,7 +202,7 @@ url = "https://github.com/astral-sh/python-build-standalone/releases/download/20
 provenance = "github-attestations"
 
 [[tools.rust]]
-version = "1.95.0"
+version = "nightly-2026-05-27"
 backend = "core:rust"
 
 [[tools.skaffold]]

--- a/mise.toml
+++ b/mise.toml
@@ -20,7 +20,7 @@ lockfile_platforms = ["linux-x64", "linux-arm64", "macos-arm64"]
 
 [tools]
 python = "3.14.5"
-rust = "1.95.0"
+rust = "nightly-2026-05-27"
 node = "24.15.0"
 kubectl = "1.36.1"
 uv = "0.10.12"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [toolchain]
-channel = "1.95.0"
+channel = "nightly-2026-05-27"


### PR DESCRIPTION
## Summary

Moves the VM driver’s openshell-sandbox supervisor bundle into Cargo’s build graph by using a bindeps artifact dependency. This makes openshell-driver-vm directly aware of changes to openshell-sandbox and removes the need for mise scripts to manufacture that dependency edge externally.

This change mark this dependency as optional until we commit on the Nix approach to distribute cross-compilers where we will leverage this to make it the default behavior. 

## Related Issue

None.

## Changes
- Enables Cargo bindeps support and pins the Rust toolchain to nightly for artifact dependencies.
- Adds target-specific openshell-sandbox binary artifact build dependencies for the VM driver.
- Compresses the Cargo-provided openshell-sandbox binary into OUT_DIR/openshell-sandbox.zst during the VM driver build.
- Keeps staged VM runtime artifacts focused on libkrun, libkrunfw, gvproxy, and umoci instead of also requiring a prebuilt sandbox supervisor bundle.

## Testing

- Cargo build passes and uses the new artifact.
- Needs to be validated on macOS.