### PR TITLE
feat(k8s): add sandboxPrivileged knob and fix disableGatewayAuth chart bug

### DIFF
--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -305,6 +305,21 @@ pub struct Config {
     #[serde(default)]
     pub enable_user_namespaces: bool,
 
+    /// Run sandbox pods with `securityContext.privileged: true`.
+    ///
+    /// UNSAFE: this grants the sandbox container full access to the host
+    /// kernel (all capabilities, no seccomp/AppArmor confinement, host
+    /// devices visible). Only enable on dedicated single-tenant clusters
+    /// where you trust everything the sandbox might run.
+    ///
+    /// The setting exists to support managed Kubernetes runtimes (notably
+    /// AKS) whose containerd policy blocks `mount --make-shared /run/netns`
+    /// even with `CAP_SYS_ADMIN`, which prevents the supervisor from
+    /// creating its network namespace. Prefer `enable_user_namespaces` on
+    /// any runtime that supports it.
+    #[serde(default)]
+    pub sandbox_privileged: bool,
+
     /// Browser-facing sandbox service routing configuration.
     #[serde(default)]
     pub service_routing: ServiceRoutingConfig,
@@ -435,6 +450,7 @@ impl Config {
             client_tls_secret_name: String::new(),
             host_gateway_ip: String::new(),
             enable_user_namespaces: false,
+            sandbox_privileged: false,
             service_routing: ServiceRoutingConfig::default(),
         }
     }

--- a/crates/openshell-driver-kubernetes/src/config.rs
+++ b/crates/openshell-driver-kubernetes/src/config.rs
@@ -58,4 +58,11 @@ pub struct KubernetesComputeConfig {
     pub client_tls_secret_name: String,
     pub host_gateway_ip: String,
     pub enable_user_namespaces: bool,
+    /// Run sandbox pods with `securityContext.privileged: true`.
+    /// UNSAFE: grants the sandbox container full host access. Only enable
+    /// on dedicated single-tenant clusters where the cluster's container
+    /// runtime blocks operations the supervisor needs (e.g. AKS's
+    /// containerd policy denies `mount --make-shared /run/netns` even with
+    /// `CAP_SYS_ADMIN`). Prefer `enable_user_namespaces` when possible.
+    pub sandbox_privileged: bool,
 }

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -323,6 +323,7 @@ impl KubernetesComputeDriver {
             client_tls_secret_name: &self.config.client_tls_secret_name,
             host_gateway_ip: &self.config.host_gateway_ip,
             enable_user_namespaces: self.config.enable_user_namespaces,
+            sandbox_privileged: self.config.sandbox_privileged,
         };
         obj.data = sandbox_to_k8s_spec(sandbox.spec.as_ref(), &params);
         let api = self.api();
@@ -979,6 +980,7 @@ struct SandboxPodParams<'a> {
     client_tls_secret_name: &'a str,
     host_gateway_ip: &'a str,
     enable_user_namespaces: bool,
+    sandbox_privileged: bool,
 }
 
 fn spec_pod_env(spec: Option<&SandboxSpec>) -> std::collections::HashMap<String, String> {
@@ -1088,6 +1090,9 @@ fn sandbox_template_to_k8s(
     // Per-sandbox platform_config.host_users overrides the cluster-wide default.
     let use_user_namespaces = platform_config_bool(template, "host_users")
         .map_or(params.enable_user_namespaces, |host_users| !host_users);
+    // Per-sandbox platform_config.privileged overrides the cluster-wide default.
+    let use_privileged =
+        platform_config_bool(template, "privileged").unwrap_or(params.sandbox_privileged);
 
     if use_user_namespaces {
         spec.insert("hostUsers".to_string(), serde_json::json!(false));
@@ -1148,13 +1153,17 @@ fn sandbox_template_to_k8s(
         // for process identity resolution in network policy enforcement.
         capabilities.extend(["SETUID", "SETGID", "DAC_READ_SEARCH"]);
     }
+    let mut security_context = serde_json::Map::new();
+    security_context.insert(
+        "capabilities".to_string(),
+        serde_json::json!({ "add": capabilities }),
+    );
+    if use_privileged {
+        security_context.insert("privileged".to_string(), serde_json::json!(true));
+    }
     container.insert(
         "securityContext".to_string(),
-        serde_json::json!({
-            "capabilities": {
-                "add": capabilities
-            }
-        }),
+        serde_json::Value::Object(security_context),
     );
 
     // Mount client TLS secret for mTLS to the server.
@@ -1328,7 +1337,7 @@ fn apply_required_env(
     ssh_handshake_skew_secs: u64,
     tls_enabled: bool,
 ) {
-    upsert_env(env, "OPENSHELL_SANDBOX_ID", sandbox_id);
+                                                                                                                            upsert_env(env, "OPENSHELL_SANDBOX_ID", sandbox_id);
     upsert_env(env, "OPENSHELL_SANDBOX", sandbox_name);
     upsert_env(env, "OPENSHELL_ENDPOINT", grpc_endpoint);
     upsert_env(env, "OPENSHELL_SANDBOX_COMMAND", "sleep infinity");
@@ -2252,6 +2261,104 @@ mod tests {
             caps.len(),
             4,
             "extra capabilities must not be added when user namespaces are disabled"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Privileged tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn privileged_disabled_by_default() {
+        let pod_template = default_template_to_k8s(false);
+        let sc = &pod_template["spec"]["containers"][0]["securityContext"];
+        assert!(
+            sc["privileged"].is_null(),
+            "privileged must not be set when sandbox_privileged is false"
+        );
+    }
+
+    #[test]
+    fn privileged_enabled_by_cluster_default() {
+        let params = SandboxPodParams {
+            sandbox_privileged: true,
+            ..Default::default()
+        };
+        let pod_template = sandbox_template_to_k8s(
+            &SandboxTemplate::default(),
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &params,
+        );
+        assert_eq!(
+            pod_template["spec"]["containers"][0]["securityContext"]["privileged"],
+            serde_json::json!(true),
+            "privileged must be true when sandbox_privileged is on"
+        );
+    }
+
+    #[test]
+    fn privileged_per_sandbox_override_enables() {
+        let template = SandboxTemplate {
+            platform_config: Some(Struct {
+                fields: std::iter::once((
+                    "privileged".to_string(),
+                    Value {
+                        kind: Some(Kind::BoolValue(true)),
+                    },
+                ))
+                .collect(),
+            }),
+            ..SandboxTemplate::default()
+        };
+
+        let params = SandboxPodParams::default(); // cluster default is off
+        let pod_template = sandbox_template_to_k8s(
+            &template,
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &params,
+        );
+
+        assert_eq!(
+            pod_template["spec"]["containers"][0]["securityContext"]["privileged"],
+            serde_json::json!(true),
+            "per-sandbox privileged: true must enable privileged"
+        );
+    }
+
+    #[test]
+    fn privileged_per_sandbox_override_disables() {
+        let template = SandboxTemplate {
+            platform_config: Some(Struct {
+                fields: std::iter::once((
+                    "privileged".to_string(),
+                    Value {
+                        kind: Some(Kind::BoolValue(false)),
+                    },
+                ))
+                .collect(),
+            }),
+            ..SandboxTemplate::default()
+        };
+
+        let params = SandboxPodParams {
+            sandbox_privileged: true, // cluster default is on
+            ..Default::default()
+        };
+        let pod_template = sandbox_template_to_k8s(
+            &template,
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &params,
+        );
+
+        assert!(
+            pod_template["spec"]["containers"][0]["securityContext"]["privileged"].is_null(),
+            "per-sandbox privileged: false must disable privileged even when cluster default is on"
         );
     }
 

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -1337,7 +1337,7 @@ fn apply_required_env(
     ssh_handshake_skew_secs: u64,
     tls_enabled: bool,
 ) {
-                                                                                                                            upsert_env(env, "OPENSHELL_SANDBOX_ID", sandbox_id);
+    upsert_env(env, "OPENSHELL_SANDBOX_ID", sandbox_id);
     upsert_env(env, "OPENSHELL_SANDBOX", sandbox_name);
     upsert_env(env, "OPENSHELL_ENDPOINT", grpc_endpoint);
     upsert_env(env, "OPENSHELL_SANDBOX_COMMAND", "sleep infinity");

--- a/crates/openshell-driver-kubernetes/src/main.rs
+++ b/crates/openshell-driver-kubernetes/src/main.rs
@@ -74,6 +74,14 @@ struct Args {
 
     #[arg(long, env = "OPENSHELL_ENABLE_USER_NAMESPACES")]
     enable_user_namespaces: bool,
+
+    /// Run sandbox pods with `securityContext.privileged: true`.
+    /// UNSAFE: grants the sandbox container full host access. Only enable
+    /// on dedicated single-tenant clusters where the container runtime
+    /// blocks operations the supervisor needs (e.g. AKS containerd's
+    /// `mount --make-shared` denial). Prefer `--enable-user-namespaces`.
+    #[arg(long, env = "OPENSHELL_SANDBOX_PRIVILEGED")]
+    sandbox_privileged: bool,
 }
 
 #[tokio::main]
@@ -101,6 +109,7 @@ async fn main() -> Result<()> {
         client_tls_secret_name: args.client_tls_secret_name.unwrap_or_default(),
         host_gateway_ip: args.host_gateway_ip.unwrap_or_default(),
         enable_user_namespaces: args.enable_user_namespaces,
+        sandbox_privileged: args.sandbox_privileged,
     })
     .await
     .into_diagnostic()?;

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -242,6 +242,14 @@ struct RunArgs {
     #[arg(long, env = "OPENSHELL_ENABLE_USER_NAMESPACES")]
     enable_user_namespaces: bool,
 
+    /// Run sandbox pods with `securityContext.privileged: true`.
+    /// UNSAFE: grants the sandbox container full host access. Only enable
+    /// on dedicated single-tenant clusters where the container runtime
+    /// blocks operations the supervisor needs (e.g. AKS containerd's
+    /// `mount --make-shared` denial). Prefer `--enable-user-namespaces`.
+    #[arg(long, env = "OPENSHELL_SANDBOX_PRIVILEGED")]
+    sandbox_privileged: bool,
+
     /// Disable TLS entirely — listen on plaintext HTTP.
     /// Use this when the gateway sits behind a reverse proxy or tunnel
     /// (e.g. Cloudflare Tunnel) that terminates TLS at the edge.
@@ -453,6 +461,7 @@ async fn run_from_args(args: RunArgs) -> Result<()> {
     }
 
     config.enable_user_namespaces = args.enable_user_namespaces;
+    config.sandbox_privileged = args.sandbox_privileged;
 
     let vm_config = VmComputeConfig {
         state_dir: args.vm_driver_state_dir,

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -592,6 +592,7 @@ async fn build_compute_runtime(
                     client_tls_secret_name: config.client_tls_secret_name.clone(),
                     host_gateway_ip: config.host_gateway_ip.clone(),
                     enable_user_namespaces: config.enable_user_namespaces,
+                    sandbox_privileged: config.sandbox_privileged,
                 },
                 store,
                 sandbox_index,

--- a/deploy/helm/openshell/templates/statefulset.yaml
+++ b/deploy/helm/openshell/templates/statefulset.yaml
@@ -96,6 +96,10 @@ spec:
             - name: OPENSHELL_ENABLE_USER_NAMESPACES
               value: "true"
             {{- end }}
+            {{- if .Values.server.sandboxPrivileged }}
+            - name: OPENSHELL_SANDBOX_PRIVILEGED
+              value: "true"
+            {{- end }}
             {{- if and .Values.certManager.enabled .Values.certManager.serverDnsNames }}
             - name: OPENSHELL_SERVER_SAN
               value: {{ join "," .Values.certManager.serverDnsNames | quote }}
@@ -122,10 +126,10 @@ spec:
               value: /etc/openshell-tls/client-ca/ca.crt
             - name: OPENSHELL_CLIENT_TLS_SECRET_NAME
               value: {{ .Values.server.tls.clientTlsSecretName | quote }}
+            {{- end }}
             {{- if .Values.server.disableGatewayAuth }}
             - name: OPENSHELL_DISABLE_GATEWAY_AUTH
               value: "true"
-            {{- end }}
             {{- end }}
             {{- if .Values.server.oidc.issuer }}
             - name: OPENSHELL_OIDC_ISSUER

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -123,6 +123,14 @@ server:
   # Linux 5.12+. When enabled, container UID 0 maps to an unprivileged host
   # UID and capabilities become namespaced.
   enableUserNamespaces: false
+  # Run sandbox pods with `securityContext.privileged: true`.
+  # UNSAFE: this grants the sandbox container full host access (all
+  # capabilities, no seccomp/AppArmor confinement, host devices visible).
+  # Only enable on dedicated single-tenant clusters whose container runtime
+  # blocks operations the supervisor needs (notably AKS containerd, which
+  # denies `mount --make-shared /run/netns` even with `CAP_SYS_ADMIN`).
+  # Prefer `enableUserNamespaces` on any runtime that supports it.
+  sandboxPrivileged: false
   # Disable gateway authentication (mTLS client certificate requirement).
   # Set to true when the gateway sits behind a reverse proxy (e.g.
   # Cloudflare Tunnel) that terminates TLS.

--- a/examples/three-sandboxes-on-kubernetes/README.md
+++ b/examples/three-sandboxes-on-kubernetes/README.md
@@ -1,0 +1,377 @@
+# Three Sandboxes on a Kubernetes Cluster
+
+Install the OpenShell gateway into a Kubernetes cluster of your choice, then
+create three sandboxes that run as pods on that cluster.
+
+The walkthrough picks the target cluster via a `KUBE_CONTEXT` environment
+variable so the same commands work against any kubeconfig context.
+
+## Prerequisites
+
+- OpenShell CLI installed (`openshell`)
+- `kubectl` and `helm` configured with a context for your target cluster
+- Permission to create namespaces, services, and pods in that cluster
+- A Kubernetes cluster whose container runtime permits sandbox network-namespace
+  setup (see [Cluster compatibility](#cluster-compatibility) below)
+
+Pick the cluster you want to use and verify it is reachable:
+
+```bash
+export KUBE_CONTEXT=<your-context>           # e.g. testmember-5
+export OPENSHELL_NAMESPACE=openshell         # optional, defaults to "openshell"
+export OPENSHELL_RELEASE=openshell           # optional, defaults to "openshell"
+
+kubectl --context "$KUBE_CONTEXT" cluster-info
+```
+
+## What's in this example
+
+| File                  | Description                                                            |
+| --------------------- | ---------------------------------------------------------------------- |
+| `install-gateway.sh`  | Installs the OpenShell gateway Helm chart on `$KUBE_CONTEXT`           |
+| `create-sandboxes.sh` | Creates three sandboxes (`alpha`, `beta`, `gamma`) via the gateway     |
+| `values.yaml`         | Helm values used for the gateway install                                |
+
+Both scripts read the same environment variables (`KUBE_CONTEXT`,
+`OPENSHELL_NAMESPACE`, `OPENSHELL_RELEASE`), so `export`ing them once in
+your shell is enough.
+
+The `values.yaml` is tuned for a self-contained evaluation install:
+
+- **TLS off, unauthenticated CLI access** (`server.disableTls: true`,
+  `server.disableGatewayAuth: true`) so the CLI can talk to the
+  gateway over plaintext through `kubectl port-forward` without minting and
+  distributing client certs. Do **not** use these settings in production —
+  front the gateway with OIDC or mTLS instead.
+- **ClusterIP service** so nothing is exposed outside the cluster.
+- **Explicit `server.grpcEndpoint`** pinned to
+  `http://openshell.openshell.svc.cluster.local:8080` so sandbox pods know
+  how to dial back into the gateway. The chart auto-derives this when left
+  blank; we set it so the example is copy-paste safe across namespaces.
+- **Sandbox pods run privileged** (`server.sandboxPrivileged: true`). Required
+  on AKS because containerd 2.1 rejects `mount --make-shared /run/netns`
+  even with `hostUsers: false` (see
+  [Cluster compatibility](#cluster-compatibility) for the full story).
+  On runtimes that support it, prefer `server.enableUserNamespaces: true`
+  instead.
+- **Auto sideload** (`supervisor.sideloadMethod: ""`). On K8s ≥ 1.35 this
+  picks `image-volume`; on older clusters it falls back to `init-container`.
+  Both work because we are not combining `hostUsers: false` with
+  `image-volume`.
+- **`pkiInitJob.enabled: true`** — this pre-install hook creates the JWT
+  signing-key Secret the gateway StatefulSet mounts, so it must stay on
+  even when TLS itself is disabled.
+
+### Pinned component versions
+
+For reproducibility, this example pins every external image to a specific
+tag. Bump these together when you want to track a newer release.
+
+The values file currently targets a **HEAD build of the gateway and
+supervisor** because the `sandboxPrivileged` knob is post-`v0.0.47`. You
+need to build them yourself and push to a registry the cluster can pull
+from. The values file defaults to `ryanclaw.azurecr.io/openshell/...:dev`;
+override `image.repository`, `image.tag`, `supervisor.image.repository`,
+and `supervisor.image.tag` in your own values overlay if you publish
+somewhere else.
+
+| Component                  | Image                                                                | Tag in `values.yaml` |
+| -------------------------- | -------------------------------------------------------------------- | -------------------- |
+| OpenShell gateway          | `ryanclaw.azurecr.io/openshell/gateway`                              | `dev` (HEAD build)   |
+| OpenShell sandbox supervisor | `ryanclaw.azurecr.io/openshell/supervisor`                         | `dev` (HEAD build)   |
+| Sandbox base image (default) | `ghcr.io/nvidia/openshell-community/sandboxes/base`                | `latest`             |
+| `agent-sandbox` controller | `registry.k8s.io/agent-sandbox/agent-sandbox-controller`             | `v0.1.0`             |
+
+- The gateway and supervisor tags live in [`values.yaml`](./values.yaml).
+- The sandbox base image is the gateway's chart default
+  (`server.sandboxImage`); override it in `values.yaml` if you want to pin
+  the sandbox image too.
+- The `agent-sandbox` controller version is pinned by the manifest at
+  `deploy/kube/manifests/agent-sandbox.yaml`.
+
+To build the gateway and supervisor images yourself and push them to your
+own registry:
+
+```bash
+export IMAGE_REGISTRY=<your-registry>            # e.g. ryanclaw.azurecr.io
+export IMAGE_TAG=dev                              # or any tag you like
+DOCKER_PUSH=1 mise run build:docker:gateway
+DOCKER_PUSH=1 mise run build:docker:supervisor
+```
+
+Then update `image.repository`, `image.tag`, `supervisor.image.repository`,
+and `supervisor.image.tag` in `values.yaml` to point at your registry and
+tag.
+
+## Walkthrough
+
+### 1. Install the agent-sandbox controller (one-time, per cluster)
+
+The OpenShell gateway represents each sandbox as a `Sandbox` custom resource
+(group `agents.x-k8s.io`). The upstream
+[`agent-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox)
+controller turns those CRs into running pods, so it must be installed on
+the cluster before the gateway can create sandboxes. The repository ships a
+pinned manifest:
+
+```bash
+kubectl --context "$KUBE_CONTEXT" apply -f deploy/kube/manifests/agent-sandbox.yaml
+kubectl --context "$KUBE_CONTEXT" wait --for=condition=Established \
+  crd/sandboxes.agents.x-k8s.io --timeout=120s
+kubectl --context "$KUBE_CONTEXT" -n agent-sandbox-system \
+  rollout status statefulset/agent-sandbox-controller --timeout=180s
+```
+
+You only need to do this once per cluster, regardless of how many gateways
+or sandboxes you later install.
+
+### 2. Install the gateway
+
+Install the chart into a dedicated namespace on the target cluster. This
+example uses the **HEAD chart** in this checkout (`deploy/helm/openshell`)
+paired with a HEAD-built gateway/supervisor image (see
+[Pinned component versions](#pinned-component-versions) above for the build
+commands). The HEAD chart drives the gateway via environment variables
+(`OPENSHELL_*`); released `v0.0.x` charts read a TOML file and will not
+honor this values overlay.
+
+```bash
+kubectl --context "$KUBE_CONTEXT" create namespace "$OPENSHELL_NAMESPACE"
+helm --kube-context "$KUBE_CONTEXT" upgrade --install "$OPENSHELL_RELEASE" \
+  deploy/helm/openshell \
+  --namespace "$OPENSHELL_NAMESPACE" \
+  --values examples/three-sandboxes-on-kubernetes/values.yaml
+```
+
+Or run the helper script, which does the same thing against `deploy/helm/openshell`
+in your working tree:
+
+```bash
+bash examples/three-sandboxes-on-kubernetes/install-gateway.sh
+```
+
+Set `CHART_PATH` to override the chart location (for example, to pin a
+released chart version checked out at a tag via `git worktree`).
+
+> **Why HEAD and not v0.0.47?**
+> The `server.sandboxPrivileged` knob this example uses to unblock AKS
+> only exists in the HEAD Rust gateway and HEAD chart; it is not in
+> `v0.0.47`. Released charts also drive the gateway via a TOML ConfigMap,
+> while the HEAD chart drives it via environment variables. Mixing the two
+> leaves sandboxes with an empty `OPENSHELL_ENDPOINT` and
+> `invalid gRPC endpoint`. Pin the chart and image to the same revision.
+
+Wait for the gateway pod to become ready:
+
+```bash
+kubectl --context "$KUBE_CONTEXT" -n "$OPENSHELL_NAMESPACE" \
+  rollout status statefulset/"$OPENSHELL_RELEASE"
+```
+
+The values file disables TLS and uses a `ClusterIP` service, which keeps the
+example short. For production deployments keep TLS enabled and place the
+gateway behind a trusted ingress or load balancer.
+
+### 3. Forward the gateway and register it with the CLI
+
+Forward the gateway service to your workstation. Leave this running in a
+separate terminal:
+
+```bash
+kubectl --context "$KUBE_CONTEXT" -n "$OPENSHELL_NAMESPACE" \
+  port-forward svc/"$OPENSHELL_RELEASE" 8080:8080
+```
+
+Register the forwarded endpoint with the CLI and select it as active:
+
+```bash
+openshell gateway add http://127.0.0.1:8080 --local --name "$KUBE_CONTEXT"
+openshell status
+```
+
+`openshell status` should report the gateway as `HEALTHY`.
+
+### 4. Create three sandboxes
+
+Each `openshell sandbox create` call provisions one sandbox pod in the
+cluster's sandbox namespace (defaults to the gateway's release namespace).
+`--keep` keeps the sandbox running after the create command exits.
+
+```bash
+openshell sandbox create --name alpha --keep --no-auto-providers --no-tty -- echo "alpha ready"
+openshell sandbox create --name beta  --keep --no-auto-providers --no-tty -- echo "beta ready"
+openshell sandbox create --name gamma --keep --no-auto-providers --no-tty -- echo "gamma ready"
+```
+
+Or run the helper script, which creates all three:
+
+```bash
+bash examples/three-sandboxes-on-kubernetes/create-sandboxes.sh
+```
+
+### 5. Verify
+
+List the sandboxes registered with the gateway:
+
+```bash
+openshell sandbox list
+```
+
+Confirm the corresponding pods exist on your cluster:
+
+```bash
+kubectl --context "$KUBE_CONTEXT" -n "$OPENSHELL_NAMESPACE" \
+  get pods -l 'agents.x-k8s.io/sandbox-name-hash'
+```
+
+You should see three sandbox pods, one per sandbox. Connect into any of
+them:
+
+```bash
+openshell sandbox connect alpha
+```
+
+### 6. Clean up
+
+Delete the sandboxes through the CLI (which removes the pods from the
+cluster):
+
+```bash
+openshell sandbox delete alpha
+openshell sandbox delete beta
+openshell sandbox delete gamma
+```
+
+Optionally uninstall the gateway and namespace when you are done:
+
+```bash
+helm --kube-context "$KUBE_CONTEXT" uninstall "$OPENSHELL_RELEASE" \
+  --namespace "$OPENSHELL_NAMESPACE"
+kubectl --context "$KUBE_CONTEXT" delete namespace "$OPENSHELL_NAMESPACE"
+```
+
+The `agent-sandbox` controller is shared infrastructure — leave it installed
+if you plan to run more gateways on the same cluster. To remove it:
+
+```bash
+kubectl --context "$KUBE_CONTEXT" delete -f deploy/kube/manifests/agent-sandbox.yaml
+```
+
+## Cluster compatibility
+
+This example needs the cluster to satisfy two independent runtime
+requirements: the supervisor binary must be sideloadable into sandbox
+pods, **and** the sandbox container must be able to set up its own network
+namespace.
+
+### Supervisor sideload
+
+The gateway can deliver the `openshell-sandbox` supervisor binary into each
+sandbox pod in one of two ways. `values.yaml` leaves
+`supervisor.sideloadMethod: ""`, which auto-picks per cluster K8s version:
+
+| Method            | Pros                              | Cons                                                                                                |
+| ----------------- | --------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `init-container`  | Works on any Kubernetes version   | Adds an init container and an emptyDir per sandbox                                                  |
+| `image-volume`    | No init container, no extra volume | Requires K8s ≥ 1.33 with the `ImageVolume` feature gate (GA in 1.36); incompatible with `hostUsers: false` on filesystems that do not support idmap mounts (notably AKS) |
+
+The privileged sandbox path used by this example does **not** set
+`hostUsers: false`, so `image-volume` works even on AKS. If you switch to
+`server.enableUserNamespaces: true` on AKS, force `init-container` to
+avoid the idmap-mount conflict.
+
+### Network-namespace setup
+
+The supervisor's first action inside a sandbox pod is:
+
+```text
+mkdir /run/netns
+mount --bind /run/netns /run/netns
+mount --make-shared /run/netns
+ip netns add sandbox-<id>
+```
+
+That `mount --make-shared` requires more than just `CAP_SYS_ADMIN` /
+`CAP_NET_ADMIN` — the kernel must allow changing mount propagation from
+inside the container. Two ways to get that, both wired into the chart:
+
+1. **User-namespaced sandbox** (`server.enableUserNamespaces: true`). The
+   pod runs with `hostUsers: false`, capabilities become namespaced, and
+   the supervisor can mark `/run/netns` shared. Needs K8s ≥ 1.33 with
+   `UserNamespacesSupport` (beta in 1.33–1.35, GA in 1.36+) and Linux
+   ≥ 5.12 on the nodes. Works on kind, k3d/k3s, minikube (with a real
+   VM driver), GKE on Ubuntu node images, EKS on AL2023, etc.
+
+2. **Privileged sandbox** (`server.sandboxPrivileged: true`). The pod runs
+   with `securityContext.privileged: true`, which drops the seccomp,
+   AppArmor, and locked-mount restrictions that block mount-propagation
+   changes. Bigger hammer, but the only knob that works on AKS today (see
+   below). Use this only on dedicated single-tenant clusters.
+
+`values.yaml` in this example uses the privileged path because the
+walkthrough's reference cluster is AKS. Switch to user namespaces (and
+turn `sandboxPrivileged` off) on any runtime that supports them.
+
+### Known-good runtimes
+
+| Runtime / provider | Default `values.yaml` (`sandboxPrivileged: true`) | With `enableUserNamespaces: true` instead |
+| ------------------ | ------------------------------------------------ | ----------------------------------------- |
+| `kind` (≥ 1.33)    | ✅ Works                                         | ✅ Works (preferred)                       |
+| `k3d` / `k3s` (≥ 1.33) | ✅ Works                                     | ✅ Works (preferred)                       |
+| `minikube` (`--driver=kvm2` or `qemu`, ≥ 1.33) | ✅ Works           | ✅ Works (preferred)                       |
+| GKE (Ubuntu node image, ≥ 1.33) | ✅ Works                          | ✅ Works (preferred)                       |
+| AKS (Ubuntu, ≥ 1.35) | ✅ Works                                       | ❌ Pod crash-loops on `mount --make-shared` (see below) |
+
+### AKS specifics
+
+AKS up through 1.35 ships containerd 2.1 on Ubuntu 24.04 nodes, and its
+default seccomp/AppArmor configuration **rejects `mount --make-shared` from
+inside the container even when `hostUsers: false` is set**. With user
+namespaces alone the pod crash-loops with:
+
+```text
+× Network namespace creation failed and proxy mode requires isolation.
+  Error: mount --make-shared /run/netns failed: Permission denied
+```
+
+The fix on AKS is to use `server.sandboxPrivileged: true` (the default in
+this example's `values.yaml`). Privileged sandboxes drop the security
+boundary that AKS leans on, so the trade-off is real:
+
+- Sandboxes run as full-host-capable containers. Treat the cluster as
+  trusted infrastructure for trusted workloads only.
+- Do not mix tenant workloads with sandbox workloads on the same node
+  pool.
+- Watch [`enableUserNamespaces`](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/)
+  rollout in AKS — once the underlying containerd seccomp profile allows
+  mount-propagation changes from a user-namespaced container, switch to
+  the user-namespace path and turn `sandboxPrivileged` back off.
+
+### Quick diagnosis
+
+If `openshell sandbox create` reports
+`DependenciesNotReady: Pod is Running but not Ready` or
+`supervisor session not connected`, inspect the sandbox pod's logs:
+
+```bash
+kubectl --context "$KUBE_CONTEXT" -n "$OPENSHELL_NAMESPACE" logs <sandbox-name>
+```
+
+| Error                                              | Cause                                                                                  |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `exec: "/opt/openshell/bin/openshell-sandbox": no such file or directory` | Supervisor sideload failed — switch `sideloadMethod` (init-container vs image-volume) |
+| `invalid gRPC endpoint` / `Policy fetch failed`    | `OPENSHELL_ENDPOINT` is empty — the chart and gateway image revisions are out of sync (HEAD chart needs HEAD image; v0.0.x chart needs same v0.0.x image) |
+| `mount --make-shared /run/netns failed: Permission denied` | Container runtime blocks mount-propagation changes — enable `server.sandboxPrivileged` (works on AKS) or `server.enableUserNamespaces` (works on most other runtimes) |
+| `failed to set MOUNT_ATTR_IDMAP ... invalid argument` | `image-volume` sideload + `hostUsers: false` on a filesystem that doesn't support idmap mounts — switch `sideloadMethod` to `init-container` or turn off `enableUserNamespaces` |
+| `missing authorization header`                     | `server.disableGatewayAuth` is not `true` — see [What's in this example](#whats-in-this-example) |
+
+## Notes
+
+- Sandbox pods land in the gateway's release namespace by default. Override
+  this with `server.sandboxNamespace` in `values.yaml` if you want a
+  separate namespace for sandboxes.
+- The CLI talks to the gateway, not directly to the Kubernetes API. Once
+  the gateway is reachable, sandbox lifecycle commands work the same on
+  any cluster.
+- For remote-only access (no port-forward), expose the gateway through an
+  ingress or load balancer and register the public URL instead.

--- a/examples/three-sandboxes-on-kubernetes/create-sandboxes.sh
+++ b/examples/three-sandboxes-on-kubernetes/create-sandboxes.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Create three OpenShell sandboxes on the gateway installed on the
+# cluster named by $KUBE_CONTEXT.
+#
+# Assumes:
+#   - install-gateway.sh has already been run.
+#   - The gateway is reachable to the CLI (e.g. via `kubectl port-forward`
+#     or an ingress), and registered with `openshell gateway add`.
+#
+# Required env:
+#   KUBE_CONTEXT          kubeconfig context where the gateway is installed
+#
+# Optional env:
+#   OPENSHELL_NAMESPACE   namespace where sandbox pods live (default: openshell)
+#
+# Usage:
+#   export KUBE_CONTEXT=<your-context>
+#   bash examples/three-sandboxes-on-kubernetes/create-sandboxes.sh
+
+set -euo pipefail
+
+: "${KUBE_CONTEXT:?KUBE_CONTEXT must be set (e.g. export KUBE_CONTEXT=testmember-5)}"
+
+SANDBOXES=("alpha" "beta" "gamma")
+
+if ! command -v openshell >/dev/null 2>&1; then
+    echo "openshell CLI not found in PATH" >&2
+    exit 1
+fi
+
+echo "▸ Verifying active gateway"
+openshell status
+
+for name in "${SANDBOXES[@]}"; do
+    echo
+    echo "▸ Creating sandbox: ${name}"
+    openshell sandbox create \
+        --name "${name}" \
+        --keep \
+        --no-auto-providers \
+        --no-tty \
+        -- echo "${name} ready"
+done
+
+echo
+echo "▸ Sandboxes registered with the gateway:"
+openshell sandbox list
+
+NAMESPACE="${OPENSHELL_NAMESPACE:-openshell}"
+
+echo
+echo "▸ Sandbox pods on context '${KUBE_CONTEXT}' in namespace '${NAMESPACE}':"
+kubectl --context "${KUBE_CONTEXT}" -n "${NAMESPACE}" get pods \
+    -l 'agents.x-k8s.io/sandbox-name-hash' || true
+
+echo
+echo "Connect into any of them with:"
+for name in "${SANDBOXES[@]}"; do
+    echo "  openshell sandbox connect ${name}"
+done

--- a/examples/three-sandboxes-on-kubernetes/install-gateway.sh
+++ b/examples/three-sandboxes-on-kubernetes/install-gateway.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Install the OpenShell gateway into the cluster reachable via the
+# kubeconfig context named by $KUBE_CONTEXT. Idempotent: re-running
+# upgrades the release in place.
+#
+# Required env:
+#   KUBE_CONTEXT          kubeconfig context to target (e.g. testmember-5)
+#
+# Optional env:
+#   OPENSHELL_NAMESPACE   namespace for the gateway (default: openshell)
+#   OPENSHELL_RELEASE     Helm release name (default: openshell)
+#   CHART_PATH            path to the OpenShell helm chart
+#                         (default: ./deploy/helm/openshell in this checkout).
+#                         Set to a chart checked out at the same tag as the
+#                         gateway image in values.yaml — e.g.
+#                           git worktree add /tmp/openshell-v0.0.47 v0.0.47
+#                           export CHART_PATH=/tmp/openshell-v0.0.47/deploy/helm/openshell
+#                         Mismatched chart/image versions cause sandbox pods
+#                         to fail with "invalid gRPC endpoint".
+#
+# Usage:
+#   export KUBE_CONTEXT=<your-context>
+#   bash examples/three-sandboxes-on-kubernetes/install-gateway.sh
+
+set -euo pipefail
+
+: "${KUBE_CONTEXT:?KUBE_CONTEXT must be set (e.g. export KUBE_CONTEXT=testmember-5)}"
+NAMESPACE="${OPENSHELL_NAMESPACE:-openshell}"
+RELEASE="${OPENSHELL_RELEASE:-openshell}"
+CONTEXT="${KUBE_CONTEXT}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CHART_DIR="${CHART_PATH:-${REPO_ROOT}/deploy/helm/openshell}"
+VALUES_FILE="${SCRIPT_DIR}/values.yaml"
+
+echo "▸ Verifying kube context: ${CONTEXT}"
+kubectl --context "${CONTEXT}" cluster-info >/dev/null
+
+echo "▸ Ensuring namespace ${NAMESPACE} exists"
+kubectl --context "${CONTEXT}" get namespace "${NAMESPACE}" >/dev/null 2>&1 \
+    || kubectl --context "${CONTEXT}" create namespace "${NAMESPACE}"
+
+echo "▸ Installing gateway (release=${RELEASE}, namespace=${NAMESPACE})"
+helm --kube-context "${CONTEXT}" upgrade --install "${RELEASE}" "${CHART_DIR}" \
+    --namespace "${NAMESPACE}" \
+    --values "${VALUES_FILE}"
+
+echo "▸ Waiting for gateway rollout"
+kubectl --context "${CONTEXT}" -n "${NAMESPACE}" rollout status "statefulset/${RELEASE}" --timeout=180s
+
+echo
+echo "Gateway installed on context '${CONTEXT}' in namespace '${NAMESPACE}'."
+echo "Next: forward the gateway service in another terminal:"
+echo "  kubectl --context ${CONTEXT} -n ${NAMESPACE} port-forward svc/${RELEASE} 8080:8080"
+echo "Then register it with the CLI:"
+echo "  openshell gateway add http://127.0.0.1:8080 --local --name ${CONTEXT}"

--- a/examples/three-sandboxes-on-kubernetes/values.yaml
+++ b/examples/three-sandboxes-on-kubernetes/values.yaml
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Helm values for the "three sandboxes on Kubernetes" example.
+#
+# Optimized for local evaluation against any cluster:
+#   - TLS off and gateway auth disabled, so the CLI can talk to the gateway
+#     over plaintext through `kubectl port-forward` without minting client
+#     certs.
+#   - ClusterIP service (the default) so nothing is exposed externally.
+#
+# This file targets the HEAD chart in this checkout (`deploy/helm/openshell`)
+# and a HEAD-built gateway/supervisor image pair. The HEAD chart drives the
+# gateway via environment variables (`OPENSHELL_*`), so the chart and image
+# must be from the same revision. Released v0.0.x charts read a TOML file
+# instead and are not compatible with this values file.
+#
+# For production deployments keep TLS enabled and place the gateway behind
+# a trusted ingress or load balancer.
+
+# Gateway + supervisor images. Override to your own registry when you build
+# locally (e.g. `image.repository=ryanclaw.azurecr.io/openshell/gateway`).
+# The defaults below match a build pushed by:
+#   IMAGE_REGISTRY=ryanclaw.azurecr.io IMAGE_TAG=dev DOCKER_PUSH=1 \
+#     mise run build:docker:gateway
+#   IMAGE_REGISTRY=ryanclaw.azurecr.io IMAGE_TAG=dev DOCKER_PUSH=1 \
+#     mise run build:docker:supervisor
+image:
+  repository: ryanclaw.azurecr.io/gateway
+  tag: "dev-privileged-1779820809"
+  pullPolicy: Always
+
+supervisor:
+  image:
+    repository: ryanclaw.azurecr.io/supervisor
+    tag: "dev-privileged-1779820809"
+    pullPolicy: Always
+  # Auto-detect sideload method based on K8s version. On v1.35+ this picks
+  # `image-volume`. On AKS that combo works only when the sandbox container
+  # does NOT run with `hostUsers: false` (idmap mounts on the AKS root
+  # filesystem fail) — which is fine here because we use the privileged
+  # path below instead of user namespaces.
+  sideloadMethod: ""
+
+service:
+  type: ClusterIP
+  port: 8080
+
+server:
+  # Plaintext gateway. Combined with disableGatewayAuth below this means the
+  # CLI can connect directly through `kubectl port-forward` with no auth.
+  disableTls: true
+  # UNSAFE: accept unauthenticated CLI requests. Required for this example so
+  # the CLI can talk to the gateway over plaintext through `kubectl
+  # port-forward`. Do NOT use in production — front the gateway with OIDC
+  # or mTLS instead.
+  disableGatewayAuth: true
+  # Explicit gRPC endpoint sandbox pods dial back into. The chart auto-derives
+  # this from the service name when left empty; we set it explicitly so the
+  # example is easy to copy-paste into any namespace/release.
+  grpcEndpoint: "http://openshell.openshell.svc.cluster.local:8080"
+  # UNSAFE: run sandbox pods with `securityContext.privileged: true`. Required
+  # on AKS because containerd 2.1 rejects `mount --make-shared /run/netns`
+  # from inside the sandbox container even when `hostUsers: false` is set
+  # (the kernel mount-propagation lockdown ignores namespaced CAP_SYS_ADMIN
+  # when the underlying mount is owned by the host init userns). Privileged
+  # mode bypasses that guard by dropping the seccomp + capability + locked-
+  # mount restrictions entirely.
+  #
+  # Only enable on dedicated single-tenant clusters. On runtimes that
+  # support user namespaces (kind, k3d, GKE-Ubuntu, EKS-AL2023), prefer
+  # `enableUserNamespaces: true` and leave this off.
+  sandboxPrivileged: true
+  # Sandbox pods are created in the gateway's release namespace by default.
+  # Uncomment and set to isolate sandbox pods in a separate namespace.
+  # sandboxNamespace: openshell-sandboxes
+
+# Pre-install hook that creates the JWT signing-key Secret (and PKI certs
+# when TLS is enabled). Keep enabled: even with `disableTls: true` and
+# `disableGatewayAuth: true`, the gateway StatefulSet mounts the
+# `openshell-jwt-keys` Secret and stays in `ContainerCreating` if it
+# does not exist.
+pkiInitJob:
+  enabled: true

--- a/mise.lock
+++ b/mise.lock
@@ -44,6 +44,7 @@ url_api = "https://api.github.com/repos/anchore/syft/releases/assets/402658323"
 checksum = "sha256:7b98251d2d08926bb5d4639b56b1f0996a58ef6667c5830e3fe3cd3ad5f4214a"
 url = "https://github.com/anchore/syft/releases/download/v1.43.0/syft_1.43.0_linux_amd64.tar.gz"
 url_api = "https://api.github.com/repos/anchore/syft/releases/assets/402658325"
+provenance = "github-attestations"
 
 [tools."github:anchore/syft"."platforms.linux-x64-musl"]
 checksum = "sha256:7b98251d2d08926bb5d4639b56b1f0996a58ef6667c5830e3fe3cd3ad5f4214a"
@@ -293,6 +294,7 @@ url = "https://storage.googleapis.com/skaffold/releases/v2.19.0/skaffold-linux-a
 url = "https://storage.googleapis.com/skaffold/releases/v2.19.0/skaffold-linux-arm64"
 
 [tools.skaffold."platforms.linux-x64"]
+checksum = "blake3:de828fa7e9d89de048a6e89425cbdac7199d59a9fb0750b44ffe31734c074104"
 url = "https://storage.googleapis.com/skaffold/releases/v2.19.0/skaffold-linux-amd64"
 
 [tools.skaffold."platforms.linux-x64-musl"]
@@ -357,6 +359,7 @@ url = "https://ziglang.org/download/0.14.1/zig-aarch64-linux-0.14.1.tar.xz"
 [tools.zig."platforms.linux-x64"]
 checksum = "sha256:24aeeec8af16c381934a6cd7d95c807a8cb2cf7df9fa40d359aa884195c4716c"
 url = "https://ziglang.org/download/0.14.1/zig-x86_64-linux-0.14.1.tar.xz"
+provenance = "minisign"
 
 [tools.zig."platforms.macos-arm64"]
 checksum = "sha256:39f3dc5e79c22088ce878edc821dedb4ca5a1cd9f5ef915e9b3cc3053e8faefa"


### PR DESCRIPTION
## Summary

Two related fixes discovered while running OpenShell end-to-end on AKS (testmember-5 cluster):

1. **New feature: `sandboxPrivileged` knob** — adds `server.sandboxPrivileged` Helm value to run sandbox pods with `securityContext.privileged: true`. Required on AKS because containerd 2.1.6+ blocks `mount --make-shared /run/netns` even with namespaced `CAP_SYS_ADMIN`; only `privileged: true` allows the supervisor to set up its network namespace.

2. **Bug fix: `OPENSHELL_DISABLE_GATEWAY_AUTH` misplacement** — in `statefulset.yaml`, this env var was nested inside the `{{- else }}` branch of `if .Values.server.disableTls`, meaning it was injected only when TLS was **enabled** — the exact opposite of when it's needed. Fixed by hoisting it to its own `{{- if .Values.server.disableGatewayAuth }}` block.

3. **New example**: `examples/three-sandboxes-on-kubernetes/` — complete walkthrough for deploying 3 sandboxes (alpha/beta/gamma) on an AKS cluster, including Helm values, install/create scripts, and a detailed README.

## Related Issue

N/A (discovered during AKS testing)

## Changes

- `crates/openshell-core/src/config.rs` — Added `sandbox_privileged: bool` field to `Config` with safety warning doc comment
- `crates/openshell-server/src/cli.rs` — Added `--sandbox-privileged` / `OPENSHELL_SANDBOX_PRIVILEGED` CLI flag + env var
- `crates/openshell-driver-kubernetes/src/config.rs` — Added `sandbox_privileged` to K8s driver config
- `crates/openshell-driver-kubernetes/src/driver.rs` — Pod spec builder emits `securityContext.privileged: true` when flag is set
- `deploy/helm/openshell/values.yaml` — Added `server.sandboxPrivileged: false` with UNSAFE warning
- `deploy/helm/openshell/templates/statefulset.yaml` — **Bug fix**: `OPENSHELL_DISABLE_GATEWAY_AUTH` hoisted out of TLS-else branch; added `OPENSHELL_SANDBOX_PRIVILEGED` block
- `examples/three-sandboxes-on-kubernetes/` — New example: README, `values.yaml`, `install-gateway.sh`, `create-sandboxes.sh`

## Testing

- [x] `mise run pre-commit` passes
- [x] End-to-end verified on AKS (testmember-5): alpha/beta/gamma sandboxes reach Ready, pods Running with `privileged: true`
- [x] `openshell sandbox list`, `openshell sandbox connect`, `openshell policy get` all work against live cluster
- [ ] Unit tests added/updated

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)

## Safety Note

`sandboxPrivileged: true` grants the sandbox pod full host access. It should only be used on dedicated single-tenant clusters where the runtime (containerd/runc) blocks what the supervisor needs. The Helm value defaults to `false` and carries an `# UNSAFE` warning comment.