### PR TITLE
fix(sdk): initialize sandbox annotations

### DIFF
--- a/crates/openshell-sdk/src/client.rs
+++ b/crates/openshell-sdk/src/client.rs
@@ -468,6 +468,7 @@ fn create_sandbox_request(spec: SandboxSpec) -> proto::CreateSandboxRequest {
         }),
         name: name.unwrap_or_default(),
         labels,
+        annotations: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/openshell-sdk/tests/client_mock.rs
+++ b/crates/openshell-sdk/tests/client_mock.rs
@@ -55,6 +55,7 @@ fn sandbox_with_phase(name: &str, phase: proto::SandboxPhase) -> proto::Sandbox 
             created_at_ms: 0,
             labels: HashMap::new(),
             resource_version: 1,
+            annotations: HashMap::new(),
         }),
         spec: None,
         status: Some(proto::SandboxStatus {


### PR DESCRIPTION
## Summary

Fix the Rust check failure on `main` by initializing protobuf annotation maps in the newly added SDK request builder and test fixture.

## Related Issue

No issue. Fixes the failing [main branch Rust job](https://github.com/NVIDIA/OpenShell/actions/runs/29391860771/job/87285249372).

## Changes

- Initialize `CreateSandboxRequest.annotations` in the high-level SDK request builder.
- Initialize `ObjectMeta.annotations` in the SDK mock sandbox fixture.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests updated
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)
