### PR TITLE
fix(install): drop podman as hard dependency for RPM installation

### DIFF
--- a/.github/workflows/rpm-package.yml
+++ b/.github/workflows/rpm-package.yml
@@ -113,6 +113,44 @@ jobs:
           echo "=== Built RPMs ==="
           ls -lah artifacts/
 
+      - name: Verify runtime-neutral RPM installation
+        run: |
+          set -euo pipefail
+
+          cli_rpm=""
+          gateway_rpm=""
+          for rpm_file in artifacts/*.rpm; do
+            case "$(rpm -qp --queryformat '%{NAME}' "$rpm_file")" in
+              openshell) cli_rpm="$rpm_file" ;;
+              openshell-gateway) gateway_rpm="$rpm_file" ;;
+            esac
+          done
+          test -n "$cli_rpm"
+          test -n "$gateway_rpm"
+
+          if rpm -qp --recommends "$cli_rpm" | grep -Eq '^podman([[:space:]]|$)'; then
+            echo "::error::The openshell RPM still recommends Podman"
+            exit 1
+          fi
+          if rpm -qp --requires "$gateway_rpm" | grep -Eq '^podman([[:space:]]|$)'; then
+            echo "::error::The openshell-gateway RPM still requires Podman"
+            exit 1
+          fi
+
+          if rpm -q podman >/dev/null 2>&1; then
+            dnf remove -y podman
+          fi
+          if rpm -q podman >/dev/null 2>&1; then
+            echo "::error::Podman must be absent before the package install test"
+            exit 1
+          fi
+
+          dnf install -y "$cli_rpm" "$gateway_rpm"
+          if rpm -q podman >/dev/null 2>&1; then
+            echo "::error::Installing OpenShell unexpectedly installed Podman"
+            exit 1
+          fi
+
       - name: Upload RPM artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3906,6 +3906,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite 0.26.2",
  "toml",
+ "toml_edit",
  "tonic",
  "tower 0.5.3",
  "tower-http 0.6.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yml = "0.0.12"
 toml = "0.8"
+toml_edit = "0.22"
 apollo-parser = "0.8.5"
 tower-mcp-types = "0.12.0"
 

--- a/architecture/build.md
+++ b/architecture/build.md
@@ -86,9 +86,10 @@ Runtime layout:
   gateway binaries must not reference `GLIBC_*` symbols newer than
   `GLIBC_2.28`; release workflows verify this before publishing artifacts. The
   gateway bundles z3, so the image does not need a distro-provided z3 runtime.
-- **VM driver**: host GNU-linked binary installed at
-  `/usr/libexec/openshell/openshell-driver-vm` in Linux packages and published
-  as a release artifact. Linux GNU VM driver binaries must not reference
+- **VM driver**: host GNU-linked binary included at
+  `/usr/libexec/openshell/openshell-driver-vm` in Debian packages and published
+  as a standalone release artifact for RPM hosts. Homebrew installs it in the
+  formula libexec directory; RPM and Snap do not bundle it. Linux GNU VM driver binaries must not reference
   `GLIBC_*` symbols newer than `GLIBC_2.28`; release workflows verify this
   before publishing artifacts.
 - **Supervisor**: `scratch` base, static musl binary at `/openshell-sandbox`.

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -448,6 +448,13 @@ Driver implementation settings live in the TOML driver tables. See
 `docs/reference/gateway-config.mdx` for worked per-driver examples and RFC
 0003 for the full schema.
 
+`openshell-gateway config set` provides typed, comment-preserving updates for
+installer- and operator-managed settings. It resolves the same explicit or XDG
+config path as gateway startup, validates the complete document, and replaces
+it atomically. Installers persist driver choices through this interface instead
+of adding service environment overrides, which would take precedence over
+later TOML edits.
+
 `database_url` is env-only and rejected when present in the file
 (`OPENSHELL_DB_URL` / `--db-url`).
 

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -470,20 +470,16 @@ Driver implementation settings live in the TOML driver tables. See
 0003 for the full schema.
 
 `openshell-gateway config detect-driver` exposes the gateway's automatic driver
-detection as a side-effect-free, machine-readable command. Package installers
-use it for runtime-specific guidance without persisting an inferred driver or
-changing the listener. `openshell-gateway config set` provides typed,
-comment-preserving updates for operator-managed settings. It resolves the same
-explicit or XDG config path as gateway startup, validates the complete
-document, and replaces it atomically. Service environment overrides remain an
-operator escape hatch because they take precedence over later TOML edits.
+detection as a side-effect-free, machine-readable command.
+`openshell-gateway config set` provides typed, comment-preserving updates for
+operator-managed settings. It resolves the same explicit or XDG config path as
+gateway startup, validates the complete document, and replaces it atomically.
+Service environment overrides remain an operator escape hatch because they
+take precedence over later TOML edits.
 
-When selection remains automatic, the gateway probes all available runtimes at
-every process start, logs the selected driver, and warns when multiple drivers
-are available. The warning includes the config command for pinning an intended
-driver. Auto-selected Podman on a loopback listener also emits the rootless
-Podman bind-address command. Keeping this guidance in the gateway covers
-runtimes installed or removed after the original package installation.
+When selection remains automatic, the gateway probes available runtimes at
+every process start. Runtime-specific recovery guidance belongs to gateway and
+installer diagnostics so it stays synchronized with detection behavior.
 
 `database_url` is env-only and rejected when present in the file
 (`OPENSHELL_DB_URL` / `--db-url`).

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -448,12 +448,14 @@ Driver implementation settings live in the TOML driver tables. See
 `docs/reference/gateway-config.mdx` for worked per-driver examples and RFC
 0003 for the full schema.
 
-`openshell-gateway config set` provides typed, comment-preserving updates for
-installer- and operator-managed settings. It resolves the same explicit or XDG
-config path as gateway startup, validates the complete document, and replaces
-it atomically. Installers persist driver choices through this interface instead
-of adding service environment overrides, which would take precedence over
-later TOML edits.
+`openshell-gateway config detect-driver` exposes the gateway's automatic driver
+detection as a side-effect-free, machine-readable command. Package installers
+use it for runtime-specific guidance without persisting an inferred driver or
+changing the listener. `openshell-gateway config set` provides typed,
+comment-preserving updates for operator-managed settings. It resolves the same
+explicit or XDG config path as gateway startup, validates the complete
+document, and replaces it atomically. Service environment overrides remain an
+operator escape hatch because they take precedence over later TOML edits.
 
 `database_url` is env-only and rejected when present in the file
 (`OPENSHELL_DB_URL` / `--db-url`).

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -471,11 +471,12 @@ Driver implementation settings live in the TOML driver tables. See
 
 `openshell-gateway config detect-driver` exposes the gateway's automatic driver
 detection as a side-effect-free, machine-readable command.
-`openshell-gateway config set` provides typed, comment-preserving updates for
-operator-managed settings. It resolves the same explicit or XDG config path as
-gateway startup, validates the complete document, and replaces it atomically.
-Service environment overrides remain an operator escape hatch because they
-take precedence over later TOML edits.
+`openshell-gateway config set` accepts repeatable dotted `KEY=VALUE`
+assignments for typed, comment-preserving updates to operator-managed settings.
+It resolves the same explicit or XDG config path as gateway startup, validates
+the complete document, and replaces it atomically. Service environment
+overrides remain an operator escape hatch because they take precedence over
+later TOML edits.
 
 When selection remains automatic, the gateway probes available runtimes at
 every process start. Runtime-specific recovery guidance belongs to gateway and

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -429,6 +429,27 @@ requested present -> generate and write. This guards continuity across restarts
 and upgrades while still recovering cleanly if an operator deletes everything
 and starts over.
 
+### Package installer invariants
+
+Package installers follow these boundaries across Debian, RPM, and Homebrew:
+
+- Select the supported native package method deterministically for the host.
+- Install matching OpenShell CLI and gateway artifacts in the package manager's
+  standard executable path.
+- Install and enable the gateway as a supervised user service.
+- Preserve existing gateway configuration and state across installs and
+  upgrades.
+- Keep the listener on loopback with TLS unless the operator changes it.
+- Do not install, remove, start, or configure optional Docker and Podman
+  runtimes.
+- Leave compute-driver selection automatic unless the operator explicitly pins
+  a driver.
+- Treat package installation and gateway health as separate outcomes. A
+  gateway startup failure leaves the package and service installed, returns a
+  nonzero installer status, and prints recovery instructions.
+- Remain safe to rerun after the operator fixes an optional runtime or service
+  prerequisite.
+
 Operators who manage TLS PKI with cert-manager enable `certManager.enabled`;
 cert-manager takes precedence over built-in TLS generation and the chart still
 renders the JWT-only hook. Operators who pre-create all TLS and JWT Secrets can
@@ -456,6 +477,13 @@ comment-preserving updates for operator-managed settings. It resolves the same
 explicit or XDG config path as gateway startup, validates the complete
 document, and replaces it atomically. Service environment overrides remain an
 operator escape hatch because they take precedence over later TOML edits.
+
+When selection remains automatic, the gateway probes all available runtimes at
+every process start, logs the selected driver, and warns when multiple drivers
+are available. The warning includes the config command for pinning an intended
+driver. Auto-selected Podman on a loopback listener also emits the rootless
+Podman bind-address command. Keeping this guidance in the gateway covers
+runtimes installed or removed after the original package installation.
 
 `database_url` is env-only and rejected when present in the file
 (`OPENSHELL_DB_URL` / `--db-url`).

--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -113,30 +113,40 @@ impl FromStr for ComputeDriverKind {
     }
 }
 
-/// Auto-detect the appropriate compute driver based on the runtime environment.
+/// Detect available compute drivers based on the runtime environment.
 ///
 /// Priority order: Kubernetes → Podman → Docker.
 /// VM is never auto-detected (requires explicit `--drivers vm`).
 ///
-/// Returns the first driver where the environment check passes.
-/// Returns `None` if no compatible driver is found.
-pub fn detect_driver() -> Option<ComputeDriverKind> {
+/// Returns every available driver in selection priority order.
+///
+/// VM is excluded because it requires explicit operator selection.
+#[must_use]
+pub fn detect_drivers() -> Vec<ComputeDriverKind> {
+    let mut drivers = Vec::new();
+
     // Kubernetes: check for KUBERNETES_SERVICE_HOST env var (set inside pods)
     if std::env::var_os("KUBERNETES_SERVICE_HOST").is_some() {
-        return Some(ComputeDriverKind::Kubernetes);
+        drivers.push(ComputeDriverKind::Kubernetes);
     }
 
     // Podman: check for a reachable local API socket.
     if is_podman_available() {
-        return Some(ComputeDriverKind::Podman);
+        drivers.push(ComputeDriverKind::Podman);
     }
 
     // Docker: check if the CLI is available or a local Docker socket exists.
     if is_docker_available() {
-        return Some(ComputeDriverKind::Docker);
+        drivers.push(ComputeDriverKind::Docker);
     }
 
-    None
+    drivers
+}
+
+/// Returns the first available driver in automatic selection priority order.
+#[must_use]
+pub fn detect_driver() -> Option<ComputeDriverKind> {
+    detect_drivers().into_iter().next()
 }
 
 /// Check if a binary is available on the system PATH.

--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -113,16 +113,23 @@ impl FromStr for ComputeDriverKind {
     }
 }
 
+/// Result of automatic compute-driver detection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriverDetection {
+    /// Driver selected according to automatic selection priority.
+    pub selected: Option<ComputeDriverKind>,
+    /// Every available driver in automatic selection priority order.
+    pub available: Vec<ComputeDriverKind>,
+}
+
 /// Detect available compute drivers based on the runtime environment.
 ///
 /// Priority order: Kubernetes → Podman → Docker.
 /// VM is never auto-detected (requires explicit `--drivers vm`).
 ///
-/// Returns every available driver in selection priority order.
-///
 /// VM is excluded because it requires explicit operator selection.
 #[must_use]
-pub fn detect_drivers() -> Vec<ComputeDriverKind> {
+pub fn detect_drivers() -> DriverDetection {
     let mut drivers = Vec::new();
 
     // Kubernetes: check for KUBERNETES_SERVICE_HOST env var (set inside pods)
@@ -140,13 +147,16 @@ pub fn detect_drivers() -> Vec<ComputeDriverKind> {
         drivers.push(ComputeDriverKind::Docker);
     }
 
-    drivers
+    DriverDetection {
+        selected: drivers.first().copied(),
+        available: drivers,
+    }
 }
 
-/// Returns the first available driver in automatic selection priority order.
+/// Returns the selected driver in automatic selection priority order.
 #[must_use]
 pub fn detect_driver() -> Option<ComputeDriverKind> {
-    detect_drivers().into_iter().next()
+    detect_drivers().selected
 }
 
 /// Check if a binary is available on the system PATH.
@@ -800,8 +810,8 @@ mod tests {
     use super::is_reachable_unix_socket;
     use super::{
         ComputeDriverKind, Config, DEFAULT_SERVICE_ROUTING_DOMAIN, GatewayJwtConfig, detect_driver,
-        docker_host_unix_socket_path, is_unix_socket, normalize_compute_driver_name,
-        podman_socket_candidates_from_env, podman_socket_responds,
+        detect_drivers, docker_host_unix_socket_path, is_unix_socket,
+        normalize_compute_driver_name, podman_socket_candidates_from_env, podman_socket_responds,
     };
     #[cfg(unix)]
     use std::io::{Read as _, Write as _};
@@ -1063,8 +1073,13 @@ mod tests {
             std::env::set_var("KUBERNETES_SERVICE_HOST", "127.0.0.1");
         }
 
-        let result = detect_driver();
-        assert_eq!(result, Some(ComputeDriverKind::Kubernetes));
+        let detection = detect_drivers();
+        assert_eq!(detection.selected, Some(ComputeDriverKind::Kubernetes));
+        assert_eq!(
+            detection.available.first().copied(),
+            Some(ComputeDriverKind::Kubernetes)
+        );
+        assert_eq!(detect_driver(), detection.selected);
 
         // Restore the original env var
         unsafe {

--- a/crates/openshell-driver-vm/README.md
+++ b/crates/openshell-driver-vm/README.md
@@ -263,7 +263,12 @@ auto-detection. Set `OPENSHELL_DRIVERS=vm` to force the VM driver.
 
 On RPM-family Linux x86_64 and aarch64 systems, `install.sh` installs the
 `openshell` and `openshell-gateway` RPM packages from the selected release tag.
-The RPM gateway package is configured for the Podman driver.
+The RPM does not include `openshell-driver-vm`. Install the matching standalone
+release artifact under `~/.local/libexec/openshell`,
+`/usr/libexec/openshell`, or `/usr/local/libexec/openshell`, or set
+`[openshell.drivers.vm].driver_dir` to its location. The RPM leaves compute
+driver selection unset, so the gateway auto-detects Podman or Docker unless VM
+is selected explicitly.
 
 On Apple Silicon macOS, `install.sh` stages the generated `openshell.rb`
 formula from the selected release in the `nvidia/openshell` Homebrew tap.

--- a/crates/openshell-driver-vm/README.md
+++ b/crates/openshell-driver-vm/README.md
@@ -264,8 +264,9 @@ auto-detection. Set `OPENSHELL_DRIVERS=vm` to force the VM driver.
 On RPM-family Linux x86_64 and aarch64 systems, `install.sh` installs the
 `openshell` and `openshell-gateway` RPM packages from the selected release tag.
 The RPM does not include `openshell-driver-vm`. Install the matching standalone
-release artifact under `~/.local/libexec/openshell`,
-`/usr/libexec/openshell`, or `/usr/local/libexec/openshell`, or set
+release artifact under one of the directories the gateway searches
+(`~/.local/libexec/openshell`, `/usr/libexec/openshell`,
+`/usr/local/libexec/openshell`, or `/usr/local/libexec`), or set
 `[openshell.drivers.vm].driver_dir` to its location. The RPM leaves compute
 driver selection unset, so the gateway auto-detects Podman or Docker unless VM
 is selected explicitly.

--- a/crates/openshell-server/Cargo.toml
+++ b/crates/openshell-server/Cargo.toml
@@ -77,6 +77,8 @@ pin-project-lite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
+tempfile = "3"
 tokio-stream = { workspace = true }
 sqlx = { workspace = true }
 reqwest = { workspace = true }
@@ -92,7 +94,6 @@ russh = "0.57"
 rand = { workspace = true }
 petname = "2"
 ipnet = "2"
-tempfile = "3"
 rustix = { workspace = true }
 x509-parser = "0.16"
 arc-swap = "1"

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -39,17 +39,19 @@ struct Cli {
 enum Commands {
     /// Generate mTLS PKI and write Kubernetes Secrets (Helm pre-install hook).
     GenerateCerts(certgen::CertgenArgs),
+    /// Inspect or update the gateway TOML configuration.
+    Config(crate::config_edit::ConfigArgs),
 }
 
 #[derive(clap::Args, Debug)]
 #[allow(clippy::struct_excessive_bools)]
 struct RunArgs {
-    /// Path to a TOML configuration file (see RFC 0003).
+    /// Path to the gateway TOML configuration file (see RFC 0003).
     ///
-    /// When set, gateway-wide settings and per-driver tables are read from
-    /// the file. Gateway command-line flags and `OPENSHELL_*` environment
-    /// variables continue to take precedence over gateway file values.
-    #[arg(long, env = "OPENSHELL_GATEWAY_CONFIG")]
+    /// Gateway startup reads this file. Config subcommands update it. Gateway
+    /// command-line flags and `OPENSHELL_*` environment variables continue to
+    /// take precedence over file values at runtime.
+    #[arg(long, env = "OPENSHELL_GATEWAY_CONFIG", global = true)]
     config: Option<PathBuf>,
 
     /// IP address to bind the server, health, and metrics listeners to.
@@ -228,6 +230,7 @@ pub async fn run_cli() -> Result<()> {
 
     match cli.command {
         Some(Commands::GenerateCerts(args)) => certgen::run(args).await,
+        Some(Commands::Config(args)) => crate::config_edit::run(args, cli.run.config),
         None => Box::pin(run_from_args(cli.run, matches)).await,
     }
 }
@@ -1073,6 +1076,57 @@ mod tests {
             cli.command,
             Some(super::Commands::GenerateCerts(_))
         ));
+    }
+
+    #[test]
+    fn config_set_uses_explicit_config_path() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _g = EnvVarGuard::remove("OPENSHELL_GATEWAY_CONFIG");
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("custom/gateway.toml");
+        let path_string = path.to_string_lossy().into_owned();
+
+        let cli = Cli::try_parse_from([
+            "openshell-gateway",
+            "config",
+            "set",
+            "--config",
+            &path_string,
+            "--compute-driver",
+            "podman",
+            "--bind-address",
+            "0.0.0.0:17670",
+        ])
+        .expect("config set should parse without runtime arguments");
+        let Cli { command, run } = cli;
+        let Some(super::Commands::Config(args)) = command else {
+            panic!("expected config subcommand");
+        };
+
+        crate::config_edit::run(args, run.config).unwrap();
+
+        let loaded = crate::config_file::load(&path).unwrap();
+        assert_eq!(
+            loaded.openshell.gateway.compute_drivers,
+            Some(vec!["podman".to_string()])
+        );
+        assert_eq!(
+            loaded.openshell.gateway.bind_address,
+            Some("0.0.0.0:17670".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn config_set_requires_at_least_one_setting() {
+        let error = Cli::try_parse_from(["openshell-gateway", "config", "set"])
+            .expect_err("config set without a setting should fail");
+
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
     }
 
     #[test]

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -1130,6 +1130,14 @@ mod tests {
     }
 
     #[test]
+    fn config_detect_driver_parses_without_runtime_arguments() {
+        let cli = Cli::try_parse_from(["openshell-gateway", "config", "detect-driver"])
+            .expect("config detect-driver should parse");
+
+        assert!(matches!(cli.command, Some(super::Commands::Config(_))));
+    }
+
+    #[test]
     fn bare_invocation_with_no_db_url_parses_for_runtime_defaults() {
         // db_url is Option<String> at the clap level so subcommand parsing
         // does not require it. The Run path fills a default URL from XDG

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -1094,10 +1094,8 @@ mod tests {
             "set",
             "--config",
             &path_string,
-            "--compute-driver",
-            "podman",
-            "--bind-address",
-            "0.0.0.0:17670",
+            "openshell.gateway.compute_drivers=[\"podman\"]",
+            "openshell.gateway.bind_address=0.0.0.0:17670",
         ])
         .expect("config set should parse without runtime arguments");
         let Cli { command, run } = cli;
@@ -1127,6 +1125,19 @@ mod tests {
             error.kind(),
             clap::error::ErrorKind::MissingRequiredArgument
         );
+    }
+
+    #[test]
+    fn config_set_rejects_non_assignment_arguments() {
+        let error = Cli::try_parse_from([
+            "openshell-gateway",
+            "config",
+            "set",
+            "openshell.gateway.log_level",
+        ])
+        .expect_err("config set arguments must use KEY=VALUE syntax");
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
     }
 
     #[test]

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -40,7 +40,7 @@ enum Commands {
     /// Generate mTLS PKI and write Kubernetes Secrets (Helm pre-install hook).
     GenerateCerts(certgen::CertgenArgs),
     /// Inspect or update the gateway TOML configuration.
-    Config(crate::config_edit::ConfigArgs),
+    Config(crate::config_command::ConfigArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -230,7 +230,7 @@ pub async fn run_cli() -> Result<()> {
 
     match cli.command {
         Some(Commands::GenerateCerts(args)) => certgen::run(args).await,
-        Some(Commands::Config(args)) => crate::config_edit::run(args, cli.run.config),
+        Some(Commands::Config(args)) => crate::config_command::run(args, cli.run.config),
         None => Box::pin(run_from_args(cli.run, matches)).await,
     }
 }
@@ -1105,7 +1105,7 @@ mod tests {
             panic!("expected config subcommand");
         };
 
-        crate::config_edit::run(args, run.config).unwrap();
+        crate::config_command::run(args, run.config).unwrap();
 
         let loaded = crate::config_file::load(&path).unwrap();
         assert_eq!(

--- a/crates/openshell-server/src/config_command.rs
+++ b/crates/openshell-server/src/config_command.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Typed, comment-preserving updates to the gateway TOML configuration.
+//! CLI handlers for inspecting and updating the gateway TOML configuration.
 
 use std::fs;
 use std::io::Write;

--- a/crates/openshell-server/src/config_command.rs
+++ b/crates/openshell-server/src/config_command.rs
@@ -5,13 +5,13 @@
 
 use std::fs;
 use std::io::Write;
-use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
-use clap::{ArgGroup, Args, Subcommand};
+use clap::{Args, Subcommand};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use tempfile::NamedTempFile;
-use toml_edit::{Array, DocumentMut, Item, Table, value};
+use toml_edit::{DocumentMut, Item, Table, value};
 
 use crate::{config_file, defaults};
 
@@ -25,25 +25,52 @@ pub struct ConfigArgs {
 enum ConfigCommand {
     /// Detect the compute driver available in the current environment.
     DetectDriver,
-    /// Update selected fields in the gateway TOML configuration.
+    /// Update fields in the gateway TOML configuration.
     Set(SetArgs),
 }
 
 #[derive(Debug, Args)]
-#[command(group(
-    ArgGroup::new("setting")
-        .required(true)
-        .multiple(true)
-        .args(["compute_driver", "gateway_bind_address"])
-))]
 struct SetArgs {
-    /// Select one compute driver, or use `auto` to remove an existing pin.
-    #[arg(long, value_name = "DRIVER")]
-    compute_driver: Option<String>,
+    /// Dotted TOML key and value to set. May be repeated.
+    #[arg(required = true, value_name = "KEY=VALUE")]
+    assignments: Vec<Assignment>,
+}
 
-    /// Set the gateway listener socket address.
-    #[arg(long = "bind-address", value_name = "IP:PORT")]
-    gateway_bind_address: Option<SocketAddr>,
+#[derive(Clone, Debug)]
+struct Assignment {
+    key: Vec<String>,
+    value: Item,
+}
+
+impl FromStr for Assignment {
+    type Err = String;
+
+    fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
+        let (raw_key, raw_value) = input.split_once('=').ok_or_else(|| {
+            format!("invalid assignment '{input}': expected a dotted KEY=VALUE argument")
+        })?;
+
+        let key = raw_key
+            .split('.')
+            .map(|component| {
+                if component.is_empty()
+                    || !component
+                        .chars()
+                        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
+                {
+                    return Err(format!(
+                        "invalid config key '{raw_key}': use dot-separated TOML bare keys"
+                    ));
+                }
+                Ok(component.to_string())
+            })
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            key,
+            value: parse_assignment_value(raw_value.trim()),
+        })
+    }
 }
 
 pub fn run(args: ConfigArgs, explicit_path: Option<PathBuf>) -> Result<()> {
@@ -92,26 +119,36 @@ fn set(path: &Path, settings: &SetArgs) -> Result<()> {
     if !openshell.contains_key("version") {
         openshell.insert("version", value(i64::from(config_file::SCHEMA_VERSION)));
     }
-    let gateway = ensure_table(openshell, "gateway")?;
 
-    if let Some(driver) = settings.compute_driver.as_deref() {
-        if driver.eq_ignore_ascii_case("auto") {
-            gateway.remove("compute_drivers");
-        } else {
-            let driver = openshell_core::config::normalize_compute_driver_name(driver)
-                .map_err(|err| miette::miette!("{err}"))?;
-            let mut drivers = Array::new();
-            drivers.push(driver);
-            gateway.insert("compute_drivers", value(drivers));
-        }
-    }
-    if let Some(bind_address) = settings.gateway_bind_address {
-        gateway.insert("bind_address", value(bind_address.to_string()));
+    for assignment in &settings.assignments {
+        apply_assignment(&mut document, assignment)?;
     }
 
     let rendered = document.to_string();
     config_file::parse(&rendered, path).map_err(|err| miette::miette!("{err}"))?;
     write_atomically(path, rendered.as_bytes())
+}
+
+fn parse_assignment_value(raw: &str) -> Item {
+    let source = format!("value = {raw}");
+    source
+        .parse::<DocumentMut>()
+        .ok()
+        .and_then(|mut document| document.as_table_mut().remove("value"))
+        .unwrap_or_else(|| value(raw))
+}
+
+fn apply_assignment(document: &mut DocumentMut, assignment: &Assignment) -> Result<()> {
+    let (key, parents) = assignment
+        .key
+        .split_last()
+        .ok_or_else(|| miette::miette!("config assignment key must not be empty"))?;
+    let mut table = document.as_table_mut();
+    for parent in parents {
+        table = ensure_table(table, parent)?;
+    }
+    table.insert(key, assignment.value.clone());
+    Ok(())
 }
 
 fn ensure_table<'a>(parent: &'a mut Table, key: &str) -> Result<&'a mut Table> {
@@ -170,10 +207,12 @@ fn write_atomically(path: &Path, contents: &[u8]) -> Result<()> {
 mod tests {
     use super::*;
 
-    fn settings(driver: Option<&str>, bind_address: Option<&str>) -> SetArgs {
+    fn settings(assignments: &[&str]) -> SetArgs {
         SetArgs {
-            compute_driver: driver.map(str::to_string),
-            gateway_bind_address: bind_address.map(|value| value.parse().unwrap()),
+            assignments: assignments
+                .iter()
+                .map(|assignment| assignment.parse().unwrap())
+                .collect(),
         }
     }
 
@@ -195,7 +234,14 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("openshell/gateway.toml");
 
-        set(&path, &settings(Some("podman"), Some("0.0.0.0:17670"))).unwrap();
+        set(
+            &path,
+            &settings(&[
+                "openshell.gateway.compute_drivers=[\"podman\"]",
+                "openshell.gateway.bind_address=0.0.0.0:17670",
+            ]),
+        )
+        .unwrap();
 
         let loaded = config_file::load(&path).unwrap();
         assert_eq!(loaded.openshell.version, Some(config_file::SCHEMA_VERSION));
@@ -219,7 +265,11 @@ mod tests {
         )
         .unwrap();
 
-        set(&path, &settings(Some("podman"), None)).unwrap();
+        set(
+            &path,
+            &settings(&["openshell.gateway.compute_drivers=[\"podman\"]"]),
+        )
+        .unwrap();
 
         let updated = fs::read_to_string(&path).unwrap();
         assert!(updated.contains("# keep this comment"));
@@ -232,7 +282,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_removes_driver_without_changing_bind_address() {
+    fn empty_driver_array_enables_auto_detection_without_changing_bind_address() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("gateway.toml");
         fs::write(
@@ -241,10 +291,10 @@ mod tests {
         )
         .unwrap();
 
-        set(&path, &settings(Some("auto"), None)).unwrap();
+        set(&path, &settings(&["openshell.gateway.compute_drivers=[]"])).unwrap();
 
         let loaded = config_file::load(&path).unwrap();
-        assert_eq!(loaded.openshell.gateway.compute_drivers, None);
+        assert_eq!(loaded.openshell.gateway.compute_drivers, Some(Vec::new()));
         assert_eq!(
             loaded.openshell.gateway.bind_address,
             Some("0.0.0.0:17670".parse().unwrap())
@@ -258,7 +308,11 @@ mod tests {
         let original = "[openshell\ninvalid";
         fs::write(&path, original).unwrap();
 
-        let error = set(&path, &settings(Some("docker"), None)).unwrap_err();
+        let error = set(
+            &path,
+            &settings(&["openshell.gateway.compute_drivers=[\"docker\"]"]),
+        )
+        .unwrap_err();
 
         assert!(error.to_string().contains("failed to parse gateway config"));
         assert_eq!(fs::read_to_string(&path).unwrap(), original);
@@ -271,7 +325,11 @@ mod tests {
         let original = "[openshell]\nversion = 999\n";
         fs::write(&path, original).unwrap();
 
-        let error = set(&path, &settings(Some("docker"), None)).unwrap_err();
+        let error = set(
+            &path,
+            &settings(&["openshell.gateway.compute_drivers=[\"docker\"]"]),
+        )
+        .unwrap_err();
 
         assert!(
             error
@@ -282,15 +340,107 @@ mod tests {
     }
 
     #[test]
-    fn invalid_driver_name_is_not_written() {
+    fn unknown_key_is_not_written() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("gateway.toml");
         let original = "[openshell]\nversion = 1\n";
         fs::write(&path, original).unwrap();
 
-        let error = set(&path, &settings(Some("bad/name"), None)).unwrap_err();
+        let error = set(
+            &path,
+            &settings(&["openshell.gateway.unknown_setting=value"]),
+        )
+        .unwrap_err();
 
-        assert!(error.to_string().contains("invalid compute driver name"));
+        assert!(error.to_string().contains("unknown field"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn assignment_values_support_toml_types_and_unquoted_strings() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("gateway.toml");
+
+        set(
+            &path,
+            &settings(&[
+                "openshell.gateway.log_level=debug",
+                "openshell.gateway.grpc_rate_limit_requests=42",
+                "openshell.gateway.enable_loopback_service_http=false",
+                "openshell.gateway.server_sans=[\"gateway.example.com\", \"*.example.com\"]",
+                "openshell.drivers.vm.vcpus=4",
+            ]),
+        )
+        .unwrap();
+
+        let loaded = config_file::load(&path).unwrap();
+        let gateway = loaded.openshell.gateway;
+        assert_eq!(gateway.log_level.as_deref(), Some("debug"));
+        assert_eq!(gateway.grpc_rate_limit_requests, Some(42));
+        assert_eq!(gateway.enable_loopback_service_http, Some(false));
+        assert_eq!(
+            gateway.server_sans,
+            Some(vec![
+                "gateway.example.com".to_string(),
+                "*.example.com".to_string()
+            ])
+        );
+        assert_eq!(
+            loaded.openshell.drivers["vm"]
+                .get("vcpus")
+                .and_then(toml::Value::as_integer),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn later_assignment_to_the_same_key_wins() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("gateway.toml");
+
+        set(
+            &path,
+            &settings(&[
+                "openshell.gateway.log_level=info",
+                "openshell.gateway.log_level=debug",
+            ]),
+        )
+        .unwrap();
+
+        let loaded = config_file::load(&path).unwrap();
+        assert_eq!(loaded.openshell.gateway.log_level.as_deref(), Some("debug"));
+    }
+
+    #[test]
+    fn assignment_requires_key_value_syntax_and_bare_dotted_keys() {
+        let missing_value = "openshell.gateway.log_level"
+            .parse::<Assignment>()
+            .unwrap_err();
+        assert!(missing_value.contains("KEY=VALUE"));
+
+        let invalid_key = "openshell.gateway.bad key=value"
+            .parse::<Assignment>()
+            .unwrap_err();
+        assert!(invalid_key.contains("dot-separated TOML bare keys"));
+    }
+
+    #[test]
+    fn repeated_assignments_are_atomic_when_validation_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("gateway.toml");
+        let original = "[openshell]\nversion = 1\n\n[openshell.gateway]\nlog_level = \"info\"\n";
+        fs::write(&path, original).unwrap();
+
+        let error = set(
+            &path,
+            &settings(&[
+                "openshell.gateway.log_level=debug",
+                "openshell.gateway.unknown_setting=value",
+            ]),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("unknown field"));
         assert_eq!(fs::read_to_string(&path).unwrap(), original);
     }
 }

--- a/crates/openshell-server/src/config_edit.rs
+++ b/crates/openshell-server/src/config_edit.rs
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Typed, comment-preserving updates to the gateway TOML configuration.
+
+use std::fs;
+use std::io::Write;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+
+use clap::{ArgGroup, Args, Subcommand};
+use miette::{IntoDiagnostic, Result, WrapErr};
+use tempfile::NamedTempFile;
+use toml_edit::{Array, DocumentMut, Item, Table, value};
+
+use crate::{config_file, defaults};
+
+#[derive(Debug, Args)]
+pub struct ConfigArgs {
+    #[command(subcommand)]
+    command: ConfigCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum ConfigCommand {
+    /// Update selected fields in the gateway TOML configuration.
+    Set(SetArgs),
+}
+
+#[derive(Debug, Args)]
+#[command(group(
+    ArgGroup::new("setting")
+        .required(true)
+        .multiple(true)
+        .args(["compute_driver", "gateway_bind_address"])
+))]
+struct SetArgs {
+    /// Select one compute driver, or use `auto` to remove an existing pin.
+    #[arg(long, value_name = "DRIVER")]
+    compute_driver: Option<String>,
+
+    /// Set the gateway listener socket address.
+    #[arg(long = "bind-address", value_name = "IP:PORT")]
+    gateway_bind_address: Option<SocketAddr>,
+}
+
+pub fn run(args: ConfigArgs, explicit_path: Option<PathBuf>) -> Result<()> {
+    let path = explicit_path.map_or_else(defaults::default_gateway_config_path, Ok)?;
+    match args.command {
+        ConfigCommand::Set(settings) => set(&path, &settings)?,
+    }
+    println!("updated gateway configuration: {}", path.display());
+    println!("Restart the gateway service for changes to take effect.");
+    Ok(())
+}
+
+fn set(path: &Path, settings: &SetArgs) -> Result<()> {
+    let original = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(err) => {
+            return Err(err)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("failed to read gateway config '{}'", path.display()));
+        }
+    };
+
+    let mut document = if original.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        original
+            .parse::<DocumentMut>()
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to parse gateway config '{}'", path.display()))?
+    };
+
+    let openshell = ensure_table(document.as_table_mut(), "openshell")?;
+    if !openshell.contains_key("version") {
+        openshell.insert("version", value(i64::from(config_file::SCHEMA_VERSION)));
+    }
+    let gateway = ensure_table(openshell, "gateway")?;
+
+    if let Some(driver) = settings.compute_driver.as_deref() {
+        if driver.eq_ignore_ascii_case("auto") {
+            gateway.remove("compute_drivers");
+        } else {
+            let driver = openshell_core::config::normalize_compute_driver_name(driver)
+                .map_err(|err| miette::miette!("{err}"))?;
+            let mut drivers = Array::new();
+            drivers.push(driver);
+            gateway.insert("compute_drivers", value(drivers));
+        }
+    }
+    if let Some(bind_address) = settings.gateway_bind_address {
+        gateway.insert("bind_address", value(bind_address.to_string()));
+    }
+
+    let rendered = document.to_string();
+    config_file::parse(&rendered, path).map_err(|err| miette::miette!("{err}"))?;
+    write_atomically(path, rendered.as_bytes())
+}
+
+fn ensure_table<'a>(parent: &'a mut Table, key: &str) -> Result<&'a mut Table> {
+    if !parent.contains_key(key) {
+        parent.insert(key, Item::Table(Table::new()));
+    }
+    parent
+        .get_mut(key)
+        .and_then(Item::as_table_mut)
+        .ok_or_else(|| miette::miette!("gateway config key '{key}' must be a TOML table"))
+}
+
+fn write_atomically(path: &Path, contents: &[u8]) -> Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        miette::miette!(
+            "gateway config path '{}' has no parent directory",
+            path.display()
+        )
+    })?;
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    fs::create_dir_all(parent)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to create config directory '{}'", parent.display()))?;
+
+    let permissions = fs::metadata(path)
+        .ok()
+        .map(|metadata| metadata.permissions());
+    let mut temp = NamedTempFile::new_in(parent)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to create temporary file in '{}'", parent.display()))?;
+    temp.write_all(contents)
+        .into_diagnostic()
+        .wrap_err("failed to write gateway configuration")?;
+    temp.as_file()
+        .sync_all()
+        .into_diagnostic()
+        .wrap_err("failed to sync gateway configuration")?;
+    if let Some(permissions) = permissions {
+        temp.as_file()
+            .set_permissions(permissions)
+            .into_diagnostic()
+            .wrap_err("failed to preserve gateway config permissions")?;
+    }
+    temp.persist(path)
+        .map_err(|err| err.error)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to replace gateway config '{}'", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings(driver: Option<&str>, bind_address: Option<&str>) -> SetArgs {
+        SetArgs {
+            compute_driver: driver.map(str::to_string),
+            gateway_bind_address: bind_address.map(|value| value.parse().unwrap()),
+        }
+    }
+
+    #[test]
+    fn set_creates_config_with_driver_and_bind_address() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("openshell/gateway.toml");
+
+        set(&path, &settings(Some("podman"), Some("0.0.0.0:17670"))).unwrap();
+
+        let loaded = config_file::load(&path).unwrap();
+        assert_eq!(loaded.openshell.version, Some(config_file::SCHEMA_VERSION));
+        assert_eq!(
+            loaded.openshell.gateway.compute_drivers,
+            Some(vec!["podman".to_string()])
+        );
+        assert_eq!(
+            loaded.openshell.gateway.bind_address,
+            Some("0.0.0.0:17670".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn set_preserves_comments_and_unrelated_settings() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("gateway.toml");
+        fs::write(
+            &path,
+            "# keep this comment\n[openshell]\nversion = 1\n\n[openshell.gateway]\nlog_level = \"debug\"\ncompute_drivers = [\"docker\"]\n",
+        )
+        .unwrap();
+
+        set(&path, &settings(Some("podman"), None)).unwrap();
+
+        let updated = fs::read_to_string(&path).unwrap();
+        assert!(updated.contains("# keep this comment"));
+        assert!(updated.contains("log_level = \"debug\""));
+        let loaded = config_file::load(&path).unwrap();
+        assert_eq!(
+            loaded.openshell.gateway.compute_drivers,
+            Some(vec!["podman".to_string()])
+        );
+    }
+
+    #[test]
+    fn auto_removes_driver_without_changing_bind_address() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("gateway.toml");
+        fs::write(
+            &path,
+            "[openshell]\nversion = 1\n\n[openshell.gateway]\nbind_address = \"0.0.0.0:17670\"\ncompute_drivers = [\"podman\"]\n",
+        )
+        .unwrap();
+
+        set(&path, &settings(Some("auto"), None)).unwrap();
+
+        let loaded = config_file::load(&path).unwrap();
+        assert_eq!(loaded.openshell.gateway.compute_drivers, None);
+        assert_eq!(
+            loaded.openshell.gateway.bind_address,
+            Some("0.0.0.0:17670".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn invalid_existing_config_is_not_replaced() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("gateway.toml");
+        let original = "[openshell\ninvalid";
+        fs::write(&path, original).unwrap();
+
+        let error = set(&path, &settings(Some("docker"), None)).unwrap_err();
+
+        assert!(error.to_string().contains("failed to parse gateway config"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn schema_validation_failure_is_not_written() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("gateway.toml");
+        let original = "[openshell]\nversion = 999\n";
+        fs::write(&path, original).unwrap();
+
+        let error = set(&path, &settings(Some("docker"), None)).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported gateway config version")
+        );
+        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn invalid_driver_name_is_not_written() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("gateway.toml");
+        let original = "[openshell]\nversion = 1\n";
+        fs::write(&path, original).unwrap();
+
+        let error = set(&path, &settings(Some("bad/name"), None)).unwrap_err();
+
+        assert!(error.to_string().contains("invalid compute driver name"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+    }
+}

--- a/crates/openshell-server/src/config_edit.rs
+++ b/crates/openshell-server/src/config_edit.rs
@@ -23,6 +23,8 @@ pub struct ConfigArgs {
 
 #[derive(Debug, Subcommand)]
 enum ConfigCommand {
+    /// Detect the compute driver available in the current environment.
+    DetectDriver,
     /// Update selected fields in the gateway TOML configuration.
     Set(SetArgs),
 }
@@ -45,13 +47,25 @@ struct SetArgs {
 }
 
 pub fn run(args: ConfigArgs, explicit_path: Option<PathBuf>) -> Result<()> {
-    let path = explicit_path.map_or_else(defaults::default_gateway_config_path, Ok)?;
     match args.command {
-        ConfigCommand::Set(settings) => set(&path, &settings)?,
+        ConfigCommand::DetectDriver => {
+            println!(
+                "{}",
+                detected_driver_name(openshell_core::config::detect_driver())
+            );
+        }
+        ConfigCommand::Set(settings) => {
+            let path = explicit_path.map_or_else(defaults::default_gateway_config_path, Ok)?;
+            set(&path, &settings)?;
+            println!("updated gateway configuration: {}", path.display());
+            println!("Restart the gateway service for changes to take effect.");
+        }
     }
-    println!("updated gateway configuration: {}", path.display());
-    println!("Restart the gateway service for changes to take effect.");
     Ok(())
+}
+
+fn detected_driver_name(driver: Option<openshell_core::ComputeDriverKind>) -> &'static str {
+    driver.map_or("none", openshell_core::ComputeDriverKind::as_str)
 }
 
 fn set(path: &Path, settings: &SetArgs) -> Result<()> {
@@ -161,6 +175,19 @@ mod tests {
             compute_driver: driver.map(str::to_string),
             gateway_bind_address: bind_address.map(|value| value.parse().unwrap()),
         }
+    }
+
+    #[test]
+    fn detect_driver_output_is_machine_readable() {
+        assert_eq!(
+            detected_driver_name(Some(openshell_core::ComputeDriverKind::Podman)),
+            "podman"
+        );
+        assert_eq!(
+            detected_driver_name(Some(openshell_core::ComputeDriverKind::Docker)),
+            "docker"
+        );
+        assert_eq!(detected_driver_name(None), "none");
     }
 
     #[test]

--- a/crates/openshell-server/src/config_file.rs
+++ b/crates/openshell-server/src/config_file.rs
@@ -622,7 +622,7 @@ version = 2
     }
 
     /// Contract test: the RPM default config template must parse against the
-    /// current schema and must retain the settings that Podman deployments require.
+    /// current schema and must retain the safe package defaults.
     ///
     /// This test loads `deploy/rpm/gateway.toml.default` through the same
     /// `load()` path that the gateway uses at runtime, catching:
@@ -641,9 +641,8 @@ version = 2
             .bind_address
             .expect("bind_address must be explicitly set in the RPM default config");
         assert!(
-            addr.ip().is_unspecified(),
-            "RPM default bind_address must be 0.0.0.0 so Podman sandbox containers \
-             can reach the gateway over the host network bridge, got {addr}"
+            addr.ip().is_loopback(),
+            "RPM default bind_address must remain loopback-only, got {addr}"
         );
         assert_eq!(
             addr.port(),

--- a/crates/openshell-server/src/config_file.rs
+++ b/crates/openshell-server/src/config_file.rs
@@ -618,15 +618,15 @@ version = 2
     }
 
     /// Contract test: the RPM default config template must parse against the
-    /// current schema and must pin the settings that Podman deployments require.
+    /// current schema and must retain the settings that Podman deployments require.
     ///
     /// This test loads `deploy/rpm/gateway.toml.default` through the same
     /// `load()` path that the gateway uses at runtime, catching:
     ///   - template corruption or unknown fields (`deny_unknown_fields`)
     ///   - schema drift (version bump or field renames)
-    ///   - accidental changes to the bind address or compute driver list
+    ///   - accidental changes to the bind address or runtime-neutral driver selection
     #[test]
-    fn rpm_default_config_parses_and_has_podman_defaults() {
+    fn rpm_default_config_parses_and_auto_detects_compute_driver() {
         let path =
             Path::new(env!("CARGO_MANIFEST_DIR")).join("../../deploy/rpm/gateway.toml.default");
         let config =
@@ -648,15 +648,10 @@ version = 2
             openshell_core::config::DEFAULT_SERVER_PORT
         );
 
-        let drivers = gw
-            .compute_drivers
-            .as_ref()
-            .expect("compute_drivers must be explicitly set in the RPM default config");
-        assert_eq!(
-            drivers,
-            &["podman".to_string()],
-            "RPM default must pin compute_drivers to [podman] to prevent unexpected \
-             driver selection when Docker is also installed"
+        assert!(
+            gw.compute_drivers.is_none(),
+            "RPM default must leave compute_drivers unset so the gateway auto-detects \
+             an available local runtime"
         );
     }
 }

--- a/crates/openshell-server/src/config_file.rs
+++ b/crates/openshell-server/src/config_file.rs
@@ -197,10 +197,14 @@ pub fn load(path: &Path) -> Result<ConfigFile, ConfigFileError> {
         path: path.to_path_buf(),
         source,
     })?;
+    parse(&contents, path)
+}
+
+pub(crate) fn parse(contents: &str, path: &Path) -> Result<ConfigFile, ConfigFileError> {
     if contents.trim().is_empty() {
         return Ok(ConfigFile::default());
     }
-    let file: ConfigFile = toml::from_str(&contents).map_err(|source| ConfigFileError::Parse {
+    let file: ConfigFile = toml::from_str(contents).map_err(|source| ConfigFileError::Parse {
         path: path.to_path_buf(),
         source,
     })?;

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -27,7 +27,7 @@ mod auth;
 pub mod certgen;
 pub mod cli;
 mod compute;
-mod config_edit;
+mod config_command;
 pub mod config_file;
 mod defaults;
 mod grpc;
@@ -840,8 +840,8 @@ fn configured_compute_driver(
 ) -> Result<ConfiguredComputeDriver> {
     match config.compute_drivers.as_slice() {
         [] => {
-            let detected = openshell_core::config::detect_drivers();
-            let Some(driver) = detected.first().copied() else {
+            let detection = openshell_core::config::detect_drivers();
+            let Some(driver) = detection.selected else {
                 return Err(Error::config(
                     "no compute driver configured and auto-detection found no suitable driver; \
                     install and start Docker or Podman, or install the VM driver and select it \
@@ -855,7 +855,7 @@ fn configured_compute_driver(
                 ));
             }
 
-            log_auto_detected_driver(config, driver, &detected);
+            log_auto_detected_driver(config, driver, &detection.available);
             Ok(ConfiguredComputeDriver::Builtin(driver))
         }
         [driver] => resolve_configured_compute_driver(driver, driver_startup),

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -27,6 +27,7 @@ mod auth;
 pub mod certgen;
 pub mod cli;
 mod compute;
+mod config_edit;
 pub mod config_file;
 mod defaults;
 mod grpc;

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -839,22 +839,78 @@ fn configured_compute_driver(
     driver_startup: compute::driver_config::DriverStartupContext<'_>,
 ) -> Result<ConfiguredComputeDriver> {
     match config.compute_drivers.as_slice() {
-        [] => match openshell_core::config::detect_driver() {
-            Some(ComputeDriverKind::Vm) => Err(Error::config(
-                "vm compute driver is opt-in only; set --drivers vm or OPENSHELL_DRIVERS=vm",
-            )),
-            Some(driver) => Ok(ConfiguredComputeDriver::Builtin(driver)),
-            None => Err(Error::config(
-                "no compute driver configured and auto-detection found no suitable driver; \
-                set --drivers or OPENSHELL_DRIVERS to kubernetes, podman, docker, or vm",
-            )),
-        },
+        [] => {
+            let detected = openshell_core::config::detect_drivers();
+            let Some(driver) = detected.first().copied() else {
+                return Err(Error::config(
+                    "no compute driver configured and auto-detection found no suitable driver; \
+                    install and start Docker or Podman, or install the VM driver and select it \
+                    with `openshell-gateway config set --compute-driver vm`",
+                ));
+            };
+
+            if driver == ComputeDriverKind::Vm {
+                return Err(Error::config(
+                    "vm compute driver is opt-in only; set --drivers vm or OPENSHELL_DRIVERS=vm",
+                ));
+            }
+
+            log_auto_detected_driver(config, driver, &detected);
+            Ok(ConfiguredComputeDriver::Builtin(driver))
+        }
         [driver] => resolve_configured_compute_driver(driver, driver_startup),
         drivers => Err(Error::config(format!(
             "multiple compute drivers are not supported yet; configured drivers: {}",
             drivers.join(",")
         ))),
     }
+}
+
+fn log_auto_detected_driver(
+    config: &Config,
+    selected: ComputeDriverKind,
+    detected: &[ComputeDriverKind],
+) {
+    let available = detected
+        .iter()
+        .map(|driver| driver.as_str())
+        .collect::<Vec<_>>()
+        .join(",");
+    info!(
+        driver = %selected,
+        available_drivers = %available,
+        "Auto-selected compute driver"
+    );
+
+    for guidance in auto_detection_guidance(config, selected, detected.len()) {
+        warn!(
+            driver = %selected,
+            available_drivers = %available,
+            bind_address = %config.bind_address,
+            "{guidance}"
+        );
+    }
+}
+
+fn auto_detection_guidance(
+    config: &Config,
+    selected: ComputeDriverKind,
+    detected_count: usize,
+) -> Vec<String> {
+    let mut guidance = Vec::new();
+    if detected_count > 1 {
+        guidance.push(
+            "Multiple compute drivers are available. Auto-detection is evaluated at every gateway start; pin the intended driver with `openshell-gateway config set --compute-driver <driver>`, then restart the gateway service"
+                .to_string(),
+        );
+    }
+    if selected == ComputeDriverKind::Podman && config.bind_address.ip().is_loopback() {
+        guidance.push(format!(
+            "Podman was auto-selected while the gateway is bound to loopback. If you use rootless Podman, run `openshell-gateway config set --bind-address 0.0.0.0:{}`, then restart the gateway service",
+            config.bind_address.port()
+        ));
+    }
+    guidance
 }
 
 fn resolve_configured_compute_driver(
@@ -900,8 +956,8 @@ fn warn_if_kubernetes_sandbox_jwt_expiry_disabled(config: &Config) {
 mod tests {
     use super::{
         ConfiguredComputeDriver, ConnectionProtocol, MultiplexService, ServerState, TlsAcceptor,
-        allow_plaintext_service_http, classify_initial_bytes, configured_compute_driver,
-        gateway_listener_addresses, is_benign_tls_handshake_failure,
+        allow_plaintext_service_http, auto_detection_guidance, classify_initial_bytes,
+        configured_compute_driver, gateway_listener_addresses, is_benign_tls_handshake_failure,
         kubernetes_sandbox_jwt_expiry_disabled, serve_gateway_listener,
     };
     use openshell_core::{
@@ -1252,6 +1308,34 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn auto_detection_warns_how_to_pin_when_multiple_drivers_are_available() {
+        let config = Config::new(None);
+
+        let guidance = auto_detection_guidance(&config, ComputeDriverKind::Docker, 2).join("\n");
+
+        assert!(guidance.contains("Auto-detection is evaluated at every gateway start"));
+        assert!(guidance.contains("openshell-gateway config set --compute-driver <driver>"));
+        assert!(guidance.contains("restart the gateway service"));
+    }
+
+    #[test]
+    fn auto_detected_podman_on_loopback_warns_with_bind_command() {
+        let config = Config::new(None).with_bind_address("127.0.0.1:17670".parse().unwrap());
+
+        let guidance = auto_detection_guidance(&config, ComputeDriverKind::Podman, 1).join("\n");
+
+        assert!(guidance.contains("openshell-gateway config set --bind-address 0.0.0.0:17670"));
+        assert!(guidance.contains("If you use rootless Podman"));
+    }
+
+    #[test]
+    fn auto_detected_podman_on_non_loopback_needs_no_bind_guidance() {
+        let config = Config::new(None).with_bind_address("0.0.0.0:17670".parse().unwrap());
+
+        assert!(auto_detection_guidance(&config, ComputeDriverKind::Podman, 1).is_empty());
     }
 
     #[test]

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -845,7 +845,7 @@ fn configured_compute_driver(
                 return Err(Error::config(
                     "no compute driver configured and auto-detection found no suitable driver; \
                     install and start Docker or Podman, or install the VM driver and select it \
-                    with `openshell-gateway config set --compute-driver vm`",
+                    with `openshell-gateway config set 'openshell.gateway.compute_drivers=[\"vm\"]'`",
                 ));
             };
 
@@ -900,13 +900,13 @@ fn auto_detection_guidance(
     let mut guidance = Vec::new();
     if detected_count > 1 {
         guidance.push(
-            "Multiple compute drivers are available. Auto-detection is evaluated at every gateway start; pin the intended driver with `openshell-gateway config set --compute-driver <driver>`, then restart the gateway service"
+            "Multiple compute drivers are available. Auto-detection is evaluated at every gateway start; pin the intended driver with `openshell-gateway config set 'openshell.gateway.compute_drivers=[\"<driver>\"]'`, then restart the gateway service"
                 .to_string(),
         );
     }
     if selected == ComputeDriverKind::Podman && config.bind_address.ip().is_loopback() {
         guidance.push(format!(
-            "Podman was auto-selected while the gateway is bound to loopback. If you use rootless Podman, run `openshell-gateway config set --bind-address 0.0.0.0:{}`, then restart the gateway service",
+            "Podman was auto-selected while the gateway is bound to loopback. If you use rootless Podman, run `openshell-gateway config set openshell.gateway.bind_address=0.0.0.0:{}`, then restart the gateway service",
             config.bind_address.port()
         ));
     }
@@ -1317,7 +1317,9 @@ mod tests {
         let guidance = auto_detection_guidance(&config, ComputeDriverKind::Docker, 2).join("\n");
 
         assert!(guidance.contains("Auto-detection is evaluated at every gateway start"));
-        assert!(guidance.contains("openshell-gateway config set --compute-driver <driver>"));
+        assert!(guidance.contains(
+            "openshell-gateway config set 'openshell.gateway.compute_drivers=[\"<driver>\"]'"
+        ));
         assert!(guidance.contains("restart the gateway service"));
     }
 
@@ -1327,7 +1329,11 @@ mod tests {
 
         let guidance = auto_detection_guidance(&config, ComputeDriverKind::Podman, 1).join("\n");
 
-        assert!(guidance.contains("openshell-gateway config set --bind-address 0.0.0.0:17670"));
+        assert!(
+            guidance.contains(
+                "openshell-gateway config set openshell.gateway.bind_address=0.0.0.0:17670"
+            )
+        );
         assert!(guidance.contains("If you use rootless Podman"));
     }
 

--- a/deploy/man/openshell-gateway.8.md
+++ b/deploy/man/openshell-gateway.8.md
@@ -14,6 +14,9 @@ openshell-gateway - OpenShell gateway server daemon
 
 **openshell-gateway** \[*OPTIONS*\]
 
+**openshell-gateway config set** \[*--config PATH*\]
+\[*--compute-driver DRIVER*\] \[*--bind-address IP:PORT*\]
+
 # DESCRIPTION
 
 **openshell-gateway** is the control-plane server for OpenShell. It
@@ -110,6 +113,23 @@ TLS.
 Compute driver settings such as sandbox image, callback endpoint, image
 pull policy, network name, VM state directory, and guest TLS material are
 configured in the TOML file passed with **--config**.
+
+# CONFIG SUBCOMMAND
+
+**openshell-gateway config set** updates the gateway TOML file without
+discarding comments or unrelated settings. It creates the default XDG config
+file when needed, validates the complete result, and replaces the file
+atomically.
+
+**--compute-driver** *DRIVER*
+:   Persist one compute driver. Use **auto** to remove the existing driver pin.
+
+**--bind-address** *IP:PORT*
+:   Persist the gateway listener socket address.
+
+**--config** *PATH*
+:   Update a specific gateway TOML file instead of the default XDG location.
+    Environment: **OPENSHELL_GATEWAY_CONFIG**.
 
 # SYSTEMD INTEGRATION
 

--- a/deploy/man/openshell-gateway.8.md
+++ b/deploy/man/openshell-gateway.8.md
@@ -17,7 +17,7 @@ openshell-gateway - OpenShell gateway server daemon
 **openshell-gateway config detect-driver**
 
 **openshell-gateway config set** \[*--config PATH*\]
-\[*--compute-driver DRIVER*\] \[*--bind-address IP:PORT*\]
+*KEY=VALUE* \[*KEY=VALUE* ...\]
 
 # DESCRIPTION
 
@@ -125,13 +125,14 @@ gateway configuration, or change system state.
 **openshell-gateway config set** updates the gateway TOML file without
 discarding comments or unrelated settings. It creates the default XDG config
 file when needed, validates the complete result, and replaces the file
-atomically.
+atomically. Each argument uses a dotted TOML key. TOML booleans, integers,
+arrays, and quoted strings retain their types; other unquoted values are
+stored as strings. Multiple assignments are applied in one transaction.
 
-**--compute-driver** *DRIVER*
-:   Persist one compute driver. Use **auto** to remove the existing driver pin.
-
-**--bind-address** *IP:PORT*
-:   Persist the gateway listener socket address.
+*KEY=VALUE*
+:   Set a field by its dotted TOML path. Repeat to update multiple fields.
+    Set **openshell.gateway.compute_drivers=[]** to restore automatic driver
+    selection.
 
 **--config** *PATH*
 :   Update a specific gateway TOML file instead of the default XDG location.

--- a/deploy/man/openshell-gateway.8.md
+++ b/deploy/man/openshell-gateway.8.md
@@ -122,6 +122,12 @@ detection as gateway startup and prints one value: **kubernetes**, **podman**,
 **docker**, or **none**. It does not detect the opt-in VM driver, read the
 gateway configuration, or change system state.
 
+When no driver is configured, gateway startup logs the auto-selected driver and
+every available driver. If multiple runtimes are available, it warns that
+selection is evaluated again at every start and shows how to pin the intended
+driver. Auto-selected Podman on a loopback listener also logs the command
+needed for rootless Podman callbacks.
+
 **openshell-gateway config set** updates the gateway TOML file without
 discarding comments or unrelated settings. It creates the default XDG config
 file when needed, validates the complete result, and replaces the file

--- a/deploy/man/openshell-gateway.8.md
+++ b/deploy/man/openshell-gateway.8.md
@@ -122,12 +122,6 @@ detection as gateway startup and prints one value: **kubernetes**, **podman**,
 **docker**, or **none**. It does not detect the opt-in VM driver, read the
 gateway configuration, or change system state.
 
-When no driver is configured, gateway startup logs the auto-selected driver and
-every available driver. If multiple runtimes are available, it warns that
-selection is evaluated again at every start and shows how to pin the intended
-driver. Auto-selected Podman on a loopback listener also logs the command
-needed for rootless Podman callbacks.
-
 **openshell-gateway config set** updates the gateway TOML file without
 discarding comments or unrelated settings. It creates the default XDG config
 file when needed, validates the complete result, and replaces the file

--- a/deploy/man/openshell-gateway.8.md
+++ b/deploy/man/openshell-gateway.8.md
@@ -97,10 +97,9 @@ TLS.
 
 **--disable-tls**
 :   Disable TLS entirely and listen on plaintext HTTP. When the bind
-    address is **0.0.0.0** (the RPM default), disabling TLS exposes the
-    API to the entire network without authentication. Only use when the
-    gateway sits behind a TLS-terminating reverse proxy, or restrict
-    **--bind-address** to **127.0.0.1**.
+    address is **0.0.0.0**, disabling TLS exposes the API to the entire
+    network without authentication. Only use when the gateway sits behind a
+    TLS-terminating reverse proxy. The RPM default is **127.0.0.1**.
     Environment: **OPENSHELL_DISABLE_TLS**.
 
 **--server-san** *SAN*

--- a/deploy/man/openshell-gateway.8.md
+++ b/deploy/man/openshell-gateway.8.md
@@ -14,6 +14,8 @@ openshell-gateway - OpenShell gateway server daemon
 
 **openshell-gateway** \[*OPTIONS*\]
 
+**openshell-gateway config detect-driver**
+
 **openshell-gateway config set** \[*--config PATH*\]
 \[*--compute-driver DRIVER*\] \[*--bind-address IP:PORT*\]
 
@@ -114,6 +116,11 @@ pull policy, network name, VM state directory, and guest TLS material are
 configured in the TOML file passed with **--config**.
 
 # CONFIG SUBCOMMAND
+
+**openshell-gateway config detect-driver** runs the same automatic driver
+detection as gateway startup and prints one value: **kubernetes**, **podman**,
+**docker**, or **none**. It does not detect the opt-in VM driver, read the
+gateway configuration, or change system state.
 
 **openshell-gateway config set** updates the gateway TOML file without
 discarding comments or unrelated settings. It creates the default XDG config

--- a/deploy/rpm/CONFIGURATION.md
+++ b/deploy/rpm/CONFIGURATION.md
@@ -34,9 +34,9 @@ reachable Podman socket, then Docker. Set `compute_drivers = ["docker"]` or
 `compute_drivers = ["podman"]` to require a specific container runtime.
 
 The RPM does not include the VM driver. To use VM-backed sandboxes, download
-the matching `openshell-driver-vm` release artifact, install the binary under
-`~/.local/libexec/openshell`, `/usr/libexec/openshell`, or
-`/usr/local/libexec/openshell`, and select it explicitly:
+the matching `openshell-driver-vm` release artifact, install the binary in a
+conventional libexec directory (or set `driver_dir` to its location), and
+select it explicitly:
 
 ```toml
 [openshell.gateway]
@@ -46,20 +46,22 @@ compute_drivers = ["vm"]
 grpc_endpoint = "https://host.containers.internal:17670"
 ```
 
-Set `[openshell.drivers.vm].driver_dir` when installing the binary elsewhere.
-The gateway never auto-detects VM support.
+The gateway never auto-detects VM support. If it cannot find the binary, the
+startup error lists every directory it searched.
 
 ### Customizing the configuration
 
-Use the gateway config command to select a driver or update the listener:
+Use the gateway config command to select a driver or update the listener. For
+example, pin Docker:
 
 ```shell
-openshell-gateway config set --compute-driver docker --bind-address 127.0.0.1:17670
+openshell-gateway config set --compute-driver docker
 systemctl --user restart openshell-gateway
 ```
 
-Use `--compute-driver auto` to remove an existing driver pin. The command
-preserves comments and unrelated settings. You can also edit
+Pass `--bind-address IP:PORT` to update the listener. Use `--compute-driver
+auto` to remove an existing driver pin. The command preserves comments and
+unrelated settings. You can also edit
 `~/.config/openshell/gateway.toml` directly. The template at
 `/usr/share/openshell-gateway/gateway.toml.default` is not read at runtime
 and is not overwritten by RPM upgrades.

--- a/deploy/rpm/CONFIGURATION.md
+++ b/deploy/rpm/CONFIGURATION.md
@@ -13,21 +13,22 @@ The RPM ships a default TOML configuration template at
 `openshell-gateway.service`, the systemd unit copies this template to
 `~/.config/openshell/gateway.toml` if no config file exists there yet.
 
-The default keeps the bind address required by rootless Podman while leaving
-compute driver selection automatic:
+The default keeps the listener on loopback while leaving compute driver
+selection automatic:
 
 ```toml
 [openshell]
 version = 1
 
 [openshell.gateway]
-bind_address = "0.0.0.0:17670"
+bind_address = "127.0.0.1:17670"
 ```
 
-`bind_address = "0.0.0.0:17670"` is required because Podman sandbox
-containers reach the gateway over the host network bridge and cannot
-connect to `127.0.0.1` inside the gateway's network namespace. mTLS is
-enabled by default and protects all connections.
+The loopback default avoids exposing the gateway on host network interfaces.
+Rootless Podman sandbox containers cannot reach host loopback from their
+network namespace. Select Podman through `install.sh --compute-driver podman`
+or configure both `compute_drivers = ["podman"]` and
+`bind_address = "0.0.0.0:17670"` before creating Podman-backed sandboxes.
 
 When `compute_drivers` is unset, the gateway auto-detects Kubernetes, then a
 reachable Podman socket, then Docker. Set `compute_drivers = ["docker"]` or
@@ -89,7 +90,7 @@ systemctl --user edit openshell-gateway
 
 The RPM enables mutual TLS by default. The gateway requires a valid
 client certificate for all API connections and listens on
-`0.0.0.0:17670` by default (see "Default configuration" above).
+`127.0.0.1:17670` by default (see "Default configuration" above).
 
 ### Auto-generated certificates
 
@@ -239,7 +240,7 @@ overrides that persist across package upgrades.
 
 | TOML option | Default | Description |
 |-------------|---------|-------------|
-| `bind_address` | `0.0.0.0:17670` (RPM default) | Address for the gRPC/HTTP API. |
+| `bind_address` | `127.0.0.1:17670` | Address for the gRPC/HTTP API. Rootless Podman requires `0.0.0.0:17670`. |
 | `compute_drivers` | unset | The gateway auto-detects Kubernetes, then a reachable Podman socket, then Docker. VM requires explicit selection. |
 | `default_image` | `ghcr.io/nvidia/openshell-community/sandboxes/base:latest` | Default sandbox image. |
 | `supervisor_image` | `ghcr.io/nvidia/openshell/supervisor:latest` | Supervisor image mounted into Podman sandboxes. |

--- a/deploy/rpm/CONFIGURATION.md
+++ b/deploy/rpm/CONFIGURATION.md
@@ -51,7 +51,16 @@ The gateway never auto-detects VM support.
 
 ### Customizing the configuration
 
-Edit `~/.config/openshell/gateway.toml` directly. The template at
+Use the gateway config command to select a driver or update the listener:
+
+```shell
+openshell-gateway config set --compute-driver docker --bind-address 127.0.0.1:17670
+systemctl --user restart openshell-gateway
+```
+
+Use `--compute-driver auto` to remove an existing driver pin. The command
+preserves comments and unrelated settings. You can also edit
+`~/.config/openshell/gateway.toml` directly. The template at
 `/usr/share/openshell-gateway/gateway.toml.default` is not read at runtime
 and is not overwritten by RPM upgrades.
 

--- a/deploy/rpm/CONFIGURATION.md
+++ b/deploy/rpm/CONFIGURATION.md
@@ -13,7 +13,8 @@ The RPM ships a default TOML configuration template at
 `openshell-gateway.service`, the systemd unit copies this template to
 `~/.config/openshell/gateway.toml` if no config file exists there yet.
 
-The defaults are tuned for rootless Podman use:
+The default keeps the bind address required by rootless Podman while leaving
+compute driver selection automatic:
 
 ```toml
 [openshell]
@@ -21,7 +22,6 @@ version = 1
 
 [openshell.gateway]
 bind_address = "0.0.0.0:17670"
-compute_drivers = ["podman"]
 ```
 
 `bind_address = "0.0.0.0:17670"` is required because Podman sandbox
@@ -29,9 +29,25 @@ containers reach the gateway over the host network bridge and cannot
 connect to `127.0.0.1` inside the gateway's network namespace. mTLS is
 enabled by default and protects all connections.
 
-`compute_drivers = ["podman"]` pins the compute driver to Podman. Without
-this, the gateway auto-detects in order: Kubernetes, Podman, Docker. Pinning
-prevents unexpected driver selection if Docker is also installed on the host.
+When `compute_drivers` is unset, the gateway auto-detects Kubernetes, then a
+reachable Podman socket, then Docker. Set `compute_drivers = ["docker"]` or
+`compute_drivers = ["podman"]` to require a specific container runtime.
+
+The RPM does not include the VM driver. To use VM-backed sandboxes, download
+the matching `openshell-driver-vm` release artifact, install the binary under
+`~/.local/libexec/openshell`, `/usr/libexec/openshell`, or
+`/usr/local/libexec/openshell`, and select it explicitly:
+
+```toml
+[openshell.gateway]
+compute_drivers = ["vm"]
+
+[openshell.drivers.vm]
+grpc_endpoint = "https://host.containers.internal:17670"
+```
+
+Set `[openshell.drivers.vm].driver_dir` when installing the binary elsewhere.
+The gateway never auto-detects VM support.
 
 ### Customizing the configuration
 
@@ -215,7 +231,7 @@ overrides that persist across package upgrades.
 | TOML option | Default | Description |
 |-------------|---------|-------------|
 | `bind_address` | `0.0.0.0:17670` (RPM default) | Address for the gRPC/HTTP API. |
-| `compute_drivers` | `["podman"]` (RPM default) | When unset, the gateway auto-detects Kubernetes, then Podman, then Docker. The RPM default pins to Podman. |
+| `compute_drivers` | unset | The gateway auto-detects Kubernetes, then a reachable Podman socket, then Docker. VM requires explicit selection. |
 | `default_image` | `ghcr.io/nvidia/openshell-community/sandboxes/base:latest` | Default sandbox image. |
 | `supervisor_image` | `ghcr.io/nvidia/openshell/supervisor:latest` | Supervisor image mounted into Podman sandboxes. |
 | `guest_tls_ca`, `guest_tls_cert`, `guest_tls_key` | auto-generated paths | Client TLS material bind-mounted into sandbox containers. |
@@ -228,7 +244,7 @@ the gateway uses `sqlite:$XDG_STATE_HOME/openshell/gateway/openshell.db`.
 ### Driver TOML settings
 
 Create `~/.config/openshell/gateway.toml` when you need to customize driver
-settings:
+settings. For example, pin Podman explicitly:
 
 ```toml
 [openshell]

--- a/deploy/rpm/CONFIGURATION.md
+++ b/deploy/rpm/CONFIGURATION.md
@@ -27,9 +27,7 @@ bind_address = "127.0.0.1:17670"
 The loopback default avoids exposing the gateway on host network interfaces.
 Rootless Podman sandbox containers cannot reach host loopback from their
 network namespace. Configure `bind_address = "0.0.0.0:17670"` before creating
-Podman-backed sandboxes. The install script prints the equivalent
-`openshell-gateway config set` command when automatic detection finds Podman,
-but it does not apply the change or pin the detected driver.
+Podman-backed sandboxes.
 
 When `compute_drivers` is unset, the gateway auto-detects Kubernetes, then a
 reachable Podman socket, then Docker. Set `compute_drivers = ["docker"]` or

--- a/deploy/rpm/CONFIGURATION.md
+++ b/deploy/rpm/CONFIGURATION.md
@@ -26,9 +26,10 @@ bind_address = "127.0.0.1:17670"
 
 The loopback default avoids exposing the gateway on host network interfaces.
 Rootless Podman sandbox containers cannot reach host loopback from their
-network namespace. Select Podman through `install.sh --compute-driver podman`
-or configure both `compute_drivers = ["podman"]` and
-`bind_address = "0.0.0.0:17670"` before creating Podman-backed sandboxes.
+network namespace. Configure `bind_address = "0.0.0.0:17670"` before creating
+Podman-backed sandboxes. The install script prints the equivalent
+`openshell-gateway config set` command when automatic detection finds Podman,
+but it does not apply the change or pin the detected driver.
 
 When `compute_drivers` is unset, the gateway auto-detects Kubernetes, then a
 reachable Podman socket, then Docker. Set `compute_drivers = ["docker"]` or

--- a/deploy/rpm/CONFIGURATION.md
+++ b/deploy/rpm/CONFIGURATION.md
@@ -55,13 +55,13 @@ Use the gateway config command to select a driver or update the listener. For
 example, pin Docker:
 
 ```shell
-openshell-gateway config set --compute-driver docker
+openshell-gateway config set 'openshell.gateway.compute_drivers=["docker"]'
 systemctl --user restart openshell-gateway
 ```
 
-Pass `--bind-address IP:PORT` to update the listener. Use `--compute-driver
-auto` to remove an existing driver pin. The command preserves comments and
-unrelated settings. You can also edit
+Pass another dotted `KEY=VALUE` argument to update more fields atomically. Set
+`openshell.gateway.compute_drivers=[]` to restore automatic driver selection.
+The command preserves comments and unrelated settings. You can also edit
 `~/.config/openshell/gateway.toml` directly. The template at
 `/usr/share/openshell-gateway/gateway.toml.default` is not read at runtime
 and is not overwritten by RPM upgrades.

--- a/deploy/rpm/QUICKSTART.md
+++ b/deploy/rpm/QUICKSTART.md
@@ -60,7 +60,7 @@ Make the gateway reachable from rootless Podman containers before creating a
 sandbox:
 
 ```shell
-openshell-gateway config set --bind-address 0.0.0.0:17670
+openshell-gateway config set openshell.gateway.bind_address=0.0.0.0:17670
 ```
 
 ### Network access

--- a/deploy/rpm/QUICKSTART.md
+++ b/deploy/rpm/QUICKSTART.md
@@ -8,7 +8,7 @@ Get from `dnf install` to a running sandbox in five minutes.
 
 Install and start either Docker or Podman before starting the gateway. The RPM
 does not install a container runtime. When `compute_drivers` is unset, the
-gateway selects a reachable Podman socket first, then Docker.
+gateway auto-detects Kubernetes, then a reachable Podman socket, then Docker.
 
 For Docker, verify that the daemon is running:
 

--- a/deploy/rpm/QUICKSTART.md
+++ b/deploy/rpm/QUICKSTART.md
@@ -101,10 +101,20 @@ systemctl --user status openshell-gateway
 ```
 
 If neither Docker nor Podman is usable, the service exits and the journal
-reports that no compute driver is available. The RPM remains installed. Install
-and start a container runtime, then restart the service. The VM driver is a
-separate release artifact and must be installed and selected explicitly; see
+reports that no compute driver is available. The RPM remains installed and the
+supervised service retries automatically. Install and start a container
+runtime; restart the service manually if it does not recover. The VM driver is
+a separate release artifact and must be installed and selected explicitly; see
 CONFIGURATION.md.
+
+Automatic selection is evaluated on every gateway start. The gateway logs its
+selection and warns when multiple runtimes are available. Pin Docker before a
+restart if Podman is later installed but Docker should remain selected:
+
+```shell
+openshell-gateway config set --compute-driver docker
+systemctl --user restart openshell-gateway
+```
 
 ## Register the gateway with the CLI
 

--- a/deploy/rpm/QUICKSTART.md
+++ b/deploy/rpm/QUICKSTART.md
@@ -56,17 +56,23 @@ socket activation:
 systemctl --user enable --now podman.socket
 ```
 
-When using `install.sh`, you can select Podman explicitly after completing
-these prerequisites:
+When using `install.sh`, select Podman explicitly after completing these
+prerequisites:
 
 ```shell
 curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh -s -- --compute-driver podman
 ```
 
-The option updates the gateway configuration; it does not install or start
-Podman. The option is not required on RPM installations: without it, the
-gateway keeps automatic driver selection and the RPM's bridge-reachable bind
-address still supports Podman callbacks.
+The option updates the gateway configuration with the Podman driver and its
+required bridge-reachable bind address; it does not install or start Podman.
+For a direct RPM transaction, configure the same settings before starting the
+service:
+
+```shell
+openshell-gateway config set \
+  --compute-driver podman \
+  --bind-address 0.0.0.0:17670
+```
 
 ### Network access
 
@@ -88,11 +94,11 @@ On first start, the gateway automatically generates:
 
 - A self-signed PKI bundle (CA, server cert, client cert) for mTLS
 
-> **Note:** The RPM default configuration binds to `0.0.0.0:17670` so
-> Podman sandbox containers can reach the gateway over the host network
-> bridge. Mutual TLS (mTLS) is enabled automatically on first start,
-> requiring a valid client certificate for every connection. See
-> CONFIGURATION.md for details.
+> **Note:** The RPM default configuration binds to `127.0.0.1:17670` to avoid
+> exposing the gateway on host network interfaces. Driver auto-detection does
+> not widen the listener. Configure Podman as shown above before creating
+> Podman-backed sandboxes. Mutual TLS (mTLS) is enabled automatically on first
+> start. See CONFIGURATION.md for details.
 
 Verify the service is running:
 

--- a/deploy/rpm/QUICKSTART.md
+++ b/deploy/rpm/QUICKSTART.md
@@ -56,6 +56,18 @@ socket activation:
 systemctl --user enable --now podman.socket
 ```
 
+When using `install.sh`, you can select Podman explicitly after completing
+these prerequisites:
+
+```shell
+curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh -s -- --compute-driver podman
+```
+
+The option updates the gateway configuration; it does not install or start
+Podman. The option is not required on RPM installations: without it, the
+gateway keeps automatic driver selection and the RPM's bridge-reachable bind
+address still supports Podman callbacks.
+
 ### Network access
 
 The gateway pulls container images from ghcr.io on first sandbox

--- a/deploy/rpm/QUICKSTART.md
+++ b/deploy/rpm/QUICKSTART.md
@@ -4,10 +4,19 @@ Get from `dnf install` to a running sandbox in five minutes.
 
 ## Prerequisites
 
-### Podman (rootless)
+### Container runtime
 
-The gateway uses rootless Podman for sandbox containers. Verify
-Podman is installed and the cgroup version is v2:
+Install and start either Docker or Podman before starting the gateway. The RPM
+does not install a container runtime. When `compute_drivers` is unset, the
+gateway selects a reachable Podman socket first, then Docker.
+
+For Docker, verify that the daemon is running:
+
+```shell
+docker info
+```
+
+For rootless Podman, verify Podman is installed and the cgroup version is v2:
 
 ```shell
 podman --version
@@ -22,7 +31,9 @@ sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=1"
 sudo reboot
 ```
 
-### Subordinate UID/GID ranges
+The following subordinate ID and socket steps apply only to rootless Podman.
+
+### Subordinate UID/GID ranges (Podman)
 
 Rootless containers require subordinate UID/GID mappings:
 
@@ -50,8 +61,8 @@ systemctl --user enable --now podman.socket
 The gateway pulls container images from ghcr.io on first sandbox
 creation. Ensure the host can reach ghcr.io over HTTPS (port 443).
 
-For air-gapped environments, pre-load images with `podman pull` and
-set `image_pull_policy = "never"` in
+For air-gapped environments, pre-load images with `docker pull` or
+`podman pull` and set the selected driver's `image_pull_policy = "never"` in
 `~/.config/openshell/gateway.toml`. See CONFIGURATION.md for
 details.
 
@@ -76,6 +87,12 @@ Verify the service is running:
 ```shell
 systemctl --user status openshell-gateway
 ```
+
+If neither Docker nor Podman is usable, the service exits and the journal
+reports that no compute driver is available. The RPM remains installed. Install
+and start a container runtime, then restart the service. The VM driver is a
+separate release artifact and must be installed and selected explicitly; see
+CONFIGURATION.md.
 
 ## Register the gateway with the CLI
 

--- a/deploy/rpm/QUICKSTART.md
+++ b/deploy/rpm/QUICKSTART.md
@@ -56,23 +56,17 @@ socket activation:
 systemctl --user enable --now podman.socket
 ```
 
-When using `install.sh`, select Podman explicitly after completing these
-prerequisites:
+The install script uses the gateway's automatic detection after installing the
+package. When it detects Podman, it prints the following command for rootless
+Podman users:
 
 ```shell
-curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh -s -- --compute-driver podman
+openshell-gateway config set --bind-address 0.0.0.0:17670
 ```
 
-The option updates the gateway configuration with the Podman driver and its
-required bridge-reachable bind address; it does not install or start Podman.
-For a direct RPM transaction, configure the same settings before starting the
-service:
-
-```shell
-openshell-gateway config set \
-  --compute-driver podman \
-  --bind-address 0.0.0.0:17670
-```
+The installer does not apply the command, pin the auto-detected driver, or
+install and start Podman. For a direct RPM transaction, run it before starting
+Podman-backed sandboxes.
 
 ### Network access
 

--- a/deploy/rpm/QUICKSTART.md
+++ b/deploy/rpm/QUICKSTART.md
@@ -56,17 +56,12 @@ socket activation:
 systemctl --user enable --now podman.socket
 ```
 
-The install script uses the gateway's automatic detection after installing the
-package. When it detects Podman, it prints the following command for rootless
-Podman users:
+Make the gateway reachable from rootless Podman containers before creating a
+sandbox:
 
 ```shell
 openshell-gateway config set --bind-address 0.0.0.0:17670
 ```
-
-The installer does not apply the command, pin the auto-detected driver, or
-install and start Podman. For a direct RPM transaction, run it before starting
-Podman-backed sandboxes.
 
 ### Network access
 
@@ -98,22 +93,6 @@ Verify the service is running:
 
 ```shell
 systemctl --user status openshell-gateway
-```
-
-If neither Docker nor Podman is usable, the service exits and the journal
-reports that no compute driver is available. The RPM remains installed and the
-supervised service retries automatically. Install and start a container
-runtime; restart the service manually if it does not recover. The VM driver is
-a separate release artifact and must be installed and selected explicitly; see
-CONFIGURATION.md.
-
-Automatic selection is evaluated on every gateway start. The gateway logs its
-selection and warns when multiple runtimes are available. Pin Docker before a
-restart if Podman is later installed but Docker should remain selected:
-
-```shell
-openshell-gateway config set --compute-driver docker
-systemctl --user restart openshell-gateway
 ```
 
 ## Register the gateway with the CLI

--- a/deploy/rpm/TROUBLESHOOTING.md
+++ b/deploy/rpm/TROUBLESHOOTING.md
@@ -6,10 +6,9 @@ and upgrade procedures for the RPM deployment.
 ## CLI compatibility
 
 The RPM installs the gateway as a systemd user service. On a standard RPM
-install the gateway auto-detects Podman because the package depends on it.
-The published online docs and some CLI commands assume a Docker/K3s
-deployment model. This section clarifies which commands work, which do not,
-and what to use instead.
+install the gateway auto-detects a reachable Podman socket, then Docker. The RPM
+does not install either runtime. This section clarifies which commands work,
+which do not, and what to use instead.
 
 ### Commands that work normally
 
@@ -47,9 +46,9 @@ systemd commands directly:
 
 ### Building from local Dockerfiles
 
-`openshell sandbox create --from ./Dockerfile` builds via the local
-Docker daemon. With the RPM Podman driver, build the image with Podman
-and reference it directly:
+`openshell sandbox create --from ./Dockerfile` builds via the local Docker
+daemon. When using Podman, build the image with Podman and reference it
+directly:
 
 ```shell
 podman build -t my-sandbox ./my-dir
@@ -134,6 +133,25 @@ journalctl --user -u openshell-gateway --no-pager -n 50
 
 Common causes:
 
+**No compute driver is available.** Install and start Docker or Podman, then
+restart the gateway:
+
+```shell
+# Docker
+docker info
+systemctl --user restart openshell-gateway
+
+# Or rootless Podman
+systemctl --user enable --now podman.socket
+systemctl --user restart openshell-gateway
+```
+
+The package remains installed after this startup failure. To use VM instead,
+install the matching `openshell-driver-vm` release artifact in a conventional
+libexec directory (or configure `driver_dir`), set
+`compute_drivers = ["vm"]`, and restart the gateway. Configuration alone does
+not install the VM driver, and the gateway never auto-detects it.
+
 **cgroups v1 detected.** The Podman driver requires cgroups v2.
 Check the version:
 
@@ -214,14 +232,14 @@ After upgrading the RPM packages:
 
 ```shell
 sudo dnf update openshell openshell-gateway
-systemctl --user restart podman.socket
 systemctl --user restart openshell-gateway
 ```
 
 The SQLite database schema is auto-migrated on startup. Running
 sandboxes are stopped during the restart.
 
-Restarting `podman.socket` after a package upgrade is recommended: if the
+When using Podman, restarting `podman.socket` after a package upgrade is
+recommended: if the
 unit file changed on disk during the upgrade, the running socket may become
 non-functional until restarted, causing the gateway to fail with a
 connection error on `/run/user/<uid>/podman/podman.sock`. The gateway
@@ -230,6 +248,10 @@ retries briefly on startup, but a stale socket will not recover on its own.
 Package upgrades do not overwrite `~/.config/openshell/gateway.toml` when you
 create one. New gateway process options can be added manually by referencing
 CONFIGURATION.md or running `openshell-gateway --help`.
+
+Existing RPM configurations that contain `compute_drivers = ["podman"]` keep
+that explicit selection after upgrade. Remove the setting to use automatic
+Podman/Docker detection, or change it to `compute_drivers = ["docker"]`.
 
 To pick up new container images after an upgrade:
 

--- a/deploy/rpm/TROUBLESHOOTING.md
+++ b/deploy/rpm/TROUBLESHOOTING.md
@@ -133,8 +133,9 @@ journalctl --user -u openshell-gateway --no-pager -n 50
 
 Common causes:
 
-**No compute driver is available.** Install and start Docker or Podman, then
-restart the gateway:
+**No compute driver is available.** The package remains installed and the
+supervised service retries automatically. Install and start Docker or Podman,
+then restart the gateway manually if it does not recover:
 
 ```shell
 # Docker
@@ -146,11 +147,19 @@ systemctl --user enable --now podman.socket
 systemctl --user restart openshell-gateway
 ```
 
-The package remains installed after this startup failure. To use VM instead,
-install the matching `openshell-driver-vm` release artifact in a conventional
-libexec directory (or configure `driver_dir`), set
+To use VM instead, install the matching `openshell-driver-vm` release artifact
+in a conventional libexec directory (or configure `driver_dir`), set
 `compute_drivers = ["vm"]`, and restart the gateway. Configuration alone does
 not install the VM driver, and the gateway never auto-detects it.
+
+The gateway logs which driver it auto-selects at each start. If the journal
+lists multiple available runtimes, pin the intended choice before another
+runtime changes the automatic result:
+
+```shell
+openshell-gateway config set --compute-driver docker
+systemctl --user restart openshell-gateway
+```
 
 **cgroups v1 detected.** The Podman driver requires cgroups v2.
 Check the version:

--- a/deploy/rpm/TROUBLESHOOTING.md
+++ b/deploy/rpm/TROUBLESHOOTING.md
@@ -133,9 +133,8 @@ journalctl --user -u openshell-gateway --no-pager -n 50
 
 Common causes:
 
-**No compute driver is available.** The package remains installed and the
-supervised service retries automatically. Install and start Docker or Podman,
-then restart the gateway manually if it does not recover:
+**No compute driver is available.** Install and start Docker or Podman, then
+restart the gateway:
 
 ```shell
 # Docker
@@ -151,15 +150,6 @@ To use VM instead, install the matching `openshell-driver-vm` release artifact
 in a conventional libexec directory (or configure `driver_dir`), set
 `compute_drivers = ["vm"]`, and restart the gateway. Configuration alone does
 not install the VM driver, and the gateway never auto-detects it.
-
-The gateway logs which driver it auto-selects at each start. If the journal
-lists multiple available runtimes, pin the intended choice before another
-runtime changes the automatic result:
-
-```shell
-openshell-gateway config set --compute-driver docker
-systemctl --user restart openshell-gateway
-```
 
 **cgroups v1 detected.** The Podman driver requires cgroups v2.
 Check the version:

--- a/deploy/rpm/gateway.toml.default
+++ b/deploy/rpm/gateway.toml.default
@@ -20,8 +20,8 @@ version = 1
 [openshell.gateway]
 # Listen on loopback by default. Rootless Podman requires an explicit
 # 0.0.0.0:17670 bind so sandbox containers can reach the gateway through the
-# host bridge. Use install.sh --compute-driver podman or update this setting
-# with openshell-gateway config set before starting Podman-backed sandboxes.
+# host bridge. Update this setting with openshell-gateway config set before
+# starting Podman-backed sandboxes.
 bind_address = "127.0.0.1:17670"
 
 # The gateway auto-detects Kubernetes, then a reachable Podman socket, then

--- a/deploy/rpm/gateway.toml.default
+++ b/deploy/rpm/gateway.toml.default
@@ -18,11 +18,11 @@
 version = 1
 
 [openshell.gateway]
-# Podman sandbox containers reach the gateway over the host network bridge,
-# which requires binding to all interfaces. Override to 127.0.0.1:17670 if
-# you don't use Podman or want loopback-only access (e.g. behind a reverse
-# proxy). mTLS is enabled by default and protects all connections.
-bind_address = "0.0.0.0:17670"
+# Listen on loopback by default. Rootless Podman requires an explicit
+# 0.0.0.0:17670 bind so sandbox containers can reach the gateway through the
+# host bridge. Use install.sh --compute-driver podman or update this setting
+# with openshell-gateway config set before starting Podman-backed sandboxes.
+bind_address = "127.0.0.1:17670"
 
 # The gateway auto-detects Kubernetes, then a reachable Podman socket, then
 # Docker. Set compute_drivers explicitly to override automatic selection.

--- a/deploy/rpm/gateway.toml.default
+++ b/deploy/rpm/gateway.toml.default
@@ -24,7 +24,5 @@ version = 1
 # proxy). mTLS is enabled by default and protects all connections.
 bind_address = "0.0.0.0:17670"
 
-# Pin to the Podman compute driver. Without this, the gateway auto-detects
-# in order: Kubernetes, Podman, Docker. Pinning prevents unexpected driver
-# selection if Docker is also installed on the host.
-compute_drivers = ["podman"]
+# The gateway auto-detects Kubernetes, then a reachable Podman socket, then
+# Docker. Set compute_drivers explicitly to override automatic selection.

--- a/docs/about/installation.mdx
+++ b/docs/about/installation.mdx
@@ -16,7 +16,7 @@ Install OpenShell with a single command:
 curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
 ```
 
-The script detects your operating system and installs the OpenShell CLI and gateway with your native package manager. It then starts the local gateway server so you can begin creating sandboxes. Install and start Docker or Podman first, unless you plan to install and explicitly select the VM driver.
+The script detects your operating system and installs the OpenShell CLI and gateway with your native package manager. It then starts the local gateway server so you can begin creating sandboxes. Install and start Docker or Podman first. For other compute options, refer to [Sandbox Compute Drivers](/reference/sandbox-compute-drivers).
 
 OpenShell packages do not have a hard dependency on Docker or Podman. A direct package-manager installation can therefore finish without a usable compute runtime. When `install.sh` cannot start the gateway, it prints service diagnostics and runtime recovery steps, exits nonzero, and leaves OpenShell installed.
 
@@ -35,17 +35,6 @@ OpenShell supports several local compute drivers. Package-managed gateways leave
 | MicroVM | The gateway is configured to create VM-backed sandboxes. | Host virtualization support. MicroVM uses Hypervisor.framework on macOS, KVM on Linux, and QEMU for GPU-backed sandboxes on Linux. |
 
 For detailed driver behavior, refer to [Sandbox Compute Drivers](/reference/sandbox-compute-drivers). For gateway and sandbox operations, refer to [Gateways](/sandboxes/manage-gateways) and [Sandboxes](/sandboxes/manage-sandboxes).
-
-## Package Runtime and Service Behavior
-
-| Installation | Container Runtime Dependency | VM Driver | Gateway Service |
-|---|---|---|---|
-| Debian/Ubuntu package | Docker or Podman must be installed separately. | Included, but never auto-detected. | `install.sh` enables and starts a systemd user service. A direct package transaction installs the unit without proving a runtime is available. |
-| Fedora/RHEL RPM | Docker or Podman must be installed separately. | Install the matching standalone release artifact separately. | `install.sh` enables and starts a systemd user service. A direct DNF transaction can succeed without a runtime. |
-| Homebrew | Docker Desktop, Docker Engine, or Podman must be installed separately. | Included, but never auto-detected. | `install.sh` starts the Homebrew service. |
-| Snap | Connect the Docker plug to the Docker snap; system-installed Docker and Podman are not available through that plug. | Not included. | snapd starts the system service. |
-
-Package-managed gateways leave `compute_drivers` unset unless you add an override. The gateway checks Kubernetes, then a reachable Podman socket, then Docker. It does not auto-detect the VM driver; set `compute_drivers = ["vm"]` or `OPENSHELL_DRIVERS=vm` after installing `openshell-driver-vm`.
 
 ## macOS
 
@@ -70,7 +59,7 @@ On Debian and Ubuntu, the install script uses a Debian package. The Debian packa
 
 Linux packages require glibc 2.28 or newer. The installer checks libc before downloading packages and exits with an error on older glibc versions, Alpine, musl-based distributions, or unknown libc environments.
 
-The Debian user service listens on `https://127.0.0.1:17670`. The RPM seeds `~/.config/openshell/gateway.toml` with `0.0.0.0:17670` so rootless Podman sandboxes can call back through the host bridge. Both services generate a local mTLS bundle before the gateway starts.
+The Linux user service listens on `https://127.0.0.1:17670`, starts from built-in defaults, and generates a local mTLS bundle before the gateway starts. Create `~/.config/openshell/gateway.toml` only when you need to override those defaults.
 
 The CLI reads the client bundle from `~/.config/openshell/gateways/openshell/mtls/`.
 

--- a/docs/about/installation.mdx
+++ b/docs/about/installation.mdx
@@ -18,7 +18,14 @@ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | 
 
 The script detects your operating system and installs the OpenShell CLI and gateway with your native package manager. It then starts the local gateway server so you can begin creating sandboxes. Install and start Docker or Podman first. For other compute options, refer to [Sandbox Compute Drivers](/reference/sandbox-compute-drivers).
 
-OpenShell packages do not have a hard dependency on Docker or Podman. A direct package-manager installation can therefore finish without a usable compute runtime. When `install.sh` cannot start the gateway, it prints service diagnostics and runtime recovery steps, exits nonzero, and leaves OpenShell installed.
+OpenShell packages do not have a hard dependency on Docker or Podman. Package
+installation and gateway health are separate outcomes. A direct package-manager
+installation can finish without a usable compute runtime. When `install.sh`
+cannot make the gateway healthy, it reports that package installation
+succeeded, prints service diagnostics and runtime recovery steps, exits
+nonzero, and leaves the supervised service installed. The service retries, so
+installing and starting Docker or Podman can make it healthy without
+reinstalling OpenShell.
 
 After installing the package, `install.sh` asks the gateway binary to detect the
 available compute driver. Detection does not change the gateway configuration
@@ -33,6 +40,17 @@ Rootless Podman containers cannot reach a gateway bound to host loopback. Run
 the command only when you use rootless Podman, then restart the gateway
 service. Docker and installations with no detected runtime retain the package's
 loopback listener. The command leaves driver selection automatic.
+
+The gateway repeats automatic detection at every process start and logs the
+selected driver. When multiple runtimes are available, it lists them and shows
+how to pin the intended driver. Installing Podman on a Docker-only host does
+not change the running gateway, but the next restart selects Podman because it
+has higher detection priority. Pin Docker before restarting if you want to keep
+using it:
+
+```shell
+openshell-gateway config set --compute-driver docker
+```
 
 You can also download release artifacts directly from the [OpenShell GitHub Releases](https://github.com/NVIDIA/OpenShell/releases) page.
 

--- a/docs/about/installation.mdx
+++ b/docs/about/installation.mdx
@@ -16,7 +16,9 @@ Install OpenShell with a single command:
 curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
 ```
 
-The script detects your operating system and installs the OpenShell CLI and gateway with your native package manager. It then starts the local gateway server so you can begin creating sandboxes.
+The script detects your operating system and installs the OpenShell CLI and gateway with your native package manager. It then starts the local gateway server so you can begin creating sandboxes. Install and start Docker or Podman first, unless you plan to install and explicitly select the VM driver.
+
+OpenShell packages do not have a hard dependency on Docker or Podman. A direct package-manager installation can therefore finish without a usable compute runtime. When `install.sh` cannot start the gateway, it prints service diagnostics and runtime recovery steps, exits nonzero, and leaves OpenShell installed.
 
 You can also download release artifacts directly from the [OpenShell GitHub Releases](https://github.com/NVIDIA/OpenShell/releases) page.
 
@@ -33,6 +35,17 @@ OpenShell supports several local compute drivers. Package-managed gateways leave
 | MicroVM | The gateway is configured to create VM-backed sandboxes. | Host virtualization support. MicroVM uses Hypervisor.framework on macOS, KVM on Linux, and QEMU for GPU-backed sandboxes on Linux. |
 
 For detailed driver behavior, refer to [Sandbox Compute Drivers](/reference/sandbox-compute-drivers). For gateway and sandbox operations, refer to [Gateways](/sandboxes/manage-gateways) and [Sandboxes](/sandboxes/manage-sandboxes).
+
+## Package Runtime and Service Behavior
+
+| Installation | Container Runtime Dependency | VM Driver | Gateway Service |
+|---|---|---|---|
+| Debian/Ubuntu package | Docker or Podman must be installed separately. | Included, but never auto-detected. | `install.sh` enables and starts a systemd user service. A direct package transaction installs the unit without proving a runtime is available. |
+| Fedora/RHEL RPM | Docker or Podman must be installed separately. | Install the matching standalone release artifact separately. | `install.sh` enables and starts a systemd user service. A direct DNF transaction can succeed without a runtime. |
+| Homebrew | Docker Desktop, Docker Engine, or Podman must be installed separately. | Included, but never auto-detected. | `install.sh` starts the Homebrew service. |
+| Snap | Connect the Docker plug to the Docker snap; system-installed Docker and Podman are not available through that plug. | Not included. | snapd starts the system service. |
+
+Package-managed gateways leave `compute_drivers` unset unless you add an override. The gateway checks Kubernetes, then a reachable Podman socket, then Docker. It does not auto-detect the VM driver; set `compute_drivers = ["vm"]` or `OPENSHELL_DRIVERS=vm` after installing `openshell-driver-vm`.
 
 ## macOS
 
@@ -57,7 +70,7 @@ On Debian and Ubuntu, the install script uses a Debian package. The Debian packa
 
 Linux packages require glibc 2.28 or newer. The installer checks libc before downloading packages and exits with an error on older glibc versions, Alpine, musl-based distributions, or unknown libc environments.
 
-The Linux user service listens on `https://127.0.0.1:17670`, starts from built-in defaults, and generates a local mTLS bundle before the gateway starts. Create `~/.config/openshell/gateway.toml` only when you need to override those defaults.
+The Debian user service listens on `https://127.0.0.1:17670`. The RPM seeds `~/.config/openshell/gateway.toml` with `0.0.0.0:17670` so rootless Podman sandboxes can call back through the host bridge. Both services generate a local mTLS bundle before the gateway starts.
 
 The CLI reads the client bundle from `~/.config/openshell/gateways/openshell/mtls/`.
 

--- a/docs/about/installation.mdx
+++ b/docs/about/installation.mdx
@@ -20,6 +20,22 @@ The script detects your operating system and installs the OpenShell CLI and gate
 
 OpenShell packages do not have a hard dependency on Docker or Podman. A direct package-manager installation can therefore finish without a usable compute runtime. When `install.sh` cannot start the gateway, it prints service diagnostics and runtime recovery steps, exits nonzero, and leaves OpenShell installed.
 
+To select a driver during a Debian, RPM, or Homebrew installation, pass
+`--compute-driver`. Install and start the selected runtime before running the
+installer; this option configures OpenShell but does not install or manage the
+runtime.
+
+```shell
+curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh -s -- --compute-driver podman
+```
+
+Supported values are `docker`, `podman`, `vm`, and `auto`. Podman selection
+also makes the gateway listener reachable from rootless containers. Docker and
+VM selection keep the listener on loopback. `auto` removes an existing driver
+pin so the gateway can detect a runtime. Set
+`OPENSHELL_INSTALL_COMPUTE_DRIVER` instead when an environment variable is more
+convenient; the command-line option takes precedence.
+
 You can also download release artifacts directly from the [OpenShell GitHub Releases](https://github.com/NVIDIA/OpenShell/releases) page.
 
 Use `openshell status` to confirm the CLI can reach the gateway.

--- a/docs/about/installation.mdx
+++ b/docs/about/installation.mdx
@@ -18,39 +18,8 @@ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | 
 
 The script detects your operating system and installs the OpenShell CLI and gateway with your native package manager. It then starts the local gateway server so you can begin creating sandboxes. Install and start Docker or Podman first. For other compute options, refer to [Sandbox Compute Drivers](/reference/sandbox-compute-drivers).
 
-OpenShell packages do not have a hard dependency on Docker or Podman. Package
-installation and gateway health are separate outcomes. A direct package-manager
-installation can finish without a usable compute runtime. When `install.sh`
-cannot make the gateway healthy, it reports that package installation
-succeeded, prints service diagnostics and runtime recovery steps, exits
-nonzero, and leaves the supervised service installed. The service retries, so
-installing and starting Docker or Podman can make it healthy without
-reinstalling OpenShell.
-
-After installing the package, `install.sh` asks the gateway binary to detect the
-available compute driver. Detection does not change the gateway configuration
-or listener address. If the gateway detects Podman, the installer prints the
-following command for rootless Podman users:
-
-```shell
-openshell-gateway config set --bind-address 0.0.0.0:17670
-```
-
-Rootless Podman containers cannot reach a gateway bound to host loopback. Run
-the command only when you use rootless Podman, then restart the gateway
-service. Docker and installations with no detected runtime retain the package's
-loopback listener. The command leaves driver selection automatic.
-
-The gateway repeats automatic detection at every process start and logs the
-selected driver. When multiple runtimes are available, it lists them and shows
-how to pin the intended driver. Installing Podman on a Docker-only host does
-not change the running gateway, but the next restart selects Podman because it
-has higher detection priority. Pin Docker before restarting if you want to keep
-using it:
-
-```shell
-openshell-gateway config set --compute-driver docker
-```
+The installer reports package installation and gateway health separately.
+Follow the printed recovery steps if the gateway is not healthy.
 
 You can also download release artifacts directly from the [OpenShell GitHub Releases](https://github.com/NVIDIA/OpenShell/releases) page.
 

--- a/docs/about/installation.mdx
+++ b/docs/about/installation.mdx
@@ -20,22 +20,19 @@ The script detects your operating system and installs the OpenShell CLI and gate
 
 OpenShell packages do not have a hard dependency on Docker or Podman. A direct package-manager installation can therefore finish without a usable compute runtime. When `install.sh` cannot start the gateway, it prints service diagnostics and runtime recovery steps, exits nonzero, and leaves OpenShell installed.
 
-To select a driver during a Debian, RPM, or Homebrew installation, pass
-`--compute-driver`. Install and start the selected runtime before running the
-installer; this option configures OpenShell but does not install or manage the
-runtime.
+After installing the package, `install.sh` asks the gateway binary to detect the
+available compute driver. Detection does not change the gateway configuration
+or listener address. If the gateway detects Podman, the installer prints the
+following command for rootless Podman users:
 
 ```shell
-curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh -s -- --compute-driver podman
+openshell-gateway config set --bind-address 0.0.0.0:17670
 ```
 
-Supported values are `docker`, `podman`, and `vm`. Podman selection also makes
-the gateway listener reachable from rootless containers. Docker and VM
-selection keep the listener on loopback. Omit the option to retain automatic
-driver selection and the package's loopback listener; on RPM installations,
-select Podman explicitly so sandbox callbacks can reach the gateway. Set
-`OPENSHELL_INSTALL_COMPUTE_DRIVER` instead when an environment variable is more
-convenient; the command-line option takes precedence.
+Rootless Podman containers cannot reach a gateway bound to host loopback. Run
+the command only when you use rootless Podman, then restart the gateway
+service. Docker and installations with no detected runtime retain the package's
+loopback listener. The command leaves driver selection automatic.
 
 You can also download release artifacts directly from the [OpenShell GitHub Releases](https://github.com/NVIDIA/OpenShell/releases) page.
 

--- a/docs/about/installation.mdx
+++ b/docs/about/installation.mdx
@@ -32,7 +32,8 @@ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | 
 Supported values are `docker`, `podman`, and `vm`. Podman selection also makes
 the gateway listener reachable from rootless containers. Docker and VM
 selection keep the listener on loopback. Omit the option to retain automatic
-driver selection. Set
+driver selection and the package's loopback listener; on RPM installations,
+select Podman explicitly so sandbox callbacks can reach the gateway. Set
 `OPENSHELL_INSTALL_COMPUTE_DRIVER` instead when an environment variable is more
 convenient; the command-line option takes precedence.
 

--- a/docs/about/installation.mdx
+++ b/docs/about/installation.mdx
@@ -29,10 +29,10 @@ runtime.
 curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh -s -- --compute-driver podman
 ```
 
-Supported values are `docker`, `podman`, `vm`, and `auto`. Podman selection
-also makes the gateway listener reachable from rootless containers. Docker and
-VM selection keep the listener on loopback. `auto` removes an existing driver
-pin so the gateway can detect a runtime. Set
+Supported values are `docker`, `podman`, and `vm`. Podman selection also makes
+the gateway listener reachable from rootless containers. Docker and VM
+selection keep the listener on loopback. Omit the option to retain automatic
+driver selection. Set
 `OPENSHELL_INSTALL_COMPUTE_DRIVER` instead when an environment variable is more
 convenient; the command-line option takes precedence.
 

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -31,6 +31,18 @@ Package-managed gateways do not require a TOML file. Create one at the package's
 
 ## Update Configuration from the CLI
 
+Use `detect-driver` to run the same automatic driver detection as gateway
+startup:
+
+```shell
+openshell-gateway config detect-driver
+```
+
+The command prints one machine-readable value: `kubernetes`, `podman`,
+`docker`, or `none`. It checks drivers in that order and does not detect the
+opt-in VM driver. The command only inspects the current environment; it does
+not read or update the gateway configuration.
+
 Use `openshell-gateway config set` for typed updates to driver selection and
 the listener address:
 

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -29,6 +29,28 @@ Package-managed gateways do not require a TOML file. Create one at the package's
 | Fedora/RHEL RPM | `$XDG_CONFIG_HOME/openshell/gateway.toml`, usually `~/.config/openshell/gateway.toml` for the systemd user service. |
 | Snap | `$SNAP_COMMON/gateway.toml`, usually `/var/snap/openshell/common/gateway.toml`. |
 
+## Update Configuration from the CLI
+
+Use `openshell-gateway config set` for typed updates to driver selection and
+the listener address:
+
+```shell
+openshell-gateway config set \
+  --compute-driver podman \
+  --bind-address 0.0.0.0:17670
+```
+
+The command updates `$XDG_CONFIG_HOME/openshell/gateway.toml`, creating the
+file and parent directory when needed. Pass `--config <PATH>` or set
+`OPENSHELL_GATEWAY_CONFIG` to update another file. The command validates the
+result, replaces the file atomically, and preserves comments and unrelated
+settings. Use `--compute-driver auto` to remove only the `compute_drivers`
+setting.
+
+Restart the gateway service after updating a running installation. Gateway
+process flags and `OPENSHELL_*` runtime overrides still take precedence over
+the TOML file.
+
 ## Layout
 
 The file is rooted at `[openshell]`. Gateway-wide settings live under `[openshell.gateway]`. Each compute driver owns its own `[openshell.drivers.<name>]` table. Shared keys set at gateway scope are inherited into driver tables when not overridden.

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -43,14 +43,6 @@ The command prints one machine-readable value: `kubernetes`, `podman`,
 opt-in VM driver. The command only inspects the current environment; it does
 not read or update the gateway configuration.
 
-Gateway startup evaluates the same order on every process start. It logs the
-selected driver and warns when multiple runtimes are available. Pin a driver
-when you do not want later runtime changes to affect selection:
-
-```shell
-openshell-gateway config set --compute-driver docker
-```
-
 Use `openshell-gateway config set` for typed updates to driver selection and
 the listener address:
 

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -43,21 +43,22 @@ The command prints one machine-readable value: `kubernetes`, `podman`,
 opt-in VM driver. The command only inspects the current environment; it does
 not read or update the gateway configuration.
 
-Use `openshell-gateway config set` for typed updates to driver selection and
-the listener address:
+Use `openshell-gateway config set` with one or more dotted `KEY=VALUE`
+assignments. The command applies every assignment atomically:
 
 ```shell
 openshell-gateway config set \
-  --compute-driver podman \
-  --bind-address 0.0.0.0:17670
+  'openshell.gateway.compute_drivers=["podman"]' \
+  openshell.gateway.bind_address=0.0.0.0:17670
 ```
 
 The command updates `$XDG_CONFIG_HOME/openshell/gateway.toml`, creating the
 file and parent directory when needed. Pass `--config <PATH>` or set
 `OPENSHELL_GATEWAY_CONFIG` to update another file. The command validates the
 result, replaces the file atomically, and preserves comments and unrelated
-settings. Use `--compute-driver auto` to remove only the `compute_drivers`
-setting.
+settings. TOML booleans, integers, arrays, and quoted strings retain their
+types. Other unquoted values are stored as strings. Set
+`openshell.gateway.compute_drivers=[]` to restore automatic driver selection.
 
 Restart the gateway service after updating a running installation. Gateway
 process flags and `OPENSHELL_*` runtime overrides still take precedence over

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -43,6 +43,14 @@ The command prints one machine-readable value: `kubernetes`, `podman`,
 opt-in VM driver. The command only inspects the current environment; it does
 not read or update the gateway configuration.
 
+Gateway startup evaluates the same order on every process start. It logs the
+selected driver and warns when multiple runtimes are available. Pin a driver
+when you do not want later runtime changes to affect selection:
+
+```shell
+openshell-gateway config set --compute-driver docker
+```
+
 Use `openshell-gateway config set` for typed updates to driver selection and
 the listener address:
 

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -29,6 +29,19 @@ Package-managed gateways do not require a TOML file. Create one at the package's
 | Fedora/RHEL RPM | `$XDG_CONFIG_HOME/openshell/gateway.toml`, usually `~/.config/openshell/gateway.toml` for the systemd user service. |
 | Snap | `$SNAP_COMMON/gateway.toml`, usually `/var/snap/openshell/common/gateway.toml`. |
 
+When `compute_drivers` is unset, package-managed gateways auto-detect
+Kubernetes, then a reachable Podman socket, then Docker. The RPM service seeds
+a TOML file only to retain its `0.0.0.0:17670` callback address; it leaves
+driver selection unset. Existing RPM configuration files are not overwritten
+on upgrade, so remove an old `compute_drivers = ["podman"]` entry to opt into
+automatic Podman/Docker selection.
+
+The VM driver is never auto-detected. Debian packages and Homebrew include the
+driver binary. RPM and Snap do not; RPM users must install the matching
+standalone release artifact in a conventional libexec directory or set
+`[openshell.drivers.vm].driver_dir`. Select VM with
+`compute_drivers = ["vm"]` or `OPENSHELL_DRIVERS=vm`.
+
 ## Layout
 
 The file is rooted at `[openshell]`. Gateway-wide settings live under `[openshell.gateway]`. Each compute driver owns its own `[openshell.drivers.<name>]` table. Shared keys set at gateway scope are inherited into driver tables when not overridden.

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -29,19 +29,6 @@ Package-managed gateways do not require a TOML file. Create one at the package's
 | Fedora/RHEL RPM | `$XDG_CONFIG_HOME/openshell/gateway.toml`, usually `~/.config/openshell/gateway.toml` for the systemd user service. |
 | Snap | `$SNAP_COMMON/gateway.toml`, usually `/var/snap/openshell/common/gateway.toml`. |
 
-When `compute_drivers` is unset, package-managed gateways auto-detect
-Kubernetes, then a reachable Podman socket, then Docker. The RPM service seeds
-a TOML file only to retain its `0.0.0.0:17670` callback address; it leaves
-driver selection unset. Existing RPM configuration files are not overwritten
-on upgrade, so remove an old `compute_drivers = ["podman"]` entry to opt into
-automatic Podman/Docker selection.
-
-The VM driver is never auto-detected. Debian packages and Homebrew include the
-driver binary. RPM and Snap do not; RPM users must install the matching
-standalone release artifact in a conventional libexec directory or set
-`[openshell.drivers.vm].driver_dir`. Select VM with
-`compute_drivers = ["vm"]` or `OPENSHELL_DRIVERS=vm`.
-
 ## Layout
 
 The file is rooted at `[openshell]`. Gateway-wide settings live under `[openshell.gateway]`. Each compute driver owns its own `[openshell.drivers.<name>]` table. Shared keys set at gateway scope are inherited into driver tables when not overridden.

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -27,19 +27,6 @@ Non-reserved names select an extension driver and require a
 
 When `compute_drivers` is unset, the gateway auto-detects Kubernetes, then Podman, then Docker by CLI availability or a local Unix socket. The VM driver is never auto-detected; configure it explicitly with `compute_drivers = ["vm"]` or set `OPENSHELL_DRIVERS=vm` in the launch environment.
 
-The gateway evaluates automatic selection at every process start and logs both
-the selected driver and the available drivers. When more than one runtime is
-available, it warns that the selected driver can change after environment
-changes and shows how to pin the intended choice:
-
-```shell
-openshell-gateway config set --compute-driver docker
-```
-
-Auto-selected Podman on a loopback listener also logs the rootless Podman
-bind-address command. These startup warnings cover runtimes installed after
-the original OpenShell installation.
-
 For Linux package-managed gateways, persist the selection without editing TOML
 directly:
 
@@ -47,19 +34,6 @@ directly:
 openshell-gateway config set --compute-driver docker
 systemctl --user restart openshell-gateway
 ```
-
-The Debian, RPM, and Homebrew installer runs
-`openshell-gateway config detect-driver` after package installation. Detection
-does not change the gateway configuration. When Podman is detected, the
-installer tells rootless Podman users to select Podman and make the listener
-reachable through the host bridge:
-
-```shell
-openshell-gateway config set --bind-address 0.0.0.0:17670
-```
-
-Restart the gateway service after running the command. The installer does not
-pin the detected driver or install and manage Docker, Podman, or the VM driver.
 
 Package availability differs by installation method:
 

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -31,7 +31,7 @@ For Linux package-managed gateways, persist the selection without editing TOML
 directly:
 
 ```shell
-openshell-gateway config set --compute-driver docker
+openshell-gateway config set 'openshell.gateway.compute_drivers=["docker"]'
 systemctl --user restart openshell-gateway
 ```
 

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -35,9 +35,18 @@ openshell-gateway config set --compute-driver docker
 systemctl --user restart openshell-gateway
 ```
 
-The Debian, RPM, and Homebrew installer also accepts `--compute-driver`. The
-installer configures the selected driver and its listener address, but it does
-not install or manage Docker, Podman, or the VM driver.
+The Debian, RPM, and Homebrew installer runs
+`openshell-gateway config detect-driver` after package installation. Detection
+does not change the gateway configuration. When Podman is detected, the
+installer tells rootless Podman users to select Podman and make the listener
+reachable through the host bridge:
+
+```shell
+openshell-gateway config set --bind-address 0.0.0.0:17670
+```
+
+Restart the gateway service after running the command. The installer does not
+pin the detected driver or install and manage Docker, Podman, or the VM driver.
 
 Package availability differs by installation method:
 

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -27,6 +27,18 @@ Non-reserved names select an extension driver and require a
 
 When `compute_drivers` is unset, the gateway auto-detects Kubernetes, then Podman, then Docker by CLI availability or a local Unix socket. The VM driver is never auto-detected; configure it explicitly with `compute_drivers = ["vm"]` or set `OPENSHELL_DRIVERS=vm` in the launch environment.
 
+For Linux package-managed gateways, persist the selection without editing TOML
+directly:
+
+```shell
+openshell-gateway config set --compute-driver docker
+systemctl --user restart openshell-gateway
+```
+
+The Debian, RPM, and Homebrew installer also accepts `--compute-driver`. The
+installer configures the selected driver and its listener address, but it does
+not install or manage Docker, Podman, or the VM driver.
+
 Package availability differs by installation method:
 
 | Installation | `openshell-driver-vm` availability |

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -27,6 +27,18 @@ Non-reserved names select an extension driver and require a
 
 When `compute_drivers` is unset, the gateway auto-detects Kubernetes, then Podman, then Docker by CLI availability or a local Unix socket. The VM driver is never auto-detected; configure it explicitly with `compute_drivers = ["vm"]` or set `OPENSHELL_DRIVERS=vm` in the launch environment.
 
+Package availability differs by installation method:
+
+| Installation | `openshell-driver-vm` availability |
+|---|---|
+| Debian/Ubuntu package | Included under `/usr/libexec/openshell`. |
+| Homebrew | Included under the formula's libexec directory. |
+| Fedora/RHEL RPM | Not included. Install the matching standalone release artifact in a conventional libexec directory or configure `driver_dir`. |
+| Snap | Not included. |
+
+Standalone VM driver tarballs are published with OpenShell releases. Installing
+the binary does not select it; VM always requires an explicit driver setting.
+
 Common gateway options:
 
 | Gateway TOML option | Description |
@@ -254,7 +266,9 @@ For maintainer-level implementation details, refer to the [VM driver README](htt
 
 ### Enable the VM Driver
 
-The VM driver is opt-in. Release packages can install `openshell-driver-vm`, but the gateway does not select it unless you configure the driver explicitly.
+The VM driver is opt-in. Debian packages and Homebrew include
+`openshell-driver-vm`; RPM and Snap packages do not. The gateway does not select
+VM unless you configure the driver explicitly.
 
 Enable VM by setting `compute_drivers = ["vm"]` in the gateway TOML file:
 

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -27,6 +27,19 @@ Non-reserved names select an extension driver and require a
 
 When `compute_drivers` is unset, the gateway auto-detects Kubernetes, then Podman, then Docker by CLI availability or a local Unix socket. The VM driver is never auto-detected; configure it explicitly with `compute_drivers = ["vm"]` or set `OPENSHELL_DRIVERS=vm` in the launch environment.
 
+The gateway evaluates automatic selection at every process start and logs both
+the selected driver and the available drivers. When more than one runtime is
+available, it warns that the selected driver can change after environment
+changes and shows how to pin the intended choice:
+
+```shell
+openshell-gateway config set --compute-driver docker
+```
+
+Auto-selected Podman on a loopback listener also logs the rootless Podman
+bind-address command. These startup warnings cover runtimes installed after
+the original OpenShell installation.
+
 For Linux package-managed gateways, persist the selection without editing TOML
 directly:
 

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -31,8 +31,8 @@ Package availability differs by installation method:
 
 | Installation | `openshell-driver-vm` availability |
 |---|---|
-| Debian/Ubuntu package | Included under `/usr/libexec/openshell`. |
-| Homebrew | Included under the formula's libexec directory. |
+| Debian/Ubuntu package | Included under `/usr/libexec/openshell`; the gateway searches this location automatically after you select VM. |
+| Homebrew | Included under the formula's libexec directory; the gateway searches the formula prefix automatically after you select VM. |
 | Fedora/RHEL RPM | Not included. Install the matching standalone release artifact in a conventional libexec directory or configure `driver_dir`. |
 | Snap | Not included. |
 
@@ -266,9 +266,8 @@ For maintainer-level implementation details, refer to the [VM driver README](htt
 
 ### Enable the VM Driver
 
-The VM driver is opt-in. Debian packages and Homebrew include
-`openshell-driver-vm`; RPM and Snap packages do not. The gateway does not select
-VM unless you configure the driver explicitly.
+The VM driver is opt-in. The gateway does not select VM unless you configure
+the driver explicitly, even when `openshell-driver-vm` is installed.
 
 Enable VM by setting `compute_drivers = ["vm"]` in the gateway TOML file:
 

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,7 @@ HOMEBREW_FORMULA_NAME="openshell"
 BREAKING_RELEASE_VERSION="0.0.37"
 LINUX_PACKAGE_GLIBC_MIN_VERSION="2.28"
 UPGRADE_NOTICE_ACK="${OPENSHELL_ACK_BREAKING_UPGRADE:-}"
+INSTALL_COMPUTE_DRIVER="${OPENSHELL_INSTALL_COMPUTE_DRIVER:-}"
 
 info() {
   printf '%s: %s\n' "$APP_NAME" "$*" >&2
@@ -46,7 +47,10 @@ USAGE:
     curl -fsSL https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
 
 OPTIONS:
-    --help       Print this help message
+    --compute-driver DRIVER
+                 Persist the gateway compute driver: auto, docker, podman,
+                 or vm. Install the required runtime or driver separately.
+    --help       Print this help message.
 
 ENVIRONMENT VARIABLES:
     OPENSHELL_VERSION   Release tag to install (default: latest tagged release).
@@ -54,6 +58,9 @@ ENVIRONMENT VARIABLES:
     OPENSHELL_ACK_BREAKING_UPGRADE
                         Set to 1 only after backing up and cleaning up a
                         pre-v0.0.37 installation.
+    OPENSHELL_INSTALL_COMPUTE_DRIVER
+                        Same as --compute-driver. The command-line option
+                        takes precedence when both are set.
 
 NOTES:
     When OPENSHELL_VERSION is unset, this resolves the latest tagged release
@@ -64,6 +71,54 @@ NOTES:
     macOS installs the release Homebrew formula on Apple Silicon and starts a
     brew services-backed local gateway.
 EOF
+}
+
+parse_install_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --compute-driver)
+        [ "$#" -ge 2 ] || error "--compute-driver requires a value"
+        INSTALL_COMPUTE_DRIVER="$2"
+        shift 2
+        ;;
+      --compute-driver=*)
+        INSTALL_COMPUTE_DRIVER="${1#*=}"
+        [ -n "$INSTALL_COMPUTE_DRIVER" ] || error "--compute-driver requires a value"
+        shift
+        ;;
+      --help)
+        usage
+        exit 0
+        ;;
+      *)
+        error "unknown option: $1"
+        ;;
+    esac
+  done
+
+  case "$INSTALL_COMPUTE_DRIVER" in
+    "" | auto | docker | podman | vm)
+      ;;
+    kubernetes)
+      error "--compute-driver kubernetes is not supported by the local installer; use the OpenShell Helm chart"
+      ;;
+    *)
+      error "unsupported compute driver '${INSTALL_COMPUTE_DRIVER}'; expected auto, docker, podman, or vm"
+      ;;
+  esac
+}
+
+print_compute_driver_prerequisite_notice() {
+  case "$INSTALL_COMPUTE_DRIVER" in
+    docker)
+      warn "Docker is not installed or managed by the OpenShell installer. Install and start Docker before the gateway starts."
+      info "Docker installation instructions: https://docs.docker.com/engine/install/"
+      ;;
+    podman)
+      warn "Podman is not installed or managed by the OpenShell installer. Install Podman and start its API socket before the gateway starts."
+      info "Podman installation instructions: https://podman.io/docs/installation"
+      ;;
+  esac
 }
 
 has_cmd() {
@@ -682,6 +737,26 @@ patch_homebrew_formula() {
 
 }
 
+configure_gateway_compute_driver() {
+  [ -n "$INSTALL_COMPUTE_DRIVER" ] || return 0
+
+  _gateway_bin="${OPENSHELL_GATEWAY_BIN:-openshell-gateway}"
+  set -- "$_gateway_bin" config set --compute-driver "$INSTALL_COMPUTE_DRIVER"
+  case "$INSTALL_COMPUTE_DRIVER" in
+    podman)
+      set -- "$@" --bind-address "0.0.0.0:${LOCAL_GATEWAY_PORT}"
+      ;;
+    docker | vm)
+      set -- "$@" --bind-address "127.0.0.1:${LOCAL_GATEWAY_PORT}"
+      ;;
+    auto)
+      ;;
+  esac
+
+  info "configuring gateway compute driver: ${INSTALL_COMPUTE_DRIVER}"
+  as_target_user "$@"
+}
+
 start_user_gateway() {
   info "restarting openshell-gateway user service as ${TARGET_USER}..."
 
@@ -915,6 +990,7 @@ install_linux_deb() {
   info "installing ${_deb_file}..."
   install_deb_package "$_deb_path"
   info "installed ${APP_NAME} package from ${RELEASE_TAG}"
+  configure_gateway_compute_driver
   start_user_gateway
 }
 
@@ -962,6 +1038,7 @@ install_linux_rpm() {
   info "installing ${_rpm_file} and ${_gateway_rpm_file}..."
   install_rpm_packages "${_tmpdir}/${_rpm_file}" "${_tmpdir}/${_gateway_rpm_file}"
   info "installed ${APP_NAME} RPM packages from ${RELEASE_TAG}"
+  configure_gateway_compute_driver
   start_user_gateway
 }
 
@@ -1000,9 +1077,13 @@ install_macos_homebrew() {
     as_target_user brew install --formula "$_formula_ref"
   fi
 
+  _brew_prefix="$(as_target_user brew --prefix 2>/dev/null || true)"
+  if [ -n "$_brew_prefix" ]; then
+    OPENSHELL_GATEWAY_BIN="${_brew_prefix}/bin/openshell-gateway"
+  fi
+  configure_gateway_compute_driver
   restart_homebrew_gateway "$_formula_ref"
 
-  _brew_prefix="$(as_target_user brew --prefix 2>/dev/null || true)"
   if [ -n "$_brew_prefix" ] && [ -x "${_brew_prefix}/bin/openshell" ]; then
     OPENSHELL_REGISTER_BIN="${_brew_prefix}/bin/openshell"
   fi
@@ -1023,17 +1104,8 @@ restart_homebrew_gateway() {
 }
 
 main() {
-  if [ "$#" -gt 0 ]; then
-    case "$1" in
-      --help)
-        usage
-        exit 0
-        ;;
-      *)
-        error "unknown option: $1"
-        ;;
-    esac
-  fi
+  parse_install_args "$@"
+  print_compute_driver_prerequisite_notice
 
   require_cmd curl
   RELEASE_TAG="$(resolve_release_tag)"

--- a/install.sh
+++ b/install.sh
@@ -686,20 +686,32 @@ start_user_gateway() {
   info "restarting openshell-gateway user service as ${TARGET_USER}..."
 
   if ! as_target_user systemctl --user daemon-reload; then
-    info "could not reach the user systemd manager for ${TARGET_USER}"
-    info "restart the gateway later with: systemctl --user enable openshell-gateway && systemctl --user restart openshell-gateway"
-    info "then register it with: openshell gateway add https://127.0.0.1:17670 --local --name openshell"
-    return 0
+    dump_local_gateway_diagnostics
+    gateway_startup_error "could not reload the user systemd manager for ${TARGET_USER}"
   fi
 
-  as_target_user systemctl --user enable openshell-gateway
-  as_target_user systemctl --user restart openshell-gateway
-  as_target_user systemctl --user is-active --quiet openshell-gateway
+  if ! as_target_user systemctl --user enable openshell-gateway; then
+    dump_local_gateway_diagnostics
+    gateway_startup_error "could not enable the openshell-gateway user service"
+  fi
+  if ! as_target_user systemctl --user restart openshell-gateway; then
+    dump_local_gateway_diagnostics
+    gateway_startup_error "could not restart the openshell-gateway user service"
+  fi
+  if ! as_target_user systemctl --user is-active --quiet openshell-gateway; then
+    dump_local_gateway_diagnostics
+    gateway_startup_error "the openshell-gateway user service is not active"
+  fi
 
   info "registering local gateway as ${TARGET_USER}..."
   register_local_gateway
   wait_for_local_gateway_listener
   wait_for_local_gateway_status
+}
+
+gateway_startup_error() {
+  _reason="$1"
+  error "${_reason}. Review the diagnostics above. OpenShell remains installed. If the logs report that no compute driver is available, install and start Docker or Podman, or install openshell-driver-vm and explicitly configure compute_drivers = [\"vm\"]. Then restart the gateway service."
 }
 
 dump_local_gateway_diagnostics() {
@@ -781,7 +793,7 @@ wait_for_local_gateway_listener() {
 
   [ -z "$_last_output" ] || printf '%s\n' "$_last_output" >&2
   dump_local_gateway_diagnostics
-  error "local gateway listener did not become reachable at ${_probe_url} within ${_timeout}s"
+  gateway_startup_error "local gateway listener did not become reachable at ${_probe_url} within ${_timeout}s"
 }
 
 wait_for_local_gateway_status() {
@@ -806,7 +818,7 @@ wait_for_local_gateway_status() {
 
   [ -z "$_status_output" ] || printf '%s\n' "$_status_output" >&2
   dump_local_gateway_diagnostics
-  error "openshell status did not report connected within ${_timeout}s"
+  gateway_startup_error "openshell status did not report connected within ${_timeout}s"
 }
 
 remove_local_gateway_registration() {
@@ -988,13 +1000,7 @@ install_macos_homebrew() {
     as_target_user brew install --formula "$_formula_ref"
   fi
 
-  info "restarting OpenShell Homebrew service..."
-  if ! as_target_user brew services restart "$_formula_ref"; then
-    warn "could not restart the OpenShell Homebrew service"
-    info "restart it later with: brew services restart ${_formula_ref}"
-    info "then register it with: openshell gateway add https://127.0.0.1:${LOCAL_GATEWAY_PORT} --local --name openshell"
-    return 0
-  fi
+  restart_homebrew_gateway "$_formula_ref"
 
   _brew_prefix="$(as_target_user brew --prefix 2>/dev/null || true)"
   if [ -n "$_brew_prefix" ] && [ -x "${_brew_prefix}/bin/openshell" ]; then
@@ -1005,6 +1011,15 @@ install_macos_homebrew() {
   register_local_gateway
   wait_for_local_gateway_listener
   wait_for_local_gateway_status
+}
+
+restart_homebrew_gateway() {
+  _formula_ref="$1"
+  info "restarting OpenShell Homebrew service..."
+  if ! as_target_user brew services restart "$_formula_ref"; then
+    dump_local_gateway_diagnostics
+    gateway_startup_error "could not restart the OpenShell Homebrew service"
+  fi
 }
 
 main() {

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,6 @@ HOMEBREW_FORMULA_NAME="openshell"
 BREAKING_RELEASE_VERSION="0.0.37"
 LINUX_PACKAGE_GLIBC_MIN_VERSION="2.28"
 UPGRADE_NOTICE_ACK="${OPENSHELL_ACK_BREAKING_UPGRADE:-}"
-INSTALL_COMPUTE_DRIVER="${OPENSHELL_INSTALL_COMPUTE_DRIVER:-}"
 
 info() {
   printf '%s: %s\n' "$APP_NAME" "$*" >&2
@@ -47,9 +46,6 @@ USAGE:
     curl -fsSL https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
 
 OPTIONS:
-    --compute-driver DRIVER
-                 Persist the gateway compute driver: docker, podman, or vm.
-                 Install the required runtime or driver separately.
     --help       Print this help message.
 
 ENVIRONMENT VARIABLES:
@@ -58,10 +54,6 @@ ENVIRONMENT VARIABLES:
     OPENSHELL_ACK_BREAKING_UPGRADE
                         Set to 1 only after backing up and cleaning up a
                         pre-v0.0.37 installation.
-    OPENSHELL_INSTALL_COMPUTE_DRIVER
-                        Same as --compute-driver. The command-line option
-                        takes precedence when both are set.
-
 NOTES:
     When OPENSHELL_VERSION is unset, this resolves the latest tagged release
     from ${GITHUB_URL}/releases/latest.
@@ -71,54 +63,6 @@ NOTES:
     macOS installs the release Homebrew formula on Apple Silicon and starts a
     brew services-backed local gateway.
 EOF
-}
-
-parse_install_args() {
-  while [ "$#" -gt 0 ]; do
-    case "$1" in
-      --compute-driver)
-        [ "$#" -ge 2 ] || error "--compute-driver requires a value"
-        INSTALL_COMPUTE_DRIVER="$2"
-        shift 2
-        ;;
-      --compute-driver=*)
-        INSTALL_COMPUTE_DRIVER="${1#*=}"
-        [ -n "$INSTALL_COMPUTE_DRIVER" ] || error "--compute-driver requires a value"
-        shift
-        ;;
-      --help)
-        usage
-        exit 0
-        ;;
-      *)
-        error "unknown option: $1"
-        ;;
-    esac
-  done
-
-  case "$INSTALL_COMPUTE_DRIVER" in
-    "" | docker | podman | vm)
-      ;;
-    kubernetes)
-      error "--compute-driver kubernetes is not supported by the local installer; use the OpenShell Helm chart"
-      ;;
-    *)
-      error "unsupported compute driver '${INSTALL_COMPUTE_DRIVER}'; expected docker, podman, or vm"
-      ;;
-  esac
-}
-
-print_compute_driver_prerequisite_notice() {
-  case "$INSTALL_COMPUTE_DRIVER" in
-    docker)
-      warn "Docker is not installed or managed by the OpenShell installer. Install and start Docker before the gateway starts."
-      info "Docker installation instructions: https://docs.docker.com/engine/install/"
-      ;;
-    podman)
-      warn "Podman is not installed or managed by the OpenShell installer. Install Podman and start its API socket before the gateway starts."
-      info "Podman installation instructions: https://podman.io/docs/installation"
-      ;;
-  esac
 }
 
 has_cmd() {
@@ -737,22 +681,25 @@ patch_homebrew_formula() {
 
 }
 
-configure_gateway_compute_driver() {
-  [ -n "$INSTALL_COMPUTE_DRIVER" ] || return 0
-
+report_detected_compute_driver() {
   _gateway_bin="${OPENSHELL_GATEWAY_BIN:-openshell-gateway}"
-  set -- "$_gateway_bin" config set --compute-driver "$INSTALL_COMPUTE_DRIVER"
-  case "$INSTALL_COMPUTE_DRIVER" in
+  if ! _detected_driver="$(as_target_user "$_gateway_bin" config detect-driver)"; then
+    warn "could not detect an available compute driver; the gateway will report runtime errors when it starts"
+    return 0
+  fi
+
+  case "$_detected_driver" in
     podman)
-      set -- "$@" --bind-address "0.0.0.0:${LOCAL_GATEWAY_PORT}"
+      warn "Podman was auto-detected. If you use rootless Podman, configure the gateway to listen on the host bridge:"
+      info "openshell-gateway config set --bind-address 0.0.0.0:${LOCAL_GATEWAY_PORT}"
+      info "Restart the gateway service for changes to take effect."
       ;;
-    docker | vm)
-      set -- "$@" --bind-address "127.0.0.1:${LOCAL_GATEWAY_PORT}"
+    kubernetes | docker | none)
+      ;;
+    *)
+      warn "gateway returned an unexpected detected compute driver: ${_detected_driver}"
       ;;
   esac
-
-  info "configuring gateway compute driver: ${INSTALL_COMPUTE_DRIVER}"
-  as_target_user "$@"
 }
 
 start_user_gateway() {
@@ -988,7 +935,7 @@ install_linux_deb() {
   info "installing ${_deb_file}..."
   install_deb_package "$_deb_path"
   info "installed ${APP_NAME} package from ${RELEASE_TAG}"
-  configure_gateway_compute_driver
+  report_detected_compute_driver
   start_user_gateway
 }
 
@@ -1036,7 +983,7 @@ install_linux_rpm() {
   info "installing ${_rpm_file} and ${_gateway_rpm_file}..."
   install_rpm_packages "${_tmpdir}/${_rpm_file}" "${_tmpdir}/${_gateway_rpm_file}"
   info "installed ${APP_NAME} RPM packages from ${RELEASE_TAG}"
-  configure_gateway_compute_driver
+  report_detected_compute_driver
   start_user_gateway
 }
 
@@ -1079,7 +1026,7 @@ install_macos_homebrew() {
   if [ -n "$_brew_prefix" ]; then
     OPENSHELL_GATEWAY_BIN="${_brew_prefix}/bin/openshell-gateway"
   fi
-  configure_gateway_compute_driver
+  report_detected_compute_driver
   restart_homebrew_gateway "$_formula_ref"
 
   if [ -n "$_brew_prefix" ] && [ -x "${_brew_prefix}/bin/openshell" ]; then
@@ -1102,8 +1049,17 @@ restart_homebrew_gateway() {
 }
 
 main() {
-  parse_install_args "$@"
-  print_compute_driver_prerequisite_notice
+  if [ "$#" -gt 0 ]; then
+    case "$1" in
+      --help)
+        usage
+        exit 0
+        ;;
+      *)
+        error "unknown option: $1"
+        ;;
+    esac
+  fi
 
   require_cmd curl
   RELEASE_TAG="$(resolve_release_tag)"

--- a/install.sh
+++ b/install.sh
@@ -48,8 +48,8 @@ USAGE:
 
 OPTIONS:
     --compute-driver DRIVER
-                 Persist the gateway compute driver: auto, docker, podman,
-                 or vm. Install the required runtime or driver separately.
+                 Persist the gateway compute driver: docker, podman, or vm.
+                 Install the required runtime or driver separately.
     --help       Print this help message.
 
 ENVIRONMENT VARIABLES:
@@ -97,13 +97,13 @@ parse_install_args() {
   done
 
   case "$INSTALL_COMPUTE_DRIVER" in
-    "" | auto | docker | podman | vm)
+    "" | docker | podman | vm)
       ;;
     kubernetes)
       error "--compute-driver kubernetes is not supported by the local installer; use the OpenShell Helm chart"
       ;;
     *)
-      error "unsupported compute driver '${INSTALL_COMPUTE_DRIVER}'; expected auto, docker, podman, or vm"
+      error "unsupported compute driver '${INSTALL_COMPUTE_DRIVER}'; expected docker, podman, or vm"
       ;;
   esac
 }
@@ -748,8 +748,6 @@ configure_gateway_compute_driver() {
       ;;
     docker | vm)
       set -- "$@" --bind-address "127.0.0.1:${LOCAL_GATEWAY_PORT}"
-      ;;
-    auto)
       ;;
   esac
 

--- a/install.sh
+++ b/install.sh
@@ -691,7 +691,7 @@ report_detected_compute_driver() {
   case "$_detected_driver" in
     podman)
       warn "Podman was auto-detected. If you use rootless Podman, configure the gateway to listen on the host bridge:"
-      info "openshell-gateway config set --bind-address 0.0.0.0:${LOCAL_GATEWAY_PORT}"
+      info "openshell-gateway config set openshell.gateway.bind_address=0.0.0.0:${LOCAL_GATEWAY_PORT}"
       info "Restart the gateway service for changes to take effect."
       ;;
     kubernetes | docker | none)

--- a/install.sh
+++ b/install.sh
@@ -727,11 +727,12 @@ start_user_gateway() {
   register_local_gateway
   wait_for_local_gateway_listener
   wait_for_local_gateway_status
+  info "gateway service is healthy"
 }
 
 gateway_startup_error() {
   _reason="$1"
-  error "${_reason}. Review the diagnostics above. OpenShell remains installed. If the logs report that no compute driver is available, install and start Docker or Podman, or install openshell-driver-vm and explicitly configure compute_drivers = [\"vm\"]. Then restart the gateway service."
+  error "${_reason}. OpenShell package installation succeeded, but the gateway service is not healthy. Review the diagnostics above. If no compute driver is available, install and start Docker or Podman, or install openshell-driver-vm and explicitly select VM. The supervised service will normally retry automatically; restart it if needed."
 }
 
 dump_local_gateway_diagnostics() {
@@ -934,7 +935,7 @@ install_linux_deb() {
 
   info "installing ${_deb_file}..."
   install_deb_package "$_deb_path"
-  info "installed ${APP_NAME} package from ${RELEASE_TAG}"
+  info "package installation succeeded: installed ${APP_NAME} from ${RELEASE_TAG}"
   report_detected_compute_driver
   start_user_gateway
 }
@@ -982,7 +983,7 @@ install_linux_rpm() {
 
   info "installing ${_rpm_file} and ${_gateway_rpm_file}..."
   install_rpm_packages "${_tmpdir}/${_rpm_file}" "${_tmpdir}/${_gateway_rpm_file}"
-  info "installed ${APP_NAME} RPM packages from ${RELEASE_TAG}"
+  info "package installation succeeded: installed ${APP_NAME} RPM packages from ${RELEASE_TAG}"
   report_detected_compute_driver
   start_user_gateway
 }
@@ -1021,6 +1022,7 @@ install_macos_homebrew() {
     info "installing OpenShell with Homebrew..."
     as_target_user brew install --formula "$_formula_ref"
   fi
+  info "package installation succeeded: installed ${APP_NAME} with Homebrew from ${RELEASE_TAG}"
 
   _brew_prefix="$(as_target_user brew --prefix 2>/dev/null || true)"
   if [ -n "$_brew_prefix" ]; then
@@ -1037,6 +1039,7 @@ install_macos_homebrew() {
   register_local_gateway
   wait_for_local_gateway_listener
   wait_for_local_gateway_status
+  info "gateway service is healthy"
 }
 
 restart_homebrew_gateway() {

--- a/openshell.spec
+++ b/openshell.spec
@@ -53,10 +53,6 @@ BuildRequires:  pandoc
 # Python sub-package build dependencies
 BuildRequires:  python3-devel
 
-# Runtime: container runtime for package-managed gateway sandboxes.
-# The gateway auto-detects Podman when the package-managed service starts.
-Recommends:     podman
-
 %description
 OpenShell provides safe, sandboxed runtimes for autonomous AI agents.
 It offers a CLI for managing gateway registrations, sandboxes, and providers with
@@ -65,16 +61,14 @@ LLM inference routing.
 
 # --- Gateway sub-package ---
 %package gateway
-Summary:        OpenShell gateway server with Podman sandbox driver
-Requires:       podman
+Summary:        OpenShell gateway server
 Requires:       openssl
 Requires:       %{name} = %{version}-%{release}
 
 %description gateway
 OpenShell gateway server providing the control-plane API for sandbox
-lifecycle management. This package installs Podman-oriented defaults in
-gateway TOML while leaving compute driver selection to gateway auto-detection
-or explicit operator configuration.
+lifecycle management. Compute driver selection uses gateway auto-detection or
+explicit operator configuration.
 
 # --- Python SDK sub-package ---
 %package -n python3-%{name}
@@ -155,8 +149,6 @@ cat > %{buildroot}%{_userunitdir}/%{name}-gateway.service << 'EOF'
 [Unit]
 Description=OpenShell Gateway (user)
 Documentation=https://github.com/NVIDIA/OpenShell
-After=podman.socket
-Wants=podman.socket
 
 [Service]
 Type=exec

--- a/python/openshell/release_formula_test.py
+++ b/python/openshell/release_formula_test.py
@@ -57,6 +57,7 @@ def test_generate_homebrew_formula_uses_tagged_macos_driver_asset_without_defaul
     assert 'bind_address = "127.0.0.1:17670"' not in formula
     assert '# compute_drivers = ["vm"]' not in formula
     assert 'run opt_libexec/"openshell-gateway-homebrew-service"' in formula
+    assert "keep_alive successful_exit: false" in formula
     assert 'xdg_config_home="${XDG_CONFIG_HOME:-${HOME}/.config}"' in formula
     assert 'xdg_gateway_config="${xdg_config_home}/openshell/gateway.toml"' in formula
     assert 'prefix_gateway_config="#{var}/openshell/gateway.toml"' in formula
@@ -130,6 +131,8 @@ def test_rpm_spec_uses_gateway_defaults_without_config_helper() -> None:
     assert "Environment=OPENSHELL_BIND_ADDRESS" not in spec
     assert "Environment=OPENSHELL_PODMAN_TLS_CA" not in spec
     assert "ExecStart=/usr/bin/openshell-gateway" in spec
+    assert "Restart=on-failure" in spec
+    assert "RestartSec=5" in spec
     assert "--config" not in spec
     assert "--db-url" not in spec
 
@@ -149,5 +152,7 @@ def test_deb_user_service_uses_gateway_defaults_without_config_helper() -> None:
     assert "%S/openshell/tls" not in unit
     assert "init-gateway-config.sh" not in unit
     assert "ExecStart=/usr/bin/openshell-gateway" in unit
+    assert "Restart=on-failure" in unit
+    assert "RestartSec=5s" in unit
     assert "--config" not in unit
     assert "--db-url" not in unit

--- a/tasks/scripts/test-install-sh.sh
+++ b/tasks/scripts/test-install-sh.sh
@@ -35,7 +35,7 @@ assert_glibc_preflight_fails() {
     exit 1
   fi
 
-  if ! grep -Fq "$expected" "$err"; then
+  if ! grep -Fq -- "$expected" "$err"; then
     echo "FAIL: ${name}: missing expected message" >&2
     echo "Expected: ${expected}" >&2
     echo "Actual:" >&2
@@ -81,7 +81,89 @@ assert_gateway_failure() {
     "OpenShell remains installed" \
     "install and start Docker or Podman" \
     "install openshell-driver-vm and explicitly configure compute_drivers = [\"vm\"]"; do
-    if ! grep -Fq "$expected" "$err"; then
+    if ! grep -Fq -- "$expected" "$err"; then
+      echo "FAIL: ${name}: missing expected message: ${expected}" >&2
+      cat "$err" >&2 || true
+      exit 1
+    fi
+  done
+}
+
+assert_driver_parse() {
+  local name=$1
+  local env_driver=$2
+  local expected=$3
+  shift 3
+
+  if ! (
+    INSTALL_COMPUTE_DRIVER="$env_driver"
+    parse_install_args "$@"
+    [ "$INSTALL_COMPUTE_DRIVER" = "$expected" ]
+  ) >"$out" 2>"$err"; then
+    echo "FAIL: ${name}" >&2
+    cat "$err" >&2 || true
+    exit 1
+  fi
+}
+
+assert_driver_parse_fails() {
+  local name=$1
+  local expected=$2
+  shift 2
+
+  if (INSTALL_COMPUTE_DRIVER=""; parse_install_args "$@") >"$out" 2>"$err"; then
+    echo "FAIL: ${name}: expected failure" >&2
+    exit 1
+  fi
+  if ! grep -Fq -- "$expected" "$err"; then
+    echo "FAIL: ${name}: missing expected message: ${expected}" >&2
+    cat "$err" >&2 || true
+    exit 1
+  fi
+}
+
+assert_driver_configuration() {
+  local name=$1
+  local driver=$2
+  local expected=$3
+
+  if ! (
+    INSTALL_COMPUTE_DRIVER="$driver"
+    OPENSHELL_GATEWAY_BIN="/test/bin/openshell-gateway"
+    as_target_user() {
+      printf '%s\n' "$*" >"$out"
+    }
+    configure_gateway_compute_driver
+  ) 2>"$err"; then
+    echo "FAIL: ${name}" >&2
+    cat "$err" >&2 || true
+    exit 1
+  fi
+  if ! grep -Fxq "$expected" "$out"; then
+    echo "FAIL: ${name}: unexpected config command" >&2
+    echo "Expected: ${expected}" >&2
+    echo "Actual:" >&2
+    cat "$out" >&2 || true
+    exit 1
+  fi
+}
+
+assert_driver_prerequisite_notice() {
+  local name=$1
+  local driver=$2
+  local expected_warning=$3
+  local expected_url=$4
+
+  if ! (
+    INSTALL_COMPUTE_DRIVER="$driver"
+    print_compute_driver_prerequisite_notice
+  ) >"$out" 2>"$err"; then
+    echo "FAIL: ${name}" >&2
+    cat "$err" >&2 || true
+    exit 1
+  fi
+  for expected in "$expected_warning" "$expected_url"; do
+    if ! grep -Fq -- "$expected" "$err"; then
       echo "FAIL: ${name}: missing expected message: ${expected}" >&2
       cat "$err" >&2 || true
       exit 1
@@ -144,6 +226,80 @@ assert_glibc_preflight_fails \
   "ldd musl fallback fails" \
   "OpenShell Linux packages require glibc >= 2.28; detected musl or unsupported libc." \
   setup_ldd_musl
+
+assert_driver_parse \
+  "compute-driver flag selects podman" \
+  "" \
+  podman \
+  --compute-driver podman
+
+assert_driver_parse \
+  "compute-driver flag overrides environment" \
+  podman \
+  docker \
+  --compute-driver=docker
+
+assert_driver_parse \
+  "compute-driver environment is preserved without flag" \
+  vm \
+  vm
+
+assert_driver_parse_fails \
+  "compute-driver rejects unsupported values" \
+  "unsupported compute driver 'containerd'" \
+  --compute-driver containerd
+
+if (INSTALL_COMPUTE_DRIVER="containerd"; parse_install_args) >"$out" 2>"$err"; then
+  echo "FAIL: compute-driver rejects unsupported environment value: expected failure" >&2
+  exit 1
+fi
+if ! grep -Fq -- "unsupported compute driver 'containerd'" "$err"; then
+  echo "FAIL: compute-driver rejects unsupported environment value: missing expected message" >&2
+  cat "$err" >&2 || true
+  exit 1
+fi
+
+assert_driver_parse_fails \
+  "compute-driver rejects kubernetes for local installs" \
+  "use the OpenShell Helm chart" \
+  --compute-driver kubernetes
+
+assert_driver_parse_fails \
+  "compute-driver requires a value" \
+  "--compute-driver requires a value" \
+  --compute-driver
+
+assert_driver_configuration \
+  "podman selection configures bridge-reachable binding" \
+  podman \
+  "/test/bin/openshell-gateway config set --compute-driver podman --bind-address 0.0.0.0:17670"
+
+assert_driver_configuration \
+  "docker selection configures loopback binding" \
+  docker \
+  "/test/bin/openshell-gateway config set --compute-driver docker --bind-address 127.0.0.1:17670"
+
+assert_driver_configuration \
+  "vm selection configures loopback binding" \
+  vm \
+  "/test/bin/openshell-gateway config set --compute-driver vm --bind-address 127.0.0.1:17670"
+
+assert_driver_configuration \
+  "auto selection removes only the driver pin" \
+  auto \
+  "/test/bin/openshell-gateway config set --compute-driver auto"
+
+assert_driver_prerequisite_notice \
+  "docker selection prints prerequisite guidance" \
+  docker \
+  "Docker is not installed or managed by the OpenShell installer" \
+  "https://docs.docker.com/engine/install/"
+
+assert_driver_prerequisite_notice \
+  "podman selection prints prerequisite guidance" \
+  podman \
+  "Podman is not installed or managed by the OpenShell installer" \
+  "https://podman.io/docs/installation"
 
 assert_gateway_failure \
   "systemd enable failure is actionable" \

--- a/tasks/scripts/test-install-sh.sh
+++ b/tasks/scripts/test-install-sh.sh
@@ -209,7 +209,7 @@ assert_detected_driver_guidance \
   "If you use rootless Podman, configure the gateway to listen on the host bridge"
 
 if ! grep -Fq -- \
-  "openshell-gateway config set --bind-address 0.0.0.0:17670" \
+  "openshell-gateway config set openshell.gateway.bind_address=0.0.0.0:17670" \
   "$err"; then
   echo "FAIL: podman detection: missing configuration command" >&2
   cat "$err" >&2 || true

--- a/tasks/scripts/test-install-sh.sh
+++ b/tasks/scripts/test-install-sh.sh
@@ -284,10 +284,10 @@ assert_driver_configuration \
   vm \
   "/test/bin/openshell-gateway config set --compute-driver vm --bind-address 127.0.0.1:17670"
 
-assert_driver_configuration \
-  "auto selection removes only the driver pin" \
-  auto \
-  "/test/bin/openshell-gateway config set --compute-driver auto"
+assert_driver_parse_fails \
+  "compute-driver leaves automatic selection to the default installation" \
+  "unsupported compute driver 'auto'" \
+  --compute-driver auto
 
 assert_driver_prerequisite_notice \
   "docker selection prints prerequisite guidance" \

--- a/tasks/scripts/test-install-sh.sh
+++ b/tasks/scripts/test-install-sh.sh
@@ -89,86 +89,36 @@ assert_gateway_failure() {
   done
 }
 
-assert_driver_parse() {
+assert_detected_driver_guidance() {
   local name=$1
-  local env_driver=$2
+  local driver=$2
   local expected=$3
-  shift 3
 
   if ! (
-    INSTALL_COMPUTE_DRIVER="$env_driver"
-    parse_install_args "$@"
-    [ "$INSTALL_COMPUTE_DRIVER" = "$expected" ]
+    OPENSHELL_GATEWAY_BIN="/test/bin/openshell-gateway"
+    as_target_user() {
+      if [ "$*" != "/test/bin/openshell-gateway config detect-driver" ]; then
+        echo "unexpected detection command: $*" >&2
+        return 1
+      fi
+      printf '%s\n' "$driver"
+    }
+    report_detected_compute_driver
   ) >"$out" 2>"$err"; then
     echo "FAIL: ${name}" >&2
     cat "$err" >&2 || true
     exit 1
   fi
-}
-
-assert_driver_parse_fails() {
-  local name=$1
-  local expected=$2
-  shift 2
-
-  if (INSTALL_COMPUTE_DRIVER=""; parse_install_args "$@") >"$out" 2>"$err"; then
-    echo "FAIL: ${name}: expected failure" >&2
-    exit 1
-  fi
-  if ! grep -Fq -- "$expected" "$err"; then
+  if [ -n "$expected" ] && ! grep -Fq -- "$expected" "$err"; then
     echo "FAIL: ${name}: missing expected message: ${expected}" >&2
     cat "$err" >&2 || true
     exit 1
   fi
-}
-
-assert_driver_configuration() {
-  local name=$1
-  local driver=$2
-  local expected=$3
-
-  if ! (
-    INSTALL_COMPUTE_DRIVER="$driver"
-    OPENSHELL_GATEWAY_BIN="/test/bin/openshell-gateway"
-    as_target_user() {
-      printf '%s\n' "$*" >"$out"
-    }
-    configure_gateway_compute_driver
-  ) 2>"$err"; then
-    echo "FAIL: ${name}" >&2
+  if [ -z "$expected" ] && [ -s "$err" ]; then
+    echo "FAIL: ${name}: unexpected guidance" >&2
     cat "$err" >&2 || true
     exit 1
   fi
-  if ! grep -Fxq "$expected" "$out"; then
-    echo "FAIL: ${name}: unexpected config command" >&2
-    echo "Expected: ${expected}" >&2
-    echo "Actual:" >&2
-    cat "$out" >&2 || true
-    exit 1
-  fi
-}
-
-assert_driver_prerequisite_notice() {
-  local name=$1
-  local driver=$2
-  local expected_warning=$3
-  local expected_url=$4
-
-  if ! (
-    INSTALL_COMPUTE_DRIVER="$driver"
-    print_compute_driver_prerequisite_notice
-  ) >"$out" 2>"$err"; then
-    echo "FAIL: ${name}" >&2
-    cat "$err" >&2 || true
-    exit 1
-  fi
-  for expected in "$expected_warning" "$expected_url"; do
-    if ! grep -Fq -- "$expected" "$err"; then
-      echo "FAIL: ${name}: missing expected message: ${expected}" >&2
-      cat "$err" >&2 || true
-      exit 1
-    fi
-  done
 }
 
 setup_glibc_227() {
@@ -227,79 +177,33 @@ assert_glibc_preflight_fails \
   "OpenShell Linux packages require glibc >= 2.28; detected musl or unsupported libc." \
   setup_ldd_musl
 
-assert_driver_parse \
-  "compute-driver flag selects podman" \
-  "" \
+assert_detected_driver_guidance \
+  "podman detection prints rootless bind guidance" \
   podman \
-  --compute-driver podman
+  "If you use rootless Podman, configure the gateway to listen on the host bridge"
 
-assert_driver_parse \
-  "compute-driver flag overrides environment" \
-  podman \
-  docker \
-  --compute-driver=docker
-
-assert_driver_parse \
-  "compute-driver environment is preserved without flag" \
-  vm \
-  vm
-
-assert_driver_parse_fails \
-  "compute-driver rejects unsupported values" \
-  "unsupported compute driver 'containerd'" \
-  --compute-driver containerd
-
-if (INSTALL_COMPUTE_DRIVER="containerd"; parse_install_args) >"$out" 2>"$err"; then
-  echo "FAIL: compute-driver rejects unsupported environment value: expected failure" >&2
+if ! grep -Fq -- \
+  "openshell-gateway config set --bind-address 0.0.0.0:17670" \
+  "$err"; then
+  echo "FAIL: podman detection: missing configuration command" >&2
+  cat "$err" >&2 || true
   exit 1
 fi
-if ! grep -Fq -- "unsupported compute driver 'containerd'" "$err"; then
-  echo "FAIL: compute-driver rejects unsupported environment value: missing expected message" >&2
+if ! grep -Fq -- "Restart the gateway service for changes to take effect." "$err"; then
+  echo "FAIL: podman detection: missing restart guidance" >&2
   cat "$err" >&2 || true
   exit 1
 fi
 
-assert_driver_parse_fails \
-  "compute-driver rejects kubernetes for local installs" \
-  "use the OpenShell Helm chart" \
-  --compute-driver kubernetes
-
-assert_driver_parse_fails \
-  "compute-driver requires a value" \
-  "--compute-driver requires a value" \
-  --compute-driver
-
-assert_driver_configuration \
-  "podman selection configures bridge-reachable binding" \
-  podman \
-  "/test/bin/openshell-gateway config set --compute-driver podman --bind-address 0.0.0.0:17670"
-
-assert_driver_configuration \
-  "docker selection configures loopback binding" \
+assert_detected_driver_guidance \
+  "docker detection does not print bind guidance" \
   docker \
-  "/test/bin/openshell-gateway config set --compute-driver docker --bind-address 127.0.0.1:17670"
+  ""
 
-assert_driver_configuration \
-  "vm selection configures loopback binding" \
-  vm \
-  "/test/bin/openshell-gateway config set --compute-driver vm --bind-address 127.0.0.1:17670"
-
-assert_driver_parse_fails \
-  "compute-driver leaves automatic selection to the default installation" \
-  "unsupported compute driver 'auto'" \
-  --compute-driver auto
-
-assert_driver_prerequisite_notice \
-  "docker selection prints prerequisite guidance" \
-  docker \
-  "Docker is not installed or managed by the OpenShell installer" \
-  "https://docs.docker.com/engine/install/"
-
-assert_driver_prerequisite_notice \
-  "podman selection prints prerequisite guidance" \
-  podman \
-  "Podman is not installed or managed by the OpenShell installer" \
-  "https://podman.io/docs/installation"
+assert_detected_driver_guidance \
+  "no detected driver does not print bind guidance" \
+  none \
+  ""
 
 assert_gateway_failure \
   "systemd enable failure is actionable" \

--- a/tasks/scripts/test-install-sh.sh
+++ b/tasks/scripts/test-install-sh.sh
@@ -44,6 +44,51 @@ assert_glibc_preflight_fails() {
   fi
 }
 
+assert_gateway_failure() {
+  local name=$1
+  local platform=$2
+  local action=$3
+
+  if (
+    export PLATFORM="$platform"
+    TARGET_USER="test-user"
+    TARGET_HOME="${tmpdir}/home"
+
+    as_target_user() {
+      if [ "$*" = "$action" ]; then
+        return 1
+      fi
+      return 0
+    }
+    dump_local_gateway_diagnostics() {
+      echo "TEST gateway diagnostics" >&2
+    }
+    register_local_gateway() { return 0; }
+    wait_for_local_gateway_listener() { return 0; }
+    wait_for_local_gateway_status() { return 0; }
+
+    case "$platform" in
+      linux) start_user_gateway ;;
+      darwin) restart_homebrew_gateway "${HOMEBREW_TAP}/${HOMEBREW_FORMULA_NAME}" ;;
+    esac
+  ) >"$out" 2>"$err"; then
+    echo "FAIL: ${name}: expected failure" >&2
+    exit 1
+  fi
+
+  for expected in \
+    "TEST gateway diagnostics" \
+    "OpenShell remains installed" \
+    "install and start Docker or Podman" \
+    "install openshell-driver-vm and explicitly configure compute_drivers = [\"vm\"]"; do
+    if ! grep -Fq "$expected" "$err"; then
+      echo "FAIL: ${name}: missing expected message: ${expected}" >&2
+      cat "$err" >&2 || true
+      exit 1
+    fi
+  done
+}
+
 setup_glibc_227() {
   export OPENSHELL_TEST_GETCONF_UNAVAILABLE=1
   export OPENSHELL_TEST_LDD_OUTPUT="ldd (GNU libc) 2.27"
@@ -100,4 +145,24 @@ assert_glibc_preflight_fails \
   "OpenShell Linux packages require glibc >= 2.28; detected musl or unsupported libc." \
   setup_ldd_musl
 
-echo "install.sh libc preflight tests passed"
+assert_gateway_failure \
+  "systemd enable failure is actionable" \
+  linux \
+  "systemctl --user enable openshell-gateway"
+
+assert_gateway_failure \
+  "systemd restart failure is actionable" \
+  linux \
+  "systemctl --user restart openshell-gateway"
+
+assert_gateway_failure \
+  "inactive systemd service is actionable" \
+  linux \
+  "systemctl --user is-active --quiet openshell-gateway"
+
+assert_gateway_failure \
+  "Homebrew restart failure is actionable" \
+  darwin \
+  "brew services restart ${HOMEBREW_TAP}/${HOMEBREW_FORMULA_NAME}"
+
+echo "install.sh tests passed"

--- a/tasks/scripts/test-install-sh.sh
+++ b/tasks/scripts/test-install-sh.sh
@@ -78,15 +78,41 @@ assert_gateway_failure() {
 
   for expected in \
     "TEST gateway diagnostics" \
-    "OpenShell remains installed" \
+    "OpenShell package installation succeeded" \
+    "gateway service is not healthy" \
     "install and start Docker or Podman" \
-    "install openshell-driver-vm and explicitly configure compute_drivers = [\"vm\"]"; do
+    "supervised service will normally retry automatically"; do
     if ! grep -Fq -- "$expected" "$err"; then
       echo "FAIL: ${name}: missing expected message: ${expected}" >&2
       cat "$err" >&2 || true
       exit 1
     fi
   done
+}
+
+assert_gateway_healthy() {
+  if ! (
+    export PLATFORM="linux"
+    TARGET_USER="test-user"
+    TARGET_HOME="${tmpdir}/home"
+
+    as_target_user() { return 0; }
+    register_local_gateway() { return 0; }
+    wait_for_local_gateway_listener() { return 0; }
+    wait_for_local_gateway_status() { return 0; }
+
+    start_user_gateway
+  ) >"$out" 2>"$err"; then
+    echo "FAIL: healthy gateway service should succeed" >&2
+    cat "$err" >&2 || true
+    exit 1
+  fi
+
+  if ! grep -Fq -- "gateway service is healthy" "$err"; then
+    echo "FAIL: healthy gateway service should report its outcome" >&2
+    cat "$err" >&2 || true
+    exit 1
+  fi
 }
 
 assert_detected_driver_guidance() {
@@ -204,6 +230,8 @@ assert_detected_driver_guidance \
   "no detected driver does not print bind guidance" \
   none \
   ""
+
+assert_gateway_healthy
 
 assert_gateway_failure \
   "systemd enable failure is actionable" \

--- a/tasks/scripts/test-packaging-assets.sh
+++ b/tasks/scripts/test-packaging-assets.sh
@@ -49,6 +49,8 @@ assert_contains \
 assert_contains \
   "$service" \
   'ExecStartPre=/usr/bin/openshell-gateway generate-certs --output-dir ${OPENSHELL_LOCAL_TLS_DIR} --server-san host.openshell.internal'
+assert_contains "$service" 'Restart=on-failure'
+assert_contains "$service" 'RestartSec=5s'
 assert_not_contains "$service" '%S/openshell/tls'
 
 assert_contains \
@@ -57,6 +59,8 @@ assert_contains \
 assert_contains \
   "$spec" \
   'ExecStartPre=/usr/bin/openshell-gateway generate-certs --output-dir ${OPENSHELL_LOCAL_TLS_DIR} --server-san host.openshell.internal'
+assert_contains "$spec" 'Restart=on-failure'
+assert_contains "$spec" 'RestartSec=5'
 assert_not_contains "$spec" '%%S/openshell/tls'
 
 echo "packaging asset tests passed"


### PR DESCRIPTION
## Summary

Make package installation runtime-neutral so installing OpenShell does not require Podman, Docker, or another optional compute runtime. The RPM no longer depends on Podman, package-managed gateways retain automatic driver selection, and the installer reports package installation and gateway health as separate outcomes.

This version keeps runtime detection inside the gateway. `install.sh` uses the read-only detection CLI for immediate guidance, while every gateway start logs the selected driver, all detected alternatives, multi-runtime pinning guidance, and the rootless Podman bind command when applicable.

## Related Issue

Closes #2007

## Installation Invariants

- Select the supported native installation method deterministically for the host.
- Install matching `openshell` and `openshell-gateway` artifacts in the package manager's standard executable path.
- Install and enable the gateway as a supervised user service.
- Preserve existing gateway configuration and state across installs and upgrades.
- Keep the listener on loopback with TLS unless the operator explicitly changes it.
- Do not install, remove, start, or configure optional Docker and Podman runtimes.
- Leave compute-driver selection automatic unless the operator explicitly pins a driver.
- Treat package installation and gateway health as separate outcomes: activation failure leaves OpenShell installed, returns nonzero, and prints recovery instructions.
- Keep the installer safe to rerun after the operator fixes a runtime or service prerequisite.

## Changes

- Remove Podman dependencies and `podman.socket` ordering from the RPM spec.
- Leave the RPM compute driver unset and default its listener to `127.0.0.1:17670`.
- Add `openshell-gateway config detect-driver` with stable `kubernetes`, `podman`, `docker`, or `none` output.
- Detect all available runtimes at gateway startup while retaining Kubernetes → Podman → Docker selection priority.
- Log the auto-selected driver and detected alternatives on every gateway start.
- Warn when multiple runtimes are available and show how to pin the intended driver.
- Warn when Podman is auto-selected on loopback and show the explicit rootless Podman bind command.
- Keep `install.sh` advisory: it never changes driver selection or listener configuration.
- Add `openshell-gateway config set` with repeatable dotted `KEY=VALUE` assignments for typed, validated, comment-preserving, atomic TOML updates.
- Report `package installation succeeded` separately from `gateway service is healthy`.
- Leave installed packages and the supervised service in place after activation failure, with actionable recovery guidance.
- Verify Linux and Homebrew service definitions retain automatic restart supervision.
- Keep published docs focused on stable prerequisites and configuration; context-dependent recovery guidance remains owned by `install.sh` and gateway diagnostics.

## Runtime Scenarios

| Environment | Result |
|---|---|
| No Docker or Podman | Package installation succeeds, gateway health fails, and `install.sh` returns nonzero with diagnostics. The service keeps retrying and can recover after a runtime is installed. Rootless Podman still requires the explicit bind change before sandboxes can call back. |
| Podman available | Podman is auto-selected. The installer and gateway show the rootless bind command without applying it. Installing Docker later does not override Podman because Podman has higher priority. |
| Docker available | Docker is auto-selected. If Podman is installed later, the running process remains on Docker, but the next restart selects Podman unless Docker is explicitly pinned. |
| Multiple runtimes | The gateway logs every detected runtime, the selected driver, and `openshell-gateway config set 'openshell.gateway.compute_drivers=["<driver>"]'` guidance. |
| VM | VM remains opt-in and is never auto-detected. The driver must be installed where needed and selected explicitly. |

## Why This Option

This design follows the invariants above: package installation stays independent of optional runtimes, configuration remains operator-owned and visible in TOML, loopback is never widened implicitly, and runtime changes after installation remain observable. Keeping the warning in the gateway is important because an installer-only warning cannot cover Docker or Podman installed later.

Automatic selection remains the zero-configuration recovery path. Explicit `config set` commands are the stability mechanism when an operator wants a fixed driver.

## Alternatives Explored

- **Keep Podman as an RPM dependency.** Rejected because it prevents Docker-only hosts from installing OpenShell.
- **Install Docker or Podman from `install.sh`.** Rejected because repository setup, rootless configuration, daemon lifecycle, licensing, and enterprise policy vary across supported systems.
- **Add `install.sh --compute-driver` / `OPENSHELL_INSTALL_COMPUTE_DRIVER`.** Implemented during exploration, then removed because it duplicated gateway configuration policy and made installation persist a driver choice.
- **Persist the auto-detected driver automatically.** Rejected because observational detection should not silently become operator configuration or prevent future fallback.
- **Set `OPENSHELL_DRIVERS` in service definitions.** Rejected because environment values outrank TOML and make later config edits appear ineffective.
- **Rewrite TOML from shell.** Rejected because preserving comments, schema validity, and atomicity in shell would be fragile.
- **Automatically bind `0.0.0.0` when Podman is detected.** Rejected because runtime probing must not silently expose the gateway on host interfaces.
- **Warn only from `install.sh`.** Insufficient because runtimes can be installed or removed after installation.
- **Warn only in gateway service logs.** Insufficient for initial discoverability, so the installer also uses `detect-driver` for immediate Podman guidance.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] `mise run test` passes (included by `mise run pre-commit`)
- [x] `mise run ci` passes (`mise run pre-commit` is the `ci` alias)
- [x] E2E tests added/updated (not applicable; no E2E files changed)

Focused coverage:

- Driver detection ordering and first-driver compatibility
- Multi-runtime pinning guidance
- Rootless Podman loopback guidance
- Generic `config set` parsing, TOML value types, validation, and atomic multi-key updates
- Installer package-success/service-health outcome messages
- Linux and Homebrew service restart supervision
- RPM metadata and Podman-absent installation behavior

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture and published docs updated
