### PR TITLE
test(cli): avoid browser launch in auth rollback test

### DIFF
--- a/crates/openshell-cli/src/auth.rs
+++ b/crates/openshell-cli/src/auth.rs
@@ -102,6 +102,15 @@ pub async fn browser_auth_flow(gateway_endpoint: &str) -> Result<String> {
         ));
     }
 
+    #[cfg(test)]
+    if std::env::var("OPENSHELL_TEST_BROWSER_AUTH_FAIL")
+        .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    {
+        return Err(miette::miette!(
+            "browser authentication failed (OPENSHELL_TEST_BROWSER_AUTH_FAIL is set)"
+        ));
+    }
+
     let listener = TcpListener::bind("127.0.0.1:0").await.into_diagnostic()?;
     let local_addr = listener.local_addr().into_diagnostic()?;
     let callback_port = local_addr.port();

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -8975,6 +8975,8 @@ mod tests {
         let _ = rustls::crypto::ring::default_provider().install_default();
         let tmpdir = tempfile::tempdir().expect("create tmpdir");
         with_tmp_xdg(tmpdir.path(), || {
+            let _no_browser = EnvVarGuard::set("OPENSHELL_NO_BROWSER", "0");
+            let _browser_auth_failure = EnvVarGuard::set("OPENSHELL_TEST_BROWSER_AUTH_FAIL", "1");
             let runtime = tokio::runtime::Runtime::new().expect("create runtime");
 
             // Register a working plaintext gateway first.
@@ -8995,12 +8997,9 @@ mod tests {
             });
             assert_eq!(load_active_gateway().as_deref(), Some("existing-gw"));
 
-            // Attempt cloud gateway add. The browser flow will fail because
-            // OPENSHELL_NO_BROWSER is NOT set but the /auth/connect endpoint
-            // is unreachable (connection refused), so the 120s timeout would
-            // kick in. To keep the test fast, set OPENSHELL_NO_BROWSER=0
-            // (explicitly not suppressed) and use a port that refuses connections.
-            // The CF auth flow will fail quickly on connection refused.
+            // Attempt cloud gateway add. Keep browser suppression disabled so
+            // auth failure still rolls back the registration, but use the
+            // test-only auth failure hook instead of opening the OS browser.
             runtime.block_on(async {
                 gateway_add(
                     "https://127.0.0.1:1",


### PR DESCRIPTION
## Summary

Prevent `mise run test:rust` from opening the OS browser during the Cloudflare auth rollback unit test. The test now uses a `#[cfg(test)]` auth failure hook so rollback is still exercised without launching `/auth/connect`.

## Related Issue

Closes #1806

## Changes

- Added a test-only `OPENSHELL_TEST_BROWSER_AUTH_FAIL` branch in `browser_auth_flow`.
- Updated `gateway_add_cloud_rolls_back_on_auth_failure` to keep browser suppression false while forcing auth failure through the test hook.
- Replaced the stale comment that claimed the refused gateway port made the browser auth flow fail quickly.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (not applicable)

Additional focused check: `mise exec -- cargo test -p openshell-cli gateway_add_cloud_rolls_back_on_auth_failure -- --nocapture`

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)