### PR TITLE
fix(agents): make baked payload readable

### DIFF
--- a/scripts/agents/run.sh
+++ b/scripts/agents/run.sh
@@ -639,6 +639,7 @@ File.open(dockerfile_path, "a") do |file|
   file.puts
   file.puts "USER root"
   file.puts "COPY openshell-agent-payload/ #{payload_image_dir}/"
+  file.puts "RUN chmod -R a+rX #{payload_image_dir}"
   file.puts "RUN chmod -R a-w #{payload_image_dir}"
   file.puts final_user if final_user
 end


### PR DESCRIPTION
## Summary

Make the immutable agent payload readable and executable by the non-root sandbox user after it is copied into generated sandbox images.

## Related Issue

None.

## Changes

- Add a generated Dockerfile permission step that applies `chmod -R a+rX` to `/etc/openshell/agent-payload` before removing write bits.
- Preserve the existing immutable payload behavior with the following `chmod -R a-w` step.

## Testing

- [x] `bash -n scripts/agents/run.sh` passes
- [x] `bash scripts/agents/runtime/supervisor_test.sh` passes
- [x] `bash scripts/agents/gator/bin/gh_guard_test.sh` passes
- [x] Live gator launch for PR #2153 reached sandbox `Ready` and started watch cycle 1
- [ ] `mise run pre-commit` passes (skipped at operator request)
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)