### PR TITLE
fix(server): share gateway shutdown channel

### DIFF
--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -422,8 +422,6 @@ pub async fn run_server(
         info!("Metrics server disabled");
     }
 
-    let (shutdown_tx, shutdown_rx) = watch::channel(false);
-
     // Build TLS acceptor when TLS is configured; otherwise serve plaintext.
     let tls_acceptor = if let Some(tls) = &config.tls {
         let acceptor = TlsAcceptor::from_files(


### PR DESCRIPTION
## Summary

Fix the `main` CI Rust lint failure from https://github.com/NVIDIA/OpenShell/actions/runs/27656754843/job/81792472668 by removing the duplicate gateway shutdown channel introduced by the merge of #1870 onto a `main` that already included #1577.

PR #1870 passed checks on stale head `29d57cc`, which did not include #1577. The final merge commit `ff028ce0` combined #1870 TLS reload shutdown handling with #1577 compute watcher shutdown handling, shadowing `shutdown_tx` and leaving the first sender unused under `-D warnings`.

## Related Issue

None.

## Changes

- Reuse the existing `run_server` shutdown channel for compute watchers, TLS reload, and gateway listener shutdown.
- Remove the second `watch::channel(false)` allocation that shadowed `shutdown_tx` and `shutdown_rx`.

## Testing

- [x] `mise run rust:lint` passes
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

`mise run pre-commit` was attempted locally and failed in the unrelated `helm:lint` task before this PR changes any Helm files: `chart metadata is missing these dependencies: postgresql`. Rust lint, rust check, and Rust tests completed successfully during that run before the overall task exited non-zero.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)