### PR TITLE
feat(podman): make container health check interval configurable

### DIFF
--- a/crates/openshell-driver-podman/src/config.rs
+++ b/crates/openshell-driver-podman/src/config.rs
@@ -126,7 +126,16 @@ pub struct PodmanComputeConfig {
     /// `template.driver_config`.
     #[serde(default)]
     pub enable_bind_mounts: bool,
+    /// Health check interval in seconds for sandbox containers.
+    ///
+    /// Podman runs the health check command at this interval to determine
+    /// container readiness. Lower values detect readiness faster but
+    /// increase process churn (each check spawns a conmon subprocess).
+    /// Defaults to [`DEFAULT_HEALTH_CHECK_INTERVAL_SECS`].
+    pub health_check_interval_secs: u64,
 }
+
+pub const DEFAULT_HEALTH_CHECK_INTERVAL_SECS: u64 = 10;
 
 impl PodmanComputeConfig {
     /// Returns `true` when all three TLS paths are configured.
@@ -251,6 +260,7 @@ impl Default for PodmanComputeConfig {
             guest_tls_key: None,
             sandbox_pids_limit: DEFAULT_SANDBOX_PIDS_LIMIT,
             enable_bind_mounts: false,
+            health_check_interval_secs: DEFAULT_HEALTH_CHECK_INTERVAL_SECS,
         }
     }
 }
@@ -273,6 +283,10 @@ impl std::fmt::Debug for PodmanComputeConfig {
             .field("guest_tls_key", &self.guest_tls_key)
             .field("sandbox_pids_limit", &self.sandbox_pids_limit)
             .field("enable_bind_mounts", &self.enable_bind_mounts)
+            .field(
+                "health_check_interval_secs",
+                &self.health_check_interval_secs,
+            )
             .finish()
     }
 }
@@ -312,6 +326,12 @@ mod tests {
                 PathBuf::from(format!("/run/user/{uid}/podman/podman.sock"))
             );
         });
+    }
+
+    #[test]
+    fn default_config_sets_health_check_interval() {
+        let cfg = PodmanComputeConfig::default();
+        assert_eq!(cfg.health_check_interval_secs, DEFAULT_HEALTH_CHECK_INTERVAL_SECS);
     }
 
     #[test]

--- a/crates/openshell-driver-podman/src/config.rs
+++ b/crates/openshell-driver-podman/src/config.rs
@@ -131,7 +131,8 @@ pub struct PodmanComputeConfig {
     /// Podman runs the health check command at this interval to determine
     /// container readiness. Lower values detect readiness faster but
     /// increase process churn (each check spawns a conmon subprocess).
-    /// Defaults to [`DEFAULT_HEALTH_CHECK_INTERVAL_SECS`].
+    /// Set to `0` to disable health checks entirely.
+    /// Defaults to [`DEFAULT_HEALTH_CHECK_INTERVAL_SECS`] (10 seconds).
     pub health_check_interval_secs: u64,
 }
 

--- a/crates/openshell-driver-podman/src/config.rs
+++ b/crates/openshell-driver-podman/src/config.rs
@@ -331,7 +331,10 @@ mod tests {
     #[test]
     fn default_config_sets_health_check_interval() {
         let cfg = PodmanComputeConfig::default();
-        assert_eq!(cfg.health_check_interval_secs, DEFAULT_HEALTH_CHECK_INTERVAL_SECS);
+        assert_eq!(
+            cfg.health_check_interval_secs,
+            DEFAULT_HEALTH_CHECK_INTERVAL_SECS
+        );
     }
 
     #[test]

--- a/crates/openshell-driver-podman/src/container.rs
+++ b/crates/openshell-driver-podman/src/container.rs
@@ -880,7 +880,7 @@ pub fn try_build_container_spec_with_token(
                     openshell_core::config::DEFAULT_SSH_PORT
                 ),
             ],
-            interval: 3_000_000_000,
+            interval: config.health_check_interval_secs * 1_000_000_000,
             timeout: 2_000_000_000,
             retries: 10,
             start_period: 5_000_000_000,
@@ -1326,6 +1326,19 @@ mod tests {
             command.contains("test -S /run/openshell/test-ssh.sock"),
             "healthcheck should consider the supervisor Unix socket ready"
         );
+    }
+
+    #[test]
+    fn container_spec_healthcheck_interval_from_config() {
+        let sandbox = test_sandbox("test-id", "test-name");
+        let mut config = test_config();
+        config.health_check_interval_secs = 30;
+        let spec = build_container_spec(&sandbox, &config);
+
+        let interval = spec["healthconfig"]["Interval"]
+            .as_u64()
+            .expect("healthcheck interval should be a u64");
+        assert_eq!(interval, 30_000_000_000);
     }
 
     #[test]

--- a/crates/openshell-driver-podman/src/main.rs
+++ b/crates/openshell-driver-podman/src/main.rs
@@ -135,7 +135,7 @@ async fn main() -> Result<()> {
         guest_tls_cert: args.podman_tls_cert,
         guest_tls_key: args.podman_tls_key,
         sandbox_pids_limit: args.sandbox_pids_limit,
-        enable_bind_mounts: false,
+        ..PodmanComputeConfig::default()
     })
     .await
     .into_diagnostic()?;

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -262,6 +262,10 @@ guest_tls_key           = "/etc/openshell/certs/client-key.pem"
 enable_bind_mounts      = false
 # Set to 0 to leave Podman's runtime default unchanged.
 sandbox_pids_limit      = 2048
+# Health check interval in seconds. Lower values detect readiness faster
+# but increase process churn (each check spawns a conmon subprocess).
+# Default: 10.
+health_check_interval_secs = 10
 ```
 
 ### MicroVM

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -264,7 +264,7 @@ enable_bind_mounts      = false
 sandbox_pids_limit      = 2048
 # Health check interval in seconds. Lower values detect readiness faster
 # but increase process churn (each check spawns a conmon subprocess).
-# Default: 10.
+# Set to 0 to disable health checks entirely. Default: 10.
 health_check_interval_secs = 10
 ```
 


### PR DESCRIPTION
## Summary

Make the Podman driver's container health check interval configurable instead of hardcoded at 3 seconds. The short default spawns a conmon subprocess every tick per container, creating sustained process churn and unnecessary CPU overhead on systems running multiple sandboxes.

## Related Issue

Closes #1832

## Changes

- Add `health_check_interval_secs` field to `PodmanComputeConfig` (default: 10s)
- Wire the config value into the health check spec in `build_container_spec()`
- Backfill the new field via `..PodmanComputeConfig::default()` in the standalone driver binary
- Document the new field in `docs/reference/gateway-config.mdx`

## Testing

- [x] `mise run pre-commit` passes (excluding pre-existing `test:python` grpc version mismatch)
- [x] Unit tests added: `default_config_sets_health_check_interval`, `container_spec_healthcheck_interval_from_config`
- [ ] E2E tests added/updated (if applicable)
- [x] Deployed patched binary locally, verified `podman inspect` shows configured interval

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)