### PR TITLE
fix(ci): fix mirror SHA detection in e2e-label-help workflow

### DIFF
--- a/.github/workflows/e2e-label-help.yml
+++ b/.github/workflows/e2e-label-help.yml
@@ -59,7 +59,8 @@ jobs:
           esac
 
           mirror_ref="pull-request/$PR_NUMBER"
-          mirror_sha=$(gh api "repos/$GH_REPO/branches/$mirror_ref" --jq '.commit.sha' 2>/dev/null || echo "")
+          mirror_sha=$(gh api "repos/$GH_REPO/git/ref/heads/$mirror_ref" --jq '.object.sha' 2>/dev/null || true)
+          if [[ ! "$mirror_sha" =~ ^[0-9a-f]{40}$ ]]; then mirror_sha=""; fi
           short_pr=${PR_HEAD_SHA:0:7}
 
           if [ -z "$mirror_sha" ]; then


### PR DESCRIPTION
## Summary

- Fix the `e2e-label-help` workflow incorrectly displaying raw JSON (`{"messa`) instead of a SHA when the mirror branch doesn't exist or the API call fails.
- Switch from the `/branches/` API (which can't handle ref names with slashes like `pull-request/2223`) to `/git/ref/heads/` which handles them natively.
- Add a regex guard to validate that `mirror_sha` is a 40-char hex string, resetting to empty on any garbage output.

## Related Issue

Observed on [PR #2223 comment](https://github.com/NVIDIA/OpenShell/pull/2223#issuecomment-4955074040) where the hint comment displayed `` `{"messa` `` as the mirror SHA.

## Root Cause

When the GitHub branches API returns a 404, `gh api` writes the error JSON to **stdout** before exiting non-zero. The `2>/dev/null` only suppresses stderr, and the `|| echo ""` fallback never fires because stdout already captured the JSON. So `mirror_sha` gets the full error object, and `${mirror_sha:0:7}` truncates it to `{"messa`.

## Changes

- `.github/workflows/e2e-label-help.yml`: Switch API endpoint and add SHA validation

## Testing

- Verified locally that `gh api repos/NVIDIA/OpenShell/branches/pull-request/2223 --jq '.commit.sha' 2>/dev/null || echo ""` returns the raw error JSON (the bug).
- Verified that `gh api repos/NVIDIA/OpenShell/git/ref/heads/pull-request/2223 --jq '.object.sha' 2>/dev/null || true` with the regex guard correctly yields an empty string.

## Checklist

- [x] Commit message follows conventional commits
- [x] DCO sign-off included
- [x] No unrelated changes