### PR TITLE
feat(server): add read-only web dashboard behind OPENSHELL_WEB_UI gate

### DIFF
--- a/crates/openshell-server/assets/ui.html
+++ b/crates/openshell-server/assets/ui.html
@@ -1,0 +1,579 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OpenShell Console</title>
+<style>
+  :root {
+    --bg: #0C120C;
+    --panel: #121A12;
+    --line: #223022;
+    --text: #D6E2D0;
+    --muted: #7C8E7A;
+    --accent: #76B900;
+    --accent-dim: #4A7400;
+    --warn: #E0A64B;
+    --err: #E5484D;
+    --mono: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--mono);
+    font-size: 13px;
+    line-height: 1.5;
+    overflow: hidden;
+  }
+  a { color: var(--accent); }
+  button { font-family: inherit; }
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+  .app { display: grid; grid-template-columns: 264px 1fr; height: 100vh; }
+
+  /* ---------------- rail ---------------- */
+  .rail {
+    border-right: 1px solid var(--line);
+    background: var(--panel);
+    display: flex; flex-direction: column;
+    min-height: 0;
+  }
+  .brand {
+    padding: 14px 16px 10px;
+    border-bottom: 1px solid var(--line);
+  }
+  .brand h1 {
+    font-size: 14px; font-weight: 700; letter-spacing: 0.08em;
+  }
+  .brand h1 .tail { color: var(--accent); }
+  .brand .sub { color: var(--muted); font-size: 11px; margin-top: 2px; }
+  .gw {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--line);
+    font-size: 11px; color: var(--muted);
+    display: flex; flex-direction: column; gap: 2px;
+  }
+  .gw .row { display: flex; justify-content: space-between; }
+  .gw .row b { color: var(--text); font-weight: 400; }
+  .rail-label {
+    padding: 12px 16px 6px;
+    font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--muted);
+  }
+  .sb-list { overflow-y: auto; flex: 1; }
+  .sb-item {
+    width: 100%; text-align: left; display: block;
+    padding: 10px 16px;
+    background: none; border: none; border-left: 2px solid transparent;
+    color: var(--text); cursor: pointer; font-size: 13px;
+  }
+  .sb-item:hover { background: rgba(118, 185, 0, 0.06); }
+  .sb-item.sel { background: rgba(118, 185, 0, 0.10); border-left-color: var(--accent); }
+  .sb-item .meta { display: flex; gap: 8px; align-items: center; margin-top: 2px; }
+  .sb-item .meta small { color: var(--muted); font-size: 11px; }
+  .led { width: 7px; height: 7px; border-radius: 50%; display: inline-block; flex: none; }
+  .led.Ready { background: var(--accent); box-shadow: 0 0 6px rgba(118,185,0,0.7); }
+  .led.Provisioning { background: var(--warn); }
+  .led.Error, .led.Unknown { background: var(--err); }
+  .led.Deleting { background: var(--muted); }
+  .rail-empty { padding: 16px; color: var(--muted); font-size: 12px; }
+  .rail-empty code { color: var(--text); }
+  .rail-foot {
+    border-top: 1px solid var(--line);
+    padding: 8px 16px; font-size: 10px; color: var(--muted);
+  }
+  .rail-foot kbd {
+    border: 1px solid var(--line); border-radius: 3px;
+    padding: 0 4px; font-size: 10px; color: var(--text);
+  }
+
+  /* ---------------- main ---------------- */
+  .main { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
+  .head {
+    display: flex; align-items: baseline; gap: 14px;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--line);
+    background: var(--panel);
+    flex-wrap: wrap;
+  }
+  .head .name { font-size: 16px; font-weight: 700; }
+  .head .chip {
+    font-size: 11px; padding: 1px 8px; border-radius: 3px;
+    border: 1px solid var(--line); color: var(--muted);
+  }
+  .head .chip.phase-Ready { color: var(--accent); border-color: var(--accent-dim); }
+  .head .chip.phase-Provisioning { color: var(--warn); }
+  .head .chip.phase-Error { color: var(--err); }
+  .head .spacer { flex: 1; }
+  .tabs { display: flex; gap: 2px; }
+  .tab {
+    background: none; border: 1px solid var(--line); border-bottom: none;
+    color: var(--muted); padding: 3px 14px; cursor: pointer;
+    font-size: 12px; border-radius: 4px 4px 0 0;
+  }
+  .tab.sel { color: var(--bg); background: var(--accent); border-color: var(--accent); font-weight: 700; }
+
+  .body { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+  .pane { flex: 1; min-height: 0; display: none; flex-direction: column; }
+  .pane.sel { display: flex; }
+
+  /* ---------------- live pane ---------------- */
+  .pulse-track {
+    height: 3px; background: var(--panel); position: relative; overflow: hidden;
+    border-bottom: 1px solid var(--line);
+  }
+  .pulse-track .tick {
+    position: absolute; top: 0; bottom: 0; width: 40px;
+    background: linear-gradient(90deg, transparent, var(--accent));
+    animation: sweep 0.9s linear forwards;
+  }
+  .pulse-track .tick.deny { background: linear-gradient(90deg, transparent, var(--warn)); }
+  @keyframes sweep { from { left: -40px; } to { left: 100%; } }
+
+  .live-grid {
+    flex: 1; min-height: 0;
+    display: grid; grid-template-rows: minmax(120px, 42%) 1fr;
+  }
+  .board { overflow-y: auto; padding: 10px 20px; }
+  .board-label, .tail-label {
+    font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--muted); margin-bottom: 6px;
+    display: flex; justify-content: space-between; align-items: center;
+  }
+  .strip {
+    display: flex; align-items: center; gap: 10px;
+    border: 1px solid var(--line); border-left-width: 3px;
+    border-radius: 3px; padding: 4px 10px; margin-bottom: 4px;
+    background: var(--panel);
+  }
+  .strip.allow { border-left-color: var(--accent); }
+  .strip.deny  { border-left-color: var(--warn); background: rgba(224,166,75,0.07); }
+  .strip.fail  { border-left-color: var(--err); background: rgba(229,72,77,0.07); }
+  @media (prefers-reduced-motion: no-preference) {
+    .strip.fresh { animation: land 0.35s ease-out; }
+    @keyframes land { from { transform: translateY(-4px); opacity: 0; } to { transform: none; opacity: 1; } }
+  }
+  .strip .verdict { font-weight: 700; font-size: 11px; width: 56px; flex: none; }
+  .strip.allow .verdict { color: var(--accent); }
+  .strip.deny .verdict  { color: var(--warn); }
+  .strip.fail .verdict  { color: var(--err); }
+  .strip .bin { color: var(--muted); max-width: 34%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .strip .arrow { color: var(--muted); flex: none; }
+  .strip .dst { font-weight: 700; }
+  .strip .pol { margin-left: auto; color: var(--muted); font-size: 11px; white-space: nowrap; }
+  .strip .t { color: var(--muted); font-size: 10px; flex: none; width: 60px; }
+  .board-empty { color: var(--muted); padding: 18px 0; font-size: 12px; }
+
+  .tail-wrap {
+    border-top: 1px solid var(--line);
+    display: flex; flex-direction: column; min-height: 0;
+  }
+  .tail-label { padding: 8px 20px 0; margin-bottom: 0; }
+  .tail-controls { display: flex; gap: 6px; }
+  .fchip {
+    background: none; border: 1px solid var(--line); border-radius: 10px;
+    color: var(--muted); font-size: 10px; padding: 0 8px; cursor: pointer;
+  }
+  .fchip.on { color: var(--bg); background: var(--accent); border-color: var(--accent); }
+  .tail { flex: 1; overflow-y: auto; padding: 6px 20px 14px; font-size: 12px; }
+  .ln { white-space: pre-wrap; word-break: break-all; }
+  .ln .ts { color: var(--muted); }
+  .ln .lv-WARN { color: var(--warn); }
+  .ln .lv-ERROR { color: var(--err); }
+  .ln .lv-INFO { color: var(--accent-dim); }
+  .ln .src { color: var(--muted); }
+
+  /* ---------------- policy pane ---------------- */
+  .policy-grid {
+    flex: 1; min-height: 0;
+    display: grid; grid-template-columns: 1fr 380px; gap: 0;
+  }
+  .yaml { overflow: auto; padding: 14px 20px; border-right: 1px solid var(--line); }
+  .yaml pre { font-size: 12px; line-height: 1.55; }
+  .yaml .k { color: var(--accent); }
+  .revs { overflow-y: auto; padding: 14px 16px; }
+  table { border-collapse: collapse; width: 100%; font-size: 12px; }
+  th {
+    text-align: left; font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase;
+    color: var(--muted); font-weight: 400; padding: 4px 8px 6px;
+    border-bottom: 1px solid var(--line);
+  }
+  td { padding: 5px 8px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  td.st-Loaded, td.st-Effective { color: var(--accent); }
+  td.st-Failed { color: var(--err); }
+  td .err-detail { color: var(--err); font-size: 11px; }
+  tr.active-rev td:first-child::after { content: " ●"; color: var(--accent); }
+
+  .placeholder {
+    flex: 1; display: flex; align-items: center; justify-content: center;
+    color: var(--muted); flex-direction: column; gap: 8px;
+  }
+  .placeholder .big { font-size: 15px; color: var(--text); }
+  .conn-warn {
+    padding: 6px 20px; font-size: 11px; color: var(--err);
+    border-bottom: 1px solid var(--line); display: none;
+  }
+  .conn-warn.show { display: block; }
+</style>
+</head>
+<body>
+<div class="app">
+  <nav class="rail">
+    <div class="brand">
+      <h1>OPEN<span class="tail">SHELL</span></h1>
+      <div class="sub">gateway console</div>
+    </div>
+    <div class="gw" id="gw">
+      <div class="row"><span>gateway</span><b id="gw-version">—</b></div>
+      <div class="row"><span>sandboxes</span><b id="gw-count">—</b></div>
+    </div>
+    <div class="rail-label">Sandboxes</div>
+    <div class="sb-list" id="sb-list" role="listbox" aria-label="Sandboxes"></div>
+    <div class="rail-foot"><kbd>j</kbd>/<kbd>k</kbd> select · <kbd>1</kbd> live · <kbd>2</kbd> policy</div>
+  </nav>
+
+  <main class="main">
+    <div class="conn-warn" id="conn-warn">Gateway unreachable — retrying…</div>
+    <div id="placeholder" class="placeholder">
+      <div class="big">Select a sandbox</div>
+      <div>Live network decisions, logs, and policy will appear here.</div>
+    </div>
+
+    <div id="detail" style="display:none; flex:1; min-height:0; flex-direction:column;">
+      <div class="head">
+        <span class="name" id="d-name">—</span>
+        <span class="chip" id="d-phase">—</span>
+        <span class="chip" id="d-policy">policy v—</span>
+        <span class="chip" id="d-image">—</span>
+        <span class="spacer"></span>
+        <div class="tabs">
+          <button class="tab sel" id="tab-live" onclick="selectTab('live')">Live</button>
+          <button class="tab" id="tab-policy" onclick="selectTab('policy')">Policy</button>
+        </div>
+      </div>
+
+      <div class="body">
+        <section class="pane sel" id="pane-live">
+          <div class="pulse-track" id="pulse"></div>
+          <div class="live-grid">
+            <div class="board">
+              <div class="board-label"><span>Network decisions</span><span id="board-count"></span></div>
+              <div id="board"><div class="board-empty">No network activity observed yet.</div></div>
+            </div>
+            <div class="tail-wrap">
+              <div class="tail-label">
+                <span>Log tail</span>
+                <span class="tail-controls">
+                  <button class="fchip on" data-src="all">all</button>
+                  <button class="fchip" data-src="sandbox">sandbox</button>
+                  <button class="fchip" data-src="gateway">gateway</button>
+                  <button class="fchip" id="follow-chip" onclick="toggleFollow()">following</button>
+                </span>
+              </div>
+              <div class="tail" id="tail"></div>
+            </div>
+          </div>
+        </section>
+
+        <section class="pane" id="pane-policy">
+          <div class="policy-grid">
+            <div class="yaml"><pre id="yaml">—</pre></div>
+            <div class="revs">
+              <table>
+                <thead><tr><th>ver</th><th>status</th><th>hash</th><th>loaded</th></tr></thead>
+                <tbody id="rev-body"></tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </main>
+</div>
+
+<script>
+"use strict";
+const $ = (id) => document.getElementById(id);
+
+const state = {
+  sandboxes: [],
+  selected: null,     // sandbox name
+  selectedId: null,   // sandbox uuid
+  es: null,           // EventSource
+  follow: true,
+  srcFilter: "all",
+  stripCount: 0,
+};
+
+// ---------------- data plumbing ----------------
+
+async function jget(url) {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
+async function refreshRail() {
+  try {
+    const [ov, sbs] = await Promise.all([
+      jget("/ui/api/overview"),
+      jget("/ui/api/sandboxes"),
+    ]);
+    $("conn-warn").classList.remove("show");
+    $("gw-version").textContent = "v" + ov.version;
+    $("gw-count").textContent = ov.ready_count + "/" + ov.sandbox_count + " ready";
+    state.sandboxes = sbs;
+    renderRail();
+    if (state.selected) {
+      const cur = sbs.find((s) => s.name === state.selected);
+      if (cur) renderHead(cur);
+    }
+  } catch {
+    $("conn-warn").classList.add("show");
+  }
+}
+
+function renderRail() {
+  const el = $("sb-list");
+  if (!state.sandboxes.length) {
+    el.innerHTML = '<div class="rail-empty">No sandboxes yet.<br>Create one with <code>openshell sandbox create</code>.</div>';
+    return;
+  }
+  el.innerHTML = "";
+  for (const sb of state.sandboxes) {
+    const b = document.createElement("button");
+    b.className = "sb-item" + (sb.name === state.selected ? " sel" : "");
+    b.setAttribute("role", "option");
+    b.onclick = () => selectSandbox(sb.name);
+    const age = fmtAge(Date.now() - sb.created_at_ms);
+    b.innerHTML = '<div>' + esc(sb.name) + '</div>' +
+      '<div class="meta"><span class="led ' + esc(sb.phase) + '"></span>' +
+      '<small>' + esc(sb.phase) + ' · ' + age + '</small></div>';
+    el.appendChild(b);
+  }
+}
+
+async function selectSandbox(name) {
+  state.selected = name;
+  renderRail();
+  $("placeholder").style.display = "none";
+  const d = $("detail");
+  d.style.display = "flex";
+  $("board").innerHTML = '<div class="board-empty">No network activity observed yet.</div>';
+  state.stripCount = 0;
+  $("board-count").textContent = "";
+  $("tail").innerHTML = "";
+
+  try {
+    const detail = await jget("/ui/api/sandboxes/" + encodeURIComponent(name));
+    state.selectedId = detail.sandbox.id;
+    renderHead(detail.sandbox);
+    renderPolicy(detail);
+    const logs = await jget("/ui/api/sandboxes/" + encodeURIComponent(name) + "/logs?lines=200");
+    for (const line of logs) ingest(line, false);
+    scrollTail(true);
+    openStream(name);
+  } catch (e) {
+    $("tail").innerHTML = '<div class="ln lv-ERROR">Failed to load sandbox: ' + esc(String(e.message || e)) + '</div>';
+  }
+}
+
+function openStream(name) {
+  if (state.es) { state.es.close(); state.es = null; }
+  const es = new EventSource("/ui/api/sandboxes/" + encodeURIComponent(name) + "/stream");
+  es.onmessage = (ev) => {
+    try { ingest(JSON.parse(ev.data), true); } catch { /* skip */ }
+  };
+  state.es = es;
+}
+
+// ---------------- rendering ----------------
+
+function renderHead(sb) {
+  $("d-name").textContent = sb.name;
+  const ph = $("d-phase");
+  ph.textContent = sb.phase;
+  ph.className = "chip phase-" + sb.phase;
+  $("d-policy").textContent = "policy v" + sb.active_policy_version;
+  $("d-image").textContent = shortImage(sb.image);
+}
+
+function renderPolicy(detail) {
+  $("yaml").innerHTML = hlYaml(detail.policy_yaml || "# no policy payload");
+  const tb = $("rev-body");
+  tb.innerHTML = "";
+  const active = detail.sandbox.active_policy_version;
+  for (const r of detail.revisions) {
+    const tr = document.createElement("tr");
+    if (r.version === active) tr.className = "active-rev";
+    const loaded = r.loaded_at_ms ? fmtTime(r.loaded_at_ms) : "—";
+    const err = r.load_error ? '<div class="err-detail">' + esc(r.load_error) + "</div>" : "";
+    tr.innerHTML = "<td>" + r.version + "</td>" +
+      '<td class="st-' + esc(r.status) + '">' + esc(r.status) + err + "</td>" +
+      "<td>" + esc(r.hash.slice(0, 8)) + "</td>" +
+      "<td>" + loaded + "</td>";
+    tb.appendChild(tr);
+  }
+}
+
+// OCSF shorthand examples:
+//   "ALLOWED /usr/bin/curl(85) -> pypi.org:443 [policy:allow_pypi engine:opa]"
+//   "CONNECT denied example.com:443"  /  "NET:FAIL ..." arrives as message text
+const DECISION_RE = /(ALLOWED|DENIED)\s+(\S+?)\((\d+)\)\s+->\s+(\S+)(?:\s+\[policy:([^\s\]]+))?/;
+
+function ingest(line, live) {
+  // 1) decision board strips
+  const m = DECISION_RE.exec(line.message);
+  const isFail = line.message.includes("NET:FAIL") || (line.fields && line.fields.activity === "Fail");
+  if (m) {
+    addStrip({
+      verdict: m[1] === "ALLOWED" ? "allow" : "deny",
+      label: m[1],
+      bin: m[2],
+      dst: m[4],
+      pol: m[5] || "",
+      ts: line.timestamp_ms,
+    }, live);
+  } else if (isFail) {
+    const dst = (line.message.match(/(\S+:\d+)/) || [])[1] || "";
+    addStrip({ verdict: "fail", label: "FAIL", bin: "", dst, pol: "", ts: line.timestamp_ms }, live);
+  }
+
+  // 2) log tail
+  if (state.srcFilter !== "all" && (line.source || "gateway") !== state.srcFilter) return;
+  appendTailLine(line);
+  if (live) scrollTail();
+}
+
+function addStrip(s, live) {
+  const board = $("board");
+  const empty = board.querySelector(".board-empty");
+  if (empty) empty.remove();
+  const div = document.createElement("div");
+  div.className = "strip " + s.verdict + (live ? " fresh" : "");
+  div.innerHTML =
+    '<span class="t">' + fmtTime(s.ts) + "</span>" +
+    '<span class="verdict">' + esc(s.label) + "</span>" +
+    '<span class="bin">' + esc(s.bin) + "</span>" +
+    (s.bin ? '<span class="arrow">→</span>' : "") +
+    '<span class="dst">' + esc(s.dst) + "</span>" +
+    '<span class="pol">' + esc(s.pol) + "</span>";
+  board.prepend(div);
+  state.stripCount++;
+  $("board-count").textContent = state.stripCount + " events";
+  while (board.children.length > 200) board.lastChild.remove();
+  if (live) pulse(s.verdict !== "allow");
+}
+
+function appendTailLine(line) {
+  const tail = $("tail");
+  const div = document.createElement("div");
+  div.className = "ln";
+  const lv = (line.level || "").toUpperCase();
+  div.innerHTML =
+    '<span class="ts">' + fmtTime(line.timestamp_ms) + "</span> " +
+    '<span class="src">[' + esc(line.source || "gateway") + "]</span> " +
+    '<span class="lv-' + esc(lv) + '">' + esc(lv.padEnd(5)) + "</span> " +
+    esc(line.message);
+  tail.appendChild(div);
+  while (tail.children.length > 1000) tail.firstChild.remove();
+}
+
+function pulse(deny) {
+  const track = $("pulse");
+  const tick = document.createElement("div");
+  tick.className = "tick" + (deny ? " deny" : "");
+  track.appendChild(tick);
+  setTimeout(() => tick.remove(), 1000);
+}
+
+function scrollTail(force) {
+  if (!state.follow && !force) return;
+  const t = $("tail");
+  t.scrollTop = t.scrollHeight;
+}
+
+function toggleFollow() {
+  state.follow = !state.follow;
+  const chip = $("follow-chip");
+  chip.textContent = state.follow ? "following" : "paused";
+  chip.classList.toggle("on", state.follow);
+  if (state.follow) scrollTail(true);
+}
+
+function selectTab(which) {
+  for (const t of ["live", "policy"]) {
+    $("tab-" + t).classList.toggle("sel", t === which);
+    $("pane-" + t).classList.toggle("sel", t === which);
+  }
+}
+
+// ---------------- helpers ----------------
+
+function esc(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+  }[c]));
+}
+function fmtTime(ms) {
+  if (!ms) return "—";
+  return new Date(ms).toTimeString().slice(0, 8);
+}
+function fmtAge(ms) {
+  const m = Math.floor(ms / 60000);
+  if (m < 1) return "just now";
+  if (m < 60) return m + "m";
+  const h = Math.floor(m / 60);
+  if (h < 24) return h + "h";
+  return Math.floor(h / 24) + "d";
+}
+function shortImage(img) {
+  if (!img) return "no image";
+  const parts = img.split("/");
+  return parts[parts.length - 1];
+}
+function hlYaml(y) {
+  return esc(y).replace(/^(\s*)([\w.-]+)(:)/gm, '$1<span class="k">$2</span>$3');
+}
+
+// ---------------- keyboard ----------------
+
+document.addEventListener("keydown", (e) => {
+  if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") return;
+  if (e.key === "1") selectTab("live");
+  if (e.key === "2") selectTab("policy");
+  if (e.key === "j" || e.key === "k") {
+    if (!state.sandboxes.length) return;
+    let idx = state.sandboxes.findIndex((s) => s.name === state.selected);
+    idx = e.key === "j" ? Math.min(idx + 1, state.sandboxes.length - 1) : Math.max(idx - 1, 0);
+    selectSandbox(state.sandboxes[idx].name);
+  }
+});
+
+// source filter chips
+for (const chip of document.querySelectorAll(".fchip[data-src]")) {
+  chip.onclick = () => {
+    state.srcFilter = chip.dataset.src;
+    for (const c of document.querySelectorAll(".fchip[data-src]")) {
+      c.classList.toggle("on", c === chip);
+    }
+    if (state.selected) selectSandbox(state.selected);
+  };
+}
+
+// pause follow when the user scrolls up
+$("tail").addEventListener("scroll", () => {
+  const t = $("tail");
+  const atBottom = t.scrollHeight - t.scrollTop - t.clientHeight < 30;
+  if (!atBottom && state.follow) toggleFollow();
+  else if (atBottom && !state.follow) toggleFollow();
+});
+
+// ---------------- boot ----------------
+refreshRail();
+setInterval(refreshRail, 3000);
+</script>
+</body>
+</html>

--- a/crates/openshell-server/src/grpc/mod.rs
+++ b/crates/openshell-server/src/grpc/mod.rs
@@ -6,7 +6,7 @@
 mod auth_rpc;
 pub mod policy;
 pub mod provider;
-mod sandbox;
+pub mod sandbox;
 mod service;
 mod validation;
 

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -1912,7 +1912,7 @@ async fn handle_update_config_inner(
 // Policy status handlers
 // ---------------------------------------------------------------------------
 
-pub(super) async fn handle_get_sandbox_policy_status(
+pub async fn handle_get_sandbox_policy_status(
     state: &Arc<ServerState>,
     request: Request<GetSandboxPolicyStatusRequest>,
 ) -> Result<Response<GetSandboxPolicyStatusResponse>, Status> {
@@ -1963,7 +1963,7 @@ pub(super) async fn handle_get_sandbox_policy_status(
     }))
 }
 
-pub(super) async fn handle_list_sandbox_policies(
+pub async fn handle_list_sandbox_policies(
     state: &Arc<ServerState>,
     request: Request<ListSandboxPoliciesRequest>,
 ) -> Result<Response<ListSandboxPoliciesResponse>, Status> {
@@ -2084,7 +2084,7 @@ pub(super) async fn handle_report_policy_status(
 // ---------------------------------------------------------------------------
 
 #[allow(clippy::unused_async)] // Must be async to match the trait signature
-pub(super) async fn handle_get_sandbox_logs(
+pub async fn handle_get_sandbox_logs(
     state: &Arc<ServerState>,
     request: Request<GetSandboxLogsRequest>,
 ) -> Result<Response<GetSandboxLogsResponse>, Status> {

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -232,7 +232,7 @@ async fn handle_create_sandbox_inner(
     }))
 }
 
-pub(super) async fn handle_get_sandbox(
+pub async fn handle_get_sandbox(
     state: &Arc<ServerState>,
     request: Request<GetSandboxRequest>,
 ) -> Result<Response<SandboxResponse>, Status> {
@@ -253,7 +253,7 @@ pub(super) async fn handle_get_sandbox(
     }))
 }
 
-pub(super) async fn handle_list_sandboxes(
+pub async fn handle_list_sandboxes(
     state: &Arc<ServerState>,
     request: Request<ListSandboxesRequest>,
 ) -> Result<Response<ListSandboxesResponse>, Status> {

--- a/crates/openshell-server/src/http.rs
+++ b/crates/openshell-server/src/http.rs
@@ -181,6 +181,7 @@ async fn render_metrics(State(handle): State<PrometheusHandle>) -> impl IntoResp
 pub fn http_router(state: Arc<crate::ServerState>) -> Router {
     crate::ws_tunnel::router(state.clone())
         .merge(crate::auth::router(state.clone()))
+        .merge(crate::web_ui::router(state.clone()))
         .layer(middleware::from_fn_with_state(
             state,
             sandbox_service_routing_first,

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -49,6 +49,7 @@ mod tls;
 #[cfg(test)]
 pub(crate) mod tls_test_utils;
 pub mod tracing_bus;
+mod web_ui;
 mod ws_tunnel;
 
 use metrics_exporter_prometheus::PrometheusBuilder;

--- a/crates/openshell-server/src/web_ui.rs
+++ b/crates/openshell-server/src/web_ui.rs
@@ -1,0 +1,363 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Read-only web dashboard for developers and operators (demo scaffolding).
+//!
+//! Serves a single-file SPA at `/ui` plus a small JSON/SSE API under
+//! `/ui/api/*` that adapts existing gRPC handler logic for browser
+//! consumption. The whole surface is disabled unless the
+//! `OPENSHELL_WEB_UI` environment variable is set to `1` or `true`,
+//! because these routes intentionally bypass gRPC bearer authentication
+//! and are only suitable for trusted local/dev gateways.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{Html, IntoResponse, Json};
+use axum::routing::get;
+use serde::{Deserialize, Serialize};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::Request;
+
+use openshell_core::proto::{
+    GetSandboxLogsRequest, GetSandboxPolicyStatusRequest, GetSandboxRequest,
+    ListSandboxPoliciesRequest, ListSandboxesRequest, Sandbox, SandboxLogLine, SandboxPhase,
+    sandbox_stream_event,
+};
+
+use crate::ServerState;
+use crate::grpc::{policy, sandbox};
+
+/// Returns true when the web UI surface is enabled for this process.
+pub fn enabled() -> bool {
+    matches!(
+        std::env::var("OPENSHELL_WEB_UI").as_deref(),
+        Ok("1" | "true")
+    )
+}
+
+/// Build the `/ui` router. Returns an empty router when disabled.
+pub fn router(state: Arc<ServerState>) -> Router {
+    if !enabled() {
+        return Router::new();
+    }
+    Router::new()
+        .route("/ui", get(index))
+        .route("/ui/", get(index))
+        .route("/ui/api/overview", get(overview))
+        .route("/ui/api/sandboxes", get(list_sandboxes))
+        .route("/ui/api/sandboxes/{name}", get(sandbox_detail))
+        .route("/ui/api/sandboxes/{name}/logs", get(sandbox_logs))
+        .route("/ui/api/sandboxes/{name}/stream", get(sandbox_stream))
+        .with_state(state)
+}
+
+async fn index() -> impl IntoResponse {
+    Html(include_str!("../assets/ui.html"))
+}
+
+// ---------------------------------------------------------------------------
+// JSON shapes (stable UI contract, decoupled from proto)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct OverviewJson {
+    version: String,
+    sandbox_count: usize,
+    ready_count: usize,
+}
+
+#[derive(Serialize)]
+struct SandboxJson {
+    id: String,
+    name: String,
+    phase: String,
+    created_at_ms: i64,
+    image: String,
+    providers: Vec<String>,
+    active_policy_version: u32,
+    conditions: Vec<ConditionJson>,
+}
+
+#[derive(Serialize)]
+struct ConditionJson {
+    r#type: String,
+    status: String,
+    reason: String,
+    message: String,
+}
+
+#[derive(Serialize)]
+struct PolicyRevisionJson {
+    version: u32,
+    hash: String,
+    status: String,
+    load_error: String,
+    created_at_ms: i64,
+    loaded_at_ms: i64,
+}
+
+#[derive(Serialize)]
+struct SandboxDetailJson {
+    sandbox: SandboxJson,
+    revisions: Vec<PolicyRevisionJson>,
+    policy_yaml: String,
+}
+
+#[derive(Serialize)]
+struct LogLineJson {
+    timestamp_ms: i64,
+    level: String,
+    target: String,
+    message: String,
+    source: String,
+    fields: std::collections::HashMap<String, String>,
+}
+
+fn phase_name(phase: i32) -> String {
+    match SandboxPhase::try_from(phase) {
+        Ok(SandboxPhase::Provisioning) => "Provisioning",
+        Ok(SandboxPhase::Ready) => "Ready",
+        Ok(SandboxPhase::Error) => "Error",
+        Ok(SandboxPhase::Deleting) => "Deleting",
+        _ => "Unknown",
+    }
+    .to_string()
+}
+
+fn sandbox_json(sb: &Sandbox) -> SandboxJson {
+    let meta = sb.metadata.clone().unwrap_or_default();
+    let spec = sb.spec.clone().unwrap_or_default();
+    let status = sb.status.clone().unwrap_or_default();
+    let image = spec
+        .template
+        .as_ref()
+        .map(|t| t.image.clone())
+        .unwrap_or_default();
+    SandboxJson {
+        id: meta.id,
+        name: meta.name,
+        phase: phase_name(status.phase),
+        created_at_ms: meta.created_at_ms,
+        image,
+        providers: spec.providers,
+        active_policy_version: status.current_policy_version,
+        conditions: status
+            .conditions
+            .iter()
+            .map(|c| ConditionJson {
+                r#type: c.r#type.clone(),
+                status: c.status.clone(),
+                reason: c.reason.clone(),
+                message: c.message.clone(),
+            })
+            .collect(),
+    }
+}
+
+fn log_line_json(line: &SandboxLogLine) -> LogLineJson {
+    LogLineJson {
+        timestamp_ms: line.timestamp_ms,
+        level: line.level.clone(),
+        target: line.target.clone(),
+        message: line.message.clone(),
+        source: line.source.clone(),
+        fields: line.fields.clone(),
+    }
+}
+
+fn status_error(status: tonic::Status) -> (StatusCode, String) {
+    let code = match status.code() {
+        tonic::Code::NotFound => StatusCode::NOT_FOUND,
+        tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    (code, status.message().to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn overview(
+    State(state): State<Arc<ServerState>>,
+) -> Result<Json<OverviewJson>, (StatusCode, String)> {
+    let resp = sandbox::handle_list_sandboxes(
+        &state,
+        Request::new(ListSandboxesRequest {
+            limit: 500,
+            ..Default::default()
+        }),
+    )
+    .await
+    .map_err(status_error)?
+    .into_inner();
+
+    let ready_count = resp
+        .sandboxes
+        .iter()
+        .filter(|sb| sb.status.as_ref().map(|s| s.phase) == Some(SandboxPhase::Ready as i32))
+        .count();
+
+    Ok(Json(OverviewJson {
+        version: openshell_core::VERSION.to_string(),
+        sandbox_count: resp.sandboxes.len(),
+        ready_count,
+    }))
+}
+
+async fn list_sandboxes(
+    State(state): State<Arc<ServerState>>,
+) -> Result<Json<Vec<SandboxJson>>, (StatusCode, String)> {
+    let resp = sandbox::handle_list_sandboxes(
+        &state,
+        Request::new(ListSandboxesRequest {
+            limit: 500,
+            ..Default::default()
+        }),
+    )
+    .await
+    .map_err(status_error)?
+    .into_inner();
+    Ok(Json(resp.sandboxes.iter().map(sandbox_json).collect()))
+}
+
+async fn sandbox_detail(
+    State(state): State<Arc<ServerState>>,
+    Path(name): Path<String>,
+) -> Result<Json<SandboxDetailJson>, (StatusCode, String)> {
+    let sb = sandbox::handle_get_sandbox(
+        &state,
+        Request::new(GetSandboxRequest { name: name.clone() }),
+    )
+    .await
+    .map_err(status_error)?
+    .into_inner()
+    .sandbox
+    .ok_or_else(|| (StatusCode::NOT_FOUND, "sandbox not found".to_string()))?;
+
+    let revisions = policy::handle_list_sandbox_policies(
+        &state,
+        Request::new(ListSandboxPoliciesRequest {
+            name: name.clone(),
+            limit: 50,
+            ..Default::default()
+        }),
+    )
+    .await
+    .map_err(status_error)?
+    .into_inner()
+    .revisions
+    .iter()
+    .map(|r| PolicyRevisionJson {
+        version: r.version,
+        hash: r.policy_hash.clone(),
+        status: format!("{:?}", r.status()),
+        load_error: r.load_error.clone(),
+        created_at_ms: r.created_at_ms,
+        loaded_at_ms: r.loaded_at_ms,
+    })
+    .collect();
+
+    // Latest revision with full policy payload for the YAML pane.
+    let policy_yaml = policy::handle_get_sandbox_policy_status(
+        &state,
+        Request::new(GetSandboxPolicyStatusRequest {
+            name: name.clone(),
+            ..Default::default()
+        }),
+    )
+    .await
+    .ok()
+    .and_then(|resp| resp.into_inner().revision)
+    .and_then(|rev| rev.policy)
+    .and_then(|p| openshell_policy::serialize_sandbox_policy(&p).ok())
+    .unwrap_or_default();
+
+    Ok(Json(SandboxDetailJson {
+        sandbox: sandbox_json(&sb),
+        revisions,
+        policy_yaml,
+    }))
+}
+
+#[derive(Deserialize)]
+struct LogsQuery {
+    #[serde(default)]
+    lines: u32,
+}
+
+async fn sandbox_logs(
+    State(state): State<Arc<ServerState>>,
+    Path(name): Path<String>,
+    Query(q): Query<LogsQuery>,
+) -> Result<Json<Vec<LogLineJson>>, (StatusCode, String)> {
+    let id = resolve_sandbox_id(&state, &name).await?;
+    let resp = policy::handle_get_sandbox_logs(
+        &state,
+        Request::new(GetSandboxLogsRequest {
+            sandbox_id: id,
+            lines: if q.lines == 0 { 300 } else { q.lines },
+            ..Default::default()
+        }),
+    )
+    .await
+    .map_err(status_error)?
+    .into_inner();
+    Ok(Json(resp.logs.iter().map(log_line_json).collect()))
+}
+
+/// Live event stream: forwards the sandbox's tracing bus to the browser as
+/// SSE messages, one JSON-encoded log line per event.
+async fn sandbox_stream(
+    State(state): State<Arc<ServerState>>,
+    Path(name): Path<String>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let id = resolve_sandbox_id(&state, &name).await?;
+    let mut rx = state.tracing_log_bus.subscribe(&id);
+    let (tx, out_rx) = tokio::sync::mpsc::channel::<Result<Event, Infallible>>(256);
+
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    let Some(sandbox_stream_event::Payload::Log(line)) = event.payload else {
+                        continue;
+                    };
+                    let Ok(json) = serde_json::to_string(&log_line_json(&line)) else {
+                        continue;
+                    };
+                    if tx.send(Ok(Event::default().data(json))).await.is_err() {
+                        break; // client went away
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+
+    Ok(Sse::new(ReceiverStream::new(out_rx)).keep_alive(KeepAlive::default()))
+}
+
+async fn resolve_sandbox_id(
+    state: &Arc<ServerState>,
+    name: &str,
+) -> Result<String, (StatusCode, String)> {
+    let sb = sandbox::handle_get_sandbox(
+        state,
+        Request::new(GetSandboxRequest {
+            name: name.to_string(),
+        }),
+    )
+    .await
+    .map_err(status_error)?
+    .into_inner()
+    .sandbox
+    .ok_or_else(|| (StatusCode::NOT_FOUND, "sandbox not found".to_string()))?;
+    Ok(sb.metadata.unwrap_or_default().id)
+}


### PR DESCRIPTION
## Summary

Adds a read-only web dashboard embedded in the gateway (`/ui`) for developers and DevOps engineers: fleet view, sandbox detail with policy revision history, and a live SSE event stream that surfaces network policy decisions (allow/deny with the full reason) in real time. The entire surface is disabled unless `OPENSHELL_WEB_UI=1` is set, keeping it dev/local-only until proper authn/z is added.

## Related Issue

Closes #2192

## Changes

- New `web_ui` module in `openshell-server`: serves an embedded single-file SPA at `/ui` and a small JSON adapter API under `/ui/api/*` (overview, sandbox list, sandbox detail incl. policy YAML + revisions, log tail, SSE live stream bridged from `TracingLogBus`)
- Reuses existing gRPC handler logic in-process — widened `handle_get_sandbox`, `handle_list_sandboxes`, `handle_get_sandbox_policy_status`, `handle_list_sandbox_policies`, `handle_get_sandbox_logs` (and the `grpc::sandbox` module) to `pub`; no data-access duplication, no new workspace dependencies
- Frontend is a dependency-free embedded HTML file: sandbox rail with phase indicators and j/k keyboard navigation, a live "decision board" rendering OCSF allow/deny events as strips, a filterable auto-following log tail, and a policy pane (YAML + revision status)
- Gate check in `web_ui::router()`: returns an empty router unless `OPENSHELL_WEB_UI=1|true`

## Testing

- [x] `mise run pre-commit` passes (fmt, clippy `-D warnings`, license headers)
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- Manually verified against a live Docker-driver gateway running a real policy-constrained agent workload: all five endpoints serve live data; a policy denial triggered inside the sandbox appeared on the decision board in real time with the full denial reason; SPA JS validated with `node --check`; UI disabled by default (routes absent without the env var)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)