### PR TITLE
fix(helm): vendor chart dependencies before release packaging

### DIFF
--- a/.github/actions/release-helm-oci/action.yml
+++ b/.github/actions/release-helm-oci/action.yml
@@ -71,6 +71,14 @@ runs:
           exit 1
         fi
 
+    - name: Build chart dependencies
+      env:
+        CHART_DIR: ${{ steps.prep.outputs.chart_dir }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        helm dependency build "${CHART_DIR}"
+
     - name: Package Helm chart
       env:
         CHART_DIR: ${{ steps.prep.outputs.chart_dir }}


### PR DESCRIPTION
## Summary

Fix the Helm OCI release packaging path that failed in https://github.com/NVIDIA/OpenShell/actions/runs/26617316250/job/78436974753. The release action now vendors chart dependencies in the staged chart before running helm package, so the PostgreSQL subchart is included without committing generated chart artifacts.

## Related Issue

References pipeline failure: https://github.com/NVIDIA/OpenShell/actions/runs/26617316250/job/78436974753

## Changes

- Added a Build chart dependencies step to the reusable Helm OCI release action.
- Run helm dependency build against the temporary staged chart before dev, public, and SHA-pinned chart packaging.

## Testing

- [x] helm dependency build + helm package against a temporary chart copy
- [x] helm lint against the staged chart
- [x] mise run pre-commit passes
- [ ] Unit tests added/updated (not applicable)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
