### PR TITLE
ci(release): fix Ubuntu Snap canary install and registration

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -153,12 +153,16 @@ jobs:
     steps:
       - name: Install snapd
         run: |
+          set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y snapd
+          sudo systemctl enable --now snapd.socket
           sudo systemctl start snapd
+          sudo snap wait system seed.loaded
 
       - name: Install Docker snap
         run: |
+          set -euo pipefail
           sudo snap install docker
 
       - name: Download snap from release-dev artifacts
@@ -167,20 +171,28 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           pattern: snap-linux-amd64
           path: release/
+          merge-multiple: true
 
       - name: Install snap (dangerous — from release, not store)
         run: |
+          set -euo pipefail
           sudo snap install ./release/*.snap --dangerous
 
       - name: Connect interfaces
         run: |
+          set -euo pipefail
           sudo snap connect openshell:docker docker:docker-daemon
           sudo snap connect openshell:log-observe
           sudo snap connect openshell:system-observe
           sudo snap connect openshell:ssh-keys
 
-      - name: Check status
+      - name: Register snap gateway and check status
         run: |
+          set -euo pipefail
+          openshell --version
+          sudo snap services openshell
+          openshell gateway add http://127.0.0.1:17670 --local --name snap-docker
+          openshell gateway select snap-docker
           openshell status
 
   kubernetes:


### PR DESCRIPTION


## Summary
Install the Snap built by the triggering Release Dev workflow by setting `merge-multiple: true` on the artifact download. `actions/download-artifact` otherwise extracts each artifact into its own subdirectory, leaving the package at release/snap-linux-amd64/\*.snap, so the install glob ./release/\*.snap matched nothing. Merging flattens the artifact's contents directly into release/ where the dangerous local snap install expects it.

Harden the Snap canary setup by enabling snapd.socket, waiting for snap seeding (snap wait system seed.loaded), and running every step with strict shell options (set -euo pipefail) so failures surface immediately.

Register the snapped gateway with the CLI as the documented local plaintext snap-docker gateway, and print version and snap services, before running openshell status so the canary verifies a configured and reachable gateway instead of only the install.

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
