### PR TITLE
fix(supervisor): keep instance id stable across reconnects

### DIFF
--- a/crates/openshell-supervisor-process/src/supervisor_session.rs
+++ b/crates/openshell-supervisor-process/src/supervisor_session.rs
@@ -302,6 +302,9 @@ async fn run_session_loop(
 ) {
     let mut backoff = INITIAL_BACKOFF;
     let mut attempt: u64 = 0;
+    // `instance_id` identifies this supervisor process, not an individual
+    // connection attempt, so reconnects must reuse it.
+    let instance_id = uuid::Uuid::new_v4().to_string();
 
     loop {
         attempt += 1;
@@ -313,6 +316,7 @@ async fn run_session_loop(
             netns_fd,
             expected_ssh_peer_pid,
             Arc::clone(&terminating),
+            &instance_id,
         )
         .await
         {
@@ -344,6 +348,7 @@ async fn run_single_session(
     netns_fd: Option<i32>,
     expected_ssh_peer_pid: Option<u32>,
     terminating: Arc<AtomicBool>,
+    instance_id: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Connect to the gateway. The same `Channel` is used for both the
     // long-lived control stream and all data-plane `RelayStream` calls, so
@@ -359,12 +364,11 @@ async fn run_single_session(
     let outbound = tokio_stream::wrappers::ReceiverStream::new(rx);
 
     // Send hello as the first message.
-    let instance_id = uuid::Uuid::new_v4().to_string();
     tx.send(SupervisorMessage {
-        payload: Some(supervisor_message::Payload::Hello(SupervisorHello {
-            sandbox_id: sandbox_id.to_string(),
-            instance_id: instance_id.clone(),
-        })),
+        payload: Some(supervisor_message::Payload::Hello(build_supervisor_hello(
+            sandbox_id,
+            instance_id,
+        ))),
     })
     .await
     .map_err(|_| "failed to queue hello")?;
@@ -440,6 +444,13 @@ async fn run_single_session(
                 }
             }
         }
+    }
+}
+
+fn build_supervisor_hello(sandbox_id: &str, instance_id: &str) -> SupervisorHello {
+    SupervisorHello {
+        sandbox_id: sandbox_id.to_string(),
+        instance_id: instance_id.to_string(),
     }
 }
 
@@ -798,6 +809,16 @@ fn normalize_tcp_target_host(target: &TcpRelayTarget) -> Result<String, String> 
 #[cfg(test)]
 mod target_tests {
     use super::*;
+
+    #[test]
+    fn supervisor_hello_reuses_caller_owned_instance_id() {
+        let instance_id = uuid::Uuid::new_v4().to_string();
+        let first = build_supervisor_hello("sandbox-1", &instance_id);
+        let second = build_supervisor_hello("sandbox-1", &instance_id);
+
+        assert_eq!(first.instance_id, instance_id);
+        assert_eq!(second.instance_id, first.instance_id);
+    }
 
     fn tcp(host: &str, port: u32) -> TcpRelayTarget {
         TcpRelayTarget {

--- a/crates/openshell-supervisor-process/src/supervisor_session.rs
+++ b/crates/openshell-supervisor-process/src/supervisor_session.rs
@@ -255,6 +255,9 @@ async fn run_session_loop(
 ) {
     let mut backoff = INITIAL_BACKOFF;
     let mut attempt: u64 = 0;
+    // `instance_id` identifies this supervisor process, not an individual
+    // connection attempt, so reconnects must reuse it.
+    let instance_id = uuid::Uuid::new_v4().to_string();
 
     loop {
         attempt += 1;
@@ -265,6 +268,7 @@ async fn run_session_loop(
             &ssh_socket_path,
             netns_fd,
             expected_ssh_peer_pid,
+            &instance_id,
         )
         .await
         {
@@ -295,6 +299,7 @@ async fn run_single_session(
     ssh_socket_path: &std::path::Path,
     netns_fd: Option<i32>,
     expected_ssh_peer_pid: Option<u32>,
+    instance_id: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Connect to the gateway. The same `Channel` is used for both the
     // long-lived control stream and all data-plane `RelayStream` calls, so
@@ -310,12 +315,11 @@ async fn run_single_session(
     let outbound = tokio_stream::wrappers::ReceiverStream::new(rx);
 
     // Send hello as the first message.
-    let instance_id = uuid::Uuid::new_v4().to_string();
     tx.send(SupervisorMessage {
-        payload: Some(supervisor_message::Payload::Hello(SupervisorHello {
-            sandbox_id: sandbox_id.to_string(),
-            instance_id: instance_id.clone(),
-        })),
+        payload: Some(supervisor_message::Payload::Hello(build_supervisor_hello(
+            sandbox_id,
+            instance_id,
+        ))),
     })
     .await
     .map_err(|_| "failed to queue hello")?;
@@ -380,6 +384,13 @@ async fn run_single_session(
                 }
             }
         }
+    }
+}
+
+fn build_supervisor_hello(sandbox_id: &str, instance_id: &str) -> SupervisorHello {
+    SupervisorHello {
+        sandbox_id: sandbox_id.to_string(),
+        instance_id: instance_id.to_string(),
     }
 }
 
@@ -709,6 +720,16 @@ fn normalize_tcp_target_host(target: &TcpRelayTarget) -> Result<String, String> 
 #[cfg(test)]
 mod target_tests {
     use super::*;
+
+    #[test]
+    fn supervisor_hello_reuses_caller_owned_instance_id() {
+        let instance_id = uuid::Uuid::new_v4().to_string();
+        let first = build_supervisor_hello("sandbox-1", &instance_id);
+        let second = build_supervisor_hello("sandbox-1", &instance_id);
+
+        assert_eq!(first.instance_id, instance_id);
+        assert_eq!(second.instance_id, first.instance_id);
+    }
 
     fn tcp(host: &str, port: u32) -> TcpRelayTarget {
         TcpRelayTarget {


### PR DESCRIPTION
## Summary

Keep `SupervisorHello.instance_id` stable across reconnect attempts made by one supervisor process. The existing protobuf defines the field as a boot/process epoch, so each new process still receives a fresh UUID while connection retries reuse it.

## Related Issue

Extracted from #1868 for independent review.

## Changes

- Generate the supervisor instance UUID once per `run_session_loop`.
- Pass the same instance ID into every `run_single_session` attempt.
- Keep the `SupervisorHello` wire format unchanged.
- Add focused regression coverage for caller-owned instance-ID reuse.

## Testing

- [ ] `mise run pre-commit` passes
  - Attempted inside the Nix environment with reduced mise concurrency. The five-minute run timed out during concurrent workspace Rust builds; remaining compiler processes were resource-killed with `SIGKILL`, not failed assertions. Completed format, license, Helm, Markdown, Python, packaging, and install-script checks passed.
- [x] `nix develop -c cargo test -p openshell-supervisor-process` (78 passed, 1 ignored)
- [x] `nix develop -c cargo clippy -p openshell-supervisor-process --all-targets -- -D warnings`
- [x] Focused instance-ID regression test
- [ ] E2E tests added/updated (not applicable; wire format and connection behavior are otherwise unchanged)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)