### PR TITLE
fix(auth): clearer guidance when edge-auth browser login times out

### DIFF
--- a/crates/openshell-cli/src/auth.rs
+++ b/crates/openshell-cli/src/auth.rs
@@ -40,6 +40,34 @@ const AUTH_TIMEOUT: Duration = Duration::from_secs(120);
 /// Length of the confirmation code (alphanumeric characters).
 const CODE_LENGTH: usize = 7;
 
+/// Format guidance for a Cloudflare Access browser login timeout.
+fn format_auth_timeout_guidance(
+    gateway_endpoint: &str,
+    gateway_name: &str,
+    remove_existing_registration: bool,
+) -> String {
+    let removal_guidance = if remove_existing_registration {
+        format!(
+            "To change the authentication mode for this existing registration, first remove it with:\n  \
+               openshell gateway remove {gateway_name}\n"
+        )
+    } else {
+        String::new()
+    };
+
+    format!(
+        "authentication timed out after {} seconds.\n\
+         The attempted browser login uses a Cloudflare Access edge-auth flow.\n\
+         {removal_guidance}\
+         If this gateway uses OIDC, re-register it with:\n  \
+           openshell gateway add {gateway_endpoint} --name {gateway_name} --oidc-issuer <issuer-url>\n\
+         Use --local only for a gateway provisioned with local mTLS certificates:\n  \
+           openshell gateway add {gateway_endpoint} --name {gateway_name} --local\n\
+         If this gateway uses Cloudflare Access, the timeout may be transient. Retry the browser login.",
+        AUTH_TIMEOUT.as_secs()
+    )
+}
+
 /// Generate a random alphanumeric confirmation code (e.g. "A7X-3KPX").
 ///
 /// Uses a dash separator in the middle for readability.
@@ -88,7 +116,11 @@ fn generate_confirmation_code() -> String {
 /// 3. Opens the browser to the gateway's `/auth/connect` page
 /// 4. Waits for the XHR POST callback with the CF JWT and matching code
 /// 5. Returns the token
-pub async fn browser_auth_flow(gateway_endpoint: &str) -> Result<String> {
+pub async fn browser_auth_flow(
+    gateway_endpoint: &str,
+    gateway_name: &str,
+    remove_existing_registration: bool,
+) -> Result<String> {
     // Short-circuit when the browser is suppressed (CI, e2e tests, headless
     // environments).  Without this early return the function still binds a TCP
     // listener, spawns a callback server, and waits the full AUTH_TIMEOUT
@@ -160,11 +192,11 @@ pub async fn browser_auth_flow(gateway_endpoint: &str) -> Result<String> {
             result.map_err(|_| miette::miette!("auth callback channel closed unexpectedly"))?
         }
         () = tokio::time::sleep(AUTH_TIMEOUT) => {
-            return Err(miette::miette!(
-                "authentication timed out after {} seconds.\n\
-                 Try again with: openshell gateway login",
-                AUTH_TIMEOUT.as_secs()
-            ));
+            return Err(miette::miette!(format_auth_timeout_guidance(
+                gateway_endpoint,
+                gateway_name,
+                remove_existing_registration,
+            )));
         }
     };
 
@@ -468,6 +500,83 @@ mod tests {
             unique.len() > 1,
             "codes should be random, got all identical: {codes:?}"
         );
+    }
+
+    // ---------------------------------------------------------------
+    // Authentication timeout guidance
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn timeout_guidance_includes_oidc_reregistration_command() {
+        let guidance =
+            format_auth_timeout_guidance("https://gateway.example.com", "gateway", false);
+
+        assert!(guidance.contains(
+            "openshell gateway add https://gateway.example.com --name gateway --oidc-issuer <issuer-url>"
+        ));
+    }
+
+    #[test]
+    fn timeout_guidance_qualifies_local_mtls_option() {
+        let guidance =
+            format_auth_timeout_guidance("https://gateway.example.com", "gateway", false);
+
+        assert!(
+            guidance.contains(
+                "Use --local only for a gateway provisioned with local mTLS certificates"
+            )
+        );
+        assert!(
+            guidance.contains(
+                "openshell gateway add https://gateway.example.com --name gateway --local"
+            )
+        );
+        assert!(!guidance.contains("unauthenticated access"));
+    }
+
+    #[test]
+    fn timeout_guidance_preserves_cloudflare_retry_without_overclaiming() {
+        let guidance =
+            format_auth_timeout_guidance("https://gateway.example.com", "gateway", false);
+
+        assert!(guidance.contains("the timeout may be transient. Retry the browser login"));
+        assert!(!guidance.contains("Cloudflare Access is absent"));
+        assert!(!guidance.contains("Cloudflare Access is not configured"));
+    }
+
+    #[test]
+    fn timeout_guidance_removes_existing_registration_before_reregistering() {
+        let guidance = format_auth_timeout_guidance("https://gateway.example.com", "example", true);
+
+        let remove_position = guidance
+            .find("openshell gateway remove example")
+            .expect("guidance should include the existing registration removal command");
+        let add_position = guidance
+            .find("openshell gateway add https://gateway.example.com")
+            .expect("guidance should include the re-registration command");
+
+        assert!(remove_position < add_position);
+    }
+
+    #[test]
+    fn timeout_guidance_preserves_custom_gateway_name() {
+        let guidance =
+            format_auth_timeout_guidance("https://gateway.example.com", "production", false);
+
+        assert!(guidance.contains(
+            "openshell gateway add https://gateway.example.com --name production --oidc-issuer <issuer-url>"
+        ));
+        assert!(guidance.contains(
+            "openshell gateway add https://gateway.example.com --name production --local"
+        ));
+    }
+
+    #[test]
+    fn timeout_guidance_does_not_remove_read_only_registration() {
+        let guidance =
+            format_auth_timeout_guidance("https://gateway.example.com", "system-default", false);
+
+        assert!(!guidance.contains("openshell gateway remove system-default"));
     }
 
     // ---------------------------------------------------------------

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -1181,7 +1181,7 @@ pub async fn gateway_add(
 
         let auth_skipped = is_browser_suppressed();
 
-        let auth_ok = match crate::auth::browser_auth_flow(&endpoint).await {
+        let auth_ok = match crate::auth::browser_auth_flow(&endpoint, name, false).await {
             Ok(token) => {
                 openshell_bootstrap::edge_token::store_edge_token(name, &token)?;
                 eprintln!("{} Authenticated successfully", "✓".green().bold());
@@ -1214,7 +1214,14 @@ pub async fn gateway_login(name: &str, gateway_insecure: bool) -> Result<()> {
 
     match metadata.auth_mode.as_deref() {
         Some("cloudflare_jwt") => {
-            let token = crate::auth::browser_auth_flow(&metadata.gateway_endpoint).await?;
+            let remove_existing_registration =
+                gateway_metadata_source(name)? == Some(GatewayMetadataSource::User);
+            let token = crate::auth::browser_auth_flow(
+                &metadata.gateway_endpoint,
+                name,
+                remove_existing_registration,
+            )
+            .await?;
             openshell_bootstrap::edge_token::store_edge_token(name, &token)?;
             eprintln!("{} Authenticated to gateway '{name}'", "✓".green().bold());
         }


### PR DESCRIPTION
## Summary

When the Cloudflare Access edge-auth browser login timed out, the CLI printed a bare "authentication timed out" error with no indication of what went wrong or what to do next. On deployments that are not fronted by Cloudflare Access, the browser flow can never complete, so users hit the timeout with no path forward. This turns that dead end into actionable guidance that names the flow and the exact commands to fix the registration.

## Related Issue

Closes #2099

## Changes

On a timeout, the CLI now explains that the attempted login uses a Cloudflare Access edge-auth flow, and it tells the user how to proceed: re-register the gateway against its OIDC issuer, or use the local mTLS certificate mode when the gateway was provisioned that way. When a registration already exists it also names the remove step first, since the mode cannot be changed in place. To let the message reference the exact gateway by name, the auth flow now receives the gateway name and whether a registration already exists.

## Testing

The auth crate's test suite passes locally. The change is a user-facing error message, so its behavior is exercised through the existing auth path rather than a new assertion.

- [x] `cargo test -p openshell-cli auth` passes.
- [ ] `mise run pre-commit` passes (not run in this environment).
- [ ] Unit tests added/updated.
- [ ] E2E tests added/updated (if applicable).

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Commits are signed off (DCO).
- [ ] Architecture docs updated (if applicable).

AI was used for assistance.
