### PR TITLE
fix(sdk): initialize sandbox annotations

### DIFF
--- a/crates/openshell-sdk/src/client.rs
+++ b/crates/openshell-sdk/src/client.rs
@@ -19,6 +19,7 @@ use crate::types::{
 };
 use futures::StreamExt;
 use openshell_core::proto;
+use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -468,6 +469,7 @@ fn create_sandbox_request(spec: SandboxSpec) -> proto::CreateSandboxRequest {
         }),
         name: name.unwrap_or_default(),
         labels,
+        annotations: HashMap::new(),
     }
 }
 

--- a/crates/openshell-sdk/tests/client_mock.rs
+++ b/crates/openshell-sdk/tests/client_mock.rs
@@ -55,6 +55,7 @@ fn sandbox_with_phase(name: &str, phase: proto::SandboxPhase) -> proto::Sandbox 
             created_at_ms: 0,
             labels: HashMap::new(),
             resource_version: 1,
+            annotations: HashMap::new(),
         }),
         spec: None,
         status: Some(proto::SandboxStatus {
@@ -623,6 +624,7 @@ async fn create_sandbox_passes_spec_through() {
     let observed = state.last_create.lock().await.clone().unwrap();
     assert_eq!(observed.name, "my-box");
     assert_eq!(observed.labels, labels);
+    assert!(observed.annotations.is_empty());
     let observed_spec = observed.spec.unwrap();
     assert!(
         observed_spec


### PR DESCRIPTION
## Summary

Fix the SDK test failures introduced when #1862 merged after the sandbox annotations protobuf changes. The SDK and its mock gateway now initialize the new annotation maps, restoring compilation on main.

## Related Issue

Follow-up to #1862 and [commit e6f319c](https://github.com/NVIDIA/OpenShell/commit/e6f319c76de8ff029e2a012fa8dea1ee45035771).

## Changes

- Initialize `CreateSandboxRequest.annotations` in the curated SDK client
- Initialize `ObjectMeta.annotations` in the mock gateway fixture
- Assert that curated sandbox creation sends an empty annotations map

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (not applicable)

Additional verification:

- `cargo test -p openshell-sdk`
- `mise run test`

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; no behavior or architecture change)
