### PR TITLE
fix(e2e): correct return type of _stub_with_token

### DIFF
--- a/e2e/python/oidc/oidc_auth_test.py
+++ b/e2e/python/oidc/oidc_auth_test.py
@@ -149,7 +149,7 @@ def _grpc_channel() -> grpc.Channel:
     return grpc.insecure_channel(target)
 
 
-def _stub_with_token(token: str) -> openshell_pb2_grpc.OpenShellStub:
+def _stub_with_token(token: str) -> tuple[openshell_pb2_grpc.OpenShellStub, list[tuple[str, str]]]:
     """Create a gRPC stub that injects a Bearer token."""
     channel = _grpc_channel()
     return openshell_pb2_grpc.OpenShellStub(channel), [


### PR DESCRIPTION
`_stub_with_token` returns a `tuple[OpenShellStub, list[tuple[str, str]]]` 
but was annotated as `OpenShellStub`. 
This caused 31 mypy errors cascading to every call site.
1-line fix to match the actual return value.