### PR TITLE
docs: fix good first issue link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ We use a vouch system. This exists because AI makes it trivial to generate plaus
 
 ### Finding Work
 
-Issues labeled [`good-first-issue`](https://github.com/NVIDIA/OpenShell/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue) are scoped, well-documented, and friendly to new contributors. Start there. If you need guidance, comment on the issue.
+Issues labeled [`good-first-issue`](https://github.com/NVIDIA/OpenShell/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are scoped, well-documented, and friendly to new contributors. Start there. If you need guidance, comment on the issue.
 
 All open issues are actionable — if it's in the issue tracker, it's ready to be worked on.
 


### PR DESCRIPTION
## Summary
- update the CONTRIBUTING.md good-first-issue search link to use the repository's existing `good first issue` label
- keep the link target scoped to open issues

## Validation
- `git diff --check`

Closes #2045