### PR TITLE
fix(supervisor): wire prepare_supervisor_identity_mount_namespace_from_env

### DIFF
--- a/crates/openshell-supervisor-process/src/run.rs
+++ b/crates/openshell-supervisor-process/src/run.rs
@@ -79,6 +79,12 @@ pub async fn run_process(
     #[cfg(unix)]
     crate::process::prepare_filesystem(policy)?;
 
+    // Wire the SPIFFE Workload API mount namespace so that
+    // supervisor_identity_mount_from_env() succeeds in spawn_entrypoint when
+    // PROVIDER_SPIFFE_WORKLOAD_API_SOCKET is set.
+    #[cfg(target_os = "linux")]
+    crate::process::prepare_supervisor_identity_mount_namespace_from_env()?;
+
     // Eagerly fetch initial settings and install the agent skill if the
     // proposals flag is on at startup, rather than waiting for the policy
     // poll loop's first tick. In offline/file-mode there is no gateway, so


### PR DESCRIPTION
## Problem

When a gateway is configured with `provider_spiffe_workload_api_socket_path`, the Kubernetes driver injects `PROVIDER_SPIFFE_WORKLOAD_API_SOCKET` into sandbox pods. The supervisor then calls `supervisor_identity_mount_from_env()` inside `spawn_entrypoint()` (process.rs:524), which expects `SUPERVISOR_IDENTITY_MOUNT_NS` to be initialised by `prepare_supervisor_identity_mount_namespace_from_env()`.

Without this call the `OnceLock` is never populated, causing every sandbox pod to crash with:

```
Error: Failed to prepare supervisor identity isolation: supervisor identity
mount namespace was not prepared before startup hardening
```

This makes the `provider_spiffe_workload_api_socket_path` gateway config option completely unusable — any cluster that enables it will have all sandbox pods crash-loop.

## Root Cause

`prepare_supervisor_identity_mount_namespace_from_env()` is defined in `process.rs` but was never wired into the startup sequence. The function creates a private mount namespace to hide the SPIFFE Workload API socket from the child process (security isolation). It must run before `supervisor_identity_mount_from_env()` is called.

## Fix

Call `prepare_supervisor_identity_mount_namespace_from_env()` in `run_process()` immediately after `prepare_filesystem()`, before any child processes are spawned.

## Testing

Verified against an EKS cluster with SPIRE deployed:
1. Set `provider_spiffe_workload_api_socket_path = "/run/spire/certs/spire-agent.sock"` in gateway config
2. **Before fix**: sandbox pod crashes on every start with the error above
3. **After fix**: sandbox pod starts cleanly, `/run/spire/certs/spire-agent.sock` is accessible inside the container