### PR TITLE
feat(sandbox): add OPENSHELL_OCSF_JSONL opt-in for standalone mode

### DIFF
--- a/crates/openshell-core/src/sandbox_env.rs
+++ b/crates/openshell-core/src/sandbox_env.rs
@@ -53,3 +53,6 @@ pub const SANDBOX_TOKEN_FILE: &str = "OPENSHELL_SANDBOX_TOKEN_FILE";
 /// writes and rotates this file; the supervisor exchanges its contents
 /// for a gateway JWT at startup and on refresh.
 pub const K8S_SA_TOKEN_FILE: &str = "OPENSHELL_K8S_SA_TOKEN_FILE";
+
+/// Opt-in switch for the OCSF JSONL tracing layer in standalone mode.
+pub const OCSF_JSONL_ENABLED: &str = "OPENSHELL_OCSF_JSONL";

--- a/crates/openshell-sandbox/src/main.rs
+++ b/crates/openshell-sandbox/src/main.rs
@@ -221,7 +221,10 @@ fn main() -> Result<()> {
         // Shared flag: the sandbox poll loop toggles this when the
         // `ocsf_json_enabled` setting changes. The JSONL layer checks it
         // on each event and short-circuits when false.
-        let ocsf_enabled = Arc::new(AtomicBool::new(false));
+        let ocsf_enabled = Arc::new(AtomicBool::new(
+            std::env::var(openshell_core::sandbox_env::OCSF_JSONL_ENABLED)
+                .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true")),
+        ));
 
         // Keep guards alive for the entire process. When a guard is dropped the
         // non-blocking writer flushes remaining logs.

--- a/docs/observability/ocsf-json-export.mdx
+++ b/docs/observability/ocsf-json-export.mdx
@@ -33,6 +33,10 @@ To disable:
 openshell settings set --global --key ocsf_json_enabled --value false
 ```
 
+### Standalone mode
+
+When the supervisor runs without a gateway endpoint, the policy poll loop that toggles `ocsf_json_enabled` never starts. Set `OPENSHELL_OCSF_JSONL=1` in the supervisor's environment at startup to enable JSON export in this mode.
+
 ## Output Location
 
 When enabled, OCSF JSON records are written to `/var/log/openshell-ocsf.YYYY-MM-DD.log` inside the sandbox. The file rotates daily and retains the 3 most recent files, matching the main log file rotation.


### PR DESCRIPTION
## Summary

The OCSF JSONL audit layer in `openshell-sandbox` is gated by an `AtomicBool` that the policy poll loop swaps when the gateway-side `ocsf_json_enabled` setting changes. The poll loop only spawns when `OPENSHELL_ENDPOINT` is set, so a supervisor running standalone has no way to flip the flag and `/var/log/openshell-ocsf.YYYY-MM-DD.log` stays empty. Seed the initial value from a new `OPENSHELL_OCSF_JSONL` env var so standalone supervisors can opt in.

## Related Issue

None.

## Changes

- Add `OPENSHELL_OCSF_JSONL` constant in `openshell-core::sandbox_env`.
- Seed `ocsf_enabled: AtomicBool` from that env var at supervisor startup, using the same boolean-env parsing pattern as `OPENSHELL_NO_BROWSER` (`v == "1" || v.eq_ignore_ascii_case("true")`).
- Document the standalone-mode opt-in in `docs/observability/ocsf-json-export.mdx`.

The default is unchanged: an unset variable still starts the flag at `false`. In gateway-connected mode the first poll cycle overwrites the seeded value with the gateway setting, so the env var only meaningfully changes behavior when no endpoint is configured.

## Testing

- [x] `cargo clippy -p openshell-core -p openshell-sandbox --tests --no-deps -- -D warnings` clean for the touched code
- [ ] `mise run pre-commit` passes (fails in upstream `rust:lint` on unrelated `crates/openshell-sandbox/src/process.rs:23` unused import: `warn` — present on pristine `main` before this branch)
- [ ] Unit tests added/updated (not applicable — change is a 3-line env-var read using the same pattern as `OPENSHELL_NO_BROWSER`, which is also untested)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable)