### PR TITLE
fix(tasks): scope pre-commit to lint checks

### DIFF
--- a/.agents/skills/build-from-issue/SKILL.md
+++ b/.agents/skills/build-from-issue/SKILL.md
@@ -377,7 +377,7 @@ Verification has two phases: unit tests + pre-commit, then E2E tests (if applica
 On each attempt:
 
 ```bash
-# Run pre-commit checks (includes unit tests, linting, formatting)
+# Run pre-commit checks (linting, formatting, license headers)
 mise run pre-commit
 ```
 
@@ -640,7 +640,7 @@ If the `state:in-progress` label is present, the skill was previously started bu
 | `gh pr list --state open --search "..."` | Search for open PRs |
 | `gh pr create --title "..." --body "..."` | Create a pull request |
 | `gh api user --jq '.login'` | Get current GitHub username |
-| `mise run pre-commit` | Run pre-commit checks (includes unit tests, lint, format) |
+| `mise run pre-commit` | Run pre-commit checks (lint, format, license headers) |
 | `mise run e2e:docker` | Run smoke E2E against a standalone Docker-backed gateway |
 | `mise run e2e:podman` | Run smoke E2E against a Podman-backed gateway |
 | `mise run e2e:vm` | Run smoke E2E against the VM compute driver |

--- a/tasks/ci.toml
+++ b/tasks/ci.toml
@@ -64,6 +64,6 @@ depends = ["ci"]
 hide = true
 
 ["pre-commit"]
-description = "Alias for ci"
-depends = ["ci"]
+description = "Run lint, formatting, and license checks"
+depends = ["lint"]
 hide = true


### PR DESCRIPTION
## Summary

Align `mise run pre-commit` with the documented contributor workflow by limiting it to lint, formatting, and license checks. Full unit tests and compile/type checks remain available through `mise run test` and `mise run ci`.

## Related Issue

N/A — maintenance fix.

## Changes

- Change the `pre-commit` task dependency from `ci` to `lint`
- Update `build-from-issue` workflow guidance to describe the corrected pre-commit scope

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)