### PR TITLE
feat(snap): add snap install method to `install.sh` when snap is available

### DIFF
--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Ubuntu 24.04 instances
+
+# snapd-no-docker: snapd only, no docker.
+# install.sh chooses the "snap" install path.
+$(eval $(call define-instance,ubuntu-cloud-24.04,snapd-no-docker))
+define UBUNTU_24.04@snapd-no-docker_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- snap wait system seed.loaded
+- snap install snapd
+packages:
+- snapd
+endef
+
+# snapd-classic-docker: snapd + native docker (docker.io deb package).
+# install.sh chooses the "classic" install path because native docker is detected.
+$(eval $(call define-instance,ubuntu-cloud-24.04,snapd-classic-docker))
+define UBUNTU_24.04@snapd-classic-docker_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- snap wait system seed.loaded
+- snap install snapd
+packages:
+- snapd
+- docker.io
+endef
+
+# no-snapd: snapd removed, docker.io installed.
+# install.sh chooses the "classic" install path because snapd is absent.
+$(eval $(call define-instance,ubuntu-cloud-24.04,no-snapd))
+define UBUNTU_24.04@no-snapd_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- apt-get purge -y snapd
+packages:
+- docker.io
+endef
+
+# Ubuntu 26.04 instances
+
+# snapd-no-docker: snapd only, no docker.
+# install.sh chooses the "snap" install path.
+$(eval $(call define-instance,ubuntu-cloud-26.04,snapd-no-docker))
+define UBUNTU_26.04@snapd-no-docker_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- snap wait system seed.loaded
+- snap install snapd
+packages:
+- snapd
+endef
+
+# snapd-classic-docker: snapd + native docker (docker.io deb package).
+# install.sh chooses the "classic" install path because native docker is detected.
+$(eval $(call define-instance,ubuntu-cloud-26.04,snapd-classic-docker))
+define UBUNTU_26.04@snapd-classic-docker_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- snap wait system seed.loaded
+- snap install snapd
+packages:
+- snapd
+- docker.io
+endef
+
+# no-snapd: snapd removed, docker.io installed.
+# install.sh chooses the "classic" install path because snapd is absent.
+$(eval $(call define-instance,ubuntu-cloud-26.04,no-snapd))
+define UBUNTU_26.04@no-snapd_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- apt-get purge -y snapd
+packages:
+- docker.io
+endef
+
+# Debian 13 instances
+
+# snapd-no-docker: snapd only, no docker.
+# install.sh chooses the "snap" install path.
+$(eval $(call define-instance,debian-cloud-13,snapd-no-docker))
+define DEBIAN_13@snapd-no-docker_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- snap wait system seed.loaded
+- snap install snapd
+packages:
+- snapd
+endef
+
+# snapd-classic-docker: snapd + native docker (docker.io deb package).
+# install.sh chooses the "classic" install path because native docker is detected.
+$(eval $(call define-instance,debian-cloud-13,snapd-classic-docker))
+define DEBIAN_13@snapd-classic-docker_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- snap wait system seed.loaded
+- snap install snapd
+packages:
+- snapd
+- docker.io
+endef
+
+# no-snapd: snapd removed, docker.io installed.
+# install.sh chooses the "classic" install path because snapd is absent.
+$(eval $(call define-instance,debian-cloud-13,no-snapd))
+define DEBIAN_13@no-snapd_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- apt-get purge -y snapd
+packages:
+- docker.io
+endef
+
+# Fedora 44 instances
+
+# snapd-no-docker: snapd only, no docker.
+# install.sh chooses the "snap" install path.
+$(eval $(call define-instance,fedora-cloud-44,snapd-no-docker))
+define FEDORA_44@snapd-no-docker_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- systemctl enable --now snapd.socket
+- snap wait system seed.loaded
+packages:
+- snapd
+endef
+
+# snapd-docker: snapd + native docker (docker rpm package).
+# install.sh chooses the "classic" install path because native docker is detected.
+$(eval $(call define-instance,fedora-cloud-44,snapd-docker))
+define FEDORA_44@snapd-docker_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+- systemctl enable --now snapd.socket
+- snap wait system seed.loaded
+packages:
+- snapd
+- docker
+endef
+
+# no-snapd: just docker, no snapd.
+# install.sh chooses the "classic" install path because snapd is absent.
+$(eval $(call define-instance,fedora-cloud-44,no-snapd))
+define FEDORA_44@no-snapd_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+packages:
+- docker
+endef

--- a/.image-garden/.gitignore
+++ b/.image-garden/.gitignore
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+*.img
+*.iso
+*.lock
+*.log
+*.meta-data
+*.qcow2
+*.run
+*.user-data

--- a/docs/about/installation.mdx
+++ b/docs/about/installation.mdx
@@ -16,7 +16,10 @@ Install OpenShell with a single command:
 curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
 ```
 
-The script detects your operating system and installs the OpenShell CLI and gateway with your native package manager. It then starts the local gateway server so you can begin creating sandboxes.
+The script detects your operating system and installs the OpenShell CLI and
+gateway. On Linux, the Snap path is preferred when `snapd` is available;
+otherwise the script uses the native DEB or RPM package. The gateway then
+starts automatically so you can begin creating sandboxes.
 
 You can also download release artifacts directly from the [OpenShell GitHub Releases](https://github.com/NVIDIA/OpenShell/releases) page.
 
@@ -51,6 +54,13 @@ brew services restart openshell
 
 ## Linux
 
+On distributions that ship with `snapd`, the install script uses the Snap path
+described below, provided no non-snap Docker is detected. If a native Docker
+package is present, the installer silently falls back to DEB or RPM. On hosts
+without `snapd` (or with
+`OPENSHELL_INSTALL_METHOD=classic` set), the script falls back to the classic
+package manager.
+
 On Fedora and RHEL, the install script uses RPM packages. The RPM installs the `openshell` CLI, the `openshell-gateway` daemon, and a systemd user service.
 
 On Debian and Ubuntu, the install script uses a Debian package. The Debian package installs the `openshell` CLI, the `openshell-gateway` daemon, VM sandbox support, and a systemd user service.
@@ -77,10 +87,15 @@ sudo loginctl enable-linger $USER
 
 ## Snap
 
-Install the OpenShell snap from the Snap Store:
+On Linux distributions that ship with `snapd`, the install script installs
+OpenShell from the Snap Store. The OpenShell snap bundles the CLI, the terminal
+UI, and a managed gateway daemon. snapd handles upgrades and rollback; the
+gateway runs as a system service inside the snap.
+
+You can also install the snap directly:
 
 ```shell
-sudo snap install openshell --classic
+sudo snap install openshell
 ```
 
 The snap defines two apps: the `openshell` CLI and the `openshell.gateway`
@@ -89,19 +104,35 @@ stores its database at `$SNAP_COMMON/gateway.db` (typically
 `/var/snap/openshell/common/gateway.db`). Create `$SNAP_COMMON/gateway.toml`
 when you need to override gateway settings.
 
+The snap requires the Docker snap. `default-provider: docker` on the OpenShell
+snap installs the Docker snap automatically on first use, but you can install
+it up front with:
+
+```shell
+sudo snap install docker
+```
+
 ### Snap store installs
 
-When installing from the Snap Store, snapd automatically connects the `home`,
-`network`, `network-bind`, and `ssh-keys` plugs. The `docker` plug still
-requires manual connection:
+When installing from the Snap Store, snapd automatically connects the `home`
+and `network` plugs. The remaining plugs — `network-bind`, `ssh-keys`,
+`log-observe`, `system-observe`, and `docker` — still require manual connection:
 
 ```shell
 sudo snap connect openshell:docker docker:docker-daemon
+sudo snap connect openshell:log-observe
+sudo snap connect openshell:ssh-keys
+sudo snap connect openshell:system-observe
 ```
 
-The snap declares `default-provider: docker` on the Docker plug so snapd will
-offer to install the Docker snap, but the connection itself must be made
-manually.
+The Docker slot is the Docker snap's `docker-daemon` slot; OpenShell does not
+work with a host-installed Docker Engine. The snap declares `default-provider:
+docker` on the Docker plug so snapd will offer to install the Docker snap, but
+the connection itself must be made manually. The installer runs these
+connections for you on Snap installs; run them by hand if you install the snap
+manually. The installer is best-effort: if a connect fails (for example because
+the Docker snap is not yet running), the snap still installs and the installer
+prints a warning.
 
 ### Locally built snap packages
 
@@ -123,6 +154,26 @@ to read logs and inspect system processes. The `docker` plug requires the
 `docker:docker-daemon` slot from the Docker snap and does not work with
 system-installed Docker.
 
+### Verify the gateway
+
+The snap-managed gateway service is `openshell.gateway`. Inspect it with:
+
+```shell
+snap services openshell
+snap logs -n 100 openshell.gateway
+```
+
+Register the gateway with the CLI:
+
+```shell
+openshell gateway add http://127.0.0.1:17670 --local --name openshell
+openshell status
+```
+
+The gateway listens on `http://127.0.0.1:17670` and stores its state under
+`/var/snap/openshell/common/`. Override gateway settings by creating
+`/var/snap/openshell/common/gateway.toml`.
+
 ### Gateway service
 
 The gateway runs as a snap daemon with `refresh-mode: endure`, meaning snapd
@@ -133,6 +184,20 @@ a snap refresh when you need the updated binary:
 ```shell
 sudo systemctl restart snap.openshell.gateway
 ```
+
+### When to choose Snap
+
+Use Snap when `snapd` is available and no native Docker Engine is installed,
+and you want atomic upgrades and rollback, a single self-contained install that
+bundles the Docker provider, or a desktop launcher that surfaces the OpenShell
+terminal UI in the application menu.
+
+Use DEB or RPM when `snapd` is unavailable or when you already run Docker Engine
+from a non-snap source. The installer falls back to DEB or RPM on hosts with
+native Docker.
+
+Set `OPENSHELL_INSTALL_METHOD=classic` to force the classic package on hosts
+that also have `snapd` available.
 
 ## Kubernetes
 

--- a/install.sh
+++ b/install.sh
@@ -60,9 +60,10 @@ NOTES:
     from ${GITHUB_URL}/releases/latest.
 
     Linux installs the Debian package on amd64/arm64 or the RPM packages on
-    x86_64/aarch64, depending on the host package manager.
-    macOS installs the release Homebrew formula on Apple Silicon and starts a
-    brew services-backed local gateway.
+    x86_64/aarch64, depending on the host package manager. When snapd is
+    available and no native Docker Engine is installed, the installer prefers
+    the Snap path. macOS installs the release Homebrew formula on Apple Silicon
+    and starts a brew services-backed local gateway.
 EOF
 }
 
@@ -74,6 +75,14 @@ require_cmd() {
   if ! has_cmd "$1"; then
     error "'$1' is required"
   fi
+}
+
+has_snapd() {
+  has_cmd snap && systemctl is-active --quiet snapd.socket 2>/dev/null
+}
+
+has_native_docker() {
+  has_cmd docker && ! snap list docker >/dev/null 2>&1
 }
 
 download() {
@@ -468,6 +477,17 @@ detect_platform() {
 }
 
 linux_package_method() {
+  case "${OPENSHELL_INSTALL_METHOD:-}" in
+    classic)
+      ;;
+    *)
+      if has_snapd && ! has_native_docker; then
+        echo "snap"
+        return 0
+      fi
+      ;;
+  esac
+
   if has_cmd dpkg; then
     echo "deb"
   elif has_cmd rpm; then
@@ -953,6 +973,83 @@ install_linux_rpm() {
   start_user_gateway
 }
 
+install_linux_snap() {
+  set_linux_target_runtime_dir
+
+  # Docker snap must be installed before openshell so that the
+  # openshell:docker -> docker:docker-daemon interface connection
+  # can succeed. The docker-daemon slot doesn't exist until the
+  # Docker snap itself is present.
+  if ! snap list docker >/dev/null 2>&1; then
+    info "docker snap not found, installing..."
+    as_root snap install docker
+  else
+    info "docker snap already present"
+  fi
+
+  info "installing openshell snap..."
+  as_root snap install openshell
+
+  # Connect required interfaces. Network and network-bind auto-connect
+  # on install; the remaining plugs need explicit connection. snap connect
+  # is idempotent — it succeeds whether the connection was just made or
+  # already existed.
+  as_root snap connect openshell:docker docker:docker-daemon
+  as_root snap connect openshell:log-observe
+  as_root snap connect openshell:system-observe
+  as_root snap connect openshell:ssh-keys
+
+  info "installed openshell snap from Snap Store"
+  info "registering local gateway as ${TARGET_USER}..."
+  register_local_gateway_snap
+  wait_for_local_gateway_listener_snap
+  wait_for_local_gateway_status
+}
+
+register_local_gateway_snap() {
+  _register_bin="${OPENSHELL_REGISTER_BIN:-openshell}"
+
+  if _add_output="$($_register_bin gateway add "http://127.0.0.1:${LOCAL_GATEWAY_PORT}" --local --name openshell 2>&1)"; then
+    [ -z "$_add_output" ] || print_gateway_add_output "$_add_output"
+    return 0
+  fi
+
+  _add_status=$?
+
+  case "$_add_output" in
+    *"already exists"*)
+      info "local gateway already exists; removing and re-adding it..."
+      remove_local_gateway_registration
+      "$_register_bin" gateway add "http://127.0.0.1:${LOCAL_GATEWAY_PORT}" --local --name openshell
+      ;;
+    *)
+      printf '%s\n' "$_add_output" >&2
+      return "$_add_status"
+      ;;
+  esac
+}
+
+wait_for_local_gateway_listener_snap() {
+  _timeout="${OPENSHELL_INSTALL_GATEWAY_TIMEOUT_SNAP:-90}"
+  _elapsed=0
+  _last_output=""
+  _probe_url="http://127.0.0.1:${LOCAL_GATEWAY_PORT}/"
+
+  info "waiting for local gateway listener to become reachable..."
+  while [ "$_elapsed" -lt "$_timeout" ]; do
+    if _last_output="$(curl -sS --max-time 2 "$_probe_url" 2>&1)"; then
+      info "local gateway listener is reachable"
+      return 0
+    fi
+    sleep 1
+    _elapsed=$((_elapsed + 1))
+  done
+
+  [ -z "$_last_output" ] || printf '%s
+' "$_last_output" >&2
+  error "local gateway listener did not become reachable at ${_probe_url} within ${_timeout}s"
+}
+
 install_macos_homebrew() {
   check_macos_platform
 
@@ -1033,12 +1130,16 @@ main() {
 
   case "$PLATFORM" in
     linux)
-      require_linux_package_glibc
       case "$(linux_package_method)" in
+        snap)
+          install_linux_snap
+          ;;
         deb)
+          require_linux_package_glibc
           install_linux_deb
           ;;
         rpm)
+          require_linux_package_glibc
           install_linux_rpm
           ;;
         *)

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+project: openshell
+
+backends:
+    garden:
+        type: adhoc
+        allocate: |
+            # Spread automatically injects /snap/bin to PATH. When we are
+            # running from the image-garden snap then SPREAD_HOST_PATH is the
+            # original path before such modifications were applied. Snap
+            # applications cannot normally run /snap/bin/* entry-points
+            # successfully so re-set PATH to the original value, as provided by
+            # snapcraft.
+            if [ -n "${SPREAD_HOST_PATH-}" ]; then
+                PATH="${SPREAD_HOST_PATH}"
+            fi
+            export GARDEN_ARCH="$(uname -m)"
+            export SYSTEM="${SPREAD_SYSTEM/-plus-/+}"
+            export SYSTEM="${SYSTEM/-at-/@}"
+            exec image-garden allocate --spread "$SYSTEM"."$GARDEN_ARCH"
+        discard: |
+            # Spread automatically injects /snap/bin to PATH. When we are
+            # running from the image-garden snap then SPREAD_HOST_PATH is the
+            # original path before such modifications were applied. Snap
+            # applications cannot normally run /snap/bin/* entry-points
+            # successfully so re-set PATH to the original value, as provided by
+            # snapcraft.
+            if [ -n "${SPREAD_HOST_PATH-}" ]; then
+                PATH="${SPREAD_HOST_PATH}"
+            fi
+            image-garden discard "$SPREAD_SYSTEM_ADDRESS"
+        systems:
+            # Each system name follows the pattern: {os}-{version}-{variant}.
+            #
+            # Three variants are available:
+            #
+            #   snapd-no-docker   — snapd installed, no docker. The installer
+            #                       chooses the snap install path.
+            #
+            #   *-classic-docker  — snapd + native docker installed. The
+            #                       installer chooses the classic (deb/rpm)
+            #                       install path.
+            #
+            #   no-snapd          — docker installed, snapd absent. The
+            #                       installer chooses the classic (deb/rpm)
+            #                       install path.
+            #
+            # See .image-garden.mk for the cloud-init templates that define
+            # the per-system setup.
+            - ubuntu-cloud-24.04-at-snapd-no-docker:
+                  username: root
+                  password: root
+            - ubuntu-cloud-24.04-at-snapd-classic-docker:
+                  username: root
+                  password: root
+            - ubuntu-cloud-24.04-at-no-snapd:
+                  username: root
+                  password: root
+            - ubuntu-cloud-26.04-at-snapd-no-docker:
+                  username: root
+                  password: root
+            - ubuntu-cloud-26.04-at-snapd-classic-docker:
+                  username: root
+                  password: root
+            - ubuntu-cloud-26.04-at-no-snapd:
+                  username: root
+                  password: root
+            - debian-cloud-13-at-snapd-no-docker:
+                  username: root
+                  password: root
+            - debian-cloud-13-at-snapd-classic-docker:
+                  username: root
+                  password: root
+            - debian-cloud-13-at-no-snapd:
+                  username: root
+                  password: root
+            - fedora-cloud-44-at-snapd-no-docker:
+                  username: root
+                  password: root
+                  environment:
+                      PATH: /var/lib/snapd/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            - fedora-cloud-44-at-snapd-docker:
+                  username: root
+                  password: root
+                  environment:
+                      PATH: /var/lib/snapd/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            - fedora-cloud-44-at-no-snapd:
+                  username: root
+                  password: root
+
+exclude:
+    - ".cache/*"
+    - ".image-garden/*"
+    - "target/*"
+    - ".spread-reuse.*.yaml"
+
+path: /root/openshell
+
+debug-each: |
+    echo "Kernel and architecture:"
+    uname -a
+
+    echo "OS release info:"
+    cat /etc/os-release
+
+    echo "Docker availability:"
+    command -v docker >/dev/null 2>&1 && {
+        docker version --format '{{.Server.Version}}' 2>/dev/null || true
+    }
+    command -v snap >/dev/null 2>&1 && snap list docker 2>/dev/null || true
+
+suites:
+    tests/install/:
+        summary: Install smoke tests for OpenShell

--- a/tests/install/install-classic/task.yaml
+++ b/tests/install/install-classic/task.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+summary: Install via native package (deb or rpm) on classic install path
+details: |
+    This test installs OpenShell via the classic install path using a native
+    package (deb on Ubuntu/Debian, rpm on Fedora). The installer chooses this
+    path when native docker is present. On Ubuntu 24.04, Ubuntu 26.04 and
+    Debian 13, snapd is removed via cloud-init for the no-snapd variant; on
+    Fedora 44, snapd is absent by default. This verifies that the native
+    package installation, user gateway service, and gateway registration work
+    correctly across all supported systems.
+
+systems:
+    - ubuntu-cloud-24.04-at-snapd-classic-docker
+    - ubuntu-cloud-24.04-at-no-snapd
+    - ubuntu-cloud-26.04-at-snapd-classic-docker
+    - ubuntu-cloud-26.04-at-no-snapd
+    - debian-cloud-13-at-snapd-classic-docker
+    - debian-cloud-13-at-no-snapd
+    - fedora-cloud-44-at-snapd-docker
+    - fedora-cloud-44-at-no-snapd
+
+prepare: |
+    cat "$SPREAD_PATH/install.sh" | sh
+
+execute: |
+    which openshell | NOMATCH "/snap/"
+    openshell status | sed 's/\x1b\[[0-9;]*m//g' | MATCH "Status: Connected"

--- a/tests/install/install-snap-only/task.yaml
+++ b/tests/install/install-snap-only/task.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+summary: Install via snap on snapd-only system
+details: |
+    This test installs OpenShell on a system with only snapd (no docker).
+    The installer detects snapd and no classic docker, choosing the snap
+    install path. This verifies that the snap can be installed, its
+    interfaces connected, and the gateway registered.
+
+systems:
+    - ubuntu-cloud-24.04-at-snapd-no-docker
+    - ubuntu-cloud-26.04-at-snapd-no-docker
+    - debian-cloud-13-at-snapd-no-docker
+    - fedora-cloud-44-at-snapd-no-docker
+
+execute: |
+    cat "$SPREAD_PATH/install.sh" | sh
+    which openshell | MATCH "/snap/bin/openshell"
+    openshell status | sed 's/\x1b\[[0-9;]*m//g' | MATCH "Status: Connected"


### PR DESCRIPTION
## Summary
Update the installation script to use the snap package if snapd is available on the system and conditions are met. The installation instructions are updated to match.

## Related Issue
https://github.com/NVIDIA/OpenShell/issues/1674

## Changes
- The install script detects the presence of snapd and if compatible conditions (docker) are met, installs the snap from the store.

## Testing
<!-- What testing was done? -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] The install.sh script was tested in a LXD container

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
