### PR TITLE
refactor(core): remove unused extra bind addresses

### DIFF
--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -340,14 +340,6 @@ pub struct Config {
     /// When `None`, the dedicated metrics listener is disabled.
     pub metrics_bind_address: Option<SocketAddr>,
 
-    /// Additional bind addresses that serve the same multiplexed gRPC/HTTP
-    /// surface as `bind_address`.
-    ///
-    /// Compute drivers may register extra listeners during startup so that
-    /// sandbox workloads can call back into the gateway over an interface
-    /// that the operator-supplied `bind_address` does not expose.
-    pub extra_bind_addresses: Vec<SocketAddr>,
-
     /// Log level (trace, debug, info, warn, error).
     pub log_level: String,
 
@@ -579,7 +571,6 @@ impl Config {
             bind_address: default_bind_address(),
             health_bind_address: None,
             metrics_bind_address: None,
-            extra_bind_addresses: Vec::new(),
             log_level: default_log_level(),
             tls,
             oidc: None,
@@ -612,19 +603,6 @@ impl Config {
     #[must_use]
     pub const fn with_metrics_bind_address(mut self, addr: SocketAddr) -> Self {
         self.metrics_bind_address = Some(addr);
-        self
-    }
-
-    /// Append an extra listener address to the multiplex service.
-    ///
-    /// Duplicate entries (matching `bind_address` or any existing entry) are
-    /// silently dropped so callers can naively push driver-derived addresses
-    /// without checking for collisions.
-    #[must_use]
-    pub fn with_extra_bind_address(mut self, addr: SocketAddr) -> Self {
-        if addr != self.bind_address && !self.extra_bind_addresses.contains(&addr) {
-            self.extra_bind_addresses.push(addr);
-        }
         self
     }
 

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -381,10 +381,8 @@ pub(crate) async fn run_server(
     // Create the multiplexed service
     let service = MultiplexService::new(state.clone());
 
-    let mut extra_listener_addresses = config.extra_bind_addresses.clone();
-    extra_listener_addresses.extend_from_slice(state.compute.gateway_bind_addresses());
     let gateway_listener_addresses =
-        gateway_listener_addresses(config.bind_address, &extra_listener_addresses);
+        gateway_listener_addresses(config.bind_address, state.compute.gateway_bind_addresses());
     let mut gateway_listeners = Vec::with_capacity(gateway_listener_addresses.len());
     for address in gateway_listener_addresses {
         let listener = TcpListener::bind(address)

--- a/rfc/0003-gateway-configuration/README.md
+++ b/rfc/0003-gateway-configuration/README.md
@@ -68,7 +68,6 @@ version = 1                      # optional; reserved for future schema migratio
 bind_address          = "127.0.0.1:17670"  # default: 127.0.0.1:17670 (loopback)
 health_bind_address   = "0.0.0.0:8081"     # optional; omit to disable
 metrics_bind_address  = "0.0.0.0:9090"     # optional; omit to disable
-extra_bind_addresses  = []                 # additional listeners (driver callbacks, etc.)
 
 # Logging
 log_level             = "info"


### PR DESCRIPTION
## Summary

Remove the unused Config.extra_bind_addresses option while preserving compute-driver-derived gateway listeners.

## Related Issue

Closes #1952

## Changes

- Remove Config.extra_bind_addresses and its builder method
- Continue binding additional addresses reported by compute drivers
- Remove the stale option from the gateway configuration RFC example

## Testing

- [ ] mise run pre-commit passes (workspace tests hit an unrelated local macOS linker error: library not found for -lSystem)
- [x] mise exec -- cargo test -p openshell-core (296 passed)
- [x] mise exec -- cargo test -p openshell-server gateway_listener_addresses (2 passed)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)