### PR TITLE
fix(ci): grant E2E permissions to release workflows

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -69,6 +69,10 @@ jobs:
 
   e2e:
     needs: [build-gateway, build-supervisor]
+    permissions:
+      actions: read
+      contents: read
+      packages: read
     uses: ./.github/workflows/e2e-test.yml
     with:
       image-tag: ${{ github.sha }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -91,6 +91,10 @@ jobs:
 
   e2e:
     needs: [compute-versions, build-gateway, build-supervisor]
+    permissions:
+      actions: read
+      contents: read
+      packages: read
     uses: ./.github/workflows/e2e-test.yml
     with:
       image-tag: ${{ needs.compute-versions.outputs.source_sha }}


### PR DESCRIPTION
## Summary

Restore Release Dev workflow startup by granting the reusable E2E workflow the token permissions it requests. Apply the same fix to Release Tag so the next tagged release does not hit the latent startup failure.

The regression was introduced by #2311, which added artifact downloads and `actions: read` to `.github/workflows/e2e-test.yml` but updated only the branch and merge-queue caller permissions. Release Dev has failed at startup since that merge: https://github.com/NVIDIA/OpenShell/actions/runs/29770548461

## Related Issue

Follow-up to #2311. No issue.

## Changes

- Grant `actions: read`, `contents: read`, and `packages: read` to the Release Dev E2E caller
- Grant the same least-privilege permissions to the identically affected Release Tag E2E caller
- Leave merge-queue E2E configuration unchanged because it already grants the required permissions

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated (not applicable; workflow permissions only)
- [ ] E2E tests added/updated (not applicable; workflow permissions only)
- [x] Parsed the modified workflow YAML and verified caller permissions satisfy the reusable workflow permissions
- [x] `git diff --check` passes

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; workflow permissions only)