### PR TITLE
feat(snap): switch to prebuilt binary model to avoid copying entire r…

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -654,7 +654,7 @@ jobs:
 
   build-snap:
     name: Build Snap
-    needs: [compute-versions]
+    needs: [compute-versions, build-cli-linux, build-gateway-binary-linux, build-supervisor-binary-linux]
     uses: ./.github/workflows/snap-package.yml
     with:
       checkout-ref: ${{ github.sha }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -690,7 +690,7 @@ jobs:
 
   build-snap:
     name: Build Snap
-    needs: [compute-versions]
+    needs: [compute-versions, build-cli-linux, build-gateway-binary-linux, build-supervisor-binary-linux]
     uses: ./.github/workflows/snap-package.yml
     with:
       checkout-ref: ${{ inputs.tag || github.ref }}

--- a/.github/workflows/snap-package.yml
+++ b/.github/workflows/snap-package.yml
@@ -76,6 +76,59 @@ jobs:
           set -euo pipefail
           sudo snap install snapcraft --classic
 
+      - name: Download prebuilt CLI binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b40e67214ff5f5447ce83dd # v8
+        with:
+          name: cli-linux-${{ matrix.arch }}
+          path: prebuilt/cli
+
+      - name: Download prebuilt gateway binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b40e67214ff5f5447ce83dd # v8
+        with:
+          name: gateway-binary-linux-${{ matrix.arch }}
+          path: prebuilt/gateway
+
+      - name: Download prebuilt sandbox binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b40e67214ff5f5447ce83dd # v8
+        with:
+          name: supervisor-binary-linux-${{ matrix.arch }}
+          path: prebuilt/sandbox
+
+      - name: Extract prebuilt binaries
+        run: |
+          set -euo pipefail
+          mkdir -p prebuilt/{cli,gateway,sandbox}
+
+          for d in cli gateway sandbox; do
+            for tarball in prebuilt/$d/*.tar.gz; do
+              if [ -f "$tarball" ]; then
+                tar -xzf "$tarball" -C "prebuilt/$d"
+              else
+                echo "WARNING: no tarball found in prebuilt/$d/" >&2
+              fi
+            done
+          done
+          ls -laR prebuilt/
+
+      - name: Prepare snap build directory
+        run: |
+          set -euo pipefail
+          mkdir -p snap/prebuilt
+
+          cp prebuilt/cli/openshell snap/prebuilt/openshell
+          cp prebuilt/gateway/openshell-gateway snap/prebuilt/openshell-gateway
+          cp prebuilt/sandbox/openshell-sandbox snap/prebuilt/openshell-sandbox
+
+          cp deploy/snap/bin/openshell-gateway-wrapper snap/prebuilt/
+          cp LICENSE snap/prebuilt/
+          cp README.md snap/prebuilt/
+
+          mkdir -p snap/prebuilt/meta/gui
+          cp snap/local/term.desktop snap/prebuilt/meta/gui/term.desktop
+          cp snap/local/icon.png snap/prebuilt/meta/gui/icon.png
+
+          python3 tasks/scripts/release.py get-version --snap > snap/prebuilt/version
+
       - name: Build snap
         run: |
           set -euo pipefail

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -69,43 +69,44 @@ apps:
 
 parts:
   openshell:
-    plugin: rust
-    rust-channel: "1.95.0"
-    source: .
-    build-packages:
-      - build-essential
-      - ca-certificates
-      - clang
-      - cmake
-      - git
-      - libclang-dev
-      - libssl-dev
-      - libz3-dev
-      - pkg-config
-      - python3
+    plugin: nil
+    source: ./snap/prebuilt
     override-pull: |
       craftctl default
-      craftctl set version="$(python3 "$CRAFT_PROJECT_DIR/tasks/scripts/release.py" get-version --snap)"
+      craftctl set version="$(cat "$CRAFT_PART_SRC/version")"
     override-build: |
       set -euo pipefail
 
-      cargo build --release --locked -p openshell-cli --features bundled-z3
-      cargo build --release --locked -p openshell-server --bin openshell-gateway --features bundled-z3
-      cargo build --release --locked -p openshell-sandbox --bin openshell-sandbox
+      MISSING=()
+      for bin in openshell openshell-gateway openshell-sandbox openshell-gateway-wrapper; do
+        if [ ! -f "$CRAFT_PART_SRC/$bin" ]; then
+          MISSING+=("$bin")
+        fi
+      done
 
-      install -D -m 0755 "$CRAFT_PART_BUILD/target/release/openshell" \
+      if [ ${#MISSING[@]} -gt 0 ]; then
+        printf '%s\n' \
+          "ERROR: snap/prebuilt/ is incomplete:" \
+          "${MISSING[@]/#/'  - '}" \
+          "" \
+          "The snap build directory must be populated by CI before snapcraft pack." \
+          >&2
+        exit 1
+      fi
+
+      install -D -m 0755 "$CRAFT_PART_SRC/openshell" \
         "$CRAFT_PART_INSTALL/bin/openshell"
-      install -D -m 0755 "$CRAFT_PART_BUILD/target/release/openshell-gateway" \
+      install -D -m 0755 "$CRAFT_PART_SRC/openshell-gateway" \
         "$CRAFT_PART_INSTALL/bin/openshell-gateway"
-      install -D -m 0755 "$CRAFT_PART_BUILD/target/release/openshell-sandbox" \
+      install -D -m 0755 "$CRAFT_PART_SRC/openshell-sandbox" \
         "$CRAFT_PART_INSTALL/bin/openshell-sandbox"
-      install -D -m 0755 "$CRAFT_PROJECT_DIR/tasks/scripts/snap-gateway-wrapper.sh" \
+      install -D -m 0755 "$CRAFT_PART_SRC/openshell-gateway-wrapper" \
         "$CRAFT_PART_INSTALL/bin/openshell-gateway-wrapper"
-      install -D -m 0644 "$CRAFT_PROJECT_DIR/snap/local/term.desktop" \
+      install -D -m 0644 "$CRAFT_PART_SRC/meta/gui/term.desktop" \
         "$CRAFT_PART_INSTALL/meta/gui/term.desktop"
-      install -D -m 0644 "$CRAFT_PROJECT_DIR/snap/local/icon.png" \
+      install -D -m 0644 "$CRAFT_PART_SRC/meta/gui/icon.png" \
         "$CRAFT_PART_INSTALL/meta/gui/icon.png"
-      install -D -m 0644 "$CRAFT_PROJECT_DIR/LICENSE" \
+      install -D -m 0644 "$CRAFT_PART_SRC/LICENSE" \
         "$CRAFT_PART_INSTALL/usr/share/doc/openshell/LICENSE"
-      install -D -m 0644 "$CRAFT_PROJECT_DIR/README.md" \
+      install -D -m 0644 "$CRAFT_PART_SRC/README.md" \
         "$CRAFT_PART_INSTALL/usr/share/doc/openshell/README.md"


### PR DESCRIPTION
## Summary
This PR changes the snapcraft build pipeline to reuse existing binaries built earlier in the pipeline.

## Related Issue
Closes #1361

## Changes
- Link the snap build job with earlier artifact producing jobs
- Download artifacts using action steps
- Switch snapcraft.yaml source: to a sub-directory snap/prebuilt to avoid snapcraft having to copy the huge targets/ directory during local builds

## Testing
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
