### PR TITLE
fix(sbom): handle SPDX expression licenses in extract_licenses

### DIFF
--- a/deploy/sbom/sbom_to_csv.py
+++ b/deploy/sbom/sbom_to_csv.py
@@ -23,8 +23,11 @@ def extract_licenses(component: dict) -> str:
     licenses = component.get("licenses", [])
     ids = []
     for entry in licenses:
-        lic = entry.get("license", {})
-        ids.append(lic.get("id") or lic.get("name", ""))
+        if "expression" in entry:
+            ids.append(entry["expression"])
+        else:
+            lic = entry.get("license", {})
+            ids.append(lic.get("id") or lic.get("name", ""))
     return " | ".join(filter(None, ids))
 
 


### PR DESCRIPTION
CycloneDX allows licenses in 2 forms:

`{"license": {"id": "MIT"}}`; handled correctly

`{"expression": "MIT OR Apache-2.0"}`; silently dropped

`extract_licenses` only checked for the `license` key, so any component
using the `expression` form got an empty license field in the CSV output.

Add a check for `expression` before falling back to the `license` block.