### PR TITLE
fix(gateway): place supervisor_image under podman driver TOML table

### DIFF
--- a/tasks/scripts/gateway.sh
+++ b/tasks/scripts/gateway.sh
@@ -336,9 +336,9 @@ EOF
     ;;
   podman)
     cat >>"${CONFIG_PATH}" <<EOF
-supervisor_image = "${OPENSHELL_SUPERVISOR_IMAGE}"
 
 [openshell.drivers.podman]
+supervisor_image = "${OPENSHELL_SUPERVISOR_IMAGE}"
 image_pull_policy = "$(podman_pull_policy "${SANDBOX_IMAGE_PULL_POLICY}")"
 EOF
     if [[ -n "${GRPC_ENDPOINT}" ]]; then


### PR DESCRIPTION
The `mise run gateway` script placed `supervisor_image` after the `[openshell.gateway.gateway_jwt]` table header in the generated TOML config. TOML parsed it as a `gateway_jwt` field, so the Podman driver never saw the override and silently fell back to `ghcr.io/nvidia/openshell/supervisor:latest`.
Move `supervisor_image` into `[openshell.drivers.podman]` where the driver config deserializer expects it.
- Move `supervisor_image` line from after `gateway_jwt` section into the `[openshell.drivers.podman]` table in `tasks/scripts/gateway.sh`
- [x] Verified on macOS with Podman: before fix, `podman inspect` showed `ghcr.io/nvidia/openshell/supervisor:latest`; after fix, shows `openshell/supervisor:dev`
- [x] Created sandbox successfully with the locally built supervisor image
- [x] Follows Conventional Commits