### PR TITLE
feat(providers): add anthropic-oauth provider for subscription plan auth

### DIFF
--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -265,7 +265,7 @@ Cluster inference routes store only `provider_name`, `model_id`, and optional
 timeout. The gateway resolves endpoint URLs, protocols, credentials, auth
 style, and route-shaping metadata from the provider record when supervisors call
 `GetInferenceBundle`. Supported provider types for cluster inference are
-`openai`, `anthropic`, `nvidia`, and `google-vertex-ai`.
+`openai`, `anthropic`, `anthropic-oauth`, `nvidia`, and `google-vertex-ai`.
 
 The bundle carries enough information for sandbox-local routers to construct
 upstream URLs without re-deriving provider-specific routing logic. Each resolved
@@ -322,6 +322,20 @@ successful create therefore yields an immediately usable provider; failures roll
 back the provider record. Service-account JSON and private keys are gateway-side
 refresh bootstrap material only; sandbox runtime inference receives minted
 access tokens, not raw service-account material.
+
+The `anthropic-oauth` provider type (alias `claude-plan`) routes the direct
+Anthropic API with a subscription OAuth token instead of an API key. Its
+inference profile uses `Authorization: Bearer` plus a mandatory
+`anthropic-beta: oauth-2025-04-20` default header; the sandbox router merges that
+flag with any client-sent `anthropic-beta` value so the sandbox cannot drop it.
+The CLI `--from-claude-login` harvests the local Claude Code login (macOS
+Keychain `Claude Code-credentials` or `~/.claude/.credentials.json`) on the host,
+stores the access token under the non-injectable `ANTHROPIC_OAUTH_TOKEN`
+credential, and calls `ConfigureProviderRefresh` with the subscription's refresh
+token (Anthropic public `client_id` only, no secret). The background refresh
+worker rotates the access token ahead of expiry and persists Anthropic's rotated
+refresh token. The access token is never exported into sandbox environments; it
+rides the inference route bundle and is injected only at the egress boundary.
 
 ## Supervisor Relay
 

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -716,7 +716,7 @@ impl From<CliEditor> for openshell_cli::ssh::Editor {
 #[derive(Subcommand, Debug)]
 enum ProviderCommands {
     /// Create a provider config.
-    #[command(group = clap::ArgGroup::new("cred_source").required(true).args(["from_existing", "credentials", "from_gcloud_adc", "runtime_credentials"]), help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
+    #[command(group = clap::ArgGroup::new("cred_source").required(true).args(["from_existing", "credentials", "from_gcloud_adc", "from_claude_login", "runtime_credentials"]), help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
     Create {
         /// Provider name.
         #[arg(long)]
@@ -727,25 +727,31 @@ enum ProviderCommands {
         provider_type: String,
 
         /// Load provider credentials/config from existing local state.
-        #[arg(long, conflicts_with_all = ["credentials", "from_gcloud_adc", "runtime_credentials"])]
+        #[arg(long, conflicts_with_all = ["credentials", "from_gcloud_adc", "from_claude_login", "runtime_credentials"])]
         from_existing: bool,
 
         /// Provider credential pair (`KEY=VALUE`) or env lookup key (`KEY`).
         #[arg(
             long = "credential",
             value_name = "KEY[=VALUE]",
-            conflicts_with_all = ["from_existing", "from_gcloud_adc", "runtime_credentials"]
+            conflicts_with_all = ["from_existing", "from_gcloud_adc", "from_claude_login", "runtime_credentials"]
         )]
         credentials: Vec<String>,
 
         /// Configure credentials from gcloud Application Default Credentials
         /// (`~/.config/gcloud/application_default_credentials.json`).
         /// Only valid for google-vertex-ai providers.
-        #[arg(long, group = "cred_source", conflicts_with_all = ["from_existing", "credentials", "runtime_credentials"])]
+        #[arg(long, group = "cred_source", conflicts_with_all = ["from_existing", "credentials", "from_claude_login", "runtime_credentials"])]
         from_gcloud_adc: bool,
 
+        /// Configure credentials from the local Claude Code subscription login
+        /// (macOS Keychain or `~/.claude/.credentials.json`).
+        /// Only valid for anthropic-oauth providers.
+        #[arg(long, group = "cred_source", conflicts_with_all = ["from_existing", "credentials", "from_gcloud_adc", "runtime_credentials"])]
+        from_claude_login: bool,
+
         /// Create a provider whose required credentials are resolved at runtime by the gateway/sandbox.
-        #[arg(long, conflicts_with_all = ["from_existing", "credentials", "from_gcloud_adc"])]
+        #[arg(long, conflicts_with_all = ["from_existing", "credentials", "from_gcloud_adc", "from_claude_login"])]
         runtime_credentials: bool,
 
         /// Provider config key/value pair.
@@ -2834,6 +2840,7 @@ async fn main() -> Result<()> {
                     from_existing,
                     credentials,
                     from_gcloud_adc,
+                    from_claude_login,
                     runtime_credentials,
                     config,
                 } => {
@@ -2844,6 +2851,7 @@ async fn main() -> Result<()> {
                         from_existing,
                         &credentials,
                         from_gcloud_adc,
+                        from_claude_login,
                         runtime_credentials,
                         &config,
                         &tls,

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -4347,6 +4347,178 @@ fn read_gcloud_adc() -> Result<(String, String, String)> {
     Ok((client_id, client_secret, refresh_token))
 }
 
+/// Canonical provider type string for the Anthropic subscription OAuth flow.
+const ANTHROPIC_OAUTH_PROVIDER_TYPE: &str = "anthropic-oauth";
+
+/// Anthropic's public OAuth client ID used by Claude Code. The refresh grant
+/// requires only this client ID (no client secret).
+const ANTHROPIC_OAUTH_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+
+/// OAuth credentials harvested from a local Claude Code subscription login.
+struct ClaudeOauthCredentials {
+    access_token: String,
+    refresh_token: String,
+    /// Access-token expiry in epoch milliseconds (0 if unknown).
+    expires_at_ms: i64,
+}
+
+/// Read the Anthropic subscription OAuth credentials from the local Claude Code
+/// login. Prefers the macOS Keychain item, falling back to
+/// `~/.claude/.credentials.json`.
+fn read_claude_oauth() -> Result<ClaudeOauthCredentials> {
+    if let Some(raw) = read_claude_credentials_keychain()? {
+        return parse_claude_oauth_json(&raw);
+    }
+    if let Some(raw) = read_claude_credentials_file()? {
+        return parse_claude_oauth_json(&raw);
+    }
+    Err(miette::miette!(
+        "no local Claude Code subscription login found. \
+         Run `claude login` (or `claude /login`) on this host first, then retry. \
+         Looked in the macOS Keychain item 'Claude Code-credentials' and \
+         ~/.claude/.credentials.json"
+    ))
+}
+
+/// Read the raw credentials JSON from `~/.claude/.credentials.json`, if present.
+fn read_claude_credentials_file() -> Result<Option<String>> {
+    let home = std::env::var("HOME")
+        .map_err(|_| miette::miette!("HOME is not set; cannot locate the Claude Code login"))?;
+    let path = PathBuf::from(home)
+        .join(".claude")
+        .join(".credentials.json");
+    match std::fs::read_to_string(&path) {
+        Ok(content) => Ok(Some(content)),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(miette::miette!(
+            "failed to read Claude Code credentials file at {}: {err}",
+            path.display()
+        )),
+    }
+}
+
+/// Read the raw credentials JSON from the macOS Keychain. Returns `None` on
+/// non-macOS hosts or when the item is absent.
+#[cfg(target_os = "macos")]
+fn read_claude_credentials_keychain() -> Result<Option<String>> {
+    let output = Command::new("security")
+        .args([
+            "find-generic-password",
+            "-s",
+            "Claude Code-credentials",
+            "-w",
+        ])
+        .output();
+    match output {
+        Ok(out) if out.status.success() => {
+            let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if raw.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(raw))
+            }
+        }
+        // Non-zero exit means the item was not found; fall through to the file.
+        Ok(_) => Ok(None),
+        Err(err) => Err(miette::miette!(
+            "failed to query the macOS Keychain for the Claude Code login: {err}"
+        )),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_claude_credentials_keychain() -> Result<Option<String>> {
+    Ok(None)
+}
+
+/// Parse the Claude Code credentials JSON, extracting the access token, refresh
+/// token, and normalized access-token expiry.
+fn parse_claude_oauth_json(raw: &str) -> Result<ClaudeOauthCredentials> {
+    let json: serde_json::Value = serde_json::from_str(raw)
+        .map_err(|err| miette::miette!("failed to parse Claude Code credentials: {err}"))?;
+
+    let oauth = json.get("claudeAiOauth").ok_or_else(|| {
+        miette::miette!(
+            "Claude Code credentials are missing the 'claudeAiOauth' object; \
+             the local login may be from an incompatible Claude Code version"
+        )
+    })?;
+
+    let access_token = oauth
+        .get("accessToken")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| miette::miette!("Claude Code login is missing 'accessToken'"))?
+        .to_string();
+
+    let refresh_token = oauth
+        .get("refreshToken")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            miette::miette!(
+                "Claude Code login is missing 'refreshToken'; \
+                 gateway-managed refresh requires it"
+            )
+        })?
+        .to_string();
+
+    let expires_at_ms = oauth
+        .get("expiresAt")
+        .and_then(serde_json::Value::as_i64)
+        .map_or(0, normalize_expires_at_ms);
+
+    Ok(ClaudeOauthCredentials {
+        access_token,
+        refresh_token,
+        expires_at_ms,
+    })
+}
+
+/// Normalize an `expiresAt` value to epoch milliseconds. Claude Code stores
+/// milliseconds, but tolerate a seconds-valued timestamp by scaling it up.
+fn normalize_expires_at_ms(value: i64) -> i64 {
+    if value > 0 && value < 1_000_000_000_000 {
+        value * 1000
+    } else {
+        value
+    }
+}
+
+async fn rollback_provider_create_after_claude_login_failure(
+    client: &mut crate::tls::GrpcClient,
+    provider_name: &str,
+    source: &Status,
+) -> Result<()> {
+    match client
+        .delete_provider(DeleteProviderRequest {
+            name: provider_name.to_string(),
+        })
+        .await
+    {
+        Ok(_) => Err(miette!(
+            "failed to configure Anthropic subscription refresh from the local Claude Code login \
+             for provider '{provider_name}': {source}. The provider was rolled back successfully."
+        )),
+        Err(cleanup_err) => {
+            eprintln!(
+                "{} Failed to clean up provider '{}' after configuring refresh failed: {}. \
+                 Run 'openshell provider delete {}' to remove it manually.",
+                "⚠".yellow(),
+                provider_name,
+                cleanup_err,
+                provider_name
+            );
+            Err(miette!(
+                "failed to configure Anthropic subscription refresh from the local Claude Code login \
+                 for provider '{provider_name}': {source}. \
+                 Cleanup also failed, so the provider may still exist. \
+                 Run 'openshell provider delete {provider_name}' to remove it manually."
+            ))
+        }
+    }
+}
+
 async fn rollback_provider_create_after_vertex_adc_failure(
     client: &mut crate::tls::GrpcClient,
     provider_name: &str,
@@ -4519,6 +4691,7 @@ pub async fn provider_create(
         credentials,
         from_gcloud_adc,
         false,
+        false,
         config,
         tls,
     )
@@ -4526,6 +4699,7 @@ pub async fn provider_create(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::fn_params_excessive_bools)]
 pub async fn provider_create_with_options(
     server: &str,
     name: &str,
@@ -4533,6 +4707,7 @@ pub async fn provider_create_with_options(
     from_existing: bool,
     credentials: &[String],
     from_gcloud_adc: bool,
+    from_claude_login: bool,
     runtime_credentials: bool,
     config: &[String],
     tls: &TlsOptions,
@@ -4540,6 +4715,11 @@ pub async fn provider_create_with_options(
     if from_gcloud_adc && (from_existing || !credentials.is_empty() || runtime_credentials) {
         return Err(miette::miette!(
             "--from-gcloud-adc cannot be combined with --from-existing or --credential; it also cannot be combined with --runtime-credentials"
+        ));
+    }
+    if from_claude_login && (from_existing || !credentials.is_empty() || runtime_credentials) {
+        return Err(miette::miette!(
+            "--from-claude-login cannot be combined with --from-existing, --credential, or --runtime-credentials"
         ));
     }
     if from_existing && (!credentials.is_empty() || runtime_credentials) {
@@ -4589,6 +4769,12 @@ pub async fn provider_create_with_options(
         ));
     }
 
+    if from_claude_login && provider_type != ANTHROPIC_OAUTH_PROVIDER_TYPE {
+        return Err(miette::miette!(
+            "--from-claude-login is only valid for anthropic-oauth providers"
+        ));
+    }
+
     let mut credential_map = parse_credential_pairs(credentials)?;
     let mut config_map = parse_key_value_pairs(config, "--config")?;
 
@@ -4607,6 +4793,22 @@ pub async fn provider_create_with_options(
             config_map.entry(key).or_insert(value);
         }
     }
+
+    // Read the local Claude Code login BEFORE creating the provider so a missing
+    // or malformed credential does not leave an orphan provider behind. The
+    // access token is stored as the provider credential; it is marked
+    // non-injectable server-side, so it is only ever injected at the egress
+    // boundary and never inside the sandbox.
+    let claude_login_material = if from_claude_login {
+        let creds = read_claude_oauth()?;
+        credential_map.insert(
+            openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY.to_string(),
+            creds.access_token.clone(),
+        );
+        Some(creds)
+    } else {
+        None
+    };
 
     if credential_map.is_empty() {
         if from_existing {
@@ -4644,6 +4846,19 @@ pub async fn provider_create_with_options(
         None
     };
 
+    // Seed the initial access-token expiry so the gateway's background refresh
+    // worker knows when to mint a fresh token. Sourced from the local Claude
+    // Code login's `expiresAt`.
+    let mut credential_expires_at_ms = HashMap::new();
+    if let Some(creds) = &claude_login_material
+        && creds.expires_at_ms > 0
+    {
+        credential_expires_at_ms.insert(
+            openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY.to_string(),
+            creds.expires_at_ms,
+        );
+    }
+
     let response = client
         .create_provider(CreateProviderRequest {
             provider: Some(Provider {
@@ -4657,7 +4872,7 @@ pub async fn provider_create_with_options(
                 r#type: provider_type.clone(),
                 credentials: credential_map,
                 config: config_map,
-                credential_expires_at_ms: HashMap::new(),
+                credential_expires_at_ms,
             }),
         })
         .await
@@ -4718,6 +4933,42 @@ pub async fn provider_create_with_options(
         println!(
             "Configured Vertex AI credentials from gcloud ADC and minted the initial access token"
         );
+        return Ok(());
+    }
+
+    if let Some(creds) = claude_login_material {
+        let mut material = HashMap::new();
+        material.insert(
+            "client_id".to_string(),
+            ANTHROPIC_OAUTH_CLIENT_ID.to_string(),
+        );
+        material.insert("refresh_token".to_string(), creds.refresh_token);
+
+        // No initial rotate: the access token harvested from the local login is
+        // already valid, and rotating now would invalidate the user's local
+        // Claude Code refresh token (Anthropic rotates refresh tokens on use).
+        // The background worker refreshes only as the token nears expiry.
+        if let Err(configure_err) = client
+            .configure_provider_refresh(ConfigureProviderRefreshRequest {
+                provider: provider_name.clone(),
+                credential_key: openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY.to_string(),
+                strategy: ProviderCredentialRefreshStrategy::Oauth2RefreshToken as i32,
+                material,
+                secret_material_keys: vec!["refresh_token".to_string()],
+                expires_at_ms: (creds.expires_at_ms > 0).then_some(creds.expires_at_ms),
+            })
+            .await
+        {
+            return rollback_provider_create_after_claude_login_failure(
+                &mut client,
+                &provider_name,
+                &configure_err,
+            )
+            .await;
+        }
+
+        println!("{} Created provider {}", "✓".green().bold(), provider_name);
+        println!("Configured Anthropic subscription credentials from the local Claude Code login");
         return Ok(());
     }
 
@@ -9066,6 +9317,80 @@ mod tests {
                 || msg.contains("invalid")
                 || msg.contains("failed"),
             "error message should mention parse/JSON failure, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_claude_oauth_json_extracts_fields() {
+        let raw = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-oat-test",
+                "refreshToken": "sk-ant-ort-test",
+                "expiresAt": 1_750_000_000_000_i64,
+                "scopes": ["user:inference"],
+                "subscriptionType": "pro"
+            }
+        })
+        .to_string();
+        let creds = super::parse_claude_oauth_json(&raw).expect("valid login should parse");
+        assert_eq!(creds.access_token, "sk-ant-oat-test");
+        assert_eq!(creds.refresh_token, "sk-ant-ort-test");
+        assert_eq!(creds.expires_at_ms, 1_750_000_000_000_i64);
+    }
+
+    #[test]
+    fn parse_claude_oauth_json_normalizes_seconds_expiry() {
+        let raw = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-oat-test",
+                "refreshToken": "sk-ant-ort-test",
+                "expiresAt": 1_750_000_000_i64
+            }
+        })
+        .to_string();
+        let creds = super::parse_claude_oauth_json(&raw).expect("valid login should parse");
+        assert_eq!(creds.expires_at_ms, 1_750_000_000_000_i64);
+    }
+
+    #[test]
+    fn parse_claude_oauth_json_missing_refresh_token_errors() {
+        let raw = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-oat-test"
+            }
+        })
+        .to_string();
+        let err = super::parse_claude_oauth_json(&raw)
+            .err()
+            .expect("missing refresh token errors");
+        assert!(
+            err.to_string().contains("refreshToken"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_claude_oauth_json_missing_oauth_object_errors() {
+        let raw = serde_json::json!({ "somethingElse": {} }).to_string();
+        let err = super::parse_claude_oauth_json(&raw)
+            .err()
+            .expect("missing oauth object should error");
+        assert!(
+            err.to_string().contains("claudeAiOauth"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn normalize_expires_at_ms_scales_seconds_only() {
+        assert_eq!(super::normalize_expires_at_ms(0), 0);
+        assert_eq!(
+            super::normalize_expires_at_ms(1_700_000_000),
+            1_700_000_000_000
+        );
+        assert_eq!(
+            super::normalize_expires_at_ms(1_700_000_000_000),
+            1_700_000_000_000
         );
     }
 

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -1192,6 +1192,7 @@ async fn provider_create_allows_empty_credentials_for_gateway_refresh_profiles()
         false,
         &[],
         false,
+        false,
         true,
         &[],
         &ts.tls,

--- a/crates/openshell-core/src/inference.rs
+++ b/crates/openshell-core/src/inference.rs
@@ -91,6 +91,40 @@ static ANTHROPIC_PROFILE: InferenceProviderProfile = InferenceProviderProfile {
     passthrough_headers: &["anthropic-version", "anthropic-beta"],
 };
 
+/// Credential key holding the Anthropic subscription ("plan") OAuth access token.
+///
+/// Written by the gateway's `OAuth2` refresh worker via the `--from-claude-login`
+/// CLI flow and consumed by [`ANTHROPIC_OAUTH_PROFILE`]. This credential is
+/// proxy-only: it is injected as an `Authorization: Bearer` header at the egress
+/// boundary and is never exported into the sandbox environment.
+pub const ANTHROPIC_OAUTH_TOKEN_KEY: &str = "ANTHROPIC_OAUTH_TOKEN";
+
+/// The `anthropic-beta` flag required for requests authenticated with an
+/// Anthropic subscription OAuth token (as opposed to an API key).
+pub const ANTHROPIC_OAUTH_BETA: &str = "oauth-2025-04-20";
+
+/// Inference profile for the Anthropic subscription ("plan") OAuth flow.
+///
+/// Differs from [`ANTHROPIC_PROFILE`] in two ways the Anthropic API requires for
+/// subscription tokens: the token is sent as `Authorization: Bearer <token>`
+/// (not `x-api-key`), and every request must carry `anthropic-beta:
+/// oauth-2025-04-20`. The beta flag is a default header so the boundary forces it
+/// even when the sandbox client does not send it; the router merges it with any
+/// client-supplied `anthropic-beta` value.
+static ANTHROPIC_OAUTH_PROFILE: InferenceProviderProfile = InferenceProviderProfile {
+    provider_type: "anthropic-oauth",
+    default_base_url: "https://api.anthropic.com/v1",
+    protocols: ANTHROPIC_PROTOCOLS,
+    credential_key_names: &[ANTHROPIC_OAUTH_TOKEN_KEY],
+    base_url_config_keys: &["ANTHROPIC_BASE_URL"],
+    auth: AuthHeader::Bearer,
+    default_headers: &[
+        ("anthropic-version", "2023-06-01"),
+        ("anthropic-beta", ANTHROPIC_OAUTH_BETA),
+    ],
+    passthrough_headers: &["anthropic-version", "anthropic-beta"],
+};
+
 /// Credential environment variable names for the Vertex AI provider, in priority order.
 ///
 /// These are referenced by both the provider discovery logic in `openshell-providers`
@@ -166,6 +200,7 @@ pub fn normalize_inference_provider_type(input: &str) -> Option<&'static str> {
     match input.trim().to_ascii_lowercase().as_str() {
         "openai" => Some("openai"),
         "anthropic" => Some("anthropic"),
+        "anthropic-oauth" | "claude-plan" => Some("anthropic-oauth"),
         "nvidia" => Some("nvidia"),
         "google-vertex-ai" | "vertex" | "vertex-ai" | "google-vertex" | "gcp-vertex" => {
             Some("google-vertex-ai")
@@ -182,6 +217,7 @@ pub fn profile_for(provider_type: &str) -> Option<&'static InferenceProviderProf
     match normalize_inference_provider_type(provider_type)? {
         "openai" => Some(&OPENAI_PROFILE),
         "anthropic" => Some(&ANTHROPIC_PROFILE),
+        "anthropic-oauth" => Some(&ANTHROPIC_OAUTH_PROFILE),
         "nvidia" => Some(&NVIDIA_PROFILE),
         "google-vertex-ai" => Some(&VERTEX_AI_PROFILE),
         _ => None,
@@ -377,6 +413,43 @@ mod tests {
         let (auth, headers) = auth_for_provider_type("google-vertex-ai");
         assert_eq!(auth, AuthHeader::Bearer);
         assert!(headers.is_empty());
+    }
+
+    #[test]
+    fn profile_for_anthropic_oauth_types() {
+        for key in &["anthropic-oauth", "claude-plan", "Anthropic-OAuth"] {
+            let profile = profile_for(key).expect("anthropic-oauth profile should be Some");
+            assert_eq!(profile.provider_type, "anthropic-oauth");
+        }
+    }
+
+    #[test]
+    fn normalize_aliases_claude_plan_to_anthropic_oauth() {
+        assert_eq!(
+            normalize_inference_provider_type("claude-plan"),
+            Some("anthropic-oauth")
+        );
+        assert_eq!(
+            normalize_inference_provider_type("anthropic-oauth"),
+            Some("anthropic-oauth")
+        );
+    }
+
+    #[test]
+    fn auth_for_anthropic_oauth_uses_bearer_with_default_headers() {
+        let (auth, headers) = auth_for_provider_type("anthropic-oauth");
+        assert_eq!(auth, AuthHeader::Bearer);
+        assert!(
+            headers
+                .iter()
+                .any(|(k, v)| *k == "anthropic-version" && *v == "2023-06-01")
+        );
+        assert!(
+            headers
+                .iter()
+                .any(|(k, v)| *k == "anthropic-beta" && *v == ANTHROPIC_OAUTH_BETA),
+            "anthropic-beta must be a default header so the sandbox cannot omit it"
+        );
     }
 
     #[test]

--- a/crates/openshell-providers/src/profiles.rs
+++ b/crates/openshell-providers/src/profiles.rs
@@ -20,6 +20,7 @@ use std::sync::OnceLock;
 const PATH_TEMPLATE_CREDENTIAL_PLACEHOLDER: &str = "{credential}";
 
 const BUILT_IN_PROFILE_YAMLS: &[&str] = &[
+    include_str!("../../../providers/anthropic-oauth.yaml"),
     include_str!("../../../providers/claude-code.yaml"),
     include_str!("../../../providers/codex.yaml"),
     include_str!("../../../providers/copilot.yaml"),

--- a/crates/openshell-router/src/backend.rs
+++ b/crates/openshell-router/src/backend.rs
@@ -82,6 +82,23 @@ const VERTEX_ANTHROPIC_VERSION: &str = "vertex-2023-10-16";
 const COMMON_INFERENCE_REQUEST_HEADERS: [&str; 4] =
     ["content-type", "accept", "accept-encoding", "user-agent"];
 
+/// The Anthropic beta-flags header. Its value is a comma-separated token list,
+/// so route-forced flags must be merged with client-supplied ones rather than
+/// overwriting them.
+const ANTHROPIC_BETA_HEADER: &str = "anthropic-beta";
+
+/// Merge a comma-separated `anthropic-beta` value into `tokens`, preserving
+/// order and dropping case-insensitive duplicates and empty entries.
+fn merge_beta_tokens(tokens: &mut Vec<String>, raw: &str) {
+    for token in raw.split(',') {
+        let token = token.trim();
+        if token.is_empty() || tokens.iter().any(|t| t.eq_ignore_ascii_case(token)) {
+            continue;
+        }
+        tokens.push(token.to_string());
+    }
+}
+
 impl StreamingProxyResponse {
     /// Create from a fully-buffered [`ProxyResponse`] (for mock routes).
     pub fn from_buffered(resp: ProxyResponse) -> Self {
@@ -217,17 +234,36 @@ fn prepare_backend_request(
             builder = builder.header(*header_name, &route.api_key);
         }
     }
+    // `anthropic-beta` is handled separately below: a route may both forward a
+    // client-supplied value and force its own (e.g. the Anthropic OAuth profile
+    // must always send `oauth-2025-04-20`). Applying it in this loop would emit a
+    // duplicate header, so collect its tokens instead of forwarding here.
+    let mut beta_tokens: Vec<String> = Vec::new();
     for (name, value) in &headers {
-        builder = builder.header(name.as_str(), value.as_str());
+        if name.eq_ignore_ascii_case(ANTHROPIC_BETA_HEADER) {
+            merge_beta_tokens(&mut beta_tokens, value);
+        } else {
+            builder = builder.header(name.as_str(), value.as_str());
+        }
     }
 
     // Apply route-level default headers (e.g. anthropic-version) unless
-    // the client already sent them.
+    // the client already sent them. `anthropic-beta` defaults are merged into
+    // the client's value rather than skipped, so a forced beta flag survives
+    // alongside any betas the client requested.
     for (name, value) in &route.default_headers {
+        if name.eq_ignore_ascii_case(ANTHROPIC_BETA_HEADER) {
+            merge_beta_tokens(&mut beta_tokens, value);
+            continue;
+        }
         let already_sent = headers.iter().any(|(h, _)| h.eq_ignore_ascii_case(name));
         if !already_sent {
             builder = builder.header(name.as_str(), value.as_str());
         }
+    }
+
+    if !beta_tokens.is_empty() {
+        builder = builder.header(ANTHROPIC_BETA_HEADER, beta_tokens.join(","));
     }
 
     // Rewrite the JSON body for backend compatibility:
@@ -1694,6 +1730,97 @@ mod tests {
             !received_body.as_object().unwrap().contains_key("model"),
             "Vertex Anthropic route must not inject model into the body, got: {received_body}"
         );
+    }
+
+    /// The anthropic-oauth route carries `anthropic-beta: oauth-2025-04-20` as a
+    /// mandatory default header. A client that also sends `anthropic-beta` must
+    /// not be able to drop it: the route default and the client value are merged
+    /// into a single comma-separated header.
+    #[tokio::test]
+    async fn anthropic_oauth_route_merges_mandatory_beta_with_client_betas() {
+        let mock_server = MockServer::start().await;
+
+        let route = ResolvedRoute {
+            name: "inference.local".to_string(),
+            endpoint: mock_server.uri(),
+            model: "claude-sonnet-4-20250514".to_string(),
+            api_key: "sk-ant-oat-test".to_string(),
+            protocols: vec!["anthropic_messages".to_string()],
+            auth: AuthHeader::Bearer,
+            default_headers: vec![
+                ("anthropic-version".to_string(), "2023-06-01".to_string()),
+                ("anthropic-beta".to_string(), "oauth-2025-04-20".to_string()),
+            ],
+            passthrough_headers: vec![
+                "anthropic-version".to_string(),
+                "anthropic-beta".to_string(),
+            ],
+            timeout: DEFAULT_ROUTE_TIMEOUT,
+            model_in_path: false,
+            request_path_override: None,
+        };
+
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "m"})))
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::builder().build().unwrap();
+        let body = bytes::Bytes::from_static(b"{}");
+        let headers = vec![
+            ("content-type".to_string(), "application/json".to_string()),
+            (
+                "anthropic-beta".to_string(),
+                "tool-use-2024-10-22".to_string(),
+            ),
+        ];
+
+        let (builder, _url) = super::prepare_backend_request(
+            &client,
+            &route,
+            "POST",
+            "/v1/messages",
+            &headers,
+            body,
+            false,
+        )
+        .unwrap();
+
+        let response = builder.send().await.unwrap();
+        assert_eq!(response.status().as_u16(), 200);
+
+        let received = mock_server.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1);
+        // The outgoing request must carry a single merged anthropic-beta header
+        // containing both the mandatory OAuth flag and the client's beta.
+        let beta_values: Vec<&str> = received[0]
+            .headers
+            .get_all("anthropic-beta")
+            .iter()
+            .map(|v| v.to_str().unwrap())
+            .collect();
+        assert_eq!(
+            beta_values.len(),
+            1,
+            "anthropic-beta must be emitted exactly once, got: {beta_values:?}"
+        );
+        let merged = beta_values[0];
+        assert!(
+            merged.contains("oauth-2025-04-20"),
+            "mandatory OAuth beta must survive, got: {merged}"
+        );
+        assert!(
+            merged.contains("tool-use-2024-10-22"),
+            "client beta must be preserved, got: {merged}"
+        );
+
+        // The Bearer token must be injected at the boundary as Authorization.
+        let auth = received[0]
+            .headers
+            .get("authorization")
+            .map(|v| v.to_str().unwrap());
+        assert_eq!(auth, Some("Bearer sk-ant-oat-test"));
     }
 
     /// Claude Code and other Anthropic SDK clients always send "model" in the

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -1140,9 +1140,16 @@ fn active_provider_credential_keys(provider: &Provider, now_ms: i64) -> Vec<Stri
 }
 
 fn is_non_injectable_provider_credential(provider: &Provider, key: &str) -> bool {
-    openshell_core::inference::normalize_inference_provider_type(&provider.r#type)
-        == Some("google-vertex-ai")
-        && key == "GOOGLE_SERVICE_ACCOUNT_KEY"
+    match openshell_core::inference::normalize_inference_provider_type(&provider.r#type) {
+        // The Vertex service-account key is used by the gateway to mint tokens; it
+        // must never be exported into the sandbox environment.
+        Some("google-vertex-ai") => key == "GOOGLE_SERVICE_ACCOUNT_KEY",
+        // The Anthropic subscription OAuth access token is injected as a Bearer
+        // header at the egress boundary only. It must never reach the sandbox
+        // environment, so the user never authenticates inside the sandbox.
+        Some("anthropic-oauth") => key == openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY,
+        _ => false,
+    }
 }
 
 pub(super) fn is_valid_env_key(key: &str) -> bool {
@@ -2642,6 +2649,7 @@ mod tests {
         assert_eq!(
             ids,
             vec![
+                "anthropic-oauth",
                 "claude-code",
                 "codex",
                 "copilot",
@@ -4803,6 +4811,64 @@ mod tests {
             result.get("GOOGLE_VERTEX_AI_SERVICE_ACCOUNT_TOKEN"),
             Some(&"ya29.short-lived".to_string())
         );
+    }
+
+    #[test]
+    fn anthropic_oauth_access_token_is_non_injectable() {
+        let provider = Provider {
+            r#type: "anthropic-oauth".to_string(),
+            ..Default::default()
+        };
+        assert!(is_non_injectable_provider_credential(
+            &provider,
+            openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY
+        ));
+        // The alias resolves to the same provider type and stays non-injectable.
+        let aliased = Provider {
+            r#type: "claude-plan".to_string(),
+            ..Default::default()
+        };
+        assert!(is_non_injectable_provider_credential(
+            &aliased,
+            openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY
+        ));
+        // An unrelated key on the same provider is still injectable.
+        assert!(!is_non_injectable_provider_credential(
+            &provider,
+            "SOME_OTHER_KEY"
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolve_provider_env_anthropic_oauth_never_injects_access_token() {
+        let store = test_store().await;
+        create_provider_record(
+            &store,
+            Provider {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: String::new(),
+                    name: "anthropic-plan".to_string(),
+                    created_at_ms: 0,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                }),
+                r#type: "anthropic-oauth".to_string(),
+                credentials: HashMap::from([(
+                    openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY.to_string(),
+                    "sk-ant-oat-secret".to_string(),
+                )]),
+                config: HashMap::new(),
+                credential_expires_at_ms: HashMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let result = resolve_provider_environment(&store, &["anthropic-plan".to_string()])
+            .await
+            .unwrap();
+
+        assert!(!result.contains_key(openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY));
     }
 
     #[tokio::test]

--- a/docs/providers/anthropic-subscription.mdx
+++ b/docs/providers/anthropic-subscription.mdx
@@ -1,0 +1,100 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Anthropic Subscription"
+sidebar-title: "Anthropic Subscription"
+description: "Run Claude Code in a sandbox on an Anthropic Pro or Max subscription, with the OAuth token acquired and refreshed outside the sandbox."
+keywords: "Generative AI, AI Agents, Sandboxing, Anthropic, Claude, OAuth, Subscription, Inference Routing"
+---
+
+The `anthropic-oauth` provider routes `inference.local` traffic to the Anthropic API using a subscription ("plan") OAuth token instead of an API key. You authenticate once on the host with your Anthropic Pro or Max plan, and the gateway refreshes the token and injects it only at the egress boundary. The token is never written into the sandbox environment, filesystem, or logs.
+
+Use this provider when you want sandboxed agents to consume your Claude subscription rather than a metered API key. For API-key access, use a standard `anthropic` provider instead.
+
+## Prerequisites
+
+- A local Claude Code login on an Anthropic Pro or Max plan. Run `claude login` (or `/login` inside Claude Code) on the host before creating the provider.
+- The host running `openshell provider create` must be able to read the local login: the macOS Keychain item `Claude Code-credentials`, or `~/.claude/.credentials.json` on Linux.
+- A gateway and sandbox supervisor image new enough to support the `anthropic-oauth` provider type. The supervisor applies the `Authorization: Bearer` and `anthropic-beta` headers inside the sandbox boundary, so a stale supervisor image silently drops them and Anthropic rejects the request. Keep the gateway and supervisor images on the same build.
+
+## Authentication
+
+Create the provider with `--from-claude-login`:
+
+```shell
+openshell provider create \
+  --name claude-plan \
+  --type anthropic-oauth \
+  --from-claude-login
+```
+
+`--from-claude-login` reads the local Claude Code login, stores the access token as the gateway-side `ANTHROPIC_OAUTH_TOKEN` credential, and configures an OAuth2 refresh-token flow using your subscription's refresh token. The gateway refreshes the access token ahead of expiry and updates running sandboxes without a restart.
+
+The CLI reads the macOS Keychain first, then falls back to `~/.claude/.credentials.json`. If neither contains a login, the command fails and directs you to run `claude login`.
+
+<Note>
+`--from-claude-login` is only valid for `anthropic-oauth` providers. It cannot be combined with `--from-existing`, `--credential`, or `--runtime-credentials`.
+</Note>
+
+<Warning>
+The access token is marked non-injectable: it is stored only as gateway refresh state and is never exported into sandboxes. Sandboxes reach the model through `inference.local`, where the gateway adds the `Authorization: Bearer` header and the required `anthropic-beta: oauth-2025-04-20` flag at the egress boundary.
+</Warning>
+
+## Token Lifecycle
+
+The subscription OAuth token represents your whole plan, so it is shared across every sandbox bound to the provider, and revoking it is provider-wide. Anthropic rotates the refresh token on each refresh; the gateway persists the rotated token so refresh keeps working. The long-lived refresh material lives only in gateway state, never in a sandbox.
+
+To rotate or revoke, delete and recreate the provider, or rotate the credential through `openshell provider refresh`.
+
+## Configure Inference Routing
+
+Enable provider endpoint injection so the Anthropic network endpoint is added to sandbox policies automatically:
+
+```shell
+openshell settings set --global --key providers_v2_enabled --value true --yes
+```
+
+Then point `inference.local` at the provider:
+
+```shell
+openshell inference set \
+  --provider claude-plan \
+  --model claude-sonnet-4-6
+```
+
+Sandboxes on that gateway reach the model at `https://inference.local`. For full details, refer to [Inference Routing](/sandboxes/inference-routing).
+
+## Use from a Sandbox
+
+Agents inside sandboxes reach Anthropic through `inference.local`, not by connecting to the API directly. The gateway holds the subscription token and injects it on egress; the agent only points its SDK at the local endpoint.
+
+The complete setup from scratch:
+
+```shell
+# 1. Enable provider endpoint injection
+openshell settings set --global --key providers_v2_enabled --value true --yes
+
+# 2. Authenticate on the host, then create the provider
+claude login
+openshell provider create --name claude-plan --type anthropic-oauth --from-claude-login
+
+# 3. Configure inference routing
+openshell inference set --provider claude-plan --model claude-sonnet-4-6
+
+# 4. Create a sandbox with the provider attached
+openshell sandbox create --name my-sandbox --provider claude-plan
+```
+
+Then inside the sandbox, launch Claude Code against the local endpoint:
+
+```shell
+ANTHROPIC_BASE_URL="https://inference.local" ANTHROPIC_API_KEY=unused claude -p "Reply with exactly: pong"
+```
+
+Setting `ANTHROPIC_API_KEY` to any placeholder makes Claude Code talk to the gateway endpoint directly instead of starting its own OAuth login flow inside the sandbox. The placeholder key never reaches Anthropic — `inference.local` strips it and injects the real subscription token before forwarding. Drop the `-p "…"` to launch the interactive TUI instead.
+
+## Next Steps
+
+- To configure `inference.local` routing, refer to [Inference Routing](/sandboxes/inference-routing).
+- To manage provider credentials and refresh, refer to [Providers](/sandboxes/manage-providers).
+- To apply network policies to sandboxes using this provider, refer to [Policies](/sandboxes/policies).

--- a/docs/sandboxes/manage-providers.mdx
+++ b/docs/sandboxes/manage-providers.mdx
@@ -284,6 +284,7 @@ The following providers have been tested with `inference.local`. Any provider th
 |---|---|---|---|---|
 | NVIDIA API Catalog | `nvidia-prod` | `nvidia` | `https://integrate.api.nvidia.com/v1` | `NVIDIA_API_KEY` |
 | Anthropic | `anthropic-prod` | `anthropic` | `https://api.anthropic.com` | `ANTHROPIC_API_KEY` |
+| Anthropic (subscription) | `claude-plan` | `anthropic-oauth` | `https://api.anthropic.com` | OAuth — use `--from-claude-login` |
 | Google Vertex AI | `vertex-prod` | `google-vertex-ai` | Regional, global, or multi-region Vertex endpoint | `GOOGLE_VERTEX_AI_TOKEN` or `GOOGLE_VERTEX_AI_SERVICE_ACCOUNT_TOKEN` |
 | Baseten | `baseten` | `openai` | `https://inference.baseten.co/v1` | `OPENAI_API_KEY` |
 | Bitdeer AI | `bitdeer` | `openai` | `https://api-inference.bitdeer.ai/v1` | `OPENAI_API_KEY` |
@@ -292,7 +293,7 @@ The following providers have been tested with `inference.local`. Any provider th
 | Ollama (local) | `ollama` | `openai` | `http://host.openshell.internal:11434/v1` | `OPENAI_API_KEY` |
 | LM Studio (local) | `lmstudio` | `openai` | `http://host.openshell.internal:1234/v1` | `OPENAI_API_KEY` |
 
-Refer to your provider's documentation for the correct base URL, available models, and API key setup. For the Vertex-specific auth flows and config keys, refer to [Google Vertex AI](/providers/google-vertex-ai). To configure inference routing, refer to [Inference Routing](/sandboxes/inference-routing).
+Refer to your provider's documentation for the correct base URL, available models, and API key setup. For the Vertex-specific auth flows and config keys, refer to [Google Vertex AI](/providers/google-vertex-ai). To run Claude Code on an Anthropic Pro or Max subscription with the token acquired outside the sandbox, refer to [Anthropic Subscription](/providers/anthropic-subscription). To configure inference routing, refer to [Inference Routing](/sandboxes/inference-routing).
 
 ## Next Steps
 

--- a/providers/anthropic-oauth.yaml
+++ b/providers/anthropic-oauth.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: anthropic-oauth
+display_name: Anthropic (Subscription OAuth)
+description: Anthropic Claude inference using a subscription ("plan") OAuth token. The token is refreshed by the gateway and injected only at the egress boundary, never inside the sandbox.
+category: inference
+inference_capable: true
+credentials:
+  - name: oauth_token
+    description: Anthropic subscription OAuth access token; injected as an Authorization Bearer header at the egress boundary and never exported into sandboxes
+    env_vars: [ANTHROPIC_OAUTH_TOKEN]
+    required: false
+    auth_style: bearer
+    header_name: authorization
+    refresh:
+      strategy: oauth2_refresh_token
+      token_url: https://console.anthropic.com/v1/oauth/token
+      refresh_before_seconds: 300
+      max_lifetime_seconds: 28800
+      material:
+        - name: client_id
+          description: Anthropic public OAuth client ID
+          required: true
+        - name: refresh_token
+          description: Anthropic OAuth refresh token harvested from the local Claude Code login
+          required: true
+          secret: true
+discovery:
+  credentials: [oauth_token]
+endpoints:
+  - host: api.anthropic.com
+    port: 443
+    protocol: rest
+    access: read-write
+    enforcement: enforce


### PR DESCRIPTION
## Summary

Adds an `anthropic-oauth` provider type (alias `claude-plan`) so sandboxes can run Claude Code on an Anthropic Pro/Max **subscription** plan instead of a metered API key. The subscription OAuth token is harvested, stored, and refreshed entirely **outside** the sandbox and injected only at the egress proxy boundary — it is never written into the sandbox environment, filesystem, or logs. This reuses the existing gateway-side OAuth2 refresh machinery and the non-injectable/proxy-only credential path (the same pattern as the Vertex `--from-gcloud-adc` flow).

## Related Issue

N/A — no tracking issue.

## Changes

- **inference** (`openshell-core`): new `anthropic-oauth` profile — `Authorization: Bearer` plus a mandatory `anthropic-beta: oauth-2025-04-20` default header (subscription tokens require it where API keys do not). `normalize_inference_provider_type` aliases `claude-plan`.
- **router** (`openshell-router`): merge the mandatory `anthropic-beta` flag with any client-sent `anthropic-beta` value into a single header, so a sandbox client cannot drop the OAuth flag (and we never emit a duplicate header).
- **server** (`openshell-server`): mark `ANTHROPIC_OAUTH_TOKEN` non-injectable so it rides the inference route bundle but is never exported into the sandbox env.
- **cli** (`openshell-cli`): `provider create --from-claude-login` reads the local Claude Code login (macOS Keychain `Claude Code-credentials` or `~/.claude/.credentials.json`), stores the access token as the proxy-only credential, and configures the gateway's `Oauth2RefreshToken` background refresh (Anthropic public `client_id`, no client secret). Includes create-failure rollback.
- **provider profile**: new `providers/anthropic-oauth.yaml`.
- **docs**: new `docs/providers/anthropic-subscription.mdx`; updated `architecture/gateway.md` and the provider table in `docs/sandboxes/manage-providers.mdx`.

## Testing

- [x] `mise run pre-commit` passes (lint, format, license headers, full unit suite — clippy `-D warnings` clean).
- [x] Unit tests added: profile/alias resolution and Bearer + default-header derivation; the non-injectable rule and a `resolve_provider_environment` assertion that the access token is never returned to the sandbox; the router `anthropic-beta` merge (mandatory flag survives, no duplicate, Bearer injected); CLI credential JSON parsing (field extraction, ms/seconds expiry normalization, missing-field errors).
- [x] **Manual e2e on macOS (validated end-to-end):** `claude login` on host → `openshell provider create --name claude-plan --type anthropic-oauth --from-claude-login` → `openshell inference set --provider claude-plan --model claude-sonnet-4-6` → sandbox bound to the provider → `ANTHROPIC_BASE_URL=https://inference.local ANTHROPIC_API_KEY=unused claude -p "…"` returns a 200 completion.
- [x] **Token-never-in-sandbox verified:** inside the sandbox the OAuth token does not appear in env/filesystem; the `Authorization: Bearer` header is applied at the egress boundary, not by the sandbox.
- [ ] **Linux not yet validated.** The CLI reader is OS-agnostic for the file path: the Keychain reader is macOS-gated and falls through to `~/.claude/.credentials.json`, which is where Claude Code writes its login on Linux. This should work unchanged but has not been validated on Linux (and a keyring-backed Linux login, if any, is not yet supported).

### Note for maintainers (ghcr images)

The **supervisor** applies the Bearer + `anthropic-beta` headers at the sandbox boundary, so the `supervisor` image must be rebuilt for this feature to take effect — a stale supervisor silently drops the headers and Anthropic rejects the request. On merge to `main`, `release-dev.yml` rebuilds and republishes `gateway:dev` and `supervisor:dev`, so keep the two on the same build.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (`architecture/gateway.md`) and user docs added (`docs/providers/anthropic-subscription.mdx`)
