### PR TITLE
feat(server): out-of-process compute driver via --compute-driver-socket

### DIFF
--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -40,30 +40,38 @@ pub const DEFAULT_SUPERVISOR_IMAGE: &str = "ghcr.io/nvidia/openshell/supervisor:
 pub const CDI_GPU_DEVICE_ALL: &str = "nvidia.com/gpu=all";
 
 /// Compute backends the gateway can orchestrate sandboxes through.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ComputeDriverKind {
     Kubernetes,
     Vm,
     Docker,
     Podman,
+    /// Out-of-process compute driver speaking the gRPC compute_driver.proto contract over a Unix domain socket. The path is supplied by --compute-driver-socket or OPENSHELL_COMPUTE_DRIVER_SOCKET.
+    External(PathBuf),
 }
 
 impl ComputeDriverKind {
     #[must_use]
-    pub const fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             Self::Kubernetes => "kubernetes",
             Self::Vm => "vm",
             Self::Docker => "docker",
             Self::Podman => "podman",
+            Self::External(_) => "external",
         }
     }
 }
 
 impl fmt::Display for ComputeDriverKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
+        match self {
+            Self::Kubernetes | Self::Vm | Self::Docker | Self::Podman => {
+                f.write_str(self.as_str())
+            }
+            Self::External(path) => write!(f, "external:{}", path.display()),
+        }
     }
 }
 
@@ -71,13 +79,31 @@ impl FromStr for ComputeDriverKind {
     type Err = String;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.trim().to_ascii_lowercase().as_str() {
+        let trimmed = value.trim();
+        let lower = trimmed.to_ascii_lowercase();
+        if let Some(suffix_lower) = lower.strip_prefix("external:") {
+            // Use the case-preserving suffix for the path.
+            let suffix = &trimmed[trimmed.len() - suffix_lower.len()..];
+            if suffix.is_empty() {
+                return Err(
+                    "compute driver 'external:' requires a non-empty socket path \
+                     (e.g. 'external:/var/run/openshell-driver.sock')"
+                        .to_string(),
+                );
+            }
+            return Ok(Self::External(PathBuf::from(suffix)));
+        }
+        match lower.as_str() {
             "kubernetes" => Ok(Self::Kubernetes),
             "vm" => Ok(Self::Vm),
             "docker" => Ok(Self::Docker),
             "podman" => Ok(Self::Podman),
+            "external" => Err(
+                "compute driver 'external' requires a socket path: 'external:/path/to/driver.sock' (or set --compute-driver-socket)"
+                    .to_string(),
+            ),
             other => Err(format!(
-                "unsupported compute driver '{other}'. expected one of: kubernetes, vm, docker, podman"
+                "unsupported compute driver '{other}'. expected one of: kubernetes, vm, docker, podman, external:<path>"
             )),
         }
     }
@@ -629,6 +655,42 @@ mod tests {
     }
 
     #[test]
+    fn compute_driver_kind_external_displays_with_path() {
+        let kind = ComputeDriverKind::External(PathBuf::from("/x/y"));
+        assert_eq!(kind.to_string(), "external:/x/y");
+    }
+
+    #[test]
+    fn compute_driver_kind_parses_external_with_socket_path() {
+        let parsed: ComputeDriverKind =
+            "external:/var/run/openshell-driver.sock".parse().unwrap();
+        match parsed {
+            ComputeDriverKind::External(path) => {
+                assert_eq!(path, PathBuf::from("/var/run/openshell-driver.sock"));
+            }
+            other => panic!("expected External(_), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compute_driver_kind_rejects_bare_external_without_path() {
+        let err = "external".parse::<ComputeDriverKind>().unwrap_err();
+        assert!(
+            err.contains("requires a socket path"),
+            "missing socket-path hint in error: {err}"
+        );
+    }
+
+    #[test]
+    fn compute_driver_kind_unknown_error_lists_external_in_supported() {
+        let err = "unknown".parse::<ComputeDriverKind>().unwrap_err();
+        assert!(
+            err.contains("external:<path>"),
+            "expected supported list to mention external:<path>, got: {err}"
+        );
+    }
+
+    #[test]
     fn config_defaults_to_loopback_bind_address() {
         let expected: SocketAddr = "127.0.0.1:17670".parse().expect("valid address");
         assert_eq!(Config::new(None).bind_address, expected);
@@ -752,6 +814,41 @@ mod tests {
                 Some(val) => std::env::set_var("KUBERNETES_SERVICE_HOST", val),
                 None => std::env::remove_var("KUBERNETES_SERVICE_HOST"),
             }
+        }
+    }
+
+    #[test]
+    fn compute_driver_kind_display_roundtrips_through_from_str() {
+        use std::path::PathBuf;
+        for kind in [
+            ComputeDriverKind::Kubernetes,
+            ComputeDriverKind::Vm,
+            ComputeDriverKind::Docker,
+            ComputeDriverKind::Podman,
+            ComputeDriverKind::External(PathBuf::from("/var/run/openshell-driver.sock")),
+        ] {
+            let s = kind.to_string();
+            let parsed: ComputeDriverKind = s.parse().expect("round-trip parse");
+            assert_eq!(parsed, kind, "round-trip mismatch for {s}");
+        }
+    }
+
+    #[test]
+    fn compute_driver_kind_rejects_external_with_empty_path() {
+        let err = "external:".parse::<ComputeDriverKind>().unwrap_err();
+        assert!(err.contains("non-empty socket path"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn compute_driver_kind_external_is_case_insensitive_on_prefix() {
+        let parsed: ComputeDriverKind = "External:/var/run/openshell-driver.sock"
+            .parse()
+            .expect("case-insensitive prefix should be accepted");
+        match parsed {
+            ComputeDriverKind::External(p) => {
+                assert_eq!(p, PathBuf::from("/var/run/openshell-driver.sock"));
+            }
+            other => panic!("expected External, got {other:?}"),
         }
     }
 }

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -613,7 +613,7 @@ fn merge_file_into_args(args: &mut RunArgs, file: &GatewayFileSection, matches: 
 fn effective_single_driver(args: &RunArgs) -> Option<ComputeDriverKind> {
     match args.drivers.as_slice() {
         [] => openshell_core::config::detect_driver(),
-        [driver] => Some(*driver),
+        [driver] => Some(driver.clone()),
         _ => None,
     }
 }

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -111,6 +111,16 @@ struct RunArgs {
     )]
     drivers: Vec<ComputeDriverKind>,
 
+    /// Path to a Unix domain socket served by an external compute driver
+    /// implementing `compute_driver.proto`.
+    ///
+    /// When set, the gateway uses `ComputeDriverKind::External(<path>)` and
+    /// skips both the `--drivers` list and the auto-detection probe. This
+    /// lets out-of-tree driver binaries (Kyma, custom backends) connect to
+    /// an already-running gateway without rebuilding it.
+    #[arg(long, env = "OPENSHELL_COMPUTE_DRIVER_SOCKET")]
+    compute_driver_socket: Option<PathBuf>,
+
     /// Disable TLS entirely — listen on plaintext HTTP.
     /// Use this when the gateway sits behind a reverse proxy or tunnel
     /// (e.g. Cloudflare Tunnel) that terminates TLS at the edge.
@@ -350,9 +360,18 @@ async fn run_from_args(mut args: RunArgs, matches: ArgMatches) -> Result<()> {
         config = config.with_metrics_bind_address(addr);
     }
 
+    // The --compute-driver-socket flag pins an external driver and overrides
+    // the --drivers list. `effective_single_driver` already mirrors this for
+    // pre-runtime checks; do the same here so `configured_compute_driver`
+    // sees the External entry when it inspects `config.compute_drivers`.
+    let configured_drivers = if let Some(socket) = args.compute_driver_socket.clone() {
+        vec![ComputeDriverKind::External(socket)]
+    } else {
+        args.drivers.clone()
+    };
     config = config
         .with_database_url(db_url)
-        .with_compute_drivers(args.drivers.clone())
+        .with_compute_drivers(configured_drivers)
         .with_server_sans(args.server_sans.clone())
         .with_loopback_service_http(args.enable_loopback_service_http);
 
@@ -611,6 +630,11 @@ fn merge_file_into_args(args: &mut RunArgs, file: &GatewayFileSection, matches: 
 }
 
 fn effective_single_driver(args: &RunArgs) -> Option<ComputeDriverKind> {
+    // The --compute-driver-socket flag pins an out-of-tree driver and
+    // therefore wins over both the explicit --drivers list and auto-detection.
+    if let Some(socket) = args.compute_driver_socket.clone() {
+        return Some(ComputeDriverKind::External(socket));
+    }
     match args.drivers.as_slice() {
         [] => openshell_core::config::detect_driver(),
         [driver] => Some(driver.clone()),
@@ -1426,6 +1450,80 @@ enable_loopback_service_http = false
             args.enable_loopback_service_http,
             "env var must win over file"
         );
+    }
+
+    #[test]
+    fn compute_driver_socket_flag_yields_external_driver() {
+        // The CLI flag pins ComputeDriverKind::External(<path>) so that
+        // out-of-tree drivers (Kyma, custom backends) can be wired without
+        // recompiling the gateway.
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _g1 = EnvVarGuard::remove("OPENSHELL_COMPUTE_DRIVER_SOCKET");
+        let _g2 = EnvVarGuard::remove("OPENSHELL_DRIVERS");
+
+        let (args, _) = parse_with_args(&[
+            "openshell-gateway",
+            "--db-url",
+            "sqlite::memory:",
+            "--compute-driver-socket",
+            "/tmp/openshell-driver.sock",
+        ]);
+
+        match super::effective_single_driver(&args) {
+            Some(super::ComputeDriverKind::External(p)) => {
+                assert_eq!(p, std::path::PathBuf::from("/tmp/openshell-driver.sock"));
+            }
+            other => panic!("expected External, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compute_driver_socket_flag_overrides_drivers_list() {
+        // Even when --drivers is set, --compute-driver-socket pins the
+        // external driver. This avoids forcing operators to wipe a
+        // gateway-wide --drivers list to add an out-of-tree driver.
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _g1 = EnvVarGuard::remove("OPENSHELL_COMPUTE_DRIVER_SOCKET");
+        let _g2 = EnvVarGuard::remove("OPENSHELL_DRIVERS");
+
+        let (args, _) = parse_with_args(&[
+            "openshell-gateway",
+            "--db-url",
+            "sqlite::memory:",
+            "--drivers",
+            "docker",
+            "--compute-driver-socket",
+            "/tmp/x.sock",
+        ]);
+
+        match super::effective_single_driver(&args) {
+            Some(super::ComputeDriverKind::External(p)) => {
+                assert_eq!(p, std::path::PathBuf::from("/tmp/x.sock"));
+            }
+            other => panic!("expected External, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compute_driver_socket_reads_from_env_var() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _g1 = EnvVarGuard::set("OPENSHELL_COMPUTE_DRIVER_SOCKET", "/run/external.sock");
+        let _g2 = EnvVarGuard::remove("OPENSHELL_DRIVERS");
+
+        let (args, _) = parse_with_args(&["openshell-gateway", "--db-url", "sqlite::memory:"]);
+
+        match super::effective_single_driver(&args) {
+            Some(super::ComputeDriverKind::External(p)) => {
+                assert_eq!(p, std::path::PathBuf::from("/run/external.sock"));
+            }
+            other => panic!("expected External, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -216,6 +216,44 @@ impl ComputeDriver for RemoteComputeDriver {
     }
 }
 
+/// Build a tonic [`Channel`] connected to a Unix domain socket served by an
+/// external compute driver. Used by the `External(PathBuf)` dispatch arm in
+/// `lib.rs::build_compute_runtime`. The dummy authority `http://[::]:50051`
+/// matches the connector convention used by the VM driver — tonic ignores it
+/// once a custom service connector is supplied.
+#[cfg(unix)]
+pub(crate) async fn connect_external_compute_driver(
+    socket_path: std::path::PathBuf,
+) -> Result<Channel, openshell_core::Error> {
+    use hyper_util::rt::TokioIo;
+    use tokio::net::UnixStream;
+    use tonic::transport::Endpoint;
+    use tower::service_fn;
+
+    let display_path = socket_path.clone();
+    Endpoint::from_static("http://[::]:50051")
+        .connect_with_connector(service_fn(move |_: tonic::transport::Uri| {
+            let socket_path = socket_path.clone();
+            async move { UnixStream::connect(socket_path).await.map(TokioIo::new) }
+        }))
+        .await
+        .map_err(|e| {
+            openshell_core::Error::execution(format!(
+                "failed to connect to external compute driver socket '{}': {e}",
+                display_path.display()
+            ))
+        })
+}
+
+#[cfg(not(unix))]
+pub(crate) async fn connect_external_compute_driver(
+    _socket_path: std::path::PathBuf,
+) -> Result<Channel, openshell_core::Error> {
+    Err(openshell_core::Error::config(
+        "the external compute driver requires unix domain socket support",
+    ))
+}
+
 #[derive(Clone)]
 pub struct ComputeRuntime {
     driver: SharedComputeDriver,
@@ -362,6 +400,38 @@ impl ComputeRuntime {
             None,
             None,
             driver_process,
+            store,
+            sandbox_index,
+            sandbox_watch_bus,
+            tracing_log_bus,
+            supervisor_sessions,
+            true,
+            Vec::new(),
+        )
+        .await
+    }
+
+    /// Build a `ComputeRuntime` over a tonic `Channel` connected to an
+    /// already-running external compute driver process.
+    ///
+    /// Unlike [`new_remote_vm`], this constructor does not own a child
+    /// process — the external driver's lifecycle is the operator's
+    /// responsibility (systemd unit, sidecar container, etc.). The
+    /// underlying `RemoteComputeDriver` proxy is identical.
+    pub(crate) async fn new_remote_external(
+        channel: Channel,
+        store: Arc<Store>,
+        sandbox_index: SandboxIndex,
+        sandbox_watch_bus: SandboxWatchBus,
+        tracing_log_bus: TracingLogBus,
+        supervisor_sessions: Arc<SupervisorSessionRegistry>,
+    ) -> Result<Self, ComputeError> {
+        let driver: SharedComputeDriver = Arc::new(RemoteComputeDriver::new(channel));
+        Self::from_driver(
+            driver,
+            None,
+            None,
+            None,
             store,
             sandbox_index,
             sandbox_watch_bus,

--- a/crates/openshell-server/src/config_file.rs
+++ b/crates/openshell-server/src/config_file.rs
@@ -285,6 +285,10 @@ fn inheritable_keys(driver: ComputeDriverKind) -> &'static [&'static str] {
             "guest_tls_cert",
             "guest_tls_key",
         ],
+        // The external driver is configured via the --compute-driver-socket
+        // CLI flag, not a TOML driver table, so no gateway-section keys are
+        // inheritable.
+        ComputeDriverKind::External(_) => &[],
     }
 }
 

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -762,11 +762,23 @@ async fn build_compute_runtime(
             .await
             .map_err(|e| Error::execution(format!("failed to create compute runtime: {e}")))
         }
-        ComputeDriverKind::External(_) => Err(Error::config(
-            "external compute driver dispatch is not yet wired; \
-             tonic UDS client lands in plan task 2a.4 \
-             (st-gr/openshell-driver-kyma docs/superpowers/plans/2026-05-27-phase2a-gateway-fork.md)",
-        )),
+        ComputeDriverKind::External(socket) => {
+            info!(
+                socket = %socket.display(),
+                "Connecting to external compute driver over Unix domain socket"
+            );
+            let channel = compute::connect_external_compute_driver(socket.clone()).await?;
+            ComputeRuntime::new_remote_external(
+                channel,
+                store,
+                sandbox_index,
+                sandbox_watch_bus,
+                tracing_log_bus,
+                supervisor_sessions,
+            )
+            .await
+            .map_err(|e| Error::execution(format!("failed to create compute runtime: {e}")))
+        }
     }
 }
 

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -762,6 +762,11 @@ async fn build_compute_runtime(
             .await
             .map_err(|e| Error::execution(format!("failed to create compute runtime: {e}")))
         }
+        ComputeDriverKind::External(_) => Err(Error::config(
+            "external compute driver dispatch is not yet wired; \
+             tonic UDS client lands in plan task 2a.4 \
+             (st-gr/openshell-driver-kyma docs/superpowers/plans/2026-05-27-phase2a-gateway-fork.md)",
+        )),
     }
 }
 
@@ -853,12 +858,7 @@ fn configured_compute_driver(config: &Config) -> Result<ComputeDriverKind> {
                 set --drivers or OPENSHELL_DRIVERS to kubernetes, podman, docker, or vm",
             )),
         },
-        [
-            driver @ (ComputeDriverKind::Kubernetes
-            | ComputeDriverKind::Vm
-            | ComputeDriverKind::Docker
-            | ComputeDriverKind::Podman),
-        ] => Ok(*driver),
+        [driver] => Ok(driver.clone()),
         drivers => Err(Error::config(format!(
             "multiple compute drivers are not supported yet; configured drivers: {}",
             drivers


### PR DESCRIPTION
## Summary

Adds an out-of-process compute driver mechanism: when the gateway is started with `--compute-driver-socket=PATH` (or `OPENSHELL_COMPUTE_DRIVER_SOCKET=PATH`), it connects a tonic gRPC channel over the supplied Unix domain socket and uses that as the compute driver. The remote driver speaks the existing \`compute_driver.proto\` contract (no proto changes).

This unblocks third-party compute drivers (e.g., custom Kubernetes flavors, on-cluster managed services like SAP BTP Kyma) that ship as separate binaries without having to be merged into this workspace.

## What's in the patch (3 commits)

1. \`feat(core): add External(PathBuf) variant to ComputeDriverKind\` — the enum drops \`Copy\` (PathBuf isn't Copy), gains an \`External(PathBuf)\` variant, \`Display\` round-trips as \`external:<path>\`, and \`FromStr\` accepts \`external:<path>\` (case-insensitive prefix), rejecting bare \`external\` with a clear error pointing at the new flag. 9 unit tests, including a Display↔FromStr round-trip for all variants.

2. \`feat(server): add --compute-driver-socket CLI flag\` — top-level flag in \`RunArgs\` with env binding. When set, the resolved single driver is \`External(path)\`, overriding both \`--drivers\` and auto-detection. Updates both \`effective_single_driver\` (used by mTLS/OIDC pre-checks) and \`with_compute_drivers\` (used by the runtime factory) so the two paths cannot diverge. 3 unit tests including env-var binding and override behavior.

3. \`feat(server): wire ComputeDriverKind::External via tonic UDS channel\` — \`build_compute_runtime\` connects a tonic \`Channel\` to the configured UDS using \`hyper-util\`'s \`TokioIo\` connector and constructs a \`ComputeRuntime\` via a new \`new_remote_external\` constructor (sibling to \`new_remote_vm\`, takes only the channel and not a \`ManagedDriverProcess\` since the operator owns the external driver's lifecycle).

No new dependencies (\`hyper-util\`, \`tower\`, \`tonic\`, \`tokio\` already in-tree). All commits DCO-signed.

## Test plan

- [x] \`cargo test -p openshell-core compute_driver_kind\` — 9 tests passing (5 new External-variant cases + 1 round-trip across all variants + 3 pre-existing).
- [x] \`cargo test -p openshell-server --lib cli::\` — 37 tests, 3 new for the flag (presence, override-of-drivers-list, env-var binding).
- [x] Full \`cargo test -p openshell-core\` and \`cargo test -p openshell-server --lib\` — 144 + 680 tests, no regressions.
- [x] Container smoke test: built \`Dockerfile.gateway\` (fork-only, not in this PR), ran with \`--compute-driver-socket /tmp/no.sock\`, confirmed clean error trace pointing at the missing socket.
- [ ] CI build of upstream main + this PR (will run automatically once opened).

## Why upstream

The companion driver lives at https://github.com/st-gr/openshell-driver-kyma (Apache-2.0). The author of the OpenShift compute driver maintains an analogous fork at https://github.com/zanetworker/OpenShell with the same flag — they noted in their docs that they would like to upstream the patch when stable. Two independent forks both carrying this same ~150-line change is a reasonable signal that the feature is generally useful.

## Compatibility

- The default driver dispatch is unchanged: \`--drivers kubernetes\`, auto-detection, etc. all behave exactly as before.
- \`ComputeDriverKind\` no longer derives \`Copy\` because \`PathBuf\` isn't \`Copy\`. Three call sites in \`openshell-server\` were updated to clone instead. No public API change for downstream consumers — the enum was already \`Clone\`.
- \`as_str\` signature changed from \`const fn (self) -> &'static str\` to \`fn (&self) -> &'static str\` for the same reason. No const-context callers exist in the workspace.

## Open questions for reviewers

- Should the CLI flag's name be \`--compute-driver-socket\` or something like \`--external-driver-socket\`? Happy to bikeshed.
- Should \`External(PathBuf)\` carry an optional auth/identity field (mTLS cert path, bearer token) for the driver-side connection, or is that out of scope for v1? The current patch assumes UDS file permissions are the auth boundary, which is the same trust model as the existing in-tree drivers.

Signed-off-by: st-gr <38470677+st-gr@users.noreply.github.com>