### PR TITLE
chore(gitignore): ignore nix result links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,7 @@ rfc.md
 
 # Markdown/mermaid lint tooling deps
 scripts/lint-mermaid/node_modules/
+
+# Nix
+/result
+/result-*


### PR DESCRIPTION
## Summary

Ignore local Nix build out-links so `nix build` artifacts do not appear as untracked files. The patterns cover the default `/result` link and `/result-*` out-links without hiding every top-level `result*` name.

## Related Issue

None.

## Changes

- Add top-level `.gitignore` patterns for `/result` and `/result-*`.

## Testing

- [ ] `mise run pre-commit` passes (not run per request)
- [ ] Unit tests added/updated (not applicable)
- [ ] E2E tests added/updated (not applicable)
- [x] Verified `git check-ignore` matches `result`, `result-1`, and `result-foo`, but not `results` or `resultfoo`

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)