### PR TITLE
docs(mcp): fix granular policy lifecycle examples

### DIFF
--- a/docs/reference/policy-schema.mdx
+++ b/docs/reference/policy-schema.mdx
@@ -296,7 +296,7 @@ Use `rules` for MCP allow rules and `deny_rules` for MCP deny rules. Deny rules 
 | `tool` | string or matcher | No | Convenience matcher for `tools/call` `params.name`. Supports a glob string or `{ any: [...] }`. Requires `method: tools/call` unless `mcp.allow_all_known_mcp_methods` is `true`; validation fails otherwise. Omit to match every tool. |
 | `params` | map | No | MCP currently accepts only `params.name` as a lower-level tool-name matcher. Requires `method: tools/call` unless `mcp.allow_all_known_mcp_methods` is `true`; validation fails otherwise. Tool argument matching is not supported yet; allowed tools accept all argument payloads by default. |
 
-Example MCP rules:
+An MCP client first sends `initialize`. After the server returns a successful response, the client sends `notifications/initialized`. After initialization completes and the server advertises the `tools` capability, the client can call an advertised tool. The response does not need an allow rule because these rules inspect messages sent from the client to the server. This example adds both client initialization messages to the existing tool rules. It omits `tools/list` because it assumes the client already knows the tool names; add that method when the client performs discovery.
 
 ```yaml showLineNumbers={false}
 endpoints:
@@ -308,6 +308,10 @@ endpoints:
     mcp:
       max_body_bytes: 131072
     rules:
+      - allow:
+          method: initialize
+      - allow:
+          method: notifications/initialized
       - allow:
           method: tools/call
           tool: search_web

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -590,6 +590,8 @@ MCP policy enforcement is directional. It applies to HTTP request bodies sent by
 
 MCP and JSON-RPC endpoint policies currently require full policy YAML applied with `openshell policy set`; the incremental `openshell policy update --add-endpoint` parser does not accept `mcp` or `json-rpc` as protocols.
 
+An MCP client first sends `initialize`. After the server returns a successful response, the client sends `notifications/initialized`. After initialization completes and the server advertises the `tools` capability, the client can call an advertised tool. The response does not need an allow rule because these rules inspect messages sent from the client to the server. This example adds both client initialization messages to the existing tool rules. It omits `tools/list` because it assumes the client already knows the tool names; add that method when the client performs discovery.
+
 ```yaml showLineNumbers={false}
   mcp_server:
     name: mcp_server
@@ -602,6 +604,10 @@ MCP and JSON-RPC endpoint policies currently require full policy YAML applied wi
         mcp:
           max_body_bytes: 131072
         rules:
+          - allow:
+              method: initialize
+          - allow:
+              method: notifications/initialized
           - allow:
               method: tools/call
               tool: read_status


### PR DESCRIPTION
## Summary
This PR makes the granular MCP policy examples usable by a conforming client. Each copied example permits the client initialize request and initialized notification before its existing tool allow and deny rules, while explaining that discovery is optional when the client already knows the tool names.

## Related Issue
https://github.com/NVIDIA/OpenShell/issues/2065

## Changes
- Documentation change: Describe the required sequence as client `initialize`, successful server response, client `notifications/initialized`, then tool operations advertised by a server that negotiated the `tools` capability. Explain that the server response needs no client-to-server allow rule and that `tools/list` is optional when the client already knows the tool names.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
