### PR TITLE
docs: add step for creating the GatewayClass

### DIFF
--- a/docs/kubernetes/ingress.mdx
+++ b/docs/kubernetes/ingress.mdx
@@ -14,15 +14,30 @@ OpenShell uses the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io) for
 
 ## Install Envoy Gateway
 
-Envoy Gateway installs the Gateway API CRDs and registers the `eg` GatewayClass:
+Envoy Gateway installs the Gateway API CRDs and controller:
 
 ```shell
 helm install eg \
   oci://docker.io/envoyproxy/gateway-helm \
-  --version v1.7.2 \
+  --version v1.8.1 \
   --namespace envoy-gateway-system \
   --create-namespace \
   --wait
+```
+
+## Create the GatewayClass
+
+Create the `eg` GatewayClass that the OpenShell chart references:
+
+```shell
+kubectl apply -f - <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+EOF
 ```
 
 Verify the GatewayClass is accepted:


### PR DESCRIPTION
## Summary
<!-- 1-3 sentences: what this PR does and why -->
Updates the Kubernetes ingress docs to add a dedicated step for creating the `eg` GatewayClass that the OpenShell chart references. Previously the docs implied Envoy Gateway registered the GatewayClass automatically, but EG helm chart installs only the CRDs and controller, so the GatewayClass must be created explicitly. Also bumps the Envoy Gateway Helm chart version from v1.7.2 to v1.8.1.

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->
N/A — small docs fix.

## Changes
<!-- Bullet list of key changes -->
- Reworded the "Install Envoy Gateway" section to clarify that the Helm install provides the Gateway API CRDs and controller (not the GatewayClass)
- Bumped the Envoy Gateway Helm chart version from v1.7.2 to v1.8.1
- Added a new "Create the GatewayClass" section with a kubectl apply snippet that creates the eg GatewayClass using the `gateway.envoyproxy.io/gatewayclass-controller` controller

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
