### PR TITLE
ci(release): authenticate snap canary artifact download

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -168,6 +168,7 @@ jobs:
       - name: Download snap from release-dev artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
           pattern: snap-linux-amd64
           path: release/


### PR DESCRIPTION


## Summary
The Ubuntu Snap canary downloads its artifact from a different workflow run (the triggering Release Dev run) via run-id. Cross-run downloads require authentication, so pass github.token to actions/download-artifact. See note: https://docs.github.com/en/actions/tutorials/store-and-share-data#downloading-artifacts-during-a-workflow-run

This is an(other) attempt to fix the release canary.

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
