### PR TITLE
ci(release): bring Fedora RPM canary to parity

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -57,21 +57,93 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: linux-amd64-cpu8
     timeout-minutes: 20
-    container:
-      image: fedora:latest
-      options: --privileged
+    env:
+      FEDORA_CANARY_CONTAINER: openshell-fedora-canary-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - name: Ensure Podman
+      - name: Start Fedora systemd container and root user manager
         run: |
-          dnf install -y curl podman
-          mkdir -p "${HOME}/.config/openshell"
-          printf 'OPENSHELL_DRIVERS=podman\n' > "${HOME}/.config/openshell/gateway.env"
-          podman info
+          set -euo pipefail
+
+          docker run --detach \
+            --name "${FEDORA_CANARY_CONTAINER}" \
+            --privileged \
+            --cgroupns=host \
+            --tmpfs /run \
+            --tmpfs /tmp \
+            --volume /sys/fs/cgroup:/sys/fs/cgroup:rw \
+            fedora:latest \
+            bash -lc 'dnf install -y curl dbus-daemon podman systemd && exec /usr/sbin/init'
+
+          for _ in $(seq 1 120); do
+            if docker exec "${FEDORA_CANARY_CONTAINER}" systemctl list-units --no-pager >/dev/null 2>&1; then
+              break
+            fi
+            if [ "$(docker inspect -f '{{.State.Running}}' "${FEDORA_CANARY_CONTAINER}")" != "true" ]; then
+              echo "::error::Fedora systemd container exited before systemd became reachable"
+              docker logs "${FEDORA_CANARY_CONTAINER}" >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+
+          if ! docker exec "${FEDORA_CANARY_CONTAINER}" systemctl list-units --no-pager >/dev/null 2>&1; then
+            echo "::error::Fedora systemd container did not become reachable within 120s"
+            docker logs "${FEDORA_CANARY_CONTAINER}" >&2 || true
+            exit 1
+          fi
+
+          docker exec --interactive "${FEDORA_CANARY_CONTAINER}" env \
+            HOME=/root \
+            XDG_RUNTIME_DIR=/run/user/0 \
+            DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/0/bus \
+            bash -s <<'EOF'
+          set -euo pipefail
+          # install.sh manages the RPM gateway as a systemd user unit. This
+          # container is booted with systemd as PID 1, but it still has no
+          # login session. Start root's user manager explicitly so the
+          # installer can test service restart and gateway registration
+          # instead of its "restart later" fallback.
+          mkdir -p "${XDG_RUNTIME_DIR}"
+          chmod 700 "${XDG_RUNTIME_DIR}"
+          systemctl start user-runtime-dir@0.service || true
+          systemctl start user@0.service
+
+          for _ in $(seq 1 30); do
+            if systemctl --user daemon-reload; then
+              break
+            fi
+            sleep 1
+          done
+          if ! systemctl --user daemon-reload; then
+            systemctl status user@0.service --no-pager >&2 || true
+            journalctl -u user@0.service --no-pager -n 80 >&2 || true
+            systemctl --user status --no-pager >&2 || true
+            exit 1
+          fi
+          EOF
 
       - name: Install and check status
         run: |
-          curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/${{ github.event.workflow_run.head_sha || github.sha }}/install.sh | sh
+          set -euo pipefail
+
+          docker exec --interactive "${FEDORA_CANARY_CONTAINER}" env \
+            HOME=/root \
+            XDG_RUNTIME_DIR=/run/user/0 \
+            DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/0/bus \
+            INSTALL_SH_URL="https://raw.githubusercontent.com/NVIDIA/OpenShell/${{ github.event.workflow_run.head_sha || github.sha }}/install.sh" \
+            bash -s <<'EOF'
+          set -euo pipefail
+          mkdir -p "${HOME}/.config/openshell"
+          printf 'OPENSHELL_DRIVERS=podman\n' > "${HOME}/.config/openshell/gateway.env"
+          podman info
+          curl -LsSf "${INSTALL_SH_URL}" | sh
           openshell status
+          EOF
+
+      - name: Stop Fedora systemd container
+        if: always()
+        run: |
+          docker rm -f "${FEDORA_CANARY_CONTAINER}" >/dev/null 2>&1 || true
 
   ubuntu-snap:
     name: Ubuntu Snap


### PR DESCRIPTION
## Summary
The Fedora RPM canary needs to exercise the install.sh user-service path, but a GitHub Actions job container does not boot with systemd as PID 1. This means the Fedora RPM canary was incomplete as compared to the others.

With this change, we run Fedora as a nested privileged systemd container instead, wait for systemd to become reachable, then start the root user manager so systemctl --user works for the RPM gateway unit, achieving parity with the
other canary tests.

Instead of this:

```
openshell: installed openshell RPM packages from v0.0.54
openshell: restarting openshell-gateway user service as root...
Failed to connect to user scope bus via local transport: No such file or directory
openshell: could not reach the user systemd manager for root
openshell: restart the gateway later with: systemctl --user enable openshell-gateway && systemctl --user restart openshell-gateway
openshell: then register it with: openshell gateway add https://127.0.0.1:17670/ --local --name openshell
Gateway Status

  Status: No gateway configured.

Register a gateway with: openshell gateway add <endpoint>
```

We now get this:

```
openshell: installed openshell RPM packages from v0.0.54
openshell: restarting openshell-gateway user service as root...
Created symlink '/root/.config/systemd/user/default.target.wants/openshell-gateway.service' → '/usr/lib/systemd/user/openshell-gateway.service'.
openshell: registering local gateway as root...
✓ Gateway 'openshell' added and set as active
  Endpoint: https://127.0.0.1:17670/
  Type: local
✓ TLS certificates present
openshell: waiting for local gateway listener to become reachable...
openshell: local gateway listener is reachable
openshell: waiting for openshell status to report connected...
openshell: openshell status reports connected
Server Status

  Gateway: openshell
  Server: https://127.0.0.1:17670/
  Status: Connected
  Version: 0.0.54
```

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
