### PR TITLE
fix(ci): use existing snap gateway wrapper

### DIFF
--- a/.github/workflows/snap-package.yml
+++ b/.github/workflows/snap-package.yml
@@ -119,7 +119,7 @@ jobs:
           cp prebuilt/gateway/openshell-gateway snap/prebuilt/openshell-gateway
           cp prebuilt/sandbox/openshell-sandbox snap/prebuilt/openshell-sandbox
 
-          cp deploy/snap/bin/openshell-gateway-wrapper snap/prebuilt/
+          cp tasks/scripts/snap-gateway-wrapper.sh snap/prebuilt/openshell-gateway-wrapper
           cp LICENSE snap/prebuilt/
           cp README.md snap/prebuilt/
 


### PR DESCRIPTION
## Summary

Fix the snap packaging workflow after the artifact action pin fix in #1855. The snap job now resolves `actions/download-artifact`, but fails while preparing `snap/prebuilt/` because it copies a gateway wrapper from the deleted `deploy/snap/` tree.

## Related Issue

None.

## Changes

- Copies `tasks/scripts/snap-gateway-wrapper.sh` into `snap/prebuilt/openshell-gateway-wrapper`, which is the filename expected by `snapcraft.yaml`.

## Testing

- [x] `git diff --check` passes
- [x] `bash -n tasks/scripts/snap-gateway-wrapper.sh` passes
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)