### PR TITLE
fix(cli): present client certificates in --gateway-insecure mode

### DIFF
--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -1611,7 +1611,8 @@ async fn http_health_check(server: &str, tls: &TlsOptions) -> Result<Option<Stat
 
     let scheme = uri.scheme_str().unwrap_or("https");
     let https = if tls.gateway_insecure && scheme.eq_ignore_ascii_case("https") {
-        let insecure_config = build_insecure_rustls_config()?;
+        let materials = require_tls_materials(server, tls).ok();
+        let insecure_config = build_insecure_rustls_config(materials.as_ref())?;
         HttpsConnectorBuilder::new()
             .with_tls_config(insecure_config)
             .https_or_http()

--- a/crates/openshell-cli/src/tls.rs
+++ b/crates/openshell-cli/src/tls.rs
@@ -302,11 +302,24 @@ impl tower::Service<hyper::Uri> for InsecureTlsConnector {
     }
 }
 
-pub fn build_insecure_rustls_config() -> Result<rustls::ClientConfig> {
-    let config = rustls::ClientConfig::builder()
+pub fn build_insecure_rustls_config(
+    materials: Option<&TlsMaterials>,
+) -> Result<rustls::ClientConfig> {
+    let dangerous = rustls::ClientConfig::builder()
         .dangerous()
-        .with_custom_certificate_verifier(std::sync::Arc::new(InsecureServerCertVerifier))
-        .with_no_client_auth();
+        .with_custom_certificate_verifier(std::sync::Arc::new(InsecureServerCertVerifier));
+    let config = if let Some(m) = materials {
+        let mut cert_cursor = Cursor::new(&m.cert);
+        let cert_chain = rustls_pemfile::certs(&mut cert_cursor)
+            .collect::<Result<Vec<CertificateDer<'static>>, _>>()
+            .into_diagnostic()?;
+        let key = load_private_key(&m.key)?;
+        dangerous
+            .with_client_auth_cert(cert_chain, key)
+            .into_diagnostic()?
+    } else {
+        dangerous.with_no_client_auth()
+    };
     Ok(config)
 }
 
@@ -372,7 +385,8 @@ pub async fn build_channel(server: &str, tls: &TlsOptions) -> Result<Channel> {
 
     if tls.gateway_insecure && server.starts_with("https://") {
         tracing::warn!("TLS certificate verification is disabled — do not use in production");
-        let rustls_config = build_insecure_rustls_config()?;
+        let materials = require_tls_materials(server, tls).ok();
+        let rustls_config = build_insecure_rustls_config(materials.as_ref())?;
         let tls_connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(rustls_config));
         let connector = InsecureTlsConnector { tls_connector };
         // Use http:// so tonic does not layer its own TLS on top — our
@@ -448,4 +462,58 @@ pub async fn grpc_inference_client(server: &str, tls: &TlsOptions) -> Result<Grp
     let channel = build_channel(server, tls).await?;
     let interceptor = interceptor_from_tls(tls)?;
     Ok(InferenceClient::with_interceptor(channel, interceptor))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn install_provider() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    fn generate_test_materials() -> TlsMaterials {
+        use rcgen::{BasicConstraints, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyPair};
+        let ca_key = KeyPair::generate().unwrap();
+        let mut ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+        let client_key = KeyPair::generate().unwrap();
+        let mut client_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        client_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
+        let client_cert = client_params
+            .signed_by(&client_key, &ca_cert, &ca_key)
+            .unwrap();
+
+        TlsMaterials {
+            ca: ca_cert.pem().into_bytes(),
+            cert: client_cert.pem().into_bytes(),
+            key: client_key.serialize_pem().into_bytes(),
+        }
+    }
+
+    #[test]
+    fn insecure_config_without_materials_succeeds() {
+        install_provider();
+        build_insecure_rustls_config(None).expect("should build without client materials");
+    }
+
+    #[test]
+    fn insecure_config_with_materials_succeeds() {
+        install_provider();
+        let materials = generate_test_materials();
+        build_insecure_rustls_config(Some(&materials)).expect("should build with client materials");
+    }
+
+    #[test]
+    fn insecure_config_with_invalid_cert_fails() {
+        install_provider();
+        let materials = TlsMaterials {
+            ca: b"not a cert".to_vec(),
+            cert: b"not a cert".to_vec(),
+            key: b"not a key".to_vec(),
+        };
+        assert!(build_insecure_rustls_config(Some(&materials)).is_err());
+    }
 }


### PR DESCRIPTION
## Summary

`--gateway-insecure` (`OPENSHELL_GATEWAY_INSECURE=true`) disables TLS server certificate verification but was also dropping client certificate presentation via `.with_no_client_auth()`. This broke mTLS gateways that require client certs — semantically, "insecure" should mean "skip server verification" (like `curl -k`), not "don't authenticate myself."

## Related Issue

Fixes #2354

## Changes

- Modified `build_insecure_rustls_config` to accept optional `TlsMaterials` — when provided, uses `.with_client_auth_cert()` instead of `.with_no_client_auth()`
- Updated both call sites (`build_channel` and `http_health_check` in `run.rs`) to attempt loading client certs from the gateway's mtls directory before building the insecure config
- Falls back to `.with_no_client_auth()` when certs are unavailable (no regression for non-mTLS setups)

## Testing

Verified live against a local mTLS gateway:

```
# Before fix: "Client auth requested but no cert/sigscheme available"
# After fix:
OPENSHELL_GATEWAY_INSECURE=true RUST_LOG=debug openshell provider list 2>&1 | grep client
  Got CertificateRequest ...
  Attempting client auth    # <-- client certs now presented
```

- [x] `mise run pre-commit` passes
- [x] Unit tests added: `insecure_config_without_materials_succeeds`, `insecure_config_with_materials_succeeds`, `insecure_config_with_invalid_cert_fails`
- [x] Live-tested against local mTLS gateway (Docker driver)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable — no behavioral contract change)