### PR TITLE
feat(providers): add DeepInfra as a built-in inference provider

### DIFF
--- a/crates/openshell-core/src/inference.rs
+++ b/crates/openshell-core/src/inference.rs
@@ -154,6 +154,17 @@ static NVIDIA_PROFILE: InferenceProviderProfile = InferenceProviderProfile {
     passthrough_headers: &["x-model-id"],
 };
 
+static DEEPINFRA_PROFILE: InferenceProviderProfile = InferenceProviderProfile {
+    provider_type: "deepinfra",
+    default_base_url: "https://api.deepinfra.com/v1/openai",
+    protocols: OPENAI_PROTOCOLS,
+    credential_key_names: &["DEEPINFRA_API_KEY"],
+    base_url_config_keys: &["DEEPINFRA_BASE_URL"],
+    auth: AuthHeader::Bearer,
+    default_headers: &[],
+    passthrough_headers: &["x-model-id"],
+};
+
 /// Canonicalize an inference provider type string to a well-known identifier.
 ///
 /// Returns `Some(canonical_name)` for recognized inference providers,
@@ -166,6 +177,7 @@ pub fn normalize_inference_provider_type(input: &str) -> Option<&'static str> {
         "openai" => Some("openai"),
         "anthropic" => Some("anthropic"),
         "nvidia" => Some("nvidia"),
+        "deepinfra" => Some("deepinfra"),
         "google-vertex-ai" | "vertex" | "vertex-ai" | "google-vertex" | "gcp-vertex" => {
             Some("google-vertex-ai")
         }
@@ -182,6 +194,7 @@ pub fn profile_for(provider_type: &str) -> Option<&'static InferenceProviderProf
         "openai" => Some(&OPENAI_PROFILE),
         "anthropic" => Some(&ANTHROPIC_PROFILE),
         "nvidia" => Some(&NVIDIA_PROFILE),
+        "deepinfra" => Some(&DEEPINFRA_PROFILE),
         "google-vertex-ai" => Some(&VERTEX_AI_PROFILE),
         _ => None,
     }
@@ -302,7 +315,19 @@ mod tests {
         assert!(profile_for("openai").is_some());
         assert!(profile_for("anthropic").is_some());
         assert!(profile_for("nvidia").is_some());
+        assert!(profile_for("deepinfra").is_some());
         assert!(profile_for("OpenAI").is_some()); // case insensitive
+    }
+
+    #[test]
+    fn profile_for_deepinfra() {
+        let profile = profile_for("deepinfra").expect("deepinfra profile should exist");
+        assert_eq!(profile.provider_type, "deepinfra");
+        assert_eq!(
+            profile.default_base_url,
+            "https://api.deepinfra.com/v1/openai"
+        );
+        assert_eq!(profile.auth, AuthHeader::Bearer);
     }
 
     #[test]

--- a/crates/openshell-providers/src/lib.rs
+++ b/crates/openshell-providers/src/lib.rs
@@ -116,6 +116,7 @@ impl ProviderRegistry {
         registry.register(providers::openai::SPEC);
         registry.register(providers::anthropic::SPEC);
         registry.register(providers::nvidia::SPEC);
+        registry.register(providers::deepinfra::SPEC);
         registry.register(providers::gitlab::SPEC);
         registry.register(providers::github::SPEC);
         registry.register(providers::outlook::OutlookProvider);

--- a/crates/openshell-providers/src/profiles.rs
+++ b/crates/openshell-providers/src/profiles.rs
@@ -23,6 +23,7 @@ const BUILT_IN_PROFILE_YAMLS: &[&str] = &[
     include_str!("../../../providers/cursor.yaml"),
     include_str!("../../../providers/github.yaml"),
     include_str!("../../../providers/google-vertex-ai.yaml"),
+    include_str!("../../../providers/deepinfra.yaml"),
     include_str!("../../../providers/nvidia.yaml"),
     include_str!("../../../providers/pypi.yaml"),
 ];

--- a/crates/openshell-providers/src/providers/deepinfra.rs
+++ b/crates/openshell-providers/src/providers/deepinfra.rs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ProviderDiscoverySpec;
+
+pub const SPEC: ProviderDiscoverySpec = ProviderDiscoverySpec {
+    id: "deepinfra",
+    credential_env_vars: &["DEEPINFRA_API_KEY"],
+};
+
+test_discovers_env_credential!(
+    discovers_deepinfra_env_credentials,
+    "DEEPINFRA_API_KEY",
+    "di-test123"
+);

--- a/crates/openshell-providers/src/providers/mod.rs
+++ b/crates/openshell-providers/src/providers/mod.rs
@@ -33,6 +33,7 @@ macro_rules! test_discovers_env_credential {
 pub mod anthropic;
 pub mod claude;
 pub mod codex;
+pub mod deepinfra;
 pub mod copilot;
 pub mod generic;
 pub mod github;

--- a/crates/openshell-router/src/backend.rs
+++ b/crates/openshell-router/src/backend.rs
@@ -642,7 +642,11 @@ fn build_provider_url(
 
 fn build_backend_url(endpoint: &str, path: &str) -> String {
     let base = endpoint.trim_end_matches('/');
-    if base.ends_with("/v1") && (path == "/v1" || path.starts_with("/v1/")) {
+    // Strip the /v1 prefix from the request path when the base URL already
+    // contains a /v1 segment — either ending with it (e.g. openai, nvidia)
+    // or containing it internally (e.g. deepinfra: /v1/openai).
+    let base_has_v1 = base.ends_with("/v1") || base.contains("/v1/");
+    if base_has_v1 && (path == "/v1" || path.starts_with("/v1/")) {
         return format!("{base}{}", &path[3..]);
     }
 
@@ -701,6 +705,19 @@ mod tests {
         assert_eq!(
             build_backend_url("https://api.openai.com/v1", "/v1"),
             "https://api.openai.com/v1"
+        );
+    }
+
+    #[test]
+    fn build_backend_url_dedupes_v1_for_base_with_v1_subpath() {
+        // DeepInfra base URL contains /v1/ internally — /v1 in the request
+        // path must still be stripped so chat/completions is not doubled.
+        assert_eq!(
+            build_backend_url(
+                "https://api.deepinfra.com/v1/openai",
+                "/v1/chat/completions"
+            ),
+            "https://api.deepinfra.com/v1/openai/chat/completions"
         );
     }
 

--- a/docs/sandboxes/manage-providers.mdx
+++ b/docs/sandboxes/manage-providers.mdx
@@ -253,6 +253,7 @@ The following provider types are supported.
 | `generic` | User-defined | Any service with custom credentials |
 | `github` | `GITHUB_TOKEN`, `GH_TOKEN` | GitHub API and `gh` CLI. Refer to [GitHub Sandbox](/get-started/tutorials/github-sandbox). |
 | `gitlab` | `GITLAB_TOKEN`, `GLAB_TOKEN`, `CI_JOB_TOKEN` | GitLab API, `glab` CLI |
+| `deepinfra` | `DEEPINFRA_API_KEY` | DeepInfra inference API |
 | `nvidia` | `NVIDIA_API_KEY` | NVIDIA API Catalog |
 | `openai` | `OPENAI_API_KEY` | Any OpenAI-compatible endpoint. Set `--config OPENAI_BASE_URL` to point to the provider. Refer to [Inference Routing](/sandboxes/inference-routing). |
 | `opencode` | `OPENCODE_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY` | OpenCode |
@@ -278,7 +279,7 @@ The following providers have been tested with `inference.local`. Any provider th
 | Google Vertex AI | `vertex-prod` | `google-vertex-ai` | Regional, global, or multi-region Vertex endpoint | `GOOGLE_VERTEX_AI_TOKEN` or `GOOGLE_VERTEX_AI_SERVICE_ACCOUNT_TOKEN` |
 | Baseten | `baseten` | `openai` | `https://inference.baseten.co/v1` | `OPENAI_API_KEY` |
 | Bitdeer AI | `bitdeer` | `openai` | `https://api-inference.bitdeer.ai/v1` | `OPENAI_API_KEY` |
-| Deepinfra | `deepinfra` | `openai` | `https://api.deepinfra.com/v1/openai` | `OPENAI_API_KEY` |
+| DeepInfra | `deepinfra` | `deepinfra` | `https://api.deepinfra.com/v1/openai` | `DEEPINFRA_API_KEY` |
 | Groq | `groq` | `openai` | `https://api.groq.com/openai/v1` | `OPENAI_API_KEY` |
 | Ollama (local) | `ollama` | `openai` | `http://host.openshell.internal:11434/v1` | `OPENAI_API_KEY` |
 | LM Studio (local) | `lmstudio` | `openai` | `http://host.openshell.internal:1234/v1` | `OPENAI_API_KEY` |

--- a/docs/sandboxes/providers-v2.mdx
+++ b/docs/sandboxes/providers-v2.mdx
@@ -98,6 +98,7 @@ Built-in Providers v2 profiles currently include:
 | `cursor` | `agent` | None |
 | `github` | `source_control` | `GITHUB_TOKEN`, `GH_TOKEN` |
 | `google-vertex-ai` | `inference` | `GOOGLE_SERVICE_ACCOUNT_KEY`, `GOOGLE_VERTEX_AI_SERVICE_ACCOUNT_TOKEN`, `VERTEX_AI_SERVICE_ACCOUNT_TOKEN`, `GOOGLE_VERTEX_AI_TOKEN`, `VERTEX_AI_TOKEN` |
+| `deepinfra` | `inference` | `DEEPINFRA_API_KEY` |
 | `nvidia` | `inference` | `NVIDIA_API_KEY` |
 | `pypi` | `data` | None |
 

--- a/providers/deepinfra.yaml
+++ b/providers/deepinfra.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: deepinfra
+display_name: DeepInfra
+description: DeepInfra inference endpoints
+category: inference
+inference_capable: true
+credentials:
+  - name: api_key
+    description: DeepInfra API key
+    env_vars: [DEEPINFRA_API_KEY]
+    required: true
+    auth_style: bearer
+    header_name: authorization
+discovery:
+  credentials: [api_key]
+endpoints:
+  - host: api.deepinfra.com
+    port: 443
+    protocol: rest
+    access: read-write
+    enforcement: enforce
+binaries: [/usr/bin/curl, /usr/local/bin/curl]


### PR DESCRIPTION
## Summary

DeepInfra is one of the top open source LLM providers and a perfect fit for agent frameworks with its low cost and high performance. This PR promotes it from a documented workaround to a core built-in provider in OpenShell.

- Adds `deepinfra` as a built-in inference provider alongside `nvidia`, `openai`, and `anthropic`
- `DEEPINFRA_API_KEY` is now discovered automatically via `--from-existing`
- `openshell provider list-profiles` shows DeepInfra in the INFERENCE section
- Fixes `build_backend_url` to correctly strip `/v1` from request paths when the provider base URL contains `/v1/` as an internal path segment (e.g. `https://api.deepinfra.com/v1/openai`) — without this fix, requests were routed to `.../v1/openai/v1/chat/completions` (404) instead of `.../v1/openai/chat/completions`

## Related Issue

N/A

## Changes

- `providers/deepinfra.yaml` — new built-in profile (inference category, `api.deepinfra.com:443`, Bearer auth, `DEEPINFRA_API_KEY`)
- `crates/openshell-core/src/inference.rs` — `DEEPINFRA_PROFILE`, normalization, `profile_for` entries + tests
- `crates/openshell-providers/src/providers/deepinfra.rs` — discovery spec + env-var test
- `crates/openshell-providers/src/{lib,profiles,providers/mod}.rs` — registration (alphabetical module order)
- `crates/openshell-router/src/backend.rs` — URL construction fix + test
- `docs/sandboxes/providers-v2.mdx`, `docs/sandboxes/manage-providers.mdx` — DeepInfra rows

## Testing

- [x] `mise run pre-commit` passes (rust, helm, markdown, license; `python:proto` is a pre-existing failure unrelated to this PR)
- [x] 262 Rust unit tests pass across `openshell-core`, `openshell-providers`, `openshell-router` (`cargo test -p openshell-core -p openshell-providers -p openshell-router`)
- [x] `openshell provider list-profiles` shows `deepinfra` in INFERENCE section
- [x] `openshell provider create --name di --type deepinfra --from-existing` discovers `DEEPINFRA_API_KEY`
- [x] `openshell inference set --provider di --model <model> --no-verify` configures route
- [x] `curl https://inference.local/v1/chat/completions` from inside sandbox returns a valid completion from DeepInfra

### Unit test results

```
test result: ok. 164 passed; 0 failed; 0 ignored  (openshell-core)
test result: ok. 37 passed;  0 failed; 0 ignored  (openshell-providers)
test result: ok. 44 passed;  0 failed; 0 ignored  (openshell-router)
test result: ok. 17 passed;  0 failed; 0 ignored  (openshell-router integration)
```

Includes `inference::tests::profile_for_deepinfra`, `providers::deepinfra::tests::discovers_deepinfra_env_credentials`, and `backend::tests::build_backend_url_dedupes_v1_for_base_with_v1_subpath`.

### Provider list-profiles

```
INFERENCE
  deepinfra         DeepInfra         endpoints: 1  inference
  google-vertex-ai  Google Vertex AI  endpoints: 4  inference
  nvidia            NVIDIA            endpoints: 1  inference
```

### End-to-end inference from inside sandbox

```
$ curl -s https://inference.local/v1/chat/completions --insecure \
    -H "Content-Type: application/json" \
    -d '{"model":"Qwen/Qwen3-30B-A3B","messages":[{"role":"user","content":"Say hello"}],"max_tokens":50}'

{"id":"chatcmpl-RvC46ezaN8prTxquYHZZJLMX","object":"chat.completion","model":"Qwen/Qwen3-30B-A3B",
 "choices":[{"message":{"role":"assistant","content":"<think>\nOkay, the user said \"Say hello.\" ..."}}],
 "usage":{"prompt_tokens":10,"total_tokens":60,"completion_tokens":50,"estimated_cost":2.34e-05}}
```

Screenshots / Logs

<img width="1462" height="846" alt="Screenshot 2026-06-05 at 15 55 32" src="https://github.com/user-attachments/assets/357f1143-646b-4536-a759-a7d7649f554f" />
<img width="642" height="870" alt="Screenshot 2026-06-05 at 15 55 53" src="https://github.com/user-attachments/assets/2666d2e0-f649-4517-a77e-05de9f40012f" />
<img width="759" height="868" alt="Screenshot 2026-06-05 at 15 56 28" src="https://github.com/user-attachments/assets/3635e299-6ef5-43fa-b1b0-db5b650278e9" />
<img width="751" height="862" alt="Screenshot 2026-06-05 at 15 56 39" src="https://github.com/user-attachments/assets/bed265fe-393c-4cc1-8da4-7b8c5c54c13e" />
<img width="728" height="508" alt="Screenshot 2026-06-05 at 15 56 53" src="https://github.com/user-attachments/assets/e4eef8e0-53ef-461f-9a97-4566ffa23ec5" />
<img width="645" height="270" alt="Screenshot 2026-06-05 at 15 57 45" src="https://github.com/user-attachments/assets/5563cee2-7809-42e2-a840-45fc5934ab23" />
<img width="1462" height="169" alt="Screenshot 2026-06-05 at 15 58 53" src="https://github.com/user-attachments/assets/a56eb499-849e-425a-844f-261f4d2b3e02" />


## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (`docs/sandboxes/providers-v2.mdx`, `docs/sandboxes/manage-providers.mdx`)