### PR TITLE
fix: use hickory-dns to avoid musl getaddrinfo failures in Kubernetes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ apollo-parser = "0.8.5"
 tower-mcp-types = "0.12.0"
 
 # HTTP client
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots", "hickory-dns"] }
 
 # WebSocket
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }


### PR DESCRIPTION
## Summary

Enable the `hickory-dns` feature on reqwest so the supervisor's router uses a pure-Rust DNS resolver instead of musl's `getaddrinfo`.

## Problem

The supervisor is statically linked with musl libc. musl's `getaddrinfo` sends A and AAAA DNS queries simultaneously on a single UDP socket. With Kubernetes' default `ndots:5` and 5 search domains, external FQDNs like `aiplatform.googleapis.com` (3 dots < 5) get expanded through all search domains first — 12+ concurrent queries whose responses arrive out of order, causing musl to return zero usable addresses. This manifests as 503 `"inference service unavailable"` on every inference call to external providers (Vertex AI, Anthropic API, etc.).

## Fix

One-line change in workspace `Cargo.toml`:

```diff
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots", "hickory-dns"] }
```

`hickory-dns` (formerly trust-dns) is a pure-Rust async DNS resolver. It bypasses musl's `getaddrinfo` entirely, eliminating the concurrent A+AAAA query issue regardless of `ndots` configuration. This also aligns with the supervisor's static-binary design — no libc dependency for DNS resolution.

## Verification

- `cargo check -p openshell-sandbox` — compiles cleanly
- `cargo check -p openshell-router` — compiles cleanly

Fixes #2053