### PR TITLE
fix(snap): use snap-owned XDG directories

### DIFF
--- a/docs/about/installation.mdx
+++ b/docs/about/installation.mdx
@@ -80,7 +80,7 @@ sudo loginctl enable-linger $USER
 Install the OpenShell snap from the Snap Store:
 
 ```shell
-sudo snap install openshell --classic
+sudo snap install openshell
 ```
 
 The snap defines two apps: the `openshell` CLI and the `openshell.gateway`
@@ -88,6 +88,11 @@ systemd service. The gateway listens on `https://127.0.0.1:17670` and
 stores its database at `$SNAP_COMMON/gateway.db` (typically
 `/var/snap/openshell/common/gateway.db`). Create `$SNAP_COMMON/gateway.toml`
 when you need to override gateway settings.
+
+The snap CLI stores per-user config, data, and state under `$SNAP_USER_COMMON`,
+typically `~/snap/openshell/common`. Gateway registrations live under
+`$SNAP_USER_COMMON/.config/openshell/gateways/` instead of
+`~/.config/openshell/gateways/`.
 
 ### Snap store installs
 
@@ -108,7 +113,7 @@ manually.
 When installing a locally built `.snap` file, no plugs are connected by default:
 
 ```shell
-sudo snap install ./openshell_*.snap --dangerous --classic
+sudo snap install ./openshell_*.snap --dangerous
 sudo snap connect openshell:home
 sudo snap connect openshell:network
 sudo snap connect openshell:network-bind

--- a/python/openshell/release_formula_test.py
+++ b/python/openshell/release_formula_test.py
@@ -113,6 +113,15 @@ def test_snap_wrapper_uses_optional_gateway_config_without_generating_toml() -> 
     assert 'exec "${SNAP}/bin/openshell-gateway" "$@"' in wrapper
 
 
+def test_snap_cli_uses_snap_owned_xdg_dirs() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    snapcraft = (repo_root / "snapcraft.yaml").read_text(encoding="utf-8")
+
+    assert snapcraft.count('XDG_CONFIG_HOME: "$SNAP_USER_COMMON/.config"') == 2
+    assert snapcraft.count('XDG_DATA_HOME: "$SNAP_USER_COMMON/.local/share"') == 2
+    assert snapcraft.count('XDG_STATE_HOME: "$SNAP_USER_COMMON/.local/state"') == 2
+
+
 def test_rpm_spec_uses_gateway_defaults_without_config_helper() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     spec = (repo_root / "openshell.spec").read_text(encoding="utf-8")

--- a/python/openshell/release_formula_test.py
+++ b/python/openshell/release_formula_test.py
@@ -113,15 +113,6 @@ def test_snap_wrapper_uses_optional_gateway_config_without_generating_toml() -> 
     assert 'exec "${SNAP}/bin/openshell-gateway" "$@"' in wrapper
 
 
-def test_snap_cli_uses_snap_owned_xdg_dirs() -> None:
-    repo_root = Path(__file__).resolve().parents[2]
-    snapcraft = (repo_root / "snapcraft.yaml").read_text(encoding="utf-8")
-
-    assert snapcraft.count('XDG_CONFIG_HOME: "$SNAP_USER_COMMON/.config"') == 2
-    assert snapcraft.count('XDG_DATA_HOME: "$SNAP_USER_COMMON/.local/share"') == 2
-    assert snapcraft.count('XDG_STATE_HOME: "$SNAP_USER_COMMON/.local/state"') == 2
-
-
 def test_rpm_spec_uses_gateway_defaults_without_config_helper() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     spec = (repo_root / "openshell.spec").read_text(encoding="utf-8")

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -62,6 +62,10 @@ platforms:
 apps:
   openshell:
     command: bin/openshell
+    environment:
+      XDG_CONFIG_HOME: "$SNAP_USER_COMMON/.config"
+      XDG_DATA_HOME: "$SNAP_USER_COMMON/.local/share"
+      XDG_STATE_HOME: "$SNAP_USER_COMMON/.local/state"
     plugs:
       - home
       - network
@@ -70,6 +74,10 @@ apps:
   term:
     command: bin/openshell term
     desktop: meta/gui/term.desktop
+    environment:
+      XDG_CONFIG_HOME: "$SNAP_USER_COMMON/.config"
+      XDG_DATA_HOME: "$SNAP_USER_COMMON/.local/share"
+      XDG_STATE_HOME: "$SNAP_USER_COMMON/.local/state"
     plugs:
       - home
       - network


### PR DESCRIPTION
## Summary

Fix the Ubuntu Snap release canary failure where the snapped `openshell` CLI tried to write gateway metadata under the host `~/.config/openshell` and hit snap confinement. The snap now points user-facing OpenShell commands at persistent snap-owned XDG directories under `$SNAP_USER_COMMON`.

This follows the Snap data-location pattern for app-owned per-user data: snapd exposes `$SNAP_USER_COMMON` as user data shared across revisions, and `snapcraft.yaml` supports app-level runtime environment variables for directing commands to those locations. See:

- https://snapcraft.io/docs/reference/administration/data-locations/
- https://snapcraft.io/docs/reference/development/environment-variables/
- https://documentation.ubuntu.com/snapcraft/9.0/reference/project-file/snapcraft-yaml/#apps-app-name-environment

## Related Issue

No existing issue found. Investigated failing Release Canary run: https://github.com/NVIDIA/OpenShell/actions/runs/27986564035

## Changes

- Set `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, and `XDG_STATE_HOME` for the `openshell` and `term` snap apps.
- Update Snap installation docs to remove stale `--classic` examples and document the snap-owned CLI storage location.

## Testing

- [x] `uv run --frozen pytest python/openshell/release_formula_test.py -q`
- [x] `mise run pre-commit` passes
- [x] `mise exec -- markdownlint-cli2 docs/about/installation.mdx --no-globs`
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable)
