### PR TITLE
AGENTS.md: Add more detailed signoff guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ ocsf_emit!(event);
 - Always use [Conventional Commits](https://www.conventionalcommits.org/) format for commit messages
 - Format: `<type>(<scope>): <description>` (scope is optional)
 - Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `perf`
-- Sign off on each commit for DCO compliance. Use the `--signoff` option to `git commit` to add the `Signed-off-by` header to ensure the user's configured email address is used.
+- Sign off on each commit for DCO compliance. Use the `--signoff` option to `git commit` to add the `Signed-off-by` footer to ensure the user's configured email address is used.
 - Never mention Claude or any AI agent in commits (no author attribution, no Co-Authored-By, no references in commit messages)
 
 ## Pre-commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ ocsf_emit!(event);
 - Always use [Conventional Commits](https://www.conventionalcommits.org/) format for commit messages
 - Format: `<type>(<scope>): <description>` (scope is optional)
 - Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `perf`
-- Sign each commit for DCO compliance (`git commit -s`, or include a `Signed-off-by: Name <email>` trailer)
+- Sign off on each commit for DCO compliance. Use the `--signoff` option to `git commit` to add the `Signed-off-by` header to ensure the user's configured email address is used.
 - Never mention Claude or any AI agent in commits (no author attribution, no Co-Authored-By, no references in commit messages)
 
 ## Pre-commit


### PR DESCRIPTION
My coding agent started hallucinating my email address to be
`rbryant@nvidia.com`. Add more guidance in `AGENTS.md` about how the
`Signed-off-by` header should be added so that it uses the email
address from git configuration instead of one it makes up.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
