### PR TITLE
feat(kubernetes): WIP node enforcer isolation proof of concept

### DIFF
--- a/.agents/skills/debug-openshell-cluster/SKILL.md
+++ b/.agents/skills/debug-openshell-cluster/SKILL.md
@@ -181,6 +181,21 @@ helm -n openshell get values openshell | grep -E 'repository|tag|supervisorImage
 
 The gateway image built from `deploy/docker/Dockerfile.gateway` and the scratch supervisor image built from `deploy/docker/Dockerfile.supervisor` should use the same build tag in branch and E2E deploys. A stale supervisor image can make sandbox behavior lag behind gateway policy or proto changes.
 
+Check the sandbox supervisor topology rendered into gateway config:
+
+```bash
+kubectl -n openshell get configmap openshell-config -o jsonpath='{.data.gateway\.toml}' | grep -E 'supervisor_role|network_enforcement_mode|enforcer_endpoint|privileged'
+```
+
+Expected Kubernetes default is `supervisor_role = "workload"` and
+`network_enforcement_mode = "soft-proxy"`. This starts unprivileged sandbox
+pods and logs that direct socket egress is not kernel-blocked. Use
+`network_enforcement_mode = "supervisor-netns"` only when the sandbox pod has
+the required capabilities or `server.sandboxPrivileged=true`. Use
+`network_enforcement_mode = "external-enforcer"` with `nodeEnforcer.enabled=true`
+to test node-enforcer enforcement; the enforcer should log workload
+registration and successful sandbox network egress enforcement installation.
+
 For local/external pull mode (the default local path via `mise run cluster`), local images are tagged to the configured local registry base, pushed to that registry, and pulled by k3s via the `registries.yaml` mirror endpoint. The `cluster` task pushes prebuilt local tags (`openshell/*:dev`, falling back to `localhost:5000/openshell/*:dev` or `127.0.0.1:5000/openshell/*:dev`).
 
 Gateway image builds stage a partial Rust workspace from `deploy/docker/Dockerfile.images`. If cargo fails with a missing manifest under `/build/crates/...`, or an imported symbol exists locally but is missing in the image build, verify that every current gateway dependency crate, including `openshell-driver-docker`, `openshell-driver-kubernetes`, and `openshell-ocsf`, is copied into the staged workspace there.
@@ -204,6 +219,18 @@ Check service exposure:
 ```bash
 kubectl -n openshell get svc openshell -o wide
 kubectl -n openshell get endpoints openshell
+```
+
+When the gateway is exposed through Envoy Gateway, deployment infrastructure may
+need a `BackendTrafficPolicy` to disable Envoy's request and stream duration
+timeouts for OpenShell's long-lived gRPC streams. A missing or rejected policy
+commonly shows up as CLI failures around 15 seconds with `h2 protocol error:
+error reading a body from connection`, especially on `sandbox create -- <cmd>`,
+upload/download, sync, `WatchSandbox`, `ForwardTcp`, and `RelayStream` paths.
+
+```bash
+kubectl -n openshell get backendtrafficpolicy openshell-grpc-streams -o yaml
+kubectl -n openshell get grpcroute openshell -o yaml
 ```
 
 For local port-forward testing:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3686,6 +3686,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "uuid",
  "webpki-roots 1.0.7",
 ]

--- a/SPIKE.md
+++ b/SPIKE.md
@@ -1,0 +1,443 @@
+# Node Enforcer Topology Findings
+
+Date: 2026-05-29
+
+## Summary
+
+This branch explored how OpenShell can remove `privileged: true` from sandbox
+workload pods while preserving the current network proxy value proposition and
+keeping the supervisor responsible for agent lifecycle.
+
+The core finding is that Linux still needs an elevated component to modify
+network enforcement for an already-running sandbox. The viable short-term shape
+is to move that authority out of the agent-controlled sandbox container and into
+an operator-controlled node component.
+
+That does not eliminate privilege from the system. It moves privilege to a
+smaller, auditable infrastructure component.
+
+## Problem
+
+The existing Kubernetes sandbox topology needs Linux permissions that are
+problematic for managed clusters and hardened runtimes:
+
+- Sandbox containers needed elevated network permissions to install bypass
+  prevention rules.
+- Managed runtime environments can reject privileged sandbox pods with:
+  `Privileged=true is not supported`.
+- A per-sandbox `--privileged` CLI flag was the wrong product shape because this
+  is gateway/operator configuration, not per-sandbox user configuration.
+- Runtime-specific isolation layers can still be useful future hardening, but
+  this spike should not rely on cluster-specific runtime availability.
+- Kubernetes `NetworkPolicy` and most CNI-level controls are too static for our
+  current need: OpenShell must be able to update enforcement for a running
+  sandbox as policy changes.
+
+## Prototype Topology
+
+The implemented prototype splits the supervisor into runtime roles:
+
+- `combined`: current local-style behavior where one supervisor owns lifecycle
+  and hard controls.
+- `workload`: runs inside the sandbox pod and owns policy loading, proxying,
+  SSH, logs, and agent lifecycle.
+- `enforcer`: runs as a privileged node-side component.
+
+The Kubernetes topology uses:
+
+- A workload supervisor inside each sandbox pod.
+- A privileged `node-enforcer` DaemonSet, one pod per node.
+- A node-local registration flow from workload supervisor to node enforcer.
+- Host-side nftables installation into the sandbox pod network namespace.
+
+The workload supervisor still owns the agent lifecycle. The node enforcer does
+not run agent code, does not need provider credentials, and does not need access
+to sandbox files.
+
+## Enforcement Model
+
+The node enforcer currently installs a coarse nftables table in the sandbox
+pod's network namespace:
+
+- Allow loopback so sandbox processes can reach the local OpenShell proxy.
+- Allow established and related connections.
+- Allow UID 0 traffic so the supervisor-owned proxy can reach upstreams.
+- Reject non-root TCP and UDP egress so sandbox-user traffic must go through the
+  proxy, where OPA and L7 policy are enforced.
+
+This restores the observable behavior required by the existing bypass-detection
+e2e test: direct raw sockets from sandbox user code fail fast with
+`ECONNREFUSED` instead of hanging.
+
+## Control Flow
+
+The current prototype enforcement flow is registration-driven:
+
+1. The gateway creates sandbox pods with `supervisor_role = "workload"` and
+   `network_enforcement_mode = "external-enforcer"`.
+
+2. The Kubernetes driver injects node-local routing data into each sandbox pod:
+   `OPENSHELL_NODE_IP` from `status.hostIP`, `OPENSHELL_POD_IP` from
+   `status.podIP`, and `OPENSHELL_ENFORCER_ENDPOINT`. If no custom endpoint is
+   configured, the endpoint defaults to `http://$(OPENSHELL_NODE_IP):17671`.
+
+3. The node enforcer DaemonSet runs the same supervisor binary with
+   `supervisor_role = "enforcer"`. In that role it does not start an agent
+   supervisor; it binds `0.0.0.0:17671` and waits for workload registrations.
+
+4. The workload supervisor starts normally, loads policy, computes the effective
+   network enforcement mode, and registers with the node enforcer before
+   spawning the agent process. The registration is an HTTP `POST` to
+   `/v1/sandboxes/{sandbox_id}/register` with:
+
+   ```json
+   {
+     "sandbox_id": "sb-...",
+     "sandbox_name": "optional-name",
+     "pod_ip": "10.x.y.z",
+     "protocol": "openshell-node-enforcer-prototype-v1"
+   }
+   ```
+
+5. The node enforcer accepts the registration, chooses the target pod IP from
+   the payload, and falls back to the peer address only when the peer is
+   non-loopback. Loopback registrations without a pod IP are accepted but do not
+   install host-side enforcement.
+
+6. On Linux, the enforcer finds the target pod network namespace by scanning
+   `/proc/<pid>/net/fib_trie` for IPv4 or `/proc/<pid>/net/if_inet6` for IPv6.
+   For IPv4 it requires the pod IP to appear as `/32 host LOCAL`, which avoids
+   selecting the host namespace where the pod IP may exist only as a routed
+   `UNICAST` entry.
+
+7. The enforcer opens `/proc/<pid>/ns/net`, forks `nft` from a trusted absolute
+   path, calls `setns(CLONE_NEWNET)` in the child process, deletes any prior
+   OpenShell table, and loads the generated `openshell_external_enforcer`
+   ruleset into the pod namespace.
+
+8. Once the table is installed, non-root TCP and UDP egress from the sandbox
+   namespace is rejected, loopback remains available, established flows remain
+   available, and UID 0 traffic remains available for the supervisor-owned
+   proxy. User code must therefore reach the network through the OpenShell proxy
+   path where policy is enforced.
+
+The workload supervisor remains in charge of policy loading, proxying, SSH,
+settings reloads, logs, and agent lifecycle. The node enforcer owns only
+host-side namespace lookup and coarse kernel egress enforcement.
+
+Current limitations:
+
+- Reconciliation is registration-triggered, not yet watch-based.
+- Re-registration is idempotent because the enforcer deletes and recreates its
+  owned nftables table.
+- Cleanup for deleted pods, restarted pods, and stale namespace state remains a
+  hardening item.
+- Registration currently uses prototype HTTP and must be replaced or wrapped
+  with strong workload identity before production use.
+
+## Multiple Gateway Behavior
+
+The topology can support multiple gateways scheduling sandboxes into the same
+cluster because enforcement is node-local and pod-local, not gateway-local:
+
+- Each sandbox pod resolves its own `OPENSHELL_NODE_IP` and `OPENSHELL_POD_IP`
+  from Kubernetes downward API fields.
+- Each workload supervisor registers with the node enforcer on the node where
+  its sandbox pod was scheduled.
+- The node enforcer installs nftables state into the registered pod's network
+  namespace. The table name can be the same across sandboxes because each pod
+  has its own network namespace.
+- `sandbox_id` is currently used for logs and nft log prefixes; isolation comes
+  from the selected pod network namespace, not from a gateway-specific table.
+
+The important deployment constraint is that the node enforcer should be treated
+as shared node infrastructure. A node can only have one process binding the
+default host-network listener `0.0.0.0:17671`. If multiple gateway releases each
+enable their own node-enforcer DaemonSet on the same nodes with the same listen
+address, they will compete for the same port and duplicate the privileged
+component.
+
+For a shared cluster, the expected shape is one node-enforcer DaemonSet per
+node pool or cluster security boundary, with all participating gateways pointing
+their sandbox workloads at that node-local endpoint. If separate gateway
+installations need isolated enforcers, they must use separate node pools, node
+selectors, or distinct listener ports and matching `OPENSHELL_ENFORCER_ENDPOINT`
+templates.
+
+This also raises the bar for the hardening work. Multi-gateway support needs
+registration authorization that understands allowed gateway identities,
+namespaces, and sandbox pod labels. The enforcer must verify that a registered
+pod IP belongs to an OpenShell-owned sandbox pod on the same node and that the
+registering workload is allowed to ask for enforcement on that pod.
+
+## Validation
+
+Validated against the development Kubernetes cluster using the normal OpenShell
+gateway path. GKE was used as a real managed-cluster validation target, but it
+should not be part of the implementation criteria.
+
+The unchanged Kubernetes e2e test passed:
+
+```shell
+OPENSHELL_GATEWAY_ENDPOINT=http://34.171.165.42 \
+  cargo test --manifest-path e2e/rust/Cargo.toml \
+  --features e2e-kubernetes \
+  --test bypass_detection \
+  -- --nocapture
+```
+
+Result:
+
+```text
+test bypass_attempt_is_rejected_fast ... ok
+1 passed; 0 failed
+```
+
+The full existing Rust e2e suite also passed unchanged against the Kubernetes
+gateway once the local e2e invocation used a named temporary gateway config:
+
+```shell
+XDG_CONFIG_HOME=/private/tmp/openshell-gke/e2e-config \
+OPENSHELL_GATEWAY=gke-e2e \
+OPENSHELL_E2E_DRIVER=kubernetes \
+  cargo test --manifest-path e2e/rust/Cargo.toml \
+  --features e2e \
+  --no-fail-fast \
+  -- --nocapture
+```
+
+Result:
+
+```text
+all e2e test targets passed
+```
+
+Important test harness note: the e2e settings test expects the local CLI to be
+built with `openshell-core/dev-settings`, which the normal e2e scripts already
+do. Direct ad hoc cargo invocations should rebuild `openshell-cli` with that
+feature before running the full suite.
+
+Node-enforcer logs showed the expected action:
+
+```text
+Observed sandbox workload registration
+Reconciling sandbox network enforcement
+Installing sandbox network egress enforcement for pod 10.40.1.35
+Sandbox network egress enforcement installed for pod 10.40.1.35 in /proc/309096/ns/net
+```
+
+## Key Debug Finding
+
+The first version looked up a pod network namespace by scanning
+`/proc/*/net/fib_trie` for the pod IP. That was insufficient because the host
+network namespace also contains pod IPs as routed `UNICAST` entries.
+
+The enforcer installed rules into the host namespace instead of the sandbox pod
+namespace, so bypass attempts timed out rather than being rejected.
+
+The fix was to require that the pod IP is present as a local address in the
+target namespace:
+
+```text
+10.40.1.33
+/32 host LOCAL
+```
+
+That distinction selected the sandbox pod namespace instead of the host
+namespace and made the unchanged e2e test pass.
+
+## Envoy Gateway Timeout Finding
+
+The managed-cluster validation exposed a second, unrelated deployment issue:
+Envoy Gateway was terminating long-lived gRPC streams after about 15 seconds.
+The symptom was:
+
+```text
+h2 protocol error: error reading a body from connection
+```
+
+This affected the existing `WatchSandbox`, `ForwardTcp`, and supervisor
+`RelayStream` paths used by `sandbox create -- <cmd>`, upload/create, sync, and
+TTY lifecycle tests. The sandbox pods themselves were running and the node
+enforcer had installed rules correctly; the failure was at the external gateway
+proxy layer.
+
+The fix belongs to the deployment that installs Envoy Gateway, not to the
+OpenShell product Helm chart. Envoy Gateway deployments can attach a
+`BackendTrafficPolicy` to the OpenShell `GRPCRoute`:
+
+```yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: openshell-grpc-streams
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
+      name: openshell
+  timeout:
+    http:
+      requestTimeout: 0s
+      maxStreamDuration: 0s
+```
+
+After that policy was applied, Envoy reported it as accepted and the previous
+15-second failures passed without test changes.
+
+## Product Finding
+
+This topology shifts the privileged boundary from the sandbox workload to a
+node-level infrastructure component.
+
+That is likely the right direction if the goal is:
+
+- Agent-controlled workload containers are not privileged.
+- Runtime-specific sandboxing is out of scope for this spike, not required.
+- OpenShell keeps dynamic network proxy enforcement.
+- The supervisor remains responsible for the agent lifecycle.
+- Non-Kubernetes deployments can keep the existing combined supervisor mode.
+- External ingress and Gateway API controllers are deployment concerns. If they
+  impose request or stream duration limits, the deployment must configure them
+  to preserve OpenShell's long-lived gRPC streams.
+
+It is not a claim that the system has no privileged code. On Linux, dynamic
+network namespace enforcement needs some trusted component with elevated
+authority unless we delegate entirely to a CNI, runtime, or kernel feature.
+
+## RuntimeClass Is Out Of Scope
+
+RuntimeClass was useful as an early validation stimulus because it exposed why
+privileged sandbox pods are a brittle product shape. It is not part of the final
+spike topology.
+
+The node-enforcer result does not depend on gVisor, Kata, or any other
+RuntimeClass. The workload pod starts with normal Kubernetes networking, reports
+its pod IP to the node-local enforcer, and the enforcer installs rules into that
+pod's network namespace. That path works independently of whether a cluster also
+uses a runtime isolation layer.
+
+RuntimeClass may still be useful later as defense-in-depth, but it should remain
+separate from OpenShell's network enforcement model. It does not solve dynamic
+per-sandbox policy updates by itself, and it should not be part of this spike's
+enforcement design.
+
+## Why Not Only CNI or NetworkPolicy
+
+Kubernetes `NetworkPolicy` is too coarse and too asynchronous for our immediate
+needs:
+
+- It is not naturally tied to OpenShell's per-sandbox policy lifecycle.
+- It is awkward for fast policy changes on running sandboxes.
+- It does not preserve OpenShell's L7 proxy semantics by itself.
+- CNI-specific extensions would create provider and plugin dependencies.
+
+A future CNI or eBPF backend could be worthwhile, but it should be another
+backend behind the enforcement interface, not the only implementation.
+
+## Current Risks
+
+The prototype proves the topology, but it is not yet ready as a hardened
+production component.
+
+Known risks:
+
+- Registration is prototype-level HTTP and is not yet strongly authenticated.
+- The enforcer trusts pod IP registration too much.
+- The node enforcer is privileged and host-networked/host-PID, so compromise has
+  node-level blast radius.
+- Cleanup and reconciliation need to handle deleted pods, restarted pods, and
+  stale nftables state.
+- Multi-gateway deployments need a shared-enforcer model or explicit
+  per-enforcer scheduling and port separation. The current Helm shape can deploy
+  one enforcer DaemonSet per release, which is not safe to enable repeatedly on
+  the same nodes without coordination.
+- The current rules are coarse: UID 0 is allowed, non-root TCP/UDP is rejected.
+- IPv6 namespace lookup exists conceptually but has not been validated in the
+  managed-cluster path.
+- Observability is useful but should become structured enough for operators to
+  prove what pod/netns/rules were acted on.
+- Edge proxies can break otherwise healthy sandboxes if they impose short
+  request or stream duration timeouts on gRPC. This is deployment-specific and
+  should be validated wherever OpenShell is exposed through a proxy.
+
+## Hardening Plan
+
+Before this becomes more than a prototype, the node enforcer should be hardened
+around identity, scope, and reconciliation.
+
+Recommended next steps:
+
+1. Authenticate registration.
+   Use Kubernetes-projected workload identity, mTLS, or a gateway-minted token
+   so the node enforcer can verify the registering sandbox.
+
+2. Authorize against Kubernetes state.
+   Verify that the registered pod IP belongs to an OpenShell-owned sandbox pod
+   scheduled on the same node as the enforcer. In multi-gateway clusters, this
+   authorization also needs to validate the gateway identity, namespace, and
+   tenant boundary allowed to register that sandbox.
+
+3. Reduce privilege where possible.
+   Determine whether `privileged: true` can be replaced with a narrower set of
+   Linux capabilities and namespace access. If host PID is still needed, document
+   why.
+
+4. Add reconciliation.
+   Watch OpenShell sandbox pods, ensure expected rules exist, and remove stale
+   rules when pods are deleted.
+
+5. Make rule ownership explicit.
+   Keep all nftables state in an OpenShell-owned table and make installs
+   idempotent.
+
+6. Strengthen logs and metrics.
+   Emit clear events for registration, authorization, selected netns, ruleset
+   install, cleanup, and failures.
+
+7. Keep e2e parity non-negotiable.
+   The existing e2e tests should remain unaltered and passing. Topology changes
+   should be invisible at the behavioral API layer.
+
+## Implementation Notes From This Branch
+
+The branch added configuration and code paths for:
+
+- `OPENSHELL_SUPERVISOR_ROLE`
+- `OPENSHELL_NETWORK_ENFORCEMENT_MODE`
+- `OPENSHELL_ENFORCER_ENDPOINT`
+- `OPENSHELL_NODE_IP`
+- `OPENSHELL_POD_IP`
+- Helm `nodeEnforcer` configuration
+- Helm `server.supervisorRole`
+- Helm `server.networkEnforcementMode`
+- Helm `server.sandboxImagePullPolicy`
+- Kubernetes driver injection of node and pod IP environment variables
+- Supervisor image packaging with `nftables`
+- Deployment-owned Envoy Gateway `BackendTrafficPolicy` for long-lived
+  OpenShell gRPC streams.
+
+The development cluster currently uses:
+
+- `server.supervisorRole: workload`
+- `server.networkEnforcementMode: external-enforcer`
+- `server.sandboxImagePullPolicy: IfNotPresent`
+- `nodeEnforcer.enabled: true`
+- An Envoy Gateway `BackendTrafficPolicy` with `requestTimeout = 0s` and
+  `maxStreamDuration = 0s`.
+
+## Recommendation
+
+Continue with the node-enforcer topology as the next prototype target. It gives
+us the cleanest path to unprivileged sandbox workload pods without giving up the
+OpenShell proxy model or requiring a specific runtime class.
+
+Do not present it as removing privilege entirely. Present it as moving privileged
+network enforcement into a narrow, operator-controlled component that can be
+authenticated, audited, reconciled, and hardened independently from untrusted
+agent workloads.
+
+Keep Envoy Gateway and other ingress-controller tuning out of the product chart
+unless OpenShell intentionally takes ownership of that controller. The product
+requirement is that long-lived gRPC streams must be supported; the deployment
+implementation should provide the controller-specific policy.

--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -87,6 +87,28 @@ runtime still owns GPU device injection.
 ## Deployment Shape
 
 Kubernetes deployments use the Helm chart under `deploy/helm/openshell`.
+The Kubernetes driver can set a default `runtimeClassName` for sandbox pods,
+for example `gvisor` or a Kata Containers RuntimeClass, while preserving
+per-sandbox template overrides. When a default RuntimeClass is configured, the
+Kubernetes driver validates its existence at startup so missing cluster runtime
+support fails before any sandbox pods are requested. Per-sandbox RuntimeClass
+overrides are validated during sandbox admission/create because they are not
+known at gateway startup. The Kubernetes driver can also set
+`securityContext.privileged` on all sandbox pod containers as a deployment-wide,
+short-term compatibility escape hatch for clusters that require privileged pod
+admission; this weakens the container boundary and is not a replacement for a
+stronger runtime isolation model. Kubernetes deployments also select an
+explicit supervisor/network topology. The default is
+`supervisor_role = "workload"` with `network_enforcement_mode = "soft-proxy"`,
+which keeps sandbox pods unprivileged and relies on the proxy for cooperative
+traffic while reporting that direct sockets are not kernel-blocked. The existing
+hard supervisor-managed netns/veth/nft path remains available through
+`network_enforcement_mode = "supervisor-netns"`. The experimental
+`external-enforcer` mode registers workload supervisors with a privileged
+node-side enforcer DaemonSet, which enters the pod network namespace and
+installs coarse nftables egress rules so non-root sandbox processes must use the
+proxy. Dynamic endpoint, binary, and L7 policy remains inside the workload
+proxy.
 Standalone local deployments start the gateway with a selected runtime such as
 Docker, Podman, or VM. The CLI can register multiple gateways and switch between
 them without changing the sandbox architecture.

--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -12,6 +12,7 @@ Each sandbox workload has two trust levels:
 |---|---|
 | Supervisor | Starts as root inside the workload, prepares isolation, runs the proxy, fetches config, injects credentials, serves the relay socket, and launches child processes. |
 | Agent child | Runs as an unprivileged user with filesystem, process, and network restrictions applied. |
+| Node enforcer | Optional privileged host/node-side supervisor role for Kubernetes. It accepts workload registrations and installs coarse pod-netns egress rules while policy decisions stay in the workload proxy. |
 
 The supervisor keeps enough privilege to manage the sandbox, but the agent child
 loses that privilege before user code runs.
@@ -40,6 +41,13 @@ OpenShell uses overlapping controls rather than a single sandbox primitive:
 | Seccomp | Blocks dangerous syscalls, including raw socket paths that bypass the proxy. |
 | Network namespace | Forces ordinary agent egress through the local CONNECT proxy. |
 | Policy proxy | Evaluates destination, binary identity, TLS/L7 rules, SSRF checks, and inference interception. |
+
+The supervisor resolves an explicit network enforcement mode at startup.
+`combined`/`supervisor-netns` preserves the local hard netns path. Kubernetes
+defaults to `workload`/`soft-proxy`, which keeps the pod unprivileged and
+reports that direct sockets are not kernel-blocked. `external-enforcer`
+delegates the coarse direct-egress boundary to a host/node component while
+leaving dynamic endpoint policy in the proxy.
 
 The supervisor may enrich baseline filesystem allowances for runtime-required
 paths, such as proxy support files or GPU device paths when a GPU is present.

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -4388,6 +4388,16 @@ mod tests {
     }
 
     #[test]
+    fn sandbox_create_rejects_privileged_flag() {
+        let err = Cli::try_parse_from(["openshell", "sandbox", "create", "--privileged"])
+            .expect_err("privileged must not be a per-sandbox CLI flag");
+        assert!(
+            err.to_string().contains("--privileged"),
+            "error should identify the rejected flag"
+        );
+    }
+
+    #[test]
     fn service_expose_accepts_positional_target_port_and_service() {
         let cli = Cli::try_parse_from([
             "openshell",

--- a/crates/openshell-core/src/sandbox_env.rs
+++ b/crates/openshell-core/src/sandbox_env.rs
@@ -63,3 +63,138 @@ pub const USER_ENVIRONMENT: &str = "OPENSHELL_USER_ENVIRONMENT";
 /// writes and rotates this file; the supervisor exchanges its contents
 /// for a gateway JWT at startup and on refresh.
 pub const K8S_SA_TOKEN_FILE: &str = "OPENSHELL_K8S_SA_TOKEN_FILE";
+
+/// Runtime role selected for the sandbox supervisor binary.
+pub const SUPERVISOR_ROLE: &str = "OPENSHELL_SUPERVISOR_ROLE";
+
+/// Network enforcement mode selected for the sandbox supervisor binary.
+pub const NETWORK_ENFORCEMENT_MODE: &str = "OPENSHELL_NETWORK_ENFORCEMENT_MODE";
+
+/// Endpoint for an external node/host enforcer.
+pub const ENFORCER_ENDPOINT: &str = "OPENSHELL_ENFORCER_ENDPOINT";
+
+/// Node IP injected by Kubernetes when an external node enforcer is used.
+pub const NODE_IP: &str = "OPENSHELL_NODE_IP";
+
+/// Pod IP injected by Kubernetes for node-enforcer registration.
+pub const POD_IP: &str = "OPENSHELL_POD_IP";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SupervisorRole {
+    /// Runs inside the sandbox/container and owns workload lifecycle.
+    Workload,
+    /// Runs as a privileged host/node-side enforcement component.
+    Enforcer,
+    /// Current local-style topology: one supervisor owns lifecycle and hard controls.
+    #[default]
+    Combined,
+}
+
+impl SupervisorRole {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Workload => "workload",
+            Self::Enforcer => "enforcer",
+            Self::Combined => "combined",
+        }
+    }
+}
+
+impl std::fmt::Display for SupervisorRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for SupervisorRole {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "workload" => Ok(Self::Workload),
+            "enforcer" => Ok(Self::Enforcer),
+            "combined" => Ok(Self::Combined),
+            other => Err(format!(
+                "unknown supervisor role '{other}'; expected 'workload', 'enforcer', or 'combined'"
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NetworkEnforcementMode {
+    /// Resolve from the supervisor role and runtime hints.
+    #[default]
+    Auto,
+    /// Cooperative proxy environment only; direct sockets are not kernel-blocked.
+    SoftProxy,
+    /// Supervisor-managed netns/veth/nft enforcement.
+    SupervisorNetns,
+    /// Enforcement delegated to a node/host enforcer.
+    ExternalEnforcer,
+}
+
+impl NetworkEnforcementMode {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::SoftProxy => "soft-proxy",
+            Self::SupervisorNetns => "supervisor-netns",
+            Self::ExternalEnforcer => "external-enforcer",
+        }
+    }
+}
+
+impl std::fmt::Display for NetworkEnforcementMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for NetworkEnforcementMode {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "soft-proxy" => Ok(Self::SoftProxy),
+            "supervisor-netns" => Ok(Self::SupervisorNetns),
+            "external-enforcer" => Ok(Self::ExternalEnforcer),
+            other => Err(format!(
+                "unknown network enforcement mode '{other}'; expected 'auto', 'soft-proxy', 'supervisor-netns', or 'external-enforcer'"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NetworkEnforcementMode, SupervisorRole};
+
+    #[test]
+    fn supervisor_role_round_trips_kebab_case() {
+        assert_eq!("workload".parse(), Ok(SupervisorRole::Workload));
+        assert_eq!(SupervisorRole::Enforcer.to_string(), "enforcer");
+        assert_eq!(
+            serde_json::to_value(SupervisorRole::Combined).unwrap(),
+            serde_json::json!("combined")
+        );
+    }
+
+    #[test]
+    fn network_enforcement_mode_round_trips_kebab_case() {
+        assert_eq!("soft-proxy".parse(), Ok(NetworkEnforcementMode::SoftProxy));
+        assert_eq!(
+            NetworkEnforcementMode::ExternalEnforcer.to_string(),
+            "external-enforcer"
+        );
+        assert_eq!(
+            serde_json::to_value(NetworkEnforcementMode::SupervisorNetns).unwrap(),
+            serde_json::json!("supervisor-netns")
+        );
+    }
+}

--- a/crates/openshell-driver-kubernetes/README.md
+++ b/crates/openshell-driver-kubernetes/README.md
@@ -13,6 +13,30 @@ this driver. Kubernetes owns scheduling and pod lifecycle. The
 `openshell-sandbox` supervisor inside each workload owns agent isolation,
 credential injection, policy polling, logs, and the gateway relay.
 
+Set `default_runtime_class_name` in the driver config to assign a default Kubernetes
+RuntimeClass, such as `gvisor` or a Kata Containers RuntimeClass, to sandbox
+pods. Per-sandbox template `runtime_class_name` values override the driver
+default. When `default_runtime_class_name` is configured, the driver validates
+that the cluster has that RuntimeClass during startup so a missing runtime fails
+fast instead of surfacing later as pod sandbox creation errors. Per-sandbox
+RuntimeClass overrides are validated during sandbox
+admission/create. As a short-term compatibility escape hatch, the driver can set
+`privileged = true` deployment-wide; the driver maps that to
+`podTemplate.spec.containers[0].securityContext.privileged` for all sandbox pod
+containers. Use it only for trusted clusters that require privileged pod
+admission because it weakens the container boundary.
+
+Kubernetes deployments default to `supervisor_role = "workload"` and
+`network_enforcement_mode = "soft-proxy"`. In this mode the supervisor runs the
+proxy, policy reload, relay, and agent lifecycle without creating a Linux
+network namespace; proxy-aware traffic is enforced, but direct socket egress is
+not kernel-blocked. Set `network_enforcement_mode = "supervisor-netns"` to use
+the existing netns/veth/nft path when the sandbox pod has the required Linux
+capabilities. Set `network_enforcement_mode = "external-enforcer"` to try the
+node-enforcer topology; the workload supervisor registers with a node-side
+enforcer, which installs coarse pod-netns egress rules while dynamic endpoint
+policy stays inside the proxy.
+
 ## Sandbox Resource
 
 The driver works with the `agents.x-k8s.io/v1alpha1` `Sandbox` custom resource.

--- a/crates/openshell-driver-kubernetes/src/config.rs
+++ b/crates/openshell-driver-kubernetes/src/config.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use openshell_core::config::DEFAULT_SUPERVISOR_IMAGE;
+use openshell_core::sandbox_env::{NetworkEnforcementMode, SupervisorRole};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::str::FromStr;
 
@@ -176,6 +177,19 @@ pub struct KubernetesComputeConfig {
         deserialize_with = "deserialize_optional_app_armor_profile"
     )]
     pub app_armor_profile: Option<AppArmorProfile>,
+    /// Runtime role passed to the sandbox supervisor binary.
+    pub supervisor_role: SupervisorRole,
+    /// Network enforcement mode passed to the sandbox supervisor binary.
+    pub network_enforcement_mode: NetworkEnforcementMode,
+    /// Endpoint template for a node/host enforcer. Supports Kubernetes env
+    /// expansion such as `http://$(OPENSHELL_NODE_IP):17671`.
+    pub enforcer_endpoint: String,
+    /// Set `securityContext.privileged` on sandbox pod containers.
+    ///
+    /// This is a deployment-wide compatibility escape hatch for clusters that
+    /// require privileged pod admission. It weakens the container boundary and
+    /// should stay disabled unless the Kubernetes environment is trusted.
+    pub privileged: bool,
     pub workspace_default_storage_size: String,
     /// Default Kubernetes `runtimeClassName` for sandbox pods.
     /// Applied when a `CreateSandbox` request does not specify one.
@@ -221,6 +235,10 @@ impl Default for KubernetesComputeConfig {
             host_gateway_ip: String::new(),
             enable_user_namespaces: false,
             app_armor_profile: None,
+            supervisor_role: SupervisorRole::Workload,
+            network_enforcement_mode: NetworkEnforcementMode::SoftProxy,
+            enforcer_endpoint: String::new(),
+            privileged: false,
             workspace_default_storage_size: DEFAULT_WORKSPACE_STORAGE_SIZE.to_string(),
             default_runtime_class_name: String::new(),
             sa_token_ttl_secs: 3600,
@@ -361,5 +379,40 @@ mod tests {
         });
         let cfg: KubernetesComputeConfig = serde_json::from_value(json).unwrap();
         assert_eq!(cfg.image_pull_secrets, ["regcred", "backup-regcred"]);
+    }
+
+    #[test]
+    fn serde_override_privileged() {
+        let json = serde_json::json!({
+            "privileged": true
+        });
+        let cfg: KubernetesComputeConfig = serde_json::from_value(json).unwrap();
+        assert!(cfg.privileged);
+    }
+
+    #[test]
+    fn default_kubernetes_supervisor_mode_is_soft_workload() {
+        let cfg = KubernetesComputeConfig::default();
+        assert_eq!(cfg.supervisor_role, SupervisorRole::Workload);
+        assert_eq!(
+            cfg.network_enforcement_mode,
+            NetworkEnforcementMode::SoftProxy
+        );
+    }
+
+    #[test]
+    fn serde_override_supervisor_network_mode() {
+        let json = serde_json::json!({
+            "supervisor_role": "combined",
+            "network_enforcement_mode": "supervisor-netns",
+            "enforcer_endpoint": "http://$(OPENSHELL_NODE_IP):17671"
+        });
+        let cfg: KubernetesComputeConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(cfg.supervisor_role, SupervisorRole::Combined);
+        assert_eq!(
+            cfg.network_enforcement_mode,
+            NetworkEnforcementMode::SupervisorNetns
+        );
+        assert_eq!(cfg.enforcer_endpoint, "http://$(OPENSHELL_NODE_IP):17671");
     }
 }

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -9,6 +9,7 @@ use crate::config::{
 };
 use futures::{Stream, StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::{Event as KubeEventObj, Node};
+use k8s_openapi::api::node::v1::RuntimeClass;
 use kube::api::{Api, ApiResource, DeleteParams, ListParams, PostParams};
 use kube::core::gvk::GroupVersionKind;
 use kube::core::{DynamicObject, ObjectMeta};
@@ -28,6 +29,7 @@ use openshell_core::proto::compute::v1::{
     GetCapabilitiesResponse, WatchSandboxesDeletedEvent, WatchSandboxesEvent,
     WatchSandboxesPlatformEvent, WatchSandboxesSandboxEvent, watch_sandboxes_event,
 };
+use openshell_core::sandbox_env::{NetworkEnforcementMode, SupervisorRole};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::pin::Pin;
@@ -174,25 +176,30 @@ impl std::fmt::Debug for KubernetesComputeDriver {
 }
 
 impl KubernetesComputeDriver {
-    pub async fn new(config: KubernetesComputeConfig) -> Result<Self, KubeError> {
+    pub async fn new(mut config: KubernetesComputeConfig) -> Result<Self, KubernetesDriverError> {
         let base_config = match kube::Config::incluster() {
             Ok(c) => c,
             Err(_) => kube::Config::infer()
                 .await
-                .map_err(kube::Error::InferConfig)?,
+                .map_err(kube::Error::InferConfig)
+                .map_err(KubernetesDriverError::from_kube)?,
         };
 
         let mut kube_config = base_config.clone();
         kube_config.connect_timeout = Some(Duration::from_secs(10));
         kube_config.read_timeout = Some(Duration::from_secs(30));
         kube_config.write_timeout = Some(Duration::from_secs(30));
-        let client = Client::try_from(kube_config)?;
+        let client = Client::try_from(kube_config).map_err(KubernetesDriverError::from_kube)?;
 
         let mut watch_kube_config = base_config;
         watch_kube_config.connect_timeout = Some(Duration::from_secs(10));
         watch_kube_config.read_timeout = None;
         watch_kube_config.write_timeout = Some(Duration::from_secs(30));
-        let watch_client = Client::try_from(watch_kube_config)?;
+        let watch_client =
+            Client::try_from(watch_kube_config).map_err(KubernetesDriverError::from_kube)?;
+
+        config.default_runtime_class_name = config.default_runtime_class_name.trim().to_string();
+        validate_runtime_class_exists(&client, &config.default_runtime_class_name).await?;
 
         Ok(Self {
             client,
@@ -244,6 +251,17 @@ impl KubernetesComputeDriver {
         }))
     }
 
+    async fn validate_sandbox_runtime_class_override(
+        &self,
+        sandbox: &Sandbox,
+    ) -> Result<(), KubernetesDriverError> {
+        let Some(runtime_class_name) = sandbox_runtime_class_override(sandbox) else {
+            return Ok(());
+        };
+
+        validate_runtime_class_exists(&self.client, &runtime_class_name).await
+    }
+
     pub async fn validate_sandbox_create(&self, sandbox: &Sandbox) -> Result<(), tonic::Status> {
         let gpu_requested = sandbox.spec.as_ref().is_some_and(|spec| spec.gpu);
         if gpu_requested
@@ -255,6 +273,17 @@ impl KubernetesComputeDriver {
                 "GPU sandbox requested, but the active gateway has no allocatable GPUs. Please refer to documentation and use `openshell doctor` commands to inspect GPU support and gateway configuration.",
             ));
         }
+        self.validate_sandbox_runtime_class_override(sandbox)
+            .await
+            .map_err(|err| match err {
+                KubernetesDriverError::Precondition(message) => {
+                    tonic::Status::failed_precondition(message)
+                }
+                KubernetesDriverError::AlreadyExists => {
+                    tonic::Status::already_exists("sandbox already exists")
+                }
+                KubernetesDriverError::Message(message) => tonic::Status::internal(message),
+            })?;
         Ok(())
     }
 
@@ -346,6 +375,9 @@ impl KubernetesComputeDriver {
             "Creating sandbox in Kubernetes"
         );
 
+        self.validate_sandbox_runtime_class_override(sandbox)
+            .await?;
+
         let gvk = GroupVersionKind::gvk(SANDBOX_GROUP, SANDBOX_VERSION, SANDBOX_KIND);
         let resource = ApiResource::from_gvk(&gvk);
         let mut obj = DynamicObject::new(name, &resource);
@@ -371,6 +403,10 @@ impl KubernetesComputeDriver {
             host_gateway_ip: &self.config.host_gateway_ip,
             enable_user_namespaces: self.config.enable_user_namespaces,
             app_armor_profile: self.config.app_armor_profile.as_ref(),
+            supervisor_role: self.config.supervisor_role,
+            network_enforcement_mode: self.config.network_enforcement_mode,
+            enforcer_endpoint: &self.config.enforcer_endpoint,
+            privileged: self.config.privileged,
             workspace_default_storage_size: &self.config.workspace_default_storage_size,
             default_runtime_class_name: &self.config.default_runtime_class_name,
             sa_token_ttl_secs: self.config.effective_sa_token_ttl_secs(),
@@ -1085,6 +1121,10 @@ struct SandboxPodParams<'a> {
     host_gateway_ip: &'a str,
     enable_user_namespaces: bool,
     app_armor_profile: Option<&'a AppArmorProfile>,
+    supervisor_role: SupervisorRole,
+    network_enforcement_mode: NetworkEnforcementMode,
+    enforcer_endpoint: &'a str,
+    privileged: bool,
     workspace_default_storage_size: &'a str,
     default_runtime_class_name: &'a str,
     /// Lifetime (seconds) of the projected `ServiceAccount` token used
@@ -1110,11 +1150,57 @@ impl Default for SandboxPodParams<'_> {
             host_gateway_ip: "",
             enable_user_namespaces: false,
             app_armor_profile: None,
+            supervisor_role: SupervisorRole::Workload,
+            network_enforcement_mode: NetworkEnforcementMode::SoftProxy,
+            enforcer_endpoint: "",
+            privileged: false,
             workspace_default_storage_size: DEFAULT_WORKSPACE_STORAGE_SIZE,
             default_runtime_class_name: "",
             sa_token_ttl_secs: 3600,
         }
     }
+}
+
+async fn validate_runtime_class_exists(
+    client: &Client,
+    runtime_class_name: &str,
+) -> Result<(), KubernetesDriverError> {
+    let runtime_class_name = runtime_class_name.trim();
+    if runtime_class_name.is_empty() {
+        return Ok(());
+    }
+
+    let runtime_classes: Api<RuntimeClass> = Api::all(client.clone());
+    match tokio::time::timeout(KUBE_API_TIMEOUT, runtime_classes.get(runtime_class_name)).await {
+        Ok(Ok(_runtime_class)) => {
+            info!(
+                runtime_class_name,
+                "Validated configured Kubernetes RuntimeClass"
+            );
+            Ok(())
+        }
+        Ok(Err(KubeError::Api(err))) if err.code == 404 => {
+            Err(KubernetesDriverError::Precondition(format!(
+                "Kubernetes RuntimeClass '{runtime_class_name}' does not exist; create it before starting OpenShell or choose an existing RuntimeClass"
+            )))
+        }
+        Ok(Err(err)) => Err(KubernetesDriverError::Message(format!(
+            "failed to validate Kubernetes RuntimeClass '{runtime_class_name}': {err}"
+        ))),
+        Err(_elapsed) => Err(KubernetesDriverError::Message(format!(
+            "timed out after {}s validating Kubernetes RuntimeClass '{runtime_class_name}'",
+            KUBE_API_TIMEOUT.as_secs()
+        ))),
+    }
+}
+
+fn sandbox_runtime_class_override(sandbox: &Sandbox) -> Option<String> {
+    sandbox
+        .spec
+        .as_ref()?
+        .template
+        .as_ref()
+        .and_then(|template| platform_config_string(template, "runtime_class_name"))
 }
 
 fn spec_pod_env(spec: Option<&SandboxSpec>) -> std::collections::HashMap<String, String> {
@@ -1337,10 +1423,49 @@ fn sandbox_template_to_k8s(
         params.ssh_socket_path,
         !params.client_tls_secret_name.is_empty(),
     );
+    let mut env = env;
+    upsert_env(
+        &mut env,
+        openshell_core::sandbox_env::SUPERVISOR_ROLE,
+        params.supervisor_role.as_str(),
+    );
+    upsert_env(
+        &mut env,
+        openshell_core::sandbox_env::NETWORK_ENFORCEMENT_MODE,
+        params.network_enforcement_mode.as_str(),
+    );
+    if matches!(
+        params.network_enforcement_mode,
+        NetworkEnforcementMode::ExternalEnforcer
+    ) {
+        upsert_env_field_ref(
+            &mut env,
+            openshell_core::sandbox_env::NODE_IP,
+            "status.hostIP",
+        );
+        upsert_env_field_ref(
+            &mut env,
+            openshell_core::sandbox_env::POD_IP,
+            "status.podIP",
+        );
+        upsert_env(
+            &mut env,
+            openshell_core::sandbox_env::ENFORCER_ENDPOINT,
+            if params.enforcer_endpoint.is_empty() {
+                "http://$(OPENSHELL_NODE_IP):17671"
+            } else {
+                params.enforcer_endpoint
+            },
+        );
+    }
 
     container.insert("env".to_string(), serde_json::Value::Array(env));
 
-    let mut capabilities: Vec<&str> = vec!["SYS_ADMIN", "NET_ADMIN", "SYS_PTRACE", "SYSLOG"];
+    let mut capabilities: Vec<&str> = if pod_uses_supervisor_netns(params) {
+        vec!["SYS_ADMIN", "NET_ADMIN", "SYS_PTRACE", "SYSLOG"]
+    } else {
+        vec!["SYS_PTRACE"]
+    };
     if use_user_namespaces {
         // In a user namespace the bounding set is reset. SETUID/SETGID are
         // needed for the supervisor to drop privileges to the sandbox user.
@@ -1355,6 +1480,9 @@ fn sandbox_template_to_k8s(
     });
     if let Some(profile) = params.app_armor_profile {
         security_context["appArmorProfile"] = app_armor_profile_to_k8s(profile);
+    }
+    if params.privileged {
+        security_context["privileged"] = serde_json::json!(true);
     }
     container.insert("securityContext".to_string(), security_context);
 
@@ -1727,12 +1855,44 @@ fn upsert_env(env: &mut Vec<serde_json::Value>, name: &str, value: &str) {
     env.push(serde_json::json!({"name": name, "value": value}));
 }
 
+fn upsert_env_field_ref(env: &mut Vec<serde_json::Value>, name: &str, field_path: &str) {
+    let value = serde_json::json!({
+        "name": name,
+        "valueFrom": {
+            "fieldRef": {
+                "fieldPath": field_path
+            }
+        }
+    });
+    if let Some(existing) = env
+        .iter_mut()
+        .find(|item| item.get("name").and_then(|value| value.as_str()) == Some(name))
+    {
+        *existing = value;
+        return;
+    }
+
+    env.push(value);
+}
+
+fn pod_uses_supervisor_netns(params: &SandboxPodParams<'_>) -> bool {
+    matches!(
+        params.network_enforcement_mode,
+        NetworkEnforcementMode::SupervisorNetns
+    ) || (matches!(
+        params.network_enforcement_mode,
+        NetworkEnforcementMode::Auto
+    ) && matches!(params.supervisor_role, SupervisorRole::Combined))
+}
+
 /// Extract a string value from the template's `platform_config` Struct.
 fn platform_config_string(template: &SandboxTemplate, key: &str) -> Option<String> {
     let config = template.platform_config.as_ref()?;
     let value = config.fields.get(key)?;
     match value.kind.as_ref() {
-        Some(prost_types::value::Kind::StringValue(s)) if !s.is_empty() => Some(s.clone()),
+        Some(prost_types::value::Kind::StringValue(s)) if !s.trim().is_empty() => {
+            Some(s.trim().to_string())
+        }
         _ => None,
     }
 }
@@ -1917,6 +2077,51 @@ mod tests {
         assert!(config.pod.node_selector.is_empty());
         assert!(config.containers.agent.resources.requests.is_empty());
         assert!(config.containers.agent.resources.limits.is_empty());
+    }
+
+    fn pod_env_value<'a>(pod_template: &'a serde_json::Value, name: &str) -> Option<&'a str> {
+        pod_template["spec"]["containers"][0]["env"]
+            .as_array()?
+            .iter()
+            .find(|item| item.get("name").and_then(|value| value.as_str()) == Some(name))
+            .and_then(|item| item.get("value"))
+            .and_then(|value| value.as_str())
+    }
+
+    fn pod_env_field_ref<'a>(pod_template: &'a serde_json::Value, name: &str) -> Option<&'a str> {
+        pod_template["spec"]["containers"][0]["env"]
+            .as_array()?
+            .iter()
+            .find(|item| item.get("name").and_then(|value| value.as_str()) == Some(name))
+            .and_then(|item| item.pointer("/valueFrom/fieldRef/fieldPath"))
+            .and_then(|value| value.as_str())
+    }
+
+    #[test]
+    fn sandbox_runtime_class_override_reads_template_value() {
+        let sandbox = Sandbox {
+            spec: Some(SandboxSpec {
+                template: Some(SandboxTemplate {
+                    platform_config: Some(Struct {
+                        fields: std::iter::once((
+                            "runtime_class_name".to_string(),
+                            Value {
+                                kind: Some(Kind::StringValue(" kata-qemu ".to_string())),
+                            },
+                        ))
+                        .collect(),
+                    }),
+                    ..SandboxTemplate::default()
+                }),
+                ..SandboxSpec::default()
+            }),
+            ..Sandbox::default()
+        };
+
+        assert_eq!(
+            sandbox_runtime_class_override(&sandbox),
+            Some("kata-qemu".to_string())
+        );
     }
 
     #[test]
@@ -2486,6 +2691,95 @@ mod tests {
     }
 
     #[test]
+    fn template_runtime_class_name_is_trimmed() {
+        let template = SandboxTemplate {
+            platform_config: Some(Struct {
+                fields: std::iter::once((
+                    "runtime_class_name".to_string(),
+                    Value {
+                        kind: Some(Kind::StringValue(" gvisor ".to_string())),
+                    },
+                ))
+                .collect(),
+            }),
+            ..SandboxTemplate::default()
+        };
+        let pod_template = sandbox_template_to_k8s(
+            &template,
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &SandboxPodParams::default(),
+        );
+
+        assert_eq!(
+            pod_template["spec"]["runtimeClassName"],
+            serde_json::json!("gvisor")
+        );
+    }
+
+    #[test]
+    fn kubernetes_default_sets_workload_soft_proxy_env() {
+        let pod_template = sandbox_template_to_k8s(
+            &SandboxTemplate::default(),
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &SandboxPodParams::default(),
+        );
+
+        assert_eq!(
+            pod_env_value(&pod_template, openshell_core::sandbox_env::SUPERVISOR_ROLE),
+            Some("workload")
+        );
+        assert_eq!(
+            pod_env_value(
+                &pod_template,
+                openshell_core::sandbox_env::NETWORK_ENFORCEMENT_MODE
+            ),
+            Some("soft-proxy")
+        );
+    }
+
+    #[test]
+    fn external_enforcer_mode_injects_node_registration_env() {
+        let params = SandboxPodParams {
+            network_enforcement_mode: NetworkEnforcementMode::ExternalEnforcer,
+            ..Default::default()
+        };
+        let pod_template = sandbox_template_to_k8s(
+            &SandboxTemplate::default(),
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &params,
+        );
+
+        assert_eq!(
+            pod_env_value(
+                &pod_template,
+                openshell_core::sandbox_env::NETWORK_ENFORCEMENT_MODE
+            ),
+            Some("external-enforcer")
+        );
+        assert_eq!(
+            pod_env_value(
+                &pod_template,
+                openshell_core::sandbox_env::ENFORCER_ENDPOINT
+            ),
+            Some("http://$(OPENSHELL_NODE_IP):17671")
+        );
+        assert_eq!(
+            pod_env_field_ref(&pod_template, openshell_core::sandbox_env::NODE_IP),
+            Some("status.hostIP")
+        );
+        assert_eq!(
+            pod_env_field_ref(&pod_template, openshell_core::sandbox_env::POD_IP),
+            Some("status.podIP")
+        );
+    }
+
+    #[test]
     fn gpu_sandbox_preserves_existing_resource_limits() {
         use openshell_core::proto::compute::v1::DriverResourceRequirements;
         let template = SandboxTemplate {
@@ -2855,7 +3149,7 @@ mod tests {
         let caps = pod_template["spec"]["containers"][0]["securityContext"]["capabilities"]["add"]
             .as_array()
             .unwrap();
-        assert_eq!(caps.len(), 4);
+        assert_eq!(caps, &[serde_json::json!("SYS_PTRACE")]);
         assert!(!caps.contains(&serde_json::json!("SETUID")));
     }
 
@@ -2875,14 +3169,34 @@ mod tests {
         let caps = pod_template["spec"]["containers"][0]["securityContext"]["capabilities"]["add"]
             .as_array()
             .unwrap();
+        assert!(caps.contains(&serde_json::json!("SYS_PTRACE")));
+        assert!(caps.contains(&serde_json::json!("SETUID")));
+        assert!(caps.contains(&serde_json::json!("SETGID")));
+        assert!(caps.contains(&serde_json::json!("DAC_READ_SEARCH")));
+        assert_eq!(caps.len(), 4);
+    }
+
+    #[test]
+    fn supervisor_netns_mode_adds_network_capabilities() {
+        let params = SandboxPodParams {
+            network_enforcement_mode: NetworkEnforcementMode::SupervisorNetns,
+            ..Default::default()
+        };
+        let pod_template = sandbox_template_to_k8s(
+            &SandboxTemplate::default(),
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &params,
+        );
+        let caps = pod_template["spec"]["containers"][0]["securityContext"]["capabilities"]["add"]
+            .as_array()
+            .unwrap();
         assert!(caps.contains(&serde_json::json!("SYS_ADMIN")));
         assert!(caps.contains(&serde_json::json!("NET_ADMIN")));
         assert!(caps.contains(&serde_json::json!("SYS_PTRACE")));
         assert!(caps.contains(&serde_json::json!("SYSLOG")));
-        assert!(caps.contains(&serde_json::json!("SETUID")));
-        assert!(caps.contains(&serde_json::json!("SETGID")));
-        assert!(caps.contains(&serde_json::json!("DAC_READ_SEARCH")));
-        assert_eq!(caps.len(), 7);
+        assert_eq!(caps.len(), 4);
     }
 
     #[test]
@@ -2956,8 +3270,45 @@ mod tests {
             .unwrap();
         assert_eq!(
             caps.len(),
-            4,
+            1,
             "extra capabilities must not be added when user namespaces are disabled"
+        );
+    }
+
+    #[test]
+    fn configured_privileged_sets_container_security_context() {
+        let params = SandboxPodParams {
+            privileged: true,
+            ..SandboxPodParams::default()
+        };
+        let pod_template = sandbox_template_to_k8s(
+            &SandboxTemplate::default(),
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &params,
+        );
+
+        assert_eq!(
+            pod_template["spec"]["containers"][0]["securityContext"]["privileged"],
+            serde_json::json!(true),
+            "privileged config must map to container securityContext"
+        );
+    }
+
+    #[test]
+    fn privileged_omitted_by_default() {
+        let pod_template = sandbox_template_to_k8s(
+            &SandboxTemplate::default(),
+            false,
+            &std::collections::HashMap::new(),
+            true,
+            &SandboxPodParams::default(),
+        );
+
+        assert!(
+            pod_template["spec"]["containers"][0]["securityContext"]["privileged"].is_null(),
+            "privileged must be omitted unless configured"
         );
     }
 

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -3110,7 +3110,7 @@ mod tests {
         );
         assert_eq!(
             pod_template["spec"]["containers"][0]["securityContext"]["capabilities"]["add"][0],
-            serde_json::json!("SYS_ADMIN"),
+            serde_json::json!("SYS_PTRACE"),
             "AppArmor rendering must preserve required capabilities"
         );
     }

--- a/crates/openshell-driver-kubernetes/src/main.rs
+++ b/crates/openshell-driver-kubernetes/src/main.rs
@@ -9,6 +9,7 @@ use tracing_subscriber::EnvFilter;
 
 use openshell_core::VERSION;
 use openshell_core::proto::compute::v1::compute_driver_server::ComputeDriverServer;
+use openshell_core::sandbox_env::{NetworkEnforcementMode, SupervisorRole};
 use openshell_driver_kubernetes::{
     AppArmorProfile, ComputeDriverService, DEFAULT_SANDBOX_SERVICE_ACCOUNT_NAME,
     KubernetesComputeConfig, KubernetesComputeDriver, SupervisorSideloadMethod,
@@ -86,6 +87,31 @@ struct Args {
     #[arg(long, env = "OPENSHELL_K8S_APP_ARMOR_PROFILE")]
     app_armor_profile: Option<AppArmorProfile>,
 
+    /// Runtime role passed to openshell-sandbox in workload pods.
+    #[arg(
+        long,
+        env = "OPENSHELL_SUPERVISOR_ROLE",
+        default_value_t = SupervisorRole::Workload
+    )]
+    supervisor_role: SupervisorRole,
+
+    /// Network enforcement mode passed to openshell-sandbox in workload pods.
+    #[arg(
+        long,
+        env = "OPENSHELL_NETWORK_ENFORCEMENT_MODE",
+        default_value_t = NetworkEnforcementMode::SoftProxy
+    )]
+    network_enforcement_mode: NetworkEnforcementMode,
+
+    /// Endpoint template for the optional node/host enforcer.
+    #[arg(long, env = "OPENSHELL_ENFORCER_ENDPOINT")]
+    enforcer_endpoint: Option<String>,
+
+    /// Default Kubernetes `runtimeClassName` for sandbox pods.
+    /// Per-sandbox template `runtime_class_name` values override this default.
+    #[arg(long, env = "OPENSHELL_K8S_DEFAULT_RUNTIME_CLASS_NAME")]
+    default_runtime_class_name: Option<String>,
+
     /// Lifetime (seconds) of the projected `ServiceAccount` token
     /// kubelet writes into each sandbox pod for the `IssueSandboxToken`
     /// bootstrap exchange. Kubelet enforces a minimum of 600s; the
@@ -120,14 +146,17 @@ async fn main() -> Result<()> {
         host_gateway_ip: args.host_gateway_ip.unwrap_or_default(),
         enable_user_namespaces: args.enable_user_namespaces,
         app_armor_profile: args.app_armor_profile,
+        supervisor_role: args.supervisor_role,
+        network_enforcement_mode: args.network_enforcement_mode,
+        enforcer_endpoint: args.enforcer_endpoint.unwrap_or_default(),
+        privileged: false,
         workspace_default_storage_size: std::env::var(
             "OPENSHELL_K8S_WORKSPACE_DEFAULT_STORAGE_SIZE",
         )
         .unwrap_or_else(|_| {
             openshell_driver_kubernetes::DEFAULT_WORKSPACE_STORAGE_SIZE.to_string()
         }),
-        default_runtime_class_name: std::env::var("OPENSHELL_K8S_DEFAULT_RUNTIME_CLASS_NAME")
-            .unwrap_or_default(),
+        default_runtime_class_name: args.default_runtime_class_name.unwrap_or_default(),
         sa_token_ttl_secs: args.sa_token_ttl_secs,
     })
     .await

--- a/crates/openshell-sandbox/Cargo.toml
+++ b/crates/openshell-sandbox/Cargo.toml
@@ -63,6 +63,7 @@ sha1 = "0.10"
 
 # IP network / CIDR parsing
 ipnet = "2"
+url = { workspace = true }
 
 # Serialization
 serde = { workspace = true }

--- a/crates/openshell-sandbox/src/enforcer.rs
+++ b/crates/openshell-sandbox/src/enforcer.rs
@@ -3,7 +3,7 @@
 
 //! Node/host enforcer entrypoint and workload registration client.
 //!
-//! The node enforcer runs as a privileged host-PID DaemonSet. Workload
+//! The node enforcer runs as a privileged host-PID `DaemonSet`. Workload
 //! supervisors register after loading policy and before spawning the agent
 //! process. The enforcer locates the pod network namespace by pod IP and
 //! installs coarse nftables rules in that namespace:
@@ -225,11 +225,14 @@ async fn install_external_enforcement_blocking(sandbox_id: String, pod_ip: IpAdd
 }
 
 #[cfg(not(target_os = "linux"))]
-async fn install_external_enforcement_blocking(sandbox_id: String, pod_ip: IpAddr) -> Result<()> {
+fn install_external_enforcement_blocking(
+    sandbox_id: String,
+    pod_ip: IpAddr,
+) -> std::future::Ready<Result<()>> {
     let _ = sandbox_id;
-    Err(miette::miette!(
+    std::future::ready(Err(miette::miette!(
         "external node enforcement is only supported on Linux nodes (pod_ip={pod_ip})"
-    ))
+    )))
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/openshell-sandbox/src/enforcer.rs
+++ b/crates/openshell-sandbox/src/enforcer.rs
@@ -1,0 +1,593 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Node/host enforcer entrypoint and workload registration client.
+//!
+//! The node enforcer runs as a privileged host-PID DaemonSet. Workload
+//! supervisors register after loading policy and before spawning the agent
+//! process. The enforcer locates the pod network namespace by pod IP and
+//! installs coarse nftables rules in that namespace:
+//!
+//! - loopback traffic is allowed so sandbox processes can reach the local proxy
+//! - UID 0 traffic is allowed so the supervisor-owned proxy can reach upstreams
+//! - non-root TCP/UDP egress is rejected, forcing sandbox-user traffic through
+//!   the proxy where OPA and L7 policy are evaluated
+
+use miette::{IntoDiagnostic, Result};
+use openshell_core::sandbox_env::NetworkEnforcementMode;
+use serde::Deserialize;
+use std::net::{IpAddr, SocketAddr};
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
+#[cfg(target_os = "linux")]
+use std::os::unix::process::CommandExt;
+#[cfg(target_os = "linux")]
+use std::path::{Path, PathBuf};
+#[cfg(target_os = "linux")]
+use std::process::Command;
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tracing::{debug, info, warn};
+use url::Url;
+
+pub const DEFAULT_LISTEN_ADDR: &str = "0.0.0.0:17671";
+#[cfg(target_os = "linux")]
+const ENFORCER_TABLE: &str = "openshell_external_enforcer";
+#[cfg(target_os = "linux")]
+const NFT_SEARCH_PATHS: &[&str] = &["/usr/sbin/nft", "/sbin/nft", "/usr/bin/nft"];
+#[cfg(target_os = "linux")]
+const PROC_ROOT: &str = "/proc";
+
+#[derive(Debug, Clone)]
+pub struct EnforcerRuntimeConfig {
+    pub listen_addr: SocketAddr,
+    pub network_enforcement_mode: NetworkEnforcementMode,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkloadRegistration {
+    pub endpoint: String,
+    pub sandbox_id: String,
+    pub sandbox_name: Option<String>,
+    pub pod_ip: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistrationPayload {
+    sandbox_id: String,
+    sandbox_name: Option<String>,
+    pod_ip: Option<String>,
+    protocol: Option<String>,
+}
+
+pub async fn run(config: EnforcerRuntimeConfig) -> Result<i32> {
+    let listener = TcpListener::bind(config.listen_addr)
+        .await
+        .into_diagnostic()?;
+    warn!(
+        listen_addr = %config.listen_addr,
+        network_enforcement_mode = %config.network_enforcement_mode,
+        "OpenShell node enforcer started; workload registrations install coarse pod-netns egress rules"
+    );
+    info!(
+        listen_addr = %config.listen_addr,
+        "Node enforcer is watching for workload supervisor registrations"
+    );
+
+    loop {
+        let (stream, peer) = listener.accept().await.into_diagnostic()?;
+        let mode = config.network_enforcement_mode;
+        tokio::spawn(async move {
+            if let Err(error) = handle_registration(stream, peer, mode).await {
+                debug!(error = %error, peer = %peer, "Failed to handle enforcer request");
+            }
+        });
+    }
+}
+
+async fn handle_registration(
+    mut stream: TcpStream,
+    peer: SocketAddr,
+    mode: NetworkEnforcementMode,
+) -> Result<()> {
+    let request_bytes = read_http_request(&mut stream).await?;
+    let request = String::from_utf8_lossy(&request_bytes);
+    let request_line = request.lines().next().unwrap_or_default();
+    let payload = request
+        .split_once("\r\n\r\n")
+        .and_then(|(_, body)| serde_json::from_str::<RegistrationPayload>(body).ok());
+
+    if let Some(payload) = payload {
+        info!(
+            peer = %peer,
+            request = request_line,
+            sandbox_id = %payload.sandbox_id,
+            sandbox_name = payload.sandbox_name.as_deref().unwrap_or_default(),
+            pod_ip = payload.pod_ip.as_deref().unwrap_or_default(),
+            protocol = payload.protocol.as_deref().unwrap_or_default(),
+            "Observed sandbox workload registration"
+        );
+        info!(
+            sandbox_id = %payload.sandbox_id,
+            pod_ip = payload.pod_ip.as_deref().unwrap_or_default(),
+            network_enforcement_mode = %mode,
+            action = "install-coarse-egress-enforcement",
+            "Reconciling sandbox network enforcement"
+        );
+
+        if matches!(mode, NetworkEnforcementMode::ExternalEnforcer) {
+            let target_ip = target_pod_ip(&payload, peer);
+            if let Some(pod_ip) = target_ip {
+                let sandbox_id = payload.sandbox_id.clone();
+                install_external_enforcement_blocking(sandbox_id, pod_ip).await?;
+            } else {
+                warn!(
+                    peer = %peer,
+                    sandbox_id = %payload.sandbox_id,
+                    pod_ip = payload.pod_ip.as_deref().unwrap_or_default(),
+                    "Skipping host-side enforcement because no non-loopback pod IP is available"
+                );
+            }
+        }
+    } else {
+        warn!(
+            peer = %peer,
+            request = request_line,
+            "Accepted workload supervisor registration without parseable payload"
+        );
+    }
+
+    let response = concat!(
+        "HTTP/1.1 202 Accepted\r\n",
+        "Content-Length: 0\r\n",
+        "Connection: close\r\n",
+        "\r\n"
+    );
+    stream
+        .write_all(response.as_bytes())
+        .await
+        .into_diagnostic()?;
+    Ok(())
+}
+
+async fn read_http_request(stream: &mut TcpStream) -> Result<Vec<u8>> {
+    let mut buf = vec![0_u8; 8192];
+    let mut len = 0_usize;
+    let mut header_end = None;
+
+    while len < buf.len() {
+        let read = stream.read(&mut buf[len..]).await.into_diagnostic()?;
+        if read == 0 {
+            break;
+        }
+        len += read;
+        if let Some(pos) = find_header_end(&buf[..len]) {
+            header_end = Some(pos);
+            break;
+        }
+    }
+
+    let Some(header_end) = header_end else {
+        buf.truncate(len);
+        return Ok(buf);
+    };
+
+    let headers = String::from_utf8_lossy(&buf[..header_end]);
+    let content_length = headers
+        .lines()
+        .find_map(|line| line.split_once(':'))
+        .and_then(|(name, value)| {
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())
+                .flatten()
+        })
+        .unwrap_or(0);
+    let request_len = header_end + 4 + content_length;
+
+    if request_len > buf.len() {
+        buf.resize(request_len, 0);
+    }
+    while len < request_len {
+        let read = stream
+            .read(&mut buf[len..request_len])
+            .await
+            .into_diagnostic()?;
+        if read == 0 {
+            break;
+        }
+        len += read;
+    }
+
+    buf.truncate(len);
+    Ok(buf)
+}
+
+fn find_header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn target_pod_ip(payload: &RegistrationPayload, peer: SocketAddr) -> Option<IpAddr> {
+    payload
+        .pod_ip
+        .as_deref()
+        .and_then(|ip| ip.parse::<IpAddr>().ok())
+        .or_else(|| (!peer.ip().is_loopback()).then_some(peer.ip()))
+        .filter(|ip| !ip.is_loopback())
+}
+
+#[cfg(target_os = "linux")]
+async fn install_external_enforcement_blocking(sandbox_id: String, pod_ip: IpAddr) -> Result<()> {
+    tokio::task::spawn_blocking(move || install_external_enforcement(&sandbox_id, pod_ip))
+        .await
+        .map_err(|error| miette::miette!("enforcer task panicked: {error}"))?
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn install_external_enforcement_blocking(sandbox_id: String, pod_ip: IpAddr) -> Result<()> {
+    let _ = sandbox_id;
+    Err(miette::miette!(
+        "external node enforcement is only supported on Linux nodes (pod_ip={pod_ip})"
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn install_external_enforcement(sandbox_id: &str, pod_ip: IpAddr) -> Result<()> {
+    info!(
+        sandbox_id,
+        pod_ip = %pod_ip,
+        "Installing sandbox network egress enforcement for pod {pod_ip}"
+    );
+    let netns_path = find_pod_netns_path(pod_ip)?;
+    let nft_path = find_nft().ok_or_else(|| {
+        miette::miette!(
+            "nft binary not found; node enforcer image must include nftables for external enforcement"
+        )
+    })?;
+
+    delete_enforcer_table(&netns_path, &nft_path);
+    let ruleset = generate_external_enforcer_ruleset(&external_log_prefix(sandbox_id));
+    run_nft_ruleset_in_netns(&netns_path, &nft_path, &ruleset)?;
+
+    info!(
+        sandbox_id,
+        pod_ip = %pod_ip,
+        netns = %netns_path.display(),
+        "Sandbox network egress enforcement installed for pod {pod_ip} in {}",
+        netns_path.display()
+    );
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn find_pod_netns_path(pod_ip: IpAddr) -> Result<PathBuf> {
+    let mut last_error = None;
+    for _ in 0..20 {
+        match find_pod_netns_path_once(pod_ip) {
+            Ok(path) => return Ok(path),
+            Err(error) => last_error = Some(error),
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        miette::miette!("failed to find pod network namespace for pod IP {pod_ip}")
+    }))
+}
+
+#[cfg(target_os = "linux")]
+fn find_pod_netns_path_once(pod_ip: IpAddr) -> Result<PathBuf> {
+    let proc = Path::new(PROC_ROOT);
+    let entries = std::fs::read_dir(proc).into_diagnostic()?;
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(pid) = file_name.to_str() else {
+            continue;
+        };
+        if !pid.as_bytes().iter().all(u8::is_ascii_digit) {
+            continue;
+        }
+
+        let netns_path = proc.join(pid).join("ns/net");
+        if !netns_path.exists() {
+            continue;
+        }
+
+        if proc_netns_has_local_ip(&proc.join(pid), pod_ip) {
+            return Ok(netns_path);
+        }
+    }
+
+    Err(miette::miette!(
+        "failed to find pod network namespace for pod IP {pod_ip}"
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn proc_netns_has_local_ip(proc_pid_path: &Path, pod_ip: IpAddr) -> bool {
+    match pod_ip {
+        IpAddr::V4(ip) => {
+            let fib_trie_path = proc_pid_path.join("net/fib_trie");
+            let Ok(fib_trie) = std::fs::read_to_string(&fib_trie_path) else {
+                return false;
+            };
+            fib_trie_contains_local_address(&fib_trie, &ip.to_string())
+        }
+        IpAddr::V6(ip) => {
+            let if_inet6_path = proc_pid_path.join("net/if_inet6");
+            let Ok(if_inet6) = std::fs::read_to_string(&if_inet6_path) else {
+                return false;
+            };
+            let compact = ip
+                .segments()
+                .iter()
+                .map(|segment| format!("{segment:04x}"))
+                .collect::<String>();
+            if_inet6
+                .lines()
+                .filter_map(|line| line.split_whitespace().next())
+                .any(|address| address.eq_ignore_ascii_case(&compact))
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn fib_trie_contains_local_address(fib_trie: &str, pod_ip: &str) -> bool {
+    let mut matched_leaf = false;
+
+    for line in fib_trie.lines() {
+        let mut parts = line.split_whitespace();
+        if let (Some(marker), Some(address)) = (parts.next(), parts.next())
+            && marker.ends_with("--")
+        {
+            matched_leaf = address == pod_ip;
+            continue;
+        }
+
+        if matched_leaf && line.split_whitespace().eq(["/32", "host", "LOCAL"]) {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn delete_enforcer_table(netns_path: &Path, nft_path: &str) {
+    if let Err(error) = run_nft_args_in_netns(
+        netns_path,
+        nft_path,
+        &["delete", "table", "inet", ENFORCER_TABLE],
+    ) {
+        debug!(
+            error = %error,
+            netns = %netns_path.display(),
+            "No prior external enforcer nftables table to delete"
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn run_nft_ruleset_in_netns(netns_path: &Path, nft_path: &str, ruleset: &str) -> Result<()> {
+    let mut file = tempfile::Builder::new()
+        .prefix("openshell-external-enforcer-")
+        .suffix(".nft")
+        .tempfile()
+        .into_diagnostic()?;
+    std::io::Write::write_all(&mut file, ruleset.as_bytes()).into_diagnostic()?;
+    let path = file.path().to_string_lossy().to_string();
+    run_nft_args_in_netns(netns_path, nft_path, &["-f", &path])
+}
+
+#[cfg(target_os = "linux")]
+fn run_nft_args_in_netns(netns_path: &Path, nft_path: &str, args: &[&str]) -> Result<()> {
+    let netns = std::fs::File::open(netns_path).into_diagnostic()?;
+    let fd = netns.as_raw_fd();
+    let output = {
+        let mut command = Command::new(nft_path);
+        command.args(args);
+        // SAFETY: pre_exec runs in the child after fork and before exec. setns
+        // is async-signal-safe and only affects the child process.
+        #[allow(unsafe_code)]
+        unsafe {
+            command.pre_exec(move || {
+                let result = libc::setns(fd, libc::CLONE_NEWNET);
+                if result != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        command.output().into_diagnostic()?
+    };
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(miette::miette!(
+        "nft command failed in pod netns: {}",
+        stderr.trim()
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn generate_external_enforcer_ruleset(log_prefix: &str) -> String {
+    format!(
+        r#"table inet {ENFORCER_TABLE} {{
+    chain output {{
+        type filter hook output priority 0; policy accept;
+
+        oifname "lo" accept
+        ct state established,related accept
+        meta skuid 0 accept
+        tcp flags syn limit rate 5/second burst 10 packets log prefix "{log_prefix}" flags skuid
+        meta nfproto ipv4 meta l4proto tcp reject with icmp type port-unreachable
+        meta nfproto ipv6 meta l4proto tcp reject with icmpv6 type port-unreachable
+        meta l4proto udp limit rate 5/second burst 10 packets log prefix "{log_prefix}" flags skuid
+        meta nfproto ipv4 meta l4proto udp reject with icmp type port-unreachable
+        meta nfproto ipv6 meta l4proto udp reject with icmpv6 type port-unreachable
+    }}
+}}
+"#
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn external_log_prefix(sandbox_id: &str) -> String {
+    let short_id: String = sandbox_id
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || *ch == '-')
+        .take(16)
+        .collect();
+    format!("openshell:external:{short_id}:")
+}
+
+#[cfg(target_os = "linux")]
+fn find_nft() -> Option<String> {
+    NFT_SEARCH_PATHS
+        .iter()
+        .find(|path| Path::new(path).is_file())
+        .map(|path| (*path).to_string())
+}
+
+pub async fn register_workload(registration: WorkloadRegistration) -> Result<()> {
+    let url = Url::parse(registration.endpoint.trim()).into_diagnostic()?;
+    if url.scheme() != "http" {
+        return Err(miette::miette!(
+            "external enforcer endpoint must use http:// for the prototype registration protocol"
+        ));
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| miette::miette!("external enforcer endpoint is missing a host"))?;
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(|| miette::miette!("external enforcer endpoint is missing a port"))?;
+    let addr = format!("{host}:{port}");
+    let path = if url.path().is_empty() || url.path() == "/" {
+        format!("/v1/sandboxes/{}/register", registration.sandbox_id)
+    } else {
+        url.path().to_string()
+    };
+
+    let mut stream = TcpStream::connect(&addr).await.into_diagnostic()?;
+    let body = serde_json::json!({
+        "sandbox_id": registration.sandbox_id,
+        "sandbox_name": registration.sandbox_name,
+        "pod_ip": registration.pod_ip,
+        "protocol": "openshell-node-enforcer-prototype-v1"
+    })
+    .to_string();
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: {host}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .into_diagnostic()?;
+
+    let mut response = [0_u8; 128];
+    let read = stream.read(&mut response).await.into_diagnostic()?;
+    let status = String::from_utf8_lossy(&response[..read]);
+    if status.starts_with("HTTP/1.1 202") || status.starts_with("HTTP/1.1 200") {
+        info!(endpoint = %registration.endpoint, "External enforcer registration acknowledged");
+        return Ok(());
+    }
+
+    Err(miette::miette!(
+        "external enforcer registration failed: {}",
+        status.lines().next().unwrap_or("empty response")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn register_workload_accepts_enforcer_ack() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, peer) = listener.accept().await.unwrap();
+            handle_registration(stream, peer, NetworkEnforcementMode::ExternalEnforcer)
+                .await
+                .unwrap();
+        });
+
+        register_workload(WorkloadRegistration {
+            endpoint: format!("http://{addr}"),
+            sandbox_id: "sb-123".to_string(),
+            sandbox_name: Some("demo".to_string()),
+            pod_ip: None,
+        })
+        .await
+        .unwrap();
+
+        server.await.unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn external_ruleset_allows_root_and_rejects_non_root_tcp_udp() {
+        let ruleset = generate_external_enforcer_ruleset("openshell:external:test:");
+
+        assert!(ruleset.contains("table inet openshell_external_enforcer"));
+        assert!(ruleset.contains("oifname \"lo\" accept"));
+        assert!(ruleset.contains("meta skuid 0 accept"));
+        assert!(ruleset.contains("meta nfproto ipv4 meta l4proto tcp reject"));
+        assert!(ruleset.contains("meta nfproto ipv4 meta l4proto udp reject"));
+        assert!(
+            ruleset.find("meta skuid 0 accept").unwrap()
+                < ruleset
+                    .find("meta nfproto ipv4 meta l4proto tcp reject")
+                    .unwrap()
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn fib_trie_match_requires_local_address() {
+        let host_route = r#"
+           +-- 10.40.0.0/14 2 0 2
+              |-- 10.40.1.33
+                 /32 host UNICAST
+        "#;
+        let pod_local = r#"
+           +-- 0.0.0.0/0 3 0 5
+              |-- 10.40.1.33
+                 /32 host LOCAL
+        "#;
+
+        assert!(!fib_trie_contains_local_address(host_route, "10.40.1.33"));
+        assert!(fib_trie_contains_local_address(pod_local, "10.40.1.33"));
+    }
+
+    #[test]
+    fn target_pod_ip_prefers_payload_and_ignores_loopback() {
+        let payload = RegistrationPayload {
+            sandbox_id: "sb".to_string(),
+            sandbox_name: None,
+            pod_ip: Some("10.40.1.28".to_string()),
+            protocol: None,
+        };
+        let peer = "127.0.0.1:1234".parse().unwrap();
+        assert_eq!(
+            target_pod_ip(&payload, peer),
+            Some("10.40.1.28".parse().unwrap())
+        );
+
+        let payload = RegistrationPayload {
+            sandbox_id: "sb".to_string(),
+            sandbox_name: None,
+            pod_ip: None,
+            protocol: None,
+        };
+        assert_eq!(target_pod_ip(&payload, peer), None);
+    }
+}

--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -10,6 +10,7 @@ pub mod bypass_monitor;
 mod child_env;
 pub mod debug_rpc;
 pub mod denial_aggregator;
+pub mod enforcer;
 mod grpc_client;
 mod identity;
 pub mod l7;
@@ -43,6 +44,7 @@ use std::time::Duration;
 use tokio::time::timeout;
 use tracing::{debug, info, trace, warn};
 
+use openshell_core::sandbox_env::{NetworkEnforcementMode, SupervisorRole};
 use openshell_ocsf::{
     ActionId, ActivityId, AppLifecycleBuilder, ConfigStateChangeBuilder, DetectionFindingBuilder,
     DispositionId, FindingInfo, LaunchTypeId, Process as OcsfProcess, ProcessActivityBuilder,
@@ -189,6 +191,63 @@ pub use sandbox::apply_supervisor_startup_hardening;
 /// refreshed.
 const DEFAULT_ROUTE_REFRESH_INTERVAL_SECS: u64 = 5;
 
+#[derive(Debug, Clone)]
+pub struct SupervisorRuntimeConfig {
+    pub role: SupervisorRole,
+    pub network_enforcement_mode: NetworkEnforcementMode,
+    pub enforcer_endpoint: Option<String>,
+    pub pod_ip: Option<String>,
+}
+
+impl Default for SupervisorRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            role: SupervisorRole::Combined,
+            network_enforcement_mode: NetworkEnforcementMode::Auto,
+            enforcer_endpoint: None,
+            pod_ip: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffectiveNetworkEnforcementMode {
+    SoftProxy,
+    SupervisorNetns,
+    ExternalEnforcer,
+}
+
+impl EffectiveNetworkEnforcementMode {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SoftProxy => "soft-proxy",
+            Self::SupervisorNetns => "supervisor-netns",
+            Self::ExternalEnforcer => "external-enforcer",
+        }
+    }
+}
+
+pub fn resolve_network_enforcement_mode(
+    role: SupervisorRole,
+    requested: NetworkEnforcementMode,
+) -> EffectiveNetworkEnforcementMode {
+    match requested {
+        NetworkEnforcementMode::SoftProxy => EffectiveNetworkEnforcementMode::SoftProxy,
+        NetworkEnforcementMode::SupervisorNetns => EffectiveNetworkEnforcementMode::SupervisorNetns,
+        NetworkEnforcementMode::ExternalEnforcer => {
+            EffectiveNetworkEnforcementMode::ExternalEnforcer
+        }
+        NetworkEnforcementMode::Auto => {
+            if matches!(role, SupervisorRole::Workload) {
+                EffectiveNetworkEnforcementMode::SoftProxy
+            } else {
+                EffectiveNetworkEnforcementMode::SupervisorNetns
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InferenceRouteSource {
     File,
@@ -301,6 +360,7 @@ fn is_managed_child(pid: i32) -> bool {
 #[allow(clippy::too_many_arguments, clippy::similar_names)]
 pub async fn run_sandbox(
     command: Vec<String>,
+    runtime_config: SupervisorRuntimeConfig,
     workdir: Option<String>,
     timeout_secs: u64,
     interactive: bool,
@@ -344,6 +404,30 @@ pub async fn run_sandbox(
             debug!("OCSF context already initialized, keeping existing");
         }
     }
+
+    let effective_network_enforcement = resolve_network_enforcement_mode(
+        runtime_config.role,
+        runtime_config.network_enforcement_mode,
+    );
+    info!(
+        supervisor_role = %runtime_config.role,
+        requested_network_enforcement = %runtime_config.network_enforcement_mode,
+        effective_network_enforcement = effective_network_enforcement.as_str(),
+        "Resolved sandbox supervisor runtime mode"
+    );
+    ocsf_emit!(
+        ConfigStateChangeBuilder::new(ocsf_ctx())
+            .severity(SeverityId::Informational)
+            .status(StatusId::Success)
+            .state(StateId::Enabled, "resolved")
+            .message(format!(
+                "Supervisor mode resolved [role:{} requested_network:{} effective_network:{}]",
+                runtime_config.role,
+                runtime_config.network_enforcement_mode,
+                effective_network_enforcement.as_str()
+            ))
+            .build()
+    );
 
     // Load policy and initialize OPA engine
     let openshell_endpoint_for_proxy = openshell_endpoint.clone();
@@ -550,11 +634,62 @@ pub async fn run_sandbox(
         (None, None)
     };
 
+    if matches!(policy.network.mode, NetworkMode::Proxy) {
+        match effective_network_enforcement {
+            EffectiveNetworkEnforcementMode::SoftProxy => {
+                warn!(
+                    "Network enforcement is running in soft-proxy mode; proxy-aware traffic is enforced, but direct sockets are not kernel-blocked"
+                );
+                ocsf_emit!(
+                    ConfigStateChangeBuilder::new(ocsf_ctx())
+                        .severity(SeverityId::High)
+                        .status(StatusId::Success)
+                        .state(StateId::Other, "soft-proxy")
+                        .message(
+                            "Network enforcement is soft-proxy only; direct egress bypass is not kernel-blocked"
+                        )
+                        .build()
+                );
+            }
+            EffectiveNetworkEnforcementMode::ExternalEnforcer => {
+                let endpoint = runtime_config.enforcer_endpoint.as_deref().ok_or_else(|| {
+                    miette::miette!(
+                        "external-enforcer mode requires {} to be set",
+                        openshell_core::sandbox_env::ENFORCER_ENDPOINT
+                    )
+                })?;
+                let id = sandbox_id.as_deref().ok_or_else(|| {
+                    miette::miette!("external-enforcer mode requires a sandbox id")
+                })?;
+                enforcer::register_workload(enforcer::WorkloadRegistration {
+                    endpoint: endpoint.to_string(),
+                    sandbox_id: id.to_string(),
+                    sandbox_name: sandbox_name_for_agg.clone(),
+                    pod_ip: runtime_config.pod_ip.clone(),
+                })
+                .await?;
+                ocsf_emit!(
+                    ConfigStateChangeBuilder::new(ocsf_ctx())
+                        .severity(SeverityId::Informational)
+                        .status(StatusId::Success)
+                        .state(StateId::Other, "external-enforcer")
+                        .message("External network enforcer registration acknowledged")
+                        .build()
+                );
+            }
+            EffectiveNetworkEnforcementMode::SupervisorNetns => {}
+        }
+    }
+
     // Create network namespace for proxy mode (Linux only)
     // This must be created before the proxy AND SSH server so that SSH
     // sessions can enter the namespace for network isolation.
     #[cfg(target_os = "linux")]
-    let netns = if matches!(policy.network.mode, NetworkMode::Proxy) {
+    let netns = if matches!(policy.network.mode, NetworkMode::Proxy)
+        && matches!(
+            effective_network_enforcement,
+            EffectiveNetworkEnforcementMode::SupervisorNetns
+        ) {
         match NetworkNamespace::create() {
             Ok(ns) => {
                 // Install bypass detection rules (nftables log + reject).
@@ -582,9 +717,9 @@ pub async fn run_sandbox(
             }
             Err(e) => {
                 return Err(miette::miette!(
-                    "Network namespace creation failed and proxy mode requires isolation. \
-                     Ensure CAP_NET_ADMIN and CAP_SYS_ADMIN are available and iproute2 is installed. \
-                     Error: {e}"
+                    "Network namespace creation failed and supervisor-netns mode requires isolation. \
+                     Ensure CAP_NET_ADMIN and CAP_SYS_ADMIN are available and iproute2 is installed, \
+                     or select soft-proxy/external-enforcer mode. Error: {e}"
                 ));
             }
         }
@@ -714,15 +849,28 @@ pub async fn run_sandbox(
     let ssh_proxy_url = if matches!(policy.network.mode, NetworkMode::Proxy) {
         #[cfg(target_os = "linux")]
         {
-            netns.as_ref().map(|ns| {
-                let port = policy
-                    .network
-                    .proxy
-                    .as_ref()
-                    .and_then(|p| p.http_addr)
-                    .map_or(3128, |addr| addr.port());
-                format!("http://{}:{port}", ns.host_ip())
-            })
+            Some(netns.as_ref().map_or_else(
+                || {
+                    policy
+                        .network
+                        .proxy
+                        .as_ref()
+                        .and_then(|p| p.http_addr)
+                        .map_or_else(
+                            || "http://127.0.0.1:3128".to_string(),
+                            |addr| format!("http://{addr}"),
+                        )
+                },
+                |ns| {
+                    let port = policy
+                        .network
+                        .proxy
+                        .as_ref()
+                        .and_then(|p| p.http_addr)
+                        .map_or(3128, |addr| addr.port());
+                    format!("http://{}:{port}", ns.host_ip())
+                },
+            ))
         }
         #[cfg(not(target_os = "linux"))]
         {
@@ -2893,6 +3041,46 @@ mod tests {
     use temp_env::with_vars;
 
     static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    #[test]
+    fn auto_network_mode_resolves_to_soft_for_workload_role() {
+        assert_eq!(
+            resolve_network_enforcement_mode(
+                SupervisorRole::Workload,
+                NetworkEnforcementMode::Auto,
+            ),
+            EffectiveNetworkEnforcementMode::SoftProxy
+        );
+    }
+
+    #[test]
+    fn auto_network_mode_preserves_current_combined_netns_default() {
+        assert_eq!(
+            resolve_network_enforcement_mode(
+                SupervisorRole::Combined,
+                NetworkEnforcementMode::Auto,
+            ),
+            EffectiveNetworkEnforcementMode::SupervisorNetns
+        );
+    }
+
+    #[test]
+    fn explicit_network_mode_overrides_role_resolution() {
+        assert_eq!(
+            resolve_network_enforcement_mode(
+                SupervisorRole::Workload,
+                NetworkEnforcementMode::SupervisorNetns,
+            ),
+            EffectiveNetworkEnforcementMode::SupervisorNetns
+        );
+        assert_eq!(
+            resolve_network_enforcement_mode(
+                SupervisorRole::Combined,
+                NetworkEnforcementMode::ExternalEnforcer,
+            ),
+            EffectiveNetworkEnforcementMode::ExternalEnforcer
+        );
+    }
 
     #[test]
     fn bundle_to_resolved_routes_converts_all_fields() {

--- a/crates/openshell-sandbox/src/main.rs
+++ b/crates/openshell-sandbox/src/main.rs
@@ -15,7 +15,8 @@ use tracing_subscriber::EnvFilter;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::{Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
-use openshell_sandbox::run_sandbox;
+use openshell_core::sandbox_env::{NetworkEnforcementMode, SupervisorRole};
+use openshell_sandbox::{SupervisorRuntimeConfig, run_sandbox};
 
 /// Subcommand name used to self-copy the supervisor binary into a shared volume.
 ///
@@ -105,6 +106,34 @@ struct Args {
     /// Port for health check endpoint.
     #[arg(long, default_value = "8080")]
     health_port: u16,
+
+    /// Runtime role for this supervisor process.
+    #[arg(
+        long,
+        env = openshell_core::sandbox_env::SUPERVISOR_ROLE,
+        default_value_t = SupervisorRole::Combined
+    )]
+    supervisor_role: SupervisorRole,
+
+    /// Network enforcement mode for this supervisor process.
+    #[arg(
+        long,
+        env = openshell_core::sandbox_env::NETWORK_ENFORCEMENT_MODE,
+        default_value_t = NetworkEnforcementMode::Auto
+    )]
+    network_enforcement_mode: NetworkEnforcementMode,
+
+    /// Endpoint for a node/host enforcer when using external-enforcer mode.
+    #[arg(long, env = openshell_core::sandbox_env::ENFORCER_ENDPOINT)]
+    enforcer_endpoint: Option<String>,
+
+    /// Pod IP supplied by Kubernetes for external enforcer registration.
+    #[arg(long, env = openshell_core::sandbox_env::POD_IP)]
+    pod_ip: Option<String>,
+
+    /// Listen address used when this process runs as a node/host enforcer.
+    #[arg(long, default_value = openshell_sandbox::enforcer::DEFAULT_LISTEN_ADDR)]
+    enforcer_listen_addr: std::net::SocketAddr,
 }
 
 /// Copy the running executable to `dest`, creating parent directories as
@@ -287,6 +316,28 @@ fn main() -> Result<()> {
             vec!["/bin/bash".to_string()]
         };
 
+        if matches!(args.supervisor_role, SupervisorRole::Enforcer) {
+            info!(
+                listen_addr = %args.enforcer_listen_addr,
+                network_enforcement_mode = %args.network_enforcement_mode,
+                "Starting OpenShell node enforcer"
+            );
+            return openshell_sandbox::enforcer::run(
+                openshell_sandbox::enforcer::EnforcerRuntimeConfig {
+                    listen_addr: args.enforcer_listen_addr,
+                    network_enforcement_mode: args.network_enforcement_mode,
+                },
+            )
+            .await;
+        }
+
+        let runtime_config = SupervisorRuntimeConfig {
+            role: args.supervisor_role,
+            network_enforcement_mode: args.network_enforcement_mode,
+            enforcer_endpoint: args.enforcer_endpoint,
+            pod_ip: args.pod_ip,
+        };
+
         info!(command = ?command, "Starting sandbox");
         // Note: "Starting sandbox" stays as plain info!() since the OCSF context
         // is not yet initialized at this point (run_sandbox hasn't been called).
@@ -294,6 +345,7 @@ fn main() -> Result<()> {
 
         run_sandbox(
             command,
+            runtime_config,
             args.workdir,
             args.timeout,
             args.interactive,

--- a/crates/openshell-sandbox/src/process.rs
+++ b/crates/openshell-sandbox/src/process.rs
@@ -242,8 +242,11 @@ impl ProcessHandle {
                 for (key, value) in child_env::proxy_env_vars(&proxy_url) {
                     cmd.env(key, value);
                 }
-            } else if let Some(http_addr) = proxy.http_addr {
-                let proxy_url = format!("http://{http_addr}");
+            } else {
+                let proxy_url = proxy.http_addr.map_or_else(
+                    || "http://127.0.0.1:3128".to_string(),
+                    |http_addr| format!("http://{http_addr}"),
+                );
                 for (key, value) in child_env::proxy_env_vars(&proxy_url) {
                     cmd.env(key, value);
                 }
@@ -541,6 +544,10 @@ pub fn drop_privileges(policy: &SandboxPolicy) -> Result<()> {
             .into_diagnostic()?
             .ok_or_else(|| miette::miette!("Failed to resolve user primary group"))?
     };
+
+    if nix::unistd::geteuid() == user.uid && nix::unistd::getegid() == group.gid {
+        return Ok(());
+    }
 
     if user_name.is_some() {
         let user_cstr =

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -1538,4 +1538,23 @@ default_image = "k8s-specific:1.0"
             .expect("deserializes");
         assert_eq!(parsed.default_image, "k8s-specific:1.0");
     }
+
+    #[test]
+    fn kubernetes_driver_parses_privileged_from_driver_table() {
+        let file = config_file_from_toml(
+            r#"
+[openshell.drivers.kubernetes]
+privileged = true
+"#,
+        );
+        let merged = crate::config_file::driver_table(
+            super::ComputeDriverKind::Kubernetes,
+            &file.openshell.gateway,
+            file.openshell.drivers.get("kubernetes"),
+        );
+        let parsed = merged
+            .try_into::<openshell_driver_kubernetes::KubernetesComputeConfig>()
+            .expect("deserializes");
+        assert!(parsed.privileged);
+    }
 }

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -1542,10 +1542,10 @@ default_image = "k8s-specific:1.0"
     #[test]
     fn kubernetes_driver_parses_privileged_from_driver_table() {
         let file = config_file_from_toml(
-            r#"
+            r"
 [openshell.drivers.kubernetes]
 privileged = true
-"#,
+",
         );
         let merged = crate::config_file::driver_table(
             super::ComputeDriverKind::Kubernetes,

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -334,7 +334,7 @@ impl ComputeRuntime {
     ) -> Result<Self, ComputeError> {
         let driver = KubernetesComputeDriver::new(config)
             .await
-            .map_err(|err| ComputeError::Message(err.to_string()))?;
+            .map_err(ComputeError::from)?;
         let driver: SharedComputeDriver = Arc::new(ComputeDriverService::new(driver));
         Self::from_driver(
             ComputeDriverKind::Kubernetes,

--- a/deploy/docker/Dockerfile.supervisor
+++ b/deploy/docker/Dockerfile.supervisor
@@ -5,10 +5,10 @@
 
 # Supervisor image build.
 #
-# The final image is `scratch`: it only carries the static `openshell-sandbox`
-# binary used by Docker extraction, Podman image volumes, and the Kubernetes
-# init container copy-self path. A static musl binary lets the image stay
-# `scratch` while still being executable as an init container.
+# The final image carries the static `openshell-sandbox` binary used by Docker
+# extraction, Podman image volumes, and the Kubernetes init container copy-self
+# path. It also includes nftables so the same image can run the Kubernetes
+# node-enforcer DaemonSet and install pod network-namespace egress rules.
 #
 # The Rust binary is built natively before this image build runs and staged at:
 #   deploy/docker/.build/prebuilt-binaries/<arch>/openshell-sandbox
@@ -19,9 +19,11 @@
 # target) and uploads it as an artifact, which is downloaded into the same
 # staging directory before the image build job runs.
 
-FROM scratch AS supervisor
+FROM alpine:3.22 AS supervisor
 
 ARG TARGETARCH
+
+RUN apk add --no-cache nftables
 
 # --chmod=0550 drops world-execute and survives the actions/upload-artifact
 # + download-artifact roundtrip (which strips exec perms). Ownership is left

--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -151,6 +151,13 @@ JWT signing Secret.
 | imagePullSecrets | list | `[]` | Image pull secrets attached to gateway and helper pods. |
 | nameOverride | string | `"openshell"` | Override the chart name used in generated resource names. |
 | networkPolicy.enabled | bool | `true` | Create a NetworkPolicy restricting SSH ingress on sandbox pods to the gateway. |
+| nodeEnforcer.affinity | object | `{}` | Affinity rules for the node enforcer DaemonSet. |
+| nodeEnforcer.enabled | bool | `false` | Deploy the privileged node enforcer DaemonSet. |
+| nodeEnforcer.listenAddress | string | `"0.0.0.0:17671"` | Listen address for the node enforcer registration endpoint. |
+| nodeEnforcer.logLevel | string | `"info"` | Node enforcer log level. |
+| nodeEnforcer.nodeSelector | object | `{}` | Node selector for the node enforcer DaemonSet. |
+| nodeEnforcer.resources | object | `{}` | Node enforcer pod resource requests and limits. |
+| nodeEnforcer.tolerations | list | `[]` | Tolerations for the node enforcer DaemonSet. |
 | nodeSelector | object | `{}` | Node selector for the gateway pod. |
 | pkiInitJob.enabled | bool | `true` | Run a pre-install/pre-upgrade Job that creates gateway and client mTLS Secrets. When certManager.enabled=true, cert-manager owns TLS and this same hook runs in JWT-only mode even if pkiInitJob.enabled remains true. |
 | pkiInitJob.serverDnsNames | list | `[]` | Extra DNS SANs to append to the server certificate. |
@@ -188,14 +195,16 @@ JWT signing Secret.
 | server.appArmorProfile | string | `"Unconfined"` | Kubernetes AppArmor profile requested for sandbox agent containers. Default Unconfined avoids runtime/default AppArmor blocking the supervisor's network namespace mount setup on AppArmor-enabled nodes. Set to "" to omit the field, "RuntimeDefault" to force the runtime default profile, or "Localhost/profile-name" for an operator-managed localhost profile. |
 | server.auth.allowUnauthenticatedUsers | bool | `false` | UNSAFE: accept unauthenticated CLI/user requests as a local developer principal. Intended only for trusted local Skaffold/k3d development or a fully trusted fronting proxy. Leave false for shared or production clusters. |
 | server.dbUrl | string | `"sqlite:/var/openshell/openshell.db"` | Gateway database URL (used for the default SQLite backend). |
-| server.defaultRuntimeClassName | string | `""` | Default Kubernetes runtimeClassName for sandbox pods. Applied when a CreateSandbox request does not specify one. Empty (default) = omit the field, using the cluster's default RuntimeClass. Set to a RuntimeClass name (e.g. "kata-containers", "nvidia") to apply it to all sandboxes that don't explicitly override it. |
+| server.defaultRuntimeClassName | string | `""` | Default Kubernetes runtimeClassName for sandbox pods. Applied when a CreateSandbox request does not specify one. Empty (default) = omit the field, using the cluster's default RuntimeClass. Set to a RuntimeClass name (e.g. "gvisor", "kata-containers", "nvidia") to apply it to all sandboxes that don't explicitly override it. The gateway validates this RuntimeClass during startup when configured. |
 | server.disableTls | bool | `false` | Disable TLS entirely - the server listens on plaintext HTTP. Set to true when a reverse proxy / tunnel terminates TLS at the edge. |
 | server.enableLoopbackServiceHttp | bool | `true` | Enable plaintext HTTP routing for loopback sandbox service URLs on TLS-enabled gateways. |
 | server.enableUserNamespaces | bool | `false` | Enable Kubernetes user namespace isolation (hostUsers: false) for sandbox pods. Requires Kubernetes 1.33+ with user namespace support available (beta through 1.35, GA in 1.36+), plus a supporting container runtime and Linux 5.12+. When enabled, container UID 0 maps to an unprivileged host UID and capabilities become namespaced. |
+| server.enforcerEndpoint | string | `""` | Endpoint template for external-enforcer mode. Empty defaults each sandbox to http://$(OPENSHELL_NODE_IP):17671. |
 | server.externalDbSecret | string | `""` | Name of a pre-existing Opaque Secret containing a PostgreSQL connection URI (key: uri). When set, the gateway reads OPENSHELL_DB_URL from this Secret instead of using dbUrl. The Secret must contain a `uri` key, e.g. postgresql://user:pass@host:5432/dbname. |
 | server.grpcEndpoint | string | `""` | gRPC endpoint sandboxes call back into the gateway. Leave empty to derive it from the chart fullname, release namespace, service port, and disableTls flag, for example https://openshell.openshell.svc.cluster.local:8080. Override only when sandboxes must reach the gateway via a different hostname (e.g. an external ingress or a host alias). |
 | server.hostGatewayIP | string | `""` | Host gateway IP for sandbox pod hostAliases. When set, sandbox pods get hostAliases entries mapping host.docker.internal and host.openshell.internal to this IP, allowing them to reach services running on the Docker host. Auto-detected by the cluster entrypoint script. |
 | server.logLevel | string | `"info"` | Gateway log level. |
+| server.networkEnforcementMode | string | `"soft-proxy"` | Network enforcement mode for sandbox supervisors. soft-proxy keeps pods unprivileged and enforces proxy-aware traffic; direct socket bypass is not kernel-blocked. Use supervisor-netns only with trusted privileged sandbox pods. external-enforcer registers with the optional nodeEnforcer DaemonSet for coarse pod-netns egress blocking while dynamic policy stays in the proxy. |
 | server.oidc.adminRole | string | `""` | Role name for admin access. Leave empty (with userRole also empty) for authentication-only mode. Both must be set or both empty. |
 | server.oidc.audience | string | `"openshell-cli"` | Expected audience claim for the API resource server. This should match the server's --oidc-audience, NOT the CLI client ID. |
 | server.oidc.caConfigMapName | string | `""` | Name of a ConfigMap containing a CA certificate bundle (key: ca.crt) for verifying the OIDC issuer's TLS certificate. Required when the issuer uses a non-public CA (e.g. OpenShift ingress, private PKI). |
@@ -213,6 +222,8 @@ JWT signing Secret.
 | server.sandboxJwt.signingSecretName | string | `""` | Name of the Opaque Secret holding the signing key material. Empty falls back to the chart fullname with "-jwt-keys" appended. |
 | server.sandboxJwt.ttlSecs | int | `3600` | Token TTL in seconds. Defaults to 3600 (1h). |
 | server.sandboxNamespace | string | `""` | Namespace where sandbox pods are created. Defaults to the Helm release namespace (.Release.Namespace) when left empty. |
+| server.sandboxPrivileged | bool | `false` | Set securityContext.privileged on all sandbox pod containers. This is a short-term compatibility escape hatch for trusted clusters that require privileged pod admission and weakens the container boundary. |
+| server.supervisorRole | string | `"workload"` | Runtime role passed to the sandbox supervisor. Kubernetes defaults to workload mode so the injected binary owns agent lifecycle without assuming it can perform host/node-level enforcement. |
 | server.tls.certSecretName | string | `"openshell-server-tls"` | K8s secret (type kubernetes.io/tls) with tls.crt and tls.key for the server. |
 | server.tls.clientCaSecretName | string | `"openshell-server-client-ca"` | K8s secret with ca.crt for client certificate verification (mTLS). Set to "" to disable mTLS and run HTTPS-only (use OIDC for auth instead). |
 | server.tls.clientTlsSecretName | string | `"openshell-client-tls"` | K8s secret mounted into sandbox pods for mTLS to the server. |

--- a/deploy/helm/openshell/ci/values-node-enforcer.yaml
+++ b/deploy/helm/openshell/ci/values-node-enforcer.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# CI/dev overlay for exercising the Kubernetes node-enforcer topology.
+# Sandbox pods stay unprivileged in workload supervisor mode, while the
+# privileged node enforcer DaemonSet owns coarse pod-network-namespace egress
+# enforcement.
+nodeEnforcer:
+  enabled: true
+
+server:
+  networkEnforcementMode: external-enforcer

--- a/deploy/helm/openshell/skaffold.yaml
+++ b/deploy/helm/openshell/skaffold.yaml
@@ -97,6 +97,8 @@ deploy:
           #- ci/values-keycloak.yaml
           # To enable the Gateway API HTTPRoute (requires Envoy Gateway above):
           #- ci/values-gateway.yaml
+          # To test the external node-enforcer topology:
+          #- ci/values-node-enforcer.yaml
           # To test HA gateway behavior with bundled PostgreSQL:
           #- ci/values-high-availability.yaml
         setValueTemplates:

--- a/deploy/helm/openshell/templates/_helpers.tpl
+++ b/deploy/helm/openshell/templates/_helpers.tpl
@@ -49,6 +49,30 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Selector labels for the node enforcer DaemonSet.
+
+The node enforcer must not share the gateway Service selector labels because it
+does not expose the gateway's named ports.
+*/}}
+{{- define "openshell.nodeEnforcerName" -}}
+{{- printf "%s-node-enforcer" (include "openshell.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "openshell.nodeEnforcerSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "openshell.nodeEnforcerName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "openshell.nodeEnforcerLabels" -}}
+helm.sh/chart: {{ include "openshell.chart" . }}
+{{ include "openshell.nodeEnforcerSelectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "openshell.serviceAccountName" -}}

--- a/deploy/helm/openshell/templates/clusterrole.yaml
+++ b/deploy/helm/openshell/templates/clusterrole.yaml
@@ -24,3 +24,12 @@ rules:
       - get
       - list
       - watch
+  # Startup preflight validates the configured RuntimeClass before accepting
+  # sandbox work so missing classes fail at gateway startup instead of later
+  # as pod sandbox creation errors.
+  - apiGroups:
+      - node.k8s.io
+    resources:
+      - runtimeclasses
+    verbs:
+      - get

--- a/deploy/helm/openshell/templates/gateway-config.yaml
+++ b/deploy/helm/openshell/templates/gateway-config.yaml
@@ -100,6 +100,14 @@ data:
 
     [openshell.drivers.kubernetes]
     grpc_endpoint                = {{ include "openshell.grpcEndpoint" . | quote }}
+    supervisor_role             = {{ .Values.server.supervisorRole | quote }}
+    network_enforcement_mode    = {{ .Values.server.networkEnforcementMode | quote }}
+    {{- if .Values.server.enforcerEndpoint }}
+    enforcer_endpoint           = {{ .Values.server.enforcerEndpoint | quote }}
+    {{- end }}
+    {{- if .Values.server.sandboxPrivileged }}
+    privileged                   = true
+    {{- end }}
     service_account_name         = {{ include "openshell.sandboxServiceAccountName" . | quote }}
     supervisor_sideload_method   = {{ include "openshell.supervisorSideloadMethod" . | quote }}
     sa_token_ttl_secs            = {{ .Values.server.sandboxJwt.k8sSaTokenTtlSecs | default 3600 }}

--- a/deploy/helm/openshell/templates/node-enforcer.yaml
+++ b/deploy/helm/openshell/templates/node-enforcer.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.nodeEnforcer.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "openshell.fullname" . }}-node-enforcer
+  labels:
+    {{- include "openshell.labels" . | nindent 4 }}
+    app.kubernetes.io/component: node-enforcer
+spec:
+  selector:
+    matchLabels:
+      {{- include "openshell.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: node-enforcer
+  template:
+    metadata:
+      labels:
+        {{- include "openshell.labels" . | nindent 8 }}
+        app.kubernetes.io/component: node-enforcer
+    spec:
+      hostNetwork: true
+      hostPID: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: {{ include "openshell.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: node-enforcer
+          image: {{ include "openshell.supervisorImage" . | quote }}
+          imagePullPolicy: {{ .Values.supervisor.image.pullPolicy | default .Values.image.pullPolicy }}
+          args:
+            - --supervisor-role
+            - enforcer
+            - --network-enforcement-mode
+            - external-enforcer
+            - --enforcer-listen-addr
+            - {{ .Values.nodeEnforcer.listenAddress | quote }}
+            - --log-level
+            - {{ .Values.nodeEnforcer.logLevel | quote }}
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+          {{- with .Values.nodeEnforcer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeEnforcer.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeEnforcer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeEnforcer.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/openshell/templates/node-enforcer.yaml
+++ b/deploy/helm/openshell/templates/node-enforcer.yaml
@@ -12,12 +12,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "openshell.selectorLabels" . | nindent 6 }}
+      {{- include "openshell.nodeEnforcerSelectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: node-enforcer
   template:
     metadata:
       labels:
-        {{- include "openshell.labels" . | nindent 8 }}
+        {{- include "openshell.nodeEnforcerLabels" . | nindent 8 }}
         app.kubernetes.io/component: node-enforcer
     spec:
       hostNetwork: true

--- a/deploy/helm/openshell/tests/gateway_config_test.yaml
+++ b/deploy/helm/openshell/tests/gateway_config_test.yaml
@@ -96,6 +96,64 @@ tests:
           path: data["gateway.toml"]
           pattern: 'image_pull_secrets\s*='
 
+  - it: omits default_runtime_class_name by default
+    template: templates/gateway-config.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["gateway.toml"]
+          pattern: 'default_runtime_class_name\s*='
+
+  - it: renders the configured default RuntimeClass under [openshell.drivers.kubernetes]
+    template: templates/gateway-config.yaml
+    set:
+      server.defaultRuntimeClassName: gvisor
+    asserts:
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?ms)\[openshell\.drivers\.kubernetes\].*?default_runtime_class_name\s*=\s*"gvisor"'
+
+  - it: renders default supervisor workload soft-proxy mode
+    template: templates/gateway-config.yaml
+    asserts:
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?ms)\[openshell\.drivers\.kubernetes\].*?supervisor_role\s*=\s*"workload"'
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?ms)\[openshell\.drivers\.kubernetes\].*?network_enforcement_mode\s*=\s*"soft-proxy"'
+
+  - it: renders external enforcer endpoint when configured
+    template: templates/gateway-config.yaml
+    set:
+      server.networkEnforcementMode: external-enforcer
+      server.enforcerEndpoint: http://$(OPENSHELL_NODE_IP):17671
+    asserts:
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?ms)\[openshell\.drivers\.kubernetes\].*?network_enforcement_mode\s*=\s*"external-enforcer"'
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?ms)\[openshell\.drivers\.kubernetes\].*?enforcer_endpoint\s*=\s*"http://\$\(OPENSHELL_NODE_IP\):17671"'
+
+  - it: omits privileged sandbox pods by default
+    template: templates/gateway-config.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["gateway.toml"]
+          pattern: 'privileged\s*='
+
+  - it: renders privileged sandbox pods under [openshell.drivers.kubernetes]
+    template: templates/gateway-config.yaml
+    set:
+      server.sandboxPrivileged: true
+    asserts:
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?ms)\[openshell\.drivers\.kubernetes\].*?privileged\s*=\s*true'
+      - notMatchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?ms)\[openshell\.gateway\][^\[]*?privileged\s*='
+
   - it: does not render local mTLS user auth for Kubernetes deployments
     template: templates/gateway-config.yaml
     asserts:

--- a/deploy/helm/openshell/tests/node_enforcer_test.yaml
+++ b/deploy/helm/openshell/tests/node_enforcer_test.yaml
@@ -25,6 +25,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.privileged
           value: true
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: openshell-node-enforcer
       - contains:
           path: spec.template.spec.containers[0].args
           content: external-enforcer

--- a/deploy/helm/openshell/tests/node_enforcer_test.yaml
+++ b/deploy/helm/openshell/tests/node_enforcer_test.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: node enforcer
+templates:
+  - templates/node-enforcer.yaml
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders privileged node enforcer daemonset when enabled
+    set:
+      nodeEnforcer.enabled: true
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.template.spec.hostPID
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.privileged
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: external-enforcer

--- a/deploy/helm/openshell/tests/runtime_class_rbac_test.yaml
+++ b/deploy/helm/openshell/tests/runtime_class_rbac_test.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: runtime class RBAC
+templates:
+  - templates/clusterrole.yaml
+release:
+  name: openshell
+  namespace: my-namespace
+
+tests:
+  - it: allows the gateway to preflight configured RuntimeClasses
+    asserts:
+      - equal:
+          path: rules[2].apiGroups[0]
+          value: node.k8s.io
+      - equal:
+          path: rules[2].resources[0]
+          value: runtimeclasses
+      - equal:
+          path: rules[2].verbs[0]
+          value: get

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -122,6 +122,25 @@ probes:
 # -- Gateway pod resource requests and limits.
 resources: {}
 
+# Optional node-side enforcer topology. This runs the supervisor image as a
+# privileged DaemonSet so sandbox pods can stay unprivileged while a node
+# component owns coarse pod-network-namespace egress enforcement.
+nodeEnforcer:
+  # -- Deploy the privileged node enforcer DaemonSet.
+  enabled: false
+  # -- Listen address for the node enforcer registration endpoint.
+  listenAddress: "0.0.0.0:17671"
+  # -- Node enforcer log level.
+  logLevel: info
+  # -- Node enforcer pod resource requests and limits.
+  resources: {}
+  # -- Node selector for the node enforcer DaemonSet.
+  nodeSelector: {}
+  # -- Tolerations for the node enforcer DaemonSet.
+  tolerations: []
+  # -- Affinity rules for the node enforcer DaemonSet.
+  affinity: {}
+
 # -- Node selector for the gateway pod.
 nodeSelector: {}
 
@@ -161,8 +180,9 @@ server:
   # -- Default Kubernetes runtimeClassName for sandbox pods.
   # Applied when a CreateSandbox request does not specify one.
   # Empty (default) = omit the field, using the cluster's default RuntimeClass.
-  # Set to a RuntimeClass name (e.g. "kata-containers", "nvidia") to apply it
-  # to all sandboxes that don't explicitly override it.
+  # Set to a RuntimeClass name (e.g. "gvisor", "kata-containers", "nvidia") to
+  # apply it to all sandboxes that don't explicitly override it. The gateway
+  # validates this RuntimeClass during startup when configured.
   defaultRuntimeClassName: ""
   # -- gRPC endpoint sandboxes call back into the gateway. Leave empty to derive
   # it from the chart fullname, release namespace, service port, and
@@ -189,6 +209,23 @@ server:
   # the field, "RuntimeDefault" to force the runtime default profile, or
   # "Localhost/profile-name" for an operator-managed localhost profile.
   appArmorProfile: "Unconfined"
+  # -- Runtime role passed to the sandbox supervisor. Kubernetes defaults to
+  # workload mode so the injected binary owns agent lifecycle without assuming
+  # it can perform host/node-level enforcement.
+  supervisorRole: workload
+  # -- Network enforcement mode for sandbox supervisors. soft-proxy keeps pods
+  # unprivileged and enforces proxy-aware traffic; direct socket bypass is not
+  # kernel-blocked. Use supervisor-netns only with trusted privileged sandbox
+  # pods. external-enforcer registers with the optional nodeEnforcer DaemonSet
+  # for coarse pod-netns egress blocking while dynamic policy stays in the proxy.
+  networkEnforcementMode: soft-proxy
+  # -- Endpoint template for external-enforcer mode. Empty defaults each
+  # sandbox to http://$(OPENSHELL_NODE_IP):17671.
+  enforcerEndpoint: ""
+  # -- Set securityContext.privileged on all sandbox pod containers. This is a
+  # short-term compatibility escape hatch for trusted clusters that require
+  # privileged pod admission and weakens the container boundary.
+  sandboxPrivileged: false
   # -- Disable TLS entirely - the server listens on plaintext HTTP.
   # Set to true when a reverse proxy / tunnel terminates TLS at the edge.
   disableTls: false

--- a/docs/kubernetes/setup.mdx
+++ b/docs/kubernetes/setup.mdx
@@ -139,6 +139,7 @@ The most commonly changed values are:
 | `server.sandboxNamespace` | Namespace where sandbox pods are created. Defaults to the Helm release namespace when left empty. |
 | `server.sandboxImage` | Default sandbox image used when a sandbox does not specify one. |
 | `server.sandboxImagePullSecrets` | Image pull secrets attached to sandbox pods. Referenced Secrets must exist in the sandbox namespace. |
+| `server.defaultRuntimeClassName` | Default Kubernetes RuntimeClass for sandbox pods, such as `gvisor` or a Kata RuntimeClass name. Leave empty to use the cluster default. The gateway validates this RuntimeClass at startup when configured. |
 | `server.grpcEndpoint` | Endpoint that sandbox supervisors use to call back to the gateway. Must be reachable from inside the cluster. |
 | `server.appArmorProfile` | AppArmor profile requested for sandbox agent containers. Defaults to `Unconfined`. |
 | `server.disableTls` | Run the gateway over plaintext HTTP. Use only behind a trusted transport. |
@@ -206,6 +207,7 @@ The ClusterRole grants node inspection and token validation:
 |---|---|---|
 | `authentication.k8s.io` | `tokenreviews` | create |
 | `""` | `nodes` | get, list, watch |
+| `node.k8s.io` | `runtimeclasses` | get |
 
 To use an existing ServiceAccount instead of creating one, set `serviceAccount.create=false` and supply its name:
 

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -169,6 +169,13 @@ image_pull_policy              = "IfNotPresent"
 image_pull_secrets             = ["regcred"]
 supervisor_image               = "ghcr.io/nvidia/openshell/supervisor:latest"
 supervisor_image_pull_policy   = "IfNotPresent"
+supervisor_role                = "workload"
+network_enforcement_mode       = "soft-proxy"
+# Optional for network_enforcement_mode = "external-enforcer".
+enforcer_endpoint              = "http://$(OPENSHELL_NODE_IP):17671"
+# Short-term compatibility escape hatch for trusted clusters that require
+# privileged sandbox pod admission.
+privileged                     = false
 # Use the image volume on Kubernetes >= 1.35 (GA in 1.36); switch to "init-container"
 # on older clusters or where the ImageVolume feature gate is off.
 supervisor_sideload_method     = "image-volume"
@@ -181,10 +188,26 @@ app_armor_profile              = "Unconfined"
 workspace_default_storage_size = "10Gi"
 # Kubernetes RuntimeClass applied to sandbox pods when the API request does
 # not specify one. Empty (default) = omit the field, using the cluster default.
-# default_runtime_class_name   = "kata-containers"
+default_runtime_class_name     = "gvisor"
 # Kubelet clamps projected tokens below 600 seconds. The driver caps values at 86400.
 sa_token_ttl_secs              = 3600
 ```
+
+When `default_runtime_class_name` is set, the Kubernetes driver validates that the
+RuntimeClass exists during startup. Missing RuntimeClasses fail the gateway
+early instead of surfacing later as pod sandbox creation errors. Per-sandbox
+template RuntimeClass overrides are validated during sandbox admission/create.
+
+`privileged = true` sets `securityContext.privileged` on every Kubernetes
+sandbox pod container. Use it only as a short-term compatibility escape hatch
+for trusted clusters that require privileged pod admission.
+
+`network_enforcement_mode = "soft-proxy"` lets Kubernetes sandbox pods run
+without supervisor-managed netns setup. The proxy still enforces
+proxy-aware traffic and hot-reloads `network_policies`, but direct socket egress
+is not kernel-blocked in this mode. Use `supervisor-netns` for the current hard
+netns/veth/nft path, or `external-enforcer` to use the node-enforcer topology
+for coarse pod-netns egress blocking while dynamic policy stays in the proxy.
 
 ### Docker
 

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -145,6 +145,11 @@ For maintainer-level implementation details, refer to the [Kubernetes driver REA
 | `default_image` | `server.sandboxImage` | Set the default sandbox image. |
 | `image_pull_policy` | `server.sandboxImagePullPolicy` | Set the Kubernetes image pull policy for sandbox pods. |
 | `image_pull_secrets` | `server.sandboxImagePullSecrets` | Attach Kubernetes image pull secrets to sandbox pods. Referenced Secrets must exist in the sandbox namespace. |
+| `default_runtime_class_name` | `server.defaultRuntimeClassName` | Set the default Kubernetes RuntimeClass for sandbox pods, such as `gvisor` for GKE Sandbox or a Kata RuntimeClass name. The gateway validates this class at startup when configured. Per-sandbox template runtime classes override this default and are validated during sandbox admission/create. |
+| `supervisor_role` | `server.supervisorRole` | Select the supervisor topology role for sandbox pods. Kubernetes defaults to `workload`; local non-Kubernetes supervisors keep `combined` by default. |
+| `network_enforcement_mode` | `server.networkEnforcementMode` | Select sandbox network posture. `soft-proxy` injects proxy env vars and enforces cooperative proxy traffic without kernel-blocking direct sockets. `supervisor-netns` uses the existing supervisor-managed netns/veth/nft path and requires the needed Linux capabilities. `external-enforcer` registers with a node/host enforcer that installs coarse pod-netns egress rules while dynamic policy stays in the proxy. |
+| `enforcer_endpoint` | `server.enforcerEndpoint` | Optional endpoint template for `external-enforcer` mode. Empty defaults sandbox pods to `http://$(OPENSHELL_NODE_IP):17671`. |
+| `privileged` | `server.sandboxPrivileged` | Set `securityContext.privileged` on all Kubernetes sandbox pod containers. This is a short-term compatibility escape hatch for trusted clusters that require privileged pod admission and reduces the container boundary. |
 | `grpc_endpoint` | `server.grpcEndpoint` | Set the gateway callback endpoint reachable from sandbox pods. |
 | `client_tls_secret_name` | `server.tls.clientTlsSecretName` | Mount sandbox client TLS materials from a Kubernetes secret. |
 | `supervisor_image` | `supervisor.image.repository` / `supervisor.image.tag` | Set the supervisor image that provides the `openshell-sandbox` binary. |
@@ -155,6 +160,11 @@ For maintainer-level implementation details, refer to the [Kubernetes driver REA
 | `sa_token_ttl_secs` | `server.sandboxJwt.k8sSaTokenTtlSecs` | Set the projected ServiceAccount token TTL used for the bootstrap token exchange. |
 
 The Kubernetes driver creates namespaced `agents.x-k8s.io/v1alpha1` `Sandbox` resources from the Kubernetes SIG Apps [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) project. The Agent Sandbox controller turns those resources into sandbox pods and related storage.
+
+`nodeEnforcer.enabled=true` deploys an optional privileged DaemonSet that runs
+the supervisor image in `enforcer` mode. This topology is experimental: the
+current enforcer acknowledges workload registrations so the deployment shape can
+be tested, but host-side rule installation is not active yet.
 
 <Note>
 `Sandbox.spec.volumeClaimTemplates` is immutable after creation. To change storage configuration, delete the sandbox and create a new one with the updated spec.

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -163,8 +163,10 @@ The Kubernetes driver creates namespaced `agents.x-k8s.io/v1alpha1` `Sandbox` re
 
 `nodeEnforcer.enabled=true` deploys an optional privileged DaemonSet that runs
 the supervisor image in `enforcer` mode. This topology is experimental: the
-current enforcer acknowledges workload registrations so the deployment shape can
-be tested, but host-side rule installation is not active yet.
+current enforcer accepts workload registrations and installs coarse nftables
+egress rules inside the registered pod network namespace. Production hardening
+still needs authenticated registration, pod ownership checks, cleanup and
+reconciliation behavior, and shared-cluster deployment rules.
 
 <Note>
 `Sandbox.spec.volumeClaimTemplates` is immutable after creation. To change storage configuration, delete the sandbox and create a new one with the updated spec.

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -77,6 +77,18 @@ This provides defense-in-depth: even if a container escape vulnerability exists,
 | Risk if enabled with GPU | NVIDIA device plugin compatibility with user namespaces is unverified. OpenShell logs a warning when both GPU and user namespaces are active on the same sandbox. |
 | Recommendation | Enable on non-GPU clusters running Kubernetes with user namespace support available (1.33+ beta, 1.36+ GA) for stronger host isolation. Test GPU workloads separately before enabling on GPU clusters. |
 
+### Privileged Kubernetes Pods
+
+Kubernetes gateway deployments can set `securityContext.privileged` on every sandbox pod container for clusters that require privileged pod admission.
+This is a short-term compatibility escape hatch and weakens the container boundary.
+
+| Aspect | Detail |
+|---|---|
+| Default | Disabled. |
+| What you can change | Enable deployment-wide through Helm with `server.sandboxPrivileged: true` or in gateway config with `[openshell.drivers.kubernetes] privileged = true`. |
+| Risk if enabled | The container receives privileged Linux capabilities and broader host-facing access. Treat the cluster and workload as trusted. |
+| Recommendation | Leave disabled unless a trusted Kubernetes deployment requires the `supervisor-netns` enforcement mode. The Kubernetes default is `soft-proxy`, which avoids privileged pod admission but does not kernel-block direct socket egress. Prefer `external-enforcer` when a cluster can run the privileged node enforcer DaemonSet and sandbox pods should remain unprivileged. |
+
 ### Binary Identity Binding
 
 The proxy identifies which binary initiated each connection by reading `/proc/<pid>/exe` (the kernel-trusted executable path).

--- a/spike/README.md
+++ b/spike/README.md
@@ -1,6 +1,17 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Node Enforcer Topology Findings
 
 Date: 2026-05-29
+
+## Diagrams
+
+- [OpenShell isolation architecture](openshell-isolation-diagram.html)
+- [Kubernetes isolation tradeoffs](kubernetes-isolation-tradeoffs-diagram.html)
+- [Kubernetes node-enforcer option](kubernetes-node-enforcer-options-diagram.html)
 
 ## Summary
 
@@ -83,7 +94,8 @@ The current prototype enforcement flow is registration-driven:
 
 3. The node enforcer DaemonSet runs the same supervisor binary with
    `supervisor_role = "enforcer"`. In that role it does not start an agent
-   supervisor; it binds `0.0.0.0:17671` and waits for workload registrations.
+   supervisor; it binds the configured host-network listener and waits for
+   workload registrations.
 
 4. The workload supervisor starts normally, loads policy, computes the effective
    network enforcement mode, and registers with the node enforcer before
@@ -152,10 +164,9 @@ cluster because enforcement is node-local and pod-local, not gateway-local:
 
 The important deployment constraint is that the node enforcer should be treated
 as shared node infrastructure. A node can only have one process binding the
-default host-network listener `0.0.0.0:17671`. If multiple gateway releases each
-enable their own node-enforcer DaemonSet on the same nodes with the same listen
-address, they will compete for the same port and duplicate the privileged
-component.
+same host-network listener. If multiple gateway releases each enable their own
+node-enforcer DaemonSet on the same nodes with the same listen address, they
+will compete for the same port and duplicate the privileged component.
 
 For a shared cluster, the expected shape is one node-enforcer DaemonSet per
 node pool or cluster security boundary, with all participating gateways pointing
@@ -172,58 +183,44 @@ registering workload is allowed to ask for enforcement on that pod.
 
 ## Validation
 
-Validated against the development Kubernetes cluster using the normal OpenShell
-gateway path. GKE was used as a real managed-cluster validation target, but it
-should not be part of the implementation criteria.
+Validated against the local Kubernetes development cluster using the normal
+OpenShell gateway path and the node-enforcer Helm overlay.
 
-The unchanged Kubernetes e2e test passed:
-
-```shell
-OPENSHELL_GATEWAY_ENDPOINT=http://34.171.165.42 \
-  cargo test --manifest-path e2e/rust/Cargo.toml \
-  --features e2e-kubernetes \
-  --test bypass_detection \
-  -- --nocapture
-```
-
-Result:
-
-```text
-test bypass_attempt_is_rejected_fast ... ok
-1 passed; 0 failed
-```
-
-The full existing Rust e2e suite also passed unchanged against the Kubernetes
-gateway once the local e2e invocation used a named temporary gateway config:
+The Kubernetes smoke path passed with the node-enforcer overlay:
 
 ```shell
-XDG_CONFIG_HOME=/private/tmp/openshell-gke/e2e-config \
-OPENSHELL_GATEWAY=gke-e2e \
-OPENSHELL_E2E_DRIVER=kubernetes \
-  cargo test --manifest-path e2e/rust/Cargo.toml \
-  --features e2e \
-  --no-fail-fast \
-  -- --nocapture
+OPENSHELL_E2E_KUBE_CONTEXT=k3d-openshell-dev-tmutch \
+OPENSHELL_E2E_KUBE_EXTRA_VALUES=deploy/helm/openshell/ci/values-node-enforcer.yaml \
+OPENSHELL_E2E_KUBE_BUILD_IMAGES=1 \
+OPENSHELL_E2E_KUBE_TEST=smoke \
+  e2e/rust/e2e-kubernetes.sh
 ```
 
-Result:
+The bypass-detection path also passed with the same overlay:
 
-```text
-all e2e test targets passed
+```shell
+OPENSHELL_E2E_KUBE_CONTEXT=k3d-openshell-dev-tmutch \
+OPENSHELL_E2E_KUBE_EXTRA_VALUES=deploy/helm/openshell/ci/values-node-enforcer.yaml \
+OPENSHELL_E2E_KUBE_BUILD_IMAGES=1 \
+OPENSHELL_E2E_KUBE_TEST=bypass_detection \
+  e2e/rust/e2e-kubernetes.sh
 ```
 
-Important test harness note: the e2e settings test expects the local CLI to be
-built with `openshell-core/dev-settings`, which the normal e2e scripts already
-do. Direct ad hoc cargo invocations should rebuild `openshell-cli` with that
-feature before running the full suite.
-
-Node-enforcer logs showed the expected action:
+Manual validation also created a sandbox through the gateway and confirmed the
+node enforcer acted on the sandbox network namespace:
 
 ```text
 Observed sandbox workload registration
 Reconciling sandbox network enforcement
-Installing sandbox network egress enforcement for pod 10.40.1.35
-Sandbox network egress enforcement installed for pod 10.40.1.35 in /proc/309096/ns/net
+Installing sandbox network egress enforcement for registered pod
+Sandbox network egress enforcement installed for registered pod
+```
+
+The manual sandbox check then attempted raw direct TCP from the sandbox user
+path and observed a fast rejection instead of a hanging bypass attempt.
+
+```text
+direct-connect-exit-code 111
 ```
 
 ## Key Debug Finding
@@ -239,51 +236,12 @@ The fix was to require that the pod IP is present as a local address in the
 target namespace:
 
 ```text
-10.40.1.33
-/32 host LOCAL
+<pod-ip>
+<host-local-route-marker>
 ```
 
 That distinction selected the sandbox pod namespace instead of the host
 namespace and made the unchanged e2e test pass.
-
-## Envoy Gateway Timeout Finding
-
-The managed-cluster validation exposed a second, unrelated deployment issue:
-Envoy Gateway was terminating long-lived gRPC streams after about 15 seconds.
-The symptom was:
-
-```text
-h2 protocol error: error reading a body from connection
-```
-
-This affected the existing `WatchSandbox`, `ForwardTcp`, and supervisor
-`RelayStream` paths used by `sandbox create -- <cmd>`, upload/create, sync, and
-TTY lifecycle tests. The sandbox pods themselves were running and the node
-enforcer had installed rules correctly; the failure was at the external gateway
-proxy layer.
-
-The fix belongs to the deployment that installs Envoy Gateway, not to the
-OpenShell product Helm chart. Envoy Gateway deployments can attach a
-`BackendTrafficPolicy` to the OpenShell `GRPCRoute`:
-
-```yaml
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: BackendTrafficPolicy
-metadata:
-  name: openshell-grpc-streams
-spec:
-  targetRefs:
-    - group: gateway.networking.k8s.io
-      kind: GRPCRoute
-      name: openshell
-  timeout:
-    http:
-      requestTimeout: 0s
-      maxStreamDuration: 0s
-```
-
-After that policy was applied, Envoy reported it as accepted and the previous
-15-second failures passed without test changes.
 
 ## Product Finding
 
@@ -297,9 +255,6 @@ That is likely the right direction if the goal is:
 - OpenShell keeps dynamic network proxy enforcement.
 - The supervisor remains responsible for the agent lifecycle.
 - Non-Kubernetes deployments can keep the existing combined supervisor mode.
-- External ingress and Gateway API controllers are deployment concerns. If they
-  impose request or stream duration limits, the deployment must configure them
-  to preserve OpenShell's long-lived gRPC streams.
 
 It is not a claim that the system has no privileged code. On Linux, dynamic
 network namespace enforcement needs some trusted component with elevated
@@ -353,13 +308,9 @@ Known risks:
   one enforcer DaemonSet per release, which is not safe to enable repeatedly on
   the same nodes without coordination.
 - The current rules are coarse: UID 0 is allowed, non-root TCP/UDP is rejected.
-- IPv6 namespace lookup exists conceptually but has not been validated in the
-  managed-cluster path.
+- IPv6 namespace lookup exists conceptually but has not been validated.
 - Observability is useful but should become structured enough for operators to
   prove what pod/netns/rules were acted on.
-- Edge proxies can break otherwise healthy sandboxes if they impose short
-  request or stream duration timeouts on gRPC. This is deployment-specific and
-  should be validated wherever OpenShell is exposed through a proxy.
 
 ## Hardening Plan
 
@@ -414,8 +365,6 @@ The branch added configuration and code paths for:
 - Helm `server.sandboxImagePullPolicy`
 - Kubernetes driver injection of node and pod IP environment variables
 - Supervisor image packaging with `nftables`
-- Deployment-owned Envoy Gateway `BackendTrafficPolicy` for long-lived
-  OpenShell gRPC streams.
 
 The development cluster currently uses:
 
@@ -423,8 +372,6 @@ The development cluster currently uses:
 - `server.networkEnforcementMode: external-enforcer`
 - `server.sandboxImagePullPolicy: IfNotPresent`
 - `nodeEnforcer.enabled: true`
-- An Envoy Gateway `BackendTrafficPolicy` with `requestTimeout = 0s` and
-  `maxStreamDuration = 0s`.
 
 ## Recommendation
 
@@ -436,8 +383,3 @@ Do not present it as removing privilege entirely. Present it as moving privilege
 network enforcement into a narrow, operator-controlled component that can be
 authenticated, audited, reconciled, and hardened independently from untrusted
 agent workloads.
-
-Keep Envoy Gateway and other ingress-controller tuning out of the product chart
-unless OpenShell intentionally takes ownership of that controller. The product
-requirement is that long-lived gRPC streams must be supported; the deployment
-implementation should provide the controller-specific policy.

--- a/spike/kubernetes-isolation-tradeoffs-diagram.html
+++ b/spike/kubernetes-isolation-tradeoffs-diagram.html
@@ -1,0 +1,434 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenShell Kubernetes Isolation Tradeoffs</title>
+  <style>
+    :root {
+      --bg: #05070b;
+      --panel: #0f172a;
+      --line: #334155;
+      --text: #e5e7eb;
+      --muted: #9ca3af;
+      --blue: #38bdf8;
+      --green: #34d399;
+      --amber: #fbbf24;
+      --red: #fb7185;
+      --violet: #a78bfa;
+      --orange: #fb923c;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: var(--text);
+      background:
+        linear-gradient(140deg, rgba(56, 189, 248, 0.08), transparent 28rem),
+        linear-gradient(330deg, rgba(251, 191, 36, 0.07), transparent 30rem),
+        var(--bg);
+      font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+
+    main {
+      width: min(1640px, calc(100vw - 32px));
+      margin: 0 auto;
+      padding: 28px 0 36px;
+    }
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: end;
+      gap: 24px;
+      margin-bottom: 18px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(24px, 4vw, 40px);
+      letter-spacing: 0;
+      font-weight: 780;
+    }
+
+    .subtitle {
+      margin: 9px 0 0;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.55;
+      max-width: 980px;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 10px;
+      border: 1px solid rgba(148, 163, 184, 0.22);
+      border-radius: 8px;
+      color: #cbd5e1;
+      background: rgba(15, 23, 42, 0.72);
+      font-size: 11px;
+      white-space: nowrap;
+    }
+
+    .tag::before {
+      content: "";
+      width: 8px;
+      height: 8px;
+      border-radius: 999px;
+      background: var(--amber);
+      box-shadow: 0 0 16px rgba(251, 191, 36, 0.75);
+    }
+
+    .diagram {
+      overflow: auto;
+      border: 1px solid rgba(148, 163, 184, 0.24);
+      border-radius: 8px;
+      background: rgba(15, 23, 42, 0.72);
+      box-shadow: 0 20px 70px rgba(0, 0, 0, 0.34);
+    }
+
+    svg {
+      display: block;
+      width: 100%;
+      min-width: 1220px;
+      height: auto;
+    }
+
+    .notes {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 14px;
+      margin-top: 16px;
+    }
+
+    .note {
+      border: 1px solid rgba(148, 163, 184, 0.22);
+      border-radius: 8px;
+      background: rgba(15, 23, 42, 0.76);
+      padding: 14px;
+    }
+
+    .note h3 {
+      margin: 0 0 8px;
+      font-size: 12px;
+      letter-spacing: 0;
+    }
+
+    .note p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 11px;
+      line-height: 1.55;
+    }
+
+    footer {
+      margin-top: 15px;
+      color: #64748b;
+      font-size: 10px;
+      line-height: 1.6;
+    }
+
+    footer a {
+      color: #93c5fd;
+    }
+
+    @media (max-width: 980px) {
+      main {
+        width: calc(100vw - 20px);
+        padding-top: 18px;
+      }
+
+      .header {
+        display: block;
+      }
+
+      .tag {
+        margin-top: 12px;
+      }
+
+      .notes {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header class="header">
+      <div>
+        <h1>Kubernetes Isolation Tradeoffs</h1>
+        <p class="subtitle">
+          Current OpenShell keeps the supervisor and agent in one Kubernetes sandbox pod. The split-pod proposals move untrusted agent execution into a separate pod and use platform egress controls, while the Isolation Backend proposal turns the boundary machinery into an explicit contract.
+        </p>
+      </div>
+      <div class="tag">current vs proposed states</div>
+    </header>
+
+    <section class="diagram" aria-label="OpenShell Kubernetes isolation tradeoff diagram">
+      <svg viewBox="0 0 1600 1380" role="img" aria-labelledby="diagram-title diagram-desc">
+        <title id="diagram-title">OpenShell Kubernetes isolation tradeoffs</title>
+        <desc id="diagram-desc">Comparison of current in-pod isolation, proposed split-pod isolation, and an isolation backend abstraction for OpenShell Kubernetes sandboxes.</desc>
+        <defs>
+          <pattern id="grid" width="36" height="36" patternUnits="userSpaceOnUse">
+            <path d="M 36 0 L 0 0 0 36" fill="none" stroke="#1f2937" stroke-width="0.5"/>
+          </pattern>
+          <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#38bdf8"/>
+          </marker>
+          <marker id="arrow-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#34d399"/>
+          </marker>
+          <marker id="arrow-amber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#fbbf24"/>
+          </marker>
+          <marker id="arrow-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#fb7185"/>
+          </marker>
+          <marker id="arrow-violet" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#a78bfa"/>
+          </marker>
+          <style>
+            .title { fill: #f8fafc; font-size: 17px; font-weight: 780; letter-spacing: 0; }
+            .subtitle { fill: #94a3b8; font-size: 9px; letter-spacing: 0; }
+            .label { fill: #cbd5e1; font-size: 9px; letter-spacing: 0; }
+            .tiny { fill: #94a3b8; font-size: 7px; letter-spacing: 0; }
+            .box-title { fill: #f8fafc; font-size: 11px; font-weight: 750; letter-spacing: 0; }
+            .box-sub { fill: #cbd5e1; font-size: 8px; letter-spacing: 0; }
+            .warn { fill: #fbbf24; font-size: 8px; letter-spacing: 0; }
+            .loss { fill: #fb7185; font-size: 8px; letter-spacing: 0; }
+            .gain { fill: #34d399; font-size: 8px; letter-spacing: 0; }
+            .flow { fill: none; stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; }
+            .dash { fill: none; stroke-width: 1.4; stroke-dasharray: 5 5; stroke-linecap: round; stroke-linejoin: round; }
+            .thin { fill: none; stroke-width: 1.1; stroke-linecap: round; stroke-linejoin: round; }
+          </style>
+        </defs>
+
+        <rect width="1600" height="1380" fill="#05070b"/>
+        <rect width="1600" height="1380" fill="url(#grid)" opacity="0.9"/>
+
+        <!-- Column panels -->
+        <rect x="40" y="42" width="480" height="865" rx="12" fill="rgba(30, 41, 59, 0.50)" stroke="#64748b" stroke-width="1.3"/>
+        <text x="66" y="78" class="title">A. Current Kubernetes State</text>
+        <text x="66" y="99" class="subtitle">single sandbox pod, supervisor builds the inner boundary</text>
+
+        <rect x="560" y="42" width="480" height="865" rx="12" fill="rgba(6, 78, 59, 0.18)" stroke="#34d399" stroke-width="1.3"/>
+        <text x="586" y="78" class="title">B. Split-Pod Proposal</text>
+        <text x="586" y="99" class="subtitle">trusted supervisor pod, untrusted agent pod, CNI egress boundary</text>
+
+        <rect x="1080" y="42" width="480" height="865" rx="12" fill="rgba(76, 29, 149, 0.18)" stroke="#a78bfa" stroke-width="1.3"/>
+        <text x="1106" y="78" class="title">C. Isolation Backend Interface</text>
+        <text x="1106" y="99" class="subtitle">common supervisor contract, backend-specific boundary realization</text>
+
+        <!-- Current column -->
+        <rect x="86" y="128" width="388" height="520" rx="12" fill="rgba(15, 23, 42, 0.86)" stroke="#94a3b8" stroke-width="1.2" stroke-dasharray="8 4"/>
+        <text x="108" y="156" class="label">Sandbox Pod</text>
+
+        <rect x="116" y="184" width="328" height="106" rx="7" fill="#0f172a" stroke="#34d399" stroke-width="1.4"/>
+        <text x="142" y="216" class="box-title">openshell-sandbox supervisor</text>
+        <text x="142" y="236" class="box-sub">root prelude, proxy, OPA, credentials</text>
+        <text x="142" y="253" class="box-sub">SSH relay, logs, process spawn</text>
+        <text x="142" y="271" class="warn">requires elevated pod capabilities</text>
+
+        <rect x="116" y="342" width="328" height="120" rx="7" fill="#0f172a" stroke="#38bdf8" stroke-width="1.4"/>
+        <text x="142" y="374" class="box-title">Inner network namespace</text>
+        <text x="142" y="394" class="box-sub">veth route forces egress to proxy</text>
+        <text x="142" y="411" class="box-sub">nftables rejects direct TCP/UDP bypass</text>
+        <text x="142" y="429" class="box-sub">bypass monitor records attempts</text>
+
+        <rect x="154" y="514" width="252" height="76" rx="7" fill="#0f172a" stroke="#fb7185" stroke-width="1.4"/>
+        <text x="180" y="544" class="box-title">Restricted agent process</text>
+        <text x="180" y="564" class="box-sub">sandbox user, Landlock, seccomp</text>
+        <text x="180" y="580" class="box-sub">binary identity via /proc</text>
+
+        <path class="flow" d="M280 290 L280 334" stroke="#34d399" marker-end="url(#arrow-green)"/>
+        <text x="292" y="318" class="label">spawn</text>
+        <path class="flow" d="M280 462 L280 506" stroke="#38bdf8" marker-end="url(#arrow-blue)"/>
+        <text x="292" y="489" class="label">enter namespace</text>
+
+        <rect x="88" y="694" width="386" height="170" rx="8" fill="rgba(2, 6, 23, 0.58)" stroke="#475569"/>
+        <text x="112" y="724" class="box-title">Current tradeoffs</text>
+        <text x="112" y="750" class="gain">+ Strong in-pod egress forcing independent of CNI</text>
+        <text x="112" y="772" class="gain">+ Per-binary network policy input still available</text>
+        <text x="112" y="794" class="loss">- Supervisor privilege sits in same pod as agent</text>
+        <text x="112" y="816" class="loss">- Blocks restricted-v2 / hardened managed clusters</text>
+        <text x="112" y="838" class="loss">- Agent and supervisor logs share the workload stream</text>
+
+        <!-- Split-pod column -->
+        <rect x="598" y="132" width="178" height="228" rx="12" fill="rgba(15, 23, 42, 0.86)" stroke="#34d399" stroke-width="1.2" stroke-dasharray="8 4"/>
+        <text x="624" y="160" class="label">Supervisor Pod</text>
+
+        <rect x="620" y="188" width="134" height="66" rx="7" fill="#0f172a" stroke="#34d399" stroke-width="1.4"/>
+        <text x="640" y="217" class="box-title">Proxy + OPA</text>
+        <text x="640" y="236" class="box-sub">L7 policy gate</text>
+
+        <rect x="620" y="276" width="134" height="54" rx="7" fill="#0f172a" stroke="#a78bfa" stroke-width="1.4"/>
+        <text x="640" y="307" class="box-title">Credentials</text>
+        <text x="640" y="323" class="box-sub">never in agent pod</text>
+
+        <rect x="820" y="132" width="178" height="228" rx="12" fill="rgba(15, 23, 42, 0.86)" stroke="#fb7185" stroke-width="1.2" stroke-dasharray="8 4"/>
+        <text x="844" y="160" class="label">Agent Pod</text>
+
+        <rect x="842" y="188" width="134" height="70" rx="7" fill="#0f172a" stroke="#fb7185" stroke-width="1.4"/>
+        <text x="862" y="217" class="box-title">Untrusted image</text>
+        <text x="862" y="236" class="box-sub">non-root, no caps</text>
+        <text x="862" y="251" class="box-sub">gVisor or Kata</text>
+
+        <rect x="842" y="278" width="134" height="52" rx="7" fill="#0f172a" stroke="#fbbf24" stroke-width="1.4"/>
+        <text x="858" y="308" class="box-title">Sideload binary</text>
+        <text x="858" y="323" class="box-sub">optional SSH/Landlock</text>
+
+        <rect x="635" y="420" width="320" height="95" rx="8" fill="#0f172a" stroke="#38bdf8" stroke-width="1.4"/>
+        <text x="662" y="452" class="box-title">Kubernetes NetworkPolicy</text>
+        <text x="662" y="472" class="box-sub">allow: agent pod to supervisor:3128</text>
+        <text x="662" y="489" class="box-sub">allow: DNS when configured</text>
+        <text x="662" y="506" class="box-sub">deny: all other direct egress at CNI layer</text>
+
+        <rect x="635" y="558" width="320" height="72" rx="8" fill="#0f172a" stroke="#fb923c" stroke-width="1.4"/>
+        <text x="662" y="588" class="box-title">RuntimeClass</text>
+        <text x="662" y="608" class="box-sub">gVisor userspace kernel or Kata VM boundary</text>
+
+        <path class="flow" d="M842 224 C800 224 802 224 762 224" stroke="#38bdf8" marker-end="url(#arrow-blue)"/>
+        <text x="774" y="211" class="label">HTTP_PROXY</text>
+        <path class="dash" d="M909 258 L909 412" stroke="#38bdf8" marker-end="url(#arrow-blue)"/>
+        <text x="922" y="382" class="label">non-cooperative traffic</text>
+        <path class="flow" d="M795 515 L795 550" stroke="#fb923c" marker-end="url(#arrow-amber)"/>
+
+        <rect x="598" y="694" width="402" height="170" rx="8" fill="rgba(2, 6, 23, 0.58)" stroke="#475569"/>
+        <text x="622" y="724" class="box-title">Split-pod tradeoffs</text>
+        <text x="622" y="750" class="gain">+ Agent pod can run non-root with zero capabilities</text>
+        <text x="622" y="772" class="gain">+ gVisor/Kata reduces host-kernel blast radius</text>
+        <text x="622" y="794" class="gain">+ Separate log streams for audit and agent output</text>
+        <text x="622" y="816" class="loss">- Per-binary destination restrictions are lost cross-pod</text>
+        <text x="622" y="838" class="loss">- Enforcement now depends on CNI NetworkPolicy support</text>
+
+        <!-- Isolation backend column -->
+        <rect x="1118" y="128" width="402" height="96" rx="8" fill="#0f172a" stroke="#34d399" stroke-width="1.4"/>
+        <text x="1146" y="160" class="box-title">Supervisor stays policy authority</text>
+        <text x="1146" y="181" class="box-sub">proxy, OPA, credentials, audit, inference routing</text>
+        <text x="1146" y="199" class="box-sub">drives one runtime contract instead of inline topology code</text>
+
+        <rect x="1118" y="272" width="402" height="102" rx="8" fill="#0f172a" stroke="#a78bfa" stroke-width="1.4"/>
+        <text x="1146" y="304" class="box-title">Isolation Backend contract</text>
+        <text x="1146" y="325" class="box-sub">realize boundary, return verifiable handle</text>
+        <text x="1146" y="342" class="box-sub">fail closed if boundary is not ready</text>
+        <text x="1146" y="359" class="box-sub">operator-selected, not workload-selected</text>
+
+        <rect x="1118" y="422" width="128" height="88" rx="8" fill="#0f172a" stroke="#38bdf8" stroke-width="1.4"/>
+        <text x="1142" y="456" class="box-title">In-pod</text>
+        <text x="1142" y="476" class="box-sub">netns + nft</text>
+        <text x="1142" y="492" class="box-sub">status quo path</text>
+
+        <rect x="1252" y="422" width="128" height="88" rx="8" fill="#0f172a" stroke="#34d399" stroke-width="1.4"/>
+        <text x="1274" y="456" class="box-title">Delegated</text>
+        <text x="1274" y="476" class="box-sub">split pod</text>
+        <text x="1274" y="492" class="box-sub">CNI boundary</text>
+
+        <rect x="1386" y="422" width="128" height="88" rx="8" fill="#0f172a" stroke="#fb923c" stroke-width="1.4"/>
+        <text x="1408" y="456" class="box-title">VM / Node</text>
+        <text x="1408" y="476" class="box-sub">microVM</text>
+        <text x="1408" y="492" class="box-sub">node agent</text>
+
+        <rect x="1118" y="562" width="402" height="72" rx="8" fill="#0f172a" stroke="#fbbf24" stroke-width="1.4"/>
+        <text x="1146" y="592" class="box-title">Two invariants</text>
+        <text x="1146" y="612" class="box-sub">no unguarded workload egress before verification</text>
+        <text x="1146" y="628" class="box-sub">no workload execution before boundary ready</text>
+
+        <path class="flow" d="M1319 224 L1319 264" stroke="#a78bfa" marker-end="url(#arrow-violet)"/>
+        <path class="flow" d="M1319 374 L1319 414" stroke="#a78bfa" marker-end="url(#arrow-violet)"/>
+        <path class="thin" d="M1319 510 L1319 554" stroke="#fbbf24" marker-end="url(#arrow-amber)"/>
+        <path class="thin" d="M1319 510 C1240 532 1184 536 1184 554" stroke="#38bdf8" marker-end="url(#arrow-blue)"/>
+        <path class="thin" d="M1319 510 C1418 532 1450 536 1450 554" stroke="#fb923c" marker-end="url(#arrow-amber)"/>
+
+        <rect x="1118" y="694" width="402" height="170" rx="8" fill="rgba(2, 6, 23, 0.58)" stroke="#475569"/>
+        <text x="1142" y="724" class="box-title">Abstraction tradeoffs</text>
+        <text x="1142" y="750" class="gain">+ Separates policy authority from boundary machinery</text>
+        <text x="1142" y="772" class="gain">+ Lets split-pod, VM, or node-agent backends share a contract</text>
+        <text x="1142" y="794" class="gain">+ Enables in-pod refactor first, delegated later</text>
+        <text x="1142" y="816" class="loss">- Requires verifiable handoff and fail-closed semantics</text>
+        <text x="1142" y="838" class="loss">- Scope is unsettled: network only vs fs/syscall/process too</text>
+
+        <!-- Cross-column comparison -->
+        <rect x="40" y="948" width="1520" height="300" rx="12" fill="rgba(15, 23, 42, 0.68)" stroke="#334155" stroke-width="1.2"/>
+        <text x="66" y="985" class="title">Decision Map</text>
+        <text x="66" y="1006" class="subtitle">The diagrams point to different places for the hard boundary. That changes who must be trusted and which controls are enforceable.</text>
+
+        <line x1="66" y1="1030" x2="1534" y2="1030" stroke="#334155"/>
+        <text x="80" y="1058" class="label">Hard egress boundary</text>
+        <text x="390" y="1058" class="box-sub">current: netns + nftables inside pod</text>
+        <text x="755" y="1058" class="box-sub">split-pod: CNI NetworkPolicy outside agent pod</text>
+        <text x="1185" y="1058" class="box-sub">backend: selected per environment, verified by contract</text>
+
+        <line x1="66" y1="1078" x2="1534" y2="1078" stroke="#1f2937"/>
+        <text x="80" y="1106" class="label">Kernel isolation</text>
+        <text x="390" y="1106" class="box-sub">current: runc + seccomp + Landlock</text>
+        <text x="755" y="1106" class="box-sub">split-pod: gVisor userspace kernel or Kata VM</text>
+        <text x="1185" y="1106" class="box-sub">backend: can represent in-pod, VM, or delegated runtime</text>
+
+        <line x1="66" y1="1126" x2="1534" y2="1126" stroke="#1f2937"/>
+        <text x="80" y="1154" class="label">L7, credentials, inference</text>
+        <text x="390" y="1154" class="box-sub">current: local supervisor proxy</text>
+        <text x="755" y="1154" class="box-sub">split-pod: supervisor pod proxy</text>
+        <text x="1185" y="1154" class="box-sub">backend: remains with supervisor policy authority</text>
+
+        <line x1="66" y1="1174" x2="1534" y2="1174" stroke="#1f2937"/>
+        <text x="80" y="1202" class="label">Known loss / risk</text>
+        <text x="390" y="1202" class="box-sub">current: privileged setup near untrusted workload</text>
+        <text x="755" y="1202" class="box-sub">split-pod: per-binary policy and deny logs become weaker</text>
+        <text x="1185" y="1202" class="box-sub">backend: verification and versioning become first-class</text>
+
+        <line x1="66" y1="1222" x2="1534" y2="1222" stroke="#1f2937"/>
+        <text x="80" y="1250" class="label">Best fit</text>
+        <text x="390" y="1250" class="box-sub">local dev, k3d/k3s, environments allowing capabilities</text>
+        <text x="755" y="1250" class="box-sub">enterprise clusters, OpenShift/Gardener-style restrictions</text>
+        <text x="1185" y="1250" class="box-sub">long-term architecture that lets both shapes coexist</text>
+
+        <!-- Source strip -->
+        <rect x="220" y="1288" width="1160" height="48" rx="8" fill="rgba(2, 6, 23, 0.7)" stroke="#334155"/>
+        <text x="244" y="1318" class="tiny">Sources: current code/docs; #899 restricted SCC; #981 split supervisor/agent pod; #1305 proxy/runtime decomposition; #1650 process/network split PR; #1703 external compute driver PR; #1737 Isolation Backend interface.</text>
+      </svg>
+    </section>
+
+    <section class="notes" aria-label="summary notes">
+      <article class="note">
+        <h3>Current State</h3>
+        <p>The Kubernetes driver creates one Sandbox CR whose pod runs the agent container with supervisor sideloading and elevated capabilities so the supervisor can create the inner network namespace.</p>
+      </article>
+      <article class="note">
+        <h3>Split Pod</h3>
+        <p>The proposal moves the proxy and policy authority into a trusted supervisor pod. The agent pod becomes untrusted, non-root, no-capabilities, and optionally gVisor or Kata isolated.</p>
+      </article>
+      <article class="note">
+        <h3>NetworkPolicy</h3>
+        <p>Today Helm renders an ingress-only sandbox SSH NetworkPolicy. The split-pod proposal adds egress NetworkPolicy so agent pods can reach only the supervisor proxy and DNS.</p>
+      </article>
+      <article class="note">
+        <h3>Backend Interface</h3>
+        <p>The interface proposal keeps the supervisor as policy authority while letting in-pod, split-pod, VM, or node-agent backends realize the isolation boundary with explicit verification.</p>
+      </article>
+    </section>
+
+    <footer>
+      Sources used: <a href="https://github.com/NVIDIA/OpenShell/issues/899">#899</a>,
+      <a href="https://github.com/NVIDIA/OpenShell/issues/981">#981</a>,
+      <a href="https://github.com/NVIDIA/OpenShell/issues/1305">#1305</a>,
+      <a href="https://github.com/NVIDIA/OpenShell/pull/1650">PR #1650</a>,
+      <a href="https://github.com/NVIDIA/OpenShell/pull/1703">PR #1703</a>,
+      <a href="https://github.com/NVIDIA/OpenShell/issues/1737">#1737</a>,
+      plus local files <code>architecture/compute-runtimes.md</code>,
+      <code>deploy/helm/openshell/templates/networkpolicy.yaml</code>, and
+      <code>crates/openshell-driver-kubernetes/src/driver.rs</code>.
+    </footer>
+  </main>
+</body>
+</html>

--- a/spike/kubernetes-node-enforcer-options-diagram.html
+++ b/spike/kubernetes-node-enforcer-options-diagram.html
@@ -1,0 +1,412 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenShell Kubernetes Node Enforcer Option</title>
+  <style>
+    :root {
+      --bg: #06080d;
+      --panel: #101827;
+      --panel-2: #0b1120;
+      --text: #e5e7eb;
+      --muted: #9ca3af;
+      --line: #334155;
+      --blue: #38bdf8;
+      --green: #34d399;
+      --amber: #fbbf24;
+      --red: #fb7185;
+      --violet: #a78bfa;
+      --orange: #fb923c;
+      --teal: #2dd4bf;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: var(--text);
+      background:
+        linear-gradient(145deg, rgba(45, 212, 191, 0.08), transparent 28rem),
+        linear-gradient(315deg, rgba(251, 146, 60, 0.08), transparent 28rem),
+        var(--bg);
+      font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+
+    main {
+      width: min(1680px, calc(100vw - 32px));
+      margin: 0 auto;
+      padding: 28px 0 36px;
+    }
+
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: end;
+      gap: 24px;
+      margin-bottom: 18px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(24px, 4vw, 40px);
+      font-weight: 780;
+      letter-spacing: 0;
+    }
+
+    .subtitle {
+      margin: 9px 0 0;
+      max-width: 1020px;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.55;
+    }
+
+    .branch {
+      padding: 8px 10px;
+      border-radius: 8px;
+      border: 1px solid rgba(148, 163, 184, 0.22);
+      background: rgba(15, 23, 42, 0.72);
+      color: #cbd5e1;
+      font-size: 11px;
+      white-space: nowrap;
+    }
+
+    .diagram {
+      overflow: auto;
+      border: 1px solid rgba(148, 163, 184, 0.24);
+      border-radius: 8px;
+      background: rgba(15, 23, 42, 0.72);
+      box-shadow: 0 20px 72px rgba(0, 0, 0, 0.36);
+    }
+
+    svg {
+      display: block;
+      width: 100%;
+      min-width: 1240px;
+      height: auto;
+    }
+
+    .notes {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 14px;
+      margin-top: 16px;
+    }
+
+    .note {
+      border: 1px solid rgba(148, 163, 184, 0.22);
+      border-radius: 8px;
+      background: rgba(15, 23, 42, 0.76);
+      padding: 14px;
+    }
+
+    .note h3 {
+      margin: 0 0 8px;
+      font-size: 12px;
+      letter-spacing: 0;
+    }
+
+    .note p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 11px;
+      line-height: 1.55;
+    }
+
+    footer {
+      margin-top: 15px;
+      color: #64748b;
+      font-size: 10px;
+      line-height: 1.6;
+    }
+
+    footer a {
+      color: #93c5fd;
+    }
+
+    @media (max-width: 980px) {
+      main {
+        width: calc(100vw - 20px);
+        padding-top: 18px;
+      }
+
+      header {
+        display: block;
+      }
+
+      .branch {
+        display: inline-block;
+        margin-top: 12px;
+      }
+
+      .notes {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>Kubernetes Node Enforcer Option</h1>
+        <p class="subtitle">
+          The node-enforcer branch adds a fourth Kubernetes isolation shape: keep the workload supervisor and proxy in the sandbox pod, but move privileged pod-network-namespace enforcement to an operator-controlled DaemonSet on each node.
+        </p>
+      </div>
+      <div class="branch">branch: node-enforcer-poc/tmutch</div>
+    </header>
+
+    <section class="diagram" aria-label="OpenShell Kubernetes node-enforcer option diagram">
+      <svg viewBox="0 0 1680 1460" role="img" aria-labelledby="diagram-title diagram-desc">
+        <title id="diagram-title">OpenShell Kubernetes node-enforcer option</title>
+        <desc id="diagram-desc">Diagram of the node-enforcer topology and comparison to supervisor-netns, soft-proxy, split-pod, and isolation backend options.</desc>
+        <defs>
+          <pattern id="grid" width="36" height="36" patternUnits="userSpaceOnUse">
+            <path d="M 36 0 L 0 0 0 36" fill="none" stroke="#1f2937" stroke-width="0.5"/>
+          </pattern>
+          <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#38bdf8"/>
+          </marker>
+          <marker id="arrow-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#34d399"/>
+          </marker>
+          <marker id="arrow-amber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#fbbf24"/>
+          </marker>
+          <marker id="arrow-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#fb7185"/>
+          </marker>
+          <marker id="arrow-violet" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#a78bfa"/>
+          </marker>
+          <style>
+            .title { fill: #f8fafc; font-size: 18px; font-weight: 780; letter-spacing: 0; }
+            .sub { fill: #94a3b8; font-size: 9px; letter-spacing: 0; }
+            .label { fill: #cbd5e1; font-size: 9px; letter-spacing: 0; }
+            .tiny { fill: #94a3b8; font-size: 7px; letter-spacing: 0; }
+            .box-title { fill: #f8fafc; font-size: 11px; font-weight: 750; letter-spacing: 0; }
+            .box-sub { fill: #cbd5e1; font-size: 8px; letter-spacing: 0; }
+            .gain { fill: #34d399; font-size: 8px; letter-spacing: 0; }
+            .loss { fill: #fb7185; font-size: 8px; letter-spacing: 0; }
+            .warn { fill: #fbbf24; font-size: 8px; letter-spacing: 0; }
+            .flow { fill: none; stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; }
+            .dash { fill: none; stroke-width: 1.4; stroke-dasharray: 5 5; stroke-linecap: round; stroke-linejoin: round; }
+            .thin { fill: none; stroke-width: 1.1; stroke-linecap: round; stroke-linejoin: round; }
+          </style>
+        </defs>
+
+        <rect width="1680" height="1460" fill="#06080d"/>
+        <rect width="1680" height="1460" fill="url(#grid)" opacity="0.9"/>
+
+        <!-- Main topology panel -->
+        <rect x="40" y="42" width="1600" height="655" rx="12" fill="rgba(15, 23, 42, 0.68)" stroke="#334155" stroke-width="1.2"/>
+        <text x="68" y="78" class="title">Option 4: Node-Enforcer Topology</text>
+        <text x="68" y="99" class="sub">workload supervisor remains in the sandbox pod; privileged netns/nft enforcement moves to a node-local DaemonSet</text>
+
+        <!-- Gateway -->
+        <rect x="82" y="154" width="226" height="94" rx="8" fill="#0b1120" stroke="#34d399" stroke-width="1.4"/>
+        <text x="110" y="188" class="box-title">Gateway</text>
+        <text x="110" y="209" class="box-sub">creates Sandbox CR</text>
+        <text x="110" y="226" class="box-sub">injects role + enforcement mode</text>
+
+        <rect x="82" y="304" width="226" height="94" rx="8" fill="#0b1120" stroke="#a78bfa" stroke-width="1.4"/>
+        <text x="110" y="338" class="box-title">Kubernetes Driver</text>
+        <text x="110" y="359" class="box-sub">supervisor_role=workload</text>
+        <text x="110" y="376" class="box-sub">network=external-enforcer</text>
+
+        <!-- Cluster / node -->
+        <rect x="386" y="128" width="1184" height="530" rx="14" fill="rgba(2, 6, 23, 0.42)" stroke="#475569" stroke-width="1.3" stroke-dasharray="8 4"/>
+        <text x="414" y="156" class="label">Kubernetes node</text>
+
+        <rect x="430" y="202" width="324" height="290" rx="12" fill="rgba(15, 23, 42, 0.86)" stroke="#fb923c" stroke-width="1.4"/>
+        <text x="456" y="232" class="box-title">node-enforcer DaemonSet</text>
+        <text x="456" y="253" class="box-sub">same supervisor image, role=enforcer</text>
+        <text x="456" y="270" class="box-sub">hostNetwork + hostPID + privileged</text>
+        <text x="456" y="287" class="box-sub">listens on host-network endpoint</text>
+
+        <rect x="464" y="326" width="256" height="62" rx="7" fill="#0b1120" stroke="#fbbf24" stroke-width="1.3"/>
+        <text x="486" y="354" class="box-title">Namespace lookup</text>
+        <text x="486" y="372" class="box-sub">find pod netns by pod IP in /proc</text>
+
+        <rect x="464" y="412" width="256" height="58" rx="7" fill="#0b1120" stroke="#fb7185" stroke-width="1.3"/>
+        <text x="486" y="440" class="box-title">Install nft table</text>
+        <text x="486" y="458" class="box-sub">setns(CLONE_NEWNET) + nft -f</text>
+
+        <rect x="860" y="180" width="414" height="376" rx="12" fill="rgba(15, 23, 42, 0.86)" stroke="#38bdf8" stroke-width="1.4" stroke-dasharray="8 4"/>
+        <text x="888" y="210" class="label">Sandbox pod network namespace</text>
+
+        <rect x="894" y="242" width="332" height="90" rx="8" fill="#0b1120" stroke="#34d399" stroke-width="1.4"/>
+        <text x="924" y="274" class="box-title">Workload supervisor</text>
+        <text x="924" y="294" class="box-sub">policy loading, proxy, SSH, logs, agent lifecycle</text>
+        <text x="924" y="312" class="box-sub">registers with node enforcer before spawning agent</text>
+
+        <rect x="894" y="372" width="144" height="72" rx="8" fill="#0b1120" stroke="#34d399" stroke-width="1.4"/>
+        <text x="922" y="403" class="box-title">Local proxy</text>
+        <text x="922" y="423" class="box-sub">OPA + L7 + creds</text>
+
+        <rect x="1082" y="372" width="144" height="72" rx="8" fill="#0b1120" stroke="#fb7185" stroke-width="1.4"/>
+        <text x="1106" y="403" class="box-title">Agent child</text>
+        <text x="1106" y="423" class="box-sub">sandbox user</text>
+
+        <rect x="936" y="486" width="226" height="40" rx="7" fill="#0b1120" stroke="#fbbf24" stroke-width="1.2"/>
+        <text x="960" y="510" class="box-title">openshell_external_enforcer table</text>
+
+        <rect x="1322" y="230" width="202" height="84" rx="8" fill="#0b1120" stroke="#94a3b8" stroke-width="1.3"/>
+        <text x="1350" y="262" class="box-title">External services</text>
+        <text x="1350" y="282" class="box-sub">allowed only through proxy</text>
+
+        <rect x="1322" y="380" width="202" height="84" rx="8" fill="#0b1120" stroke="#a78bfa" stroke-width="1.3"/>
+        <text x="1350" y="412" class="box-title">Gateway session</text>
+        <text x="1350" y="432" class="box-sub">config, relay, logs</text>
+
+        <path class="flow" d="M308 201 C344 201 348 254 386 254" stroke="#34d399" marker-end="url(#arrow-green)"/>
+        <text x="322" y="187" class="label">create sandbox</text>
+        <path class="flow" d="M308 351 L386 351" stroke="#a78bfa" marker-end="url(#arrow-violet)"/>
+        <text x="322" y="339" class="label">inject env</text>
+
+        <path class="flow" d="M894 300 C820 300 812 248 762 248" stroke="#fbbf24" marker-end="url(#arrow-amber)"/>
+        <text x="770" y="288" class="label">HTTP registration</text>
+        <text x="772" y="304" class="tiny">pod IP + sandbox ID</text>
+
+        <path class="flow" d="M720 356 C780 356 810 506 928 506" stroke="#fb7185" marker-end="url(#arrow-red)"/>
+        <text x="744" y="430" class="label">install pod-netns nft rules</text>
+
+        <path class="flow" d="M1082 405 L1046 405" stroke="#38bdf8" marker-end="url(#arrow-blue)"/>
+        <text x="1046" y="391" class="label">HTTP_PROXY</text>
+        <path class="flow" d="M1038 405 L1294 272 L1314 272" stroke="#34d399" marker-end="url(#arrow-green)"/>
+        <text x="1170" y="328" class="label">UID 0 proxy egress</text>
+        <path class="dash" d="M1154 444 C1160 482 1202 512 1230 506" stroke="#fb7185" marker-end="url(#arrow-red)"/>
+        <text x="1182" y="488" class="label">non-root direct socket rejected</text>
+        <path class="dash" d="M1226 290 C1268 316 1282 406 1314 422" stroke="#a78bfa" marker-end="url(#arrow-violet)"/>
+        <text x="1240" y="374" class="label">gateway callback</text>
+
+        <rect x="82" y="534" width="674" height="92" rx="8" fill="rgba(2, 6, 23, 0.56)" stroke="#475569"/>
+        <text x="110" y="564" class="box-title">What moved out of the workload pod?</text>
+        <text x="110" y="588" class="gain">+ netns discovery and nftables installation are node-side infrastructure duties</text>
+        <text x="110" y="610" class="gain">+ workload supervisor keeps policy/proxy/credentials close to the agent</text>
+
+        <rect x="820" y="584" width="704" height="42" rx="8" fill="rgba(2, 6, 23, 0.56)" stroke="#475569"/>
+        <text x="848" y="610" class="warn">Prototype hardening required: authenticate registrations, verify pod ownership, reconcile cleanup/stale state, avoid per-release DaemonSet port conflicts.</text>
+
+        <!-- Comparison panel -->
+        <rect x="40" y="736" width="1600" height="372" rx="12" fill="rgba(15, 23, 42, 0.68)" stroke="#334155" stroke-width="1.2"/>
+        <text x="68" y="774" class="title">Comparison Against Other Kubernetes Options</text>
+        <text x="68" y="795" class="sub">The options differ mostly by where the hard network boundary lives and whether the workload pod needs elevated privileges.</text>
+
+        <line x1="68" y1="824" x2="1612" y2="824" stroke="#334155"/>
+        <text x="80" y="852" class="label">Option</text>
+        <text x="312" y="852" class="label">Hard egress boundary</text>
+        <text x="622" y="852" class="label">Privileged component</text>
+        <text x="910" y="852" class="label">What remains local to agent pod</text>
+        <text x="1260" y="852" class="label">Main tradeoff</text>
+
+        <line x1="68" y1="872" x2="1612" y2="872" stroke="#1f2937"/>
+        <text x="80" y="902" class="box-sub">Supervisor-netns</text>
+        <text x="312" y="902" class="box-sub">inner netns + veth + nft</text>
+        <text x="622" y="902" class="box-sub">sandbox workload supervisor</text>
+        <text x="910" y="902" class="box-sub">all policy, proxy, fs, process, netns</text>
+        <text x="1260" y="902" class="loss">strong but requires elevated sandbox pod</text>
+
+        <line x1="68" y1="924" x2="1612" y2="924" stroke="#1f2937"/>
+        <text x="80" y="954" class="box-sub">Soft-proxy</text>
+        <text x="312" y="954" class="box-sub">none for direct sockets</text>
+        <text x="622" y="954" class="box-sub">none for network setup</text>
+        <text x="910" y="954" class="box-sub">proxy, policy, lifecycle, logs</text>
+        <text x="1260" y="954" class="loss">deployable but bypass is not kernel-blocked</text>
+
+        <line x1="68" y1="976" x2="1612" y2="976" stroke="#1f2937"/>
+        <text x="80" y="1006" class="box-sub">Split-pod</text>
+        <text x="312" y="1006" class="box-sub">CNI NetworkPolicy</text>
+        <text x="622" y="1006" class="box-sub">trusted supervisor pod / platform</text>
+        <text x="910" y="1006" class="box-sub">agent only; optional sideload SSH/Landlock</text>
+        <text x="1260" y="1006" class="loss">loses trusted per-binary identity cross-pod</text>
+
+        <line x1="68" y1="1028" x2="1612" y2="1028" stroke="#1f2937"/>
+        <text x="80" y="1058" class="box-sub">Node-enforcer</text>
+        <text x="312" y="1058" class="box-sub">pod netns nft table installed by DaemonSet</text>
+        <text x="622" y="1058" class="box-sub">node enforcer only</text>
+        <text x="910" y="1058" class="box-sub">proxy, OPA, creds, SSH, agent lifecycle</text>
+        <text x="1260" y="1058" class="gain">keeps proxy local; moves network privilege out</text>
+
+        <line x1="68" y1="1080" x2="1612" y2="1080" stroke="#1f2937"/>
+        <text x="80" y="1102" class="box-sub">Isolation Backend</text>
+        <text x="312" y="1102" class="box-sub">selected backend: netns, CNI, node, VM</text>
+        <text x="622" y="1102" class="box-sub">backend-specific</text>
+        <text x="910" y="1102" class="box-sub">supervisor as policy authority</text>
+        <text x="1260" y="1102" class="warn">needs verifiable handoff and fail-closed contract</text>
+
+        <!-- Backend placement panel -->
+        <rect x="40" y="1148" width="1600" height="272" rx="12" fill="rgba(15, 23, 42, 0.68)" stroke="#334155" stroke-width="1.2"/>
+        <text x="68" y="1186" class="title">How Node-Enforcer Fits the Isolation Backend Abstraction</text>
+
+        <rect x="90" y="1226" width="248" height="88" rx="8" fill="#0b1120" stroke="#34d399" stroke-width="1.3"/>
+        <text x="118" y="1258" class="box-title">Supervisor contract</text>
+        <text x="118" y="1278" class="box-sub">policy authority, proxy, audit</text>
+        <text x="118" y="1295" class="box-sub">register before agent exec</text>
+
+        <rect x="442" y="1226" width="248" height="88" rx="8" fill="#0b1120" stroke="#a78bfa" stroke-width="1.3"/>
+        <text x="470" y="1258" class="box-title">Backend handle</text>
+        <text x="470" y="1278" class="box-sub">pod IP + sandbox ID</text>
+        <text x="470" y="1295" class="box-sub">node-local enforcer endpoint</text>
+
+        <rect x="794" y="1226" width="248" height="88" rx="8" fill="#0b1120" stroke="#fb923c" stroke-width="1.3"/>
+        <text x="822" y="1258" class="box-title">Backend mechanism</text>
+        <text x="822" y="1278" class="box-sub">hostPID /proc scan</text>
+        <text x="822" y="1295" class="box-sub">setns + nft ruleset</text>
+
+        <rect x="1146" y="1226" width="248" height="88" rx="8" fill="#0b1120" stroke="#fbbf24" stroke-width="1.3"/>
+        <text x="1174" y="1258" class="box-title">Required invariant</text>
+        <text x="1174" y="1278" class="box-sub">no agent execution before</text>
+        <text x="1174" y="1295" class="box-sub">boundary is installed/verified</text>
+
+        <path class="flow" d="M338 1270 L434 1270" stroke="#34d399" marker-end="url(#arrow-green)"/>
+        <path class="flow" d="M690 1270 L786 1270" stroke="#a78bfa" marker-end="url(#arrow-violet)"/>
+        <path class="flow" d="M1042 1270 L1138 1270" stroke="#fb923c" marker-end="url(#arrow-amber)"/>
+
+        <rect x="1428" y="1226" width="164" height="88" rx="8" fill="#0b1120" stroke="#fb7185" stroke-width="1.3"/>
+        <text x="1450" y="1258" class="box-title">Open questions</text>
+        <text x="1450" y="1278" class="box-sub">authn/authz</text>
+        <text x="1450" y="1295" class="box-sub">cleanup + ownership checks</text>
+
+        <text x="68" y="1370" class="tiny">Sources: node-enforcer-poc/tmutch branch files architecture/plans/node-enforcer-topology-findings.md, crates/openshell-sandbox/src/enforcer.rs, crates/openshell-sandbox/src/lib.rs, crates/openshell-driver-kubernetes/src/driver.rs, deploy/helm/openshell/templates/node-enforcer.yaml, docs/reference/sandbox-compute-drivers.mdx, plus proposal context from #981 and #1737.</text>
+      </svg>
+    </section>
+
+    <section class="notes" aria-label="node enforcer summary notes">
+      <article class="note">
+        <h3>What It Preserves</h3>
+        <p>The workload supervisor still owns proxy, OPA, credential resolution, inference routing, SSH, logs, settings reloads, and agent lifecycle inside the sandbox pod.</p>
+      </article>
+      <article class="note">
+        <h3>What It Moves</h3>
+        <p>The node enforcer owns pod network namespace discovery and coarse nftables egress enforcement, moving that privilege out of the sandbox workload pod.</p>
+      </article>
+      <article class="note">
+        <h3>What It Does Not Do</h3>
+        <p>It does not split the agent into a separate pod and does not use Kubernetes NetworkPolicy as the hard boundary. Dynamic endpoint and L7 policy still live in the proxy.</p>
+      </article>
+      <article class="note">
+        <h3>Hardening Work</h3>
+        <p>The POC needs authenticated registration, pod ownership verification, cleanup/reconciliation for stale namespaces, and shared-cluster deployment rules.</p>
+      </article>
+    </section>
+
+    <footer>
+      Related proposal context:
+      <a href="https://github.com/NVIDIA/OpenShell/issues/981">split-pod #981</a>,
+      <a href="https://github.com/NVIDIA/OpenShell/issues/1737">Isolation Backend #1737</a>.
+      Local branch sources are listed inside the diagram.
+    </footer>
+  </main>
+</body>
+</html>

--- a/spike/openshell-isolation-diagram.html
+++ b/spike/openshell-isolation-diagram.html
@@ -1,0 +1,559 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenShell Isolation Architecture</title>
+  <style>
+    :root {
+      --bg: #020617;
+      --panel: #0f172a;
+      --text: #e2e8f0;
+      --muted: #94a3b8;
+      --grid: #1e293b;
+      --cyan: #22d3ee;
+      --emerald: #34d399;
+      --violet: #a78bfa;
+      --amber: #fbbf24;
+      --rose: #fb7185;
+      --orange: #fb923c;
+      --slate: #94a3b8;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 18% 12%, rgba(34, 211, 238, 0.08), transparent 24rem),
+        radial-gradient(circle at 78% 8%, rgba(251, 191, 36, 0.07), transparent 22rem),
+        var(--bg);
+      font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+
+    main {
+      width: min(1560px, calc(100vw - 32px));
+      margin: 0 auto;
+      padding: 28px 0 36px;
+    }
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      gap: 24px;
+      align-items: end;
+      margin-bottom: 18px;
+    }
+
+    .title-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .pulse {
+      width: 12px;
+      height: 12px;
+      border-radius: 999px;
+      background: var(--emerald);
+      box-shadow: 0 0 0 rgba(52, 211, 153, 0.65);
+      animation: pulse 2.1s infinite;
+      flex: 0 0 auto;
+    }
+
+    @keyframes pulse {
+      0% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.55); }
+      70% { box-shadow: 0 0 0 12px rgba(52, 211, 153, 0); }
+      100% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0); }
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(24px, 4vw, 40px);
+      font-weight: 760;
+      letter-spacing: 0;
+    }
+
+    .subtitle {
+      margin: 8px 0 0 24px;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.55;
+      max-width: 900px;
+    }
+
+    .meta {
+      color: var(--muted);
+      font-size: 11px;
+      text-align: right;
+      line-height: 1.6;
+      white-space: nowrap;
+    }
+
+    .diagram-card {
+      border: 1px solid rgba(148, 163, 184, 0.24);
+      border-radius: 8px;
+      overflow: auto;
+      background: rgba(15, 23, 42, 0.72);
+      box-shadow: 0 22px 80px rgba(0, 0, 0, 0.32);
+    }
+
+    svg {
+      display: block;
+      width: 100%;
+      min-width: 1120px;
+      height: auto;
+    }
+
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+      margin-top: 16px;
+    }
+
+    .card {
+      border: 1px solid rgba(148, 163, 184, 0.22);
+      border-radius: 8px;
+      background: rgba(15, 23, 42, 0.78);
+      padding: 14px 15px 16px;
+    }
+
+    .card-header {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      margin-bottom: 9px;
+    }
+
+    .card-dot {
+      width: 9px;
+      height: 9px;
+      border-radius: 999px;
+      flex: 0 0 auto;
+    }
+
+    .card-dot.cyan { background: var(--cyan); }
+    .card-dot.rose { background: var(--rose); }
+    .card-dot.amber { background: var(--amber); }
+
+    h3 {
+      margin: 0;
+      font-size: 13px;
+      font-weight: 720;
+      letter-spacing: 0;
+    }
+
+    ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      color: var(--muted);
+      font-size: 11px;
+      line-height: 1.65;
+    }
+
+    footer {
+      margin-top: 16px;
+      color: #64748b;
+      font-size: 10px;
+      line-height: 1.6;
+    }
+
+    @media (max-width: 900px) {
+      main {
+        width: calc(100vw - 20px);
+        padding-top: 18px;
+      }
+
+      .header {
+        display: block;
+      }
+
+      .subtitle {
+        margin-left: 0;
+      }
+
+      .meta {
+        margin-top: 12px;
+        text-align: left;
+        white-space: normal;
+      }
+
+      .cards {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header class="header">
+      <div>
+        <div class="title-row">
+          <span class="pulse" aria-hidden="true"></span>
+          <h1>OpenShell Networking + Filesystem Isolation</h1>
+        </div>
+        <p class="subtitle">
+          Gateway policy delivery stays separate from sandbox-local enforcement. The supervisor prepares static controls, launches the agent as an unprivileged child, and forces observable egress through the policy proxy.
+        </p>
+      </div>
+      <div class="meta">
+        Standalone HTML/SVG<br>
+        Generated from repo docs + sandbox code
+      </div>
+    </header>
+
+    <section class="diagram-card" aria-label="OpenShell isolation architecture diagram">
+      <svg viewBox="0 0 1500 1360" role="img" aria-labelledby="diagram-title diagram-desc">
+        <title id="diagram-title">OpenShell isolation architecture</title>
+        <desc id="diagram-desc">A three-panel architecture diagram showing gateway and sandbox boundaries, network egress enforcement, and filesystem startup isolation.</desc>
+        <defs>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+          </pattern>
+
+          <marker id="arrow-cyan" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#22d3ee"/>
+          </marker>
+          <marker id="arrow-emerald" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#34d399"/>
+          </marker>
+          <marker id="arrow-amber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#fbbf24"/>
+          </marker>
+          <marker id="arrow-rose" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#fb7185"/>
+          </marker>
+          <marker id="arrow-slate" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#94a3b8"/>
+          </marker>
+
+          <filter id="soft-shadow" x="-30%" y="-30%" width="160%" height="160%">
+            <feDropShadow dx="0" dy="8" stdDeviation="8" flood-color="#000000" flood-opacity="0.28"/>
+          </filter>
+
+          <style>
+            .panel-title { fill: #e2e8f0; font-size: 18px; font-weight: 760; letter-spacing: 0; }
+            .panel-sub { fill: #94a3b8; font-size: 10px; letter-spacing: 0; }
+            .box-title { fill: #f8fafc; font-size: 12px; font-weight: 740; letter-spacing: 0; }
+            .box-sub { fill: #cbd5e1; font-size: 9px; letter-spacing: 0; }
+            .box-note { fill: #94a3b8; font-size: 8px; letter-spacing: 0; }
+            .tiny { fill: #94a3b8; font-size: 7px; letter-spacing: 0; }
+            .label { fill: #cbd5e1; font-size: 9px; letter-spacing: 0; }
+            .legend { fill: #cbd5e1; font-size: 9px; letter-spacing: 0; }
+            .flow { fill: none; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
+            .flow-thin { fill: none; stroke-width: 1.2; stroke-linecap: round; stroke-linejoin: round; }
+            .flow-dash { fill: none; stroke-width: 1.5; stroke-dasharray: 5 5; stroke-linecap: round; stroke-linejoin: round; }
+            .boundary-label { fill: #fbbf24; font-size: 10px; font-weight: 700; letter-spacing: 0; }
+          </style>
+        </defs>
+
+        <rect width="1500" height="1360" fill="#020617"/>
+        <rect width="1500" height="1360" fill="url(#grid)" opacity="0.9"/>
+
+        <!-- Background panel boundaries -->
+        <rect x="38" y="36" width="1424" height="386" rx="12" fill="rgba(120, 53, 15, 0.08)" stroke="#fbbf24" stroke-width="1.3" stroke-dasharray="8 4"/>
+        <text x="58" y="64" class="panel-title">1. Runtime Boundary</text>
+        <text x="58" y="84" class="panel-sub">Gateway delivers desired state. Sandbox supervisor owns runtime enforcement.</text>
+
+        <rect x="38" y="452" width="1424" height="438" rx="12" fill="rgba(136, 19, 55, 0.055)" stroke="#fb7185" stroke-width="1.3" stroke-dasharray="8 4"/>
+        <text x="58" y="480" class="panel-title">2. Network Egress Enforcement</text>
+        <text x="58" y="500" class="panel-sub">Ordinary traffic is forced through the proxy, evaluated, and either forwarded, denied, logged, or routed to inference.local.</text>
+
+        <rect x="38" y="920" width="1424" height="278" rx="12" fill="rgba(6, 78, 59, 0.055)" stroke="#34d399" stroke-width="1.3" stroke-dasharray="8 4"/>
+        <text x="58" y="948" class="panel-title">3. Filesystem + Process Startup</text>
+        <text x="58" y="968" class="panel-sub">Static controls are prepared before exec and normally require sandbox recreation to change.</text>
+
+        <!-- Runtime boundary -->
+        <rect x="76" y="116" width="205" height="72" rx="6" fill="#0f172a"/>
+        <rect x="76" y="116" width="205" height="72" rx="6" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="98" y="145" class="box-title">CLI / SDK / TUI</text>
+        <text x="98" y="164" class="box-sub">user-facing API clients</text>
+
+        <rect x="356" y="104" width="270" height="96" rx="6" fill="#0f172a"/>
+        <rect x="356" y="104" width="270" height="96" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="382" y="134" class="box-title">Gateway Control Plane</text>
+        <text x="382" y="154" class="box-sub">sandbox state, policy revisions</text>
+        <text x="382" y="171" class="box-sub">settings, credentials, inference routes</text>
+
+        <rect x="682" y="116" width="218" height="72" rx="6" fill="#0f172a"/>
+        <rect x="682" y="116" width="218" height="72" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="710" y="145" class="box-title">Compute Runtime</text>
+        <text x="710" y="164" class="box-sub">Docker, Podman, K8s, VM</text>
+
+        <rect x="950" y="92" width="404" height="310" rx="12" fill="rgba(15, 23, 42, 0.48)" stroke="#fbbf24" stroke-width="1.2" stroke-dasharray="8 4"/>
+        <text x="972" y="119" class="boundary-label">Sandbox workload</text>
+
+        <rect x="984" y="144" width="298" height="84" rx="6" fill="#0f172a"/>
+        <rect x="984" y="144" width="298" height="84" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="1012" y="174" class="box-title">Supervisor</text>
+        <text x="1012" y="193" class="box-sub">root prelude, policy load, config polling</text>
+        <text x="1012" y="210" class="box-sub">proxy, SSH relay, log push</text>
+
+        <rect x="984" y="268" width="298" height="72" rx="6" fill="#0f172a"/>
+        <rect x="984" y="268" width="298" height="72" rx="6" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="1012" y="297" class="box-title">Restricted Agent Child</text>
+        <text x="1012" y="316" class="box-sub">sandbox user + group</text>
+        <text x="1012" y="331" class="box-note">Landlock, seccomp, netns active</text>
+
+        <rect x="1320" y="146" width="116" height="50" rx="6" fill="#0f172a"/>
+        <rect x="1320" y="146" width="116" height="50" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="1339" y="174" class="box-title">OPA</text>
+        <text x="1338" y="190" class="box-sub">policy engine</text>
+
+        <rect x="1320" y="214" width="116" height="50" rx="6" fill="#0f172a"/>
+        <rect x="1320" y="214" width="116" height="50" rx="6" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="1334" y="242" class="box-title">Proxy</text>
+        <text x="1337" y="258" class="box-sub">egress gate</text>
+
+        <rect x="1320" y="282" width="116" height="50" rx="6" fill="#0f172a"/>
+        <rect x="1320" y="282" width="116" height="50" rx="6" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="1334" y="310" class="box-title">Relay</text>
+        <text x="1332" y="326" class="box-sub">connect/exec/fs</text>
+
+        <path class="flow" d="M281 152 L347 152" stroke="#22d3ee" marker-end="url(#arrow-cyan)"/>
+        <text x="296" y="141" class="label">gRPC / HTTP</text>
+
+        <path class="flow" d="M626 152 L673 152" stroke="#34d399" marker-end="url(#arrow-emerald)"/>
+        <text x="634" y="141" class="label">launch request</text>
+
+        <path class="flow" d="M900 152 C926 152 926 186 976 186" stroke="#fbbf24" marker-end="url(#arrow-amber)"/>
+        <text x="909" y="137" class="label">provisions workload</text>
+
+        <path class="flow-dash" d="M984 170 C846 182 756 210 626 184" stroke="#34d399" marker-end="url(#arrow-emerald)"/>
+        <text x="718" y="203" class="label">outbound supervisor session</text>
+        <text x="720" y="219" class="tiny">config refresh, logs, relays</text>
+
+        <path class="flow" d="M1133 228 L1133 260" stroke="#34d399" marker-end="url(#arrow-emerald)"/>
+        <text x="1146" y="250" class="label">spawn + restrict</text>
+
+        <path class="flow-thin" d="M1282 188 L1312 171" stroke="#a78bfa" marker-end="url(#arrow-slate)"/>
+        <path class="flow-thin" d="M1282 198 L1312 239" stroke="#fb7185" marker-end="url(#arrow-rose)"/>
+        <path class="flow-thin" d="M1282 206 L1312 307" stroke="#94a3b8" marker-end="url(#arrow-slate)"/>
+
+        <!-- Network panel -->
+        <rect x="76" y="552" width="185" height="74" rx="6" fill="#0f172a"/>
+        <rect x="76" y="552" width="185" height="74" rx="6" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="100" y="582" class="box-title">Agent Process</text>
+        <text x="100" y="601" class="box-sub">HTTP(S), git, model SDKs</text>
+        <text x="100" y="616" class="box-note">env: http_proxy / HTTPS_PROXY</text>
+
+        <rect x="76" y="676" width="185" height="82" rx="6" fill="#0f172a"/>
+        <rect x="76" y="676" width="185" height="82" rx="6" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="98" y="705" class="box-title">Bypass Guards</text>
+        <text x="98" y="724" class="box-sub">netns + veth route</text>
+        <text x="98" y="741" class="box-sub">nft rejects non-proxy TCP/UDP</text>
+
+        <rect x="332" y="552" width="190" height="74" rx="6" fill="#0f172a"/>
+        <rect x="332" y="552" width="190" height="74" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="358" y="582" class="box-title">Local CONNECT Proxy</text>
+        <text x="358" y="601" class="box-sub">proxy endpoint inside netns</text>
+        <text x="358" y="616" class="box-note">terminates selected TLS/L7</text>
+
+        <rect x="584" y="540" width="190" height="62" rx="6" fill="#0f172a"/>
+        <rect x="584" y="540" width="190" height="62" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="610" y="568" class="box-title">Binary Identity</text>
+        <text x="610" y="586" class="box-sub">path, sha256, ancestors</text>
+
+        <rect x="584" y="626" width="190" height="62" rx="6" fill="#0f172a"/>
+        <rect x="584" y="626" width="190" height="62" rx="6" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="610" y="654" class="box-title">SSRF Hard Blocks</text>
+        <text x="610" y="672" class="box-sub">internal IPs unless allowed</text>
+
+        <rect x="584" y="712" width="190" height="62" rx="6" fill="#0f172a"/>
+        <rect x="584" y="712" width="190" height="62" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="610" y="740" class="box-title">OPA L4 Decision</text>
+        <text x="610" y="758" class="box-sub">host, port, binary, policy</text>
+
+        <rect x="854" y="540" width="204" height="82" rx="6" fill="#0f172a"/>
+        <rect x="854" y="540" width="204" height="82" rx="6" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="882" y="570" class="box-title">TLS / L7 Inspection</text>
+        <text x="882" y="589" class="box-sub">REST, GraphQL, WebSocket</text>
+        <text x="882" y="606" class="box-note">method, path, operation, fields</text>
+
+        <rect x="1136" y="540" width="210" height="82" rx="6" fill="#0f172a"/>
+        <rect x="1136" y="540" width="210" height="82" rx="6" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="1166" y="570" class="box-title">External Services</text>
+        <text x="1166" y="589" class="box-sub">allowed upstream traffic</text>
+        <text x="1166" y="606" class="box-note">credentials resolved only in proxy</text>
+
+        <rect x="854" y="694" width="204" height="72" rx="6" fill="#0f172a"/>
+        <rect x="854" y="694" width="204" height="72" rx="6" fill="rgba(251, 146, 60, 0.3)" stroke="#fb923c" stroke-width="1.5"/>
+        <text x="884" y="723" class="box-title">inference.local</text>
+        <text x="884" y="742" class="box-sub">special route, not OPA network</text>
+
+        <rect x="1136" y="694" width="210" height="72" rx="6" fill="#0f172a"/>
+        <rect x="1136" y="694" width="210" height="72" rx="6" fill="rgba(251, 146, 60, 0.3)" stroke="#fb923c" stroke-width="1.5"/>
+        <text x="1164" y="723" class="box-title">openshell-router</text>
+        <text x="1164" y="742" class="box-sub">configured model backends</text>
+
+        <rect x="854" y="798" width="204" height="62" rx="6" fill="#0f172a"/>
+        <rect x="854" y="798" width="204" height="62" rx="6" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="884" y="826" class="box-title">Deny / Audit / Log</text>
+        <text x="884" y="844" class="box-sub">OCSF + structured 403</text>
+
+        <rect x="1136" y="798" width="210" height="62" rx="6" fill="#0f172a"/>
+        <rect x="1136" y="798" width="210" height="62" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="1164" y="826" class="box-title">Policy Proposals</text>
+        <text x="1164" y="844" class="box-sub">L4 denial summaries to gateway</text>
+
+        <path class="flow" d="M261 589 L323 589" stroke="#34d399" marker-end="url(#arrow-emerald)"/>
+        <text x="276" y="577" class="label">ordinary egress</text>
+        <path class="flow-dash" d="M168 626 L168 668" stroke="#94a3b8" marker-end="url(#arrow-slate)"/>
+        <text x="185" y="651" class="label">bypass attempt</text>
+        <path class="flow" d="M522 589 C548 589 548 571 576 571" stroke="#a78bfa" marker-end="url(#arrow-slate)"/>
+        <path class="flow" d="M522 589 C548 589 548 657 576 657" stroke="#fb7185" marker-end="url(#arrow-rose)"/>
+        <path class="flow" d="M679 602 L679 618" stroke="#a78bfa" marker-end="url(#arrow-slate)"/>
+        <path class="flow" d="M679 688 L679 704" stroke="#a78bfa" marker-end="url(#arrow-slate)"/>
+        <path class="flow" d="M774 743 C810 743 810 581 846 581" stroke="#22d3ee" marker-end="url(#arrow-cyan)"/>
+        <text x="790" y="713" class="label">allowed + protocol inspect</text>
+        <path class="flow" d="M1058 581 L1127 581" stroke="#22d3ee" marker-end="url(#arrow-cyan)"/>
+        <text x="1073" y="570" class="label">forward</text>
+        <path class="flow" d="M774 743 L846 730" stroke="#fb923c" marker-end="url(#arrow-amber)"/>
+        <text x="788" y="759" class="label">special host</text>
+        <path class="flow" d="M1058 730 L1127 730" stroke="#fb923c" marker-end="url(#arrow-amber)"/>
+        <path class="flow-dash" d="M774 743 C816 764 812 829 846 829" stroke="#fb7185" marker-end="url(#arrow-rose)"/>
+        <text x="790" y="803" class="label">deny wins</text>
+        <path class="flow-dash" d="M1058 829 L1127 829" stroke="#fbbf24" marker-end="url(#arrow-amber)"/>
+        <text x="1070" y="818" class="label">L4 DenialEvent</text>
+
+        <!-- Filesystem panel -->
+        <rect x="76" y="1016" width="178" height="74" rx="6" fill="#0f172a"/>
+        <rect x="76" y="1016" width="178" height="74" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="102" y="1046" class="box-title">Policy YAML</text>
+        <text x="102" y="1065" class="box-sub">filesystem_policy</text>
+        <text x="102" y="1080" class="box-note">read_only + read_write</text>
+
+        <rect x="306" y="1006" width="188" height="94" rx="6" fill="#0f172a"/>
+        <rect x="306" y="1006" width="188" height="94" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="332" y="1036" class="box-title">Supervisor Prelude</text>
+        <text x="332" y="1055" class="box-sub">load + validate policy</text>
+        <text x="332" y="1072" class="box-sub">enrich baseline paths</text>
+        <text x="332" y="1087" class="box-note">workdir and runtime material</text>
+
+        <rect x="554" y="1006" width="196" height="94" rx="6" fill="#0f172a"/>
+        <rect x="554" y="1006" width="196" height="94" rx="6" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="582" y="1036" class="box-title">Landlock Prepare</text>
+        <text x="582" y="1055" class="box-sub">open PathFds as root</text>
+        <text x="582" y="1072" class="box-sub">build ruleset</text>
+        <text x="582" y="1087" class="box-note">best_effort or hard_requirement</text>
+
+        <rect x="806" y="1006" width="190" height="94" rx="6" fill="#0f172a"/>
+        <rect x="806" y="1006" width="190" height="94" rx="6" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="834" y="1036" class="box-title">pre_exec Child</text>
+        <text x="834" y="1055" class="box-sub">enter netns/mount ns</text>
+        <text x="834" y="1072" class="box-sub">drop to sandbox user</text>
+        <text x="834" y="1087" class="box-note">no supervisor identity socket</text>
+
+        <rect x="1050" y="1006" width="196" height="94" rx="6" fill="#0f172a"/>
+        <rect x="1050" y="1006" width="196" height="94" rx="6" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="1078" y="1036" class="box-title">Enforce Controls</text>
+        <text x="1078" y="1055" class="box-sub">restrict_self()</text>
+        <text x="1078" y="1072" class="box-sub">seccomp filter</text>
+        <text x="1078" y="1087" class="box-note">raw socket and privilege paths blocked</text>
+
+        <rect x="1278" y="1006" width="154" height="94" rx="6" fill="#0f172a"/>
+        <rect x="1278" y="1006" width="154" height="94" rx="6" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="1306" y="1036" class="box-title">Exec Agent</text>
+        <text x="1306" y="1055" class="box-sub">restricted runtime</text>
+        <text x="1306" y="1072" class="box-note">undeclared paths denied</text>
+
+        <rect x="242" y="1134" width="200" height="48" rx="6" fill="#0f172a"/>
+        <rect x="242" y="1134" width="200" height="48" rx="6" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="266" y="1163" class="box-title">Read-only paths</text>
+        <text x="266" y="1178" class="box-note">/usr, /lib, /etc, /app...</text>
+
+        <rect x="476" y="1134" width="200" height="48" rx="6" fill="#0f172a"/>
+        <rect x="476" y="1134" width="200" height="48" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="500" y="1163" class="box-title">Read-write paths</text>
+        <text x="500" y="1178" class="box-note">/sandbox, /tmp, workdir...</text>
+
+        <rect x="710" y="1134" width="200" height="48" rx="6" fill="#0f172a"/>
+        <rect x="710" y="1134" width="200" height="48" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="734" y="1163" class="box-title">Runtime enrichment</text>
+        <text x="734" y="1178" class="box-note">proxy support, GPU devices</text>
+
+        <rect x="944" y="1134" width="200" height="48" rx="6" fill="#0f172a"/>
+        <rect x="944" y="1134" width="200" height="48" rx="6" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="968" y="1163" class="box-title">Blocked by default</text>
+        <text x="968" y="1178" class="box-note">undeclared filesystem paths</text>
+
+        <path class="flow" d="M254 1053 L297 1053" stroke="#a78bfa" marker-end="url(#arrow-slate)"/>
+        <path class="flow" d="M494 1053 L545 1053" stroke="#34d399" marker-end="url(#arrow-emerald)"/>
+        <path class="flow" d="M750 1053 L797 1053" stroke="#fb7185" marker-end="url(#arrow-rose)"/>
+        <path class="flow" d="M996 1053 L1041 1053" stroke="#94a3b8" marker-end="url(#arrow-slate)"/>
+        <path class="flow" d="M1246 1053 L1269 1053" stroke="#22d3ee" marker-end="url(#arrow-cyan)"/>
+
+        <path class="flow-thin" d="M400 1100 C400 1118 342 1118 342 1128" stroke="#22d3ee" marker-end="url(#arrow-cyan)"/>
+        <path class="flow-thin" d="M400 1100 C400 1120 576 1118 576 1128" stroke="#34d399" marker-end="url(#arrow-emerald)"/>
+        <path class="flow-thin" d="M400 1100 C400 1126 810 1118 810 1128" stroke="#fbbf24" marker-end="url(#arrow-amber)"/>
+        <path class="flow-thin" d="M1148 1100 C1148 1124 1044 1120 1044 1128" stroke="#fb7185" marker-end="url(#arrow-rose)"/>
+
+        <!-- Legend below all boundaries -->
+        <rect x="284" y="1238" width="930" height="70" rx="8" fill="rgba(15, 23, 42, 0.76)" stroke="rgba(148, 163, 184, 0.28)" stroke-width="1.2"/>
+        <text x="306" y="1264" class="legend">Legend</text>
+        <rect x="306" y="1280" width="16" height="10" rx="2" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee"/>
+        <text x="332" y="1289" class="legend">client / protocol inspection</text>
+        <rect x="510" y="1280" width="16" height="10" rx="2" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399"/>
+        <text x="536" y="1289" class="legend">gateway or supervisor control</text>
+        <rect x="744" y="1280" width="16" height="10" rx="2" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa"/>
+        <text x="770" y="1289" class="legend">policy engine / policy data</text>
+        <rect x="956" y="1280" width="16" height="10" rx="2" fill="rgba(136, 19, 55, 0.4)" stroke="#fb7185"/>
+        <text x="982" y="1289" class="legend">security enforcement / deny path</text>
+      </svg>
+    </section>
+
+    <section class="cards" aria-label="diagram notes">
+      <article class="card">
+        <div class="card-header">
+          <span class="card-dot cyan"></span>
+          <h3>Network Isolation</h3>
+        </div>
+        <ul>
+          <li>Traffic is configured for proxy mode in sandbox policy conversion.</li>
+          <li>The child receives proxy environment variables before exec.</li>
+          <li>Network namespace and nftables reject direct TCP/UDP bypass attempts.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <div class="card-header">
+          <span class="card-dot rose"></span>
+          <h3>Filesystem Isolation</h3>
+        </div>
+        <ul>
+          <li>Landlock PathFds are opened while the supervisor still has root privileges.</li>
+          <li>The child drops to the sandbox user before Landlock and seccomp enforcement.</li>
+          <li>Read-only, read-write, workdir, and enriched runtime paths define the visible filesystem.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <div class="card-header">
+          <span class="card-dot amber"></span>
+          <h3>Dynamic Policy</h3>
+        </div>
+        <ul>
+          <li>Network policy can reload for new connections or safely parsed HTTP requests.</li>
+          <li>Filesystem and process controls are startup-time controls.</li>
+          <li>L4 denials can become pending gateway policy proposals.</li>
+        </ul>
+      </article>
+    </section>
+
+    <footer>
+      References inspected: docs/about/how-it-works.mdx, architecture/sandbox.md, architecture/security-policy.md, crates/openshell-policy/src/lib.rs, crates/openshell-sandbox/src/policy.rs, crates/openshell-sandbox/src/process.rs, crates/openshell-sandbox/src/sandbox/linux/landlock.rs, crates/openshell-sandbox/src/sandbox/linux/netns.rs, crates/openshell-sandbox/src/sandbox/linux/seccomp.rs, crates/openshell-sandbox/src/sandbox/linux/nft_ruleset.rs.
+    </footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Draft proof-of-concept for the Kubernetes node-enforcer topology. This PR is intentionally WIP and meant to capture the spike result, diagrams, local validation, and tradeoffs rather than propose a finalized production design.

See the `spike/` directory README and the diagrams to see more investigation into this topology design.

## Related Issue

N/A - spike proof of concept.

## Changes

- Adds the external node-enforcer topology for Kubernetes so sandbox workload pods can run without the filesystem lockdown and network namespace privileges currently held by the combined supervisor.
- Adds Helm wiring, node-enforcer CI/dev values, and label isolation for the node-enforcer DaemonSet.
- Moves the spike notes into spike/README.md and includes the generated architecture diagrams comparing current state, split-pod options, isolation backend framing, and the node-enforcer option.

## Testing

- mise run helm:test passed.
- Kubernetes node-enforcer smoke e2e passed with deploy/helm/openshell/ci/values-node-enforcer.yaml.
- Kubernetes bypass_detection e2e passed with the node-enforcer overlay.
- Manual sandbox validation passed: the sandbox created successfully, node-enforcer enforcement logs were observed, and raw direct TCP from the sandbox user path was rejected with exit code 111.
- Final full pre-commit rerun was skipped for spike scope after the initial post-diagram run timed out during the Rust test phase; completed earlier phases had passed.

## Checklist

- [x] Draft PR
- [x] Proof-of-concept status called out in the title and summary
- [x] Spike README and diagrams included
- [ ] Production hardening complete
