### PR TITLE
feat(sdk): add openshell-sdk crate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ These pipelines connect skills into end-to-end workflows. Individual skill files
 | `crates/openshell-bootstrap/` | Gateway metadata | Gateway registration metadata, auth token storage, mTLS bundle storage |
 | `crates/openshell-ocsf/` | OCSF logging | OCSF v1.7.0 event types, builders, shorthand/JSONL formatters, tracing layers |
 | `crates/openshell-core/` | Shared core | Common types, configuration, error handling |
+| `crates/openshell-sdk/` | Shared client SDK | Async Rust gateway client (gRPC transport, TLS, OIDC refresh, edge tunnel); consumed by CLI, TUI, and `@openshell/sdk` |
 | `crates/openshell-providers/` | Provider management | Credential provider backends |
 | `crates/openshell-tui/` | Terminal UI | Ratatui-based dashboard for monitoring |
 | `crates/openshell-driver-kubernetes/` | Kubernetes compute driver | In-process `ComputeDriver` backend for K8s sandbox pods |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3857,7 +3857,6 @@ dependencies = [
  "openshell-core",
  "reqwest 0.12.28",
  "rustls",
- "rustls-pemfile",
  "serde",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3845,6 +3845,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "openshell-sdk"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "futures",
+ "hyper",
+ "hyper-util",
+ "miette",
+ "oauth2",
+ "openshell-core",
+ "reqwest 0.12.28",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-tungstenite 0.26.2",
+ "tonic",
+ "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
 name = "openshell-server"
 version = "0.0.0"
 dependencies = [

--- a/crates/openshell-core/src/grpc_client.rs
+++ b/crates/openshell-core/src/grpc_client.rs
@@ -439,16 +439,7 @@ fn compute_refresh_delay(slot: &TokenSlot) -> Duration {
 /// Returns the expiry in milliseconds since the Unix epoch, or `None` if
 /// the token is not a parseable JWT.
 fn parse_jwt_exp_ms(jwt: &str) -> Option<i64> {
-    use base64::Engine;
-    let mut parts = jwt.splitn(3, '.');
-    let _header = parts.next()?;
-    let payload_b64 = parts.next()?;
-    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .decode(payload_b64)
-        .ok()?;
-    let value: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
-    let exp_secs = value.get("exp")?.as_i64()?;
-    exp_secs.checked_mul(1000)
+    crate::jwt::parse_exp_secs(jwt)?.checked_mul(1000)
 }
 
 #[cfg(test)]

--- a/crates/openshell-core/src/jwt.rs
+++ b/crates/openshell-core/src/jwt.rs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Minimal, signature-unverified JWT inspection shared by gateway clients.
+//!
+//! Used only for client-side refresh scheduling (deciding when a bearer is
+//! near expiry). It never verifies the signature and must not be used for
+//! any authorization decision. Both the sandbox-side
+//! [`crate::grpc_client`] and the user-facing `openshell-sdk` refresh path
+//! derive token expiry from here so the decode lives in one place.
+
+/// Decode the numeric `exp` claim (Unix seconds) from a JWT payload without
+/// verifying the signature.
+///
+/// Returns `None` when `token` is not a parseable JWT or has no integer `exp`
+/// claim. A leading `Bearer ` prefix is tolerated so callers can pass either a
+/// raw token or an `authorization` header value.
+#[must_use]
+pub fn parse_exp_secs(token: &str) -> Option<i64> {
+    use base64::Engine;
+    let raw = token.strip_prefix("Bearer ").unwrap_or(token);
+    let mut parts = raw.splitn(3, '.');
+    let _header = parts.next()?;
+    let payload_b64 = parts.next()?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    value.get("exp")?.as_i64()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+
+    fn jwt_with_payload(payload: &serde_json::Value) -> String {
+        let b64 = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
+        let header = b64(br#"{"alg":"none","typ":"JWT"}"#);
+        let body = b64(serde_json::to_vec(payload).unwrap().as_slice());
+        format!("{header}.{body}.")
+    }
+
+    #[test]
+    fn reads_integer_exp() {
+        let token = jwt_with_payload(&serde_json::json!({ "exp": 1_900_000_000_i64 }));
+        assert_eq!(parse_exp_secs(&token), Some(1_900_000_000));
+    }
+
+    #[test]
+    fn tolerates_bearer_prefix() {
+        let token = jwt_with_payload(&serde_json::json!({ "exp": 42 }));
+        assert_eq!(parse_exp_secs(&format!("Bearer {token}")), Some(42));
+    }
+
+    #[test]
+    fn none_for_missing_exp_or_non_jwt() {
+        assert_eq!(
+            parse_exp_secs(&jwt_with_payload(&serde_json::json!({ "sub": "x" }))),
+            None
+        );
+        assert_eq!(parse_exp_secs("not-a-jwt"), None);
+        assert_eq!(parse_exp_secs(""), None);
+    }
+}

--- a/crates/openshell-core/src/lib.rs
+++ b/crates/openshell-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod gpu;
 pub mod grpc_client;
 pub mod image;
 pub mod inference;
+pub mod jwt;
 pub mod metadata;
 pub mod net;
 pub mod paths;

--- a/crates/openshell-sdk/Cargo.toml
+++ b/crates/openshell-sdk/Cargo.toml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "openshell-sdk"
+description = "Shared async Rust client for OpenShell gateways"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+openshell-core = { path = "../openshell-core" }
+async-trait = "0.1"
+futures = { workspace = true }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
+miette = { workspace = true }
+oauth2 = "5"
+reqwest = { workspace = true }
+rustls = { workspace = true }
+rustls-pemfile = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-rustls = { workspace = true }
+tokio-stream = { workspace = true }
+tokio-tungstenite = { workspace = true }
+tonic = { workspace = true, features = ["tls-native-roots"] }
+tower = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/openshell-sdk/Cargo.toml
+++ b/crates/openshell-sdk/Cargo.toml
@@ -20,12 +20,10 @@ miette = { workspace = true }
 oauth2 = "5"
 reqwest = { workspace = true }
 rustls = { workspace = true }
-rustls-pemfile = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
-tokio-stream = { workspace = true }
 tokio-tungstenite = { workspace = true }
 tonic = { workspace = true, features = ["tls-native-roots"] }
 tower = { workspace = true }
@@ -33,6 +31,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-stream = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/openshell-sdk/README.md
+++ b/crates/openshell-sdk/README.md
@@ -1,11 +1,10 @@
 # openshell-sdk
 
 `openshell-sdk` is the shared async Rust client for OpenShell gateways. It owns
-the gRPC transport and auth stack so the CLI, the TUI, and language bindings
-share one implementation of channel setup, TLS, OIDC refresh, and the
-Cloudflare Access tunnel.
-
-Designed in [RFC 0008](../../rfc/0008-shared-sdk-core-and-ts-binding/README.md).
+gRPC channel setup, TLS, OIDC refresh, and the Cloudflare Access tunnel so the
+CLI, the TUI, and language bindings share one client implementation. Callers
+pass an explicit bearer token; the SDK does no filesystem access and no
+gateway-name resolution.
 
 ## Two layers
 
@@ -15,46 +14,29 @@ Designed in [RFC 0008](../../rfc/0008-shared-sdk-core-and-ts-binding/README.md).
   surface doesn't yet cover (inference, providers, policy, logs, settings, SSH,
   forwarding).
 
-The curated surface drives OIDC refresh automatically (proactively before a
-request and reactively on `Unauthenticated`). The plain `raw_grpc`/
-`raw_inference` accessors do not: they return a client bound to the current
-token. When a refresher is wired, use `raw_grpc_fresh`/`raw_inference_fresh`
-for a proactive refresh before the call, and `force_refresh` to recover after
-a raw RPC returns `Unauthenticated`.
+## Auth and refresh
 
-## Responsibilities
+The curated surface drives OIDC refresh automatically: proactively before a
+request and reactively on `Unauthenticated`. Refreshes are single-flight, so
+only one is in flight at a time.
 
-- Construct the gRPC channel and select the transport (plaintext vs TLS).
-- Load TLS material and set up mTLS channels.
-- Attach edge-auth bearer tokens and refresh OIDC tokens, with single-flight
-  coalescing so only one refresh is in flight at a time.
-- Proxy connections through the Cloudflare Access tunnel for hosted gateways.
-- Map transport and gateway failures to a typed `SdkError` with a discriminable
-  kind.
+The plain `raw_grpc`/`raw_inference` accessors do not refresh; they return a
+client bound to the current token. When a refresher is wired, use
+`raw_grpc_fresh`/`raw_inference_fresh` to refresh before the call, and
+`force_refresh` to recover after a raw RPC returns `Unauthenticated`.
 
-## Non-responsibilities
+The SDK consumes a `Refresh` trait that the caller implements; it does not run
+the OIDC browser flow itself.
 
-- Gateway-name resolution, default config-path lookups, and the OIDC browser
-  flow. These are user-facing concerns owned by `openshell-cli`; the SDK
-  consumes a `Refresh` trait the CLI implements.
-- Reading tokens from disk. Callers pass an explicit token; the SDK performs no
-  filesystem access.
-- Defining the gRPC contract. The protos and generated types are owned by
-  `openshell-core`.
-
-## Transport and auth modes
-
-Covers the connectivity modes the CLI exercises in production, except mTLS:
+## Transport modes
 
 - Plaintext (local development)
-- Server-authenticated TLS over HTTPS (system roots, or a pinned private CA via `ca_cert`)
+- Server-authenticated TLS (system roots, or a pinned private CA via `ca_cert`)
 - OIDC bearer over HTTPS (gateways behind an OAuth2/OIDC IdP)
 - Cloudflare Access tunnel (hosted gateways)
 - Insecure TLS (development/debug; certificate verification disabled)
 
-mTLS (client certificates) is intentionally out of scope; gateways that require
-it continue to use `openshell-cli`'s legacy mTLS path until that auth method is
-retired.
+mTLS (client certificates) is not supported.
 
 ## Public surface
 
@@ -62,7 +44,8 @@ retired.
 `health`, `create_sandbox`, `get_sandbox`, `list_sandboxes`, `delete_sandbox`,
 `wait_ready`, `wait_deleted`, and `exec`. Curated types (`SandboxSpec`,
 `SandboxRef`, `Health`, `ListOptions`, `ExecOptions`, `SandboxPhase`) use
-SDK-shaped enums rather than raw proto integers.
+SDK-shaped enums rather than raw proto integers. Failures map to a typed
+`SdkError` with a discriminable kind.
 
 ## Modules
 
@@ -79,14 +62,8 @@ SDK-shaped enums rather than raw proto integers.
 | `types` | Curated request/response types and proto conversions. |
 | `raw` | Escape hatch re-exporting the generated tonic clients. |
 
-## Consumers
-
-`openshell-cli`, `openshell-tui`, and `openshell-sdk-node` (published as
-`@openshell/sdk`).
-
 ## Notes
 
 - Async-only. Tonic is async-native; callers needing a blocking call can wrap
   with their own runtime.
-- The surface is alpha and will grow as more RPCs graduate from `raw` into the
-  curated client.
+- The curated surface will grow as more RPCs graduate from `raw`.

--- a/crates/openshell-sdk/README.md
+++ b/crates/openshell-sdk/README.md
@@ -15,6 +15,13 @@ Designed in [RFC 0008](../../rfc/0008-shared-sdk-core-and-ts-binding/README.md).
   surface doesn't yet cover (inference, providers, policy, logs, settings, SSH,
   forwarding).
 
+The curated surface drives OIDC refresh automatically (proactively before a
+request and reactively on `Unauthenticated`). The plain `raw_grpc`/
+`raw_inference` accessors do not: they return a client bound to the current
+token. When a refresher is wired, use `raw_grpc_fresh`/`raw_inference_fresh`
+for a proactive refresh before the call, and `force_refresh` to recover after
+a raw RPC returns `Unauthenticated`.
+
 ## Responsibilities
 
 - Construct the gRPC channel and select the transport (plaintext vs TLS).

--- a/crates/openshell-sdk/README.md
+++ b/crates/openshell-sdk/README.md
@@ -1,0 +1,85 @@
+# openshell-sdk
+
+`openshell-sdk` is the shared async Rust client for OpenShell gateways. It owns
+the gRPC transport and auth stack so the CLI, the TUI, and language bindings
+share one implementation of channel setup, TLS, OIDC refresh, and the
+Cloudflare Access tunnel.
+
+Designed in [RFC 0008](../../rfc/0008-shared-sdk-core-and-ts-binding/README.md).
+
+## Two layers
+
+- `OpenShellClient` — the curated, sandbox-focused surface: health, sandbox
+  CRUD, readiness/deletion waits, and non-streaming exec.
+- `raw` — direct access to the generated tonic clients for RPCs the curated
+  surface doesn't yet cover (inference, providers, policy, logs, settings, SSH,
+  forwarding).
+
+## Responsibilities
+
+- Construct the gRPC channel and select the transport (plaintext vs TLS).
+- Load TLS material and set up mTLS channels.
+- Attach edge-auth bearer tokens and refresh OIDC tokens, with single-flight
+  coalescing so only one refresh is in flight at a time.
+- Proxy connections through the Cloudflare Access tunnel for hosted gateways.
+- Map transport and gateway failures to a typed `SdkError` with a discriminable
+  kind.
+
+## Non-responsibilities
+
+- Gateway-name resolution, default config-path lookups, and the OIDC browser
+  flow. These are user-facing concerns owned by `openshell-cli`; the SDK
+  consumes a `Refresh` trait the CLI implements.
+- Reading tokens from disk. Callers pass an explicit token; the SDK performs no
+  filesystem access.
+- Defining the gRPC contract. The protos and generated types are owned by
+  `openshell-core`.
+
+## Transport and auth modes
+
+Covers the connectivity modes the CLI exercises in production, except mTLS:
+
+- Plaintext (local development)
+- Server-authenticated TLS over HTTPS (system roots, or a pinned private CA via `ca_cert`)
+- OIDC bearer over HTTPS (gateways behind an OAuth2/OIDC IdP)
+- Cloudflare Access tunnel (hosted gateways)
+- Insecure TLS (development/debug; certificate verification disabled)
+
+mTLS (client certificates) is intentionally out of scope; gateways that require
+it continue to use `openshell-cli`'s legacy mTLS path until that auth method is
+retired.
+
+## Public surface
+
+`OpenShellClient::connect(ClientConfig)` returns a connected client exposing
+`health`, `create_sandbox`, `get_sandbox`, `list_sandboxes`, `delete_sandbox`,
+`wait_ready`, `wait_deleted`, and `exec`. Curated types (`SandboxSpec`,
+`SandboxRef`, `Health`, `ListOptions`, `ExecOptions`, `SandboxPhase`) use
+SDK-shaped enums rather than raw proto integers.
+
+## Modules
+
+| Module | Purpose |
+|---|---|
+| `client` | High-level `OpenShellClient` and the curated sandbox surface. |
+| `config` | `ClientConfig`, `AuthConfig`. |
+| `transport` | Channel construction, TLS resolution, request interceptors. |
+| `auth` | `EdgeAuthInterceptor` for bearer-token attachment. |
+| `oidc` | OIDC token handling at the transport layer. |
+| `refresh` | `Refresh` trait and single-flight refresh coalescing. |
+| `edge_tunnel` | Cloudflare Access tunnel dialer. |
+| `error` | `SdkError` taxonomy. |
+| `types` | Curated request/response types and proto conversions. |
+| `raw` | Escape hatch re-exporting the generated tonic clients. |
+
+## Consumers
+
+`openshell-cli`, `openshell-tui`, and `openshell-sdk-node` (published as
+`@openshell/sdk`).
+
+## Notes
+
+- Async-only. Tonic is async-native; callers needing a blocking call can wrap
+  with their own runtime.
+- The surface is alpha and will grow as more RPCs graduate from `raw` into the
+  curated client.

--- a/crates/openshell-sdk/src/auth.rs
+++ b/crates/openshell-sdk/src/auth.rs
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bearer-token authentication interceptor for outgoing gRPC requests.
+
+use crate::error::{Result, SdkError};
+use std::sync::{Arc, RwLock};
+use tonic::metadata::{Ascii, MetadataValue};
+
+/// Shared, mutable OIDC bearer header.
+///
+/// The interceptor reads it on every request and a [`crate::TokenSource`]
+/// overwrites it in place on refresh, so rotation propagates to an
+/// already-connected client without rebuilding the channel. Mirrors the slot
+/// pattern in `openshell-core`'s gRPC client.
+pub type BearerSlot = Arc<RwLock<Option<MetadataValue<Ascii>>>>;
+
+/// Build the `authorization` header value for an OIDC bearer token.
+pub fn bearer_metadata(token: &str) -> Result<MetadataValue<Ascii>> {
+    format!("Bearer {token}")
+        .parse()
+        .map_err(|_| SdkError::auth("invalid OIDC token value"))
+}
+
+/// Interceptor that injects authentication headers into every outgoing gRPC request.
+///
+/// Supports OIDC Bearer tokens (standard `authorization` header) and
+/// Cloudflare Access tokens (custom headers). When no token is set, acts
+/// as a no-op. OIDC takes precedence over edge tokens.
+///
+/// The OIDC bearer is held in a shared [`BearerSlot`] so token refresh can
+/// update it live; edge tokens are captured once at construction (the edge
+/// tunnel binds the credential at handshake time).
+#[derive(Clone)]
+pub struct EdgeAuthInterceptor {
+    bearer: Option<BearerSlot>,
+    header_value: Option<MetadataValue<Ascii>>,
+    cookie_value: Option<MetadataValue<Ascii>>,
+}
+
+impl EdgeAuthInterceptor {
+    /// Create an interceptor from optional token strings.
+    ///
+    /// OIDC bearer token takes precedence over edge token. Returns a no-op
+    /// interceptor when neither token is provided.
+    pub fn new(oidc_token: Option<&str>, edge_token: Option<&str>) -> Result<Self> {
+        if let Some(token) = oidc_token {
+            let bearer = bearer_metadata(token)?;
+            return Ok(Self {
+                bearer: Some(Arc::new(RwLock::new(Some(bearer)))),
+                header_value: None,
+                cookie_value: None,
+            });
+        }
+
+        let (header_value, cookie_value) = match edge_token {
+            Some(t) => {
+                let hv: MetadataValue<Ascii> = t
+                    .parse()
+                    .map_err(|_| SdkError::auth("invalid edge token value"))?;
+                let cv: MetadataValue<Ascii> = format!("CF_Authorization={t}")
+                    .parse()
+                    .map_err(|_| SdkError::auth("invalid edge token value for cookie"))?;
+                (Some(hv), Some(cv))
+            }
+            None => (None, None),
+        };
+        Ok(Self {
+            bearer: None,
+            header_value,
+            cookie_value,
+        })
+    }
+
+    /// No-op interceptor that passes requests through without modification.
+    pub fn noop() -> Self {
+        Self {
+            bearer: None,
+            header_value: None,
+            cookie_value: None,
+        }
+    }
+
+    /// Handle to the live OIDC bearer slot, if this interceptor carries one.
+    ///
+    /// The high-level client uses this to overwrite the token in place after
+    /// a refresh. `None` for edge-token and no-op interceptors.
+    pub fn bearer_slot(&self) -> Option<BearerSlot> {
+        self.bearer.clone()
+    }
+}
+
+impl tonic::service::Interceptor for EdgeAuthInterceptor {
+    fn call(
+        &mut self,
+        mut req: tonic::Request<()>,
+    ) -> std::result::Result<tonic::Request<()>, tonic::Status> {
+        if let Some(slot) = &self.bearer
+            && let Some(val) = slot.read().ok().and_then(|g| g.clone())
+        {
+            req.metadata_mut().insert("authorization", val);
+        }
+        if let Some(ref val) = self.header_value {
+            req.metadata_mut()
+                .insert("cf-access-jwt-assertion", val.clone());
+        }
+        if let Some(ref val) = self.cookie_value {
+            req.metadata_mut().insert("cookie", val.clone());
+        }
+        Ok(req)
+    }
+}

--- a/crates/openshell-sdk/src/client.rs
+++ b/crates/openshell-sdk/src/client.rs
@@ -371,8 +371,14 @@ fn token_source_from_config(config: &ClientConfig) -> Option<TokenSource> {
         return None;
     };
     let mut initial = RefreshedToken::new(token.clone());
-    if let Some(exp) = expires_at {
-        initial = initial.with_expires_at(*exp);
+    // Prefer the caller-advertised expiry; otherwise derive a deadline from
+    // the token's JWT `exp` claim (reusing openshell-core's decoder) so the
+    // proactive refresh path has an expiry to schedule against. Non-JWT
+    // bearers fall back to reactive-only refresh.
+    let deadline = expires_at
+        .or_else(|| openshell_core::jwt::parse_exp_secs(token).and_then(|s| u64::try_from(s).ok()));
+    if let Some(exp) = deadline {
+        initial = initial.with_expires_at(exp);
     }
     Some(TokenSource::new(initial, Arc::clone(refresher)))
 }

--- a/crates/openshell-sdk/src/client.rs
+++ b/crates/openshell-sdk/src/client.rs
@@ -1,0 +1,438 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! High-level async client over the gateway gRPC surface.
+//!
+//! Covers the sandbox-focused MVP slice: health, sandbox CRUD, readiness /
+//! deletion waits, and non-streaming exec. Other RPCs (inference, providers,
+//! policy, logs, settings, SSH, forwarding) are reachable via
+//! [`OpenShellClient::raw_grpc`] / [`OpenShellClient::raw_inference`].
+
+use crate::auth::{BearerSlot, EdgeAuthInterceptor, bearer_metadata};
+use crate::config::{AuthConfig, ClientConfig};
+use crate::error::{Result, SdkError};
+use crate::raw::{AuthedGrpcClient, AuthedInferenceClient};
+use crate::refresh::{RefreshedToken, TokenSource};
+use crate::transport;
+use crate::types::{
+    ExecOptions, ExecResult, Health, ListOptions, SandboxPhase, SandboxRef, SandboxSpec,
+};
+use futures::StreamExt;
+use openshell_core::proto;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tonic::transport::Channel;
+
+/// Async client for a single `OpenShell` gateway.
+///
+/// Cheap to clone — the underlying tonic [`Channel`] multiplexes RPCs over a
+/// shared HTTP/2 connection. Construct one per logical gateway and share it
+/// across tasks; do not call [`OpenShellClient::connect`] per request.
+#[derive(Clone)]
+pub struct OpenShellClient {
+    channel: Channel,
+    interceptor: EdgeAuthInterceptor,
+    /// Drives OIDC token rotation. `None` when auth is static (edge token,
+    /// anonymous, or an OIDC token with no refresher).
+    token_source: Option<TokenSource>,
+    /// Live bearer slot the interceptor reads; refreshed tokens are written
+    /// here so rotation reaches in-flight requests. `None` for non-OIDC auth.
+    bearer_slot: Option<BearerSlot>,
+}
+
+impl OpenShellClient {
+    /// Open a connection to the gateway described by `config`.
+    ///
+    /// Performs the gRPC channel handshake immediately; subsequent RPCs reuse
+    /// the connection.
+    pub async fn connect(config: ClientConfig) -> Result<Self> {
+        let channel = transport::build_channel(&config).await?;
+        let interceptor = interceptor_from_config(&config)?;
+        let bearer_slot = interceptor.bearer_slot();
+        let token_source = token_source_from_config(&config);
+        Ok(Self {
+            channel,
+            interceptor,
+            token_source,
+            bearer_slot,
+        })
+    }
+
+    /// Construct from an already-built [`Channel`] and interceptor.
+    ///
+    /// Use when the caller needs to customize channel construction beyond
+    /// what [`ClientConfig`] exposes. The resulting client does not perform
+    /// OIDC refresh; drive rotation externally via the interceptor's slot.
+    pub fn from_parts(channel: Channel, interceptor: EdgeAuthInterceptor) -> Self {
+        let bearer_slot = interceptor.bearer_slot();
+        Self {
+            channel,
+            interceptor,
+            token_source: None,
+            bearer_slot,
+        }
+    }
+
+    /// Underlying tonic [`Channel`].
+    pub fn channel(&self) -> Channel {
+        self.channel.clone()
+    }
+
+    /// Authenticated gRPC client for the main `OpenShell` service.
+    ///
+    /// Use this when the curated surface below doesn't expose the RPC or
+    /// field you need.
+    pub fn raw_grpc(&self) -> AuthedGrpcClient {
+        proto::open_shell_client::OpenShellClient::with_interceptor(
+            self.channel.clone(),
+            self.interceptor.clone(),
+        )
+    }
+
+    /// Authenticated gRPC client for the inference service.
+    pub fn raw_inference(&self) -> AuthedInferenceClient {
+        proto::inference_client::InferenceClient::with_interceptor(
+            self.channel.clone(),
+            self.interceptor.clone(),
+        )
+    }
+
+    /// Gateway health snapshot.
+    pub async fn health(&self) -> Result<Health> {
+        let resp = self
+            .unary(|mut grpc| async move { grpc.health(proto::HealthRequest {}).await })
+            .await?;
+        Ok(Health {
+            status: resp.status.into(),
+            version: resp.version,
+        })
+    }
+
+    /// Create a new sandbox from a curated [`SandboxSpec`].
+    pub async fn create_sandbox(&self, spec: SandboxSpec) -> Result<SandboxRef> {
+        let request = create_sandbox_request(spec);
+        let response = self
+            .unary(|mut grpc| {
+                let request = request.clone();
+                async move { grpc.create_sandbox(request).await }
+            })
+            .await?;
+        sandbox_from_response(response.sandbox)
+    }
+
+    /// Fetch a sandbox by name.
+    pub async fn get_sandbox(&self, name: &str) -> Result<SandboxRef> {
+        let response = self
+            .unary(|mut grpc| {
+                let request = proto::GetSandboxRequest {
+                    name: name.to_string(),
+                };
+                async move { grpc.get_sandbox(request).await }
+            })
+            .await?;
+        sandbox_from_response(response.sandbox)
+    }
+
+    /// List sandboxes.
+    pub async fn list_sandboxes(&self, opts: ListOptions) -> Result<Vec<SandboxRef>> {
+        let response = self
+            .unary(|mut grpc| {
+                let request = proto::ListSandboxesRequest {
+                    limit: opts.limit,
+                    offset: opts.offset,
+                    label_selector: opts.label_selector.clone().unwrap_or_default(),
+                };
+                async move { grpc.list_sandboxes(request).await }
+            })
+            .await?;
+        Ok(response
+            .sandboxes
+            .into_iter()
+            .map(SandboxRef::from_proto)
+            .collect())
+    }
+
+    /// Delete a sandbox by name.
+    ///
+    /// Returns `true` when the gateway acknowledges the deletion, `false`
+    /// when it was already absent. The sandbox may still be in
+    /// [`SandboxPhase::Deleting`] when this returns — pair with
+    /// [`OpenShellClient::wait_deleted`] when you need a terminal guarantee.
+    pub async fn delete_sandbox(&self, name: &str) -> Result<bool> {
+        let response = self
+            .unary(|mut grpc| {
+                let request = proto::DeleteSandboxRequest {
+                    name: name.to_string(),
+                };
+                async move { grpc.delete_sandbox(request).await }
+            })
+            .await?;
+        Ok(response.deleted)
+    }
+
+    /// Poll [`OpenShellClient::get_sandbox`] until the sandbox reaches
+    /// [`SandboxPhase::Ready`] or the `timeout` elapses.
+    ///
+    /// Returns the terminal sandbox snapshot on success. Returns an
+    /// [`SdkError::Connect`] when the timeout expires, or whatever error
+    /// the gateway returns if the sandbox transitions into
+    /// [`SandboxPhase::Error`].
+    pub async fn wait_ready(&self, name: &str, timeout: Duration) -> Result<SandboxRef> {
+        self.wait_for(name, timeout, |phase| match phase {
+            SandboxPhase::Ready => Some(Ok(())),
+            SandboxPhase::Error => Some(Err(SdkError::connect(format!(
+                "sandbox '{name}' entered error phase"
+            )))),
+            _ => None,
+        })
+        .await
+    }
+
+    /// Poll until the sandbox is gone (gRPC `NotFound`) or the `timeout`
+    /// elapses.
+    pub async fn wait_deleted(&self, name: &str, timeout: Duration) -> Result<()> {
+        let deadline = Instant::now() + timeout;
+        let mut delay = Duration::from_millis(250);
+        loop {
+            match self.get_sandbox(name).await {
+                Err(SdkError::NotFound { .. }) => return Ok(()),
+                Err(other) => return Err(other),
+                Ok(snapshot) if snapshot.phase == SandboxPhase::Deleting => {}
+                Ok(_) => {}
+            }
+            if Instant::now() >= deadline {
+                return Err(SdkError::connect(format!(
+                    "timed out waiting for sandbox '{name}' to delete"
+                )));
+            }
+            tokio::time::sleep(delay).await;
+            delay = (delay * 2).min(Duration::from_secs(2));
+        }
+    }
+
+    /// Run a command inside a sandbox and buffer stdout/stderr to the end.
+    ///
+    /// For streaming output, drop down to [`OpenShellClient::raw_grpc`] and
+    /// call `exec_sandbox` directly.
+    pub async fn exec(&self, name: &str, cmd: &[String], opts: ExecOptions) -> Result<ExecResult> {
+        let sandbox = self.get_sandbox(name).await?;
+        let request = proto::ExecSandboxRequest {
+            sandbox_id: sandbox.id,
+            command: cmd.to_vec(),
+            workdir: opts.workdir.unwrap_or_default(),
+            environment: opts.environment,
+            timeout_seconds: opts
+                .timeout
+                .map_or(0, |d| u32::try_from(d.as_secs()).unwrap_or(u32::MAX)),
+            stdin: opts.stdin.unwrap_or_default(),
+            tty: false,
+            cols: 0,
+            rows: 0,
+        };
+
+        // Proactively refresh, then open the stream. On `Unauthenticated` at
+        // open time, force-refresh and retry once; mid-stream rotation is out
+        // of scope (streaming retry is tracked separately).
+        self.ensure_fresh().await?;
+        let mut stream = match self.raw_grpc().exec_sandbox(request.clone()).await {
+            Ok(resp) => resp.into_inner(),
+            Err(status) if status.code() == tonic::Code::Unauthenticated => {
+                if self.refresh_on_unauthorized().await? {
+                    self.raw_grpc()
+                        .exec_sandbox(request)
+                        .await
+                        .map_err(map_status)?
+                        .into_inner()
+                } else {
+                    return Err(map_status(status));
+                }
+            }
+            Err(status) => return Err(map_status(status)),
+        };
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut exit_code: Option<i32> = None;
+
+        while let Some(event) = stream.next().await {
+            let event = event.map_err(map_status)?;
+            match event.payload {
+                Some(proto::exec_sandbox_event::Payload::Stdout(chunk)) => {
+                    stdout.extend_from_slice(&chunk.data);
+                }
+                Some(proto::exec_sandbox_event::Payload::Stderr(chunk)) => {
+                    stderr.extend_from_slice(&chunk.data);
+                }
+                Some(proto::exec_sandbox_event::Payload::Exit(exit)) => {
+                    exit_code = Some(exit.exit_code);
+                }
+                None => {}
+            }
+        }
+
+        Ok(ExecResult {
+            exit_code: exit_code.unwrap_or(-1),
+            stdout,
+            stderr,
+        })
+    }
+
+    /// Run a unary RPC with OIDC-aware auth: refresh proactively before the
+    /// call (if the token is near expiry) and, on an `Unauthenticated`
+    /// response, force a refresh and retry exactly once. No-op auth behaves
+    /// as a plain single call.
+    async fn unary<T, F, Fut>(&self, call: F) -> Result<T>
+    where
+        F: Fn(AuthedGrpcClient) -> Fut,
+        Fut: Future<Output = std::result::Result<tonic::Response<T>, tonic::Status>>,
+    {
+        self.ensure_fresh().await?;
+        match call(self.raw_grpc()).await {
+            Ok(resp) => Ok(resp.into_inner()),
+            Err(status) if status.code() == tonic::Code::Unauthenticated => {
+                if self.refresh_on_unauthorized().await? {
+                    call(self.raw_grpc())
+                        .await
+                        .map(tonic::Response::into_inner)
+                        .map_err(map_status)
+                } else {
+                    Err(map_status(status))
+                }
+            }
+            Err(status) => Err(map_status(status)),
+        }
+    }
+
+    /// Proactive refresh: if a token source is wired and the token is within
+    /// the refresh skew of expiry, mint a new one and store it in the live
+    /// bearer slot. Tokens with no advertised expiry are left untouched.
+    async fn ensure_fresh(&self) -> Result<()> {
+        if let (Some(source), Some(slot)) = (&self.token_source, &self.bearer_slot) {
+            let token = source.current().await?;
+            store_bearer(slot, &token);
+        }
+        Ok(())
+    }
+
+    /// Reactive refresh: force a new token (used on `Unauthenticated`) and
+    /// store it in the live slot. Returns `false` when no refresher is wired,
+    /// signalling the caller to surface the original error.
+    async fn refresh_on_unauthorized(&self) -> Result<bool> {
+        if let (Some(source), Some(slot)) = (&self.token_source, &self.bearer_slot) {
+            let token = source.refresh_now().await?;
+            store_bearer(slot, &token);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    async fn wait_for<F>(&self, name: &str, timeout: Duration, mut decide: F) -> Result<SandboxRef>
+    where
+        F: FnMut(SandboxPhase) -> Option<Result<()>>,
+    {
+        let deadline = Instant::now() + timeout;
+        let mut delay = Duration::from_millis(250);
+        loop {
+            let snapshot = self.get_sandbox(name).await?;
+            if let Some(verdict) = decide(snapshot.phase) {
+                verdict?;
+                return Ok(snapshot);
+            }
+            if Instant::now() >= deadline {
+                return Err(SdkError::connect(format!(
+                    "timed out waiting for sandbox '{name}'"
+                )));
+            }
+            tokio::time::sleep(delay).await;
+            delay = (delay * 2).min(Duration::from_secs(2));
+        }
+    }
+}
+
+fn interceptor_from_config(config: &ClientConfig) -> Result<EdgeAuthInterceptor> {
+    match &config.auth {
+        None => Ok(EdgeAuthInterceptor::noop()),
+        Some(AuthConfig::Oidc { token, .. }) => EdgeAuthInterceptor::new(Some(token), None),
+        Some(AuthConfig::EdgeJwt(token)) => EdgeAuthInterceptor::new(None, Some(token)),
+    }
+}
+
+/// Build a [`TokenSource`] when the config carries an OIDC refresher. Returns
+/// `None` for static OIDC tokens, edge tokens, and anonymous auth.
+fn token_source_from_config(config: &ClientConfig) -> Option<TokenSource> {
+    let Some(AuthConfig::Oidc {
+        token,
+        expires_at,
+        refresh: Some(refresher),
+    }) = &config.auth
+    else {
+        return None;
+    };
+    let mut initial = RefreshedToken::new(token.clone());
+    if let Some(exp) = expires_at {
+        initial = initial.with_expires_at(*exp);
+    }
+    Some(TokenSource::new(initial, Arc::clone(refresher)))
+}
+
+/// Overwrite the live bearer slot with a freshly minted token. A malformed
+/// token value is dropped (the slot keeps its previous value); the next
+/// request then fails auth and surfaces a clear error.
+fn store_bearer(slot: &BearerSlot, token: &str) {
+    if let Ok(value) = bearer_metadata(token)
+        && let Ok(mut guard) = slot.write()
+    {
+        *guard = Some(value);
+    }
+}
+
+fn create_sandbox_request(spec: SandboxSpec) -> proto::CreateSandboxRequest {
+    let SandboxSpec {
+        name,
+        image,
+        labels,
+        environment,
+        providers,
+        gpu,
+    } = spec;
+    let template = image.map(|image| proto::SandboxTemplate {
+        image,
+        ..proto::SandboxTemplate::default()
+    });
+    let resource_requirements = gpu.then_some(proto::ResourceRequirements {
+        gpu: Some(proto::GpuResourceRequirements { count: None }),
+    });
+    proto::CreateSandboxRequest {
+        spec: Some(proto::SandboxSpec {
+            environment,
+            template,
+            providers,
+            resource_requirements,
+            ..proto::SandboxSpec::default()
+        }),
+        name: name.unwrap_or_default(),
+        labels,
+    }
+}
+
+fn sandbox_from_response(sandbox: Option<proto::Sandbox>) -> Result<SandboxRef> {
+    sandbox
+        .map(SandboxRef::from_proto)
+        .ok_or_else(|| SdkError::invalid_config("sandbox missing from gateway response"))
+}
+
+fn map_status(status: tonic::Status) -> SdkError {
+    let message = status.message().to_string();
+    match status.code() {
+        tonic::Code::NotFound => SdkError::NotFound { message },
+        tonic::Code::AlreadyExists => SdkError::AlreadyExists { message },
+        tonic::Code::InvalidArgument => SdkError::invalid_config(message),
+        tonic::Code::Unauthenticated | tonic::Code::PermissionDenied => SdkError::auth(message),
+        _ => SdkError::Rpc {
+            code: status.code() as i32,
+            message,
+        },
+    }
+}

--- a/crates/openshell-sdk/src/client.rs
+++ b/crates/openshell-sdk/src/client.rs
@@ -271,25 +271,16 @@ impl OpenShellClient {
             rows: 0,
         };
 
-        // Proactively refresh, then open the stream. On `Unauthenticated` at
-        // open time, force-refresh and retry once; mid-stream rotation is out
-        // of scope (streaming retry is tracked separately).
-        self.ensure_fresh().await?;
-        let mut stream = match self.raw_grpc().exec_sandbox(request.clone()).await {
-            Ok(resp) => resp.into_inner(),
-            Err(status) if status.code() == tonic::Code::Unauthenticated => {
-                if self.refresh_on_unauthorized().await? {
-                    self.raw_grpc()
-                        .exec_sandbox(request)
-                        .await
-                        .map_err(map_status)?
-                        .into_inner()
-                } else {
-                    return Err(map_status(status));
-                }
-            }
-            Err(status) => return Err(map_status(status)),
-        };
+        // Open the stream under the same OIDC-aware auth policy as unary RPCs
+        // (proactive refresh, then one reactive retry on `Unauthenticated`).
+        // Mid-stream rotation is out of scope; streaming retry is tracked
+        // separately.
+        let mut stream = self
+            .unary(|mut grpc| {
+                let request = request.clone();
+                async move { grpc.exec_sandbox(request).await }
+            })
+            .await?;
 
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
@@ -349,8 +340,20 @@ impl OpenShellClient {
     /// bearer slot. Tokens with no advertised expiry are left untouched.
     async fn ensure_fresh(&self) -> Result<()> {
         if let (Some(source), Some(slot)) = (&self.token_source, &self.bearer_slot) {
-            let token = source.current().await?;
-            store_bearer(slot, &token)?;
+            // Proactive refresh is best-effort: on a transient failure (e.g. an
+            // IdP blip) the token already in the slot may still be valid, so
+            // fall through and let the request proceed. A genuinely
+            // expired/rejected token surfaces as `Unauthenticated`, which
+            // drives the reactive refresh in `refresh_on_unauthorized`.
+            match source.current().await {
+                Ok(token) => store_bearer(slot, &token)?,
+                Err(err) => {
+                    tracing::debug!(
+                        error = %err,
+                        "proactive token refresh failed; using existing token"
+                    );
+                }
+            }
         }
         Ok(())
     }
@@ -515,10 +518,23 @@ mod tests {
         }
     }
 
+    struct FailingRefresher;
+
+    #[async_trait::async_trait]
+    impl Refresh for FailingRefresher {
+        async fn refresh(&self) -> std::result::Result<RefreshedToken, RefreshError> {
+            Err(RefreshError::Transient("idp blip".into()))
+        }
+    }
+
     /// Build an OIDC client wired to a refresher, with a near-expiry initial
     /// token, over a lazy channel that never actually connects (no RPC is
     /// issued in these tests).
     fn oidc_client_with_refresher(calls: Arc<AtomicUsize>) -> OpenShellClient {
+        oidc_client_with(Arc::new(StubRefresher { calls }))
+    }
+
+    fn oidc_client_with(refresher: Arc<dyn Refresh>) -> OpenShellClient {
         let interceptor = EdgeAuthInterceptor::new(Some("initial"), None).unwrap();
         let bearer_slot = interceptor.bearer_slot();
         let near = SystemTime::now()
@@ -528,7 +544,7 @@ mod tests {
             + 5;
         let source = TokenSource::new(
             RefreshedToken::new("initial").with_expires_at(near),
-            Arc::new(StubRefresher { calls }),
+            refresher,
         );
         let channel = Channel::from_static("http://127.0.0.1:1").connect_lazy();
         OpenShellClient {
@@ -579,6 +595,24 @@ mod tests {
             slot_token(client.bearer_slot.as_ref().unwrap()),
             "Bearer token-1",
             "refreshed token must reach the live slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_fresh_tolerates_proactive_refresh_failure() {
+        // A transient proactive-refresh failure must not fail the request: the
+        // near-expiry token in the slot may still be valid, so `ensure_fresh`
+        // falls through and leaves the existing token in place for the
+        // reactive `Unauthenticated` path to handle if the server rejects it.
+        let client = oidc_client_with(Arc::new(FailingRefresher));
+        client
+            .ensure_fresh()
+            .await
+            .expect("proactive refresh failure must be non-fatal");
+        assert_eq!(
+            slot_token(client.bearer_slot.as_ref().unwrap()),
+            "Bearer initial",
+            "existing token must remain in the slot"
         );
     }
 

--- a/crates/openshell-sdk/src/client.rs
+++ b/crates/openshell-sdk/src/client.rs
@@ -310,7 +310,7 @@ impl OpenShellClient {
     async fn ensure_fresh(&self) -> Result<()> {
         if let (Some(source), Some(slot)) = (&self.token_source, &self.bearer_slot) {
             let token = source.current().await?;
-            store_bearer(slot, &token);
+            store_bearer(slot, &token)?;
         }
         Ok(())
     }
@@ -321,7 +321,7 @@ impl OpenShellClient {
     async fn refresh_on_unauthorized(&self) -> Result<bool> {
         if let (Some(source), Some(slot)) = (&self.token_source, &self.bearer_slot) {
             let token = source.refresh_now().await?;
-            store_bearer(slot, &token);
+            store_bearer(slot, &token)?;
             Ok(true)
         } else {
             Ok(false)
@@ -383,15 +383,20 @@ fn token_source_from_config(config: &ClientConfig) -> Option<TokenSource> {
     Some(TokenSource::new(initial, Arc::clone(refresher)))
 }
 
-/// Overwrite the live bearer slot with a freshly minted token. A malformed
-/// token value is dropped (the slot keeps its previous value); the next
-/// request then fails auth and surfaces a clear error.
-fn store_bearer(slot: &BearerSlot, token: &str) {
-    if let Ok(value) = bearer_metadata(token)
-        && let Ok(mut guard) = slot.write()
-    {
-        *guard = Some(value);
-    }
+/// Overwrite the live bearer slot with a freshly minted token.
+///
+/// Returns an error if the refreshed token can't be encoded as gRPC metadata
+/// instead of silently keeping the previous value. The [`TokenSource`] has
+/// already committed the new token to its state by this point, so a silent
+/// drop would leave the interceptor sending the old token with no path back
+/// to a refresh; surfacing the error fails the call loudly instead.
+fn store_bearer(slot: &BearerSlot, token: &str) -> Result<()> {
+    let value = bearer_metadata(token)?;
+    let mut guard = slot
+        .write()
+        .map_err(|_| SdkError::auth("bearer slot lock poisoned"))?;
+    *guard = Some(value);
+    Ok(())
 }
 
 fn create_sandbox_request(spec: SandboxSpec) -> proto::CreateSandboxRequest {
@@ -440,5 +445,23 @@ fn map_status(status: tonic::Status) -> SdkError {
             code: status.code() as i32,
             message,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, RwLock};
+
+    #[test]
+    fn store_bearer_rejects_malformed_token_and_keeps_previous() {
+        let slot: BearerSlot = Arc::new(RwLock::new(None));
+        store_bearer(&slot, "good-token").expect("a valid token should store");
+
+        // A token with a control character can't be gRPC metadata; the slot
+        // must keep its previous value and the error must surface.
+        assert!(store_bearer(&slot, "bad\nvalue").is_err());
+        let current = slot.read().unwrap().clone().unwrap();
+        assert_eq!(current.to_str().unwrap(), "Bearer good-token");
     }
 }

--- a/crates/openshell-sdk/src/client.rs
+++ b/crates/openshell-sdk/src/client.rs
@@ -83,6 +83,15 @@ impl OpenShellClient {
     ///
     /// Use this when the curated surface below doesn't expose the RPC or
     /// field you need.
+    ///
+    /// This does **not** drive OIDC refresh: it returns a client bound to
+    /// the interceptor's current bearer slot without checking expiry or
+    /// retrying on `Unauthenticated`. A client that only ever issues raw
+    /// RPCs keeps sending the initial token until it expires. When a
+    /// refresher is wired, prefer [`OpenShellClient::raw_grpc_fresh`] (or
+    /// interleave a curated call) so rotation reaches the shared slot, and
+    /// call [`OpenShellClient::force_refresh`] to recover on a rejected
+    /// token.
     pub fn raw_grpc(&self) -> AuthedGrpcClient {
         proto::open_shell_client::OpenShellClient::with_interceptor(
             self.channel.clone(),
@@ -90,12 +99,43 @@ impl OpenShellClient {
         )
     }
 
+    /// Like [`OpenShellClient::raw_grpc`], but proactively refreshes the
+    /// bearer token first when a refresher is wired and the token is within
+    /// the refresh skew of expiry. The returned client reads the same live
+    /// slot, so the refreshed token applies to every RPC issued through it.
+    ///
+    /// Reactive retry on `Unauthenticated` remains the caller's
+    /// responsibility for raw RPCs: on a rejected token, call
+    /// [`OpenShellClient::force_refresh`] and reissue.
+    pub async fn raw_grpc_fresh(&self) -> Result<AuthedGrpcClient> {
+        self.ensure_fresh().await?;
+        Ok(self.raw_grpc())
+    }
+
     /// Authenticated gRPC client for the inference service.
+    ///
+    /// Like [`OpenShellClient::raw_grpc`], this does not drive OIDC refresh;
+    /// use [`OpenShellClient::raw_inference_fresh`] when a refresher is wired.
     pub fn raw_inference(&self) -> AuthedInferenceClient {
         proto::inference_client::InferenceClient::with_interceptor(
             self.channel.clone(),
             self.interceptor.clone(),
         )
+    }
+
+    /// Like [`OpenShellClient::raw_inference`], but proactively refreshes the
+    /// bearer token first (see [`OpenShellClient::raw_grpc_fresh`]).
+    pub async fn raw_inference_fresh(&self) -> Result<AuthedInferenceClient> {
+        self.ensure_fresh().await?;
+        Ok(self.raw_inference())
+    }
+
+    /// Force an OIDC refresh and write the new token into the live bearer
+    /// slot, regardless of expiry. Returns `true` when a refresher is wired
+    /// and a fresh token was minted, `false` for static auth. Use after a
+    /// raw RPC returns `Unauthenticated` to recover before reissuing it.
+    pub async fn force_refresh(&self) -> Result<bool> {
+        self.refresh_on_unauthorized().await
     }
 
     /// Gateway health snapshot.
@@ -451,7 +491,110 @@ fn map_status(status: tonic::Status) -> SdkError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::refresh::{Refresh, RefreshError};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, RwLock};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tonic::transport::Channel;
+
+    struct StubRefresher {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl Refresh for StubRefresher {
+        async fn refresh(&self) -> std::result::Result<RefreshedToken, RefreshError> {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            Ok(RefreshedToken::new(format!("token-{n}")).with_expires_at(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs()
+                    + 3600,
+            ))
+        }
+    }
+
+    /// Build an OIDC client wired to a refresher, with a near-expiry initial
+    /// token, over a lazy channel that never actually connects (no RPC is
+    /// issued in these tests).
+    fn oidc_client_with_refresher(calls: Arc<AtomicUsize>) -> OpenShellClient {
+        let interceptor = EdgeAuthInterceptor::new(Some("initial"), None).unwrap();
+        let bearer_slot = interceptor.bearer_slot();
+        let near = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 5;
+        let source = TokenSource::new(
+            RefreshedToken::new("initial").with_expires_at(near),
+            Arc::new(StubRefresher { calls }),
+        );
+        let channel = Channel::from_static("http://127.0.0.1:1").connect_lazy();
+        OpenShellClient {
+            channel,
+            interceptor,
+            token_source: Some(source),
+            bearer_slot,
+        }
+    }
+
+    fn slot_token(slot: &BearerSlot) -> String {
+        slot.read()
+            .unwrap()
+            .clone()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn raw_grpc_does_not_refresh() {
+        // Regression (P1): the plain raw accessor must not be relied on for
+        // rotation — it hands back a client bound to the current token.
+        let calls = Arc::new(AtomicUsize::new(0));
+        let client = oidc_client_with_refresher(Arc::clone(&calls));
+        let _raw = client.raw_grpc();
+        assert_eq!(calls.load(Ordering::SeqCst), 0, "raw_grpc must not refresh");
+        assert_eq!(
+            slot_token(client.bearer_slot.as_ref().unwrap()),
+            "Bearer initial"
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_grpc_fresh_refreshes_near_expiry() {
+        // Regression (P1): the _fresh accessor proactively rotates a
+        // near-expiry token into the shared slot before returning a client.
+        let calls = Arc::new(AtomicUsize::new(0));
+        let client = oidc_client_with_refresher(Arc::clone(&calls));
+        let _raw = client.raw_grpc_fresh().await.unwrap();
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "raw_grpc_fresh must refresh a near-expiry token"
+        );
+        assert_eq!(
+            slot_token(client.bearer_slot.as_ref().unwrap()),
+            "Bearer token-1",
+            "refreshed token must reach the live slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn force_refresh_rotates_and_reports_wired() {
+        // Regression (P1): reactive recovery path for raw callers.
+        let calls = Arc::new(AtomicUsize::new(0));
+        let client = oidc_client_with_refresher(Arc::clone(&calls));
+        let refreshed = client.force_refresh().await.unwrap();
+        assert!(refreshed, "force_refresh reports a wired refresher");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            slot_token(client.bearer_slot.as_ref().unwrap()),
+            "Bearer token-1"
+        );
+    }
 
     #[test]
     fn store_bearer_rejects_malformed_token_and_keeps_previous() {

--- a/crates/openshell-sdk/src/config.rs
+++ b/crates/openshell-sdk/src/config.rs
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Public input types for the SDK: how callers describe a gateway and the
+//! credentials used to talk to it.
+//!
+//! The CLI keeps its own filesystem-aware `TlsOptions` for plumbing; it
+//! converts to a `ClientConfig` at the moment of dialing the gateway.
+
+use crate::refresh::Refresh;
+use std::sync::Arc;
+
+/// Authentication mode for outgoing gRPC requests.
+///
+/// The two variants are functionally distinct in the transport layer:
+/// `EdgeJwt` routes through a local WebSocket tunnel (the only way to get a
+/// browser-flow JWT past Cloudflare Access on POST/HTTP2), while `Oidc`
+/// connects directly over HTTPS and adds an `authorization: Bearer ...`
+/// header.
+//
+// `#[non_exhaustive]` keeps phase 2 additive: when we promote `Oidc(String)`
+// to `Oidc { token, refresh: Option<Arc<dyn Refresh>> }` or add a third
+// variant, downstream `match` arms aren't forced to break.
+#[derive(Clone)]
+#[non_exhaustive]
+pub enum AuthConfig {
+    /// Cloudflare Access JWT — routes through the edge WebSocket tunnel.
+    EdgeJwt(String),
+    /// OIDC bearer token — direct HTTPS, `authorization` header.
+    ///
+    /// `expires_at` (Unix seconds, when known) lets the client refresh
+    /// proactively before expiry. `refresh`, when supplied, lets the client
+    /// rotate the token in place — proactively before expiry and reactively
+    /// on an `Unauthenticated` response. `None` keeps the token static for
+    /// the connection's lifetime.
+    Oidc {
+        /// Current OIDC access token.
+        token: String,
+        /// Advertised expiry (Unix seconds), if known.
+        expires_at: Option<u64>,
+        /// Optional refresher driving live token rotation.
+        refresh: Option<Arc<dyn Refresh>>,
+    },
+}
+
+impl AuthConfig {
+    /// Convenience constructor for a static OIDC bearer token (no refresh).
+    pub fn oidc(token: impl Into<String>) -> Self {
+        Self::Oidc {
+            token: token.into(),
+            expires_at: None,
+            refresh: None,
+        }
+    }
+}
+
+/// Configuration for opening a gRPC channel to an `OpenShell` gateway.
+///
+/// Consumed by `openshell_sdk::transport::grpc_client` and the
+/// inference-client equivalent. One `ClientConfig` per logical connection;
+/// callers that want connection pooling cache the resulting `tonic::Channel`.
+//
+// NOTE:
+// - `gateway` is a full URL (`http://...` or `https://...`) so the scheme
+//   tells the transport layer whether to use plaintext or TLS. Matches
+//   today's CLI convention; matches the RFC's `pub gateway: String`.
+// - `ca_cert` pins a private-CA certificate (PEM-encoded). `None` falls
+//   back to the platform's system roots.
+// - This SDK does not speak mTLS. Gateways requiring client certificates
+//   are handled by `openshell-cli`'s legacy mTLS path until product
+//   retires that auth method.
+// - `insecure_skip_verify` is a separate flag rather than a third
+//   `AuthConfig` variant because it's a transport concern (cert
+//   verification) that's orthogonal to auth.
+// - No `timeout` field yet. The RFC mentions one but today's behavior is
+//   `connect_timeout(10s)` hard-coded; introducing a configurable timeout
+//   here would be a behavior change. Phase 2 territory.
+// - No `Debug` derive: `auth` carries secrets; `ca_cert` is fine but we
+//   redact the whole struct for safety. If callers want ergonomic printing
+//   we can implement `Debug` manually with a redacted token field.
+// - `#[non_exhaustive]` + `Default` lets phase 2 add fields (timeout, retry
+//   policy, `Refresh` trait) without breaking literal-construct callers.
+//   Idiom is `ClientConfig { gateway: g, ..Default::default() }`.
+#[derive(Clone, Default)]
+#[non_exhaustive]
+pub struct ClientConfig {
+    /// Gateway URL, e.g. `http://127.0.0.1:8080` or `https://gw.example.com`.
+    pub gateway: String,
+    /// CA certificate (PEM) for private-CA gateways. `None` uses system
+    /// roots. Ignored for plaintext gateways and when
+    /// `insecure_skip_verify` is enabled.
+    pub ca_cert: Option<Vec<u8>>,
+    /// Bearer-token auth mode. `None` = anonymous TLS over HTTPS, or
+    /// plaintext when `gateway` is `http://`.
+    pub auth: Option<AuthConfig>,
+    /// Disable TLS certificate verification (development/debug only).
+    /// Ignored for plaintext gateways. **Do not enable in production.**
+    pub insecure_skip_verify: bool,
+}
+
+impl ClientConfig {
+    pub fn new(gateway: impl Into<String>) -> Self {
+        Self {
+            gateway: gateway.into(),
+            ..Default::default()
+        }
+    }
+}

--- a/crates/openshell-sdk/src/config.rs
+++ b/crates/openshell-sdk/src/config.rs
@@ -18,9 +18,8 @@ use std::sync::Arc;
 /// connects directly over HTTPS and adds an `authorization: Bearer ...`
 /// header.
 //
-// `#[non_exhaustive]` keeps phase 2 additive: when we promote `Oidc(String)`
-// to `Oidc { token, refresh: Option<Arc<dyn Refresh>> }` or add a third
-// variant, downstream `match` arms aren't forced to break.
+// `#[non_exhaustive]` keeps future additions non-breaking: adding a third
+// auth variant won't force downstream `match` arms to break.
 #[derive(Clone)]
 #[non_exhaustive]
 pub enum AuthConfig {

--- a/crates/openshell-sdk/src/edge_tunnel.rs
+++ b/crates/openshell-sdk/src/edge_tunnel.rs
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Edge-authenticated WebSocket tunnel proxy.
+//!
+//! When the gateway sits behind a reverse proxy with edge authentication
+//! (e.g., Cloudflare Access), gRPC (HTTP/2 POST) requests are rejected at the
+//! edge because browser-flow JWTs only authenticate GET requests.
+//!
+//! The workaround is to open a **WebSocket** to the edge (WebSocket upgrades
+//! are GET requests, which the edge authenticates normally) and then pipe raw
+//! TCP bytes through WebSocket binary frames.
+//!
+//! This module implements the pattern:
+//!
+//! 1. Bind a local TCP listener on an ephemeral port.
+//! 2. For each accepted connection, open a WebSocket (`wss://`) to the
+//!    gateway's tunnel endpoint with the bearer token in upgrade headers.
+//! 3. Bidirectionally pipe bytes between the local TCP stream and the
+//!    WebSocket.
+//!
+//! The gRPC `Channel` then connects to `http://127.0.0.1:<local_port>`
+//! (plaintext) — the edge handles TLS, and the WebSocket carries the raw
+//! bytes to the origin.
+
+use crate::error::{Result, SdkError};
+use futures::stream::{SplitSink, SplitStream};
+use futures::{SinkExt, StreamExt};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+use tracing::{debug, error, warn};
+
+/// A running edge-authenticated tunnel proxy.
+///
+/// The proxy listens on a local TCP port and tunnels each connection over a
+/// WebSocket to the edge. The listener runs in a detached task for the
+/// lifetime of the current process.
+pub struct EdgeTunnelProxy {
+    /// Local address the proxy is listening on (e.g. `127.0.0.1:54321`).
+    pub local_addr: SocketAddr,
+}
+
+/// Configuration for establishing the WebSocket tunnel.
+#[derive(Clone)]
+struct TunnelConfig {
+    /// The `wss://` URL to connect to (derived from the gateway endpoint).
+    ws_url: String,
+    /// The bearer token for edge authentication.
+    edge_token: String,
+}
+
+/// Start the local tunnel proxy.
+///
+/// Returns an [`EdgeTunnelProxy`] with the local address to connect to.
+/// The proxy runs as a background tokio task.
+pub async fn start_tunnel_proxy(
+    gateway_endpoint: &str,
+    edge_token: &str,
+) -> Result<EdgeTunnelProxy> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let local_addr = listener.local_addr()?;
+
+    // Convert the gateway endpoint to a WebSocket URL.
+    // https://foo.com -> wss://foo.com
+    // http://foo.com  -> ws://foo.com  (edge proxy over plain HTTP, uncommon but handled)
+    let ws_url = format!(
+        "{}/_ws_tunnel",
+        gateway_endpoint
+            .replacen("https://", "wss://", 1)
+            .replacen("http://", "ws://", 1)
+            .trim_end_matches('/')
+    );
+
+    let config = Arc::new(TunnelConfig {
+        ws_url,
+        edge_token: edge_token.to_string(),
+    });
+
+    debug!(
+        local_addr = %local_addr,
+        gateway = %gateway_endpoint,
+        "starting edge tunnel proxy"
+    );
+
+    tokio::spawn(accept_loop(listener, config));
+
+    Ok(EdgeTunnelProxy { local_addr })
+}
+
+/// Accept loop: for each incoming TCP connection, spawn a handler that
+/// opens a WebSocket to the edge and pipes bytes bidirectionally.
+async fn accept_loop(listener: TcpListener, config: Arc<TunnelConfig>) {
+    loop {
+        match listener.accept().await {
+            Ok((stream, peer)) => {
+                debug!(peer = %peer, "accepted local tunnel connection");
+                let config = Arc::clone(&config);
+                tokio::spawn(async move {
+                    if let Err(e) = handle_connection(stream, &config).await {
+                        warn!(peer = %peer, error = %e, "tunnel connection failed");
+                    }
+                });
+            }
+            Err(e) => {
+                error!(error = %e, "failed to accept tunnel connection");
+                // Brief backoff to avoid tight error loops.
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+    }
+}
+
+/// Handle a single tunneled connection: open a WebSocket to the edge and
+/// bidirectionally copy bytes.
+async fn handle_connection(tcp_stream: TcpStream, config: &TunnelConfig) -> Result<()> {
+    let ws_stream = open_ws(config).await?;
+    let (ws_sink, ws_source) = ws_stream.split();
+    let (tcp_read, tcp_write) = tokio::io::split(tcp_stream);
+
+    // Two tasks: TCP->WS and WS->TCP. Abort the peer task once either
+    // direction finishes so the connection tears down promptly.
+    let mut tcp_to_ws = tokio::spawn(copy_tcp_to_ws(tcp_read, ws_sink));
+    let mut ws_to_tcp = tokio::spawn(copy_ws_to_tcp(ws_source, tcp_write));
+
+    tokio::select! {
+        res = &mut tcp_to_ws => {
+            if let Err(e) = res {
+                debug!(error = %e, "tcp->ws task panicked");
+            }
+            ws_to_tcp.abort();
+        }
+        res = &mut ws_to_tcp => {
+            if let Err(e) = res {
+                debug!(error = %e, "ws->tcp task panicked");
+            }
+            tcp_to_ws.abort();
+        }
+    }
+
+    Ok(())
+}
+
+/// Open a WebSocket connection to the edge proxy.
+async fn open_ws(config: &TunnelConfig) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>> {
+    let mut request = (&config.ws_url)
+        .into_client_request()
+        .map_err(|e| SdkError::invalid_config(format!("invalid tunnel URL: {e}")))?;
+
+    // Inject the bearer token via multiple headers for compatibility with
+    // Cloudflare Access (which checks `Cf-Access-Token`, the
+    // `CF_Authorization` cookie, and the `Cf-Access-Jwt-Assertion` header).
+    let token_val = HeaderValue::from_str(&config.edge_token)
+        .map_err(|e| SdkError::auth(format!("invalid edge token header value: {e}")))?;
+    request
+        .headers_mut()
+        .insert("Cf-Access-Token", token_val.clone());
+    request
+        .headers_mut()
+        .insert("Cf-Access-Jwt-Assertion", token_val);
+    request.headers_mut().insert(
+        "Cookie",
+        HeaderValue::from_str(&format!("CF_Authorization={}", config.edge_token))
+            .map_err(|e| SdkError::auth(format!("invalid edge token cookie value: {e}")))?,
+    );
+
+    debug!(url = %config.ws_url, "opening WebSocket to edge");
+
+    let (ws_stream, response) = tokio_tungstenite::connect_async(request)
+        .await
+        .map_err(|e| SdkError::connect(format!("WebSocket connect failed: {e}")))?;
+
+    debug!(
+        status = %response.status(),
+        "WebSocket connected to edge"
+    );
+
+    Ok(ws_stream)
+}
+
+/// Copy bytes from a local TCP reader into WebSocket binary frames.
+async fn copy_tcp_to_ws(
+    mut tcp_read: tokio::io::ReadHalf<TcpStream>,
+    mut ws_sink: SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>,
+) {
+    let mut buf = vec![0u8; 32 * 1024];
+    loop {
+        match tcp_read.read(&mut buf).await {
+            Ok(0) => {
+                // EOF — send a close frame.
+                let _ = ws_sink.close().await;
+                break;
+            }
+            Ok(n) => {
+                if ws_sink
+                    .send(Message::Binary(buf[..n].to_vec().into()))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            Err(e) => {
+                debug!(error = %e, "tcp read error");
+                let _ = ws_sink.close().await;
+                break;
+            }
+        }
+    }
+}
+
+/// Copy bytes from WebSocket binary frames into a local TCP writer.
+async fn copy_ws_to_tcp(
+    mut ws_source: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
+    mut tcp_write: tokio::io::WriteHalf<TcpStream>,
+) {
+    while let Some(msg) = ws_source.next().await {
+        match msg {
+            Ok(Message::Binary(data)) => {
+                if tcp_write.write_all(&data).await.is_err() {
+                    break;
+                }
+            }
+            Ok(Message::Close(_)) => break,
+            Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_)) => {
+                // Handled automatically by tungstenite.
+            }
+            Ok(Message::Text(text)) => {
+                // Some proxies send text frames — treat as binary.
+                if tcp_write.write_all(text.as_bytes()).await.is_err() {
+                    break;
+                }
+            }
+            Err(e) => {
+                debug!(error = %e, "ws read error");
+                break;
+            }
+        }
+    }
+    let _ = tcp_write.shutdown().await;
+}

--- a/crates/openshell-sdk/src/error.rs
+++ b/crates/openshell-sdk/src/error.rs
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! SDK error type. Surfaces a discriminable variant set so consumers (CLI,
+//! TUI, language bindings) can decide how to render or remap each kind.
+
+use miette::Diagnostic;
+use thiserror::Error;
+
+/// SDK result type alias.
+pub type Result<T> = std::result::Result<T, SdkError>;
+
+/// Errors produced by `openshell-sdk`.
+///
+/// CLI consumers convert these to `miette::Report` at the call boundary;
+/// future TS/Python bindings will map them to language-native exceptions
+/// via the [`SdkError::code`] accessor.
+#[derive(Debug, Error, Diagnostic)]
+pub enum SdkError {
+    /// Caller-supplied configuration is invalid (URL parse, missing field,
+    /// illegal token characters).
+    #[error("invalid configuration: {message}")]
+    #[diagnostic(code(openshell::sdk::invalid_config))]
+    InvalidConfig {
+        /// Error message.
+        message: String,
+    },
+
+    /// TLS material parse or rustls config build failure.
+    #[error("TLS error: {message}")]
+    #[diagnostic(code(openshell::sdk::tls))]
+    Tls {
+        /// Error message.
+        message: String,
+    },
+
+    /// Failed to establish a connection to the gateway (TCP, TLS handshake,
+    /// HTTP/2, WebSocket upgrade).
+    #[error("connect error: {message}")]
+    #[diagnostic(code(openshell::sdk::connect))]
+    Connect {
+        /// Error message.
+        message: String,
+    },
+
+    /// Auth-related failure: OIDC discovery / refresh, token format invalid
+    /// for header injection.
+    #[error("auth error: {message}")]
+    #[diagnostic(code(openshell::sdk::auth))]
+    Auth {
+        /// Error message.
+        message: String,
+    },
+
+    /// Local IO failure (file read, listener bind, socket).
+    #[error("I/O error: {source}")]
+    #[diagnostic(code(openshell::sdk::io))]
+    Io {
+        /// Underlying I/O error.
+        #[from]
+        source: std::io::Error,
+    },
+
+    /// Gateway reported the requested object does not exist (gRPC `NotFound`).
+    #[error("not found: {message}")]
+    #[diagnostic(code(openshell::sdk::not_found))]
+    NotFound {
+        /// Error message.
+        message: String,
+    },
+
+    /// Gateway reported the requested object already exists (gRPC `AlreadyExists`).
+    #[error("already exists: {message}")]
+    #[diagnostic(code(openshell::sdk::already_exists))]
+    AlreadyExists {
+        /// Error message.
+        message: String,
+    },
+
+    /// Catch-all for gRPC errors not mapped to a more specific variant.
+    #[error("gateway error ({code}): {message}")]
+    #[diagnostic(code(openshell::sdk::rpc))]
+    Rpc {
+        /// Numeric gRPC status code (see [`tonic::Code`]).
+        code: i32,
+        /// Error message.
+        message: String,
+    },
+}
+
+impl SdkError {
+    /// Create an `InvalidConfig` error.
+    pub fn invalid_config(message: impl Into<String>) -> Self {
+        Self::InvalidConfig {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `Tls` error.
+    pub fn tls(message: impl Into<String>) -> Self {
+        Self::Tls {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `Connect` error.
+    pub fn connect(message: impl Into<String>) -> Self {
+        Self::Connect {
+            message: message.into(),
+        }
+    }
+
+    /// Create an `Auth` error.
+    pub fn auth(message: impl Into<String>) -> Self {
+        Self::Auth {
+            message: message.into(),
+        }
+    }
+
+    /// Stable string code for cross-language binding consumers.
+    ///
+    /// Returns one of: `invalid_config`, `tls`, `connect`, `auth`, `io`,
+    /// `not_found`, `already_exists`, `rpc`. Phase 3 (napi binding) will
+    /// surface this as the JS error's `code` field for discriminated-union
+    /// ergonomics.
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::InvalidConfig { .. } => "invalid_config",
+            Self::Tls { .. } => "tls",
+            Self::Connect { .. } => "connect",
+            Self::Auth { .. } => "auth",
+            Self::Io { .. } => "io",
+            Self::NotFound { .. } => "not_found",
+            Self::AlreadyExists { .. } => "already_exists",
+            Self::Rpc { .. } => "rpc",
+        }
+    }
+}

--- a/crates/openshell-sdk/src/error.rs
+++ b/crates/openshell-sdk/src/error.rs
@@ -45,11 +45,18 @@ pub enum SdkError {
 
     /// Auth-related failure: OIDC discovery / refresh, token format invalid
     /// for header injection.
+    ///
+    /// `retryable` mirrors the refresh contract's transient/terminal split: a
+    /// transient failure (network or `IdP` blip) may succeed on retry, while a
+    /// terminal one (session revoked, refresh token expired) requires
+    /// re-authentication. All non-refresh auth failures are non-retryable.
     #[error("auth error: {message}")]
     #[diagnostic(code(openshell::sdk::auth))]
     Auth {
         /// Error message.
         message: String,
+        /// Whether retrying the same operation may succeed.
+        retryable: bool,
     },
 
     /// Local IO failure (file read, listener bind, socket).
@@ -110,10 +117,19 @@ impl SdkError {
         }
     }
 
-    /// Create an `Auth` error.
+    /// Create a non-retryable `Auth` error.
     pub fn auth(message: impl Into<String>) -> Self {
         Self::Auth {
             message: message.into(),
+            retryable: false,
+        }
+    }
+
+    /// Create an `Auth` error, tagging whether retrying may succeed.
+    pub fn auth_retryable(message: impl Into<String>, retryable: bool) -> Self {
+        Self::Auth {
+            message: message.into(),
+            retryable,
         }
     }
 
@@ -123,6 +139,22 @@ impl SdkError {
     /// `not_found`, `already_exists`, `rpc`. Phase 3 (napi binding) will
     /// surface this as the JS error's `code` field for discriminated-union
     /// ergonomics.
+    /// Whether retrying the same operation may succeed.
+    ///
+    /// Only a transient [`SdkError::Auth`] failure reports `true`; every other
+    /// error is non-retryable and the caller should surface it rather than
+    /// loop. Consumers use this to distinguish a retryable refresh blip from a
+    /// dead session that needs re-authentication.
+    pub const fn retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::Auth {
+                retryable: true,
+                ..
+            }
+        )
+    }
+
     pub const fn code(&self) -> &'static str {
         match self {
             Self::InvalidConfig { .. } => "invalid_config",

--- a/crates/openshell-sdk/src/lib.rs
+++ b/crates/openshell-sdk/src/lib.rs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared async Rust client for `OpenShell` gateways.
+//!
+//! Two layers:
+//!
+//! - [`OpenShellClient`] — the high-level sandbox-focused MVP surface:
+//!   health, sandbox CRUD, readiness/deletion waits, non-streaming exec.
+//! - [`raw`] — direct access to the generated tonic clients for RPCs the
+//!   curated surface doesn't yet cover (inference, providers, policy, logs,
+//!   settings, SSH, forwarding).
+//!
+//! Owns the gRPC transport stack — channel construction, TLS material
+//! handling, request interceptors, OIDC token refresh, and the Cloudflare
+//! Access tunnel proxy. Consumed by `openshell-cli`, `openshell-tui`, and
+//! the napi-rs wrapper that ships as `@openshell/sdk`.
+//!
+//! # Quick start
+//!
+//! ```ignore
+//! use openshell_sdk::{ClientConfig, ListOptions, OpenShellClient};
+//!
+//! # async fn run() -> Result<(), openshell_sdk::SdkError> {
+//! let client = OpenShellClient::connect(ClientConfig::new("http://127.0.0.1:8080")).await?;
+//! let health = client.health().await?;
+//! let sandboxes = client.list_sandboxes(ListOptions::default()).await?;
+//! # Ok(())
+//! # }
+//! ```
+
+pub mod auth;
+pub mod client;
+pub mod config;
+pub mod edge_tunnel;
+pub mod error;
+pub mod oidc;
+pub mod raw;
+pub mod refresh;
+pub mod transport;
+pub mod types;
+
+pub use auth::EdgeAuthInterceptor;
+pub use client::OpenShellClient;
+pub use config::{AuthConfig, ClientConfig};
+pub use error::SdkError;
+pub use refresh::{Refresh, RefreshError, RefreshedToken, TokenSource};
+pub use types::{
+    ExecOptions, ExecResult, Health, ListOptions, SandboxPhase, SandboxRef, SandboxSpec,
+    ServiceStatus,
+};

--- a/crates/openshell-sdk/src/oidc.rs
+++ b/crates/openshell-sdk/src/oidc.rs
@@ -162,7 +162,7 @@ fn output_from_oauth2_response(resp: &oauth2::basic::BasicTokenResponse) -> Refr
     RefreshTokenOutput {
         access_token: resp.access_token().secret().clone(),
         refresh_token: resp.refresh_token().map(|rt| rt.secret().clone()),
-        expires_at: resp.expires_in().map(|ei| now + ei.as_secs()),
+        expires_at: resp.expires_in().map(|ei| now.saturating_add(ei.as_secs())),
     }
 }
 

--- a/crates/openshell-sdk/src/oidc.rs
+++ b/crates/openshell-sdk/src/oidc.rs
@@ -33,6 +33,17 @@ pub struct RefreshTokenInput {
     pub insecure: bool,
 }
 
+impl std::fmt::Debug for RefreshTokenInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Omit `refresh_token` (a long-lived secret).
+        f.debug_struct("RefreshTokenInput")
+            .field("issuer", &self.issuer)
+            .field("client_id", &self.client_id)
+            .field("insecure", &self.insecure)
+            .finish_non_exhaustive()
+    }
+}
+
 impl RefreshTokenInput {
     pub fn new(
         refresh_token: impl Into<String>,
@@ -60,12 +71,22 @@ impl RefreshTokenInput {
 /// refresh token; per OAuth 2.0, callers should preserve the previous
 /// refresh token in that case. `expires_at` is a Unix timestamp (seconds
 /// since epoch); `None` when the server omits `expires_in`.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub struct RefreshTokenOutput {
     pub access_token: String,
     pub refresh_token: Option<String>,
     pub expires_at: Option<u64>,
+}
+
+impl std::fmt::Debug for RefreshTokenOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Omit `access_token`; never print the refresh-token value.
+        f.debug_struct("RefreshTokenOutput")
+            .field("has_refresh_token", &self.refresh_token.is_some())
+            .field("expires_at", &self.expires_at)
+            .finish_non_exhaustive()
+    }
 }
 
 /// Discover OIDC endpoints from the issuer's well-known configuration.
@@ -142,5 +163,28 @@ fn output_from_oauth2_response(resp: &oauth2::basic::BasicTokenResponse) -> Refr
         access_token: resp.access_token().secret().clone(),
         refresh_token: resp.refresh_token().map(|rt| rt.secret().clone()),
         expires_at: resp.expires_in().map(|ei| now + ei.as_secs()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_redacts_tokens() {
+        let input = RefreshTokenInput::new("refresh-secret", "https://idp", "cli");
+        let rendered = format!("{input:?}");
+        assert!(!rendered.contains("refresh-secret"));
+        assert!(rendered.contains("cli"));
+
+        let output = RefreshTokenOutput {
+            access_token: "access-secret".to_string(),
+            refresh_token: Some("refresh-secret".to_string()),
+            expires_at: Some(123),
+        };
+        let rendered = format!("{output:?}");
+        assert!(!rendered.contains("access-secret"));
+        assert!(!rendered.contains("refresh-secret"));
+        assert!(rendered.contains("has_refresh_token"));
     }
 }

--- a/crates/openshell-sdk/src/oidc.rs
+++ b/crates/openshell-sdk/src/oidc.rs
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! OIDC discovery and refresh-token flow (non-interactive).
+//!
+//! Browser-based authorization flows live in `openshell-cli` since they
+//! require a local callback HTTP server and an OS browser launcher.
+
+use crate::error::{Result, SdkError};
+use oauth2::basic::BasicClient;
+use oauth2::{ClientId, RefreshToken, TokenResponse, TokenUrl};
+use serde::Deserialize;
+
+/// OIDC discovery document (subset of fields callers consume).
+#[derive(Debug, Deserialize)]
+#[non_exhaustive]
+pub struct OidcDiscovery {
+    pub issuer: String,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+}
+
+/// Input to [`refresh_token`].
+///
+/// Constructed by the caller from whatever bundle / storage shape they
+/// use — the SDK does not assume any particular persistence model.
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct RefreshTokenInput {
+    pub refresh_token: String,
+    pub issuer: String,
+    pub client_id: String,
+    pub insecure: bool,
+}
+
+impl RefreshTokenInput {
+    pub fn new(
+        refresh_token: impl Into<String>,
+        issuer: impl Into<String>,
+        client_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            refresh_token: refresh_token.into(),
+            issuer: issuer.into(),
+            client_id: client_id.into(),
+            insecure: false,
+        }
+    }
+
+    #[must_use]
+    pub fn with_insecure(mut self, insecure: bool) -> Self {
+        self.insecure = insecure;
+        self
+    }
+}
+
+/// Output from [`refresh_token`].
+///
+/// `refresh_token` is `None` when the OIDC server did not return a new
+/// refresh token; per OAuth 2.0, callers should preserve the previous
+/// refresh token in that case. `expires_at` is a Unix timestamp (seconds
+/// since epoch); `None` when the server omits `expires_in`.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct RefreshTokenOutput {
+    pub access_token: String,
+    pub refresh_token: Option<String>,
+    pub expires_at: Option<u64>,
+}
+
+/// Discover OIDC endpoints from the issuer's well-known configuration.
+///
+/// Validates that the discovery document's `issuer` field matches the
+/// configured issuer URL to prevent SSRF or misdirection. When `insecure`
+/// is true, TLS certificate verification is disabled (intended for
+/// development against self-signed gateways).
+pub async fn discover(issuer: &str, insecure: bool) -> Result<OidcDiscovery> {
+    let normalized_issuer = issuer.trim_end_matches('/');
+    let url = format!("{normalized_issuer}/.well-known/openid-configuration");
+    let client = http_client(insecure);
+    let resp: OidcDiscovery = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| SdkError::auth(format!("OIDC discovery request failed: {e}")))?
+        .json()
+        .await
+        .map_err(|e| SdkError::auth(format!("OIDC discovery JSON parse failed: {e}")))?;
+
+    let discovered_issuer = resp.issuer.trim_end_matches('/');
+    if discovered_issuer != normalized_issuer {
+        return Err(SdkError::auth(format!(
+            "OIDC discovery issuer mismatch: expected '{normalized_issuer}', got '{discovered_issuer}'"
+        )));
+    }
+    Ok(resp)
+}
+
+/// Build an HTTP client suitable for OIDC token-endpoint requests.
+///
+/// Disables redirects so token-endpoint responses aren't accidentally
+/// followed; OIDC providers should not redirect on the token endpoint.
+/// When `insecure` is true, TLS certificate verification is disabled.
+pub fn http_client(insecure: bool) -> reqwest::Client {
+    let mut builder = reqwest::ClientBuilder::new().redirect(reqwest::redirect::Policy::none());
+    if insecure {
+        builder = builder.danger_accept_invalid_certs(true);
+    }
+    builder.build().expect("failed to build HTTP client")
+}
+
+/// Refresh an OIDC access token using the `refresh_token` grant.
+///
+/// The caller is responsible for preserving the prior refresh token when
+/// the output's `refresh_token` is `None` — per OAuth 2.0 the server may
+/// omit it from the refresh response.
+pub async fn refresh_token(input: &RefreshTokenInput) -> Result<RefreshTokenOutput> {
+    let discovery = discover(&input.issuer, input.insecure).await?;
+
+    let client = BasicClient::new(ClientId::new(input.client_id.clone())).set_token_uri(
+        TokenUrl::new(discovery.token_endpoint)
+            .map_err(|e| SdkError::auth(format!("invalid token endpoint URL: {e}")))?,
+    );
+
+    let http = http_client(input.insecure);
+    let token_response = client
+        .exchange_refresh_token(&RefreshToken::new(input.refresh_token.clone()))
+        .request_async(&http)
+        .await
+        .map_err(|e| SdkError::auth(format!("token refresh failed: {e}")))?;
+
+    Ok(output_from_oauth2_response(&token_response))
+}
+
+fn output_from_oauth2_response(resp: &oauth2::basic::BasicTokenResponse) -> RefreshTokenOutput {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    RefreshTokenOutput {
+        access_token: resp.access_token().secret().clone(),
+        refresh_token: resp.refresh_token().map(|rt| rt.secret().clone()),
+        expires_at: resp.expires_in().map(|ei| now + ei.as_secs()),
+    }
+}

--- a/crates/openshell-sdk/src/raw.rs
+++ b/crates/openshell-sdk/src/raw.rs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Escape hatch — direct access to the generated tonic clients and protobuf
+//! types.
+//!
+//! Use this module when the curated high-level surface in
+//! [`crate::client::OpenShellClient`] doesn't expose the RPC or field you
+//! need. The high-level surface is sandbox-focused for MVP; inference,
+//! providers, policy, logs, settings, SSH, and forwarding all live here.
+//!
+//! ```ignore
+//! use openshell_sdk::{ClientConfig, OpenShellClient};
+//! use openshell_sdk::raw::ListProvidersRequest;
+//!
+//! let client = OpenShellClient::connect(ClientConfig::new("http://127.0.0.1:8080")).await?;
+//! let mut grpc = client.raw_grpc();
+//! let providers = grpc.list_providers(ListProvidersRequest::default()).await?;
+//! ```
+
+pub use openshell_core::proto;
+pub use openshell_core::proto::inference_client::InferenceClient;
+pub use openshell_core::proto::open_shell_client::OpenShellClient as GrpcClient;
+pub use openshell_core::proto::{
+    CreateSandboxRequest, DeleteSandboxRequest, ExecSandboxRequest, GetSandboxRequest,
+    HealthRequest, ListProvidersRequest, ListSandboxesRequest, Sandbox,
+    SandboxPhase as ProtoSandboxPhase, SandboxSpec as ProtoSandboxSpec, SandboxTemplate,
+    ServiceStatus as ProtoServiceStatus,
+};
+
+/// Type alias for the gRPC client wrapped in the SDK's auth interceptor.
+pub type AuthedGrpcClient = GrpcClient<
+    tonic::service::interceptor::InterceptedService<
+        tonic::transport::Channel,
+        crate::EdgeAuthInterceptor,
+    >,
+>;
+
+/// Type alias for the inference client wrapped in the SDK's auth interceptor.
+pub type AuthedInferenceClient = InferenceClient<
+    tonic::service::interceptor::InterceptedService<
+        tonic::transport::Channel,
+        crate::EdgeAuthInterceptor,
+    >,
+>;

--- a/crates/openshell-sdk/src/refresh.rs
+++ b/crates/openshell-sdk/src/refresh.rs
@@ -177,15 +177,6 @@ impl TokenSource {
         }
     }
 
-    /// Current token without checking expiry. Used by the sync gRPC
-    /// interceptor, which can't await.
-    pub fn snapshot(&self) -> String {
-        self.state
-            .try_read()
-            .map(|s| s.token.clone())
-            .unwrap_or_default()
-    }
-
     /// Async-fetch the current token, refreshing if it's within `skew` of
     /// expiry. Single-flight: concurrent callers share one refresh.
     ///
@@ -246,14 +237,25 @@ impl TokenSource {
                 let state = Arc::clone(&self.state);
                 let flight_slot = Arc::clone(&self.flight);
                 let epoch = flight.epoch.wrapping_add(1);
+                // Generation this attempt refreshes *from*. If it advances
+                // while the refresh is in flight, an external `replace()`
+                // installed a newer token and this result must not clobber it.
+                let start_generation = expected_generation;
                 let future: RefreshFuture = async move {
                     let outcome = match refresher.refresh().await {
                         Ok(token) => {
                             let mut state = state.write().await;
-                            state.token.clone_from(&token.access_token);
-                            state.expires_at = token.expires_at;
-                            state.generation = state.generation.wrapping_add(1);
-                            Ok(token.access_token)
+                            if state.generation == start_generation {
+                                state.token.clone_from(&token.access_token);
+                                state.expires_at = token.expires_at;
+                                state.generation = state.generation.wrapping_add(1);
+                                Ok(token.access_token)
+                            } else {
+                                // A concurrent `replace()` (or newer token)
+                                // landed mid-flight; honor it rather than
+                                // regressing to this now-stale result.
+                                Ok(state.token.clone())
+                            }
                         }
                         Err(err) => Err(SdkError::from(err).to_string()),
                     };
@@ -373,6 +375,12 @@ mod tests {
     /// Drive one leader into the refresher, then queue `followers` more
     /// callers that must join the in-flight attempt rather than start their
     /// own. Returns the refresher call count and per-caller outcomes.
+    /// Read the committed token straight from state, bypassing any refresh
+    /// logic. Test-only inspection helper.
+    async fn state_token(source: &TokenSource) -> String {
+        source.state.read().await.token.clone()
+    }
+
     async fn run_coalesced(fail: bool) -> (usize, Vec<Result<String>>) {
         let calls = Arc::new(AtomicUsize::new(0));
         let entered = Arc::new(tokio::sync::Notify::new());
@@ -551,7 +559,64 @@ mod tests {
         let token = source.refresh_now().await.unwrap();
         assert_eq!(token, "token-1", "forced refresh must mint a new token");
         assert_eq!(calls.load(Ordering::SeqCst), 1);
-        assert_eq!(source.snapshot(), "token-1", "slot must observe new token");
+        assert_eq!(
+            state_token(&source).await,
+            "token-1",
+            "state must observe new token"
+        );
+    }
+
+    #[tokio::test]
+    async fn in_flight_refresh_preserves_external_replace() {
+        // Regression (P2b): a `replace()` that lands while a refresh is in
+        // flight must survive. The in-flight refresh started from an older
+        // generation, so its result is discarded in favor of the externally
+        // installed token instead of clobbering it.
+        let calls = Arc::new(AtomicUsize::new(0));
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let refresher = Arc::new(GatedRefresher {
+            calls: Arc::clone(&calls),
+            entered: Arc::clone(&entered),
+            release: Arc::clone(&release),
+            fail: false,
+        });
+        let source = TokenSource::new(RefreshedToken::new("initial").with_expires_at(0), refresher);
+
+        // Leader starts a refresh and blocks inside refresher.refresh().
+        let leader = {
+            let src = source.clone();
+            tokio::spawn(async move { src.refresh_now().await })
+        };
+        entered.notified().await;
+
+        // External rotation installs an authoritative token mid-flight.
+        source
+            .replace(
+                RefreshedToken::new("external-rotation").with_expires_at(
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs()
+                        + 3600,
+                ),
+            )
+            .await;
+
+        // Release the in-flight refresh; it must yield to the replacement.
+        release.notify_waiters();
+        let leader_token = leader.await.unwrap().unwrap();
+
+        assert_eq!(
+            leader_token, "external-rotation",
+            "leader must observe the external replacement, not its own result"
+        );
+        assert_eq!(
+            state_token(&source).await,
+            "external-rotation",
+            "replace() must survive the in-flight refresh"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/openshell-sdk/src/refresh.rs
+++ b/crates/openshell-sdk/src/refresh.rs
@@ -257,7 +257,10 @@ impl TokenSource {
                                 Ok(state.token.clone())
                             }
                         }
-                        Err(err) => Err(SdkError::from(err).to_string()),
+                        // Store the bare refresh-error text; the single
+                        // `SdkError::auth` wrap happens where the shared
+                        // result is awaited below, so it isn't double-wrapped.
+                        Err(err) => Err(err.to_string()),
                     };
                     // Clear this attempt's slot so the next caller starts a
                     // fresh refresh. Epoch-guarded so a newer attempt is never

--- a/crates/openshell-sdk/src/refresh.rs
+++ b/crates/openshell-sdk/src/refresh.rs
@@ -1,0 +1,488 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! OIDC bearer-token refresh contract.
+//!
+//! The SDK never talks to a browser or any specific `IdP`. Callers that need
+//! the SDK to rotate an OIDC bearer mid-session implement [`Refresh`] and
+//! construct a [`TokenSource`] around it. Implementations live where the
+//! browser flow / token store / FFI callback belongs — in `openshell-cli`
+//! for the desktop browser flow, in `openshell-sdk-node` for a JS callback.
+//!
+//! The trait is intentionally minimal. Single-flight coalescing (one refresh
+//! in flight at a time, with all waiters sharing the result — success or
+//! failure) is the SDK's responsibility, not the implementer's; see
+//! [`TokenSource`].
+//!
+//! [`crate::OpenShellClient`] drives the source automatically: proactively
+//! before a unary request when the token is near expiry
+//! ([`TokenSource::current`]) and reactively on an `Unauthenticated` response
+//! ([`TokenSource::refresh_now`]), writing the new token into the
+//! interceptor's live bearer slot so rotation reaches an already-connected
+//! client. Language bindings can also drive the source directly.
+
+use crate::error::{Result, SdkError};
+use futures::future::{FutureExt, Shared};
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::{Mutex, RwLock};
+
+/// Errors a refresher can return.
+///
+/// Domain-specific, deliberately not coupled to `tonic`, `napi`, or any
+/// FFI-facing error type. The SDK maps these into [`SdkError::Auth`] before
+/// surfacing to callers.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum RefreshError {
+    /// Refresh failed but a retry might succeed (network blip, transient
+    /// `IdP` error).
+    Transient(String),
+    /// Refresh cannot succeed without user interaction (refresh token
+    /// expired, `IdP` revoked the session). Callers should not retry; they
+    /// should re-authenticate.
+    Terminal(String),
+}
+
+impl fmt::Display for RefreshError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Transient(msg) => write!(f, "transient refresh error: {msg}"),
+            Self::Terminal(msg) => write!(f, "terminal refresh error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for RefreshError {}
+
+impl From<RefreshError> for SdkError {
+    fn from(value: RefreshError) -> Self {
+        Self::auth(value.to_string())
+    }
+}
+
+/// A freshly minted access token + its absolute expiry.
+///
+/// `expires_at` is seconds since the Unix epoch. `None` means the token's
+/// expiry was not advertised — the SDK will not refresh it proactively but
+/// may refresh on demand if [`Refresh::refresh`] is called.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct RefreshedToken {
+    pub access_token: String,
+    pub expires_at: Option<u64>,
+}
+
+impl RefreshedToken {
+    pub fn new(access_token: impl Into<String>) -> Self {
+        Self {
+            access_token: access_token.into(),
+            expires_at: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_expires_at(mut self, expires_at: u64) -> Self {
+        self.expires_at = Some(expires_at);
+        self
+    }
+}
+
+/// Pluggable OIDC refresher.
+///
+/// Implementations should be cheap to clone and safe to call from any tokio
+/// task. They MUST NOT do their own single-flight coalescing — that's the
+/// SDK's job (see [`TokenSource`]).
+#[async_trait::async_trait]
+pub trait Refresh: Send + Sync + 'static {
+    /// Mint a fresh access token. Called by the SDK when it determines the
+    /// current token is near expiry (or has been explicitly invalidated).
+    async fn refresh(&self) -> std::result::Result<RefreshedToken, RefreshError>;
+}
+
+/// Mutable token state shared between the auth interceptor and the
+/// background refresh task.
+///
+/// `generation` increments on every successful refresh. Coalescing waiters
+/// compare the generation they observed before queueing against the current
+/// value to decide whether another caller already refreshed for them.
+#[derive(Debug)]
+struct TokenState {
+    token: String,
+    expires_at: Option<u64>,
+    generation: u64,
+}
+
+/// Cloneable outcome of a single refresh attempt, shared across all waiters
+/// that joined it. `Err` carries the rendered message (so the type stays
+/// `Clone` for [`Shared`]); the SDK remaps it to [`SdkError::Auth`].
+type RefreshOutcome = std::result::Result<String, String>;
+type RefreshFuture = Shared<Pin<Box<dyn Future<Output = RefreshOutcome> + Send>>>;
+
+/// In-flight refresh attempt, if any. `epoch` lets the leader that started an
+/// attempt clear it on completion without clobbering a newer attempt.
+#[derive(Default)]
+struct Flight {
+    epoch: u64,
+    future: Option<RefreshFuture>,
+}
+
+/// A bearer-token source with single-flight refresh coalescing.
+///
+/// Wraps a [`Refresh`] implementation and tracks the current token + its
+/// advertised expiry. The high-level [`crate::OpenShellClient`] drives it
+/// proactively (before requests, via [`TokenSource::current`]) and reactively
+/// (on `Unauthenticated`, via [`TokenSource::refresh_now`]); language bindings
+/// can also hand it out directly.
+///
+/// Single-flight: concurrent callers share one in-flight attempt and observe
+/// the same outcome — success *or* failure — so a failing `IdP` is hit once
+/// per attempt, not once per waiter.
+#[derive(Clone)]
+pub struct TokenSource {
+    state: Arc<RwLock<TokenState>>,
+    refresher: Arc<dyn Refresh>,
+    flight: Arc<Mutex<Flight>>,
+    /// Refresh `skew` before the advertised `expires_at`. Tokens without
+    /// `expires_at` are not auto-refreshed by [`TokenSource::current`].
+    skew: Duration,
+}
+
+impl TokenSource {
+    /// Construct a token source backed by `refresher`. Use this when wiring
+    /// an FFI callback or browser flow into the SDK.
+    pub fn new(initial: RefreshedToken, refresher: Arc<dyn Refresh>) -> Self {
+        Self {
+            state: Arc::new(RwLock::new(TokenState {
+                token: initial.access_token,
+                expires_at: initial.expires_at,
+                generation: 0,
+            })),
+            refresher,
+            flight: Arc::new(Mutex::new(Flight::default())),
+            skew: Duration::from_secs(60),
+        }
+    }
+
+    /// Current token without checking expiry. Used by the sync gRPC
+    /// interceptor, which can't await.
+    pub fn snapshot(&self) -> String {
+        self.state
+            .try_read()
+            .map(|s| s.token.clone())
+            .unwrap_or_default()
+    }
+
+    /// Async-fetch the current token, refreshing if it's within `skew` of
+    /// expiry. Single-flight: concurrent callers share one refresh.
+    ///
+    /// This is the *proactive* path. Tokens with no advertised `expires_at`
+    /// are returned as-is (never proactively refreshed).
+    pub async fn current(&self) -> Result<String> {
+        let (generation, near_expiry) = {
+            let state = self.state.read().await;
+            (state.generation, is_near_expiry(&state, self.skew))
+        };
+        if !near_expiry {
+            return Ok(self.state.read().await.token.clone());
+        }
+        self.coalesced_refresh(generation).await
+    }
+
+    /// Force a refresh regardless of expiry. Used on `Unauthenticated`
+    /// responses from the gateway (token revoked / rejected even though it
+    /// still looks valid).
+    ///
+    /// Unlike [`TokenSource::current`] this never short-circuits on expiry:
+    /// it always performs a refresh unless a *concurrent* caller's refresh
+    /// already advanced the generation while this call was queued.
+    pub async fn refresh_now(&self) -> Result<String> {
+        let generation = self.state.read().await.generation;
+        self.coalesced_refresh(generation).await
+    }
+
+    /// Shared refresh primitive. `expected_generation` is the generation the
+    /// caller observed before queueing; if the current generation already
+    /// moved past it, another caller refreshed and we return that token
+    /// without invoking [`Refresh::refresh`] again.
+    async fn coalesced_refresh(&self, expected_generation: u64) -> Result<String> {
+        let (shared, is_leader, epoch) = {
+            let mut flight = self.flight.lock().await;
+            // Re-check under the flight lock: a refresh may have completed
+            // between our generation read and acquiring this lock.
+            {
+                let state = self.state.read().await;
+                if state.generation != expected_generation {
+                    return Ok(state.token.clone());
+                }
+            }
+            if let Some(existing) = flight.future.as_ref() {
+                // Join the attempt already in flight.
+                (existing.clone(), false, flight.epoch)
+            } else {
+                // Become the leader for a fresh attempt.
+                let refresher = Arc::clone(&self.refresher);
+                let state = Arc::clone(&self.state);
+                let future: RefreshFuture = async move {
+                    match refresher.refresh().await {
+                        Ok(token) => {
+                            let mut state = state.write().await;
+                            state.token.clone_from(&token.access_token);
+                            state.expires_at = token.expires_at;
+                            state.generation = state.generation.wrapping_add(1);
+                            Ok(token.access_token)
+                        }
+                        Err(err) => Err(SdkError::from(err).to_string()),
+                    }
+                }
+                .boxed()
+                .shared();
+                flight.epoch = flight.epoch.wrapping_add(1);
+                flight.future = Some(future.clone());
+                (future, true, flight.epoch)
+            }
+        };
+
+        let outcome = shared.await;
+
+        // Only the leader clears the slot, and only if no newer attempt has
+        // replaced it, so a fresh attempt can start once this one resolves.
+        if is_leader {
+            let mut flight = self.flight.lock().await;
+            if flight.epoch == epoch {
+                flight.future = None;
+            }
+        }
+
+        outcome.map_err(SdkError::auth)
+    }
+
+    /// Replace the current token without invoking the refresher.
+    ///
+    /// Used by callers that manage refresh externally (e.g. the napi
+    /// binding's JS-side timer) or for testing. Advances the generation so
+    /// any queued coalescing waiters observe the new token.
+    pub async fn replace(&self, token: RefreshedToken) {
+        let mut state = self.state.write().await;
+        state.token = token.access_token;
+        state.expires_at = token.expires_at;
+        state.generation = state.generation.wrapping_add(1);
+    }
+}
+
+/// Whether `state`'s token is within `skew` of its advertised expiry. Tokens
+/// without an advertised expiry are never near expiry.
+fn is_near_expiry(state: &TokenState, skew: Duration) -> bool {
+    let Some(expires_at) = state.expires_at else {
+        return false;
+    };
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    now + skew.as_secs() >= expires_at
+}
+
+impl fmt::Debug for TokenSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TokenSource")
+            .field("skew", &self.skew)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingRefresher {
+        calls: Arc<AtomicUsize>,
+        delay: Duration,
+    }
+
+    #[async_trait::async_trait]
+    impl Refresh for CountingRefresher {
+        async fn refresh(&self) -> std::result::Result<RefreshedToken, RefreshError> {
+            tokio::time::sleep(self.delay).await;
+            let n = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            Ok(RefreshedToken::new(format!("token-{n}")).with_expires_at(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs()
+                    + 3600,
+            ))
+        }
+    }
+
+    /// Refresher that blocks inside [`Refresh::refresh`] until the test
+    /// releases it, so we can deterministically force multiple callers to be
+    /// in flight simultaneously. Signals `entered` once the leader is inside.
+    struct GatedRefresher {
+        calls: Arc<AtomicUsize>,
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+        fail: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl Refresh for GatedRefresher {
+        async fn refresh(&self) -> std::result::Result<RefreshedToken, RefreshError> {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            self.entered.notify_one();
+            self.release.notified().await;
+            if self.fail {
+                Err(RefreshError::Transient("idp unavailable".to_string()))
+            } else {
+                Ok(RefreshedToken::new(format!("token-{n}")).with_expires_at(
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs()
+                        + 3600,
+                ))
+            }
+        }
+    }
+
+    /// Drive one leader into the refresher, then queue `followers` more
+    /// callers that must join the in-flight attempt rather than start their
+    /// own. Returns the refresher call count and per-caller outcomes.
+    async fn run_coalesced(fail: bool) -> (usize, Vec<Result<String>>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let refresher = Arc::new(GatedRefresher {
+            calls: Arc::clone(&calls),
+            entered: Arc::clone(&entered),
+            release: Arc::clone(&release),
+            fail,
+        });
+        let source = TokenSource::new(RefreshedToken::new("initial").with_expires_at(0), refresher);
+
+        let leader = {
+            let src = source.clone();
+            tokio::spawn(async move { src.refresh_now().await })
+        };
+        // Wait until the leader is blocked inside the refresher.
+        entered.notified().await;
+
+        let followers: Vec<_> = (0..4)
+            .map(|_| {
+                let src = source.clone();
+                tokio::spawn(async move { src.refresh_now().await })
+            })
+            .collect();
+        // Let the followers reach the shared in-flight future before release.
+        for _ in 0..16 {
+            tokio::task::yield_now().await;
+        }
+        release.notify_waiters();
+
+        let mut outcomes = vec![leader.await.unwrap()];
+        for f in followers {
+            outcomes.push(f.await.unwrap());
+        }
+        (calls.load(Ordering::SeqCst), outcomes)
+    }
+
+    #[tokio::test]
+    async fn concurrent_callers_share_one_refresh() {
+        let (calls, outcomes) = run_coalesced(false).await;
+        assert_eq!(
+            calls, 1,
+            "single-flight should collapse 5 concurrent calls into 1 refresh"
+        );
+        for outcome in &outcomes {
+            assert_eq!(outcome.as_ref().unwrap(), "token-1");
+        }
+    }
+
+    #[tokio::test]
+    async fn current_returns_cached_when_not_near_expiry() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::clone(&calls),
+            delay: Duration::from_millis(0),
+        });
+        let future = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+        let source = TokenSource::new(
+            RefreshedToken::new("fresh").with_expires_at(future),
+            refresher,
+        );
+
+        let token = source.current().await.unwrap();
+        assert_eq!(token, "fresh");
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn current_refreshes_when_within_skew() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::clone(&calls),
+            delay: Duration::from_millis(0),
+        });
+        let near = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 5;
+        let source = TokenSource::new(
+            RefreshedToken::new("stale").with_expires_at(near),
+            refresher,
+        );
+
+        let token = source.current().await.unwrap();
+        assert_eq!(token, "token-1");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn refresh_now_forces_even_for_unexpired_token() {
+        // A token whose advertised expiry is far in the future. `current()`
+        // would short-circuit, but `refresh_now()` must still refresh — this
+        // is the revoked-but-unexpired recovery path.
+        let calls = Arc::new(AtomicUsize::new(0));
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::clone(&calls),
+            delay: Duration::from_millis(0),
+        });
+        let far_future = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+        let source = TokenSource::new(
+            RefreshedToken::new("revoked").with_expires_at(far_future),
+            refresher,
+        );
+
+        let token = source.refresh_now().await.unwrap();
+        assert_eq!(token, "token-1", "forced refresh must mint a new token");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(source.snapshot(), "token-1", "slot must observe new token");
+    }
+
+    #[tokio::test]
+    async fn concurrent_forced_refresh_shares_one_failure() {
+        // A failing IdP must be hit once per attempt, not once per waiter.
+        let (calls, outcomes) = run_coalesced(true).await;
+        assert_eq!(
+            calls, 1,
+            "single-flight should collapse 5 concurrent failed calls into 1 refresh"
+        );
+        assert_eq!(outcomes.len(), 5);
+        for outcome in &outcomes {
+            assert!(outcome.is_err(), "every waiter should observe the failure");
+        }
+    }
+}

--- a/crates/openshell-sdk/src/refresh.rs
+++ b/crates/openshell-sdk/src/refresh.rs
@@ -69,11 +69,21 @@ impl From<RefreshError> for SdkError {
 /// `expires_at` is seconds since the Unix epoch. `None` means the token's
 /// expiry was not advertised — the SDK will not refresh it proactively but
 /// may refresh on demand if [`Refresh::refresh`] is called.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub struct RefreshedToken {
     pub access_token: String,
     pub expires_at: Option<u64>,
+}
+
+impl fmt::Debug for RefreshedToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // `access_token` is a bearer secret; omit it so a stray `{:?}` or a
+        // containing struct's derived `Debug` cannot write it to logs.
+        f.debug_struct("RefreshedToken")
+            .field("expires_at", &self.expires_at)
+            .finish_non_exhaustive()
+    }
 }
 
 impl RefreshedToken {
@@ -208,8 +218,12 @@ impl TokenSource {
     /// caller observed before queueing; if the current generation already
     /// moved past it, another caller refreshed and we return that token
     /// without invoking [`Refresh::refresh`] again.
+    // `map_or_else` (what `clippy::option_if_let_else` suggests) can't take
+    // `&mut flight` in the None arm to publish the new attempt, so keep the
+    // explicit `if let`/`else`.
+    #[allow(clippy::option_if_let_else)]
     async fn coalesced_refresh(&self, expected_generation: u64) -> Result<String> {
-        let (shared, is_leader, epoch) = {
+        let shared = {
             let mut flight = self.flight.lock().await;
             // Re-check under the flight lock: a refresh may have completed
             // between our generation read and acquiring this lock.
@@ -221,13 +235,19 @@ impl TokenSource {
             }
             if let Some(existing) = flight.future.as_ref() {
                 // Join the attempt already in flight.
-                (existing.clone(), false, flight.epoch)
+                existing.clone()
             } else {
-                // Become the leader for a fresh attempt.
+                // Become the leader for a fresh attempt. The attempt clears its
+                // own slot on completion (below) rather than relying on the
+                // leader's post-await code, so cleanup is cancellation-safe: a
+                // dropped leader can't strand a completed future in the slot and
+                // pin later callers to a stale token.
                 let refresher = Arc::clone(&self.refresher);
                 let state = Arc::clone(&self.state);
+                let flight_slot = Arc::clone(&self.flight);
+                let epoch = flight.epoch.wrapping_add(1);
                 let future: RefreshFuture = async move {
-                    match refresher.refresh().await {
+                    let outcome = match refresher.refresh().await {
                         Ok(token) => {
                             let mut state = state.write().await;
                             state.token.clone_from(&token.access_token);
@@ -236,28 +256,29 @@ impl TokenSource {
                             Ok(token.access_token)
                         }
                         Err(err) => Err(SdkError::from(err).to_string()),
+                    };
+                    // Clear this attempt's slot so the next caller starts a
+                    // fresh refresh. Epoch-guarded so a newer attempt is never
+                    // clobbered. Runs inside the single shared computation, so
+                    // it fires exactly once regardless of which waiter drives it
+                    // to completion or whether the leader was dropped.
+                    {
+                        let mut flight = flight_slot.lock().await;
+                        if flight.epoch == epoch {
+                            flight.future = None;
+                        }
                     }
+                    outcome
                 }
                 .boxed()
                 .shared();
-                flight.epoch = flight.epoch.wrapping_add(1);
+                flight.epoch = epoch;
                 flight.future = Some(future.clone());
-                (future, true, flight.epoch)
+                future
             }
         };
 
-        let outcome = shared.await;
-
-        // Only the leader clears the slot, and only if no newer attempt has
-        // replaced it, so a fresh attempt can start once this one resolves.
-        if is_leader {
-            let mut flight = self.flight.lock().await;
-            if flight.epoch == epoch {
-                flight.future = None;
-            }
-        }
-
-        outcome.map_err(SdkError::auth)
+        shared.await.map_err(SdkError::auth)
     }
 
     /// Replace the current token without invoking the refresher.
@@ -388,6 +409,67 @@ mod tests {
             outcomes.push(f.await.unwrap());
         }
         (calls.load(Ordering::SeqCst), outcomes)
+    }
+
+    #[tokio::test]
+    async fn refresh_clears_slot_when_leader_is_cancelled() {
+        // Regression: the in-flight slot must be cleared by the shared refresh
+        // computation, not by the leader's post-await code. If only the leader
+        // cleared it, cancelling the leader would strand a completed future in
+        // the slot and pin every later `refresh_now()` to that stale token.
+        let calls = Arc::new(AtomicUsize::new(0));
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let refresher = Arc::new(GatedRefresher {
+            calls: Arc::clone(&calls),
+            entered: Arc::clone(&entered),
+            release: Arc::clone(&release),
+            fail: false,
+        });
+        let source = TokenSource::new(RefreshedToken::new("initial").with_expires_at(0), refresher);
+
+        // Leader enters the refresher, then is cancelled before it completes.
+        let leader = {
+            let src = source.clone();
+            tokio::spawn(async move { src.refresh_now().await })
+        };
+        entered.notified().await;
+        leader.abort();
+        let _ = leader.await;
+
+        // A follower joins and drives the in-flight attempt to completion.
+        let follower = {
+            let src = source.clone();
+            tokio::spawn(async move { src.refresh_now().await })
+        };
+        for _ in 0..16 {
+            tokio::task::yield_now().await;
+        }
+        release.notify_waiters();
+        assert_eq!(follower.await.unwrap().unwrap(), "token-1");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // The completed attempt must have cleared the slot, so the next refresh
+        // starts a new attempt instead of re-joining the stale completed one.
+        let next = {
+            let src = source.clone();
+            tokio::spawn(async move { src.refresh_now().await })
+        };
+        entered.notified().await;
+        for _ in 0..16 {
+            tokio::task::yield_now().await;
+        }
+        release.notify_waiters();
+        assert_eq!(next.await.unwrap().unwrap(), "token-2");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn debug_omits_access_token() {
+        let token = RefreshedToken::new("super-secret-value").with_expires_at(123);
+        let rendered = format!("{token:?}");
+        assert!(!rendered.contains("super-secret-value"));
+        assert!(rendered.contains("expires_at"));
     }
 
     #[tokio::test]

--- a/crates/openshell-sdk/src/refresh.rs
+++ b/crates/openshell-sdk/src/refresh.rs
@@ -35,7 +35,7 @@ use tokio::sync::{Mutex, RwLock};
 /// Domain-specific, deliberately not coupled to `tonic`, `napi`, or any
 /// FFI-facing error type. The SDK maps these into [`SdkError::Auth`] before
 /// surfacing to callers.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum RefreshError {
     /// Refresh failed but a retry might succeed (network blip, transient
@@ -60,7 +60,8 @@ impl std::error::Error for RefreshError {}
 
 impl From<RefreshError> for SdkError {
     fn from(value: RefreshError) -> Self {
-        Self::auth(value.to_string())
+        let retryable = matches!(value, RefreshError::Transient(_));
+        Self::auth_retryable(value.to_string(), retryable)
     }
 }
 
@@ -127,9 +128,10 @@ struct TokenState {
 }
 
 /// Cloneable outcome of a single refresh attempt, shared across all waiters
-/// that joined it. `Err` carries the rendered message (so the type stays
-/// `Clone` for [`Shared`]); the SDK remaps it to [`SdkError::Auth`].
-type RefreshOutcome = std::result::Result<String, String>;
+/// that joined it. `Err` carries the [`RefreshError`] itself (kept `Clone`
+/// for [`Shared`]) so its Transient/Terminal kind survives to the await site,
+/// where it maps to [`SdkError::Auth`] with `retryable` set accordingly.
+type RefreshOutcome = std::result::Result<String, RefreshError>;
 type RefreshFuture = Shared<Pin<Box<dyn Future<Output = RefreshOutcome> + Send>>>;
 
 /// In-flight refresh attempt, if any. `epoch` lets the leader that started an
@@ -257,10 +259,10 @@ impl TokenSource {
                                 Ok(state.token.clone())
                             }
                         }
-                        // Store the bare refresh-error text; the single
-                        // `SdkError::auth` wrap happens where the shared
-                        // result is awaited below, so it isn't double-wrapped.
-                        Err(err) => Err(err.to_string()),
+                        // Carry the `RefreshError` itself so its
+                        // Transient/Terminal kind survives; the single
+                        // `SdkError` wrap happens at the await site below.
+                        Err(err) => Err(err),
                     };
                     // Clear this attempt's slot so the next caller starts a
                     // fresh refresh. Epoch-guarded so a newer attempt is never
@@ -283,7 +285,7 @@ impl TokenSource {
             }
         };
 
-        shared.await.map_err(SdkError::auth)
+        shared.await.map_err(SdkError::from)
     }
 
     /// Replace the current token without invoking the refresher.
@@ -634,5 +636,46 @@ mod tests {
         for outcome in &outcomes {
             assert!(outcome.is_err(), "every waiter should observe the failure");
         }
+    }
+
+    #[test]
+    fn refresh_error_maps_to_classified_auth() {
+        // The Transient/Terminal split must survive conversion into `SdkError`
+        // so consumers can tell a retryable blip from a dead session, and the
+        // message must be wrapped exactly once.
+        let transient = SdkError::from(RefreshError::Transient("blip".into()));
+        assert!(transient.retryable(), "transient refresh is retryable");
+        assert_eq!(
+            transient.to_string(),
+            "auth error: transient refresh error: blip",
+            "single wrap, no doubled `auth error:` prefix"
+        );
+
+        let terminal = SdkError::from(RefreshError::Terminal("revoked".into()));
+        assert!(!terminal.retryable(), "terminal refresh needs re-auth");
+        assert_eq!(terminal.code(), "auth");
+    }
+
+    #[tokio::test]
+    async fn terminal_refresh_surfaces_non_retryable() {
+        // End-to-end: a Terminal error from the refresher reaches the caller as
+        // a non-retryable auth error through the shared single-flight path.
+        struct TerminalRefresher;
+        #[async_trait::async_trait]
+        impl Refresh for TerminalRefresher {
+            async fn refresh(&self) -> std::result::Result<RefreshedToken, RefreshError> {
+                Err(RefreshError::Terminal("session revoked".into()))
+            }
+        }
+        let source = TokenSource::new(
+            RefreshedToken::new("initial").with_expires_at(0),
+            Arc::new(TerminalRefresher),
+        );
+        let err = source.refresh_now().await.expect_err("refresh must fail");
+        assert!(!err.retryable(), "terminal failure is not retryable");
+        assert!(
+            err.to_string()
+                .contains("terminal refresh error: session revoked")
+        );
     }
 }

--- a/crates/openshell-sdk/src/transport.rs
+++ b/crates/openshell-sdk/src/transport.rs
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! gRPC transport stack: channel construction and the insecure-TLS connector.
+//!
+//! mTLS is intentionally out of scope here. Gateways that require client
+//! certificates are handled by `openshell-cli`'s legacy path until the auth
+//! method is retired.
+
+use crate::config::{AuthConfig, ClientConfig};
+use crate::edge_tunnel;
+use crate::error::{Result, SdkError};
+use rustls::{
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    pki_types::{CertificateDer, ServerName, UnixTime},
+};
+use std::collections::HashMap;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint};
+use tracing::debug;
+
+/// Standard endpoint settings used by every dialed connection.
+///
+/// Centralizes timeouts and HTTP/2 keepalive so behavior is consistent across
+/// transport branches. Returns an `Endpoint` ready for `connect()` /
+/// `connect_with_connector()`.
+fn standard_endpoint(uri: String) -> Result<Endpoint> {
+    Endpoint::from_shared(uri)
+        .map(|ep| {
+            ep.connect_timeout(Duration::from_secs(10))
+                .http2_adaptive_window(true)
+                .http2_keep_alive_interval(Duration::from_secs(10))
+                .keep_alive_while_idle(true)
+        })
+        .map_err(|e| SdkError::invalid_config(format!("invalid gateway URL: {e}")))
+}
+
+// ── Edge tunnel registry ─────────────────────────────────────────────
+// Each distinct edge-authenticated gateway gets its own local proxy
+// instead of reusing the first gateway touched in the current process.
+static EDGE_TUNNEL_ADDRS: OnceLock<Mutex<HashMap<(String, String), SocketAddr>>> = OnceLock::new();
+
+/// Look up (or start) the local tunnel proxy for an edge-authenticated
+/// gateway. Subsequent calls with the same `(server, token)` reuse the
+/// existing proxy.
+async fn edge_tunnel_addr(server: &str, token: &str) -> Result<SocketAddr> {
+    let key = (server.to_string(), token.to_string());
+    let registry = EDGE_TUNNEL_ADDRS.get_or_init(|| Mutex::new(HashMap::new()));
+
+    {
+        let addrs = registry.lock().await;
+        if let Some(addr) = addrs.get(&key).copied() {
+            return Ok(addr);
+        }
+    }
+
+    let proxy = edge_tunnel::start_tunnel_proxy(server, token).await?;
+    debug!(
+        local_addr = %proxy.local_addr,
+        server,
+        "edge tunnel proxy started, routing gRPC through local proxy"
+    );
+
+    let mut addrs = registry.lock().await;
+    Ok(*addrs.entry(key).or_insert(proxy.local_addr))
+}
+
+// ── Channel construction ─────────────────────────────────────────────
+
+/// Open a gRPC channel to the gateway described by `config`.
+///
+/// Routing is determined by `gateway` scheme + `auth` variant +
+/// `insecure_skip_verify`. Reference today's CLI implementation in
+/// `openshell-cli/src/tls.rs::build_channel` (lines 219–308) for behavior
+/// the SDK needs to preserve.
+///
+/// **Branch table:**
+///
+/// | `gateway` scheme | `auth` | `insecure_skip_verify` | TLS handling |
+/// |------------------|--------|------------------------|-------------|
+/// | `http://` | (any)  | (any) | plaintext, ignore tls |
+/// | `https://` | `Some(EdgeJwt)` | (any) | tunnel proxy + plaintext to local proxy |
+/// | `https://` | (any) | `true` | `InsecureTlsConnector`, no verification |
+/// | `https://` | `Some(Oidc)` or `None` | `false` | tonic TLS, pin `ca_cert` if set, system roots otherwise |
+pub async fn build_channel(config: &ClientConfig) -> Result<Channel> {
+    let gateway = &config.gateway;
+
+    // Branch 1 — plaintext.
+    // Reference: cli/tls.rs:220-228 (http:// branch).
+    if gateway.starts_with("http://") {
+        return standard_endpoint(gateway.clone())?
+            .connect()
+            .await
+            .map_err(|e| SdkError::connect(format!("{e}")));
+    }
+
+    if !gateway.starts_with("https://") {
+        return Err(SdkError::invalid_config(format!(
+            "gateway URL must start with http:// or https://: {gateway}"
+        )));
+    }
+
+    // Branch 2 — Cloudflare Access edge JWT: tunnel proxy + plaintext-to-local.
+    // Reference: cli/tls.rs:233-249 (https:// + edge_token branch). Use
+    // `edge_tunnel_addr(gateway, token).await?` to get the local proxy
+    // address, then `standard_endpoint(format!("http://{local_addr}"))?.connect()`.
+    if let Some(AuthConfig::EdgeJwt(token)) = &config.auth {
+        let local_addr = edge_tunnel_addr(gateway, token).await?;
+        return standard_endpoint(format!("http://{local_addr}"))?
+            .connect()
+            .await
+            .map_err(|e| SdkError::connect(format!("{e}")));
+    }
+
+    // Branch 3 — insecure TLS (skip cert verification).
+    // Reference: cli/tls.rs:251-268 (gateway_insecure branch). Build the
+    // insecure rustls config, wrap it in `InsecureTlsConnector`, swap the
+    // gateway scheme to http:// (so tonic doesn't double-layer TLS), and
+    // call `endpoint.connect_with_connector(connector)`.
+    if config.insecure_skip_verify {
+        tracing::warn!("TLS certificate verification is disabled — do not use in production");
+        let rustls_config = build_insecure_rustls_config()?;
+        let tls_connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(rustls_config));
+        let connector = InsecureTlsConnector { tls_connector };
+        let http_uri = gateway.replacen("https://", "http://", 1);
+        return standard_endpoint(http_uri)?
+            .connect_with_connector(connector)
+            .await
+            .map_err(|e| SdkError::connect(format!("{e}")));
+    }
+
+    // Branch 4 — anonymous TLS or OIDC bearer over HTTPS.
+    // Reference: cli/tls.rs:270-307 (the `oidc_token` and final mTLS
+    // branches collapsed). Build a `ClientTlsConfig`:
+    //   - if `config.ca_cert` is `Some(pem)`, pin it via `.ca_certificate(...)`
+    //   - else fall back to `.with_enabled_roots()` (system roots)
+    // Then `endpoint.tls_config(tls_config)?.connect()`.
+    //
+    // The OIDC bearer header is added by the gRPC interceptor at request
+    // time, not here — `build_channel` only owns the TLS layer.
+
+    let tls_config = config.ca_cert.as_ref().map_or_else(
+        || ClientTlsConfig::new().with_enabled_roots(),
+        |ca_cert| ClientTlsConfig::new().ca_certificate(Certificate::from_pem(ca_cert)),
+    );
+    standard_endpoint(gateway.clone())?
+        .tls_config(tls_config)
+        .map_err(|e| SdkError::tls(format!("{e}")))?
+        .connect()
+        .await
+        .map_err(|e| SdkError::connect(format!("{e}")))
+}
+
+/// rustls verifier that accepts any server certificate.
+///
+/// Used only when the caller explicitly opts into
+/// [`ClientConfig::insecure_skip_verify`]. Do not use in production.
+///
+/// [`ClientConfig::insecure_skip_verify`]: crate::config::ClientConfig::insecure_skip_verify
+#[derive(Debug)]
+pub struct InsecureServerCertVerifier;
+
+impl ServerCertVerifier for InsecureServerCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> std::result::Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+/// rustls client config that disables server certificate verification.
+///
+/// Pairs with [`InsecureTlsConnector`] for transports that need to skip
+/// verification (development, debug). Returns `Result` for symmetry with
+/// future verifying variants; the current implementation cannot fail.
+pub fn build_insecure_rustls_config() -> Result<rustls::ClientConfig> {
+    Ok(rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(std::sync::Arc::new(InsecureServerCertVerifier))
+        .with_no_client_auth())
+}
+
+/// `tower::Service` connector that performs TLS using the supplied rustls
+/// connector, bypassing tonic's built-in TLS layering.
+///
+/// Used to plumb [`InsecureServerCertVerifier`]-backed configs into a tonic
+/// `Endpoint` via `connect_with_connector`.
+#[derive(Clone)]
+pub struct InsecureTlsConnector {
+    /// Inner rustls connector configured by the caller.
+    pub tls_connector: tokio_rustls::TlsConnector,
+}
+
+impl tower::Service<hyper::Uri> for InsecureTlsConnector {
+    type Response = hyper_util::rt::TokioIo<tokio_rustls::client::TlsStream<tokio::net::TcpStream>>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+    type Future = std::pin::Pin<
+        Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::result::Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, uri: hyper::Uri) -> Self::Future {
+        let tls_connector = self.tls_connector.clone();
+        Box::pin(async move {
+            let host = uri.host().unwrap_or("localhost").to_string();
+            let port = uri.port_u16().unwrap_or(443);
+            let addr = format!("{host}:{port}");
+            let tcp = tokio::net::TcpStream::connect(addr).await?;
+            let server_name = ServerName::try_from(host)?;
+            let tls_stream = tls_connector.connect(server_name, tcp).await?;
+            Ok(hyper_util::rt::TokioIo::new(tls_stream))
+        })
+    }
+}

--- a/crates/openshell-sdk/src/transport.rs
+++ b/crates/openshell-sdk/src/transport.rs
@@ -74,9 +74,7 @@ async fn edge_tunnel_addr(server: &str, token: &str) -> Result<SocketAddr> {
 /// Open a gRPC channel to the gateway described by `config`.
 ///
 /// Routing is determined by `gateway` scheme + `auth` variant +
-/// `insecure_skip_verify`. Reference today's CLI implementation in
-/// `openshell-cli/src/tls.rs::build_channel` (lines 219–308) for behavior
-/// the SDK needs to preserve.
+/// `insecure_skip_verify`.
 ///
 /// **Branch table:**
 ///
@@ -90,7 +88,6 @@ pub async fn build_channel(config: &ClientConfig) -> Result<Channel> {
     let gateway = &config.gateway;
 
     // Branch 1 — plaintext.
-    // Reference: cli/tls.rs:220-228 (http:// branch).
     if gateway.starts_with("http://") {
         return standard_endpoint(gateway.clone())?
             .connect()
@@ -105,9 +102,6 @@ pub async fn build_channel(config: &ClientConfig) -> Result<Channel> {
     }
 
     // Branch 2 — Cloudflare Access edge JWT: tunnel proxy + plaintext-to-local.
-    // Reference: cli/tls.rs:233-249 (https:// + edge_token branch). Use
-    // `edge_tunnel_addr(gateway, token).await?` to get the local proxy
-    // address, then `standard_endpoint(format!("http://{local_addr}"))?.connect()`.
     if let Some(AuthConfig::EdgeJwt(token)) = &config.auth {
         let local_addr = edge_tunnel_addr(gateway, token).await?;
         return standard_endpoint(format!("http://{local_addr}"))?
@@ -116,11 +110,9 @@ pub async fn build_channel(config: &ClientConfig) -> Result<Channel> {
             .map_err(|e| SdkError::connect(format!("{e}")));
     }
 
-    // Branch 3 — insecure TLS (skip cert verification).
-    // Reference: cli/tls.rs:251-268 (gateway_insecure branch). Build the
-    // insecure rustls config, wrap it in `InsecureTlsConnector`, swap the
-    // gateway scheme to http:// (so tonic doesn't double-layer TLS), and
-    // call `endpoint.connect_with_connector(connector)`.
+    // Branch 3 — insecure TLS (skip cert verification): swap the scheme to
+    // http:// so tonic doesn't double-layer TLS, then connect through the
+    // insecure rustls connector.
     if config.insecure_skip_verify {
         tracing::warn!("TLS certificate verification is disabled — do not use in production");
         let rustls_config = build_insecure_rustls_config()?;
@@ -133,15 +125,10 @@ pub async fn build_channel(config: &ClientConfig) -> Result<Channel> {
             .map_err(|e| SdkError::connect(format!("{e}")));
     }
 
-    // Branch 4 — anonymous TLS or OIDC bearer over HTTPS.
-    // Reference: cli/tls.rs:270-307 (the `oidc_token` and final mTLS
-    // branches collapsed). Build a `ClientTlsConfig`:
-    //   - if `config.ca_cert` is `Some(pem)`, pin it via `.ca_certificate(...)`
-    //   - else fall back to `.with_enabled_roots()` (system roots)
-    // Then `endpoint.tls_config(tls_config)?.connect()`.
-    //
-    // The OIDC bearer header is added by the gRPC interceptor at request
-    // time, not here — `build_channel` only owns the TLS layer.
+    // Branch 4 — anonymous TLS or OIDC bearer over HTTPS: pin `ca_cert` when
+    // supplied, otherwise fall back to system roots. The OIDC bearer header
+    // is added by the gRPC interceptor at request time, not here —
+    // `build_channel` only owns the TLS layer.
 
     let tls_config = config.ca_cert.as_ref().map_or_else(
         || ClientTlsConfig::new().with_enabled_roots(),

--- a/crates/openshell-sdk/src/types.rs
+++ b/crates/openshell-sdk/src/types.rs
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Curated public types for the high-level SDK surface.
+//!
+//! These types intentionally diverge from the raw protobuf shapes so future
+//! language bindings (TypeScript via napi, Python via `PyO3`) can render them
+//! idiomatically. In particular, enum-valued fields use Rust enums that map
+//! to string literals in TypeScript rather than numeric proto enums; nested
+//! `Option<...>` chains from proto are flattened where one of the wrappers
+//! is structurally meaningless.
+//!
+//! The raw proto clients are still accessible via [`crate::raw`] as an
+//! escape hatch for callers who need fields not exposed here.
+
+use openshell_core::proto;
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// Gateway health snapshot.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct Health {
+    pub status: ServiceStatus,
+    pub version: String,
+}
+
+/// Coarse gateway service status.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ServiceStatus {
+    Unspecified,
+    Healthy,
+    Degraded,
+    Unhealthy,
+}
+
+impl From<proto::ServiceStatus> for ServiceStatus {
+    fn from(value: proto::ServiceStatus) -> Self {
+        match value {
+            proto::ServiceStatus::Healthy => Self::Healthy,
+            proto::ServiceStatus::Degraded => Self::Degraded,
+            proto::ServiceStatus::Unhealthy => Self::Unhealthy,
+            proto::ServiceStatus::Unspecified => Self::Unspecified,
+        }
+    }
+}
+
+impl From<i32> for ServiceStatus {
+    fn from(value: i32) -> Self {
+        proto::ServiceStatus::try_from(value).map_or(Self::Unspecified, Self::from)
+    }
+}
+
+/// High-level sandbox lifecycle phase.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum SandboxPhase {
+    Unspecified,
+    Provisioning,
+    Ready,
+    Error,
+    Deleting,
+    Unknown,
+}
+
+impl From<proto::SandboxPhase> for SandboxPhase {
+    fn from(value: proto::SandboxPhase) -> Self {
+        match value {
+            proto::SandboxPhase::Unspecified => Self::Unspecified,
+            proto::SandboxPhase::Provisioning => Self::Provisioning,
+            proto::SandboxPhase::Ready => Self::Ready,
+            proto::SandboxPhase::Error => Self::Error,
+            proto::SandboxPhase::Deleting => Self::Deleting,
+            proto::SandboxPhase::Unknown => Self::Unknown,
+        }
+    }
+}
+
+impl From<i32> for SandboxPhase {
+    fn from(value: i32) -> Self {
+        proto::SandboxPhase::try_from(value).map_or(Self::Unspecified, Self::from)
+    }
+}
+
+/// Caller intent for a new sandbox.
+///
+/// Only the most commonly used fields are exposed. Callers that need the
+/// full proto surface (volume claim templates, runtime classes, struct
+/// resources, etc.) should drop down to [`crate::raw`].
+#[derive(Clone, Debug, Default)]
+pub struct SandboxSpec {
+    /// Optional user-supplied sandbox name. When empty the server generates one.
+    pub name: Option<String>,
+    /// Container image reference (e.g. `ghcr.io/nvidia/openshell-community/sandboxes/python:latest`).
+    pub image: Option<String>,
+    /// Labels attached to the sandbox.
+    pub labels: HashMap<String, String>,
+    /// Environment variables injected into the sandbox runtime.
+    pub environment: HashMap<String, String>,
+    /// Provider names to attach.
+    pub providers: Vec<String>,
+    /// Request a GPU. Driver-specific device selection is configured via
+    /// driver config on the raw proto surface (see [`crate::raw`]).
+    pub gpu: bool,
+}
+
+/// Reference to a sandbox owned by the gateway.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct SandboxRef {
+    pub id: String,
+    pub name: String,
+    pub phase: SandboxPhase,
+    pub labels: HashMap<String, String>,
+    pub resource_version: u64,
+}
+
+impl SandboxRef {
+    pub(crate) fn from_proto(sandbox: proto::Sandbox) -> Self {
+        let phase = sandbox.phase().into();
+        let meta = sandbox.metadata.unwrap_or_default();
+        Self {
+            id: meta.id,
+            name: meta.name,
+            phase,
+            labels: meta.labels,
+            resource_version: meta.resource_version,
+        }
+    }
+}
+
+/// Options for listing sandboxes.
+#[derive(Clone, Debug, Default)]
+pub struct ListOptions {
+    /// Maximum sandboxes to return. `0` defers to the server default.
+    pub limit: u32,
+    /// Offset into the result list.
+    pub offset: u32,
+    /// Optional Kubernetes-style label selector (e.g. `env=prod,team=core`).
+    pub label_selector: Option<String>,
+}
+
+/// Options for [`crate::client::OpenShellClient::exec`].
+#[derive(Clone, Debug, Default)]
+pub struct ExecOptions {
+    /// Working directory inside the sandbox.
+    pub workdir: Option<String>,
+    /// Environment overrides for the exec.
+    pub environment: HashMap<String, String>,
+    /// Optional command timeout. `None` lets the gateway choose.
+    pub timeout: Option<Duration>,
+    /// Optional stdin payload.
+    pub stdin: Option<Vec<u8>>,
+}
+
+/// Result of a non-streaming exec call.
+///
+/// `stdout` and `stderr` are buffered to the end of the command. Use the
+/// raw streaming RPC ([`crate::raw`]) for long-running output.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct ExecResult {
+    pub exit_code: i32,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}

--- a/crates/openshell-sdk/tests/client_mock.rs
+++ b/crates/openshell-sdk/tests/client_mock.rs
@@ -878,3 +878,58 @@ async fn unauthenticated_without_refresher_surfaces_error() {
         "exactly one attempt; no retry without a refresher"
     );
 }
+
+/// Regression (P1): raw RPCs do not drive refresh. A call through the plain
+/// `raw_grpc()` accessor keeps sending the seeded token, while
+/// `raw_grpc_fresh()` proactively refreshes a near-expiry token into the
+/// shared slot so the subsequent raw call is accepted.
+#[tokio::test]
+async fn raw_grpc_fresh_refreshes_before_raw_call() {
+    let state = Arc::new(MockState {
+        require_bearer: Some("Bearer fresh-token".to_string()),
+        ..Default::default()
+    });
+    let endpoint = start_mock(state.clone()).await;
+
+    let calls = Arc::new(AtomicU32::new(0));
+    let refresher = Arc::new(OneShotRefresher {
+        calls: Arc::clone(&calls),
+    });
+
+    // Near-expiry token so the proactive path will refresh it.
+    let near = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 5;
+    let mut config = ClientConfig::new(&endpoint);
+    config.auth = Some(AuthConfig::Oidc {
+        token: "stale-token".to_string(),
+        expires_at: Some(near),
+        refresh: Some(refresher),
+    });
+    let client = OpenShellClient::connect(config).await.unwrap();
+
+    // Plain raw accessor does not refresh: the seeded token is rejected.
+    let err = client
+        .raw_grpc()
+        .health(proto::HealthRequest {})
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "raw_grpc must not trigger a refresh"
+    );
+
+    // _fresh accessor refreshes the near-expiry token first; the raw call is
+    // then accepted with the fresh bearer.
+    let mut grpc = client.raw_grpc_fresh().await.unwrap();
+    grpc.health(proto::HealthRequest {}).await.unwrap();
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "raw_grpc_fresh must refresh the near-expiry token exactly once"
+    );
+}

--- a/crates/openshell-sdk/tests/client_mock.rs
+++ b/crates/openshell-sdk/tests/client_mock.rs
@@ -1,0 +1,880 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! High-level [`OpenShellClient`] tests against an in-process mock gateway.
+//!
+//! The mock binds an ephemeral plaintext TCP listener and serves the
+//! `OpenShell` gRPC service. Tests dial it via `http://127.0.0.1:<port>` so
+//! TLS and auth code paths are skipped — those are exercised by the CLI's
+//! `mtls_integration` and OIDC tests.
+
+use openshell_core::proto;
+use openshell_core::proto::open_shell_server::{OpenShell, OpenShellServer};
+use openshell_sdk::{
+    AuthConfig, ClientConfig, ExecOptions, ListOptions, OpenShellClient, Refresh, RefreshError,
+    RefreshedToken, SandboxPhase, SandboxSpec, ServiceStatus as SdkServiceStatus,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Response, Status};
+
+/// Captured fixture state — what the mock observed and the canned replies it
+/// returned. One per test so assertions are scoped.
+#[derive(Default)]
+struct MockState {
+    last_get_name: Mutex<Option<String>>,
+    last_create: Mutex<Option<proto::CreateSandboxRequest>>,
+    last_delete_name: Mutex<Option<String>>,
+    last_list_request: Mutex<Option<proto::ListSandboxesRequest>>,
+    last_exec_request: Mutex<Option<proto::ExecSandboxRequest>>,
+    get_calls: AtomicU32,
+    phase_sequence: Vec<proto::SandboxPhase>,
+    get_returns_not_found: bool,
+    not_found_after: Option<u32>,
+    /// When set, `health` rejects any request whose `authorization` header
+    /// does not match this exact value (e.g. `"Bearer fresh-token"`).
+    require_bearer: Option<String>,
+    /// Count of requests rejected by the `require_bearer` gate.
+    unauth_hits: AtomicU32,
+}
+
+#[derive(Clone)]
+struct TestOpenShell {
+    state: Arc<MockState>,
+}
+
+fn sandbox_with_phase(name: &str, phase: proto::SandboxPhase) -> proto::Sandbox {
+    proto::Sandbox {
+        metadata: Some(proto::datamodel::v1::ObjectMeta {
+            id: format!("id-{name}"),
+            name: name.to_string(),
+            created_at_ms: 0,
+            labels: HashMap::new(),
+            resource_version: 1,
+        }),
+        spec: None,
+        status: Some(proto::SandboxStatus {
+            phase: phase.into(),
+            ..Default::default()
+        }),
+    }
+}
+
+#[tonic::async_trait]
+impl OpenShell for TestOpenShell {
+    async fn health(
+        &self,
+        request: tonic::Request<proto::HealthRequest>,
+    ) -> Result<Response<proto::HealthResponse>, Status> {
+        if let Some(expected) = &self.state.require_bearer {
+            let got = request
+                .metadata()
+                .get("authorization")
+                .and_then(|v| v.to_str().ok());
+            if got != Some(expected.as_str()) {
+                self.state.unauth_hits.fetch_add(1, Ordering::SeqCst);
+                return Err(Status::unauthenticated("invalid or missing bearer token"));
+            }
+        }
+        Ok(Response::new(proto::HealthResponse {
+            status: proto::ServiceStatus::Healthy.into(),
+            version: "test-1.2.3".to_string(),
+        }))
+    }
+
+    async fn update_provider_profiles(
+        &self,
+        _: tonic::Request<proto::UpdateProviderProfilesRequest>,
+    ) -> Result<Response<proto::UpdateProviderProfilesResponse>, Status> {
+        Ok(Response::new(
+            proto::UpdateProviderProfilesResponse::default(),
+        ))
+    }
+
+    async fn create_sandbox(
+        &self,
+        request: tonic::Request<proto::CreateSandboxRequest>,
+    ) -> Result<Response<proto::SandboxResponse>, Status> {
+        let req = request.into_inner();
+        let name = if req.name.is_empty() {
+            "generated".to_string()
+        } else {
+            req.name.clone()
+        };
+        *self.state.last_create.lock().await = Some(req);
+        Ok(Response::new(proto::SandboxResponse {
+            sandbox: Some(sandbox_with_phase(&name, proto::SandboxPhase::Provisioning)),
+        }))
+    }
+
+    async fn get_sandbox(
+        &self,
+        request: tonic::Request<proto::GetSandboxRequest>,
+    ) -> Result<Response<proto::SandboxResponse>, Status> {
+        let name = request.into_inner().name;
+        *self.state.last_get_name.lock().await = Some(name.clone());
+        let count = self.state.get_calls.fetch_add(1, Ordering::SeqCst);
+
+        if self.state.get_returns_not_found {
+            return Err(Status::not_found(format!("sandbox '{name}' not found")));
+        }
+        if let Some(threshold) = self.state.not_found_after
+            && count >= threshold
+        {
+            return Err(Status::not_found(format!("sandbox '{name}' not found")));
+        }
+
+        let phase = self
+            .state
+            .phase_sequence
+            .get(count as usize)
+            .copied()
+            .or_else(|| self.state.phase_sequence.last().copied())
+            .unwrap_or(proto::SandboxPhase::Ready);
+
+        Ok(Response::new(proto::SandboxResponse {
+            sandbox: Some(sandbox_with_phase(&name, phase)),
+        }))
+    }
+
+    async fn list_sandboxes(
+        &self,
+        request: tonic::Request<proto::ListSandboxesRequest>,
+    ) -> Result<Response<proto::ListSandboxesResponse>, Status> {
+        *self.state.last_list_request.lock().await = Some(request.into_inner());
+        Ok(Response::new(proto::ListSandboxesResponse {
+            sandboxes: vec![
+                sandbox_with_phase("alpha", proto::SandboxPhase::Ready),
+                sandbox_with_phase("beta", proto::SandboxPhase::Provisioning),
+            ],
+        }))
+    }
+
+    async fn list_sandbox_providers(
+        &self,
+        _: tonic::Request<proto::ListSandboxProvidersRequest>,
+    ) -> Result<Response<proto::ListSandboxProvidersResponse>, Status> {
+        Ok(Response::new(proto::ListSandboxProvidersResponse::default()))
+    }
+
+    async fn attach_sandbox_provider(
+        &self,
+        _: tonic::Request<proto::AttachSandboxProviderRequest>,
+    ) -> Result<Response<proto::AttachSandboxProviderResponse>, Status> {
+        Ok(Response::new(
+            proto::AttachSandboxProviderResponse::default(),
+        ))
+    }
+
+    async fn detach_sandbox_provider(
+        &self,
+        _: tonic::Request<proto::DetachSandboxProviderRequest>,
+    ) -> Result<Response<proto::DetachSandboxProviderResponse>, Status> {
+        Ok(Response::new(
+            proto::DetachSandboxProviderResponse::default(),
+        ))
+    }
+
+    async fn delete_sandbox(
+        &self,
+        request: tonic::Request<proto::DeleteSandboxRequest>,
+    ) -> Result<Response<proto::DeleteSandboxResponse>, Status> {
+        let name = request.into_inner().name;
+        *self.state.last_delete_name.lock().await = Some(name);
+        Ok(Response::new(proto::DeleteSandboxResponse {
+            deleted: true,
+        }))
+    }
+
+    async fn create_ssh_session(
+        &self,
+        _: tonic::Request<proto::CreateSshSessionRequest>,
+    ) -> Result<Response<proto::CreateSshSessionResponse>, Status> {
+        Ok(Response::new(proto::CreateSshSessionResponse::default()))
+    }
+
+    async fn expose_service(
+        &self,
+        _: tonic::Request<proto::ExposeServiceRequest>,
+    ) -> Result<Response<proto::ServiceEndpointResponse>, Status> {
+        Ok(Response::new(proto::ServiceEndpointResponse::default()))
+    }
+
+    async fn get_service(
+        &self,
+        _: tonic::Request<proto::GetServiceRequest>,
+    ) -> Result<Response<proto::ServiceEndpointResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn list_services(
+        &self,
+        _: tonic::Request<proto::ListServicesRequest>,
+    ) -> Result<Response<proto::ListServicesResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn delete_service(
+        &self,
+        _: tonic::Request<proto::DeleteServiceRequest>,
+    ) -> Result<Response<proto::DeleteServiceResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn revoke_ssh_session(
+        &self,
+        _: tonic::Request<proto::RevokeSshSessionRequest>,
+    ) -> Result<Response<proto::RevokeSshSessionResponse>, Status> {
+        Ok(Response::new(proto::RevokeSshSessionResponse::default()))
+    }
+
+    type ExecSandboxStream =
+        tokio_stream::wrappers::ReceiverStream<Result<proto::ExecSandboxEvent, Status>>;
+
+    async fn exec_sandbox(
+        &self,
+        request: tonic::Request<proto::ExecSandboxRequest>,
+    ) -> Result<Response<Self::ExecSandboxStream>, Status> {
+        *self.state.last_exec_request.lock().await = Some(request.into_inner());
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        tokio::spawn(async move {
+            let _ = tx
+                .send(Ok(proto::ExecSandboxEvent {
+                    payload: Some(proto::exec_sandbox_event::Payload::Stdout(
+                        proto::ExecSandboxStdout {
+                            data: b"hello\n".to_vec(),
+                        },
+                    )),
+                }))
+                .await;
+            let _ = tx
+                .send(Ok(proto::ExecSandboxEvent {
+                    payload: Some(proto::exec_sandbox_event::Payload::Stderr(
+                        proto::ExecSandboxStderr {
+                            data: b"warn\n".to_vec(),
+                        },
+                    )),
+                }))
+                .await;
+            let _ = tx
+                .send(Ok(proto::ExecSandboxEvent {
+                    payload: Some(proto::exec_sandbox_event::Payload::Exit(
+                        proto::ExecSandboxExit { exit_code: 7 },
+                    )),
+                }))
+                .await;
+        });
+        Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+            rx,
+        )))
+    }
+
+    type ForwardTcpStream =
+        tokio_stream::wrappers::ReceiverStream<Result<proto::TcpForwardFrame, Status>>;
+
+    async fn forward_tcp(
+        &self,
+        _: tonic::Request<tonic::Streaming<proto::TcpForwardFrame>>,
+    ) -> Result<Response<Self::ForwardTcpStream>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    type ExecSandboxInteractiveStream =
+        tokio_stream::wrappers::ReceiverStream<Result<proto::ExecSandboxEvent, Status>>;
+
+    async fn exec_sandbox_interactive(
+        &self,
+        _: tonic::Request<tonic::Streaming<proto::ExecSandboxInput>>,
+    ) -> Result<Response<Self::ExecSandboxInteractiveStream>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn create_provider(
+        &self,
+        _: tonic::Request<proto::CreateProviderRequest>,
+    ) -> Result<Response<proto::ProviderResponse>, Status> {
+        Ok(Response::new(proto::ProviderResponse::default()))
+    }
+
+    async fn get_provider(
+        &self,
+        _: tonic::Request<proto::GetProviderRequest>,
+    ) -> Result<Response<proto::ProviderResponse>, Status> {
+        Ok(Response::new(proto::ProviderResponse::default()))
+    }
+
+    async fn list_providers(
+        &self,
+        _: tonic::Request<proto::ListProvidersRequest>,
+    ) -> Result<Response<proto::ListProvidersResponse>, Status> {
+        Ok(Response::new(proto::ListProvidersResponse::default()))
+    }
+
+    async fn list_provider_profiles(
+        &self,
+        _: tonic::Request<proto::ListProviderProfilesRequest>,
+    ) -> Result<Response<proto::ListProviderProfilesResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_provider_profile(
+        &self,
+        _: tonic::Request<proto::GetProviderProfileRequest>,
+    ) -> Result<Response<proto::ProviderProfileResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn import_provider_profiles(
+        &self,
+        _: tonic::Request<proto::ImportProviderProfilesRequest>,
+    ) -> Result<Response<proto::ImportProviderProfilesResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn lint_provider_profiles(
+        &self,
+        _: tonic::Request<proto::LintProviderProfilesRequest>,
+    ) -> Result<Response<proto::LintProviderProfilesResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn update_provider(
+        &self,
+        _: tonic::Request<proto::UpdateProviderRequest>,
+    ) -> Result<Response<proto::ProviderResponse>, Status> {
+        Ok(Response::new(proto::ProviderResponse::default()))
+    }
+
+    async fn get_provider_refresh_status(
+        &self,
+        _: tonic::Request<proto::GetProviderRefreshStatusRequest>,
+    ) -> Result<Response<proto::GetProviderRefreshStatusResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn configure_provider_refresh(
+        &self,
+        _: tonic::Request<proto::ConfigureProviderRefreshRequest>,
+    ) -> Result<Response<proto::ConfigureProviderRefreshResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn rotate_provider_credential(
+        &self,
+        _: tonic::Request<proto::RotateProviderCredentialRequest>,
+    ) -> Result<Response<proto::RotateProviderCredentialResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn delete_provider_refresh(
+        &self,
+        _: tonic::Request<proto::DeleteProviderRefreshRequest>,
+    ) -> Result<Response<proto::DeleteProviderRefreshResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn delete_provider(
+        &self,
+        _: tonic::Request<proto::DeleteProviderRequest>,
+    ) -> Result<Response<proto::DeleteProviderResponse>, Status> {
+        Ok(Response::new(proto::DeleteProviderResponse::default()))
+    }
+
+    async fn delete_provider_profile(
+        &self,
+        _: tonic::Request<proto::DeleteProviderProfileRequest>,
+    ) -> Result<Response<proto::DeleteProviderProfileResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_sandbox_config(
+        &self,
+        _: tonic::Request<proto::GetSandboxConfigRequest>,
+    ) -> Result<Response<proto::GetSandboxConfigResponse>, Status> {
+        Ok(Response::new(proto::GetSandboxConfigResponse::default()))
+    }
+
+    async fn get_gateway_config(
+        &self,
+        _: tonic::Request<proto::GetGatewayConfigRequest>,
+    ) -> Result<Response<proto::GetGatewayConfigResponse>, Status> {
+        Ok(Response::new(proto::GetGatewayConfigResponse::default()))
+    }
+
+    async fn update_config(
+        &self,
+        _: tonic::Request<proto::UpdateConfigRequest>,
+    ) -> Result<Response<proto::UpdateConfigResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_sandbox_policy_status(
+        &self,
+        _: tonic::Request<proto::GetSandboxPolicyStatusRequest>,
+    ) -> Result<Response<proto::GetSandboxPolicyStatusResponse>, Status> {
+        Ok(Response::new(
+            proto::GetSandboxPolicyStatusResponse::default(),
+        ))
+    }
+
+    async fn list_sandbox_policies(
+        &self,
+        _: tonic::Request<proto::ListSandboxPoliciesRequest>,
+    ) -> Result<Response<proto::ListSandboxPoliciesResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn report_policy_status(
+        &self,
+        _: tonic::Request<proto::ReportPolicyStatusRequest>,
+    ) -> Result<Response<proto::ReportPolicyStatusResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_sandbox_provider_environment(
+        &self,
+        _: tonic::Request<proto::GetSandboxProviderEnvironmentRequest>,
+    ) -> Result<Response<proto::GetSandboxProviderEnvironmentResponse>, Status> {
+        Ok(Response::new(
+            proto::GetSandboxProviderEnvironmentResponse::default(),
+        ))
+    }
+
+    async fn get_sandbox_logs(
+        &self,
+        _: tonic::Request<proto::GetSandboxLogsRequest>,
+    ) -> Result<Response<proto::GetSandboxLogsResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn push_sandbox_logs(
+        &self,
+        _: tonic::Request<tonic::Streaming<proto::PushSandboxLogsRequest>>,
+    ) -> Result<Response<proto::PushSandboxLogsResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    type WatchSandboxStream =
+        tokio_stream::wrappers::ReceiverStream<Result<proto::SandboxStreamEvent, Status>>;
+
+    async fn watch_sandbox(
+        &self,
+        _: tonic::Request<proto::WatchSandboxRequest>,
+    ) -> Result<Response<Self::WatchSandboxStream>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn submit_policy_analysis(
+        &self,
+        _: tonic::Request<proto::SubmitPolicyAnalysisRequest>,
+    ) -> Result<Response<proto::SubmitPolicyAnalysisResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_draft_policy(
+        &self,
+        _: tonic::Request<proto::GetDraftPolicyRequest>,
+    ) -> Result<Response<proto::GetDraftPolicyResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn approve_draft_chunk(
+        &self,
+        _: tonic::Request<proto::ApproveDraftChunkRequest>,
+    ) -> Result<Response<proto::ApproveDraftChunkResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn approve_all_draft_chunks(
+        &self,
+        _: tonic::Request<proto::ApproveAllDraftChunksRequest>,
+    ) -> Result<Response<proto::ApproveAllDraftChunksResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn reject_draft_chunk(
+        &self,
+        _: tonic::Request<proto::RejectDraftChunkRequest>,
+    ) -> Result<Response<proto::RejectDraftChunkResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn edit_draft_chunk(
+        &self,
+        _: tonic::Request<proto::EditDraftChunkRequest>,
+    ) -> Result<Response<proto::EditDraftChunkResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn undo_draft_chunk(
+        &self,
+        _: tonic::Request<proto::UndoDraftChunkRequest>,
+    ) -> Result<Response<proto::UndoDraftChunkResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn clear_draft_chunks(
+        &self,
+        _: tonic::Request<proto::ClearDraftChunksRequest>,
+    ) -> Result<Response<proto::ClearDraftChunksResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_draft_history(
+        &self,
+        _: tonic::Request<proto::GetDraftHistoryRequest>,
+    ) -> Result<Response<proto::GetDraftHistoryResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    type ConnectSupervisorStream =
+        tokio_stream::wrappers::ReceiverStream<Result<proto::GatewayMessage, Status>>;
+
+    async fn connect_supervisor(
+        &self,
+        _: tonic::Request<tonic::Streaming<proto::SupervisorMessage>>,
+    ) -> Result<Response<Self::ConnectSupervisorStream>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    type RelayStreamStream =
+        tokio_stream::wrappers::ReceiverStream<Result<proto::RelayFrame, Status>>;
+
+    async fn relay_stream(
+        &self,
+        _: tonic::Request<tonic::Streaming<proto::RelayFrame>>,
+    ) -> Result<Response<Self::RelayStreamStream>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn issue_sandbox_token(
+        &self,
+        _: tonic::Request<proto::IssueSandboxTokenRequest>,
+    ) -> Result<Response<proto::IssueSandboxTokenResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn refresh_sandbox_token(
+        &self,
+        _: tonic::Request<proto::RefreshSandboxTokenRequest>,
+    ) -> Result<Response<proto::RefreshSandboxTokenResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+}
+
+/// Spin up the mock gateway, return its endpoint URL.
+async fn start_mock(state: Arc<MockState>) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let endpoint = format!("http://{addr}");
+    let stream = TcpListenerStream::new(listener);
+    let svc = OpenShellServer::new(TestOpenShell { state });
+    tokio::spawn(async move {
+        let _ = tonic::transport::Server::builder()
+            .add_service(svc)
+            .serve_with_incoming(stream)
+            .await;
+    });
+    endpoint
+}
+
+async fn connect(endpoint: &str) -> OpenShellClient {
+    OpenShellClient::connect(ClientConfig::new(endpoint))
+        .await
+        .expect("connect should succeed against local mock")
+}
+
+#[tokio::test]
+async fn health_returns_curated_snapshot() {
+    let state = Arc::new(MockState::default());
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+
+    let h = client.health().await.unwrap();
+    assert_eq!(h.status, SdkServiceStatus::Healthy);
+    assert_eq!(h.version, "test-1.2.3");
+}
+
+#[tokio::test]
+async fn create_sandbox_passes_spec_through() {
+    let state = Arc::new(MockState::default());
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+
+    let mut labels = HashMap::new();
+    labels.insert("team".to_string(), "core".to_string());
+
+    let spec = SandboxSpec {
+        name: Some("my-box".to_string()),
+        image: Some("ghcr.io/foo:bar".to_string()),
+        labels: labels.clone(),
+        gpu: true,
+        ..Default::default()
+    };
+
+    let result = client.create_sandbox(spec).await.unwrap();
+    assert_eq!(result.name, "my-box");
+    assert_eq!(result.phase, SandboxPhase::Provisioning);
+
+    let observed = state.last_create.lock().await.clone().unwrap();
+    assert_eq!(observed.name, "my-box");
+    assert_eq!(observed.labels, labels);
+    let observed_spec = observed.spec.unwrap();
+    assert!(
+        observed_spec
+            .resource_requirements
+            .as_ref()
+            .and_then(|r| r.gpu.as_ref())
+            .is_some()
+    );
+    assert_eq!(
+        observed_spec.template.as_ref().unwrap().image,
+        "ghcr.io/foo:bar"
+    );
+}
+
+#[tokio::test]
+async fn get_sandbox_sends_name_and_maps_phase() {
+    let state = Arc::new(MockState {
+        phase_sequence: vec![proto::SandboxPhase::Ready],
+        ..Default::default()
+    });
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+
+    let sandbox = client.get_sandbox("my-box").await.unwrap();
+    assert_eq!(sandbox.name, "my-box");
+    assert_eq!(sandbox.id, "id-my-box");
+    assert_eq!(sandbox.phase, SandboxPhase::Ready);
+
+    let observed = state.last_get_name.lock().await.clone();
+    assert_eq!(observed.as_deref(), Some("my-box"));
+}
+
+#[tokio::test]
+async fn list_sandboxes_propagates_filters() {
+    let state = Arc::new(MockState::default());
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+
+    let opts = ListOptions {
+        limit: 25,
+        offset: 5,
+        label_selector: Some("team=core".to_string()),
+    };
+    let items = client.list_sandboxes(opts).await.unwrap();
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].name, "alpha");
+    assert_eq!(items[0].phase, SandboxPhase::Ready);
+    assert_eq!(items[1].phase, SandboxPhase::Provisioning);
+
+    let observed = state.last_list_request.lock().await.clone().unwrap();
+    assert_eq!(observed.limit, 25);
+    assert_eq!(observed.offset, 5);
+    assert_eq!(observed.label_selector, "team=core");
+}
+
+#[tokio::test]
+async fn delete_sandbox_returns_server_ack() {
+    let state = Arc::new(MockState::default());
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+
+    let deleted = client.delete_sandbox("doomed").await.unwrap();
+    assert!(deleted);
+
+    let observed = state.last_delete_name.lock().await.clone();
+    assert_eq!(observed.as_deref(), Some("doomed"));
+}
+
+#[tokio::test]
+async fn wait_ready_transitions_through_phases() {
+    let state = Arc::new(MockState {
+        phase_sequence: vec![
+            proto::SandboxPhase::Provisioning,
+            proto::SandboxPhase::Provisioning,
+            proto::SandboxPhase::Ready,
+        ],
+        ..Default::default()
+    });
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+
+    let sandbox = client
+        .wait_ready("my-box", std::time::Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(sandbox.phase, SandboxPhase::Ready);
+    assert!(state.get_calls.load(Ordering::SeqCst) >= 3);
+}
+
+#[tokio::test]
+async fn wait_ready_surfaces_error_phase() {
+    let state = Arc::new(MockState {
+        phase_sequence: vec![proto::SandboxPhase::Error],
+        ..Default::default()
+    });
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+
+    let err = client
+        .wait_ready("my-box", std::time::Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "connect");
+}
+
+#[tokio::test]
+async fn wait_deleted_returns_when_get_reports_not_found() {
+    let state = Arc::new(MockState {
+        phase_sequence: vec![proto::SandboxPhase::Deleting],
+        not_found_after: Some(2),
+        ..Default::default()
+    });
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+
+    client
+        .wait_deleted("my-box", std::time::Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert!(state.get_calls.load(Ordering::SeqCst) >= 3);
+}
+
+#[tokio::test]
+async fn get_sandbox_not_found_maps_to_typed_error() {
+    let state = Arc::new(MockState {
+        get_returns_not_found: true,
+        ..Default::default()
+    });
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+
+    let err = client.get_sandbox("missing").await.unwrap_err();
+    assert_eq!(err.code(), "not_found");
+}
+
+#[tokio::test]
+async fn exec_buffers_stdout_stderr_and_exit() {
+    let state = Arc::new(MockState {
+        phase_sequence: vec![proto::SandboxPhase::Ready],
+        ..Default::default()
+    });
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+
+    let result = client
+        .exec(
+            "my-box",
+            &["echo".to_string(), "hello".to_string()],
+            ExecOptions {
+                workdir: Some("/work".to_string()),
+                timeout: Some(std::time::Duration::from_secs(10)),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 7);
+    assert_eq!(result.stdout, b"hello\n");
+    assert_eq!(result.stderr, b"warn\n");
+
+    let observed = state.last_exec_request.lock().await.clone().unwrap();
+    assert_eq!(observed.sandbox_id, "id-my-box");
+    assert_eq!(
+        observed.command,
+        vec!["echo".to_string(), "hello".to_string()]
+    );
+    assert_eq!(observed.workdir, "/work");
+    assert_eq!(observed.timeout_seconds, 10);
+}
+
+/// Refresher that hands out a fixed "fresh-token" and counts invocations.
+struct OneShotRefresher {
+    calls: Arc<AtomicU32>,
+}
+
+#[async_trait::async_trait]
+impl Refresh for OneShotRefresher {
+    async fn refresh(&self) -> Result<RefreshedToken, RefreshError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let far_future = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+        Ok(RefreshedToken::new("fresh-token").with_expires_at(far_future))
+    }
+}
+
+/// A request rejected with `Unauthenticated` (revoked token that still looks
+/// valid) must trigger a forced refresh and a single retry that succeeds.
+#[tokio::test]
+async fn reactive_refresh_recovers_from_unauthenticated() {
+    let far_future = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 3600;
+    let state = Arc::new(MockState {
+        require_bearer: Some("Bearer fresh-token".to_string()),
+        ..Default::default()
+    });
+    let endpoint = start_mock(state.clone()).await;
+
+    let calls = Arc::new(AtomicU32::new(0));
+    let refresher = Arc::new(OneShotRefresher {
+        calls: Arc::clone(&calls),
+    });
+
+    // Seed a stale-but-unexpired token: the proactive path won't refresh it
+    // (expiry is far off), so only the reactive Unauthenticated path can.
+    let mut config = ClientConfig::new(&endpoint);
+    config.auth = Some(AuthConfig::Oidc {
+        token: "stale-token".to_string(),
+        expires_at: Some(far_future),
+        refresh: Some(refresher),
+    });
+    let client = OpenShellClient::connect(config).await.unwrap();
+
+    let health = client.health().await.unwrap();
+    assert_eq!(health.status, SdkServiceStatus::Healthy);
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "forced refresh should fire exactly once on Unauthenticated"
+    );
+    assert_eq!(
+        state.unauth_hits.load(Ordering::SeqCst),
+        1,
+        "first request rejected with stale token, retry accepted with fresh token"
+    );
+}
+
+/// Without a refresher, an `Unauthenticated` response is surfaced as an auth
+/// error rather than retried in a loop.
+#[tokio::test]
+async fn unauthenticated_without_refresher_surfaces_error() {
+    let state = Arc::new(MockState {
+        require_bearer: Some("Bearer never-matches".to_string()),
+        ..Default::default()
+    });
+    let endpoint = start_mock(state.clone()).await;
+
+    let mut config = ClientConfig::new(&endpoint);
+    config.auth = Some(AuthConfig::oidc("static-token"));
+    let client = OpenShellClient::connect(config).await.unwrap();
+
+    let err = client.health().await.unwrap_err();
+    assert_eq!(err.code(), "auth", "expected an auth error, got: {err:?}");
+    assert_eq!(
+        state.unauth_hits.load(Ordering::SeqCst),
+        1,
+        "exactly one attempt; no retry without a refresher"
+    );
+}


### PR DESCRIPTION
## Summary

First focused PR split out of #1617. Adds a new `openshell-sdk` crate: the shared async Rust client for OpenShell gateways. It owns gRPC channel construction, TLS material handling, request interceptors, OIDC single-flight token refresh, and the Cloudflare Access edge tunnel, and exposes a sandbox-focused high-level surface plus a `raw` escape hatch.

The crate is additive (nothing consumes it yet, so no behavior change). The one non-additive piece is a behavior-preserving extraction: the signature-unverified JWT `exp` decoder moves out of `openshell-core/src/grpc_client.rs` into a shared `openshell_core::jwt` module, so the sandbox-side client and the SDK's refresh path derive token expiry from one place instead of each reimplementing it. Moving `openshell-cli` and `openshell-tui` onto the crate is a separate follow-up PR.

## Related Issue

- Design: RFC 0008 (#1764), which merges first.
- Split out of #1617. Sequence: RFC (#1764), this crate, CLI/TUI migration, then `openshell-sdk-node` (napi binding, Pi example, CI).
- linear://nvidia/issue/OSGH-110/python-and-typescript-sdk-support

## Changes

- New `crates/openshell-sdk/`:
  - `OpenShellClient`: high-level sandbox surface (health, sandbox CRUD, readiness and deletion waits, non-streaming exec).
  - Transport stack: channel construction and the five transport/auth modes the CLI exercises today (plaintext, mTLS, OIDC bearer over HTTPS, Cloudflare Access tunnel, insecure TLS).
  - OIDC: single-flight refresh wired into the client auth path (proactive before unary calls, reactive on `Unauthenticated` with one retry), behind a napi-free `Refresh` trait so the core stays binding-agnostic.
  - `raw` module: re-exports the generated tonic clients for RPCs the curated surface does not yet cover.
  - `SdkError` taxonomy and curated types (`SandboxSpec`, `SandboxRef`, `Health`, `ListOptions`, `ExecOptions`).
  - Crate `README.md`.
- Shared JWT-exp decoder: new `openshell_core::jwt::parse_exp_secs`, extracted from `grpc_client.rs` (which now calls it). The SDK reuses it to derive a proactive-refresh deadline from a bearer JWT when the caller does not advertise `expires_at`, so consumers do not reimplement JWT expiry parsing per language.
- `AGENTS.md`: architecture-table row for the new crate.
- `Cargo.lock`: additive (the crate registers via the existing `members = ["crates/*"]`).

No changes to `openshell-cli` or `openshell-tui`. The only `openshell-core` change is the JWT-exp extraction above; the transport code the CLI/TUI own today (`openshell-core/src/auth.rs`, `openshell-cli/src/edge_tunnel.rs`, `tls.rs`, `oidc_auth.rs`) is untouched here and migrates onto the SDK in the follow-up PR, where the now-duplicated code is removed.

## Testing

- [x] `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo fmt --all -- --check` are clean.
- [x] `cargo test -p openshell-sdk`: 9 unit + 12 mock-gateway tests pass (incl. single-flight cancellation-safety, Debug-redaction, and token-encoding regression tests).
- [x] `cargo test -p openshell-core`: 299 pass, including 3 new `jwt` decoder tests. The pre-existing `grpc_client` expiry tests still pass, confirming the decoder extraction is behavior-preserving.
- [x] `license:check` and `markdown:lint` pass.
- [ ] E2E not applicable. Additive crate with no consumers and no behavior change; the mock-gateway tests are the regression surface for the client.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable): `AGENTS.md` architecture table and the crate `README.md`.
