### PR TITLE
feat(policy): add MCP-aware JSON-RPC L7 governance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3782,6 +3782,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite 0.26.2",
+ "tower-mcp-types",
  "tracing",
  "uuid",
  "webpki-roots 1.0.7",
@@ -6454,6 +6455,18 @@ name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-mcp-types"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6511f1f32c7cb7fd4525edc0eb4dcf307db8f7eceb2833ab24a37b4cc10cda61"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = ["crates/*"]
 [workspace.package]
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.90"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA/OpenShell"
 
@@ -73,6 +73,7 @@ serde_json = "1"
 serde_yml = "0.0.12"
 toml = "0.8"
 apollo-parser = "0.8.5"
+tower-mcp-types = "0.12.0"
 
 # HTTP client
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }

--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -51,11 +51,14 @@ identifies the calling binary, checks trust-on-first-use binary identity, reject
 unsafe internal destinations, and evaluates the active policy.
 For inspected HTTP traffic, the proxy can enforce REST method/path rules,
 WebSocket upgrade and text-message rules, GraphQL operation rules, and
-JSON-RPC method and params rules on sandbox-to-server request bodies. JSON-RPC
-request inspection buffers up to the endpoint `json_rpc.max_body_bytes` limit.
-Literal dotted keys in JSON-RPC params are accepted. If a literal key and a
-flattened nested selector path produce the same matcher key, the literal key
-takes precedence.
+MCP or generic JSON-RPC method and params rules on sandbox-to-server request
+bodies. MCP and JSON-RPC inspection buffers up to the endpoint
+`mcp.max_body_bytes` or `json_rpc.max_body_bytes` limit. MCP `tools/call`
+tool names are checked against the spec-recommended syntax by default before
+policy evaluation, with a per-endpoint `mcp.strict_tool_names` compatibility
+opt-out. Literal dotted keys in generic JSON-RPC params are accepted. If a
+literal key and a flattened nested selector path produce the same matcher key,
+the literal key takes precedence.
 JSON-RPC responses and server-to-client MCP messages on response or SSE streams
 are relayed but are not currently parsed for policy enforcement.
 

--- a/crates/openshell-policy/src/lib.rs
+++ b/crates/openshell-policy/src/lib.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use openshell_core::proto::{
     FilesystemPolicy, GraphqlOperation, L7Allow, L7DenyRule, L7QueryMatcher, L7Rule,
-    LandlockPolicy, NetworkBinary, NetworkEndpoint, NetworkPolicyRule, ProcessPolicy,
+    LandlockPolicy, McpOptions, NetworkBinary, NetworkEndpoint, NetworkPolicyRule, ProcessPolicy,
     SandboxPolicy,
 };
 use serde::{Deserialize, Serialize};
@@ -137,6 +137,8 @@ struct NetworkEndpointDef {
     graphql_max_body_bytes: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     json_rpc: Option<JsonRpcConfigDef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    mcp: Option<McpConfigDef>,
 }
 
 // Signature dictated by serde's `skip_serializing_if`, which requires `&T`.
@@ -160,6 +162,31 @@ struct JsonRpcConfigDef {
 
 fn json_rpc_config_from_proto(max_body_bytes: u32) -> Option<JsonRpcConfigDef> {
     (max_body_bytes > 0).then_some(JsonRpcConfigDef { max_body_bytes })
+}
+
+// MCP rides the same HTTP/JSON-RPC inspection machinery at runtime, but it
+// gets its own policy stanza so user-authored YAML can name the primary
+// protocol instead of treating MCP as generic JSON-RPC.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct McpConfigDef {
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    max_body_bytes: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    strict_tool_names: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    allow_all_known_mcp_methods: Option<bool>,
+}
+
+fn mcp_config_from_proto(max_body_bytes: u32, mcp: Option<&McpOptions>) -> Option<McpConfigDef> {
+    let strict_tool_names = mcp.and_then(|config| config.strict_tool_names);
+    let allow_all_known_mcp_methods = mcp.and_then(|config| config.allow_all_known_mcp_methods);
+    (max_body_bytes > 0 || strict_tool_names.is_some() || allow_all_known_mcp_methods.is_some())
+        .then_some(McpConfigDef {
+            max_body_bytes,
+            strict_tool_names,
+            allow_all_known_mcp_methods,
+        })
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -196,18 +223,31 @@ struct L7AllowDef {
     operation_name: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     fields: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tool: Option<QueryMatcherDef>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    params: BTreeMap<String, QueryMatcherDef>,
+    params: BTreeMap<String, ParamMatcherDef>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 enum QueryMatcherDef {
+    // Short form: `query: { repo: "NVIDIA/*" }`.
     Glob(String),
+    // Expanded form: `query: { repo: { any: ["NVIDIA/*", "openai/*"] } }`.
     Any(QueryAnyDef),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+// JSON-RPC/MCP params can be authored as nested maps in YAML, but the runtime
+// matcher map remains flat so the Rego policy can share query-param matching.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum ParamMatcherDef {
+    Matcher(QueryMatcherDef),
+    Object(BTreeMap<String, Self>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct QueryAnyDef {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -231,8 +271,10 @@ struct L7DenyRuleDef {
     operation_name: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     fields: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tool: Option<QueryMatcherDef>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    params: BTreeMap<String, QueryMatcherDef>,
+    params: BTreeMap<String, ParamMatcherDef>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -267,6 +309,289 @@ fn matcher_proto_to_def(matcher: L7QueryMatcher) -> QueryMatcherDef {
     }
 }
 
+// Convert user-authored nested params maps into the flat proto/Rego keyspace.
+// For example, `arguments: { scope: "x" }` becomes `arguments.scope`.
+fn flatten_param_matchers(
+    params: BTreeMap<String, ParamMatcherDef>,
+) -> BTreeMap<String, QueryMatcherDef> {
+    let mut flattened = BTreeMap::new();
+    for (key, matcher) in params {
+        flatten_param_matcher(&key, matcher, &mut flattened);
+    }
+    flattened
+}
+
+// Walk one params subtree, carrying the flattened dot-path key accumulated so
+// far. Leaf matchers are inserted into the map consumed by the runtime policy.
+fn flatten_param_matcher(
+    key: &str,
+    matcher: ParamMatcherDef,
+    out: &mut BTreeMap<String, QueryMatcherDef>,
+) {
+    match matcher {
+        ParamMatcherDef::Matcher(matcher) => {
+            out.insert(key.to_string(), matcher);
+        }
+        ParamMatcherDef::Object(children) => {
+            for (child_key, child) in children {
+                let nested_key = format!("{key}.{child_key}");
+                flatten_param_matcher(&nested_key, child, out);
+            }
+        }
+    }
+}
+
+// Convert flat runtime params back to YAML. MCP gets readable nested params
+// when the flat keys can be losslessly split; generic JSON-RPC keeps flat keys.
+fn flat_params_to_def(
+    protocol: &str,
+    params: BTreeMap<String, QueryMatcherDef>,
+) -> BTreeMap<String, ParamMatcherDef> {
+    let flat = params.into_iter().collect::<Vec<_>>();
+    // Generic JSON-RPC keeps the flat form because JSON-RPC does not define a
+    // conventional params object shape. MCP uses nested YAML for readability.
+    if !is_mcp_protocol(protocol) {
+        return flat_param_matchers_to_def(flat);
+    }
+
+    let mut nested = BTreeMap::new();
+    for (key, matcher) in &flat {
+        if insert_nested_param(&mut nested, key, ParamMatcherDef::Matcher(matcher.clone())).is_err()
+        {
+            return flat_param_matchers_to_def(flat);
+        }
+    }
+    nested
+}
+
+fn flat_param_matchers_to_def(
+    params: Vec<(String, QueryMatcherDef)>,
+) -> BTreeMap<String, ParamMatcherDef> {
+    params
+        .into_iter()
+        .map(|(key, matcher)| (key, ParamMatcherDef::Matcher(matcher)))
+        .collect()
+}
+
+// Build one nested params path from a flat key. Collisions such as `a` and
+// `a.b` cannot round-trip as nested YAML, so callers fall back to the flat map.
+fn insert_nested_param(
+    root: &mut BTreeMap<String, ParamMatcherDef>,
+    key: &str,
+    matcher: ParamMatcherDef,
+) -> Result<(), ()> {
+    let mut parts = key.split('.').peekable();
+    let Some(first) = parts.next() else {
+        return Err(());
+    };
+
+    if parts.peek().is_none() {
+        root.insert(first.to_string(), matcher);
+        return Ok(());
+    }
+
+    let child = root
+        .entry(first.to_string())
+        .or_insert_with(|| ParamMatcherDef::Object(BTreeMap::new()));
+    let ParamMatcherDef::Object(children) = child else {
+        return Err(());
+    };
+    let remainder = parts.collect::<Vec<_>>().join(".");
+    insert_nested_param(children, &remainder, matcher)
+}
+
+// MCP `tool` is a policy convenience for the standard `tools/call` params.name
+// field. When the endpoint method profile is enabled, authored tool selectors
+// can omit method and are normalized to tools/call internally. Tool arguments
+// intentionally have no policy matcher yet, so every allowed tool call permits
+// all argument payloads by default.
+fn params_with_tool(
+    mut params: BTreeMap<String, ParamMatcherDef>,
+    tool: Option<QueryMatcherDef>,
+) -> BTreeMap<String, ParamMatcherDef> {
+    if let Some(tool) = tool {
+        params
+            .entry("name".to_string())
+            .or_insert_with(|| ParamMatcherDef::Matcher(tool));
+    }
+    params
+}
+
+fn allow_def_to_proto(_protocol: &str, allow: L7AllowDef) -> L7Allow {
+    let params = flatten_param_matchers(params_with_tool(allow.params, allow.tool));
+    L7Allow {
+        method: allow.method,
+        path: allow.path,
+        command: allow.command,
+        operation_type: allow.operation_type,
+        operation_name: allow.operation_name,
+        fields: allow.fields,
+        query: allow
+            .query
+            .into_iter()
+            .map(|(key, matcher)| (key, matcher_def_to_proto(matcher)))
+            .collect(),
+        params: params
+            .into_iter()
+            .map(|(key, matcher)| (key, matcher_def_to_proto(matcher)))
+            .collect(),
+    }
+}
+
+fn deny_def_to_proto(_protocol: &str, deny: L7DenyRuleDef) -> L7DenyRule {
+    let params = flatten_param_matchers(params_with_tool(deny.params, deny.tool));
+    L7DenyRule {
+        method: deny.method,
+        path: deny.path,
+        command: deny.command,
+        operation_type: deny.operation_type,
+        operation_name: deny.operation_name,
+        fields: deny.fields,
+        query: deny
+            .query
+            .into_iter()
+            .map(|(key, matcher)| (key, matcher_def_to_proto(matcher)))
+            .collect(),
+        params: params
+            .into_iter()
+            .map(|(key, matcher)| (key, matcher_def_to_proto(matcher)))
+            .collect(),
+    }
+}
+
+fn json_rpc_max_body_bytes(json_rpc: &Option<JsonRpcConfigDef>, mcp: &Option<McpConfigDef>) -> u32 {
+    // The proto has one JSON-RPC-family body limit. Prefer the MCP stanza when
+    // present because MCP policies should not need a shadow `json_rpc` block.
+    mcp.as_ref().map_or_else(
+        || json_rpc.as_ref().map_or(0, |config| config.max_body_bytes),
+        |config| config.max_body_bytes,
+    )
+}
+
+fn mcp_strict_tool_names(mcp: &Option<McpConfigDef>) -> Option<bool> {
+    mcp.as_ref().and_then(|config| config.strict_tool_names)
+}
+
+fn mcp_allow_all_known_mcp_methods(mcp: &Option<McpConfigDef>) -> Option<bool> {
+    mcp.as_ref()
+        .and_then(|config| config.allow_all_known_mcp_methods)
+}
+
+fn mcp_options(mcp: &Option<McpConfigDef>) -> Option<McpOptions> {
+    let strict_tool_names = mcp_strict_tool_names(mcp);
+    let allow_all_known_mcp_methods = mcp_allow_all_known_mcp_methods(mcp);
+    (strict_tool_names.is_some() || allow_all_known_mcp_methods.is_some()).then_some(McpOptions {
+        strict_tool_names,
+        allow_all_known_mcp_methods,
+    })
+}
+
+fn is_mcp_protocol(protocol: &str) -> bool {
+    protocol.eq_ignore_ascii_case("mcp")
+}
+
+fn split_tool_param(
+    protocol: &str,
+    params: BTreeMap<String, QueryMatcherDef>,
+) -> (Option<QueryMatcherDef>, BTreeMap<String, QueryMatcherDef>) {
+    // Only MCP has the tool-name convention. Generic JSON-RPC keeps `name` as a
+    // normal params matcher so serialization does not invent MCP semantics.
+    if !is_mcp_protocol(protocol) {
+        return (None, params);
+    }
+
+    let mut params = params;
+    let tool = params.remove("name");
+    (tool, params)
+}
+
+fn allow_proto_to_def(
+    protocol: &str,
+    allow: L7Allow,
+    mcp_allow_all_known_mcp_methods: bool,
+) -> L7AllowDef {
+    let params: BTreeMap<String, QueryMatcherDef> = allow
+        .params
+        .into_iter()
+        .map(|(key, matcher)| (key, matcher_proto_to_def(matcher)))
+        .collect();
+    let (tool, params) = split_tool_param(protocol, params);
+    let params = flat_params_to_def(protocol, params);
+    let method = yaml_mcp_method(
+        protocol,
+        &allow.method,
+        tool.is_some(),
+        mcp_allow_all_known_mcp_methods,
+    );
+    L7AllowDef {
+        method,
+        path: allow.path,
+        command: allow.command,
+        query: allow
+            .query
+            .into_iter()
+            .map(|(key, matcher)| (key, matcher_proto_to_def(matcher)))
+            .collect(),
+        operation_type: allow.operation_type,
+        operation_name: allow.operation_name,
+        fields: allow.fields,
+        tool,
+        params,
+    }
+}
+
+fn deny_proto_to_def(
+    protocol: &str,
+    deny: &L7DenyRule,
+    mcp_allow_all_known_mcp_methods: bool,
+) -> L7DenyRuleDef {
+    let params: BTreeMap<String, QueryMatcherDef> = deny
+        .params
+        .iter()
+        .map(|(key, matcher)| (key.clone(), matcher_proto_to_def(matcher.clone())))
+        .collect();
+    let (tool, params) = split_tool_param(protocol, params);
+    let params = flat_params_to_def(protocol, params);
+    let method = yaml_mcp_method(
+        protocol,
+        &deny.method,
+        tool.is_some(),
+        mcp_allow_all_known_mcp_methods,
+    );
+    L7DenyRuleDef {
+        method,
+        path: deny.path.clone(),
+        command: deny.command.clone(),
+        query: deny
+            .query
+            .iter()
+            .map(|(key, matcher)| (key.clone(), matcher_proto_to_def(matcher.clone())))
+            .collect(),
+        operation_type: deny.operation_type.clone(),
+        operation_name: deny.operation_name.clone(),
+        fields: deny.fields.clone(),
+        tool,
+        params,
+    }
+}
+
+fn yaml_mcp_method(
+    protocol: &str,
+    method: &str,
+    has_tool: bool,
+    mcp_allow_all_known_mcp_methods: bool,
+) -> String {
+    if is_mcp_protocol(protocol) {
+        if !has_tool && method == "*" {
+            return String::new();
+        }
+        if has_tool && method == "tools/call" && mcp_allow_all_known_mcp_methods {
+            return String::new();
+        }
+    }
+    method.to_string()
+}
+
 fn to_proto(raw: PolicyFile) -> SandboxPolicy {
     let network_policies = raw
         .network_policies
@@ -282,6 +607,9 @@ fn to_proto(raw: PolicyFile) -> SandboxPolicy {
                     .endpoints
                     .into_iter()
                     .map(|e| {
+                        let protocol = e.protocol;
+                        let allow_rules = e.rules;
+                        let deny_rules = e.deny_rules;
                         // Normalize port/ports: ports takes precedence, else
                         // single port is promoted to ports array.
                         let normalized_ports: Vec<u32> = if !e.ports.is_empty() {
@@ -296,62 +624,20 @@ fn to_proto(raw: PolicyFile) -> SandboxPolicy {
                             path: e.path,
                             port: normalized_ports.first().copied().unwrap_or(0),
                             ports: normalized_ports,
-                            protocol: e.protocol,
+                            protocol: protocol.clone(),
                             tls: e.tls,
                             enforcement: e.enforcement,
                             access: e.access,
-                            rules: e
-                                .rules
+                            rules: allow_rules
                                 .into_iter()
                                 .map(|r| L7Rule {
-                                    allow: Some(L7Allow {
-                                        method: r.allow.method,
-                                        path: r.allow.path,
-                                        command: r.allow.command,
-                                        operation_type: r.allow.operation_type,
-                                        operation_name: r.allow.operation_name,
-                                        fields: r.allow.fields,
-                                        query: r
-                                            .allow
-                                            .query
-                                            .into_iter()
-                                            .map(|(key, matcher)| {
-                                                (key, matcher_def_to_proto(matcher))
-                                            })
-                                            .collect(),
-                                        params: r
-                                            .allow
-                                            .params
-                                            .into_iter()
-                                            .map(|(key, matcher)| {
-                                                (key, matcher_def_to_proto(matcher))
-                                            })
-                                            .collect(),
-                                    }),
+                                    allow: Some(allow_def_to_proto(&protocol, r.allow)),
                                 })
                                 .collect(),
                             allowed_ips: e.allowed_ips,
-                            deny_rules: e
-                                .deny_rules
+                            deny_rules: deny_rules
                                 .into_iter()
-                                .map(|d| L7DenyRule {
-                                    method: d.method,
-                                    path: d.path,
-                                    command: d.command,
-                                    operation_type: d.operation_type,
-                                    operation_name: d.operation_name,
-                                    fields: d.fields,
-                                    query: d
-                                        .query
-                                        .into_iter()
-                                        .map(|(key, matcher)| (key, matcher_def_to_proto(matcher)))
-                                        .collect(),
-                                    params: d
-                                        .params
-                                        .into_iter()
-                                        .map(|(key, matcher)| (key, matcher_def_to_proto(matcher)))
-                                        .collect(),
-                                })
+                                .map(|deny| deny_def_to_proto(&protocol, deny))
                                 .collect(),
                             allow_encoded_slash: e.allow_encoded_slash,
                             websocket_credential_rewrite: e.websocket_credential_rewrite,
@@ -375,10 +661,8 @@ fn to_proto(raw: PolicyFile) -> SandboxPolicy {
                                 })
                                 .collect(),
                             graphql_max_body_bytes: e.graphql_max_body_bytes,
-                            json_rpc_max_body_bytes: e
-                                .json_rpc
-                                .as_ref()
-                                .map_or(0, |config| config.max_body_bytes),
+                            json_rpc_max_body_bytes: json_rpc_max_body_bytes(&e.json_rpc, &e.mcp),
+                            mcp: mcp_options(&e.mcp),
                         }
                     })
                     .collect(),
@@ -458,73 +742,50 @@ fn from_proto(policy: &SandboxPolicy) -> PolicyFile {
                         } else {
                             (clamp(e.ports.first().copied().unwrap_or(e.port)), vec![])
                         };
+                        let protocol = e.protocol.clone();
+                        let mcp_allow_all_known_mcp_methods = !is_mcp_protocol(&protocol)
+                            || e.mcp
+                                .as_ref()
+                                .and_then(|options| options.allow_all_known_mcp_methods)
+                                .unwrap_or(true);
+                        let rules = e
+                            .rules
+                            .iter()
+                            .map(|r| L7RuleDef {
+                                allow: allow_proto_to_def(
+                                    &protocol,
+                                    r.allow.clone().unwrap_or_default(),
+                                    mcp_allow_all_known_mcp_methods,
+                                ),
+                            })
+                            .collect();
+                        let deny_rules: Vec<L7DenyRuleDef> = e
+                            .deny_rules
+                            .iter()
+                            .map(|d| {
+                                deny_proto_to_def(&protocol, d, mcp_allow_all_known_mcp_methods)
+                            })
+                            .collect();
+                        let (json_rpc, mcp) = if is_mcp_protocol(&protocol) {
+                            (
+                                None,
+                                mcp_config_from_proto(e.json_rpc_max_body_bytes, e.mcp.as_ref()),
+                            )
+                        } else {
+                            (json_rpc_config_from_proto(e.json_rpc_max_body_bytes), None)
+                        };
                         NetworkEndpointDef {
                             host: e.host.clone(),
                             path: e.path.clone(),
                             port,
                             ports,
-                            protocol: e.protocol.clone(),
+                            protocol,
                             tls: e.tls.clone(),
                             enforcement: e.enforcement.clone(),
                             access: e.access.clone(),
-                            rules: e
-                                .rules
-                                .iter()
-                                .map(|r| {
-                                    let a = r.allow.clone().unwrap_or_default();
-                                    L7RuleDef {
-                                        allow: L7AllowDef {
-                                            method: a.method,
-                                            path: a.path,
-                                            command: a.command,
-                                            operation_type: a.operation_type,
-                                            operation_name: a.operation_name,
-                                            fields: a.fields,
-                                            query: a
-                                                .query
-                                                .into_iter()
-                                                .map(|(key, matcher)| {
-                                                    (key, matcher_proto_to_def(matcher))
-                                                })
-                                                .collect(),
-                                            params: a
-                                                .params
-                                                .into_iter()
-                                                .map(|(key, matcher)| {
-                                                    (key, matcher_proto_to_def(matcher))
-                                                })
-                                                .collect(),
-                                        },
-                                    }
-                                })
-                                .collect(),
+                            rules,
                             allowed_ips: e.allowed_ips.clone(),
-                            deny_rules: e
-                                .deny_rules
-                                .iter()
-                                .map(|d| L7DenyRuleDef {
-                                    method: d.method.clone(),
-                                    path: d.path.clone(),
-                                    command: d.command.clone(),
-                                    operation_type: d.operation_type.clone(),
-                                    operation_name: d.operation_name.clone(),
-                                    fields: d.fields.clone(),
-                                    query: d
-                                        .query
-                                        .iter()
-                                        .map(|(key, matcher)| {
-                                            (key.clone(), matcher_proto_to_def(matcher.clone()))
-                                        })
-                                        .collect(),
-                                    params: d
-                                        .params
-                                        .iter()
-                                        .map(|(key, matcher)| {
-                                            (key.clone(), matcher_proto_to_def(matcher.clone()))
-                                        })
-                                        .collect(),
-                                })
-                                .collect(),
+                            deny_rules,
                             allow_encoded_slash: e.allow_encoded_slash,
                             websocket_credential_rewrite: e.websocket_credential_rewrite,
                             request_body_credential_rewrite: e.request_body_credential_rewrite,
@@ -544,7 +805,8 @@ fn from_proto(policy: &SandboxPolicy) -> PolicyFile {
                                 })
                                 .collect(),
                             graphql_max_body_bytes: e.graphql_max_body_bytes,
-                            json_rpc: json_rpc_config_from_proto(e.json_rpc_max_body_bytes),
+                            json_rpc,
+                            mcp,
                         }
                     })
                     .collect(),
@@ -1759,6 +2021,110 @@ network_policies:
         let ep = &proto2.network_policies["mcp"].endpoints[0];
         assert_eq!(ep.protocol, "json-rpc");
         assert_eq!(ep.json_rpc_max_body_bytes, 131_072);
+    }
+
+    #[test]
+    fn parse_mcp_rules_to_runtime_fields() {
+        let yaml = r"
+version: 1
+network_policies:
+  mcp:
+    name: mcp
+    endpoints:
+      - host: mcp.example.com
+        port: 443
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        mcp:
+          max_body_bytes: 131072
+          strict_tool_names: false
+          allow_all_known_mcp_methods: false
+        rules:
+          - allow:
+              method: initialize
+          - allow:
+              method: tools/list
+          - allow:
+              method: tools/call
+              tool:
+                any: [search_web, list_tools]
+        deny_rules:
+          - method: tools/call
+            tool: send_email
+    binaries:
+      - path: /usr/bin/curl
+";
+        let proto = parse_sandbox_policy(yaml).expect("parse failed");
+        let ep = &proto.network_policies["mcp"].endpoints[0];
+
+        assert_eq!(ep.protocol, "mcp");
+        assert_eq!(ep.json_rpc_max_body_bytes, 131_072);
+        assert_eq!(
+            ep.mcp
+                .as_ref()
+                .and_then(|options| options.strict_tool_names),
+            Some(false)
+        );
+        assert_eq!(
+            ep.mcp
+                .as_ref()
+                .and_then(|options| options.allow_all_known_mcp_methods),
+            Some(false)
+        );
+        assert_eq!(ep.rules.len(), 3);
+        assert_eq!(ep.rules[2].allow.as_ref().unwrap().method, "tools/call");
+        assert_eq!(
+            ep.rules[2].allow.as_ref().unwrap().params["name"].any,
+            vec!["search_web".to_string(), "list_tools".to_string()]
+        );
+        assert_eq!(ep.deny_rules.len(), 1);
+        assert_eq!(ep.deny_rules[0].method, "tools/call");
+        assert_eq!(ep.deny_rules[0].params["name"].glob, "send_email");
+    }
+
+    #[test]
+    fn round_trip_mcp_policy_serializes_mcp_expression() {
+        let yaml = r"
+version: 1
+network_policies:
+  mcp:
+    name: mcp
+    endpoints:
+      - host: mcp.example.com
+        port: 443
+        protocol: mcp
+        mcp:
+          max_body_bytes: 131072
+          strict_tool_names: false
+          allow_all_known_mcp_methods: false
+        rules:
+          - allow:
+              method: tools/call
+              tool: search_web
+        deny_rules:
+          - method: tools/call
+            tool:
+              any: [send_email, delete_resource]
+    binaries:
+      - path: /usr/bin/curl
+";
+        let proto1 = parse_sandbox_policy(yaml).expect("parse failed");
+        let yaml_out = serialize_sandbox_policy(&proto1).expect("serialize failed");
+        let proto2 = parse_sandbox_policy(&yaml_out).expect("re-parse failed");
+
+        assert!(yaml_out.contains("protocol: mcp"));
+        assert!(yaml_out.contains("method: tools/call"));
+        assert!(yaml_out.contains("tool: search_web"));
+        assert!(yaml_out.contains("any:"));
+        assert!(yaml_out.contains("- send_email"));
+        assert!(yaml_out.contains("- delete_resource"));
+        assert!(yaml_out.contains("deny_rules:"));
+        assert!(!yaml_out.contains("arguments:"));
+        assert!(yaml_out.contains("mcp:"));
+        assert!(yaml_out.contains("strict_tool_names: false"));
+        assert!(yaml_out.contains("allow_all_known_mcp_methods: false"));
+        assert_eq!(proto1, proto2);
     }
 
     #[test]

--- a/crates/openshell-providers/src/profiles.rs
+++ b/crates/openshell-providers/src/profiles.rs
@@ -6,10 +6,10 @@
 #![allow(deprecated)] // NetworkBinary::harness remains in the public proto for compatibility.
 
 use openshell_core::proto::{
-    GraphqlOperation, L7Allow, L7DenyRule, L7QueryMatcher, L7Rule, NetworkBinary, NetworkEndpoint,
-    NetworkPolicyRule, ProviderCredentialRefresh, ProviderCredentialRefreshMaterial,
-    ProviderCredentialRefreshStrategy, ProviderProfile, ProviderProfileCategory,
-    ProviderProfileCredential, ProviderProfileDiscovery,
+    GraphqlOperation, L7Allow, L7DenyRule, L7QueryMatcher, L7Rule, McpOptions, NetworkBinary,
+    NetworkEndpoint, NetworkPolicyRule, ProviderCredentialRefresh,
+    ProviderCredentialRefreshMaterial, ProviderCredentialRefreshStrategy, ProviderProfile,
+    ProviderProfileCategory, ProviderProfileCredential, ProviderProfileDiscovery,
 };
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
@@ -203,8 +203,18 @@ pub struct EndpointProfile {
     pub graphql_max_body_bytes: u32,
     #[serde(default, skip_serializing_if = "is_zero")]
     pub json_rpc_max_body_bytes: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp: Option<McpOptionsProfile>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub path: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct McpOptionsProfile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strict_tool_names: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_all_known_mcp_methods: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -747,6 +757,7 @@ fn endpoint_to_proto(endpoint: &EndpointProfile) -> NetworkEndpoint {
             .collect(),
         graphql_max_body_bytes: endpoint.graphql_max_body_bytes,
         json_rpc_max_body_bytes: endpoint.json_rpc_max_body_bytes,
+        mcp: endpoint.mcp.as_ref().map(mcp_options_to_proto),
         path: endpoint.path.clone(),
     }
 }
@@ -778,7 +789,22 @@ fn endpoint_from_proto(endpoint: &NetworkEndpoint) -> EndpointProfile {
             .collect(),
         graphql_max_body_bytes: endpoint.graphql_max_body_bytes,
         json_rpc_max_body_bytes: endpoint.json_rpc_max_body_bytes,
+        mcp: endpoint.mcp.map(mcp_options_from_proto),
         path: endpoint.path.clone(),
+    }
+}
+
+fn mcp_options_to_proto(options: &McpOptionsProfile) -> McpOptions {
+    McpOptions {
+        strict_tool_names: options.strict_tool_names,
+        allow_all_known_mcp_methods: options.allow_all_known_mcp_methods,
+    }
+}
+
+fn mcp_options_from_proto(options: McpOptions) -> McpOptionsProfile {
+    McpOptionsProfile {
+        strict_tool_names: options.strict_tool_names,
+        allow_all_known_mcp_methods: options.allow_all_known_mcp_methods,
     }
 }
 
@@ -1834,6 +1860,62 @@ discovery:
         let exported = profile_to_yaml(&from_proto).expect("yaml");
         assert!(exported.contains("discovery:"));
         assert!(exported.contains("api_key"));
+    }
+
+    #[test]
+    fn mcp_endpoint_strict_tool_names_round_trips_through_proto_and_yaml() {
+        let profile = parse_profile_yaml(
+            r"
+id: mcp-example
+display_name: MCP Example
+endpoints:
+  - host: mcp.example.com
+    port: 443
+    path: /mcp
+    protocol: mcp
+    mcp:
+      strict_tool_names: false
+      allow_all_known_mcp_methods: false
+binaries:
+  - /usr/bin/example-agent
+",
+        )
+        .expect("profile should parse");
+
+        assert_eq!(
+            profile.endpoints[0]
+                .mcp
+                .as_ref()
+                .and_then(|options| options.strict_tool_names),
+            Some(false)
+        );
+        assert_eq!(
+            profile.endpoints[0]
+                .mcp
+                .as_ref()
+                .and_then(|options| options.allow_all_known_mcp_methods),
+            Some(false)
+        );
+        let from_proto = ProviderTypeProfile::from_proto(&profile.to_proto());
+        assert_eq!(
+            from_proto.endpoints[0]
+                .mcp
+                .as_ref()
+                .and_then(|options| options.strict_tool_names),
+            Some(false)
+        );
+        assert_eq!(
+            from_proto.endpoints[0]
+                .mcp
+                .as_ref()
+                .and_then(|options| options.allow_all_known_mcp_methods),
+            Some(false)
+        );
+
+        let exported = profile_to_yaml(&from_proto).expect("yaml");
+        assert!(exported.contains("mcp:"));
+        assert!(exported.contains("strict_tool_names: false"));
+        assert!(exported.contains("allow_all_known_mcp_methods: false"));
     }
 
     #[test]

--- a/crates/openshell-supervisor-network/Cargo.toml
+++ b/crates/openshell-supervisor-network/Cargo.toml
@@ -38,6 +38,7 @@ spiffe = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
+tower-mcp-types = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 webpki-roots = { workspace = true }

--- a/crates/openshell-supervisor-network/data/sandbox-policy.rego
+++ b/crates/openshell-supervisor-network/data/sandbox-policy.rego
@@ -257,7 +257,7 @@ deny_request if {
 # --- L7 deny rule matching: REST method + path + query ---
 
 request_denied_for_endpoint(request, endpoint) if {
-	object.get(endpoint, "protocol", "") != "json-rpc"
+	not jsonrpc_family_endpoint(endpoint)
 	some deny_rule
 	deny_rule := endpoint.deny_rules[_]
 	deny_rule.method
@@ -278,7 +278,7 @@ request_denied_for_endpoint(request, endpoint) if {
 # --- L7 deny rule matching: JSON-RPC method + params ---
 
 request_denied_for_endpoint(request, endpoint) if {
-	endpoint.protocol == "json-rpc"
+	jsonrpc_family_endpoint(endpoint)
 	request.method == "POST"
 	some deny_rule
 	deny_rule := endpoint.deny_rules[_]
@@ -403,6 +403,7 @@ request_deny_reason := reason if {
 request_deny_reason := reason if {
 	input.request
 	jsonrpc_response_frame_present(input.request)
+	matched_endpoint_config.protocol == "json-rpc"
 	reason := "JSON-RPC response frames are not permitted from client to server"
 }
 
@@ -426,7 +427,7 @@ request_deny_reason := reason if {
 # --- L7 rule matching: REST method + path ---
 
 request_allowed_for_endpoint(request, endpoint) if {
-	object.get(endpoint, "protocol", "") != "json-rpc"
+	not jsonrpc_family_endpoint(endpoint)
 	some rule
 	rule := endpoint.rules[_]
 	rule.allow.method
@@ -447,7 +448,7 @@ request_allowed_for_endpoint(request, endpoint) if {
 # --- L7 rule matching: JSON-RPC method ---
 
 request_allowed_for_endpoint(request, endpoint) if {
-	endpoint.protocol == "json-rpc"
+	jsonrpc_family_endpoint(endpoint)
 	request.method == "POST"
 	some rule
 	rule := endpoint.rules[_]
@@ -456,17 +457,68 @@ request_allowed_for_endpoint(request, endpoint) if {
 	jsonrpc_rule_matches(request, rule.allow)
 }
 
-# MCP Streamable HTTP uses GET on the JSON-RPC endpoint as a receive stream for
-# server-to-client messages. The stream itself has no client-to-server JSON-RPC
-# request body to inspect; allow it once the endpoint path and binary matched.
+# MCP can allow the method layer by endpoint option while still using
+# tool-specific rules to narrow tools/call params.name.
 request_allowed_for_endpoint(request, endpoint) if {
+	endpoint.protocol == "mcp"
+	mcp_allow_all_known_mcp_methods(endpoint)
+	request.method == "POST"
+	not jsonrpc_response_frame_present(request)
+	jsonrpc := object.get(request, "jsonrpc", null)
+	is_object(jsonrpc)
+	jsonrpc_no_parse_error(jsonrpc)
+	method := object.get(jsonrpc, "method", "")
+	is_string(method)
+	method != ""
+	not mcp_tool_call_narrowed_by_policy(endpoint, method)
+}
+
+# MCP Streamable HTTP allows client-to-server JSON-RPC response frames for
+# server-originated requests such as elicitation/create. Generic JSON-RPC keeps
+# response frames denied because it has no MCP request-correlation semantics.
+request_allowed_for_endpoint(request, endpoint) if {
+	endpoint.protocol == "mcp"
+	request.method == "POST"
+	jsonrpc_response_frame_present(request)
+	jsonrpc := object.get(request, "jsonrpc", null)
+	is_object(jsonrpc)
+	jsonrpc_no_parse_error(jsonrpc)
+}
+
+jsonrpc_family_endpoint(endpoint) if {
 	endpoint.protocol == "json-rpc"
+}
+
+jsonrpc_family_endpoint(endpoint) if {
+	endpoint.protocol == "mcp"
+}
+
+mcp_allow_all_known_mcp_methods(endpoint) if {
+	object.get(endpoint, "mcp_allow_all_known_mcp_methods", true)
+}
+
+mcp_tool_call_narrowed_by_policy(endpoint, method) if {
+	method == "tools/call"
+	some rule
+	rule := endpoint.rules[_]
+	params := object.get(rule.allow, "params", {})
+	is_object(params)
+	params.name
+}
+
+# MCP Streamable HTTP uses GET on the JSON-RPC-family endpoint as a receive
+# stream for server-to-client messages. The stream itself has no
+# client-to-server JSON-RPC request body to inspect; allow it once the endpoint
+# path and binary matched.
+request_allowed_for_endpoint(request, endpoint) if {
+	jsonrpc_family_endpoint(endpoint)
 	request.method == "GET"
-	is_object(request.jsonrpc)
-	object.get(request.jsonrpc, "receive_stream", false)
-	jsonrpc_no_parse_error(request.jsonrpc)
-	object.get(request.jsonrpc, "method", null) == null
-	not object.get(request.jsonrpc, "has_response", false)
+	jsonrpc := object.get(request, "jsonrpc", null)
+	is_object(jsonrpc)
+	object.get(jsonrpc, "receive_stream", false)
+	jsonrpc_no_parse_error(jsonrpc)
+	object.get(jsonrpc, "method", null) == null
+	not object.get(jsonrpc, "has_response", false)
 }
 
 # --- L7 rule matching: GraphQL operation ---
@@ -694,31 +746,38 @@ query_value_matches(value, matcher) if {
 # as dot-separated matcher keys, e.g. arguments.scope. Literal dotted param keys
 # are preserved by Rust flattening and take precedence over deeper nested paths.
 jsonrpc_rule_matches(request, rule) if {
-	jsonrpc := object.get(request, "jsonrpc", {})
+	jsonrpc := object.get(request, "jsonrpc", null)
 	is_object(jsonrpc)
-	method := object.get(jsonrpc, "method", null)
-	method != null
-	glob.match(rule.method, [], method)
+	method := object.get(jsonrpc, "method", "")
+	is_string(method)
+	method != ""
+	rule_method := object.get(rule, "method", "")
+	is_string(rule_method)
+	rule_method != ""
+	glob.match(rule_method, [], method)
 	jsonrpc_params_match(jsonrpc, rule)
 }
 
 jsonrpc_response_frame_present(request) if {
-	jsonrpc := object.get(request, "jsonrpc", {})
+	jsonrpc := object.get(request, "jsonrpc", null)
 	is_object(jsonrpc)
 	object.get(jsonrpc, "has_response", false)
 }
 
 jsonrpc_no_parse_error(jsonrpc) if {
+	is_object(jsonrpc)
 	object.get(jsonrpc, "error", null) == null
 }
 
 jsonrpc_no_parse_error(jsonrpc) if {
+	is_object(jsonrpc)
 	object.get(jsonrpc, "error", "") == ""
 }
 
 jsonrpc_params_match(jsonrpc, rule) if {
 	is_object(jsonrpc)
 	param_rules := object.get(rule, "params", {})
+	is_object(param_rules)
 	not jsonrpc_param_mismatch(jsonrpc, param_rules)
 }
 
@@ -729,6 +788,7 @@ jsonrpc_param_mismatch(jsonrpc, param_rules) if {
 }
 
 jsonrpc_param_key_matches(jsonrpc, key, matcher) if {
+	is_object(jsonrpc)
 	params := object.get(jsonrpc, "params", {})
 	is_object(params)
 	value := object.get(params, key, null)

--- a/crates/openshell-supervisor-network/src/l7/jsonrpc.rs
+++ b/crates/openshell-supervisor-network/src/l7/jsonrpc.rs
@@ -8,11 +8,58 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tower_mcp_types::protocol::{
+    JSONRPC_VERSION, JsonRpcNotification, JsonRpcRequest, McpNotification, McpRequest,
+};
 
 use crate::l7::provider::{L7Provider, L7Request};
 
 pub const DEFAULT_MAX_BODY_BYTES: usize = 64 * 1024;
 
+/// Selects whether the parser should treat a JSON-RPC message as generic
+/// JSON-RPC 2.0 or as an MCP message with MCP method/params validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsonRpcInspectionMode {
+    JsonRpc,
+    Mcp,
+}
+
+impl JsonRpcInspectionMode {
+    pub(crate) fn for_protocol(protocol: crate::l7::L7Protocol) -> Self {
+        match protocol {
+            crate::l7::L7Protocol::Mcp => Self::Mcp,
+            _ => Self::JsonRpc,
+        }
+    }
+}
+
+/// Endpoint-specific JSON-RPC-family parser settings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JsonRpcInspectionOptions {
+    pub mode: JsonRpcInspectionMode,
+    pub mcp_strict_tool_names: bool,
+}
+
+impl JsonRpcInspectionOptions {
+    pub(crate) fn for_config(config: &crate::l7::L7EndpointConfig) -> Self {
+        Self {
+            mode: JsonRpcInspectionMode::for_protocol(config.protocol),
+            mcp_strict_tool_names: config.mcp_strict_tool_names,
+        }
+    }
+}
+
+impl From<JsonRpcInspectionMode> for JsonRpcInspectionOptions {
+    fn from(mode: JsonRpcInspectionMode) -> Self {
+        Self {
+            mode,
+            mcp_strict_tool_names: true,
+        }
+    }
+}
+
+/// Parsed HTTP request plus the JSON-RPC-family metadata extracted from the
+/// body. The original HTTP request is still forwarded if policy allows it.
 pub struct JsonRpcHttpRequest {
     pub request: L7Request,
     pub info: JsonRpcRequestInfo,
@@ -22,6 +69,7 @@ pub(crate) async fn parse_jsonrpc_http_request<C: AsyncRead + AsyncWrite + Unpin
     client: &mut C,
     max_body_bytes: usize,
     canonicalize_options: crate::l7::path::CanonicalizeOptions,
+    inspection_options: JsonRpcInspectionOptions,
 ) -> Result<Option<JsonRpcHttpRequest>> {
     let provider = crate::l7::rest::RestProvider::with_options(canonicalize_options);
     let Some(mut request) = provider.parse_request(client).await? else {
@@ -35,12 +83,14 @@ pub(crate) async fn parse_jsonrpc_http_request<C: AsyncRead + AsyncWrite + Unpin
     }
     let body =
         crate::l7::http::read_body_for_inspection(client, &mut request, max_body_bytes).await?;
-    let info = parse_jsonrpc_body(&body);
+    let info = parse_jsonrpc_body_with_options(&body, inspection_options);
     Ok(Some(JsonRpcHttpRequest { request, info }))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct JsonRpcRequestInfo {
+    /// Calls found in the request body. Responses and receive-stream GETs have
+    /// no calls but are still represented so policy can allow relay behavior.
     pub calls: Vec<JsonRpcCallInfo>,
     pub is_batch: bool,
     pub receive_stream: bool,
@@ -50,11 +100,20 @@ pub struct JsonRpcRequestInfo {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct JsonRpcCallInfo {
+    /// JSON-RPC method, or the MCP method name after typed MCP parsing.
     pub method: String,
+    /// Flattened scalar params used by the current Rego matcher path. Strings,
+    /// numbers, and booleans are represented as strings for compatibility with
+    /// the existing query matcher implementation.
     pub params: HashMap<String, String>,
+    /// MCP `tools/call` tool name when known. Generic JSON-RPC leaves this as
+    /// a best-effort projection of `params.name`.
+    pub tool: Option<String>,
 }
 
 impl JsonRpcRequestInfo {
+    /// MCP streamable HTTP uses an empty GET to receive server messages. It has
+    /// no request body to inspect, but it must still pass through MCP endpoints.
     pub(crate) fn receive_stream() -> Self {
         Self {
             calls: Vec::new(),
@@ -65,6 +124,8 @@ impl JsonRpcRequestInfo {
         }
     }
 
+    /// Logs store only a digest of params. For batches, hash the per-call
+    /// canonical maps so denied-call logging cannot leak raw argument values.
     pub(crate) fn params_sha256(&self) -> Option<String> {
         if self.is_batch {
             if self.calls.is_empty() || self.calls.iter().all(|call| call.params.is_empty()) {
@@ -115,11 +176,19 @@ fn request_accepts_sse(request: &L7Request) -> bool {
             })
     })
 }
-/// Parse a JSON-RPC 2.0 request body and extract the `method` field.
-///
-/// Returns an info struct with `method` set on success, or `error` set if the
-/// body is not valid JSON-RPC 2.0.
-pub fn parse_jsonrpc_body(body: &[u8]) -> JsonRpcRequestInfo {
+/// Parse a JSON-RPC-family body using the endpoint's inspection mode.
+pub fn parse_jsonrpc_body(
+    body: &[u8],
+    inspection_mode: JsonRpcInspectionMode,
+) -> JsonRpcRequestInfo {
+    parse_jsonrpc_body_with_options(body, inspection_mode.into())
+}
+
+/// Parse a JSON-RPC-family body using the endpoint's inspection options.
+pub fn parse_jsonrpc_body_with_options(
+    body: &[u8],
+    inspection_options: JsonRpcInspectionOptions,
+) -> JsonRpcRequestInfo {
     let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
         return JsonRpcRequestInfo {
             calls: Vec::new(),
@@ -143,7 +212,7 @@ pub fn parse_jsonrpc_body(body: &[u8]) -> JsonRpcRequestInfo {
         let mut calls = Vec::new();
         let mut has_response = false;
         for item in &items {
-            match parse_jsonrpc_message(item) {
+            match parse_jsonrpc_message(item, inspection_options) {
                 Ok(JsonRpcMessageInfo::Call(call)) => calls.push(call),
                 Ok(JsonRpcMessageInfo::Response) => has_response = true,
                 Err(error) => {
@@ -166,7 +235,7 @@ pub fn parse_jsonrpc_body(body: &[u8]) -> JsonRpcRequestInfo {
         };
     }
 
-    match parse_jsonrpc_message(&value) {
+    match parse_jsonrpc_message(&value, inspection_options) {
         Ok(JsonRpcMessageInfo::Call(call)) => JsonRpcRequestInfo {
             calls: vec![call],
             is_batch: false,
@@ -196,14 +265,17 @@ enum JsonRpcMessageInfo {
     Response,
 }
 
+// Shared framing for JSON-RPC-family messages. MCP-specific validation starts
+// only after the common JSON-RPC version/method/response checks.
 fn parse_jsonrpc_message(
     value: &serde_json::Value,
+    inspection_options: JsonRpcInspectionOptions,
 ) -> std::result::Result<JsonRpcMessageInfo, String> {
     let version = value
         .get("jsonrpc")
         .and_then(|v| v.as_str())
         .ok_or_else(|| "missing or non-string 'jsonrpc' field".to_string())?;
-    if version != "2.0" {
+    if version != JSONRPC_VERSION {
         return Err(format!("unsupported JSON-RPC version '{version}'"));
     }
 
@@ -219,23 +291,32 @@ fn parse_jsonrpc_message(
     }
 
     if has_method {
-        return parse_jsonrpc_call(value).map(JsonRpcMessageInfo::Call);
+        return parse_jsonrpc_call(value, inspection_options).map(JsonRpcMessageInfo::Call);
     }
 
     Err("missing or non-string 'method' field".to_string())
 }
 
-fn parse_jsonrpc_call(value: &serde_json::Value) -> std::result::Result<JsonRpcCallInfo, String> {
+fn parse_jsonrpc_call(
+    value: &serde_json::Value,
+    inspection_options: JsonRpcInspectionOptions,
+) -> std::result::Result<JsonRpcCallInfo, String> {
+    // MCP mode delegates method-specific validation to tower-mcp-types. The
+    // generic mode intentionally remains looser for non-MCP JSON-RPC servers.
+    if inspection_options.mode == JsonRpcInspectionMode::Mcp {
+        return parse_mcp_call(value, inspection_options.mcp_strict_tool_names);
+    }
+
     let method = value
         .get("method")
         .and_then(|m| m.as_str())
         .ok_or_else(|| "missing or non-string 'method' field".to_string())?;
-    let params = value
-        .get("params")
-        .map_or_else(|| Ok(HashMap::new()), flatten_jsonrpc_params)?;
+    let params = flatten_jsonrpc_params_opt(value.get("params"))?;
+    let tool = params.get("name").cloned();
     Ok(JsonRpcCallInfo {
         method: method.to_string(),
         params,
+        tool,
     })
 }
 
@@ -268,6 +349,52 @@ fn parse_jsonrpc_response(value: &serde_json::Value) -> std::result::Result<(), 
     Ok(())
 }
 
+fn parse_mcp_call(
+    value: &serde_json::Value,
+    strict_tool_names: bool,
+) -> std::result::Result<JsonRpcCallInfo, String> {
+    if value.get("id").is_some() {
+        // Typed parsing validates known MCP params, but policy method profiles
+        // stay OpenShell-owned; see McpOptions in proto/sandbox.proto.
+        let request: JsonRpcRequest = serde_json::from_value(value.clone())
+            .map_err(|error| format!("invalid MCP request: {error}"))?;
+        request
+            .validate()
+            .map_err(|error| format!("invalid MCP request: {error:?}"))?;
+        let mcp_request = McpRequest::from_jsonrpc(&request)
+            .map_err(|error| format!("invalid MCP request params: {error}"))?;
+        let tool = mcp_tool_name(&mcp_request);
+        if strict_tool_names && let Some(tool_name) = tool.as_deref() {
+            validate_mcp_tool_name(tool_name)?;
+        }
+
+        return Ok(JsonRpcCallInfo {
+            method: mcp_request.method_name().to_string(),
+            params: flatten_jsonrpc_params_opt(request.params.as_ref())?,
+            tool,
+        });
+    }
+
+    // Notifications have no id and no response expectation. Validate them as
+    // MCP notifications but keep extension notifications addressable.
+    let notification: JsonRpcNotification = serde_json::from_value(value.clone())
+        .map_err(|error| format!("invalid MCP notification: {error}"))?;
+    if notification.jsonrpc != JSONRPC_VERSION {
+        return Err(format!(
+            "unsupported JSON-RPC version '{}'",
+            notification.jsonrpc
+        ));
+    }
+    McpNotification::from_jsonrpc(&notification)
+        .map_err(|error| format!("invalid MCP notification params: {error}"))?;
+
+    Ok(JsonRpcCallInfo {
+        method: notification.method,
+        params: flatten_jsonrpc_params_opt(notification.params.as_ref())?,
+        tool: None,
+    })
+}
+
 fn flatten_jsonrpc_params(
     value: &serde_json::Value,
 ) -> std::result::Result<HashMap<String, String>, String> {
@@ -277,6 +404,37 @@ fn flatten_jsonrpc_params(
         .into_iter()
         .map(|(key, param)| (key, param.value))
         .collect())
+}
+
+fn flatten_jsonrpc_params_opt(
+    value: Option<&serde_json::Value>,
+) -> std::result::Result<HashMap<String, String>, String> {
+    value.map_or_else(|| Ok(HashMap::new()), flatten_jsonrpc_params)
+}
+
+fn mcp_tool_name(request: &McpRequest) -> Option<String> {
+    if let McpRequest::CallTool(params) = request {
+        Some(params.name.clone())
+    } else {
+        None
+    }
+}
+
+// OpenShell's default MCP hardening enforces the spec-recommended tool-name
+// boundary for tools/call. See McpOptions in proto/sandbox.proto for sources.
+fn validate_mcp_tool_name(name: &str) -> std::result::Result<(), String> {
+    if name.is_empty()
+        || name.len() > 128
+        || !name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.'))
+    {
+        return Err(
+            "MCP tool name must match ^[A-Za-z0-9_.-]{1,128}$ when strict_tool_names is enabled"
+                .to_string(),
+        );
+    }
+    Ok(())
 }
 
 fn canonical_params_map(params: &HashMap<String, String>) -> BTreeMap<String, String> {
@@ -297,6 +455,9 @@ fn flatten_json_value(
     value: &serde_json::Value,
     out: &mut HashMap<String, FlattenedParam>,
 ) -> std::result::Result<(), String> {
+    // Keep the runtime input flat for the existing OPA matcher. Literal dotted
+    // keys are accepted; if they collide with a flattened nested path, the
+    // literal key wins because it has fewer JSON path segments.
     match value {
         serde_json::Value::Object(map) => {
             for (key, child) in map {
@@ -358,7 +519,7 @@ mod tests {
     #[test]
     fn parses_method_from_request_body() {
         let body = br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
-        let info = parse_jsonrpc_body(body);
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
         assert_eq!(
             info.calls.first().map(|call| call.method.as_str()),
             Some("initialize")
@@ -372,7 +533,7 @@ mod tests {
     #[test]
     fn parses_jsonrpc_response_body_without_method() {
         let body = br#"{"jsonrpc":"2.0","id":1,"result":{"action":"accept","content":{}}}"#;
-        let info = parse_jsonrpc_body(body);
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
 
         assert!(info.calls.is_empty());
         assert!(!info.is_batch);
@@ -385,7 +546,7 @@ mod tests {
     fn parses_jsonrpc_error_response_body_without_method() {
         let body =
             br#"{"jsonrpc":"2.0","id":"request-1","error":{"code":-32603,"message":"failed"}}"#;
-        let info = parse_jsonrpc_body(body);
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
 
         assert!(info.calls.is_empty());
         assert!(info.has_response);
@@ -395,7 +556,7 @@ mod tests {
     #[test]
     fn flattens_object_params_for_policy_matching() {
         let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"submit_report","arguments":{"scope":"workspace/main"}}}"#;
-        let info = parse_jsonrpc_body(body);
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
         let params = &info.calls.first().expect("single request call").params;
         assert_eq!(
             params.get("name").map(String::as_str),
@@ -408,9 +569,87 @@ mod tests {
     }
 
     #[test]
+    fn mcp_mode_validates_known_methods_and_extracts_tool() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_web","arguments":{"query":"openshell"}}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::Mcp);
+
+        assert!(info.error.is_none(), "expected valid MCP call: {info:?}");
+        let call = info.calls.first().expect("single MCP call");
+        assert_eq!(call.method, "tools/call");
+        assert_eq!(call.tool.as_deref(), Some("search_web"));
+        assert_eq!(
+            call.params.get("arguments.query").map(String::as_str),
+            Some("openshell")
+        );
+    }
+
+    #[test]
+    fn mcp_mode_rejects_non_recommended_tool_names_by_default() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read status","arguments":{}}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::Mcp);
+
+        assert!(info.calls.is_empty());
+        assert!(
+            info.error
+                .as_deref()
+                .is_some_and(|error| error.contains("strict_tool_names")),
+            "expected strict tool-name error, got {info:?}"
+        );
+    }
+
+    #[test]
+    fn mcp_mode_can_disable_strict_tool_names() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read status","arguments":{}}}"#;
+        let info = parse_jsonrpc_body_with_options(
+            body,
+            JsonRpcInspectionOptions {
+                mode: JsonRpcInspectionMode::Mcp,
+                mcp_strict_tool_names: false,
+            },
+        );
+
+        let call = info
+            .calls
+            .first()
+            .expect("permissive MCP call should parse");
+        assert!(info.error.is_none(), "permissive MCP call failed: {info:?}");
+        assert_eq!(call.tool.as_deref(), Some("read status"));
+    }
+
+    #[test]
+    fn mcp_mode_rejects_invalid_known_method_params() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"arguments":{"query":"openshell"}}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::Mcp);
+
+        assert!(info.calls.is_empty());
+        assert!(
+            info.error
+                .as_deref()
+                .is_some_and(|error| error.contains("invalid MCP request params")),
+            "expected MCP params validation error, got {info:?}"
+        );
+    }
+
+    #[test]
+    fn mcp_mode_allows_unknown_extension_methods() {
+        let body =
+            br#"{"jsonrpc":"2.0","id":1,"method":"vendor/extension","params":{"name":"custom"}}"#;
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::Mcp);
+
+        assert!(
+            info.error.is_none(),
+            "extension method should remain addressable"
+        );
+        assert_eq!(
+            info.calls.first().map(|call| call.method.as_str()),
+            Some("vendor/extension")
+        );
+    }
+
+    #[test]
     fn allows_literal_dotted_param_keys() {
         let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"arguments.scope":"workspace/other","arguments":{"scope":"workspace/main"}}}"#;
-        let info = parse_jsonrpc_body(body);
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
         let params = &info.calls.first().expect("single request call").params;
 
         assert!(info.error.is_none());
@@ -456,7 +695,7 @@ mod tests {
     #[test]
     fn rejects_requests_missing_jsonrpc_version() {
         let body = br#"{"id":1,"method":"tools/list"}"#;
-        let info = parse_jsonrpc_body(body);
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
 
         assert!(info.calls.is_empty());
         assert_eq!(
@@ -471,7 +710,7 @@ mod tests {
             {"jsonrpc":"2.0","id":1,"method":"tools/list"},
             {"id":2,"method":"tools/call","params":{"name":"read_status"}}
         ]"#;
-        let info = parse_jsonrpc_body(body);
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
 
         assert!(info.calls.is_empty());
         assert!(info.is_batch);
@@ -484,7 +723,7 @@ mod tests {
     #[test]
     fn rejects_unsupported_jsonrpc_version() {
         let body = br#"{"jsonrpc":"1.0","id":1,"method":"tools/list"}"#;
-        let info = parse_jsonrpc_body(body);
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
 
         assert!(info.calls.is_empty());
         assert_eq!(
@@ -515,7 +754,7 @@ mod tests {
             {"jsonrpc":"2.0","id":1,"method":"tools/list"},
             {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"read_status"}}
         ]"#;
-        let info = parse_jsonrpc_body(body);
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
         assert!(info.error.is_none());
         assert!(info.is_batch);
         assert!(!info.has_response);
@@ -534,7 +773,7 @@ mod tests {
             {"jsonrpc":"2.0","id":1,"method":"tools/list"},
             {"jsonrpc":"2.0","id":2,"result":{"ok":true}}
         ]"#;
-        let info = parse_jsonrpc_body(body);
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
 
         assert!(info.error.is_none());
         assert!(info.is_batch);
@@ -547,7 +786,7 @@ mod tests {
     fn rejects_invalid_jsonrpc_response_body() {
         let body =
             br#"{"jsonrpc":"2.0","id":1,"result":{},"error":{"code":-32603,"message":"failed"}}"#;
-        let info = parse_jsonrpc_body(body);
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
 
         assert!(info.calls.is_empty());
         assert!(!info.has_response);
@@ -560,7 +799,7 @@ mod tests {
     #[test]
     fn rejects_message_with_method_and_result_or_error() {
         let result_body = br#"{"jsonrpc":"2.0","id":1,"method":"initialize","result":{}}"#;
-        let result_info = parse_jsonrpc_body(result_body);
+        let result_info = parse_jsonrpc_body(result_body, JsonRpcInspectionMode::JsonRpc);
         assert!(result_info.calls.is_empty());
         assert_eq!(
             result_info.error.as_deref(),
@@ -568,7 +807,7 @@ mod tests {
         );
 
         let error_body = br#"{"jsonrpc":"2.0","id":1,"method":"initialize","error":{"code":-32603,"message":"failed"}}"#;
-        let error_info = parse_jsonrpc_body(error_body);
+        let error_info = parse_jsonrpc_body(error_body, JsonRpcInspectionMode::JsonRpc);
         assert!(error_info.calls.is_empty());
         assert_eq!(
             error_info.error.as_deref(),
@@ -582,7 +821,7 @@ mod tests {
             {"jsonrpc":"2.0","id":1,"method":"tools/list"},
             {"jsonrpc":"2.0","id":2,"method":"initialize","result":{}}
         ]"#;
-        let info = parse_jsonrpc_body(body);
+        let info = parse_jsonrpc_body(body, JsonRpcInspectionMode::JsonRpc);
 
         assert!(info.calls.is_empty());
         assert!(info.is_batch);
@@ -596,12 +835,15 @@ mod tests {
     fn params_digest_is_canonical_and_redacted() {
         let first = parse_jsonrpc_body(
             br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"submit_report","arguments":{"scope":"workspace/main"}}}"#,
+            JsonRpcInspectionMode::JsonRpc,
         );
         let reordered = parse_jsonrpc_body(
             br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"arguments":{"scope":"workspace/main"},"name":"submit_report"}}"#,
+            JsonRpcInspectionMode::JsonRpc,
         );
         let changed = parse_jsonrpc_body(
             br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"submit_report","arguments":{"scope":"workspace/other"}}}"#,
+            JsonRpcInspectionMode::JsonRpc,
         );
 
         let digest = first.params_sha256().expect("params digest");
@@ -620,12 +862,14 @@ mod tests {
                 {"jsonrpc":"2.0","id":1,"method":"tools/list"},
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"blocked_action"}}
             ]"#,
+            JsonRpcInspectionMode::JsonRpc,
         );
         let empty_batch = parse_jsonrpc_body(
             br#"[
                 {"jsonrpc":"2.0","id":1,"method":"tools/list"},
                 {"jsonrpc":"2.0","id":2,"method":"initialize"}
             ]"#,
+            JsonRpcInspectionMode::JsonRpc,
         );
 
         let digest = batch.params_sha256().expect("batch params digest");

--- a/crates/openshell-supervisor-network/src/l7/mod.rs
+++ b/crates/openshell-supervisor-network/src/l7/mod.rs
@@ -28,6 +28,7 @@ pub enum L7Protocol {
     Graphql,
     Sql,
     JsonRpc,
+    Mcp,
 }
 
 impl L7Protocol {
@@ -38,8 +39,13 @@ impl L7Protocol {
             "graphql" => Some(Self::Graphql),
             "sql" => Some(Self::Sql),
             "json-rpc" => Some(Self::JsonRpc),
+            "mcp" => Some(Self::Mcp),
             _ => None,
         }
+    }
+
+    pub fn is_jsonrpc_family(self) -> bool {
+        matches!(self, Self::JsonRpc | Self::Mcp)
     }
 }
 
@@ -82,6 +88,9 @@ pub struct L7EndpointConfig {
     pub graphql_max_body_bytes: usize,
     /// Maximum JSON-RPC request body bytes to buffer for inspection.
     pub json_rpc_max_body_bytes: usize,
+    /// MCP-only strict validation for tools/call params.name. Defaults to true
+    /// for MCP endpoints and is ignored by other JSON-RPC-family protocols.
+    pub mcp_strict_tool_names: bool,
     /// When true, percent-encoded `/` (`%2F`) is preserved in path segments
     /// rather than rejected at the parser. Needed by upstreams like GitLab
     /// that embed `%2F` in namespaced project paths. Defaults to false.
@@ -177,6 +186,8 @@ pub fn parse_l7_config(val: &regorus::Value) -> Option<L7EndpointConfig> {
         .and_then(|v| usize::try_from(v).ok())
         .filter(|v| *v > 0)
         .unwrap_or(jsonrpc::DEFAULT_MAX_BODY_BYTES);
+    let mcp_strict_tool_names = protocol == L7Protocol::Mcp
+        && get_object_bool(val, "mcp_strict_tool_names").unwrap_or(true);
 
     Some(L7EndpointConfig {
         protocol,
@@ -185,6 +196,7 @@ pub fn parse_l7_config(val: &regorus::Value) -> Option<L7EndpointConfig> {
         enforcement,
         graphql_max_body_bytes,
         json_rpc_max_body_bytes,
+        mcp_strict_tool_names,
         allow_encoded_slash,
         websocket_credential_rewrite,
         request_body_credential_rewrite,
@@ -483,28 +495,45 @@ fn validate_graphql_rule(
     validate_graphql_fields(errors, warnings, loc, rule.get("fields"));
 }
 
-fn validate_l7_matcher_map(
+#[derive(Clone, Copy)]
+enum MatcherNesting {
+    // REST query matchers are a flat map: each key maps directly to a matcher.
+    Flat,
+    // JSON-RPC/MCP params may use nested maps that flatten into dot-path keys
+    // before Rego evaluation.
+    Nested,
+}
+
+// Validate a matcher map when it exists. Null is treated like omission because
+// policy loading normalizes absent optional maps the same way.
+fn validate_matcher_map(
     errors: &mut Vec<String>,
     warnings: &mut Vec<String>,
     loc: &str,
-    value: &serde_json::Value,
-    label: &str,
+    value: Option<&serde_json::Value>,
+    nesting: MatcherNesting,
 ) {
-    let Some(matchers) = value.as_object() else {
-        errors.push(format!("{loc}: expected map of {label} matchers"));
+    let Some(value) = value.filter(|v| !v.is_null()) else {
+        return;
+    };
+    let Some(obj) = value.as_object() else {
+        errors.push(format!("{loc}: expected map of matchers"));
         return;
     };
 
-    for (param, matcher) in matchers {
-        validate_l7_matcher(errors, warnings, &format!("{loc}.{param}"), matcher);
+    for (key, matcher) in obj {
+        validate_matcher_value(errors, warnings, &format!("{loc}.{key}"), matcher, nesting);
     }
 }
 
-fn validate_l7_matcher(
+// Validate one matcher leaf. In nested mode, an object without `glob` or `any`
+// is treated as another params namespace and walked recursively.
+fn validate_matcher_value(
     errors: &mut Vec<String>,
     warnings: &mut Vec<String>,
     loc: &str,
     matcher: &serde_json::Value,
+    nesting: MatcherNesting,
 ) {
     if let Some(glob_str) = matcher.as_str() {
         if let Some(warning) = check_glob_syntax(glob_str) {
@@ -514,12 +543,35 @@ fn validate_l7_matcher(
     }
 
     let Some(matcher_obj) = matcher.as_object() else {
-        errors.push(format!("{loc}: expected string glob or object with `any`"));
+        errors.push(format!("{loc}: {}", matcher_expected_message(nesting)));
         return;
     };
 
     let has_any = matcher_obj.get("any").is_some();
     let has_glob = matcher_obj.get("glob").is_some();
+    if !has_any && !has_glob {
+        if matches!(nesting, MatcherNesting::Flat) {
+            errors.push(format!(
+                "{loc}: unknown matcher keys; only `glob` or `any` are supported"
+            ));
+            return;
+        }
+        if matcher_obj.is_empty() {
+            errors.push(format!("{loc}: nested matcher map must not be empty"));
+            return;
+        }
+        for (key, child) in matcher_obj {
+            validate_matcher_value(
+                errors,
+                warnings,
+                &format!("{loc}.{key}"),
+                child,
+                MatcherNesting::Nested,
+            );
+        }
+        return;
+    }
+
     let has_unknown = matcher_obj.keys().any(|k| k != "any" && k != "glob");
     if has_unknown {
         errors.push(format!(
@@ -535,18 +587,11 @@ fn validate_l7_matcher(
         return;
     }
 
-    if !has_glob && !has_any {
-        errors.push(format!(
-            "{loc}: object matcher requires `glob` string or non-empty `any` list"
-        ));
-        return;
-    }
-
     if has_glob {
         match matcher_obj.get("glob").and_then(|v| v.as_str()) {
             None => errors.push(format!("{loc}.glob: expected glob string")),
-            Some(g) => {
-                if let Some(warning) = check_glob_syntax(g) {
+            Some(glob_str) => {
+                if let Some(warning) = check_glob_syntax(glob_str) {
                     warnings.push(format!("{loc}.glob: {warning}"));
                 }
             }
@@ -554,26 +599,265 @@ fn validate_l7_matcher(
         return;
     }
 
-    let any = matcher_obj.get("any").and_then(|v| v.as_array());
-    let Some(any) = any else {
+    let Some(any) = matcher_obj.get("any").and_then(|v| v.as_array()) else {
         errors.push(format!("{loc}.any: expected array of glob strings"));
         return;
     };
-
     if any.is_empty() {
         errors.push(format!("{loc}.any: list must not be empty"));
         return;
     }
-
     if any.iter().any(|v| v.as_str().is_none()) {
         errors.push(format!("{loc}.any: all values must be strings"));
     }
-
     for item in any.iter().filter_map(|v| v.as_str()) {
         if let Some(warning) = check_glob_syntax(item) {
             warnings.push(format!("{loc}.any: {warning}"));
         }
     }
+}
+
+// Keep the leaf-shape error specific to the policy surface being validated:
+// REST query maps cannot nest, while JSON-RPC/MCP params maps can.
+fn matcher_expected_message(nesting: MatcherNesting) -> &'static str {
+    match nesting {
+        MatcherNesting::Flat => "expected string glob or matcher object",
+        MatcherNesting::Nested => "expected string glob, matcher object, or nested matcher map",
+    }
+}
+
+// Validate the shared JSON-RPC-family rule surface. Generic JSON-RPC requires
+// an explicit method and can match params. MCP keeps method optional while the
+// endpoint-level method profile is enabled; disabling that profile makes
+// method explicit on every authored MCP rule. MCP does not expose tool-argument
+// matching.
+fn validate_jsonrpc_rule_fields(
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    loc: &str,
+    rule: &serde_json::Value,
+    protocol: &str,
+    mcp_strict_tool_names: bool,
+    mcp_allow_all_known_mcp_methods: bool,
+) {
+    let method = rule.get("method").and_then(|v| v.as_str()).unwrap_or("");
+    let has_params = rule.get("params").is_some_and(|v| !v.is_null());
+    let has_tool = rule.get("tool").is_some_and(|v| !v.is_null());
+    let has_tool_selector = mcp_rule_has_tool_selector(rule);
+
+    if protocol == "json-rpc" {
+        if method.is_empty() {
+            errors.push(format!("{loc}.method: required for {protocol} L7 rules"));
+        } else if let Some(warning) = check_glob_syntax(method) {
+            warnings.push(format!("{loc}.method: {warning}"));
+        }
+        validate_matcher_map(
+            errors,
+            warnings,
+            &format!("{loc}.params"),
+            rule.get("params"),
+            MatcherNesting::Nested,
+        );
+        if json_rule_has_non_empty_path_or_query(rule) {
+            errors.push(format!(
+                "{loc}: {protocol} L7 rules must use method/params, not path/query"
+            ));
+        }
+        return;
+    }
+
+    if protocol == "mcp" {
+        validate_mcp_method_field(errors, warnings, loc, method);
+        if method.is_empty() && !mcp_allow_all_known_mcp_methods {
+            errors.push(format!(
+                "{loc}.method: required when mcp.allow_all_known_mcp_methods is false"
+            ));
+        } else if has_tool_selector && !method.is_empty() && method != "tools/call" {
+            errors.push(format!(
+                "{loc}.method: must be tools/call when an MCP rule uses tool or params.name, got '{method}'"
+            ));
+        }
+        validate_mcp_tool_field(errors, warnings, loc, rule, mcp_strict_tool_names);
+        validate_mcp_params_field(errors, warnings, loc, rule, has_tool, mcp_strict_tool_names);
+        if json_rule_has_non_empty_path_or_query(rule) {
+            errors.push(format!(
+                "{loc}: {protocol} L7 rules must use method/tool, not path/query"
+            ));
+        }
+        return;
+    }
+
+    if has_tool {
+        errors.push(format!(
+            "{loc}.tool: MCP tool matching is only valid for protocol mcp"
+        ));
+    }
+
+    if has_params {
+        errors.push(format!(
+            "{loc}.params: JSON-RPC params matching is only valid for protocol json-rpc or mcp"
+        ));
+    }
+}
+
+fn validate_mcp_method_field(
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    loc: &str,
+    method: &str,
+) {
+    if method.is_empty() {
+        return;
+    }
+    if let Some(warning) = check_glob_syntax(method) {
+        warnings.push(format!("{loc}.method: {warning}"));
+    }
+    if glob_uses_wildcard(method) && !method.starts_with("tools/") {
+        errors.push(format!(
+            "{loc}.method: MCP method globs are only valid for the tools/ method family; omit method to use the endpoint method profile"
+        ));
+    }
+}
+
+fn method_matcher_matches_tools_call(method: &str) -> bool {
+    method == "tools/call"
+        || method == "*"
+        || glob::Pattern::new(method).is_ok_and(|pattern| pattern.matches("tools/call"))
+}
+
+fn mcp_rule_has_tool_selector(rule: &serde_json::Value) -> bool {
+    rule.get("tool").is_some_and(|v| !v.is_null())
+        || rule
+            .get("params")
+            .and_then(serde_json::Value::as_object)
+            .and_then(|params| params.get("name"))
+            .is_some_and(|v| !v.is_null())
+}
+
+fn mcp_endpoint_has_tool_allow_selectors(ep: &serde_json::Value) -> bool {
+    ep.get("rules")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|rules| {
+            rules.iter().any(|rule| {
+                let allow = rule.get("allow").unwrap_or(rule);
+                mcp_rule_has_tool_selector(allow)
+            })
+        })
+}
+
+fn validate_mcp_tool_field(
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    loc: &str,
+    rule: &serde_json::Value,
+    mcp_strict_tool_names: bool,
+) {
+    let Some(tool) = rule.get("tool").filter(|v| !v.is_null()) else {
+        return;
+    };
+    validate_matcher_value(
+        errors,
+        warnings,
+        &format!("{loc}.tool"),
+        tool,
+        MatcherNesting::Flat,
+    );
+    validate_mcp_tool_name_wildcard_policy(
+        errors,
+        &format!("{loc}.tool"),
+        tool,
+        mcp_strict_tool_names,
+    );
+}
+
+fn validate_mcp_params_field(
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    loc: &str,
+    rule: &serde_json::Value,
+    has_tool: bool,
+    mcp_strict_tool_names: bool,
+) {
+    let Some(params) = rule.get("params").filter(|v| !v.is_null()) else {
+        return;
+    };
+    let Some(params_obj) = params.as_object() else {
+        errors.push(format!("{loc}.params: expected map of matchers"));
+        return;
+    };
+
+    if has_tool && params_obj.contains_key("name") {
+        errors.push(format!(
+            "{loc}: MCP rules must use either tool or params.name, not both"
+        ));
+    }
+
+    for key in params_obj.keys() {
+        if key != "name" {
+            errors.push(format!(
+                "{loc}.params.{key}: MCP tool argument matching is not supported yet"
+            ));
+        }
+    }
+
+    validate_matcher_map(
+        errors,
+        warnings,
+        &format!("{loc}.params"),
+        Some(params),
+        MatcherNesting::Nested,
+    );
+    if let Some(name_matcher) = params_obj.get("name") {
+        validate_mcp_tool_name_wildcard_policy(
+            errors,
+            &format!("{loc}.params.name"),
+            name_matcher,
+            mcp_strict_tool_names,
+        );
+    }
+}
+
+fn validate_mcp_tool_name_wildcard_policy(
+    errors: &mut Vec<String>,
+    loc: &str,
+    matcher: &serde_json::Value,
+    mcp_strict_tool_names: bool,
+) {
+    if !mcp_strict_tool_names && matcher_uses_glob_wildcard(matcher) {
+        errors.push(format!(
+            "{loc}: wildcard tool-name matchers require mcp.strict_tool_names to remain enabled"
+        ));
+    }
+}
+
+fn matcher_uses_glob_wildcard(matcher: &serde_json::Value) -> bool {
+    if let Some(glob) = matcher.as_str() {
+        return glob_uses_wildcard(glob);
+    }
+
+    let Some(obj) = matcher.as_object() else {
+        return false;
+    };
+    if obj
+        .get("glob")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(glob_uses_wildcard)
+    {
+        return true;
+    }
+    obj.get("any")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|values| {
+            values
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .any(glob_uses_wildcard)
+        })
+}
+
+fn glob_uses_wildcard(glob: &str) -> bool {
+    glob.bytes()
+        .any(|b| matches!(b, b'*' | b'?' | b'[' | b']' | b'{' | b'}'))
 }
 
 fn json_rule_has_graphql_fields(rule: &serde_json::Value) -> bool {
@@ -591,11 +875,6 @@ fn json_rule_has_transport_fields(rule: &serde_json::Value) -> bool {
     rule.get("method").is_some() || rule.get("path").is_some() || rule.get("query").is_some()
 }
 
-fn json_rule_has_non_empty_jsonrpc_params(rule: &serde_json::Value) -> bool {
-    rule.get("params")
-        .is_some_and(|v| !v.is_null() && !v.as_object().is_some_and(serde_json::Map::is_empty))
-}
-
 fn json_rule_has_non_empty_path_or_query(rule: &serde_json::Value) -> bool {
     rule.get("path")
         .and_then(|v| v.as_str())
@@ -604,33 +883,6 @@ fn json_rule_has_non_empty_path_or_query(rule: &serde_json::Value) -> bool {
             .get("query")
             .and_then(|v| v.as_object())
             .is_some_and(|v| !v.is_empty())
-}
-
-fn validate_jsonrpc_rule(
-    errors: &mut Vec<String>,
-    warnings: &mut Vec<String>,
-    loc: &str,
-    rule: &serde_json::Value,
-    kind: &str,
-) {
-    let method = rule.get("method").and_then(|v| v.as_str()).unwrap_or("");
-    if method.is_empty() {
-        errors.push(format!(
-            "{loc}: JSON-RPC {kind} rules must specify method, for example \"*\""
-        ));
-    } else if let Some(warning) = check_glob_syntax(method) {
-        warnings.push(format!("{loc}.method: {warning}"));
-    }
-
-    if json_rule_has_non_empty_path_or_query(rule) {
-        errors.push(format!(
-            "{loc}: JSON-RPC {kind} rules must use method/params, not path/query"
-        ));
-    }
-
-    if let Some(params) = rule.get("params").filter(|v| !v.is_null()) {
-        validate_l7_matcher_map(errors, warnings, &format!("{loc}.params"), params, "params");
-    }
 }
 
 fn json_endpoint_has_graphql_policy(ep: &serde_json::Value) -> bool {
@@ -679,6 +931,8 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
 
         for (i, ep) in endpoints.iter().enumerate() {
             let protocol = ep.get("protocol").and_then(|v| v.as_str()).unwrap_or("");
+            let l7_protocol = L7Protocol::parse(protocol);
+            let jsonrpc_family = l7_protocol.is_some_and(L7Protocol::is_jsonrpc_family);
             let tls = ep.get("tls").and_then(|v| v.as_str()).unwrap_or("");
             let enforcement = ep.get("enforcement").and_then(|v| v.as_str()).unwrap_or("");
             let access = ep.get("access").and_then(|v| v.as_str()).unwrap_or("");
@@ -703,6 +957,19 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                 |arr| arr.iter().filter_map(serde_json::Value::as_u64).collect(),
             );
             let loc = format!("{name}.endpoints[{i}]");
+
+            if protocol == "mcp" {
+                if host.trim().is_empty() {
+                    errors.push(format!(
+                        "{loc}: protocol mcp requires host; protocol alone is not a wildcard endpoint"
+                    ));
+                }
+                if !ports.iter().any(|port| *port > 0) {
+                    errors.push(format!(
+                        "{loc}: protocol mcp requires port or ports; protocol alone is not a wildcard endpoint"
+                    ));
+                }
+            }
 
             if !endpoint_path.is_empty() {
                 if !endpoint_path.starts_with('/') && endpoint_path != "**" {
@@ -737,28 +1004,34 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                 errors.push(format!("{loc}: rules and access are mutually exclusive"));
             }
 
-            if protocol == "json-rpc" && !access.is_empty() {
-                errors.push(format!(
-                    "{loc}: protocol json-rpc does not support access presets; use explicit rules with allow.method such as \"*\""
-                ));
+            if jsonrpc_family && !access.is_empty() {
+                if protocol == "mcp" {
+                    errors.push(format!(
+                        "{loc}: protocol {protocol} does not support access presets; use rules/deny_rules or omit rules for the default allow-all MCP policy"
+                    ));
+                } else {
+                    errors.push(format!(
+                        "{loc}: protocol {protocol} does not support access presets; use explicit rules with allow.method such as \"*\""
+                    ));
+                }
             }
 
             if protocol == "json-rpc" && !has_rules {
                 errors.push(format!(
-                    "{loc}: protocol json-rpc requires explicit rules with allow.method"
+                    "{loc}: protocol {protocol} requires explicit rules with allow.method"
                 ));
             }
 
             // protocol requires rules or access
-            if !protocol.is_empty() && !has_rules && access.is_empty() {
+            if !protocol.is_empty() && protocol != "mcp" && !has_rules && access.is_empty() {
                 errors.push(format!(
                     "{loc}: protocol requires rules or access to define allowed traffic"
                 ));
             }
 
-            if !protocol.is_empty() && L7Protocol::parse(protocol).is_none() {
+            if !protocol.is_empty() && l7_protocol.is_none() {
                 errors.push(format!(
-                    "{loc}: unknown protocol '{protocol}' (expected rest, websocket, graphql, sql, or json-rpc)"
+                    "{loc}: unknown protocol '{protocol}' (expected rest, websocket, graphql, sql, json-rpc, or mcp)"
                 ));
             }
 
@@ -807,9 +1080,59 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                 ));
             }
 
-            if protocol != "json-rpc" && ep.get("json_rpc_max_body_bytes").is_some() {
+            if !jsonrpc_family && ep.get("json_rpc_max_body_bytes").is_some() {
                 warnings.push(format!(
-                    "{loc}: JSON-RPC-specific endpoint fields are ignored unless protocol is json-rpc"
+                    "{loc}: JSON-RPC-specific endpoint fields are ignored unless protocol is json-rpc or mcp"
+                ));
+            }
+            let has_mcp_strict_tool_names = ep.get("mcp_strict_tool_names").is_some();
+            let has_mcp_allow_all_known_mcp_methods =
+                ep.get("mcp_allow_all_known_mcp_methods").is_some();
+            if has_mcp_strict_tool_names {
+                if ep
+                    .get("mcp_strict_tool_names")
+                    .and_then(serde_json::Value::as_bool)
+                    .is_none()
+                {
+                    errors.push(format!("{loc}: mcp.strict_tool_names must be boolean"));
+                }
+                if protocol != "mcp" {
+                    errors.push(format!(
+                        "{loc}: mcp.strict_tool_names is only valid for protocol mcp"
+                    ));
+                }
+            }
+            if has_mcp_allow_all_known_mcp_methods {
+                if ep
+                    .get("mcp_allow_all_known_mcp_methods")
+                    .and_then(serde_json::Value::as_bool)
+                    .is_none()
+                {
+                    errors.push(format!(
+                        "{loc}: mcp.allow_all_known_mcp_methods must be boolean"
+                    ));
+                }
+                if protocol != "mcp" {
+                    errors.push(format!(
+                        "{loc}: mcp.allow_all_known_mcp_methods is only valid for protocol mcp"
+                    ));
+                }
+            }
+            let mcp_strict_tool_names = ep
+                .get("mcp_strict_tool_names")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true);
+            let mcp_allow_all_known_mcp_methods = ep
+                .get("mcp_allow_all_known_mcp_methods")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true);
+            if protocol == "mcp"
+                && !has_rules
+                && access.is_empty()
+                && !mcp_allow_all_known_mcp_methods
+            {
+                errors.push(format!(
+                    "{loc}: protocol mcp requires rules when mcp.allow_all_known_mcp_methods is false"
                 ));
             }
 
@@ -899,15 +1222,30 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                 }
 
                 // deny_rules require some allow base (access or rules)
-                if !has_rules && access.is_empty() {
+                if protocol != "mcp" && !has_rules && access.is_empty() {
                     errors.push(format!(
                         "{loc}: deny_rules require rules or access to define the base allow set"
                     ));
                 }
 
+                let has_mcp_tool_allow_selectors =
+                    protocol == "mcp" && mcp_endpoint_has_tool_allow_selectors(ep);
+
                 if let Some(deny_rules) = ep.get("deny_rules").and_then(|v| v.as_array()) {
                     for (deny_idx, deny_rule) in deny_rules.iter().enumerate() {
                         let deny_loc = format!("{loc}.deny_rules[{deny_idx}]");
+
+                        if has_mcp_tool_allow_selectors
+                            && deny_rule
+                                .get("method")
+                                .and_then(serde_json::Value::as_str)
+                                .is_some_and(method_matcher_matches_tools_call)
+                            && !mcp_rule_has_tool_selector(deny_rule)
+                        {
+                            errors.push(format!(
+                                "{deny_loc}: method matcher denies every tool call and conflicts with MCP tool allow rules; add tool or params.name to deny specific tools, or remove the tool allow rules"
+                            ));
+                        }
 
                         // Validate method
                         if let Some(method) = deny_rule.get("method").and_then(|m| m.as_str())
@@ -932,14 +1270,24 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
 
                         // Validate query matchers — mirrors allow-side validation exactly
                         if let Some(query) = deny_rule.get("query").filter(|v| !v.is_null()) {
-                            validate_l7_matcher_map(
+                            validate_matcher_map(
                                 &mut errors,
                                 &mut warnings,
                                 &format!("{deny_loc}.query"),
-                                query,
-                                "query",
+                                Some(query),
+                                MatcherNesting::Flat,
                             );
                         }
+
+                        validate_jsonrpc_rule_fields(
+                            &mut errors,
+                            &mut warnings,
+                            &deny_loc,
+                            deny_rule,
+                            protocol,
+                            mcp_strict_tool_names,
+                            mcp_allow_all_known_mcp_methods,
+                        );
 
                         // SQL command validation
                         if let Some(command) = deny_rule.get("command").and_then(|c| c.as_str())
@@ -971,20 +1319,6 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                         } else if deny_has_graphql {
                             warnings.push(format!(
                                 "{deny_loc}: GraphQL rule fields are ignored unless protocol is graphql or websocket"
-                            ));
-                        }
-
-                        if protocol == "json-rpc" {
-                            validate_jsonrpc_rule(
-                                &mut errors,
-                                &mut warnings,
-                                &deny_loc,
-                                deny_rule,
-                                "deny",
-                            );
-                        } else if json_rule_has_non_empty_jsonrpc_params(deny_rule) {
-                            errors.push(format!(
-                                "{deny_loc}: params are only valid on protocol json-rpc endpoints"
                             ));
                         }
                     }
@@ -1028,35 +1362,44 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                             continue;
                         };
 
-                        validate_l7_matcher_map(
+                        validate_matcher_map(
                             &mut errors,
                             &mut warnings,
                             &format!("{loc}.rules[{rule_idx}].allow.query"),
-                            query,
-                            "query",
+                            Some(query),
+                            MatcherNesting::Flat,
                         );
                     }
                 }
             }
 
+            let has_mcp_tool_allow_selectors =
+                protocol == "mcp" && mcp_endpoint_has_tool_allow_selectors(ep);
             if has_rules && let Some(rules) = ep.get("rules").and_then(|v| v.as_array()) {
                 for (rule_idx, rule) in rules.iter().enumerate() {
                     let allow = rule.get("allow").unwrap_or(rule);
                     let rule_loc = format!("{loc}.rules[{rule_idx}].allow");
-                    let allow_has_graphql = json_rule_has_graphql_fields(allow);
-                    if protocol == "json-rpc" {
-                        validate_jsonrpc_rule(
-                            &mut errors,
-                            &mut warnings,
-                            &rule_loc,
-                            allow,
-                            "allow",
-                        );
-                    } else if json_rule_has_non_empty_jsonrpc_params(allow) {
+                    if has_mcp_tool_allow_selectors
+                        && allow
+                            .get("method")
+                            .and_then(serde_json::Value::as_str)
+                            .is_some_and(method_matcher_matches_tools_call)
+                        && !mcp_rule_has_tool_selector(allow)
+                    {
                         errors.push(format!(
-                            "{rule_loc}: params are only valid on protocol json-rpc endpoints"
+                            "{rule_loc}: method matcher allows every tool call and conflicts with MCP tool allow rules; add tool or params.name to narrow tools/call, or remove the tool allow rules"
                         ));
                     }
+                    validate_jsonrpc_rule_fields(
+                        &mut errors,
+                        &mut warnings,
+                        &rule_loc,
+                        allow,
+                        protocol,
+                        mcp_strict_tool_names,
+                        mcp_allow_all_known_mcp_methods,
+                    );
+                    let allow_has_graphql = json_rule_has_graphql_fields(allow);
                     if websocket_has_graphql_policy
                         && allow
                             .get("method")
@@ -1107,29 +1450,46 @@ pub fn expand_access_presets(data: &mut serde_json::Value) {
         };
 
         for ep in endpoints.iter_mut() {
+            let protocol = ep
+                .get("protocol")
+                .and_then(|v| v.as_str())
+                .unwrap_or("rest");
+            let has_rules = ep
+                .get("rules")
+                .and_then(|v| v.as_array())
+                .is_some_and(|a| !a.is_empty());
             let access = ep
                 .get("access")
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
 
+            let mcp_allow_all_known_mcp_methods = ep
+                .get("mcp_allow_all_known_mcp_methods")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true);
+
+            if protocol == "mcp"
+                && access.is_empty()
+                && !has_rules
+                && mcp_allow_all_known_mcp_methods
+            {
+                ep.as_object_mut().unwrap().insert(
+                    "rules".to_string(),
+                    serde_json::Value::Array(vec![jsonrpc_rule_json("*")]),
+                );
+                continue;
+            }
+
             if access.is_empty() {
                 continue;
             }
 
             // Don't expand if rules already exist (validation will catch this)
-            if ep
-                .get("rules")
-                .and_then(|v| v.as_array())
-                .is_some_and(|a| !a.is_empty())
-            {
+            if has_rules {
                 continue;
             }
 
-            let protocol = ep
-                .get("protocol")
-                .and_then(|v| v.as_str())
-                .unwrap_or("rest");
             let rules = if protocol == "graphql" {
                 match access.as_str() {
                     "read-only" => vec![graphql_rule_json("query")],
@@ -1176,6 +1536,14 @@ fn rule_json(method: &str, path: &str) -> serde_json::Value {
         "allow": {
             "method": method,
             "path": path
+        }
+    })
+}
+
+fn jsonrpc_rule_json(method: &str) -> serde_json::Value {
+    serde_json::json!({
+        "allow": {
+            "method": method
         }
     })
 }
@@ -1271,6 +1639,26 @@ mod tests {
         .unwrap();
         let config = parse_l7_config(&val).unwrap();
         assert!(config.allow_encoded_slash);
+    }
+
+    #[test]
+    fn parse_l7_config_mcp_strict_tool_names_defaults_true() {
+        let val = regorus::Value::from_json_str(
+            r#"{"protocol": "mcp", "host": "mcp.example.com", "port": 443}"#,
+        )
+        .unwrap();
+        let config = parse_l7_config(&val).unwrap();
+        assert!(config.mcp_strict_tool_names);
+    }
+
+    #[test]
+    fn parse_l7_config_mcp_strict_tool_names_can_disable() {
+        let val = regorus::Value::from_json_str(
+            r#"{"protocol": "mcp", "host": "mcp.example.com", "port": 443, "mcp_strict_tool_names": false}"#,
+        )
+        .unwrap();
+        let config = parse_l7_config(&val).unwrap();
+        assert!(!config.mcp_strict_tool_names);
     }
 
     #[test]
@@ -1580,7 +1968,7 @@ mod tests {
         assert!(
             errors
                 .iter()
-                .any(|e| { e.contains("JSON-RPC allow rules must specify method") }),
+                .any(|e| { e.contains("rules[0].allow.method") && e.contains("required") }),
             "JSON-RPC allow rules without method should be rejected: {errors:?}"
         );
         assert!(
@@ -1588,6 +1976,323 @@ mod tests {
                 .iter()
                 .any(|e| { e.contains("must use method/params, not path/query") }),
             "JSON-RPC allow rules with path/query should be rejected: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_tool_selectors_use_endpoint_method_profile_and_reject_arguments() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "rules": [{
+                            "allow": {
+                                "tool": { "any": ["read_status", "submit_*"] }
+                            }
+                        }, {
+                            "allow": {
+                                "method": "tools/call",
+                                "tool": "submit_report",
+                                "params": {
+                                    "arguments": {
+                                        "scope": "workspace/main"
+                                    }
+                                }
+                            }
+                        }, {
+                            "allow": {
+                                "method": "initialize"
+                            }
+                        }, {
+                            "allow": {
+                                "method": "tools/call",
+                                "tool": "list_reports"
+                            }
+                        }],
+                        "deny_rules": [{
+                            "tool": "delete_*"
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.contains("rules[0].allow.method") && e.contains("required")),
+            "MCP tool rules can omit method while allow_all_known_mcp_methods is enabled: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[1].allow.params.arguments")
+                    && e.contains("argument matching is not supported")
+            }),
+            "MCP argument params should be rejected: {errors:?}"
+        );
+        assert!(
+            !errors.iter().any(|e| e.contains("rules[2].allow.method")),
+            "MCP method-only rules should not require a tool selector: {errors:?}"
+        );
+        assert!(
+            !errors.iter().any(|e| e.contains("rules[3].allow.method")),
+            "MCP tool rules with method: tools/call should validate: {errors:?}"
+        );
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.contains("deny_rules[0].method") && e.contains("tools/call")),
+            "MCP deny tool rules can omit method while allow_all_known_mcp_methods is enabled: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_tool_selectors_require_method_when_method_profile_disabled() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "mcp_allow_all_known_mcp_methods": false,
+                        "rules": [{
+                            "allow": {
+                                "tool": "read_status"
+                            }
+                        }],
+                        "deny_rules": [{
+                            "tool": "delete_*"
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[0].allow.method")
+                    && e.contains("mcp.allow_all_known_mcp_methods is false")
+            }),
+            "MCP allow tool rules should require method when method profile is disabled: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("deny_rules[0].method")
+                    && e.contains("mcp.allow_all_known_mcp_methods is false")
+            }),
+            "MCP deny tool rules should require method when method profile is disabled: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_method_globs_are_tools_family_only() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "rules": [{
+                            "allow": {
+                                "method": "vendor/extension"
+                            }
+                        }, {
+                            "allow": {
+                                "method": "vendor/*"
+                            }
+                        }, {
+                            "allow": {
+                                "method": "*"
+                            }
+                        }, {
+                            "allow": {
+                                "method": "tools/*"
+                            }
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            !errors.iter().any(|e| e.contains("rules[0].allow.method")),
+            "literal extension methods should stay addressable: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[1].allow.method")
+                    && e.contains("only valid for the tools/ method family")
+            }),
+            "non-tools method globs should be rejected: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[2].allow.method")
+                    && e.contains("only valid for the tools/ method family")
+            }),
+            "authored method: * should be rejected for MCP: {errors:?}"
+        );
+        assert!(
+            !errors.iter().any(|e| e.contains("rules[3].allow.method")),
+            "tools-family method globs should validate: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_wildcard_tool_requires_strict_tool_names() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "mcp_strict_tool_names": false,
+                        "rules": [{
+                            "allow": {
+                                "method": "tools/call",
+                                "tool": "read_*"
+                            }
+                        }, {
+                            "allow": {
+                                "method": "tools/call",
+                                "params": {
+                                    "name": { "any": ["safe_tool", "list_*"] }
+                                }
+                            }
+                        }],
+                        "deny_rules": [{
+                            "method": "tools/call",
+                            "tool": "delete_resource"
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[0].allow.tool")
+                    && e.contains("strict_tool_names to remain enabled")
+            }),
+            "wildcard tool aliases should require strict tool names: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[1].allow.params.name")
+                    && e.contains("strict_tool_names to remain enabled")
+            }),
+            "wildcard params.name should require strict tool names: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_protocol_requires_endpoint_target() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "protocol": "mcp"
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("protocol mcp requires host")),
+            "MCP protocol-only endpoint should require host: {errors:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("protocol mcp requires port or ports")),
+            "MCP protocol-only endpoint should require port: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_broad_tools_call_deny_rejects_tool_allow_rules() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "rules": [{
+                            "allow": {
+                                "method": "tools/call",
+                                "tool": "read_status"
+                            }
+                        }],
+                        "deny_rules": [{
+                            "method": "tools/call"
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("deny_rules[0]")
+                    && e.contains("denies every tool call")
+                    && e.contains("conflicts with MCP tool allow rules")
+            }),
+            "broad tools/call deny should reject tool allow rules with a reason: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_broad_tools_call_allow_rejects_tool_allow_rules() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "rules": [{
+                            "allow": {
+                                "method": "tools/*"
+                            }
+                        }, {
+                            "allow": {
+                                "tool": "read_status"
+                            }
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|e| {
+                e.contains("rules[0].allow")
+                    && e.contains("allows every tool call")
+                    && e.contains("conflicts with MCP tool allow rules")
+            }),
+            "broad tools/call allow should reject tool allow rules with a reason: {errors:?}"
         );
     }
 
@@ -1621,14 +2326,111 @@ mod tests {
         assert!(
             errors
                 .iter()
-                .any(|e| { e.contains("rules[0].allow") && e.contains("params are only valid") }),
+                .any(|e| { e.contains("rules[0].allow.params") && e.contains("only valid") }),
             "REST allow rules with JSON-RPC fields should be rejected: {errors:?}"
         );
         assert!(
             errors
                 .iter()
-                .any(|e| { e.contains("deny_rules[0]") && e.contains("params are only valid") }),
+                .any(|e| { e.contains("deny_rules[0].params") && e.contains("only valid") }),
             "REST deny rules with JSON-RPC fields should be rejected: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_strict_tool_names_is_mcp_only() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [
+                        {
+                            "host": "mcp.example.com",
+                            "port": 443,
+                            "path": "/mcp",
+                            "protocol": "mcp",
+                            "mcp_strict_tool_names": false,
+                            "rules": [{ "allow": { "method": "tools/call" } }]
+                        },
+                        {
+                            "host": "api.example.com",
+                            "port": 443,
+                            "protocol": "rest",
+                            "mcp_strict_tool_names": false,
+                            "mcp_allow_all_known_mcp_methods": false,
+                            "access": "full"
+                        }
+                    ],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert_eq!(
+            errors
+                .iter()
+                .filter(|error| error.contains("is only valid for protocol mcp"))
+                .count(),
+            2,
+            "only the REST endpoint should reject MCP-specific options: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_options_require_bool() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "mcp_strict_tool_names": "false",
+                        "mcp_allow_all_known_mcp_methods": "false",
+                        "rules": [{ "allow": { "method": "tools/call" } }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("mcp.strict_tool_names must be boolean")),
+            "expected bool validation error: {errors:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("mcp.allow_all_known_mcp_methods must be boolean")),
+            "expected bool validation error: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_mcp_requires_rules_when_method_profile_disabled() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "path": "/mcp",
+                        "protocol": "mcp",
+                        "mcp_allow_all_known_mcp_methods": false
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.iter().any(|error| {
+                error.contains("protocol mcp requires rules")
+                    && error.contains("mcp.allow_all_known_mcp_methods is false")
+            }),
+            "expected disabled method profile to require rules: {errors:?}"
         );
     }
 
@@ -1659,7 +2461,7 @@ mod tests {
         assert!(
             errors
                 .iter()
-                .any(|e| e.contains("JSON-RPC deny rules must specify method")),
+                .any(|e| e.contains("deny_rules[0].method") && e.contains("required")),
             "JSON-RPC deny rules without method should be rejected: {errors:?}"
         );
     }
@@ -1678,7 +2480,7 @@ mod tests {
                             "allow": {
                                 "method": "tools/call",
                                 "params": {
-                                    "name": { "mode": "read-*" },
+                                    "name": { "glob": "read-*", "mode": "strict" },
                                     "scope": { "any": [] },
                                     "count": 1
                                 }
@@ -1710,7 +2512,8 @@ mod tests {
         );
         assert!(
             errors.iter().any(|e| {
-                e.contains("allow.params.count") && e.contains("expected string glob or object")
+                e.contains("allow.params.count")
+                    && e.contains("expected string glob, matcher object, or nested matcher map")
             }),
             "JSON-RPC params should reject non-string/non-object matchers: {errors:?}"
         );
@@ -2491,6 +3294,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn validate_jsonrpc_nested_params_matchers_are_accepted() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [{
+                        "host": "mcp.example.com",
+                        "port": 443,
+                        "protocol": "json-rpc",
+                        "rules": [{
+                            "allow": {
+                                "method": "tools/call",
+                                "params": {
+                                    "name": "submit_report",
+                                    "arguments": {
+                                        "scope": "workspace/main",
+                                        "repository": { "any": ["NVIDIA/OpenShell", "NVIDIA/*"] }
+                                    }
+                                }
+                            }
+                        }]
+                    }],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, warnings) = validate_l7_policies(&data);
+        assert!(
+            errors.is_empty(),
+            "valid nested params matchers should not error: {errors:?}"
+        );
+        assert!(
+            warnings.is_empty(),
+            "valid nested params matchers should not warn: {warnings:?}"
+        );
+    }
+
     // --- Deny rules validation tests ---
 
     #[test]
@@ -2644,7 +3484,7 @@ mod tests {
         assert!(
             errors
                 .iter()
-                .any(|e| e.contains("expected string glob or object")),
+                .any(|e| e.contains("expected string glob or matcher object")),
             "should reject non-string/non-object matcher in deny query: {errors:?}"
         );
     }

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -140,6 +140,7 @@ fn engine_type_for_protocol(protocol: L7Protocol) -> &'static str {
     match protocol {
         L7Protocol::Graphql => "l7-graphql",
         L7Protocol::JsonRpc => "l7-jsonrpc",
+        L7Protocol::Mcp => "l7-mcp",
         L7Protocol::Websocket => "l7-websocket",
         L7Protocol::Rest | L7Protocol::Sql => "l7",
     }
@@ -216,7 +217,9 @@ where
                 .into_diagnostic()?;
             Ok(())
         }
-        L7Protocol::JsonRpc => relay_jsonrpc(config, &engine, client, upstream, ctx).await,
+        L7Protocol::JsonRpc | L7Protocol::Mcp => {
+            relay_jsonrpc(config, &engine, client, upstream, ctx).await
+        }
     }
 }
 
@@ -310,6 +313,43 @@ where
         } else {
             None
         };
+        let jsonrpc_info = if config.protocol.is_jsonrpc_family() {
+            if crate::l7::jsonrpc::jsonrpc_receive_stream_request(&req) {
+                Some(crate::l7::jsonrpc::JsonRpcRequestInfo::receive_stream())
+            } else {
+                match crate::l7::http::read_body_for_inspection(
+                    client,
+                    &mut req,
+                    config.json_rpc_max_body_bytes,
+                )
+                .await
+                {
+                    Ok(body) => Some(crate::l7::jsonrpc::parse_jsonrpc_body_with_options(
+                        &body,
+                        crate::l7::jsonrpc::JsonRpcInspectionOptions::for_config(config),
+                    )),
+                    Err(e) => {
+                        if is_benign_connection_error(&e) {
+                            debug!(
+                                host = %ctx.host,
+                                port = ctx.port,
+                                error = %e,
+                                "JSON-RPC L7 connection closed"
+                            );
+                        } else {
+                            let detail = parse_rejection_detail(
+                                &e.to_string(),
+                                ParseRejectionMode::L7Endpoint,
+                            );
+                            emit_parse_rejection(ctx, &detail, "l7-jsonrpc");
+                        }
+                        return Ok(());
+                    }
+                }
+            }
+        } else {
+            None
+        };
 
         if close_if_stale(engine.generation_guard(), ctx) {
             return Ok(());
@@ -340,7 +380,7 @@ where
             target: redacted_target.clone(),
             query_params: req.query_params.clone(),
             graphql: graphql_info.clone(),
-            jsonrpc: None,
+            jsonrpc: jsonrpc_info.clone(),
         };
         let websocket_request = crate::l7::rest::request_is_websocket_upgrade(&req.raw_header);
         if config.protocol == L7Protocol::Websocket && !websocket_request {
@@ -364,7 +404,13 @@ where
         let parse_error_reason = graphql_info
             .as_ref()
             .and_then(|info| info.error.as_deref())
-            .map(|error| format!("GraphQL request rejected: {error}"));
+            .map(|error| format!("GraphQL request rejected: {error}"))
+            .or_else(|| {
+                jsonrpc_info
+                    .as_ref()
+                    .and_then(|info| info.error.as_deref())
+                    .map(|error| format!("JSON-RPC request rejected: {error}"))
+            });
         let force_deny = parse_error_reason.is_some();
         let (allowed, reason) = if let Some(reason) = parse_error_reason {
             (false, reason)
@@ -385,8 +431,12 @@ where
         let engine_type = match config.protocol {
             L7Protocol::Graphql => "l7-graphql",
             L7Protocol::Websocket => "l7-websocket",
-            L7Protocol::Rest | L7Protocol::Sql | L7Protocol::JsonRpc => "l7",
+            L7Protocol::JsonRpc => "l7-jsonrpc",
+            L7Protocol::Mcp => "l7-mcp",
+            L7Protocol::Rest | L7Protocol::Sql => "l7",
         };
+        let protocol_summary =
+            l7_protocol_log_summary(graphql_info.as_ref(), jsonrpc_info.as_ref());
         emit_l7_request_log(
             ctx,
             &request_info,
@@ -394,7 +444,7 @@ where
             decision_str,
             engine_type,
             &reason,
-            graphql_info.as_ref(),
+            &protocol_summary,
         );
 
         let _ = &eval_target;
@@ -472,7 +522,7 @@ fn emit_l7_request_log(
     decision_str: &str,
     engine_type: &str,
     reason: &str,
-    graphql_info: Option<&crate::l7::graphql::GraphqlRequestInfo>,
+    protocol_summary: &str,
 ) {
     let (action_id, disposition_id, severity) = match decision_str {
         "deny" => (ActionId::Denied, DispositionId::Blocked, SeverityId::Medium),
@@ -487,9 +537,6 @@ fn emit_l7_request_log(
             SeverityId::Informational,
         ),
     };
-    let summary = graphql_info
-        .map(|info| format!(" {}", graphql_log_summary(info)))
-        .unwrap_or_default();
     let event = HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
         .activity(ActivityId::Other)
         .action(action_id)
@@ -503,11 +550,31 @@ fn emit_l7_request_log(
         .firewall_rule(&ctx.policy_name, engine_type)
         .message(format!(
             "L7_REQUEST {decision_str} {} {}:{}{}{} reason={}",
-            request_info.action, ctx.host, ctx.port, redacted_target, summary, reason,
+            request_info.action, ctx.host, ctx.port, redacted_target, protocol_summary, reason,
         ))
         .build();
     ocsf_emit!(event);
     emit_activity(ctx, decision_str == "deny", "l7_policy");
+}
+
+fn l7_protocol_log_summary(
+    graphql_info: Option<&crate::l7::graphql::GraphqlRequestInfo>,
+    jsonrpc_info: Option<&crate::l7::jsonrpc::JsonRpcRequestInfo>,
+) -> String {
+    if let Some(info) = graphql_info {
+        return format!(" {}", graphql_log_summary(info));
+    }
+
+    if let Some(info) = jsonrpc_info {
+        return format!(
+            " rule_methods={} params_sha256={}",
+            rule_method_names_for_log(info),
+            info.params_sha256()
+                .unwrap_or_else(|| "<empty>".to_string())
+        );
+    }
+
+    String::new()
 }
 
 fn emit_activity(ctx: &L7EvalContext, denied: bool, deny_group: &'static str) {
@@ -657,6 +724,13 @@ pub(crate) fn websocket_extension_mode(config: &L7EndpointConfig) -> WebSocketEx
         WebSocketExtensionMode::PermessageDeflate
     } else {
         WebSocketExtensionMode::Preserve
+    }
+}
+
+fn jsonrpc_engine_type(protocol: L7Protocol) -> &'static str {
+    match protocol {
+        L7Protocol::Mcp => "l7-mcp",
+        _ => "l7-jsonrpc",
     }
 }
 
@@ -950,6 +1024,9 @@ where
             return Ok(());
         }
 
+        // Future MCP version-profile request checks should hook here before OPA
+        // evaluation. See McpOptions in proto/sandbox.proto for the policy
+        // roadmap and source documentation.
         let parsed = match crate::l7::jsonrpc::parse_jsonrpc_http_request(
             client,
             config.json_rpc_max_body_bytes,
@@ -957,6 +1034,7 @@ where
                 allow_encoded_slash: config.allow_encoded_slash,
                 ..Default::default()
             },
+            crate::l7::jsonrpc::JsonRpcInspectionOptions::for_config(config),
         )
         .await
         {
@@ -973,7 +1051,7 @@ where
                 } else {
                     let detail =
                         parse_rejection_detail(&e.to_string(), ParseRejectionMode::L7Endpoint);
-                    emit_parse_rejection(ctx, &detail, "l7-jsonrpc");
+                    emit_parse_rejection(ctx, &detail, jsonrpc_engine_type(config.protocol));
                 }
                 return Ok(());
             }
@@ -1000,9 +1078,8 @@ where
             .error
             .as_deref()
             .map(|e| format!("JSON-RPC request rejected: {e}"));
-        let response_frame_reason = jsonrpc_info
-            .has_response
-            .then(|| JSONRPC_RESPONSE_FRAME_DENY_REASON.to_string());
+        let response_frame_reason =
+            jsonrpc_response_frame_hard_deny_reason(config.protocol, &jsonrpc_info);
         let force_deny = parse_error_reason.is_some() || response_frame_reason.is_some();
         let (allowed, reason, jsonrpc_log_info) = if let Some(reason) = parse_error_reason {
             (false, reason, jsonrpc_info.clone())
@@ -1049,7 +1126,7 @@ where
                     OcsfUrl::new("http", &ctx.host, &redacted_target, ctx.port),
                 ))
                 .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
-                .firewall_rule(&ctx.policy_name, "l7-jsonrpc")
+                .firewall_rule(&ctx.policy_name, jsonrpc_engine_type(config.protocol))
                 .message(jsonrpc_log_message(
                     decision_str,
                     &request_info.action,
@@ -1064,6 +1141,11 @@ where
         }
 
         if allowed || (config.enforcement == EnforcementMode::Audit && !force_deny) {
+            // Future MCP response/SSE introspection or rewrite would hook here
+            // before returning upstream bytes. The current policy schema has no
+            // trusted-annotations or version-profile field, so MCP responses and
+            // SSE streams are relayed unchanged; see McpOptions in
+            // proto/sandbox.proto for planned policy extensions.
             let outcome = crate::l7::rest::relay_http_request_with_resolver_guarded(
                 &req,
                 client,
@@ -1357,9 +1439,16 @@ pub(crate) fn rule_method_names_for_log(info: &crate::l7::jsonrpc::JsonRpcReques
     }
     info.calls
         .iter()
-        .map(|call| call.method.as_str())
+        .map(|call| sanitize_log_token(&call.method))
         .collect::<Vec<_>>()
         .join(",")
+}
+
+fn sanitize_log_token(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_control() { '?' } else { ch })
+        .collect()
 }
 
 struct JsonRpcEvaluation {
@@ -1370,6 +1459,14 @@ struct JsonRpcEvaluation {
 
 pub(crate) const JSONRPC_RESPONSE_FRAME_DENY_REASON: &str =
     "JSON-RPC response frames are not permitted from client to server";
+
+pub(crate) fn jsonrpc_response_frame_hard_deny_reason(
+    protocol: L7Protocol,
+    jsonrpc: &crate::l7::jsonrpc::JsonRpcRequestInfo,
+) -> Option<String> {
+    (protocol != L7Protocol::Mcp && jsonrpc.has_response)
+        .then(|| JSONRPC_RESPONSE_FRAME_DENY_REASON.to_string())
+}
 
 /// Check if a miette error represents a benign connection close.
 ///
@@ -1398,15 +1495,15 @@ pub fn evaluate_l7_request(
     request: &L7RequestInfo,
 ) -> Result<(bool, String)> {
     if let Some(jsonrpc) = &request.jsonrpc
-        && jsonrpc.has_response
-    {
-        return Ok((false, JSONRPC_RESPONSE_FRAME_DENY_REASON.to_string()));
-    }
-
-    if let Some(jsonrpc) = &request.jsonrpc
         && jsonrpc.is_batch
         && !jsonrpc.calls.is_empty()
     {
+        if jsonrpc.has_response {
+            let (allowed, reason) = evaluate_l7_request_once(engine, ctx, request)?;
+            if !allowed {
+                return Ok((false, reason));
+            }
+        }
         for call in &jsonrpc.calls {
             let item_request = jsonrpc_request_for_call(request, call);
             let (allowed, reason) = evaluate_l7_request_once(engine, ctx, &item_request)?;
@@ -1427,11 +1524,14 @@ fn evaluate_jsonrpc_l7_request_for_log(
     jsonrpc: &crate::l7::jsonrpc::JsonRpcRequestInfo,
 ) -> Result<JsonRpcEvaluation> {
     if jsonrpc.has_response {
-        return Ok(JsonRpcEvaluation {
-            allowed: false,
-            reason: JSONRPC_RESPONSE_FRAME_DENY_REASON.to_string(),
-            log_info: jsonrpc.clone(),
-        });
+        let (allowed, reason) = evaluate_l7_request_once(engine, ctx, request)?;
+        if !allowed || !jsonrpc.is_batch || jsonrpc.calls.is_empty() {
+            return Ok(JsonRpcEvaluation {
+                allowed,
+                reason,
+                log_info: jsonrpc.clone(),
+            });
+        }
     }
 
     if jsonrpc.is_batch && !jsonrpc.calls.is_empty() {
@@ -1889,6 +1989,52 @@ network_policies:
         (config, tunnel_engine, ctx)
     }
 
+    fn mcp_test_relay_context() -> (L7EndpointConfig, TunnelPolicyEngine, L7EvalContext) {
+        let data = r"
+network_policies:
+  mcp_api:
+    name: mcp_api
+    endpoints:
+      - host: mcp.example.test
+        port: 8000
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - { path: /usr/bin/python3 }
+";
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
+        let input = NetworkInput {
+            host: "mcp.example.test".into(),
+            port: 8000,
+            binary_path: PathBuf::from("/usr/bin/python3"),
+            binary_sha256: "unused".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+        };
+        let (endpoint_config, generation) = engine
+            .query_endpoint_config_with_generation(&input)
+            .unwrap();
+        let config = crate::l7::parse_l7_config(&endpoint_config.unwrap()).unwrap();
+        let tunnel_engine = engine.clone_engine_for_tunnel(generation).unwrap();
+        let ctx = L7EvalContext {
+            host: "mcp.example.test".into(),
+            port: 8000,
+            policy_name: "mcp_api".into(),
+            binary_path: "/usr/bin/python3".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            activity_tx: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
+        };
+        (config, tunnel_engine, ctx)
+    }
+
     fn authorization_header_count(headers: &str) -> usize {
         headers
             .lines()
@@ -2270,6 +2416,7 @@ network_policies:
                     {"jsonrpc":"2.0","id":1,"method":"tools/list"},
                     {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"read_status"}}
                 ]"#,
+                crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
             )),
         };
 
@@ -2281,6 +2428,7 @@ network_policies:
                 {"jsonrpc":"2.0","id":1,"method":"tools/list"},
                 {"jsonrpc":"2.0","id":2,"result":{"ok":true}}
             ]"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
         ));
         let (allowed, reason) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
         assert!(!allowed);
@@ -2298,6 +2446,7 @@ network_policies:
 
         request.jsonrpc = Some(crate::l7::jsonrpc::parse_jsonrpc_body(
             br#"{"jsonrpc":"2.0","id":2,"result":{"ok":true}}"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
         ));
         let (allowed, reason) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
         assert!(!allowed);
@@ -2316,6 +2465,7 @@ network_policies:
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"blocked_action"}},
                 {"jsonrpc":"2.0","id":3,"method":"tools/delete","params":{"name":"purge_cache"}}
             ]"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
         ));
         let (allowed, _) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
         assert!(!allowed);
@@ -2396,6 +2546,7 @@ network_policies:
             graphql: None,
             jsonrpc: Some(crate::l7::jsonrpc::parse_jsonrpc_body(
                 br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"arguments.scope":"workspace/other","arguments":{"scope":"workspace/main"}}}"#,
+                crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
             )),
         };
 
@@ -2404,15 +2555,97 @@ network_policies:
 
         request.jsonrpc = Some(crate::l7::jsonrpc::parse_jsonrpc_body(
             br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"arguments":{"scope":"workspace/other"}}}"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
         ));
         let (allowed, reason) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
         assert!(allowed, "{reason}");
     }
 
     #[test]
+    fn mcp_tool_deny_rule_blocks_tools_call() {
+        let data = r#"
+network_policies:
+  mcp_api:
+    name: mcp_api
+    endpoints:
+      - host: api.example.test
+        port: 443
+        path: "/mcp"
+        protocol: mcp
+        enforcement: enforce
+        mcp:
+          max_body_bytes: 131072
+        rules:
+          - allow:
+              method: initialize
+          - allow:
+              method: tools/list
+          - allow:
+              method: tools/call
+              tool: read_status
+        deny_rules:
+          - method: tools/call
+            tool: delete_resource
+    binaries:
+      - { path: /usr/bin/node }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
+        let tunnel_engine = engine
+            .clone_engine_for_tunnel(engine.current_generation())
+            .unwrap();
+        let ctx = L7EvalContext {
+            host: "api.example.test".into(),
+            port: 443,
+            policy_name: "mcp_api".into(),
+            binary_path: "/usr/bin/node".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            activity_tx: None,
+            dynamic_credentials: None,
+            token_grant_resolver: None,
+        };
+        let mut request = L7RequestInfo {
+            action: "POST".into(),
+            target: "/mcp".into(),
+            query_params: std::collections::HashMap::new(),
+            graphql: None,
+            jsonrpc: Some(crate::l7::jsonrpc::parse_jsonrpc_body(
+                br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_status","arguments":{}}}"#,
+                crate::l7::jsonrpc::JsonRpcInspectionMode::Mcp,
+            )),
+        };
+
+        let (allowed, reason) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
+        assert!(allowed, "{reason}");
+
+        request.jsonrpc = Some(crate::l7::jsonrpc::parse_jsonrpc_body(
+            br#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delete_resource","arguments":{"scope":"workspace/main"}}}"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::Mcp,
+        ));
+        let parsed = request.jsonrpc.as_ref().expect("parsed MCP request");
+        assert!(
+            parsed.error.is_none(),
+            "MCP request should parse: {parsed:?}"
+        );
+        assert_eq!(
+            parsed.calls.first().and_then(|call| call.tool.as_deref()),
+            Some("delete_resource")
+        );
+
+        let (allowed, reason) = evaluate_l7_request(&tunnel_engine, &ctx, &request).unwrap();
+        assert!(!allowed, "delete_resource must match the MCP deny rule");
+        assert!(
+            reason.contains("deny rule"),
+            "deny reason should identify policy denial: {reason}"
+        );
+    }
+
+    #[test]
     fn jsonrpc_log_records_digest_not_args() {
         let info = crate::l7::jsonrpc::parse_jsonrpc_body(
             br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"delete_resource","arguments":{"scope":"secret-scope"}}}"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
         );
         let params_sha256 = info.params_sha256().expect("params digest");
         let message = jsonrpc_log_message(
@@ -2438,6 +2671,7 @@ network_policies:
                 {"jsonrpc":"2.0","id":1,"method":"tools/list"},
                 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delete_resource"}}
             ]"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
         );
         let batch_params_sha256 = batch.params_sha256().expect("batch params digest");
         let batch_message = jsonrpc_log_message(
@@ -2459,6 +2693,7 @@ network_policies:
 
         let no_params = crate::l7::jsonrpc::parse_jsonrpc_body(
             br#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#,
+            crate::l7::jsonrpc::JsonRpcInspectionMode::JsonRpc,
         );
         let no_params_sha256 = no_params
             .params_sha256()
@@ -2505,6 +2740,7 @@ network_policies:
             enforcement: EnforcementMode::Enforce,
             graphql_max_body_bytes: 0,
             json_rpc_max_body_bytes: crate::l7::jsonrpc::DEFAULT_MAX_BODY_BYTES,
+            mcp_strict_tool_names: true,
             allow_encoded_slash: false,
             websocket_credential_rewrite: true,
             request_body_credential_rewrite: false,
@@ -2609,6 +2845,7 @@ network_policies:
             enforcement: EnforcementMode::Enforce,
             graphql_max_body_bytes: 0,
             json_rpc_max_body_bytes: crate::l7::jsonrpc::DEFAULT_MAX_BODY_BYTES,
+            mcp_strict_tool_names: true,
             allow_encoded_slash: false,
             websocket_credential_rewrite: true,
             request_body_credential_rewrite: false,
@@ -2730,6 +2967,7 @@ network_policies:
             enforcement: EnforcementMode::Enforce,
             graphql_max_body_bytes: 0,
             json_rpc_max_body_bytes: crate::l7::jsonrpc::DEFAULT_MAX_BODY_BYTES,
+            mcp_strict_tool_names: true,
             allow_encoded_slash: false,
             websocket_credential_rewrite: true,
             request_body_credential_rewrite: false,
@@ -3136,6 +3374,62 @@ network_policies:
             .expect("upstream response should reach client")
             .unwrap();
         assert!(String::from_utf8_lossy(&response[..n]).contains("200 OK"));
+
+        drop(app);
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should complete")
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn mcp_relay_forwards_jsonrpc_response_frame() {
+        let (config, tunnel_engine, ctx) = mcp_test_relay_context();
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_with_inspection(
+                &config,
+                tunnel_engine,
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+            )
+            .await
+        });
+
+        let body = br#"{"jsonrpc":"2.0","id":7,"result":{"action":"accept","content":{}}}"#;
+        let request = format!(
+            "POST /mcp HTTP/1.1\r\nHost: mcp.example.test:8000\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        app.write_all(request.as_bytes()).await.unwrap();
+        app.write_all(body).await.unwrap();
+
+        let mut upstream_buf = [0u8; 1024];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upstream.read(&mut upstream_buf),
+        )
+        .await
+        .expect("MCP response frame should reach upstream")
+        .unwrap();
+        let upstream_request = String::from_utf8_lossy(&upstream_buf[..n]);
+        assert!(upstream_request.starts_with("POST /mcp HTTP/1.1"));
+        assert!(upstream_request.contains(r#""result":{"action":"accept""#));
+
+        upstream
+            .write_all(b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .await
+            .unwrap();
+
+        let mut response = [0u8; 512];
+        let n = tokio::time::timeout(std::time::Duration::from_secs(1), app.read(&mut response))
+            .await
+            .expect("upstream response should reach client")
+            .unwrap();
+        assert!(String::from_utf8_lossy(&response[..n]).contains("202 Accepted"));
 
         drop(app);
         tokio::time::timeout(std::time::Duration::from_secs(1), relay)

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -218,6 +218,8 @@ impl OpaEngine {
             ));
         }
 
+        normalize_l7_policy_rule_aliases(&mut data);
+
         // Expand access presets to explicit rules after validation
         crate::l7::expand_access_presets(&mut data);
 
@@ -743,6 +745,7 @@ fn preprocess_yaml_data(yaml_str: &str) -> Result<String> {
 
     // Normalize port → ports for all endpoints so Rego always sees "ports" array.
     normalize_endpoint_ports(&mut data);
+    normalize_l7_config_aliases(&mut data);
 
     // Validate BEFORE expanding presets (catches user errors like rules+access)
     let (errors, warnings) = crate::l7::validate_l7_policies(&data);
@@ -763,6 +766,8 @@ fn preprocess_yaml_data(yaml_str: &str) -> Result<String> {
             errors.join("\n")
         ));
     }
+
+    normalize_l7_policy_rule_aliases(&mut data);
 
     // Expand access presets to explicit rules after validation
     crate::l7::expand_access_presets(&mut data);
@@ -817,6 +822,206 @@ fn normalize_endpoint_ports(data: &mut serde_json::Value) {
             ep_obj.remove("port");
         }
     }
+}
+
+fn normalize_l7_config_aliases(data: &mut serde_json::Value) {
+    let Some(policies) = data
+        .get_mut("network_policies")
+        .and_then(|v| v.as_object_mut())
+    else {
+        return;
+    };
+
+    for (_name, policy) in policies.iter_mut() {
+        let Some(endpoints) = policy.get_mut("endpoints").and_then(|v| v.as_array_mut()) else {
+            continue;
+        };
+
+        for ep in endpoints.iter_mut() {
+            let Some(ep_obj) = ep.as_object_mut() else {
+                continue;
+            };
+            normalize_jsonrpc_config_alias(ep_obj, "json_rpc");
+            normalize_jsonrpc_config_alias(ep_obj, "mcp");
+        }
+    }
+}
+
+fn normalize_l7_policy_rule_aliases(data: &mut serde_json::Value) {
+    let Some(policies) = data
+        .get_mut("network_policies")
+        .and_then(|v| v.as_object_mut())
+    else {
+        return;
+    };
+
+    for (_name, policy) in policies.iter_mut() {
+        let Some(endpoints) = policy.get_mut("endpoints").and_then(|v| v.as_array_mut()) else {
+            continue;
+        };
+
+        for ep in endpoints.iter_mut() {
+            let Some(ep_obj) = ep.as_object_mut() else {
+                continue;
+            };
+            normalize_l7_rules_aliases(ep_obj);
+        }
+    }
+}
+
+fn normalize_jsonrpc_config_alias(ep: &mut serde_json::Map<String, serde_json::Value>, key: &str) {
+    let Some(config) = ep.remove(key) else {
+        return;
+    };
+    let Some(config_obj) = config.as_object() else {
+        return;
+    };
+    if let Some(max_body_bytes) = config_obj
+        .get("max_body_bytes")
+        .and_then(serde_json::Value::as_u64)
+    {
+        ep.entry("json_rpc_max_body_bytes".to_string())
+            .or_insert_with(|| serde_json::json!(max_body_bytes));
+    }
+    if key == "mcp"
+        && let Some(strict_tool_names) = config_obj.get("strict_tool_names")
+    {
+        ep.entry("mcp_strict_tool_names".to_string())
+            .or_insert_with(|| strict_tool_names.clone());
+    }
+    if key == "mcp"
+        && let Some(allow_all_known_mcp_methods) = config_obj.get("allow_all_known_mcp_methods")
+    {
+        ep.entry("mcp_allow_all_known_mcp_methods".to_string())
+            .or_insert_with(|| allow_all_known_mcp_methods.clone());
+    }
+}
+
+fn normalize_l7_rules_aliases(ep: &mut serde_json::Map<String, serde_json::Value>) {
+    let protocol = ep
+        .get("protocol")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let mcp_allow_all_known_mcp_methods = ep
+        .get("mcp_allow_all_known_mcp_methods")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true);
+    if let Some(rules) = ep.get_mut("rules").and_then(|v| v.as_array_mut()) {
+        for rule in rules {
+            if let Some(allow) = rule
+                .get_mut("allow")
+                .and_then(serde_json::Value::as_object_mut)
+            {
+                normalize_l7_rule_aliases(allow, &protocol, mcp_allow_all_known_mcp_methods);
+            } else if let Some(allow) = rule.as_object_mut() {
+                normalize_l7_rule_aliases(allow, &protocol, mcp_allow_all_known_mcp_methods);
+            }
+        }
+    }
+
+    if let Some(denies) = ep.get_mut("deny_rules").and_then(|v| v.as_array_mut()) {
+        for deny in denies {
+            if let Some(deny_obj) = deny.as_object_mut() {
+                normalize_l7_rule_aliases(deny_obj, &protocol, mcp_allow_all_known_mcp_methods);
+            }
+        }
+    }
+}
+
+fn normalize_l7_rule_aliases(
+    rule: &mut serde_json::Map<String, serde_json::Value>,
+    protocol: &str,
+    mcp_allow_all_known_mcp_methods: bool,
+) {
+    if protocol == "mcp" {
+        let mut has_tool_selector = rule
+            .get("params")
+            .and_then(serde_json::Value::as_object)
+            .and_then(|params| params.get("name"))
+            .is_some_and(|v| !v.is_null());
+        if let Some(tool) = rule.remove("tool").filter(|v| !v.is_null()) {
+            let params = rule
+                .entry("params".to_string())
+                .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+            if let Some(params) = params.as_object_mut() {
+                params.entry("name".to_string()).or_insert(tool);
+                has_tool_selector = true;
+            }
+        }
+
+        if mcp_allow_all_known_mcp_methods
+            && rule
+                .get("method")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("")
+                .is_empty()
+        {
+            let method = if has_tool_selector { "tools/call" } else { "*" };
+            rule.insert(
+                "method".to_string(),
+                serde_json::Value::String(method.to_string()),
+            );
+        }
+    } else if let Some(tool) = rule.remove("tool")
+        && let Some(tool_name) = tool.as_str().filter(|s| !s.is_empty())
+    {
+        let params = rule
+            .entry("params".to_string())
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+        if let Some(params) = params.as_object_mut() {
+            params
+                .entry("name".to_string())
+                .or_insert_with(|| serde_json::Value::String(tool_name.to_string()));
+        }
+    }
+
+    normalize_jsonrpc_params(rule);
+}
+
+// Raw JSON/YAML policy data reaches Rego without the typed policy conversion
+// path, so flatten nested JSON-RPC/MCP params here as the serializer does.
+fn normalize_jsonrpc_params(rule: &mut serde_json::Map<String, serde_json::Value>) {
+    let Some(params) = rule
+        .get_mut("params")
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+
+    let mut flattened = serde_json::Map::new();
+    for (key, matcher) in std::mem::take(params) {
+        flatten_jsonrpc_param_matcher(&key, matcher, &mut flattened);
+    }
+    *params = flattened;
+}
+
+// Treat `{glob: ...}` and `{any: [...]}` as matcher leaves. Other objects are
+// nested params maps and become dot-path keys for the Rego matcher table.
+fn flatten_jsonrpc_param_matcher(
+    key: &str,
+    matcher: serde_json::Value,
+    out: &mut serde_json::Map<String, serde_json::Value>,
+) {
+    let serde_json::Value::Object(children) = matcher else {
+        out.insert(key.to_string(), matcher);
+        return;
+    };
+
+    if is_jsonrpc_matcher_object(&children) || children.is_empty() {
+        out.insert(key.to_string(), serde_json::Value::Object(children));
+        return;
+    }
+
+    for (child_key, child) in children {
+        flatten_jsonrpc_param_matcher(&format!("{key}.{child_key}"), child, out);
+    }
+}
+
+// A matcher object is identified by the reserved matcher keys; objects without
+// those keys are interpreted as nested params maps by the normalizer.
+fn is_jsonrpc_matcher_object(obj: &serde_json::Map<String, serde_json::Value>) -> bool {
+    obj.contains_key("any") || obj.contains_key("glob")
 }
 
 /// Resolve a policy binary path through the container's root filesystem.
@@ -1161,6 +1366,15 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                     }
                     if e.json_rpc_max_body_bytes > 0 {
                         ep["json_rpc_max_body_bytes"] = e.json_rpc_max_body_bytes.into();
+                    }
+                    if let Some(mcp) = &e.mcp {
+                        if let Some(strict_tool_names) = mcp.strict_tool_names {
+                            ep["mcp_strict_tool_names"] = strict_tool_names.into();
+                        }
+                        if let Some(allow_all_known_mcp_methods) = mcp.allow_all_known_mcp_methods {
+                            ep["mcp_allow_all_known_mcp_methods"] =
+                                allow_all_known_mcp_methods.into();
+                        }
                     }
                     ep
                 })
@@ -2817,6 +3031,84 @@ network_policies:
             }
         });
         assert!(!eval_l7(&engine, &bodyless_get_without_receive_stream));
+
+        let null_metadata_get = serde_json::json!({
+            "network": { "host": "mcp.stream.test", "port": 8000 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "GET",
+                "path": "/mcp",
+                "query_params": {},
+                "jsonrpc": null
+            }
+        });
+        assert!(!eval_l7(&engine, &null_metadata_get));
+    }
+
+    #[test]
+    fn l7_mcp_receive_stream_get_is_allowed_for_matching_endpoint() {
+        let data = r#"
+network_policies:
+  mcp_stream:
+    name: mcp_stream
+    endpoints:
+      - host: mcp.stream.test
+        port: 8000
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+        let allow_input = serde_json::json!({
+            "network": { "host": "mcp.stream.test", "port": 8000 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "GET",
+                "path": "/mcp",
+                "query_params": {},
+                "jsonrpc": {
+                    "method": null,
+                    "params": {},
+                    "receive_stream": true,
+                    "error": null
+                }
+            }
+        });
+        assert!(eval_l7(&engine, &allow_input));
+
+        let deny_input = serde_json::json!({
+            "network": { "host": "mcp.stream.test", "port": 8000 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "GET",
+                "path": "/other",
+                "query_params": {},
+                "jsonrpc": {
+                    "method": null,
+                    "params": {},
+                    "receive_stream": true,
+                    "error": null
+                }
+            }
+        });
+        assert!(!eval_l7(&engine, &deny_input));
     }
 
     #[test]
@@ -2850,6 +3142,32 @@ network_policies:
         );
         mixed_input["request"]["jsonrpc"]["has_response"] = serde_json::json!(true);
         assert!(!eval_l7(&engine, &mixed_input));
+
+        let deny_input = l7_jsonrpc_response_input("mcp.response.test", 8000, "/other");
+        assert!(!eval_l7(&engine, &deny_input));
+    }
+
+    #[test]
+    fn l7_mcp_response_post_is_allowed_for_matching_endpoint() {
+        let data = r#"
+network_policies:
+  mcp_response:
+    name: mcp_response
+    endpoints:
+      - host: mcp.response.test
+        port: 8000
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        rules:
+          - allow:
+              method: initialize
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+        let response_input = l7_jsonrpc_response_input("mcp.response.test", 8000, "/mcp");
+        assert!(eval_l7(&engine, &response_input));
 
         let deny_input = l7_jsonrpc_response_input("mcp.response.test", 8000, "/other");
         assert!(!eval_l7(&engine, &deny_input));
@@ -3008,6 +3326,221 @@ network_policies:
     }
 
     #[test]
+    fn l7_mcp_rules_filter_tools_call() {
+        let data = r#"
+network_policies:
+  mcp_params:
+    name: mcp_params
+    endpoints:
+      - host: mcp.params.test
+        port: 8000
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        mcp:
+          max_body_bytes: 131072
+        rules:
+          - allow:
+              tool:
+                any: [read_status, submit_*]
+        deny_rules:
+          - tool: blocked_action
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+
+        let read_status = l7_jsonrpc_input_with_params(
+            "mcp.params.test",
+            8000,
+            "/mcp",
+            "tools/call",
+            serde_json::json!({
+                "name": "read_status",
+                "arguments.scope": "workspace/main"
+            }),
+        );
+        assert!(eval_l7(&engine, &read_status));
+
+        let read_status_any_args = l7_jsonrpc_input_with_params(
+            "mcp.params.test",
+            8000,
+            "/mcp",
+            "tools/call",
+            serde_json::json!({
+                "name": "read_status",
+                "arguments.scope": "workspace/other"
+            }),
+        );
+        assert!(eval_l7(&engine, &read_status_any_args));
+
+        let submit_report = l7_jsonrpc_input_with_params(
+            "mcp.params.test",
+            8000,
+            "/mcp",
+            "tools/call",
+            serde_json::json!({"name": "submit_report"}),
+        );
+        assert!(eval_l7(&engine, &submit_report));
+
+        let blocked = l7_jsonrpc_input_with_params(
+            "mcp.params.test",
+            8000,
+            "/mcp",
+            "tools/call",
+            serde_json::json!({"name": "blocked_action"}),
+        );
+        assert!(!eval_l7(&engine, &blocked));
+
+        let list_tools = l7_jsonrpc_input("mcp.params.test", 8000, "/mcp", "tools/list");
+        assert!(eval_l7(&engine, &list_tools));
+    }
+
+    #[test]
+    fn l7_mcp_endpoint_defaults_to_allow_all_tools() {
+        let data = r#"
+network_policies:
+  mcp_default:
+    name: mcp_default
+    endpoints:
+      - host: mcp.default.test
+        port: 8000
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+
+        let tool_call = l7_jsonrpc_input_with_params(
+            "mcp.default.test",
+            8000,
+            "/mcp",
+            "tools/call",
+            serde_json::json!({
+                "name": "any_tool",
+                "arguments.scope": "workspace/other"
+            }),
+        );
+        assert!(eval_l7(&engine, &tool_call));
+
+        let list_tools = l7_jsonrpc_input("mcp.default.test", 8000, "/mcp", "tools/list");
+        assert!(eval_l7(&engine, &list_tools));
+    }
+
+    #[test]
+    fn l7_jsonrpc_null_metadata_non_matches_without_opa_error() {
+        let data = r#"
+network_policies:
+  jsonrpc_null:
+    name: jsonrpc_null
+    endpoints:
+      - host: mcp.null.test
+        port: 8000
+        path: /mcp
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: tools/list
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+        let input = serde_json::json!({
+            "network": { "host": "mcp.null.test", "port": 8000 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "POST",
+                "path": "/mcp",
+                "query_params": {},
+                "jsonrpc": null
+            }
+        });
+
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_jsonrpc_null_params_non_matches_without_opa_error() {
+        let data = r#"
+network_policies:
+  jsonrpc_null_params:
+    name: jsonrpc_null_params
+    endpoints:
+      - host: mcp.null-params.test
+        port: 8000
+        path: /mcp
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: tools/call
+              params:
+                name: read_status
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+        let input = serde_json::json!({
+            "network": { "host": "mcp.null-params.test", "port": 8000 },
+            "exec": {
+                "path": "/usr/bin/curl",
+                "ancestors": [],
+                "cmdline_paths": []
+            },
+            "request": {
+                "method": "POST",
+                "path": "/mcp",
+                "query_params": {},
+                "jsonrpc": {
+                    "method": "tools/call",
+                    "params": null
+                }
+            }
+        });
+
+        assert!(!eval_l7(&engine, &input));
+    }
+
+    #[test]
+    fn l7_jsonrpc_params_matcher_validation_rejects_invalid_shape() {
+        let data = r#"
+network_policies:
+  invalid_jsonrpc_params:
+    name: invalid_jsonrpc_params
+    endpoints:
+      - host: mcp.invalid.test
+        port: 8000
+        path: /mcp
+        protocol: json-rpc
+        enforcement: enforce
+        rules:
+          - allow:
+              method: tools/call
+              params:
+                name:
+                  any: []
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let Err(err) = OpaEngine::from_strings(TEST_POLICY, data) else {
+            panic!("invalid params matcher should fail validation");
+        };
+
+        assert!(
+            err.to_string()
+                .contains("params.name.any: list must not be empty"),
+            "unexpected validation error: {err}"
+        );
+    }
+
+    #[test]
     fn l7_no_request_on_l4_only_endpoint() {
         // L4-only endpoint should not match L7 allow_request
         let engine = l7_engine();
@@ -3069,6 +3602,44 @@ network_policies:
         let l7 = crate::l7::parse_l7_config(&config).unwrap();
         assert_eq!(l7.protocol, crate::l7::L7Protocol::Rest);
         assert_eq!(l7.enforcement, crate::l7::EnforcementMode::Enforce);
+    }
+
+    #[test]
+    fn l7_endpoint_config_preserves_mcp_strict_tool_names_opt_out() {
+        let data = r#"
+network_policies:
+  mcp:
+    name: mcp
+    endpoints:
+      - host: mcp.example.com
+        port: 443
+        path: /mcp
+        protocol: mcp
+        enforcement: enforce
+        mcp:
+          strict_tool_names: false
+        rules:
+          - allow:
+              method: tools/call
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).expect("engine from yaml");
+        let input = NetworkInput {
+            host: "mcp.example.com".into(),
+            port: 443,
+            binary_path: PathBuf::from("/usr/bin/curl"),
+            binary_sha256: "unused".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+        };
+        let config = engine
+            .query_endpoint_config(&input)
+            .expect("query endpoint config")
+            .expect("expected mcp endpoint config");
+        let l7 = crate::l7::parse_l7_config(&config).expect("parse l7 config");
+        assert_eq!(l7.protocol, crate::l7::L7Protocol::Mcp);
+        assert!(!l7.mcp_strict_tool_names);
     }
 
     #[test]

--- a/crates/openshell-supervisor-network/src/policy_local.rs
+++ b/crates/openshell-supervisor-network/src/policy_local.rs
@@ -1128,6 +1128,7 @@ fn network_endpoint_from_json(
         graphql_persisted_queries: HashMap::new(),
         graphql_max_body_bytes: 0,
         json_rpc_max_body_bytes: 0,
+        mcp: None,
         path: String::new(),
     })
 }

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -428,7 +428,10 @@ fn emit_forward_success_activity(tx: Option<&ActivitySender>, l7_activity_pendin
     );
 }
 
-fn forward_l7_hard_deny_reason(request_info: &crate::l7::L7RequestInfo) -> Option<String> {
+fn forward_l7_hard_deny_reason(
+    protocol: crate::l7::L7Protocol,
+    request_info: &crate::l7::L7RequestInfo,
+) -> Option<String> {
     request_info
         .graphql
         .as_ref()
@@ -440,9 +443,7 @@ fn forward_l7_hard_deny_reason(request_info: &crate::l7::L7RequestInfo) -> Optio
                     .as_deref()
                     .map(|error| format!("JSON-RPC request rejected: {error}"))
                     .or_else(|| {
-                        info.has_response.then(|| {
-                            crate::l7::relay::JSONRPC_RESPONSE_FRAME_DENY_REASON.to_string()
-                        })
+                        crate::l7::relay::jsonrpc_response_frame_hard_deny_reason(protocol, info)
                     })
             })
         })
@@ -3585,7 +3586,7 @@ async fn handle_forward_proxy(
         } else {
             None
         };
-        let jsonrpc = if l7_config.config.protocol == crate::l7::L7Protocol::JsonRpc {
+        let jsonrpc = if l7_config.config.protocol.is_jsonrpc_family() {
             let header_end = forward_request_bytes
                 .windows(4)
                 .position(|w| w == b"\r\n\r\n")
@@ -3636,7 +3637,10 @@ async fn handle_forward_proxy(
                     }
                 };
                 forward_request_bytes = jsonrpc_request.raw_header;
-                Some(crate::l7::jsonrpc::parse_jsonrpc_body(&body))
+                Some(crate::l7::jsonrpc::parse_jsonrpc_body_with_options(
+                    &body,
+                    crate::l7::jsonrpc::JsonRpcInspectionOptions::for_config(&l7_config.config),
+                ))
             }
         } else {
             None
@@ -3649,7 +3653,8 @@ async fn handle_forward_proxy(
             jsonrpc,
         };
 
-        let parse_error_reason = forward_l7_hard_deny_reason(&request_info);
+        let parse_error_reason =
+            forward_l7_hard_deny_reason(l7_config.config.protocol, &request_info);
         let force_deny = parse_error_reason.is_some();
         let (allowed, reason) = parse_error_reason.map_or_else(
             || {
@@ -3693,6 +3698,7 @@ async fn handle_forward_proxy(
             let engine_type = match l7_config.config.protocol {
                 crate::l7::L7Protocol::Graphql => "l7-graphql",
                 crate::l7::L7Protocol::JsonRpc => "l7-jsonrpc",
+                crate::l7::L7Protocol::Mcp => "l7-mcp",
                 _ => "l7",
             };
             let log_message = request_info.jsonrpc.as_ref().map_or_else(
@@ -4356,6 +4362,7 @@ mod tests {
             enforcement: crate::l7::EnforcementMode::Enforce,
             graphql_max_body_bytes: crate::l7::graphql::DEFAULT_MAX_BODY_BYTES,
             json_rpc_max_body_bytes: crate::l7::jsonrpc::DEFAULT_MAX_BODY_BYTES,
+            mcp_strict_tool_names: true,
             allow_encoded_slash: false,
             websocket_credential_rewrite,
             request_body_credential_rewrite: false,
@@ -4530,7 +4537,8 @@ network_policies:
             }),
         };
 
-        let reason = forward_l7_hard_deny_reason(&request_info).expect("JSON-RPC parse error");
+        let reason = forward_l7_hard_deny_reason(crate::l7::L7Protocol::JsonRpc, &request_info)
+            .expect("JSON-RPC parse error");
 
         assert_eq!(
             reason,
@@ -4554,10 +4562,14 @@ network_policies:
             }),
         };
 
-        let reason =
-            forward_l7_hard_deny_reason(&request_info).expect("JSON-RPC response hard deny");
+        let reason = forward_l7_hard_deny_reason(crate::l7::L7Protocol::JsonRpc, &request_info)
+            .expect("JSON-RPC response hard deny");
 
         assert_eq!(reason, crate::l7::relay::JSONRPC_RESPONSE_FRAME_DENY_REASON);
+        assert!(
+            forward_l7_hard_deny_reason(crate::l7::L7Protocol::Mcp, &request_info).is_none(),
+            "MCP response frames are evaluated by policy instead of hard-denied"
+        );
     }
 
     #[test]
@@ -5119,6 +5131,7 @@ network_policies:
                     enforcement: crate::l7::EnforcementMode::Enforce,
                     graphql_max_body_bytes: crate::l7::graphql::DEFAULT_MAX_BODY_BYTES,
                     json_rpc_max_body_bytes: crate::l7::jsonrpc::DEFAULT_MAX_BODY_BYTES,
+                    mcp_strict_tool_names: true,
                     allow_encoded_slash: false,
                     websocket_credential_rewrite: false,
                     request_body_credential_rewrite: false,
@@ -5133,6 +5146,7 @@ network_policies:
                     enforcement: crate::l7::EnforcementMode::Enforce,
                     graphql_max_body_bytes: crate::l7::graphql::DEFAULT_MAX_BODY_BYTES,
                     json_rpc_max_body_bytes: crate::l7::jsonrpc::DEFAULT_MAX_BODY_BYTES,
+                    mcp_strict_tool_names: true,
                     allow_encoded_slash: false,
                     websocket_credential_rewrite: false,
                     request_body_credential_rewrite: false,

--- a/docs/reference/policy-schema.mdx
+++ b/docs/reference/policy-schema.mdx
@@ -155,11 +155,11 @@ Each endpoint defines a reachable destination and optional inspection rules.
 | `host` | string | Yes | Hostname or IP address. Supports a `*` wildcard inside the first DNS label only: `*.example.com`, `**.example.com`, and intra-label patterns like `*-aiplatform.googleapis.com` are accepted; bare `*`/`**`, TLD wildcards (`*.com`), and wildcards outside the first label are rejected at load time. |
 | `port` | integer | Yes | TCP port number. |
 | `path` | string | No | Optional HTTP path glob used to select between L7 endpoints that share the same host and port. Empty means all paths. Use this when REST and GraphQL live under the same host, such as `/repos/**` and `/graphql`. |
-| `protocol` | string | No | Set to `rest` for HTTP method/path inspection, `websocket` for RFC 6455 upgrade and client text-message inspection, `graphql` for GraphQL-over-HTTP operation inspection, or `json-rpc` for sandbox-to-server JSON-RPC-over-HTTP method and params inspection. WebSocket endpoints can also use GraphQL operation rules for GraphQL-over-WebSocket traffic. Omit for TCP passthrough. |
+| `protocol` | string | No | Set to `rest` for HTTP method/path inspection, `websocket` for RFC 6455 upgrade and client text-message inspection, `graphql` for GraphQL-over-HTTP operation inspection, `mcp` for MCP Streamable HTTP request inspection, or `json-rpc` for generic JSON-RPC-over-HTTP compatibility. WebSocket endpoints can also use GraphQL operation rules for GraphQL-over-WebSocket traffic. Omit for TCP passthrough. |
 | `tls` | string | No | TLS handling mode. The proxy auto-detects TLS by peeking the first bytes of each connection and terminates it for inspected HTTPS traffic, so this field is optional in most cases. Set to `skip` to disable auto-detection for edge cases such as client-certificate mTLS or non-standard protocols. The values `terminate` and `passthrough` are deprecated and log a warning; they are still accepted for backward compatibility but have no effect on behavior. |
 | `enforcement` | string | No | `enforce` actively blocks disallowed requests. `audit` logs violations but allows traffic through. |
-| `access` | string | No | Access preset. One of `read-only`, `read-write`, or `full`. Mutually exclusive with `rules`. Not valid on `protocol: json-rpc`; JSON-RPC endpoints must use explicit `rules` with `method`. |
-| `rules` | list of rule objects | No | Fine-grained protocol-specific allow rules. Mutually exclusive with `access`. |
+| `access` | string | No | Access preset. One of `read-only`, `read-write`, or `full`. Mutually exclusive with `rules`. Not valid on `protocol: mcp` or `protocol: json-rpc`; MCP endpoints can use explicit rules or omit rules for the default allow-all MCP policy, and generic JSON-RPC endpoints must use explicit rules. |
+| `rules` | list of allow rule objects | No | Fine-grained protocol-specific allow rules. Mutually exclusive with `access`. |
 | `deny_rules` | list of deny rule objects | No | L7 deny rules that block specific requests even when allowed by `access` or `rules`. Deny rules take precedence over allow rules. |
 | `allowed_ips` | list of string | No | CIDR or IP allowlist for SSRF override. Exact user-declared hostname endpoints may resolve to RFC 1918 private addresses without this field, but wildcard, hostless, and policy-advisor-proposed endpoints still require `allowed_ips` for private resolved IPs. Entries overlapping loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), or unspecified (`0.0.0.0`) are rejected at load time. |
 | `allow_encoded_slash` | bool | No | When `true`, L7 request parsing preserves `%2F` inside path segments instead of rejecting it. Use this for registries and APIs such as npm scoped packages (`/@scope%2Fname`). Defaults to `false`. |
@@ -168,21 +168,25 @@ Each endpoint defines a reachable destination and optional inspection rules.
 | `persisted_queries` | string | No | GraphQL hash-only behavior for `protocol: graphql` and GraphQL-over-WebSocket operation policy. Default is `deny`; use `allow_registered` only with `graphql_persisted_queries`. |
 | `graphql_persisted_queries` | map | No | Trusted GraphQL persisted-query registry keyed by hash or saved-query ID. Values contain `operation_type`, optional `operation_name`, and optional root `fields`. |
 | `graphql_max_body_bytes` | integer | No | Maximum GraphQL-over-HTTP request body bytes buffered for inspection. Defaults to `65536`. |
+| `mcp` | object | No | MCP endpoint options for `protocol: mcp`. MCP endpoints must set a concrete `host` and `port` or `ports`; `protocol: mcp` alone is invalid and is not treated as a wildcard endpoint. |
+| `mcp.max_body_bytes` | integer | No | Maximum MCP JSON-RPC-over-HTTP request body bytes buffered for inspection. Defaults to `65536`. |
+| `mcp.strict_tool_names` | bool | No | Defaults to `true`. Requires `tools/call` `params.name` values to match `^[A-Za-z0-9_.-]{1,128}$` before policy evaluation. Set to `false` only for compatibility with MCP servers that intentionally use non-recommended tool names. Wildcard `tool` matchers require this to remain enabled. |
+| `mcp.allow_all_known_mcp_methods` | bool | No | Defaults to `true`. Enables the endpoint MCP method profile: omitted `rules` allow all MCP-family methods and all tools before `deny_rules`, and omitted rule `method` uses that profile. Set to `false` to require explicit MCP method rules; rules with `tool` or `params.name` must then set `method: tools/call`. |
 | `json_rpc` | object | No | JSON-RPC endpoint options. For `protocol: json-rpc`, `json_rpc.max_body_bytes` sets the maximum JSON-RPC-over-HTTP request body bytes buffered for inspection. Defaults to `65536`. |
 
 Credential rewrite recognizes the canonical `openshell:resolve:env:KEY` placeholder form and whole-token provider-shaped aliases such as `provider-OPENSHELL-RESOLVE-ENV-API_TOKEN` when the referenced environment key exists in the configured provider credentials.
 
 #### Access Levels
 
-The `access` field accepts one of the following values on REST, WebSocket, and GraphQL endpoints. JSON-RPC endpoints reject `access` because HTTP method/path presets cannot authorize JSON-RPC safely; use explicit `rules` with `method` instead.
+The `access` field accepts one of the following values on REST, WebSocket, and GraphQL endpoints. MCP and JSON-RPC endpoints reject `access` because HTTP method/path presets cannot authorize JSON-RPC safely; use explicit MCP or JSON-RPC rules instead, or omit MCP rules for the default allow-all MCP policy.
 
-| Value | REST expansion | WebSocket expansion | GraphQL expansion | JSON-RPC behavior |
+| Value | REST expansion | WebSocket expansion | GraphQL expansion | MCP / JSON-RPC expansion |
 |---|---|---|---|---|
 | `full` | All methods and paths. | WebSocket upgrade and all inspected client text-message paths. | All operation types. | Rejected. |
 | `read-only` | `GET`, `HEAD`, `OPTIONS`. | WebSocket upgrade handshake only. | `query` operations. | Rejected. |
 | `read-write` | `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT`, `PATCH`. | WebSocket upgrade handshake and client text messages. | `query` and `mutation` operations. | Rejected. |
 
-For JSON-RPC endpoints, configure explicit `rules` with `method` and optional `params`.
+For MCP endpoints, configure explicit `rules` with `method`, optional `tool`, and optional `params`. For generic JSON-RPC endpoints, use `method` and optional `params`.
 
 #### Allow Rule Objects
 
@@ -277,13 +281,47 @@ rules:
 
 Do not combine `method`, `path`, or `query` with `operation_type`, `operation_name`, or `fields` inside the same WebSocket rule. When a WebSocket endpoint has GraphQL operation policy, use GraphQL rules for client messages instead of a raw `WEBSOCKET_TEXT` allow rule.
 
-##### JSON-RPC Allow Rule (`protocol: json-rpc`)
+##### MCP Allow And Deny Rules (`protocol: mcp`)
 
-JSON-RPC allow rules match sandbox-to-server JSON-RPC-over-HTTP request objects by RPC method and optional params. They apply to single JSON-RPC requests and batch requests. For a batch, OpenShell evaluates each call independently. Client-to-server JSON-RPC response frames in POST bodies are denied. Server-to-client messages on HTTP response bodies or MCP SSE streams are relayed but are not currently parsed for policy enforcement.
+MCP rules match sandbox-to-server MCP Streamable HTTP request bodies by optional MCP method and optional tool selectors. OpenShell parses the underlying JSON-RPC 2.0 envelope, validates known MCP request and notification params, and preserves unknown extension methods as policy-addressable literal method strings. Until OpenShell exposes explicit MCP version profiles, `mcp.allow_all_known_mcp_methods` defaults to `true`; with that default, rules can omit `method` and tool selectors are normalized to `tools/call` internally. Set `mcp.allow_all_known_mcp_methods: false` to require explicit MCP method rules; in that mode, rules with `tool` or `params.name` must set `method: tools/call`. By default, `tools/call` `params.name` must match the MCP-recommended tool-name pattern `^[A-Za-z0-9_.-]{1,128}$`; configure `mcp.strict_tool_names: false` on the endpoint only to allow a server that intentionally uses names outside that pattern. Wildcard `tool` matchers require `mcp.strict_tool_names` to remain enabled. JSON-RPC responses and server-to-client MCP messages on response bodies or SSE streams are relayed but are not currently parsed for policy enforcement.
+
+Use `rules` for MCP allow rules and `deny_rules` for MCP deny rules. Deny rules take precedence over allow rules. If an MCP endpoint omits `rules` while `mcp.allow_all_known_mcp_methods` is unset or `true`, OpenShell allows all MCP-family methods and all tools, then applies any `deny_rules`. If `mcp.allow_all_known_mcp_methods` is `false`, the endpoint must define explicit rules. A broad allow or deny rule whose method matcher includes `tools/call` cannot be combined with tool-specific allow rules because it would bypass or erase the tool filter; add `tool` or `params.name` to scope `tools/call`, or remove the tool-specific rules. In a batch request, one denied call denies the full batch.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `method` | string | Yes | JSON-RPC method name such as `initialize`, `tools/list`, `tools/*`, or glob, `*`, which matches any JSON-RPC method. |
+| `method` | string | No | MCP method name, such as `initialize`, `tools/list`, `tools/call`, or an unknown extension method. Globs are accepted only for the `tools/` method family, such as `tools/*`. Required when `mcp.allow_all_known_mcp_methods` is `false`; otherwise omitted method uses the endpoint method profile. Do not use `method: "*"` for MCP; omit `method` to use the allow-all MCP method profile. |
+| `tool` | string or matcher | No | Convenience matcher for `tools/call` `params.name`. Supports a glob string or `{ any: [...] }`. When `mcp.allow_all_known_mcp_methods` is `false`, `method` must also be set to `tools/call`; validation fails otherwise. Omit to match every tool. |
+| `params` | map | No | MCP currently accepts only `params.name` as a lower-level tool-name matcher. When `mcp.allow_all_known_mcp_methods` is `false` and `params.name` is present, `method` must also be set to `tools/call`; validation fails otherwise. Tool argument matching is not supported yet; allowed tools accept all argument payloads by default. |
+
+Example MCP rules:
+
+```yaml showLineNumbers={false}
+endpoints:
+  - host: mcp.example.com
+    port: 443
+    path: /mcp
+    protocol: mcp
+    enforcement: enforce
+    mcp:
+      max_body_bytes: 131072
+    rules:
+      - allow:
+          tool: search_web
+      - allow:
+          tool:
+            any: [create_issue, list_issues]
+    deny_rules:
+      - tool: send_email
+      - tool: execute_code
+```
+
+##### JSON-RPC Allow Rule (`protocol: json-rpc`)
+
+JSON-RPC allow rules match sandbox-to-server JSON-RPC-over-HTTP request objects by RPC method and optional params. They apply to single JSON-RPC requests and batch requests. For a batch, OpenShell evaluates each call independently. JSON-RPC responses and server-to-client messages on response bodies or SSE streams are relayed but are not currently parsed for policy enforcement.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `method` | string | Yes | JSON-RPC method name or OpenShell glob, such as `initialize`, `tools/list`, or `tools/*`. `*` is OpenShell policy matching syntax, not JSON-RPC method syntax. |
 | `params` | map | No | Params matchers keyed by flattened object-param path. Use dot-separated keys for nested object params, such as `arguments.scope`. Matcher value can be a glob string or an object with `any`. Strings, numbers, and booleans are converted to strings; arrays, `null`, and non-object top-level params do not produce matcher keys. Literal `.` characters in JSON-RPC params object keys are allowed; when a literal key and a flattened nested path produce the same matcher key, the literal key takes precedence. |
 
 Example JSON-RPC allow rules:
@@ -310,7 +348,8 @@ endpoints:
           method: tools/call
           params:
             name: submit_report
-            arguments.scope: workspace/main
+            arguments:
+              scope: workspace/main
 ```
 
 #### Deny Rule Objects

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -148,7 +148,7 @@ The following steps outline the hot-reload policy update workflow.
 
    To inspect a stored sandbox-authored revision instead of the current effective policy, pass `--rev <version>`.
 
-5. Edit the YAML: add or adjust `network_policies` entries, binaries, `access`, `rules`, or protocol-specific matchers such as GraphQL operation fields and JSON-RPC `method` / `params` rules.
+5. Edit the YAML: add or adjust `network_policies` entries, binaries, `access`, `rules`, or protocol-specific matchers such as GraphQL operation fields, MCP `method` / `tool` rules, and generic JSON-RPC `method` / `params` rules.
 
 6. Push the updated policy when you need a full replacement. Exit codes: 0 = loaded, 1 = validation failed, 124 = timeout.
 
@@ -173,7 +173,7 @@ Use `openshell policy update` when you want to merge network policy changes into
 - remove one endpoint or one named rule without rewriting the rest of the file.
 - preview a merged result locally with `--dry-run` before you send it to the gateway.
 
-Use `openshell policy set` instead when you want to replace the full policy, update static sections, or make broader edits that are easier to express in YAML. Use full YAML for GraphQL and JSON-RPC rule shapes.
+Use `openshell policy set` instead when you want to replace the full policy, update static sections, or make broader edits that are easier to express in YAML. Use full YAML for GraphQL, MCP, and JSON-RPC rule shapes.
 
 ### Update Commands
 
@@ -210,7 +210,7 @@ This is the practical difference:
 Current constraints:
 
 - `--add-allow` and `--add-deny` work on `protocol: rest` and `protocol: websocket` endpoints.
-- GraphQL and JSON-RPC fine-grained rules require full policy YAML applied with `openshell policy set`.
+- GraphQL, MCP, and JSON-RPC fine-grained rules require full policy YAML applied with `openshell policy set`.
 - `--add-deny` requires the endpoint to already have an allow base, either an `access` preset or explicit allow `rules`.
 - `protocol: sql` is not a practical incremental workflow today. OpenShell does not do full SQL parsing, and SQL enforcement is not meaningfully supported yet.
 
@@ -549,7 +549,7 @@ For an end-to-end walkthrough that combines this policy with a GitHub credential
       - { path: /usr/bin/gh }
 ```
 
-Endpoints with `protocol: rest` enable HTTP request inspection and can opt in to supported text request body credential rewrite. Endpoints with `protocol: websocket` validate WebSocket upgrades and inspect client text messages on the upgraded request path. WebSocket endpoints can also classify GraphQL-over-WebSocket operation messages with the same operation rules used by GraphQL-over-HTTP. Endpoints with `protocol: graphql` parse GraphQL-over-HTTP payloads before evaluating rules. Endpoints with `protocol: json-rpc` parse JSON-RPC-over-HTTP request bodies and evaluate `method` and optional params rules. The endpoint-level `path` field lets these protocols share `api.github.com:443` without treating GraphQL payloads as plain REST `POST /graphql` requests.
+Endpoints with `protocol: rest` enable HTTP request inspection and can opt in to supported text request body credential rewrite. Endpoints with `protocol: websocket` validate WebSocket upgrades and inspect client text messages on the upgraded request path. WebSocket endpoints can also classify GraphQL-over-WebSocket operation messages with the same operation rules used by GraphQL-over-HTTP. Endpoints with `protocol: graphql` parse GraphQL-over-HTTP payloads before evaluating rules. Endpoints with `protocol: mcp` parse MCP Streamable HTTP request bodies and evaluate `method`, optional `tool`, and optional params rules. Endpoints with `protocol: json-rpc` keep generic JSON-RPC-over-HTTP compatibility by evaluating `method` and optional params rules. The endpoint-level `path` field lets these protocols share `api.github.com:443` without treating GraphQL payloads as plain REST `POST /graphql` requests.
 </Tab>
 
 </Tabs>
@@ -580,13 +580,15 @@ REST rules can also constrain query parameter values:
 
 `query` matchers are case-sensitive and run on decoded values. If a request has duplicate keys (for example, `tag=a&tag=b`), every value for that key must match the configured glob(s).
 
-### JSON-RPC matching
+### MCP and JSON-RPC matching
 
-JSON-RPC endpoints use `protocol: json-rpc`. The proxy parses sandbox-to-server JSON-RPC-over-HTTP request bodies, evaluates the JSON-RPC `method` field against rule `method`, and can match object params through dot-separated `params` keys.
+MCP endpoints use `protocol: mcp`. The proxy parses sandbox-to-server MCP Streamable HTTP request bodies, validates known MCP request and notification params, can evaluate the MCP method against rule `method`, and can match tool calls with the `tool` alias. Unknown extension methods stay addressable as literal method strings. Until OpenShell exposes MCP version profiles, `mcp.allow_all_known_mcp_methods` defaults to `true`; with that default, rules can omit `method` and tool selectors are normalized to `tools/call` internally. Set `mcp.allow_all_known_mcp_methods: false` to require explicit MCP method rules; in that mode, rules with `tool` or `params.name` must set `method: tools/call`. By default, MCP `tools/call` tool names must match `^[A-Za-z0-9_.-]{1,128}$`; set `mcp.strict_tool_names: false` on that endpoint only when a server intentionally uses names outside the MCP-recommended pattern. Wildcard `tool` matchers require `mcp.strict_tool_names` to remain enabled. Generic JSON-RPC endpoints use `protocol: json-rpc`, evaluate `method`, and can match object params.
 
-JSON-RPC policy enforcement is directional. It applies to HTTP request bodies sent by the sandboxed process to the configured endpoint. JSON-RPC responses and server-to-client messages carried on response bodies or MCP SSE streams are relayed but are not currently parsed for policy enforcement.
+MCP endpoints must declare a concrete destination with `host` and `port` or `ports`. A policy entry that only sets `protocol: mcp` is invalid and is not treated as a wildcard MCP authorization. Use `path: /mcp` when the server's MCP endpoint is path-scoped; omitting `path` matches every HTTP path on that host and port.
 
-JSON-RPC endpoint policies currently require full policy YAML applied with `openshell policy set`; the incremental `openshell policy update --add-endpoint` parser does not accept `json-rpc` as a protocol.
+MCP policy enforcement is directional. It applies to HTTP request bodies sent by the sandboxed process to the configured endpoint. JSON-RPC responses and server-to-client MCP messages carried on response bodies or SSE streams are relayed but are not currently parsed for policy enforcement.
+
+MCP and JSON-RPC endpoint policies currently require full policy YAML applied with `openshell policy set`; the incremental `openshell policy update --add-endpoint` parser does not accept `mcp` or `json-rpc` as protocols.
 
 ```yaml showLineNumbers={false}
   mcp_server:
@@ -595,35 +597,29 @@ JSON-RPC endpoint policies currently require full policy YAML applied with `open
       - host: mcp.example.com
         port: 443
         path: /mcp
-        protocol: json-rpc
+        protocol: mcp
         enforcement: enforce
-        json_rpc:
+        mcp:
           max_body_bytes: 131072
         rules:
           - allow:
-              method: initialize
+              tool: read_status
           - allow:
-              method: tools/list
-          - allow:
-              method: tools/call
-              params:
-                name: read_status
-          - allow:
-              method: tools/call
-              params:
-                name: submit_report
-                arguments.scope: workspace/main
+              tool:
+                any: [submit_report, list_reports]
         deny_rules:
-          - method: tools/call
-            params:
-              name: delete_resource
+          - tool: delete_resource
     binaries:
       - { path: /usr/bin/python3 }
 ```
 
-`json_rpc.max_body_bytes` controls how many JSON-RPC-over-HTTP request body bytes OpenShell buffers for inspection. It defaults to `65536`.
+`mcp.max_body_bytes` controls how many MCP-over-HTTP request body bytes OpenShell buffers for inspection. It defaults to `65536`. `mcp.strict_tool_names` defaults to `true` for each MCP endpoint. `mcp.allow_all_known_mcp_methods` defaults to `true`; when it is `false`, the endpoint must define explicit MCP method rules. If an MCP endpoint omits `rules` while `mcp.allow_all_known_mcp_methods` is unset or `true`, OpenShell allows all MCP-family methods and all tools, then applies any `deny_rules`. A broad allow or deny rule whose method matcher includes `tools/call` cannot be combined with tool-specific allow rules because it would bypass or erase the tool filter; add `tool` or `params.name` to scope `tools/call`, or remove the tool-specific rules.
 
-`params` matchers are case-sensitive and use the same string glob or `{ any: [...] }` matcher syntax as REST query parameters. They match scalar leaf values from object params: strings, numbers, and booleans are converted to strings, and nested JSON object params are flattened with dot-separated keys before matching. Arrays, `null`, and non-object top-level params do not produce matcher keys. Literal `.` characters in JSON-RPC params object keys are allowed; when a literal key and a flattened nested path produce the same matcher key, the literal key takes precedence. This is useful for controls such as matching MCP `tools/call` by `params.name`, but it is not a complete MCP payload policy for rich nested content. For batch requests, OpenShell evaluates each JSON-RPC call independently and denies the whole batch if any call is denied.
+Use `protocol: json-rpc` and `method` when you need generic JSON-RPC 2.0 matching for a non-MCP server. `json_rpc.max_body_bytes` controls the generic JSON-RPC inspection buffer.
+
+Generic JSON-RPC `params` matchers are case-sensitive and use the same string glob or `{ any: [...] }` matcher syntax as REST query parameters. They match scalar leaf values from object params: strings, numbers, and booleans are converted to strings, and nested JSON object params are flattened with dot-separated keys before matching. Arrays, `null`, and non-object top-level params do not produce matcher keys. Literal `.` characters in JSON-RPC params object keys are allowed; when a literal key and a flattened nested path produce the same matcher key, the literal key takes precedence.
+
+For MCP, `tool` accepts a string glob or `{ any: [...] }` matcher for `tools/call` `params.name`. Rules that use `tool` or lower-level `params.name` can omit `method` while `mcp.allow_all_known_mcp_methods` is enabled; if that option is `false`, those rules must set `method: tools/call`. MCP method globs are accepted only for the `tools/` method family, such as `tools/*`; omit `method` instead of writing `method: "*"` when the endpoint method profile should allow all MCP methods. Omit `tool` to allow all tools for a `tools/call` method rule. OpenShell does not support MCP tool argument matching yet; allowed tools accept all argument payloads by default. Other MCP `params` keys are rejected. For batch requests, OpenShell evaluates each JSON-RPC call independently and denies the whole batch if any call is denied.
 
 ### GraphQL matching
 

--- a/e2e/mcp-conformance.sh
+++ b/e2e/mcp-conformance.sh
@@ -8,10 +8,10 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=e2e/support/gateway-common.sh disable=SC1091
 source "${ROOT}/e2e/support/gateway-common.sh"
 CONFORMANCE_DIR="${OPENSHELL_MCP_CONFORMANCE_DIR:-${ROOT}/.cache/mcp-conformance}"
-# Pinned after v0.1.16 because that tag has an upstream scenario-name mismatch:
-# the runner exposes `tools_call`, while the bundled client only accepts
-# `tools-call`. This commit registers both names in the client and keeps the
-# runner's canonical `tools_call` scenario name.
+# Pinned after v0.1.16 for the upstream tools_call fixture fix. The current
+# checkout still needs temporary client-fixture patches for
+# modelcontextprotocol/conformance#345; remove patch_conformance_clients when
+# OPENSHELL_MCP_CONFORMANCE_REF points at a release containing those fixes.
 CONFORMANCE_REF="${OPENSHELL_MCP_CONFORMANCE_REF:-b9041ea41b0188581803459dbae71bc7e02fd995}"
 CLIENT_IMAGE="${OPENSHELL_MCP_CONFORMANCE_CLIENT_IMAGE:-openshell-mcp-conformance-client:local}"
 SCENARIOS="${OPENSHELL_MCP_CONFORMANCE_SCENARIOS:-}"
@@ -22,6 +22,7 @@ DOCKER_PULL="${OPENSHELL_MCP_CONFORMANCE_DOCKER_PULL:-0}"
 CLIENT_IMAGE_REF_LABEL="org.openshell.mcp-conformance.ref"
 CLIENT_IMAGE_DOCKERFILE_LABEL="org.openshell.mcp-conformance.dockerfile"
 CLIENT_IMAGE_DOCKERIGNORE_LABEL="org.openshell.mcp-conformance.dockerignore"
+CLIENT_IMAGE_FIXTURE_HASH_LABEL="org.openshell.mcp-conformance.fixture-hash"
 RUN_SCENARIOS_COMMAND="__openshell_mcp_run_scenarios"
 CLIENT_SANDBOX_MANAGED=0
 HOST_BRIDGE_PID=""
@@ -107,6 +108,67 @@ openshell_bin() {
   local target_dir
   target_dir="$(e2e_cargo_target_dir "${ROOT}")"
   printf '%s\n' "${target_dir}/debug/openshell"
+}
+
+patch_conformance_clients() {
+  node - "${CONFORMANCE_DIR}" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = process.argv[2];
+
+function rewrite(file, rewriter) {
+  const target = path.join(root, file);
+  const source = fs.readFileSync(target, 'utf8');
+  const next = rewriter(source, file);
+
+  if (next !== source) {
+    fs.writeFileSync(target, next);
+    console.error(`Patched upstream MCP conformance fixture: ${file}`);
+  }
+}
+
+function patchApplyDefaults(source, file) {
+  if (/elicitation:\s*{\s*form:\s*{\s*applyDefaults:\s*true\s*}\s*}/m.test(source)) {
+    return source;
+  }
+
+  const broken = /elicitation:\s*{\s*applyDefaults:\s*true\s*}/m;
+  if (!broken.test(source)) {
+    throw new Error(`${file}: could not find the known elicitation defaults fixture`);
+  }
+
+  return source.replace(
+    broken,
+    `elicitation: {
+            form: {
+              applyDefaults: true
+            }
+          }`
+  );
+}
+
+rewrite('examples/clients/typescript/everything-client.ts', (source, file) => {
+  let next = patchApplyDefaults(source, file);
+  if (next.includes('elicitation-sep1034-client-defaults')) {
+    return next;
+  }
+
+  const oldRegistration = "registerScenario('elicitation-defaults', runElicitationDefaultsClient);";
+  const newRegistration = `registerScenarios(
+  ['elicitation-defaults', 'elicitation-sep1034-client-defaults'],
+  runElicitationDefaultsClient
+);`;
+
+  if (!next.includes(oldRegistration)) {
+    throw new Error(`${file}: could not find the known elicitation scenario registration`);
+  }
+
+  return next.replace(oldRegistration, newRegistration);
+});
+
+rewrite('examples/clients/typescript/elicitation-defaults-test.ts', patchApplyDefaults);
+NODE
 }
 
 start_host_bridge() {
@@ -210,21 +272,29 @@ stop_host_bridge() {
 }
 
 build_client_image() {
-  local conformance_head dockerfile_hash dockerignore_hash
-  local image_ref image_dockerfile image_dockerignore
+  local conformance_head dockerfile_hash dockerignore_hash fixture_hash
+  local image_ref image_dockerfile image_dockerignore image_fixture_hash
   local -a pull_args=()
 
   conformance_head="$(git -C "${CONFORMANCE_DIR}" rev-parse HEAD)"
   dockerfile_hash="$(git -C "${ROOT}" hash-object "${ROOT}/e2e/mcp-conformance/Dockerfile.client")"
   dockerignore_hash="$(git -C "${ROOT}" hash-object "${ROOT}/e2e/mcp-conformance/Dockerfile.client.dockerignore")"
+  fixture_hash="$(
+    git -C "${CONFORMANCE_DIR}" diff -- \
+      examples/clients/typescript/everything-client.ts \
+      examples/clients/typescript/elicitation-defaults-test.ts |
+      git hash-object --stdin
+  )"
 
   image_ref="$(docker_image_label "${CLIENT_IMAGE}" "${CLIENT_IMAGE_REF_LABEL}")"
   image_dockerfile="$(docker_image_label "${CLIENT_IMAGE}" "${CLIENT_IMAGE_DOCKERFILE_LABEL}")"
   image_dockerignore="$(docker_image_label "${CLIENT_IMAGE}" "${CLIENT_IMAGE_DOCKERIGNORE_LABEL}")"
+  image_fixture_hash="$(docker_image_label "${CLIENT_IMAGE}" "${CLIENT_IMAGE_FIXTURE_HASH_LABEL}")"
   if [ "${FORCE_REBUILD}" != "1" ] \
     && [ "${image_ref}" = "${conformance_head}" ] \
     && [ "${image_dockerfile}" = "${dockerfile_hash}" ] \
-    && [ "${image_dockerignore}" = "${dockerignore_hash}" ]; then
+    && [ "${image_dockerignore}" = "${dockerignore_hash}" ] \
+    && [ "${image_fixture_hash}" = "${fixture_hash}" ]; then
     echo "Using cached MCP conformance client image ${CLIENT_IMAGE} (${conformance_head})." >&2
     return
   fi
@@ -237,6 +307,7 @@ build_client_image() {
     --label "${CLIENT_IMAGE_REF_LABEL}=${conformance_head}" \
     --label "${CLIENT_IMAGE_DOCKERFILE_LABEL}=${dockerfile_hash}" \
     --label "${CLIENT_IMAGE_DOCKERIGNORE_LABEL}=${dockerignore_hash}" \
+    --label "${CLIENT_IMAGE_FIXTURE_HASH_LABEL}=${fixture_hash}" \
     -f "${ROOT}/e2e/mcp-conformance/Dockerfile.client" \
     -t "${CLIENT_IMAGE}" \
     "${CONFORMANCE_DIR}"
@@ -429,16 +500,18 @@ main() {
     return
   fi
 
-  # git fetches and pins the upstream conformance repo (and hashes it for image
-  # caching); docker builds and runs the runner/client containers; python3 runs
-  # the host bridge and renders policies. The conformance runner itself (node,
-  # npm, tsx) now runs inside the container image, not on the host.
+  # git fetches and pins the upstream conformance repo; node patches temporary
+  # fixture drift before the image build; docker builds and runs the
+  # runner/client containers; python3 runs the host bridge and renders policies.
+  # npm and tsx run inside the container image, not on the host.
   require_command git
+  require_command node
   require_command docker
   require_command python3
 
   echo "MCP conformance spec version: ${SPEC_VERSION}" >&2
   checkout_conformance
+  patch_conformance_clients
   build_client_image
   run_scenarios_under_gateway "$@"
 }

--- a/e2e/mcp-conformance/README.md
+++ b/e2e/mcp-conformance/README.md
@@ -35,19 +35,30 @@ bridge at `host.openshell.internal` (the alias `e2e/with-docker-gateway.sh`
 attaches to the CI job container on the e2e network), at `host.docker.internal`
 on local Docker Desktop, or via `--add-host ...:host-gateway` on local Linux.
 
-The generated policy allows valid JSON-RPC requests to the conformance server
-with `method: "*"`. That keeps OpenShell deny-by-default at the network
-boundary while allowing the upstream scenarios to exercise MCP behavior. The
-policy body lives in `policy-template.yaml`; the wrapper renders its host, port,
-and path placeholders from the upstream server URL.
+The generated policy uses `protocol: mcp` and allows valid MCP requests to the
+conformance server by omitting `method`, which uses the endpoint MCP method
+profile. That keeps OpenShell deny-by-default at the network boundary while
+allowing the upstream scenarios to exercise MCP behavior. The policy body lives
+in `policy-template.yaml`; the wrapper renders its host, port, and path
+placeholders from the upstream server URL.
 
-The upstream `everything-client` has a few handler names that do not line up
-with released-spec scenario names. The wrapper maps those names when forwarding
-`MCP_CONFORMANCE_SCENARIO` into the sandbox, but it does not patch the upstream
-checkout.
+For local runs, build or stage a static supervisor binary and pass it with
+`OPENSHELL_DOCKER_SUPERVISOR_BIN` if the default local supervisor build is
+linked against a newer glibc than the conformance client image provides.
+
+The pinned upstream checkout includes reference-client fixture drift that is
+tracked in `modelcontextprotocol/conformance#345`. The wrapper patches the
+checkout before building the client image so the bundled TypeScript client
+advertises `elicitation.form.applyDefaults` and accepts the canonical
+`elicitation-sep1034-client-defaults` scenario. It also routes `sse-retry` to
+the upstream standalone `sse-retry-test.ts` client so the reconnect timing path
+is exercised instead of aliasing it to another scenario.
+
+Remove those local workarounds when `OPENSHELL_MCP_CONFORMANCE_REF` points at
+an upstream release that includes the `#345` fixes.
 
 When enabling broader upstream suites, add scenarios that OpenShell does not yet
-support through the JSON-RPC proxy to `expected-failures.yml`. The upstream
+support through the MCP proxy to `expected-failures.yml`. The upstream
 runner treats listed failures as allowed and treats stale entries as failures.
 The default run uses a static scenario list in `e2e/mcp-conformance.sh`. To
 refresh it after changing the pinned upstream ref or default spec, list the

--- a/e2e/mcp-conformance/client-through-openshell.sh
+++ b/e2e/mcp-conformance/client-through-openshell.sh
@@ -60,24 +60,13 @@ trap 'rm -f "${POLICY_FILE}"' EXIT
 CLIENT_SERVER_URL="$(python3 "${ROOT}/e2e/mcp-conformance/render-policy.py" "${SERVER_URL}" "${POLICY_FILE}" "${POLICY_TEMPLATE}")"
 
 ENV_ARGS=()
-CLIENT_SCENARIO="${MCP_CONFORMANCE_SCENARIO:-}"
-case "${CLIENT_SCENARIO}" in
-  elicitation-sep1034-client-defaults)
-    CLIENT_SCENARIO="elicitation-defaults"
-    ;;
-  sse-retry)
-    CLIENT_SCENARIO="tools_call"
-    ;;
-esac
 
 # These environment variables are set by the upstream conformance test runner
 # before it invokes the configured client command. Forward them into the
 # sandbox because the sandboxed TypeScript client depends on them to select the
 # scenario and read scenario-specific context.
 for NAME in MCP_CONFORMANCE_SCENARIO MCP_CONFORMANCE_CONTEXT MCP_CONFORMANCE_PROTOCOL_VERSION; do
-  if [ "${NAME}" = "MCP_CONFORMANCE_SCENARIO" ] && [ -n "${CLIENT_SCENARIO}" ]; then
-    ENV_ARGS+=(--env "MCP_CONFORMANCE_SCENARIO=${CLIENT_SCENARIO}")
-  elif [ -n "${!NAME+x}" ]; then
+  if [ -n "${!NAME+x}" ]; then
     ENV_ARGS+=(--env "${NAME}=${!NAME}")
   fi
 done
@@ -91,7 +80,12 @@ if [ "${POLICY_WAIT}" = "1" ]; then
 fi
 "${POLICY_SET_COMMAND[@]}"
 
+# Exec request validation rejects newline/control characters in command
+# arguments, so keep the sandbox-side script as a single argument without
+# embedded newlines.
 # shellcheck disable=SC2016
+SANDBOX_CLIENT_SCRIPT='cd /opt/mcp-conformance; case "${MCP_CONFORMANCE_SCENARIO:-}" in tools_call|tools-call) client=examples/clients/typescript/test2.ts ;; sse-retry) client=examples/clients/typescript/sse-retry-test.ts ;; *) client=examples/clients/typescript/everything-client.ts ;; esac; exec ./node_modules/.bin/tsx "$client" "$1"'
+
 SANDBOX_COMMAND=(
   "${OPENSHELL_BIN}" sandbox exec
   --name "${CLIENT_SANDBOX}"
@@ -99,7 +93,7 @@ SANDBOX_COMMAND=(
   --timeout "${CLIENT_TIMEOUT_SECONDS}"
   "${ENV_ARGS[@]}"
   --
-  sh -c 'cd /opt/mcp-conformance && exec ./node_modules/.bin/tsx examples/clients/typescript/everything-client.ts "$1"'
+  sh -c "${SANDBOX_CLIENT_SCRIPT}" \
   sh "${CLIENT_SERVER_URL}"
 )
 

--- a/e2e/mcp-conformance/expected-failures.yml
+++ b/e2e/mcp-conformance/expected-failures.yml
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Add client scenarios here when enabling broader MCP conformance suites that
-# currently fail in the pinned upstream example client or through OpenShell.
-client:
-  - elicitation-sep1034-client-defaults
-  - sse-retry
+# Add scenarios here only for known OpenShell MCP conformance gaps.
+# Upstream reference-client fixture drift is handled by the local wrapper and
+# checkout patching in e2e/mcp-conformance.sh so it does not hide OpenShell
+# regressions behind expected failures.
+client: []
 server: []

--- a/e2e/mcp-conformance/policy-template.yaml
+++ b/e2e/mcp-conformance/policy-template.yaml
@@ -36,18 +36,17 @@ network_policies:
       - ${host_spec}
 ${port_spec}
         path: ${path}
-        protocol: json-rpc
+        protocol: mcp
         enforcement: enforce
         allowed_ips:
           - "10.0.0.0/8"
           - "172.16.0.0/12"
           - "192.168.0.0/16"
           - "fc00::/7"
-        json_rpc:
+        mcp:
           max_body_bytes: 131072
         rules:
-          - allow:
-              method: "*"
+          - allow: {}
     binaries:
       - path: /bin/sh
       - path: /usr/bin/env

--- a/e2e/rust/tests/forward_proxy_jsonrpc_l7.rs
+++ b/e2e/rust/tests/forward_proxy_jsonrpc_l7.rs
@@ -16,9 +16,10 @@ use openshell_e2e::harness::container::ContainerHttpServer;
 use openshell_e2e::harness::sandbox::SandboxGuard;
 use tempfile::NamedTempFile;
 
-const TEST_SERVER_ALIAS: &str = "jsonrpc-l7.openshell.test";
+const RULES_TEST_SERVER_ALIAS: &str = "jsonrpc-l7-rules.openshell.test";
+const AUDIT_TEST_SERVER_ALIAS: &str = "jsonrpc-l7-audit.openshell.test";
 
-async fn start_test_server() -> Result<ContainerHttpServer, String> {
+async fn start_test_server(alias: &str) -> Result<ContainerHttpServer, String> {
     let script = r#"from http.server import BaseHTTPRequestHandler, HTTPServer
 
 class Handler(BaseHTTPRequestHandler):
@@ -56,7 +57,7 @@ class Handler(BaseHTTPRequestHandler):
 HTTPServer(("0.0.0.0", 8000), Handler).serve_forever()
 "#;
 
-    ContainerHttpServer::start_python(TEST_SERVER_ALIAS, script).await
+    ContainerHttpServer::start_python(alias, script).await
 }
 
 fn write_jsonrpc_policy(host: &str, port: u16) -> Result<NamedTempFile, String> {
@@ -196,7 +197,9 @@ network_policies:
 #[tokio::test]
 #[allow(clippy::too_many_lines)]
 async fn jsonrpc_l7_enforces_method_and_params_rules_on_forward_and_connect_paths() {
-    let server = start_test_server().await.expect("start test server");
+    let server = start_test_server(RULES_TEST_SERVER_ALIAS)
+        .await
+        .expect("start test server");
     let policy = write_jsonrpc_policy(&server.host, server.port).expect("write custom policy");
     let policy_path = policy
         .path()
@@ -468,7 +471,9 @@ print(json.dumps(results, sort_keys=True))
 
 #[tokio::test]
 async fn jsonrpc_forward_proxy_hard_denies_response_frames_in_default_audit_mode() {
-    let server = start_test_server().await.expect("start test server");
+    let server = start_test_server(AUDIT_TEST_SERVER_ALIAS)
+        .await
+        .expect("start test server");
     let policy =
         write_jsonrpc_default_audit_policy(&server.host, server.port).expect("write custom policy");
     let policy_path = policy

--- a/e2e/with-docker-gateway.sh
+++ b/e2e/with-docker-gateway.sh
@@ -21,6 +21,10 @@
 # The default community sandbox image uses :latest. This wrapper refreshes it
 # before starting the gateway, while the Docker driver defaults to IfNotPresent
 # so local Dockerfile-built images remain usable.
+#
+# Set OPENSHELL_DOCKER_SUPERVISOR_BIN to force a specific Linux
+# openshell-sandbox binary. This is useful when a staged static supervisor
+# binary should be used instead of the host glibc-linked local target build.
 
 set -euo pipefail
 
@@ -428,32 +432,46 @@ fi
 
 e2e_build_gateway_binaries "${ROOT}" TARGET_DIR GATEWAY_BIN CLI_BIN
 
-SUPERVISOR_IMAGE="$(resolve_docker_supervisor_image)"
-if [ -n "${SUPERVISOR_IMAGE}" ]; then
-  ensure_docker_supervisor_image "${SUPERVISOR_IMAGE}"
-  echo "Using Docker supervisor image: ${SUPERVISOR_IMAGE}"
-  DOCKER_SUPERVISOR_ARGS=(--docker-supervisor-image "${SUPERVISOR_IMAGE}")
-else
-  echo "Building openshell-sandbox for ${SUPERVISOR_TARGET}..."
-  mkdir -p "${SUPERVISOR_OUT_DIR}"
-  if [ "${HOST_OS}" = "Linux" ] && [ "${HOST_ARCH}" = "${DAEMON_ARCH}" ]; then
-    rustup target add "${SUPERVISOR_TARGET}" >/dev/null 2>&1 || true
-    cargo build ${CARGO_BUILD_JOBS_ARG[@]+"${CARGO_BUILD_JOBS_ARG[@]}"} \
-      --release -p openshell-sandbox --target "${SUPERVISOR_TARGET}"
-    cp "${TARGET_DIR}/${SUPERVISOR_TARGET}/release/openshell-sandbox" "${SUPERVISOR_BIN}"
-  else
-    CONTAINER_ENGINE=docker \
-    DOCKER_PLATFORM="linux/${DAEMON_ARCH}" \
-    DOCKER_OUTPUT="type=local,dest=${SUPERVISOR_OUT_DIR}" \
-      bash "${ROOT}/tasks/scripts/docker-build-image.sh" supervisor-output
-  fi
-
+if [ -n "${OPENSHELL_DOCKER_SUPERVISOR_BIN:-}" ]; then
+  case "${OPENSHELL_DOCKER_SUPERVISOR_BIN}" in
+    /*) SUPERVISOR_BIN="${OPENSHELL_DOCKER_SUPERVISOR_BIN}" ;;
+    *) SUPERVISOR_BIN="${ROOT}/${OPENSHELL_DOCKER_SUPERVISOR_BIN}" ;;
+  esac
   if [ ! -f "${SUPERVISOR_BIN}" ]; then
-    echo "ERROR: expected supervisor binary at ${SUPERVISOR_BIN}" >&2
-    exit 1
+    echo "ERROR: Docker supervisor binary '${SUPERVISOR_BIN}' does not exist." >&2
+    exit 2
   fi
   chmod +x "${SUPERVISOR_BIN}"
+  echo "Using Docker supervisor binary: ${SUPERVISOR_BIN}"
   DOCKER_SUPERVISOR_ARGS=(--docker-supervisor-bin "${SUPERVISOR_BIN}")
+else
+  SUPERVISOR_IMAGE="$(resolve_docker_supervisor_image)"
+  if [ -n "${SUPERVISOR_IMAGE}" ]; then
+    ensure_docker_supervisor_image "${SUPERVISOR_IMAGE}"
+    echo "Using Docker supervisor image: ${SUPERVISOR_IMAGE}"
+    DOCKER_SUPERVISOR_ARGS=(--docker-supervisor-image "${SUPERVISOR_IMAGE}")
+  else
+    echo "Building openshell-sandbox for ${SUPERVISOR_TARGET}..."
+    mkdir -p "${SUPERVISOR_OUT_DIR}"
+    if [ "${HOST_OS}" = "Linux" ] && [ "${HOST_ARCH}" = "${DAEMON_ARCH}" ]; then
+      rustup target add "${SUPERVISOR_TARGET}" >/dev/null 2>&1 || true
+      cargo build ${CARGO_BUILD_JOBS_ARG[@]+"${CARGO_BUILD_JOBS_ARG[@]}"} \
+        --release -p openshell-sandbox --target "${SUPERVISOR_TARGET}"
+      cp "${TARGET_DIR}/${SUPERVISOR_TARGET}/release/openshell-sandbox" "${SUPERVISOR_BIN}"
+    else
+      CONTAINER_ENGINE=docker \
+      DOCKER_PLATFORM="linux/${DAEMON_ARCH}" \
+      DOCKER_OUTPUT="type=local,dest=${SUPERVISOR_OUT_DIR}" \
+        bash "${ROOT}/tasks/scripts/docker-build-image.sh" supervisor-output
+    fi
+
+    if [ ! -f "${SUPERVISOR_BIN}" ]; then
+      echo "ERROR: expected supervisor binary at ${SUPERVISOR_BIN}" >&2
+      exit 1
+    fi
+    chmod +x "${SUPERVISOR_BIN}"
+    DOCKER_SUPERVISOR_ARGS=(--docker-supervisor-bin "${SUPERVISOR_BIN}")
+  fi
 fi
 
 DEFAULT_SANDBOX_IMAGE="ghcr.io/nvidia/openshell-community/sandboxes/base:latest"

--- a/proto/sandbox.proto
+++ b/proto/sandbox.proto
@@ -131,6 +131,40 @@ message NetworkEndpoint {
   // Maximum JSON-RPC-over-HTTP request body bytes to buffer for inspection.
   // Defaults to 65536 when unset.
   uint32 json_rpc_max_body_bytes = 19;
+  // MCP-only policy and inspection options. Only used when protocol is "mcp".
+  McpOptions mcp = 20;
+}
+
+// MCP options are grouped so MCP-specific policy can grow without adding more
+// top-level NetworkEndpoint fields. Current enforcement targets the active
+// 2025-11-25 Streamable HTTP/tools behavior, while preserving space for
+// version-profile policy if OpenShell adopts 2026-07-28 draft behavior later.
+//
+// Planned policy extensions should use OpenShell-owned static definitions for
+// MCP method/version profiles rather than treating dependency enums as the
+// policy contract. Candidate profile checks include request metadata/header
+// validation, response/SSE introspection, trusted annotation handling,
+// resultType/cache metadata validation, x-mcp-header tool-definition checks,
+// and subscriptions/listen handling.
+//
+// Sources:
+// - https://modelcontextprotocol.io/specification/2025-11-25/server/tools
+// - https://modelcontextprotocol.io/specification/draft/changelog
+// - https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http
+// - https://modelcontextprotocol.io/specification/draft/server/tools
+message McpOptions {
+  // Hardening boundary for tools/call params.name. When unset or true, the
+  // supervisor enforces the MCP recommended tool-name syntax
+  // ^[A-Za-z0-9_.-]{1,128}$ before policy evaluation. Set false only for
+  // compatibility with servers that intentionally use non-recommended names.
+  //
+  // Source:
+  // - https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-names
+  optional bool strict_tool_names = 1;
+  // Method-layer default for MCP endpoints. When unset or true, OpenShell
+  // allows parsed MCP-family methods at the method layer unless a tool-name
+  // policy narrows tools/call. Set false to require explicit method rules.
+  optional bool allow_all_known_mcp_methods = 2;
 }
 
 // Trusted GraphQL operation classification.


### PR DESCRIPTION
## Summary

Builds on https://github.com/NVIDIA/OpenShell/pull/1865 by keeping its shared JSON-RPC-family L7 enforcement foundation and adding an MCP-specific policy surface on top of it.

PR #1865 introduces generic JSON-RPC method/params enforcement. This variant preserves generic JSON-RPC as a first-class supported protocol for non-MCP services, while adding MCP-specific policy syntax, MCP request validation via `tower-mcp-types`, MCP tool-name enforcement, and conformance-oriented e2e coverage.

## Related Issue

Addresses https://github.com/NVIDIA/OpenShell/issues/1793.

Builds on https://github.com/NVIDIA/OpenShell/pull/1865.

## Changes

### Relationship to NVIDIA/OpenShell#1865

PR #1865 adds the shared JSON-RPC-family L7 enforcement layer. This branch builds on that layer with an MCP-specific policy surface and MCP message validation via `tower-mcp-types`, while preserving generic JSON-RPC as a first-class supported protocol for non-MCP services.

### How This Addresses #1793

Issue #1793 asks for method-level governance for MCP tool calls because MCP traffic is carried as JSON-RPC over a single allowed connection, making network-only policy all-or-nothing.

This branch addresses that by allowing policy to distinguish MCP requests inside the connection:

- `protocol: mcp` selects MCP-aware JSON-RPC inspection.
- `method` can match MCP method names such as `initialize`, `tools/list`, and `tools/call` when authors want explicit method rules.
- `tool` is a convenience matcher for `tools/call` `params.name`.
- `deny_rules` can block specific MCP calls even when broader allow rules match.
- Allow and deny rules are evaluated before forwarding to the MCP server.
- MCP traffic remains in OpenShell's existing policy/audit path instead of requiring an external governance gateway.

### MCP Policy Shape

- Adds MCP endpoint options under `mcp`:
  - `mcp.max_body_bytes`
  - `mcp.strict_tool_names`
  - `mcp.allow_all_known_mcp_methods`
- Adds a dedicated `McpOptions` protobuf message so MCP policy can evolve without taking over generic L7 endpoint fields.
- Requires `protocol: mcp` endpoints to declare a concrete `host` plus `port` or `ports`; `protocol: mcp` alone is invalid and is not treated as MCP everywhere.
- Defaults `mcp.strict_tool_names` to `true`, enforcing the MCP-recommended tool-name pattern `^[A-Za-z0-9_.-]{1,128}$` before policy evaluation.
- Allows `tool` glob matchers only while `mcp.strict_tool_names` remains enabled.
- Defaults `mcp.allow_all_known_mcp_methods` to `true`, so omitted `rules` allow the MCP method profile and all tools before applying `deny_rules`.
- When `mcp.allow_all_known_mcp_methods` is `false`, explicit rules are required, and rules using `tool` or `params.name` must set `method: tools/call`.
- MCP tool argument matching is intentionally not supported yet; allowed tools currently accept all argument payloads.

### JSON-RPC / MCP Enforcement

- Adds `JsonRpcInspectionMode` so parsing can distinguish generic JSON-RPC from MCP-specific inspection.
- Uses `tower-mcp-types` to validate known MCP request and notification parameter shapes.
- Preserves unknown MCP extension methods as policy-addressable literal method strings.
- Keeps generic JSON-RPC parsing protocol-neutral for non-MCP JSON-RPC servers.
- Keeps enforcement on the existing OPA path by compiling MCP policy syntax back to the current JSON-RPC-family rule model.
- Preserves literal dotted JSON-RPC param keys on the generic JSON-RPC path.
- Relays MCP response frames and server-to-client MCP messages for current conformance compatibility; those frames are not currently parsed for policy enforcement.

### Conformance Notes

The MCP conformance policy template now uses:

```yaml
protocol: mcp
mcp:
  max_body_bytes: 131072
rules:
  - allow: {}
```

Expected-failure carve-outs are empty:

```yaml
client: []
server: []
```

> [!NOTE]
> The wrapper still carries a temporary workaround for modelcontextprotocol/conformance#345 while pinned to an upstream ref where the bundled TypeScript client fixtures drift from the runner scenarios. The wrapper patches the local checkout before building the client image so `elicitation-sep1034-client-defaults` and `sse-retry` exercise the intended MCP paths through OpenShell. Remove this workaround when `OPENSHELL_MCP_CONFORMANCE_REF` points at an upstream release containing that fix.

### Follow-up

Typed MCP argument enforcement would be better handled as a wider L7 policy input change, for example by preserving scalar JSON type metadata alongside the existing flattened matcher keys. That would let a future MCP argument policy express `type: integer` or `type: boolean` without weakening the existing JSON-RPC compatibility path.

OpenShell should also eventually own explicit MCP version profiles rather than relying on dependency enums as the policy contract. That would let policy choose between the current `2025-11-25` behavior and future MCP transport or method-profile changes.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated

Local validation run for this branch includes:

- `mise run pre-commit`
- `cargo test -p openshell-policy`
- `cargo test -p openshell-supervisor-network mcp_tool_deny_rule_blocks_tools_call`
- `cargo test -p openshell-supervisor-network l7_mcp`
- `cargo test --manifest-path e2e/rust/Cargo.toml --test forward_proxy_jsonrpc_l7 --features e2e-host-gateway --no-run`
- `OPENSHELL_DOCKER_SUPERVISOR_BIN=deploy/docker/.build/prebuilt-binaries/amd64/openshell-sandbox mise run e2e:mcp`
  - Passed: `initialize`, `tools_call`, `elicitation-sep1034-client-defaults`, `sse-retry`
  - Failed: none

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
