### PR TITLE
test(e2e): retry forward proxy stale policy flake

### DIFF
--- a/e2e/rust/tests/forward_proxy_graphql_l7.rs
+++ b/e2e/rust/tests/forward_proxy_graphql_l7.rs
@@ -218,6 +218,19 @@ def forward_persisted_get_status(hash_value):
         error.read()
         return error.code
 
+# The sandbox may resolve policy binary symlinks shortly after the entrypoint
+# starts, bumping the policy generation during the first forward request.
+# Retry expected-allowed forward requests so the test still targets L7 behavior.
+def retry_forward_allowed(label, request_fn):
+    last_status = None
+    for attempt in range(6):
+        last_status = request_fn()
+        if last_status != 403:
+            return last_status
+        DETAILS[f"{{label}}_transient_403_attempts"] = attempt + 1
+        time.sleep(0.3)
+    return last_status
+
 def proxy_parts(*names):
     proxy_url = next((os.environ.get(name) for name in names if os.environ.get(name)), None)
     parsed = urllib.parse.urlparse(proxy_url)
@@ -379,14 +392,14 @@ def connect_chunked_status(query):
     return connect_http_status("connect_chunked_query_allowed", request)
 
 results = {{
-    "forward_query_allowed": forward_status(QUERY_VIEWER),
-    "forward_get_query_allowed": forward_get_status(QUERY_VIEWER),
+    "forward_query_allowed": retry_forward_allowed("forward_query_allowed", lambda: forward_status(QUERY_VIEWER)),
+    "forward_get_query_allowed": retry_forward_allowed("forward_get_query_allowed", lambda: forward_get_status(QUERY_VIEWER)),
     "forward_duplicate_get_denied": forward_duplicate_get_status(),
-    "forward_persisted_get_allowed": forward_persisted_get_status("abc123"),
+    "forward_persisted_get_allowed": retry_forward_allowed("forward_persisted_get_allowed", lambda: forward_persisted_get_status("abc123")),
     "forward_unregistered_persisted_get_denied": forward_persisted_get_status("missing"),
-    "forward_chunked_query_allowed": forward_chunked_status(QUERY_VIEWER),
+    "forward_chunked_query_allowed": retry_forward_allowed("forward_chunked_query_allowed", lambda: forward_chunked_status(QUERY_VIEWER)),
     "forward_unlisted_field_denied": forward_status(QUERY_REPOSITORY),
-    "forward_mutation_allowed": forward_status(MUTATION_CREATE),
+    "forward_mutation_allowed": retry_forward_allowed("forward_mutation_allowed", lambda: forward_status(MUTATION_CREATE)),
     "forward_deny_rule_denied": forward_status(MUTATION_DELETE),
     "connect_query_allowed": connect_status(QUERY_VIEWER, "connect_query_allowed"),
     "connect_get_query_allowed": connect_get_status(QUERY_VIEWER, "connect_get_query_allowed"),

--- a/e2e/rust/tests/forward_proxy_l7_bypass.rs
+++ b/e2e/rust/tests/forward_proxy_l7_bypass.rs
@@ -109,15 +109,25 @@ async fn forward_proxy_allows_l7_permitted_request() {
 
     let script = format!(
         r#"
-import urllib.request, urllib.error, json, sys
+import urllib.request, urllib.error, json, sys, time
 url = "http://{host}:{port}/allowed"
-try:
-    resp = urllib.request.urlopen(url, timeout=15)
-    print(json.dumps({{"status": resp.status, "error": None}}))
-except urllib.error.HTTPError as e:
-    print(json.dumps({{"status": e.code, "error": str(e)}}))
-except Exception as e:
-    print(json.dumps({{"status": -1, "error": str(e)}}))
+# Retry expected-allowed requests across the startup symlink-resolution reload,
+# which can transiently surface as a stale-policy 403 in the forward proxy.
+last = {{"status": -1, "error": "not attempted"}}
+for attempt in range(6):
+    try:
+        resp = urllib.request.urlopen(url, timeout=15)
+        last = {{"status": resp.status, "error": None, "attempt": attempt + 1}}
+        break
+    except urllib.error.HTTPError as e:
+        last = {{"status": e.code, "error": str(e), "attempt": attempt + 1}}
+        if e.code != 403:
+            break
+        time.sleep(0.3)
+    except Exception as e:
+        last = {{"status": -1, "error": str(e), "attempt": attempt + 1}}
+        break
+print(json.dumps(last))
 "#,
         host = server.host,
         port = server.port,


### PR DESCRIPTION
## Summary

Retry expected-allowed forward-proxy e2e requests across the startup policy symlink-resolution reload. This addresses the main-branch Release Dev flake where an in-flight forward request can see a stale policy generation and transiently return `403`.

## Related Issue

Refs #1810

## Changes

- Added a bounded retry helper for expected-allowed GraphQL forward-proxy requests.
- Added a bounded retry around the expected-allowed REST L7 forward-proxy request.
- Left denied-request assertions unchanged so permanent L7 policy regressions still fail.

## Testing

- [ ] `mise run pre-commit` passes
- [x] E2E tests added/updated
- [x] `rustfmt --edition 2024 --check e2e/rust/tests/forward_proxy_graphql_l7.rs e2e/rust/tests/forward_proxy_l7_bypass.rs`
- [x] `cargo test --manifest-path e2e/rust/Cargo.toml --features e2e-docker --test forward_proxy_l7_bypass --no-run`
- [x] `cargo test --manifest-path e2e/rust/Cargo.toml --features e2e-docker --test forward_proxy_graphql_l7 --no-run`
- [x] `git diff --check -- e2e/rust/tests/forward_proxy_graphql_l7.rs e2e/rust/tests/forward_proxy_l7_bypass.rs`

`mise run pre-commit` was attempted locally but did not complete in this temporary worktree. It failed `python:proto` while the newly-created venv was missing `grpc_tools`; the Rust lint phase also hit local toolchain/dependency failures (`z3.h` missing for `z3-sys`, plus an `aws-lc-sys` GCC/macOS SDK compile error). The focused e2e targets compile.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
