### PR TITLE
fix(ci): add /root/.local/bin to rootless e2e PATH so mise is found

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -89,6 +89,10 @@ jobs:
           chown openshell-test: "/run/user/$(id -u openshell-test)"
           chmod 700 "/run/user/$(id -u openshell-test)"
           chown -R openshell-test: .
+          # Root's home is mode 0700, so the rootless user cannot traverse it
+          # to reach mise (/root/.local/bin) or cargo (/root/.cargo/bin) on
+          # PATH. Add the search bit so those binaries are reachable.
+          chmod a+x /root
           for dir in /root/.cargo /root/.rustup /root/.local/bin /root/.local/share/mise /opt/mise; do
             [ -d "$dir" ] && chmod -R a+rX "$dir"
           done

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -89,7 +89,7 @@ jobs:
           chown openshell-test: "/run/user/$(id -u openshell-test)"
           chmod 700 "/run/user/$(id -u openshell-test)"
           chown -R openshell-test: .
-          for dir in /root/.cargo /root/.rustup /root/.local/share/mise /opt/mise; do
+          for dir in /root/.cargo /root/.rustup /root/.local/bin /root/.local/share/mise /opt/mise; do
             [ -d "$dir" ] && chmod -R a+rX "$dir"
           done
 
@@ -107,7 +107,7 @@ jobs:
             runuser -u openshell-test -- env \
               XDG_RUNTIME_DIR="/run/user/${TESTUID}" \
               HOME="/home/openshell-test" \
-              PATH="/root/.cargo/bin:/opt/mise/shims:/opt/mise/bin:${PATH}" \
+              PATH="/root/.cargo/bin:/root/.local/bin:/opt/mise/shims:/opt/mise/bin:${PATH}" \
               CARGO_HOME="/root/.cargo" \
               RUSTUP_HOME="/root/.rustup" \
               OPENSHELL_SUPERVISOR_IMAGE="${OPENSHELL_SUPERVISOR_IMAGE}" \

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -114,6 +114,7 @@ jobs:
               PATH="/root/.cargo/bin:/root/.local/bin:/opt/mise/shims:/opt/mise/bin:${PATH}" \
               CARGO_HOME="/root/.cargo" \
               RUSTUP_HOME="/root/.rustup" \
+              MISE_CACHE_DIR="/home/openshell-test/.cache/mise" \
               OPENSHELL_SUPERVISOR_IMAGE="${OPENSHELL_SUPERVISOR_IMAGE}" \
               OPENSHELL_REGISTRY="${OPENSHELL_REGISTRY}" \
               OPENSHELL_REGISTRY_HOST="${OPENSHELL_REGISTRY_HOST}" \


### PR DESCRIPTION
## Summary
The `rust-podman-rootless` E2E suite (added in #1623) fails on every run. When the suite drops to the `openshell-test` user via `runuser`, three compounding problems prevent the run from getting past `mise`:

1. **mise not on PATH.** The rebuilt `PATH` omitted `/root/.local/bin`, where the `mise` binary is installed by `curl https://mise.run` (see `deploy/docker/Dockerfile.ci`). `/opt/mise/shims` only holds tool shims, not the `mise` executable. → `mise: command not found` (127).
2. **`/root` not traversable.** Root's home is mode `0700`, so the non-root user cannot *search* into it to reach `/root/.local/bin/mise` or `/root/.cargo/bin`. Bash silently skips unsearchable `PATH` dirs, so this also surfaced as 127 (not 126).
3. **mise cache not writable.** The image sets `MISE_CACHE_DIR=/opt/mise/cache` (root-owned). The rootless user inherits it but only has read/exec (`a+rX`), not write. `mise run` must write tool bin-path caches (`/opt/mise/cache/<tool>/.../bin_paths-*.msgpack`) and task lock files (`/opt/mise/cache/lockfiles/*`) even with `--skip-deps`. → `Permission denied (os error 13)` at `src/lock_file.rs:37`.

(Config trust is not an issue in CI: the container sets `CI=true`, which makes mise auto-trust the repo config.)

## Related Issue
Regression introduced by #1623 (which added the rootless suite). No tracking issue; fixing directly.

## Changes
- Add `/root/.local/bin` to the `PATH` override passed to `runuser` so the `mise` binary is discoverable, and to the `chmod -R a+rX` loop for consistency.
- Add `chmod a+x /root` to the rootless setup step so the `openshell-test` user can traverse root's home (0700 → 0711, search bit only, no read) to reach the already-755 `/root/.local/bin` and `/root/.cargo/bin` subtrees.
- Override `MISE_CACHE_DIR` to the rootless user's home (`/home/openshell-test/.cache/mise`) so mise has a writable cache, keeping the shared `/opt/mise` tool data dir read-only. The state dir already defaults to the user's home; `MISE_DATA_DIR` stays inherited so the prebuilt toolchain is reused.

## Why this is safe and doesn't undermine the test
- **Test integrity:** This suite validates rootless Podman networking end-to-end (pasta, user-namespace isolation, subuid/subgid, the driver detecting rootless mode). None of that depends on `/root` perms or the mise cache location, so the changes neither mask a real rootless bug nor create a false pass.
- **Security:** `chmod a+x /root` adds only the *search* bit (`0711`), not read. The shared `/opt/mise` stays read-only — the rootless user writes mise cache/state only inside its own home. This runs in an ephemeral, already `--privileged` CI container built from a tooling image with no secrets, torn down after the job.
- **Alternatives considered:** moving permission tweaks into `Dockerfile.ci` (touches the shared image), provisioning a dedicated rootless user/toolchain in the image (larger change, partial duplication), `chmod -R a+rwX /opt/mise` (broad write on the shared tool dir), or installing mise/rust as the rootless user at job time (re-installs the toolchain per run, defeating the prebuilt image). The scoped workflow changes were chosen as the lowest-risk fix confined to the one job that needs it.

## Testing
- [x] YAML syntax validated.
- [x] Reproduced and verified locally against the exact CI image digest (`ghcr.io/nvidia/openshell/ci:latest`, `sha256:ef52bb40…`), replicating the rootless setup, `runuser` env, `CI=true`, and the inherited `MISE_CACHE_DIR=/opt/mise/cache`:
  - `mise` resolves at `/root/.local/bin/mise`; `cargo` at `/root/.cargo/bin/cargo`.
  - No `Permission denied (os error 13)` and no trust error.
  - The task renders and runs through into `e2e/rust/e2e-podman-rootless.sh` (the actual test entrypoint).
- [ ] `mise run pre-commit` passes.
- [x] E2E tests added/updated (if applicable) — validated by this PR's own `rust-podman-rootless` job.

> Note: local repro validates everything up to the test script entrypoint. The script itself needs Podman rootless networking and the supervisor image, exercised only in CI — any failure beyond this point is genuine test behavior, separate from this PATH/traversal/cache regression.

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — N/A