### PR TITLE
fix(compute): recover Error-phase sandboxes on gateway startup

### DIFF
--- a/crates/openshell-core/src/driver_utils.rs
+++ b/crates/openshell-core/src/driver_utils.rs
@@ -46,6 +46,18 @@ pub fn openshell_sandbox_label_selector() -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Sandbox condition reason strings set by compute drivers.
+// ---------------------------------------------------------------------------
+
+/// Ready-condition reason when a container exits on its own (e.g. SIGTERM
+/// from a machine restart, OOM kill, application crash).
+pub const CONDITION_EXITED: &str = "ContainerExited";
+
+/// Ready-condition reason when a container is explicitly stopped via the
+/// runtime API (e.g. `podman stop`, gateway-initiated shutdown).
+pub const CONDITION_STOPPED: &str = "ContainerStopped";
+
+// ---------------------------------------------------------------------------
 
 /// Path to the sandbox supervisor binary inside the container image.
 ///

--- a/crates/openshell-core/src/driver_utils.rs
+++ b/crates/openshell-core/src/driver_utils.rs
@@ -31,6 +31,18 @@ pub const LABEL_SANDBOX_NAMESPACE: &str = "openshell.ai/sandbox-namespace";
 pub const LABEL_SANDBOX_WORKSPACE: &str = "openshell.ai/sandbox-workspace";
 
 // ---------------------------------------------------------------------------
+// Sandbox condition reason strings set by compute drivers.
+// ---------------------------------------------------------------------------
+
+/// Ready-condition reason when a container exits on its own (e.g. SIGTERM
+/// from a machine restart, OOM kill, application crash).
+pub const CONDITION_EXITED: &str = "ContainerExited";
+
+/// Ready-condition reason when a container is explicitly stopped via the
+/// runtime API (e.g. `podman stop`, gateway-initiated shutdown).
+pub const CONDITION_STOPPED: &str = "ContainerStopped";
+
+// ---------------------------------------------------------------------------
 
 /// Path to the sandbox supervisor binary inside the container image.
 ///

--- a/crates/openshell-core/src/driver_utils.rs
+++ b/crates/openshell-core/src/driver_utils.rs
@@ -49,9 +49,21 @@ pub fn openshell_sandbox_label_selector() -> String {
 // Sandbox condition reason strings set by compute drivers.
 // ---------------------------------------------------------------------------
 
-/// Ready-condition reason when a container exits on its own (e.g. SIGTERM
-/// from a machine restart, OOM kill, application crash).
+/// Ready-condition reason when a container exits on its own.
+///
+/// Covers an ordinary application exit or crash (exit 0, a non-zero error code,
+/// or an uncaught fault). This is a terminal reason: gateway startup does NOT
+/// auto-restart it, so a genuine failure keeps its error signal instead of
+/// being relaunched.
 pub const CONDITION_EXITED: &str = "ContainerExited";
+
+/// Ready-condition reason when a container was terminated by an external signal.
+///
+/// SIGKILL/SIGTERM (exit 137/143) is what a Podman/Docker machine or daemon
+/// restart does to running containers. Distinct from `CONDITION_EXITED` so
+/// gateway startup can recover machine-restart victims while leaving ordinary
+/// application exits terminal.
+pub const CONDITION_RUNTIME_RESTART: &str = "ContainerRuntimeRestart";
 
 /// Ready-condition reason when a container is explicitly stopped via the
 /// runtime API (e.g. `podman stop`, gateway-initiated shutdown).

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -2832,7 +2832,7 @@ fn container_ready_condition(
             ("False", "ContainerPaused", "Container is paused", false)
         }
         ContainerSummaryStateEnum::EXITED => {
-            ("False", "ContainerExited", "Container exited", false)
+            ("False", openshell_core::driver_utils::CONDITION_EXITED, "Container exited", false)
         }
         ContainerSummaryStateEnum::DEAD => ("False", "ContainerDead", "Container is dead", false),
     }

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -24,10 +24,10 @@ use openshell_core::config::{
 };
 use openshell_core::driver_mounts;
 use openshell_core::driver_utils::{
-    LABEL_MANAGED_BY, LABEL_MANAGED_BY_VALUE, LABEL_SANDBOX_ID, LABEL_SANDBOX_NAME,
-    LABEL_SANDBOX_NAMESPACE, LABEL_SANDBOX_WORKSPACE, SUPERVISOR_IMAGE_BINARY_PATH,
-    extract_first_tar_entry, supervisor_image_should_refresh, temp_extract_container_name,
-    validate_linux_elf_binary, write_cache_binary_atomic,
+    CONDITION_EXITED, CONDITION_RUNTIME_RESTART, LABEL_MANAGED_BY, LABEL_MANAGED_BY_VALUE,
+    LABEL_SANDBOX_ID, LABEL_SANDBOX_NAME, LABEL_SANDBOX_NAMESPACE, LABEL_SANDBOX_WORKSPACE,
+    SUPERVISOR_IMAGE_BINARY_PATH, extract_first_tar_entry, supervisor_image_should_refresh,
+    temp_extract_container_name, validate_linux_elf_binary, write_cache_binary_atomic,
 };
 use openshell_core::gpu::{
     CdiGpuDefaultSelector, CdiGpuInventory, CdiGpuSelectionError, driver_gpu_requirements,
@@ -688,10 +688,37 @@ impl DockerComputeDriver {
 
     async fn current_snapshots(&self) -> Result<Vec<DriverSandbox>, Status> {
         let containers = self.list_managed_container_summaries().await?;
-        let container_sandboxes = containers
-            .iter()
-            .filter_map(sandbox_from_container_summary)
-            .collect::<Vec<_>>();
+        let mut container_sandboxes = Vec::with_capacity(containers.len());
+        for summary in &containers {
+            let Some(mut sandbox) = sandbox_from_container_summary(summary) else {
+                continue;
+            };
+            // Docker's list summary carries no exit code, so an exited
+            // container is reported as the generic terminal `ContainerExited`.
+            // Inspect it to tell a machine/daemon-restart signal kill apart
+            // from an ordinary application exit, mirroring the Podman driver,
+            // so startup recovery can revive restart victims while leaving
+            // crashes terminal.
+            if summary.state == Some(ContainerSummaryStateEnum::EXITED)
+                && let Some(container_id) = summary.id.as_deref()
+            {
+                match self.docker.inspect_container(container_id, None).await {
+                    Ok(inspected) => {
+                        if let Some(state) = inspected.state.as_ref() {
+                            apply_docker_exit_classification(&mut sandbox, state);
+                        }
+                    }
+                    Err(err) => {
+                        debug!(
+                            container_id,
+                            error = %err,
+                            "Could not inspect exited Docker container to classify its exit"
+                        );
+                    }
+                }
+            }
+            container_sandboxes.push(sandbox);
+        }
         let mut by_id = self.pending_snapshot_map().await;
         for sandbox in container_sandboxes {
             by_id.insert(sandbox.id.clone(), sandbox);
@@ -3092,6 +3119,34 @@ fn driver_status_from_summary(
     }
 }
 
+/// Refine an exited Docker sandbox's `Ready` condition from inspected state.
+///
+/// A signal kill (exit 137/143 = SIGKILL/SIGTERM, not OOM) is the signature of
+/// a machine/daemon restart terminating a running container. Reclassify it from
+/// the generic terminal `ContainerExited` to the recoverable
+/// `ContainerRuntimeRestart` so gateway startup can revive it. OOM kills and
+/// ordinary application exits stay `ContainerExited` and terminal.
+fn apply_docker_exit_classification(sandbox: &mut DriverSandbox, state: &ContainerState) {
+    if state.oom_killed == Some(true) {
+        return;
+    }
+    let Some(code) = state.exit_code.filter(|&code| matches!(code, 137 | 143)) else {
+        return;
+    };
+    let Some(condition) = sandbox
+        .status
+        .as_mut()
+        .and_then(|status| status.conditions.iter_mut().find(|c| c.r#type == "Ready"))
+    else {
+        return;
+    };
+    if condition.reason != CONDITION_EXITED {
+        return;
+    }
+    condition.reason = CONDITION_RUNTIME_RESTART.to_string();
+    condition.message = format!("Container terminated by signal (exit code {code})");
+}
+
 fn container_ready_condition(
     state: ContainerSummaryStateEnum,
 ) -> (&'static str, &'static str, &'static str, bool) {
@@ -3115,12 +3170,7 @@ fn container_ready_condition(
         ContainerSummaryStateEnum::PAUSED => {
             ("False", "ContainerPaused", "Container is paused", false)
         }
-        ContainerSummaryStateEnum::EXITED => (
-            "False",
-            openshell_core::driver_utils::CONDITION_EXITED,
-            "Container exited",
-            false,
-        ),
+        ContainerSummaryStateEnum::EXITED => ("False", CONDITION_EXITED, "Container exited", false),
         ContainerSummaryStateEnum::DEAD => ("False", "ContainerDead", "Container is dead", false),
     }
 }

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -3116,7 +3116,12 @@ fn container_ready_condition(
             ("False", "ContainerPaused", "Container is paused", false)
         }
         ContainerSummaryStateEnum::EXITED => {
-            ("False", "ContainerExited", "Container exited", false)
+            (
+                "False",
+                openshell_core::driver_utils::CONDITION_EXITED,
+                "Container exited",
+                false,
+            )
         }
         ContainerSummaryStateEnum::DEAD => ("False", "ContainerDead", "Container is dead", false),
     }

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -3115,14 +3115,12 @@ fn container_ready_condition(
         ContainerSummaryStateEnum::PAUSED => {
             ("False", "ContainerPaused", "Container is paused", false)
         }
-        ContainerSummaryStateEnum::EXITED => {
-            (
-                "False",
-                openshell_core::driver_utils::CONDITION_EXITED,
-                "Container exited",
-                false,
-            )
-        }
+        ContainerSummaryStateEnum::EXITED => (
+            "False",
+            openshell_core::driver_utils::CONDITION_EXITED,
+            "Container exited",
+            false,
+        ),
         ContainerSummaryStateEnum::DEAD => ("False", "ContainerDead", "Container is dead", false),
     }
 }

--- a/crates/openshell-driver-docker/src/tests.rs
+++ b/crates/openshell-driver-docker/src/tests.rs
@@ -2647,3 +2647,88 @@ fn lifecycle_fence_rejects_polled_exit_from_before_restart() {
     fences.remove("sandbox-1");
     assert!(fences.previous_exit("sandbox-1").is_none());
 }
+
+fn exited_sandbox_with_ready_reason(reason: &str) -> DriverSandbox {
+    DriverSandbox {
+        id: "sbx-exit".to_string(),
+        name: "demo".to_string(),
+        namespace: String::new(),
+        spec: None,
+        status: Some(DriverSandboxStatus {
+            sandbox_name: "demo".to_string(),
+            instance_id: "container-1".to_string(),
+            agent_fd: String::new(),
+            sandbox_fd: String::new(),
+            conditions: vec![DriverCondition {
+                r#type: "Ready".to_string(),
+                status: "False".to_string(),
+                reason: reason.to_string(),
+                message: "Container exited".to_string(),
+                last_transition_time: String::new(),
+            }],
+            deleting: false,
+        }),
+        workspace: String::new(),
+    }
+}
+
+fn ready_reason(sandbox: &DriverSandbox) -> &str {
+    sandbox
+        .status
+        .as_ref()
+        .and_then(|status| status.conditions.iter().find(|c| c.r#type == "Ready"))
+        .map(|c| c.reason.as_str())
+        .expect("Ready condition present")
+}
+
+#[test]
+fn docker_signal_kill_reclassified_as_runtime_restart() {
+    // 137 (128+SIGKILL) and 143 (128+SIGTERM) mark an external termination —
+    // the signature of a machine/daemon restart — and become recoverable
+    // `ContainerRuntimeRestart`.
+    for exit_code in [137, 143] {
+        let mut sandbox = exited_sandbox_with_ready_reason(CONDITION_EXITED);
+        let state = ContainerState {
+            status: Some(ContainerStateStatusEnum::EXITED),
+            oom_killed: Some(false),
+            exit_code: Some(exit_code),
+            ..Default::default()
+        };
+        apply_docker_exit_classification(&mut sandbox, &state);
+        assert_eq!(
+            ready_reason(&sandbox),
+            CONDITION_RUNTIME_RESTART,
+            "exit code {exit_code} should reclassify as runtime restart"
+        );
+    }
+}
+
+#[test]
+fn docker_ordinary_exit_stays_terminal() {
+    // An application exit (non-zero error code) stays `ContainerExited` so its
+    // failure signal survives instead of being relaunched on startup.
+    let mut sandbox = exited_sandbox_with_ready_reason(CONDITION_EXITED);
+    let state = ContainerState {
+        status: Some(ContainerStateStatusEnum::EXITED),
+        oom_killed: Some(false),
+        exit_code: Some(1),
+        ..Default::default()
+    };
+    apply_docker_exit_classification(&mut sandbox, &state);
+    assert_eq!(ready_reason(&sandbox), CONDITION_EXITED);
+}
+
+#[test]
+fn docker_oom_kill_stays_terminal_despite_137() {
+    // An OOM kill reports exit 137 but must NOT be treated as a recoverable
+    // restart — it is a genuine failure and stays terminal.
+    let mut sandbox = exited_sandbox_with_ready_reason(CONDITION_EXITED);
+    let state = ContainerState {
+        status: Some(ContainerStateStatusEnum::EXITED),
+        oom_killed: Some(true),
+        exit_code: Some(137),
+        ..Default::default()
+    };
+    apply_docker_exit_classification(&mut sandbox, &state);
+    assert_eq!(ready_reason(&sandbox), CONDITION_EXITED);
+}

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -704,6 +704,25 @@ impl PodmanComputeDriver {
         Ok(!entries.is_empty())
     }
 
+    /// Resume an exited sandbox container. Returns `Ok(true)` if the
+    /// container exists and was (re)started, `Ok(false)` if it is gone.
+    pub async fn resume_sandbox(&self, sandbox_name: &str) -> Result<bool, ComputeDriverError> {
+        let name = container::container_name(sandbox_name);
+        let inspect = match self.client.inspect_container(&name).await {
+            Ok(i) => i,
+            Err(PodmanApiError::NotFound(_)) => return Ok(false),
+            Err(e) => return Err(ComputeDriverError::from(e)),
+        };
+        if inspect.state.running {
+            return Ok(true);
+        }
+        match self.client.start_container(&name).await {
+            Ok(()) => Ok(true),
+            Err(PodmanApiError::NotFound(_)) => Ok(false),
+            Err(e) => Err(ComputeDriverError::from(e)),
+        }
+    }
+
     /// Fetch a single sandbox by ID.
     pub async fn get_sandbox(
         &self,

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -706,17 +706,20 @@ impl PodmanComputeDriver {
 
     /// Resume an exited sandbox container. Returns `Ok(true)` if the
     /// container exists and was (re)started, `Ok(false)` if it is gone.
-    pub async fn resume_sandbox(&self, sandbox_name: &str) -> Result<bool, ComputeDriverError> {
-        let name = container::container_name(sandbox_name);
-        let inspect = match self.client.inspect_container(&name).await {
-            Ok(i) => i,
-            Err(PodmanApiError::NotFound(_)) => return Ok(false),
-            Err(e) => return Err(ComputeDriverError::from(e)),
+    pub async fn resume_sandbox(&self, sandbox_id: &str) -> Result<bool, ComputeDriverError> {
+        let id_filter = format!("{LABEL_SANDBOX_ID}={sandbox_id}");
+        let entries = self
+            .client
+            .list_containers(&[LABEL_MANAGED_FILTER, &id_filter])
+            .await
+            .map_err(ComputeDriverError::from)?;
+        let Some(entry) = entries.first() else {
+            return Ok(false);
         };
-        if inspect.state.running {
+        if entry.state == "running" {
             return Ok(true);
         }
-        match self.client.start_container(&name).await {
+        match self.client.start_container(&entry.id).await {
             Ok(()) => Ok(true),
             Err(PodmanApiError::NotFound(_)) => Ok(false),
             Err(e) => Err(ComputeDriverError::from(e)),

--- a/crates/openshell-driver-podman/src/watcher.rs
+++ b/crates/openshell-driver-podman/src/watcher.rs
@@ -26,8 +26,7 @@ use tracing::{debug, info, warn};
 // Condition reason constants shared across event-building paths.
 const CONDITION_RUNNING: &str = "ContainerRunning";
 const CONDITION_STARTING: &str = "ContainerStarting";
-const CONDITION_EXITED: &str = "ContainerExited";
-const CONDITION_STOPPED: &str = "ContainerStopped";
+use openshell_core::driver_utils::{CONDITION_EXITED, CONDITION_STOPPED};
 
 pub type WatchStream =
     Pin<Box<dyn Stream<Item = Result<WatchSandboxesEvent, ComputeDriverError>> + Send>>;

--- a/crates/openshell-driver-podman/src/watcher.rs
+++ b/crates/openshell-driver-podman/src/watcher.rs
@@ -24,8 +24,7 @@ use tracing::{debug, info, warn};
 // Condition reason constants shared across event-building paths.
 const CONDITION_RUNNING: &str = "ContainerRunning";
 const CONDITION_STARTING: &str = "ContainerStarting";
-const CONDITION_EXITED: &str = "ContainerExited";
-const CONDITION_STOPPED: &str = "ContainerStopped";
+use openshell_core::driver_utils::{CONDITION_EXITED, CONDITION_STOPPED};
 
 pub type WatchStream =
     Pin<Box<dyn Stream<Item = Result<WatchSandboxesEvent, ComputeDriverError>> + Send>>;

--- a/crates/openshell-driver-podman/src/watcher.rs
+++ b/crates/openshell-driver-podman/src/watcher.rs
@@ -26,7 +26,9 @@ use tracing::{debug, info, warn};
 // Condition reason constants shared across event-building paths.
 const CONDITION_RUNNING: &str = "ContainerRunning";
 const CONDITION_STARTING: &str = "ContainerStarting";
-use openshell_core::driver_utils::{CONDITION_EXITED, CONDITION_STOPPED};
+use openshell_core::driver_utils::{
+    CONDITION_EXITED, CONDITION_RUNTIME_RESTART, CONDITION_STOPPED,
+};
 
 pub type WatchStream =
     Pin<Box<dyn Stream<Item = Result<WatchSandboxesEvent, ComputeDriverError>> + Send>>;
@@ -444,15 +446,29 @@ fn condition_from_state(state: &ContainerState) -> DriverCondition {
         },
         "created" => ("False", "ContainerCreated", String::new()),
         "exited" | "stopped" => {
-            let msg = if state.oom_killed {
-                "Container was killed by the OOM killer".to_string()
+            // Exit codes 137 (128+SIGKILL) and 143 (128+SIGTERM) mean the
+            // container was terminated by an external signal rather than
+            // exiting on its own — the signature of a machine/daemon restart
+            // killing running containers. Those are recoverable at gateway
+            // startup; ordinary application exits (0, non-zero, faults) are not.
+            let (reason, msg) = if state.oom_killed {
+                (
+                    "OOMKilled",
+                    "Container was killed by the OOM killer".to_string(),
+                )
+            } else if matches!(state.exit_code, 137 | 143) {
+                (
+                    CONDITION_RUNTIME_RESTART,
+                    format!(
+                        "Container terminated by signal (exit code {})",
+                        state.exit_code
+                    ),
+                )
             } else {
-                format!("Container exited with code {}", state.exit_code)
-            };
-            let reason = if state.oom_killed {
-                "OOMKilled"
-            } else {
-                CONDITION_EXITED
+                (
+                    CONDITION_EXITED,
+                    format!("Container exited with code {}", state.exit_code),
+                )
             };
             ("False", reason, msg)
         }
@@ -597,6 +613,32 @@ mod tests {
         assert_eq!(cond.status, "False");
         assert_eq!(cond.reason, "ContainerExited");
         assert!(cond.message.contains("code 1"));
+    }
+
+    #[test]
+    fn condition_signal_kill_is_runtime_restart() {
+        // 137 (128+SIGKILL) and 143 (128+SIGTERM) are external terminations —
+        // the signature of a machine/daemon restart. They classify as
+        // recoverable `ContainerRuntimeRestart`, distinct from an ordinary
+        // application exit.
+        for exit_code in [137, 143] {
+            let state = ContainerState {
+                status: "exited".to_string(),
+                running: false,
+                exit_code,
+                oom_killed: false,
+                health: None,
+                started_at: None,
+                finished_at: Some("2026-04-14T12:30:00Z".to_string()),
+            };
+            let cond = condition_from_state(&state);
+            assert_eq!(cond.status, "False");
+            assert_eq!(
+                cond.reason, "ContainerRuntimeRestart",
+                "exit code {exit_code} should classify as runtime restart"
+            );
+            assert!(cond.message.contains(&format!("code {exit_code}")));
+        }
     }
 
     #[test]

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -115,8 +115,8 @@ impl StartupResume for DockerComputeDriver {
 }
 #[tonic::async_trait]
 impl StartupResume for PodmanComputeDriver {
-    async fn resume_sandbox(&self, _sandbox_id: &str, sandbox_name: &str) -> Result<bool, String> {
-        Self::resume_sandbox(self, sandbox_name)
+    async fn resume_sandbox(&self, sandbox_id: &str, _sandbox_name: &str) -> Result<bool, String> {
+        Self::resume_sandbox(self, sandbox_id)
             .await
             .map_err(|err| err.to_string())
     }

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -113,6 +113,15 @@ impl StartupResume for DockerComputeDriver {
             .map_err(|err| err.to_string())
     }
 }
+#[tonic::async_trait]
+impl StartupResume for PodmanComputeDriver {
+    async fn resume_sandbox(&self, _sandbox_id: &str, sandbox_name: &str) -> Result<bool, String> {
+        Self::resume_sandbox(self, sandbox_name)
+            .await
+            .map_err(|err| err.to_string())
+    }
+}
+
 /// Interval between store-vs-backend reconciliation sweeps.
 const RECONCILE_INTERVAL: Duration = Duration::from_secs(60);
 
@@ -454,12 +463,13 @@ impl ComputeRuntime {
         let driver = PodmanComputeDriver::new(config)
             .await
             .map_err(|err| ComputeError::Message(err.to_string()))?;
+        let startup_resume: Arc<dyn StartupResume> = Arc::new(driver.clone());
         let driver: SharedComputeDriver = Arc::new(PodmanDriverService::new(driver));
         Self::from_driver(
             ComputeDriverKind::Podman.as_str().to_string(),
             driver,
             None,
-            None,
+            Some(startup_resume),
             None,
             store,
             sandbox_index,
@@ -779,11 +789,12 @@ impl ComputeRuntime {
     /// Resume sandboxes whose store records say they should be running.
     /// Drivers that do not auto-restart compute resources across gateway
     /// restarts (currently only Docker) implement `StartupResume`. For
-    /// each sandbox in the store whose phase is not `Deleting` or
-    /// `Error`, we ask the driver to resume the underlying resource. If
-    /// the driver reports that the resource no longer exists or fails to
-    /// start, the sandbox is moved to the `Error` phase so the failure
-    /// surfaces in the UI.
+    /// each sandbox in the store whose phase is not `Deleting`, we ask
+    /// the driver to resume the underlying resource. Error-phase
+    /// sandboxes are included: if the container still exists (e.g. after
+    /// a Podman machine restart), it is restarted and the sandbox is
+    /// moved back to `Provisioning`. If the container is gone or the
+    /// driver fails, the sandbox stays in `Error`.
     ///
     /// Should be called once at gateway startup, before watchers spawn,
     /// so the watch loop sees the post-resume state on its first poll.
@@ -799,6 +810,7 @@ impl ComputeRuntime {
             .map_err(|e| e.to_string())?;
 
         let mut resumed = 0usize;
+        let mut recovered = 0usize;
         let mut missing = 0usize;
         let mut failed = 0usize;
 
@@ -812,40 +824,45 @@ impl ComputeRuntime {
             };
 
             let phase = SandboxPhase::try_from(sandbox.phase()).unwrap_or(SandboxPhase::Unknown);
-            if !sandbox_phase_should_be_running(phase) {
+            if phase == SandboxPhase::Deleting {
                 continue;
             }
+            let sandbox_error = phase == SandboxPhase::Error;
 
             match resume
                 .resume_sandbox(sandbox.object_id(), sandbox.object_name())
                 .await
             {
                 Ok(true) => {
+                    if sandbox_error {
+                        self.clear_sandbox_error(&sandbox).await;
+                    }
                     info!(
                         sandbox_id = %sandbox.object_id(),
                         sandbox_name = %sandbox.object_name(),
                         ?phase,
+                        recovered = sandbox_error,
                         "Resumed sandbox during gateway startup"
                     );
                     resumed += 1;
+                    if sandbox_error {
+                        recovered += 1;
+                    }
                 }
                 Ok(false) => {
-                    // Backend resource is gone but the store still
-                    // remembers the sandbox. Mark Error so the UI
-                    // surfaces the inconsistency; the reconcile loop
-                    // will eventually prune it after the orphan grace
-                    // period.
                     warn!(
                         sandbox_id = %sandbox.object_id(),
                         sandbox_name = %sandbox.object_name(),
                         "Cannot resume sandbox: backend resource is missing"
                     );
-                    self.mark_sandbox_error(
-                        &sandbox,
-                        "BackendResourceMissing",
-                        "Sandbox container disappeared while the gateway was offline",
-                    )
-                    .await;
+                    if !sandbox_error {
+                        self.mark_sandbox_error(
+                            &sandbox,
+                            "BackendResourceMissing",
+                            "Sandbox container disappeared while the gateway was offline",
+                        )
+                        .await;
+                    }
                     missing += 1;
                 }
                 Err(err) => {
@@ -855,12 +872,14 @@ impl ComputeRuntime {
                         error = %err,
                         "Failed to resume sandbox during gateway startup"
                     );
-                    self.mark_sandbox_error(
-                        &sandbox,
-                        "ResumeFailed",
-                        &format!("Failed to resume sandbox during gateway startup: {err}"),
-                    )
-                    .await;
+                    if !sandbox_error {
+                        self.mark_sandbox_error(
+                            &sandbox,
+                            "ResumeFailed",
+                            &format!("Failed to resume sandbox during gateway startup: {err}"),
+                        )
+                        .await;
+                    }
                     failed += 1;
                 }
             }
@@ -869,6 +888,7 @@ impl ComputeRuntime {
         if resumed > 0 || missing > 0 || failed > 0 {
             info!(
                 resumed,
+                recovered,
                 missing_backend = missing,
                 failed,
                 "Sandbox resume sweep complete"
@@ -910,6 +930,42 @@ impl ComputeRuntime {
                     sandbox_id = %sandbox_id,
                     error = %err,
                     "Failed to persist sandbox error state during startup resume"
+                );
+            }
+        }
+    }
+
+    async fn clear_sandbox_error(&self, sandbox: &Sandbox) {
+        let _guard = self.sync_lock.lock().await;
+        let sandbox_id = sandbox.object_id().to_string();
+        match self
+            .store
+            .update_message_cas::<Sandbox, _>(&sandbox_id, 0, |s| {
+                s.set_phase(SandboxPhase::Provisioning as i32);
+                let name = s.object_name().to_string();
+                upsert_ready_condition(
+                    &mut s.status,
+                    &name,
+                    SandboxCondition {
+                        r#type: "Ready".to_string(),
+                        status: "False".to_string(),
+                        reason: "Resumed".to_string(),
+                        message: "Sandbox recovered during gateway startup".to_string(),
+                        last_transition_time: String::new(),
+                    },
+                );
+            })
+            .await
+        {
+            Ok(updated) => {
+                self.sandbox_index.update_from_sandbox(&updated);
+                self.sandbox_watch_bus.notify(&sandbox_id);
+            }
+            Err(err) => {
+                warn!(
+                    sandbox_id = %sandbox_id,
+                    error = %err,
+                    "Failed to clear sandbox error state during startup resume"
                 );
             }
         }
@@ -2068,22 +2124,6 @@ fn rewrite_user_facing_conditions(status: &mut Option<SandboxStatus>, spec: Opti
             }
         }
     }
-}
-
-/// Phases for which a sandbox should have a running compute resource.
-/// `Deleting` and `Error` are intentionally excluded: deletion is in
-/// progress, or the sandbox has already failed and should not be
-/// silently revived. `Unspecified` is included because it is the proto
-/// default value; persisted rows with that value should be reconciled
-/// from the live driver state rather than skipped forever.
-fn sandbox_phase_should_be_running(phase: SandboxPhase) -> bool {
-    matches!(
-        phase,
-        SandboxPhase::Unspecified
-            | SandboxPhase::Provisioning
-            | SandboxPhase::Ready
-            | SandboxPhase::Unknown
-    )
 }
 
 fn is_terminal_failure_reason(reason: &str) -> bool {
@@ -3472,6 +3512,7 @@ mod tests {
         assert_eq!(
             called_ids,
             vec![
+                "sb-error".to_string(),
                 "sb-prov".to_string(),
                 "sb-ready".to_string(),
                 "sb-unknown".to_string(),
@@ -3560,6 +3601,92 @@ mod tests {
         assert_eq!(
             SandboxPhase::try_from(stored.phase()).unwrap(),
             SandboxPhase::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_persisted_sandboxes_recovers_error_phase_when_container_exists() {
+        let resume = Arc::new(RecordingResume::default());
+        resume.set_result("sb-err-recover", Ok(true)).await;
+        let runtime =
+            test_runtime_with_resume(Arc::new(TestDriver::default()), Some(resume.clone())).await;
+
+        let sandbox = sandbox_record("sb-err-recover", "recover", SandboxPhase::Error);
+        runtime.store.put_message(&sandbox).await.unwrap();
+
+        runtime.resume_persisted_sandboxes().await.unwrap();
+
+        assert_eq!(resume.calls().await.len(), 1);
+
+        let stored = runtime
+            .store
+            .get_message::<Sandbox>("sb-err-recover")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            SandboxPhase::try_from(stored.phase()).unwrap(),
+            SandboxPhase::Provisioning
+        );
+        let ready = stored
+            .status
+            .as_ref()
+            .and_then(|s| s.conditions.iter().find(|c| c.r#type == "Ready"))
+            .expect("Ready condition present");
+        assert_eq!(ready.reason, "Resumed");
+    }
+
+    #[tokio::test]
+    async fn resume_persisted_sandboxes_leaves_error_when_container_missing() {
+        let resume = Arc::new(RecordingResume::default());
+        resume.set_result("sb-err-gone", Ok(false)).await;
+        let runtime =
+            test_runtime_with_resume(Arc::new(TestDriver::default()), Some(resume.clone())).await;
+
+        let sandbox = sandbox_record("sb-err-gone", "gone", SandboxPhase::Error);
+        runtime.store.put_message(&sandbox).await.unwrap();
+
+        runtime.resume_persisted_sandboxes().await.unwrap();
+
+        assert_eq!(resume.calls().await.len(), 1);
+
+        let stored = runtime
+            .store
+            .get_message::<Sandbox>("sb-err-gone")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            SandboxPhase::try_from(stored.phase()).unwrap(),
+            SandboxPhase::Error
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_persisted_sandboxes_leaves_error_when_resume_fails() {
+        let resume = Arc::new(RecordingResume::default());
+        resume
+            .set_result("sb-err-fail", Err("docker broke".to_string()))
+            .await;
+        let runtime =
+            test_runtime_with_resume(Arc::new(TestDriver::default()), Some(resume.clone())).await;
+
+        let sandbox = sandbox_record("sb-err-fail", "fail", SandboxPhase::Error);
+        runtime.store.put_message(&sandbox).await.unwrap();
+
+        runtime.resume_persisted_sandboxes().await.unwrap();
+
+        assert_eq!(resume.calls().await.len(), 1);
+
+        let stored = runtime
+            .store
+            .get_message::<Sandbox>("sb-err-fail")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            SandboxPhase::try_from(stored.phase()).unwrap(),
+            SandboxPhase::Error
         );
     }
 

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -827,25 +827,31 @@ impl ComputeRuntime {
             if phase == SandboxPhase::Deleting {
                 continue;
             }
-            let sandbox_error = phase == SandboxPhase::Error;
+            let recoverable_error = phase == SandboxPhase::Error
+                && is_recoverable_error_reason(&sandbox);
+            if phase == SandboxPhase::Error && !recoverable_error {
+                continue;
+            }
 
             match resume
                 .resume_sandbox(sandbox.object_id(), sandbox.object_name())
                 .await
             {
                 Ok(true) => {
-                    if sandbox_error {
-                        self.clear_sandbox_error(&sandbox).await;
-                    }
+                    let did_recover = if recoverable_error {
+                        self.clear_recoverable_error(&sandbox).await
+                    } else {
+                        false
+                    };
                     info!(
                         sandbox_id = %sandbox.object_id(),
                         sandbox_name = %sandbox.object_name(),
                         ?phase,
-                        recovered = sandbox_error,
+                        recovered = did_recover,
                         "Resumed sandbox during gateway startup"
                     );
                     resumed += 1;
-                    if sandbox_error {
+                    if did_recover {
                         recovered += 1;
                     }
                 }
@@ -855,7 +861,7 @@ impl ComputeRuntime {
                         sandbox_name = %sandbox.object_name(),
                         "Cannot resume sandbox: backend resource is missing"
                     );
-                    if !sandbox_error {
+                    if !recoverable_error {
                         self.mark_sandbox_error(
                             &sandbox,
                             "BackendResourceMissing",
@@ -872,7 +878,7 @@ impl ComputeRuntime {
                         error = %err,
                         "Failed to resume sandbox during gateway startup"
                     );
-                    if !sandbox_error {
+                    if !recoverable_error {
                         self.mark_sandbox_error(
                             &sandbox,
                             "ResumeFailed",
@@ -935,7 +941,7 @@ impl ComputeRuntime {
         }
     }
 
-    async fn clear_sandbox_error(&self, sandbox: &Sandbox) {
+    async fn clear_recoverable_error(&self, sandbox: &Sandbox) -> bool {
         let _guard = self.sync_lock.lock().await;
         let sandbox_id = sandbox.object_id().to_string();
         match self
@@ -960,6 +966,7 @@ impl ComputeRuntime {
             Ok(updated) => {
                 self.sandbox_index.update_from_sandbox(&updated);
                 self.sandbox_watch_bus.notify(&sandbox_id);
+                true
             }
             Err(err) => {
                 warn!(
@@ -967,6 +974,7 @@ impl ComputeRuntime {
                     error = %err,
                     "Failed to clear sandbox error state during startup resume"
                 );
+                false
             }
         }
     }
@@ -2126,6 +2134,19 @@ fn rewrite_user_facing_conditions(status: &mut Option<SandboxStatus>, spec: Opti
     }
 }
 
+/// Error-phase sandboxes are only eligible for startup recovery when
+/// their Ready condition reason indicates a container exit or stop —
+/// i.e. the runtime went away (machine restart, daemon restart) rather
+/// than a genuine application or infrastructure failure.
+fn is_recoverable_error_reason(sandbox: &Sandbox) -> bool {
+    use openshell_core::driver_utils::{CONDITION_EXITED, CONDITION_STOPPED};
+    sandbox
+        .status
+        .as_ref()
+        .and_then(|s| s.conditions.iter().find(|c| c.r#type == "Ready"))
+        .is_some_and(|c| c.reason == CONDITION_EXITED || c.reason == CONDITION_STOPPED)
+}
+
 fn is_terminal_failure_reason(reason: &str) -> bool {
     let reason = reason.to_ascii_lowercase();
     let transient_reasons = [
@@ -2542,6 +2563,19 @@ mod tests {
             ..Default::default()
         };
         sandbox.set_phase(phase as i32);
+        sandbox
+    }
+
+    fn error_sandbox_record(id: &str, name: &str, reason: &str) -> Sandbox {
+        let mut sandbox = sandbox_record(id, name, SandboxPhase::Error);
+        let status = sandbox.status.get_or_insert_with(Default::default);
+        status.conditions.push(SandboxCondition {
+            r#type: "Ready".to_string(),
+            status: "False".to_string(),
+            reason: reason.to_string(),
+            message: String::new(),
+            last_transition_time: String::new(),
+        });
         sandbox
     }
 
@@ -3494,11 +3528,12 @@ mod tests {
             ("sb-ready", "ready", SandboxPhase::Ready),
             ("sb-unknown", "unknown", SandboxPhase::Unknown),
             ("sb-deleting", "deleting", SandboxPhase::Deleting),
-            ("sb-error", "error", SandboxPhase::Error),
         ] {
             let sandbox = sandbox_record(id, name, phase);
             runtime.store.put_message(&sandbox).await.unwrap();
         }
+        let error_sb = error_sandbox_record("sb-error", "error", "ContainerExited");
+        runtime.store.put_message(&error_sb).await.unwrap();
 
         runtime.resume_persisted_sandboxes().await.unwrap();
 
@@ -3611,7 +3646,7 @@ mod tests {
         let runtime =
             test_runtime_with_resume(Arc::new(TestDriver::default()), Some(resume.clone())).await;
 
-        let sandbox = sandbox_record("sb-err-recover", "recover", SandboxPhase::Error);
+        let sandbox = error_sandbox_record("sb-err-recover", "recover", "ContainerExited");
         runtime.store.put_message(&sandbox).await.unwrap();
 
         runtime.resume_persisted_sandboxes().await.unwrap();
@@ -3643,7 +3678,7 @@ mod tests {
         let runtime =
             test_runtime_with_resume(Arc::new(TestDriver::default()), Some(resume.clone())).await;
 
-        let sandbox = sandbox_record("sb-err-gone", "gone", SandboxPhase::Error);
+        let sandbox = error_sandbox_record("sb-err-gone", "gone", "ContainerExited");
         runtime.store.put_message(&sandbox).await.unwrap();
 
         runtime.resume_persisted_sandboxes().await.unwrap();
@@ -3671,7 +3706,7 @@ mod tests {
         let runtime =
             test_runtime_with_resume(Arc::new(TestDriver::default()), Some(resume.clone())).await;
 
-        let sandbox = sandbox_record("sb-err-fail", "fail", SandboxPhase::Error);
+        let sandbox = error_sandbox_record("sb-err-fail", "fail", "ContainerExited");
         runtime.store.put_message(&sandbox).await.unwrap();
 
         runtime.resume_persisted_sandboxes().await.unwrap();
@@ -3681,6 +3716,32 @@ mod tests {
         let stored = runtime
             .store
             .get_message::<Sandbox>("sb-err-fail")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            SandboxPhase::try_from(stored.phase()).unwrap(),
+            SandboxPhase::Error
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_persisted_sandboxes_skips_non_recoverable_error() {
+        let resume = Arc::new(RecordingResume::default());
+        let runtime =
+            test_runtime_with_resume(Arc::new(TestDriver::default()), Some(resume.clone())).await;
+
+        let sandbox =
+            error_sandbox_record("sb-err-perm", "perm", "BackendResourceMissing");
+        runtime.store.put_message(&sandbox).await.unwrap();
+
+        runtime.resume_persisted_sandboxes().await.unwrap();
+
+        assert!(resume.calls().await.is_empty());
+
+        let stored = runtime
+            .store
+            .get_message::<Sandbox>("sb-err-perm")
             .await
             .unwrap()
             .unwrap();

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -2147,9 +2147,11 @@ impl ComputeRuntime {
     /// requires running compute for drivers that request gateway-managed
     /// lifecycle. Stable stopped and deleting states are deliberately left
     /// alone. Error-phase sandboxes are included only when their Ready
-    /// condition indicates a container exit or stop (e.g. after a Podman/Docker
-    /// machine restart): if the container still exists it is restarted and the
-    /// sandbox is moved back to `Provisioning`; otherwise it stays in `Error`.
+    /// condition indicates the runtime went away underneath a running container
+    /// — a signal-kill from a machine/daemon restart or an explicit runtime
+    /// stop. If the container still exists it is restarted and the sandbox is
+    /// moved back to `Provisioning`; otherwise it stays in `Error`. Ordinary
+    /// application exits and crashes stay terminal and are not relaunched.
     ///
     /// Should be called once at gateway startup, before watchers spawn,
     /// so the watch loop sees the post-start state on its first poll.
@@ -4109,16 +4111,19 @@ fn sandbox_phase_should_be_running(phase: SandboxPhase) -> bool {
 }
 
 /// Error-phase sandboxes are only eligible for startup recovery when their
-/// Ready condition reason indicates a container exit or stop — i.e. the
-/// runtime went away (machine restart, daemon restart) rather than a genuine
-/// application or infrastructure failure.
+/// Ready condition reason indicates the runtime went away underneath a running
+/// container — a machine/daemon restart that terminated it by signal
+/// (`CONDITION_RUNTIME_RESTART`) or an explicit runtime stop
+/// (`CONDITION_STOPPED`). Ordinary application exits (`CONDITION_EXITED`, which
+/// covers crashes and non-zero exits) stay terminal so a genuine failure keeps
+/// its error signal instead of being relaunched on every gateway startup.
 fn is_recoverable_error_reason(sandbox: &Sandbox) -> bool {
-    use openshell_core::driver_utils::{CONDITION_EXITED, CONDITION_STOPPED};
+    use openshell_core::driver_utils::{CONDITION_RUNTIME_RESTART, CONDITION_STOPPED};
     sandbox
         .status
         .as_ref()
         .and_then(|s| s.conditions.iter().find(|c| c.r#type == "Ready"))
-        .is_some_and(|c| c.reason == CONDITION_EXITED || c.reason == CONDITION_STOPPED)
+        .is_some_and(|c| c.reason == CONDITION_RUNTIME_RESTART || c.reason == CONDITION_STOPPED)
 }
 
 fn is_terminal_failure_reason(reason: &str) -> bool {
@@ -8881,7 +8886,9 @@ mod tests {
             let sandbox = sandbox_record(id, name, phase);
             runtime.store.put_message(&sandbox).await.unwrap();
         }
-        // A non-recoverable error is skipped; a container-exit error is retried.
+        // Terminal errors are skipped: a backend-missing error and an ordinary
+        // container exit (crash) both stay in Error. Only a signal-kill from a
+        // machine/daemon restart is retried.
         runtime
             .store
             .put_message(&error_sandbox_record(
@@ -8900,6 +8907,15 @@ mod tests {
             ))
             .await
             .unwrap();
+        runtime
+            .store
+            .put_message(&error_sandbox_record(
+                "sb-error-restart",
+                "error-restart",
+                "ContainerRuntimeRestart",
+            ))
+            .await
+            .unwrap();
 
         runtime.start_persisted_sandboxes().await.unwrap();
 
@@ -8912,7 +8928,7 @@ mod tests {
         assert_eq!(
             called_ids,
             vec![
-                "sb-error-exit".to_string(),
+                "sb-error-restart".to_string(),
                 "sb-prov".to_string(),
                 "sb-ready".to_string(),
                 "sb-unknown".to_string(),
@@ -9088,7 +9104,7 @@ mod tests {
         // Default start outcome is Ok: the container is restarted successfully.
         let runtime = test_runtime_with_gateway_managed_lifecycle(driver.clone(), "podman").await;
 
-        let sandbox = error_sandbox_record("sb-err-recover", "recover", "ContainerExited");
+        let sandbox = error_sandbox_record("sb-err-recover", "recover", "ContainerRuntimeRestart");
         runtime.store.put_message(&sandbox).await.unwrap();
 
         runtime.start_persisted_sandboxes().await.unwrap();
@@ -9119,7 +9135,7 @@ mod tests {
         driver.set_start_outcome(ControlledLifecycleOutcome::NotFound);
         let runtime = test_runtime_with_gateway_managed_lifecycle(driver.clone(), "podman").await;
 
-        let sandbox = error_sandbox_record("sb-err-gone", "gone", "ContainerExited");
+        let sandbox = error_sandbox_record("sb-err-gone", "gone", "ContainerRuntimeRestart");
         runtime.store.put_message(&sandbox).await.unwrap();
 
         runtime.start_persisted_sandboxes().await.unwrap();
@@ -9142,7 +9158,7 @@ mod tests {
             .as_ref()
             .and_then(|s| s.conditions.iter().find(|c| c.r#type == "Ready"))
             .expect("Ready condition present");
-        assert_eq!(ready.reason, "ContainerExited");
+        assert_eq!(ready.reason, "ContainerRuntimeRestart");
     }
 
     #[tokio::test]
@@ -9199,6 +9215,42 @@ mod tests {
             SandboxPhase::try_from(stored.phase()).unwrap(),
             SandboxPhase::Error
         );
+    }
+
+    #[tokio::test]
+    async fn start_persisted_sandboxes_leaves_generic_container_exit_terminal() {
+        // A container that exited on its own — an ordinary application crash or
+        // non-zero exit — is stored as Error with `ContainerExited`. Startup
+        // recovery must NOT relaunch it: doing so would erase the failure
+        // signal and repeatedly revive a crash-prone workload. Only a
+        // signal-kill (`ContainerRuntimeRestart`) from a machine/daemon restart
+        // is recoverable.
+        let driver = ControlledDriver::new();
+        let runtime = test_runtime_with_gateway_managed_lifecycle(driver.clone(), "podman").await;
+
+        let sandbox = error_sandbox_record("sb-err-crash", "crash", "ContainerExited");
+        runtime.store.put_message(&sandbox).await.unwrap();
+
+        runtime.start_persisted_sandboxes().await.unwrap();
+
+        assert_eq!(driver.start_calls(), 0);
+
+        let stored = runtime
+            .store
+            .get_message::<Sandbox>("sb-err-crash")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            SandboxPhase::try_from(stored.phase()).unwrap(),
+            SandboxPhase::Error
+        );
+        let ready = stored
+            .status
+            .as_ref()
+            .and_then(|s| s.conditions.iter().find(|c| c.r#type == "Ready"))
+            .expect("Ready condition present");
+        assert_eq!(ready.reason, "ContainerExited");
     }
 
     #[test]

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -2145,8 +2145,11 @@ impl ComputeRuntime {
     ///
     /// `StartSandbox` is idempotent, so call it for every persisted phase that
     /// requires running compute for drivers that request gateway-managed
-    /// lifecycle. Stable stopped, deleting, and error states are deliberately
-    /// left alone.
+    /// lifecycle. Stable stopped and deleting states are deliberately left
+    /// alone. Error-phase sandboxes are included only when their Ready
+    /// condition indicates a container exit or stop (e.g. after a Podman/Docker
+    /// machine restart): if the container still exists it is restarted and the
+    /// sandbox is moved back to `Provisioning`; otherwise it stays in `Error`.
     ///
     /// Should be called once at gateway startup, before watchers spawn,
     /// so the watch loop sees the post-start state on its first poll.
@@ -2159,6 +2162,7 @@ impl ComputeRuntime {
         let sandbox_ids = self.list_persisted_sandbox_ids("gateway startup").await?;
 
         let mut started = 0usize;
+        let mut recovered = 0usize;
         let mut missing = 0usize;
         let mut failed = 0usize;
 
@@ -2179,7 +2183,9 @@ impl ComputeRuntime {
             };
 
             let phase = SandboxPhase::try_from(sandbox.phase()).unwrap_or(SandboxPhase::Unknown);
-            if !sandbox_phase_should_be_running(phase) {
+            let recoverable_error =
+                phase == SandboxPhase::Error && is_recoverable_error_reason(&sandbox);
+            if !sandbox_phase_should_be_running(phase) && !recoverable_error {
                 continue;
             }
 
@@ -2201,13 +2207,22 @@ impl ComputeRuntime {
                 .await
             {
                 Ok(_) => {
+                    let did_recover = if recoverable_error {
+                        self.clear_recoverable_error(&sandbox).await
+                    } else {
+                        false
+                    };
                     info!(
                         sandbox_id = %sandbox.object_id(),
                         sandbox_name = %sandbox.object_name(),
                         ?phase,
+                        recovered = did_recover,
                         "Started sandbox during gateway startup"
                     );
                     started += 1;
+                    if did_recover {
+                        recovered += 1;
+                    }
                 }
                 Err(err) if err.code() == Code::NotFound => {
                     // Backend resource is gone but the store still
@@ -2220,12 +2235,14 @@ impl ComputeRuntime {
                         sandbox_name = %sandbox.object_name(),
                         "Cannot start sandbox: backend resource is missing"
                     );
-                    self.mark_sandbox_error(
-                        &sandbox,
-                        "BackendResourceMissing",
-                        "Sandbox compute resource disappeared while the gateway was offline",
-                    )
-                    .await;
+                    if !recoverable_error {
+                        self.mark_sandbox_error(
+                            &sandbox,
+                            "BackendResourceMissing",
+                            "Sandbox compute resource disappeared while the gateway was offline",
+                        )
+                        .await;
+                    }
                     missing += 1;
                 }
                 Err(err) => {
@@ -2235,15 +2252,17 @@ impl ComputeRuntime {
                         error = %err,
                         "Failed to start sandbox during gateway startup"
                     );
-                    self.mark_sandbox_error(
-                        &sandbox,
-                        "StartFailed",
-                        &format!(
-                            "Failed to start sandbox during gateway startup: {}",
-                            err.message()
-                        ),
-                    )
-                    .await;
+                    if !recoverable_error {
+                        self.mark_sandbox_error(
+                            &sandbox,
+                            "StartFailed",
+                            &format!(
+                                "Failed to start sandbox during gateway startup: {}",
+                                err.message()
+                            ),
+                        )
+                        .await;
+                    }
                     failed += 1;
                 }
             }
@@ -2252,6 +2271,7 @@ impl ComputeRuntime {
         if started > 0 || missing > 0 || failed > 0 {
             info!(
                 started,
+                recovered,
                 missing_backend = missing,
                 failed,
                 "Sandbox start sweep complete"
@@ -2417,6 +2437,48 @@ impl ComputeRuntime {
                     error = %err,
                     "Failed to persist sandbox error state during gateway startup"
                 );
+            }
+        }
+    }
+
+    /// Clear a recoverable `Error` state after the underlying container has
+    /// been restarted during the startup sweep. Moves the sandbox back to
+    /// `Provisioning` with a `Resumed` Ready condition. Returns `true` if the
+    /// store update succeeded.
+    async fn clear_recoverable_error(&self, sandbox: &Sandbox) -> bool {
+        let _guard = self.sync_lock.lock().await;
+        let sandbox_id = sandbox.object_id().to_string();
+        match self
+            .store
+            .update_message_cas::<Sandbox, _>(&sandbox_id, 0, |s| {
+                s.set_phase(SandboxPhase::Provisioning as i32);
+                let name = s.object_name().to_string();
+                upsert_ready_condition(
+                    &mut s.status,
+                    &name,
+                    SandboxCondition {
+                        r#type: "Ready".to_string(),
+                        status: "False".to_string(),
+                        reason: "Resumed".to_string(),
+                        message: "Sandbox recovered during gateway startup".to_string(),
+                        last_transition_time: String::new(),
+                    },
+                );
+            })
+            .await
+        {
+            Ok(updated) => {
+                self.sandbox_index.update_from_sandbox(&updated);
+                self.sandbox_watch_bus.notify(&sandbox_id);
+                true
+            }
+            Err(err) => {
+                warn!(
+                    sandbox_id = %sandbox_id,
+                    error = %err,
+                    "Failed to clear sandbox error state during startup resume"
+                );
+                false
             }
         }
     }
@@ -4046,6 +4108,19 @@ fn sandbox_phase_should_be_running(phase: SandboxPhase) -> bool {
     )
 }
 
+/// Error-phase sandboxes are only eligible for startup recovery when their
+/// Ready condition reason indicates a container exit or stop — i.e. the
+/// runtime went away (machine restart, daemon restart) rather than a genuine
+/// application or infrastructure failure.
+fn is_recoverable_error_reason(sandbox: &Sandbox) -> bool {
+    use openshell_core::driver_utils::{CONDITION_EXITED, CONDITION_STOPPED};
+    sandbox
+        .status
+        .as_ref()
+        .and_then(|s| s.conditions.iter().find(|c| c.r#type == "Ready"))
+        .is_some_and(|c| c.reason == CONDITION_EXITED || c.reason == CONDITION_STOPPED)
+}
+
 fn is_terminal_failure_reason(reason: &str) -> bool {
     let reason = reason.to_ascii_lowercase();
     let transient_reasons = [
@@ -5197,6 +5272,19 @@ mod tests {
         let status = stored.status.unwrap();
         assert_eq!(status.main_process_instance_id, "instance-new");
         assert_eq!(status.exit_code, Some(1));
+    }
+
+    fn error_sandbox_record(id: &str, name: &str, reason: &str) -> Sandbox {
+        let mut sandbox = sandbox_record(id, name, SandboxPhase::Error);
+        let status = sandbox.status.get_or_insert_with(Default::default);
+        status.conditions.push(SandboxCondition {
+            r#type: "Ready".to_string(),
+            status: "False".to_string(),
+            reason: reason.to_string(),
+            message: String::new(),
+            last_transition_time: String::new(),
+        });
+        sandbox
     }
 
     fn ssh_session_record(id: &str, sandbox_id: &str) -> SshSession {
@@ -8789,11 +8877,29 @@ mod tests {
             ("sb-stopping", "stopping", SandboxPhase::Stopping),
             ("sb-stopped", "stopped", SandboxPhase::Stopped),
             ("sb-deleting", "deleting", SandboxPhase::Deleting),
-            ("sb-error", "error", SandboxPhase::Error),
         ] {
             let sandbox = sandbox_record(id, name, phase);
             runtime.store.put_message(&sandbox).await.unwrap();
         }
+        // A non-recoverable error is skipped; a container-exit error is retried.
+        runtime
+            .store
+            .put_message(&error_sandbox_record(
+                "sb-error-perm",
+                "error-perm",
+                "BackendResourceMissing",
+            ))
+            .await
+            .unwrap();
+        runtime
+            .store
+            .put_message(&error_sandbox_record(
+                "sb-error-exit",
+                "error-exit",
+                "ContainerExited",
+            ))
+            .await
+            .unwrap();
 
         runtime.start_persisted_sandboxes().await.unwrap();
 
@@ -8806,6 +8912,7 @@ mod tests {
         assert_eq!(
             called_ids,
             vec![
+                "sb-error-exit".to_string(),
                 "sb-prov".to_string(),
                 "sb-ready".to_string(),
                 "sb-unknown".to_string(),
@@ -8973,6 +9080,125 @@ mod tests {
                 "{driver_name} should not receive stable-running startup reconciliation"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn start_persisted_sandboxes_recovers_error_phase_when_container_exists() {
+        let driver = ControlledDriver::new();
+        // Default start outcome is Ok: the container is restarted successfully.
+        let runtime = test_runtime_with_gateway_managed_lifecycle(driver.clone(), "podman").await;
+
+        let sandbox = error_sandbox_record("sb-err-recover", "recover", "ContainerExited");
+        runtime.store.put_message(&sandbox).await.unwrap();
+
+        runtime.start_persisted_sandboxes().await.unwrap();
+
+        assert_eq!(driver.start_calls(), 1);
+
+        let stored = runtime
+            .store
+            .get_message::<Sandbox>("sb-err-recover")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            SandboxPhase::try_from(stored.phase()).unwrap(),
+            SandboxPhase::Provisioning
+        );
+        let ready = stored
+            .status
+            .as_ref()
+            .and_then(|s| s.conditions.iter().find(|c| c.r#type == "Ready"))
+            .expect("Ready condition present");
+        assert_eq!(ready.reason, "Resumed");
+    }
+
+    #[tokio::test]
+    async fn start_persisted_sandboxes_leaves_error_when_container_missing() {
+        let driver = ControlledDriver::new();
+        driver.set_start_outcome(ControlledLifecycleOutcome::NotFound);
+        let runtime = test_runtime_with_gateway_managed_lifecycle(driver.clone(), "podman").await;
+
+        let sandbox = error_sandbox_record("sb-err-gone", "gone", "ContainerExited");
+        runtime.store.put_message(&sandbox).await.unwrap();
+
+        runtime.start_persisted_sandboxes().await.unwrap();
+
+        // Recovery was attempted, but the error state is preserved untouched.
+        assert_eq!(driver.start_calls(), 1);
+
+        let stored = runtime
+            .store
+            .get_message::<Sandbox>("sb-err-gone")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            SandboxPhase::try_from(stored.phase()).unwrap(),
+            SandboxPhase::Error
+        );
+        let ready = stored
+            .status
+            .as_ref()
+            .and_then(|s| s.conditions.iter().find(|c| c.r#type == "Ready"))
+            .expect("Ready condition present");
+        assert_eq!(ready.reason, "ContainerExited");
+    }
+
+    #[tokio::test]
+    async fn start_persisted_sandboxes_leaves_error_when_start_fails() {
+        let driver = ControlledDriver::new();
+        driver.set_start_outcome(ControlledLifecycleOutcome::Error("runtime angry"));
+        let runtime = test_runtime_with_gateway_managed_lifecycle(driver.clone(), "podman").await;
+
+        let sandbox = error_sandbox_record("sb-err-fail", "fail", "ContainerStopped");
+        runtime.store.put_message(&sandbox).await.unwrap();
+
+        runtime.start_persisted_sandboxes().await.unwrap();
+
+        assert_eq!(driver.start_calls(), 1);
+
+        let stored = runtime
+            .store
+            .get_message::<Sandbox>("sb-err-fail")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            SandboxPhase::try_from(stored.phase()).unwrap(),
+            SandboxPhase::Error
+        );
+        let ready = stored
+            .status
+            .as_ref()
+            .and_then(|s| s.conditions.iter().find(|c| c.r#type == "Ready"))
+            .expect("Ready condition present");
+        assert_eq!(ready.reason, "ContainerStopped");
+    }
+
+    #[tokio::test]
+    async fn start_persisted_sandboxes_skips_non_recoverable_error() {
+        let driver = ControlledDriver::new();
+        let runtime = test_runtime_with_gateway_managed_lifecycle(driver.clone(), "podman").await;
+
+        let sandbox = error_sandbox_record("sb-err-perm", "perm", "BackendResourceMissing");
+        runtime.store.put_message(&sandbox).await.unwrap();
+
+        runtime.start_persisted_sandboxes().await.unwrap();
+
+        // A non-container-exit error is never retried.
+        assert_eq!(driver.start_calls(), 0);
+
+        let stored = runtime
+            .store
+            .get_message::<Sandbox>("sb-err-perm")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            SandboxPhase::try_from(stored.phase()).unwrap(),
+            SandboxPhase::Error
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- After a Podman/Docker machine restart, sandbox containers exit with SIGTERM (code 143) but remain on disk. The gateway marked them `Error` and on next startup the resume sweep skipped Error-phase sandboxes entirely — leaving them stuck until the user deleted and recreated them, losing state.
- `resume_persisted_sandboxes()` now attempts Error-phase sandboxes: if the container still exists it is restarted and the sandbox transitions back to `Provisioning` → `Ready`; if the container is gone or the driver fails, the sandbox stays in `Error` without overwriting the original error reason.
- Adds `resume_sandbox()` to the Podman driver and wires `StartupResume` for `PodmanComputeDriver` so the resume sweep runs on Podman-backed gateways (previously Docker-only).

## Related Issue

Closes #2179

## Changes

- **`crates/openshell-driver-podman/src/driver.rs`** — Added `resume_sandbox()` method that inspects container state and calls `start_container` if the container exists but is not running.
- **`crates/openshell-server/src/compute/mod.rs`**:
  - Modified phase filter in `resume_persisted_sandboxes()` to only skip `Deleting` (not `Error`)
  - Added `clear_sandbox_error()` method (mirrors `mark_sandbox_error()`) to reset phase to `Provisioning` and set Ready condition to `"Resumed"`
  - Guarded `Ok(false)` and `Err` arms to avoid overwriting existing error state on already-Error sandboxes
  - Implemented `StartupResume` for `PodmanComputeDriver` and wired it into `new_podman()`
  - Added `recovered` counter to summary log line for observability
  - Removed unused `sandbox_phase_should_be_running()` function
  - Updated doc comments to reflect new behavior

## Testing

### Unit tests (3 new + 1 updated)

- `resume_persisted_sandboxes_recovers_error_phase_when_container_exists` — `Ok(true)` → phase becomes `Provisioning`, Ready condition reason = `"Resumed"`
- `resume_persisted_sandboxes_leaves_error_when_container_missing` — `Ok(false)` → phase stays `Error`, no overwrite
- `resume_persisted_sandboxes_leaves_error_when_resume_fails` — `Err` → phase stays `Error`, no overwrite
- Updated `resume_persisted_sandboxes_resumes_running_phases` to expect Error-phase sandbox in called_ids

All 1032 tests pass across `openshell-server` and `openshell-driver-podman`. Clippy clean.

### Manual verification

Full end-to-end reproduction of issue #2179:

1. Created sandbox with Vertex AI provider: `openshell sandbox create --name my-podman-sandbox --provider vertex-prod`
2. Verified sandbox `Ready` and container `Up (healthy)`
3. Stopped Podman machine: `podman machine stop`
4. Restarted Podman machine: `podman machine start`
5. Verified container `Exited (143)` and sandbox stuck in `Error` (before fix — screenshot 1)
6. Restarted gateway with fix — logs show `Resumed sandbox ... phase=Error recovered=true` and `Sandbox resume sweep complete resumed=1 recovered=1` (screenshot 2)
7. Verified sandbox recovered to `Ready` and container `Up (healthy)` (screenshot 2)
8. Verified sandbox usable via `openshell term` TUI (screenshot 3)

### Screenshot 1 — Before fix: sandbox stuck in Error after Podman machine restart
<img width="1903" height="195" alt="Screenshot 2026-07-14 at 18 38 12" src="https://github.com/user-attachments/assets/196f57ca-9b04-487e-bbc0-a436fd697bd4" />


### Screenshot 2 — After fix: gateway restart recovers sandbox to Ready
<img width="1896" height="385" alt="Screenshot 2026-07-14 at 18 43 10" src="https://github.com/user-attachments/assets/d0dee1da-77bf-47f7-b376-6a38fb524fdd" />


### Screenshot 3 — Sandbox usable in OpenShell TUI after recovery
<img width="1052" height="981" alt="Screenshot 2026-07-14 at 18 44 54" src="https://github.com/user-attachments/assets/c26eff3a-e548-4a29-8d12-ae7a0e8c7a60" />


## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Signed off (DCO)
- [x] Unit tests added and passing
- [x] Pre-commit checks passing
- [x] Manual end-to-end verification complete
- [x] No proto changes, no new gRPC RPCs, no CLI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)