### PR TITLE
fix(config): reject unknown fields in nested gateway config tables

### DIFF
--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -167,22 +167,25 @@ fn is_unix_socket(path: &Path) -> bool {
 }
 
 /// Server configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Built programmatically in [`crate::Config::new`] and the gateway CLI from
+/// the parsed config file, env vars, and CLI flags. It is never deserialized
+/// directly; the on-disk config schema lives in the gateway's `config_file`
+/// module ([`crate::TlsConfig`] and the other nested tables carry their own
+/// `Deserialize` impls for that purpose).
+#[derive(Debug, Clone)]
 pub struct Config {
     /// Address to bind the server to.
-    #[serde(default = "default_bind_address")]
     pub bind_address: SocketAddr,
 
     /// Address to bind the unauthenticated health endpoint to.
     ///
     /// When `None`, the dedicated health listener is disabled.
-    #[serde(default)]
     pub health_bind_address: Option<SocketAddr>,
 
     /// Address to bind the Prometheus metrics endpoint to.
     ///
     /// When `None`, the dedicated metrics listener is disabled.
-    #[serde(default)]
     pub metrics_bind_address: Option<SocketAddr>,
 
     /// Additional bind addresses that serve the same multiplexed gRPC/HTTP
@@ -191,36 +194,30 @@ pub struct Config {
     /// Compute drivers may register extra listeners during startup so that
     /// sandbox workloads can call back into the gateway over an interface
     /// that the operator-supplied `bind_address` does not expose.
-    #[serde(default)]
     pub extra_bind_addresses: Vec<SocketAddr>,
 
     /// Log level (trace, debug, info, warn, error).
-    #[serde(default = "default_log_level")]
     pub log_level: String,
 
     /// TLS configuration.  When `None`, the server listens on plaintext HTTP.
     pub tls: Option<TlsConfig>,
 
     /// OIDC configuration. When `Some`, the server validates Bearer JWTs.
-    #[serde(default)]
     pub oidc: Option<OidcConfig>,
 
     /// Gateway user authentication behavior.
-    #[serde(default)]
     pub auth: GatewayAuthConfig,
 
     /// mTLS user authentication configuration. When enabled, a verified TLS
     /// client certificate can authenticate CLI/SDK callers as a
     /// `Principal::User`. This is for local single-user gateways only;
     /// sandbox identity is always carried by gateway-minted sandbox JWTs.
-    #[serde(default)]
     pub mtls_auth: MtlsAuthConfig,
 
     /// Gateway-minted sandbox JWT configuration. When `Some`, the gateway
     /// loads the signing key from disk and accepts gateway-issued sandbox
     /// JWTs as `Principal::Sandbox`. Required for the per-sandbox identity
     /// flow (issue #1354).
-    #[serde(default)]
     pub gateway_jwt: Option<GatewayJwtConfig>,
 
     /// Database URL for persistence.
@@ -231,29 +228,26 @@ pub struct Config {
     /// The config shape allows multiple drivers so the gateway can evolve
     /// toward multi-backend routing. Current releases require exactly one
     /// configured driver.
-    #[serde(default)]
     pub compute_drivers: Vec<ComputeDriverKind>,
 
     /// TTL for SSH session tokens, in seconds. 0 disables expiry.
-    #[serde(default = "default_ssh_session_ttl_secs")]
     pub ssh_session_ttl_secs: u64,
 
     /// Browser-facing sandbox service routing configuration.
-    #[serde(default)]
     pub service_routing: ServiceRoutingConfig,
 }
 
 /// Browser-facing sandbox service routing configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Part of the programmatically-built [`Config`]; never deserialized directly.
+#[derive(Debug, Clone)]
 pub struct ServiceRoutingConfig {
     /// Base domains accepted for `sandbox--service.<domain>` routes.
     /// The first domain is used when the gateway prints endpoint URLs.
-    #[serde(default = "default_service_routing_domains")]
     pub base_domains: Vec<String>,
 
     /// Enable TLS-enabled loopback gateway listeners to also accept plaintext
     /// HTTP for sandbox service hostnames.
-    #[serde(default = "default_enable_loopback_service_http")]
     pub enable_loopback_service_http: bool,
 }
 
@@ -269,6 +263,7 @@ pub struct ServiceRoutingConfig {
 /// In both modes, authentication is handled at the application layer
 /// (e.g. OIDC bearer tokens).  mTLS is an additional mechanism.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TlsConfig {
     /// Path to the TLS certificate file.
     pub cert_path: PathBuf,
@@ -299,6 +294,7 @@ pub struct TlsConfig {
 /// - Entra ID / Okta: `roles`
 /// - Custom: any dot-separated path into the JWT claims
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OidcConfig {
     /// OIDC issuer URL (e.g., `http://localhost:8180/realms/openshell`).
     pub issuer: String,
@@ -333,6 +329,7 @@ pub struct OidcConfig {
 
 /// mTLS user authentication for local, single-user gateways.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MtlsAuthConfig {
     /// When true, the gateway maps a verified TLS client certificate into a
     /// user principal. Keep disabled for Kubernetes deployments because
@@ -343,6 +340,7 @@ pub struct MtlsAuthConfig {
 
 /// Gateway user authentication settings.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GatewayAuthConfig {
     /// When true, unauthenticated user/CLI calls are accepted as a local
     /// developer principal. This is an unsafe local-development escape hatch
@@ -363,6 +361,7 @@ const fn default_jwks_ttl_secs() -> u64 {
 /// signing key never leaves the gateway process; the public key is loaded
 /// by the same gateway so it can validate its own tokens.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GatewayJwtConfig {
     /// Path to the Ed25519 signing key (PKCS#8 PEM).
     pub signing_key_path: PathBuf,

--- a/crates/openshell-server/src/config_file.rs
+++ b/crates/openshell-server/src/config_file.rs
@@ -421,6 +421,26 @@ nonsense = true
     }
 
     #[test]
+    fn rejects_unknown_field_in_nested_gateway_jwt_table() {
+        // Regression guard for the class of silent-misconfig bug fixed in
+        // PR #1661: a key indented under the wrong table header (here,
+        // `sandbox_namespace` landing under `[openshell.gateway.gateway_jwt]`
+        // instead of `[openshell.gateway]`) must be rejected rather than
+        // silently ignored.
+        let toml = r#"
+[openshell.gateway.gateway_jwt]
+signing_key_path = "/tmp/jwt/signing.pem"
+public_key_path = "/tmp/jwt/public.pem"
+kid_path = "/tmp/jwt/kid"
+sandbox_namespace = "agents"
+"#;
+        let tmp = write_tmp(toml);
+        let err =
+            load(tmp.path()).expect_err("unknown field in nested gateway_jwt table must be rejected");
+        assert!(matches!(err, ConfigFileError::Parse { .. }));
+    }
+
+    #[test]
     fn rejects_removed_ssh_endpoint_fields() {
         let toml = r"
 [openshell.gateway]

--- a/crates/openshell-server/src/config_file.rs
+++ b/crates/openshell-server/src/config_file.rs
@@ -435,8 +435,8 @@ kid_path = "/tmp/jwt/kid"
 sandbox_namespace = "agents"
 "#;
         let tmp = write_tmp(toml);
-        let err =
-            load(tmp.path()).expect_err("unknown field in nested gateway_jwt table must be rejected");
+        let err = load(tmp.path())
+            .expect_err("unknown field in nested gateway_jwt table must be rejected");
         assert!(matches!(err, ConfigFileError::Parse { .. }));
     }
 

--- a/tasks/scripts/gateway.sh
+++ b/tasks/scripts/gateway.sh
@@ -333,7 +333,6 @@ EOF
 case "${DRIVER}" in
   kubernetes)
     cat >>"${CONFIG_PATH}" <<EOF
-sandbox_namespace = "${SANDBOX_NAMESPACE}"
 
 [openshell.drivers.kubernetes]
 namespace = "${SANDBOX_NAMESPACE}"


### PR DESCRIPTION
## Summary

Follow-up to #1661. That PR fixed one symptom (`supervisor_image` placed under `[openshell.gateway.gateway_jwt]` was silently ignored); this PR addresses the underlying cause and removes another instance of the same bug.

The gateway TOML loader silently accepted keys placed under the wrong table header. The top-level tables (`ConfigFile`, `OpenShellRoot`, `GatewayFileSection`) and the driver tables already set `#[serde(deny_unknown_fields)]`, but the **nested** gateway tables did not, so a misplaced key parsed cleanly and was dropped.

## Changes

- Add `#[serde(deny_unknown_fields)]` to the nested gateway config tables that are part of the config-file parse tree: `TlsConfig`, `OidcConfig`, `MtlsAuthConfig`, `GatewayAuthConfig`, `GatewayJwtConfig`.
- Remove the misplaced `sandbox_namespace` line from `tasks/scripts/gateway.sh`. It was emitted right after the `[openshell.gateway.gateway_jwt]` heredoc, so it landed inside the `gateway_jwt` table rather than `[openshell.gateway]`. The Kubernetes driver already receives the namespace via `[openshell.drivers.kubernetes]` (`namespace = ...`), so the line was dead config.
- Drop the unused `Serialize`/`Deserialize` derives from `Config` and `ServiceRoutingConfig` (details below).
- Add a regression test that a key under the wrong nested table is rejected.

## Why we could remove `Serialize`/`Deserialize` from `Config` and `ServiceRoutingConfig`

The on-disk schema is **not** parsed into `openshell_core::Config`. The TOML file is deserialized into the gateway's dedicated loader types — `ConfigFile` → `OpenShellRoot` → `GatewayFileSection` (in `openshell-server::config_file`). `Config` is then assembled **programmatically** in `Config::new` plus the gateway CLI (`crates/openshell-server/src/cli.rs`), merging the parsed file with env vars and CLI flags by precedence (`CLI > env > file > default`).

A repo-wide search found **no** call site that serializes or deserializes either struct:
- no `toml::from_str`/`serde_json`/`serde_yml` round-trip targeting `Config` or `ServiceRoutingConfig`,
- no DB persistence — `database_url` is just a connection string the gateway reads, the struct itself is never stored,
- `Config` is only ever built field-by-field.

The derives were **stale**: under the original design (RFC 0003) the file mapped directly onto `openshell_core::Config`, but the loader was later refactored into the separate `ConfigFile`/`GatewayFileSection` types and the derives on `Config` were left behind. Since these crates are not published, removing them is not a public-API break. The remaining `#[serde(default = "...")]` helper fns are still used by `Config::new`/`Default`, so nothing is orphaned (clippy is clean).

This leaves the parse tree (`ConfigFile` and below) as the single, unambiguous deserialization surface.

## Testing

- `cargo build --workspace` — succeeds
- `cargo clippy -p openshell-core -p openshell-server` — no warnings
- `cargo test -p openshell-core --lib config::` — 13/13 pass
- `cargo test -p openshell-server --lib config_file::tests` — 15/15 pass (incl. new regression test)
- `bash -n tasks/scripts/gateway.sh` — OK
- Follows Conventional Commits
