### PR TITLE
docs(config): update gateway config reference

### DIFF
--- a/.agents/skills/build-from-issue/SKILL.md
+++ b/.agents/skills/build-from-issue/SKILL.md
@@ -148,7 +148,8 @@ In the prompt, instruct the reviewer to:
    - **Medium**: Multiple files/components, some design decisions, but well-scoped
    - **High**: Cross-cutting changes, architectural decisions needed, significant unknowns
 8. Call out risks, unknowns, and decisions that need stakeholder input.
-9. Assess **LSM compatibility** — if the change touches process identity, `/proc` filesystem access, binary execution, or inter-process visibility, flag whether it will behave differently on hosts running SELinux (enforcing) or AppArmor. In particular, tests that fork+exec into system binaries will fail on SELinux-enforcing hosts due to cross-label `/proc/<pid>/exe` access restrictions.
+9. Assess **gateway config documentation impact** — if the change adds, removes, renames, or changes defaults for gateway TOML keys or driver-specific config options, the plan must include an update to `docs/reference/gateway-config.mdx`. If the change is surfaced through Helm or a compute-driver overview, also include `docs/reference/sandbox-compute-drivers.mdx` or the relevant deployment docs.
+10. Assess **LSM compatibility** — if the change touches process identity, `/proc` filesystem access, binary execution, or inter-process visibility, flag whether it will behave differently on hosts running SELinux (enforcing) or AppArmor. In particular, tests that fork+exec into system binaries will fail on SELinux-enforcing hosts due to cross-label `/proc/<pid>/exe` access restrictions.
 
 ### A2: Post the Plan Comment
 
@@ -435,6 +436,13 @@ Do not proceed to PR creation if E2E verification is not green.
 Review the documentation requirements in `AGENTS.md` and update any affected
 docs as part of the implementation. Keep documentation changes scoped to the
 behavior or subsystem that changed.
+
+If the implementation changes gateway TOML parsing, `[openshell.gateway]`
+fields, `[openshell.drivers.<name>]` fields, driver config defaults, or Helm
+rendering of `gateway.toml`, update `docs/reference/gateway-config.mdx` in the
+same branch. If the change affects user-facing compute-driver setup, also
+update `docs/reference/sandbox-compute-drivers.mdx` or the relevant deployment
+page.
 
 ### Step 12: Commit and Push
 

--- a/.agents/skills/create-github-pr/SKILL.md
+++ b/.agents/skills/create-github-pr/SKILL.md
@@ -15,6 +15,15 @@ Create pull requests on GitHub using the `gh` CLI.
 
 ## Before Creating a PR
 
+### Check Config Documentation
+
+If the branch changes gateway TOML parsing, `[openshell.gateway]` fields,
+`[openshell.drivers.<name>]` fields, driver config defaults, or Helm rendering
+of `gateway.toml`, verify that `docs/reference/gateway-config.mdx` is updated
+in the same branch. If the change affects user-facing compute-driver setup,
+also update `docs/reference/sandbox-compute-drivers.mdx` or the relevant
+deployment docs.
+
 ### Run Pre-commit Checks
 
 Run the local pre-commit task before opening a PR:

--- a/.agents/skills/create-spike/SKILL.md
+++ b/.agents/skills/create-spike/SKILL.md
@@ -91,9 +91,11 @@ The prompt to the reviewer **must** instruct it to:
 
 9. **Check architecture docs** in the `architecture/` directory for relevant documentation about the affected subsystems.
 
-10. **Assess Linux Security Module (LSM) impact.** If the change involves process identity, `/proc` filesystem access, file labeling, binary execution, or inter-process visibility, call out whether it will behave differently on hosts running SELinux (enforcing) or AppArmor. For example: reading `/proc/<pid>/exe` across an SELinux domain boundary returns ENOENT, not EACCES. Tests that fork+exec into system binaries (different SELinux label) will fail on enforcing hosts. Flag any LSM-sensitive code paths and recommend mitigations.
+10. **Assess gateway config documentation impact.** If the change would add, remove, rename, or change defaults for gateway TOML keys or driver-specific config options, call out that `docs/reference/gateway-config.mdx` must be updated. If the change is surfaced through Helm or compute-driver setup docs, call out the relevant deployment or compute-driver docs too.
 
-11. **Determine the issue type:** `feat`, `fix`, `refactor`, `chore`, `perf`, or `docs`.
+11. **Assess Linux Security Module (LSM) impact.** If the change involves process identity, `/proc` filesystem access, file labeling, binary execution, or inter-process visibility, call out whether it will behave differently on hosts running SELinux (enforcing) or AppArmor. For example: reading `/proc/<pid>/exe` across an SELinux domain boundary returns ENOENT, not EACCES. Tests that fork+exec into system binaries (different SELinux label) will fail on enforcing hosts. Flag any LSM-sensitive code paths and recommend mitigations.
+
+12. **Determine the issue type:** `feat`, `fix`, `refactor`, `chore`, `perf`, or `docs`.
 
 ### What makes a good investigation prompt
 

--- a/.agents/skills/update-docs/SKILL.md
+++ b/.agents/skills/update-docs/SKILL.md
@@ -34,7 +34,7 @@ git log -50 --oneline --no-merges
 Filter to commits that are likely to affect docs. Look for these signals:
 
 1. **Commit type**: `feat`, `fix`, `refactor`, `perf` commits often change behavior. `docs` commits are already doc changes. `chore`, `ci`, `test` commits rarely need doc updates.
-2. **Files changed**: Changes to `crates/openshell-cli/`, `python/`, `proto/`, `deploy/`, or policy-related code are high-signal.
+2. **Files changed**: Changes to `crates/openshell-cli/`, `python/`, `proto/`, `deploy/`, gateway config parsing, driver config structs, or policy-related code are high-signal.
 3. **Ignore**: Changes limited to `tests/`, `e2e/`, `.github/`, `tasks/`, or internal-only modules.
 
 ```bash
@@ -52,6 +52,10 @@ For each relevant commit, determine which doc page(s) it affects. Use this mappi
 | `crates/openshell-cli/` (sandbox commands) | `docs/sandboxes/manage-sandboxes.mdx` |
 | `crates/openshell-cli/` (provider commands) | `docs/sandboxes/manage-providers.mdx` |
 | `crates/openshell-cli/` (new top-level command) | May need a new page or `docs/reference/` entry |
+| `crates/openshell-server/src/config_file.rs` or gateway TOML parsing | `docs/reference/gateway-config.mdx` |
+| `crates/openshell-server/src/cli.rs` gateway config merge/default behavior | `docs/reference/gateway-config.mdx` |
+| `crates/openshell-driver-*/` config structs or driver defaults | `docs/reference/gateway-config.mdx`, `docs/reference/sandbox-compute-drivers.mdx` |
+| `deploy/helm/openshell/templates/gateway-config.yaml` | `docs/reference/gateway-config.mdx`, `docs/reference/sandbox-compute-drivers.mdx`, Helm docs if values change |
 | Proxy or policy code | `docs/sandboxes/policies.mdx`, `docs/reference/policy-schema.mdx` |
 | Inference code | `docs/inference/configure.mdx` |
 | `python/` (SDK changes) | `docs/reference/` or `docs/get-started/quickstart.mdx` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,7 @@ ocsf_emit!(event);
 
 - When making changes, update the relevant documentation in the `architecture/` directory.
 - When changes affect user-facing behavior, update the relevant published docs pages under `docs/` and navigation in `docs/index.yml`.
+- When changing gateway TOML fields, driver-specific config options, config defaults, or Helm rendering of `gateway.toml`, update `docs/reference/gateway-config.mdx` in the same branch.
 - `fern/` contains the Fern site config, components, preview workflow inputs, and publish settings.
 - Follow the docs style guide in [docs/CONTRIBUTING.mdx](docs/CONTRIBUTING.mdx): active voice, minimal formatting, no filler introductions, `shell` fences for copyable commands, and no duplicate body H1.
 - Fern PR previews run through `.github/workflows/branch-docs.yml`, and production publish runs through the `publish-fern-docs` job in `.github/workflows/release-tag.yml`.

--- a/docs/CONTRIBUTING.mdx
+++ b/docs/CONTRIBUTING.mdx
@@ -25,6 +25,7 @@ Update documentation when your change:
 
 - Adds, removes, or renames a CLI command or flag.
 - Changes default behavior or configuration.
+- Adds, removes, renames, or changes defaults for gateway TOML fields or driver-specific config options. Update `docs/reference/gateway-config.mdx` for these changes.
 - Adds a new feature that users interact with.
 - Fixes a bug that the docs describe incorrectly.
 - Changes an API, protocol, or policy schema.

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -68,11 +68,12 @@ metrics_bind_address  = "0.0.0.0:9090"
 
 log_level             = "info"
 
-# When empty the gateway auto-detects (Kubernetes -> Podman -> Docker). VM is
-# never auto-detected and requires an explicit entry here.
+# When empty, the gateway auto-detects Kubernetes, then Podman, then Docker.
+# VM is never auto-detected and requires an explicit entry here.
 compute_drivers       = ["kubernetes"]
 
 sandbox_namespace     = "openshell"
+ssh_session_ttl_secs  = 3600
 
 # Subject Alternative Names baked into the gateway server certificate.
 # Wildcard DNS SANs (e.g. "*.dev.openshell.localhost") also enable sandbox
@@ -81,17 +82,28 @@ server_sans                  = ["openshell", "*.dev.openshell.localhost"]
 # Allow plaintext HTTP routing for loopback sandbox service URLs.
 enable_loopback_service_http = true
 
-# Shared driver defaults — inherited into [openshell.drivers.<name>] tables
+# Set true only for local plaintext gateways or trusted TLS termination.
+disable_tls = false
+
+# Shared driver defaults. These inherit into [openshell.drivers.<name>] tables
 # when the driver-specific table does not override them.
-default_image          = "ghcr.io/nvidia/openshell/sandbox:latest"
-supervisor_image       = "ghcr.io/nvidia/openshell/supervisor:latest"
-client_tls_secret_name = "openshell-client-tls"
+default_image           = "ghcr.io/nvidia/openshell/sandbox:latest"
+supervisor_image        = "ghcr.io/nvidia/openshell/supervisor:latest"
+client_tls_secret_name  = "openshell-client-tls"
+service_account_name    = "openshell-sandbox"
+host_gateway_ip         = "10.0.0.1"
+enable_user_namespaces  = false
+sa_token_ttl_secs       = 3600
+guest_tls_ca            = "/etc/openshell/certs/ca.pem"
+guest_tls_cert          = "/etc/openshell/certs/client.pem"
+guest_tls_key           = "/etc/openshell/certs/client-key.pem"
 
 # Gateway listener TLS (distinct from the per-driver guest_tls_*).
 [openshell.gateway.tls]
 cert_path             = "/etc/openshell/certs/gateway.pem"
 key_path              = "/etc/openshell/certs/gateway-key.pem"
 client_ca_path        = "/etc/openshell/certs/client-ca.pem"
+require_client_auth   = false
 
 [openshell.gateway.gateway_jwt]
 signing_key_path = "/etc/openshell/jwt/signing.pem"
@@ -103,6 +115,9 @@ ttl_secs         = 3600
 [openshell.gateway.auth]
 allow_unauthenticated_users = false
 
+[openshell.gateway.mtls_auth]
+enabled = false
+
 [openshell.gateway.oidc]
 issuer        = "https://idp.example.com/realms/openshell"
 audience      = "openshell-cli"
@@ -110,19 +125,22 @@ jwks_ttl_secs = 3600
 roles_claim   = "realm_access.roles"
 admin_role    = "openshell-admin"
 user_role     = "openshell-user"
+scopes_claim  = ""
 ```
 
 Local Docker, Podman, and VM gateways can also set `[openshell.gateway.mtls_auth] enabled = true` to authenticate CLI callers from verified client certificates. Kubernetes deployments must leave this unset and use OIDC or a trusted access proxy; the Helm chart does not render this table.
 
 `[openshell.gateway.auth] allow_unauthenticated_users = true` is an unsafe local-development and trusted-proxy escape hatch. It accepts user-facing CLI/API calls without OIDC or mTLS credentials while sandbox supervisors still authenticate with gateway-minted sandbox JWTs. Leave it false for shared and production gateways.
 
-`image_pull_policy` is intentionally not a shared gateway key. Kubernetes uses `Always | IfNotPresent | Never` while Podman uses `always | missing | never | newer`. Set it inside the relevant driver table.
+`image_pull_policy` is intentionally not a shared gateway key. Kubernetes and Docker use `Always`, `IfNotPresent`, or `Never`. Podman uses `always`, `missing`, `never`, or `newer`. Set it inside the relevant driver table.
 
-## Per-Driver Examples
+## Driver References
+
+Each example is a complete TOML file for one compute driver. The examples repeat `[openshell]` and `[openshell.gateway]` so they stay copyable, and the driver tables list the accepted driver-specific keys. Driver-specific values override inherited gateway defaults. The gateway rejects unknown driver fields after inheritance is merged.
 
 ### Kubernetes
 
-The gateway runs as a Pod and creates sandbox Pods in another namespace. mTLS material for sandboxes is delivered via a Kubernetes Secret rather than host-side file paths.
+The gateway runs as a Pod and creates sandbox Pods in another namespace. mTLS material for sandboxes is delivered through a Kubernetes Secret rather than host-side file paths.
 
 ```toml
 [openshell]
@@ -135,23 +153,29 @@ metrics_bind_address  = "0.0.0.0:9090"
 log_level             = "info"
 compute_drivers       = ["kubernetes"]
 
-default_image          = "ghcr.io/nvidia/openshell/sandbox:latest"
-supervisor_image       = "ghcr.io/nvidia/openshell/supervisor:latest"
-client_tls_secret_name = "openshell-client-tls"
-
 [openshell.gateway.tls]
 cert_path      = "/etc/openshell-tls/server/tls.crt"
 key_path       = "/etc/openshell-tls/server/tls.key"
 client_ca_path = "/etc/openshell-tls/client-ca/ca.crt"
 
 [openshell.drivers.kubernetes]
-namespace                  = "agents"
-grpc_endpoint              = "https://openshell-gateway.agents.svc:8080"
-service_account_name       = "openshell-sandbox"
-image_pull_policy          = "IfNotPresent"
-# Use the image volume on K8s >= 1.35 (GA in 1.36); switch to "init-container"
+namespace                      = "agents"
+service_account_name           = "openshell-sandbox"
+default_image                  = "ghcr.io/nvidia/openshell/sandbox:latest"
+image_pull_policy              = "IfNotPresent"
+supervisor_image               = "ghcr.io/nvidia/openshell/supervisor:latest"
+supervisor_image_pull_policy   = "IfNotPresent"
+# Use the image volume on Kubernetes >= 1.35 (GA in 1.36); switch to "init-container"
 # on older clusters or where the ImageVolume feature gate is off.
-supervisor_sideload_method = "image-volume"
+supervisor_sideload_method     = "image-volume"
+grpc_endpoint                  = "https://openshell-gateway.agents.svc:8080"
+ssh_socket_path                = "/run/openshell/ssh.sock"
+client_tls_secret_name         = "openshell-client-tls"
+host_gateway_ip                = "10.0.0.1"
+enable_user_namespaces         = false
+workspace_default_storage_size = "10Gi"
+# Kubelet clamps projected tokens below 600 seconds. The driver caps values at 86400.
+sa_token_ttl_secs              = 3600
 ```
 
 ### Docker
@@ -167,19 +191,24 @@ bind_address    = "127.0.0.1:17670"
 log_level       = "info"
 compute_drivers = ["docker"]
 
-supervisor_image = "ghcr.io/nvidia/openshell/supervisor:latest"
-guest_tls_ca     = "/etc/openshell/certs/ca.pem"
-guest_tls_cert   = "/etc/openshell/certs/client.pem"
-guest_tls_key    = "/etc/openshell/certs/client-key.pem"
-
 [openshell.drivers.docker]
-default_image    = "ghcr.io/nvidia/openshell/sandbox:latest"
-image_pull_policy = "IfNotPresent"
-sandbox_namespace = "docker-dev"
-grpc_endpoint    = "https://host.openshell.internal:17670"
-network_name     = "openshell-docker"
+default_image      = "ghcr.io/nvidia/openshell/sandbox:latest"
+# Docker vocabulary: Always | IfNotPresent | Never. Empty behaves like IfNotPresent.
+image_pull_policy  = "IfNotPresent"
+sandbox_namespace  = "docker-dev"
+# Empty auto-detects https://host.openshell.internal:<gateway-port> when guest TLS is set.
+grpc_endpoint      = "https://host.openshell.internal:17670"
 # Skip the image-pull-and-extract step by pointing at a locally built binary.
-supervisor_bin   = "/usr/local/libexec/openshell/openshell-sandbox"
+supervisor_bin     = "/usr/local/libexec/openshell/openshell-sandbox"
+supervisor_image   = "ghcr.io/nvidia/openshell/supervisor:latest"
+guest_tls_ca       = "/etc/openshell/certs/ca.pem"
+guest_tls_cert     = "/etc/openshell/certs/client.pem"
+guest_tls_key      = "/etc/openshell/certs/client-key.pem"
+network_name       = "openshell-docker"
+host_gateway_ip    = "172.17.0.1"
+ssh_socket_path    = "/run/openshell/ssh.sock"
+# Set to 0 to leave Docker's runtime default unchanged.
+sandbox_pids_limit = 2048
 ```
 
 ### Podman
@@ -195,18 +224,23 @@ bind_address    = "127.0.0.1:17670"
 log_level       = "info"
 compute_drivers = ["podman"]
 
-default_image     = "ghcr.io/nvidia/openshell/sandbox:latest"
-supervisor_image  = "ghcr.io/nvidia/openshell/supervisor:latest"
-guest_tls_ca      = "/etc/openshell/certs/ca.pem"
-guest_tls_cert    = "/etc/openshell/certs/client.pem"
-guest_tls_key     = "/etc/openshell/certs/client-key.pem"
-
 [openshell.drivers.podman]
 # Rootless socket path. For root Podman use /run/podman/podman.sock.
-socket_path       = "/run/user/1000/podman/podman.sock"
-network_name      = "openshell"
-stop_timeout_secs = 10
-image_pull_policy = "missing"   # Podman vocabulary: always | missing | never | newer
+socket_path             = "/run/user/1000/podman/podman.sock"
+default_image           = "ghcr.io/nvidia/openshell/sandbox:latest"
+image_pull_policy       = "missing"   # always | missing | never | newer
+grpc_endpoint           = "https://host.containers.internal:17670"
+# The gateway overwrites gateway_port from bind_address at runtime.
+gateway_port            = 17670
+network_name            = "openshell"
+sandbox_ssh_socket_path = "/run/openshell/ssh.sock"
+stop_timeout_secs       = 10
+supervisor_image        = "ghcr.io/nvidia/openshell/supervisor:latest"
+guest_tls_ca            = "/etc/openshell/certs/ca.pem"
+guest_tls_cert          = "/etc/openshell/certs/client.pem"
+guest_tls_key           = "/etc/openshell/certs/client-key.pem"
+# Set to 0 to leave Podman's runtime default unchanged.
+sandbox_pids_limit      = 2048
 ```
 
 ### MicroVM
@@ -223,17 +257,19 @@ log_level       = "info"
 # VM is never auto-detected; an explicit entry here is required.
 compute_drivers = ["vm"]
 
-default_image  = "ghcr.io/nvidia/openshell/sandbox:latest"
-guest_tls_ca   = "/var/lib/openshell/guest-tls/ca.pem"
-guest_tls_cert = "/var/lib/openshell/guest-tls/client.pem"
-guest_tls_key  = "/var/lib/openshell/guest-tls/client-key.pem"
-
 [openshell.drivers.vm]
-grpc_endpoint = "https://host.containers.internal:17670"
-state_dir      = "/var/lib/openshell/vm"
+state_dir        = "/var/lib/openshell/vm"
 # Where the gateway looks for the openshell-driver-vm subprocess binary.
-driver_dir     = "/usr/local/libexec/openshell"
-vcpus          = 2
-mem_mib        = 2048
-krun_log_level = 1
+driver_dir       = "/usr/local/libexec/openshell"
+default_image    = "ghcr.io/nvidia/openshell/sandbox:latest"
+grpc_endpoint    = "https://host.containers.internal:17670"
+# Empty falls back to default_image.
+bootstrap_image  = "ghcr.io/nvidia/openshell/sandbox:latest"
+krun_log_level   = 1
+vcpus            = 2
+mem_mib          = 2048
+overlay_disk_mib = 4096
+guest_tls_ca     = "/var/lib/openshell/guest-tls/ca.pem"
+guest_tls_cert   = "/var/lib/openshell/guest-tls/client.pem"
+guest_tls_key    = "/var/lib/openshell/guest-tls/client-key.pem"
 ```

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -46,7 +46,7 @@ The gateway talks to the Docker daemon to create sandbox containers. Docker is a
 
 For maintainer-level implementation details, refer to the [Docker driver README](https://github.com/NVIDIA/OpenShell/blob/main/crates/openshell-driver-docker/README.md).
 
-Select Docker with `compute_drivers = ["docker"]` in `[openshell.gateway]`. Configure Docker driver values such as `grpc_endpoint`, `network_name`, `supervisor_bin`, `supervisor_image`, `image_pull_policy`, and `guest_tls_*` in `[openshell.drivers.docker]`.
+Select Docker with `compute_drivers = ["docker"]` in `[openshell.gateway]`. Configure Docker driver values such as `grpc_endpoint`, `network_name`, `supervisor_bin`, `supervisor_image`, `image_pull_policy`, `ssh_socket_path`, `sandbox_pids_limit`, and `guest_tls_*` in `[openshell.drivers.docker]`.
 
 For GPU-backed Docker sandboxes, configure Docker CDI before starting the gateway so OpenShell can detect the daemon capability.
 
@@ -58,7 +58,7 @@ The gateway talks to the Podman API socket. The Podman driver requires Podman 5.
 
 For maintainer-level implementation details, refer to the [Podman driver README](https://github.com/NVIDIA/OpenShell/blob/main/crates/openshell-driver-podman/README.md) and [Podman networking notes](https://github.com/NVIDIA/OpenShell/blob/main/crates/openshell-driver-podman/NETWORKING.md).
 
-Select Podman with `compute_drivers = ["podman"]` in `[openshell.gateway]`. Configure Podman driver values such as `socket_path`, `network_name`, `supervisor_image`, `stop_timeout_secs`, `image_pull_policy`, `grpc_endpoint`, and `guest_tls_*` in `[openshell.drivers.podman]`.
+Select Podman with `compute_drivers = ["podman"]` in `[openshell.gateway]`. Configure Podman driver values such as `socket_path`, `network_name`, `supervisor_image`, `stop_timeout_secs`, `image_pull_policy`, `grpc_endpoint`, `sandbox_ssh_socket_path`, `sandbox_pids_limit`, and `guest_tls_*` in `[openshell.drivers.podman]`.
 
 ## MicroVM Driver
 
@@ -122,7 +122,11 @@ For maintainer-level implementation details, refer to the [Kubernetes driver REA
 | `image_pull_policy` | `server.sandboxImagePullPolicy` | Set the Kubernetes image pull policy for sandbox pods. |
 | `grpc_endpoint` | `server.grpcEndpoint` | Set the gateway callback endpoint reachable from sandbox pods. |
 | `client_tls_secret_name` | `server.tls.clientTlsSecretName` | Mount sandbox client TLS materials from a Kubernetes secret. |
+| `supervisor_image` | `supervisor.image.repository` / `supervisor.image.tag` | Set the supervisor image that provides the `openshell-sandbox` binary. |
+| `supervisor_image_pull_policy` | `supervisor.image.pullPolicy` | Set the Kubernetes image pull policy for the supervisor image. |
 | `supervisor_sideload_method` | `supervisor.sideloadMethod` | How the supervisor binary is delivered into sandbox pods. Leave empty to auto-detect from cluster version. Set to `image-volume` to mount the supervisor OCI image directly as a volume (requires Kubernetes 1.33+ with the ImageVolume feature gate; GA in 1.36), or `init-container` to copy it through an init container on older clusters. |
+| `workspace_default_storage_size` | `server.workspaceDefaultStorageSize` | Set the default workspace PVC size for new sandboxes. |
+| `sa_token_ttl_secs` | `server.sandboxJwt.k8sSaTokenTtlSecs` | Set the projected ServiceAccount token TTL used for the bootstrap token exchange. |
 
 The Kubernetes driver creates namespaced `agents.x-k8s.io/v1alpha1` `Sandbox` resources from the Kubernetes SIG Apps [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) project. The Agent Sandbox controller turns those resources into sandbox pods and related storage.
 


### PR DESCRIPTION
## Summary

Update the gateway configuration reference so the examples are the authoritative schema surface for gateway and driver-specific TOML options.

## Related Issue

None.

## Changes

- Expanded `docs/reference/gateway-config.mdx` with complete, copyable gateway and per-driver examples covering the latest driver-specific config options.
- Updated `docs/reference/sandbox-compute-drivers.mdx` with newer Docker, Podman, and Kubernetes config references.
- Added agent-skill and contributor guardrails so gateway TOML and driver config changes require updating the gateway config reference.

## Testing

- [ ] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

Validation run:

- `uv run python -c ...` parsed all TOML snippets in `docs/reference/gateway-config.mdx`.
- `mise run markdown:lint:md` passes.
- `mise run docs` passes with 0 errors and 2 Fern warnings not printed by default.
- `mise run pre-commit` was attempted, but `rust:lint` fails on an existing unused import in untouched `crates/openshell-sandbox/src/process.rs` (`use tracing::{debug, warn};`).

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
