### PR TITLE
fix(ci): retry flaky mise lock verification

### DIFF
--- a/.github/workflows/branch-checks.yml
+++ b/.github/workflows/branch-checks.yml
@@ -54,11 +54,20 @@ jobs:
 
       - name: Verify mise.lock is in sync with mise.toml
         run: |
-          mise lock
-          if ! git diff --exit-code mise.lock; then
-            echo "::error::mise.lock is out of sync with mise.toml. Run 'mise lock' locally and commit the result." >&2
-            exit 1
-          fi
+          for attempt in 1 2 3; do
+            if mise lock && git diff --quiet -- mise.lock; then
+              exit 0
+            fi
+
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::mise lock did not reproduce the committed lockfile (attempt $attempt/3); retrying"
+              git restore --source=HEAD --worktree -- mise.lock
+            fi
+          done
+
+          git diff -- mise.lock || true
+          echo "::error::mise.lock is out of sync with mise.toml. Run 'mise lock' locally and commit the result." >&2
+          exit 1
 
   license-headers:
     name: License Headers


### PR DESCRIPTION
## Summary

Make the mise lockfile check tolerate transient lock-resolution drift without hiding persistent lockfile changes. The same committed `mise.lock` and CI image digest failed once and passed on retry, so the check now makes up to three clean attempts.

## Related Issue

N/A — CI regression observed on main-derived PR checks.

## Changes

- Retry `mise lock` verification up to three times
- Restore the committed lockfile before each retry
- Preserve the final diff and failure when drift persists

Observed runs:
- [Transient failure](https://github.com/NVIDIA/OpenShell/actions/runs/29842583848)
- [Successful rerun with identical lockfile and CI image](https://github.com/NVIDIA/OpenShell/actions/runs/29849881676)

## Testing

- [x] `mise run pre-commit` passes
- [x] Updated shell logic executed successfully against the committed lockfile
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)