### PR TITLE
chore(deps): remove unused regorus yaml feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,6 @@ dependencies = [
  "rand 0.9.4",
  "serde",
  "serde_json",
- "serde_yaml",
  "spin",
  "thiserror 2.0.18",
 ]

--- a/crates/openshell-prover/src/policy.rs
+++ b/crates/openshell-prover/src/policy.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 
 use miette::{IntoDiagnostic, Result, WrapErr};
 use serde::Deserialize;
+use serde::de::IgnoredAny;
 
 // ---------------------------------------------------------------------------
 // Policy intent
@@ -60,10 +61,10 @@ struct PolicyFile {
     // Ignored fields the prover does not need.
     #[serde(default)]
     #[allow(dead_code)]
-    landlock: Option<serde_yml::Value>,
+    landlock: Option<IgnoredAny>,
     #[serde(default)]
     #[allow(dead_code)]
-    process: Option<serde_yml::Value>,
+    process: Option<IgnoredAny>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/openshell-supervisor-network/Cargo.toml
+++ b/crates/openshell-supervisor-network/Cargo.toml
@@ -25,7 +25,7 @@ hex = "0.4"
 ipnet = "2"
 miette = { workspace = true }
 rcgen = { workspace = true }
-regorus = { version = "0.9", default-features = false, features = ["std", "arc", "glob", "yaml"] }
+regorus = { version = "0.9", default-features = false, features = ["std", "arc", "glob"] }
 reqwest = { workspace = true }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }


### PR DESCRIPTION
## Summary

Remove the unused `yaml` feature from `regorus` so `openshell-supervisor-network` no longer pulls deprecated YAML parser crates through the policy engine path. Replace prover fields that intentionally ignore unsupported policy sections with `serde::de::IgnoredAny`.

## Related Issue

Refs #2018

## Changes

- Removed `yaml` from the `regorus` feature list in `openshell-supervisor-network`.
- Updated `Cargo.lock` to reflect the removed `regorus` YAML feature.
- Replaced ignored prover YAML value fields with `serde::de::IgnoredAny`.

## Testing

- [x] `mise exec -- cargo check -p openshell-supervisor-network`
- [x] `mise exec -- cargo test -p openshell-supervisor-network opa`
- [x] `mise exec -- cargo check -p openshell-prover`
- [x] `mise exec -- cargo test -p openshell-prover`
- [x] `git diff --check`
- [ ] `mise run pre-commit` passes (attempted; local macOS Command Line Tools cannot resolve the SDK, and `xcrun --show-sdk-path` fails with `unable to find sdk: 'macosx'`; failure occurs while compiling the temporary `fake-forward-process` in `openshell-cli` integration tests)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
