### PR TITLE
fix(sandbox): resolve host-gateway aliases from proxy /etc/hosts

### DIFF
--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -20,6 +20,8 @@ use openshell_ocsf::{
     NetworkActivityBuilder, Process, SeverityId, StatusId, Url as OcsfUrl, ocsf_emit,
 };
 use std::net::{IpAddr, SocketAddr};
+#[cfg(any(target_os = "linux", test))]
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -2840,15 +2842,31 @@ async fn resolve_from_sandbox_hosts(
 /// `/etc/hosts` is the container-level file populated by the compute driver's
 /// `--add-host` flag.
 #[cfg(any(target_os = "linux", test))]
-fn resolve_from_proxy_hosts(host: &str, port: u16) -> Option<Vec<SocketAddr>> {
-    let contents = std::fs::read_to_string("/etc/hosts").ok()?;
-    let addrs = resolve_from_hosts_file_contents(&contents, host, port);
-    if addrs.is_empty() { None } else { Some(addrs) }
+async fn resolve_from_proxy_hosts(host: &str, port: u16) -> Option<Vec<SocketAddr>> {
+    resolve_from_hosts_file(Path::new("/etc/hosts"), host, port).await
 }
 
 #[cfg(not(any(target_os = "linux", test)))]
-fn resolve_from_proxy_hosts(_host: &str, _port: u16) -> Option<Vec<SocketAddr>> {
+#[allow(clippy::unused_async)]
+async fn resolve_from_proxy_hosts(_host: &str, _port: u16) -> Option<Vec<SocketAddr>> {
     None
+}
+
+#[cfg(any(target_os = "linux", test))]
+async fn resolve_from_hosts_file(path: &Path, host: &str, port: u16) -> Option<Vec<SocketAddr>> {
+    let contents = match tokio::fs::read_to_string(path).await {
+        Ok(contents) => contents,
+        Err(error) => {
+            debug!(
+                path = %path.display(),
+                host,
+                "Falling back to DNS; failed to read hosts file: {error}"
+            );
+            return None;
+        }
+    };
+    let addrs = resolve_from_hosts_file_contents(&contents, host, port);
+    if addrs.is_empty() { None } else { Some(addrs) }
 }
 
 async fn resolve_socket_addrs(
@@ -2870,8 +2888,8 @@ async fn resolve_socket_addrs(
     // /etc/hosts does not contain the entry. Fall back to the proxy's own
     // /etc/hosts (the container's) before trying system DNS, which will
     // also fail for these synthetic names.
-    if is_host_gateway_alias(&host.to_ascii_lowercase())
-        && let Some(addrs) = resolve_from_proxy_hosts(host, port)
+    if is_host_gateway_alias(host)
+        && let Some(addrs) = resolve_from_proxy_hosts(host, port).await
     {
         return Ok(addrs);
     }
@@ -7196,39 +7214,49 @@ network_policies:
 
     // -- resolve_from_proxy_hosts --
 
-    #[test]
-    fn test_resolve_from_proxy_hosts_finds_host_gateway_alias() {
+    #[tokio::test]
+    async fn test_resolve_from_hosts_file_reads_host_gateway_alias_from_disk() {
         // The proxy's /etc/hosts is the container-level file populated by
         // --add-host. resolve_from_proxy_hosts reads it directly, bypassing
         // the system resolver, so host-gateway aliases resolve even when the
         // sandbox's mount namespace has a different /etc/hosts.
-        //
-        // We test the underlying parser since the production function reads
-        // the real /etc/hosts.
-        let contents = "172.17.0.1\thost.openshell.internal host.containers.internal\n\
-                        127.0.0.1\tlocalhost\n";
-        let addrs = resolve_from_hosts_file_contents(contents, "host.openshell.internal", 9318);
+        let dir = tempfile::tempdir().unwrap();
+        let hosts_path = dir.path().join("hosts");
+        std::fs::write(
+            &hosts_path,
+            "172.17.0.1\thost.openshell.internal host.containers.internal\n\
+             127.0.0.1\tlocalhost\n",
+        )
+        .unwrap();
+
+        let addrs = resolve_from_hosts_file(&hosts_path, "host.openshell.internal", 9318).await;
+        let addrs = addrs.expect("alias should resolve from hosts file");
         assert_eq!(addrs.len(), 1);
         assert_eq!(addrs[0].ip(), IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1)));
         assert_eq!(addrs[0].port(), 9318);
     }
 
-    #[test]
-    fn test_resolve_from_proxy_hosts_returns_none_when_missing() {
-        let contents = "127.0.0.1\tlocalhost\n";
-        let addrs = resolve_from_hosts_file_contents(contents, "host.openshell.internal", 9318);
-        assert!(addrs.is_empty());
+    #[tokio::test]
+    async fn test_resolve_from_hosts_file_returns_none_when_alias_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let hosts_path = dir.path().join("hosts");
+        std::fs::write(&hosts_path, "127.0.0.1\tlocalhost\n").unwrap();
+
+        let addrs = resolve_from_hosts_file(&hosts_path, "host.openshell.internal", 9318).await;
+        assert!(addrs.is_none(), "missing alias should yield None");
     }
 
-    #[test]
-    fn test_host_gateway_alias_triggers_proxy_hosts_fallback() {
-        // Verify that is_host_gateway_alias returns true for all known
-        // aliases, ensuring the resolve_socket_addrs fallback is reachable.
-        assert!(is_host_gateway_alias("host.openshell.internal"));
-        assert!(is_host_gateway_alias("host.containers.internal"));
-        assert!(is_host_gateway_alias("host.docker.internal"));
-        assert!(!is_host_gateway_alias("example.com"));
-        assert!(!is_host_gateway_alias("inference.local"));
+    #[tokio::test]
+    async fn test_resolve_from_hosts_file_returns_none_when_file_unreadable() {
+        // Missing file path: read fails, function returns None (logged at debug)
+        // rather than panicking or surfacing a DNS error.
+        let addrs = resolve_from_hosts_file(
+            Path::new("/nonexistent/openshell-test-hosts-9f3a2c"),
+            "host.openshell.internal",
+            9318,
+        )
+        .await;
+        assert!(addrs.is_none(), "unreadable hosts file should yield None");
     }
 
     #[tokio::test]

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -9897,7 +9897,7 @@ network_policies:
         use std::time::Duration;
 
         // Skip if /bin/bash is not present (e.g. minimal containers).
-        if !std::path::Path::new("/bin/bash").exists() {
+        if !Path::new("/bin/bash").exists() {
             eprintln!("skipping: /bin/bash not available");
             return;
         }
@@ -10033,7 +10033,7 @@ network_policies:
             }
         }
 
-        if !std::path::Path::new("/bin/sleep").exists() {
+        if !Path::new("/bin/sleep").exists() {
             eprintln!("skipping: /bin/sleep not available");
             return;
         }

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -2832,6 +2832,25 @@ async fn resolve_from_sandbox_hosts(
     None
 }
 
+/// Resolve a hostname using the proxy's own `/etc/hosts` file.
+///
+/// Used as a fallback for host-gateway aliases when the sandbox's `/etc/hosts`
+/// (read via `/proc/{pid}/root/etc/hosts`) does not contain the entry — e.g.
+/// because the sandbox runs in a separate mount namespace. The proxy's
+/// `/etc/hosts` is the container-level file populated by the compute driver's
+/// `--add-host` flag.
+#[cfg(any(target_os = "linux", test))]
+fn resolve_from_proxy_hosts(host: &str, port: u16) -> Option<Vec<SocketAddr>> {
+    let contents = std::fs::read_to_string("/etc/hosts").ok()?;
+    let addrs = resolve_from_hosts_file_contents(&contents, host, port);
+    if addrs.is_empty() { None } else { Some(addrs) }
+}
+
+#[cfg(not(any(target_os = "linux", test)))]
+fn resolve_from_proxy_hosts(_host: &str, _port: u16) -> Option<Vec<SocketAddr>> {
+    None
+}
+
 async fn resolve_socket_addrs(
     host: &str,
     port: u16,
@@ -2842,6 +2861,18 @@ async fn resolve_socket_addrs(
     }
 
     if let Some(addrs) = resolve_from_sandbox_hosts(host, port, entrypoint_pid).await {
+        return Ok(addrs);
+    }
+
+    // Host-gateway aliases (host.openshell.internal, etc.) are synthetic
+    // hostnames injected by compute drivers into the container's /etc/hosts.
+    // The sandbox process may run in a separate mount namespace whose
+    // /etc/hosts does not contain the entry. Fall back to the proxy's own
+    // /etc/hosts (the container's) before trying system DNS, which will
+    // also fail for these synthetic names.
+    if is_host_gateway_alias(&host.to_ascii_lowercase())
+        && let Some(addrs) = resolve_from_proxy_hosts(host, port)
+    {
         return Ok(addrs);
     }
 
@@ -7161,6 +7192,43 @@ network_policies:
             err.contains("DNS resolution failed"),
             "expected 'DNS resolution failed' in error: {err}"
         );
+    }
+
+    // -- resolve_from_proxy_hosts --
+
+    #[test]
+    fn test_resolve_from_proxy_hosts_finds_host_gateway_alias() {
+        // The proxy's /etc/hosts is the container-level file populated by
+        // --add-host. resolve_from_proxy_hosts reads it directly, bypassing
+        // the system resolver, so host-gateway aliases resolve even when the
+        // sandbox's mount namespace has a different /etc/hosts.
+        //
+        // We test the underlying parser since the production function reads
+        // the real /etc/hosts.
+        let contents = "172.17.0.1\thost.openshell.internal host.containers.internal\n\
+                        127.0.0.1\tlocalhost\n";
+        let addrs = resolve_from_hosts_file_contents(contents, "host.openshell.internal", 9318);
+        assert_eq!(addrs.len(), 1);
+        assert_eq!(addrs[0].ip(), IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1)));
+        assert_eq!(addrs[0].port(), 9318);
+    }
+
+    #[test]
+    fn test_resolve_from_proxy_hosts_returns_none_when_missing() {
+        let contents = "127.0.0.1\tlocalhost\n";
+        let addrs = resolve_from_hosts_file_contents(contents, "host.openshell.internal", 9318);
+        assert!(addrs.is_empty());
+    }
+
+    #[test]
+    fn test_host_gateway_alias_triggers_proxy_hosts_fallback() {
+        // Verify that is_host_gateway_alias returns true for all known
+        // aliases, ensuring the resolve_socket_addrs fallback is reachable.
+        assert!(is_host_gateway_alias("host.openshell.internal"));
+        assert!(is_host_gateway_alias("host.containers.internal"));
+        assert!(is_host_gateway_alias("host.docker.internal"));
+        assert!(!is_host_gateway_alias("example.com"));
+        assert!(!is_host_gateway_alias("inference.local"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Fix SSRF engine blocking `host.openshell.internal` in 0.0.91 by adding a DNS resolution fallback that reads the proxy's own `/etc/hosts` for host-gateway aliases.
- The sandbox process runs in a separate mount namespace whose `/etc/hosts` does not contain the driver-injected entry, and the system DNS resolver cannot resolve proxy-internal names. The proxy's `/etc/hosts` (populated by the compute driver's `--add-host` flag) is the correct source of truth.

## Related Issue

Fixes #2478

## Changes

**`crates/openshell-supervisor-network/src/proxy.rs`**
- Added `resolve_from_proxy_hosts()` (async) backed by a path-parameterized `resolve_from_hosts_file()` helper — reads the proxy's own `/etc/hosts` via `tokio::fs` (matches the sibling `resolve_from_sandbox_hosts` I/O pattern) using the existing `parse_hosts_file_for_host` parser. Scoped to Linux + test. Read failures log at `debug!` and return `None` (fall through to DNS) rather than failing silently.
- Extended `resolve_socket_addrs()` with a new resolution step between sandbox `/etc/hosts` and system DNS: for host-gateway aliases only, try the proxy's `/etc/hosts` as a fallback.
- Added 3 unit tests against a temp hosts file exercising the real file-reading path: alias resolves, missing alias → `None`, unreadable file → `None`.

**Resolution order is now:**
1. IP literal
2. Sandbox `/etc/hosts` (via `/proc/{pid}/root/etc/hosts`)
3. **Proxy `/etc/hosts` (host-gateway aliases only)** ← new
4. System DNS

**Security properties preserved:**
- SSRF guards unchanged (link-local-only for trusted-gateway exemption)
- Resolved IPs still flow through full SSRF validation (`allowed_ips` or `exact_declared_endpoint_host` path)
- Cloud metadata, loopback, and control-plane ports still always blocked
- Fallback only triggers for 3 hardcoded aliases in `HOST_GATEWAY_ALIASES`

## Testing

- [x] 1011 unit tests pass (`cargo test -p openshell-supervisor-network`)
- [x] Clippy clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Format clean (`cargo fmt --all -- --check`)
- [x] License headers pass
- [x] E2E `sandbox_reaches_host_openshell_internal_via_host_gateway_alias` — **PASS** (podman, macOS arm64, applehv, bridge network gateway_ip=10.89.0.1)
- [x] E2E `sandbox_inference_local_routes_to_host_openshell_internal` — **PASS**
- [x] E2E `inference_set_supports_no_verify_for_unreachable_endpoint` — **PASS**
- [x] Manual verification: sandbox with `allowed_ips` policy reached host server; sandbox without policy correctly denied; non-alias hostname correctly denied

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
