### PR TITLE
fix(policy): avoid panic truncating multi-byte UTF-8 paths for display

### DIFF
--- a/crates/openshell-policy/src/lib.rs
+++ b/crates/openshell-policy/src/lib.rs
@@ -1438,7 +1438,13 @@ fn truncate_for_display(s: &str) -> String {
     if s.len() <= 80 {
         s.to_string()
     } else {
-        format!("{}...", &s[..77])
+        // Back off to a char boundary: slicing at a fixed byte index panics
+        // on multi-byte UTF-8 (e.g. non-ASCII characters in policy paths).
+        let mut end = 77;
+        while !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &s[..end])
     }
 }
 
@@ -1459,6 +1465,21 @@ pub use openshell_core::paths::normalize_path;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn truncate_for_display_handles_multi_byte_utf8_without_panicking() {
+        // Byte index 77 falls inside the multi-byte 'é'.
+        let s = format!("/{}{}", "a".repeat(75), "é".repeat(100));
+        let truncated = truncate_for_display(&s);
+        assert!(truncated.ends_with("..."));
+        assert!(truncated.len() <= 80);
+    }
+
+    #[test]
+    fn truncate_for_display_leaves_short_strings_untouched() {
+        let s = "short path";
+        assert_eq!(truncate_for_display(s), s);
+    }
 
     /// Verify that the serialized YAML uses `filesystem_policy` (not
     /// `filesystem`) so it can be fed back to `parse_sandbox_policy`.


### PR DESCRIPTION
## Summary

`truncate_for_display` in `openshell-policy` sliced over-long strings at a fixed byte index (`&s[..77]`), panicking when the index lands inside a multi-byte UTF-8 character. A policy YAML with a filesystem path longer than `MAX_PATH_LENGTH` (4096) containing multi-byte characters crashes the sandbox supervisor and OPA policy loader instead of producing the intended `FieldTooLong` policy violation.

## Related Issue

N/A — small fix found during code review. Same bug class as #2406 (byte-index slicing on possibly multi-byte strings).

## Changes

- `truncate_for_display` backs off to the nearest char boundary before slicing
- Added regression tests: multi-byte input no longer panics; short strings pass through unchanged

## Testing

- [x] `mise run pre-commit` passes (mise unavailable in this environment; ran equivalent `cargo fmt` + `cargo clippy -p openshell-policy --all-targets` — clean)
- [x] Unit tests added/updated (`cargo test -p openshell-policy truncate_for_display` — 2 passed)
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)