### PR TITLE
fix(server): respect tty flag in ExecSandboxInteractive

### DIFF
--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -2627,6 +2627,21 @@ mod tests {
     }
 
     #[test]
+    fn interactive_exec_accepts_tty_false() {
+        use openshell_core::proto::exec_sandbox_input;
+        let msg = ExecSandboxInput {
+            payload: Some(exec_sandbox_input::Payload::Start(ExecSandboxRequest {
+                sandbox_id: "test-id".to_string(),
+                command: vec!["bash".to_string()],
+                tty: false,
+                ..Default::default()
+            })),
+        };
+        let req = validate_interactive_exec_start(Some(msg)).unwrap();
+        assert!(!req.tty);
+    }
+
+    #[test]
     fn interactive_exec_accepts_valid_start() {
         use openshell_core::proto::exec_sandbox_input;
         let msg = ExecSandboxInput {

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -1287,6 +1287,7 @@ pub(super) async fn handle_exec_sandbox_interactive(
     let timeout_seconds = req.timeout_seconds;
     let cols = if req.cols == 0 { 80 } else { req.cols };
     let rows = if req.rows == 0 { 24 } else { req.rows };
+    let tty = req.tty;
 
     let sandbox_id = sandbox.object_id().to_string();
 
@@ -1314,6 +1315,7 @@ pub(super) async fn handle_exec_sandbox_interactive(
             timeout_seconds,
             cols,
             rows,
+            tty,
         )
         .await
         {
@@ -1634,6 +1636,7 @@ async fn stream_interactive_exec_over_relay(
     timeout_seconds: u32,
     cols: u32,
     rows: u32,
+    tty: bool,
 ) -> Result<(), Status> {
     let command_preview: String = command
         .chars()
@@ -1658,6 +1661,7 @@ async fn stream_interactive_exec_over_relay(
         input_stream,
         cols,
         rows,
+        tty,
         tx.clone(),
     );
 
@@ -1709,6 +1713,7 @@ async fn run_interactive_exec_with_russh(
     mut input_stream: tonic::Streaming<ExecSandboxInput>,
     cols: u32,
     rows: u32,
+    tty: bool,
     tx: mpsc::Sender<Result<ExecSandboxEvent, Status>>,
 ) -> Result<i32, Status> {
     use openshell_core::proto::exec_sandbox_input::Payload;
@@ -1752,10 +1757,12 @@ async fn run_interactive_exec_with_russh(
         .await
         .map_err(|e| Status::internal(format!("failed to open ssh channel: {e}")))?;
 
-    channel
-        .request_pty(false, "xterm-256color", cols, rows, 0, 0, &[])
-        .await
-        .map_err(|e| Status::internal(format!("failed to allocate PTY: {e}")))?;
+    if tty {
+        channel
+            .request_pty(false, "xterm-256color", cols, rows, 0, 0, &[])
+            .await
+            .map_err(|e| Status::internal(format!("failed to allocate PTY: {e}")))?;
+    }
 
     channel
         .exec(true, command.as_bytes())
@@ -1773,9 +1780,11 @@ async fn run_interactive_exec_with_russh(
                     }
                 }
                 Some(Payload::Resize(resize)) => {
-                    let _ = write_half
-                        .window_change(resize.cols, resize.rows, 0, 0)
-                        .await;
+                    if tty {
+                        let _ = write_half
+                            .window_change(resize.cols, resize.rows, 0, 0)
+                            .await;
+                    }
                 }
                 Some(Payload::Start(_)) | None => {}
             }


### PR DESCRIPTION
## Summary
ExecSandboxInteractive accepted `tty=false` in the start request but unconditionally allocated a PTY over SSH, causing processes to always observe terminal-backed file descriptors. This PR threads the tty flag through the interactive exec call chain and guards `request_pty` and window_change behind it.

## Related Issue
Fixes #2228 

## Changes
- Thread tty: bool through `stream_interactive_exec_over_relay` and `run_interactive_exec_with_russh`
- Guard `request_pty` and window_change behind if tty
- Add unit test for `tty=false` validation

## Reproduction

Used the reproduction script from #2228 to verify behavior before and after the fix.

**Before:**
<img width="944" height="483" alt="image" src="https://github.com/user-attachments/assets/fd4a314a-6342-4da1-bca5-3b2f884c0114" />

**After:**
<img width="989" height="428" alt="image" src="https://github.com/user-attachments/assets/aa4e7d03-fe3a-4c5a-98ae-7f49166277d6" />

## Testing
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
