### PR TITLE
refactor(server): colocate Docker driver config construction with Podman/K8s

### DIFF
--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -14,7 +14,7 @@ use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 
 use crate::certgen;
-use crate::compute::{DockerComputeConfig, VmComputeConfig};
+use crate::compute::VmComputeConfig;
 use crate::config_file::{self, ConfigFile, GatewayFileSection};
 use crate::defaults::{self, LocalTlsPaths};
 use crate::{run_server, tracing_bus::TracingLogBus};
@@ -428,8 +428,6 @@ async fn run_from_args(mut args: RunArgs, matches: ArgMatches) -> Result<()> {
         args.disable_tls,
         args.port,
     )?;
-    let docker_config = build_docker_config(file.as_ref(), local_tls.as_ref())?;
-
     if args.disable_tls {
         warn!("TLS disabled — listening on plaintext HTTP");
     } else {
@@ -464,15 +462,9 @@ async fn run_from_args(mut args: RunArgs, matches: ArgMatches) -> Result<()> {
 
     info!(bind = %config.bind_address, "Starting OpenShell server");
 
-    Box::pin(run_server(
-        config,
-        vm_config,
-        docker_config,
-        file,
-        tracing_log_bus,
-    ))
-    .await
-    .into_diagnostic()
+    Box::pin(run_server(config, vm_config, file, tracing_log_bus))
+        .await
+        .into_diagnostic()
 }
 
 fn parse_compute_driver(value: &str) -> std::result::Result<String, String> {
@@ -779,33 +771,6 @@ fn build_vm_config(
         let scheme = if disable_tls { "http" } else { "https" };
         cfg.grpc_endpoint = format!("{scheme}://127.0.0.1:{gateway_port}");
     }
-    apply_guest_tls_defaults(
-        &mut cfg.guest_tls_ca,
-        &mut cfg.guest_tls_cert,
-        &mut cfg.guest_tls_key,
-        local_tls,
-    );
-    Ok(cfg)
-}
-
-/// Build [`DockerComputeConfig`] using the same inheritance pattern as
-/// [`build_vm_config`].
-fn build_docker_config(
-    file: Option<&ConfigFile>,
-    local_tls: Option<&LocalTlsPaths>,
-) -> Result<DockerComputeConfig> {
-    let mut cfg = if let Some(file) = file {
-        let merged = config_file::driver_table(
-            ComputeDriverKind::Docker,
-            &file.openshell.gateway,
-            file.openshell.drivers.get("docker"),
-        );
-        merged
-            .try_into::<DockerComputeConfig>()
-            .map_err(|e| miette::miette!("invalid [openshell.drivers.docker] table: {e}"))?
-    } else {
-        DockerComputeConfig::default()
-    };
     apply_guest_tls_defaults(
         &mut cfg.guest_tls_ca,
         &mut cfg.guest_tls_cert,
@@ -1838,19 +1803,5 @@ default_image = "k8s-specific:1.0"
             .try_into::<openshell_driver_kubernetes::KubernetesComputeConfig>()
             .expect("deserializes");
         assert_eq!(parsed.default_image, "k8s-specific:1.0");
-    }
-
-    #[test]
-    fn docker_config_reads_bind_mount_opt_in_from_driver_table() {
-        let file = config_file_from_toml(
-            r"
-[openshell.drivers.docker]
-enable_bind_mounts = true
-",
-        );
-
-        let cfg = super::build_docker_config(Some(&file), None).expect("docker config");
-
-        assert!(cfg.enable_bind_mounts);
     }
 }

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -208,7 +208,6 @@ impl ServerState {
 pub async fn run_server(
     config: Config,
     vm_config: VmComputeConfig,
-    docker_config: DockerComputeConfig,
     config_file: Option<config_file::ConfigFile>,
     tracing_log_bus: TracingLogBus,
 ) -> Result<()> {
@@ -243,7 +242,6 @@ pub async fn run_server(
     let compute = build_compute_runtime(
         &config,
         &vm_config,
-        &docker_config,
         config_file.as_ref(),
         store.clone(),
         sandbox_index.clone(),
@@ -720,7 +718,6 @@ async fn terminate_signal() {
 async fn build_compute_runtime(
     config: &Config,
     vm_config: &VmComputeConfig,
-    docker_config: &DockerComputeConfig,
     file: Option<&config_file::ConfigFile>,
     store: Arc<Store>,
     sandbox_index: SandboxIndex,
@@ -751,17 +748,21 @@ async fn build_compute_runtime(
             .await
             .map_err(|e| Error::execution(format!("failed to create compute runtime: {e}")))
         }
-        ConfiguredComputeDriver::Builtin(ComputeDriverKind::Docker) => ComputeRuntime::new_docker(
-            config.clone(),
-            docker_config.clone(),
-            store,
-            sandbox_index,
-            sandbox_watch_bus,
-            tracing_log_bus,
-            supervisor_sessions,
-        )
-        .await
-        .map_err(|e| Error::execution(format!("failed to create compute runtime: {e}"))),
+        ConfiguredComputeDriver::Builtin(ComputeDriverKind::Docker) => {
+            let mut docker = docker_config_from_file(file)?;
+            apply_docker_local_tls_defaults(config, &mut docker)?;
+            ComputeRuntime::new_docker(
+                config.clone(),
+                docker,
+                store,
+                sandbox_index,
+                sandbox_watch_bus,
+                tracing_log_bus,
+                supervisor_sessions,
+            )
+            .await
+            .map_err(|e| Error::execution(format!("failed to create compute runtime: {e}")))
+        }
         ConfiguredComputeDriver::Builtin(ComputeDriverKind::Podman) => {
             let mut podman = podman_config_from_file(file)?;
             podman.gateway_port = config.bind_address.port();
@@ -894,6 +895,44 @@ fn apply_podman_local_tls_defaults(
     podman.guest_tls_ca = Some(paths.ca);
     podman.guest_tls_cert = Some(paths.client_cert);
     podman.guest_tls_key = Some(paths.client_key);
+    Ok(())
+}
+
+/// Same pattern as [`kubernetes_config_from_file`] but for Docker.
+fn docker_config_from_file(file: Option<&config_file::ConfigFile>) -> Result<DockerComputeConfig> {
+    let Some(file) = file else {
+        return Ok(DockerComputeConfig::default());
+    };
+    let merged = config_file::driver_table(
+        ComputeDriverKind::Docker,
+        &file.openshell.gateway,
+        file.openshell.drivers.get("docker"),
+    );
+    merged
+        .try_into()
+        .map_err(|e| Error::config(format!("invalid [openshell.drivers.docker] table: {e}")))
+}
+
+fn apply_docker_local_tls_defaults(
+    config: &Config,
+    docker: &mut DockerComputeConfig,
+) -> Result<()> {
+    if config.tls.is_none()
+        || docker.guest_tls_ca.is_some()
+        || docker.guest_tls_cert.is_some()
+        || docker.guest_tls_key.is_some()
+    {
+        return Ok(());
+    }
+
+    let Some(paths) = defaults::complete_local_tls_paths()
+        .map_err(|e| Error::config(format!("failed to resolve local TLS defaults: {e}")))?
+    else {
+        return Ok(());
+    };
+    docker.guest_tls_ca = Some(paths.ca);
+    docker.guest_tls_cert = Some(paths.client_cert);
+    docker.guest_tls_key = Some(paths.client_key);
     Ok(())
 }
 
@@ -1545,6 +1584,21 @@ enable_bind_mounts = true
         .expect("valid config");
 
         let cfg = crate::podman_config_from_file(Some(&file)).expect("podman config");
+
+        assert!(cfg.enable_bind_mounts);
+    }
+
+    #[test]
+    fn docker_config_reads_bind_mount_opt_in_from_driver_table() {
+        let file: crate::config_file::ConfigFile = toml::from_str(
+            r"
+[openshell.drivers.docker]
+enable_bind_mounts = true
+",
+        )
+        .expect("valid config");
+
+        let cfg = crate::docker_config_from_file(Some(&file)).expect("docker config");
 
         assert!(cfg.enable_bind_mounts);
     }


### PR DESCRIPTION
## Summary

- Move Docker config construction from `cli.rs` into `lib.rs` to match the pattern used by Podman and Kubernetes drivers
- Docker config is now built inside `build_compute_runtime()` via `docker_config_from_file()` and `apply_docker_local_tls_defaults()`, eliminating the `docker_config` parameter from `run_server()` and `build_compute_runtime()`
- Colocate `docker_config_reads_bind_mount_opt_in_from_driver_table` test next to its constructor in `lib.rs`

## Related Issue

Closes https://github.com/NVIDIA/OpenShell/issues/1853

## Changes

### `crates/openshell-server/src/lib.rs`
- Add `docker_config_from_file()` — mirrors `podman_config_from_file()` / `kubernetes_config_from_file()`
- Add `apply_docker_local_tls_defaults()` — mirrors `apply_podman_local_tls_defaults()`
- Wire Docker branch in `build_compute_runtime()` to build config inline (matches Podman branch)
- Remove `docker_config` parameter from `run_server()` and `build_compute_runtime()`
- Move Docker config test from `cli.rs` to `lib.rs`

### `crates/openshell-server/src/cli.rs`
- Remove `build_docker_config()` function
- Remove `DockerComputeConfig` import
- Remove Docker config test (moved to `lib.rs`)
- Remove `docker_config` from `run_from_args()` call site

### `crates/openshell-server/src/compute/mod.rs`
- Fix pre-existing type mismatch in `driver_sandbox_spec_from_public` test (separate commit)

## Testing

- [x] `cargo test -p openshell-server` — 892 passed
- [x] `mise run ci` — full green
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean
- [x] No behavioral change — Docker driver config still inherits from gateway section, merges driver-specific overrides, and applies TLS defaults

## Checklist

- [x] Conventional Commits format
- [x] Signed-off-by (DCO)
- [x] No secrets or credentials
- [x] Scoped to issue at hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)