### PR TITLE
fix(driver-podman): bind gateway to 0.0.0.0 in rootless mode

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,6 +40,10 @@ jobs:
           - suite: rust-podman
             cmd: "mise run --no-deps --skip-deps e2e:podman"
             apt_packages: "openssh-client podman"
+          - suite: rust-podman-rootless
+            cmd: "mise run --no-deps --skip-deps e2e:podman:rootless"
+            apt_packages: "openssh-client podman uidmap"
+            rootless: true
     container:
       image: ghcr.io/nvidia/openshell/ci:latest
       credentials:
@@ -72,8 +76,22 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Log in to GHCR with Podman
-        if: matrix.suite == 'rust-podman'
+        if: startsWith(matrix.suite, 'rust-podman')
         run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Set up rootless Podman user
+        if: matrix.rootless
+        run: |
+          useradd -m openshell-test
+          echo "openshell-test:100000:65536" >> /etc/subuid
+          echo "openshell-test:100000:65536" >> /etc/subgid
+          mkdir -p "/run/user/$(id -u openshell-test)"
+          chown openshell-test: "/run/user/$(id -u openshell-test)"
+          chmod 700 "/run/user/$(id -u openshell-test)"
+          chown -R openshell-test: .
+          for dir in /root/.cargo /root/.rustup /root/.local/share/mise /opt/mise; do
+            [ -d "$dir" ] && chmod -R a+rX "$dir"
+          done
 
       - name: Install Python dependencies and generate protobuf stubs
         if: matrix.suite == 'python'
@@ -82,4 +100,24 @@ jobs:
       - name: Run tests
         env:
           OPENSHELL_SUPERVISOR_IMAGE: ${{ format('ghcr.io/nvidia/openshell/supervisor:{0}', inputs.image-tag) }}
-        run: ${{ matrix.cmd }}
+          E2E_CMD: ${{ matrix.cmd }}
+        run: |
+          if [ "${{ matrix.rootless }}" = "true" ]; then
+            TESTUID="$(id -u openshell-test)"
+            runuser -u openshell-test -- env \
+              XDG_RUNTIME_DIR="/run/user/${TESTUID}" \
+              HOME="/home/openshell-test" \
+              PATH="/root/.cargo/bin:/opt/mise/shims:/opt/mise/bin:${PATH}" \
+              CARGO_HOME="/root/.cargo" \
+              RUSTUP_HOME="/root/.rustup" \
+              OPENSHELL_SUPERVISOR_IMAGE="${OPENSHELL_SUPERVISOR_IMAGE}" \
+              OPENSHELL_REGISTRY="${OPENSHELL_REGISTRY}" \
+              OPENSHELL_REGISTRY_HOST="${OPENSHELL_REGISTRY_HOST}" \
+              OPENSHELL_REGISTRY_USERNAME="${OPENSHELL_REGISTRY_USERNAME}" \
+              OPENSHELL_REGISTRY_PASSWORD="${OPENSHELL_REGISTRY_PASSWORD}" \
+              IMAGE_TAG="${IMAGE_TAG}" \
+              MISE_GITHUB_TOKEN="${MISE_GITHUB_TOKEN}" \
+              bash -c "${E2E_CMD}"
+          else
+            ${E2E_CMD}
+          fi

--- a/e2e/rust/e2e-podman-rootless.sh
+++ b/e2e/rust/e2e-podman-rootless.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run the Podman e2e suite and verify rootless mode.
+#
+# Identical to e2e-podman.sh but fails fast if Podman is not running
+# rootless. Use this to explicitly validate the rootless networking
+# path (pasta, host-gateway, bind address).
+
+set -euo pipefail
+
+if podman info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -q false; then
+  echo "ERROR: podman is not running rootless; this test requires rootless mode" >&2
+  exit 2
+fi
+
+exec "$(dirname "${BASH_SOURCE[0]}")/e2e-podman.sh"

--- a/tasks/scripts/gateway.sh
+++ b/tasks/scripts/gateway.sh
@@ -271,6 +271,15 @@ if [[ "${DRIVER}" == "podman" ]]; then
   SUPERVISOR_IMAGE="${OPENSHELL_SUPERVISOR_IMAGE:-openshell/supervisor:dev}"
   ensure_podman_supervisor_image "${SUPERVISOR_IMAGE}"
   export OPENSHELL_SUPERVISOR_IMAGE="${SUPERVISOR_IMAGE}"
+
+  # Rootless Podman containers reach the host via pasta's local connection
+  # bypass, which translates to host L4 sockets. The gateway must listen on
+  # 0.0.0.0 so pasta can reach it — 127.0.0.1 is not routable through pasta.
+  if [[ -z "${OPENSHELL_BIND_ADDRESS:-}" ]]; then
+    if podman info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -q true; then
+      export OPENSHELL_BIND_ADDRESS="0.0.0.0"
+    fi
+  fi
 fi
 
 if [[ ! "${GATEWAY_NAME}" =~ ^[A-Za-z0-9._-]+$ ]]; then

--- a/tasks/test.toml
+++ b/tasks/test.toml
@@ -71,6 +71,10 @@ run = "e2e/with-docker-gateway.sh uv run pytest -o python_files='test_*.py' -m g
 description = "Run Rust CLI e2e tests against a Podman-backed gateway"
 run = "e2e/rust/e2e-podman.sh"
 
+["e2e:podman:rootless"]
+description = "Run Rust CLI e2e tests against a rootless Podman-backed gateway"
+run = "e2e/rust/e2e-podman-rootless.sh"
+
 ["e2e:podman:gpu"]
 description = "Run GPU e2e against a standalone gateway with the Podman compute driver"
 env = { OPENSHELL_E2E_PODMAN_GPU = "1", OPENSHELL_E2E_PODMAN_TEST = "gpu_device_selection", OPENSHELL_E2E_PODMAN_FEATURES = "e2e-podman-gpu" }


### PR DESCRIPTION
## Summary

Rootless Podman sandbox containers reach the host through pasta's local
connection bypass, which translates L2 frames to L4 host sockets. The dev
gateway script binds to `127.0.0.1` by default, which is not routable
through pasta — sandbox creation fails with "Policy fetch failed after 5
attempts: failed to connect to OpenShell server". Auto-detect rootless
mode and bind to `0.0.0.0`.

## Related Issue

None — discovered during local rootless Podman testing.

## Changes

- `tasks/scripts/gateway.sh`: auto-detect rootless Podman via
  `podman info --format '{{.Host.Security.Rootless}}'` and export
  `OPENSHELL_BIND_ADDRESS=0.0.0.0` when not explicitly set
- `e2e/rust/e2e-podman-rootless.sh`: new e2e wrapper that gates on
  rootless mode and delegates to existing `e2e-podman.sh`
- `tasks/test.toml`: add `e2e:podman:rootless` mise task
- `.github/workflows/e2e-test.yml`: add `rust-podman-rootless` CI matrix
  entry that creates a non-root user inside the privileged container to
  trigger Podman's rootless code paths (pasta networking, user namespace
  isolation)

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)
- [x] Manual verification: `mise run gateway` on rootless Podman binds
  to `0.0.0.0` and sandbox creation succeeds

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)