### PR TITLE
test(e2e): run rootless podman on ubuntu host

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,13 +37,6 @@ jobs:
           - suite: rust-docker
             cmd: "mise run --no-deps --skip-deps e2e:rust"
             apt_packages: "openssh-client"
-          - suite: rust-podman
-            cmd: "mise run --no-deps --skip-deps e2e:podman"
-            apt_packages: "openssh-client podman"
-          - suite: rust-podman-rootless
-            cmd: "mise run --no-deps --skip-deps e2e:podman:rootless"
-            apt_packages: "openssh-client podman uidmap"
-            rootless: true
           - suite: mcp
             cmd: "mise run --no-deps --skip-deps e2e:mcp"
             apt_packages: ""
@@ -89,28 +82,6 @@ jobs:
       - name: Log in to GHCR with Docker
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      - name: Log in to GHCR with Podman
-        if: startsWith(matrix.suite, 'rust-podman')
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
-
-      - name: Set up rootless Podman user
-        if: matrix.rootless
-        run: |
-          useradd -m openshell-test
-          echo "openshell-test:100000:65536" >> /etc/subuid
-          echo "openshell-test:100000:65536" >> /etc/subgid
-          mkdir -p "/run/user/$(id -u openshell-test)"
-          chown openshell-test: "/run/user/$(id -u openshell-test)"
-          chmod 700 "/run/user/$(id -u openshell-test)"
-          chown -R openshell-test: .
-          mkdir -p /home/openshell-test/.cache/mise /home/openshell-test/.cargo /home/openshell-test/.local/state/mise
-          chown -R openshell-test: /home/openshell-test/.cache /home/openshell-test/.cargo /home/openshell-test/.local
-          install -m 0755 "$(command -v mise)" /usr/local/bin/mise
-          chmod a+x /root /root/.local /root/.local/bin
-          for dir in /root/.cargo /root/.rustup /root/.local/share/mise /opt/mise; do
-            [ -d "$dir" ] && chmod -R a+rX "$dir"
-          done
-
       - name: Install Python dependencies and generate protobuf stubs
         if: matrix.suite == 'python'
         run: uv sync --frozen && mise run --no-deps python:proto
@@ -119,27 +90,81 @@ jobs:
         env:
           OPENSHELL_SUPERVISOR_IMAGE: ${{ format('ghcr.io/nvidia/openshell/supervisor:{0}', inputs.image-tag) }}
           OPENSHELL_MCP_CONFORMANCE_CLIENT_IMAGE: ${{ format('openshell-mcp-conformance-client:{0}', inputs.image-tag) }}
-          E2E_CMD: ${{ matrix.cmd }}
+        run: ${{ matrix.cmd }}
+
+  e2e-podman-rootless:
+    name: E2E (rust-podman-rootless)
+    # Run directly on the Ubuntu host so the test observes the host's AppArmor
+    # and unprivileged-user-namespace policy. A privileged job container masks
+    # the restrictions that production rootless Podman installations enforce.
+    runs-on: ubuntu-26.04
+    timeout-minutes: 30
+    env:
+      IMAGE_TAG: ${{ inputs.image-tag }}
+      MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OPENSHELL_REGISTRY: ghcr.io/nvidia/openshell
+      OPENSHELL_REGISTRY_HOST: ghcr.io
+      OPENSHELL_REGISTRY_NAMESPACE: nvidia/openshell
+      OPENSHELL_REGISTRY_USERNAME: ${{ github.actor }}
+      OPENSHELL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      OPENSHELL_SUPERVISOR_IMAGE: ${{ format('ghcr.io/nvidia/openshell/supervisor:{0}', inputs.image-tag) }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs['checkout-ref'] || github.sha }}
+          persist-credentials: false
+
+      - name: Install mise
         run: |
-          if [ "${{ matrix.rootless }}" = "true" ]; then
-            TESTUID="$(id -u openshell-test)"
-            runuser -u openshell-test -- env \
-              XDG_RUNTIME_DIR="/run/user/${TESTUID}" \
-              HOME="/home/openshell-test" \
-              PATH="/usr/local/bin:/root/.cargo/bin:/opt/mise/shims:/root/.local/bin:${PATH}" \
-              CARGO_HOME="/home/openshell-test/.cargo" \
-              RUSTUP_HOME="/root/.rustup" \
-              MISE_DATA_DIR="/opt/mise" \
-              MISE_CACHE_DIR="/home/openshell-test/.cache/mise" \
-              MISE_STATE_DIR="/home/openshell-test/.local/state/mise" \
-              OPENSHELL_SUPERVISOR_IMAGE="${OPENSHELL_SUPERVISOR_IMAGE}" \
-              OPENSHELL_REGISTRY="${OPENSHELL_REGISTRY}" \
-              OPENSHELL_REGISTRY_HOST="${OPENSHELL_REGISTRY_HOST}" \
-              OPENSHELL_REGISTRY_USERNAME="${OPENSHELL_REGISTRY_USERNAME}" \
-              OPENSHELL_REGISTRY_PASSWORD="${OPENSHELL_REGISTRY_PASSWORD}" \
-              IMAGE_TAG="${IMAGE_TAG}" \
-              MISE_GITHUB_TOKEN="${MISE_GITHUB_TOKEN}" \
-              bash -c "${E2E_CMD}"
-          else
-            ${E2E_CMD}
+          curl https://mise.run | MISE_VERSION=v2026.4.25 sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/share/mise/shims" >> "$GITHUB_PATH"
+
+      - name: Install tools
+        run: mise install --locked
+
+      - name: Install Podman and build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            clang \
+            fuse-overlayfs \
+            libssl-dev \
+            libz3-dev \
+            openssh-client \
+            passt \
+            pkg-config \
+            podman \
+            slirp4netns \
+            uidmap
+
+      - name: Configure rootless Podman
+        run: |
+          set -euo pipefail
+          if ! grep -q "^${USER}:" /etc/subuid; then
+            sudo usermod --add-subuids 100000-165535 "$USER"
           fi
+          if ! grep -q "^${USER}:" /etc/subgid; then
+            sudo usermod --add-subgids 100000-165535 "$USER"
+          fi
+          runtime_dir="/run/user/$(id -u)"
+          sudo install -d -m 0700 -o "$(id -u)" -g "$(id -g)" "$runtime_dir"
+          echo "XDG_RUNTIME_DIR=$runtime_dir" >> "$GITHUB_ENV"
+
+      - name: Verify rootless Podman environment
+        run: |
+          set -euo pipefail
+          podman_version="$(podman version --format '{{.Client.Version}}')"
+          case "$podman_version" in
+            5.*) ;;
+            *) echo "ERROR: expected Podman 5.x, found $podman_version" >&2; exit 1 ;;
+          esac
+          test "$(podman info --format '{{.Host.Security.Rootless}}')" = "true"
+          test "$(sudo sysctl -n kernel.apparmor_restrict_unprivileged_userns)" = "1"
+
+      - name: Log in to GHCR with Podman
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Run rootless Podman E2E
+        run: mise run --no-deps --skip-deps e2e:podman:rootless

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -103,16 +103,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Ubuntu 24.04 reproduces #2069: AppArmor blocks PR_CAPBSET_DROP
-          # while CAP_SETPCAP remains in the bounding set.
+          # Ubuntu 24.04 matches the environment reported in #2069 and ships
+          # Podman 4.x. The probe records whether AppArmor blocks the drop.
           - runner: ubuntu-24.04
             podman_major: "4"
-            expected_capbset_drop: eperm
-          # Ubuntu 26.04 provides the supported Podman 5.x coverage and, as of
-          # runner image 20260622.50.1, permits the same bounding-set drop.
+          # Ubuntu 26.04 provides the supported Podman 5.x coverage for
+          # comparison with the Ubuntu 24.04 environment.
           - runner: ubuntu-26.04
             podman_major: "5"
-            expected_capbset_drop: success
     env:
       IMAGE_TAG: ${{ inputs.image-tag }}
       MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -186,8 +184,6 @@ jobs:
           podman info --debug
 
       - name: Probe rootless capability bounding set
-        env:
-          EXPECTED_CAPBSET_DROP: ${{ matrix.expected_capbset_drop }}
         run: |
           set -euo pipefail
           probe="$RUNNER_TEMP/openshell-capbset-probe"
@@ -198,7 +194,7 @@ jobs:
             --cap-add=SETPCAP \
             --volume "$probe:/openshell-capbset-probe:ro" \
             docker.io/library/alpine:3.22 \
-            /openshell-capbset-probe "$EXPECTED_CAPBSET_DROP"
+            /openshell-capbset-probe
 
       - name: Log in to GHCR with Podman
         run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -93,12 +93,26 @@ jobs:
         run: ${{ matrix.cmd }}
 
   e2e-podman-rootless:
-    name: E2E (rust-podman-rootless)
+    name: E2E (rust-podman-rootless, ${{ matrix.runner }})
     # Run directly on the Ubuntu host so the test observes the host's AppArmor
     # and unprivileged-user-namespace policy. A privileged job container masks
     # the restrictions that production rootless Podman installations enforce.
-    runs-on: ubuntu-26.04
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Ubuntu 24.04 reproduces #2069: AppArmor blocks PR_CAPBSET_DROP
+          # while CAP_SETPCAP remains in the bounding set.
+          - runner: ubuntu-24.04
+            podman_major: "4"
+            expected_capbset_drop: eperm
+          # Ubuntu 26.04 provides the supported Podman 5.x coverage and, as of
+          # runner image 20260622.50.1, permits the same bounding-set drop.
+          - runner: ubuntu-26.04
+            podman_major: "5"
+            expected_capbset_drop: success
     env:
       IMAGE_TAG: ${{ inputs.image-tag }}
       MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -157,14 +171,41 @@ jobs:
           set -euo pipefail
           podman_version="$(podman version --format '{{.Client.Version}}')"
           case "$podman_version" in
-            5.*) ;;
-            *) echo "ERROR: expected Podman 5.x, found $podman_version" >&2; exit 1 ;;
+            "${{ matrix.podman_major }}".*) ;;
+            *) echo "ERROR: expected Podman ${{ matrix.podman_major }}.x, found $podman_version" >&2; exit 1 ;;
           esac
           test "$(podman info --format '{{.Host.Security.Rootless}}')" = "true"
           test "$(sudo sysctl -n kernel.apparmor_restrict_unprivileged_userns)" = "1"
+          echo "=== host ==="
+          uname -a
+          echo "=== AppArmor ==="
+          cat /proc/self/attr/current
+          sudo aa-status || true
+          echo "=== Podman ==="
+          podman version
+          podman info --debug
+
+      - name: Probe rootless capability bounding set
+        env:
+          EXPECTED_CAPBSET_DROP: ${{ matrix.expected_capbset_drop }}
+        run: |
+          set -euo pipefail
+          probe="$RUNNER_TEMP/openshell-capbset-probe"
+          cc -static -O2 -Wall -Wextra -Werror \
+            e2e/support/capbset-probe.c \
+            -o "$probe"
+          podman run --rm \
+            --cap-add=SETPCAP \
+            --volume "$probe:/openshell-capbset-probe:ro" \
+            docker.io/library/alpine:3.22 \
+            /openshell-capbset-probe "$EXPECTED_CAPBSET_DROP"
 
       - name: Log in to GHCR with Podman
         run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Run rootless Podman E2E
         run: mise run --no-deps --skip-deps e2e:podman:rootless
+
+      - name: Print AppArmor denials
+        if: always()
+        run: sudo dmesg | grep -E 'apparmor=.*DENIED|profile="unprivileged_userns"' | tail -100 || true

--- a/e2e/rust/e2e-podman-rootless.sh
+++ b/e2e/rust/e2e-podman-rootless.sh
@@ -10,8 +10,9 @@
 
 set -euo pipefail
 
-if podman info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -q false; then
-  echo "ERROR: podman is not running rootless; this test requires rootless mode" >&2
+rootless="$(podman info --format '{{.Host.Security.Rootless}}' 2>/dev/null || true)"
+if [ "${rootless}" != "true" ]; then
+  echo "ERROR: podman is not running rootless; expected true, got '${rootless:-<empty>}'" >&2
   exit 2
 fi
 

--- a/e2e/support/capbset-probe.c
+++ b/e2e/support/capbset-probe.c
@@ -58,9 +58,8 @@ static void print_apparmor_profile(void) {
 }
 
 int main(int argc, char **argv) {
-    if (argc != 2 ||
-        (strcmp(argv[1], "eperm") != 0 && strcmp(argv[1], "success") != 0)) {
-        fprintf(stderr, "usage: %s <eperm|success>\n", argv[0]);
+    if (argc != 1) {
+        fprintf(stderr, "usage: %s\n", argv[0]);
         return EXIT_FAILURE;
     }
 
@@ -95,15 +94,18 @@ int main(int argc, char **argv) {
     printf("cap_bnd_after=%016llx\n", cap_bnd_after);
     printf("setpcap_bounding_after=%d\n", setpcap_after);
 
-    if (strcmp(argv[1], "eperm") == 0) {
-        if (drop_result != -1 || drop_errno != EPERM || setpcap_after != 1 ||
-            (cap_bnd_after & setpcap_mask) == 0) {
-            fprintf(stderr, "expected EPERM with CAP_SETPCAP remaining in the bounding set\n");
+    if (drop_result == 0) {
+        if (setpcap_after != 0 || (cap_bnd_after & setpcap_mask) != 0) {
+            fprintf(stderr, "CAP_SETPCAP remained in the bounding set after a successful drop\n");
             return EXIT_FAILURE;
         }
-    } else if (drop_result != 0 || setpcap_after != 0 ||
-               (cap_bnd_after & setpcap_mask) != 0) {
-        fprintf(stderr, "expected CAP_SETPCAP bounding-set drop to succeed\n");
+    } else if (drop_errno == EPERM) {
+        if (setpcap_after != 1 || (cap_bnd_after & setpcap_mask) == 0) {
+            fprintf(stderr, "CAP_SETPCAP changed in the bounding set after EPERM\n");
+            return EXIT_FAILURE;
+        }
+    } else {
+        fprintf(stderr, "unexpected PR_CAPBSET_DROP result\n");
         return EXIT_FAILURE;
     }
 

--- a/e2e/support/capbset-probe.c
+++ b/e2e/support/capbset-probe.c
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Verify the capability-bounding-set condition behind issue #2069 from
+// inside a rootless Podman container.
+
+#include <errno.h>
+#include <linux/capability.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/prctl.h>
+
+static unsigned long long status_capability(const char *field) {
+    FILE *status = fopen("/proc/self/status", "r");
+    if (status == NULL) {
+        perror("fopen(/proc/self/status)");
+        exit(EXIT_FAILURE);
+    }
+
+    char line[256];
+    unsigned long long value = 0;
+    int found = 0;
+    while (fgets(line, sizeof(line), status) != NULL) {
+        char name[32];
+        unsigned long long candidate;
+        if (sscanf(line, "%31[^:]:%llx", name, &candidate) == 2 &&
+            strcmp(name, field) == 0) {
+            value = candidate;
+            found = 1;
+            break;
+        }
+    }
+    fclose(status);
+
+    if (!found) {
+        fprintf(stderr, "missing %s in /proc/self/status\n", field);
+        exit(EXIT_FAILURE);
+    }
+    return value;
+}
+
+static void print_apparmor_profile(void) {
+    FILE *profile = fopen("/proc/self/attr/current", "r");
+    if (profile == NULL) {
+        perror("fopen(/proc/self/attr/current)");
+        return;
+    }
+
+    char line[256];
+    if (fgets(line, sizeof(line), profile) != NULL) {
+        printf("apparmor_profile=%s", line);
+        if (strchr(line, '\n') == NULL) {
+            putchar('\n');
+        }
+    }
+    fclose(profile);
+}
+
+int main(int argc, char **argv) {
+    if (argc != 2 ||
+        (strcmp(argv[1], "eperm") != 0 && strcmp(argv[1], "success") != 0)) {
+        fprintf(stderr, "usage: %s <eperm|success>\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    const unsigned long long setpcap_mask = 1ULL << CAP_SETPCAP;
+    const unsigned long long cap_bnd_before = status_capability("CapBnd");
+    const unsigned long long cap_eff_before = status_capability("CapEff");
+    const int setpcap_before = prctl(PR_CAPBSET_READ, CAP_SETPCAP, 0, 0, 0);
+    if (setpcap_before == -1) {
+        perror("prctl(PR_CAPBSET_READ) before drop");
+        return EXIT_FAILURE;
+    }
+
+    print_apparmor_profile();
+    printf("cap_bnd_before=%016llx\n", cap_bnd_before);
+    printf("cap_eff_before=%016llx\n", cap_eff_before);
+    printf("setpcap_bounding_before=%d\n", setpcap_before);
+
+    if (cap_bnd_before == 0 || (cap_bnd_before & setpcap_mask) == 0 ||
+        (cap_eff_before & setpcap_mask) == 0 || setpcap_before != 1) {
+        fprintf(stderr, "CAP_SETPCAP must be effective and present in a non-empty bounding set\n");
+        return EXIT_FAILURE;
+    }
+
+    errno = 0;
+    const int drop_result = prctl(PR_CAPBSET_DROP, CAP_SETPCAP, 0, 0, 0);
+    const int drop_errno = errno;
+    const unsigned long long cap_bnd_after = status_capability("CapBnd");
+    const int setpcap_after = prctl(PR_CAPBSET_READ, CAP_SETPCAP, 0, 0, 0);
+
+    printf("drop_result=%d\n", drop_result);
+    printf("drop_errno=%d (%s)\n", drop_errno, strerror(drop_errno));
+    printf("cap_bnd_after=%016llx\n", cap_bnd_after);
+    printf("setpcap_bounding_after=%d\n", setpcap_after);
+
+    if (strcmp(argv[1], "eperm") == 0) {
+        if (drop_result != -1 || drop_errno != EPERM || setpcap_after != 1 ||
+            (cap_bnd_after & setpcap_mask) == 0) {
+            fprintf(stderr, "expected EPERM with CAP_SETPCAP remaining in the bounding set\n");
+            return EXIT_FAILURE;
+        }
+    } else if (drop_result != 0 || setpcap_after != 0 ||
+               (cap_bnd_after & setpcap_mask) != 0) {
+        fprintf(stderr, "expected CAP_SETPCAP bounding-set drop to succeed\n");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Run the rootless Podman e2e suite directly on an Ubuntu 26.04 host so it exercises the host AppArmor and unprivileged-user-namespace policy instead of a privileged CI container. Remove the duplicate rootful Podman CI lane while retaining the generic local task.

## Related Issue

Related to #2069.

## Changes

- Move rootless Podman e2e coverage out of the privileged container matrix
- Install and validate Podman 5.x on a host-native Ubuntu 26.04 runner
- Verify rootless mode and AppArmor user-namespace enforcement before running tests
- Make the rootless wrapper fail closed unless Podman explicitly reports rootless mode

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [x] E2E tests added/updated

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)