### PR TITLE
feat(snap): vendor ssh in openshell snap and remove ssh-keys interface

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -185,7 +185,6 @@ jobs:
           sudo snap connect openshell:docker docker:docker-daemon
           sudo snap connect openshell:log-observe
           sudo snap connect openshell:system-observe
-          sudo snap connect openshell:ssh-keys
 
       - name: Register snap gateway and check status
         run: |

--- a/docs/about/installation.mdx
+++ b/docs/about/installation.mdx
@@ -97,7 +97,7 @@ typically `~/snap/openshell/common`. Gateway registrations live under
 ### Snap store installs
 
 When installing from the Snap Store, snapd automatically connects the `home`,
-`network`, `network-bind`, and `ssh-keys` plugs. The `docker` plug still
+`network`, and `network-bind` plugs. The `docker` plug still
 requires manual connection:
 
 ```shell
@@ -117,7 +117,6 @@ sudo snap install ./openshell_*.snap --dangerous
 sudo snap connect openshell:home
 sudo snap connect openshell:network
 sudo snap connect openshell:network-bind
-sudo snap connect openshell:ssh-keys
 sudo snap connect openshell:docker docker:docker-daemon
 sudo snap connect openshell:log-observe
 sudo snap connect openshell:system-observe

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -27,7 +27,6 @@ description: |
          sudo snap connect openshell:docker docker:docker-daemon
          sudo snap connect openshell:log-observe
          sudo snap connect openshell:system-observe
-         sudo snap connect openshell:ssh-keys
          sudo snap start openshell.gateway
 
     3. Verify the gateway and register it locally:
@@ -69,7 +68,6 @@ apps:
     plugs:
       - home
       - network
-      - ssh-keys
       - system-observe
   term:
     command: bin/openshell term
@@ -81,7 +79,6 @@ apps:
     plugs:
       - home
       - network
-      - ssh-keys
       - system-observe
   gateway:
     command: bin/openshell-gateway-wrapper
@@ -104,7 +101,6 @@ apps:
       - log-observe
       - network
       - network-bind
-      - ssh-keys
       - system-observe
 
 parts:
@@ -150,3 +146,14 @@ parts:
         "$CRAFT_PART_INSTALL/usr/share/doc/openshell/LICENSE"
       install -D -m 0644 "$CRAFT_PART_SRC/README.md" \
         "$CRAFT_PART_INSTALL/usr/share/doc/openshell/README.md"
+
+  ssh:
+    # Vendor the openssh-client `ssh` binary into the snap so the CLI/TUI
+    # can spawn `ssh` for sandbox connect/exec/forward without relying on
+    # the host's ssh-keys interface. The binary lands at
+    # $SNAP/usr/bin/ssh and is found via the snap runtime PATH.
+    plugin: nil
+    stage-packages:
+      - openssh-client
+    prime:
+      - usr/bin/ssh


### PR DESCRIPTION
## Summary

This PR removes the `ssh-keys` interface and instead vendors the `ssh` binary within the snap.

This is safe because OpenShell always invokes the `ssh` binary with `StrictHostKeyChecking=no`, `UserKnownHostsFile=/dev/null`, and `GlobalKnownHostsFile=/dev/null`, and never uses any host credentials or ssh configuration. Openshell only ever access to `~/.ssh/config` to write OpenShell-managed aliases, and this can safely live within the snap sandbox, rather than leaking into the host environment.

## Related Issue

Addresses: #2277

## Changes

- Remove `ssh-keys` interface from the OpenShell snap
- Vendors the `ssh` binary within the OpenShell snap

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
