### PR TITLE
fix(kubernetes): configure sandbox apparmor profile

### DIFF
--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -40,6 +40,11 @@ template resource limits. Docker and Podman apply them as runtime limits.
 Kubernetes mirrors each limit into the matching request. VM accepts the fields
 but currently ignores them.
 
+Kubernetes deployments may set an AppArmor profile on sandbox agent containers
+through the driver configuration. The Helm chart defaults sandbox agents to
+`Unconfined` so runtime/default AppArmor profiles do not block supervisor
+network namespace setup on AppArmor-enabled nodes.
+
 VM runtime state paths are derived only from driver-validated sandbox IDs
 matching `[A-Za-z0-9._-]{1,128}`. The gateway-owned VM driver socket uses a
 private `run/` directory plus Unix peer UID/PID checks. Standalone

--- a/crates/openshell-driver-kubernetes/README.md
+++ b/crates/openshell-driver-kubernetes/README.md
@@ -47,6 +47,18 @@ bootstrap exchange.
 The gateway uses the supervisor relay for connect, exec, and file sync. Sandbox
 pods do not need direct external ingress for SSH.
 
+## Container Security Context
+
+The driver grants the sandbox agent container the Linux capabilities the
+supervisor needs for namespace setup and policy enforcement. It can also request
+a Kubernetes AppArmor profile through `app_armor_profile`.
+
+Supported values are `Unconfined`, `RuntimeDefault`, and
+`Localhost/<profile-name>`. An empty or unset value omits
+`securityContext.appArmorProfile`. Helm deployments default sandbox agent
+containers to `Unconfined` because runtime/default AppArmor profiles can block
+the supervisor's network namespace mount setup on AppArmor-enabled nodes.
+
 ## GPU Support
 
 When a sandbox requests GPU support, the driver checks node allocatable capacity

--- a/crates/openshell-driver-kubernetes/src/config.rs
+++ b/crates/openshell-driver-kubernetes/src/config.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use openshell_core::config::DEFAULT_SUPERVISOR_IMAGE;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::str::FromStr;
 
 /// Default Kubernetes namespace for sandbox resources.
 pub const DEFAULT_K8S_NAMESPACE: &str = "openshell";
@@ -36,7 +37,7 @@ impl std::fmt::Display for SupervisorSideloadMethod {
     }
 }
 
-impl std::str::FromStr for SupervisorSideloadMethod {
+impl FromStr for SupervisorSideloadMethod {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -47,6 +48,98 @@ impl std::str::FromStr for SupervisorSideloadMethod {
                 "unknown supervisor sideload method '{other}'; expected 'image-volume' or 'init-container'"
             )),
         }
+    }
+}
+
+/// Kubernetes `AppArmor` profile requested for the sandbox agent container.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AppArmorProfile {
+    RuntimeDefault,
+    Unconfined,
+    Localhost(String),
+}
+
+impl AppArmorProfile {
+    #[must_use]
+    pub fn to_k8s_type(&self) -> &'static str {
+        match self {
+            Self::RuntimeDefault => "RuntimeDefault",
+            Self::Unconfined => "Unconfined",
+            Self::Localhost(_) => "Localhost",
+        }
+    }
+
+    #[must_use]
+    pub fn localhost_profile(&self) -> Option<&str> {
+        match self {
+            Self::Localhost(profile) => Some(profile),
+            Self::RuntimeDefault | Self::Unconfined => None,
+        }
+    }
+}
+
+impl std::fmt::Display for AppArmorProfile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RuntimeDefault => f.write_str("RuntimeDefault"),
+            Self::Unconfined => f.write_str("Unconfined"),
+            Self::Localhost(profile) => write!(f, "Localhost/{profile}"),
+        }
+    }
+}
+
+impl FromStr for AppArmorProfile {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "RuntimeDefault" => Ok(Self::RuntimeDefault),
+            "Unconfined" => Ok(Self::Unconfined),
+            other => match other.strip_prefix("Localhost/") {
+                Some("") => Err(
+                    "invalid AppArmor profile 'Localhost/'; expected non-empty profile name"
+                        .to_string(),
+                ),
+                Some(profile) => Ok(Self::Localhost(profile.to_string())),
+                None => Err(format!(
+                    "unknown AppArmor profile '{other}'; expected 'RuntimeDefault', 'Unconfined', or 'Localhost/<profile-name>'"
+                )),
+            },
+        }
+    }
+}
+
+impl Serialize for AppArmorProfile {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for AppArmorProfile {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::from_str(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+fn deserialize_optional_app_armor_profile<'de, D>(
+    deserializer: D,
+) -> Result<Option<AppArmorProfile>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    match value.as_deref() {
+        None | Some("") => Ok(None),
+        Some(value) => AppArmorProfile::from_str(value)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
     }
 }
 
@@ -75,6 +168,14 @@ pub struct KubernetesComputeConfig {
     pub client_tls_secret_name: String,
     pub host_gateway_ip: String,
     pub enable_user_namespaces: bool,
+    /// Kubernetes `AppArmor` profile requested for the sandbox agent container.
+    /// Empty/None omits the `appArmorProfile` field from sandbox pod specs.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_app_armor_profile"
+    )]
+    pub app_armor_profile: Option<AppArmorProfile>,
     pub workspace_default_storage_size: String,
     /// Default Kubernetes `runtimeClassName` for sandbox pods.
     /// Applied when a `CreateSandbox` request does not specify one.
@@ -119,6 +220,7 @@ impl Default for KubernetesComputeConfig {
             client_tls_secret_name: String::new(),
             host_gateway_ip: String::new(),
             enable_user_namespaces: false,
+            app_armor_profile: None,
             workspace_default_storage_size: DEFAULT_WORKSPACE_STORAGE_SIZE.to_string(),
             default_runtime_class_name: String::new(),
             sa_token_ttl_secs: 3600,
@@ -194,6 +296,62 @@ mod tests {
     fn default_runtime_class_name_is_empty() {
         let cfg = KubernetesComputeConfig::default();
         assert!(cfg.default_runtime_class_name.is_empty());
+    }
+
+    #[test]
+    fn default_app_armor_profile_is_none() {
+        let cfg = KubernetesComputeConfig::default();
+        assert!(cfg.app_armor_profile.is_none());
+    }
+
+    #[test]
+    fn serde_override_app_armor_profile_unconfined() {
+        let json = serde_json::json!({
+            "app_armor_profile": "Unconfined"
+        });
+        let cfg: KubernetesComputeConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(cfg.app_armor_profile, Some(AppArmorProfile::Unconfined));
+    }
+
+    #[test]
+    fn serde_override_app_armor_profile_runtime_default() {
+        let json = serde_json::json!({
+            "app_armor_profile": "RuntimeDefault"
+        });
+        let cfg: KubernetesComputeConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(cfg.app_armor_profile, Some(AppArmorProfile::RuntimeDefault));
+    }
+
+    #[test]
+    fn serde_override_app_armor_profile_localhost() {
+        let json = serde_json::json!({
+            "app_armor_profile": "Localhost/openshell-supervisor"
+        });
+        let cfg: KubernetesComputeConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            cfg.app_armor_profile,
+            Some(AppArmorProfile::Localhost(
+                "openshell-supervisor".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn serde_empty_app_armor_profile_disables_field() {
+        let json = serde_json::json!({
+            "app_armor_profile": ""
+        });
+        let cfg: KubernetesComputeConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(cfg.app_armor_profile, None);
+    }
+
+    #[test]
+    fn serde_rejects_invalid_app_armor_profile() {
+        let json = serde_json::json!({
+            "app_armor_profile": "runtime/default"
+        });
+        let err = serde_json::from_value::<KubernetesComputeConfig>(json).unwrap_err();
+        assert!(err.to_string().contains("unknown AppArmor profile"));
     }
 
     #[test]

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -4,8 +4,8 @@
 //! Kubernetes compute driver.
 
 use crate::config::{
-    DEFAULT_SANDBOX_SERVICE_ACCOUNT_NAME, DEFAULT_WORKSPACE_STORAGE_SIZE, KubernetesComputeConfig,
-    SupervisorSideloadMethod,
+    AppArmorProfile, DEFAULT_SANDBOX_SERVICE_ACCOUNT_NAME, DEFAULT_WORKSPACE_STORAGE_SIZE,
+    KubernetesComputeConfig, SupervisorSideloadMethod,
 };
 use futures::{Stream, StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::{Event as KubeEventObj, Node};
@@ -328,6 +328,7 @@ impl KubernetesComputeDriver {
             client_tls_secret_name: &self.config.client_tls_secret_name,
             host_gateway_ip: &self.config.host_gateway_ip,
             enable_user_namespaces: self.config.enable_user_namespaces,
+            app_armor_profile: self.config.app_armor_profile.as_ref(),
             workspace_default_storage_size: &self.config.workspace_default_storage_size,
             default_runtime_class_name: &self.config.default_runtime_class_name,
             sa_token_ttl_secs: self.config.effective_sa_token_ttl_secs(),
@@ -1041,6 +1042,7 @@ struct SandboxPodParams<'a> {
     client_tls_secret_name: &'a str,
     host_gateway_ip: &'a str,
     enable_user_namespaces: bool,
+    app_armor_profile: Option<&'a AppArmorProfile>,
     workspace_default_storage_size: &'a str,
     default_runtime_class_name: &'a str,
     /// Lifetime (seconds) of the projected `ServiceAccount` token used
@@ -1065,6 +1067,7 @@ impl Default for SandboxPodParams<'_> {
             client_tls_secret_name: "",
             host_gateway_ip: "",
             enable_user_namespaces: false,
+            app_armor_profile: None,
             workspace_default_storage_size: DEFAULT_WORKSPACE_STORAGE_SIZE,
             default_runtime_class_name: "",
             sa_token_ttl_secs: 3600,
@@ -1280,14 +1283,15 @@ fn sandbox_template_to_k8s(
         // for process identity resolution in network policy enforcement.
         capabilities.extend(["SETUID", "SETGID", "DAC_READ_SEARCH"]);
     }
-    container.insert(
-        "securityContext".to_string(),
-        serde_json::json!({
-            "capabilities": {
-                "add": capabilities
-            }
-        }),
-    );
+    let mut security_context = serde_json::json!({
+        "capabilities": {
+            "add": capabilities
+        }
+    });
+    if let Some(profile) = params.app_armor_profile {
+        security_context["appArmorProfile"] = app_armor_profile_to_k8s(profile);
+    }
+    container.insert("securityContext".to_string(), security_context);
 
     // Mount client TLS secret for mTLS to the server, plus the projected
     // ServiceAccount token used to bootstrap the sandbox's gateway JWT
@@ -1389,6 +1393,16 @@ fn image_pull_secret_refs(secrets: &[String]) -> Vec<serde_json::Value> {
         .filter(|secret| !secret.is_empty())
         .map(|secret| serde_json::json!({ "name": secret }))
         .collect()
+}
+
+fn app_armor_profile_to_k8s(profile: &AppArmorProfile) -> serde_json::Value {
+    let mut value = serde_json::json!({
+        "type": profile.to_k8s_type()
+    });
+    if let Some(localhost_profile) = profile.localhost_profile() {
+        value["localhostProfile"] = serde_json::json!(localhost_profile);
+    }
+    value
 }
 
 fn container_resources(template: &SandboxTemplate, gpu: bool) -> Option<serde_json::Value> {
@@ -2459,6 +2473,65 @@ mod tests {
             true,
             &params,
         )
+    }
+
+    #[test]
+    fn app_armor_profile_omitted_by_default() {
+        let pod_template = default_template_to_k8s(false);
+        assert!(
+            pod_template["spec"]["containers"][0]["securityContext"]["appArmorProfile"].is_null(),
+            "appArmorProfile must be omitted when no profile is configured"
+        );
+    }
+
+    #[test]
+    fn app_armor_profile_renders_unconfined() {
+        let profile = AppArmorProfile::Unconfined;
+        let params = SandboxPodParams {
+            app_armor_profile: Some(&profile),
+            ..Default::default()
+        };
+        let pod_template = sandbox_template_to_k8s(
+            &SandboxTemplate::default(),
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &params,
+        );
+
+        assert_eq!(
+            pod_template["spec"]["containers"][0]["securityContext"]["appArmorProfile"],
+            serde_json::json!({ "type": "Unconfined" })
+        );
+        assert_eq!(
+            pod_template["spec"]["containers"][0]["securityContext"]["capabilities"]["add"][0],
+            serde_json::json!("SYS_ADMIN"),
+            "AppArmor rendering must preserve required capabilities"
+        );
+    }
+
+    #[test]
+    fn app_armor_profile_renders_localhost_profile() {
+        let profile = AppArmorProfile::Localhost("openshell-supervisor".to_string());
+        let params = SandboxPodParams {
+            app_armor_profile: Some(&profile),
+            ..Default::default()
+        };
+        let pod_template = sandbox_template_to_k8s(
+            &SandboxTemplate::default(),
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &params,
+        );
+
+        assert_eq!(
+            pod_template["spec"]["containers"][0]["securityContext"]["appArmorProfile"],
+            serde_json::json!({
+                "type": "Localhost",
+                "localhostProfile": "openshell-supervisor"
+            })
+        );
     }
 
     #[test]

--- a/crates/openshell-driver-kubernetes/src/lib.rs
+++ b/crates/openshell-driver-kubernetes/src/lib.rs
@@ -6,8 +6,8 @@ pub mod driver;
 pub mod grpc;
 
 pub use config::{
-    DEFAULT_SANDBOX_SERVICE_ACCOUNT_NAME, DEFAULT_WORKSPACE_STORAGE_SIZE, KubernetesComputeConfig,
-    SupervisorSideloadMethod,
+    AppArmorProfile, DEFAULT_SANDBOX_SERVICE_ACCOUNT_NAME, DEFAULT_WORKSPACE_STORAGE_SIZE,
+    KubernetesComputeConfig, SupervisorSideloadMethod,
 };
 pub use driver::{KubernetesComputeDriver, KubernetesDriverError};
 pub use grpc::ComputeDriverService;

--- a/crates/openshell-driver-kubernetes/src/main.rs
+++ b/crates/openshell-driver-kubernetes/src/main.rs
@@ -10,8 +10,8 @@ use tracing_subscriber::EnvFilter;
 use openshell_core::VERSION;
 use openshell_core::proto::compute::v1::compute_driver_server::ComputeDriverServer;
 use openshell_driver_kubernetes::{
-    ComputeDriverService, DEFAULT_SANDBOX_SERVICE_ACCOUNT_NAME, KubernetesComputeConfig,
-    KubernetesComputeDriver, SupervisorSideloadMethod,
+    AppArmorProfile, ComputeDriverService, DEFAULT_SANDBOX_SERVICE_ACCOUNT_NAME,
+    KubernetesComputeConfig, KubernetesComputeDriver, SupervisorSideloadMethod,
 };
 
 #[derive(Parser, Debug)]
@@ -83,6 +83,9 @@ struct Args {
     #[arg(long, env = "OPENSHELL_ENABLE_USER_NAMESPACES")]
     enable_user_namespaces: bool,
 
+    #[arg(long, env = "OPENSHELL_K8S_APP_ARMOR_PROFILE")]
+    app_armor_profile: Option<AppArmorProfile>,
+
     /// Lifetime (seconds) of the projected `ServiceAccount` token
     /// kubelet writes into each sandbox pod for the `IssueSandboxToken`
     /// bootstrap exchange. Kubelet enforces a minimum of 600s; the
@@ -116,6 +119,7 @@ async fn main() -> Result<()> {
         client_tls_secret_name: args.client_tls_secret_name.unwrap_or_default(),
         host_gateway_ip: args.host_gateway_ip.unwrap_or_default(),
         enable_user_namespaces: args.enable_user_namespaces,
+        app_armor_profile: args.app_armor_profile,
         workspace_default_storage_size: std::env::var(
             "OPENSHELL_K8S_WORKSPACE_DEFAULT_STORAGE_SIZE",
         )

--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -185,6 +185,7 @@ JWT signing Secret.
 | securityContext.capabilities.drop | list | `["ALL"]` | Linux capabilities dropped from the gateway container. |
 | securityContext.runAsNonRoot | bool | `true` | Require the gateway container to run as a non-root user. |
 | securityContext.runAsUser | int | `1000` | UID assigned to the gateway container. |
+| server.appArmorProfile | string | `"Unconfined"` | Kubernetes AppArmor profile requested for sandbox agent containers. Default Unconfined avoids runtime/default AppArmor blocking the supervisor's network namespace mount setup on AppArmor-enabled nodes. Set to "" to omit the field, "RuntimeDefault" to force the runtime default profile, or "Localhost/profile-name" for an operator-managed localhost profile. |
 | server.auth.allowUnauthenticatedUsers | bool | `false` | UNSAFE: accept unauthenticated CLI/user requests as a local developer principal. Intended only for trusted local Skaffold/k3d development or a fully trusted fronting proxy. Leave false for shared or production clusters. |
 | server.dbUrl | string | `"sqlite:/var/openshell/openshell.db"` | Gateway database URL (used for the default SQLite backend). |
 | server.defaultRuntimeClassName | string | `""` | Default Kubernetes runtimeClassName for sandbox pods. Applied when a CreateSandbox request does not specify one. Empty (default) = omit the field, using the cluster's default RuntimeClass. Set to a RuntimeClass name (e.g. "kata-containers", "nvidia") to apply it to all sandboxes that don't explicitly override it. |

--- a/deploy/helm/openshell/templates/gateway-config.yaml
+++ b/deploy/helm/openshell/templates/gateway-config.yaml
@@ -121,6 +121,9 @@ data:
     {{- if .Values.server.defaultRuntimeClassName }}
     default_runtime_class_name   = {{ .Values.server.defaultRuntimeClassName | quote }}
     {{- end }}
+    {{- if .Values.server.appArmorProfile }}
+    app_armor_profile            = {{ .Values.server.appArmorProfile | quote }}
+    {{- end }}
     {{- if .Values.supervisor.image.pullPolicy }}
     supervisor_image_pull_policy = {{ .Values.supervisor.image.pullPolicy | quote }}
     {{- end }}

--- a/deploy/helm/openshell/tests/gateway_config_test.yaml
+++ b/deploy/helm/openshell/tests/gateway_config_test.yaml
@@ -70,6 +70,22 @@ tests:
           path: data["gateway.toml"]
           pattern: '(?ms)\[openshell\.drivers\.kubernetes\].*?image_pull_secrets\s*=\s*\["regcred", "backup-regcred"\]'
 
+  - it: renders the default sandbox AppArmor profile under [openshell.drivers.kubernetes]
+    template: templates/gateway-config.yaml
+    asserts:
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?ms)\[openshell\.drivers\.kubernetes\].*?app_armor_profile\s*=\s*"Unconfined"'
+
+  - it: omits sandbox AppArmor profile when disabled
+    template: templates/gateway-config.yaml
+    set:
+      server.appArmorProfile: ""
+    asserts:
+      - notMatchRegex:
+          path: data["gateway.toml"]
+          pattern: 'app_armor_profile\s*='
+
   - it: does not reuse gateway image pull secrets for sandbox pods
     template: templates/gateway-config.yaml
     set:

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -183,6 +183,12 @@ server:
   # Linux 5.12+. When enabled, container UID 0 maps to an unprivileged host
   # UID and capabilities become namespaced.
   enableUserNamespaces: false
+  # -- Kubernetes AppArmor profile requested for sandbox agent containers.
+  # Default Unconfined avoids runtime/default AppArmor blocking the supervisor's
+  # network namespace mount setup on AppArmor-enabled nodes. Set to "" to omit
+  # the field, "RuntimeDefault" to force the runtime default profile, or
+  # "Localhost/profile-name" for an operator-managed localhost profile.
+  appArmorProfile: "Unconfined"
   # -- Disable TLS entirely - the server listens on plaintext HTTP.
   # Set to true when a reverse proxy / tunnel terminates TLS at the edge.
   disableTls: false

--- a/docs/kubernetes/setup.mdx
+++ b/docs/kubernetes/setup.mdx
@@ -140,6 +140,7 @@ The most commonly changed values are:
 | `server.sandboxImage` | Default sandbox image used when a sandbox does not specify one. |
 | `server.sandboxImagePullSecrets` | Image pull secrets attached to sandbox pods. Referenced Secrets must exist in the sandbox namespace. |
 | `server.grpcEndpoint` | Endpoint that sandbox supervisors use to call back to the gateway. Must be reachable from inside the cluster. |
+| `server.appArmorProfile` | AppArmor profile requested for sandbox agent containers. Defaults to `Unconfined`. |
 | `server.disableTls` | Run the gateway over plaintext HTTP. Use only behind a trusted transport. |
 | `server.auth.allowUnauthenticatedUsers` | Accept user-facing calls without OIDC or mTLS credentials. Use only for trusted local development or a fully trusted access proxy. |
 | `server.enableLoopbackServiceHttp` | Enable local plaintext HTTP for loopback sandbox service URLs. Defaults to `true`. |
@@ -155,6 +156,13 @@ helm upgrade --install openshell \
   --namespace openshell \
   --values my-values.yaml
 ```
+
+The chart defaults `server.appArmorProfile` to `Unconfined` because
+runtime/default AppArmor profiles can block the supervisor's network namespace
+mount setup on AppArmor-enabled nodes. Set `server.appArmorProfile` to an empty
+string to omit the field, `RuntimeDefault` to force the runtime default, or
+`Localhost/<profile-name>` when you load and manage a localhost profile on each
+node.
 
 To use private sandbox images, create a `kubernetes.io/dockerconfigjson` Secret
 in the sandbox namespace and reference its name:

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -177,6 +177,7 @@ ssh_socket_path                = "/run/openshell/ssh.sock"
 client_tls_secret_name         = "openshell-client-tls"
 host_gateway_ip                = "10.0.0.1"
 enable_user_namespaces         = false
+app_armor_profile              = "Unconfined"
 workspace_default_storage_size = "10Gi"
 # Kubernetes RuntimeClass applied to sandbox pods when the API request does
 # not specify one. Empty (default) = omit the field, using the cluster default.

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -128,6 +128,7 @@ For maintainer-level implementation details, refer to the [Kubernetes driver REA
 | `supervisor_image` | `supervisor.image.repository` / `supervisor.image.tag` | Set the supervisor image that provides the `openshell-sandbox` binary. |
 | `supervisor_image_pull_policy` | `supervisor.image.pullPolicy` | Set the Kubernetes image pull policy for the supervisor image. |
 | `supervisor_sideload_method` | `supervisor.sideloadMethod` | How the supervisor binary is delivered into sandbox pods. Leave empty to auto-detect from cluster version. Set to `image-volume` to mount the supervisor OCI image directly as a volume (requires Kubernetes 1.33+ with the ImageVolume feature gate; GA in 1.36), or `init-container` to copy it through an init container on older clusters. |
+| `app_armor_profile` | `server.appArmorProfile` | Set the sandbox agent container's AppArmor profile. Helm defaults this to `Unconfined` so AppArmor-enabled nodes do not block supervisor network namespace setup. Set the Helm value to an empty string to omit the field, or use `RuntimeDefault` or `Localhost/<profile-name>` for operator-managed profiles. |
 | `workspace_default_storage_size` | `server.workspaceDefaultStorageSize` | Set the default workspace PVC size for new sandboxes. |
 | `sa_token_ttl_secs` | `server.sandboxJwt.k8sSaTokenTtlSecs` | Set the projected ServiceAccount token TTL used for the bootstrap token exchange. |
 


### PR DESCRIPTION
## Summary

Expose Kubernetes AppArmor profile configuration for sandbox agent containers and default the Helm chart to `Unconfined` so AppArmor-enabled nodes do not block supervisor network namespace setup.

## Related Issue

Closes #1643

## Changes

- Added `app_armor_profile` parsing for `Unconfined`, `RuntimeDefault`, and `Localhost/<profile>` in the Kubernetes driver.
- Rendered `securityContext.appArmorProfile` onto sandbox agent containers when configured.
- Added Helm `server.appArmorProfile` with default `Unconfined` and chart tests for default/opt-out rendering.
- Updated gateway config, Kubernetes setup, compute-driver, architecture, and driver README docs.

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo test -p openshell-driver-kubernetes`
- [x] `cargo test -p openshell-server kubernetes`
- [x] `mise run helm:test`
- [x] `mise run helm:docs:check`
- [x] `mise run helm:lint`
- [x] `mise run e2e:kubernetes`

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
