### PR TITLE
fix(gateway): honor tty flag for interactive exec

### DIFF
--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -1284,6 +1284,7 @@ pub(super) async fn handle_exec_sandbox_interactive(
 
     let command_str = build_remote_exec_command(&req)
         .map_err(|e| Status::invalid_argument(format!("command construction failed: {e}")))?;
+    let request_tty = req.tty;
     let timeout_seconds = req.timeout_seconds;
     let cols = if req.cols == 0 { 80 } else { req.cols };
     let rows = if req.rows == 0 { 24 } else { req.rows };
@@ -1311,6 +1312,7 @@ pub(super) async fn handle_exec_sandbox_interactive(
             relay_stream,
             &command_str,
             input_stream,
+            request_tty,
             timeout_seconds,
             cols,
             rows,
@@ -1631,6 +1633,7 @@ async fn stream_interactive_exec_over_relay(
     relay_stream: tokio::io::DuplexStream,
     command: &str,
     input_stream: tonic::Streaming<ExecSandboxInput>,
+    request_tty: bool,
     timeout_seconds: u32,
     cols: u32,
     rows: u32,
@@ -1656,6 +1659,7 @@ async fn stream_interactive_exec_over_relay(
         local_proxy_port,
         command,
         input_stream,
+        request_tty,
         cols,
         rows,
         tx.clone(),
@@ -1707,6 +1711,7 @@ async fn run_interactive_exec_with_russh(
     local_proxy_port: u16,
     command: &str,
     mut input_stream: tonic::Streaming<ExecSandboxInput>,
+    request_tty: bool,
     cols: u32,
     rows: u32,
     tx: mpsc::Sender<Result<ExecSandboxEvent, Status>>,
@@ -1752,10 +1757,12 @@ async fn run_interactive_exec_with_russh(
         .await
         .map_err(|e| Status::internal(format!("failed to open ssh channel: {e}")))?;
 
-    channel
-        .request_pty(false, "xterm-256color", cols, rows, 0, 0, &[])
-        .await
-        .map_err(|e| Status::internal(format!("failed to allocate PTY: {e}")))?;
+    if request_tty {
+        channel
+            .request_pty(false, "xterm-256color", cols, rows, 0, 0, &[])
+            .await
+            .map_err(|e| Status::internal(format!("failed to allocate PTY: {e}")))?;
+    }
 
     channel
         .exec(true, command.as_bytes())
@@ -1773,9 +1780,11 @@ async fn run_interactive_exec_with_russh(
                     }
                 }
                 Some(Payload::Resize(resize)) => {
-                    let _ = write_half
-                        .window_change(resize.cols, resize.rows, 0, 0)
-                        .await;
+                    if request_tty {
+                        let _ = write_half
+                            .window_change(resize.cols, resize.rows, 0, 0)
+                            .await;
+                    }
                 }
                 Some(Payload::Start(_)) | None => {}
             }

--- a/e2e/python/test_sandbox_api.py
+++ b/e2e/python/test_sandbox_api.py
@@ -67,7 +67,11 @@ def test_sandbox_interactive_exec_honors_tty(
     sandbox: Callable[..., Sandbox],
     sandbox_client: SandboxClient,
 ) -> None:
-    def exec_interactive(sandbox_id: str, *, tty: bool) -> bytes:
+    stdin_sentinel = b"streamed-stdin-sentinel"
+    stdout_sentinel = b"stdout-sentinel"
+    stderr_sentinel = b"stderr-sentinel"
+
+    def exec_interactive(sandbox_id: str, *, tty: bool) -> tuple[bytes, bytes]:
         request = openshell_pb2.ExecSandboxInput(
             start=openshell_pb2.ExecSandboxRequest(
                 sandbox_id=sandbox_id,
@@ -76,7 +80,11 @@ def test_sandbox_interactive_exec_honors_tty(
                     "-c",
                     "[ -t 0 ] && printf T || printf N; "
                     "[ -t 1 ] && printf T || printf N; "
-                    "[ -t 2 ] && printf T || printf N; printf '\\n'",
+                    "[ -t 2 ] && printf T || printf N; printf '\\n'; "
+                    "IFS= read -r stdin_value; "
+                    "printf 'stdin:%s\\n' \"$stdin_value\"; "
+                    "printf 'stdout-sentinel\\n'; "
+                    "printf 'stderr-sentinel\\n' >&2",
                 ],
                 tty=tty,
                 timeout_seconds=20,
@@ -87,29 +95,39 @@ def test_sandbox_interactive_exec_honors_tty(
 
         def requests():
             yield request
+            yield openshell_pb2.ExecSandboxInput(stdin=stdin_sentinel + b"\n")
             done.wait(timeout=30)
 
-        output: list[bytes] = []
+        stdout: list[bytes] = []
+        stderr: list[bytes] = []
         exit_code: int | None = None
         try:
             events = sandbox_client._stub.ExecSandboxInteractive(requests(), timeout=30)
             for event in events:
                 payload = event.WhichOneof("payload")
                 if payload == "stdout":
-                    output.append(bytes(event.stdout.data))
+                    stdout.append(bytes(event.stdout.data))
                 elif payload == "stderr":
-                    output.append(bytes(event.stderr.data))
+                    stderr.append(bytes(event.stderr.data))
                 elif payload == "exit":
                     exit_code = int(event.exit.exit_code)
         finally:
             done.set()
 
         assert exit_code == 0
-        return b"".join(output)
+        return b"".join(stdout), b"".join(stderr)
 
     with sandbox(delete_on_exit=True) as sb:
-        assert b"NNN" in exec_interactive(sb.id, tty=False)
-        assert b"TTT" in exec_interactive(sb.id, tty=True)
+        stdout, stderr = exec_interactive(sb.id, tty=False)
+        assert b"NNN" in stdout
+        assert b"stdin:" + stdin_sentinel in stdout
+        assert stdout_sentinel in stdout
+        assert stdout_sentinel not in stderr
+        assert stderr_sentinel in stderr
+        assert stderr_sentinel not in stdout
+
+        stdout, stderr = exec_interactive(sb.id, tty=True)
+        assert b"TTT" in stdout + stderr
 
 
 def test_sandbox_labels_and_selectors(sandbox_client: SandboxClient) -> None:

--- a/e2e/python/test_sandbox_api.py
+++ b/e2e/python/test_sandbox_api.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING
+
+from openshell._proto import openshell_pb2
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -58,6 +61,55 @@ def test_sandbox_api_crud_and_exec(
         )
         assert verify_file.exit_code == 0
         assert verify_file.stdout.strip() == "ok"
+
+
+def test_sandbox_interactive_exec_honors_tty(
+    sandbox: Callable[..., Sandbox],
+    sandbox_client: SandboxClient,
+) -> None:
+    def exec_interactive(sandbox_id: str, *, tty: bool) -> bytes:
+        request = openshell_pb2.ExecSandboxInput(
+            start=openshell_pb2.ExecSandboxRequest(
+                sandbox_id=sandbox_id,
+                command=[
+                    "/bin/sh",
+                    "-c",
+                    "[ -t 0 ] && printf T || printf N; "
+                    "[ -t 1 ] && printf T || printf N; "
+                    "[ -t 2 ] && printf T || printf N; printf '\\n'",
+                ],
+                tty=tty,
+                timeout_seconds=20,
+            )
+        )
+
+        done = threading.Event()
+
+        def requests():
+            yield request
+            done.wait(timeout=30)
+
+        output: list[bytes] = []
+        exit_code: int | None = None
+        try:
+            events = sandbox_client._stub.ExecSandboxInteractive(requests(), timeout=30)
+            for event in events:
+                payload = event.WhichOneof("payload")
+                if payload == "stdout":
+                    output.append(bytes(event.stdout.data))
+                elif payload == "stderr":
+                    output.append(bytes(event.stderr.data))
+                elif payload == "exit":
+                    exit_code = int(event.exit.exit_code)
+        finally:
+            done.set()
+
+        assert exit_code == 0
+        return b"".join(output)
+
+    with sandbox(delete_on_exit=True) as sb:
+        assert b"NNN" in exec_interactive(sb.id, tty=False)
+        assert b"TTT" in exec_interactive(sb.id, tty=True)
 
 
 def test_sandbox_labels_and_selectors(sandbox_client: SandboxClient) -> None:


### PR DESCRIPTION
## Summary

Honor the requested TTY mode throughout the interactive SSH relay. When TTY is disabled, the gateway skips PTY allocation and ignores resize events, preserving pipe-based execution semantics.

## Related Issue

Fixes #2228

## Changes

- Pass `ExecSandboxRequest.tty` through the interactive exec relay.
- Request an SSH PTY only when `tty=true`.
- Forward terminal resize events only for PTY-backed sessions.
- Add E2E regression coverage verifying all three standard file descriptors are non-TTY with `tty=false` and TTY-backed with `tty=true`.

## Testing

- `mise run pre-commit` all passed.
- `cargo test -p openshell-server interactive_exec --lib` — 10 passed.
- `e2e/python/test_sandbox_api.py::test_sandbox_interactive_exec_honors_tty` against a Docker-backed gateway — 1 passed.
- `cargo fmt --all -- --check` — passed.
- Ruff format and lint checks — passed.

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated — existing focused unit tests passed; behavior is covered by E2E.
- [x] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)