### PR TITLE
fix(release-dev): update azure/setup-helm to v5.0.1

### DIFF
--- a/.github/actions/release-helm-oci/action.yml
+++ b/.github/actions/release-helm-oci/action.yml
@@ -41,7 +41,7 @@ runs:
         password: ${{ github.token }}
 
     - name: Install Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
     - name: Stage chart and patch version
       id: prep


### PR DESCRIPTION
## Summary

Dependabot updated the Helm setup action in release-canary but missed the same reference in the release composite action.

This also may be a fix for this failed job: https://github.com/NVIDIA/OpenShell/actions/runs/29354562538/job/87174136321

<!-- 1-3 sentences: what this PR does and why -->

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- What testing was done? -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
