### PR TITLE
refactor(prover): remove legacy unused reachability constraints

### DIFF
--- a/crates/openshell-prover/src/lib.rs
+++ b/crates/openshell-prover/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! Encodes sandbox policies, binary capabilities, and credential scopes as Z3
 //! SMT constraints, then checks reachability queries to detect data exfiltration
-//! paths and write-bypass violations.
+//! paths.
 
 pub mod accepted_risks;
 pub mod credentials;

--- a/crates/openshell-prover/src/model.rs
+++ b/crates/openshell-prover/src/model.rs
@@ -45,14 +45,8 @@ pub struct ReachabilityModel {
     l7_enforced: HashMap<String, Bool>,
     l7_allows_write: HashMap<String, Bool>,
     binary_bypasses_l7: HashMap<String, Bool>,
-    binary_can_write: HashMap<String, Bool>,
     binary_can_exfil: HashMap<String, Bool>,
     binary_can_construct_http: HashMap<String, Bool>,
-    credential_has_write: HashMap<String, Bool>,
-    #[allow(dead_code)]
-    credential_has_destructive: HashMap<String, Bool>,
-    #[allow(dead_code)]
-    filesystem_readable: HashMap<String, Bool>,
 }
 
 impl ReachabilityModel {
@@ -74,12 +68,8 @@ impl ReachabilityModel {
             l7_enforced: HashMap::new(),
             l7_allows_write: HashMap::new(),
             binary_bypasses_l7: HashMap::new(),
-            binary_can_write: HashMap::new(),
             binary_can_exfil: HashMap::new(),
             binary_can_construct_http: HashMap::new(),
-            credential_has_write: HashMap::new(),
-            credential_has_destructive: HashMap::new(),
-            filesystem_readable: HashMap::new(),
         };
         model.build();
         model
@@ -91,8 +81,6 @@ impl ReachabilityModel {
         self.encode_policy_allows();
         self.encode_l7_enforcement();
         self.encode_binary_capabilities();
-        self.encode_credentials();
-        self.encode_filesystem();
     }
 
     fn index_endpoints(&mut self) {
@@ -198,14 +186,6 @@ impl ReachabilityModel {
             }
             self.binary_bypasses_l7.insert(bpath.clone(), bypass_var);
 
-            let write_var = Bool::new_const(format!("binary_can_write_{bpath}"));
-            if cap.can_write() {
-                self.solver.assert(&write_var);
-            } else {
-                self.solver.assert(&!write_var.clone());
-            }
-            self.binary_can_write.insert(bpath.clone(), write_var);
-
             let exfil_var = Bool::new_const(format!("binary_can_exfil_{bpath}"));
             if cap.can_exfiltrate {
                 self.solver.assert(&exfil_var);
@@ -225,104 +205,10 @@ impl ReachabilityModel {
         }
     }
 
-    fn encode_credentials(&mut self) {
-        let hosts: HashSet<String> = self.endpoints.iter().map(|e| e.host.clone()).collect();
-
-        for host in &hosts {
-            let creds = self.credentials.credentials_for_host(host);
-            let api = self.credentials.api_for_host(host);
-
-            let mut has_write = false;
-            let mut has_destructive = false;
-
-            for cred in &creds {
-                if let Some(api) = api {
-                    if !api.write_actions_for_scopes(&cred.scopes).is_empty() {
-                        has_write = true;
-                    }
-                    if !api.destructive_actions_for_scopes(&cred.scopes).is_empty() {
-                        has_destructive = true;
-                    }
-                } else if !cred.scopes.is_empty() {
-                    has_write = true;
-                }
-            }
-
-            let cw_var = Bool::new_const(format!("credential_has_write_{host}"));
-            if has_write {
-                self.solver.assert(&cw_var);
-            } else {
-                self.solver.assert(&!cw_var.clone());
-            }
-            self.credential_has_write.insert(host.clone(), cw_var);
-
-            let destructive_var = Bool::new_const(format!("credential_has_destructive_{host}"));
-            if has_destructive {
-                self.solver.assert(&destructive_var);
-            } else {
-                self.solver.assert(&!destructive_var.clone());
-            }
-            self.credential_has_destructive
-                .insert(host.clone(), destructive_var);
-        }
-    }
-
-    fn encode_filesystem(&mut self) {
-        for path in self.policy.filesystem_policy.readable_paths(None) {
-            let var = Bool::new_const(format!("fs_readable_{path}"));
-            self.solver.assert(&var);
-            self.filesystem_readable.insert(path, var);
-        }
-    }
-
     // --- Query helpers ---
 
     fn false_val() -> Bool {
         Bool::from_bool(false)
-    }
-
-    /// Build a Z3 expression for whether a binary can write to an endpoint.
-    pub fn can_write_to_endpoint(&self, bpath: &str, eid: &EndpointId) -> Bool {
-        let ek = eid.key();
-        let access_key = format!("{bpath}:{ek}");
-
-        let has_access = match self.policy_allows.get(&access_key) {
-            Some(v) => v.clone(),
-            None => return Self::false_val(),
-        };
-
-        let bypass = self
-            .binary_bypasses_l7
-            .get(bpath)
-            .cloned()
-            .unwrap_or_else(Self::false_val);
-        let l7_enforced = self
-            .l7_enforced
-            .get(&ek)
-            .cloned()
-            .unwrap_or_else(Self::false_val);
-        let l7_write = self
-            .l7_allows_write
-            .get(&ek)
-            .cloned()
-            .unwrap_or_else(Self::false_val);
-        let binary_write = self
-            .binary_can_write
-            .get(bpath)
-            .cloned()
-            .unwrap_or_else(Self::false_val);
-        let cred_write = self
-            .credential_has_write
-            .get(&eid.host)
-            .cloned()
-            .unwrap_or_else(Self::false_val);
-
-        Bool::and(&[
-            has_access,
-            binary_write,
-            Bool::or(&[!l7_enforced, l7_write, bypass]),
-            cred_write,
-        ])
     }
 
     /// Build a Z3 expression for whether data can be exfiltrated via this path.

--- a/crates/openshell-prover/src/registry.rs
+++ b/crates/openshell-prover/src/registry.rs
@@ -100,15 +100,6 @@ pub struct BinaryProtocol {
     pub actions: Vec<BinaryAction>,
 }
 
-impl BinaryProtocol {
-    /// Whether any action in this protocol is a write or destructive action.
-    pub fn can_write(&self) -> bool {
-        self.actions
-            .iter()
-            .any(|a| matches!(a.action_type, ActionType::Write | ActionType::Destructive))
-    }
-}
-
 /// Capability descriptor for a single binary.
 #[derive(Debug, Clone)]
 pub struct BinaryCapability {
@@ -125,29 +116,6 @@ impl BinaryCapability {
     /// Whether any protocol bypasses L7 inspection.
     pub fn bypasses_l7(&self) -> bool {
         self.protocols.iter().any(|p| p.bypasses_l7)
-    }
-
-    /// Whether the binary can perform write actions.
-    pub fn can_write(&self) -> bool {
-        self.protocols.iter().any(BinaryProtocol::can_write) || self.can_construct_http
-    }
-
-    /// Short mechanisms by which this binary can write.
-    pub fn write_mechanisms(&self) -> Vec<String> {
-        let mut mechanisms = Vec::new();
-        for p in &self.protocols {
-            if p.can_write() {
-                for a in &p.actions {
-                    if matches!(a.action_type, ActionType::Write | ActionType::Destructive) {
-                        mechanisms.push(format!("{}: {}", p.name, a.name));
-                    }
-                }
-            }
-        }
-        if self.can_construct_http {
-            mechanisms.push("arbitrary HTTP request construction".to_owned());
-        }
-        mechanisms
     }
 }
 


### PR DESCRIPTION
## Summary
Removes `can_write_to_endpoint()` and the solver variables and encoding methods that exist solely to support it. The active query layer uses `can_exfil_via_endpoint()` and direct credential lookups exclusively; the removed Z3 encodings were scaffolding for query categories that were never implemented or were later cut. Confirmed zero callers across the monorepo; crate is not published externally and no release notes reference its public API surface.

Also removes three dead write-capability helpers from `registry.rs` that lost their only callers as a direct consequence of the `model.rs` cleanup.

## Related Issue
Closes #2412

## Changes
- Removed `can_write_to_endpoint()` — zero callers confirmed across the monorepo
- Removed `binary_can_write`, `credential_has_write` — only consumed by `can_write_to_endpoint()`
- Removed `credential_has_destructive`, `filesystem_readable` — directly dead, previously silenced with `#[allow(dead_code)]`
- Removed `encode_credentials()`, `encode_filesystem()` — exclusively populated the above fields
- Removed two `#[allow(dead_code)]` allowances, `HashMap::new()` initialisers, and the `encode_credentials()` / `encode_filesystem()` calls inside `build()`.
- Removed `BinaryProtocol::can_write()`, `BinaryCapability::can_write()` — made dead by the `model.rs` cleanup above
- Removed `write_mechanisms()` — pre-existing dead code, no callers prior to this series

## Follow-up Dead Code

This PR leaves behind two dead code clusters that are out of scope here but should be tracked:

1. registry.rs - write action data layer (caused by this PR). Removing `can_write()` and `write_mechanisms()` orphaned their only consumers of `BinaryProtocol::actions`, `BinaryAction`, and `ActionType::Write`/`Destructive`. The data is still loaded from YAML at parse time but never queried.
2. credentials.rs - API registry subsystem (pre-existing, surfaced by this PR). `write_actions_for_scopes` and `destructive_actions_for_scopes` were killed here (their sole caller `encode_credentials()` was removed). The cascade beneath them - `actions_for_scopes`, `ApiCapability`, `ApiAction`, and all associated loaders and serde types - was already dead before this PR. This is the full API registry subsystem in credentials.rs, which was never fully wired up. 
 
To avoid scope creep I have omitted these from this PR but can address it here if preferred - left as a follow-up outside scope of this PR for now.

## Testing
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

`cargo test -p openshell-prover` passes. No new tests added — existing tests (`test_findings_for_github_policy`, `test_wildcard_endpoint_covering_credential_host_emits_credential_reach`, `test_known_metadata_hostname_emits_link_local_finding`, `test_empty_policy_no_findings`) cover all four active finding categories end-to-end. `can_write_to_endpoint()` was never invoked by `prove()` or any live query path — no test could have detected its presence or absence.

## Checklist
- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — no architecture doc covers prover model internals
