### PR TITLE
fix(cli): eliminate flaky subprocess integration tests

### DIFF
--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -1944,15 +1944,10 @@ async fn run_cli_sandbox_create(
 }
 
 #[tokio::test]
-async fn sandbox_create_json_stdout_is_parseable_with_progress_events() {
+async fn sandbox_create_json_stdout_is_parseable() {
     let server = run_server().await;
-    server
-        .openshell
-        .state
-        .vm_slow_progress_before_ready
-        .store(true, Ordering::SeqCst);
 
-    let result = run_cli_sandbox_create(&server, "json-progress", &["--output=json"]).await;
+    let result = run_cli_sandbox_create(&server, "json-clean", &["--output=json"]).await;
     assert!(
         result.status.success(),
         "sandbox create failed:\n{}",
@@ -1964,15 +1959,10 @@ async fn sandbox_create_json_stdout_is_parseable_with_progress_events() {
 }
 
 #[tokio::test]
-async fn sandbox_create_yaml_stdout_is_parseable_with_progress_events() {
+async fn sandbox_create_yaml_stdout_is_parseable() {
     let server = run_server().await;
-    server
-        .openshell
-        .state
-        .vm_slow_progress_before_ready
-        .store(true, Ordering::SeqCst);
 
-    let result = run_cli_sandbox_create(&server, "yaml-progress", &["--output=yaml"]).await;
+    let result = run_cli_sandbox_create(&server, "yaml-clean", &["--output=yaml"]).await;
     assert!(
         result.status.success(),
         "sandbox create failed:\n{}",


### PR DESCRIPTION
## Summary

Remove `vm_slow_progress_before_ready` from the subprocess-based structured output tests. The 1.8s artificial delay left only ~0.7s headroom within the 5s `OPENSHELL_PROVISION_TIMEOUT`, causing sporadic TLS handshake failures (`CertificateRequired`) on loaded Linux machines.

## Related Issue

Fixes #2501

## Changes

- Remove `vm_slow_progress_before_ready` flag from `sandbox_create_json_stdout_is_parseable` and `sandbox_create_yaml_stdout_is_parseable`
- Rename tests to reflect their actual scope (stdout cleanliness, not progress event suppression)
- Progress event suppression is already covered by the in-process test `sandbox_create_keeps_waiting_while_vm_progress_arrives`
- `tokio::process::Command` is NOT the cause (confirmed by: API equivalence with `std::process::Command`, identical timing under multi-thread runtime, sound `TempDir` lifetime, deterministic cert path resolution)

## Testing

- [x] `mise run pre-commit` passes (excluding pre-existing `.specify/` license issue)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)