### PR TITLE
docs: document DCO commit sign-off requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,7 @@ ocsf_emit!(event);
 - Always use [Conventional Commits](https://www.conventionalcommits.org/) format for commit messages
 - Format: `<type>(<scope>): <description>` (scope is optional)
 - Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `perf`
+- Sign each commit for DCO compliance (`git commit -s`, or include a `Signed-off-by: Name <email>` trailer)
 - Never mention Claude or any AI agent in commits (no author attribution, no Co-Authored-By, no references in commit messages)
 
 ## Pre-commit


### PR DESCRIPTION
## Summary

Add the DCO sign-off requirement to `AGENTS.md` so agents see it in the primary injected instruction surface, alongside the existing conventional commit guidance.

## Related Issue

None.

## Changes

- Added a commit instruction requiring DCO sign-off via `git commit -s` or an equivalent `Signed-off-by` trailer.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated (not applicable)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)