### PR TITLE
fix: remove mentions of bundled-z3 in CI and wheel builds

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -292,7 +292,7 @@ jobs:
           sed -i -E '/^\[workspace\.package\]/,/^\[/{s/^version[[:space:]]*=[[:space:]]*".*"/version = "'"${{ needs.compute-versions.outputs.cargo_version }}"'"/}' Cargo.toml
 
       - name: Build ${{ matrix.target }}
-        run: mise x -- cargo build --release --target ${{ matrix.target }} -p openshell-cli --features bundled-z3
+        run: mise x -- cargo build --release --target ${{ matrix.target }} -p openshell-cli
 
       - name: sccache stats
         if: always()

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -324,7 +324,7 @@ jobs:
           sed -i -E '/^\[workspace\.package\]/,/^\[/{s/^version[[:space:]]*=[[:space:]]*".*"/version = "'"${{ needs.compute-versions.outputs.cargo_version }}"'"/}' Cargo.toml
 
       - name: Build ${{ matrix.target }}
-        run: mise x -- cargo build --release --target ${{ matrix.target }} -p openshell-cli --features bundled-z3
+        run: mise x -- cargo build --release --target ${{ matrix.target }} -p openshell-cli
 
       - name: sccache stats
         if: always()

--- a/deploy/docker/Dockerfile.cli-macos
+++ b/deploy/docker/Dockerfile.cli-macos
@@ -97,7 +97,7 @@ RUN mkdir -p crates/openshell-cli/src \
 RUN --mount=type=cache,id=cargo-registry-cli-macos,sharing=locked,target=/root/.cargo/registry \
     --mount=type=cache,id=cargo-git-cli-macos,sharing=locked,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-target-cli-macos-${CARGO_TARGET_CACHE_SCOPE},sharing=locked,target=/build/target \
-    cargo build --release --target aarch64-apple-darwin -p openshell-cli --features bundled-z3 2>/dev/null || true
+    cargo build --release --target aarch64-apple-darwin -p openshell-cli  2>/dev/null || true
 
 # ---------------------------------------------------------------------------
 # Stage 2: real build
@@ -126,7 +126,7 @@ RUN --mount=type=cache,id=cargo-registry-cli-macos,sharing=locked,target=/root/.
     if [ -n "${OPENSHELL_CARGO_VERSION:-}" ]; then \
       sed -i -E '/^\[workspace\.package\]/,/^\[/{s/^version[[:space:]]*=[[:space:]]*".*"/version = "'"${OPENSHELL_CARGO_VERSION}"'"/}' Cargo.toml; \
     fi && \
-    cargo build --release --target aarch64-apple-darwin -p openshell-cli --features bundled-z3 && \
+    cargo build --release --target aarch64-apple-darwin -p openshell-cli && \
     cp target/aarch64-apple-darwin/release/openshell /openshell
 
 FROM scratch AS binary

--- a/deploy/docker/Dockerfile.python-wheels
+++ b/deploy/docker/Dockerfile.python-wheels
@@ -75,7 +75,7 @@ RUN --mount=type=cache,id=cargo-registry-python-wheels-${TARGETARCH},sharing=loc
     --mount=type=cache,id=cargo-git-python-wheels-${TARGETARCH},sharing=locked,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-target-python-wheels-${TARGETARCH}-${CARGO_TARGET_CACHE_SCOPE},sharing=locked,target=/build/target \
     --mount=type=cache,id=sccache-python-wheels-${TARGETARCH},sharing=locked,target=/tmp/sccache \
-    . cross-build.sh && cargo_cross_build --release -p openshell-cli --features bundled-z3 2>/dev/null || true
+    . cross-build.sh && cargo_cross_build --release -p openshell-cli 2>/dev/null || true
 
 # Copy actual source code and Python packaging files.
 COPY crates/ crates/
@@ -109,7 +109,7 @@ RUN --mount=type=cache,id=cargo-registry-python-wheels-${TARGETARCH},sharing=loc
     if [ -n "${OPENSHELL_CARGO_VERSION:-}" ]; then \
       sed -i -E '/^\[workspace\.package\]/,/^\[/{s/^version[[:space:]]*=[[:space:]]*".*"/version = "'"${OPENSHELL_CARGO_VERSION}"'"/}' Cargo.toml; \
     fi && \
-    maturin build --release --target "${CARGO_BUILD_TARGET}" --features bundled-z3 --out /wheels
+    maturin build --release --target "${CARGO_BUILD_TARGET}" --out /wheels
 
 FROM scratch AS wheels
 COPY --from=builder /wheels/*.whl /

--- a/deploy/docker/Dockerfile.python-wheels-macos
+++ b/deploy/docker/Dockerfile.python-wheels-macos
@@ -88,7 +88,7 @@ RUN mkdir -p crates/openshell-cli/src crates/openshell-core/src crates/openshell
 RUN --mount=type=cache,id=cargo-registry-python-wheels-macos-${TARGETARCH},sharing=locked,target=/root/.cargo/registry \
     --mount=type=cache,id=cargo-git-python-wheels-macos-${TARGETARCH},sharing=locked,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-target-python-wheels-macos-${TARGETARCH}-${CARGO_TARGET_CACHE_SCOPE},sharing=locked,target=/build/target \
-    cargo build --release --target aarch64-apple-darwin -p openshell-cli --features bundled-z3 2>/dev/null || true
+    cargo build --release --target aarch64-apple-darwin -p openshell-cli  2>/dev/null || true
 
 # Copy actual source code and Python packaging files.
 COPY crates/ crates/
@@ -120,7 +120,7 @@ RUN --mount=type=cache,id=cargo-registry-python-wheels-macos-${TARGETARCH},shari
     if [ -n "${OPENSHELL_CARGO_VERSION:-}" ]; then \
       sed -i -E '/^\[workspace\.package\]/,/^\[/{s/^version[[:space:]]*=[[:space:]]*".*"/version = "'"${OPENSHELL_CARGO_VERSION}"'"/}' Cargo.toml; \
     fi && \
-    maturin build --release --target aarch64-apple-darwin --features bundled-z3 --out /wheels
+    maturin build --release --target aarch64-apple-darwin --out /wheels
 
 FROM scratch AS wheels
 COPY --from=builder /wheels/*.whl /

--- a/scripts/bin/openshell
+++ b/scripts/bin/openshell
@@ -109,11 +109,6 @@ if [[ "$needs_build" == "1" ]]; then
         break
       fi
     done
-
-    if [[ -z "${Z3_SYS_Z3_HEADER:-}" ]]; then
-      echo "Falling back to bundled Z3 for local CLI build." >&2
-      build_args+=(--features bundled-z3)
-    fi
   fi
   cargo build "${build_args[@]}"
   # Persist state after successful build

--- a/tasks/ci.toml
+++ b/tasks/ci.toml
@@ -30,7 +30,7 @@ hide = true
 ["build:rust:snap"]
 description = "Build release Rust binaries consumed by the hand-staged snap"
 run = [
-  "cargo build --release -p openshell-cli --features bundled-z3",
+  "cargo build --release -p openshell-cli",
   "cargo build --release -p openshell-server --features bundled-z3",
   "cargo build --release -p openshell-sandbox",
 ]

--- a/tasks/python.toml
+++ b/tasks/python.toml
@@ -76,7 +76,7 @@ fi
 rm -rf "$WHEEL_OUTPUT_DIR"
 mkdir -p "$WHEEL_OUTPUT_DIR"
 
-uv run maturin build --release --features bundled-z3 --out "$WHEEL_OUTPUT_DIR"
+uv run maturin build --release --out "$WHEEL_OUTPUT_DIR"
 
 ls -la "$WHEEL_OUTPUT_DIR"/*.whl
 '''


### PR DESCRIPTION
## Summary
remove mentions of bundled-z3 in CI and wheel builds

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
