### PR TITLE
fix(server): persist sandbox labels on create

### DIFF
--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -509,6 +509,14 @@ impl ComputeRuntime {
         // Create with MustCreate condition to prevent duplicate creation race
         self.sandbox_index.update_from_sandbox(&sandbox);
         let mut sandbox = sandbox;
+        let labels_json = sandbox
+            .metadata
+            .as_ref()
+            .map(|metadata| &metadata.labels)
+            .filter(|labels| !labels.is_empty())
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| Status::internal(format!("failed to serialize labels: {e}")))?;
         let result = self
             .store
             .put_if(
@@ -516,7 +524,7 @@ impl ComputeRuntime {
                 &sandbox_id,
                 sandbox.object_name(),
                 &sandbox.encode_to_vec(),
-                None,
+                labels_json.as_deref(),
                 WriteCondition::MustCreate,
             )
             .await
@@ -3601,6 +3609,29 @@ mod tests {
             1,
             "database should have resource_version: 1 after create"
         );
+    }
+
+    #[tokio::test]
+    async fn created_sandbox_is_immediately_visible_to_label_selectors() {
+        let runtime = test_runtime(Arc::new(TestDriver::default())).await;
+        let mut sandbox =
+            sandbox_record("sb-labeled", "labeled-sandbox", SandboxPhase::Provisioning);
+        sandbox
+            .metadata
+            .as_mut()
+            .unwrap()
+            .labels
+            .insert("env".to_string(), "prod".to_string());
+
+        runtime.create_sandbox(sandbox, None).await.unwrap();
+
+        let matching = runtime
+            .store
+            .list_messages_with_selector::<Sandbox>("env=prod", 10, 0)
+            .await
+            .unwrap();
+        assert_eq!(matching.len(), 1);
+        assert_eq!(matching[0].object_id(), "sb-labeled");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- persist sandbox metadata labels in the dedicated labels column during the initial `create_sandbox` write
- add a deterministic regression test that creates a labeled sandbox and immediately queries it with a label selector

## What went wrong

Sandbox labels are stored in two places: the protobuf payload and a separate labels column used by selector queries. The initial `create_sandbox` call wrote the protobuf payload with labels but passed `None` for the labels column, so the row was created with an empty label map.

A later driver status reconciliation rewrote the sandbox through `update_message_cas`, which derives and backfills the labels column from the protobuf. That made selector visibility depend on whether the first reconciliation had completed. Newly created sandboxes could therefore be returned by `get` while remaining invisible to `list(label_selector=...)`.

This explains the timing-dependent failure in [the E2E CI job](https://github.com/NVIDIA/OpenShell/actions/runs/29456129500/job/87491937631): an older sandbox had already reconciled and matched the selector, while the most recently created sandbox had not.

The fix serializes `sandbox.metadata.labels` for the initial conditional write. Because both SQLite and Postgres selectors use the dedicated labels column, fixing this caller addresses both backends.

## Validation

- `cargo test -p openshell-server compute::tests::` — 37 passed
- `cargo clippy -p openshell-server --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
