### PR TITLE
fix(ci): prune snap assets from dev release

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -935,7 +935,7 @@ jobs:
               release = await github.rest.repos.getReleaseByTag({ owner, repo, tag: 'dev' });
             } catch (err) {
               if (err.status === 404) {
-                core.info('No existing dev release found; skipping wheel pruning.');
+                core.info('No existing dev release found; skipping managed asset pruning.');
                 return;
               }
               throw err;
@@ -954,7 +954,8 @@ jobs:
                 name.endsWith('.txt') ||
                 name.endsWith('.whl') ||
                 name.endsWith('.deb') ||
-                name.endsWith('.rpm')
+                name.endsWith('.rpm') ||
+                name.endsWith('.snap')
               )
             );
 


### PR DESCRIPTION
## Summary

Prune versioned Snap packages from the rolling `dev` release before publishing the current builds. This prevents Snap assets from accumulating while preserving the existing behavior for unmanaged assets.

Right now, the dev release has 370 artifacts on it: https://github.com/NVIDIA/OpenShell/releases/tag/dev

The ones that are not cleaned up are `.snap`.
<img width="782" height="596" alt="image" src="https://github.com/user-attachments/assets/32eeafee-9326-489b-a3a4-11ae7f0c1a69" />

## Changes

- Treat `.snap` files with the `openshell` prefix as managed dev-release assets
- Update the missing-release log message to describe all managed asset pruning

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated (not applicable; workflow-only predicate change)
- [ ] E2E tests added/updated (not applicable)
- [x] GitHub Actions workflow YAML parses successfully
- [x] Managed-asset predicate accepts generated amd64/arm64 Snap filenames and rejects unmanaged assets
- [x] `git diff --check` passes

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; CI-only change)
