### PR TITLE
fix(helm): build chart dependencies before lint

### DIFF
--- a/tasks/helm.toml
+++ b/tasks/helm.toml
@@ -26,6 +26,7 @@ hide = true
 description = "Lint the openshell Helm chart (defaults + all CI configuration variants)"
 run = """
   set -e
+  helm dependency build deploy/helm/openshell
   echo "--- helm lint: defaults ---"
   echo "values files: deploy/helm/openshell/values.yaml"
   helm lint deploy/helm/openshell
@@ -45,6 +46,7 @@ run = """
   if ! helm plugin list | grep -q unittest; then
     helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
   fi
+  helm dependency build deploy/helm/openshell
   helm unittest deploy/helm/openshell
 """
 


### PR DESCRIPTION
## Summary

Build Helm chart dependencies before running chart lint and helm-unittest so optional subchart dependencies are resolved consistently.

## Related Issue

None.

## Changes

- Run `helm dependency build deploy/helm/openshell` before `helm lint`.
- Run `helm dependency build deploy/helm/openshell` before `helm unittest`.

## Testing

- [ ] `mise run pre-commit` passes
- [x] `mise run helm:lint` passes
- [x] `mise run helm:test` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

Note: `mise run pre-commit` was run and failed in unrelated `rust:lint` on `crates/openshell-server/src/lib.rs:347` due to an existing unused `shutdown_tx` warning promoted to an error.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)