### PR TITLE
fix(helm): switch bitnami charts from OCI to HTTPS repository

### DIFF
--- a/deploy/helm/openshell/Chart.lock
+++ b/deploy/helm/openshell/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
+  repository: https://charts.bitnami.com/bitnami
   version: 18.6.7
-digest: sha256:e4df764483edb0695ac56dd4e27eb3a225a9c0b0ef52a8b60e3e0b51e36153ab
-generated: "2026-05-28T18:05:12.507876-04:00"
+digest: sha256:ad5d03a28d06bb10dfdd9e082284efe8d487892625b28e46cada24c4f9a29750
+generated: "2026-06-09T18:24:58.974269-04:00"

--- a/deploy/helm/openshell/Chart.yaml
+++ b/deploy/helm/openshell/Chart.yaml
@@ -14,6 +14,6 @@ appVersion: "0.0.0"
 dependencies:
   - name: postgresql
     version: 18.6.7
-    repository: oci://registry-1.docker.io/bitnamicharts
+    repository: https://charts.bitnami.com/bitnami
     condition: postgres.enabled
     alias: postgres

--- a/e2e/rust/e2e-openshift.sh
+++ b/e2e/rust/e2e-openshift.sh
@@ -135,7 +135,8 @@ EXTERNAL_PG_DATABASE="openshell"
 EXTERNAL_PG_USERNAME="openshell"
 
 log "Deploying standalone PostgreSQL as external database..."
-helm install "$EXTERNAL_PG_RELEASE" oci://registry-1.docker.io/bitnamicharts/postgresql \
+helm repo add bitnami https://charts.bitnami.com/bitnami 2>/dev/null || true
+helm install "$EXTERNAL_PG_RELEASE" bitnami/postgresql --version 18.6.7 \
   -n "$NAMESPACE" \
   --set auth.username="$EXTERNAL_PG_USERNAME" \
   --set auth.password="$EXTERNAL_PG_PASSWORD" \

--- a/e2e/with-kube-gateway.sh
+++ b/e2e/with-kube-gateway.sh
@@ -198,7 +198,8 @@ scenario_cleanup_release() {
 scenario_deploy_external_pg() {
   local pg_host pg_uri
   echo "==> Deploying standalone PostgreSQL as external database..."
-  helmctl install pg-external oci://registry-1.docker.io/bitnamicharts/postgresql \
+  helmctl repo add bitnami https://charts.bitnami.com/bitnami 2>/dev/null || true
+  helmctl install pg-external bitnami/postgresql --version 18.6.7 \
     --namespace "${NAMESPACE}" \
     --set auth.username=openshell \
     --set auth.password=ext-test-password \


### PR DESCRIPTION
## Summary

Switch Bitnami Helm chart dependencies from OCI (Docker Hub) to HTTPS repository to avoid Docker Hub rate-limiting in CI.

## Related Issue

N/A — fixes recurring CI failures from unauthenticated OCI pulls.

## Changes

- Changed postgresql dependency repository from `oci://registry-1.docker.io/bitnamicharts` to `https://charts.bitnami.com/bitnami` in `Chart.yaml`
- Updated `Chart.lock` accordingly
- Added `helm repo add bitnami` to e2e scripts that install bitnami charts directly

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)