### PR TITLE
change packit target to new correct copr project

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -66,7 +66,7 @@ jobs:
     trigger: commit
     branch: main
     owner: "maxamillion"
-    project: "openshell"
+    project: "nvidia-openshell"
     identifier: main-commit
     targets:
       - fedora-all
@@ -79,7 +79,7 @@ jobs:
   - job: copr_build
     trigger: release
     owner: "maxamillion"
-    project: "openshell"
+    project: "nvidia-openshell"
     targets:
       - fedora-all
       - epel-10


### PR DESCRIPTION
## Summary
<!-- 1-3 sentences: what this PR does and why -->

need to update the packit config to point to the copr repo I've been using since the other one still carried old out of tree patches unrelated to upstream and I don't want to break that build flow 


