### PR TITLE
fix(server): allow newlines in exec command arguments

### DIFF
--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -2064,7 +2064,25 @@ mod tests {
             workdir: "/tmp\nmalicious".to_string(),
             ..Default::default()
         };
-        assert!(build_remote_exec_command(&req).is_err());
+        // Validation layer rejects newlines in workdir
+        assert!(validate_exec_request_fields(&req).is_err());
+    }
+
+    #[test]
+    fn build_remote_exec_command_accepts_multiline_script() {
+        use openshell_core::proto::ExecSandboxRequest;
+        let req = ExecSandboxRequest {
+            sandbox_id: "test".to_string(),
+            command: vec![
+                "python3".to_string(),
+                "-c".to_string(),
+                "def f():\n    return 1\nprint(f())".to_string(),
+            ],
+            ..Default::default()
+        };
+        let cmd = build_remote_exec_command(&req).unwrap();
+        assert!(cmd.starts_with("python3 -c "));
+        assert!(cmd.contains("'def f():\n    return 1\nprint(f())'"));
     }
 
     #[test]

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -1457,9 +1457,6 @@ fn shell_escape(value: &str) -> Result<String, String> {
     if value.bytes().any(|b| b == 0) {
         return Err("value contains null bytes".to_string());
     }
-    if value.bytes().any(|b| b == b'\n' || b == b'\r') {
-        return Err("value contains newline or carriage return".to_string());
-    }
     if value.is_empty() {
         return Ok("''".to_string());
     }
@@ -1998,10 +1995,20 @@ mod tests {
     }
 
     #[test]
-    fn shell_escape_rejects_newlines() {
-        assert!(shell_escape("line1\nline2").is_err());
-        assert!(shell_escape("line1\rline2").is_err());
-        assert!(shell_escape("line1\r\nline2").is_err());
+    fn shell_escape_allows_newlines() {
+        assert!(shell_escape("line1\nline2").is_ok());
+        assert!(shell_escape("line1\rline2").is_ok());
+        assert!(shell_escape("line1\r\nline2").is_ok());
+    }
+
+    #[test]
+    fn shell_escape_preserves_newlines_in_single_quotes() {
+        assert_eq!(shell_escape("line1\nline2").unwrap(), "'line1\nline2'");
+        assert_eq!(
+            shell_escape("def f():\n    return 1").unwrap(),
+            "'def f():\n    return 1'"
+        );
+        assert_eq!(shell_escape("line1\r\nline2").unwrap(), "'line1\r\nline2'");
     }
 
     // ---- build_remote_exec_command ----

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -1513,7 +1513,11 @@ async fn stream_exec_over_relay(
     timeout_seconds: u32,
     request_tty: bool,
 ) -> Result<(), Status> {
-    let command_preview: String = command.chars().take(120).collect();
+    let command_preview: String = command
+        .chars()
+        .take(120)
+        .flat_map(char::escape_default)
+        .collect();
     info!(
         sandbox_id = %sandbox_id,
         channel_id = %channel_id,
@@ -1589,7 +1593,11 @@ async fn stream_interactive_exec_over_relay(
     cols: u32,
     rows: u32,
 ) -> Result<(), Status> {
-    let command_preview: String = command.chars().take(120).collect();
+    let command_preview: String = command
+        .chars()
+        .take(120)
+        .flat_map(char::escape_default)
+        .collect();
     info!(
         sandbox_id = %sandbox_id,
         channel_id = %channel_id,
@@ -2083,6 +2091,26 @@ mod tests {
         let cmd = build_remote_exec_command(&req).unwrap();
         assert!(cmd.starts_with("python3 -c "));
         assert!(cmd.contains("'def f():\n    return 1\nprint(f())'"));
+    }
+
+    #[test]
+    fn build_remote_exec_command_multiline_with_single_quotes() {
+        use openshell_core::proto::ExecSandboxRequest;
+        let req = ExecSandboxRequest {
+            sandbox_id: "test".to_string(),
+            command: vec![
+                "python3".to_string(),
+                "-c".to_string(),
+                "print('one')\r\nprint('two')".to_string(),
+            ],
+            ..Default::default()
+        };
+        let cmd = build_remote_exec_command(&req).unwrap();
+        assert!(cmd.starts_with("python3 -c "));
+        assert!(
+            cmd.contains("'print('\"'\"'one'\"'\"')\r\nprint('\"'\"'two'\"'\"')'"),
+            "CR/LF with embedded single quotes must compose correctly: {cmd}"
+        );
     }
 
     #[test]

--- a/crates/openshell-server/src/grpc/validation.rs
+++ b/crates/openshell-server/src/grpc/validation.rs
@@ -46,7 +46,7 @@ pub(super) fn validate_exec_request_fields(req: &ExecSandboxRequest) -> Result<(
                 "command argument {i} exceeds {MAX_EXEC_ARG_LEN} byte limit"
             )));
         }
-        reject_null_bytes(arg, &format!("command argument {i}"))?;
+        reject_null_char(arg, &format!("command argument {i}"))?;
     }
     for (key, value) in &req.environment {
         if value.len() > MAX_EXEC_ARG_LEN {
@@ -70,28 +70,26 @@ pub(super) fn validate_exec_request_fields(req: &ExecSandboxRequest) -> Result<(
 
 /// Reject null bytes and newlines in a user-supplied value.
 pub(super) fn reject_control_chars(value: &str, field_name: &str) -> Result<(), Status> {
+    reject_null_char(value, field_name)?;
+    reject_newline_chars(value, field_name)?;
+    Ok(())
+}
+
+/// Reject null bytes in a user-supplied value.
+pub(super) fn reject_null_char(value: &str, field_name: &str) -> Result<(), Status> {
     if value.bytes().any(|b| b == 0) {
         return Err(Status::invalid_argument(format!(
             "{field_name} contains null bytes"
-        )));
-    }
-    if value.bytes().any(|b| b == b'\n' || b == b'\r') {
-        return Err(Status::invalid_argument(format!(
-            "{field_name} contains newline or carriage return characters"
         )));
     }
     Ok(())
 }
 
-/// Reject only null bytes in a user-supplied value.
-///
-/// Use this for exec command arguments where newlines are legitimate
-/// (e.g. multi-line scripts passed to `bash -c` or `python3 -c`).
-/// The shell-escape layer handles newline safety via single-quoting.
-pub(super) fn reject_null_bytes(value: &str, field_name: &str) -> Result<(), Status> {
-    if value.bytes().any(|b| b == 0) {
+/// Reject newline and carriage return characters in a user-supplied value.
+pub(super) fn reject_newline_chars(value: &str, field_name: &str) -> Result<(), Status> {
+    if value.bytes().any(|b| b == b'\n' || b == b'\r') {
         return Err(Status::invalid_argument(format!(
-            "{field_name} contains null bytes"
+            "{field_name} contains newline or carriage return characters"
         )));
     }
     Ok(())

--- a/crates/openshell-server/src/grpc/validation.rs
+++ b/crates/openshell-server/src/grpc/validation.rs
@@ -46,7 +46,7 @@ pub(super) fn validate_exec_request_fields(req: &ExecSandboxRequest) -> Result<(
                 "command argument {i} exceeds {MAX_EXEC_ARG_LEN} byte limit"
             )));
         }
-        reject_control_chars(arg, &format!("command argument {i}"))?;
+        reject_null_bytes(arg, &format!("command argument {i}"))?;
     }
     for (key, value) in &req.environment {
         if value.len() > MAX_EXEC_ARG_LEN {
@@ -78,6 +78,20 @@ pub(super) fn reject_control_chars(value: &str, field_name: &str) -> Result<(), 
     if value.bytes().any(|b| b == b'\n' || b == b'\r') {
         return Err(Status::invalid_argument(format!(
             "{field_name} contains newline or carriage return characters"
+        )));
+    }
+    Ok(())
+}
+
+/// Reject only null bytes in a user-supplied value.
+///
+/// Use this for exec command arguments where newlines are legitimate
+/// (e.g. multi-line scripts passed to `bash -c` or `python3 -c`).
+/// The shell-escape layer handles newline safety via single-quoting.
+pub(super) fn reject_null_bytes(value: &str, field_name: &str) -> Result<(), Status> {
+    if value.bytes().any(|b| b == 0) {
+        return Err(Status::invalid_argument(format!(
+            "{field_name} contains null bytes"
         )));
     }
     Ok(())
@@ -1717,5 +1731,55 @@ mod tests {
     fn reject_control_chars_rejects_newlines() {
         assert!(reject_control_chars("line1\nline2", "test").is_err());
         assert!(reject_control_chars("line1\rline2", "test").is_err());
+    }
+
+    #[test]
+    fn validate_exec_allows_newlines_in_command_args() {
+        let req = ExecSandboxRequest {
+            sandbox_id: "test".to_string(),
+            command: vec![
+                "python3".to_string(),
+                "-c".to_string(),
+                "def f():\n    return 1\nprint(f())".to_string(),
+            ],
+            ..Default::default()
+        };
+        assert!(validate_exec_request_fields(&req).is_ok());
+    }
+
+    #[test]
+    fn validate_exec_still_rejects_null_bytes_in_command_args() {
+        let req = ExecSandboxRequest {
+            sandbox_id: "test".to_string(),
+            command: vec!["echo".to_string(), "hello\x00world".to_string()],
+            ..Default::default()
+        };
+        let err = validate_exec_request_fields(&req).unwrap_err();
+        assert!(err.message().contains("null"));
+    }
+
+    #[test]
+    fn validate_exec_still_rejects_newlines_in_workdir() {
+        let req = ExecSandboxRequest {
+            sandbox_id: "test".to_string(),
+            command: vec!["ls".to_string()],
+            workdir: "/tmp\nmalicious".to_string(),
+            ..Default::default()
+        };
+        let err = validate_exec_request_fields(&req).unwrap_err();
+        assert!(err.message().contains("newline"));
+    }
+
+    #[test]
+    fn validate_exec_still_rejects_newlines_in_env_values() {
+        let req = ExecSandboxRequest {
+            sandbox_id: "test".to_string(),
+            command: vec!["ls".to_string()],
+            environment: std::iter::once(("VAR".to_string(), "val\nmalicious".to_string()))
+                .collect(),
+            ..Default::default()
+        };
+        let err = validate_exec_request_fields(&req).unwrap_err();
+        assert!(err.message().contains("newline"));
     }
 }

--- a/crates/openshell-server/src/grpc/validation.rs
+++ b/crates/openshell-server/src/grpc/validation.rs
@@ -32,8 +32,10 @@ pub(super) const MAX_EXEC_ARG_LEN: usize = 32 * 1024; // 32 KiB
 /// Maximum length of the workdir field (bytes).
 pub(super) const MAX_EXEC_WORKDIR_LEN: usize = 4096;
 
-/// Validate fields of an `ExecSandboxRequest` for control characters and size
-/// limits before constructing a shell command string.
+/// Validate exec request size limits and field-specific character constraints.
+///
+/// Command arguments only reject NUL (newlines are valid for inline scripts).
+/// Environment values and workdir reject both NUL and newlines.
 pub(super) fn validate_exec_request_fields(req: &ExecSandboxRequest) -> Result<(), Status> {
     if req.command.len() > MAX_EXEC_COMMAND_ARGS {
         return Err(Status::invalid_argument(format!(


### PR DESCRIPTION
## Summary

Allow newline characters in `sandbox exec` command arguments so multi-line scripts (`python3 -c "def f():\n  ..."`, `bash -c "echo 'line1\nline2'"`) work without base64 workarounds.

## Related Issue

Fixes #1963

## Changes

- **`shell_escape()`** (`sandbox.rs`): Remove newline rejection. Newlines inside POSIX single quotes are literal characters, not command separators. Null byte rejection preserved.
- **`validate_exec_request_fields()`** (`validation.rs`): Add `reject_null_bytes()` for exec command arguments instead of `reject_control_chars()`. Newline rejection preserved for workdir and environment values.

## Testing

Verified end-to-end against a live gateway with podman driver on macOS:

```
$ openshell sandbox exec -n multiline-test -- python3 -c "
def hello():
    print('multi-line scripts work!')
hello()
"
multi-line scripts work!
```

- [x] `cargo test --package openshell-server` — 857 tests pass, 0 failures
- [x] Multi-line Python script via `sandbox exec` — works
- [x] Multi-line bash script via `sandbox exec` — works
- [x] Single-line commands — no regression
- [x] Null bytes in args — still rejected
- [x] Newlines in workdir — still rejected
- [x] Newlines in env values — still rejected

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable — no architectural change)