### PR TITLE
docs(prover): correct prove() exit code doc comment

### DIFF
--- a/crates/openshell-prover/src/lib.rs
+++ b/crates/openshell-prover/src/lib.rs
@@ -26,11 +26,11 @@ use policy::parse_policy;
 use queries::run_all_queries;
 use report::{render_compact, render_report};
 
-/// Run the prover end-to-end and return an exit code.
+/// Run the prover end-to-end and return a result containing an exit code.
 ///
-/// - `0` — pass (no critical/high findings, or all accepted)
-/// - `1` — fail (critical or high findings present)
-/// - `2` — input error
+/// - `Ok(0)` — pass (no findings, or all accepted)
+/// - `Ok(1)` — fail (one or more unaccepted findings present)
+/// - `Err(_)` — input or registry loading error
 ///
 /// Binary and API capability registries are embedded at compile time.
 /// Pass `registry_dir` to override with a custom filesystem registry.


### PR DESCRIPTION
## Summary

Corrects the `prove()` doc comment which incorrectly described exit code 1 as
firing on "critical or high findings." The prover has no severity grades — exit
code 1 fires on any unaccepted finding.

## Related Issue

Closes #2394

## Changes

- Corrected exit code descriptions in `crates/openshell-prover/src/lib.rs:31-32`

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated — not applicable, doc comment only
- [ ] E2E tests added/updated — not applicable

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — not applicable