### PR TITLE
fix(server): bind gateway listeners before sandbox resume

### DIFF
--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -443,17 +443,11 @@ pub(crate) async fn run_server(
     // Create the multiplexed service
     let service = MultiplexService::new(state.clone());
 
-    let gateway_listener_addresses =
-        gateway_listener_addresses(config.bind_address, state.compute.gateway_bind_addresses());
-    let mut gateway_listeners = Vec::with_capacity(gateway_listener_addresses.len());
-    for address in gateway_listener_addresses {
-        let listener = TcpListener::bind(address)
-            .await
-            .map_err(|e| Error::transport(format!("failed to bind to {address}: {e}")))?;
-        let local_addr = listener.local_addr().unwrap_or(address);
-        info!(address = %local_addr, "Server listening");
-        gateway_listeners.push((listener, local_addr));
-    }
+    let gateway_listeners = bind_gateway_listeners(
+        config.bind_address,
+        state.compute.gateway_bind_addresses(),
+    )
+    .await?;
 
     // Bind the unauthenticated health endpoint on a separate port when configured.
     if let Some(health_bind_address) = config.health_bind_address {
@@ -567,6 +561,23 @@ fn gateway_listener_addresses(
         }
     }
     addresses
+}
+
+async fn bind_gateway_listeners(
+    bind_address: SocketAddr,
+    extra_addresses: &[SocketAddr],
+) -> Result<Vec<(TcpListener, SocketAddr)>> {
+    let addresses = gateway_listener_addresses(bind_address, extra_addresses);
+    let mut listeners = Vec::with_capacity(addresses.len());
+    for address in addresses {
+        let listener = TcpListener::bind(address)
+            .await
+            .map_err(|e| Error::transport(format!("failed to bind to {address}: {e}")))?;
+        let local_addr = listener.local_addr().unwrap_or(address);
+        info!(address = %local_addr, "Server listening");
+        listeners.push((listener, local_addr));
+    }
+    Ok(listeners)
 }
 
 fn listener_covers(existing: SocketAddr, requested: SocketAddr) -> bool {

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -431,6 +431,9 @@ pub(crate) async fn run_server(
     // snapshot on its first poll.
     ensure_default_workspace(&store).await?;
 
+    let gateway_listeners =
+        bind_gateway_listeners(config.bind_address, state.compute.gateway_bind_addresses()).await?;
+
     if let Err(err) = state.compute.resume_persisted_sandboxes().await {
         warn!(error = %err, "Failed to resume persisted sandboxes during startup");
     }
@@ -442,12 +445,6 @@ pub(crate) async fn run_server(
 
     // Create the multiplexed service
     let service = MultiplexService::new(state.clone());
-
-    let gateway_listeners = bind_gateway_listeners(
-        config.bind_address,
-        state.compute.gateway_bind_addresses(),
-    )
-    .await?;
 
     // Bind the unauthenticated health endpoint on a separate port when configured.
     if let Some(health_bind_address) = config.health_bind_address {
@@ -1031,8 +1028,8 @@ pub(crate) async fn ensure_default_workspace(store: &Store) -> Result<()> {
 mod tests {
     use super::{
         ConfiguredComputeDriver, ConnectionProtocol, MultiplexService, ServerState, TlsAcceptor,
-        allow_plaintext_service_http, classify_initial_bytes, configured_compute_driver,
-        gateway_listener_addresses, is_benign_tls_handshake_failure,
+        allow_plaintext_service_http, bind_gateway_listeners, classify_initial_bytes,
+        configured_compute_driver, gateway_listener_addresses, is_benign_tls_handshake_failure,
         kubernetes_sandbox_jwt_expiry_disabled, serve_gateway_listener,
     };
     use openshell_core::{
@@ -1041,7 +1038,10 @@ mod tests {
     };
     use std::io::{Error, ErrorKind};
     use std::net::SocketAddr;
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
     use std::time::Duration;
     use tempfile::{TempDir, tempdir};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -1522,6 +1522,30 @@ mod tests {
         assert_eq!(
             gateway_listener_addresses(primary, &[docker, docker]),
             vec![primary, docker]
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_gateway_listener_bind_does_not_attempt_persisted_sandbox_resume() {
+        let occupied_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let occupied_address = occupied_listener.local_addr().unwrap();
+        let resume_attempted = AtomicBool::new(false);
+        let primary_address: SocketAddr = "127.0.0.1:0".parse().unwrap();
+
+        let result: openshell_core::Result<()> = async {
+            let _listeners = bind_gateway_listeners(primary_address, &[occupied_address]).await?;
+            resume_attempted.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+        .await;
+
+        assert!(
+            result.is_err(),
+            "binding the occupied extra gateway address should fail"
+        );
+        assert!(
+            !resume_attempted.load(Ordering::SeqCst),
+            "persisted sandbox resume must not run before every gateway listener is bound"
         );
     }
 }


### PR DESCRIPTION
## Summary

Bind all resolved gateway listener sockets before resuming persisted sandboxes. This prevents a startup bind failure from occurring after sandbox compute has already been resumed, while preserving the invariant that resume completes before compute watchers start.

## Related Issue

No linked issue.

## Changes

- Extract gateway listener address resolution and socket binding into a focused helper
- Bind the primary and driver-provided gateway listeners before persisted sandbox resume
- Keep watcher startup after resume so watchers observe post-resume state
- Add a regression test proving a failed extra-listener bind prevents the resume path from being reached

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated (`cargo test -p openshell-server gateway_listener`)
- [ ] E2E tests added/updated (not applicable; startup ordering is covered by the regression unit test)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; no stable documented interface changed)
