### PR TITLE
build(macos): remove unused import of tracing::warn

### DIFF
--- a/crates/openshell-sandbox/src/process.rs
+++ b/crates/openshell-sandbox/src/process.rs
@@ -20,7 +20,9 @@ use std::os::unix::io::RawFd;
 use std::path::PathBuf;
 use std::process::Stdio;
 use tokio::process::{Child, Command};
-use tracing::{debug, warn};
+use tracing::debug;
+#[cfg(target_os = "linux")]
+use tracing::warn;
 
 fn inject_provider_env(cmd: &mut Command, provider_env: &HashMap<String, String>) {
     for (key, value) in provider_env {


### PR DESCRIPTION
## Summary
Currently running `mise run pre-commit` on `main` with a macos machine leads to:
```
rust:check]     Checking openshell-cli v0.0.0 (/Users/cmurray/repos/OpenShell/feature-0/crates/openshell-cli)
[rust:check] warning: unused import: `warn`
[rust:check]   --> crates/openshell-sandbox/src/process.rs:23:22
[rust:check]    |
[rust:check] 23 | use tracing::{debug, warn};
[rust:check]    |                      ^^^^
[rust:check]    |
```

This is because `tracing::warn` is only used in linux (not macos)

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
