### PR TITLE
feat(tui): add PageUp/PageDown scrolling to all panes

### DIFF
--- a/crates/openshell-tui/src/app.rs
+++ b/crates/openshell-tui/src/app.rs
@@ -495,6 +495,8 @@ pub struct App {
     pub sandbox_providers_list: Vec<String>,
     pub policy_lines: Vec<ratatui::text::Line<'static>>,
     pub policy_scroll: usize,
+    /// Visible line count in the policy pane, set during draw for PageUp/PageDown.
+    pub policy_viewport_height: usize,
 
     // Create sandbox modal
     pub create_form: Option<CreateSandboxForm>,
@@ -656,6 +658,7 @@ impl App {
             sandbox_providers_list: Vec::new(),
             policy_lines: Vec::new(),
             policy_scroll: 0,
+            policy_viewport_height: 0,
             create_form: None,
             pending_create_sandbox: false,
             pending_forward_ports: Vec::new(),
@@ -1155,9 +1158,21 @@ impl App {
             KeyCode::Char('k') | KeyCode::Up => {
                 self.scroll_policy(-1);
             }
+            // Page-scroll by one viewport height.
+            KeyCode::PageDown => {
+                let delta = self.policy_viewport_height.max(1) as isize;
+                self.scroll_policy(delta);
+            }
+            KeyCode::PageUp => {
+                let delta = self.policy_viewport_height.max(1) as isize;
+                self.scroll_policy(-delta);
+            }
             KeyCode::Char('G') => {
-                // Scroll to bottom.
-                self.policy_scroll = self.policy_lines.len().saturating_sub(1);
+                // Scroll to bottom, keeping a full viewport visible.
+                self.policy_scroll = self
+                    .policy_lines
+                    .len()
+                    .saturating_sub(self.policy_viewport_height.max(1));
             }
             KeyCode::Char('g') => {
                 self.policy_scroll = 0;
@@ -1426,6 +1441,21 @@ impl App {
                     self.draft_scroll -= 1;
                 }
             }
+            // Page-scroll by one viewport height, clamping the cursor to
+            // stay within the visible range.
+            KeyCode::PageDown if total > 0 => {
+                let page = vh.max(1);
+                let max_scroll = total.saturating_sub(vh.min(total));
+                self.draft_scroll = (self.draft_scroll + page).min(max_scroll);
+                let visible = total.saturating_sub(self.draft_scroll).min(vh);
+                self.draft_selected = self.draft_selected.min(visible.saturating_sub(1));
+            }
+            KeyCode::PageUp => {
+                let page = vh.max(1);
+                self.draft_scroll = self.draft_scroll.saturating_sub(page);
+                let visible = total.saturating_sub(self.draft_scroll).min(vh);
+                self.draft_selected = self.draft_selected.min(visible.saturating_sub(1));
+            }
             KeyCode::Char('g') => {
                 self.draft_scroll = 0;
                 self.draft_selected = 0;
@@ -1490,8 +1520,11 @@ impl App {
     }
 
     /// Scroll policy pane by a delta (positive = down, negative = up).
+    ///
+    /// Clamps so at least one viewport of content remains visible.
     pub fn scroll_policy(&mut self, delta: isize) {
-        let max = self.policy_lines.len().saturating_sub(1);
+        let total = self.policy_lines.len();
+        let max = total.saturating_sub(self.policy_viewport_height.max(1));
         if delta < 0 {
             self.policy_scroll = self.policy_scroll.saturating_sub(delta.unsigned_abs());
         } else {
@@ -1607,6 +1640,15 @@ impl App {
                     self.sandbox_log_scroll -= 1;
                 }
                 self.log_autoscroll = false;
+            }
+            // Page-scroll by one viewport height.
+            KeyCode::PageDown => {
+                let delta = vh.max(1) as isize;
+                self.scroll_logs(delta);
+            }
+            KeyCode::PageUp => {
+                let delta = vh.max(1) as isize;
+                self.scroll_logs(-delta);
             }
             KeyCode::Char('G' | 'f') => {
                 self.log_selection_anchor = None;

--- a/crates/openshell-tui/src/ui/sandbox_policy.rs
+++ b/crates/openshell-tui/src/ui/sandbox_policy.rs
@@ -11,15 +11,17 @@ use crate::app::App;
 /// Draw the scrollable policy viewer pane (bottom ~80% of the sandbox screen).
 ///
 /// Always focused when visible (the metadata pane above is non-interactive).
-pub fn draw(frame: &mut Frame<'_>, app: &App, area: Rect) {
+pub fn draw(frame: &mut Frame<'_>, app: &mut App, area: Rect) {
+    // Calculate inner dimensions (borders + padding) and store the viewport
+    // height so PageUp/PageDown key handlers know how far to scroll.
+    let inner_height = area.height.saturating_sub(2) as usize;
+    app.policy_viewport_height = inner_height;
+
     let t = &app.theme;
     let version = app.sandbox_policy.as_ref().map_or(0, |p| p.version);
 
     let tab_title = super::sandbox_settings::draw_policy_tab_title(app);
     let version_hint = format!(" (v{version}) ");
-
-    // Calculate inner dimensions (borders + padding).
-    let inner_height = area.height.saturating_sub(2) as usize;
 
     if app.policy_lines.is_empty() {
         let lines = vec![Line::from(Span::styled("Loading...", t.muted))];


### PR DESCRIPTION
## Summary

Add PageUp/PageDown key support to the policy, logs, and draft/rules views in `openshell term`. All three scrollable panes now scroll by one viewport height per keypress, matching standard terminal conventions.

Also fixes a pre-existing scroll clamping bug where pressing `G` (go to bottom) or scrolling past the end would overshoot into a blank screen.

## Related Issue

N/A (user-reported usability gap, no tracking issue)

## Changes

- Add `policy_viewport_height` field to `App`, set during draw (matching the existing pattern used by logs and draft panes)
- Handle `KeyCode::PageDown` / `KeyCode::PageUp` in `handle_policy_key()`, `handle_logs_key()`, and `handle_draft_key()`
- Fix `scroll_policy()` max clamp to use viewport-aware bound (`total - viewport`) instead of `total - 1`
- Fix `G` keybinding in policy view to use the same viewport-aware clamping
- Change `sandbox_policy::draw()` signature from `&App` to `&mut App` to allow storing viewport height

## Testing

- [x] Built with `cargo build --release -p openshell-cli`
- [x] Manual testing: verified PageUp/PageDown in policy view with 90+ rules
- [x] Verified no blank-screen overshoot on PageDown at end of content
- [x] LSP diagnostics clean on all changed files
- [ ] `mise run pre-commit` passes

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)