### PR TITLE
chore(deploy): use OCI registry for cert-manager Helm chart

### DIFF
--- a/deploy/helm/openshell/skaffold.yaml
+++ b/deploy/helm/openshell/skaffold.yaml
@@ -63,8 +63,7 @@ deploy:
       # when you want cert-manager to manage TLS while certgen handles JWT.
       # Requires cert-manager CRDs to be installed in the cluster first.
       #- name: cert-manager
-      #  repo: https://charts.jetstack.io
-      #  remoteChart: cert-manager
+      #  remoteChart: oci://quay.io/jetstack/charts/cert-manager
       #  version: v1.20.2
       #  namespace: cert-manager
       #  createNamespace: true

--- a/docs/kubernetes/managing-certificates.mdx
+++ b/docs/kubernetes/managing-certificates.mdx
@@ -26,12 +26,11 @@ cert-manager precedence applies even if `pkiInitJob.enabled` remains true.
 
 ## Install cert-manager
 
-Add the Jetstack Helm repository and install cert-manager with CRD support enabled:
+Install cert-manager from the OCI registry with CRD support enabled:
 
 ```shell
-helm repo add jetstack https://charts.jetstack.io
-helm repo update
-helm upgrade --install cert-manager jetstack/cert-manager \
+helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+  --version v1.20.2 \
   --namespace cert-manager \
   --create-namespace \
   --set crds.enabled=true \


### PR DESCRIPTION
## Summary

- Migrate cert-manager Helm chart references from the legacy HTTP repository to the recommended OCI registry (`oci://quay.io/jetstack/charts/cert-manager`)
  - Xref: https://cert-manager.io/docs/installation/helm/#installing-cert-manager-with-helm
- Remove the now-unnecessary `helm repo add` / `helm repo update` steps from user-facing doc

## Related Issue

N/A

This is well-scoped minor non-code improvement so I directly raise as a PR.

## Changes

- `deploy/helm/openshell/skaffold.yaml`: Replace `repo` + `remoteChart` with a single `remoteChart: oci://...` URI
- `docs/kubernetes/managing-certificates.mdx`: Simplify install instructions to use OCI directly with pinned `--version v1.20.2`

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
