### PR TITLE
fix(helm): generate namespace-aware SANs in certgen and cert-manager templates

### DIFF
--- a/deploy/helm/openshell/templates/_helpers.tpl
+++ b/deploy/helm/openshell/templates/_helpers.tpl
@@ -145,6 +145,24 @@ init-container
 {{- end }}
 
 {{/*
+Default server certificate DNS SANs derived from the release name and namespace.
+Returns a YAML list. Append extra SANs from values with range loops.
+*/}}
+{{- define "openshell.defaultServerDnsNames" -}}
+{{- $name := include "openshell.fullname" . -}}
+{{- $ns := .Release.Namespace -}}
+{{- list $name
+      (printf "%s.%s.svc" $name $ns)
+      (printf "%s.%s.svc.cluster.local" $name $ns)
+      "localhost"
+      (printf "%s.localhost" $name)
+      (printf "*.%s.localhost" $name)
+      "host.docker.internal"
+      "host.containers.internal"
+  | toYaml }}
+{{- end }}
+
+{{/*
 Gateway workload kind. StatefulSet is the default because the default SQLite
 database requires persistent per-pod storage.
 */}}

--- a/deploy/helm/openshell/templates/cert-manager-pki.yaml
+++ b/deploy/helm/openshell/templates/cert-manager-pki.yaml
@@ -55,7 +55,12 @@ spec:
   renewBefore: {{ .Values.certManager.certificateRenewBefore | quote }}
   commonName: openshell-server
   dnsNames:
-    {{- toYaml .Values.certManager.serverDnsNames | nindent 4 }}
+    {{- range (include "openshell.defaultServerDnsNames" . | fromYamlArray) }}
+    - {{ . | quote }}
+    {{- end }}
+    {{- range .Values.certManager.serverDnsNames }}
+    - {{ . | quote }}
+    {{- end }}
   {{- if .Values.certManager.serverIpAddresses }}
   ipAddresses:
     {{- toYaml .Values.certManager.serverIpAddresses | nindent 4 }}

--- a/deploy/helm/openshell/templates/certgen.yaml
+++ b/deploy/helm/openshell/templates/certgen.yaml
@@ -103,6 +103,10 @@ spec:
             {{- end }}
             - --jwt-secret-name={{ include "openshell.sandboxJwtSecretName" . }}
             {{- if and .Values.pkiInitJob.enabled (not .Values.certManager.enabled) }}
+            {{- range (include "openshell.defaultServerDnsNames" . | fromYamlArray) }}
+            - --server-san={{ . }}
+            {{- end }}
+            - --server-san=127.0.0.1
             {{- range .Values.pkiInitJob.serverDnsNames }}
             - --server-san={{ . }}
             {{- end }}


### PR DESCRIPTION
The certgen hook and cert-manager Certificate template hardcoded `openshell.openshell.svc.cluster.local` in server certificate SANs, breaking deployments in any namespace other than `openshell`. This PR adds an `openshell.defaultServerDnsNames` helper that derives SANs from `.Release.Namespace`, so the server certificate matches the actual service FQDN regardless of the target namespace.

## Summary

The certgen hook and cert-manager Certificate template hardcoded `openshell.openshell.svc.cluster.local` in server certificate SANs, breaking deployments in any namespace other than `openshell`. This PR adds an `openshell.defaultServerDnsNames` helper that derives SANs from `.Release.Namespace`, so the server certificate matches the actual service FQDN regardless of the target namespace.

## Related Issue

Closes #2060 by implementing option B (Helm-generated SANs).

## Changes

- **`_helpers.tpl`**: new `openshell.defaultServerDnsNames` helper that builds the default SAN list using `.Release.Namespace` via `list` + `toYaml`
- **`certgen.yaml`**: iterate the helper output with `fromYamlArray` to pass namespace-aware `--server-san` args to the certgen binary
- **`cert-manager-pki.yaml`**: replace `toYaml .Values.certManager.serverDnsNames` with the same helper loop for the Certificate `dnsNames` field, appending user-provided extra SANs from values

Note: the Rust `DEFAULT_SERVER_SANS` constant in `pki.rs` still adds the hardcoded `openshell.openshell.svc` SANs alongside the Helm-generated ones. This results in harmless duplicate/extra SANs in the certificate. Fully removing the Rust defaults is tracked as option A in #2060.

## Testing

- Deployed the patched chart in namespace `openshell-system` on OpenShift (ROSA HCP 4.21)
- Verified the generated server certificate contains `openshell.openshell-system.svc.cluster.local` in SANs
- Confirmed sandbox supervisor mTLS connections succeed (no `BadCertificate` errors) — previously failed with `TLS handshake failed error=received fatal alert: BadCertificate`
- Verified `helm template` renders correctly for both `openshell` and `openshell-system` namespaces
- Verified cert-manager path renders correctly with `--set certManager.enabled=true`
- [x] `mise run pre-commit` — helm:lint fails on main too (missing postgresql dependency, pre-existing)
- [ ] Unit tests added/updated
- [x] E2E tests added/updated (if applicable) — N/A, Helm template change only

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — N/A