### PR TITLE
fix(core): bracket IPv6 bind addresses in forward arg and access URL

### DIFF
--- a/crates/openshell-core/src/forward.rs
+++ b/crates/openshell-core/src/forward.rs
@@ -580,18 +580,38 @@ impl ForwardSpec {
     }
 
     /// The SSH `-L` local-forward argument: `bind_addr:port:127.0.0.1:port`.
+    /// IPv6 bind addresses are bracketed as OpenSSH requires (`[::1]:port:...`).
     pub fn ssh_forward_arg(&self) -> String {
-        format!("{}:{}:127.0.0.1:{}", self.bind_addr, self.port, self.port)
+        format!(
+            "{}:{}:127.0.0.1:{}",
+            bracket_ipv6(&self.bind_addr),
+            self.port,
+            self.port
+        )
     }
 
     /// A human-readable URL for the forwarded port.
     pub fn access_url(&self) -> String {
         let host = if self.bind_addr == "0.0.0.0" || self.bind_addr == "::" {
-            "localhost"
+            "localhost".to_string()
         } else {
-            &self.bind_addr
+            bracket_ipv6(&self.bind_addr)
         };
         format!("http://{host}:{}/", self.port)
+    }
+}
+
+/// Bracket an IPv6 literal for use in `host:port` contexts (SSH `-L`
+/// arguments and URLs); leave other addresses unchanged.
+fn bracket_ipv6(addr: &str) -> String {
+    if addr
+        .parse::<std::net::IpAddr>()
+        .is_ok_and(|ip| ip.is_ipv6())
+        && !addr.starts_with('[')
+    {
+        format!("[{addr}]")
+    } else {
+        addr.to_string()
     }
 }
 
@@ -1411,6 +1431,9 @@ mod tests {
 
         let spec = ForwardSpec::parse("8080").unwrap();
         assert_eq!(spec.ssh_forward_arg(), "127.0.0.1:8080:127.0.0.1:8080");
+
+        let spec = ForwardSpec::parse("::1:8080").unwrap();
+        assert_eq!(spec.ssh_forward_arg(), "[::1]:8080:127.0.0.1:8080");
     }
 
     #[test]
@@ -1661,6 +1684,9 @@ mod tests {
 
         let spec = ForwardSpec::parse("0.0.0.0:8080").unwrap();
         assert_eq!(spec.access_url(), "http://localhost:8080/");
+
+        let spec = ForwardSpec::parse("::1:8080").unwrap();
+        assert_eq!(spec.access_url(), "http://[::1]:8080/");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`ForwardSpec::parse` supports IPv6 bind addresses (e.g. `openshell forward ::1:8080`, covered by an existing parse test), but two formatters emitted unbracketed output:

- `ssh_forward_arg()` produced `::1:8080:127.0.0.1:8080`, which OpenSSH misparses — the `-L` forward fails
- `access_url()` produced `http://::1:8080/`, an invalid URL (RFC 3986 requires `[::1]`) printed verbatim to users

## Related Issue

N/A — small fix found during code review. The same file already brackets IPv6 literals correctly in `format_gateway_url`; this applies the same logic to the forward spec.

## Changes

- Added a `bracket_ipv6` helper (same condition as `format_gateway_url`) and used it in `ssh_forward_arg()` and `access_url()`
- Extended `forward_spec_ssh_forward_arg` and `forward_spec_access_url` tests with `::1` cases

## Testing

- [x] `mise run pre-commit` passes (mise unavailable in this environment; ran equivalent `cargo fmt` + `cargo clippy -p openshell-core --all-targets` — clean)
- [x] Unit tests added/updated (`cargo test -p openshell-core forward_spec` — 9 passed)
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)