### PR TITLE
fix(podman): diagnostics for containerized rootless socket + subuid preflight

### DIFF
--- a/crates/openshell-driver-podman/README.md
+++ b/crates/openshell-driver-podman/README.md
@@ -393,11 +393,14 @@ resolution, making the proxy's ACLs the effective egress control.
 The Podman driver is designed for rootless operation. The following adaptations
 matter compared to cluster or rootful runtimes:
 
-1. subuid/subgid preflight check: on non-macOS hosts, `check_subuid_range()` in
-   `driver.rs` warns operators if `/etc/subuid` or `/etc/subgid` entries are
-   missing for the current user. This is not a hard error because some systems
-   use LDAP or other mechanisms. macOS skips the check because `podman machine`
-   runs the Podman service inside a Linux VM.
+1. subuid/subgid preflight check: on non-macOS, non-root hosts,
+   `check_subuid_range()` in `driver.rs` warns operators if `/etc/subuid` or
+   `/etc/subgid` entries are missing for the current user. This is not a hard
+   error because some systems use LDAP or other mechanisms. The check is
+   skipped when the gateway itself runs in a container because those files do
+   not describe the Podman host. For containerized gateways using a mounted
+   rootless Podman socket, run the gateway container with `--userns=keep-id` so
+   its UID matches the host user that owns the socket.
 2. cgroups v2 requirement: the driver refuses to start if cgroups v1 is
    detected. Rootless Podman requires the unified cgroup hierarchy.
 3. `nsenter` for namespace operations: `openshell-sandbox` uses

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -276,6 +276,7 @@ impl PodmanComputeDriver {
                 Ok(()) => break,
                 Err(e) if attempts < MAX_PING_RETRIES => {
                     attempts += 1;
+                    let e = enrich_socket_connection_error(e, running_inside_container());
                     warn!(
                         attempt = attempts,
                         max_retries = MAX_PING_RETRIES,
@@ -284,7 +285,12 @@ impl PodmanComputeDriver {
                     );
                     tokio::time::sleep(PING_RETRY_DELAY).await;
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    return Err(enrich_socket_connection_error(
+                        e,
+                        running_inside_container(),
+                    ));
+                }
             }
         }
 
@@ -316,7 +322,11 @@ impl PodmanComputeDriver {
         // Rootless pre-flight: warn if subuid/subgid ranges look missing.
         // Not a hard error because some systems configure these via LDAP or
         // other mechanisms that /etc/subuid does not reflect.
-        if !cfg!(target_os = "macos") && rustix::process::getuid().as_raw() != 0 {
+        if should_check_subuid_range(
+            cfg!(target_os = "macos"),
+            rustix::process::getuid().as_raw() == 0,
+            running_inside_container(),
+        ) {
             check_subuid_range();
         }
 
@@ -911,6 +921,35 @@ fn supervisor_image_pull_policy(image: &str) -> &'static str {
     }
 }
 
+fn running_inside_container() -> bool {
+    Path::new("/run/.containerenv").exists() || Path::new("/.dockerenv").exists()
+}
+
+fn enrich_socket_connection_error(
+    err: PodmanApiError,
+    is_containerized_gateway: bool,
+) -> PodmanApiError {
+    match err {
+        // PodmanClient has already flattened io::Error into this connection message.
+        PodmanApiError::Connection(message)
+            if is_containerized_gateway && message.contains("Permission denied") =>
+        {
+            PodmanApiError::Connection(format!(
+                "{message}. Gateway is running inside a container and cannot access the mounted Podman socket; for rootless Podman socket deployments run the gateway container with --userns=keep-id so the container UID matches the host user that owns the socket"
+            ))
+        }
+        other => other,
+    }
+}
+
+fn should_check_subuid_range(
+    is_macos: bool,
+    is_root: bool,
+    is_containerized_gateway: bool,
+) -> bool {
+    !is_macos && !is_root && !is_containerized_gateway
+}
+
 /// Check whether the current user has subuid/subgid ranges configured.
 ///
 /// Rootless Podman requires entries in `/etc/subuid` and `/etc/subgid` for
@@ -1031,6 +1070,53 @@ mod tests {
     fn podman_driver_error_from_not_found() {
         let err = ComputeDriverError::from(PodmanApiError::NotFound("gone".into()));
         assert!(matches!(err, ComputeDriverError::Message(_)));
+    }
+
+    #[test]
+    fn socket_permission_error_in_container_includes_keep_id_guidance() {
+        let err = enrich_socket_connection_error(
+            PodmanApiError::Connection("Permission denied".into()),
+            true,
+        );
+
+        assert!(err.to_string().contains("Permission denied"));
+        assert!(err.to_string().contains("--userns=keep-id"));
+    }
+
+    #[test]
+    fn socket_permission_error_on_host_is_unchanged() {
+        let err = enrich_socket_connection_error(
+            PodmanApiError::Connection("Permission denied".into()),
+            false,
+        );
+
+        assert_eq!(err.to_string(), "connection error: Permission denied");
+    }
+
+    #[test]
+    fn unrelated_socket_error_in_container_is_unchanged() {
+        let err = enrich_socket_connection_error(
+            PodmanApiError::Connection("Connection refused".into()),
+            true,
+        );
+
+        assert_eq!(err.to_string(), "connection error: Connection refused");
+    }
+
+    #[test]
+    fn subuid_preflight_skips_containerized_gateway() {
+        assert!(!should_check_subuid_range(false, false, true));
+    }
+
+    #[test]
+    fn subuid_preflight_runs_for_non_root_linux_host() {
+        assert!(should_check_subuid_range(false, false, false));
+    }
+
+    #[test]
+    fn subuid_preflight_skips_root_and_macos() {
+        assert!(!should_check_subuid_range(false, true, false));
+        assert!(!should_check_subuid_range(true, false, false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Improve Podman diagnostics and preflight behavior when the OpenShell gateway runs inside a container. Containerized gateways now report actionable guidance for rootless Podman socket permission failures and avoid misleading subordinate-ID warnings based on the container's filesystem rather than the Podman host.

This resolves the subuid/subgid false positive from #1909. It adds operator guidance for the separate `--userns=keep-id` socket ownership problem but does not automatically fix that configuration.

This PR no longer changes callback listener discovery or gateway network exposure; that design work is being handled separately.

## Related Issue

Refs #1909

## Changes

- Detect when the gateway process is running inside a container.
- Add `--userns=keep-id` guidance when a containerized gateway cannot access a mounted rootless Podman socket due to `Permission denied`.
- Apply the enriched diagnostic to both Podman socket retry warnings and the final connection error.
- Skip the local `/etc/subuid` and `/etc/subgid` preflight inside gateway containers, where those files do not describe the host running the Podman service.
- Preserve existing diagnostics and preflight behavior for direct-host deployments, root, macOS, and unrelated connection errors.
- Document the container skip and `--userns=keep-id` guidance in the Podman driver README.
- Add focused unit coverage for the new diagnostic and preflight decisions.

## Testing

- [ ] `mise run pre-commit` passes (`mise` is unavailable in the current environment)
- [x] `cargo test -p openshell-driver-podman --lib`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p openshell-driver-podman --all-targets -- -D warnings`
- [x] `git diff --check upstream/main...HEAD`
- [x] Unit tests added/updated
- [x] E2E tests not applicable; this change only affects startup diagnostics and a host preflight warning

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs not applicable; no runtime boundaries, callback behavior, or configuration changed
