### PR TITLE
feat(l7): add JSON-RPC and MCP policy enforcement

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -44,6 +44,9 @@ jobs:
             cmd: "mise run --no-deps --skip-deps e2e:podman:rootless"
             apt_packages: "openssh-client podman uidmap"
             rootless: true
+          - suite: mcp
+            cmd: "mise run --no-deps --skip-deps e2e:mcp"
+            apt_packages: ""
     container:
       image: ghcr.io/nvidia/openshell/ci:latest
       credentials:
@@ -65,6 +68,17 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs['checkout-ref'] || github.sha }}
+          persist-credentials: false
+
+      - name: Check out MCP conformance tests
+        if: matrix.suite == 'mcp'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          repository: modelcontextprotocol/conformance
+          # Pin after v0.1.16 to include the tools_call client scenario fix.
+          ref: b9041ea41b0188581803459dbae71bc7e02fd995
+          path: .cache/mcp-conformance
+          persist-credentials: false
 
       - name: Install OS test dependencies
         if: matrix.apt_packages != ''
@@ -104,6 +118,7 @@ jobs:
       - name: Run tests
         env:
           OPENSHELL_SUPERVISOR_IMAGE: ${{ format('ghcr.io/nvidia/openshell/supervisor:{0}', inputs.image-tag) }}
+          OPENSHELL_MCP_CONFORMANCE_CLIENT_IMAGE: ${{ format('openshell-mcp-conformance-client:{0}', inputs.image-tag) }}
           E2E_CMD: ${{ matrix.cmd }}
         run: |
           if [ "${{ matrix.rootless }}" = "true" ]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3946,6 +3946,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite 0.26.2",
+ "tower-mcp-types",
  "tracing",
  "uuid",
  "webpki-roots 1.0.7",
@@ -6629,6 +6630,18 @@ name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-mcp-types"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6511f1f32c7cb7fd4525edc0eb4dcf307db8f7eceb2833ab24a37b4cc10cda61"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = ["crates/*"]
 [workspace.package]
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.90"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA/OpenShell"
 
@@ -73,6 +73,7 @@ serde_json = "1"
 serde_yml = "0.0.12"
 toml = "0.8"
 apollo-parser = "0.8.5"
+tower-mcp-types = "0.12.0"
 
 # HTTP client
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }

--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -49,6 +49,17 @@ paths, such as proxy support files or GPU device paths when a GPU is present.
 All ordinary agent egress is routed through the sandbox proxy. The proxy
 identifies the calling binary, checks trust-on-first-use binary identity, rejects
 unsafe internal destinations, and evaluates the active policy.
+For inspected HTTP traffic, the proxy can enforce REST method/path rules,
+WebSocket upgrade and text-message rules, GraphQL operation rules, and
+MCP method, tool, and supported params rules or generic JSON-RPC method rules
+on sandbox-to-server request bodies. MCP and JSON-RPC inspection buffers up to
+the endpoint `mcp.max_body_bytes` or `json_rpc.max_body_bytes` limit. MCP
+`tools/call` tool names are checked against the spec-recommended syntax by
+default before policy evaluation, with a per-endpoint `mcp.strict_tool_names`
+compatibility opt-out. Generic JSON-RPC policies do not support `params`
+matchers; generic JSON-RPC rules match only the method.
+JSON-RPC responses and server-to-client MCP messages on response or SSE streams
+are relayed but are not currently parsed for policy enforcement.
 
 `https://inference.local` is special. It bypasses OPA network policy and is
 handled by the inference interception path:

--- a/crates/openshell-cli/src/policy_update.rs
+++ b/crates/openshell-cli/src/policy_update.rs
@@ -205,6 +205,7 @@ fn group_allow_rules(specs: &[String]) -> Result<BTreeMap<(String, u32), Vec<L7R
                     operation_type: String::new(),
                     operation_name: String::new(),
                     fields: Vec::new(),
+                    params: HashMap::default(),
                 }),
             });
     }
@@ -226,6 +227,7 @@ fn group_deny_rules(specs: &[String]) -> Result<BTreeMap<(String, u32), Vec<L7De
                 operation_type: String::new(),
                 operation_name: String::new(),
                 fields: Vec::new(),
+                params: HashMap::default(),
             });
     }
     Ok(grouped)

--- a/crates/openshell-policy/src/lib.rs
+++ b/crates/openshell-policy/src/lib.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use openshell_core::proto::{
     FilesystemPolicy, GraphqlOperation, L7Allow, L7DenyRule, L7QueryMatcher, L7Rule,
-    LandlockPolicy, NetworkBinary, NetworkEndpoint, NetworkPolicyRule, ProcessPolicy,
+    LandlockPolicy, McpOptions, NetworkBinary, NetworkEndpoint, NetworkPolicyRule, ProcessPolicy,
     SandboxPolicy,
 };
 use serde::{Deserialize, Serialize};
@@ -144,6 +144,10 @@ struct NetworkEndpointDef {
     signing_service: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     signing_region: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    json_rpc: Option<JsonRpcConfigDef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    mcp: Option<McpConfigDef>,
 }
 
 // Signature dictated by serde's `skip_serializing_if`, which requires `&T`.
@@ -156,6 +160,109 @@ fn is_zero(v: &u16) -> bool {
 #[allow(clippy::trivially_copy_pass_by_ref)]
 fn is_zero_u32(v: &u32) -> bool {
     *v == 0
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct JsonRpcConfigDef {
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    max_body_bytes: u32,
+}
+
+fn json_rpc_config_from_proto(max_body_bytes: u32) -> Option<JsonRpcConfigDef> {
+    (max_body_bytes > 0).then_some(JsonRpcConfigDef { max_body_bytes })
+}
+
+// MCP rides the same HTTP/JSON-RPC inspection machinery at runtime, but it
+// gets its own policy stanza so user-authored YAML can name the primary
+// protocol instead of treating MCP as generic JSON-RPC.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct McpConfigDef {
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    max_body_bytes: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    strict_tool_names: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    allow_all_known_mcp_methods: Option<bool>,
+}
+
+fn mcp_config_from_proto(max_body_bytes: u32, mcp: Option<&McpOptions>) -> Option<McpConfigDef> {
+    let strict_tool_names = mcp.and_then(|config| config.strict_tool_names);
+    let allow_all_known_mcp_methods = mcp.and_then(|config| config.allow_all_known_mcp_methods);
+    (max_body_bytes > 0 || strict_tool_names.is_some() || allow_all_known_mcp_methods.is_some())
+        .then_some(McpConfigDef {
+            max_body_bytes,
+            strict_tool_names,
+            allow_all_known_mcp_methods,
+        })
+}
+
+/// Nested L7 config stanzas accepted by the YAML policy schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum L7ConfigStanza {
+    JsonRpc,
+    Mcp,
+}
+
+impl L7ConfigStanza {
+    pub const ALL: [Self; 2] = [Self::JsonRpc, Self::Mcp];
+
+    #[must_use]
+    pub const fn key(self) -> &'static str {
+        match self {
+            Self::JsonRpc => "json_rpc",
+            Self::Mcp => "mcp",
+        }
+    }
+}
+
+/// Parse an L7 nested config stanza and return the flattened runtime fields
+/// consumed by the supervisor policy engine.
+///
+/// The stanza schema stays tied to this crate's canonical serde definitions, so
+/// adding a new supported field requires updating this conversion next to the
+/// type that parses it.
+pub fn l7_config_alias_runtime_fields(
+    stanza: L7ConfigStanza,
+    value: serde_json::Value,
+) -> Result<Vec<(&'static str, serde_json::Value)>> {
+    match stanza {
+        L7ConfigStanza::JsonRpc => {
+            let JsonRpcConfigDef { max_body_bytes } = serde_json::from_value(value)
+                .map_err(|error| miette::miette!("invalid json_rpc config: {error}"))?;
+            let mut fields = Vec::new();
+            if max_body_bytes > 0 {
+                fields.push(("json_rpc_max_body_bytes", serde_json::json!(max_body_bytes)));
+            }
+            Ok(fields)
+        }
+        L7ConfigStanza::Mcp => {
+            let McpConfigDef {
+                max_body_bytes,
+                strict_tool_names,
+                allow_all_known_mcp_methods,
+            } = serde_json::from_value(value)
+                .map_err(|error| miette::miette!("invalid mcp config: {error}"))?;
+            let mut fields = Vec::new();
+            if max_body_bytes > 0 {
+                fields.push(("json_rpc_max_body_bytes", serde_json::json!(max_body_bytes)));
+            }
+            if let Some(strict_tool_names) = strict_tool_names {
+                fields.push((
+                    "mcp_strict_tool_names",
+                    serde_json::json!(strict_tool_names),
+                ));
+            }
+            if let Some(allow_all_known_mcp_methods) = allow_all_known_mcp_methods {
+                fields.push((
+                    "mcp_allow_all_known_mcp_methods",
+                    serde_json::json!(allow_all_known_mcp_methods),
+                ));
+            }
+            Ok(fields)
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -192,16 +299,31 @@ struct L7AllowDef {
     operation_name: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     fields: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tool: Option<QueryMatcherDef>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    params: BTreeMap<String, ParamMatcherDef>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 enum QueryMatcherDef {
+    // Short form: `query: { repo: "NVIDIA/*" }`.
     Glob(String),
+    // Expanded form: `query: { repo: { any: ["NVIDIA/*", "openai/*"] } }`.
     Any(QueryAnyDef),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+// MCP params can be authored as nested maps in YAML, but the runtime matcher
+// map remains flat so the Rego policy can share query-param matching.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum ParamMatcherDef {
+    Matcher(QueryMatcherDef),
+    Object(BTreeMap<String, Self>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct QueryAnyDef {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -225,6 +347,10 @@ struct L7DenyRuleDef {
     operation_name: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     fields: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tool: Option<QueryMatcherDef>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    params: BTreeMap<String, ParamMatcherDef>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -241,6 +367,310 @@ struct NetworkBinaryDef {
 // YAML → proto conversion
 // ---------------------------------------------------------------------------
 
+fn matcher_def_to_proto(matcher: QueryMatcherDef) -> L7QueryMatcher {
+    match matcher {
+        QueryMatcherDef::Glob(glob) => L7QueryMatcher { glob, any: vec![] },
+        QueryMatcherDef::Any(any) => L7QueryMatcher {
+            glob: String::new(),
+            any: any.any,
+        },
+    }
+}
+
+fn matcher_proto_to_def(matcher: L7QueryMatcher) -> QueryMatcherDef {
+    if matcher.any.is_empty() {
+        QueryMatcherDef::Glob(matcher.glob)
+    } else {
+        QueryMatcherDef::Any(QueryAnyDef { any: matcher.any })
+    }
+}
+
+// Convert MCP params maps into the flat proto/Rego keyspace. Only `name` is
+// currently enforced for tools/call, but this keeps the YAML shape compatible
+// with any future MCP-owned params selectors.
+fn flatten_param_matchers(
+    params: BTreeMap<String, ParamMatcherDef>,
+) -> BTreeMap<String, QueryMatcherDef> {
+    let mut flattened = BTreeMap::new();
+    for (key, matcher) in params {
+        flatten_param_matcher(&key, matcher, &mut flattened);
+    }
+    flattened
+}
+
+// Walk one params subtree, carrying the flattened dot-path key accumulated so
+// far. Leaf matchers are inserted into the map consumed by the runtime policy.
+fn flatten_param_matcher(
+    key: &str,
+    matcher: ParamMatcherDef,
+    out: &mut BTreeMap<String, QueryMatcherDef>,
+) {
+    match matcher {
+        ParamMatcherDef::Matcher(matcher) => {
+            out.insert(key.to_string(), matcher);
+        }
+        ParamMatcherDef::Object(children) => {
+            for (child_key, child) in children {
+                let nested_key = format!("{key}.{child_key}");
+                flatten_param_matcher(&nested_key, child, out);
+            }
+        }
+    }
+}
+
+// Convert flat runtime params back to YAML. MCP gets readable nested params
+// when the flat keys can be losslessly split. Non-MCP protocols keep flat keys
+// only for lossless serialization; generic JSON-RPC validation rejects params
+// matchers before enforcement.
+fn flat_params_to_def(
+    protocol: &str,
+    params: BTreeMap<String, QueryMatcherDef>,
+) -> BTreeMap<String, ParamMatcherDef> {
+    let flat = params.into_iter().collect::<Vec<_>>();
+    // MCP uses nested YAML for readability. Non-MCP protocols keep the flat
+    // form for lossless serialization of existing proto data only.
+    if !is_mcp_protocol(protocol) {
+        return flat_param_matchers_to_def(flat);
+    }
+
+    let mut nested = BTreeMap::new();
+    for (key, matcher) in &flat {
+        if insert_nested_param(&mut nested, key, ParamMatcherDef::Matcher(matcher.clone())).is_err()
+        {
+            return flat_param_matchers_to_def(flat);
+        }
+    }
+    nested
+}
+
+fn flat_param_matchers_to_def(
+    params: Vec<(String, QueryMatcherDef)>,
+) -> BTreeMap<String, ParamMatcherDef> {
+    params
+        .into_iter()
+        .map(|(key, matcher)| (key, ParamMatcherDef::Matcher(matcher)))
+        .collect()
+}
+
+// Build one nested params path from a flat key. Collisions such as `a` and
+// `a.b` cannot round-trip as nested YAML, so callers fall back to the flat map.
+fn insert_nested_param(
+    root: &mut BTreeMap<String, ParamMatcherDef>,
+    key: &str,
+    matcher: ParamMatcherDef,
+) -> Result<(), ()> {
+    let mut parts = key.split('.').peekable();
+    let Some(first) = parts.next() else {
+        return Err(());
+    };
+
+    if parts.peek().is_none() {
+        root.insert(first.to_string(), matcher);
+        return Ok(());
+    }
+
+    let child = root
+        .entry(first.to_string())
+        .or_insert_with(|| ParamMatcherDef::Object(BTreeMap::new()));
+    let ParamMatcherDef::Object(children) = child else {
+        return Err(());
+    };
+    let remainder = parts.collect::<Vec<_>>().join(".");
+    insert_nested_param(children, &remainder, matcher)
+}
+
+// MCP `tool` is a policy convenience for the standard `tools/call` params.name
+// field. When the endpoint method profile is enabled, authored tool selectors
+// can omit method and are normalized to tools/call internally. Tool arguments
+// intentionally have no policy matcher yet, so every allowed tool call permits
+// all argument payloads by default.
+fn params_with_tool(
+    mut params: BTreeMap<String, ParamMatcherDef>,
+    tool: Option<QueryMatcherDef>,
+) -> BTreeMap<String, ParamMatcherDef> {
+    if let Some(tool) = tool {
+        params
+            .entry("name".to_string())
+            .or_insert_with(|| ParamMatcherDef::Matcher(tool));
+    }
+    params
+}
+
+fn allow_def_to_proto(_protocol: &str, allow: L7AllowDef) -> L7Allow {
+    let params = flatten_param_matchers(params_with_tool(allow.params, allow.tool));
+    L7Allow {
+        method: allow.method,
+        path: allow.path,
+        command: allow.command,
+        operation_type: allow.operation_type,
+        operation_name: allow.operation_name,
+        fields: allow.fields,
+        query: allow
+            .query
+            .into_iter()
+            .map(|(key, matcher)| (key, matcher_def_to_proto(matcher)))
+            .collect(),
+        params: params
+            .into_iter()
+            .map(|(key, matcher)| (key, matcher_def_to_proto(matcher)))
+            .collect(),
+    }
+}
+
+fn deny_def_to_proto(_protocol: &str, deny: L7DenyRuleDef) -> L7DenyRule {
+    let params = flatten_param_matchers(params_with_tool(deny.params, deny.tool));
+    L7DenyRule {
+        method: deny.method,
+        path: deny.path,
+        command: deny.command,
+        operation_type: deny.operation_type,
+        operation_name: deny.operation_name,
+        fields: deny.fields,
+        query: deny
+            .query
+            .into_iter()
+            .map(|(key, matcher)| (key, matcher_def_to_proto(matcher)))
+            .collect(),
+        params: params
+            .into_iter()
+            .map(|(key, matcher)| (key, matcher_def_to_proto(matcher)))
+            .collect(),
+    }
+}
+
+fn json_rpc_max_body_bytes(json_rpc: &Option<JsonRpcConfigDef>, mcp: &Option<McpConfigDef>) -> u32 {
+    // The proto has one JSON-RPC-family body limit. Prefer the MCP stanza when
+    // present because MCP policies should not need a shadow `json_rpc` block.
+    mcp.as_ref().map_or_else(
+        || json_rpc.as_ref().map_or(0, |config| config.max_body_bytes),
+        |config| config.max_body_bytes,
+    )
+}
+
+fn mcp_strict_tool_names(mcp: &Option<McpConfigDef>) -> Option<bool> {
+    mcp.as_ref().and_then(|config| config.strict_tool_names)
+}
+
+fn mcp_allow_all_known_mcp_methods(mcp: &Option<McpConfigDef>) -> Option<bool> {
+    mcp.as_ref()
+        .and_then(|config| config.allow_all_known_mcp_methods)
+}
+
+fn mcp_options(mcp: &Option<McpConfigDef>) -> Option<McpOptions> {
+    let strict_tool_names = mcp_strict_tool_names(mcp);
+    let allow_all_known_mcp_methods = mcp_allow_all_known_mcp_methods(mcp);
+    (strict_tool_names.is_some() || allow_all_known_mcp_methods.is_some()).then_some(McpOptions {
+        strict_tool_names,
+        allow_all_known_mcp_methods,
+    })
+}
+
+fn is_mcp_protocol(protocol: &str) -> bool {
+    protocol.eq_ignore_ascii_case("mcp")
+}
+
+fn split_tool_param(
+    protocol: &str,
+    params: BTreeMap<String, QueryMatcherDef>,
+) -> (Option<QueryMatcherDef>, BTreeMap<String, QueryMatcherDef>) {
+    // Only MCP has the tool-name convention. Non-MCP protocols preserve proto
+    // params on round-trip without inventing MCP semantics.
+    if !is_mcp_protocol(protocol) {
+        return (None, params);
+    }
+
+    let mut params = params;
+    let tool = params.remove("name");
+    (tool, params)
+}
+
+fn allow_proto_to_def(
+    protocol: &str,
+    allow: L7Allow,
+    mcp_allow_all_known_mcp_methods: bool,
+) -> L7AllowDef {
+    let params: BTreeMap<String, QueryMatcherDef> = allow
+        .params
+        .into_iter()
+        .map(|(key, matcher)| (key, matcher_proto_to_def(matcher)))
+        .collect();
+    let (tool, params) = split_tool_param(protocol, params);
+    let params = flat_params_to_def(protocol, params);
+    let method = yaml_mcp_method(
+        protocol,
+        &allow.method,
+        tool.is_some(),
+        mcp_allow_all_known_mcp_methods,
+    );
+    L7AllowDef {
+        method,
+        path: allow.path,
+        command: allow.command,
+        query: allow
+            .query
+            .into_iter()
+            .map(|(key, matcher)| (key, matcher_proto_to_def(matcher)))
+            .collect(),
+        operation_type: allow.operation_type,
+        operation_name: allow.operation_name,
+        fields: allow.fields,
+        tool,
+        params,
+    }
+}
+
+fn deny_proto_to_def(
+    protocol: &str,
+    deny: &L7DenyRule,
+    mcp_allow_all_known_mcp_methods: bool,
+) -> L7DenyRuleDef {
+    let params: BTreeMap<String, QueryMatcherDef> = deny
+        .params
+        .iter()
+        .map(|(key, matcher)| (key.clone(), matcher_proto_to_def(matcher.clone())))
+        .collect();
+    let (tool, params) = split_tool_param(protocol, params);
+    let params = flat_params_to_def(protocol, params);
+    let method = yaml_mcp_method(
+        protocol,
+        &deny.method,
+        tool.is_some(),
+        mcp_allow_all_known_mcp_methods,
+    );
+    L7DenyRuleDef {
+        method,
+        path: deny.path.clone(),
+        command: deny.command.clone(),
+        query: deny
+            .query
+            .iter()
+            .map(|(key, matcher)| (key.clone(), matcher_proto_to_def(matcher.clone())))
+            .collect(),
+        operation_type: deny.operation_type.clone(),
+        operation_name: deny.operation_name.clone(),
+        fields: deny.fields.clone(),
+        tool,
+        params,
+    }
+}
+
+fn yaml_mcp_method(
+    protocol: &str,
+    method: &str,
+    has_tool: bool,
+    mcp_allow_all_known_mcp_methods: bool,
+) -> String {
+    if is_mcp_protocol(protocol) {
+        if !has_tool && method == "*" {
+            return String::new();
+        }
+        if has_tool && method == "tools/call" && mcp_allow_all_known_mcp_methods {
+            return String::new();
+        }
+    }
+    method.to_string()
+}
+
 fn to_proto(raw: PolicyFile) -> SandboxPolicy {
     let network_policies = raw
         .network_policies
@@ -256,6 +686,9 @@ fn to_proto(raw: PolicyFile) -> SandboxPolicy {
                     .endpoints
                     .into_iter()
                     .map(|e| {
+                        let protocol = e.protocol;
+                        let allow_rules = e.rules;
+                        let deny_rules = e.deny_rules;
                         // Normalize port/ports: ports takes precedence, else
                         // single port is promoted to ports array.
                         let normalized_ports: Vec<u32> = if !e.ports.is_empty() {
@@ -270,69 +703,20 @@ fn to_proto(raw: PolicyFile) -> SandboxPolicy {
                             path: e.path,
                             port: normalized_ports.first().copied().unwrap_or(0),
                             ports: normalized_ports,
-                            protocol: e.protocol,
+                            protocol: protocol.clone(),
                             tls: e.tls,
                             enforcement: e.enforcement,
                             access: e.access,
-                            rules: e
-                                .rules
+                            rules: allow_rules
                                 .into_iter()
                                 .map(|r| L7Rule {
-                                    allow: Some(L7Allow {
-                                        method: r.allow.method,
-                                        path: r.allow.path,
-                                        command: r.allow.command,
-                                        operation_type: r.allow.operation_type,
-                                        operation_name: r.allow.operation_name,
-                                        fields: r.allow.fields,
-                                        query: r
-                                            .allow
-                                            .query
-                                            .into_iter()
-                                            .map(|(key, matcher)| {
-                                                let proto = match matcher {
-                                                    QueryMatcherDef::Glob(glob) => {
-                                                        L7QueryMatcher { glob, any: vec![] }
-                                                    }
-                                                    QueryMatcherDef::Any(any) => L7QueryMatcher {
-                                                        glob: String::new(),
-                                                        any: any.any,
-                                                    },
-                                                };
-                                                (key, proto)
-                                            })
-                                            .collect(),
-                                    }),
+                                    allow: Some(allow_def_to_proto(&protocol, r.allow)),
                                 })
                                 .collect(),
                             allowed_ips: e.allowed_ips,
-                            deny_rules: e
-                                .deny_rules
+                            deny_rules: deny_rules
                                 .into_iter()
-                                .map(|d| L7DenyRule {
-                                    method: d.method,
-                                    path: d.path,
-                                    command: d.command,
-                                    operation_type: d.operation_type,
-                                    operation_name: d.operation_name,
-                                    fields: d.fields,
-                                    query: d
-                                        .query
-                                        .into_iter()
-                                        .map(|(key, matcher)| {
-                                            let proto = match matcher {
-                                                QueryMatcherDef::Glob(glob) => {
-                                                    L7QueryMatcher { glob, any: vec![] }
-                                                }
-                                                QueryMatcherDef::Any(any) => L7QueryMatcher {
-                                                    glob: String::new(),
-                                                    any: any.any,
-                                                },
-                                            };
-                                            (key, proto)
-                                        })
-                                        .collect(),
-                                })
+                                .map(|deny| deny_def_to_proto(&protocol, deny))
                                 .collect(),
                             allow_encoded_slash: e.allow_encoded_slash,
                             websocket_credential_rewrite: e.websocket_credential_rewrite,
@@ -359,6 +743,8 @@ fn to_proto(raw: PolicyFile) -> SandboxPolicy {
                             credential_signing: e.credential_signing,
                             signing_service: e.signing_service,
                             signing_region: e.signing_region,
+                            json_rpc_max_body_bytes: json_rpc_max_body_bytes(&e.json_rpc, &e.mcp),
+                            mcp: mcp_options(&e.mcp),
                         }
                     })
                     .collect(),
@@ -438,73 +824,50 @@ fn from_proto(policy: &SandboxPolicy) -> PolicyFile {
                         } else {
                             (clamp(e.ports.first().copied().unwrap_or(e.port)), vec![])
                         };
+                        let protocol = e.protocol.clone();
+                        let mcp_allow_all_known_mcp_methods = !is_mcp_protocol(&protocol)
+                            || e.mcp
+                                .as_ref()
+                                .and_then(|options| options.allow_all_known_mcp_methods)
+                                .unwrap_or(false);
+                        let rules = e
+                            .rules
+                            .iter()
+                            .map(|r| L7RuleDef {
+                                allow: allow_proto_to_def(
+                                    &protocol,
+                                    r.allow.clone().unwrap_or_default(),
+                                    mcp_allow_all_known_mcp_methods,
+                                ),
+                            })
+                            .collect();
+                        let deny_rules: Vec<L7DenyRuleDef> = e
+                            .deny_rules
+                            .iter()
+                            .map(|d| {
+                                deny_proto_to_def(&protocol, d, mcp_allow_all_known_mcp_methods)
+                            })
+                            .collect();
+                        let (json_rpc, mcp) = if is_mcp_protocol(&protocol) {
+                            (
+                                None,
+                                mcp_config_from_proto(e.json_rpc_max_body_bytes, e.mcp.as_ref()),
+                            )
+                        } else {
+                            (json_rpc_config_from_proto(e.json_rpc_max_body_bytes), None)
+                        };
                         NetworkEndpointDef {
                             host: e.host.clone(),
                             path: e.path.clone(),
                             port,
                             ports,
-                            protocol: e.protocol.clone(),
+                            protocol,
                             tls: e.tls.clone(),
                             enforcement: e.enforcement.clone(),
                             access: e.access.clone(),
-                            rules: e
-                                .rules
-                                .iter()
-                                .map(|r| {
-                                    let a = r.allow.clone().unwrap_or_default();
-                                    L7RuleDef {
-                                        allow: L7AllowDef {
-                                            method: a.method,
-                                            path: a.path,
-                                            command: a.command,
-                                            operation_type: a.operation_type,
-                                            operation_name: a.operation_name,
-                                            fields: a.fields,
-                                            query: a
-                                                .query
-                                                .into_iter()
-                                                .map(|(key, matcher)| {
-                                                    let yaml_matcher = if matcher.any.is_empty() {
-                                                        QueryMatcherDef::Glob(matcher.glob)
-                                                    } else {
-                                                        QueryMatcherDef::Any(QueryAnyDef {
-                                                            any: matcher.any,
-                                                        })
-                                                    };
-                                                    (key, yaml_matcher)
-                                                })
-                                                .collect(),
-                                        },
-                                    }
-                                })
-                                .collect(),
+                            rules,
                             allowed_ips: e.allowed_ips.clone(),
-                            deny_rules: e
-                                .deny_rules
-                                .iter()
-                                .map(|d| L7DenyRuleDef {
-                                    method: d.method.clone(),
-                                    path: d.path.clone(),
-                                    command: d.command.clone(),
-                                    operation_type: d.operation_type.clone(),
-                                    operation_name: d.operation_name.clone(),
-                                    fields: d.fields.clone(),
-                                    query: d
-                                        .query
-                                        .iter()
-                                        .map(|(key, matcher)| {
-                                            let yaml_matcher = if matcher.any.is_empty() {
-                                                QueryMatcherDef::Glob(matcher.glob.clone())
-                                            } else {
-                                                QueryMatcherDef::Any(QueryAnyDef {
-                                                    any: matcher.any.clone(),
-                                                })
-                                            };
-                                            (key.clone(), yaml_matcher)
-                                        })
-                                        .collect(),
-                                })
-                                .collect(),
+                            deny_rules,
                             allow_encoded_slash: e.allow_encoded_slash,
                             websocket_credential_rewrite: e.websocket_credential_rewrite,
                             request_body_credential_rewrite: e.request_body_credential_rewrite,
@@ -527,6 +890,8 @@ fn from_proto(policy: &SandboxPolicy) -> PolicyFile {
                             credential_signing: e.credential_signing.clone(),
                             signing_service: e.signing_service.clone(),
                             signing_region: e.signing_region.clone(),
+                            json_rpc,
+                            mcp,
                         }
                     })
                     .collect(),
@@ -1162,6 +1527,35 @@ network_policies:
     fn parse_rejects_unknown_fields() {
         let yaml = "version: 1\nbogus_field: true\n";
         assert!(parse_sandbox_policy(yaml).is_err());
+    }
+
+    #[test]
+    fn l7_config_stanza_runtime_fields_use_canonical_schema() {
+        let fields = l7_config_alias_runtime_fields(
+            L7ConfigStanza::Mcp,
+            serde_json::json!({
+                "max_body_bytes": 131_072,
+                "strict_tool_names": false,
+                "allow_all_known_mcp_methods": true
+            }),
+        )
+        .expect("valid mcp config");
+
+        assert_eq!(
+            fields,
+            vec![
+                ("json_rpc_max_body_bytes", serde_json::json!(131_072)),
+                ("mcp_strict_tool_names", serde_json::json!(false)),
+                ("mcp_allow_all_known_mcp_methods", serde_json::json!(true)),
+            ]
+        );
+
+        let err = l7_config_alias_runtime_fields(
+            L7ConfigStanza::JsonRpc,
+            serde_json::json!({"on_parse_error": "allow"}),
+        )
+        .expect_err("unknown JSON-RPC config fields must be rejected");
+        assert!(err.to_string().contains("on_parse_error"));
     }
 
     #[test]
@@ -1932,6 +2326,155 @@ network_policies:
         assert_eq!(ep.rules[1].allow.as_ref().unwrap().operation_name, "Issue*");
         assert_eq!(ep.deny_rules[0].operation_type, "mutation");
         assert_eq!(ep.deny_rules[0].fields, vec!["deleteRepository"]);
+    }
+
+    #[test]
+    fn round_trip_preserves_json_rpc_max_body_bytes() {
+        let yaml = r"
+version: 1
+network_policies:
+  jsonrpc_api:
+    name: jsonrpc_api
+    endpoints:
+      - host: jsonrpc.example.com
+        port: 443
+        protocol: json-rpc
+        enforcement: enforce
+        json_rpc:
+          max_body_bytes: 131072
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - path: /usr/bin/curl
+";
+        let proto1 = parse_sandbox_policy(yaml).expect("parse failed");
+        let yaml_out = serialize_sandbox_policy(&proto1).expect("serialize failed");
+        let proto2 = parse_sandbox_policy(&yaml_out).expect("re-parse failed");
+
+        let ep = &proto2.network_policies["jsonrpc_api"].endpoints[0];
+        assert_eq!(ep.protocol, "json-rpc");
+        assert_eq!(ep.json_rpc_max_body_bytes, 131_072);
+    }
+
+    #[test]
+    fn parse_mcp_rules_to_runtime_fields() {
+        let yaml = r"
+version: 1
+network_policies:
+  mcp:
+    name: mcp
+    endpoints:
+      - host: mcp.example.com
+        port: 443
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        mcp:
+          max_body_bytes: 131072
+          strict_tool_names: false
+        rules:
+          - allow:
+              method: initialize
+          - allow:
+              method: tools/list
+          - allow:
+              method: tools/call
+              tool:
+                any: [search_web, list_tools]
+        deny_rules:
+          - method: tools/call
+            tool: send_email
+    binaries:
+      - path: /usr/bin/curl
+";
+        let proto = parse_sandbox_policy(yaml).expect("parse failed");
+        let ep = &proto.network_policies["mcp"].endpoints[0];
+
+        assert_eq!(ep.protocol, "mcp");
+        assert_eq!(ep.json_rpc_max_body_bytes, 131_072);
+        assert_eq!(
+            ep.mcp
+                .as_ref()
+                .and_then(|options| options.strict_tool_names),
+            Some(false)
+        );
+        assert_eq!(ep.rules.len(), 3);
+        assert_eq!(ep.rules[2].allow.as_ref().unwrap().method, "tools/call");
+        assert_eq!(
+            ep.rules[2].allow.as_ref().unwrap().params["name"].any,
+            vec!["search_web".to_string(), "list_tools".to_string()]
+        );
+        assert_eq!(ep.deny_rules.len(), 1);
+        assert_eq!(ep.deny_rules[0].method, "tools/call");
+        assert_eq!(ep.deny_rules[0].params["name"].glob, "send_email");
+    }
+
+    #[test]
+    fn round_trip_mcp_policy_serializes_mcp_expression() {
+        let yaml = r"
+version: 1
+network_policies:
+  mcp:
+    name: mcp
+    endpoints:
+      - host: mcp.example.com
+        port: 443
+        protocol: mcp
+        mcp:
+          max_body_bytes: 131072
+          strict_tool_names: false
+        rules:
+          - allow:
+              method: tools/call
+              tool: search_web
+        deny_rules:
+          - method: tools/call
+            tool:
+              any: [send_email, delete_resource]
+    binaries:
+      - path: /usr/bin/curl
+";
+        let proto1 = parse_sandbox_policy(yaml).expect("parse failed");
+        let yaml_out = serialize_sandbox_policy(&proto1).expect("serialize failed");
+        let proto2 = parse_sandbox_policy(&yaml_out).expect("re-parse failed");
+
+        assert!(yaml_out.contains("protocol: mcp"));
+        assert!(yaml_out.contains("method: tools/call"));
+        assert!(yaml_out.contains("tool: search_web"));
+        assert!(yaml_out.contains("any:"));
+        assert!(yaml_out.contains("- send_email"));
+        assert!(yaml_out.contains("- delete_resource"));
+        assert!(yaml_out.contains("deny_rules:"));
+        assert!(!yaml_out.contains("arguments:"));
+        assert!(yaml_out.contains("mcp:"));
+        assert!(yaml_out.contains("strict_tool_names: false"));
+        assert_eq!(proto1, proto2);
+    }
+
+    #[test]
+    fn parse_rejects_unsupported_json_rpc_config_fields() {
+        let yaml = r"
+version: 1
+network_policies:
+  jsonrpc_api:
+    endpoints:
+      - host: jsonrpc.example.com
+        port: 443
+        protocol: json-rpc
+        json_rpc:
+          max_body_bytes: 131072
+          on_parse_error: deny
+          batch_policy: all
+        access: full
+    binaries:
+      - path: /usr/bin/curl
+";
+
+        assert!(
+            parse_sandbox_policy(yaml).is_err(),
+            "unsupported json_rpc fields must not be silently accepted"
+        );
     }
 
     #[test]

--- a/crates/openshell-policy/src/merge.rs
+++ b/crates/openshell-policy/src/merge.rs
@@ -749,6 +749,7 @@ fn expand_access_preset(protocol: &str, access: &str) -> Option<Vec<L7Rule>> {
                     operation_type: String::new(),
                     operation_name: String::new(),
                     fields: Vec::new(),
+                    params: HashMap::default(),
                 }),
             })
             .collect(),
@@ -963,6 +964,7 @@ mod tests {
                 operation_type: String::new(),
                 operation_name: String::new(),
                 fields: Vec::new(),
+                params: HashMap::default(),
             }),
         }
     }

--- a/crates/openshell-providers/src/profiles.rs
+++ b/crates/openshell-providers/src/profiles.rs
@@ -6,10 +6,10 @@
 #![allow(deprecated)] // NetworkBinary::harness remains in the public proto for compatibility.
 
 use openshell_core::proto::{
-    GraphqlOperation, L7Allow, L7DenyRule, L7QueryMatcher, L7Rule, NetworkBinary, NetworkEndpoint,
-    NetworkPolicyRule, ProviderCredentialRefresh, ProviderCredentialRefreshMaterial,
-    ProviderCredentialRefreshStrategy, ProviderProfile, ProviderProfileCategory,
-    ProviderProfileCredential, ProviderProfileDiscovery,
+    GraphqlOperation, L7Allow, L7DenyRule, L7QueryMatcher, L7Rule, McpOptions, NetworkBinary,
+    NetworkEndpoint, NetworkPolicyRule, ProviderCredentialRefresh,
+    ProviderCredentialRefreshMaterial, ProviderCredentialRefreshStrategy, ProviderProfile,
+    ProviderProfileCategory, ProviderProfileCredential, ProviderProfileDiscovery,
 };
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
@@ -203,6 +203,10 @@ pub struct EndpointProfile {
     pub graphql_persisted_queries: HashMap<String, GraphqlOperationProfile>,
     #[serde(default, skip_serializing_if = "is_zero")]
     pub graphql_max_body_bytes: u32,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub json_rpc_max_body_bytes: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp: Option<McpOptionsProfile>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub path: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -211,6 +215,14 @@ pub struct EndpointProfile {
     pub signing_service: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub signing_region: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct McpOptionsProfile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strict_tool_names: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_all_known_mcp_methods: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -780,6 +792,8 @@ fn endpoint_to_proto(endpoint: &EndpointProfile) -> NetworkEndpoint {
             .map(|(name, operation)| (name.clone(), graphql_operation_to_proto(operation)))
             .collect(),
         graphql_max_body_bytes: endpoint.graphql_max_body_bytes,
+        json_rpc_max_body_bytes: endpoint.json_rpc_max_body_bytes,
+        mcp: endpoint.mcp.as_ref().map(mcp_options_to_proto),
         path: endpoint.path.clone(),
         credential_signing: endpoint.credential_signing.clone(),
         signing_service: endpoint.signing_service.clone(),
@@ -813,10 +827,26 @@ fn endpoint_from_proto(endpoint: &NetworkEndpoint) -> EndpointProfile {
             .map(|(name, operation)| (name.clone(), graphql_operation_from_proto(operation)))
             .collect(),
         graphql_max_body_bytes: endpoint.graphql_max_body_bytes,
+        json_rpc_max_body_bytes: endpoint.json_rpc_max_body_bytes,
+        mcp: endpoint.mcp.map(mcp_options_from_proto),
         path: endpoint.path.clone(),
         credential_signing: endpoint.credential_signing.clone(),
         signing_service: endpoint.signing_service.clone(),
         signing_region: endpoint.signing_region.clone(),
+    }
+}
+
+fn mcp_options_to_proto(options: &McpOptionsProfile) -> McpOptions {
+    McpOptions {
+        strict_tool_names: options.strict_tool_names,
+        allow_all_known_mcp_methods: options.allow_all_known_mcp_methods,
+    }
+}
+
+fn mcp_options_from_proto(options: McpOptions) -> McpOptionsProfile {
+    McpOptionsProfile {
+        strict_tool_names: options.strict_tool_names,
+        allow_all_known_mcp_methods: options.allow_all_known_mcp_methods,
     }
 }
 
@@ -859,6 +889,7 @@ fn allow_to_proto(allow: &L7AllowProfile) -> L7Allow {
         operation_type: allow.operation_type.clone(),
         operation_name: allow.operation_name.clone(),
         fields: allow.fields.clone(),
+        params: HashMap::new(),
     }
 }
 
@@ -891,6 +922,7 @@ fn deny_rule_to_proto(rule: &L7DenyRuleProfile) -> L7DenyRule {
         operation_type: rule.operation_type.clone(),
         operation_name: rule.operation_name.clone(),
         fields: rule.fields.clone(),
+        params: HashMap::new(),
     }
 }
 
@@ -1937,6 +1969,46 @@ discovery:
         let exported = profile_to_yaml(&from_proto).expect("yaml");
         assert!(exported.contains("discovery:"));
         assert!(exported.contains("api_key"));
+    }
+
+    #[test]
+    fn mcp_endpoint_strict_tool_names_round_trips_through_proto_and_yaml() {
+        let profile = parse_profile_yaml(
+            r"
+id: mcp-example
+display_name: MCP Example
+endpoints:
+  - host: mcp.example.com
+    port: 443
+    path: /mcp
+    protocol: mcp
+    mcp:
+      strict_tool_names: false
+binaries:
+  - /usr/bin/example-agent
+",
+        )
+        .expect("profile should parse");
+
+        assert_eq!(
+            profile.endpoints[0]
+                .mcp
+                .as_ref()
+                .and_then(|options| options.strict_tool_names),
+            Some(false)
+        );
+        let from_proto = ProviderTypeProfile::from_proto(&profile.to_proto());
+        assert_eq!(
+            from_proto.endpoints[0]
+                .mcp
+                .as_ref()
+                .and_then(|options| options.strict_tool_names),
+            Some(false)
+        );
+
+        let exported = profile_to_yaml(&from_proto).expect("yaml");
+        assert!(exported.contains("mcp:"));
+        assert!(exported.contains("strict_tool_names: false"));
     }
 
     #[test]

--- a/crates/openshell-sandbox/src/mechanistic_mapper.rs
+++ b/crates/openshell-sandbox/src/mechanistic_mapper.rs
@@ -355,6 +355,7 @@ fn build_l7_rules(samples: &HashMap<(String, String), u32>) -> Vec<L7Rule> {
                 operation_type: String::new(),
                 operation_name: String::new(),
                 fields: Vec::new(),
+                params: HashMap::new(),
             }),
         });
     }

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -8328,6 +8328,7 @@ mod tests {
                     operation_type: String::new(),
                     operation_name: String::new(),
                     fields: Vec::new(),
+                    params: HashMap::default(),
                 }),
             }],
         };
@@ -8723,6 +8724,7 @@ mod tests {
                     operation_type: String::new(),
                     operation_name: String::new(),
                     fields: Vec::new(),
+                    params: HashMap::default(),
                 }),
             }],
         }];
@@ -8869,6 +8871,7 @@ mod tests {
                     operation_type: String::new(),
                     operation_name: String::new(),
                     fields: Vec::new(),
+                    params: HashMap::default(),
                 }),
             }],
         };

--- a/crates/openshell-supervisor-network/Cargo.toml
+++ b/crates/openshell-supervisor-network/Cargo.toml
@@ -42,6 +42,7 @@ spiffe = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
+tower-mcp-types = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 webpki-roots = { workspace = true }

--- a/crates/openshell-supervisor-network/data/sandbox-policy.rego
+++ b/crates/openshell-supervisor-network/data/sandbox-policy.rego
@@ -257,6 +257,7 @@ deny_request if {
 # --- L7 deny rule matching: REST method + path + query ---
 
 request_denied_for_endpoint(request, endpoint) if {
+	not jsonrpc_family_endpoint(endpoint)
 	some deny_rule
 	deny_rule := endpoint.deny_rules[_]
 	deny_rule.method
@@ -272,6 +273,23 @@ request_denied_for_endpoint(request, endpoint) if {
 	deny_rule := endpoint.deny_rules[_]
 	deny_rule.command
 	command_matches(request.command, deny_rule.command)
+}
+
+# --- L7 deny rule matching: JSON-RPC method ---
+
+request_denied_for_endpoint(request, endpoint) if {
+	jsonrpc_family_endpoint(endpoint)
+	request.method == "POST"
+	some deny_rule
+	deny_rule := endpoint.deny_rules[_]
+	deny_rule.method
+	jsonrpc_rule_matches(request, endpoint, deny_rule)
+}
+
+request_denied_for_endpoint(request, endpoint) if {
+	endpoint.protocol == "json-rpc"
+	request.method == "POST"
+	jsonrpc_response_frame_present(request)
 }
 
 # --- L7 deny rule matching: GraphQL operation ---
@@ -384,8 +402,16 @@ request_deny_reason := reason if {
 
 request_deny_reason := reason if {
 	input.request
+	jsonrpc_response_frame_present(input.request)
+	matched_endpoint_config.protocol == "json-rpc"
+	reason := "JSON-RPC response frames are not permitted from client to server"
+}
+
+request_deny_reason := reason if {
+	input.request
 	deny_request
 	not graphql_request_has_operations(input.request)
+	not jsonrpc_response_frame_present(input.request)
 	reason := sprintf("%s %s blocked by deny rule", [input.request.method, input.request.path])
 }
 
@@ -394,12 +420,14 @@ request_deny_reason := reason if {
 	not deny_request
 	not allow_request
 	not graphql_request_has_operations(input.request)
+	not jsonrpc_response_frame_present(input.request)
 	reason := sprintf("%s %s not permitted by policy", [input.request.method, input.request.path])
 }
 
 # --- L7 rule matching: REST method + path ---
 
 request_allowed_for_endpoint(request, endpoint) if {
+	not jsonrpc_family_endpoint(endpoint)
 	some rule
 	rule := endpoint.rules[_]
 	rule.allow.method
@@ -415,6 +443,82 @@ request_allowed_for_endpoint(request, endpoint) if {
 	rule := endpoint.rules[_]
 	rule.allow.command
 	command_matches(request.command, rule.allow.command)
+}
+
+# --- L7 rule matching: JSON-RPC method ---
+
+request_allowed_for_endpoint(request, endpoint) if {
+	jsonrpc_family_endpoint(endpoint)
+	request.method == "POST"
+	some rule
+	rule := endpoint.rules[_]
+	rule.allow.method
+	not jsonrpc_response_frame_present(request)
+	jsonrpc_rule_matches(request, endpoint, rule.allow)
+}
+
+# MCP can allow the method layer by endpoint option while still using
+# tool-specific rules to narrow tools/call params.name.
+request_allowed_for_endpoint(request, endpoint) if {
+	endpoint.protocol == "mcp"
+	mcp_allow_all_known_mcp_methods(endpoint)
+	request.method == "POST"
+	not jsonrpc_response_frame_present(request)
+	jsonrpc := object.get(request, "jsonrpc", null)
+	is_object(jsonrpc)
+	jsonrpc_no_parse_error(jsonrpc)
+	method := object.get(jsonrpc, "method", "")
+	is_string(method)
+	method != ""
+	not mcp_tool_call_narrowed_by_policy(endpoint, method)
+}
+
+# MCP Streamable HTTP allows client-to-server JSON-RPC response frames for
+# server-originated requests such as elicitation/create. Generic JSON-RPC keeps
+# response frames denied because it has no MCP request-correlation semantics.
+request_allowed_for_endpoint(request, endpoint) if {
+	endpoint.protocol == "mcp"
+	request.method == "POST"
+	jsonrpc_response_frame_present(request)
+	jsonrpc := object.get(request, "jsonrpc", null)
+	is_object(jsonrpc)
+	jsonrpc_no_parse_error(jsonrpc)
+}
+
+jsonrpc_family_endpoint(endpoint) if {
+	endpoint.protocol == "json-rpc"
+}
+
+jsonrpc_family_endpoint(endpoint) if {
+	endpoint.protocol == "mcp"
+}
+
+mcp_allow_all_known_mcp_methods(endpoint) if {
+	object.get(endpoint, "mcp_allow_all_known_mcp_methods", false)
+}
+
+mcp_tool_call_narrowed_by_policy(endpoint, method) if {
+	method == "tools/call"
+	some rule
+	rule := endpoint.rules[_]
+	params := object.get(rule.allow, "params", {})
+	is_object(params)
+	params.name
+}
+
+# MCP Streamable HTTP uses GET on the JSON-RPC-family endpoint as a receive
+# stream for server-to-client messages. The stream itself has no
+# client-to-server JSON-RPC request body to inspect; allow it once the endpoint
+# path and binary matched.
+request_allowed_for_endpoint(request, endpoint) if {
+	endpoint.protocol == "mcp"
+	request.method == "GET"
+	jsonrpc := object.get(request, "jsonrpc", null)
+	is_object(jsonrpc)
+	object.get(jsonrpc, "receive_stream", false)
+	jsonrpc_no_parse_error(jsonrpc)
+	object.get(jsonrpc, "method", null) == null
+	not object.get(jsonrpc, "has_response", false)
 }
 
 # --- L7 rule matching: GraphQL operation ---
@@ -636,6 +740,85 @@ query_value_matches(value, matcher) if {
 	count(any_patterns) > 0
 	some i
 	glob.match(any_patterns[i], [], value)
+}
+
+# JSON-RPC-family method matching. Generic JSON-RPC policies match only method.
+# MCP policies may also match params.name from tool aliases.
+jsonrpc_rule_matches(request, endpoint, rule) if {
+	jsonrpc := object.get(request, "jsonrpc", null)
+	is_object(jsonrpc)
+	method := object.get(jsonrpc, "method", "")
+	is_string(method)
+	method != ""
+	rule_method := object.get(rule, "method", "")
+	is_string(rule_method)
+	rule_method != ""
+	jsonrpc_rule_method_matches(endpoint, method, rule_method)
+	jsonrpc_rule_params_match_for_protocol(jsonrpc, endpoint, rule)
+}
+
+jsonrpc_rule_method_matches(endpoint, _, rule_method) if {
+	endpoint.protocol == "json-rpc"
+	rule_method == "*"
+}
+
+jsonrpc_rule_method_matches(endpoint, method, rule_method) if {
+	endpoint.protocol == "json-rpc"
+	rule_method != "*"
+	rule_method == method
+}
+
+jsonrpc_rule_method_matches(endpoint, method, rule_method) if {
+	endpoint.protocol == "mcp"
+	glob.match(rule_method, [], method)
+}
+
+jsonrpc_rule_params_match_for_protocol(_, endpoint, _) if {
+	endpoint.protocol == "json-rpc"
+}
+
+jsonrpc_rule_params_match_for_protocol(jsonrpc, endpoint, rule) if {
+	endpoint.protocol == "mcp"
+	jsonrpc_params_match(jsonrpc, rule)
+}
+
+jsonrpc_response_frame_present(request) if {
+	jsonrpc := object.get(request, "jsonrpc", null)
+	is_object(jsonrpc)
+	object.get(jsonrpc, "has_response", false)
+}
+
+jsonrpc_no_parse_error(jsonrpc) if {
+	is_object(jsonrpc)
+	object.get(jsonrpc, "error", null) == null
+}
+
+jsonrpc_no_parse_error(jsonrpc) if {
+	is_object(jsonrpc)
+	object.get(jsonrpc, "error", "") == ""
+}
+
+jsonrpc_params_match(jsonrpc, rule) if {
+	is_object(jsonrpc)
+	param_rules := object.get(rule, "params", {})
+	is_object(param_rules)
+	not jsonrpc_param_mismatch(jsonrpc, param_rules)
+}
+
+jsonrpc_param_mismatch(jsonrpc, param_rules) if {
+	some key
+	matcher := param_rules[key]
+	not jsonrpc_param_key_matches(jsonrpc, key, matcher)
+}
+
+jsonrpc_param_key_matches(jsonrpc, key, matcher) if {
+	is_object(jsonrpc)
+	params := object.get(jsonrpc, "params", {})
+	is_object(params)
+	value := object.get(params, key, null)
+	value != null
+	is_string(value)
+	query_value_matches(value, matcher)
 }
 
 # SQL command matching: "*" matches any; otherwise case-insensitive.

--- a/crates/openshell-supervisor-network/src/l7/graphql.rs
+++ b/crates/openshell-supervisor-network/src/l7/graphql.rs
@@ -810,6 +810,7 @@ network_policies:
             target: req.target,
             query_params: req.query_params,
             graphql: Some(info),
+            jsonrpc: None,
         };
 
         let tunnel_engine = engine

--- a/crates/openshell-supervisor-network/src/l7/http.rs
+++ b/crates/openshell-supervisor-network/src/l7/http.rs
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared HTTP/1.1 request helpers for L7 protocols carried over HTTP.
+
+use crate::l7::provider::{BodyLength, L7Request};
+use miette::{IntoDiagnostic, Result, miette};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+const READ_BUF_SIZE: usize = 8192;
+
+pub async fn read_body_for_inspection<C: AsyncRead + Unpin>(
+    client: &mut C,
+    request: &mut L7Request,
+    max_body_bytes: usize,
+) -> Result<Vec<u8>> {
+    let header_end = request
+        .raw_header
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map_or(request.raw_header.len(), |p| p + 4);
+    let overflow = request.raw_header[header_end..].to_vec();
+
+    match request.body_length {
+        BodyLength::None => Ok(Vec::new()),
+        BodyLength::ContentLength(len) => {
+            let len = usize::try_from(len)
+                .map_err(|_| miette!("HTTP request body length exceeds platform limit"))?;
+            if len > max_body_bytes {
+                return Err(miette!(
+                    "HTTP request body exceeds {max_body_bytes} byte inspection limit"
+                ));
+            }
+            if overflow.len() > len {
+                return Err(miette!(
+                    "HTTP request contains more body bytes than Content-Length"
+                ));
+            }
+            let remaining = len - overflow.len();
+            let mut body = overflow;
+            if remaining > 0 {
+                let start = body.len();
+                body.resize(len, 0);
+                client
+                    .read_exact(&mut body[start..])
+                    .await
+                    .into_diagnostic()?;
+            }
+            request.raw_header.truncate(header_end);
+            request.raw_header.extend_from_slice(&body);
+            Ok(body)
+        }
+        BodyLength::Chunked => {
+            let body = read_chunked_body_for_inspection(
+                client,
+                request,
+                header_end,
+                overflow,
+                max_body_bytes,
+            )
+            .await?;
+            normalize_chunked_request_to_content_length(request, header_end, &body)?;
+            Ok(body)
+        }
+    }
+}
+
+fn normalize_chunked_request_to_content_length(
+    request: &mut L7Request,
+    header_end: usize,
+    body: &[u8],
+) -> Result<()> {
+    let header_str = std::str::from_utf8(&request.raw_header[..header_end])
+        .map_err(|_| miette!("HTTP headers contain invalid UTF-8"))?;
+    let header_str = header_str
+        .strip_suffix("\r\n\r\n")
+        .ok_or_else(|| miette!("HTTP headers missing terminator"))?;
+
+    let mut normalized = Vec::with_capacity(header_str.len() + body.len() + 32);
+    for (idx, line) in header_str.split("\r\n").enumerate() {
+        if idx > 0 {
+            let name = line
+                .split_once(':')
+                .map(|(name, _)| name.trim().to_ascii_lowercase());
+            if matches!(
+                name.as_deref(),
+                Some("transfer-encoding" | "content-length" | "trailer")
+            ) {
+                continue;
+            }
+        }
+        normalized.extend_from_slice(line.as_bytes());
+        normalized.extend_from_slice(b"\r\n");
+    }
+    normalized.extend_from_slice(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes());
+    normalized.extend_from_slice(body);
+
+    request.raw_header = normalized;
+    request.body_length = BodyLength::ContentLength(body.len() as u64);
+    Ok(())
+}
+
+async fn read_chunked_body_for_inspection<C: AsyncRead + Unpin>(
+    client: &mut C,
+    request: &mut L7Request,
+    header_end: usize,
+    overflow: Vec<u8>,
+    max_body_bytes: usize,
+) -> Result<Vec<u8>> {
+    let mut raw = overflow;
+    let mut decoded = Vec::new();
+    let mut pos = 0usize;
+
+    loop {
+        let size_line_end = loop {
+            if let Some(end) = find_crlf(&raw, pos) {
+                break end;
+            }
+            read_more(client, &mut raw, max_body_bytes).await?;
+        };
+        let size_line = std::str::from_utf8(&raw[pos..size_line_end])
+            .into_diagnostic()
+            .map_err(|_| miette!("Invalid UTF-8 in HTTP chunk-size line"))?;
+        let size_token = size_line
+            .split(';')
+            .next()
+            .map(str::trim)
+            .unwrap_or_default();
+        let chunk_size = usize::from_str_radix(size_token, 16)
+            .into_diagnostic()
+            .map_err(|_| miette!("Invalid HTTP chunk size token: {size_token:?}"))?;
+        pos = size_line_end + 2;
+
+        if decoded.len().saturating_add(chunk_size) > max_body_bytes {
+            return Err(miette!(
+                "HTTP request body exceeds {max_body_bytes} byte inspection limit"
+            ));
+        }
+
+        if chunk_size == 0 {
+            loop {
+                let trailer_end = loop {
+                    if let Some(end) = find_crlf(&raw, pos) {
+                        break end;
+                    }
+                    read_more(client, &mut raw, max_body_bytes).await?;
+                };
+                let trailer_line = &raw[pos..trailer_end];
+                pos = trailer_end + 2;
+                if trailer_line.is_empty() {
+                    request.raw_header.truncate(header_end);
+                    request.raw_header.extend_from_slice(&raw[..pos]);
+                    return Ok(decoded);
+                }
+            }
+        }
+
+        let chunk_end = pos
+            .checked_add(chunk_size)
+            .ok_or_else(|| miette!("HTTP chunk size overflow"))?;
+        let chunk_with_crlf_end = chunk_end
+            .checked_add(2)
+            .ok_or_else(|| miette!("HTTP chunk size overflow"))?;
+        while raw.len() < chunk_with_crlf_end {
+            read_more(client, &mut raw, max_body_bytes).await?;
+        }
+        decoded.extend_from_slice(&raw[pos..chunk_end]);
+        if raw.get(chunk_end..chunk_with_crlf_end) != Some(&b"\r\n"[..]) {
+            return Err(miette!("HTTP chunk payload missing terminating CRLF"));
+        }
+        pos = chunk_with_crlf_end;
+    }
+}
+
+async fn read_more<C: AsyncRead + Unpin>(
+    client: &mut C,
+    raw: &mut Vec<u8>,
+    max_body_bytes: usize,
+) -> Result<()> {
+    if raw.len() > max_body_bytes.saturating_mul(2).max(max_body_bytes) {
+        return Err(miette!(
+            "HTTP chunked request body exceeds inspection framing limit"
+        ));
+    }
+    let mut buf = [0u8; READ_BUF_SIZE];
+    let n = client.read(&mut buf).await.into_diagnostic()?;
+    if n == 0 {
+        return Err(miette!("HTTP chunked body ended before terminator"));
+    }
+    raw.extend_from_slice(&buf[..n]);
+    Ok(())
+}
+
+fn find_crlf(buf: &[u8], start: usize) -> Option<usize> {
+    buf.get(start..)?
+        .windows(2)
+        .position(|w| w == b"\r\n")
+        .map(|p| start + p)
+}

--- a/crates/openshell-supervisor-network/src/l7/jsonrpc.rs
+++ b/crates/openshell-supervisor-network/src/l7/jsonrpc.rs
@@ -1,0 +1,750 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! JSON-RPC 2.0 over HTTP L7 inspection.
+
+use std::collections::HashMap;
+
+use miette::Result;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tower_mcp_types::protocol::{
+    JSONRPC_VERSION, JsonRpcNotification, JsonRpcRequest, McpNotification, McpRequest,
+};
+
+use crate::l7::provider::{L7Provider, L7Request};
+
+pub const DEFAULT_MAX_BODY_BYTES: usize = 64 * 1024;
+
+/// Selects whether the parser should treat a JSON-RPC message as generic
+/// JSON-RPC 2.0 or as an MCP message with MCP method/params validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsonRpcInspectionMode {
+    JsonRpc,
+    Mcp,
+}
+
+impl JsonRpcInspectionMode {
+    pub(crate) fn for_protocol(protocol: crate::l7::L7Protocol) -> Self {
+        match protocol {
+            crate::l7::L7Protocol::Mcp => Self::Mcp,
+            _ => Self::JsonRpc,
+        }
+    }
+}
+
+/// Endpoint-specific JSON-RPC-family parser settings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JsonRpcInspectionOptions {
+    pub mode: JsonRpcInspectionMode,
+    pub mcp_strict_tool_names: bool,
+}
+
+impl JsonRpcInspectionOptions {
+    pub(crate) fn for_config(config: &crate::l7::L7EndpointConfig) -> Self {
+        Self {
+            mode: JsonRpcInspectionMode::for_protocol(config.protocol),
+            mcp_strict_tool_names: config.mcp_strict_tool_names,
+        }
+    }
+}
+
+impl From<JsonRpcInspectionMode> for JsonRpcInspectionOptions {
+    fn from(mode: JsonRpcInspectionMode) -> Self {
+        Self {
+            mode,
+            mcp_strict_tool_names: true,
+        }
+    }
+}
+
+/// Parsed HTTP request plus the JSON-RPC-family metadata extracted from the
+/// body. The original HTTP request is still forwarded if policy allows it.
+pub struct JsonRpcHttpRequest {
+    pub request: L7Request,
+    pub info: JsonRpcRequestInfo,
+}
+
+pub(crate) async fn parse_jsonrpc_http_request<C: AsyncRead + AsyncWrite + Unpin + Send>(
+    client: &mut C,
+    max_body_bytes: usize,
+    canonicalize_options: crate::l7::path::CanonicalizeOptions,
+    inspection_options: JsonRpcInspectionOptions,
+) -> Result<Option<JsonRpcHttpRequest>> {
+    let provider = crate::l7::rest::RestProvider::with_options(canonicalize_options);
+    let Some(mut request) = provider.parse_request(client).await? else {
+        return Ok(None);
+    };
+    if jsonrpc_receive_stream_request(&request) {
+        return Ok(Some(JsonRpcHttpRequest {
+            request,
+            info: JsonRpcRequestInfo::receive_stream(),
+        }));
+    }
+    let body =
+        crate::l7::http::read_body_for_inspection(client, &mut request, max_body_bytes).await?;
+    let info = parse_jsonrpc_body_with_options(&body, inspection_options);
+    Ok(Some(JsonRpcHttpRequest { request, info }))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsonRpcRequestInfo {
+    /// Calls found in the request body. Responses and receive-stream GETs have
+    /// no calls but are still represented so policy can allow relay behavior.
+    pub calls: Vec<JsonRpcCallInfo>,
+    pub is_batch: bool,
+    pub receive_stream: bool,
+    pub has_response: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsonRpcCallInfo {
+    /// JSON-RPC method, or the MCP method name after typed MCP parsing.
+    pub method: String,
+    /// Policy-visible params for JSON-RPC-family matching. Generic JSON-RPC
+    /// leaves this empty because params matching is not supported. MCP exposes
+    /// only `params.name` for tools/call tool selection.
+    pub params: HashMap<String, String>,
+    /// MCP `tools/call` tool name when known. Generic JSON-RPC leaves this
+    /// unset because params are not inspected.
+    pub tool: Option<String>,
+}
+
+impl JsonRpcRequestInfo {
+    /// MCP streamable HTTP uses an empty GET to receive server messages. It has
+    /// no request body to inspect, but it must still pass through MCP endpoints.
+    pub(crate) fn receive_stream() -> Self {
+        Self {
+            calls: Vec::new(),
+            is_batch: false,
+            receive_stream: true,
+            has_response: false,
+            error: None,
+        }
+    }
+}
+
+pub(crate) fn jsonrpc_receive_stream_request(request: &L7Request) -> bool {
+    request.action.eq_ignore_ascii_case("GET")
+        && matches!(
+            request.body_length,
+            crate::l7::provider::BodyLength::None
+                | crate::l7::provider::BodyLength::ContentLength(0)
+        )
+        && request_accepts_sse(request)
+}
+
+fn request_accepts_sse(request: &L7Request) -> bool {
+    let header_end = request
+        .raw_header
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map_or(request.raw_header.len(), |p| p + 4);
+    let header = String::from_utf8_lossy(&request.raw_header[..header_end]);
+    header.lines().skip(1).any(|line| {
+        let Some((name, value)) = line.split_once(':') else {
+            return false;
+        };
+        name.trim().eq_ignore_ascii_case("accept")
+            && value.split(',').any(|part| {
+                part.split(';').next().is_some_and(|media_type| {
+                    media_type.trim().eq_ignore_ascii_case("text/event-stream")
+                })
+            })
+    })
+}
+/// Parse a JSON-RPC-family body using the endpoint's inspection mode.
+pub fn parse_jsonrpc_body(
+    body: &[u8],
+    inspection_mode: JsonRpcInspectionMode,
+) -> JsonRpcRequestInfo {
+    parse_jsonrpc_body_with_options(body, inspection_mode.into())
+}
+
+/// Parse a JSON-RPC-family body using the endpoint's inspection options.
+pub fn parse_jsonrpc_body_with_options(
+    body: &[u8],
+    inspection_options: JsonRpcInspectionOptions,
+) -> JsonRpcRequestInfo {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return JsonRpcRequestInfo {
+            calls: Vec::new(),
+            is_batch: false,
+            receive_stream: false,
+            has_response: false,
+            error: Some("invalid JSON".to_string()),
+        };
+    };
+
+    if let serde_json::Value::Array(items) = value {
+        if items.is_empty() {
+            return JsonRpcRequestInfo {
+                calls: Vec::new(),
+                is_batch: true,
+                receive_stream: false,
+                has_response: false,
+                error: Some("empty batch".to_string()),
+            };
+        }
+        let mut calls = Vec::new();
+        let mut has_response = false;
+        for item in &items {
+            match parse_jsonrpc_message(item, inspection_options) {
+                Ok(JsonRpcMessageInfo::Call(call)) => calls.push(call),
+                Ok(JsonRpcMessageInfo::Response) => has_response = true,
+                Err(error) => {
+                    return JsonRpcRequestInfo {
+                        calls: Vec::new(),
+                        is_batch: true,
+                        receive_stream: false,
+                        has_response: false,
+                        error: Some(format!("batch item invalid: {error}")),
+                    };
+                }
+            }
+        }
+        return JsonRpcRequestInfo {
+            calls,
+            is_batch: true,
+            receive_stream: false,
+            has_response,
+            error: None,
+        };
+    }
+
+    match parse_jsonrpc_message(&value, inspection_options) {
+        Ok(JsonRpcMessageInfo::Call(call)) => JsonRpcRequestInfo {
+            calls: vec![call],
+            is_batch: false,
+            receive_stream: false,
+            has_response: false,
+            error: None,
+        },
+        Ok(JsonRpcMessageInfo::Response) => JsonRpcRequestInfo {
+            calls: Vec::new(),
+            is_batch: false,
+            receive_stream: false,
+            has_response: true,
+            error: None,
+        },
+        Err(error) => JsonRpcRequestInfo {
+            calls: Vec::new(),
+            is_batch: false,
+            receive_stream: false,
+            has_response: false,
+            error: Some(error),
+        },
+    }
+}
+
+enum JsonRpcMessageInfo {
+    Call(JsonRpcCallInfo),
+    Response,
+}
+
+// Shared framing for JSON-RPC-family messages. MCP-specific validation starts
+// only after the common JSON-RPC version/method/response checks.
+fn parse_jsonrpc_message(
+    value: &serde_json::Value,
+    inspection_options: JsonRpcInspectionOptions,
+) -> std::result::Result<JsonRpcMessageInfo, String> {
+    let version = value
+        .get("jsonrpc")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing or non-string 'jsonrpc' field".to_string())?;
+    if version != JSONRPC_VERSION {
+        return Err(format!("unsupported JSON-RPC version '{version}'"));
+    }
+
+    let has_method = value.get("method").is_some();
+    let has_response_payload = jsonrpc_response_payload_present(value);
+    if has_method && has_response_payload {
+        return Err("JSON-RPC message includes both method and result/error".to_string());
+    }
+
+    if has_response_payload {
+        parse_jsonrpc_response(value)?;
+        return Ok(JsonRpcMessageInfo::Response);
+    }
+
+    if has_method {
+        return parse_jsonrpc_call(value, inspection_options).map(JsonRpcMessageInfo::Call);
+    }
+
+    Err("missing or non-string 'method' field".to_string())
+}
+
+fn parse_jsonrpc_call(
+    value: &serde_json::Value,
+    inspection_options: JsonRpcInspectionOptions,
+) -> std::result::Result<JsonRpcCallInfo, String> {
+    // MCP mode delegates method-specific validation to tower-mcp-types. The
+    // generic mode intentionally remains looser for non-MCP JSON-RPC servers.
+    if inspection_options.mode == JsonRpcInspectionMode::Mcp {
+        return parse_mcp_call(value, inspection_options.mcp_strict_tool_names);
+    }
+
+    let method = value
+        .get("method")
+        .and_then(|m| m.as_str())
+        .ok_or_else(|| "missing or non-string 'method' field".to_string())?;
+    Ok(JsonRpcCallInfo {
+        method: method.to_string(),
+        params: HashMap::new(),
+        tool: None,
+    })
+}
+
+fn jsonrpc_response_payload_present(value: &serde_json::Value) -> bool {
+    value.get("result").is_some() || value.get("error").is_some()
+}
+
+fn parse_jsonrpc_response(value: &serde_json::Value) -> std::result::Result<(), String> {
+    let has_result = value.get("result").is_some();
+    let has_error = value.get("error").is_some();
+    match (has_result, has_error) {
+        (true, true) => return Err("JSON-RPC response includes both result and error".to_string()),
+        (false, false) => return Err("JSON-RPC response missing result or error".to_string()),
+        _ => {}
+    }
+
+    let id = value
+        .get("id")
+        .ok_or_else(|| "JSON-RPC response missing id".to_string())?;
+    if !(id.is_string() || id.is_number() || id.is_null()) {
+        return Err("JSON-RPC response id must be string, number, or null".to_string());
+    }
+
+    if let Some(error) = value.get("error")
+        && !error.is_object()
+    {
+        return Err("JSON-RPC response error must be an object".to_string());
+    }
+
+    Ok(())
+}
+
+fn parse_mcp_call(
+    value: &serde_json::Value,
+    strict_tool_names: bool,
+) -> std::result::Result<JsonRpcCallInfo, String> {
+    if value.get("id").is_some() {
+        // Typed parsing validates known MCP params, but policy method profiles
+        // stay OpenShell-owned; see McpOptions in proto/sandbox.proto.
+        let request: JsonRpcRequest = serde_json::from_value(value.clone())
+            .map_err(|error| format!("invalid MCP request: {error}"))?;
+        request
+            .validate()
+            .map_err(|error| format!("invalid MCP request: {error:?}"))?;
+        let mcp_request = McpRequest::from_jsonrpc(&request)
+            .map_err(|error| format!("invalid MCP request params: {error}"))?;
+        let tool = mcp_tool_name(&mcp_request);
+        if strict_tool_names && let Some(tool_name) = tool.as_deref() {
+            validate_mcp_tool_name(tool_name)?;
+        }
+
+        let params = mcp_policy_params(tool.as_deref());
+        return Ok(JsonRpcCallInfo {
+            method: mcp_request.method_name().to_string(),
+            params,
+            tool,
+        });
+    }
+
+    // Notifications have no id and no response expectation. Validate them as
+    // MCP notifications but keep extension notifications addressable.
+    let notification: JsonRpcNotification = serde_json::from_value(value.clone())
+        .map_err(|error| format!("invalid MCP notification: {error}"))?;
+    if notification.jsonrpc != JSONRPC_VERSION {
+        return Err(format!(
+            "unsupported JSON-RPC version '{}'",
+            notification.jsonrpc
+        ));
+    }
+    McpNotification::from_jsonrpc(&notification)
+        .map_err(|error| format!("invalid MCP notification params: {error}"))?;
+
+    Ok(JsonRpcCallInfo {
+        method: notification.method,
+        params: HashMap::new(),
+        tool: None,
+    })
+}
+
+fn mcp_tool_name(request: &McpRequest) -> Option<String> {
+    if let McpRequest::CallTool(params) = request {
+        Some(params.name.clone())
+    } else {
+        None
+    }
+}
+
+fn mcp_policy_params(tool: Option<&str>) -> HashMap<String, String> {
+    let mut params = HashMap::new();
+    if let Some(tool) = tool {
+        params.insert("name".to_string(), tool.to_string());
+    }
+    params
+}
+
+// OpenShell's default MCP hardening enforces the spec-recommended tool-name
+// boundary for tools/call. See McpOptions in proto/sandbox.proto for sources.
+fn validate_mcp_tool_name(name: &str) -> std::result::Result<(), String> {
+    if name.is_empty()
+        || name.len() > 128
+        || !name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.'))
+    {
+        return Err(
+            "MCP tool name must match ^[A-Za-z0-9_.-]{1,128}$ when strict_tool_names is enabled"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn parses_method_from_request_body() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
+        assert_eq!(
+            info.calls.first().map(|call| call.method.as_str()),
+            Some("initialize")
+        );
+        assert_eq!(info.calls.len(), 1);
+        assert!(!info.is_batch);
+        assert!(!info.has_response);
+        assert!(info.error.is_none());
+    }
+
+    #[test]
+    fn parses_jsonrpc_response_body_without_method() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"result":{"action":"accept","content":{}}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
+
+        assert!(info.calls.is_empty());
+        assert!(!info.is_batch);
+        assert!(info.has_response);
+        assert!(info.error.is_none());
+    }
+
+    #[test]
+    fn parses_jsonrpc_error_response_body_without_method() {
+        let body =
+            br#"{"jsonrpc":"2.0","id":"request-1","error":{"code":-32603,"message":"failed"}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
+
+        assert!(info.calls.is_empty());
+        assert!(info.has_response);
+        assert!(info.error.is_none());
+    }
+
+    #[test]
+    fn ignores_params_when_extracting_method() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"reports.search","params":{"query":"quarterly","filters":{"scope":"workspace/main"}}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
+        assert!(info.error.is_none());
+        assert_eq!(
+            info.calls.first().map(|call| call.method.as_str()),
+            Some("reports.search")
+        );
+        let call = info.calls.first().expect("single request call");
+        assert!(call.params.is_empty());
+        assert!(call.tool.is_none());
+    }
+
+    #[test]
+    fn ignores_dotted_param_collisions_for_generic_jsonrpc() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"reports.search","params":{"filters.scope":{"value":"literal"},"filters":{"scope.value":"nested"}}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
+
+        assert!(info.error.is_none(), "params should be ignored: {info:?}");
+        assert_eq!(
+            info.calls.first().map(|call| call.method.as_str()),
+            Some("reports.search")
+        );
+        assert!(
+            info.calls
+                .first()
+                .is_some_and(|call| call.params.is_empty() && call.tool.is_none())
+        );
+    }
+
+    #[test]
+    fn mcp_mode_validates_known_methods_and_extracts_tool() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_web","arguments":{"query":"openshell"}}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::Mcp);
+
+        assert!(info.error.is_none(), "expected valid MCP call: {info:?}");
+        let call = info.calls.first().expect("single MCP call");
+        assert_eq!(call.method, "tools/call");
+        assert_eq!(call.tool.as_deref(), Some("search_web"));
+        assert_eq!(
+            call.params.get("name").map(String::as_str),
+            Some("search_web")
+        );
+        assert_eq!(call.params.len(), 1);
+    }
+
+    #[test]
+    fn mcp_mode_rejects_non_recommended_tool_names_by_default() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read status","arguments":{}}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::Mcp);
+
+        assert!(info.calls.is_empty());
+        assert!(
+            info.error
+                .as_deref()
+                .is_some_and(|error| error.contains("strict_tool_names")),
+            "expected strict tool-name error, got {info:?}"
+        );
+    }
+
+    #[test]
+    fn mcp_mode_can_disable_strict_tool_names() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read status","arguments":{}}}"#;
+        let info = parse_jsonrpc_body_with_options(
+            body,
+            JsonRpcInspectionOptions {
+                mode: JsonRpcInspectionMode::Mcp,
+                mcp_strict_tool_names: false,
+            },
+        );
+
+        let call = info
+            .calls
+            .first()
+            .expect("permissive MCP call should parse");
+        assert!(info.error.is_none(), "permissive MCP call failed: {info:?}");
+        assert_eq!(call.tool.as_deref(), Some("read status"));
+        assert_eq!(
+            call.params.get("name").map(String::as_str),
+            Some("read status")
+        );
+    }
+
+    #[test]
+    fn mcp_mode_rejects_invalid_known_method_params() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"arguments":{"query":"openshell"}}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::Mcp);
+
+        assert!(info.calls.is_empty());
+        assert!(
+            info.error
+                .as_deref()
+                .is_some_and(|error| error.contains("invalid MCP request params")),
+            "expected MCP params validation error, got {info:?}"
+        );
+    }
+
+    #[test]
+    fn mcp_mode_allows_unknown_extension_methods() {
+        let body =
+            br#"{"jsonrpc":"2.0","id":1,"method":"vendor/extension","params":{"name":"custom"}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::Mcp);
+
+        assert!(
+            info.error.is_none(),
+            "extension method should remain addressable"
+        );
+        assert_eq!(
+            info.calls.first().map(|call| call.method.as_str()),
+            Some("vendor/extension")
+        );
+        assert!(
+            info.calls
+                .first()
+                .is_some_and(|call| call.params.is_empty() && call.tool.is_none())
+        );
+    }
+
+    #[test]
+    fn mcp_mode_ignores_tool_arguments_when_extracting_policy_params() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_status","arguments":{"scope.key":"literal","scope":{"key":"nested"}}}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::Mcp);
+        let call = info.calls.first().expect("single MCP call");
+
+        assert!(info.error.is_none(), "expected valid MCP call: {info:?}");
+        assert_eq!(call.tool.as_deref(), Some("read_status"));
+        assert_eq!(
+            call.params.get("name").map(String::as_str),
+            Some("read_status")
+        );
+        assert_eq!(call.params.len(), 1);
+    }
+
+    #[test]
+    fn accepts_any_valid_jsonrpc_params_shape() {
+        let body =
+            br#"{"jsonrpc":"2.0","id":1,"method":"reports.search","params":["ignored",{"nested":true}]}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
+
+        assert!(info.error.is_none());
+        assert_eq!(
+            info.calls.first().map(|call| call.method.as_str()),
+            Some("reports.search")
+        );
+        assert!(
+            info.calls
+                .first()
+                .is_some_and(|call| call.params.is_empty() && call.tool.is_none())
+        );
+    }
+
+    #[test]
+    fn recognizes_streamable_http_get_receive_streams() {
+        let request = L7Request {
+            action: "GET".to_string(),
+            target: "/rpc".to_string(),
+            query_params: HashMap::new(),
+            raw_header: b"GET /rpc HTTP/1.1\r\nHost: jsonrpc.test\r\nAccept: application/json, text/event-stream\r\n\r\n".to_vec(),
+            body_length: crate::l7::provider::BodyLength::None,
+        };
+
+        assert!(jsonrpc_receive_stream_request(&request));
+
+        let info = JsonRpcRequestInfo::receive_stream();
+        assert!(info.receive_stream);
+        assert!(info.error.is_none());
+        assert!(info.calls.is_empty());
+    }
+
+    #[test]
+    fn bodyless_get_without_sse_accept_is_not_receive_stream() {
+        let request = L7Request {
+            action: "GET".to_string(),
+            target: "/rpc".to_string(),
+            query_params: HashMap::new(),
+            raw_header:
+                b"GET /rpc HTTP/1.1\r\nHost: jsonrpc.test\r\nAccept: application/json\r\n\r\n"
+                    .to_vec(),
+            body_length: crate::l7::provider::BodyLength::None,
+        };
+
+        assert!(!jsonrpc_receive_stream_request(&request));
+    }
+
+    #[test]
+    fn rejects_requests_missing_jsonrpc_version() {
+        let body = br#"{"id":1,"method":"reports.list"}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
+
+        assert!(info.calls.is_empty());
+        assert_eq!(
+            info.error.as_deref(),
+            Some("missing or non-string 'jsonrpc' field")
+        );
+    }
+
+    #[test]
+    fn rejects_batch_items_missing_jsonrpc_version() {
+        let body = br#"[
+            {"jsonrpc":"2.0","id":1,"method":"reports.list"},
+            {"id":2,"method":"reports.search","params":{"query":"quarterly"}}
+        ]"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
+
+        assert!(info.calls.is_empty());
+        assert!(info.is_batch);
+        assert_eq!(
+            info.error.as_deref(),
+            Some("batch item invalid: missing or non-string 'jsonrpc' field")
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_jsonrpc_version() {
+        let body = br#"{"jsonrpc":"1.0","id":1,"method":"reports.list"}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
+
+        assert!(info.calls.is_empty());
+        assert_eq!(
+            info.error.as_deref(),
+            Some("unsupported JSON-RPC version '1.0'")
+        );
+    }
+
+    #[test]
+    fn parses_valid_batch_without_error() {
+        let body = br#"[
+            {"jsonrpc":"2.0","id":1,"method":"reports.list"},
+            {"jsonrpc":"2.0","id":2,"method":"reports.search","params":{"query":"quarterly"}}
+        ]"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
+        assert!(info.error.is_none());
+        assert!(info.is_batch);
+        assert!(!info.has_response);
+        assert_eq!(info.calls.len(), 2);
+        assert_eq!(info.calls[0].method, "reports.list");
+        assert_eq!(info.calls[1].method, "reports.search");
+    }
+
+    #[test]
+    fn parses_batch_with_calls_and_responses() {
+        let body = br#"[
+            {"jsonrpc":"2.0","id":1,"method":"reports.list"},
+            {"jsonrpc":"2.0","id":2,"result":{"ok":true}}
+        ]"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
+
+        assert!(info.error.is_none());
+        assert!(info.is_batch);
+        assert!(info.has_response);
+        assert_eq!(info.calls.len(), 1);
+        assert_eq!(info.calls[0].method, "reports.list");
+    }
+
+    #[test]
+    fn rejects_invalid_jsonrpc_response_body() {
+        let body =
+            br#"{"jsonrpc":"2.0","id":1,"result":{},"error":{"code":-32603,"message":"failed"}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
+
+        assert!(info.calls.is_empty());
+        assert!(!info.has_response);
+        assert_eq!(
+            info.error.as_deref(),
+            Some("JSON-RPC response includes both result and error")
+        );
+    }
+
+    #[test]
+    fn rejects_message_with_method_and_result_or_error() {
+        let result_body = br#"{"jsonrpc":"2.0","id":1,"method":"initialize","result":{}}"#;
+        let result_info = parse_jsonrpc_body(result_body, JsonRpcInspectionMode::JsonRpc);
+        assert!(result_info.calls.is_empty());
+        assert_eq!(
+            result_info.error.as_deref(),
+            Some("JSON-RPC message includes both method and result/error")
+        );
+
+        let error_body = br#"{"jsonrpc":"2.0","id":1,"method":"initialize","error":{"code":-32603,"message":"failed"}}"#;
+        let error_info = parse_jsonrpc_body(error_body, JsonRpcInspectionMode::JsonRpc);
+        assert!(error_info.calls.is_empty());
+        assert_eq!(
+            error_info.error.as_deref(),
+            Some("JSON-RPC message includes both method and result/error")
+        );
+    }
+
+    #[test]
+    fn rejects_batch_item_with_method_and_result() {
+        let body = br#"[
+            {"jsonrpc":"2.0","id":1,"method":"reports.list"},
+            {"jsonrpc":"2.0","id":2,"method":"initialize","result":{}}
+        ]"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
+
+        assert!(info.calls.is_empty());
+        assert!(info.is_batch);
+        assert_eq!(
+            info.error.as_deref(),
+            Some("batch item invalid: JSON-RPC message includes both method and result/error")
+        );
+    }
+}

--- a/crates/openshell-supervisor-network/src/l7/mod.rs
+++ b/crates/openshell-supervisor-network/src/l7/mod.rs
@@ -9,7 +9,9 @@
 //! evaluated against OPA policy, and either forwarded or denied.
 
 pub mod graphql;
+pub(crate) mod http;
 pub mod inference;
+pub mod jsonrpc;
 pub mod path;
 pub mod provider;
 pub mod relay;
@@ -25,6 +27,8 @@ pub enum L7Protocol {
     Websocket,
     Graphql,
     Sql,
+    JsonRpc,
+    Mcp,
 }
 
 impl L7Protocol {
@@ -34,8 +38,14 @@ impl L7Protocol {
             "websocket" => Some(Self::Websocket),
             "graphql" => Some(Self::Graphql),
             "sql" => Some(Self::Sql),
+            "json-rpc" => Some(Self::JsonRpc),
+            "mcp" => Some(Self::Mcp),
             _ => None,
         }
+    }
+
+    pub fn is_jsonrpc_family(self) -> bool {
+        matches!(self, Self::JsonRpc | Self::Mcp)
     }
 }
 
@@ -96,6 +106,11 @@ pub struct L7EndpointConfig {
     pub enforcement: EnforcementMode,
     /// Maximum GraphQL request body bytes to buffer for inspection.
     pub graphql_max_body_bytes: usize,
+    /// Maximum JSON-RPC request body bytes to buffer for inspection.
+    pub json_rpc_max_body_bytes: usize,
+    /// MCP-only strict validation for tools/call params.name. Defaults to true
+    /// for MCP endpoints and is ignored by other JSON-RPC-family protocols.
+    pub mcp_strict_tool_names: bool,
     /// When true, percent-encoded `/` (`%2F`) is preserved in path segments
     /// rather than rejected at the parser. Needed by upstreams like GitLab
     /// that embed `%2F` in namespaced project paths. Defaults to false.
@@ -138,6 +153,8 @@ pub struct L7RequestInfo {
     pub query_params: std::collections::HashMap<String, Vec<String>>,
     /// Parsed GraphQL operation metadata for GraphQL endpoints.
     pub graphql: Option<graphql::GraphqlRequestInfo>,
+    /// Parsed JSON-RPC request metadata for JSON-RPC endpoints.
+    pub jsonrpc: Option<jsonrpc::JsonRpcRequestInfo>,
 }
 
 /// Parse an L7 endpoint config from a regorus Value (returned by Rego query).
@@ -193,6 +210,12 @@ pub fn parse_l7_config(val: &regorus::Value) -> Option<L7EndpointConfig> {
         .and_then(|v| usize::try_from(v).ok())
         .filter(|v| *v > 0)
         .unwrap_or(graphql::DEFAULT_MAX_BODY_BYTES);
+    let json_rpc_max_body_bytes = get_object_u64(val, "json_rpc_max_body_bytes")
+        .and_then(|v| usize::try_from(v).ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(jsonrpc::DEFAULT_MAX_BODY_BYTES);
+    let mcp_strict_tool_names = protocol == L7Protocol::Mcp
+        && get_object_bool(val, "mcp_strict_tool_names").unwrap_or(true);
 
     let credential_signing = match get_object_str(val, "credential_signing").as_deref() {
         Some("sigv4") => CredentialSigning::SigV4,
@@ -231,6 +254,8 @@ pub fn parse_l7_config(val: &regorus::Value) -> Option<L7EndpointConfig> {
         tls,
         enforcement,
         graphql_max_body_bytes,
+        json_rpc_max_body_bytes,
+        mcp_strict_tool_names,
         allow_encoded_slash,
         websocket_credential_rewrite,
         request_body_credential_rewrite,
@@ -532,6 +557,332 @@ fn validate_graphql_rule(
     validate_graphql_fields(errors, warnings, loc, rule.get("fields"));
 }
 
+// Validate a matcher map when it exists. Null is treated like omission because
+// policy loading normalizes absent optional maps the same way.
+fn validate_matcher_map(
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    loc: &str,
+    value: Option<&serde_json::Value>,
+) {
+    let Some(value) = value.filter(|v| !v.is_null()) else {
+        return;
+    };
+    let Some(obj) = value.as_object() else {
+        errors.push(format!("{loc}: expected map of matchers"));
+        return;
+    };
+
+    for (key, matcher) in obj {
+        validate_matcher_value(errors, warnings, &format!("{loc}.{key}"), matcher);
+    }
+}
+
+// Validate one matcher leaf. Objects must use the explicit matcher keys.
+fn validate_matcher_value(
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    loc: &str,
+    matcher: &serde_json::Value,
+) {
+    if let Some(glob_str) = matcher.as_str() {
+        if let Some(warning) = check_glob_syntax(glob_str) {
+            warnings.push(format!("{loc}: {warning}"));
+        }
+        return;
+    }
+
+    let Some(matcher_obj) = matcher.as_object() else {
+        errors.push(format!("{loc}: expected string glob or matcher object"));
+        return;
+    };
+
+    let has_any = matcher_obj.get("any").is_some();
+    let has_glob = matcher_obj.get("glob").is_some();
+    if !has_any && !has_glob {
+        errors.push(format!(
+            "{loc}: unknown matcher keys; only `glob` or `any` are supported"
+        ));
+        return;
+    }
+
+    let has_unknown = matcher_obj.keys().any(|k| k != "any" && k != "glob");
+    if has_unknown {
+        errors.push(format!(
+            "{loc}: unknown matcher keys; only `glob` or `any` are supported"
+        ));
+        return;
+    }
+
+    if has_glob && has_any {
+        errors.push(format!(
+            "{loc}: matcher cannot specify both `glob` and `any`"
+        ));
+        return;
+    }
+
+    if has_glob {
+        match matcher_obj.get("glob").and_then(|v| v.as_str()) {
+            None => errors.push(format!("{loc}.glob: expected glob string")),
+            Some(glob_str) => {
+                if let Some(warning) = check_glob_syntax(glob_str) {
+                    warnings.push(format!("{loc}.glob: {warning}"));
+                }
+            }
+        }
+        return;
+    }
+
+    let Some(any) = matcher_obj.get("any").and_then(|v| v.as_array()) else {
+        errors.push(format!("{loc}.any: expected array of glob strings"));
+        return;
+    };
+    if any.is_empty() {
+        errors.push(format!("{loc}.any: list must not be empty"));
+        return;
+    }
+    if any.iter().any(|v| v.as_str().is_none()) {
+        errors.push(format!("{loc}.any: all values must be strings"));
+    }
+    for item in any.iter().filter_map(|v| v.as_str()) {
+        if let Some(warning) = check_glob_syntax(item) {
+            warnings.push(format!("{loc}.any: {warning}"));
+        }
+    }
+}
+
+// Validate the shared JSON-RPC-family rule surface. Generic JSON-RPC requires
+// an explicit method but does not support authored params matchers yet. MCP
+// keeps method optional while the endpoint-level method profile is enabled;
+// disabling that profile makes method explicit on every authored MCP rule. MCP
+// does not expose tool-argument matching.
+fn validate_jsonrpc_rule_fields(
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    loc: &str,
+    rule: &serde_json::Value,
+    protocol: &str,
+    mcp_strict_tool_names: bool,
+    mcp_allow_all_known_mcp_methods: bool,
+) {
+    let method = rule.get("method").and_then(|v| v.as_str()).unwrap_or("");
+    let has_params = rule.get("params").is_some_and(|v| !v.is_null());
+    let has_tool = rule.get("tool").is_some_and(|v| !v.is_null());
+    let has_tool_selector = mcp_rule_has_tool_selector(rule);
+
+    if protocol == "json-rpc" {
+        if method.is_empty() {
+            errors.push(format!("{loc}.method: required for {protocol} L7 rules"));
+        } else if method != "*" && glob_uses_wildcard(method) {
+            errors.push(format!(
+                "{loc}.method: generic JSON-RPC method rules do not support glob or wildcard matchers; use \"*\" to allow all methods or an exact method name"
+            ));
+        }
+        if has_params {
+            errors.push(format!(
+                "{loc}: JSON-RPC rules do not support params matchers yet"
+            ));
+        }
+        if has_tool {
+            errors.push(format!(
+                "{loc}.tool: MCP tool matching is only valid for protocol mcp"
+            ));
+        }
+        if json_rule_has_non_empty_path_or_query(rule) {
+            errors.push(format!(
+                "{loc}: {protocol} L7 rules must use method, not path/query"
+            ));
+        }
+        return;
+    }
+
+    if protocol == "mcp" {
+        validate_mcp_method_field(errors, warnings, loc, method);
+        if method.is_empty() && !mcp_allow_all_known_mcp_methods {
+            errors.push(format!(
+                "{loc}.method: required when mcp.allow_all_known_mcp_methods is false"
+            ));
+        } else if has_tool_selector && !method.is_empty() && method != "tools/call" {
+            errors.push(format!(
+                "{loc}.method: must be tools/call when an MCP rule uses tool or params.name, got '{method}'"
+            ));
+        }
+        validate_mcp_tool_field(errors, warnings, loc, rule, mcp_strict_tool_names);
+        validate_mcp_params_field(errors, warnings, loc, rule, has_tool, mcp_strict_tool_names);
+        if json_rule_has_non_empty_path_or_query(rule) {
+            errors.push(format!(
+                "{loc}: {protocol} L7 rules must use method/tool, not path/query"
+            ));
+        }
+        return;
+    }
+
+    if has_tool {
+        errors.push(format!(
+            "{loc}.tool: MCP tool matching is only valid for protocol mcp"
+        ));
+    }
+
+    if has_params {
+        errors.push(format!(
+            "{loc}.params: params matching is only valid for protocol mcp"
+        ));
+    }
+}
+
+fn validate_mcp_method_field(
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    loc: &str,
+    method: &str,
+) {
+    if method.is_empty() {
+        return;
+    }
+    if let Some(warning) = check_glob_syntax(method) {
+        warnings.push(format!("{loc}.method: {warning}"));
+    }
+    if glob_uses_wildcard(method) && !method.starts_with("tools/") {
+        errors.push(format!(
+            "{loc}.method: MCP method globs are only valid for the tools/ method family; omit method to use the endpoint method profile"
+        ));
+    }
+}
+
+fn method_matcher_matches_tools_call(method: &str) -> bool {
+    method == "tools/call"
+        || method == "*"
+        || glob::Pattern::new(method).is_ok_and(|pattern| pattern.matches("tools/call"))
+}
+
+fn mcp_rule_has_tool_selector(rule: &serde_json::Value) -> bool {
+    rule.get("tool").is_some_and(|v| !v.is_null())
+        || rule
+            .get("params")
+            .and_then(serde_json::Value::as_object)
+            .and_then(|params| params.get("name"))
+            .is_some_and(|v| !v.is_null())
+}
+
+fn mcp_endpoint_has_tool_allow_selectors(ep: &serde_json::Value) -> bool {
+    ep.get("rules")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|rules| {
+            rules.iter().any(|rule| {
+                let allow = rule.get("allow").unwrap_or(rule);
+                mcp_rule_has_tool_selector(allow)
+            })
+        })
+}
+
+fn validate_mcp_tool_field(
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    loc: &str,
+    rule: &serde_json::Value,
+    mcp_strict_tool_names: bool,
+) {
+    let Some(tool) = rule.get("tool").filter(|v| !v.is_null()) else {
+        return;
+    };
+    validate_matcher_value(errors, warnings, &format!("{loc}.tool"), tool);
+    validate_mcp_tool_name_wildcard_policy(
+        errors,
+        &format!("{loc}.tool"),
+        tool,
+        mcp_strict_tool_names,
+    );
+}
+
+fn validate_mcp_params_field(
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    loc: &str,
+    rule: &serde_json::Value,
+    has_tool: bool,
+    mcp_strict_tool_names: bool,
+) {
+    let Some(params) = rule.get("params").filter(|v| !v.is_null()) else {
+        return;
+    };
+    let Some(params_obj) = params.as_object() else {
+        errors.push(format!("{loc}.params: expected map of matchers"));
+        return;
+    };
+
+    if has_tool && params_obj.contains_key("name") {
+        errors.push(format!(
+            "{loc}: MCP rules must use either tool or params.name, not both"
+        ));
+    }
+
+    for key in params_obj.keys() {
+        if key != "name" {
+            errors.push(format!(
+                "{loc}.params.{key}: MCP tool argument matching is not supported yet"
+            ));
+        }
+    }
+
+    if let Some(name_matcher) = params_obj.get("name") {
+        validate_matcher_value(
+            errors,
+            warnings,
+            &format!("{loc}.params.name"),
+            name_matcher,
+        );
+        validate_mcp_tool_name_wildcard_policy(
+            errors,
+            &format!("{loc}.params.name"),
+            name_matcher,
+            mcp_strict_tool_names,
+        );
+    }
+}
+
+fn validate_mcp_tool_name_wildcard_policy(
+    errors: &mut Vec<String>,
+    loc: &str,
+    matcher: &serde_json::Value,
+    mcp_strict_tool_names: bool,
+) {
+    if !mcp_strict_tool_names && matcher_uses_glob_wildcard(matcher) {
+        errors.push(format!(
+            "{loc}: wildcard tool-name matchers require mcp.strict_tool_names to remain enabled"
+        ));
+    }
+}
+
+fn matcher_uses_glob_wildcard(matcher: &serde_json::Value) -> bool {
+    if let Some(glob) = matcher.as_str() {
+        return glob_uses_wildcard(glob);
+    }
+
+    let Some(obj) = matcher.as_object() else {
+        return false;
+    };
+    if obj
+        .get("glob")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(glob_uses_wildcard)
+    {
+        return true;
+    }
+    obj.get("any")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|values| {
+            values
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .any(glob_uses_wildcard)
+        })
+}
+
+fn glob_uses_wildcard(glob: &str) -> bool {
+    glob.bytes()
+        .any(|b| matches!(b, b'*' | b'?' | b'[' | b']' | b'{' | b'}'))
+}
+
 fn json_rule_has_graphql_fields(rule: &serde_json::Value) -> bool {
     rule.get("operation_type")
         .and_then(|v| v.as_str())
@@ -545,6 +896,16 @@ fn json_rule_has_graphql_fields(rule: &serde_json::Value) -> bool {
 
 fn json_rule_has_transport_fields(rule: &serde_json::Value) -> bool {
     rule.get("method").is_some() || rule.get("path").is_some() || rule.get("query").is_some()
+}
+
+fn json_rule_has_non_empty_path_or_query(rule: &serde_json::Value) -> bool {
+    rule.get("path")
+        .and_then(|v| v.as_str())
+        .is_some_and(|v| !v.is_empty())
+        || rule
+            .get("query")
+            .and_then(|v| v.as_object())
+            .is_some_and(|v| !v.is_empty())
 }
 
 fn json_endpoint_has_graphql_policy(ep: &serde_json::Value) -> bool {
@@ -593,6 +954,8 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
 
         for (i, ep) in endpoints.iter().enumerate() {
             let protocol = ep.get("protocol").and_then(|v| v.as_str()).unwrap_or("");
+            let l7_protocol = L7Protocol::parse(protocol);
+            let jsonrpc_family = l7_protocol.is_some_and(L7Protocol::is_jsonrpc_family);
             let tls = ep.get("tls").and_then(|v| v.as_str()).unwrap_or("");
             let enforcement = ep.get("enforcement").and_then(|v| v.as_str()).unwrap_or("");
             let access = ep.get("access").and_then(|v| v.as_str()).unwrap_or("");
@@ -617,6 +980,19 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                 |arr| arr.iter().filter_map(serde_json::Value::as_u64).collect(),
             );
             let loc = format!("{name}.endpoints[{i}]");
+
+            if protocol == "mcp" {
+                if host.trim().is_empty() {
+                    errors.push(format!(
+                        "{loc}: protocol mcp requires host; protocol alone is not a wildcard endpoint"
+                    ));
+                }
+                if !ports.iter().any(|port| *port > 0) {
+                    errors.push(format!(
+                        "{loc}: protocol mcp requires port or ports; protocol alone is not a wildcard endpoint"
+                    ));
+                }
+            }
 
             if !endpoint_path.is_empty() {
                 if !endpoint_path.starts_with('/') && endpoint_path != "**" {
@@ -651,16 +1027,34 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                 errors.push(format!("{loc}: rules and access are mutually exclusive"));
             }
 
+            if jsonrpc_family && !access.is_empty() {
+                if protocol == "mcp" {
+                    errors.push(format!(
+                        "{loc}: protocol {protocol} does not support access presets; use rules/deny_rules or set mcp.allow_all_known_mcp_methods: true for an allow-all MCP policy"
+                    ));
+                } else {
+                    errors.push(format!(
+                        "{loc}: protocol {protocol} does not support access presets; use explicit rules with allow.method such as \"*\""
+                    ));
+                }
+            }
+
+            if protocol == "json-rpc" && !has_rules {
+                errors.push(format!(
+                    "{loc}: protocol {protocol} requires explicit rules with allow.method"
+                ));
+            }
+
             // protocol requires rules or access
-            if !protocol.is_empty() && !has_rules && access.is_empty() {
+            if !protocol.is_empty() && protocol != "mcp" && !has_rules && access.is_empty() {
                 errors.push(format!(
                     "{loc}: protocol requires rules or access to define allowed traffic"
                 ));
             }
 
-            if !protocol.is_empty() && L7Protocol::parse(protocol).is_none() {
+            if !protocol.is_empty() && l7_protocol.is_none() {
                 errors.push(format!(
-                    "{loc}: unknown protocol '{protocol}' (expected rest, websocket, graphql, or sql)"
+                    "{loc}: unknown protocol '{protocol}' (expected rest, websocket, graphql, sql, json-rpc, or mcp)"
                 ));
             }
 
@@ -686,6 +1080,18 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                 }
             }
 
+            if ep.get("json_rpc_max_body_bytes").is_some() {
+                let valid_max = ep
+                    .get("json_rpc_max_body_bytes")
+                    .and_then(serde_json::Value::as_u64)
+                    .is_some_and(|v| v > 0);
+                if !valid_max {
+                    errors.push(format!(
+                        "{loc}: json_rpc_max_body_bytes must be a positive integer"
+                    ));
+                }
+            }
+
             if protocol != "graphql"
                 && protocol != "websocket"
                 && (ep.get("persisted_queries").is_some()
@@ -694,6 +1100,62 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
             {
                 warnings.push(format!(
                     "{loc}: GraphQL-specific endpoint fields are ignored unless protocol is graphql or websocket"
+                ));
+            }
+
+            if !jsonrpc_family && ep.get("json_rpc_max_body_bytes").is_some() {
+                warnings.push(format!(
+                    "{loc}: JSON-RPC-specific endpoint fields are ignored unless protocol is json-rpc or mcp"
+                ));
+            }
+            let has_mcp_strict_tool_names = ep.get("mcp_strict_tool_names").is_some();
+            let has_mcp_allow_all_known_mcp_methods =
+                ep.get("mcp_allow_all_known_mcp_methods").is_some();
+            if has_mcp_strict_tool_names {
+                if ep
+                    .get("mcp_strict_tool_names")
+                    .and_then(serde_json::Value::as_bool)
+                    .is_none()
+                {
+                    errors.push(format!("{loc}: mcp.strict_tool_names must be boolean"));
+                }
+                if protocol != "mcp" {
+                    errors.push(format!(
+                        "{loc}: mcp.strict_tool_names is only valid for protocol mcp"
+                    ));
+                }
+            }
+            if has_mcp_allow_all_known_mcp_methods {
+                if ep
+                    .get("mcp_allow_all_known_mcp_methods")
+                    .and_then(serde_json::Value::as_bool)
+                    .is_none()
+                {
+                    errors.push(format!(
+                        "{loc}: mcp.allow_all_known_mcp_methods must be boolean"
+                    ));
+                }
+                if protocol != "mcp" {
+                    errors.push(format!(
+                        "{loc}: mcp.allow_all_known_mcp_methods is only valid for protocol mcp"
+                    ));
+                }
+            }
+            let mcp_strict_tool_names = ep
+                .get("mcp_strict_tool_names")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true);
+            let mcp_allow_all_known_mcp_methods = ep
+                .get("mcp_allow_all_known_mcp_methods")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+            if protocol == "mcp"
+                && !has_rules
+                && access.is_empty()
+                && !mcp_allow_all_known_mcp_methods
+            {
+                errors.push(format!(
+                    "{loc}: protocol mcp requires rules when mcp.allow_all_known_mcp_methods is false"
                 ));
             }
 
@@ -783,15 +1245,30 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                 }
 
                 // deny_rules require some allow base (access or rules)
-                if !has_rules && access.is_empty() {
+                if protocol != "mcp" && !has_rules && access.is_empty() {
                     errors.push(format!(
                         "{loc}: deny_rules require rules or access to define the base allow set"
                     ));
                 }
 
+                let has_mcp_tool_allow_selectors =
+                    protocol == "mcp" && mcp_endpoint_has_tool_allow_selectors(ep);
+
                 if let Some(deny_rules) = ep.get("deny_rules").and_then(|v| v.as_array()) {
                     for (deny_idx, deny_rule) in deny_rules.iter().enumerate() {
                         let deny_loc = format!("{loc}.deny_rules[{deny_idx}]");
+
+                        if has_mcp_tool_allow_selectors
+                            && deny_rule
+                                .get("method")
+                                .and_then(serde_json::Value::as_str)
+                                .is_some_and(method_matcher_matches_tools_call)
+                            && !mcp_rule_has_tool_selector(deny_rule)
+                        {
+                            errors.push(format!(
+                                "{deny_loc}: method matcher denies every tool call and conflicts with MCP tool allow rules; add tool or params.name to deny specific tools, or remove the tool allow rules"
+                            ));
+                        }
 
                         // Validate method
                         if let Some(method) = deny_rule.get("method").and_then(|m| m.as_str())
@@ -816,102 +1293,23 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
 
                         // Validate query matchers — mirrors allow-side validation exactly
                         if let Some(query) = deny_rule.get("query").filter(|v| !v.is_null()) {
-                            let Some(query_obj) = query.as_object() else {
-                                errors.push(format!(
-                                    "{deny_loc}.query: expected map of query matchers"
-                                ));
-                                continue;
-                            };
-
-                            for (param, matcher) in query_obj {
-                                if let Some(glob_str) = matcher.as_str() {
-                                    if let Some(warning) = check_glob_syntax(glob_str) {
-                                        warnings
-                                            .push(format!("{deny_loc}.query.{param}: {warning}"));
-                                    }
-                                    continue;
-                                }
-
-                                let Some(matcher_obj) = matcher.as_object() else {
-                                    errors.push(format!(
-                                        "{deny_loc}.query.{param}: expected string glob or object with `any`"
-                                    ));
-                                    continue;
-                                };
-
-                                let has_any = matcher_obj.get("any").is_some();
-                                let has_glob = matcher_obj.get("glob").is_some();
-                                let has_unknown =
-                                    matcher_obj.keys().any(|k| k != "any" && k != "glob");
-                                if has_unknown {
-                                    errors.push(format!(
-                                        "{deny_loc}.query.{param}: unknown matcher keys; only `glob` or `any` are supported"
-                                    ));
-                                    continue;
-                                }
-
-                                if has_glob && has_any {
-                                    errors.push(format!(
-                                        "{deny_loc}.query.{param}: matcher cannot specify both `glob` and `any`"
-                                    ));
-                                    continue;
-                                }
-
-                                if !has_glob && !has_any {
-                                    errors.push(format!(
-                                        "{deny_loc}.query.{param}: object matcher requires `glob` string or non-empty `any` list"
-                                    ));
-                                    continue;
-                                }
-
-                                if has_glob {
-                                    match matcher_obj.get("glob").and_then(|v| v.as_str()) {
-                                        None => {
-                                            errors.push(format!(
-                                                "{deny_loc}.query.{param}.glob: expected glob string"
-                                            ));
-                                        }
-                                        Some(g) => {
-                                            if let Some(warning) = check_glob_syntax(g) {
-                                                warnings.push(format!(
-                                                    "{deny_loc}.query.{param}.glob: {warning}"
-                                                ));
-                                            }
-                                        }
-                                    }
-                                    continue;
-                                }
-
-                                let any = matcher_obj.get("any").and_then(|v| v.as_array());
-                                let Some(any) = any else {
-                                    errors.push(format!(
-                                        "{deny_loc}.query.{param}.any: expected array of glob strings"
-                                    ));
-                                    continue;
-                                };
-
-                                if any.is_empty() {
-                                    errors.push(format!(
-                                        "{deny_loc}.query.{param}.any: list must not be empty"
-                                    ));
-                                    continue;
-                                }
-
-                                if any.iter().any(|v| v.as_str().is_none()) {
-                                    errors.push(format!(
-                                        "{deny_loc}.query.{param}.any: all values must be strings"
-                                    ));
-                                }
-
-                                for item in any.iter().filter_map(|v| v.as_str()) {
-                                    if let Some(warning) = check_glob_syntax(item) {
-                                        warnings.push(format!(
-                                            "{deny_loc}.query.{param}.any: {warning}"
-                                        ));
-                                    }
-                                }
-                            }
+                            validate_matcher_map(
+                                &mut errors,
+                                &mut warnings,
+                                &format!("{deny_loc}.query"),
+                                Some(query),
+                            );
                         }
+
+                        validate_jsonrpc_rule_fields(
+                            &mut errors,
+                            &mut warnings,
+                            &deny_loc,
+                            deny_rule,
+                            protocol,
+                            mcp_strict_tool_names,
+                            mcp_allow_all_known_mcp_methods,
+                        );
 
                         // SQL command validation
                         if let Some(command) = deny_rule.get("command").and_then(|c| c.as_str())
@@ -986,109 +1384,42 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                             continue;
                         };
 
-                        let Some(query_obj) = query.as_object() else {
-                            errors.push(format!(
-                                "{loc}.rules[{rule_idx}].allow.query: expected map of query matchers"
-                            ));
-                            continue;
-                        };
-
-                        for (param, matcher) in query_obj {
-                            if let Some(glob_str) = matcher.as_str() {
-                                if let Some(warning) = check_glob_syntax(glob_str) {
-                                    warnings.push(format!(
-                                        "{loc}.rules[{rule_idx}].allow.query.{param}: {warning}"
-                                    ));
-                                }
-                                continue;
-                            }
-
-                            let Some(matcher_obj) = matcher.as_object() else {
-                                errors.push(format!(
-                                    "{loc}.rules[{rule_idx}].allow.query.{param}: expected string glob or object with `any`"
-                                ));
-                                continue;
-                            };
-
-                            let has_any = matcher_obj.get("any").is_some();
-                            let has_glob = matcher_obj.get("glob").is_some();
-                            let has_unknown = matcher_obj.keys().any(|k| k != "any" && k != "glob");
-                            if has_unknown {
-                                errors.push(format!(
-                                    "{loc}.rules[{rule_idx}].allow.query.{param}: unknown matcher keys; only `glob` or `any` are supported"
-                                ));
-                                continue;
-                            }
-
-                            if has_glob && has_any {
-                                errors.push(format!(
-                                    "{loc}.rules[{rule_idx}].allow.query.{param}: matcher cannot specify both `glob` and `any`"
-                                ));
-                                continue;
-                            }
-
-                            if !has_glob && !has_any {
-                                errors.push(format!(
-                                    "{loc}.rules[{rule_idx}].allow.query.{param}: object matcher requires `glob` string or non-empty `any` list"
-                                ));
-                                continue;
-                            }
-
-                            if has_glob {
-                                match matcher_obj.get("glob").and_then(|v| v.as_str()) {
-                                    None => {
-                                        errors.push(format!(
-                                            "{loc}.rules[{rule_idx}].allow.query.{param}.glob: expected glob string"
-                                        ));
-                                    }
-                                    Some(g) => {
-                                        if let Some(warning) = check_glob_syntax(g) {
-                                            warnings.push(format!(
-                                                "{loc}.rules[{rule_idx}].allow.query.{param}.glob: {warning}"
-                                            ));
-                                        }
-                                    }
-                                }
-                                continue;
-                            }
-
-                            let any = matcher_obj.get("any").and_then(|v| v.as_array());
-                            let Some(any) = any else {
-                                errors.push(format!(
-                                    "{loc}.rules[{rule_idx}].allow.query.{param}.any: expected array of glob strings"
-                                ));
-                                continue;
-                            };
-
-                            if any.is_empty() {
-                                errors.push(format!(
-                                    "{loc}.rules[{rule_idx}].allow.query.{param}.any: list must not be empty"
-                                ));
-                                continue;
-                            }
-
-                            if any.iter().any(|v| v.as_str().is_none()) {
-                                errors.push(format!(
-                                    "{loc}.rules[{rule_idx}].allow.query.{param}.any: all values must be strings"
-                                ));
-                            }
-
-                            for item in any.iter().filter_map(|v| v.as_str()) {
-                                if let Some(warning) = check_glob_syntax(item) {
-                                    warnings.push(format!(
-                                        "{loc}.rules[{rule_idx}].allow.query.{param}.any: {warning}"
-                                    ));
-                                }
-                            }
-                        }
+                        validate_matcher_map(
+                            &mut errors,
+                            &mut warnings,
+                            &format!("{loc}.rules[{rule_idx}].allow.query"),
+                            Some(query),
+                        );
                     }
                 }
             }
 
+            let has_mcp_tool_allow_selectors =
+                protocol == "mcp" && mcp_endpoint_has_tool_allow_selectors(ep);
             if has_rules && let Some(rules) = ep.get("rules").and_then(|v| v.as_array()) {
                 for (rule_idx, rule) in rules.iter().enumerate() {
                     let allow = rule.get("allow").unwrap_or(rule);
                     let rule_loc = format!("{loc}.rules[{rule_idx}].allow");
+                    if has_mcp_tool_allow_selectors
+                        && allow
+                            .get("method")
+                            .and_then(serde_json::Value::as_str)
+                            .is_some_and(method_matcher_matches_tools_call)
+                        && !mcp_rule_has_tool_selector(allow)
+                    {
+                        errors.push(format!(
+                            "{rule_loc}: method matcher allows every tool call and conflicts with MCP tool allow rules; add tool or params.name to narrow tools/call, or remove the tool allow rules"
+                        ));
+                    }
+                    validate_jsonrpc_rule_fields(
+                        &mut errors,
+                        &mut warnings,
+                        &rule_loc,
+                        allow,
+                        protocol,
+                        mcp_strict_tool_names,
+                        mcp_allow_all_known_mcp_methods,
+                    );
                     let allow_has_graphql = json_rule_has_graphql_fields(allow);
                     if websocket_has_graphql_policy
                         && allow
@@ -1140,29 +1471,46 @@ pub fn expand_access_presets(data: &mut serde_json::Value) {
         };
 
         for ep in endpoints.iter_mut() {
+            let protocol = ep
+                .get("protocol")
+                .and_then(|v| v.as_str())
+                .unwrap_or("rest");
+            let has_rules = ep
+                .get("rules")
+                .and_then(|v| v.as_array())
+                .is_some_and(|a| !a.is_empty());
             let access = ep
                 .get("access")
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
 
+            let mcp_allow_all_known_mcp_methods = ep
+                .get("mcp_allow_all_known_mcp_methods")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+
+            if protocol == "mcp"
+                && access.is_empty()
+                && !has_rules
+                && mcp_allow_all_known_mcp_methods
+            {
+                ep.as_object_mut().unwrap().insert(
+                    "rules".to_string(),
+                    serde_json::Value::Array(vec![jsonrpc_rule_json("*")]),
+                );
+                continue;
+            }
+
             if access.is_empty() {
                 continue;
             }
 
             // Don't expand if rules already exist (validation will catch this)
-            if ep
-                .get("rules")
-                .and_then(|v| v.as_array())
-                .is_some_and(|a| !a.is_empty())
-            {
+            if has_rules {
                 continue;
             }
 
-            let protocol = ep
-                .get("protocol")
-                .and_then(|v| v.as_str())
-                .unwrap_or("rest");
             let rules = if protocol == "graphql" {
                 match access.as_str() {
                     "read-only" => vec![graphql_rule_json("query")],
@@ -1209,6 +1557,14 @@ fn rule_json(method: &str, path: &str) -> serde_json::Value {
         "allow": {
             "method": method,
             "path": path
+        }
+    })
+}
+
+fn jsonrpc_rule_json(method: &str) -> serde_json::Value {
+    serde_json::json!({
+        "allow": {
+            "method": method
         }
     })
 }
@@ -1339,6 +1695,26 @@ mod tests {
         .unwrap();
         let config = parse_l7_config(&val).unwrap();
         assert!(config.allow_encoded_slash);
+    }
+
+    #[test]
+    fn parse_l7_config_mcp_strict_tool_names_defaults_true() {
+        let val = regorus::Value::from_json_str(
+            r#"{"protocol": "mcp", "host": "mcp.example.com", "port": 443}"#,
+        )
+        .unwrap();
+        let config = parse_l7_config(&val).unwrap();
+        assert!(config.mcp_strict_tool_names);
+    }
+
+    #[test]
+    fn parse_l7_config_mcp_strict_tool_names_can_disable() {
+        let val = regorus::Value::from_json_str(
+            r#"{"protocol": "mcp", "host": "mcp.example.com", "port": 443, "mcp_strict_tool_names": false}"#,
+        )
+        .unwrap();
+        let config = parse_l7_config(&val).unwrap();
+        assert!(!config.mcp_strict_tool_names);
     }
 
     #[test]
@@ -1595,6 +1971,601 @@ mod tests {
         });
         let (errors, _warnings) = validate_l7_policies(&data);
         assert!(errors.iter().any(|e| e.contains("mutually exclusive")));
+    }
+
+    #[test]
+    fn validate_jsonrpc_rejects_access_presets() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "jsonrpc.example.com",
+                        "port": 443,
+                        "path": "/rpc",
+                        "protocol": "json-rpc",
+                        "access": "full"
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("json-rpc")
+                    && e.contains("does not support access presets")
+                    && e.contains("method")
+            }),
+            "JSON-RPC access presets should be rejected: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_jsonrpc_requires_method_rules() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "jsonrpc.example.com",
+                        "port": 443,
+                        "path": "/rpc",
+                        "protocol": "json-rpc",
+                        "rules": [{
+                            "allow": {
+                                "path": "/rpc"
+                            }
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors
+                .iter()
+                .any(|e| { e.contains("rules[0].allow.method") && e.contains("required") }),
+            "JSON-RPC allow rules without method should be rejected: {errors:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| { e.contains("must use method, not path/query") }),
+            "JSON-RPC allow rules with path/query should be rejected: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_tool_selectors_use_endpoint_method_profile_and_reject_arguments() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "mcp_allow_all_known_mcp_methods": true,
+                        "rules": [{
+                            "allow": {
+                                "tool": { "any": ["read_status", "submit_*"] }
+                            }
+                        }, {
+                            "allow": {
+                                "method": "tools/call",
+                                "tool": "submit_report",
+                                "params": {
+                                    "arguments": {
+                                        "scope": "workspace/main"
+                                    }
+                                }
+                            }
+                        }, {
+                            "allow": {
+                                "method": "initialize"
+                            }
+                        }, {
+                            "allow": {
+                                "method": "tools/call",
+                                "tool": "list_reports"
+                            }
+                        }],
+                        "deny_rules": [{
+                            "tool": "delete_*"
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.contains("rules[0].allow.method") && e.contains("required")),
+            "MCP tool rules can omit method while allow_all_known_mcp_methods is enabled: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[1].allow.params.arguments")
+                    && e.contains("argument matching is not supported")
+            }),
+            "MCP argument params should be rejected: {errors:?}"
+        );
+        assert!(
+            !errors.iter().any(|e| e.contains("rules[2].allow.method")),
+            "MCP method-only rules should not require a tool selector: {errors:?}"
+        );
+        assert!(
+            !errors.iter().any(|e| e.contains("rules[3].allow.method")),
+            "MCP tool rules with method: tools/call should validate: {errors:?}"
+        );
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.contains("deny_rules[0].method") && e.contains("tools/call")),
+            "MCP deny tool rules can omit method while allow_all_known_mcp_methods is enabled: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_tool_selectors_require_method_by_default() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "rules": [{
+                            "allow": {
+                                "tool": "read_status"
+                            }
+                        }],
+                        "deny_rules": [{
+                            "tool": "delete_*"
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[0].allow.method")
+                    && e.contains("mcp.allow_all_known_mcp_methods is false")
+            }),
+            "MCP allow tool rules should require method when method profile is disabled: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("deny_rules[0].method")
+                    && e.contains("mcp.allow_all_known_mcp_methods is false")
+            }),
+            "MCP deny tool rules should require method when method profile is disabled: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_method_globs_are_tools_family_only() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "rules": [{
+                            "allow": {
+                                "method": "vendor/extension"
+                            }
+                        }, {
+                            "allow": {
+                                "method": "vendor/*"
+                            }
+                        }, {
+                            "allow": {
+                                "method": "*"
+                            }
+                        }, {
+                            "allow": {
+                                "method": "tools/*"
+                            }
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            !errors.iter().any(|e| e.contains("rules[0].allow.method")),
+            "literal extension methods should stay addressable: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[1].allow.method")
+                    && e.contains("only valid for the tools/ method family")
+            }),
+            "non-tools method globs should be rejected: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[2].allow.method")
+                    && e.contains("only valid for the tools/ method family")
+            }),
+            "authored method: * should be rejected for MCP: {errors:?}"
+        );
+        assert!(
+            !errors.iter().any(|e| e.contains("rules[3].allow.method")),
+            "tools-family method globs should validate: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_wildcard_tool_requires_strict_tool_names() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "mcp_strict_tool_names": false,
+                        "rules": [{
+                            "allow": {
+                                "method": "tools/call",
+                                "tool": "read_*"
+                            }
+                        }, {
+                            "allow": {
+                                "method": "tools/call",
+                                "params": {
+                                    "name": { "any": ["safe_tool", "list_*"] }
+                                }
+                            }
+                        }],
+                        "deny_rules": [{
+                            "method": "tools/call",
+                            "tool": "delete_resource"
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[0].allow.tool")
+                    && e.contains("strict_tool_names to remain enabled")
+            }),
+            "wildcard tool aliases should require strict tool names: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[1].allow.params.name")
+                    && e.contains("strict_tool_names to remain enabled")
+            }),
+            "wildcard params.name should require strict tool names: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_protocol_requires_endpoint_target() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "protocol": "mcp"
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("protocol mcp requires host")),
+            "MCP protocol-only endpoint should require host: {errors:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("protocol mcp requires port or ports")),
+            "MCP protocol-only endpoint should require port: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_broad_tools_call_deny_rejects_tool_allow_rules() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "rules": [{
+                            "allow": {
+                                "method": "tools/call",
+                                "tool": "read_status"
+                            }
+                        }],
+                        "deny_rules": [{
+                            "method": "tools/call"
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("deny_rules[0]")
+                    && e.contains("denies every tool call")
+                    && e.contains("conflicts with MCP tool allow rules")
+            }),
+            "broad tools/call deny should reject tool allow rules with a reason: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_broad_tools_call_allow_rejects_tool_allow_rules() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "rules": [{
+                            "allow": {
+                                "method": "tools/*"
+                            }
+                        }, {
+                            "allow": {
+                                "tool": "read_status"
+                            }
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[0].allow")
+                    && e.contains("allows every tool call")
+                    && e.contains("conflicts with MCP tool allow rules")
+            }),
+            "broad tools/call allow should reject tool allow rules with a reason: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_jsonrpc_rejects_params_matchers() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "jsonrpc.example.com",
+                        "port": 443,
+                        "path": "/rpc",
+                        "protocol": "json-rpc",
+                        "rules": [{
+                            "allow": {
+                                "method": "reports.search",
+                                "params": { "query": "quarterly" }
+                            }
+                        }],
+                        "deny_rules": [{
+                            "method": "reports.archive",
+                            "params": { "report_id": "rpt-123" }
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors
+                .iter()
+                .any(|e| { e.contains("rules[0].allow") && e.contains("do not support params") }),
+            "JSON-RPC allow params should be rejected: {errors:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| { e.contains("deny_rules[0]") && e.contains("do not support params") }),
+            "JSON-RPC deny params should be rejected: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_strict_tool_names_is_mcp_only() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [
+                        {
+                            "host": "mcp.example.com",
+                            "port": 443,
+                            "path": "/mcp",
+                            "protocol": "mcp",
+                            "mcp_strict_tool_names": false,
+                            "rules": [{ "allow": { "method": "tools/call" } }]
+                        },
+                        {
+                            "host": "api.example.com",
+                            "port": 443,
+                            "protocol": "rest",
+                            "mcp_strict_tool_names": false,
+                            "mcp_allow_all_known_mcp_methods": true,
+                            "access": "full"
+                        }
+                    ],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert_eq!(
+            errors
+                .iter()
+                .filter(|error| error.contains("is only valid for protocol mcp"))
+                .count(),
+            2,
+            "only the REST endpoint should reject MCP-specific options: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_options_require_bool() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "mcp_strict_tool_names": "false",
+                        "mcp_allow_all_known_mcp_methods": "false",
+                        "rules": [{ "allow": { "method": "tools/call" } }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("mcp.strict_tool_names must be boolean")),
+            "expected bool validation error: {errors:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("mcp.allow_all_known_mcp_methods must be boolean")),
+            "expected bool validation error: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_requires_rules_by_default() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp"
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|error| {
+                error.contains("protocol mcp requires rules")
+                    && error.contains("mcp.allow_all_known_mcp_methods is false")
+            }),
+            "expected disabled method profile to require rules: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_jsonrpc_deny_rules_require_method() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "jsonrpc.example.com",
+                        "port": 443,
+                        "path": "/rpc",
+                        "protocol": "json-rpc",
+                        "rules": [{
+                            "allow": {
+                                "method": "*"
+                            }
+                        }],
+                        "deny_rules": [{
+                            "params": { "name": "delete_resource" }
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("deny_rules[0].method") && e.contains("required")),
+            "JSON-RPC deny rules without method should be rejected: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_jsonrpc_method_rejects_globs_except_allow_all() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "jsonrpc.example.com",
+                        "port": 443,
+                        "path": "/rpc",
+                        "protocol": "json-rpc",
+                        "rules": [{
+                            "allow": {
+                                "method": "*"
+                            }
+                        }, {
+                            "allow": {
+                                "method": "reports.*"
+                            }
+                        }],
+                        "deny_rules": [{
+                            "method": "reports/{archive,delete}"
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            !errors.iter().any(|e| e.contains("rules[0].allow.method")),
+            "JSON-RPC method: * should remain the allow-all sentinel: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[1].allow.method")
+                    && e.contains("do not support glob or wildcard matchers")
+            }),
+            "JSON-RPC allow method globs should be rejected: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("deny_rules[0].method")
+                    && e.contains("do not support glob or wildcard matchers")
+            }),
+            "JSON-RPC deny method globs should be rejected: {errors:?}"
+        );
     }
 
     #[test]
@@ -2324,6 +3295,45 @@ mod tests {
         );
     }
 
+    #[test]
+    fn validate_jsonrpc_nested_params_matchers_are_rejected() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "jsonrpc.example.com",
+                        "port": 443,
+                        "protocol": "json-rpc",
+                        "rules": [{
+                            "allow": {
+                                "method": "reports.search",
+                                "params": {
+                                    "query": "quarterly",
+                                    "filters": {
+                                        "scope": "workspace/main",
+                                        "repository": { "any": ["NVIDIA/OpenShell", "NVIDIA/*"] }
+                                    }
+                                }
+                            }
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, warnings) = validate_l7_policies(&data);
+        assert!(
+            errors
+                .iter()
+                .any(|e| { e.contains("rules[0].allow") && e.contains("do not support params") }),
+            "JSON-RPC nested params matchers should be rejected: {errors:?}"
+        );
+        assert!(
+            warnings.is_empty(),
+            "unsupported params should not emit warnings: {warnings:?}"
+        );
+    }
+
     // --- Deny rules validation tests ---
 
     #[test]
@@ -2477,7 +3487,7 @@ mod tests {
         assert!(
             errors
                 .iter()
-                .any(|e| e.contains("expected string glob or object")),
+                .any(|e| e.contains("expected string glob or matcher object")),
             "should reject non-string/non-object matcher in deny query: {errors:?}"
         );
     }

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -139,6 +139,8 @@ fn emit_parse_rejection(ctx: &L7EvalContext, detail: &str, engine_type: &str) {
 fn engine_type_for_protocol(protocol: L7Protocol) -> &'static str {
     match protocol {
         L7Protocol::Graphql => "l7-graphql",
+        L7Protocol::JsonRpc => "l7-jsonrpc",
+        L7Protocol::Mcp => "l7-mcp",
         L7Protocol::Websocket => "l7-websocket",
         L7Protocol::Rest | L7Protocol::Sql => "l7",
     }
@@ -214,6 +216,9 @@ where
                 .await
                 .into_diagnostic()?;
             Ok(())
+        }
+        L7Protocol::JsonRpc | L7Protocol::Mcp => {
+            relay_jsonrpc(config, &engine, client, upstream, ctx).await
         }
     }
 }
@@ -308,6 +313,43 @@ where
         } else {
             None
         };
+        let jsonrpc_info = if config.protocol.is_jsonrpc_family() {
+            if crate::l7::jsonrpc::jsonrpc_receive_stream_request(&req) {
+                Some(crate::l7::jsonrpc::JsonRpcRequestInfo::receive_stream())
+            } else {
+                match crate::l7::http::read_body_for_inspection(
+                    client,
+                    &mut req,
+                    config.json_rpc_max_body_bytes,
+                )
+                .await
+                {
+                    Ok(body) => Some(crate::l7::jsonrpc::parse_jsonrpc_body_with_options(
+                        &body,
+                        crate::l7::jsonrpc::JsonRpcInspectionOptions::for_config(config),
+                    )),
+                    Err(e) => {
+                        if is_benign_connection_error(&e) {
+                            debug!(
+                                host = %ctx.host,
+                                port = ctx.port,
+                                error = %e,
+                                "JSON-RPC L7 connection closed"
+                            );
+                        } else {
+                            let detail = parse_rejection_detail(
+                                &e.to_string(),
+                                ParseRejectionMode::L7Endpoint,
+                            );
+                            emit_parse_rejection(ctx, &detail, "l7-jsonrpc");
+                        }
+                        return Ok(());
+                    }
+                }
+            }
+        } else {
+            None
+        };
 
         if close_if_stale(engine.generation_guard(), ctx) {
             return Ok(());
@@ -338,6 +380,7 @@ where
             target: redacted_target.clone(),
             query_params: req.query_params.clone(),
             graphql: graphql_info.clone(),
+            jsonrpc: jsonrpc_info.clone(),
         };
         let websocket_request = crate::l7::rest::request_is_websocket_upgrade(&req.raw_header);
         if config.protocol == L7Protocol::Websocket && !websocket_request {
@@ -361,7 +404,13 @@ where
         let parse_error_reason = graphql_info
             .as_ref()
             .and_then(|info| info.error.as_deref())
-            .map(|error| format!("GraphQL request rejected: {error}"));
+            .map(|error| format!("GraphQL request rejected: {error}"))
+            .or_else(|| {
+                jsonrpc_info
+                    .as_ref()
+                    .and_then(|info| info.error.as_deref())
+                    .map(|error| format!("JSON-RPC request rejected: {error}"))
+            });
         let force_deny = parse_error_reason.is_some();
         let (allowed, reason) = if let Some(reason) = parse_error_reason {
             (false, reason)
@@ -382,8 +431,12 @@ where
         let engine_type = match config.protocol {
             L7Protocol::Graphql => "l7-graphql",
             L7Protocol::Websocket => "l7-websocket",
+            L7Protocol::JsonRpc => "l7-jsonrpc",
+            L7Protocol::Mcp => "l7-mcp",
             L7Protocol::Rest | L7Protocol::Sql => "l7",
         };
+        let protocol_summary =
+            l7_protocol_log_summary(graphql_info.as_ref(), jsonrpc_info.as_ref());
         emit_l7_request_log(
             ctx,
             &request_info,
@@ -391,7 +444,7 @@ where
             decision_str,
             engine_type,
             &reason,
-            graphql_info.as_ref(),
+            &protocol_summary,
         );
 
         let _ = &eval_target;
@@ -474,7 +527,7 @@ fn emit_l7_request_log(
     decision_str: &str,
     engine_type: &str,
     reason: &str,
-    graphql_info: Option<&crate::l7::graphql::GraphqlRequestInfo>,
+    protocol_summary: &str,
 ) {
     let (action_id, disposition_id, severity) = match decision_str {
         "deny" => (ActionId::Denied, DispositionId::Blocked, SeverityId::Medium),
@@ -489,9 +542,6 @@ fn emit_l7_request_log(
             SeverityId::Informational,
         ),
     };
-    let summary = graphql_info
-        .map(|info| format!(" {}", graphql_log_summary(info)))
-        .unwrap_or_default();
     let event = HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
         .activity(ActivityId::Other)
         .action(action_id)
@@ -505,11 +555,26 @@ fn emit_l7_request_log(
         .firewall_rule(&ctx.policy_name, engine_type)
         .message(format!(
             "L7_REQUEST {decision_str} {} {}:{}{}{} reason={}",
-            request_info.action, ctx.host, ctx.port, redacted_target, summary, reason,
+            request_info.action, ctx.host, ctx.port, redacted_target, protocol_summary, reason,
         ))
         .build();
     ocsf_emit!(event);
     emit_activity(ctx, decision_str == "deny", "l7_policy");
+}
+
+fn l7_protocol_log_summary(
+    graphql_info: Option<&crate::l7::graphql::GraphqlRequestInfo>,
+    jsonrpc_info: Option<&crate::l7::jsonrpc::JsonRpcRequestInfo>,
+) -> String {
+    if let Some(info) = graphql_info {
+        return format!(" {}", graphql_log_summary(info));
+    }
+
+    if let Some(info) = jsonrpc_info {
+        return format!(" rule_methods={}", rule_method_names_for_log(info));
+    }
+
+    String::new()
 }
 
 fn emit_activity(ctx: &L7EvalContext, denied: bool, deny_group: &'static str) {
@@ -662,6 +727,13 @@ pub(crate) fn websocket_extension_mode(config: &L7EndpointConfig) -> WebSocketEx
     }
 }
 
+fn jsonrpc_engine_type(protocol: L7Protocol) -> &'static str {
+    match protocol {
+        L7Protocol::Mcp => "l7-mcp",
+        _ => "l7-jsonrpc",
+    }
+}
+
 /// REST relay loop: parse request -> evaluate -> allow/deny -> relay response -> repeat.
 async fn relay_rest<C, U>(
     config: &L7EndpointConfig,
@@ -744,6 +816,7 @@ where
             target: redacted_target.clone(),
             query_params: req.query_params.clone(),
             graphql: None,
+            jsonrpc: None,
         };
         let websocket_request = crate::l7::rest::request_is_websocket_upgrade(&req.raw_header);
         if config.protocol == L7Protocol::Websocket && !websocket_request {
@@ -940,6 +1013,182 @@ fn close_if_stale(guard: &PolicyGenerationGuard, ctx: &L7EvalContext) -> bool {
     true
 }
 
+async fn relay_jsonrpc<C, U>(
+    config: &L7EndpointConfig,
+    engine: &TunnelPolicyEngine,
+    client: &mut C,
+    upstream: &mut U,
+    ctx: &L7EvalContext,
+) -> Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin + Send,
+    U: AsyncRead + AsyncWrite + Unpin + Send,
+{
+    loop {
+        if close_if_stale(engine.generation_guard(), ctx) {
+            return Ok(());
+        }
+
+        // Future MCP version-profile request checks should hook here before OPA
+        // evaluation. See McpOptions in proto/sandbox.proto for the policy
+        // roadmap and source documentation.
+        let parsed = match crate::l7::jsonrpc::parse_jsonrpc_http_request(
+            client,
+            config.json_rpc_max_body_bytes,
+            crate::l7::path::CanonicalizeOptions {
+                allow_encoded_slash: config.allow_encoded_slash,
+                ..Default::default()
+            },
+            crate::l7::jsonrpc::JsonRpcInspectionOptions::for_config(config),
+        )
+        .await
+        {
+            Ok(Some(parsed)) => parsed,
+            Ok(None) => return Ok(()),
+            Err(e) => {
+                if is_benign_connection_error(&e) {
+                    debug!(
+                        host = %ctx.host,
+                        port = ctx.port,
+                        error = %e,
+                        "JSON-RPC L7 connection closed"
+                    );
+                } else {
+                    let detail =
+                        parse_rejection_detail(&e.to_string(), ParseRejectionMode::L7Endpoint);
+                    emit_parse_rejection(ctx, &detail, jsonrpc_engine_type(config.protocol));
+                }
+                return Ok(());
+            }
+        };
+
+        let req = parsed.request;
+        let jsonrpc_info = parsed.info;
+
+        if close_if_stale(engine.generation_guard(), ctx) {
+            return Ok(());
+        }
+
+        let redacted_target = req.target.clone();
+
+        let request_info = L7RequestInfo {
+            action: req.action.clone(),
+            target: redacted_target.clone(),
+            query_params: req.query_params.clone(),
+            graphql: None,
+            jsonrpc: Some(jsonrpc_info.clone()),
+        };
+
+        let parse_error_reason = jsonrpc_info
+            .error
+            .as_deref()
+            .map(|e| format!("JSON-RPC request rejected: {e}"));
+        let response_frame_reason =
+            jsonrpc_response_frame_hard_deny_reason(config.protocol, &jsonrpc_info);
+        let force_deny = parse_error_reason.is_some() || response_frame_reason.is_some();
+        let (allowed, reason, jsonrpc_log_info) = if let Some(reason) = parse_error_reason {
+            (false, reason, jsonrpc_info.clone())
+        } else if let Some(reason) = response_frame_reason {
+            (false, reason, jsonrpc_info.clone())
+        } else {
+            let evaluation =
+                evaluate_jsonrpc_l7_request_for_log(engine, ctx, &request_info, &jsonrpc_info)?;
+            (evaluation.allowed, evaluation.reason, evaluation.log_info)
+        };
+
+        if close_if_stale(engine.generation_guard(), ctx) {
+            return Ok(());
+        }
+
+        let decision_str = match (allowed, config.enforcement) {
+            (_, _) if force_deny => "deny",
+            (true, _) => "allow",
+            (false, EnforcementMode::Audit) => "audit",
+            (false, EnforcementMode::Enforce) => "deny",
+        };
+
+        {
+            let (action_id, disposition_id, severity) = match decision_str {
+                "deny" => (ActionId::Denied, DispositionId::Blocked, SeverityId::Medium),
+                _ => (
+                    ActionId::Allowed,
+                    DispositionId::Allowed,
+                    SeverityId::Informational,
+                ),
+            };
+            let endpoint = format!("{}:{}{}", ctx.host, ctx.port, redacted_target);
+            let policy_version = engine.captured_generation();
+            let event = HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
+                .activity(ActivityId::Other)
+                .action(action_id)
+                .disposition(disposition_id)
+                .severity(severity)
+                .http_request(HttpRequest::new(
+                    &request_info.action,
+                    OcsfUrl::new("http", &ctx.host, &redacted_target, ctx.port),
+                ))
+                .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+                .firewall_rule(&ctx.policy_name, jsonrpc_engine_type(config.protocol))
+                .message(jsonrpc_log_message(
+                    decision_str,
+                    &request_info.action,
+                    &endpoint,
+                    &jsonrpc_log_info,
+                    policy_version,
+                    &reason,
+                ))
+                .build();
+            ocsf_emit!(event);
+        }
+
+        if allowed || (config.enforcement == EnforcementMode::Audit && !force_deny) {
+            // Future MCP response/SSE introspection or rewrite would hook here
+            // before returning upstream bytes. The current policy schema has no
+            // trusted-annotations or version-profile field, so MCP responses and
+            // SSE streams are relayed unchanged; see McpOptions in
+            // proto/sandbox.proto for planned policy extensions.
+            let outcome = crate::l7::rest::relay_http_request_with_resolver_guarded(
+                &req,
+                client,
+                upstream,
+                ctx.secret_resolver.as_deref(),
+                Some(engine.generation_guard()),
+            )
+            .await?;
+            match outcome {
+                RelayOutcome::Reusable => {}
+                RelayOutcome::Consumed => {
+                    debug!(
+                        host = %ctx.host,
+                        port = ctx.port,
+                        "Upstream connection not reusable, closing JSON-RPC L7 relay"
+                    );
+                    return Ok(());
+                }
+                RelayOutcome::Upgraded { .. } => {
+                    return Ok(());
+                }
+            }
+        } else {
+            crate::l7::rest::RestProvider::default()
+                .deny_with_redacted_target(
+                    &req,
+                    &ctx.policy_name,
+                    &reason,
+                    client,
+                    Some(&redacted_target),
+                    Some(crate::l7::rest::DenyResponseContext {
+                        host: Some(&ctx.host),
+                        port: Some(ctx.port),
+                        binary: Some(&ctx.binary_path),
+                    }),
+                )
+                .await?;
+            return Ok(());
+        }
+    }
+}
+
 async fn relay_graphql<C, U>(
     config: &L7EndpointConfig,
     engine: &TunnelPolicyEngine,
@@ -1021,6 +1270,7 @@ where
             target: redacted_target.clone(),
             query_params: req.query_params.clone(),
             graphql: Some(graphql_info.clone()),
+            jsonrpc: None,
         };
 
         // Malformed or ambiguous GraphQL requests, such as duplicated GET
@@ -1169,6 +1419,55 @@ fn graphql_log_summary(info: &crate::l7::graphql::GraphqlRequestInfo) -> String 
     format!("graphql_ops={}", ops.join(";"))
 }
 
+pub(crate) fn jsonrpc_log_message(
+    decision: &str,
+    http_method: &str,
+    endpoint: &str,
+    info: &crate::l7::jsonrpc::JsonRpcRequestInfo,
+    policy_version: u64,
+    reason: &str,
+) -> String {
+    let rule_methods = rule_method_names_for_log(info);
+    format!(
+        "JSONRPC_L7_REQUEST decision={decision} http_method={http_method} endpoint={endpoint} rule_methods={rule_methods} policy_version={policy_version} reason={reason}"
+    )
+}
+
+pub(crate) fn rule_method_names_for_log(info: &crate::l7::jsonrpc::JsonRpcRequestInfo) -> String {
+    if info.calls.is_empty() {
+        return "-".to_string();
+    }
+    info.calls
+        .iter()
+        .map(|call| sanitize_log_token(&call.method))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn sanitize_log_token(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_control() { '?' } else { ch })
+        .collect()
+}
+
+struct JsonRpcEvaluation {
+    allowed: bool,
+    reason: String,
+    log_info: crate::l7::jsonrpc::JsonRpcRequestInfo,
+}
+
+pub(crate) const JSONRPC_RESPONSE_FRAME_DENY_REASON: &str =
+    "JSON-RPC response frames are not permitted from client to server";
+
+pub(crate) fn jsonrpc_response_frame_hard_deny_reason(
+    protocol: L7Protocol,
+    jsonrpc: &crate::l7::jsonrpc::JsonRpcRequestInfo,
+) -> Option<String> {
+    (protocol != L7Protocol::Mcp && jsonrpc.has_response)
+        .then(|| JSONRPC_RESPONSE_FRAME_DENY_REASON.to_string())
+}
+
 /// Check if a miette error represents a benign connection close.
 ///
 /// TLS handshake EOF, missing `close_notify`, connection resets, and broken
@@ -1191,6 +1490,109 @@ fn is_benign_connection_error(err: &miette::Report) -> bool {
 ///
 /// Returns `(allowed, deny_reason)`.
 pub fn evaluate_l7_request(
+    engine: &TunnelPolicyEngine,
+    ctx: &L7EvalContext,
+    request: &L7RequestInfo,
+) -> Result<(bool, String)> {
+    if let Some(jsonrpc) = &request.jsonrpc
+        && jsonrpc.is_batch
+        && !jsonrpc.calls.is_empty()
+    {
+        if jsonrpc.has_response {
+            let (allowed, reason) = evaluate_l7_request_once(engine, ctx, request)?;
+            if !allowed {
+                return Ok((false, reason));
+            }
+        }
+        for call in &jsonrpc.calls {
+            let item_request = jsonrpc_request_for_call(request, call);
+            let (allowed, reason) = evaluate_l7_request_once(engine, ctx, &item_request)?;
+            if !allowed {
+                return Ok((false, reason));
+            }
+        }
+        return Ok((true, String::new()));
+    }
+
+    evaluate_l7_request_once(engine, ctx, request)
+}
+
+fn evaluate_jsonrpc_l7_request_for_log(
+    engine: &TunnelPolicyEngine,
+    ctx: &L7EvalContext,
+    request: &L7RequestInfo,
+    jsonrpc: &crate::l7::jsonrpc::JsonRpcRequestInfo,
+) -> Result<JsonRpcEvaluation> {
+    if jsonrpc.has_response {
+        let (allowed, reason) = evaluate_l7_request_once(engine, ctx, request)?;
+        if !allowed || !jsonrpc.is_batch || jsonrpc.calls.is_empty() {
+            return Ok(JsonRpcEvaluation {
+                allowed,
+                reason,
+                log_info: jsonrpc.clone(),
+            });
+        }
+    }
+
+    if jsonrpc.is_batch && !jsonrpc.calls.is_empty() {
+        let mut denied_calls = Vec::new();
+        let mut first_denied_reason = None;
+        for call in &jsonrpc.calls {
+            let item_request = jsonrpc_request_for_call(request, call);
+            let (allowed, reason) = evaluate_l7_request_once(engine, ctx, &item_request)?;
+            if !allowed {
+                if first_denied_reason.is_none() {
+                    first_denied_reason = Some(reason);
+                }
+                denied_calls.push(call.clone());
+            }
+        }
+
+        if denied_calls.is_empty() {
+            return Ok(JsonRpcEvaluation {
+                allowed: true,
+                reason: String::new(),
+                log_info: jsonrpc.clone(),
+            });
+        }
+
+        return Ok(JsonRpcEvaluation {
+            allowed: false,
+            reason: first_denied_reason.unwrap_or_else(|| "request denied by policy".to_string()),
+            log_info: crate::l7::jsonrpc::JsonRpcRequestInfo {
+                calls: denied_calls,
+                is_batch: true,
+                receive_stream: false,
+                has_response: false,
+                error: None,
+            },
+        });
+    }
+
+    let (allowed, reason) = evaluate_l7_request_once(engine, ctx, request)?;
+    Ok(JsonRpcEvaluation {
+        allowed,
+        reason,
+        log_info: jsonrpc.clone(),
+    })
+}
+
+fn jsonrpc_request_for_call(
+    request: &L7RequestInfo,
+    call: &crate::l7::jsonrpc::JsonRpcCallInfo,
+) -> L7RequestInfo {
+    let mut item_request = request.clone();
+    item_request.jsonrpc = Some(crate::l7::jsonrpc::JsonRpcRequestInfo {
+        calls: vec![call.clone()],
+        is_batch: false,
+        receive_stream: false,
+        has_response: false,
+        error: None,
+    });
+    item_request
+}
+
+fn evaluate_l7_request_once(
     engine: &TunnelPolicyEngine,
     ctx: &L7EvalContext,
     request: &L7RequestInfo,
@@ -1218,6 +1620,17 @@ pub fn evaluate_l7_request(
             "path": request.target,
             "query_params": request.query_params.clone(),
             "graphql": request.graphql.clone(),
+            "jsonrpc": request.jsonrpc.as_ref().map(|j| {
+                let call = if j.is_batch { None } else { j.calls.first() };
+                serde_json::json!({
+                    "method": call.map(|call| call.method.as_str()),
+                    "params": call.map(|call| &call.params),
+                    "tool": call.and_then(|call| call.tool.as_deref()),
+                    "receive_stream": j.receive_stream,
+                    "has_response": j.has_response,
+                    "error": j.error,
+                })
+            }),
         }
     });
 
@@ -1529,6 +1942,98 @@ network_policies:
         };
 
         (generation_guard, ctx, fixture)
+    }
+
+    fn jsonrpc_test_relay_context() -> (L7EndpointConfig, TunnelPolicyEngine, L7EvalContext) {
+        let data = r"
+network_policies:
+  jsonrpc_api:
+    name: jsonrpc_api
+    endpoints:
+      - host: jsonrpc.example.test
+        port: 8000
+        path: /rpc
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - { path: /usr/bin/python3 }
+";
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
+        let input = NetworkInput {
+            host: "jsonrpc.example.test".into(),
+            port: 8000,
+            binary_path: PathBuf::from("/usr/bin/python3"),
+            binary_sha256: "unused".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+        };
+        let (endpoint_config, generation) = engine
+            .query_endpoint_config_with_generation(&input)
+            .unwrap();
+        let config = crate::l7::parse_l7_config(&endpoint_config.unwrap()).unwrap();
+        let tunnel_engine = engine.clone_engine_for_tunnel(generation).unwrap();
+        let ctx = L7EvalContext {
+            host: "jsonrpc.example.test".into(),
+            port: 8000,
+            policy_name: "jsonrpc_api".into(),
+            binary_path: "/usr/bin/python3".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            activity_tx: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
+        };
+        (config, tunnel_engine, ctx)
+    }
+
+    fn mcp_test_relay_context() -> (L7EndpointConfig, TunnelPolicyEngine, L7EvalContext) {
+        let data = r"
+network_policies:
+  mcp_api:
+    name: mcp_api
+    endpoints:
+      - host: mcp.example.test
+        port: 8000
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - { path: /usr/bin/python3 }
+";
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
+        let input = NetworkInput {
+            host: "mcp.example.test".into(),
+            port: 8000,
+            binary_path: PathBuf::from("/usr/bin/python3"),
+            binary_sha256: "unused".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+        };
+        let (endpoint_config, generation) = engine
+            .query_endpoint_config_with_generation(&input)
+            .unwrap();
+        let config = crate::l7::parse_l7_config(&endpoint_config.unwrap()).unwrap();
+        let tunnel_engine = engine.clone_engine_for_tunnel(generation).unwrap();
+        let ctx = L7EvalContext {
+            host: "mcp.example.test".into(),
+            port: 8000,
+            policy_name: "mcp_api".into(),
+            binary_path: "/usr/bin/python3".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            activity_tx: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
+        };
+        (config, tunnel_engine, ctx)
     }
 
     fn authorization_header_count(headers: &str) -> usize {
@@ -1851,12 +2356,332 @@ network_policies:
             target: "/ws".into(),
             query_params: std::collections::HashMap::new(),
             graphql: None,
+            jsonrpc: None,
         };
 
         let (allowed, reason) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
 
         assert!(!allowed);
         assert!(reason.contains("WEBSOCKET_TEXT /ws not permitted"));
+    }
+
+    #[test]
+    fn jsonrpc_batch_evaluates_each_call() {
+        let data = r#"
+network_policies:
+  jsonrpc_api:
+    name: jsonrpc_api
+    endpoints:
+      - host: api.example.test
+        port: 443
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: "reports.list"
+          - allow:
+              method: "reports.search"
+        deny_rules:
+          - method: "reports.delete"
+    binaries:
+      - { path: /usr/bin/node }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
+        let tunnel_engine = engine
+            .clone_engine_for_tunnel(engine.current_generation())
+            .unwrap();
+        let ctx = L7EvalContext {
+            host: "api.example.test".into(),
+            port: 443,
+            policy_name: "jsonrpc_api".into(),
+            binary_path: "/usr/bin/node".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            activity_tx: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
+        };
+        let mut request = L7RequestInfo {
+            action: "POST".into(),
+            target: "/rpc".into(),
+            query_params: std::collections::HashMap::new(),
+            graphql: None,
+            jsonrpc: Some(crate::l7::jsonrpc::parse_jsonrpc_body(
+                br#"[
+                    {"jsonrpc":"2.0","id":1,"method":"reports.list"},
+                    {"jsonrpc":"2.0","id":2,"method":"reports.search","params":{"query":"private_query_value"}}
+                ]"#,
+                crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
+            )),
+        };
+
+        let (allowed, reason) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
+        assert!(allowed, "{reason}");
+
+        request.jsonrpc = Some(crate::l7::jsonrpc::parse_jsonrpc_body(
+            br#"[
+                {"jsonrpc":"2.0","id":1,"method":"reports.list"},
+                {"jsonrpc":"2.0","id":2,"result":{"ok":true}}
+            ]"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
+        ));
+        let (allowed, reason) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
+        assert!(!allowed);
+        assert!(reason.contains("response frames"));
+
+        let jsonrpc = request.jsonrpc.as_ref().expect("jsonrpc request");
+        let evaluation =
+            evaluate_jsonrpc_l7_request_for_log(&tunnel_engine, &ctx, &request, jsonrpc).unwrap();
+        assert!(!evaluation.allowed);
+        assert!(evaluation.log_info.has_response);
+        assert_eq!(
+            rule_method_names_for_log(&evaluation.log_info),
+            "reports.list"
+        );
+
+        request.jsonrpc = Some(crate::l7::jsonrpc::parse_jsonrpc_body(
+            br#"{"jsonrpc":"2.0","id":2,"result":{"ok":true}}"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
+        ));
+        let (allowed, reason) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
+        assert!(!allowed);
+        assert!(reason.contains("response frames"));
+
+        let jsonrpc = request.jsonrpc.as_ref().expect("jsonrpc response");
+        let evaluation =
+            evaluate_jsonrpc_l7_request_for_log(&tunnel_engine, &ctx, &request, jsonrpc).unwrap();
+        assert!(!evaluation.allowed);
+        assert!(evaluation.log_info.has_response);
+        assert_eq!(rule_method_names_for_log(&evaluation.log_info), "-");
+
+        request.jsonrpc = Some(crate::l7::jsonrpc::parse_jsonrpc_body(
+            br#"[
+                {"jsonrpc":"2.0","id":1,"method":"reports.list"},
+                {"jsonrpc":"2.0","id":2,"method":"reports.search","params":{"query":"private_query_value"}},
+                {"jsonrpc":"2.0","id":3,"method":"reports.delete","params":{"id":"purge_cache"}}
+            ]"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
+        ));
+        let (allowed, _) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
+        assert!(!allowed);
+
+        let jsonrpc = request.jsonrpc.as_ref().expect("jsonrpc request");
+        let evaluation =
+            evaluate_jsonrpc_l7_request_for_log(&tunnel_engine, &ctx, &request, jsonrpc).unwrap();
+        assert!(!evaluation.allowed);
+        assert!(evaluation.log_info.is_batch);
+        assert_eq!(
+            rule_method_names_for_log(&evaluation.log_info),
+            "reports.delete"
+        );
+
+        let message = jsonrpc_log_message(
+            "deny",
+            "POST",
+            "api.example.test:443/rpc",
+            &evaluation.log_info,
+            42,
+            &evaluation.reason,
+        );
+        assert!(message.contains("rule_methods=reports.delete"));
+        assert!(message.contains("policy_version=42"));
+        assert!(!message.contains("reports.list"));
+        assert!(!message.contains("reports.search"));
+        assert!(!message.contains("private_query_value"));
+        assert!(!message.contains("purge_cache"));
+    }
+
+    #[test]
+    fn jsonrpc_request_params_do_not_affect_method_policy() {
+        let data = r#"
+network_policies:
+  jsonrpc_api:
+    name: jsonrpc_api
+    endpoints:
+      - host: api.example.test
+        port: 443
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: "reports.search"
+    binaries:
+      - { path: /usr/bin/node }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
+        let tunnel_engine = engine
+            .clone_engine_for_tunnel(engine.current_generation())
+            .unwrap();
+        let ctx = L7EvalContext {
+            host: "api.example.test".into(),
+            port: 443,
+            policy_name: "jsonrpc_api".into(),
+            binary_path: "/usr/bin/node".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            activity_tx: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
+        };
+        let mut request = L7RequestInfo {
+            action: "POST".into(),
+            target: "/rpc".into(),
+            query_params: std::collections::HashMap::new(),
+            graphql: None,
+            jsonrpc: Some(crate::l7::jsonrpc::parse_jsonrpc_body(
+                br#"{"jsonrpc":"2.0","id":1,"method":"reports.search","params":{"query":"delete_resource","filters":{"scope":"workspace/secret"}}}"#,
+                crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
+            )),
+        };
+
+        let (allowed, reason) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
+        assert!(allowed, "{reason}");
+
+        request.jsonrpc = Some(crate::l7::jsonrpc::parse_jsonrpc_body(
+            br#"{"jsonrpc":"2.0","id":1,"method":"reports.search","params":["ignored",{"nested":true}]}"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
+        ));
+        let (allowed, reason) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
+        assert!(allowed, "{reason}");
+    }
+
+    #[test]
+    fn mcp_tool_deny_rule_blocks_tools_call() {
+        let data = r#"
+network_policies:
+  mcp_api:
+    name: mcp_api
+    endpoints:
+      - host: api.example.test
+        port: 443
+        path: "/mcp"
+        protocol: mcp
+        enforcement: enforce
+        mcp:
+          max_body_bytes: 131072
+        rules:
+          - allow:
+              method: initialize
+          - allow:
+              method: tools/list
+          - allow:
+              method: tools/call
+              tool: read_status
+        deny_rules:
+          - method: tools/call
+            tool: delete_resource
+    binaries:
+      - { path: /usr/bin/node }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
+        let tunnel_engine = engine
+            .clone_engine_for_tunnel(engine.current_generation())
+            .unwrap();
+        let ctx = L7EvalContext {
+            host: "api.example.test".into(),
+            port: 443,
+            policy_name: "mcp_api".into(),
+            binary_path: "/usr/bin/node".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            activity_tx: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
+        };
+        let mut request = L7RequestInfo {
+            action: "POST".into(),
+            target: "/mcp".into(),
+            query_params: std::collections::HashMap::new(),
+            graphql: None,
+            jsonrpc: Some(crate::l7::jsonrpc::parse_jsonrpc_body(
+                br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_status","arguments":{}}}"#,
+                crate::l7::jsonrpc::JsonRpcInspectionMode::Mcp,
+            )),
+        };
+
+        let (allowed, reason) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
+        assert!(allowed, "{reason}");
+
+        request.jsonrpc = Some(crate::l7::jsonrpc::parse_jsonrpc_body(
+            br#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delete_resource","arguments":{"scope":"workspace/main"}}}"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::Mcp,
+        ));
+        let parsed = request.jsonrpc.as_ref().expect("parsed MCP request");
+        assert!(
+            parsed.error.is_none(),
+            "MCP request should parse: {parsed:?}"
+        );
+        assert_eq!(
+            parsed.calls.first().and_then(|call| call.tool.as_deref()),
+            Some("delete_resource")
+        );
+
+        let (allowed, reason) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
+        assert!(!allowed, "delete_resource must match the MCP deny rule");
+        assert!(
+            reason.contains("deny rule"),
+            "deny reason should identify policy denial: {reason}"
+        );
+    }
+
+    #[test]
+    fn jsonrpc_log_records_method_names_not_params() {
+        let info = crate::l7::jsonrpc::parse_jsonrpc_body(
+            br#"{"jsonrpc":"2.0","id":1,"method":"reports.archive","params":{"id":"delete_resource","filters":{"scope":"secret-scope"}}}"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
+        );
+        let message = jsonrpc_log_message(
+            "deny",
+            "POST",
+            "jsonrpc.example.com:443/rpc",
+            &info,
+            42,
+            "request denied by policy",
+        );
+
+        assert!(message.contains("endpoint=jsonrpc.example.com:443/rpc"));
+        assert!(message.contains("rule_methods=reports.archive"));
+        assert!(message.contains("policy_version=42"));
+        assert!(!message.contains("delete_resource"));
+        assert!(!message.contains("secret-scope"));
+
+        let batch = crate::l7::jsonrpc::parse_jsonrpc_body(
+            br#"[
+                {"jsonrpc":"2.0","id":1,"method":"reports.list"},
+                {"jsonrpc":"2.0","id":2,"method":"reports.archive","params":{"id":"delete_resource"}}
+            ]"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
+        );
+        let batch_message = jsonrpc_log_message(
+            "allow",
+            "POST",
+            "jsonrpc.example.com:443/rpc",
+            &batch,
+            43,
+            "",
+        );
+
+        assert!(batch_message.starts_with("JSONRPC_L7_REQUEST "));
+        assert!(batch_message.contains("rule_methods=reports.list,reports.archive"));
+        assert!(batch_message.contains("policy_version=43"));
+        assert!(!batch_message.contains("delete_resource"));
+
+        let no_params = crate::l7::jsonrpc::parse_jsonrpc_body(
+            br#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
+        );
+        let no_params_message = jsonrpc_log_message(
+            "allow",
+            "POST",
+            "jsonrpc.example.com:443/rpc",
+            &no_params,
+            44,
+            "",
+        );
+        assert!(no_params_message.contains("rule_methods=initialize"));
     }
 
     #[tokio::test]
@@ -1887,6 +2712,8 @@ network_policies:
             tls: crate::l7::TlsMode::Auto,
             enforcement: EnforcementMode::Enforce,
             graphql_max_body_bytes: 0,
+            json_rpc_max_body_bytes: crate::l7::jsonrpc::DEFAULT_MAX_BODY_BYTES,
+            mcp_strict_tool_names: true,
             allow_encoded_slash: false,
             websocket_credential_rewrite: true,
             request_body_credential_rewrite: false,
@@ -1993,6 +2820,8 @@ network_policies:
             tls: crate::l7::TlsMode::Auto,
             enforcement: EnforcementMode::Enforce,
             graphql_max_body_bytes: 0,
+            json_rpc_max_body_bytes: crate::l7::jsonrpc::DEFAULT_MAX_BODY_BYTES,
+            mcp_strict_tool_names: true,
             allow_encoded_slash: false,
             websocket_credential_rewrite: true,
             request_body_credential_rewrite: false,
@@ -2116,6 +2945,8 @@ network_policies:
             tls: crate::l7::TlsMode::Auto,
             enforcement: EnforcementMode::Enforce,
             graphql_max_body_bytes: 0,
+            json_rpc_max_body_bytes: crate::l7::jsonrpc::DEFAULT_MAX_BODY_BYTES,
+            mcp_strict_tool_names: true,
             allow_encoded_slash: false,
             websocket_credential_rewrite: true,
             request_body_credential_rewrite: false,
@@ -2474,5 +3305,181 @@ network_policies:
             n, 0,
             "stale passthrough request must not be forwarded upstream"
         );
+    }
+
+    #[tokio::test]
+    async fn jsonrpc_relay_forwards_allowed_method() {
+        let (config, tunnel_engine, ctx) = jsonrpc_test_relay_context();
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_with_inspection(
+                &config,
+                tunnel_engine,
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+            )
+            .await
+        });
+
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#;
+        let request = format!(
+            "POST /rpc HTTP/1.1\r\nHost: jsonrpc.example.test:8000\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        app.write_all(request.as_bytes()).await.unwrap();
+        app.write_all(body).await.unwrap();
+
+        let mut upstream_bytes = Vec::new();
+        let mut upstream_buf = [0u8; 1024];
+        loop {
+            let n = tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                upstream.read(&mut upstream_buf),
+            )
+            .await
+            .expect("allowed JSON-RPC request should reach upstream")
+            .unwrap();
+            assert_ne!(n, 0, "upstream closed before JSON-RPC body arrived");
+            upstream_bytes.extend_from_slice(&upstream_buf[..n]);
+            if String::from_utf8_lossy(&upstream_bytes).contains(r#""method":"initialize""#) {
+                break;
+            }
+        }
+        let upstream_request = String::from_utf8_lossy(&upstream_bytes);
+        assert!(upstream_request.starts_with("POST /rpc HTTP/1.1"));
+        assert!(upstream_request.contains(r#""method":"initialize""#));
+
+        upstream
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 36\r\nConnection: close\r\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}",
+            )
+            .await
+            .unwrap();
+
+        let mut response = [0u8; 512];
+        let n = tokio::time::timeout(std::time::Duration::from_secs(1), app.read(&mut response))
+            .await
+            .expect("upstream response should reach client")
+            .unwrap();
+        assert!(String::from_utf8_lossy(&response[..n]).contains("200 OK"));
+
+        drop(app);
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should complete")
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn mcp_relay_forwards_jsonrpc_response_frame() {
+        let (config, tunnel_engine, ctx) = mcp_test_relay_context();
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_with_inspection(
+                &config,
+                tunnel_engine,
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+            )
+            .await
+        });
+
+        let body = br#"{"jsonrpc":"2.0","id":7,"result":{"action":"accept","content":{}}}"#;
+        let request = format!(
+            "POST /mcp HTTP/1.1\r\nHost: mcp.example.test:8000\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        app.write_all(request.as_bytes()).await.unwrap();
+        app.write_all(body).await.unwrap();
+
+        let mut upstream_buf = [0u8; 1024];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upstream.read(&mut upstream_buf),
+        )
+        .await
+        .expect("MCP response frame should reach upstream")
+        .unwrap();
+        let upstream_request = String::from_utf8_lossy(&upstream_buf[..n]);
+        assert!(upstream_request.starts_with("POST /mcp HTTP/1.1"));
+        assert!(upstream_request.contains(r#""result":{"action":"accept""#));
+
+        upstream
+            .write_all(b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .await
+            .unwrap();
+
+        let mut response = [0u8; 512];
+        let n = tokio::time::timeout(std::time::Duration::from_secs(1), app.read(&mut response))
+            .await
+            .expect("upstream response should reach client")
+            .unwrap();
+        assert!(String::from_utf8_lossy(&response[..n]).contains("202 Accepted"));
+
+        drop(app);
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should complete")
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn jsonrpc_relay_denies_method_not_in_allow_list() {
+        let (config, tunnel_engine, ctx) = jsonrpc_test_relay_context();
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_with_inspection(
+                &config,
+                tunnel_engine,
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+            )
+            .await
+        });
+
+        let body =
+            br#"{"jsonrpc":"2.0","id":1,"method":"reports.search","params":{"query":"list_repos"}}"#;
+        let request = format!(
+            "POST /rpc HTTP/1.1\r\nHost: jsonrpc.example.test:8000\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        app.write_all(request.as_bytes()).await.unwrap();
+        app.write_all(body).await.unwrap();
+
+        let mut response = [0u8; 512];
+        let n = tokio::time::timeout(std::time::Duration::from_secs(2), app.read(&mut response))
+            .await
+            .expect("relay should respond without reaching upstream")
+            .unwrap();
+        let response = String::from_utf8_lossy(&response[..n]);
+        assert!(
+            response.contains("403"),
+            "reports.search not in allow list must be denied with 403, got: {response:?}"
+        );
+
+        let mut upstream_buf = [0u8; 128];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            upstream.read(&mut upstream_buf),
+        )
+        .await
+        .unwrap_or(Ok(0))
+        .unwrap_or(0);
+        assert_eq!(n, 0, "denied request must not be forwarded to upstream");
+
+        drop(app);
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should complete")
+            .unwrap()
+            .unwrap();
     }
 }

--- a/crates/openshell-supervisor-network/src/l7/rest.rs
+++ b/crates/openshell-supervisor-network/src/l7/rest.rs
@@ -1955,6 +1955,7 @@ where
     let header_str = String::from_utf8_lossy(&buf[..header_end]);
     let status_code = parse_status_code(&header_str).unwrap_or(200);
     let server_wants_close = parse_connection_close(&header_str);
+    let event_stream = response_is_event_stream(&header_str);
     let body_length = parse_body_length(&header_str)?;
 
     debug!(
@@ -2014,19 +2015,29 @@ where
     // No explicit framing (no Content-Length, no Transfer-Encoding).
     // Per RFC 7230 §3.3.3 the body is delimited by connection close.
     if matches!(body_length, BodyLength::None) {
-        if server_wants_close {
-            // Server indicated it will close — read until EOF.
+        if server_wants_close || event_stream {
+            // Server indicated it will close, or this is a streaming response
+            // such as SSE where the body is intentionally delimited by EOF.
             let before_end = &buf[..header_end - 2];
             client.write_all(before_end).await.into_diagnostic()?;
-            client
-                .write_all(b"Connection: close\r\n\r\n")
-                .await
-                .into_diagnostic()?;
+            if server_wants_close {
+                client
+                    .write_all(b"Connection: close\r\n\r\n")
+                    .await
+                    .into_diagnostic()?;
+            } else {
+                client.write_all(b"\r\n").await.into_diagnostic()?;
+            }
             let overflow = &buf[header_end..];
             if !overflow.is_empty() {
                 client.write_all(overflow).await.into_diagnostic()?;
+                client.flush().await.into_diagnostic()?;
             }
-            relay_until_eof(upstream, client).await?;
+            if event_stream {
+                relay_until_eof_without_idle_timeout(upstream, client).await?;
+            } else {
+                relay_until_eof(upstream, client).await?;
+            }
             client.flush().await.into_diagnostic()?;
             return Ok(RelayOutcome::Consumed);
         }
@@ -2094,6 +2105,19 @@ fn parse_connection_close(headers: &str) -> bool {
         }
     }
     false
+}
+
+fn response_is_event_stream(headers: &str) -> bool {
+    headers.lines().skip(1).any(|line| {
+        let lower = line.to_ascii_lowercase();
+        let Some(value) = lower.strip_prefix("content-type:") else {
+            return false;
+        };
+        value
+            .split(';')
+            .next()
+            .is_some_and(|mime| mime.trim() == "text/event-stream")
+    })
 }
 
 fn validate_websocket_response(
@@ -2300,7 +2324,10 @@ where
     loop {
         match tokio::time::timeout(RELAY_EOF_IDLE_TIMEOUT, reader.read(&mut buf)).await {
             Ok(Ok(0)) => return Ok(()),
-            Ok(Ok(n)) => writer.write_all(&buf[..n]).await.into_diagnostic()?,
+            Ok(Ok(n)) => {
+                writer.write_all(&buf[..n]).await.into_diagnostic()?;
+                writer.flush().await.into_diagnostic()?;
+            }
             Ok(Err(e)) => return Err(miette::miette!("{e}")),
             Err(_) => {
                 debug!(
@@ -2310,6 +2337,26 @@ where
                 return Ok(());
             }
         }
+    }
+}
+
+/// Relay all bytes from reader to writer until EOF without an idle timeout.
+///
+/// Used for server-sent events, where long idle gaps are part of the protocol
+/// and do not mean the response body is complete.
+async fn relay_until_eof_without_idle_timeout<R, W>(reader: &mut R, writer: &mut W) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut buf = [0u8; RELAY_BUF_SIZE];
+    loop {
+        let n = reader.read(&mut buf).await.into_diagnostic()?;
+        if n == 0 {
+            return Ok(());
+        }
+        writer.write_all(&buf[..n]).await.into_diagnostic()?;
+        writer.flush().await.into_diagnostic()?;
     }
 }
 
@@ -3338,6 +3385,19 @@ mod tests {
     }
 
     #[test]
+    fn test_response_is_event_stream() {
+        assert!(response_is_event_stream(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n"
+        ));
+        assert!(response_is_event_stream(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream; charset=utf-8\r\n\r\n"
+        ));
+        assert!(!response_is_event_stream(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n"
+        ));
+    }
+
+    #[test]
     fn test_is_bodiless_response() {
         assert!(is_bodiless_response("HEAD", 200));
         assert!(is_bodiless_response("GET", 100));
@@ -3391,6 +3451,99 @@ mod tests {
         assert!(
             received_str.contains("hello world"),
             "body should be forwarded"
+        );
+    }
+
+    #[tokio::test]
+    async fn relay_response_no_framing_event_stream_reads_until_eof() {
+        let response =
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\nevent: message\ndata: {}\r\n\r\n";
+
+        let (mut upstream_read, mut upstream_write) = tokio::io::duplex(4096);
+        let (mut client_read, mut client_write) = tokio::io::duplex(4096);
+
+        tokio::spawn(async move {
+            upstream_write.write_all(response).await.unwrap();
+            upstream_write.shutdown().await.unwrap();
+        });
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            relay_response(
+                "GET",
+                &mut upstream_read,
+                &mut client_write,
+                RelayResponseOptions::default(),
+            ),
+        )
+        .await
+        .expect("relay_response should not deadlock");
+
+        let outcome = result.expect("relay_response should succeed");
+        assert!(
+            matches!(outcome, RelayOutcome::Consumed),
+            "event stream is consumed by read-until-EOF"
+        );
+
+        client_write.shutdown().await.unwrap();
+        let mut received = Vec::new();
+        client_read.read_to_end(&mut received).await.unwrap();
+        let received_str = String::from_utf8_lossy(&received);
+        assert!(received_str.contains("Content-Type: text/event-stream"));
+        assert!(received_str.contains("event: message"));
+    }
+
+    #[tokio::test]
+    async fn relay_response_no_framing_event_stream_survives_idle_gap() {
+        let (mut upstream_read, mut upstream_write) = tokio::io::duplex(4096);
+        let (mut client_read, mut client_write) = tokio::io::duplex(4096);
+
+        let upstream_task = tokio::spawn(async move {
+            upstream_write
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream; charset=utf-8\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            upstream_write
+                .write_all(b"event: first\ndata: {}\r\n\r\n")
+                .await
+                .unwrap();
+            upstream_write.flush().await.unwrap();
+            tokio::time::sleep(RELAY_EOF_IDLE_TIMEOUT + std::time::Duration::from_secs(1)).await;
+            let _ = upstream_write
+                .write_all(b"event: second\ndata: {}\r\n\r\n")
+                .await;
+            let _ = upstream_write.shutdown().await;
+        });
+
+        let result = tokio::time::timeout(
+            RELAY_EOF_IDLE_TIMEOUT + std::time::Duration::from_secs(3),
+            relay_response(
+                "GET",
+                &mut upstream_read,
+                &mut client_write,
+                RelayResponseOptions::default(),
+            ),
+        )
+        .await
+        .expect("event stream relay must outlive the generic EOF idle timeout");
+
+        let outcome = result.expect("relay_response should succeed");
+        assert!(
+            matches!(outcome, RelayOutcome::Consumed),
+            "event stream is consumed by read-until-EOF"
+        );
+        upstream_task.await.expect("upstream task should complete");
+
+        client_write.shutdown().await.unwrap();
+        let mut received = Vec::new();
+        client_read.read_to_end(&mut received).await.unwrap();
+        let received_str = String::from_utf8_lossy(&received);
+        assert!(received_str.contains("event: first"));
+        assert!(
+            received_str.contains("event: second"),
+            "SSE event after idle gap should be forwarded, got: {received_str}"
         );
     }
 

--- a/crates/openshell-supervisor-network/src/l7/websocket.rs
+++ b/crates/openshell-supervisor-network/src/l7/websocket.rs
@@ -545,6 +545,7 @@ fn inspect_websocket_text_message(
         target: inspector.target.clone(),
         query_params: inspector.query_params.clone(),
         graphql: None,
+        jsonrpc: None,
     };
     let (allowed, reason) = evaluate_l7_request(inspector.engine, inspector.ctx, &request_info)?;
     let decision = match (allowed, inspector.enforcement) {
@@ -581,6 +582,7 @@ fn inspect_graphql_websocket_message(
                 target: inspector.target.clone(),
                 query_params: inspector.query_params.clone(),
                 graphql: None,
+                jsonrpc: None,
             };
             emit_websocket_l7_event(
                 host,
@@ -602,6 +604,7 @@ fn inspect_graphql_websocket_message(
                 target: inspector.target.clone(),
                 query_params: inspector.query_params.clone(),
                 graphql: Some(graphql.clone()),
+                jsonrpc: None,
             };
             let parse_error_reason = graphql
                 .error

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -12,6 +12,7 @@ use openshell_core::policy::{
     FilesystemPolicy, LandlockCompatibility, LandlockPolicy, ProcessPolicy,
 };
 use openshell_core::proto::SandboxPolicy as ProtoSandboxPolicy;
+use openshell_policy::L7ConfigStanza;
 use std::path::{Path, PathBuf};
 use std::sync::{
     Arc, Mutex,
@@ -217,6 +218,8 @@ impl OpaEngine {
                 errors.join("\n")
             ));
         }
+
+        normalize_l7_policy_rule_aliases(&mut data);
 
         // Expand access presets to explicit rules after validation
         crate::l7::expand_access_presets(&mut data);
@@ -723,6 +726,13 @@ fn preprocess_yaml_data(yaml_str: &str) -> Result<String> {
 
     // Normalize port → ports for all endpoints so Rego always sees "ports" array.
     normalize_endpoint_ports(&mut data);
+    let config_errors = normalize_l7_config_aliases(&mut data);
+    if !config_errors.is_empty() {
+        return Err(miette::miette!(
+            "L7 policy validation failed:\n{}",
+            config_errors.join("\n")
+        ));
+    }
 
     // Validate BEFORE expanding presets (catches user errors like rules+access)
     let (errors, warnings) = crate::l7::validate_l7_policies(&data);
@@ -743,6 +753,8 @@ fn preprocess_yaml_data(yaml_str: &str) -> Result<String> {
             errors.join("\n")
         ));
     }
+
+    normalize_l7_policy_rule_aliases(&mut data);
 
     // Expand access presets to explicit rules after validation
     crate::l7::expand_access_presets(&mut data);
@@ -795,6 +807,150 @@ fn normalize_endpoint_ports(data: &mut serde_json::Value) {
 
             // Remove scalar "port" — Rego only uses "ports".
             ep_obj.remove("port");
+        }
+    }
+}
+
+fn normalize_l7_config_aliases(data: &mut serde_json::Value) -> Vec<String> {
+    let mut errors = Vec::new();
+    let Some(policies) = data
+        .get_mut("network_policies")
+        .and_then(|v| v.as_object_mut())
+    else {
+        return errors;
+    };
+
+    for (policy_name, policy) in policies.iter_mut() {
+        let Some(endpoints) = policy.get_mut("endpoints").and_then(|v| v.as_array_mut()) else {
+            continue;
+        };
+
+        for (index, ep) in endpoints.iter_mut().enumerate() {
+            let Some(ep_obj) = ep.as_object_mut() else {
+                continue;
+            };
+            let loc = format!("network_policies.{policy_name}.endpoints[{index}]");
+            for stanza in L7ConfigStanza::ALL {
+                normalize_l7_config_alias(&mut errors, ep_obj, &loc, stanza);
+            }
+        }
+    }
+
+    errors
+}
+
+fn normalize_l7_config_alias(
+    errors: &mut Vec<String>,
+    ep: &mut serde_json::Map<String, serde_json::Value>,
+    loc: &str,
+    stanza: L7ConfigStanza,
+) {
+    let key = stanza.key();
+    let Some(config) = ep.get(key).cloned() else {
+        return;
+    };
+    if config.is_null() {
+        ep.remove(key);
+        return;
+    }
+    match openshell_policy::l7_config_alias_runtime_fields(stanza, config) {
+        Ok(fields) => {
+            ep.remove(key);
+            for (field, value) in fields {
+                ep.entry(field.to_string()).or_insert(value);
+            }
+        }
+        Err(error) => errors.push(format!("{loc}.{key}: {error}")),
+    }
+}
+
+fn normalize_l7_policy_rule_aliases(data: &mut serde_json::Value) {
+    let Some(policies) = data
+        .get_mut("network_policies")
+        .and_then(|v| v.as_object_mut())
+    else {
+        return;
+    };
+
+    for (_name, policy) in policies.iter_mut() {
+        let Some(endpoints) = policy.get_mut("endpoints").and_then(|v| v.as_array_mut()) else {
+            continue;
+        };
+
+        for ep in endpoints.iter_mut() {
+            let Some(ep_obj) = ep.as_object_mut() else {
+                continue;
+            };
+            normalize_l7_rules_aliases(ep_obj);
+        }
+    }
+}
+
+fn normalize_l7_rules_aliases(ep: &mut serde_json::Map<String, serde_json::Value>) {
+    let protocol = ep
+        .get("protocol")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let mcp_allow_all_known_mcp_methods = ep
+        .get("mcp_allow_all_known_mcp_methods")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if let Some(rules) = ep.get_mut("rules").and_then(|v| v.as_array_mut()) {
+        for rule in rules {
+            if let Some(allow) = rule
+                .get_mut("allow")
+                .and_then(serde_json::Value::as_object_mut)
+            {
+                normalize_l7_rule_aliases(allow, &protocol, mcp_allow_all_known_mcp_methods);
+            } else if let Some(allow) = rule.as_object_mut() {
+                normalize_l7_rule_aliases(allow, &protocol, mcp_allow_all_known_mcp_methods);
+            }
+        }
+    }
+
+    if let Some(denies) = ep.get_mut("deny_rules").and_then(|v| v.as_array_mut()) {
+        for deny in denies {
+            if let Some(deny_obj) = deny.as_object_mut() {
+                normalize_l7_rule_aliases(deny_obj, &protocol, mcp_allow_all_known_mcp_methods);
+            }
+        }
+    }
+}
+
+fn normalize_l7_rule_aliases(
+    rule: &mut serde_json::Map<String, serde_json::Value>,
+    protocol: &str,
+    mcp_allow_all_known_mcp_methods: bool,
+) {
+    if protocol == "mcp" {
+        let mut has_tool_selector = rule
+            .get("params")
+            .and_then(serde_json::Value::as_object)
+            .and_then(|params| params.get("name"))
+            .is_some_and(|v| !v.is_null());
+        if let Some(tool) = rule.remove("tool").filter(|v| !v.is_null()) {
+            let params = rule
+                .entry("params".to_string())
+                .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+            if let Some(params) = params.as_object_mut() {
+                params.entry("name".to_string()).or_insert(tool);
+                has_tool_selector = true;
+            }
+        }
+
+        if mcp_allow_all_known_mcp_methods
+            && rule
+                .get("method")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("")
+                .is_empty()
+        {
+            let method = if has_tool_selector { "tools/call" } else { "*" };
+            rule.insert(
+                "method".to_string(),
+                serde_json::Value::String(method.to_string()),
+            );
         }
     }
 }
@@ -925,6 +1081,24 @@ fn resolve_binary_in_container(_policy_path: &str, _entrypoint_pid: u32) -> Opti
     None
 }
 
+fn l7_matchers_to_json(
+    matchers: &std::collections::HashMap<String, openshell_core::proto::L7QueryMatcher>,
+) -> serde_json::Map<String, serde_json::Value> {
+    matchers
+        .iter()
+        .map(|(key, matcher)| {
+            let mut matcher_json = serde_json::json!({});
+            if !matcher.glob.is_empty() {
+                matcher_json["glob"] = matcher.glob.clone().into();
+            }
+            if !matcher.any.is_empty() {
+                matcher_json["any"] = matcher.any.clone().into();
+            }
+            (key.clone(), matcher_json)
+        })
+        .collect()
+}
+
 /// Convert typed proto policy fields to JSON suitable for `engine.add_data_json()`.
 ///
 /// The rego rules reference `data.*` directly, so the JSON structure has
@@ -1029,28 +1203,17 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                                 {
                                     allow["fields"] = a.fields.clone().into();
                                 }
-                                let query: serde_json::Map<String, serde_json::Value> = a
-                                    .map(|allow| {
-                                        allow
-                                            .query
-                                            .iter()
-                                            .map(|(key, matcher)| {
-                                                let mut matcher_json = serde_json::json!({});
-                                                if !matcher.glob.is_empty() {
-                                                    matcher_json["glob"] =
-                                                        matcher.glob.clone().into();
-                                                }
-                                                if !matcher.any.is_empty() {
-                                                    matcher_json["any"] =
-                                                        matcher.any.clone().into();
-                                                }
-                                                (key.clone(), matcher_json)
-                                            })
-                                            .collect()
-                                    })
-                                    .unwrap_or_default();
+                                let query = a.map_or_else(serde_json::Map::new, |allow| {
+                                    l7_matchers_to_json(&allow.query)
+                                });
                                 if !query.is_empty() {
                                     allow["query"] = query.into();
+                                }
+                                let params = a.map_or_else(serde_json::Map::new, |allow| {
+                                    l7_matchers_to_json(&allow.params)
+                                });
+                                if !params.is_empty() {
+                                    allow["params"] = params.into();
                                 }
                                 serde_json::json!({ "allow": allow })
                             })
@@ -1087,22 +1250,13 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                                 if !d.fields.is_empty() {
                                     deny["fields"] = d.fields.clone().into();
                                 }
-                                let query: serde_json::Map<String, serde_json::Value> = d
-                                    .query
-                                    .iter()
-                                    .map(|(key, matcher)| {
-                                        let mut matcher_json = serde_json::json!({});
-                                        if !matcher.glob.is_empty() {
-                                            matcher_json["glob"] = matcher.glob.clone().into();
-                                        }
-                                        if !matcher.any.is_empty() {
-                                            matcher_json["any"] = matcher.any.clone().into();
-                                        }
-                                        (key.clone(), matcher_json)
-                                    })
-                                    .collect();
+                                let query = l7_matchers_to_json(&d.query);
                                 if !query.is_empty() {
                                     deny["query"] = query.into();
+                                }
+                                let params = l7_matchers_to_json(&d.params);
+                                if !params.is_empty() {
+                                    deny["params"] = params.into();
                                 }
                                 deny
                             })
@@ -1149,6 +1303,18 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                     }
                     if e.graphql_max_body_bytes > 0 {
                         ep["graphql_max_body_bytes"] = e.graphql_max_body_bytes.into();
+                    }
+                    if e.json_rpc_max_body_bytes > 0 {
+                        ep["json_rpc_max_body_bytes"] = e.json_rpc_max_body_bytes.into();
+                    }
+                    if let Some(mcp) = &e.mcp {
+                        if let Some(strict_tool_names) = mcp.strict_tool_names {
+                            ep["mcp_strict_tool_names"] = strict_tool_names.into();
+                        }
+                        if let Some(allow_all_known_mcp_methods) = mcp.allow_all_known_mcp_methods {
+                            ep["mcp_allow_all_known_mcp_methods"] =
+                                allow_all_known_mcp_methods.into();
+                        }
                     }
                     ep
                 })
@@ -1957,6 +2123,58 @@ process:
         })
     }
 
+    fn l7_jsonrpc_input(host: &str, port: u16, path: &str, method: &str) -> serde_json::Value {
+        serde_json::json!({
+            "network": { "host": host, "port": port },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "POST",
+                "path": path,
+                "query_params": {},
+                "jsonrpc": {
+                    "method": method
+                }
+            }
+        })
+    }
+
+    fn l7_jsonrpc_input_with_params(
+        host: &str,
+        port: u16,
+        path: &str,
+        method: &str,
+        params: serde_json::Value,
+    ) -> serde_json::Value {
+        let mut input = l7_jsonrpc_input(host, port, path, method);
+        input["request"]["jsonrpc"]["params"] = params;
+        input
+    }
+
+    fn l7_jsonrpc_response_input(host: &str, port: u16, path: &str) -> serde_json::Value {
+        serde_json::json!({
+            "network": { "host": host, "port": port },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "POST",
+                "path": path,
+                "query_params": {},
+                "jsonrpc": {
+                    "method": null,
+                    "has_response": true,
+                    "error": null
+                }
+            }
+        })
+    }
+
     fn l7_graphql_input(host: &str, operations: serde_json::Value) -> serde_json::Value {
         serde_json::json!({
             "network": { "host": host, "port": 443 },
@@ -2019,6 +2237,21 @@ process:
         let mut eng = engine.engine.lock().unwrap();
         eng.set_input_json(&input.to_string()).unwrap();
         let val = eng
+            .eval_rule("data.openshell.sandbox.allow_request".into())
+            .unwrap();
+        val == regorus::Value::from(true)
+    }
+
+    fn eval_l7_raw_data(data: serde_json::Value, input: serde_json::Value) -> bool {
+        let mut engine = regorus::Engine::new();
+        engine
+            .add_policy("policy.rego".into(), TEST_POLICY.into())
+            .unwrap();
+        engine
+            .add_data_json(&data.to_string())
+            .expect("add raw data json");
+        engine.set_input_json(&input.to_string()).unwrap();
+        let val = engine
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
         val == regorus::Value::from(true)
@@ -2461,6 +2694,24 @@ network_policies:
     }
 
     #[test]
+    fn l7_rest_request_ignores_null_jsonrpc_metadata() {
+        let engine = l7_engine();
+        let mut input = l7_input_with_query(
+            "api.query.com",
+            8080,
+            "GET",
+            "/download",
+            serde_json::json!({
+                "tag": ["foo-a"],
+            }),
+        );
+        input["request"]["graphql"] = serde_json::Value::Null;
+        input["request"]["jsonrpc"] = serde_json::Value::Null;
+
+        assert!(eval_l7(&engine, &input));
+    }
+
+    #[test]
     fn l7_query_missing_required_key_denied() {
         let engine = l7_engine();
         let input = l7_input_with_query(
@@ -2503,6 +2754,7 @@ network_policies:
                             operation_type: String::new(),
                             operation_name: String::new(),
                             fields: Vec::new(),
+                            params: std::collections::HashMap::new(),
                         }),
                     }],
                     ..Default::default()
@@ -2549,6 +2801,864 @@ network_policies:
             serde_json::json!({ "tag": ["evil"] }),
         );
         assert!(!eval_l7(&engine, &deny_input));
+    }
+
+    #[test]
+    fn l7_method_from_proto_is_enforced() {
+        let mut network_policies = std::collections::HashMap::new();
+        network_policies.insert(
+            "jsonrpc_proto".to_string(),
+            NetworkPolicyRule {
+                name: "jsonrpc_proto".to_string(),
+                endpoints: vec![NetworkEndpoint {
+                    host: "jsonrpc.proto.com".to_string(),
+                    port: 8000,
+                    path: "/rpc".to_string(),
+                    protocol: "json-rpc".to_string(),
+                    enforcement: "enforce".to_string(),
+                    rules: vec![L7Rule {
+                        allow: Some(L7Allow {
+                            method: "initialize".to_string(),
+                            path: String::new(),
+                            command: String::new(),
+                            query: std::collections::HashMap::new(),
+                            operation_type: String::new(),
+                            operation_name: String::new(),
+                            fields: Vec::new(),
+                            params: std::collections::HashMap::new(),
+                        }),
+                    }],
+                    ..Default::default()
+                }],
+                binaries: vec![NetworkBinary {
+                    path: "/usr/bin/curl".to_string(),
+                    ..Default::default()
+                }],
+            },
+        );
+
+        let proto = ProtoSandboxPolicy {
+            version: 1,
+            filesystem: Some(ProtoFs {
+                include_workdir: true,
+                read_only: vec![],
+                read_write: vec![],
+            }),
+            landlock: Some(openshell_core::proto::LandlockPolicy {
+                compatibility: "best_effort".to_string(),
+            }),
+            process: Some(ProtoProc {
+                run_as_user: "sandbox".to_string(),
+                run_as_group: "sandbox".to_string(),
+            }),
+            network_policies,
+        };
+
+        let engine = OpaEngine::from_proto(&proto).expect("engine from proto");
+        let allow_input = l7_jsonrpc_input("jsonrpc.proto.com", 8000, "/rpc", "initialize");
+        assert!(eval_l7(&engine, &allow_input));
+
+        let deny_input = l7_jsonrpc_input("jsonrpc.proto.com", 8000, "/rpc", "reports.list");
+        assert!(!eval_l7(&engine, &deny_input));
+    }
+
+    #[test]
+    fn l7_mcp_tool_params_from_proto_are_enforced() {
+        // Regression: the proto load path (from_proto) must carry the rule
+        // `params` matcher map. If it is dropped, a tools/call allow rule
+        // narrowed to one tool degrades to allow-any-tool in production, even
+        // though the YAML/add_data_json path enforces it correctly.
+        let mut params = std::collections::HashMap::new();
+        params.insert(
+            "name".to_string(),
+            L7QueryMatcher {
+                glob: String::new(),
+                any: vec!["read_status".to_string(), "submit_*".to_string()],
+            },
+        );
+
+        let mut network_policies = std::collections::HashMap::new();
+        network_policies.insert(
+            "mcp_proto".to_string(),
+            NetworkPolicyRule {
+                name: "mcp_proto".to_string(),
+                endpoints: vec![NetworkEndpoint {
+                    host: "mcp.proto.com".to_string(),
+                    port: 8000,
+                    path: "/mcp".to_string(),
+                    protocol: "mcp".to_string(),
+                    enforcement: "enforce".to_string(),
+                    rules: vec![L7Rule {
+                        allow: Some(L7Allow {
+                            method: "tools/call".to_string(),
+                            path: String::new(),
+                            command: String::new(),
+                            query: std::collections::HashMap::new(),
+                            operation_type: String::new(),
+                            operation_name: String::new(),
+                            fields: Vec::new(),
+                            params,
+                        }),
+                    }],
+                    ..Default::default()
+                }],
+                binaries: vec![NetworkBinary {
+                    path: "/usr/bin/curl".to_string(),
+                    ..Default::default()
+                }],
+            },
+        );
+
+        let proto = ProtoSandboxPolicy {
+            version: 1,
+            filesystem: Some(ProtoFs {
+                include_workdir: true,
+                read_only: vec![],
+                read_write: vec![],
+            }),
+            landlock: Some(openshell_core::proto::LandlockPolicy {
+                compatibility: "best_effort".to_string(),
+            }),
+            process: Some(ProtoProc {
+                run_as_user: "sandbox".to_string(),
+                run_as_group: "sandbox".to_string(),
+            }),
+            network_policies,
+        };
+
+        let engine = OpaEngine::from_proto(&proto).expect("engine from proto");
+
+        let allowed_tool = l7_jsonrpc_input_with_params(
+            "mcp.proto.com",
+            8000,
+            "/mcp",
+            "tools/call",
+            serde_json::json!({ "name": "read_status" }),
+        );
+        assert!(
+            eval_l7(&engine, &allowed_tool),
+            "tools/call for an allowed tool should be permitted"
+        );
+
+        let blocked_tool = l7_jsonrpc_input_with_params(
+            "mcp.proto.com",
+            8000,
+            "/mcp",
+            "tools/call",
+            serde_json::json!({ "name": "blocked_action" }),
+        );
+        assert!(
+            !eval_l7(&engine, &blocked_tool),
+            "tools/call for a non-matching tool must be denied (params matcher must survive the proto load path)"
+        );
+    }
+
+    #[test]
+    fn l7_jsonrpc_endpoint_ignores_rest_shaped_allow_rules() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "jsonrpc_rest_bypass": {
+                    "name": "jsonrpc_rest_bypass",
+                    "endpoints": [{
+                        "host": "jsonrpc.rest-bypass.test",
+                        "ports": [8000],
+                        "path": "/rpc",
+                        "protocol": "json-rpc",
+                        "rules": [{
+                            "allow": {
+                                "method": "POST",
+                                "path": "**"
+                            }
+                        }]
+                    }],
+                    "binaries": [{ "path": "/usr/bin/curl" }]
+                }
+            }
+        });
+        let input = l7_jsonrpc_input("jsonrpc.rest-bypass.test", 8000, "/rpc", "reports.list");
+        assert!(
+            !eval_l7_raw_data(data, input),
+            "REST-shaped method/path rules must not authorize JSON-RPC endpoints"
+        );
+    }
+
+    #[test]
+    fn l7_jsonrpc_receive_stream_get_is_denied_for_matching_endpoint() {
+        let data = r#"
+network_policies:
+  jsonrpc_stream:
+    name: jsonrpc_stream
+    endpoints:
+      - host: jsonrpc.stream.test
+        port: 8000
+        path: /rpc
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+        let receive_stream_get = serde_json::json!({
+            "network": { "host": "jsonrpc.stream.test", "port": 8000 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "GET",
+                "path": "/rpc",
+                "query_params": {},
+                "jsonrpc": {
+                    "method": null,
+                    "receive_stream": true,
+                    "error": null
+                }
+            }
+        });
+        assert!(!eval_l7(&engine, &receive_stream_get));
+
+        let deny_input = serde_json::json!({
+            "network": { "host": "jsonrpc.stream.test", "port": 8000 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "GET",
+                "path": "/other",
+                "query_params": {},
+                "jsonrpc": {
+                    "method": null,
+                    "receive_stream": true,
+                    "error": null
+                }
+            }
+        });
+        assert!(!eval_l7(&engine, &deny_input));
+
+        let bodyless_get_without_receive_stream = serde_json::json!({
+            "network": { "host": "jsonrpc.stream.test", "port": 8000 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "GET",
+                "path": "/rpc",
+                "query_params": {},
+                "jsonrpc": {
+                    "method": null,
+                    "error": null
+                }
+            }
+        });
+        assert!(!eval_l7(&engine, &bodyless_get_without_receive_stream));
+
+        let null_metadata_get = serde_json::json!({
+            "network": { "host": "mcp.stream.test", "port": 8000 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "GET",
+                "path": "/mcp",
+                "query_params": {},
+                "jsonrpc": null
+            }
+        });
+        assert!(!eval_l7(&engine, &null_metadata_get));
+    }
+
+    #[test]
+    fn l7_mcp_receive_stream_get_is_allowed_for_matching_endpoint() {
+        let data = r#"
+network_policies:
+  mcp_stream:
+    name: mcp_stream
+    endpoints:
+      - host: mcp.stream.test
+        port: 8000
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+        let allow_input = serde_json::json!({
+            "network": { "host": "mcp.stream.test", "port": 8000 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "GET",
+                "path": "/mcp",
+                "query_params": {},
+                "jsonrpc": {
+                    "method": null,
+                    "params": {},
+                    "receive_stream": true,
+                    "error": null
+                }
+            }
+        });
+        assert!(eval_l7(&engine, &allow_input));
+
+        let deny_input = serde_json::json!({
+            "network": { "host": "mcp.stream.test", "port": 8000 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "GET",
+                "path": "/other",
+                "query_params": {},
+                "jsonrpc": {
+                    "method": null,
+                    "params": {},
+                    "receive_stream": true,
+                    "error": null
+                }
+            }
+        });
+        assert!(!eval_l7(&engine, &deny_input));
+    }
+
+    #[test]
+    fn l7_jsonrpc_response_post_is_denied_for_matching_endpoint() {
+        let data = r#"
+network_policies:
+  jsonrpc_response:
+    name: jsonrpc_response
+    endpoints:
+      - host: jsonrpc.response.test
+        port: 8000
+        path: /rpc
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+        let response_input = l7_jsonrpc_response_input("jsonrpc.response.test", 8000, "/rpc");
+        assert!(!eval_l7(&engine, &response_input));
+
+        let mut mixed_input = l7_jsonrpc_input("jsonrpc.response.test", 8000, "/rpc", "initialize");
+        mixed_input["request"]["jsonrpc"]["has_response"] = serde_json::json!(true);
+        assert!(!eval_l7(&engine, &mixed_input));
+
+        let deny_input = l7_jsonrpc_response_input("jsonrpc.response.test", 8000, "/other");
+        assert!(!eval_l7(&engine, &deny_input));
+    }
+
+    #[test]
+    fn l7_mcp_response_post_is_allowed_for_matching_endpoint() {
+        let data = r#"
+network_policies:
+  mcp_response:
+    name: mcp_response
+    endpoints:
+      - host: mcp.response.test
+        port: 8000
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+        let response_input = l7_jsonrpc_response_input("mcp.response.test", 8000, "/mcp");
+        assert!(eval_l7(&engine, &response_input));
+
+        let deny_input = l7_jsonrpc_response_input("mcp.response.test", 8000, "/other");
+        assert!(!eval_l7(&engine, &deny_input));
+    }
+
+    #[test]
+    fn l7_jsonrpc_unlisted_method_is_denied() {
+        let data = r#"
+network_policies:
+  jsonrpc_methods:
+    name: jsonrpc_methods
+    endpoints:
+      - host: jsonrpc.methods.test
+        port: 8000
+        path: /rpc
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+        let unlisted_input =
+            l7_jsonrpc_input("jsonrpc.methods.test", 8000, "/rpc", "reports.progress");
+
+        assert!(!eval_l7(&engine, &unlisted_input));
+    }
+
+    #[test]
+    fn l7_method_rules_require_post() {
+        let data = r#"
+network_policies:
+  jsonrpc_post:
+    name: jsonrpc_post
+    endpoints:
+      - host: jsonrpc.post.test
+        port: 8000
+        path: /rpc
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: initialize
+        deny_rules:
+          - method: reports.archive
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+
+        let mut post_input = l7_jsonrpc_input("jsonrpc.post.test", 8000, "/rpc", "initialize");
+        assert!(eval_l7(&engine, &post_input));
+
+        post_input["request"]["method"] = serde_json::json!("PUT");
+        assert!(!eval_l7(&engine, &post_input));
+
+        let mut get_with_method = l7_jsonrpc_input("jsonrpc.post.test", 8000, "/rpc", "initialize");
+        get_with_method["request"]["method"] = serde_json::json!("GET");
+        assert!(!eval_l7(&engine, &get_with_method));
+    }
+
+    #[test]
+    fn l7_jsonrpc_request_params_do_not_affect_method_policy() {
+        let data = r#"
+network_policies:
+  jsonrpc_params:
+    name: jsonrpc_params
+    endpoints:
+      - host: jsonrpc.params.test
+        port: 8000
+        path: /rpc
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: reports.search
+        deny_rules:
+          - method: reports.archive
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+
+        let read_status = l7_jsonrpc_input_with_params(
+            "jsonrpc.params.test",
+            8000,
+            "/rpc",
+            "reports.search",
+            serde_json::json!({"query": "quarterly"}),
+        );
+        assert!(eval_l7(&engine, &read_status));
+
+        let submit_report = l7_jsonrpc_input_with_params(
+            "jsonrpc.params.test",
+            8000,
+            "/rpc",
+            "reports.search",
+            serde_json::json!({
+                "query": "quarterly",
+                "filters.scope": "workspace/main"
+            }),
+        );
+        assert!(eval_l7(&engine, &submit_report));
+
+        let blocked_without_args = l7_jsonrpc_input_with_params(
+            "jsonrpc.params.test",
+            8000,
+            "/rpc",
+            "reports.search",
+            serde_json::json!({"query": "blocked"}),
+        );
+        assert!(eval_l7(&engine, &blocked_without_args));
+
+        let blocked_with_args = l7_jsonrpc_input_with_params(
+            "jsonrpc.params.test",
+            8000,
+            "/rpc",
+            "reports.search",
+            serde_json::json!({
+                "query": "blocked",
+                "filters.reason": "test"
+            }),
+        );
+        assert!(eval_l7(&engine, &blocked_with_args));
+    }
+
+    #[test]
+    fn l7_jsonrpc_method_globs_are_exact_literals_in_rego() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "jsonrpc_glob_literal": {
+                    "name": "jsonrpc_glob_literal",
+                    "endpoints": [{
+                        "host": "jsonrpc.glob-literal.test",
+                        "ports": [8000],
+                        "path": "/rpc",
+                        "protocol": "json-rpc",
+                        "rules": [{
+                            "allow": {
+                                "method": "reports.*"
+                            }
+                        }]
+                    }],
+                    "binaries": [{ "path": "/usr/bin/curl" }]
+                }
+            }
+        });
+
+        let glob_match_candidate =
+            l7_jsonrpc_input("jsonrpc.glob-literal.test", 8000, "/rpc", "reports.list");
+        assert!(
+            !eval_l7_raw_data(data.clone(), glob_match_candidate),
+            "generic JSON-RPC method rules must not use glob semantics"
+        );
+
+        let exact_literal =
+            l7_jsonrpc_input("jsonrpc.glob-literal.test", 8000, "/rpc", "reports.*");
+        assert!(
+            eval_l7_raw_data(data, exact_literal),
+            "generic JSON-RPC method rules should use exact method equality"
+        );
+    }
+
+    #[test]
+    fn l7_jsonrpc_allow_all_still_allows_any_method() {
+        let data = r#"
+network_policies:
+  jsonrpc_allow_all:
+    name: jsonrpc_allow_all
+    endpoints:
+      - host: jsonrpc.allow-all.test
+        port: 8000
+        path: /rpc
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: "*"
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+
+        let initialize = l7_jsonrpc_input("jsonrpc.allow-all.test", 8000, "/rpc", "initialize");
+        assert!(eval_l7(&engine, &initialize));
+
+        let archive_report =
+            l7_jsonrpc_input("jsonrpc.allow-all.test", 8000, "/rpc", "reports.archive");
+        assert!(eval_l7(&engine, &archive_report));
+    }
+
+    #[test]
+    fn l7_mcp_rules_filter_tools_call() {
+        let data = r#"
+network_policies:
+  mcp_params:
+    name: mcp_params
+    endpoints:
+      - host: mcp.params.test
+        port: 8000
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        mcp:
+          max_body_bytes: 131072
+        rules:
+          - allow:
+              method: tools/call
+              tool:
+                any: [read_status, submit_*]
+        deny_rules:
+          - method: tools/call
+            tool: blocked_action
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+
+        let read_status = l7_jsonrpc_input_with_params(
+            "mcp.params.test",
+            8000,
+            "/mcp",
+            "tools/call",
+            serde_json::json!({
+                "name": "read_status",
+                "arguments.scope": "workspace/main"
+            }),
+        );
+        assert!(eval_l7(&engine, &read_status));
+
+        let read_status_any_args = l7_jsonrpc_input_with_params(
+            "mcp.params.test",
+            8000,
+            "/mcp",
+            "tools/call",
+            serde_json::json!({
+                "name": "read_status",
+                "arguments.scope": "workspace/other"
+            }),
+        );
+        assert!(eval_l7(&engine, &read_status_any_args));
+
+        let submit_report = l7_jsonrpc_input_with_params(
+            "mcp.params.test",
+            8000,
+            "/mcp",
+            "tools/call",
+            serde_json::json!({"name": "submit_report"}),
+        );
+        assert!(eval_l7(&engine, &submit_report));
+
+        let blocked = l7_jsonrpc_input_with_params(
+            "mcp.params.test",
+            8000,
+            "/mcp",
+            "tools/call",
+            serde_json::json!({"name": "blocked_action"}),
+        );
+        assert!(!eval_l7(&engine, &blocked));
+
+        let list_tools = l7_jsonrpc_input("mcp.params.test", 8000, "/mcp", "tools/list");
+        assert!(!eval_l7(&engine, &list_tools));
+    }
+
+    #[test]
+    fn l7_mcp_method_profile_allows_all_tools() {
+        let data = r#"
+network_policies:
+  mcp_default:
+    name: mcp_default
+    endpoints:
+      - host: mcp.default.test
+        port: 8000
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        mcp:
+          allow_all_known_mcp_methods: true
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+
+        let tool_call = l7_jsonrpc_input_with_params(
+            "mcp.default.test",
+            8000,
+            "/mcp",
+            "tools/call",
+            serde_json::json!({
+                "name": "any_tool",
+                "arguments.scope": "workspace/other"
+            }),
+        );
+        assert!(eval_l7(&engine, &tool_call));
+
+        let list_tools = l7_jsonrpc_input("mcp.default.test", 8000, "/mcp", "tools/list");
+        assert!(eval_l7(&engine, &list_tools));
+    }
+
+    #[test]
+    fn l7_jsonrpc_null_metadata_non_matches_without_opa_error() {
+        let data = r#"
+network_policies:
+  jsonrpc_null:
+    name: jsonrpc_null
+    endpoints:
+      - host: jsonrpc.null.test
+        port: 8000
+        path: /rpc
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: reports.list
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+        let input = serde_json::json!({
+            "network": { "host": "jsonrpc.null.test", "port": 8000 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "POST",
+                "path": "/rpc",
+                "query_params": {},
+                "jsonrpc": null
+            }
+        });
+
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_mcp_null_params_non_matches_without_opa_error() {
+        let data = r#"
+network_policies:
+  mcp_null_params:
+    name: mcp_null_params
+    endpoints:
+      - host: mcp.null-params.test
+        port: 8000
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        rules:
+          - allow:
+              method: tools/call
+              tool: read_status
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+        let input = serde_json::json!({
+            "network": { "host": "mcp.null-params.test", "port": 8000 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "POST",
+                "path": "/mcp",
+                "query_params": {},
+                "jsonrpc": {
+                    "method": "tools/call",
+                    "params": null
+                }
+            }
+        });
+
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_jsonrpc_params_matchers_are_rejected() {
+        let data = r#"
+network_policies:
+  invalid_jsonrpc_params:
+    name: invalid_jsonrpc_params
+    endpoints:
+      - host: jsonrpc.invalid.test
+        port: 8000
+        path: /rpc
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: reports.search
+              params:
+                query: quarterly
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let Err(err) = OpaEngine::from_strings(TEST_POLICY, data) else {
+            panic!("JSON-RPC params matchers should fail validation");
+        };
+
+        assert!(
+            err.to_string().contains("do not support params"),
+            "unexpected validation error: {err}"
+        );
+    }
+
+    #[test]
+    fn l7_jsonrpc_config_alias_unknown_fields_are_rejected() {
+        let data = r#"
+network_policies:
+  invalid_jsonrpc_config:
+    name: invalid_jsonrpc_config
+    endpoints:
+      - host: jsonrpc.invalid-config.test
+        port: 8000
+        path: /rpc
+        protocol: json-rpc
+        enforcement: enforce
+        json_rpc:
+          on_parse_error: allow
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let Err(err) = OpaEngine::from_strings(TEST_POLICY, data) else {
+            panic!("unknown JSON-RPC config fields should fail validation");
+        };
+
+        let message = err.to_string();
+        assert!(
+            message.contains("json_rpc") && message.contains("on_parse_error"),
+            "unexpected validation error: {err}"
+        );
+    }
+
+    #[test]
+    fn l7_mcp_config_alias_types_are_rejected() {
+        let data = r#"
+network_policies:
+  invalid_mcp_config:
+    name: invalid_mcp_config
+    endpoints:
+      - host: mcp.invalid-config.test
+        port: 8000
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        mcp:
+          max_body_bytes: large
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let Err(err) = OpaEngine::from_strings(TEST_POLICY, data) else {
+            panic!("mistyped MCP config fields should fail validation");
+        };
+
+        let message = err.to_string();
+        assert!(
+            message.contains("mcp") && message.contains("large"),
+            "unexpected validation error: {err}"
+        );
     }
 
     #[test]
@@ -2613,6 +3723,44 @@ network_policies:
         let l7 = crate::l7::parse_l7_config(&config).unwrap();
         assert_eq!(l7.protocol, crate::l7::L7Protocol::Rest);
         assert_eq!(l7.enforcement, crate::l7::EnforcementMode::Enforce);
+    }
+
+    #[test]
+    fn l7_endpoint_config_preserves_mcp_strict_tool_names_opt_out() {
+        let data = r#"
+network_policies:
+  mcp:
+    name: mcp
+    endpoints:
+      - host: mcp.example.com
+        port: 443
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        mcp:
+          strict_tool_names: false
+        rules:
+          - allow:
+              method: tools/call
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+        let input = NetworkInput {
+            host: "mcp.example.com".into(),
+            port: 443,
+            binary_path: PathBuf::from("/usr/bin/curl"),
+            binary_sha256: "unused".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+        };
+        let config = engine
+            .query_endpoint_config(&input)
+            .expect("query endpoint config")
+            .expect("expected mcp endpoint config");
+        let l7 = crate::l7::parse_l7_config(&config).expect("parse l7 config");
+        assert_eq!(l7.protocol, crate::l7::L7Protocol::Mcp);
+        assert!(!l7.mcp_strict_tool_names);
     }
 
     #[test]

--- a/crates/openshell-supervisor-network/src/policy_local.rs
+++ b/crates/openshell-supervisor-network/src/policy_local.rs
@@ -1088,6 +1088,7 @@ fn network_endpoint_from_json(
                 operation_type: String::new(),
                 operation_name: String::new(),
                 fields: Vec::new(),
+                params: HashMap::new(),
             }),
         })
         .collect();
@@ -1102,6 +1103,7 @@ fn network_endpoint_from_json(
             operation_type: String::new(),
             operation_name: String::new(),
             fields: Vec::new(),
+            params: HashMap::new(),
         })
         .collect();
 
@@ -1125,6 +1127,8 @@ fn network_endpoint_from_json(
         persisted_queries: String::new(),
         graphql_persisted_queries: HashMap::new(),
         graphql_max_body_bytes: 0,
+        json_rpc_max_body_bytes: 0,
+        mcp: None,
         path: String::new(),
         credential_signing: String::new(),
         signing_service: String::new(),

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -13,7 +13,7 @@ use openshell_core::denial::DenialEvent;
 use openshell_core::net::{is_always_blocked_ip, is_internal_ip, is_link_local_ip};
 use openshell_core::policy::ProxyPolicy;
 use openshell_core::provider_credentials::ProviderCredentialState;
-use openshell_core::secrets::{SecretResolver, rewrite_header_line_checked};
+use openshell_core::secrets::{self, SecretResolver, rewrite_header_line_checked};
 use openshell_ocsf::{
     ActionId, ActivityId, DispositionId, Endpoint, HttpActivityBuilder, HttpRequest,
     NetworkActivityBuilder, Process, SeverityId, StatusId, Url as OcsfUrl, ocsf_emit,
@@ -185,7 +185,7 @@ impl ProxyHandle {
     /// The proxy uses OPA for network decisions with process-identity binding
     /// via `/proc/net/tcp`. All connections are evaluated through OPA policy.
     #[allow(clippy::too_many_arguments)]
-    pub async fn start_with_bind_addr(
+    pub(crate) async fn start_with_bind_addr(
         policy: &ProxyPolicy,
         bind_addr: Option<SocketAddr>,
         opa_engine: Arc<OpaEngine>,
@@ -454,6 +454,27 @@ fn emit_forward_success_activity(tx: Option<&ActivitySender>, l7_activity_pendin
     );
 }
 
+fn forward_l7_hard_deny_reason(
+    protocol: crate::l7::L7Protocol,
+    request_info: &crate::l7::L7RequestInfo,
+) -> Option<String> {
+    request_info
+        .graphql
+        .as_ref()
+        .and_then(|info| info.error.as_deref())
+        .map(|error| format!("GraphQL request rejected: {error}"))
+        .or_else(|| {
+            request_info.jsonrpc.as_ref().and_then(|info| {
+                info.error
+                    .as_deref()
+                    .map(|error| format!("JSON-RPC request rejected: {error}"))
+                    .or_else(|| {
+                        crate::l7::relay::jsonrpc_response_frame_hard_deny_reason(protocol, info)
+                    })
+            })
+        })
+}
+
 /// Emit a denial event to the aggregator channel (if configured).
 /// Used by `handle_tcp_connection` which owns `Option<Sender>`.
 fn emit_denial(
@@ -601,6 +622,7 @@ async fn handle_tcp_connection(
         )
         .await?;
         if let InferenceOutcome::Denied { reason } = outcome {
+            emit_activity(&activity_tx, true, "forward_policy");
             let event = NetworkActivityBuilder::new(openshell_ocsf::ctx::ctx())
                 .activity(ActivityId::Open)
                 .action(ActionId::Denied)
@@ -2918,16 +2940,14 @@ fn rewrite_forward_request(
     path: &str,
     secret_resolver: Option<&SecretResolver>,
     request_body_credential_rewrite: bool,
-) -> Result<Vec<u8>, openshell_core::secrets::UnresolvedPlaceholderError> {
+) -> Result<Vec<u8>, secrets::UnresolvedPlaceholderError> {
     let header_end = raw[..used]
         .windows(4)
         .position(|w| w == b"\r\n\r\n")
         .map_or(used, |p| p + 4);
     let websocket_upgrade = crate::l7::rest::request_is_websocket_upgrade(&raw[..header_end]);
     let upstream_path = match secret_resolver {
-        Some(resolver) => {
-            openshell_core::secrets::rewrite_target_for_eval(path, resolver)?.resolved
-        }
+        Some(resolver) => secrets::rewrite_target_for_eval(path, resolver)?.resolved,
         None => path.to_string(),
     };
 
@@ -3020,10 +3040,10 @@ fn rewrite_forward_request(
             output.len()
         };
         let output_str = String::from_utf8_lossy(&output[..scan_end]);
-        if output_str.contains(openshell_core::secrets::PLACEHOLDER_PREFIX_PUBLIC)
-            || output_str.contains(openshell_core::secrets::PROVIDER_ALIAS_MARKER_PUBLIC)
+        if output_str.contains(secrets::PLACEHOLDER_PREFIX_PUBLIC)
+            || output_str.contains(secrets::PROVIDER_ALIAS_MARKER_PUBLIC)
         {
-            return Err(openshell_core::secrets::UnresolvedPlaceholderError { location: "header" });
+            return Err(secrets::UnresolvedPlaceholderError { location: "header" });
         }
     }
 
@@ -3597,18 +3617,75 @@ async fn handle_forward_proxy(
         } else {
             None
         };
+        let jsonrpc = if l7_config.config.protocol.is_jsonrpc_family() {
+            let header_end = forward_request_bytes
+                .windows(4)
+                .position(|w| w == b"\r\n\r\n")
+                .map_or(forward_request_bytes.len(), |p| p + 4);
+            let header_str = std::str::from_utf8(&forward_request_bytes[..header_end])
+                .map_err(|_| miette::miette!("Forward JSON-RPC headers contain invalid UTF-8"))?;
+            let body_length = crate::l7::rest::parse_body_length(header_str)?;
+            let mut jsonrpc_request = crate::l7::provider::L7Request {
+                action: method.to_string(),
+                target: path.clone(),
+                query_params: query_params.clone(),
+                raw_header: forward_request_bytes,
+                body_length,
+            };
+            if crate::l7::jsonrpc::jsonrpc_receive_stream_request(&jsonrpc_request) {
+                forward_request_bytes = jsonrpc_request.raw_header;
+                Some(crate::l7::jsonrpc::JsonRpcRequestInfo::receive_stream())
+            } else {
+                let body = match crate::l7::http::read_body_for_inspection(
+                    client,
+                    &mut jsonrpc_request,
+                    l7_config.config.json_rpc_max_body_bytes,
+                )
+                .await
+                {
+                    Ok(body) => body,
+                    Err(e) => {
+                        let event = NetworkActivityBuilder::new(openshell_ocsf::ctx::ctx())
+                            .activity(ActivityId::Fail)
+                            .severity(SeverityId::Medium)
+                            .status(StatusId::Failure)
+                            .dst_endpoint(Endpoint::from_domain(&host_lc, port))
+                            .message(format!("FORWARD_JSONRPC_L7 request rejected: {e}"))
+                            .build();
+                        ocsf_emit!(event);
+                        emit_activity_simple(activity_tx, true, "l7_parse_rejection");
+                        respond(
+                            client,
+                            &build_json_error_response(
+                                400,
+                                "Bad Request",
+                                "invalid_jsonrpc_request",
+                                &format!("JSON-RPC request rejected before policy evaluation: {e}"),
+                            ),
+                        )
+                        .await?;
+                        return Ok(());
+                    }
+                };
+                forward_request_bytes = jsonrpc_request.raw_header;
+                Some(crate::l7::jsonrpc::parse_jsonrpc_body_with_options(
+                    &body,
+                    crate::l7::jsonrpc::JsonRpcInspectionOptions::for_config(&l7_config.config),
+                ))
+            }
+        } else {
+            None
+        };
         let request_info = crate::l7::L7RequestInfo {
             action: method.to_string(),
             target: path.clone(),
             query_params,
             graphql,
+            jsonrpc,
         };
 
-        let parse_error_reason = request_info
-            .graphql
-            .as_ref()
-            .and_then(|info| info.error.as_deref())
-            .map(|error| format!("GraphQL request rejected: {error}"));
+        let parse_error_reason =
+            forward_l7_hard_deny_reason(l7_config.config.protocol, &request_info);
         let force_deny = parse_error_reason.is_some();
         let (allowed, reason) = parse_error_reason.map_or_else(
             || {
@@ -3649,16 +3726,36 @@ async fn handle_forward_proxy(
                     SeverityId::Informational,
                 ),
             };
-            let engine_type = if l7_config.config.protocol == crate::l7::L7Protocol::Graphql {
-                "l7-graphql"
-            } else {
-                "l7"
+            let engine_type = match l7_config.config.protocol {
+                crate::l7::L7Protocol::Graphql => "l7-graphql",
+                crate::l7::L7Protocol::JsonRpc => "l7-jsonrpc",
+                crate::l7::L7Protocol::Mcp => "l7-mcp",
+                _ => "l7",
             };
-            let message_prefix = if l7_config.config.protocol == crate::l7::L7Protocol::Graphql {
-                "FORWARD_GRAPHQL_L7"
-            } else {
-                "FORWARD_L7"
-            };
+            let log_message = request_info.jsonrpc.as_ref().map_or_else(
+                || {
+                    let message_prefix =
+                        if l7_config.config.protocol == crate::l7::L7Protocol::Graphql {
+                            "FORWARD_GRAPHQL_L7"
+                        } else {
+                            "FORWARD_L7"
+                        };
+                    format!(
+                        "{message_prefix} {decision_str} {method} {host_lc}:{port}{path} reason={reason}"
+                    )
+                },
+                |jsonrpc_info| {
+                    let endpoint = format!("{host_lc}:{port}{path}");
+                    crate::l7::relay::jsonrpc_log_message(
+                        decision_str,
+                        method,
+                        &endpoint,
+                        jsonrpc_info,
+                        tunnel_engine.captured_generation(),
+                        &reason,
+                    )
+                },
+            );
             let event = HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
                 .activity(ActivityId::Other)
                 .action(action_id)
@@ -3675,9 +3772,7 @@ async fn handle_forward_proxy(
                         .with_cmd_line(&cmdline_str),
                 )
                 .firewall_rule(policy_str, engine_type)
-                .message(format!(
-                    "{message_prefix} {decision_str} {method} {host_lc}:{port}{path} reason={reason}"
-                ))
+                .message(log_message)
                 .build();
             ocsf_emit!(event);
         }
@@ -4294,6 +4389,8 @@ mod tests {
             tls: crate::l7::TlsMode::Auto,
             enforcement: crate::l7::EnforcementMode::Enforce,
             graphql_max_body_bytes: crate::l7::graphql::DEFAULT_MAX_BODY_BYTES,
+            json_rpc_max_body_bytes: crate::l7::jsonrpc::DEFAULT_MAX_BODY_BYTES,
+            mcp_strict_tool_names: true,
             allow_encoded_slash: false,
             websocket_credential_rewrite,
             request_body_credential_rewrite: false,
@@ -4453,6 +4550,57 @@ network_policies:
             .expect("CONNECT without an L7 route should emit activity");
         assert!(!event.denied);
         assert_eq!(event.deny_group, "unknown");
+    }
+
+    #[test]
+    fn forward_l7_hard_deny_reason_includes_jsonrpc_errors() {
+        let request_info = crate::l7::L7RequestInfo {
+            action: "POST".to_string(),
+            target: "/rpc".to_string(),
+            query_params: std::collections::HashMap::new(),
+            graphql: None,
+            jsonrpc: Some(crate::l7::jsonrpc::JsonRpcRequestInfo {
+                calls: Vec::new(),
+                is_batch: false,
+                receive_stream: false,
+                has_response: false,
+                error: Some("missing or non-string 'jsonrpc' field".to_string()),
+            }),
+        };
+
+        let reason = forward_l7_hard_deny_reason(crate::l7::L7Protocol::JsonRpc, &request_info)
+            .expect("JSON-RPC parse error");
+
+        assert_eq!(
+            reason,
+            "JSON-RPC request rejected: missing or non-string 'jsonrpc' field"
+        );
+    }
+
+    #[test]
+    fn forward_l7_hard_deny_reason_includes_jsonrpc_response_frames() {
+        let request_info = crate::l7::L7RequestInfo {
+            action: "POST".to_string(),
+            target: "/rpc".to_string(),
+            query_params: std::collections::HashMap::new(),
+            graphql: None,
+            jsonrpc: Some(crate::l7::jsonrpc::JsonRpcRequestInfo {
+                calls: Vec::new(),
+                is_batch: false,
+                receive_stream: false,
+                has_response: true,
+                error: None,
+            }),
+        };
+
+        let reason = forward_l7_hard_deny_reason(crate::l7::L7Protocol::JsonRpc, &request_info)
+            .expect("JSON-RPC response hard deny");
+
+        assert_eq!(reason, crate::l7::relay::JSONRPC_RESPONSE_FRAME_DENY_REASON);
+        assert!(
+            forward_l7_hard_deny_reason(crate::l7::L7Protocol::Mcp, &request_info).is_none(),
+            "MCP response frames are evaluated by policy instead of hard-denied"
+        );
     }
 
     #[test]
@@ -5013,6 +5161,8 @@ network_policies:
                     tls: crate::l7::TlsMode::Auto,
                     enforcement: crate::l7::EnforcementMode::Enforce,
                     graphql_max_body_bytes: crate::l7::graphql::DEFAULT_MAX_BODY_BYTES,
+                    json_rpc_max_body_bytes: crate::l7::jsonrpc::DEFAULT_MAX_BODY_BYTES,
+                    mcp_strict_tool_names: true,
                     allow_encoded_slash: false,
                     websocket_credential_rewrite: false,
                     request_body_credential_rewrite: false,
@@ -5029,6 +5179,8 @@ network_policies:
                     tls: crate::l7::TlsMode::Auto,
                     enforcement: crate::l7::EnforcementMode::Enforce,
                     graphql_max_body_bytes: crate::l7::graphql::DEFAULT_MAX_BODY_BYTES,
+                    json_rpc_max_body_bytes: crate::l7::jsonrpc::DEFAULT_MAX_BODY_BYTES,
+                    mcp_strict_tool_names: true,
                     allow_encoded_slash: false,
                     websocket_credential_rewrite: false,
                     request_body_credential_rewrite: false,

--- a/docs/reference/policy-schema.mdx
+++ b/docs/reference/policy-schema.mdx
@@ -155,11 +155,11 @@ Each endpoint defines a reachable destination and optional inspection rules.
 | `host` | string | Yes | Hostname or IP address. Supports a `*` wildcard inside the first DNS label only: `*.example.com`, `**.example.com`, and intra-label patterns like `*-aiplatform.googleapis.com` are accepted; bare `*`/`**`, TLD wildcards (`*.com`), and wildcards outside the first label are rejected at load time. |
 | `port` | integer | Yes | TCP port number. |
 | `path` | string | No | Optional HTTP path glob used to select between L7 endpoints that share the same host and port. Empty means all paths. Use this when REST and GraphQL live under the same host, such as `/repos/**` and `/graphql`. |
-| `protocol` | string | No | Set to `rest` for HTTP method/path inspection, `websocket` for RFC 6455 upgrade and client text-message inspection, or `graphql` for GraphQL-over-HTTP operation inspection. WebSocket endpoints can also use GraphQL operation rules for GraphQL-over-WebSocket traffic. Omit for TCP passthrough. |
+| `protocol` | string | No | Set to `rest` for HTTP method/path inspection, `websocket` for RFC 6455 upgrade and client text-message inspection, `graphql` for GraphQL-over-HTTP operation inspection, `mcp` for MCP Streamable HTTP request inspection, or `json-rpc` for generic JSON-RPC-over-HTTP method inspection. WebSocket endpoints can also use GraphQL operation rules for GraphQL-over-WebSocket traffic. Omit for TCP passthrough. |
 | `tls` | string | No | TLS handling mode. The proxy auto-detects TLS by peeking the first bytes of each connection and terminates it for inspected HTTPS traffic, so this field is optional in most cases. Set to `skip` to disable auto-detection for edge cases such as client-certificate mTLS or non-standard protocols. The values `terminate` and `passthrough` are deprecated and log a warning; they are still accepted for backward compatibility but have no effect on behavior. |
 | `enforcement` | string | No | `enforce` actively blocks disallowed requests. `audit` logs violations but allows traffic through. |
-| `access` | string | No | Access preset. One of `read-only`, `read-write`, or `full`. Mutually exclusive with `rules`. |
-| `rules` | list of rule objects | No | Fine-grained protocol-specific allow rules. Mutually exclusive with `access`. |
+| `access` | string | No | Access preset. One of `read-only`, `read-write`, or `full`. Mutually exclusive with `rules`. Not valid on `protocol: mcp` or `protocol: json-rpc`; MCP uses explicit rules unless `mcp.allow_all_known_mcp_methods: true` enables the endpoint method profile, and JSON-RPC always uses explicit rules. |
+| `rules` | list of allow rule objects | No | Fine-grained protocol-specific allow rules. Mutually exclusive with `access`. |
 | `deny_rules` | list of deny rule objects | No | L7 deny rules that block specific requests even when allowed by `access` or `rules`. Deny rules take precedence over allow rules. |
 | `allowed_ips` | list of string | No | CIDR or IP allowlist for SSRF override. Exact user-declared hostname endpoints may resolve to RFC 1918 private addresses without this field, but wildcard, hostless, and policy-advisor-proposed endpoints still require `allowed_ips` for private resolved IPs. Entries overlapping loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), or unspecified (`0.0.0.0`) are rejected at load time. |
 | `allow_encoded_slash` | bool | No | When `true`, L7 request parsing preserves `%2F` inside path segments instead of rejecting it. Use this for registries and APIs such as npm scoped packages (`/@scope%2Fname`). Defaults to `false`. |
@@ -171,18 +171,25 @@ Each endpoint defines a reachable destination and optional inspection rules.
 | `persisted_queries` | string | No | GraphQL hash-only behavior for `protocol: graphql` and GraphQL-over-WebSocket operation policy. Default is `deny`; use `allow_registered` only with `graphql_persisted_queries`. |
 | `graphql_persisted_queries` | map | No | Trusted GraphQL persisted-query registry keyed by hash or saved-query ID. Values contain `operation_type`, optional `operation_name`, and optional root `fields`. |
 | `graphql_max_body_bytes` | integer | No | Maximum GraphQL-over-HTTP request body bytes buffered for inspection. Defaults to `65536`. |
+| `mcp` | object | No | MCP endpoint options for `protocol: mcp`. MCP endpoints must set a concrete `host` and `port` or `ports`; `protocol: mcp` alone is invalid and is not treated as a wildcard endpoint. |
+| `mcp.max_body_bytes` | integer | No | Maximum MCP JSON-RPC-over-HTTP request body bytes buffered for inspection. Defaults to `65536`. |
+| `mcp.strict_tool_names` | bool | No | Defaults to `true`. Requires `tools/call` `params.name` values to match `^[A-Za-z0-9_.-]{1,128}$` before policy evaluation. Set to `false` only for compatibility with MCP servers that intentionally use non-recommended tool names. Wildcard `tool` matchers require this to remain enabled. |
+| `mcp.allow_all_known_mcp_methods` | bool | No | Defaults to `false`. When `true`, enables the endpoint MCP method profile: omitted `rules` allow all MCP-family methods and all tools before `deny_rules`, and omitted rule `method` uses that profile. When unset or `false`, explicit MCP method rules are required; rules with `tool` or `params.name` must set `method: tools/call`. |
+| `json_rpc` | object | No | JSON-RPC endpoint options. For `protocol: json-rpc`, `json_rpc.max_body_bytes` sets the maximum JSON-RPC-over-HTTP request body bytes buffered for inspection. Defaults to `65536`. |
 
 Credential rewrite recognizes the canonical `openshell:resolve:env:KEY` placeholder form and whole-token provider-shaped aliases such as `provider-OPENSHELL-RESOLVE-ENV-API_TOKEN` when the referenced environment key exists in the configured provider credentials.
 
 #### Access Levels
 
-The `access` field accepts one of the following values:
+The `access` field accepts one of the following values on REST, WebSocket, and GraphQL endpoints. MCP and JSON-RPC endpoints reject `access` because HTTP method/path presets cannot authorize JSON-RPC safely. Use explicit MCP rules, set `mcp.allow_all_known_mcp_methods: true` for the MCP method profile, or use explicit JSON-RPC rules.
 
-| Value | REST expansion | WebSocket expansion | GraphQL expansion |
-|---|---|---|---|
-| `full` | All methods and paths. | WebSocket upgrade and all inspected client text-message paths. | All operation types. |
-| `read-only` | `GET`, `HEAD`, `OPTIONS`. | WebSocket upgrade handshake only. | `query` operations. |
-| `read-write` | `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT`, `PATCH`. | WebSocket upgrade handshake and client text messages. | `query` and `mutation` operations. |
+| Value | REST expansion | WebSocket expansion | GraphQL expansion | MCP / JSON-RPC expansion |
+|---|---|---|---|---|
+| `full` | All methods and paths. | WebSocket upgrade and all inspected client text-message paths. | All operation types. | Rejected. |
+| `read-only` | `GET`, `HEAD`, `OPTIONS`. | WebSocket upgrade handshake only. | `query` operations. | Rejected. |
+| `read-write` | `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT`, `PATCH`. | WebSocket upgrade handshake and client text messages. | `query` and `mutation` operations. | Rejected. |
+
+For MCP endpoints, configure explicit `rules` with `method`, optional `tool`, and supported `params`. For generic JSON-RPC endpoints, configure explicit `rules` with `method`; JSON-RPC policy `params` matchers are not presently supported.
 
 #### Allow Rule Objects
 
@@ -277,6 +284,74 @@ rules:
 
 Do not combine `method`, `path`, or `query` with `operation_type`, `operation_name`, or `fields` inside the same WebSocket rule. When a WebSocket endpoint has GraphQL operation policy, use GraphQL rules for client messages instead of a raw `WEBSOCKET_TEXT` allow rule.
 
+##### MCP Allow And Deny Rules (`protocol: mcp`)
+
+MCP rules match sandbox-to-server MCP Streamable HTTP request bodies by MCP method and optional tool selectors. OpenShell parses the underlying JSON-RPC 2.0 envelope, validates known MCP request and notification params, and preserves unknown extension methods as policy-addressable literal method strings. Until OpenShell exposes explicit MCP version profiles, `mcp.allow_all_known_mcp_methods` defaults to `false`, so endpoints require explicit MCP method rules. Set `mcp.allow_all_known_mcp_methods: true` to enable the endpoint method profile; in that mode, rules can omit `method`, and tool selectors are normalized to `tools/call` internally. By default, `tools/call` `params.name` must match the MCP-recommended tool-name pattern `^[A-Za-z0-9_.-]{1,128}$`; configure `mcp.strict_tool_names: false` on the endpoint only to allow a server that intentionally uses names outside that pattern. Wildcard `tool` matchers require `mcp.strict_tool_names` to remain enabled. JSON-RPC responses and server-to-client MCP messages on response bodies or SSE streams are relayed but are not currently parsed for policy enforcement.
+
+Use `rules` for MCP allow rules and `deny_rules` for MCP deny rules. Deny rules take precedence over allow rules. If an MCP endpoint sets `mcp.allow_all_known_mcp_methods: true` and omits `rules`, OpenShell allows all MCP-family methods and all tools, then applies any `deny_rules`. Otherwise, the endpoint must define explicit rules. A broad allow or deny rule whose method matcher includes `tools/call` cannot be combined with tool-specific allow rules because it would bypass or erase the tool filter; add `tool` or `params.name` to scope `tools/call`, or remove the tool-specific rules. In a batch request, one denied call denies the full batch.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `method` | string | No | MCP method name, such as `initialize`, `tools/list`, `tools/call`, or an unknown extension method. Globs are accepted only for the `tools/` method family, such as `tools/*`. Required unless `mcp.allow_all_known_mcp_methods` is `true`; when that option is true, omitted method uses the endpoint method profile. Do not use `method: "*"` for MCP; omit `method` only when using the allow-all MCP method profile. |
+| `tool` | string or matcher | No | Convenience matcher for `tools/call` `params.name`. Supports a glob string or `{ any: [...] }`. Requires `method: tools/call` unless `mcp.allow_all_known_mcp_methods` is `true`; validation fails otherwise. Omit to match every tool. |
+| `params` | map | No | MCP currently accepts only `params.name` as a lower-level tool-name matcher. Requires `method: tools/call` unless `mcp.allow_all_known_mcp_methods` is `true`; validation fails otherwise. Tool argument matching is not supported yet; allowed tools accept all argument payloads by default. |
+
+Example MCP rules:
+
+```yaml showLineNumbers={false}
+endpoints:
+  - host: mcp.example.com
+    port: 443
+    path: /mcp
+    protocol: mcp
+    enforcement: enforce
+    mcp:
+      max_body_bytes: 131072
+    rules:
+      - allow:
+          method: tools/call
+          tool: search_web
+      - allow:
+          method: tools/call
+          tool:
+            any: [create_issue, list_issues]
+    deny_rules:
+      - method: tools/call
+        tool: send_email
+      - method: tools/call
+        tool: execute_code
+```
+
+##### JSON-RPC Allow Rule (`protocol: json-rpc`)
+
+JSON-RPC allow rules match sandbox-to-server JSON-RPC-over-HTTP request objects by RPC method. They apply to single JSON-RPC requests and batch requests. For a batch, OpenShell evaluates each call independently. Client-to-server JSON-RPC response frames in POST bodies are denied. Server-to-client messages on HTTP response bodies or MCP SSE streams are relayed but are not currently parsed for policy enforcement.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `method` | string | Yes | Exact JSON-RPC method name such as `initialize` or `reports.search`. Use `*` only as the allow-all sentinel. Other wildcard or glob patterns are rejected for generic JSON-RPC endpoints. |
+
+Generic JSON-RPC policy `params` matchers are not supported. Allow rules match only the JSON-RPC method.
+
+Example JSON-RPC allow rules:
+
+```yaml showLineNumbers={false}
+endpoints:
+  - host: jsonrpc.example.com
+    port: 443
+    path: /rpc
+    protocol: json-rpc
+    enforcement: enforce
+    json_rpc:
+      max_body_bytes: 131072
+    rules:
+      - allow:
+          method: initialize
+      - allow:
+          method: reports.list
+      - allow:
+          method: reports.search
+```
+
 #### Deny Rule Objects
 
 Blocks specific operations on endpoints that otherwise have broad access. Deny rules are evaluated after allow rules and take precedence: if a request matches any deny rule, it is blocked regardless of what the allow rules or access preset permit.
@@ -357,6 +432,32 @@ endpoints:
         fields: [deleteRepository]
       - operation_type: mutation
         operation_name: Admin*
+```
+
+##### JSON-RPC Deny Rule (`protocol: json-rpc`)
+
+JSON-RPC deny rules use the same field names as JSON-RPC allow rules, but they appear directly under each `deny_rules` entry instead of under an `allow` wrapper. Deny rules take precedence over allow rules. In a batch request, one denied call denies the full batch.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `method` | string | Yes | Exact JSON-RPC method name to deny, or `*` to deny all JSON-RPC methods. Other wildcard or glob patterns are rejected for generic JSON-RPC endpoints. |
+
+JSON-RPC deny rules do not support policy `params` matchers yet. Use MCP `tool` rules for MCP tool calls, or deny generic JSON-RPC methods by `method`.
+
+Example JSON-RPC deny rules:
+
+```yaml showLineNumbers={false}
+endpoints:
+  - host: jsonrpc.example.com
+    port: 443
+    path: /rpc
+    protocol: json-rpc
+    enforcement: enforce
+    rules:
+      - allow:
+          method: "*"
+    deny_rules:
+      - method: reports.delete
 ```
 
 ### Binary Object

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -148,7 +148,7 @@ The following steps outline the hot-reload policy update workflow.
 
    To inspect the effective policy that the sandbox enforces, including provider-composed entries, use `openshell policy get <name> --full`. To inspect a stored sandbox-authored revision instead of the current effective policy, pass `--rev <version>`.
 
-5. Edit the YAML: add or adjust `network_policies` entries, binaries, `access`, or `rules`.
+5. Edit the YAML: add or adjust `network_policies` entries, binaries, `access`, `rules`, or protocol-specific matchers such as GraphQL operation fields, MCP `method` / `tool` rules, and generic JSON-RPC `method` rules.
 
 6. Push the updated policy when you need a full replacement. Exit codes: 0 = loaded, 1 = validation failed, 124 = timeout.
 
@@ -173,7 +173,7 @@ Use `openshell policy update` when you want to merge network policy changes into
 - remove one endpoint or one named rule without rewriting the rest of the file.
 - preview a merged result locally with `--dry-run` before you send it to the gateway.
 
-Use `openshell policy set` instead when you want to replace the full policy, update static sections, or make broader edits that are easier to express in YAML.
+Use `openshell policy set` instead when you want to replace the full policy, update static sections, or make broader edits that are easier to express in YAML. Use full YAML for GraphQL, MCP, and JSON-RPC rule shapes.
 
 ### Update Commands
 
@@ -210,6 +210,7 @@ This is the practical difference:
 Current constraints:
 
 - `--add-allow` and `--add-deny` work on `protocol: rest` and `protocol: websocket` endpoints.
+- GraphQL, MCP, and JSON-RPC fine-grained rules require full policy YAML applied with `openshell policy set`.
 - `--add-deny` requires the endpoint to already have an allow base, either an `access` preset or explicit allow `rules`.
 - `protocol: sql` is not a practical incremental workflow today. OpenShell does not do full SQL parsing, and SQL enforcement is not meaningfully supported yet.
 
@@ -228,7 +229,7 @@ Each segment has a fixed meaning:
 | `host` | Yes | Destination hostname. |
 | `port` | Yes | Destination port, `1` through `65535`. |
 | `access` | No | Access preset for L7 endpoints: `read-only`, `read-write`, or `full`. Incremental updates expand presets into protocol-specific method/path rules for REST and WebSocket endpoints. |
-| `protocol` | No | L7 inspection mode: `rest`, `websocket`, or `sql`. `sql` is audit-only and not a recommended workflow today. |
+| `protocol` | No | L7 inspection mode accepted by `openshell policy update`: `rest`, `websocket`, or `sql`. `sql` is audit-only and not a recommended workflow today. Full policy YAML also supports `graphql`, `mcp`, and `json-rpc`. |
 | `enforcement` | No | Enforcement mode for inspected traffic: `enforce` or `audit`. |
 | `options` | No | Comma-separated endpoint options. Use `websocket-credential-rewrite` with `protocol: websocket` or REST compatibility endpoints that perform a WebSocket upgrade. Use `request-body-credential-rewrite` only with `protocol: rest`. |
 
@@ -548,7 +549,7 @@ For an end-to-end walkthrough that combines this policy with a GitHub credential
       - { path: /usr/bin/gh }
 ```
 
-Endpoints with `protocol: rest` enable HTTP request inspection and can opt in to supported text request body credential rewrite. Endpoints with `protocol: websocket` validate WebSocket upgrades and inspect client text messages on the upgraded request path. WebSocket endpoints can also classify GraphQL-over-WebSocket operation messages with the same operation rules used by GraphQL-over-HTTP. Endpoints with `protocol: graphql` parse GraphQL-over-HTTP payloads before evaluating rules. The endpoint-level `path` field lets these protocols share `api.github.com:443` without treating GraphQL payloads as plain REST `POST /graphql` requests.
+Endpoints with `protocol: rest` enable HTTP request inspection and can opt in to supported text request body credential rewrite. Endpoints with `protocol: websocket` validate WebSocket upgrades and inspect client text messages on the upgraded request path. WebSocket endpoints can also classify GraphQL-over-WebSocket operation messages with the same operation rules used by GraphQL-over-HTTP. Endpoints with `protocol: graphql` parse GraphQL-over-HTTP payloads before evaluating rules. Endpoints with `protocol: mcp` parse MCP Streamable HTTP request bodies and evaluate `method`, optional `tool`, and supported params rules. Endpoints with `protocol: json-rpc` parse JSON-RPC-over-HTTP request bodies and evaluate `method` rules. The endpoint-level `path` field lets these protocols share `api.github.com:443` without treating GraphQL payloads as plain REST `POST /graphql` requests.
 </Tab>
 
 </Tabs>
@@ -578,6 +579,50 @@ REST rules can also constrain query parameter values:
 ```
 
 `query` matchers are case-sensitive and run on decoded values. If a request has duplicate keys (for example, `tag=a&tag=b`), every value for that key must match the configured glob(s).
+
+### MCP and JSON-RPC matching
+
+MCP endpoints use `protocol: mcp`. The proxy parses sandbox-to-server MCP Streamable HTTP request bodies, validates known MCP request and notification params, can evaluate the MCP method against rule `method`, and can match tool calls with the `tool` alias. Unknown extension methods stay addressable as literal method strings. Until OpenShell exposes MCP version profiles, `mcp.allow_all_known_mcp_methods` defaults to `false`, so endpoints require explicit MCP method rules. Set `mcp.allow_all_known_mcp_methods: true` to enable the endpoint method profile; in that mode, rules can omit `method`, and tool selectors are normalized to `tools/call` internally. By default, MCP `tools/call` tool names must match `^[A-Za-z0-9_.-]{1,128}$`; set `mcp.strict_tool_names: false` on that endpoint only when a server intentionally uses names outside the MCP-recommended pattern. Wildcard `tool` matchers require `mcp.strict_tool_names` to remain enabled. Generic JSON-RPC endpoints use `protocol: json-rpc` and evaluate `method`.
+
+MCP endpoints must declare a concrete destination with `host` and `port` or `ports`. A policy entry that only sets `protocol: mcp` is invalid and is not treated as a wildcard MCP authorization. Use `path: /mcp` when the server's MCP endpoint is path-scoped; omitting `path` matches every HTTP path on that host and port.
+
+MCP policy enforcement is directional. It applies to HTTP request bodies sent by the sandboxed process to the configured endpoint. JSON-RPC responses and server-to-client MCP messages carried on response bodies or SSE streams are relayed but are not currently parsed for policy enforcement.
+
+MCP and JSON-RPC endpoint policies currently require full policy YAML applied with `openshell policy set`; the incremental `openshell policy update --add-endpoint` parser does not accept `mcp` or `json-rpc` as protocols.
+
+```yaml showLineNumbers={false}
+  mcp_server:
+    name: mcp_server
+    endpoints:
+      - host: mcp.example.com
+        port: 443
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        mcp:
+          max_body_bytes: 131072
+        rules:
+          - allow:
+              method: tools/call
+              tool: read_status
+          - allow:
+              method: tools/call
+              tool:
+                any: [submit_report, list_reports]
+        deny_rules:
+          - method: tools/call
+            tool: delete_resource
+    binaries:
+      - { path: /usr/bin/python3 }
+```
+
+`mcp.max_body_bytes` controls how many MCP-over-HTTP request body bytes OpenShell buffers for inspection. It defaults to `65536`. `mcp.strict_tool_names` defaults to `true` for each MCP endpoint. `mcp.allow_all_known_mcp_methods` defaults to `false`; when it is unset or `false`, the endpoint must define explicit MCP method rules. If an MCP endpoint sets `mcp.allow_all_known_mcp_methods: true` and omits `rules`, OpenShell allows all MCP-family methods and all tools, then applies any `deny_rules`. A broad allow or deny rule whose method matcher includes `tools/call` cannot be combined with tool-specific allow rules because it would bypass or erase the tool filter; add `tool` or `params.name` to scope `tools/call`, or remove the tool-specific rules.
+
+Use `protocol: json-rpc` and `method` when you need generic JSON-RPC 2.0 matching for a non-MCP server. Generic JSON-RPC method rules accept exact method names, or `method: "*"` as the all-method sentinel; other wildcard or glob patterns are rejected. `json_rpc.max_body_bytes` controls the generic JSON-RPC inspection buffer.
+
+Generic JSON-RPC policy `params` matchers are not supported. Generic JSON-RPC policy rules match only the JSON-RPC method. For batch requests, OpenShell evaluates each JSON-RPC call independently and denies the whole batch if any call is denied.
+
+For MCP, `tool` accepts a string glob or `{ any: [...] }` matcher for `tools/call` `params.name`. Rules that use `tool` or lower-level `params.name` must set `method: tools/call` unless `mcp.allow_all_known_mcp_methods: true` enables the endpoint method profile. MCP method globs are accepted only for the `tools/` method family, such as `tools/*`; omit `method` instead of writing `method: "*"` only when the endpoint method profile should allow all MCP methods. Omit `tool` to allow all tools for a `tools/call` method rule. OpenShell does not support MCP tool argument matching yet; allowed tools accept all argument payloads by default. Other MCP `params` keys are rejected. For batch requests, OpenShell evaluates each JSON-RPC call independently and denies the whole batch if any call is denied.
 
 ### GraphQL matching
 

--- a/e2e/mcp-conformance.sh
+++ b/e2e/mcp-conformance.sh
@@ -1,0 +1,519 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=e2e/support/gateway-common.sh disable=SC1091
+source "${ROOT}/e2e/support/gateway-common.sh"
+CONFORMANCE_DIR="${OPENSHELL_MCP_CONFORMANCE_DIR:-${ROOT}/.cache/mcp-conformance}"
+# Pinned after v0.1.16 for the upstream tools_call fixture fix. The current
+# checkout still needs temporary client-fixture patches for
+# modelcontextprotocol/conformance#345; remove patch_conformance_clients when
+# OPENSHELL_MCP_CONFORMANCE_REF points at a release containing those fixes.
+CONFORMANCE_REF="${OPENSHELL_MCP_CONFORMANCE_REF:-b9041ea41b0188581803459dbae71bc7e02fd995}"
+CLIENT_IMAGE="${OPENSHELL_MCP_CONFORMANCE_CLIENT_IMAGE:-openshell-mcp-conformance-client:local}"
+SCENARIOS="${OPENSHELL_MCP_CONFORMANCE_SCENARIOS:-}"
+SPEC_VERSION="${OPENSHELL_MCP_CONFORMANCE_SPEC_VERSION:-2025-11-25}"
+TIMEOUT_MS="${OPENSHELL_MCP_CONFORMANCE_TIMEOUT_MS:-900000}"
+FORCE_REBUILD="${OPENSHELL_MCP_CONFORMANCE_FORCE_REBUILD:-0}"
+DOCKER_PULL="${OPENSHELL_MCP_CONFORMANCE_DOCKER_PULL:-0}"
+CLIENT_IMAGE_REF_LABEL="org.openshell.mcp-conformance.ref"
+CLIENT_IMAGE_DOCKERFILE_LABEL="org.openshell.mcp-conformance.dockerfile"
+CLIENT_IMAGE_DOCKERIGNORE_LABEL="org.openshell.mcp-conformance.dockerignore"
+CLIENT_IMAGE_FIXTURE_HASH_LABEL="org.openshell.mcp-conformance.fixture-hash"
+RUN_SCENARIOS_COMMAND="__openshell_mcp_run_scenarios"
+CLIENT_SANDBOX_MANAGED=0
+HOST_BRIDGE_PID=""
+HOST_BRIDGE_LOG=""
+HOST_BRIDGE_TOKEN=""
+RUNNER_CONTAINER_IP=""
+RUNNER_CONTAINER=""
+
+# Static default scenarios for the pinned CONFORMANCE_REF and default
+# SPEC_VERSION. To refresh this list after changing either value, list the
+# scenarios from the built client image:
+#
+#   docker run --rm openshell-mcp-conformance-client:local \
+#     ./node_modules/.bin/tsx src/index.ts list --client --spec-version 2025-11-25
+#
+# Then confirm each scenario has a compatible handler in the pinned
+# examples/clients/typescript/everything-client.ts. Keep auth/OAuth scenarios
+# and the slow sse-retry scenario opt-in unless intentionally broadening the
+# default MCP e2e coverage.
+DEFAULT_SCENARIOS=(
+  initialize
+  tools_call
+  elicitation-sep1034-client-defaults
+)
+
+require_command() {
+  local name=$1
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "ERROR: ${name} is required to run MCP conformance e2e tests." >&2
+    exit 2
+  fi
+}
+
+is_commit_ref() {
+  [[ "$1" =~ ^[0-9a-fA-F]{40}$ ]]
+}
+
+checkout_conformance() {
+  mkdir -p "$(dirname "${CONFORMANCE_DIR}")"
+
+  if [ ! -e "${CONFORMANCE_DIR}" ]; then
+    git init "${CONFORMANCE_DIR}"
+    git -C "${CONFORMANCE_DIR}" remote add origin \
+      https://github.com/modelcontextprotocol/conformance.git
+  fi
+
+  if [ ! -d "${CONFORMANCE_DIR}/.git" ]; then
+    echo "ERROR: ${CONFORMANCE_DIR} exists but is not a git checkout." >&2
+    echo "       Set OPENSHELL_MCP_CONFORMANCE_DIR to another path or remove the directory." >&2
+    exit 2
+  fi
+
+  if is_commit_ref "${CONFORMANCE_REF}"; then
+    local current_head=""
+    current_head="$(git -C "${CONFORMANCE_DIR}" rev-parse HEAD 2>/dev/null || true)"
+    if [ "${current_head}" = "${CONFORMANCE_REF}" ] \
+      && git -C "${CONFORMANCE_DIR}" diff --quiet \
+      && git -C "${CONFORMANCE_DIR}" diff --cached --quiet; then
+      echo "Using cached MCP conformance checkout ${CONFORMANCE_REF}." >&2
+      return
+    fi
+  fi
+
+  git -C "${CONFORMANCE_DIR}" fetch --depth 1 origin "${CONFORMANCE_REF}"
+  git -C "${CONFORMANCE_DIR}" checkout --force --detach FETCH_HEAD
+}
+
+docker_image_label() {
+  local image=$1
+  local label=$2
+
+  docker image inspect \
+    --format "{{ index .Config.Labels \"${label}\" }}" \
+    "${image}" 2>/dev/null || true
+}
+
+openshell_bin() {
+  if [ -n "${OPENSHELL_BIN:-}" ]; then
+    printf '%s\n' "${OPENSHELL_BIN}"
+    return
+  fi
+
+  local target_dir
+  target_dir="$(e2e_cargo_target_dir "${ROOT}")"
+  printf '%s\n' "${target_dir}/debug/openshell"
+}
+
+patch_conformance_clients() {
+  node - "${CONFORMANCE_DIR}" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = process.argv[2];
+
+function rewrite(file, rewriter) {
+  const target = path.join(root, file);
+  const source = fs.readFileSync(target, 'utf8');
+  const next = rewriter(source, file);
+
+  if (next !== source) {
+    fs.writeFileSync(target, next);
+    console.error(`Patched upstream MCP conformance fixture: ${file}`);
+  }
+}
+
+function patchApplyDefaults(source, file) {
+  if (/elicitation:\s*{\s*form:\s*{\s*applyDefaults:\s*true\s*}\s*}/m.test(source)) {
+    return source;
+  }
+
+  const broken = /elicitation:\s*{\s*applyDefaults:\s*true\s*}/m;
+  if (!broken.test(source)) {
+    throw new Error(`${file}: could not find the known elicitation defaults fixture`);
+  }
+
+  return source.replace(
+    broken,
+    `elicitation: {
+            form: {
+              applyDefaults: true
+            }
+          }`
+  );
+}
+
+rewrite('examples/clients/typescript/everything-client.ts', (source, file) => {
+  let next = patchApplyDefaults(source, file);
+  if (next.includes('elicitation-sep1034-client-defaults')) {
+    return next;
+  }
+
+  const oldRegistration = "registerScenario('elicitation-defaults', runElicitationDefaultsClient);";
+  const newRegistration = `registerScenarios(
+  ['elicitation-defaults', 'elicitation-sep1034-client-defaults'],
+  runElicitationDefaultsClient
+);`;
+
+  if (!next.includes(oldRegistration)) {
+    throw new Error(`${file}: could not find the known elicitation scenario registration`);
+  }
+
+  return next.replace(oldRegistration, newRegistration);
+});
+
+rewrite('examples/clients/typescript/elicitation-defaults-test.ts', patchApplyDefaults);
+NODE
+}
+
+start_host_bridge() {
+  local port=$1
+  local openshell runner_ip
+  HOST_BRIDGE_LOG="${ROOT}/.cache/mcp-conformance/host-bridge.log"
+  mkdir -p "$(dirname "${HOST_BRIDGE_LOG}")"
+
+  if ! openshell="$(openshell_bin)"; then
+    return 1
+  fi
+  if ! runner_ip="$(runner_container_ip)"; then
+    return 1
+  fi
+
+  RUNNER_CONTAINER_IP="${runner_ip}"
+  HOST_BRIDGE_TOKEN="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+  OPENSHELL_BIN="${openshell}" \
+    OPENSHELL_MCP_CONFORMANCE_RUNNER_IP="${runner_ip}" \
+    OPENSHELL_MCP_CONFORMANCE_BRIDGE_TOKEN="${HOST_BRIDGE_TOKEN}" \
+    python3 "${ROOT}/e2e/mcp-conformance/host-bridge.py" \
+    "${port}" "${ROOT}" "${HOST_BRIDGE_LOG}" &
+  HOST_BRIDGE_PID=$!
+
+  local deadline
+  deadline=$((SECONDS + ${OPENSHELL_MCP_CONFORMANCE_HOST_BRIDGE_START_TIMEOUT_SECONDS:-10}))
+  until python3 - "${port}" <<'PY'
+import socket
+import sys
+
+try:
+    with socket.create_connection(("127.0.0.1", int(sys.argv[1])), timeout=0.2):
+        pass
+except OSError:
+    raise SystemExit(1)
+PY
+  do
+    if ! kill -0 "${HOST_BRIDGE_PID}" 2>/dev/null; then
+      echo "ERROR: MCP conformance host bridge exited before becoming ready (see ${HOST_BRIDGE_LOG})." >&2
+      return 1
+    fi
+    if [ "${SECONDS}" -ge "${deadline}" ]; then
+      echo "ERROR: MCP conformance host bridge did not become ready on 127.0.0.1:${port} (see ${HOST_BRIDGE_LOG})." >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+}
+
+# Resolve the hostname the runner container uses to reach the host bridge.
+# In CI, e2e/with-docker-gateway.sh connects the job container (which hosts the
+# bridge) to the e2e Docker network with the host.openshell.internal alias. On
+# local Docker Desktop, host.docker.internal reaches the host. On local Linux,
+# the runner container is started with --add-host ...:host-gateway.
+host_bridge_hostname() {
+  if [ -n "${OPENSHELL_MCP_CONFORMANCE_HOST_BRIDGE_HOSTNAME:-}" ]; then
+    printf '%s\n' "${OPENSHELL_MCP_CONFORMANCE_HOST_BRIDGE_HOSTNAME}"
+    return
+  fi
+
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    printf '%s\n' "host.openshell.internal"
+  elif [ "$(uname -s)" = "Darwin" ]; then
+    printf '%s\n' "host.docker.internal"
+  else
+    printf '%s\n' "host.openshell.internal"
+  fi
+}
+
+runner_container_ip() {
+  local network ip
+
+  network="${OPENSHELL_E2E_DOCKER_NETWORK_NAME:-${OPENSHELL_E2E_NETWORK_NAME:-}}"
+  if [ -z "${network}" ]; then
+    echo "ERROR: no e2e Docker network resolved for the MCP conformance runner container." >&2
+    return 1
+  fi
+  if [ -z "${RUNNER_CONTAINER}" ]; then
+    echo "ERROR: MCP conformance runner container has not been started." >&2
+    return 1
+  fi
+
+  ip="$(docker inspect \
+    --format "{{with index .NetworkSettings.Networks \"${network}\"}}{{.IPAddress}}{{end}}" \
+    "${RUNNER_CONTAINER}")"
+  if [ -z "${ip}" ]; then
+    echo "ERROR: failed to resolve MCP conformance runner IP on Docker network ${network}." >&2
+    return 1
+  fi
+  printf '%s\n' "${ip}"
+}
+
+stop_host_bridge() {
+  if [ -n "${HOST_BRIDGE_PID}" ] && kill -0 "${HOST_BRIDGE_PID}" 2>/dev/null; then
+    kill "${HOST_BRIDGE_PID}" 2>/dev/null || true
+    wait "${HOST_BRIDGE_PID}" 2>/dev/null || true
+  fi
+  HOST_BRIDGE_PID=""
+  HOST_BRIDGE_TOKEN=""
+  RUNNER_CONTAINER_IP=""
+}
+
+build_client_image() {
+  local conformance_head dockerfile_hash dockerignore_hash fixture_hash
+  local image_ref image_dockerfile image_dockerignore image_fixture_hash
+  local -a pull_args=()
+
+  conformance_head="$(git -C "${CONFORMANCE_DIR}" rev-parse HEAD)"
+  dockerfile_hash="$(git -C "${ROOT}" hash-object "${ROOT}/e2e/mcp-conformance/Dockerfile.client")"
+  dockerignore_hash="$(git -C "${ROOT}" hash-object "${ROOT}/e2e/mcp-conformance/Dockerfile.client.dockerignore")"
+  fixture_hash="$(
+    git -C "${CONFORMANCE_DIR}" diff -- \
+      examples/clients/typescript/everything-client.ts \
+      examples/clients/typescript/elicitation-defaults-test.ts |
+      git hash-object --stdin
+  )"
+
+  image_ref="$(docker_image_label "${CLIENT_IMAGE}" "${CLIENT_IMAGE_REF_LABEL}")"
+  image_dockerfile="$(docker_image_label "${CLIENT_IMAGE}" "${CLIENT_IMAGE_DOCKERFILE_LABEL}")"
+  image_dockerignore="$(docker_image_label "${CLIENT_IMAGE}" "${CLIENT_IMAGE_DOCKERIGNORE_LABEL}")"
+  image_fixture_hash="$(docker_image_label "${CLIENT_IMAGE}" "${CLIENT_IMAGE_FIXTURE_HASH_LABEL}")"
+  if [ "${FORCE_REBUILD}" != "1" ] \
+    && [ "${image_ref}" = "${conformance_head}" ] \
+    && [ "${image_dockerfile}" = "${dockerfile_hash}" ] \
+    && [ "${image_dockerignore}" = "${dockerignore_hash}" ] \
+    && [ "${image_fixture_hash}" = "${fixture_hash}" ]; then
+    echo "Using cached MCP conformance client image ${CLIENT_IMAGE} (${conformance_head})." >&2
+    return
+  fi
+
+  if [ "${DOCKER_PULL}" = "1" ]; then
+    pull_args=(--pull)
+  fi
+
+  docker build "${pull_args[@]}" \
+    --label "${CLIENT_IMAGE_REF_LABEL}=${conformance_head}" \
+    --label "${CLIENT_IMAGE_DOCKERFILE_LABEL}=${dockerfile_hash}" \
+    --label "${CLIENT_IMAGE_DOCKERIGNORE_LABEL}=${dockerignore_hash}" \
+    --label "${CLIENT_IMAGE_FIXTURE_HASH_LABEL}=${fixture_hash}" \
+    -f "${ROOT}/e2e/mcp-conformance/Dockerfile.client" \
+    -t "${CLIENT_IMAGE}" \
+    "${CONFORMANCE_DIR}"
+}
+
+create_client_sandbox() {
+  if [ -n "${OPENSHELL_MCP_CONFORMANCE_CLIENT_SANDBOX:-}" ]; then
+    echo "Using existing MCP conformance client sandbox ${OPENSHELL_MCP_CONFORMANCE_CLIENT_SANDBOX}." >&2
+    return
+  fi
+
+  local sandbox_name policy_file openshell
+  sandbox_name="openshell-mcp-client-$$"
+  policy_file="$(mktemp "${TMPDIR:-/tmp}/openshell-mcp-conformance-base-policy.XXXXXX.yaml")"
+  openshell="$(openshell_bin)"
+
+  # The upstream runner binds its per-scenario test server with listen(0), and
+  # the port can be outside the OS ephemeral range. Create the reusable sandbox
+  # with a harmless placeholder; the client wrapper installs the exact policy
+  # for each scenario URL before executing the TypeScript client.
+  python3 "${ROOT}/e2e/mcp-conformance/render-policy.py" \
+    "http://192.0.2.1:1/" "${policy_file}" \
+    "${ROOT}/e2e/mcp-conformance/policy-template.yaml" >/dev/null
+
+  echo "Creating MCP conformance client sandbox ${sandbox_name}..." >&2
+  if ! "${openshell}" sandbox create \
+    --name "${sandbox_name}" \
+    --from "${CLIENT_IMAGE}" \
+    --policy "${policy_file}" \
+    --no-tty \
+    -- true; then
+    rm -f "${policy_file}"
+    return 1
+  fi
+  rm -f "${policy_file}"
+
+  export OPENSHELL_MCP_CONFORMANCE_CLIENT_SANDBOX="${sandbox_name}"
+  export OPENSHELL_MCP_CONFORMANCE_POLICY_WAIT="${OPENSHELL_MCP_CONFORMANCE_POLICY_WAIT:-1}"
+  CLIENT_SANDBOX_MANAGED=1
+}
+
+cleanup_client_sandbox() {
+  if [ "${CLIENT_SANDBOX_MANAGED}" != "1" ]; then
+    return
+  fi
+
+  local openshell
+  openshell="$(openshell_bin)"
+  echo "Deleting MCP conformance client sandbox ${OPENSHELL_MCP_CONFORMANCE_CLIENT_SANDBOX}..." >&2
+  "${openshell}" sandbox delete "${OPENSHELL_MCP_CONFORMANCE_CLIENT_SANDBOX}" >/dev/null 2>&1 || true
+}
+
+# Start the upstream conformance runner in a plain Docker container on the e2e
+# network. The runner runs node (and the bundled MCP test server) off the host
+# for isolation, but unlike an OpenShell sandbox it has an ordinary,
+# externally-routable network address: its listen(0) test server is reachable
+# from the client sandbox, and it can call the host bridge back directly.
+create_runner_container() {
+  local network
+  local -a add_host_args=()
+
+  network="${OPENSHELL_E2E_DOCKER_NETWORK_NAME:-${OPENSHELL_E2E_NETWORK_NAME:-}}"
+  if [ -z "${network}" ]; then
+    echo "ERROR: no e2e Docker network resolved for the MCP conformance runner container." >&2
+    return 1
+  fi
+
+  RUNNER_CONTAINER="openshell-mcp-runner-$$"
+
+  # On local Linux the host bridge runs on the host, so map the bridge hostnames
+  # to the Docker host gateway. CI (job-container network alias) and Docker
+  # Desktop resolve these names without an explicit mapping.
+  if [ "${GITHUB_ACTIONS:-}" != "true" ] && [ "$(uname -s)" != "Darwin" ]; then
+    add_host_args=(--add-host "host.openshell.internal:host-gateway" --add-host "host.docker.internal:host-gateway")
+  fi
+
+  echo "Starting MCP conformance runner container ${RUNNER_CONTAINER} on Docker network ${network}..." >&2
+  if ! docker run -d --rm \
+    --name "${RUNNER_CONTAINER}" \
+    --network "${network}" \
+    "${add_host_args[@]}" \
+    "${CLIENT_IMAGE}" \
+    sleep infinity >/dev/null; then
+    RUNNER_CONTAINER=""
+    return 1
+  fi
+
+  if ! docker cp "${ROOT}/e2e/mcp-conformance/runner-shim.mjs" "${RUNNER_CONTAINER}:/tmp/openshell-mcp-runner-shim.mjs" \
+    || ! docker cp "${ROOT}/e2e/mcp-conformance/expected-failures.yml" "${RUNNER_CONTAINER}:/tmp/expected-failures.yml"; then
+    return 1
+  fi
+}
+
+cleanup_runner_container() {
+  if [ -n "${RUNNER_CONTAINER}" ]; then
+    docker rm -f "${RUNNER_CONTAINER}" >/dev/null 2>&1 || true
+  fi
+  RUNNER_CONTAINER=""
+}
+
+scenario_list_for_args() {
+  local scenario_list
+  local -a scenario_args=("$@")
+
+  if [ "${#scenario_args[@]}" -gt 0 ]; then
+    scenario_list="${scenario_args[*]}"
+  elif [ -n "${SCENARIOS}" ]; then
+    scenario_list="${SCENARIOS}"
+  else
+    scenario_list="${DEFAULT_SCENARIOS[*]}"
+  fi
+
+  printf '%s\n' "${scenario_list}"
+}
+
+run_scenarios_in_runner_container() {
+  local bridge_host bridge_port scenario scenario_list
+  local -a passed=()
+  local -a failed=()
+
+  scenario_list="$(scenario_list_for_args "$@")"
+  if [ -z "${scenario_list}" ]; then
+    echo "ERROR: no MCP conformance scenarios resolved." >&2
+    return 2
+  fi
+
+  bridge_port="$(e2e_pick_port)"
+  create_client_sandbox || return 1
+  create_runner_container || return 1
+  start_host_bridge "${bridge_port}" || return 1
+
+  bridge_host="$(host_bridge_hostname)"
+  echo "MCP conformance host bridge callback: http://${bridge_host}:${bridge_port}/run" >&2
+
+  for scenario in ${scenario_list}; do
+    echo "=== MCP conformance: ${scenario} ==="
+    # shellcheck disable=SC2016
+    if docker exec \
+      --env "MCP_CONFORMANCE_HOST_BRIDGE_URL=http://${bridge_host}:${bridge_port}/run" \
+      --env "MCP_CONFORMANCE_HOST_BRIDGE_TOKEN=${HOST_BRIDGE_TOKEN}" \
+      --env "MCP_CONFORMANCE_RUNNER_IP=${RUNNER_CONTAINER_IP}" \
+      "${RUNNER_CONTAINER}" \
+      sh -c 'cd /opt/mcp-conformance && exec node dist/index.js client --command "node /tmp/openshell-mcp-runner-shim.mjs" --scenario "$1" --spec-version "$2" --expected-failures "$3" --timeout "$4"' \
+      sh "${scenario}" "${SPEC_VERSION}" "/tmp/expected-failures.yml" "${TIMEOUT_MS}" \
+      </dev/null; then
+      passed+=("${scenario}")
+    else
+      failed+=("${scenario}")
+    fi
+  done
+
+  echo "=== MCP conformance summary ==="
+  echo "Passed (${#passed[@]}): ${passed[*]:-<none>}"
+  echo "Failed (${#failed[@]}): ${failed[*]:-<none>}"
+
+  if [ "${#failed[@]}" -ne 0 ]; then
+    return 1
+  fi
+}
+
+cleanup_scenario_resources() {
+  cleanup_runner_container
+  stop_host_bridge
+  cleanup_client_sandbox
+}
+
+run_scenarios_with_client_sandbox() {
+  # Tear down the runner container, host bridge, and client sandbox on any exit,
+  # including Ctrl-C / SIGTERM. The cleanups are no-ops if their resource was
+  # never created, so an early failure is safe too.
+  trap cleanup_scenario_resources EXIT
+  trap 'exit 130' INT TERM
+
+  run_scenarios_in_runner_container "$@"
+}
+
+run_scenarios_under_gateway() {
+  export OPENSHELL_MCP_CONFORMANCE_CLIENT_IMAGE="${CLIENT_IMAGE}"
+  export OPENSHELL_E2E_DOCKER_SANDBOX_IMAGE="${OPENSHELL_E2E_DOCKER_SANDBOX_IMAGE:-${CLIENT_IMAGE}}"
+
+  "${ROOT}/e2e/with-docker-gateway.sh" bash "${BASH_SOURCE[0]}" "${RUN_SCENARIOS_COMMAND}" "$@"
+}
+
+main() {
+  cd "${ROOT}"
+
+  if [ "${1:-}" = "${RUN_SCENARIOS_COMMAND}" ]; then
+    shift
+    run_scenarios_with_client_sandbox "$@"
+    return
+  fi
+
+  # git fetches and pins the upstream conformance repo; node patches temporary
+  # fixture drift before the image build; docker builds and runs the
+  # runner/client containers; python3 runs the host bridge and renders policies.
+  # npm and tsx run inside the container image, not on the host.
+  require_command git
+  require_command node
+  require_command docker
+  require_command python3
+
+  echo "MCP conformance spec version: ${SPEC_VERSION}" >&2
+  checkout_conformance
+  patch_conformance_clients
+  build_client_image
+  run_scenarios_under_gateway "$@"
+}
+
+main "$@"

--- a/e2e/mcp-conformance/Dockerfile.client
+++ b/e2e/mcp-conformance/Dockerfile.client
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM public.ecr.aws/docker/library/node:22-bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG SANDBOX_UID=1000660000
+ARG SANDBOX_GID=1000660000
+
+# Match the sandbox user expected by OpenShell policies and supervisor setup.
+# The UID/GID are intentionally outside Debian's default login.defs range.
+RUN groupadd -K "GID_MAX=${SANDBOX_GID}" -g "${SANDBOX_GID}" sandbox \
+    && useradd -K "UID_MAX=${SANDBOX_UID}" --no-log-init -m -u "${SANDBOX_UID}" -g sandbox sandbox
+
+WORKDIR /opt/mcp-conformance
+
+COPY . .
+RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
+RUN npm run build
+RUN chown -R sandbox:sandbox /opt/mcp-conformance /home/sandbox
+
+USER sandbox
+CMD ["sleep", "infinity"]

--- a/e2e/mcp-conformance/Dockerfile.client.dockerignore
+++ b/e2e/mcp-conformance/Dockerfile.client.dockerignore
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+.git
+dist
+node_modules
+.openshell-mcp-conformance-*.stamp

--- a/e2e/mcp-conformance/README.md
+++ b/e2e/mcp-conformance/README.md
@@ -1,0 +1,82 @@
+# MCP Conformance E2E
+
+This directory contains the OpenShell wrapper for the upstream
+`modelcontextprotocol/conformance` runner.
+
+The workflow checks out and builds the upstream conformance repository, then
+runs its CLI in client mode. To keep the untrusted upstream node runner off the
+host, the wrapper runs it inside a plain Docker container on the e2e Docker
+network (not an OpenShell sandbox, which is egress-only and could not accept the
+client's inbound connection). The upstream runner starts a real MCP test server
+and invokes its client command — `runner-shim.mjs` — with that server URL.
+
+`runner-shim.mjs` stands in for the MCP client: instead of speaking MCP itself,
+it posts the server URL back to the host bridge (`host-bridge.py`) over HTTP. The
+host bridge runs `client-through-openshell.sh`, which runs the upstream
+TypeScript `everything-client` inside an OpenShell client sandbox for each
+scenario, so the MCP traffic crosses the sandbox proxy. A single Docker-backed
+OpenShell e2e gateway and one reusable client sandbox serve the whole scenario
+list. The runner deliberately has no gateway credentials; keeping the privileged
+client launch on `host-bridge.py` is the trust boundary. The harness gives the
+runner a per-run bridge capability and gives the bridge the runner container IP.
+The bridge only accepts requests with that capability, only renders server URLs
+whose host is the runner container IP, only forwards the MCP conformance
+scenario environment allowlist, and starts the client wrapper with a small host
+environment allowlist instead of inheriting token-bearing host environment
+variables. It does not use the HTTP peer source address as the runner identity,
+because Docker NAT can make legitimate callbacks appear to come from a gateway
+address.
+
+The upstream runner reports its test server URL as `localhost`. The runner
+container has an ordinary, externally-routable address on the e2e network, so
+`runner-shim.mjs` rewrites `localhost` to that container's IP — which the client
+sandbox can reach through its egress proxy. The runner container reaches the host
+bridge at `host.openshell.internal` (the alias `e2e/with-docker-gateway.sh`
+attaches to the CI job container on the e2e network), at `host.docker.internal`
+on local Docker Desktop, or via `--add-host ...:host-gateway` on local Linux.
+
+The generated policy uses `protocol: mcp` and sets
+`mcp.allow_all_known_mcp_methods: true` so omitted rule methods use the endpoint
+MCP method profile. That keeps OpenShell deny-by-default at the network boundary
+while allowing the upstream scenarios to exercise MCP behavior. The policy body
+lives in `policy-template.yaml`; the wrapper renders its host, port, and path
+placeholders from the upstream server URL.
+
+For local runs, the wrapper builds `openshell/supervisor:dev` automatically
+when no supervisor image override is set. Set `OPENSHELL_DOCKER_SUPERVISOR_IMAGE`
+or `OPENSHELL_SUPERVISOR_IMAGE` to use a prebuilt pullable image instead.
+
+The pinned upstream checkout includes reference-client fixture drift that is
+tracked in `modelcontextprotocol/conformance#345`. The wrapper patches the
+checkout before building the client image so the bundled TypeScript client
+advertises `elicitation.form.applyDefaults` and accepts the canonical
+`elicitation-sep1034-client-defaults` scenario. It also routes `sse-retry` to
+the upstream standalone `sse-retry-test.ts` client so the reconnect timing path
+is exercised instead of aliasing it to another scenario.
+
+Remove those local workarounds when `OPENSHELL_MCP_CONFORMANCE_REF` points at
+an upstream release that includes the `#345` fixes.
+
+When enabling broader upstream suites, add scenarios that OpenShell does not yet
+support through the MCP proxy to `expected-failures.yml`. The upstream
+runner treats listed failures as allowed and treats stale entries as failures.
+The default run uses a static scenario list in `e2e/mcp-conformance.sh`. To
+refresh it after changing the pinned upstream ref or default spec, list the
+scenarios from the built client image:
+
+```shell
+docker run --rm openshell-mcp-conformance-client:local \
+  ./node_modules/.bin/tsx src/index.ts list --client --spec-version 2025-11-25
+```
+
+Then confirm each scenario has a compatible handler in the pinned
+`examples/clients/typescript/everything-client.ts`. The default list skips
+opt-in scenarios, including auth/OAuth flows and the slow `sse-retry` scenario.
+Set `OPENSHELL_MCP_CONFORMANCE_SCENARIOS=sse-retry` or pass `sse-retry` as an
+argument to run it explicitly.
+
+The wrapper caches the pinned upstream checkout, the local conformance runner
+build, and the Docker client image. Set
+`OPENSHELL_MCP_CONFORMANCE_FORCE_REBUILD=1` to refresh those build artifacts, or
+`OPENSHELL_MCP_CONFORMANCE_DOCKER_PULL=1` to pull the client image base during a
+rebuild.

--- a/e2e/mcp-conformance/client-through-openshell.sh
+++ b/e2e/mcp-conformance/client-through-openshell.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Runs the upstream MCP conformance client in an OpenShell-managed sandbox.
+#
+# The modelcontextprotocol/conformance runner runs in a separate container and
+# posts the URL of its MCP test server to a host bridge, which invokes this
+# script with that URL. The parent harness creates one reusable conformance
+# client sandbox for the whole scenario list before this script is invoked. This
+# wrapper verifies the active gateway is reachable, applies the per-scenario
+# server policy to that sandbox, and runs the upstream TypeScript
+# everything-client inside it so its MCP traffic crosses the sandbox proxy.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <conformance-server-url>" >&2
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 2
+fi
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# shellcheck source=e2e/support/gateway-common.sh disable=SC1091
+source "${ROOT}/e2e/support/gateway-common.sh"
+if [ -z "${OPENSHELL_BIN:-}" ]; then
+  TARGET_DIR="$(e2e_cargo_target_dir "${ROOT}")"
+  OPENSHELL_BIN="${TARGET_DIR}/debug/openshell"
+fi
+
+require_active_gateway() {
+  local status_output
+
+  if ! status_output="$("${OPENSHELL_BIN}" status 2>&1)"; then
+    echo "ERROR: no reachable active OpenShell gateway for MCP conformance." >&2
+    echo "       Run e2e/mcp-conformance.sh so it starts one shared Docker-backed gateway." >&2
+    echo "=== openshell status output ===" >&2
+    printf '%s\n' "${status_output}" >&2
+    echo "=== end openshell status output ===" >&2
+    exit 2
+  fi
+}
+
+SERVER_URL="$1"
+CLIENT_SANDBOX="${OPENSHELL_MCP_CONFORMANCE_CLIENT_SANDBOX:?set OPENSHELL_MCP_CONFORMANCE_CLIENT_SANDBOX to the reusable conformance client sandbox name}"
+POLICY_TEMPLATE="${ROOT}/e2e/mcp-conformance/policy-template.yaml"
+POLICY_WAIT="${OPENSHELL_MCP_CONFORMANCE_POLICY_WAIT:-0}"
+POLICY_WAIT_TIMEOUT="${OPENSHELL_MCP_CONFORMANCE_POLICY_WAIT_TIMEOUT:-60}"
+CLIENT_TIMEOUT_SECONDS="${OPENSHELL_MCP_CONFORMANCE_CLIENT_TIMEOUT_SECONDS:-120}"
+
+require_active_gateway
+
+POLICY_FILE="$(mktemp "${TMPDIR:-/tmp}/openshell-mcp-conformance-policy.XXXXXX.yaml")"
+trap 'rm -f "${POLICY_FILE}"' EXIT
+
+CLIENT_SERVER_URL="$(python3 "${ROOT}/e2e/mcp-conformance/render-policy.py" "${SERVER_URL}" "${POLICY_FILE}" "${POLICY_TEMPLATE}")"
+
+ENV_ARGS=()
+
+# These environment variables are set by the upstream conformance test runner
+# before it invokes the configured client command. Forward them into the
+# sandbox because the sandboxed TypeScript client depends on them to select the
+# scenario and read scenario-specific context.
+for NAME in MCP_CONFORMANCE_SCENARIO MCP_CONFORMANCE_CONTEXT MCP_CONFORMANCE_PROTOCOL_VERSION; do
+  if [ -n "${!NAME+x}" ]; then
+    ENV_ARGS+=(--env "${NAME}=${!NAME}")
+  fi
+done
+
+POLICY_SET_COMMAND=(
+  "${OPENSHELL_BIN}" policy set "${CLIENT_SANDBOX}"
+  --policy "${POLICY_FILE}"
+)
+if [ "${POLICY_WAIT}" = "1" ]; then
+  POLICY_SET_COMMAND+=(--wait --timeout "${POLICY_WAIT_TIMEOUT}")
+fi
+"${POLICY_SET_COMMAND[@]}"
+
+# Exec request validation rejects newline/control characters in command
+# arguments, so keep the sandbox-side script as a single argument without
+# embedded newlines.
+# shellcheck disable=SC2016
+SANDBOX_CLIENT_SCRIPT='cd /opt/mcp-conformance; case "${MCP_CONFORMANCE_SCENARIO:-}" in tools_call|tools-call) client=examples/clients/typescript/test2.ts ;; sse-retry) client=examples/clients/typescript/sse-retry-test.ts ;; *) client=examples/clients/typescript/everything-client.ts ;; esac; exec ./node_modules/.bin/tsx "$client" "$1"'
+
+SANDBOX_COMMAND=(
+  "${OPENSHELL_BIN}" sandbox exec
+  --name "${CLIENT_SANDBOX}"
+  --no-tty
+  --timeout "${CLIENT_TIMEOUT_SECONDS}"
+  "${ENV_ARGS[@]}"
+  --
+  sh -c "${SANDBOX_CLIENT_SCRIPT}" \
+  sh "${CLIENT_SERVER_URL}"
+)
+
+"${SANDBOX_COMMAND[@]}" </dev/null

--- a/e2e/mcp-conformance/expected-failures.yml
+++ b/e2e/mcp-conformance/expected-failures.yml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Add scenarios here only for known OpenShell MCP conformance gaps.
+# Upstream reference-client fixture drift is handled by the local wrapper and
+# checkout patching in e2e/mcp-conformance.sh so it does not hide OpenShell
+# regressions behind expected failures.
+client: []
+server: []

--- a/e2e/mcp-conformance/host-bridge.py
+++ b/e2e/mcp-conformance/host-bridge.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host bridge for the MCP conformance runner.
+
+The conformance runner runs in an isolated container and posts the URL of its
+MCP test server to this bridge. The bridge runs the real MCP client inside an
+OpenShell sandbox (via client-through-openshell.sh) and returns its result, so
+the untrusted runner never needs gateway credentials.
+
+Usage: host-bridge.py <port> <repo-root> <log-path>
+"""
+
+import hmac
+import json
+import os
+import subprocess
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from ipaddress import ip_address
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+PORT = int(sys.argv[1])
+ROOT = Path(sys.argv[2])
+LOG_PATH = Path(sys.argv[3])
+TIMEOUT = (
+    int(os.environ.get("OPENSHELL_MCP_CONFORMANCE_CLIENT_TIMEOUT_SECONDS", "120")) + 30
+)
+REQUEST_BODY_TIMEOUT_SECONDS = 10
+MAX_REQUEST_BODY_BYTES = 256 * 1024
+TOKEN_HEADER = "x-openshell-mcp-conformance-token"
+BRIDGE_TOKEN = os.environ["OPENSHELL_MCP_CONFORMANCE_BRIDGE_TOKEN"]
+RUNNER_IP = os.environ["OPENSHELL_MCP_CONFORMANCE_RUNNER_IP"]
+ALLOWED_CONFORMANCE_ENV = frozenset(
+    {
+        "MCP_CONFORMANCE_SCENARIO",
+        "MCP_CONFORMANCE_CONTEXT",
+        "MCP_CONFORMANCE_PROTOCOL_VERSION",
+    }
+)
+HOST_ENV_ALLOWLIST = frozenset(
+    {
+        "CARGO_HOME",
+        "CARGO_TARGET_DIR",
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "MISE_CACHE_DIR",
+        "MISE_CONFIG_DIR",
+        "MISE_DATA_DIR",
+        "MISE_STATE_DIR",
+        "OPENSHELL_BIN",
+        "OPENSHELL_GATEWAY",
+        "OPENSHELL_MCP_CONFORMANCE_CLIENT_SANDBOX",
+        "OPENSHELL_MCP_CONFORMANCE_CLIENT_TIMEOUT_SECONDS",
+        "OPENSHELL_MCP_CONFORMANCE_POLICY_WAIT",
+        "OPENSHELL_MCP_CONFORMANCE_POLICY_WAIT_TIMEOUT",
+        "OPENSHELL_PROVISION_TIMEOUT",
+        "PATH",
+        "RUSTUP_HOME",
+        "TMP",
+        "TEMP",
+        "TMPDIR",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "XDG_STATE_HOME",
+    }
+)
+
+
+def log(message: str) -> None:
+    with LOG_PATH.open("a", encoding="utf-8") as fh:
+        fh.write(message + "\n")
+
+
+def canonical_ip(value: str):
+    parsed = ip_address(value)
+    return getattr(parsed, "ipv4_mapped", None) or parsed
+
+
+def captured_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def subprocess_env(
+    payload_env: dict[str, str], expected_server_host: str
+) -> dict[str, str]:
+    env = {name: os.environ[name] for name in HOST_ENV_ALLOWLIST if name in os.environ}
+    env.update(payload_env)
+    env["OPENSHELL_MCP_CONFORMANCE_EXPECTED_SERVER_HOST"] = expected_server_host
+    return env
+
+
+class Handler(BaseHTTPRequestHandler):
+    def setup(self) -> None:
+        super().setup()
+        self.connection.settimeout(REQUEST_BODY_TIMEOUT_SECONDS)
+
+    def send_json(self, status: int, body: dict[str, object]) -> None:
+        encoded = json.dumps(body).encode("utf-8")
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(encoded)))
+        self.send_header("connection", "close")
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def reject(self, status: int, detail: str) -> None:
+        self.close_connection = True
+        log(f"rejecting bridge request from {self.client_address[0]}: {detail}")
+        self.send_json(status, {"error": "invalid_bridge_request", "detail": detail})
+
+    def bridge_token_valid(self) -> bool:
+        supplied = self.headers.get(TOKEN_HEADER, "")
+        return hmac.compare_digest(supplied, BRIDGE_TOKEN)
+
+    def request_body_length(self) -> int | None:
+        raw_length = self.headers.get("content-length")
+        if raw_length is None:
+            self.reject(411, "content-length is required")
+            return None
+        try:
+            length = int(raw_length)
+        except ValueError:
+            self.reject(400, "content-length must be an integer")
+            return None
+        if length < 0:
+            self.reject(400, "content-length must not be negative")
+            return None
+        if length > MAX_REQUEST_BODY_BYTES:
+            self.reject(413, "request body is too large")
+            return None
+        return length
+
+    def read_request_payload(self, length: int) -> dict[str, Any] | None:
+        try:
+            raw_body = self.rfile.read(length)
+        except TimeoutError:
+            self.reject(408, "timed out reading request body")
+            return None
+        if len(raw_body) != length:
+            self.reject(400, "request body ended before content-length")
+            return None
+        try:
+            payload = json.loads(raw_body)
+        except json.JSONDecodeError as err:
+            self.reject(400, str(err))
+            return None
+        if not isinstance(payload, dict):
+            self.reject(400, "request body must be a JSON object")
+            return None
+        return payload
+
+    def do_POST(self) -> None:
+        if self.path != "/run":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        if not self.bridge_token_valid():
+            self.reject(403, "invalid bridge capability")
+            return
+
+        length = self.request_body_length()
+        if length is None:
+            return
+
+        payload = self.read_request_payload(length)
+        if payload is None:
+            return
+
+        server_url = payload.get("server_url")
+        if not isinstance(server_url, str):
+            self.reject(400, "server_url must be a string")
+            return
+
+        parsed = urlparse(server_url)
+        if parsed.scheme not in {"http", "https"}:
+            self.reject(403, "server_url scheme must be http or https")
+            return
+
+        try:
+            target_ip = canonical_ip(parsed.hostname or "")
+            expected_ip = canonical_ip(RUNNER_IP)
+        except ValueError:
+            self.reject(403, "server_url host must match the runner container IP")
+            return
+
+        if target_ip != expected_ip:
+            self.reject(403, "server_url host must match the runner container IP")
+            return
+
+        payload_env = payload.get("env", {})
+        if not isinstance(payload_env, dict):
+            self.reject(400, "env must be an object")
+            return
+        if any(name not in ALLOWED_CONFORMANCE_ENV for name in payload_env):
+            self.reject(403, "env contains unsupported keys")
+            return
+        if any(not isinstance(value, str) for value in payload_env.values()):
+            self.reject(400, "env values must be strings")
+            return
+
+        env = subprocess_env(payload_env, str(expected_ip))
+        log(f"running client for {server_url}")
+        try:
+            result = subprocess.run(
+                ["bash", "e2e/mcp-conformance/client-through-openshell.sh", server_url],
+                cwd=ROOT,
+                env=env,
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                timeout=TIMEOUT,
+            )
+            log(f"client exited {result.returncode} for {server_url}")
+            body = {
+                "exit_code": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        except subprocess.TimeoutExpired as err:
+            body = {
+                "exit_code": 124,
+                "stdout": captured_text(err.stdout),
+                "stderr": captured_text(err.stderr)
+                + f"\nhost bridge timed out after {TIMEOUT}s\n",
+            }
+        self.send_json(200, body)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        log(format % args)
+
+
+def main() -> None:
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    log(f"host bridge listening on {PORT}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/mcp-conformance/policy-template.yaml
+++ b/e2e/mcp-conformance/policy-template.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /bin
+    - /usr
+    - /lib
+    - /lib64
+    - /proc
+    - /sys
+    - /dev/urandom
+    - /etc
+    - /opt
+    - /var/log
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+    - /home/sandbox
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  mcp_conformance:
+    name: mcp_conformance
+    endpoints:
+      - ${host_spec}
+${port_spec}
+        path: ${path}
+        protocol: mcp
+        enforcement: enforce
+        allowed_ips:
+          - "10.0.0.0/8"
+          - "172.16.0.0/12"
+          - "192.168.0.0/16"
+          - "fc00::/7"
+        mcp:
+          max_body_bytes: 131072
+          allow_all_known_mcp_methods: true
+        rules:
+          - allow: {}
+    binaries:
+      - path: /bin/sh
+      - path: /usr/bin/env
+      - path: /usr/local/bin/node
+      - path: /usr/bin/node
+      - path: /opt/mcp-conformance/node_modules/.bin/*

--- a/e2e/mcp-conformance/render-policy.py
+++ b/e2e/mcp-conformance/render-policy.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render the OpenShell client policy for a conformance server URL.
+
+Parses the server URL into host/port/path, substitutes them into
+policy-template.yaml, writes the rendered policy, and prints the (possibly
+rewritten) URL the client should connect to. Used both to seed the reusable
+client sandbox with a placeholder policy and to install the per-scenario policy
+in client-through-openshell.sh.
+
+Usage: render-policy.py <server-url> <policy-file> <policy-template>
+"""
+
+import json
+import os
+import string
+import sys
+from ipaddress import ip_address
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
+
+raw_url, policy_file, policy_template = sys.argv[1:4]
+parsed = urlparse(raw_url)
+
+if parsed.scheme not in ("http", "https"):
+    raise SystemExit(f"unsupported conformance server URL scheme: {parsed.scheme!r}")
+
+host = parsed.hostname
+if not host:
+    raise SystemExit(f"conformance server URL is missing a host: {raw_url}")
+
+expected_host = os.environ.get("OPENSHELL_MCP_CONFORMANCE_EXPECTED_SERVER_HOST")
+if expected_host:
+    try:
+        actual_ip = ip_address(host)
+        actual_ip = getattr(actual_ip, "ipv4_mapped", None) or actual_ip
+        expected_ip = ip_address(expected_host)
+        expected_ip = getattr(expected_ip, "ipv4_mapped", None) or expected_ip
+    except ValueError as err:
+        raise SystemExit(
+            "conformance server URL host must be an IP address when "
+            "OPENSHELL_MCP_CONFORMANCE_EXPECTED_SERVER_HOST is set"
+        ) from err
+    if actual_ip != expected_ip:
+        raise SystemExit(
+            f"conformance server URL host {actual_ip} does not match expected "
+            f"runner host {expected_ip}"
+        )
+
+target_host = (
+    "host.openshell.internal" if host in {"localhost", "127.0.0.1", "::1"} else host
+)
+port = parsed.port or (443 if parsed.scheme == "https" else 80)
+path = parsed.path or "/"
+netloc_host = (
+    f"[{target_host}]"
+    if ":" in target_host and not target_host.startswith("[")
+    else target_host
+)
+netloc = f"{netloc_host}:{port}"
+rewritten = urlunparse(
+    (parsed.scheme, netloc, path, parsed.params, parsed.query, parsed.fragment)
+)
+
+template = string.Template(Path(policy_template).read_text(encoding="utf-8"))
+policy = template.substitute(
+    host_spec=f"host: {json.dumps(target_host)}",
+    port_spec=f"        port: {port}",
+    path=json.dumps(path),
+)
+Path(policy_file).write_text(policy, encoding="utf-8")
+
+print(rewritten)

--- a/e2e/mcp-conformance/runner-shim.mjs
+++ b/e2e/mcp-conformance/runner-shim.mjs
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Client command for the upstream MCP conformance runner, executed inside the
+// runner container.
+//
+// Why this indirection exists: the conformance runner runs untrusted upstream
+// node off the host, so it deliberately has no openshell binary and no gateway
+// credentials. But the MCP client under test must run inside an OpenShell
+// sandbox so its traffic crosses the policy-enforced proxy (the whole point of
+// the e2e). This script bridges that gap without widening the runner's
+// privileges: instead of running the MCP client itself, it posts the test
+// server URL to the host bridge, which holds the gateway credentials and runs
+// the real client in a sandbox, then returns its result. The runner can only
+// ask "run a client against this URL" — it cannot touch the gateway control
+// plane.
+
+import http from 'node:http';
+import os from 'node:os';
+import process from 'node:process';
+
+// Resolve the routable IPv4 address of the runner container on the e2e Docker
+// network. The conformance runner reports its test server URL as localhost; the
+// client sandbox connects from a different container, so localhost must be
+// rewritten to this container's network address.
+function runnerAddress() {
+  if (process.env.MCP_CONFORMANCE_RUNNER_IP) {
+    return process.env.MCP_CONFORMANCE_RUNNER_IP;
+  }
+  for (const addrs of Object.values(os.networkInterfaces())) {
+    for (const addr of addrs ?? []) {
+      if (addr.family === 'IPv4' && !addr.internal) {
+        return addr.address;
+      }
+    }
+  }
+  throw new Error('failed to resolve runner container IPv4 address');
+}
+
+function rewriteServerUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  if (['localhost', '127.0.0.1', '[::1]', '::1'].includes(url.hostname)) {
+    url.hostname = runnerAddress();
+  }
+  return url.toString();
+}
+
+const bridgeUrl = process.env.MCP_CONFORMANCE_HOST_BRIDGE_URL;
+if (!bridgeUrl) {
+  throw new Error('MCP_CONFORMANCE_HOST_BRIDGE_URL is required');
+}
+const bridgeToken = process.env.MCP_CONFORMANCE_HOST_BRIDGE_TOKEN;
+if (!bridgeToken) {
+  throw new Error('MCP_CONFORMANCE_HOST_BRIDGE_TOKEN is required');
+}
+const parsedBridgeUrl = new URL(bridgeUrl);
+if (parsedBridgeUrl.protocol !== 'http:') {
+  throw new Error(`bridge URL must use http:, got ${parsedBridgeUrl.protocol}`);
+}
+const serverUrl = process.argv[2];
+if (!serverUrl) {
+  throw new Error('usage: node runner-shim.mjs <server-url>');
+}
+
+// POST the rewritten server URL to the host bridge, which runs the real MCP
+// client inside an OpenShell sandbox and returns its result. The runner is a
+// plain container with ordinary egress, so this is a direct HTTP call.
+function postJson(url, payload) {
+  const body = Buffer.from(JSON.stringify(payload), 'utf8');
+  const timeoutMs = Number.parseInt(process.env.MCP_CONFORMANCE_HOST_BRIDGE_TIMEOUT_MS ?? '600000', 10);
+
+  function snippet(raw) {
+    return raw.length > 4096 ? `${raw.slice(0, 4096)}...` : raw;
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      hostname: url.hostname,
+      port: url.port || 80,
+      path: `${url.pathname}${url.search}`,
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-length': body.length,
+        'x-openshell-mcp-conformance-token': bridgeToken,
+      },
+      agent: false,
+    }, (response) => {
+      const chunks = [];
+      response.on('data', (chunk) => chunks.push(chunk));
+      response.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        const statusCode = response.statusCode ?? 0;
+        try {
+          const parsed = JSON.parse(raw);
+          if (statusCode < 200 || statusCode >= 300) {
+            reject(new Error(`bridge callback failed (HTTP ${statusCode}): ${snippet(raw)}`));
+            return;
+          }
+          resolve(parsed);
+        } catch (error) {
+          reject(new Error(`bridge returned invalid JSON (HTTP ${statusCode}): ${snippet(raw) || error.message}`));
+        }
+      });
+    });
+    request.on('error', reject);
+    request.setTimeout(timeoutMs, () => {
+      request.destroy(new Error(`bridge callback timed out after ${timeoutMs}ms to ${url.toString()}`));
+    });
+    request.end(body);
+  });
+}
+
+const forwardedEnv = {};
+for (const name of [
+  'MCP_CONFORMANCE_SCENARIO',
+  'MCP_CONFORMANCE_CONTEXT',
+  'MCP_CONFORMANCE_PROTOCOL_VERSION',
+]) {
+  if (process.env[name] !== undefined) {
+    forwardedEnv[name] = process.env[name];
+  }
+}
+
+const body = await postJson(parsedBridgeUrl, {
+  server_url: rewriteServerUrl(serverUrl),
+  env: forwardedEnv,
+});
+if (typeof body.exit_code !== 'number') {
+  const raw = JSON.stringify(body);
+  throw new Error(`bridge returned JSON without numeric exit_code: ${raw.length > 4096 ? `${raw.slice(0, 4096)}...` : raw}`);
+}
+if (body.stdout) {
+  process.stdout.write(body.stdout);
+}
+if (body.stderr) {
+  process.stderr.write(body.stderr);
+}
+process.exit(body.exit_code);

--- a/e2e/rust/Cargo.toml
+++ b/e2e/rust/Cargo.toml
@@ -98,6 +98,11 @@ path = "tests/forward_proxy_graphql_l7.rs"
 required-features = ["e2e-host-gateway"]
 
 [[test]]
+name = "forward_proxy_jsonrpc_l7"
+path = "tests/forward_proxy_jsonrpc_l7.rs"
+required-features = ["e2e-host-gateway"]
+
+[[test]]
 name = "gpu_device_selection"
 path = "tests/gpu_device_selection.rs"
 required-features = ["e2e-gpu"]

--- a/e2e/rust/tests/forward_proxy_jsonrpc_l7.rs
+++ b/e2e/rust/tests/forward_proxy_jsonrpc_l7.rs
@@ -1,0 +1,520 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! E2E tests for JSON-RPC L7 inspection across both proxy entry points.
+//!
+//! The upstream server deliberately does not implement JSON-RPC. `OpenShell`
+//! parses and enforces JSON-RPC before forwarding, so any HTTP server that
+//! accepts POST /rpc is enough to prove allowed requests reach upstream
+//! and denied requests are stopped by the sandbox proxy.
+
+#![cfg(feature = "e2e")]
+
+use std::io::Write;
+
+use openshell_e2e::harness::container::ContainerHttpServer;
+use openshell_e2e::harness::sandbox::SandboxGuard;
+use tempfile::NamedTempFile;
+
+const RULES_TEST_SERVER_ALIAS: &str = "jsonrpc-l7-rules.openshell.test";
+const AUDIT_TEST_SERVER_ALIAS: &str = "jsonrpc-l7-audit.openshell.test";
+
+async fn start_test_server(alias: &str) -> Result<ContainerHttpServer, String> {
+    let script = r#"from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def read_body(self):
+        if self.headers.get("Transfer-Encoding", "").lower() == "chunked":
+            data = b""
+            while True:
+                size_line = self.rfile.readline()
+                if not size_line:
+                    break
+                size = int(size_line.split(b";", 1)[0].strip(), 16)
+                if size == 0:
+                    while self.rfile.readline().strip():
+                        pass
+                    break
+                data += self.rfile.read(size)
+                self.rfile.read(2)
+            return data
+        return self.rfile.read(int(self.headers.get("Content-Length", "0")))
+
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+
+    def do_POST(self):
+        self.read_body()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"jsonrpc":"2.0","id":1,"result":{}}')
+
+    def log_message(self, format, *args):
+        pass
+
+HTTPServer(("0.0.0.0", 8000), Handler).serve_forever()
+"#;
+
+    ContainerHttpServer::start_python(alias, script).await
+}
+
+fn write_jsonrpc_policy(host: &str, port: u16) -> Result<NamedTempFile, String> {
+    let mut file = NamedTempFile::new().map_err(|e| format!("create temp policy file: {e}"))?;
+    let policy = format!(
+        r#"version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /proc
+    - /dev/urandom
+    - /app
+    - /etc
+    - /var/log
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  test_jsonrpc_l7:
+    name: test_jsonrpc_l7
+    endpoints:
+      - host: {host}
+        port: {port}
+        path: /rpc
+        protocol: json-rpc
+        enforcement: enforce
+        allowed_ips:
+          - "10.0.0.0/8"
+          - "172.0.0.0/8"
+          - "192.168.0.0/16"
+          - "fc00::/7"
+        json_rpc:
+          max_body_bytes: 65536
+        rules:
+          - allow:
+              method: initialize
+          - allow:
+              method: tools/list
+          - allow:
+              method: tools/call
+        deny_rules:
+          - method: tools/delete
+    binaries:
+      - path: /usr/bin/python*
+      - path: /usr/local/bin/python*
+      - path: /sandbox/.uv/python/*/bin/python*
+"#
+    );
+    file.write_all(policy.as_bytes())
+        .map_err(|e| format!("write temp policy file: {e}"))?;
+    file.flush()
+        .map_err(|e| format!("flush temp policy file: {e}"))?;
+    Ok(file)
+}
+
+fn write_jsonrpc_default_audit_policy(host: &str, port: u16) -> Result<NamedTempFile, String> {
+    let mut file = NamedTempFile::new().map_err(|e| format!("create temp policy file: {e}"))?;
+    let policy = format!(
+        r#"version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /proc
+    - /dev/urandom
+    - /app
+    - /etc
+    - /var/log
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  test_jsonrpc_l7_audit:
+    name: test_jsonrpc_l7_audit
+    endpoints:
+      - host: {host}
+        port: {port}
+        path: /rpc
+        protocol: json-rpc
+        allowed_ips:
+          - "10.0.0.0/8"
+          - "100.64.0.0/10"
+          - "172.0.0.0/8"
+          - "198.18.0.0/15"
+          - "192.168.0.0/16"
+          - "fc00::/7"
+        json_rpc:
+          max_body_bytes: 65536
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - path: /usr/bin/python*
+      - path: /usr/local/bin/python*
+      - path: /sandbox/.uv/python/*/bin/python*
+"#
+    );
+    file.write_all(policy.as_bytes())
+        .map_err(|e| format!("write temp policy file: {e}"))?;
+    file.flush()
+        .map_err(|e| format!("flush temp policy file: {e}"))?;
+    Ok(file)
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn jsonrpc_l7_enforces_method_rules_on_forward_and_connect_paths() {
+    let server = start_test_server(RULES_TEST_SERVER_ALIAS)
+        .await
+        .expect("start test server");
+    let policy = write_jsonrpc_policy(&server.host, server.port).expect("write custom policy");
+    let policy_path = policy
+        .path()
+        .to_str()
+        .expect("temp policy path should be utf-8")
+        .to_string();
+
+    let script = format!(
+        r#"
+import json
+import os
+import socket
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+HOST = {host:?}
+PORT = {port}
+DETAILS = {{
+    "debug_target": {{"host": HOST, "port": PORT}},
+    "debug_proxy_env": {{
+        "http_proxy": os.environ.get("http_proxy"),
+        "https_proxy": os.environ.get("https_proxy"),
+        "HTTP_PROXY": os.environ.get("HTTP_PROXY"),
+        "HTTPS_PROXY": os.environ.get("HTTPS_PROXY"),
+        "NO_PROXY": os.environ.get("NO_PROXY"),
+        "no_proxy": os.environ.get("no_proxy"),
+    }},
+}}
+
+def text(data):
+    return data.decode(errors="replace")
+
+def selected_headers(headers):
+    return {{
+        key.lower(): value
+        for key, value in headers.items()
+        if key.lower() in ("content-type", "content-length", "server")
+    }}
+
+def record_http_error(label, error, request_body):
+    response_body = error.read()
+    DETAILS[f"{{label}}_request"] = request_body
+    DETAILS[f"{{label}}_response"] = {{
+        "status": error.code,
+        "reason": str(error.reason),
+        "headers": selected_headers(error.headers),
+        "body": text(response_body),
+    }}
+    return error.code
+
+def post_jsonrpc(label, method, params=None, req_id=1):
+    body = {{"jsonrpc": "2.0", "id": req_id, "method": method}}
+    if params is not None:
+        body["params"] = params
+    encoded = json.dumps(body).encode()
+    request = urllib.request.Request(
+        f"http://{{HOST}}:{{PORT}}/rpc",
+        data=encoded,
+        headers={{"Content-Type": "application/json"}},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            response.read()
+            return response.status
+    except urllib.error.HTTPError as error:
+        return record_http_error(label, error, body)
+
+def post_jsonrpc_batch(label, requests):
+    encoded = json.dumps(requests).encode()
+    request = urllib.request.Request(
+        f"http://{{HOST}}:{{PORT}}/rpc",
+        data=encoded,
+        headers={{"Content-Type": "application/json"}},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            response.read()
+            return response.status
+    except urllib.error.HTTPError as error:
+        return record_http_error(label, error, requests)
+
+def post_invalid_json(label):
+    encoded = b"not valid json {{"
+    request = urllib.request.Request(
+        f"http://{{HOST}}:{{PORT}}/rpc",
+        data=encoded,
+        headers={{"Content-Type": "application/json", "Content-Length": str(len(encoded))}},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            response.read()
+            return response.status
+    except urllib.error.HTTPError as error:
+        return record_http_error(label, error, text(encoded))
+
+def proxy_parts(*names):
+    proxy_url = next((os.environ.get(name) for name in names if os.environ.get(name)), None)
+    parsed = urllib.parse.urlparse(proxy_url)
+    return parsed.hostname, parsed.port or 80
+
+def read_until(sock, marker):
+    data = b""
+    while marker not in data:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+    return data
+
+def read_response(sock):
+    response = read_until(sock, b"\r\n\r\n")
+    headers, _, body = response.partition(b"\r\n\r\n")
+    content_length = 0
+    for line in headers.split(b"\r\n")[1:]:
+        if line.lower().startswith(b"content-length:"):
+            content_length = int(line.split(b":", 1)[1].strip())
+            break
+    while len(body) < content_length:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        body += chunk
+    return response, body
+
+def status_code(response, label):
+    parts = response.split()
+    if len(parts) < 2:
+        DETAILS[f"{{label}}_raw"] = response.decode(errors="replace")
+        raise RuntimeError(f"{{label}}: malformed HTTP response: {{response!r}}")
+    try:
+        return int(parts[1])
+    except ValueError as error:
+        DETAILS[f"{{label}}_raw"] = response.decode(errors="replace")
+        raise RuntimeError(f"{{label}}: non-numeric HTTP status: {{response!r}}") from error
+
+def record_raw_response(label, response, body=b""):
+    code = status_code(response, label)
+    if code != 200:
+        DETAILS[f"{{label}}_raw"] = text(response)
+        if body:
+            DETAILS[f"{{label}}_body"] = text(body)
+    return code
+
+def connect_http_status(label, request):
+    proxy_host, proxy_port = proxy_parts("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy")
+    target = f"{{HOST}}:{{PORT}}"
+
+    last_error = None
+    for attempt in range(5):
+        try:
+            with socket.create_connection((proxy_host, proxy_port), timeout=15) as sock:
+                sock.sendall(
+                    f"CONNECT {{target}} HTTP/1.1\r\nHost: {{target}}\r\n\r\n".encode()
+                )
+                connect_response = read_until(sock, b"\r\n\r\n")
+                connect_code = record_raw_response(f"{{label}}_connect", connect_response)
+                if connect_code != 200:
+                    return connect_code
+                sock.sendall(request)
+                sock.shutdown(socket.SHUT_WR)
+                response, body = read_response(sock)
+                return record_raw_response(f"{{label}}_response", response, body)
+        except (OSError, RuntimeError) as error:
+            last_error = error
+            DETAILS[f"{{label}}_attempt_{{attempt + 1}}_error"] = str(error)
+            time.sleep(0.2)
+
+    raise RuntimeError(f"{{label}}: failed after 5 attempts: {{last_error}}")
+
+def connect_jsonrpc_status(method, params, label):
+    target = f"{{HOST}}:{{PORT}}"
+    body = {{"jsonrpc": "2.0", "id": 1, "method": method}}
+    if params is not None:
+        body["params"] = params
+    encoded = json.dumps(body).encode()
+    request = (
+        f"POST /rpc HTTP/1.1\r\n"
+        f"Host: {{target}}\r\n"
+        f"Content-Type: application/json\r\n"
+        f"Content-Length: {{len(encoded)}}\r\n"
+        f"Connection: close\r\n"
+        f"\r\n"
+    ).encode() + encoded
+    return connect_http_status(label, request)
+
+results = {{
+    # forward proxy — method-only allow rules
+    "forward_method_initialize_allowed": post_jsonrpc("forward_method_initialize_allowed", "initialize", {{"protocolVersion": "2025-11-25", "capabilities": {{}}}}),
+    "forward_method_tools_list_allowed": post_jsonrpc("forward_method_tools_list_allowed", "tools/list"),
+
+    # forward proxy — method allow/deny rules
+    "forward_method_tools_call_allowed": post_jsonrpc("forward_method_tools_call_allowed", "tools/call", {{"name": "read_status"}}),
+    "forward_method_tools_call_with_unmatched_params_allowed": post_jsonrpc("forward_method_tools_call_with_unmatched_params_allowed", "tools/call", {{"name": "blocked_action", "arguments": {{"scope": "ignored"}}}}),
+    "forward_method_tools_delete_denied": post_jsonrpc("forward_method_tools_delete_denied", "tools/delete", {{"name": "purge_cache"}}),
+
+    # forward proxy — batch: all requests allowed
+    "forward_batch_all_allowed": post_jsonrpc_batch("forward_batch_all_allowed", [
+        {{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}},
+        {{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {{"name": "read_status"}}}},
+    ]),
+
+    # forward proxy — batch: one denied request causes full batch denial
+    "forward_batch_one_denied": post_jsonrpc_batch("forward_batch_one_denied", [
+        {{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}},
+        {{"jsonrpc": "2.0", "id": 2, "method": "tools/delete", "params": {{"name": "purge_cache"}}}},
+    ]),
+
+    # forward proxy — invalid JSON body fails closed before generic rules apply
+    "forward_invalid_json_denied": post_invalid_json("forward_invalid_json_denied"),
+
+    # CONNECT path — representative allowed and denied cases
+    "connect_method_initialize_allowed": connect_jsonrpc_status("initialize", {{"protocolVersion": "2025-11-25", "capabilities": {{}}}}, "connect_method_initialize_allowed"),
+    "connect_method_tools_list_allowed": connect_jsonrpc_status("tools/list", None, "connect_method_tools_list_allowed"),
+    "connect_method_tools_call_allowed": connect_jsonrpc_status("tools/call", {{"name": "read_status"}}, "connect_method_tools_call_allowed"),
+    "connect_method_tools_call_with_unmatched_params_allowed": connect_jsonrpc_status("tools/call", {{"name": "blocked_action", "arguments": {{"scope": "ignored"}}}}, "connect_method_tools_call_with_unmatched_params_allowed"),
+    "connect_method_tools_delete_denied": connect_jsonrpc_status("tools/delete", {{"name": "purge_cache"}}, "connect_method_tools_delete_denied"),
+}}
+results.update(DETAILS)
+print(json.dumps(results, sort_keys=True))
+"#,
+        host = server.host,
+        port = server.port,
+    );
+
+    let guard = SandboxGuard::create(&["--policy", &policy_path, "--", "python3", "-c", &script])
+        .await
+        .expect("sandbox create");
+
+    for (key, expected) in [
+        // forward proxy — allowed
+        ("forward_method_initialize_allowed", 200),
+        ("forward_method_tools_list_allowed", 200),
+        ("forward_method_tools_call_allowed", 200),
+        ("forward_method_tools_call_with_unmatched_params_allowed", 200),
+        // forward proxy — method denied
+        ("forward_method_tools_delete_denied", 403),
+        // forward proxy — batch
+        ("forward_batch_all_allowed", 200),
+        ("forward_batch_one_denied", 403),
+        // forward proxy — parse error
+        ("forward_invalid_json_denied", 403),
+        // CONNECT path — allowed
+        ("connect_method_initialize_allowed", 200),
+        ("connect_method_tools_list_allowed", 200),
+        ("connect_method_tools_call_allowed", 200),
+        ("connect_method_tools_call_with_unmatched_params_allowed", 200),
+        // CONNECT path — method denied
+        ("connect_method_tools_delete_denied", 403),
+    ] {
+        let expected_fragment = format!(r#""{key}": {expected}"#);
+        assert!(
+            guard.create_output.contains(&expected_fragment),
+            "expected {key}={expected}, got:\n{}",
+            guard.create_output
+        );
+    }
+}
+
+#[tokio::test]
+async fn jsonrpc_forward_proxy_hard_denies_response_frames_in_default_audit_mode() {
+    let server = start_test_server(AUDIT_TEST_SERVER_ALIAS)
+        .await
+        .expect("start test server");
+    let policy =
+        write_jsonrpc_default_audit_policy(&server.host, server.port).expect("write custom policy");
+    let policy_path = policy
+        .path()
+        .to_str()
+        .expect("temp policy path should be utf-8")
+        .to_string();
+
+    let script = format!(
+        r#"
+import json
+import urllib.error
+import urllib.request
+
+HOST = {host:?}
+PORT = {port}
+
+def post_jsonrpc(body):
+    encoded = json.dumps(body).encode()
+    request = urllib.request.Request(
+        f"http://{{HOST}}:{{PORT}}/rpc",
+        data=encoded,
+        headers={{"Content-Type": "application/json"}},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            response.read()
+            return response.status
+    except urllib.error.HTTPError as error:
+        error.read()
+        return error.code
+
+results = {{
+    "forward_unknown_method_audited": post_jsonrpc({{"jsonrpc": "2.0", "id": 1, "method": "unknown/method"}}),
+    "forward_response_frame_hard_denied": post_jsonrpc({{"jsonrpc": "2.0", "id": 1, "result": {{}}}}),
+}}
+print(json.dumps(results, sort_keys=True))
+"#,
+        host = server.host,
+        port = server.port,
+    );
+
+    let guard = SandboxGuard::create(&["--policy", &policy_path, "--", "python3", "-c", &script])
+        .await
+        .expect("sandbox create");
+
+    for (key, expected) in [
+        ("forward_unknown_method_audited", 200),
+        ("forward_response_frame_hard_denied", 403),
+    ] {
+        let expected_fragment = format!(r#""{key}": {expected}"#);
+        assert!(
+            guard.create_output.contains(&expected_fragment),
+            "expected {key}={expected}, got:\n{}",
+            guard.create_output
+        );
+    }
+}

--- a/e2e/with-docker-gateway.sh
+++ b/e2e/with-docker-gateway.sh
@@ -21,7 +21,7 @@
 # The default community sandbox image uses :latest. This wrapper refreshes it
 # before starting the gateway, while the Docker driver defaults to IfNotPresent
 # so local Dockerfile-built images remain usable.
-
+#
 set -euo pipefail
 
 if [ "$#" -eq 0 ]; then

--- a/mise.toml
+++ b/mise.toml
@@ -65,7 +65,7 @@ DOCKER_BUILDKIT = "1"
 
 [vars]
 # Python paths to include in formatting/linting
-python_paths = "python/ tasks/scripts/*.py deploy/sbom/*.py"
+python_paths = "python/ tasks/scripts/*.py e2e/mcp-conformance/*.py deploy/sbom/*.py"
 
 [task_config]
 includes = ["tasks/*.toml"]

--- a/proto/sandbox.proto
+++ b/proto/sandbox.proto
@@ -138,6 +138,43 @@ message NetworkEndpoint {
   // AWS region override for SigV4 signing. When set, takes precedence over
   // hostname-based region extraction. Required for non-standard endpoints.
   string signing_region = 21;
+  // Maximum JSON-RPC-over-HTTP request body bytes to buffer for inspection.
+  // Defaults to 65536 when unset.
+  uint32 json_rpc_max_body_bytes = 22;
+  // MCP-only policy and inspection options. Only used when protocol is "mcp".
+  McpOptions mcp = 23;
+}
+
+// MCP options are grouped so MCP-specific policy can grow without adding more
+// top-level NetworkEndpoint fields. Current enforcement targets the active
+// 2025-11-25 Streamable HTTP/tools behavior, while preserving space for
+// version-profile policy if OpenShell adopts 2026-07-28 draft behavior later.
+//
+// Planned policy extensions should use OpenShell-owned static definitions for
+// MCP method/version profiles rather than treating dependency enums as the
+// policy contract. Candidate profile checks include request metadata/header
+// validation, response/SSE introspection, trusted annotation handling,
+// resultType/cache metadata validation, x-mcp-header tool-definition checks,
+// and subscriptions/listen handling.
+//
+// Sources:
+// - https://modelcontextprotocol.io/specification/2025-11-25/server/tools
+// - https://modelcontextprotocol.io/specification/draft/changelog
+// - https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http
+// - https://modelcontextprotocol.io/specification/draft/server/tools
+message McpOptions {
+  // Hardening boundary for tools/call params.name. When unset or true, the
+  // supervisor enforces the MCP recommended tool-name syntax
+  // ^[A-Za-z0-9_.-]{1,128}$ before policy evaluation. Set false only for
+  // compatibility with servers that intentionally use non-recommended names.
+  //
+  // Source:
+  // - https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-names
+  optional bool strict_tool_names = 1;
+  // Method-layer default for MCP endpoints. When true, OpenShell allows parsed
+  // MCP-family methods at the method layer unless a tool-name policy narrows
+  // tools/call. When unset or false, explicit method rules are required.
+  optional bool allow_all_known_mcp_methods = 2;
 }
 
 // Trusted GraphQL operation classification.
@@ -154,7 +191,8 @@ message GraphqlOperation {
 // Mirrors L7Allow — same fields, same matching semantics, inverted effect.
 // Deny rules are evaluated after allow rules and take precedence.
 message L7DenyRule {
-  // HTTP method (REST): GET, POST, etc. or "*" for any.
+  // Protocol method: HTTP method (REST/WebSocket), JSON-RPC method name, or
+  // "*" for any when supported by the protocol.
   string method = 1;
   // URL path glob pattern (REST): "/repos/*/pulls/*/reviews", "**" for any.
   string path = 2;
@@ -170,6 +208,10 @@ message L7DenyRule {
   // GraphQL root field globs. Deny rules match when any selected root field
   // matches any configured glob.
   repeated string fields = 7;
+  reserved 8;
+  // MCP params matcher map. Currently only params.name is supported for
+  // tools/call filtering. Generic protocol "json-rpc" rejects params matchers.
+  map<string, L7QueryMatcher> params = 9;
 }
 
 // An L7 policy rule (allow-only).
@@ -179,7 +221,8 @@ message L7Rule {
 
 // Allowed action definition for L7 rules.
 message L7Allow {
-  // HTTP method (REST): GET, POST, etc. or "*" for any.
+  // Protocol method: HTTP method (REST/WebSocket), JSON-RPC method name, or
+  // "*" for any when supported by the protocol.
   string method = 1;
   // URL path glob pattern (REST): "/repos/**", "**" for any.
   string path = 2;
@@ -196,6 +239,10 @@ message L7Allow {
   // GraphQL root field globs. Allow rules match only when every selected root
   // field matches one of the configured globs. Omit to match all fields.
   repeated string fields = 7;
+  reserved 8;
+  // MCP params matcher map. Currently only params.name is supported for
+  // tools/call filtering. Generic protocol "json-rpc" rejects params matchers.
+  map<string, L7QueryMatcher> params = 9;
 }
 
 // Query value matcher for one query parameter key.

--- a/tasks/test.toml
+++ b/tasks/test.toml
@@ -29,8 +29,8 @@ run = "tasks/scripts/test-packaging-assets.sh"
 hide = true
 
 [e2e]
-description = "Run all end-to-end tests (Rust + Python)"
-depends = ["e2e:rust", "e2e:python"]
+description = "Run all end-to-end tests (Rust + Python + MCP)"
+depends = ["e2e:rust", "e2e:python", "e2e:mcp"]
 
 ["e2e:gpu"]
 description = "Run Docker GPU end-to-end tests"
@@ -70,6 +70,14 @@ run = [
   "cargo build -p openshell-cli",
   "e2e/with-docker-gateway.sh cargo test --manifest-path e2e/rust/Cargo.toml --features e2e-docker --test websocket_conformance",
 ]
+
+["e2e:mcp"]
+description = "Run MCP conformance e2e scenarios against one Docker-backed gateway (static defaults for spec 2025-11-25; set OPENSHELL_MCP_CONFORMANCE_SCENARIOS for a focused subset)"
+run = "bash e2e/mcp-conformance.sh"
+
+["e2e:nodejs"]
+description = "Alias for e2e:mcp"
+depends = ["e2e:mcp"]
 
 ["e2e:python"]
 description = "Run Python e2e tests against a Docker-backed gateway (E2E_PARALLEL=N or 'auto'; default 5)"


### PR DESCRIPTION
## Summary
Add first-class L7 policy support for `protocol: json-rpc` and `protocol: mcp`, so sandbox egress can be constrained at the JSON-RPC method and MCP tool layer rather than just host/path. The L7 forward proxy now parses JSON-RPC request bodies (single and batch), enforces per-call decisions, fails closed on ambiguous or response-shaped frames, and relays MCP SSE responses without prematurely closing streams.

## Related Issue
Closes #1793

## Changes
  - **Policy schema, proto, and OPA wiring** for `json-rpc` and `mcp` protocols (`openshell-policy`, `proto/sandbox.proto`, `openshell-supervisor-network/opa.rs`, `data/sandbox-policy.rego`, provider profiles).
    - JSON-RPC endpoints match **exact method names only** (method globs rejected at policy validation) and do **not** support params matchers.
    - MCP endpoints additionally support method globs and `tool`/`params.name` matching to narrow `tools/call`, enforced identically on the YAML and proto load paths.
  - **L7 forward-proxy parsing** (`l7/jsonrpc.rs`, `l7/http.rs`, `l7/mod.rs`, `l7/proxy.rs`): parse JSON-RPC bodies and batches with bounded reads (`json_rpc_max_body_bytes`), fail closed on invalid/ambiguous/response-shaped frames, deny a batch if any element is denied, and redact params in decision logs.
  - **SSE relay** (`l7/relay.rs`, `l7/rest.rs`): relay unframed or sparse MCP SSE responses without prematurely closing streams.
  - **MCP-only options** via a grouped `McpOptions` proto message (`strict_tool_names`, `allow_all_known_mcp_methods`).
  - **Docs**: new policy protocols and current params-matcher limitations (`docs/reference/policy-schema.mdx`, `docs/sandboxes/policies.mdx`, `architecture/sandbox.md`).
  - **Tests**: MCP conformance suite through the Docker gateway runner (`e2e/mcp-conformance*`), JSON-RPC L7 e2e coverage (`e2e/rust/tests/forward_proxy_jsonrpc_l7.rs`), plus extensive OPA/policy unit
    tests.
  - **Bug fix**: `proto_to_opa_data_json` now carries the per-rule `params` matcher map for both allow and deny rules. Previously it was dropped on the proto load path, silently degrading an MCP tool-scoped allow rule into allow-any-tool in production (the YAML path enforced correctly). Covered by a new `from_proto` regression test.

## Testing
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)

Additional targeted checks:
- `cargo test -p openshell-sandbox jsonrpc`
- `mise run e2e:rust -- --test forward_proxy_jsonrpc_l7`

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
