### PR TITLE
fix(e2e): refresh latest sandbox image for docker runs

### DIFF
--- a/e2e/with-docker-gateway.sh
+++ b/e2e/with-docker-gateway.sh
@@ -13,6 +13,13 @@
 #
 # HTTPS endpoint-only mode is intentionally unsupported here. Use a named
 # gateway config when mTLS materials are needed.
+#
+# Sandbox image overrides:
+#   OPENSHELL_E2E_DOCKER_SANDBOX_IMAGE=...
+#   OPENSHELL_E2E_DOCKER_SANDBOX_IMAGE_PULL_POLICY=Always|IfNotPresent|Never
+#
+# The default community sandbox image uses :latest and is pulled with Always so
+# local e2e runs do not reuse stale images that drift from the repo toolchain.
 
 set -euo pipefail
 
@@ -342,6 +349,34 @@ ensure_docker_supervisor_image() {
   exit 2
 }
 
+image_uses_latest_tag() {
+  local image=$1
+  local last_component
+
+  # Digest references are immutable even if the tag portion says latest.
+  if [[ "${image}" == *@* ]]; then
+    return 1
+  fi
+
+  last_component="${image##*/}"
+  # Docker treats an omitted tag as :latest.
+  if [[ "${last_component}" != *:* ]]; then
+    return 0
+  fi
+
+  [[ "${last_component}" == *:latest ]]
+}
+
+default_sandbox_pull_policy() {
+  local image=$1
+
+  if image_uses_latest_tag "${image}"; then
+    printf '%s\n' "Always"
+  else
+    printf '%s\n' "IfNotPresent"
+  fi
+}
+
 DAEMON_ARCH="$(normalize_arch "$(docker info --format '{{.Architecture}}' 2>/dev/null || true)")"
 SUPERVISOR_TARGET="$(linux_target_triple "${DAEMON_ARCH}")"
 HOST_OS="$(uname -s)"
@@ -386,6 +421,10 @@ fi
 
 DEFAULT_SANDBOX_IMAGE="ghcr.io/nvidia/openshell-community/sandboxes/base:latest"
 SANDBOX_IMAGE="${OPENSHELL_E2E_DOCKER_SANDBOX_IMAGE:-${OPENSHELL_SANDBOX_IMAGE:-${DEFAULT_SANDBOX_IMAGE}}}"
+SANDBOX_IMAGE_PULL_POLICY="${OPENSHELL_E2E_DOCKER_SANDBOX_IMAGE_PULL_POLICY:-${OPENSHELL_SANDBOX_IMAGE_PULL_POLICY:-}}"
+if [ -z "${SANDBOX_IMAGE_PULL_POLICY}" ]; then
+  SANDBOX_IMAGE_PULL_POLICY="$(default_sandbox_pull_policy "${SANDBOX_IMAGE}")"
+fi
 if ! docker image inspect "${SANDBOX_IMAGE}" >/dev/null 2>&1; then
   echo "Pulling ${SANDBOX_IMAGE}..."
   if ! docker_pull_with_retry "${SANDBOX_IMAGE}"; then
@@ -420,6 +459,7 @@ else
 fi
 
 echo "Starting openshell-gateway on port ${HOST_PORT} (namespace: ${E2E_NAMESPACE})..."
+echo "Using sandbox image: ${SANDBOX_IMAGE} (pull policy: ${SANDBOX_IMAGE_PULL_POLICY})"
 e2e_generate_gateway_jwt "${JWT_DIR}"
 
 # Driver-specific options moved from CLI flags into a TOML config table
@@ -446,7 +486,7 @@ GATEWAY_CONFIG="${STATE_DIR}/gateway.toml"
   printf 'network_name = %s\n'         "$(toml_string "${DOCKER_NETWORK_NAME}")"
   printf 'grpc_endpoint = %s\n'        "$(toml_string "${GATEWAY_ENDPOINT}")"
   printf 'default_image = %s\n'        "$(toml_string "${SANDBOX_IMAGE}")"
-  printf 'image_pull_policy = "IfNotPresent"\n'
+  printf 'image_pull_policy = %s\n'    "$(toml_string "${SANDBOX_IMAGE_PULL_POLICY}")"
   printf 'guest_tls_ca = %s\n'         "$(toml_string "${PKI_DIR}/ca.crt")"
   printf 'guest_tls_cert = %s\n'       "$(toml_string "${PKI_DIR}/client/tls.crt")"
   printf 'guest_tls_key = %s\n'        "$(toml_string "${PKI_DIR}/client/tls.key")"

--- a/e2e/with-docker-gateway.sh
+++ b/e2e/with-docker-gateway.sh
@@ -18,8 +18,9 @@
 #   OPENSHELL_E2E_DOCKER_SANDBOX_IMAGE=...
 #   OPENSHELL_E2E_DOCKER_SANDBOX_IMAGE_PULL_POLICY=Always|IfNotPresent|Never
 #
-# The default community sandbox image uses :latest and is pulled with Always so
-# local e2e runs do not reuse stale images that drift from the repo toolchain.
+# The default community sandbox image uses :latest. This wrapper refreshes it
+# before starting the gateway, while the Docker driver defaults to IfNotPresent
+# so local Dockerfile-built images remain usable.
 
 set -euo pipefail
 
@@ -367,14 +368,21 @@ image_uses_latest_tag() {
   [[ "${last_component}" == *:latest ]]
 }
 
-default_sandbox_pull_policy() {
+ensure_sandbox_image_available() {
   local image=$1
 
   if image_uses_latest_tag "${image}"; then
-    printf '%s\n' "Always"
-  else
-    printf '%s\n' "IfNotPresent"
+    echo "Refreshing latest sandbox image ${image}..."
+    docker_pull_with_retry "${image}"
+    return
   fi
+
+  if docker image inspect "${image}" >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "Pulling ${image}..."
+  docker_pull_with_retry "${image}"
 }
 
 DAEMON_ARCH="$(normalize_arch "$(docker info --format '{{.Architecture}}' 2>/dev/null || true)")"
@@ -421,16 +429,10 @@ fi
 
 DEFAULT_SANDBOX_IMAGE="ghcr.io/nvidia/openshell-community/sandboxes/base:latest"
 SANDBOX_IMAGE="${OPENSHELL_E2E_DOCKER_SANDBOX_IMAGE:-${OPENSHELL_SANDBOX_IMAGE:-${DEFAULT_SANDBOX_IMAGE}}}"
-SANDBOX_IMAGE_PULL_POLICY="${OPENSHELL_E2E_DOCKER_SANDBOX_IMAGE_PULL_POLICY:-${OPENSHELL_SANDBOX_IMAGE_PULL_POLICY:-}}"
-if [ -z "${SANDBOX_IMAGE_PULL_POLICY}" ]; then
-  SANDBOX_IMAGE_PULL_POLICY="$(default_sandbox_pull_policy "${SANDBOX_IMAGE}")"
-fi
-if ! docker image inspect "${SANDBOX_IMAGE}" >/dev/null 2>&1; then
-  echo "Pulling ${SANDBOX_IMAGE}..."
-  if ! docker_pull_with_retry "${SANDBOX_IMAGE}"; then
-    echo "ERROR: sandbox image '${SANDBOX_IMAGE}' is not available." >&2
-    exit 2
-  fi
+SANDBOX_IMAGE_PULL_POLICY="${OPENSHELL_E2E_DOCKER_SANDBOX_IMAGE_PULL_POLICY:-${OPENSHELL_SANDBOX_IMAGE_PULL_POLICY:-IfNotPresent}}"
+if ! ensure_sandbox_image_available "${SANDBOX_IMAGE}"; then
+  echo "ERROR: sandbox image '${SANDBOX_IMAGE}' is not available." >&2
+  exit 2
 fi
 
 PKI_DIR="${WORKDIR}/pki"


### PR DESCRIPTION


## Summary
This fixes an issue where you may run e.g. `mise run e2e:python`, then after Python is upgraded in mise.toml, subsequent runs of `e2e:python` fail because the Python version is out of sync.

Agent notes:
<details>

* Python 3.14.5 is selected by mise.toml:22.
* e2e:python runs uv run pytest through tasks/test.toml:74, using that mise-managed Python.
* The sandbox image was relying on ghcr.io/nvidia/openshell-community/sandboxes/base:latest in e2e/with-docker-gateway.sh:422.
* The stale-image bug came from pairing that mutable latest tag with image_pull_policy = "IfNotPresent".

I changed the Docker e2e wrapper so:

* :latest or omitted-tag images use image_pull_policy = "Always".
* pinned tags and digest refs use IfNotPresent.
* callers can override with OPENSHELL_E2E_DOCKER_SANDBOX_IMAGE_PULL_POLICY or OPENSHELL_SANDBOX_IMAGE_PULL_POLICY.

I chose pull-on-latest over pinning because this path already depends on the community base:latest image tracking the repo toolchain. Pinning a digest would just move the sync burden into the repo every time Python changes.
</details>

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
* Changes the ImagePullPolicy to Always when pulling an image with either `latest` or no tag (which is treated as `latest`)



## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
