### PR TITLE
feat(providersv2): inject static auth headers from v2 provider profiles

### DIFF
--- a/crates/openshell-providers/src/profiles.rs
+++ b/crates/openshell-providers/src/profiles.rs
@@ -1643,6 +1643,9 @@ fn validate_token_grant_header_name(credential: &CredentialProfile) -> Result<()
 fn validate_static_credential_header_name(credential: &CredentialProfile) -> Result<(), String> {
     let header_name = match credential.auth_style.trim().to_ascii_lowercase().as_str() {
         "bearer" if credential.header_name.trim().is_empty() => "Authorization",
+        "header" if credential.header_name.trim().is_empty() => {
+            return Err("credential auth_style header requires header_name".to_string());
+        }
         "bearer" | "header" => credential.header_name.trim(),
         _ => return Ok(()),
     };
@@ -2466,6 +2469,33 @@ endpoints:
         assert!(
             diagnostics.is_empty(),
             "valid static credential header should produce no diagnostics, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn validate_profile_set_rejects_static_credential_header_style_missing_header_name() {
+        let profile = parse_profile_yaml(
+            r"
+id: header-style-no-name
+display_name: Header Style No Name
+credentials:
+  - name: api_token
+    env_vars: [API_TOKEN]
+    auth_style: header
+",
+        )
+        .expect("profile should parse");
+
+        let diagnostics = validate_profile_set(&[("header-no-name.yaml".to_string(), profile)]);
+        let diagnostic = diagnostics
+            .iter()
+            .find(|d| {
+                d.field == "credentials.header_name" && d.message.contains("requires header_name")
+            })
+            .expect("empty header_name with auth_style header should be rejected");
+        assert_eq!(
+            diagnostic.message,
+            "credential auth_style header requires header_name"
         );
     }
 

--- a/crates/openshell-providers/src/profiles.rs
+++ b/crates/openshell-providers/src/profiles.rs
@@ -1325,6 +1325,16 @@ pub fn validate_profile_set(
                     message,
                 ));
             }
+            if credential.token_grant.is_none()
+                && let Err(message) = validate_static_credential_header_name(credential)
+            {
+                diagnostics.push(ProfileValidationDiagnostic::error(
+                    source,
+                    profile_id,
+                    "credentials.header_name",
+                    message,
+                ));
+            }
         }
 
         for (index, endpoint) in profile.endpoints.iter().enumerate() {
@@ -1627,6 +1637,19 @@ fn validate_token_grant_header_name(credential: &CredentialProfile) -> Result<()
         "" | "bearer" | "header" => credential.header_name.trim(),
         _ => return Ok(()),
     };
+    validate_credential_header_name(header_name, "token_grant")
+}
+
+fn validate_static_credential_header_name(credential: &CredentialProfile) -> Result<(), String> {
+    let header_name = match credential.auth_style.trim().to_ascii_lowercase().as_str() {
+        "bearer" if credential.header_name.trim().is_empty() => "Authorization",
+        "bearer" | "header" => credential.header_name.trim(),
+        _ => return Ok(()),
+    };
+    validate_credential_header_name(header_name, "credential")
+}
+
+fn validate_credential_header_name(header_name: &str, label: &str) -> Result<(), String> {
     if header_name.is_empty() {
         return Ok(());
     }
@@ -1651,13 +1674,14 @@ fn validate_token_grant_header_name(credential: &CredentialProfile) -> Result<()
             )
     });
     if !valid {
-        return Err("token_grant header_name is not a valid HTTP header name".to_string());
+        return Err(format!(
+            "{label} header_name is not a valid HTTP header name"
+        ));
     }
     match header_name.to_ascii_lowercase().as_str() {
-        "host" | "content-length" | "transfer-encoding" | "connection" => Err(
-            "token_grant header_name may not override HTTP framing or connection headers"
-                .to_string(),
-        ),
+        "host" | "content-length" | "transfer-encoding" | "connection" => Err(format!(
+            "{label} header_name may not override HTTP framing or connection headers"
+        )),
         _ => Ok(()),
     }
 }
@@ -2355,6 +2379,93 @@ credentials:
         assert_eq!(
             diagnostic.message,
             "token_grant header_name may not override HTTP framing or connection headers"
+        );
+    }
+
+    #[test]
+    fn validate_profile_set_rejects_static_credential_framing_header_name() {
+        let profile = parse_profile_yaml(
+            r"
+id: framing-header-static
+display_name: Framing Header Static
+credentials:
+  - name: api_token
+    env_vars: [API_TOKEN]
+    auth_style: header
+    header_name: Host
+",
+        )
+        .expect("profile should parse");
+
+        let diagnostics = validate_profile_set(&[("framing-static.yaml".to_string(), profile)]);
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| {
+                diagnostic.field == "credentials.header_name"
+                    && diagnostic.message.contains("HTTP framing")
+            })
+            .expect("framing header diagnostic should be reported for static credentials");
+
+        assert_eq!(
+            diagnostic.message,
+            "credential header_name may not override HTTP framing or connection headers"
+        );
+    }
+
+    #[test]
+    fn validate_profile_set_rejects_static_credential_invalid_header_name() {
+        let profile = parse_profile_yaml(
+            r"
+id: invalid-header-static
+display_name: Invalid Header Static
+credentials:
+  - name: api_token
+    env_vars: [API_TOKEN]
+    auth_style: header
+    header_name: 'Invalid Header'
+",
+        )
+        .expect("profile should parse");
+
+        let diagnostics =
+            validate_profile_set(&[("invalid-header-static.yaml".to_string(), profile)]);
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| {
+                diagnostic.field == "credentials.header_name"
+                    && diagnostic.message.contains("not a valid HTTP header name")
+            })
+            .expect("invalid header name diagnostic should be reported for static credentials");
+
+        assert_eq!(
+            diagnostic.message,
+            "credential header_name is not a valid HTTP header name"
+        );
+    }
+
+    #[test]
+    fn validate_profile_set_accepts_static_credential_valid_header_name() {
+        let profile = parse_profile_yaml(
+            r"
+id: valid-header-static
+display_name: Valid Header Static
+credentials:
+  - name: api_token
+    env_vars: [API_TOKEN]
+    auth_style: header
+    header_name: X-Api-Key
+endpoints:
+  - host: api.example.com
+    port: 443
+",
+        )
+        .expect("profile should parse");
+
+        let diagnostics =
+            validate_profile_set(&[("valid-header-static.yaml".to_string(), profile)]);
+        assert!(
+            diagnostics.is_empty(),
+            "valid static credential header should produce no diagnostics, got: {diagnostics:?}"
         );
     }
 

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -1220,8 +1220,12 @@ pub(super) async fn handle_get_sandbox_config(
 
     let settings = merge_effective_settings(&global_settings, &sandbox_settings)?;
     let config_revision = compute_config_revision(policy.as_ref(), &settings, policy_source);
-    let provider_env_revision =
-        compute_provider_env_revision(state.store.as_ref(), &sandbox_provider_names).await?;
+    let provider_env_revision = compute_provider_env_revision(
+        state.store.as_ref(),
+        &sandbox_provider_names,
+        providers_v2_enabled,
+    )
+    .await?;
 
     Ok(Response::new(GetSandboxConfigResponse {
         policy,
@@ -1238,9 +1242,11 @@ pub(super) async fn handle_get_sandbox_config(
 pub(super) async fn compute_provider_env_revision(
     store: &Store,
     provider_names: &[String],
+    providers_v2_enabled: bool,
 ) -> Result<u64, Status> {
     let mut hasher = Sha256::new();
     hasher.update(b"openshell-provider-env-revision-v1");
+    hasher.update([u8::from(providers_v2_enabled)]);
 
     for provider_name in provider_names {
         hasher.update(provider_name.as_bytes());
@@ -1367,6 +1373,16 @@ async fn profile_provider_policy_layers(
     Ok(layers)
 }
 
+pub async fn is_providers_v2_enabled(store: &Store) -> bool {
+    load_global_settings(store)
+        .await
+        .and_then(|s| bool_setting_enabled(&s, settings::PROVIDERS_V2_ENABLED_KEY))
+        .unwrap_or_else(|e| {
+            warn!("failed to read providers_v2_enabled setting, defaulting to false: {e}");
+            false
+        })
+}
+
 fn bool_setting_enabled(settings: &StoredSettings, key: &str) -> Result<bool, Status> {
     match settings.settings.get(key) {
         None => Ok(false),
@@ -1408,12 +1424,19 @@ pub(super) async fn handle_get_sandbox_provider_environment(
         .spec
         .ok_or_else(|| Status::internal("sandbox has no spec"))?;
 
+    let providers_v2_enabled = is_providers_v2_enabled(state.store.as_ref()).await;
+
     let provider_names = spec.providers;
     let provider_env_revision =
-        compute_provider_env_revision(state.store.as_ref(), &provider_names).await?;
-    let provider_environment =
-        super::provider::resolve_provider_environment(state.store.as_ref(), &provider_names)
+        compute_provider_env_revision(state.store.as_ref(), &provider_names, providers_v2_enabled)
             .await?;
+
+    let provider_environment = super::provider::resolve_provider_environment(
+        state.store.as_ref(),
+        &provider_names,
+        providers_v2_enabled,
+    )
+    .await?;
 
     info!(
         sandbox_id = %sandbox_id,
@@ -5171,10 +5194,13 @@ mod tests {
             .await
             .unwrap();
 
-        let first =
-            compute_provider_env_revision(state.store.as_ref(), &["work-custom-token".to_string()])
-                .await
-                .unwrap();
+        let first = compute_provider_env_revision(
+            state.store.as_ref(),
+            &["work-custom-token".to_string()],
+            false,
+        )
+        .await
+        .unwrap();
 
         tokio::time::sleep(Duration::from_millis(2)).await;
         let mut rotated_profile = token_grant_profile("https://auth.example.com/rotated-token")
@@ -5204,14 +5230,40 @@ mod tests {
         .await
         .unwrap();
 
-        let second =
-            compute_provider_env_revision(state.store.as_ref(), &["work-custom-token".to_string()])
-                .await
-                .unwrap();
+        let second = compute_provider_env_revision(
+            state.store.as_ref(),
+            &["work-custom-token".to_string()],
+            false,
+        )
+        .await
+        .unwrap();
 
         assert_ne!(
             first, second,
             "custom provider profile updates must trigger sandbox dynamic credential refresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_env_revision_changes_when_providers_v2_enabled_toggles() {
+        let state = test_server_state().await;
+        let store = state.store.as_ref();
+        let provider = test_provider("work-github", "github");
+        store.put_message(&provider).await.unwrap();
+
+        let revision_v2_off =
+            compute_provider_env_revision(store, &["work-github".to_string()], false)
+                .await
+                .unwrap();
+
+        let revision_v2_on =
+            compute_provider_env_revision(store, &["work-github".to_string()], true)
+                .await
+                .unwrap();
+
+        assert_ne!(
+            revision_v2_off, revision_v2_on,
+            "toggling providers_v2_enabled must change provider_env_revision so running sandboxes refresh"
         );
     }
 

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -1882,9 +1882,9 @@ async fn profile_attached_sandbox_diagnostics(
                 diagnostics.push(ProfileValidationDiagnostic {
                     source: source.clone(),
                     profile_id: profile_id.clone(),
-                    field: "credentials.token_grant.audience_overrides".to_string(),
+                    field: "credentials".to_string(),
                     message: format!(
-                        "{operation} would create ambiguous dynamic token grants on sandbox '{sandbox_name}': {}",
+                        "{operation} would create ambiguous provider credential bindings on sandbox '{sandbox_name}': {}",
                         err.message()
                     ),
                     severity: "error".to_string(),
@@ -3212,7 +3212,7 @@ mod tests {
         assert!(response.diagnostics.iter().any(|diagnostic| {
             diagnostic
                 .message
-                .contains("import would create ambiguous dynamic token grants")
+                .contains("import would create ambiguous provider credential bindings")
         }));
     }
 

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -5,6 +5,7 @@
 
 #![allow(clippy::result_large_err)] // gRPC handlers return Result<Response<_>, Status>
 
+use crate::grpc::policy::is_providers_v2_enabled;
 use crate::persistence::{
     ObjectId, ObjectLabels, ObjectName, ObjectType, Store, WriteCondition, generate_name,
 };
@@ -222,6 +223,9 @@ pub(super) async fn update_provider_record(
         provider.credential_expires_at_ms,
     );
 
+    // check the providers_v2_enabled flag, which affects provider validation
+    let providers_v2_enabled = is_providers_v2_enabled(store).await;
+
     // Validate BEFORE writing to prevent persisting invalid state.
     // Validate only the mutable fields (credentials/config) plus metadata and
     // attached-sandbox invariants. The immutable name/type are carried forward
@@ -230,7 +234,8 @@ pub(super) async fn update_provider_record(
     // #1347.
     super::validation::validate_object_metadata(candidate.metadata.as_ref(), "provider")?;
     validate_provider_mutable_fields(&candidate)?;
-    validate_provider_update_against_attached_sandboxes(store, &candidate).await?;
+    validate_provider_update_against_attached_sandboxes(store, &candidate, providers_v2_enabled)
+        .await?;
 
     // Serialize labels for storage
     let labels_map = candidate.object_labels();
@@ -434,6 +439,7 @@ fn merge_i64_map(
 pub(super) async fn resolve_provider_environment(
     store: &Store,
     provider_names: &[String],
+    providers_v2_enabled: bool,
 ) -> Result<ProviderEnvironment, Status> {
     if provider_names.is_empty() {
         return Ok(ProviderEnvironment::default());
@@ -442,7 +448,14 @@ pub(super) async fn resolve_provider_environment(
     let mut env = std::collections::HashMap::new();
     let mut expires = std::collections::HashMap::new();
     let now_ms = crate::persistence::current_time_ms();
-    validate_provider_environment_keys_unique_at(store, provider_names, None, now_ms).await?;
+    validate_provider_environment_keys_unique_at(
+        store,
+        provider_names,
+        None,
+        now_ms,
+        providers_v2_enabled,
+    )
+    .await?;
     let registry = openshell_providers::ProviderRegistry::new();
 
     for name in provider_names {
@@ -495,7 +508,13 @@ pub(super) async fn resolve_provider_environment(
     Ok(ProviderEnvironment {
         environment: env,
         credential_expires_at_ms: expires,
-        dynamic_credentials: resolve_dynamic_credentials(store, provider_names).await?,
+        dynamic_credentials: resolve_dynamic_credentials(
+            store,
+            provider_names,
+            providers_v2_enabled,
+            now_ms,
+        )
+        .await?,
     })
 }
 
@@ -507,6 +526,8 @@ pub(super) async fn resolve_provider_environment(
 pub(super) async fn resolve_dynamic_credentials(
     store: &Store,
     provider_names: &[String],
+    providers_v2_enabled: bool,
+    now_ms: i64,
 ) -> Result<std::collections::HashMap<String, ProviderProfileCredential>, Status> {
     if provider_names.is_empty() {
         return Ok(std::collections::HashMap::new());
@@ -534,7 +555,9 @@ pub(super) async fn resolve_dynamic_credentials(
         insert_dynamic_credentials_for_profile(
             &mut dynamic_creds,
             &profile.to_proto(),
-            provider_name,
+            &provider,
+            providers_v2_enabled,
+            now_ms,
         );
     }
 
@@ -544,10 +567,13 @@ pub(super) async fn resolve_dynamic_credentials(
 fn insert_dynamic_credentials_for_profile(
     dynamic_creds: &mut std::collections::HashMap<String, ProviderProfileCredential>,
     profile: &ProviderProfile,
-    provider_name: &str,
+    provider: &Provider,
+    providers_v2_enabled: bool,
+    now_ms: i64,
 ) {
+    let provider_name = provider.object_name();
     for credential in &profile.credentials {
-        if credential.token_grant.is_none() {
+        if !can_inject_credential(credential, provider, providers_v2_enabled, now_ms) {
             continue;
         }
         for endpoint in &profile.endpoints {
@@ -817,12 +843,14 @@ fn endpoint_path_matches(pattern: &str, path: &str) -> bool {
 pub async fn validate_provider_environment_keys_unique(
     store: &Store,
     provider_names: &[String],
+    providers_v2_enabled: bool,
 ) -> Result<(), Status> {
     validate_provider_environment_keys_unique_at(
         store,
         provider_names,
         None,
         crate::persistence::current_time_ms(),
+        providers_v2_enabled,
     )
     .await
 }
@@ -831,6 +859,7 @@ pub async fn validate_provider_credential_key_available_for_attached_sandboxes(
     store: &Store,
     provider: &Provider,
     credential_key: &str,
+    providers_v2_enabled: bool,
 ) -> Result<(), Status> {
     let mut candidate = provider.clone();
     candidate
@@ -838,12 +867,14 @@ pub async fn validate_provider_credential_key_available_for_attached_sandboxes(
         .entry(credential_key.to_string())
         .or_insert_with(|| "pending".to_string());
     candidate.credential_expires_at_ms.remove(credential_key);
-    validate_provider_update_against_attached_sandboxes(store, &candidate).await
+    validate_provider_update_against_attached_sandboxes(store, &candidate, providers_v2_enabled)
+        .await
 }
 
 pub async fn validate_provider_update_against_attached_sandboxes(
     store: &Store,
     provider: &Provider,
+    providers_v2_enabled: bool,
 ) -> Result<(), Status> {
     let provider_name = provider.object_name().to_string();
     for sandbox in sandboxes_using_provider_records(store, &provider_name).await? {
@@ -856,6 +887,7 @@ pub async fn validate_provider_update_against_attached_sandboxes(
             &spec.providers,
             Some(provider),
             crate::persistence::current_time_ms(),
+            providers_v2_enabled,
         )
         .await
         .map_err(|err| {
@@ -873,6 +905,7 @@ async fn validate_provider_environment_keys_unique_at(
     provider_names: &[String],
     candidate_provider: Option<&Provider>,
     now_ms: i64,
+    providers_v2_enabled: bool,
 ) -> Result<(), Status> {
     let mut seen = std::collections::HashMap::<String, String>::new();
     let mut dynamic_bindings = Vec::new();
@@ -899,14 +932,17 @@ async fn validate_provider_environment_keys_unique_at(
                 seen.insert(key, provider_name.clone());
             }
         }
-        dynamic_bindings.extend(dynamic_token_grant_bindings_for_provider(store, &provider).await?);
+        dynamic_bindings.extend(
+            credential_bindings_for_provider(store, &provider, providers_v2_enabled, now_ms)
+                .await?,
+        );
     }
-    validate_dynamic_token_grant_bindings_unambiguous(&dynamic_bindings)?;
+    validate_credential_bindings_unambiguous(&dynamic_bindings)?;
     Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct DynamicTokenGrantBinding {
+struct CredentialBinding {
     provider_name: String,
     credential_name: String,
     host: String,
@@ -915,33 +951,39 @@ struct DynamicTokenGrantBinding {
     score: u32,
 }
 
-async fn dynamic_token_grant_bindings_for_provider(
+async fn credential_bindings_for_provider(
     store: &Store,
     provider: &Provider,
-) -> Result<Vec<DynamicTokenGrantBinding>, Status> {
-    let provider_name = provider.object_name().to_string();
+    providers_v2_enabled: bool,
+    now_ms: i64,
+) -> Result<Vec<CredentialBinding>, Status> {
     let profile_id = normalize_provider_type(&provider.r#type).unwrap_or(provider.r#type.as_str());
     let Some(profile) = get_provider_type_profile(store, profile_id).await? else {
         return Ok(Vec::new());
     };
-    Ok(dynamic_token_grant_bindings_for_profile(
-        &provider_name,
+    Ok(credential_bindings_for_profile(
         &profile.to_proto(),
+        provider,
+        providers_v2_enabled,
+        now_ms,
     ))
 }
 
-fn dynamic_token_grant_bindings_for_profile(
-    provider_name: &str,
+fn credential_bindings_for_profile(
     profile: &ProviderProfile,
-) -> Vec<DynamicTokenGrantBinding> {
+    provider: &Provider,
+    providers_v2_enabled: bool,
+    now_ms: i64,
+) -> Vec<CredentialBinding> {
+    let provider_name = provider.object_name();
     let mut bindings = Vec::new();
     for credential in &profile.credentials {
-        if credential.token_grant.is_none() {
+        if !can_inject_credential(credential, provider, providers_v2_enabled, now_ms) {
             continue;
         }
         for endpoint in &profile.endpoints {
             for port in endpoint_ports(endpoint.port, &endpoint.ports) {
-                push_dynamic_token_grant_bindings_for_endpoint(
+                push_credential_bindings_for_endpoint(
                     &mut bindings,
                     provider_name,
                     credential,
@@ -955,15 +997,15 @@ fn dynamic_token_grant_bindings_for_profile(
     bindings
 }
 
-fn push_dynamic_token_grant_bindings_for_endpoint(
-    bindings: &mut Vec<DynamicTokenGrantBinding>,
+fn push_credential_bindings_for_endpoint(
+    bindings: &mut Vec<CredentialBinding>,
     provider_name: &str,
     credential: &ProviderProfileCredential,
     endpoint_host: &str,
     endpoint_port: u32,
     endpoint_path: &str,
 ) {
-    push_dynamic_token_grant_binding(
+    push_credential_binding(
         bindings,
         provider_name,
         &credential.name,
@@ -995,7 +1037,7 @@ fn push_dynamic_token_grant_bindings_for_endpoint(
         } else {
             override_config.path.as_str()
         };
-        push_dynamic_token_grant_binding(
+        push_credential_binding(
             bindings,
             provider_name,
             &credential.name,
@@ -1006,15 +1048,15 @@ fn push_dynamic_token_grant_bindings_for_endpoint(
     }
 }
 
-fn push_dynamic_token_grant_binding(
-    bindings: &mut Vec<DynamicTokenGrantBinding>,
+fn push_credential_binding(
+    bindings: &mut Vec<CredentialBinding>,
     provider_name: &str,
     credential_name: &str,
     host: &str,
     port: u32,
     path: &str,
 ) {
-    let candidate = DynamicTokenGrantBinding {
+    let candidate = CredentialBinding {
         provider_name: provider_name.to_string(),
         credential_name: credential_name.to_string(),
         host: host.to_ascii_lowercase(),
@@ -1027,9 +1069,7 @@ fn push_dynamic_token_grant_binding(
     }
 }
 
-fn validate_dynamic_token_grant_bindings_unambiguous(
-    bindings: &[DynamicTokenGrantBinding],
-) -> Result<(), Status> {
+fn validate_credential_bindings_unambiguous(bindings: &[CredentialBinding]) -> Result<(), Status> {
     for (index, first) in bindings.iter().enumerate() {
         for second in bindings.iter().skip(index + 1) {
             if first.provider_name == second.provider_name
@@ -1043,7 +1083,7 @@ fn validate_dynamic_token_grant_bindings_unambiguous(
                 && path_patterns_can_overlap(&first.path, &second.path)
             {
                 return Err(Status::failed_precondition(format!(
-                    "dynamic token grants for '{}:{}' and '{}:{}' are ambiguous for {}:{} path selectors '{}' and '{}'; make one host/path selector more specific or attach only one matching provider",
+                    "credentials for '{}:{}' and '{}:{}' are ambiguous for {}:{} path selectors '{}' and '{}'; make one host/path selector more specific or attach only one matching provider",
                     first.provider_name,
                     first.credential_name,
                     second.provider_name,
@@ -1079,18 +1119,27 @@ async fn active_provider_environment_keys(
     Ok(keys)
 }
 
+/// Whether a single credential key is currently active: not a non-injectable
+/// special-case key, syntactically valid as an env var, and not expired.
+///
+/// Shared between `active_provider_credential_keys` (env-var resolution) and
+/// `can_inject_credential` (static injection metadata) so the two paths always
+/// agree on which keys are live.
+fn is_credential_key_active(provider: &Provider, key: &str, now_ms: i64) -> bool {
+    provider.credentials.contains_key(key)
+        && !is_non_injectable_provider_credential(provider, key)
+        && is_valid_env_key(key)
+        && provider
+            .credential_expires_at_ms
+            .get(key)
+            .is_none_or(|expires_at_ms| *expires_at_ms <= 0 || *expires_at_ms > now_ms)
+}
+
 fn active_provider_credential_keys(provider: &Provider, now_ms: i64) -> Vec<String> {
     provider
         .credentials
         .keys()
-        .filter(|key| !is_non_injectable_provider_credential(provider, key))
-        .filter(|key| is_valid_env_key(key))
-        .filter(|key| {
-            provider
-                .credential_expires_at_ms
-                .get(*key)
-                .is_none_or(|expires_at_ms| *expires_at_ms <= 0 || *expires_at_ms > now_ms)
-        })
+        .filter(|key| is_credential_key_active(provider, key, now_ms))
         .cloned()
         .collect()
 }
@@ -1110,6 +1159,38 @@ pub(super) fn is_valid_env_key(key: &str) -> bool {
         return false;
     }
     bytes.all(|byte| byte == b'_' || byte.is_ascii_alphanumeric())
+}
+
+// Which static cred auth styles we currently support injecting into the sandbox
+const INJECTABLE_STATIC_AUTH_STYLES: &[&str] = &["bearer", "header"];
+
+/// Whether a credential should produce injection bindings for this provider.
+///
+/// Token grants are unconditional — they resolve via SPIFFE, not env vars.
+/// Static credentials require (a) `providers_v2` enabled, (b) a supported
+/// `auth_style`, and (c) that the provider actually has at least one of the
+/// credential's env vars populated **and active** (not expired, valid key
+/// name, not a non-injectable special-case key).  Condition (c) matters for
+/// profiles like google-vertex-ai that declare multiple credentials targeting
+/// the same header, only one of which is active at a time.  The active-key
+/// check uses `is_credential_key_active` — the same predicate used by
+/// `active_provider_credential_keys` — so the two paths always agree.
+fn can_inject_credential(
+    cred: &ProviderProfileCredential,
+    provider: &Provider,
+    providers_v2_enabled: bool,
+    now_ms: i64,
+) -> bool {
+    if cred.token_grant.is_some() {
+        return true;
+    }
+    providers_v2_enabled
+        && INJECTABLE_STATIC_AUTH_STYLES
+            .contains(&cred.auth_style.trim().to_ascii_lowercase().as_str())
+        && cred
+            .env_vars
+            .iter()
+            .any(|env| is_credential_key_active(provider, env, now_ms))
 }
 
 // ---------------------------------------------------------------------------
@@ -1728,6 +1809,7 @@ async fn profile_attached_sandbox_diagnostics(
     profiles: &[(String, ProviderTypeProfile)],
     operation: &str,
 ) -> Result<Vec<ProfileValidationDiagnostic>, Status> {
+    let now_ms = crate::persistence::current_time_ms();
     let mut candidate_profiles =
         std::collections::HashMap::<String, (String, ProviderProfile)>::new();
     for (source, profile) in profiles {
@@ -1748,6 +1830,9 @@ async fn profile_attached_sandbox_diagnostics(
             .then_some(sandbox)
     })
     .await?;
+
+    let providers_v2_enabled = is_providers_v2_enabled(store).await;
+
     let mut diagnostics = Vec::new();
     for sandbox in sandboxes {
         let sandbox_name = sandbox.object_name().to_string();
@@ -1766,23 +1851,33 @@ async fn profile_attached_sandbox_diagnostics(
             let profile_id =
                 normalize_provider_type(&provider.r#type).unwrap_or(provider.r#type.as_str());
             if let Some((source, profile)) = candidate_profiles.get(profile_id) {
-                bindings.extend(dynamic_token_grant_bindings_for_profile(
-                    provider.object_name(),
+                bindings.extend(credential_bindings_for_profile(
                     profile,
+                    &provider,
+                    providers_v2_enabled,
+                    now_ms,
                 ));
                 let used = (source.clone(), profile_id.to_string());
                 if !imported_profiles_used.contains(&used) {
                     imported_profiles_used.push(used);
                 }
             } else {
-                bindings.extend(dynamic_token_grant_bindings_for_provider(store, &provider).await?);
+                bindings.extend(
+                    credential_bindings_for_provider(
+                        store,
+                        &provider,
+                        providers_v2_enabled,
+                        now_ms,
+                    )
+                    .await?,
+                );
             }
         }
 
         if imported_profiles_used.is_empty() {
             continue;
         }
-        if let Err(err) = validate_dynamic_token_grant_bindings_unambiguous(&bindings) {
+        if let Err(err) = validate_credential_bindings_unambiguous(&bindings) {
             for (source, profile_id) in &imported_profiles_used {
                 diagnostics.push(ProfileValidationDiagnostic {
                     source: source.clone(),
@@ -2058,10 +2153,13 @@ pub(super) async fn handle_configure_provider_refresh(
         .await
         .map_err(|e| Status::internal(format!("fetch provider failed: {e}")))?
         .ok_or_else(|| Status::not_found("provider not found"))?;
+
+    let providers_v2_enabled = is_providers_v2_enabled(state.store.as_ref()).await;
     validate_provider_credential_key_available_for_attached_sandboxes(
         state.store.as_ref(),
         &provider,
         credential_key,
+        providers_v2_enabled,
     )
     .await?;
     let refresh_defaults =
@@ -2470,8 +2568,9 @@ mod tests {
             discovery: None,
         };
 
+        let provider = test_provider("keycloak", &[]);
         let mut dynamic_creds = HashMap::new();
-        insert_dynamic_credentials_for_profile(&mut dynamic_creds, &profile, "keycloak");
+        insert_dynamic_credentials_for_profile(&mut dynamic_creds, &profile, &provider, false, 0);
 
         assert_eq!(dynamic_creds.len(), 4);
         for (host, audience) in service_audiences {
@@ -2481,6 +2580,350 @@ mod tests {
             assert_eq!(grant.scopes, vec![audience.to_string()]);
             assert!(grant.audience_overrides.is_empty());
         }
+    }
+
+    #[test]
+    fn static_credentials_included_when_flag_enabled() {
+        let credential = ProviderProfileCredential {
+            name: "api_token".to_string(),
+            env_vars: vec!["GITHUB_TOKEN".to_string(), "GH_TOKEN".to_string()],
+            auth_style: "bearer".to_string(),
+            header_name: "Authorization".to_string(),
+            token_grant: None,
+            ..Default::default()
+        };
+        let profile = ProviderProfile {
+            id: "github".to_string(),
+            display_name: "GitHub".to_string(),
+            description: String::new(),
+            category: ProviderProfileCategory::SourceControl as i32,
+            credentials: vec![credential],
+            endpoints: vec![
+                NetworkEndpoint {
+                    host: "api.github.com".to_string(),
+                    port: 443,
+                    ..Default::default()
+                },
+                NetworkEndpoint {
+                    host: "github.com".to_string(),
+                    port: 443,
+                    ..Default::default()
+                },
+            ],
+            binaries: Vec::new(),
+            inference_capable: false,
+            discovery: None,
+            resource_version: 0,
+        };
+
+        let provider = test_provider("my-github", &["GITHUB_TOKEN"]);
+
+        // With flag off, no static credentials emitted.
+        let mut creds_off = HashMap::new();
+        insert_dynamic_credentials_for_profile(&mut creds_off, &profile, &provider, false, 0);
+        assert!(
+            creds_off.is_empty(),
+            "static credentials should be skipped when flag is false"
+        );
+
+        // With flag on, static credentials are emitted for each endpoint.
+        let mut creds_on = HashMap::new();
+        insert_dynamic_credentials_for_profile(&mut creds_on, &profile, &provider, true, 0);
+        assert_eq!(creds_on.len(), 2, "one entry per endpoint expected");
+
+        let api_key = dynamic_credential_key("api.github.com", 443, "", "my-github", "api_token");
+        let web_key = dynamic_credential_key("github.com", 443, "", "my-github", "api_token");
+        let api_cred = &creds_on[&api_key];
+        assert_eq!(api_cred.auth_style, "bearer");
+        assert_eq!(api_cred.env_vars, vec!["GITHUB_TOKEN", "GH_TOKEN"]);
+        assert!(api_cred.token_grant.is_none());
+        assert!(creds_on.contains_key(&web_key));
+    }
+
+    #[test]
+    fn static_credentials_flag_does_not_affect_token_grants() {
+        let credential = ProviderProfileCredential {
+            name: "access_token".to_string(),
+            env_vars: Vec::new(),
+            auth_style: "bearer".to_string(),
+            header_name: "Authorization".to_string(),
+            token_grant: Some(ProviderCredentialTokenGrant {
+                token_endpoint: "https://auth.example.com/token".to_string(),
+                audience: "api://default".to_string(),
+                jwt_svid_audience: "https://auth.example.com".to_string(),
+                client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                    .to_string(),
+                scopes: vec!["read".to_string()],
+                cache_ttl_seconds: 300,
+                audience_overrides: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        let profile = ProviderProfile {
+            id: "example".to_string(),
+            display_name: "Example".to_string(),
+            description: String::new(),
+            category: ProviderProfileCategory::Other as i32,
+            credentials: vec![credential],
+            endpoints: vec![NetworkEndpoint {
+                host: "api.example.com".to_string(),
+                port: 443,
+                ..Default::default()
+            }],
+            binaries: Vec::new(),
+            inference_capable: false,
+            discovery: None,
+            resource_version: 0,
+        };
+
+        let provider = test_provider("example", &[]);
+        let mut creds_off = HashMap::new();
+        insert_dynamic_credentials_for_profile(&mut creds_off, &profile, &provider, false, 0);
+        let mut creds_on = HashMap::new();
+        insert_dynamic_credentials_for_profile(&mut creds_on, &profile, &provider, true, 0);
+
+        assert_eq!(
+            creds_off.len(),
+            1,
+            "token grant should be emitted regardless of flag"
+        );
+        assert_eq!(creds_off.len(), creds_on.len());
+        let key = dynamic_credential_key("api.example.com", 443, "", "example", "access_token");
+        assert!(creds_off[&key].token_grant.is_some());
+        assert!(creds_on[&key].token_grant.is_some());
+    }
+
+    #[test]
+    fn multi_credential_profile_without_auth_style_not_injected() {
+        // Simulates a Codex-like profile: multiple credentials, none with auth_style.
+        let credentials = vec![
+            ProviderProfileCredential {
+                name: "access_token".to_string(),
+                env_vars: vec!["CODEX_AUTH_ACCESS_TOKEN".to_string()],
+                ..Default::default()
+            },
+            ProviderProfileCredential {
+                name: "refresh_token".to_string(),
+                env_vars: vec!["CODEX_AUTH_REFRESH_TOKEN".to_string()],
+                ..Default::default()
+            },
+            ProviderProfileCredential {
+                name: "account_id".to_string(),
+                env_vars: vec!["CODEX_AUTH_ACCOUNT_ID".to_string()],
+                ..Default::default()
+            },
+        ];
+        let profile = ProviderProfile {
+            id: "codex-like".to_string(),
+            display_name: "Codex-like".to_string(),
+            credentials,
+            endpoints: vec![
+                NetworkEndpoint {
+                    host: "api.openai.com".to_string(),
+                    port: 443,
+                    ..Default::default()
+                },
+                NetworkEndpoint {
+                    host: "auth.openai.com".to_string(),
+                    port: 443,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let provider = test_provider("codex-like", &[]);
+        let mut creds = HashMap::new();
+        insert_dynamic_credentials_for_profile(&mut creds, &profile, &provider, true, 0);
+
+        assert!(
+            creds.is_empty(),
+            "credentials without explicit auth_style should not be injected even with v2 enabled"
+        );
+    }
+
+    #[test]
+    fn vertex_only_active_token_source_produces_bindings() {
+        // Simulates google-vertex-ai: two credentials both target Authorization
+        // on the same endpoints, but only one has an active env var in the
+        // provider.  Without the active-env-var gate, both would emit bindings
+        // and cause a false ambiguity rejection.
+        let sa_credential = ProviderProfileCredential {
+            name: "service_account_token".to_string(),
+            env_vars: vec![
+                "GOOGLE_VERTEX_AI_SERVICE_ACCOUNT_TOKEN".to_string(),
+                "VERTEX_AI_SERVICE_ACCOUNT_TOKEN".to_string(),
+            ],
+            auth_style: "bearer".to_string(),
+            header_name: "Authorization".to_string(),
+            token_grant: None,
+            ..Default::default()
+        };
+        let adc_credential = ProviderProfileCredential {
+            name: "gcloud_adc_token".to_string(),
+            env_vars: vec![
+                "GOOGLE_VERTEX_AI_TOKEN".to_string(),
+                "VERTEX_AI_TOKEN".to_string(),
+            ],
+            auth_style: "bearer".to_string(),
+            header_name: "Authorization".to_string(),
+            token_grant: None,
+            ..Default::default()
+        };
+        let profile = ProviderProfile {
+            id: "google-vertex-ai".to_string(),
+            display_name: "Google Vertex AI".to_string(),
+            credentials: vec![sa_credential, adc_credential],
+            endpoints: vec![NetworkEndpoint {
+                host: "us-central1-aiplatform.googleapis.com".to_string(),
+                port: 443,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        // Only the service-account token is active.
+        let provider = test_provider("my-vertex", &["GOOGLE_VERTEX_AI_SERVICE_ACCOUNT_TOKEN"]);
+        let mut creds = HashMap::new();
+        insert_dynamic_credentials_for_profile(&mut creds, &profile, &provider, true, 0);
+        assert_eq!(
+            creds.len(),
+            1,
+            "only the active credential should produce a binding"
+        );
+        let key = dynamic_credential_key(
+            "us-central1-aiplatform.googleapis.com",
+            443,
+            "",
+            "my-vertex",
+            "service_account_token",
+        );
+        assert!(creds.contains_key(&key));
+
+        // Neither token source is active — no bindings at all.
+        let provider_none = test_provider("my-vertex", &[]);
+        let mut creds_none = HashMap::new();
+        insert_dynamic_credentials_for_profile(&mut creds_none, &profile, &provider_none, true, 0);
+        assert!(
+            creds_none.is_empty(),
+            "no bindings when no active env var is present"
+        );
+    }
+
+    #[test]
+    fn expired_static_credential_excluded_from_bindings() {
+        // Simulates google-vertex-ai with two token sources targeting the same
+        // header on the same endpoint.  One token source is expired and the
+        // other is active.  Only the active one should produce bindings —
+        // matching the filtering done by active_provider_credential_keys.
+        let sa_credential = ProviderProfileCredential {
+            name: "service_account_token".to_string(),
+            env_vars: vec!["VERTEX_SA_TOKEN".to_string()],
+            auth_style: "bearer".to_string(),
+            header_name: "Authorization".to_string(),
+            token_grant: None,
+            ..Default::default()
+        };
+        let adc_credential = ProviderProfileCredential {
+            name: "gcloud_adc_token".to_string(),
+            env_vars: vec!["VERTEX_ADC_TOKEN".to_string()],
+            auth_style: "bearer".to_string(),
+            header_name: "Authorization".to_string(),
+            token_grant: None,
+            ..Default::default()
+        };
+        let profile = ProviderProfile {
+            id: "google-vertex-ai".to_string(),
+            display_name: "Google Vertex AI".to_string(),
+            credentials: vec![sa_credential, adc_credential],
+            endpoints: vec![NetworkEndpoint {
+                host: "us-central1-aiplatform.googleapis.com".to_string(),
+                port: 443,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let now_ms = 1_000_000;
+        // Both keys present, but VERTEX_SA_TOKEN is expired.
+        let mut provider = test_provider("my-vertex", &["VERTEX_SA_TOKEN", "VERTEX_ADC_TOKEN"]);
+        provider.credential_expires_at_ms = [
+            ("VERTEX_SA_TOKEN".to_string(), now_ms - 60_000),
+            ("VERTEX_ADC_TOKEN".to_string(), now_ms + 60_000),
+        ]
+        .into_iter()
+        .collect();
+
+        let mut creds = HashMap::new();
+        insert_dynamic_credentials_for_profile(&mut creds, &profile, &provider, true, now_ms);
+        assert_eq!(
+            creds.len(),
+            1,
+            "only the non-expired credential should produce a binding"
+        );
+        let key = dynamic_credential_key(
+            "us-central1-aiplatform.googleapis.com",
+            443,
+            "",
+            "my-vertex",
+            "gcloud_adc_token",
+        );
+        assert!(
+            creds.contains_key(&key),
+            "active (non-expired) credential should produce binding"
+        );
+
+        // Both expired — no bindings at all.
+        provider.credential_expires_at_ms = [
+            ("VERTEX_SA_TOKEN".to_string(), now_ms - 60_000),
+            ("VERTEX_ADC_TOKEN".to_string(), now_ms - 30_000),
+        ]
+        .into_iter()
+        .collect();
+        let mut creds_expired = HashMap::new();
+        insert_dynamic_credentials_for_profile(
+            &mut creds_expired,
+            &profile,
+            &provider,
+            true,
+            now_ms,
+        );
+        assert!(
+            creds_expired.is_empty(),
+            "no bindings when all credentials are expired"
+        );
+    }
+
+    async fn import_static_credential_profile(
+        state: &Arc<ServerState>,
+        id: &str,
+        host: &str,
+        port: u32,
+        path: &str,
+    ) {
+        // Derive env_var from profile id so it matches the credential key in
+        // create_static_credential_provider (which uses provider_type = id).
+        let env_var = format!("{}_TOKEN", id.to_ascii_uppercase().replace('-', "_"));
+        let mut profile = custom_profile(id);
+        profile.credentials = vec![static_credential("api_token", &env_var, true)];
+        profile.endpoints = vec![NetworkEndpoint {
+            host: host.to_string(),
+            port,
+            path: path.to_string(),
+            protocol: "rest".to_string(),
+            ..Default::default()
+        }];
+        handle_import_provider_profiles(
+            state,
+            Request::new(ImportProviderProfilesRequest {
+                profiles: vec![ProviderProfileImportItem {
+                    profile: Some(profile),
+                    source: format!("{id}.yaml"),
+                }],
+            }),
+        )
+        .await
+        .unwrap();
     }
 
     async fn import_token_grant_profile(
@@ -2537,6 +2980,60 @@ mod tests {
         .unwrap()
     }
 
+    async fn create_static_credential_provider(
+        store: &Store,
+        name: &str,
+        provider_type: &str,
+    ) -> Provider {
+        // Derive the credential key from provider_type to match the profile's
+        // env_var (import_static_credential_profile uses the same derivation).
+        // Different profile ids produce unique env_vars, avoiding the env-key
+        // uniqueness check while still satisfying can_inject_credential's
+        // active-env-var gate.
+        let credential_key = format!(
+            "{}_TOKEN",
+            provider_type.to_ascii_uppercase().replace('-', "_")
+        );
+        create_provider_record(
+            store,
+            Provider {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: String::new(),
+                    name: name.to_string(),
+                    created_at_ms: 1_000_000,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                }),
+                r#type: provider_type.to_string(),
+                credentials: std::iter::once((credential_key, "secret".to_string())).collect(),
+                config: HashMap::new(),
+                credential_expires_at_ms: HashMap::new(),
+            },
+        )
+        .await
+        .unwrap()
+    }
+
+    /// Build a minimal `Provider` for unit tests that don't need store persistence.
+    fn test_provider(name: &str, credential_keys: &[&str]) -> Provider {
+        Provider {
+            metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                id: String::new(),
+                name: name.to_string(),
+                created_at_ms: 0,
+                labels: HashMap::new(),
+                resource_version: 0,
+            }),
+            r#type: String::new(),
+            credentials: credential_keys
+                .iter()
+                .map(|k| (k.to_string(), "secret".to_string()))
+                .collect(),
+            config: HashMap::new(),
+            credential_expires_at_ms: HashMap::new(),
+        }
+    }
+
     #[tokio::test]
     async fn dynamic_token_grants_reject_equal_specificity_overlap() {
         let state = test_server_state().await;
@@ -2549,12 +3046,13 @@ mod tests {
         let err = validate_provider_environment_keys_unique(
             store,
             &["provider-a".to_string(), "provider-b".to_string()],
+            false,
         )
         .await
         .expect_err("equal-specificity dynamic grants should be ambiguous");
 
         assert_eq!(err.code(), Code::FailedPrecondition);
-        assert!(err.message().contains("dynamic token grants"));
+        assert!(err.message().contains("credential"));
         assert!(err.message().contains("ambiguous"));
     }
 
@@ -2577,9 +3075,81 @@ mod tests {
         validate_provider_environment_keys_unique(
             store,
             &["provider-default".to_string(), "provider-admin".to_string()],
+            false,
         )
         .await
         .expect("more-specific path should make dynamic grants deterministic");
+    }
+
+    #[tokio::test]
+    async fn static_credentials_reject_equal_specificity_overlap() {
+        let state = test_server_state().await;
+        let store = state.store.as_ref();
+        import_static_credential_profile(&state, "static-a", "api.example.com", 443, "").await;
+        import_static_credential_profile(&state, "static-b", "api.example.com", 443, "").await;
+        create_static_credential_provider(store, "provider-static-a", "static-a").await;
+        create_static_credential_provider(store, "provider-static-b", "static-b").await;
+
+        let err = validate_provider_environment_keys_unique(
+            store,
+            &[
+                "provider-static-a".to_string(),
+                "provider-static-b".to_string(),
+            ],
+            true,
+        )
+        .await
+        .expect_err("equal-specificity static credentials should be ambiguous");
+
+        assert_eq!(err.code(), Code::FailedPrecondition);
+        assert!(err.message().contains("credential"));
+        assert!(err.message().contains("ambiguous"));
+    }
+
+    #[tokio::test]
+    async fn static_credentials_not_checked_when_v2_disabled() {
+        let state = test_server_state().await;
+        let store = state.store.as_ref();
+        import_static_credential_profile(&state, "static-c", "api.example.com", 443, "").await;
+        import_static_credential_profile(&state, "static-d", "api.example.com", 443, "").await;
+        create_static_credential_provider(store, "provider-static-c", "static-c").await;
+        create_static_credential_provider(store, "provider-static-d", "static-d").await;
+
+        validate_provider_environment_keys_unique(
+            store,
+            &[
+                "provider-static-c".to_string(),
+                "provider-static-d".to_string(),
+            ],
+            false,
+        )
+        .await
+        .expect("static credential overlap should not be checked when v2 is disabled");
+    }
+
+    #[tokio::test]
+    async fn static_vs_token_grant_reject_equal_specificity_overlap() {
+        let state = test_server_state().await;
+        let store = state.store.as_ref();
+        import_static_credential_profile(&state, "static-mixed", "api.example.com", 443, "/v1/**")
+            .await;
+        import_token_grant_profile(&state, "grant-mixed", "api.example.com", 443, "/v1/**").await;
+        create_static_credential_provider(store, "provider-static-mixed", "static-mixed").await;
+        create_empty_token_grant_provider(store, "provider-grant-mixed", "grant-mixed").await;
+
+        let err = validate_provider_environment_keys_unique(
+            store,
+            &[
+                "provider-static-mixed".to_string(),
+                "provider-grant-mixed".to_string(),
+            ],
+            true,
+        )
+        .await
+        .expect_err("static vs token grant at equal specificity should be ambiguous");
+
+        assert_eq!(err.code(), Code::FailedPrecondition);
+        assert!(err.message().contains("ambiguous"));
     }
 
     #[tokio::test]
@@ -4978,7 +5548,9 @@ mod tests {
     #[tokio::test]
     async fn resolve_provider_env_empty_list_returns_empty() {
         let store = test_store().await;
-        let result = resolve_provider_environment(&store, &[]).await.unwrap();
+        let result = resolve_provider_environment(&store, &[], false)
+            .await
+            .unwrap();
         assert!(result.is_empty());
     }
 
@@ -5009,7 +5581,7 @@ mod tests {
         };
         create_provider_record(&store, provider).await.unwrap();
 
-        let result = resolve_provider_environment(&store, &["claude-local".to_string()])
+        let result = resolve_provider_environment(&store, &["claude-local".to_string()], false)
             .await
             .unwrap();
         assert_eq!(result.get("ANTHROPIC_API_KEY"), Some(&"sk-abc".to_string()));
@@ -5027,7 +5599,7 @@ mod tests {
         .await
         .unwrap();
 
-        let result = resolve_provider_environment(&store, &["static-provider".to_string()])
+        let result = resolve_provider_environment(&store, &["static-provider".to_string()], false)
             .await
             .unwrap();
 
@@ -5064,9 +5636,10 @@ mod tests {
         };
         create_provider_record(&store, provider).await.unwrap();
 
-        let result = resolve_provider_environment(&store, &["expiring-provider".to_string()])
-            .await
-            .unwrap();
+        let result =
+            resolve_provider_environment(&store, &["expiring-provider".to_string()], false)
+                .await
+                .unwrap();
         assert_eq!(result.get("FRESH_TOKEN"), Some(&"fresh".to_string()));
         assert!(!result.contains_key("STALE_TOKEN"));
         assert_eq!(
@@ -5078,7 +5651,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_provider_env_unknown_name_returns_error() {
         let store = test_store().await;
-        let err = resolve_provider_environment(&store, &["nonexistent".to_string()])
+        let err = resolve_provider_environment(&store, &["nonexistent".to_string()], false)
             .await
             .unwrap_err();
         assert_eq!(err.code(), Code::FailedPrecondition);
@@ -5109,7 +5682,7 @@ mod tests {
         };
         create_provider_record(&store, provider).await.unwrap();
 
-        let result = resolve_provider_environment(&store, &["test-provider".to_string()])
+        let result = resolve_provider_environment(&store, &["test-provider".to_string()], false)
             .await
             .unwrap();
         assert_eq!(result.get("VALID_KEY"), Some(&"value".to_string()));
@@ -5165,6 +5738,7 @@ mod tests {
         let result = resolve_provider_environment(
             &store,
             &["claude-local".to_string(), "gitlab-local".to_string()],
+            false,
         )
         .await
         .unwrap();
@@ -5220,6 +5794,7 @@ mod tests {
         let err = resolve_provider_environment(
             &store,
             &["provider-a".to_string(), "provider-b".to_string()],
+            false,
         )
         .await
         .unwrap_err();
@@ -5263,7 +5838,7 @@ mod tests {
         .await
         .unwrap();
 
-        let result = resolve_provider_environment(&store, &["vertex-local".to_string()])
+        let result = resolve_provider_environment(&store, &["vertex-local".to_string()], false)
             .await
             .unwrap();
 
@@ -5336,7 +5911,7 @@ mod tests {
         .await
         .unwrap();
 
-        let result = resolve_provider_environment(&store, &["vertex-bootstrap".to_string()])
+        let result = resolve_provider_environment(&store, &["vertex-bootstrap".to_string()], false)
             .await
             .unwrap();
 
@@ -5373,7 +5948,7 @@ mod tests {
         .await
         .unwrap();
 
-        let result = resolve_provider_environment(&store, &["vertex-no-config".to_string()])
+        let result = resolve_provider_environment(&store, &["vertex-no-config".to_string()], false)
             .await
             .unwrap();
 
@@ -5431,7 +6006,7 @@ mod tests {
         .await
         .unwrap();
 
-        let result = resolve_provider_environment(&store, &["vertex-collision".to_string()])
+        let result = resolve_provider_environment(&store, &["vertex-collision".to_string()], false)
             .await
             .unwrap();
 
@@ -5465,7 +6040,7 @@ mod tests {
         .await
         .unwrap();
 
-        let result = resolve_provider_environment(&store, &["openai-local".to_string()])
+        let result = resolve_provider_environment(&store, &["openai-local".to_string()], false)
             .await
             .unwrap();
 
@@ -5623,7 +6198,7 @@ mod tests {
             .unwrap()
             .unwrap();
         let spec = loaded.spec.unwrap();
-        let env = resolve_provider_environment(&store, &spec.providers)
+        let env = resolve_provider_environment(&store, &spec.providers, false)
             .await
             .unwrap();
 
@@ -5656,7 +6231,7 @@ mod tests {
             .unwrap()
             .unwrap();
         let spec = loaded.spec.unwrap();
-        let env = resolve_provider_environment(&store, &spec.providers)
+        let env = resolve_provider_environment(&store, &spec.providers, false)
             .await
             .unwrap();
 

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -3538,7 +3538,7 @@ mod tests {
         assert!(response.diagnostics.iter().any(|diagnostic| {
             diagnostic
                 .message
-                .contains("update would create ambiguous dynamic token grants")
+                .contains("update would create ambiguous provider credential bindings")
         }));
     }
 

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::cast_possible_wrap)] // Intentional u32->i32 conversions for proto compat
 
 use crate::ServerState;
+use crate::grpc::policy::is_providers_v2_enabled;
 use crate::persistence::{ObjectType, WriteCondition, generate_name};
 use futures::future;
 use openshell_core::proto::{
@@ -149,7 +150,13 @@ async fn handle_create_sandbox_inner(
             .map_err(|e| Status::internal(format!("fetch provider failed: {e}")))?
             .ok_or_else(|| Status::failed_precondition(format!("provider '{name}' not found")))?;
     }
-    validate_provider_environment_keys_unique(state.store.as_ref(), &spec.providers).await?;
+    let providers_v2_enabled = is_providers_v2_enabled(state.store.as_ref()).await;
+    validate_provider_environment_keys_unique(
+        state.store.as_ref(),
+        &spec.providers,
+        providers_v2_enabled,
+    )
+    .await?;
 
     // Ensure the template always carries the resolved image.
     let mut spec = spec;
@@ -356,8 +363,13 @@ pub(super) async fn handle_attach_sandbox_provider(
         candidate_spec.providers.push(request.provider_name.clone());
     }
     validate_sandbox_spec(&request.sandbox_name, &candidate_spec)?;
-    validate_provider_environment_keys_unique(state.store.as_ref(), &candidate_spec.providers)
-        .await?;
+    let providers_v2_enabled = is_providers_v2_enabled(state.store.as_ref()).await;
+    validate_provider_environment_keys_unique(
+        state.store.as_ref(),
+        &candidate_spec.providers,
+        providers_v2_enabled,
+    )
+    .await?;
 
     let provider_name = request.provider_name.clone();
     let attached = Arc::new(AtomicBool::new(false));

--- a/crates/openshell-server/src/provider_refresh.rs
+++ b/crates/openshell-server/src/provider_refresh.rs
@@ -414,8 +414,13 @@ async fn apply_minted_credential(
     } else {
         updated.credential_expires_at_ms.remove(credential_key);
     }
-    crate::grpc::provider::validate_provider_update_against_attached_sandboxes(store, &updated)
-        .await?;
+    let providers_v2_enabled = crate::grpc::policy::is_providers_v2_enabled(store).await;
+    crate::grpc::provider::validate_provider_update_against_attached_sandboxes(
+        store,
+        &updated,
+        providers_v2_enabled,
+    )
+    .await?;
     store
         .update_message_cas::<Provider, _>(provider.object_id(), 0, |current| {
             current

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -450,8 +450,23 @@ where
         let _ = &eval_target;
 
         if allowed || (config.enforcement == EnforcementMode::Audit && !force_deny) {
+            let req_with_auth =
+                match crate::l7::token_grant_injection::inject_if_needed(req, ctx).await {
+                    Ok(req) => req,
+                    Err(e) => {
+                        warn!(
+                            host = %ctx.host,
+                            port = ctx.port,
+                            error = %e,
+                            "credential injection failed in route-selected L7 relay"
+                        );
+                        write_bad_gateway_response(client).await?;
+                        return Ok(());
+                    }
+                };
+
             let outcome = crate::l7::rest::relay_http_request_with_options_guarded(
-                &req,
+                &req_with_auth,
                 client,
                 upstream,
                 crate::l7::rest::RelayRequestOptions {
@@ -480,7 +495,7 @@ where
                         ctx,
                         websocket_request,
                         &redacted_target,
-                        &req.query_params,
+                        &req_with_auth.query_params,
                         Some(&engine),
                     );
                     options.websocket.permessage_deflate = websocket_permessage_deflate;
@@ -911,7 +926,7 @@ where
                             host = %ctx.host,
                             port = ctx.port,
                             error = %e,
-                            "Token grant failed in L7 relay"
+                            "credential injection failed in L7 relay"
                         );
                         write_bad_gateway_response(client).await?;
                         return Ok(());
@@ -1336,8 +1351,23 @@ where
         let _ = &eval_target;
 
         if allowed || (config.enforcement == EnforcementMode::Audit && !force_deny) {
+            let req_with_auth =
+                match crate::l7::token_grant_injection::inject_if_needed(req, ctx).await {
+                    Ok(req) => req,
+                    Err(e) => {
+                        warn!(
+                            host = %ctx.host,
+                            port = ctx.port,
+                            error = %e,
+                            "credential injection failed in GraphQL L7 relay"
+                        );
+                        write_bad_gateway_response(client).await?;
+                        return Ok(());
+                    }
+                };
+
             let outcome = crate::l7::rest::relay_http_request_with_resolver_guarded(
-                &req,
+                &req_with_auth,
                 client,
                 upstream,
                 ctx.secret_resolver.as_deref(),
@@ -1764,7 +1794,7 @@ where
                     host = %ctx.host,
                     port = ctx.port,
                     error = %e,
-                    "Token grant failed in passthrough relay"
+                    "credential injection failed in passthrough relay"
                 );
                 write_bad_gateway_response(client).await?;
                 return Ok(());

--- a/crates/openshell-supervisor-network/src/l7/token_grant_injection.rs
+++ b/crates/openshell-supervisor-network/src/l7/token_grant_injection.rs
@@ -259,6 +259,10 @@ fn inject_static_credential(
 /// Fail-closed check: reject injection if the request already has a
 /// placeholder-based value for the header this credential targets.
 /// Applies to both token grant and static credential paths.
+///
+/// This function operates byte-wise so that non-UTF-8 obs-text bytes
+/// elsewhere in the header block do not cause the check to be silently
+/// skipped.
 fn check_placeholder_collision(
     raw_header: &[u8],
     cred: &ProviderProfileCredential,
@@ -280,26 +284,59 @@ fn check_placeholder_collision(
     if header_name.is_empty() {
         return Ok(());
     }
-    if let Ok(header_block) = std::str::from_utf8(raw_header) {
-        let end = header_block.find("\r\n\r\n").unwrap_or(header_block.len());
-        for line in header_block[..end].split("\r\n").skip(1) {
-            if let Some((name, val)) = line.split_once(':')
-                && name.trim().eq_ignore_ascii_case(header_name)
-                && openshell_core::secrets::contains_reserved_credential_marker(val)
-            {
-                return Err(miette!(
-                    "credential injection rejected: header '{}' on {}:{} already \
-                     contains a placeholder-based value from provider {}; remove \
-                     the placeholder or the profile credential to resolve the conflict",
-                    header_name,
-                    host,
-                    port,
-                    provider_key,
-                ));
-            }
+    let header_name_bytes = header_name.as_bytes();
+    let placeholder_marker = openshell_core::secrets::PLACEHOLDER_PREFIX_PUBLIC.as_bytes();
+    let alias_marker = openshell_core::secrets::PROVIDER_ALIAS_MARKER_PUBLIC.as_bytes();
+
+    // Find the end of the header block (\r\n\r\n) so we don't scan the body.
+    let header_end = raw_header
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .unwrap_or(raw_header.len());
+
+    // Split header block into lines (skip the request line).
+    for line in raw_header[..header_end].split(|&b| b == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        let Some(colon_pos) = line.iter().position(|&b| b == b':') else {
+            continue;
+        };
+        let name = trim_ascii(&line[..colon_pos]);
+        if !name.eq_ignore_ascii_case(header_name_bytes) {
+            continue;
+        }
+        let value = &line[colon_pos + 1..];
+        if contains_bytes(value, placeholder_marker) || contains_bytes(value, alias_marker) {
+            return Err(miette!(
+                "credential injection rejected: header '{}' on {}:{} already \
+                 contains a placeholder-based value from provider {}; remove \
+                 the placeholder or the profile credential to resolve the conflict",
+                header_name,
+                host,
+                port,
+                provider_key,
+            ));
         }
     }
     Ok(())
+}
+
+fn trim_ascii(bytes: &[u8]) -> &[u8] {
+    let start = bytes
+        .iter()
+        .position(|b| !b.is_ascii_whitespace())
+        .unwrap_or(bytes.len());
+    let end = bytes
+        .iter()
+        .rposition(|b| !b.is_ascii_whitespace())
+        .map_or(start, |p| p + 1);
+    &bytes[start..end]
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    haystack.windows(needle.len()).any(|w| w == needle)
 }
 
 fn ocsf_message_field(value: &str) -> String {
@@ -1268,5 +1305,119 @@ mod tests {
             .expect("unmatched request should pass through");
         let raw = String::from_utf8(result.raw_header).expect("UTF-8");
         assert!(!raw.contains("Authorization"));
+    }
+
+    #[tokio::test]
+    async fn inject_static_credential_rejects_placeholder_collision_with_non_utf8_obs_text() {
+        // A request with non-UTF-8 obs-text in another header must NOT cause
+        // check_placeholder_collision to skip the scan.  The Authorization
+        // header itself carries a placeholder, so the check must reject it
+        // even though the overall header block is not valid UTF-8.
+        let (ctx, _) =
+            static_credential_ctx("GITHUB_TOKEN", "ghp_secret123", "bearer", "Authorization");
+        let mut raw = b"GET /repos/owner/repo HTTP/1.1\r\nHost: api.example.com\r\n".to_vec();
+        raw.extend_from_slice(b"Authorization: Bearer openshell:resolve:env:GITHUB_TOKEN\r\n");
+        // obs-text byte (0x80) in a different header — valid HTTP but not valid UTF-8.
+        raw.extend_from_slice(b"X-Custom: value\x80rest\r\n");
+        raw.extend_from_slice(b"\r\n");
+        let req = L7Request {
+            action: "GET".to_string(),
+            target: "/repos/owner/repo".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: raw,
+            body_length: BodyLength::None,
+        };
+
+        let err = inject_if_needed(req, &ctx)
+            .await
+            .expect_err("placeholder collision must be detected despite non-UTF-8 elsewhere");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("placeholder"),
+            "error should mention placeholder conflict, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn inject_if_needed_passthrough_preserves_graphql_body_in_raw_header() {
+        // GraphQL inspection appends the full request body to raw_header.
+        // inject_if_needed must pass this through unchanged when no credentials
+        // are configured, so the relay function receives the body intact.
+        let body = b"{\"query\":\"query Viewer { viewer { login } }\"}";
+        let mut raw = b"POST /graphql HTTP/1.1\r\nHost: graphql.example.com\r\nContent-Type: application/json\r\nContent-Length: 46\r\n\r\n".to_vec();
+        raw.extend_from_slice(body);
+        let raw_clone = raw.clone();
+        let ctx = L7EvalContext {
+            host: "graphql.example.com".into(),
+            port: 443,
+            policy_name: "api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            activity_tx: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
+        };
+        let req = L7Request {
+            action: "POST".to_string(),
+            target: "/graphql".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: raw,
+            body_length: BodyLength::ContentLength(body.len() as u64),
+        };
+
+        let result = inject_if_needed(req, &ctx)
+            .await
+            .expect("no-credential passthrough should succeed");
+        assert_eq!(
+            result.raw_header, raw_clone,
+            "raw_header (including body) must be preserved exactly"
+        );
+        assert!(
+            matches!(result.body_length, BodyLength::ContentLength(n) if n == body.len() as u64),
+            "body_length must be preserved"
+        );
+    }
+
+    #[tokio::test]
+    async fn inject_static_credential_works_with_graphql_body_in_raw_header() {
+        // When a credential IS injected on a GraphQL-style request (body in
+        // raw_header), the body must be preserved after the rewritten headers.
+        let body = b"{\"query\":\"query Viewer { viewer { login } }\"}";
+        let mut raw = b"POST /graphql HTTP/1.1\r\nHost: api.example.com\r\nContent-Type: application/json\r\nContent-Length: 46\r\n\r\n".to_vec();
+        raw.extend_from_slice(body);
+        let (ctx, _) = static_credential_ctx("API_KEY", "sk-secret", "header", "x-api-key");
+        let req = L7Request {
+            action: "POST".to_string(),
+            target: "/graphql".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: raw,
+            body_length: BodyLength::ContentLength(body.len() as u64),
+        };
+
+        let result = inject_if_needed(req, &ctx)
+            .await
+            .expect("credential injection on GraphQL body-in-raw-header should succeed");
+        let raw_str = String::from_utf8(result.raw_header.clone()).expect("UTF-8");
+        assert!(
+            raw_str.contains("x-api-key: sk-secret\r\n"),
+            "injected header must be present"
+        );
+        // Body must appear after \r\n\r\n
+        let header_end = result
+            .raw_header
+            .windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .expect("must have header terminator");
+        let body_after = &result.raw_header[header_end + 4..];
+        assert_eq!(
+            body_after, body,
+            "body must be preserved after header injection"
+        );
+        assert!(
+            matches!(result.body_length, BodyLength::ContentLength(n) if n == body.len() as u64),
+            "body_length must be preserved"
+        );
     }
 }

--- a/crates/openshell-supervisor-network/src/l7/token_grant_injection.rs
+++ b/crates/openshell-supervisor-network/src/l7/token_grant_injection.rs
@@ -449,9 +449,7 @@ fn credential_auth_header(
         "header" => {
             let header_name = credential.header_name.trim();
             if header_name.is_empty() {
-                return Err(miette!(
-                    "credential auth_style header requires header_name"
-                ));
+                return Err(miette!("credential auth_style header requires header_name"));
             }
             validate_header_name(header_name)?;
             Ok((header_name.to_string(), access_token.to_string()))

--- a/crates/openshell-supervisor-network/src/l7/token_grant_injection.rs
+++ b/crates/openshell-supervisor-network/src/l7/token_grant_injection.rs
@@ -65,95 +65,241 @@ pub fn default_resolver() -> Arc<dyn TokenGrantResolver> {
 /// Checks for endpoint-bound token grant credentials and injects an
 /// Authorization header before forwarding the request upstream.
 pub async fn inject_if_needed(req: L7Request, ctx: &L7EvalContext) -> Result<L7Request> {
-    let request_path = req.target.split('?').next().unwrap_or(req.target.as_str());
-    let token_grant_credential = ctx.dynamic_credentials.as_ref().and_then(|dyn_creds| {
+    let request_path = req
+        .target
+        .split('?')
+        .next()
+        .unwrap_or(req.target.as_str())
+        .to_string();
+    let matched_credential = ctx.dynamic_credentials.as_ref().and_then(|dyn_creds| {
         dyn_creds.read().map_or(None, |creds_guard| {
             creds_guard
                 .iter()
                 .filter_map(|(key, cred)| {
-                    let score =
-                        dynamic_credential_key_match_score(key, &ctx.host, ctx.port, request_path)?;
-                    cred.token_grant
-                        .is_some()
-                        .then(|| (score, key.clone(), cred.clone()))
+                    let score = dynamic_credential_key_match_score(
+                        key,
+                        &ctx.host,
+                        ctx.port,
+                        &request_path,
+                    )?;
+                    Some((score, key.clone(), cred.clone()))
                 })
                 .max_by_key(|(score, key, _)| (*score, key.clone()))
                 .map(|(_, key, cred)| (key, cred))
         })
     });
 
-    if let Some((provider_key, cred)) = token_grant_credential
-        && let Some(ref token_grant) = cred.token_grant
-    {
-        let resolver = ctx
-            .token_grant_resolver
-            .as_ref()
-            .ok_or_else(|| miette!("token grant resolver unavailable"))?;
-        let request = token_grant_request(&provider_key, token_grant);
+    if let Some((provider_key, cred)) = matched_credential {
+        check_placeholder_collision(&req.raw_header, &cred, &ctx.host, ctx.port, &provider_key)?;
+        if let Some(ref token_grant) = cred.token_grant {
+            inject_token_grant(req, ctx, &request_path, &provider_key, token_grant, &cred).await
+        } else {
+            inject_static_credential(req, ctx, &request_path, &provider_key, &cred)
+        }
+    } else {
+        Ok(req)
+    }
+}
 
-        match resolver.obtain(request).await {
-            Ok(access_token) => {
-                let modified_raw_header =
-                    inject_token_grant_header(&req.raw_header, &cred, &access_token)?;
-                let provider_key = ocsf_message_field(&provider_key);
-                ocsf_emit!(
-                    HttpActivityBuilder::new(ocsf_ctx())
-                        .activity(ActivityId::Other)
-                        .action(ActionId::Allowed)
-                        .disposition(DispositionId::Allowed)
-                        .severity(SeverityId::Informational)
-                        .http_request(HttpRequest::new(
-                            &req.action,
-                            OcsfUrl::new("http", &ctx.host, request_path, ctx.port),
-                        ))
-                        .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
-                        .message(format!(
-                            "Token grant successful for {} to {}:{}",
-                            provider_key, ctx.host, ctx.port
-                        ))
-                        .build()
-                );
-                return Ok(L7Request {
-                    action: req.action,
-                    target: req.target,
-                    query_params: req.query_params,
-                    raw_header: modified_raw_header,
-                    body_length: req.body_length,
-                });
+async fn inject_token_grant(
+    req: L7Request,
+    ctx: &L7EvalContext,
+    request_path: &str,
+    provider_key: &str,
+    token_grant: &ProviderCredentialTokenGrant,
+    cred: &ProviderProfileCredential,
+) -> Result<L7Request> {
+    let resolver = ctx
+        .token_grant_resolver
+        .as_ref()
+        .ok_or_else(|| miette!("token grant resolver unavailable"))?;
+    let request = token_grant_request(provider_key, token_grant);
+
+    match resolver.obtain(request).await {
+        Ok(access_token) => {
+            let modified_raw_header =
+                inject_token_grant_header(&req.raw_header, cred, &access_token)?;
+            let provider_key = ocsf_message_field(provider_key);
+            ocsf_emit!(
+                HttpActivityBuilder::new(ocsf_ctx())
+                    .activity(ActivityId::Other)
+                    .action(ActionId::Allowed)
+                    .disposition(DispositionId::Allowed)
+                    .severity(SeverityId::Informational)
+                    .http_request(HttpRequest::new(
+                        &req.action,
+                        OcsfUrl::new("http", &ctx.host, request_path, ctx.port),
+                    ))
+                    .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+                    .message(format!(
+                        "Token grant successful for {} to {}:{}",
+                        provider_key, ctx.host, ctx.port
+                    ))
+                    .build()
+            );
+            Ok(L7Request {
+                action: req.action,
+                target: req.target,
+                query_params: req.query_params,
+                raw_header: modified_raw_header,
+                body_length: req.body_length,
+            })
+        }
+        Err(e) => {
+            warn!(
+                host = %ctx.host,
+                port = ctx.port,
+                provider = %provider_key,
+                error = %e,
+                "Token grant failed"
+            );
+            let provider_key = ocsf_message_field(provider_key);
+            ocsf_emit!(
+                HttpActivityBuilder::new(ocsf_ctx())
+                    .activity(ActivityId::Fail)
+                    .action(ActionId::Denied)
+                    .disposition(DispositionId::Blocked)
+                    .severity(SeverityId::Medium)
+                    .status(StatusId::Failure)
+                    .http_request(HttpRequest::new(
+                        &req.action,
+                        OcsfUrl::new("http", &ctx.host, request_path, ctx.port),
+                    ))
+                    .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+                    .message(format!(
+                        "Token grant failed for {} to {}:{}: {}",
+                        provider_key, ctx.host, ctx.port, e
+                    ))
+                    .build()
+            );
+            Err(miette!("Token grant failed: {}", e))
+        }
+    }
+}
+
+fn inject_static_credential(
+    req: L7Request,
+    ctx: &L7EvalContext,
+    request_path: &str,
+    provider_key: &str,
+    cred: &ProviderProfileCredential,
+) -> Result<L7Request> {
+    let Some(value) = cred.env_vars.iter().find_map(|env_var| {
+        let placeholder = format!(
+            "{}{env_var}",
+            openshell_core::secrets::PLACEHOLDER_PREFIX_PUBLIC
+        );
+        ctx.secret_resolver
+            .as_ref()
+            .and_then(|r| r.resolve_placeholder(&placeholder))
+    }) else {
+        let provider_key = ocsf_message_field(provider_key);
+        ocsf_emit!(
+            HttpActivityBuilder::new(ocsf_ctx())
+                .activity(ActivityId::Fail)
+                .action(ActionId::Denied)
+                .disposition(DispositionId::Blocked)
+                .severity(SeverityId::Medium)
+                .status(StatusId::Failure)
+                .http_request(HttpRequest::new(
+                    &req.action,
+                    OcsfUrl::new("http", &ctx.host, request_path, ctx.port),
+                ))
+                .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+                .message(format!(
+                    "No credential found for {} on provider {}",
+                    cred.name, provider_key
+                ))
+                .build()
+        );
+        return Err(miette!(
+            "no credential value found for credential '{}' on provider {}",
+            cred.name,
+            provider_key,
+        ));
+    };
+    match cred.auth_style.trim().to_ascii_lowercase().as_str() {
+        "bearer" | "header" => {
+            validate_static_credential_value(value)?;
+            let (header_name, header_value) = credential_auth_header(cred, value)?;
+            let modified_raw_header = inject_header(&req.raw_header, &header_name, &header_value)?;
+            let provider_key = ocsf_message_field(provider_key);
+            ocsf_emit!(
+                HttpActivityBuilder::new(ocsf_ctx())
+                    .activity(ActivityId::Other)
+                    .action(ActionId::Allowed)
+                    .disposition(DispositionId::Allowed)
+                    .severity(SeverityId::Informational)
+                    .http_request(HttpRequest::new(
+                        &req.action,
+                        OcsfUrl::new("http", &ctx.host, request_path, ctx.port),
+                    ))
+                    .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+                    .message(format!(
+                        "Provider credential injected for {} on {}:{}",
+                        provider_key, ctx.host, ctx.port
+                    ))
+                    .build()
+            );
+            Ok(L7Request {
+                action: req.action,
+                target: req.target,
+                query_params: req.query_params,
+                raw_header: modified_raw_header,
+                body_length: req.body_length,
+            })
+        }
+        other => Err(miette!(
+            "credential injection for auth_style '{}' is not yet supported",
+            other
+        )),
+    }
+}
+
+/// Fail-closed check: reject injection if the request already has a
+/// placeholder-based value for the header this credential targets.
+/// Applies to both token grant and static credential paths.
+fn check_placeholder_collision(
+    raw_header: &[u8],
+    cred: &ProviderProfileCredential,
+    host: &str,
+    port: u16,
+    provider_key: &str,
+) -> Result<()> {
+    let header_name = match cred.auth_style.trim().to_ascii_lowercase().as_str() {
+        "" | "bearer" => {
+            if cred.header_name.trim().is_empty() {
+                "Authorization"
+            } else {
+                cred.header_name.trim()
             }
-            Err(e) => {
-                warn!(
-                    host = %ctx.host,
-                    port = ctx.port,
-                    provider = %provider_key,
-                    error = %e,
-                    "Token grant failed"
-                );
-                let provider_key = ocsf_message_field(&provider_key);
-                ocsf_emit!(
-                    HttpActivityBuilder::new(ocsf_ctx())
-                        .activity(ActivityId::Fail)
-                        .action(ActionId::Denied)
-                        .disposition(DispositionId::Blocked)
-                        .severity(SeverityId::Medium)
-                        .status(StatusId::Failure)
-                        .http_request(HttpRequest::new(
-                            &req.action,
-                            OcsfUrl::new("http", &ctx.host, request_path, ctx.port),
-                        ))
-                        .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
-                        .message(format!(
-                            "Token grant failed for {} to {}:{}: {}",
-                            provider_key, ctx.host, ctx.port, e
-                        ))
-                        .build()
-                );
-                return Err(miette!("Token grant failed: {}", e));
+        }
+        "header" => cred.header_name.trim(),
+        _ => return Ok(()),
+    };
+    if header_name.is_empty() {
+        return Ok(());
+    }
+    if let Ok(header_block) = std::str::from_utf8(raw_header) {
+        let end = header_block.find("\r\n\r\n").unwrap_or(header_block.len());
+        for line in header_block[..end].split("\r\n").skip(1) {
+            if let Some((name, val)) = line.split_once(':')
+                && name.trim().eq_ignore_ascii_case(header_name)
+                && openshell_core::secrets::contains_reserved_credential_marker(val)
+            {
+                return Err(miette!(
+                    "credential injection rejected: header '{}' on {}:{} already \
+                     contains a placeholder-based value from provider {}; remove \
+                     the placeholder or the profile credential to resolve the conflict",
+                    header_name,
+                    host,
+                    port,
+                    provider_key,
+                ));
             }
         }
     }
-
-    Ok(req)
+    Ok(())
 }
 
 fn ocsf_message_field(value: &str) -> String {
@@ -261,17 +407,32 @@ fn count_as_u32(count: usize) -> u32 {
     u32::try_from(count).unwrap_or(u32::MAX)
 }
 
+/// Validates a static credential value at the injection sink.  Unlike
+/// `validate_access_token` (token68 for token grants), this only rejects
+/// characters that would enable HTTP header injection.
+fn validate_static_credential_value(value: &str) -> Result<()> {
+    if value.is_empty() {
+        return Err(miette!("static credential value must not be empty"));
+    }
+    if value.bytes().any(|b| matches!(b, b'\r' | b'\n' | b'\0')) {
+        return Err(miette!(
+            "static credential value contains unsafe HTTP header bytes (CR, LF, or NUL)"
+        ));
+    }
+    Ok(())
+}
+
 fn inject_token_grant_header(
     raw_header: &[u8],
     credential: &ProviderProfileCredential,
     access_token: &str,
 ) -> Result<Vec<u8>> {
     crate::token_grant::validate_access_token(access_token)?;
-    let (header_name, header_value) = token_grant_header(credential, access_token)?;
+    let (header_name, header_value) = credential_auth_header(credential, access_token)?;
     inject_header(raw_header, &header_name, &header_value)
 }
 
-fn token_grant_header(
+fn credential_auth_header(
     credential: &ProviderProfileCredential,
     access_token: &str,
 ) -> Result<(String, String)> {
@@ -289,14 +450,14 @@ fn token_grant_header(
             let header_name = credential.header_name.trim();
             if header_name.is_empty() {
                 return Err(miette!(
-                    "token grant auth_style header requires header_name"
+                    "credential auth_style header requires header_name"
                 ));
             }
             validate_header_name(header_name)?;
             Ok((header_name.to_string(), access_token.to_string()))
         }
         other => Err(miette!(
-            "token grant auth_style '{other}' is not supported; use bearer or header"
+            "credential auth_style '{other}' is not supported; use bearer or header"
         )),
     }
 }
@@ -325,12 +486,12 @@ fn validate_header_name(header_name: &str) -> Result<()> {
         });
     if !valid {
         return Err(miette!(
-            "token grant header_name is not a valid HTTP header name"
+            "credential header_name is not a valid HTTP header name"
         ));
     }
     match header_name.to_ascii_lowercase().as_str() {
         "host" | "content-length" | "transfer-encoding" | "connection" => Err(miette!(
-            "token grant header_name may not override HTTP framing or connection headers"
+            "credential header_name may not override HTTP framing or connection headers"
         )),
         _ => Ok(()),
     }
@@ -662,13 +823,13 @@ mod tests {
     }
 
     #[test]
-    fn token_grant_header_rejects_framing_and_connection_headers() {
+    fn credential_auth_header_rejects_framing_and_connection_headers() {
         for header_name in ["Host", "Content-Length", "Transfer-Encoding", "Connection"] {
-            let err = token_grant_header(&credential("header", header_name), "grant-token")
+            let err = credential_auth_header(&credential("header", header_name), "grant-token")
                 .expect_err("framing header override should be rejected");
             assert_eq!(
                 err.to_string(),
-                "token grant header_name may not override HTTP framing or connection headers"
+                "credential header_name may not override HTTP framing or connection headers"
             );
         }
     }
@@ -790,5 +951,324 @@ mod tests {
             "token grant returned a malformed access token"
         );
         fixture.assert_one_request("api.example.com\t443\t/v1/**\tprovider:access_token");
+    }
+
+    fn static_credential_ctx(
+        env_var: &str,
+        secret_value: &str,
+        auth_style: &str,
+        header_name: &str,
+    ) -> (L7EvalContext, String) {
+        let (_, resolver) = openshell_core::secrets::SecretResolver::from_provider_env(
+            std::iter::once((env_var.to_string(), secret_value.to_string())).collect(),
+        );
+
+        let key = format!("api.example.com\t443\t\tmy-provider:{env_var}");
+        let mut dynamic_credentials = std::collections::HashMap::new();
+        dynamic_credentials.insert(
+            key.clone(),
+            ProviderProfileCredential {
+                name: "api_token".to_string(),
+                env_vars: vec![env_var.to_string()],
+                auth_style: auth_style.to_string(),
+                header_name: header_name.to_string(),
+                token_grant: None,
+                ..Default::default()
+            },
+        );
+
+        let ctx = L7EvalContext {
+            host: "api.example.com".into(),
+            port: 443,
+            policy_name: "api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: resolver.map(Arc::new),
+            activity_tx: None,
+            dynamic_credentials: Some(Arc::new(std::sync::RwLock::new(dynamic_credentials))),
+            token_grant_resolver: None,
+        };
+        (ctx, key)
+    }
+
+    #[tokio::test]
+    async fn inject_static_credential_injects_bearer_token() {
+        let (ctx, _) =
+            static_credential_ctx("GITHUB_TOKEN", "ghp_secret123", "bearer", "Authorization");
+        let req = L7Request {
+            action: "GET".to_string(),
+            target: "/repos/owner/repo".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: b"GET /repos/owner/repo HTTP/1.1\r\nHost: api.example.com\r\n\r\n".to_vec(),
+            body_length: BodyLength::None,
+        };
+
+        let rewritten = inject_if_needed(req, &ctx)
+            .await
+            .expect("static credential injection should succeed");
+        let rewritten =
+            String::from_utf8(rewritten.raw_header).expect("rewritten request should be UTF-8");
+
+        assert!(rewritten.contains("Authorization: Bearer ghp_secret123\r\n"));
+    }
+
+    #[tokio::test]
+    async fn inject_static_credential_injects_custom_header() {
+        let (ctx, _) =
+            static_credential_ctx("ANTHROPIC_API_KEY", "sk-ant-secret", "header", "x-api-key");
+        let req = L7Request {
+            action: "GET".to_string(),
+            target: "/v1/messages".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: b"GET /v1/messages HTTP/1.1\r\nHost: api.example.com\r\n\r\n".to_vec(),
+            body_length: BodyLength::None,
+        };
+
+        let rewritten = inject_if_needed(req, &ctx)
+            .await
+            .expect("static credential injection should succeed");
+        let rewritten =
+            String::from_utf8(rewritten.raw_header).expect("rewritten request should be UTF-8");
+
+        assert!(rewritten.contains("x-api-key: sk-ant-secret\r\n"));
+        assert!(!rewritten.contains("Bearer"));
+    }
+
+    #[tokio::test]
+    async fn inject_static_credential_fails_when_credential_missing() {
+        // Set up a credential entry pointing to an env var that is NOT in the resolver.
+        let mut dynamic_credentials = std::collections::HashMap::new();
+        dynamic_credentials.insert(
+            "api.example.com\t443\t\tmy-provider:MISSING_TOKEN".to_string(),
+            ProviderProfileCredential {
+                name: "api_token".to_string(),
+                env_vars: vec!["MISSING_TOKEN".to_string()],
+                auth_style: "bearer".to_string(),
+                header_name: "Authorization".to_string(),
+                token_grant: None,
+                ..Default::default()
+            },
+        );
+        let ctx = L7EvalContext {
+            host: "api.example.com".into(),
+            port: 443,
+            policy_name: "api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            activity_tx: None,
+            dynamic_credentials: Some(Arc::new(std::sync::RwLock::new(dynamic_credentials))),
+            token_grant_resolver: None,
+        };
+        let req = L7Request {
+            action: "GET".to_string(),
+            target: "/v1/data".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: b"GET /v1/data HTTP/1.1\r\nHost: api.example.com\r\n\r\n".to_vec(),
+            body_length: BodyLength::None,
+        };
+
+        let err = inject_if_needed(req, &ctx)
+            .await
+            .expect_err("missing credential should fail closed");
+        assert!(err.to_string().contains("no credential value found"));
+    }
+
+    #[tokio::test]
+    async fn inject_static_credential_resolves_fallback_env_var() {
+        // Credential declares two env vars, only the second is in the resolver.
+        let (_, resolver) = openshell_core::secrets::SecretResolver::from_provider_env(
+            std::iter::once(("GH_TOKEN".to_string(), "ghp_fallback".to_string())).collect(),
+        );
+        let mut dynamic_credentials = std::collections::HashMap::new();
+        dynamic_credentials.insert(
+            "api.example.com\t443\t\tmy-provider:api_token".to_string(),
+            ProviderProfileCredential {
+                name: "api_token".to_string(),
+                env_vars: vec!["GITHUB_TOKEN".to_string(), "GH_TOKEN".to_string()],
+                auth_style: "bearer".to_string(),
+                header_name: "Authorization".to_string(),
+                token_grant: None,
+                ..Default::default()
+            },
+        );
+        let ctx = L7EvalContext {
+            host: "api.example.com".into(),
+            port: 443,
+            policy_name: "api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: resolver.map(Arc::new),
+            activity_tx: None,
+            dynamic_credentials: Some(Arc::new(std::sync::RwLock::new(dynamic_credentials))),
+            token_grant_resolver: None,
+        };
+        let req = L7Request {
+            action: "GET".to_string(),
+            target: "/repos".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: b"GET /repos HTTP/1.1\r\nHost: api.example.com\r\n\r\n".to_vec(),
+            body_length: BodyLength::None,
+        };
+
+        let rewritten = inject_if_needed(req, &ctx)
+            .await
+            .expect("should resolve fallback env var");
+        let rewritten =
+            String::from_utf8(rewritten.raw_header).expect("rewritten request should be UTF-8");
+
+        assert!(rewritten.contains("Authorization: Bearer ghp_fallback\r\n"));
+    }
+
+    #[tokio::test]
+    async fn inject_static_credential_rejects_unsupported_auth_style() {
+        let (ctx, _) = static_credential_ctx("API_KEY", "secret123", "query", "");
+        let req = L7Request {
+            action: "GET".to_string(),
+            target: "/v1/data".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: b"GET /v1/data HTTP/1.1\r\nHost: api.example.com\r\n\r\n".to_vec(),
+            body_length: BodyLength::None,
+        };
+
+        let err = inject_if_needed(req, &ctx)
+            .await
+            .expect_err("unsupported auth_style should fail");
+        assert!(err.to_string().contains("not yet supported"));
+    }
+
+    #[tokio::test]
+    async fn inject_static_credential_rejects_placeholder_collision() {
+        let (ctx, _) =
+            static_credential_ctx("GITHUB_TOKEN", "ghp_secret123", "bearer", "Authorization");
+        let req = L7Request {
+            action: "GET".to_string(),
+            target: "/repos/owner/repo".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: b"GET /repos/owner/repo HTTP/1.1\r\nHost: api.example.com\r\nAuthorization: Bearer openshell:resolve:env:GITHUB_TOKEN\r\n\r\n".to_vec(),
+            body_length: BodyLength::None,
+        };
+
+        let err = inject_if_needed(req, &ctx)
+            .await
+            .expect_err("placeholder/profile collision must fail closed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("placeholder"),
+            "error should mention placeholder conflict, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn inject_token_grant_rejects_placeholder_collision() {
+        let fixture = TokenGrantTestFixture::success(
+            "api.example.com\t443\t/v1/**\tprovider:access_token",
+            "grant-token",
+        );
+        let ctx = L7EvalContext {
+            host: "api.example.com".into(),
+            port: 443,
+            policy_name: "api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            activity_tx: None,
+            dynamic_credentials: Some(fixture.dynamic_credentials()),
+            token_grant_resolver: Some(fixture.resolver()),
+        };
+        let req = L7Request {
+            action: "GET".to_string(),
+            target: "/v1/projects".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: b"GET /v1/projects HTTP/1.1\r\nHost: api.example.com\r\nAuthorization: Bearer openshell:resolve:env:MY_TOKEN\r\n\r\n".to_vec(),
+            body_length: BodyLength::None,
+        };
+
+        let err = inject_if_needed(req, &ctx)
+            .await
+            .expect_err("placeholder/profile collision must fail closed for token grants too");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("placeholder"),
+            "error should mention placeholder conflict, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn inject_static_credential_rejects_crlf_value_end_to_end() {
+        // SecretResolver also rejects CRLF at resolution time, so the e2e
+        // path fails before reaching the sink validation.  This test ensures
+        // the overall pipeline fails closed for CRLF credential values.
+        let (ctx, _) = static_credential_ctx(
+            "API_KEY",
+            "secret\r\nX-Injected: yes",
+            "header",
+            "x-api-key",
+        );
+        let req = L7Request {
+            action: "GET".to_string(),
+            target: "/v1/data".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: b"GET /v1/data HTTP/1.1\r\nHost: api.example.com\r\n\r\n".to_vec(),
+            body_length: BodyLength::None,
+        };
+
+        inject_if_needed(req, &ctx)
+            .await
+            .expect_err("CRLF in credential value must be rejected");
+    }
+
+    #[test]
+    fn validate_static_credential_value_rejects_crlf() {
+        let err = validate_static_credential_value("secret\r\nX-Injected: yes")
+            .expect_err("CRLF must be rejected");
+        assert!(err.to_string().contains("unsafe HTTP header bytes"));
+    }
+
+    #[test]
+    fn validate_static_credential_value_rejects_null() {
+        let err =
+            validate_static_credential_value("secret\0rest").expect_err("NUL must be rejected");
+        assert!(err.to_string().contains("unsafe HTTP header bytes"));
+    }
+
+    #[test]
+    fn validate_static_credential_value_rejects_empty() {
+        let err = validate_static_credential_value("").expect_err("empty must be rejected");
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn validate_static_credential_value_accepts_non_token68() {
+        // Static credentials can contain characters outside the token68
+        // alphabet — this is the key difference from token grant validation.
+        validate_static_credential_value("sk-ant-api03-abc123")
+            .expect("API key with non-token68 chars should be accepted");
+    }
+
+    #[tokio::test]
+    async fn inject_no_match_passes_request_through() {
+        let (ctx, _) = static_credential_ctx("TOKEN", "secret", "bearer", "Authorization");
+        let req = L7Request {
+            action: "GET".to_string(),
+            target: "/data".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: b"GET /data HTTP/1.1\r\nHost: other.example.com\r\n\r\n".to_vec(),
+            body_length: BodyLength::None,
+        };
+
+        // Host doesn't match, so request should pass through unmodified.
+        let mut ctx_wrong_host = ctx;
+        ctx_wrong_host.host = "other.example.com".into();
+
+        let result = inject_if_needed(req, &ctx_wrong_host)
+            .await
+            .expect("unmatched request should pass through");
+        let raw = String::from_utf8(result.raw_header).expect("UTF-8");
+        assert!(!raw.contains("Authorization"));
     }
 }

--- a/crates/openshell-supervisor-network/src/l7/token_grant_injection.rs
+++ b/crates/openshell-supervisor-network/src/l7/token_grant_injection.rs
@@ -532,39 +532,46 @@ fn validate_header_name(header_name: &str) -> Result<()> {
     }
 }
 
+/// Injects (or replaces) a header in the raw HTTP request.
+///
+/// Operates byte-wise so that non-UTF-8 obs-text bytes in unrelated
+/// headers do not cause the injection to fail.  Only the header name
+/// comparison is ASCII — header values are preserved as raw bytes.
 fn inject_header(raw_header: &[u8], header_name: &str, header_value: &str) -> Result<Vec<u8>> {
     let header_end = raw_header
         .windows(4)
         .position(|w| w == b"\r\n\r\n")
         .ok_or_else(|| miette!("HTTP headers missing final CRLF CRLF"))?;
 
-    let header_block = std::str::from_utf8(&raw_header[..header_end])
-        .map_err(|_| miette!("HTTP headers contain invalid UTF-8"))?;
-    let mut lines = header_block.split("\r\n");
-    let request_line = lines
-        .next()
-        .ok_or_else(|| miette!("HTTP headers missing request line"))?;
-
+    let header_name_bytes = header_name.as_bytes();
     let inserted_header = format!("{header_name}: {header_value}");
     let mut new_raw_header = Vec::with_capacity(raw_header.len() + inserted_header.len() + 2);
-    new_raw_header.extend_from_slice(request_line.as_bytes());
-    new_raw_header.extend_from_slice(b"\r\n");
 
-    for line in lines {
+    let mut first_line = true;
+    for line in raw_header[..header_end].split(|&b| b == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        if first_line {
+            // Request line — always preserve.
+            first_line = false;
+            new_raw_header.extend_from_slice(line);
+            new_raw_header.extend_from_slice(b"\r\n");
+            continue;
+        }
         if line.is_empty() {
             break;
         }
-        if line
-            .split_once(':')
-            .is_some_and(|(name, _)| name.trim().eq_ignore_ascii_case(header_name))
-        {
-            continue;
+        if let Some(colon_pos) = line.iter().position(|&b| b == b':') {
+            let name = trim_ascii(&line[..colon_pos]);
+            if name.eq_ignore_ascii_case(header_name_bytes) {
+                continue; // drop the existing header — we'll append the new one
+            }
         }
-        new_raw_header.extend_from_slice(line.as_bytes());
+        new_raw_header.extend_from_slice(line);
         new_raw_header.extend_from_slice(b"\r\n");
     }
 
     new_raw_header.extend_from_slice(inserted_header.as_bytes());
+    // Preserve the original terminator and any trailing body bytes.
     new_raw_header.extend_from_slice(&raw_header[header_end..]);
 
     Ok(new_raw_header)
@@ -1335,6 +1342,51 @@ mod tests {
         assert!(
             msg.contains("placeholder"),
             "error should mention placeholder conflict, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn inject_static_credential_succeeds_with_non_utf8_obs_text_in_unrelated_header() {
+        // A request with non-UTF-8 obs-text in an unrelated header must NOT
+        // cause inject_header to fail.  The injection should succeed and
+        // preserve the non-UTF-8 bytes in the unrelated header.
+        let (ctx, _) =
+            static_credential_ctx("GITHUB_TOKEN", "ghp_secret123", "bearer", "Authorization");
+        let mut raw = b"GET /repos/owner/repo HTTP/1.1\r\nHost: api.example.com\r\n".to_vec();
+        // obs-text byte (0x80) in a different header — valid HTTP but not valid UTF-8.
+        raw.extend_from_slice(b"X-Custom: value\x80rest\r\n");
+        raw.extend_from_slice(b"\r\n");
+        let req = L7Request {
+            action: "GET".to_string(),
+            target: "/repos/owner/repo".to_string(),
+            query_params: std::collections::HashMap::new(),
+            raw_header: raw,
+            body_length: BodyLength::None,
+        };
+
+        let result = inject_if_needed(req, &ctx)
+            .await
+            .expect("injection must succeed despite non-UTF-8 in unrelated header");
+
+        // The injected header must be present.
+        let header_end = result
+            .raw_header
+            .windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .expect("must have header terminator");
+        let header_block = &result.raw_header[..header_end];
+        assert!(
+            header_block
+                .windows(b"Authorization: Bearer ghp_secret123".len())
+                .any(|w| w == b"Authorization: Bearer ghp_secret123"),
+            "injected Authorization header must be present"
+        );
+        // The non-UTF-8 header must be preserved as raw bytes.
+        assert!(
+            header_block
+                .windows(b"X-Custom: value\x80rest".len())
+                .any(|w| w == b"X-Custom: value\x80rest"),
+            "non-UTF-8 obs-text header must be preserved"
         );
     }
 

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -7186,7 +7186,7 @@ network_policies:
              Host: api.example.test:8080\r\n\
              Authorization: Bearer {}MY_API_TOKEN\r\n\
              Connection: close\r\n\r\n",
-            openshell_core::secrets::PLACEHOLDER_PREFIX_PUBLIC,
+            secrets::PLACEHOLDER_PREFIX_PUBLIC,
         )
         .into_bytes();
 

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -4196,15 +4196,15 @@ async fn handle_forward_proxy(
                 dst_host = %host_lc,
                 dst_port = port,
                 error = %e,
-                "token grant failed in forward proxy"
+                "credential injection failed in forward proxy"
             );
             respond(
                 client,
                 &build_json_error_response(
                     502,
                     "Bad Gateway",
-                    "token_grant_failed",
-                    "dynamic token grant failed",
+                    "credential_injection_failed",
+                    "credential injection failed",
                 ),
             )
             .await?;
@@ -7144,6 +7144,60 @@ network_policies:
         assert!(err.to_string().contains("Token grant failed"));
         assert!(err.to_string().contains("oauth unavailable"));
         fixture.assert_one_request("api.example.test\t8080\t/v1/**\tprovider:access_token");
+    }
+
+    #[tokio::test]
+    async fn forward_proxy_rejects_placeholder_profile_collision() {
+        // Build a static credential context (no token grant) for the forward
+        // proxy.  The request already contains a placeholder-based value for
+        // Authorization, which should trigger the fail-closed collision check.
+        let env_var = "MY_API_TOKEN";
+        let (_, resolver) = SecretResolver::from_provider_env(
+            std::iter::once((env_var.to_string(), "secret-value".to_string())).collect(),
+        );
+        let key = "api.example.test\t8080\t\tprovider:api_token";
+        let mut dynamic_credentials = std::collections::HashMap::new();
+        dynamic_credentials.insert(
+            key.to_string(),
+            openshell_core::proto::ProviderProfileCredential {
+                name: "api_token".to_string(),
+                env_vars: vec![env_var.to_string()],
+                auth_style: "bearer".to_string(),
+                header_name: "Authorization".to_string(),
+                token_grant: None,
+                ..Default::default()
+            },
+        );
+        let ctx = crate::l7::relay::L7EvalContext {
+            host: "api.example.test".into(),
+            port: 8080,
+            policy_name: "rest_api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: resolver.map(Arc::new),
+            activity_tx: None,
+            dynamic_credentials: Some(Arc::new(std::sync::RwLock::new(dynamic_credentials))),
+            token_grant_resolver: None,
+        };
+
+        let raw = format!(
+            "GET http://api.example.test:8080/data HTTP/1.1\r\n\
+             Host: api.example.test:8080\r\n\
+             Authorization: Bearer {}MY_API_TOKEN\r\n\
+             Connection: close\r\n\r\n",
+            openshell_core::secrets::PLACEHOLDER_PREFIX_PUBLIC,
+        )
+        .into_bytes();
+
+        let err = inject_token_grant_for_forward_request("GET", "/data", raw, &ctx)
+            .await
+            .expect_err("placeholder/profile collision must fail closed in forward proxy");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("placeholder"),
+            "error should mention placeholder conflict, got: {msg}"
+        );
     }
 
     #[test]

--- a/docs/sandboxes/providers-v2.mdx
+++ b/docs/sandboxes/providers-v2.mdx
@@ -68,8 +68,8 @@ The following Providers v2 design items are not part of the current behavior:
 
 | Roadmap item | Current behavior |
 |---|---|
-| General profile-driven credential placement | Static `auth_style`, `header_name`, `query_param`, and `path_template` placement metadata is stored and validated, but static credential injection still depends on environment placeholders generated from provider credentials. Dynamic `token_grant` credentials support `bearer` and `header` placement for matching HTTP endpoints. |
-| Endpoint and binary scoped credential injection | Provider profile endpoints and binaries affect policy composition. Dynamic token grants are endpoint-scoped. Static placeholder injection is not yet restricted by profile endpoint or binary metadata. |
+| General profile-driven credential placement | Static credentials with `auth_style: bearer` or `auth_style: header` are proxy-injected for matching profile endpoints, alongside dynamic `token_grant` credentials. Other placement modes (`query`, `path`) are stored and validated but not yet injected at runtime. |
+| Binary scoped credential injection | Provider profile binaries affect policy composition but do not yet restrict which processes receive credential injection. |
 | Credential verification on create | `openshell provider create` does not yet probe provider verification endpoints or expose `--no-verify`. |
 | Automatic credential scope extraction | OpenShell does not yet inspect upstream provider responses to discover credential scopes. |
 | Inference mounting from attached providers | `inference_capable` is profile metadata. Attaching an inference-capable provider does not yet create `inference.local` routes. |
@@ -175,7 +175,8 @@ credentials:
 
     # Accepted values: basic, bearer, header, query, path.
     # These fields describe static credential placement.
-    # Static runtime injection still uses env placeholder resolution.
+    # When auth_style is bearer or header, the sandbox proxy injects
+    # the credential value into matching profile endpoint traffic.
     auth_style: bearer
     header_name: authorization
     query_param: api_key
@@ -273,7 +274,7 @@ binaries:
 
 `category` groups profiles in `openshell provider list-profiles`. Use one of the values in the category enum.
 
-`credentials` declares the credential names, environment variables, auth metadata, optional refresh metadata, and optional dynamic token grant metadata for the provider type. The `auth_style` field accepts `basic`, `bearer`, `header`, `query`, or `path`. When `auth_style` is `path`, set `path_template` to a URL path containing the `{credential}` placeholder exactly once (for example, `/v1/{credential}/resources`). Static credentials are exposed as placeholder environment variables and resolved in outbound HTTP requests. Dynamic token grants are resolved by the sandbox proxy on demand for matching profile endpoints and support `bearer` or `header` placement. Credential environment variable names must not use the reserved `v<digits>_` prefix, such as `v10_GITHUB_TOKEN`, because OpenShell uses that namespace for revision-scoped placeholders.
+`credentials` declares the credential names, environment variables, auth metadata, optional refresh metadata, and optional dynamic token grant metadata for the provider type. The `auth_style` field accepts `basic`, `bearer`, `header`, `query`, or `path`. When `auth_style` is `path`, set `path_template` to a URL path containing the `{credential}` placeholder exactly once (for example, `/v1/{credential}/resources`). Static credentials are exposed as placeholder environment variables and resolved in outbound HTTP requests. When `providers_v2_enabled` is set and a static credential declares `auth_style: bearer` or `auth_style: header`, the sandbox proxy also injects the credential value into matching profile endpoint traffic, using the same header placement rules as dynamic token grants. Credentials without an explicit `auth_style` are not proxy-injected. Dynamic token grants are resolved by the sandbox proxy on demand for matching profile endpoints and support `bearer` or `header` placement. Credential environment variable names must not use the reserved `v<digits>_` prefix, such as `v10_GITHUB_TOKEN`, because OpenShell uses that namespace for revision-scoped placeholders.
 
 `discovery` controls what `--from-existing` scans when
 `providers_v2_enabled=true`. Each entry in `discovery.credentials` must name a
@@ -686,7 +687,9 @@ Already-running processes keep the environment they started with. OpenShell does
 
 Detaching a provider removes its provider policy layer from future effective policy reads and removes its credential placeholders from future process environments. It does not remove environment variables from already-running processes.
 
-OpenShell rejects provider updates and refresh configuration when they would make two providers attached to the same sandbox expose the same active credential environment key. It also rejects attached provider sets with ambiguous dynamic token grants at equal host/path specificity. Use provider-specific credential names and make one dynamic grant selector more specific when one sandbox needs multiple providers with overlapping upstream concepts.
+OpenShell rejects provider updates and refresh configuration when they would make two providers attached to the same sandbox expose the same active credential environment key. It also rejects attached provider sets with ambiguous credential bindings — both static and dynamic — at equal host/path specificity. Use provider-specific credential names and make one credential selector more specific when one sandbox needs multiple providers with overlapping upstream endpoints.
+
+If a request header already contains a placeholder-based credential value for the same header that profile injection would target, the request is rejected. Remove the placeholder from the request to use profile-based credential injection, or disable profile injection to continue using placeholder resolution.
 
 ## Next Steps
 

--- a/e2e/python/test_sandbox_providers.py
+++ b/e2e/python/test_sandbox_providers.py
@@ -7,12 +7,22 @@ Provider credentials are fetched at runtime by the sandbox supervisor via the
 GetSandboxProviderEnvironment gRPC call. Sandboxed child processes should see
 placeholder values (not raw secrets). Credentials must never be present in the
 persisted sandbox spec environment map.
+
+Tests in the "Providers v2 static injection" section verify that static
+provider credentials are injected into outbound HTTP requests by the proxy
+when ``providers_v2_enabled`` is active. They exercise the full server →
+sandbox → proxy injection path with a local echo server and check that the
+upstream receives the real header value while the sandbox process sees only
+the existing credential placeholder, never the raw secret.
 """
 
 from __future__ import annotations
 
+import fcntl
+import json
 import time
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import grpc
@@ -191,9 +201,7 @@ def test_nvidia_provider_injects_nvidia_api_key_env_var(
         with sandbox(spec=spec, delete_on_exit=True) as sb:
             result = sb.exec_python(read_nvidia_key)
             assert result.exit_code == 0, result.stderr
-            assert _is_placeholder_for_env_key(
-                result.stdout.strip(), "NVIDIA_API_KEY"
-            )
+            assert _is_placeholder_for_env_key(result.stdout.strip(), "NVIDIA_API_KEY")
 
 
 def test_attach_detach_updates_credentials_for_later_exec_launches(
@@ -484,3 +492,501 @@ def test_update_provider_rejects_type_change(
         assert "type cannot be changed" in exc_info.value.details()
     finally:
         _delete_provider(stub, name)
+
+
+# ===========================================================================
+# Providers v2 static injection — helpers
+# ===========================================================================
+
+# Standard sandbox network namespace addresses
+_PROXY_HOST = "10.200.0.1"
+_PROXY_PORT = 3128
+_SANDBOX_IP = "10.200.0.2"
+_ECHO_SERVER_PORT = 19876
+_PROVIDERS_V2_CONFIG_LOCK = Path("/tmp/openshell-e2e-providers-v2-config.lock")
+
+
+def _set_providers_v2_enabled(stub: object, enabled: bool) -> None:
+    """Toggle the providers_v2_enabled gateway-global setting."""
+    stub.UpdateConfig(
+        openshell_pb2.UpdateConfigRequest(
+            setting_key="providers_v2_enabled",
+            setting_value=sandbox_pb2.SettingValue(bool_value=enabled),
+            **{"global": True},
+        )
+    )
+
+
+def _delete_providers_v2_setting(stub: object) -> None:
+    """Remove the providers_v2_enabled setting so it returns to the default."""
+    with suppress(grpc.RpcError):
+        stub.UpdateConfig(
+            openshell_pb2.UpdateConfigRequest(
+                setting_key="providers_v2_enabled",
+                delete_setting=True,
+                **{"global": True},
+            )
+        )
+
+
+@contextmanager
+def _providers_v2_enabled(stub: object) -> Iterator[None]:
+    """Context manager that enables providers_v2 for the block, then resets."""
+    with _PROVIDERS_V2_CONFIG_LOCK.open("a+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        _set_providers_v2_enabled(stub, True)
+        try:
+            yield
+        finally:
+            _delete_providers_v2_setting(stub)
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _import_custom_profile(
+    stub: object,
+    *,
+    profile_id: str,
+    credential_name: str,
+    auth_style: str,
+    header_name: str,
+    env_vars: list[str],
+    endpoint_host: str,
+    endpoint_port: int,
+) -> None:
+    """Import a custom provider type profile for E2E injection testing."""
+    profile = openshell_pb2.ProviderProfile(
+        id=profile_id,
+        display_name=f"E2E {profile_id}",
+        description="Temporary E2E test profile for static credential injection",
+        credentials=[
+            openshell_pb2.ProviderProfileCredential(
+                name=credential_name,
+                description="E2E test credential",
+                env_vars=env_vars,
+                required=True,
+                auth_style=auth_style,
+                header_name=header_name,
+            ),
+        ],
+        endpoints=[
+            sandbox_pb2.NetworkEndpoint(
+                host=endpoint_host,
+                port=endpoint_port,
+                protocol="rest",
+                enforcement="enforce",
+                access="full",
+            ),
+        ],
+        binaries=[sandbox_pb2.NetworkBinary(path="/**")],
+    )
+    resp = stub.ImportProviderProfiles(
+        openshell_pb2.ImportProviderProfilesRequest(
+            profiles=[
+                openshell_pb2.ProviderProfileImportItem(
+                    profile=profile,
+                    source="e2e-test",
+                ),
+            ],
+        )
+    )
+    for diag in resp.diagnostics:
+        if diag.severity == "error":
+            raise RuntimeError(f"Profile import error: {diag.field}: {diag.message}")
+
+
+def _delete_custom_profile(stub: object, profile_id: str) -> None:
+    """Delete a custom provider profile, ignoring not-found errors."""
+    try:
+        stub.DeleteProviderProfile(
+            openshell_pb2.DeleteProviderProfileRequest(id=profile_id)
+        )
+    except grpc.RpcError as exc:
+        if hasattr(exc, "code") and exc.code() == grpc.StatusCode.NOT_FOUND:
+            pass
+        else:
+            raise
+
+
+def _injection_policy() -> sandbox_pb2.SandboxPolicy:
+    """Build a sandbox policy allowing L7-inspected traffic to the echo server."""
+    return sandbox_pb2.SandboxPolicy(
+        version=1,
+        filesystem=sandbox_pb2.FilesystemPolicy(
+            include_workdir=True,
+            read_only=["/usr", "/lib", "/etc", "/app", "/dev/urandom"],
+            read_write=["/sandbox", "/tmp"],
+        ),
+        landlock=sandbox_pb2.LandlockPolicy(compatibility="best_effort"),
+        process=sandbox_pb2.ProcessPolicy(
+            run_as_user="sandbox", run_as_group="sandbox"
+        ),
+        network_policies={
+            "echo": sandbox_pb2.NetworkPolicyRule(
+                name="echo",
+                endpoints=[
+                    sandbox_pb2.NetworkEndpoint(
+                        host=_SANDBOX_IP,
+                        port=_ECHO_SERVER_PORT,
+                        protocol="rest",
+                        enforcement="enforce",
+                        access="full",
+                        allowed_ips=["10.200.0.0/24"],
+                    ),
+                ],
+                binaries=[sandbox_pb2.NetworkBinary(path="/**")],
+            ),
+        },
+    )
+
+
+def _header_echo_server_and_request():
+    """Return a closure that starts an echo server and sends a proxied request.
+
+    The echo server returns all received HTTP request headers as a JSON object
+    in the response body. The closure CONNECTs through the sandbox proxy, sends
+    a plain HTTP request to the local server, and returns the JSON-decoded
+    response.
+    """
+
+    def fn(
+        proxy_host,
+        proxy_port,
+        target_host,
+        target_port,
+        extra_headers="",
+    ):
+        import json as _json
+        import socket
+        import threading
+        import time
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        class EchoHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                headers_dict = dict(self.headers.items())
+                body = _json.dumps(headers_dict).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args):
+                pass
+
+        srv = HTTPServer(("0.0.0.0", int(target_port)), EchoHandler)
+        threading.Thread(target=srv.handle_request, daemon=True).start()
+        time.sleep(0.5)
+
+        conn = socket.create_connection((proxy_host, int(proxy_port)), timeout=30)
+        try:
+            conn.sendall(
+                f"CONNECT {target_host}:{target_port} HTTP/1.1\r\n"
+                f"Host: {target_host}\r\n\r\n".encode()
+            )
+            connect_resp = conn.recv(256).decode("latin1")
+            if "200" not in connect_resp:
+                return _json.dumps(
+                    {
+                        "connect_status": connect_resp.strip(),
+                        "http_status": 0,
+                        "headers": {},
+                    }
+                )
+
+            request = (
+                f"GET /echo HTTP/1.1\r\n"
+                f"Host: {target_host}\r\n"
+                f"Connection: close\r\n"
+                f"{extra_headers}"
+                f"\r\n"
+            )
+            conn.sendall(request.encode())
+
+            data = b""
+            conn.settimeout(10)
+            try:
+                while True:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        break
+                    data += chunk
+            except TimeoutError:
+                pass
+
+            response = data.decode("latin1", errors="replace")
+            status_line = response.split("\r\n")[0] if response else ""
+            status_code = (
+                int(status_line.split()[1]) if len(status_line.split()) >= 2 else 0
+            )
+
+            header_end = response.find("\r\n\r\n")
+            body = response[header_end + 4 :] if header_end > 0 else ""
+
+            # Parse JSON body if present
+            try:
+                headers = _json.loads(body)
+            except Exception:
+                headers = {}
+
+            return _json.dumps(
+                {
+                    "connect_status": connect_resp.strip(),
+                    "http_status": status_code,
+                    "headers": headers,
+                    "raw_body": body,
+                }
+            )
+        finally:
+            conn.close()
+            srv.server_close()
+
+    return fn
+
+
+# ===========================================================================
+# Tests: providers v2 static credential injection
+# ===========================================================================
+
+
+def test_providers_v2_static_bearer_injection_through_proxy(
+    sandbox: Callable[..., Sandbox],
+    sandbox_client: SandboxClient,
+) -> None:
+    """Static bearer credential is injected into outbound requests by the proxy.
+
+    Verifies the full server → sandbox → proxy injection path:
+    1. The sandbox process sees only the credential placeholder, not the raw
+       secret.
+    2. The proxy injects ``Authorization: Bearer <secret>`` into the request
+       before forwarding to the upstream echo server.
+    """
+    stub = sandbox_client._stub
+    profile_id = "e2e-static-bearer-inject"
+    provider_name = "e2e-provider-bearer-inject"
+    secret = "sk-e2e-bearer-secret-12345"
+    env_key = "E2E_BEARER_TOKEN"
+
+    _delete_provider(stub, provider_name)
+    _delete_custom_profile(stub, profile_id)
+
+    with _providers_v2_enabled(stub):
+        try:
+            _import_custom_profile(
+                stub,
+                profile_id=profile_id,
+                credential_name="api_key",
+                auth_style="bearer",
+                header_name="authorization",
+                env_vars=[env_key],
+                endpoint_host=_SANDBOX_IP,
+                endpoint_port=_ECHO_SERVER_PORT,
+            )
+
+            with provider(
+                stub,
+                name=provider_name,
+                provider_type=profile_id,
+                credentials={env_key: secret},
+            ):
+                spec = datamodel_pb2.SandboxSpec(
+                    policy=_injection_policy(),
+                    providers=[provider_name],
+                )
+
+                def read_env_var() -> str:
+                    import os
+
+                    return os.environ.get("E2E_BEARER_TOKEN", "NOT_SET")
+
+                with sandbox(spec=spec, delete_on_exit=True) as sb:
+                    # 1. The sandbox process receives only the placeholder.
+                    env_result = sb.exec_python(read_env_var)
+                    assert env_result.exit_code == 0, env_result.stderr
+                    env_value = env_result.stdout.strip()
+                    assert _is_placeholder_for_env_key(env_value, env_key), (
+                        f"expected placeholder for {env_key}, got {env_value!r}"
+                    )
+                    assert env_value != secret
+
+                    # 2. Proxy injects real credential into upstream request
+                    echo_result = sb.exec_python(
+                        _header_echo_server_and_request(),
+                        args=(
+                            _PROXY_HOST,
+                            _PROXY_PORT,
+                            _SANDBOX_IP,
+                            _ECHO_SERVER_PORT,
+                        ),
+                    )
+                    assert echo_result.exit_code == 0, echo_result.stderr
+                    resp = json.loads(echo_result.stdout)
+                    assert resp["http_status"] == 200, (
+                        "expected 200 from echo server, got "
+                        f"{resp['http_status']} after {resp['connect_status']!r}"
+                    )
+                    echoed_headers = resp["headers"]
+                    # The proxy should have injected the Authorization header
+                    auth_header = echoed_headers.get(
+                        "Authorization", echoed_headers.get("authorization", "")
+                    )
+                    assert auth_header == f"Bearer {secret}", (
+                        "proxy did not inject the expected bearer credential"
+                    )
+        finally:
+            _delete_custom_profile(stub, profile_id)
+
+
+def test_providers_v2_static_header_injection_through_proxy(
+    sandbox: Callable[..., Sandbox],
+    sandbox_client: SandboxClient,
+) -> None:
+    """Static header credential is injected with a custom header name.
+
+    Uses ``auth_style: header`` with ``header_name: X-Custom-Api-Key`` to
+    verify that the proxy injects the credential as a raw header value (no
+    ``Bearer`` prefix).
+    """
+    stub = sandbox_client._stub
+    profile_id = "e2e-static-header-inject"
+    provider_name = "e2e-provider-header-inject"
+    secret = "custom-header-secret-67890"
+    env_key = "E2E_CUSTOM_HEADER_TOKEN"
+
+    _delete_provider(stub, provider_name)
+    _delete_custom_profile(stub, profile_id)
+
+    with _providers_v2_enabled(stub):
+        try:
+            _import_custom_profile(
+                stub,
+                profile_id=profile_id,
+                credential_name="api_key",
+                auth_style="header",
+                header_name="X-Custom-Api-Key",
+                env_vars=[env_key],
+                endpoint_host=_SANDBOX_IP,
+                endpoint_port=_ECHO_SERVER_PORT,
+            )
+
+            with provider(
+                stub,
+                name=provider_name,
+                provider_type=profile_id,
+                credentials={env_key: secret},
+            ):
+                spec = datamodel_pb2.SandboxSpec(
+                    policy=_injection_policy(),
+                    providers=[provider_name],
+                )
+
+                def read_env_var() -> str:
+                    import os
+
+                    return os.environ.get("E2E_CUSTOM_HEADER_TOKEN", "NOT_SET")
+
+                with sandbox(spec=spec, delete_on_exit=True) as sb:
+                    env_result = sb.exec_python(read_env_var)
+                    assert env_result.exit_code == 0, env_result.stderr
+                    env_value = env_result.stdout.strip()
+                    assert _is_placeholder_for_env_key(env_value, env_key), (
+                        f"expected placeholder for {env_key}, got {env_value!r}"
+                    )
+                    assert env_value != secret
+
+                    echo_result = sb.exec_python(
+                        _header_echo_server_and_request(),
+                        args=(
+                            _PROXY_HOST,
+                            _PROXY_PORT,
+                            _SANDBOX_IP,
+                            _ECHO_SERVER_PORT,
+                        ),
+                    )
+                    assert echo_result.exit_code == 0, echo_result.stderr
+                    resp = json.loads(echo_result.stdout)
+                    assert resp["http_status"] == 200, (
+                        "expected 200 from echo server, got "
+                        f"{resp['http_status']} after {resp['connect_status']!r}"
+                    )
+                    echoed_headers = resp["headers"]
+                    custom_header = echoed_headers.get(
+                        "X-Custom-Api-Key",
+                        echoed_headers.get("x-custom-api-key", ""),
+                    )
+                    assert custom_header == secret, (
+                        "proxy did not inject the expected custom-header credential"
+                    )
+        finally:
+            _delete_custom_profile(stub, profile_id)
+
+
+def test_providers_v2_placeholder_profile_collision_fails_closed(
+    sandbox: Callable[..., Sandbox],
+    sandbox_client: SandboxClient,
+) -> None:
+    """Proxy rejects requests with placeholder-based values in the target header.
+
+    Defense-in-depth: even though v2 credentials are suppressed from the
+    sandbox environment, an application could construct a header containing
+    a placeholder string directly. The proxy must detect the collision and
+    fail closed (502 Bad Gateway) instead of double-injecting or leaking
+    credentials.
+    """
+    stub = sandbox_client._stub
+    profile_id = "e2e-collision-bearer"
+    provider_name = "e2e-provider-collision"
+    secret = "sk-collision-secret-99999"
+    env_key = "E2E_COLLISION_TOKEN"
+
+    _delete_provider(stub, provider_name)
+    _delete_custom_profile(stub, profile_id)
+
+    with _providers_v2_enabled(stub):
+        try:
+            _import_custom_profile(
+                stub,
+                profile_id=profile_id,
+                credential_name="api_key",
+                auth_style="bearer",
+                header_name="authorization",
+                env_vars=[env_key],
+                endpoint_host=_SANDBOX_IP,
+                endpoint_port=_ECHO_SERVER_PORT,
+            )
+
+            with provider(
+                stub,
+                name=provider_name,
+                provider_type=profile_id,
+                credentials={env_key: secret},
+            ):
+                spec = datamodel_pb2.SandboxSpec(
+                    policy=_injection_policy(),
+                    providers=[provider_name],
+                )
+
+                with sandbox(spec=spec, delete_on_exit=True) as sb:
+                    # Send a request that already has a placeholder-based
+                    # Authorization header — the proxy must reject it.
+                    placeholder_value = f"openshell:resolve:env:{env_key}"
+                    collision_header = f"Authorization: Bearer {placeholder_value}\r\n"
+                    echo_result = sb.exec_python(
+                        _header_echo_server_and_request(),
+                        args=(
+                            _PROXY_HOST,
+                            _PROXY_PORT,
+                            _SANDBOX_IP,
+                            _ECHO_SERVER_PORT,
+                            collision_header,
+                        ),
+                    )
+                    assert echo_result.exit_code == 0, echo_result.stderr
+                    resp = json.loads(echo_result.stdout)
+                    # Injection collision → 502 Bad Gateway (fail closed)
+                    assert resp["http_status"] == 502, (
+                        "expected 502 for placeholder collision, got "
+                        f"{resp['http_status']} after {resp['connect_status']!r}"
+                    )
+        finally:
+            _delete_custom_profile(stub, profile_id)

--- a/proto/openshell.proto
+++ b/proto/openshell.proto
@@ -1185,9 +1185,10 @@ message GetSandboxProviderEnvironmentResponse {
   uint64 provider_env_revision = 2;
   // Expiration timestamps for returned environment variables.
   map<string, int64> credential_expires_at_ms = 3;
-  // Dynamic credentials that require token grants or other runtime injection.
-  // Maps endpoint-bound provider metadata to credential metadata.
-  // Supervisor uses this to inject Authorization headers for token grant credentials.
+  // Endpoint-bound provider credentials for proxy-side injection.
+  // Maps endpoint keys to credential metadata. Entries with a token_grant
+  // use SPIFFE-backed runtime exchange; entries without resolve credential
+  // values from the environment map above.
   map<string, ProviderProfileCredential> dynamic_credentials = 4;
 }
 


### PR DESCRIPTION
## Summary
This PR enables injection of static provider credentials that are auth headers when `providers_v2_enabled` is set. It extends the existing token grant injection path to resolve and inject bearer/header credentials from provider profiles, without requiring child-env placeholder resolution.


## Related Issue
Part of #896 

## Changes
- Gate static credential inclusion in `dynamic_credentials` behind `providers_v2_enabled` in the server
- Extend sandbox side `inject_if_needed` to handle static credentials as well as the existing token grant path

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)