### PR TITLE
fix(python): include generated proto stubs in Linux wheels

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -679,7 +679,7 @@ jobs:
 
   smoke-linux-dev-artifacts:
     name: Smoke Linux Dev Artifacts (${{ matrix.name }})
-    needs: [build-gateway-binary-linux, build-driver-vm-linux, build-deb, build-rpm]
+    needs: [build-gateway-binary-linux, build-driver-vm-linux, build-deb, build-rpm, build-python-wheels-linux]
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -707,6 +707,18 @@ jobs:
             runner: linux-arm64-cpu8
             image: fedora:latest
             kind: rpm
+            artifact_arch: arm64
+            rpm_arch: aarch64
+          - name: python-wheel-amd64
+            runner: linux-amd64-cpu8
+            image: python:3.12-slim
+            kind: wheel
+            artifact_arch: amd64
+            rpm_arch: x86_64
+          - name: python-wheel-arm64
+            runner: linux-arm64-cpu8
+            image: python:3.12-slim
+            kind: wheel
             artifact_arch: arm64
             rpm_arch: aarch64
     runs-on: ${{ matrix.runner }}
@@ -742,6 +754,25 @@ jobs:
           set -euo pipefail
           dnf install -y ./package-input/openshell-[0-9]*.rpm ./package-input/openshell-gateway-*.rpm
           LD_BIND_NOW=1 openshell-gateway --version
+
+      - name: Download Python wheel artifact
+        if: matrix.kind == 'wheel'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-wheels-linux-${{ matrix.artifact_arch }}
+          path: wheel-input/
+
+      - name: Smoke Python wheel
+        if: matrix.kind == 'wheel'
+        run: |
+          set -euo pipefail
+          pip install --no-cache-dir wheel-input/*.whl
+          python - <<'PY'
+          import importlib
+          for name in ("openshell", "openshell._proto", "openshell.sandbox"):
+              importlib.import_module(name)
+              print(name, "OK")
+          PY
 
   # ---------------------------------------------------------------------------
   # Create / update the dev GitHub Release with CLI, gateway, driver, and wheels

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -715,7 +715,7 @@ jobs:
 
   smoke-linux-release-artifacts:
     name: Smoke Linux Release Artifacts (${{ matrix.name }})
-    needs: [build-gateway-binary-linux, build-driver-vm-linux, build-deb, build-rpm]
+    needs: [build-gateway-binary-linux, build-driver-vm-linux, build-deb, build-rpm, build-python-wheels-linux]
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -760,6 +760,20 @@ jobs:
             runner: linux-arm64-cpu8
             image: fedora:latest
             kind: rpm
+            artifact_arch: arm64
+            rpm_arch: aarch64
+            target: aarch64-unknown-linux-gnu
+          - name: python-wheel
+            runner: linux-amd64-cpu8
+            image: python:3.12-slim
+            kind: wheel
+            artifact_arch: amd64
+            rpm_arch: x86_64
+            target: x86_64-unknown-linux-gnu
+          - name: python-wheel-arm64
+            runner: linux-arm64-cpu8
+            image: python:3.12-slim
+            kind: wheel
             artifact_arch: arm64
             rpm_arch: aarch64
             target: aarch64-unknown-linux-gnu
@@ -821,6 +835,25 @@ jobs:
           set -euo pipefail
           dnf install -y ./package-input/openshell-[0-9]*.rpm ./package-input/openshell-gateway-*.rpm
           LD_BIND_NOW=1 openshell-gateway --version
+
+      - name: Download Python wheel artifact
+        if: matrix.kind == 'wheel'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-wheels-linux-${{ matrix.artifact_arch }}
+          path: wheel-input/
+
+      - name: Smoke Python wheel
+        if: matrix.kind == 'wheel'
+        run: |
+          set -euo pipefail
+          pip install --no-cache-dir wheel-input/*.whl
+          python - <<'PY'
+          import importlib
+          for name in ("openshell", "openshell._proto", "openshell.sandbox"):
+              importlib.import_module(name)
+              print(name, "OK")
+          PY
 
   # ---------------------------------------------------------------------------
   # Create a tagged GitHub Release with CLI, gateway, driver, and wheels

--- a/architecture/build.md
+++ b/architecture/build.md
@@ -126,6 +126,16 @@ contexts use `KIND_EXPERIMENTAL_PROVIDER=docker|podman` when set, and ambiguous
 or unknown contexts require an explicit `CONTAINER_ENGINE`. Other image builds
 do not infer from kube context.
 
+## Python Wheel Packaging
+
+The generated protobuf/gRPC stubs under `python/openshell/_proto/` are gitignored
+build outputs of `mise run python:proto`. maturin honors `.gitignore` when
+collecting `python-source` files, so native builds (Linux CI, local
+`pip install .`) would drop them and ship an unimportable wheel. `pyproject.toml`
+pins them back in with `[tool.maturin].include` globs. The release workflows
+install each Linux wheel in a clean image and import `openshell.sandbox` as a
+smoke check.
+
 ## CI and E2E
 
 Required checks run on GitHub Actions. Workflows that use NVIDIA self-hosted runners trigger from copy-pr-bot mirror branches, so trusted PRs are mirrored into `pull-request/<N>` branches before those workflows run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,13 @@ bindings = "bin"
 manifest-path = "crates/openshell-cli/Cargo.toml"
 python-source = "python"
 module-name = "openshell"
+# _proto/ stubs are gitignored; force them into the wheel so git-aware
+# maturin builds don't drop them (package-relative paths).
+include = [
+    "openshell/_proto/*_pb2.py",
+    "openshell/_proto/*_pb2_grpc.py",
+    "openshell/_proto/*.pyi",
+]
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
## Summary

The `openshell` Linux wheels (`0.0.54`) shipped without the generated protobuf/gRPC stubs under `openshell/_proto/`, so importing the package failed immediately on Linux. This pins those generated modules into the wheel and adds a wheel import smoke check to the release pipelines so the regression can't ship again.

## Related Issue

Closes #1705

## Changes

- **Root cause fix** (`pyproject.toml`): add explicit, package-relative `[tool.maturin].include` globs for the `openshell/_proto/*_pb2.py`, `*_pb2_grpc.py`, and `*.pyi` stubs. These files are gitignored build outputs of `mise run python:proto`; maturin honors `.gitignore` when collecting `python-source` files from a git checkout, so native builds (Linux release CI, local `pip install .`) dropped them. The macOS wheel only included them by accident — it builds in a Docker context whose `COPY` omits `.git`, so maturin had no gitignore to apply. The explicit `include` makes inclusion independent of `.git` presence.
- **Release smoke** (`.github/workflows/release-tag.yml`, `release-dev.yml`): add a `wheel` matrix entry (amd64 + arm64) to the existing Linux smoke jobs that installs each built wheel in a clean `python:3.12-slim` image and imports `openshell`, `openshell._proto`, and `openshell.sandbox`.
- **Docs** (`architecture/build.md`): document the gitignored-stub / maturin invariant and the wheel smoke check.

## Testing

- [x] `mise run pre-commit` passes (full lint + check + test; Rust and Python suites green — `test:python` 58 passed, `test:rust`/`test:sbom`/`test:docs-website`/`test:install-sh`/`test:packaging-assets` all pass)
- [x] Reproduced the bug and verified the fix locally: a `maturin build` inside the git repo dropped the stubs before the change and includes all 12 after; a clean `pip install` of the fixed wheel imports `openshell.sandbox` successfully
- [ ] Unit tests added/updated — N/A by design; coverage is the CI wheel install+import smoke rather than a unit test
- [ ] E2E tests added/updated — N/A

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
