### PR TITLE
fix: assorted small validation and robustness fixes

### DIFF
--- a/crates/openshell-cli/src/commands/common.rs
+++ b/crates/openshell-cli/src/commands/common.rs
@@ -180,8 +180,7 @@ pub fn short_hash(hash: &str) -> &str {
     // Slice at the 13th character boundary so multi-byte UTF-8 cannot panic.
     hash.char_indices()
         .nth(12)
-        .map(|(idx, _)| &hash[..idx])
-        .unwrap_or(hash)
+        .map_or(hash, |(idx, _)| &hash[..idx])
 }
 
 pub fn non_empty_or<'a>(value: &'a str, fallback: &'a str) -> &'a str {

--- a/crates/openshell-cli/src/commands/common.rs
+++ b/crates/openshell-cli/src/commands/common.rs
@@ -174,7 +174,13 @@ pub fn truncate_display(value: &str, max_width: usize) -> String {
 }
 
 pub fn short_hash(hash: &str) -> &str {
-    if hash.len() >= 12 { &hash[..12] } else { hash }
+    if hash.chars().count() <= 12 {
+        return hash;
+    }
+    // Slice at the 13th character boundary so multi-byte UTF-8 cannot panic.
+    hash.char_indices()
+        .nth(12)
+        .map_or(hash, |(idx, _)| &hash[..idx])
 }
 
 pub fn non_empty_or<'a>(value: &'a str, fallback: &'a str) -> &'a str {
@@ -974,5 +980,31 @@ mod tests {
 
         let err = parse_duration_to_ms("\u{20ac}").expect_err("missing number should error");
         assert!(err.to_string().contains("invalid duration"));
+    }
+
+    #[test]
+    fn short_hash_returns_first_12_characters() {
+        assert_eq!(short_hash("abcdefghijkl"), "abcdefghijkl");
+        assert_eq!(short_hash("abcdefghijklm"), "abcdefghijkl");
+    }
+
+    #[test]
+    fn short_hash_leaves_short_input_unchanged() {
+        assert_eq!(short_hash("abc"), "abc");
+        assert_eq!(short_hash(""), "");
+    }
+
+    #[test]
+    fn short_hash_handles_multibyte_characters() {
+        // 12 'a' + one 2-byte 'é' is 14 bytes and 13 chars; byte 12 is exactly
+        // the 'é' boundary, so even the old byte-slice would not panic here.
+        assert_eq!(short_hash("aaaaaaaaaaaaé"), "aaaaaaaaaaaa");
+        // 11 'a' + 2-byte 'é' + 'x': a byte-slice at 12 would split 'é' and
+        // panic; slicing at the 13th character boundary keeps 'é' intact.
+        assert_eq!(short_hash("aaaaaaaaaaaéx"), "aaaaaaaaaaaé");
+        // A 12-char hash ending in a multi-byte char is returned unchanged.
+        assert_eq!(short_hash("aaaaaaaaaaaé"), "aaaaaaaaaaaé");
+        // All-multi-byte input still slices on a character boundary.
+        assert_eq!(short_hash("ééééééééééééé"), "éééééééééééé");
     }
 }

--- a/crates/openshell-cli/src/commands/common.rs
+++ b/crates/openshell-cli/src/commands/common.rs
@@ -174,7 +174,14 @@ pub fn truncate_display(value: &str, max_width: usize) -> String {
 }
 
 pub fn short_hash(hash: &str) -> &str {
-    if hash.len() >= 12 { &hash[..12] } else { hash }
+    if hash.chars().count() <= 12 {
+        return hash;
+    }
+    // Slice at the 13th character boundary so multi-byte UTF-8 cannot panic.
+    hash.char_indices()
+        .nth(12)
+        .map(|(idx, _)| &hash[..idx])
+        .unwrap_or(hash)
 }
 
 pub fn non_empty_or<'a>(value: &'a str, fallback: &'a str) -> &'a str {
@@ -974,5 +981,28 @@ mod tests {
 
         let err = parse_duration_to_ms("\u{20ac}").expect_err("missing number should error");
         assert!(err.to_string().contains("invalid duration"));
+    }
+
+    #[test]
+    fn short_hash_returns_first_12_characters() {
+        assert_eq!(short_hash("abcdefghijkl"), "abcdefghijkl");
+        assert_eq!(short_hash("abcdefghijklm"), "abcdefghijkl");
+    }
+
+    #[test]
+    fn short_hash_leaves_short_input_unchanged() {
+        assert_eq!(short_hash("abc"), "abc");
+        assert_eq!(short_hash(""), "");
+    }
+
+    #[test]
+    fn short_hash_handles_multibyte_characters() {
+        // "aaaaaaaaaaaaé" is 14 bytes (12 'a' + one 2-byte 'é') and 13 chars.
+        // The old byte-slice at 12 would split 'é' and panic.
+        assert_eq!(short_hash("aaaaaaaaaaaaé"), "aaaaaaaaaaaa");
+        // A 12-char hash ending in a multi-byte char is returned unchanged.
+        assert_eq!(short_hash("aaaaaaaaaaaé"), "aaaaaaaaaaaé");
+        // All-multi-byte input still slices on a character boundary.
+        assert_eq!(short_hash("ééééééééééééé"), "éééééééééééé");
     }
 }

--- a/crates/openshell-cli/src/commands/common.rs
+++ b/crates/openshell-cli/src/commands/common.rs
@@ -996,9 +996,12 @@ mod tests {
 
     #[test]
     fn short_hash_handles_multibyte_characters() {
-        // "aaaaaaaaaaaaé" is 14 bytes (12 'a' + one 2-byte 'é') and 13 chars.
-        // The old byte-slice at 12 would split 'é' and panic.
+        // 12 'a' + one 2-byte 'é' is 14 bytes and 13 chars; byte 12 is exactly
+        // the 'é' boundary, so even the old byte-slice would not panic here.
         assert_eq!(short_hash("aaaaaaaaaaaaé"), "aaaaaaaaaaaa");
+        // 11 'a' + 2-byte 'é' + 'x': a byte-slice at 12 would split 'é' and
+        // panic; slicing at the 13th character boundary keeps 'é' intact.
+        assert_eq!(short_hash("aaaaaaaaaaaéx"), "aaaaaaaaaaaé");
         // A 12-char hash ending in a multi-byte char is returned unchanged.
         assert_eq!(short_hash("aaaaaaaaaaaé"), "aaaaaaaaaaaé");
         // All-multi-byte input still slices on a character boundary.

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -5805,7 +5805,7 @@ pub async fn sandbox_policy_set(
             "{} Policy unchanged (version {}, hash: {})",
             "·".dimmed(),
             resp.version,
-            &resp.policy_hash[..12]
+            short_hash(&resp.policy_hash)
         );
         return Ok(());
     }
@@ -5814,7 +5814,7 @@ pub async fn sandbox_policy_set(
         "{} Policy version {} submitted (hash: {})",
         "✓".green().bold(),
         resp.version,
-        &resp.policy_hash[..12]
+        short_hash(&resp.policy_hash)
     );
 
     if !wait {
@@ -6513,7 +6513,13 @@ fn print_policy_revision_table(revisions: &[openshell_core::proto::SandboxPolicy
             &rev.policy_hash
         };
         let error_short = if rev.load_error.len() > 40 {
-            format!("{}...", &rev.load_error[..40])
+            // Back off to a char boundary: byte-index slicing panics on
+            // multi-byte UTF-8 in server-supplied error messages.
+            let mut end = 40;
+            while !rev.load_error.is_char_boundary(end) {
+                end -= 1;
+            }
+            format!("{}...", &rev.load_error[..end])
         } else {
             rev.load_error.clone()
         };

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -5443,11 +5443,7 @@ pub async fn sandbox_policy_set_global(
     eprintln!(
         "{} Global policy configured (hash: {}, settings revision: {})",
         "✓".green().bold(),
-        if response.policy_hash.len() >= 12 {
-            &response.policy_hash[..12]
-        } else {
-            &response.policy_hash
-        },
+        short_hash(&response.policy_hash),
         response.settings_revision,
     );
     Ok(())
@@ -6796,7 +6792,7 @@ pub async fn sandbox_draft_approve(
         "{} Chunk approved. Policy version: {}, hash: {}",
         "OK".green().bold(),
         inner.policy_version,
-        &inner.policy_hash[..12.min(inner.policy_hash.len())]
+        short_hash(&inner.policy_hash)
     );
 
     Ok(())

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -5443,11 +5443,7 @@ pub async fn sandbox_policy_set_global(
     eprintln!(
         "{} Global policy configured (hash: {}, settings revision: {})",
         "✓".green().bold(),
-        if response.policy_hash.len() >= 12 {
-            &response.policy_hash[..12]
-        } else {
-            &response.policy_hash
-        },
+        short_hash(&response.policy_hash),
         response.settings_revision,
     );
     Ok(())
@@ -5805,7 +5801,7 @@ pub async fn sandbox_policy_set(
             "{} Policy unchanged (version {}, hash: {})",
             "·".dimmed(),
             resp.version,
-            &resp.policy_hash[..12]
+            short_hash(&resp.policy_hash)
         );
         return Ok(());
     }
@@ -5814,7 +5810,7 @@ pub async fn sandbox_policy_set(
         "{} Policy version {} submitted (hash: {})",
         "✓".green().bold(),
         resp.version,
-        &resp.policy_hash[..12]
+        short_hash(&resp.policy_hash)
     );
 
     if !wait {
@@ -6500,6 +6496,19 @@ pub async fn sandbox_policy_list_global(
     Ok(())
 }
 
+fn truncate_error_message(error: &str, max_bytes: usize) -> String {
+    if error.len() <= max_bytes {
+        return error.to_string();
+    }
+    // Back off to a char boundary: byte-index slicing panics on multi-byte
+    // UTF-8 in server-supplied error messages.
+    let mut end = max_bytes;
+    while !error.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &error[..end])
+}
+
 fn print_policy_revision_table(revisions: &[openshell_core::proto::SandboxPolicyRevision]) {
     println!(
         "{:<8} {:<14} {:<12} {:<24} ERROR",
@@ -6507,16 +6516,8 @@ fn print_policy_revision_table(revisions: &[openshell_core::proto::SandboxPolicy
     );
     for rev in revisions {
         let status = PolicyStatus::try_from(rev.status).unwrap_or(PolicyStatus::Unspecified);
-        let hash_short = if rev.policy_hash.len() >= 12 {
-            &rev.policy_hash[..12]
-        } else {
-            &rev.policy_hash
-        };
-        let error_short = if rev.load_error.len() > 40 {
-            format!("{}...", &rev.load_error[..40])
-        } else {
-            rev.load_error.clone()
-        };
+        let hash_short = short_hash(&rev.policy_hash);
+        let error_short = truncate_error_message(&rev.load_error, 40);
         println!(
             "{:<8} {:<14} {:<12} {:<24} {}",
             rev.version,
@@ -6791,7 +6792,7 @@ pub async fn sandbox_draft_approve(
         "{} Chunk approved. Policy version: {}, hash: {}",
         "OK".green().bold(),
         inner.policy_version,
-        &inner.policy_hash[..12.min(inner.policy_hash.len())]
+        short_hash(&inner.policy_hash)
     );
 
     Ok(())
@@ -8385,5 +8386,29 @@ mod tests {
         assert_eq!(json["policy_source"], "sandbox");
         assert!(json["revision"].is_null());
         assert!(json["policy"].is_null());
+    }
+
+    #[test]
+    fn truncate_error_message_leaves_short_input_unchanged() {
+        assert_eq!(
+            super::truncate_error_message("short error", 40),
+            "short error"
+        );
+    }
+
+    #[test]
+    fn truncate_error_message_backs_off_to_char_boundary() {
+        // 39 'a' + one 2-byte 'é' means byte 40 splits the multibyte char.
+        let error = "a".repeat(39) + "é";
+        let truncated = super::truncate_error_message(&error, 40);
+        assert!(
+            truncated.ends_with("..."),
+            "expected ellipsis, got {truncated:?}"
+        );
+        assert!(
+            !truncated.contains("é"),
+            "expected char boundary backoff, got {truncated:?}"
+        );
+        assert_eq!(truncated.len(), 39 + 3); // 39 ASCII chars + "..."
     }
 }

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -6500,6 +6500,19 @@ pub async fn sandbox_policy_list_global(
     Ok(())
 }
 
+fn truncate_error_message(error: &str, max_bytes: usize) -> String {
+    if error.len() <= max_bytes {
+        return error.to_string();
+    }
+    // Back off to a char boundary: byte-index slicing panics on multi-byte
+    // UTF-8 in server-supplied error messages.
+    let mut end = max_bytes;
+    while !error.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &error[..end])
+}
+
 fn print_policy_revision_table(revisions: &[openshell_core::proto::SandboxPolicyRevision]) {
     println!(
         "{:<8} {:<14} {:<12} {:<24} ERROR",
@@ -6507,22 +6520,8 @@ fn print_policy_revision_table(revisions: &[openshell_core::proto::SandboxPolicy
     );
     for rev in revisions {
         let status = PolicyStatus::try_from(rev.status).unwrap_or(PolicyStatus::Unspecified);
-        let hash_short = if rev.policy_hash.len() >= 12 {
-            &rev.policy_hash[..12]
-        } else {
-            &rev.policy_hash
-        };
-        let error_short = if rev.load_error.len() > 40 {
-            // Back off to a char boundary: byte-index slicing panics on
-            // multi-byte UTF-8 in server-supplied error messages.
-            let mut end = 40;
-            while !rev.load_error.is_char_boundary(end) {
-                end -= 1;
-            }
-            format!("{}...", &rev.load_error[..end])
-        } else {
-            rev.load_error.clone()
-        };
+        let hash_short = short_hash(&rev.policy_hash);
+        let error_short = truncate_error_message(&rev.load_error, 40);
         println!(
             "{:<8} {:<14} {:<12} {:<24} {}",
             rev.version,
@@ -8391,5 +8390,29 @@ mod tests {
         assert_eq!(json["policy_source"], "sandbox");
         assert!(json["revision"].is_null());
         assert!(json["policy"].is_null());
+    }
+
+    #[test]
+    fn truncate_error_message_leaves_short_input_unchanged() {
+        assert_eq!(
+            super::truncate_error_message("short error", 40),
+            "short error"
+        );
+    }
+
+    #[test]
+    fn truncate_error_message_backs_off_to_char_boundary() {
+        // 39 'a' + one 2-byte 'é' means byte 40 splits the multibyte char.
+        let error = "a".repeat(39) + "é";
+        let truncated = super::truncate_error_message(&error, 40);
+        assert!(
+            truncated.ends_with("..."),
+            "expected ellipsis, got {truncated:?}"
+        );
+        assert!(
+            !truncated.contains("é"),
+            "expected char boundary backoff, got {truncated:?}"
+        );
+        assert_eq!(truncated.len(), 39 + 3); // 39 ASCII chars + "..."
     }
 }

--- a/crates/openshell-sandbox/src/mechanistic_mapper.rs
+++ b/crates/openshell-sandbox/src/mechanistic_mapper.rs
@@ -308,7 +308,8 @@ fn generate_security_notes(host: &str, port: u16, is_ssrf: bool) -> String {
     }
 
     // High port numbers may indicate ephemeral services.
-    if port > 49152 {
+    // The IANA dynamic/private (ephemeral) range is 49152-65535 inclusive.
+    if port >= 49152 {
         notes.push(format!(
             "Port {port} is in the ephemeral range — \
              this may be a temporary service."
@@ -470,6 +471,15 @@ mod tests {
     fn test_security_notes_ssrf() {
         let notes = generate_security_notes("169.254.169.254", 80, true);
         assert!(notes.contains("SSRF"));
+    }
+
+    #[test]
+    fn test_security_notes_ephemeral_range_inclusive_boundary() {
+        // 49151 is just below the IANA ephemeral range; 49152 is the first
+        // ephemeral port and must be flagged.
+        assert!(!generate_security_notes("api.example.com", 49151, false).contains("ephemeral"));
+        assert!(generate_security_notes("api.example.com", 49152, false).contains("ephemeral"));
+        assert!(generate_security_notes("api.example.com", 65535, false).contains("ephemeral"));
     }
 
     #[test]

--- a/crates/openshell-sandbox/src/mechanistic_mapper.rs
+++ b/crates/openshell-sandbox/src/mechanistic_mapper.rs
@@ -474,6 +474,15 @@ mod tests {
     }
 
     #[test]
+    fn test_security_notes_ephemeral_range_inclusive_boundary() {
+        // 49151 is just below the IANA ephemeral range; 49152 is the first
+        // ephemeral port and must be flagged.
+        assert!(!generate_security_notes("api.example.com", 49151, false).contains("ephemeral"));
+        assert!(generate_security_notes("api.example.com", 49152, false).contains("ephemeral"));
+        assert!(generate_security_notes("api.example.com", 65535, false).contains("ephemeral"));
+    }
+
+    #[test]
     fn test_security_notes_internal_ip_uses_canonical_classifier() {
         // RFC 1918 is 172.16.0.0/12 only: the old starts_with("172.") prefix
         // wrongly flagged 172.15/172.32 and missed CGNAT (100.64.0.0/10). #1777.

--- a/crates/openshell-sandbox/src/mechanistic_mapper.rs
+++ b/crates/openshell-sandbox/src/mechanistic_mapper.rs
@@ -308,7 +308,8 @@ fn generate_security_notes(host: &str, port: u16, is_ssrf: bool) -> String {
     }
 
     // High port numbers may indicate ephemeral services.
-    if port > 49152 {
+    // The IANA dynamic/private (ephemeral) range is 49152-65535 inclusive.
+    if port >= 49152 {
         notes.push(format!(
             "Port {port} is in the ephemeral range — \
              this may be a temporary service."

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -3881,7 +3881,7 @@ fn generate_security_notes(rule: &NetworkPolicyRule) -> String {
         };
         for raw_port in ports {
             let port = u16::try_from(*raw_port).unwrap_or(0);
-            if port > 49152 {
+            if port >= 49152 {
                 notes.push(format!(
                     "Port {port} is in the ephemeral range — this may be a temporary service."
                 ));
@@ -4820,6 +4820,36 @@ mod tests {
         assert!(notes.contains("Port 5432 is a well-known database/service port."));
         assert!(notes.contains("Port 50000 is in the ephemeral range"));
         assert!(!notes.contains("Port 3306"));
+    }
+
+    #[test]
+    fn security_notes_ephemeral_range_boundary_49152_inclusive() {
+        // IANA dynamic/private range is 49152-65535 inclusive.
+        let below = generate_security_notes(&NetworkPolicyRule {
+            endpoints: vec![NetworkEndpoint {
+                host: "api.example.com".to_string(),
+                port: 49151,
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        assert!(
+            !below.contains("ephemeral"),
+            "49151 should not be flagged: {below}"
+        );
+
+        let at = generate_security_notes(&NetworkPolicyRule {
+            endpoints: vec![NetworkEndpoint {
+                host: "api.example.com".to_string(),
+                port: 49152,
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        assert!(
+            at.contains("Port 49152 is in the ephemeral range"),
+            "49152 should be flagged: {at}"
+        );
     }
 
     #[test]

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -4833,7 +4833,10 @@ mod tests {
             }],
             ..Default::default()
         });
-        assert!(!below.contains("ephemeral"), "49151 should not be flagged: {below}");
+        assert!(
+            !below.contains("ephemeral"),
+            "49151 should not be flagged: {below}"
+        );
 
         let at = generate_security_notes(&NetworkPolicyRule {
             endpoints: vec![NetworkEndpoint {
@@ -4843,7 +4846,10 @@ mod tests {
             }],
             ..Default::default()
         });
-        assert!(at.contains("Port 49152 is in the ephemeral range"), "49152 should be flagged: {at}");
+        assert!(
+            at.contains("Port 49152 is in the ephemeral range"),
+            "49152 should be flagged: {at}"
+        );
     }
 
     #[test]

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -3881,7 +3881,7 @@ fn generate_security_notes(rule: &NetworkPolicyRule) -> String {
         };
         for raw_port in ports {
             let port = u16::try_from(*raw_port).unwrap_or(0);
-            if port > 49152 {
+            if port >= 49152 {
                 notes.push(format!(
                     "Port {port} is in the ephemeral range — this may be a temporary service."
                 ));
@@ -4820,6 +4820,30 @@ mod tests {
         assert!(notes.contains("Port 5432 is a well-known database/service port."));
         assert!(notes.contains("Port 50000 is in the ephemeral range"));
         assert!(!notes.contains("Port 3306"));
+    }
+
+    #[test]
+    fn security_notes_ephemeral_range_boundary_49152_inclusive() {
+        // IANA dynamic/private range is 49152-65535 inclusive.
+        let below = generate_security_notes(&NetworkPolicyRule {
+            endpoints: vec![NetworkEndpoint {
+                host: "api.example.com".to_string(),
+                port: 49151,
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        assert!(!below.contains("ephemeral"), "49151 should not be flagged: {below}");
+
+        let at = generate_security_notes(&NetworkPolicyRule {
+            endpoints: vec![NetworkEndpoint {
+                host: "api.example.com".to_string(),
+                port: 49152,
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        assert!(at.contains("Port 49152 is in the ephemeral range"), "49152 should be flagged: {at}");
     }
 
     #[test]

--- a/crates/openshell-server/src/grpc/validation.rs
+++ b/crates/openshell-server/src/grpc/validation.rs
@@ -513,7 +513,7 @@ pub(super) fn validate_label_key(key: &str) -> Result<(), Status> {
     // Name must contain only alphanumeric, hyphens, underscores, and dots
     if !name
         .chars()
-        .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == '.')
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
     {
         return Err(Status::invalid_argument(format!(
             "label key name segment contains invalid characters (must be alphanumeric, '-', '_', or '.'): '{key}'"
@@ -523,12 +523,12 @@ pub(super) fn validate_label_key(key: &str) -> Result<(), Status> {
     // Name must start and end with alphanumeric
     let first = name.chars().next().unwrap(); // safe: we checked !is_empty()
     let last = name.chars().last().unwrap();
-    if !first.is_alphanumeric() {
+    if !first.is_ascii_alphanumeric() {
         return Err(Status::invalid_argument(format!(
             "label key name segment must start with alphanumeric character: '{key}'"
         )));
     }
-    if !last.is_alphanumeric() {
+    if !last.is_ascii_alphanumeric() {
         return Err(Status::invalid_argument(format!(
             "label key name segment must end with alphanumeric character: '{key}'"
         )));
@@ -604,7 +604,7 @@ pub(super) fn validate_label_value(value: &str) -> Result<(), Status> {
     // Must contain only alphanumeric, hyphens, underscores, and dots
     if !value
         .chars()
-        .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == '.')
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
     {
         return Err(Status::invalid_argument(format!(
             "label value contains invalid characters (must be alphanumeric, '-', '_', or '.'): '{value}'"
@@ -614,12 +614,12 @@ pub(super) fn validate_label_value(value: &str) -> Result<(), Status> {
     // Must start and end with alphanumeric
     let first = value.chars().next().unwrap(); // safe: we checked !is_empty()
     let last = value.chars().last().unwrap();
-    if !first.is_alphanumeric() {
+    if !first.is_ascii_alphanumeric() {
         return Err(Status::invalid_argument(format!(
             "label value must start with alphanumeric character: '{value}'"
         )));
     }
-    if !last.is_alphanumeric() {
+    if !last.is_ascii_alphanumeric() {
         return Err(Status::invalid_argument(format!(
             "label value must end with alphanumeric character: '{value}'"
         )));
@@ -1506,6 +1506,17 @@ mod tests {
         assert!(err.message().contains("invalid characters"));
     }
 
+    #[test]
+    fn validate_label_key_rejects_unicode_characters() {
+        // The Kubernetes label spec is ASCII-only; Unicode alphanumerics
+        // must not pass gateway validation.
+        let err = validate_label_key("日本語").unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+
+        let err = validate_label_key("café").unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+    }
+
     // ---- Label value validation ----
 
     #[test]
@@ -1571,6 +1582,14 @@ mod tests {
         let err = validate_label_value("value@123").unwrap_err();
         assert_eq!(err.code(), Code::InvalidArgument);
         assert!(err.message().contains("invalid characters"));
+    }
+
+    #[test]
+    fn validate_label_value_rejects_unicode_characters() {
+        // The Kubernetes label spec is ASCII-only; Unicode alphanumerics
+        // must not pass gateway validation.
+        let err = validate_label_value("café").unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
     }
 
     // ---- Label selector validation ----


### PR DESCRIPTION
## Summary

Three small, independent robustness fixes found during code review, one commit each:

1. **server:** Kubernetes label key/value validation used Unicode-aware `is_alphanumeric()`, so labels like `café` or `日本語` passed gateway validation but would be rejected by the Kubernetes API server (the label spec is ASCII-only). The same functions already validate the key prefix with ASCII-only checks.
2. **cli:** `print_policy_revision_table` truncated server-supplied `load_error` strings at a fixed byte index (`&rev.load_error[..40]`), panicking when the index lands inside a multi-byte UTF-8 character (same bug class as #2446).
3. **sandbox:** the ephemeral-port advisory check used `port > 49152`, omitting port 49152 itself from the IANA dynamic/private range (49152–65535 inclusive).

This PR supersedes #2410, which was auto-closed by the vouch-check workflow before I was vouched.

## Related Issue

N/A — small fixes found during code review.

## Changes

- `validate_label_key`/`validate_label_value`: use `is_ascii_alphanumeric()`; added Unicode rejection tests
- `print_policy_revision_table`: back off to a char boundary when truncating `load_error`
- `mechanistic_mapper`: `port >= 49152` for the ephemeral range note

## Testing

- [x] `mise run pre-commit` passes (mise unavailable in this environment; ran equivalent `cargo fmt` + `cargo clippy` on all touched crates — clean)
- [x] Unit tests added/updated (`cargo test -p openshell-server validate_label` — 40 passed, incl. 2 new)
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)