### PR TITLE
test(helm): match CA volumes by name

### DIFF
--- a/deploy/helm/openshell/tests/gateway_config_test.yaml
+++ b/deploy/helm/openshell/tests/gateway_config_test.yaml
@@ -49,18 +49,19 @@ tests:
       server.oidc.issuer: https://issuer.example.com
       server.oidc.caConfigMapName: openshell-oidc-ca
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[3].name
-          value: oidc-ca
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[3].mountPath
-          value: /etc/openshell-tls/oidc-ca
-      - equal:
-          path: spec.template.spec.volumes[2].name
-          value: oidc-ca
-      - equal:
-          path: spec.template.spec.volumes[2].configMap.name
-          value: openshell-oidc-ca
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: oidc-ca
+            mountPath: /etc/openshell-tls/oidc-ca
+          any: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: oidc-ca
+            configMap:
+              name: openshell-oidc-ca
+          any: true
 
   # Regression for the P1 bug Drew flagged: grpc_endpoint MUST live in the
   # Kubernetes driver table, not in [openshell.gateway]. The gateway-side

--- a/deploy/helm/openshell/tests/gateway_config_test.yaml
+++ b/deploy/helm/openshell/tests/gateway_config_test.yaml
@@ -69,18 +69,19 @@ tests:
       server.oidc.issuer: https://issuer.example.com
       server.oidc.caConfigMapName: openshell-oidc-ca
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[3].name
-          value: oidc-ca
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[3].mountPath
-          value: /etc/openshell-tls/oidc-ca
-      - equal:
-          path: spec.template.spec.volumes[2].name
-          value: oidc-ca
-      - equal:
-          path: spec.template.spec.volumes[2].configMap.name
-          value: openshell-oidc-ca
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: oidc-ca
+            mountPath: /etc/openshell-tls/oidc-ca
+          any: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: oidc-ca
+            configMap:
+              name: openshell-oidc-ca
+          any: true
 
   # Regression for the P1 bug Drew flagged: grpc_endpoint MUST live in the
   # Kubernetes driver table, not in [openshell.gateway]. The gateway-side

--- a/deploy/helm/openshell/tests/statefulset_client_ca_test.yaml
+++ b/deploy/helm/openshell/tests/statefulset_client_ca_test.yaml
@@ -16,15 +16,15 @@ tests:
       pkiInitJob.enabled: true
       certManager.enabled: false
     asserts:
-      - equal:
-          path: spec.template.spec.volumes[3].name
-          value: tls-client-ca
-      - equal:
-          path: spec.template.spec.volumes[3].secret.secretName
-          value: openshell-server-tls
-      - equal:
-          path: spec.template.spec.volumes[3].secret.items[0].key
-          value: ca.crt
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls-client-ca
+            secret:
+              secretName: openshell-server-tls
+              items:
+                - key: ca.crt
+                  path: ca.crt
 
   - it: shares the cert-manager server TLS ca.crt when clientCaFromServerTlsSecret is true
     template: templates/statefulset.yaml
@@ -32,15 +32,15 @@ tests:
       certManager.enabled: true
       certManager.clientCaFromServerTlsSecret: true
     asserts:
-      - equal:
-          path: spec.template.spec.volumes[3].name
-          value: tls-client-ca
-      - equal:
-          path: spec.template.spec.volumes[3].secret.secretName
-          value: openshell-server-tls
-      - equal:
-          path: spec.template.spec.volumes[3].secret.items[0].key
-          value: ca.crt
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls-client-ca
+            secret:
+              secretName: openshell-server-tls
+              items:
+                - key: ca.crt
+                  path: ca.crt
 
   # Regression: with cert-manager enabled and pkiInitJob left at its default
   # `true`, the client CA condition must honor certManager precedence and NOT
@@ -54,14 +54,13 @@ tests:
       certManager.clientCaFromServerTlsSecret: false
       pkiInitJob.enabled: true
     asserts:
-      - equal:
-          path: spec.template.spec.volumes[3].name
-          value: tls-client-ca
-      - equal:
-          path: spec.template.spec.volumes[3].secret.secretName
-          value: openshell-server-client-ca
-      - notExists:
-          path: spec.template.spec.volumes[3].secret.items
+      # Exact matching (without any: true) also verifies that secret.items is absent.
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls-client-ca
+            secret:
+              secretName: openshell-server-client-ca
 
   # When cert-manager owns TLS, does not share its CA, and no separate client CA
   # secret is configured, there is no client CA to mount: the volume must not
@@ -74,12 +73,14 @@ tests:
       pkiInitJob.enabled: true
       server.tls.clientCaSecretName: ""
     asserts:
-      - lengthEqual:
+      - notContains:
           path: spec.template.spec.volumes
-          count: 3
+          content:
+            name: tls-client-ca
+          any: true
       - notContains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: tls-client-ca
             mountPath: /etc/openshell-tls/client-ca
-            readOnly: true
+          any: true

--- a/deploy/helm/openshell/tests/statefulset_client_ca_test.yaml
+++ b/deploy/helm/openshell/tests/statefulset_client_ca_test.yaml
@@ -16,15 +16,15 @@ tests:
       pkiInitJob.enabled: true
       certManager.enabled: false
     asserts:
-      - equal:
-          path: spec.template.spec.volumes[3].name
-          value: tls-client-ca
-      - equal:
-          path: spec.template.spec.volumes[3].secret.secretName
-          value: openshell-server-tls
-      - equal:
-          path: spec.template.spec.volumes[3].secret.items[0].key
-          value: ca.crt
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls-client-ca
+            secret:
+              secretName: openshell-server-tls
+              items:
+                - key: ca.crt
+                  path: ca.crt
 
   - it: shares the cert-manager server TLS ca.crt when clientCaFromServerTlsSecret is true
     template: templates/statefulset.yaml
@@ -32,15 +32,15 @@ tests:
       certManager.enabled: true
       certManager.clientCaFromServerTlsSecret: true
     asserts:
-      - equal:
-          path: spec.template.spec.volumes[3].name
-          value: tls-client-ca
-      - equal:
-          path: spec.template.spec.volumes[3].secret.secretName
-          value: openshell-server-tls
-      - equal:
-          path: spec.template.spec.volumes[3].secret.items[0].key
-          value: ca.crt
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls-client-ca
+            secret:
+              secretName: openshell-server-tls
+              items:
+                - key: ca.crt
+                  path: ca.crt
 
   # Regression: with cert-manager enabled and pkiInitJob left at its default
   # `true`, the client CA condition must honor certManager precedence and NOT
@@ -55,14 +55,13 @@ tests:
       pkiInitJob.enabled: true
       server.tls.clientCaSecretName: openshell-ca-tls
     asserts:
-      - equal:
-          path: spec.template.spec.volumes[3].name
-          value: tls-client-ca
-      - equal:
-          path: spec.template.spec.volumes[3].secret.secretName
-          value: openshell-ca-tls
-      - notExists:
-          path: spec.template.spec.volumes[3].secret.items
+      # Exact matching (without any: true) also verifies that secret.items is absent.
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls-client-ca
+            secret:
+              secretName: openshell-ca-tls
 
   # When cert-manager owns TLS, does not share its CA, and no separate client CA
   # secret is configured, there is no client CA to mount: the volume must not
@@ -75,12 +74,14 @@ tests:
       pkiInitJob.enabled: true
       server.tls.clientCaSecretName: ""
     asserts:
-      - lengthEqual:
+      - notContains:
           path: spec.template.spec.volumes
-          count: 3
+          content:
+            name: tls-client-ca
+          any: true
       - notContains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: tls-client-ca
             mountPath: /etc/openshell-tls/client-ca
-            readOnly: true
+          any: true


### PR DESCRIPTION
## Summary

Make the existing OIDC CA and gateway client CA Helm tests insensitive to unrelated volume insertion. The assertions now identify volumes and mounts by name while preserving coverage of secret names, key mappings, mount paths, and omission behavior.

## Related Issue

Related to #1868. This is a generally applicable test cleanup extracted from the HA review.

## Changes

- Replace positional OIDC CA volume and volume-mount checks with name-based `contains` assertions.
- Replace positional client CA secret checks with exact named-volume assertions, including the `ca.crt` item mapping.
- Keep the separate client CA case exact so `secret.items` must remain absent.
- Replace the brittle expected volume count with name-based `notContains` checks for the HTTPS-only omission case.

## Testing

- [x] `mise run pre-commit` passes (run inside `nix develop`)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (not applicable)

Focused validation:

- [x] `mise run helm:test` — 62 tests passed across 5 suites
- [x] `mise run helm:lint` — defaults and every CI values variant passed

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; test-only change)

## Notes

PR #2235 also touches these test files for a client CA behavior fix. It does not implement this assertion cleanup, but merge order may require a trivial rebase.
