### PR TITLE
docs: add pkg-config to macOS prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,11 +150,11 @@ xcode-select --install
 
 ### Z3 installation
 
-The `openshell-prover` crate links against the system Z3 library via pkg-config.
+The `openshell-prover` crate links against the system Z3 library via `pkg-config`.
 
 ```bash
 # macOS
-brew install z3
+brew install z3 pkg-config
 
 # Ubuntu / Debian
 sudo apt install libz3-dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,7 +321,7 @@ system Z3 development package; `z3-sys` discovers it through `pkg-config`.
 
 ```bash
 # macOS
-brew install z3
+brew install z3 pkg-config
 
 # Ubuntu / Debian
 sudo apt install libz3-dev


### PR DESCRIPTION
## Summary
The Z3 installation section mentions `pkg-config` but doesn't list it as a required install on macOS. Adds it to the brew install line.

## Checklist
- [X] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [X] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
