### PR TITLE
fix(ci): fix linting issues

### DIFF
--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -7,8 +7,10 @@
 
 mod activity_aggregator;
 mod denial_aggregator;
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 mod google_cloud_metadata;
 mod mechanistic_mapper;
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 mod metadata_server;
 
 use miette::Result;
@@ -65,6 +67,7 @@ use openshell_supervisor_network::opa::OpaEngine;
 pub use openshell_supervisor_process::process::{ProcessHandle, ProcessStatus};
 use openshell_supervisor_process::skills;
 use tokio::sync::mpsc::UnboundedSender;
+#[cfg(target_os = "linux")]
 use tokio::time::timeout;
 
 /// Run a command in the sandbox.

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -344,7 +344,7 @@ pub async fn run_server(
 
     let state = Arc::new(state);
 
-    let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
     // Resume sandboxes that were stopped during the previous gateway
     // shutdown so the running compute state matches the persisted store.


### PR DESCRIPTION
## Summary

Fix the lint failures currently present at the tip of `main`.

## Related Issue

N/A

## Changes

- Restore the gateway shutdown sender name in `openshell-server` so `shutdown_tx.send(true)` compiles.
- Allow the GCE metadata emulator modules to be dead code on non-Linux builds, where their production caller is compiled out.
- Gate the sandbox `tokio::time::timeout` import to Linux for the same reason.

## Findings

`main` currently fails `mise run pre-commit` because of two independent regressions.

First bad commit for the sandbox lint failure:

- `48545cfb feat(sandbox): add GCE metadata emulator for Google Cloud (#1763)`
- Verified by running `mise run rust:lint` at `48a7d09e`, which passed, then at `48545cfb`, which failed.
- Cause: PR branch checks run Rust jobs only on Linux runners. The GCE metadata emulator is used only behind `#[cfg(target_os = "linux")]`, so Linux clippy sees the modules as used. On macOS/non-Linux, the production caller is compiled out and `-D warnings` turns the modules/import into dead-code and unused-import errors.

Second regression at the current `main` tip:

- `4ee27d99 feat(sandbox,providers): add aws-bedrock as a recognized inference provider (#1704)`
- Cause: the PR renamed the first gateway shutdown sender to `_shutdown_tx`, but `run_server` still calls `shutdown_tx.send(true)` later. The PR passed before merge because branch protection has `strict: false`; it was not rebuilt against the current `main` merge result after `4c75b854 fix(server): share gateway shutdown channel (#1945)` changed the shutdown-channel shape.

CI coverage that would have caught this before merge:

- A required macOS/non-Linux Rust lint job running `mise run rust:lint` or `cargo clippy --workspace --all-targets -- -D warnings`.
- Strict required checks or merge queue testing so PRs are validated against the current `main` merge result before merge.

## Testing

- [x] `mise run rust:lint` passes
- [x] `mise run pre-commit` passes
- [x] `git diff --check` passes
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
