### PR TITLE
fix(driver-podman): gate Linux-only Path import

### DIFF
--- a/crates/openshell-driver-podman/src/container.rs
+++ b/crates/openshell-driver-podman/src/container.rs
@@ -14,6 +14,7 @@ use openshell_core::{driver_mounts, proto_struct};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashSet};
+#[cfg(target_os = "linux")]
 use std::path::Path;
 
 /// Returns `true` when `SELinux` is enabled (enforcing or permissive).


### PR DESCRIPTION
## Summary
Apply the Linux cfg to the Path import so native macOS lint runs do not report it as unused when the only call site is compiled out.

This fixes `mise run rust:lint` on macOS.

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
