### PR TITLE
fix(examples): add missing workspace fields to governance interceptor

### DIFF
--- a/examples/governance-interceptor/Cargo.lock
+++ b/examples/governance-interceptor/Cargo.lock
@@ -865,6 +865,7 @@ name = "openshell-core"
 version = "0.0.0"
 dependencies = [
  "base64",
+ "glob",
  "ipnet",
  "miette",
  "prost",
@@ -907,6 +908,7 @@ version = "0.0.0"
 dependencies = [
  "miette",
  "openshell-core",
+ "prost-types",
  "serde",
  "serde_json",
  "serde_yml",

--- a/examples/governance-interceptor/src/main.rs
+++ b/examples/governance-interceptor/src/main.rs
@@ -1235,6 +1235,8 @@ async fn propagate_policy_to_running_sandboxes(
                 limit,
                 offset,
                 label_selector: String::new(),
+                workspace: String::new(),
+                all_workspaces: true,
             })
             .await
             .map_err(|status| format!("list sandboxes failed: {status}"))?


### PR DESCRIPTION
## Summary

The `ListSandboxesRequest` proto gained `workspace` and `all_workspaces` fields as part of the workspace feature, but the governance interceptor example was not updated, causing a compilation failure:

```
error[E0063]: missing fields `all_workspaces` and `workspace` in initializer of
              `openshell_core::proto::ListSandboxesRequest`
```

Sets `all_workspaces: true` so the interceptor's policy reload covers sandboxes across all workspaces.

## Related Issue

None — found while running `examples/governance-interceptor/smoke.sh` on current main.

## Changes

- Added `workspace: String::new()` and `all_workspaces: true` to the `ListSandboxesRequest` initializer in the policy reload loop (`src/main.rs`)

## Testing

- `cargo build --manifest-path examples/governance-interceptor/Cargo.toml` compiles successfully
- `./smoke.sh` starts the gateway and interceptor without build errors