### PR TITLE
fix(e2e): detect gateway workload for Kubernetes health port-forward

### DIFF
--- a/e2e/with-kube-gateway.sh
+++ b/e2e/with-kube-gateway.sh
@@ -115,6 +115,19 @@ helmctl() {
   helm --kube-context "${KUBE_CONTEXT}" "$@"
 }
 
+# Return the kubectl resource reference (e.g. "sts/openshell" or "deploy/openshell")
+# for the deployed gateway workload. The chart deploys a StatefulSet by default
+# and a Deployment when workload.kind=deployment (external DB / HA mode).
+kube_workload_ref() {
+  local name="$1"
+  local ns="${2:-${NAMESPACE}}"
+  if kctl -n "${ns}" get statefulset "${name}" >/dev/null 2>&1; then
+    echo "sts/${name}"
+  else
+    echo "deploy/${name}"
+  fi
+}
+
 deploy_postgres_fixture() {
   local secret_name="$1"
   local pg_uri
@@ -320,8 +333,10 @@ run_scenario() {
   fi
 
   HEALTH_LOCAL_PORT="$(e2e_pick_port)"
-  echo "Starting kubectl port-forward sts/${RELEASE_NAME} ${HEALTH_LOCAL_PORT}:health..."
-  kctl -n "${NAMESPACE}" port-forward "sts/${RELEASE_NAME}" \
+  local workload_ref
+  workload_ref="$(kube_workload_ref "${RELEASE_NAME}")"
+  echo "Starting kubectl port-forward ${workload_ref} ${HEALTH_LOCAL_PORT}:health..."
+  kctl -n "${NAMESPACE}" port-forward "${workload_ref}" \
     "${HEALTH_LOCAL_PORT}:health" >"${PORTFORWARD_HEALTH_LOG}" 2>&1 &
   PORTFORWARD_HEALTH_PID=$!
 
@@ -652,8 +667,9 @@ else
   fi
 
   HEALTH_LOCAL_PORT="$(e2e_pick_port)"
-  echo "Starting kubectl port-forward sts/${RELEASE_NAME} ${HEALTH_LOCAL_PORT}:health..."
-  kctl -n "${NAMESPACE}" port-forward "sts/${RELEASE_NAME}" \
+  WORKLOAD_REF="$(kube_workload_ref "${RELEASE_NAME}")"
+  echo "Starting kubectl port-forward ${WORKLOAD_REF} ${HEALTH_LOCAL_PORT}:health..."
+  kctl -n "${NAMESPACE}" port-forward "${WORKLOAD_REF}" \
     "${HEALTH_LOCAL_PORT}:health" >"${PORTFORWARD_HEALTH_LOG}" 2>&1 &
   PORTFORWARD_HEALTH_PID=$!
 


### PR DESCRIPTION
## Summary

The Kubernetes HA E2E deploys the gateway as a Deployment, but the test harness hardcoded the health port-forward to a StatefulSet. That caused the HA job to fail before the test suite could exercise the deployment.

This PR makes the minimal harness change required to select the deployed workload kind. The existing test:e2e-kubernetes label triggers the optional HA proof-of-life workflow.

HA gateway behavior is not expected to pass on current main. Full HA gateway rebalancing, peer routing, and supervisor relay handoff are being implemented in #1868. Until that PR merges, the HA suite is expected to expose those outstanding failures after this port-forward prerequisite succeeds.

## Related Issue

Related to #2153, where the health port-forward failure was observed.

HA implementation: #1868.

## Changes

- Add a small kube_workload_ref helper that selects sts/<name> or deploy/<name> from the cluster.
- Use that reference for the health port-forward in both Kubernetes E2E execution paths.

## Testing

- [x] bash -n e2e/with-kube-gateway.sh
- [x] The HA workflow selects deploy/openshell and reaches the Rust E2E suite.
- [ ] Kubernetes HA E2E passes. Failure is expected on current main until #1868 lands; this PR intentionally exposes that known gap and does not attempt to implement HA support.

Proof-of-life run for this minimal commit: https://github.com/NVIDIA/OpenShell/actions/runs/29091285118/job/86358988762

## Checklist

- [x] Follows Conventional Commits
- [x] Commit is signed off (DCO)
- [x] Change is limited to the HA health port-forward prerequisite