### PR TITLE
refactor: deduplicate shared utilities across driver crates

### DIFF
--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -39,6 +39,11 @@ pub const DEFAULT_SUPERVISOR_IMAGE: &str = "ghcr.io/nvidia/openshell/supervisor:
 /// CDI device identifier for requesting all NVIDIA GPUs.
 pub const CDI_GPU_DEVICE_ALL: &str = "nvidia.com/gpu=all";
 
+/// Default maximum number of processes (PIDs) allowed inside a sandbox container.
+///
+/// Shared by the Docker and Podman drivers; override via driver config.
+pub const DEFAULT_SANDBOX_PIDS_LIMIT: i64 = 2048;
+
 /// Compute backends the gateway can orchestrate sandboxes through.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/openshell-core/src/progress.rs
+++ b/crates/openshell-core/src/progress.rs
@@ -37,3 +37,24 @@ pub fn mark_progress_detail<S: BuildHasher>(
 ) {
     metadata.insert(PROGRESS_ACTIVE_DETAIL_KEY.to_string(), detail.into());
 }
+
+/// Format a byte count as a human-readable string (B / KB / MB / GB).
+///
+/// Used by compute drivers when reporting image pull progress.
+pub fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * KB;
+    const GB: u64 = 1024 * MB;
+
+    if bytes >= GB {
+        #[allow(clippy::cast_precision_loss)]
+        let gb = bytes as f64 / GB as f64;
+        format!("{gb:.1} GB")
+    } else if bytes >= MB {
+        format!("{} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("{} KB", bytes / KB)
+    } else {
+        format!("{bytes} B")
+    }
+}

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -18,7 +18,9 @@ use bollard::query_parameters::{
 };
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-use openshell_core::config::{DEFAULT_DOCKER_NETWORK_NAME, DEFAULT_STOP_TIMEOUT_SECS};
+use openshell_core::config::{
+    DEFAULT_DOCKER_NETWORK_NAME, DEFAULT_SANDBOX_PIDS_LIMIT, DEFAULT_STOP_TIMEOUT_SECS,
+};
 use openshell_core::driver_utils::{
     LABEL_MANAGED_BY, LABEL_MANAGED_BY_VALUE, LABEL_SANDBOX_ID, LABEL_SANDBOX_NAME,
     LABEL_SANDBOX_NAMESPACE, SUPERVISOR_IMAGE_BINARY_PATH,
@@ -26,7 +28,7 @@ use openshell_core::driver_utils::{
 use openshell_core::gpu::cdi_gpu_device_ids;
 use openshell_core::progress::{
     PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX, PROGRESS_STEP_STARTING_SANDBOX,
-    mark_progress_active, mark_progress_complete, mark_progress_detail,
+    format_bytes, mark_progress_active, mark_progress_complete, mark_progress_detail,
 };
 use openshell_core::proto::compute::v1::{
     CreateSandboxRequest, CreateSandboxResponse, DeleteSandboxRequest, DeleteSandboxResponse,
@@ -67,7 +69,6 @@ const SUPERVISOR_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 const HOST_OPENSHELL_INTERNAL: &str = "host.openshell.internal";
 const HOST_DOCKER_INTERNAL: &str = "host.docker.internal";
 const DOCKER_NETWORK_DRIVER: &str = "bridge";
-const DEFAULT_SANDBOX_PIDS_LIMIT: i64 = 2048;
 
 /// Default image holding the Linux `openshell-sandbox` binary. The gateway
 /// pulls this image and extracts the binary to a host-side cache when no
@@ -1443,24 +1444,6 @@ fn format_progress_detail(progress: &ProgressDetail) -> Option<String> {
         }
         (Some(current), _) if current > 0 => Some(format_bytes(current)),
         _ => None,
-    }
-}
-
-fn format_bytes(bytes: u64) -> String {
-    const KB: u64 = 1024;
-    const MB: u64 = 1024 * KB;
-    const GB: u64 = 1024 * MB;
-
-    if bytes >= GB {
-        #[allow(clippy::cast_precision_loss)]
-        let gb = bytes as f64 / GB as f64;
-        format!("{gb:.1} GB")
-    } else if bytes >= MB {
-        format!("{} MB", bytes / MB)
-    } else if bytes >= KB {
-        format!("{} KB", bytes / KB)
-    } else {
-        format!("{bytes} B")
     }
 }
 

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -19,7 +19,7 @@ use openshell_core::driver_utils::{
 };
 use openshell_core::progress::{
     PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX, PROGRESS_STEP_STARTING_SANDBOX,
-    mark_progress_active, mark_progress_complete, mark_progress_detail,
+    format_bytes, mark_progress_active, mark_progress_complete, mark_progress_detail,
 };
 use openshell_core::proto::compute::v1::{
     DriverCondition as SandboxCondition, DriverPlatformEvent as PlatformEvent,
@@ -722,24 +722,6 @@ fn extract_image_size(message: &str) -> Option<u64> {
     let rest = &message[start..];
     let end = rest.find(' ')?;
     rest[..end].parse().ok()
-}
-
-fn format_bytes(bytes: u64) -> String {
-    const KB: u64 = 1024;
-    const MB: u64 = 1024 * KB;
-    const GB: u64 = 1024 * MB;
-
-    if bytes >= GB {
-        #[allow(clippy::cast_precision_loss)]
-        let gb = bytes as f64 / GB as f64;
-        format!("{gb:.1} GB")
-    } else if bytes >= MB {
-        format!("{} MB", bytes / MB)
-    } else if bytes >= KB {
-        format!("{} KB", bytes / KB)
-    } else {
-        format!("{bytes} B")
-    }
 }
 
 /// Path where the supervisor binary is mounted inside the agent container.

--- a/crates/openshell-driver-podman/src/config.rs
+++ b/crates/openshell-driver-podman/src/config.rs
@@ -8,8 +8,10 @@ use std::str::FromStr;
 
 /// Default Podman bridge network name.
 pub const DEFAULT_NETWORK_NAME: &str = "openshell";
-pub const DEFAULT_SANDBOX_PIDS_LIMIT: i64 = 2048;
 pub const MACOS_PODMAN_MACHINE_HOST_GATEWAY_IP: &str = "192.168.127.254";
+
+// Re-export the shared default so existing imports inside this crate keep working.
+pub use openshell_core::config::DEFAULT_SANDBOX_PIDS_LIMIT;
 
 /// Image pull policy for sandbox and supervisor images.
 ///

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -26,7 +26,7 @@ use oci_client::secrets::RegistryAuth;
 use oci_client::{Reference, RegistryOperation};
 use openshell_core::progress::{
     PROGRESS_STEP_PULLING_IMAGE, PROGRESS_STEP_REQUESTING_SANDBOX, PROGRESS_STEP_STARTING_SANDBOX,
-    mark_progress_active, mark_progress_complete, mark_progress_detail,
+    format_bytes, mark_progress_active, mark_progress_complete, mark_progress_detail,
 };
 use openshell_core::proto::compute::v1::{
     CreateSandboxRequest, CreateSandboxResponse, DeleteSandboxRequest, DeleteSandboxResponse,
@@ -4404,24 +4404,6 @@ fn pulling_layer_detail(metadata: &HashMap<String, String>) -> Option<String> {
         || format!("Layer {index}/{total}"),
         |size| format!("Layer {index}/{total} ({size})"),
     ))
-}
-
-fn format_bytes(bytes: u64) -> String {
-    const KB: u64 = 1024;
-    const MB: u64 = 1024 * KB;
-    const GB: u64 = 1024 * MB;
-
-    if bytes >= GB {
-        #[allow(clippy::cast_precision_loss)]
-        let gb = bytes as f64 / GB as f64;
-        format!("{gb:.1} GB")
-    } else if bytes >= MB {
-        format!("{} MB", bytes / MB)
-    } else if bytes >= KB {
-        format!("{} KB", bytes / KB)
-    } else {
-        format!("{bytes} B")
-    }
 }
 
 #[cfg(test)]

--- a/crates/openshell-sandbox/src/secrets.rs
+++ b/crates/openshell-sandbox/src/secrets.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use base64::Engine as _;
+use openshell_core::time::now_ms;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -24,13 +25,6 @@ fn is_alias_token_char(b: u8) -> bool {
 
 fn contains_raw_reserved_marker(value: &str) -> bool {
     value.contains(PLACEHOLDER_PREFIX) || value.contains(PROVIDER_ALIAS_MARKER)
-}
-
-fn current_time_ms() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| i64::try_from(duration.as_millis()).unwrap_or(i64::MAX))
-        .unwrap_or_default()
 }
 
 pub fn contains_reserved_credential_marker(value: &str) -> bool {
@@ -225,7 +219,7 @@ impl SecretResolver {
             let canonical = placeholder_for_env_key(key);
             self.by_placeholder.get(&canonical)?
         };
-        if secret.expires_at_ms > 0 && secret.expires_at_ms <= current_time_ms() {
+        if secret.expires_at_ms > 0 && secret.expires_at_ms <= now_ms() {
             tracing::warn!(
                 location = "resolve_placeholder",
                 "credential resolution rejected: credential is expired"


### PR DESCRIPTION
## Summary

Remove three sets of duplicated code by consolidating definitions into \`openshell-core\` where all consumers already have a dependency.

## Related Issue

N/A — housekeeping refactor.

## Changes

- **\`format_bytes\`** — identical 14-line byte-formatting function existed independently in the Docker, Kubernetes, and VM drivers. Moved to \`openshell-core::progress\` (where all three already imported other symbols) and removed the three local copies.
- **\`DEFAULT_SANDBOX_PIDS_LIMIT\`** — the \`i64\` constant \`2048\` was defined separately in the Docker driver and Podman config. Moved to \`openshell-core::config\` alongside the other shared defaults (\`DEFAULT_STOP_TIMEOUT_SECS\`, etc.). Podman re-exports it via \`pub use\` so existing intra-crate call sites continue to compile without changes.
- **\`current_time_ms\`** — \`openshell-sandbox::secrets\` reimplemented the same logic already provided by \`openshell-core::time::now_ms()\`. Removed the local copy and called \`now_ms()\` directly.

Net: −31 lines, 0 behaviour change.

## Testing

- [x] \`cargo build --workspace\` passes
- [x] \`cargo test --workspace --exclude openshell-server\` — all tests pass (797 unit tests across the workspace)
- [ ] E2E tests added/updated (not applicable — no behaviour change)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)