### PR TITLE
fix(supervisor): fail fast with diagnostic error when CAP_SETPCAP is unavailable

### DIFF
--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -19,7 +19,11 @@ capability bounding set during privilege drop so later execs cannot regain
 container-granted capabilities. This is fail-closed: the supervisor retains
 `CAP_SETPCAP` solely to perform the clear, and spawning the workload or SSH shell
 aborts unless the bounding set ends up empty. A `setpcap` `EPERM` is tolerated
-only when the set is already empty; any other outcome fails the spawn.
+only when the set is already empty; any other outcome fails the spawn. Because
+the clear runs inside `pre_exec`, which cannot emit structured logs, the parent
+probes `PR_CAPBSET_DROP` availability before forking and refuses the spawn with
+a diagnostic error and an OCSF `DetectionFinding` when `CAP_SETPCAP` is
+unavailable (for example, when the container runtime did not grant it).
 
 ## Startup Flow
 

--- a/crates/openshell-supervisor-process/src/process.rs
+++ b/crates/openshell-supervisor-process/src/process.rs
@@ -234,10 +234,85 @@ fn validate_capability_bounding_set_clear(
                 "Failed to clear unknown child capability bounding set entries: {unknown_err}"
             )),
         },
+        Err(err) if err.code() == libc::EPERM => Err(miette::miette!(
+            "Failed to clear child capability bounding set: CAP_SETPCAP is not in the \
+             effective set (EPERM) and capabilities remain raised: {remaining:?}; \
+             configure the container runtime to grant CAP_SETPCAP to the supervisor"
+        )),
         Err(err) => Err(miette::miette!(
             "Failed to clear child capability bounding set: {err}"
         )),
     }
+}
+
+/// Preflight check for the child capability bounding-set clear, run in the
+/// parent before `fork()`. The clear is fail-closed inside `pre_exec`, a
+/// context that cannot reliably emit structured logs — without this check a
+/// blocked clear surfaces only as an opaque child exit.
+///
+/// The probe tries a non-destructive `bounding::drop()` on a capability
+/// that is already absent from the bounding set. This triggers the same
+/// `prctl(PR_CAPBSET_DROP)` syscall that `bounding::clear()` uses, so
+/// environments where `CAP_SETPCAP` is missing from the effective set
+/// (e.g. container runtimes that do not grant it, LSM restrictions) are
+/// detected here. On detection, emit an OCSF `DetectionFinding` and refuse
+/// the spawn with a diagnostic error.
+#[cfg(target_os = "linux")]
+fn check_capability_bounding_set_readiness() -> Result<()> {
+    // The child clears the bounding set only when it starts as root.
+    if !nix::unistd::geteuid().is_root() {
+        return Ok(());
+    }
+
+    let bounding = capctl::caps::bounding::probe();
+    // An EPERM clear is tolerated when the set is already empty.
+    if bounding.is_empty() {
+        return Ok(());
+    }
+
+    // Find a capability NOT in the bounding set so that drop() is a no-op
+    // when the syscall is permitted.  If every known capability is raised
+    // (unusual), skip the probe — clear() is attempted in the child and
+    // fails the spawn there.
+    let probe_cap = capctl::caps::Cap::iter().find(|cap| !bounding.has(*cap));
+    let clear_blocked = probe_cap.is_some_and(|cap| {
+        capctl::caps::bounding::drop(cap).is_err_and(|e| e.code() == libc::EPERM)
+    });
+
+    if !clear_blocked {
+        return Ok(());
+    }
+
+    openshell_ocsf::ocsf_emit!(
+        openshell_ocsf::DetectionFindingBuilder::new(openshell_ocsf::ctx::ctx())
+            .activity(openshell_ocsf::ActivityId::Open)
+            .severity(openshell_ocsf::SeverityId::High)
+            .confidence(openshell_ocsf::ConfidenceId::High)
+            .is_alert(true)
+            .finding_info(
+                openshell_ocsf::FindingInfo::new(
+                    "bounding-set-clear-blocked",
+                    "Capability Bounding Set Clear Blocked",
+                )
+                .with_desc(
+                    "The supervisor cannot clear the child capability bounding set \
+                     because PR_CAPBSET_DROP returns EPERM — CAP_SETPCAP is not \
+                     in the effective set. The spawn is refused to keep privilege \
+                     drop fail-closed. Configure the container runtime to grant \
+                     CAP_SETPCAP to the supervisor.",
+                ),
+            )
+            .message(format!(
+                "PR_CAPBSET_DROP blocked, refusing spawn with non-empty capability bounding set: {bounding:?}"
+            ))
+            .build()
+    );
+
+    Err(miette::miette!(
+        "Cannot clear the child capability bounding set: PR_CAPBSET_DROP returns EPERM \
+         (CAP_SETPCAP is not in the effective set) and capabilities remain raised: {bounding:?}; \
+         configure the container runtime to grant CAP_SETPCAP to the supervisor"
+    ))
 }
 
 // Pins the pre-seccomp child mount namespace where supervisor identity sockets
@@ -605,6 +680,15 @@ impl ProcessHandle {
         #[cfg(target_os = "linux")]
         if enforcement_mode.enforces_child_sandbox() {
             sandbox::linux::log_sandbox_readiness(policy, workdir);
+        }
+
+        // Fail fast when the child's capability bounding-set clear would
+        // fail: the clear is fail-closed inside pre_exec, which cannot emit
+        // structured logs, so the parent probes first and refuses the spawn
+        // with a diagnostic error and an OCSF finding.
+        #[cfg(target_os = "linux")]
+        if enforcement_mode.uses_privileged_process_setup() {
+            check_capability_bounding_set_readiness()?;
         }
 
         // Phase 1: Prepare Landlock ruleset by opening PathFds.
@@ -1544,6 +1628,21 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "linux")]
+    fn capability_bounding_set_readiness_matches_clear_availability() {
+        let result = check_capability_bounding_set_readiness();
+        if !nix::unistd::geteuid().is_root()
+            || capctl::caps::bounding::probe().is_empty()
+            || capability_bounding_set_clear_available()
+        {
+            assert!(result.is_ok(), "readiness check failed: {result:?}");
+        } else {
+            let msg = format!("{}", result.unwrap_err());
+            assert!(msg.contains("CAP_SETPCAP"), "unexpected error: {msg}");
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
     fn capability_bounding_set_clear_accepts_empty_eperm() {
         let remaining = capctl::caps::CapSet::empty();
 
@@ -1570,12 +1669,9 @@ mod tests {
         );
 
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Failed to clear child capability bounding set")
-        );
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Failed to clear child capability bounding set"));
+        assert!(msg.contains("CAP_SETPCAP"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When the supervisor lacks `CAP_SETPCAP` in its effective set (for example, a container runtime that does not grant it), the child's `prctl(PR_CAPBSET_DROP)` returns `EPERM` during privilege drop. The clear runs inside `pre_exec`, which cannot emit structured logs, so the failure surfaced only as an opaque child exit with code 1.

Following the review discussion, this PR keeps the bounding-set clear **fail-closed** — no tolerance path, no degraded mode — and instead makes the failure diagnosable:

- A parent-side preflight probes `PR_CAPBSET_DROP` availability before `fork()`. When the clear would fail with a non-empty bounding set, it emits an OCSF `DetectionFinding` alert and refuses the spawn with an actionable error, instead of letting the child die inside `pre_exec` where structured logging is unavailable.
- The child-side `EPERM` error in `validate_capability_bounding_set_clear()` now carries the same `CAP_SETPCAP` diagnosis and remediation hint, as a backstop for environments the parent probe cannot predict.

The version-skew trigger that originally surfaced this (older gateway pulling a newer `:latest` supervisor image) was fixed separately by #2070, which closed #2068. This PR addresses the remaining gap from #2069: a supervisor that cannot clear the bounding set should fail fast with a clear diagnosis rather than an undiagnosable crash.

## Related Issue

Related to #2069

## Changes

- **`crates/openshell-supervisor-process/src/process.rs`**:
  - Add `check_capability_bounding_set_readiness()`, called before `fork()` under `uses_privileged_process_setup()`. It probes with a non-destructive `bounding::drop()` on a capability already absent from the bounding set (the same `prctl(PR_CAPBSET_DROP)` syscall `bounding::clear()` uses), and on `EPERM` with a non-empty set emits a High-severity OCSF `DetectionFinding` and fails the spawn with a diagnostic error.
  - Extend the `EPERM` + non-empty arm of `validate_capability_bounding_set_clear()` to return a diagnostic error naming `CAP_SETPCAP` and the remediation, keeping the existing fail-closed behavior.
  - Add `capability_bounding_set_readiness_matches_clear_availability` test; strengthen `capability_bounding_set_clear_rejects_nonempty_eperm` to assert the `CAP_SETPCAP` diagnosis.
- **`architecture/sandbox.md`**: Keep the fail-closed invariant text and document the parent-side preflight (diagnostic error + OCSF finding when `CAP_SETPCAP` is unavailable).

Compared to the previous revision of this PR: the `EPERM`-tolerance branch, the degraded-mode documentation, and the `rootless-caps` CI job are all dropped per review feedback.

## Testing

- [x] `cargo test -p openshell-supervisor-process --lib -- capability_bounding drop_privileges` — 15 passed (rust:1.95 Linux container)
- [x] Same suite in a container with `--cap-drop SETPCAP` (root, non-empty bounding set, denied `PR_CAPBSET_DROP`) — 15 passed; `drop_privileges_succeeds_for_current_group` exercises the fail-closed error path and the new readiness test hits its error branch with the `CAP_SETPCAP` diagnosis
- [x] `cargo clippy -p openshell-supervisor-process --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated
