### PR TITLE
ci(kubernetes): expose e2e test selection

### DIFF
--- a/.github/workflows/e2e-kubernetes-test.yml
+++ b/.github/workflows/e2e-kubernetes-test.yml
@@ -42,6 +42,16 @@ on:
         required: false
         type: string
         default: "e2e:kubernetes"
+      test-name:
+        description: "Rust e2e test target to run (sets OPENSHELL_E2E_KUBE_TEST)"
+        required: false
+        type: string
+        default: ""
+      kubernetes-features:
+        description: "Cargo feature list for the Kubernetes e2e crate (uses script defaults when empty)"
+        required: false
+        type: string
+        default: ""
       mise-version:
         description: "mise version to install on the bare Kubernetes e2e runner"
         required: false
@@ -141,6 +151,8 @@ jobs:
           OPENSHELL_E2E_KUBE_CONTEXT: kind-${{ env.KIND_CLUSTER_NAME }}
           OPENSHELL_E2E_KUBE_EXTRA_VALUES: ${{ inputs.extra-helm-values }}
           OPENSHELL_E2E_KUBE_EXTERNAL_POSTGRES_SECRET: ${{ inputs.external-postgres-secret }}
+          OPENSHELL_E2E_KUBE_TEST: ${{ inputs.test-name }}
+          OPENSHELL_E2E_KUBERNETES_FEATURES: ${{ inputs.kubernetes-features }}
           IMAGE_TAG: ${{ inputs.image-tag }}
           OPENSHELL_REGISTRY: ghcr.io/nvidia/openshell
           E2E_TASK: ${{ inputs.e2e-task }}

--- a/.github/workflows/e2e-kubernetes-test.yml
+++ b/.github/workflows/e2e-kubernetes-test.yml
@@ -37,6 +37,16 @@ on:
         required: false
         type: string
         default: "v0.5.0"
+      test-name:
+        description: "Rust e2e test target to run (sets OPENSHELL_E2E_KUBE_TEST)"
+        required: false
+        type: string
+        default: ""
+      kubernetes-features:
+        description: "Cargo feature list for the Kubernetes e2e crate (uses script defaults when empty)"
+        required: false
+        type: string
+        default: ""
       mise-version:
         description: "mise version to install on the bare Kubernetes e2e runner"
         required: false
@@ -136,6 +146,8 @@ jobs:
           OPENSHELL_E2E_KUBE_CONTEXT: kind-${{ env.KIND_CLUSTER_NAME }}
           OPENSHELL_E2E_KUBE_EXTRA_VALUES: ${{ inputs.extra-helm-values }}
           OPENSHELL_E2E_KUBE_EXTERNAL_POSTGRES_SECRET: ${{ inputs.external-postgres-secret }}
+          OPENSHELL_E2E_KUBE_TEST: ${{ inputs.test-name }}
+          OPENSHELL_E2E_KUBERNETES_FEATURES: ${{ inputs.kubernetes-features }}
           IMAGE_TAG: ${{ inputs.image-tag }}
           OPENSHELL_REGISTRY: ghcr.io/nvidia/openshell
         run: mise run --no-deps --skip-deps e2e:kubernetes


### PR DESCRIPTION
## Summary

Expose optional Rust test-target and Cargo feature selection through the reusable Kubernetes e2e workflow. Empty inputs preserve the current test suite and the existing `OPENSHELL_E2E_KUBERNETES_FEATURES` developer-facing contract.

This remains a draft because `main` has no independent caller that consumes the new inputs yet. The intended first consumer is currently part of #1868; this PR deliberately does not add HA tests or callers.

## Related Issue

Extracted from #1868 for independent review.

## Changes

- Add optional `test-name` and `kubernetes-features` `workflow_call` inputs.
- Forward the inputs through `OPENSHELL_E2E_KUBE_TEST` and the existing `OPENSHELL_E2E_KUBERNETES_FEATURES` variable.
- Keep empty values behavior-neutral by relying on the existing shell defaults.

## Testing

- [ ] `mise run pre-commit` passes
  - Attempted inside the Nix environment after pre-syncing Python dependencies. The five-minute run timed out during parallel cold Rust builds; remaining Rust processes were resource-killed with `SIGKILL`, not failed assertions. Completed format, license, Helm, Markdown, Python lint/typecheck/tests, packaging, and install-script checks passed.
- [x] Parsed the workflow YAML and asserted both input defaults and environment wiring.
- [x] `bash -n e2e/rust/e2e-kubernetes.sh`
- [x] Verified unset, empty, and explicit `OPENSHELL_E2E_KUBERNETES_FEATURES` expansion.
- [ ] E2E tests run (no independent caller on `main` yet)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)