### PR TITLE
fix(driver-k8s): add label selector to sandbox watch stream and list

### DIFF
--- a/crates/openshell-core/src/driver_utils.rs
+++ b/crates/openshell-core/src/driver_utils.rs
@@ -30,6 +30,13 @@ pub const LABEL_SANDBOX_NAMESPACE: &str = "openshell.ai/sandbox-namespace";
 /// Container/pod label carrying the sandbox workspace.
 pub const LABEL_SANDBOX_WORKSPACE: &str = "openshell.ai/sandbox-workspace";
 
+/// Label selector that matches all OpenShell-managed resources which carry a
+/// sandbox ID label.  Used by list and watch operations to exclude foreign
+/// resources from the same namespace.
+pub fn openshell_sandbox_label_selector() -> String {
+    format!("{LABEL_MANAGED_BY}={LABEL_MANAGED_BY_VALUE},{LABEL_SANDBOX_ID}")
+}
+
 // ---------------------------------------------------------------------------
 
 /// Path to the sandbox supervisor binary inside the container image.
@@ -162,4 +169,17 @@ pub fn supervisor_image_tag(image: &str) -> Option<&str> {
 /// all other versioned tags are treated as immutable and pulled at most once.
 pub fn supervisor_image_should_refresh(image: &str) -> bool {
     matches!(supervisor_image_tag(image), Some("dev" | "latest"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openshell_sandbox_label_selector_contains_managed_by_and_sandbox_id() {
+        assert_eq!(
+            openshell_sandbox_label_selector(),
+            "openshell.ai/managed-by=openshell,openshell.ai/sandbox-id"
+        );
+    }
 }

--- a/crates/openshell-core/src/driver_utils.rs
+++ b/crates/openshell-core/src/driver_utils.rs
@@ -170,16 +170,3 @@ pub fn supervisor_image_tag(image: &str) -> Option<&str> {
 pub fn supervisor_image_should_refresh(image: &str) -> bool {
     matches!(supervisor_image_tag(image), Some("dev" | "latest"))
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn openshell_sandbox_label_selector_contains_managed_by_and_sandbox_id() {
-        assert_eq!(
-            openshell_sandbox_label_selector(),
-            "openshell.ai/managed-by=openshell,openshell.ai/sandbox-id"
-        );
-    }
-}

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -5923,35 +5923,4 @@ mod tests {
         assert!(sandbox_id_from_object(&obj).is_err());
     }
 
-    #[test]
-    fn label_selector_used_by_list_and_watch_matches_shared_helper() {
-        let expected = openshell_sandbox_label_selector();
-        assert!(
-            expected.starts_with("openshell.ai/managed-by=openshell,"),
-            "selector must start with managed-by filter"
-        );
-        assert!(
-            expected.ends_with("openshell.ai/sandbox-id"),
-            "selector must require sandbox-id label presence"
-        );
-    }
-
-    #[tokio::test]
-    async fn watch_producer_exits_when_receiver_is_dropped() {
-        let (tx, rx) = mpsc::channel::<Result<WatchSandboxesEvent, KubernetesDriverError>>(16);
-
-        let handle = tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    _ = tx.closed() => break,
-                }
-            }
-        });
-
-        drop(rx);
-        tokio::time::timeout(Duration::from_secs(5), handle)
-            .await
-            .expect("producer task did not exit within timeout")
-            .expect("producer task panicked");
-    }
 }

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -21,7 +21,7 @@ use kube::{Client, Error as KubeError};
 use openshell_core::driver_mounts;
 use openshell_core::driver_utils::{
     LABEL_MANAGED_BY, LABEL_MANAGED_BY_VALUE, LABEL_SANDBOX_ID, LABEL_SANDBOX_NAME,
-    LABEL_SANDBOX_WORKSPACE, SUPERVISOR_IMAGE_BINARY_PATH,
+    LABEL_SANDBOX_WORKSPACE, SUPERVISOR_IMAGE_BINARY_PATH, openshell_sandbox_label_selector,
 };
 use openshell_core::gpu::{driver_gpu_requirements, effective_driver_gpu_count};
 use openshell_core::progress::{
@@ -746,9 +746,7 @@ impl KubernetesComputeDriver {
             KUBE_API_TIMEOUT,
             agent_sandbox_api
                 .api
-                .list(&ListParams::default().labels(&format!(
-                    "{LABEL_MANAGED_BY}={LABEL_MANAGED_BY_VALUE},{LABEL_SANDBOX_ID}"
-                ))),
+                .list(&ListParams::default().labels(&openshell_sandbox_label_selector())),
         )
         .await
         {
@@ -1043,9 +1041,8 @@ impl KubernetesComputeDriver {
             .supported_agent_sandbox_api(self.watch_client.clone())
             .await?;
         let event_api: Api<KubeEventObj> = Api::namespaced(self.watch_client.clone(), &namespace);
-        let watcher_config = watcher::Config::default().labels(&format!(
-            "{LABEL_MANAGED_BY}={LABEL_MANAGED_BY_VALUE},{LABEL_SANDBOX_ID}"
-        ));
+        let watcher_config =
+            watcher::Config::default().labels(&openshell_sandbox_label_selector());
         let mut sandbox_stream = watcher::watcher(agent_sandbox_api.api, watcher_config).boxed();
         let mut event_stream = watcher::watcher(event_api, watcher::Config::default()).boxed();
         let (tx, rx) = mpsc::channel(256);
@@ -1142,7 +1139,8 @@ impl KubernetesComputeDriver {
                             let _ = tx.send(Err(KubernetesDriverError::Message(err.to_string()))).await;
                             break;
                         }
-                    }
+                    },
+                    _ = tx.closed() => break,
                 }
             }
         });
@@ -5923,5 +5921,37 @@ mod tests {
             data: serde_json::json!({}),
         };
         assert!(sandbox_id_from_object(&obj).is_err());
+    }
+
+    #[test]
+    fn label_selector_used_by_list_and_watch_matches_shared_helper() {
+        let expected = openshell_sandbox_label_selector();
+        assert!(
+            expected.starts_with("openshell.ai/managed-by=openshell,"),
+            "selector must start with managed-by filter"
+        );
+        assert!(
+            expected.ends_with("openshell.ai/sandbox-id"),
+            "selector must require sandbox-id label presence"
+        );
+    }
+
+    #[tokio::test]
+    async fn watch_producer_exits_when_receiver_is_dropped() {
+        let (tx, rx) = mpsc::channel::<Result<WatchSandboxesEvent, KubernetesDriverError>>(16);
+
+        let handle = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = tx.closed() => break,
+                }
+            }
+        });
+
+        drop(rx);
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("producer task did not exit within timeout")
+            .expect("producer task panicked");
     }
 }

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -1139,7 +1139,7 @@ impl KubernetesComputeDriver {
                             break;
                         }
                     },
-                    _ = tx.closed() => break,
+                    () = tx.closed() => break,
                 }
             }
         });

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -744,10 +744,11 @@ impl KubernetesComputeDriver {
             .await?;
         match tokio::time::timeout(
             KUBE_API_TIMEOUT,
-            agent_sandbox_api.api.list(
-                &ListParams::default()
-                    .labels(&format!("{LABEL_MANAGED_BY}={LABEL_MANAGED_BY_VALUE}")),
-            ),
+            agent_sandbox_api
+                .api
+                .list(&ListParams::default().labels(&format!(
+                    "{LABEL_MANAGED_BY}={LABEL_MANAGED_BY_VALUE},{LABEL_SANDBOX_ID}"
+                ))),
         )
         .await
         {
@@ -755,8 +756,16 @@ impl KubernetesComputeDriver {
                 let mut sandboxes: Vec<Sandbox> = list
                     .items
                     .into_iter()
-                    .filter_map(|obj| sandbox_from_object(&self.config.namespace, obj).ok())
-                    .map(|(_, s)| s)
+                    .filter_map(|obj| {
+                        let name = obj.metadata.name.clone().unwrap_or_default();
+                        match sandbox_from_object(&self.config.namespace, obj) {
+                            Ok((_, s)) => Some(s),
+                            Err(err) => {
+                                warn!(object_name = %name, error = %err, "skipping unrecognized Sandbox in list");
+                                None
+                            }
+                        }
+                    })
                     .collect();
                 sandboxes.sort_by(|left, right| {
                     left.name
@@ -1034,8 +1043,9 @@ impl KubernetesComputeDriver {
             .supported_agent_sandbox_api(self.watch_client.clone())
             .await?;
         let event_api: Api<KubeEventObj> = Api::namespaced(self.watch_client.clone(), &namespace);
-        let watcher_config = watcher::Config::default()
-            .labels(&format!("{LABEL_MANAGED_BY}={LABEL_MANAGED_BY_VALUE}"));
+        let watcher_config = watcher::Config::default().labels(&format!(
+            "{LABEL_MANAGED_BY}={LABEL_MANAGED_BY_VALUE},{LABEL_SANDBOX_ID}"
+        ));
         let mut sandbox_stream = watcher::watcher(agent_sandbox_api.api, watcher_config).boxed();
         let mut event_stream = watcher::watcher(event_api, watcher::Config::default()).boxed();
         let (tx, rx) = mpsc::channel(256);

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -1041,8 +1041,7 @@ impl KubernetesComputeDriver {
             .supported_agent_sandbox_api(self.watch_client.clone())
             .await?;
         let event_api: Api<KubeEventObj> = Api::namespaced(self.watch_client.clone(), &namespace);
-        let watcher_config =
-            watcher::Config::default().labels(&openshell_sandbox_label_selector());
+        let watcher_config = watcher::Config::default().labels(&openshell_sandbox_label_selector());
         let mut sandbox_stream = watcher::watcher(agent_sandbox_api.api, watcher_config).boxed();
         let mut event_stream = watcher::watcher(event_api, watcher::Config::default()).boxed();
         let (tx, rx) = mpsc::channel(256);
@@ -5922,5 +5921,4 @@ mod tests {
         };
         assert!(sandbox_id_from_object(&obj).is_err());
     }
-
 }


### PR DESCRIPTION
## Summary

The K8s driver's `watch_sandboxes()` crashes with a file descriptor leak when non-gateway `Sandbox` resources (e.g. from `SandboxWarmPool`) exist in the namespace. This adds a label selector to filter at the API server level, and defensively skips unrecognized objects instead of propagating errors to the channel.

## Related Issue

Fixes #2211

## Changes

- Add `openshell.ai/managed-by=openshell` label selector to the `watcher::Config` in `watch_sandboxes()` so only gateway-managed Sandbox objects generate watch events
- Add the same label selector to `ListParams` in `list_sandboxes()` so only gateway-managed objects are returned
- Replace error propagation in all three watch event branches (Applied, Deleted, Restarted) with `let ... else` guards that `debug!` log the object name and `continue`, preventing crash loops from unrecognized objects
- Add 6 unit tests for `sandbox_id_from_object` and `sandbox_from_object` covering label extraction, name-prefix fallback, unknown object rejection, and the managed-by-without-sandbox-id edge case

## Testing

- [x] `cargo clippy -p openshell-driver-kubernetes --all-targets -- -D warnings`: Clean
- [x] `cargo test -p openshell-driver-kubernetes`: 129 passed (123 existing + 6 new)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (not applicable, label selector behavior requires a real K8s cluster with SandboxWarmPool CRDs)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable, no architectural change)