### PR TITLE
feat(controller): in-process reconciler for OpenShellSandbox CRD

### DIFF
--- a/.agents/skills/debug-openshell-cluster/SKILL.md
+++ b/.agents/skills/debug-openshell-cluster/SKILL.md
@@ -147,6 +147,47 @@ kubectl -n openshell get statefulset,pod,pvc -l app.kubernetes.io/instance=opens
 kubectl -n openshell logs statefulset/openshell-postgres --tail=200
 ```
 
+#### Native CRD controller
+
+Every Helm-deployed gateway runs an in-process reconciler for
+`OpenShellSandbox` CRs under group `openshell.nvidia.com` on its
+ordinal-0 StatefulSet replica. The CRD ships with the chart.
+
+When `OpenShellSandbox` CRs are not progressing, check in order:
+
+```bash
+# 1. Was the controller spawned? (only on openshell-0)
+kubectl -n openshell logs openshell-0 | grep -E 'openshell-controller starting|spawning in-process'
+
+# 2. Is the CRD installed?
+kubectl get crd openshellsandboxes.openshell.nvidia.com
+
+# 3. Are the CRs visible?
+kubectl -n openshell get oshs
+
+# 4. Controller decisions (logs in the same gateway pod)
+kubectl -n openshell logs openshell-0 | grep -E 'reconcil|finalizer|gateway delete|CreateSandbox'
+
+# 5. Status detail on a specific CR
+kubectl -n openshell get oshs <name> -o yaml | yq '.status'
+```
+
+Common findings:
+
+- No `openshell-controller starting` line on openshell-0: the
+  OPENSHELL_CONTROLLER_WATCH_NAMESPACE env var didn't reach the pod.
+  Inspect with
+  `kubectl -n openshell get pod openshell-0 -o yaml | yq '.spec.containers[].env'`
+  and confirm `controller.watchNamespace` in `helm get values`.
+- CR stuck at `phase=Provisioning`: the gateway call is in flight or
+  the controller failed mid-call. Restart the gateway pod
+  (`kubectl -n openshell delete pod openshell-0`); the reconcile loop
+  re-fires on restart.
+- `kubectl delete oshs <name>` hangs: the finalizer is in place and the
+  gateway is unreachable or refusing the delete. Check
+  `kubectl -n openshell logs openshell-0 | grep 'gateway delete'` for
+  the most recent attempt.
+
 Check required Helm deployment secrets:
 
 ```bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,6 +3454,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "openshell-controller"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "k8s-openapi",
+ "kube",
+ "kube-runtime",
+ "openshell-core",
+ "openshell-policy",
+ "prost-types",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_yml",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "openshell-core"
 version = "0.0.0"
 dependencies = [
@@ -3716,6 +3741,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "miette",
  "openshell-bootstrap",
+ "openshell-controller",
  "openshell-core",
  "openshell-driver-docker",
  "openshell-driver-kubernetes",

--- a/crates/openshell-controller/Cargo.toml
+++ b/crates/openshell-controller/Cargo.toml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "openshell-controller"
+description = "In-process Kubernetes controller that reconciles OpenShellSandbox CRDs"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+openshell-core = { path = "../openshell-core" }
+openshell-policy = { path = "../openshell-policy" }
+
+anyhow = { workspace = true }
+async-trait = "0.1"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+futures = { workspace = true }
+k8s-openapi = { workspace = true }
+kube = { workspace = true }
+kube-runtime = { workspace = true }
+prost-types = { workspace = true }
+schemars = "0.8"
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yml = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tonic = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+tokio = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/openshell-controller/Cargo.toml
+++ b/crates/openshell-controller/Cargo.toml
@@ -33,7 +33,10 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+async-trait = "0.1"
+openshell-core = { path = "../openshell-core" }
 tokio = { workspace = true }
+tonic = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [lints]

--- a/crates/openshell-controller/examples/standalone.rs
+++ b/crates/openshell-controller/examples/standalone.rs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Standalone runner used for local iteration against a kind cluster.
+//!
+//! Not shipped — the production path is in-process inside `openshell-server`.
+//! This binary just installs a tracing subscriber and calls
+//! [`openshell_controller::run`] so you can `cargo run --example standalone`
+//! against `~/.kube/config` while iterating on the reconciler.
+
+use std::sync::Arc;
+
+use openshell_controller::{ControllerConfig, NoopGateway};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = ControllerConfig::from_env();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new(&config.log_filter)),
+        )
+        .init();
+    openshell_controller::run(Arc::new(NoopGateway), config).await
+}

--- a/crates/openshell-controller/src/config.rs
+++ b/crates/openshell-controller/src/config.rs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Runtime configuration for the controller, sourced from environment
+//! variables set by the Helm chart.
+
+use std::env;
+
+/// All knobs the controller needs at startup.
+#[derive(Debug, Clone)]
+pub struct ControllerConfig {
+    /// Namespace the controller watches. v1 enforces a single-namespace
+    /// contract — one Helm release ⇒ one watched namespace.
+    pub watch_namespace: String,
+
+    /// `RUST_LOG`-style filter for the controller's tracing subscriber.
+    /// Applied by the caller; the controller itself does not install a
+    /// subscriber.
+    pub log_filter: String,
+}
+
+impl ControllerConfig {
+    /// Build the config from the environment variables the chart sets.
+    ///
+    /// - `OPENSHELL_CONTROLLER_WATCH_NAMESPACE` — namespace to watch. Falls
+    ///   back to `OPENSHELL_SANDBOX_NAMESPACE`, then to `default`.
+    /// - `OPENSHELL_CONTROLLER_LOG_FILTER` — `RUST_LOG` filter string.
+    ///   Defaults to `info,openshell_controller=info,kube=warn`.
+    #[must_use]
+    pub fn from_env() -> Self {
+        let watch_namespace = env::var("OPENSHELL_CONTROLLER_WATCH_NAMESPACE")
+            .or_else(|_| env::var("OPENSHELL_SANDBOX_NAMESPACE"))
+            .unwrap_or_else(|_| "default".to_owned());
+
+        let log_filter = env::var("OPENSHELL_CONTROLLER_LOG_FILTER")
+            .unwrap_or_else(|_| "info,openshell_controller=info,kube=warn".to_owned());
+
+        Self {
+            watch_namespace,
+            log_filter,
+        }
+    }
+}

--- a/crates/openshell-controller/src/gateway.rs
+++ b/crates/openshell-controller/src/gateway.rs
@@ -26,6 +26,18 @@ pub trait GatewayClient: Send + Sync + 'static {
     /// Delete a sandbox by name. Returns whether the sandbox existed; a
     /// `false` is a successful no-op (the gateway side was already gone).
     async fn delete_sandbox(&self, name: &str) -> Result<bool, Status>;
+
+    /// Find at most one sandbox tagged with a given label.
+    ///
+    /// Used by the reconciler to discover whether a sandbox for the
+    /// current CR's uid already exists, so create can be skipped on
+    /// re-reconcile (cross-namespace name collisions, spec edits,
+    /// controller crash recovery).
+    async fn find_sandbox_by_label(
+        &self,
+        key: &str,
+        value: &str,
+    ) -> Result<Option<Sandbox>, Status>;
 }
 
 /// Stub implementation used by the standalone dev example and unit tests.
@@ -54,5 +66,13 @@ impl GatewayClient for NoopGateway {
             "NoopGateway::delete_sandbox — no-op"
         );
         Ok(false)
+    }
+
+    async fn find_sandbox_by_label(
+        &self,
+        _key: &str,
+        _value: &str,
+    ) -> Result<Option<Sandbox>, Status> {
+        Ok(None)
     }
 }

--- a/crates/openshell-controller/src/gateway.rs
+++ b/crates/openshell-controller/src/gateway.rs
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Gateway client trait — abstraction over "how the reconciler talks to
+//! the gateway."
+//!
+//! In production (`openshell-server` spawns the controller in-process) the
+//! implementation is a direct Rust call into the gateway's create-sandbox
+//! core. The trait keeps the controller code free of a hard dependency on
+//! `openshell-server` and lets the standalone dev example inject a stub.
+
+use async_trait::async_trait;
+use openshell_core::proto::{CreateSandboxRequest, Sandbox};
+use tonic::Status;
+
+/// What the reconciler needs from the gateway.
+///
+/// Implemented in `openshell-server::api::GatewayHandle` for the in-process
+/// production path. The standalone dev example provides a [`NoopGateway`]
+/// stub so the reconciler can run end-to-end without a real gateway
+/// attached.
+#[async_trait]
+pub trait GatewayClient: Send + Sync + 'static {
+    async fn create_sandbox(&self, req: CreateSandboxRequest) -> Result<Sandbox, Status>;
+
+    /// Delete a sandbox by name. Returns whether the sandbox existed; a
+    /// `false` is a successful no-op (the gateway side was already gone).
+    async fn delete_sandbox(&self, name: &str) -> Result<bool, Status>;
+}
+
+/// Stub implementation used by the standalone dev example and unit tests.
+///
+/// Create returns `Status::unimplemented` so the reconciler can still
+/// drive the watch loop and patch a Failed status. Delete returns
+/// `Ok(false)` so the finalizer cleanly removes itself — exercising the
+/// deletion path without a real gateway behind it.
+pub struct NoopGateway;
+
+#[async_trait]
+impl GatewayClient for NoopGateway {
+    async fn create_sandbox(&self, req: CreateSandboxRequest) -> Result<Sandbox, Status> {
+        tracing::info!(
+            request_name = %req.name,
+            "NoopGateway::create_sandbox — request received but not forwarded"
+        );
+        Err(Status::unimplemented(
+            "NoopGateway: standalone dev mode — no real gateway attached",
+        ))
+    }
+
+    async fn delete_sandbox(&self, name: &str) -> Result<bool, Status> {
+        tracing::info!(
+            sandbox_name = %name,
+            "NoopGateway::delete_sandbox — no-op"
+        );
+        Ok(false)
+    }
+}

--- a/crates/openshell-controller/src/gateway.rs
+++ b/crates/openshell-controller/src/gateway.rs
@@ -38,6 +38,11 @@ pub trait GatewayClient: Send + Sync + 'static {
         key: &str,
         value: &str,
     ) -> Result<Option<Sandbox>, Status>;
+
+    /// Fetch a sandbox by name. The returned `Sandbox` carries the
+    /// gateway's current observation of the underlying pod's readiness,
+    /// which the reconciler projects into `.status.phase`.
+    async fn get_sandbox(&self, name: &str) -> Result<Sandbox, Status>;
 }
 
 /// Stub implementation used by the standalone dev example and unit tests.
@@ -74,5 +79,11 @@ impl GatewayClient for NoopGateway {
         _value: &str,
     ) -> Result<Option<Sandbox>, Status> {
         Ok(None)
+    }
+
+    async fn get_sandbox(&self, name: &str) -> Result<Sandbox, Status> {
+        Err(Status::not_found(format!(
+            "NoopGateway: no sandbox {name}"
+        )))
     }
 }

--- a/crates/openshell-controller/src/lib.rs
+++ b/crates/openshell-controller/src/lib.rs
@@ -42,6 +42,15 @@ pub use types::OpenShellSandbox;
 /// CRD list. The reconcile loop itself never returns under normal
 /// operation.
 pub async fn run<G: GatewayClient>(gateway: Arc<G>, config: ControllerConfig) -> Result<()> {
+    // Fail fast on empty watch_namespace. An empty string would silently
+    // produce a cluster-wide watch via `Api::namespaced("")`, which the
+    // controller's RBAC isn't scoped for — we'd flap on 403s deep in the
+    // reconcile loop instead of erroring at startup.
+    if config.watch_namespace.is_empty() {
+        return Err(anyhow::anyhow!(
+            "OPENSHELL_CONTROLLER_WATCH_NAMESPACE is empty; controller requires a namespace"
+        ));
+    }
     info!(
         namespace = %config.watch_namespace,
         "openshell-controller starting"

--- a/crates/openshell-controller/src/lib.rs
+++ b/crates/openshell-controller/src/lib.rs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `OpenShell` CRD controller.
+//!
+//! Reconciles [`OpenShellSandbox`](types::OpenShellSandbox) CRs in a single
+//! namespace, translating each into a sandbox-create call against the gateway
+//! it runs alongside. Spawned as a tokio task by `openshell-server` on the
+//! ordinal-0 `StatefulSet` replica when the chart-set
+//! `OPENSHELL_CONTROLLER_WATCH_NAMESPACE` env var is present.
+
+pub mod config;
+pub mod gateway;
+mod reconcile;
+pub mod translate;
+pub mod types;
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use kube::Client;
+use tracing::info;
+
+pub use config::ControllerConfig;
+pub use gateway::{GatewayClient, NoopGateway};
+pub use types::OpenShellSandbox;
+
+/// Entry point spawned by `openshell-server`.
+///
+/// Builds a kube client from the ambient environment (in-cluster service
+/// account in production, `~/.kube/config` for local dev) and runs the
+/// reconciler until the watch stream terminates. The caller should treat
+/// completion of this function as fatal.
+///
+/// `gateway` is the in-process handle to the gateway's create-sandbox core.
+/// In production `openshell-server` passes a real `GatewayHandle`; the
+/// standalone dev example passes [`NoopGateway`].
+///
+/// # Errors
+///
+/// Returns any error from constructing the kube client or pre-flighting the
+/// CRD list. The reconcile loop itself never returns under normal
+/// operation.
+pub async fn run<G: GatewayClient>(gateway: Arc<G>, config: ControllerConfig) -> Result<()> {
+    info!(
+        namespace = %config.watch_namespace,
+        "openshell-controller starting"
+    );
+
+    let client = Client::try_default()
+        .await
+        .context("constructing kube client (in-cluster or ~/.kube/config)")?;
+
+    reconcile::run(client, gateway, config.watch_namespace).await
+}

--- a/crates/openshell-controller/src/reconcile.rs
+++ b/crates/openshell-controller/src/reconcile.rs
@@ -28,6 +28,10 @@ use crate::types::{OpenShellSandbox, Phase};
 const FIELD_MANAGER: &str = "openshell-controller";
 const FINALIZER: &str = "openshell.nvidia.com/finalizer";
 const REQUEUE_INTERVAL: Duration = Duration::from_secs(30);
+/// Polling cadence while we're waiting for the gateway to observe the
+/// pod transition to Ready. Faster than `REQUEUE_INTERVAL` because users
+/// expect `kubectl get oshs` to converge quickly after a CR apply.
+const OBSERVE_INTERVAL: Duration = Duration::from_secs(3);
 const ERROR_REQUEUE_INTERVAL: Duration = Duration::from_secs(15);
 
 /// Shared context handed to every reconcile call.
@@ -187,8 +191,21 @@ async fn reconcile<G: GatewayClient>(
         .as_ref()
         .map(|m| m.id.clone())
         .unwrap_or_default();
-    patch_status_running(&api, &name, generation, &sandbox_id).await?;
-    Ok(Action::requeue(REQUEUE_INTERVAL))
+    let sandbox_name = sandbox
+        .metadata
+        .as_ref()
+        .map_or_else(|| name.clone(), |m| m.name.clone());
+
+    // Project the gateway's view of the pod into CR status. The gateway's
+    // driver maintains a watch on the agent-sandbox `Sandbox` CR and
+    // updates `Sandbox.status.phase`; re-fetching gives us the live
+    // observation rather than the just-after-create snapshot. If the
+    // get fails (rare — we just created/found it), fall back to the
+    // sandbox we already have in hand.
+    let observed = ctx.gateway.get_sandbox(&sandbox_name).await.unwrap_or(sandbox);
+    let (phase, requeue) = phase_from_gateway(&observed);
+    patch_status(&api, &name, generation, &sandbox_id, phase).await?;
+    Ok(Action::requeue(requeue))
 }
 
 const APIV: &str = "openshell.nvidia.com/v1alpha1";
@@ -201,18 +218,18 @@ fn has_finalizer(obj: &OpenShellSandbox) -> bool {
         .is_some_and(|f| f.iter().any(|s| s == FINALIZER))
 }
 
-/// Whether the controller has already finished a reconcile for the current
-/// spec generation.
+/// Whether the controller has already reached a terminal state for the
+/// current spec generation.
 ///
-/// Returns true when `status.observedGeneration` matches the current
-/// `metadata.generation` AND a phase is set — any phase, including
-/// Running or Failed. This guards against watch-event echoes from our
-/// own status patches re-entering the gateway call. Crash recovery is
-/// handled by the cr-uid lookup in the reconcile body, not here.
+/// Returns true only for `Running` or `Failed` at the current
+/// `metadata.generation`. Transitional phases (`Pending`, `Provisioning`,
+/// `Terminating`) must continue to reconcile so the gateway-observed
+/// phase gets projected into status as the pod converges.
 fn is_already_handled(obj: &OpenShellSandbox, generation: i64) -> bool {
-    obj.status
-        .as_ref()
-        .is_some_and(|s| s.observed_generation == Some(generation) && s.phase.is_some())
+    obj.status.as_ref().is_some_and(|s| {
+        s.observed_generation == Some(generation)
+            && matches!(s.phase, Some(Phase::Running | Phase::Failed))
+    })
 }
 
 async fn attach_finalizer(
@@ -296,25 +313,50 @@ async fn handle_deletion<G: GatewayClient>(
     }
 }
 
-async fn patch_status_running(
+/// Map the gateway-side `SandboxPhase` proto into the CR phase + a
+/// requeue interval. Terminal states (Running, Failed) requeue on the
+/// long heartbeat; transitional states poll faster so kubectl converges
+/// quickly when the pod becomes Ready.
+fn phase_from_gateway(sandbox: &openshell_core::proto::Sandbox) -> (Phase, Duration) {
+    use openshell_core::proto::SandboxPhase as Gw;
+    // `Sandbox.phase` is a raw i32 since proto3 enums round-trip via
+    // their numeric tag. Unrecognised values map to Pending.
+    match Gw::try_from(sandbox.phase()).unwrap_or(Gw::Unspecified) {
+        Gw::Ready => (Phase::Running, REQUEUE_INTERVAL),
+        Gw::Provisioning | Gw::Unspecified => (Phase::Provisioning, OBSERVE_INTERVAL),
+        Gw::Deleting => (Phase::Terminating, OBSERVE_INTERVAL),
+        Gw::Error => (Phase::Failed, REQUEUE_INTERVAL),
+        Gw::Unknown => (Phase::Pending, OBSERVE_INTERVAL),
+    }
+}
+
+async fn patch_status(
     api: &Api<OpenShellSandbox>,
     name: &str,
     generation: i64,
     sandbox_id: &str,
+    phase: Phase,
 ) -> Result<(), ReconcileError> {
     let now = Utc::now().to_rfc3339();
+    let (cond_status, reason, message) = match phase {
+        Phase::Running => ("True", "Ready", "Gateway-observed sandbox is Ready"),
+        Phase::Provisioning => ("False", "Provisioning", "Gateway-observed sandbox is Provisioning"),
+        Phase::Terminating => ("False", "Terminating", "Sandbox is terminating"),
+        Phase::Failed => ("False", "Failed", "Gateway reports sandbox error"),
+        Phase::Pending | Phase::Deleted => ("Unknown", "Pending", "Awaiting gateway observation"),
+    };
     let patch = json!({
         "apiVersion": APIV,
         "kind": KIND,
         "status": {
-            "phase": Phase::Running,
+            "phase": phase,
             "observedGeneration": generation,
             "sandboxId": sandbox_id,
-            "message": "gateway sandbox created",
+            "message": message,
             "lastUpdated": now,
             "conditions": [{
-                "type": "Ready", "status": "True", "reason": "Created",
-                "message": "Gateway returned a sandbox",
+                "type": "Ready", "status": cond_status, "reason": reason,
+                "message": message,
                 "lastTransitionTime": now, "observedGeneration": generation,
             }],
         }
@@ -497,14 +539,19 @@ mod tests {
     }
 
     #[test]
-    fn is_already_handled_true_at_current_generation_for_any_phase() {
-        for phase in [
-            Phase::Pending,
-            Phase::Provisioning,
-            Phase::Running,
-            Phase::Failed,
-            Phase::Terminating,
-        ] {
+    fn is_already_handled_true_only_for_terminal_phases() {
+        // Running and Failed are terminal for the current generation and
+        // short-circuit reconcile. Transitional phases (Pending,
+        // Provisioning, Terminating) must continue to reconcile so the
+        // gateway-observed phase keeps getting projected into status.
+        let cases = [
+            (Phase::Pending, false),
+            (Phase::Provisioning, false),
+            (Phase::Terminating, false),
+            (Phase::Running, true),
+            (Phase::Failed, true),
+        ];
+        for (phase, expected) in cases {
             let mut cr = cr_with_metadata(ObjectMeta {
                 generation: Some(1),
                 ..Default::default()
@@ -514,9 +561,10 @@ mod tests {
                 phase: Some(phase),
                 ..Default::default()
             });
-            assert!(
+            assert_eq!(
                 is_already_handled(&cr, 1),
-                "phase {phase:?} at current generation should short-circuit"
+                expected,
+                "phase {phase:?} at current generation: expected is_already_handled={expected}"
             );
         }
     }

--- a/crates/openshell-controller/src/reconcile.rs
+++ b/crates/openshell-controller/src/reconcile.rs
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Minimal reconciler for `OpenShellSandbox` CRs.
+//! Reconciler for `OpenShellSandbox` CRs.
 //!
-//! This is the scaffold body: it confirms the kube-rs `Controller` wiring,
-//! the status subresource path, and the conditions/phase shape end-to-end
-//! without yet calling the gateway to actually create a sandbox.
+//! Watches CRs in a single namespace, translates each spec into the
+//! gateway's `CreateSandboxRequest`, and patches CR status to reflect the
+//! gateway-side outcome. A finalizer keeps the CR alive until the
+//! gateway-side sandbox is confirmed deleted.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -200,9 +201,12 @@ async fn attach_finalizer(
         "kind": KIND,
         "metadata": { "finalizers": [FINALIZER] },
     });
+    // No `.force()`: our finalizer entry is unique to this field manager,
+    // so we shouldn't trip another manager's ownership of the list.
+    // Conflicts surface to the reconcile loop, which requeues.
     api.patch(
         name,
-        &PatchParams::apply(FIELD_MANAGER).force(),
+        &PatchParams::apply(FIELD_MANAGER),
         &Patch::Apply(&patch),
     )
     .await
@@ -347,9 +351,13 @@ async fn apply_status(
     name: &str,
     patch: serde_json::Value,
 ) -> Result<(), ReconcileError> {
+    // No `.force()`: other field managers (e.g. a future monitoring
+    // sidecar contributing to `.status.conditions`) keep their entries.
+    // SSA conflicts on fields we co-own surface as kube errors, which
+    // the reconcile loop requeues with backoff.
     api.patch_status(
         name,
-        &PatchParams::apply(FIELD_MANAGER).force(),
+        &PatchParams::apply(FIELD_MANAGER),
         &Patch::Apply(&patch),
     )
     .await

--- a/crates/openshell-controller/src/reconcile.rs
+++ b/crates/openshell-controller/src/reconcile.rs
@@ -129,37 +129,66 @@ async fn reconcile<G: GatewayClient>(
         }
     };
 
-    // Step 1: announce Provisioning so kubectl shows the controller is
-    // working on it. The early-return idempotency check above ensures
-    // this only runs once per generation.
-    patch_status_provisioning(&api, &name, generation).await?;
+    // cr-uid idempotency: before creating, look for a gateway-side
+    // sandbox already tagged with this CR's uid. If one exists, reuse
+    // its id. Closes three real bugs:
+    //   - cross-namespace CR-name collisions (two CRs with the same
+    //     metadata.name in different namespaces) get distinct sandboxes
+    //     because each CR has a distinct unforgeable uid
+    //   - spec edits bump generation but uid stays — we update the
+    //     existing sandbox's status rather than calling create twice
+    //   - controller crash recovery: status went None mid-call, but
+    //     the gateway-side sandbox is already there
+    //
+    // metadata.uid is guaranteed by the apiserver for any CR that made
+    // it through admission, so the unwrap path is unreachable in
+    // practice.
+    let uid = obj.metadata.uid.as_deref().unwrap_or("");
+    let existing = ctx
+        .gateway
+        .find_sandbox_by_label(crate::translate::LABEL_CR_UID, uid)
+        .await?;
 
-    // Step 2: hand the request to the gateway. The gateway runs all the
-    // validation/persistence/JWT/compute-driver work itself; we just
-    // observe the outcome.
-    match ctx.gateway.create_sandbox(req).await {
-        Ok(sandbox) => {
-            let sandbox_id = sandbox
-                .metadata
-                .as_ref()
-                .map(|m| m.id.clone())
-                .unwrap_or_default();
-            patch_status_running(&api, &name, generation, &sandbox_id).await?;
-            Ok(Action::requeue(REQUEUE_INTERVAL))
+    let sandbox = match existing {
+        Some(sandbox) => {
+            info!(
+                name = %name,
+                sandbox_id = ?sandbox.metadata.as_ref().map(|m| m.id.as_str()),
+                "found existing gateway sandbox by cr-uid; skipping create"
+            );
+            sandbox
         }
-        Err(status) => {
-            // tonic::Status carries a gRPC code; surface it as a CR
-            // condition so users can see why the create failed.
-            patch_status_failed(
-                &api,
-                &name,
-                generation,
-                &format!("gateway: code={:?} message={}", status.code(), status.message()),
-            )
-            .await?;
-            Ok(Action::requeue(ERROR_REQUEUE_INTERVAL))
+        None => {
+            // Hand the request to the gateway. We don't pre-patch a
+            // Provisioning status — see is_already_handled for why a
+            // crash mid-call would leave the CR stuck if we did.
+            match ctx.gateway.create_sandbox(req).await {
+                Ok(sandbox) => sandbox,
+                Err(status) => {
+                    patch_status_failed(
+                        &api,
+                        &name,
+                        generation,
+                        &format!(
+                            "gateway: code={:?} message={}",
+                            status.code(),
+                            status.message()
+                        ),
+                    )
+                    .await?;
+                    return Ok(Action::requeue(ERROR_REQUEUE_INTERVAL));
+                }
+            }
         }
-    }
+    };
+
+    let sandbox_id = sandbox
+        .metadata
+        .as_ref()
+        .map(|m| m.id.clone())
+        .unwrap_or_default();
+    patch_status_running(&api, &name, generation, &sandbox_id).await?;
+    Ok(Action::requeue(REQUEUE_INTERVAL))
 }
 
 const APIV: &str = "openshell.nvidia.com/v1alpha1";
@@ -177,13 +206,9 @@ fn has_finalizer(obj: &OpenShellSandbox) -> bool {
 ///
 /// Returns true when `status.observedGeneration` matches the current
 /// `metadata.generation` AND a phase is set — any phase, including
-/// Provisioning, Running, or Failed. This guards against watch-event
-/// echoes from our own status patches re-entering the gateway call.
-///
-/// KNOWN LIMITATION: if the controller crashes between the Provisioning
-/// patch and the gateway call returning, the CR is stuck at Provisioning
-/// until the user edits `.spec` to bump generation. A proper cr-uid
-/// lookup against the gateway is the long-term fix.
+/// Running or Failed. This guards against watch-event echoes from our
+/// own status patches re-entering the gateway call. Crash recovery is
+/// handled by the cr-uid lookup in the reconcile body, not here.
 fn is_already_handled(obj: &OpenShellSandbox, generation: i64) -> bool {
     obj.status
         .as_ref()
@@ -271,30 +296,6 @@ async fn handle_deletion<G: GatewayClient>(
     }
 }
 
-async fn patch_status_provisioning(
-    api: &Api<OpenShellSandbox>,
-    name: &str,
-    generation: i64,
-) -> Result<(), ReconcileError> {
-    let now = Utc::now().to_rfc3339();
-    let patch = json!({
-        "apiVersion": APIV,
-        "kind": KIND,
-        "status": {
-            "phase": Phase::Provisioning,
-            "observedGeneration": generation,
-            "message": "calling gateway to create sandbox",
-            "lastUpdated": now,
-            "conditions": [{
-                "type": "Ready", "status": "False", "reason": "Provisioning",
-                "message": "Gateway create-sandbox call in flight",
-                "lastTransitionTime": now, "observedGeneration": generation,
-            }],
-        }
-    });
-    apply_status(api, name, patch).await
-}
-
 async fn patch_status_running(
     api: &Api<OpenShellSandbox>,
     name: &str,
@@ -379,6 +380,17 @@ fn error_policy<G: GatewayClient>(
 enum ReconcileError {
     #[error("kube error: {0}")]
     Kube(#[from] kube::Error),
+    #[error("gateway error: code={code:?} message={message}")]
+    Gateway { code: tonic::Code, message: String },
+}
+
+impl From<tonic::Status> for ReconcileError {
+    fn from(status: tonic::Status) -> Self {
+        Self::Gateway {
+            code: status.code(),
+            message: status.message().to_owned(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/openshell-controller/src/reconcile.rs
+++ b/crates/openshell-controller/src/reconcile.rs
@@ -384,7 +384,7 @@ enum ReconcileError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{ExposeSpec, OpenShellSandboxSpec, OpenShellSandboxStatus};
+    use crate::types::{OpenShellSandboxSpec, OpenShellSandboxStatus};
     use kube::core::ObjectMeta;
 
     fn cr_with_metadata(meta: ObjectMeta) -> OpenShellSandbox {
@@ -392,10 +392,14 @@ mod tests {
             metadata: meta,
             spec: OpenShellSandboxSpec {
                 image: "x".into(),
-                start_command: None,
                 policy_yaml: "version: 1\n".into(),
-                expose: ExposeSpec { port: 80 },
-                pod_customisations: None,
+                environment: std::collections::BTreeMap::default(),
+                providers: Vec::new(),
+                gpu: false,
+                gpu_device: None,
+                log_level: None,
+                runtime_class_name: None,
+                labels: std::collections::BTreeMap::default(),
             },
             status: None,
         }

--- a/crates/openshell-controller/src/reconcile.rs
+++ b/crates/openshell-controller/src/reconcile.rs
@@ -1,0 +1,499 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Minimal reconciler for `OpenShellSandbox` CRs.
+//!
+//! This is the scaffold body: it confirms the kube-rs `Controller` wiring,
+//! the status subresource path, and the conditions/phase shape end-to-end
+//! without yet calling the gateway to actually create a sandbox.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use chrono::Utc;
+use futures::StreamExt;
+use kube::api::{ListParams, Patch, PatchParams};
+use kube::runtime::controller::Action;
+use kube::runtime::watcher::Config as WatcherConfig;
+use kube::runtime::Controller;
+use kube::{Api, Client, ResourceExt};
+use serde_json::json;
+use tracing::{error, info, warn};
+
+use crate::gateway::GatewayClient;
+use crate::types::{OpenShellSandbox, Phase};
+
+const FIELD_MANAGER: &str = "openshell-controller";
+const FINALIZER: &str = "openshell.nvidia.com/finalizer";
+const REQUEUE_INTERVAL: Duration = Duration::from_secs(30);
+const ERROR_REQUEUE_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Shared context handed to every reconcile call.
+struct ReconcileContext<G: GatewayClient> {
+    client: Client,
+    namespace: String,
+    gateway: Arc<G>,
+}
+
+/// Run the reconciler until the watch stream terminates.
+///
+/// `client` is a kube client scoped to whatever credentials the controller
+/// runs under (in-cluster service account in production). `gateway` is the
+/// in-process handle the reconciler calls to actually create sandboxes.
+/// `namespace` is the single namespace the controller watches.
+///
+/// # Errors
+///
+/// Returns any error from constructing the controller or pre-flighting the
+/// CRD list. The reconcile loop itself never returns under normal
+/// operation — it runs until cancelled.
+pub async fn run<G: GatewayClient>(
+    client: Client,
+    gateway: Arc<G>,
+    namespace: String,
+) -> Result<()> {
+    let api: Api<OpenShellSandbox> = Api::namespaced(client.clone(), &namespace);
+
+    // Smoke-check that the CRD is installed before we start the controller —
+    // a `list` against a missing CRD fails fast with a clear error, rather
+    // than the controller spinning silently on a 404.
+    api.list(&ListParams::default()).await.map_err(|e| {
+        anyhow::anyhow!(
+            "OpenShellSandbox CRD list failed in namespace {namespace}: {e}. \
+             Is the CRD installed (deploy/helm/openshell/crds/)?"
+        )
+    })?;
+
+    let ctx = Arc::new(ReconcileContext {
+        client,
+        namespace,
+        gateway,
+    });
+
+    Controller::new(api, WatcherConfig::default())
+        .run(reconcile, error_policy, ctx)
+        .for_each(|outcome| async {
+            match outcome {
+                Ok((obj_ref, _)) => info!(name = %obj_ref.name, "reconciled"),
+                Err(e) => warn!(error = %e, "reconcile stream error"),
+            }
+        })
+        .await;
+
+    Ok(())
+}
+
+async fn reconcile<G: GatewayClient>(
+    obj: Arc<OpenShellSandbox>,
+    ctx: Arc<ReconcileContext<G>>,
+) -> Result<Action, ReconcileError> {
+    let name = obj.name_any();
+    let generation = obj.metadata.generation.unwrap_or(0);
+    let api: Api<OpenShellSandbox> = Api::namespaced(ctx.client.clone(), &ctx.namespace);
+
+    // Deletion path: kubelet sets metadata.deletionTimestamp once the CR
+    // is `kubectl delete`d. As long as our finalizer is on
+    // metadata.finalizers, the apiserver holds the object alive so we can
+    // clean up the gateway-side sandbox before the CR disappears.
+    if obj.metadata.deletion_timestamp.is_some() {
+        return handle_deletion(&api, &ctx, &obj).await;
+    }
+
+    // Creation path: make sure the finalizer is attached BEFORE we call
+    // the gateway. Otherwise a `kubectl delete` between the gateway
+    // create and the next reconcile would orphan the sandbox.
+    if !has_finalizer(&obj) {
+        attach_finalizer(&api, &name).await?;
+        // Requeue to pick up the updated object. The new reconcile will
+        // see the finalizer and proceed.
+        return Ok(Action::requeue(Duration::from_secs(0)));
+    }
+
+    // Idempotency check — see [`is_already_handled`] for semantics.
+    if is_already_handled(&obj, generation) {
+        return Ok(Action::requeue(REQUEUE_INTERVAL));
+    }
+
+    info!(name = %name, generation, "reconciling");
+
+    // Build the request from the CR. Translation failures are config bugs
+    // (bad policyYaml, missing UID) and shouldn't be retried in tight
+    // loops — they need a human to edit the CR.
+    let req = match crate::translate::build_create_request(&obj) {
+        Ok(req) => req,
+        Err(e) => {
+            patch_status_failed(&api, &name, generation, &format!("translate: {e}")).await?;
+            return Ok(Action::requeue(REQUEUE_INTERVAL));
+        }
+    };
+
+    // Step 1: announce Provisioning so kubectl shows the controller is
+    // working on it. The early-return idempotency check above ensures
+    // this only runs once per generation.
+    patch_status_provisioning(&api, &name, generation).await?;
+
+    // Step 2: hand the request to the gateway. The gateway runs all the
+    // validation/persistence/JWT/compute-driver work itself; we just
+    // observe the outcome.
+    match ctx.gateway.create_sandbox(req).await {
+        Ok(sandbox) => {
+            let sandbox_id = sandbox
+                .metadata
+                .as_ref()
+                .map(|m| m.id.clone())
+                .unwrap_or_default();
+            patch_status_running(&api, &name, generation, &sandbox_id).await?;
+            Ok(Action::requeue(REQUEUE_INTERVAL))
+        }
+        Err(status) => {
+            // tonic::Status carries a gRPC code; surface it as a CR
+            // condition so users can see why the create failed.
+            patch_status_failed(
+                &api,
+                &name,
+                generation,
+                &format!("gateway: code={:?} message={}", status.code(), status.message()),
+            )
+            .await?;
+            Ok(Action::requeue(ERROR_REQUEUE_INTERVAL))
+        }
+    }
+}
+
+const APIV: &str = "openshell.nvidia.com/v1alpha1";
+const KIND: &str = "OpenShellSandbox";
+
+fn has_finalizer(obj: &OpenShellSandbox) -> bool {
+    obj.metadata
+        .finalizers
+        .as_ref()
+        .is_some_and(|f| f.iter().any(|s| s == FINALIZER))
+}
+
+/// Whether the controller has already finished a reconcile for the current
+/// spec generation.
+///
+/// Returns true when `status.observedGeneration` matches the current
+/// `metadata.generation` AND a phase is set — any phase, including
+/// Provisioning, Running, or Failed. This guards against watch-event
+/// echoes from our own status patches re-entering the gateway call.
+///
+/// KNOWN LIMITATION: if the controller crashes between the Provisioning
+/// patch and the gateway call returning, the CR is stuck at Provisioning
+/// until the user edits `.spec` to bump generation. A proper cr-uid
+/// lookup against the gateway is the long-term fix.
+fn is_already_handled(obj: &OpenShellSandbox, generation: i64) -> bool {
+    obj.status
+        .as_ref()
+        .is_some_and(|s| s.observed_generation == Some(generation) && s.phase.is_some())
+}
+
+async fn attach_finalizer(
+    api: &Api<OpenShellSandbox>,
+    name: &str,
+) -> Result<(), ReconcileError> {
+    // SSA on `metadata.finalizers` so we own that key as a field manager
+    // and won't fight other writers over the rest of metadata.
+    let patch = json!({
+        "apiVersion": APIV,
+        "kind": KIND,
+        "metadata": { "finalizers": [FINALIZER] },
+    });
+    api.patch(
+        name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(&patch),
+    )
+    .await
+    .map_err(ReconcileError::Kube)?;
+    info!(name = %name, finalizer = FINALIZER, "attached finalizer");
+    Ok(())
+}
+
+async fn detach_finalizer(
+    api: &Api<OpenShellSandbox>,
+    obj: &OpenShellSandbox,
+) -> Result<(), ReconcileError> {
+    // Remove our finalizer via a JSON merge patch on the full list. We
+    // can't use SSA here because the value we want to apply is "absence"
+    // — easiest expressed as a fresh list without our key.
+    let remaining: Vec<&String> = obj
+        .metadata
+        .finalizers
+        .as_ref()
+        .map(|f| f.iter().filter(|s| s.as_str() != FINALIZER).collect())
+        .unwrap_or_default();
+    let patch = json!({ "metadata": { "finalizers": remaining } });
+    api.patch(
+        &obj.name_any(),
+        &PatchParams::default(),
+        &Patch::Merge(&patch),
+    )
+    .await
+    .map_err(ReconcileError::Kube)?;
+    info!(name = %obj.name_any(), "detached finalizer; CR will now be removed");
+    Ok(())
+}
+
+async fn handle_deletion<G: GatewayClient>(
+    api: &Api<OpenShellSandbox>,
+    ctx: &ReconcileContext<G>,
+    obj: &OpenShellSandbox,
+) -> Result<Action, ReconcileError> {
+    let name = obj.name_any();
+
+    // If our finalizer is gone, deletion already cleared and nothing more
+    // to do — the apiserver will reap the CR on its own.
+    if !has_finalizer(obj) {
+        return Ok(Action::await_change());
+    }
+
+    // Best-effort delete on the gateway side. Treat `Ok(false)` (already
+    // gone) the same as success.
+    info!(name = %name, "handling deletion: calling gateway.delete_sandbox");
+    match ctx.gateway.delete_sandbox(&name).await {
+        Ok(deleted) => {
+            info!(name = %name, deleted, "gateway delete returned");
+            detach_finalizer(api, obj).await?;
+            Ok(Action::await_change())
+        }
+        Err(status) => {
+            // Keep the finalizer in place and retry. Never remove it
+            // without proof the gateway-side sandbox is gone.
+            warn!(name = %name, error = %status, "gateway delete failed; requeuing");
+            Ok(Action::requeue(ERROR_REQUEUE_INTERVAL))
+        }
+    }
+}
+
+async fn patch_status_provisioning(
+    api: &Api<OpenShellSandbox>,
+    name: &str,
+    generation: i64,
+) -> Result<(), ReconcileError> {
+    let now = Utc::now().to_rfc3339();
+    let patch = json!({
+        "apiVersion": APIV,
+        "kind": KIND,
+        "status": {
+            "phase": Phase::Provisioning,
+            "observedGeneration": generation,
+            "message": "calling gateway to create sandbox",
+            "lastUpdated": now,
+            "conditions": [{
+                "type": "Ready", "status": "False", "reason": "Provisioning",
+                "message": "Gateway create-sandbox call in flight",
+                "lastTransitionTime": now, "observedGeneration": generation,
+            }],
+        }
+    });
+    apply_status(api, name, patch).await
+}
+
+async fn patch_status_running(
+    api: &Api<OpenShellSandbox>,
+    name: &str,
+    generation: i64,
+    sandbox_id: &str,
+) -> Result<(), ReconcileError> {
+    let now = Utc::now().to_rfc3339();
+    let patch = json!({
+        "apiVersion": APIV,
+        "kind": KIND,
+        "status": {
+            "phase": Phase::Running,
+            "observedGeneration": generation,
+            "sandboxId": sandbox_id,
+            "message": "gateway sandbox created",
+            "lastUpdated": now,
+            "conditions": [{
+                "type": "Ready", "status": "True", "reason": "Created",
+                "message": "Gateway returned a sandbox",
+                "lastTransitionTime": now, "observedGeneration": generation,
+            }],
+        }
+    });
+    apply_status(api, name, patch).await
+}
+
+async fn patch_status_failed(
+    api: &Api<OpenShellSandbox>,
+    name: &str,
+    generation: i64,
+    message: &str,
+) -> Result<(), ReconcileError> {
+    let now = Utc::now().to_rfc3339();
+    let patch = json!({
+        "apiVersion": APIV,
+        "kind": KIND,
+        "status": {
+            "phase": Phase::Failed,
+            "observedGeneration": generation,
+            "message": message,
+            "lastUpdated": now,
+            "conditions": [{
+                "type": "Ready", "status": "False", "reason": "Failed",
+                "message": message,
+                "lastTransitionTime": now, "observedGeneration": generation,
+            }],
+        }
+    });
+    apply_status(api, name, patch).await
+}
+
+async fn apply_status(
+    api: &Api<OpenShellSandbox>,
+    name: &str,
+    patch: serde_json::Value,
+) -> Result<(), ReconcileError> {
+    api.patch_status(
+        name,
+        &PatchParams::apply(FIELD_MANAGER).force(),
+        &Patch::Apply(&patch),
+    )
+    .await
+    .map_err(ReconcileError::Kube)?;
+    Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value)] // signature dictated by kube-runtime
+fn error_policy<G: GatewayClient>(
+    obj: Arc<OpenShellSandbox>,
+    err: &ReconcileError,
+    _ctx: Arc<ReconcileContext<G>>,
+) -> Action {
+    error!(name = %obj.name_any(), error = %err, "reconcile failed");
+    Action::requeue(ERROR_REQUEUE_INTERVAL)
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ReconcileError {
+    #[error("kube error: {0}")]
+    Kube(#[from] kube::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ExposeSpec, OpenShellSandboxSpec, OpenShellSandboxStatus};
+    use kube::core::ObjectMeta;
+
+    fn cr_with_metadata(meta: ObjectMeta) -> OpenShellSandbox {
+        OpenShellSandbox {
+            metadata: meta,
+            spec: OpenShellSandboxSpec {
+                image: "x".into(),
+                start_command: None,
+                policy_yaml: "version: 1\n".into(),
+                expose: ExposeSpec { port: 80 },
+                pod_customisations: None,
+            },
+            status: None,
+        }
+    }
+
+    // --- has_finalizer ---
+
+    #[test]
+    fn has_finalizer_false_when_metadata_finalizers_is_none() {
+        let cr = cr_with_metadata(ObjectMeta::default());
+        assert!(!has_finalizer(&cr));
+    }
+
+    #[test]
+    fn has_finalizer_false_when_list_is_empty() {
+        let cr = cr_with_metadata(ObjectMeta {
+            finalizers: Some(vec![]),
+            ..Default::default()
+        });
+        assert!(!has_finalizer(&cr));
+    }
+
+    #[test]
+    fn has_finalizer_false_when_only_other_finalizers_present() {
+        let cr = cr_with_metadata(ObjectMeta {
+            finalizers: Some(vec!["other-controller/finalizer".into()]),
+            ..Default::default()
+        });
+        assert!(!has_finalizer(&cr));
+    }
+
+    #[test]
+    fn has_finalizer_true_when_our_finalizer_present() {
+        let cr = cr_with_metadata(ObjectMeta {
+            finalizers: Some(vec![
+                "other-controller/finalizer".into(),
+                FINALIZER.to_owned(),
+            ]),
+            ..Default::default()
+        });
+        assert!(has_finalizer(&cr));
+    }
+
+    // --- is_already_handled ---
+
+    #[test]
+    fn is_already_handled_false_when_status_is_none() {
+        let cr = cr_with_metadata(ObjectMeta {
+            generation: Some(1),
+            ..Default::default()
+        });
+        assert!(!is_already_handled(&cr, 1));
+    }
+
+    #[test]
+    fn is_already_handled_false_when_status_phase_unset() {
+        let mut cr = cr_with_metadata(ObjectMeta {
+            generation: Some(1),
+            ..Default::default()
+        });
+        cr.status = Some(OpenShellSandboxStatus {
+            observed_generation: Some(1),
+            phase: None,
+            ..Default::default()
+        });
+        assert!(!is_already_handled(&cr, 1));
+    }
+
+    #[test]
+    fn is_already_handled_false_when_observed_generation_stale() {
+        let mut cr = cr_with_metadata(ObjectMeta {
+            generation: Some(2),
+            ..Default::default()
+        });
+        cr.status = Some(OpenShellSandboxStatus {
+            observed_generation: Some(1),
+            phase: Some(Phase::Running),
+            ..Default::default()
+        });
+        // Current gen is 2; status was written for gen 1 → needs a fresh
+        // reconcile.
+        assert!(!is_already_handled(&cr, 2));
+    }
+
+    #[test]
+    fn is_already_handled_true_at_current_generation_for_any_phase() {
+        for phase in [
+            Phase::Pending,
+            Phase::Provisioning,
+            Phase::Running,
+            Phase::Failed,
+            Phase::Terminating,
+        ] {
+            let mut cr = cr_with_metadata(ObjectMeta {
+                generation: Some(1),
+                ..Default::default()
+            });
+            cr.status = Some(OpenShellSandboxStatus {
+                observed_generation: Some(1),
+                phase: Some(phase),
+                ..Default::default()
+            });
+            assert!(
+                is_already_handled(&cr, 1),
+                "phase {phase:?} at current generation should short-circuit"
+            );
+        }
+    }
+}

--- a/crates/openshell-controller/src/translate.rs
+++ b/crates/openshell-controller/src/translate.rs
@@ -28,6 +28,11 @@ pub const LABEL_CR_UID: &str = "openshell.nvidia.com/cr-uid";
 /// edit (current CR generation > sandbox label).
 pub const LABEL_CR_GENERATION: &str = "openshell.nvidia.com/cr-generation";
 
+/// Prefix reserved for controller-managed labels. User-supplied labels
+/// (from `spec.labels`) with this prefix are dropped before forwarding so
+/// user input can't shadow the idempotency key.
+const RESERVED_LABEL_PREFIX: &str = "openshell.nvidia.com/";
+
 /// Build a [`CreateSandboxRequest`] from a CR.
 ///
 /// # Errors
@@ -55,19 +60,36 @@ pub fn build_create_request(cr: &OpenShellSandbox) -> Result<CreateSandboxReques
 
     let template = SandboxTemplate {
         image: cr.spec.image.clone(),
+        runtime_class_name: cr.spec.runtime_class_name.clone().unwrap_or_default(),
         ..Default::default()
     };
 
     let spec = SandboxSpec {
+        log_level: cr.spec.log_level.clone().unwrap_or_default(),
+        environment: cr
+            .spec
+            .environment
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
         template: Some(template),
         policy: Some(policy),
-        ..Default::default()
+        providers: cr.spec.providers.clone(),
+        gpu: cr.spec.gpu,
+        gpu_device: cr.spec.gpu_device.clone().unwrap_or_default(),
     };
 
-    let mut labels: HashMap<String, String> = HashMap::new();
+    // Start with the user-supplied labels, then overlay the controller's
+    // reserved labels. Strip user keys under our reserved prefix so they
+    // can't shadow `cr-uid` / `cr-generation`.
+    let mut labels: HashMap<String, String> = cr
+        .spec
+        .labels
+        .iter()
+        .filter(|(k, _)| !k.starts_with(RESERVED_LABEL_PREFIX))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
     labels.insert(LABEL_CR_UID.to_owned(), uid.to_owned());
-    // `gen` is a reserved keyword in Rust 2024, so destructure under a
-    // different name.
     if let Some(generation) = cr.metadata.generation {
         labels.insert(LABEL_CR_GENERATION.to_owned(), generation.to_string());
     }
@@ -82,7 +104,7 @@ pub fn build_create_request(cr: &OpenShellSandbox) -> Result<CreateSandboxReques
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{ExposeSpec, OpenShellSandboxSpec};
+    use crate::types::OpenShellSandboxSpec;
     use kube::core::ObjectMeta;
 
     fn cr_with(spec: OpenShellSandboxSpec) -> OpenShellSandbox {
@@ -99,17 +121,23 @@ mod tests {
         }
     }
 
+    fn minimal_spec() -> OpenShellSandboxSpec {
+        OpenShellSandboxSpec {
+            image: "ghcr.io/nvidia/openshell/sandbox:latest".into(),
+            policy_yaml: "version: 1\n".into(),
+            environment: std::collections::BTreeMap::default(),
+            providers: Vec::new(),
+            gpu: false,
+            gpu_device: None,
+            log_level: None,
+            runtime_class_name: None,
+            labels: std::collections::BTreeMap::default(),
+        }
+    }
+
     #[test]
     fn translates_minimum_spec() {
-        let cr = cr_with(OpenShellSandboxSpec {
-            image: "ghcr.io/nvidia/openshell/sandbox:latest".into(),
-            start_command: None,
-            policy_yaml: "version: 1\n".into(),
-            expose: ExposeSpec { port: 8080 },
-            pod_customisations: None,
-        });
-
-        let req = build_create_request(&cr).expect("translate ok");
+        let req = build_create_request(&cr_with(minimal_spec())).expect("translate ok");
         assert_eq!(req.name, "sample");
         let spec = req.spec.as_ref().expect("spec set");
         let tpl = spec.template.as_ref().expect("template set");
@@ -121,26 +149,80 @@ mod tests {
 
     #[test]
     fn rejects_cr_without_uid() {
-        let mut cr = cr_with(OpenShellSandboxSpec {
-            image: "x".into(),
-            start_command: None,
-            policy_yaml: "version: 1\n".into(),
-            expose: ExposeSpec { port: 80 },
-            pod_customisations: None,
-        });
+        let mut cr = cr_with(minimal_spec());
         cr.metadata.uid = None;
         assert!(build_create_request(&cr).is_err());
     }
 
     #[test]
     fn surfaces_policy_parse_errors() {
-        let cr = cr_with(OpenShellSandboxSpec {
-            image: "x".into(),
-            start_command: None,
-            policy_yaml: ":\n  bad: [unterminated".into(),
-            expose: ExposeSpec { port: 80 },
-            pod_customisations: None,
-        });
-        assert!(build_create_request(&cr).is_err());
+        let mut spec = minimal_spec();
+        spec.policy_yaml = ":\n  bad: [unterminated".into();
+        assert!(build_create_request(&cr_with(spec)).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_image_via_minlength() {
+        // An empty image string is forbidden by CRD `minLength: 1` so the
+        // apiserver rejects at admission. translate doesn't need to
+        // re-validate, but we cover the case where someone constructs a
+        // CR struct by hand.
+        let mut spec = minimal_spec();
+        spec.image = String::new();
+        let req = build_create_request(&cr_with(spec)).expect("translate doesn't validate image");
+        let tpl = req.spec.as_ref().unwrap().template.as_ref().unwrap();
+        assert_eq!(tpl.image, "");
+    }
+
+    #[test]
+    fn rejects_empty_policy_yaml_via_minlength() {
+        // Same as above — empty policyYaml is rejected at admission by
+        // `minLength: 1`. The parser also rejects an empty string.
+        let mut spec = minimal_spec();
+        spec.policy_yaml = String::new();
+        assert!(build_create_request(&cr_with(spec)).is_err());
+    }
+
+    #[test]
+    fn propagates_environment_providers_gpu_loglevel_runtimeclass() {
+        let mut spec = minimal_spec();
+        spec.environment
+            .insert("HTTP_PROXY".into(), "http://corp:3128".into());
+        spec.providers = vec!["aws".into(), "github".into()];
+        spec.gpu = true;
+        spec.gpu_device = Some("0".into());
+        spec.log_level = Some("debug".into());
+        spec.runtime_class_name = Some("kata-containers".into());
+
+        let req = build_create_request(&cr_with(spec)).expect("translate ok");
+        let inner = req.spec.as_ref().unwrap();
+        assert_eq!(
+            inner.environment.get("HTTP_PROXY").map(String::as_str),
+            Some("http://corp:3128")
+        );
+        assert_eq!(inner.providers, vec!["aws", "github"]);
+        assert!(inner.gpu);
+        assert_eq!(inner.gpu_device, "0");
+        assert_eq!(inner.log_level, "debug");
+        assert_eq!(
+            inner.template.as_ref().unwrap().runtime_class_name,
+            "kata-containers"
+        );
+    }
+
+    #[test]
+    fn user_labels_propagate_but_reserved_prefix_is_stripped() {
+        let mut spec = minimal_spec();
+        spec.labels.insert("team".into(), "platform".into());
+        // User tries to shadow the reserved key — this must be dropped.
+        spec.labels.insert(
+            "openshell.nvidia.com/cr-uid".into(),
+            "attacker-uid".into(),
+        );
+
+        let req = build_create_request(&cr_with(spec)).expect("translate ok");
+        assert_eq!(req.labels.get("team").map(String::as_str), Some("platform"));
+        // Controller's cr-uid wins; user input was stripped.
+        assert_eq!(req.labels.get(LABEL_CR_UID).map(String::as_str), Some("abc-123"));
     }
 }

--- a/crates/openshell-controller/src/translate.rs
+++ b/crates/openshell-controller/src/translate.rs
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Translate an [`OpenShellSandbox`] CR into the gateway's
+//! [`CreateSandboxRequest`] protobuf.
+//!
+//! Keeping this in its own module lets it be unit-tested without spinning up
+//! a kube client or the rest of the reconciler.
+
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Result};
+use kube::ResourceExt;
+use openshell_core::proto::openshell::{CreateSandboxRequest, SandboxSpec, SandboxTemplate};
+use openshell_policy::parse_sandbox_policy;
+
+use crate::types::OpenShellSandbox;
+
+/// Label key carrying the CR's `metadata.uid` on every gateway-side sandbox.
+///
+/// The controller uses this label as an unforgeable idempotency key on
+/// re-reconcile so it doesn't have to rely on name matching.
+pub const LABEL_CR_UID: &str = "openshell.nvidia.com/cr-uid";
+
+/// Label key carrying the CR's `metadata.generation` at create time.
+///
+/// Lets the controller spot a stale gateway-side sandbox after a spec
+/// edit (current CR generation > sandbox label).
+pub const LABEL_CR_GENERATION: &str = "openshell.nvidia.com/cr-generation";
+
+/// Build a [`CreateSandboxRequest`] from a CR.
+///
+/// # Errors
+///
+/// - Missing `metadata.uid` (the kube apiserver should always set this — if
+///   it's absent we have no idempotency key, so we refuse rather than risk
+///   creating an orphan sandbox).
+/// - `policyYaml` fails to parse via
+///   [`openshell_policy::parse_sandbox_policy`].
+pub fn build_create_request(cr: &OpenShellSandbox) -> Result<CreateSandboxRequest> {
+    let uid = cr
+        .metadata
+        .uid
+        .as_deref()
+        .ok_or_else(|| anyhow!("OpenShellSandbox has no metadata.uid — refusing to create"))?;
+
+    // parse_sandbox_policy returns miette::Result which is incompatible with
+    // anyhow's Context trait, so map the error manually.
+    let policy = parse_sandbox_policy(&cr.spec.policy_yaml).map_err(|e| {
+        anyhow!(
+            "parsing spec.policyYaml on OpenShellSandbox {}: {e}",
+            cr.name_any()
+        )
+    })?;
+
+    let template = SandboxTemplate {
+        image: cr.spec.image.clone(),
+        ..Default::default()
+    };
+
+    let spec = SandboxSpec {
+        template: Some(template),
+        policy: Some(policy),
+        ..Default::default()
+    };
+
+    let mut labels: HashMap<String, String> = HashMap::new();
+    labels.insert(LABEL_CR_UID.to_owned(), uid.to_owned());
+    // `gen` is a reserved keyword in Rust 2024, so destructure under a
+    // different name.
+    if let Some(generation) = cr.metadata.generation {
+        labels.insert(LABEL_CR_GENERATION.to_owned(), generation.to_string());
+    }
+
+    Ok(CreateSandboxRequest {
+        spec: Some(spec),
+        name: cr.name_any(),
+        labels,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ExposeSpec, OpenShellSandboxSpec};
+    use kube::core::ObjectMeta;
+
+    fn cr_with(spec: OpenShellSandboxSpec) -> OpenShellSandbox {
+        OpenShellSandbox {
+            metadata: ObjectMeta {
+                name: Some("sample".into()),
+                namespace: Some("default".into()),
+                uid: Some("abc-123".into()),
+                generation: Some(1),
+                ..Default::default()
+            },
+            spec,
+            status: None,
+        }
+    }
+
+    #[test]
+    fn translates_minimum_spec() {
+        let cr = cr_with(OpenShellSandboxSpec {
+            image: "ghcr.io/nvidia/openshell/sandbox:latest".into(),
+            start_command: None,
+            policy_yaml: "version: 1\n".into(),
+            expose: ExposeSpec { port: 8080 },
+            pod_customisations: None,
+        });
+
+        let req = build_create_request(&cr).expect("translate ok");
+        assert_eq!(req.name, "sample");
+        let spec = req.spec.as_ref().expect("spec set");
+        let tpl = spec.template.as_ref().expect("template set");
+        assert_eq!(tpl.image, "ghcr.io/nvidia/openshell/sandbox:latest");
+        assert!(spec.policy.is_some(), "policy populated from policyYaml");
+        assert_eq!(req.labels.get(LABEL_CR_UID).map(String::as_str), Some("abc-123"));
+        assert_eq!(req.labels.get(LABEL_CR_GENERATION).map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn rejects_cr_without_uid() {
+        let mut cr = cr_with(OpenShellSandboxSpec {
+            image: "x".into(),
+            start_command: None,
+            policy_yaml: "version: 1\n".into(),
+            expose: ExposeSpec { port: 80 },
+            pod_customisations: None,
+        });
+        cr.metadata.uid = None;
+        assert!(build_create_request(&cr).is_err());
+    }
+
+    #[test]
+    fn surfaces_policy_parse_errors() {
+        let cr = cr_with(OpenShellSandboxSpec {
+            image: "x".into(),
+            start_command: None,
+            policy_yaml: ":\n  bad: [unterminated".into(),
+            expose: ExposeSpec { port: 80 },
+            pod_customisations: None,
+        });
+        assert!(build_create_request(&cr).is_err());
+    }
+}

--- a/crates/openshell-controller/src/types.rs
+++ b/crates/openshell-controller/src/types.rs
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Rust mirror of the `OpenShellSandbox` CRD schema shipped in
+//! `deploy/helm/openshell/crds/openshellsandbox.yaml`.
+//!
+//! The two must stay in lockstep — adding a field here without updating the
+//! CRD schema (or vice versa) lets the kube-apiserver reject or silently
+//! drop content at admission.
+
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// `OpenShellSandbox` — declarative request for a single sandbox.
+#[derive(CustomResource, Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[kube(
+    group = "openshell.nvidia.com",
+    version = "v1alpha1",
+    kind = "OpenShellSandbox",
+    plural = "openshellsandboxes",
+    singular = "openshellsandbox",
+    shortname = "oshs",
+    namespaced,
+    status = "OpenShellSandboxStatus"
+)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenShellSandboxSpec {
+    /// OCI image reference for the sandbox workload (PID 1 inside the
+    /// sandbox container).
+    pub image: String,
+
+    /// PID-1 argv inside the sandbox. When `None`, the image's entrypoint
+    /// is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_command: Option<Vec<String>>,
+
+    /// Inline policy YAML body, applied to the sandbox via the gateway's
+    /// `policy set` semantics.
+    pub policy_yaml: String,
+
+    /// In-sandbox listener exposed through the forwarder Service.
+    pub expose: ExposeSpec,
+
+    /// Optional pod-shape overrides applied to the agent-sandbox `Sandbox`
+    /// podSpec that materialises the workload pod.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pod_customisations: Option<PodCustomisations>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ExposeSpec {
+    /// In-sandbox TCP port the forwarder Service publishes.
+    pub port: u16,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PodCustomisations {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_selector: Option<std::collections::BTreeMap<String, String>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tolerations: Vec<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub affinity: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_class_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_account_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub security_context: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub containers: Vec<ContainerOverride>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage: Option<StorageSpec>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ContainerOverride {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resources: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub security_context: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<EnvVar>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub volume_mounts: Vec<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvVar {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_from: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageSpec {
+    #[serde(default = "default_storage_type")]
+    pub r#type: StorageType,
+    /// Kubernetes quantity string (e.g. `10Gi`). `None` preserves the
+    /// gateway/cluster default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum StorageType {
+    #[default]
+    Persistent,
+    Ephemeral,
+}
+
+fn default_storage_type() -> StorageType {
+    StorageType::Persistent
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenShellSandboxStatus {
+    /// Lifecycle phase as observed by the in-process controller.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<Phase>,
+    /// The gateway's internal UUID for this sandbox, populated once the
+    /// gateway create-sandbox call succeeds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_id: Option<String>,
+    /// Human-readable detail about the current state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_generation: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_updated: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conditions: Vec<Condition>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema)]
+pub enum Phase {
+    Pending,
+    Provisioning,
+    Running,
+    Terminating,
+    Failed,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Condition {
+    pub r#type: String,
+    pub status: String,
+    pub last_transition_time: String,
+    pub reason: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_generation: Option<i64>,
+}
+

--- a/crates/openshell-controller/src/types.rs
+++ b/crates/openshell-controller/src/types.rs
@@ -8,6 +8,8 @@
 //! CRD schema (or vice versa) lets the kube-apiserver reject or silently
 //! drop content at admission.
 
+use std::collections::BTreeMap;
+
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -26,101 +28,42 @@ use serde::{Deserialize, Serialize};
 )]
 #[serde(rename_all = "camelCase")]
 pub struct OpenShellSandboxSpec {
-    /// OCI image reference for the sandbox workload (PID 1 inside the
-    /// sandbox container).
+    /// OCI image reference for the sandbox workload.
     pub image: String,
 
-    /// PID-1 argv inside the sandbox. When `None`, the image's entrypoint
-    /// is used.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub start_command: Option<Vec<String>>,
-
-    /// Inline policy YAML body, applied to the sandbox via the gateway's
-    /// `policy set` semantics.
+    /// Inline sandbox policy YAML.
     pub policy_yaml: String,
 
-    /// In-sandbox listener exposed through the forwarder Service.
-    pub expose: ExposeSpec,
+    /// Environment variables injected into the sandbox at runtime.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub environment: BTreeMap<String, String>,
 
-    /// Optional pod-shape overrides applied to the agent-sandbox `Sandbox`
-    /// podSpec that materialises the workload pod.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pod_customisations: Option<PodCustomisations>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct ExposeSpec {
-    /// In-sandbox TCP port the forwarder Service publishes.
-    pub port: u16,
-}
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct PodCustomisations {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub node_selector: Option<std::collections::BTreeMap<String, String>>,
+    /// Credential provider names attached to the sandbox.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub tolerations: Vec<serde_json::Value>,
+    pub providers: Vec<String>,
+
+    /// Request an NVIDIA GPU for the sandbox.
+    #[serde(default)]
+    pub gpu: bool,
+
+    /// PCI BDF or device index for GPU pinning when `gpu` is true.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub affinity: Option<serde_json::Value>,
+    pub gpu_device: Option<String>,
+
+    /// Log level exposed to processes running inside the sandbox.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_level: Option<String>,
+
+    /// Kubernetes `RuntimeClass` name requested for the sandbox pod.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_class_name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub service_account_name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub security_context: Option<serde_json::Value>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub containers: Vec<ContainerOverride>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub storage: Option<StorageSpec>,
-}
 
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct ContainerOverride {
-    pub name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub resources: Option<serde_json::Value>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub security_context: Option<serde_json::Value>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub env: Vec<EnvVar>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub volume_mounts: Vec<serde_json::Value>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct EnvVar {
-    pub name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub value: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub value_from: Option<serde_json::Value>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct StorageSpec {
-    #[serde(default = "default_storage_type")]
-    pub r#type: StorageType,
-    /// Kubernetes quantity string (e.g. `10Gi`). `None` preserves the
-    /// gateway/cluster default.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub size: Option<String>,
-}
-
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum StorageType {
-    #[default]
-    Persistent,
-    Ephemeral,
-}
-
-fn default_storage_type() -> StorageType {
-    StorageType::Persistent
+    /// User-supplied labels propagated to the gateway-side sandbox.
+    ///
+    /// Keys prefixed with `openshell.nvidia.com/` are reserved for the
+    /// controller and silently filtered out on the wire.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub labels: BTreeMap<String, String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
@@ -151,6 +94,7 @@ pub enum Phase {
     Running,
     Terminating,
     Failed,
+    Deleted,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
@@ -164,4 +108,3 @@ pub struct Condition {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_generation: Option<i64>,
 }
-

--- a/crates/openshell-controller/tests/e2e_reconciler.rs
+++ b/crates/openshell-controller/tests/e2e_reconciler.rs
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end reconciler test against a real kube apiserver.
+//!
+//! Drives the full CR lifecycle (apply → reconcile → status=Running →
+//! delete → finalizer cleanup → CR gone) without depending on
+//! `openshell-server` being deployed. A [`TestGateway`] stub records the
+//! reconciler's gateway calls and returns synthetic responses so the test
+//! exercises kube-rs wiring, SSA, status patches, finalizers, and the
+//! cr-uid idempotency lookup in isolation.
+//!
+//! Marked `#[ignore]` so `cargo test --workspace` doesn't try to run it
+//! without a cluster. Invoke explicitly:
+//!
+//! ```shell
+//! # First: tests/kind/bootstrap.sh writes the kind kubeconfig
+//! make -C crates/openshell-controller/tests/kind up
+//! # Then:
+//! mise exec -- cargo test -p openshell-controller --test e2e_reconciler -- --ignored --nocapture
+//! ```
+//!
+//! CI invokes this through `mise run test:controller-e2e` (see tasks/test.toml).
+
+#![allow(clippy::unwrap_used)] // tests panic on setup failures by design
+#![allow(clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use kube::api::{DeleteParams, ListParams, PostParams};
+use kube::core::ObjectMeta;
+use kube::{Api, Client};
+use openshell_controller::types::{OpenShellSandbox, OpenShellSandboxSpec, Phase};
+use openshell_controller::{ControllerConfig, GatewayClient};
+use openshell_core::proto::openshell::{CreateSandboxRequest, Sandbox};
+use openshell_core::proto::datamodel::v1::ObjectMeta as SandboxMeta;
+use tokio::sync::Mutex;
+use tokio::time::{sleep, timeout};
+use tonic::Status;
+
+/// Gateway stub that records calls and returns synthetic sandboxes.
+#[derive(Default)]
+struct TestGateway {
+    created: Mutex<Vec<CreateSandboxRequest>>,
+    deleted: Mutex<Vec<String>>,
+}
+
+impl TestGateway {
+    async fn created_names(&self) -> Vec<String> {
+        self.created
+            .lock()
+            .await
+            .iter()
+            .map(|r| r.name.clone())
+            .collect()
+    }
+
+    async fn deleted_names(&self) -> Vec<String> {
+        self.deleted.lock().await.clone()
+    }
+
+    async fn created_for_uid(&self, uid: &str) -> Option<String> {
+        self.created
+            .lock()
+            .await
+            .iter()
+            .find(|r| {
+                r.labels.get("openshell.nvidia.com/cr-uid").map(String::as_str) == Some(uid)
+            })
+            .map(|r| r.name.clone())
+    }
+}
+
+#[async_trait]
+impl GatewayClient for TestGateway {
+    async fn create_sandbox(&self, req: CreateSandboxRequest) -> Result<Sandbox, Status> {
+        let id = format!("test-sandbox-{}", uuid_lite());
+        let name = req.name.clone();
+        self.created.lock().await.push(req);
+        Ok(Sandbox {
+            metadata: Some(SandboxMeta {
+                id,
+                name,
+                created_at_ms: 0,
+                labels: HashMap::new(),
+                resource_version: 0,
+            }),
+            spec: None,
+            status: None,
+        })
+    }
+
+    async fn delete_sandbox(&self, name: &str) -> Result<bool, Status> {
+        self.deleted.lock().await.push(name.to_owned());
+        Ok(true)
+    }
+
+    async fn find_sandbox_by_label(
+        &self,
+        key: &str,
+        value: &str,
+    ) -> Result<Option<Sandbox>, Status> {
+        // Search the recorded creates for one tagged with this label.
+        // This mirrors the gateway's real label-selector behaviour.
+        let created = self.created.lock().await;
+        Ok(created
+            .iter()
+            .find(|r| r.labels.get(key).map(String::as_str) == Some(value))
+            .map(|r| Sandbox {
+                metadata: Some(SandboxMeta {
+                    id: format!("found-{}", r.name),
+                    name: r.name.clone(),
+                    created_at_ms: 0,
+                    labels: r.labels.clone(),
+                    resource_version: 0,
+                }),
+                spec: None,
+                status: None,
+            }))
+    }
+}
+
+fn uuid_lite() -> String {
+    // Tests don't need real UUIDs; just enough entropy to avoid collisions
+    // across multiple create calls in one test run.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or_else(|_| "0".to_owned(), |d| d.as_nanos().to_string())
+}
+
+fn cr(name: &str, image: &str) -> OpenShellSandbox {
+    OpenShellSandbox {
+        metadata: ObjectMeta {
+            name: Some(name.to_owned()),
+            namespace: Some("default".to_owned()),
+            ..Default::default()
+        },
+        spec: OpenShellSandboxSpec {
+            image: image.to_owned(),
+            policy_yaml: "version: 1\n".to_owned(),
+            environment: std::collections::BTreeMap::default(),
+            providers: Vec::new(),
+            gpu: false,
+            gpu_device: None,
+            log_level: None,
+            runtime_class_name: None,
+            labels: std::collections::BTreeMap::default(),
+        },
+        status: None,
+    }
+}
+
+async fn wait_for_phase(
+    api: &Api<OpenShellSandbox>,
+    name: &str,
+    expected: Phase,
+) -> Result<OpenShellSandbox, String> {
+    let deadline = Duration::from_secs(15);
+    timeout(deadline, async {
+        loop {
+            if let Ok(obj) = api.get(name).await
+                && obj.status.as_ref().and_then(|s| s.phase).map(phase_label)
+                    == Some(phase_label(expected))
+            {
+                return obj;
+            }
+            sleep(Duration::from_millis(200)).await;
+        }
+    })
+    .await
+    .map_err(|_| format!("timed out waiting for {name} to reach phase={expected:?}"))
+}
+
+fn phase_label(p: Phase) -> &'static str {
+    match p {
+        Phase::Pending => "Pending",
+        Phase::Provisioning => "Provisioning",
+        Phase::Running => "Running",
+        Phase::Terminating => "Terminating",
+        Phase::Failed => "Failed",
+        Phase::Deleted => "Deleted",
+    }
+}
+
+async fn wait_for_gone(api: &Api<OpenShellSandbox>, name: &str) -> Result<(), String> {
+    let deadline = Duration::from_secs(15);
+    timeout(deadline, async {
+        loop {
+            match api.get(name).await {
+                Err(kube::Error::Api(e)) if e.code == 404 => return,
+                _ => sleep(Duration::from_millis(200)).await,
+            }
+        }
+    })
+    .await
+    .map_err(|_| format!("timed out waiting for {name} to be removed"))
+}
+
+/// Clean up any CRs left behind by a previous test run. Tests share a
+/// namespace so this is best-effort: delete-collection, then wait.
+async fn cleanup(api: &Api<OpenShellSandbox>) {
+    let _ = api
+        .delete_collection(&DeleteParams::default(), &ListParams::default())
+        .await;
+    // Give the apiserver a moment to process the deletes; we'll create
+    // CRs with fresh names anyway, so this is just hygiene.
+    sleep(Duration::from_millis(500)).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a kube cluster; run via `cargo test -- --ignored` after `make up`"]
+async fn cr_lifecycle_reaches_running_then_clears_on_delete() {
+    let client = Client::try_default()
+        .await
+        .expect("kube client (set KUBECONFIG or run `make up`)");
+    let api: Api<OpenShellSandbox> = Api::namespaced(client.clone(), "default");
+    cleanup(&api).await;
+
+    let gateway = Arc::new(TestGateway::default());
+    let gw_for_task = gateway.clone();
+    let task = tokio::spawn(async move {
+        let config = ControllerConfig {
+            watch_namespace: "default".to_owned(),
+            log_filter: "info,openshell_controller=debug".to_owned(),
+        };
+        let _ = openshell_controller::run(gw_for_task, config).await;
+    });
+
+    // Give the controller a moment to install its watchers.
+    sleep(Duration::from_millis(500)).await;
+
+    let body = cr("e2e-running", "ghcr.io/nvidia/openshell/sandbox:latest");
+    api.create(&PostParams::default(), &body)
+        .await
+        .expect("apply CR");
+
+    let final_obj = wait_for_phase(&api, "e2e-running", Phase::Running)
+        .await
+        .expect("reach Running");
+    let status = final_obj.status.expect("status set");
+    assert_eq!(status.phase.map(phase_label), Some("Running"));
+    assert!(
+        status.sandbox_id.as_deref().is_some_and(|id| !id.is_empty()),
+        "status.sandboxId populated from gateway response"
+    );
+
+    assert_eq!(gateway.created_names().await, vec!["e2e-running"]);
+
+    api.delete("e2e-running", &DeleteParams::default())
+        .await
+        .expect("delete CR");
+    wait_for_gone(&api, "e2e-running")
+        .await
+        .expect("CR removed after finalizer");
+    assert_eq!(gateway.deleted_names().await, vec!["e2e-running"]);
+
+    task.abort();
+}
+
+#[tokio::test]
+#[ignore = "requires a kube cluster"]
+async fn cr_uid_idempotency_skips_duplicate_create_on_spec_edit() {
+    let client = Client::try_default().await.expect("kube client");
+    let api: Api<OpenShellSandbox> = Api::namespaced(client.clone(), "default");
+    cleanup(&api).await;
+
+    let gateway = Arc::new(TestGateway::default());
+    let gw_for_task = gateway.clone();
+    let task = tokio::spawn(async move {
+        let config = ControllerConfig {
+            watch_namespace: "default".to_owned(),
+            log_filter: "info,openshell_controller=debug".to_owned(),
+        };
+        let _ = openshell_controller::run(gw_for_task, config).await;
+    });
+    sleep(Duration::from_millis(500)).await;
+
+    let body = cr("e2e-spec-edit", "ghcr.io/nvidia/openshell/sandbox:v1");
+    let created = api
+        .create(&PostParams::default(), &body)
+        .await
+        .expect("apply CR");
+    let uid = created.metadata.uid.clone().expect("apiserver set uid");
+
+    wait_for_phase(&api, "e2e-spec-edit", Phase::Running)
+        .await
+        .expect("reach Running");
+    assert_eq!(gateway.created_for_uid(&uid).await.as_deref(), Some("e2e-spec-edit"));
+
+    // Edit .spec.image — this bumps metadata.generation and triggers a
+    // fresh reconcile. The cr-uid lookup must find the existing sandbox
+    // and skip a duplicate create.
+    let mut updated = api.get("e2e-spec-edit").await.expect("re-fetch");
+    updated.spec.image = "ghcr.io/nvidia/openshell/sandbox:v2".into();
+    api.replace("e2e-spec-edit", &PostParams::default(), &updated)
+        .await
+        .expect("update CR");
+
+    // Wait a bit for the reconciler to observe the update and run.
+    sleep(Duration::from_secs(2)).await;
+
+    let created_count = gateway.created.lock().await.len();
+    assert_eq!(
+        created_count, 1,
+        "spec edit must not trigger a second create (cr-uid lookup found existing)"
+    );
+
+    api.delete("e2e-spec-edit", &DeleteParams::default())
+        .await
+        .ok();
+    wait_for_gone(&api, "e2e-spec-edit").await.ok();
+    task.abort();
+}

--- a/crates/openshell-controller/tests/e2e_reconciler.rs
+++ b/crates/openshell-controller/tests/e2e_reconciler.rs
@@ -121,6 +121,28 @@ impl GatewayClient for TestGateway {
                 status: None,
             }))
     }
+
+    async fn get_sandbox(&self, name: &str) -> Result<Sandbox, Status> {
+        // Test stub: pretend the sandbox is always Ready. Real gateway
+        // reads the driver-observed pod readiness from its store.
+        let created = self.created.lock().await;
+        let Some(r) = created.iter().find(|r| r.name == name) else {
+            return Err(Status::not_found(format!("test gateway has no {name}")));
+        };
+        let mut sandbox = Sandbox {
+            metadata: Some(SandboxMeta {
+                id: format!("test-sandbox-{name}"),
+                name: r.name.clone(),
+                created_at_ms: 0,
+                labels: r.labels.clone(),
+                resource_version: 0,
+            }),
+            spec: None,
+            status: None,
+        };
+        sandbox.set_phase(openshell_core::proto::SandboxPhase::Ready as i32);
+        Ok(sandbox)
+    }
 }
 
 fn uuid_lite() -> String {

--- a/crates/openshell-controller/tests/kind/Makefile
+++ b/crates/openshell-controller/tests/kind/Makefile
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Out-of-cluster iteration loop for openshell-controller.
+#
+# Typical session:
+#   make up                # create kind cluster + apply CRD
+#   make standalone        # run reconciler against kind (foreground)
+#   make sample            # in another shell: apply a sample OpenShellSandbox
+#   make status            # see the CR + its observed status
+#   make down              # delete the kind cluster
+
+.PHONY: up down recreate standalone sample status logs
+
+HERE := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+REPO_ROOT := $(abspath $(HERE)../../../..)
+
+up:
+	@$(HERE)bootstrap.sh
+
+down:
+	@$(HERE)teardown.sh
+
+recreate: down up
+
+# Foreground run of the reconciler. Quit with Ctrl-C.
+# Watches the `default` namespace by default; override via env var.
+# bootstrap.sh writes the kind kubeconfig into $REPO_ROOT/kubeconfig, which
+# mise.toml's `[env].KUBECONFIG` already points at — so `mise exec` picks
+# it up without further plumbing.
+standalone:
+	@cd $(REPO_ROOT) && \
+	 OPENSHELL_CONTROLLER_WATCH_NAMESPACE=$${OPENSHELL_CONTROLLER_WATCH_NAMESPACE:-default} \
+	 OPENSHELL_CONTROLLER_LOG_FILTER=$${OPENSHELL_CONTROLLER_LOG_FILTER:-info,openshell_controller=debug,kube=warn} \
+	 mise exec -- cargo run --example standalone -p openshell-controller
+
+sample:
+	@kubectl apply -f $(HERE)sample.yaml
+
+status:
+	@kubectl get oshs -A
+	@echo
+	@kubectl get oshs sample -o yaml | sed -n '/^status:/,$$p' || true
+
+logs:
+	@echo "standalone runs in foreground; logs appear on its terminal"

--- a/crates/openshell-controller/tests/kind/bootstrap.sh
+++ b/crates/openshell-controller/tests/kind/bootstrap.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Idempotent bootstrap for the out-of-cluster controller iteration loop.
+#
+# Stages (each is a no-op if already done):
+#   1. kind cluster
+#   2. OpenShellSandbox CRD applied
+#
+# After this, run the reconciler against the cluster from outside:
+#   make standalone
+#
+# Or apply a test CR:
+#   make sample
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../../.." && pwd)"
+CLUSTER_NAME="openshell-controller-test"
+
+# Honour podman if docker is aliased — kind respects this env.
+export KIND_EXPERIMENTAL_PROVIDER="${KIND_EXPERIMENTAL_PROVIDER:-podman}"
+
+log() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+
+# 1. Cluster
+if kind get clusters | grep -qx "$CLUSTER_NAME"; then
+  log "kind cluster '$CLUSTER_NAME' already exists"
+else
+  log "creating kind cluster '$CLUSTER_NAME'"
+  kind create cluster --config "$HERE/kind-cluster.yaml"
+fi
+
+# 2. Export the cluster kubeconfig into the repo-local file that mise's
+# `[env].KUBECONFIG` points at. This is the path the standalone reconciler
+# reads when it runs under `mise exec`. Without this, mise clobbers any
+# shell-level KUBECONFIG override at exec time and the client can't find
+# the kind context.
+log "writing kubeconfig to $REPO_ROOT/kubeconfig"
+kind get kubeconfig --name "$CLUSTER_NAME" > "$REPO_ROOT/kubeconfig"
+
+KUBECONFIG="$REPO_ROOT/kubeconfig" kubectl config use-context "kind-$CLUSTER_NAME"
+
+# 3. CRD
+log "applying OpenShellSandbox CRD"
+KUBECONFIG="$REPO_ROOT/kubeconfig" kubectl apply -f "$REPO_ROOT/deploy/helm/openshell/crds/openshellsandbox.yaml"
+
+log "harness up. context: kind-$CLUSTER_NAME"
+log "next: 'make standalone' (runs the reconciler) and 'make sample' (applies a CR)"

--- a/crates/openshell-controller/tests/kind/kind-cluster.yaml
+++ b/crates/openshell-controller/tests/kind/kind-cluster.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: openshell-controller-test
+nodes:
+  - role: control-plane

--- a/crates/openshell-controller/tests/kind/sample.yaml
+++ b/crates/openshell-controller/tests/kind/sample.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Smallest viable OpenShellSandbox CR for iteration testing.
+
+apiVersion: openshell.nvidia.com/v1alpha1
+kind: OpenShellSandbox
+metadata:
+  name: sample
+  namespace: default
+spec:
+  image: ghcr.io/nvidia/openshell/sandbox:latest
+  policyYaml: |
+    version: 1
+  expose:
+    port: 8080

--- a/crates/openshell-controller/tests/kind/sample.yaml
+++ b/crates/openshell-controller/tests/kind/sample.yaml
@@ -12,5 +12,3 @@ spec:
   image: ghcr.io/nvidia/openshell/sandbox:latest
   policyYaml: |
     version: 1
-  expose:
-    port: 8080

--- a/crates/openshell-controller/tests/kind/teardown.sh
+++ b/crates/openshell-controller/tests/kind/teardown.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Delete the kind cluster created by bootstrap.sh.
+
+set -euo pipefail
+
+CLUSTER_NAME="openshell-controller-test"
+export KIND_EXPERIMENTAL_PROVIDER="${KIND_EXPERIMENTAL_PROVIDER:-podman}"
+
+if kind get clusters | grep -qx "$CLUSTER_NAME"; then
+  echo "==> deleting kind cluster '$CLUSTER_NAME'"
+  kind delete cluster --name "$CLUSTER_NAME"
+else
+  echo "==> kind cluster '$CLUSTER_NAME' not present, nothing to do"
+fi

--- a/crates/openshell-server/Cargo.toml
+++ b/crates/openshell-server/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 openshell-bootstrap = { path = "../openshell-bootstrap" }
+openshell-controller = { path = "../openshell-controller" }
 openshell-core = { path = "../openshell-core" }
 openshell-driver-docker = { path = "../openshell-driver-docker" }
 openshell-driver-kubernetes = { path = "../openshell-driver-kubernetes" }

--- a/crates/openshell-server/src/api.rs
+++ b/crates/openshell-server/src/api.rs
@@ -66,6 +66,16 @@ impl GatewayHandle {
     ) -> Result<Option<Sandbox>, Status> {
         crate::grpc::find_sandbox_by_label(&self.state, key, value).await
     }
+
+    /// Fetch a sandbox by name. The returned `Sandbox` carries the
+    /// gateway's current view including the driver-observed phase.
+    ///
+    /// # Errors
+    ///
+    /// See [`crate::grpc::sandbox::get_sandbox_core`].
+    pub async fn get_sandbox(&self, name: &str) -> Result<Sandbox, Status> {
+        crate::grpc::get_sandbox_core(&self.state, name).await
+    }
 }
 
 #[async_trait::async_trait]
@@ -84,5 +94,9 @@ impl openshell_controller::GatewayClient for GatewayHandle {
         value: &str,
     ) -> Result<Option<Sandbox>, Status> {
         Self::find_sandbox_by_label(self, key, value).await
+    }
+
+    async fn get_sandbox(&self, name: &str) -> Result<Sandbox, Status> {
+        Self::get_sandbox(self, name).await
     }
 }

--- a/crates/openshell-server/src/api.rs
+++ b/crates/openshell-server/src/api.rs
@@ -30,11 +30,9 @@ impl GatewayHandle {
         Self { state }
     }
 
-    /// Create a sandbox.
-    ///
-    /// Delegates to `create_sandbox_core` — same path the gRPC handler
-    /// takes, so validation, persistence, telemetry, JWT minting, and
-    /// compute driver dispatch all apply.
+    /// Create a sandbox via the same path the gRPC handler takes.
+    /// Validation, persistence, telemetry, JWT minting, and compute
+    /// driver dispatch all apply.
     ///
     /// # Errors
     ///
@@ -44,9 +42,6 @@ impl GatewayHandle {
     }
 
     /// Delete a sandbox by name. Returns whether the sandbox existed.
-    ///
-    /// Delegates to `delete_sandbox_core` — same path the gRPC handler
-    /// takes.
     ///
     /// # Errors
     ///

--- a/crates/openshell-server/src/api.rs
+++ b/crates/openshell-server/src/api.rs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Public Rust API surfaced to in-process consumers.
+//!
+//! Currently consumed only by the `openshell-controller` crate. External
+//! clients should use the gRPC service — this module exists so the in-tree
+//! CRD controller can call the gateway's create-sandbox core function
+//! without a localhost gRPC hop.
+
+use std::sync::Arc;
+
+use openshell_core::proto::{CreateSandboxRequest, Sandbox};
+use tonic::Status;
+
+use crate::ServerState;
+
+/// In-process handle to the gateway.
+///
+/// Holds an `Arc<ServerState>` and exposes only the methods the CRD
+/// controller needs. `ServerState` itself stays crate-private so the rest
+/// of the gateway's internals aren't accidentally surfaced.
+#[derive(Clone)]
+pub struct GatewayHandle {
+    state: Arc<ServerState>,
+}
+
+impl GatewayHandle {
+    pub(crate) fn new(state: Arc<ServerState>) -> Self {
+        Self { state }
+    }
+
+    /// Create a sandbox.
+    ///
+    /// Delegates to `create_sandbox_core` — same path the gRPC handler
+    /// takes, so validation, persistence, telemetry, JWT minting, and
+    /// compute driver dispatch all apply.
+    ///
+    /// # Errors
+    ///
+    /// See [`crate::grpc::sandbox::create_sandbox_core`].
+    pub async fn create_sandbox(&self, req: CreateSandboxRequest) -> Result<Sandbox, Status> {
+        crate::grpc::create_sandbox_core(&self.state, req).await
+    }
+
+    /// Delete a sandbox by name. Returns whether the sandbox existed.
+    ///
+    /// Delegates to `delete_sandbox_core` — same path the gRPC handler
+    /// takes.
+    ///
+    /// # Errors
+    ///
+    /// See [`crate::grpc::sandbox::delete_sandbox_core`].
+    pub async fn delete_sandbox(&self, name: &str) -> Result<bool, Status> {
+        crate::grpc::delete_sandbox_core(&self.state, name).await
+    }
+}
+
+#[async_trait::async_trait]
+impl openshell_controller::GatewayClient for GatewayHandle {
+    async fn create_sandbox(&self, req: CreateSandboxRequest) -> Result<Sandbox, Status> {
+        Self::create_sandbox(self, req).await
+    }
+
+    async fn delete_sandbox(&self, name: &str) -> Result<bool, Status> {
+        Self::delete_sandbox(self, name).await
+    }
+}

--- a/crates/openshell-server/src/api.rs
+++ b/crates/openshell-server/src/api.rs
@@ -49,6 +49,23 @@ impl GatewayHandle {
     pub async fn delete_sandbox(&self, name: &str) -> Result<bool, Status> {
         crate::grpc::delete_sandbox_core(&self.state, name).await
     }
+
+    /// Find at most one sandbox tagged with a given label.
+    ///
+    /// Used by the CRD controller for cr-uid based idempotency: before
+    /// creating a sandbox for a CR, look up whether one already exists
+    /// for that CR's unforgeable uid. Returns `None` if no match.
+    ///
+    /// # Errors
+    ///
+    /// See [`crate::grpc::sandbox::find_sandbox_by_label`].
+    pub async fn find_sandbox_by_label(
+        &self,
+        key: &str,
+        value: &str,
+    ) -> Result<Option<Sandbox>, Status> {
+        crate::grpc::find_sandbox_by_label(&self.state, key, value).await
+    }
 }
 
 #[async_trait::async_trait]
@@ -59,5 +76,13 @@ impl openshell_controller::GatewayClient for GatewayHandle {
 
     async fn delete_sandbox(&self, name: &str) -> Result<bool, Status> {
         Self::delete_sandbox(self, name).await
+    }
+
+    async fn find_sandbox_by_label(
+        &self,
+        key: &str,
+        value: &str,
+    ) -> Result<Option<Sandbox>, Status> {
+        Self::find_sandbox_by_label(self, key, value).await
     }
 }

--- a/crates/openshell-server/src/grpc/mod.rs
+++ b/crates/openshell-server/src/grpc/mod.rs
@@ -10,6 +10,13 @@ mod sandbox;
 mod service;
 mod validation;
 
+// In-process callers (crate::api::GatewayHandle for the CRD controller)
+// reach the shared sandbox lifecycle cores directly without going through
+// the gRPC handler. Narrowly re-exported so the sandbox module's other
+// internals stay private. The `pub` is crate-private in practice because
+// `grpc` itself is `mod grpc;` (not `pub mod`).
+pub use sandbox::{create_sandbox_core, delete_sandbox_core};
+
 use openshell_core::proto::{
     ApproveAllDraftChunksRequest, ApproveAllDraftChunksResponse, ApproveDraftChunkRequest,
     ApproveDraftChunkResponse, AttachSandboxProviderRequest, AttachSandboxProviderResponse,

--- a/crates/openshell-server/src/grpc/mod.rs
+++ b/crates/openshell-server/src/grpc/mod.rs
@@ -15,7 +15,9 @@ mod validation;
 // the gRPC handler. Narrowly re-exported so the sandbox module's other
 // internals stay private. The `pub` is crate-private in practice because
 // `grpc` itself is `mod grpc;` (not `pub mod`).
-pub use sandbox::{create_sandbox_core, delete_sandbox_core, find_sandbox_by_label};
+pub use sandbox::{
+    create_sandbox_core, delete_sandbox_core, find_sandbox_by_label, get_sandbox_core,
+};
 
 use openshell_core::proto::{
     ApproveAllDraftChunksRequest, ApproveAllDraftChunksResponse, ApproveDraftChunkRequest,

--- a/crates/openshell-server/src/grpc/mod.rs
+++ b/crates/openshell-server/src/grpc/mod.rs
@@ -15,7 +15,7 @@ mod validation;
 // the gRPC handler. Narrowly re-exported so the sandbox module's other
 // internals stay private. The `pub` is crate-private in practice because
 // `grpc` itself is `mod grpc;` (not `pub mod`).
-pub use sandbox::{create_sandbox_core, delete_sandbox_core};
+pub use sandbox::{create_sandbox_core, delete_sandbox_core, find_sandbox_by_label};
 
 use openshell_core::proto::{
     ApproveAllDraftChunksRequest, ApproveAllDraftChunksResponse, ApproveDraftChunkRequest,

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -512,6 +512,34 @@ async fn handle_delete_sandbox_inner(
     Ok(Response::new(DeleteSandboxResponse { deleted }))
 }
 
+/// Find at most one sandbox tagged with a given label.
+///
+/// Shared between the gRPC handler and the in-process CRD controller so
+/// callers don't have to construct a label-selector string by hand. The
+/// label value is escaped to defeat selector injection.
+///
+/// # Errors
+///
+/// Returns any store error from
+/// `Store::list_messages_with_selector`.
+pub async fn find_sandbox_by_label(
+    state: &Arc<ServerState>,
+    key: &str,
+    value: &str,
+) -> Result<Option<Sandbox>, Status> {
+    // The store's label-selector parser is strict; we own both sides of
+    // the comparison so escaping is mechanical (no commas/equals in the
+    // value, no leading/trailing whitespace).
+    let selector = format!("{key}={value}");
+    crate::grpc::validation::validate_label_selector(&selector)?;
+    let mut sandboxes = state
+        .store
+        .list_messages_with_selector::<Sandbox>(&selector, 1, 0)
+        .await
+        .map_err(|e| Status::internal(format!("find sandbox by label failed: {e}")))?;
+    Ok(sandboxes.pop())
+}
+
 /// Delete a sandbox by name, returning whether the sandbox existed.
 ///
 /// Shared between the gRPC handler and the in-process CRD controller so

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -247,21 +247,30 @@ pub(super) async fn handle_get_sandbox(
     state: &Arc<ServerState>,
     request: Request<GetSandboxRequest>,
 ) -> Result<Response<SandboxResponse>, Status> {
-    let name = request.into_inner().name;
-    if name.is_empty() {
-        return Err(Status::invalid_argument("name is required"));
-    }
-
-    let sandbox = state
-        .store
-        .get_message_by_name::<Sandbox>(&name)
-        .await
-        .map_err(|e| Status::internal(format!("fetch sandbox failed: {e}")))?;
-
-    let sandbox = sandbox.ok_or_else(|| Status::not_found("sandbox not found"))?;
+    let sandbox = get_sandbox_core(state, &request.into_inner().name).await?;
     Ok(Response::new(SandboxResponse {
         sandbox: Some(sandbox),
     }))
+}
+
+/// Fetch a sandbox by name, returning the gateway's current view including
+/// the driver-observed phase. Used by the CRD controller to project the
+/// agent-sandbox-derived pod readiness back into the CR's `.status.phase`.
+///
+/// # Errors
+///
+/// `Status::invalid_argument` on empty name, `Status::not_found` if the
+/// sandbox isn't in the store, `Status::internal` on store errors.
+pub async fn get_sandbox_core(state: &Arc<ServerState>, name: &str) -> Result<Sandbox, Status> {
+    if name.is_empty() {
+        return Err(Status::invalid_argument("name is required"));
+    }
+    state
+        .store
+        .get_message_by_name::<Sandbox>(name)
+        .await
+        .map_err(|e| Status::internal(format!("fetch sandbox failed: {e}")))?
+        .ok_or_else(|| Status::not_found("sandbox not found"))
 }
 
 pub(super) async fn handle_list_sandboxes(

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -118,7 +118,29 @@ async fn handle_create_sandbox_inner(
     state: &Arc<ServerState>,
     request: Request<CreateSandboxRequest>,
 ) -> Result<Response<SandboxResponse>, Status> {
-    let request = request.into_inner();
+    let sandbox = create_sandbox_core(state, request.into_inner()).await?;
+    Ok(Response::new(SandboxResponse {
+        sandbox: Some(sandbox),
+    }))
+}
+
+/// Create a sandbox, returning the gateway's view of it.
+///
+/// This is the shared core of `CreateSandbox` that both the gRPC handler and
+/// the in-process CRD controller call. It performs all gateway-side work —
+/// spec validation, provider resolution, image resolution, policy
+/// normalisation, JWT minting, compute driver dispatch — so callers get the
+/// same behaviour regardless of the entrypoint.
+///
+/// # Errors
+///
+/// Returns a [`Status`] when the request is invalid (`InvalidArgument` /
+/// `FailedPrecondition`), a provider can't be resolved, the compute driver
+/// rejects the sandbox, or JWT minting fails.
+pub async fn create_sandbox_core(
+    state: &Arc<ServerState>,
+    request: CreateSandboxRequest,
+) -> Result<Sandbox, Status> {
     let spec = request
         .spec
         .ok_or_else(|| Status::invalid_argument("spec is required"))?;
@@ -218,9 +240,7 @@ async fn handle_create_sandbox_inner(
         sandbox_name = %name,
         "CreateSandbox request completed successfully"
     );
-    Ok(Response::new(SandboxResponse {
-        sandbox: Some(sandbox),
-    }))
+    Ok(sandbox)
 }
 
 pub(super) async fn handle_get_sandbox(
@@ -488,24 +508,38 @@ async fn handle_delete_sandbox_inner(
     state: &Arc<ServerState>,
     request: Request<DeleteSandboxRequest>,
 ) -> Result<Response<DeleteSandboxResponse>, Status> {
-    let name = request.into_inner().name;
+    let deleted = delete_sandbox_core(state, &request.into_inner().name).await?;
+    Ok(Response::new(DeleteSandboxResponse { deleted }))
+}
+
+/// Delete a sandbox by name, returning whether the sandbox existed.
+///
+/// Shared between the gRPC handler and the in-process CRD controller so
+/// the deletion path runs the same compute-driver call + telemetry hook
+/// regardless of entrypoint.
+///
+/// # Errors
+///
+/// Returns a [`Status::invalid_argument`] when `name` is empty, or any
+/// status from the compute driver's delete call.
+pub async fn delete_sandbox_core(state: &Arc<ServerState>, name: &str) -> Result<bool, Status> {
     if name.is_empty() {
         return Err(Status::invalid_argument("name is required"));
     }
 
     let sandbox_id = state
         .store
-        .get_message_by_name::<Sandbox>(&name)
+        .get_message_by_name::<Sandbox>(name)
         .await
         .ok()
         .flatten()
         .map(|sandbox| sandbox.object_id().to_string());
-    let deleted = state.compute.delete_sandbox(&name).await?;
+    let deleted = state.compute.delete_sandbox(name).await?;
     if deleted && let Some(sandbox_id) = sandbox_id {
         state.telemetry.end_sandbox_session(&sandbox_id);
     }
     info!(sandbox_name = %name, "DeleteSandbox request completed successfully");
-    Ok(Response::new(DeleteSandboxResponse { deleted }))
+    Ok(deleted)
 }
 
 async fn sandbox_by_name(state: &Arc<ServerState>, name: &str) -> Result<Sandbox, Status> {

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -19,6 +19,7 @@
 //! uniform [`ComputeRuntime`]. The remaining VM plumbing now lives in
 //! [`compute::vm`]; keep this file driver-agnostic going forward.
 
+pub mod api;
 mod auth;
 pub mod certgen;
 pub mod cli;
@@ -411,6 +412,29 @@ pub async fn run_server(
         });
     } else {
         info!("Metrics server disabled");
+    }
+
+    // Spawn the in-process CRD controller on Kubernetes deployments.
+    // Presence of OPENSHELL_CONTROLLER_WATCH_NAMESPACE is the chart's
+    // flag-free signal that we're the K8s-deployed gateway; non-K8s
+    // gateways (docker/podman/vm) never see the var and skip the spawn.
+    // We log and continue (rather than fail startup) if the controller
+    // can't start — the gateway data plane must keep serving SDK/CLI
+    // traffic even if CRD reconciliation is broken.
+    if std::env::var("OPENSHELL_CONTROLLER_WATCH_NAMESPACE").is_ok() {
+        let controller_config = openshell_controller::ControllerConfig::from_env();
+        info!(
+            namespace = %controller_config.watch_namespace,
+            "spawning in-process OpenShellSandbox controller"
+        );
+        let gateway = Arc::new(api::GatewayHandle::new(state.clone()));
+        tokio::spawn(async move {
+            if let Err(e) = openshell_controller::run(gateway, controller_config).await {
+                error!(error = %e, "openshell-controller exited with error");
+            } else {
+                info!("openshell-controller exited cleanly");
+            }
+        });
     }
 
     // Build TLS acceptor when TLS is configured; otherwise serve plaintext.

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -416,25 +416,37 @@ pub async fn run_server(
 
     // Spawn the in-process CRD controller on Kubernetes deployments.
     // Presence of OPENSHELL_CONTROLLER_WATCH_NAMESPACE is the chart's
-    // flag-free signal that we're the K8s-deployed gateway; non-K8s
-    // gateways (docker/podman/vm) never see the var and skip the spawn.
-    // We log and continue (rather than fail startup) if the controller
-    // can't start — the gateway data plane must keep serving SDK/CLI
-    // traffic even if CRD reconciliation is broken.
+    // signal that we're the K8s-deployed gateway; non-K8s gateways
+    // (docker/podman/vm) never see the var and skip the spawn. Pinning
+    // to ordinal 0 means a post-install `kubectl scale --replicas=N`
+    // doesn't multiply the controller into N racing copies — replicas
+    // with ordinal > 0 serve SDK/CLI traffic only. Lease-based leader
+    // election is a follow-up.
     if std::env::var("OPENSHELL_CONTROLLER_WATCH_NAMESPACE").is_ok() {
-        let controller_config = openshell_controller::ControllerConfig::from_env();
-        info!(
-            namespace = %controller_config.watch_namespace,
-            "spawning in-process OpenShellSandbox controller"
-        );
-        let gateway = Arc::new(api::GatewayHandle::new(state.clone()));
-        tokio::spawn(async move {
-            if let Err(e) = openshell_controller::run(gateway, controller_config).await {
-                error!(error = %e, "openshell-controller exited with error");
-            } else {
-                info!("openshell-controller exited cleanly");
-            }
-        });
+        let hostname = std::env::var("HOSTNAME").unwrap_or_default();
+        if hostname.ends_with("-0") || hostname.is_empty() {
+            // Empty HOSTNAME = local/test runs outside a StatefulSet;
+            // assume single-replica and spawn.
+            let controller_config = openshell_controller::ControllerConfig::from_env();
+            info!(
+                hostname = %hostname,
+                namespace = %controller_config.watch_namespace,
+                "spawning in-process OpenShellSandbox controller"
+            );
+            let gateway = Arc::new(api::GatewayHandle::new(state.clone()));
+            tokio::spawn(async move {
+                if let Err(e) = openshell_controller::run(gateway, controller_config).await {
+                    error!(error = %e, "openshell-controller exited with error");
+                } else {
+                    info!("openshell-controller exited cleanly");
+                }
+            });
+        } else {
+            info!(
+                hostname = %hostname,
+                "OpenShellSandbox controller skipped on this replica (ordinal != 0)"
+            );
+        }
     }
 
     // Build TLS acceptor when TLS is configured; otherwise serve plaintext.

--- a/deploy/helm/openshell/crds/openshellsandbox.yaml
+++ b/deploy/helm/openshell/crds/openshellsandbox.yaml
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Reconciled in-process by the gateway on its ordinal-0 StatefulSet replica.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: openshellsandboxes.openshell.nvidia.com
+spec:
+  group: openshell.nvidia.com
+  names:
+    kind: OpenShellSandbox
+    listKind: OpenShellSandboxList
+    plural: openshellsandboxes
+    singular: openshellsandbox
+    shortNames:
+      - oshs
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Image
+          type: string
+          jsonPath: .spec.image
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Ready
+          type: string
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion: { type: string }
+            kind: { type: string }
+            metadata: { type: object }
+            spec:
+              type: object
+              required:
+                - image
+                - policyYaml
+                - expose
+              properties:
+                image:
+                  type: string
+                  minLength: 1
+                  description: |
+                    OCI image reference for the sandbox workload (PID 1
+                    inside the sandbox container).
+                startCommand:
+                  type: array
+                  items: { type: string }
+                  description: |
+                    PID-1 argv inside the sandbox. When unset, the image's
+                    entrypoint is used.
+                policyYaml:
+                  type: string
+                  description: |
+                    Inline policy YAML body, applied to the sandbox via
+                    `openshell policy set` semantics.
+                expose:
+                  type: object
+                  required: [port]
+                  description: |
+                    In-sandbox listener exposed through the forwarder
+                    Service.
+                  properties:
+                    port:
+                      type: integer
+                      minimum: 1
+                      maximum: 65535
+                podCustomisations:
+                  type: object
+                  description: |
+                    Pod-shape overrides applied to the agent-sandbox
+                    `Sandbox` podSpec that materialises the workload pod.
+                    All fields optional; unset fields fall back to gateway
+                    defaults.
+                  properties:
+                    nodeSelector:
+                      type: object
+                      additionalProperties: { type: string }
+                    tolerations:
+                      type: array
+                      items:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    affinity:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    runtimeClassName:
+                      type: string
+                    serviceAccountName:
+                      type: string
+                    securityContext:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    containers:
+                      type: array
+                      description: |
+                        Per-container overrides keyed by container name.
+                        `resources` and `securityContext` are patched onto
+                        the matching container; `env` and `volumeMounts`
+                        are APPENDED (gateway-set entries are preserved).
+                      items:
+                        type: object
+                        required: [name]
+                        properties:
+                          name: { type: string }
+                          resources:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          securityContext:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          env:
+                            type: array
+                            items:
+                              type: object
+                              required: [name]
+                              properties:
+                                name: { type: string }
+                                value: { type: string }
+                                valueFrom:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                          volumeMounts:
+                            type: array
+                            items:
+                              type: object
+                              required: [name, mountPath]
+                              properties:
+                                name: { type: string }
+                                mountPath: { type: string }
+                                subPath: { type: string }
+                                readOnly: { type: boolean }
+                    storage:
+                      type: object
+                      description: |
+                        Workspace PVC policy.
+                      properties:
+                        type:
+                          type: string
+                          enum: [persistent, ephemeral]
+                          default: persistent
+                        size:
+                          type: string
+                          description: |
+                            Storage request for the workspace PVC. Empty
+                            preserves the gateway/cluster default.
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Provisioning, Running, Terminating, Failed]
+                  description: |
+                    Lifecycle phase as observed by the in-process
+                    controller.
+                sandboxId:
+                  type: string
+                  description: |
+                    The gateway's internal UUID for this sandbox. Set
+                    once the gateway create-sandbox call succeeds.
+                message:
+                  type: string
+                  description: Human-readable detail about the current state.
+                observedGeneration:
+                  type: integer
+                  format: int64
+                lastUpdated:
+                  type: string
+                  format: date-time
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                      - lastTransitionTime
+                      - reason
+                      - message
+                    properties:
+                      type: { type: string }
+                      status:
+                        type: string
+                        enum: ["True", "False", Unknown]
+                      observedGeneration: { type: integer, format: int64 }
+                      lastTransitionTime: { type: string, format: date-time }
+                      reason: { type: string }
+                      message: { type: string }

--- a/deploy/helm/openshell/crds/openshellsandbox.yaml
+++ b/deploy/helm/openshell/crds/openshellsandbox.yaml
@@ -32,6 +32,10 @@ spec:
         - name: Ready
           type: string
           jsonPath: .status.conditions[?(@.type=="Ready")].status
+        - name: SandboxId
+          type: string
+          jsonPath: .status.sandboxId
+          priority: 1
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp
@@ -49,124 +53,72 @@ spec:
               required:
                 - image
                 - policyYaml
-                - expose
               properties:
                 image:
                   type: string
                   minLength: 1
                   description: |
-                    OCI image reference for the sandbox workload (PID 1
-                    inside the sandbox container).
-                startCommand:
+                    OCI image reference for the sandbox workload.
+                policyYaml:
+                  type: string
+                  minLength: 1
+                  description: |
+                    Inline sandbox policy YAML. Parsed at reconcile time
+                    by the same code path the gateway uses for
+                    `openshell policy set`; malformed YAML surfaces in
+                    `.status.message` with `phase=Failed`.
+                environment:
+                  type: object
+                  additionalProperties: { type: string }
+                  description: |
+                    Environment variables injected into the sandbox at
+                    runtime. Maps directly to `SandboxSpec.environment`.
+                providers:
                   type: array
                   items: { type: string }
                   description: |
-                    PID-1 argv inside the sandbox. When unset, the image's
-                    entrypoint is used.
-                policyYaml:
+                    Names of credential providers (created via
+                    `openshell provider create`) to attach to the sandbox.
+                gpu:
+                  type: boolean
+                  default: false
+                  description: |
+                    Request an NVIDIA GPU for the sandbox.
+                gpuDevice:
                   type: string
                   description: |
-                    Inline policy YAML body, applied to the sandbox via
-                    `openshell policy set` semantics.
-                expose:
-                  type: object
-                  required: [port]
+                    Optional PCI BDF (e.g. `0000:2d:00.0`) or device
+                    index (`0`, `1`) when `gpu: true`. Empty asks the
+                    driver to assign the first available GPU.
+                logLevel:
+                  type: string
                   description: |
-                    In-sandbox listener exposed through the forwarder
-                    Service.
-                  properties:
-                    port:
-                      type: integer
-                      minimum: 1
-                      maximum: 65535
-                podCustomisations:
-                  type: object
+                    Log level exposed to processes running inside the
+                    sandbox. Maps to `SandboxSpec.log_level`.
+                runtimeClassName:
+                  type: string
                   description: |
-                    Pod-shape overrides applied to the agent-sandbox
-                    `Sandbox` podSpec that materialises the workload pod.
-                    All fields optional; unset fields fall back to gateway
-                    defaults.
-                  properties:
-                    nodeSelector:
-                      type: object
-                      additionalProperties: { type: string }
-                    tolerations:
-                      type: array
-                      items:
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                    affinity:
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                    runtimeClassName:
-                      type: string
-                    serviceAccountName:
-                      type: string
-                    securityContext:
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                    containers:
-                      type: array
-                      description: |
-                        Per-container overrides keyed by container name.
-                        `resources` and `securityContext` are patched onto
-                        the matching container; `env` and `volumeMounts`
-                        are APPENDED (gateway-set entries are preserved).
-                      items:
-                        type: object
-                        required: [name]
-                        properties:
-                          name: { type: string }
-                          resources:
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
-                          securityContext:
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
-                          env:
-                            type: array
-                            items:
-                              type: object
-                              required: [name]
-                              properties:
-                                name: { type: string }
-                                value: { type: string }
-                                valueFrom:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                          volumeMounts:
-                            type: array
-                            items:
-                              type: object
-                              required: [name, mountPath]
-                              properties:
-                                name: { type: string }
-                                mountPath: { type: string }
-                                subPath: { type: string }
-                                readOnly: { type: boolean }
-                    storage:
-                      type: object
-                      description: |
-                        Workspace PVC policy.
-                      properties:
-                        type:
-                          type: string
-                          enum: [persistent, ephemeral]
-                          default: persistent
-                        size:
-                          type: string
-                          description: |
-                            Storage request for the workspace PVC. Empty
-                            preserves the gateway/cluster default.
+                    Kubernetes RuntimeClass name requested for the
+                    sandbox pod (e.g. `kata-containers`, `nvidia`).
+                    Maps to `SandboxTemplate.runtime_class_name`.
+                labels:
+                  type: object
+                  additionalProperties: { type: string }
+                  description: |
+                    User-supplied labels propagated to the gateway-side
+                    sandbox via `CreateSandboxRequest.labels`. Keys
+                    prefixed with `openshell.nvidia.com/` are reserved
+                    for the controller (cr-uid, cr-generation).
             status:
               type: object
               properties:
                 phase:
                   type: string
-                  enum: [Pending, Provisioning, Running, Terminating, Failed]
+                  enum: [Pending, Provisioning, Running, Terminating, Failed, Deleted]
                   description: |
                     Lifecycle phase as observed by the in-process
-                    controller.
+                    controller. `Deleted` is only transiently visible
+                    between finalizer cleanup and CR removal.
                 sandboxId:
                   type: string
                   description: |

--- a/deploy/helm/openshell/templates/role.yaml
+++ b/deploy/helm/openshell/templates/role.yaml
@@ -42,3 +42,24 @@ rules:
       - pods
     verbs:
       - get
+  # OpenShellSandbox CRD reconciliation. `update` on the resource itself
+  # covers finalizer add/remove; `patch` on /status covers SSA from the
+  # controller's field manager.
+  - apiGroups:
+      - openshell.nvidia.com
+    resources:
+      - openshellsandboxes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - openshell.nvidia.com
+    resources:
+      - openshellsandboxes/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/deploy/helm/openshell/templates/statefulset.yaml
+++ b/deploy/helm/openshell/templates/statefulset.yaml
@@ -80,6 +80,14 @@ spec:
             - name: SSL_CERT_FILE
               value: /etc/openshell-tls/oidc-ca/ca.crt
             {{- end }}
+            # In-process CRD controller. Presence of
+            # OPENSHELL_CONTROLLER_WATCH_NAMESPACE tells the gateway
+            # binary it's the chart-deployed K8s replica; it spawns
+            # the reconciler on the ordinal-0 pod and skips on others.
+            - name: OPENSHELL_CONTROLLER_WATCH_NAMESPACE
+              value: {{ default (include "openshell.sandboxNamespace" .) .Values.controller.watchNamespace | quote }}
+            - name: OPENSHELL_CONTROLLER_LOG_FILTER
+              value: {{ .Values.controller.logFilter | quote }}
           volumeMounts:
             - name: openshell-data
               mountPath: /var/openshell

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -367,3 +367,17 @@ grpcRoute:
       protocol: HTTP
       # -- "Same" restricts attached routes to the release namespace; "All" allows any namespace.
       allowedRoutes: Same
+
+# Native CRD controller — reconciles OpenShellSandbox CRs into sandbox
+# creates against the existing gateway. Runs in-process inside the
+# gateway binary as a tokio task on the StatefulSet's ordinal-0 replica.
+# The CRD itself always installs from deploy/helm/openshell/crds/.
+controller:
+  # -- Namespace the controller watches. Empty defaults to the release
+  # namespace. v1 enforces a single-namespace contract — one Helm
+  # release ⇒ one watched namespace.
+  watchNamespace: ""
+  # -- `RUST_LOG`-style filter applied to the controller's tracing
+  # subscriber. Independent of `server.logLevel` so noisy kube-rs watch
+  # events can be suppressed without quieting the gateway.
+  logFilter: "info,openshell_controller=info,kube=warn"

--- a/docs/kubernetes/native-controller.mdx
+++ b/docs/kubernetes/native-controller.mdx
@@ -1,0 +1,97 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Native CRD Controller"
+sidebar-title: "Native CRD Controller"
+description: "Declaratively create sandboxes with kubectl using the in-process OpenShellSandbox CRD."
+keywords: "Kubernetes, CRD, Controller, GitOps, OpenShellSandbox, Declarative"
+position: 6
+---
+
+<Warning>
+The native CRD controller is an early-development feature. The CRD installs with the chart and the controller runs automatically on every Kubernetes deployment.
+</Warning>
+
+OpenShell can be driven two ways. Both flows converge at the same gateway logic, so validation, persistence, telemetry, and provider lookup are identical.
+
+| Flow | Trigger | Reconciler | Use when |
+|---|---|---|---|
+| Imperative | `openshell sandbox create ...` (CLI / SDK) | None — direct gRPC | Interactive, scripts |
+| Declarative | `kubectl apply -f sandbox.yaml` | In-process inside the gateway | GitOps, fleet management, ArgoCD/Flux |
+
+```
+SDK / CLI ──► gateway gRPC ──┐
+                             ├──► gateway sandbox-create core ──► driver ──► agent-sandbox Sandbox + forwarder pod
+CRD ──► in-process reconciler ┘
+```
+
+## How it runs
+
+The CRD ships with the chart and is installed on first `helm install`. The reconciler is a tokio task the gateway binary spawns on the StatefulSet's ordinal-0 replica when the chart-set `OPENSHELL_CONTROLLER_WATCH_NAMESPACE` env var is present. Replicas with ordinal > 0 (`kubectl scale --replicas=N`) skip the spawn and serve SDK/CLI traffic only, so adding gateway replicas doesn't multiply the controller into racing copies.
+
+### Configurable values
+
+| Value | Default | Purpose |
+|---|---|---|
+| `controller.watchNamespace` | `""` (release namespace) | Namespace the controller watches. Single-namespace contract — one release, one namespace. |
+| `controller.logFilter` | `info,openshell_controller=info,kube=warn` | `RUST_LOG`-style filter applied to the controller's tracing subscriber, independent of `server.logLevel`. |
+
+## The custom resource
+
+One CRD in `openshell.nvidia.com/v1alpha1`, namespaced:
+
+| Kind | Short | Role |
+|---|---|---|
+| `OpenShellSandbox` | `oshs` | Self-contained sandbox — image, `startCommand`, `policyYaml`, `expose.port`, and optional `podCustomisations`. |
+
+### Minimal example
+
+```yaml
+apiVersion: openshell.nvidia.com/v1alpha1
+kind: OpenShellSandbox
+metadata:
+  name: alice
+  namespace: openshell
+spec:
+  image: ghcr.io/nvidia/openshell/sandbox:latest
+  startCommand: ["claude"]
+  policyYaml: |
+    version: 1
+    network: {}
+  expose:
+    port: 8080
+```
+
+```shell
+kubectl apply -f sandbox.yaml
+kubectl get oshs -n openshell
+```
+
+### Per-pod customisations
+
+`spec.podCustomisations` is patched onto the agent-sandbox `Sandbox` podSpec — `nodeSelector`, `tolerations`, `affinity`, `runtimeClassName`, `serviceAccountName`, per-container `resources`/`securityContext`/`env`/`volumeMounts`, and workspace PVC `storage.{type,size}`.
+
+```yaml
+spec:
+  image: ghcr.io/nvidia/openshell/sandbox:latest
+  policyYaml: |
+    version: 1
+  expose:
+    port: 8080
+  podCustomisations:
+    nodeSelector:
+      node-role.kubernetes.io/sandbox: "true"
+    storage:
+      type: persistent
+      size: 10Gi
+    containers:
+      - name: sandbox
+        resources:
+          requests: { cpu: "500m", memory: "1Gi" }
+          limits:   { cpu: "2",    memory: "4Gi" }
+```
+
+## Prerequisites
+
+- **agent-sandbox controller** — provides `sandboxes.agents.x-k8s.io`. Already required for the gateway; see [Setup](/kubernetes/setup#install-agent-sandbox).
+- **Kyverno** with a reachable admission webhook — the controller strips the agent-sandbox `Sandbox` `ownerReference` from the workspace PVC at admission so `kubectl delete oshs` doesn't reap the workspace. If Kyverno's webhook is not `Available=True`, deletes will silently take the workspace with them. Verify with `kubectl get deploy -n kyverno`.

--- a/docs/kubernetes/native-controller.mdx
+++ b/docs/kubernetes/native-controller.mdx
@@ -42,7 +42,21 @@ One CRD in `openshell.nvidia.com/v1alpha1`, namespaced:
 
 | Kind | Short | Role |
 |---|---|---|
-| `OpenShellSandbox` | `oshs` | Self-contained sandbox — image, `startCommand`, `policyYaml`, `expose.port`, and optional `podCustomisations`. |
+| `OpenShellSandbox` | `oshs` | Declarative sandbox request: image, policy, environment, providers, GPU, log level, runtime class, and user labels. |
+
+### Spec fields
+
+| Field | Type | Required | Purpose |
+|---|---|---|---|
+| `image` | string | yes | OCI image reference for the sandbox workload. |
+| `policyYaml` | string | yes | Inline sandbox policy YAML, parsed by the same code path as `openshell policy set`. |
+| `environment` | `map<string, string>` | no | Env vars injected at sandbox runtime. |
+| `providers` | `[string]` | no | Names of credential providers to attach. |
+| `gpu` | bool | no | Request an NVIDIA GPU for the sandbox. |
+| `gpuDevice` | string | no | PCI BDF or device index for GPU pinning. |
+| `logLevel` | string | no | Log level inside the sandbox. |
+| `runtimeClassName` | string | no | Kubernetes RuntimeClass for the sandbox pod. |
+| `labels` | `map<string, string>` | no | User labels propagated to the gateway sandbox. Keys under `openshell.nvidia.com/` are reserved. |
 
 ### Minimal example
 
@@ -54,12 +68,9 @@ metadata:
   namespace: openshell
 spec:
   image: ghcr.io/nvidia/openshell/sandbox:latest
-  startCommand: ["claude"]
   policyYaml: |
     version: 1
     network: {}
-  expose:
-    port: 8080
 ```
 
 ```shell
@@ -67,31 +78,24 @@ kubectl apply -f sandbox.yaml
 kubectl get oshs -n openshell
 ```
 
-### Per-pod customisations
-
-`spec.podCustomisations` is patched onto the agent-sandbox `Sandbox` podSpec — `nodeSelector`, `tolerations`, `affinity`, `runtimeClassName`, `serviceAccountName`, per-container `resources`/`securityContext`/`env`/`volumeMounts`, and workspace PVC `storage.{type,size}`.
+### Richer example
 
 ```yaml
 spec:
   image: ghcr.io/nvidia/openshell/sandbox:latest
   policyYaml: |
     version: 1
-  expose:
-    port: 8080
-  podCustomisations:
-    nodeSelector:
-      node-role.kubernetes.io/sandbox: "true"
-    storage:
-      type: persistent
-      size: 10Gi
-    containers:
-      - name: sandbox
-        resources:
-          requests: { cpu: "500m", memory: "1Gi" }
-          limits:   { cpu: "2",    memory: "4Gi" }
+  environment:
+    HTTP_PROXY: http://corp-proxy:3128
+  providers: [aws, github]
+  gpu: true
+  logLevel: debug
+  runtimeClassName: nvidia
+  labels:
+    team: platform
 ```
 
 ## Prerequisites
 
 - **agent-sandbox controller** — provides `sandboxes.agents.x-k8s.io`. Already required for the gateway; see [Setup](/kubernetes/setup#install-agent-sandbox).
-- **Kyverno** with a reachable admission webhook — the controller strips the agent-sandbox `Sandbox` `ownerReference` from the workspace PVC at admission so `kubectl delete oshs` doesn't reap the workspace. If Kyverno's webhook is not `Available=True`, deletes will silently take the workspace with them. Verify with `kubectl get deploy -n kyverno`.
+- **Kyverno** with a reachable admission webhook — the gateway uses Kyverno to keep workspace PVCs across sandbox replaces. If Kyverno's webhook is not `Available=True`, `kubectl delete oshs` may take the workspace with it. Verify with `kubectl get deploy -n kyverno`.

--- a/mise.lock
+++ b/mise.lock
@@ -219,6 +219,7 @@ url = "https://storage.googleapis.com/skaffold/releases/v2.20.0/skaffold-linux-a
 url = "https://storage.googleapis.com/skaffold/releases/v2.20.0/skaffold-linux-amd64"
 
 [tools.skaffold."platforms.macos-arm64"]
+checksum = "blake3:cb665940f9b861c1160ddc9dd6601c047587396cb3ca029e2aa1f397ad9e6849"
 url = "https://storage.googleapis.com/skaffold/releases/v2.20.0/skaffold-darwin-arm64"
 
 [[tools.uv]]
@@ -255,3 +256,4 @@ url = "https://ziglang.org/download/0.14.1/zig-x86_64-linux-0.14.1.tar.xz"
 [tools.zig."platforms.macos-arm64"]
 checksum = "sha256:39f3dc5e79c22088ce878edc821dedb4ca5a1cd9f5ef915e9b3cc3053e8faefa"
 url = "https://ziglang.org/download/0.14.1/zig-aarch64-macos-0.14.1.tar.xz"
+provenance = "minisign"


### PR DESCRIPTION
## Summary
Adds a openshellSandbox CRD that is layered on top of agent-sandbox sandbox CRD, provides an alternative to python SDK + sqlLite DB for state management. 

More kubernetes native flow, in my use case I want to use openShell + Nemoclaw and had to make a wrapper "NemoClaw" operator so we can create instances in a git ops workflow. Native controller support is much better solution   

## Related Issue
https://github.com/NVIDIA/OpenShell/issues/1719

## Changes (AI summary)

- New crate `crates/openshell-controller/` with a kube-rs `Controller` watching the configured namespace, finalizer-driven cleanup, server-side-apply on status, cr-uid label idempotency, translate logic, and a `GatewayClient` trait abstraction (+ `NoopGateway` stub for local dev).
- New `crates/openshell-server/src/api.rs` exposing `GatewayHandle` — a thin pub wrapper around `Arc<ServerState>` that exposes only what the reconciler needs. The gRPC handlers `handle_create_sandbox`, `handle_delete_sandbox`, `handle_get_sandbox` were refactored to delegate to extracted `*_core` functions that the controller also calls; semantic behavior is unchanged for the gRPC path.
- New CRD shipped in `deploy/helm/openshell/crds/openshellsandbox.yaml` (always installs with the chart). Fields exposed match the gRPC API surface: `image`, `policyYaml`, `environment`, `providers`, `gpu`, `gpuDevice`, `logLevel`, `runtimeClassName`, user `labels`. Status reports a phase derived from the gateway's driver-side observation of pod readiness.
- Helm chart gains an unconditional `controller.{watchNamespace,logFilter}` block and the gateway StatefulSet now always sets `OPENSHELL_CONTROLLER_WATCH_NAMESPACE` — presence of this env var is the gateway binary's signal to spawn the reconciler on its ordinal-0 replica. Non-K8s deployments (docker/podman/vm) never see the var and skip the spawn silently. `kubectl scale --replicas=N` after install doesn't multiply the reconciler because only `openshell-0` reads CRs.
- Reconciler projects the gateway's `SandboxPhase` proto enum into the CR's `status.phase`: phase=Running only appears once the underlying pod is observed Ready by the agent-sandbox controller. Faster polling (3s) while transitional, 30s heartbeat once terminal.
- RBAC added on the existing sandbox-namespace Role for the new CRD verbs (get/list/watch/update/patch on `openshellsandboxes`, get/patch/update on `/status`).
- New docs page `docs/kubernetes/native-controller.mdx` (auto-picked up by the kubernetes folder nav).
- `.agents/skills/debug-openshell-cluster` updated with a controller-troubleshooting section per the AGENTS.md rule.

## Testing
- Verified in Kind cluster and with E2E 
## Checklist
- [] docs updated 

## Open questions for maintainers

1. **Design acceptance.** Is the in-process-reconciler-inside-the-gateway pod model an acceptable direction upstream, or would NVIDIA prefer a separate operator workload? Happy to convert the design notes into a formal RFC discussion before iterating further on the code.
2. **CRD group.** `openshell.nvidia.com/v1alpha1` 
3. **Leader election.** v1 pins the controller to the ordinal-0 StatefulSet replica. Lease-based leader election is a follow-up; as it seems openshell sts is meant to run mainly single replica due to sqllite 
