### PR TITLE
feat(flake): Add missing packages to flake for running mise commands

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,13 @@
             llvmPackages.libclang
             # system dependency for openshell-prover
             z3
+            # mise dependencies
+            mise
+            cmakeMinimal
+            zlib
+            openssl_3_5
+            xz
+            gh
           ];
 
           env = {

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,13 @@
             z3
             # Coverage
             lcov
+            # mise dependencies
+            mise
+            cmakeMinimal
+            zlib
+            openssl_3_5
+            xz
+            gh
           ];
 
           env = {


### PR DESCRIPTION
## Summary
Adding missing packages allowing us to run `mise run vm:supervisor && cargo build --release`

## Related Issue
N/a

## Changes
added missing packages to flake.nix file

## Testing
<!-- What testing was done? -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
