### PR TITLE
feat(tui): add config key support to provider create/update forms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4007,6 +4007,7 @@ version = "0.0.0"
 dependencies = [
  "base64 0.22.1",
  "crossterm 0.28.1",
+ "indexmap",
  "miette",
  "openshell-bootstrap",
  "openshell-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ pin-project-lite = "0.2"
 tokio-stream = "0.1"
 protobuf-src = "1.1.0"
 url = "2"
+indexmap = "2"
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "sqlite", "migrate"] }

--- a/crates/openshell-tui/Cargo.toml
+++ b/crates/openshell-tui/Cargo.toml
@@ -27,6 +27,7 @@ owo-colors = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+indexmap = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/openshell-tui/src/app.rs
+++ b/crates/openshell-tui/src/app.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use indexmap::IndexMap;
 use openshell_bootstrap::GatewayMetadataSource;
 use openshell_core::auth::EdgeAuthInterceptor;
 use openshell_core::proto::open_shell_client::OpenShellClient;
@@ -347,6 +348,10 @@ pub enum ProviderKeyField {
     EnvVarName,
     /// Custom env var value (generic / no-known-env-vars types only).
     GenericValue,
+    /// Config key name input.
+    ConfigKeyName,
+    /// Config key value input.
+    ConfigKeyValue,
     Submit,
 }
 
@@ -363,6 +368,12 @@ pub struct CreateProviderForm {
     pub credentials: Vec<(String, String)>,
     /// Which credential row is focused.
     pub cred_cursor: usize,
+    /// TODO: inline doc for config, possibilities of using IndexMap
+    pub config: IndexMap<String, String>,
+    /// Which config row is focused.
+    pub config_cursor: usize,
+    pub config_key_input: String,
+    pub config_value_input: String,
     /// For generic / types with no known env vars: custom env var name.
     pub generic_env_name: String,
     /// For generic / types with no known env vars: custom value.
@@ -2111,6 +2122,10 @@ impl App {
             name: String::new(),
             credentials: Vec::new(),
             cred_cursor: 0,
+            config: IndexMap::new(),
+            config_cursor: 0,
+            config_key_input: String::new(),
+            config_value_input: String::new(),
             generic_env_name: String::new(),
             generic_value: String::new(),
             key_field: ProviderKeyField::Name,
@@ -2219,6 +2234,10 @@ impl App {
                     form.name.clear();
                     form.credentials.clear();
                     form.cred_cursor = 0;
+                    form.config.clear();
+                    form.config_cursor = 0;
+                    form.config_key_input.clear();
+                    form.config_value_input.clear();
                     form.generic_env_name.clear();
                     form.generic_value.clear();
                 }
@@ -2232,11 +2251,11 @@ impl App {
                             _ => ProviderKeyField::Name,
                         };
                     } else {
-                        // Name → Credential[0..N-1] → Submit → Name
+                        // Name → Credential[0..N-1] → ConfigKeyName → ConfigKeyValue → Submit → Name
                         match form.key_field {
                             ProviderKeyField::Name => {
                                 if form.credentials.is_empty() {
-                                    form.key_field = ProviderKeyField::Submit;
+                                    form.key_field = ProviderKeyField::ConfigKeyName;
                                 } else {
                                     form.key_field = ProviderKeyField::Credential;
                                     form.cred_cursor = 0;
@@ -2246,7 +2265,27 @@ impl App {
                                 if form.cred_cursor < form.credentials.len().saturating_sub(1) {
                                     form.cred_cursor += 1;
                                 } else {
+                                    form.key_field = ProviderKeyField::ConfigKeyName;
+                                }
+                            }
+                            ProviderKeyField::ConfigKeyName => {
+                                form.key_field = ProviderKeyField::ConfigKeyValue;
+                            }
+                            ProviderKeyField::ConfigKeyValue => {
+                                if !form.config_key_input.is_empty()
+                                    && !form.config_value_input.is_empty()
+                                {
+                                    form.config.insert(
+                                        std::mem::take(&mut form.config_key_input),
+                                        std::mem::take(&mut form.config_value_input),
+                                    );
+                                    form.key_field = ProviderKeyField::ConfigKeyName;
+                                } else if form.config_key_input.is_empty()
+                                    && form.config_value_input.is_empty()
+                                {
                                     form.key_field = ProviderKeyField::Submit;
+                                } else {
+                                    form.key_field = ProviderKeyField::ConfigKeyName;
                                 }
                             }
                             _ => {
@@ -2272,13 +2311,19 @@ impl App {
                                     form.key_field = ProviderKeyField::Name;
                                 }
                             }
-                            ProviderKeyField::Submit => {
+                            ProviderKeyField::ConfigKeyValue => {
+                                form.key_field = ProviderKeyField::ConfigKeyName;
+                            }
+                            ProviderKeyField::ConfigKeyName => {
                                 if form.credentials.is_empty() {
                                     form.key_field = ProviderKeyField::Name;
                                 } else {
                                     form.key_field = ProviderKeyField::Credential;
                                     form.cred_cursor = form.credentials.len().saturating_sub(1);
                                 }
+                            }
+                            ProviderKeyField::Submit => {
+                                form.key_field = ProviderKeyField::ConfigKeyValue;
                             }
                             _ => {
                                 form.key_field = ProviderKeyField::Submit;
@@ -2293,6 +2338,50 @@ impl App {
                             Self::handle_text_input(value, key);
                         }
                     }
+                    ProviderKeyField::ConfigKeyName => match key.code {
+                        KeyCode::Enter => {
+                            if !form.config_key_input.is_empty()
+                                && !form.config_value_input.is_empty()
+                            {
+                                form.config.insert(
+                                    std::mem::take(&mut form.config_key_input),
+                                    std::mem::take(&mut form.config_value_input),
+                                );
+                            }
+                        }
+                        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            if !form.config.is_empty() {
+                                let key_to_remove = form
+                                    .config
+                                    .keys()
+                                    .nth(form.config_cursor)
+                                    .cloned()
+                                    .unwrap_or_default();
+                                form.config.shift_remove(&key_to_remove);
+                                form.config_cursor = form
+                                    .config_cursor
+                                    .min(form.config.len().saturating_sub(1));
+                            }
+                        }
+                        _ => {
+                            Self::handle_text_input(&mut form.config_key_input, key);
+                        }
+                    },
+                    ProviderKeyField::ConfigKeyValue => match key.code {
+                        KeyCode::Enter => {
+                            if !form.config_key_input.is_empty()
+                                && !form.config_value_input.is_empty()
+                            {
+                                form.config.insert(
+                                    std::mem::take(&mut form.config_key_input),
+                                    std::mem::take(&mut form.config_value_input),
+                                );
+                            }
+                        }
+                        _ => {
+                            Self::handle_text_input(&mut form.config_value_input, key);
+                        }
+                    },
                     ProviderKeyField::EnvVarName => {
                         Self::handle_text_input(&mut form.generic_env_name, key);
                     }

--- a/crates/openshell-tui/src/app.rs
+++ b/crates/openshell-tui/src/app.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![warn(missing_debug_implementations)]
+
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
@@ -368,11 +370,13 @@ pub struct CreateProviderForm {
     pub credentials: Vec<(String, String)>,
     /// Which credential row is focused.
     pub cred_cursor: usize,
-    /// TODO: inline doc for config, possibilities of using IndexMap
+    /// Provider config key-value pairs (e.g. `ANTHROPIC_BASE_URL`).
     pub config: IndexMap<String, String>,
-    /// Which config row is focused.
+    /// Which existing config entry is selected (for deletion).
     pub config_cursor: usize,
+    /// Config key being entered.
     pub config_key_input: String,
+    /// Config value being entered.
     pub config_value_input: String,
     /// For generic / types with no known env vars: custom env var name.
     pub generic_env_name: String,
@@ -508,7 +512,20 @@ pub struct UpdateProviderForm {
     pub provider_type: String,
     pub credential_key: String,
     pub new_value: String,
+    pub config: IndexMap<String, String>,
+    pub config_key_input: String,
+    pub config_value_input: String,
+    pub config_cursor: usize,
+    pub focus: UpdateProviderField,
     pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateProviderField {
+    CredentialValue,
+    ConfigKey,
+    ConfigValue,
+    Submit,
 }
 
 // ---------------------------------------------------------------------------
@@ -2358,9 +2375,8 @@ impl App {
                                     .cloned()
                                     .unwrap_or_default();
                                 form.config.shift_remove(&key_to_remove);
-                                form.config_cursor = form
-                                    .config_cursor
-                                    .min(form.config.len().saturating_sub(1));
+                                form.config_cursor =
+                                    form.config_cursor.min(form.config.len().saturating_sub(1));
                             }
                         }
                         _ => {
@@ -2503,6 +2519,17 @@ impl App {
             .get(self.provider_selected)
             .cloned()
             .unwrap_or_default();
+        let existing_config = self
+            .provider_entries
+            .get(self.provider_selected)
+            .map(|e| {
+                e.provider
+                    .config
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect::<IndexMap<_, _>>()
+            })
+            .unwrap_or_default();
 
         // If we don't know the credential key, derive from registry.
         let key = if cred_key.is_empty() {
@@ -2520,6 +2547,11 @@ impl App {
             provider_type: ptype,
             credential_key: key,
             new_value: String::new(),
+            config: existing_config,
+            config_key_input: String::new(),
+            config_value_input: String::new(),
+            config_cursor: 0,
+            focus: UpdateProviderField::CredentialValue,
             status: None,
         });
     }
@@ -2533,18 +2565,100 @@ impl App {
             KeyCode::Esc => {
                 self.update_provider_form = None;
             }
-            KeyCode::Enter => {
-                if form.new_value.is_empty() {
-                    form.status = Some("Value is required.".to_string());
-                    return;
+            KeyCode::Tab => match form.focus {
+                UpdateProviderField::CredentialValue => {
+                    form.focus = UpdateProviderField::ConfigKey;
                 }
-                self.pending_provider_update = true;
-            }
-            KeyCode::Char(c) => form.new_value.push(c),
-            KeyCode::Backspace => {
-                form.new_value.pop();
-            }
-            _ => {}
+                UpdateProviderField::ConfigKey => {
+                    form.focus = UpdateProviderField::ConfigValue;
+                }
+                UpdateProviderField::ConfigValue => {
+                    if !form.config_key_input.is_empty() && !form.config_value_input.is_empty() {
+                        form.config.insert(
+                            std::mem::take(&mut form.config_key_input),
+                            std::mem::take(&mut form.config_value_input),
+                        );
+                        form.focus = UpdateProviderField::ConfigKey;
+                    } else if form.config_key_input.is_empty() && form.config_value_input.is_empty()
+                    {
+                        form.focus = UpdateProviderField::Submit;
+                    } else {
+                        form.focus = UpdateProviderField::ConfigKey;
+                    }
+                }
+                UpdateProviderField::Submit => {
+                    form.focus = UpdateProviderField::CredentialValue;
+                }
+            },
+            KeyCode::BackTab => match form.focus {
+                UpdateProviderField::CredentialValue => {
+                    form.focus = UpdateProviderField::Submit;
+                }
+                UpdateProviderField::ConfigKey => {
+                    form.focus = UpdateProviderField::CredentialValue;
+                }
+                UpdateProviderField::ConfigValue => {
+                    form.focus = UpdateProviderField::ConfigKey;
+                }
+                UpdateProviderField::Submit => {
+                    form.focus = UpdateProviderField::ConfigValue;
+                }
+            },
+            _ => match form.focus {
+                UpdateProviderField::CredentialValue => {
+                    Self::handle_text_input(&mut form.new_value, key);
+                }
+                UpdateProviderField::ConfigKey => match key.code {
+                    KeyCode::Enter => {
+                        if !form.config_key_input.is_empty() && !form.config_value_input.is_empty()
+                        {
+                            form.config.insert(
+                                std::mem::take(&mut form.config_key_input),
+                                std::mem::take(&mut form.config_value_input),
+                            );
+                        }
+                    }
+                    KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        if !form.config.is_empty() {
+                            let key_to_remove = form
+                                .config
+                                .keys()
+                                .nth(form.config_cursor)
+                                .cloned()
+                                .unwrap_or_default();
+                            form.config.shift_remove(&key_to_remove);
+                            form.config_cursor =
+                                form.config_cursor.min(form.config.len().saturating_sub(1));
+                        }
+                    }
+                    _ => {
+                        Self::handle_text_input(&mut form.config_key_input, key);
+                    }
+                },
+                UpdateProviderField::ConfigValue => match key.code {
+                    KeyCode::Enter => {
+                        if !form.config_key_input.is_empty() && !form.config_value_input.is_empty()
+                        {
+                            form.config.insert(
+                                std::mem::take(&mut form.config_key_input),
+                                std::mem::take(&mut form.config_value_input),
+                            );
+                        }
+                    }
+                    _ => {
+                        Self::handle_text_input(&mut form.config_value_input, key);
+                    }
+                },
+                UpdateProviderField::Submit => {
+                    if key.code == KeyCode::Enter {
+                        if form.new_value.is_empty() {
+                            form.status = Some("Value is required.".to_string());
+                            return;
+                        }
+                        self.pending_provider_update = true;
+                    }
+                }
+            },
         }
     }
 

--- a/crates/openshell-tui/src/lib.rs
+++ b/crates/openshell-tui/src/lib.rs
@@ -1597,6 +1597,11 @@ fn spawn_create_provider(app: &App, tx: mpsc::UnboundedSender<Event>) {
         form.name.clone()
     };
     let credentials = form.discovered_credentials.clone().unwrap_or_default();
+    let config: HashMap<String, String> = form
+        .config
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
 
     tokio::spawn(async move {
         // Try with the chosen name, retry with suffix on collision.
@@ -1618,7 +1623,7 @@ fn spawn_create_provider(app: &App, tx: mpsc::UnboundedSender<Event>) {
                     }),
                     r#type: ptype.clone(),
                     credentials: credentials.clone(),
-                    config: HashMap::default(),
+                    config: config.clone(),
                     credential_expires_at_ms: HashMap::default(),
                 }),
             };

--- a/crates/openshell-tui/src/lib.rs
+++ b/crates/openshell-tui/src/lib.rs
@@ -1699,6 +1699,11 @@ fn spawn_update_provider(app: &App, tx: mpsc::UnboundedSender<Event>) {
     let ptype = form.provider_type.clone();
     let cred_key = form.credential_key.clone();
     let new_value = form.new_value.clone();
+    let config: HashMap<String, String> = form
+        .config
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
 
     tokio::spawn(async move {
         let mut credentials = HashMap::new();
@@ -1715,7 +1720,7 @@ fn spawn_update_provider(app: &App, tx: mpsc::UnboundedSender<Event>) {
                 }),
                 r#type: ptype,
                 credentials,
-                config: HashMap::default(),
+                config,
                 credential_expires_at_ms: HashMap::default(),
             }),
             credential_expires_at_ms: HashMap::default(),

--- a/crates/openshell-tui/src/ui/create_provider.rs
+++ b/crates/openshell-tui/src/ui/create_provider.rs
@@ -207,8 +207,10 @@ fn draw_enter_key(
         warning_rows + 12
     } else {
         let num_creds = form.credentials.len().clamp(1, 8) as u16;
+        let config_rows = (form.config.len() as u16).min(6) + 3; // existing entries + label(1) + key input(1) + value input(1) 
         // type(1) + name(2) + spacer(1) + creds + spacer(1) + submit(1) + status(1) + hint(1)
-        warning_rows + 1 + 2 + 1 + num_creds + 1 + 1 + 1 + 1
+
+        warning_rows + 1 + 2 + 1 + num_creds + 1 + config_rows + 1 + 1 + 1 + 1
     };
     let modal_height = (content_height + 4).min(area.height.saturating_sub(2));
     let popup_area = centered_rect(modal_width, modal_height, area);
@@ -241,6 +243,17 @@ fn draw_enter_key(
         let num_creds = form.credentials.len().clamp(1, 8) as u16;
         constraints.push(Constraint::Length(num_creds)); // credential rows
     }
+
+    constraints.push(Constraint::Length(1)); // spacer before config
+    constraints.push(Constraint::Length(1)); // config keys label
+    #[allow(clippy::cast_possible_truncation)]
+    let num_config = form.config.len().min(6) as u16;
+    if num_config > 0 {
+        constraints.push(Constraint::Length(num_config)); // existing config entries
+    }
+    constraints.push(Constraint::Length(1)); // config key input
+    constraints.push(Constraint::Length(1)); // config value input
+
     constraints.push(Constraint::Length(1)); // spacer
     constraints.push(Constraint::Length(1)); // submit
     constraints.push(Constraint::Length(1)); // status
@@ -361,7 +374,78 @@ fn draw_enter_key(
     }
     idx += 1;
 
-    // Spacer.
+    // Spacer before config.
+    idx += 1;
+
+    // Config Keys label.
+    let config_focused = matches!(
+        form.key_field,
+        ProviderKeyField::ConfigKeyName | ProviderKeyField::ConfigKeyValue
+    );
+    let header_style = if config_focused { t.accent_bold } else { t.muted };
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled("Config Keys:", header_style))),
+        chunks[idx],
+    );
+    idx += 1;
+
+    // Existing config entries.
+    if !form.config.is_empty() {
+        let config_lines: Vec<Line<'_>> = form
+            .config
+            .iter()
+            .enumerate()
+            .take(6)
+            .map(|(i, (key, value))| {
+                let is_selected = config_focused && i == form.config_cursor;
+                let style = if is_selected { t.accent_bold } else { t.text };
+                Line::from(vec![
+                    Span::styled(format!("  {key}="), style),
+                    Span::styled(value.as_str(), if is_selected { t.accent } else { t.muted }),
+                ])
+            })
+            .collect();
+        frame.render_widget(Paragraph::new(config_lines), chunks[idx]);
+        idx += 1;
+    }
+
+    // Config key input.
+    let editing_key = form.key_field == ProviderKeyField::ConfigKeyName;
+    let key_display = if form.config_key_input.is_empty() {
+        if editing_key { "_".to_string() } else { "key".to_string() }
+    } else {
+        let mut s = form.config_key_input.clone();
+        if editing_key { s.push('_'); }
+        s
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("  Key: ", t.muted),
+            Span::styled(key_display, if editing_key { t.accent } else { t.muted }),
+        ])),
+        chunks[idx],
+    );
+    idx += 1;
+
+    // Config value input.
+    let editing_val = form.key_field == ProviderKeyField::ConfigKeyValue;
+    let val_display = if form.config_value_input.is_empty() {
+        if editing_val { "_".to_string() } else { "value".to_string() }
+    } else {
+        let mut s = form.config_value_input.clone();
+        if editing_val { s.push('_'); }
+        s
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("  Val: ", t.muted),
+            Span::styled(val_display, if editing_val { t.accent } else { t.muted }),
+        ])),
+        chunks[idx],
+    );
+    idx += 1;
+
+    // Spacer before submit.
     idx += 1;
 
     // Submit button.

--- a/crates/openshell-tui/src/ui/create_provider.rs
+++ b/crates/openshell-tui/src/ui/create_provider.rs
@@ -6,7 +6,7 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph};
 
-use crate::app::{App, CreateProviderPhase, ProviderKeyField};
+use crate::app::{App, CreateProviderPhase, ProviderKeyField, UpdateProviderField};
 
 use super::centered_rect;
 
@@ -382,7 +382,11 @@ fn draw_enter_key(
         form.key_field,
         ProviderKeyField::ConfigKeyName | ProviderKeyField::ConfigKeyValue
     );
-    let header_style = if config_focused { t.accent_bold } else { t.muted };
+    let header_style = if config_focused {
+        t.accent_bold
+    } else {
+        t.muted
+    };
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled("Config Keys:", header_style))),
         chunks[idx],
@@ -412,10 +416,16 @@ fn draw_enter_key(
     // Config key input.
     let editing_key = form.key_field == ProviderKeyField::ConfigKeyName;
     let key_display = if form.config_key_input.is_empty() {
-        if editing_key { "_".to_string() } else { "key".to_string() }
+        if editing_key {
+            "_".to_string()
+        } else {
+            "key".to_string()
+        }
     } else {
         let mut s = form.config_key_input.clone();
-        if editing_key { s.push('_'); }
+        if editing_key {
+            s.push('_');
+        }
         s
     };
     frame.render_widget(
@@ -430,10 +440,16 @@ fn draw_enter_key(
     // Config value input.
     let editing_val = form.key_field == ProviderKeyField::ConfigKeyValue;
     let val_display = if form.config_value_input.is_empty() {
-        if editing_val { "_".to_string() } else { "value".to_string() }
+        if editing_val {
+            "_".to_string()
+        } else {
+            "value".to_string()
+        }
     } else {
         let mut s = form.config_value_input.clone();
-        if editing_val { s.push('_'); }
+        if editing_val {
+            s.push('_');
+        }
         s
     };
     frame.render_widget(
@@ -753,9 +769,14 @@ pub fn draw_update(frame: &mut Frame<'_>, app: &App, area: Rect) {
         return;
     };
 
-    let modal_width = 60u16.min(area.width.saturating_sub(4));
-    // name(1) + type(1) + spacer(1) + key_label(1) + value(1) + cursor_hint(1) + spacer(1) + status(1) + hint(1)
-    let content_height = 9;
+    let modal_width = 64u16.min(area.width.saturating_sub(4));
+
+    #[allow(clippy::cast_possible_truncation)]
+    let num_config = form.config.len().min(6) as u16;
+    let config_rows = num_config + 3; // existing entries + label(1) + key input(1) + value input(1)
+    // name(1) + type(1) + spacer(1) + key_label(1) + value(1) + spacer(1)
+    // + config_section + spacer(1) + submit(1) + status(1) + hint(1)
+    let content_height: u16 = 1 + 1 + 1 + 1 + 1 + 1 + config_rows + 1 + 1 + 1 + 1;
     let modal_height = (content_height + 4).min(area.height.saturating_sub(2));
     let popup_area = centered_rect(modal_width, modal_height, area);
 
@@ -770,69 +791,193 @@ pub fn draw_update(frame: &mut Frame<'_>, app: &App, area: Rect) {
     let inner = block.inner(popup_area);
     frame.render_widget(block, popup_area);
 
+    let mut constraints = vec![
+        Constraint::Length(1), // name
+        Constraint::Length(1), // type
+        Constraint::Length(1), // spacer
+        Constraint::Length(1), // key label
+        Constraint::Length(1), // value input
+        Constraint::Length(1), // spacer before config
+        Constraint::Length(1), // config keys label
+    ];
+    if num_config > 0 {
+        constraints.push(Constraint::Length(num_config)); // existing config entries
+    }
+    constraints.extend([
+        Constraint::Length(1), // config key input
+        Constraint::Length(1), // config value input
+        Constraint::Length(1), // spacer before submit
+        Constraint::Length(1), // submit
+        Constraint::Length(1), // status
+        Constraint::Length(1), // hint
+        Constraint::Min(0),
+    ]);
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1), // name
-            Constraint::Length(1), // type
-            Constraint::Length(1), // spacer
-            Constraint::Length(1), // key label
-            Constraint::Length(1), // value input
-            Constraint::Length(1), // cursor hint
-            Constraint::Length(1), // spacer
-            Constraint::Length(1), // status
-            Constraint::Length(1), // hint
-            Constraint::Min(0),
-        ])
+        .constraints(constraints)
         .split(inner);
 
+    let mut idx = 0;
+
+    // Name.
     frame.render_widget(
         Paragraph::new(Line::from(vec![
             Span::styled("Name: ", t.muted),
             Span::styled(&form.provider_name, t.heading),
         ])),
-        chunks[0],
+        chunks[idx],
     );
+    idx += 1;
 
+    // Type.
     frame.render_widget(
         Paragraph::new(Line::from(vec![
             Span::styled("Type: ", t.muted),
             Span::styled(&form.provider_type, t.text),
         ])),
-        chunks[1],
+        chunks[idx],
     );
+    idx += 1;
 
+    // Spacer.
+    idx += 1;
+
+    // Credential key label.
+    let cred_focused = form.focus == UpdateProviderField::CredentialValue;
     let key_label = if form.credential_key.is_empty() {
-        "New value:"
+        "New value"
     } else {
         &form.credential_key
     };
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(
             format!("{key_label}:"),
-            t.accent_bold,
+            if cred_focused { t.accent_bold } else { t.muted },
         ))),
-        chunks[3],
+        chunks[idx],
     );
+    idx += 1;
 
-    // Mask the input value as dots.
+    // Credential value input (masked).
     let masked: String = "*".repeat(form.new_value.len());
+    let cred_style = if cred_focused { t.accent } else { t.muted };
+    let mut cred_spans = vec![Span::styled(format!("  {masked}"), cred_style)];
+    if cred_focused {
+        cred_spans.push(Span::styled("_", t.accent));
+    }
+    frame.render_widget(Paragraph::new(Line::from(cred_spans)), chunks[idx]);
+    idx += 1;
+
+    // Spacer before config.
+    idx += 1;
+
+    // Config Keys label.
+    let config_focused = matches!(
+        form.focus,
+        UpdateProviderField::ConfigKey | UpdateProviderField::ConfigValue
+    );
+    let header_style = if config_focused {
+        t.accent_bold
+    } else {
+        t.muted
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled("Config Keys:", header_style))),
+        chunks[idx],
+    );
+    idx += 1;
+
+    // Existing config entries.
+    if !form.config.is_empty() {
+        let config_lines: Vec<Line<'_>> = form
+            .config
+            .iter()
+            .enumerate()
+            .take(6)
+            .map(|(i, (key, value))| {
+                let is_selected = config_focused && i == form.config_cursor;
+                let style = if is_selected { t.accent_bold } else { t.text };
+                Line::from(vec![
+                    Span::styled(format!("  {key}="), style),
+                    Span::styled(value.as_str(), if is_selected { t.accent } else { t.muted }),
+                ])
+            })
+            .collect();
+        frame.render_widget(Paragraph::new(config_lines), chunks[idx]);
+        idx += 1;
+    }
+
+    // Config key input.
+    let editing_key = form.focus == UpdateProviderField::ConfigKey;
+    let key_display = if form.config_key_input.is_empty() {
+        if editing_key {
+            "_".to_string()
+        } else {
+            "key".to_string()
+        }
+    } else {
+        let mut s = form.config_key_input.clone();
+        if editing_key {
+            s.push('_');
+        }
+        s
+    };
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled(format!("  {masked}"), t.accent),
-            Span::styled("_", t.accent),
+            Span::styled("  Key: ", t.muted),
+            Span::styled(key_display, if editing_key { t.accent } else { t.muted }),
         ])),
-        chunks[4],
+        chunks[idx],
     );
+    idx += 1;
 
+    // Config value input.
+    let editing_val = form.focus == UpdateProviderField::ConfigValue;
+    let val_display = if form.config_value_input.is_empty() {
+        if editing_val {
+            "_".to_string()
+        } else {
+            "value".to_string()
+        }
+    } else {
+        let mut s = form.config_value_input.clone();
+        if editing_val {
+            s.push('_');
+        }
+        s
+    };
     frame.render_widget(
-        Paragraph::new(Line::from(Span::styled(
-            "  Type the new credential value",
-            t.muted,
-        ))),
-        chunks[5],
+        Paragraph::new(Line::from(vec![
+            Span::styled("  Val: ", t.muted),
+            Span::styled(val_display, if editing_val { t.accent } else { t.muted }),
+        ])),
+        chunks[idx],
     );
+    idx += 1;
 
+    // Spacer before submit.
+    idx += 1;
+
+    // Submit button.
+    let submit_focused = form.focus == UpdateProviderField::Submit;
+    let submit_style = if submit_focused {
+        t.accent_bold
+    } else {
+        t.muted
+    };
+    let submit_label = if submit_focused {
+        "  > Update Provider"
+    } else {
+        "  Update Provider"
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(submit_label, submit_style))),
+        chunks[idx],
+    );
+    idx += 1;
+
+    // Status.
     if let Some(ref status) = form.status {
         let style = if status.contains("required")
             || status.contains("failed")
@@ -844,17 +989,23 @@ pub fn draw_update(frame: &mut Frame<'_>, app: &App, area: Rect) {
         };
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(format!("  {status}"), style))),
-            chunks[7],
+            chunks[idx],
         );
     }
+    idx += 1;
 
+    // Hint.
     let hint = Line::from(vec![
+        Span::styled("[Tab]", t.key_hint),
+        Span::styled(" Next ", t.muted),
+        Span::styled("[S-Tab]", t.key_hint),
+        Span::styled(" Prev ", t.muted),
         Span::styled("[Enter]", t.key_hint),
-        Span::styled(" Update ", t.muted),
+        Span::styled(" Submit ", t.muted),
         Span::styled("[Esc]", t.key_hint),
         Span::styled(" Cancel", t.muted),
     ]);
-    frame.render_widget(Paragraph::new(hint), chunks[8]);
+    frame.render_widget(Paragraph::new(hint), chunks[idx]);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Add config key (`config` map) support to the TUI's Create Provider and Update Provider forms.

Previously, both forms only handled credentials and hardcoded `config: HashMap::default()`, making it impossible to set provider config keys like `ANTHROPIC_BASE_URL` or `OPENAI_BASE_URL` via `openshell term`. The CLI's `--config KEY=VALUE` flag worked correctly, only the TUI surface was affected.

## Related Issue
#1798 

## Changes
- **Create Provider form**: Added config key/value input section with Tab-based navigation between key and
  value fields, auto-commit on Tab, and Ctrl+D to delete entries
- **Update Provider form**: Added config key/value editing with existing config hydrated from the provider
  on form open, preserving config that the user doesn't modify
- **Spawn functions**: `spawn_create_provider` and `spawn_update_provider` now plumb the form's config map
  into the gRPC request instead of sending empty maps

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)

## Screenshots

You can run `cargo run -p openshell-cli -- term` to try it out yourself.

<img width="3020" height="1672" alt="image" src="https://github.com/user-attachments/assets/92854bbf-09af-4268-9a76-beb7aa528d77" />

<img width="3024" height="1700" alt="image" src="https://github.com/user-attachments/assets/c4950d3e-7d5d-486a-b314-fd5c7d94f447" />

