### PR TITLE
fix(build): use zigbuild for musl supervisor staging

### DIFF
--- a/architecture/build.md
+++ b/architecture/build.md
@@ -61,7 +61,9 @@ Binary staging is driven by `tasks/scripts/stage-prebuilt-binaries.sh`. Gateway
 binaries use `cargo zigbuild` with GNU targets pinned to glibc 2.31, including
 native-architecture builds, so the gateway image, standalone tarballs, and Linux
 packages share the same host portability floor. Supervisor binaries remain
-static musl. Local Docker image tasks infer the target architecture from
+static musl and use `cargo zigbuild` when available, including native CPU
+architectures, so C dependencies are compiled for the musl target instead of the
+host GNU libc target. Local Docker image tasks infer the target architecture from
 `DOCKER_PLATFORM` when set, otherwise from the container engine host metadata
 with the kernel architecture as the fallback. CI invokes the same staging step
 via the `rust-native-build.yml` workflow (per-architecture, per-component) and

--- a/tasks/scripts/stage-prebuilt-binaries.sh
+++ b/tasks/scripts/stage-prebuilt-binaries.sh
@@ -52,6 +52,10 @@ host_os() {
   uname -s
 }
 
+has_cargo_zigbuild() {
+  command -v cargo-zigbuild >/dev/null 2>&1 || mise which cargo-zigbuild >/dev/null 2>&1
+}
+
 detect_arches() {
   if [[ -n "${PREBUILT_ARCH:-}" ]]; then
     normalize_arch "${PREBUILT_ARCH}"
@@ -159,15 +163,17 @@ build_component_for_arch() {
   build_target="$target"
 
   if [[ "$component" == "gateway" ]]; then
-    if command -v cargo-zigbuild >/dev/null 2>&1 || mise which cargo-zigbuild >/dev/null 2>&1; then
+    if has_cargo_zigbuild; then
       cargo_subcommand=(cargo zigbuild)
       build_target="${target}.2.31"
     else
       echo "Error: cargo-zigbuild + zig are required to build ${binary} with the glibc 2.31 floor." >&2
       exit 1
     fi
+  elif [[ "$target_libc" == "musl" ]] && has_cargo_zigbuild; then
+    cargo_subcommand=(cargo zigbuild)
   elif [[ "$current_host_os" != "Linux" || "$current_host_arch" != "$arch" ]]; then
-    if command -v cargo-zigbuild >/dev/null 2>&1 || mise which cargo-zigbuild >/dev/null 2>&1; then
+    if has_cargo_zigbuild; then
       cargo_subcommand=(cargo zigbuild)
     else
       echo "Error: cannot build ${binary} for linux/${arch} on ${current_host_os}/${current_host_arch}." >&2


### PR DESCRIPTION
## Summary

Use `cargo zigbuild` for static musl supervisor binary staging whenever it is available, including native CPU architectures. This keeps C dependencies such as `aws-lc-sys` on the musl target toolchain instead of letting them fall back to the host GNU libc compiler path.

## Related Issue

None.

## Context

This was reproduced on current `origin/main` at `27fd31c9` before this change. On the affected machine, the host is `aarch64`, glibc is `2.42`, and `cc` is a Nix clang wrapper targeting `aarch64-unknown-linux-gnu`. A native-architecture supervisor build still targets `aarch64-unknown-linux-musl`, so plain Cargo allowed `aws-lc-sys` C objects to pick up glibc-only references during a musl link:

- `__isoc23_sscanf`
- `__fprintf_chk`

The machine is not too old; the newer glibc/compiler path makes the existing target mismatch visible. The fix is to use the same Zig-backed musl target path for supervisor staging even when the CPU architecture matches the host.

## Changes

- Add a shared `has_cargo_zigbuild` helper to the prebuilt binary staging script.
- Route musl supervisor staging through `cargo zigbuild` when available, including same-architecture Linux builds.
- Update `architecture/build.md` with the musl/C-dependency rationale.

## Testing

- [x] `mise run pre-commit` passes
- [x] `mise run build:docker:supervisor` passes
- [x] `mise run build` passes
- [ ] Unit tests added/updated (not applicable; build script/docs change)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated
