### PR TITLE
fix(e2e): clean up temp files in sandbox-runner on exit

### DIFF
--- a/e2e/policy-advisor/sandbox-runner.sh
+++ b/e2e/policy-advisor/sandbox-runner.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+_td="$(mktemp -d)"
+trap 'rm -rf "$_td"' EXIT
+
 cmd="$1"
 shift
 
@@ -23,7 +26,7 @@ case "$cmd" in
         ;;
 
     current-policy)
-        body="$(mktemp)"
+        body="$_td/body"
         status="$(curl -sS -o "$body" -w "%{http_code}" http://policy.local/v1/policy/current)"
         json_status_response "$status" "$body"
         ;;
@@ -34,8 +37,8 @@ case "$cmd" in
         branch="$3"
         file_path="$4"
         run_id="$5"
-        body="$(mktemp)"
-        payload="$(mktemp)"
+        body="$_td/body"
+        payload="$_td/payload"
 
         python3 - "$branch" "$run_id" > "$payload" <<'PY'
 import base64
@@ -76,8 +79,8 @@ PY
         owner="$1"
         repo="$2"
         file_path="$3"
-        body="$(mktemp)"
-        payload="$(mktemp)"
+        body="$_td/body"
+        payload="$_td/payload"
 
         python3 - "$owner" "$repo" "$file_path" > "$payload" <<'PY'
 import json
@@ -140,8 +143,8 @@ PY
         # — we never make outbound calls, the gateway just persists the
         # chunk and the reviewer decides on it.
         rule_id="$1"
-        body="$(mktemp)"
-        payload="$(mktemp)"
+        body="$_td/body"
+        payload="$_td/payload"
 
         python3 - "$rule_id" > "$payload" <<'PY'
 import json
@@ -184,7 +187,7 @@ PY
 
     proposal-status)
         chunk_id="$1"
-        body="$(mktemp)"
+        body="$_td/body"
         status="$(curl -sS \
             -o "$body" \
             -w "%{http_code}" \
@@ -195,7 +198,7 @@ PY
     proposal-wait)
         chunk_id="$1"
         timeout="${2:-60}"
-        body="$(mktemp)"
+        body="$_td/body"
         # No --max-time on curl: the server bounds the wait at `timeout`,
         # which is already clamped to [1, 300] by policy.local. Let the
         # request return naturally.


### PR DESCRIPTION
`sandbox-runner.sh` used `mktemp` on every call but had no cleanup. 

Temp files leaked into `/tmp` for the lifetime of the sandbox.

`e2e/policy-advisor/sandbox-runner.sh`: one temp dir at startup, removed on exit via `trap`. 

All `mktemp` calls replaced with paths inside that dir.

Testing

- `bash -n`: syntax OK
- `shellcheck`: no warnings
- trap cleanup verified: dir removed after exit
- `mise run pre-commit`: all tests pass