### PR TITLE
fix(dco): Fix mismatched wording that breaks initial DCO checks

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -6,6 +6,9 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
+env:
+  DCO_SIGN_COMMENT: "I have read the DCO document and I hereby sign the DCO."
+
 permissions:
   actions: write
   checks: none
@@ -29,7 +32,7 @@ jobs:
       - name: "DCO Assistant"
         if: |
           (github.event.comment.body == 'recheck' ||
-           github.event.comment.body == 'I have read the Contributor Agreement including DCO and I hereby sign the Contributor Agreement and DCO') ||
+           github.event.comment.body == env.DCO_SIGN_COMMENT) ||
           github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08
         env:
@@ -46,6 +49,6 @@ jobs:
             [Developer Certificate of Origin](https://github.com/NVIDIA/OpenShell/blob/main/DCO)
             before we can accept your contribution. You can sign the DCO by
             adding a comment below using this text:
-          custom-pr-sign-comment: "I have read the DCO document and I hereby sign the DCO."
+          custom-pr-sign-comment: ${{ env.DCO_SIGN_COMMENT }}
           lock-pullrequest-aftermerge: false
           use-dco-flag: true


### PR DESCRIPTION
## Summary

Fix the DCO Assistant workflow so the comment it asks first-time contributors to post also triggers signature processing. Today, contributors can work around the problem by posting a second `recheck` comment, but the documented one-comment signing flow does not work.

PR #2395 exposed the issue: its commit contains a valid `Signed-off-by` trailer and the contributor posted the requested DCO signature comment, but the comment-triggered workflow skipped its only action step and left the original check failing.

## Related Issue

Observed on #2395.

## Changes

- Define the requested DCO signature text once as `DCO_SIGN_COMMENT`.
- Use that value both in the workflow trigger and in `custom-pr-sign-comment`.
- Remove the stale CLA-oriented trigger text, which does not match the DCO comment shown to contributors.

## Why This Is Needed

The current workflow asks contributors to post:

`I have read the DCO document and I hereby sign the DCO.`

However, its step condition expects:

`I have read the Contributor Agreement including DCO and I hereby sign the Contributor Agreement and DCO`

Because those values differ, posting the requested signature starts an `issue_comment` workflow run but skips the DCO Assistant step. A subsequent `recheck` comment happens to work because it triggers the action, which scans the earlier comments, finds the DCO signature, records the user in `dco-signatures.json`, and reruns the failed check.

Recent first-time contributors have passed through this two-comment workaround, including #2367, #2315, #2319, #2324, #2285, and #2250. Contributors already present in `dco-signatures.json` pass without encountering the bug.

The upstream action documents a one-comment flow: the configured signature comment must also appear in the workflow condition. This change restores that intended behavior. It does not alter the DCO policy or signature text, and `recheck` remains available for manual retriggering.

## Testing

- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (not applicable)
- [x] Compared the workflow condition with `custom-pr-sign-comment`
- [x] Verified #2395 skipped the DCO Assistant step after the requested signature comment
- [x] Verified recent first-time signers passed after posting `recheck`

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)