### PR TITLE
feat(providers): add Enclawed agent provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Docker-backed GPU sandboxes auto-select CDI when available and otherwise fall ba
 | [Codex](https://developers.openai.com/codex)                  | [`base`](https://github.com/NVIDIA/OpenShell-Community/tree/main/sandboxes/base) | Works out of the box. Provider uses `OPENAI_API_KEY`.                         |
 | [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) | [`base`](https://github.com/NVIDIA/OpenShell-Community/tree/main/sandboxes/base) | Works out of the box. Provider uses `GITHUB_TOKEN` or `COPILOT_GITHUB_TOKEN`. |
 | [OpenClaw](https://openclaw.ai/)                 | [NemoClaw](https://github.com/NVIDIA/NemoClaw)                                   | Run OpenClaw more securely inside NVIDIA OpenShell with managed inference using NemoClaw.       |
+| [Enclawed](https://enclawed.com/)                             | [enclawed-sandbox](https://github.com/enclawed/openshell-enclawed-sandbox)       | Classification-gated AI agent gateway with MCP-attested transport. Credentials bootstrapped via the OS keyring at sandbox provisioning. |
 | [Ollama](https://ollama.com/)                                 | [Community](https://github.com/NVIDIA/OpenShell-Community)                       | Launch with `openshell sandbox create --from ollama`.                         |
 | [Pi](https://pi.dev/)                                 | [Community](https://github.com/NVIDIA/OpenShell-Community)                       | Launch with `openshell sandbox create --from pi`.                         |
 

--- a/crates/openshell-providers/src/lib.rs
+++ b/crates/openshell-providers/src/lib.rs
@@ -111,6 +111,7 @@ impl ProviderRegistry {
         registry.register(providers::claude::SPEC);
         registry.register(providers::codex::SPEC);
         registry.register(providers::copilot::SPEC);
+        registry.register(providers::enclawed::EnclawedProvider);
         registry.register(providers::opencode::OpencodeProvider);
         registry.register(providers::generic::GenericProvider);
         registry.register(providers::openai::SPEC);

--- a/crates/openshell-providers/src/providers/enclawed.rs
+++ b/crates/openshell-providers/src/providers/enclawed.rs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{DiscoveredProvider, ProviderError, ProviderPlugin};
+
+/// Enclawed: a classification-gated, MCP-attested AI agent gateway.
+///
+/// Unlike the env-var-discovered providers (Claude Code, Codex, Copilot, ...),
+/// Enclawed bootstraps every credential into the operator's OS keyring at
+/// install time and never reads them from the environment. There is therefore
+/// nothing for OpenShell to discover at provider-discovery time; the matching
+/// sandbox image is responsible for running Enclawed's installer at first
+/// boot to populate the keyring. Modeled on [`GenericProvider`] for that
+/// reason.
+pub struct EnclawedProvider;
+
+impl ProviderPlugin for EnclawedProvider {
+    fn id(&self) -> &'static str {
+        "enclawed"
+    }
+
+    fn discover_existing(&self) -> Result<Option<DiscoveredProvider>, ProviderError> {
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EnclawedProvider;
+    use crate::ProviderPlugin;
+
+    #[test]
+    fn enclawed_provider_discovery_is_empty_by_default() {
+        let provider = EnclawedProvider;
+        let discovered = provider.discover_existing().expect("discovery");
+        assert!(discovered.is_none());
+    }
+}

--- a/crates/openshell-providers/src/providers/mod.rs
+++ b/crates/openshell-providers/src/providers/mod.rs
@@ -34,6 +34,7 @@ pub mod anthropic;
 pub mod claude;
 pub mod codex;
 pub mod copilot;
+pub mod enclawed;
 pub mod generic;
 pub mod github;
 pub mod gitlab;

--- a/providers/enclawed.yaml
+++ b/providers/enclawed.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: enclawed
+display_name: Enclawed
+description: Classification-gated AI agent gateway with MCP-attested transport (enclawed-oss)
+category: agent
+inference_capable: true
+# Enclawed bootstraps every credential into the operator's OS keyring at
+# install time (libsecret on Linux, Keychain on macOS, Credential Manager
+# on Windows). Nothing is read from environment variables at sandbox
+# entry, so OpenShell performs no env-var discovery for this provider.
+# The sandbox image (enclawed/openshell-enclawed-sandbox) is responsible
+# for running Enclawed's installer at first boot to populate the keyring.
+credentials: []
+discovery:
+  credentials: []
+endpoints:
+  # Default Anthropic backend, used by the bundled coding-agent path
+  # (pi-coding-agent / codex). Operators whose Enclawed install targets
+  # a different LLM backend extend this allowlist in their sandbox
+  # config rather than here.
+  - host: api.anthropic.com
+    port: 443
+    protocol: rest
+    access: read-write
+    enforcement: enforce
+  # Local Ollama, used by the bundled secretary path (default model
+  # qwen2.5:32b-instruct). Stays on loopback inside the sandbox.
+  - host: 127.0.0.1
+    port: 11434
+    protocol: rest
+    access: read-write
+    enforcement: enforce
+binaries: [/usr/bin/enclawed, /usr/local/bin/enclawed]


### PR DESCRIPTION
## Summary

Adds [Enclawed](https://enclawed.com/) as an agent provider, in the same shape as Claude Code, Codex, Copilot, OpenCode. The actual sandbox image lives in a partner-owned external repo ([`enclawed/openshell-enclawed-sandbox`](https://github.com/enclawed/openshell-enclawed-sandbox)) per the OpenClaw / NemoClaw pattern; this PR is only the OpenShell-side plumbing.

## What's Enclawed?

A classification-gated AI agent gateway with an MCP-attested transport layer (see [arXiv:2605.24248](https://arxiv.org/abs/2605.24248), source at [github.com/enclawed/enclawed-oss](https://github.com/enclawed/enclawed-oss)). It composes admission control + tool-level authorization + a hash-chained audit log around standard MCP servers. The bundled `secretary` and `codex` apps run on top.

## Why zero-credential discovery

Unlike the env-var-discovered providers, Enclawed bootstraps every credential into the operator's OS keyring at install time (libsecret on Linux, Keychain on macOS, Credential Manager on Windows) and reads none from the environment. The provider plugin has nothing to discover at provider-discovery time — modeled on `GenericProvider` for that reason. The matching sandbox image runs Enclawed's installer at first boot to populate the keyring inside the sandbox.

## Changes

- `providers/enclawed.yaml` — declarative provider spec, `category: agent`, `credentials: []`. Endpoints declare the two backends Enclawed ships with: `api.anthropic.com` (codex / pi-coding-agent path) and `127.0.0.1:11434` (local Ollama; secretary path).
- `crates/openshell-providers/src/providers/enclawed.rs` — `ProviderPlugin` impl with empty discovery + smoke test.
- `crates/openshell-providers/src/providers/mod.rs` — module entry.
- `crates/openshell-providers/src/lib.rs` — registry entry.
- `README.md` — Supported Agents table row pointing at the partner sandbox repo.

## Test plan

- [ ] `mise run ci` (lint + compile + tests) passes
- [ ] `cargo test -p openshell-providers` includes `enclawed_provider_discovery_is_empty_by_default`
- [ ] `openshell provider create --type enclawed` succeeds with no env credentials present
- [x] Partner sandbox repo (`enclawed/openshell-enclawed-sandbox`) public and reachable from the README link

DCO signed-off-by Alfredo Metere. Commit is SSH-signed.