### PR TITLE
fix(ci): pin snap artifact downloads to valid action

### DIFF
--- a/.github/workflows/snap-package.yml
+++ b/.github/workflows/snap-package.yml
@@ -77,19 +77,19 @@ jobs:
           sudo snap install snapcraft --classic
 
       - name: Download prebuilt CLI binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b40e67214ff5f5447ce83dd # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cli-linux-${{ matrix.arch }}
           path: prebuilt/cli
 
       - name: Download prebuilt gateway binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b40e67214ff5f5447ce83dd # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: gateway-binary-linux-${{ matrix.arch }}
           path: prebuilt/gateway
 
       - name: Download prebuilt sandbox binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b40e67214ff5f5447ce83dd # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: supervisor-binary-linux-${{ matrix.arch }}
           path: prebuilt/sandbox


### PR DESCRIPTION
## Summary

Fix the snap package workflow by replacing the invalid actions/download-artifact SHA in the three prebuilt binary download steps with the verified v8.0.1 pin already used by the rest of the release workflows.

## Related Issue

N/A

## Changes

- Updated snap CLI, gateway, and sandbox artifact download steps to use actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c.
- Updated the inline pin comments from v8 to v8.0.1 for consistency with existing workflows.

## Testing

- [x] git diff --check passes
- [x] Verified the bad SHA is absent from .github/workflows
- [x] Verified 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c resolves as the actions/download-artifact v8.0.1 tag target
- [ ] mise run pre-commit passes; failed locally because python:proto started before grpc_tools was available and rust check/lint could not build z3-sys without local z3.h headers

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)