### PR TITLE
fix(supervisor-network): L7 endpoint validation edge cases

### DIFF
--- a/crates/openshell-supervisor-network/src/l7/mod.rs
+++ b/crates/openshell-supervisor-network/src/l7/mod.rs
@@ -958,6 +958,11 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
         };
 
         for (i, ep) in endpoints.iter().enumerate() {
+            let loc = format!("{name}.endpoints[{i}]");
+            if !ep.is_object() {
+                errors.push(format!("{loc}: endpoint entry must be an object"));
+                continue;
+            }
             let protocol = ep.get("protocol").and_then(|v| v.as_str()).unwrap_or("");
             let l7_protocol = L7Protocol::parse(protocol);
             let jsonrpc_family = l7_protocol.is_some_and(L7Protocol::is_jsonrpc_family);
@@ -982,9 +987,13 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                         .into_iter()
                         .collect()
                 },
-                |arr| arr.iter().filter_map(serde_json::Value::as_u64).collect(),
+                |arr| {
+                    arr.iter()
+                        .filter_map(serde_json::Value::as_u64)
+                        .filter(|p| *p > 0)
+                        .collect()
+                },
             );
-            let loc = format!("{name}.endpoints[{i}]");
 
             if protocol == "mcp" {
                 if host.trim().is_empty() {
@@ -1537,7 +1546,13 @@ pub fn expand_access_presets(data: &mut serde_json::Value) -> Vec<String> {
                 && !has_rules
                 && mcp_allow_all_known_mcp_methods
             {
-                ep.as_object_mut().unwrap().insert(
+                let Some(obj) = ep.as_object_mut() else {
+                    warnings.push(format!(
+                        "{name}.endpoints[{i}]: endpoint entry is not an object; skipping access preset expansion"
+                    ));
+                    continue;
+                };
+                obj.insert(
                     "rules".to_string(),
                     serde_json::Value::Array(vec![jsonrpc_rule_json("*")]),
                 );
@@ -1562,9 +1577,13 @@ pub fn expand_access_presets(data: &mut serde_json::Value) -> Vec<String> {
                 continue;
             };
 
-            ep.as_object_mut()
-                .unwrap()
-                .insert("rules".to_string(), serde_json::Value::Array(rules));
+            if let Some(obj) = ep.as_object_mut() {
+                obj.insert("rules".to_string(), serde_json::Value::Array(rules));
+            } else {
+                warnings.push(format!(
+                    "{name}.endpoints[{i}]: endpoint entry is not an object; skipping access preset expansion"
+                ));
+            }
         }
     }
 
@@ -1608,6 +1627,34 @@ fn graphql_rule_json(operation_type: &str) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validate_l7_policies_rejects_non_object_endpoint() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [
+                        "not-an-object",
+                        {"host": "api.example.com", "port": 443, "protocol": "rest"},
+                        42,
+                    ],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("endpoint entry must be an object")),
+            "expected non-object endpoint error: {errors:?}"
+        );
+        // The valid object endpoint should not produce an error.
+        assert!(
+            !errors.iter().any(|e| e.contains("api.example.com")),
+            "valid endpoint should not be blamed: {errors:?}"
+        );
+    }
 
     #[test]
     fn parse_l7_config_rest_enforce() {
@@ -2828,6 +2875,43 @@ mod tests {
                 "allow-my-service.endpoints[0]: unsupported L7 access preset 'allow' ignored; expected one of: read-only, read-write, full".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn expand_access_presets_skips_non_object_endpoint_and_expands_valid() {
+        let mut data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [
+                        "not-an-object",
+                        {
+                            "host": "api.example.com",
+                            "port": 80,
+                            "protocol": "rest",
+                            "access": "read-only"
+                        },
+                    ],
+                    "binaries": []
+                }
+            }
+        });
+        let warnings = expand_access_presets(&mut data);
+        let endpoints = data["network_policies"]["test"]["endpoints"]
+            .as_array()
+            .unwrap();
+        // Invalid entry is left untouched.
+        assert_eq!(endpoints[0], serde_json::json!("not-an-object"));
+        // Valid preset endpoint is expanded.
+        let rules = endpoints[1]["rules"].as_array().unwrap();
+        assert_eq!(rules.len(), 3);
+        let methods: Vec<&str> = rules
+            .iter()
+            .map(|r| r["allow"]["method"].as_str().unwrap())
+            .collect();
+        assert!(methods.contains(&"GET"));
+        assert!(methods.contains(&"HEAD"));
+        assert!(methods.contains(&"OPTIONS"));
+        assert!(warnings.is_empty(), "expected no warnings: {warnings:?}");
     }
 
     #[test]

--- a/crates/openshell-supervisor-network/src/l7/mod.rs
+++ b/crates/openshell-supervisor-network/src/l7/mod.rs
@@ -1629,6 +1629,34 @@ mod tests {
     use super::*;
 
     #[test]
+    fn validate_l7_policies_rejects_non_object_endpoint() {
+        let data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [
+                        "not-an-object",
+                        {"host": "api.example.com", "port": 443, "protocol": "rest"},
+                        42,
+                    ],
+                    "binaries": []
+                }
+            }
+        });
+        let (errors, _warnings) = validate_l7_policies(&data);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("endpoint entry must be an object")),
+            "expected non-object endpoint error: {errors:?}"
+        );
+        // The valid object endpoint should not produce an error.
+        assert!(
+            !errors.iter().any(|e| e.contains("api.example.com")),
+            "valid endpoint should not be blamed: {errors:?}"
+        );
+    }
+
+    #[test]
     fn parse_l7_config_rest_enforce() {
         let val = regorus::Value::from_json_str(
             r#"{"protocol": "rest", "tls": "terminate", "enforcement": "enforce", "host": "api.example.com", "port": 443}"#,

--- a/crates/openshell-supervisor-network/src/l7/mod.rs
+++ b/crates/openshell-supervisor-network/src/l7/mod.rs
@@ -2878,6 +2878,43 @@ mod tests {
     }
 
     #[test]
+    fn expand_access_presets_skips_non_object_endpoint_and_expands_valid() {
+        let mut data = serde_json::json!({
+            "network_policies": {
+                "test": {
+                    "endpoints": [
+                        "not-an-object",
+                        {
+                            "host": "api.example.com",
+                            "port": 80,
+                            "protocol": "rest",
+                            "access": "read-only"
+                        },
+                    ],
+                    "binaries": []
+                }
+            }
+        });
+        let warnings = expand_access_presets(&mut data);
+        let endpoints = data["network_policies"]["test"]["endpoints"]
+            .as_array()
+            .unwrap();
+        // Invalid entry is left untouched.
+        assert_eq!(endpoints[0], serde_json::json!("not-an-object"));
+        // Valid preset endpoint is expanded.
+        let rules = endpoints[1]["rules"].as_array().unwrap();
+        assert_eq!(rules.len(), 3);
+        let methods: Vec<&str> = rules
+            .iter()
+            .map(|r| r["allow"]["method"].as_str().unwrap())
+            .collect();
+        assert!(methods.contains(&"GET"));
+        assert!(methods.contains(&"HEAD"));
+        assert!(methods.contains(&"OPTIONS"));
+        assert!(warnings.is_empty(), "expected no warnings: {warnings:?}");
+    }
+
+    #[test]
     fn expand_graphql_readonly_preset() {
         let mut data = serde_json::json!({
             "network_policies": {

--- a/crates/openshell-supervisor-network/src/l7/mod.rs
+++ b/crates/openshell-supervisor-network/src/l7/mod.rs
@@ -958,6 +958,11 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
         };
 
         for (i, ep) in endpoints.iter().enumerate() {
+            let loc = format!("{name}.endpoints[{i}]");
+            if !ep.is_object() {
+                errors.push(format!("{loc}: endpoint entry must be an object"));
+                continue;
+            }
             let protocol = ep.get("protocol").and_then(|v| v.as_str()).unwrap_or("");
             let l7_protocol = L7Protocol::parse(protocol);
             let jsonrpc_family = l7_protocol.is_some_and(L7Protocol::is_jsonrpc_family);
@@ -982,9 +987,13 @@ pub fn validate_l7_policies(data_json: &serde_json::Value) -> (Vec<String>, Vec<
                         .into_iter()
                         .collect()
                 },
-                |arr| arr.iter().filter_map(serde_json::Value::as_u64).collect(),
+                |arr| {
+                    arr.iter()
+                        .filter_map(serde_json::Value::as_u64)
+                        .filter(|p| *p > 0)
+                        .collect()
+                },
             );
-            let loc = format!("{name}.endpoints[{i}]");
 
             if protocol == "mcp" {
                 if host.trim().is_empty() {
@@ -1537,7 +1546,13 @@ pub fn expand_access_presets(data: &mut serde_json::Value) -> Vec<String> {
                 && !has_rules
                 && mcp_allow_all_known_mcp_methods
             {
-                ep.as_object_mut().unwrap().insert(
+                let Some(obj) = ep.as_object_mut() else {
+                    warnings.push(format!(
+                        "{name}.endpoints[{i}]: endpoint entry is not an object; skipping access preset expansion"
+                    ));
+                    continue;
+                };
+                obj.insert(
                     "rules".to_string(),
                     serde_json::Value::Array(vec![jsonrpc_rule_json("*")]),
                 );
@@ -1562,9 +1577,13 @@ pub fn expand_access_presets(data: &mut serde_json::Value) -> Vec<String> {
                 continue;
             };
 
-            ep.as_object_mut()
-                .unwrap()
-                .insert("rules".to_string(), serde_json::Value::Array(rules));
+            if let Some(obj) = ep.as_object_mut() {
+                obj.insert("rules".to_string(), serde_json::Value::Array(rules));
+            } else {
+                warnings.push(format!(
+                    "{name}.endpoints[{i}]: endpoint entry is not an object; skipping access preset expansion"
+                ));
+            }
         }
     }
 

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -1272,14 +1272,27 @@ fn normalize_endpoint_ports(data: &mut serde_json::Value) {
                 continue;
             };
 
-            // If "ports" already exists and is non-empty, keep it.
+            // A present "ports" array takes precedence over scalar "port".
+            // Record whether it existed before filtering so an all-zero array
+            // does not silently fall back to the scalar.
+            let ports_was_present = ep_obj.contains_key("ports");
+
+            // If "ports" already exists, filter out numeric zero values so
+            // OPA never sees a zero port. Non-numeric entries are left intact
+            // so downstream validation can fail closed on malformed input
+            // rather than silently dropping it.
+            if let Some(ports) = ep_obj.get_mut("ports").and_then(|v| v.as_array_mut()) {
+                ports.retain(|p| p.as_u64().is_none_or(|n| n != 0));
+            }
+
             let has_ports = ep_obj
                 .get("ports")
                 .and_then(|v| v.as_array())
                 .is_some_and(|a| !a.is_empty());
 
-            if !has_ports {
-                // Promote scalar "port" to "ports" array.
+            if !ports_was_present && !has_ports {
+                // Promote scalar "port" to "ports" array only when no
+                // "ports" key was originally present.
                 let port = ep_obj
                     .get("port")
                     .and_then(serde_json::Value::as_u64)
@@ -1647,10 +1660,12 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                 .endpoints
                 .iter()
                 .map(|e| {
-                    // Normalize port/ports: ports takes precedence, then
-                    // single port promoted to array. Rego always sees "ports".
+                    // Normalize port/ports: filter zero ports first so OPA
+                    // never sees them, then a present `ports` array takes
+                    // precedence over the scalar `port`. Rego always sees "ports".
+                    let filtered: Vec<u32> = e.ports.iter().copied().filter(|&p| p > 0).collect();
                     let ports: Vec<u32> = if !e.ports.is_empty() {
-                        e.ports.clone()
+                        filtered
                     } else if e.port > 0 {
                         vec![e.port]
                     } else {
@@ -7963,5 +7978,176 @@ network_policies:
             ancestors: vec![],
             cmdline_paths: vec![],
         }
+    }
+
+    #[test]
+    fn normalize_endpoint_ports_filters_zero_values() {
+        let mut data = serde_json::json!({
+            "network_policies": {
+                "p": {
+                    "endpoints": [
+                        {"host": "h1.test", "ports": [0, 443]},
+                        {"host": "h2.test", "ports": [0]},
+                        {"host": "h3.test", "port": 0},
+                        {"host": "h4.test", "port": 8080},
+                    ]
+                }
+            }
+        });
+        normalize_endpoint_ports(&mut data);
+        let endpoints = data["network_policies"]["p"]["endpoints"]
+            .as_array()
+            .unwrap();
+
+        // Mixed array: zero removed, positive kept.
+        assert_eq!(endpoints[0]["ports"], serde_json::json!([443]));
+        // All-zero array: becomes empty, no fallback port.
+        assert_eq!(endpoints[1]["ports"], serde_json::json!([]));
+        assert!(endpoints[1].get("port").is_none());
+        // Zero scalar port: not promoted, removed.
+        assert!(endpoints[2].get("ports").is_none());
+        assert!(endpoints[2].get("port").is_none());
+        // Positive scalar port: promoted to ports array.
+        assert_eq!(endpoints[3]["ports"], serde_json::json!([8080]));
+        assert!(endpoints[3].get("port").is_none());
+    }
+
+    #[test]
+    fn normalize_endpoint_ports_skips_non_object_endpoints() {
+        let mut data = serde_json::json!({
+            "network_policies": {
+                "p": {
+                    "endpoints": [
+                        "not-an-object",
+                        {"host": "h.test", "port": 443},
+                        42,
+                    ]
+                }
+            }
+        });
+        normalize_endpoint_ports(&mut data);
+        let endpoints = data["network_policies"]["p"]["endpoints"]
+            .as_array()
+            .unwrap();
+
+        // Non-object entries are left untouched rather than panicking.
+        assert_eq!(endpoints[0], serde_json::json!("not-an-object"));
+        assert_eq!(endpoints[1]["ports"], serde_json::json!([443]));
+        assert_eq!(endpoints[2], serde_json::json!(42));
+    }
+
+    #[test]
+    fn normalize_endpoint_ports_empty_array_after_filtering() {
+        let mut data = serde_json::json!({
+            "network_policies": {
+                "p": {
+                    "endpoints": [
+                        {"host": "h.test", "ports": [0], "port": 8080},
+                    ]
+                }
+            }
+        });
+        normalize_endpoint_ports(&mut data);
+        let endpoints = data["network_policies"]["p"]["endpoints"]
+            .as_array()
+            .unwrap();
+        // A present "ports" array takes precedence over scalar "port", even
+        // when filtering leaves the array empty.
+        assert_eq!(endpoints[0]["ports"], serde_json::json!([]));
+        assert!(endpoints[0].get("port").is_none());
+    }
+
+    #[test]
+    fn normalize_endpoint_ports_preserves_non_numeric_entries() {
+        let mut data = serde_json::json!({
+            "network_policies": {
+                "p": {
+                    "endpoints": [
+                        {"host": "h.test", "ports": [0, "bad", 443]},
+                    ]
+                }
+            }
+        });
+        normalize_endpoint_ports(&mut data);
+        let endpoints = data["network_policies"]["p"]["endpoints"]
+            .as_array()
+            .unwrap();
+        // Numeric zeros are removed; non-numeric entries are preserved so
+        // downstream validation can fail closed on malformed input.
+        assert_eq!(endpoints[0]["ports"], serde_json::json!(["bad", 443]));
+    }
+
+    fn proto_with_endpoint_ports(port: u32, ports: Vec<u32>) -> ProtoSandboxPolicy {
+        let mut network_policies = std::collections::HashMap::new();
+        network_policies.insert(
+            "p".to_string(),
+            NetworkPolicyRule {
+                name: "p".to_string(),
+                endpoints: vec![NetworkEndpoint {
+                    host: "api.example.com".to_string(),
+                    port,
+                    ports,
+                    ..Default::default()
+                }],
+                binaries: vec![],
+            },
+        );
+        ProtoSandboxPolicy {
+            version: 1,
+            filesystem: None,
+            landlock: None,
+            process: None,
+            network_policies,
+            network_middlewares: std::collections::HashMap::default(),
+        }
+    }
+
+    #[test]
+    fn proto_to_opa_data_json_filters_zero_ports_in_production_path() {
+        // Mixed array: zero removed, positive kept.
+        let proto = proto_with_endpoint_ports(0, vec![0, 443]);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&proto_to_opa_data_json(&proto, 0)).unwrap();
+        assert_eq!(
+            parsed["network_policies"]["p"]["endpoints"][0]["ports"],
+            serde_json::json!([443])
+        );
+
+        // Zero-only array: becomes empty, no fallback to scalar port.
+        let proto = proto_with_endpoint_ports(0, vec![0]);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&proto_to_opa_data_json(&proto, 0)).unwrap();
+        assert_eq!(
+            parsed["network_policies"]["p"]["endpoints"][0]["ports"],
+            serde_json::json!([])
+        );
+
+        // Zero scalar port: not promoted.
+        let proto = proto_with_endpoint_ports(0, vec![]);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&proto_to_opa_data_json(&proto, 0)).unwrap();
+        assert_eq!(
+            parsed["network_policies"]["p"]["endpoints"][0]["ports"],
+            serde_json::json!([])
+        );
+
+        // Positive scalar port with zero-only array: present `ports` wins,
+        // so the scalar port is NOT promoted.
+        let proto = proto_with_endpoint_ports(8080, vec![0]);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&proto_to_opa_data_json(&proto, 0)).unwrap();
+        assert_eq!(
+            parsed["network_policies"]["p"]["endpoints"][0]["ports"],
+            serde_json::json!([])
+        );
+
+        // Positive scalar port with positive array: array wins.
+        let proto = proto_with_endpoint_ports(8080, vec![443]);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&proto_to_opa_data_json(&proto, 0)).unwrap();
+        assert_eq!(
+            parsed["network_policies"]["p"]["endpoints"][0]["ports"],
+            serde_json::json!([443])
+        );
     }
 }

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -1272,11 +1272,12 @@ fn normalize_endpoint_ports(data: &mut serde_json::Value) {
                 continue;
             };
 
-            // If "ports" already exists, filter out zero values so OPA never
-            // sees a zero port. An all-zero array becomes empty and falls back
-            // to scalar "port" promotion below.
+            // If "ports" already exists, filter out numeric zero values so
+            // OPA never sees a zero port. Non-numeric entries are left intact
+            // so downstream validation can fail closed on malformed input
+            // rather than silently dropping it.
             if let Some(ports) = ep_obj.get_mut("ports").and_then(|v| v.as_array_mut()) {
-                ports.retain(|p| p.as_u64().is_some_and(|n| n > 0));
+                ports.retain(|p| !p.as_u64().is_some_and(|n| n == 0));
             }
 
             let has_ports = ep_obj
@@ -1654,10 +1655,10 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                 .iter()
                 .map(|e| {
                     // Normalize port/ports: filter zero ports first so OPA
-                    // never sees them, then ports takes precedence over a
-                    // single promoted port. Rego always sees "ports".
+                    // never sees them, then a present `ports` array takes
+                    // precedence over the scalar `port`. Rego always sees "ports".
                     let filtered: Vec<u32> = e.ports.iter().copied().filter(|&p| p > 0).collect();
-                    let ports: Vec<u32> = if !filtered.is_empty() {
+                    let ports: Vec<u32> = if !e.ports.is_empty() {
                         filtered
                     } else if e.port > 0 {
                         vec![e.port]
@@ -8049,6 +8050,26 @@ network_policies:
         assert!(endpoints[0].get("port").is_none());
     }
 
+    #[test]
+    fn normalize_endpoint_ports_preserves_non_numeric_entries() {
+        let mut data = serde_json::json!({
+            "network_policies": {
+                "p": {
+                    "endpoints": [
+                        {"host": "h.test", "ports": [0, "bad", 443]},
+                    ]
+                }
+            }
+        });
+        normalize_endpoint_ports(&mut data);
+        let endpoints = data["network_policies"]["p"]["endpoints"]
+            .as_array()
+            .unwrap();
+        // Numeric zeros are removed; non-numeric entries are preserved so
+        // downstream validation can fail closed on malformed input.
+        assert_eq!(endpoints[0]["ports"], serde_json::json!(["bad", 443]));
+    }
+
     fn proto_with_endpoint_ports(port: u32, ports: Vec<u32>) -> ProtoSandboxPolicy {
         let mut network_policies = std::collections::HashMap::new();
         network_policies.insert(
@@ -8103,13 +8124,23 @@ network_policies:
             serde_json::json!([])
         );
 
-        // Positive scalar port with zero-only array: scalar promoted.
+        // Positive scalar port with zero-only array: present `ports` wins,
+        // so the scalar port is NOT promoted.
         let proto = proto_with_endpoint_ports(8080, vec![0]);
         let parsed: serde_json::Value =
             serde_json::from_str(&proto_to_opa_data_json(&proto, 0)).unwrap();
         assert_eq!(
             parsed["network_policies"]["p"]["endpoints"][0]["ports"],
-            serde_json::json!([8080])
+            serde_json::json!([])
+        );
+
+        // Positive scalar port with positive array: array wins.
+        let proto = proto_with_endpoint_ports(8080, vec![443]);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&proto_to_opa_data_json(&proto, 0)).unwrap();
+        assert_eq!(
+            parsed["network_policies"]["p"]["endpoints"][0]["ports"],
+            serde_json::json!([443])
         );
     }
 }

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -1282,7 +1282,7 @@ fn normalize_endpoint_ports(data: &mut serde_json::Value) {
             // so downstream validation can fail closed on malformed input
             // rather than silently dropping it.
             if let Some(ports) = ep_obj.get_mut("ports").and_then(|v| v.as_array_mut()) {
-                ports.retain(|p| !p.as_u64().is_some_and(|n| n == 0));
+                ports.retain(|p| p.as_u64().is_none_or(|n| n != 0));
             }
 
             let has_ports = ep_obj

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -1272,6 +1272,11 @@ fn normalize_endpoint_ports(data: &mut serde_json::Value) {
                 continue;
             };
 
+            // A present "ports" array takes precedence over scalar "port".
+            // Record whether it existed before filtering so an all-zero array
+            // does not silently fall back to the scalar.
+            let ports_was_present = ep_obj.contains_key("ports");
+
             // If "ports" already exists, filter out numeric zero values so
             // OPA never sees a zero port. Non-numeric entries are left intact
             // so downstream validation can fail closed on malformed input
@@ -1285,8 +1290,9 @@ fn normalize_endpoint_ports(data: &mut serde_json::Value) {
                 .and_then(|v| v.as_array())
                 .is_some_and(|a| !a.is_empty());
 
-            if !has_ports {
-                // Promote scalar "port" to "ports" array.
+            if !ports_was_present && !has_ports {
+                // Promote scalar "port" to "ports" array only when no
+                // "ports" key was originally present.
                 let port = ep_obj
                     .get("port")
                     .and_then(serde_json::Value::as_u64)
@@ -8045,8 +8051,9 @@ network_policies:
         let endpoints = data["network_policies"]["p"]["endpoints"]
             .as_array()
             .unwrap();
-        // Zero-only ports array becomes empty; scalar port is promoted.
-        assert_eq!(endpoints[0]["ports"], serde_json::json!([8080]));
+        // A present "ports" array takes precedence over scalar "port", even
+        // when filtering leaves the array empty.
+        assert_eq!(endpoints[0]["ports"], serde_json::json!([]));
         assert!(endpoints[0].get("port").is_none());
     }
 

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -1272,7 +1272,13 @@ fn normalize_endpoint_ports(data: &mut serde_json::Value) {
                 continue;
             };
 
-            // If "ports" already exists and is non-empty, keep it.
+            // If "ports" already exists, filter out zero values so OPA never
+            // sees a zero port. An all-zero array becomes empty and falls back
+            // to scalar "port" promotion below.
+            if let Some(ports) = ep_obj.get_mut("ports").and_then(|v| v.as_array_mut()) {
+                ports.retain(|p| p.as_u64().is_some_and(|n| n > 0));
+            }
+
             let has_ports = ep_obj
                 .get("ports")
                 .and_then(|v| v.as_array())
@@ -7963,5 +7969,81 @@ network_policies:
             ancestors: vec![],
             cmdline_paths: vec![],
         }
+    }
+
+    #[test]
+    fn normalize_endpoint_ports_filters_zero_values() {
+        let mut data = serde_json::json!({
+            "network_policies": {
+                "p": {
+                    "endpoints": [
+                        {"host": "h1.test", "ports": [0, 443]},
+                        {"host": "h2.test", "ports": [0]},
+                        {"host": "h3.test", "port": 0},
+                        {"host": "h4.test", "port": 8080},
+                    ]
+                }
+            }
+        });
+        normalize_endpoint_ports(&mut data);
+        let endpoints = data["network_policies"]["p"]["endpoints"]
+            .as_array()
+            .unwrap();
+
+        // Mixed array: zero removed, positive kept.
+        assert_eq!(endpoints[0]["ports"], serde_json::json!([443]));
+        // All-zero array: becomes empty, no fallback port.
+        assert_eq!(endpoints[1]["ports"], serde_json::json!([]));
+        assert!(endpoints[1].get("port").is_none());
+        // Zero scalar port: not promoted, removed.
+        assert!(endpoints[2].get("ports").is_none());
+        assert!(endpoints[2].get("port").is_none());
+        // Positive scalar port: promoted to ports array.
+        assert_eq!(endpoints[3]["ports"], serde_json::json!([8080]));
+        assert!(endpoints[3].get("port").is_none());
+    }
+
+    #[test]
+    fn normalize_endpoint_ports_skips_non_object_endpoints() {
+        let mut data = serde_json::json!({
+            "network_policies": {
+                "p": {
+                    "endpoints": [
+                        "not-an-object",
+                        {"host": "h.test", "port": 443},
+                        42,
+                    ]
+                }
+            }
+        });
+        normalize_endpoint_ports(&mut data);
+        let endpoints = data["network_policies"]["p"]["endpoints"]
+            .as_array()
+            .unwrap();
+
+        // Non-object entries are left untouched rather than panicking.
+        assert_eq!(endpoints[0], serde_json::json!("not-an-object"));
+        assert_eq!(endpoints[1]["ports"], serde_json::json!([443]));
+        assert_eq!(endpoints[2], serde_json::json!(42));
+    }
+
+    #[test]
+    fn normalize_endpoint_ports_empty_array_after_filtering() {
+        let mut data = serde_json::json!({
+            "network_policies": {
+                "p": {
+                    "endpoints": [
+                        {"host": "h.test", "ports": [0], "port": 8080},
+                    ]
+                }
+            }
+        });
+        normalize_endpoint_ports(&mut data);
+        let endpoints = data["network_policies"]["p"]["endpoints"]
+            .as_array()
+            .unwrap();
+        // Zero-only ports array becomes empty; scalar port is promoted.
+        assert_eq!(endpoints[0]["ports"], serde_json::json!([8080]));
+        assert!(endpoints[0].get("port").is_none());
     }
 }

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -1653,10 +1653,12 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                 .endpoints
                 .iter()
                 .map(|e| {
-                    // Normalize port/ports: ports takes precedence, then
-                    // single port promoted to array. Rego always sees "ports".
-                    let ports: Vec<u32> = if !e.ports.is_empty() {
-                        e.ports.clone()
+                    // Normalize port/ports: filter zero ports first so OPA
+                    // never sees them, then ports takes precedence over a
+                    // single promoted port. Rego always sees "ports".
+                    let filtered: Vec<u32> = e.ports.iter().copied().filter(|&p| p > 0).collect();
+                    let ports: Vec<u32> = if !filtered.is_empty() {
+                        filtered
                     } else if e.port > 0 {
                         vec![e.port]
                     } else {
@@ -8045,5 +8047,69 @@ network_policies:
         // Zero-only ports array becomes empty; scalar port is promoted.
         assert_eq!(endpoints[0]["ports"], serde_json::json!([8080]));
         assert!(endpoints[0].get("port").is_none());
+    }
+
+    fn proto_with_endpoint_ports(port: u32, ports: Vec<u32>) -> ProtoSandboxPolicy {
+        let mut network_policies = std::collections::HashMap::new();
+        network_policies.insert(
+            "p".to_string(),
+            NetworkPolicyRule {
+                name: "p".to_string(),
+                endpoints: vec![NetworkEndpoint {
+                    host: "api.example.com".to_string(),
+                    port,
+                    ports,
+                    ..Default::default()
+                }],
+                binaries: vec![],
+            },
+        );
+        ProtoSandboxPolicy {
+            version: 1,
+            filesystem: None,
+            landlock: None,
+            process: None,
+            network_policies,
+            network_middlewares: std::collections::HashMap::default(),
+        }
+    }
+
+    #[test]
+    fn proto_to_opa_data_json_filters_zero_ports_in_production_path() {
+        // Mixed array: zero removed, positive kept.
+        let proto = proto_with_endpoint_ports(0, vec![0, 443]);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&proto_to_opa_data_json(&proto, 0)).unwrap();
+        assert_eq!(
+            parsed["network_policies"]["p"]["endpoints"][0]["ports"],
+            serde_json::json!([443])
+        );
+
+        // Zero-only array: becomes empty, no fallback to scalar port.
+        let proto = proto_with_endpoint_ports(0, vec![0]);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&proto_to_opa_data_json(&proto, 0)).unwrap();
+        assert_eq!(
+            parsed["network_policies"]["p"]["endpoints"][0]["ports"],
+            serde_json::json!([])
+        );
+
+        // Zero scalar port: not promoted.
+        let proto = proto_with_endpoint_ports(0, vec![]);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&proto_to_opa_data_json(&proto, 0)).unwrap();
+        assert_eq!(
+            parsed["network_policies"]["p"]["endpoints"][0]["ports"],
+            serde_json::json!([])
+        );
+
+        // Positive scalar port with zero-only array: scalar promoted.
+        let proto = proto_with_endpoint_ports(8080, vec![0]);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&proto_to_opa_data_json(&proto, 0)).unwrap();
+        assert_eq!(
+            parsed["network_policies"]["p"]["endpoints"][0]["ports"],
+            serde_json::json!([8080])
+        );
     }
 }

--- a/crates/openshell-supervisor-network/src/policy_local.rs
+++ b/crates/openshell-supervisor-network/src/policy_local.rs
@@ -1104,6 +1104,7 @@ fn network_endpoint_from_json(
     }
 
     let mut ports = endpoint.ports;
+    ports.retain(|p| *p > 0);
     if ports.is_empty() && endpoint.port > 0 {
         ports.push(endpoint.port);
     }

--- a/crates/openshell-supervisor-network/src/policy_local.rs
+++ b/crates/openshell-supervisor-network/src/policy_local.rs
@@ -1104,6 +1104,7 @@ fn network_endpoint_from_json(
     }
 
     let mut ports = endpoint.ports;
+    ports.retain(|p| *p > 0);
     if ports.is_empty() && endpoint.port > 0 {
         ports.push(endpoint.port);
     }
@@ -1436,6 +1437,58 @@ mod tests {
             rule.endpoints[0].rules[0].allow.as_ref().unwrap().path,
             "/user/repos"
         );
+    }
+
+    fn proposal_body_with_endpoint_ports(port: u32, ports: serde_json::Value) -> Vec<u8> {
+        serde_json::json!({
+            "operations": [
+                {
+                    "addRule": {
+                        "ruleName": "ports_case",
+                        "rule": {
+                            "endpoints": [
+                                {
+                                    "host": "api.example.com",
+                                    "port": port,
+                                    "ports": ports,
+                                }
+                            ],
+                            "binaries": []
+                        }
+                    }
+                }
+            ]
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    #[test]
+    fn proposal_chunks_from_body_filters_mixed_zero_ports() {
+        let body = proposal_body_with_endpoint_ports(0, serde_json::json!([0, 443]));
+        let chunks = proposal_chunks_from_body(&body).unwrap();
+        let rule = chunks[0].proposed_rule.as_ref().unwrap();
+        assert_eq!(rule.endpoints[0].ports, vec![443]);
+        assert_eq!(rule.endpoints[0].port, 443);
+    }
+
+    #[test]
+    fn proposal_chunks_from_body_rejects_zero_only_ports() {
+        let body = proposal_body_with_endpoint_ports(0, serde_json::json!([0]));
+        let err = proposal_chunks_from_body(&body).unwrap_err();
+        assert!(
+            err.contains("endpoint.port or endpoint.ports is required"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn proposal_chunks_from_body_zero_ports_falls_back_to_scalar_port() {
+        let body = proposal_body_with_endpoint_ports(8080, serde_json::json!([0]));
+        let chunks = proposal_chunks_from_body(&body).unwrap();
+        let rule = chunks[0].proposed_rule.as_ref().unwrap();
+        assert_eq!(rule.endpoints[0].ports, vec![8080]);
+        assert_eq!(rule.endpoints[0].port, 8080);
     }
 
     #[test]

--- a/crates/openshell-supervisor-network/src/policy_local.rs
+++ b/crates/openshell-supervisor-network/src/policy_local.rs
@@ -1439,6 +1439,58 @@ mod tests {
         );
     }
 
+    fn proposal_body_with_endpoint_ports(port: u32, ports: serde_json::Value) -> Vec<u8> {
+        serde_json::json!({
+            "operations": [
+                {
+                    "addRule": {
+                        "ruleName": "ports_case",
+                        "rule": {
+                            "endpoints": [
+                                {
+                                    "host": "api.example.com",
+                                    "port": port,
+                                    "ports": ports,
+                                }
+                            ],
+                            "binaries": []
+                        }
+                    }
+                }
+            ]
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    #[test]
+    fn proposal_chunks_from_body_filters_mixed_zero_ports() {
+        let body = proposal_body_with_endpoint_ports(0, serde_json::json!([0, 443]));
+        let chunks = proposal_chunks_from_body(&body).unwrap();
+        let rule = chunks[0].proposed_rule.as_ref().unwrap();
+        assert_eq!(rule.endpoints[0].ports, vec![443]);
+        assert_eq!(rule.endpoints[0].port, 443);
+    }
+
+    #[test]
+    fn proposal_chunks_from_body_rejects_zero_only_ports() {
+        let body = proposal_body_with_endpoint_ports(0, serde_json::json!([0]));
+        let err = proposal_chunks_from_body(&body).unwrap_err();
+        assert!(
+            err.contains("endpoint.port or endpoint.ports is required"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn proposal_chunks_from_body_zero_ports_falls_back_to_scalar_port() {
+        let body = proposal_body_with_endpoint_ports(8080, serde_json::json!([0]));
+        let chunks = proposal_chunks_from_body(&body).unwrap();
+        let rule = chunks[0].proposed_rule.as_ref().unwrap();
+        assert_eq!(rule.endpoints[0].ports, vec![8080]);
+        assert_eq!(rule.endpoints[0].port, 8080);
+    }
+
     #[test]
     fn proposal_chunks_from_body_rejects_query_in_l7_path() {
         let body = br#"{


### PR DESCRIPTION
## Summary

Two small robustness fixes in L7 network policy handling:

1. `validate_l7_policies` assumed every entry in `network_policies.<name>.endpoints` was a JSON object, and `expand_access_presets` called `ep.as_object_mut().unwrap()`. A malformed non-object endpoint caused a panic. This change adds an object-shape validation error and replaces the unwraps with safe pattern matching.
2. The scalar `port` field was already validated to be `> 0`, but the `ports` array accepted `0` values silently. The same inconsistency existed in the agent-proposal endpoint parser. Both paths now filter out zero ports.

## Related Issue

N/A — small fixes found during code review.

## Changes

- `l7/mod.rs`: validate endpoint is an object; replace `as_object_mut().unwrap()` with safe matching; filter `ports` array to `> 0`
- `policy_local.rs`: filter zero entries from `endpoint.ports`

## Testing

- [x] `mise run pre-commit` passes (mise unavailable in this environment; ran equivalent `cargo fmt` + `cargo clippy -p openshell-supervisor-network --all-targets` — clean)
- [x] Unit tests pass (`cargo test -p openshell-supervisor-network --lib` — 969 passed)
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)