### PR TITLE
fix(build): raise open-file limit for host musl cross-compile on macOS

### DIFF
--- a/architecture/build.md
+++ b/architecture/build.md
@@ -59,7 +59,12 @@ and the supervisor image from `deploy/docker/Dockerfile.supervisor`. Neither
 Dockerfile compiles Rust — both copy a staged binary out of
 `deploy/docker/.build/prebuilt-binaries/<arch>/` into the final image.
 
-Binary staging is driven by `tasks/scripts/stage-prebuilt-binaries.sh`. Gateway
+Binary staging is driven by `tasks/scripts/stage-prebuilt-binaries.sh`. Because
+staging cross-compiles on the host, it sources `tasks/scripts/build-env.sh` and
+raises the per-process open-file limit before invoking `cargo zigbuild` on
+macOS — the static musl link opens hundreds of `.rlib` files at once and would
+otherwise fail with `ProcessFdQuotaExceeded` under macOS's default soft limit of
+256. The guard is a no-op on Linux and when `cargo-zigbuild` is absent. Gateway
 binaries use `cargo zigbuild` with GNU targets pinned to glibc 2.28, including
 native-architecture builds, so the gateway image, standalone tarballs, and Linux
 packages share the same host portability floor. The gateway build enables

--- a/tasks/scripts/build-env.sh
+++ b/tasks/scripts/build-env.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Shared build-environment helpers for host-side cross-compilation.
+#
+# Source this file (do not execute it) and call the helpers before invoking
+# cargo-zigbuild on the host.
+
+# ensure_build_nofile_limit raises the per-process open-file limit before a
+# host cargo-zigbuild cross-compile. The static *-unknown-linux-musl link opens
+# hundreds of .rlib files simultaneously, which exceeds macOS's default soft
+# limit of 256 and fails with ProcessFdQuotaExceeded. The raised limit
+# propagates to the cargo/zig children the caller spawns.
+#
+# The limit is read from OPENSHELL_BUILD_NOFILE_LIMIT (default 8192), honoring
+# the legacy OPENSHELL_VM_BUILD_NOFILE_LIMIT for back-compat. This is a no-op on
+# Linux and when cargo-zigbuild is not installed (native builds, CI Linux
+# runners), so it must be safe to call unconditionally.
+ensure_build_nofile_limit() {
+    local desired="${OPENSHELL_BUILD_NOFILE_LIMIT:-${OPENSHELL_VM_BUILD_NOFILE_LIMIT:-8192}}"
+    local minimum=1024
+    local current=""
+    local hard=""
+    local target=""
+
+    [ "$(uname -s)" = "Darwin" ] || return 0
+    command -v cargo-zigbuild >/dev/null 2>&1 || return 0
+
+    current="$(ulimit -n 2>/dev/null || echo "")"
+    case "${current}" in
+        ''|*[!0-9]*)
+            return 0
+            ;;
+    esac
+
+    if [ "${current}" -ge "${desired}" ]; then
+        return 0
+    fi
+
+    hard="$(ulimit -Hn 2>/dev/null || echo "")"
+    target="${desired}"
+    case "${hard}" in
+        ''|unlimited|infinity)
+            ;;
+        *[!0-9]*)
+            ;;
+        *)
+            if [ "${hard}" -lt "${target}" ]; then
+                target="${hard}"
+            fi
+            ;;
+    esac
+
+    if [ "${target}" -gt "${current}" ] && ulimit -n "${target}" 2>/dev/null; then
+        echo "==> Raised open file limit for cargo-zigbuild: ${current} -> $(ulimit -n)"
+    fi
+
+    current="$(ulimit -n 2>/dev/null || echo "${current}")"
+    case "${current}" in
+        ''|*[!0-9]*)
+            return 0
+            ;;
+    esac
+
+    if [ "${current}" -lt "${desired}" ]; then
+        echo "WARNING: Open file limit is ${current}; cargo-zigbuild is more reliable at ${desired}+ on macOS."
+    fi
+
+    if [ "${current}" -lt "${minimum}" ]; then
+        echo "ERROR: Open file limit (${current}) is too low for cargo-zigbuild on macOS." >&2
+        echo "       Run: ulimit -n ${desired}" >&2
+        echo "       Then re-run this script." >&2
+        exit 1
+    fi
+}

--- a/tasks/scripts/gateway-docker.sh
+++ b/tasks/scripts/gateway-docker.sh
@@ -112,9 +112,11 @@ HOST_OS="$(uname -s)"
 HOST_ARCH="$(normalize_arch "$(uname -m)")"
 SUPERVISOR_TARGET="$(linux_target_triple "${DAEMON_ARCH}")"
 # Cache the supervisor binary alongside the gateway state. Reuses the same
-# Docker pipeline used for the supervisor image, so the cross-compile happens
-# inside Linux containers — sidestepping macOS's per-process
-# file-descriptor cap that breaks zig/ld for this many rlibs.
+# Docker pipeline used for the supervisor image. The Dockerfiles do not compile
+# Rust; the cross-compile runs on the host via cargo zigbuild and the binary is
+# staged into the build context. On macOS the host staging path raises the
+# per-process file-descriptor limit automatically (see build-env.sh), so the
+# static musl link no longer hits ProcessFdQuotaExceeded on this many rlibs.
 SUPERVISOR_OUT_DIR="${STATE_DIR}/supervisor/${DAEMON_ARCH}"
 SUPERVISOR_BIN="${SUPERVISOR_OUT_DIR}/openshell-sandbox"
 

--- a/tasks/scripts/stage-prebuilt-binaries.sh
+++ b/tasks/scripts/stage-prebuilt-binaries.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
+# shellcheck source=tasks/scripts/build-env.sh
+source "${SCRIPT_DIR}/build-env.sh"
+
 usage() {
   echo "Usage: stage-prebuilt-binaries.sh <gateway|sandbox|supervisor|supervisor-output|all>" >&2
 }
@@ -229,6 +232,11 @@ fi
 
 restore_cargo_toml=0
 trap restore_workspace_version EXIT
+
+# Raise the open-file limit before any host cargo-zigbuild cross-compile. This
+# single chokepoint covers the docker, podman, and all docker:*/multiarch host
+# staging paths. No-op on Linux and when cargo-zigbuild is absent.
+ensure_build_nofile_limit
 
 patch_workspace_version
 

--- a/tasks/scripts/test-build-env.sh
+++ b/tasks/scripts/test-build-env.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=tasks/scripts/build-env.sh
+source "${SCRIPT_DIR}/build-env.sh"
+
+pass() { echo "PASS: $1"; }
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# The function must be defined by sourcing the helper.
+if ! declare -F ensure_build_nofile_limit >/dev/null; then
+  fail "ensure_build_nofile_limit not defined after sourcing build-env.sh"
+fi
+pass "ensure_build_nofile_limit is defined"
+
+os="$(uname -s)"
+
+if [ "${os}" != "Darwin" ]; then
+  # On non-Darwin hosts the helper must be a no-op regardless of the current
+  # limit — CI Linux runners and native Linux dev must be unaffected.
+  (
+    ulimit -Sn 256 2>/dev/null || true
+    before="$(ulimit -n)"
+    ensure_build_nofile_limit >/dev/null
+    after="$(ulimit -n)"
+    [ "${before}" = "${after}" ] || fail "limit changed on non-Darwin host (${before} -> ${after})"
+  )
+  pass "no-op on non-Darwin host (${os})"
+  echo "All build-env tests passed."
+  exit 0
+fi
+
+# Darwin below.
+if ! command -v cargo-zigbuild >/dev/null 2>&1; then
+  # Without cargo-zigbuild the helper must be a no-op even on macOS.
+  (
+    ulimit -Sn 256 2>/dev/null || true
+    before="$(ulimit -n)"
+    ensure_build_nofile_limit >/dev/null
+    after="$(ulimit -n)"
+    [ "${before}" = "${after}" ] || fail "limit changed on macOS without cargo-zigbuild (${before} -> ${after})"
+  )
+  pass "no-op on macOS without cargo-zigbuild"
+  echo "All build-env tests passed."
+  exit 0
+fi
+
+# Darwin + cargo-zigbuild: the helper should raise a low soft limit.
+(
+  if ! ulimit -Sn 256 2>/dev/null; then
+    echo "SKIP: unable to lower soft limit to 256 for test"
+    exit 0
+  fi
+  ensure_build_nofile_limit >/dev/null
+  after="$(ulimit -n)"
+  hard="$(ulimit -Hn 2>/dev/null || echo unlimited)"
+  case "${hard}" in
+    unlimited|infinity)
+      [ "${after}" -ge 8192 ] || fail "expected soft limit >= 8192, got ${after}"
+      ;;
+    *[!0-9]*)
+      [ "${after}" -gt 256 ] || fail "expected soft limit to rise above 256, got ${after}"
+      ;;
+    *)
+      expected=8192
+      [ "${hard}" -lt "${expected}" ] && expected="${hard}"
+      [ "${after}" -ge "${expected}" ] || fail "expected soft limit >= ${expected}, got ${after}"
+      ;;
+  esac
+)
+pass "raises low soft limit on macOS with cargo-zigbuild"
+
+# Idempotent: when the current limit already meets the desired value, the helper
+# leaves it unchanged (drive this via the env override so it holds regardless of
+# the host default).
+(
+  before="$(ulimit -n)"
+  OPENSHELL_BUILD_NOFILE_LIMIT=1 ensure_build_nofile_limit >/dev/null
+  after="$(ulimit -n)"
+  [ "${before}" = "${after}" ] || fail "limit changed when already above desired (${before} -> ${after})"
+)
+pass "no-op when current limit already meets desired"
+
+echo "All build-env tests passed."

--- a/tasks/scripts/vm/build-supervisor-bundle.sh
+++ b/tasks/scripts/vm/build-supervisor-bundle.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 OUTPUT_DIR="${OPENSHELL_VM_RUNTIME_COMPRESSED_DIR:-${ROOT}/target/vm-runtime-compressed}"
 
+# shellcheck source=tasks/scripts/build-env.sh
+source "${ROOT}/tasks/scripts/build-env.sh"
+
 GUEST_ARCH=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -57,64 +60,6 @@ esac
 
 SUPERVISOR_BIN="${ROOT}/target/${RUST_TARGET}/release/openshell-sandbox"
 SUPERVISOR_OUTPUT="${OUTPUT_DIR}/openshell-sandbox.zst"
-
-ensure_build_nofile_limit() {
-    local desired="${OPENSHELL_VM_BUILD_NOFILE_LIMIT:-8192}"
-    local minimum=1024
-    local current=""
-    local hard=""
-    local target=""
-
-    [ "$(uname -s)" = "Darwin" ] || return 0
-    command -v cargo-zigbuild >/dev/null 2>&1 || return 0
-
-    current="$(ulimit -n 2>/dev/null || echo "")"
-    case "${current}" in
-        ''|*[!0-9]*)
-            return 0
-            ;;
-    esac
-
-    if [ "${current}" -ge "${desired}" ]; then
-        return 0
-    fi
-
-    hard="$(ulimit -Hn 2>/dev/null || echo "")"
-    target="${desired}"
-    case "${hard}" in
-        ''|unlimited|infinity)
-            ;;
-        *[!0-9]*)
-            ;;
-        *)
-            if [ "${hard}" -lt "${target}" ]; then
-                target="${hard}"
-            fi
-            ;;
-    esac
-
-    if [ "${target}" -gt "${current}" ] && ulimit -n "${target}" 2>/dev/null; then
-        echo "==> Raised open file limit for cargo-zigbuild: ${current} -> $(ulimit -n)"
-    fi
-
-    current="$(ulimit -n 2>/dev/null || echo "${current}")"
-    case "${current}" in
-        ''|*[!0-9]*)
-            return 0
-            ;;
-    esac
-
-    if [ "${current}" -lt "${desired}" ]; then
-        echo "WARNING: Open file limit is ${current}; cargo-zigbuild is more reliable at ${desired}+ on macOS."
-    fi
-
-    if [ "${current}" -lt "${minimum}" ]; then
-        echo "ERROR: Open file limit (${current}) is too low for cargo-zigbuild on macOS." >&2
-        echo "       Run: ulimit -n ${desired}" >&2
-        echo "       Then re-run this script." >&2
-        exit 1
-    fi
-}
 
 echo "==> Building openshell-sandbox supervisor bundle"
 echo "    Guest arch: ${GUEST_ARCH}"

--- a/tasks/test.toml
+++ b/tasks/test.toml
@@ -5,7 +5,7 @@
 
 [test]
 description = "Run all tests (Rust + Python)"
-depends = ["test:rust", "test:python", "test:sbom", "test:install-sh", "test:packaging-assets", "test:docs-website"]
+depends = ["test:rust", "test:python", "test:sbom", "test:install-sh", "test:build-env", "test:packaging-assets", "test:docs-website"]
 
 ["test:docs-website"]
 description = "Test the docs-website sync script"
@@ -21,6 +21,11 @@ hide = true
 ["test:install-sh"]
 description = "Run focused install.sh shell tests"
 run = "tasks/scripts/test-install-sh.sh"
+hide = true
+
+["test:build-env"]
+description = "Run build-env.sh helper shell tests"
+run = "tasks/scripts/test-build-env.sh"
 hide = true
 
 ["test:packaging-assets"]


### PR DESCRIPTION
## Summary

The host `cargo zigbuild` for `*-unknown-linux-musl` opens ~333 `.rlib` files at once during the static link, exceeding macOS's default soft limit of 256 and failing with `ProcessFdQuotaExceeded`. This blocked the docker/podman `mise run gateway` paths for macOS contributors; only the VM driver path guarded against it. This PR extends the fd-limit guard to every host cross-compile chokepoint.

## Related Issue

Closes #2112

## Changes

- Extract the VM path's `ensure_build_nofile_limit` guard into a shared `tasks/scripts/build-env.sh`.
- Call the guard from the host-staging chokepoint (`stage-prebuilt-binaries.sh`), fixing docker, podman, and all `docker:*`/multiarch host cross-compiles at once.
- De-duplicate the VM script (`vm/build-supervisor-bundle.sh`) to source the shared helper.
- Guard is a no-op on Linux and when `cargo-zigbuild` is absent, so CI and Linux dev are unaffected.
- Limit read from `OPENSHELL_BUILD_NOFILE_LIMIT` (default 8192), honoring the legacy `OPENSHELL_VM_BUILD_NOFILE_LIMIT` for back-compat.
- Correct the stale comment in `gateway-docker.sh` (the cross-compile runs on the host, not inside Linux containers).
- Document the guard in `architecture/build.md`.
- Add `tasks/scripts/test-build-env.sh`, wired into `mise run test` via `test:build-env`.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated (`tasks/scripts/test-build-env.sh` — 3 cases, all pass)
- [ ] E2E tests added/updated (if applicable) — n/a, build-tooling change

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)