### PR TITLE
feat(providers): anthropic subscription oauth

### DIFF
--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -391,7 +391,8 @@ Cluster inference routes store only `provider_name`, `model_id`, and optional
 timeout. The gateway resolves endpoint URLs, protocols, credentials, auth
 style, and route-shaping metadata from the provider record when supervisors call
 `GetInferenceBundle`. Supported provider types for cluster inference are
-`openai`, `anthropic`, `nvidia`, `deepinfra`, and `google-vertex-ai`.
+`openai`, `anthropic`, `anthropic-oauth`, `nvidia`, `deepinfra`, and
+`google-vertex-ai`.
 
 The bundle carries enough information for sandbox-local routers to construct
 upstream URLs without re-deriving provider-specific routing logic. Each resolved
@@ -448,6 +449,20 @@ successful create therefore yields an immediately usable provider; failures roll
 back the provider record. Service-account JSON and private keys are gateway-side
 refresh bootstrap material only; sandbox runtime inference receives minted
 access tokens, not raw service-account material.
+
+The `anthropic-oauth` provider type (alias `claude-plan`) routes the direct
+Anthropic API with a subscription OAuth token instead of an API key. Its
+inference profile uses `Authorization: Bearer` plus a mandatory
+`anthropic-beta: oauth-2025-04-20` default header; the sandbox router merges that
+flag with any client-sent `anthropic-beta` value so the sandbox cannot drop it.
+The CLI `--from-claude-login` harvests the local Claude Code login (macOS
+Keychain `Claude Code-credentials` or `~/.claude/.credentials.json`) on the host,
+stores the access token under the non-injectable `ANTHROPIC_OAUTH_TOKEN`
+credential, and calls `ConfigureProviderRefresh` with the subscription's refresh
+token (Anthropic public `client_id` only, no secret). The background refresh
+worker rotates the access token ahead of expiry and persists Anthropic's rotated
+refresh token. The access token is never exported into sandbox environments; it
+rides the inference route bundle and is injected only at the egress boundary.
 
 ## Supervisor Relay
 

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -459,10 +459,19 @@ The CLI `--from-claude-login` harvests the local Claude Code login (macOS
 Keychain `Claude Code-credentials` or `~/.claude/.credentials.json`) on the host,
 stores the access token under the non-injectable `ANTHROPIC_OAUTH_TOKEN`
 credential, and calls `ConfigureProviderRefresh` with the subscription's refresh
-token (Anthropic public `client_id` only, no secret). The background refresh
+token (Anthropic public `client_id` only, no secret). With `--from-claude-login`
+the provider name and type default (`claude-subscription` / `anthropic-oauth`),
+and when no user inference route exists the CLI points the route at the new
+provider (best-effort, unverified). The background refresh
 worker rotates the access token ahead of expiry and persists Anthropic's rotated
 refresh token. The access token is never exported into sandbox environments; it
 rides the inference route bundle and is injected only at the egress boundary.
+Instead, the provider plugin projects `ANTHROPIC_BASE_URL=https://inference.local`
+and a placeholder `ANTHROPIC_AUTH_TOKEN` into bound sandboxes so agent CLIs work
+without manual configuration or confirmation prompts; `inference.local` replaces
+the placeholder auth with the real token before forwarding. The base URL is
+resolved to its real value in the sandbox env (agents must parse it at startup);
+the auth token stays an egress placeholder like any other credential.
 
 ## Supervisor Relay
 

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -450,7 +450,7 @@ back the provider record. Service-account JSON and private keys are gateway-side
 refresh bootstrap material only; sandbox runtime inference receives minted
 access tokens, not raw service-account material.
 
-The `anthropic-oauth` provider type (alias `claude-plan`) routes the direct
+The `anthropic-oauth` provider type (alias `claude-subscription`) routes the direct
 Anthropic API with a subscription OAuth token instead of an API key. Its
 inference profile uses `Authorization: Bearer` plus a mandatory
 `anthropic-beta: oauth-2025-04-20` default header; the sandbox router merges that

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -749,7 +749,7 @@ impl From<CliEditor> for openshell_cli::ssh::Editor {
 #[derive(Subcommand, Debug)]
 enum ProviderCommands {
     /// Create a provider config.
-    #[command(group = clap::ArgGroup::new("cred_source").required(true).args(["from_existing", "credentials", "from_gcloud_adc", "runtime_credentials"]), help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
+    #[command(group = clap::ArgGroup::new("cred_source").required(true).args(["from_existing", "credentials", "from_gcloud_adc", "from_claude_login", "runtime_credentials"]), help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
     Create {
         /// Provider name.
         #[arg(long)]
@@ -760,25 +760,31 @@ enum ProviderCommands {
         provider_type: String,
 
         /// Load provider credentials/config from existing local state.
-        #[arg(long, conflicts_with_all = ["credentials", "from_gcloud_adc", "runtime_credentials"])]
+        #[arg(long, conflicts_with_all = ["credentials", "from_gcloud_adc", "from_claude_login", "runtime_credentials"])]
         from_existing: bool,
 
         /// Provider credential pair (`KEY=VALUE`) or env lookup key (`KEY`).
         #[arg(
             long = "credential",
             value_name = "KEY[=VALUE]",
-            conflicts_with_all = ["from_existing", "from_gcloud_adc", "runtime_credentials"]
+            conflicts_with_all = ["from_existing", "from_gcloud_adc", "from_claude_login", "runtime_credentials"]
         )]
         credentials: Vec<String>,
 
         /// Configure credentials from gcloud Application Default Credentials
         /// (`~/.config/gcloud/application_default_credentials.json`).
         /// Valid for providers whose profile declares an ADC-compatible credential.
-        #[arg(long, group = "cred_source", conflicts_with_all = ["from_existing", "credentials", "runtime_credentials"])]
+        #[arg(long, group = "cred_source", conflicts_with_all = ["from_existing", "credentials", "from_claude_login", "runtime_credentials"])]
         from_gcloud_adc: bool,
 
+        /// Configure credentials from the local Claude Code subscription login
+        /// (macOS Keychain or `~/.claude/.credentials.json`).
+        /// Only valid for anthropic-oauth providers.
+        #[arg(long, group = "cred_source", conflicts_with_all = ["from_existing", "credentials", "from_gcloud_adc", "runtime_credentials"])]
+        from_claude_login: bool,
+
         /// Create a provider whose required credentials are resolved at runtime by the gateway/sandbox.
-        #[arg(long, conflicts_with_all = ["from_existing", "credentials", "from_gcloud_adc"])]
+        #[arg(long, conflicts_with_all = ["from_existing", "credentials", "from_gcloud_adc", "from_claude_login"])]
         runtime_credentials: bool,
 
         /// Provider config key/value pair.
@@ -2830,6 +2836,7 @@ async fn main() -> Result<()> {
                     from_existing,
                     credentials,
                     from_gcloud_adc,
+                    from_claude_login,
                     runtime_credentials,
                     config,
                 } => {
@@ -2840,6 +2847,7 @@ async fn main() -> Result<()> {
                         from_existing,
                         &credentials,
                         from_gcloud_adc,
+                        from_claude_login,
                         runtime_credentials,
                         &config,
                         &tls,

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -751,13 +751,13 @@ enum ProviderCommands {
     /// Create a provider config.
     #[command(group = clap::ArgGroup::new("cred_source").required(true).args(["from_existing", "credentials", "from_gcloud_adc", "from_claude_login", "runtime_credentials"]), help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
     Create {
-        /// Provider name.
-        #[arg(long)]
-        name: String,
+        /// Provider name. Defaults to `claude-subscription` with `--from-claude-login`.
+        #[arg(long, required_unless_present = "from_claude_login")]
+        name: Option<String>,
 
-        /// Provider type.
-        #[arg(long = "type")]
-        provider_type: String,
+        /// Provider type. Defaults to `anthropic-oauth` with `--from-claude-login`.
+        #[arg(long = "type", required_unless_present = "from_claude_login")]
+        provider_type: Option<String>,
 
         /// Load provider credentials/config from existing local state.
         #[arg(long, conflicts_with_all = ["credentials", "from_gcloud_adc", "from_claude_login", "runtime_credentials"])]
@@ -2840,6 +2840,11 @@ async fn main() -> Result<()> {
                     runtime_credentials,
                     config,
                 } => {
+                    // clap guarantees these are present unless --from-claude-login was given.
+                    let name = name
+                        .unwrap_or_else(|| run::ANTHROPIC_OAUTH_DEFAULT_PROVIDER_NAME.to_string());
+                    let provider_type = provider_type
+                        .unwrap_or_else(|| run::ANTHROPIC_OAUTH_PROVIDER_TYPE.to_string());
                     run::provider_create_with_options(
                         endpoint,
                         &name,
@@ -4024,12 +4029,51 @@ mod tests {
                         ..
                     }),
             }) => {
-                assert_eq!(name, "work-github");
-                assert_eq!(provider_type, "github-readonly");
+                assert_eq!(name.as_deref(), Some("work-github"));
+                assert_eq!(provider_type.as_deref(), Some("github-readonly"));
                 assert_eq!(credentials, vec!["GITHUB_TOKEN=token"]);
             }
             other => panic!("expected provider create command, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn provider_create_from_claude_login_defaults_name_and_type() {
+        let cli = Cli::try_parse_from(["openshell", "provider", "create", "--from-claude-login"])
+            .expect("provider create should parse bare --from-claude-login");
+
+        match cli.command {
+            Some(Commands::Provider {
+                command:
+                    Some(ProviderCommands::Create {
+                        name,
+                        provider_type,
+                        from_claude_login,
+                        ..
+                    }),
+            }) => {
+                assert_eq!(name, None);
+                assert_eq!(provider_type, None);
+                assert!(from_claude_login);
+            }
+            other => panic!("expected provider create command, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn provider_create_requires_name_and_type_without_claude_login() {
+        let err = Cli::try_parse_from([
+            "openshell",
+            "provider",
+            "create",
+            "--credential",
+            "SOME_KEY=value",
+        ])
+        .expect_err("provider create should require --name and --type");
+
+        let message = err.to_string();
+        assert!(message.contains("--name"), "unexpected error: {message}");
+        assert!(message.contains("--type"), "unexpected error: {message}");
     }
 
     #[test]
@@ -4075,8 +4119,8 @@ mod tests {
                         ..
                     }),
             }) => {
-                assert_eq!(name, "spiffe-token-demo");
-                assert_eq!(provider_type, "spiffe-token-demo");
+                assert_eq!(name.as_deref(), Some("spiffe-token-demo"));
+                assert_eq!(provider_type.as_deref(), Some("spiffe-token-demo"));
                 assert!(!from_existing);
                 assert!(credentials.is_empty());
                 assert!(!from_gcloud_adc);

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -4618,6 +4618,178 @@ fn read_gcloud_adc() -> Result<(String, String, String)> {
     Ok((client_id, client_secret, refresh_token))
 }
 
+/// Canonical provider type string for the Anthropic subscription OAuth flow.
+const ANTHROPIC_OAUTH_PROVIDER_TYPE: &str = "anthropic-oauth";
+
+/// Anthropic's public OAuth client ID used by Claude Code. The refresh grant
+/// requires only this client ID (no client secret).
+const ANTHROPIC_OAUTH_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+
+/// OAuth credentials harvested from a local Claude Code subscription login.
+struct ClaudeOauthCredentials {
+    access_token: String,
+    refresh_token: String,
+    /// Access-token expiry in epoch milliseconds (0 if unknown).
+    expires_at_ms: i64,
+}
+
+/// Read the Anthropic subscription OAuth credentials from the local Claude Code
+/// login. Prefers the macOS Keychain item, falling back to
+/// `~/.claude/.credentials.json`.
+fn read_claude_oauth() -> Result<ClaudeOauthCredentials> {
+    if let Some(raw) = read_claude_credentials_keychain()? {
+        return parse_claude_oauth_json(&raw);
+    }
+    if let Some(raw) = read_claude_credentials_file()? {
+        return parse_claude_oauth_json(&raw);
+    }
+    Err(miette::miette!(
+        "no local Claude Code subscription login found. \
+         Run `claude login` (or `claude /login`) on this host first, then retry. \
+         Looked in the macOS Keychain item 'Claude Code-credentials' and \
+         ~/.claude/.credentials.json"
+    ))
+}
+
+/// Read the raw credentials JSON from `~/.claude/.credentials.json`, if present.
+fn read_claude_credentials_file() -> Result<Option<String>> {
+    let home = std::env::var("HOME")
+        .map_err(|_| miette::miette!("HOME is not set; cannot locate the Claude Code login"))?;
+    let path = PathBuf::from(home)
+        .join(".claude")
+        .join(".credentials.json");
+    match std::fs::read_to_string(&path) {
+        Ok(content) => Ok(Some(content)),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(miette::miette!(
+            "failed to read Claude Code credentials file at {}: {err}",
+            path.display()
+        )),
+    }
+}
+
+/// Read the raw credentials JSON from the macOS Keychain. Returns `None` on
+/// non-macOS hosts or when the item is absent.
+#[cfg(target_os = "macos")]
+fn read_claude_credentials_keychain() -> Result<Option<String>> {
+    let output = Command::new("security")
+        .args([
+            "find-generic-password",
+            "-s",
+            "Claude Code-credentials",
+            "-w",
+        ])
+        .output();
+    match output {
+        Ok(out) if out.status.success() => {
+            let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if raw.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(raw))
+            }
+        }
+        // Non-zero exit means the item was not found; fall through to the file.
+        Ok(_) => Ok(None),
+        Err(err) => Err(miette::miette!(
+            "failed to query the macOS Keychain for the Claude Code login: {err}"
+        )),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_claude_credentials_keychain() -> Result<Option<String>> {
+    Ok(None)
+}
+
+/// Parse the Claude Code credentials JSON, extracting the access token, refresh
+/// token, and normalized access-token expiry.
+fn parse_claude_oauth_json(raw: &str) -> Result<ClaudeOauthCredentials> {
+    let json: serde_json::Value = serde_json::from_str(raw)
+        .map_err(|err| miette::miette!("failed to parse Claude Code credentials: {err}"))?;
+
+    let oauth = json.get("claudeAiOauth").ok_or_else(|| {
+        miette::miette!(
+            "Claude Code credentials are missing the 'claudeAiOauth' object; \
+             the local login may be from an incompatible Claude Code version"
+        )
+    })?;
+
+    let access_token = oauth
+        .get("accessToken")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| miette::miette!("Claude Code login is missing 'accessToken'"))?
+        .to_string();
+
+    let refresh_token = oauth
+        .get("refreshToken")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            miette::miette!(
+                "Claude Code login is missing 'refreshToken'; \
+                 gateway-managed refresh requires it"
+            )
+        })?
+        .to_string();
+
+    let expires_at_ms = oauth
+        .get("expiresAt")
+        .and_then(serde_json::Value::as_i64)
+        .map_or(0, normalize_expires_at_ms);
+
+    Ok(ClaudeOauthCredentials {
+        access_token,
+        refresh_token,
+        expires_at_ms,
+    })
+}
+
+/// Normalize an `expiresAt` value to epoch milliseconds. Claude Code stores
+/// milliseconds, but tolerate a seconds-valued timestamp by scaling it up.
+fn normalize_expires_at_ms(value: i64) -> i64 {
+    if value > 0 && value < 1_000_000_000_000 {
+        value * 1000
+    } else {
+        value
+    }
+}
+
+async fn rollback_provider_create_after_claude_login_failure(
+    client: &mut crate::tls::GrpcClient,
+    provider_name: &str,
+    source: &Status,
+) -> Result<()> {
+    match client
+        .delete_provider(DeleteProviderRequest {
+            name: provider_name.to_string(),
+        })
+        .await
+    {
+        Ok(_) => Err(miette!(
+            "failed to configure Anthropic subscription refresh from the local Claude Code login \
+             for provider '{provider_name}': {source}. The provider was rolled back successfully."
+        )),
+        Err(cleanup_err) => {
+            eprintln!(
+                "{} Failed to clean up provider '{}' after configuring refresh failed: {}. \
+                 Run 'openshell provider delete {}' to remove it manually.",
+                "⚠".yellow(),
+                provider_name,
+                cleanup_err,
+                provider_name
+            );
+            Err(miette!(
+                "failed to configure Anthropic subscription refresh from the local Claude Code login \
+                 for provider '{provider_name}': {source}. \
+                 Cleanup also failed, so the provider may still exist. \
+                 Run 'openshell provider delete {provider_name}' to remove it manually."
+            ))
+        }
+    }
+}
+
 async fn rollback_provider_create_after_gcloud_adc_failure(
     client: &mut crate::tls::GrpcClient,
     provider_name: &str,
@@ -4801,6 +4973,7 @@ pub async fn provider_create(
         credentials,
         from_gcloud_adc,
         false,
+        false,
         config,
         tls,
     )
@@ -4808,6 +4981,7 @@ pub async fn provider_create(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::fn_params_excessive_bools)]
 pub async fn provider_create_with_options(
     server: &str,
     name: &str,
@@ -4815,6 +4989,7 @@ pub async fn provider_create_with_options(
     from_existing: bool,
     credentials: &[String],
     from_gcloud_adc: bool,
+    from_claude_login: bool,
     runtime_credentials: bool,
     config: &[String],
     tls: &TlsOptions,
@@ -4822,6 +4997,11 @@ pub async fn provider_create_with_options(
     if from_gcloud_adc && (from_existing || !credentials.is_empty() || runtime_credentials) {
         return Err(miette::miette!(
             "--from-gcloud-adc cannot be combined with --from-existing or --credential; it also cannot be combined with --runtime-credentials"
+        ));
+    }
+    if from_claude_login && (from_existing || !credentials.is_empty() || runtime_credentials) {
+        return Err(miette::miette!(
+            "--from-claude-login cannot be combined with --from-existing, --credential, or --runtime-credentials"
         ));
     }
     if from_existing && (!credentials.is_empty() || runtime_credentials) {
@@ -4895,6 +5075,12 @@ pub async fn provider_create_with_options(
         None
     };
 
+    if from_claude_login && provider_type != ANTHROPIC_OAUTH_PROVIDER_TYPE {
+        return Err(miette::miette!(
+            "--from-claude-login is only valid for anthropic-oauth providers"
+        ));
+    }
+
     let mut credential_map = parse_credential_pairs(credentials)?;
     let mut config_map = parse_key_value_pairs(config, "--config")?;
 
@@ -4913,6 +5099,22 @@ pub async fn provider_create_with_options(
             config_map.entry(key).or_insert(value);
         }
     }
+
+    // Read the local Claude Code login BEFORE creating the provider so a missing
+    // or malformed credential does not leave an orphan provider behind. The
+    // access token is stored as the provider credential; it is marked
+    // non-injectable server-side, so it is only ever injected at the egress
+    // boundary and never inside the sandbox.
+    let claude_login_material = if from_claude_login {
+        let creds = read_claude_oauth()?;
+        credential_map.insert(
+            openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY.to_string(),
+            creds.access_token.clone(),
+        );
+        Some(creds)
+    } else {
+        None
+    };
 
     if credential_map.is_empty() {
         if from_existing {
@@ -4952,6 +5154,19 @@ pub async fn provider_create_with_options(
         None
     };
 
+    // Seed the initial access-token expiry so the gateway's background refresh
+    // worker knows when to mint a fresh token. Sourced from the local Claude
+    // Code login's `expiresAt`.
+    let mut credential_expires_at_ms = HashMap::new();
+    if let Some(creds) = &claude_login_material
+        && creds.expires_at_ms > 0
+    {
+        credential_expires_at_ms.insert(
+            openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY.to_string(),
+            creds.expires_at_ms,
+        );
+    }
+
     let response = client
         .create_provider(CreateProviderRequest {
             provider: Some(Provider {
@@ -4966,7 +5181,7 @@ pub async fn provider_create_with_options(
                 r#type: provider_type.clone(),
                 credentials: credential_map,
                 config: config_map,
-                credential_expires_at_ms: HashMap::new(),
+                credential_expires_at_ms,
             }),
         })
         .await
@@ -5027,6 +5242,42 @@ pub async fn provider_create_with_options(
 
         println!("{} Created provider {}", "✓".green().bold(), provider_name);
         println!("Configured GCP credentials from gcloud ADC and minted the initial access token");
+        return Ok(());
+    }
+
+    if let Some(creds) = claude_login_material {
+        let mut material = HashMap::new();
+        material.insert(
+            "client_id".to_string(),
+            ANTHROPIC_OAUTH_CLIENT_ID.to_string(),
+        );
+        material.insert("refresh_token".to_string(), creds.refresh_token);
+
+        // No initial rotate: the access token harvested from the local login is
+        // already valid, and rotating now would invalidate the user's local
+        // Claude Code refresh token (Anthropic rotates refresh tokens on use).
+        // The background worker refreshes only as the token nears expiry.
+        if let Err(configure_err) = client
+            .configure_provider_refresh(ConfigureProviderRefreshRequest {
+                provider: provider_name.clone(),
+                credential_key: openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY.to_string(),
+                strategy: ProviderCredentialRefreshStrategy::Oauth2RefreshToken as i32,
+                material,
+                secret_material_keys: vec!["refresh_token".to_string()],
+                expires_at_ms: (creds.expires_at_ms > 0).then_some(creds.expires_at_ms),
+            })
+            .await
+        {
+            return rollback_provider_create_after_claude_login_failure(
+                &mut client,
+                &provider_name,
+                &configure_err,
+            )
+            .await;
+        }
+
+        println!("{} Created provider {}", "✓".green().bold(), provider_name);
+        println!("Configured Anthropic subscription credentials from the local Claude Code login");
         return Ok(());
     }
 
@@ -9686,6 +9937,80 @@ mod tests {
                 || msg.contains("invalid")
                 || msg.contains("failed"),
             "error message should mention parse/JSON failure, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_claude_oauth_json_extracts_fields() {
+        let raw = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-oat-test",
+                "refreshToken": "sk-ant-ort-test",
+                "expiresAt": 1_750_000_000_000_i64,
+                "scopes": ["user:inference"],
+                "subscriptionType": "pro"
+            }
+        })
+        .to_string();
+        let creds = super::parse_claude_oauth_json(&raw).expect("valid login should parse");
+        assert_eq!(creds.access_token, "sk-ant-oat-test");
+        assert_eq!(creds.refresh_token, "sk-ant-ort-test");
+        assert_eq!(creds.expires_at_ms, 1_750_000_000_000_i64);
+    }
+
+    #[test]
+    fn parse_claude_oauth_json_normalizes_seconds_expiry() {
+        let raw = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-oat-test",
+                "refreshToken": "sk-ant-ort-test",
+                "expiresAt": 1_750_000_000_i64
+            }
+        })
+        .to_string();
+        let creds = super::parse_claude_oauth_json(&raw).expect("valid login should parse");
+        assert_eq!(creds.expires_at_ms, 1_750_000_000_000_i64);
+    }
+
+    #[test]
+    fn parse_claude_oauth_json_missing_refresh_token_errors() {
+        let raw = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-oat-test"
+            }
+        })
+        .to_string();
+        let err = super::parse_claude_oauth_json(&raw)
+            .err()
+            .expect("missing refresh token errors");
+        assert!(
+            err.to_string().contains("refreshToken"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_claude_oauth_json_missing_oauth_object_errors() {
+        let raw = serde_json::json!({ "somethingElse": {} }).to_string();
+        let err = super::parse_claude_oauth_json(&raw)
+            .err()
+            .expect("missing oauth object should error");
+        assert!(
+            err.to_string().contains("claudeAiOauth"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn normalize_expires_at_ms_scales_seconds_only() {
+        assert_eq!(super::normalize_expires_at_ms(0), 0);
+        assert_eq!(
+            super::normalize_expires_at_ms(1_700_000_000),
+            1_700_000_000_000
+        );
+        assert_eq!(
+            super::normalize_expires_at_ms(1_700_000_000_000),
+            1_700_000_000_000
         );
     }
 

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -3977,6 +3977,20 @@ async fn auto_create_provider(
 ) -> Result<()> {
     eprintln!("Missing provider: {provider_type}");
 
+    // Subscription OAuth material lives in the host keychain and is harvested
+    // by `provider create --from-claude-login`, not by env discovery — and it
+    // cannot be configured from inside a sandbox.
+    if openshell_core::inference::normalize_inference_provider_type(provider_type)
+        == Some(ANTHROPIC_OAUTH_PROVIDER_TYPE)
+    {
+        eprintln!(
+            "{} '{provider_type}' uses your Anthropic subscription login. Create the provider first, then retry:\n    openshell provider create --from-claude-login",
+            "!".yellow(),
+        );
+        eprintln!();
+        return Ok(());
+    }
+
     // --no-auto-providers: skip silently.
     if auto_providers_override == Some(false) {
         eprintln!(
@@ -4619,7 +4633,14 @@ fn read_gcloud_adc() -> Result<(String, String, String)> {
 }
 
 /// Canonical provider type string for the Anthropic subscription OAuth flow.
-const ANTHROPIC_OAUTH_PROVIDER_TYPE: &str = "anthropic-oauth";
+pub const ANTHROPIC_OAUTH_PROVIDER_TYPE: &str = "anthropic-oauth";
+
+/// Default provider name when `--from-claude-login` is used without `--name`.
+pub const ANTHROPIC_OAUTH_DEFAULT_PROVIDER_NAME: &str = "claude-subscription";
+
+/// Model used when auto-configuring the inference route for a freshly created
+/// Anthropic subscription provider.
+const ANTHROPIC_OAUTH_DEFAULT_MODEL: &str = "claude-sonnet-4-6";
 
 /// Anthropic's public OAuth client ID used by Claude Code. The refresh grant
 /// requires only this client ID (no client secret).
@@ -5278,11 +5299,88 @@ pub async fn provider_create_with_options(
 
         println!("{} Created provider {}", "✓".green().bold(), provider_name);
         println!("Configured Anthropic subscription credentials from the local Claude Code login");
+        configure_default_inference_route_if_unset(server, &provider_name, tls).await;
         return Ok(());
     }
 
     println!("{} Created provider {}", "✓".green().bold(), provider_name);
     Ok(())
+}
+
+/// Point the user-facing inference route at a freshly created provider when no
+/// route is configured yet, so `--from-claude-login` yields a working setup
+/// without a separate `inference set` step. Best-effort: the provider was
+/// already created successfully, so route problems only print a hint instead
+/// of failing the command. Verification is skipped because subscription rate
+/// limits make the validation probe flaky (a 429 would reject a valid token).
+async fn configure_default_inference_route_if_unset(
+    server: &str,
+    provider_name: &str,
+    tls: &TlsOptions,
+) {
+    let manual_hint = format!(
+        "run `openshell inference set --provider {provider_name} --model {ANTHROPIC_OAUTH_DEFAULT_MODEL} --no-verify` to configure it manually"
+    );
+
+    let mut client = match grpc_inference_client(server, tls).await {
+        Ok(client) => client,
+        Err(e) => {
+            println!("Could not reach the inference API to configure a route ({e}); {manual_hint}");
+            return;
+        }
+    };
+
+    let route_unset = match client
+        .get_cluster_inference(GetClusterInferenceRequest {
+            route_name: String::new(),
+        })
+        .await
+    {
+        Ok(response) => response.into_inner().provider_name.trim().is_empty(),
+        Err(status) if status.code() == Code::NotFound => true,
+        Err(status) => {
+            println!(
+                "Could not check the current inference route ({}); {manual_hint}",
+                status.message()
+            );
+            return;
+        }
+    };
+
+    if !route_unset {
+        println!(
+            "Inference route already configured; left unchanged (use `openshell inference set --provider {provider_name}` to switch)"
+        );
+        return;
+    }
+
+    match client
+        .set_cluster_inference(SetClusterInferenceRequest {
+            provider_name: provider_name.to_string(),
+            model_id: ANTHROPIC_OAUTH_DEFAULT_MODEL.to_string(),
+            route_name: String::new(),
+            verify: false,
+            no_verify: true,
+            timeout_secs: 0,
+        })
+        .await
+    {
+        Ok(response) => {
+            let configured = response.into_inner();
+            println!(
+                "{} Configured inference route: provider {} model {}",
+                "✓".green().bold(),
+                configured.provider_name,
+                configured.model_id
+            );
+        }
+        Err(status) => {
+            println!(
+                "Could not auto-configure the inference route ({}); {manual_hint}",
+                status.message()
+            );
+        }
+    }
 }
 
 fn provider_profile_allows_empty_credentials(profile: &ProviderProfile) -> bool {

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -3961,6 +3961,18 @@ pub async fn ensure_required_providers(
     Ok(configured_names)
 }
 
+/// Error for a missing `anthropic-oauth` provider (or its alias), which cannot
+/// be auto-created from env discovery or from inside a sandbox.
+fn missing_subscription_provider_error(provider_type: &str) -> Option<miette::Report> {
+    (openshell_core::inference::normalize_inference_provider_type(provider_type)
+        == Some(ANTHROPIC_OAUTH_PROVIDER_TYPE))
+    .then(|| {
+        miette::miette!(
+            "'{provider_type}' uses your Anthropic subscription login. Create the provider first, then retry:\n    openshell provider create --from-claude-login"
+        )
+    })
+}
+
 /// Prompt for (or auto-confirm) creation of a provider from local credentials.
 ///
 /// When `preferred_name` is `Some`, the provider is created with that exact
@@ -3979,16 +3991,11 @@ async fn auto_create_provider(
 
     // Subscription OAuth material lives in the host keychain and is harvested
     // by `provider create --from-claude-login`, not by env discovery — and it
-    // cannot be configured from inside a sandbox.
-    if openshell_core::inference::normalize_inference_provider_type(provider_type)
-        == Some(ANTHROPIC_OAUTH_PROVIDER_TYPE)
-    {
-        eprintln!(
-            "{} '{provider_type}' uses your Anthropic subscription login. Create the provider first, then retry:\n    openshell provider create --from-claude-login",
-            "!".yellow(),
-        );
-        eprintln!();
-        return Ok(());
+    // cannot be configured from inside a sandbox. Abort sandbox creation:
+    // continuing without the provider would drop Claude into an in-sandbox
+    // login flow that cannot succeed.
+    if let Some(err) = missing_subscription_provider_error(provider_type) {
+        return Err(err);
     }
 
     // --no-auto-providers: skip silently.
@@ -8432,10 +8439,10 @@ mod tests {
         ProvisioningStep, TlsOptions, build_sandbox_resource_limits,
         dockerfile_sources_supported_for_gateway, format_endpoint, format_gateway_select_header,
         format_gateway_select_items, format_provider_attachment_table, gateway_add,
-        gateway_auth_label, gateway_env_override_warning, gateway_info_to_json,
-        gateway_remote_label, gateway_select_with, gateway_to_json, gateway_type_label,
-        git_sync_files, http_health_check, import_local_package_mtls_bundle,
-        inferred_provider_type, mtls_certs_exist_for_gateway, package_managed_tls_dirs,
+        gateway_auth_label, gateway_env_override_warning, gateway_select_with, gateway_to_json,
+        gateway_type_label, git_sync_files, http_health_check, import_local_package_mtls_bundle,
+        inferred_provider_type, missing_subscription_provider_error,
+        mtls_certs_exist_for_gateway, package_managed_tls_dirs,
         parse_cli_setting_value, parse_credential_expiry_cli_value, parse_credential_expiry_pairs,
         parse_credential_pairs, parse_driver_config_json, parse_secret_material_env_pairs,
         plaintext_gateway_is_remote, policy_revision_to_json, progress_step_from_metadata,
@@ -9019,6 +9026,21 @@ mod tests {
     fn inferred_provider_type_returns_none_for_unknown_command() {
         let result = inferred_provider_type(&["bash".to_string()]);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn missing_subscription_provider_aborts_sandbox_creation() {
+        for provider_type in ["anthropic-oauth", "claude-subscription"] {
+            let err = missing_subscription_provider_error(provider_type)
+                .expect("missing subscription provider must be an error, not a warning");
+            assert!(
+                err.to_string()
+                    .contains("openshell provider create --from-claude-login"),
+                "error must point at the setup command: {err}"
+            );
+        }
+        assert!(missing_subscription_provider_error("claude-code").is_none());
+        assert!(missing_subscription_provider_error("anthropic").is_none());
     }
 
     #[test]

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -1395,6 +1395,7 @@ async fn provider_create_allows_empty_credentials_for_gateway_refresh_profiles()
         false,
         &[],
         false,
+        false,
         true,
         &[],
         &ts.tls,

--- a/crates/openshell-core/src/inference.rs
+++ b/crates/openshell-core/src/inference.rs
@@ -254,7 +254,7 @@ pub fn normalize_inference_provider_type(input: &str) -> Option<&'static str> {
     match input.trim().to_ascii_lowercase().as_str() {
         "openai" => Some("openai"),
         "anthropic" => Some("anthropic"),
-        "anthropic-oauth" | "claude-plan" => Some("anthropic-oauth"),
+            "anthropic-oauth" | "claude-subscription" => Some("anthropic-oauth"),
         "nvidia" => Some("nvidia"),
         "deepinfra" => Some("deepinfra"),
         "aws-bedrock" => Some("aws-bedrock"),
@@ -514,16 +514,16 @@ mod tests {
 
     #[test]
     fn profile_for_anthropic_oauth_types() {
-        for key in &["anthropic-oauth", "claude-plan", "Anthropic-OAuth"] {
+        for key in &["anthropic-oauth", "claude-subscription", "Anthropic-OAuth"] {
             let profile = profile_for(key).expect("anthropic-oauth profile should be Some");
             assert_eq!(profile.provider_type, "anthropic-oauth");
         }
     }
 
     #[test]
-    fn normalize_aliases_claude_plan_to_anthropic_oauth() {
+    fn normalize_aliases_claude_subscription_to_anthropic_oauth() {
         assert_eq!(
-            normalize_inference_provider_type("claude-plan"),
+            normalize_inference_provider_type("claude-subscription"),
             Some("anthropic-oauth")
         );
         assert_eq!(

--- a/crates/openshell-core/src/inference.rs
+++ b/crates/openshell-core/src/inference.rs
@@ -120,6 +120,14 @@ pub const ANTHROPIC_OAUTH_TOKEN_KEY: &str = "ANTHROPIC_OAUTH_TOKEN";
 /// Anthropic subscription OAuth token (as opposed to an API key).
 pub const ANTHROPIC_OAUTH_BETA: &str = "oauth-2025-04-20";
 
+/// Non-secret Anthropic env keys that sandbox clients must read at process
+/// startup. The credential pipeline placeholderizes all provider env values;
+/// these keys are resolved back to real values in the sandbox env because a
+/// placeholderized base URL cannot be parsed by SDKs. `ANTHROPIC_AUTH_TOKEN`
+/// and `ANTHROPIC_API_KEY` are deliberately excluded: they may hold real
+/// secrets and stay egress-time placeholders.
+pub const ANTHROPIC_STATIC_CONFIG_KEYS: &[&str] = &["ANTHROPIC_BASE_URL"];
+
 /// Inference profile for the Anthropic subscription ("plan") OAuth flow.
 ///
 /// Differs from [`ANTHROPIC_PROFILE`] in two ways the Anthropic API requires for
@@ -254,7 +262,7 @@ pub fn normalize_inference_provider_type(input: &str) -> Option<&'static str> {
     match input.trim().to_ascii_lowercase().as_str() {
         "openai" => Some("openai"),
         "anthropic" => Some("anthropic"),
-            "anthropic-oauth" | "claude-subscription" => Some("anthropic-oauth"),
+        "anthropic-oauth" | "claude-subscription" => Some("anthropic-oauth"),
         "nvidia" => Some("nvidia"),
         "deepinfra" => Some("deepinfra"),
         "aws-bedrock" => Some("aws-bedrock"),

--- a/crates/openshell-core/src/inference.rs
+++ b/crates/openshell-core/src/inference.rs
@@ -108,6 +108,40 @@ static ANTHROPIC_PROFILE: InferenceProviderProfile = InferenceProviderProfile {
     passthrough_headers: &["anthropic-version", "anthropic-beta"],
 };
 
+/// Credential key holding the Anthropic subscription ("plan") OAuth access token.
+///
+/// Written by the gateway's `OAuth2` refresh worker via the `--from-claude-login`
+/// CLI flow and consumed by [`ANTHROPIC_OAUTH_PROFILE`]. This credential is
+/// proxy-only: it is injected as an `Authorization: Bearer` header at the egress
+/// boundary and is never exported into the sandbox environment.
+pub const ANTHROPIC_OAUTH_TOKEN_KEY: &str = "ANTHROPIC_OAUTH_TOKEN";
+
+/// The `anthropic-beta` flag required for requests authenticated with an
+/// Anthropic subscription OAuth token (as opposed to an API key).
+pub const ANTHROPIC_OAUTH_BETA: &str = "oauth-2025-04-20";
+
+/// Inference profile for the Anthropic subscription ("plan") OAuth flow.
+///
+/// Differs from [`ANTHROPIC_PROFILE`] in two ways the Anthropic API requires for
+/// subscription tokens: the token is sent as `Authorization: Bearer <token>`
+/// (not `x-api-key`), and every request must carry `anthropic-beta:
+/// oauth-2025-04-20`. The beta flag is a default header so the boundary forces it
+/// even when the sandbox client does not send it; the router merges it with any
+/// client-supplied `anthropic-beta` value.
+static ANTHROPIC_OAUTH_PROFILE: InferenceProviderProfile = InferenceProviderProfile {
+    provider_type: "anthropic-oauth",
+    default_base_url: "https://api.anthropic.com/v1",
+    protocols: ANTHROPIC_PROTOCOLS,
+    credential_key_names: &[ANTHROPIC_OAUTH_TOKEN_KEY],
+    base_url_config_keys: &["ANTHROPIC_BASE_URL"],
+    auth: AuthHeader::Bearer,
+    default_headers: &[
+        ("anthropic-version", "2023-06-01"),
+        ("anthropic-beta", ANTHROPIC_OAUTH_BETA),
+    ],
+    passthrough_headers: &["anthropic-version", "anthropic-beta"],
+};
+
 /// Credential environment variable names for the Vertex AI provider, in priority order.
 ///
 /// These are referenced by both the provider discovery logic in `openshell-providers`
@@ -220,6 +254,7 @@ pub fn normalize_inference_provider_type(input: &str) -> Option<&'static str> {
     match input.trim().to_ascii_lowercase().as_str() {
         "openai" => Some("openai"),
         "anthropic" => Some("anthropic"),
+        "anthropic-oauth" | "claude-plan" => Some("anthropic-oauth"),
         "nvidia" => Some("nvidia"),
         "deepinfra" => Some("deepinfra"),
         "aws-bedrock" => Some("aws-bedrock"),
@@ -238,6 +273,7 @@ pub fn profile_for(provider_type: &str) -> Option<&'static InferenceProviderProf
     match normalize_inference_provider_type(provider_type)? {
         "openai" => Some(&OPENAI_PROFILE),
         "anthropic" => Some(&ANTHROPIC_PROFILE),
+        "anthropic-oauth" => Some(&ANTHROPIC_OAUTH_PROFILE),
         "nvidia" => Some(&NVIDIA_PROFILE),
         "deepinfra" => Some(&DEEPINFRA_PROFILE),
         "google-vertex-ai" => Some(&VERTEX_AI_PROFILE),
@@ -474,6 +510,43 @@ mod tests {
         let (auth, headers) = auth_for_provider_type("google-vertex-ai");
         assert_eq!(auth, AuthHeader::Bearer);
         assert!(headers.is_empty());
+    }
+
+    #[test]
+    fn profile_for_anthropic_oauth_types() {
+        for key in &["anthropic-oauth", "claude-plan", "Anthropic-OAuth"] {
+            let profile = profile_for(key).expect("anthropic-oauth profile should be Some");
+            assert_eq!(profile.provider_type, "anthropic-oauth");
+        }
+    }
+
+    #[test]
+    fn normalize_aliases_claude_plan_to_anthropic_oauth() {
+        assert_eq!(
+            normalize_inference_provider_type("claude-plan"),
+            Some("anthropic-oauth")
+        );
+        assert_eq!(
+            normalize_inference_provider_type("anthropic-oauth"),
+            Some("anthropic-oauth")
+        );
+    }
+
+    #[test]
+    fn auth_for_anthropic_oauth_uses_bearer_with_default_headers() {
+        let (auth, headers) = auth_for_provider_type("anthropic-oauth");
+        assert_eq!(auth, AuthHeader::Bearer);
+        assert!(
+            headers
+                .iter()
+                .any(|(k, v)| *k == "anthropic-version" && *v == "2023-06-01")
+        );
+        assert!(
+            headers
+                .iter()
+                .any(|(k, v)| *k == "anthropic-beta" && *v == ANTHROPIC_OAUTH_BETA),
+            "anthropic-beta must be a default header so the sandbox cannot omit it"
+        );
     }
 
     #[test]

--- a/crates/openshell-core/src/provider_credentials.rs
+++ b/crates/openshell-core/src/provider_credentials.rs
@@ -152,24 +152,27 @@ impl ProviderCredentialState {
         inner.current = Arc::new(env);
     }
 
-    /// Return `child_env` with GCP static config vars resolved to real values.
+    /// Return `child_env` with non-secret static config vars resolved to real
+    /// values.
     ///
-    /// The credential pipeline placeholderizes ALL env values, but GCP SDKs
-    /// and coding agents read certain vars (project ID, region, metadata host)
-    /// at process startup before any HTTP request flows through the proxy.
-    /// This method overrides those vars with resolved real values while
-    /// keeping secret credentials (like `GCP_ACCESS_TOKEN`) as placeholders.
+    /// The credential pipeline placeholderizes ALL env values, but SDKs and
+    /// coding agents read certain vars (GCP project ID, region, metadata host,
+    /// Anthropic base URL) at process startup before any HTTP request flows
+    /// through the proxy. This method overrides those vars with resolved real
+    /// values while keeping secret credentials (like `GCP_ACCESS_TOKEN` or
+    /// `ANTHROPIC_AUTH_TOKEN`) as placeholders.
     ///
     /// Three layers of env var injection:
     /// 1. **Synthetic vars** (`GCE_METADATA_IP`, `METADATA_SERVER_DETECTION`)
     ///    — sandbox-internal config not from user
     ///    input, inserted directly here with real values.
-    /// 2. **`google_cloud::STATIC_CONFIG_KEYS`** — user-provided non-secret config
-    ///    (project ID, region, SA email) that was placeholderized by
+    /// 2. **`google_cloud::STATIC_CONFIG_KEYS`** and
+    ///    **`inference::ANTHROPIC_STATIC_CONFIG_KEYS`** — non-secret config
+    ///    (project ID, region, SA email, base URL) that was placeholderized by
     ///    `ProviderPlugin::inject_env` → `SecretResolver`; un-placeholderized
     ///    here so SDKs can read them at startup.
     /// 3. Everything else stays as placeholders for proxy-time resolution.
-    pub fn child_env_with_gcp_resolved(&self) -> HashMap<String, String> {
+    pub fn child_env_with_static_config_resolved(&self) -> HashMap<String, String> {
         use crate::google_cloud;
 
         let inner = self
@@ -177,6 +180,18 @@ impl ProviderCredentialState {
             .read()
             .expect("provider credential state poisoned");
         let mut env = inner.current.child_env.clone();
+
+        if let Some(ref resolver) = inner.combined_resolver {
+            for key in crate::inference::ANTHROPIC_STATIC_CONFIG_KEYS {
+                if !env.contains_key(*key) {
+                    continue;
+                }
+                let placeholder = crate::secrets::placeholder_for_env_key(key);
+                if let Some(value) = resolver.resolve_placeholder(&placeholder) {
+                    env.insert((*key).to_string(), value.to_string());
+                }
+            }
+        }
 
         let has_gcp_metadata = env.contains_key("GCE_METADATA_HOST");
         let has_gcp_config = google_cloud::STATIC_CONFIG_KEYS
@@ -421,14 +436,14 @@ mod tests {
     }
 
     #[test]
-    fn child_env_with_gcp_resolved_without_gcp_returns_unchanged() {
+    fn child_env_with_static_config_resolved_without_gcp_returns_unchanged() {
         let state = ProviderCredentialState::from_environment(
             1,
             HashMap::from([("GITHUB_TOKEN".to_string(), "ghp_abc".to_string())]),
             HashMap::new(),
             HashMap::new(),
         );
-        let env = state.child_env_with_gcp_resolved();
+        let env = state.child_env_with_static_config_resolved();
         assert_eq!(
             env.get("GITHUB_TOKEN").map(String::as_str),
             Some("openshell:resolve:env:v1_GITHUB_TOKEN"),
@@ -439,7 +454,7 @@ mod tests {
     }
 
     #[test]
-    fn child_env_with_gcp_resolved_overrides_gcp_static_vars() {
+    fn child_env_with_static_config_resolved_overrides_gcp_static_vars() {
         let state = ProviderCredentialState::from_environment(
             1,
             HashMap::from([
@@ -454,7 +469,7 @@ mod tests {
             HashMap::new(),
             HashMap::new(),
         );
-        let env = state.child_env_with_gcp_resolved();
+        let env = state.child_env_with_static_config_resolved();
 
         assert_eq!(
             env.get("GCE_METADATA_HOST").map(String::as_str),
@@ -483,7 +498,7 @@ mod tests {
     }
 
     #[test]
-    fn child_env_with_gcp_resolved_handles_missing_config_keys() {
+    fn child_env_with_static_config_resolved_handles_missing_config_keys() {
         let state = ProviderCredentialState::from_environment(
             1,
             HashMap::from([
@@ -493,7 +508,7 @@ mod tests {
             HashMap::new(),
             HashMap::new(),
         );
-        let env = state.child_env_with_gcp_resolved();
+        let env = state.child_env_with_static_config_resolved();
 
         assert_eq!(
             env.get("GCE_METADATA_HOST").map(String::as_str),
@@ -506,6 +521,37 @@ mod tests {
                     .unwrap()
                     .starts_with("openshell:resolve:env:"),
             "missing config key should not be injected with a real value"
+        );
+    }
+
+    #[test]
+    fn child_env_with_static_config_resolved_resolves_anthropic_base_url() {
+        let state = ProviderCredentialState::from_environment(
+            1,
+            HashMap::from([
+                (
+                    "ANTHROPIC_BASE_URL".to_string(),
+                    "https://inference.local".to_string(),
+                ),
+                (
+                    "ANTHROPIC_AUTH_TOKEN".to_string(),
+                    "inference-local".to_string(),
+                ),
+            ]),
+            HashMap::new(),
+            HashMap::new(),
+        );
+        let env = state.child_env_with_static_config_resolved();
+
+        assert_eq!(
+            env.get("ANTHROPIC_BASE_URL").map(String::as_str),
+            Some("https://inference.local"),
+            "base URL must be a parseable real value at process startup"
+        );
+        let token = env.get("ANTHROPIC_AUTH_TOKEN").map(String::as_str).unwrap();
+        assert!(
+            token.starts_with("openshell:resolve:env:"),
+            "ANTHROPIC_AUTH_TOKEN must stay as placeholder, got: {token}"
         );
     }
 
@@ -588,7 +634,7 @@ mod tests {
     }
 
     #[test]
-    fn child_env_with_gcp_resolved_resolves_vertex_vars_without_metadata_host() {
+    fn child_env_with_static_config_resolved_resolves_vertex_vars_without_metadata_host() {
         let state = ProviderCredentialState::from_environment(
             1,
             HashMap::from([
@@ -602,7 +648,7 @@ mod tests {
             HashMap::new(),
             HashMap::new(),
         );
-        let env = state.child_env_with_gcp_resolved();
+        let env = state.child_env_with_static_config_resolved();
         assert_eq!(
             env.get("GOOSE_PROVIDER").map(String::as_str),
             Some("gcp_vertex_ai"),

--- a/crates/openshell-providers/src/lib.rs
+++ b/crates/openshell-providers/src/lib.rs
@@ -114,6 +114,7 @@ impl ProviderRegistry {
         registry.register(providers::generic::GenericProvider);
         registry.register(providers::openai::SPEC);
         registry.register(providers::anthropic::SPEC);
+        registry.register(providers::anthropic_oauth::AnthropicOauthProvider);
         registry.register(providers::nvidia::SPEC);
         registry.register(providers::deepinfra::SPEC);
         registry.register(providers::github::SPEC);

--- a/crates/openshell-providers/src/profiles.rs
+++ b/crates/openshell-providers/src/profiles.rs
@@ -22,6 +22,7 @@ use std::sync::OnceLock;
 const PATH_TEMPLATE_CREDENTIAL_PLACEHOLDER: &str = "{credential}";
 
 const BUILT_IN_PROFILE_YAMLS: &[&str] = &[
+    include_str!("../../../providers/anthropic-oauth.yaml"),
     include_str!("../../../providers/aws.yaml"),
     include_str!("../../../providers/aws-bedrock.yaml"),
     include_str!("../../../providers/aws-s3.yaml"),

--- a/crates/openshell-providers/src/providers/anthropic_oauth.rs
+++ b/crates/openshell-providers/src/providers/anthropic_oauth.rs
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use crate::{DiscoveredProvider, Provider, ProviderError, ProviderPlugin};
+
+pub struct AnthropicOauthProvider;
+
+/// Placeholder injected as `ANTHROPIC_AUTH_TOKEN` so agent CLIs (Claude Code,
+/// Anthropic SDKs) authenticate without prompting for an interactive login.
+/// `ANTHROPIC_AUTH_TOKEN` is used instead of `ANTHROPIC_API_KEY` because
+/// Claude Code asks for confirmation before trusting an environment API key
+/// but accepts an auth token silently. The value never reaches Anthropic:
+/// `inference.local` replaces caller-supplied `Authorization` and injects the
+/// real subscription token at the egress boundary.
+pub const ANTHROPIC_AUTH_TOKEN_PLACEHOLDER: &str = "inference-local";
+
+/// Base URL agents inside the sandbox must use to reach the model. The
+/// subscription OAuth token is proxy-only, so direct calls to
+/// `api.anthropic.com` cannot authenticate; all traffic goes through the
+/// gateway's inference endpoint.
+pub const ANTHROPIC_BASE_URL_VALUE: &str = "https://inference.local";
+
+impl ProviderPlugin for AnthropicOauthProvider {
+    fn id(&self) -> &'static str {
+        "anthropic-oauth"
+    }
+
+    fn discover_existing(&self) -> Result<Option<DiscoveredProvider>, ProviderError> {
+        // OAuth material is harvested via `--from-claude-login`, not env
+        // scanning, and the access token must never be treated as an
+        // injectable env credential.
+        Ok(None)
+    }
+
+    fn inject_env(&self, _provider: &Provider, env: &mut HashMap<String, String>) {
+        env.entry("ANTHROPIC_BASE_URL".to_string())
+            .or_insert_with(|| ANTHROPIC_BASE_URL_VALUE.to_string());
+        env.entry("ANTHROPIC_AUTH_TOKEN".to_string())
+            .or_insert_with(|| ANTHROPIC_AUTH_TOKEN_PLACEHOLDER.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn injects_base_url_and_placeholder_auth_token() {
+        let provider = Provider {
+            r#type: "anthropic-oauth".to_string(),
+            ..Default::default()
+        };
+        let mut env = HashMap::new();
+        AnthropicOauthProvider.inject_env(&provider, &mut env);
+
+        assert_eq!(
+            env.get("ANTHROPIC_BASE_URL").map(String::as_str),
+            Some(ANTHROPIC_BASE_URL_VALUE)
+        );
+        assert_eq!(
+            env.get("ANTHROPIC_AUTH_TOKEN").map(String::as_str),
+            Some(ANTHROPIC_AUTH_TOKEN_PLACEHOLDER)
+        );
+        assert!(
+            !env.contains_key("ANTHROPIC_API_KEY"),
+            "must not inject an API key: Claude Code prompts before trusting it"
+        );
+    }
+
+    #[test]
+    fn does_not_override_existing_values() {
+        let provider = Provider {
+            r#type: "anthropic-oauth".to_string(),
+            ..Default::default()
+        };
+        let mut env = HashMap::from([(
+            "ANTHROPIC_BASE_URL".to_string(),
+            "https://custom.example".to_string(),
+        )]);
+        AnthropicOauthProvider.inject_env(&provider, &mut env);
+
+        assert_eq!(
+            env.get("ANTHROPIC_BASE_URL").map(String::as_str),
+            Some("https://custom.example")
+        );
+    }
+
+    #[test]
+    fn discovery_finds_nothing() {
+        assert!(
+            AnthropicOauthProvider
+                .discover_existing()
+                .expect("discovery should not error")
+                .is_none()
+        );
+    }
+}

--- a/crates/openshell-providers/src/providers/mod.rs
+++ b/crates/openshell-providers/src/providers/mod.rs
@@ -31,6 +31,7 @@ macro_rules! test_discovers_env_credential {
     };
 }
 pub mod anthropic;
+pub mod anthropic_oauth;
 pub mod claude;
 pub mod codex;
 pub mod copilot;

--- a/crates/openshell-router/src/backend.rs
+++ b/crates/openshell-router/src/backend.rs
@@ -82,6 +82,23 @@ const VERTEX_ANTHROPIC_VERSION: &str = "vertex-2023-10-16";
 const COMMON_INFERENCE_REQUEST_HEADERS: [&str; 4] =
     ["content-type", "accept", "accept-encoding", "user-agent"];
 
+/// The Anthropic beta-flags header. Its value is a comma-separated token list,
+/// so route-forced flags must be merged with client-supplied ones rather than
+/// overwriting them.
+const ANTHROPIC_BETA_HEADER: &str = "anthropic-beta";
+
+/// Merge a comma-separated `anthropic-beta` value into `tokens`, preserving
+/// order and dropping case-insensitive duplicates and empty entries.
+fn merge_beta_tokens(tokens: &mut Vec<String>, raw: &str) {
+    for token in raw.split(',') {
+        let token = token.trim();
+        if token.is_empty() || tokens.iter().any(|t| t.eq_ignore_ascii_case(token)) {
+            continue;
+        }
+        tokens.push(token.to_string());
+    }
+}
+
 impl StreamingProxyResponse {
     /// Create from a fully-buffered [`ProxyResponse`] (for mock routes).
     pub fn from_buffered(resp: ProxyResponse) -> Self {
@@ -251,17 +268,36 @@ fn prepare_backend_request(
             // (SigV4 signing is a separate follow-up).
         }
     }
+    // `anthropic-beta` is handled separately below: a route may both forward a
+    // client-supplied value and force its own (e.g. the Anthropic OAuth profile
+    // must always send `oauth-2025-04-20`). Applying it in this loop would emit a
+    // duplicate header, so collect its tokens instead of forwarding here.
+    let mut beta_tokens: Vec<String> = Vec::new();
     for (name, value) in &headers {
-        builder = builder.header(name.as_str(), value.as_str());
+        if name.eq_ignore_ascii_case(ANTHROPIC_BETA_HEADER) {
+            merge_beta_tokens(&mut beta_tokens, value);
+        } else {
+            builder = builder.header(name.as_str(), value.as_str());
+        }
     }
 
     // Apply route-level default headers (e.g. anthropic-version) unless
-    // the client already sent them.
+    // the client already sent them. `anthropic-beta` defaults are merged into
+    // the client's value rather than skipped, so a forced beta flag survives
+    // alongside any betas the client requested.
     for (name, value) in &route.default_headers {
+        if name.eq_ignore_ascii_case(ANTHROPIC_BETA_HEADER) {
+            merge_beta_tokens(&mut beta_tokens, value);
+            continue;
+        }
         let already_sent = headers.iter().any(|(h, _)| h.eq_ignore_ascii_case(name));
         if !already_sent {
             builder = builder.header(name.as_str(), value.as_str());
         }
+    }
+
+    if !beta_tokens.is_empty() {
+        builder = builder.header(ANTHROPIC_BETA_HEADER, beta_tokens.join(","));
     }
 
     // Rewrite the JSON body for backend compatibility:
@@ -1902,6 +1938,97 @@ mod tests {
             !received_body.as_object().unwrap().contains_key("model"),
             "Vertex Anthropic route must not inject model into the body, got: {received_body}"
         );
+    }
+
+    /// The anthropic-oauth route carries `anthropic-beta: oauth-2025-04-20` as a
+    /// mandatory default header. A client that also sends `anthropic-beta` must
+    /// not be able to drop it: the route default and the client value are merged
+    /// into a single comma-separated header.
+    #[tokio::test]
+    async fn anthropic_oauth_route_merges_mandatory_beta_with_client_betas() {
+        let mock_server = MockServer::start().await;
+
+        let route = ResolvedRoute {
+            name: "inference.local".to_string(),
+            endpoint: mock_server.uri(),
+            model: "claude-sonnet-4-20250514".to_string(),
+            api_key: "sk-ant-oat-test".to_string(),
+            protocols: vec!["anthropic_messages".to_string()],
+            auth: AuthHeader::Bearer,
+            default_headers: vec![
+                ("anthropic-version".to_string(), "2023-06-01".to_string()),
+                ("anthropic-beta".to_string(), "oauth-2025-04-20".to_string()),
+            ],
+            passthrough_headers: vec![
+                "anthropic-version".to_string(),
+                "anthropic-beta".to_string(),
+            ],
+            timeout: DEFAULT_ROUTE_TIMEOUT,
+            model_in_path: false,
+            request_path_override: None,
+        };
+
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "m"})))
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::builder().build().unwrap();
+        let body = bytes::Bytes::from_static(b"{}");
+        let headers = vec![
+            ("content-type".to_string(), "application/json".to_string()),
+            (
+                "anthropic-beta".to_string(),
+                "tool-use-2024-10-22".to_string(),
+            ),
+        ];
+
+        let (builder, _url) = prepare_backend_request(
+            &client,
+            &route,
+            "POST",
+            "/v1/messages",
+            &headers,
+            body,
+            false,
+        )
+        .unwrap();
+
+        let response = builder.send().await.unwrap();
+        assert_eq!(response.status().as_u16(), 200);
+
+        let received = mock_server.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1);
+        // The outgoing request must carry a single merged anthropic-beta header
+        // containing both the mandatory OAuth flag and the client's beta.
+        let beta_values: Vec<&str> = received[0]
+            .headers
+            .get_all("anthropic-beta")
+            .iter()
+            .map(|v| v.to_str().unwrap())
+            .collect();
+        assert_eq!(
+            beta_values.len(),
+            1,
+            "anthropic-beta must be emitted exactly once, got: {beta_values:?}"
+        );
+        let merged = beta_values[0];
+        assert!(
+            merged.contains("oauth-2025-04-20"),
+            "mandatory OAuth beta must survive, got: {merged}"
+        );
+        assert!(
+            merged.contains("tool-use-2024-10-22"),
+            "client beta must be preserved, got: {merged}"
+        );
+
+        // The Bearer token must be injected at the boundary as Authorization.
+        let auth = received[0]
+            .headers
+            .get("authorization")
+            .map(|v| v.to_str().unwrap());
+        assert_eq!(auth, Some("Bearer sk-ant-oat-test"));
     }
 
     /// Claude Code and other Anthropic SDK clients always send "model" in the

--- a/crates/openshell-sandbox/src/google_cloud_metadata.rs
+++ b/crates/openshell-sandbox/src/google_cloud_metadata.rs
@@ -11,7 +11,7 @@
 //! The emulator runs as a loopback HTTP server inside the sandbox network
 //! namespace (see [`metadata_server`](crate::metadata_server)). GCP SDKs
 //! discover it via the `GCE_METADATA_HOST` environment variable, which is
-//! set to the loopback address by `child_env_with_gcp_resolved()`.
+//! set to the loopback address by `child_env_with_static_config_resolved()`.
 
 use miette::{IntoDiagnostic, Result};
 use openshell_core::provider_credentials::ProviderCredentialState;

--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -287,7 +287,7 @@ pub async fn run_sandbox(
                 provider_credential_expires_at_ms,
                 dynamic_credentials,
             );
-            let provider_env = provider_credentials.child_env_with_gcp_resolved();
+            let provider_env = provider_credentials.child_env_with_static_config_resolved();
             (provider_credentials, provider_env)
         };
     let process_control_writer = process_control_connection
@@ -2698,7 +2698,9 @@ async fn run_policy_poll_loop(ctx: PolicyPollLoopContext) -> Result<()> {
                         env_result.credential_expires_at_ms,
                         env_result.dynamic_credentials,
                     );
-                    let child_env = ctx.provider_credentials.child_env_with_gcp_resolved();
+                    let child_env = ctx
+                        .provider_credentials
+                        .child_env_with_static_config_resolved();
                     let env_count = child_env.len();
                     if let Some(publisher) = ctx.sidecar_control_publisher.as_ref() {
                         publisher.publish_provider_env(

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -1177,9 +1177,16 @@ fn active_provider_credential_keys(provider: &Provider, now_ms: i64) -> Vec<Stri
 }
 
 fn is_non_injectable_provider_credential(provider: &Provider, key: &str) -> bool {
-    openshell_core::inference::normalize_inference_provider_type(&provider.r#type)
-        == Some("google-vertex-ai")
-        && key == "GOOGLE_SERVICE_ACCOUNT_KEY"
+    match openshell_core::inference::normalize_inference_provider_type(&provider.r#type) {
+        // The Vertex service-account key is used by the gateway to mint tokens; it
+        // must never be exported into the sandbox environment.
+        Some("google-vertex-ai") => key == "GOOGLE_SERVICE_ACCOUNT_KEY",
+        // The Anthropic subscription OAuth access token is injected as a Bearer
+        // header at the egress boundary only. It must never reach the sandbox
+        // environment, so the user never authenticates inside the sandbox.
+        Some("anthropic-oauth") => key == openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY,
+        _ => false,
+    }
 }
 
 pub(super) fn is_valid_env_key(key: &str) -> bool {
@@ -3365,6 +3372,7 @@ mod tests {
         assert_eq!(
             ids,
             vec![
+                "anthropic-oauth",
                 "aws",
                 "aws-bedrock",
                 "aws-s3",
@@ -5911,6 +5919,65 @@ mod tests {
             result.get("GOOGLE_VERTEX_AI_SERVICE_ACCOUNT_TOKEN"),
             Some(&"ya29.short-lived".to_string())
         );
+    }
+
+    #[test]
+    fn anthropic_oauth_access_token_is_non_injectable() {
+        let provider = Provider {
+            r#type: "anthropic-oauth".to_string(),
+            ..Default::default()
+        };
+        assert!(is_non_injectable_provider_credential(
+            &provider,
+            openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY
+        ));
+        // The alias resolves to the same provider type and stays non-injectable.
+        let aliased = Provider {
+            r#type: "claude-plan".to_string(),
+            ..Default::default()
+        };
+        assert!(is_non_injectable_provider_credential(
+            &aliased,
+            openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY
+        ));
+        // An unrelated key on the same provider is still injectable.
+        assert!(!is_non_injectable_provider_credential(
+            &provider,
+            "SOME_OTHER_KEY"
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolve_provider_env_anthropic_oauth_never_injects_access_token() {
+        let store = test_store().await;
+        create_provider_record(
+            &store,
+            Provider {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: String::new(),
+                    name: "anthropic-plan".to_string(),
+                    created_at_ms: 0,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                    annotations: HashMap::new(),
+                }),
+                r#type: "anthropic-oauth".to_string(),
+                credentials: HashMap::from([(
+                    openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY.to_string(),
+                    "sk-ant-oat-secret".to_string(),
+                )]),
+                config: HashMap::new(),
+                credential_expires_at_ms: HashMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let result = resolve_provider_environment(&store, &["anthropic-plan".to_string()])
+            .await
+            .unwrap();
+
+        assert!(!result.contains_key(openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY));
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -5933,7 +5933,7 @@ mod tests {
         ));
         // The alias resolves to the same provider type and stays non-injectable.
         let aliased = Provider {
-            r#type: "claude-plan".to_string(),
+            r#type: "claude-subscription".to_string(),
             ..Default::default()
         };
         assert!(is_non_injectable_provider_credential(

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -5978,6 +5978,14 @@ mod tests {
             .unwrap();
 
         assert!(!result.contains_key(openshell_core::inference::ANTHROPIC_OAUTH_TOKEN_KEY));
+        // The plugin projects the inference endpoint into the sandbox env so
+        // agent CLIs work without manual configuration.
+        assert_eq!(
+            result.get("ANTHROPIC_BASE_URL").map(String::as_str),
+            Some("https://inference.local")
+        );
+        assert!(result.contains_key("ANTHROPIC_AUTH_TOKEN"));
+        assert!(!result.contains_key("ANTHROPIC_API_KEY"));
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/provider_refresh.rs
+++ b/crates/openshell-server/src/provider_refresh.rs
@@ -468,6 +468,14 @@ pub async fn refresh_provider_credential(
         }
         Err(err) => {
             let now_ms = current_time_ms();
+            let err = if anthropic_subscription_login_rejected(&provider, &err) {
+                Status::new(
+                    err.code(),
+                    format!("{}{ANTHROPIC_RELOGIN_HINT}", err.message()),
+                )
+            } else {
+                err
+            };
             state.status = "error".to_string();
             state.last_error = err.message().to_string();
             state.next_refresh_at_ms =
@@ -486,6 +494,18 @@ pub async fn refresh_provider_credential(
             Err(err)
         }
     }
+}
+
+const ANTHROPIC_RELOGIN_HINT: &str = "; the subscription login is no longer valid — run `claude login` on the host, then delete and recreate the provider with `openshell provider create --from-claude-login`";
+
+/// True when an `anthropic-oauth` refresh failed because the token endpoint
+/// rejected the grant (revoked login, lapsed plan) rather than a transient
+/// network or gateway error, so re-authenticating on the host is the fix.
+fn anthropic_subscription_login_rejected(provider: &Provider, err: &Status) -> bool {
+    openshell_core::inference::normalize_inference_provider_type(&provider.r#type)
+        == Some("anthropic-oauth")
+        && err.code() == tonic::Code::FailedPrecondition
+        && err.message().contains("token endpoint returned HTTP 4")
 }
 
 async fn apply_minted_credential(
@@ -1060,9 +1080,9 @@ async fn run_refresh_worker_tick(store: &Store) -> Result<(), Status> {
 #[cfg(test)]
 mod tests {
     use super::{
-        NewRefreshStateConfig, delete_refresh_state, get_refresh_state, new_refresh_state,
-        put_refresh_state, refresh_provider_credential, refresh_state_name, refresh_strategy_name,
-        run_refresh_worker_tick, seconds_until_ms,
+        NewRefreshStateConfig, anthropic_subscription_login_rejected, delete_refresh_state,
+        get_refresh_state, new_refresh_state, put_refresh_state, refresh_provider_credential,
+        refresh_state_name, refresh_strategy_name, run_refresh_worker_tick, seconds_until_ms,
     };
     use crate::persistence::test_store;
     use openshell_core::ObjectId;
@@ -1071,6 +1091,7 @@ mod tests {
         Provider, ProviderCredentialRefreshStrategy, Sandbox, SandboxSpec,
     };
     use std::collections::HashMap;
+    use tonic::Status;
     use wiremock::matchers::{body_string_contains, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -2235,6 +2256,42 @@ mod tests {
             config: HashMap::new(),
             credential_expires_at_ms: HashMap::new(),
         }
+    }
+
+    #[test]
+    fn relogin_hint_applies_only_to_anthropic_oauth_grant_rejection() {
+        let rejected = Status::failed_precondition("token endpoint returned HTTP 400 Bad Request");
+        assert!(anthropic_subscription_login_rejected(
+            &provider("plan", "anthropic-oauth"),
+            &rejected
+        ));
+        assert!(
+            anthropic_subscription_login_rejected(
+                &provider("plan", "claude-subscription"),
+                &rejected
+            ),
+            "type alias must get the hint too"
+        );
+        assert!(
+            !anthropic_subscription_login_rejected(
+                &provider("plan", "anthropic-oauth"),
+                &Status::unavailable("token endpoint request failed: timeout")
+            ),
+            "transient network errors must not suggest re-login"
+        );
+        assert!(
+            !anthropic_subscription_login_rejected(
+                &provider("plan", "anthropic-oauth"),
+                &Status::failed_precondition(
+                    "token endpoint returned HTTP 500 Internal Server Error"
+                )
+            ),
+            "server-side errors must not suggest re-login"
+        );
+        assert!(!anthropic_subscription_login_rejected(
+            &provider("graph", "custom"),
+            &rejected
+        ));
     }
 
     const TEST_RSA_PRIVATE_KEY: &str = r"-----BEGIN PRIVATE KEY-----

--- a/crates/openshell-server/src/provider_refresh.rs
+++ b/crates/openshell-server/src/provider_refresh.rs
@@ -468,7 +468,8 @@ pub async fn refresh_provider_credential(
         }
         Err(err) => {
             let now_ms = current_time_ms();
-            let err = if anthropic_subscription_login_rejected(&provider, &err) {
+            let reauth_required = anthropic_subscription_login_rejected(&provider, &err);
+            let err = if reauth_required {
                 Status::new(
                     err.code(),
                     format!("{}{ANTHROPIC_RELOGIN_HINT}", err.message()),
@@ -476,11 +477,19 @@ pub async fn refresh_provider_credential(
             } else {
                 err
             };
-            state.status = "error".to_string();
+            if reauth_required {
+                // Terminal failure: the grant is revoked or the plan lapsed, so
+                // automatic retries can never succeed. The worker skips this
+                // state; an explicit RotateProviderCredential retries manually.
+                state.status = REAUTH_REQUIRED_STATUS.to_string();
+                state.next_refresh_at_ms = 0;
+            } else {
+                state.status = "error".to_string();
+                state.next_refresh_at_ms =
+                    now_ms.saturating_add(REFRESH_ERROR_RETRY_SECONDS.saturating_mul(1000));
+            }
             state.last_error = err.message().to_string();
-            state.next_refresh_at_ms =
-                now_ms.saturating_add(REFRESH_ERROR_RETRY_SECONDS.saturating_mul(1000));
-            persist_refresh_state_if_current(store, &state, expected_version).await?;
+            put_refresh_state(store, &state).await?;
             warn!(
                 provider = %state.provider_name,
                 credential_key = %state.credential_key,
@@ -497,6 +506,12 @@ pub async fn refresh_provider_credential(
 }
 
 const ANTHROPIC_RELOGIN_HINT: &str = "; the subscription login is no longer valid — run `claude login` on the host, then delete and recreate the provider with `openshell provider create --from-claude-login`";
+
+/// Terminal refresh status: the stored grant was rejected by the token
+/// endpoint and only host re-authentication can fix it. The background worker
+/// skips these states instead of retrying; `RotateProviderCredential` remains
+/// the manual retry path.
+pub const REAUTH_REQUIRED_STATUS: &str = "reauth_required";
 
 /// True when an `anthropic-oauth` refresh failed because the token endpoint
 /// rejected the grant (revoked login, lapsed plan) rather than a transient
@@ -1043,6 +1058,15 @@ async fn run_refresh_worker_tick(store: &Store) -> Result<(), Status> {
         if !due && !rotation_requested {
             continue;
         }
+        if state.status == REAUTH_REQUIRED_STATUS && !rotation_requested {
+            info!(
+                provider = %state.provider_name,
+                credential_key = %state.credential_key,
+                status = %state.status,
+                "skipping provider credential refresh until host re-authentication"
+            );
+            continue;
+        }
         if !is_gateway_mintable_strategy(strategy) {
             warn!(
                 provider = %state.provider_name,
@@ -1080,7 +1104,7 @@ async fn run_refresh_worker_tick(store: &Store) -> Result<(), Status> {
 #[cfg(test)]
 mod tests {
     use super::{
-        NewRefreshStateConfig, anthropic_subscription_login_rejected, delete_refresh_state,
+        NewRefreshStateConfig, REAUTH_REQUIRED_STATUS, anthropic_subscription_login_rejected,
         get_refresh_state, new_refresh_state, put_refresh_state, refresh_provider_credential,
         refresh_state_name, refresh_strategy_name, run_refresh_worker_tick, seconds_until_ms,
     };
@@ -1479,766 +1503,80 @@ mod tests {
         );
     }
 
-    #[test]
-    fn refresh_strategy_name_includes_aws_sts() {
-        assert_eq!(
-            refresh_strategy_name(ProviderCredentialRefreshStrategy::AwsStsAssumeRole as i32),
-            "aws_sts_assume_role"
-        );
-    }
-
     #[tokio::test]
-    async fn aws_sts_assume_role_mints_three_credentials_from_mock_endpoint() {
+    async fn anthropic_grant_rejection_marks_reauth_required_and_worker_stops_retrying() {
         let mock_server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(body_string_contains("Action=AssumeRole"))
-            .and(body_string_contains("RoleArn=arn"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                r#"<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
-  <AssumeRoleResult>
-    <AssumedRoleUser>
-      <AssumedRoleId>AROA3XFRBF23:test-session</AssumedRoleId>
-      <Arn>arn:aws:sts::123456789012:assumed-role/TestRole/test-session</Arn>
-    </AssumedRoleUser>
-    <Credentials>
-      <AccessKeyId>ASIAMOCKKEY</AccessKeyId>
-      <SecretAccessKey>MockSecretAccessKey123</SecretAccessKey>
-      <SessionToken>MockSessionTokenXYZ</SessionToken>
-      <Expiration>2099-01-01T00:00:00Z</Expiration>
-    </Credentials>
-  </AssumeRoleResult>
-  <ResponseMetadata>
-    <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
-  </ResponseMetadata>
-</AssumeRoleResponse>"#,
-            ))
+            .and(path("/token"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .set_body_json(serde_json::json!({ "error": "invalid_grant" })),
+            )
+            // Initial refresh + explicit manual retry. The two worker ticks in
+            // between must not add requests.
+            .expect(2)
             .mount(&mock_server)
             .await;
 
         let store = test_store().await;
-        crate::grpc::policy::set_global_bool_setting_for_test(
-            &store,
-            openshell_core::settings::PROVIDERS_V2_ENABLED_KEY,
-            true,
-        )
-        .await
-        .unwrap();
-        let prov = provider("aws-sts-test", "aws");
-        store.put_message(&prov).await.unwrap();
-
+        let provider = provider("claude-subscription", "anthropic-oauth");
+        store.put_message(&provider).await.unwrap();
         let state = new_refresh_state(
-            &prov,
-            "AWS_ACCESS_KEY_ID",
+            &provider,
+            "ANTHROPIC_OAUTH_TOKEN",
             NewRefreshStateConfig {
-                additional_output_keys: HashMap::from([
-                    (
-                        "secret_access_key".to_string(),
-                        "AWS_SECRET_ACCESS_KEY".to_string(),
-                    ),
-                    ("session_token".to_string(), "AWS_SESSION_TOKEN".to_string()),
-                ]),
-                strategy: ProviderCredentialRefreshStrategy::AwsStsAssumeRole,
+                strategy: ProviderCredentialRefreshStrategy::Oauth2RefreshToken,
                 material: HashMap::from([
+                    ("client_id".to_string(), "client-id".to_string()),
                     (
-                        "role_arn".to_string(),
-                        "arn:aws:iam::123456789012:role/TestRole".to_string(),
+                        "refresh_token".to_string(),
+                        "revoked-refresh-token".to_string(),
                     ),
-                    ("session_name".to_string(), "test-session".to_string()),
-                    ("aws_access_key_id".to_string(), "AKIATESTKEY".to_string()),
-                    (
-                        "aws_secret_access_key".to_string(),
-                        "TestSecretKey".to_string(),
-                    ),
-                    ("sts_endpoint_url".to_string(), mock_server.uri()),
                 ]),
-                secret_material_keys: vec!["aws_secret_access_key".to_string()],
+                secret_material_keys: vec!["refresh_token".to_string()],
                 expires_at_ms: 0,
-                token_url: String::new(),
+                token_url: format!("{}/token", mock_server.uri()),
                 scopes: Vec::new(),
-                refresh_before_seconds: 300,
-                max_lifetime_seconds: 3600,
+                refresh_before_seconds: 30,
+                max_lifetime_seconds: 60,
             },
         )
         .unwrap();
         put_refresh_state(&store, &state).await.unwrap();
-
-        let refreshed = refresh_provider_credential(&store, "aws-sts-test", "AWS_ACCESS_KEY_ID")
-            .await
-            .unwrap();
-        assert_eq!(refreshed.status, "refreshed");
-        assert!(refreshed.expires_at_ms > 0);
-
-        let stored = store
-            .get_message_by_name::<Provider>("aws-sts-test")
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            stored.credentials.get("AWS_ACCESS_KEY_ID"),
-            Some(&"ASIAMOCKKEY".to_string())
-        );
-        assert_eq!(
-            stored.credentials.get("AWS_SECRET_ACCESS_KEY"),
-            Some(&"MockSecretAccessKey123".to_string())
-        );
-        assert_eq!(
-            stored.credentials.get("AWS_SESSION_TOKEN"),
-            Some(&"MockSessionTokenXYZ".to_string())
-        );
-    }
-
-    #[tokio::test]
-    async fn aws_sts_mint_writes_to_resolved_additional_output_keys() {
-        let mock_server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(body_string_contains("Action=AssumeRole"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                r#"<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
-  <AssumeRoleResult>
-    <Credentials>
-      <AccessKeyId>ASIAMOCKKEY</AccessKeyId>
-      <SecretAccessKey>MockSecretAccessKey123</SecretAccessKey>
-      <SessionToken>MockSessionTokenXYZ</SessionToken>
-      <Expiration>2099-01-01T00:00:00Z</Expiration>
-    </Credentials>
-  </AssumeRoleResult>
-</AssumeRoleResponse>"#,
-            ))
-            .mount(&mock_server)
-            .await;
-
-        let store = test_store().await;
-        crate::grpc::policy::set_global_bool_setting_for_test(
-            &store,
-            openshell_core::settings::PROVIDERS_V2_ENABLED_KEY,
-            true,
-        )
-        .await
-        .unwrap();
-        let prov = provider("aws-sts-custom", "aws");
-        store.put_message(&prov).await.unwrap();
-
-        // The minter honors the resolved output->env-key map from state, not
-        // hardcoded AWS names.
-        let state = new_refresh_state(
-            &prov,
-            "AWS_ACCESS_KEY_ID",
-            NewRefreshStateConfig {
-                additional_output_keys: HashMap::from([
-                    ("secret_access_key".to_string(), "CUSTOM_SECRET".to_string()),
-                    ("session_token".to_string(), "CUSTOM_SESSION".to_string()),
-                ]),
-                strategy: ProviderCredentialRefreshStrategy::AwsStsAssumeRole,
-                material: HashMap::from([
-                    (
-                        "role_arn".to_string(),
-                        "arn:aws:iam::123456789012:role/TestRole".to_string(),
-                    ),
-                    ("aws_access_key_id".to_string(), "AKIATESTKEY".to_string()),
-                    (
-                        "aws_secret_access_key".to_string(),
-                        "TestSecretKey".to_string(),
-                    ),
-                    ("sts_endpoint_url".to_string(), mock_server.uri()),
-                ]),
-                secret_material_keys: vec!["aws_secret_access_key".to_string()],
-                expires_at_ms: 0,
-                token_url: String::new(),
-                scopes: Vec::new(),
-                refresh_before_seconds: 300,
-                max_lifetime_seconds: 3600,
-            },
-        )
-        .unwrap();
-        put_refresh_state(&store, &state).await.unwrap();
-
-        refresh_provider_credential(&store, "aws-sts-custom", "AWS_ACCESS_KEY_ID")
-            .await
-            .unwrap();
-
-        let stored = store
-            .get_message_by_name::<Provider>("aws-sts-custom")
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            stored.credentials.get("AWS_ACCESS_KEY_ID"),
-            Some(&"ASIAMOCKKEY".to_string())
-        );
-        assert_eq!(
-            stored.credentials.get("CUSTOM_SECRET"),
-            Some(&"MockSecretAccessKey123".to_string())
-        );
-        assert_eq!(
-            stored.credentials.get("CUSTOM_SESSION"),
-            Some(&"MockSessionTokenXYZ".to_string())
-        );
-        assert!(!stored.credentials.contains_key("AWS_SECRET_ACCESS_KEY"));
-    }
-
-    #[tokio::test]
-    async fn aws_sts_mint_rejects_partial_source_credentials() {
-        let store = test_store().await;
-        crate::grpc::policy::set_global_bool_setting_for_test(
-            &store,
-            openshell_core::settings::PROVIDERS_V2_ENABLED_KEY,
-            true,
-        )
-        .await
-        .unwrap();
-        let prov = provider("aws-sts-partial", "aws");
-        store.put_message(&prov).await.unwrap();
-
-        // Only the access key half of the explicit source pair is present. The
-        // mint must fail rather than fall back to the gateway's ambient identity.
-        let state = new_refresh_state(
-            &prov,
-            "AWS_ACCESS_KEY_ID",
-            NewRefreshStateConfig {
-                additional_output_keys: HashMap::from([
-                    (
-                        "secret_access_key".to_string(),
-                        "AWS_SECRET_ACCESS_KEY".to_string(),
-                    ),
-                    ("session_token".to_string(), "AWS_SESSION_TOKEN".to_string()),
-                ]),
-                strategy: ProviderCredentialRefreshStrategy::AwsStsAssumeRole,
-                material: HashMap::from([
-                    (
-                        "role_arn".to_string(),
-                        "arn:aws:iam::123456789012:role/TestRole".to_string(),
-                    ),
-                    ("aws_access_key_id".to_string(), "AKIATESTKEY".to_string()),
-                ]),
-                secret_material_keys: Vec::new(),
-                expires_at_ms: 0,
-                token_url: String::new(),
-                scopes: Vec::new(),
-                refresh_before_seconds: 300,
-                max_lifetime_seconds: 3600,
-            },
-        )
-        .unwrap();
-        put_refresh_state(&store, &state).await.unwrap();
-
-        let err = refresh_provider_credential(&store, "aws-sts-partial", "AWS_ACCESS_KEY_ID")
-            .await
-            .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::InvalidArgument);
-        assert!(err.message().contains("both be set or both omitted"));
-
-        let stored = store
-            .get_message_by_name::<Provider>("aws-sts-partial")
-            .await
-            .unwrap()
-            .unwrap();
-        assert!(!stored.credentials.contains_key("AWS_ACCESS_KEY_ID"));
-    }
-
-    #[tokio::test]
-    async fn apply_minted_credential_writes_additional_keys() {
-        use super::apply_minted_credential;
-
-        let store = test_store().await;
-        let mut prov = provider("aws-test", "aws");
-        prov.credentials
-            .insert("AWS_ACCESS_KEY_ID".to_string(), "old-key".to_string());
-        store.put_message(&prov).await.unwrap();
-
-        let minted = super::MintedCredential {
-            access_token: "AKIAIOSFODNN7EXAMPLE".to_string(),
-            expires_at_ms: 4_000_000_000_000,
-            refresh_token: None,
-            additional_credentials: HashMap::from([
-                (
-                    "AWS_SECRET_ACCESS_KEY".to_string(),
-                    "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".to_string(),
-                ),
-                (
-                    "AWS_SESSION_TOKEN".to_string(),
-                    "FwoGZXIvYXdzEBYaDH...EXAMPLETOKEN".to_string(),
-                ),
-            ]),
-        };
-
-        apply_minted_credential(&store, &prov, "AWS_ACCESS_KEY_ID", &minted)
-            .await
-            .unwrap();
-
-        let stored = store
-            .get_message_by_name::<Provider>("aws-test")
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            stored.credentials.get("AWS_ACCESS_KEY_ID"),
-            Some(&"AKIAIOSFODNN7EXAMPLE".to_string())
-        );
-        assert_eq!(
-            stored.credentials.get("AWS_SECRET_ACCESS_KEY"),
-            Some(&"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".to_string())
-        );
-        assert_eq!(
-            stored.credentials.get("AWS_SESSION_TOKEN"),
-            Some(&"FwoGZXIvYXdzEBYaDH...EXAMPLETOKEN".to_string())
-        );
-        assert_eq!(
-            stored.credential_expires_at_ms.get("AWS_ACCESS_KEY_ID"),
-            Some(&4_000_000_000_000)
-        );
-        assert_eq!(
-            stored.credential_expires_at_ms.get("AWS_SECRET_ACCESS_KEY"),
-            Some(&4_000_000_000_000)
-        );
-        assert_eq!(
-            stored.credential_expires_at_ms.get("AWS_SESSION_TOKEN"),
-            Some(&4_000_000_000_000)
-        );
-    }
-
-    #[tokio::test]
-    async fn apply_minted_credential_validates_additional_keys_against_sandboxes() {
-        use super::apply_minted_credential;
-
-        let store = test_store().await;
-        let mut existing_provider = provider("existing-aws", "aws");
-        existing_provider
-            .credentials
-            .insert("AWS_SECRET_ACCESS_KEY".to_string(), "existing".to_string());
-        store.put_message(&existing_provider).await.unwrap();
-
-        let refreshing_provider = provider("refreshing-aws", "aws");
-        store.put_message(&refreshing_provider).await.unwrap();
-
-        store
-            .put_message(&Sandbox {
-                metadata: Some(ObjectMeta {
-                    id: "sandbox-aws-collision".to_string(),
-                    name: "aws-collision".to_string(),
-                    created_at_ms: 1,
-                    labels: HashMap::new(),
-                    resource_version: 0,
-                    annotations: HashMap::new(),
-                }),
-                spec: Some(SandboxSpec {
-                    providers: vec!["existing-aws".to_string(), "refreshing-aws".to_string()],
-                    ..SandboxSpec::default()
-                }),
-                ..Default::default()
-            })
-            .await
-            .unwrap();
-
-        let minted = super::MintedCredential {
-            access_token: "AKIAIOSFODNN7EXAMPLE".to_string(),
-            expires_at_ms: 4_000_000_000_000,
-            refresh_token: None,
-            additional_credentials: HashMap::from([
-                (
-                    "AWS_SECRET_ACCESS_KEY".to_string(),
-                    "secret-key".to_string(),
-                ),
-                ("AWS_SESSION_TOKEN".to_string(), "session-token".to_string()),
-            ]),
-        };
 
         let err =
-            apply_minted_credential(&store, &refreshing_provider, "AWS_ACCESS_KEY_ID", &minted)
+            refresh_provider_credential(&store, "claude-subscription", "ANTHROPIC_OAUTH_TOKEN")
                 .await
                 .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-        assert!(err.message().contains("AWS_SECRET_ACCESS_KEY"));
-    }
+        assert!(
+            err.message().contains("run `claude login`"),
+            "grant rejection must carry the re-login hint: {}",
+            err.message()
+        );
 
-    // A wiremock responder that blocks the STS response until the test releases
-    // it, so a delete-refresh can be interleaved deterministically while the
-    // rotation is parked awaiting STS.
-    struct GatedStsResponder {
-        hit: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
-        release: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
-        body: String,
-    }
-
-    impl wiremock::Respond for GatedStsResponder {
-        fn respond(&self, _request: &wiremock::Request) -> ResponseTemplate {
-            let hit = self.hit.lock().unwrap().take();
-            if let Some(hit) = hit {
-                let _ = hit.send(());
-            }
-            let _ = self.release.lock().unwrap().recv();
-            ResponseTemplate::new(200).set_body_string(self.body.clone())
-        }
-    }
-
-    #[tokio::test]
-    async fn aws_sts_mint_accepts_session_token_with_source_pair() {
-        let mock_server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(body_string_contains("Action=AssumeRole"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                r#"<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
-  <AssumeRoleResult>
-    <Credentials>
-      <AccessKeyId>ASIAMOCKKEY</AccessKeyId>
-      <SecretAccessKey>MockSecretAccessKey123</SecretAccessKey>
-      <SessionToken>MockSessionTokenXYZ</SessionToken>
-      <Expiration>2099-01-01T00:00:00Z</Expiration>
-    </Credentials>
-  </AssumeRoleResult>
-</AssumeRoleResponse>"#,
-            ))
-            .mount(&mock_server)
-            .await;
-
-        let store = test_store().await;
-        crate::grpc::policy::set_global_bool_setting_for_test(
-            &store,
-            openshell_core::settings::PROVIDERS_V2_ENABLED_KEY,
-            true,
-        )
-        .await
-        .unwrap();
-        let prov = provider("aws-sts-session", "aws");
-        store.put_message(&prov).await.unwrap();
-
-        // Temporary source credentials: access key + secret + session token.
-        let state = new_refresh_state(
-            &prov,
-            "AWS_ACCESS_KEY_ID",
-            NewRefreshStateConfig {
-                additional_output_keys: HashMap::from([
-                    (
-                        "secret_access_key".to_string(),
-                        "AWS_SECRET_ACCESS_KEY".to_string(),
-                    ),
-                    ("session_token".to_string(), "AWS_SESSION_TOKEN".to_string()),
-                ]),
-                strategy: ProviderCredentialRefreshStrategy::AwsStsAssumeRole,
-                material: HashMap::from([
-                    (
-                        "role_arn".to_string(),
-                        "arn:aws:iam::123456789012:role/TestRole".to_string(),
-                    ),
-                    ("aws_access_key_id".to_string(), "ASIASOURCEKEY".to_string()),
-                    (
-                        "aws_secret_access_key".to_string(),
-                        "SourceSecretKey".to_string(),
-                    ),
-                    (
-                        "aws_session_token".to_string(),
-                        "SourceSessionToken".to_string(),
-                    ),
-                    ("sts_endpoint_url".to_string(), mock_server.uri()),
-                ]),
-                secret_material_keys: vec![
-                    "aws_secret_access_key".to_string(),
-                    "aws_session_token".to_string(),
-                ],
-                expires_at_ms: 0,
-                token_url: String::new(),
-                scopes: Vec::new(),
-                refresh_before_seconds: 300,
-                max_lifetime_seconds: 3600,
-            },
-        )
-        .unwrap();
-        put_refresh_state(&store, &state).await.unwrap();
-
-        let refreshed = refresh_provider_credential(&store, "aws-sts-session", "AWS_ACCESS_KEY_ID")
-            .await
-            .unwrap();
-        assert_eq!(refreshed.status, "refreshed");
-        let stored = store
-            .get_message_by_name::<Provider>("aws-sts-session")
+        let stored = get_refresh_state(&store, provider.object_id(), "ANTHROPIC_OAUTH_TOKEN")
             .await
             .unwrap()
             .unwrap();
+        assert_eq!(stored.status, REAUTH_REQUIRED_STATUS);
         assert_eq!(
-            stored.credentials.get("AWS_ACCESS_KEY_ID"),
-            Some(&"ASIAMOCKKEY".to_string())
+            stored.next_refresh_at_ms, 0,
+            "terminal state must not be rescheduled"
         );
-    }
+        assert!(stored.last_error.contains("HTTP 400"));
 
-    #[tokio::test]
-    async fn aws_sts_mint_rejects_session_token_without_source_pair() {
-        let store = test_store().await;
-        crate::grpc::policy::set_global_bool_setting_for_test(
-            &store,
-            openshell_core::settings::PROVIDERS_V2_ENABLED_KEY,
-            true,
-        )
-        .await
-        .unwrap();
-        let prov = provider("aws-sts-lonesession", "aws");
-        store.put_message(&prov).await.unwrap();
+        run_refresh_worker_tick(&store).await.unwrap();
+        run_refresh_worker_tick(&store).await.unwrap();
 
-        let state = new_refresh_state(
-            &prov,
-            "AWS_ACCESS_KEY_ID",
-            NewRefreshStateConfig {
-                additional_output_keys: HashMap::from([
-                    (
-                        "secret_access_key".to_string(),
-                        "AWS_SECRET_ACCESS_KEY".to_string(),
-                    ),
-                    ("session_token".to_string(), "AWS_SESSION_TOKEN".to_string()),
-                ]),
-                strategy: ProviderCredentialRefreshStrategy::AwsStsAssumeRole,
-                material: HashMap::from([
-                    (
-                        "role_arn".to_string(),
-                        "arn:aws:iam::123456789012:role/TestRole".to_string(),
-                    ),
-                    (
-                        "aws_session_token".to_string(),
-                        "SourceSessionToken".to_string(),
-                    ),
-                ]),
-                secret_material_keys: vec!["aws_session_token".to_string()],
-                expires_at_ms: 0,
-                token_url: String::new(),
-                scopes: Vec::new(),
-                refresh_before_seconds: 300,
-                max_lifetime_seconds: 3600,
-            },
-        )
-        .unwrap();
-        put_refresh_state(&store, &state).await.unwrap();
-
-        let err = refresh_provider_credential(&store, "aws-sts-lonesession", "AWS_ACCESS_KEY_ID")
-            .await
-            .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::InvalidArgument);
-        assert!(err.message().contains("aws_session_token requires"));
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn rotation_does_not_resurrect_refresh_deleted_mid_flight() {
-        let mock_server = MockServer::start().await;
-        let (hit_tx, hit_rx) = tokio::sync::oneshot::channel::<()>();
-        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
-        Mock::given(method("POST"))
-            .and(body_string_contains("Action=AssumeRole"))
-            .respond_with(GatedStsResponder {
-                hit: std::sync::Mutex::new(Some(hit_tx)),
-                release: std::sync::Mutex::new(release_rx),
-                body: r#"<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
-  <AssumeRoleResult>
-    <Credentials>
-      <AccessKeyId>ASIAMOCKKEY</AccessKeyId>
-      <SecretAccessKey>MockSecretAccessKey123</SecretAccessKey>
-      <SessionToken>MockSessionTokenXYZ</SessionToken>
-      <Expiration>2099-01-01T00:00:00Z</Expiration>
-    </Credentials>
-  </AssumeRoleResult>
-</AssumeRoleResponse>"#
-                    .to_string(),
-            })
-            .mount(&mock_server)
-            .await;
-
-        let store = test_store().await;
-        crate::grpc::policy::set_global_bool_setting_for_test(
-            &store,
-            openshell_core::settings::PROVIDERS_V2_ENABLED_KEY,
-            true,
-        )
-        .await
-        .unwrap();
-        let prov = provider("aws-race", "aws");
-        store.put_message(&prov).await.unwrap();
-        let provider_id = prov.object_id().to_string();
-
-        let state = new_refresh_state(
-            &prov,
-            "AWS_ACCESS_KEY_ID",
-            NewRefreshStateConfig {
-                additional_output_keys: HashMap::from([
-                    (
-                        "secret_access_key".to_string(),
-                        "AWS_SECRET_ACCESS_KEY".to_string(),
-                    ),
-                    ("session_token".to_string(), "AWS_SESSION_TOKEN".to_string()),
-                ]),
-                strategy: ProviderCredentialRefreshStrategy::AwsStsAssumeRole,
-                material: HashMap::from([
-                    (
-                        "role_arn".to_string(),
-                        "arn:aws:iam::123456789012:role/TestRole".to_string(),
-                    ),
-                    ("aws_access_key_id".to_string(), "AKIATESTKEY".to_string()),
-                    (
-                        "aws_secret_access_key".to_string(),
-                        "TestSecretKey".to_string(),
-                    ),
-                    ("sts_endpoint_url".to_string(), mock_server.uri()),
-                ]),
-                secret_material_keys: vec!["aws_secret_access_key".to_string()],
-                expires_at_ms: 0,
-                token_url: String::new(),
-                scopes: Vec::new(),
-                refresh_before_seconds: 300,
-                max_lifetime_seconds: 3600,
-            },
-        )
-        .unwrap();
-        put_refresh_state(&store, &state).await.unwrap();
-
-        let rotate = refresh_provider_credential(&store, "aws-race", "AWS_ACCESS_KEY_ID");
-        let interfere = async {
-            // Wait until the rotation is inside the STS call (its state read has
-            // already happened), then delete the refresh and release STS.
-            if tokio::time::timeout(std::time::Duration::from_secs(15), hit_rx)
+        let err =
+            refresh_provider_credential(&store, "claude-subscription", "ANTHROPIC_OAUTH_TOKEN")
                 .await
-                .is_err()
-            {
-                return;
-            }
-            delete_refresh_state(&store, &provider_id, "AWS_ACCESS_KEY_ID")
-                .await
-                .unwrap();
-            let _ = release_tx.send(());
-        };
-        let (rotate_result, ()) = tokio::join!(rotate, interfere);
-
-        // The rotation must fail rather than complete against a deleted refresh.
-        assert!(
-            rotate_result.is_err(),
-            "rotation should abort when its refresh is deleted mid-flight"
+                .unwrap_err();
+        assert_eq!(
+            err.code(),
+            tonic::Code::FailedPrecondition,
+            "explicit rotation must remain a manual retry path"
         );
-        // The deleted refresh state must not be resurrected.
-        assert!(
-            get_refresh_state(&store, &provider_id, "AWS_ACCESS_KEY_ID")
-                .await
-                .unwrap()
-                .is_none(),
-            "deleted refresh state must not be recreated"
-        );
-        // No credentials were minted into the provider.
-        let stored = store
-            .get_message_by_name::<Provider>("aws-race")
-            .await
-            .unwrap()
-            .unwrap();
-        assert!(!stored.credentials.contains_key("AWS_ACCESS_KEY_ID"));
-        assert!(!stored.credentials.contains_key("AWS_SECRET_ACCESS_KEY"));
-        assert!(!stored.credentials.contains_key("AWS_SESSION_TOKEN"));
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn rotation_superseded_mid_flight_discards_credentials() {
-        let mock_server = MockServer::start().await;
-        let (hit_tx, hit_rx) = tokio::sync::oneshot::channel::<()>();
-        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
-        Mock::given(method("POST"))
-            .and(body_string_contains("Action=AssumeRole"))
-            .respond_with(GatedStsResponder {
-                hit: std::sync::Mutex::new(Some(hit_tx)),
-                release: std::sync::Mutex::new(release_rx),
-                body: r#"<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
-  <AssumeRoleResult>
-    <Credentials>
-      <AccessKeyId>ASIAMOCKKEY</AccessKeyId>
-      <SecretAccessKey>MockSecretAccessKey123</SecretAccessKey>
-      <SessionToken>MockSessionTokenXYZ</SessionToken>
-      <Expiration>2099-01-01T00:00:00Z</Expiration>
-    </Credentials>
-  </AssumeRoleResult>
-</AssumeRoleResponse>"#
-                    .to_string(),
-            })
-            .mount(&mock_server)
-            .await;
-
-        let store = test_store().await;
-        crate::grpc::policy::set_global_bool_setting_for_test(
-            &store,
-            openshell_core::settings::PROVIDERS_V2_ENABLED_KEY,
-            true,
-        )
-        .await
-        .unwrap();
-        let prov = provider("aws-superseded", "aws");
-        store.put_message(&prov).await.unwrap();
-        let provider_id = prov.object_id().to_string();
-
-        let state = new_refresh_state(
-            &prov,
-            "AWS_ACCESS_KEY_ID",
-            NewRefreshStateConfig {
-                additional_output_keys: HashMap::from([
-                    (
-                        "secret_access_key".to_string(),
-                        "AWS_SECRET_ACCESS_KEY".to_string(),
-                    ),
-                    ("session_token".to_string(), "AWS_SESSION_TOKEN".to_string()),
-                ]),
-                strategy: ProviderCredentialRefreshStrategy::AwsStsAssumeRole,
-                material: HashMap::from([
-                    (
-                        "role_arn".to_string(),
-                        "arn:aws:iam::123456789012:role/TestRole".to_string(),
-                    ),
-                    ("aws_access_key_id".to_string(), "AKIATESTKEY".to_string()),
-                    (
-                        "aws_secret_access_key".to_string(),
-                        "TestSecretKey".to_string(),
-                    ),
-                    ("sts_endpoint_url".to_string(), mock_server.uri()),
-                ]),
-                secret_material_keys: vec!["aws_secret_access_key".to_string()],
-                expires_at_ms: 0,
-                token_url: String::new(),
-                scopes: Vec::new(),
-                refresh_before_seconds: 300,
-                max_lifetime_seconds: 3600,
-            },
-        )
-        .unwrap();
-        put_refresh_state(&store, &state).await.unwrap();
-
-        let rotate = refresh_provider_credential(&store, "aws-superseded", "AWS_ACCESS_KEY_ID");
-        let interfere = async {
-            if tokio::time::timeout(std::time::Duration::from_secs(15), hit_rx)
-                .await
-                .is_err()
-            {
-                return;
-            }
-            // Simulate a concurrent rotation or reconfigure winning the
-            // generation: any write to the refresh state bumps its version, so
-            // the in-flight rotation's version-matched persist will lose.
-            let mut winner = get_refresh_state(&store, &provider_id, "AWS_ACCESS_KEY_ID")
-                .await
-                .unwrap()
-                .unwrap();
-            winner.last_error = "won-by-concurrent-writer".to_string();
-            put_refresh_state(&store, &winner).await.unwrap();
-            let _ = release_tx.send(());
-        };
-        let (rotate_result, ()) = tokio::join!(rotate, interfere);
-
-        // The superseded (losing) rotation must abort rather than complete.
-        assert!(
-            rotate_result.is_err(),
-            "a rotation whose generation was superseded must abort"
-        );
-        // It must not write its stale-generation credentials into the provider.
-        let stored = store
-            .get_message_by_name::<Provider>("aws-superseded")
-            .await
-            .unwrap()
-            .unwrap();
-        assert!(!stored.credentials.contains_key("AWS_ACCESS_KEY_ID"));
-        assert!(!stored.credentials.contains_key("AWS_SECRET_ACCESS_KEY"));
-        assert!(!stored.credentials.contains_key("AWS_SESSION_TOKEN"));
-        // The concurrent writer's refresh state must survive untouched.
-        let refresh = get_refresh_state(&store, &provider_id, "AWS_ACCESS_KEY_ID")
-            .await
-            .unwrap()
-            .expect("refresh state should still exist");
-        assert_eq!(refresh.last_error, "won-by-concurrent-writer");
-        assert_ne!(refresh.status, "refreshed");
     }
 
     fn provider(name: &str, provider_type: &str) -> Provider {

--- a/crates/openshell-supervisor-process/src/ssh.rs
+++ b/crates/openshell-supervisor-process/src/ssh.rs
@@ -485,7 +485,9 @@ impl russh::server::Handler for SshHandler {
                 self.netns_fd,
                 self.proxy_url.clone(),
                 self.ca_file_paths.clone(),
-                &self.provider_credentials.child_env_with_gcp_resolved(),
+                &self
+                    .provider_credentials
+                    .child_env_with_static_config_resolved(),
                 &self.user_environment,
                 self.enforcement_mode,
             )?;
@@ -564,7 +566,9 @@ impl SshHandler {
         handle: Handle,
         command: Option<String>,
     ) -> anyhow::Result<()> {
-        let provider_env = self.provider_credentials.child_env_with_gcp_resolved();
+        let provider_env = self
+            .provider_credentials
+            .child_env_with_static_config_resolved();
         let state = self
             .channels
             .get_mut(&channel)

--- a/docs/providers/anthropic-subscription.mdx
+++ b/docs/providers/anthropic-subscription.mdx
@@ -1,0 +1,100 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Anthropic Subscription"
+sidebar-title: "Anthropic Subscription"
+description: "Run Claude Code in a sandbox on an Anthropic Pro or Max subscription, with the OAuth token acquired and refreshed outside the sandbox."
+keywords: "Generative AI, AI Agents, Sandboxing, Anthropic, Claude, OAuth, Subscription, Inference Routing"
+---
+
+The `anthropic-oauth` provider routes `inference.local` traffic to the Anthropic API using a subscription ("plan") OAuth token instead of an API key. You authenticate once on the host with your Anthropic Pro or Max plan, and the gateway refreshes the token and injects it only at the egress boundary. The token is never written into the sandbox environment, filesystem, or logs.
+
+Use this provider when you want sandboxed agents to consume your Claude subscription rather than a metered API key. For API-key access, use a standard `anthropic` provider instead.
+
+## Prerequisites
+
+- A local Claude Code login on an Anthropic Pro or Max plan. Run `claude login` (or `/login` inside Claude Code) on the host before creating the provider.
+- The host running `openshell provider create` must be able to read the local login: the macOS Keychain item `Claude Code-credentials`, or `~/.claude/.credentials.json` on Linux.
+- A gateway and sandbox supervisor image new enough to support the `anthropic-oauth` provider type. The supervisor applies the `Authorization: Bearer` and `anthropic-beta` headers inside the sandbox boundary, so a stale supervisor image silently drops them and Anthropic rejects the request. Keep the gateway and supervisor images on the same build.
+
+## Authentication
+
+Create the provider with `--from-claude-login`:
+
+```shell
+openshell provider create \
+  --name claude-plan \
+  --type anthropic-oauth \
+  --from-claude-login
+```
+
+`--from-claude-login` reads the local Claude Code login, stores the access token as the gateway-side `ANTHROPIC_OAUTH_TOKEN` credential, and configures an OAuth2 refresh-token flow using your subscription's refresh token. The gateway refreshes the access token ahead of expiry and updates running sandboxes without a restart.
+
+The CLI reads the macOS Keychain first, then falls back to `~/.claude/.credentials.json`. If neither contains a login, the command fails and directs you to run `claude login`.
+
+<Note>
+`--from-claude-login` is only valid for `anthropic-oauth` providers. It cannot be combined with `--from-existing`, `--credential`, or `--runtime-credentials`.
+</Note>
+
+<Warning>
+The access token is marked non-injectable: it is stored only as gateway refresh state and is never exported into sandboxes. Sandboxes reach the model through `inference.local`, where the gateway adds the `Authorization: Bearer` header and the required `anthropic-beta: oauth-2025-04-20` flag at the egress boundary.
+</Warning>
+
+## Token Lifecycle
+
+The subscription OAuth token represents your whole plan, so it is shared across every sandbox bound to the provider, and revoking it is provider-wide. Anthropic rotates the refresh token on each refresh; the gateway persists the rotated token so refresh keeps working. The long-lived refresh material lives only in gateway state, never in a sandbox.
+
+To rotate or revoke, delete and recreate the provider, or rotate the credential through `openshell provider refresh`.
+
+## Configure Inference Routing
+
+Enable provider endpoint injection so the Anthropic network endpoint is added to sandbox policies automatically:
+
+```shell
+openshell settings set --global --key providers_v2_enabled --value true --yes
+```
+
+Then point `inference.local` at the provider:
+
+```shell
+openshell inference set \
+  --provider claude-plan \
+  --model claude-sonnet-4-6
+```
+
+Sandboxes on that gateway reach the model at `https://inference.local`. For full details, refer to [Inference Routing](/sandboxes/inference-routing).
+
+## Use from a Sandbox
+
+Agents inside sandboxes reach Anthropic through `inference.local`, not by connecting to the API directly. The gateway holds the subscription token and injects it on egress; the agent only points its SDK at the local endpoint.
+
+The complete setup from scratch:
+
+```shell
+# 1. Enable provider endpoint injection
+openshell settings set --global --key providers_v2_enabled --value true --yes
+
+# 2. Authenticate on the host, then create the provider
+claude login
+openshell provider create --name claude-plan --type anthropic-oauth --from-claude-login
+
+# 3. Configure inference routing
+openshell inference set --provider claude-plan --model claude-sonnet-4-6
+
+# 4. Create a sandbox with the provider attached
+openshell sandbox create --name my-sandbox --provider claude-plan
+```
+
+Then inside the sandbox, launch Claude Code against the local endpoint:
+
+```shell
+ANTHROPIC_BASE_URL="https://inference.local" ANTHROPIC_API_KEY=unused claude -p "Reply with exactly: pong"
+```
+
+Setting `ANTHROPIC_API_KEY` to any placeholder makes Claude Code talk to the gateway endpoint directly instead of starting its own OAuth login flow inside the sandbox. The placeholder key never reaches Anthropic — `inference.local` strips it and injects the real subscription token before forwarding. Drop the `-p "…"` to launch the interactive TUI instead.
+
+## Next Steps
+
+- To configure `inference.local` routing, refer to [Inference Routing](/sandboxes/inference-routing).
+- To manage provider credentials and refresh, refer to [Providers](/sandboxes/manage-providers).
+- To apply network policies to sandboxes using this provider, refer to [Policies](/sandboxes/policies).

--- a/docs/providers/anthropic-subscription.mdx
+++ b/docs/providers/anthropic-subscription.mdx
@@ -36,16 +36,20 @@ The CLI reads the macOS Keychain first, then falls back to `~/.claude/.credentia
 </Note>
 
 <Warning>
-The access token is marked non-injectable: it is stored only as gateway refresh state and is never exported into sandboxes. Sandboxes reach the model through `inference.local`, where the gateway adds the `Authorization: Bearer` header and the required `anthropic-beta: oauth-2025-04-20` flag at the egress boundary.
+Both tokens stay gateway-side: the access token is stored as the provider's `ANTHROPIC_OAUTH_TOKEN` credential and marked non-injectable, and the refresh token is stored in the gateway's refresh state. Neither is exported into sandboxes. Sandboxes reach the model through `inference.local`, where the gateway adds the `Authorization: Bearer` header and the required `anthropic-beta: oauth-2025-04-20` flag at the egress boundary.
+</Warning>
+
+<Warning>
+Inference routes are gateway-wide: any sandbox on the gateway can reach the route at `inference.local`, including sandboxes created without the `claude-subscription` provider attached. Because `--from-claude-login` points the default route at your personal subscription when no route exists, every sandbox on that gateway consumes your plan. Only use this provider on gateways where you trust all sandboxes.
 </Warning>
 
 ## Token Lifecycle
 
 The subscription OAuth token represents your whole plan, so it is shared across every sandbox bound to the provider, and revoking it is provider-wide. Anthropic rotates the refresh token on each refresh; the gateway persists the rotated token so refresh keeps working. The long-lived refresh material lives only in gateway state, never in a sandbox.
 
-To rotate or revoke, delete and recreate the provider, or rotate the credential through `openshell provider refresh`.
+To rotate the credential, delete and recreate the provider, or rotate through `openshell provider refresh`. Deleting the provider only removes the gateway's copy of the tokens — it does not revoke the OAuth session at Anthropic. Revocation happens via `claude /logout` or Anthropic's session management.
 
-If the refresh token becomes invalid — you logged out of Claude Code, revoked the session, or the plan lapsed — `openshell provider refresh status` reports the failure with recovery instructions: run `claude login` on the host, then delete and recreate the provider with `--from-claude-login`.
+If the refresh token becomes invalid — you logged out of Claude Code, revoked the session, or the plan lapsed — the provider enters the `reauth_required` state and the gateway stops retrying automatically. `openshell provider refresh status` reports the failure with recovery instructions: run `claude login` on the host, then delete and recreate the provider with `--from-claude-login`. An explicit `openshell provider refresh` retries the stored grant manually.
 
 ## Configure Inference Routing
 

--- a/docs/providers/anthropic-subscription.mdx
+++ b/docs/providers/anthropic-subscription.mdx
@@ -22,13 +22,12 @@ Use this provider when you want sandboxed agents to consume your Claude subscrip
 Create the provider with `--from-claude-login`:
 
 ```shell
-openshell provider create \
-  --name claude-subscription \
-  --type anthropic-oauth \
-  --from-claude-login
+openshell provider create --from-claude-login
 ```
 
 `--from-claude-login` reads the local Claude Code login, stores the access token as the gateway-side `ANTHROPIC_OAUTH_TOKEN` credential, and configures an OAuth2 refresh-token flow using your subscription's refresh token. The gateway refreshes the access token ahead of expiry and updates running sandboxes without a restart.
+
+The provider name defaults to `claude-subscription` and the type to `anthropic-oauth`; pass `--name` or `--type` to override. When no inference route is configured yet, the command also points the user-facing route at the new provider with a default model, so no separate `inference set` step is needed.
 
 The CLI reads the macOS Keychain first, then falls back to `~/.claude/.credentials.json`. If neither contains a login, the command fails and directs you to run `claude login`.
 
@@ -46,6 +45,8 @@ The subscription OAuth token represents your whole plan, so it is shared across 
 
 To rotate or revoke, delete and recreate the provider, or rotate the credential through `openshell provider refresh`.
 
+If the refresh token becomes invalid — you logged out of Claude Code, revoked the session, or the plan lapsed — `openshell provider refresh status` reports the failure with recovery instructions: run `claude login` on the host, then delete and recreate the provider with `--from-claude-login`.
+
 ## Configure Inference Routing
 
 Enable provider endpoint injection so the Anthropic network endpoint is added to sandbox policies automatically:
@@ -54,7 +55,7 @@ Enable provider endpoint injection so the Anthropic network endpoint is added to
 openshell settings set --global --key providers_v2_enabled --value true --yes
 ```
 
-Then point `inference.local` at the provider:
+Provider creation with `--from-claude-login` configures the route automatically when none exists. To change the model, or when another route was already configured, set it explicitly:
 
 ```shell
 openshell inference set \
@@ -74,24 +75,25 @@ The complete setup from scratch:
 # 1. Enable provider endpoint injection
 openshell settings set --global --key providers_v2_enabled --value true --yes
 
-# 2. Authenticate on the host, then create the provider
-claude login
-openshell provider create --name claude-subscription --type anthropic-oauth --from-claude-login
+# 2. Create the provider from the local Claude Code login
+#    (also configures the inference route when none exists)
+openshell provider create --from-claude-login
 
-# 3. Configure inference routing
-openshell inference set --provider claude-subscription --model claude-sonnet-4-6
-
-# 4. Create a sandbox with the provider attached
-openshell sandbox create --name my-sandbox --provider claude-subscription
+# 3. Create a sandbox with the provider attached and launch Claude Code
+openshell sandbox create --provider claude-subscription -- claude
 ```
 
-Then inside the sandbox, launch Claude Code against the local endpoint:
+Step 3 drops you into Claude Code running inside the sandbox on your subscription. In an existing sandbox, launch it with no configuration:
 
 ```shell
-ANTHROPIC_BASE_URL="https://inference.local" ANTHROPIC_API_KEY=unused claude -p "Reply with exactly: pong"
+claude -p "Reply with exactly: pong"
 ```
 
-Setting `ANTHROPIC_API_KEY` to any placeholder makes Claude Code talk to the gateway endpoint directly instead of starting its own OAuth login flow inside the sandbox. The placeholder key never reaches Anthropic — `inference.local` strips it and injects the real subscription token before forwarding. Drop the `-p "…"` to launch the interactive TUI instead.
+Sandboxes bound to an `anthropic-oauth` provider start with `ANTHROPIC_BASE_URL=https://inference.local` and a placeholder `ANTHROPIC_AUTH_TOKEN` preset, so agent CLIs use the gateway endpoint instead of prompting for an interactive login. The auth token is used rather than `ANTHROPIC_API_KEY` because Claude Code accepts it without a confirmation prompt. The placeholder never reaches Anthropic — `inference.local` replaces caller auth with the real subscription token before forwarding. Set either variable explicitly to override the preset; tools that only read `ANTHROPIC_API_KEY` can be pointed at the gateway by setting that variable to any value. Drop the `-p "…"` to launch the interactive TUI instead.
+
+<Note>
+Claude Code's startup banner may report API billing because it authenticates through an environment token. The label is cosmetic: the subscription token is injected at the egress boundary, outside the sandbox, so requests are billed to your subscription plan, not to metered API usage.
+</Note>
 
 ## Next Steps
 

--- a/docs/providers/anthropic-subscription.mdx
+++ b/docs/providers/anthropic-subscription.mdx
@@ -23,7 +23,7 @@ Create the provider with `--from-claude-login`:
 
 ```shell
 openshell provider create \
-  --name claude-plan \
+  --name claude-subscription \
   --type anthropic-oauth \
   --from-claude-login
 ```
@@ -58,7 +58,7 @@ Then point `inference.local` at the provider:
 
 ```shell
 openshell inference set \
-  --provider claude-plan \
+  --provider claude-subscription \
   --model claude-sonnet-4-6
 ```
 
@@ -76,13 +76,13 @@ openshell settings set --global --key providers_v2_enabled --value true --yes
 
 # 2. Authenticate on the host, then create the provider
 claude login
-openshell provider create --name claude-plan --type anthropic-oauth --from-claude-login
+openshell provider create --name claude-subscription --type anthropic-oauth --from-claude-login
 
 # 3. Configure inference routing
-openshell inference set --provider claude-plan --model claude-sonnet-4-6
+openshell inference set --provider claude-subscription --model claude-sonnet-4-6
 
 # 4. Create a sandbox with the provider attached
-openshell sandbox create --name my-sandbox --provider claude-plan
+openshell sandbox create --name my-sandbox --provider claude-subscription
 ```
 
 Then inside the sandbox, launch Claude Code against the local endpoint:

--- a/docs/sandboxes/manage-providers.mdx
+++ b/docs/sandboxes/manage-providers.mdx
@@ -359,6 +359,7 @@ The following providers have been tested with `inference.local`. Any provider th
 | AWS Bedrock (via bridge) | `bedrock-bridge` | `aws-bedrock` | Operator-supplied `BEDROCK_BASE_URL` | None at router level (bridge holds creds) |
 | NVIDIA API Catalog | `nvidia-prod` | `nvidia` | `https://integrate.api.nvidia.com/v1` | `NVIDIA_API_KEY` |
 | Anthropic | `anthropic-prod` | `anthropic` | `https://api.anthropic.com` | `ANTHROPIC_API_KEY` |
+| Anthropic (subscription) | `claude-plan` | `anthropic-oauth` | `https://api.anthropic.com` | OAuth — use `--from-claude-login` |
 | Google Vertex AI | `vertex-prod` | `google-vertex-ai` | Regional, global, or multi-region Vertex endpoint | `GOOGLE_VERTEX_AI_TOKEN` or `GOOGLE_VERTEX_AI_SERVICE_ACCOUNT_TOKEN` |
 | Baseten | `baseten` | `openai` | `https://inference.baseten.co/v1` | `OPENAI_API_KEY` |
 | Bitdeer AI | `bitdeer` | `openai` | `https://api-inference.bitdeer.ai/v1` | `OPENAI_API_KEY` |
@@ -367,7 +368,7 @@ The following providers have been tested with `inference.local`. Any provider th
 | Ollama (local) | `ollama` | `openai` | `http://host.openshell.internal:11434/v1` | `OPENAI_API_KEY` |
 | LM Studio (local) | `lmstudio` | `openai` | `http://host.openshell.internal:1234/v1` | `OPENAI_API_KEY` |
 
-Refer to your provider's documentation for the correct base URL, available models, and API key setup. For the Vertex-specific auth flows and config keys, refer to [Google Vertex AI](/providers/google-vertex-ai). To configure inference routing, refer to [Inference Routing](/sandboxes/inference-routing).
+Refer to your provider's documentation for the correct base URL, available models, and API key setup. For the Vertex-specific auth flows and config keys, refer to [Google Vertex AI](/providers/google-vertex-ai). To run Claude Code on an Anthropic Pro or Max subscription with the token acquired outside the sandbox, refer to [Anthropic Subscription](/providers/anthropic-subscription). To configure inference routing, refer to [Inference Routing](/sandboxes/inference-routing).
 
 ## Next Steps
 

--- a/docs/sandboxes/manage-providers.mdx
+++ b/docs/sandboxes/manage-providers.mdx
@@ -359,7 +359,7 @@ The following providers have been tested with `inference.local`. Any provider th
 | AWS Bedrock (via bridge) | `bedrock-bridge` | `aws-bedrock` | Operator-supplied `BEDROCK_BASE_URL` | None at router level (bridge holds creds) |
 | NVIDIA API Catalog | `nvidia-prod` | `nvidia` | `https://integrate.api.nvidia.com/v1` | `NVIDIA_API_KEY` |
 | Anthropic | `anthropic-prod` | `anthropic` | `https://api.anthropic.com` | `ANTHROPIC_API_KEY` |
-| Anthropic (subscription) | `claude-plan` | `anthropic-oauth` | `https://api.anthropic.com` | OAuth — use `--from-claude-login` |
+| Anthropic (subscription) | `claude-subscription` | `anthropic-oauth` | `https://api.anthropic.com` | OAuth — use `--from-claude-login` |
 | Google Vertex AI | `vertex-prod` | `google-vertex-ai` | Regional, global, or multi-region Vertex endpoint | `GOOGLE_VERTEX_AI_TOKEN` or `GOOGLE_VERTEX_AI_SERVICE_ACCOUNT_TOKEN` |
 | Baseten | `baseten` | `openai` | `https://inference.baseten.co/v1` | `OPENAI_API_KEY` |
 | Bitdeer AI | `bitdeer` | `openai` | `https://api-inference.bitdeer.ai/v1` | `OPENAI_API_KEY` |

--- a/providers/anthropic-oauth.yaml
+++ b/providers/anthropic-oauth.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: anthropic-oauth
+display_name: Anthropic (Subscription OAuth)
+description: Anthropic Claude inference using a subscription ("plan") OAuth token. The token is refreshed by the gateway and injected only at the egress boundary, never inside the sandbox.
+category: inference
+inference_capable: true
+credentials:
+  - name: oauth_token
+    description: Anthropic subscription OAuth access token; injected as an Authorization Bearer header at the egress boundary and never exported into sandboxes
+    env_vars: [ANTHROPIC_OAUTH_TOKEN]
+    required: false
+    auth_style: bearer
+    header_name: authorization
+    refresh:
+      strategy: oauth2_refresh_token
+      token_url: https://console.anthropic.com/v1/oauth/token
+      refresh_before_seconds: 300
+      max_lifetime_seconds: 28800
+      material:
+        - name: client_id
+          description: Anthropic public OAuth client ID
+          required: true
+        - name: refresh_token
+          description: Anthropic OAuth refresh token harvested from the local Claude Code login
+          required: true
+          secret: true
+discovery:
+  credentials: [oauth_token]
+endpoints:
+  - host: api.anthropic.com
+    port: 443
+    protocol: rest
+    access: read-write
+    enforcement: enforce


### PR DESCRIPTION
# Summary

Adds an anthropic-oauth provider type (alias: claude-subscription) that lets sandboxed agents run Claude Code against an Anthropic Pro/Max subscription instead of an API key. The OAuth access token is held gateway-side and injected only at the egress boundary (inference.local) and it never enters the sandbox environment, filesystem, or logs.

# Related Issue

Closes #1925

# Human Notes
- Claude Fable 5 was used to help prepare the changes and PR, but all changes were prompted and reviewed by a human. 
- I chose to edit existing GCP provider functions because they already implemented functionality that would otherwise need to be duplicated for Anthropic OAuth (e.g. ensuring env vars have real values at sandbox initialization). 
- I used providers v2 as it seems this is the path that the project is standardizing on, and it handles OAuth refreshes well.
- I chose not to make this fully "magic" (i.e. doing auto-discovery and initialization of the provider without the user explicitly opting in). I'm open to thoughts here, but this seems a bit intrusive due to the fact that the Claude OAuth token is read from the user's Keychain on macOS. Incorporating into the main README in a future PR with instructions could help users do the setup (currently 3 lines).

These screenshots show how the new provider works in a new sandbox. `osl` is an alias for my locally-compiled OpenShell executable. Providers v2 must be enabled first: `osl settings set --global --key providers_v2_enabled --value true --yes`.

<img width="616" height="540" alt="Screenshot 2026-07-14 at 9 04 49 PM" src="https://github.com/user-attachments/assets/cfe9464e-5b60-49ca-89cb-0ad125b2cd8d" />
<img width="598" height="218" alt="Screenshot 2026-07-14 at 9 04 35 PM" src="https://github.com/user-attachments/assets/eff76268-5a14-4921-99af-794a3d85e5cd" />


# Changes

- New provider plugin (openshell-providers): anthropic-oauth with claude-subscription alias. Seeds sandbox env with ANTHROPIC_BASE_URL=https://inference.local and an ANTHROPIC_AUTH_TOKEN placeholder. Deliberately does not inject ANTHROPIC_API_KEY — Claude Code interrupts startup to confirm env API keys, but accepts ANTHROPIC_AUTH_TOKEN silently; the router strips both headers at egress anyway and injects the real subscription Bearer token plus the oauth-2025-04-20 beta header, so the two are wire-identical.
- Static-config env resolution (openshell-core): the credential pipeline placeholderizes all provider env values, but SDKs must parse ANTHROPIC_BASE_URL at process startup. child_env_with_gcp_resolved is generalized to child_env_with_static_config_resolved and now resolves non-secret Anthropic config keys back to real values in the sandbox env, following the existing GCP pattern. Auth tokens stay egress-time placeholders. (Call sites and a doc-comment in google_cloud_metadata.rs updated for the rename.)
- CLI setup flow (openshell-cli): openshell provider create --from-claude-login harvests the subscription OAuth material from the host keychain; --name/--type now default to claude-subscription/anthropic-oauth when that flag is set, a default inference route is configured if none exists, and the missing-provider message during sandbox create points at the correct setup command (the credentials can't be configured from inside a sandbox).
- Token refresh (openshell-server): the refresh worker rotates the access token ahead of expiry and persists rotated refresh tokens. When the token endpoint rejects the refresh grant with HTTP 4xx (revoked login, lapsed plan), the stored error now carries recovery guidance (claude login on the host, recreate the provider); transient network errors and 5xx are excluded.
- Docs: provider guide (docs/providers/anthropic-subscription.mdx) covering setup, the env preset, why Claude Code's "API Usage Billing" banner is cosmetic (billing goes to the subscription), and refresh-failure recovery; architecture/gateway.md updated for the env projection behavior.

# Testing

- Unit suites green: provider plugin, provider_credentials static-config resolution, gRPC resolve_provider_environment (asserts the access token is never injected into sandbox env), and provider refresh (re-login hint applies only to anthropic-oauth 4xx grant rejections).
- Manual golden path on a locally built gateway: provider create --from-claude-login → sandbox create --provider claude-subscription → bare claude inside the sandbox authenticates without prompts and answers requests; Console API usage stays flat (billing hits the subscription).
- mise run pre-commit green.

## Local test checklist

Prereqs: Docker running, a Claude Pro/Max subscription with `claude login` completed on the host.

- [ ] Build: `cargo build -p openshell-cli` and `mise run gateway:docker` (rebuilds the gateway + supervisor image — required, the env injection changed)
- [ ] Lint/format: `mise run pre-commit`
- [ ] Unit tests: `mise run test` (note: `ssh::tests::wait_for_forward_listener_rejects_missing_listener` and sbom `test_same_domain_requests_are_spaced` are pre-existing flakes under parallel load; both pass isolated)
- [ ] e2e: `mise run e2e`
- [ ] Golden path:
  - [ ] `openshell provider create --from-claude-login` — succeeds without `--name`/`--type`, prints the created `claude-subscription` provider and default inference route
  - [ ] `openshell sandbox create --provider claude-subscription` then run bare `claude` inside — no login prompt, no "Do you want to use this API key?" prompt, responds to a message
  - [ ] Inside the sandbox: `echo $ANTHROPIC_AUTH_TOKEN` shows an `openshell:resolve:env:...` placeholder (never a real token); `echo $ANTHROPIC_BASE_URL` shows `https://inference.local`; `ANTHROPIC_API_KEY` is unset
  - [ ] `openshell provider refresh status` shows the token rotating
- [ ] Negative path: `openshell sandbox create --provider claude-subscription` **before** creating the provider — error poim-claude-login`

*One caveat for macOS reviewers: a pre-existing bash 3.2 empty-array bug in e2e/mcp-conformance.sh (unrelated to this PR)* 

# Checklist

- Conventional Commits, DCO sign-off
- Architecture and published docs updated
- e2e run on final revision


