### PR TITLE
ci(branch-checks): align Python checks with pre-commit

### DIFF
--- a/.github/workflows/branch-checks.yml
+++ b/.github/workflows/branch-checks.yml
@@ -160,8 +160,14 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
 
+      - name: Format
+        run: mise run python:format:check
+
       - name: Lint
         run: mise run python:lint
+
+      - name: Typecheck
+        run: mise run python:typecheck
 
       - name: Test
         run: mise run test:python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ dev = [
     "setuptools-scm>=8",
     "grpcio-tools>=1.60",
     "pyelftools>=0.30",
+    "pyyaml==6.0.2",
+    "types-pyyaml>=6.0.12.20260518",
 ]
 
 [tool.uv]

--- a/tasks/scripts/sync_docs_website.py
+++ b/tasks/scripts/sync_docs_website.py
@@ -16,13 +16,14 @@ import re
 import shutil
 import sys
 import tempfile
-from collections.abc import MutableMapping, MutableSequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 import yaml
 
 SLUG_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+YamlMapping = dict[str, object]
 
 
 @dataclass
@@ -39,7 +40,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--operation", choices=["sync", "remove"], default="sync")
     parser.add_argument("--source-root", type=Path)
     parser.add_argument("--docs-website-root", required=True, type=Path)
-    parser.add_argument("--channel", required=True, choices=["dev", "latest", "version"])
+    parser.add_argument(
+        "--channel", required=True, choices=["dev", "latest", "version"]
+    )
     parser.add_argument("--source-ref", default="")
     parser.add_argument("--version-slug", default="")
     parser.add_argument("--display-name", default="")
@@ -58,11 +61,15 @@ def resolve_slug(channel: str, version_slug: str) -> str:
     if not version_slug:
         raise ValueError("--version-slug is required when --channel=version")
     if not SLUG_RE.fullmatch(version_slug):
-        raise ValueError(f"version slug contains unsupported characters: {version_slug}")
+        raise ValueError(
+            f"version slug contains unsupported characters: {version_slug}"
+        )
     return version_slug
 
 
-def resolve_display_name(channel: str, slug: str, source_ref: str, override: str) -> str:
+def resolve_display_name(
+    channel: str, slug: str, source_ref: str, override: str
+) -> str:
     if override:
         return override
     if channel == "dev":
@@ -116,15 +123,15 @@ def copy_if_exists(src: Path, dst: Path) -> None:
         shutil.copy2(src, dst)
 
 
-def read_yaml(path: Path) -> dict:
+def read_yaml(path: Path) -> YamlMapping:
     ensure_existing(path, "YAML file")
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError(f"expected YAML mapping in {path}")
-    return data
+    return cast("YamlMapping", data)
 
 
-def write_yaml(path: Path, data: dict) -> None:
+def write_yaml(path: Path, data: YamlMapping) -> None:
     path.write_text(
         yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
         encoding="utf-8",
@@ -140,20 +147,23 @@ def prefix_path(value: object, pages_dir: str) -> object:
 
 
 def prefix_navigation_paths(value: object, pages_dir: str) -> object:
-    if isinstance(value, MutableMapping):
+    if isinstance(value, dict):
+        mapping = cast("YamlMapping", value)
         for key in ("path", "folder"):
-            if key in value:
-                value[key] = prefix_path(value[key], pages_dir)
-        for child in value.values():
+            if key in mapping:
+                mapping[key] = prefix_path(mapping[key], pages_dir)
+        for child in mapping.values():
             prefix_navigation_paths(child, pages_dir)
-    elif isinstance(value, MutableSequence):
-        for child in value:
+    elif isinstance(value, list):
+        for child in cast("list[object]", value):
             prefix_navigation_paths(child, pages_dir)
     return value
 
 
-def version_navigation(source_index: Path, pages_dir: str) -> dict:
-    return prefix_navigation_paths(read_yaml(source_index), pages_dir)
+def version_navigation(source_index: Path, pages_dir: str) -> YamlMapping:
+    data = read_yaml(source_index)
+    prefix_navigation_paths(data, pages_dir)
+    return data
 
 
 def parse_versions(raw_versions: object) -> list[VersionEntry]:
@@ -162,20 +172,27 @@ def parse_versions(raw_versions: object) -> list[VersionEntry]:
     if not isinstance(raw_versions, list):
         raise ValueError("docs.yml versions must be a list")
     entries: list[VersionEntry] = []
-    for raw in raw_versions:
+    for raw in cast("list[object]", raw_versions):
         if not isinstance(raw, dict):
             continue
-        slug = raw.get("slug")
-        display_name = raw.get("display-name")
-        path = raw.get("path")
-        if isinstance(slug, str) and isinstance(display_name, str) and isinstance(path, str):
+        entry = cast("YamlMapping", raw)
+        slug = entry.get("slug")
+        display_name = entry.get("display-name")
+        path = entry.get("path")
+        if (
+            isinstance(slug, str)
+            and isinstance(display_name, str)
+            and isinstance(path, str)
+        ):
             entries.append(
                 VersionEntry(slug=slug, display_name=display_name, path=path)
             )
     return entries
 
 
-def ordered_entries(existing: list[VersionEntry], updated: VersionEntry) -> list[VersionEntry]:
+def ordered_entries(
+    existing: list[VersionEntry], updated: VersionEntry
+) -> list[VersionEntry]:
     by_slug = {entry.slug: entry for entry in existing}
     by_slug[updated.slug] = updated
     existing_order = [entry.slug for entry in existing if entry.slug != updated.slug]
@@ -206,7 +223,9 @@ def render_versions(entries: list[VersionEntry]) -> list[dict[str, str]]:
 def component_dirs(fern_dir: Path) -> list[str]:
     dirs: list[str] = []
     preferred = ["pages-latest", "pages-dev"]
-    all_page_dirs = sorted(path.name for path in fern_dir.glob("pages-*") if path.is_dir())
+    all_page_dirs = sorted(
+        path.name for path in fern_dir.glob("pages-*") if path.is_dir()
+    )
     for name in preferred + all_page_dirs:
         path = fern_dir / name / "_components"
         component = f"./{name}/_components"
@@ -229,7 +248,9 @@ def update_docs_yml(docs_yml: Path, updated: VersionEntry, fern_dir: Path) -> No
 
 def remove_docs_yml_entry(docs_yml: Path, slug: str, fern_dir: Path) -> None:
     data = read_yaml(docs_yml)
-    entries = [entry for entry in parse_versions(data.get("versions")) if entry.slug != slug]
+    entries = [
+        entry for entry in parse_versions(data.get("versions")) if entry.slug != slug
+    ]
     data["experimental"] = {
         "mdx-components": component_dirs(fern_dir),
     }
@@ -274,7 +295,9 @@ def sync_docs(args: argparse.Namespace) -> None:
     )
     if refresh_shared:
         copy_if_exists(source_fern / "main.css", target_fern / "main.css")
-        copy_if_exists(source_fern / "fern.config.json", target_fern / "fern.config.json")
+        copy_if_exists(
+            source_fern / "fern.config.json", target_fern / "fern.config.json"
+        )
 
     versions_dir = target_fern / "versions"
     versions_dir.mkdir(parents=True, exist_ok=True)
@@ -294,8 +317,7 @@ def sync_docs(args: argparse.Namespace) -> None:
     )
 
     print(
-        f"Synced {channel} docs from {source_ref} to fern/{pages_dir} "
-        f"({display_name})"
+        f"Synced {channel} docs from {source_ref} to fern/{pages_dir} ({display_name})"
     )
 
 

--- a/tasks/scripts/sync_docs_website_test.py
+++ b/tasks/scripts/sync_docs_website_test.py
@@ -11,7 +11,7 @@ sibling script imports directly as `sync_docs_website`.
 from __future__ import annotations
 
 from argparse import Namespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 import sync_docs_website as sdw
@@ -66,7 +66,7 @@ def test_ordered_entries_pins_latest_then_dev() -> None:
 
 
 def test_prefix_navigation_paths() -> None:
-    nav = {
+    nav: dict[str, object] = {
         "navigation": [
             {"page": "Intro", "path": "intro.mdx"},
             {
@@ -78,11 +78,14 @@ def test_prefix_navigation_paths() -> None:
         ]
     }
     sdw.prefix_navigation_paths(nav, "pages-dev")
-    assert nav["navigation"][0]["path"] == "../pages-dev/intro.mdx"
-    assert nav["navigation"][1]["folder"] == "../pages-dev/guide"
-    assert nav["navigation"][1]["contents"][0]["path"] == "../pages-dev/guide/a.mdx"
+    navigation = cast("list[dict[str, object]]", nav["navigation"])
+    guide = navigation[1]
+    contents = cast("list[dict[str, object]]", guide["contents"])
+    assert navigation[0]["path"] == "../pages-dev/intro.mdx"
+    assert guide["folder"] == "../pages-dev/guide"
+    assert contents[0]["path"] == "../pages-dev/guide/a.mdx"
     # Absolute URLs are left untouched.
-    assert nav["navigation"][2]["path"] == "https://example.com"
+    assert navigation[2]["path"] == "https://example.com"
 
 
 def _make_source_tree(root: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -304,9 +304,11 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
+    { name = "pyyaml" },
     { name = "ruff" },
     { name = "setuptools-scm" },
     { name = "ty" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -326,9 +328,11 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-cov", specifier = ">=4.0" },
     { name = "pytest-xdist", specifier = ">=3.0" },
+    { name = "pyyaml", specifier = "==6.0.2" },
     { name = "ruff", specifier = ">=0.4" },
     { name = "setuptools-scm", specifier = ">=8" },
     { name = "ty", specifier = ">=0.0.1a6" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
 ]
 
 [[package]]
@@ -439,6 +443,32 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.14"
 source = { registry = "https://pypi.org/simple" }
@@ -508,6 +538,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/08/d5/655beb51224d1bfd4f9ddc0bb209659bfe71ff141bcf05c418ab670698f0/ty-0.0.14-py3-none-win32.whl", hash = "sha256:b20e22cf54c66b3e37e87377635da412d9a552c9bf4ad9fc449fed8b2e19dad2", size = 9507626, upload-time = "2026-01-27T00:57:41.43Z" },
     { url = "https://files.pythonhosted.org/packages/b6/d9/c569c9961760e20e0a4bc008eeb1415754564304fd53997a371b7cf3f864/ty-0.0.14-py3-none-win_amd64.whl", hash = "sha256:e312ff9475522d1a33186657fe74d1ec98e4a13e016d66f5758a452c90ff6409", size = 10437980, upload-time = "2026-01-27T00:57:36.422Z" },
     { url = "https://files.pythonhosted.org/packages/ad/0c/186829654f5bfd9a028f6648e9caeb11271960a61de97484627d24443f91/ty-0.0.14-py3-none-win_arm64.whl", hash = "sha256:b6facdbe9b740cb2c15293a1d178e22ffc600653646452632541d01c36d5e378", size = 9885831, upload-time = "2026-01-27T00:57:49.747Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fix the docs website sync automation that made local `pre-commit` fail on current `main`, and align Branch Checks with the local Python gates so this class of failure is caught before merge.

## Related Issue

N/A

## Changes

- Format `tasks/scripts/sync_docs_website.py` with Ruff.
- Add PyYAML and `types-PyYAML` to the dev dependency group so `python:typecheck` can resolve the docs sync script import.
- Tighten YAML map typing in the docs sync script and tests for `ty`.
- Add Python format and typecheck steps to `.github/workflows/branch-checks.yml`.

## Testing

- [x] `mise run pre-commit` passes
- [x] `mise run test:docs-website` passes
- [ ] Unit tests added/updated (not applicable; existing docs sync tests cover the touched behavior)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)