### PR TITLE
perf(build): share sccache across worktrees

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,21 @@ openshell --help
 openshell sandbox create -- codex
 ```
 
+### Rust build cache
+
+Mise configures sccache to use `$XDG_CACHE_HOME/openshell/sccache`. When
+`XDG_CACHE_HOME` is unset, mise uses the platform cache directory, such as
+`$HOME/.cache` on Linux or `$HOME/Library/Caches` on macOS. All OpenShell
+worktrees share this compiler cache, while Cargo output remains in each
+worktree's `target/` directory. Existing worktree-local `.cache/sccache`
+directories are not migrated automatically and can be removed manually when
+they are no longer needed.
+
+OpenShell does not set `SCCACHE_BASEDIRS`. Sccache loads base directories when
+its machine-local daemon starts, but the correct workspace root differs for
+each worktree. Consequently, dependencies can be reused across worktrees while
+absolute paths can still prevent hits for workspace-local crates.
+
 ## Main Tasks
 
 These are the primary `mise` tasks for day-to-day development:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,18 +197,25 @@ openshell sandbox create -- codex
 
 ### Rust build cache
 
-Mise configures sccache to use `$XDG_CACHE_HOME/openshell/sccache`. When
-`XDG_CACHE_HOME` is unset, mise uses the platform cache directory, such as
-`$HOME/.cache` on Linux or `$HOME/Library/Caches` on macOS. All OpenShell
-worktrees share this compiler cache, while Cargo output remains in each
-worktree's `target/` directory. Existing worktree-local `.cache/sccache`
-directories are not migrated automatically and can be removed manually when
-they are no longer needed.
+Mise preserves an existing `SCCACHE_DIR` so each environment can choose where
+to store compiler cache entries. When `SCCACHE_DIR` is unset, OpenShell uses
+the worktree-local `.cache/sccache` directory. To make cache entries available
+to multiple worktrees on a workstation, set the variable to a user-level
+directory before activating mise. For example:
+
+```shell
+export SCCACHE_DIR="$HOME/.cache/openshell/sccache"
+```
+
+CI can select a different directory or configure a remote sccache backend
+without changing the workstation setting. Cargo output remains in each
+worktree's `target/` directory.
 
 OpenShell does not set `SCCACHE_BASEDIRS`. Sccache loads base directories when
 its machine-local daemon starts, but the correct workspace root differs for
-each worktree. Consequently, dependencies can be reused across worktrees while
-absolute paths can still prevent hits for workspace-local crates.
+each worktree. Cache reuse therefore depends on the compiler inputs: outputs
+that embed absolute paths, including Rust dependencies in some builds, can
+still miss across worktrees.
 
 ## Main Tasks
 

--- a/mise.toml
+++ b/mise.toml
@@ -53,11 +53,10 @@ _.file = [".env"]
 KUBECONFIG = "{{config_root}}/kubeconfig"
 UV_CACHE_DIR = "{{config_root}}/.cache/uv"
 
-# Enable sccache for faster Rust builds.
-# Local builds share an OpenShell-specific user cache across worktrees; CI sets
-# SCCACHE_MEMCACHED_ENDPOINT via repository variables to use memcached instead.
+# Enable sccache for faster Rust builds. Preserve an SCCACHE_DIR selected by the
+# caller so workstations and CI can configure their cache locations separately.
 RUSTC_WRAPPER = "sccache"
-SCCACHE_DIR = "{{xdg_cache_home}}/openshell/sccache"
+SCCACHE_DIR = { default = "{{config_root}}/.cache/sccache" }
 
 # Shared build constants (overridable via environment).
 # DOCKER_BUILDKIT enables BuildKit for Docker; ignored by podman.

--- a/mise.toml
+++ b/mise.toml
@@ -54,10 +54,10 @@ KUBECONFIG = "{{config_root}}/kubeconfig"
 UV_CACHE_DIR = "{{config_root}}/.cache/uv"
 
 # Enable sccache for faster Rust builds.
-# Local builds use a disk cache (SCCACHE_DIR); CI sets SCCACHE_MEMCACHED_ENDPOINT
-# via repository variables to use a shared memcached backend instead.
+# Local builds share an OpenShell-specific user cache across worktrees; CI sets
+# SCCACHE_MEMCACHED_ENDPOINT via repository variables to use memcached instead.
 RUSTC_WRAPPER = "sccache"
-SCCACHE_DIR = "{{config_root}}/.cache/sccache"
+SCCACHE_DIR = "{{xdg_cache_home}}/openshell/sccache"
 
 # Shared build constants (overridable via environment).
 # DOCKER_BUILDKIT enables BuildKit for Docker; ignored by podman.

--- a/mise.toml
+++ b/mise.toml
@@ -56,7 +56,7 @@ UV_CACHE_DIR = "{{config_root}}/.cache/uv"
 # Enable sccache for faster Rust builds. Preserve an SCCACHE_DIR selected by the
 # caller so workstations and CI can configure their cache locations separately.
 RUSTC_WRAPPER = "sccache"
-SCCACHE_DIR = { default = "{{config_root}}/.cache/sccache" }
+SCCACHE_DIR = "{{ get_env(name='SCCACHE_DIR', default=config_root ~ '/.cache/sccache') }}"
 
 # Shared build constants (overridable via environment).
 # DOCKER_BUILDKIT enables BuildKit for Docker; ignored by podman.


### PR DESCRIPTION
## Summary

Make the local sccache directory configurable per environment without changing
the existing CI fallback. Workstations can point `SCCACHE_DIR` at one shared
location, while CI can choose its own directory or remote backend.

## Related Issue

None.

## Changes

- Preserve a non-empty `SCCACHE_DIR` supplied before mise runs.
- Fall back to each worktree's existing `.cache/sccache` directory when the
  variable is unset, keeping current CI cache paths unchanged.
- Keep Cargo output in each worktree's local `target/` directory.
- Document workstation configuration and the cross-worktree limitations of
  leaving `SCCACHE_BASEDIRS` unset.

## Testing

- [x] `mise run pre-commit` passes
- [x] Confirmed an explicit `SCCACHE_DIR` reaches `mise x` subprocesses
  unchanged
- [x] Confirmed an unset `SCCACHE_DIR` resolves to the worktree-local
  `.cache/sccache` fallback
- [x] Built `openshell-core` from two worktrees at the same commit using an
  isolated shared sccache directory and separate Cargo target directories

### Cache experiment

The experiment used sccache 0.14.0 with `CARGO_INCREMENTAL=0`, a fresh cache,
and a dedicated daemon. Each build used a separate Cargo target directory.

| Build | Time | Cache hits | Cache misses |
| --- | ---: | ---: | ---: |
| First worktree | 1m 16s | 0 | 200 (176 Rust, 13 C/C++, 11 assembler) |
| Second worktree | 1m 15s | 24 (13 C/C++, 11 assembler) | 176 Rust |

The second build had a 12% cache hit rate across cacheable compilations and no
cache read, write, or configuration errors. All Rust compilations missed because
absolute worktree paths remained part of their compiler inputs. This is why the
change makes the cache location configurable but does not set
`SCCACHE_BASEDIRS` or promise universal Rust reuse across worktrees.

- [ ] Unit tests added/updated (not applicable; configuration and documentation only)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; developer tooling behavior is documented in `CONTRIBUTING.md`)

The source branch name was explicitly selected for this work and does not include an issue number.
