### PR TITLE
feat(providers): support on-demand token grants using SPIFFE credentials

### DIFF
--- a/.agents/skills/debug-openshell-cluster/SKILL.md
+++ b/.agents/skills/debug-openshell-cluster/SKILL.md
@@ -154,6 +154,22 @@ If the gateway exits with `failed to read sandbox JWT signing key from
 `sandbox-jwt` secret at `/etc/openshell-jwt`. The sandbox JWT mount is required
 even when local Helm values disable TLS.
 
+If `server.spiffe.enabled=true`, the sandbox JWT ConfigMap block and
+`sandbox-jwt` StatefulSet mount are intentionally omitted. Instead verify that
+SPIRE is installed, the CSI driver is available, and the gateway pod mounts the
+SPIFFE Workload API socket:
+
+```bash
+helm -n openshell get values openshell | grep -E 'spiffe|trustDomain|workloadApiSocketPath'
+kubectl get pods -A | grep -E 'spire|spiffe'
+kubectl -n openshell get statefulset openshell -o yaml | grep -E 'spiffe-workload-api|csi.spiffe.io'
+```
+
+Sandbox pods in SPIFFE mode should have `openshell.io/sandbox-id` and
+`openshell.io/spiffe-id` annotations, an `openshell.ai/managed-by=openshell`
+label, and supervisor env vars `OPENSHELL_SPIFFE_WORKLOAD_API_SOCKET`,
+`OPENSHELL_SPIFFE_AUDIENCE`, and `OPENSHELL_SPIFFE_ID`.
+
 Check the image references currently used by the gateway deployment:
 
 ```bash

--- a/.agents/skills/helm-dev-environment/SKILL.md
+++ b/.agents/skills/helm-dev-environment/SKILL.md
@@ -172,6 +172,21 @@ To remove Keycloak:
 mise run keycloak:k8s:teardown
 ```
 
+### SPIRE / SPIFFE Sandbox Identity
+
+Skaffold can install SPIRE with the SPIFFE hardened Helm charts. To activate
+SPIFFE JWT-SVID supervisor authentication:
+
+1. Uncomment the `spire-crds` and `spire` releases in `deploy/helm/openshell/skaffold.yaml`
+2. Uncomment `#- ci/values-spire.yaml` in the OpenShell release values files
+3. Redeploy: `mise run helm:skaffold:run`
+
+`ci/values-spire-stack.yaml` configures the local SPIRE trust domain as
+`openshell.local` and adds a `ClusterSPIFFEID` that maps sandbox pod
+annotations to `spiffe://openshell.local/openshell/sandbox/<sandbox-id>`.
+OpenShell mounts the SPIFFE CSI Workload API socket at
+`/spiffe-workload-api/spire-agent.sock`.
+
 ---
 
 ## Cluster Lifecycle (suspend/resume)
@@ -199,6 +214,8 @@ mise run helm:k3s:status
 | `deploy/helm/openshell/ci/values-cert-manager.yaml` | cert-manager PKI overlay (opt-in; disables pkiInitJob) |
 | `deploy/helm/openshell/ci/values-gateway.yaml` | Envoy Gateway GRPCRoute + Gateway overlay |
 | `deploy/helm/openshell/ci/values-keycloak.yaml` | Keycloak OIDC overlay |
+| `deploy/helm/openshell/ci/values-spire.yaml` | SPIFFE/SPIRE sandbox supervisor auth overlay |
+| `deploy/helm/openshell/ci/values-spire-stack.yaml` | SPIRE hardened chart values for local dev |
 | `deploy/helm/openshell/ci/values-tls-disabled.yaml` | Lint-only: TLS + auth disabled (reverse-proxy edge termination) |
 | `deploy/kube/manifests/envoy-gateway-openshell.yaml` | GatewayClass for Envoy Gateway (`mise run helm:gateway:apply`) |
 | `tasks/scripts/helm-k3s-local.sh` | k3d cluster create/delete/start/stop/status |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,6 +3578,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rcgen",
  "regorus",
+ "reqwest 0.12.28",
  "russh",
  "rustix 1.1.4",
  "rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,28 +224,6 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -305,38 +292,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -347,7 +307,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -364,26 +324,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -1855,18 +1795,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2149,7 +2083,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2326,16 +2260,6 @@ checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2959,12 +2883,6 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -3011,7 +2929,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "indexmap 2.14.0",
+ "indexmap",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -3467,7 +3385,8 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "url",
 ]
 
@@ -3669,6 +3588,7 @@ dependencies = [
  "serde_yml",
  "sha1 0.10.6",
  "sha2 0.10.9",
+ "spiffe",
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",
@@ -3690,7 +3610,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "bytes",
  "clap",
  "futures",
@@ -3733,6 +3653,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "spiffe",
  "sqlx",
  "tempfile",
  "thiserror 2.0.18",
@@ -4017,12 +3938,13 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
- "indexmap 2.14.0",
+ "hashbrown 0.15.5",
+ "indexmap",
 ]
 
 [[package]]
@@ -4260,9 +4182,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4270,19 +4192,20 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
  "itertools 0.14.0",
  "log",
  "multimap",
- "once_cell",
  "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.117",
  "tempfile",
@@ -4290,9 +4213,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -4303,9 +4226,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
@@ -4317,6 +4240,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
 dependencies = [
  "autotools",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -4347,7 +4290,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4385,7 +4328,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5241,7 +5184,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -5254,7 +5197,7 @@ version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "libyml",
  "memchr",
@@ -5437,22 +5380,40 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spiffe"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d3f9e45e9e53f03cb452fe0f050101a9280ff4f4214e326037bc8275284d906"
+dependencies = [
+ "arc-swap",
+ "base64ct",
+ "fastrand",
+ "futures",
+ "hyper-util",
+ "log",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tonic-prost",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -5515,7 +5476,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "memchr",
  "once_cell",
@@ -6081,7 +6042,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -6187,7 +6148,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6203,13 +6164,12 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -6221,14 +6181,13 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
  "rustls-native-certs",
- "rustls-pemfile",
- "socket2 0.5.10",
+ "socket2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6236,9 +6195,32 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -6246,6 +6228,8 @@ dependencies = [
  "prost-types",
  "quote",
  "syn 2.0.117",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]
@@ -6256,11 +6240,8 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.6",
- "slab",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -6276,9 +6257,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6765,7 +6749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6791,7 +6775,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -7356,7 +7340,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -7387,7 +7371,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -7406,7 +7390,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -7620,7 +7604,7 @@ dependencies = [
  "flate2",
  "getrandom 0.4.2",
  "hmac",
- "indexmap 2.14.0",
+ "indexmap",
  "lzma-rust2",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ repository = "https://github.com/NVIDIA/OpenShell"
 tokio = { version = "1.43", features = ["full"] }
 
 # gRPC/Protobuf
-tonic = "0.12"
-tonic-build = "0.12"
-prost = "0.13"
-prost-types = "0.13"
+tonic = "0.14"
+tonic-prost = "0.14"
+tonic-prost-build = "0.14"
+prost = "0.14"
+prost-types = "0.14"
 
 # HTTP server
 axum = { version = "0.8", features = ["ws"] }
@@ -87,6 +88,7 @@ sha2 = "0.10"
 rand = "0.9"
 jsonwebtoken = "9"
 getrandom = "0.3"
+spiffe = { version = "0.15", default-features = false, features = ["workload-api-jwt", "tracing"] }
 
 # Filesystem embedding
 include_dir = "0.7"

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -46,10 +46,16 @@ Supported auth modes:
 | Unauthenticated local users | Trusted Kubernetes dev or fully trusted proxy deployments only. |
 | Cloudflare JWT | Edge-authenticated deployments where Cloudflare Access supplies identity. |
 | OIDC | Bearer-token auth for users, with browser PKCE or client credentials login. |
+| SPIFFE JWT-SVID | Sandbox supervisor authentication through a local SPIFFE Workload API implementation such as SPIRE. |
 
-Sandbox supervisor RPCs authenticate with gateway-minted sandbox JWTs when that
-authenticator is configured; mTLS does not grant sandbox identity. User-facing
-mutations are authorized by role policy when OIDC or edge identity is enabled.
+Sandbox supervisor RPCs authenticate with explicit sandbox credentials; mTLS
+does not grant sandbox identity. Kubernetes deployments can use either the
+gateway-minted JWT bootstrap path or SPIFFE JWT-SVIDs. In SPIFFE mode, the
+supervisor fetches a JWT-SVID from the SPIFFE Workload API and the gateway
+validates it through its own local Workload API socket, then maps
+`spiffe://<trust-domain>/openshell/sandbox/<id>` to `Principal::Sandbox`.
+User-facing mutations are authorized by role policy when OIDC or edge identity
+is enabled.
 
 Sandbox secrets are gateway-signed JWTs bound to a single sandbox ID. Docker,
 Podman, and VM drivers deliver the initial token through supervisor-only

--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -78,6 +78,11 @@ Credential placeholders in proxied HTTP requests can be resolved by the proxy
 when policy allows the target endpoint. Secrets must not be logged in OCSF or
 plain tracing output.
 
+Provider profiles can also declare dynamic token grants. For matching HTTP
+endpoints, the supervisor obtains a SPIFFE JWT-SVID from the local Workload API,
+exchanges it for an OAuth2 access token, caches the token, and injects it as an
+`Authorization: Bearer` header before forwarding the request.
+
 ## Connect and Logs
 
 The supervisor runs an SSH server on a Unix socket inside the sandbox. The

--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -70,6 +70,10 @@ agent process and SSH child processes. Driver-controlled environment variables
 override template values so sandbox images cannot spoof identity, callback, or
 relay settings.
 
+Supervisor bootstrap identity is not inherited by agent child processes. In
+Kubernetes SPIFFE mode, children also enter a private mount namespace where the
+Workload API socket directory is hidden before privilege drop.
+
 Credential placeholders in proxied HTTP requests can be resolved by the proxy
 when policy allows the target endpoint. Secrets must not be logged in OCSF or
 plain tracing output.

--- a/crates/openshell-cli/Cargo.toml
+++ b/crates/openshell-cli/Cargo.toml
@@ -30,7 +30,7 @@ prost-types = { workspace = true }
 tokio = { workspace = true }
 
 # gRPC client
-tonic = { workspace = true, features = ["tls", "tls-native-roots"] }
+tonic = { workspace = true, features = ["tls-native-roots"] }
 
 # CLI
 chrono = "0.4"

--- a/crates/openshell-core/Cargo.toml
+++ b/crates/openshell-core/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace = true
 prost = { workspace = true }
 prost-types = { workspace = true }
 tonic = { workspace = true }
+tonic-prost = { workspace = true }
 thiserror = { workspace = true }
 miette = { workspace = true }
 serde = { workspace = true }
@@ -28,7 +29,7 @@ ipnet = "2"
 dev-settings = []
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }
 protobuf-src = { workspace = true }
 
 [dev-dependencies]

--- a/crates/openshell-core/build.rs
+++ b/crates/openshell-core/build.rs
@@ -40,11 +40,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     collect_proto_files(&proto_root, &mut proto_files)?;
     proto_files.sort();
 
-    // Configure tonic-build
-    tonic_build::configure()
+    // Configure tonic/prost protobuf code generation.
+    let include_paths = [proto_root];
+    tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
-        .compile_protos(&proto_files, &[proto_root.as_path()])?;
+        .compile_protos(&proto_files, &include_paths)?;
 
     Ok(())
 }

--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -223,6 +223,12 @@ pub struct Config {
     #[serde(default)]
     pub gateway_jwt: Option<GatewayJwtConfig>,
 
+    /// SPIFFE Workload API configuration. When `Some`, the gateway validates
+    /// sandbox JWT-SVIDs through the local SPIFFE implementation and maps
+    /// matching SPIFFE IDs to sandbox principals.
+    #[serde(default)]
+    pub spiffe: Option<SpiffeConfig>,
+
     /// Database URL for persistence.
     pub database_url: String,
 
@@ -379,12 +385,40 @@ pub struct GatewayJwtConfig {
     pub ttl_secs: u64,
 }
 
+/// SPIFFE-based sandbox identity configuration.
+///
+/// The gateway uses the local SPIFFE Workload API to validate JWT-SVIDs
+/// presented by sandbox supervisors. Supervisors request those JWT-SVIDs
+/// for the configured audience and use SPIFFE IDs shaped as
+/// `spiffe://<trust_domain>/<sandbox_id_prefix><sandbox-id>`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpiffeConfig {
+    /// Path to the SPIFFE Workload API UNIX socket.
+    pub workload_api_socket_path: PathBuf,
+    /// Trust domain accepted for sandbox SPIFFE IDs.
+    pub trust_domain: String,
+    /// Audience expected in sandbox JWT-SVIDs.
+    #[serde(default = "default_spiffe_audience")]
+    pub audience: String,
+    /// Path prefix, below the trust domain, that precedes the sandbox UUID.
+    #[serde(default = "default_spiffe_sandbox_id_prefix")]
+    pub sandbox_id_prefix: String,
+}
+
 fn default_gateway_id() -> String {
     "openshell".to_string()
 }
 
 const fn default_sandbox_token_ttl_secs() -> u64 {
     3_600
+}
+
+fn default_spiffe_audience() -> String {
+    "openshell-gateway".to_string()
+}
+
+fn default_spiffe_sandbox_id_prefix() -> String {
+    "/openshell/sandbox/".to_string()
 }
 
 fn default_roles_claim() -> String {
@@ -413,6 +447,7 @@ impl Config {
             auth: GatewayAuthConfig::default(),
             mtls_auth: MtlsAuthConfig::default(),
             gateway_jwt: None,
+            spiffe: None,
             database_url: String::new(),
             compute_drivers: vec![],
             ssh_session_ttl_secs: default_ssh_session_ttl_secs(),

--- a/crates/openshell-core/src/lib.rs
+++ b/crates/openshell-core/src/lib.rs
@@ -28,7 +28,7 @@ pub mod time;
 
 pub use config::{
     ComputeDriverKind, Config, GatewayAuthConfig, GatewayJwtConfig, MtlsAuthConfig, OidcConfig,
-    TlsConfig,
+    SpiffeConfig, TlsConfig,
 };
 pub use error::{ComputeDriverError, Error, Result};
 pub use metadata::{GetResourceVersion, ObjectId, ObjectLabels, ObjectName, SetResourceVersion};

--- a/crates/openshell-core/src/sandbox_env.rs
+++ b/crates/openshell-core/src/sandbox_env.rs
@@ -53,3 +53,15 @@ pub const SANDBOX_TOKEN_FILE: &str = "OPENSHELL_SANDBOX_TOKEN_FILE";
 /// writes and rotates this file; the supervisor exchanges its contents
 /// for a gateway JWT at startup and on refresh.
 pub const K8S_SA_TOKEN_FILE: &str = "OPENSHELL_K8S_SA_TOKEN_FILE";
+
+/// Filesystem path to the SPIFFE Workload API UNIX socket.
+///
+/// When set, the supervisor fetches a JWT-SVID from the local Workload API
+/// and presents that token directly to the gateway.
+pub const SPIFFE_WORKLOAD_API_SOCKET: &str = "OPENSHELL_SPIFFE_WORKLOAD_API_SOCKET";
+
+/// Audience requested when fetching a SPIFFE JWT-SVID.
+pub const SPIFFE_AUDIENCE: &str = "OPENSHELL_SPIFFE_AUDIENCE";
+
+/// Optional exact SPIFFE ID requested from the Workload API.
+pub const SPIFFE_ID: &str = "OPENSHELL_SPIFFE_ID";

--- a/crates/openshell-driver-kubernetes/src/config.rs
+++ b/crates/openshell-driver-kubernetes/src/config.rs
@@ -83,6 +83,16 @@ pub struct KubernetesComputeConfig {
     /// this token within a few seconds of pod start, so any value at
     /// the floor is sufficient. Default 3600.
     pub sa_token_ttl_secs: i64,
+    /// SPIFFE Workload API socket path mounted into sandbox pods. Empty
+    /// disables SPIFFE identity material and keeps the `ServiceAccount`
+    /// bootstrap path active.
+    pub spiffe_workload_api_socket_path: String,
+    /// SPIFFE trust domain used for sandbox identities.
+    pub spiffe_trust_domain: String,
+    /// Audience requested by sandbox supervisors for JWT-SVIDs.
+    pub spiffe_audience: String,
+    /// Path prefix under the trust domain before the sandbox UUID.
+    pub spiffe_sandbox_id_prefix: String,
 }
 
 /// Lower bound enforced by kubelet for projected SA tokens.
@@ -114,6 +124,10 @@ impl Default for KubernetesComputeConfig {
             enable_user_namespaces: false,
             workspace_default_storage_size: DEFAULT_WORKSPACE_STORAGE_SIZE.to_string(),
             sa_token_ttl_secs: 3600,
+            spiffe_workload_api_socket_path: String::new(),
+            spiffe_trust_domain: String::new(),
+            spiffe_audience: "openshell-gateway".to_string(),
+            spiffe_sandbox_id_prefix: "/openshell/sandbox/".to_string(),
         }
     }
 }
@@ -130,6 +144,13 @@ impl KubernetesComputeConfig {
             self.sa_token_ttl_secs
                 .clamp(MIN_SA_TOKEN_TTL_SECS, MAX_SA_TOKEN_TTL_SECS)
         }
+    }
+
+    #[must_use]
+    pub fn spiffe_enabled(&self) -> bool {
+        !self.spiffe_workload_api_socket_path.trim().is_empty()
+            && !self.spiffe_trust_domain.trim().is_empty()
+            && !self.spiffe_audience.trim().is_empty()
     }
 }
 

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -78,6 +78,7 @@ pub const SANDBOX_KIND: &str = "Sandbox";
 
 const GPU_RESOURCE_NAME: &str = "nvidia.com/gpu";
 const GPU_RESOURCE_QUANTITY: &str = "1";
+const SPIFFE_WORKLOAD_API_VOLUME_NAME: &str = "spiffe-workload-api";
 
 // ---------------------------------------------------------------------------
 // Default workspace persistence (temporary — will be replaced by snapshotting)
@@ -331,6 +332,11 @@ impl KubernetesComputeDriver {
             enable_user_namespaces: self.config.enable_user_namespaces,
             workspace_default_storage_size: &self.config.workspace_default_storage_size,
             sa_token_ttl_secs: self.config.effective_sa_token_ttl_secs(),
+            spiffe_enabled: self.config.spiffe_enabled(),
+            spiffe_workload_api_socket_path: &self.config.spiffe_workload_api_socket_path,
+            spiffe_trust_domain: &self.config.spiffe_trust_domain,
+            spiffe_audience: &self.config.spiffe_audience,
+            spiffe_sandbox_id_prefix: &self.config.spiffe_sandbox_id_prefix,
         };
         obj.data = sandbox_to_k8s_spec(sandbox.spec.as_ref(), &params);
         let api = self.api();
@@ -1062,6 +1068,11 @@ struct SandboxPodParams<'a> {
     /// Lifetime (seconds) of the projected `ServiceAccount` token used
     /// for the bootstrap `IssueSandboxToken` exchange.
     sa_token_ttl_secs: i64,
+    spiffe_enabled: bool,
+    spiffe_workload_api_socket_path: &'a str,
+    spiffe_trust_domain: &'a str,
+    spiffe_audience: &'a str,
+    spiffe_sandbox_id_prefix: &'a str,
 }
 
 impl Default for SandboxPodParams<'_> {
@@ -1082,6 +1093,11 @@ impl Default for SandboxPodParams<'_> {
             enable_user_namespaces: false,
             workspace_default_storage_size: DEFAULT_WORKSPACE_STORAGE_SIZE,
             sa_token_ttl_secs: 3600,
+            spiffe_enabled: false,
+            spiffe_workload_api_socket_path: "",
+            spiffe_trust_domain: "",
+            spiffe_audience: "openshell-gateway",
+            spiffe_sandbox_id_prefix: "/openshell/sandbox/",
         }
     }
 }
@@ -1172,8 +1188,25 @@ fn sandbox_template_to_k8s(
     params: &SandboxPodParams<'_>,
 ) -> serde_json::Value {
     let mut metadata = serde_json::Map::new();
-    if !template.labels.is_empty() {
-        metadata.insert("labels".to_string(), serde_json::json!(template.labels));
+    let mut pod_labels = template
+        .labels
+        .iter()
+        .map(|(key, value)| (key.clone(), serde_json::Value::String(value.clone())))
+        .collect::<serde_json::Map<String, serde_json::Value>>();
+    if params.spiffe_enabled {
+        pod_labels.insert(
+            LABEL_MANAGED_BY.to_string(),
+            serde_json::Value::String(LABEL_MANAGED_BY_VALUE.to_string()),
+        );
+        if !params.sandbox_id.is_empty() {
+            pod_labels.insert(
+                LABEL_SANDBOX_ID.to_string(),
+                serde_json::Value::String(params.sandbox_id.to_string()),
+            );
+        }
+    }
+    if !pod_labels.is_empty() {
+        metadata.insert("labels".to_string(), serde_json::Value::Object(pod_labels));
     }
     // Carry the sandbox UUID as a pod annotation so the gateway can resolve
     // a projected SA token claim (pod name + uid) back to a sandbox identity
@@ -1191,6 +1224,12 @@ fn sandbox_template_to_k8s(
         pod_annotations.insert(
             "openshell.io/sandbox-id".to_string(),
             serde_json::Value::String(params.sandbox_id.to_string()),
+        );
+    }
+    if params.spiffe_enabled {
+        pod_annotations.insert(
+            "openshell.io/spiffe-id".to_string(),
+            serde_json::Value::String(sandbox_spiffe_id(params)),
         );
     }
     if !pod_annotations.is_empty() {
@@ -1270,6 +1309,7 @@ fn sandbox_template_to_k8s(
         params.grpc_endpoint,
         params.ssh_socket_path,
         !params.client_tls_secret_name.is_empty(),
+        spiffe_env(params),
     );
 
     container.insert("env".to_string(), serde_json::Value::Array(env));
@@ -1291,9 +1331,10 @@ fn sandbox_template_to_k8s(
         }),
     );
 
-    // Mount client TLS secret for mTLS to the server, plus the projected
-    // ServiceAccount token used to bootstrap the sandbox's gateway JWT
-    // via `IssueSandboxToken`.
+    // Mount client TLS secret for mTLS to the server, plus exactly one
+    // sandbox identity source: SPIFFE Workload API socket when configured,
+    // otherwise a projected ServiceAccount token for the gateway-JWT
+    // bootstrap path.
     let mut volume_mounts: Vec<serde_json::Value> = Vec::new();
     if !params.client_tls_secret_name.is_empty() {
         volume_mounts.push(serde_json::json!({
@@ -1302,11 +1343,19 @@ fn sandbox_template_to_k8s(
             "readOnly": true
         }));
     }
-    volume_mounts.push(serde_json::json!({
-        "name": "openshell-sa-token",
-        "mountPath": "/var/run/secrets/openshell",
-        "readOnly": true,
-    }));
+    if params.spiffe_enabled {
+        volume_mounts.push(serde_json::json!({
+            "name": SPIFFE_WORKLOAD_API_VOLUME_NAME,
+            "mountPath": spiffe_socket_mount_path(params.spiffe_workload_api_socket_path),
+            "readOnly": true,
+        }));
+    } else {
+        volume_mounts.push(serde_json::json!({
+            "name": "openshell-sa-token",
+            "mountPath": "/var/run/secrets/openshell",
+            "readOnly": true,
+        }));
+    }
     container.insert(
         "volumeMounts".to_string(),
         serde_json::Value::Array(volume_mounts),
@@ -1329,23 +1378,33 @@ fn sandbox_template_to_k8s(
             "secret": { "secretName": params.client_tls_secret_name, "defaultMode": 256 }
         }));
     }
-    // Projected ServiceAccountToken volume — kubelet writes a short-lived
-    // audience-bound JWT into /var/run/secrets/openshell/token and rotates
-    // it automatically. The supervisor exchanges this for a gateway-minted
-    // JWT via `IssueSandboxToken` once at startup.
-    volumes.push(serde_json::json!({
-        "name": "openshell-sa-token",
-        "projected": {
-            "sources": [{
-                "serviceAccountToken": {
-                    "audience": "openshell-gateway",
-                    "expirationSeconds": params.sa_token_ttl_secs,
-                    "path": "token"
-                }
-            }],
-            "defaultMode": 256
-        }
-    }));
+    if params.spiffe_enabled {
+        volumes.push(serde_json::json!({
+            "name": SPIFFE_WORKLOAD_API_VOLUME_NAME,
+            "csi": {
+                "driver": "csi.spiffe.io",
+                "readOnly": true
+            }
+        }));
+    } else {
+        // Projected ServiceAccountToken volume — kubelet writes a short-lived
+        // audience-bound JWT into /var/run/secrets/openshell/token and rotates
+        // it automatically. The supervisor exchanges this for a gateway-minted
+        // JWT via `IssueSandboxToken` once at startup.
+        volumes.push(serde_json::json!({
+            "name": "openshell-sa-token",
+            "projected": {
+                "sources": [{
+                    "serviceAccountToken": {
+                        "audience": "openshell-gateway",
+                        "expirationSeconds": params.sa_token_ttl_secs,
+                        "path": "token"
+                    }
+                }],
+                "defaultMode": 256
+            }
+        }));
+    }
     spec.insert("volumes".to_string(), serde_json::Value::Array(volumes));
 
     // Add hostAliases so sandbox pods can reach the Docker host.
@@ -1457,6 +1516,7 @@ fn build_env_list(
     grpc_endpoint: &str,
     ssh_socket_path: &str,
     tls_enabled: bool,
+    spiffe_env: Option<SpiffeEnv>,
 ) -> Vec<serde_json::Value> {
     let mut env = existing_env.cloned().unwrap_or_default();
     apply_env_map(&mut env, template_environment);
@@ -1468,6 +1528,7 @@ fn build_env_list(
         grpc_endpoint,
         ssh_socket_path,
         tls_enabled,
+        spiffe_env,
     );
     env
 }
@@ -1490,6 +1551,7 @@ fn apply_required_env(
     grpc_endpoint: &str,
     ssh_socket_path: &str,
     tls_enabled: bool,
+    spiffe_env: Option<SpiffeEnv>,
 ) {
     upsert_env(env, openshell_core::sandbox_env::SANDBOX_ID, sandbox_id);
     upsert_env(env, openshell_core::sandbox_env::SANDBOX, sandbox_name);
@@ -1525,14 +1587,79 @@ fn apply_required_env(
             "/etc/openshell-tls/client/tls.key",
         );
     }
-    // Projected ServiceAccount token written by kubelet (see the volume
-    // definition in `sandbox_template_to_k8s`). The supervisor reads this
-    // and exchanges it for a gateway-minted JWT via `IssueSandboxToken`.
-    upsert_env(
-        env,
-        openshell_core::sandbox_env::K8S_SA_TOKEN_FILE,
-        "/var/run/secrets/openshell/token",
-    );
+    if let Some(spiffe) = spiffe_env {
+        upsert_env(
+            env,
+            openshell_core::sandbox_env::SPIFFE_WORKLOAD_API_SOCKET,
+            &spiffe.socket_path,
+        );
+        upsert_env(
+            env,
+            openshell_core::sandbox_env::SPIFFE_AUDIENCE,
+            &spiffe.audience,
+        );
+        upsert_env(env, openshell_core::sandbox_env::SPIFFE_ID, &spiffe.id);
+    } else {
+        // Projected ServiceAccount token written by kubelet (see the volume
+        // definition in `sandbox_template_to_k8s`). The supervisor reads this
+        // and exchanges it for a gateway-minted JWT via `IssueSandboxToken`.
+        upsert_env(
+            env,
+            openshell_core::sandbox_env::K8S_SA_TOKEN_FILE,
+            "/var/run/secrets/openshell/token",
+        );
+    }
+}
+
+#[derive(Clone)]
+struct SpiffeEnv {
+    socket_path: String,
+    audience: String,
+    id: String,
+}
+
+fn spiffe_env(params: &SandboxPodParams<'_>) -> Option<SpiffeEnv> {
+    params.spiffe_enabled.then(|| SpiffeEnv {
+        socket_path: params.spiffe_workload_api_socket_path.to_string(),
+        audience: params.spiffe_audience.to_string(),
+        id: sandbox_spiffe_id(params),
+    })
+}
+
+fn sandbox_spiffe_id(params: &SandboxPodParams<'_>) -> String {
+    format!(
+        "spiffe://{}{}{}",
+        params
+            .spiffe_trust_domain
+            .trim()
+            .trim_start_matches("spiffe://")
+            .trim_end_matches('/'),
+        normalize_spiffe_path_prefix(params.spiffe_sandbox_id_prefix),
+        params.sandbox_id,
+    )
+}
+
+fn normalize_spiffe_path_prefix(prefix: &str) -> String {
+    let trimmed = prefix.trim();
+    let with_leading = if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{trimmed}")
+    };
+    if with_leading.ends_with('/') {
+        with_leading
+    } else {
+        format!("{with_leading}/")
+    }
+}
+
+fn spiffe_socket_mount_path(socket_path: &str) -> String {
+    std::path::Path::new(socket_path)
+        .parent()
+        .and_then(std::path::Path::to_str)
+        .filter(|path| !path.is_empty())
+        .unwrap_or("/spiffe-workload-api")
+        .to_string()
 }
 
 fn upsert_env(env: &mut Vec<serde_json::Value>, name: &str, value: &str) {
@@ -1952,6 +2079,7 @@ mod tests {
             "https://endpoint:8080",
             "0.0.0.0:2222",
             true, // tls_enabled
+            None,
         );
 
         // Extract the TLS-related env vars
@@ -2527,6 +2655,65 @@ mod tests {
             pod_template["spec"]["automountServiceAccountToken"],
             serde_json::json!(false),
             "explicit service account selection must not re-enable default token automounting"
+        );
+    }
+
+    #[test]
+    fn spiffe_mode_mounts_csi_socket_and_sets_identity_env() {
+        let params = SandboxPodParams {
+            sandbox_id: "sandbox-123",
+            sandbox_name: "sandbox",
+            spiffe_enabled: true,
+            spiffe_workload_api_socket_path: "/spiffe-workload-api/spire-agent.sock",
+            spiffe_trust_domain: "openshell.local",
+            spiffe_audience: "openshell-gateway",
+            spiffe_sandbox_id_prefix: "/openshell/sandbox/",
+            ..SandboxPodParams::default()
+        };
+        let pod_template = sandbox_template_to_k8s(
+            &SandboxTemplate::default(),
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &params,
+        );
+
+        let env = pod_template["spec"]["containers"][0]["env"]
+            .as_array()
+            .expect("env");
+        assert!(env.iter().any(|e| {
+            e["name"] == openshell_core::sandbox_env::SPIFFE_WORKLOAD_API_SOCKET
+                && e["value"] == "/spiffe-workload-api/spire-agent.sock"
+        }));
+        assert!(env.iter().any(|e| {
+            e["name"] == openshell_core::sandbox_env::SPIFFE_ID
+                && e["value"] == "spiffe://openshell.local/openshell/sandbox/sandbox-123"
+        }));
+        assert!(
+            !env.iter()
+                .any(|e| e["name"] == openshell_core::sandbox_env::K8S_SA_TOKEN_FILE),
+            "SPIFFE mode must not expose the ServiceAccount bootstrap token"
+        );
+
+        let volumes = pod_template["spec"]["volumes"].as_array().expect("volumes");
+        assert!(volumes.iter().any(|volume| {
+            volume["name"] == SPIFFE_WORKLOAD_API_VOLUME_NAME
+                && volume["csi"]["driver"] == "csi.spiffe.io"
+        }));
+        assert!(
+            !volumes
+                .iter()
+                .any(|volume| volume["name"] == "openshell-sa-token"),
+            "SPIFFE mode must not mount the ServiceAccount token volume"
+        );
+
+        assert_eq!(
+            pod_template["metadata"]["annotations"]["openshell.io/spiffe-id"],
+            serde_json::json!("spiffe://openshell.local/openshell/sandbox/sandbox-123")
+        );
+        assert_eq!(
+            pod_template["metadata"]["labels"][LABEL_MANAGED_BY],
+            serde_json::json!(LABEL_MANAGED_BY_VALUE)
         );
     }
 

--- a/crates/openshell-driver-kubernetes/src/main.rs
+++ b/crates/openshell-driver-kubernetes/src/main.rs
@@ -82,6 +82,26 @@ struct Args {
     /// gateway clamps values outside `[600, 86400]`. Default 3600.
     #[arg(long, env = "OPENSHELL_K8S_SA_TOKEN_TTL_SECS", default_value_t = 3600)]
     sa_token_ttl_secs: i64,
+
+    #[arg(long, env = "OPENSHELL_SPIFFE_WORKLOAD_API_SOCKET")]
+    spiffe_workload_api_socket_path: Option<String>,
+
+    #[arg(long, env = "OPENSHELL_SPIFFE_TRUST_DOMAIN")]
+    spiffe_trust_domain: Option<String>,
+
+    #[arg(
+        long,
+        env = "OPENSHELL_SPIFFE_AUDIENCE",
+        default_value = "openshell-gateway"
+    )]
+    spiffe_audience: String,
+
+    #[arg(
+        long,
+        env = "OPENSHELL_SPIFFE_SANDBOX_ID_PREFIX",
+        default_value = "/openshell/sandbox/"
+    )]
+    spiffe_sandbox_id_prefix: String,
 }
 
 #[tokio::main]
@@ -115,6 +135,10 @@ async fn main() -> Result<()> {
             openshell_driver_kubernetes::DEFAULT_WORKSPACE_STORAGE_SIZE.to_string()
         }),
         sa_token_ttl_secs: args.sa_token_ttl_secs,
+        spiffe_workload_api_socket_path: args.spiffe_workload_api_socket_path.unwrap_or_default(),
+        spiffe_trust_domain: args.spiffe_trust_domain.unwrap_or_default(),
+        spiffe_audience: args.spiffe_audience,
+        spiffe_sandbox_id_prefix: args.spiffe_sandbox_id_prefix,
     })
     .await
     .into_diagnostic()?;

--- a/crates/openshell-providers/src/discovery.rs
+++ b/crates/openshell-providers/src/discovery.rs
@@ -96,6 +96,7 @@ mod tests {
                     header_name: String::new(),
                     query_param: String::new(),
                     refresh: None,
+                    token_grant: None,
                 },
                 CredentialProfile {
                     name: "secondary".to_string(),
@@ -106,6 +107,7 @@ mod tests {
                     header_name: String::new(),
                     query_param: String::new(),
                     refresh: None,
+                    token_grant: None,
                 },
             ],
             endpoints: Vec::new(),

--- a/crates/openshell-providers/src/profiles.rs
+++ b/crates/openshell-providers/src/profiles.rs
@@ -81,6 +81,36 @@ pub struct CredentialProfile {
     pub query_param: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub refresh: Option<CredentialRefreshProfile>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_grant: Option<TokenGrantProfile>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct TokenGrantProfile {
+    pub token_endpoint: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub audience: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub jwt_svid_audience: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_zero_i64")]
+    pub cache_ttl_seconds: i64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub audience_overrides: Vec<TokenGrantAudienceOverrideProfile>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct TokenGrantAudienceOverrideProfile {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub host: String,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub port: u32,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub path: String,
+    pub audience: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -280,6 +310,7 @@ impl ProviderTypeProfile {
                         .refresh
                         .as_ref()
                         .map(credential_refresh_from_proto),
+                    token_grant: credential.token_grant.as_ref().map(token_grant_from_proto),
                 })
                 .collect(),
             endpoints: profile.endpoints.iter().map(endpoint_from_proto).collect(),
@@ -325,6 +356,7 @@ impl ProviderTypeProfile {
                     header_name: credential.header_name.clone(),
                     query_param: credential.query_param.clone(),
                     refresh: credential.refresh.as_ref().map(credential_refresh_to_proto),
+                    token_grant: credential.token_grant.as_ref().map(token_grant_to_proto),
                 })
                 .collect(),
             endpoints: self.endpoints.iter().map(endpoint_to_proto).collect(),
@@ -557,6 +589,64 @@ fn credential_refresh_to_proto(refresh: &CredentialRefreshProfile) -> ProviderCr
                 secret: material.secret,
             })
             .collect(),
+    }
+}
+
+fn token_grant_from_proto(
+    token_grant: &openshell_core::proto::ProviderCredentialTokenGrant,
+) -> TokenGrantProfile {
+    TokenGrantProfile {
+        token_endpoint: token_grant.token_endpoint.clone(),
+        audience: token_grant.audience.clone(),
+        jwt_svid_audience: token_grant.jwt_svid_audience.clone(),
+        scopes: token_grant.scopes.clone(),
+        cache_ttl_seconds: token_grant.cache_ttl_seconds,
+        audience_overrides: token_grant
+            .audience_overrides
+            .iter()
+            .map(token_grant_audience_override_from_proto)
+            .collect(),
+    }
+}
+
+fn token_grant_to_proto(
+    token_grant: &TokenGrantProfile,
+) -> openshell_core::proto::ProviderCredentialTokenGrant {
+    openshell_core::proto::ProviderCredentialTokenGrant {
+        token_endpoint: token_grant.token_endpoint.clone(),
+        audience: token_grant.audience.clone(),
+        jwt_svid_audience: token_grant.jwt_svid_audience.clone(),
+        scopes: token_grant.scopes.clone(),
+        cache_ttl_seconds: token_grant.cache_ttl_seconds,
+        audience_overrides: token_grant
+            .audience_overrides
+            .iter()
+            .map(token_grant_audience_override_to_proto)
+            .collect(),
+    }
+}
+
+fn token_grant_audience_override_from_proto(
+    override_config: &openshell_core::proto::ProviderCredentialTokenGrantAudienceOverride,
+) -> TokenGrantAudienceOverrideProfile {
+    TokenGrantAudienceOverrideProfile {
+        host: override_config.host.clone(),
+        port: override_config.port,
+        path: override_config.path.clone(),
+        audience: override_config.audience.clone(),
+        scopes: override_config.scopes.clone(),
+    }
+}
+
+fn token_grant_audience_override_to_proto(
+    override_config: &TokenGrantAudienceOverrideProfile,
+) -> openshell_core::proto::ProviderCredentialTokenGrantAudienceOverride {
+    openshell_core::proto::ProviderCredentialTokenGrantAudienceOverride {
+        host: override_config.host.clone(),
+        port: override_config.port,
+        path: override_config.path.clone(),
+        audience: override_config.audience.clone(),
+        scopes: override_config.scopes.clone(),
     }
 }
 
@@ -1229,6 +1319,62 @@ credentials:
         let exported = profile_to_yaml(&from_proto).expect("yaml");
         assert!(exported.contains("oauth2_client_credentials"));
         assert!(exported.contains("client_secret"));
+    }
+
+    #[test]
+    fn token_grant_audience_overrides_round_trip_through_proto() {
+        let profile = parse_profile_yaml(
+            r"
+id: keycloak-example
+display_name: Keycloak Example
+credentials:
+  - name: access_token
+    auth_style: bearer
+    header_name: Authorization
+    token_grant:
+      token_endpoint: http://keycloak/realms/openshell/protocol/openid-connect/token
+      jwt_svid_audience: http://keycloak/realms/openshell
+      audience: api://default
+      scopes: [openid]
+      cache_ttl_seconds: 300
+      audience_overrides:
+        - host: alpha.default.svc.cluster.local
+          port: 80
+          audience: api://alpha
+        - host: beta.default.svc.cluster.local
+          port: 80
+          path: /v1/**
+          audience: api://beta
+          scopes: [beta.read]
+",
+        )
+        .expect("profile should parse");
+
+        let token_grant = profile.credentials[0]
+            .token_grant
+            .as_ref()
+            .expect("token grant should parse");
+        assert_eq!(
+            token_grant.jwt_svid_audience,
+            "http://keycloak/realms/openshell"
+        );
+        assert_eq!(token_grant.audience_overrides.len(), 2);
+        assert_eq!(token_grant.audience_overrides[1].path, "/v1/**");
+        assert_eq!(token_grant.audience_overrides[1].scopes, vec!["beta.read"]);
+
+        let reparsed = ProviderTypeProfile::from_proto(&profile.to_proto());
+        let reparsed_token_grant = reparsed.credentials[0]
+            .token_grant
+            .as_ref()
+            .expect("token grant should round trip");
+        assert_eq!(
+            reparsed_token_grant.jwt_svid_audience,
+            token_grant.jwt_svid_audience
+        );
+        assert_eq!(
+            reparsed_token_grant.audience_overrides,
+            token_grant.audience_overrides
+        );
     }
 
     #[test]

--- a/crates/openshell-sandbox/Cargo.toml
+++ b/crates/openshell-sandbox/Cargo.toml
@@ -24,8 +24,9 @@ openshell-router = { path = "../openshell-router" }
 tokio = { workspace = true }
 
 # gRPC
-tonic = { workspace = true, features = ["channel", "tls"] }
+tonic = { workspace = true, features = ["channel", "tls-native-roots"] }
 tokio-stream = { workspace = true }
+spiffe = { workspace = true }
 
 # CLI
 clap = { workspace = true }

--- a/crates/openshell-sandbox/Cargo.toml
+++ b/crates/openshell-sandbox/Cargo.toml
@@ -53,6 +53,7 @@ webpki-roots = { workspace = true }
 
 # HTTP
 bytes = { workspace = true }
+reqwest = { workspace = true }
 
 # UUID
 uuid = { workspace = true }

--- a/crates/openshell-sandbox/src/grpc_client.rs
+++ b/crates/openshell-sandbox/src/grpc_client.rs
@@ -4,21 +4,24 @@
 //! gRPC client for fetching sandbox policy, provider environment, and inference
 //! route bundles from `OpenShell` server.
 //!
-//! Every request carries a gateway-minted JWT in the `Authorization` header.
-//! The token is resolved at startup from one of three sources:
+//! Every request carries a sandbox bearer credential in the `Authorization`
+//! header. The token is resolved at startup from one of four sources:
 //!
 //! 1. `OPENSHELL_SANDBOX_TOKEN` — raw JWT in the env (test harness path).
 //! 2. `OPENSHELL_SANDBOX_TOKEN_FILE` — file containing the JWT (Docker /
 //!    Podman / VM drivers write this to a bundle file at sandbox-create
 //!    time).
-//! 3. `OPENSHELL_K8S_SA_TOKEN_FILE` — projected `ServiceAccount` JWT; the
+//! 3. `OPENSHELL_SPIFFE_WORKLOAD_API_SOCKET` — local SPIFFE Workload API
+//!    socket; the supervisor fetches a JWT-SVID and presents it directly.
+//! 4. `OPENSHELL_K8S_SA_TOKEN_FILE` — projected `ServiceAccount` JWT; the
 //!    supervisor exchanges it for a gateway JWT via `IssueSandboxToken`
 //!    once at startup.
 //!
-//! The resolved gateway JWT is held in process memory thereafter and
+//! The resolved bearer credential is held in process memory thereafter and
 //! injected on every outbound call by [`AuthInterceptor`].
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -31,6 +34,7 @@ use openshell_core::proto::{
     UpdateConfigRequest, inference_client::InferenceClient, open_shell_client::OpenShellClient,
 };
 use openshell_core::sandbox_env;
+use spiffe::{SpiffeId, WorkloadApiClient};
 use tonic::Status;
 use tonic::metadata::AsciiMetadataValue;
 use tonic::service::interceptor::InterceptedService;
@@ -53,18 +57,12 @@ enum TokenSource {
     K8sServiceAccount,
 }
 
-#[derive(Debug)]
-struct AcquiredToken {
-    token: String,
-    source: TokenSource,
-}
-
 /// Process-wide token slot. Initialized by the first [`connect_channel`]
 /// call and shared with every subsequent client and the renewal loop.
 static TOKEN_SLOT: OnceLock<TokenSlot> = OnceLock::new();
 
-/// Source used to acquire the process-wide token slot.
-static TOKEN_SOURCE: OnceLock<TokenSource> = OnceLock::new();
+/// Refresh strategy used by the process-wide token slot.
+static TOKEN_REFRESH_MODE: OnceLock<RefreshMode> = OnceLock::new();
 
 /// Serializes the first token acquisition. Several supervisor subsystems
 /// connect during startup; without this guard they can all observe an empty
@@ -73,6 +71,25 @@ static TOKEN_INIT_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new((
 
 /// One-shot guard so the renewal loop spawns at most once per process.
 static REFRESH_SPAWNED: OnceLock<()> = OnceLock::new();
+
+#[derive(Clone, Debug)]
+enum RefreshMode {
+    GatewayJwt(TokenSource),
+    Spiffe(SpiffeTokenSource),
+}
+
+#[derive(Clone, Debug)]
+struct SpiffeTokenSource {
+    socket_path: PathBuf,
+    audience: String,
+    spiffe_id: Option<String>,
+}
+
+#[derive(Debug)]
+struct AcquiredToken {
+    token: String,
+    refresh_mode: RefreshMode,
+}
 
 fn install_token_slot(token: &str) -> Result<TokenSlot> {
     let bearer = AsciiMetadataValue::try_from(format!("Bearer {token}"))
@@ -188,36 +205,52 @@ async fn build_plain_channel(endpoint: &str) -> Result<Channel> {
 /// spawned once per process via [`REFRESH_SPAWNED`].
 async fn connect_channel(endpoint: &str) -> Result<AuthedChannel> {
     let channel = build_plain_channel(endpoint).await?;
-    let (slot, source) = token_slot(endpoint, &channel).await?;
+    let (slot, refresh_mode) = token_slot(endpoint, &channel).await?;
     let plain_channel = channel.clone();
     let intercepted = InterceptedService::new(channel, AuthInterceptor::new(slot.clone()));
     if REFRESH_SPAWNED.set(()).is_ok() {
-        let refresh_channel = intercepted.clone();
-        let endpoint = endpoint.to_string();
-        tokio::spawn(async move {
-            refresh_token_loop(refresh_channel, slot, source, endpoint, plain_channel).await;
-        });
+        match refresh_mode {
+            RefreshMode::GatewayJwt(source) => {
+                let refresh_channel = intercepted.clone();
+                let endpoint = endpoint.to_string();
+                tokio::spawn(async move {
+                    refresh_token_loop(refresh_channel, slot, source, endpoint, plain_channel)
+                        .await;
+                });
+            }
+            RefreshMode::Spiffe(source) => {
+                tokio::spawn(async move {
+                    refresh_spiffe_token_loop(source, slot).await;
+                });
+            }
+        }
     }
     Ok(intercepted)
 }
 
-async fn token_slot(endpoint: &str, plain_channel: &Channel) -> Result<(TokenSlot, TokenSource)> {
+async fn token_slot(endpoint: &str, plain_channel: &Channel) -> Result<(TokenSlot, RefreshMode)> {
     if let Some(existing) = TOKEN_SLOT.get() {
-        let source = TOKEN_SOURCE.get().copied().unwrap_or(TokenSource::Env);
-        return Ok((existing.clone(), source));
+        let refresh_mode = TOKEN_REFRESH_MODE
+            .get()
+            .cloned()
+            .unwrap_or(RefreshMode::GatewayJwt(TokenSource::Env));
+        return Ok((existing.clone(), refresh_mode));
     }
 
     let _guard = TOKEN_INIT_LOCK.lock().await;
 
     if let Some(existing) = TOKEN_SLOT.get() {
-        let source = TOKEN_SOURCE.get().copied().unwrap_or(TokenSource::Env);
-        return Ok((existing.clone(), source));
+        let refresh_mode = TOKEN_REFRESH_MODE
+            .get()
+            .cloned()
+            .unwrap_or(RefreshMode::GatewayJwt(TokenSource::Env));
+        return Ok((existing.clone(), refresh_mode));
     }
 
     let acquired = acquire_sandbox_token(endpoint, plain_channel).await?;
     let slot = install_token_slot(&acquired.token)?;
-    let _ = TOKEN_SOURCE.set(acquired.source);
-    Ok((slot, acquired.source))
+    let _ = TOKEN_REFRESH_MODE.set(acquired.refresh_mode.clone());
+    Ok((slot, acquired.refresh_mode))
 }
 
 /// Resolve the sandbox JWT used to authenticate every outbound RPC.
@@ -233,7 +266,7 @@ async fn acquire_sandbox_token(endpoint: &str, plain_channel: &Channel) -> Resul
         debug!(source = "env", "loaded sandbox token");
         return Ok(AcquiredToken {
             token: t,
-            source: TokenSource::Env,
+            refresh_mode: RefreshMode::GatewayJwt(TokenSource::Env),
         });
     }
 
@@ -246,7 +279,21 @@ async fn acquire_sandbox_token(endpoint: &str, plain_channel: &Channel) -> Resul
         debug!(source = "file", path = %path, "loaded sandbox token");
         return Ok(AcquiredToken {
             token: contents.trim().to_string(),
-            source: TokenSource::File,
+            refresh_mode: RefreshMode::GatewayJwt(TokenSource::File),
+        });
+    }
+
+    if let Some(source) = spiffe_token_source_from_env()? {
+        info!(
+            socket = %source.socket_path.display(),
+            audience = %source.audience,
+            spiffe_id = source.spiffe_id.as_deref().unwrap_or(""),
+            "fetching SPIFFE JWT-SVID for sandbox gateway authentication"
+        );
+        let token = fetch_spiffe_jwt_svid(&source).await?;
+        return Ok(AcquiredToken {
+            token,
+            refresh_mode: RefreshMode::Spiffe(source),
         });
     }
 
@@ -255,14 +302,15 @@ async fn acquire_sandbox_token(endpoint: &str, plain_channel: &Channel) -> Resul
     {
         return Ok(AcquiredToken {
             token: acquire_k8s_sandbox_token(endpoint, plain_channel, &sa_path).await?,
-            source: TokenSource::K8sServiceAccount,
+            refresh_mode: RefreshMode::GatewayJwt(TokenSource::K8sServiceAccount),
         });
     }
 
     Err(miette::miette!(
-        "no sandbox token source available — set one of {}, {}, or {}",
+        "no sandbox token source available — set one of {}, {}, {}, or {}",
         sandbox_env::SANDBOX_TOKEN,
         sandbox_env::SANDBOX_TOKEN_FILE,
+        sandbox_env::SPIFFE_WORKLOAD_API_SOCKET,
         sandbox_env::K8S_SA_TOKEN_FILE,
     ))
 }
@@ -295,6 +343,64 @@ async fn acquire_k8s_sandbox_token(
         .into_diagnostic()
         .wrap_err("IssueSandboxToken bootstrap exchange failed")?;
     Ok(resp.into_inner().token)
+}
+
+fn spiffe_token_source_from_env() -> Result<Option<SpiffeTokenSource>> {
+    let Ok(socket_path) = std::env::var(sandbox_env::SPIFFE_WORKLOAD_API_SOCKET) else {
+        return Ok(None);
+    };
+    if socket_path.trim().is_empty() {
+        return Ok(None);
+    }
+    let audience = std::env::var(sandbox_env::SPIFFE_AUDIENCE)
+        .unwrap_or_else(|_| "openshell-gateway".to_string());
+    if audience.trim().is_empty() {
+        return Err(miette::miette!(
+            "{} must not be empty when {} is set",
+            sandbox_env::SPIFFE_AUDIENCE,
+            sandbox_env::SPIFFE_WORKLOAD_API_SOCKET,
+        ));
+    }
+    let spiffe_id = std::env::var(sandbox_env::SPIFFE_ID)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    Ok(Some(SpiffeTokenSource {
+        socket_path: PathBuf::from(socket_path),
+        audience,
+        spiffe_id,
+    }))
+}
+
+async fn fetch_spiffe_jwt_svid(source: &SpiffeTokenSource) -> Result<String> {
+    let endpoint = spiffe_workload_api_endpoint(&source.socket_path);
+    let client = WorkloadApiClient::connect_to(&endpoint)
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| {
+            format!("failed to connect to SPIFFE Workload API endpoint {endpoint}")
+        })?;
+    let requested_spiffe_id = source
+        .spiffe_id
+        .as_deref()
+        .map(SpiffeId::try_from)
+        .transpose()
+        .into_diagnostic()
+        .wrap_err("invalid SPIFFE ID requested for JWT-SVID")?;
+    client
+        .fetch_jwt_token([source.audience.as_str()], requested_spiffe_id.as_ref())
+        .await
+        .into_diagnostic()
+        .wrap_err("SPIFFE FetchJWTSVID failed")
+}
+
+fn spiffe_workload_api_endpoint(path: &std::path::Path) -> String {
+    let path = path.to_string_lossy();
+    if path.starts_with("unix:") || path.starts_with("tcp:") {
+        path.into_owned()
+    } else {
+        format!("unix:{path}")
+    }
 }
 
 /// Build an authenticated channel for direct external use (e.g. the
@@ -380,6 +486,30 @@ async fn refresh_token_loop(
                 warn!(error = %status, "RefreshSandboxToken failed; will retry");
                 // Backoff so we don't spin against a sustained failure.
                 tokio::time::sleep(Duration::from_secs(10)).await;
+            }
+        }
+    }
+}
+
+async fn refresh_spiffe_token_loop(source: SpiffeTokenSource, slot: TokenSlot) {
+    loop {
+        let sleep = compute_refresh_delay(&slot);
+        tokio::time::sleep(sleep).await;
+        match fetch_spiffe_jwt_svid(&source).await {
+            Ok(new_token) => match AsciiMetadataValue::try_from(format!("Bearer {new_token}")) {
+                Ok(value) => {
+                    if let Ok(mut guard) = slot.write() {
+                        *guard = value;
+                        info!("rotated SPIFFE JWT-SVID in-place");
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, "refreshed SPIFFE JWT-SVID contained invalid header bytes");
+                }
+            },
+            Err(err) => {
+                warn!(error = %err, "SPIFFE FetchJWTSVID failed; will retry");
+                tokio::time::sleep(Duration::from_secs(60)).await;
             }
         }
     }

--- a/crates/openshell-sandbox/src/grpc_client.rs
+++ b/crates/openshell-sandbox/src/grpc_client.rs
@@ -373,7 +373,7 @@ fn spiffe_token_source_from_env() -> Result<Option<SpiffeTokenSource>> {
 }
 
 async fn fetch_spiffe_jwt_svid(source: &SpiffeTokenSource) -> Result<String> {
-    let endpoint = spiffe_workload_api_endpoint(&source.socket_path);
+    let endpoint = crate::spiffe_endpoint::workload_api_endpoint(&source.socket_path);
     let client = WorkloadApiClient::connect_to(&endpoint)
         .await
         .into_diagnostic()
@@ -392,15 +392,6 @@ async fn fetch_spiffe_jwt_svid(source: &SpiffeTokenSource) -> Result<String> {
         .await
         .into_diagnostic()
         .wrap_err("SPIFFE FetchJWTSVID failed")
-}
-
-fn spiffe_workload_api_endpoint(path: &std::path::Path) -> String {
-    let path = path.to_string_lossy();
-    if path.starts_with("unix:") || path.starts_with("tcp:") {
-        path.into_owned()
-    } else {
-        format!("unix:{path}")
-    }
 }
 
 /// Build an authenticated channel for direct external use (e.g. the
@@ -784,6 +775,7 @@ pub async fn fetch_provider_environment(
         environment: inner.environment,
         provider_env_revision: inner.provider_env_revision,
         credential_expires_at_ms: inner.credential_expires_at_ms,
+        dynamic_credentials: inner.dynamic_credentials,
     })
 }
 
@@ -814,6 +806,7 @@ pub struct ProviderEnvironmentResult {
     pub environment: HashMap<String, String>,
     pub provider_env_revision: u64,
     pub credential_expires_at_ms: HashMap<String, i64>,
+    pub dynamic_credentials: HashMap<String, openshell_core::proto::ProviderProfileCredential>,
 }
 
 impl CachedOpenShellClient {

--- a/crates/openshell-sandbox/src/l7/graphql.rs
+++ b/crates/openshell-sandbox/src/l7/graphql.rs
@@ -801,6 +801,8 @@ network_policies:
             ancestors: Vec::new(),
             cmdline_paths: Vec::new(),
             secret_resolver: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
         };
         let request_info = crate::l7::L7RequestInfo {
             action: req.action,

--- a/crates/openshell-sandbox/src/l7/mod.rs
+++ b/crates/openshell-sandbox/src/l7/mod.rs
@@ -15,6 +15,7 @@ pub mod provider;
 pub mod relay;
 pub mod rest;
 pub mod tls;
+pub(crate) mod token_grant_injection;
 pub(crate) mod websocket;
 
 /// Application-layer protocol for L7 inspection.

--- a/crates/openshell-sandbox/src/l7/relay.rs
+++ b/crates/openshell-sandbox/src/l7/relay.rs
@@ -37,6 +37,17 @@ pub struct L7EvalContext {
     pub cmdline_paths: Vec<String>,
     /// Supervisor-only placeholder resolver for outbound headers.
     pub(crate) secret_resolver: Option<Arc<SecretResolver>>,
+    /// Dynamic credentials (token grants) keyed by endpoint-bound provider metadata.
+    pub(crate) dynamic_credentials: Option<
+        Arc<
+            std::sync::RwLock<
+                std::collections::HashMap<String, openshell_core::proto::ProviderProfileCredential>,
+            >,
+        >,
+    >,
+    /// Dynamic token grant resolver for endpoint-bound credentials.
+    pub(crate) token_grant_resolver:
+        Option<Arc<dyn crate::l7::token_grant_injection::TokenGrantResolver>>,
 }
 
 #[derive(Default)]
@@ -758,9 +769,12 @@ where
         let _ = &eval_target;
 
         if allowed || config.enforcement == EnforcementMode::Audit {
+            let req_with_auth =
+                crate::l7::token_grant_injection::inject_if_needed(req, ctx).await?;
+
             // Forward request to upstream and relay response
             let outcome = crate::l7::rest::relay_http_request_with_options_guarded(
-                &req,
+                &req_with_auth,
                 client,
                 upstream,
                 crate::l7::rest::RelayRequestOptions {
@@ -791,7 +805,7 @@ where
                         ctx,
                         websocket_request,
                         &redacted_target,
-                        &req.query_params,
+                        &req_with_auth.query_params,
                         Some(engine),
                     );
                     options.websocket.permessage_deflate = websocket_permessage_deflate;
@@ -1247,11 +1261,29 @@ where
             ocsf_emit!(event);
         }
 
+        let req_with_auth = match crate::l7::token_grant_injection::inject_if_needed(req, ctx).await
+        {
+            Ok(req) => req,
+            Err(e) => {
+                warn!(
+                    host = %ctx.host,
+                    port = ctx.port,
+                    error = %e,
+                    "Token grant failed in passthrough relay"
+                );
+                let response =
+                    b"HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                client.write_all(response).await.into_diagnostic()?;
+                client.flush().await.into_diagnostic()?;
+                return Ok(());
+            }
+        };
+
         // Forward request with credential rewriting and relay the response.
         // relay_http_request_with_resolver handles both directions: it sends
         // the request upstream and reads the response back to the client.
         let outcome = crate::l7::rest::relay_http_request_with_options_guarded(
-            &req,
+            &req_with_auth,
             client,
             upstream,
             crate::l7::rest::RelayRequestOptions {
@@ -1298,6 +1330,126 @@ mod tests {
 
     const TEST_POLICY: &str = include_str!("../../data/sandbox-policy.rego");
 
+    fn rest_token_grant_relay_context(
+        resolver_response: std::result::Result<&str, &str>,
+    ) -> (
+        L7EndpointConfig,
+        TunnelPolicyEngine,
+        L7EvalContext,
+        crate::l7::token_grant_injection::test_support::TokenGrantTestFixture,
+    ) {
+        let data = r#"
+network_policies:
+  rest_api:
+    name: rest_api
+    endpoints:
+      - host: api.example.test
+        port: 8080
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow:
+              method: GET
+              path: "/v1/**"
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
+        let input = NetworkInput {
+            host: "api.example.test".into(),
+            port: 8080,
+            binary_path: PathBuf::from("/usr/bin/curl"),
+            binary_sha256: "unused".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+        };
+        let (endpoint_config, generation) = engine
+            .query_endpoint_config_with_generation(&input)
+            .unwrap();
+        let config = crate::l7::parse_l7_config(&endpoint_config.unwrap()).unwrap();
+        let tunnel_engine = engine.clone_engine_for_tunnel(generation).unwrap();
+        let provider_key = "api.example.test\t8080\t/v1/**\tprovider:access_token";
+        let fixture = match resolver_response {
+            Ok(token) => {
+                crate::l7::token_grant_injection::test_support::TokenGrantTestFixture::success(
+                    provider_key,
+                    token,
+                )
+            }
+            Err(error) => {
+                crate::l7::token_grant_injection::test_support::TokenGrantTestFixture::failure(
+                    provider_key,
+                    error,
+                )
+            }
+        };
+        let ctx = L7EvalContext {
+            host: "api.example.test".into(),
+            port: 8080,
+            policy_name: "rest_api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            dynamic_credentials: Some(fixture.dynamic_credentials()),
+            token_grant_resolver: Some(fixture.resolver()),
+        };
+
+        (config, tunnel_engine, ctx, fixture)
+    }
+
+    fn passthrough_token_grant_relay_context(
+        resolver_response: std::result::Result<&str, &str>,
+    ) -> (
+        PolicyGenerationGuard,
+        L7EvalContext,
+        crate::l7::token_grant_injection::test_support::TokenGrantTestFixture,
+    ) {
+        let policy_data = "network_policies: {}\n";
+        let engine = OpaEngine::from_strings(TEST_POLICY, policy_data).unwrap();
+        let generation_guard = engine
+            .generation_guard(engine.current_generation())
+            .unwrap();
+        let provider_key = "api.example.test\t8080\t/v1/**\tprovider:access_token";
+        let fixture = match resolver_response {
+            Ok(token) => {
+                crate::l7::token_grant_injection::test_support::TokenGrantTestFixture::success(
+                    provider_key,
+                    token,
+                )
+            }
+            Err(error) => {
+                crate::l7::token_grant_injection::test_support::TokenGrantTestFixture::failure(
+                    provider_key,
+                    error,
+                )
+            }
+        };
+        let ctx = L7EvalContext {
+            host: "api.example.test".into(),
+            port: 8080,
+            policy_name: "rest_api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            dynamic_credentials: Some(fixture.dynamic_credentials()),
+            token_grant_resolver: Some(fixture.resolver()),
+        };
+
+        (generation_guard, ctx, fixture)
+    }
+
+    fn authorization_header_count(headers: &str) -> usize {
+        headers
+            .lines()
+            .filter(|line| {
+                line.split_once(':')
+                    .is_some_and(|(name, _)| name.eq_ignore_ascii_case("authorization"))
+            })
+            .count()
+    }
+
     #[test]
     fn parse_rejection_detail_adds_l7_hint_for_encoded_slash() {
         let detail = parse_rejection_detail(
@@ -1329,6 +1481,226 @@ mod tests {
             parse_rejection_detail(error, ParseRejectionMode::L7Endpoint),
             error
         );
+    }
+
+    #[tokio::test]
+    async fn l7_rest_relay_injects_token_grant_authorization_header() {
+        let (config, tunnel_engine, ctx, fixture) =
+            rest_token_grant_relay_context(Ok("grant-token"));
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_with_inspection(
+                &config,
+                tunnel_engine,
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+            )
+            .await
+        });
+
+        app.write_all(
+            b"GET /v1/projects HTTP/1.1\r\nHost: api.example.test\r\nAuthorization: Bearer stale-token\r\nConnection: close\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        let mut upstream_request = [0u8; 1024];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upstream.read(&mut upstream_request),
+        )
+        .await
+        .expect("request should reach upstream")
+        .unwrap();
+        let upstream_request = String::from_utf8_lossy(&upstream_request[..n]);
+
+        assert!(upstream_request.starts_with("GET /v1/projects HTTP/1.1\r\n"));
+        assert!(upstream_request.contains("Authorization: Bearer grant-token\r\n"));
+        assert!(!upstream_request.contains("stale-token"));
+        assert_eq!(authorization_header_count(&upstream_request), 1);
+
+        upstream
+            .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .await
+            .unwrap();
+
+        let mut client_response = [0u8; 512];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            app.read(&mut client_response),
+        )
+        .await
+        .expect("response should reach client")
+        .unwrap();
+        assert!(String::from_utf8_lossy(&client_response[..n]).contains("204 No Content"));
+        drop(app);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should finish")
+            .unwrap()
+            .unwrap();
+
+        fixture.assert_one_request("api.example.test\t8080\t/v1/**\tprovider:access_token");
+    }
+
+    #[tokio::test]
+    async fn l7_rest_relay_token_grant_failure_does_not_forward_request() {
+        let (config, tunnel_engine, ctx, fixture) =
+            rest_token_grant_relay_context(Err("oauth unavailable"));
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_with_inspection(
+                &config,
+                tunnel_engine,
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+            )
+            .await
+        });
+
+        app.write_all(
+            b"GET /v1/projects HTTP/1.1\r\nHost: api.example.test\r\nConnection: close\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        let err = tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should fail promptly")
+            .unwrap()
+            .expect_err("token grant failure should fail the L7 relay");
+        assert!(err.to_string().contains("Token grant failed"));
+        assert!(err.to_string().contains("oauth unavailable"));
+
+        let mut upstream_request = [0u8; 128];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upstream.read(&mut upstream_request),
+        )
+        .await
+        .expect("upstream should close without forwarded data")
+        .unwrap();
+        assert_eq!(n, 0, "unauthenticated request must not reach upstream");
+
+        fixture.assert_one_request("api.example.test\t8080\t/v1/**\tprovider:access_token");
+    }
+
+    #[tokio::test]
+    async fn passthrough_relay_injects_token_grant_authorization_header() {
+        let (generation_guard, ctx, fixture) =
+            passthrough_token_grant_relay_context(Ok("grant-token"));
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_passthrough_with_credentials(
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+                &generation_guard,
+            )
+            .await
+        });
+
+        app.write_all(
+            b"GET /v1/projects HTTP/1.1\r\nHost: api.example.test\r\nAuthorization: Bearer stale-token\r\nConnection: close\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        let mut upstream_request = [0u8; 1024];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upstream.read(&mut upstream_request),
+        )
+        .await
+        .expect("request should reach upstream")
+        .unwrap();
+        let upstream_request = String::from_utf8_lossy(&upstream_request[..n]);
+
+        assert!(upstream_request.starts_with("GET /v1/projects HTTP/1.1\r\n"));
+        assert!(upstream_request.contains("Authorization: Bearer grant-token\r\n"));
+        assert!(!upstream_request.contains("stale-token"));
+        assert_eq!(authorization_header_count(&upstream_request), 1);
+
+        upstream
+            .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .await
+            .unwrap();
+
+        let mut client_response = [0u8; 512];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            app.read(&mut client_response),
+        )
+        .await
+        .expect("response should reach client")
+        .unwrap();
+        assert!(String::from_utf8_lossy(&client_response[..n]).contains("204 No Content"));
+        drop(app);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should finish")
+            .unwrap()
+            .unwrap();
+
+        fixture.assert_one_request("api.example.test\t8080\t/v1/**\tprovider:access_token");
+    }
+
+    #[tokio::test]
+    async fn passthrough_relay_token_grant_failure_returns_bad_gateway_without_forwarding() {
+        let (generation_guard, ctx, fixture) =
+            passthrough_token_grant_relay_context(Err("oauth unavailable"));
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_passthrough_with_credentials(
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+                &generation_guard,
+            )
+            .await
+        });
+
+        app.write_all(
+            b"GET /v1/projects HTTP/1.1\r\nHost: api.example.test\r\nConnection: close\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should finish")
+            .unwrap()
+            .unwrap();
+
+        let mut client_response = [0u8; 512];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            app.read(&mut client_response),
+        )
+        .await
+        .expect("bad gateway response should reach client")
+        .unwrap();
+        assert!(String::from_utf8_lossy(&client_response[..n]).contains("502 Bad Gateway"));
+
+        let mut upstream_request = [0u8; 128];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upstream.read(&mut upstream_request),
+        )
+        .await
+        .expect("upstream should close without forwarded data")
+        .unwrap();
+        assert_eq!(n, 0, "unauthenticated request must not reach upstream");
+
+        fixture.assert_one_request("api.example.test\t8080\t/v1/**\tprovider:access_token");
     }
 
     #[test]
@@ -1371,6 +1743,8 @@ network_policies:
             ancestors: vec![],
             cmdline_paths: vec![],
             secret_resolver: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
         };
         let request = L7RequestInfo {
             action: "WEBSOCKET_TEXT".into(),
@@ -1426,6 +1800,8 @@ network_policies:
             ancestors: vec![],
             cmdline_paths: vec![],
             secret_resolver: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
         };
 
         let (mut app, mut relay_client) = tokio::io::duplex(8192);
@@ -1530,6 +1906,8 @@ network_policies:
             ancestors: vec![],
             cmdline_paths: vec![],
             secret_resolver: resolver.map(Arc::new),
+            dynamic_credentials: None,
+            token_grant_resolver: None,
         };
 
         let (mut app, mut relay_client) = tokio::io::duplex(8192);
@@ -1647,6 +2025,8 @@ network_policies:
             ancestors: vec![],
             cmdline_paths: vec![],
             secret_resolver: resolver.map(Arc::new),
+            dynamic_credentials: None,
+            token_grant_resolver: None,
         };
 
         let (mut app, mut relay_client) = tokio::io::duplex(8192);
@@ -1817,6 +2197,8 @@ network_policies:
             ancestors: vec![],
             cmdline_paths: vec![],
             secret_resolver: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
         };
 
         let (mut app, mut relay_client) = tokio::io::duplex(8192);
@@ -1904,6 +2286,8 @@ network_policies:
             ancestors: vec![],
             cmdline_paths: vec![],
             secret_resolver: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
         };
 
         let (mut app, mut relay_client) = tokio::io::duplex(8192);

--- a/crates/openshell-sandbox/src/l7/token_grant_injection.rs
+++ b/crates/openshell-sandbox/src/l7/token_grant_injection.rs
@@ -1,0 +1,578 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Endpoint-bound dynamic token grant injection for HTTP relay paths.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use miette::{Result, miette};
+use openshell_core::proto::ProviderCredentialTokenGrant;
+use openshell_ocsf::{
+    ActionId, ActivityId, DispositionId, Endpoint, NetworkActivityBuilder, SeverityId, StatusId,
+    ocsf_emit,
+};
+use tracing::warn;
+
+use crate::l7::provider::L7Request;
+use crate::l7::relay::L7EvalContext;
+
+pub struct TokenGrantRequest<'a> {
+    pub provider_key: &'a str,
+    pub token_endpoint: &'a str,
+    pub jwt_svid_audience: &'a str,
+    pub audience: &'a str,
+    pub scopes: &'a [String],
+    pub cache_ttl_seconds: i64,
+}
+
+pub trait TokenGrantResolver: Send + Sync {
+    fn obtain<'a>(
+        &'a self,
+        request: TokenGrantRequest<'a>,
+    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>>;
+}
+
+#[derive(Default)]
+pub struct SpiffeTokenGrantResolver;
+
+impl TokenGrantResolver for SpiffeTokenGrantResolver {
+    fn obtain<'a>(
+        &'a self,
+        request: TokenGrantRequest<'a>,
+    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+        Box::pin(async move {
+            crate::token_grant::obtain_provider_token(
+                request.provider_key,
+                request.token_endpoint,
+                request.jwt_svid_audience,
+                request.audience,
+                request.scopes,
+                request.cache_ttl_seconds,
+            )
+            .await
+        })
+    }
+}
+
+pub fn default_resolver() -> Arc<dyn TokenGrantResolver> {
+    Arc::new(SpiffeTokenGrantResolver)
+}
+
+/// Checks for endpoint-bound token grant credentials and injects an
+/// Authorization header before forwarding the request upstream.
+pub async fn inject_if_needed(req: L7Request, ctx: &L7EvalContext) -> Result<L7Request> {
+    let request_path = req.target.split('?').next().unwrap_or(req.target.as_str());
+    let token_grant_credential = ctx.dynamic_credentials.as_ref().and_then(|dyn_creds| {
+        dyn_creds.read().map_or(None, |creds_guard| {
+            creds_guard
+                .iter()
+                .filter_map(|(key, cred)| {
+                    let score =
+                        dynamic_credential_key_match_score(key, &ctx.host, ctx.port, request_path)?;
+                    cred.token_grant
+                        .is_some()
+                        .then(|| (score, key.clone(), cred.clone()))
+                })
+                .max_by_key(|(score, key, _)| (*score, key.clone()))
+                .map(|(_, key, cred)| (key, cred))
+        })
+    });
+
+    if let Some((provider_key, cred)) = token_grant_credential
+        && let Some(ref token_grant) = cred.token_grant
+    {
+        let resolver = ctx
+            .token_grant_resolver
+            .as_ref()
+            .ok_or_else(|| miette!("token grant resolver unavailable"))?;
+        let request = token_grant_request(&provider_key, token_grant);
+
+        match resolver.obtain(request).await {
+            Ok(access_token) => {
+                ocsf_emit!(
+                    NetworkActivityBuilder::new(crate::ocsf_ctx())
+                        .activity(ActivityId::Other)
+                        .action(ActionId::Allowed)
+                        .disposition(DispositionId::Allowed)
+                        .severity(SeverityId::Informational)
+                        .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+                        .message(format!(
+                            "Token grant successful for {} to {}:{}",
+                            provider_key, ctx.host, ctx.port
+                        ))
+                        .build()
+                );
+                let modified_raw_header =
+                    inject_authorization_header(&req.raw_header, &access_token)?;
+                return Ok(L7Request {
+                    action: req.action,
+                    target: req.target,
+                    query_params: req.query_params,
+                    raw_header: modified_raw_header,
+                    body_length: req.body_length,
+                });
+            }
+            Err(e) => {
+                warn!(
+                    host = %ctx.host,
+                    port = ctx.port,
+                    provider = %provider_key,
+                    error = %e,
+                    "Token grant failed"
+                );
+                ocsf_emit!(
+                    NetworkActivityBuilder::new(crate::ocsf_ctx())
+                        .activity(ActivityId::Fail)
+                        .action(ActionId::Denied)
+                        .disposition(DispositionId::Blocked)
+                        .severity(SeverityId::High)
+                        .status(StatusId::Failure)
+                        .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+                        .message(format!(
+                            "Token grant failed for {} to {}:{}: {}",
+                            provider_key, ctx.host, ctx.port, e
+                        ))
+                        .build()
+                );
+                return Err(miette!("Token grant failed: {}", e));
+            }
+        }
+    }
+
+    Ok(req)
+}
+
+fn token_grant_request<'a>(
+    provider_key: &'a str,
+    token_grant: &'a ProviderCredentialTokenGrant,
+) -> TokenGrantRequest<'a> {
+    TokenGrantRequest {
+        provider_key,
+        token_endpoint: &token_grant.token_endpoint,
+        jwt_svid_audience: &token_grant.jwt_svid_audience,
+        audience: &token_grant.audience,
+        scopes: &token_grant.scopes,
+        cache_ttl_seconds: token_grant.cache_ttl_seconds,
+    }
+}
+
+#[cfg(test)]
+fn dynamic_credential_key_matches(key: &str, host: &str, port: u16, request_path: &str) -> bool {
+    dynamic_credential_key_match_score(key, host, port, request_path).is_some()
+}
+
+fn dynamic_credential_key_match_score(
+    key: &str,
+    host: &str,
+    port: u16,
+    request_path: &str,
+) -> Option<u32> {
+    let mut parts = key.splitn(4, '\t');
+    let endpoint_host = parts.next()?;
+    let endpoint_port = parts.next()?;
+    let endpoint_path = parts.next()?;
+    let _provider_key = parts.next()?;
+
+    if endpoint_port.parse::<u16>().ok() != Some(port) {
+        return None;
+    }
+
+    let host_lc = host.to_ascii_lowercase();
+    let endpoint_host_lc = endpoint_host.to_ascii_lowercase();
+    if !host_pattern_matches(&endpoint_host_lc, &host_lc)
+        || !crate::l7::endpoint_path_matches(endpoint_path, request_path)
+    {
+        return None;
+    }
+
+    Some(host_pattern_specificity(&endpoint_host_lc) + endpoint_path_specificity(endpoint_path))
+}
+
+fn host_pattern_matches(pattern: &str, host: &str) -> bool {
+    if pattern == host {
+        return true;
+    }
+    if !pattern.contains('*') {
+        return false;
+    }
+
+    let pattern_labels: Vec<&str> = pattern.split('.').collect();
+    let host_labels: Vec<&str> = host.split('.').collect();
+    host_pattern_labels_match(&pattern_labels, &host_labels)
+}
+
+fn host_pattern_labels_match(pattern: &[&str], host: &[&str]) -> bool {
+    match pattern.split_first() {
+        None => host.is_empty(),
+        Some((label, rest)) if *label == "**" => {
+            host_pattern_labels_match(rest, host)
+                || (!host.is_empty() && host_pattern_labels_match(pattern, &host[1..]))
+        }
+        Some((label, rest)) if *label == "*" => {
+            !host.is_empty() && host_pattern_labels_match(rest, &host[1..])
+        }
+        Some((literal, rest)) => {
+            host.first().is_some_and(|label| label == literal)
+                && host_pattern_labels_match(rest, &host[1..])
+        }
+    }
+}
+
+fn host_pattern_specificity(pattern: &str) -> u32 {
+    let wildcard_penalty = count_as_u32(pattern.matches('*').count());
+    let label_count = count_as_u32(pattern.split('.').filter(|label| !label.is_empty()).count());
+    let literal_chars = count_as_u32(pattern.chars().filter(|ch| *ch != '*').count());
+    100_000u32
+        .saturating_sub(wildcard_penalty.saturating_mul(10_000))
+        .saturating_add(label_count.saturating_mul(100))
+        .saturating_add(literal_chars)
+}
+
+fn endpoint_path_specificity(path: &str) -> u32 {
+    if path.is_empty() || path == "**" {
+        return 0;
+    }
+    1_000_000u32.saturating_add(count_as_u32(path.chars().filter(|ch| *ch != '*').count()))
+}
+
+fn count_as_u32(count: usize) -> u32 {
+    u32::try_from(count).unwrap_or(u32::MAX)
+}
+
+fn inject_authorization_header(raw_header: &[u8], access_token: &str) -> Result<Vec<u8>> {
+    let header_end = raw_header
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .ok_or_else(|| miette!("HTTP headers missing final CRLF CRLF"))?;
+
+    let header_block = std::str::from_utf8(&raw_header[..header_end])
+        .map_err(|_| miette!("HTTP headers contain invalid UTF-8"))?;
+    let mut lines = header_block.split("\r\n");
+    let request_line = lines
+        .next()
+        .ok_or_else(|| miette!("HTTP headers missing request line"))?;
+
+    let auth_header = format!("Authorization: Bearer {access_token}");
+    let mut new_raw_header = Vec::with_capacity(raw_header.len() + auth_header.len() + 2);
+    new_raw_header.extend_from_slice(request_line.as_bytes());
+    new_raw_header.extend_from_slice(b"\r\n");
+
+    for line in lines {
+        if line.is_empty() {
+            break;
+        }
+        if line
+            .split_once(':')
+            .is_some_and(|(name, _)| name.eq_ignore_ascii_case("authorization"))
+        {
+            continue;
+        }
+        new_raw_header.extend_from_slice(line.as_bytes());
+        new_raw_header.extend_from_slice(b"\r\n");
+    }
+
+    new_raw_header.extend_from_slice(auth_header.as_bytes());
+    new_raw_header.extend_from_slice(&raw_header[header_end..]);
+
+    Ok(new_raw_header)
+}
+
+#[cfg(test)]
+pub mod test_support {
+    use super::*;
+    use openshell_core::proto::{ProviderCredentialTokenGrant, ProviderProfileCredential};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    struct FakeTokenGrantResolver {
+        requests: Arc<Mutex<Vec<OwnedTokenGrantRequest>>>,
+        response: std::result::Result<String, String>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct OwnedTokenGrantRequest {
+        provider_key: String,
+        token_endpoint: String,
+        jwt_svid_audience: String,
+        audience: String,
+        scopes: Vec<String>,
+        cache_ttl_seconds: i64,
+    }
+
+    pub struct TokenGrantTestFixture {
+        dynamic_credentials: Arc<std::sync::RwLock<HashMap<String, ProviderProfileCredential>>>,
+        resolver: Arc<dyn TokenGrantResolver>,
+        requests: Arc<Mutex<Vec<OwnedTokenGrantRequest>>>,
+    }
+
+    impl TokenGrantTestFixture {
+        pub fn success(key: &str, token: &str) -> Self {
+            Self::new(key, Ok(token))
+        }
+
+        pub fn failure(key: &str, error: &str) -> Self {
+            Self::new(key, Err(error))
+        }
+
+        fn new(key: &str, response: std::result::Result<&str, &str>) -> Self {
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            let resolver = Arc::new(FakeTokenGrantResolver {
+                requests: requests.clone(),
+                response: response.map(str::to_string).map_err(str::to_string),
+            });
+
+            let mut dynamic_credentials = HashMap::new();
+            dynamic_credentials.insert(
+                key.to_string(),
+                ProviderProfileCredential {
+                    name: "access_token".to_string(),
+                    auth_style: "bearer".to_string(),
+                    header_name: "Authorization".to_string(),
+                    token_grant: Some(token_grant()),
+                    ..Default::default()
+                },
+            );
+
+            Self {
+                dynamic_credentials: Arc::new(std::sync::RwLock::new(dynamic_credentials)),
+                resolver,
+                requests,
+            }
+        }
+
+        pub fn dynamic_credentials(
+            &self,
+        ) -> Arc<std::sync::RwLock<HashMap<String, ProviderProfileCredential>>> {
+            self.dynamic_credentials.clone()
+        }
+
+        pub fn resolver(&self) -> Arc<dyn TokenGrantResolver> {
+            self.resolver.clone()
+        }
+
+        pub fn assert_one_request(&self, expected_provider_key: &str) {
+            let requests = self
+                .requests
+                .lock()
+                .expect("fake token grant requests lock poisoned");
+            assert_eq!(requests.len(), 1);
+
+            let request = &requests[0];
+            assert_eq!(request.provider_key, expected_provider_key);
+            assert_eq!(request.token_endpoint, "https://auth.example.com/token");
+            assert_eq!(request.jwt_svid_audience, "https://auth.example.com");
+            assert_eq!(request.audience, "api://example");
+            assert_eq!(request.scopes, ["read"]);
+            assert_eq!(request.cache_ttl_seconds, 300);
+        }
+    }
+
+    fn token_grant() -> ProviderCredentialTokenGrant {
+        ProviderCredentialTokenGrant {
+            token_endpoint: "https://auth.example.com/token".to_string(),
+            audience: "api://example".to_string(),
+            jwt_svid_audience: "https://auth.example.com".to_string(),
+            scopes: vec!["read".to_string()],
+            cache_ttl_seconds: 300,
+            audience_overrides: Vec::new(),
+        }
+    }
+
+    impl TokenGrantResolver for FakeTokenGrantResolver {
+        fn obtain<'a>(
+            &'a self,
+            request: TokenGrantRequest<'a>,
+        ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+            let owned = OwnedTokenGrantRequest {
+                provider_key: request.provider_key.to_string(),
+                token_endpoint: request.token_endpoint.to_string(),
+                jwt_svid_audience: request.jwt_svid_audience.to_string(),
+                audience: request.audience.to_string(),
+                scopes: request.scopes.to_vec(),
+                cache_ttl_seconds: request.cache_ttl_seconds,
+            };
+            Box::pin(async move {
+                self.requests
+                    .lock()
+                    .expect("fake token grant requests lock poisoned")
+                    .push(owned);
+                self.response.clone().map_err(|err| miette!("{err}"))
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::l7::provider::{BodyLength, L7Request};
+    use crate::l7::token_grant_injection::test_support::TokenGrantTestFixture;
+
+    #[test]
+    fn dynamic_credential_key_matches_endpoint_host_port_and_path() {
+        let key = "api.example.com\t443\t/repos/**\tgithub:access_token";
+
+        assert!(dynamic_credential_key_matches(
+            key,
+            "api.example.com",
+            443,
+            "/repos/owner/repo"
+        ));
+        assert!(!dynamic_credential_key_matches(
+            key,
+            "uploads.example.com",
+            443,
+            "/repos/owner/repo"
+        ));
+        assert!(!dynamic_credential_key_matches(
+            key,
+            "api.example.com",
+            80,
+            "/repos/owner/repo"
+        ));
+        assert!(!dynamic_credential_key_matches(
+            key,
+            "api.example.com",
+            443,
+            "/orgs/owner"
+        ));
+    }
+
+    #[test]
+    fn dynamic_credential_key_matches_wildcard_hosts_and_empty_path() {
+        let key = "*.example.com\t443\t\tprovider:access_token";
+
+        assert!(dynamic_credential_key_matches(
+            key,
+            "api.example.com",
+            443,
+            "/anything"
+        ));
+        assert!(!dynamic_credential_key_matches(
+            key,
+            "api.other.com",
+            443,
+            "/anything"
+        ));
+        assert!(!dynamic_credential_key_matches(
+            key,
+            "nested.api.example.com",
+            443,
+            "/anything"
+        ));
+    }
+
+    #[test]
+    fn dynamic_credential_key_matches_double_wildcard_hosts() {
+        let key = "**.example.com\t443\t\tprovider:access_token";
+
+        assert!(dynamic_credential_key_matches(
+            key,
+            "api.example.com",
+            443,
+            "/anything"
+        ));
+        assert!(dynamic_credential_key_matches(
+            key,
+            "nested.api.example.com",
+            443,
+            "/anything"
+        ));
+    }
+
+    #[test]
+    fn dynamic_credential_match_score_prefers_path_specific_key() {
+        let default_key = "alpha.default.svc.cluster.local\t80\t\tprovider:access_token";
+        let path_key = "alpha.default.svc.cluster.local\t80\t/admin/**\tprovider:access_token";
+        let request_path = "/admin/users";
+
+        let default_score = dynamic_credential_key_match_score(
+            default_key,
+            "alpha.default.svc.cluster.local",
+            80,
+            request_path,
+        )
+        .expect("default key should match");
+        let path_score = dynamic_credential_key_match_score(
+            path_key,
+            "alpha.default.svc.cluster.local",
+            80,
+            request_path,
+        )
+        .expect("path key should match");
+
+        assert!(path_score > default_score);
+    }
+
+    #[test]
+    fn inject_authorization_header_replaces_existing_authorization() {
+        let raw = b"GET /v1 HTTP/1.1\r\nHost: api.example.com\r\nauthorization: Bearer stale-token\r\nAccept: application/json\r\n\r\n";
+
+        let rewritten =
+            inject_authorization_header(raw, "grant-token").expect("header should rewrite");
+        let rewritten = String::from_utf8(rewritten).expect("rewritten header should be UTF-8");
+
+        assert!(rewritten.contains("Authorization: Bearer grant-token\r\n"));
+        assert!(!rewritten.contains("stale-token"));
+        assert_eq!(
+            rewritten
+                .lines()
+                .filter(|line| line
+                    .split_once(':')
+                    .is_some_and(|(name, _)| name.eq_ignore_ascii_case("authorization")))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn inject_authorization_header_preserves_header_terminator_before_body() {
+        let raw = b"POST /v1 HTTP/1.1\r\nHost: api.example.com\r\nContent-Length: 2\r\n\r\nOK";
+
+        let rewritten =
+            inject_authorization_header(raw, "grant-token").expect("header should rewrite");
+
+        assert_eq!(
+            rewritten,
+            b"POST /v1 HTTP/1.1\r\nHost: api.example.com\r\nContent-Length: 2\r\nAuthorization: Bearer grant-token\r\n\r\nOK"
+        );
+    }
+
+    #[tokio::test]
+    async fn inject_if_needed_uses_configured_resolver() {
+        let fixture = TokenGrantTestFixture::success(
+            "api.example.com\t443\t/v1/**\tprovider:access_token",
+            "grant-token",
+        );
+
+        let ctx = L7EvalContext {
+            host: "api.example.com".into(),
+            port: 443,
+            policy_name: "api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            dynamic_credentials: Some(fixture.dynamic_credentials()),
+            token_grant_resolver: Some(fixture.resolver()),
+        };
+        let req = L7Request {
+            action: "GET".to_string(),
+            target: "/v1/projects".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: b"GET /v1/projects HTTP/1.1\r\nHost: api.example.com\r\n\r\n".to_vec(),
+            body_length: BodyLength::None,
+        };
+
+        let rewritten = inject_if_needed(req, &ctx)
+            .await
+            .expect("fake token grant should inject");
+        let rewritten =
+            String::from_utf8(rewritten.raw_header).expect("rewritten request should be UTF-8");
+
+        assert!(rewritten.contains("Authorization: Bearer grant-token\r\n"));
+        fixture.assert_one_request("api.example.com\t443\t/v1/**\tprovider:access_token");
+    }
+}

--- a/crates/openshell-sandbox/src/l7/websocket.rs
+++ b/crates/openshell-sandbox/src/l7/websocket.rs
@@ -1270,6 +1270,8 @@ network_policies:
             ancestors: vec![],
             cmdline_paths: vec![],
             secret_resolver: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
         };
         let (mut client_write, mut relay_read) = tokio::io::duplex(MAX_TEXT_MESSAGE_BYTES + 1024);
         let (mut relay_write, mut upstream_read) = tokio::io::duplex(MAX_TEXT_MESSAGE_BYTES + 1024);

--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -24,8 +24,10 @@ pub mod proxy;
 mod sandbox;
 mod secrets;
 mod skills;
+mod spiffe_endpoint;
 mod ssh;
 mod supervisor_session;
+mod token_grant;
 
 use miette::{IntoDiagnostic, Result};
 #[cfg(target_os = "linux")]
@@ -352,57 +354,65 @@ pub async fn run_sandbox(
     // Fetch provider environment variables from the server.
     // This is done after loading the policy so the sandbox can still start
     // even if provider env fetch fails (graceful degradation).
-    let (provider_env_revision, provider_env, provider_credential_expires_at_ms) =
-        if let (Some(id), Some(endpoint)) = (&sandbox_id, &openshell_endpoint) {
-            match grpc_client::fetch_provider_environment(endpoint, id).await {
-                Ok(result) => {
-                    ocsf_emit!(
-                        ConfigStateChangeBuilder::new(ocsf_ctx())
-                            .severity(SeverityId::Informational)
-                            .status(StatusId::Success)
-                            .state(StateId::Enabled, "loaded")
-                            .message(format!(
-                                "Fetched provider environment [env_count:{}]",
-                                result.environment.len()
-                            ))
-                            .build()
-                    );
-                    (
-                        result.provider_env_revision,
-                        result.environment,
-                        result.credential_expires_at_ms,
-                    )
-                }
-                Err(e) => {
-                    ocsf_emit!(
-                        ConfigStateChangeBuilder::new(ocsf_ctx())
-                            .severity(SeverityId::Medium)
-                            .status(StatusId::Failure)
-                            .state(StateId::Other, "degraded")
-                            .message(format!(
-                                "Failed to fetch provider environment, continuing without: {e}"
-                            ))
-                            .build()
-                    );
-                    (
-                        0,
-                        std::collections::HashMap::new(),
-                        std::collections::HashMap::new(),
-                    )
-                }
+    let (
+        provider_env_revision,
+        provider_env,
+        provider_credential_expires_at_ms,
+        dynamic_credentials,
+    ) = if let (Some(id), Some(endpoint)) = (&sandbox_id, &openshell_endpoint) {
+        match grpc_client::fetch_provider_environment(endpoint, id).await {
+            Ok(result) => {
+                ocsf_emit!(
+                    ConfigStateChangeBuilder::new(ocsf_ctx())
+                        .severity(SeverityId::Informational)
+                        .status(StatusId::Success)
+                        .state(StateId::Enabled, "loaded")
+                        .message(format!(
+                            "Fetched provider environment [env_count:{}]",
+                            result.environment.len()
+                        ))
+                        .build()
+                );
+                (
+                    result.provider_env_revision,
+                    result.environment,
+                    result.credential_expires_at_ms,
+                    result.dynamic_credentials,
+                )
             }
-        } else {
-            (
-                0,
-                std::collections::HashMap::new(),
-                std::collections::HashMap::new(),
-            )
-        };
+            Err(e) => {
+                ocsf_emit!(
+                    ConfigStateChangeBuilder::new(ocsf_ctx())
+                        .severity(SeverityId::Medium)
+                        .status(StatusId::Failure)
+                        .state(StateId::Other, "degraded")
+                        .message(format!(
+                            "Failed to fetch provider environment, continuing without: {e}"
+                        ))
+                        .build()
+                );
+                (
+                    0,
+                    std::collections::HashMap::new(),
+                    std::collections::HashMap::new(),
+                    std::collections::HashMap::new(),
+                )
+            }
+        }
+    } else {
+        (
+            0,
+            std::collections::HashMap::new(),
+            std::collections::HashMap::new(),
+            std::collections::HashMap::new(),
+        )
+    };
 
     let provider_credentials = provider_credentials::ProviderCredentialState::from_environment(
         provider_env_revision,
         provider_env,
         provider_credential_expires_at_ms,
+        dynamic_credentials,
     );
     let provider_env = provider_credentials.snapshot().child_env.clone();
 
@@ -2381,6 +2391,7 @@ async fn run_policy_poll_loop(ctx: PolicyPollLoopContext) -> Result<()> {
                         env_result.provider_env_revision,
                         env_result.environment,
                         env_result.credential_expires_at_ms,
+                        env_result.dynamic_credentials,
                     );
                     current_provider_env_revision = env_result.provider_env_revision;
                     ocsf_emit!(

--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -563,6 +563,13 @@ pub async fn run_sandbox(
     #[allow(clippy::no_effect_underscore_binding)]
     let _netns: Option<()> = None;
 
+    // Prepare the child-only mount namespace before the supervisor seccomp
+    // prelude blocks mount operations. Children enter this namespace with
+    // `setns` in pre_exec so supervisor identity sockets stay hidden from
+    // untrusted code while remaining available to the supervisor for refresh.
+    #[cfg(target_os = "linux")]
+    process::prepare_supervisor_identity_mount_namespace_from_env()?;
+
     // Install the supervisor seccomp prelude after privileged startup helpers
     // (network namespace setup, nftables probes) complete, but before the SSH
     // listener and workload process are exposed.

--- a/crates/openshell-sandbox/src/process.rs
+++ b/crates/openshell-sandbox/src/process.rs
@@ -16,14 +16,42 @@ use nix::unistd::{Group, Pid, User};
 use std::collections::HashMap;
 use std::ffi::CString;
 #[cfg(target_os = "linux")]
-use std::os::unix::io::RawFd;
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+#[cfg(target_os = "linux")]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(any(test, target_os = "linux"))]
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Stdio;
+#[cfg(target_os = "linux")]
+use std::sync::OnceLock;
 use tokio::process::{Child, Command};
 use tracing::debug;
 
+const SUPERVISOR_ONLY_ENV_VARS: &[&str] = &[
+    openshell_core::sandbox_env::SANDBOX_TOKEN,
+    openshell_core::sandbox_env::SANDBOX_TOKEN_FILE,
+    openshell_core::sandbox_env::K8S_SA_TOKEN_FILE,
+    openshell_core::sandbox_env::SPIFFE_WORKLOAD_API_SOCKET,
+    openshell_core::sandbox_env::SPIFFE_AUDIENCE,
+    openshell_core::sandbox_env::SPIFFE_ID,
+];
+
+pub fn is_supervisor_only_env_var(key: &str) -> bool {
+    SUPERVISOR_ONLY_ENV_VARS.contains(&key)
+}
+
+fn strip_supervisor_only_env(cmd: &mut Command) {
+    for key in SUPERVISOR_ONLY_ENV_VARS {
+        cmd.env_remove(key);
+    }
+}
+
 fn inject_provider_env(cmd: &mut Command, provider_env: &HashMap<String, String>) {
     for (key, value) in provider_env {
+        if is_supervisor_only_env_var(key) {
+            continue;
+        }
         cmd.env(key, value);
     }
 }
@@ -61,6 +89,209 @@ pub fn harden_child_process() -> Result<()> {
             .map_err(|e| miette::miette!("Failed to set PR_SET_DUMPABLE=0: {e}"))?;
     }
 
+    Ok(())
+}
+
+// Pins the pre-seccomp child mount namespace where supervisor identity sockets
+// are shadowed. Children enter it with setns before dropping privileges.
+#[cfg(target_os = "linux")]
+static SUPERVISOR_IDENTITY_MOUNT_NS: OnceLock<Option<SupervisorIdentityMountNamespace>> =
+    OnceLock::new();
+
+#[cfg(target_os = "linux")]
+pub(crate) struct SupervisorIdentityMountNamespace {
+    fd: OwnedFd,
+}
+
+#[cfg(target_os = "linux")]
+type SupervisorIdentityNsRef = &'static SupervisorIdentityMountNamespace;
+
+#[cfg(target_os = "linux")]
+impl SupervisorIdentityMountNamespace {
+    fn from_socket_path(socket_path: &str) -> Result<Option<Self>> {
+        let Some(target) = supervisor_identity_mount_target(socket_path)? else {
+            return Ok(None);
+        };
+        Ok(Some(Self {
+            fd: create_supervisor_identity_mount_namespace(&target)?,
+        }))
+    }
+
+    pub(crate) fn enter_for_child(&self) -> std::io::Result<()> {
+        set_mount_namespace(self.fd.as_raw_fd())
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn prepare_supervisor_identity_mount_namespace_from_env() -> Result<()> {
+    if SUPERVISOR_IDENTITY_MOUNT_NS.get().is_some() {
+        return Ok(());
+    }
+
+    let Ok(socket_path) = std::env::var(openshell_core::sandbox_env::SPIFFE_WORKLOAD_API_SOCKET)
+    else {
+        let _ = SUPERVISOR_IDENTITY_MOUNT_NS.set(None);
+        return Ok(());
+    };
+    let namespace = SupervisorIdentityMountNamespace::from_socket_path(&socket_path)?;
+    let _ = SUPERVISOR_IDENTITY_MOUNT_NS.set(namespace);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn supervisor_identity_mount_from_env() -> Result<Option<SupervisorIdentityNsRef>> {
+    let Some(namespace) = SUPERVISOR_IDENTITY_MOUNT_NS.get() else {
+        if std::env::var(openshell_core::sandbox_env::SPIFFE_WORKLOAD_API_SOCKET)
+            .is_ok_and(|socket_path| !socket_path.trim().is_empty())
+        {
+            return Err(miette::miette!(
+                "supervisor identity mount namespace was not prepared before startup hardening"
+            ));
+        }
+        return Ok(None);
+    };
+    Ok(namespace.as_ref())
+}
+
+#[cfg(any(test, target_os = "linux"))]
+fn supervisor_identity_mount_target(socket_path: &str) -> Result<Option<PathBuf>> {
+    let trimmed = socket_path.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if trimmed.starts_with("tcp:") {
+        return Err(miette::miette!(
+            "{} must be a UNIX socket path so sandbox child processes can hide it",
+            openshell_core::sandbox_env::SPIFFE_WORKLOAD_API_SOCKET
+        ));
+    }
+    let path = trimmed.strip_prefix("unix:").unwrap_or(trimmed);
+    let path = Path::new(path);
+    if !path.is_absolute() {
+        return Err(miette::miette!(
+            "{} must be an absolute UNIX socket path",
+            openshell_core::sandbox_env::SPIFFE_WORKLOAD_API_SOCKET
+        ));
+    }
+    let Some(parent) = path.parent() else {
+        return Err(miette::miette!(
+            "{} has no parent directory",
+            openshell_core::sandbox_env::SPIFFE_WORKLOAD_API_SOCKET
+        ));
+    };
+    if parent == Path::new("/") {
+        return Err(miette::miette!(
+            "{} must live below a dedicated directory, not directly under /",
+            openshell_core::sandbox_env::SPIFFE_WORKLOAD_API_SOCKET
+        ));
+    }
+    Ok(Some(parent.to_path_buf()))
+}
+
+#[cfg(target_os = "linux")]
+fn cstring_path(path: &Path) -> Result<CString> {
+    CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| miette::miette!("path contains an interior NUL byte: {}", path.display()))
+}
+
+#[cfg(target_os = "linux")]
+fn create_supervisor_identity_mount_namespace(target: &Path) -> Result<OwnedFd> {
+    let original_ns = open_current_mount_namespace()
+        .map_err(|err| miette::miette!("failed to open original mount namespace: {err}"))?;
+
+    private_mount_namespace()
+        .map_err(|err| miette::miette!("failed to create supervisor identity namespace: {err}"))?;
+
+    let target = cstring_path(target)?;
+    let result = (|| -> Result<OwnedFd> {
+        mount_empty_tmpfs(&target).map_err(|err| {
+            miette::miette!("failed to hide supervisor identity mount from child namespace: {err}")
+        })?;
+        open_current_mount_namespace()
+            .map_err(|err| miette::miette!("failed to open sanitized mount namespace: {err}"))
+    })();
+
+    set_mount_namespace(original_ns.as_raw_fd()).map_err(|restore_err| {
+        let result_msg = result.as_ref().err().map_or_else(
+            || "sanitized namespace was created".to_string(),
+            ToString::to_string,
+        );
+        miette::miette!(
+            "failed to restore original mount namespace after supervisor identity isolation setup: \
+             {restore_err}; setup result: {result_msg}"
+        )
+    })?;
+
+    result
+}
+
+#[cfg(target_os = "linux")]
+fn open_current_mount_namespace() -> std::io::Result<OwnedFd> {
+    let file = std::fs::File::open("/proc/self/ns/mnt")?;
+    Ok(file.into())
+}
+
+#[cfg(target_os = "linux")]
+fn private_mount_namespace() -> std::io::Result<()> {
+    #[allow(unsafe_code)]
+    let rc = unsafe { libc::unshare(libc::CLONE_NEWNS) };
+    if rc != 0 {
+        return Err(std::io::Error::other(format!(
+            "failed to create private mount namespace: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+
+    #[allow(unsafe_code)]
+    let rc = unsafe {
+        libc::mount(
+            std::ptr::null(),
+            c"/".as_ptr(),
+            std::ptr::null(),
+            (libc::MS_REC | libc::MS_PRIVATE) as libc::c_ulong,
+            std::ptr::null(),
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::other(format!(
+            "failed to mark mount namespace private: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn set_mount_namespace(fd: RawFd) -> std::io::Result<()> {
+    #[allow(unsafe_code)]
+    let rc = unsafe { libc::setns(fd, libc::CLONE_NEWNS) };
+    if rc != 0 {
+        return Err(std::io::Error::other(format!(
+            "failed to enter mount namespace: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn mount_empty_tmpfs(target: &CString) -> std::io::Result<()> {
+    #[allow(unsafe_code)]
+    let rc = unsafe {
+        libc::mount(
+            c"tmpfs".as_ptr(),
+            target.as_ptr(),
+            c"tmpfs".as_ptr(),
+            (libc::MS_NOSUID | libc::MS_NODEV | libc::MS_NOEXEC | libc::MS_RDONLY) as libc::c_ulong,
+            c"mode=0555,size=4k".as_ptr().cast(),
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::other(format!(
+            "failed to hide supervisor identity mount from child process: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
     Ok(())
 }
 
@@ -146,14 +377,11 @@ impl ProcessHandle {
             .kill_on_drop(true)
             .env(openshell_core::sandbox_env::SANDBOX, "1");
 
-        // Strip supervisor-only credentials from the entrypoint's inherited
-        // environment. The entrypoint drops to the sandbox user before
-        // `exec`; without this strip, anything running as the sandbox user
-        // (e.g. an SSH-spawned shell) could read /proc/<entrypoint_pid>/environ
-        // and recover the gateway-minted JWT. Issue #1354.
-        cmd.env_remove(openshell_core::sandbox_env::SANDBOX_TOKEN)
-            .env_remove(openshell_core::sandbox_env::SANDBOX_TOKEN_FILE)
-            .env_remove(openshell_core::sandbox_env::K8S_SA_TOKEN_FILE);
+        // Strip supervisor-only identity material from the entrypoint's
+        // inherited environment. The entrypoint drops to the sandbox user
+        // before `exec`; without this strip, sandbox code could recover
+        // supervisor credentials from its inherited environment.
+        strip_supervisor_only_env(&mut cmd);
 
         inject_provider_env(&mut cmd, provider_env);
 
@@ -204,6 +432,10 @@ impl ProcessHandle {
         #[cfg(target_os = "linux")]
         let prepared_sandbox = sandbox::linux::prepare(policy, workdir)
             .map_err(|err| miette::miette!("Failed to prepare sandbox: {err}"))?;
+        #[cfg(target_os = "linux")]
+        let supervisor_identity_mount = supervisor_identity_mount_from_env().map_err(|err| {
+            miette::miette!("Failed to prepare supervisor identity isolation: {err}")
+        })?;
 
         // Set up process group for signal handling (non-interactive mode only).
         // In interactive mode, we inherit the parent's process group to maintain
@@ -216,6 +448,8 @@ impl ProcessHandle {
             // pre_exec is only called once (after fork, before exec).
             #[cfg(target_os = "linux")]
             let mut prepared_sandbox = Some(prepared_sandbox);
+            #[cfg(target_os = "linux")]
+            let supervisor_identity_mount = supervisor_identity_mount;
             #[allow(unsafe_code)]
             unsafe {
                 cmd.pre_exec(move || {
@@ -230,6 +464,11 @@ impl ProcessHandle {
                         if result != 0 {
                             return Err(std::io::Error::last_os_error());
                         }
+                    }
+
+                    #[cfg(target_os = "linux")]
+                    if let Some(mount) = supervisor_identity_mount {
+                        mount.enter_for_child()?;
                     }
 
                     // Drop privileges. initgroups/setgid/setuid need access to
@@ -281,14 +520,9 @@ impl ProcessHandle {
             .kill_on_drop(true)
             .env(openshell_core::sandbox_env::SANDBOX, "1");
 
-        // Strip supervisor-only credentials from the entrypoint's inherited
-        // environment. The entrypoint drops to the sandbox user before
-        // `exec`; without this strip, anything running as the sandbox user
-        // (e.g. an SSH-spawned shell) could read /proc/<entrypoint_pid>/environ
-        // and recover the gateway-minted JWT. Issue #1354.
-        cmd.env_remove(openshell_core::sandbox_env::SANDBOX_TOKEN)
-            .env_remove(openshell_core::sandbox_env::SANDBOX_TOKEN_FILE)
-            .env_remove(openshell_core::sandbox_env::K8S_SA_TOKEN_FILE);
+        // Strip supervisor-only identity material from the entrypoint's
+        // inherited environment.
+        strip_supervisor_only_env(&mut cmd);
 
         inject_provider_env(&mut cmd, provider_env);
 
@@ -823,5 +1057,96 @@ mod tests {
         let output = cmd.output().await.expect("spawn env");
         let stdout = String::from_utf8(output.stdout).expect("utf8");
         assert!(stdout.contains("ANTHROPIC_API_KEY=openshell:resolve:env:ANTHROPIC_API_KEY"));
+    }
+
+    #[tokio::test]
+    async fn inject_provider_env_skips_supervisor_identity_material() {
+        let mut cmd = Command::new("/usr/bin/env");
+        cmd.env_clear()
+            .stdin(StdStdio::null())
+            .stdout(StdStdio::piped())
+            .stderr(StdStdio::null());
+
+        let provider_env = HashMap::from([
+            (
+                "ANTHROPIC_API_KEY".to_string(),
+                "openshell:resolve:env:ANTHROPIC_API_KEY".to_string(),
+            ),
+            (
+                openshell_core::sandbox_env::SANDBOX_TOKEN.to_string(),
+                "provider-token".to_string(),
+            ),
+            (
+                openshell_core::sandbox_env::SPIFFE_WORKLOAD_API_SOCKET.to_string(),
+                "/spiffe-workload-api/spire-agent.sock".to_string(),
+            ),
+        ]);
+
+        inject_provider_env(&mut cmd, &provider_env);
+
+        let output = cmd.output().await.expect("spawn env");
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).expect("utf8");
+        assert!(stdout.contains("ANTHROPIC_API_KEY=openshell:resolve:env:ANTHROPIC_API_KEY"));
+        assert!(!stdout.contains(openshell_core::sandbox_env::SANDBOX_TOKEN));
+        assert!(!stdout.contains(openshell_core::sandbox_env::SPIFFE_WORKLOAD_API_SOCKET));
+    }
+
+    #[tokio::test]
+    async fn strip_supervisor_only_env_removes_identity_material() {
+        let mut cmd = Command::new("/usr/bin/env");
+        cmd.stdin(StdStdio::null())
+            .stdout(StdStdio::piped())
+            .stderr(StdStdio::null())
+            .env("OPENSHELL_ENDPOINT", "https://gateway.example.test");
+
+        for key in SUPERVISOR_ONLY_ENV_VARS {
+            cmd.env(key, format!("{key}-secret"));
+        }
+
+        strip_supervisor_only_env(&mut cmd);
+
+        let output = cmd.output().await.expect("spawn env");
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).expect("utf8");
+
+        for key in SUPERVISOR_ONLY_ENV_VARS {
+            assert!(
+                !stdout
+                    .lines()
+                    .any(|line| line.starts_with(&format!("{key}="))),
+                "{key} must not be inherited by sandbox child processes"
+            );
+        }
+        assert!(stdout.contains("OPENSHELL_ENDPOINT=https://gateway.example.test"));
+    }
+
+    #[test]
+    fn supervisor_identity_mount_target_uses_socket_parent() {
+        assert_eq!(
+            supervisor_identity_mount_target("/spiffe-workload-api/spire-agent.sock")
+                .expect("plain path should parse"),
+            Some(PathBuf::from("/spiffe-workload-api"))
+        );
+        assert_eq!(
+            supervisor_identity_mount_target("unix:/spiffe-workload-api/spire-agent.sock")
+                .expect("unix path should parse"),
+            Some(PathBuf::from("/spiffe-workload-api"))
+        );
+    }
+
+    #[test]
+    fn supervisor_identity_mount_target_ignores_empty_socket_path() {
+        assert_eq!(
+            supervisor_identity_mount_target("   ").expect("empty path should be ignored"),
+            None
+        );
+    }
+
+    #[test]
+    fn supervisor_identity_mount_target_rejects_unhideable_endpoints() {
+        assert!(supervisor_identity_mount_target("tcp:127.0.0.1:8081").is_err());
+        assert!(supervisor_identity_mount_target("spiffe-workload-api/spire-agent.sock").is_err());
+        assert!(supervisor_identity_mount_target("/spire-agent.sock").is_err());
     }
 }

--- a/crates/openshell-sandbox/src/process.rs
+++ b/crates/openshell-sandbox/src/process.rs
@@ -99,7 +99,7 @@ static SUPERVISOR_IDENTITY_MOUNT_NS: OnceLock<Option<SupervisorIdentityMountName
     OnceLock::new();
 
 #[cfg(target_os = "linux")]
-pub(crate) struct SupervisorIdentityMountNamespace {
+pub struct SupervisorIdentityMountNamespace {
     fd: OwnedFd,
 }
 
@@ -117,13 +117,13 @@ impl SupervisorIdentityMountNamespace {
         }))
     }
 
-    pub(crate) fn enter_for_child(&self) -> std::io::Result<()> {
+    pub fn enter_for_child(&self) -> std::io::Result<()> {
         set_mount_namespace(self.fd.as_raw_fd())
     }
 }
 
 #[cfg(target_os = "linux")]
-pub(crate) fn prepare_supervisor_identity_mount_namespace_from_env() -> Result<()> {
+pub fn prepare_supervisor_identity_mount_namespace_from_env() -> Result<()> {
     if SUPERVISOR_IDENTITY_MOUNT_NS.get().is_some() {
         return Ok(());
     }
@@ -139,7 +139,7 @@ pub(crate) fn prepare_supervisor_identity_mount_namespace_from_env() -> Result<(
 }
 
 #[cfg(target_os = "linux")]
-pub(crate) fn supervisor_identity_mount_from_env() -> Result<Option<SupervisorIdentityNsRef>> {
+pub fn supervisor_identity_mount_from_env() -> Result<Option<SupervisorIdentityNsRef>> {
     let Some(namespace) = SUPERVISOR_IDENTITY_MOUNT_NS.get() else {
         if std::env::var(openshell_core::sandbox_env::SPIFFE_WORKLOAD_API_SOCKET)
             .is_ok_and(|socket_path| !socket_path.trim().is_empty())
@@ -244,11 +244,12 @@ fn private_mount_namespace() -> std::io::Result<()> {
 
     #[allow(unsafe_code)]
     let rc = unsafe {
+        let flags: libc::c_ulong = libc::MS_REC | libc::MS_PRIVATE;
         libc::mount(
             std::ptr::null(),
             c"/".as_ptr(),
             std::ptr::null(),
-            (libc::MS_REC | libc::MS_PRIVATE) as libc::c_ulong,
+            flags,
             std::ptr::null(),
         )
     };
@@ -278,11 +279,13 @@ fn set_mount_namespace(fd: RawFd) -> std::io::Result<()> {
 fn mount_empty_tmpfs(target: &CString) -> std::io::Result<()> {
     #[allow(unsafe_code)]
     let rc = unsafe {
+        let flags: libc::c_ulong =
+            libc::MS_NOSUID | libc::MS_NODEV | libc::MS_NOEXEC | libc::MS_RDONLY;
         libc::mount(
             c"tmpfs".as_ptr(),
             target.as_ptr(),
             c"tmpfs".as_ptr(),
-            (libc::MS_NOSUID | libc::MS_NODEV | libc::MS_NOEXEC | libc::MS_RDONLY) as libc::c_ulong,
+            flags,
             c"mode=0555,size=4k".as_ptr().cast(),
         )
     };
@@ -448,8 +451,6 @@ impl ProcessHandle {
             // pre_exec is only called once (after fork, before exec).
             #[cfg(target_os = "linux")]
             let mut prepared_sandbox = Some(prepared_sandbox);
-            #[cfg(target_os = "linux")]
-            let supervisor_identity_mount = supervisor_identity_mount;
             #[allow(unsafe_code)]
             unsafe {
                 cmd.pre_exec(move || {

--- a/crates/openshell-sandbox/src/provider_credentials.rs
+++ b/crates/openshell-sandbox/src/provider_credentials.rs
@@ -13,6 +13,7 @@ const MAX_RETAINED_CREDENTIAL_GENERATIONS: usize = 8;
 pub struct ProviderCredentialSnapshot {
     pub revision: u64,
     pub child_env: HashMap<String, String>,
+    pub dynamic_credentials: HashMap<String, openshell_core::proto::ProviderProfileCredential>,
 }
 
 #[derive(Debug)]
@@ -33,6 +34,7 @@ impl ProviderCredentialState {
         revision: u64,
         env: HashMap<String, String>,
         credential_expires_at_ms: HashMap<String, i64>,
+        dynamic_credentials: HashMap<String, openshell_core::proto::ProviderProfileCredential>,
     ) -> Self {
         let (child_env, generation_resolver, current_resolver) =
             SecretResolver::from_provider_env_for_current_revision(
@@ -43,6 +45,7 @@ impl ProviderCredentialState {
         let snapshot = Arc::new(ProviderCredentialSnapshot {
             revision,
             child_env,
+            dynamic_credentials,
         });
         let generations: VecDeque<_> = generation_resolver.map(Arc::new).into_iter().collect();
         let current_resolver = current_resolver.map(Arc::new);
@@ -79,6 +82,7 @@ impl ProviderCredentialState {
         revision: u64,
         env: HashMap<String, String>,
         credential_expires_at_ms: HashMap<String, i64>,
+        dynamic_credentials: HashMap<String, openshell_core::proto::ProviderProfileCredential>,
     ) -> usize {
         let (child_env, generation_resolver, current_resolver) =
             SecretResolver::from_provider_env_for_current_revision(
@@ -94,6 +98,7 @@ impl ProviderCredentialState {
         inner.current = Arc::new(ProviderCredentialSnapshot {
             revision,
             child_env,
+            dynamic_credentials,
         });
         inner.current_resolver = current_resolver.map(Arc::new);
 
@@ -132,6 +137,7 @@ mod tests {
             10,
             HashMap::from([("GITHUB_TOKEN".to_string(), "old".to_string())]),
             HashMap::new(),
+            HashMap::new(),
         );
         let first = state.snapshot();
         assert_eq!(
@@ -142,6 +148,7 @@ mod tests {
         state.install_environment(
             11,
             HashMap::from([("GITHUB_TOKEN".to_string(), "new".to_string())]),
+            HashMap::new(),
             HashMap::new(),
         );
         let second = state.snapshot();
@@ -175,9 +182,10 @@ mod tests {
             10,
             HashMap::from([("GITHUB_TOKEN".to_string(), "old".to_string())]),
             HashMap::new(),
+            HashMap::new(),
         );
 
-        state.install_environment(11, HashMap::new(), HashMap::new());
+        state.install_environment(11, HashMap::new(), HashMap::new(), HashMap::new());
 
         assert!(state.snapshot().child_env.is_empty());
         let resolver = state.resolver().expect("old resolver retained");
@@ -208,12 +216,14 @@ mod tests {
             10,
             HashMap::from([("GITHUB_TOKEN".to_string(), "old".to_string())]),
             HashMap::from([("GITHUB_TOKEN".to_string(), now_ms - 1_000)]),
+            HashMap::new(),
         );
 
         state.install_environment(
             11,
             HashMap::from([("GITHUB_TOKEN".to_string(), "new".to_string())]),
             HashMap::from([("GITHUB_TOKEN".to_string(), now_ms + 60_000)]),
+            HashMap::new(),
         );
 
         let resolver = state.resolver().expect("resolver");

--- a/crates/openshell-sandbox/src/proxy.rs
+++ b/crates/openshell-sandbox/src/proxy.rs
@@ -240,6 +240,11 @@ impl ProxyHandle {
                         let resolver = provider_credentials
                             .as_ref()
                             .and_then(ProviderCredentialState::resolver);
+                        let dynamic_credentials = provider_credentials.as_ref().map(|state| {
+                            Arc::new(std::sync::RwLock::new(
+                                state.snapshot().dynamic_credentials.clone(),
+                            ))
+                        });
                         let dtx = denial_tx.clone();
                         tokio::spawn(async move {
                             if let Err(err) = handle_tcp_connection(
@@ -252,6 +257,7 @@ impl ProxyHandle {
                                 policy_local,
                                 gw,
                                 resolver,
+                                dynamic_credentials,
                                 dtx,
                             )
                             .await
@@ -370,6 +376,13 @@ async fn handle_tcp_connection(
     policy_local_ctx: Option<Arc<PolicyLocalContext>>,
     trusted_host_gateway: Arc<Option<IpAddr>>,
     secret_resolver: Option<Arc<SecretResolver>>,
+    dynamic_credentials: Option<
+        Arc<
+            std::sync::RwLock<
+                std::collections::HashMap<String, openshell_core::proto::ProviderProfileCredential>,
+            >,
+        >,
+    >,
     denial_tx: Option<mpsc::UnboundedSender<DenialEvent>>,
 ) -> Result<()> {
     let mut buf = vec![0u8; MAX_HEADER_BYTES];
@@ -416,6 +429,7 @@ async fn handle_tcp_connection(
             policy_local_ctx,
             trusted_host_gateway,
             secret_resolver,
+            dynamic_credentials,
             denial_tx.as_ref(),
         )
         .await;
@@ -845,6 +859,10 @@ async fn handle_tcp_connection(
             .map(|p| p.to_string_lossy().into_owned())
             .collect(),
         secret_resolver: secret_resolver.clone(),
+        dynamic_credentials: dynamic_credentials.clone(),
+        token_grant_resolver: dynamic_credentials
+            .as_ref()
+            .map(|_| crate::l7::token_grant_injection::default_resolver()),
     };
 
     if effective_tls_skip {
@@ -2677,6 +2695,33 @@ where
     .await
 }
 
+async fn inject_token_grant_for_forward_request(
+    method: &str,
+    upstream_target: &str,
+    forward_request_bytes: Vec<u8>,
+    l7_ctx: &crate::l7::relay::L7EvalContext,
+) -> Result<Vec<u8>> {
+    let header_end = forward_request_bytes
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map_or(forward_request_bytes.len(), |p| p + 4);
+    let header_str = std::str::from_utf8(&forward_request_bytes[..header_end])
+        .into_diagnostic()
+        .map_err(|_| miette::miette!("Forward HTTP headers contain invalid UTF-8"))?;
+    let body_length = crate::l7::rest::parse_body_length(header_str)?;
+    let forward_request_for_token_grant = crate::l7::provider::L7Request {
+        action: method.to_string(),
+        target: upstream_target.to_string(),
+        query_params: std::collections::HashMap::new(),
+        raw_header: forward_request_bytes,
+        body_length,
+    };
+
+    crate::l7::token_grant_injection::inject_if_needed(forward_request_for_token_grant, l7_ctx)
+        .await
+        .map(|req| req.raw_header)
+}
+
 /// Handle a plain HTTP forward proxy request (non-CONNECT).
 ///
 /// Public IPs are allowed through when the endpoint passes OPA evaluation.
@@ -2698,6 +2743,13 @@ async fn handle_forward_proxy(
     policy_local_ctx: Option<Arc<PolicyLocalContext>>,
     trusted_host_gateway: Arc<Option<IpAddr>>,
     secret_resolver: Option<Arc<SecretResolver>>,
+    dynamic_credentials: Option<
+        Arc<
+            std::sync::RwLock<
+                std::collections::HashMap<String, openshell_core::proto::ProviderProfileCredential>,
+            >,
+        >,
+    >,
     denial_tx: Option<&mpsc::UnboundedSender<DenialEvent>>,
 ) -> Result<()> {
     // 1. Parse the absolute-form URI. `path` is marked `mut` so that, when an
@@ -2923,6 +2975,10 @@ async fn handle_forward_proxy(
             .map(|p| p.to_string_lossy().into_owned())
             .collect(),
         secret_resolver: secret_resolver.clone(),
+        dynamic_credentials: dynamic_credentials.clone(),
+        token_grant_resolver: dynamic_credentials
+            .as_ref()
+            .map(|_| crate::l7::token_grant_injection::default_resolver()),
     };
 
     // 4b. If the endpoint has L7 config, evaluate the request against
@@ -3519,6 +3575,36 @@ async fn handle_forward_proxy(
         ocsf_emit!(event);
     }
 
+    forward_request_bytes = match inject_token_grant_for_forward_request(
+        method,
+        &upstream_target,
+        forward_request_bytes,
+        &l7_ctx,
+    )
+    .await
+    {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            warn!(
+                dst_host = %host_lc,
+                dst_port = port,
+                error = %e,
+                "token grant failed in forward proxy"
+            );
+            respond(
+                client,
+                &build_json_error_response(
+                    502,
+                    "Bad Gateway",
+                    "token_grant_failed",
+                    "dynamic token grant failed",
+                ),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
     // 9. Rewrite request and forward to upstream
     let rewritten = match rewrite_forward_request(
         &forward_request_bytes,
@@ -3788,6 +3874,52 @@ mod tests {
             .map_err(|e| miette::miette!("upstream task failed: {e}"))
     }
 
+    fn forward_token_grant_context(
+        resolver_response: std::result::Result<&str, &str>,
+    ) -> (
+        crate::l7::relay::L7EvalContext,
+        crate::l7::token_grant_injection::test_support::TokenGrantTestFixture,
+    ) {
+        let provider_key = "api.example.test\t8080\t/v1/**\tprovider:access_token";
+        let fixture = match resolver_response {
+            Ok(token) => {
+                crate::l7::token_grant_injection::test_support::TokenGrantTestFixture::success(
+                    provider_key,
+                    token,
+                )
+            }
+            Err(error) => {
+                crate::l7::token_grant_injection::test_support::TokenGrantTestFixture::failure(
+                    provider_key,
+                    error,
+                )
+            }
+        };
+        let ctx = crate::l7::relay::L7EvalContext {
+            host: "api.example.test".into(),
+            port: 8080,
+            policy_name: "rest_api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            dynamic_credentials: Some(fixture.dynamic_credentials()),
+            token_grant_resolver: Some(fixture.resolver()),
+        };
+
+        (ctx, fixture)
+    }
+
+    fn authorization_header_count(headers: &str) -> usize {
+        headers
+            .lines()
+            .filter(|line| {
+                line.split_once(':')
+                    .is_some_and(|(name, _)| name.eq_ignore_ascii_case("authorization"))
+            })
+            .count()
+    }
+
     fn forward_websocket_policy_parts(
         data: &str,
         host: &str,
@@ -3828,6 +3960,8 @@ mod tests {
             ancestors: vec![],
             cmdline_paths: vec![],
             secret_resolver: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
         };
         (config, tunnel_engine, ctx)
     }
@@ -3993,6 +4127,8 @@ mod tests {
             ancestors: vec![],
             cmdline_paths: vec![],
             secret_resolver: resolver,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
         };
         let query_params = std::collections::HashMap::new();
 
@@ -4033,6 +4169,8 @@ mod tests {
             ancestors: vec![],
             cmdline_paths: vec![],
             secret_resolver: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
         };
         let query_params = std::collections::HashMap::new();
         let config = websocket_l7_config(crate::l7::L7Protocol::Rest, false);
@@ -5715,6 +5853,40 @@ network_policies:
     }
 
     // --- rewrite_forward_request tests ---
+
+    #[tokio::test]
+    async fn forward_proxy_injects_token_grant_before_rewriting_request() {
+        let (ctx, fixture) = forward_token_grant_context(Ok("grant-token"));
+        let raw = b"GET http://api.example.test:8080/v1/projects HTTP/1.1\r\nHost: api.example.test:8080\r\nAuthorization: Bearer stale-token\r\nConnection: close\r\n\r\n".to_vec();
+
+        let with_token = inject_token_grant_for_forward_request("GET", "/v1/projects", raw, &ctx)
+            .await
+            .expect("forward token grant should inject");
+        let rewritten =
+            rewrite_forward_request(&with_token, with_token.len(), "/v1/projects", None, false)
+                .expect("forward request should rewrite");
+        let rewritten = String::from_utf8_lossy(&rewritten);
+
+        assert!(rewritten.starts_with("GET /v1/projects HTTP/1.1\r\n"));
+        assert!(rewritten.contains("Authorization: Bearer grant-token\r\n"));
+        assert!(!rewritten.contains("stale-token"));
+        assert_eq!(authorization_header_count(&rewritten), 1);
+        fixture.assert_one_request("api.example.test\t8080\t/v1/**\tprovider:access_token");
+    }
+
+    #[tokio::test]
+    async fn forward_proxy_token_grant_failure_returns_error_before_rewrite() {
+        let (ctx, fixture) = forward_token_grant_context(Err("oauth unavailable"));
+        let raw = b"GET http://api.example.test:8080/v1/projects HTTP/1.1\r\nHost: api.example.test:8080\r\nConnection: close\r\n\r\n".to_vec();
+
+        let err = inject_token_grant_for_forward_request("GET", "/v1/projects", raw, &ctx)
+            .await
+            .expect_err("forward token grant failure should stop request rewriting");
+
+        assert!(err.to_string().contains("Token grant failed"));
+        assert!(err.to_string().contains("oauth unavailable"));
+        fixture.assert_one_request("api.example.test\t8080\t/v1/**\tprovider:access_token");
+    }
 
     #[test]
     fn test_rewrite_get_request() {

--- a/crates/openshell-sandbox/src/spiffe_endpoint.rs
+++ b/crates/openshell-sandbox/src/spiffe_endpoint.rs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+/// Convert a path to a SPIFFE Workload API endpoint URL.
+///
+/// If the path already has a scheme (`unix:` or `tcp:`), use it as-is.
+/// Otherwise, assume it is a Unix socket path and prepend `unix:`.
+pub fn workload_api_endpoint(path: &Path) -> String {
+    let path = path.to_string_lossy();
+    if path.starts_with("unix:") || path.starts_with("tcp:") {
+        path.into_owned()
+    } else {
+        format!("unix:{path}")
+    }
+}

--- a/crates/openshell-sandbox/src/ssh.rs
+++ b/crates/openshell-sandbox/src/ssh.rs
@@ -1095,7 +1095,7 @@ mod unsafe_pty {
                     netns_fd,
                     &policy,
                     #[cfg(target_os = "linux")]
-                    supervisor_identity_mount.as_ref(),
+                    supervisor_identity_mount,
                     #[cfg(target_os = "linux")]
                     prepared.take(),
                 )
@@ -1135,7 +1135,7 @@ mod unsafe_pty {
                     netns_fd,
                     &policy,
                     #[cfg(target_os = "linux")]
-                    supervisor_identity_mount.as_ref(),
+                    supervisor_identity_mount,
                     #[cfg(target_os = "linux")]
                     prepared.take(),
                 )

--- a/crates/openshell-sandbox/src/ssh.rs
+++ b/crates/openshell-sandbox/src/ssh.rs
@@ -5,7 +5,7 @@
 
 use crate::child_env;
 use crate::policy::SandboxPolicy;
-use crate::process::drop_privileges;
+use crate::process::{drop_privileges, is_supervisor_only_env_var};
 use crate::provider_credentials::ProviderCredentialState;
 use crate::sandbox;
 #[cfg(target_os = "linux")]
@@ -700,6 +700,9 @@ fn apply_child_env(
     }
 
     for (key, value) in provider_env {
+        if is_supervisor_only_env_var(key) {
+            continue;
+        }
         cmd.env(key, value);
     }
 }
@@ -790,7 +793,7 @@ fn spawn_pty_shell(
             netns_fd,
             #[cfg(target_os = "linux")]
             prepared_sandbox,
-        );
+        )?;
     }
 
     let mut child = cmd.spawn()?;
@@ -936,7 +939,7 @@ fn spawn_pipe_exec(
             netns_fd,
             #[cfg(target_os = "linux")]
             prepared_sandbox,
-        );
+        )?;
     }
 
     let mut child = cmd.spawn()?;
@@ -1059,6 +1062,13 @@ mod unsafe_pty {
     }
 
     #[allow(unsafe_code)]
+    #[cfg_attr(
+        not(target_os = "linux"),
+        allow(
+            clippy::unnecessary_wraps,
+            reason = "Linux pre_exec setup can fail while non-Linux setup cannot."
+        )
+    )]
     pub fn install_pre_exec(
         cmd: &mut Command,
         policy: SandboxPolicy,
@@ -1066,11 +1076,16 @@ mod unsafe_pty {
         slave_fd: RawFd,
         netns_fd: Option<RawFd>,
         #[cfg(target_os = "linux")] prepared: crate::sandbox::linux::PreparedSandbox,
-    ) {
+    ) -> anyhow::Result<()> {
         // Wrap in Option so we can .take() it out of the FnMut closure.
         // pre_exec is only called once (after fork, before exec).
         #[cfg(target_os = "linux")]
         let mut prepared = Some(prepared);
+        #[cfg(target_os = "linux")]
+        let supervisor_identity_mount = crate::process::supervisor_identity_mount_from_env()
+            .map_err(|err| {
+                anyhow::anyhow!("failed to prepare supervisor identity isolation: {err}")
+            })?;
         unsafe {
             cmd.pre_exec(move || {
                 setsid().map_err(|err| std::io::Error::other(err.to_string()))?;
@@ -1080,40 +1095,61 @@ mod unsafe_pty {
                     netns_fd,
                     &policy,
                     #[cfg(target_os = "linux")]
+                    supervisor_identity_mount.as_ref(),
+                    #[cfg(target_os = "linux")]
                     prepared.take(),
                 )
             });
         }
+        Ok(())
     }
 
     /// Pre-exec hook for pipe-based (non-PTY) exec.
     ///
     /// Skips `setsid` and `TIOCSCTTY` since there is no controlling terminal.
     #[allow(unsafe_code)]
+    #[cfg_attr(
+        not(target_os = "linux"),
+        allow(
+            clippy::unnecessary_wraps,
+            reason = "Linux pre_exec setup can fail while non-Linux setup cannot."
+        )
+    )]
     pub fn install_pre_exec_no_pty(
         cmd: &mut Command,
         policy: SandboxPolicy,
         _workdir: Option<String>,
         netns_fd: Option<RawFd>,
         #[cfg(target_os = "linux")] prepared: crate::sandbox::linux::PreparedSandbox,
-    ) {
+    ) -> anyhow::Result<()> {
         #[cfg(target_os = "linux")]
         let mut prepared = Some(prepared);
+        #[cfg(target_os = "linux")]
+        let supervisor_identity_mount = crate::process::supervisor_identity_mount_from_env()
+            .map_err(|err| {
+                anyhow::anyhow!("failed to prepare supervisor identity isolation: {err}")
+            })?;
         unsafe {
             cmd.pre_exec(move || {
                 enter_netns_and_sandbox(
                     netns_fd,
                     &policy,
                     #[cfg(target_os = "linux")]
+                    supervisor_identity_mount.as_ref(),
+                    #[cfg(target_os = "linux")]
                     prepared.take(),
                 )
             });
         }
+        Ok(())
     }
 
     fn enter_netns_and_sandbox(
         netns_fd: Option<RawFd>,
         policy: &SandboxPolicy,
+        #[cfg(target_os = "linux")] supervisor_identity_mount: Option<
+            &crate::process::SupervisorIdentityMountNamespace,
+        >,
         #[cfg(target_os = "linux")] prepared: Option<crate::sandbox::linux::PreparedSandbox>,
     ) -> std::io::Result<()> {
         // Enter network namespace before dropping privileges.
@@ -1131,6 +1167,11 @@ mod unsafe_pty {
 
         #[cfg(not(target_os = "linux"))]
         let _ = netns_fd;
+
+        #[cfg(target_os = "linux")]
+        if let Some(mount) = supervisor_identity_mount {
+            mount.enter_for_child()?;
+        }
 
         // Drop privileges. initgroups/setgid/setuid need /etc/group and
         // /etc/passwd which would be blocked if Landlock were already enforced.
@@ -1517,7 +1558,8 @@ mod tests {
                 None,
             )
             .expect("prepare should succeed in test environment"),
-        );
+        )
+        .expect("install pre_exec should succeed");
 
         let output = cmd
             .spawn()

--- a/crates/openshell-sandbox/src/token_grant.rs
+++ b/crates/openshell-sandbox/src/token_grant.rs
@@ -1,0 +1,1034 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `OAuth2` JWT client assertion token grant using SPIFFE JWT-SVID.
+//!
+//! When a provider profile includes a `token_grant` configuration, the
+//! supervisor obtains `OAuth2` access tokens on-demand by authenticating to the
+//! token service using the sandbox's SPIFFE JWT-SVID as the client assertion.
+//!
+//! ## Flow
+//!
+//! 1. HTTP proxy intercepts outbound request to provider endpoint
+//! 2. Check token cache for unexpired access token
+//! 3. On cache miss or expiry:
+//!    a. Fetch JWT-SVID from SPIRE agent (via Workload API)
+//!    b. POST to token service with JWT client assertion grant
+//!    c. Cache the returned access token with TTL
+//! 4. Inject `Authorization: Bearer <access_token>` header
+//!
+//! ## Configuration
+//!
+//! Token grant parameters come from the provider profile `token_grant` field:
+//! - `token_endpoint` — `OAuth2` token service URL
+//! - `jwt_svid_audience` — SPIRE JWT-SVID audience override (optional)
+//! - `audience` — Resource audience to request from the token service
+//! - `scopes` — `OAuth2` scopes to request (optional)
+//! - `cache_ttl_seconds` — Cache override (0 = use `expires_in` from response)
+//!
+//! ## Environment
+//!
+//! Requires `OPENSHELL_SPIFFE_WORKLOAD_API_SOCKET` to be set (path to SPIRE
+//! agent socket). This is configured by the SPIRE `DaemonSet` in Kubernetes or
+//! mounted by the compute driver in standalone deployments.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::{Arc, LazyLock, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use miette::{IntoDiagnostic, Result, WrapErr};
+use openshell_core::sandbox_env;
+use serde::Deserialize;
+use spiffe::WorkloadApiClient;
+
+/// Token cache shared across all provider token grants.
+static TOKEN_CACHE: LazyLock<TokenCache> = LazyLock::new(TokenCache::new);
+const MAX_OAUTH_ERROR_FIELD_LEN: usize = 256;
+
+/// `OAuth2` token response from the authorization server.
+#[derive(Debug, Clone, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    token_type: String,
+    #[serde(default)]
+    expires_in: i64,
+    #[serde(default)]
+    #[allow(dead_code)]
+    scope: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthErrorResponse {
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+/// Cached access token with expiration metadata.
+#[derive(Debug, Clone)]
+struct CachedToken {
+    access_token: String,
+    expires_at_ms: i64,
+}
+
+/// Thread-safe token cache keyed by provider name.
+struct TokenCache {
+    tokens: Arc<RwLock<HashMap<String, CachedToken>>>,
+}
+
+impl TokenCache {
+    fn new() -> Self {
+        Self {
+            tokens: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Get a cached token if it exists and is not expired.
+    fn get(&self, provider_name: &str) -> Option<String> {
+        let now_ms = current_time_ms();
+        let tokens = self.tokens.read().ok()?;
+        let cached = tokens.get(provider_name)?;
+        if cached.expires_at_ms > now_ms {
+            Some(cached.access_token.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Store a token with expiration time.
+    fn set(&self, provider_name: String, access_token: String, expires_at_ms: i64) {
+        if let Ok(mut tokens) = self.tokens.write() {
+            tokens.insert(
+                provider_name,
+                CachedToken {
+                    access_token,
+                    expires_at_ms,
+                },
+            );
+        }
+    }
+}
+
+/// Obtain an `OAuth2` access token for a provider using JWT client assertion grant.
+///
+/// This function fetches the sandbox's SPIFFE JWT-SVID from the local SPIRE
+/// agent, then exchanges it for an access token with a POST request to the provider's
+/// token endpoint with the JWT client assertion grant flow (RFC 7523).
+///
+/// Tokens are cached per provider name with TTL. Subsequent calls return the
+/// cached token if it has not expired.
+///
+/// # Arguments
+///
+/// * `provider_name` — Unique provider identifier (used as cache key)
+/// * `token_endpoint` — `OAuth2` token service URL
+/// * `jwt_svid_audience` — Optional audience to request when fetching the JWT-SVID
+/// * `audience` — Resource audience to request in the token request
+/// * `scopes` — `OAuth2` scopes to request (may be empty)
+/// * `cache_ttl_override` — Cache TTL in seconds (0 = use `expires_in` from response)
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - SPIFFE Workload API socket is not configured
+/// - SPIRE agent is unreachable
+/// - JWT-SVID fetch fails
+/// - Token service request fails
+/// - Token response is invalid
+pub async fn obtain_provider_token(
+    provider_name: &str,
+    token_endpoint: &str,
+    jwt_svid_audience: &str,
+    audience: &str,
+    scopes: &[String],
+    cache_ttl_override: i64,
+) -> Result<String> {
+    obtain_provider_token_with_grant(
+        ObtainProviderTokenInput {
+            cache: &TOKEN_CACHE,
+            provider_name,
+            token_endpoint,
+            jwt_svid_audience,
+            audience,
+            scopes,
+            cache_ttl_override,
+        },
+        |jwt_audience| async move {
+            // Fetch JWT-SVID with authorization server as audience
+            // For RFC 7523, the JWT assertion's aud claim identifies the issuer/realm
+            let jwt_svid = fetch_jwt_svid_for_token_grant(&jwt_audience).await?;
+
+            // Perform OAuth2 JWT client assertion grant
+            // The audience parameter in the token request specifies the resource server
+            perform_token_grant(token_endpoint, &jwt_svid, audience, scopes).await
+        },
+    )
+    .await
+}
+
+struct ObtainProviderTokenInput<'a> {
+    cache: &'a TokenCache,
+    provider_name: &'a str,
+    token_endpoint: &'a str,
+    jwt_svid_audience: &'a str,
+    audience: &'a str,
+    scopes: &'a [String],
+    cache_ttl_override: i64,
+}
+
+async fn obtain_provider_token_with_grant<F, Fut>(
+    input: ObtainProviderTokenInput<'_>,
+    grant: F,
+) -> Result<String>
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = Result<TokenResponse>>,
+{
+    // Derive authorization server audience from token endpoint
+    // For Keycloak: http://keycloak/realms/openshell/protocol/openid-connect/token
+    //           -> http://keycloak/realms/openshell
+    let jwt_audience = effective_jwt_svid_audience(input.token_endpoint, input.jwt_svid_audience);
+    let cache_key = token_cache_key(
+        input.provider_name,
+        input.token_endpoint,
+        &jwt_audience,
+        input.audience,
+        input.scopes,
+    );
+
+    // Check cache first
+    if let Some(cached) = input.cache.get(&cache_key) {
+        return Ok(cached);
+    }
+
+    let token_response = grant(jwt_audience).await?;
+
+    // Calculate expiration time
+    let expires_at_ms = if input.cache_ttl_override > 0 {
+        current_time_ms() + (input.cache_ttl_override * 1000)
+    } else if token_response.expires_in > 0 {
+        current_time_ms() + (token_response.expires_in * 1000)
+    } else {
+        // Default to 5 minutes if no expiry provided
+        current_time_ms() + (300 * 1000)
+    };
+
+    // Cache the token
+    input.cache.set(
+        cache_key,
+        token_response.access_token.clone(),
+        expires_at_ms,
+    );
+
+    Ok(token_response.access_token)
+}
+
+/// Fetch JWT-SVID from SPIRE agent for token grant authentication.
+///
+/// This function connects to the local SPIRE agent via the Workload API and
+/// requests a JWT-SVID with the specified audience. The JWT-SVID is used as
+/// the client assertion in the `OAuth2` grant request.
+async fn fetch_jwt_svid_for_token_grant(audience: &str) -> Result<String> {
+    // Get SPIFFE Workload API socket path from environment
+    let socket_path = std::env::var(sandbox_env::SPIFFE_WORKLOAD_API_SOCKET)
+        .into_diagnostic()
+        .wrap_err_with(|| {
+            format!(
+                "{} not set — SPIFFE authentication unavailable for token grant",
+                sandbox_env::SPIFFE_WORKLOAD_API_SOCKET
+            )
+        })?;
+
+    let endpoint =
+        crate::spiffe_endpoint::workload_api_endpoint(std::path::Path::new(&socket_path));
+
+    // Connect to SPIRE agent
+    let client = WorkloadApiClient::connect_to(&endpoint)
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| {
+            format!("failed to connect to SPIFFE Workload API endpoint {endpoint}")
+        })?;
+
+    // Fetch JWT-SVID with token service audience
+    // None = use the sandbox's default SPIFFE ID
+    client
+        .fetch_jwt_token([audience], None)
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to fetch JWT-SVID for token grant")
+}
+
+/// Perform `OAuth2` JWT client assertion grant.
+///
+/// POSTs to the token endpoint with:
+/// - `grant_type=client_credentials`
+/// - `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-spiffe`
+/// - `client_assertion=<JWT-SVID>` (client identity is in the JWT's `sub` claim)
+/// - `audience=<audience>` (if provided)
+/// - `scope=<scopes>` (if provided)
+///
+/// Note: `client_id` is NOT included - the client is identified by the `sub` claim
+/// in the JWT-SVID itself.
+async fn perform_token_grant(
+    token_endpoint: &str,
+    jwt_svid: &str,
+    audience: &str,
+    scopes: &[String],
+) -> Result<TokenResponse> {
+    let mut form_params = vec![
+        ("grant_type", "client_credentials"),
+        (
+            "client_assertion_type",
+            "urn:ietf:params:oauth:client-assertion-type:jwt-spiffe",
+        ),
+        ("client_assertion", jwt_svid),
+    ];
+
+    // Add audience if provided
+    let audience_param;
+    if !audience.is_empty() {
+        audience_param = audience.to_string();
+        form_params.push(("audience", &audience_param));
+    }
+
+    // Add scopes if provided
+    let scope_param;
+    if !scopes.is_empty() {
+        scope_param = scopes.join(" ");
+        form_params.push(("scope", &scope_param));
+    }
+
+    // POST to token endpoint
+    let client = reqwest::Client::new();
+    let response = client
+        .post(token_endpoint)
+        .form(&form_params)
+        .send()
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to POST to token endpoint {token_endpoint}"))?;
+
+    // Check response status
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "<failed to read response body>".to_string());
+        return Err(miette::miette!(
+            "{}",
+            token_grant_failure_message(status, &body)
+        ));
+    }
+
+    // Parse token response
+    response
+        .json::<TokenResponse>()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to parse token response as JSON")
+}
+
+/// Derive the issuer/realm URL from a token endpoint URL.
+///
+/// For Keycloak token endpoints like:
+///   `http://keycloak/realms/openshell/protocol/openid-connect/token`
+/// Returns:
+///   `http://keycloak/realms/openshell`
+///
+/// This is used as the JWT-SVID audience claim when authenticating to the
+/// authorization server via JWT client assertion (RFC 7523).
+fn derive_issuer_from_token_endpoint(token_endpoint: &str) -> String {
+    // For Keycloak, strip everything after /realms/{realm-name}
+    if let Some(realms_idx) = token_endpoint.find("/realms/") {
+        // Find the next path segment after the realm name
+        let after_realms = &token_endpoint[realms_idx + "/realms/".len()..];
+        if let Some(slash_idx) = after_realms.find('/') {
+            // Return everything up to (but not including) the next slash
+            let realm_end = realms_idx + "/realms/".len() + slash_idx;
+            return token_endpoint[..realm_end].to_string();
+        }
+    }
+
+    // Fallback: if we can't parse it, use the full token endpoint
+    // This works for some OAuth2 servers that accept the token endpoint as aud
+    token_endpoint.to_string()
+}
+
+fn effective_jwt_svid_audience(token_endpoint: &str, jwt_svid_audience: &str) -> String {
+    if jwt_svid_audience.is_empty() {
+        derive_issuer_from_token_endpoint(token_endpoint)
+    } else {
+        jwt_svid_audience.to_string()
+    }
+}
+
+fn token_cache_key(
+    provider_name: &str,
+    token_endpoint: &str,
+    jwt_svid_audience: &str,
+    audience: &str,
+    scopes: &[String],
+) -> String {
+    format!(
+        "{}\t{}\t{}\t{}\t{}",
+        provider_name,
+        token_endpoint,
+        jwt_svid_audience,
+        audience,
+        scopes.join(" ")
+    )
+}
+
+fn token_grant_failure_message(status: reqwest::StatusCode, body: &str) -> String {
+    let Ok(error_response) = serde_json::from_str::<OAuthErrorResponse>(body) else {
+        return format!("token grant failed with status {status}");
+    };
+
+    let error = error_response
+        .error
+        .as_deref()
+        .map(sanitize_oauth_error_field)
+        .filter(|value| !value.is_empty());
+    let description = error_response
+        .error_description
+        .as_deref()
+        .map(sanitize_oauth_error_field)
+        .filter(|value| !value.is_empty());
+
+    match (error, description) {
+        (Some(error), Some(description)) => {
+            format!(
+                "token grant failed with status {status}: error={error}; error_description={description}"
+            )
+        }
+        (Some(error), None) => {
+            format!("token grant failed with status {status}: error={error}")
+        }
+        (None, Some(description)) => {
+            format!("token grant failed with status {status}: error_description={description}")
+        }
+        (None, None) => format!("token grant failed with status {status}"),
+    }
+}
+
+fn sanitize_oauth_error_field(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
+        .take(MAX_OAUTH_ERROR_FIELD_LEN)
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
+/// Get current Unix timestamp in milliseconds.
+fn current_time_ms() -> i64 {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::from_secs(0))
+        .as_millis();
+    i64::try_from(millis).unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    #[derive(Debug)]
+    struct CapturedTokenRequest {
+        request_line: String,
+        headers: HashMap<String, String>,
+        form: HashMap<String, String>,
+    }
+
+    async fn token_endpoint_once(
+        status: &str,
+        body: &str,
+    ) -> (String, tokio::task::JoinHandle<CapturedTokenRequest>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind token endpoint");
+        let addr = listener.local_addr().expect("token endpoint local addr");
+        let status = status.to_string();
+        let body = body.to_string();
+        let handle = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept token request");
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 512];
+            let mut expected_len = None;
+
+            loop {
+                let n = stream.read(&mut chunk).await.expect("read token request");
+                assert!(n > 0, "token request stream closed before headers");
+                buf.extend_from_slice(&chunk[..n]);
+
+                if expected_len.is_none()
+                    && let Some(header_end) = header_end(&buf)
+                {
+                    let headers = String::from_utf8_lossy(&buf[..header_end]);
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().ok())
+                                .flatten()
+                        })
+                        .unwrap_or(0);
+                    expected_len = Some(header_end + content_length);
+                }
+
+                if expected_len.is_some_and(|len| buf.len() >= len) {
+                    break;
+                }
+            }
+
+            let captured = parse_token_request(&buf);
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write token response");
+            captured
+        });
+
+        (format!("http://{addr}/token"), handle)
+    }
+
+    fn header_end(buf: &[u8]) -> Option<usize> {
+        buf.windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .map(|idx| idx + 4)
+    }
+
+    fn parse_token_request(buf: &[u8]) -> CapturedTokenRequest {
+        let header_end = header_end(buf).expect("request should contain header terminator");
+        let headers = String::from_utf8_lossy(&buf[..header_end]);
+        let mut lines = headers.lines();
+        let request_line = lines.next().expect("request line").to_string();
+        let headers = lines
+            .filter_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                Some((name.to_ascii_lowercase(), value.trim().to_string()))
+            })
+            .collect();
+        let body = String::from_utf8_lossy(&buf[header_end..]).to_string();
+
+        CapturedTokenRequest {
+            request_line,
+            headers,
+            form: parse_form_body(&body),
+        }
+    }
+
+    fn parse_form_body(body: &str) -> HashMap<String, String> {
+        body.split('&')
+            .filter(|part| !part.is_empty())
+            .filter_map(|part| {
+                let (name, value) = part.split_once('=')?;
+                Some((decode_form_component(name), decode_form_component(value)))
+            })
+            .collect()
+    }
+
+    fn decode_form_component(value: &str) -> String {
+        let bytes = value.as_bytes();
+        let mut decoded = Vec::with_capacity(bytes.len());
+        let mut idx = 0;
+        while idx < bytes.len() {
+            match bytes[idx] {
+                b'+' => {
+                    decoded.push(b' ');
+                    idx += 1;
+                }
+                b'%' if idx + 2 < bytes.len() => {
+                    let hex = &value[idx + 1..idx + 3];
+                    if let Ok(byte) = u8::from_str_radix(hex, 16) {
+                        decoded.push(byte);
+                        idx += 3;
+                    } else {
+                        decoded.push(bytes[idx]);
+                        idx += 1;
+                    }
+                }
+                byte => {
+                    decoded.push(byte);
+                    idx += 1;
+                }
+            }
+        }
+        String::from_utf8(decoded).expect("form body should be UTF-8")
+    }
+
+    struct CountedTokenGrantInput<'a> {
+        cache: &'a TokenCache,
+        provider_name: &'a str,
+        token_endpoint: &'a str,
+        jwt_svid_audience: &'a str,
+        audience: &'a str,
+        scopes: &'a [String],
+        cache_ttl_override: i64,
+        expires_in: i64,
+        grant_calls: Arc<AtomicUsize>,
+    }
+
+    async fn obtain_counted_test_token(input: CountedTokenGrantInput<'_>) -> Result<String> {
+        obtain_provider_token_with_grant(
+            ObtainProviderTokenInput {
+                cache: input.cache,
+                provider_name: input.provider_name,
+                token_endpoint: input.token_endpoint,
+                jwt_svid_audience: input.jwt_svid_audience,
+                audience: input.audience,
+                scopes: input.scopes,
+                cache_ttl_override: input.cache_ttl_override,
+            },
+            move |_| {
+                let grant_calls = input.grant_calls.clone();
+                async move {
+                    let call = grant_calls.fetch_add(1, Ordering::SeqCst) + 1;
+                    Ok(TokenResponse {
+                        access_token: format!("token-{call}"),
+                        token_type: "Bearer".to_string(),
+                        expires_in: input.expires_in,
+                        scope: input.scopes.join(" "),
+                    })
+                }
+            },
+        )
+        .await
+    }
+
+    async fn obtain_token_without_grant_call(
+        cache: &TokenCache,
+        provider_name: &str,
+        token_endpoint: &str,
+        jwt_svid_audience: &str,
+        audience: &str,
+        scopes: &[String],
+        cache_ttl_override: i64,
+    ) -> Result<String> {
+        obtain_provider_token_with_grant(
+            ObtainProviderTokenInput {
+                cache,
+                provider_name,
+                token_endpoint,
+                jwt_svid_audience,
+                audience,
+                scopes,
+                cache_ttl_override,
+            },
+            |_| async { Err(miette::miette!("grant should not be called on cache hit")) },
+        )
+        .await
+    }
+
+    #[test]
+    fn test_derive_issuer_from_keycloak_token_endpoint() {
+        let token_endpoint = "http://keycloak/realms/openshell/protocol/openid-connect/token";
+        let issuer = derive_issuer_from_token_endpoint(token_endpoint);
+        assert_eq!(issuer, "http://keycloak/realms/openshell");
+    }
+
+    #[test]
+    fn test_derive_issuer_from_https_keycloak_endpoint() {
+        let token_endpoint =
+            "https://auth.example.com/realms/production/protocol/openid-connect/token";
+        let issuer = derive_issuer_from_token_endpoint(token_endpoint);
+        assert_eq!(issuer, "https://auth.example.com/realms/production");
+    }
+
+    #[test]
+    fn test_derive_issuer_fallback_for_non_keycloak() {
+        let token_endpoint = "https://oauth.example.com/token";
+        let issuer = derive_issuer_from_token_endpoint(token_endpoint);
+        // Fallback: returns the full token endpoint
+        assert_eq!(issuer, "https://oauth.example.com/token");
+    }
+
+    #[test]
+    fn effective_jwt_svid_audience_prefers_explicit_override() {
+        let audience = effective_jwt_svid_audience(
+            "http://keycloak/realms/openshell/protocol/openid-connect/token",
+            "spiffe://custom-audience",
+        );
+
+        assert_eq!(audience, "spiffe://custom-audience");
+    }
+
+    #[test]
+    fn token_cache_key_varies_by_resource_audience_and_scopes() {
+        let base = token_cache_key(
+            "alpha.default.svc.cluster.local\t80\t\tprovider:access_token",
+            "http://keycloak/realms/openshell/protocol/openid-connect/token",
+            "http://keycloak/realms/openshell",
+            "alpha",
+            &["alpha".to_string()],
+        );
+        let different_audience = token_cache_key(
+            "alpha.default.svc.cluster.local\t80\t\tprovider:access_token",
+            "http://keycloak/realms/openshell/protocol/openid-connect/token",
+            "http://keycloak/realms/openshell",
+            "delta",
+            &["alpha".to_string()],
+        );
+        let different_scopes = token_cache_key(
+            "alpha.default.svc.cluster.local\t80\t\tprovider:access_token",
+            "http://keycloak/realms/openshell/protocol/openid-connect/token",
+            "http://keycloak/realms/openshell",
+            "alpha",
+            &["delta".to_string()],
+        );
+
+        assert_ne!(base, different_audience);
+        assert_ne!(base, different_scopes);
+    }
+
+    #[tokio::test]
+    async fn obtain_provider_token_uses_cache_for_same_key() {
+        let cache = TokenCache::new();
+        let grant_calls = Arc::new(AtomicUsize::new(0));
+        let scopes = vec!["read".to_string()];
+
+        let first = obtain_counted_test_token(CountedTokenGrantInput {
+            cache: &cache,
+            provider_name: "api.example.test\t443\t/v1/**\tprovider:access_token",
+            token_endpoint: "https://auth.example.com/token",
+            jwt_svid_audience: "https://auth.example.com",
+            audience: "api://resource",
+            scopes: &scopes,
+            cache_ttl_override: 0,
+            expires_in: 60,
+            grant_calls: grant_calls.clone(),
+        })
+        .await
+        .expect("first call should grant token");
+        let second = obtain_token_without_grant_call(
+            &cache,
+            "api.example.test\t443\t/v1/**\tprovider:access_token",
+            "https://auth.example.com/token",
+            "https://auth.example.com",
+            "api://resource",
+            &scopes,
+            0,
+        )
+        .await
+        .expect("second call should use cache");
+
+        assert_eq!(first, "token-1");
+        assert_eq!(second, "token-1");
+        assert_eq!(grant_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn obtain_provider_token_separates_cache_by_audience_and_scopes() {
+        let cache = TokenCache::new();
+        let grant_calls = Arc::new(AtomicUsize::new(0));
+        let read_scope = vec!["read".to_string()];
+        let write_scope = vec!["write".to_string()];
+
+        let first = obtain_counted_test_token(CountedTokenGrantInput {
+            cache: &cache,
+            provider_name: "api.example.test\t443\t/v1/**\tprovider:access_token",
+            token_endpoint: "https://auth.example.com/token",
+            jwt_svid_audience: "https://auth.example.com",
+            audience: "api://resource-one",
+            scopes: &read_scope,
+            cache_ttl_override: 0,
+            expires_in: 60,
+            grant_calls: grant_calls.clone(),
+        })
+        .await
+        .expect("first audience should grant token");
+        let different_audience = obtain_counted_test_token(CountedTokenGrantInput {
+            cache: &cache,
+            provider_name: "api.example.test\t443\t/v1/**\tprovider:access_token",
+            token_endpoint: "https://auth.example.com/token",
+            jwt_svid_audience: "https://auth.example.com",
+            audience: "api://resource-two",
+            scopes: &read_scope,
+            cache_ttl_override: 0,
+            expires_in: 60,
+            grant_calls: grant_calls.clone(),
+        })
+        .await
+        .expect("different audience should grant token");
+        let different_scope = obtain_counted_test_token(CountedTokenGrantInput {
+            cache: &cache,
+            provider_name: "api.example.test\t443\t/v1/**\tprovider:access_token",
+            token_endpoint: "https://auth.example.com/token",
+            jwt_svid_audience: "https://auth.example.com",
+            audience: "api://resource-one",
+            scopes: &write_scope,
+            cache_ttl_override: 0,
+            expires_in: 60,
+            grant_calls: grant_calls.clone(),
+        })
+        .await
+        .expect("different scope should grant token");
+
+        assert_eq!(first, "token-1");
+        assert_eq!(different_audience, "token-2");
+        assert_eq!(different_scope, "token-3");
+        assert_eq!(grant_calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn obtain_provider_token_regrants_after_expired_cache_entry() {
+        let cache = TokenCache::new();
+        let grant_calls = Arc::new(AtomicUsize::new(0));
+        let scopes = vec!["read".to_string()];
+        let provider_name = "api.example.test\t443\t/v1/**\tprovider:access_token";
+        let token_endpoint = "https://auth.example.com/token";
+        let jwt_svid_audience = "https://auth.example.com";
+        let audience = "api://resource";
+
+        let cache_key = token_cache_key(
+            provider_name,
+            token_endpoint,
+            jwt_svid_audience,
+            audience,
+            &scopes,
+        );
+        cache.set(
+            cache_key,
+            "expired-token".to_string(),
+            current_time_ms() - 1,
+        );
+
+        let token = obtain_counted_test_token(CountedTokenGrantInput {
+            cache: &cache,
+            provider_name,
+            token_endpoint,
+            jwt_svid_audience,
+            audience,
+            scopes: &scopes,
+            cache_ttl_override: 0,
+            expires_in: 60,
+            grant_calls: grant_calls.clone(),
+        })
+        .await
+        .expect("expired cache entry should grant token again");
+
+        assert_eq!(token, "token-1");
+        assert_eq!(grant_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn obtain_provider_token_cache_ttl_override_extends_zero_expires_in() {
+        let cache = TokenCache::new();
+        let grant_calls = Arc::new(AtomicUsize::new(0));
+        let scopes = vec!["read".to_string()];
+
+        let first = obtain_counted_test_token(CountedTokenGrantInput {
+            cache: &cache,
+            provider_name: "api.example.test\t443\t/v1/**\tprovider:access_token",
+            token_endpoint: "https://auth.example.com/token",
+            jwt_svid_audience: "https://auth.example.com",
+            audience: "api://resource",
+            scopes: &scopes,
+            cache_ttl_override: 60,
+            expires_in: 0,
+            grant_calls: grant_calls.clone(),
+        })
+        .await
+        .expect("first override call should grant token");
+        let second = obtain_token_without_grant_call(
+            &cache,
+            "api.example.test\t443\t/v1/**\tprovider:access_token",
+            "https://auth.example.com/token",
+            "https://auth.example.com",
+            "api://resource",
+            &scopes,
+            60,
+        )
+        .await
+        .expect("override should keep token cached");
+
+        assert_eq!(first, "token-1");
+        assert_eq!(second, "token-1");
+        assert_eq!(grant_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn perform_token_grant_posts_jwt_assertion_and_parses_success_response() {
+        let (endpoint, request) = token_endpoint_once(
+            "200 OK",
+            r#"{"access_token":"access-123","token_type":"Bearer","expires_in":42,"scope":"read write"}"#,
+        )
+        .await;
+        let scopes = vec!["read".to_string(), "write".to_string()];
+
+        let response = perform_token_grant(&endpoint, "jwt-svid-token", "api://resource", &scopes)
+            .await
+            .expect("token grant should succeed");
+        let request = request.await.expect("token endpoint task should finish");
+
+        assert_eq!(response.access_token, "access-123");
+        assert_eq!(response.expires_in, 42);
+        assert_eq!(request.request_line, "POST /token HTTP/1.1");
+        assert_eq!(
+            request.headers.get("content-type").map(String::as_str),
+            Some("application/x-www-form-urlencoded")
+        );
+        assert_eq!(
+            request.form.get("grant_type").map(String::as_str),
+            Some("client_credentials")
+        );
+        assert_eq!(
+            request
+                .form
+                .get("client_assertion_type")
+                .map(String::as_str),
+            Some("urn:ietf:params:oauth:client-assertion-type:jwt-spiffe")
+        );
+        assert_eq!(
+            request.form.get("client_assertion").map(String::as_str),
+            Some("jwt-svid-token")
+        );
+        assert_eq!(
+            request.form.get("audience").map(String::as_str),
+            Some("api://resource")
+        );
+        assert_eq!(
+            request.form.get("scope").map(String::as_str),
+            Some("read write")
+        );
+        assert!(
+            !request.form.contains_key("client_id"),
+            "JWT-SVID subject should identify the client"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_token_grant_omits_empty_audience_and_scope() {
+        let (endpoint, request) =
+            token_endpoint_once("200 OK", r#"{"access_token":"access-123"}"#).await;
+
+        let response = perform_token_grant(&endpoint, "jwt-svid-token", "", &[])
+            .await
+            .expect("token grant should succeed without audience or scopes");
+        let request = request.await.expect("token endpoint task should finish");
+
+        assert_eq!(response.access_token, "access-123");
+        assert_eq!(
+            request.form.get("client_assertion").map(String::as_str),
+            Some("jwt-svid-token")
+        );
+        assert!(!request.form.contains_key("audience"));
+        assert!(!request.form.contains_key("scope"));
+    }
+
+    #[tokio::test]
+    async fn perform_token_grant_reports_sanitized_oauth_error_response() {
+        let (endpoint, request) = token_endpoint_once(
+            "401 Unauthorized",
+            r#"{"error":"invalid_client","error_description":"bad jwt assertion"}"#,
+        )
+        .await;
+
+        let err = perform_token_grant(&endpoint, "jwt-svid-token", "api://resource", &[])
+            .await
+            .expect_err("token grant should fail on OAuth error");
+        let request = request.await.expect("token endpoint task should finish");
+
+        assert_eq!(
+            request.form.get("audience").map(String::as_str),
+            Some("api://resource")
+        );
+        assert_eq!(
+            err.to_string(),
+            "token grant failed with status 401 Unauthorized: error=invalid_client; error_description=bad jwt assertion"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_token_grant_does_not_echo_unstructured_error_body() {
+        let (endpoint, request) = token_endpoint_once(
+            "500 Internal Server Error",
+            "internal stack trace with implementation details",
+        )
+        .await;
+
+        let err = perform_token_grant(&endpoint, "jwt-svid-token", "", &[])
+            .await
+            .expect_err("token grant should fail on server error");
+        let _request = request.await.expect("token endpoint task should finish");
+        let message = err.to_string();
+
+        assert_eq!(
+            message,
+            "token grant failed with status 500 Internal Server Error"
+        );
+        assert!(!message.contains("stack trace"));
+        assert!(!message.contains("implementation details"));
+    }
+
+    #[tokio::test]
+    async fn perform_token_grant_reports_malformed_success_json() {
+        let (endpoint, request) = token_endpoint_once("200 OK", r#"{"access_token":42"#).await;
+
+        let err = perform_token_grant(&endpoint, "jwt-svid-token", "", &[])
+            .await
+            .expect_err("malformed token response should fail");
+        let _request = request.await.expect("token endpoint task should finish");
+
+        assert!(
+            err.to_string()
+                .contains("failed to parse token response as JSON")
+        );
+    }
+
+    #[test]
+    fn token_grant_failure_message_reports_oauth_error_fields() {
+        let message = token_grant_failure_message(
+            reqwest::StatusCode::UNAUTHORIZED,
+            r#"{"error":"invalid_client","error_description":"Invalid client credentials"}"#,
+        );
+
+        assert_eq!(
+            message,
+            "token grant failed with status 401 Unauthorized: error=invalid_client; error_description=Invalid client credentials"
+        );
+    }
+
+    #[test]
+    fn token_grant_failure_message_omits_unstructured_response_body() {
+        let message = token_grant_failure_message(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            "internal error containing implementation details",
+        );
+
+        assert_eq!(
+            message,
+            "token grant failed with status 500 Internal Server Error"
+        );
+    }
+
+    #[test]
+    fn token_grant_failure_message_sanitizes_oauth_error_fields() {
+        let long_description = "a".repeat(MAX_OAUTH_ERROR_FIELD_LEN + 20);
+        let body =
+            format!(r#"{{"error":"invalid_client\n","error_description":"{long_description}"}}"#);
+        let message = token_grant_failure_message(reqwest::StatusCode::UNAUTHORIZED, &body);
+
+        assert!(!message.contains('\n'));
+        assert!(message.contains("error=invalid_client"));
+        assert!(message.contains(&"a".repeat(MAX_OAUTH_ERROR_FIELD_LEN)));
+        assert!(!message.contains(&"a".repeat(MAX_OAUTH_ERROR_FIELD_LEN + 1)));
+    }
+}

--- a/crates/openshell-server/Cargo.toml
+++ b/crates/openshell-server/Cargo.toml
@@ -33,7 +33,7 @@ k8s-openapi = { workspace = true }
 tokio = { workspace = true }
 
 # gRPC
-tonic = { workspace = true, features = ["channel", "tls"] }
+tonic = { workspace = true, features = ["channel", "tls-native-roots"] }
 prost = { workspace = true }
 prost-types = { workspace = true }
 
@@ -82,6 +82,7 @@ uuid = { workspace = true }
 hmac = "0.12"
 sha2 = { workspace = true }
 jsonwebtoken = { workspace = true }
+spiffe = { workspace = true }
 async-trait = "0.1"
 url = { workspace = true }
 hex = "0.4"

--- a/crates/openshell-server/src/auth/mod.rs
+++ b/crates/openshell-server/src/auth/mod.rs
@@ -18,5 +18,6 @@ pub mod oidc;
 pub mod principal;
 pub mod sandbox_jwt;
 pub mod sandbox_methods;
+pub mod spiffe;
 
 pub use http::router;

--- a/crates/openshell-server/src/auth/spiffe.rs
+++ b/crates/openshell-server/src/auth/spiffe.rs
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! SPIFFE JWT-SVID authentication for sandbox supervisors.
+//!
+//! The gateway does not validate SPIFFE JWT-SVID signatures itself. Instead it
+//! delegates validation to the local SPIFFE Workload API, keeping algorithm and
+//! bundle handling inside the configured SPIFFE implementation.
+
+use super::authenticator::Authenticator;
+use super::principal::{Principal, SandboxIdentitySource, SandboxPrincipal};
+use async_trait::async_trait;
+use openshell_core::SpiffeConfig;
+use spiffe::{JwtSvid, WorkloadApiClient};
+use std::path::Path;
+use tonic::Status;
+use tracing::{debug, info, warn};
+
+/// Authenticator backed by the SPIFFE Workload API `ValidateJWTSVID` RPC.
+pub struct SpiffeAuthenticator {
+    client: WorkloadApiClient,
+    config: SpiffeConfig,
+}
+
+impl std::fmt::Debug for SpiffeAuthenticator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpiffeAuthenticator")
+            .field("socket", &self.config.workload_api_socket_path)
+            .field("trust_domain", &self.config.trust_domain)
+            .field("audience", &self.config.audience)
+            .field("sandbox_id_prefix", &self.config.sandbox_id_prefix)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SpiffeAuthenticator {
+    pub async fn new(config: SpiffeConfig) -> Result<Self, String> {
+        let endpoint = workload_api_endpoint(&config.workload_api_socket_path);
+        let client = WorkloadApiClient::connect_to(&endpoint)
+            .await
+            .map_err(|e| {
+                format!("failed to connect to SPIFFE Workload API endpoint {endpoint}: {e}")
+            })?;
+        info!(
+            socket = %config.workload_api_socket_path.display(),
+            trust_domain = %config.trust_domain,
+            audience = %config.audience,
+            "SPIFFE JWT-SVID sandbox authenticator enabled"
+        );
+        Ok(Self { client, config })
+    }
+
+    #[allow(clippy::result_large_err)]
+    async fn validate_bearer(&self, token: &str) -> Result<Option<Principal>, Status> {
+        let Some(candidate_id) = candidate_spiffe_id(token) else {
+            return Ok(None);
+        };
+        if parse_sandbox_id_from_spiffe_id(
+            &candidate_id,
+            &self.config.trust_domain,
+            &self.config.sandbox_id_prefix,
+        )
+        .is_none()
+        {
+            return Ok(None);
+        }
+
+        let svid = self
+            .client
+            .validate_jwt_token(&self.config.audience, token)
+            .await
+            .map_err(|status| {
+                debug!(error = %status, "SPIFFE JWT-SVID validation failed");
+                Status::unauthenticated("invalid SPIFFE JWT-SVID")
+            })?;
+
+        self.principal_from_validated_svid(&svid)
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn principal_from_validated_svid(&self, svid: &JwtSvid) -> Result<Option<Principal>, Status> {
+        let spiffe_id = svid.spiffe_id().to_string();
+        let Some(sandbox_id) = parse_sandbox_id_from_spiffe_id(
+            &spiffe_id,
+            &self.config.trust_domain,
+            &self.config.sandbox_id_prefix,
+        ) else {
+            warn!(
+                spiffe_id = %spiffe_id,
+                trust_domain = %self.config.trust_domain,
+                prefix = %self.config.sandbox_id_prefix,
+                "validated SPIFFE ID is outside the configured sandbox identity namespace"
+            );
+            return Err(Status::permission_denied(
+                "SPIFFE ID is not authorized as an OpenShell sandbox",
+            ));
+        };
+
+        Ok(Some(Principal::Sandbox(SandboxPrincipal {
+            sandbox_id,
+            source: SandboxIdentitySource::SpiffeSvid { spiffe_id },
+            trust_domain: Some(self.config.trust_domain.clone()),
+        })))
+    }
+}
+
+#[async_trait]
+impl Authenticator for SpiffeAuthenticator {
+    async fn authenticate(
+        &self,
+        headers: &http::HeaderMap,
+        _path: &str,
+    ) -> Result<Option<Principal>, Status> {
+        let Some(token) = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+        else {
+            return Ok(None);
+        };
+        self.validate_bearer(token).await
+    }
+}
+
+fn parse_sandbox_id_from_spiffe_id(
+    spiffe_id: &str,
+    trust_domain: &str,
+    sandbox_id_prefix: &str,
+) -> Option<String> {
+    let trust_domain = trust_domain.trim().trim_start_matches("spiffe://");
+    let prefix = format!(
+        "spiffe://{}{}",
+        trust_domain.trim_end_matches('/'),
+        normalize_spiffe_path_prefix(sandbox_id_prefix)
+    );
+    let sandbox_id = spiffe_id.strip_prefix(&prefix)?;
+    (!sandbox_id.is_empty() && !sandbox_id.contains('/')).then(|| sandbox_id.to_string())
+}
+
+fn normalize_spiffe_path_prefix(prefix: &str) -> String {
+    let trimmed = prefix.trim();
+    if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{trimmed}")
+    }
+}
+
+fn candidate_spiffe_id(jwt: &str) -> Option<String> {
+    JwtSvid::parse_insecure(jwt)
+        .ok()
+        .map(|svid| svid.spiffe_id().to_string())
+}
+
+fn workload_api_endpoint(path: &Path) -> String {
+    let path = path.to_string_lossy();
+    if path.starts_with("unix:") || path.starts_with("tcp:") {
+        path.into_owned()
+    } else {
+        format!("unix:{path}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_sandbox_id_from_configured_spiffe_id() {
+        assert_eq!(
+            parse_sandbox_id_from_spiffe_id(
+                "spiffe://openshell.local/openshell/sandbox/abc",
+                "openshell.local",
+                "/openshell/sandbox/",
+            )
+            .as_deref(),
+            Some("abc")
+        );
+    }
+
+    #[test]
+    fn rejects_spiffe_id_outside_sandbox_namespace() {
+        assert!(
+            parse_sandbox_id_from_spiffe_id(
+                "spiffe://openshell.local/ns/openshell/sa/default",
+                "openshell.local",
+                "/openshell/sandbox/",
+            )
+            .is_none()
+        );
+        assert!(
+            parse_sandbox_id_from_spiffe_id(
+                "spiffe://other.local/openshell/sandbox/abc",
+                "openshell.local",
+                "/openshell/sandbox/",
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn prefixes_plain_socket_paths_as_unix_endpoints() {
+        assert_eq!(
+            workload_api_endpoint(Path::new("/spiffe-workload-api/spire-agent.sock")),
+            "unix:/spiffe-workload-api/spire-agent.sock"
+        );
+        assert_eq!(
+            workload_api_endpoint(Path::new("unix:/tmp/spire.sock")),
+            "unix:/tmp/spire.sock"
+        );
+    }
+}

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -387,6 +387,12 @@ async fn run_from_args(mut args: RunArgs, matches: ArgMatches) -> Result<()> {
     } else if let Some(jwt) = local_jwt {
         config.gateway_jwt = Some(jwt);
     }
+    if let Some(spiffe) = file
+        .as_ref()
+        .and_then(|f| f.openshell.gateway.spiffe.clone())
+    {
+        config.spiffe = Some(spiffe);
+    }
 
     let vm_config = build_vm_config(
         file.as_ref(),
@@ -411,6 +417,10 @@ async fn run_from_args(mut args: RunArgs, matches: ArgMatches) -> Result<()> {
     if has_oidc {
         info!("OIDC authentication enabled");
     }
+    if config.spiffe.is_some() {
+        info!("SPIFFE sandbox authentication enabled");
+    }
+
     if config.auth.allow_unauthenticated_users {
         warn!(
             "Unauthenticated user access enabled — only use this for trusted local development or a fully trusted fronting proxy"
@@ -421,9 +431,10 @@ async fn run_from_args(mut args: RunArgs, matches: ArgMatches) -> Result<()> {
         && !config.mtls_auth.enabled
         && !has_oidc
         && config.gateway_jwt.is_none()
+        && config.spiffe.is_none()
     {
         warn!(
-            "Neither mTLS user auth nor OIDC nor sandbox JWT auth is configured — \
+            "Neither mTLS user auth nor OIDC nor sandbox JWT nor SPIFFE auth is configured — \
              the gateway has no authentication mechanism"
         );
     }

--- a/crates/openshell-server/src/config_file.rs
+++ b/crates/openshell-server/src/config_file.rs
@@ -25,7 +25,9 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
 use openshell_core::config::ComputeDriverKind;
-use openshell_core::{GatewayAuthConfig, GatewayJwtConfig, MtlsAuthConfig, OidcConfig, TlsConfig};
+use openshell_core::{
+    GatewayAuthConfig, GatewayJwtConfig, MtlsAuthConfig, OidcConfig, SpiffeConfig, TlsConfig,
+};
 use serde::{Deserialize, Serialize};
 
 /// Latest schema version this build understands.
@@ -146,6 +148,8 @@ pub struct GatewayFileSection {
     pub mtls_auth: Option<MtlsAuthConfig>,
     #[serde(default)]
     pub gateway_jwt: Option<GatewayJwtConfig>,
+    #[serde(default)]
+    pub spiffe: Option<SpiffeConfig>,
 
     // ── Disallowed-in-file fields ────────────────────────────────────────
     //
@@ -262,6 +266,10 @@ fn inheritable_keys(driver: ComputeDriverKind) -> &'static [&'static str] {
             "host_gateway_ip",
             "enable_user_namespaces",
             "sa_token_ttl_secs",
+            "spiffe_workload_api_socket_path",
+            "spiffe_trust_domain",
+            "spiffe_audience",
+            "spiffe_sandbox_id_prefix",
         ],
         ComputeDriverKind::Docker => &[
             "sandbox_namespace",
@@ -298,6 +306,22 @@ fn gateway_inherited_value(g: &GatewayFileSection, key: &str) -> Option<toml::Va
         "host_gateway_ip" => g.host_gateway_ip.as_deref().map(string_value),
         "enable_user_namespaces" => g.enable_user_namespaces.map(toml::Value::Boolean),
         "sa_token_ttl_secs" => g.sa_token_ttl_secs.map(toml::Value::Integer),
+        "spiffe_workload_api_socket_path" => g
+            .spiffe
+            .as_ref()
+            .map(|spiffe| path_value(&spiffe.workload_api_socket_path)),
+        "spiffe_trust_domain" => g
+            .spiffe
+            .as_ref()
+            .map(|spiffe| string_value(&spiffe.trust_domain)),
+        "spiffe_audience" => g
+            .spiffe
+            .as_ref()
+            .map(|spiffe| string_value(&spiffe.audience)),
+        "spiffe_sandbox_id_prefix" => g
+            .spiffe
+            .as_ref()
+            .map(|spiffe| string_value(&spiffe.sandbox_id_prefix)),
         "guest_tls_ca" => g.guest_tls_ca.as_deref().map(path_value),
         "guest_tls_cert" => g.guest_tls_cert.as_deref().map(path_value),
         "guest_tls_key" => g.guest_tls_key.as_deref().map(path_value),

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -558,6 +558,7 @@ pub(super) async fn compute_provider_env_revision(
                     Status::internal(format!("decode provider '{provider_name}' failed: {e}"))
                 })?;
                 hasher.update(provider.r#type.as_bytes());
+                hash_provider_profile_revision(store, &provider.r#type, &mut hasher).await?;
 
                 let mut credential_keys: Vec<_> = provider.credentials.keys().collect();
                 credential_keys.sort();
@@ -581,6 +582,41 @@ pub(super) async fn compute_provider_env_revision(
     Ok(u64::from_le_bytes(digest[..8].try_into().map_err(
         |_| Status::internal("provider env revision digest too short"),
     )?))
+}
+
+async fn hash_provider_profile_revision(
+    store: &Store,
+    provider_type: &str,
+    hasher: &mut Sha256,
+) -> Result<(), Status> {
+    if get_default_profile(provider_type).is_some() {
+        hasher.update(b"builtin-profile");
+        hasher.update(provider_type.as_bytes());
+        return Ok(());
+    }
+
+    hasher.update(b"custom-profile");
+    match store
+        .get_by_name(
+            openshell_core::proto::StoredProviderProfile::object_type(),
+            provider_type,
+        )
+        .await
+        .map_err(|e| {
+            Status::internal(format!(
+                "fetch provider profile '{provider_type}' failed: {e}"
+            ))
+        })? {
+        Some(record) => {
+            hasher.update(record.id.as_bytes());
+            hasher.update(record.updated_at_ms.to_le_bytes());
+            hasher.update(record.payload.as_slice());
+        }
+        None => {
+            hasher.update(b"missing");
+        }
+    }
+    Ok(())
 }
 
 async fn profile_provider_policy_layers(
@@ -691,6 +727,7 @@ pub(super) async fn handle_get_sandbox_provider_environment(
         environment: provider_environment.environment,
         provider_env_revision,
         credential_expires_at_ms: provider_environment.credential_expires_at_ms,
+        dynamic_credentials: provider_environment.dynamic_credentials,
     }))
 }
 
@@ -3936,6 +3973,88 @@ mod tests {
         assert_eq!(
             second.environment.get("GITHUB_TOKEN"),
             Some(&"rotated".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_env_revision_changes_when_custom_profile_token_grant_changes() {
+        use openshell_core::proto::{
+            ProviderCredentialTokenGrant, ProviderProfile, ProviderProfileCategory,
+            ProviderProfileCredential, StoredProviderProfile,
+        };
+        use std::time::Duration;
+
+        fn token_grant_profile(token_endpoint: &str) -> StoredProviderProfile {
+            StoredProviderProfile {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: "profile-custom-token".to_string(),
+                    name: "custom-token".to_string(),
+                    created_at_ms: 1_000_000,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                }),
+                profile: Some(ProviderProfile {
+                    id: "custom-token".to_string(),
+                    display_name: "Custom Token".to_string(),
+                    description: String::new(),
+                    category: ProviderProfileCategory::Other as i32,
+                    credentials: vec![ProviderProfileCredential {
+                        name: "access_token".to_string(),
+                        auth_style: "bearer".to_string(),
+                        header_name: "authorization".to_string(),
+                        token_grant: Some(ProviderCredentialTokenGrant {
+                            token_endpoint: token_endpoint.to_string(),
+                            audience: "api://default".to_string(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }],
+                    endpoints: vec![NetworkEndpoint {
+                        host: "api.custom.example".to_string(),
+                        port: 443,
+                        ..Default::default()
+                    }],
+                    binaries: Vec::new(),
+                    inference_capable: false,
+                    discovery: None,
+                }),
+            }
+        }
+
+        let state = test_server_state().await;
+        state
+            .store
+            .put_message(&test_provider("work-custom-token", "custom-token"))
+            .await
+            .unwrap();
+        state
+            .store
+            .put_message(&token_grant_profile("https://auth.example.com/token"))
+            .await
+            .unwrap();
+
+        let first =
+            compute_provider_env_revision(state.store.as_ref(), &["work-custom-token".to_string()])
+                .await
+                .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        state
+            .store
+            .put_message(&token_grant_profile(
+                "https://auth.example.com/rotated-token",
+            ))
+            .await
+            .unwrap();
+
+        let second =
+            compute_provider_env_revision(state.store.as_ref(), &["work-custom-token".to_string()])
+                .await
+                .unwrap();
+
+        assert_ne!(
+            first, second,
+            "custom provider profile updates must trigger sandbox dynamic credential refresh"
         );
     }
 

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -8,7 +8,10 @@
 use crate::persistence::{
     ObjectId, ObjectLabels, ObjectName, ObjectType, Store, WriteCondition, generate_name,
 };
-use openshell_core::proto::{Provider, Sandbox};
+use openshell_core::proto::{
+    Provider, ProviderCredentialTokenGrantAudienceOverride, ProviderProfile,
+    ProviderProfileCredential, Sandbox,
+};
 use prost::Message;
 use tonic::Status;
 use tracing::warn;
@@ -33,10 +36,11 @@ fn redact_provider_credentials(mut provider: Provider) -> Provider {
     provider
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub(super) struct ProviderEnvironment {
     pub environment: std::collections::HashMap<String, String>,
     pub credential_expires_at_ms: std::collections::HashMap<String, i64>,
+    pub dynamic_credentials: std::collections::HashMap<String, ProviderProfileCredential>,
 }
 
 impl ProviderEnvironment {
@@ -472,7 +476,218 @@ pub(super) async fn resolve_provider_environment(
     Ok(ProviderEnvironment {
         environment: env,
         credential_expires_at_ms: expires,
+        dynamic_credentials: resolve_dynamic_credentials(store, provider_names).await?,
     })
+}
+
+/// Resolve dynamic credentials (token grants) from provider profiles.
+///
+/// Returns a map of endpoint-bound keys to credential metadata for credentials
+/// that have `token_grant` configuration. Keys are internal supervisor metadata:
+/// host, port, endpoint path, and provider credential identity.
+pub(super) async fn resolve_dynamic_credentials(
+    store: &Store,
+    provider_names: &[String],
+) -> Result<std::collections::HashMap<String, ProviderProfileCredential>, Status> {
+    if provider_names.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+
+    let mut dynamic_creds = std::collections::HashMap::new();
+
+    for provider_name in provider_names {
+        let provider = store
+            .get_message_by_name::<Provider>(provider_name)
+            .await
+            .map_err(|e| {
+                Status::internal(format!("failed to fetch provider '{provider_name}': {e}"))
+            })?
+            .ok_or_else(|| {
+                Status::failed_precondition(format!("provider '{provider_name}' not found"))
+            })?;
+
+        let profile_id = openshell_providers::normalize_provider_type(&provider.r#type)
+            .unwrap_or(provider.r#type.as_str());
+        let Some(profile) = get_provider_type_profile(store, profile_id).await? else {
+            continue;
+        };
+
+        insert_dynamic_credentials_for_profile(
+            &mut dynamic_creds,
+            &profile.to_proto(),
+            provider_name,
+        );
+    }
+
+    Ok(dynamic_creds)
+}
+
+fn insert_dynamic_credentials_for_profile(
+    dynamic_creds: &mut std::collections::HashMap<String, ProviderProfileCredential>,
+    profile: &ProviderProfile,
+    provider_name: &str,
+) {
+    for credential in &profile.credentials {
+        if credential.token_grant.is_none() {
+            continue;
+        }
+        for endpoint in &profile.endpoints {
+            for port in endpoint_ports(endpoint.port, &endpoint.ports) {
+                insert_dynamic_credentials_for_endpoint(
+                    dynamic_creds,
+                    &endpoint.host,
+                    port,
+                    &endpoint.path,
+                    provider_name,
+                    &credential.name,
+                    credential,
+                );
+            }
+        }
+    }
+}
+
+fn endpoint_ports(port: u32, ports: &[u32]) -> Vec<u32> {
+    if ports.is_empty() {
+        if port == 0 { Vec::new() } else { vec![port] }
+    } else {
+        ports.iter().copied().filter(|port| *port != 0).collect()
+    }
+}
+
+fn dynamic_credential_key(
+    host: &str,
+    port: u32,
+    path: &str,
+    provider_name: &str,
+    credential_name: &str,
+) -> String {
+    format!(
+        "{}\t{port}\t{}\t{}:{}",
+        host.to_ascii_lowercase(),
+        path,
+        provider_name,
+        credential_name
+    )
+}
+
+fn insert_dynamic_credentials_for_endpoint(
+    dynamic_creds: &mut std::collections::HashMap<String, ProviderProfileCredential>,
+    endpoint_host: &str,
+    endpoint_port: u32,
+    endpoint_path: &str,
+    provider_name: &str,
+    credential_name: &str,
+    credential: &ProviderProfileCredential,
+) {
+    let default_key = dynamic_credential_key(
+        endpoint_host,
+        endpoint_port,
+        endpoint_path,
+        provider_name,
+        credential_name,
+    );
+    dynamic_creds.insert(default_key, resolved_dynamic_credential(credential, None));
+
+    let Some(token_grant) = credential.token_grant.as_ref() else {
+        return;
+    };
+
+    for override_config in &token_grant.audience_overrides {
+        if !token_grant_override_matches_endpoint(override_config, endpoint_host, endpoint_port) {
+            continue;
+        }
+
+        let override_host = if override_config.host.is_empty() {
+            endpoint_host
+        } else {
+            override_config.host.as_str()
+        };
+        let override_port = if override_config.port == 0 {
+            endpoint_port
+        } else {
+            override_config.port
+        };
+        let override_path = if override_config.path.is_empty() {
+            endpoint_path
+        } else {
+            override_config.path.as_str()
+        };
+        let override_key = dynamic_credential_key(
+            override_host,
+            override_port,
+            override_path,
+            provider_name,
+            credential_name,
+        );
+        dynamic_creds.insert(
+            override_key,
+            resolved_dynamic_credential(credential, Some(override_config)),
+        );
+    }
+}
+
+fn resolved_dynamic_credential(
+    credential: &ProviderProfileCredential,
+    override_config: Option<&ProviderCredentialTokenGrantAudienceOverride>,
+) -> ProviderProfileCredential {
+    let mut credential = credential.clone();
+    if let Some(token_grant) = credential.token_grant.as_mut() {
+        if let Some(override_config) = override_config {
+            if !override_config.audience.is_empty() {
+                token_grant.audience.clone_from(&override_config.audience);
+            }
+            if !override_config.scopes.is_empty() {
+                token_grant.scopes.clone_from(&override_config.scopes);
+            }
+        }
+        token_grant.audience_overrides.clear();
+    }
+    credential
+}
+
+fn token_grant_override_matches_endpoint(
+    override_config: &ProviderCredentialTokenGrantAudienceOverride,
+    endpoint_host: &str,
+    endpoint_port: u32,
+) -> bool {
+    let host_matches = override_config.host.is_empty()
+        || host_pattern_matches(&override_config.host, endpoint_host)
+        || host_pattern_matches(endpoint_host, &override_config.host);
+    let port_matches = override_config.port == 0 || override_config.port == endpoint_port;
+    host_matches && port_matches
+}
+
+fn host_pattern_matches(pattern: &str, host: &str) -> bool {
+    let pattern = pattern.to_ascii_lowercase();
+    let host = host.to_ascii_lowercase();
+    if pattern == host {
+        return true;
+    }
+    if !pattern.contains('*') {
+        return false;
+    }
+
+    let pattern_labels: Vec<&str> = pattern.split('.').collect();
+    let host_labels: Vec<&str> = host.split('.').collect();
+    host_pattern_labels_match(&pattern_labels, &host_labels)
+}
+
+fn host_pattern_labels_match(pattern: &[&str], host: &[&str]) -> bool {
+    match pattern.split_first() {
+        None => host.is_empty(),
+        Some((label, rest)) if *label == "**" => {
+            host_pattern_labels_match(rest, host)
+                || (!host.is_empty() && host_pattern_labels_match(pattern, &host[1..]))
+        }
+        Some((label, rest)) if *label == "*" => {
+            !host.is_empty() && host_pattern_labels_match(rest, &host[1..])
+        }
+        Some((literal, rest)) => {
+            host.first().is_some_and(|label| label == literal)
+                && host_pattern_labels_match(rest, &host[1..])
+        }
+    }
 }
 
 pub async fn validate_provider_environment_keys_unique(
@@ -632,10 +847,9 @@ use openshell_core::proto::{
     GetProviderRequest, ImportProviderProfilesRequest, ImportProviderProfilesResponse,
     LintProviderProfilesRequest, LintProviderProfilesResponse, ListProviderProfilesRequest,
     ListProviderProfilesResponse, ListProvidersRequest, ListProvidersResponse,
-    ProviderCredentialRefreshStrategy, ProviderProfile, ProviderProfileDiagnostic,
-    ProviderProfileImportItem, ProviderProfileResponse, ProviderResponse,
-    RotateProviderCredentialRequest, RotateProviderCredentialResponse, StoredProviderProfile,
-    UpdateProviderRequest,
+    ProviderCredentialRefreshStrategy, ProviderProfileDiagnostic, ProviderProfileImportItem,
+    ProviderProfileResponse, ProviderResponse, RotateProviderCredentialRequest,
+    RotateProviderCredentialResponse, StoredProviderProfile, UpdateProviderRequest,
 };
 use openshell_providers::{
     CredentialRefreshProfile, ProfileValidationDiagnostic, ProviderTypeProfile, default_profiles,
@@ -1455,6 +1669,7 @@ mod tests {
         DeleteProviderProfileRequest, GetProviderProfileRequest, ImportProviderProfilesRequest,
         L7Allow, L7Rule, LintProviderProfilesRequest, ListProviderProfilesRequest, NetworkBinary,
         NetworkEndpoint, ProviderCredentialRefresh, ProviderCredentialRefreshMaterial,
+        ProviderCredentialTokenGrant, ProviderCredentialTokenGrantAudienceOverride,
         ProviderProfile, ProviderProfileCategory, ProviderProfileCredential,
         ProviderProfileImportItem, Sandbox, SandboxSpec,
     };
@@ -1477,6 +1692,76 @@ mod tests {
         assert!(!is_valid_env_key("BAD KEY"));
         assert!(!is_valid_env_key("X=Y"));
         assert!(!is_valid_env_key("X;rm -rf /"));
+    }
+
+    #[test]
+    fn dynamic_credentials_expand_endpoint_audience_overrides() {
+        let service_audiences = [
+            ("alpha.default.svc.cluster.local", "alpha"),
+            ("beta.default.svc.cluster.local", "beta"),
+            ("gamma.default.svc.cluster.local", "gamma"),
+            ("delta.default.svc.cluster.local", "delta"),
+        ];
+        let credential = ProviderProfileCredential {
+            name: "access_token".to_string(),
+            description: String::new(),
+            env_vars: Vec::new(),
+            required: false,
+            auth_style: "bearer".to_string(),
+            header_name: "Authorization".to_string(),
+            query_param: String::new(),
+            refresh: None,
+            token_grant: Some(ProviderCredentialTokenGrant {
+                token_endpoint: "http://keycloak/realms/openshell/protocol/openid-connect/token"
+                    .to_string(),
+                audience: "api://default".to_string(),
+                jwt_svid_audience: "http://keycloak/realms/openshell".to_string(),
+                scopes: vec!["openid".to_string()],
+                cache_ttl_seconds: 300,
+                audience_overrides: service_audiences
+                    .iter()
+                    .map(
+                        |(host, audience)| ProviderCredentialTokenGrantAudienceOverride {
+                            host: (*host).to_string(),
+                            port: 80,
+                            path: String::new(),
+                            audience: (*audience).to_string(),
+                            scopes: vec![(*audience).to_string()],
+                        },
+                    )
+                    .collect(),
+            }),
+        };
+        let profile = ProviderProfile {
+            id: "keycloak-sso".to_string(),
+            display_name: "Keycloak SSO".to_string(),
+            description: String::new(),
+            category: ProviderProfileCategory::Other as i32,
+            credentials: vec![credential],
+            endpoints: service_audiences
+                .iter()
+                .map(|(host, _)| NetworkEndpoint {
+                    host: (*host).to_string(),
+                    port: 80,
+                    ..Default::default()
+                })
+                .collect(),
+            binaries: Vec::new(),
+            inference_capable: false,
+            discovery: None,
+        };
+
+        let mut dynamic_creds = HashMap::new();
+        insert_dynamic_credentials_for_profile(&mut dynamic_creds, &profile, "keycloak");
+
+        assert_eq!(dynamic_creds.len(), 4);
+        for (host, audience) in service_audiences {
+            let key = dynamic_credential_key(host, 80, "", "keycloak", "access_token");
+            let grant = dynamic_creds[&key].token_grant.as_ref().unwrap();
+            assert_eq!(grant.audience, audience);
+            assert_eq!(grant.scopes, vec![audience.to_string()]);
+            assert!(grant.audience_overrides.is_empty());
+        }
     }
 
     fn provider_with_values(name: &str, provider_type: &str) -> Provider {
@@ -1559,6 +1844,7 @@ mod tests {
                     },
                 ],
             }),
+            token_grant: None,
         }
     }
 
@@ -1595,6 +1881,7 @@ mod tests {
             header_name: "authorization".to_string(),
             query_param: String::new(),
             refresh: None,
+            token_grant: None,
         }
     }
 
@@ -2949,6 +3236,7 @@ mod tests {
                                     },
                                 ],
                             }),
+                            token_grant: None,
                         }],
                         endpoints: vec![],
                         binaries: vec![],
@@ -3307,6 +3595,24 @@ mod tests {
         assert_eq!(result.get("ANTHROPIC_API_KEY"), Some(&"sk-abc".to_string()));
         assert_eq!(result.get("CLAUDE_API_KEY"), Some(&"sk-abc".to_string()));
         assert!(!result.contains_key("endpoint"));
+    }
+
+    #[tokio::test]
+    async fn resolve_provider_env_allows_static_provider_without_profile() {
+        let store = test_store().await;
+        create_provider_record(
+            &store,
+            provider_with_values("static-provider", "unprofiled-static-api"),
+        )
+        .await
+        .unwrap();
+
+        let result = resolve_provider_environment(&store, &["static-provider".to_string()])
+            .await
+            .unwrap();
+
+        assert_eq!(result.get("API_TOKEN"), Some(&"token-123".to_string()));
+        assert!(result.dynamic_credentials.is_empty());
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -123,6 +123,10 @@ pub struct ServerState {
     /// presenting a freshly minted token are recognized.
     pub sandbox_jwt_authenticator: Option<Arc<auth::sandbox_jwt::SandboxJwtAuthenticator>>,
 
+    /// Authenticator that validates SPIFFE JWT-SVIDs through the local SPIFFE
+    /// Workload API and maps authorized SPIFFE IDs to sandbox principals.
+    pub spiffe_authenticator: Option<Arc<auth::spiffe::SpiffeAuthenticator>>,
+
     /// Optional K8s `ServiceAccount` authenticator that backs the
     /// `IssueSandboxToken` bootstrap path. Only present when the gateway
     /// runs in-cluster.
@@ -173,6 +177,7 @@ impl ServerState {
             oidc_cache,
             sandbox_jwt_issuer: None,
             sandbox_jwt_authenticator: None,
+            spiffe_authenticator: None,
             k8s_sa_authenticator: None,
         }
     }
@@ -291,6 +296,13 @@ pub async fn run_server(
         );
         state.sandbox_jwt_issuer = Some(Arc::new(issuer));
         state.sandbox_jwt_authenticator = Some(Arc::new(authenticator));
+    }
+
+    if let Some(ref spiffe) = config.spiffe {
+        let authenticator = auth::spiffe::SpiffeAuthenticator::new(spiffe.clone())
+            .await
+            .map_err(|e| Error::config(format!("SPIFFE initialization failed: {e}")))?;
+        state.spiffe_authenticator = Some(Arc::new(authenticator));
     }
 
     // K8s ServiceAccount bootstrap authenticator. Only constructed when

--- a/crates/openshell-server/src/multiplex.rs
+++ b/crates/openshell-server/src/multiplex.rs
@@ -273,7 +273,10 @@ where
 ///    other path; only present when the gateway runs in-cluster.
 /// 2. `SandboxJwtAuthenticator` — validates gateway-minted JWTs. Recognized
 ///    via a distinctive `kid` so non-matching Bearer tokens fall through.
-/// 3. `OidcAuthenticator` — validates user Bearer tokens against the
+/// 3. `SpiffeAuthenticator` — validates SPIFFE JWT-SVIDs through the
+///    local SPIFFE Workload API and maps sandbox SPIFFE IDs to
+///    `Principal::Sandbox`.
+/// 4. `OidcAuthenticator` — validates user Bearer tokens against the
 ///    configured OIDC issuer. Returns `Unauthenticated` for missing
 ///    Bearer headers so non-OIDC clients can't sneak through.
 ///
@@ -283,9 +286,9 @@ where
 /// for local single-user gateways, or to an unsafe local developer user when
 /// `auth.allow_unauthenticated_users` is explicitly enabled.
 ///
-/// When neither OIDC nor gateway-minted JWTs are configured (a barebones
+/// When neither OIDC nor sandbox credentials are configured (a barebones
 /// dev gateway), the chain is left as `None` so the router short-circuits
-/// to pass-through.
+/// to pass-through unless mTLS or local unauthenticated users are enabled.
 fn build_authenticator_chain(state: &ServerState) -> Option<AuthenticatorChain> {
     let mut authenticators: Vec<Arc<dyn crate::auth::authenticator::Authenticator>> = Vec::new();
     if let Some(k8s) = state.k8s_sa_authenticator.clone() {
@@ -293,6 +296,9 @@ fn build_authenticator_chain(state: &ServerState) -> Option<AuthenticatorChain> 
     }
     if let Some(jwt) = state.sandbox_jwt_authenticator.clone() {
         authenticators.push(jwt);
+    }
+    if let Some(spiffe) = state.spiffe_authenticator.clone() {
+        authenticators.push(spiffe);
     }
     if let Some(cache) = state.oidc_cache.clone() {
         authenticators.push(Arc::new(OidcAuthenticator::new(cache)));
@@ -368,19 +374,13 @@ fn unauthenticated_dev_user_principal() -> Principal {
     })
 }
 
-fn status_response(status: tonic::Status) -> Response<tonic::body::BoxBody> {
-    let response = status.into_http();
-    let (parts, body) = response.into_parts();
-    let body = tonic::body::BoxBody::new(body);
-    Response::from_parts(parts, body)
+fn status_response(status: tonic::Status) -> Response<tonic::body::Body> {
+    status.into_http()
 }
 
 impl<S, B> tower::Service<Request<B>> for AuthGrpcRouter<S>
 where
-    S: tower::Service<Request<B>, Response = Response<tonic::body::BoxBody>>
-        + Clone
-        + Send
-        + 'static,
+    S: tower::Service<Request<B>, Response = Response<tonic::body::Body>> + Clone + Send + 'static,
     S::Future: Send,
     S::Error: Send + Into<Box<dyn std::error::Error + Send + Sync>>,
     B: Send + 'static,
@@ -938,7 +938,7 @@ mod tests {
         }
 
         impl<B: Send + 'static> Service<Request<B>> for PrincipalRecorder {
-            type Response = Response<tonic::body::BoxBody>;
+            type Response = Response<tonic::body::Body>;
             type Error = std::convert::Infallible;
             type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
@@ -949,14 +949,7 @@ mod tests {
             fn call(&mut self, req: Request<B>) -> Self::Future {
                 let principal = req.extensions().get::<Principal>().cloned();
                 *self.recorded.lock().unwrap() = principal;
-                Box::pin(async move {
-                    let body = tonic::body::BoxBody::new(
-                        Full::new(Bytes::new())
-                            .map_err(|never| match never {})
-                            .boxed_unsync(),
-                    );
-                    Ok(Response::new(body))
-                })
+                Box::pin(async move { Ok(Response::new(tonic::body::Body::empty())) })
             }
         }
 

--- a/crates/openshell-tui/Cargo.toml
+++ b/crates/openshell-tui/Cargo.toml
@@ -21,7 +21,7 @@ ratatui = { workspace = true }
 crossterm = { workspace = true }
 terminal-colorsaurus = { workspace = true }
 tokio = { workspace = true }
-tonic = { workspace = true, features = ["tls"] }
+tonic = { workspace = true, features = ["tls-native-roots"] }
 miette = { workspace = true }
 owo-colors = { workspace = true }
 serde = { workspace = true }

--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -57,6 +57,8 @@ See [`values.yaml`](values.yaml) for source defaults. Selected overlays:
 - [`ci/values-gateway.yaml`](ci/values-gateway.yaml) - gateway-only configuration
 - [`ci/values-cert-manager.yaml`](ci/values-cert-manager.yaml) - cert-manager integration
 - [`ci/values-keycloak.yaml`](ci/values-keycloak.yaml) - Keycloak OIDC integration
+- [`ci/values-spire.yaml`](ci/values-spire.yaml) - SPIFFE/SPIRE sandbox supervisor authentication
+- [`ci/values-spire-stack.yaml`](ci/values-spire-stack.yaml) - SPIRE hardened chart values for local development
 
 ## PKI bootstrap
 
@@ -74,6 +76,16 @@ The Job is idempotent:
 Disable with `--set pkiInitJob.enabled=false` when bringing your own PKI (cert-manager,
 external CA, or pre-created Secrets). See `certManager.*` in `values.yaml` for the
 cert-manager alternative.
+
+## SPIFFE/SPIRE sandbox identity
+
+Set `server.spiffe.enabled=true` to use SPIFFE JWT-SVIDs for sandbox supervisor
+authentication instead of gateway-minted sandbox JWTs. The chart mounts the
+SPIFFE CSI Workload API socket into the gateway pod and configures sandbox pods
+to request `spiffe://<trust-domain>/openshell/sandbox/<sandbox-id>` JWT-SVIDs.
+
+For local development, uncomment the SPIRE Helm releases in `skaffold.yaml` and
+add `ci/values-spire.yaml` to the OpenShell release values files.
 
 ## Values
 
@@ -154,6 +166,11 @@ cert-manager alternative.
 | server.sandboxJwt.signingSecretName | string | `""` | Name of the Opaque Secret holding the signing key material. Empty falls back to the chart fullname with "-jwt-keys" appended. |
 | server.sandboxJwt.ttlSecs | int | `3600` | Token TTL in seconds. Defaults to 3600 (1h). |
 | server.sandboxNamespace | string | `""` | Namespace where sandbox pods are created. Defaults to the Helm release namespace (.Release.Namespace) when left empty. |
+| server.spiffe.audience | string | `"openshell-gateway"` |  |
+| server.spiffe.enabled | bool | `false` |  |
+| server.spiffe.sandboxIdPrefix | string | `"/openshell/sandbox/"` |  |
+| server.spiffe.trustDomain | string | `"openshell.local"` |  |
+| server.spiffe.workloadApiSocketPath | string | `"/spiffe-workload-api/spire-agent.sock"` |  |
 | server.tls.certSecretName | string | `"openshell-server-tls"` | K8s secret (type kubernetes.io/tls) with tls.crt and tls.key for the server. |
 | server.tls.clientCaSecretName | string | `"openshell-server-client-ca"` | K8s secret with ca.crt for client certificate verification (mTLS). Set to "" to disable mTLS and run HTTPS-only (use OIDC for auth instead). |
 | server.tls.clientTlsSecretName | string | `"openshell-client-tls"` | K8s secret mounted into sandbox pods for mTLS to the server. |

--- a/deploy/helm/openshell/README.md.gotmpl
+++ b/deploy/helm/openshell/README.md.gotmpl
@@ -57,6 +57,8 @@ See [`values.yaml`](values.yaml) for source defaults. Selected overlays:
 - [`ci/values-gateway.yaml`](ci/values-gateway.yaml) - gateway-only configuration
 - [`ci/values-cert-manager.yaml`](ci/values-cert-manager.yaml) - cert-manager integration
 - [`ci/values-keycloak.yaml`](ci/values-keycloak.yaml) - Keycloak OIDC integration
+- [`ci/values-spire.yaml`](ci/values-spire.yaml) - SPIFFE/SPIRE sandbox supervisor authentication
+- [`ci/values-spire-stack.yaml`](ci/values-spire-stack.yaml) - SPIRE hardened chart values for local development
 
 ## PKI bootstrap
 
@@ -74,6 +76,16 @@ The Job is idempotent:
 Disable with `--set pkiInitJob.enabled=false` when bringing your own PKI (cert-manager,
 external CA, or pre-created Secrets). See `certManager.*` in `values.yaml` for the
 cert-manager alternative.
+
+## SPIFFE/SPIRE sandbox identity
+
+Set `server.spiffe.enabled=true` to use SPIFFE JWT-SVIDs for sandbox supervisor
+authentication instead of gateway-minted sandbox JWTs. The chart mounts the
+SPIFFE CSI Workload API socket into the gateway pod and configures sandbox pods
+to request `spiffe://<trust-domain>/openshell/sandbox/<sandbox-id>` JWT-SVIDs.
+
+For local development, uncomment the SPIRE Helm releases in `skaffold.yaml` and
+add `ci/values-spire.yaml` to the OpenShell release values files.
 
 {{ template "chart.valuesSection" . }}
 {{ template "helm-docs.versionFooter" . }}

--- a/deploy/helm/openshell/ci/values-spire-stack.yaml
+++ b/deploy/helm/openshell/ci/values-spire-stack.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# SPIRE hardened chart values for the local Helm dev environment.
+global:
+  spire:
+    clusterName: openshell-dev
+    trustDomain: openshell.local
+
+spire-server:
+  controllerManager:
+    identities:
+      clusterSPIFFEIDs:
+        openshell-sandboxes:
+          enabled: true
+          spiffeIDTemplate: 'spiffe://{{ .TrustDomain }}/openshell/sandbox/{{ index .PodMeta.Annotations "openshell.io/sandbox-id" }}'
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshell
+          podSelector:
+            matchLabels:
+              openshell.ai/managed-by: openshell

--- a/deploy/helm/openshell/ci/values-spire-stack.yaml
+++ b/deploy/helm/openshell/ci/values-spire-stack.yaml
@@ -5,9 +5,11 @@
 global:
   spire:
     clusterName: openshell-dev
+    jwtIssuer: https://spire-spiffe-oidc-discovery-provider.spire.svc.cluster.local
     trustDomain: openshell.local
 
 spire-server:
+  defaultJwtSvidTTL: 5m
   controllerManager:
     identities:
       clusterSPIFFEIDs:

--- a/deploy/helm/openshell/ci/values-spire.yaml
+++ b/deploy/helm/openshell/ci/values-spire.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# OpenShell overlay for local SPIRE-backed supervisor authentication.
+server:
+  spiffe:
+    enabled: true
+    trustDomain: openshell.local
+    audience: openshell-gateway
+    workloadApiSocketPath: /spiffe-workload-api/spire-agent.sock
+    sandboxIdPrefix: /openshell/sandbox/

--- a/deploy/helm/openshell/skaffold.yaml
+++ b/deploy/helm/openshell/skaffold.yaml
@@ -79,6 +79,24 @@ deploy:
       #  # wait ensures Gateway API CRDs are registered before the openshell
       #  # release attempts to create Gateway and HTTPRoute resources.
       #  wait: true
+      # SPIRE — installs SPIRE Server, Agent, Controller Manager, CSI Driver,
+      # and OIDC Discovery Provider using the SPIFFE hardened charts.
+      # Uncomment both releases and ci/values-spire.yaml below to use
+      # SPIFFE JWT-SVIDs for sandbox supervisor authentication.
+      #- name: spire-crds
+      #  repo: https://spiffe.github.io/helm-charts-hardened/
+      #  remoteChart: spire-crds
+      #  namespace: spire
+      #  createNamespace: true
+      #  wait: true
+      #- name: spire
+      #  repo: https://spiffe.github.io/helm-charts-hardened/
+      #  remoteChart: spire
+      #  namespace: spire
+      #  createNamespace: true
+      #  valuesFiles:
+      #    - ci/values-spire-stack.yaml
+      #  wait: true
       - name: openshell
         chartPath: .
         namespace: openshell
@@ -95,6 +113,9 @@ deploy:
           #- ci/values-keycloak.yaml
           # To enable the Gateway API HTTPRoute (requires Envoy Gateway above):
           #- ci/values-gateway.yaml
+          # To enable SPIFFE/SPIRE sandbox supervisor authentication (requires
+          # the spire-crds and spire releases above):
+          #- ci/values-spire.yaml
         setValueTemplates:
           image.repository: '{{.IMAGE_REPO_openshell_gateway}}'
           image.tag: '{{.IMAGE_TAG_openshell_gateway}}'

--- a/deploy/helm/openshell/templates/_helpers.tpl
+++ b/deploy/helm/openshell/templates/_helpers.tpl
@@ -136,3 +136,11 @@ init-container
 {{- printf "%s://%s.%s.svc.cluster.local:%d" $scheme (include "openshell.fullname" .) .Release.Namespace (int .Values.service.port) -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Directory mounted for the SPIFFE Workload API CSI volume. The socket itself
+lives at server.spiffe.workloadApiSocketPath.
+*/}}
+{{- define "openshell.spiffeWorkloadApiMountPath" -}}
+{{- dir .Values.server.spiffe.workloadApiSocketPath -}}
+{{- end }}

--- a/deploy/helm/openshell/templates/gateway-config.yaml
+++ b/deploy/helm/openshell/templates/gateway-config.yaml
@@ -67,12 +67,20 @@ data:
     allow_unauthenticated_users = true
     {{- end }}
 
+    {{- if .Values.server.spiffe.enabled }}
+    [openshell.gateway.spiffe]
+    workload_api_socket_path = {{ .Values.server.spiffe.workloadApiSocketPath | quote }}
+    trust_domain             = {{ .Values.server.spiffe.trustDomain | quote }}
+    audience                 = {{ .Values.server.spiffe.audience | quote }}
+    sandbox_id_prefix        = {{ .Values.server.spiffe.sandboxIdPrefix | quote }}
+    {{- else }}
     [openshell.gateway.gateway_jwt]
     signing_key_path = "/etc/openshell-jwt/signing.pem"
     public_key_path  = "/etc/openshell-jwt/public.pem"
     kid_path         = "/etc/openshell-jwt/kid"
     gateway_id       = {{ .Values.server.sandboxJwt.gatewayId | default (include "openshell.fullname" .) | quote }}
     ttl_secs         = {{ .Values.server.sandboxJwt.ttlSecs | default 3600 }}
+    {{- end }}
 
     {{- if .Values.server.oidc.issuer }}
 
@@ -98,7 +106,14 @@ data:
     grpc_endpoint                = {{ include "openshell.grpcEndpoint" . | quote }}
     service_account_name         = {{ include "openshell.sandboxServiceAccountName" . | quote }}
     supervisor_sideload_method   = {{ include "openshell.supervisorSideloadMethod" . | quote }}
+    {{- if .Values.server.spiffe.enabled }}
+    spiffe_workload_api_socket_path = {{ .Values.server.spiffe.workloadApiSocketPath | quote }}
+    spiffe_trust_domain             = {{ .Values.server.spiffe.trustDomain | quote }}
+    spiffe_audience                 = {{ .Values.server.spiffe.audience | quote }}
+    spiffe_sandbox_id_prefix        = {{ .Values.server.spiffe.sandboxIdPrefix | quote }}
+    {{- else }}
     sa_token_ttl_secs            = {{ .Values.server.sandboxJwt.k8sSaTokenTtlSecs | default 3600 }}
+    {{- end }}
     {{- if .Values.server.sandboxImagePullPolicy }}
     image_pull_policy            = {{ .Values.server.sandboxImagePullPolicy | quote }}
     {{- end }}

--- a/deploy/helm/openshell/templates/statefulset.yaml
+++ b/deploy/helm/openshell/templates/statefulset.yaml
@@ -75,9 +75,15 @@ spec:
             - name: gateway-config
               mountPath: /etc/openshell
               readOnly: true
+            {{- if .Values.server.spiffe.enabled }}
+            - name: spiffe-workload-api
+              mountPath: {{ include "openshell.spiffeWorkloadApiMountPath" . | quote }}
+              readOnly: true
+            {{- else }}
             - name: sandbox-jwt
               mountPath: /etc/openshell-jwt
               readOnly: true
+            {{- end }}
             {{- if not .Values.server.disableTls }}
             - name: tls-cert
               mountPath: /etc/openshell-tls/server
@@ -134,10 +140,17 @@ spec:
         - name: gateway-config
           configMap:
             name: {{ include "openshell.fullname" . }}-config
+        {{- if .Values.server.spiffe.enabled }}
+        - name: spiffe-workload-api
+          csi:
+            driver: csi.spiffe.io
+            readOnly: true
+        {{- else }}
         - name: sandbox-jwt
           secret:
             secretName: {{ .Values.server.sandboxJwt.signingSecretName | default (printf "%s-jwt-keys" (include "openshell.fullname" .)) }}
             defaultMode: 0400
+        {{- end }}
         {{- if not .Values.server.disableTls }}
         - name: tls-cert
           secret:

--- a/deploy/helm/openshell/tests/gateway_config_test.yaml
+++ b/deploy/helm/openshell/tests/gateway_config_test.yaml
@@ -125,3 +125,30 @@ tests:
       - matchRegex:
           path: data["gateway.toml"]
           pattern: 'server_sans\s*=\s*\["openshell", "\*\.dev\.openshell\.localhost"\]'
+
+  - it: renders SPIFFE sandbox auth instead of gateway JWT when enabled
+    set:
+      server.spiffe.enabled: true
+    template: templates/gateway-config.yaml
+    asserts:
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '\[openshell\.gateway\.spiffe\]'
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: 'spiffe_workload_api_socket_path\s*=\s*"/spiffe-workload-api/spire-agent\.sock"'
+      - notMatchRegex:
+          path: data["gateway.toml"]
+          pattern: '\[openshell\.gateway\.gateway_jwt\]'
+
+  - it: mounts the SPIFFE Workload API socket when SPIFFE is enabled
+    set:
+      server.spiffe.enabled: true
+    template: templates/statefulset.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.volumes[1].name
+          pattern: '^spiffe-workload-api$'
+      - matchRegex:
+          path: spec.template.spec.volumes[1].csi.driver
+          pattern: '^csi\.spiffe\.io$'

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -206,6 +206,15 @@ server:
     # values outside [600, 86400]. Default 3600 — generous, since the
     # supervisor consumes the token within seconds of pod start.
     k8sSaTokenTtlSecs: 3600
+  # SPIFFE/SPIRE sandbox identity. When enabled, sandbox supervisors fetch a
+  # JWT-SVID from the SPIFFE Workload API and present it directly to the
+  # gateway instead of bootstrapping a gateway-minted sandbox JWT.
+  spiffe:
+    enabled: false
+    trustDomain: openshell.local
+    audience: openshell-gateway
+    workloadApiSocketPath: /spiffe-workload-api/spire-agent.sock
+    sandboxIdPrefix: /openshell/sandbox/
   # OIDC (OpenID Connect) configuration for JWT-based authentication.
   # When issuer is set, the server validates Bearer tokens on gRPC requests.
   oidc:

--- a/docs/kubernetes/access-control.mdx
+++ b/docs/kubernetes/access-control.mdx
@@ -19,6 +19,14 @@ The Helm chart always generates mTLS certificates at install time. The gateway u
 
 For how the CLI resolves gateways and stores credentials, refer to [Gateway Authentication](/reference/gateway-auth).
 
+## Sandbox Supervisor Identity
+
+Kubernetes sandbox supervisors authenticate back to the gateway as sandbox workloads. By default, the gateway mints its own sandbox JWTs and Kubernetes sandboxes bootstrap them with a projected ServiceAccount token.
+
+Set `server.spiffe.enabled=true` to use SPIFFE JWT-SVIDs instead. In this mode, sandbox pods mount the SPIFFE CSI Workload API socket, request a JWT-SVID for `server.spiffe.audience`, and present that token directly to the gateway. The gateway validates the token through its local SPIFFE Workload API socket and accepts SPIFFE IDs under `spiffe://<trust-domain>/openshell/sandbox/`.
+
+SPIFFE mode requires a SPIFFE implementation such as SPIRE and a `ClusterSPIFFEID` that assigns per-sandbox IDs from the pod's `openshell.io/sandbox-id` annotation.
+
 ## OIDC User Authentication
 
 Set `server.oidc.issuer` to enable OIDC. The gateway validates the `Authorization: Bearer <token>` header on every request against the issuer's JWKS endpoint.

--- a/docs/kubernetes/access-control.mdx
+++ b/docs/kubernetes/access-control.mdx
@@ -27,6 +27,8 @@ Set `server.spiffe.enabled=true` to use SPIFFE JWT-SVIDs instead. In this mode, 
 
 SPIFFE mode requires a SPIFFE implementation such as SPIRE and a `ClusterSPIFFEID` that assigns per-sandbox IDs from the pod's `openshell.io/sandbox-id` annotation.
 
+The same sandbox Workload API socket is also used by dynamic provider token grants. Provider profiles with `token_grant` metadata cause the sandbox supervisor to request JWT-SVIDs and exchange them for upstream OAuth2 access tokens.
+
 ## OIDC User Authentication
 
 Set `server.oidc.issuer` to enable OIDC. The gateway validates the `Authorization: Bearer <token>` header on every request against the issuer's JWKS endpoint.

--- a/docs/sandboxes/providers-v2.mdx
+++ b/docs/sandboxes/providers-v2.mdx
@@ -44,7 +44,7 @@ openshell settings delete --global --key providers_v2_enabled
 ```
 
 <Note>
-The feature flag controls provider-derived policy layers. It does not change the current credential injection model. OpenShell still injects placeholder environment variables into sandbox processes and resolves those placeholders in outbound HTTP traffic.
+The feature flag controls provider-derived policy layers. OpenShell still supports placeholder environment variables for provider credentials, and provider profiles can also declare dynamic token grants that the sandbox proxy resolves on demand for matching HTTP endpoints.
 </Note>
 
 ## Available Features
@@ -60,6 +60,7 @@ Providers v2 currently includes these user-facing features:
 - Runtime sandbox provider lifecycle commands under `openshell sandbox provider list|attach|detach`.
 - Credential refresh configuration with `openshell provider refresh status|configure|rotate|delete`.
 - Credential expiry metadata with `openshell provider update --credential-expires-at`; values accept Unix epoch milliseconds or ISO/RFC3339 timestamps.
+- Dynamic token grants that use the sandbox's SPIFFE JWT-SVID as an OAuth2 client assertion and inject a short-lived `Authorization: Bearer` token for matching profile endpoints.
 
 ## Roadmap
 
@@ -67,8 +68,8 @@ The following Providers v2 design items are not part of the current behavior:
 
 | Roadmap item | Current behavior |
 |---|---|
-| Profile-driven explicit credential injection | Profile `auth_style`, `header_name`, and `query_param` fields are stored and validated, but runtime injection still depends on environment placeholders generated from provider credentials. |
-| Endpoint and binary scoped credential injection | Provider profile endpoints and binaries affect policy composition. They do not yet restrict which outbound requests can receive credential injection. |
+| General profile-driven credential placement | Static `auth_style`, `header_name`, and `query_param` placement metadata is stored and validated, but static credential injection still depends on environment placeholders generated from provider credentials. Dynamic `token_grant` credentials inject bearer tokens for matching HTTP endpoints. |
+| Endpoint and binary scoped credential injection | Provider profile endpoints and binaries affect policy composition. Dynamic token grants are endpoint-scoped. Static placeholder injection is not yet restricted by profile endpoint or binary metadata. |
 | Credential verification on create | `openshell provider create` does not yet probe provider verification endpoints or expose `--no-verify`. |
 | Automatic credential scope extraction | OpenShell does not yet inspect upstream provider responses to discover credential scopes. |
 | Inference mounting from attached providers | `inference_capable` is profile metadata. Attaching an inference-capable provider does not yet create `inference.local` routes. |
@@ -154,8 +155,8 @@ credentials:
     required: true
 
     # Accepted values: basic, bearer, header, query.
-    # These fields describe the intended credential placement.
-    # Runtime injection still uses env placeholder resolution today.
+    # These fields describe static credential placement.
+    # Static runtime injection still uses env placeholder resolution.
     auth_style: bearer
     header_name: authorization
     query_param: api_key
@@ -178,6 +179,23 @@ credentials:
           description: OAuth client secret
           required: true
           secret: true
+
+    # Optional dynamic credential. The sandbox supervisor requests a
+    # SPIFFE JWT-SVID, exchanges it at token_endpoint, caches the returned
+    # access token, and injects it as Authorization: Bearer for matching
+    # endpoint traffic.
+    token_grant:
+      token_endpoint: https://login.example.com/realms/custom/protocol/openid-connect/token
+      audience: api://custom-api
+      jwt_svid_audience: https://login.example.com/realms/custom
+      scopes: [api.read, api.write]
+      cache_ttl_seconds: 300
+      audience_overrides:
+        - host: api.example.com
+          port: 443
+          path: /v1/projects/**
+          audience: api://custom-projects
+          scopes: [projects.read]
 
 discovery:
   credentials: [api_token]
@@ -234,7 +252,7 @@ binaries:
 
 `category` groups profiles in `openshell provider list-profiles`. Use one of the values in the category enum.
 
-`credentials` declares the credential names, environment variables, auth metadata, and optional refresh metadata for the provider type. The current runtime still exposes configured credential keys as placeholder environment variables and resolves placeholders in outbound HTTP requests.
+`credentials` declares the credential names, environment variables, auth metadata, optional refresh metadata, and optional dynamic token grant metadata for the provider type. Static credentials are exposed as placeholder environment variables and resolved in outbound HTTP requests. Dynamic token grants are resolved by the sandbox proxy on demand for matching profile endpoints.
 
 `discovery` controls what `--from-existing` scans when
 `providers_v2_enabled=true`. Each entry in `discovery.credentials` must name a
@@ -273,6 +291,23 @@ Gateway-managed refresh strategies use these material keys:
 | `google_service_account_jwt` | `client_email`, `private_key`, optional `subject` or `sub`. |
 
 OpenShell keeps token endpoints profile-owned. Refresh material cannot override `token_url` or `token_uri` during refresh configuration.
+
+### Dynamic Token Grants
+
+`token_grant` belongs to one credential declaration. When a sandbox with the provider attached sends HTTP traffic to a matching profile endpoint, the supervisor requests a SPIFFE JWT-SVID from the local Workload API, exchanges it at `token_endpoint`, caches the returned access token, and injects `Authorization: Bearer <token>` before forwarding the request upstream.
+
+Token grant fields:
+
+| Field | Required | Behavior |
+|---|---|---|
+| `token_endpoint` | Yes | OAuth2 token endpoint that accepts a SPIFFE JWT-SVID client assertion. |
+| `audience` | No | Resource audience requested from the token service. |
+| `jwt_svid_audience` | No | Audience used when requesting the JWT-SVID. When omitted, OpenShell derives an issuer-style audience from Keycloak token endpoint paths or falls back to the full token endpoint URL. |
+| `scopes` | No | OAuth2 scopes sent as a space-separated `scope` parameter. |
+| `cache_ttl_seconds` | No | Token cache TTL override. When omitted or `0`, OpenShell uses the token response `expires_in`, or five minutes if the response does not include an expiry. |
+| `audience_overrides` | No | Endpoint-specific `audience` and `scopes` overrides selected by host, port, and path. |
+
+Token grants require the sandbox supervisor to have access to a SPIFFE Workload API socket. They apply to HTTP traffic that the proxy can inspect. Endpoints with `tls: skip` bypass TLS termination and cannot receive dynamic token grant injection for HTTPS traffic.
 
 ## Provider Instances
 

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -212,7 +212,7 @@ OpenShell applies seccomp in two phases. A narrow supervisor-startup prelude run
 
 | Aspect | Detail |
 |---|---|
-| Startup prelude | After privileged bootstrap helpers complete, the supervisor sets `PR_SET_NO_NEW_PRIVS` and synchronizes a seccomp filter across all runtime threads that blocks `mount`, the new mount API syscalls, `pivot_root`, `umount2`, `bpf`, `perf_event_open`, `userfaultfd`, module-loading syscalls, and kexec. This closes the long-lived privileged remount and kernel-surface window while leaving required setup syscalls such as `setns` available. |
+| Startup prelude | After privileged bootstrap helpers complete, including network setup and SPIFFE child mount-namespace preparation, the supervisor sets `PR_SET_NO_NEW_PRIVS` and synchronizes a seccomp filter across all runtime threads that blocks `mount`, the new mount API syscalls, `pivot_root`, `umount2`, `bpf`, `perf_event_open`, `userfaultfd`, module-loading syscalls, and kexec. This closes the long-lived privileged remount and kernel-surface window while leaving required setup syscalls such as `setns` available. |
 | Socket domains | The filter allows `AF_INET` and `AF_INET6` (for proxy communication) and blocks `AF_NETLINK`, `AF_PACKET`, `AF_BLUETOOTH`, and `AF_VSOCK` with `EPERM`. |
 | Runtime unconditional syscall blocks | `memfd_create`, `ptrace`, `bpf`, `process_vm_readv`, `process_vm_writev`, `pidfd_open`, `pidfd_getfd`, `pidfd_send_signal`, `io_uring_setup`, `mount`, `fsopen`, `fsconfig`, `fsmount`, `fspick`, `move_mount`, `open_tree`, `setns`, `umount2`, `pivot_root`, `userfaultfd`, `perf_event_open`. |
 | Conditional syscall blocks | `execveat` with `AT_EMPTY_PATH`, `unshare` and `clone` with `CLONE_NEWUSER`, and `seccomp(SECCOMP_SET_MODE_FILTER)` are denied with `EPERM`. |
@@ -225,9 +225,9 @@ OpenShell applies seccomp in two phases. A narrow supervisor-startup prelude run
 The sandbox supervisor applies enforcement in a specific order during process startup.
 This ordering is intentional: named network-namespace setup still relies on privileged helpers, and privilege dropping still needs `/etc/group` and `/etc/passwd`, which Landlock subsequently restricts.
 
-1. Privileged supervisor bootstrap helpers, including network-namespace setup and optional `nft` probes.
+1. Privileged supervisor bootstrap helpers, including network-namespace setup, SPIFFE child mount-namespace setup, and optional `nft` probes.
 2. Supervisor startup prelude seccomp (`PR_SET_NO_NEW_PRIVS` plus the early syscall denylist) synchronized across runtime threads.
-3. Network namespace entry (`setns`) in child `pre_exec`.
+3. Network and child-only mount namespace entry (`setns`) in child `pre_exec`.
 4. Privilege drop (`initgroups` + `setgid` + `setuid`).
 5. Core-dump hardening (`RLIMIT_CORE=0`, plus `PR_SET_DUMPABLE=0` on Linux).
 6. Landlock filesystem restrictions.

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -122,7 +122,7 @@ This enables credential injection and L7 inspection without explicit configurati
 |---|---|
 | Default | Auto-detect and terminate. OpenShell generates the sandbox CA at startup and injects it into the process trust stores (`NODE_EXTRA_CA_CERTS`, `DENO_CERT`, `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`). |
 | What you can change | Set `tls: skip` on an endpoint to disable TLS detection and termination for that endpoint. Use this for client-certificate mTLS to upstream or non-standard binary protocols. |
-| Risk if relaxed | `tls: skip` disables credential injection and L7 inspection for that endpoint. The proxy relays encrypted traffic without seeing the contents. |
+| Risk if relaxed | `tls: skip` disables placeholder credential rewriting, dynamic token grant injection, and L7 inspection for that endpoint. The proxy relays encrypted traffic without seeing the contents. |
 | Recommendation | Use auto-detect (the default) for most endpoints. Use `tls: skip` only when the upstream requires the client's own TLS certificate (mTLS) or uses a non-HTTP protocol. |
 
 ### SSRF Protection
@@ -286,7 +286,7 @@ The following patterns weaken security without providing meaningful benefit.
 | Using `access: full` when finer rules would suffice | `access: full` with `protocol: rest` or `protocol: websocket` enables inspection but allows all methods and paths for that protocol. | Use `access: read-only` or explicit `rules` to restrict what the agent can do at the L7 level. |
 | Adding endpoints permanently when operator approval would suffice | Adding endpoints to the policy YAML makes them permanently reachable across all instances. | Use operator approval. Approved endpoints persist within the sandbox instance but reset on re-creation. |
 | Using broad binary globs | A glob like `/**` allows any binary to reach the endpoint, defeating binary-scoped enforcement. | Scope globs to specific directories (for example, `/sandbox/.vscode-server/**`). |
-| Skipping TLS termination on HTTPS APIs | Setting `tls: skip` disables credential injection and L7 inspection. | Use the default auto-detect behavior unless the upstream requires client-certificate mTLS. |
+| Skipping TLS termination on HTTPS APIs | Setting `tls: skip` disables placeholder credential rewriting, dynamic token grant injection, and L7 inspection. | Use the default auto-detect behavior unless the upstream requires client-certificate mTLS. |
 | Setting `enforcement: enforce` before auditing | Jumping to `enforce` without first running in `audit` mode risks breaking the agent's workflow. | Start with `audit`, review the logs, and switch to `enforce` after you validate the rules. |
 
 ## Related Topics

--- a/mise.lock
+++ b/mise.lock
@@ -35,6 +35,7 @@ url_api = "https://api.github.com/repos/anchore/syft/releases/assets/410001182"
 checksum = "sha256:0e91737aee2b5baf1d255b959630194a302335d848ff97bb07921eb6205b5f5a"
 url = "https://github.com/anchore/syft/releases/download/v1.44.0/syft_1.44.0_linux_amd64.tar.gz"
 url_api = "https://api.github.com/repos/anchore/syft/releases/assets/410001183"
+provenance = "github-attestations"
 
 [tools."github:anchore/syft"."platforms.macos-arm64"]
 checksum = "sha256:24e4d34078ae81da7c82539616f0ccac3e226cf4f74a38ce6fb3463619e50a55"
@@ -213,6 +214,7 @@ backend = "aqua:GoogleContainerTools/skaffold"
 url = "https://storage.googleapis.com/skaffold/releases/v2.20.0/skaffold-linux-arm64"
 
 [tools.skaffold."platforms.linux-x64"]
+checksum = "blake3:4de6b14984ff1c7e5f107dd12d15890feb4b6600032d61158162c243a81d9156"
 url = "https://storage.googleapis.com/skaffold/releases/v2.20.0/skaffold-linux-amd64"
 
 [tools.skaffold."platforms.macos-arm64"]

--- a/proto/openshell.proto
+++ b/proto/openshell.proto
@@ -877,6 +877,48 @@ message ProviderProfileDiagnostic {
   string severity = 5;
 }
 
+// Endpoint selector for token grant audience overrides.
+message ProviderCredentialTokenGrantAudienceOverride {
+  // Optional: endpoint host selector. If omitted, inherits the profile endpoint host.
+  string host = 1;
+
+  // Optional: endpoint port selector. If omitted, matches the expanded profile endpoint port.
+  uint32 port = 2;
+
+  // Optional: endpoint path selector. If omitted, inherits the profile endpoint path.
+  string path = 3;
+
+  // Resource audience to request for matching endpoints.
+  string audience = 4;
+
+  // Optional: OAuth2 scopes to request. If omitted, inherits the token grant scopes.
+  repeated string scopes = 5;
+}
+
+// Provider credential token grant configuration.
+// When present, the credential is obtained dynamically via OAuth2 grant when needed.
+message ProviderCredentialTokenGrant {
+  // OAuth2 token endpoint URL (e.g., https://keycloak.example.com/realms/my-realm/protocol/openid-connect/token)
+  string token_endpoint = 1;
+
+  // Optional: default resource audience to request from the token service
+  string audience = 2;
+
+  // Optional: audience to request when fetching the JWT-SVID from SPIRE.
+  // If omitted, the sandbox derives this from token_endpoint.
+  string jwt_svid_audience = 6;
+
+  // Optional: OAuth2 scopes to request
+  repeated string scopes = 3;
+
+  // Optional: override token cache TTL (seconds)
+  // If 0 or omitted, use expires_in from token response
+  int64 cache_ttl_seconds = 4;
+
+  // Optional: endpoint-specific resource audience overrides.
+  repeated ProviderCredentialTokenGrantAudienceOverride audience_overrides = 5;
+}
+
 // Provider credential declaration.
 message ProviderProfileCredential {
   string name = 1;
@@ -887,6 +929,7 @@ message ProviderProfileCredential {
   string header_name = 6;
   string query_param = 7;
   ProviderCredentialRefresh refresh = 8;
+  ProviderCredentialTokenGrant token_grant = 9;
 }
 
 enum ProviderCredentialRefreshStrategy {
@@ -1084,6 +1127,10 @@ message GetSandboxProviderEnvironmentResponse {
   uint64 provider_env_revision = 2;
   // Expiration timestamps for returned environment variables.
   map<string, int64> credential_expires_at_ms = 3;
+  // Dynamic credentials that require token grants or other runtime injection.
+  // Maps endpoint-bound provider metadata to credential metadata.
+  // Supervisor uses this to inject Authorization headers for token grant credentials.
+  map<string, ProviderProfileCredential> dynamic_credentials = 4;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The objective of this PR is to support the dynamic issuing of tokens on demand, using the sandbox SPIFFE credentials to authenticate to the IdP granting the tokens.

## Related Issue
This is built on top of https://github.com/NVIDIA/OpenShell/pull/1414 to avoid duplicating the SPIRE related code, so will need to wait for that to merge. I am putting this draft up in the hope of getting some feedback on approach.

## Example usage

As an example of intended usage, the following profile could be defined (keycloak.example.test would be replaced by the hostname for the IdP in use):

```
id: keycloak-svcs
display_name: Keycloak protected services
description: Dynamic token grant for Keycloak-protected services using SPIFFE authentication
category: other

credentials:
  - name: access_token
    description: Access token obtained via JWT client assertion grant
    auth_style: bearer
    header_name: Authorization
    token_grant:
      token_endpoint: http://keycloak.example.test/realms/openshell/protocol/openid-connect/token
      jwt_svid_audience: http://keycloak.example.test/realms/openshell
      audience_overrides:
        - host: alpha.default.svc.cluster.local
          audience: alpha
          scopes: [alpha]
        - host: beta.default.svc.cluster.local
          audience: beta
          scopes: [beta]
        - host: gamma.default.svc.cluster.local
          audience: gamma
          scopes: [gamma]
        - host: delta.default.svc.cluster.local
          audience: delta
          scopes: [delta]

endpoints:
  - host: alpha.default.svc.cluster.local
    port: 80
    protocol: rest
    tls: none
    access: read-write
    allowed_ips:
      - 10.96.0.0/12  # Kubernetes service CIDR
  - host: beta.default.svc.cluster.local
    port: 80
    protocol: rest
    tls: none
    access: read-write
    allowed_ips:
      - 10.96.0.0/12  # Kubernetes service CIDR
  - host: gamma.default.svc.cluster.local
    port: 80
    protocol: rest
    tls: none
    access: read-write
    allowed_ips:
      - 10.96.0.0/12  # Kubernetes service CIDR
  - host: delta.default.svc.cluster.local
    port: 80
    protocol: rest
    tls: none
    access: read-write
    allowed_ips:
      - 10.96.0.0/12  # Kubernetes service CIDR

binaries:
  - path: /usr/bin/curl
  - path: /usr/bin/wget
```

This would then be imported and used to create a provider and then a sandbox:

```
openshell provider profile import -f provider-profile.yaml
openshell provider create --name keycloak --type keycloak-svcs --credential foo=bar
openshell sandbox create --name token-test --provider keycloak --policy policy.yaml
```

Within the sandbox thus created, assuming the IdP has been correctly configured to recognise its SPIFFE ID and allow appropriate token grants, calls can be made to services defined in the profile and valid tokens will be injected into the request automatically (note: not all the claims in the token are included in the text below for the sake of clarity):

```
sandbox@token-test:/$ curl alpha.default.svc.cluster.local
alpha called with path /:
  sub: 27893a90-0e0c-4402-8f29-5f486fd08f10
  aud: alpha, account
  iss: http://keycloak.example.test/realms/openshell
  scope: alpha profile email
  azp: spiffe://openshell.local/openshell/sandbox/7739c4e9-d8bc-4f0e-a08a-10296f0127d8
  client_id: spiffe://openshell.local/openshell/sandbox/7739c4e9-d8bc-4f0e-a08a-10296f0127d8
sandbox@token-test:/$ curl beta.default.svc.cluster.local
beta called with path /:
  sub: 27893a90-0e0c-4402-8f29-5f486fd08f10
  aud: beta, account
  iss: http://keycloak.example.test/realms/openshell
  scope: beta profile email
  azp: spiffe://openshell.local/openshell/sandbox/7739c4e9-d8bc-4f0e-a08a-10296f0127d8
  client_id: spiffe://openshell.local/openshell/sandbox/7739c4e9-d8bc-4f0e-a08a-10296f0127d8
```

## Benefit

The value of this behaviour, is (a) the ease of use for the sandbox user, who does not need to manually deal with any tokens in order to use the platform provided services and (b) there is no need to maintain active tokens just in case they are needed.


## Changes

  - Added provider profile schema support for token_grant, including configuration of token endpoint and the ability to define endpoint-specific audience overrides.
  - Extended protobuf provider environment responses to carry details of any desired dynamic credentials to be inserted from the gateway to sandbox supervisors.
  - Implemented gateway-side expansion of token-grant credentials across profile endpoints, applying audience_overrides by host/port/path and clearing override metadata before sending resolved credentials to
    sandboxes.
  - Added sandbox-side SPIFFE token grant flow that fetches JWT-SVIDs from the Workload API and exchanges them with the IdP using a jwt-spiffe client assertion grant.
  - Added L7/forward-proxy token injection so matching outbound HTTP requests receive an Authorization: Bearer <token> header automatically.
  - Added token grant caching keyed by provider, token endpoint, JWT-SVID audience, resource audience, and scopes.
  - Added tests for token grant profile round-tripping, dynamic credential expansion, endpoint matching/specificity, token injection behavior, and sanitized token-grant error handling.
  - Updated SPIRE Helm stack values for JWT issuer and default JWT-SVID TTL.
  - Updated docs/architecture notes to describe dynamic token grants and OIDC/SPIFFE-related behavior

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
