### PR TITLE
fix(sandbox): undo tmpfs overlay when setns fails during SPIFFE mount namespace setup

### DIFF
--- a/crates/openshell-supervisor-process/src/process.rs
+++ b/crates/openshell-supervisor-process/src/process.rs
@@ -386,8 +386,12 @@ fn create_supervisor_identity_mount_namespace(target: &Path) -> Result<OwnedFd> 
         // overlay so the SPIFFE workload API socket stays reachable in the
         // namespace PID 1 is stuck in.
         #[allow(unsafe_code)]
-        unsafe {
-            libc::umount2(target.as_ptr(), libc::MNT_DETACH);
+        let umount_rc = unsafe { libc::umount2(target.as_ptr(), libc::MNT_DETACH) };
+        if umount_rc != 0 {
+            tracing::warn!(
+                errno = ?std::io::Error::last_os_error(),
+                "umount2 cleanup failed after setns error; SPIFFE socket may remain hidden"
+            );
         }
         let result_msg = result.as_ref().err().map_or_else(
             || "sanitized namespace was created".to_string(),

--- a/crates/openshell-supervisor-process/src/process.rs
+++ b/crates/openshell-supervisor-process/src/process.rs
@@ -381,16 +381,24 @@ fn create_supervisor_identity_mount_namespace(target: &Path) -> Result<OwnedFd> 
             .map_err(|err| miette::miette!("failed to open sanitized mount namespace: {err}"))
     })();
 
-    set_mount_namespace(original_ns.as_raw_fd()).map_err(|restore_err| {
+    if let Err(restore_err) = set_mount_namespace(original_ns.as_raw_fd()) {
+        // Cannot restore the original mount namespace. Undo the tmpfs
+        // overlay so the SPIFFE workload API socket stays reachable in the
+        // namespace PID 1 is stuck in.
+        #[allow(unsafe_code)]
+        unsafe {
+            libc::umount2(target.as_ptr(), libc::MNT_DETACH);
+        }
         let result_msg = result.as_ref().err().map_or_else(
             || "sanitized namespace was created".to_string(),
             ToString::to_string,
         );
-        miette::miette!(
+        return Err(miette::miette!(
             "failed to restore original mount namespace after supervisor identity isolation setup: \
-             {restore_err}; setup result: {result_msg}"
-        )
-    })?;
+             {restore_err}; undid tmpfs overlay so SPIFFE socket remains accessible; \
+             setup result: {result_msg}"
+        ));
+    }
 
     result
 }


### PR DESCRIPTION
## Summary

- When `setns(CLONE_NEWNS)` fails with `EPERM` (common on OpenShift and hardened K8s without `CAP_SYS_ADMIN`), `create_supervisor_identity_mount_namespace` leaves an empty tmpfs mounted over the SPIFFE workload API socket directory. Since PID 1 is stuck in the new mount namespace, the socket becomes invisible to all processes in the container, even though the CSI volume is healthy.
- This fix calls `umount2(MNT_DETACH)` in the `setns()` error path to remove the tmpfs overlay before returning, keeping the SPIFFE socket accessible.

## Related Issue

N/A (discovered during SPIFFE + token grant integration testing on OpenShift)

## Changes

- `crates/openshell-supervisor-process/src/process.rs`:
  - `create_supervisor_identity_mount_namespace`: on `setns()` failure, `umount2(target, MNT_DETACH)` before returning error

## Testing

- Built patched supervisor binary (static musl, cross-compiled from macOS via cargo-zigbuild)
- Deployed as custom supervisor image on OpenShift 4.x cluster with SPIRE CSI driver
- Confirmed supervisor logs show: "undid tmpfs overlay so SPIFFE socket remains accessible"
- Confirmed `/spiffe-workload-api/spire-agent.sock` is visible inside sandbox container
- Confirmed sandbox proxy allows traffic to provider endpoints (401 from protected service, not 403 policy_denied)
- All existing tests pass (`cargo test --workspace`)

## Checklist

- [x] Conventional commit format
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] All tests pass
- [x] Signed off (DCO)