### PR TITLE
docs: warn to redact credentials from log output before sharing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,7 +59,9 @@ body:
     id: logs
     attributes:
       label: Logs
-      description: Relevant log output, error messages, or stack traces.
+      description: |
+        Relevant log output, error messages, or stack traces.
+        Redact credentials, API keys, and tokens before pasting — verbose error output from some frameworks includes the full request config.
       render: shell
     validations:
       required: false

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -288,6 +288,7 @@ The following patterns weaken security without providing meaningful benefit.
 | Using broad binary globs | A glob like `/**` allows any binary to reach the endpoint, defeating binary-scoped enforcement. | Scope globs to specific directories (for example, `/sandbox/.vscode-server/**`). |
 | Skipping TLS termination on HTTPS APIs | Setting `tls: skip` disables placeholder credential rewriting, dynamic token grant injection, and L7 inspection. | Use the default auto-detect behavior unless the upstream requires client-certificate mTLS. |
 | Setting `enforcement: enforce` before auditing | Jumping to `enforce` without first running in `audit` mode risks breaking the agent's workflow. | Start with `audit`, review the logs, and switch to `enforce` after you validate the rules. |
+| Pasting raw stack traces in bug reports | Some frameworks include the full request config — including credentials — in error objects. The sandbox does not scrub application-level output. | Inspect error output before sharing. Redact any credentials, API keys, or tokens. |
 
 ## Related Topics
 


### PR DESCRIPTION
## Summary

- Adds a redaction reminder to the bug report template's **Logs** field, shown at the point of submission
- Adds a new row to the **Common Mistakes** table in `docs/security/best-practices.mdx` noting that some frameworks include credentials in error objects and that the sandbox does not scrub application-level output

## Related Issue

Prompted by secret scanning alert #8, where a reporter inadvertently leaked a Lark application secret by pasting a raw framework stack trace that included the full request config.

## Changes

- `.github/ISSUE_TEMPLATE/bug_report.yml` — expanded `Logs` field description to remind reporters to redact credentials before pasting
- `docs/security/best-practices.mdx` — new Common Mistakes row covering credential leakage via stack traces

## Testing

- [x] `mise run markdown:lint` passes
- [x] No source code changed; pre-commit Rust/Python checks not required

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)