### PR TITLE
refactor: deduplicate shared driver and TUI helpers

### DIFF
--- a/crates/openshell-core/src/driver_utils.rs
+++ b/crates/openshell-core/src/driver_utils.rs
@@ -89,3 +89,38 @@ pub fn sandbox_log_level(sandbox: &DriverSandbox, default_level: &str) -> String
         .unwrap_or(default_level)
         .to_string()
 }
+
+// ---------------------------------------------------------------------------
+// Supervisor image helpers (shared by Docker and Podman drivers)
+// ---------------------------------------------------------------------------
+
+/// Return the tag portion of a supervisor image reference, or `None` if the
+/// reference uses a digest (`@sha256:...`).
+///
+/// Examples:
+/// - `"ghcr.io/org/image:1.2.3"` → `Some("1.2.3")`
+/// - `"ghcr.io/org/image:latest"` → `Some("latest")`
+/// - `"ghcr.io/org/image"` → `Some("latest")`  (implied tag)
+/// - `"ghcr.io/org/image@sha256:abc"` → `None`  (pinned by digest)
+/// - `"ghcr.io/org/image:"` → `None`  (empty tag)
+pub fn supervisor_image_tag(image: &str) -> Option<&str> {
+    if image.contains('@') {
+        return None;
+    }
+
+    let image_name = image.rsplit('/').next().unwrap_or(image);
+    image_name
+        .rsplit_once(':')
+        .map_or(Some("latest"), |(_, tag)| {
+            if tag.is_empty() { None } else { Some(tag) }
+        })
+}
+
+/// Return `true` if the supervisor image should be refreshed before each use.
+///
+/// Mutable tags (`dev`, `latest`) are always re-pulled so that the running
+/// container tracks the latest pushed version.  Digest-pinned references and
+/// all other versioned tags are treated as immutable and pulled at most once.
+pub fn supervisor_image_should_refresh(image: &str) -> bool {
+    matches!(supervisor_image_tag(image), Some("dev" | "latest"))
+}

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -23,7 +23,7 @@ use openshell_core::config::{
 };
 use openshell_core::driver_utils::{
     LABEL_MANAGED_BY, LABEL_MANAGED_BY_VALUE, LABEL_SANDBOX_ID, LABEL_SANDBOX_NAME,
-    LABEL_SANDBOX_NAMESPACE, SUPERVISOR_IMAGE_BINARY_PATH,
+    LABEL_SANDBOX_NAMESPACE, SUPERVISOR_IMAGE_BINARY_PATH, supervisor_image_should_refresh,
 };
 use openshell_core::gpu::cdi_gpu_device_ids;
 use openshell_core::progress::{
@@ -2570,23 +2570,6 @@ async fn extract_supervisor_bin_from_image(docker: &Docker, image: &str) -> Core
     write_cache_binary_atomic(&cache_path, &binary_bytes)?;
     validate_linux_elf_binary(&cache_path)?;
     Ok(cache_path)
-}
-
-fn supervisor_image_should_refresh(image: &str) -> bool {
-    matches!(supervisor_image_tag(image), Some("dev" | "latest"))
-}
-
-fn supervisor_image_tag(image: &str) -> Option<&str> {
-    if image.contains('@') {
-        return None;
-    }
-
-    let image_name = image.rsplit('/').next().unwrap_or(image);
-    image_name
-        .rsplit_once(':')
-        .map_or(Some("latest"), |(_, tag)| {
-            if tag.is_empty() { None } else { Some(tag) }
-        })
 }
 
 async fn pull_supervisor_image(docker: &Docker, image: &str) -> CoreResult<()> {

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -10,6 +10,7 @@ use crate::watcher::{
     self, WatchStream, driver_sandbox_from_inspect, driver_sandbox_from_list_entry,
 };
 use openshell_core::ComputeDriverError;
+use openshell_core::driver_utils::supervisor_image_should_refresh;
 use openshell_core::proto::compute::v1::{DriverSandbox, GetCapabilitiesResponse};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -590,23 +591,6 @@ fn supervisor_image_pull_policy(image: &str) -> &'static str {
     } else {
         "missing"
     }
-}
-
-fn supervisor_image_should_refresh(image: &str) -> bool {
-    matches!(supervisor_image_tag(image), Some("dev" | "latest"))
-}
-
-fn supervisor_image_tag(image: &str) -> Option<&str> {
-    if image.contains('@') {
-        return None;
-    }
-
-    let image_name = image.rsplit('/').next().unwrap_or(image);
-    image_name
-        .rsplit_once(':')
-        .map_or(Some("latest"), |(_, tag)| {
-            if tag.is_empty() { None } else { Some(tag) }
-        })
 }
 
 /// Check whether the current user has subuid/subgid ranges configured.

--- a/crates/openshell-server/src/ssh_sessions.rs
+++ b/crates/openshell-server/src/ssh_sessions.rs
@@ -5,6 +5,7 @@
 
 use openshell_core::ObjectId;
 use openshell_core::proto::SshSession;
+use openshell_core::time::now_ms;
 use prost::Message;
 use std::sync::Arc;
 use std::time::Duration;
@@ -33,7 +34,7 @@ pub fn spawn_session_reaper(store: Arc<Store>, interval: Duration) {
 }
 
 async fn reap_expired_sessions(store: &Store) -> Result<(), String> {
-    let now_ms = unix_epoch_millis();
+    let now_ms = now_ms();
 
     let records = store
         .list(SshSession::object_type(), 1000, 0)
@@ -68,16 +69,6 @@ async fn reap_expired_sessions(store: &Store) -> Result<(), String> {
     Ok(())
 }
 
-fn unix_epoch_millis() -> i64 {
-    i64::try_from(
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis(),
-    )
-    .unwrap_or(i64::MAX)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -101,10 +92,6 @@ mod tests {
             expires_at_ms,
             revoked,
         }
-    }
-
-    fn now_ms() -> i64 {
-        unix_epoch_millis()
     }
 
     #[tokio::test]

--- a/crates/openshell-tui/src/ui/dashboard.rs
+++ b/crates/openshell-tui/src/ui/dashboard.rs
@@ -4,8 +4,9 @@
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Cell, Padding, Paragraph, Row, Table};
+use ratatui::widgets::{Block, Borders, Cell, Padding, Row, Table};
 
+use super::draw_empty_message;
 use crate::app::{App, Focus, MiddlePaneTab};
 
 pub fn draw(frame: &mut Frame<'_>, app: &App, area: Rect) {
@@ -118,13 +119,6 @@ fn draw_gateway_list(frame: &mut Frame<'_>, app: &App, area: Rect) {
     frame.render_widget(table, area);
 
     if app.gateways.is_empty() {
-        let inner = Rect {
-            x: area.x + 2,
-            y: area.y + 2,
-            width: area.width.saturating_sub(4),
-            height: area.height.saturating_sub(3),
-        };
-        let msg = Paragraph::new(Span::styled(" No gateways found.", t.muted));
-        frame.render_widget(msg, inner);
+        draw_empty_message(frame, area, " No gateways found.", t.muted);
     }
 }

--- a/crates/openshell-tui/src/ui/global_settings.rs
+++ b/crates/openshell-tui/src/ui/global_settings.rs
@@ -6,6 +6,8 @@ use ratatui::layout::{Constraint, Rect};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Clear, Padding, Paragraph, Row, Table};
 
+use super::draw_empty_message;
+
 use crate::app::{App, MiddlePaneTab};
 
 pub fn draw(frame: &mut Frame<'_>, app: &App, area: Rect, focused: bool) {
@@ -72,14 +74,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App, area: Rect, focused: bool) {
     frame.render_widget(table, area);
 
     if app.global_settings.is_empty() {
-        let inner = Rect {
-            x: area.x + 2,
-            y: area.y + 2,
-            width: area.width.saturating_sub(4),
-            height: area.height.saturating_sub(3),
-        };
-        let msg = Paragraph::new(Span::styled(" No settings available.", t.muted));
-        frame.render_widget(msg, inner);
+        draw_empty_message(frame, area, " No settings available.", t.muted);
     }
 
     // Draw edit overlay if active.

--- a/crates/openshell-tui/src/ui/mod.rs
+++ b/crates/openshell-tui/src/ui/mod.rs
@@ -16,6 +16,7 @@ mod splash;
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
@@ -472,6 +473,21 @@ fn draw_command_bar(frame: &mut Frame<'_>, app: &App, area: Rect) {
 
     let bar = Paragraph::new(line).block(Block::default().borders(Borders::NONE));
     frame.render_widget(bar, area);
+}
+
+/// Render an empty-state message inside a bordered panel.
+///
+/// Calculates an inset [`Rect`] that clears the panel border and renders
+/// `text` with the given `style`.  Use this whenever a table or list has no
+/// rows to display.
+pub fn draw_empty_message(frame: &mut Frame<'_>, area: Rect, text: &str, style: Style) {
+    let inner = Rect {
+        x: area.x + 2,
+        y: area.y + 2,
+        width: area.width.saturating_sub(4),
+        height: area.height.saturating_sub(3),
+    };
+    frame.render_widget(Paragraph::new(Span::styled(text, style)), inner);
 }
 
 /// Center a popup rectangle within `area` using absolute width and height (in

--- a/crates/openshell-tui/src/ui/providers.rs
+++ b/crates/openshell-tui/src/ui/providers.rs
@@ -4,7 +4,7 @@
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Rect};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Cell, Padding, Paragraph, Row, Table};
+use ratatui::widgets::{Block, Borders, Cell, Padding, Row, Table};
 
 use crate::app::App;
 
@@ -83,14 +83,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App, area: Rect, focused: bool) {
     frame.render_widget(table, area);
 
     if app.provider_count == 0 {
-        let inner = Rect {
-            x: area.x + 2,
-            y: area.y + 2,
-            width: area.width.saturating_sub(4),
-            height: area.height.saturating_sub(3),
-        };
-        let msg = Paragraph::new(Span::styled(" No providers. Press [c] to create.", t.muted));
-        frame.render_widget(msg, inner);
+        super::draw_empty_message(frame, area, " No providers. Press [c] to create.", t.muted);
     }
 }
 
@@ -172,13 +165,6 @@ fn draw_v2(frame: &mut Frame<'_>, app: &App, area: Rect, focused: bool) {
     frame.render_widget(table, area);
 
     if app.provider_count == 0 {
-        let inner = Rect {
-            x: area.x + 2,
-            y: area.y + 2,
-            width: area.width.saturating_sub(4),
-            height: area.height.saturating_sub(3),
-        };
-        let msg = Paragraph::new(Span::styled(" No providers found.", t.muted));
-        frame.render_widget(msg, inner);
+        super::draw_empty_message(frame, area, " No providers found.", t.muted);
     }
 }

--- a/crates/openshell-tui/src/ui/sandbox_settings.rs
+++ b/crates/openshell-tui/src/ui/sandbox_settings.rs
@@ -6,6 +6,7 @@ use ratatui::layout::{Constraint, Rect};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Clear, Padding, Paragraph, Row, Table};
 
+use super::draw_empty_message;
 use crate::app::{App, SandboxPolicyTab, SettingScope};
 
 pub fn draw(frame: &mut Frame<'_>, app: &App, area: Rect) {
@@ -83,14 +84,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App, area: Rect) {
     frame.render_widget(table, area);
 
     if app.sandbox_settings.is_empty() {
-        let inner = Rect {
-            x: area.x + 2,
-            y: area.y + 2,
-            width: area.width.saturating_sub(4),
-            height: area.height.saturating_sub(3),
-        };
-        let msg = Paragraph::new(Span::styled(" No settings available.", t.muted));
-        frame.render_widget(msg, inner);
+        draw_empty_message(frame, area, " No settings available.", t.muted);
     }
 
     // Overlays.

--- a/crates/openshell-tui/src/ui/sandboxes.rs
+++ b/crates/openshell-tui/src/ui/sandboxes.rs
@@ -4,7 +4,7 @@
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Rect};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Cell, Padding, Paragraph, Row, Table};
+use ratatui::widgets::{Block, Borders, Cell, Padding, Row, Table};
 
 use crate::app::App;
 
@@ -102,13 +102,6 @@ pub fn draw(frame: &mut Frame<'_>, app: &App, area: Rect, focused: bool) {
     frame.render_widget(table, area);
 
     if app.sandbox_count == 0 {
-        let inner = Rect {
-            x: area.x + 2,
-            y: area.y + 2,
-            width: area.width.saturating_sub(4),
-            height: area.height.saturating_sub(3),
-        };
-        let msg = Paragraph::new(Span::styled(" No sandboxes. Press [c] to create.", t.muted));
-        frame.render_widget(msg, inner);
+        super::draw_empty_message(frame, area, " No sandboxes. Press [c] to create.", t.muted);
     }
 }


### PR DESCRIPTION
## Summary

Remove three categories of copy-pasted code that had grown across the codebase:

1. **`supervisor_image_tag` / `supervisor_image_should_refresh`** — character-for-character duplicates in `openshell-driver-docker` and `openshell-driver-podman`. Moved to `openshell-core::driver_utils`, which already hosts shared driver utilities. Both drivers now import the single canonical copy.

2. **`unix_epoch_millis` in `openshell-server::ssh_sessions`** — a private reimplementation of `openshell_core::time::now_ms`. Replaced with the existing shared function, whose doc-comment explicitly says "prefer this over local implementations."

3. **TUI empty-state panel pattern** — the same 4-line `Rect` + `Paragraph` block appeared in 6 places across 5 UI files (`dashboard`, `sandboxes`, `providers` ×2, `global_settings`, `sandbox_settings`). Extracted as `draw_empty_message()` in `ui/mod.rs` alongside the existing `centered_rect` / `centered_popup` helpers.

## Related Issue

N/A — opportunistic deduplication found via codebase analysis.

## Changes

- `crates/openshell-core/src/driver_utils.rs`: add `supervisor_image_tag` and `supervisor_image_should_refresh` with doc-comments
- `crates/openshell-driver-docker/src/lib.rs`: remove local copies; import from core
- `crates/openshell-driver-podman/src/driver.rs`: remove local copies; import from core
- `crates/openshell-server/src/ssh_sessions.rs`: replace `unix_epoch_millis` with `openshell_core::time::now_ms`
- `crates/openshell-tui/src/ui/mod.rs`: add `draw_empty_message` helper + `Style` import
- `crates/openshell-tui/src/ui/{dashboard,sandboxes,providers,global_settings,sandbox_settings}.rs`: use the helper

Net change: **−101 / +68 lines** (33 lines removed).

## Testing

- [x] `mise run pre-commit` passes (lint, format, license headers, helm, markdown, Python, unit tests)
- [ ] Unit tests added/updated (no new logic; behavior identical)
- [ ] E2E tests added/updated (not applicable — pure refactor)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)