### PR TITLE
fix(cli): respect CARGO_TARGET_DIR in openshell wrapper script

### DIFF
--- a/scripts/bin/openshell
+++ b/scripts/bin/openshell
@@ -3,7 +3,8 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-BINARY="$PROJECT_ROOT/target/debug/openshell"
+TARGET_DIR="${CARGO_TARGET_DIR:-$PROJECT_ROOT/target}"
+BINARY="$TARGET_DIR/debug/openshell"
 STATE_FILE="$PROJECT_ROOT/.cache/openshell-build.state"
 CALLER_PWD="$PWD"
 


### PR DESCRIPTION
## Summary

The `scripts/bin/openshell` wrapper script hardcodes the binary path to `$PROJECT_ROOT/target/debug/openshell`. When `CARGO_TARGET_DIR` is set (e.g. via `.bashrc`, mise, or CI config), cargo places the binary in a different directory and the wrapper fails with `No such file or directory`.

This fix uses `${CARGO_TARGET_DIR:-$PROJECT_ROOT/target}` so the wrapper resolves the binary path correctly regardless of where build artifacts are configured to live.

## Changes

- Replaced the hardcoded `$PROJECT_ROOT/target/debug/openshell` binary path with `${CARGO_TARGET_DIR:-$PROJECT_ROOT/target}/debug/openshell`
- Falls back to the default `target/` directory when `CARGO_TARGET_DIR` is not set (no behavior change for existing users)

## Testing

- [x] Verified the build succeeds with `CARGO_TARGET_DIR=/mnt/build-artifacts/cargo-target`
- [x] Verified the wrapper script finds and executes the binary at the custom target dir
- [x] `mise run pre-commit` passes

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)