### PR TITLE
refactor(api): remove SandboxTemplate.volume_claim_templates

### DIFF
--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -1298,17 +1298,6 @@ fn sandbox_to_k8s_spec(
 ) -> serde_json::Value {
     let mut root = serde_json::Map::new();
 
-    // Determine early whether the user provided custom volumeClaimTemplates.
-    // When they haven't, we inject a default workspace VCT and corresponding
-    // init container + volume mount so sandbox data persists.  We need this
-    // flag before building the podTemplate because the workspace persistence
-    // transforms are applied inside sandbox_template_to_k8s.
-    let user_has_vct = spec
-        .and_then(|s| s.template.as_ref())
-        .and_then(|t| platform_config_struct(t, "volume_claim_templates"))
-        .is_some();
-    let inject_workspace = !user_has_vct;
-
     if let Some(spec) = spec {
         let pod_env = spec_pod_env(Some(spec));
         if let Some(template) = spec.template.as_ref() {
@@ -1318,7 +1307,7 @@ fn sandbox_to_k8s_spec(
                     template,
                     driver_gpu_requirements(spec.resource_requirements.as_ref()),
                     &pod_env,
-                    inject_workspace,
+                    true,
                     params,
                 ),
             );
@@ -1328,22 +1317,13 @@ fn sandbox_to_k8s_spec(
                     serde_json::json!(template.agent_socket_path),
                 );
             }
-            if let Some(volume_templates) =
-                platform_config_struct(template, "volume_claim_templates")
-            {
-                root.insert("volumeClaimTemplates".to_string(), volume_templates);
-            }
         }
     }
 
-    // Inject the default workspace volumeClaimTemplate when the user didn't
-    // provide their own.
-    if inject_workspace {
-        root.insert(
-            "volumeClaimTemplates".to_string(),
-            default_workspace_volume_claim_templates(params.workspace_default_storage_size),
-        );
-    }
+    root.insert(
+        "volumeClaimTemplates".to_string(),
+        default_workspace_volume_claim_templates(params.workspace_default_storage_size),
+    );
 
     // podTemplate is required by the Kubernetes CRD - ensure it's always present
     if !root.contains_key("podTemplate") {
@@ -1354,7 +1334,7 @@ fn sandbox_to_k8s_spec(
                 &SandboxTemplate::default(),
                 driver_gpu_requirements(spec.and_then(|s| s.resource_requirements.as_ref())),
                 &pod_env,
-                inject_workspace,
+                true,
                 params,
             ),
         );

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -1666,8 +1666,8 @@ fn extract_typed_resources(
 }
 
 /// Build the opaque `platform_config` Struct from platform-specific public
-/// template fields (`runtime_class_name`, annotations, `volume_claim_templates`)
-/// plus any resource fields beyond CPU/memory.
+/// template fields (`runtime_class_name`, annotations) plus any resource fields
+/// beyond CPU/memory.
 fn build_platform_config(template: &SandboxTemplate) -> Option<prost_types::Struct> {
     use prost_types::{Struct, Value, value::Kind};
 
@@ -1701,16 +1701,6 @@ fn build_platform_config(template: &SandboxTemplate) -> Option<prost_types::Stru
                 kind: Some(Kind::StructValue(Struct {
                     fields: annotation_fields,
                 })),
-            },
-        );
-    }
-
-    // Pass through the raw volume_claim_templates Struct as a nested value.
-    if let Some(ref vct) = template.volume_claim_templates {
-        fields.insert(
-            "volume_claim_templates".to_string(),
-            Value {
-                kind: Some(Kind::StructValue(vct.clone())),
             },
         );
     }

--- a/crates/openshell-server/src/grpc/validation.rs
+++ b/crates/openshell-server/src/grpc/validation.rs
@@ -206,14 +206,6 @@ fn validate_sandbox_template(tmpl: &SandboxTemplate) -> Result<(), Status> {
             )));
         }
     }
-    if let Some(ref s) = tmpl.volume_claim_templates {
-        let size = s.encoded_len();
-        if size > MAX_TEMPLATE_STRUCT_SIZE {
-            return Err(Status::invalid_argument(format!(
-                "template.volume_claim_templates serialized size exceeds maximum ({size} > {MAX_TEMPLATE_STRUCT_SIZE})"
-            )));
-        }
-    }
     if let Some(ref s) = tmpl.driver_config {
         let size = s.encoded_len();
         if size > MAX_TEMPLATE_STRUCT_SIZE {

--- a/proto/openshell.proto
+++ b/proto/openshell.proto
@@ -362,8 +362,8 @@ message SandboxTemplate {
   map<string, string> environment = 6;
   // Platform-specific compute resource requirements and limits.
   google.protobuf.Struct resources = 7;
-  // Optional platform-specific volume claim templates.
-  google.protobuf.Struct volume_claim_templates = 9;
+  reserved 9;
+  reserved "volume_claim_templates";
   // Enable Kubernetes user namespace isolation (hostUsers: false).
   // When true, container UID 0 maps to a non-root host UID and capabilities
   // become namespaced. Requires Kubernetes 1.33+ with user namespace support


### PR DESCRIPTION
## Summary

Remove `SandboxTemplate.volume_claim_templates` from the public API. The field was added during the Kubernetes driver extraction refactor (#817) but was never surfaced to users — no CLI flag, no Python SDK helper, no documentation. The only way to reach it was raw gRPC construction.

The Kubernetes driver now unconditionally injects the default workspace PVC, removing the branching logic that existed to accommodate user-supplied VCTs. Field number 9 is reserved in the proto to prevent future reuse.

See also #2034 (feat(kubernetes): support PVC subPath driver config), which covers the supported path for PVC customisation via driver config.

## Related Issue

N/A

## Changes

- `proto/openshell.proto`: removed field 9, added `reserved 9` / `reserved "volume_claim_templates"`
- `crates/openshell-server/src/grpc/validation.rs`: removed size-limit validation for the field
- `crates/openshell-server/src/compute/mod.rs`: removed pass-through in `build_platform_config()`
- `crates/openshell-driver-kubernetes/src/driver.rs`: removed `user_has_vct`/`inject_workspace` branching; default workspace VCT is now always injected

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests pass (3 pre-existing failures on `main` unrelated to this change)
- [ ] E2E tests added/updated (not applicable — no behaviour change for existing users)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)