### PR TITLE
fix(python): add encoding=utf-8 to file reads and writes in sandbox.py

### DIFF
--- a/python/openshell/sandbox.py
+++ b/python/openshell/sandbox.py
@@ -849,7 +849,7 @@ def _read_oidc_token_bundle(gateway_dir: pathlib.Path) -> dict | None:
         return json.loads(token_path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return None
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None
 
 

--- a/python/openshell/sandbox.py
+++ b/python/openshell/sandbox.py
@@ -318,7 +318,7 @@ class SandboxClient:
         gateway_dir = _xdg_config_home() / "openshell" / "gateways" / cluster_name
         metadata_path = gateway_dir / "metadata.json"
         try:
-            metadata = json.loads(metadata_path.read_text())
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
         except FileNotFoundError:
             raise SandboxError(f"gateway '{cluster_name}' not found") from None
         if "gateway_endpoint" not in metadata:
@@ -846,7 +846,7 @@ def _read_oidc_token_bundle(gateway_dir: pathlib.Path) -> dict | None:
     """
     token_path = gateway_dir / "oidc_token.json"
     try:
-        return json.loads(token_path.read_text())
+        return json.loads(token_path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return None
     except (OSError, json.JSONDecodeError):
@@ -1299,7 +1299,7 @@ class _OidcRefresher:
         )
         tmp_path = pathlib.Path(tmp_name)
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(payload)
             with contextlib.suppress(OSError):
                 tmp_path.chmod(0o600)
@@ -1374,7 +1374,7 @@ def _resolve_active_cluster() -> str:
         return env_gateway
     active_file = _xdg_config_home() / "openshell" / "active_gateway"
     try:
-        value = active_file.read_text().strip()
+        value = active_file.read_text(encoding="utf-8").strip()
     except FileNotFoundError:
         raise SandboxError("no active gateway configured") from None
     if value == "":

--- a/python/openshell/sandbox_test.py
+++ b/python/openshell/sandbox_test.py
@@ -1390,20 +1390,16 @@ def test_from_active_cluster_reads_utf8_bytes_from_active_gateway_and_metadata(
     tmp_path: Path,
     monkeypatch: Any,
 ) -> None:
-    gateway_name = "gw-utf8"
+    gateway_name = "gw-é"
     gateway_dir = tmp_path / "openshell" / "gateways" / gateway_name
-    mtls_dir = gateway_dir / "mtls"
-    mtls_dir.mkdir(parents=True)
+    gateway_dir.mkdir(parents=True)
     (tmp_path / "openshell" / "active_gateway").write_bytes(
         gateway_name.encode("utf-8")
     )
-    meta = {"gateway_endpoint": "https://127.0.0.1:8443", "note": "café"}
+    meta = {"gateway_endpoint": "http://tést.example:8080"}
     (gateway_dir / "metadata.json").write_bytes(
         json.dumps(meta, ensure_ascii=False).encode("utf-8")
     )
-    (mtls_dir / "ca.crt").write_bytes(b"ca")
-    (mtls_dir / "tls.crt").write_bytes(b"cert")
-    (mtls_dir / "tls.key").write_bytes(b"key")
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     monkeypatch.delenv("OPENSHELL_GATEWAY", raising=False)
@@ -1411,5 +1407,6 @@ def test_from_active_cluster_reads_utf8_bytes_from_active_gateway_and_metadata(
     client = SandboxClient.from_active_cluster()
     try:
         assert client._cluster_name == gateway_name
+        assert client._endpoint == "tést.example:8080"
     finally:
         client.close()

--- a/python/openshell/sandbox_test.py
+++ b/python/openshell/sandbox_test.py
@@ -1357,7 +1357,7 @@ def test_read_oidc_token_bundle_parses_non_ascii_utf8(tmp_path: Path) -> None:
     gateway_dir.mkdir()
     payload = {"refresh_token": "tok", "issuer": "https://example.com/é"}
     (gateway_dir / "oidc_token.json").write_bytes(
-        json.dumps(payload).encode("utf-8")
+        json.dumps(payload, ensure_ascii=False).encode("utf-8")
     )
     result = _read_oidc_token_bundle(gateway_dir)
     assert result == payload
@@ -1381,6 +1381,35 @@ def test_load_cluster_bearer_token_handles_non_ascii_utf8_oidc(tmp_path: Path) -
         "client_id": "c",
         "client_secret": "s",
     }
-    (gateway_dir / "oidc_token.json").write_bytes(json.dumps(bundle).encode("utf-8"))
+    (gateway_dir / "oidc_token.json").write_bytes(json.dumps(bundle, ensure_ascii=False).encode("utf-8"))
     token = _load_cluster_bearer_token(gateway_dir)
     assert token == "accéss"
+
+
+def test_from_active_cluster_reads_utf8_bytes_from_active_gateway_and_metadata(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    gateway_name = "gw-utf8"
+    gateway_dir = tmp_path / "openshell" / "gateways" / gateway_name
+    mtls_dir = gateway_dir / "mtls"
+    mtls_dir.mkdir(parents=True)
+    (tmp_path / "openshell" / "active_gateway").write_bytes(
+        gateway_name.encode("utf-8")
+    )
+    meta = {"gateway_endpoint": "https://127.0.0.1:8443", "note": "café"}
+    (gateway_dir / "metadata.json").write_bytes(
+        json.dumps(meta, ensure_ascii=False).encode("utf-8")
+    )
+    (mtls_dir / "ca.crt").write_bytes(b"ca")
+    (mtls_dir / "tls.crt").write_bytes(b"cert")
+    (mtls_dir / "tls.key").write_bytes(b"key")
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("OPENSHELL_GATEWAY", raising=False)
+
+    client = SandboxClient.from_active_cluster()
+    try:
+        assert client._cluster_name == gateway_name
+    finally:
+        client.close()

--- a/python/openshell/sandbox_test.py
+++ b/python/openshell/sandbox_test.py
@@ -24,6 +24,7 @@ from openshell.sandbox import (
     _make_cluster_bearer_provider,
     _normalize_bearer,
     _OidcRefresher,
+    _read_oidc_token_bundle,
 )
 
 
@@ -1345,3 +1346,41 @@ def test_inference_set_cluster_forwards_no_verify_flag() -> None:
 
     assert stub.request is not None
     assert stub.request.no_verify is True
+
+
+# ---------------------------------------------------------------------------
+# Encoding regression tests (utf-8 explicit on all config file reads/writes)
+# ---------------------------------------------------------------------------
+
+def test_read_oidc_token_bundle_parses_non_ascii_utf8(tmp_path: Path) -> None:
+    gateway_dir = tmp_path / "gw"
+    gateway_dir.mkdir()
+    payload = {"refresh_token": "tok", "issuer": "https://example.com/é"}
+    (gateway_dir / "oidc_token.json").write_bytes(
+        json.dumps(payload).encode("utf-8")
+    )
+    result = _read_oidc_token_bundle(gateway_dir)
+    assert result == payload
+
+
+def test_read_oidc_token_bundle_returns_none_on_corrupt_bytes(tmp_path: Path) -> None:
+    gateway_dir = tmp_path / "gw"
+    gateway_dir.mkdir()
+    (gateway_dir / "oidc_token.json").write_bytes(b"\xff\xfe not utf-8")
+    assert _read_oidc_token_bundle(gateway_dir) is None
+
+
+def test_load_cluster_bearer_token_handles_non_ascii_utf8_oidc(tmp_path: Path) -> None:
+    gateway_dir = tmp_path / "gw"
+    gateway_dir.mkdir()
+    bundle = {
+        "access_token": "accéss",
+        "refresh_token": "ref",
+        "expiry": "2099-01-01T00:00:00Z",
+        "issuer": "https://example.com",
+        "client_id": "c",
+        "client_secret": "s",
+    }
+    (gateway_dir / "oidc_token.json").write_bytes(json.dumps(bundle).encode("utf-8"))
+    token = _load_cluster_bearer_token(gateway_dir)
+    assert token == "accéss"

--- a/python/openshell/sandbox_test.py
+++ b/python/openshell/sandbox_test.py
@@ -1352,6 +1352,7 @@ def test_inference_set_cluster_forwards_no_verify_flag() -> None:
 # Encoding regression tests (utf-8 explicit on all config file reads/writes)
 # ---------------------------------------------------------------------------
 
+
 def test_read_oidc_token_bundle_parses_non_ascii_utf8(tmp_path: Path) -> None:
     gateway_dir = tmp_path / "gw"
     gateway_dir.mkdir()

--- a/python/openshell/sandbox_test.py
+++ b/python/openshell/sandbox_test.py
@@ -1381,7 +1381,9 @@ def test_load_cluster_bearer_token_handles_non_ascii_utf8_oidc(tmp_path: Path) -
         "client_id": "c",
         "client_secret": "s",
     }
-    (gateway_dir / "oidc_token.json").write_bytes(json.dumps(bundle, ensure_ascii=False).encode("utf-8"))
+    (gateway_dir / "oidc_token.json").write_bytes(
+        json.dumps(bundle, ensure_ascii=False).encode("utf-8")
+    )
     token = _load_cluster_bearer_token(gateway_dir)
     assert token == "accéss"
 


### PR DESCRIPTION
`read_text()` and `fdopen(..., "w")` without an explicit encoding use the system locale, 
which can be non-UTF-8 on some platforms (e.g. Windows).

4 call sites in `sandbox.py` read or write UTF-8 config files without specifying encoding:

- `metadata_path.read_text()` gateway `metadata.json`
- `token_path.read_text()` `oidc_token.json`
- `os.fdopen(fd, "w")` atomic write of `oidc_token.json`
- `active_file.read_text()` `active_gateway` name file

All 4 are now explicit with `encoding="utf-8"`.