### PR TITLE
fix: correct example paths in local-inference README

### DIFF
--- a/examples/local-inference/README.md
+++ b/examples/local-inference/README.md
@@ -121,9 +121,9 @@ openshell inference get
 
 ```bash
 openshell sandbox create \
-  --policy examples/inference/sandbox-policy.yaml \
+  --policy examples/local-inference/sandbox-policy.yaml \
   --name inference-demo \
-  -- python examples/inference/inference.py
+  -- python examples/local-inference/inference.py
 ```
 
 The script targets `https://inference.local/v1` directly. OpenShell
@@ -142,7 +142,7 @@ content=NAV_OK
 ```bash
 openshell sandbox connect inference-demo
 # Inside the sandbox:
-python examples/inference/inference.py
+python examples/local-inference/inference.py
 ```
 
 #### 5. Cleanup

--- a/examples/local-inference/routes.yaml
+++ b/examples/local-inference/routes.yaml
@@ -5,10 +5,10 @@
 #
 # Usage:
 #   openshell-sandbox \
-#     --inference-routes examples/inference/routes.yaml \
+#     --inference-routes examples/local-inference/routes.yaml \
 #     --policy-rules policy.rego \
-#     --policy-data examples/inference/sandbox-policy.yaml \
-#     -- python examples/inference/inference.py
+#     --policy-data examples/local-inference/sandbox-policy.yaml \
+#     -- python examples/local-inference/inference.py
 
 routes:
   - name: inference.local


### PR DESCRIPTION
The gateway section in README.md and the usage comment in routes.yaml both reference examples/inference/ which does not exist. The correct path is examples/local-inference/. Fixes 6 occurrences across 2 files.