### PR TITLE
docs(openshift): simplify install steps and update Helm README

### DIFF
--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -25,6 +25,8 @@ helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart --version <vers
 
 ## Install on OpenShift
 
+See the full [OpenShift install guide](https://docs.nvidia.com/openshell/latest/kubernetes/openshift) for details. Quick start:
+
 ```shell
 # Precreate the openshell namespace so we can create the SCC cluster role
 oc create ns openshell

--- a/deploy/helm/openshell/README.md.gotmpl
+++ b/deploy/helm/openshell/README.md.gotmpl
@@ -25,6 +25,8 @@ helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart --version <vers
 
 ## Install on OpenShift
 
+See the full [OpenShift install guide](https://docs.nvidia.com/openshell/latest/kubernetes/openshift) for details. Quick start:
+
 ```shell
 # Precreate the openshell namespace so we can create the SCC cluster role
 oc create ns openshell

--- a/docs/kubernetes/openshift.mdx
+++ b/docs/kubernetes/openshift.mdx
@@ -9,7 +9,7 @@ position: 5
 ---
 
 <Warning>
-The OpenShift install path is experimental. It currently requires running sandbox pods under the `privileged` SCC and installing the gateway with TLS and the PKI init job disabled. Use only for evaluation on a private network.
+The OpenShift install path is experimental. It currently requires running sandbox pods under the `privileged` SCC and installing the gateway with TLS disabled. Use only for evaluation on a private network.
 </Warning>
 
 OpenShift's [Security Context Constraints](https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html) reject the chart's default pod security settings. Installing on OpenShift requires precreating the namespace, granting the `privileged` SCC to the sandbox service account, and overriding a few chart values so the cluster admission controller can assign UIDs and FS groups itself.
@@ -46,7 +46,6 @@ oc adm policy add-scc-to-user privileged -z openshell-sandbox -n openshell
 helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart \
   --version <version> \
   --namespace openshell \
-  --set pkiInitJob.enabled=false \
   --set server.disableTls=true \
   --set podSecurityContext.fsGroup=null \
   --set securityContext.runAsUser=null
@@ -54,13 +53,8 @@ helm install openshell oci://ghcr.io/nvidia/openshell/helm-chart \
 
 | Override | Reason |
 |---|---|
-| `pkiInitJob.enabled=false` | Skips the built-in TLS PKI Job. TLS must also be disabled unless you provide TLS Secrets another way. |
-| `server.disableTls=true` | The gateway has no certificates without `pkiInitJob`, so it must run plaintext. |
+| `server.disableTls=true` | Runs the gateway over plaintext HTTP for simpler evaluation. |
 | `podSecurityContext.fsGroup=null` / `securityContext.runAsUser=null` | Clear the chart's hardcoded UID and fsGroup so OpenShift's SCC admission can assign them. |
-
-The gateway still needs the sandbox JWT signing Secret. When disabling
-`pkiInitJob` without enabling cert-manager, pre-create that Secret before
-installing the chart.
 
 ## Wait for the gateway to be ready
 
@@ -90,6 +84,6 @@ openshell status
 
 ## Next Steps
 
-- For TLS-enabled deployments, refer to [Managing Certificates](/kubernetes/managing-certificates) after SCC-compatible PKI is supported.
+- For TLS-enabled deployments, refer to [Managing Certificates](/kubernetes/managing-certificates).
 - To expose the gateway externally, refer to [Ingress](/kubernetes/ingress).
 - To configure OIDC authentication, refer to [Access Control](/kubernetes/access-control).


### PR DESCRIPTION
Closes: #2089 

## Summary

Simplifies the OpenShift install guide by removing the stale `pkiInitJob.enabled=false` override (no longer needed) and cleaning up the related warnings and notes. Adds a cross-reference from the Helm README to the full OpenShift docs.

## Related Issue

N/A

## Changes

- Remove `pkiInitJob.enabled=false` from the OpenShift Helm install command and its explanation
- Simplify the warning banner and "Next Steps" wording
- Add OpenShift install guide link to `README.md` and `README.md.gotmpl`

## Testing

- [x] `mise run pre-commit` passes

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)