### PR TITLE
chore(ci): pin pr gate action

### DIFF
--- a/.github/actions/pr-gate/action.yml
+++ b/.github/actions/pr-gate/action.yml
@@ -26,7 +26,7 @@ runs:
     - id: get_pr_info
       if: github.event_name == 'push'
       continue-on-error: true
-      uses: nv-gha-runners/get-pr-info@main
+      uses: nv-gha-runners/get-pr-info@090577647b8ddc4e06e809e264f7881650ecdccf # main
 
     - id: gate
       shell: bash


### PR DESCRIPTION
## Summary

Pin the external `nv-gha-runners/get-pr-info` action used by the PR gate to the current `main` commit SHA.

## Related Issue

None.

## Changes

- Replace the mutable `@main` action reference with `@090577647b8ddc4e06e809e264f7881650ecdccf`.
- Keep `# main` as a trailing comment documenting the source branch.

## Testing

- [ ] `mise run pre-commit` passes (skipped by request; action-only change)
- [ ] Unit tests added/updated (not applicable)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)