### PR TITLE
fix(cli): write exec stderr events to stderr in interactive mode

### DIFF
--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -3420,6 +3420,7 @@ async fn sandbox_exec_interactive_grpc(
 
     let mut exit_code = 0i32;
     let stdout = std::io::stdout();
+    let stderr = std::io::stderr();
 
     while let Some(event) = stream.next().await {
         let event = event.into_diagnostic()?;
@@ -3430,7 +3431,7 @@ async fn sandbox_exec_interactive_grpc(
                 handle.flush().into_diagnostic()?;
             }
             Some(exec_sandbox_event::Payload::Stderr(err)) => {
-                let mut handle = stdout.lock();
+                let mut handle = stderr.lock();
                 handle.write_all(&err.data).into_diagnostic()?;
                 handle.flush().into_diagnostic()?;
             }


### PR DESCRIPTION
## Summary

In interactive `openshell exec`, stderr payloads from the sandbox were written to stdout because the `Stderr` arm of the event loop was a verbatim copy of the `Stdout` arm (`stdout.lock()`). The non-interactive exec path in the same file handles the identical event with `stderr.lock()`. This broke shell redirection (e.g. `openshell exec ... 2>err.txt`) and piping of stdout in interactive mode.

## Related Issue

N/A — small copy-paste fix found during code review.

## Changes

- Bind `stderr` in the interactive exec event loop and lock it in the `Stderr` arm, matching the non-interactive path

## Testing

- [x] `mise run pre-commit` passes (mise unavailable in this environment; ran equivalent `cargo fmt` + `cargo clippy -p openshell-cli --all-targets` — clean)
- [ ] Unit tests added/updated (event loop requires a live gRPC stream; no existing test seam for this path)
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)