### PR TITLE
seccomp: allow memfd_create with MFD_NOEXEC_SEAL to unblock CUDA (#1696)

### DIFF
--- a/crates/openshell-sandbox/src/sandbox/linux/seccomp.rs
+++ b/crates/openshell-sandbox/src/sandbox/linux/seccomp.rs
@@ -217,8 +217,6 @@ fn build_filter_rules(allow_inet: bool) -> Result<BTreeMap<i64, Vec<SeccompRule>
     // --- Unconditional syscall blocks ---
     // These syscalls are blocked entirely (empty rule vec = unconditional EPERM).
 
-    // Fileless binary execution via memfd bypasses Landlock filesystem restrictions.
-    rules.entry(libc::SYS_memfd_create).or_default();
     // Cross-process memory inspection and code injection.
     rules.entry(libc::SYS_ptrace).or_default();
     // Kernel BPF program loading.
@@ -263,6 +261,14 @@ fn build_filter_rules(allow_inet: bool) -> Result<BTreeMap<i64, Vec<SeccompRule>
         4, // flags argument
         libc::AT_EMPTY_PATH as u64,
     )?;
+
+    // memfd_create is blocked unless MFD_NOEXEC_SEAL is set. A sealed-noexec memfd can
+    // never be made executable, so the fileless-execution vector that motivated blocking
+    // memfd_create stays closed (and is doubly covered by the execveat(AT_EMPTY_PATH) block
+    // above), while legitimate non-executable in-memory files are permitted. The NVIDIA
+    // CUDA driver requires memfd_create during initialization; blocking it unconditionally
+    // makes CUDA fail with cudaErrorOperatingSystem (304) inside the sandbox.
+    add_memfd_noexec_rule(&mut rules)?;
 
     // unshare with CLONE_NEWUSER allows creating user namespaces to escalate privileges.
     add_masked_arg_rule(
@@ -361,6 +367,31 @@ fn add_masked_arg_rule(
     Ok(())
 }
 
+/// Block `memfd_create` unless `MFD_NOEXEC_SEAL` is set in the flags argument.
+///
+/// `MFD_NOEXEC_SEAL` (Linux 6.3+) creates an anonymous file that can never be made
+/// executable, preserving the anti-fileless-execution intent of blocking `memfd_create`
+/// while allowing legitimate non-executable in-memory files (e.g. those the NVIDIA CUDA
+/// driver creates during initialization). Uses `MaskedEq(MFD_NOEXEC_SEAL) == 0`, which
+/// triggers EPERM when the flag is absent and allows the call when it is present.
+fn add_memfd_noexec_rule(rules: &mut BTreeMap<i64, Vec<SeccompRule>>) -> Result<()> {
+    // MFD_NOEXEC_SEAL is not exposed by all libc versions, so define it locally.
+    const MFD_NOEXEC_SEAL: u64 = 0x0008;
+    let condition = SeccompCondition::new(
+        1, // flags argument
+        SeccompCmpArgLen::Dword,
+        SeccompCmpOp::MaskedEq(MFD_NOEXEC_SEAL),
+        0,
+    )
+    .into_diagnostic()?;
+    let rule = SeccompRule::new(vec![condition]).into_diagnostic()?;
+    rules
+        .entry(libc::SYS_memfd_create)
+        .or_default()
+        .push(rule);
+    Ok(())
+}
+
 #[cfg(test)]
 // libc/syscall FFI requires unsafe; these tests fork children and exercise
 // blocked syscalls, so unsafe blocks/calls are pervasive.
@@ -421,7 +452,6 @@ mod tests {
 
         // Unconditional blocks have an empty Vec (no conditions = always match).
         let expected = [
-            libc::SYS_memfd_create,
             libc::SYS_ptrace,
             libc::SYS_bpf,
             libc::SYS_process_vm_readv,
@@ -463,6 +493,7 @@ mod tests {
         let filter_rules = build_filter_rules(true).unwrap();
 
         for syscall in [
+            libc::SYS_memfd_create,
             libc::SYS_execveat,
             libc::SYS_unshare,
             libc::SYS_clone,


### PR DESCRIPTION
## Context (what we're doing and why)
We're evaluating OpenShell as a **secure GPU coding-agent sandbox** on NVIDIA's Horde platform — the goal is to let a developer request a sandbox where an AI coding agent (Claude Code) can **build and run real GPU workloads** on their behalf. Using NVIDIA OVRTX (Omniverse RTX) as the test workload, everything works inside an OpenShell `--gpu` sandbox (agent runs, GPU is attached, NVML/`nvidia-smi` + Vulkan work, the project builds) **except CUDA**, which is what RTX/OptiX (and ML) need. This PR fixes that one gap. See #1696 for the full investigation.

## What
Allow `memfd_create` when `MFD_NOEXEC_SEAL` is set, instead of blocking it unconditionally.

Fixes the CUDA blocker in #1696: `--gpu` sandboxes can't initialize CUDA (`cudaErrorOperatingSystem` / 304) because the NVIDIA driver needs `memfd_create` during init. NVML/`nvidia-smi` and Vulkan work, but all CUDA/RTX/ML workloads fail.

## How
`build_filter_rules` previously blocked `memfd_create` unconditionally (empty rule vec). This PR replaces that with a conditional rule (`add_memfd_noexec_rule`) that triggers EPERM only when `MFD_NOEXEC_SEAL` is **absent** — i.e. it permits `memfd_create` only with `MFD_NOEXEC_SEAL`, mirroring the existing `add_masked_arg_rule` pattern (`MaskedEq(MFD_NOEXEC_SEAL) == 0`).

## Why it stays secure
`MFD_NOEXEC_SEAL` (Linux 6.3+) creates a memfd that can **never** be made executable, so the fileless-execution vector that motivated the original block stays closed. It's also doubly covered by the existing `execveat(AT_EMPTY_PATH)` block. Net security regression is negligible: executable memfds remain blocked, and all other containment (egress proxy, credential isolation, non-root, no ptrace, the other seccomp blocks, landlock) is unchanged. `memfd_create` grants in-memory file creation only — not network/secret/host access.

## How it was confirmed
GPU/driver/image are fine — the same workload renders via `docker exec` into the same container (bypassing the process-sandbox). A direct `ctypes` call to `memfd_create` (syscall 319) returns `EPERM` under OpenShell but succeeds via `docker exec`, isolating the cause to this seccomp rule. (Disabling landlock did not help, confirming it's seccomp, not the filesystem layer.)

## Tests
- Moved `SYS_memfd_create` from `unconditional_blocks_present_in_filter` to `conditional_blocks_have_rules`.
- `behavioral_memfd_create_blocked` still valid (it calls `memfd_create` with `flags=0`, which remains blocked since `MFD_NOEXEC_SEAL` is absent).

## Validation note
Opening as a draft — I verified the change against the existing patterns/tests but haven't run the full project CI locally. Happy to iterate. I can also validate end-to-end on a patched build (OVRTX renders in-sandbox once `memfd_create` is permitted) and report back.

Refs #1696
