### PR TITLE
fix(e2e): detect gateway workload for readyz port-forward

### DIFF
--- a/e2e/with-kube-gateway.sh
+++ b/e2e/with-kube-gateway.sh
@@ -115,6 +115,24 @@ helmctl() {
   helm --kube-context "${KUBE_CONTEXT}" "$@"
 }
 
+# Return the resource reference for the gateway workload installed by the chart.
+# SQLite releases use a StatefulSet; external-database releases may use a Deployment.
+kube_workload_ref() {
+  local name="$1"
+  local namespace="${2:-${NAMESPACE}}"
+  local resource
+
+  for resource in "statefulset/${name}" "deployment/${name}"; do
+    if kctl -n "${namespace}" get "${resource}" >/dev/null 2>&1; then
+      printf '%s\n' "${resource}"
+      return 0
+    fi
+  done
+
+  echo "ERROR: gateway workload ${name} was not found in namespace ${namespace}" >&2
+  return 1
+}
+
 deploy_postgres_fixture() {
   local secret_name="$1"
   local pg_uri
@@ -320,8 +338,10 @@ run_scenario() {
   fi
 
   HEALTH_LOCAL_PORT="$(e2e_pick_port)"
-  echo "Starting kubectl port-forward sts/${RELEASE_NAME} ${HEALTH_LOCAL_PORT}:health..."
-  kctl -n "${NAMESPACE}" port-forward "sts/${RELEASE_NAME}" \
+  local workload_ref
+  workload_ref="$(kube_workload_ref "${RELEASE_NAME}")"
+  echo "Starting kubectl port-forward ${workload_ref} ${HEALTH_LOCAL_PORT}:health..."
+  kctl -n "${NAMESPACE}" port-forward "${workload_ref}" \
     "${HEALTH_LOCAL_PORT}:health" >"${PORTFORWARD_HEALTH_LOG}" 2>&1 &
   PORTFORWARD_HEALTH_PID=$!
 
@@ -669,8 +689,9 @@ else
   fi
 
   HEALTH_LOCAL_PORT="$(e2e_pick_port)"
-  echo "Starting kubectl port-forward sts/${RELEASE_NAME} ${HEALTH_LOCAL_PORT}:health..."
-  kctl -n "${NAMESPACE}" port-forward "sts/${RELEASE_NAME}" \
+  WORKLOAD_REF="$(kube_workload_ref "${RELEASE_NAME}")"
+  echo "Starting kubectl port-forward ${WORKLOAD_REF} ${HEALTH_LOCAL_PORT}:health..."
+  kctl -n "${NAMESPACE}" port-forward "${WORKLOAD_REF}" \
     "${HEALTH_LOCAL_PORT}:health" >"${PORTFORWARD_HEALTH_LOG}" 2>&1 &
   PORTFORWARD_HEALTH_PID=$!
 


### PR DESCRIPTION
## Summary

Make the Kubernetes E2E readyz health port-forward work with both StatefulSet-backed and Deployment-backed gateway releases. This preserves the existing readyz coverage while extracting the generally applicable workload discovery from the HA work in #1868.

## Related Issue

Related to #1868. Replaces the minimal proof-of-life approach from closed PR #2198 as a standalone current-`main` change.

## Changes

- Discover the installed gateway workload as either `statefulset/<release>` or `deployment/<release>` at runtime.
- Fail explicitly when neither supported workload exists.
- Use the discovered workload for the named `health` port-forward in both database-scenario and single-install E2E paths.
- Preserve the existing `readyz_health` Rust test and its Kubernetes feature registration.

## Testing

- [x] `bash -n e2e/with-kube-gateway.sh`
- [x] `git diff --check`
- [x] Static verification that `e2e/rust/tests/readyz_health.rs` and its `e2e-kubernetes` test target remain present
- [ ] `mise run pre-commit` completes (the Nix-backed run timed out after five minutes during a cold Rust workspace test build; all reported completed checks passed, including Helm lint, formatting, licensing, Python lint/type/tests, Markdown lint, and packaging checks)
- [ ] Kubernetes E2E (not run locally)

## Checklist

- [x] Follows Conventional Commits
- [x] Commit is signed off (DCO)
- [x] Change is limited to readyz workload discovery and port-forward selection
