### PR TITLE
docs(docker-compose): replace removed OpenClaw community sandbox with NemoClaw redirect

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -19,9 +19,9 @@
 #        ANTHROPIC_API_KEY=sk-ant-... \
 #          openshell provider create --type anthropic --from-existing
 #
-#   4. Create a sandboxed agent — Claude Code or OpenClaw:
+#   4. Create a sandboxed agent — Claude Code:
 #        openshell sandbox create -- claude
-#        openshell sandbox create --from openclaw
+#      For OpenClaw, use NemoClaw: https://github.com/NVIDIA/NemoClaw
 #
 # Sandbox containers are managed by the gateway, not by this Compose file.
 # Each `openshell sandbox create` call launches a fresh container; the gateway

--- a/docs/get-started/tutorials/docker-compose.mdx
+++ b/docs/get-started/tutorials/docker-compose.mdx
@@ -4,7 +4,7 @@
 title: "Run the Gateway with Docker Compose"
 sidebar-title: "Docker Compose Setup"
 slug: "get-started/tutorials/docker-compose"
-description: "Run the OpenShell gateway as a Docker Compose service and create agent sandboxes including OpenClaw."
+description: "Run the OpenShell gateway as a Docker Compose service and create agent sandboxes."
 keywords: "Generative AI, Docker Compose, Gateway, Sandbox, OpenClaw, Docker, Installation"
 ---
 
@@ -15,7 +15,7 @@ After completing this tutorial you have:
 - An OpenShell gateway running as a Compose service.
 - The `openshell` CLI registered against that gateway.
 - An AI provider configured with your API key.
-- A running OpenClaw sandbox.
+- A running agent sandbox.
 
 ## Prerequisites
 
@@ -134,9 +134,6 @@ Sandbox images are pulled automatically on first use, but the initial pull can t
 ```shell
 # Base image — includes Claude Code, OpenCode, Codex, and Copilot
 docker pull ghcr.io/nvidia/openshell-community/sandboxes/base:latest
-
-# OpenClaw image
-docker pull ghcr.io/nvidia/openshell-community/sandboxes/openclaw:latest
 ```
 
 ## Create a sandbox
@@ -144,11 +141,9 @@ docker pull ghcr.io/nvidia/openshell-community/sandboxes/openclaw:latest
 <Tabs>
 <Tab title="OpenClaw">
 
-```shell
-openshell sandbox create --from openclaw
-```
+OpenClaw runs inside OpenShell through [NemoClaw](https://github.com/NVIDIA/NemoClaw), which manages the sandbox image, inference routing, and security policies.
 
-OpenClaw launches directly. The first run pulls the image if it is not cached.
+Follow the [NemoClaw Quickstart](https://docs.nvidia.com/nemoclaw/latest/get-started/quickstart/) to set up an OpenClaw sandbox with managed inference.
 
 </Tab>
 <Tab title="Claude Code">


### PR DESCRIPTION
## Summary

The Docker Compose tutorial and docker-compose.yml comment reference the OpenClaw community sandbox (`--from openclaw`), which was removed from NVIDIA/OpenShell-Community in PR #73 (May 16, 2026). This replaces the stale references with a redirect to the NemoClaw Quickstart, which is the supported path per `docs/about/supported-agents.mdx`.

## Related Issue

Fixes #2404

## Changes

- Remove "including OpenClaw" from the page description metadata.
- Change "A running OpenClaw sandbox" to "A running agent sandbox" in the completion checklist.
- Remove the stale `docker pull` command for the removed `openclaw` image.
- Replace the OpenClaw tab content with a redirect to the NemoClaw Quickstart.
- Update the `docker-compose.yml` comment to point to NemoClaw instead of the removed `--from openclaw` command.

## Testing

- [x] Verified all stale `--from openclaw` and `sandboxes/openclaw` references are removed with `rg`.
- [x] Verified remaining OpenClaw mentions are only the redirect tab and SEO keywords.
- [x] Verified `docs/about/supported-agents.mdx` lists OpenClaw as NemoClaw (blueprint-managed).
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated — N/A (docs-only change)
- [ ] E2E tests added/updated — N/A (docs-only change)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated — N/A (docs-only change)
