### PR TITLE
fix(podman): tolerate shutdown transport closes

### DIFF
--- a/crates/openshell-core/src/lib.rs
+++ b/crates/openshell-core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod secrets;
 pub mod settings;
 pub mod telemetry;
 pub mod time;
+pub mod transport_errors;
 
 pub use config::{
     ComputeDriverKind, Config, GatewayAuthConfig, GatewayInterceptorBindingOverride,

--- a/crates/openshell-core/src/transport_errors.rs
+++ b/crates/openshell-core/src/transport_errors.rs
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared classification for transport closes that are expected during shutdown.
+
+use std::io::ErrorKind;
+
+/// Returns `true` when a gRPC status represents the peer closing transport.
+///
+/// Callers must still decide whether shutdown is already in progress before
+/// downgrading the error. Outside shutdown these statuses remain failures.
+#[must_use]
+pub fn is_expected_transport_close_status(status: &tonic::Status) -> bool {
+    matches!(
+        status.code(),
+        tonic::Code::Cancelled
+            | tonic::Code::Unavailable
+            | tonic::Code::Unknown
+            | tonic::Code::Internal
+    ) && is_expected_transport_close_message(&status.to_string())
+}
+
+/// Returns `true` when an error looks like an expected transport close.
+///
+/// This helper intentionally matches only transport-lifecycle failures such as
+/// HTTP/2 close races, broken pipes, and reset connections.
+#[must_use]
+pub fn is_expected_transport_close_error(error: &(dyn std::error::Error + 'static)) -> bool {
+    if let Some(status) = error.downcast_ref::<tonic::Status>() {
+        return is_expected_transport_close_status(status);
+    }
+    if let Some(io) = error.downcast_ref::<std::io::Error>() {
+        return matches!(
+            io.kind(),
+            ErrorKind::BrokenPipe
+                | ErrorKind::ConnectionAborted
+                | ErrorKind::ConnectionReset
+                | ErrorKind::UnexpectedEof
+        );
+    }
+    is_expected_transport_close_message(&error.to_string())
+}
+
+/// Returns `true` for known text fragments emitted by tonic, hyper, h2, and
+/// OS I/O errors when the peer closes a stream or connection.
+#[must_use]
+pub fn is_expected_transport_close_message(message: &str) -> bool {
+    let msg = message.to_ascii_lowercase();
+    msg.contains("h2 protocol error")
+        || msg.contains("broken pipe")
+        || msg.contains("connection reset")
+        || msg.contains("connection aborted")
+        || msg.contains("connection closed")
+        || msg.contains("connection error")
+        || msg.contains("error reading a body from connection")
+        || msg.contains("peer closed connection")
+        || msg.contains("unexpected eof")
+        || msg.contains("cancelled")
+        || msg.contains("canceled")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_expected_transport_close_statuses() {
+        for status in [
+            tonic::Status::unknown("h2 protocol error: error reading a body from connection"),
+            tonic::Status::unavailable("connection reset by peer"),
+            tonic::Status::cancelled("operation cancelled"),
+            tonic::Status::internal("broken pipe"),
+        ] {
+            assert!(
+                is_expected_transport_close_status(&status),
+                "status should be expected during shutdown: {status}"
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_unexpected_statuses_out_of_shutdown_filter() {
+        for status in [
+            tonic::Status::internal("policy evaluation failed"),
+            tonic::Status::invalid_argument("bad relay frame"),
+            tonic::Status::permission_denied("cross-sandbox relay"),
+        ] {
+            assert!(
+                !is_expected_transport_close_status(&status),
+                "status should stay unexpected: {status}"
+            );
+        }
+    }
+
+    #[test]
+    fn classifies_io_transport_closes() {
+        for kind in [
+            ErrorKind::BrokenPipe,
+            ErrorKind::ConnectionAborted,
+            ErrorKind::ConnectionReset,
+            ErrorKind::UnexpectedEof,
+        ] {
+            let error = std::io::Error::new(kind, "peer closed");
+            assert!(is_expected_transport_close_error(&error));
+        }
+    }
+}

--- a/crates/openshell-driver-podman/README.md
+++ b/crates/openshell-driver-podman/README.md
@@ -339,7 +339,7 @@ Podman resources after out-of-band container removal or label drift.
 | `OPENSHELL_NETWORK_NAME` | `--network-name` | `openshell` | Podman bridge network name. |
 | `OPENSHELL_PODMAN_HOST_GATEWAY_IP` | `--host-gateway-ip` | empty on Linux, `192.168.127.254` on macOS | Host gateway IP used for sandbox host aliases. Empty uses Podman's `host-gateway` resolver. |
 | `OPENSHELL_SANDBOX_SSH_SOCKET_PATH` | `--sandbox-ssh-socket-path` | `/run/openshell/ssh.sock` | Supervisor Unix socket path in `PodmanComputeConfig`. |
-| `OPENSHELL_STOP_TIMEOUT` | `--stop-timeout` | `10` | Container stop timeout in seconds. |
+| `OPENSHELL_STOP_TIMEOUT` | `--stop-timeout` | `45` | Container stop timeout in seconds. |
 | `OPENSHELL_SANDBOX_PIDS_LIMIT` | `--sandbox-pids-limit` | `2048` | Podman cgroup PID limit for sandbox containers. Set `0` to inherit Podman's runtime/default PID limit. |
 | `OPENSHELL_SUPERVISOR_IMAGE` | `--supervisor-image` | `ghcr.io/nvidia/openshell/supervisor:latest` through the gateway, required standalone | OCI image containing the supervisor binary. |
 | `OPENSHELL_PODMAN_TLS_CA` | `--podman-tls-ca` | unset | Host path to the CA certificate mounted for sandbox mTLS. |

--- a/crates/openshell-driver-podman/src/config.rs
+++ b/crates/openshell-driver-podman/src/config.rs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use openshell_core::config::DEFAULT_STOP_TIMEOUT_SECS;
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -9,6 +8,8 @@ use std::str::FromStr;
 /// Default Podman bridge network name.
 pub const DEFAULT_NETWORK_NAME: &str = "openshell";
 pub const MACOS_PODMAN_MACHINE_HOST_GATEWAY_IP: &str = "192.168.127.254";
+/// Default Podman stop timeout in seconds (SIGTERM → SIGKILL).
+pub const DEFAULT_PODMAN_STOP_TIMEOUT_SECS: u32 = 45;
 
 // Re-export the shared default so existing imports inside this crate keep working.
 pub use openshell_core::config::DEFAULT_SANDBOX_PIDS_LIMIT;
@@ -366,7 +367,7 @@ impl Default for PodmanComputeConfig {
             sandbox_ssh_socket_path: "/run/openshell/ssh.sock".to_string(),
             network_name: DEFAULT_NETWORK_NAME.to_string(),
             host_gateway_ip: Self::default_host_gateway_ip(),
-            stop_timeout_secs: DEFAULT_STOP_TIMEOUT_SECS,
+            stop_timeout_secs: DEFAULT_PODMAN_STOP_TIMEOUT_SECS,
             supervisor_image: openshell_core::config::default_supervisor_image(),
             guest_tls_ca: None,
             guest_tls_cert: None,
@@ -426,6 +427,12 @@ mod tests {
             cfg.health_check_interval_secs,
             DEFAULT_HEALTH_CHECK_INTERVAL_SECS
         );
+    }
+
+    #[test]
+    fn default_config_sets_podman_stop_timeout() {
+        let cfg = PodmanComputeConfig::default();
+        assert_eq!(cfg.stop_timeout_secs, DEFAULT_PODMAN_STOP_TIMEOUT_SECS);
     }
 
     #[test]

--- a/crates/openshell-driver-podman/src/main.rs
+++ b/crates/openshell-driver-podman/src/main.rs
@@ -9,10 +9,10 @@ use tracing::info;
 use tracing_subscriber::EnvFilter;
 
 use openshell_core::VERSION;
-use openshell_core::config::DEFAULT_STOP_TIMEOUT_SECS;
 use openshell_core::proto::compute::v1::compute_driver_server::ComputeDriverServer;
 use openshell_driver_podman::config::{
-    DEFAULT_NETWORK_NAME, DEFAULT_SANDBOX_PIDS_LIMIT, ImagePullPolicy,
+    DEFAULT_NETWORK_NAME, DEFAULT_PODMAN_STOP_TIMEOUT_SECS, DEFAULT_SANDBOX_PIDS_LIMIT,
+    ImagePullPolicy,
 };
 use openshell_driver_podman::{ComputeDriverService, PodmanComputeConfig, PodmanComputeDriver};
 
@@ -76,7 +76,7 @@ struct Args {
     network_name: String,
 
     /// Container stop timeout in seconds (SIGTERM → SIGKILL).
-    #[arg(long, env = "OPENSHELL_STOP_TIMEOUT", default_value_t = DEFAULT_STOP_TIMEOUT_SECS)]
+    #[arg(long, env = "OPENSHELL_STOP_TIMEOUT", default_value_t = DEFAULT_PODMAN_STOP_TIMEOUT_SECS)]
     stop_timeout: u32,
 
     /// Container cgroup PID limit for sandbox containers. Set 0 to inherit

--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -17,7 +17,7 @@ mod sidecar_control;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use std::future::Future;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU32;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::Duration;
 use tracing::{debug, info, warn};
 
@@ -95,7 +95,7 @@ pub async fn run_sandbox(
     _health_check: bool,
     _health_port: u16,
     inference_routes: Option<String>,
-    ocsf_enabled: Arc<std::sync::atomic::AtomicBool>,
+    ocsf_enabled: Arc<AtomicBool>,
     network_enabled: bool,
     process_enabled: bool,
     upstream_proxy_args: openshell_supervisor_network::upstream_proxy::UpstreamProxyArgs,
@@ -942,8 +942,9 @@ fn spawn_sidecar_entrypoint_handler(
     tokio::spawn(async move {
         let mut session_started = false;
         let mut trusted_supervisor_pid = None;
+        let terminating = Arc::new(AtomicBool::new(false));
         while let Some(started) = entrypoint_rx.recv().await {
-            entrypoint_pid.store(started.pid, std::sync::atomic::Ordering::Release);
+            entrypoint_pid.store(started.pid, Ordering::Release);
             if started.start_session {
                 info!(
                     pid = started.pid,
@@ -990,11 +991,13 @@ fn spawn_sidecar_entrypoint_handler(
                     trusted_ssh_socket_path.clone(),
                     None,
                     Some(supervisor_pid),
+                    Arc::clone(&terminating),
                 );
                 session_started = true;
                 info!("sidecar supervisor session task spawned");
             }
         }
+        terminating.store(true, Ordering::Release);
     });
 }
 
@@ -2521,7 +2524,7 @@ struct PolicyPollLoopContext {
     loaded_policy_origin: LoadedPolicyOrigin,
     entrypoint_pid: Arc<AtomicU32>,
     interval_secs: u64,
-    ocsf_enabled: Arc<std::sync::atomic::AtomicBool>,
+    ocsf_enabled: Arc<AtomicBool>,
     provider_credentials: ProviderCredentialState,
     policy_local_ctx: Option<Arc<openshell_supervisor_network::policy_local::PolicyLocalContext>>,
     agent_proposals: AgentProposals,
@@ -2970,7 +2973,7 @@ async fn run_policy_poll_loop(ctx: PolicyPollLoopContext) -> Result<()> {
 }
 
 fn apply_ocsf_json_setting(
-    enabled: &std::sync::atomic::AtomicBool,
+    enabled: &AtomicBool,
     settings: &std::collections::HashMap<String, openshell_core::proto::EffectiveSetting>,
 ) {
     use std::sync::atomic::Ordering;

--- a/crates/openshell-server/src/grpc/mod.rs
+++ b/crates/openshell-server/src/grpc/mod.rs
@@ -716,8 +716,7 @@ impl OpenShell for OpenShellService {
         &self,
         request: Request<tonic::Streaming<RelayFrame>>,
     ) -> Result<Response<Self::RelayStreamStream>, Status> {
-        crate::supervisor_session::handle_relay_stream(&self.state.supervisor_sessions, request)
-            .await
+        crate::supervisor_session::handle_relay_stream_for_state(&self.state, request).await
     }
 
     // --- Workspace management ---

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -171,12 +171,7 @@ fn is_benign_tls_handshake_failure(error: &std::io::Error) -> bool {
 }
 
 fn is_benign_connection_close(error: &(dyn std::error::Error + 'static)) -> bool {
-    let msg = error.to_string();
-    msg.contains("connection closed")
-        || msg.contains("connection reset")
-        || msg.contains("connection error")
-        || msg.contains("error reading a body from connection")
-        || msg.contains("broken pipe")
+    openshell_core::transport_errors::is_expected_transport_close_error(error)
 }
 
 impl ServerState {

--- a/crates/openshell-server/src/supervisor_session.rs
+++ b/crates/openshell-server/src/supervisor_session.rs
@@ -9,13 +9,14 @@ use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use openshell_core::proto::{
-    GatewayMessage, RelayFrame, RelayInit, RelayOpen, Sandbox, SessionAccepted, SshRelayTarget,
-    SupervisorMessage, gateway_message, relay_open, supervisor_message,
+    GatewayMessage, RelayFrame, RelayInit, RelayOpen, Sandbox, SandboxPhase, SessionAccepted,
+    SshRelayTarget, SupervisorMessage, gateway_message, relay_open, supervisor_message,
 };
+use openshell_core::transport_errors::is_expected_transport_close_status;
 
 use crate::ServerState;
 use crate::auth::principal::Principal;
@@ -83,6 +84,12 @@ struct PendingRelay {
     sandbox_id: String,
     relay_open: RelayOpen,
     created_at: Instant,
+}
+
+#[derive(Debug)]
+pub struct ClaimedRelay {
+    pub stream: tokio::io::DuplexStream,
+    pub sandbox_id: String,
 }
 
 impl std::fmt::Debug for SupervisorSessionRegistry {
@@ -199,6 +206,14 @@ impl SupervisorSessionRegistry {
 
     pub fn has_session(&self, sandbox_id: &str) -> bool {
         self.sessions.lock().unwrap().contains_key(sandbox_id)
+    }
+
+    pub fn is_current_session(&self, sandbox_id: &str, session_id: &str) -> bool {
+        self.sessions
+            .lock()
+            .unwrap()
+            .get(sandbox_id)
+            .is_some_and(|session| session.session_id == session_id)
     }
 
     fn pending_channel_ids(&self, sandbox_id: &str) -> Vec<String> {
@@ -342,7 +357,7 @@ impl SupervisorSessionRegistry {
         &self,
         channel_id: &str,
         principal: Option<&Principal>,
-    ) -> Result<tokio::io::DuplexStream, Status> {
+    ) -> Result<ClaimedRelay, Status> {
         let pending = {
             let mut map = self.pending_relays.lock().unwrap();
             let pending = map
@@ -381,7 +396,10 @@ impl SupervisorSessionRegistry {
             return Err(Status::internal("relay requester dropped"));
         }
 
-        Ok(supervisor_stream)
+        Ok(ClaimedRelay {
+            stream: supervisor_stream,
+            sandbox_id: pending.sandbox_id,
+        })
     }
 
     /// Remove all pending relays that have exceeded the timeout.
@@ -458,6 +476,10 @@ async fn require_persisted_sandbox(
 /// bytes back to the supervisor over the gRPC response stream.
 const RELAY_STREAM_CHUNK_SIZE: usize = 16 * 1024;
 
+type RelayStreamResponse = Response<
+    Pin<Box<dyn tokio_stream::Stream<Item = Result<RelayFrame, Status>> + Send + 'static>>,
+>;
+
 /// Handle a `RelayStream` RPC from a supervisor.
 ///
 /// The first inbound `RelayFrame` must carry a `RelayInit` identifying the
@@ -467,12 +489,22 @@ const RELAY_STREAM_CHUNK_SIZE: usize = 16 * 1024;
 pub async fn handle_relay_stream(
     registry: &SupervisorSessionRegistry,
     request: Request<tonic::Streaming<RelayFrame>>,
-) -> Result<
-    Response<
-        Pin<Box<dyn tokio_stream::Stream<Item = Result<RelayFrame, Status>> + Send + 'static>>,
-    >,
-    Status,
-> {
+) -> Result<RelayStreamResponse, Status> {
+    handle_relay_stream_inner(registry, None, request).await
+}
+
+pub async fn handle_relay_stream_for_state(
+    state: &Arc<ServerState>,
+    request: Request<tonic::Streaming<RelayFrame>>,
+) -> Result<RelayStreamResponse, Status> {
+    handle_relay_stream_inner(&state.supervisor_sessions, Some(Arc::clone(state)), request).await
+}
+
+async fn handle_relay_stream_inner(
+    registry: &SupervisorSessionRegistry,
+    state: Option<Arc<ServerState>>,
+    request: Request<tonic::Streaming<RelayFrame>>,
+) -> Result<RelayStreamResponse, Status> {
     let principal = request.extensions().get::<Principal>().cloned();
     let mut inbound = request.into_inner();
 
@@ -495,13 +527,17 @@ pub async fn handle_relay_stream(
     };
 
     // Claim the pending relay. Consumes the entry — it cannot be reused.
-    let supervisor_side = registry.claim_relay(&channel_id, principal.as_ref())?;
-    info!(channel_id = %channel_id, "relay stream: claimed pending relay, bridging");
+    let claimed = registry.claim_relay(&channel_id, principal.as_ref())?;
+    let sandbox_id = claimed.sandbox_id;
+    let supervisor_side = claimed.stream;
+    info!(channel_id = %channel_id, sandbox_id = %sandbox_id, "relay stream: claimed pending relay, bridging");
 
     let (mut read_half, mut write_half) = tokio::io::split(supervisor_side);
 
     // Supervisor → gateway: drain `inbound` and write to the DuplexStream.
     let channel_id_in = channel_id.clone();
+    let sandbox_id_in = sandbox_id;
+    let state_in = state.clone();
     tokio::spawn(async move {
         loop {
             match inbound.message().await {
@@ -524,7 +560,23 @@ pub async fn handle_relay_stream(
                 }
                 Ok(None) => break,
                 Err(e) => {
-                    warn!(channel_id = %channel_id_in, error = %e, "relay stream: inbound errored");
+                    if let Some(state) = state_in.as_ref()
+                        && expected_transport_close_during_sandbox_teardown(
+                            state,
+                            &sandbox_id_in,
+                            &e,
+                        )
+                        .await
+                    {
+                        info!(
+                            sandbox_id = %sandbox_id_in,
+                            channel_id = %channel_id_in,
+                            error = %e,
+                            "relay stream: expected transport close during sandbox teardown"
+                        );
+                    } else {
+                        warn!(sandbox_id = %sandbox_id_in, channel_id = %channel_id_in, error = %e, "relay stream: inbound errored");
+                    }
                     break;
                 }
             }
@@ -564,6 +616,59 @@ pub async fn handle_relay_stream(
         Box<dyn tokio_stream::Stream<Item = Result<RelayFrame, Status>> + Send + 'static>,
     > = Box::pin(stream);
     Ok(Response::new(stream))
+}
+
+fn expected_transport_close_during_shutdown(status: &Status, terminating: bool) -> bool {
+    terminating && is_expected_transport_close_status(status)
+}
+
+fn sandbox_proto_is_terminating(sandbox: &Sandbox) -> bool {
+    SandboxPhase::try_from(sandbox.phase()).ok() == Some(SandboxPhase::Deleting)
+        || sandbox
+            .metadata
+            .as_ref()
+            .is_some_and(|metadata| metadata.deletion_timestamp_ms != 0)
+}
+
+async fn sandbox_is_terminating_or_gone(state: &Arc<ServerState>, sandbox_id: &str) -> bool {
+    match state.store.get_message::<Sandbox>(sandbox_id).await {
+        Ok(Some(sandbox)) => sandbox_proto_is_terminating(&sandbox),
+        Ok(None) => true,
+        Err(err) => {
+            debug!(
+                sandbox_id,
+                error = %err,
+                "failed to inspect sandbox state while classifying transport close"
+            );
+            false
+        }
+    }
+}
+
+async fn expected_transport_close_during_sandbox_teardown(
+    state: &Arc<ServerState>,
+    sandbox_id: &str,
+    status: &Status,
+) -> bool {
+    expected_transport_close_during_shutdown(
+        status,
+        sandbox_is_terminating_or_gone(state, sandbox_id).await,
+    )
+}
+
+async fn expected_transport_close_during_session_teardown(
+    state: &Arc<ServerState>,
+    sandbox_id: &str,
+    session_id: &str,
+    status: &Status,
+) -> bool {
+    let session_no_longer_current = !state
+        .supervisor_sessions
+        .is_current_session(sandbox_id, session_id);
+    expected_transport_close_during_shutdown(
+        status,
+        session_no_longer_current || sandbox_is_terminating_or_gone(state, sandbox_id).await,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -739,7 +844,23 @@ async fn run_session_loop(
                         break;
                     }
                     Err(e) => {
-                        warn!(sandbox_id = %sandbox_id, session_id = %session_id, error = %e, "supervisor session: stream error");
+                        if expected_transport_close_during_session_teardown(
+                            state,
+                            sandbox_id,
+                            session_id,
+                            &e,
+                        )
+                        .await
+                        {
+                            info!(
+                                sandbox_id = %sandbox_id,
+                                session_id = %session_id,
+                                error = %e,
+                                "supervisor session: expected transport close during teardown"
+                            );
+                        } else {
+                            warn!(sandbox_id = %sandbox_id, session_id = %session_id, error = %e, "supervisor session: stream error");
+                        }
                         break;
                     }
                 }
@@ -1287,6 +1408,45 @@ mod tests {
             .expect("persisted sandbox should be accepted");
     }
 
+    #[test]
+    fn expected_transport_close_is_nonfatal_only_during_shutdown() {
+        let status = Status::unknown("h2 protocol error: error reading a body from connection");
+
+        assert!(expected_transport_close_during_shutdown(&status, true));
+        assert!(!expected_transport_close_during_shutdown(&status, false));
+    }
+
+    #[test]
+    fn unexpected_transport_error_stays_fatal_during_shutdown() {
+        let status = Status::internal("policy evaluation failed");
+
+        assert!(!expected_transport_close_during_shutdown(&status, true));
+    }
+
+    #[test]
+    fn sandbox_proto_terminating_detects_deleting_phase() {
+        let mut sandbox = sandbox_record("sbx-1", "sandbox-one");
+        sandbox.set_phase(SandboxPhase::Deleting as i32);
+
+        assert!(sandbox_proto_is_terminating(&sandbox));
+    }
+
+    #[test]
+    fn sandbox_proto_terminating_detects_deletion_timestamp() {
+        let mut sandbox = sandbox_record("sbx-1", "sandbox-one");
+        sandbox.metadata.as_mut().unwrap().deletion_timestamp_ms = 1;
+
+        assert!(sandbox_proto_is_terminating(&sandbox));
+    }
+
+    #[test]
+    fn sandbox_proto_running_is_not_terminating() {
+        let mut sandbox = sandbox_record("sbx-1", "sandbox-one");
+        sandbox.set_phase(SandboxPhase::Ready as i32);
+
+        assert!(!sandbox_proto_is_terminating(&sandbox));
+    }
+
     // ---- claim_relay: expiry, drop, wiring ----
 
     #[test]
@@ -1433,7 +1593,8 @@ mod tests {
 
         let mut supervisor_side = registry
             .claim_relay("ch-io", Some(&sandbox_principal("sbx-test")))
-            .expect("claim should succeed");
+            .expect("claim should succeed")
+            .stream;
         let mut gateway_side = relay_rx
             .await
             .expect("gateway side should receive result")

--- a/crates/openshell-supervisor-process/src/run.rs
+++ b/crates/openshell-supervisor-process/src/run.rs
@@ -11,7 +11,7 @@
 
 use miette::{IntoDiagnostic, Result};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::Duration;
 use tokio::time::timeout;
 use tracing::info;
@@ -34,7 +34,7 @@ use openshell_core::denial::DenialEvent;
 
 #[cfg(target_os = "linux")]
 use crate::managed_children;
-use crate::process::{ProcessEnforcementMode, ProcessHandle};
+use crate::process::{ProcessEnforcementMode, ProcessHandle, ProcessStatus};
 
 fn ocsf_ctx() -> &'static openshell_ocsf::SandboxContext {
     openshell_ocsf::ctx::ctx()
@@ -294,6 +294,8 @@ pub async fn run_process(
         }
     }
 
+    let supervisor_terminating = Arc::new(AtomicBool::new(false));
+
     // Spawn the persistent supervisor session if we have a gateway endpoint
     // and sandbox identity. The session provides relay channels for SSH
     // connect and ExecSandbox through the gateway.
@@ -306,6 +308,7 @@ pub async fn run_process(
             socket.clone(),
             ssh_netns_fd,
             None,
+            Arc::clone(&supervisor_terminating),
         );
         info!("supervisor session task spawned");
     }
@@ -353,11 +356,13 @@ pub async fn run_process(
             .build()
     );
 
-    // Wait for process with optional timeout
-    let result = if timeout_secs > 0 {
-        if let Ok(result) = timeout(Duration::from_secs(timeout_secs), handle.wait()).await {
-            result
-        } else {
+    let outcome =
+        wait_for_process_exit_or_shutdown(&mut handle, timeout_secs, &supervisor_terminating)
+            .await?;
+
+    let status = match outcome {
+        ProcessWaitOutcome::Exited(status) => status,
+        ProcessWaitOutcome::TimedOut => {
             ocsf_emit!(
                 ProcessActivityBuilder::new(ocsf_ctx())
                     .activity(ActivityId::Close)
@@ -368,14 +373,18 @@ pub async fn run_process(
                     .message("Process timed out, killing")
                     .build()
             );
-            handle.kill()?;
             return Ok(124); // Standard timeout exit code
         }
-    } else {
-        handle.wait().await
+        ProcessWaitOutcome::ShutdownSignal { signal, status } => {
+            info!(
+                signal,
+                exit_code = status.code(),
+                "Entrypoint exited after supervisor shutdown signal"
+            );
+            status
+        }
     };
-
-    let status = result.into_diagnostic()?;
+    supervisor_terminating.store(true, Ordering::Release);
 
     ocsf_emit!(
         ProcessActivityBuilder::new(ocsf_ctx())
@@ -390,6 +399,117 @@ pub async fn run_process(
     );
 
     Ok(status.code())
+}
+
+enum ProcessWaitOutcome {
+    Exited(ProcessStatus),
+    TimedOut,
+    ShutdownSignal {
+        signal: &'static str,
+        status: ProcessStatus,
+    },
+}
+
+async fn wait_for_process_exit_or_shutdown(
+    handle: &mut ProcessHandle,
+    timeout_secs: u64,
+    terminating: &AtomicBool,
+) -> Result<ProcessWaitOutcome> {
+    let pid = handle.pid();
+    let wait = handle.wait();
+    tokio::pin!(wait);
+
+    if timeout_secs > 0 {
+        let deadline = tokio::time::sleep(Duration::from_secs(timeout_secs));
+        tokio::pin!(deadline);
+        tokio::select! {
+            result = &mut wait => {
+                terminating.store(true, Ordering::Release);
+                Ok(ProcessWaitOutcome::Exited(result.into_diagnostic()?))
+            }
+            () = &mut deadline => {
+                terminating.store(true, Ordering::Release);
+                terminate_then_kill_pid(pid).await;
+                Ok(ProcessWaitOutcome::TimedOut)
+            }
+            signal = wait_for_supervisor_shutdown_signal() => {
+                terminating.store(true, Ordering::Release);
+                signal_entrypoint_for_shutdown(pid, signal);
+                let status = (&mut wait).await.into_diagnostic()?;
+                Ok(ProcessWaitOutcome::ShutdownSignal { signal, status })
+            }
+        }
+    } else {
+        tokio::select! {
+            result = &mut wait => {
+                terminating.store(true, Ordering::Release);
+                Ok(ProcessWaitOutcome::Exited(result.into_diagnostic()?))
+            }
+            signal = wait_for_supervisor_shutdown_signal() => {
+                terminating.store(true, Ordering::Release);
+                signal_entrypoint_for_shutdown(pid, signal);
+                let status = (&mut wait).await.into_diagnostic()?;
+                Ok(ProcessWaitOutcome::ShutdownSignal { signal, status })
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn terminate_then_kill_pid(pid: u32) {
+    signal_pid(pid, nix::sys::signal::Signal::SIGTERM, "process timeout");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    signal_pid(pid, nix::sys::signal::Signal::SIGKILL, "process timeout");
+}
+
+#[cfg(not(unix))]
+async fn terminate_then_kill_pid(_pid: u32) {}
+
+#[cfg(unix)]
+fn signal_entrypoint_for_shutdown(pid: u32, signal: &'static str) {
+    signal_pid(pid, nix::sys::signal::Signal::SIGTERM, signal);
+}
+
+#[cfg(not(unix))]
+fn signal_entrypoint_for_shutdown(_pid: u32, _signal: &'static str) {}
+
+#[cfg(unix)]
+fn signal_pid(pid: u32, signal: nix::sys::signal::Signal, reason: &'static str) {
+    let raw_pid = i32::try_from(pid).unwrap_or(i32::MAX);
+    if let Err(error) = nix::sys::signal::kill(nix::unistd::Pid::from_raw(raw_pid), signal) {
+        tracing::warn!(
+            pid,
+            signal = ?signal,
+            reason,
+            error = %error,
+            "failed to signal entrypoint process"
+        );
+    }
+}
+
+#[cfg(unix)]
+async fn wait_for_supervisor_shutdown_signal() -> &'static str {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut sigterm = match signal(SignalKind::terminate()) {
+        Ok(signal) => signal,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "Failed to install SIGTERM handler; supervisor shutdown detection disabled"
+            );
+            return std::future::pending::<&'static str>().await;
+        }
+    };
+
+    let _ = sigterm.recv().await;
+    info!("Received SIGTERM, shutting down supervisor process");
+    "SIGTERM"
+}
+
+#[cfg(not(unix))]
+async fn wait_for_supervisor_shutdown_signal() -> &'static str {
+    std::future::pending::<&'static str>().await
 }
 
 fn ssh_proxy_url_for_policy(

--- a/crates/openshell-supervisor-process/src/supervisor_session.rs
+++ b/crates/openshell-supervisor-process/src/supervisor_session.rs
@@ -13,6 +13,8 @@
 use std::net::IpAddr;
 #[cfg(target_os = "linux")]
 use std::os::fd::RawFd;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use openshell_core::proto::open_shell_client::OpenShellClient;
@@ -31,6 +33,7 @@ use tokio_stream::StreamExt;
 use tracing::{debug, warn};
 
 use openshell_core::grpc_client;
+use openshell_core::transport_errors::is_expected_transport_close_status;
 
 const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_BACKOFF: Duration = Duration::from_secs(30);
@@ -226,6 +229,46 @@ fn map_stream_message<T>(
     }
 }
 
+#[derive(Debug)]
+enum SessionStreamMessage<T> {
+    Message(T),
+    ExpectedShutdownClose,
+}
+
+fn supervisor_is_terminating(terminating: &AtomicBool) -> bool {
+    terminating.load(Ordering::Acquire)
+}
+
+fn expected_transport_close_during_shutdown(
+    status: &tonic::Status,
+    terminating: &AtomicBool,
+) -> bool {
+    supervisor_is_terminating(terminating) && is_expected_transport_close_status(status)
+}
+
+fn map_session_stream_message<T>(
+    message: Result<Option<T>, tonic::Status>,
+    eof_error: &'static str,
+    terminating: &AtomicBool,
+) -> Result<SessionStreamMessage<T>, Box<dyn std::error::Error + Send + Sync>> {
+    match message {
+        Ok(Some(msg)) => Ok(SessionStreamMessage::Message(msg)),
+        Ok(None) if supervisor_is_terminating(terminating) => {
+            debug!("supervisor session: stream closed during local shutdown");
+            Ok(SessionStreamMessage::ExpectedShutdownClose)
+        }
+        Ok(None) => Err(eof_error.into()),
+        Err(e) if expected_transport_close_during_shutdown(&e, terminating) => {
+            debug!(
+                error = %e,
+                "supervisor session: expected transport close during local shutdown"
+            );
+            Ok(SessionStreamMessage::ExpectedShutdownClose)
+        }
+        Err(e) => Err(format!("stream error: {e}").into()),
+    }
+}
+
 /// Spawn the supervisor session task.
 ///
 /// The task runs for the lifetime of the sandbox process, reconnecting with
@@ -236,6 +279,7 @@ pub fn spawn(
     ssh_socket_path: std::path::PathBuf,
     netns_fd: Option<i32>,
     expected_ssh_peer_pid: Option<u32>,
+    terminating: Arc<AtomicBool>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(run_session_loop(
         endpoint,
@@ -243,6 +287,7 @@ pub fn spawn(
         ssh_socket_path,
         netns_fd,
         expected_ssh_peer_pid,
+        terminating,
     ))
 }
 
@@ -252,6 +297,7 @@ async fn run_session_loop(
     ssh_socket_path: std::path::PathBuf,
     netns_fd: Option<i32>,
     expected_ssh_peer_pid: Option<u32>,
+    terminating: Arc<AtomicBool>,
 ) {
     let mut backoff = INITIAL_BACKOFF;
     let mut attempt: u64 = 0;
@@ -265,6 +311,7 @@ async fn run_session_loop(
             &ssh_socket_path,
             netns_fd,
             expected_ssh_peer_pid,
+            Arc::clone(&terminating),
         )
         .await
         {
@@ -295,6 +342,7 @@ async fn run_single_session(
     ssh_socket_path: &std::path::Path,
     netns_fd: Option<i32>,
     expected_ssh_peer_pid: Option<u32>,
+    terminating: Arc<AtomicBool>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Connect to the gateway. The same `Channel` is used for both the
     // long-lived control stream and all data-plane `RelayStream` calls, so
@@ -358,15 +406,26 @@ async fn run_single_session(
     loop {
         tokio::select! {
             msg = inbound.message() => {
-                let msg = map_stream_message(msg, "gateway closed stream")?;
-                handle_gateway_message(
-                    &msg,
+                let msg = match map_session_stream_message(
+                    msg,
+                    "gateway closed stream",
+                    &terminating,
+                )? {
+                    SessionStreamMessage::Message(msg) => msg,
+                    SessionStreamMessage::ExpectedShutdownClose => return Ok(()),
+                };
+                let context = GatewayMessageContext {
                     sandbox_id,
                     ssh_socket_path,
                     netns_fd,
                     expected_ssh_peer_pid,
-                    &channel,
-                    &tx,
+                    channel: &channel,
+                    tx: &tx,
+                    terminating: &terminating,
+                };
+                handle_gateway_message(
+                    &msg,
+                    &context,
                 );
             }
             _ = heartbeat_interval.tick() => {
@@ -383,15 +442,17 @@ async fn run_single_session(
     }
 }
 
-fn handle_gateway_message(
-    msg: &GatewayMessage,
-    sandbox_id: &str,
-    ssh_socket_path: &std::path::Path,
+struct GatewayMessageContext<'a> {
+    sandbox_id: &'a str,
+    ssh_socket_path: &'a std::path::Path,
     netns_fd: Option<i32>,
     expected_ssh_peer_pid: Option<u32>,
-    channel: &grpc_client::AuthedChannel,
-    tx: &mpsc::Sender<SupervisorMessage>,
-) {
+    channel: &'a grpc_client::AuthedChannel,
+    tx: &'a mpsc::Sender<SupervisorMessage>,
+    terminating: &'a Arc<AtomicBool>,
+}
+
+fn handle_gateway_message(msg: &GatewayMessage, context: &GatewayMessageContext<'_>) {
     match &msg.payload {
         Some(gateway_message::Payload::Heartbeat(_)) => {
             // Gateway heartbeat — nothing to do.
@@ -399,10 +460,13 @@ fn handle_gateway_message(
         Some(gateway_message::Payload::RelayOpen(open)) => {
             let channel_id = open.channel_id.clone();
             let relay_open = open.clone();
-            let sandbox_id = sandbox_id.to_string();
-            let channel = channel.clone();
-            let ssh_socket_path = ssh_socket_path.to_path_buf();
-            let tx = tx.clone();
+            let sandbox_id = context.sandbox_id.to_string();
+            let channel = context.channel.clone();
+            let ssh_socket_path = context.ssh_socket_path.to_path_buf();
+            let tx = context.tx.clone();
+            let netns_fd = context.netns_fd;
+            let expected_ssh_peer_pid = context.expected_ssh_peer_pid;
+            let terminating = Arc::clone(context.terminating);
 
             let event = relay_open_event(openshell_ocsf::ctx::ctx(), &relay_open, &ssh_socket_path);
             ocsf_emit!(event);
@@ -416,6 +480,7 @@ fn handle_gateway_message(
                     expected_ssh_peer_pid,
                     channel,
                     tx,
+                    terminating,
                 )
                 .await
                 {
@@ -454,7 +519,7 @@ fn handle_gateway_message(
             ocsf_emit!(event);
         }
         _ => {
-            warn!(sandbox_id = %sandbox_id, "supervisor session: unexpected gateway message");
+            warn!(sandbox_id = %context.sandbox_id, "supervisor session: unexpected gateway message");
         }
     }
 }
@@ -472,6 +537,7 @@ async fn handle_relay_open(
     expected_ssh_peer_pid: Option<u32>,
     channel: grpc_client::AuthedChannel,
     tx: mpsc::Sender<SupervisorMessage>,
+    terminating: Arc<AtomicBool>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let channel_id = relay_open.channel_id.clone();
     let target = match open_target(
@@ -510,10 +576,18 @@ async fn handle_relay_open(
         .map_err(|_| "outbound channel closed before init")?;
 
     // Initiate the RPC. This rides the existing HTTP/2 connection.
-    let response = client
-        .relay_stream(outbound)
-        .await
-        .map_err(|e| format!("relay_stream RPC failed: {e}"))?;
+    let response = match client.relay_stream(outbound).await {
+        Ok(response) => response,
+        Err(e) if expected_transport_close_during_shutdown(&e, &terminating) => {
+            debug!(
+                channel_id = %channel_id,
+                error = %e,
+                "relay bridge: relay_stream RPC closed during local shutdown"
+            );
+            return Ok(());
+        }
+        Err(e) => return Err(format!("relay_stream RPC failed: {e}").into()),
+    };
     let mut inbound = response.into_inner();
 
     // Connect to the local SSH daemon on its Unix socket.
@@ -564,7 +638,15 @@ async fn handle_relay_open(
                 }
             }
             Err(e) => {
-                inbound_err = Some(format!("relay inbound errored: {e}"));
+                if expected_transport_close_during_shutdown(&e, &terminating) {
+                    debug!(
+                        channel_id = %channel_id,
+                        error = %e,
+                        "relay bridge: inbound closed during local shutdown"
+                    );
+                } else {
+                    inbound_err = Some(format!("relay inbound errored: {e}"));
+                }
                 break;
             }
         }
@@ -937,6 +1019,52 @@ mod ocsf_event_tests {
         let err = map_stream_message::<SupervisorMessage>(Ok(None), "gateway closed stream")
             .expect_err("eof should force reconnect");
         assert_eq!(err.to_string(), "gateway closed stream");
+    }
+
+    #[test]
+    fn map_session_stream_message_allows_expected_close_during_shutdown() {
+        let terminating = AtomicBool::new(true);
+        let message = map_session_stream_message::<GatewayMessage>(
+            Err(tonic::Status::unknown(
+                "h2 protocol error: error reading a body from connection",
+            )),
+            "gateway closed stream",
+            &terminating,
+        )
+        .expect("expected transport close should be non-fatal during shutdown");
+
+        assert!(matches!(
+            message,
+            SessionStreamMessage::ExpectedShutdownClose
+        ));
+    }
+
+    #[test]
+    fn map_session_stream_message_keeps_transport_close_fatal_when_not_shutting_down() {
+        let terminating = AtomicBool::new(false);
+        let err = map_session_stream_message::<GatewayMessage>(
+            Err(tonic::Status::unknown(
+                "h2 protocol error: error reading a body from connection",
+            )),
+            "gateway closed stream",
+            &terminating,
+        )
+        .expect_err("same transport close should fail before shutdown starts");
+
+        assert!(err.to_string().contains("h2 protocol error"));
+    }
+
+    #[test]
+    fn map_session_stream_message_keeps_unexpected_error_fatal_during_shutdown() {
+        let terminating = AtomicBool::new(true);
+        let err = map_session_stream_message::<GatewayMessage>(
+            Err(tonic::Status::internal("policy evaluation failed")),
+            "gateway closed stream",
+            &terminating,
+        )
+        .expect_err("non-transport errors must stay fatal");
+
+        assert!(err.to_string().contains("policy evaluation failed"));
     }
 
     #[cfg(target_os = "linux")]

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -375,7 +375,7 @@ network_name            = "openshell"
 # Set "" to force Podman's host-gateway resolver.
 # host_gateway_ip       = "192.168.127.254"
 sandbox_ssh_socket_path = "/run/openshell/ssh.sock"
-stop_timeout_secs       = 10
+stop_timeout_secs       = 45
 # Defaults to the gateway version; override to pin a specific build.
 # supervisor_image      = "ghcr.io/nvidia/openshell/supervisor:<version>"
 guest_tls_ca            = "/etc/openshell/certs/ca.pem"

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -182,6 +182,8 @@ For maintainer-level implementation details, refer to the [Podman driver README]
 
 Select Podman with `compute_drivers = ["podman"]` in `[openshell.gateway]`. Configure Podman driver values such as `socket_path`, `network_name`, `supervisor_image`, `stop_timeout_secs`, `image_pull_policy`, `grpc_endpoint`, `host_gateway_ip`, `sandbox_ssh_socket_path`, `sandbox_pids_limit`, and `guest_tls_*` in `[openshell.drivers.podman]`.
 
+Podman sandboxes default to a 45-second graceful stop window before Podman escalates from `SIGTERM` to `SIGKILL`. Set `stop_timeout_secs` in gateway config, or `OPENSHELL_STOP_TIMEOUT` for the standalone driver, when a local runtime needs a different teardown window.
+
 For proxy-required networks, the Podman driver also accepts the corporate egress proxy keys `https_proxy`, `no_proxy`, `proxy_auth_file`, `proxy_auth_allow_insecure`, and `proxy_connect_by_hostname`. The supervisor chains policy-approved TLS tunnels through the proxy with HTTP CONNECT instead of dialing destinations directly. See the [Gateway Configuration File](./gateway-config) reference for the full contract, including the cleartext-credential acknowledgement and the validated-IP CONNECT behavior.
 
 On macOS with `podman machine`, the driver uses gvproxy's host-loopback IP, `192.168.127.254`, for sandbox host aliases by default. Set `host_gateway_ip` only when your Podman machine uses a non-standard host-loopback address. On Linux, an empty `host_gateway_ip` keeps Podman's `host-gateway` resolver behavior.


### PR DESCRIPTION
## Summary
- increase the Podman driver graceful stop default from 10s to 45s while keeping the existing OPENSHELL_STOP_TIMEOUT override
- classify h2 protocol errors, broken pipes, cancelled streams, reset connections, and EOF as expected only once sandbox/session shutdown is already underway
- keep unexpected transport failures on the existing warning/failure path and update Podman docs for the new default

Related failing job: https://github.com/NVIDIA/OpenShell/actions/runs/30108191582/job/89533801934

## Changes
- add shared transport-close classification in openshell-core
- make gateway supervisor/relay teardown logging shutdown-aware using sandbox deletion/session state
- make the in-sandbox supervisor session stop reconnecting/failing on expected local shutdown transport closes
- update Podman stop timeout docs and config defaults

## Testing
- cargo fmt --all
- git diff --check
- cargo test -p openshell-core transport_errors
- cargo test -p openshell-server --lib supervisor_session::tests
- cargo test -p openshell-supervisor-process --lib supervisor_session

Skipped pre-commit per handoff request.

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] DCO sign-off included
- [ ] Full pre-commit/CI run