### PR TITLE
fix(vm-driver): unpack registry images correctly and validate prepared disks

### DIFF
--- a/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
+++ b/crates/openshell-driver-vm/scripts/openshell-vm-sandbox-init.sh
@@ -172,12 +172,20 @@ prepare_guest_image_rootfs() {
             /opt/openshell/bin/umoci raw unpack \
                 --image "$payload_dir/oci:openshell" \
                 "$partial_root"
-            if [ ! -d "$partial_root/rootfs" ]; then
-                ts "FATAL: umoci unpack did not produce rootfs directory"
+            # `umoci raw unpack` extracts the image filesystem directly into
+            # the target directory — there is no bundle-style rootfs/
+            # subdirectory. Accept both layouts defensively.
+            if [ -d "$partial_root/rootfs" ] \
+                && [ ! -e "$partial_root/bin" ] \
+                && [ ! -e "$partial_root/usr" ]; then
+                mv "$partial_root/rootfs" "$image_root"
+                rm -rf "$partial_root"
+            elif [ -d "$partial_root" ]; then
+                mv "$partial_root" "$image_root"
+            else
+                ts "FATAL: umoci unpack did not produce a rootfs"
                 exit 1
             fi
-            mv "$partial_root/rootfs" "$image_root"
-            rm -rf "$partial_root"
             ;;
         *)
             ts "FATAL: unknown guest image payload source: ${source:-missing}"

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -10,8 +10,8 @@ use crate::lifecycle::{
 };
 use crate::rootfs::{
     clone_or_copy_sparse_file, create_ext4_image_from_dir_with_size, create_rootfs_image_from_dir,
-    extract_rootfs_archive_to, prepare_sandbox_rootfs_from_image_root, sandbox_guest_init_path,
-    set_rootfs_image_file_mode, write_rootfs_image_file,
+    ext4_image_has_directory, extract_rootfs_archive_to, prepare_sandbox_rootfs_from_image_root,
+    sandbox_guest_init_path, set_rootfs_image_file_mode, write_rootfs_image_file,
 };
 use crate::runtime::VmBackend;
 use bollard::Docker;
@@ -2435,6 +2435,37 @@ impl VmDriver {
         {
             let _ = tokio::fs::remove_dir_all(staging_dir).await;
             return Err(err);
+        }
+
+        // Validate before caching: guest init exit codes do not survive the
+        // libkrun boundary (the VM powers off "cleanly" whatever status PID 1
+        // exited with), so a prep failure would otherwise cache a broken disk
+        // that poisons every later sandbox using this image.
+        let disk_to_validate = prepared_image.clone();
+        let has_rootfs = tokio::task::spawn_blocking(move || {
+            ext4_image_has_directory(&disk_to_validate, "/image-rootfs")
+        })
+        .await
+        .map_err(|err| Status::internal(format!("prepared image validation panicked: {err}")))?
+        .map_err(Status::internal)?;
+        if !has_rootfs {
+            let console = tokio::fs::read_to_string(staging_dir.join("image-prep-console.log"))
+                .await
+                .unwrap_or_default();
+            let tail = console
+                .lines()
+                .rev()
+                .take(12)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect::<Vec<_>>()
+                .join("\n");
+            let _ = tokio::fs::remove_dir_all(staging_dir).await;
+            return Err(Status::failed_precondition(format!(
+                "image-prep for '{image_ref}' produced a disk without /image-rootfs \
+                 (not cached). guest console tail:\n{tail}"
+            )));
         }
 
         if tokio::fs::metadata(&image_path).await.is_ok() {
@@ -4884,9 +4915,13 @@ fn prepared_image_disk_size_bytes(
             .map_err(|err| format!("stat {}: {err}", rootfs_archive.display()))?
             .len(),
     };
+    // The prep disk must hold the payload AND the unpacked rootfs at the
+    // same time (the payload is only removed after a successful unpack), and
+    // compressed layers commonly expand ~2.5-3x. The image file is created
+    // sparse, so generous headroom costs no real disk space.
     let requested = payload_size
-        .saturating_mul(3)
-        .saturating_add(512 * 1024 * 1024);
+        .saturating_mul(4)
+        .saturating_add(1024 * 1024 * 1024);
     Ok(minimum_size_bytes.max(requested))
 }
 

--- a/crates/openshell-driver-vm/src/rootfs.rs
+++ b/crates/openshell-driver-vm/src/rootfs.rs
@@ -655,6 +655,60 @@ fn sandbox_guest_user_ids(rootfs: &Path) -> Result<Option<(u32, u32)>, String> {
     Ok(None)
 }
 
+/// Check (read-only, without mounting) whether an ext4 image contains a
+/// directory at `guest_path`.
+///
+/// Used to validate image-prep output before it is cached: guest init exit
+/// codes do not survive the libkrun boundary — the VM powers off "cleanly"
+/// whatever status PID 1 exited with — so without an explicit content check
+/// a failed prep would poison the prepared-image cache forever.
+pub fn ext4_image_has_directory(image_path: &Path, guest_path: &str) -> Result<bool, String> {
+    let mut last_error = None;
+    for candidate in e2fs_tool_candidates("debugfs") {
+        let label = candidate.display().to_string();
+        let output = Command::new(&candidate)
+            .arg("-R")
+            .arg(format!("stat {guest_path}"))
+            .arg(image_path)
+            .output();
+        match output {
+            Ok(output) if output.status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                // debugfs exits 0 even when the target is missing; the
+                // result is only in its output text.
+                if stdout.contains("Type: directory") {
+                    return Ok(true);
+                }
+                if stdout.contains("File not found") || stderr.contains("File not found") {
+                    return Ok(false);
+                }
+                last_error = Some(format!(
+                    "{label} produced unrecognized output for {guest_path}\nstdout: {stdout}\nstderr: {stderr}"
+                ));
+            }
+            Ok(output) => {
+                last_error = Some(format!(
+                    "{label} failed with status {}\nstderr: {}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                last_error = Some(format!("{label} not found"));
+            }
+            Err(err) => {
+                last_error = Some(format!("run {label}: {err}"));
+            }
+        }
+    }
+    Err(format!(
+        "inspect {} for {guest_path} failed: {}. Install e2fsprogs (debugfs) and retry",
+        image_path.display(),
+        last_error.unwrap_or_else(|| "debugfs not found".to_string())
+    ))
+}
+
 fn run_debugfs_batch(image_path: &Path, commands: &[String]) -> Result<(), String> {
     let command_path = temporary_injection_path(image_path);
     let mut contents = commands.join("\n");


### PR DESCRIPTION
## Summary
Fixes the VM driver's registry image preparation: the guest prep script expected `umoci raw unpack` to produce a bundle-style `rootfs/` subdirectory (it extracts directly into the target), so every registry-path prep failed after a successful unpack — and two masking defects (guest exit codes lost across the libkrun boundary, prep disks cached without validation) turned that into a silent, permanent, cache-poisoning failure reported only as "VM process exited with status 0".

## Related Issue
Fixes #2358

## Changes
- `scripts/openshell-vm-sandbox-init.sh`: accept `umoci raw unpack`'s direct-extraction layout, keeping a defensive branch for bundle-style `rootfs/` output.
- `driver.rs::build_prepared_image_disk`: validate that the freshly built disk contains `/image-rootfs` (read-only `debugfs` stat) before renaming it into the content-addressed cache; on failure, do not cache and include the prep VM's console tail in the error instead of reporting success.
- `driver.rs::prepared_image_disk_size_bytes`: size the prep disk for the payload and the unpacked rootfs coexisting (`payload*4 + 1 GiB`, previously `payload*3 + 512 MiB`); the image file is sparse, so the extra headroom costs no real disk space.

## Testing
- [ ] `mise run pre-commit` passes — could not run `mise` in this environment; ran `cargo fmt --check`, `cargo clippy` (no lints), and the crate test suite directly instead
- [x] Unit tests added/updated — existing `openshell-driver-vm` suite passes (119 tests); no behavior-specific unit test added because the fix spans a guest shell script and a helper-VM boundary
- [ ] E2E tests added/updated (if applicable)
- Verified end-to-end on a live macOS (Apple silicon) v0.0.86 gateway with the registry/umoci prep path: before the fix, `ghcr.io/nvidia/openshell-community/sandboxes/pi:latest` failed permanently with a poisoned cache; with the fixed script, the same image reaches `ready` in ~40 s and the sandbox runs `/usr/bin/pi`. Full diagnosis, repro steps, and captured guest consoles are in #2358.

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — no architecture-doc surface for this internal driver behavior
