### PR TITLE
docs(gateway-config): remove invalid sandbox_uid from VM driver example

### DIFF
--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -420,9 +420,6 @@ overlay_disk_mib = 4096
 guest_tls_ca     = "/var/lib/openshell/guest-tls/ca.pem"
 guest_tls_cert   = "/var/lib/openshell/guest-tls/client.pem"
 guest_tls_key    = "/var/lib/openshell/guest-tls/client-key.pem"
-# Resolved sandbox UID/GID for the rootfs /etc/passwd entry.
-# Defaults to 10001 when unset; matching GID is used if sandbox_gid is empty.
-# sandbox_uid = 20001
 ```
 
 ### Extension Driver


### PR DESCRIPTION
## Summary

- Remove the commented-out `sandbox_uid` field from the VM driver TOML example in `docs/reference/gateway-config.mdx`
- `VmComputeConfig` uses `deny_unknown_fields` — uncommenting the line crashes the gateway with "unknown field `sandbox_uid`"
- The field exists on the internal `VmDriverConfig` subprocess (`crates/openshell-driver-vm/src/driver.rs:231`), set via `--sandbox-uid` CLI arg, not through the gateway TOML

## Related Issue

Fixes #2364

## Changes

Removed 3 lines (comment block + commented-out field) from the VM driver example in `docs/reference/gateway-config.mdx`. The Kubernetes driver example correctly retains `sandbox_uid` since `KubernetesComputeConfig` accepts it.

## Testing

- [x] Verified uncommenting the field causes gateway startup crash
- [x] Verified the field is accepted on the `openshell-driver-vm` subprocess via `--sandbox-uid`
- [x] `mise run pre-commit` passes (markdown lint, license check, helm lint)

## Checklist

- [x] Conventional commit format
- [x] DCO sign-off
- [x] No unrelated changes