### PR TITLE
docs(kubernetes): bump Envoy Gateway to v1.8.2

### DIFF
--- a/docs/kubernetes/ingress.mdx
+++ b/docs/kubernetes/ingress.mdx
@@ -19,7 +19,7 @@ Envoy Gateway installs the Gateway API CRDs and controller:
 ```shell
 helm install eg \
   oci://docker.io/envoyproxy/gateway-helm \
-  --version v1.8.1 \
+  --version v1.8.2 \
   --namespace envoy-gateway-system \
   --create-namespace \
   --wait


### PR DESCRIPTION
Update Envoy Gateway install command from v1.8.1 to v1.8.2.