### PR TITLE
fix(core): bracket IPv6 bind addresses in forward arg and access URL

### DIFF
--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -361,6 +361,13 @@ openshell forward start 8000 my-sandbox -d    # run in background
 
 OpenShell prints the local URL only after the forward listener is reachable. Background forwards must be tracked locally so `openshell forward list` and `openshell forward stop` can manage them.
 
+To bind the local side to an IPv6 loopback address, use `-b`/`--bind-addr`. IPv6 addresses are bracketed in both the SSH forward argument and the printed access URL:
+
+```shell
+openshell forward start 8000 my-sandbox -b ::1
+# Local URL: http://[::1]:8000/
+```
+
 List and stop active forwards:
 
 ```shell

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -361,6 +361,13 @@ openshell forward start 8000 my-sandbox -d    # run in background
 
 OpenShell prints the local URL only after the forward listener is reachable. Background forwards must be tracked locally so `openshell forward list` and `openshell forward stop` can manage them.
 
+To bind the local side to an IPv6 loopback address, pass it positionally as `[bind_address:]port`. IPv6 addresses are bracketed in both the SSH forward argument and the printed access URL:
+
+```shell
+openshell forward start ::1:8000 my-sandbox
+# Local URL: http://[::1]:8000/
+```
+
 List and stop active forwards:
 
 ```shell

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -361,10 +361,10 @@ openshell forward start 8000 my-sandbox -d    # run in background
 
 OpenShell prints the local URL only after the forward listener is reachable. Background forwards must be tracked locally so `openshell forward list` and `openshell forward stop` can manage them.
 
-To bind the local side to an IPv6 loopback address, use `-b`/`--bind-addr`. IPv6 addresses are bracketed in both the SSH forward argument and the printed access URL:
+To bind the local side to an IPv6 loopback address, pass it positionally as `[bind_address:]port`. IPv6 addresses are bracketed in both the SSH forward argument and the printed access URL:
 
 ```shell
-openshell forward start 8000 my-sandbox -b ::1
+openshell forward start ::1:8000 my-sandbox
 # Local URL: http://[::1]:8000/
 ```
 


### PR DESCRIPTION
## Summary

`ForwardSpec::parse` supports IPv6 bind addresses (e.g. `openshell forward ::1:8080`, covered by an existing parse test), but two formatters emitted unbracketed output:

- `ssh_forward_arg()` produced `::1:8080:127.0.0.1:8080`, which OpenSSH misparses — the `-L` forward fails
- `access_url()` produced `http://::1:8080/`, an invalid URL (RFC 3986 requires `[::1]`) printed verbatim to users

This PR supersedes #2409, which was auto-closed by the vouch-check workflow before I was vouched.

## Related Issue

N/A — small fix found during code review. The same file already brackets IPv6 literals correctly in `format_gateway_url`; this applies the same logic to the forward spec.

## Changes

- Added a `bracket_ipv6` helper (same condition as `format_gateway_url`) and used it in `ssh_forward_arg()` and `access_url()`
- Extended `forward_spec_ssh_forward_arg` and `forward_spec_access_url` tests with `::1` cases

## Testing

- [x] `mise run pre-commit` passes (mise unavailable in this environment; ran equivalent `cargo fmt` + `cargo clippy -p openshell-core --all-targets` — clean)
- [x] Unit tests added/updated (`cargo test -p openshell-core forward_spec` — 9 passed)
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)