### PR TITLE
fix(mise): initialize Python dependencies in fresh worktrees

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,10 +181,6 @@ mise trust
 mise run gateway
 ```
 
-Python tasks install the locked development dependencies into the current
-worktree's `.venv` when needed. You do not need to share or manually populate a
-virtual environment across worktrees.
-
 ## Building the `openshell` CLI
 
 Inside this repository, `openshell` is a local shortcut script at `scripts/bin/openshell`. The script will

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,10 @@ mise trust
 mise run gateway
 ```
 
+Python tasks install the locked development dependencies into the current
+worktree's `.venv` when needed. You do not need to share or manually populate a
+virtual environment across worktrees.
+
 ## Building the `openshell` CLI
 
 Inside this repository, `openshell` is a local shortcut script at `scripts/bin/openshell`. The script will

--- a/architecture/build.md
+++ b/architecture/build.md
@@ -133,11 +133,11 @@ do not infer from kube context.
 ## Python Wheel Packaging
 
 The generated protobuf/gRPC stubs under `python/openshell/_proto/` are gitignored
-build outputs of `mise run python:proto`. Before generation, the task installs
-the locked development dependencies into the current worktree's `.venv`; its
-subsequent `uv run` commands disable implicit synchronization. maturin honors
-`.gitignore` when collecting `python-source` files, so native builds (Linux CI,
-local `pip install .`) would drop them and ship an unimportable wheel. `pyproject.toml`
+build outputs of `mise run python:proto`. The task uses `uv run --frozen` to
+synchronize the current worktree's `.venv` from `uv.lock` before generation.
+maturin honors `.gitignore` when collecting `python-source` files, so native
+builds (Linux CI, local `pip install .`) would drop them and ship an unimportable
+wheel. `pyproject.toml`
 pins them back in with `[tool.maturin].include` globs. The release workflows
 install each Linux wheel in a clean image and import `openshell.sandbox` as a
 smoke check.

--- a/architecture/build.md
+++ b/architecture/build.md
@@ -133,9 +133,11 @@ do not infer from kube context.
 ## Python Wheel Packaging
 
 The generated protobuf/gRPC stubs under `python/openshell/_proto/` are gitignored
-build outputs of `mise run python:proto`. maturin honors `.gitignore` when
-collecting `python-source` files, so native builds (Linux CI, local
-`pip install .`) would drop them and ship an unimportable wheel. `pyproject.toml`
+build outputs of `mise run python:proto`. Before generation, the task installs
+the locked development dependencies into the current worktree's `.venv`; its
+subsequent `uv run` commands disable implicit synchronization. maturin honors
+`.gitignore` when collecting `python-source` files, so native builds (Linux CI,
+local `pip install .`) would drop them and ship an unimportable wheel. `pyproject.toml`
 pins them back in with `[tool.maturin].include` globs. The release workflows
 install each Linux wheel in a clean image and import `openshell.sandbox` as a
 smoke check.

--- a/tasks/python.toml
+++ b/tasks/python.toml
@@ -222,6 +222,7 @@ env = { UV_NO_SYNC = "1" }
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
+uv sync --frozen --group dev
 uv run python -m grpc_tools.protoc \
   -Iproto \
   --python_out=python/openshell/_proto \

--- a/tasks/python.toml
+++ b/tasks/python.toml
@@ -218,12 +218,10 @@ hide = true
 
 ["python:proto"]
 description = "Generate Python protobuf stubs from .proto files"
-env = { UV_NO_SYNC = "1" }
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
-uv sync --frozen --group dev
-uv run python -m grpc_tools.protoc \
+uv run --frozen python -m grpc_tools.protoc \
   -Iproto \
   --python_out=python/openshell/_proto \
   --pyi_out=python/openshell/_proto \
@@ -234,7 +232,7 @@ uv run python -m grpc_tools.protoc \
   proto/options.proto \
   proto/sandbox.proto
 # Fix absolute imports in generated stubs to use package-relative imports
-uv run python - <<'PY'
+uv run --frozen python - <<'PY'
 from pathlib import Path
 import re
 


### PR DESCRIPTION
## Summary

Allow Python protobuf generation and the pre-commit task to run in fresh worktrees whose mise-created `.venv` has not been manually populated. `python:proto` now uses uv's automatic, inexact project synchronization with the committed lockfile.

## Related Issue

N/A

## Changes

- Run protobuf generation and import rewriting through `uv run --frozen`
- Remove `UV_NO_SYNC` from `python:proto`
- Document protobuf environment synchronization in the build architecture

## Testing

- [x] `mise run pre-commit` passes
- [x] Generated protobuf stubs from a brand-new isolated uv environment
- [x] Confirmed `grpc_tools` was installed and imported from that isolated environment
- [ ] Unit tests added/updated (not applicable; mise task behavior change)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated