### PR TITLE
fix(release): make dev packages post-stable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -365,18 +365,6 @@ download_release_asset() {
     return 0
   fi
 
-  # GitHub normalizes `~` to `.` in release asset names, while checksum files
-  # can still record package filenames with `~dev` for correct version ordering.
-  # Download the normalized asset but verify it against the checksum entry for
-  # the original package filename.
-  _normalized="$(printf '%s' "$_filename" | tr '~' '.')"
-  if [ "$_normalized" != "$_filename" ]; then
-    if download "${GITHUB_URL}/releases/download/${_tag}/${_normalized}" "$_output"; then
-      info "using GitHub-normalized asset name ${_normalized}"
-      return 0
-    fi
-  fi
-
   return 1
 }
 

--- a/python/release_tooling_test.py
+++ b/python/release_tooling_test.py
@@ -36,12 +36,12 @@ def test_exact_tag_versions_are_stable_release_versions() -> None:
 def test_dev_versions_share_one_build_identity() -> None:
     versions = release._versions_from_parts((0, 0, 37), 108, "152d05940", "v0.0.37")
 
-    assert versions.python == "0.0.38.dev108+g152d05940"
-    assert versions.cargo == "0.0.38-dev.108+g152d05940"
-    assert versions.docker == "0.0.38-dev.108-g152d05940"
-    assert versions.deb == "0.0.38~dev.108+g152d05940-1"
-    assert versions.rpm_version == "0.0.38"
-    assert versions.rpm_release == "0.dev.108.g152d05940"
+    assert versions.python == "0.0.37.post108+g152d05940"
+    assert versions.cargo == "0.0.37+post.108.g152d05940"
+    assert versions.docker == "0.0.37-post.108.g152d05940"
+    assert versions.deb == "0.0.37+post.108.g152d05940-1"
+    assert versions.rpm_version == "0.0.37"
+    assert versions.rpm_release == "2.dev.108.g152d05940"
 
 
 def test_semver_tag_parser_excludes_vm_tags() -> None:

--- a/tasks/scripts/release.py
+++ b/tasks/scripts/release.py
@@ -97,14 +97,18 @@ def _versions_from_parts(
         rpm_version = python_version
         rpm_release = "1"
     else:
-        next_version = _format_semver(_next_patch(base_version))
-        python_version = f"{next_version}.dev{git_distance}+g{git_sha}"
-        rpm_version = next_version
-        rpm_release = f"0.dev.{git_distance}.g{git_sha}"
+        latest_version = _format_semver(base_version)
+        python_version = f"{latest_version}.post{git_distance}+g{git_sha}"
+        rpm_version = latest_version
+        rpm_release = f"2.dev.{git_distance}.g{git_sha}"
 
-    # Convert PEP 440 to a SemVer-ish string for Cargo:
-    # 0.1.0.dev3+gabcdef -> 0.1.0-dev.3+gabcdef
-    cargo_version = re.sub(r"\.dev(\d+)", r"-dev.\1", python_version)
+    # Convert PEP 440 to a SemVer-ish string for Cargo. Dev builds are
+    # post-release package-manager builds, represented as SemVer metadata so
+    # Cargo accepts the workspace version:
+    # 0.1.0.post3+gabcdef -> 0.1.0+post.3.gabcdef
+    cargo_version = re.sub(
+        r"\.post(\d+)\+g([0-9a-f]+)$", r"+post.\1.g\2", python_version
+    )
 
     # Docker tags can't contain '+'.
     docker_version = cargo_version.replace("+", "-")
@@ -114,10 +118,10 @@ def _versions_from_parts(
     if len(snap_version) > 32:
         raise ValueError(f"snap version must be at most 32 characters: {snap_version}")
 
-    # Debian versions use '~' so prereleases sort before the eventual release.
+    # Debian post-release versions use '+' so dev builds sort after the
+    # matching stable package.
     deb_version = cargo_version
     deb_version = deb_version[1:] if deb_version.startswith("v") else deb_version
-    deb_version = deb_version.replace("-dev.", "~dev.", 1)
     deb_version = f"{deb_version}-1"
 
     return Versions(


### PR DESCRIPTION


## Summary
Dev releases now use post-stable package versions in tasks/scripts/release.py:99:

  Python: 0.0.37.post108+g152d05940
  Cargo:  0.0.37+post.108.g152d05940
  Debian: 0.0.37+post.108.g152d05940-1
  RPM:    Version 0.0.37, Release 2.dev.108.g152d05940

That makes dev sort after the latest stable 0.0.37-1, while still sorting below the next stable 0.0.38-1.

This allows us to do an upgrade installation from a stable release to a dev release, but then still be able to upgrade that dev release to the next stable release.

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
  - Use base_version (current stable) instead of _next_patch(base_version) for dev builds
  - Switch Python version suffix from .dev{n} to .post{n} (PEP 440 post-release)
  - Update Cargo regex: .post{n}+g{sha} → +post.{n}.g{sha} (build metadata, not pre-release)
  - Change RPM release prefix from 0.dev. to 2.dev. so it sorts after stable release 1
  - Remove Debian ~dev. substitution (no longer needed with +post. format)

## Testing
<!-- What testing was done? -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
