### PR TITLE
fix: assorted byte-index slicing safety fixes

### DIFF
--- a/crates/openshell-bootstrap/src/build.rs
+++ b/crates/openshell-bootstrap/src/build.rs
@@ -398,7 +398,9 @@ fn glob_match(pattern: &str, path: &str, is_dir: bool) -> bool {
             return true;
         }
         for (idx, _) in path.match_indices('/') {
-            if glob_match(rest, &path[idx + 1..], is_dir) {
+            if let Some(suffix) = path.get(idx + 1..)
+                && glob_match(rest, suffix, is_dir)
+            {
                 return true;
             }
         }
@@ -592,6 +594,7 @@ mod tests {
         assert!(glob_match("**/*.log", "a/b/c.log", false));
         assert!(glob_match("**/*.log", "c.log", false));
         assert!(!glob_match("**/*.log", "c.txt", false));
+        assert!(glob_match("**/föö.log", "a/b/föö.log", false));
     }
 
     #[test]

--- a/crates/openshell-bootstrap/src/metadata.rs
+++ b/crates/openshell-bootstrap/src/metadata.rs
@@ -142,7 +142,8 @@ pub fn extract_host_from_ssh_destination(destination: &str) -> String {
 
     // Handle user@host format
     dest.find('@')
-        .map_or_else(|| dest.to_string(), |at_pos| dest[at_pos + 1..].to_string())
+        .and_then(|at_pos| dest.get(at_pos + 1..))
+        .map_or_else(|| dest.to_string(), ToString::to_string)
 }
 
 /// Resolve an SSH host alias to the actual hostname or IP address.
@@ -455,6 +456,11 @@ mod tests {
             extract_host_from_ssh_destination("ssh://myserver"),
             "myserver"
         );
+    }
+
+    #[test]
+    fn extract_host_user_at_multi_byte_hostname() {
+        assert_eq!(extract_host_from_ssh_destination("user@mülti"), "mülti");
     }
 
     #[test]

--- a/crates/openshell-router/src/backend.rs
+++ b/crates/openshell-router/src/backend.rs
@@ -824,8 +824,12 @@ fn build_backend_url(endpoint: &str, path: &str) -> String {
             let base_path = &base[path_start..];
             base_path.starts_with("/v1/") || base_path.ends_with("/v1")
         });
-    if base_path_has_v1_edge_segment && (path == "/v1" || path.starts_with("/v1/")) {
-        return format!("{base}{}", &path[3..]);
+    if base_path_has_v1_edge_segment
+        && let Some(rest) = path
+            .strip_prefix("/v1")
+            .filter(|rest| rest.is_empty() || rest.starts_with('/'))
+    {
+        return format!("{base}{rest}");
     }
 
     format!("{base}{path}")

--- a/crates/openshell-supervisor-network/src/l7/inference.rs
+++ b/crates/openshell-supervisor-network/src/l7/inference.rs
@@ -179,7 +179,10 @@ pub fn detect_inference_pattern<'a>(
             let Some(slash_at) = rest.find('/') else {
                 return false;
             };
-            return slash_at > 0 && rest[slash_at + 1..] == *after;
+            let Some(after_segment) = rest.get(slash_at + 1..) else {
+                return false;
+            };
+            return slash_at > 0 && after_segment == after;
         }
 
         path_only == p.path_glob

--- a/crates/openshell-supervisor-process/src/process.rs
+++ b/crates/openshell-supervisor-process/src/process.rs
@@ -1101,11 +1101,8 @@ fn rewrite_passwd_at(path: &Path, uid: &str, gid: &str) -> Result<()> {
             if line.starts_with("sandbox:") {
                 found = true;
                 let fields: Vec<&str> = line.split(':').collect();
-                if fields.len() >= 7 {
-                    format!(
-                        "{}:{}:{}:{}:{}:{}:{}",
-                        fields[0], fields[1], uid, gid, fields[4], fields[5], fields[6]
-                    )
+                if let [name, pass, _, _, gecos, home, shell, ..] = fields.as_slice() {
+                    format!("{name}:{pass}:{uid}:{gid}:{gecos}:{home}:{shell}")
                 } else {
                     line.to_string()
                 }
@@ -1139,8 +1136,8 @@ fn rewrite_group_at(path: &Path, gid: &str) -> Result<()> {
             if line.starts_with("sandbox:") {
                 found = true;
                 let fields: Vec<&str> = line.split(':').collect();
-                if fields.len() >= 4 {
-                    format!("{}:{}:{}:{}", fields[0], fields[1], gid, fields[3])
+                if let [name, pass, _, members, ..] = fields.as_slice() {
+                    format!("{name}:{pass}:{gid}:{members}")
                 } else {
                     line.to_string()
                 }
@@ -2300,6 +2297,30 @@ mod tests {
         let content = std::fs::read_to_string(&group).unwrap();
         assert!(content.contains("root:x:0:"));
         assert!(content.contains("sandbox:x:6000:"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rewrite_passwd_leaves_malformed_entry_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let passwd = dir.path().join("passwd");
+        // Only 3 fields — slice pattern should fall through instead of panic.
+        std::fs::write(&passwd, "sandbox:x:1000\n").unwrap();
+        rewrite_passwd_at(&passwd, "5000", "6000").unwrap();
+        let content = std::fs::read_to_string(&passwd).unwrap();
+        assert!(content.contains("sandbox:x:1000"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rewrite_group_leaves_malformed_entry_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let group = dir.path().join("group");
+        // Only 2 fields — slice pattern should fall through instead of panic.
+        std::fs::write(&group, "sandbox:x\n").unwrap();
+        rewrite_group_at(&group, "6000").unwrap();
+        let content = std::fs::read_to_string(&group).unwrap();
+        assert!(content.contains("sandbox:x"));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

Five small, independent safety fixes that replace byte-index string slicing and direct indexing with boundary-safe APIs. None are currently reachable panics (the split characters are ASCII), but they are latent panic surfaces on user/external input and flagged by strict clippy lints.

1. **supervisor-process:** `/etc/passwd` and `/etc/group` rewrites used `fields[N]` after a length guard; now use slice patterns.
2. **bootstrap:** `extract_host_from_ssh_destination` sliced `dest[at_pos + 1..]` after `@`; now uses `get()`.
3. **bootstrap:** `.dockerignore` glob matcher sliced `path[idx + 1..]` after `/`; now uses `get()`.
4. **router:** `build_backend_url` sliced `&path[3..]` when stripping `/v1`; now uses `strip_prefix()`.
5. **supervisor-network:** Bedrock-style `/*/` path matcher sliced `rest[slash_at + 1..]` after `/`; now uses `get()`.

## Related Issue

N/A — small fixes found during code review.

## Changes

- Replaced byte-index slices with `get()`, `strip_prefix()`, and slice patterns
- Added regression tests for malformed passwd/group lines, multi-byte SSH hostname, and unicode `.dockerignore` paths

## Testing

- [x] `mise run pre-commit` passes (mise unavailable in this environment; ran equivalent `cargo fmt` + `cargo clippy --all-targets` on all touched crates — clean)
- [x] Unit tests added/updated and passing:
  - `cargo test -p openshell-supervisor-process rewrite_passwd` → 4 passed
  - `cargo test -p openshell-bootstrap extract_host` → 5 passed
  - `cargo test -p openshell-bootstrap test_glob_match_double_star` → passed
  - `cargo test -p openshell-router build_backend_url` → 6 passed
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)