### PR TITLE
fix(server): use public tonic body type in gRPC rate limiter

### DIFF
--- a/crates/openshell-server/src/multiplex.rs
+++ b/crates/openshell-server/src/multiplex.rs
@@ -305,7 +305,7 @@ impl<S> GrpcRateLimitService<S> {
 
 impl<S, B> tower::Service<Request<B>> for GrpcRateLimitService<S>
 where
-    S: tower::Service<Request<B>, Response = Response<tonic::body::BoxBody>>,
+    S: tower::Service<Request<B>, Response = Response<tonic::body::Body>>,
     S::Future: Send + 'static,
     B: Send + 'static,
 {
@@ -953,7 +953,7 @@ mod tests {
     }
 
     impl Service<Request<()>> for CountingGrpcService {
-        type Response = Response<tonic::body::BoxBody>;
+        type Response = Response<tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
 
@@ -963,7 +963,7 @@ mod tests {
 
         fn call(&mut self, _req: Request<()>) -> Self::Future {
             self.calls.fetch_add(1, Ordering::Relaxed);
-            std::future::ready(Ok(Response::new(tonic::body::empty_body())))
+            std::future::ready(Ok(Response::new(tonic::body::Body::empty())))
         }
     }
 
@@ -985,7 +985,7 @@ mod tests {
     }
 
     impl Service<Request<()>> for PendingInnerService {
-        type Response = Response<tonic::body::BoxBody>;
+        type Response = Response<tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
 
@@ -995,7 +995,7 @@ mod tests {
 
         fn call(&mut self, _req: Request<()>) -> Self::Future {
             self.calls.fetch_add(1, Ordering::Relaxed);
-            std::future::ready(Ok(Response::new(tonic::body::empty_body())))
+            std::future::ready(Ok(Response::new(tonic::body::Body::empty())))
         }
     }
 


### PR DESCRIPTION
## Summary

Fix the server build with tonic 0.14 by replacing the private `tonic::body::BoxBody` alias in the gRPC rate limiter with the public `tonic::body::Body` type.

## Related Issue

Related to #1566

## Changes

- Updated the gRPC rate limiter response bound to use `tonic::body::Body`.
- Updated rate limiter test services to return `tonic::body::Body::empty()`.

## Testing

- [x] `mise run pre-commit` passes
- [x] `CARGO_TARGET_DIR=/home/op/OpenShell/target mise run build:rust:workspace` passes
- [x] `CARGO_TARGET_DIR=/home/op/OpenShell/target mise exec -- cargo test -p openshell-server multiplex::` passes
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)