### PR TITLE
fix(e2e): make postgres fixture compatible with OpenShift

### DIFF
--- a/e2e/kubernetes/postgres-fixture.yaml
+++ b/e2e/kubernetes/postgres-fixture.yaml
@@ -16,6 +16,7 @@ metadata:
 type: Opaque
 stringData:
   password: openshell-e2e-postgres
+  uri: postgresql://openshell:openshell-e2e-postgres@openshell-e2e-postgres.openshell.svc/openshell
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -48,6 +49,13 @@ spec:
                   key: password
             - name: POSTGRES_DB
               value: openshell
+            # OpenShift assigns a random UID from the namespace range instead of
+            # running as the image's "postgres" user (UID 70). The postgres
+            # entrypoint fails to chmod /var/lib/postgresql/data because it is
+            # owned by UID 70. Setting PGDATA to a subdirectory causes postgres
+            # to mkdir+chmod a new directory it owns, which succeeds.
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           ports:
             - name: postgres
               containerPort: 5432
@@ -61,6 +69,16 @@ spec:
             periodSeconds: 3
             timeoutSeconds: 2
             failureThreshold: 20
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+            - name: postgres-run
+              mountPath: /var/run/postgresql
+      volumes:
+        - name: postgres-data
+          emptyDir: {}
+        - name: postgres-run
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

Make the e2e PostgreSQL deployment fixture compatible with OpenShift by addressing UID-based filesystem permission issues that occur when OpenShift assigns random UIDs to pods.

## Changes

- Add `PGDATA` env var pointing to a subdirectory (`/var/lib/postgresql/data/pgdata`) so postgres creates and owns the directory it needs to chmod, bypassing the UID mismatch
- Add `uri` field to the postgres secret for connection string convenience
- Add `postgres-data` and `postgres-run` emptyDir volume mounts for proper filesystem isolation

## Testing

- [x] `mise run pre-commit` passes (rust lint, format, license headers all green)
- [ ] E2E tests verified on OpenShift cluster

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)