### PR TITLE
test(kubernetes): add optional Envoy-backed e2e mode

### DIFF
--- a/.agents/skills/helm-dev-environment/SKILL.md
+++ b/.agents/skills/helm-dev-environment/SKILL.md
@@ -180,6 +180,12 @@ Envoy Gateway is already installed by Skaffold (the `envoy-gateway` Helm release
 service for the proxy; klipper-lb binds it to hostPort 80, reachable via the
 `8080:80` load balancer port mapping.
 
+To exercise the same path in the standard single-replica Kubernetes E2E suite,
+run `mise run e2e:kubernetes:envoy`. The wrapper creates isolated Gateway API
+resources, reuses an existing Envoy controller when present, and forwards the
+test client through the generated Envoy proxy Service. It does not enable HA or
+provision PostgreSQL.
+
 ### Keycloak OIDC
 
 One-time setup — only needed once per cluster lifetime:

--- a/.github/workflows/branch-e2e.yml
+++ b/.github/workflows/branch-e2e.yml
@@ -162,14 +162,22 @@ jobs:
             agent_sandbox_version: v0.5.0
             topology: combined
             extra_helm_values: ""
+            use_envoy_gateway: false
           - agent_sandbox_api: v1alpha1
             agent_sandbox_version: v0.4.6
             topology: combined
             extra_helm_values: ""
+            use_envoy_gateway: false
           - agent_sandbox_api: v1beta1
             agent_sandbox_version: v0.5.0
             topology: sidecar
             extra_helm_values: deploy/helm/openshell/ci/values-sidecar.yaml
+            use_envoy_gateway: false
+          - agent_sandbox_api: v1beta1
+            agent_sandbox_version: v0.5.0
+            topology: envoy
+            extra_helm_values: ""
+            use_envoy_gateway: true
     permissions:
       actions: read
       contents: read
@@ -180,6 +188,7 @@ jobs:
       job-name: Kubernetes E2E (Rust smoke, ${{ matrix.topology }}, Agent Sandbox ${{ matrix.agent_sandbox_api }})
       agent-sandbox-version: ${{ matrix.agent_sandbox_version }}
       extra-helm-values: ${{ matrix.extra_helm_values }}
+      use-envoy-gateway: ${{ matrix.use_envoy_gateway }}
       cli-artifact-prefix: rust-binary-cli
 
   kubernetes-workspace-managed-e2e:

--- a/.github/workflows/branch-e2e.yml
+++ b/.github/workflows/branch-e2e.yml
@@ -157,14 +157,22 @@ jobs:
             agent_sandbox_version: v0.5.0
             topology: combined
             extra_helm_values: ""
+            use_envoy_gateway: false
           - agent_sandbox_api: v1alpha1
             agent_sandbox_version: v0.4.6
             topology: combined
             extra_helm_values: ""
+            use_envoy_gateway: false
           - agent_sandbox_api: v1beta1
             agent_sandbox_version: v0.5.0
             topology: sidecar
             extra_helm_values: deploy/helm/openshell/ci/values-sidecar.yaml
+            use_envoy_gateway: false
+          - agent_sandbox_api: v1beta1
+            agent_sandbox_version: v0.5.0
+            topology: envoy
+            extra_helm_values: ""
+            use_envoy_gateway: true
     permissions:
       actions: read
       contents: read
@@ -175,6 +183,7 @@ jobs:
       job-name: Kubernetes E2E (Rust smoke, ${{ matrix.topology }}, Agent Sandbox ${{ matrix.agent_sandbox_api }})
       agent-sandbox-version: ${{ matrix.agent_sandbox_version }}
       extra-helm-values: ${{ matrix.extra_helm_values }}
+      use-envoy-gateway: ${{ matrix.use_envoy_gateway }}
       cli-artifact-prefix: rust-binary-cli
 
   kubernetes-ha-e2e:

--- a/.github/workflows/e2e-kubernetes-test.yml
+++ b/.github/workflows/e2e-kubernetes-test.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: "v0.5.0"
+      use-envoy-gateway:
+        description: "Exercise Gateway API/Envoy routing for the standard single-replica e2e suite"
+        required: false
+        type: boolean
+        default: false
       e2e-task:
         description: "mise task to run for the Kubernetes e2e job"
         required: false
@@ -141,6 +146,7 @@ jobs:
           OPENSHELL_E2E_KUBE_CONTEXT: kind-${{ env.KIND_CLUSTER_NAME }}
           OPENSHELL_E2E_KUBE_EXTRA_VALUES: ${{ inputs.extra-helm-values }}
           OPENSHELL_E2E_KUBE_EXTERNAL_POSTGRES_SECRET: ${{ inputs.external-postgres-secret }}
+          OPENSHELL_E2E_KUBE_USE_ENVOY: ${{ inputs.use-envoy-gateway }}
           IMAGE_TAG: ${{ inputs.image-tag }}
           OPENSHELL_REGISTRY: ghcr.io/nvidia/openshell
           E2E_TASK: ${{ inputs.e2e-task }}

--- a/.github/workflows/e2e-kubernetes-test.yml
+++ b/.github/workflows/e2e-kubernetes-test.yml
@@ -37,6 +37,13 @@ on:
         required: false
         type: string
         default: "v0.5.0"
+      # This keeps the standard single-replica deployment and validates the
+      # Gateway API/Envoy GRPCRoute path. It does not enable HA.
+      use-envoy-gateway:
+        description: "Exercise Gateway API/Envoy routing for the standard single-replica e2e suite"
+        required: false
+        type: boolean
+        default: false
       mise-version:
         description: "mise version to install on the bare Kubernetes e2e runner"
         required: false
@@ -136,6 +143,7 @@ jobs:
           OPENSHELL_E2E_KUBE_CONTEXT: kind-${{ env.KIND_CLUSTER_NAME }}
           OPENSHELL_E2E_KUBE_EXTRA_VALUES: ${{ inputs.extra-helm-values }}
           OPENSHELL_E2E_KUBE_EXTERNAL_POSTGRES_SECRET: ${{ inputs.external-postgres-secret }}
+          OPENSHELL_E2E_KUBE_USE_ENVOY: ${{ inputs.use-envoy-gateway }}
           IMAGE_TAG: ${{ inputs.image-tag }}
           OPENSHELL_REGISTRY: ghcr.io/nvidia/openshell
         run: mise run --no-deps --skip-deps e2e:kubernetes

--- a/e2e/with-kube-gateway.sh
+++ b/e2e/with-kube-gateway.sh
@@ -20,6 +20,15 @@
 # files, relative to the repository root or absolute, to layer additional chart
 # configuration on top of ci/values-skaffold.yaml.
 #
+# Set OPENSHELL_E2E_KUBE_USE_ENVOY=1 to exercise the Gateway API/Envoy
+# GRPCRoute path for the standard single-replica suite. This does not enable HA
+# or change chart replica counts. It installs or reuses an Envoy Gateway
+# controller, enables the chart's Gateway and GRPCRoute, and connects through
+# the generated Envoy proxy Service. Resources created by this mode use
+# test-owned names and are removed without modifying pre-existing Envoy
+# resources. It is independent of the database backend; callers that enable
+# multi-replica overlays must still provide an external PostgreSQL Secret.
+#
 # Image source:
 #   - Ephemeral k3d mode builds local `openshell/{gateway,supervisor}:${IMAGE_TAG}`
 #     images by default, imports them into k3d, then installs the chart. This
@@ -80,6 +89,16 @@ EXTERNAL_PG_FIXTURE_SERVICE="openshell-e2e-postgres"
 EXTERNAL_PG_FIXTURE_USER="openshell"
 EXTERNAL_PG_FIXTURE_PASSWORD="openshell-e2e-postgres"
 EXTERNAL_PG_FIXTURE_DATABASE="openshell"
+E2E_RESOURCE_SUFFIX="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}-$$"
+ENVOY_CHART_VERSION="${OPENSHELL_E2E_ENVOY_VERSION:-v1.7.2}"
+ENVOY_RELEASE_NAME="${OPENSHELL_E2E_ENVOY_RELEASE_NAME:-envoy-gateway}"
+ENVOY_NAMESPACE="${OPENSHELL_E2E_ENVOY_NAMESPACE:-openshell-e2e-envoy-${E2E_RESOURCE_SUFFIX}}"
+ENVOY_GATEWAY_CLASS_NAME="${OPENSHELL_E2E_ENVOY_GATEWAY_CLASS_NAME:-openshell-e2e-${E2E_RESOURCE_SUFFIX}}"
+ENVOY_BACKEND_POLICY_NAME="${OPENSHELL_E2E_ENVOY_BACKEND_POLICY_NAME:-openshell-e2e-timeouts-${E2E_RESOURCE_SUFFIX}}"
+ENVOY_HELM_RELEASE_CREATED_BY_US=0
+ENVOY_NAMESPACE_CREATED_BY_US=0
+ENVOY_GATEWAY_CLASS_CREATED_BY_US=0
+ENVOY_BACKEND_POLICY_CREATED_BY_US=0
 
 # Isolate CLI/SDK gateway metadata from the developer's real config.
 export XDG_CONFIG_HOME="${WORKDIR}/config"
@@ -133,6 +152,207 @@ kube_workload_ref() {
   return 1
 }
 
+use_envoy_gateway() {
+  case "${OPENSHELL_E2E_KUBE_USE_ENVOY:-0}" in
+    1 | true | TRUE | yes | YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+envoy_gateway_controller_available() {
+  local gateway_classes
+  local deployments
+
+  gateway_classes="$(kctl get gatewayclass \
+    -o 'jsonpath={range .items[?(@.spec.controllerName=="gateway.envoyproxy.io/gatewayclass-controller")]}{.metadata.name}{"\n"}{end}' \
+    2>/dev/null || true)"
+  deployments="$(kctl get deployment -A -l control-plane=envoy-gateway \
+    -o name 2>/dev/null || true)"
+  [ -n "${gateway_classes}${deployments}" ]
+}
+
+wait_for_envoy_gateway_class() {
+  local accepted
+
+  for _ in $(seq 1 60); do
+    accepted="$(kctl get gatewayclass "${ENVOY_GATEWAY_CLASS_NAME}" \
+      -o 'jsonpath={.status.conditions[?(@.type=="Accepted")].status}' \
+      2>/dev/null || true)"
+    if [ "${accepted}" = "True" ]; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "ERROR: Envoy GatewayClass ${ENVOY_GATEWAY_CLASS_NAME} was not accepted" >&2
+  kctl get gatewayclass "${ENVOY_GATEWAY_CLASS_NAME}" -o yaml >&2 || true
+  return 1
+}
+
+prepare_envoy_gateway() {
+  if envoy_gateway_controller_available; then
+    echo "Using the existing Envoy Gateway controller without modifying its release."
+  else
+    if kctl get namespace "${ENVOY_NAMESPACE}" >/dev/null 2>&1; then
+      echo "ERROR: refusing to install Envoy Gateway into pre-existing namespace ${ENVOY_NAMESPACE}" >&2
+      return 1
+    fi
+
+    echo "Installing test-owned Envoy Gateway ${ENVOY_CHART_VERSION} in ${ENVOY_NAMESPACE}..."
+    if ! kctl create namespace "${ENVOY_NAMESPACE}"; then
+      return 1
+    fi
+    ENVOY_NAMESPACE_CREATED_BY_US=1
+    # Record ownership before install so the EXIT trap also cleans up a failed
+    # or timed-out Helm release in this invocation's unique namespace.
+    ENVOY_HELM_RELEASE_CREATED_BY_US=1
+    if ! helmctl install "${ENVOY_RELEASE_NAME}" \
+      oci://docker.io/envoyproxy/gateway-helm \
+      --version "${ENVOY_CHART_VERSION}" \
+      --namespace "${ENVOY_NAMESPACE}" \
+      --wait --timeout 5m; then
+      return 1
+    fi
+  fi
+
+  if kctl get gatewayclass "${ENVOY_GATEWAY_CLASS_NAME}" >/dev/null 2>&1; then
+    echo "ERROR: refusing to modify pre-existing GatewayClass ${ENVOY_GATEWAY_CLASS_NAME}" >&2
+    return 1
+  fi
+
+  if ! kctl create -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: ${ENVOY_GATEWAY_CLASS_NAME}
+  labels:
+    app.kubernetes.io/managed-by: openshell-e2e
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+EOF
+  then
+    return 1
+  fi
+  ENVOY_GATEWAY_CLASS_CREATED_BY_US=1
+  wait_for_envoy_gateway_class
+}
+
+configure_envoy_backend_policy() {
+  use_envoy_gateway || return 0
+  [ "${ENVOY_BACKEND_POLICY_CREATED_BY_US}" = "0" ] || return 0
+
+  if kctl -n "${NAMESPACE}" get backendtrafficpolicy.gateway.envoyproxy.io \
+    "${ENVOY_BACKEND_POLICY_NAME}" >/dev/null 2>&1; then
+    echo "ERROR: refusing to modify pre-existing BackendTrafficPolicy ${NAMESPACE}/${ENVOY_BACKEND_POLICY_NAME}" >&2
+    return 1
+  fi
+
+  # OpenShell gRPC streams can outlive Envoy's default request and stream
+  # duration limits during sandbox create, exec, and watch operations.
+  if ! kctl create -f - <<EOF
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: ${ENVOY_BACKEND_POLICY_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: openshell-e2e
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
+      name: ${RELEASE_NAME}
+  timeout:
+    http:
+      requestTimeout: 0s
+      maxStreamDuration: 0s
+EOF
+  then
+    return 1
+  fi
+  ENVOY_BACKEND_POLICY_CREATED_BY_US=1
+}
+
+wait_for_envoy_service() {
+  local service_ref
+  local service_namespace
+
+  for _ in $(seq 1 60); do
+    service_ref="$(kctl get service -A \
+      -l "gateway.envoyproxy.io/owning-gateway-name=${RELEASE_NAME},gateway.envoyproxy.io/owning-gateway-namespace=${NAMESPACE}" \
+      -o 'jsonpath={.items[0].metadata.namespace}{"/"}{.items[0].metadata.name}' \
+      2>/dev/null || true)"
+    if [ -n "${service_ref}" ]; then
+      service_namespace="${service_ref%%/*}"
+      if kctl -n "${service_namespace}" wait --for=condition=Ready pod \
+        -l "gateway.envoyproxy.io/owning-gateway-name=${RELEASE_NAME},gateway.envoyproxy.io/owning-gateway-namespace=${NAMESPACE}" \
+        --timeout=5s >/dev/null 2>&1; then
+        printf '%s\n' "${service_ref}"
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+
+  echo "ERROR: Envoy proxy Service for Gateway ${NAMESPACE}/${RELEASE_NAME} was not ready" >&2
+  kctl -n "${NAMESPACE}" get gateway,grpcroute -o wide >&2 || true
+  kctl get service,pod -A \
+    -l "gateway.envoyproxy.io/owning-gateway-name=${RELEASE_NAME},gateway.envoyproxy.io/owning-gateway-namespace=${NAMESPACE}" \
+    -o wide >&2 || true
+  return 1
+}
+
+start_gateway_portforward() {
+  local elapsed=0
+  local timeout=30
+  local target_namespace="${NAMESPACE}"
+  local target_service="${RELEASE_NAME}"
+  local target_port=8080
+  local service_ref
+
+  LOCAL_PORT="$(e2e_pick_port)"
+  if use_envoy_gateway; then
+    if ! service_ref="$(wait_for_envoy_service)"; then
+      return 1
+    fi
+    target_namespace="${service_ref%%/*}"
+    target_service="${service_ref#*/}"
+    target_port=80
+    echo "Starting kubectl port-forward -n ${target_namespace} svc/${target_service} ${LOCAL_PORT}:${target_port} (Envoy Gateway)..."
+  else
+    echo "Starting kubectl port-forward svc/${target_service} ${LOCAL_PORT}:${target_port}..."
+  fi
+
+  kctl -n "${target_namespace}" port-forward "svc/${target_service}" \
+    "${LOCAL_PORT}:${target_port}" >"${PORTFORWARD_LOG}" 2>&1 &
+  PORTFORWARD_PID=$!
+
+  while [ "${elapsed}" -lt "${timeout}" ]; do
+    if ! kill -0 "${PORTFORWARD_PID}" 2>/dev/null; then
+      echo "ERROR: kubectl port-forward exited before becoming reachable" >&2
+      cat "${PORTFORWARD_LOG}" >&2 || true
+      return 1
+    fi
+    if curl -s -o /dev/null --connect-timeout 1 "http://127.0.0.1:${LOCAL_PORT}"; then
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  echo "ERROR: port-forward did not accept TCP within ${timeout}s" >&2
+  cat "${PORTFORWARD_LOG}" >&2 || true
+  return 1
+}
+
+stop_gateway_portforward() {
+  [ -n "${PORTFORWARD_PID}" ] || return 0
+
+  kill "${PORTFORWARD_PID}" >/dev/null 2>&1 || true
+  wait "${PORTFORWARD_PID}" >/dev/null 2>&1 || true
+  PORTFORWARD_PID=""
+}
+
 deploy_postgres_fixture() {
   local secret_name="$1"
   local pg_uri
@@ -170,13 +390,47 @@ cleanup_postgres_fixture() {
   EXTERNAL_PG_FIXTURE_SECRET=""
 }
 
+cleanup_envoy_backend_policy() {
+  [ "${ENVOY_BACKEND_POLICY_CREATED_BY_US}" = "1" ] || return 0
+
+  if [ -n "${KUBE_CONTEXT}" ] && command -v kubectl >/dev/null 2>&1; then
+    kctl -n "${NAMESPACE}" delete backendtrafficpolicy.gateway.envoyproxy.io \
+      "${ENVOY_BACKEND_POLICY_NAME}" --ignore-not-found --wait=false \
+      >/dev/null 2>&1 || true
+  fi
+  ENVOY_BACKEND_POLICY_CREATED_BY_US=0
+}
+
+cleanup_envoy_gateway() {
+  if [ "${ENVOY_GATEWAY_CLASS_CREATED_BY_US}" = "1" ] \
+     && [ -n "${KUBE_CONTEXT}" ] \
+     && command -v kubectl >/dev/null 2>&1; then
+    kctl delete gatewayclass "${ENVOY_GATEWAY_CLASS_NAME}" \
+      --ignore-not-found --wait=false >/dev/null 2>&1 || true
+    ENVOY_GATEWAY_CLASS_CREATED_BY_US=0
+  fi
+
+  if [ "${ENVOY_HELM_RELEASE_CREATED_BY_US}" = "1" ] \
+     && [ -n "${KUBE_CONTEXT}" ] \
+     && command -v helm >/dev/null 2>&1; then
+    helmctl uninstall "${ENVOY_RELEASE_NAME}" --namespace "${ENVOY_NAMESPACE}" \
+      --wait --timeout 60s >/dev/null 2>&1 || true
+    ENVOY_HELM_RELEASE_CREATED_BY_US=0
+  fi
+
+  if [ "${ENVOY_NAMESPACE_CREATED_BY_US}" = "1" ] \
+     && [ -n "${KUBE_CONTEXT}" ] \
+     && command -v kubectl >/dev/null 2>&1; then
+    kctl delete namespace "${ENVOY_NAMESPACE}" --wait=true --timeout=60s \
+      --ignore-not-found >/dev/null 2>&1 || true
+    ENVOY_NAMESPACE_CREATED_BY_US=0
+  fi
+}
+
 cleanup() {
   local exit_code=$?
 
-  if [ -n "${PORTFORWARD_PID}" ]; then
-    kill "${PORTFORWARD_PID}" >/dev/null 2>&1 || true
-    wait "${PORTFORWARD_PID}" >/dev/null 2>&1 || true
-  fi
+  stop_gateway_portforward
 
   if [ -n "${PORTFORWARD_HEALTH_PID}" ]; then
     kill "${PORTFORWARD_HEALTH_PID}" >/dev/null 2>&1 || true
@@ -196,6 +450,15 @@ cleanup() {
         -l "app.kubernetes.io/instance=${RELEASE_NAME}" --tail=200 \
         --all-containers --prefix 2>&1 || true
       echo "=== end gateway debug output ==="
+      if use_envoy_gateway; then
+        echo "=== Envoy Gateway state ==="
+        kctl -n "${NAMESPACE}" get gateway,grpcroute,backendtrafficpolicy \
+          -o wide 2>&1 || true
+        kctl get service,pod -A \
+          -l "gateway.envoyproxy.io/owning-gateway-name=${RELEASE_NAME},gateway.envoyproxy.io/owning-gateway-namespace=${NAMESPACE}" \
+          -o wide 2>&1 || true
+        echo "=== end Envoy Gateway state ==="
+      fi
     fi
     if [ -f "${PORTFORWARD_LOG}" ]; then
       echo "=== port-forward log ==="
@@ -213,6 +476,8 @@ cleanup() {
     cleanup_postgres_fixture "${EXTERNAL_PG_FIXTURE_SECRET}"
   fi
 
+  cleanup_envoy_backend_policy
+
   if [ "${HELM_INSTALLED}" = "1" ] && [ -n "${KUBE_CONTEXT}" ] && [ -n "${NAMESPACE}" ]; then
     if command -v helm >/dev/null 2>&1; then
       helmctl uninstall "${RELEASE_NAME}" --namespace "${NAMESPACE}" --wait \
@@ -225,6 +490,8 @@ cleanup() {
         --ignore-not-found >/dev/null 2>&1 || true
     fi
   fi
+
+  cleanup_envoy_gateway
 
   if [ "${CLUSTER_CREATED_BY_US}" = "1" ] && [ -n "${CLUSTER_NAME}" ]; then
     if command -v k3d >/dev/null 2>&1 && k3d cluster list "${CLUSTER_NAME}" \
@@ -241,11 +508,7 @@ trap cleanup EXIT
 # --- DB-scenario helpers (used only when OPENSHELL_E2E_KUBE_DB_SCENARIOS=1) ---
 
 scenario_stop_portforward() {
-  if [ -n "${PORTFORWARD_PID}" ]; then
-    kill "${PORTFORWARD_PID}" >/dev/null 2>&1 || true
-    wait "${PORTFORWARD_PID}" >/dev/null 2>&1 || true
-    PORTFORWARD_PID=""
-  fi
+  stop_gateway_portforward
   if [ -n "${PORTFORWARD_HEALTH_PID}" ]; then
     kill "${PORTFORWARD_HEALTH_PID}" >/dev/null 2>&1 || true
     wait "${PORTFORWARD_HEALTH_PID}" >/dev/null 2>&1 || true
@@ -304,39 +567,15 @@ run_scenario() {
     --wait --timeout 5m
   HELM_INSTALLED=1
 
-  LOCAL_PORT="$(e2e_pick_port)"
-  echo "Starting kubectl port-forward svc/openshell ${LOCAL_PORT}:8080..."
-  kctl -n "${NAMESPACE}" port-forward "svc/openshell" \
-    "${LOCAL_PORT}:8080" >"${PORTFORWARD_LOG}" 2>&1 &
-  PORTFORWARD_PID=$!
-
-  local elapsed=0 pf_timeout=30
-  while [ "${elapsed}" -lt "${pf_timeout}" ]; do
-    if ! kill -0 "${PORTFORWARD_PID}" 2>/dev/null; then
-      echo "ERROR: kubectl port-forward exited before becoming reachable" >&2
-      cat "${PORTFORWARD_LOG}" >&2 || true
-      DB_FAILED=$((DB_FAILED + 1))
-      DB_SCENARIOS_SUMMARY+=("FAIL  ${scenario_label}: port-forward died")
-      scenario_stop_portforward
-      scenario_cleanup_release
-      return
-    fi
-    if curl -s -o /dev/null --connect-timeout 1 "http://127.0.0.1:${LOCAL_PORT}"; then
-      break
-    fi
-    sleep 1
-    elapsed=$((elapsed + 1))
-  done
-  if [ "${elapsed}" -ge "${pf_timeout}" ]; then
-    echo "ERROR: port-forward did not accept TCP within ${pf_timeout}s" >&2
-    cat "${PORTFORWARD_LOG}" >&2 || true
+  if ! configure_envoy_backend_policy || ! start_gateway_portforward; then
     DB_FAILED=$((DB_FAILED + 1))
-    DB_SCENARIOS_SUMMARY+=("FAIL  ${scenario_label}: port-forward timeout")
+    DB_SCENARIOS_SUMMARY+=("FAIL  ${scenario_label}: port-forward failed")
     scenario_stop_portforward
     scenario_cleanup_release
     return
   fi
 
+  local elapsed=0 pf_timeout=30
   HEALTH_LOCAL_PORT="$(e2e_pick_port)"
   local workload_ref
   workload_ref="$(kube_workload_ref "${RELEASE_NAME}")"
@@ -612,6 +851,11 @@ if [ -n "${OPENSHELL_E2E_KUBE_EXTRA_VALUES:-}" ]; then
     helm_values_args+=(--values "${values_file}")
   done
 fi
+if use_envoy_gateway; then
+  prepare_envoy_gateway
+  helm_values_args+=(--values "${ROOT}/deploy/helm/openshell/ci/values-gateway.yaml")
+  helm_extra_args+=(--set "grpcRoute.gateway.className=${ENVOY_GATEWAY_CLASS_NAME}")
+fi
 
 if [ "${OPENSHELL_E2E_KUBE_DB_SCENARIOS:-0}" = "1" ]; then
   # --- Multi-scenario mode: test all database backends ---
@@ -662,31 +906,8 @@ else
     --wait --timeout 5m
   HELM_INSTALLED=1
 
-  LOCAL_PORT="$(e2e_pick_port)"
-  echo "Starting kubectl port-forward svc/openshell ${LOCAL_PORT}:8080..."
-  kctl -n "${NAMESPACE}" port-forward "svc/openshell" \
-    "${LOCAL_PORT}:8080" >"${PORTFORWARD_LOG}" 2>&1 &
-  PORTFORWARD_PID=$!
-
-  elapsed=0
-  timeout=30
-  while [ "${elapsed}" -lt "${timeout}" ]; do
-    if ! kill -0 "${PORTFORWARD_PID}" 2>/dev/null; then
-      echo "ERROR: kubectl port-forward exited before becoming reachable" >&2
-      cat "${PORTFORWARD_LOG}" >&2 || true
-      exit 1
-    fi
-    if curl -s -o /dev/null --connect-timeout 1 "http://127.0.0.1:${LOCAL_PORT}"; then
-      break
-    fi
-    sleep 1
-    elapsed=$((elapsed + 1))
-  done
-  if [ "${elapsed}" -ge "${timeout}" ]; then
-    echo "ERROR: port-forward did not accept TCP within ${timeout}s" >&2
-    cat "${PORTFORWARD_LOG}" >&2 || true
-    exit 1
-  fi
+  configure_envoy_backend_policy
+  start_gateway_portforward
 
   HEALTH_LOCAL_PORT="$(e2e_pick_port)"
   WORKLOAD_REF="$(kube_workload_ref "${RELEASE_NAME}")"

--- a/e2e/with-kube-gateway.sh
+++ b/e2e/with-kube-gateway.sh
@@ -46,6 +46,11 @@
 #   `vault`; the Rust `credential_drivers` e2e test validates the active
 #   backend. Vault mode installs a dev OpenBao fixture because it exposes the
 #   Vault-compatible API used by the driver.
+#
+# Envoy Gateway path:
+#   Set OPENSHELL_E2E_KUBE_USE_ENVOY=1 to route the standard single-replica
+#   suite through the Gateway API GRPCRoute. The wrapper preserves an existing
+#   Envoy Gateway controller and cleans up only Envoy resources it created.
 
 set -euo pipefail
 
@@ -94,6 +99,16 @@ VAULT_CHART_VERSION="${OPENSHELL_E2E_OPENBAO_CHART_VERSION:-0.28.3}"
 VAULT_DEV_ROOT_TOKEN="${OPENSHELL_E2E_VAULT_DEV_ROOT_TOKEN:-root}"
 CORPORATE_PROXY_FIXTURE_DEPLOYED=0
 CORPORATE_PROXY_FIXTURE_SECRET="openshell-e2e-proxy-auth"
+ENVOY_RUN_ID="$(date +%s)-$$"
+ENVOY_RELEASE_NAME="openshell-e2e-envoy-${ENVOY_RUN_ID}"
+ENVOY_NAMESPACE="openshell-e2e-envoy-${ENVOY_RUN_ID}"
+ENVOY_CHART_VERSION="${OPENSHELL_E2E_ENVOY_VERSION:-v1.7.2}"
+ENVOY_GATEWAY_CLASS="openshell-e2e-envoy-${ENVOY_RUN_ID}"
+ENVOY_TRAFFIC_POLICY="openshell-e2e-envoy-${ENVOY_RUN_ID}"
+ENVOY_HELM_INSTALLED=0
+ENVOY_NAMESPACE_CREATED=0
+ENVOY_GATEWAY_CLASS_CREATED=0
+ENVOY_TRAFFIC_POLICY_CREATED=0
 
 # Isolate CLI/SDK gateway metadata from the developer's real config.
 export XDG_CONFIG_HOME="${WORKDIR}/config"
@@ -184,6 +199,158 @@ cleanup_postgres_fixture() {
   EXTERNAL_PG_FIXTURE_SECRET=""
 }
 
+use_envoy_gateway() {
+  case "${OPENSHELL_E2E_KUBE_USE_ENVOY:-0}" in
+    1 | true | TRUE | yes | YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+envoy_controller_present() {
+  if kctl get gatewayclass \
+    -o jsonpath='{range .items[*]}{.spec.controllerName}{"\n"}{end}' 2>/dev/null \
+    | grep -qx 'gateway.envoyproxy.io/gatewayclass-controller'; then
+    return 0
+  fi
+  [ -n "$(kctl get deployment -A -l app.kubernetes.io/name=gateway-helm \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)" ]
+}
+
+prepare_envoy_gateway() {
+  if envoy_controller_present; then
+    echo "Reusing an existing Envoy Gateway controller."
+  else
+    if kctl get namespace "${ENVOY_NAMESPACE}" >/dev/null 2>&1; then
+      echo "ERROR: refusing to reuse Envoy test namespace ${ENVOY_NAMESPACE}" >&2
+      return 1
+    fi
+    kctl create namespace "${ENVOY_NAMESPACE}"
+    ENVOY_NAMESPACE_CREATED=1
+
+    echo "Installing Envoy Gateway (${ENVOY_CHART_VERSION})..."
+    helmctl install "${ENVOY_RELEASE_NAME}" \
+      oci://docker.io/envoyproxy/gateway-helm \
+      --version "${ENVOY_CHART_VERSION}" \
+      --namespace "${ENVOY_NAMESPACE}" --wait --timeout 5m
+    ENVOY_HELM_INSTALLED=1
+  fi
+
+  if kctl get gatewayclass "${ENVOY_GATEWAY_CLASS}" >/dev/null 2>&1; then
+    echo "ERROR: refusing to modify existing GatewayClass ${ENVOY_GATEWAY_CLASS}" >&2
+    return 1
+  fi
+  kctl create -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: ${ENVOY_GATEWAY_CLASS}
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+EOF
+  ENVOY_GATEWAY_CLASS_CREATED=1
+  kctl wait --for=condition=Accepted "gatewayclass/${ENVOY_GATEWAY_CLASS}" --timeout=120s
+}
+
+create_envoy_traffic_policy() {
+  if kctl -n "${NAMESPACE}" get backendtrafficpolicy.gateway.envoyproxy.io \
+    "${ENVOY_TRAFFIC_POLICY}" >/dev/null 2>&1; then
+    echo "ERROR: refusing to modify existing BackendTrafficPolicy ${ENVOY_TRAFFIC_POLICY}" >&2
+    return 1
+  fi
+  kctl -n "${NAMESPACE}" create -f - <<EOF
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: ${ENVOY_TRAFFIC_POLICY}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
+      name: ${RELEASE_NAME}
+  timeout:
+    http:
+      requestTimeout: 0s
+      maxStreamDuration: 0s
+EOF
+  ENVOY_TRAFFIC_POLICY_CREATED=1
+}
+
+wait_for_envoy_service() {
+  local svc_ref=""
+  local svc_namespace=""
+
+  kctl -n "${NAMESPACE}" wait --for=condition=Accepted \
+    "gateway/${RELEASE_NAME}" --timeout=120s
+  kctl -n "${NAMESPACE}" wait --for=condition=Accepted \
+    "grpcroute/${RELEASE_NAME}" --timeout=120s
+  kctl -n "${NAMESPACE}" wait --for=condition=ResolvedRefs \
+    "grpcroute/${RELEASE_NAME}" --timeout=120s
+
+  for _ in $(seq 1 60); do
+    svc_ref="$(kctl get svc -A \
+      -l "gateway.envoyproxy.io/owning-gateway-name=${RELEASE_NAME},gateway.envoyproxy.io/owning-gateway-namespace=${NAMESPACE}" \
+      -o jsonpath='{range .items[0]}{.metadata.namespace}{"/"}{.metadata.name}{end}' \
+      2>/dev/null || true)"
+    if [ -n "${svc_ref}" ]; then
+      svc_namespace="${svc_ref%%/*}"
+      if kctl -n "${svc_namespace}" wait --for=condition=Ready pod \
+        -l "gateway.envoyproxy.io/owning-gateway-name=${RELEASE_NAME},gateway.envoyproxy.io/owning-gateway-namespace=${NAMESPACE}" \
+        --timeout=5s >/dev/null 2>&1; then
+        printf '%s\n' "${svc_ref}"
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+
+  echo "ERROR: Envoy proxy Service for Gateway ${RELEASE_NAME} was not ready." >&2
+  kctl -n "${NAMESPACE}" get gateway,grpcroute -o wide >&2 || true
+  kctl get svc -A \
+    -l "gateway.envoyproxy.io/owning-gateway-name=${RELEASE_NAME},gateway.envoyproxy.io/owning-gateway-namespace=${NAMESPACE}" \
+    -o wide >&2 || true
+  return 1
+}
+
+start_gateway_portforward() {
+  local elapsed=0
+  local timeout=30
+  local target_namespace="${NAMESPACE}"
+  local target_service="${RELEASE_NAME}"
+  local target_port=8080
+  local target_service_ref=""
+
+  LOCAL_PORT="$(e2e_pick_port)"
+  if use_envoy_gateway; then
+    target_service_ref="$(wait_for_envoy_service)"
+    target_namespace="${target_service_ref%%/*}"
+    target_service="${target_service_ref#*/}"
+    target_port=80
+    echo "Starting kubectl port-forward -n ${target_namespace} svc/${target_service} ${LOCAL_PORT}:${target_port} (Envoy Gateway)..."
+  else
+    echo "Starting kubectl port-forward svc/${target_service} ${LOCAL_PORT}:${target_port}..."
+  fi
+  kctl -n "${target_namespace}" port-forward "svc/${target_service}" \
+    "${LOCAL_PORT}:${target_port}" >"${PORTFORWARD_LOG}" 2>&1 &
+  PORTFORWARD_PID=$!
+
+  while [ "${elapsed}" -lt "${timeout}" ]; do
+    if ! kill -0 "${PORTFORWARD_PID}" 2>/dev/null; then
+      echo "ERROR: kubectl port-forward exited before becoming reachable" >&2
+      cat "${PORTFORWARD_LOG}" >&2 || true
+      return 1
+    fi
+    if curl -s -o /dev/null --connect-timeout 1 "http://127.0.0.1:${LOCAL_PORT}"; then
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  echo "ERROR: port-forward did not accept TCP within ${timeout}s" >&2
+  cat "${PORTFORWARD_LOG}" >&2 || true
+  return 1
+}
+
 deploy_vault_fixture() {
   echo "Deploying OpenBao fixture for Vault credential-driver validation..."
 
@@ -270,6 +437,23 @@ cleanup() {
 
   if [ "${VAULT_FIXTURE_DEPLOYED}" = "1" ]; then
     cleanup_vault_fixture
+  fi
+
+  if [ "${ENVOY_TRAFFIC_POLICY_CREATED}" = "1" ] && [ -n "${KUBE_CONTEXT}" ]; then
+    kctl -n "${NAMESPACE}" delete backendtrafficpolicy.gateway.envoyproxy.io \
+      "${ENVOY_TRAFFIC_POLICY}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  fi
+  if [ "${ENVOY_GATEWAY_CLASS_CREATED}" = "1" ] && [ -n "${KUBE_CONTEXT}" ]; then
+    kctl delete gatewayclass "${ENVOY_GATEWAY_CLASS}" --ignore-not-found \
+      --wait=false >/dev/null 2>&1 || true
+  fi
+  if [ "${ENVOY_HELM_INSTALLED}" = "1" ] && [ -n "${KUBE_CONTEXT}" ]; then
+    helmctl uninstall "${ENVOY_RELEASE_NAME}" --namespace "${ENVOY_NAMESPACE}" \
+      --wait --timeout 60s >/dev/null 2>&1 || true
+  fi
+  if [ "${ENVOY_NAMESPACE_CREATED}" = "1" ] && [ -n "${KUBE_CONTEXT}" ]; then
+    kctl delete namespace "${ENVOY_NAMESPACE}" --wait=true --timeout=60s \
+      --ignore-not-found >/dev/null 2>&1 || true
   fi
 
   if [ "${CORPORATE_PROXY_FIXTURE_DEPLOYED}" = "1" ]; then
@@ -765,6 +949,16 @@ if [ -n "${OPENSHELL_E2E_KUBE_EXTRA_VALUES:-}" ]; then
   done
 fi
 
+if use_envoy_gateway; then
+  if [ "${OPENSHELL_E2E_KUBE_DB_SCENARIOS:-0}" = "1" ]; then
+    echo "ERROR: Envoy Gateway mode supports only the standard single-replica Kubernetes e2e suite." >&2
+    exit 2
+  fi
+  helm_values_args+=(--values "${ROOT}/deploy/helm/openshell/ci/values-gateway.yaml")
+  helm_extra_args+=(--set "grpcRoute.gateway.className=${ENVOY_GATEWAY_CLASS}")
+  prepare_envoy_gateway
+fi
+
 if [ "${OPENSHELL_E2E_KUBE_DB_SCENARIOS:-0}" = "1" ]; then
   # --- Multi-scenario mode: test all database backends ---
   DB_PASSED=0
@@ -822,31 +1016,10 @@ else
       --docker-password=e2e-password
   fi
 
-  LOCAL_PORT="$(e2e_pick_port)"
-  echo "Starting kubectl port-forward svc/openshell ${LOCAL_PORT}:8080..."
-  kctl -n "${NAMESPACE}" port-forward "svc/openshell" \
-    "${LOCAL_PORT}:8080" >"${PORTFORWARD_LOG}" 2>&1 &
-  PORTFORWARD_PID=$!
-
-  elapsed=0
-  timeout=30
-  while [ "${elapsed}" -lt "${timeout}" ]; do
-    if ! kill -0 "${PORTFORWARD_PID}" 2>/dev/null; then
-      echo "ERROR: kubectl port-forward exited before becoming reachable" >&2
-      cat "${PORTFORWARD_LOG}" >&2 || true
-      exit 1
-    fi
-    if curl -s -o /dev/null --connect-timeout 1 "http://127.0.0.1:${LOCAL_PORT}"; then
-      break
-    fi
-    sleep 1
-    elapsed=$((elapsed + 1))
-  done
-  if [ "${elapsed}" -ge "${timeout}" ]; then
-    echo "ERROR: port-forward did not accept TCP within ${timeout}s" >&2
-    cat "${PORTFORWARD_LOG}" >&2 || true
-    exit 1
+  if use_envoy_gateway; then
+    create_envoy_traffic_policy
   fi
+  start_gateway_portforward
 
   HEALTH_LOCAL_PORT="$(e2e_pick_port)"
   WORKLOAD_REF="$(kube_workload_ref "${RELEASE_NAME}")"

--- a/tasks/test.toml
+++ b/tasks/test.toml
@@ -160,6 +160,11 @@ description = "Run Kubernetes e2e with the supervisor sidecar topology overlay"
 env = { OPENSHELL_E2E_KUBE_EXTRA_VALUES = "deploy/helm/openshell/ci/values-sidecar.yaml" }
 run = "e2e/rust/e2e-kubernetes.sh"
 
+["e2e:kubernetes:envoy"]
+description = "Run the standard single-replica Kubernetes e2e suite through an Envoy Gateway GRPCRoute"
+env = { OPENSHELL_E2E_KUBE_USE_ENVOY = "1" }
+run = "e2e/rust/e2e-kubernetes.sh"
+
 ["e2e:kubernetes:db"]
 description = "Run Kubernetes e2e with all database backend scenarios (SQLite and external PostgreSQL with existingSecret)"
 env = { OPENSHELL_E2E_KUBE_DB_SCENARIOS = "1" }

--- a/tasks/test.toml
+++ b/tasks/test.toml
@@ -122,6 +122,11 @@ description = "Run Kubernetes e2e with the supervisor sidecar topology overlay"
 env = { OPENSHELL_E2E_KUBE_EXTRA_VALUES = "deploy/helm/openshell/ci/values-sidecar.yaml" }
 run = "e2e/rust/e2e-kubernetes.sh"
 
+["e2e:kubernetes:envoy"]
+description = "Run the standard single-replica Kubernetes e2e suite through an Envoy Gateway GRPCRoute"
+env = { OPENSHELL_E2E_KUBE_USE_ENVOY = "1" }
+run = "e2e/rust/e2e-kubernetes.sh"
+
 ["e2e:kubernetes:db"]
 description = "Run Kubernetes e2e with all database backend scenarios (SQLite and external PostgreSQL with existingSecret)"
 env = { OPENSHELL_E2E_KUBE_DB_SCENARIOS = "1" }


### PR DESCRIPTION
## Summary

Add an optional Envoy-backed execution mode for the standard single-replica Kubernetes E2E suite. The mode exercises the Gateway API/Envoy `GRPCRoute` path without enabling HA, changing replica counts, or requiring PostgreSQL.

Direct Service port-forwarding remains the default. Envoy mode installs or reuses an Envoy Gateway controller, creates test-owned Gateway API resources, disables Envoy request and stream duration limits for OpenShell's long-lived gRPC streams, discovers the generated proxy Service, and routes the client port-forward through that Service.

## Related Issue

Extracted from the generally applicable Envoy/Gateway API setup in #1868. This PR intentionally leaves HA gateway rebalancing, multi-replica behavior, and external PostgreSQL coverage out of scope while the HA tests are not yet functional.

## Changes

- Add `mise run e2e:kubernetes:envoy` for local single-replica Envoy execution.
- Add `OPENSHELL_E2E_KUBE_USE_ENVOY=1` support to the Kubernetes e2e wrapper.
- Add a `use-envoy-gateway` input to the reusable Kubernetes E2E workflow.
- Add one core Kubernetes E2E matrix leg with `topology: envoy` and `use-envoy-gateway: true`.
- Reuse an existing Envoy controller without upgrading or uninstalling its release.
- Install Envoy with `helm install` only when no controller is present, using a unique test-owned namespace.
- Create uniquely named test-owned `GatewayClass` and `BackendTrafficPolicy` resources, refusing to modify pre-existing resources with those names.
- Delete only Envoy resources whose creation was recorded by the current invocation.
- Route the client port-forward through the generated Envoy proxy Service while keeping the default direct-Service path unchanged.

## Testing

- [x] `bash -n e2e/with-kube-gateway.sh`
- [x] `git diff --check`
- [x] Workflow YAML parse through the OpenShell devenv with pinned `uv`/PyYAML
- [x] Helm lint with `ci/values-gateway.yaml`
- [x] Helm render of Gateway and GRPCRoute with the per-run GatewayClass override
- [x] Focused shell simulations for existing-controller reuse, pre-existing namespace/Class refusal, and created-resource-only cleanup
- [ ] `mise run pre-commit` completes (lint, format, workspace/E2E Clippy, Helm, Python, and other reported checks passed; the first run hit a fresh-virtualenv `grpc_tools` bootstrap race, and the rerun reached the five-minute command timeout during full Rust tests)
- [ ] Kubernetes E2E (Docker was unavailable locally)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Runtime mode and reusable workflow exposure are separate logical commits
- [x] Envoy coverage is single-replica and does not add HA replicas, PostgreSQL setup, or HA tests
