### PR TITLE
fix(docker): add Podman-machine gateway regression test

### DIFF
--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -2306,6 +2306,12 @@ fn docker_gateway_route_for_host(
     }
 }
 
+/// On macOS, Docker-compatible runtimes (Docker Desktop, Colima, Podman
+/// machine, etc.) run Linux networking inside a VM. The bridge gateway IP is
+/// therefore not assigned on the host interface where the gateway process
+/// runs, so binding the gateway listener to that IP fails with
+/// EADDRNOTAVAIL. Always route callbacks via host-gateway aliases on macOS
+/// hosts, regardless of which runtime is detected.
 fn host_runtime_requires_host_gateway_alias() -> bool {
     cfg!(target_os = "macos")
 }

--- a/crates/openshell-driver-docker/src/tests.rs
+++ b/crates/openshell-driver-docker/src/tests.rs
@@ -382,6 +382,31 @@ fn docker_gateway_route_uses_bridge_gateway_for_linux_docker() {
     );
 }
 
+// Regression for macOS + OPENSHELL_DRIVERS=docker against a Podman-machine
+// socket (OpenShell issue #1358): the daemon looks like generic Linux, but the
+// bridge gateway IP only exists inside the VM. Binding it on the host fails
+// with EADDRNOTAVAIL during gateway startup.
+#[test]
+#[cfg(target_os = "macos")]
+fn docker_gateway_route_uses_host_gateway_for_podman_machine_on_macos() {
+    let info = SystemInfo {
+        // Observed values when docker CLI talks to podman machine API.
+        operating_system: Some("fedora".to_string()),
+        name: Some("localhost.localdomain".to_string()),
+        labels: None,
+        ..Default::default()
+    };
+
+    let route = docker_gateway_route(
+        &info,
+        // Typical Podman machine bridge gateway; not routable on the macOS host.
+        IpAddr::V4(Ipv4Addr::new(10, 89, 0, 1)),
+        DEFAULT_SERVER_PORT,
+        None,
+    );
+    assert_eq!(route, DockerGatewayRoute::HostGateway);
+}
+
 #[test]
 fn docker_gateway_route_uses_host_gateway_when_host_runtime_requires_it() {
     let info = SystemInfo {


### PR DESCRIPTION
## Summary

Add a macOS-only regression test for Podman machine bridging (#1358), picking up where #1653 left off per @drew's review.

## What happened in #1653

#1653 added both a regression test and a redundant macOS early-return in `uses_host_gateway_alias()`. However, #1516 had already extracted the macOS logic into `host_runtime_requires_host_gateway_alias()`, making the `uses_host_gateway_alias()` change unnecessary.

## What this PR does

- **Doc-comments** `host_runtime_requires_host_gateway_alias()` to explain why macOS always routes via host-gateway
- **Adds the Podman-machine regression test** (`docker_gateway_route_uses_host_gateway_for_podman_machine_on_macos`), gated on `#[cfg(target_os = "macos")]`, which reproduces the exact failure from #1358: a Podman machine daemon reporting `fedora` / `localhost.localdomain` / no labels routes callbacks via `HostGateway` instead of `Bridge`

No changes to `uses_host_gateway_alias()` — the routing behavior is unchanged.

## Related

- Closes #1358
- Supersedes #1653

cc @akram @drew @johntmyers