### PR TITLE
fix(vm-driver): fixes BYOC sandbox creation failing with ext4-fs writ…

### DIFF
--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -247,6 +247,10 @@ setup_overlay_root() {
     if [ "${OPENSHELL_VM_INIT_MODE:-sandbox}" = "image-prep" ]; then
         prepare_guest_image_rootfs
         sync
+        if ! umount /overlay; then
+            ts "FATAL: failed to unmount /overlay cleanly after image-prep; refusing to produce a dirty image-cache disk"
+            exit 1
+        fi
         ts "image-prep complete"
         exit 0
     fi
@@ -256,7 +260,7 @@ setup_overlay_root() {
 
     local lower_root="/lower"
     if [ -b /dev/vdc ]; then
-        mount -t ext4 -o ro /dev/vdc /image-cache
+        mount -t ext4 -o ro,noload /dev/vdc /image-cache
         if [ -d /image-cache/image-rootfs ]; then
             lower_root="/image-cache/image-rootfs"
             ts "using prepared image rootfs lowerdir"


### PR DESCRIPTION
## Summary
Fix BYOC sandbox creation failing with "EXT4-fs (vdc): write access unavailable, cannot proceed" under the VM driver by cleanly unmounting the overlay filesystem before the image-prep VM exits, preventing the ext4 journal from being left in a dirty state. Adds noload to the image-cache mount and attaches the disk as hypervisor-writable as belt-and-suspenders so a dirty journal never blocks the mount.

## Related Issue
Closes #2149

## Changes
changing how VM driver creates container

## Testing
<!-- What testing was done? -->
- [ ] `mise run pre-commit` passes | check comment
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)


- [x] manually tested before and after patch if it fixes the issue

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
