### PR TITLE
feat(proxy): bind static credentials to provider endpoints

### DIFF
--- a/.agents/skills/debug-inference/SKILL.md
+++ b/.agents/skills/debug-inference/SKILL.md
@@ -239,6 +239,15 @@ Check instead:
 3. The sandbox has that provider attached (`openshell sandbox provider list [name]`)
 4. `network_policies` allow that host, port, and HTTP rules
 
+If the response reports `credential_endpoint_mismatch`, the provider is attached
+but its credential profile does not authorize that request recipient. Inspect
+`openshell provider get <provider-name>` and compare the profile's endpoint host,
+port, and path with the direct request. Correct the provider selection or profile
+endpoint when that recipient is intentional. Do not widen the sandbox network
+policy to work around the mismatch: policy admission and credential endpoint
+authorization are separate checks, and the provider profile should authorize
+only intended credential recipients.
+
 Attach or detach a provider on an existing sandbox with `openshell sandbox provider attach <sandbox> <provider>` and `openshell sandbox provider detach <sandbox> <provider>`.
 
 Use the `generate-sandbox-policy` skill when the user needs help authoring policy YAML.
@@ -348,6 +357,7 @@ Both commands should return the upstream model list.
 | `no compatible route` | Provider type does not match request shape | Create or select a provider of the matching type, or change the client API |
 | `inference.local` works but a platform function fails | User route is configured but `sandbox-system` is missing or wrong | `openshell inference get --system`; configure or update with `--system`; inspect supervisor logs |
 | Direct call to external host is denied | Missing policy or provider attachment | Update `network_policies` and launch sandbox with the right provider |
+| Direct call returns `credential_endpoint_mismatch` | Attached provider profile does not authorize the request host, port, or path | Inspect the provider profile endpoints; select or update the profile only if it intentionally authorizes that recipient |
 | SDK fails on empty auth token | Client requires a non-empty API key even though OpenShell injects the real one | Use any placeholder token such as `test` |
 | Upstream timeout from container to host-local backend | Host firewall or network config blocks container-to-host traffic | Allow the Docker bridge subnet to reach the inference port on the host gateway IP (see firewall fix section above) |
 

--- a/.agents/skills/debug-inference/SKILL.md
+++ b/.agents/skills/debug-inference/SKILL.md
@@ -252,6 +252,13 @@ the mismatch: policy admission and credential endpoint authorization are
 separate checks, and the provider profile should authorize only intended
 credential recipients.
 
+If the response reports `request_authority_mismatch`, compare the HTTP request
+authority with the CONNECT tunnel endpoint. The host and effective port must
+match. For a tunnel to `api.example.com:8443`, send
+`Host: api.example.com:8443`; omitting the non-default port makes the request
+authority use the transport default and OpenShell rejects it. An absolute-form
+request target must use the same authority.
+
 Attach or detach a provider on an existing sandbox with `openshell sandbox provider attach <sandbox> <provider>` and `openshell sandbox provider detach <sandbox> <provider>`.
 
 Use the `generate-sandbox-policy` skill when the user needs help authoring policy YAML.
@@ -362,6 +369,7 @@ Both commands should return the upstream model list.
 | `inference.local` works but a platform function fails | User route is configured but `sandbox-system` is missing or wrong | `openshell inference get --system`; configure or update with `--system`; inspect supervisor logs |
 | Direct call to external host is denied | Missing policy or provider attachment | Update `network_policies` and launch sandbox with the right provider |
 | Direct call returns `credential_endpoint_mismatch` | Attached provider profile does not authorize the request host, port, or path | Inspect the provider profile endpoints; select or update the profile only if it intentionally authorizes that recipient |
+| Direct call returns `request_authority_mismatch` | HTTP authority does not match the CONNECT host and effective port | Include the explicit non-default port in `Host` and use the same authority in absolute-form targets |
 | SDK fails on empty auth token | Client requires a non-empty API key even though OpenShell injects the real one | Use any placeholder token such as `test` |
 | Upstream timeout from container to host-local backend | Host firewall or network config blocks container-to-host traffic | Allow the Docker bridge subnet to reach the inference port on the host gateway IP (see firewall fix section above) |
 

--- a/.agents/skills/debug-inference/SKILL.md
+++ b/.agents/skills/debug-inference/SKILL.md
@@ -240,13 +240,17 @@ Check instead:
 4. `network_policies` allow that host, port, and HTTP rules
 
 If the response reports `credential_endpoint_mismatch`, the provider is attached
-but its credential profile does not authorize that request recipient. Inspect
-`openshell provider get <provider-name>` and compare the profile's endpoint host,
-port, and path with the direct request. Correct the provider selection or profile
-endpoint when that recipient is intentional. Do not widen the sandbox network
-policy to work around the mismatch: policy admission and credential endpoint
-authorization are separate checks, and the provider profile should authorize
-only intended credential recipients.
+but its credential profile does not authorize that request recipient. Run
+`openshell provider get <provider-name>` to identify the provider type, then
+inspect its profile endpoints with
+`openshell provider profile export <type> -o yaml`. That export uses the current
+workspace scope; add `--global` when the provider was created with
+`--global-profile`. Compare the profile's endpoint host, port, and path with the
+direct request. Correct the provider selection or profile endpoint when that
+recipient is intentional. Do not widen the sandbox network policy to work around
+the mismatch: policy admission and credential endpoint authorization are
+separate checks, and the provider profile should authorize only intended
+credential recipients.
 
 Attach or detach a provider on an existing sandbox with `openshell sandbox provider attach <sandbox> <provider>` and `openshell sandbox provider detach <sandbox> <provider>`.
 

--- a/.agents/skills/generate-sandbox-policy/SKILL.md
+++ b/.agents/skills/generate-sandbox-policy/SKILL.md
@@ -449,6 +449,10 @@ The policy needs to go somewhere. Determine which mode applies:
    - If the sandbox uses an attached provider credential, confirm the provider
      profile also declares the intended host, port, and path. A sandbox policy
      allow cannot expand the profile's static credential binding.
+   - For `credential_signing`, confirm an attached endpoint-bearing profile
+     declares `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and covers the
+     signed endpoint. For an endpointless AWS profile, add
+     `credential_binding.provider` with the exact attached provider name.
 
 3. **Apply the change**:
    - **Adding a new policy**: Insert the new policy block under `network_policies`, maintaining the file's existing indentation and style.

--- a/.agents/skills/generate-sandbox-policy/SKILL.md
+++ b/.agents/skills/generate-sandbox-policy/SKILL.md
@@ -384,6 +384,9 @@ Before presenting the policy to the user, verify correctness **and** flag breadt
 
 - [ ] `protocol: rest` on port 443 should have `tls: terminate`
 - [ ] HTTP methods are standard: GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS, or `*`
+- [ ] Credentialed destinations are also covered by the attached provider
+      profile endpoint; policy admission alone does not authorize credential
+      resolution
 
 ### Structural Checks
 
@@ -443,6 +446,9 @@ The policy needs to go somewhere. Determine which mode applies:
 2. **Check for conflicts**:
    - Does a policy with the same key already exist? If so, ask the user whether to **replace** it, **merge** new endpoints/binaries into it, or use a different key.
    - Does an existing endpoint selector overlap the new selector? Compatible overlaps are allowed and can intentionally aggregate allow and deny rules. Reject or revise equally specific overlaps that disagree on connection or request-processing metadata, including TLS, destination constraints, protocol/parser behavior, enforcement, or credential handling. A more-specific path selector may override broader request-processing metadata.
+   - If the sandbox uses an attached provider credential, confirm the provider
+     profile also declares the intended host, port, and path. A sandbox policy
+     allow cannot expand the profile's static credential binding.
 
 3. **Apply the change**:
    - **Adding a new policy**: Insert the new policy block under `network_policies`, maintaining the file's existing indentation and style.

--- a/.agents/skills/openshell-cli/SKILL.md
+++ b/.agents/skills/openshell-cli/SKILL.md
@@ -128,6 +128,13 @@ when a placeholder is present but requests receive
 `credential_endpoint_mismatch`. A profileless static provider fails closed
 because the gateway cannot construct a binding.
 
+When an inspected request receives `request_authority_mismatch`, compare its
+HTTP authority with the CONNECT tunnel endpoint. The host and effective port
+must match. For a tunnel to `api.example.com:8443`, send
+`Host: api.example.com:8443`; `Host: api.example.com` omits the non-default
+port and is rejected. An absolute-form request target must use the same
+authority.
+
 Profile-backed provider policy composition is controlled by the gateway-global
 `providers_v2_enabled` setting. Static credential endpoint binding remains
 active even when policy composition is disabled:

--- a/.agents/skills/openshell-cli/SKILL.md
+++ b/.agents/skills/openshell-cli/SKILL.md
@@ -122,7 +122,15 @@ Bare `KEY` reads the value from the environment variable of that name and avoids
 
 Other credential sources are `--from-gcloud-adc` for compatible profiles and `--runtime-credentials` when the gateway or sandbox resolves the required credentials at runtime.
 
-Profile-backed provider policy and composition are controlled by the gateway-global `providers_v2_enabled` setting:
+Static provider credentials resolve only for hosts, ports, and paths declared by
+the provider profile. Use `provider profile export` to inspect that boundary
+when a placeholder is present but requests receive
+`credential_endpoint_mismatch`. A profileless static provider fails closed
+because the gateway cannot construct a binding.
+
+Profile-backed provider policy composition is controlled by the gateway-global
+`providers_v2_enabled` setting. Static credential endpoint binding remains
+active even when policy composition is disabled:
 
 ```bash
 openshell settings get --global

--- a/.agents/skills/openshell-cli/SKILL.md
+++ b/.agents/skills/openshell-cli/SKILL.md
@@ -382,7 +382,10 @@ provider-profile policy—before it stores a direct update, incremental merge,
 approved proposal, provider attachment, or profile update that affects attached
 sandboxes. An ambiguity failure returns `FAILED_PRECONDITION`; the rejected
 candidate does not create a policy revision or partially update affected
-sandboxes. Fix the conflicting endpoint selectors and submit again.
+sandboxes. The same fail-closed response applies when `credential_signing`
+does not have an attached AWS profile whose credential boundary covers the
+endpoint, or an explicit binding to an endpointless AWS profile. Fix the
+conflicting endpoint selectors or credential source and submit again.
 
 The `--wait` flag blocks until the sandbox confirms the policy is loaded (polls every second). Exit codes:
 - **0**: Policy loaded successfully

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -439,9 +439,11 @@ gateway classifies each returned environment entry as either a credential or
 non-secret provider configuration and associates every credential key with the
 host, port, and path selectors from its effective provider profile. It withholds
 static credential material from supervisors that do not advertise binding
-support and rejects profile-backed delivery when a static credential has no
-usable endpoint. Provider environment revisions include profile endpoint and
-binding changes.
+support. If a static credential has no usable endpoint, the gateway returns its
+incomplete binding metadata with the valid dynamic credential snapshot. The
+supervisor then revokes all static material while keeping the dynamic snapshot
+active. Provider environment revisions include profile endpoint and binding
+changes.
 
 ## Inference Resolution
 

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -439,11 +439,12 @@ gateway classifies each returned environment entry as either a credential or
 non-secret provider configuration and associates every credential key with the
 host, port, and path selectors from its effective provider profile. It withholds
 static credential material from supervisors that do not advertise binding
-support. If a static credential has no usable endpoint, the gateway returns its
-incomplete binding metadata with the valid dynamic credential snapshot. The
-supervisor then revokes all static material while keeping the dynamic snapshot
-active. Provider environment revisions include profile endpoint and binding
-changes.
+support. If a selected provider profile has no usable endpoint, the gateway
+withholds only that profile's static credential keys and their expiry and
+binding metadata. It continues to return provider-generated non-secret
+configuration, valid endpoint-bound static credentials from other attached
+providers, and the dynamic credential snapshot. Provider environment revisions
+include profile endpoint and binding changes.
 
 ## Inference Resolution
 

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -434,6 +434,15 @@ resolution and again by the sandbox placeholder resolver. This keeps expired
 credentials from resolving even when a running sandbox still has retained
 placeholder generations from an earlier provider credential snapshot.
 
+Static credential delivery is capability-negotiated and endpoint-bound. The
+gateway classifies each returned environment entry as either a credential or
+non-secret provider configuration and associates every credential key with the
+host, port, and path selectors from its effective provider profile. It withholds
+static credential material from supervisors that do not advertise binding
+support and rejects profile-backed delivery when a static credential has no
+usable endpoint. Provider environment revisions include profile endpoint and
+binding changes.
+
 ## Inference Resolution
 
 Cluster inference routes store only `provider_name`, `model_id`, and optional

--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -79,8 +79,10 @@ in that provider's effective profile. CONNECT, absolute-form forward HTTP,
 request targets, headers, supported request bodies, SigV4 signing, and opted-in
 WebSocket text rewriting use the same scoped resolver. Provider refresh swaps
 credential values and endpoint bindings atomically. An invalid or unavailable
-refresh clears the previous provider state instead of leaving a partially active
-or last-known-good credential set.
+refresh revokes the previous static credential state instead of leaving a
+partially active or last-known-good static set. Invalid metadata preserves the
+supplied dynamic snapshot, while a fetch failure preserves the currently active
+dynamic snapshot.
 
 Route selection and policy evaluation use a syntax-only redacted request target;
 they do not materialize real credentials. Cross-endpoint placeholder use returns

--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -237,7 +237,12 @@ For AWS endpoints that require request-level signing, the proxy supports SigV4
 re-signing. When `credential_signing: sigv4` is set on an L7 endpoint, the proxy
 strips the client's placeholder-based AWS auth headers, re-signs with real
 credentials from the provider, and forwards the request upstream. The signing
-mode is auto-detected from the client SDK's `x-amz-content-sha256` header:
+endpoint must have a credential source before the policy generation activates:
+an attached endpoint-bearing AWS profile whose boundary covers the endpoint, or
+an attached endpointless AWS profile explicitly named by the endpoint's
+`credential_binding.provider`. Policy activation rejects missing or mismatched
+sources atomically. The signing mode is auto-detected from the client SDK's
+`x-amz-content-sha256` header:
 
 - **Signed body** (hex hash): buffers the request body (up to 10 MiB), computes
   its SHA-256, and includes the hash in the signature. Used by Bedrock and most

--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -72,6 +72,22 @@ its guarded single-request relay while sharing authorization, request context,
 policy-pinning, and destination boundaries.
 Adapter-specific response and OCSF event shapes remain at the protocol boundary.
 
+Provider credential placeholders are resolved through the live provider state
+for each HTTP request, after destination and L7 policy admission. A static
+credential resolves only when the request host, port, and path match an endpoint
+in that provider's effective profile. CONNECT, absolute-form forward HTTP,
+request targets, headers, supported request bodies, SigV4 signing, and opted-in
+WebSocket text rewriting use the same scoped resolver. Provider refresh swaps
+credential values and endpoint bindings atomically. An invalid or unavailable
+refresh clears the previous provider state instead of leaving a partially active
+or last-known-good credential set.
+
+Route selection and policy evaluation use a syntax-only redacted request target;
+they do not materialize real credentials. Cross-endpoint placeholder use returns
+HTTP 403. After a WebSocket upgrade it closes the connection with policy
+violation code 1008. Both paths emit a denied activity event and a detection
+finding without logging the placeholder, environment key, secret, or query.
+
 For inspected HTTP traffic, the proxy can enforce REST method/path rules,
 WebSocket upgrade and text-message rules, GraphQL operation rules, and
 MCP method, tool, and supported params rules or generic JSON-RPC method rules

--- a/architecture/security-policy.md
+++ b/architecture/security-policy.md
@@ -81,6 +81,14 @@ with the sandbox's ephemeral CA and inspect method/path or protocol-specific
 metadata before forwarding. The proxy also supports credential injection on
 terminated HTTP streams when policy allows the endpoint.
 
+Static provider credentials have an independent endpoint-binding boundary.
+Provider profile endpoints define that boundary by default. An endpointless
+profile can delegate binding authority to sandbox policy through an endpoint
+that names the concrete attached provider instance. The gateway rejects
+unattached, profileless, endpointful, and gateway-global uses of that policy
+binding. Policy endpoint changes rotate the provider-environment revision so
+the supervisor installs policy and credential binding snapshots atomically.
+
 Raw streams and long-lived response bodies are connection scoped. Policy
 generation changes close relays pinned to the previous generation instead of
 allowing them to continue under stale authorization. HTTP upgrades switch to

--- a/crates/openshell-core/src/endpoint_path.rs
+++ b/crates/openshell-core/src/endpoint_path.rs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Canonical provider endpoint path matching shared by policy and runtime code.
+
+/// Return whether `path` is selected by a provider endpoint path pattern.
+///
+/// Empty paths and `**` match every request path. A trailing `/**` matches the
+/// named path itself and every descendant. Other patterns use glob semantics.
+#[must_use]
+pub fn matches(pattern: &str, path: &str) -> bool {
+    if pattern.is_empty() || pattern == "**" || pattern == "/**" {
+        return true;
+    }
+    if pattern == path {
+        return true;
+    }
+    if let Some(prefix) = pattern.strip_suffix("/**") {
+        return path == prefix || path.starts_with(&format!("{prefix}/"));
+    }
+    glob::Pattern::new(pattern).is_ok_and(|glob| glob.matches(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::matches;
+
+    #[test]
+    fn matches_canonical_endpoint_patterns() {
+        assert!(matches("", "/v1/messages"));
+        assert!(matches("/**", "/v1/messages"));
+        assert!(matches("/v1/**", "/v1"));
+        assert!(matches("/v1/**", "/v1/messages"));
+        assert!(matches("/v*/messages", "/v1/messages"));
+        assert!(matches("/v1/*", "/v1/chat/messages"));
+        assert!(!matches("/v1/**", "/v2/messages"));
+        assert!(!matches("/v1/*/messages", "/v1/chat/completions"));
+    }
+}

--- a/crates/openshell-core/src/endpoint_path.rs
+++ b/crates/openshell-core/src/endpoint_path.rs
@@ -3,27 +3,74 @@
 
 //! Canonical provider endpoint path matching shared by policy and runtime code.
 
+/// A compiled provider endpoint path pattern.
+///
+/// Invalid glob syntax retains the existing fail-closed behavior: it matches
+/// only when the request path is exactly equal to the configured pattern.
+#[derive(Debug, Clone)]
+pub struct EndpointPathPattern {
+    source: String,
+    kind: EndpointPathPatternKind,
+}
+
+#[derive(Debug, Clone)]
+enum EndpointPathPatternKind {
+    Any,
+    Subtree(String),
+    Glob(glob::Pattern),
+    Invalid,
+}
+
+impl EndpointPathPattern {
+    #[must_use]
+    pub fn new(pattern: &str) -> Self {
+        let kind = if pattern.is_empty() || pattern == "**" || pattern == "/**" {
+            EndpointPathPatternKind::Any
+        } else if let Some(prefix) = pattern.strip_suffix("/**") {
+            EndpointPathPatternKind::Subtree(prefix.to_string())
+        } else {
+            glob::Pattern::new(pattern).map_or(
+                EndpointPathPatternKind::Invalid,
+                EndpointPathPatternKind::Glob,
+            )
+        };
+        Self {
+            source: pattern.to_string(),
+            kind,
+        }
+    }
+
+    #[must_use]
+    pub fn matches(&self, path: &str) -> bool {
+        if self.source == path {
+            return true;
+        }
+        match &self.kind {
+            EndpointPathPatternKind::Any => true,
+            EndpointPathPatternKind::Subtree(prefix) => {
+                path == prefix
+                    || path
+                        .strip_prefix(prefix)
+                        .is_some_and(|suffix| suffix.starts_with('/'))
+            }
+            EndpointPathPatternKind::Glob(pattern) => pattern.matches(path),
+            EndpointPathPatternKind::Invalid => false,
+        }
+    }
+}
+
 /// Return whether `path` is selected by a provider endpoint path pattern.
 ///
 /// Empty paths and `**` match every request path. A trailing `/**` matches the
 /// named path itself and every descendant. Other patterns use glob semantics.
 #[must_use]
 pub fn matches(pattern: &str, path: &str) -> bool {
-    if pattern.is_empty() || pattern == "**" || pattern == "/**" {
-        return true;
-    }
-    if pattern == path {
-        return true;
-    }
-    if let Some(prefix) = pattern.strip_suffix("/**") {
-        return path == prefix || path.starts_with(&format!("{prefix}/"));
-    }
-    glob::Pattern::new(pattern).is_ok_and(|glob| glob.matches(path))
+    EndpointPathPattern::new(pattern).matches(path)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::matches;
+    use super::{EndpointPathPattern, matches};
 
     #[test]
     fn matches_canonical_endpoint_patterns() {
@@ -35,5 +82,21 @@ mod tests {
         assert!(matches("/v1/*", "/v1/chat/messages"));
         assert!(!matches("/v1/**", "/v2/messages"));
         assert!(!matches("/v1/*/messages", "/v1/chat/completions"));
+    }
+
+    #[test]
+    fn compiled_patterns_preserve_canonical_matching() {
+        let subtree = EndpointPathPattern::new("/v1/**");
+        assert!(subtree.matches("/v1"));
+        assert!(subtree.matches("/v1/chat/messages"));
+        assert!(!subtree.matches("/v2/messages"));
+
+        let glob = EndpointPathPattern::new("/v*/messages");
+        assert!(glob.matches("/v1/messages"));
+        assert!(!glob.matches("/v1/completions"));
+
+        let invalid = EndpointPathPattern::new("[");
+        assert!(invalid.matches("["));
+        assert!(!invalid.matches("/v1/messages"));
     }
 }

--- a/crates/openshell-core/src/grpc_client.rs
+++ b/crates/openshell-core/src/grpc_client.rs
@@ -741,6 +741,7 @@ pub async fn fetch_provider_environment(
     let response = client
         .get_sandbox_provider_environment(GetSandboxProviderEnvironmentRequest {
             sandbox_id: sandbox_id.to_string(),
+            supports_static_credential_bindings: true,
         })
         .await
         .into_diagnostic()?;
@@ -751,6 +752,8 @@ pub async fn fetch_provider_environment(
         provider_env_revision: inner.provider_env_revision,
         credential_expires_at_ms: inner.credential_expires_at_ms,
         dynamic_credentials: inner.dynamic_credentials,
+        static_credential_bindings: inner.static_credential_bindings,
+        non_secret_environment_keys: inner.non_secret_environment_keys,
     })
 }
 
@@ -840,6 +843,8 @@ pub struct ProviderEnvironmentResult {
     pub provider_env_revision: u64,
     pub credential_expires_at_ms: HashMap<String, i64>,
     pub dynamic_credentials: HashMap<String, crate::proto::ProviderProfileCredential>,
+    pub static_credential_bindings: HashMap<String, crate::proto::StaticCredentialBinding>,
+    pub non_secret_environment_keys: Vec<String>,
 }
 
 impl CachedOpenShellClient {

--- a/crates/openshell-core/src/host_pattern.rs
+++ b/crates/openshell-core/src/host_pattern.rs
@@ -12,13 +12,13 @@ use std::collections::{HashSet, VecDeque};
 /// semantics mirror the Rego endpoint glob matching used for network policy
 /// admission (`glob.match` with a `.` delimiter), so a pattern copied from a
 /// network endpoint selects exactly the hosts that endpoint admits.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HostPattern {
     source: String,
     labels: Vec<HostLabelPattern>,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 enum HostLabelPattern {
     Recursive,
     Label {
@@ -130,13 +130,18 @@ impl HostPattern {
     #[must_use]
     pub fn matches(&self, host: &str) -> bool {
         let host = host.to_ascii_lowercase();
-        if host.split('.').any(str::is_empty) {
-            return false;
-        }
-        self.matches_labels(&host.split('.').collect::<Vec<_>>())
+        self.matches_normalized_labels(&host.split('.').collect::<Vec<_>>())
     }
 
-    fn matches_labels(&self, host: &[&str]) -> bool {
+    /// Match pre-split lowercase DNS labels.
+    ///
+    /// This avoids repeating request-host normalization when several compiled
+    /// patterns are evaluated against the same destination.
+    #[must_use]
+    pub(crate) fn matches_normalized_labels(&self, host: &[&str]) -> bool {
+        if host.iter().any(|label| label.is_empty()) {
+            return false;
+        }
         let mut pending = vec![(0, 0)];
         let mut visited = HashSet::new();
         while let Some((pattern_idx, host_idx)) = pending.pop() {

--- a/crates/openshell-core/src/lib.rs
+++ b/crates/openshell-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod container_paths;
 pub mod denial;
 pub mod driver_mounts;
 pub mod driver_utils;
+pub mod endpoint_path;
 pub mod error;
 pub mod forward;
 pub mod google_cloud;

--- a/crates/openshell-core/src/provider_credentials.rs
+++ b/crates/openshell-core/src/provider_credentials.rs
@@ -461,6 +461,12 @@ impl ProviderCredentialState {
         inner.current.child_env.len()
     }
 
+    /// Install one gateway provider-environment snapshot.
+    ///
+    /// Callers must serialize this operation with other bound-environment
+    /// installs and revocations. The sandbox settings refresh loop is the sole
+    /// writer today. The internal lock makes each mutation memory-safe, but it
+    /// does not establish revision ordering between concurrent snapshots.
     pub fn install_bound_environment(
         &self,
         revision: u64,

--- a/crates/openshell-core/src/provider_credentials.rs
+++ b/crates/openshell-core/src/provider_credentials.rs
@@ -30,6 +30,13 @@ struct ProviderCredentialStateInner {
     suppressed_keys: HashSet<String>,
     static_credential_bindings: HashMap<String, StaticCredentialBinding>,
     known_static_credential_keys: HashSet<String>,
+    static_credential_identity_epochs: HashMap<String, StaticCredentialIdentityEpoch>,
+}
+
+#[derive(Debug)]
+struct StaticCredentialIdentityEpoch {
+    identity: String,
+    first_revision: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -81,6 +88,7 @@ impl ProviderCredentialState {
                 suppressed_keys: HashSet::new(),
                 static_credential_bindings: HashMap::new(),
                 known_static_credential_keys: HashSet::new(),
+                static_credential_identity_epochs: HashMap::new(),
             })),
         }
     }
@@ -108,6 +116,11 @@ impl ProviderCredentialState {
             inner
                 .known_static_credential_keys
                 .extend(static_credential_bindings.keys().cloned());
+            update_static_credential_identity_epochs(
+                &mut inner.static_credential_identity_epochs,
+                revision,
+                &static_credential_bindings,
+            );
             inner.static_credential_bindings = static_credential_bindings;
         }
         Ok(state)
@@ -137,6 +150,7 @@ impl ProviderCredentialState {
                 suppressed_keys: HashSet::new(),
                 static_credential_bindings: HashMap::new(),
                 known_static_credential_keys: HashSet::new(),
+                static_credential_identity_epochs: HashMap::new(),
             })),
         }
     }
@@ -171,6 +185,7 @@ impl ProviderCredentialState {
         inner.combined_resolver = None;
         inner.static_credential_bindings.clear();
         inner.known_static_credential_keys.clear();
+        inner.static_credential_identity_epochs.clear();
         inner.current.child_env.len()
     }
 
@@ -205,7 +220,7 @@ impl ProviderCredentialState {
             .read()
             .expect("provider credential state poisoned");
         let request_path = path.split_once('?').map_or(path, |(path, _)| path);
-        let allowed = inner
+        let allowed: HashSet<String> = inner
             .static_credential_bindings
             .iter()
             .filter(|(_, binding)| {
@@ -216,7 +231,23 @@ impl ProviderCredentialState {
             .map(|(key, _)| key.clone())
             .collect();
         inner.combined_resolver.as_ref().map(|resolver| {
-            Arc::new(resolver.scoped_to_env_keys(&inner.known_static_credential_keys, &allowed))
+            let revision_fallback_min_revisions = inner
+                .static_credential_identity_epochs
+                .iter()
+                .filter(|(key, epoch)| {
+                    allowed.contains(*key)
+                        && inner
+                            .static_credential_bindings
+                            .get(*key)
+                            .is_some_and(|binding| binding.credential_identity == epoch.identity)
+                })
+                .map(|(key, epoch)| (key.clone(), epoch.first_revision))
+                .collect();
+            Arc::new(resolver.scoped_to_env_keys(
+                &inner.known_static_credential_keys,
+                &allowed,
+                revision_fallback_min_revisions,
+            ))
         })
     }
 
@@ -442,6 +473,11 @@ impl ProviderCredentialState {
         inner
             .known_static_credential_keys
             .extend(static_credential_bindings.keys().cloned());
+        update_static_credential_identity_epochs(
+            &mut inner.static_credential_identity_epochs,
+            revision,
+            &static_credential_bindings,
+        );
         inner.static_credential_bindings = static_credential_bindings;
         Ok(inner.current.child_env.len())
     }
@@ -474,6 +510,7 @@ impl ProviderCredentialState {
         inner.current_resolver = None;
         inner.combined_resolver = None;
         inner.static_credential_bindings.clear();
+        inner.static_credential_identity_epochs.clear();
     }
 }
 
@@ -543,6 +580,32 @@ fn static_credential_identities(
         .iter()
         .map(|(key, binding)| (key.as_str(), binding.credential_identity.as_str()))
         .collect()
+}
+
+fn update_static_credential_identity_epochs(
+    epochs: &mut HashMap<String, StaticCredentialIdentityEpoch>,
+    revision: u64,
+    bindings: &HashMap<String, StaticCredentialBinding>,
+) {
+    epochs.retain(|key, _| bindings.contains_key(key));
+    for (key, binding) in bindings {
+        match epochs.get_mut(key) {
+            Some(epoch) if epoch.identity == binding.credential_identity => {}
+            Some(epoch) => {
+                epoch.identity.clone_from(&binding.credential_identity);
+                epoch.first_revision = revision;
+            }
+            None => {
+                epochs.insert(
+                    key.clone(),
+                    StaticCredentialIdentityEpoch {
+                        identity: binding.credential_identity.clone(),
+                        first_revision: revision,
+                    },
+                );
+            }
+        }
+    }
 }
 
 fn binding_error(message: &str) -> StaticCredentialBindingError {
@@ -719,6 +782,47 @@ mod tests {
         assert_eq!(
             resolver.resolve_placeholder("openshell:resolve:env:v2_API_KEY"),
             Some("new")
+        );
+    }
+
+    #[test]
+    fn aged_generation_falls_back_after_many_rotations_of_same_provider_credential() {
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            HashMap::from([("API_KEY".to_string(), "secret-1".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([(
+                "API_KEY".to_string(),
+                binding("api.example.com", 443, "/**"),
+            )]),
+            Vec::new(),
+        )
+        .expect("initial bindings");
+
+        for revision in 2..=10 {
+            state
+                .install_bound_environment(
+                    revision,
+                    HashMap::from([("API_KEY".to_string(), format!("secret-{revision}"))]),
+                    HashMap::new(),
+                    HashMap::new(),
+                    HashMap::from([(
+                        "API_KEY".to_string(),
+                        binding("api.example.com", 443, "/**"),
+                    )]),
+                    Vec::new(),
+                )
+                .expect("rotated bindings");
+        }
+
+        let resolver = state
+            .resolver_for_endpoint("api.example.com", 443, "/v1")
+            .expect("resolver");
+        assert_eq!(
+            resolver.resolve_placeholder("openshell:resolve:env:v1_API_KEY"),
+            Some("secret-10"),
+            "an aged-out placeholder may use the current secret while its provider identity is unchanged"
         );
     }
 

--- a/crates/openshell-core/src/provider_credentials.rs
+++ b/crates/openshell-core/src/provider_credentials.rs
@@ -28,6 +28,7 @@ struct ProviderCredentialStateInner {
     current_resolver: Option<Arc<SecretResolver>>,
     combined_resolver: Option<Arc<SecretResolver>>,
     suppressed_keys: HashSet<String>,
+    non_secret_environment_keys: HashSet<String>,
     static_credential_bindings: HashMap<String, StaticCredentialBinding>,
     known_static_credential_keys: HashSet<String>,
     static_credential_identity_epochs: HashMap<String, StaticCredentialIdentityEpoch>,
@@ -86,6 +87,7 @@ impl ProviderCredentialState {
                 current_resolver,
                 combined_resolver,
                 suppressed_keys: HashSet::new(),
+                non_secret_environment_keys: HashSet::new(),
                 static_credential_bindings: HashMap::new(),
                 known_static_credential_keys: HashSet::new(),
                 static_credential_identity_epochs: HashMap::new(),
@@ -121,6 +123,7 @@ impl ProviderCredentialState {
                 revision,
                 &static_credential_bindings,
             );
+            inner.non_secret_environment_keys = non_secret_environment_keys.into_iter().collect();
             inner.static_credential_bindings = static_credential_bindings;
         }
         Ok(state)
@@ -148,6 +151,7 @@ impl ProviderCredentialState {
                 current_resolver: None,
                 combined_resolver: None,
                 suppressed_keys: HashSet::new(),
+                non_secret_environment_keys: HashSet::new(),
                 static_credential_bindings: HashMap::new(),
                 known_static_credential_keys: HashSet::new(),
                 static_credential_identity_epochs: HashMap::new(),
@@ -183,6 +187,7 @@ impl ProviderCredentialState {
         inner.generations.clear();
         inner.current_resolver = None;
         inner.combined_resolver = None;
+        inner.non_secret_environment_keys.clear();
         inner.static_credential_bindings.clear();
         inner.known_static_credential_keys.clear();
         inner.static_credential_identity_epochs.clear();
@@ -302,10 +307,13 @@ impl ProviderCredentialState {
             .expect("provider credential state poisoned");
         let mut env = inner.current.child_env.clone();
 
-        let has_gcp_metadata = env.contains_key("GCE_METADATA_HOST");
+        let has_gcp_metadata = env.contains_key("GCE_METADATA_HOST")
+            && inner
+                .non_secret_environment_keys
+                .contains("GCE_METADATA_HOST");
         let has_gcp_config = google_cloud::STATIC_CONFIG_KEYS
             .iter()
-            .any(|k| env.contains_key(*k));
+            .any(|key| env.contains_key(*key) && inner.non_secret_environment_keys.contains(*key));
 
         if !has_gcp_metadata && !has_gcp_config {
             return env;
@@ -335,7 +343,10 @@ impl ProviderCredentialState {
         // Un-placeholderize non-secret config vars so SDKs can read them
         // at process startup before any HTTP flows through the proxy.
         if let Some(ref resolver) = inner.combined_resolver {
-            for key in google_cloud::STATIC_CONFIG_KEYS {
+            for key in google_cloud::STATIC_CONFIG_KEYS
+                .iter()
+                .filter(|key| inner.non_secret_environment_keys.contains(**key))
+            {
                 let placeholder = crate::secrets::placeholder_for_env_key(key);
                 if let Some(value) = resolver.resolve_placeholder(&placeholder) {
                     env.insert(key.to_string(), value.to_string());
@@ -416,6 +427,7 @@ impl ProviderCredentialState {
         }
         inner.combined_resolver =
             merge_resolvers(&inner.generations, inner.current_resolver.as_ref());
+        inner.non_secret_environment_keys.clear();
         inner.current.child_env.len()
     }
 
@@ -478,6 +490,7 @@ impl ProviderCredentialState {
             revision,
             &static_credential_bindings,
         );
+        inner.non_secret_environment_keys = non_secret_environment_keys.into_iter().collect();
         inner.static_credential_bindings = static_credential_bindings;
         Ok(inner.current.child_env.len())
     }
@@ -509,6 +522,7 @@ impl ProviderCredentialState {
         inner.generations.clear();
         inner.current_resolver = None;
         inner.combined_resolver = None;
+        inner.non_secret_environment_keys.clear();
         inner.static_credential_bindings.clear();
         inner.static_credential_identity_epochs.clear();
     }
@@ -1052,7 +1066,7 @@ mod tests {
 
     #[test]
     fn child_env_with_gcp_resolved_overrides_gcp_static_vars() {
-        let state = ProviderCredentialState::from_environment(
+        let state = ProviderCredentialState::from_bound_environment(
             1,
             HashMap::from([
                 ("GCE_METADATA_HOST".to_string(), "marker".to_string()),
@@ -1065,7 +1079,17 @@ mod tests {
             ]),
             HashMap::new(),
             HashMap::new(),
-        );
+            HashMap::from([(
+                "GCP_ADC_ACCESS_TOKEN".to_string(),
+                binding("oauth2.googleapis.com", 443, "/**"),
+            )]),
+            vec![
+                "GCE_METADATA_HOST".to_string(),
+                "GCP_PROJECT_ID".to_string(),
+                "CLOUD_ML_REGION".to_string(),
+            ],
+        )
+        .expect("classified GCP environment");
         let env = state.child_env_with_gcp_resolved();
 
         assert_eq!(
@@ -1096,7 +1120,7 @@ mod tests {
 
     #[test]
     fn child_env_with_gcp_resolved_handles_missing_config_keys() {
-        let state = ProviderCredentialState::from_environment(
+        let state = ProviderCredentialState::from_bound_environment(
             1,
             HashMap::from([
                 ("GCE_METADATA_HOST".to_string(), "marker".to_string()),
@@ -1104,7 +1128,13 @@ mod tests {
             ]),
             HashMap::new(),
             HashMap::new(),
-        );
+            HashMap::from([(
+                "GCP_ADC_ACCESS_TOKEN".to_string(),
+                binding("oauth2.googleapis.com", 443, "/**"),
+            )]),
+            vec!["GCE_METADATA_HOST".to_string()],
+        )
+        .expect("classified GCP environment");
         let env = state.child_env_with_gcp_resolved();
 
         assert_eq!(
@@ -1222,7 +1252,7 @@ mod tests {
 
     #[test]
     fn child_env_with_gcp_resolved_resolves_vertex_vars_without_metadata_host() {
-        let state = ProviderCredentialState::from_environment(
+        let state = ProviderCredentialState::from_bound_environment(
             1,
             HashMap::from([
                 ("GOOSE_PROVIDER".to_string(), "gcp_vertex_ai".to_string()),
@@ -1234,7 +1264,14 @@ mod tests {
             ]),
             HashMap::new(),
             HashMap::new(),
-        );
+            HashMap::new(),
+            vec![
+                "GOOSE_PROVIDER".to_string(),
+                "ANTHROPIC_VERTEX_PROJECT_ID".to_string(),
+                "VERTEX_LOCATION".to_string(),
+            ],
+        )
+        .expect("classified Vertex environment");
         let env = state.child_env_with_gcp_resolved();
         assert_eq!(
             env.get("GOOSE_PROVIDER").map(String::as_str),
@@ -1252,6 +1289,66 @@ mod tests {
         assert!(
             !env.contains_key("GCE_METADATA_IP"),
             "metadata synthetic vars should not be injected without GCE_METADATA_HOST"
+        );
+    }
+
+    #[test]
+    fn child_env_with_gcp_resolved_only_unwraps_explicitly_non_secret_config() {
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            HashMap::from([
+                (
+                    "GOOGLE_CLOUD_PROJECT".to_string(),
+                    "initial-project-config".to_string(),
+                ),
+                (
+                    "GCP_PROJECT_ID".to_string(),
+                    "visible-project-config".to_string(),
+                ),
+            ]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            vec![
+                "GOOGLE_CLOUD_PROJECT".to_string(),
+                "GCP_PROJECT_ID".to_string(),
+            ],
+        )
+        .expect("classified GCP environment");
+
+        state
+            .install_bound_environment(
+                2,
+                HashMap::from([
+                    (
+                        "GOOGLE_CLOUD_PROJECT".to_string(),
+                        "bound-project-secret".to_string(),
+                    ),
+                    (
+                        "GCP_PROJECT_ID".to_string(),
+                        "visible-project-config".to_string(),
+                    ),
+                ]),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::from([(
+                    "GOOGLE_CLOUD_PROJECT".to_string(),
+                    binding("example.googleapis.com", 443, "/**"),
+                )]),
+                vec!["GCP_PROJECT_ID".to_string()],
+            )
+            .expect("refreshed GCP environment");
+
+        let env = state.child_env_with_gcp_resolved();
+        assert_eq!(
+            env.get("GCP_PROJECT_ID").map(String::as_str),
+            Some("visible-project-config"),
+            "explicitly non-secret GCP config should be visible to the workload"
+        );
+        assert_eq!(
+            env.get("GOOGLE_CLOUD_PROJECT").map(String::as_str),
+            Some("openshell:resolve:env:v2_GOOGLE_CLOUD_PROJECT"),
+            "a reserved GCP name classified as a bound credential must stay placeholderized"
         );
     }
 

--- a/crates/openshell-core/src/provider_credentials.rs
+++ b/crates/openshell-core/src/provider_credentials.rs
@@ -704,6 +704,85 @@ mod tests {
         }
     }
 
+    fn assert_binding_validation_error(
+        env: HashMap<String, String>,
+        bindings: HashMap<String, StaticCredentialBinding>,
+        non_secret_environment_keys: Vec<String>,
+        expected: &str,
+    ) {
+        let error =
+            validate_static_credential_bindings(&env, &bindings, &non_secret_environment_keys)
+                .expect_err("malformed provider metadata must fail validation");
+        assert_eq!(error.to_string(), expected);
+    }
+
+    #[test]
+    fn rejects_each_malformed_static_credential_binding_shape() {
+        let credential_env = || HashMap::from([("API_KEY".to_string(), "secret".to_string())]);
+        let credential_binding = || {
+            HashMap::from([(
+                "API_KEY".to_string(),
+                binding("api.example.com", 443, "/**"),
+            )])
+        };
+
+        assert_binding_validation_error(
+            HashMap::from([("PROJECT_ID".to_string(), "project".to_string())]),
+            HashMap::new(),
+            vec!["PROJECT_ID".to_string(), "PROJECT_ID".to_string()],
+            "provider environment repeats a non-secret environment key",
+        );
+        assert_binding_validation_error(
+            credential_env(),
+            credential_binding(),
+            vec!["API_KEY".to_string()],
+            "provider environment classifies a key as both credential and non-secret configuration",
+        );
+        assert_binding_validation_error(
+            credential_env(),
+            HashMap::new(),
+            Vec::new(),
+            "provider environment contains an unclassified credential key",
+        );
+        assert_binding_validation_error(
+            HashMap::new(),
+            credential_binding(),
+            Vec::new(),
+            "provider environment metadata references a missing environment key",
+        );
+
+        let mut missing_identity = binding("api.example.com", 443, "/**");
+        missing_identity.credential_identity.clear();
+        assert_binding_validation_error(
+            credential_env(),
+            HashMap::from([("API_KEY".to_string(), missing_identity)]),
+            Vec::new(),
+            "static credential binding has no provider credential identity",
+        );
+
+        let mut missing_endpoints = binding("api.example.com", 443, "/**");
+        missing_endpoints.endpoints.clear();
+        assert_binding_validation_error(
+            credential_env(),
+            HashMap::from([("API_KEY".to_string(), missing_endpoints)]),
+            Vec::new(),
+            "static credential binding has no authorized endpoints",
+        );
+
+        for (host, port) in [
+            ("api.example.com", 0),
+            ("api.example.com", u32::from(u16::MAX) + 1),
+            ("invalid host", 443),
+        ] {
+            assert_binding_validation_error(
+                credential_env(),
+                HashMap::from([("API_KEY".to_string(), binding(host, port, "/**"))]),
+                Vec::new(),
+                "static credential binding contains an invalid endpoint",
+            );
+        }
+    }
+
     #[test]
     fn bound_credentials_resolve_only_at_matching_endpoint() {
         let state = ProviderCredentialState::from_bound_environment(

--- a/crates/openshell-core/src/provider_credentials.rs
+++ b/crates/openshell-core/src/provider_credentials.rs
@@ -820,6 +820,55 @@ mod tests {
     }
 
     #[test]
+    fn multiple_credentials_resolve_only_at_their_own_endpoints() {
+        let mut binding_a = binding("a.example.com", 443, "/a/**");
+        binding_a.credential_identity = "provider-a:KEY_A".to_string();
+        let mut binding_b = binding("b.example.com", 443, "/b/**");
+        binding_b.credential_identity = "provider-b:KEY_B".to_string();
+        let state = ProviderCredentialState::from_bound_environment(
+            7,
+            HashMap::from([
+                ("KEY_A".to_string(), "secret-a".to_string()),
+                ("KEY_B".to_string(), "secret-b".to_string()),
+            ]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([
+                ("KEY_A".to_string(), binding_a),
+                ("KEY_B".to_string(), binding_b),
+            ]),
+            Vec::new(),
+        )
+        .expect("valid bindings");
+
+        let resolver_a = state
+            .resolver_for_endpoint("a.example.com", 443, "/a/check")
+            .expect("endpoint A resolver");
+        assert_eq!(
+            resolver_a.resolve_placeholder("openshell:resolve:env:v7_KEY_A"),
+            Some("secret-a")
+        );
+        assert_eq!(
+            resolver_a.resolve_placeholder("openshell:resolve:env:v7_KEY_B"),
+            None,
+            "credential B must not resolve at endpoint A"
+        );
+
+        let resolver_b = state
+            .resolver_for_endpoint("b.example.com", 443, "/b/check")
+            .expect("endpoint B resolver");
+        assert_eq!(
+            resolver_b.resolve_placeholder("openshell:resolve:env:v7_KEY_B"),
+            Some("secret-b")
+        );
+        assert_eq!(
+            resolver_b.resolve_placeholder("openshell:resolve:env:v7_KEY_A"),
+            None,
+            "credential A must not resolve at endpoint B"
+        );
+    }
+
+    #[test]
     fn revisioned_path_placeholder_matches_exact_redacted_binding() {
         let state = ProviderCredentialState::from_bound_environment(
             7,

--- a/crates/openshell-core/src/provider_credentials.rs
+++ b/crates/openshell-core/src/provider_credentials.rs
@@ -36,7 +36,7 @@ struct ProviderCredentialStateInner {
 #[derive(Debug)]
 struct StaticCredentialIdentityEpoch {
     identity: String,
-    first_revision: u64,
+    revisions: HashSet<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -231,7 +231,7 @@ impl ProviderCredentialState {
             .map(|(key, _)| key.clone())
             .collect();
         inner.combined_resolver.as_ref().map(|resolver| {
-            let revision_fallback_min_revisions = inner
+            let revision_fallback_allowed_revisions = inner
                 .static_credential_identity_epochs
                 .iter()
                 .filter(|(key, epoch)| {
@@ -241,12 +241,12 @@ impl ProviderCredentialState {
                             .get(*key)
                             .is_some_and(|binding| binding.credential_identity == epoch.identity)
                 })
-                .map(|(key, epoch)| (key.clone(), epoch.first_revision))
+                .map(|(key, epoch)| (key.clone(), epoch.revisions.clone()))
                 .collect();
             Arc::new(resolver.scoped_to_env_keys(
                 &inner.known_static_credential_keys,
                 &allowed,
-                revision_fallback_min_revisions,
+                revision_fallback_allowed_revisions,
             ))
         })
     }
@@ -590,17 +590,19 @@ fn update_static_credential_identity_epochs(
     epochs.retain(|key, _| bindings.contains_key(key));
     for (key, binding) in bindings {
         match epochs.get_mut(key) {
-            Some(epoch) if epoch.identity == binding.credential_identity => {}
+            Some(epoch) if epoch.identity == binding.credential_identity => {
+                epoch.revisions.insert(revision);
+            }
             Some(epoch) => {
                 epoch.identity.clone_from(&binding.credential_identity);
-                epoch.first_revision = revision;
+                epoch.revisions = HashSet::from([revision]);
             }
             None => {
                 epochs.insert(
                     key.clone(),
                     StaticCredentialIdentityEpoch {
                         identity: binding.credential_identity.clone(),
-                        first_revision: revision,
+                        revisions: HashSet::from([revision]),
                     },
                 );
             }
@@ -786,10 +788,10 @@ mod tests {
     }
 
     #[test]
-    fn aged_generation_falls_back_after_many_rotations_of_same_provider_credential() {
+    fn aged_generation_falls_back_across_non_monotonic_same_identity_rotations() {
         let state = ProviderCredentialState::from_bound_environment(
-            1,
-            HashMap::from([("API_KEY".to_string(), "secret-1".to_string())]),
+            50,
+            HashMap::from([("API_KEY".to_string(), "secret-50".to_string())]),
             HashMap::new(),
             HashMap::new(),
             HashMap::from([(
@@ -800,7 +802,7 @@ mod tests {
         )
         .expect("initial bindings");
 
-        for revision in 2..=10 {
+        for revision in [10, 100, 9, 101, 8, 102, 7, 103, 6] {
             state
                 .install_bound_environment(
                     revision,
@@ -820,16 +822,16 @@ mod tests {
             .resolver_for_endpoint("api.example.com", 443, "/v1")
             .expect("resolver");
         assert_eq!(
-            resolver.resolve_placeholder("openshell:resolve:env:v1_API_KEY"),
-            Some("secret-10"),
-            "an aged-out placeholder may use the current secret while its provider identity is unchanged"
+            resolver.resolve_placeholder("openshell:resolve:env:v50_API_KEY"),
+            Some("secret-6"),
+            "an aged-out placeholder may use the current secret across revisions in both numeric directions while its provider identity is unchanged"
         );
     }
 
     #[test]
     fn replacing_provider_with_reused_key_purges_retained_generation() {
         let state = ProviderCredentialState::from_bound_environment(
-            1,
+            u64::MAX,
             HashMap::from([("API_KEY".to_string(), "provider-a-secret".to_string())]),
             HashMap::new(),
             HashMap::new(),
@@ -842,7 +844,7 @@ mod tests {
 
         state
             .install_bound_environment(
-                2,
+                1,
                 HashMap::from([("API_KEY".to_string(), "provider-b-secret".to_string())]),
                 HashMap::new(),
                 HashMap::new(),
@@ -855,9 +857,26 @@ mod tests {
             .resolver_for_endpoint("b.example.com", 443, "/v1")
             .expect("resolver");
         assert_eq!(
-            resolver.resolve_placeholder("openshell:resolve:env:v1_API_KEY"),
+            resolver.resolve_placeholder(&format!("openshell:resolve:env:v{}_API_KEY", u64::MAX)),
             None,
-            "a placeholder issued by another provider identity must fail closed"
+            "an opaque revision from another provider identity must fail closed even when it is numerically greater"
+        );
+        assert_eq!(
+            resolver.resolve_placeholder("openshell:resolve:env:API_KEY"),
+            None,
+            "an identityless canonical placeholder must not resolve a replacement provider"
+        );
+        assert_eq!(
+            resolver.resolve_placeholder("vendor-OPENSHELL-RESOLVE-ENV-API_KEY"),
+            None,
+            "an identityless provider alias must not resolve a replacement provider"
+        );
+        assert_eq!(
+            resolver
+                .resolve_current_env_key_checked("API_KEY", "trusted-transform")
+                .expect("binding authorizes the endpoint"),
+            Some("provider-b-secret"),
+            "trusted supervisor transforms may select the current bound credential by key"
         );
     }
 
@@ -894,6 +913,16 @@ mod tests {
             resolver.resolve_placeholder("openshell:resolve:env:v1_API_KEY"),
             None,
             "a placeholder issued before detach must not resolve to a replacement provider"
+        );
+        assert_eq!(
+            resolver.resolve_placeholder("openshell:resolve:env:API_KEY"),
+            None,
+            "an identityless canonical placeholder must not cross detach and reattach"
+        );
+        assert_eq!(
+            resolver.resolve_placeholder("vendor-OPENSHELL-RESOLVE-ENV-API_KEY"),
+            None,
+            "an identityless provider alias must not cross detach and reattach"
         );
     }
 

--- a/crates/openshell-core/src/provider_credentials.rs
+++ b/crates/openshell-core/src/provider_credentials.rs
@@ -426,6 +426,11 @@ impl ProviderCredentialState {
             dynamic_credentials,
         });
         inner.current_resolver = current_resolver.map(Arc::new);
+        if static_credential_identities(&inner.static_credential_bindings)
+            != static_credential_identities(&static_credential_bindings)
+        {
+            inner.generations.clear();
+        }
         if let Some(resolver) = generation_resolver {
             inner.generations.push_back(Arc::new(resolver));
             while inner.generations.len() > MAX_RETAINED_CREDENTIAL_GENERATIONS {
@@ -507,6 +512,11 @@ fn validate_static_credential_bindings(
         ));
     }
     for binding in bindings.values() {
+        if binding.credential_identity.is_empty() {
+            return Err(binding_error(
+                "static credential binding has no provider credential identity",
+            ));
+        }
         if binding.endpoints.is_empty() {
             return Err(binding_error(
                 "static credential binding has no authorized endpoints",
@@ -524,6 +534,15 @@ fn validate_static_credential_bindings(
         }
     }
     Ok(())
+}
+
+fn static_credential_identities(
+    bindings: &HashMap<String, StaticCredentialBinding>,
+) -> HashMap<&str, &str> {
+    bindings
+        .iter()
+        .map(|(key, binding)| (key.as_str(), binding.credential_identity.as_str()))
+        .collect()
 }
 
 fn binding_error(message: &str) -> StaticCredentialBindingError {
@@ -568,6 +587,7 @@ mod tests {
                 port,
                 path: path.to_string(),
             }],
+            credential_identity: "provider-a:API_KEY".to_string(),
         }
     }
 
@@ -642,17 +662,135 @@ mod tests {
         )
         .expect("initial bindings");
 
+        let dynamic_credentials = HashMap::from([(
+            "dynamic".to_string(),
+            crate::proto::ProviderProfileCredential::default(),
+        )]);
         let result = state.install_bound_environment(
             2,
             HashMap::from([("API_KEY".to_string(), "new".to_string())]),
             HashMap::new(),
-            HashMap::new(),
+            dynamic_credentials,
             HashMap::new(),
             Vec::new(),
         );
         assert!(result.is_err());
         assert!(state.snapshot().child_env.is_empty());
         assert!(state.resolver().is_none());
+        assert!(state.snapshot().dynamic_credentials.contains_key("dynamic"));
+    }
+
+    #[test]
+    fn retained_generation_survives_rotation_of_same_provider_credential() {
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            HashMap::from([("API_KEY".to_string(), "old".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([(
+                "API_KEY".to_string(),
+                binding("api.example.com", 443, "/**"),
+            )]),
+            Vec::new(),
+        )
+        .expect("initial bindings");
+
+        state
+            .install_bound_environment(
+                2,
+                HashMap::from([("API_KEY".to_string(), "new".to_string())]),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::from([(
+                    "API_KEY".to_string(),
+                    binding("api.example.com", 443, "/**"),
+                )]),
+                Vec::new(),
+            )
+            .expect("rotated bindings");
+
+        let resolver = state
+            .resolver_for_endpoint("api.example.com", 443, "/v1")
+            .expect("resolver");
+        assert_eq!(
+            resolver.resolve_placeholder("openshell:resolve:env:v1_API_KEY"),
+            Some("old")
+        );
+        assert_eq!(
+            resolver.resolve_placeholder("openshell:resolve:env:v2_API_KEY"),
+            Some("new")
+        );
+    }
+
+    #[test]
+    fn replacing_provider_with_reused_key_purges_retained_generation() {
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            HashMap::from([("API_KEY".to_string(), "provider-a-secret".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([("API_KEY".to_string(), binding("a.example.com", 443, "/**"))]),
+            Vec::new(),
+        )
+        .expect("initial bindings");
+        let mut replacement_binding = binding("b.example.com", 443, "/**");
+        replacement_binding.credential_identity = "provider-b:API_KEY".to_string();
+
+        state
+            .install_bound_environment(
+                2,
+                HashMap::from([("API_KEY".to_string(), "provider-b-secret".to_string())]),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::from([("API_KEY".to_string(), replacement_binding)]),
+                Vec::new(),
+            )
+            .expect("replacement bindings");
+
+        let resolver = state
+            .resolver_for_endpoint("b.example.com", 443, "/v1")
+            .expect("resolver");
+        assert_eq!(
+            resolver.resolve_placeholder("openshell:resolve:env:v1_API_KEY"),
+            None,
+            "a placeholder issued by another provider identity must fail closed"
+        );
+    }
+
+    #[test]
+    fn detach_then_attach_with_reused_key_cannot_resolve_detached_secret() {
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            HashMap::from([("API_KEY".to_string(), "provider-a-secret".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([("API_KEY".to_string(), binding("a.example.com", 443, "/**"))]),
+            Vec::new(),
+        )
+        .expect("initial bindings");
+        state.revoke_static_provider_environment(2);
+
+        let mut replacement_binding = binding("b.example.com", 443, "/**");
+        replacement_binding.credential_identity = "provider-b:API_KEY".to_string();
+        state
+            .install_bound_environment(
+                3,
+                HashMap::from([("API_KEY".to_string(), "provider-b-secret".to_string())]),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::from([("API_KEY".to_string(), replacement_binding)]),
+                Vec::new(),
+            )
+            .expect("replacement bindings");
+
+        let resolver = state
+            .resolver_for_endpoint("b.example.com", 443, "/v1")
+            .expect("resolver");
+        assert_eq!(
+            resolver.resolve_placeholder("openshell:resolve:env:v1_API_KEY"),
+            None,
+            "a placeholder issued before detach must not resolve to a replacement provider"
+        );
     }
 
     #[test]

--- a/crates/openshell-core/src/provider_credentials.rs
+++ b/crates/openshell-core/src/provider_credentials.rs
@@ -5,6 +5,7 @@
 
 use crate::secrets::SecretResolver;
 use crate::{
+    endpoint_path::EndpointPathPattern,
     host_pattern::HostPattern,
     proto::{StaticCredentialBinding, StaticCredentialEndpointBinding},
 };
@@ -29,7 +30,7 @@ struct ProviderCredentialStateInner {
     combined_resolver: Option<Arc<SecretResolver>>,
     suppressed_keys: HashSet<String>,
     non_secret_environment_keys: HashSet<String>,
-    static_credential_bindings: HashMap<String, StaticCredentialBinding>,
+    static_credential_bindings: HashMap<String, CompiledStaticCredentialBinding>,
     known_static_credential_keys: HashSet<String>,
     static_credential_identity_epochs: HashMap<String, StaticCredentialIdentityEpoch>,
 }
@@ -38,6 +39,19 @@ struct ProviderCredentialStateInner {
 struct StaticCredentialIdentityEpoch {
     identity: String,
     revisions: HashSet<u64>,
+}
+
+#[derive(Debug, Clone)]
+struct CompiledStaticCredentialBinding {
+    endpoints: Vec<CompiledStaticCredentialEndpointBinding>,
+    credential_identity: String,
+}
+
+#[derive(Debug, Clone)]
+struct CompiledStaticCredentialEndpointBinding {
+    host: HostPattern,
+    port: u16,
+    path: EndpointPathPattern,
 }
 
 #[derive(Debug, Clone)]
@@ -103,9 +117,9 @@ impl ProviderCredentialState {
         static_credential_bindings: HashMap<String, StaticCredentialBinding>,
         non_secret_environment_keys: Vec<String>,
     ) -> Result<Self, StaticCredentialBindingError> {
-        validate_static_credential_bindings(
+        let static_credential_bindings = compile_static_credential_bindings(
             &env,
-            &static_credential_bindings,
+            static_credential_bindings,
             &non_secret_environment_keys,
         )?;
         let state =
@@ -236,13 +250,16 @@ impl ProviderCredentialState {
         port: u16,
         path: &str,
     ) -> (Option<Arc<SecretResolver>>, u64) {
+        let request_path = path.split_once('?').map_or(path, |(path, _)| path);
+        let request_path = crate::secrets::redact_target_for_policy(request_path);
+        let normalized_host = host.to_ascii_lowercase();
+        let host_labels = normalized_host.split('.').collect::<Vec<_>>();
         let inner = self
             .inner
             .read()
             .expect("provider credential state poisoned");
         let revision = inner.current.revision;
-        let request_path = path.split_once('?').map_or(path, |(path, _)| path);
-        let Ok(request_path) = crate::secrets::redact_target_for_policy(request_path) else {
+        let Ok(request_path) = request_path else {
             // Binding authorization must not depend on real credential
             // material. Malformed placeholder syntax cannot be normalized
             // safely, so expose no endpoint-scoped resolver.
@@ -253,7 +270,7 @@ impl ProviderCredentialState {
             .iter()
             .filter(|(_, binding)| {
                 binding.endpoints.iter().any(|endpoint| {
-                    static_credential_endpoint_matches(endpoint, host, port, &request_path)
+                    static_credential_endpoint_matches(endpoint, &host_labels, port, &request_path)
                 })
             })
             .map(|(key, _)| key.clone())
@@ -476,14 +493,17 @@ impl ProviderCredentialState {
         static_credential_bindings: HashMap<String, StaticCredentialBinding>,
         non_secret_environment_keys: Vec<String>,
     ) -> Result<usize, StaticCredentialBindingError> {
-        if let Err(error) = validate_static_credential_bindings(
+        let static_credential_bindings = match compile_static_credential_bindings(
             &env,
-            &static_credential_bindings,
+            static_credential_bindings,
             &non_secret_environment_keys,
         ) {
-            self.revoke_static_provider_environment_inner(revision, Some(dynamic_credentials));
-            return Err(error);
-        }
+            Ok(bindings) => bindings,
+            Err(error) => {
+                self.revoke_static_provider_environment_inner(revision, Some(dynamic_credentials));
+                return Err(error);
+            }
+        };
 
         let (mut child_env, generation_resolver, current_resolver) =
             SecretResolver::from_provider_env_for_current_revision(
@@ -568,11 +588,11 @@ impl ProviderCredentialState {
     }
 }
 
-fn validate_static_credential_bindings(
+fn compile_static_credential_bindings(
     env: &HashMap<String, String>,
-    bindings: &HashMap<String, StaticCredentialBinding>,
+    bindings: HashMap<String, StaticCredentialBinding>,
     non_secret_environment_keys: &[String],
-) -> Result<(), StaticCredentialBindingError> {
+) -> Result<HashMap<String, CompiledStaticCredentialBinding>, StaticCredentialBindingError> {
     let non_secret_keys = non_secret_environment_keys
         .iter()
         .cloned()
@@ -614,21 +634,48 @@ fn validate_static_credential_bindings(
             ));
         }
         for endpoint in &binding.endpoints {
-            if endpoint.port == 0
-                || endpoint.port > u32::from(u16::MAX)
-                || HostPattern::new(&endpoint.host).is_err()
-            {
+            if endpoint.port == 0 || endpoint.port > u32::from(u16::MAX) {
                 return Err(binding_error(
                     "static credential binding contains an invalid endpoint",
                 ));
             }
         }
     }
-    Ok(())
+
+    bindings
+        .into_iter()
+        .map(|(key, binding)| {
+            let endpoints = binding
+                .endpoints
+                .into_iter()
+                .map(compile_static_credential_endpoint)
+                .collect::<Result<_, _>>()?;
+            Ok((
+                key,
+                CompiledStaticCredentialBinding {
+                    endpoints,
+                    credential_identity: binding.credential_identity,
+                },
+            ))
+        })
+        .collect()
+}
+
+fn compile_static_credential_endpoint(
+    endpoint: StaticCredentialEndpointBinding,
+) -> Result<CompiledStaticCredentialEndpointBinding, StaticCredentialBindingError> {
+    let host = HostPattern::new(&endpoint.host)
+        .map_err(|_| binding_error("static credential binding contains an invalid endpoint"))?;
+    Ok(CompiledStaticCredentialEndpointBinding {
+        host,
+        port: u16::try_from(endpoint.port)
+            .map_err(|_| binding_error("static credential binding contains an invalid endpoint"))?,
+        path: EndpointPathPattern::new(&endpoint.path),
+    })
 }
 
 fn static_credential_identities(
-    bindings: &HashMap<String, StaticCredentialBinding>,
+    bindings: &HashMap<String, CompiledStaticCredentialBinding>,
 ) -> HashMap<&str, &str> {
     bindings
         .iter()
@@ -639,7 +686,7 @@ fn static_credential_identities(
 fn update_static_credential_identity_epochs(
     epochs: &mut HashMap<String, StaticCredentialIdentityEpoch>,
     revision: u64,
-    bindings: &HashMap<String, StaticCredentialBinding>,
+    bindings: &HashMap<String, CompiledStaticCredentialBinding>,
 ) {
     epochs.retain(|key, _| bindings.contains_key(key));
     for (key, binding) in bindings {
@@ -671,14 +718,14 @@ fn binding_error(message: &str) -> StaticCredentialBindingError {
 }
 
 fn static_credential_endpoint_matches(
-    endpoint: &StaticCredentialEndpointBinding,
-    host: &str,
+    endpoint: &CompiledStaticCredentialEndpointBinding,
+    host_labels: &[&str],
     port: u16,
     path: &str,
 ) -> bool {
-    endpoint.port == u32::from(port)
-        && HostPattern::new(&endpoint.host).is_ok_and(|pattern| pattern.matches(host))
-        && crate::endpoint_path::matches(&endpoint.path, path)
+    endpoint.port == port
+        && endpoint.host.matches_normalized_labels(host_labels)
+        && endpoint.path.matches(path)
 }
 
 fn merge_resolvers(
@@ -717,7 +764,7 @@ mod tests {
         expected: &str,
     ) {
         let error =
-            validate_static_credential_bindings(&env, &bindings, &non_secret_environment_keys)
+            compile_static_credential_bindings(&env, bindings, &non_secret_environment_keys)
                 .expect_err("malformed provider metadata must fail validation");
         assert_eq!(error.to_string(), expected);
     }
@@ -872,6 +919,52 @@ mod tests {
             None,
             "credential A must not resolve at endpoint B"
         );
+    }
+
+    #[test]
+    fn refresh_replaces_compiled_endpoint_patterns() {
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            HashMap::from([("API_KEY".to_string(), "old".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([(
+                "API_KEY".to_string(),
+                binding("old.example.com", 443, "/v1/**"),
+            )]),
+            Vec::new(),
+        )
+        .expect("initial bindings");
+
+        state
+            .install_bound_environment(
+                2,
+                HashMap::from([("API_KEY".to_string(), "new".to_string())]),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::from([(
+                    "API_KEY".to_string(),
+                    binding("new.example.com", 443, "/v2/**"),
+                )]),
+                Vec::new(),
+            )
+            .expect("replacement bindings");
+
+        let replacement = state
+            .resolver_for_endpoint("new.example.com", 443, "/v2/messages")
+            .expect("replacement endpoint resolver");
+        assert_eq!(
+            replacement.resolve_placeholder("openshell:resolve:env:v2_API_KEY"),
+            Some("new")
+        );
+
+        let removed = state
+            .resolver_for_endpoint("old.example.com", 443, "/v1/messages")
+            .expect("restricted resolver");
+        let error = removed
+            .rewrite_header_value("openshell:resolve:env:v2_API_KEY")
+            .expect_err("replaced endpoint binding must no longer authorize the credential");
+        assert!(error.is_endpoint_mismatch());
     }
 
     #[test]

--- a/crates/openshell-core/src/provider_credentials.rs
+++ b/crates/openshell-core/src/provider_credentials.rs
@@ -4,7 +4,12 @@
 //! Runtime provider credential snapshots.
 
 use crate::secrets::SecretResolver;
+use crate::{
+    host_pattern::HostPattern,
+    proto::{StaticCredentialBinding, StaticCredentialEndpointBinding},
+};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
 use std::sync::{Arc, RwLock};
 
 const MAX_RETAINED_CREDENTIAL_GENERATIONS: usize = 8;
@@ -23,12 +28,27 @@ struct ProviderCredentialStateInner {
     current_resolver: Option<Arc<SecretResolver>>,
     combined_resolver: Option<Arc<SecretResolver>>,
     suppressed_keys: HashSet<String>,
+    static_credential_bindings: HashMap<String, StaticCredentialBinding>,
+    known_static_credential_keys: HashSet<String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct ProviderCredentialState {
     inner: Arc<RwLock<ProviderCredentialStateInner>>,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StaticCredentialBindingError {
+    message: String,
+}
+
+impl fmt::Display for StaticCredentialBindingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for StaticCredentialBindingError {}
 
 impl ProviderCredentialState {
     pub fn from_environment(
@@ -59,8 +79,38 @@ impl ProviderCredentialState {
                 current_resolver,
                 combined_resolver,
                 suppressed_keys: HashSet::new(),
+                static_credential_bindings: HashMap::new(),
+                known_static_credential_keys: HashSet::new(),
             })),
         }
+    }
+
+    pub fn from_bound_environment(
+        revision: u64,
+        env: HashMap<String, String>,
+        credential_expires_at_ms: HashMap<String, i64>,
+        dynamic_credentials: HashMap<String, crate::proto::ProviderProfileCredential>,
+        static_credential_bindings: HashMap<String, StaticCredentialBinding>,
+        non_secret_environment_keys: Vec<String>,
+    ) -> Result<Self, StaticCredentialBindingError> {
+        validate_static_credential_bindings(
+            &env,
+            &static_credential_bindings,
+            &non_secret_environment_keys,
+        )?;
+        let state =
+            Self::from_environment(revision, env, credential_expires_at_ms, dynamic_credentials);
+        {
+            let mut inner = state
+                .inner
+                .write()
+                .expect("provider credential state poisoned");
+            inner
+                .known_static_credential_keys
+                .extend(static_credential_bindings.keys().cloned());
+            inner.static_credential_bindings = static_credential_bindings;
+        }
+        Ok(state)
     }
 
     /// Build a static provider state from an already-prepared child
@@ -85,6 +135,8 @@ impl ProviderCredentialState {
                 current_resolver: None,
                 combined_resolver: None,
                 suppressed_keys: HashSet::new(),
+                static_credential_bindings: HashMap::new(),
+                known_static_credential_keys: HashSet::new(),
             })),
         }
     }
@@ -117,6 +169,8 @@ impl ProviderCredentialState {
         inner.generations.clear();
         inner.current_resolver = None;
         inner.combined_resolver = None;
+        inner.static_credential_bindings.clear();
+        inner.known_static_credential_keys.clear();
         inner.current.child_env.len()
     }
 
@@ -134,6 +188,45 @@ impl ProviderCredentialState {
             .expect("provider credential state poisoned")
             .combined_resolver
             .clone()
+    }
+
+    /// Resolve provider placeholders only for credentials bound to this
+    /// concrete request endpoint. The view is created from one atomic state
+    /// snapshot and shares underlying resolver material.
+    #[must_use]
+    pub fn resolver_for_endpoint(
+        &self,
+        host: &str,
+        port: u16,
+        path: &str,
+    ) -> Option<Arc<SecretResolver>> {
+        let inner = self
+            .inner
+            .read()
+            .expect("provider credential state poisoned");
+        let request_path = path.split_once('?').map_or(path, |(path, _)| path);
+        let allowed = inner
+            .static_credential_bindings
+            .iter()
+            .filter(|(_, binding)| {
+                binding.endpoints.iter().any(|endpoint| {
+                    static_credential_endpoint_matches(endpoint, host, port, request_path)
+                })
+            })
+            .map(|(key, _)| key.clone())
+            .collect();
+        inner.combined_resolver.as_ref().map(|resolver| {
+            Arc::new(resolver.scoped_to_env_keys(&inner.known_static_credential_keys, &allowed))
+        })
+    }
+
+    #[must_use]
+    pub fn revision(&self) -> u64 {
+        self.inner
+            .read()
+            .expect("provider credential state poisoned")
+            .current
+            .revision
     }
 
     /// Remove a key from the credential snapshot's child env.
@@ -294,6 +387,160 @@ impl ProviderCredentialState {
             merge_resolvers(&inner.generations, inner.current_resolver.as_ref());
         inner.current.child_env.len()
     }
+
+    pub fn install_bound_environment(
+        &self,
+        revision: u64,
+        env: HashMap<String, String>,
+        credential_expires_at_ms: HashMap<String, i64>,
+        dynamic_credentials: HashMap<String, crate::proto::ProviderProfileCredential>,
+        static_credential_bindings: HashMap<String, StaticCredentialBinding>,
+        non_secret_environment_keys: Vec<String>,
+    ) -> Result<usize, StaticCredentialBindingError> {
+        if let Err(error) = validate_static_credential_bindings(
+            &env,
+            &static_credential_bindings,
+            &non_secret_environment_keys,
+        ) {
+            self.revoke_static_provider_environment_inner(revision, Some(dynamic_credentials));
+            return Err(error);
+        }
+
+        let (mut child_env, generation_resolver, current_resolver) =
+            SecretResolver::from_provider_env_for_current_revision(
+                env,
+                credential_expires_at_ms,
+                revision,
+            );
+        let mut inner = self
+            .inner
+            .write()
+            .expect("provider credential state poisoned");
+
+        for key in &inner.suppressed_keys {
+            child_env.remove(key);
+        }
+        inner.current = Arc::new(ProviderCredentialSnapshot {
+            revision,
+            child_env,
+            dynamic_credentials,
+        });
+        inner.current_resolver = current_resolver.map(Arc::new);
+        if let Some(resolver) = generation_resolver {
+            inner.generations.push_back(Arc::new(resolver));
+            while inner.generations.len() > MAX_RETAINED_CREDENTIAL_GENERATIONS {
+                inner.generations.pop_front();
+            }
+        }
+        inner.combined_resolver =
+            merge_resolvers(&inner.generations, inner.current_resolver.as_ref());
+        inner
+            .known_static_credential_keys
+            .extend(static_credential_bindings.keys().cloned());
+        inner.static_credential_bindings = static_credential_bindings;
+        Ok(inner.current.child_env.len())
+    }
+
+    /// Atomically remove static provider material after a failed refresh.
+    ///
+    /// Dynamic token grants retain their independently endpoint-bound state
+    /// unless the caller supplies a newer dynamic snapshot.
+    pub fn revoke_static_provider_environment(&self, revision: u64) {
+        self.revoke_static_provider_environment_inner(revision, None);
+    }
+
+    fn revoke_static_provider_environment_inner(
+        &self,
+        revision: u64,
+        dynamic_credentials: Option<HashMap<String, crate::proto::ProviderProfileCredential>>,
+    ) {
+        let mut inner = self
+            .inner
+            .write()
+            .expect("provider credential state poisoned");
+        let dynamic_credentials =
+            dynamic_credentials.unwrap_or_else(|| inner.current.dynamic_credentials.clone());
+        inner.current = Arc::new(ProviderCredentialSnapshot {
+            revision,
+            child_env: HashMap::new(),
+            dynamic_credentials,
+        });
+        inner.generations.clear();
+        inner.current_resolver = None;
+        inner.combined_resolver = None;
+        inner.static_credential_bindings.clear();
+    }
+}
+
+fn validate_static_credential_bindings(
+    env: &HashMap<String, String>,
+    bindings: &HashMap<String, StaticCredentialBinding>,
+    non_secret_environment_keys: &[String],
+) -> Result<(), StaticCredentialBindingError> {
+    let non_secret_keys = non_secret_environment_keys
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    if non_secret_keys.len() != non_secret_environment_keys.len() {
+        return Err(binding_error(
+            "provider environment repeats a non-secret environment key",
+        ));
+    }
+    if bindings.keys().any(|key| non_secret_keys.contains(key)) {
+        return Err(binding_error(
+            "provider environment classifies a key as both credential and non-secret configuration",
+        ));
+    }
+    if env
+        .keys()
+        .any(|key| !bindings.contains_key(key) && !non_secret_keys.contains(key))
+    {
+        return Err(binding_error(
+            "provider environment contains an unclassified credential key",
+        ));
+    }
+    if bindings.keys().any(|key| !env.contains_key(key))
+        || non_secret_keys.iter().any(|key| !env.contains_key(key))
+    {
+        return Err(binding_error(
+            "provider environment metadata references a missing environment key",
+        ));
+    }
+    for binding in bindings.values() {
+        if binding.endpoints.is_empty() {
+            return Err(binding_error(
+                "static credential binding has no authorized endpoints",
+            ));
+        }
+        for endpoint in &binding.endpoints {
+            if endpoint.port == 0
+                || endpoint.port > u32::from(u16::MAX)
+                || HostPattern::new(&endpoint.host).is_err()
+            {
+                return Err(binding_error(
+                    "static credential binding contains an invalid endpoint",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn binding_error(message: &str) -> StaticCredentialBindingError {
+    StaticCredentialBindingError {
+        message: message.to_string(),
+    }
+}
+
+fn static_credential_endpoint_matches(
+    endpoint: &StaticCredentialEndpointBinding,
+    host: &str,
+    port: u16,
+    path: &str,
+) -> bool {
+    endpoint.port == u32::from(port)
+        && HostPattern::new(&endpoint.host).is_ok_and(|pattern| pattern.matches(host))
+        && crate::endpoint_path::matches(&endpoint.path, path)
 }
 
 fn merge_resolvers(
@@ -313,6 +560,100 @@ fn merge_resolvers(
 mod tests {
     use super::*;
     use crate::google_cloud;
+
+    fn binding(host: &str, port: u32, path: &str) -> StaticCredentialBinding {
+        StaticCredentialBinding {
+            endpoints: vec![StaticCredentialEndpointBinding {
+                host: host.to_string(),
+                port,
+                path: path.to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn bound_credentials_resolve_only_at_matching_endpoint() {
+        let state = ProviderCredentialState::from_bound_environment(
+            7,
+            HashMap::from([("API_KEY".to_string(), "secret".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([(
+                "API_KEY".to_string(),
+                binding("*.example.com", 443, "/v1/**"),
+            )]),
+            Vec::new(),
+        )
+        .expect("valid bindings");
+        let placeholder = "openshell:resolve:env:v7_API_KEY";
+
+        let allowed = state
+            .resolver_for_endpoint("api.example.com", 443, "/v1/messages?stream=true")
+            .expect("resolver");
+        assert_eq!(allowed.resolve_placeholder(placeholder), Some("secret"));
+
+        for (host, port, path) in [
+            ("example.com", 443, "/v1/messages"),
+            ("api.example.com", 80, "/v1/messages"),
+            ("api.example.com", 443, "/v2/messages"),
+        ] {
+            let denied = state
+                .resolver_for_endpoint(host, port, path)
+                .expect("resolver");
+            let error = denied
+                .rewrite_header_value(placeholder)
+                .expect_err("endpoint mismatch must fail closed");
+            assert!(error.is_endpoint_mismatch(), "{host}:{port}{path}");
+        }
+    }
+
+    #[test]
+    fn non_secret_provider_config_is_not_endpoint_scoped() {
+        let state = ProviderCredentialState::from_bound_environment(
+            3,
+            HashMap::from([("GCP_PROJECT_ID".to_string(), "project".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            vec!["GCP_PROJECT_ID".to_string()],
+        )
+        .expect("classified non-secret environment");
+        let resolver = state
+            .resolver_for_endpoint("unrelated.example", 1234, "/")
+            .expect("resolver");
+        assert_eq!(
+            resolver.resolve_placeholder("openshell:resolve:env:v3_GCP_PROJECT_ID"),
+            Some("project")
+        );
+    }
+
+    #[test]
+    fn incomplete_refresh_revokes_previous_credentials_atomically() {
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            HashMap::from([("API_KEY".to_string(), "old".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([(
+                "API_KEY".to_string(),
+                binding("api.example.com", 443, "/**"),
+            )]),
+            Vec::new(),
+        )
+        .expect("initial bindings");
+
+        let result = state.install_bound_environment(
+            2,
+            HashMap::from([("API_KEY".to_string(), "new".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            Vec::new(),
+        );
+        assert!(result.is_err());
+        assert!(state.snapshot().child_env.is_empty());
+        assert!(state.resolver().is_none());
+    }
 
     #[test]
     fn snapshots_use_revision_scoped_placeholders() {

--- a/crates/openshell-core/src/provider_credentials.rs
+++ b/crates/openshell-core/src/provider_credentials.rs
@@ -389,9 +389,15 @@ impl ProviderCredentialState {
     /// expired. The `expires_in` defaults to 3600 when expiry is unknown.
     pub fn gcp_token_response(&self) -> Option<(String, i64)> {
         const DEFAULT_EXPIRES_IN: i64 = 3600;
-        let resolver = self.resolver()?;
+        let inner = self
+            .inner
+            .read()
+            .expect("provider credential state poisoned");
+        let resolver = inner.current_resolver.as_ref()?;
         for key in crate::google_cloud::TOKEN_ENV_KEYS {
-            let placeholder = crate::secrets::placeholder_for_env_key(key);
+            let Some(placeholder) = inner.current.child_env.get(*key).cloned() else {
+                continue;
+            };
             if resolver.resolve_placeholder(&placeholder).is_none() {
                 continue;
             }
@@ -1395,9 +1401,9 @@ mod tests {
             HashMap::new(),
         );
         let (placeholder, _) = state.gcp_token_response().expect("should find token");
-        assert!(
-            placeholder.contains("GCP_SA_ACCESS_TOKEN"),
-            "SA token should win over ADC, got: {placeholder}"
+        assert_eq!(
+            placeholder, "openshell:resolve:env:v1_GCP_SA_ACCESS_TOKEN",
+            "metadata must return the current revision-scoped SA placeholder"
         );
     }
 
@@ -1410,7 +1416,10 @@ mod tests {
             HashMap::new(),
         );
         let (placeholder, _) = state.gcp_token_response().expect("should find ADC token");
-        assert!(placeholder.contains("GCP_ADC_ACCESS_TOKEN"));
+        assert_eq!(
+            placeholder, "openshell:resolve:env:v1_GCP_ADC_ACCESS_TOKEN",
+            "metadata must return the current revision-scoped ADC placeholder"
+        );
     }
 
     #[test]

--- a/crates/openshell-core/src/provider_credentials.rs
+++ b/crates/openshell-core/src/provider_credentials.rs
@@ -38,7 +38,7 @@ struct ProviderCredentialStateInner {
 #[derive(Debug)]
 struct StaticCredentialIdentityEpoch {
     identity: String,
-    revisions: HashSet<u64>,
+    revisions: Arc<HashSet<u64>>,
 }
 
 #[derive(Debug, Clone)]
@@ -692,18 +692,18 @@ fn update_static_credential_identity_epochs(
     for (key, binding) in bindings {
         match epochs.get_mut(key) {
             Some(epoch) if epoch.identity == binding.credential_identity => {
-                epoch.revisions.insert(revision);
+                Arc::make_mut(&mut epoch.revisions).insert(revision);
             }
             Some(epoch) => {
                 epoch.identity.clone_from(&binding.credential_identity);
-                epoch.revisions = HashSet::from([revision]);
+                epoch.revisions = Arc::new(HashSet::from([revision]));
             }
             None => {
                 epochs.insert(
                     key.clone(),
                     StaticCredentialIdentityEpoch {
                         identity: binding.credential_identity.clone(),
-                        revisions: HashSet::from([revision]),
+                        revisions: Arc::new(HashSet::from([revision])),
                     },
                 );
             }

--- a/crates/openshell-core/src/provider_credentials.rs
+++ b/crates/openshell-core/src/provider_credentials.rs
@@ -220,22 +220,45 @@ impl ProviderCredentialState {
         port: u16,
         path: &str,
     ) -> Option<Arc<SecretResolver>> {
+        self.resolver_for_endpoint_with_revision(host, port, path).0
+    }
+
+    /// Resolve provider placeholders for one endpoint and return the provider
+    /// revision observed from the same locked state snapshot.
+    ///
+    /// Callers that materialize credential-bearing requests asynchronously
+    /// use the revision to reject stale material immediately before its first
+    /// upstream write.
+    #[must_use]
+    pub fn resolver_for_endpoint_with_revision(
+        &self,
+        host: &str,
+        port: u16,
+        path: &str,
+    ) -> (Option<Arc<SecretResolver>>, u64) {
         let inner = self
             .inner
             .read()
             .expect("provider credential state poisoned");
+        let revision = inner.current.revision;
         let request_path = path.split_once('?').map_or(path, |(path, _)| path);
+        let Ok(request_path) = crate::secrets::redact_target_for_policy(request_path) else {
+            // Binding authorization must not depend on real credential
+            // material. Malformed placeholder syntax cannot be normalized
+            // safely, so expose no endpoint-scoped resolver.
+            return (None, revision);
+        };
         let allowed: HashSet<String> = inner
             .static_credential_bindings
             .iter()
             .filter(|(_, binding)| {
                 binding.endpoints.iter().any(|endpoint| {
-                    static_credential_endpoint_matches(endpoint, host, port, request_path)
+                    static_credential_endpoint_matches(endpoint, host, port, &request_path)
                 })
             })
             .map(|(key, _)| key.clone())
             .collect();
-        inner.combined_resolver.as_ref().map(|resolver| {
+        let resolver = inner.combined_resolver.as_ref().map(|resolver| {
             let revision_fallback_allowed_revisions = inner
                 .static_credential_identity_epochs
                 .iter()
@@ -253,7 +276,8 @@ impl ProviderCredentialState {
                 &allowed,
                 revision_fallback_allowed_revisions,
             ))
-        })
+        });
+        (resolver, revision)
     }
 
     #[must_use]
@@ -498,7 +522,12 @@ impl ProviderCredentialState {
     /// Atomically remove static provider material after a failed refresh.
     ///
     /// Dynamic token grants retain their independently endpoint-bound state
-    /// unless the caller supplies a newer dynamic snapshot.
+    /// unless the caller supplies a newer dynamic snapshot. Identity-only
+    /// revision membership remains as a tombstone so a later successful
+    /// refresh can restore placeholders issued by the same provider identity.
+    /// With no resolver or active bindings, the tombstone cannot resolve
+    /// credentials while the refresh is failed. A successful empty provider
+    /// environment removes it through the normal epoch update path.
     pub fn revoke_static_provider_environment(&self, revision: u64) {
         self.revoke_static_provider_environment_inner(revision, None);
     }
@@ -524,7 +553,6 @@ impl ProviderCredentialState {
         inner.combined_resolver = None;
         inner.non_secret_environment_keys.clear();
         inner.static_credential_bindings.clear();
-        inner.static_credential_identity_epochs.clear();
     }
 }
 
@@ -707,6 +735,87 @@ mod tests {
     }
 
     #[test]
+    fn revisioned_path_placeholder_matches_exact_redacted_binding() {
+        let state = ProviderCredentialState::from_bound_environment(
+            7,
+            HashMap::from([("API_KEY".to_string(), "secret".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([(
+                "API_KEY".to_string(),
+                binding("api.example.com", 443, "/bot[CREDENTIAL]/sendMessage"),
+            )]),
+            Vec::new(),
+        )
+        .expect("valid bindings");
+        let placeholder = "openshell:resolve:env:v7_API_KEY";
+
+        let resolver = state
+            .resolver_for_endpoint(
+                "api.example.com",
+                443,
+                &format!("/bot{placeholder}/sendMessage?stream=true"),
+            )
+            .expect("syntax-redacted path should select the binding");
+        assert_eq!(resolver.resolve_placeholder(placeholder), Some("secret"));
+    }
+
+    #[test]
+    fn provider_alias_path_placeholder_matches_glob_redacted_binding() {
+        let state = ProviderCredentialState::from_bound_environment(
+            7,
+            HashMap::from([("API_KEY".to_string(), "secret".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([(
+                "API_KEY".to_string(),
+                binding("api.example.com", 443, "/v1/*/messages"),
+            )]),
+            Vec::new(),
+        )
+        .expect("valid bindings");
+
+        let resolver = state
+            .resolver_for_endpoint(
+                "api.example.com",
+                443,
+                "/v1/vendor-OPENSHELL-RESOLVE-ENV-API_KEY/messages",
+            )
+            .expect("syntax-redacted alias path should select the binding");
+        assert_eq!(
+            resolver.resolve_placeholder("openshell:resolve:env:v7_API_KEY"),
+            Some("secret")
+        );
+    }
+
+    #[test]
+    fn malformed_path_placeholder_exposes_no_endpoint_resolver() {
+        let state = ProviderCredentialState::from_bound_environment(
+            7,
+            HashMap::from([("API_KEY".to_string(), "secret".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([(
+                "API_KEY".to_string(),
+                binding("api.example.com", 443, "/**"),
+            )]),
+            Vec::new(),
+        )
+        .expect("valid bindings");
+
+        assert!(
+            state
+                .resolver_for_endpoint(
+                    "api.example.com",
+                    443,
+                    "/v1/openshell:resolve:env:/messages",
+                )
+                .is_none(),
+            "malformed placeholder syntax must fail closed before path matching"
+        );
+    }
+
+    #[test]
     fn non_secret_provider_config_is_not_endpoint_scoped() {
         let state = ProviderCredentialState::from_bound_environment(
             3,
@@ -757,6 +866,81 @@ mod tests {
         assert!(state.snapshot().child_env.is_empty());
         assert!(state.resolver().is_none());
         assert!(state.snapshot().dynamic_credentials.contains_key("dynamic"));
+
+        state
+            .install_bound_environment(
+                3,
+                HashMap::from([("API_KEY".to_string(), "recovered".to_string())]),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::from([(
+                    "API_KEY".to_string(),
+                    binding("api.example.com", 443, "/**"),
+                )]),
+                Vec::new(),
+            )
+            .expect("same-identity recovery");
+
+        let resolver = state
+            .resolver_for_endpoint("api.example.com", 443, "/v1")
+            .expect("resolver");
+        assert_eq!(
+            resolver.resolve_placeholder("openshell:resolve:env:v1_API_KEY"),
+            Some("recovered"),
+            "a metadata failure must not permanently strand placeholders from the same provider identity"
+        );
+    }
+
+    #[test]
+    fn failed_fetch_revokes_secrets_then_same_identity_retry_recovers_running_placeholder() {
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            HashMap::from([("API_KEY".to_string(), "old".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([(
+                "API_KEY".to_string(),
+                binding("api.example.com", 443, "/**"),
+            )]),
+            Vec::new(),
+        )
+        .expect("initial bindings");
+
+        state.revoke_static_provider_environment(2);
+
+        assert!(
+            state.resolver().is_none(),
+            "no static secret resolver may remain active during the failed refresh"
+        );
+        assert!(
+            state
+                .resolver_for_endpoint("api.example.com", 443, "/v1")
+                .is_none(),
+            "an identity tombstone must not authorize requests without active bindings and secrets"
+        );
+
+        state
+            .install_bound_environment(
+                3,
+                HashMap::from([("API_KEY".to_string(), "new".to_string())]),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::from([(
+                    "API_KEY".to_string(),
+                    binding("api.example.com", 443, "/**"),
+                )]),
+                Vec::new(),
+            )
+            .expect("same-identity retry");
+
+        let resolver = state
+            .resolver_for_endpoint("api.example.com", 443, "/v1")
+            .expect("resolver");
+        assert_eq!(
+            resolver.resolve_placeholder("openshell:resolve:env:v1_API_KEY"),
+            Some("new"),
+            "the running process placeholder should recover against the current same-identity secret"
+        );
     }
 
     #[test]
@@ -895,7 +1079,7 @@ mod tests {
     }
 
     #[test]
-    fn detach_then_attach_with_reused_key_cannot_resolve_detached_secret() {
+    fn failed_refresh_then_replacement_with_reused_key_rejects_old_placeholder() {
         let state = ProviderCredentialState::from_bound_environment(
             1,
             HashMap::from([("API_KEY".to_string(), "provider-a-secret".to_string())]),
@@ -931,12 +1115,60 @@ mod tests {
         assert_eq!(
             resolver.resolve_placeholder("openshell:resolve:env:API_KEY"),
             None,
-            "an identityless canonical placeholder must not cross detach and reattach"
+            "an identityless canonical placeholder must not cross a failed refresh into a replacement identity"
         );
         assert_eq!(
             resolver.resolve_placeholder("vendor-OPENSHELL-RESOLVE-ENV-API_KEY"),
             None,
-            "an identityless provider alias must not cross detach and reattach"
+            "an identityless provider alias must not cross a failed refresh into a replacement identity"
+        );
+    }
+
+    #[test]
+    fn successful_empty_environment_clears_failed_refresh_identity_tombstones() {
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            HashMap::from([("API_KEY".to_string(), "provider-a-secret".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([("API_KEY".to_string(), binding("a.example.com", 443, "/**"))]),
+            Vec::new(),
+        )
+        .expect("initial bindings");
+
+        state.revoke_static_provider_environment(2);
+        state
+            .install_bound_environment(
+                3,
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+                Vec::new(),
+            )
+            .expect("successful detached environment");
+        state
+            .install_bound_environment(
+                4,
+                HashMap::from([("API_KEY".to_string(), "reattached".to_string())]),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::from([("API_KEY".to_string(), binding("a.example.com", 443, "/**"))]),
+                Vec::new(),
+            )
+            .expect("reattached environment");
+
+        let resolver = state
+            .resolver_for_endpoint("a.example.com", 443, "/v1")
+            .expect("resolver");
+        assert_eq!(
+            resolver.resolve_placeholder("openshell:resolve:env:v1_API_KEY"),
+            None,
+            "a successful empty environment represents detach and must invalidate old membership"
+        );
+        assert_eq!(
+            resolver.resolve_placeholder("openshell:resolve:env:v4_API_KEY"),
+            Some("reattached")
         );
     }
 

--- a/crates/openshell-core/src/secrets.rs
+++ b/crates/openshell-core/src/secrets.rs
@@ -123,7 +123,7 @@ pub struct SecretResolver {
     by_placeholder: HashMap<String, SecretValue>,
     denied_env_keys: HashSet<String>,
     identity_bound_env_keys: HashSet<String>,
-    revision_fallback_allowed_revisions: HashMap<String, HashSet<u64>>,
+    revision_fallback_allowed_revisions: HashMap<String, Arc<HashSet<u64>>>,
 }
 
 #[derive(Clone)]
@@ -286,7 +286,7 @@ impl SecretResolver {
         &self,
         bound_keys: &HashSet<String>,
         allowed_bound_keys: &HashSet<String>,
-        revision_fallback_allowed_revisions: HashMap<String, HashSet<u64>>,
+        revision_fallback_allowed_revisions: HashMap<String, Arc<HashSet<u64>>>,
     ) -> Self {
         let denied_env_keys = bound_keys
             .difference(allowed_bound_keys)

--- a/crates/openshell-core/src/secrets.rs
+++ b/crates/openshell-core/src/secrets.rs
@@ -42,7 +42,7 @@ pub fn contains_reserved_credential_marker(value: &str) -> bool {
 
 /// Error returned when a placeholder cannot be resolved or a resolved secret
 /// contains prohibited characters.
-#[derive(Debug)]
+#[derive(Debug, miette::Diagnostic)]
 pub struct UnresolvedPlaceholderError {
     pub location: &'static str, // "header", "query_param", "path"
     reason: UnresolvedPlaceholderReason,
@@ -82,6 +82,8 @@ impl fmt::Display for UnresolvedPlaceholderError {
     }
 }
 
+impl std::error::Error for UnresolvedPlaceholderError {}
+
 fn unresolved(location: &'static str) -> UnresolvedPlaceholderError {
     UnresolvedPlaceholderError {
         location,
@@ -120,6 +122,7 @@ pub struct RewriteTargetResult {
 pub struct SecretResolver {
     by_placeholder: HashMap<String, SecretValue>,
     denied_env_keys: std::collections::HashSet<String>,
+    no_revision_fallback_env_keys: std::collections::HashSet<String>,
 }
 
 #[derive(Clone)]
@@ -241,6 +244,7 @@ impl SecretResolver {
                 Some(Self {
                     by_placeholder,
                     denied_env_keys: std::collections::HashSet::new(),
+                    no_revision_fallback_env_keys: std::collections::HashSet::new(),
                 }),
             )
         }
@@ -249,9 +253,12 @@ impl SecretResolver {
     pub fn merge<'a>(resolvers: impl IntoIterator<Item = &'a Self>) -> Option<Self> {
         let mut by_placeholder = HashMap::new();
         let mut denied_env_keys = std::collections::HashSet::new();
+        let mut no_revision_fallback_env_keys = std::collections::HashSet::new();
         for resolver in resolvers {
             by_placeholder.extend(resolver.by_placeholder.clone());
             denied_env_keys.extend(resolver.denied_env_keys.iter().cloned());
+            no_revision_fallback_env_keys
+                .extend(resolver.no_revision_fallback_env_keys.iter().cloned());
         }
         if by_placeholder.is_empty() {
             None
@@ -259,6 +266,7 @@ impl SecretResolver {
             Some(Self {
                 by_placeholder,
                 denied_env_keys,
+                no_revision_fallback_env_keys,
             })
         }
     }
@@ -289,6 +297,7 @@ impl SecretResolver {
         Self {
             by_placeholder,
             denied_env_keys,
+            no_revision_fallback_env_keys: bound_keys.clone(),
         }
     }
 
@@ -318,7 +327,15 @@ impl SecretResolver {
             // Once an old generation ages out, the revision number is only a
             // namespace marker. Fall back by key to the current credential so
             // long-running child processes survive provider credential refresh.
+            // Endpoint-bound credentials are the exception: a revision belongs
+            // to one provider identity, so falling back by key after replacement
+            // would let the old process obtain the replacement provider's secret.
             let key = revisioned_placeholder_env_key(value).or_else(|| alias_env_key(value))?;
+            if revisioned_placeholder_env_key(value).is_some()
+                && self.no_revision_fallback_env_keys.contains(key)
+            {
+                return None;
+            }
             let canonical = placeholder_for_env_key(key);
             self.by_placeholder.get(&canonical)?
         };
@@ -340,6 +357,25 @@ impl SecretResolver {
                 None
             }
         }
+    }
+
+    /// Resolve a placeholder while preserving endpoint-denial information.
+    ///
+    /// `None` means the credential is genuinely unavailable. An endpoint-bound
+    /// key denied by the scoped resolver returns a typed mismatch so callers
+    /// can emit the security denial instead of treating it as missing config.
+    pub fn resolve_placeholder_checked(
+        &self,
+        value: &str,
+        location: &'static str,
+    ) -> Result<Option<&str>, UnresolvedPlaceholderError> {
+        if placeholder_env_key(value).is_some_and(|key| self.denied_env_keys.contains(key)) {
+            return Err(UnresolvedPlaceholderError {
+                location,
+                reason: UnresolvedPlaceholderReason::EndpointMismatch,
+            });
+        }
+        Ok(self.resolve_placeholder(value))
     }
 
     pub fn expires_at_ms_for_placeholder(&self, placeholder: &str) -> Option<i64> {

--- a/crates/openshell-core/src/secrets.rs
+++ b/crates/openshell-core/src/secrets.rs
@@ -5,6 +5,7 @@ use crate::time::now_ms;
 use base64::Engine as _;
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::Arc;
 
 const PLACEHOLDER_PREFIX: &str = "openshell:resolve:env:";
 const PROVIDER_ALIAS_MARKER: &str = "OPENSHELL-RESOLVE-ENV-";
@@ -44,15 +45,47 @@ pub fn contains_reserved_credential_marker(value: &str) -> bool {
 #[derive(Debug)]
 pub struct UnresolvedPlaceholderError {
     pub location: &'static str, // "header", "query_param", "path"
+    reason: UnresolvedPlaceholderReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UnresolvedPlaceholderReason {
+    Unavailable,
+    EndpointMismatch,
+}
+
+impl UnresolvedPlaceholderError {
+    #[must_use]
+    pub fn unavailable(location: &'static str) -> Self {
+        unresolved(location)
+    }
+
+    #[must_use]
+    pub fn is_endpoint_mismatch(&self) -> bool {
+        self.reason == UnresolvedPlaceholderReason::EndpointMismatch
+    }
 }
 
 impl fmt::Display for UnresolvedPlaceholderError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "unresolved credential placeholder in {}: detected reserved credential token that could not be resolved",
-            self.location
+            "{} in {}",
+            match self.reason {
+                UnresolvedPlaceholderReason::Unavailable =>
+                    "credential placeholder could not be resolved",
+                UnresolvedPlaceholderReason::EndpointMismatch =>
+                    "credential is not authorized for the request endpoint",
+            },
+            self.location,
         )
+    }
+}
+
+fn unresolved(location: &'static str) -> UnresolvedPlaceholderError {
+    UnresolvedPlaceholderError {
+        location,
+        reason: UnresolvedPlaceholderReason::Unavailable,
     }
 }
 
@@ -86,11 +119,12 @@ pub struct RewriteTargetResult {
 #[derive(Clone, Default)]
 pub struct SecretResolver {
     by_placeholder: HashMap<String, SecretValue>,
+    denied_env_keys: std::collections::HashSet<String>,
 }
 
 #[derive(Clone)]
 struct SecretValue {
-    value: String,
+    value: Arc<str>,
     expires_at_ms: i64,
 }
 
@@ -186,7 +220,7 @@ impl SecretResolver {
             }
             let placeholder = placeholder_for_env_key_for_revision(&key, revision);
             let secret = SecretValue {
-                value,
+                value: Arc::from(value),
                 expires_at_ms: credential_expires_at_ms
                     .get(&key)
                     .copied()
@@ -202,20 +236,75 @@ impl SecretResolver {
         if by_placeholder.is_empty() {
             (child_env, None)
         } else {
-            (child_env, Some(Self { by_placeholder }))
+            (
+                child_env,
+                Some(Self {
+                    by_placeholder,
+                    denied_env_keys: std::collections::HashSet::new(),
+                }),
+            )
         }
     }
 
     pub fn merge<'a>(resolvers: impl IntoIterator<Item = &'a Self>) -> Option<Self> {
         let mut by_placeholder = HashMap::new();
+        let mut denied_env_keys = std::collections::HashSet::new();
         for resolver in resolvers {
             by_placeholder.extend(resolver.by_placeholder.clone());
+            denied_env_keys.extend(resolver.denied_env_keys.iter().cloned());
         }
         if by_placeholder.is_empty() {
             None
         } else {
-            Some(Self { by_placeholder })
+            Some(Self {
+                by_placeholder,
+                denied_env_keys,
+            })
         }
+    }
+
+    /// Return a cheap endpoint-scoped resolver view.
+    ///
+    /// Secret strings are shared through cloned resolver entries. Credential
+    /// keys listed in `bound_keys` resolve only when also present in
+    /// `allowed_bound_keys`; unbound provider configuration remains available.
+    #[must_use]
+    pub fn scoped_to_env_keys(
+        &self,
+        bound_keys: &std::collections::HashSet<String>,
+        allowed_bound_keys: &std::collections::HashSet<String>,
+    ) -> Self {
+        let denied_env_keys = bound_keys
+            .difference(allowed_bound_keys)
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        let by_placeholder = self
+            .by_placeholder
+            .iter()
+            .filter(|(placeholder, _)| {
+                placeholder_env_key(placeholder).is_none_or(|key| !denied_env_keys.contains(key))
+            })
+            .map(|(placeholder, secret)| (placeholder.clone(), secret.clone()))
+            .collect();
+        Self {
+            by_placeholder,
+            denied_env_keys,
+        }
+    }
+
+    fn unresolved_for(
+        &self,
+        location: &'static str,
+        placeholder: &str,
+    ) -> UnresolvedPlaceholderError {
+        let reason = if placeholder_env_key(placeholder)
+            .is_some_and(|key| self.denied_env_keys.contains(key))
+        {
+            UnresolvedPlaceholderReason::EndpointMismatch
+        } else {
+            UnresolvedPlaceholderReason::Unavailable
+        };
+        UnresolvedPlaceholderError { location, reason }
     }
 
     /// Resolve a placeholder string to the real secret value.
@@ -240,7 +329,7 @@ impl SecretResolver {
             );
             return None;
         }
-        match validate_resolved_secret(&secret.value) {
+        match validate_resolved_secret(secret.value.as_ref()) {
             Ok(s) => Some(s),
             Err(reason) => {
                 tracing::warn!(
@@ -284,7 +373,7 @@ impl SecretResolver {
         // Prefixed placeholder: `Bearer openshell:resolve:env:KEY`
         let Some(split_at) = trimmed.find(char::is_whitespace) else {
             if contains_reserved_credential_marker(trimmed) {
-                return Err(UnresolvedPlaceholderError { location: "header" });
+                return Err(self.unresolved_for("header", trimmed));
             }
             return Ok(None);
         };
@@ -295,7 +384,7 @@ impl SecretResolver {
         }
 
         if contains_reserved_credential_marker(candidate) {
-            return Err(UnresolvedPlaceholderError { location: "header" });
+            return Err(self.unresolved_for("header", candidate));
         }
 
         Ok(None)
@@ -329,10 +418,10 @@ impl SecretResolver {
 
             if text[abs_start..].starts_with(PLACEHOLDER_PREFIX) {
                 let Some((token_end, token)) = self.credential_token_at(text, abs_start) else {
-                    return Err(UnresolvedPlaceholderError { location });
+                    return Err(unresolved(location));
                 };
                 let Some(secret) = self.resolve_placeholder(token) else {
-                    return Err(UnresolvedPlaceholderError { location });
+                    return Err(self.unresolved_for(location, token));
                 };
                 rewritten.push_str(secret);
                 replacements += 1;
@@ -342,7 +431,7 @@ impl SecretResolver {
 
             if let Some((token_end, token)) = alias_token_at(text, abs_start) {
                 let Some(secret) = self.resolve_placeholder(token) else {
-                    return Err(UnresolvedPlaceholderError { location });
+                    return Err(self.unresolved_for(location, token));
                 };
                 rewritten.push_str(secret);
                 replacements += 1;
@@ -350,11 +439,11 @@ impl SecretResolver {
                 continue;
             }
 
-            return Err(UnresolvedPlaceholderError { location });
+            return Err(unresolved(location));
         }
 
         if contains_raw_reserved_marker(&rewritten) {
-            return Err(UnresolvedPlaceholderError { location });
+            return Err(unresolved(location));
         }
 
         *text = rewritten;
@@ -493,6 +582,12 @@ fn revisioned_placeholder_env_key(token: &str) -> Option<&str> {
     let suffix = token.strip_prefix(PLACEHOLDER_PREFIX)?;
     let (_, key) = split_revisioned_env_key(suffix)?;
     Some(key)
+}
+
+fn placeholder_env_key(token: &str) -> Option<&str> {
+    revisioned_placeholder_env_key(token)
+        .or_else(|| token.strip_prefix(PLACEHOLDER_PREFIX))
+        .or_else(|| alias_env_key(token))
 }
 
 pub fn uses_reserved_revision_namespace(key: &str) -> bool {
@@ -836,7 +931,7 @@ fn rewrite_path_segment(
             let Some((token_end, full_placeholder)) = canonical_token_at(segment, abs_start)
                 .or_else(|| alias_token_at(segment, abs_start))
             else {
-                return Err(UnresolvedPlaceholderError { location: "path" });
+                return Err(unresolved("path"));
             };
             if let Some(secret) = resolver.resolve_placeholder(full_placeholder) {
                 validate_credential_for_path(secret).map_err(|reason| {
@@ -845,12 +940,12 @@ fn rewrite_path_segment(
                         %reason,
                         "credential resolution rejected: resolved value unsafe for path"
                     );
-                    UnresolvedPlaceholderError { location: "path" }
+                    unresolved("path")
                 })?;
                 resolved.push_str(secret);
                 redacted.push_str("[CREDENTIAL]");
             } else {
-                return Err(UnresolvedPlaceholderError { location: "path" });
+                return Err(resolver.unresolved_for("path", full_placeholder));
             }
             pos = token_end;
         } else {
@@ -887,9 +982,7 @@ fn rewrite_uri_query_params(
                 let replacements =
                     resolver.rewrite_text_placeholders(&mut rewritten, "query_param")?;
                 if replacements == 0 || contains_raw_reserved_marker(&rewritten) {
-                    return Err(UnresolvedPlaceholderError {
-                        location: "query_param",
-                    });
+                    return Err(unresolved("query_param"));
                 }
                 resolved_params.push(format!("{key}={}", percent_encode_query(&rewritten)));
                 redacted_params.push(format!("{key}=[CREDENTIAL]"));
@@ -941,7 +1034,7 @@ pub fn rewrite_http_header_block(
             .map_or(raw.len(), |p| raw.len().min(p + 4 + 256));
         let header_region = String::from_utf8_lossy(&raw[..scan_end]);
         if contains_reserved_credential_marker(&header_region) {
-            return Err(UnresolvedPlaceholderError { location: "header" });
+            return Err(unresolved("header"));
         }
         return Ok(RewriteResult {
             rewritten: raw.to_vec(),
@@ -988,7 +1081,7 @@ pub fn rewrite_http_header_block(
     // provider-shaped aliases in both raw and percent-decoded header bytes.
     let output_header = String::from_utf8_lossy(&output[..output.len().min(header_end + 256)]);
     if contains_reserved_credential_marker(&output_header) {
-        return Err(UnresolvedPlaceholderError { location: "header" });
+        return Err(unresolved("header"));
     }
 
     Ok(RewriteResult {
@@ -1064,6 +1157,48 @@ pub fn rewrite_target_for_eval(
     };
 
     Ok(RewriteTargetResult { resolved, redacted })
+}
+
+/// Produce the policy/logging representation of a request target without
+/// consulting or materializing credential values.
+///
+/// This validates placeholder syntax using the same URI-aware rewrite path as
+/// upstream injection, but resolves every referenced key to a fixed redaction
+/// marker. Callers can therefore select routes and evaluate policy before the
+/// real endpoint-scoped resolver is touched.
+pub fn redact_target_for_policy(target: &str) -> Result<String, UnresolvedPlaceholderError> {
+    if !contains_reserved_credential_marker(target) {
+        return Ok(target.to_string());
+    }
+
+    let decoded = percent_decode(target);
+    let mut provider_env = HashMap::new();
+    let mut pos = 0;
+    while pos < decoded.len() {
+        let next_canonical = decoded[pos..].find(PLACEHOLDER_PREFIX).map(|p| pos + p);
+        let next_alias = decoded[pos..]
+            .find(PROVIDER_ALIAS_MARKER)
+            .map(|marker_pos| alias_start_for_marker(&decoded, pos + marker_pos));
+        let Some(start) = [next_canonical, next_alias].into_iter().flatten().min() else {
+            break;
+        };
+        let Some((end, token)) =
+            canonical_token_at(&decoded, start).or_else(|| alias_token_at(&decoded, start))
+        else {
+            return Err(unresolved("request_target"));
+        };
+        let Some(key) = placeholder_env_key(token) else {
+            return Err(unresolved("request_target"));
+        };
+        provider_env.insert(key.to_string(), "[CREDENTIAL]".to_string());
+        pos = end;
+    }
+
+    let (_, resolver) = SecretResolver::from_provider_env(provider_env);
+    let Some(resolver) = resolver else {
+        return Err(unresolved("request_target"));
+    };
+    rewrite_target_for_eval(target, &resolver).map(|result| result.redacted)
 }
 
 // ---------------------------------------------------------------------------
@@ -2200,5 +2335,13 @@ mod tests {
 
         assert_eq!(result.resolved, "/bottok123/method?key=key456");
         assert_eq!(result.redacted, "/bot[CREDENTIAL]/method?key=[CREDENTIAL]");
+    }
+
+    #[test]
+    fn policy_target_redaction_never_requires_real_secret_material() {
+        let target = "/v1/openshell:resolve:env:v9_API_KEY/messages?token=provider-OPENSHELL-RESOLVE-ENV-API_KEY";
+        let redacted = redact_target_for_policy(target).expect("valid placeholder syntax");
+        assert_eq!(redacted, "/v1/[CREDENTIAL]/messages?token=[CREDENTIAL]");
+        assert!(!redacted.contains("API_KEY"));
     }
 }

--- a/crates/openshell-core/src/secrets.rs
+++ b/crates/openshell-core/src/secrets.rs
@@ -123,6 +123,7 @@ pub struct SecretResolver {
     by_placeholder: HashMap<String, SecretValue>,
     denied_env_keys: std::collections::HashSet<String>,
     no_revision_fallback_env_keys: std::collections::HashSet<String>,
+    revision_fallback_min_revisions: HashMap<String, u64>,
 }
 
 #[derive(Clone)]
@@ -245,6 +246,7 @@ impl SecretResolver {
                     by_placeholder,
                     denied_env_keys: std::collections::HashSet::new(),
                     no_revision_fallback_env_keys: std::collections::HashSet::new(),
+                    revision_fallback_min_revisions: HashMap::new(),
                 }),
             )
         }
@@ -254,11 +256,14 @@ impl SecretResolver {
         let mut by_placeholder = HashMap::new();
         let mut denied_env_keys = std::collections::HashSet::new();
         let mut no_revision_fallback_env_keys = std::collections::HashSet::new();
+        let mut revision_fallback_min_revisions = HashMap::new();
         for resolver in resolvers {
             by_placeholder.extend(resolver.by_placeholder.clone());
             denied_env_keys.extend(resolver.denied_env_keys.iter().cloned());
             no_revision_fallback_env_keys
                 .extend(resolver.no_revision_fallback_env_keys.iter().cloned());
+            revision_fallback_min_revisions
+                .extend(resolver.revision_fallback_min_revisions.clone());
         }
         if by_placeholder.is_empty() {
             None
@@ -267,6 +272,7 @@ impl SecretResolver {
                 by_placeholder,
                 denied_env_keys,
                 no_revision_fallback_env_keys,
+                revision_fallback_min_revisions,
             })
         }
     }
@@ -281,6 +287,7 @@ impl SecretResolver {
         &self,
         bound_keys: &std::collections::HashSet<String>,
         allowed_bound_keys: &std::collections::HashSet<String>,
+        revision_fallback_min_revisions: HashMap<String, u64>,
     ) -> Self {
         let denied_env_keys = bound_keys
             .difference(allowed_bound_keys)
@@ -298,6 +305,7 @@ impl SecretResolver {
             by_placeholder,
             denied_env_keys,
             no_revision_fallback_env_keys: bound_keys.clone(),
+            revision_fallback_min_revisions,
         }
     }
 
@@ -331,8 +339,12 @@ impl SecretResolver {
             // to one provider identity, so falling back by key after replacement
             // would let the old process obtain the replacement provider's secret.
             let key = revisioned_placeholder_env_key(value).or_else(|| alias_env_key(value))?;
-            if revisioned_placeholder_env_key(value).is_some()
+            if let Some((revision, key)) = revisioned_placeholder_parts(value)
                 && self.no_revision_fallback_env_keys.contains(key)
+                && self
+                    .revision_fallback_min_revisions
+                    .get(key)
+                    .is_none_or(|minimum| revision < *minimum)
             {
                 return None;
             }
@@ -615,9 +627,13 @@ fn alias_env_key(token: &str) -> Option<&str> {
 }
 
 fn revisioned_placeholder_env_key(token: &str) -> Option<&str> {
+    revisioned_placeholder_parts(token).map(|(_, key)| key)
+}
+
+fn revisioned_placeholder_parts(token: &str) -> Option<(u64, &str)> {
     let suffix = token.strip_prefix(PLACEHOLDER_PREFIX)?;
-    let (_, key) = split_revisioned_env_key(suffix)?;
-    Some(key)
+    let (revision, key) = split_revisioned_env_key(suffix)?;
+    Some((revision.parse().ok()?, key))
 }
 
 fn placeholder_env_key(token: &str) -> Option<&str> {

--- a/crates/openshell-core/src/secrets.rs
+++ b/crates/openshell-core/src/secrets.rs
@@ -3,7 +3,7 @@
 
 use crate::time::now_ms;
 use base64::Engine as _;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::Arc;
 
@@ -121,9 +121,9 @@ pub struct RewriteTargetResult {
 #[derive(Clone, Default)]
 pub struct SecretResolver {
     by_placeholder: HashMap<String, SecretValue>,
-    denied_env_keys: std::collections::HashSet<String>,
-    no_revision_fallback_env_keys: std::collections::HashSet<String>,
-    revision_fallback_min_revisions: HashMap<String, u64>,
+    denied_env_keys: HashSet<String>,
+    identity_bound_env_keys: HashSet<String>,
+    revision_fallback_allowed_revisions: HashMap<String, HashSet<u64>>,
 }
 
 #[derive(Clone)]
@@ -244,9 +244,9 @@ impl SecretResolver {
                 child_env,
                 Some(Self {
                     by_placeholder,
-                    denied_env_keys: std::collections::HashSet::new(),
-                    no_revision_fallback_env_keys: std::collections::HashSet::new(),
-                    revision_fallback_min_revisions: HashMap::new(),
+                    denied_env_keys: HashSet::new(),
+                    identity_bound_env_keys: HashSet::new(),
+                    revision_fallback_allowed_revisions: HashMap::new(),
                 }),
             )
         }
@@ -254,16 +254,15 @@ impl SecretResolver {
 
     pub fn merge<'a>(resolvers: impl IntoIterator<Item = &'a Self>) -> Option<Self> {
         let mut by_placeholder = HashMap::new();
-        let mut denied_env_keys = std::collections::HashSet::new();
-        let mut no_revision_fallback_env_keys = std::collections::HashSet::new();
-        let mut revision_fallback_min_revisions = HashMap::new();
+        let mut denied_env_keys = HashSet::new();
+        let mut identity_bound_env_keys = HashSet::new();
+        let mut revision_fallback_allowed_revisions = HashMap::new();
         for resolver in resolvers {
             by_placeholder.extend(resolver.by_placeholder.clone());
             denied_env_keys.extend(resolver.denied_env_keys.iter().cloned());
-            no_revision_fallback_env_keys
-                .extend(resolver.no_revision_fallback_env_keys.iter().cloned());
-            revision_fallback_min_revisions
-                .extend(resolver.revision_fallback_min_revisions.clone());
+            identity_bound_env_keys.extend(resolver.identity_bound_env_keys.iter().cloned());
+            revision_fallback_allowed_revisions
+                .extend(resolver.revision_fallback_allowed_revisions.clone());
         }
         if by_placeholder.is_empty() {
             None
@@ -271,8 +270,8 @@ impl SecretResolver {
             Some(Self {
                 by_placeholder,
                 denied_env_keys,
-                no_revision_fallback_env_keys,
-                revision_fallback_min_revisions,
+                identity_bound_env_keys,
+                revision_fallback_allowed_revisions,
             })
         }
     }
@@ -285,14 +284,14 @@ impl SecretResolver {
     #[must_use]
     pub fn scoped_to_env_keys(
         &self,
-        bound_keys: &std::collections::HashSet<String>,
-        allowed_bound_keys: &std::collections::HashSet<String>,
-        revision_fallback_min_revisions: HashMap<String, u64>,
+        bound_keys: &HashSet<String>,
+        allowed_bound_keys: &HashSet<String>,
+        revision_fallback_allowed_revisions: HashMap<String, HashSet<u64>>,
     ) -> Self {
         let denied_env_keys = bound_keys
             .difference(allowed_bound_keys)
             .cloned()
-            .collect::<std::collections::HashSet<_>>();
+            .collect::<HashSet<_>>();
         let by_placeholder = self
             .by_placeholder
             .iter()
@@ -304,8 +303,8 @@ impl SecretResolver {
         Self {
             by_placeholder,
             denied_env_keys,
-            no_revision_fallback_env_keys: bound_keys.clone(),
-            revision_fallback_min_revisions,
+            identity_bound_env_keys: bound_keys.clone(),
+            revision_fallback_allowed_revisions,
         }
     }
 
@@ -329,46 +328,63 @@ impl SecretResolver {
     /// Returns `None` if the placeholder is unknown or the resolved value
     /// contains prohibited control characters (CRLF, null byte).
     pub fn resolve_placeholder(&self, value: &str) -> Option<&str> {
+        if placeholder_env_key(value).is_some_and(|key| self.identity_bound_env_keys.contains(key))
+            && revisioned_placeholder_parts(value).is_none()
+        {
+            // Canonical placeholders and provider-shaped aliases carry no
+            // credential identity. Endpoint-bound request input must use the
+            // revision-scoped placeholder issued to the workload so a stale
+            // process cannot resolve a replacement provider's credential.
+            return None;
+        }
         let secret = if let Some(secret) = self.by_placeholder.get(value) {
             secret
         } else {
-            // Once an old generation ages out, the revision number is only a
-            // namespace marker. Fall back by key to the current credential so
-            // long-running child processes survive provider credential refresh.
-            // Endpoint-bound credentials are the exception: a revision belongs
-            // to one provider identity, so falling back by key after replacement
-            // would let the old process obtain the replacement provider's secret.
+            // Once an old generation ages out, fall back by key to the current
+            // credential so long-running child processes survive provider
+            // credential refresh. For endpoint-bound credentials, permit that
+            // fallback only when the exact opaque revision belongs to the
+            // current provider-identity epoch.
             let key = revisioned_placeholder_env_key(value).or_else(|| alias_env_key(value))?;
             if let Some((revision, key)) = revisioned_placeholder_parts(value)
-                && self.no_revision_fallback_env_keys.contains(key)
+                && self.identity_bound_env_keys.contains(key)
                 && self
-                    .revision_fallback_min_revisions
+                    .revision_fallback_allowed_revisions
                     .get(key)
-                    .is_none_or(|minimum| revision < *minimum)
+                    .is_none_or(|revisions| !revisions.contains(&revision))
             {
                 return None;
             }
             let canonical = placeholder_for_env_key(key);
             self.by_placeholder.get(&canonical)?
         };
-        if secret.expires_at_ms > 0 && secret.expires_at_ms <= now_ms() {
-            tracing::warn!(
-                location = "resolve_placeholder",
-                "credential resolution rejected: credential is expired"
-            );
-            return None;
+        resolve_secret_value(secret)
+    }
+
+    /// Resolve the current value for an environment key selected by trusted
+    /// supervisor code.
+    ///
+    /// Unlike [`Self::resolve_placeholder_checked`], this method accepts an
+    /// environment key rather than a user-provided placeholder token. Internal
+    /// request transforms such as `SigV4` can therefore select the endpoint-bound
+    /// current credential without making identityless placeholder aliases
+    /// available to sandbox request input.
+    pub fn resolve_current_env_key_checked(
+        &self,
+        key: &str,
+        location: &'static str,
+    ) -> Result<Option<&str>, UnresolvedPlaceholderError> {
+        if self.denied_env_keys.contains(key) {
+            return Err(UnresolvedPlaceholderError {
+                location,
+                reason: UnresolvedPlaceholderReason::EndpointMismatch,
+            });
         }
-        match validate_resolved_secret(secret.value.as_ref()) {
-            Ok(s) => Some(s),
-            Err(reason) => {
-                tracing::warn!(
-                    location = "resolve_placeholder",
-                    reason,
-                    "credential resolution rejected: resolved value contains prohibited characters"
-                );
-                None
-            }
-        }
+        let placeholder = placeholder_for_env_key(key);
+        Ok(self
+            .by_placeholder
+            .get(&placeholder)
+            .and_then(resolve_secret_value))
     }
 
     /// Resolve a placeholder while preserving endpoint-denial information.
@@ -567,6 +583,27 @@ impl SecretResolver {
         }
 
         Ok(Some(b64.encode(rewritten.as_bytes())))
+    }
+}
+
+fn resolve_secret_value(secret: &SecretValue) -> Option<&str> {
+    if secret.expires_at_ms > 0 && secret.expires_at_ms <= now_ms() {
+        tracing::warn!(
+            location = "resolve_placeholder",
+            "credential resolution rejected: credential is expired"
+        );
+        return None;
+    }
+    match validate_resolved_secret(secret.value.as_ref()) {
+        Ok(s) => Some(s),
+        Err(reason) => {
+            tracing::warn!(
+                location = "resolve_placeholder",
+                reason,
+                "credential resolution rejected: resolved value contains prohibited characters"
+            );
+            None
+        }
     }
 }
 

--- a/crates/openshell-policy/src/ambiguity.rs
+++ b/crates/openshell-policy/src/ambiguity.rs
@@ -190,7 +190,10 @@ fn connection_conflicts(left: &NetworkEndpoint, right: &NetworkEndpoint) -> Vec<
 /// cannot compete with the single L7/connection-config endpoint selected for
 /// that request.
 fn endpoint_contributes_request_pipeline_metadata(endpoint: &NetworkEndpoint) -> bool {
-    !endpoint.protocol.is_empty() || !endpoint.allowed_ips.is_empty() || !endpoint.tls.is_empty()
+    !endpoint.protocol.is_empty()
+        || !endpoint.allowed_ips.is_empty()
+        || !endpoint.tls.is_empty()
+        || endpoint.credential_binding.is_some()
 }
 
 fn request_pipeline_conflicts(left: &NetworkEndpoint, right: &NetworkEndpoint) -> Vec<String> {
@@ -252,6 +255,20 @@ fn request_pipeline_conflicts(left: &NetworkEndpoint, right: &NetworkEndpoint) -
         "signing_region",
         &left.signing_region,
         &right.signing_region,
+    );
+    push_conflict(
+        &mut conflicts,
+        "credential_binding.provider",
+        &left
+            .credential_binding
+            .as_ref()
+            .map(|binding| binding.provider.as_str())
+            .unwrap_or_default(),
+        &right
+            .credential_binding
+            .as_ref()
+            .map(|binding| binding.provider.as_str())
+            .unwrap_or_default(),
     );
 
     if left.protocol.eq_ignore_ascii_case("graphql")
@@ -893,6 +910,27 @@ mod tests {
                 .conflicts
                 .iter()
                 .any(|field| field.contains("allow_encoded_slash"))
+        );
+    }
+
+    #[test]
+    fn credential_binding_conflicts_are_rejected_on_same_endpoint() {
+        let mut left = endpoint("api.example.com", 443);
+        left.credential_binding = Some(openshell_core::proto::NetworkCredentialBinding {
+            provider: "provider-a".to_string(),
+        });
+        let mut right = endpoint("api.example.com", 443);
+        right.credential_binding = Some(openshell_core::proto::NetworkCredentialBinding {
+            provider: "provider-b".to_string(),
+        });
+
+        let ambiguities = find_endpoint_ambiguities(&policy_with(left, right));
+        assert_eq!(ambiguities.len(), 1);
+        assert!(
+            ambiguities[0]
+                .conflicts
+                .iter()
+                .any(|field| field.contains("credential_binding.provider"))
         );
     }
 

--- a/crates/openshell-policy/src/lib.rs
+++ b/crates/openshell-policy/src/lib.rs
@@ -157,9 +157,17 @@ struct NetworkEndpointDef {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     signing_region: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    credential_binding: Option<NetworkCredentialBindingDef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     json_rpc: Option<JsonRpcConfigDef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     mcp: Option<McpConfigDef>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NetworkCredentialBindingDef {
+    provider: String,
 }
 
 // Signature dictated by serde's `skip_serializing_if`, which requires `&T`.
@@ -759,6 +767,11 @@ fn to_proto(raw: PolicyFile) -> Result<SandboxPolicy> {
                             credential_signing: e.credential_signing,
                             signing_service: e.signing_service,
                             signing_region: e.signing_region,
+                            credential_binding: e.credential_binding.map(|binding| {
+                                openshell_core::proto::NetworkCredentialBinding {
+                                    provider: binding.provider,
+                                }
+                            }),
                             json_rpc_max_body_bytes: json_rpc_max_body_bytes(&e.json_rpc, &e.mcp),
                             mcp: mcp_options(&e.mcp),
                         }
@@ -907,6 +920,11 @@ fn from_proto(policy: &SandboxPolicy) -> PolicyFile {
                             credential_signing: e.credential_signing.clone(),
                             signing_service: e.signing_service.clone(),
                             signing_region: e.signing_region.clone(),
+                            credential_binding: e.credential_binding.as_ref().map(|binding| {
+                                NetworkCredentialBindingDef {
+                                    provider: binding.provider.clone(),
+                                }
+                            }),
                             json_rpc,
                             mcp,
                         }
@@ -3002,6 +3020,37 @@ network_policies:
         let ep2 = &proto2.network_policies["test"].endpoints[0];
         assert_eq!(ep1.path, "/graphql");
         assert_eq!(ep1.path, ep2.path);
+    }
+
+    #[test]
+    fn round_trip_preserves_endpoint_credential_binding() {
+        let yaml = r"
+version: 1
+network_policies:
+  gcp_storage:
+    endpoints:
+      - host: storage.googleapis.com
+        port: 443
+        protocol: rest
+        credential_binding:
+          provider: work-gcp
+";
+
+        let proto1 = parse_sandbox_policy(yaml).expect("parse failed");
+        let endpoint = &proto1.network_policies["gcp_storage"].endpoints[0];
+        assert_eq!(
+            endpoint
+                .credential_binding
+                .as_ref()
+                .map(|binding| binding.provider.as_str()),
+            Some("work-gcp")
+        );
+
+        let yaml_out = serialize_sandbox_policy(&proto1).expect("serialize failed");
+        let proto2 = parse_sandbox_policy(&yaml_out).expect("re-parse failed");
+        assert_eq!(proto1, proto2);
+        assert!(yaml_out.contains("credential_binding:"));
+        assert!(yaml_out.contains("provider: work-gcp"));
     }
 
     #[test]

--- a/crates/openshell-providers/src/profiles.rs
+++ b/crates/openshell-providers/src/profiles.rs
@@ -2439,16 +2439,7 @@ fn path_prefix_pattern(path: &str) -> Option<&str> {
 }
 
 fn endpoint_path_matches(pattern: &str, path: &str) -> bool {
-    if path_matches_all(pattern) {
-        return true;
-    }
-    if pattern == path {
-        return true;
-    }
-    if let Some(prefix) = path_prefix_pattern(pattern) {
-        return path == prefix || path.starts_with(&format!("{prefix}/"));
-    }
-    glob::Pattern::new(pattern).is_ok_and(|glob| glob.matches(path))
+    openshell_core::endpoint_path::matches(pattern, path)
 }
 
 fn validate_token_grant_endpoint(token_endpoint: &str) -> Result<(), String> {

--- a/crates/openshell-providers/src/profiles.rs
+++ b/crates/openshell-providers/src/profiles.rs
@@ -1088,6 +1088,9 @@ fn endpoint_to_proto(endpoint: &EndpointProfile) -> NetworkEndpoint {
         credential_signing: endpoint.credential_signing.clone(),
         signing_service: endpoint.signing_service.clone(),
         signing_region: endpoint.signing_region.clone(),
+        // Credential bindings reference a concrete sandbox provider instance
+        // and therefore cannot be authored by a reusable provider profile.
+        credential_binding: None,
     }
 }
 

--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -217,80 +217,112 @@ pub async fn run_sandbox(
     );
 
     #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
-    let (provider_credentials, mut provider_env) =
-        if let Some(bootstrap) = sidecar_bootstrap.as_ref() {
-            let provider_credentials = ProviderCredentialState::from_child_env_snapshot(
-                bootstrap.provider_env_revision,
-                bootstrap.provider_child_env.clone(),
-            );
-            (provider_credentials, bootstrap.provider_child_env.clone())
-        } else {
-            // Fetch provider environment variables from the server.
-            // This is done after loading the policy so the sandbox can still start
-            // even if provider env fetch fails (graceful degradation).
-            let (
-                provider_env_revision,
-                provider_env,
-                provider_credential_expires_at_ms,
-                dynamic_credentials,
-            ) = if let (Some(id), Some(endpoint)) = (&sandbox_id, &openshell_endpoint) {
-                match openshell_core::grpc_client::fetch_provider_environment(endpoint, id).await {
-                    Ok(result) => {
-                        ocsf_emit!(
-                            ConfigStateChangeBuilder::new(ocsf_ctx())
-                                .severity(SeverityId::Informational)
-                                .status(StatusId::Success)
-                                .state(StateId::Enabled, "loaded")
-                                .message(format!(
-                                    "Fetched provider environment [env_count:{}]",
-                                    result.environment.len()
-                                ))
-                                .build()
-                        );
-                        (
-                            result.provider_env_revision,
-                            result.environment,
-                            result.credential_expires_at_ms,
-                            result.dynamic_credentials,
-                        )
-                    }
-                    Err(e) => {
-                        ocsf_emit!(
-                            ConfigStateChangeBuilder::new(ocsf_ctx())
-                                .severity(SeverityId::Medium)
-                                .status(StatusId::Failure)
-                                .state(StateId::Other, "degraded")
-                                .message(format!(
-                                    "Failed to fetch provider environment, continuing without: {e}"
-                                ))
-                                .build()
-                        );
-                        (
-                            0,
-                            std::collections::HashMap::new(),
-                            std::collections::HashMap::new(),
-                            std::collections::HashMap::new(),
-                        )
-                    }
+    let (provider_credentials, mut provider_env) = if let Some(bootstrap) =
+        sidecar_bootstrap.as_ref()
+    {
+        let provider_credentials = ProviderCredentialState::from_child_env_snapshot(
+            bootstrap.provider_env_revision,
+            bootstrap.provider_child_env.clone(),
+        );
+        (provider_credentials, bootstrap.provider_child_env.clone())
+    } else {
+        // Fetch provider environment variables from the server.
+        // This is done after loading the policy so the sandbox can still start
+        // even if provider env fetch fails (graceful degradation).
+        let (
+            provider_env_revision,
+            provider_env,
+            provider_credential_expires_at_ms,
+            dynamic_credentials,
+            static_credential_bindings,
+            non_secret_environment_keys,
+        ) = if let (Some(id), Some(endpoint)) = (&sandbox_id, &openshell_endpoint) {
+            match openshell_core::grpc_client::fetch_provider_environment(endpoint, id).await {
+                Ok(result) => {
+                    ocsf_emit!(
+                        ConfigStateChangeBuilder::new(ocsf_ctx())
+                            .severity(SeverityId::Informational)
+                            .status(StatusId::Success)
+                            .state(StateId::Enabled, "loaded")
+                            .message(format!(
+                                "Fetched provider environment [env_count:{}]",
+                                result.environment.len()
+                            ))
+                            .build()
+                    );
+                    (
+                        result.provider_env_revision,
+                        result.environment,
+                        result.credential_expires_at_ms,
+                        result.dynamic_credentials,
+                        result.static_credential_bindings,
+                        result.non_secret_environment_keys,
+                    )
                 }
-            } else {
-                (
-                    0,
-                    std::collections::HashMap::new(),
-                    std::collections::HashMap::new(),
-                    std::collections::HashMap::new(),
-                )
-            };
-
-            let provider_credentials = ProviderCredentialState::from_environment(
-                provider_env_revision,
-                provider_env,
-                provider_credential_expires_at_ms,
-                dynamic_credentials,
-            );
-            let provider_env = provider_credentials.child_env_with_gcp_resolved();
-            (provider_credentials, provider_env)
+                Err(e) => {
+                    ocsf_emit!(
+                        ConfigStateChangeBuilder::new(ocsf_ctx())
+                            .severity(SeverityId::High)
+                            .status(StatusId::Failure)
+                            .state(StateId::Disabled, "fail_closed")
+                            .message(format!(
+                                "Failed to fetch provider environment; no provider credentials are active: {e}"
+                            ))
+                            .build()
+                    );
+                    (
+                        0,
+                        std::collections::HashMap::new(),
+                        std::collections::HashMap::new(),
+                        std::collections::HashMap::new(),
+                        std::collections::HashMap::new(),
+                        Vec::new(),
+                    )
+                }
+            }
+        } else {
+            (
+                0,
+                std::collections::HashMap::new(),
+                std::collections::HashMap::new(),
+                std::collections::HashMap::new(),
+                std::collections::HashMap::new(),
+                Vec::new(),
+            )
         };
+
+        let dynamic_credentials_fallback = dynamic_credentials.clone();
+        let provider_credentials = match ProviderCredentialState::from_bound_environment(
+            provider_env_revision,
+            provider_env,
+            provider_credential_expires_at_ms,
+            dynamic_credentials,
+            static_credential_bindings,
+            non_secret_environment_keys,
+        ) {
+            Ok(credentials) => credentials,
+            Err(error) => {
+                ocsf_emit!(
+                        ConfigStateChangeBuilder::new(ocsf_ctx())
+                            .severity(SeverityId::High)
+                            .status(StatusId::Failure)
+                            .state(StateId::Disabled, "fail_closed")
+                            .message(format!(
+                                "Rejected provider environment bindings; no provider credentials are active: {error}"
+                            ))
+                            .build()
+                    );
+                ProviderCredentialState::from_environment(
+                    provider_env_revision,
+                    std::collections::HashMap::new(),
+                    std::collections::HashMap::new(),
+                    dynamic_credentials_fallback,
+                )
+            }
+        };
+        let provider_env = provider_credentials.child_env_with_gcp_resolved();
+        (provider_credentials, provider_env)
+    };
 
     // Shared agent-proposals feature flag. Seed from the same initial settings
     // snapshot that produced the policy so networking and process setup agree
@@ -3099,42 +3131,67 @@ async fn run_policy_poll_loop(ctx: PolicyPollLoopContext) -> Result<()> {
             .await
             {
                 Ok(env_result) => {
-                    ctx.provider_credentials.install_environment(
-                        env_result.provider_env_revision,
+                    let provider_env_revision = env_result.provider_env_revision;
+                    let install_result = ctx.provider_credentials.install_bound_environment(
+                        provider_env_revision,
                         env_result.environment,
                         env_result.credential_expires_at_ms,
                         env_result.dynamic_credentials,
+                        env_result.static_credential_bindings,
+                        env_result.non_secret_environment_keys,
                     );
-                    let child_env = ctx.provider_credentials.child_env_with_gcp_resolved();
-                    let env_count = child_env.len();
-                    if let Some(publisher) = ctx.sidecar_control_publisher.as_ref() {
-                        publisher.publish_provider_env(
-                            env_result.provider_env_revision,
-                            child_env.clone(),
+                    if let Err(error) = install_result {
+                        ocsf_emit!(
+                            ConfigStateChangeBuilder::new(ocsf_ctx())
+                                .severity(SeverityId::High)
+                                .status(StatusId::Failure)
+                                .state(StateId::Disabled, "fail_closed")
+                                .message(format!(
+                                    "Rejected provider environment refresh; previous provider credentials are not active: {error}"
+                                ))
+                                .build()
+                        );
+                    } else {
+                        let child_env = ctx.provider_credentials.child_env_with_gcp_resolved();
+                        let env_count = child_env.len();
+                        if let Some(publisher) = ctx.sidecar_control_publisher.as_ref() {
+                            publisher
+                                .publish_provider_env(provider_env_revision, child_env.clone());
+                        }
+                        current_provider_env_revision = provider_env_revision;
+                        ocsf_emit!(
+                            ConfigStateChangeBuilder::new(ocsf_ctx())
+                                .severity(SeverityId::Informational)
+                                .status(StatusId::Success)
+                                .state(StateId::Enabled, "loaded")
+                                .unmapped(
+                                    "provider_env_revision",
+                                    serde_json::json!(provider_env_revision)
+                                )
+                                .message(format!(
+                                    "Provider environment refreshed [revision:{provider_env_revision} env_count:{env_count}]"
+                                ))
+                                .build()
                         );
                     }
-                    current_provider_env_revision = env_result.provider_env_revision;
-                    ocsf_emit!(
-                        ConfigStateChangeBuilder::new(ocsf_ctx())
-                            .severity(SeverityId::Informational)
-                            .status(StatusId::Success)
-                            .state(StateId::Enabled, "loaded")
-                            .unmapped(
-                                "provider_env_revision",
-                                serde_json::json!(env_result.provider_env_revision)
-                            )
-                            .message(format!(
-                                "Provider environment refreshed [revision:{} env_count:{env_count}]",
-                                env_result.provider_env_revision
-                            ))
-                            .build()
-                    );
                 }
                 Err(e) => {
+                    ctx.provider_credentials
+                        .revoke_static_provider_environment(result.provider_env_revision);
                     warn!(
                         error = %e,
                         provider_env_revision = result.provider_env_revision,
-                        "Settings poll: failed to refresh provider environment"
+                        "Settings poll: failed to refresh provider environment; previous provider credentials are not active"
+                    );
+                    ocsf_emit!(
+                        ConfigStateChangeBuilder::new(ocsf_ctx())
+                            .severity(SeverityId::High)
+                            .status(StatusId::Failure)
+                            .state(StateId::Disabled, "fail_closed")
+                            .message(
+                                "Provider environment refresh failed; previous provider credentials are not active"
+                            )
+                            .build()
                     );
                 }
             }

--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -308,7 +308,7 @@ pub async fn run_sandbox(
                             .status(StatusId::Failure)
                             .state(StateId::Disabled, "fail_closed")
                             .message(format!(
-                                "Rejected provider environment bindings; no provider credentials are active: {error}"
+                                "Rejected provider environment bindings; static provider credentials were revoked; fetched dynamic token grants remain active: {error}"
                             ))
                             .build()
                     );
@@ -3147,7 +3147,7 @@ async fn run_policy_poll_loop(ctx: PolicyPollLoopContext) -> Result<()> {
                                 .status(StatusId::Failure)
                                 .state(StateId::Disabled, "fail_closed")
                                 .message(format!(
-                                    "Rejected provider environment refresh; previous provider credentials are not active: {error}"
+                                    "Rejected provider environment refresh; static provider credentials were revoked; fetched dynamic token grants remain active: {error}"
                                 ))
                                 .build()
                         );
@@ -3181,7 +3181,7 @@ async fn run_policy_poll_loop(ctx: PolicyPollLoopContext) -> Result<()> {
                     warn!(
                         error = %e,
                         provider_env_revision = result.provider_env_revision,
-                        "Settings poll: failed to refresh provider environment; previous provider credentials are not active"
+                        "Settings poll: failed to refresh provider environment; static provider credentials were revoked; previous dynamic token grants remain active"
                     );
                     ocsf_emit!(
                         ConfigStateChangeBuilder::new(ocsf_ctx())
@@ -3189,7 +3189,7 @@ async fn run_policy_poll_loop(ctx: PolicyPollLoopContext) -> Result<()> {
                             .status(StatusId::Failure)
                             .state(StateId::Disabled, "fail_closed")
                             .message(
-                                "Provider environment refresh failed; previous provider credentials are not active"
+                                "Provider environment refresh failed; static provider credentials were revoked; previous dynamic token grants remain active"
                             )
                             .build()
                     );

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -1656,7 +1656,7 @@ pub(super) async fn compute_provider_env_revision_with_catalog(
     provider_names: &[String],
 ) -> Result<u64, Status> {
     let mut hasher = Sha256::new();
-    hasher.update(b"openshell-provider-env-revision-v1");
+    hasher.update(b"openshell-provider-env-revision-v2");
 
     for provider_name in provider_names {
         hasher.update(provider_name.as_bytes());
@@ -1788,6 +1788,7 @@ pub(super) async fn handle_get_sandbox_provider_environment(
     request: Request<GetSandboxProviderEnvironmentRequest>,
 ) -> Result<Response<GetSandboxProviderEnvironmentResponse>, Status> {
     let sandbox_id = request.get_ref().sandbox_id.clone();
+    let supports_static_credential_bindings = request.get_ref().supports_static_credential_bindings;
     crate::auth::guard::enforce_sandbox_scope(&request, &sandbox_id)?;
     drop(request);
 
@@ -1815,7 +1816,7 @@ pub(super) async fn handle_get_sandbox_provider_environment(
         &provider_names,
     )
     .await?;
-    let provider_environment = super::provider::resolve_provider_environment_with_credentials(
+    let mut provider_environment = super::provider::resolve_provider_environment_with_credentials(
         state.store.as_ref(),
         &provider_profile_catalog,
         &workspace,
@@ -1823,6 +1824,27 @@ pub(super) async fn handle_get_sandbox_provider_environment(
         &state.credentials,
     )
     .await?;
+
+    if supports_static_credential_bindings {
+        for key in &provider_environment.static_credential_keys {
+            let Some(binding) = provider_environment.static_credential_bindings.get(key) else {
+                return Err(Status::failed_precondition(
+                    "static provider credentials require a provider profile with network endpoints",
+                ));
+            };
+            if binding.endpoints.is_empty() {
+                return Err(Status::failed_precondition(
+                    "static provider credentials require at least one provider profile endpoint",
+                ));
+            }
+        }
+    } else {
+        for key in &provider_environment.static_credential_keys {
+            provider_environment.environment.remove(key);
+            provider_environment.credential_expires_at_ms.remove(key);
+        }
+        provider_environment.static_credential_bindings.clear();
+    }
 
     info!(
         sandbox_id = %sandbox_id,
@@ -1832,11 +1854,20 @@ pub(super) async fn handle_get_sandbox_provider_environment(
         "GetSandboxProviderEnvironment request completed successfully"
     );
 
+    let non_secret_environment_keys = provider_environment
+        .environment
+        .keys()
+        .filter(|key| !provider_environment.static_credential_keys.contains(*key))
+        .cloned()
+        .collect();
+
     Ok(Response::new(GetSandboxProviderEnvironmentResponse {
         environment: provider_environment.environment,
         provider_env_revision,
         credential_expires_at_ms: provider_environment.credential_expires_at_ms,
         dynamic_credentials: provider_environment.dynamic_credentials,
+        static_credential_bindings: provider_environment.static_credential_bindings,
+        non_secret_environment_keys,
     }))
 }
 
@@ -5904,6 +5935,7 @@ mod tests {
             &state,
             with_user(Request::new(GetSandboxProviderEnvironmentRequest {
                 sandbox_id: "sb-snapshot-consistency".to_string(),
+                supports_static_credential_bindings: true,
             })),
         )
         .await
@@ -6937,6 +6969,7 @@ mod tests {
             &state,
             with_user(Request::new(GetSandboxProviderEnvironmentRequest {
                 sandbox_id: "sb-provider-env".to_string(),
+                supports_static_credential_bindings: true,
             })),
         )
         .await
@@ -6949,6 +6982,7 @@ mod tests {
             &state,
             with_user(Request::new(GetSandboxProviderEnvironmentRequest {
                 sandbox_id: "sb-provider-env".to_string(),
+                supports_static_credential_bindings: true,
             })),
         )
         .await
@@ -6958,6 +6992,42 @@ mod tests {
 
         assert_eq!(legacy_env, v2_env);
         assert_eq!(v2_env.get("GITHUB_TOKEN"), Some(&"ghp-test".to_string()));
+    }
+
+    #[tokio::test]
+    async fn provider_environment_withholds_static_credentials_from_legacy_supervisors() {
+        use openshell_core::proto::GetSandboxProviderEnvironmentRequest;
+
+        let state = test_server_state().await;
+        state
+            .store
+            .put_message(&test_provider("work-github", "github"))
+            .await
+            .unwrap();
+        state
+            .store
+            .put_message(&test_sandbox(
+                "sb-legacy-provider-env",
+                "legacy-provider-env",
+                test_policy_with_rule("sandbox_only", "sandbox.example.com"),
+                vec!["work-github".to_string()],
+            ))
+            .await
+            .unwrap();
+
+        let response = handle_get_sandbox_provider_environment(
+            &state,
+            with_user(Request::new(GetSandboxProviderEnvironmentRequest {
+                sandbox_id: "sb-legacy-provider-env".to_string(),
+                supports_static_credential_bindings: false,
+            })),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+        assert!(!response.environment.contains_key("GITHUB_TOKEN"));
+        assert!(response.static_credential_bindings.is_empty());
     }
 
     #[tokio::test]
@@ -6983,6 +7053,7 @@ mod tests {
             &state,
             with_user(Request::new(GetSandboxProviderEnvironmentRequest {
                 sandbox_id: "sb-provider-revision".to_string(),
+                supports_static_credential_bindings: true,
             })),
         )
         .await
@@ -6999,6 +7070,7 @@ mod tests {
             &state,
             with_user(Request::new(GetSandboxProviderEnvironmentRequest {
                 sandbox_id: "sb-provider-revision".to_string(),
+                supports_static_credential_bindings: true,
             })),
         )
         .await
@@ -7170,6 +7242,7 @@ mod tests {
             &state,
             with_user(Request::new(GetSandboxProviderEnvironmentRequest {
                 sandbox_id: "sb-attach-lifecycle".to_string(),
+                supports_static_credential_bindings: true,
             })),
         )
         .await
@@ -7199,6 +7272,7 @@ mod tests {
             &state,
             with_user(Request::new(GetSandboxProviderEnvironmentRequest {
                 sandbox_id: "sb-attach-lifecycle".to_string(),
+                supports_static_credential_bindings: true,
             })),
         )
         .await
@@ -7236,6 +7310,7 @@ mod tests {
             &state,
             with_user(Request::new(GetSandboxProviderEnvironmentRequest {
                 sandbox_id: "sb-attach-lifecycle".to_string(),
+                supports_static_credential_bindings: true,
             })),
         )
         .await
@@ -7338,6 +7413,7 @@ mod tests {
             &state,
             with_user(Request::new(GetSandboxProviderEnvironmentRequest {
                 sandbox_id: "sb-attach-lifecycle".to_string(),
+                supports_static_credential_bindings: true,
             })),
         )
         .await
@@ -7370,6 +7446,7 @@ mod tests {
             &state,
             with_user(Request::new(GetSandboxProviderEnvironmentRequest {
                 sandbox_id: "sb-attach-lifecycle".to_string(),
+                supports_static_credential_bindings: true,
             })),
         )
         .await
@@ -7406,6 +7483,7 @@ mod tests {
             &state,
             with_user(Request::new(GetSandboxProviderEnvironmentRequest {
                 sandbox_id: "sb-attach-lifecycle".to_string(),
+                supports_static_credential_bindings: true,
             })),
         )
         .await

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -7576,7 +7576,7 @@ mod tests {
             with_user(Request::new(UpdateConfigRequest {
                 name: "policy-binding".to_string(),
                 workspace: "default".to_string(),
-                policy: Some(next_policy),
+                policy: Some(next_policy.clone()),
                 ..Default::default()
             })),
         )
@@ -7613,6 +7613,50 @@ mod tests {
         assert_eq!(
             next_environment.static_credential_bindings["CLOUD_TOKEN"].endpoints[0].host,
             "api2.cloud.example"
+        );
+
+        let mut unbound_policy = next_policy;
+        unbound_policy
+            .network_policies
+            .get_mut("cloud_api")
+            .unwrap()
+            .endpoints[0]
+            .credential_binding = None;
+        handle_update_config(
+            &state,
+            with_user(Request::new(UpdateConfigRequest {
+                name: "policy-binding".to_string(),
+                workspace: "default".to_string(),
+                policy: Some(unbound_policy),
+                ..Default::default()
+            })),
+        )
+        .await
+        .expect("removing a policy binding must succeed");
+        let unbound_environment = handle_get_sandbox_provider_environment(
+            &state,
+            with_user(Request::new(GetSandboxProviderEnvironmentRequest {
+                sandbox_id: "sb-policy-binding".to_string(),
+                supports_static_credential_bindings: true,
+            })),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+        assert_ne!(
+            next_environment.provider_env_revision, unbound_environment.provider_env_revision,
+            "removing the binding must rotate the provider environment revision"
+        );
+        assert!(
+            !unbound_environment.environment.contains_key("CLOUD_TOKEN"),
+            "removing the only binding must withhold the static credential"
+        );
+        assert!(
+            !unbound_environment
+                .static_credential_bindings
+                .contains_key("CLOUD_TOKEN"),
+            "an endpointless profile must not emit incomplete binding metadata"
         );
     }
 

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -44,7 +44,7 @@ use openshell_core::proto::{
 };
 use openshell_core::proto::{
     L7DenyRule, L7Rule, NetworkBinary, NetworkEndpoint, NetworkPolicyRule, Provider, Sandbox,
-    SandboxPolicy as ProtoSandboxPolicy,
+    SandboxPolicy as ProtoSandboxPolicy, StaticCredentialEndpointBinding,
 };
 use openshell_core::telemetry::{
     LifecycleOperation, LifecycleResource, PolicyDecisionOperation, TelemetryOutcome,
@@ -1136,6 +1136,144 @@ pub(super) fn validate_candidate_effective_policy(
     validate_endpoint_ambiguities(&effective_policy)
 }
 
+fn policy_static_credential_endpoint_bindings(
+    policy: Option<&ProtoSandboxPolicy>,
+) -> Result<HashMap<String, Vec<StaticCredentialEndpointBinding>>, Status> {
+    let mut bindings = HashMap::<String, Vec<StaticCredentialEndpointBinding>>::new();
+    let Some(policy) = policy else {
+        return Ok(bindings);
+    };
+
+    for rule in policy.network_policies.values() {
+        for endpoint in &rule.endpoints {
+            let Some(binding) = endpoint.credential_binding.as_ref() else {
+                continue;
+            };
+            let provider = binding.provider.trim();
+            if provider.is_empty() {
+                return Err(Status::invalid_argument(format!(
+                    "credential_binding.provider is required for endpoint '{}'",
+                    endpoint.host
+                )));
+            }
+            if provider != binding.provider {
+                return Err(Status::invalid_argument(format!(
+                    "credential_binding.provider '{}' must not contain leading or trailing whitespace",
+                    binding.provider
+                )));
+            }
+            if endpoint.host.trim().is_empty() {
+                return Err(Status::invalid_argument(format!(
+                    "credential-bound endpoint for provider '{provider}' must define a host"
+                )));
+            }
+            let ports = if endpoint.ports.is_empty() {
+                vec![endpoint.port]
+            } else {
+                endpoint.ports.clone()
+            };
+            if ports
+                .iter()
+                .any(|port| *port == 0 || *port > u32::from(u16::MAX))
+            {
+                return Err(Status::invalid_argument(format!(
+                    "credential-bound endpoint '{}' for provider '{provider}' must define ports in range 1..=65535",
+                    endpoint.host
+                )));
+            }
+            let provider_bindings = bindings.entry(provider.to_string()).or_default();
+            for port in ports {
+                let candidate = StaticCredentialEndpointBinding {
+                    host: endpoint.host.clone(),
+                    port,
+                    path: endpoint.path.clone(),
+                };
+                if !provider_bindings.contains(&candidate) {
+                    provider_bindings.push(candidate);
+                }
+            }
+        }
+    }
+
+    for endpoints in bindings.values_mut() {
+        endpoints.sort_by(|left, right| {
+            (&left.host, left.port, &left.path).cmp(&(&right.host, right.port, &right.path))
+        });
+    }
+    Ok(bindings)
+}
+
+pub(super) fn policy_has_credential_binding_for_provider(
+    policy: &ProtoSandboxPolicy,
+    provider_name: &str,
+) -> bool {
+    policy.network_policies.values().any(|rule| {
+        rule.endpoints.iter().any(|endpoint| {
+            endpoint
+                .credential_binding
+                .as_ref()
+                .is_some_and(|binding| binding.provider == provider_name)
+        })
+    })
+}
+
+fn validate_policy_credential_binding_context(
+    catalog: &EffectiveProviderProfileCatalog,
+    records: &[super::provider::ProviderEnvironmentRecord],
+    bindings: &HashMap<String, Vec<StaticCredentialEndpointBinding>>,
+) -> Result<(), Status> {
+    for provider_name in bindings.keys() {
+        let record = records
+            .iter()
+            .find(|record| record.name == *provider_name)
+            .ok_or_else(|| {
+                Status::failed_precondition(format!(
+                    "credential_binding references provider '{provider_name}', but that provider is not attached to the sandbox"
+                ))
+            })?;
+        let profile_id = normalize_provider_type(&record.provider.r#type)
+            .unwrap_or(record.provider.r#type.as_str());
+        let profile = super::provider::get_provider_type_profile_for_scope(
+            catalog,
+            profile_id,
+            &record.provider.profile_workspace,
+        )
+        .ok_or_else(|| {
+            Status::failed_precondition(format!(
+                "credential_binding provider '{provider_name}' has no provider profile"
+            ))
+        })?;
+        if !profile.to_proto().endpoints.is_empty() {
+            return Err(Status::failed_precondition(format!(
+                "credential_binding provider '{provider_name}' profile already defines endpoints; \
+                 profile endpoints remain the credential boundary"
+            )));
+        }
+    }
+    Ok(())
+}
+
+async fn validate_policy_credential_bindings_for_sandbox(
+    state: &ServerState,
+    catalog: &EffectiveProviderProfileCatalog,
+    workspace: &str,
+    provider_names: &[String],
+    policy: &ProtoSandboxPolicy,
+) -> Result<HashMap<String, Vec<StaticCredentialEndpointBinding>>, Status> {
+    let bindings = policy_static_credential_endpoint_bindings(Some(policy))?;
+    if bindings.is_empty() {
+        return Ok(bindings);
+    }
+    let records = super::provider::load_provider_environment_records(
+        state.store.as_ref(),
+        workspace,
+        provider_names,
+    )
+    .await?;
+    validate_policy_credential_binding_context(catalog, &records, &bindings)?;
+    Ok(bindings)
+}
+
 async fn provider_policy_layers_for_sandbox(
     state: &ServerState,
     workspace: &str,
@@ -1195,7 +1333,25 @@ pub(super) async fn validate_candidate_provider_attachments(
     let base_policy = current_base_policy_for_sandbox(state.store.as_ref(), sandbox).await?;
     let provider_layers =
         provider_policy_layers_for_sandbox(state, workspace, sandbox, provider_names).await?;
-    validate_candidate_effective_policy(&base_policy, &provider_layers)
+    validate_candidate_effective_policy(&base_policy, &provider_layers)?;
+    let effective_policy = if provider_layers.is_empty() {
+        base_policy
+    } else {
+        compose_effective_policy(&base_policy, &provider_layers)
+    };
+    let catalog = state
+        .provider_profile_sources
+        .snapshot_catalog(state.store.as_ref(), workspace)
+        .await?;
+    validate_policy_credential_bindings_for_sandbox(
+        state,
+        &catalog,
+        workspace,
+        provider_names,
+        &effective_policy,
+    )
+    .await?;
+    Ok(())
 }
 
 pub(super) async fn provider_policy_composition_enabled(store: &Store) -> Result<bool, Status> {
@@ -1610,11 +1766,23 @@ pub(super) async fn handle_get_sandbox_config(
         &supervisor_middleware_services,
         state.config.policy_validation_failure_mode,
     );
-    let provider_env_revision = compute_provider_env_revision_with_catalog(
+    let policy_credential_bindings = policy_static_credential_endpoint_bindings(policy.as_ref())?;
+    if let Some(policy) = policy.as_ref() {
+        validate_policy_credential_bindings_for_sandbox(
+            state.as_ref(),
+            &provider_profile_catalog,
+            &workspace,
+            &sandbox_provider_names,
+            policy,
+        )
+        .await?;
+    }
+    let provider_env_revision = compute_provider_env_revision_with_catalog_and_policy_bindings(
         state.store.as_ref(),
         &provider_profile_catalog,
         &workspace,
         &sandbox_provider_names,
+        &policy_credential_bindings,
     )
     .await?;
 
@@ -1649,14 +1817,32 @@ async fn compute_provider_env_revision(
     compute_provider_env_revision_with_catalog(store, &catalog, workspace, provider_names).await
 }
 
+#[cfg(test)]
 pub(super) async fn compute_provider_env_revision_with_catalog(
     store: &Store,
     catalog: &EffectiveProviderProfileCatalog,
     workspace: &str,
     provider_names: &[String],
 ) -> Result<u64, Status> {
+    compute_provider_env_revision_with_catalog_and_policy_bindings(
+        store,
+        catalog,
+        workspace,
+        provider_names,
+        &HashMap::new(),
+    )
+    .await
+}
+
+async fn compute_provider_env_revision_with_catalog_and_policy_bindings(
+    store: &Store,
+    catalog: &EffectiveProviderProfileCatalog,
+    workspace: &str,
+    provider_names: &[String],
+    policy_bindings: &HashMap<String, Vec<StaticCredentialEndpointBinding>>,
+) -> Result<u64, Status> {
     let mut hasher = Sha256::new();
-    hasher.update(b"openshell-provider-env-revision-v2");
+    hasher.update(b"openshell-provider-env-revision-v3");
 
     for provider_name in provider_names {
         hasher.update(provider_name.as_bytes());
@@ -1699,18 +1885,33 @@ pub(super) async fn compute_provider_env_revision_with_catalog(
         }
     }
 
+    hash_policy_credential_bindings(policy_bindings, &mut hasher);
+
     let digest = hasher.finalize();
     Ok(u64::from_le_bytes(digest[..8].try_into().map_err(
         |_| Status::internal("provider env revision digest too short"),
     )?))
 }
 
+#[cfg(test)]
 fn compute_provider_env_revision_from_records(
     catalog: &EffectiveProviderProfileCatalog,
     records: &[super::provider::ProviderEnvironmentRecord],
 ) -> Result<u64, Status> {
+    compute_provider_env_revision_from_records_and_policy_bindings(
+        catalog,
+        records,
+        &HashMap::new(),
+    )
+}
+
+fn compute_provider_env_revision_from_records_and_policy_bindings(
+    catalog: &EffectiveProviderProfileCatalog,
+    records: &[super::provider::ProviderEnvironmentRecord],
+    policy_bindings: &HashMap<String, Vec<StaticCredentialEndpointBinding>>,
+) -> Result<u64, Status> {
     let mut hasher = Sha256::new();
-    hasher.update(b"openshell-provider-env-revision-v2");
+    hasher.update(b"openshell-provider-env-revision-v3");
 
     for record in records {
         hasher.update(record.name.as_bytes());
@@ -1739,10 +1940,32 @@ fn compute_provider_env_revision_from_records(
         }
     }
 
+    hash_policy_credential_bindings(policy_bindings, &mut hasher);
+
     let digest = hasher.finalize();
     Ok(u64::from_le_bytes(digest[..8].try_into().map_err(
         |_| Status::internal("provider env revision digest too short"),
     )?))
+}
+
+fn hash_policy_credential_bindings(
+    bindings: &HashMap<String, Vec<StaticCredentialEndpointBinding>>,
+    hasher: &mut Sha256,
+) {
+    let mut provider_names: Vec<_> = bindings.keys().collect();
+    provider_names.sort();
+    for provider_name in provider_names {
+        hasher.update(provider_name.as_bytes());
+        let mut endpoints = bindings[provider_name].clone();
+        endpoints.sort_by(|left, right| {
+            (&left.host, left.port, &left.path).cmp(&(&right.host, right.port, &right.path))
+        });
+        for endpoint in endpoints {
+            hasher.update(endpoint.host.as_bytes());
+            hasher.update(endpoint.port.to_le_bytes());
+            hasher.update(endpoint.path.as_bytes());
+        }
+    }
 }
 
 fn hash_provider_profile_revision(
@@ -1848,9 +2071,10 @@ pub(super) async fn handle_get_sandbox_provider_environment(
 
     let spec = sandbox
         .spec
+        .as_ref()
         .ok_or_else(|| Status::internal("sandbox has no spec"))?;
 
-    let provider_names = spec.providers;
+    let provider_names = spec.providers.clone();
     let provider_profile_catalog = state
         .provider_profile_sources
         .snapshot_catalog(state.store.as_ref(), &workspace)
@@ -1861,13 +2085,32 @@ pub(super) async fn handle_get_sandbox_provider_environment(
         &provider_names,
     )
     .await?;
-    let provider_env_revision =
-        compute_provider_env_revision_from_records(&provider_profile_catalog, &provider_records)?;
+    let effective_policy = current_effective_policy_for_sandbox(
+        state.as_ref(),
+        &provider_profile_catalog,
+        &workspace,
+        &sandbox,
+        &sandbox_id,
+    )
+    .await?;
+    let policy_credential_bindings =
+        policy_static_credential_endpoint_bindings(Some(&effective_policy))?;
+    validate_policy_credential_binding_context(
+        &provider_profile_catalog,
+        &provider_records,
+        &policy_credential_bindings,
+    )?;
+    let provider_env_revision = compute_provider_env_revision_from_records_and_policy_bindings(
+        &provider_profile_catalog,
+        &provider_records,
+        &policy_credential_bindings,
+    )?;
     let mut provider_environment =
-        super::provider::resolve_provider_environment_from_records_with_credentials(
+        super::provider::resolve_provider_environment_from_records_with_policy_bindings_and_credentials(
             state.store.as_ref(),
             &provider_profile_catalog,
             &provider_records,
+            &policy_credential_bindings,
             &state.credentials,
         )
         .await?;
@@ -2012,6 +2255,11 @@ async fn handle_update_config_inner(
             crate::middleware::validate_policy(state.middleware_registry.as_ref(), &new_policy)
                 .await?;
             validate_candidate_effective_policy(&new_policy, &[])?;
+            if !policy_static_credential_endpoint_bindings(Some(&new_policy))?.is_empty() {
+                return Err(Status::failed_precondition(
+                    "credential_binding is sandbox-scoped and cannot be used in a global policy",
+                ));
+            }
 
             let payload = new_policy.encode_to_vec();
             let hash = deterministic_policy_hash(&new_policy);
@@ -2289,6 +2537,20 @@ async fn handle_update_config_inner(
         let provider_layers =
             provider_policy_layers_for_sandbox(state, &workspace, &sandbox, &spec.providers)
                 .await?;
+        let provider_profile_catalog = state
+            .provider_profile_sources
+            .snapshot_catalog(state.store.as_ref(), &workspace)
+            .await?;
+        let provider_records = super::provider::load_provider_environment_records(
+            state.store.as_ref(),
+            &workspace,
+            &spec.providers,
+        )
+        .await?;
+        let credential_binding_context = PolicyCredentialBindingValidationContext {
+            catalog: &provider_profile_catalog,
+            records: &provider_records,
+        };
         let atomic_context = AtomicPolicyWriteContext {
             expected_resource_version: req.expected_resource_version,
             provenance: &req.annotations,
@@ -2304,7 +2566,10 @@ async fn handle_update_config_inner(
             &workspace,
             baseline_policy.as_ref(),
             &merge_ops,
-            &provider_layers,
+            PolicyMergeValidationContext {
+                provider_layers: &provider_layers,
+                credential_binding: Some(&credential_binding_context),
+            },
             Some(&atomic_context),
         )
         .await?;
@@ -2411,6 +2676,23 @@ async fn handle_update_config_inner(
     let provider_layers =
         provider_policy_layers_for_sandbox(state, &workspace, &sandbox, &spec.providers).await?;
     validate_candidate_effective_policy(&new_policy, &provider_layers)?;
+    let provider_profile_catalog = state
+        .provider_profile_sources
+        .snapshot_catalog(state.store.as_ref(), &workspace)
+        .await?;
+    let effective_policy = if provider_layers.is_empty() {
+        new_policy.clone()
+    } else {
+        compose_effective_policy(&new_policy, &provider_layers)
+    };
+    validate_policy_credential_bindings_for_sandbox(
+        state.as_ref(),
+        &provider_profile_catalog,
+        &workspace,
+        &spec.providers,
+        &effective_policy,
+    )
+    .await?;
 
     let _sandbox_sync_guard = if backfill_policy.is_some() {
         Some(state.compute.sandbox_sync_guard().await)
@@ -4481,15 +4763,26 @@ struct AtomicPolicyWriteContext<'a> {
     annotations: &'a HashMap<String, String>,
 }
 
+struct PolicyCredentialBindingValidationContext<'a> {
+    catalog: &'a EffectiveProviderProfileCatalog,
+    records: &'a [super::provider::ProviderEnvironmentRecord],
+}
+
+struct PolicyMergeValidationContext<'a> {
+    provider_layers: &'a [ProviderPolicyLayer],
+    credential_binding: Option<&'a PolicyCredentialBindingValidationContext<'a>>,
+}
+
 async fn apply_merge_operations_with_retry(
     store: &Store,
     sandbox_id: &str,
     workspace: &str,
     baseline_policy: Option<&ProtoSandboxPolicy>,
     operations: &[PolicyMergeOp],
-    provider_layers: &[ProviderPolicyLayer],
+    validation_context: PolicyMergeValidationContext<'_>,
     atomic_context: Option<&AtomicPolicyWriteContext<'_>>,
 ) -> Result<(i64, String, Option<Sandbox>), Status> {
+    let provider_layers = validation_context.provider_layers;
     for attempt in 1..=MERGE_RETRY_LIMIT {
         let latest = store
             .get_latest_policy(sandbox_id)
@@ -4512,6 +4805,19 @@ async fn apply_merge_operations_with_retry(
         }
         validate_policy_safety(&new_policy)?;
         validate_candidate_effective_policy(&new_policy, provider_layers)?;
+        let effective_policy = if provider_layers.is_empty() {
+            new_policy.clone()
+        } else {
+            compose_effective_policy(&new_policy, provider_layers)
+        };
+        let bindings = policy_static_credential_endpoint_bindings(Some(&effective_policy))?;
+        if let Some(context) = validation_context.credential_binding {
+            validate_policy_credential_binding_context(
+                context.catalog,
+                context.records,
+                &bindings,
+            )?;
+        }
 
         if let Some(ref current) = latest
             && current.policy_hash == hash
@@ -4622,7 +4928,10 @@ pub(super) async fn merge_chunk_into_policy(
         workspace,
         None,
         &operations,
-        provider_layers,
+        PolicyMergeValidationContext {
+            provider_layers,
+            credential_binding: None,
+        },
         None,
     )
     .await
@@ -4644,7 +4953,10 @@ async fn remove_chunk_from_policy(
             rule_name: chunk.rule_name.clone(),
             binary_path: chunk.binary.clone(),
         }],
-        &[],
+        PolicyMergeValidationContext {
+            provider_layers: &[],
+            credential_binding: None,
+        },
         None,
     )
     .await
@@ -5753,6 +6065,23 @@ mod tests {
         }
     }
 
+    fn test_policy_with_credential_binding(
+        rule_name: &str,
+        host: &str,
+        provider: &str,
+    ) -> ProtoSandboxPolicy {
+        let mut policy = test_policy_with_rule(rule_name, host);
+        policy
+            .network_policies
+            .get_mut(rule_name)
+            .unwrap()
+            .endpoints[0]
+            .credential_binding = Some(openshell_core::proto::NetworkCredentialBinding {
+            provider: provider.to_string(),
+        });
+        policy
+    }
+
     fn test_ambiguous_policy() -> ProtoSandboxPolicy {
         let mut left = test_policy_with_rule("left", "api.example.com");
         left.network_policies.get_mut("left").unwrap().endpoints[0].tls = "skip".to_string();
@@ -6522,6 +6851,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_config_rejects_credential_binding_to_unattached_provider() {
+        let state = test_server_state().await;
+        let mut sandbox = test_sandbox(
+            "sb-unattached-binding",
+            "unattached-binding",
+            ProtoSandboxPolicy::default(),
+            Vec::new(),
+        );
+        sandbox.spec.as_mut().unwrap().policy = None;
+        state.store.put_message(&sandbox).await.unwrap();
+
+        let error = handle_update_config(
+            &state,
+            with_user(Request::new(UpdateConfigRequest {
+                name: "unattached-binding".to_string(),
+                workspace: "default".to_string(),
+                policy: Some(test_policy_with_credential_binding(
+                    "cloud",
+                    "api.cloud.example",
+                    "missing-provider",
+                )),
+                ..Default::default()
+            })),
+        )
+        .await
+        .expect_err("unattached provider binding must fail before persistence");
+
+        assert_eq!(error.code(), Code::FailedPrecondition);
+        assert!(error.message().contains("not attached"));
+        assert!(
+            state
+                .store
+                .get_latest_policy("sb-unattached-binding")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn update_config_rejects_policy_binding_for_endpointful_profile() {
+        let state = test_server_state().await;
+        state
+            .store
+            .put_message(&test_provider("work-github", "github"))
+            .await
+            .unwrap();
+        let mut sandbox = test_sandbox(
+            "sb-double-binding",
+            "double-binding",
+            ProtoSandboxPolicy::default(),
+            vec!["work-github".to_string()],
+        );
+        sandbox.spec.as_mut().unwrap().policy = None;
+        state.store.put_message(&sandbox).await.unwrap();
+
+        let error = handle_update_config(
+            &state,
+            with_user(Request::new(UpdateConfigRequest {
+                name: "double-binding".to_string(),
+                workspace: "default".to_string(),
+                policy: Some(test_policy_with_credential_binding(
+                    "cloud",
+                    "api.cloud.example",
+                    "work-github",
+                )),
+                ..Default::default()
+            })),
+        )
+        .await
+        .expect_err("profile and policy must not both define credential endpoints");
+
+        assert_eq!(error.code(), Code::FailedPrecondition);
+        assert!(error.message().contains("already defines endpoints"));
+    }
+
+    #[tokio::test]
     async fn merge_operations_reject_ambiguity_before_persisting_revision() {
         let state = test_server_state().await;
         let mut policy = test_ambiguous_policy();
@@ -6540,7 +6946,10 @@ mod tests {
             "default",
             None,
             &operations,
-            &[],
+            PolicyMergeValidationContext {
+                provider_layers: &[],
+                credential_binding: None,
+            },
             None,
         )
         .await
@@ -7062,6 +7471,149 @@ mod tests {
 
         assert!(!response.environment.contains_key("GITHUB_TOKEN"));
         assert!(response.static_credential_bindings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn provider_environment_uses_policy_binding_for_endpointless_profile() {
+        use openshell_core::proto::{
+            GetSandboxConfigRequest, GetSandboxProviderEnvironmentRequest,
+            NetworkCredentialBinding, ProviderProfile, ProviderProfileCategory,
+            StoredProviderProfile,
+        };
+
+        let state = test_server_state().await;
+        state
+            .store
+            .put_message(&StoredProviderProfile {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: "profile-endpointless".to_string(),
+                    name: "endpointless".to_string(),
+                    workspace: "default".to_string(),
+                    ..Default::default()
+                }),
+                profile: Some(ProviderProfile {
+                    id: "endpointless".to_string(),
+                    display_name: "Endpointless".to_string(),
+                    category: ProviderProfileCategory::Other as i32,
+                    endpoints: Vec::new(),
+                    ..Default::default()
+                }),
+            })
+            .await
+            .unwrap();
+        let mut provider = test_provider("work-cloud", "endpointless");
+        provider.credentials =
+            HashMap::from([("CLOUD_TOKEN".to_string(), "cloud-secret".to_string())]);
+        state.store.put_message(&provider).await.unwrap();
+
+        let mut policy = test_policy_with_rule("cloud_api", "api.cloud.example");
+        policy
+            .network_policies
+            .get_mut("cloud_api")
+            .unwrap()
+            .endpoints[0]
+            .credential_binding = Some(NetworkCredentialBinding {
+            provider: "work-cloud".to_string(),
+        });
+        openshell_policy::ensure_sandbox_process_identity(&mut policy);
+        state
+            .store
+            .put_message(&test_sandbox(
+                "sb-policy-binding",
+                "policy-binding",
+                policy.clone(),
+                vec!["work-cloud".to_string()],
+            ))
+            .await
+            .unwrap();
+
+        let config = handle_get_sandbox_config(
+            &state,
+            with_user(Request::new(GetSandboxConfigRequest {
+                sandbox_id: "sb-policy-binding".to_string(),
+            })),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        let environment = handle_get_sandbox_provider_environment(
+            &state,
+            with_user(Request::new(GetSandboxProviderEnvironmentRequest {
+                sandbox_id: "sb-policy-binding".to_string(),
+                supports_static_credential_bindings: true,
+            })),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+        assert_eq!(
+            environment.environment.get("CLOUD_TOKEN"),
+            Some(&"cloud-secret".to_string())
+        );
+        assert_eq!(
+            environment.static_credential_bindings["CLOUD_TOKEN"].endpoints,
+            vec![StaticCredentialEndpointBinding {
+                host: "api.cloud.example".to_string(),
+                port: 443,
+                path: String::new(),
+            }]
+        );
+        assert_eq!(
+            config.provider_env_revision, environment.provider_env_revision,
+            "config and provider environment must advertise one atomic revision"
+        );
+
+        let mut next_policy = policy;
+        next_policy
+            .network_policies
+            .get_mut("cloud_api")
+            .unwrap()
+            .endpoints[0]
+            .host = "api2.cloud.example".to_string();
+        handle_update_config(
+            &state,
+            with_user(Request::new(UpdateConfigRequest {
+                name: "policy-binding".to_string(),
+                workspace: "default".to_string(),
+                policy: Some(next_policy),
+                ..Default::default()
+            })),
+        )
+        .await
+        .expect("policy binding update must succeed");
+        let next_config = handle_get_sandbox_config(
+            &state,
+            with_user(Request::new(GetSandboxConfigRequest {
+                sandbox_id: "sb-policy-binding".to_string(),
+            })),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        let next_environment = handle_get_sandbox_provider_environment(
+            &state,
+            with_user(Request::new(GetSandboxProviderEnvironmentRequest {
+                sandbox_id: "sb-policy-binding".to_string(),
+                supports_static_credential_bindings: true,
+            })),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+        assert_ne!(
+            config.provider_env_revision, next_config.provider_env_revision,
+            "changing the policy binding must rotate the provider environment revision"
+        );
+        assert_eq!(
+            next_config.provider_env_revision,
+            next_environment.provider_env_revision
+        );
+        assert_eq!(
+            next_environment.static_credential_bindings["CLOUD_TOKEN"].endpoints[0].host,
+            "api2.cloud.example"
+        );
     }
 
     #[tokio::test]
@@ -12067,7 +12619,10 @@ mod tests {
                 "default",
                 None,
                 &add_allow,
-                &[],
+                PolicyMergeValidationContext {
+                    provider_layers: &[],
+                    credential_binding: None,
+                },
                 None
             ),
             apply_merge_operations_with_retry(
@@ -12076,7 +12631,10 @@ mod tests {
                 "default",
                 None,
                 &add_deny,
-                &[],
+                PolicyMergeValidationContext {
+                    provider_layers: &[],
+                    credential_binding: None,
+                },
                 None
             ),
         );

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -1668,7 +1668,7 @@ pub(super) async fn compute_provider_env_revision_with_catalog(
             })? {
             Some(record) => {
                 hasher.update(record.id.as_bytes());
-                hasher.update(record.updated_at_ms.to_le_bytes());
+                hasher.update(record.resource_version.to_le_bytes());
 
                 let provider = Provider::decode(record.payload.as_slice()).map_err(|e| {
                     Status::internal(format!("decode provider '{provider_name}' failed: {e}"))
@@ -1696,6 +1696,46 @@ pub(super) async fn compute_provider_env_revision_with_catalog(
             None => {
                 hasher.update(b"missing");
             }
+        }
+    }
+
+    let digest = hasher.finalize();
+    Ok(u64::from_le_bytes(digest[..8].try_into().map_err(
+        |_| Status::internal("provider env revision digest too short"),
+    )?))
+}
+
+fn compute_provider_env_revision_from_records(
+    catalog: &EffectiveProviderProfileCatalog,
+    records: &[super::provider::ProviderEnvironmentRecord],
+) -> Result<u64, Status> {
+    let mut hasher = Sha256::new();
+    hasher.update(b"openshell-provider-env-revision-v2");
+
+    for record in records {
+        hasher.update(record.name.as_bytes());
+        hasher.update(record.object_id.as_bytes());
+        hasher.update(record.resource_version.to_le_bytes());
+
+        let provider = &record.provider;
+        hasher.update(provider.r#type.as_bytes());
+        hash_provider_profile_revision(
+            catalog,
+            &provider.r#type,
+            &provider.profile_workspace,
+            &mut hasher,
+        );
+
+        let mut credential_keys: Vec<_> = provider.credentials.keys().collect();
+        credential_keys.sort();
+        for key in credential_keys {
+            hasher.update(key.as_bytes());
+        }
+        let mut expiry_keys: Vec<_> = provider.credential_expires_at_ms.keys().collect();
+        expiry_keys.sort();
+        for key in expiry_keys {
+            hasher.update(key.as_bytes());
+            hasher.update(provider.credential_expires_at_ms[key].to_le_bytes());
         }
     }
 
@@ -1815,21 +1855,22 @@ pub(super) async fn handle_get_sandbox_provider_environment(
         .provider_profile_sources
         .snapshot_catalog(state.store.as_ref(), &workspace)
         .await?;
-    let provider_env_revision = compute_provider_env_revision_with_catalog(
+    let provider_records = super::provider::load_provider_environment_records(
         state.store.as_ref(),
-        &provider_profile_catalog,
         &workspace,
         &provider_names,
     )
     .await?;
-    let mut provider_environment = super::provider::resolve_provider_environment_with_credentials(
-        state.store.as_ref(),
-        &provider_profile_catalog,
-        &workspace,
-        &provider_names,
-        &state.credentials,
-    )
-    .await?;
+    let provider_env_revision =
+        compute_provider_env_revision_from_records(&provider_profile_catalog, &provider_records)?;
+    let mut provider_environment =
+        super::provider::resolve_provider_environment_from_records_with_credentials(
+            state.store.as_ref(),
+            &provider_profile_catalog,
+            &provider_records,
+            &state.credentials,
+        )
+        .await?;
 
     if !supports_static_credential_bindings {
         for key in &provider_environment.static_credential_keys {
@@ -7113,13 +7154,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn provider_env_revision_changes_when_attached_provider_record_changes() {
+    async fn provider_env_revision_changes_on_consecutive_provider_updates_without_delay() {
         use openshell_core::proto::GetSandboxProviderEnvironmentRequest;
-        use std::time::Duration;
 
         let state = test_server_state().await;
         let mut provider = test_provider("work-github", "github");
         state.store.put_message(&provider).await.unwrap();
+        let first_resource_version = state
+            .store
+            .get_by_name(Provider::object_type(), "default", "work-github")
+            .await
+            .unwrap()
+            .unwrap()
+            .resource_version;
         state
             .store
             .put_message(&test_sandbox(
@@ -7142,11 +7189,33 @@ mod tests {
         .unwrap()
         .into_inner();
 
-        tokio::time::sleep(Duration::from_millis(2)).await;
         provider
             .credentials
             .insert("GITHUB_TOKEN".to_string(), "rotated".to_string());
-        state.store.put_message(&provider).await.unwrap();
+        state
+            .store
+            .put_if(
+                Provider::object_type(),
+                provider.object_id(),
+                provider.object_name(),
+                provider.object_workspace(),
+                &provider.encode_to_vec(),
+                None,
+                crate::persistence::WriteCondition::Unconditional,
+            )
+            .await
+            .unwrap();
+        let second_resource_version = state
+            .store
+            .get_by_name(Provider::object_type(), "default", "work-github")
+            .await
+            .unwrap()
+            .unwrap()
+            .resource_version;
+        assert_ne!(
+            first_resource_version, second_resource_version,
+            "consecutive writes must advance the authoritative resource version"
+        );
 
         let second = handle_get_sandbox_provider_environment(
             &state,
@@ -7166,6 +7235,190 @@ mod tests {
         assert_eq!(
             second.environment.get("GITHUB_TOKEN"),
             Some(&"rotated".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_environment_revision_and_payload_share_immutable_record_snapshot() {
+        use openshell_core::proto::{
+            ProviderCredentialTokenGrant, ProviderProfile, ProviderProfileCategory,
+            ProviderProfileCredential, StoredProviderProfile,
+        };
+
+        fn dynamic_profile(
+            id: &str,
+            endpoint_host: &str,
+            token_endpoint: &str,
+        ) -> StoredProviderProfile {
+            StoredProviderProfile {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: format!("profile-{id}"),
+                    name: id.to_string(),
+                    created_at_ms: 1_000_000,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                    annotations: HashMap::new(),
+                    workspace: "default".to_string(),
+                    deletion_timestamp_ms: 0,
+                }),
+                profile: Some(ProviderProfile {
+                    id: id.to_string(),
+                    display_name: id.to_string(),
+                    category: ProviderProfileCategory::Other as i32,
+                    credentials: vec![ProviderProfileCredential {
+                        name: "access_token".to_string(),
+                        auth_style: "bearer".to_string(),
+                        header_name: "authorization".to_string(),
+                        token_grant: Some(ProviderCredentialTokenGrant {
+                            token_endpoint: token_endpoint.to_string(),
+                            audience: "api://snapshot".to_string(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }],
+                    endpoints: vec![NetworkEndpoint {
+                        host: endpoint_host.to_string(),
+                        port: 443,
+                        path: "/**".to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+            }
+        }
+
+        let state = test_server_state().await;
+        state
+            .store
+            .put_message(&dynamic_profile(
+                "snapshot-a",
+                "api.snapshot-a.example",
+                "https://auth.snapshot-a.example/token",
+            ))
+            .await
+            .unwrap();
+        state
+            .store
+            .put_message(&dynamic_profile(
+                "snapshot-b",
+                "api.snapshot-b.example",
+                "https://auth.snapshot-b.example/token",
+            ))
+            .await
+            .unwrap();
+        let catalog = state
+            .provider_profile_sources
+            .snapshot_catalog(state.store.as_ref(), "default")
+            .await
+            .unwrap();
+
+        let mut first_provider = test_provider("replaceable", "snapshot-a");
+        first_provider.metadata.as_mut().unwrap().id = "provider-identity-a".to_string();
+        first_provider.credentials =
+            HashMap::from([("GITHUB_TOKEN".to_string(), "secret-a".to_string())]);
+        state.store.put_message(&first_provider).await.unwrap();
+
+        let provider_names = vec!["replaceable".to_string()];
+        let first_records = crate::grpc::provider::load_provider_environment_records(
+            state.store.as_ref(),
+            "default",
+            &provider_names,
+        )
+        .await
+        .unwrap();
+        let first_revision =
+            compute_provider_env_revision_from_records(&catalog, &first_records).unwrap();
+        let mut next_version_records = first_records.clone();
+        next_version_records[0].resource_version += 1;
+        assert_ne!(
+            first_revision,
+            compute_provider_env_revision_from_records(&catalog, &next_version_records).unwrap(),
+            "resource version alone must advance the provider environment revision"
+        );
+
+        state
+            .store
+            .delete_by_name(Provider::object_type(), "default", "replaceable")
+            .await
+            .unwrap();
+        let mut replacement = test_provider("replaceable", "snapshot-b");
+        replacement.metadata.as_mut().unwrap().id = "provider-identity-b".to_string();
+        replacement.credentials =
+            HashMap::from([("GITHUB_TOKEN".to_string(), "secret-b".to_string())]);
+        state.store.put_message(&replacement).await.unwrap();
+
+        let first_environment = crate::grpc::provider::resolve_provider_environment_from_records(
+            state.store.as_ref(),
+            &catalog,
+            &first_records,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            first_environment.environment.get("GITHUB_TOKEN"),
+            Some(&"secret-a".to_string())
+        );
+        assert_eq!(
+            first_environment
+                .static_credential_bindings
+                .get("GITHUB_TOKEN")
+                .map(|binding| binding.credential_identity.as_str()),
+            Some("provider-identity-a:GITHUB_TOKEN")
+        );
+        assert_eq!(first_environment.dynamic_credentials.len(), 1);
+        assert!(
+            first_environment
+                .dynamic_credentials
+                .values()
+                .all(|credential| {
+                    credential.token_grant.as_ref().is_some_and(|grant| {
+                        grant.token_endpoint == "https://auth.snapshot-a.example/token"
+                    })
+                }),
+            "dynamic grants must come from the first loaded provider snapshot"
+        );
+
+        let replacement_records = crate::grpc::provider::load_provider_environment_records(
+            state.store.as_ref(),
+            "default",
+            &provider_names,
+        )
+        .await
+        .unwrap();
+        let replacement_revision =
+            compute_provider_env_revision_from_records(&catalog, &replacement_records).unwrap();
+        let replacement_environment =
+            crate::grpc::provider::resolve_provider_environment_from_records(
+                state.store.as_ref(),
+                &catalog,
+                &replacement_records,
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(first_revision, replacement_revision);
+        assert_eq!(
+            replacement_environment.environment.get("GITHUB_TOKEN"),
+            Some(&"secret-b".to_string())
+        );
+        assert_eq!(
+            replacement_environment
+                .static_credential_bindings
+                .get("GITHUB_TOKEN")
+                .map(|binding| binding.credential_identity.as_str()),
+            Some("provider-identity-b:GITHUB_TOKEN")
+        );
+        assert_eq!(replacement_environment.dynamic_credentials.len(), 1);
+        assert!(
+            replacement_environment
+                .dynamic_credentials
+                .values()
+                .all(|credential| {
+                    credential.token_grant.as_ref().is_some_and(|grant| {
+                        grant.token_endpoint == "https://auth.snapshot-b.example/token"
+                    })
+                }),
+            "dynamic grants must change only after loading the replacement record"
         );
     }
 

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -51,6 +51,8 @@ use openshell_core::telemetry::{
 };
 use openshell_core::{
     VERSION,
+    endpoint_path::EndpointPathPattern,
+    host_pattern::host_matches,
     settings::{self, SettingValueKind},
 };
 use openshell_ocsf::{
@@ -1220,6 +1222,7 @@ pub(super) fn policy_has_credential_binding_for_provider(
 fn validate_policy_credential_binding_context(
     catalog: &EffectiveProviderProfileCatalog,
     records: &[super::provider::ProviderEnvironmentRecord],
+    policy: &ProtoSandboxPolicy,
     bindings: &HashMap<String, Vec<StaticCredentialEndpointBinding>>,
 ) -> Result<(), Status> {
     for provider_name in bindings.keys() {
@@ -1250,7 +1253,136 @@ fn validate_policy_credential_binding_context(
             )));
         }
     }
+
+    validate_policy_signing_credential_sources(catalog, records, policy)?;
     Ok(())
+}
+
+const SIGV4_REQUIRED_CREDENTIAL_KEYS: [&str; 2] = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"];
+
+fn validate_policy_signing_credential_sources(
+    catalog: &EffectiveProviderProfileCatalog,
+    records: &[super::provider::ProviderEnvironmentRecord],
+    policy: &ProtoSandboxPolicy,
+) -> Result<(), Status> {
+    for rule in policy.network_policies.values() {
+        for endpoint in &rule.endpoints {
+            if endpoint.credential_signing.is_empty() {
+                continue;
+            }
+
+            let source = endpoint.credential_binding.as_ref().map_or_else(
+                || {
+                    records.iter().find_map(|record| {
+                        signing_profile_for_record(catalog, record).filter(|profile| {
+                            profile_declares_sigv4_credentials(profile)
+                                && !profile.endpoints.is_empty()
+                                && signed_endpoint_is_covered(
+                                    endpoint,
+                                    &profile.to_proto().endpoints,
+                                )
+                        })
+                    })
+                },
+                |binding| {
+                    records
+                        .iter()
+                        .find(|record| record.name == binding.provider)
+                        .and_then(|record| signing_profile_for_record(catalog, record))
+                        .filter(|profile| {
+                            profile_declares_sigv4_credentials(profile)
+                                && profile.endpoints.is_empty()
+                        })
+                },
+            );
+
+            if source.is_none() {
+                let selector = format_endpoint_selector(endpoint);
+                return Err(Status::failed_precondition(format!(
+                    "credential_signing endpoint '{selector}' has no resolvable AWS credential source; attach an endpoint-bearing provider profile that declares AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY and covers this endpoint, or set credential_binding.provider to an attached endpointless profile that declares those credentials"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn signing_profile_for_record(
+    catalog: &EffectiveProviderProfileCatalog,
+    record: &super::provider::ProviderEnvironmentRecord,
+) -> Option<openshell_providers::ProviderTypeProfile> {
+    let profile_id =
+        normalize_provider_type(&record.provider.r#type).unwrap_or(record.provider.r#type.as_str());
+    super::provider::get_provider_type_profile_for_scope(
+        catalog,
+        profile_id,
+        &record.provider.profile_workspace,
+    )
+}
+
+fn profile_declares_sigv4_credentials(profile: &openshell_providers::ProviderTypeProfile) -> bool {
+    let env_vars = profile.credential_env_vars();
+    SIGV4_REQUIRED_CREDENTIAL_KEYS
+        .iter()
+        .all(|required| env_vars.contains(required))
+}
+
+fn signed_endpoint_is_covered(
+    signed: &NetworkEndpoint,
+    profile_endpoints: &[NetworkEndpoint],
+) -> bool {
+    endpoint_ports_for_validation(signed)
+        .into_iter()
+        .all(|port| {
+            profile_endpoints.iter().any(|profile| {
+                endpoint_ports_for_validation(profile).contains(&port)
+                    && host_pattern_covers(&profile.host, &signed.host)
+                    && path_pattern_covers(&profile.path, &signed.path)
+            })
+        })
+}
+
+fn endpoint_ports_for_validation(endpoint: &NetworkEndpoint) -> Vec<u32> {
+    if endpoint.ports.is_empty() {
+        vec![endpoint.port]
+    } else {
+        endpoint.ports.clone()
+    }
+}
+
+fn host_pattern_covers(binding_pattern: &str, policy_pattern: &str) -> bool {
+    if binding_pattern.eq_ignore_ascii_case(policy_pattern) {
+        return true;
+    }
+    if contains_glob_syntax(policy_pattern) {
+        return false;
+    }
+    host_matches(binding_pattern, policy_pattern).unwrap_or(false)
+}
+
+fn path_pattern_covers(binding_pattern: &str, policy_pattern: &str) -> bool {
+    if binding_pattern == policy_pattern || matches!(binding_pattern, "" | "**" | "/**") {
+        return true;
+    }
+    if contains_glob_syntax(policy_pattern) {
+        return false;
+    }
+    EndpointPathPattern::new(binding_pattern).matches(policy_pattern)
+}
+
+fn contains_glob_syntax(value: &str) -> bool {
+    value
+        .chars()
+        .any(|character| matches!(character, '*' | '?' | '['))
+}
+
+fn format_endpoint_selector(endpoint: &NetworkEndpoint) -> String {
+    let ports = endpoint_ports_for_validation(endpoint)
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("{}:{ports}{}", endpoint.host, endpoint.path)
 }
 
 async fn validate_policy_credential_bindings_for_sandbox(
@@ -1261,7 +1393,12 @@ async fn validate_policy_credential_bindings_for_sandbox(
     policy: &ProtoSandboxPolicy,
 ) -> Result<HashMap<String, Vec<StaticCredentialEndpointBinding>>, Status> {
     let bindings = policy_static_credential_endpoint_bindings(Some(policy))?;
-    if bindings.is_empty() {
+    let has_signing = policy.network_policies.values().any(|rule| {
+        rule.endpoints
+            .iter()
+            .any(|endpoint| !endpoint.credential_signing.is_empty())
+    });
+    if bindings.is_empty() && !has_signing {
         return Ok(bindings);
     }
     let records = super::provider::load_provider_environment_records(
@@ -1270,7 +1407,7 @@ async fn validate_policy_credential_bindings_for_sandbox(
         provider_names,
     )
     .await?;
-    validate_policy_credential_binding_context(catalog, &records, &bindings)?;
+    validate_policy_credential_binding_context(catalog, &records, policy, &bindings)?;
     Ok(bindings)
 }
 
@@ -2098,6 +2235,7 @@ pub(super) async fn handle_get_sandbox_provider_environment(
     validate_policy_credential_binding_context(
         &provider_profile_catalog,
         &provider_records,
+        &effective_policy,
         &policy_credential_bindings,
     )?;
     let provider_env_revision = compute_provider_env_revision_from_records_and_policy_bindings(
@@ -4815,6 +4953,7 @@ async fn apply_merge_operations_with_retry(
             validate_policy_credential_binding_context(
                 context.catalog,
                 context.records,
+                &effective_policy,
                 &bindings,
             )?;
         }
@@ -6046,6 +6185,20 @@ mod tests {
         }
     }
 
+    fn test_aws_provider(name: &str, provider_type: &str) -> Provider {
+        let mut provider = test_provider(name, provider_type);
+        provider.credentials = [
+            ("AWS_ACCESS_KEY_ID".to_string(), "AKIATEST".to_string()),
+            (
+                "AWS_SECRET_ACCESS_KEY".to_string(),
+                "test-secret".to_string(),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        provider
+    }
+
     fn test_policy_with_rule(rule_name: &str, host: &str) -> ProtoSandboxPolicy {
         ProtoSandboxPolicy {
             network_policies: std::iter::once((
@@ -6079,6 +6232,21 @@ mod tests {
             .credential_binding = Some(openshell_core::proto::NetworkCredentialBinding {
             provider: provider.to_string(),
         });
+        policy
+    }
+
+    fn test_sigv4_policy(host: &str, provider: Option<&str>) -> ProtoSandboxPolicy {
+        let mut policy = test_policy_with_rule("aws", host);
+        let endpoint = &mut policy.network_policies.get_mut("aws").unwrap().endpoints[0];
+        endpoint.protocol = "rest".to_string();
+        endpoint.tls = "terminate".to_string();
+        endpoint.access = "full".to_string();
+        endpoint.credential_signing = "sigv4".to_string();
+        endpoint.signing_service = "s3".to_string();
+        endpoint.credential_binding =
+            provider.map(|provider| openshell_core::proto::NetworkCredentialBinding {
+                provider: provider.to_string(),
+            });
         policy
     }
 
@@ -6925,6 +7093,190 @@ mod tests {
 
         assert_eq!(error.code(), Code::FailedPrecondition);
         assert!(error.message().contains("already defines endpoints"));
+    }
+
+    #[tokio::test]
+    async fn update_config_rejects_sigv4_without_credential_source_before_persisting_revision() {
+        let state = test_server_state().await;
+        let mut sandbox = test_sandbox(
+            "sb-signing-no-source",
+            "signing-no-source",
+            ProtoSandboxPolicy::default(),
+            Vec::new(),
+        );
+        sandbox.spec.as_mut().unwrap().policy = None;
+        state.store.put_message(&sandbox).await.unwrap();
+
+        let error = handle_update_config(
+            &state,
+            with_user(Request::new(UpdateConfigRequest {
+                name: "signing-no-source".to_string(),
+                workspace: "default".to_string(),
+                policy: Some(test_sigv4_policy("s3.amazonaws.com", None)),
+                ..Default::default()
+            })),
+        )
+        .await
+        .expect_err("SigV4 policy without an AWS credential source must fail before persistence");
+
+        assert_eq!(error.code(), Code::FailedPrecondition);
+        assert!(
+            error
+                .message()
+                .contains("no resolvable AWS credential source")
+        );
+        assert!(
+            state
+                .store
+                .get_latest_policy("sb-signing-no-source")
+                .await
+                .unwrap()
+                .is_none(),
+            "invalid policy must not leave a revision in history"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_config_rejects_sigv4_for_unbound_endpointless_aws_profile() {
+        let state = test_server_state().await;
+        state
+            .store
+            .put_message(&test_aws_provider("aws-prod", "aws"))
+            .await
+            .unwrap();
+        let mut sandbox = test_sandbox(
+            "sb-signing-unbound-aws",
+            "signing-unbound-aws",
+            ProtoSandboxPolicy::default(),
+            vec!["aws-prod".to_string()],
+        );
+        sandbox.spec.as_mut().unwrap().policy = None;
+        state.store.put_message(&sandbox).await.unwrap();
+
+        let error = handle_update_config(
+            &state,
+            with_user(Request::new(UpdateConfigRequest {
+                name: "signing-unbound-aws".to_string(),
+                workspace: "default".to_string(),
+                policy: Some(test_sigv4_policy("s3.amazonaws.com", None)),
+                ..Default::default()
+            })),
+        )
+        .await
+        .expect_err("endpointless AWS profile must be bound explicitly");
+
+        assert_eq!(error.code(), Code::FailedPrecondition);
+        assert!(
+            error
+                .message()
+                .contains("no resolvable AWS credential source")
+        );
+    }
+
+    #[tokio::test]
+    async fn update_config_accepts_sigv4_bound_to_endpointless_aws_profile() {
+        let state = test_server_state().await;
+        state
+            .store
+            .put_message(&test_aws_provider("aws-prod", "aws"))
+            .await
+            .unwrap();
+        let mut sandbox = test_sandbox(
+            "sb-signing-bound-aws",
+            "signing-bound-aws",
+            ProtoSandboxPolicy::default(),
+            vec!["aws-prod".to_string()],
+        );
+        sandbox.spec.as_mut().unwrap().policy = None;
+        state.store.put_message(&sandbox).await.unwrap();
+
+        handle_update_config(
+            &state,
+            with_user(Request::new(UpdateConfigRequest {
+                name: "signing-bound-aws".to_string(),
+                workspace: "default".to_string(),
+                policy: Some(test_sigv4_policy("s3.amazonaws.com", Some("aws-prod"))),
+                ..Default::default()
+            })),
+        )
+        .await
+        .expect("bound endpointless AWS profile supplies SigV4 credentials");
+
+        assert!(
+            state
+                .store
+                .get_latest_policy("sb-signing-bound-aws")
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn update_config_accepts_sigv4_covered_by_endpointful_aws_profile() {
+        let state = test_server_state().await;
+        state
+            .store
+            .put_message(&test_aws_provider("s3-prod", "aws-s3"))
+            .await
+            .unwrap();
+        let mut sandbox = test_sandbox(
+            "sb-signing-profile-endpoint",
+            "signing-profile-endpoint",
+            ProtoSandboxPolicy::default(),
+            vec!["s3-prod".to_string()],
+        );
+        sandbox.spec.as_mut().unwrap().policy = None;
+        state.store.put_message(&sandbox).await.unwrap();
+
+        handle_update_config(
+            &state,
+            with_user(Request::new(UpdateConfigRequest {
+                name: "signing-profile-endpoint".to_string(),
+                workspace: "default".to_string(),
+                policy: Some(test_sigv4_policy("bucket.s3.amazonaws.com", None)),
+                ..Default::default()
+            })),
+        )
+        .await
+        .expect("endpoint-bearing AWS profile covers the signed endpoint");
+    }
+
+    #[tokio::test]
+    async fn update_config_rejects_sigv4_outside_endpointful_aws_profile_boundary() {
+        let state = test_server_state().await;
+        state
+            .store
+            .put_message(&test_aws_provider("s3-prod", "aws-s3"))
+            .await
+            .unwrap();
+        let mut sandbox = test_sandbox(
+            "sb-signing-profile-mismatch",
+            "signing-profile-mismatch",
+            ProtoSandboxPolicy::default(),
+            vec!["s3-prod".to_string()],
+        );
+        sandbox.spec.as_mut().unwrap().policy = None;
+        state.store.put_message(&sandbox).await.unwrap();
+
+        let error = handle_update_config(
+            &state,
+            with_user(Request::new(UpdateConfigRequest {
+                name: "signing-profile-mismatch".to_string(),
+                workspace: "default".to_string(),
+                policy: Some(test_sigv4_policy("api.example.com", None)),
+                ..Default::default()
+            })),
+        )
+        .await
+        .expect_err("profile endpoint boundary must cover a signed endpoint");
+
+        assert_eq!(error.code(), Code::FailedPrecondition);
+        assert!(
+            error
+                .message()
+                .contains("no resolvable AWS credential source")
+        );
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -1674,7 +1674,12 @@ pub(super) async fn compute_provider_env_revision_with_catalog(
                     Status::internal(format!("decode provider '{provider_name}' failed: {e}"))
                 })?;
                 hasher.update(provider.r#type.as_bytes());
-                hash_provider_profile_revision(catalog, &provider.r#type, &mut hasher);
+                hash_provider_profile_revision(
+                    catalog,
+                    &provider.r#type,
+                    &provider.profile_workspace,
+                    &mut hasher,
+                );
 
                 let mut credential_keys: Vec<_> = provider.credentials.keys().collect();
                 credential_keys.sort();
@@ -1703,10 +1708,11 @@ pub(super) async fn compute_provider_env_revision_with_catalog(
 fn hash_provider_profile_revision(
     catalog: &EffectiveProviderProfileCatalog,
     provider_type: &str,
+    profile_workspace: &str,
     hasher: &mut Sha256,
 ) {
     let profile_id = normalize_provider_type(provider_type).unwrap_or(provider_type);
-    catalog.hash_profile_revision(profile_id, hasher);
+    catalog.hash_type_profile_revision_for_scope(profile_id, profile_workspace, hasher);
 }
 
 #[cfg(test)]
@@ -7277,6 +7283,94 @@ mod tests {
         assert_ne!(
             first, second,
             "custom provider profile updates must trigger sandbox dynamic credential refresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn platform_profile_narrowing_changes_platform_provider_revision_when_shadowed() {
+        use crate::persistence::WriteCondition;
+        use openshell_core::proto::{
+            ProviderProfile, ProviderProfileCategory, StoredProviderProfile,
+        };
+
+        fn stored_profile(workspace: &str, path: &str) -> StoredProviderProfile {
+            StoredProviderProfile {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: format!(
+                        "profile-scoped-revision-{}",
+                        if workspace.is_empty() {
+                            "platform"
+                        } else {
+                            workspace
+                        }
+                    ),
+                    name: "scoped-revision".to_string(),
+                    created_at_ms: 1_000_000,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                    annotations: HashMap::new(),
+                    workspace: workspace.to_string(),
+                    deletion_timestamp_ms: 0,
+                }),
+                profile: Some(ProviderProfile {
+                    id: "scoped-revision".to_string(),
+                    display_name: format!("{workspace} scoped revision"),
+                    category: ProviderProfileCategory::Other as i32,
+                    endpoints: vec![NetworkEndpoint {
+                        host: "api.example.test".to_string(),
+                        port: 443,
+                        path: path.to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+            }
+        }
+
+        let store = test_store().await;
+        store.put_message(&stored_profile("", "/**")).await.unwrap();
+        store
+            .put_message(&stored_profile("default", "/workspace/**"))
+            .await
+            .unwrap();
+        let mut provider = test_provider("platform-scoped", "scoped-revision");
+        provider.profile_workspace = String::new();
+        store.put_message(&provider).await.unwrap();
+
+        let first =
+            compute_provider_env_revision(&store, "default", &["platform-scoped".to_string()])
+                .await
+                .unwrap();
+
+        let mut platform = store
+            .get_message_by_name::<StoredProviderProfile>("", "scoped-revision")
+            .await
+            .unwrap()
+            .unwrap();
+        let metadata = platform.metadata.as_ref().unwrap();
+        let object_id = metadata.id.clone();
+        let resource_version = metadata.resource_version;
+        platform.profile.as_mut().unwrap().endpoints[0].path = "/v1/**".to_string();
+        store
+            .put_if(
+                StoredProviderProfile::object_type(),
+                &object_id,
+                "scoped-revision",
+                "",
+                &platform.encode_to_vec(),
+                None,
+                WriteCondition::MatchResourceVersion(resource_version),
+            )
+            .await
+            .unwrap();
+
+        let second =
+            compute_provider_env_revision(&store, "default", &["platform-scoped".to_string()])
+                .await
+                .unwrap();
+        assert_ne!(
+            first, second,
+            "narrowing the selected platform fallback must refresh sandbox credentials"
         );
     }
 

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -1825,20 +1825,7 @@ pub(super) async fn handle_get_sandbox_provider_environment(
     )
     .await?;
 
-    if supports_static_credential_bindings {
-        for key in &provider_environment.static_credential_keys {
-            let Some(binding) = provider_environment.static_credential_bindings.get(key) else {
-                return Err(Status::failed_precondition(
-                    "static provider credentials require a provider profile with network endpoints",
-                ));
-            };
-            if binding.endpoints.is_empty() {
-                return Err(Status::failed_precondition(
-                    "static provider credentials require at least one provider profile endpoint",
-                ));
-            }
-        }
-    } else {
+    if !supports_static_credential_bindings {
         for key in &provider_environment.static_credential_keys {
             provider_environment.environment.remove(key);
             provider_environment.credential_expires_at_ms.remove(key);
@@ -7028,6 +7015,95 @@ mod tests {
 
         assert!(!response.environment.contains_key("GITHUB_TOKEN"));
         assert!(response.static_credential_bindings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn invalid_static_binding_does_not_suppress_valid_dynamic_credentials() {
+        use openshell_core::proto::{
+            GetSandboxProviderEnvironmentRequest, ProviderCredentialTokenGrant, ProviderProfile,
+            ProviderProfileCategory, ProviderProfileCredential, StoredProviderProfile,
+        };
+
+        let state = test_server_state().await;
+        let mut invalid_static = test_provider("invalid-static", "profile-without-endpoints");
+        invalid_static.credentials =
+            HashMap::from([("INVALID_TOKEN".to_string(), "static-secret".to_string())]);
+        let dynamic = test_provider("dynamic", "custom-dynamic");
+        let dynamic_profile = StoredProviderProfile {
+            metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                id: "profile-custom-dynamic".to_string(),
+                name: "custom-dynamic".to_string(),
+                created_at_ms: 1_000_000,
+                labels: HashMap::new(),
+                resource_version: 0,
+                annotations: HashMap::new(),
+                workspace: "default".to_string(),
+                deletion_timestamp_ms: 0,
+            }),
+            profile: Some(ProviderProfile {
+                id: "custom-dynamic".to_string(),
+                display_name: "Custom Dynamic".to_string(),
+                category: ProviderProfileCategory::Other as i32,
+                credentials: vec![ProviderProfileCredential {
+                    name: "access_token".to_string(),
+                    auth_style: "bearer".to_string(),
+                    header_name: "authorization".to_string(),
+                    token_grant: Some(ProviderCredentialTokenGrant {
+                        token_endpoint: "https://auth.example.test/token".to_string(),
+                        audience: "api://default".to_string(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                endpoints: vec![NetworkEndpoint {
+                    host: "api.dynamic.example.test".to_string(),
+                    port: 443,
+                    path: "/**".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+        };
+
+        state.store.put_message(&invalid_static).await.unwrap();
+        state.store.put_message(&dynamic).await.unwrap();
+        state.store.put_message(&dynamic_profile).await.unwrap();
+        state
+            .store
+            .put_message(&test_sandbox(
+                "sb-mixed-provider-env",
+                "mixed-provider-env",
+                test_policy_with_rule("sandbox_only", "sandbox.example.com"),
+                vec!["invalid-static".to_string(), "dynamic".to_string()],
+            ))
+            .await
+            .unwrap();
+
+        let response = handle_get_sandbox_provider_environment(
+            &state,
+            with_user(Request::new(GetSandboxProviderEnvironmentRequest {
+                sandbox_id: "sb-mixed-provider-env".to_string(),
+                supports_static_credential_bindings: true,
+            })),
+        )
+        .await
+        .expect("mixed snapshot must be returned")
+        .into_inner();
+
+        assert_eq!(
+            response.environment.get("INVALID_TOKEN"),
+            Some(&"static-secret".to_string())
+        );
+        assert!(
+            !response
+                .static_credential_bindings
+                .contains_key("INVALID_TOKEN"),
+            "incomplete static metadata must reach the supervisor for fail-closed rejection"
+        );
+        assert!(
+            !response.dynamic_credentials.is_empty(),
+            "valid dynamic credentials must survive an unrelated static binding failure"
+        );
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -15,14 +15,14 @@ use crate::provider_profile_sources::{
 use openshell_core::metadata::ObjectWorkspace;
 use openshell_core::proto::{
     CredentialHandle, Provider, ProviderCredentialTokenGrantAudienceOverride, ProviderProfile,
-    ProviderProfileCredential, Sandbox,
+    ProviderProfileCredential, Sandbox, StaticCredentialBinding, StaticCredentialEndpointBinding,
 };
 use openshell_core::telemetry::{
     LifecycleOperation, ProviderProfile as TelemetryProviderProfile, TelemetryOutcome,
 };
 use openshell_policy::ProviderPolicyLayer;
 use prost::Message;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tonic::Status;
 use tracing::warn;
 
@@ -58,6 +58,8 @@ pub(super) struct ProviderEnvironment {
     pub environment: HashMap<String, String>,
     pub credential_expires_at_ms: HashMap<String, i64>,
     pub dynamic_credentials: HashMap<String, ProviderProfileCredential>,
+    pub static_credential_bindings: HashMap<String, StaticCredentialBinding>,
+    pub static_credential_keys: HashSet<String>,
 }
 
 impl ProviderEnvironment {
@@ -929,6 +931,8 @@ pub(super) async fn resolve_provider_environment_with_credentials(
 
     let mut env = HashMap::new();
     let mut expires = HashMap::new();
+    let mut static_credential_bindings = HashMap::new();
+    let mut static_credential_keys = HashSet::new();
     let now_ms = crate::persistence::current_time_ms();
     validate_provider_environment_keys_unique_at(
         store,
@@ -947,6 +951,27 @@ pub(super) async fn resolve_provider_environment_with_credentials(
             .await
             .map_err(|e| Status::internal(format!("failed to fetch provider '{name}': {e}")))?
             .ok_or_else(|| Status::failed_precondition(format!("provider '{name}' not found")))?;
+
+        let profile_id =
+            normalize_provider_type(&provider.r#type).unwrap_or(provider.r#type.as_str());
+        let profile =
+            get_provider_type_profile_for_scope(catalog, profile_id, &provider.profile_workspace);
+        let profile_endpoints = profile.as_ref().map(|profile| {
+            profile
+                .to_proto()
+                .endpoints
+                .into_iter()
+                .flat_map(|endpoint| {
+                    endpoint_ports(endpoint.port, &endpoint.ports)
+                        .into_iter()
+                        .map(move |port| StaticCredentialEndpointBinding {
+                            host: endpoint.host.clone(),
+                            port,
+                            path: endpoint.path.clone(),
+                        })
+                })
+                .collect::<Vec<_>>()
+        });
 
         for (key, value) in &provider.credentials {
             if is_non_injectable_provider_credential(&provider, key) {
@@ -976,6 +1001,15 @@ pub(super) async fn resolve_provider_environment_with_credentials(
                     expires.entry(key.clone()).or_insert(expires_at_ms);
                 }
                 env.entry(key.clone()).or_insert_with(|| value.clone());
+                static_credential_keys.insert(key.clone());
+                if let Some(endpoints) = &profile_endpoints {
+                    static_credential_bindings.insert(
+                        key.clone(),
+                        StaticCredentialBinding {
+                            endpoints: endpoints.clone(),
+                        },
+                    );
+                }
             } else {
                 warn!(
                     provider_name = %name,
@@ -1029,6 +1063,8 @@ pub(super) async fn resolve_provider_environment_with_credentials(
             provider_names,
         )
         .await?,
+        static_credential_bindings,
+        static_credential_keys,
     })
 }
 
@@ -1339,16 +1375,7 @@ fn path_prefix_pattern(path: &str) -> Option<&str> {
 }
 
 fn endpoint_path_matches(pattern: &str, path: &str) -> bool {
-    if path_matches_all(pattern) {
-        return true;
-    }
-    if pattern == path {
-        return true;
-    }
-    if let Some(prefix) = path_prefix_pattern(pattern) {
-        return path == prefix || path.starts_with(&format!("{prefix}/"));
-    }
-    glob::Pattern::new(pattern).is_ok_and(|glob| glob.matches(path))
+    openshell_core::endpoint_path::matches(pattern, path)
 }
 
 pub async fn validate_provider_environment_keys_unique(
@@ -2702,6 +2729,25 @@ async fn profile_attached_sandbox_diagnostics(
                 continue;
             }
             if let Some((source, profile)) = candidate_profiles.get(profile_id) {
+                let has_static_credentials = provider
+                    .credentials
+                    .keys()
+                    .any(|key| !is_non_injectable_provider_credential(&provider, key));
+                let has_usable_endpoint = profile.to_proto().endpoints.iter().any(|endpoint| {
+                    !endpoint_ports(endpoint.port, &endpoint.ports).is_empty()
+                        && !endpoint.host.trim().is_empty()
+                });
+                if has_static_credentials && !has_usable_endpoint {
+                    diagnostics.push(ProfileValidationDiagnostic {
+                        source: source.clone(),
+                        profile_id: profile_id.to_string(),
+                        field: "endpoints".to_string(),
+                        message: format!(
+                            "{operation} would leave static provider credentials without an authorized endpoint on sandbox '{sandbox_name}'"
+                        ),
+                        severity: "error".to_string(),
+                    });
+                }
                 bindings.extend(dynamic_token_grant_bindings_for_profile(
                     provider.object_name(),
                     &profile.to_proto(),
@@ -7497,6 +7543,18 @@ mod tests {
         assert_eq!(result.get("ANTHROPIC_API_KEY"), Some(&"sk-abc".to_string()));
         assert_eq!(result.get("CLAUDE_API_KEY"), Some(&"sk-abc".to_string()));
         assert!(!result.contains_key("endpoint"));
+        assert!(
+            result
+                .static_credential_bindings
+                .get("ANTHROPIC_API_KEY")
+                .is_some_and(|binding| !binding.endpoints.is_empty())
+        );
+        assert!(
+            result
+                .static_credential_bindings
+                .get("CLAUDE_API_KEY")
+                .is_some_and(|binding| !binding.endpoints.is_empty())
+        );
     }
 
     #[tokio::test]
@@ -7517,6 +7575,7 @@ mod tests {
 
         assert_eq!(result.get("API_TOKEN"), Some(&"token-123".to_string()));
         assert!(result.dynamic_credentials.is_empty());
+        assert!(!result.static_credential_bindings.contains_key("API_TOKEN"));
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -1012,6 +1012,7 @@ pub(super) async fn resolve_provider_environment_from_records_with_credentials(
     for record in records {
         let name = &record.name;
         let provider = &record.provider;
+        let mut provider_env = HashMap::new();
         let profile_id =
             normalize_provider_type(&provider.r#type).unwrap_or(provider.r#type.as_str());
         let profile =
@@ -1060,7 +1061,7 @@ pub(super) async fn resolve_provider_environment_from_records_with_credentials(
                 if expires_at_ms > 0 {
                     expires.entry(key.clone()).or_insert(expires_at_ms);
                 }
-                env.entry(key.clone()).or_insert_with(|| value.clone());
+                provider_env.insert(key.clone(), value.clone());
                 static_credential_keys.insert(key.clone());
                 if let Some(endpoints) = &profile_endpoints {
                     if record.object_id.is_empty() {
@@ -1106,7 +1107,7 @@ pub(super) async fn resolve_provider_environment_from_records_with_credentials(
                 {
                     expires.entry(key.clone()).or_insert(expires_at_ms);
                 }
-                env.entry(key.clone()).or_insert(value);
+                provider_env.insert(key.clone(), value);
                 static_credential_keys.insert(key.clone());
                 if let Some(endpoints) = &profile_endpoints {
                     if record.object_id.is_empty() {
@@ -1131,7 +1132,14 @@ pub(super) async fn resolve_provider_environment_from_records_with_credentials(
             }
         }
 
-        registry.inject_env(provider, &mut env);
+        // Build each provider's emitted environment independently so another
+        // provider's earlier output cannot change how this provider classifies
+        // or populates its own keys. Cross-provider credential/config
+        // collisions have already been rejected by the validation above.
+        registry.inject_env(provider, &mut provider_env);
+        for (key, value) in provider_env {
+            env.entry(key).or_insert(value);
+        }
     }
 
     Ok(ProviderEnvironment {
@@ -1538,7 +1546,8 @@ async fn validate_provider_environment_keys_unique_at(
     candidate_provider: Option<&Provider>,
     now_ms: i64,
 ) -> Result<(), Status> {
-    let mut seen = HashMap::<String, String>::new();
+    let mut seen_credentials = HashMap::<String, String>::new();
+    let mut seen_plugin_config = HashMap::<String, String>::new();
     let mut dynamic_bindings = Vec::new();
     for name in provider_names {
         let provider = match candidate_provider {
@@ -1552,17 +1561,13 @@ async fn validate_provider_environment_keys_unique_at(
                 })?,
         };
         let provider_name = provider.object_name().to_string();
-        for key in active_provider_environment_keys(store, &provider, now_ms).await? {
-            if let Some(first_provider) = seen.get(&key) {
-                if first_provider != &provider_name {
-                    return Err(Status::failed_precondition(format!(
-                        "credential env key '{key}' is provided by both provider '{first_provider}' and provider '{provider_name}'; use provider-specific env names"
-                    )));
-                }
-            } else {
-                seen.insert(key, provider_name.clone());
-            }
-        }
+        validate_provider_environment_key_ownership(
+            &mut seen_credentials,
+            &mut seen_plugin_config,
+            &provider_name,
+            active_provider_environment_keys(store, &provider, now_ms).await?,
+            provider_plugin_environment_keys(&provider),
+        )?;
         dynamic_bindings.extend(dynamic_token_grant_bindings_for_provider_with_catalog(
             catalog, &provider,
         ));
@@ -1577,35 +1582,91 @@ async fn validate_provider_environment_records_unique_at(
     records: &[ProviderEnvironmentRecord],
     now_ms: i64,
 ) -> Result<(), Status> {
-    let mut seen = HashMap::<String, String>::new();
+    let mut seen_credentials = HashMap::<String, String>::new();
+    let mut seen_plugin_config = HashMap::<String, String>::new();
     let mut dynamic_bindings = Vec::new();
     for record in records {
         let provider = &record.provider;
-        for key in active_provider_environment_keys_for_identity(
-            store,
-            provider,
-            &record.object_id,
-            now_ms,
-        )
-        .await?
-        {
-            if let Some(first_provider) = seen.get(&key) {
-                if first_provider != &record.name {
-                    return Err(Status::failed_precondition(format!(
-                        "credential env key '{key}' is provided by both provider '{first_provider}' and provider '{}'; use provider-specific env names",
-                        record.name
-                    )));
-                }
-            } else {
-                seen.insert(key, record.name.clone());
-            }
-        }
+        validate_provider_environment_key_ownership(
+            &mut seen_credentials,
+            &mut seen_plugin_config,
+            &record.name,
+            active_provider_environment_keys_for_identity(
+                store,
+                provider,
+                &record.object_id,
+                now_ms,
+            )
+            .await?,
+            provider_plugin_environment_keys(provider),
+        )?;
         dynamic_bindings.extend(dynamic_token_grant_bindings_for_provider_with_catalog(
             catalog, provider,
         ));
     }
     validate_dynamic_token_grant_bindings_unambiguous(&dynamic_bindings)?;
     Ok(())
+}
+
+fn provider_plugin_environment_keys(provider: &Provider) -> Vec<String> {
+    let mut plugin_environment = HashMap::new();
+    openshell_providers::ProviderRegistry::new().inject_env(provider, &mut plugin_environment);
+    plugin_environment.into_keys().collect()
+}
+
+fn validate_provider_environment_key_ownership(
+    seen_credentials: &mut HashMap<String, String>,
+    seen_plugin_config: &mut HashMap<String, String>,
+    provider_name: &str,
+    credential_keys: Vec<String>,
+    plugin_config_keys: Vec<String>,
+) -> Result<(), Status> {
+    for key in credential_keys {
+        if let Some(first_provider) = seen_credentials.get(&key) {
+            if first_provider != provider_name {
+                return Err(Status::failed_precondition(format!(
+                    "credential env key '{key}' is provided by both provider '{first_provider}' and provider '{provider_name}'; use provider-specific env names"
+                )));
+            }
+        } else {
+            seen_credentials.insert(key.clone(), provider_name.to_string());
+        }
+        if let Some(config_provider) = seen_plugin_config.get(&key)
+            && config_provider != provider_name
+        {
+            return Err(provider_credential_config_key_collision(
+                &key,
+                provider_name,
+                config_provider,
+            ));
+        }
+    }
+
+    for key in plugin_config_keys {
+        if let Some(credential_provider) = seen_credentials.get(&key)
+            && credential_provider != provider_name
+        {
+            return Err(provider_credential_config_key_collision(
+                &key,
+                credential_provider,
+                provider_name,
+            ));
+        }
+        seen_plugin_config
+            .entry(key)
+            .or_insert_with(|| provider_name.to_string());
+    }
+    Ok(())
+}
+
+fn provider_credential_config_key_collision(
+    key: &str,
+    credential_provider: &str,
+    config_provider: &str,
+) -> Status {
+    Status::failed_precondition(format!(
+        "credential env key '{key}' from provider '{credential_provider}' conflicts with provider-generated config from provider '{config_provider}'; use provider-specific env names"
+    ))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -8039,6 +8100,95 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn provider_environment_rejects_plugin_config_credential_collision_in_both_orders() {
+        let store = test_store().await;
+        create_provider_record(
+            &store,
+            "default",
+            Provider {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: String::new(),
+                    name: "google-config".to_string(),
+                    created_at_ms: 0,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                    annotations: HashMap::new(),
+                    workspace: "default".to_string(),
+                    deletion_timestamp_ms: 0,
+                }),
+                r#type: "google-cloud".to_string(),
+                credentials: std::iter::once((
+                    "GCP_ACCESS_TOKEN".to_string(),
+                    "google-token".to_string(),
+                ))
+                .collect(),
+                config: std::iter::once(("project_id".to_string(), "config-project".to_string()))
+                    .collect(),
+                credential_expires_at_ms: HashMap::new(),
+                profile_workspace: "default".to_string(),
+                credential_handles: HashMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+        create_provider_record(
+            &store,
+            "default",
+            Provider {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: String::new(),
+                    name: "static-credential".to_string(),
+                    created_at_ms: 0,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                    annotations: HashMap::new(),
+                    workspace: "default".to_string(),
+                    deletion_timestamp_ms: 0,
+                }),
+                r#type: "gitlab".to_string(),
+                credentials: std::iter::once((
+                    "GCP_PROJECT_ID".to_string(),
+                    "credential-value".to_string(),
+                ))
+                .collect(),
+                config: HashMap::new(),
+                credential_expires_at_ms: HashMap::new(),
+                profile_workspace: "default".to_string(),
+                credential_handles: HashMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let attachment_orders = [
+            vec!["google-config".to_string(), "static-credential".to_string()],
+            vec!["static-credential".to_string(), "google-config".to_string()],
+        ];
+        let mut messages = Vec::new();
+        for providers in attachment_orders {
+            let validation_error =
+                validate_provider_environment_keys_unique(&store, "default", &providers)
+                    .await
+                    .unwrap_err();
+            assert_eq!(validation_error.code(), Code::FailedPrecondition);
+
+            let resolution_error = resolve_provider_environment(&store, "default", &providers)
+                .await
+                .unwrap_err();
+            assert_eq!(resolution_error.code(), Code::FailedPrecondition);
+            assert_eq!(validation_error.message(), resolution_error.message());
+            assert!(resolution_error.message().contains("GCP_PROJECT_ID"));
+            assert!(resolution_error.message().contains("static-credential"));
+            assert!(resolution_error.message().contains("google-config"));
+            messages.push(resolution_error.message().to_string());
+        }
+        assert_eq!(
+            messages[0], messages[1],
+            "collision rejection must not depend on attachment order"
+        );
+    }
+
+    #[tokio::test]
     async fn resolve_provider_env_injects_vertex_agent_config() {
         let store = test_store().await;
         create_provider_record(
@@ -8432,6 +8582,122 @@ mod tests {
         assert_eq!(err.code(), Code::FailedPrecondition);
         assert!(err.message().contains("collision"));
         assert!(err.message().contains("MS_GRAPH_ACCESS_TOKEN"));
+    }
+
+    #[tokio::test]
+    async fn update_provider_rejects_plugin_config_credential_collision() {
+        let store = test_store().await;
+        create_provider_record(
+            &store,
+            "default",
+            Provider {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: String::new(),
+                    name: "google-config".to_string(),
+                    created_at_ms: 0,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                    annotations: HashMap::new(),
+                    workspace: "default".to_string(),
+                    deletion_timestamp_ms: 0,
+                }),
+                r#type: "google-cloud".to_string(),
+                credentials: std::iter::once((
+                    "GCP_ACCESS_TOKEN".to_string(),
+                    "google-token".to_string(),
+                ))
+                .collect(),
+                config: std::iter::once(("project_id".to_string(), "config-project".to_string()))
+                    .collect(),
+                credential_expires_at_ms: HashMap::new(),
+                profile_workspace: "default".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        create_provider_record(
+            &store,
+            "default",
+            Provider {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: String::new(),
+                    name: "credential-provider".to_string(),
+                    created_at_ms: 0,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                    annotations: HashMap::new(),
+                    workspace: "default".to_string(),
+                    deletion_timestamp_ms: 0,
+                }),
+                r#type: "gitlab".to_string(),
+                credentials: std::iter::once((
+                    "GITLAB_TOKEN".to_string(),
+                    "gitlab-token".to_string(),
+                ))
+                .collect(),
+                config: HashMap::new(),
+                credential_expires_at_ms: HashMap::new(),
+                profile_workspace: "default".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        store
+            .put_message(&Sandbox {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: "sandbox-plugin-config-collision".to_string(),
+                    name: "plugin-config-collision".to_string(),
+                    created_at_ms: 0,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                    annotations: HashMap::new(),
+                    workspace: "default".to_string(),
+                    deletion_timestamp_ms: 0,
+                }),
+                spec: Some(SandboxSpec {
+                    providers: vec![
+                        "google-config".to_string(),
+                        "credential-provider".to_string(),
+                    ],
+                    ..SandboxSpec::default()
+                }),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let err = update_provider_record(
+            &store,
+            "default",
+            Provider {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: String::new(),
+                    name: "credential-provider".to_string(),
+                    created_at_ms: 0,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                    annotations: HashMap::new(),
+                    workspace: "default".to_string(),
+                    deletion_timestamp_ms: 0,
+                }),
+                r#type: String::new(),
+                credentials: std::iter::once((
+                    "GCP_PROJECT_ID".to_string(),
+                    "credential-value".to_string(),
+                ))
+                .collect(),
+                config: HashMap::new(),
+                credential_expires_at_ms: HashMap::new(),
+                profile_workspace: "default".to_string(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.code(), Code::FailedPrecondition);
+        assert!(err.message().contains("GCP_PROJECT_ID"));
+        assert!(err.message().contains("credential-provider"));
+        assert!(err.message().contains("google-config"));
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -62,6 +62,19 @@ pub(super) struct ProviderEnvironment {
     pub static_credential_keys: HashSet<String>,
 }
 
+/// Immutable provider records used to build one provider-environment response.
+///
+/// The persistence metadata is kept alongside the decoded provider so callers
+/// can derive both the revision and credential identities from the exact same
+/// records used to resolve environment values and dynamic grants.
+#[derive(Debug, Clone)]
+pub(super) struct ProviderEnvironmentRecord {
+    pub name: String,
+    pub object_id: String,
+    pub resource_version: u64,
+    pub provider: Provider,
+}
+
 impl ProviderEnvironment {
     #[cfg(test)]
     fn is_empty(&self) -> bool {
@@ -925,7 +938,66 @@ pub(super) async fn resolve_provider_environment_with_credentials(
     provider_names: &[String],
     credentials: &crate::credentials::CredentialRuntime,
 ) -> Result<ProviderEnvironment, Status> {
-    if provider_names.is_empty() {
+    let records = load_provider_environment_records(store, workspace, provider_names).await?;
+    resolve_provider_environment_from_records_with_credentials(
+        store,
+        catalog,
+        &records,
+        credentials,
+    )
+    .await
+}
+
+pub(super) async fn load_provider_environment_records(
+    store: &Store,
+    workspace: &str,
+    provider_names: &[String],
+) -> Result<Vec<ProviderEnvironmentRecord>, Status> {
+    let mut records = Vec::with_capacity(provider_names.len());
+    for name in provider_names {
+        let record = store
+            .get_by_name(Provider::object_type(), workspace, name)
+            .await
+            .map_err(|e| Status::internal(format!("failed to fetch provider '{name}': {e}")))?
+            .ok_or_else(|| Status::failed_precondition(format!("provider '{name}' not found")))?;
+        let provider = Provider::decode(record.payload.as_slice())
+            .map_err(|e| Status::internal(format!("failed to decode provider '{name}': {e}")))?;
+        records.push(ProviderEnvironmentRecord {
+            name: name.clone(),
+            object_id: record.id,
+            resource_version: record.resource_version,
+            provider,
+        });
+    }
+    Ok(records)
+}
+
+#[cfg(test)]
+pub(super) async fn resolve_provider_environment_from_records(
+    store: &Store,
+    catalog: &EffectiveProviderProfileCatalog,
+    records: &[ProviderEnvironmentRecord],
+) -> Result<ProviderEnvironment, Status> {
+    let credentials = crate::credentials::CredentialRuntime::from_config(
+        &openshell_core::Config::new(None).with_credential_drivers(["test-static"]),
+    )
+    .map_err(|err| Status::internal(format!("initialize credential runtime failed: {err}")))?;
+    resolve_provider_environment_from_records_with_credentials(
+        store,
+        catalog,
+        records,
+        &credentials,
+    )
+    .await
+}
+
+pub(super) async fn resolve_provider_environment_from_records_with_credentials(
+    store: &Store,
+    catalog: &EffectiveProviderProfileCatalog,
+    records: &[ProviderEnvironmentRecord],
+    credentials: &crate::credentials::CredentialRuntime,
+) -> Result<ProviderEnvironment, Status> {
+    if records.is_empty() {
         return Ok(ProviderEnvironment::default());
     }
 
@@ -934,24 +1006,12 @@ pub(super) async fn resolve_provider_environment_with_credentials(
     let mut static_credential_bindings = HashMap::new();
     let mut static_credential_keys = HashSet::new();
     let now_ms = crate::persistence::current_time_ms();
-    validate_provider_environment_keys_unique_at(
-        store,
-        catalog,
-        workspace,
-        provider_names,
-        None,
-        now_ms,
-    )
-    .await?;
+    validate_provider_environment_records_unique_at(store, catalog, records, now_ms).await?;
     let registry = openshell_providers::ProviderRegistry::new();
 
-    for name in provider_names {
-        let provider = store
-            .get_message_by_name::<Provider>(workspace, name)
-            .await
-            .map_err(|e| Status::internal(format!("failed to fetch provider '{name}': {e}")))?
-            .ok_or_else(|| Status::failed_precondition(format!("provider '{name}' not found")))?;
-
+    for record in records {
+        let name = &record.name;
+        let provider = &record.provider;
         let profile_id =
             normalize_provider_type(&provider.r#type).unwrap_or(provider.r#type.as_str());
         let profile =
@@ -974,7 +1034,7 @@ pub(super) async fn resolve_provider_environment_with_credentials(
         });
 
         for (key, value) in &provider.credentials {
-            if is_non_injectable_provider_credential(&provider, key) {
+            if is_non_injectable_provider_credential(provider, key) {
                 warn!(
                     provider_name = %name,
                     key = %key,
@@ -1003,8 +1063,7 @@ pub(super) async fn resolve_provider_environment_with_credentials(
                 env.entry(key.clone()).or_insert_with(|| value.clone());
                 static_credential_keys.insert(key.clone());
                 if let Some(endpoints) = &profile_endpoints {
-                    let provider_identity = provider.object_id();
-                    if provider_identity.is_empty() {
+                    if record.object_id.is_empty() {
                         return Err(Status::failed_precondition(format!(
                             "provider '{name}' has no stable object identity"
                         )));
@@ -1013,7 +1072,7 @@ pub(super) async fn resolve_provider_environment_with_credentials(
                         key.clone(),
                         StaticCredentialBinding {
                             endpoints: endpoints.clone(),
-                            credential_identity: format!("{provider_identity}:{key}"),
+                            credential_identity: format!("{}:{key}", record.object_id),
                         },
                     );
                 }
@@ -1027,10 +1086,10 @@ pub(super) async fn resolve_provider_environment_with_credentials(
         }
 
         let resolved_refs = credentials
-            .resolve_provider_handles(&provider, now_ms)
+            .resolve_provider_handles(provider, now_ms)
             .await?;
         for (key, value) in resolved_refs.values {
-            if is_non_injectable_provider_credential(&provider, &key) {
+            if is_non_injectable_provider_credential(provider, &key) {
                 warn!(
                     provider_name = %name,
                     key = %key,
@@ -1047,7 +1106,22 @@ pub(super) async fn resolve_provider_environment_with_credentials(
                 {
                     expires.entry(key.clone()).or_insert(expires_at_ms);
                 }
-                env.entry(key).or_insert(value);
+                env.entry(key.clone()).or_insert(value);
+                static_credential_keys.insert(key.clone());
+                if let Some(endpoints) = &profile_endpoints {
+                    if record.object_id.is_empty() {
+                        return Err(Status::failed_precondition(format!(
+                            "provider '{name}' has no stable object identity"
+                        )));
+                    }
+                    static_credential_bindings.insert(
+                        key.clone(),
+                        StaticCredentialBinding {
+                            endpoints: endpoints.clone(),
+                            credential_identity: format!("{}:{key}", record.object_id),
+                        },
+                    );
+                }
             } else {
                 warn!(
                     provider_name = %name,
@@ -1057,52 +1131,27 @@ pub(super) async fn resolve_provider_environment_with_credentials(
             }
         }
 
-        registry.inject_env(&provider, &mut env);
+        registry.inject_env(provider, &mut env);
     }
 
     Ok(ProviderEnvironment {
         environment: env,
         credential_expires_at_ms: expires,
-        dynamic_credentials: resolve_dynamic_credentials_with_catalog(
-            store,
-            catalog,
-            workspace,
-            provider_names,
-        )
-        .await?,
+        dynamic_credentials: resolve_dynamic_credentials_from_records(catalog, records),
         static_credential_bindings,
         static_credential_keys,
     })
 }
 
-/// Resolve dynamic credentials (token grants) from provider profiles.
-///
-/// Returns a map of endpoint-bound keys to credential metadata for credentials
-/// that have `token_grant` configuration. Keys are internal supervisor metadata:
-/// host, port, endpoint path, and provider credential identity.
-pub(super) async fn resolve_dynamic_credentials_with_catalog(
-    store: &Store,
+/// Resolve dynamic credentials (token grants) from the same records used for
+/// the provider-environment revision and static credential bindings.
+fn resolve_dynamic_credentials_from_records(
     catalog: &EffectiveProviderProfileCatalog,
-    workspace: &str,
-    provider_names: &[String],
-) -> Result<HashMap<String, ProviderProfileCredential>, Status> {
-    if provider_names.is_empty() {
-        return Ok(HashMap::new());
-    }
-
+    records: &[ProviderEnvironmentRecord],
+) -> HashMap<String, ProviderProfileCredential> {
     let mut dynamic_creds = HashMap::new();
-
-    for provider_name in provider_names {
-        let provider = store
-            .get_message_by_name::<Provider>(workspace, provider_name)
-            .await
-            .map_err(|e| {
-                Status::internal(format!("failed to fetch provider '{provider_name}': {e}"))
-            })?
-            .ok_or_else(|| {
-                Status::failed_precondition(format!("provider '{provider_name}' not found"))
-            })?;
-
+    for record in records {
+        let provider = &record.provider;
         let profile_id =
             normalize_provider_type(&provider.r#type).unwrap_or(provider.r#type.as_str());
         let Some(profile) =
@@ -1110,15 +1159,13 @@ pub(super) async fn resolve_dynamic_credentials_with_catalog(
         else {
             continue;
         };
-
         insert_dynamic_credentials_for_profile(
             &mut dynamic_creds,
             &profile.to_proto(),
-            provider_name,
+            &record.name,
         );
     }
-
-    Ok(dynamic_creds)
+    dynamic_creds
 }
 
 fn insert_dynamic_credentials_for_profile(
@@ -1524,6 +1571,43 @@ async fn validate_provider_environment_keys_unique_at(
     Ok(())
 }
 
+async fn validate_provider_environment_records_unique_at(
+    store: &Store,
+    catalog: &EffectiveProviderProfileCatalog,
+    records: &[ProviderEnvironmentRecord],
+    now_ms: i64,
+) -> Result<(), Status> {
+    let mut seen = HashMap::<String, String>::new();
+    let mut dynamic_bindings = Vec::new();
+    for record in records {
+        let provider = &record.provider;
+        for key in active_provider_environment_keys_for_identity(
+            store,
+            provider,
+            &record.object_id,
+            now_ms,
+        )
+        .await?
+        {
+            if let Some(first_provider) = seen.get(&key) {
+                if first_provider != &record.name {
+                    return Err(Status::failed_precondition(format!(
+                        "credential env key '{key}' is provided by both provider '{first_provider}' and provider '{}'; use provider-specific env names",
+                        record.name
+                    )));
+                }
+            } else {
+                seen.insert(key, record.name.clone());
+            }
+        }
+        dynamic_bindings.extend(dynamic_token_grant_bindings_for_provider_with_catalog(
+            catalog, provider,
+        ));
+    }
+    validate_dynamic_token_grant_bindings_unambiguous(&dynamic_bindings)?;
+    Ok(())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DynamicTokenGrantBinding {
     provider_name: String,
@@ -1682,10 +1766,20 @@ async fn active_provider_environment_keys(
     provider: &Provider,
     now_ms: i64,
 ) -> Result<Vec<String>, Status> {
+    active_provider_environment_keys_for_identity(store, provider, provider.object_id(), now_ms)
+        .await
+}
+
+async fn active_provider_environment_keys_for_identity(
+    store: &Store,
+    provider: &Provider,
+    provider_identity: &str,
+    now_ms: i64,
+) -> Result<Vec<String>, Status> {
     let mut keys = active_provider_credential_keys(provider, now_ms);
-    if !provider.object_id().is_empty() {
+    if !provider_identity.is_empty() {
         for state in
-            crate::provider_refresh::list_refresh_states_for_provider(store, provider.object_id())
+            crate::provider_refresh::list_refresh_states_for_provider(store, provider_identity)
                 .await?
         {
             // The primary key plus every co-minted output key this refresh owns,

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -931,6 +931,7 @@ pub(super) async fn resolve_provider_environment_with_catalog(
     .await
 }
 
+#[cfg(test)]
 pub(super) async fn resolve_provider_environment_with_credentials(
     store: &Store,
     catalog: &EffectiveProviderProfileCatalog,
@@ -992,6 +993,7 @@ pub(super) async fn resolve_provider_environment_from_records(
     .await
 }
 
+#[cfg(test)]
 pub(super) async fn resolve_provider_environment_from_records_with_credentials(
     store: &Store,
     catalog: &EffectiveProviderProfileCatalog,
@@ -7958,6 +7960,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_provider_env_binds_endpointless_credential_handle_only_from_policy() {
+        let store = test_store().await;
+        let config = openshell_core::Config::new(None).with_credential_drivers(["test-static"]);
+        let credentials = crate::credentials::CredentialRuntime::from_config(&config).unwrap();
+        let catalog = ProviderProfileSources::with_default_sources()
+            .snapshot_catalog(&store, "default")
+            .await
+            .unwrap();
+        let mut google_cloud = google_cloud_provider(HashMap::from([(
+            "project_id".to_string(),
+            "sandbox-project".to_string(),
+        )]));
+        google_cloud.credentials = HashMap::from([(
+            "GCP_ADC_ACCESS_TOKEN".to_string(),
+            "google-token".to_string(),
+        )]);
+        create_provider_record_validating(
+            &store,
+            "default",
+            &catalog,
+            google_cloud,
+            Some(&credentials),
+        )
+        .await
+        .unwrap();
+
+        let provider_names = ["my-google-cloud".to_string()];
+        let records = load_provider_environment_records(&store, "default", &provider_names)
+            .await
+            .unwrap();
+        assert!(records[0].provider.credentials.is_empty());
+        assert!(
+            records[0]
+                .provider
+                .credential_handles
+                .contains_key("GCP_ADC_ACCESS_TOKEN")
+        );
+
+        let unbound =
+            resolve_provider_environment_from_records_with_policy_bindings_and_credentials(
+                &store,
+                &catalog,
+                &records,
+                &HashMap::new(),
+                &credentials,
+            )
+            .await
+            .unwrap();
+        assert!(!unbound.contains_key("GCP_ADC_ACCESS_TOKEN"));
+        assert!(
+            !unbound
+                .static_credential_bindings
+                .contains_key("GCP_ADC_ACCESS_TOKEN")
+        );
+
+        let policy_bindings = HashMap::from([(
+            "my-google-cloud".to_string(),
+            vec![StaticCredentialEndpointBinding {
+                host: "storage.googleapis.com".to_string(),
+                port: 443,
+                path: "/**".to_string(),
+            }],
+        )]);
+        let bound = resolve_provider_environment_from_records_with_policy_bindings_and_credentials(
+            &store,
+            &catalog,
+            &records,
+            &policy_bindings,
+            &credentials,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            bound.get("GCP_ADC_ACCESS_TOKEN"),
+            Some(&"google-token".to_string())
+        );
+        assert_eq!(
+            bound
+                .static_credential_bindings
+                .get("GCP_ADC_ACCESS_TOKEN")
+                .map(|binding| binding.endpoints.as_slice()),
+            Some(policy_bindings["my-google-cloud"].as_slice())
+        );
+    }
+
+    #[tokio::test]
     async fn resolve_provider_env_allows_static_provider_without_profile() {
         let store = test_store().await;
         create_provider_record(
@@ -7991,7 +8079,12 @@ mod tests {
             &store,
             "default",
             &catalog,
-            provider_with_credential_value("openai-local", "openai", "OPENAI_API_KEY", "sk-test"),
+            provider_with_credential_value(
+                "github-local",
+                "github",
+                "GITHUB_TOKEN",
+                "github-token",
+            ),
             Some(&credentials),
         )
         .await
@@ -8003,7 +8096,7 @@ mod tests {
             &store,
             &catalog,
             "default",
-            &["openai-local".to_string()],
+            &["github-local".to_string()],
             &other_credentials,
         )
         .await
@@ -8026,7 +8119,12 @@ mod tests {
             &store,
             "default",
             &catalog,
-            provider_with_credential_value("openai-local", "openai", "OPENAI_API_KEY", "sk-test"),
+            provider_with_credential_value(
+                "github-local",
+                "github",
+                "GITHUB_TOKEN",
+                "github-token",
+            ),
             Some(&credentials),
         )
         .await
@@ -8036,13 +8134,23 @@ mod tests {
             &store,
             &catalog,
             "default",
-            &["openai-local".to_string()],
+            &["github-local".to_string()],
             &credentials,
         )
         .await
         .unwrap();
 
-        assert_eq!(result.get("OPENAI_API_KEY"), Some(&"sk-test".to_string()));
+        assert_eq!(
+            result.get("GITHUB_TOKEN"),
+            Some(&"github-token".to_string())
+        );
+        assert!(result.static_credential_keys.contains("GITHUB_TOKEN"));
+        assert!(
+            result
+                .static_credential_bindings
+                .get("GITHUB_TOKEN")
+                .is_some_and(|binding| !binding.endpoints.is_empty())
+        );
     }
 
     #[tokio::test]
@@ -8849,6 +8957,7 @@ mod tests {
                     .collect(),
                 credential_expires_at_ms: HashMap::new(),
                 profile_workspace: "default".to_string(),
+                credential_handles: HashMap::new(),
             },
         )
         .await
@@ -8876,6 +8985,7 @@ mod tests {
                 config: HashMap::new(),
                 credential_expires_at_ms: HashMap::new(),
                 profile_workspace: "default".to_string(),
+                credential_handles: HashMap::new(),
             },
         )
         .await
@@ -8927,6 +9037,7 @@ mod tests {
                 config: HashMap::new(),
                 credential_expires_at_ms: HashMap::new(),
                 profile_workspace: "default".to_string(),
+                credential_handles: HashMap::new(),
             },
         )
         .await

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -1033,6 +1033,7 @@ pub(super) async fn resolve_provider_environment_from_records_with_credentials(
                 })
                 .collect::<Vec<_>>()
         });
+        let profile_has_no_usable_endpoint = profile_endpoints.as_ref().is_some_and(Vec::is_empty);
 
         for (key, value) in &provider.credentials {
             if is_non_injectable_provider_credential(provider, key) {
@@ -1044,6 +1045,18 @@ pub(super) async fn resolve_provider_environment_from_records_with_credentials(
                 continue;
             }
             if is_valid_env_key(key) {
+                if profile_has_no_usable_endpoint {
+                    // Static credentials need a complete binding. Do not send
+                    // endpointless profile credentials as invalid metadata,
+                    // because one rejected key would revoke every unrelated
+                    // static credential in the supervisor snapshot.
+                    warn!(
+                        provider_name = %name,
+                        key = %key,
+                        "withholding static provider credential from endpointless profile"
+                    );
+                    continue;
+                }
                 let expires_at_ms = provider
                     .credential_expires_at_ms
                     .get(key)
@@ -7716,6 +7729,85 @@ mod tests {
                 .static_credential_bindings
                 .get("CLAUDE_API_KEY")
                 .is_some_and(|binding| !binding.endpoints.is_empty())
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_provider_env_withholds_endpointless_profile_credentials_independently() {
+        let store = test_store().await;
+        let expires_at_ms = crate::persistence::current_time_ms() + 60_000;
+        let mut google_cloud = google_cloud_provider(HashMap::from([(
+            "project_id".to_string(),
+            "sandbox-project".to_string(),
+        )]));
+        google_cloud.credentials = HashMap::from([(
+            "GCP_ADC_ACCESS_TOKEN".to_string(),
+            "google-token".to_string(),
+        )]);
+        google_cloud.credential_expires_at_ms =
+            HashMap::from([("GCP_ADC_ACCESS_TOKEN".to_string(), expires_at_ms)]);
+        create_provider_record(&store, "default", google_cloud)
+            .await
+            .unwrap();
+
+        let mut github = provider_with_values("bound-github", "github");
+        github.credentials =
+            HashMap::from([("GITHUB_TOKEN".to_string(), "github-token".to_string())]);
+        github.config.clear();
+        create_provider_record(&store, "default", github)
+            .await
+            .unwrap();
+
+        let result = resolve_provider_environment(
+            &store,
+            "default",
+            &["my-google-cloud".to_string(), "bound-github".to_string()],
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !result.contains_key("GCP_ADC_ACCESS_TOKEN"),
+            "endpointless static credentials must be withheld"
+        );
+        assert!(
+            !result
+                .credential_expires_at_ms
+                .contains_key("GCP_ADC_ACCESS_TOKEN"),
+            "withheld static credentials must not retain expiry metadata"
+        );
+        assert!(
+            !result
+                .static_credential_keys
+                .contains("GCP_ADC_ACCESS_TOKEN"),
+            "withheld static credentials must not be classified as static"
+        );
+        assert!(
+            !result
+                .static_credential_bindings
+                .contains_key("GCP_ADC_ACCESS_TOKEN"),
+            "endpointless static credentials must not emit an invalid binding"
+        );
+        assert!(
+            result.contains_key("GCE_METADATA_HOST"),
+            "provider-generated non-secret GCP configuration must be retained"
+        );
+
+        assert_eq!(
+            result.get("GITHUB_TOKEN"),
+            Some(&"github-token".to_string()),
+            "a valid provider must not be suppressed by an endpointless provider"
+        );
+        assert!(
+            result.static_credential_keys.contains("GITHUB_TOKEN"),
+            "the valid credential must retain its static classification"
+        );
+        assert!(
+            result
+                .static_credential_bindings
+                .get("GITHUB_TOKEN")
+                .is_some_and(|binding| !binding.endpoints.is_empty()),
+            "the valid credential must retain its endpoint binding"
         );
     }
 

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -982,10 +982,11 @@ pub(super) async fn resolve_provider_environment_from_records(
         &openshell_core::Config::new(None).with_credential_drivers(["test-static"]),
     )
     .map_err(|err| Status::internal(format!("initialize credential runtime failed: {err}")))?;
-    resolve_provider_environment_from_records_with_credentials(
+    resolve_provider_environment_from_records_with_policy_bindings_and_credentials(
         store,
         catalog,
         records,
+        &HashMap::new(),
         &credentials,
     )
     .await
@@ -995,6 +996,44 @@ pub(super) async fn resolve_provider_environment_from_records_with_credentials(
     store: &Store,
     catalog: &EffectiveProviderProfileCatalog,
     records: &[ProviderEnvironmentRecord],
+    credentials: &crate::credentials::CredentialRuntime,
+) -> Result<ProviderEnvironment, Status> {
+    resolve_provider_environment_from_records_with_policy_bindings_and_credentials(
+        store,
+        catalog,
+        records,
+        &HashMap::new(),
+        credentials,
+    )
+    .await
+}
+
+#[cfg(test)]
+pub(super) async fn resolve_provider_environment_from_records_with_policy_bindings(
+    store: &Store,
+    catalog: &EffectiveProviderProfileCatalog,
+    records: &[ProviderEnvironmentRecord],
+    policy_bindings: &HashMap<String, Vec<StaticCredentialEndpointBinding>>,
+) -> Result<ProviderEnvironment, Status> {
+    let credentials = crate::credentials::CredentialRuntime::from_config(
+        &openshell_core::Config::new(None).with_credential_drivers(["test-static"]),
+    )
+    .map_err(|err| Status::internal(format!("initialize credential runtime failed: {err}")))?;
+    resolve_provider_environment_from_records_with_policy_bindings_and_credentials(
+        store,
+        catalog,
+        records,
+        policy_bindings,
+        &credentials,
+    )
+    .await
+}
+
+pub(super) async fn resolve_provider_environment_from_records_with_policy_bindings_and_credentials(
+    store: &Store,
+    catalog: &EffectiveProviderProfileCatalog,
+    records: &[ProviderEnvironmentRecord],
+    policy_bindings: &HashMap<String, Vec<StaticCredentialEndpointBinding>>,
     credentials: &crate::credentials::CredentialRuntime,
 ) -> Result<ProviderEnvironment, Status> {
     if records.is_empty() {
@@ -1033,7 +1072,28 @@ pub(super) async fn resolve_provider_environment_from_records_with_credentials(
                 })
                 .collect::<Vec<_>>()
         });
-        let profile_has_no_usable_endpoint = profile_endpoints.as_ref().is_some_and(Vec::is_empty);
+        let policy_endpoints = policy_bindings.get(name);
+        let effective_endpoints = match (&profile_endpoints, policy_endpoints) {
+            (Some(profile_endpoints), Some(_policy_endpoints)) if !profile_endpoints.is_empty() => {
+                return Err(Status::failed_precondition(format!(
+                    "provider '{name}' profile already defines credential endpoints; \
+                     remove credential_binding from the sandbox policy endpoint"
+                )));
+            }
+            (Some(profile_endpoints), Some(policy_endpoints)) => {
+                debug_assert!(profile_endpoints.is_empty());
+                Some(policy_endpoints)
+            }
+            (Some(profile_endpoints), None) => Some(profile_endpoints),
+            (None, Some(_)) => {
+                return Err(Status::failed_precondition(format!(
+                    "provider '{name}' has no provider profile; policy credential binding \
+                     requires an endpointless provider profile"
+                )));
+            }
+            (None, None) => None,
+        };
+        let has_no_usable_endpoint = effective_endpoints.is_some_and(Vec::is_empty);
 
         for (key, value) in &provider.credentials {
             if is_non_injectable_provider_credential(provider, key) {
@@ -1045,7 +1105,7 @@ pub(super) async fn resolve_provider_environment_from_records_with_credentials(
                 continue;
             }
             if is_valid_env_key(key) {
-                if profile_has_no_usable_endpoint {
+                if has_no_usable_endpoint {
                     // Static credentials need a complete binding. Do not send
                     // endpointless profile credentials as invalid metadata,
                     // because one rejected key would revoke every unrelated
@@ -1076,7 +1136,7 @@ pub(super) async fn resolve_provider_environment_from_records_with_credentials(
                 }
                 provider_env.insert(key.clone(), value.clone());
                 static_credential_keys.insert(key.clone());
-                if let Some(endpoints) = &profile_endpoints {
+                if let Some(endpoints) = effective_endpoints {
                     if record.object_id.is_empty() {
                         return Err(Status::failed_precondition(format!(
                             "provider '{name}' has no stable object identity"
@@ -1112,6 +1172,14 @@ pub(super) async fn resolve_provider_environment_from_records_with_credentials(
                 continue;
             }
             if is_valid_env_key(&key) {
+                if has_no_usable_endpoint {
+                    warn!(
+                        provider_name = %name,
+                        key = %key,
+                        "withholding static provider credential handle from endpointless profile"
+                    );
+                    continue;
+                }
                 if let Some(expires_at_ms) = resolved_refs
                     .expires_at_ms
                     .get(&key)
@@ -1122,7 +1190,7 @@ pub(super) async fn resolve_provider_environment_from_records_with_credentials(
                 }
                 provider_env.insert(key.clone(), value);
                 static_credential_keys.insert(key.clone());
-                if let Some(endpoints) = &profile_endpoints {
+                if let Some(endpoints) = effective_endpoints {
                     if record.object_id.is_empty() {
                         return Err(Status::failed_precondition(format!(
                             "provider '{name}' has no stable object identity"
@@ -2671,6 +2739,17 @@ fn profiles_from_import_items(
             });
             continue;
         };
+        for (index, endpoint) in profile.endpoints.iter().enumerate() {
+            if endpoint.credential_binding.is_some() {
+                diagnostics.push(ProfileValidationDiagnostic {
+                    source: source.clone(),
+                    profile_id: profile.id.clone(),
+                    field: format!("endpoints[{index}].credential_binding"),
+                    message: "credential_binding references a concrete sandbox provider and is only valid in sandbox policy".to_string(),
+                    severity: "error".to_string(),
+                });
+            }
+        }
         profiles.push((source, ProviderTypeProfile::from_proto(profile)));
     }
     (profiles, diagnostics)
@@ -2863,6 +2942,7 @@ async fn profile_attached_sandbox_diagnostics(
         let sandbox_name = sandbox.object_name().to_string();
         let sandbox_workspace = sandbox.object_workspace().to_string();
         let spec = sandbox.spec.as_ref().expect("filtered by scan_sandboxes");
+        let base_policy = super::policy::current_base_policy_for_sandbox(store, &sandbox).await?;
         let mut bindings = Vec::new();
         let mut provider_layers = Vec::new();
         let mut imported_profiles_used = Vec::<(String, String)>::new();
@@ -2912,13 +2992,28 @@ async fn profile_attached_sandbox_diagnostics(
                     !endpoint_ports(endpoint.port, &endpoint.ports).is_empty()
                         && !endpoint.host.trim().is_empty()
                 });
-                if has_static_credentials && !has_usable_endpoint {
+                let has_policy_binding = super::policy::policy_has_credential_binding_for_provider(
+                    &base_policy,
+                    provider_name,
+                );
+                if has_static_credentials && !has_usable_endpoint && !has_policy_binding {
                     diagnostics.push(ProfileValidationDiagnostic {
                         source: source.clone(),
                         profile_id: profile_id.to_string(),
                         field: "endpoints".to_string(),
                         message: format!(
                             "{operation} would leave static provider credentials without an authorized endpoint on sandbox '{sandbox_name}'"
+                        ),
+                        severity: "error".to_string(),
+                    });
+                }
+                if has_usable_endpoint && has_policy_binding {
+                    diagnostics.push(ProfileValidationDiagnostic {
+                        source: source.clone(),
+                        profile_id: profile_id.to_string(),
+                        field: "endpoints".to_string(),
+                        message: format!(
+                            "{operation} would give provider '{provider_name}' both profile endpoint bindings and sandbox policy credential bindings on sandbox '{sandbox_name}'"
                         ),
                         severity: "error".to_string(),
                     });
@@ -2975,25 +3070,22 @@ async fn profile_attached_sandbox_diagnostics(
                 });
             }
         }
-        if validate_policy_composition {
-            let base_policy =
-                super::policy::current_base_policy_for_sandbox(store, &sandbox).await?;
-            if let Err(error) =
+        if validate_policy_composition
+            && let Err(error) =
                 super::policy::validate_candidate_effective_policy(&base_policy, &provider_layers)
-            {
-                for (source, profile_id) in &imported_profiles_used {
-                    diagnostics.push(ProfileValidationDiagnostic {
-                        source: source.clone(),
-                        profile_id: profile_id.clone(),
-                        field: "endpoints".to_string(),
-                        message: format!(
-                            "{operation} would create ambiguous network endpoints on sandbox \
-                             '{sandbox_name}': {}",
-                            error.message()
-                        ),
-                        severity: "error".to_string(),
-                    });
-                }
+        {
+            for (source, profile_id) in &imported_profiles_used {
+                diagnostics.push(ProfileValidationDiagnostic {
+                    source: source.clone(),
+                    profile_id: profile_id.clone(),
+                    field: "endpoints".to_string(),
+                    message: format!(
+                        "{operation} would create ambiguous network endpoints on sandbox \
+                         '{sandbox_name}': {}",
+                        error.message()
+                    ),
+                    severity: "error".to_string(),
+                });
             }
         }
     }
@@ -7808,6 +7900,60 @@ mod tests {
                 .get("GITHUB_TOKEN")
                 .is_some_and(|binding| !binding.endpoints.is_empty()),
             "the valid credential must retain its endpoint binding"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_provider_env_binds_endpointless_profile_from_policy() {
+        let store = test_store().await;
+        let mut google_cloud = google_cloud_provider(HashMap::from([(
+            "project_id".to_string(),
+            "sandbox-project".to_string(),
+        )]));
+        google_cloud.credentials = HashMap::from([(
+            "GCP_ADC_ACCESS_TOKEN".to_string(),
+            "google-token".to_string(),
+        )]);
+        create_provider_record(&store, "default", google_cloud)
+            .await
+            .unwrap();
+
+        let provider_names = ["my-google-cloud".to_string()];
+        let catalog = ProviderProfileSources::with_default_sources()
+            .snapshot_catalog(&store, "default")
+            .await
+            .unwrap();
+        let records = load_provider_environment_records(&store, "default", &provider_names)
+            .await
+            .unwrap();
+        let policy_bindings = HashMap::from([(
+            "my-google-cloud".to_string(),
+            vec![StaticCredentialEndpointBinding {
+                host: "storage.googleapis.com".to_string(),
+                port: 443,
+                path: "/**".to_string(),
+            }],
+        )]);
+
+        let result = resolve_provider_environment_from_records_with_policy_bindings(
+            &store,
+            &catalog,
+            &records,
+            &policy_bindings,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.get("GCP_ADC_ACCESS_TOKEN"),
+            Some(&"google-token".to_string())
+        );
+        assert_eq!(
+            result
+                .static_credential_bindings
+                .get("GCP_ADC_ACCESS_TOKEN")
+                .map(|binding| binding.endpoints.as_slice()),
+            Some(policy_bindings["my-google-cloud"].as_slice())
         );
     }
 

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -1003,10 +1003,17 @@ pub(super) async fn resolve_provider_environment_with_credentials(
                 env.entry(key.clone()).or_insert_with(|| value.clone());
                 static_credential_keys.insert(key.clone());
                 if let Some(endpoints) = &profile_endpoints {
+                    let provider_identity = provider.object_id();
+                    if provider_identity.is_empty() {
+                        return Err(Status::failed_precondition(format!(
+                            "provider '{name}' has no stable object identity"
+                        )));
+                    }
                     static_credential_bindings.insert(
                         key.clone(),
                         StaticCredentialBinding {
                             endpoints: endpoints.clone(),
+                            credential_identity: format!("{provider_identity}:{key}"),
                         },
                     );
                 }

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -303,6 +303,17 @@ async fn handle_create_sandbox_inner(
 
     // Ensure metadata is valid (defense in depth - should always be true for server-constructed metadata)
     super::validation::validate_object_metadata(sandbox.metadata.as_ref(), "sandbox")?;
+    super::policy::validate_candidate_provider_attachments(
+        state,
+        sandbox.object_workspace(),
+        &sandbox,
+        sandbox
+            .spec
+            .as_ref()
+            .map(|spec| spec.providers.as_slice())
+            .unwrap_or_default(),
+    )
+    .await?;
 
     state
         .compute
@@ -644,10 +655,22 @@ pub(super) async fn handle_detach_sandbox_provider(
         .clone();
 
     // Pre-check: fail fast if sandbox spec is missing (invariant violation)
-    let _spec = sandbox
+    let spec = sandbox
         .spec
         .as_ref()
         .ok_or_else(|| Status::internal("sandbox spec is missing"))?;
+    let mut candidate_spec = spec.clone();
+    candidate_spec
+        .providers
+        .retain(|name| name != &request.provider_name);
+    dedupe_provider_names(&mut candidate_spec.providers);
+    super::policy::validate_candidate_provider_attachments(
+        state,
+        &workspace,
+        &sandbox,
+        &candidate_spec.providers,
+    )
+    .await?;
 
     let provider_name = request.provider_name.clone();
     let detached = Arc::new(AtomicBool::new(false));
@@ -2873,6 +2896,64 @@ mod tests {
         .unwrap()
         .into_inner();
         assert!(!response.detached);
+    }
+
+    #[tokio::test]
+    async fn detach_rejects_provider_referenced_by_policy_credential_binding() {
+        let state = test_server_state().await;
+        state
+            .store
+            .put_message(&test_provider("work-gcp", "google-cloud"))
+            .await
+            .unwrap();
+
+        let mut sandbox = test_sandbox("work", vec!["work-gcp".to_string()]);
+        let policy = sandbox
+            .spec
+            .as_mut()
+            .and_then(|spec| spec.policy.as_mut())
+            .unwrap();
+        policy.network_policies.insert(
+            "gcp_storage".to_string(),
+            openshell_core::proto::NetworkPolicyRule {
+                name: "gcp_storage".to_string(),
+                endpoints: vec![openshell_core::proto::NetworkEndpoint {
+                    host: "storage.googleapis.com".to_string(),
+                    port: 443,
+                    credential_binding: Some(openshell_core::proto::NetworkCredentialBinding {
+                        provider: "work-gcp".to_string(),
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        );
+        state.store.put_message(&sandbox).await.unwrap();
+
+        let error = handle_detach_sandbox_provider(
+            &state,
+            Request::new(DetachSandboxProviderRequest {
+                sandbox_name: "work".to_string(),
+                provider_name: "work-gcp".to_string(),
+                expected_resource_version: 0,
+                workspace: String::new(),
+            }),
+        )
+        .await
+        .expect_err("a referenced provider must remain attached");
+
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+        assert!(error.message().contains("not attached"));
+        let providers = state
+            .store
+            .get_message_by_name::<Sandbox>("default", "work")
+            .await
+            .unwrap()
+            .unwrap()
+            .spec
+            .unwrap()
+            .providers;
+        assert_eq!(providers, vec!["work-gcp"]);
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -2932,7 +2932,7 @@ mod tests {
 
         let error = handle_detach_sandbox_provider(
             &state,
-            Request::new(DetachSandboxProviderRequest {
+            authed_request(DetachSandboxProviderRequest {
                 sandbox_name: "work".to_string(),
                 provider_name: "work-gcp".to_string(),
                 expected_resource_version: 0,

--- a/crates/openshell-server/src/provider_profile_sources.rs
+++ b/crates/openshell-server/src/provider_profile_sources.rs
@@ -439,23 +439,30 @@ impl EffectiveProviderProfileCatalog {
         id: &str,
         profile_workspace: &str,
     ) -> Option<ProviderTypeProfile> {
+        self.scoped_type_profile_for_scope(id, profile_workspace)
+            .map(|entry| entry.profile.clone())
+    }
+
+    fn scoped_type_profile_for_scope(
+        &self,
+        id: &str,
+        profile_workspace: &str,
+    ) -> Option<&ScopedProfileEntry> {
         let id = normalize_profile_id(id)?;
         let entry = self.profiles.get(&id)?;
 
         if entry.effective.scope == ProfileScope::Static {
-            return Some(entry.effective.profile.clone());
+            return Some(&entry.effective);
         }
 
         if profile_workspace.is_empty() {
             match &entry.platform_fallback {
-                Some(fallback) => Some(fallback.profile.clone()),
-                None if entry.effective.scope == ProfileScope::Platform => {
-                    Some(entry.effective.profile.clone())
-                }
+                Some(fallback) => Some(fallback),
+                None if entry.effective.scope == ProfileScope::Platform => Some(&entry.effective),
                 None => None,
             }
         } else {
-            Some(entry.effective.profile.clone())
+            Some(&entry.effective)
         }
     }
 
@@ -467,34 +474,38 @@ impl EffectiveProviderProfileCatalog {
             .map(|entry| entry.effective.source_id.clone())
     }
 
-    pub(crate) fn hash_profile_revision(&self, profile_id: &str, hasher: &mut Sha256) {
-        let Some(profile_id) = normalize_profile_id(profile_id) else {
-            hasher.update(b"invalid-profile-id");
-            return;
-        };
-
-        let Some(entry) = self.profiles.get(&profile_id) else {
+    pub(crate) fn hash_type_profile_revision_for_scope(
+        &self,
+        profile_id: &str,
+        profile_workspace: &str,
+        hasher: &mut Sha256,
+    ) {
+        let Some(entry) = self.scoped_type_profile_for_scope(profile_id, profile_workspace) else {
             hasher.update(b"missing");
             return;
         };
 
-        hasher.update(b"provider-profile-source-entry");
-        hasher.update(entry.effective.source_id.as_bytes());
-        hasher.update(entry.effective.source_revision.as_bytes());
-        let scope_tag: &[u8] = match entry.effective.scope {
-            ProfileScope::Static => b"static",
-            ProfileScope::Platform => b"platform",
-            ProfileScope::Workspace => b"workspace",
-        };
-        hasher.update(scope_tag);
-        let ownership_tag: &[u8] = if entry.effective.user_managed {
-            b"user-managed"
-        } else {
-            b"source-managed"
-        };
-        hasher.update(ownership_tag);
-        hasher.update(entry.effective.response.encode_to_vec());
+        hash_scoped_profile_revision(entry, hasher);
     }
+}
+
+fn hash_scoped_profile_revision(entry: &ScopedProfileEntry, hasher: &mut Sha256) {
+    hasher.update(b"provider-profile-source-entry");
+    hasher.update(entry.source_id.as_bytes());
+    hasher.update(entry.source_revision.as_bytes());
+    let scope_tag: &[u8] = match entry.scope {
+        ProfileScope::Static => b"static",
+        ProfileScope::Platform => b"platform",
+        ProfileScope::Workspace => b"workspace",
+    };
+    hasher.update(scope_tag);
+    let ownership_tag: &[u8] = if entry.user_managed {
+        b"user-managed"
+    } else {
+        b"source-managed"
+    };
+    hasher.update(ownership_tag);
+    hasher.update(entry.response.encode_to_vec());
 }
 
 fn scope_to_string(scope: ProfileScope) -> &'static str {
@@ -921,7 +932,11 @@ mod tests {
         );
         assert!(first.get_type_profile("moving-profile").is_some());
         let mut first_profile_hash = Sha256::new();
-        first.hash_profile_revision("moving-profile", &mut first_profile_hash);
+        first.hash_type_profile_revision_for_scope(
+            "moving-profile",
+            "default",
+            &mut first_profile_hash,
+        );
         let first_profile_hash = first_profile_hash.finalize();
         assert_eq!(fetch_count.load(Ordering::SeqCst), 1);
 
@@ -932,7 +947,11 @@ mod tests {
             "revision-b"
         );
         let mut second_profile_hash = Sha256::new();
-        second.hash_profile_revision("moving-profile", &mut second_profile_hash);
+        second.hash_type_profile_revision_for_scope(
+            "moving-profile",
+            "default",
+            &mut second_profile_hash,
+        );
         assert_ne!(first_profile_hash, second_profile_hash.finalize());
         assert_ne!(first.revision(), second.revision());
     }
@@ -1631,6 +1650,65 @@ mod tests {
         let result = catalog.get_type_profile_for_scope("anthropic", "");
         assert!(result.is_some());
         assert_eq!(result.unwrap().display_name, "Platform Anthropic");
+    }
+
+    #[test]
+    fn scoped_profile_revision_hashes_platform_fallback_beneath_workspace_override() {
+        let catalog = |platform_path: &str| {
+            let mut platform = profile("anthropic");
+            platform.endpoints.truncate(1);
+            platform.endpoints[0].path = platform_path.to_string();
+            let mut workspace = profile("anthropic");
+            workspace.display_name = "Workspace Anthropic".to_string();
+
+            build_effective_profiles(vec![CollectedProviderProfileSnapshot {
+                source_id: "user".to_string(),
+                revision: "same-source-revision".to_string(),
+                profiles: vec![
+                    ScopedSnapshotProfile {
+                        scope: ProfileScope::Platform,
+                        profile: platform,
+                    },
+                    ScopedSnapshotProfile {
+                        scope: ProfileScope::Workspace,
+                        profile: workspace,
+                    },
+                ],
+                user_managed: true,
+                allow_empty: true,
+            }])
+            .unwrap()
+        };
+
+        let broad = catalog("/**");
+        let narrow = catalog("/v1/**");
+        let mut broad_platform_hash = Sha256::new();
+        broad.hash_type_profile_revision_for_scope("anthropic", "", &mut broad_platform_hash);
+        let mut narrow_platform_hash = Sha256::new();
+        narrow.hash_type_profile_revision_for_scope("anthropic", "", &mut narrow_platform_hash);
+        assert_ne!(
+            broad_platform_hash.finalize(),
+            narrow_platform_hash.finalize(),
+            "platform-scoped providers must hash the selected platform fallback"
+        );
+
+        let mut broad_workspace_hash = Sha256::new();
+        broad.hash_type_profile_revision_for_scope(
+            "anthropic",
+            "default",
+            &mut broad_workspace_hash,
+        );
+        let mut narrow_workspace_hash = Sha256::new();
+        narrow.hash_type_profile_revision_for_scope(
+            "anthropic",
+            "default",
+            &mut narrow_workspace_hash,
+        );
+        assert_eq!(
+            broad_workspace_hash.finalize(),
+            narrow_workspace_hash.finalize(),
+            "workspace-scoped providers must remain keyed to the workspace override"
+        );
     }
 
     #[test]

--- a/crates/openshell-supervisor-network/src/l7/graphql.rs
+++ b/crates/openshell-supervisor-network/src/l7/graphql.rs
@@ -39,6 +39,30 @@ pub struct GraphqlHttpRequest {
     pub info: GraphqlRequestInfo,
 }
 
+pub(crate) fn log_summary(info: &GraphqlRequestInfo) -> String {
+    if let Some(error) = &info.error {
+        return format!("graphql_error={error:?}");
+    }
+    let operations = info.operations.iter().map(|operation| {
+        let name = operation.operation_name.as_deref().unwrap_or("-");
+        let fields = if operation.fields.is_empty() {
+            "-".to_string()
+        } else {
+            operation.fields.join(",")
+        };
+        let persisted = operation
+            .persisted_query_hash
+            .as_deref()
+            .or(operation.persisted_query_id.as_deref())
+            .unwrap_or("-");
+        format!(
+            "type={} name={} fields={} persisted={}",
+            operation.operation_type, name, fields, persisted
+        )
+    });
+    format!("graphql_ops={}", operations.collect::<Vec<_>>().join(";"))
+}
+
 pub async fn parse_graphql_http_request<C: AsyncRead + AsyncWrite + Unpin + Send>(
     client: &mut C,
     max_body_bytes: usize,

--- a/crates/openshell-supervisor-network/src/l7/mod.rs
+++ b/crates/openshell-supervisor-network/src/l7/mod.rs
@@ -24,6 +24,37 @@ pub(crate) mod websocket;
 pub use openshell_policy::L7Protocol;
 use openshell_policy::{L7EndpointFields, validate_l7_endpoint_semantics};
 
+pub(crate) fn build_credential_endpoint_mismatch_finding(
+    policy_name: &str,
+    host: &str,
+    protocol: Option<&str>,
+    message: &str,
+) -> openshell_ocsf::OcsfEvent {
+    use openshell_ocsf::{
+        ActionId, ActivityId, DetectionFindingBuilder, DispositionId, FindingInfo, SeverityId,
+    };
+
+    let mut evidence = vec![("policy", policy_name), ("host", host)];
+    if let Some(protocol) = protocol {
+        evidence.push(("protocol", protocol));
+    }
+    evidence.push(("disposition", "denied"));
+
+    DetectionFindingBuilder::new(openshell_ocsf::ctx::ctx())
+        .activity(ActivityId::Open)
+        .action(ActionId::Denied)
+        .disposition(DispositionId::Blocked)
+        .severity(SeverityId::High)
+        .is_alert(true)
+        .finding_info(FindingInfo::new(
+            "openshell.provider_credential.endpoint_mismatch",
+            "Provider credential used at an unauthorized endpoint",
+        ))
+        .evidence_pairs(&evidence)
+        .message(message)
+        .build()
+}
+
 /// TLS handling mode for proxy connections.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TlsMode {

--- a/crates/openshell-supervisor-network/src/l7/mod.rs
+++ b/crates/openshell-supervisor-network/src/l7/mod.rs
@@ -256,16 +256,7 @@ impl L7EndpointConfig {
 }
 
 pub fn endpoint_path_matches(pattern: &str, path: &str) -> bool {
-    if pattern.is_empty() || pattern == "**" || pattern == "/**" {
-        return true;
-    }
-    if pattern == path {
-        return true;
-    }
-    if let Some(prefix) = pattern.strip_suffix("/**") {
-        return path == prefix || path.starts_with(&format!("{prefix}/"));
-    }
-    glob::Pattern::new(pattern).is_ok_and(|glob| glob.matches(path))
+    openshell_core::endpoint_path::matches(pattern, path)
 }
 
 /// Parse the `tls` field from an endpoint config, independent of L7 protocol.

--- a/crates/openshell-supervisor-network/src/l7/path.rs
+++ b/crates/openshell-supervisor-network/src/l7/path.rs
@@ -135,13 +135,24 @@ pub fn canonicalize_request_target(
         None => (target, None),
     };
 
-    // 4. Handle absolute-form by stripping scheme://authority.
-    let raw_path = path_part.find("://").map_or(path_part, |idx| {
-        let after_scheme = &path_part[idx + 3..];
-        after_scheme
-            .find('/')
-            .map_or("/", |slash| &after_scheme[slash..])
-    });
+    // 4. Handle absolute-form by stripping the URI authority. Origin-form
+    // targets may legitimately embed `://` in a path segment, so only a URI
+    // with a scheme is absolute-form.
+    let absolute_form_uri = path_part
+        .parse::<http::Uri>()
+        .ok()
+        .filter(|uri| uri.scheme().is_some());
+    let raw_path = absolute_form_uri
+        .as_ref()
+        .map(http::Uri::path)
+        .filter(|path| !path.is_empty())
+        .unwrap_or_else(|| {
+            if absolute_form_uri.is_some() {
+                "/"
+            } else {
+                path_part
+            }
+        });
 
     // 5. Empty is equivalent to "/".
     let raw_path = if raw_path.is_empty() { "/" } else { raw_path };
@@ -441,6 +452,20 @@ mod tests {
         assert_eq!(canon("http://host/a/../b").unwrap(), "/b");
         assert_eq!(canon("https://host").unwrap(), "/");
         assert_eq!(canon("http://host:443/foo").unwrap(), "/foo");
+    }
+
+    #[test]
+    fn origin_form_with_embedded_url_is_not_stripped_as_absolute_form() {
+        let (path, query) = canonicalize_request_target(
+            "/fetch/http://example.test?next=http://other.test",
+            &CanonicalizeOptions::default(),
+        )
+        .expect("origin-form target with embedded URLs must be accepted");
+        // Repeated slashes are canonicalized everywhere, but the embedded
+        // URL must remain part of the origin-form path rather than being
+        // treated as a new absolute-form authority.
+        assert_eq!(path.path, "/fetch/http:/example.test");
+        assert_eq!(query.as_deref(), Some("next=http://other.test"));
     }
 
     #[test]

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -79,7 +79,62 @@ fn scoped_context_for_request(ctx: &L7EvalContext, target: &str) -> Option<L7Eva
     Some(scoped)
 }
 
-async fn reject_credential_resolution<W>(
+fn build_credential_resolution_event(
+    ctx: &L7EvalContext,
+    endpoint_mismatch: bool,
+) -> openshell_ocsf::OcsfEvent {
+    HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
+        .activity(ActivityId::Fail)
+        .action(ActionId::Denied)
+        .disposition(DispositionId::Blocked)
+        .severity(if endpoint_mismatch {
+            SeverityId::High
+        } else {
+            SeverityId::Medium
+        })
+        .status(StatusId::Failure)
+        .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+        .firewall_rule(&ctx.policy_name, "credential-binding")
+        .message(if endpoint_mismatch {
+            format!(
+                "Credential use denied: credential is not authorized for {}:{}",
+                ctx.host, ctx.port
+            )
+        } else {
+            format!(
+                "Credential use denied: credential is unavailable for {}:{}",
+                ctx.host, ctx.port
+            )
+        })
+        .status_detail(if endpoint_mismatch {
+            "credential_endpoint_mismatch"
+        } else {
+            "credential_unavailable"
+        })
+        .build()
+}
+
+fn build_credential_endpoint_mismatch_finding(ctx: &L7EvalContext) -> openshell_ocsf::OcsfEvent {
+    DetectionFindingBuilder::new(openshell_ocsf::ctx::ctx())
+        .activity(ActivityId::Open)
+        .action(ActionId::Denied)
+        .disposition(DispositionId::Blocked)
+        .severity(SeverityId::High)
+        .is_alert(true)
+        .finding_info(FindingInfo::new(
+            "openshell.provider_credential.endpoint_mismatch",
+            "Provider credential used at an unauthorized endpoint",
+        ))
+        .evidence_pairs(&[
+            ("policy", ctx.policy_name.as_str()),
+            ("host", ctx.host.as_str()),
+            ("disposition", "denied"),
+        ])
+        .message("Provider credential endpoint binding mismatch; request denied")
+        .build()
+}
+
+pub(crate) async fn reject_credential_resolution<W>(
     client: &mut W,
     ctx: &L7EvalContext,
     error: &secrets::UnresolvedPlaceholderError,
@@ -108,56 +163,10 @@ where
         .into_diagnostic()?;
     client.flush().await.into_diagnostic()?;
 
-    let event = HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
-        .activity(ActivityId::Fail)
-        .action(ActionId::Denied)
-        .disposition(DispositionId::Blocked)
-        .severity(if endpoint_mismatch {
-            SeverityId::High
-        } else {
-            SeverityId::Medium
-        })
-        .status(StatusId::Failure)
-        .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
-        .firewall_rule(&ctx.policy_name, "credential-binding")
-        .message(if endpoint_mismatch {
-            format!(
-                "Credential use denied: credential is not authorized for {}:{}",
-                ctx.host, ctx.port
-            )
-        } else {
-            format!(
-                "Credential use denied: credential is unavailable for {}:{}",
-                ctx.host, ctx.port
-            )
-        })
-        .status_detail(if endpoint_mismatch {
-            "credential_endpoint_mismatch"
-        } else {
-            "credential_unavailable"
-        })
-        .build();
-    ocsf_emit!(event);
+    ocsf_emit!(build_credential_resolution_event(ctx, endpoint_mismatch));
 
     if endpoint_mismatch {
-        let finding = DetectionFindingBuilder::new(openshell_ocsf::ctx::ctx())
-            .activity(ActivityId::Open)
-            .action(ActionId::Denied)
-            .disposition(DispositionId::Blocked)
-            .severity(SeverityId::High)
-            .is_alert(true)
-            .finding_info(FindingInfo::new(
-                "openshell.provider_credential.endpoint_mismatch",
-                "Provider credential used at an unauthorized endpoint",
-            ))
-            .evidence_pairs(&[
-                ("policy", ctx.policy_name.as_str()),
-                ("host", ctx.host.as_str()),
-                ("disposition", "denied"),
-            ])
-            .message("Provider credential endpoint binding mismatch; request denied")
-            .build();
-        ocsf_emit!(finding);
+        ocsf_emit!(build_credential_endpoint_mismatch_finding(ctx));
     }
     Ok(())
 }
@@ -175,6 +184,34 @@ where
         Err(error) => {
             reject_credential_resolution(client, ctx, &error).await?;
             Ok(false)
+        }
+    }
+}
+
+async fn relay_http_request_with_credential_rejection<C, U>(
+    request: &crate::l7::provider::L7Request,
+    client: &mut C,
+    upstream: &mut U,
+    options: crate::l7::rest::RelayRequestOptions<'_>,
+    ctx: &L7EvalContext,
+) -> Result<Option<RelayOutcome>>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+    U: AsyncRead + AsyncWrite + Unpin,
+{
+    match crate::l7::rest::relay_http_request_with_options_guarded(
+        request, client, upstream, options,
+    )
+    .await
+    {
+        Ok(outcome) => Ok(Some(outcome)),
+        Err(report) => {
+            if let Some(error) = report.downcast_ref::<secrets::UnresolvedPlaceholderError>() {
+                reject_credential_resolution(client, ctx, error).await?;
+                Ok(None)
+            } else {
+                Err(report)
+            }
         }
     }
 }
@@ -616,7 +653,7 @@ where
                     return Ok(());
                 }
             };
-            let outcome = crate::l7::rest::relay_http_request_with_options_guarded(
+            let Some(outcome) = relay_http_request_with_credential_rejection(
                 &req,
                 client,
                 upstream,
@@ -632,8 +669,12 @@ where
                     host: &ctx.host,
                     port: ctx.port,
                 },
+                ctx,
             )
-            .await?;
+            .await?
+            else {
+                return Ok(());
+            };
             match outcome {
                 RelayOutcome::Reusable => {}
                 RelayOutcome::Consumed => return Ok(()),
@@ -1109,7 +1150,7 @@ where
                 };
 
             // Forward request to upstream and relay response
-            let outcome = crate::l7::rest::relay_http_request_with_options_guarded(
+            let Some(outcome) = relay_http_request_with_credential_rejection(
                 &req_with_auth,
                 client,
                 upstream,
@@ -1125,8 +1166,12 @@ where
                     host: &ctx.host,
                     port: ctx.port,
                 },
+                ctx,
             )
-            .await?;
+            .await?
+            else {
+                return Ok(());
+            };
             match outcome {
                 RelayOutcome::Reusable => {} // continue loop
                 RelayOutcome::Consumed => {
@@ -2224,7 +2269,7 @@ where
         // Forward request with credential rewriting and relay the response.
         // relay_http_request_with_resolver handles both directions: it sends
         // the request upstream and reads the response back to the client.
-        let outcome = crate::l7::rest::relay_http_request_with_options_guarded(
+        let Some(outcome) = relay_http_request_with_credential_rejection(
             &req_with_auth,
             client,
             upstream,
@@ -2233,8 +2278,12 @@ where
                 generation_guard: Some(generation_guard),
                 ..Default::default()
             },
+            ctx,
         )
-        .await?;
+        .await?
+        else {
+            return Ok(());
+        };
 
         match outcome {
             RelayOutcome::Reusable => {} // continue loop
@@ -2277,10 +2326,174 @@ where
 mod tests {
     use super::*;
     use crate::opa::{NetworkInput, OpaEngine};
+    use openshell_core::proto::{StaticCredentialBinding, StaticCredentialEndpointBinding};
+    use openshell_core::provider_credentials::ProviderCredentialState;
+    use std::collections::HashMap as TestHashMap;
     use std::path::PathBuf;
     use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 
     const TEST_POLICY: &str = include_str!("../../data/sandbox-policy.rego");
+
+    fn endpoint_binding(identity: &str) -> StaticCredentialBinding {
+        StaticCredentialBinding {
+            endpoints: vec![StaticCredentialEndpointBinding {
+                host: "allowed.example.test".to_string(),
+                port: 443,
+                path: "/allowed/**".to_string(),
+            }],
+            credential_identity: identity.to_string(),
+        }
+    }
+
+    fn endpoint_mismatch_resolver(
+        values: TestHashMap<String, String>,
+    ) -> (ProviderCredentialState, Arc<SecretResolver>) {
+        let bindings = values
+            .keys()
+            .map(|key| (key.clone(), endpoint_binding(&format!("provider-a:{key}"))))
+            .collect();
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            values,
+            TestHashMap::new(),
+            TestHashMap::new(),
+            bindings,
+            Vec::new(),
+        )
+        .expect("bound provider state");
+        let resolver = state
+            .resolver_for_endpoint("denied.example.test", 443, "/outside")
+            .expect("endpoint-scoped resolver");
+        (state, resolver)
+    }
+
+    async fn assert_credential_relay_rejected(
+        request: crate::l7::provider::L7Request,
+        resolver: &SecretResolver,
+        options: crate::l7::rest::RelayRequestOptions<'_>,
+    ) {
+        let (mut client_peer, mut client) = tokio::io::duplex(8192);
+        let (mut upstream, mut upstream_peer) = tokio::io::duplex(8192);
+        let ctx = L7EvalContext {
+            host: "denied.example.test".to_string(),
+            port: 443,
+            policy_name: "bound".to_string(),
+            secret_resolver: Some(Arc::new(resolver.clone())),
+            ..Default::default()
+        };
+
+        let outcome = relay_http_request_with_credential_rejection(
+            &request,
+            &mut client,
+            &mut upstream,
+            crate::l7::rest::RelayRequestOptions {
+                resolver: Some(resolver),
+                ..options
+            },
+            &ctx,
+        )
+        .await
+        .expect("typed credential denial");
+        assert!(outcome.is_none());
+        drop(client);
+        drop(upstream);
+
+        let mut response = String::new();
+        client_peer.read_to_string(&mut response).await.unwrap();
+        assert!(response.contains("403 Forbidden"), "{response}");
+        assert!(
+            response.contains("credential_endpoint_mismatch"),
+            "{response}"
+        );
+        let mut forwarded = Vec::new();
+        upstream_peer.read_to_end(&mut forwarded).await.unwrap();
+        assert!(
+            forwarded.is_empty(),
+            "credential mismatch must not write upstream"
+        );
+
+        let activity = build_credential_resolution_event(&ctx, true)
+            .to_json()
+            .unwrap();
+        assert_eq!(activity["status_detail"], "credential_endpoint_mismatch");
+        assert_eq!(activity["action"], "Denied");
+        assert_eq!(activity["disposition"], "Blocked");
+
+        let finding = build_credential_endpoint_mismatch_finding(&ctx)
+            .to_json()
+            .unwrap();
+        assert_eq!(
+            finding["finding_info"]["uid"],
+            "openshell.provider_credential.endpoint_mismatch"
+        );
+        assert_eq!(finding["action"], "Denied");
+        assert_eq!(finding["disposition"], "Blocked");
+    }
+
+    #[tokio::test]
+    async fn body_only_endpoint_mismatch_returns_typed_403() {
+        let (_state, resolver) = endpoint_mismatch_resolver(TestHashMap::from([(
+            "API_TOKEN".to_string(),
+            "secret".to_string(),
+        )]));
+        let body = br#"{"token":"openshell:resolve:env:v1_API_TOKEN"}"#;
+        let request = crate::l7::provider::L7Request {
+            action: "POST".to_string(),
+            target: "/outside".to_string(),
+            query_params: TestHashMap::new(),
+            raw_header: format!(
+                "POST /outside HTTP/1.1\r\nHost: denied.example.test\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
+                body.len()
+            )
+            .into_bytes()
+            .into_iter()
+            .chain(body.iter().copied())
+            .collect(),
+            body_length: crate::l7::provider::BodyLength::ContentLength(body.len() as u64),
+        };
+
+        assert_credential_relay_rejected(
+            request,
+            resolver.as_ref(),
+            crate::l7::rest::RelayRequestOptions {
+                request_body_credential_rewrite: true,
+                ..Default::default()
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn implicit_sigv4_endpoint_mismatch_returns_typed_403() {
+        let (_state, resolver) = endpoint_mismatch_resolver(TestHashMap::from([
+            ("AWS_ACCESS_KEY_ID".to_string(), "access".to_string()),
+            ("AWS_SECRET_ACCESS_KEY".to_string(), "secret".to_string()),
+            ("AWS_SESSION_TOKEN".to_string(), "session".to_string()),
+        ]));
+        let request = crate::l7::provider::L7Request {
+            action: "GET".to_string(),
+            target: "/outside".to_string(),
+            query_params: TestHashMap::new(),
+            raw_header:
+                b"GET /outside HTTP/1.1\r\nHost: denied.example.test\r\nContent-Length: 0\r\n\r\n"
+                    .to_vec(),
+            body_length: crate::l7::provider::BodyLength::ContentLength(0),
+        };
+
+        assert_credential_relay_rejected(
+            request,
+            resolver.as_ref(),
+            crate::l7::rest::RelayRequestOptions {
+                credential_signing: crate::l7::CredentialSigning::SigV4NoBody,
+                signing_service: "execute-api",
+                signing_region: "us-west-2",
+                host: "denied.example.test",
+                port: 443,
+                ..Default::default()
+            },
+        )
+        .await;
+    }
 
     fn install_builtin_middleware(engine: &OpaEngine) {
         engine.set_middleware_runner_for_tests(openshell_supervisor_middleware::ChainRunner::new(

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -171,23 +171,6 @@ where
     Ok(())
 }
 
-async fn preflight_request_credentials<W>(
-    client: &mut W,
-    ctx: &L7EvalContext,
-    request: &crate::l7::provider::L7Request,
-) -> Result<bool>
-where
-    W: AsyncWrite + Unpin,
-{
-    match secrets::rewrite_http_header_block(&request.raw_header, ctx.secret_resolver.as_deref()) {
-        Ok(_) => Ok(true),
-        Err(error) => {
-            reject_credential_resolution(client, ctx, &error).await?;
-            Ok(false)
-        }
-    }
-}
-
 async fn relay_http_request_with_credential_rejection<C, U>(
     request: &crate::l7::provider::L7Request,
     client: &mut C,
@@ -470,9 +453,6 @@ where
         };
         let scoped_ctx = scoped_context_for_request(ctx, &req.target);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
-        if !preflight_request_credentials(client, ctx, &req).await? {
-            return Ok(());
-        }
 
         if deny_h2c_upgrade_if_requested(&req, config, ctx, client).await? {
             return Ok(());
@@ -992,9 +972,6 @@ where
         };
         let scoped_ctx = scoped_context_for_request(ctx, &req.target);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
-        if !preflight_request_credentials(client, ctx, &req).await? {
-            return Ok(());
-        }
 
         if deny_h2c_upgrade_if_requested(&req, config, ctx, client).await? {
             return Ok(());
@@ -1297,9 +1274,6 @@ where
         let jsonrpc_info = parsed.info;
         let scoped_ctx = scoped_context_for_request(ctx, &req.target);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
-        if !preflight_request_credentials(client, ctx, &req).await? {
-            return Ok(());
-        }
 
         if close_if_stale(engine.generation_guard(), ctx) {
             return Ok(());
@@ -1500,9 +1474,6 @@ where
         let graphql_info = parsed.info;
         let scoped_ctx = scoped_context_for_request(ctx, &req.target);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
-        if !preflight_request_credentials(client, ctx, &req).await? {
-            return Ok(());
-        }
 
         if deny_h2c_upgrade_if_requested(&req, config, ctx, client).await? {
             return Ok(());
@@ -2166,9 +2137,6 @@ where
         let scoped_ctx = scoped_context_for_request(ctx, &req.target);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
         let resolver = ctx.secret_resolver.as_deref();
-        if !preflight_request_credentials(client, ctx, &req).await? {
-            return Ok(());
-        }
 
         if close_if_stale(generation_guard, ctx) {
             return Ok(());
@@ -3122,6 +3090,66 @@ network_policies:
         assert!(
             matches!(result, Err(_) | Ok(Ok(0))),
             "upstream should not receive request bytes"
+        );
+
+        drop(app);
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should finish")
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn l7_denial_precedes_credential_endpoint_resolution() {
+        let (config, tunnel_engine, mut ctx) =
+            middleware_relay_context("openshell/regex", "fail_closed");
+        let (_credential_state, resolver) = endpoint_mismatch_resolver(TestHashMap::from([(
+            "API_TOKEN".to_string(),
+            "secret".to_string(),
+        )]));
+        ctx.secret_resolver = Some(resolver);
+
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_with_inspection(
+                &config,
+                tunnel_engine,
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+            )
+            .await
+        });
+
+        app.write_all(
+            b"GET /outside HTTP/1.1\r\nHost: api.example.test\r\nAuthorization: Bearer openshell:resolve:env:v1_API_TOKEN\r\nConnection: close\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        let mut response = [0u8; 2048];
+        let n = tokio::time::timeout(std::time::Duration::from_secs(1), app.read(&mut response))
+            .await
+            .expect("policy denial should reach client")
+            .unwrap();
+        let response = String::from_utf8_lossy(&response[..n]);
+        assert!(response.contains("403 Forbidden"), "{response}");
+        assert!(
+            !response.contains("credential_endpoint_mismatch"),
+            "L7-denied request must not expose credential binding state: {response}"
+        );
+
+        let mut upstream_request = [0u8; 32];
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            upstream.read(&mut upstream_request),
+        )
+        .await;
+        assert!(
+            matches!(result, Err(_) | Ok(Ok(0))),
+            "L7-denied request must not reach upstream"
         );
 
         drop(app);

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -58,6 +58,10 @@ pub struct L7EvalContext {
     /// Live provider state used to scope static credentials to each request.
     pub(crate) provider_credentials:
         Option<openshell_core::provider_credentials::ProviderCredentialState>,
+    /// Provider credential revision captured atomically with the request-scoped
+    /// resolver. Used to reject a request if credentials change again before
+    /// its first upstream write.
+    pub(crate) provider_credential_revision: Option<u64>,
     /// Anonymous activity counter channel.
     pub(crate) activity_tx: Option<ActivitySender>,
     /// Dynamic credentials (token grants) keyed by endpoint-bound provider metadata.
@@ -106,12 +110,32 @@ fn scoped_context_for_request(
         // credential use. Clearing the resolver makes any placeholder or
         // signing attempt fail closed before an upstream write.
         scoped.secret_resolver = None;
+        scoped.provider_credential_revision = None;
         return Some(scoped);
     }
     let credentials = ctx.provider_credentials.as_ref()?;
-    scoped.secret_resolver =
-        credentials.resolver_for_endpoint(&ctx.host, ctx.port, &request.target);
+    let revision_before = credentials.revision();
+    let resolver = credentials.resolver_for_endpoint(&ctx.host, ctx.port, &request.target);
+    let revision_after = credentials.revision();
+    if revision_before != revision_after {
+        // The resolver and revision were not observed from one stable
+        // generation. Fail closed instead of retaining either snapshot.
+        scoped.secret_resolver = None;
+        scoped.provider_credential_revision = None;
+        return Some(scoped);
+    }
+    scoped.secret_resolver = resolver;
+    scoped.provider_credential_revision = Some(revision_before);
     Some(scoped)
+}
+
+fn credential_generation_guard(
+    ctx: &L7EvalContext,
+) -> Option<crate::l7::rest::CredentialGenerationGuard<'_>> {
+    Some(crate::l7::rest::CredentialGenerationGuard::new(
+        ctx.provider_credentials.as_ref()?,
+        ctx.provider_credential_revision?,
+    ))
 }
 
 fn request_authority_matches_endpoint(
@@ -570,9 +594,6 @@ where
                 .await?;
             return Ok(());
         };
-        let scoped_ctx = scoped_context_for_request(ctx, &req);
-        let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
-
         if deny_h2c_upgrade_if_requested(&req, config, ctx, client).await? {
             return Ok(());
         }
@@ -752,12 +773,15 @@ where
                     return Ok(());
                 }
             };
+            let scoped_ctx = scoped_context_for_request(ctx, &req);
+            let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
             let Some(outcome) = relay_http_request_with_credential_rejection(
                 &req,
                 client,
                 upstream,
                 crate::l7::rest::RelayRequestOptions {
                     resolver: ctx.secret_resolver.as_deref(),
+                    credential_generation: credential_generation_guard(ctx),
                     generation_guard: Some(engine.generation_guard()),
                     websocket_extensions: websocket_extension_mode(config),
                     request_body_credential_rewrite: config.protocol == L7Protocol::Rest
@@ -1093,9 +1117,6 @@ where
             reject_request_authority_mismatch(client, ctx).await?;
             return Ok(());
         }
-        let scoped_ctx = scoped_context_for_request(ctx, &req);
-        let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
-
         if deny_h2c_upgrade_if_requested(&req, config, ctx, client).await? {
             return Ok(());
         }
@@ -1248,6 +1269,8 @@ where
                         return Ok(());
                     }
                 };
+            let scoped_ctx = scoped_context_for_request(ctx, &req_with_auth);
+            let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
 
             // Forward request to upstream and relay response
             let Some(outcome) = relay_http_request_with_credential_rejection(
@@ -1256,6 +1279,7 @@ where
                 upstream,
                 crate::l7::rest::RelayRequestOptions {
                     resolver: ctx.secret_resolver.as_deref(),
+                    credential_generation: credential_generation_guard(ctx),
                     generation_guard: Some(engine.generation_guard()),
                     websocket_extensions: websocket_extension_mode(config),
                     request_body_credential_rewrite: config.protocol == L7Protocol::Rest
@@ -1399,9 +1423,6 @@ where
             reject_request_authority_mismatch(client, ctx).await?;
             return Ok(());
         }
-        let scoped_ctx = scoped_context_for_request(ctx, &req);
-        let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
-
         if close_if_stale(engine.generation_guard(), ctx) {
             return Ok(());
         }
@@ -1515,6 +1536,8 @@ where
                     return Ok(());
                 }
             };
+            let scoped_ctx = scoped_context_for_request(ctx, &req);
+            let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
             // Future MCP response/SSE introspection or rewrite would hook here
             // before returning upstream bytes. The current policy schema has no
             // trusted-annotations or version-profile field, so MCP responses and
@@ -1526,6 +1549,7 @@ where
                 upstream,
                 crate::l7::rest::RelayRequestOptions {
                     resolver: ctx.secret_resolver.as_deref(),
+                    credential_generation: credential_generation_guard(ctx),
                     generation_guard: Some(engine.generation_guard()),
                     ..Default::default()
                 },
@@ -1616,9 +1640,6 @@ where
             reject_request_authority_mismatch(client, ctx).await?;
             return Ok(());
         }
-        let scoped_ctx = scoped_context_for_request(ctx, &req);
-        let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
-
         if deny_h2c_upgrade_if_requested(&req, config, ctx, client).await? {
             return Ok(());
         }
@@ -1738,12 +1759,15 @@ where
                     return Ok(());
                 }
             };
+            let scoped_ctx = scoped_context_for_request(ctx, &req);
+            let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
             let Some(outcome) = relay_http_request_with_credential_rejection(
                 &req,
                 client,
                 upstream,
                 crate::l7::rest::RelayRequestOptions {
                     resolver: ctx.secret_resolver.as_deref(),
+                    credential_generation: credential_generation_guard(ctx),
                     generation_guard: Some(engine.generation_guard()),
                     ..Default::default()
                 },
@@ -2289,10 +2313,6 @@ where
             reject_request_authority_mismatch(client, ctx).await?;
             return Ok(());
         }
-        let scoped_ctx = scoped_context_for_request(ctx, &req);
-        let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
-        let resolver = ctx.secret_resolver.as_deref();
-
         if close_if_stale(generation_guard, ctx) {
             return Ok(());
         }
@@ -2310,7 +2330,7 @@ where
 
         // Log for observability via OCSF HTTP Activity event.
         // Uses redacted_target (path only, no query params) to avoid logging secrets.
-        let has_creds = resolver.is_some();
+        let has_creds = ctx.provider_credentials.is_some() || ctx.secret_resolver.is_some();
         {
             let event = HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
                 .activity(ActivityId::Other)
@@ -2388,6 +2408,9 @@ where
                 return Ok(());
             }
         };
+        let scoped_ctx = scoped_context_for_request(ctx, &req_with_auth);
+        let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
+        let resolver = ctx.secret_resolver.as_deref();
 
         // Forward request with credential rewriting and relay the response.
         // relay_http_request_with_resolver handles both directions: it sends
@@ -2398,6 +2421,7 @@ where
             upstream,
             crate::l7::rest::RelayRequestOptions {
                 resolver,
+                credential_generation: credential_generation_guard(ctx),
                 generation_guard: Some(generation_guard),
                 ..Default::default()
             },
@@ -4170,6 +4194,179 @@ network_policies:
     /// re-evaluation.
     struct BodyReplacingService {
         replacement: &'static [u8],
+    }
+
+    struct BlockingAllowService {
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[tonic::async_trait]
+    impl openshell_core::proto::middleware::v1::supervisor_middleware_server::SupervisorMiddleware
+        for BlockingAllowService
+    {
+        async fn describe(
+            &self,
+            _request: tonic::Request<()>,
+        ) -> std::result::Result<
+            tonic::Response<openshell_core::proto::MiddlewareManifest>,
+            tonic::Status,
+        > {
+            Ok(tonic::Response::new(
+                openshell_core::proto::MiddlewareManifest {
+                    name: "test/blocking-allow".into(),
+                    service_version: "test".into(),
+                    bindings: vec![openshell_core::proto::MiddlewareBinding {
+                        operation: openshell_core::proto::SupervisorMiddlewareOperation::HttpRequest
+                            as i32,
+                        phase: openshell_core::proto::SupervisorMiddlewarePhase::PreCredentials
+                            as i32,
+                        max_body_bytes: 8192,
+                        timeout: String::new(),
+                    }],
+                },
+            ))
+        }
+
+        async fn validate_config(
+            &self,
+            _request: tonic::Request<openshell_core::proto::ValidateConfigRequest>,
+        ) -> std::result::Result<
+            tonic::Response<openshell_core::proto::ValidateConfigResponse>,
+            tonic::Status,
+        > {
+            Ok(tonic::Response::new(
+                openshell_core::proto::ValidateConfigResponse {
+                    valid: true,
+                    reason: String::new(),
+                },
+            ))
+        }
+
+        async fn evaluate_http_request(
+            &self,
+            _request: tonic::Request<openshell_core::proto::HttpRequestEvaluation>,
+        ) -> std::result::Result<
+            tonic::Response<openshell_core::proto::HttpRequestResult>,
+            tonic::Status,
+        > {
+            self.entered.notify_one();
+            self.release.notified().await;
+            Ok(tonic::Response::new(
+                openshell_core::proto::HttpRequestResult {
+                    decision: openshell_core::proto::Decision::Allow as i32,
+                    ..Default::default()
+                },
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_reacquires_static_credentials_after_blocked_middleware() {
+        let data = r#"
+network_middlewares:
+  blocker:
+    middleware: test/blocking-allow
+    on_error: fail_closed
+    endpoints:
+      include: ["api.example.test"]
+network_policies:
+  rest_api:
+    name: rest_api
+    endpoints:
+      - host: api.example.test
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow:
+              method: GET
+              path: "/allowed"
+    binaries:
+      - { path: /usr/bin/node }
+"#;
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        engine.set_middleware_runner_for_tests(openshell_supervisor_middleware::ChainRunner::new(
+            Arc::new(BlockingAllowService {
+                entered: Arc::clone(&entered),
+                release: Arc::clone(&release),
+            }),
+        ));
+        let input = NetworkInput {
+            host: "api.example.test".into(),
+            port: 443,
+            binary_path: PathBuf::from("/usr/bin/node"),
+            binary_sha256: "unused".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+        };
+        let (endpoint, generation) = engine
+            .query_endpoint_config_with_generation(&input)
+            .expect("endpoint config");
+        let config = crate::l7::parse_l7_config(&endpoint.expect("REST endpoint"))
+            .expect("parse REST config");
+        let tunnel_engine = engine.clone_engine_for_tunnel(generation).unwrap();
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            TestHashMap::from([("API_TOKEN".to_string(), "real-secret".to_string())]),
+            TestHashMap::new(),
+            TestHashMap::new(),
+            TestHashMap::from([(
+                "API_TOKEN".to_string(),
+                StaticCredentialBinding {
+                    endpoints: vec![StaticCredentialEndpointBinding {
+                        host: "api.example.test".to_string(),
+                        port: 443,
+                        path: "/allowed".to_string(),
+                    }],
+                    credential_identity: "provider-a:API_TOKEN".to_string(),
+                },
+            )]),
+            Vec::new(),
+        )
+        .expect("bound provider state");
+        let ctx = L7EvalContext {
+            host: "api.example.test".into(),
+            port: 443,
+            request_default_port: Some(443),
+            policy_name: "rest_api".into(),
+            binary_path: "/usr/bin/node".into(),
+            provider_credentials: Some(state.clone()),
+            secret_resolver: state.resolver(),
+            ..Default::default()
+        };
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_rest(
+                &config,
+                &tunnel_engine,
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+            )
+            .await
+        });
+
+        app.write_all(
+            b"GET /allowed HTTP/1.1\r\nHost: api.example.test\r\nAuthorization: Bearer openshell:resolve:env:v1_API_TOKEN\r\nConnection: close\r\n\r\n",
+        )
+        .await
+        .unwrap();
+        entered.notified().await;
+        state.revoke_static_provider_environment(2);
+        release.notify_one();
+
+        relay.await.unwrap().expect("relay should fail closed");
+        drop(app);
+        let mut forwarded = Vec::new();
+        upstream.read_to_end(&mut forwarded).await.unwrap();
+        assert!(
+            forwarded.is_empty(),
+            "revoked CONNECT credential request must not reach upstream"
+        );
     }
 
     #[tonic::async_trait]

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -1279,7 +1279,13 @@ where
             return Ok(());
         }
 
-        let redacted_target = req.target.clone();
+        let redacted_target = match secrets::redact_target_for_policy(&req.target) {
+            Ok(target) => target,
+            Err(error) => {
+                reject_credential_resolution(client, ctx, &error).await?;
+                return Ok(());
+            }
+        };
 
         let request_info = L7RequestInfo {
             action: req.action.clone(),
@@ -1387,14 +1393,21 @@ where
             // trusted-annotations or version-profile field, so MCP responses and
             // SSE streams are relayed unchanged; see McpOptions in
             // proto/sandbox.proto for planned policy extensions.
-            let outcome = crate::l7::rest::relay_http_request_with_resolver_guarded(
+            let Some(outcome) = relay_http_request_with_credential_rejection(
                 &req,
                 client,
                 upstream,
-                ctx.secret_resolver.as_deref(),
-                Some(engine.generation_guard()),
+                crate::l7::rest::RelayRequestOptions {
+                    resolver: ctx.secret_resolver.as_deref(),
+                    generation_guard: Some(engine.generation_guard()),
+                    ..Default::default()
+                },
+                ctx,
             )
-            .await?;
+            .await?
+            else {
+                return Ok(());
+            };
             match outcome {
                 RelayOutcome::Reusable => {}
                 RelayOutcome::Consumed => {
@@ -1594,14 +1607,21 @@ where
                     return Ok(());
                 }
             };
-            let outcome = crate::l7::rest::relay_http_request_with_resolver_guarded(
+            let Some(outcome) = relay_http_request_with_credential_rejection(
                 &req,
                 client,
                 upstream,
-                ctx.secret_resolver.as_deref(),
-                Some(engine.generation_guard()),
+                crate::l7::rest::RelayRequestOptions {
+                    resolver: ctx.secret_resolver.as_deref(),
+                    generation_guard: Some(engine.generation_guard()),
+                    ..Default::default()
+                },
+                ctx,
             )
-            .await?;
+            .await?
+            else {
+                return Ok(());
+            };
             match outcome {
                 RelayOutcome::Reusable => {}
                 RelayOutcome::Consumed => {
@@ -2298,7 +2318,11 @@ mod tests {
     use openshell_core::provider_credentials::ProviderCredentialState;
     use std::collections::HashMap as TestHashMap;
     use std::path::PathBuf;
+    use std::sync::Mutex;
     use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+    use tracing::instrument::WithSubscriber;
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::layer::{Context as LayerContext, SubscriberExt};
 
     const TEST_POLICY: &str = include_str!("../../data/sandbox-policy.rego");
 
@@ -2333,6 +2357,101 @@ mod tests {
             .resolver_for_endpoint("denied.example.test", 443, "/outside")
             .expect("endpoint-scoped resolver");
         (state, resolver)
+    }
+
+    #[derive(Clone, Default)]
+    struct OcsfCapture {
+        events: Arc<Mutex<Vec<serde_json::Value>>>,
+    }
+
+    impl<S> Layer<S> for OcsfCapture
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: LayerContext<'_, S>) {
+            if event.metadata().target() != openshell_ocsf::OCSF_TARGET {
+                return;
+            }
+            let Some(event) = openshell_ocsf::clone_current_event() else {
+                return;
+            };
+            self.events
+                .lock()
+                .expect("OCSF capture lock")
+                .push(event.to_json().expect("OCSF event JSON"));
+        }
+    }
+
+    impl OcsfCapture {
+        fn snapshot(&self) -> Vec<serde_json::Value> {
+            self.events.lock().expect("OCSF capture lock").clone()
+        }
+    }
+
+    async fn run_single_config_credential_mismatch(
+        config: L7EndpointConfig,
+        engine: TunnelPolicyEngine,
+        mut ctx: L7EvalContext,
+        request: String,
+        resolver: Arc<SecretResolver>,
+    ) -> (String, Vec<u8>, Vec<serde_json::Value>) {
+        ctx.secret_resolver = Some(resolver);
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let capture = OcsfCapture::default();
+        let subscriber = tracing_subscriber::registry().with(capture.clone());
+        let relay = tokio::spawn(
+            async move {
+                relay_with_inspection(
+                    &config,
+                    engine,
+                    &mut relay_client,
+                    &mut relay_upstream,
+                    &ctx,
+                )
+                .await
+            }
+            .with_subscriber(subscriber),
+        );
+
+        app.write_all(request.as_bytes()).await.unwrap();
+        let mut response = String::new();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            app.read_to_string(&mut response),
+        )
+        .await
+        .expect("typed credential denial should close the client stream")
+        .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should finish")
+            .unwrap()
+            .unwrap();
+
+        let mut forwarded = Vec::new();
+        upstream.read_to_end(&mut forwarded).await.unwrap();
+        (response, forwarded, capture.snapshot())
+    }
+
+    fn assert_single_config_credential_mismatch(
+        response: &str,
+        forwarded: &[u8],
+        events: &[serde_json::Value],
+    ) {
+        assert!(response.contains("403 Forbidden"), "{response}");
+        assert!(
+            response.contains("credential_endpoint_mismatch"),
+            "{response}"
+        );
+        assert!(
+            forwarded.is_empty(),
+            "credential mismatch must not write upstream"
+        );
+
+        let events = serde_json::to_string(events).unwrap();
+        assert!(events.contains("\"status_detail\":\"credential_endpoint_mismatch\""));
+        assert!(events.contains("openshell.provider_credential.endpoint_mismatch"));
     }
 
     async fn assert_credential_relay_rejected(
@@ -2666,23 +2785,31 @@ network_policies:
     }
 
     fn jsonrpc_test_relay_context() -> (L7EndpointConfig, TunnelPolicyEngine, L7EvalContext) {
-        let data = r"
+        jsonrpc_test_relay_context_with_path("/rpc")
+    }
+
+    fn jsonrpc_test_relay_context_with_path(
+        endpoint_path: &str,
+    ) -> (L7EndpointConfig, TunnelPolicyEngine, L7EvalContext) {
+        let data = format!(
+            r#"
 network_policies:
   jsonrpc_api:
     name: jsonrpc_api
     endpoints:
       - host: jsonrpc.example.test
         port: 8000
-        path: /rpc
+        path: "{endpoint_path}"
         protocol: json-rpc
         enforcement: enforce
         rules:
           - allow:
               method: initialize
     binaries:
-      - { path: /usr/bin/python3 }
-";
-        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
+      - {{ path: /usr/bin/python3 }}
+"#
+        );
+        let engine = OpaEngine::from_strings(TEST_POLICY, &data).unwrap();
         let input = NetworkInput {
             host: "jsonrpc.example.test".into(),
             port: 8000,
@@ -2751,6 +2878,115 @@ network_policies:
             ..Default::default()
         };
         (config, tunnel_engine, ctx)
+    }
+
+    fn graphql_test_relay_context() -> (L7EndpointConfig, TunnelPolicyEngine, L7EvalContext) {
+        let data = r"
+network_policies:
+  graphql_api:
+    name: graphql_api
+    endpoints:
+      - host: graphql.example.test
+        port: 8000
+        path: /graphql
+        protocol: graphql
+        enforcement: enforce
+        rules:
+          - allow:
+              operation_type: query
+              fields: [viewer]
+    binaries:
+      - { path: /usr/bin/python3 }
+";
+        let engine = OpaEngine::from_strings(TEST_POLICY, data).unwrap();
+        let input = NetworkInput {
+            host: "graphql.example.test".into(),
+            port: 8000,
+            binary_path: PathBuf::from("/usr/bin/python3"),
+            binary_sha256: "unused".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+        };
+        let (endpoint_config, generation) = engine
+            .query_endpoint_config_with_generation(&input)
+            .unwrap();
+        let config = crate::l7::parse_l7_config(&endpoint_config.unwrap()).unwrap();
+        let tunnel_engine = engine.clone_engine_for_tunnel(generation).unwrap();
+        let ctx = L7EvalContext {
+            host: "graphql.example.test".into(),
+            port: 8000,
+            policy_name: "graphql_api".into(),
+            binary_path: "/usr/bin/python3".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            ..Default::default()
+        };
+        (config, tunnel_engine, ctx)
+    }
+
+    #[tokio::test]
+    async fn single_config_jsonrpc_credential_mismatch_is_typed_and_telemetry_safe() {
+        let (config, engine, ctx) = jsonrpc_test_relay_context_with_path("/rpc/**");
+        let (_state, resolver) = endpoint_mismatch_resolver(TestHashMap::from([(
+            "API_TOKEN".to_string(),
+            "secret".to_string(),
+        )]));
+        let body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}"#;
+        let request = format!(
+            "POST /rpc/openshell:resolve:env:v1_API_TOKEN HTTP/1.1\r\nHost: jsonrpc.example.test\r\nAuthorization: Bearer openshell:resolve:env:v1_API_TOKEN\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+
+        let (response, forwarded, events) =
+            run_single_config_credential_mismatch(config, engine, ctx, request, resolver).await;
+        assert_single_config_credential_mismatch(&response, &forwarded, &events);
+
+        let events = serde_json::to_string(&events).unwrap();
+        assert!(
+            events.contains("[CREDENTIAL]"),
+            "policy telemetry should contain the syntax-only redaction marker: {events}"
+        );
+        assert!(
+            !events.contains("API_TOKEN"),
+            "policy telemetry must not expose credential environment keys: {events}"
+        );
+    }
+
+    #[tokio::test]
+    async fn single_config_mcp_credential_mismatch_returns_typed_denial() {
+        let (config, engine, ctx) = mcp_test_relay_context();
+        let (_state, resolver) = endpoint_mismatch_resolver(TestHashMap::from([(
+            "API_TOKEN".to_string(),
+            "secret".to_string(),
+        )]));
+        let body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}"#;
+        let request = format!(
+            "POST /mcp HTTP/1.1\r\nHost: mcp.example.test\r\nAuthorization: Bearer openshell:resolve:env:v1_API_TOKEN\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+
+        let (response, forwarded, events) =
+            run_single_config_credential_mismatch(config, engine, ctx, request, resolver).await;
+        assert_single_config_credential_mismatch(&response, &forwarded, &events);
+    }
+
+    #[tokio::test]
+    async fn single_config_graphql_credential_mismatch_returns_typed_denial() {
+        let (config, engine, ctx) = graphql_test_relay_context();
+        let (_state, resolver) = endpoint_mismatch_resolver(TestHashMap::from([(
+            "API_TOKEN".to_string(),
+            "secret".to_string(),
+        )]));
+        let body = r#"{"query":"query { viewer }"}"#;
+        let request = format!(
+            "POST /graphql HTTP/1.1\r\nHost: graphql.example.test\r\nAuthorization: Bearer openshell:resolve:env:v1_API_TOKEN\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+
+        let (response, forwarded, events) =
+            run_single_config_credential_mismatch(config, engine, ctx, request, resolver).await;
+        assert_single_config_credential_mismatch(&response, &forwarded, &events);
     }
 
     fn authorization_header_count(headers: &str) -> usize {

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -810,7 +810,7 @@ where
     let use_websocket_relay = options.websocket_request
         && (options.websocket.message_policy.inspects_messages()
             || options.websocket.permessage_deflate
-            || (options.websocket.credential_rewrite && options.secret_resolver.is_some()));
+            || options.websocket.credential_rewrite);
     let relay_mode = if use_websocket_relay {
         "websocket parsed relay"
     } else {
@@ -5348,6 +5348,97 @@ network_policies:
             .expect("client side should close without 101")
             .unwrap();
         assert_eq!(n, 0, "invalid response must not forward 101 headers");
+    }
+
+    #[tokio::test]
+    async fn websocket_rewrite_stays_parsed_when_live_credentials_are_revoked_before_upgrade() {
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            TestHashMap::from([("API_TOKEN".to_string(), "real-token".to_string())]),
+            TestHashMap::new(),
+            TestHashMap::new(),
+            TestHashMap::from([(
+                "API_TOKEN".to_string(),
+                StaticCredentialBinding {
+                    endpoints: vec![StaticCredentialEndpointBinding {
+                        host: "allowed.example.test".to_string(),
+                        port: 443,
+                        path: "/allowed/**".to_string(),
+                    }],
+                    credential_identity: "provider-a:API_TOKEN".to_string(),
+                },
+            )]),
+            Vec::new(),
+        )
+        .expect("bound provider state");
+        let placeholder = state
+            .snapshot()
+            .child_env
+            .get("API_TOKEN")
+            .expect("placeholder")
+            .clone();
+        state.revoke_static_provider_environment(2);
+
+        let ctx = L7EvalContext {
+            host: "allowed.example.test".into(),
+            port: 443,
+            policy_name: "route_api".into(),
+            provider_credentials: Some(state),
+            ..Default::default()
+        };
+        let (mut app, mut relay_client) = tokio::io::duplex(4096);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(4096);
+        let relay = tokio::spawn(async move {
+            handle_upgrade(
+                &mut relay_client,
+                &mut relay_upstream,
+                Vec::new(),
+                "allowed.example.test",
+                443,
+                UpgradeRelayOptions {
+                    websocket_request: true,
+                    websocket: WebSocketUpgradeBehavior {
+                        credential_rewrite: true,
+                        ..Default::default()
+                    },
+                    ctx: Some(&ctx),
+                    target: "/allowed/socket".to_string(),
+                    policy_name: "route_api".to_string(),
+                    ..Default::default()
+                },
+            )
+            .await
+        });
+
+        app.write_all(&masked_text_frame(placeholder.as_bytes()))
+            .await
+            .unwrap();
+        app.flush().await.unwrap();
+
+        let mut forwarded = Vec::new();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upstream.read_to_end(&mut forwarded),
+        )
+        .await
+        .expect("revoked parsed relay should close upstream")
+        .unwrap();
+        assert!(
+            forwarded.is_empty(),
+            "revoked credential frame must not be raw-relayed upstream"
+        );
+
+        let error = tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("parsed relay should finish after credential rejection")
+            .unwrap()
+            .expect_err("revoked placeholder must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("credential placeholder resolution"),
+            "{error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -24,8 +24,9 @@ use miette::{IntoDiagnostic, Result, miette};
 use openshell_core::activity::{ActivitySender, try_record_activity};
 use openshell_core::secrets::{self, SecretResolver};
 use openshell_ocsf::{
-    ActionId, ActivityId, DispositionId, Endpoint, HttpActivityBuilder, HttpRequest,
-    NetworkActivityBuilder, SeverityId, StatusId, Url as OcsfUrl, ocsf_emit,
+    ActionId, ActivityId, DetectionFindingBuilder, DispositionId, Endpoint, FindingInfo,
+    HttpActivityBuilder, HttpRequest, NetworkActivityBuilder, SeverityId, StatusId, Url as OcsfUrl,
+    ocsf_emit,
 };
 #[cfg(test)]
 use std::collections::BTreeMap;
@@ -34,6 +35,7 @@ use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tracing::{debug, warn};
 
 /// Context for L7 request policy evaluation.
+#[derive(Clone)]
 #[cfg_attr(test, derive(Default))]
 pub struct L7EvalContext {
     /// Host from the CONNECT request.
@@ -50,6 +52,9 @@ pub struct L7EvalContext {
     pub cmdline_paths: Vec<String>,
     /// Supervisor-only placeholder resolver for outbound headers.
     pub(crate) secret_resolver: Option<Arc<SecretResolver>>,
+    /// Live provider state used to scope static credentials to each request.
+    pub(crate) provider_credentials:
+        Option<openshell_core::provider_credentials::ProviderCredentialState>,
     /// Anonymous activity counter channel.
     pub(crate) activity_tx: Option<ActivitySender>,
     /// Dynamic credentials (token grants) keyed by endpoint-bound provider metadata.
@@ -65,6 +70,113 @@ pub struct L7EvalContext {
         Option<Arc<dyn crate::l7::token_grant_injection::TokenGrantResolver>>,
     /// Shared feature state for agent-driven policy proposals.
     pub(crate) agent_proposals: openshell_core::proposals::AgentProposals,
+}
+
+fn scoped_context_for_request(ctx: &L7EvalContext, target: &str) -> Option<L7EvalContext> {
+    let credentials = ctx.provider_credentials.as_ref()?;
+    let mut scoped = ctx.clone();
+    scoped.secret_resolver = credentials.resolver_for_endpoint(&ctx.host, ctx.port, target);
+    Some(scoped)
+}
+
+async fn reject_credential_resolution<W>(
+    client: &mut W,
+    ctx: &L7EvalContext,
+    error: &secrets::UnresolvedPlaceholderError,
+) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let endpoint_mismatch = error.is_endpoint_mismatch();
+    let status = if endpoint_mismatch {
+        "403 Forbidden"
+    } else {
+        "500 Internal Server Error"
+    };
+    let body = if endpoint_mismatch {
+        r#"{"error":"credential_endpoint_mismatch","message":"Credential is not authorized for this request endpoint"}"#
+    } else {
+        r#"{"error":"credential_unavailable","message":"Credential placeholder could not be resolved"}"#
+    };
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    client
+        .write_all(response.as_bytes())
+        .await
+        .into_diagnostic()?;
+    client.flush().await.into_diagnostic()?;
+
+    let event = HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
+        .activity(ActivityId::Fail)
+        .action(ActionId::Denied)
+        .disposition(DispositionId::Blocked)
+        .severity(if endpoint_mismatch {
+            SeverityId::High
+        } else {
+            SeverityId::Medium
+        })
+        .status(StatusId::Failure)
+        .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+        .firewall_rule(&ctx.policy_name, "credential-binding")
+        .message(if endpoint_mismatch {
+            format!(
+                "Credential use denied: credential is not authorized for {}:{}",
+                ctx.host, ctx.port
+            )
+        } else {
+            format!(
+                "Credential use denied: credential is unavailable for {}:{}",
+                ctx.host, ctx.port
+            )
+        })
+        .status_detail(if endpoint_mismatch {
+            "credential_endpoint_mismatch"
+        } else {
+            "credential_unavailable"
+        })
+        .build();
+    ocsf_emit!(event);
+
+    if endpoint_mismatch {
+        let finding = DetectionFindingBuilder::new(openshell_ocsf::ctx::ctx())
+            .activity(ActivityId::Open)
+            .action(ActionId::Denied)
+            .disposition(DispositionId::Blocked)
+            .severity(SeverityId::High)
+            .is_alert(true)
+            .finding_info(FindingInfo::new(
+                "openshell.provider_credential.endpoint_mismatch",
+                "Provider credential used at an unauthorized endpoint",
+            ))
+            .evidence_pairs(&[
+                ("policy", ctx.policy_name.as_str()),
+                ("host", ctx.host.as_str()),
+                ("disposition", "denied"),
+            ])
+            .message("Provider credential endpoint binding mismatch; request denied")
+            .build();
+        ocsf_emit!(finding);
+    }
+    Ok(())
+}
+
+async fn preflight_request_credentials<W>(
+    client: &mut W,
+    ctx: &L7EvalContext,
+    request: &crate::l7::provider::L7Request,
+) -> Result<bool>
+where
+    W: AsyncWrite + Unpin,
+{
+    match secrets::rewrite_http_header_block(&request.raw_header, ctx.secret_resolver.as_deref()) {
+        Ok(_) => Ok(true),
+        Err(error) => {
+            reject_credential_resolution(client, ctx, &error).await?;
+            Ok(false)
+        }
+    }
 }
 
 #[derive(Default)]
@@ -299,7 +411,14 @@ where
             }
         };
 
-        let Some(config) = select_l7_config_for_path(configs, &req.target) else {
+        let route_target = match secrets::redact_target_for_policy(&req.target) {
+            Ok(target) => target,
+            Err(error) => {
+                reject_credential_resolution(client, ctx, &error).await?;
+                return Ok(());
+            }
+        };
+        let Some(config) = select_l7_config_for_path(configs, &route_target) else {
             crate::l7::rest::RestProvider::default()
                 .deny_with_redacted_target(
                     &req,
@@ -312,6 +431,11 @@ where
                 .await?;
             return Ok(());
         };
+        let scoped_ctx = scoped_context_for_request(ctx, &req.target);
+        let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
+        if !preflight_request_credentials(client, ctx, &req).await? {
+            return Ok(());
+        }
 
         if deny_h2c_upgrade_if_requested(&req, config, ctx, client).await? {
             return Ok(());
@@ -387,24 +511,12 @@ where
             return Ok(());
         }
 
-        let (eval_target, redacted_target) = if let Some(ref resolver) = ctx.secret_resolver {
-            match secrets::rewrite_target_for_eval(&req.target, resolver) {
-                Ok(result) => (result.resolved, result.redacted),
-                Err(e) => {
-                    warn!(
-                        host = %ctx.host,
-                        port = ctx.port,
-                        error = %e,
-                        "credential resolution failed in request target, rejecting"
-                    );
-                    let response = b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
-                    client.write_all(response).await.into_diagnostic()?;
-                    client.flush().await.into_diagnostic()?;
-                    return Ok(());
-                }
+        let redacted_target = match secrets::redact_target_for_policy(&req.target) {
+            Ok(target) => target,
+            Err(error) => {
+                reject_credential_resolution(client, ctx, &error).await?;
+                return Ok(());
             }
-        } else {
-            (req.target.clone(), req.target.clone())
         };
 
         let request_info = L7RequestInfo {
@@ -465,8 +577,6 @@ where
             &reason,
             &protocol_summary,
         );
-
-        let _ = &eval_target;
 
         if allowed || (config.enforcement == EnforcementMode::Audit && !force_deny) {
             let chain = engine.query_middleware_chain(&middleware_network_input(ctx))?;
@@ -716,6 +826,10 @@ where
             crate::l7::websocket::RelayOptions {
                 policy_name: &options.policy_name,
                 resolver,
+                provider_credentials: options
+                    .ctx
+                    .and_then(|ctx| ctx.provider_credentials.as_ref()),
+                target: &options.target,
                 inspector,
                 compression,
             },
@@ -765,7 +879,7 @@ pub(crate) fn upgrade_options<'a>(
             None
         },
         engine,
-        ctx: engine.map(|_| ctx),
+        ctx: (engine.is_some() || websocket_credential_rewrite).then_some(ctx),
         enforcement: config.enforcement,
         target: target.to_string(),
         query_params: query_params.clone(),
@@ -835,6 +949,11 @@ where
                 return Ok(()); // Close connection on parse error
             }
         };
+        let scoped_ctx = scoped_context_for_request(ctx, &req.target);
+        let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
+        if !preflight_request_credentials(client, ctx, &req).await? {
+            return Ok(());
+        }
 
         if deny_h2c_upgrade_if_requested(&req, config, ctx, client).await? {
             return Ok(());
@@ -844,27 +963,14 @@ where
             return Ok(());
         }
 
-        // Rewrite credential placeholders in the request target BEFORE OPA
-        // evaluation. OPA sees the redacted path; the resolved path goes only
-        // to the upstream write.
-        let (eval_target, redacted_target) = if let Some(ref resolver) = ctx.secret_resolver {
-            match secrets::rewrite_target_for_eval(&req.target, resolver) {
-                Ok(result) => (result.resolved, result.redacted),
-                Err(e) => {
-                    warn!(
-                        host = %ctx.host,
-                        port = ctx.port,
-                        error = %e,
-                        "credential resolution failed in request target, rejecting"
-                    );
-                    let response = b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
-                    client.write_all(response).await.into_diagnostic()?;
-                    client.flush().await.into_diagnostic()?;
-                    return Ok(());
-                }
+        // Redact placeholder syntax before OPA evaluation without consulting
+        // real credential material. Resolution happens only at upstream write.
+        let redacted_target = match secrets::redact_target_for_policy(&req.target) {
+            Ok(target) => target,
+            Err(error) => {
+                reject_credential_resolution(client, ctx, &error).await?;
+                return Ok(());
             }
-        } else {
-            (req.target.clone(), req.target.clone())
         };
 
         let request_info = L7RequestInfo {
@@ -950,9 +1056,6 @@ where
                 .build();
             ocsf_emit!(event);
         }
-
-        // Store the resolved target for the deny response redaction
-        let _ = &eval_target;
 
         if allowed || config.enforcement == EnforcementMode::Audit {
             let chain = engine.query_middleware_chain(&middleware_network_input(ctx))?;
@@ -1147,6 +1250,11 @@ where
 
         let req = parsed.request;
         let jsonrpc_info = parsed.info;
+        let scoped_ctx = scoped_context_for_request(ctx, &req.target);
+        let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
+        if !preflight_request_credentials(client, ctx, &req).await? {
+            return Ok(());
+        }
 
         if close_if_stale(engine.generation_guard(), ctx) {
             return Ok(());
@@ -1345,6 +1453,11 @@ where
 
         let req = parsed.request;
         let graphql_info = parsed.info;
+        let scoped_ctx = scoped_context_for_request(ctx, &req.target);
+        let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
+        if !preflight_request_credentials(client, ctx, &req).await? {
+            return Ok(());
+        }
 
         if deny_h2c_upgrade_if_requested(&req, config, ctx, client).await? {
             return Ok(());
@@ -1354,24 +1467,12 @@ where
             return Ok(());
         }
 
-        let (eval_target, redacted_target) = if let Some(ref resolver) = ctx.secret_resolver {
-            match secrets::rewrite_target_for_eval(&req.target, resolver) {
-                Ok(result) => (result.resolved, result.redacted),
-                Err(e) => {
-                    warn!(
-                        host = %ctx.host,
-                        port = ctx.port,
-                        error = %e,
-                        "credential resolution failed in GraphQL request target, rejecting"
-                    );
-                    let response = b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
-                    client.write_all(response).await.into_diagnostic()?;
-                    client.flush().await.into_diagnostic()?;
-                    return Ok(());
-                }
+        let redacted_target = match secrets::redact_target_for_policy(&req.target) {
+            Ok(target) => target,
+            Err(error) => {
+                reject_credential_resolution(client, ctx, &error).await?;
+                return Ok(());
             }
-        } else {
-            (req.target.clone(), req.target.clone())
         };
 
         let request_info = L7RequestInfo {
@@ -1438,8 +1539,6 @@ where
                 .build();
             ocsf_emit!(event);
         }
-
-        let _ = &eval_target;
 
         if allowed || (config.enforcement == EnforcementMode::Audit && !force_deny) {
             let chain = engine.query_middleware_chain(&middleware_network_input(ctx))?;
@@ -2000,8 +2099,6 @@ where
     // `allow_encoded_slash` opt-in applies.
     let provider = crate::l7::rest::RestProvider::default();
     let mut request_count: u64 = 0;
-    let resolver = ctx.secret_resolver.as_deref();
-
     loop {
         if close_if_stale(generation_guard, ctx) {
             return Ok(());
@@ -2021,6 +2118,12 @@ where
                 return Ok(());
             }
         };
+        let scoped_ctx = scoped_context_for_request(ctx, &req.target);
+        let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
+        let resolver = ctx.secret_resolver.as_deref();
+        if !preflight_request_credentials(client, ctx, &req).await? {
+            return Ok(());
+        }
 
         if close_if_stale(generation_guard, ctx) {
             return Ok(());
@@ -2028,25 +2131,13 @@ where
 
         request_count += 1;
 
-        // Resolve and redact the target for logging.
-        let redacted_target = if let Some(ref res) = ctx.secret_resolver {
-            match secrets::rewrite_target_for_eval(&req.target, res) {
-                Ok(result) => result.redacted,
-                Err(e) => {
-                    warn!(
-                        host = %ctx.host,
-                        port = ctx.port,
-                        error = %e,
-                        "credential resolution failed in request target, rejecting"
-                    );
-                    let response = b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
-                    client.write_all(response).await.into_diagnostic()?;
-                    client.flush().await.into_diagnostic()?;
-                    return Ok(());
-                }
+        // Build the logging representation without materializing a secret.
+        let redacted_target = match secrets::redact_target_for_policy(&req.target) {
+            Ok(target) => target,
+            Err(error) => {
+                reject_credential_resolution(client, ctx, &error).await?;
+                return Ok(());
             }
-        } else {
-            req.target.clone()
         };
 
         // Log for observability via OCSF HTTP Activity event.

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -80,20 +80,7 @@ pub struct L7EvalContext {
 }
 
 fn request_default_port(ctx: &L7EvalContext) -> Option<u16> {
-    ctx.request_default_port.or({
-        // Existing direct relay tests construct the request context below the
-        // production adapter that records the inspected transport. Keep those
-        // fixtures focused on their original concern; authority regressions
-        // set this field explicitly.
-        #[cfg(test)]
-        {
-            Some(ctx.port)
-        }
-        #[cfg(not(test))]
-        {
-            None
-        }
-    })
+    ctx.request_default_port
 }
 
 fn scoped_context_for_request(
@@ -2480,6 +2467,7 @@ mod tests {
         let ctx = L7EvalContext {
             host: "allowed.example.test".to_string(),
             port: 443,
+            request_default_port: Some(443),
             provider_credentials: Some(state),
             ..Default::default()
         };
@@ -2523,6 +2511,25 @@ mod tests {
             .expect("Host header");
         assert_eq!(authority.authority.host(), "[2001:db8::1]");
         assert!(request_authority_matches_endpoint(&request, &ctx));
+    }
+
+    #[test]
+    fn missing_request_default_port_does_not_infer_the_connect_port() {
+        let request = crate::l7::provider::L7Request {
+            action: "GET".to_string(),
+            target: "/v1".to_string(),
+            query_params: TestHashMap::new(),
+            raw_header: b"GET /v1 HTTP/1.1\r\nHost: api.example.test\r\n\r\n".to_vec(),
+            body_length: crate::l7::provider::BodyLength::None,
+        };
+        let ctx = L7EvalContext {
+            host: "api.example.test".to_string(),
+            port: 443,
+            request_default_port: None,
+            ..Default::default()
+        };
+
+        assert!(!request_authority_matches_endpoint(&request, &ctx));
     }
 
     async fn run_single_config_credential_mismatch(
@@ -2606,6 +2613,7 @@ mod tests {
         let ctx = L7EvalContext {
             host: "denied.example.test".to_string(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "bound".to_string(),
             secret_resolver: Some(Arc::new(resolver.clone())),
             ..Default::default()
@@ -2805,6 +2813,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 8080,
+            request_default_port: Some(8080),
             policy_name: "rest_api".into(),
             binary_path: "/usr/bin/curl".into(),
             ancestors: vec![],
@@ -2872,6 +2881,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 8080,
+            request_default_port: Some(8080),
             policy_name: "rest_api".into(),
             binary_path: "/usr/bin/curl".into(),
             ancestors: vec![],
@@ -2913,6 +2923,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 8080,
+            request_default_port: Some(8080),
             policy_name: "rest_api".into(),
             binary_path: "/usr/bin/curl".into(),
             ancestors: vec![],
@@ -2968,6 +2979,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "jsonrpc.example.test".into(),
             port: 8000,
+            request_default_port: Some(8000),
             policy_name: "jsonrpc_api".into(),
             binary_path: "/usr/bin/python3".into(),
             ancestors: vec![],
@@ -3012,6 +3024,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "mcp.example.test".into(),
             port: 8000,
+            request_default_port: Some(8000),
             policy_name: "mcp_api".into(),
             binary_path: "/usr/bin/python3".into(),
             ancestors: vec![],
@@ -3057,6 +3070,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "graphql.example.test".into(),
             port: 8000,
+            request_default_port: Some(8000),
             policy_name: "graphql_api".into(),
             binary_path: "/usr/bin/python3".into(),
             ancestors: vec![],
@@ -3577,6 +3591,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 8080,
+            request_default_port: Some(8080),
             policy_name: "passthrough_api".into(),
             binary_path: "/usr/bin/curl".into(),
             provider_credentials: Some(state),
@@ -3989,6 +4004,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "jsonrpc_api".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],
@@ -4104,6 +4120,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "p".into(),
             binary_path: "/usr/bin/curl".into(),
             ancestors: vec![],
@@ -4488,6 +4505,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "jsonrpc_api".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],
@@ -4650,6 +4668,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "graphql_api".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],
@@ -4749,6 +4768,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "db.example.test".into(),
             port: 5432,
+            request_default_port: Some(5432),
             policy_name: "sql_db".into(),
             binary_path: "/usr/bin/psql".into(),
             ancestors: vec![],
@@ -5102,6 +5122,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 80,
+            request_default_port: Some(80),
             policy_name: "api".into(),
             binary_path: "/usr/bin/curl".into(),
             ancestors: Vec::new(),
@@ -5134,6 +5155,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "rest_api".into(),
             binary_path: "/usr/bin/curl".into(),
             ancestors: vec![],
@@ -5323,6 +5345,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 8080,
+            request_default_port: Some(8080),
             policy_name: "passthrough_api".into(),
             binary_path: "/usr/bin/curl".into(),
             ancestors: vec![],
@@ -5433,6 +5456,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "gateway.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "ws_api".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],
@@ -5646,6 +5670,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "gateway.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "ws_api".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],
@@ -5721,6 +5746,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "jsonrpc_api".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],
@@ -5842,6 +5868,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "jsonrpc_api".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],
@@ -5905,6 +5932,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "mcp_api".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],
@@ -6066,6 +6094,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "gateway.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "route_api".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],
@@ -6163,6 +6192,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "gateway.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "route_api".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],
@@ -6256,6 +6286,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "allowed.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "route_api".into(),
             provider_credentials: Some(state),
             ..Default::default()
@@ -6364,6 +6395,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "gateway.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "route_api".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],
@@ -6487,6 +6519,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "gateway.example.test".into(),
             port: 443,
+            request_default_port: Some(443),
             policy_name: "route_api".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],
@@ -6658,6 +6691,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 8080,
+            request_default_port: Some(8080),
             policy_name: "rest_api".into(),
             binary_path: "/usr/bin/curl".into(),
             ancestors: vec![],
@@ -6749,6 +6783,7 @@ network_policies:
         let ctx = L7EvalContext {
             host: "api.example.test".into(),
             port: 8080,
+            request_default_port: Some(8080),
             policy_name: "rest_api".into(),
             binary_path: "/usr/bin/curl".into(),
             ancestors: vec![],

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -114,18 +114,10 @@ fn scoped_context_for_request(
         return Some(scoped);
     }
     let credentials = ctx.provider_credentials.as_ref()?;
-    let revision_before = credentials.revision();
-    let resolver = credentials.resolver_for_endpoint(&ctx.host, ctx.port, &request.target);
-    let revision_after = credentials.revision();
-    if revision_before != revision_after {
-        // The resolver and revision were not observed from one stable
-        // generation. Fail closed instead of retaining either snapshot.
-        scoped.secret_resolver = None;
-        scoped.provider_credential_revision = None;
-        return Some(scoped);
-    }
+    let (resolver, revision) =
+        credentials.resolver_for_endpoint_with_revision(&ctx.host, ctx.port, &request.target);
     scoped.secret_resolver = resolver;
-    scoped.provider_credential_revision = Some(revision_before);
+    scoped.provider_credential_revision = Some(revision);
     Some(scoped)
 }
 
@@ -2512,6 +2504,45 @@ mod tests {
             .resolver_for_endpoint("denied.example.test", 443, "/outside")
             .expect("endpoint-scoped resolver");
         (state, resolver)
+    }
+
+    #[test]
+    fn scoped_context_captures_endpoint_resolver_and_revision_together() {
+        let state = ProviderCredentialState::from_bound_environment(
+            42,
+            TestHashMap::from([("API_TOKEN".to_string(), "secret".to_string())]),
+            TestHashMap::new(),
+            TestHashMap::new(),
+            TestHashMap::from([(
+                "API_TOKEN".to_string(),
+                endpoint_binding("provider-a:API_TOKEN"),
+            )]),
+            Vec::new(),
+        )
+        .expect("bound provider state");
+        let ctx = L7EvalContext {
+            host: "allowed.example.test".to_string(),
+            port: 443,
+            provider_credentials: Some(state),
+            ..Default::default()
+        };
+        let request = crate::l7::provider::L7Request {
+            action: "GET".to_string(),
+            target: "/allowed/v1".to_string(),
+            query_params: TestHashMap::new(),
+            raw_header: b"GET /allowed/v1 HTTP/1.1\r\nHost: allowed.example.test\r\n\r\n".to_vec(),
+            body_length: crate::l7::provider::BodyLength::None,
+        };
+
+        let scoped = scoped_context_for_request(&ctx, &request).expect("scoped context");
+        assert_eq!(scoped.provider_credential_revision, Some(42));
+        assert_eq!(
+            scoped
+                .secret_resolver
+                .expect("endpoint resolver")
+                .resolve_placeholder("openshell:resolve:env:v42_API_TOKEN"),
+            Some("secret")
+        );
     }
 
     async fn run_single_config_credential_mismatch(

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -248,23 +248,12 @@ fn build_credential_resolution_event(
 }
 
 fn build_credential_endpoint_mismatch_finding(ctx: &L7EvalContext) -> openshell_ocsf::OcsfEvent {
-    DetectionFindingBuilder::new(openshell_ocsf::ctx::ctx())
-        .activity(ActivityId::Open)
-        .action(ActionId::Denied)
-        .disposition(DispositionId::Blocked)
-        .severity(SeverityId::High)
-        .is_alert(true)
-        .finding_info(FindingInfo::new(
-            "openshell.provider_credential.endpoint_mismatch",
-            "Provider credential used at an unauthorized endpoint",
-        ))
-        .evidence_pairs(&[
-            ("policy", ctx.policy_name.as_str()),
-            ("host", ctx.host.as_str()),
-            ("disposition", "denied"),
-        ])
-        .message("Provider credential endpoint binding mismatch; request denied")
-        .build()
+    crate::l7::build_credential_endpoint_mismatch_finding(
+        &ctx.policy_name,
+        &ctx.host,
+        None,
+        "Provider credential endpoint binding mismatch; request denied",
+    )
 }
 
 pub(crate) async fn reject_credential_resolution<W>(

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -42,6 +42,9 @@ pub struct L7EvalContext {
     pub host: String,
     /// Port from the CONNECT request.
     pub port: u16,
+    /// Default authority port for the inspected HTTP transport (80 for
+    /// plaintext, 443 after TLS termination).
+    pub(crate) request_default_port: Option<u16>,
     /// Matched policy name from L4 evaluation.
     pub policy_name: String,
     /// Binary path (for cross-layer Rego evaluation).
@@ -72,10 +75,42 @@ pub struct L7EvalContext {
     pub(crate) agent_proposals: openshell_core::proposals::AgentProposals,
 }
 
-fn scoped_context_for_request(ctx: &L7EvalContext, target: &str) -> Option<L7EvalContext> {
-    let credentials = ctx.provider_credentials.as_ref()?;
+fn request_default_port(ctx: &L7EvalContext) -> Option<u16> {
+    ctx.request_default_port.or({
+        // Existing direct relay tests construct the request context below the
+        // production adapter that records the inspected transport. Keep those
+        // fixtures focused on their original concern; authority regressions
+        // set this field explicitly.
+        #[cfg(test)]
+        {
+            Some(ctx.port)
+        }
+        #[cfg(not(test))]
+        {
+            None
+        }
+    })
+}
+
+fn scoped_context_for_request(
+    ctx: &L7EvalContext,
+    request: &crate::l7::provider::L7Request,
+) -> Option<L7EvalContext> {
     let mut scoped = ctx.clone();
-    scoped.secret_resolver = credentials.resolver_for_endpoint(&ctx.host, ctx.port, target);
+    if matches!(
+        crate::l7::rest::request_authority(&request.raw_header, request_default_port(ctx)),
+        Ok(None)
+    ) {
+        // HTTP/1.0 permits an origin-form request without Host. Such requests
+        // remain compatible, but an absent authority cannot authorize static
+        // credential use. Clearing the resolver makes any placeholder or
+        // signing attempt fail closed before an upstream write.
+        scoped.secret_resolver = None;
+        return Some(scoped);
+    }
+    let credentials = ctx.provider_credentials.as_ref()?;
+    scoped.secret_resolver =
+        credentials.resolver_for_endpoint(&ctx.host, ctx.port, &request.target);
     Some(scoped)
 }
 
@@ -83,20 +118,23 @@ fn request_authority_matches_endpoint(
     request: &crate::l7::provider::L7Request,
     ctx: &L7EvalContext,
 ) -> bool {
-    let authority = match crate::l7::rest::request_host_authority(&request.raw_header) {
-        Ok(Some(authority)) => authority,
-        Ok(None) => return true,
-        Err(_) => return false,
-    };
-    let request_host = authority.host().trim_end_matches('.');
+    let authority =
+        match crate::l7::rest::request_authority(&request.raw_header, request_default_port(ctx)) {
+            Ok(Some(authority)) => authority,
+            Ok(None) => {
+                return std::str::from_utf8(&request.raw_header)
+                    .is_ok_and(|request| !secrets::contains_reserved_credential_marker(request));
+            }
+            Err(_) => return false,
+        };
+    let request_host = authority.authority.host().trim_end_matches('.');
     let endpoint_host = ctx
         .host
         .trim()
         .trim_start_matches('[')
         .trim_end_matches(']')
         .trim_end_matches('.');
-    request_host.eq_ignore_ascii_case(endpoint_host)
-        && authority.port_u16().is_none_or(|port| port == ctx.port)
+    request_host.eq_ignore_ascii_case(endpoint_host) && authority.effective_port == ctx.port
 }
 
 async fn reject_request_authority_mismatch<W>(client: &mut W, ctx: &L7EvalContext) -> Result<()>
@@ -532,7 +570,7 @@ where
                 .await?;
             return Ok(());
         };
-        let scoped_ctx = scoped_context_for_request(ctx, &req.target);
+        let scoped_ctx = scoped_context_for_request(ctx, &req);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
 
         if deny_h2c_upgrade_if_requested(&req, config, ctx, client).await? {
@@ -1055,7 +1093,7 @@ where
             reject_request_authority_mismatch(client, ctx).await?;
             return Ok(());
         }
-        let scoped_ctx = scoped_context_for_request(ctx, &req.target);
+        let scoped_ctx = scoped_context_for_request(ctx, &req);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
 
         if deny_h2c_upgrade_if_requested(&req, config, ctx, client).await? {
@@ -1361,7 +1399,7 @@ where
             reject_request_authority_mismatch(client, ctx).await?;
             return Ok(());
         }
-        let scoped_ctx = scoped_context_for_request(ctx, &req.target);
+        let scoped_ctx = scoped_context_for_request(ctx, &req);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
 
         if close_if_stale(engine.generation_guard(), ctx) {
@@ -1578,7 +1616,7 @@ where
             reject_request_authority_mismatch(client, ctx).await?;
             return Ok(());
         }
-        let scoped_ctx = scoped_context_for_request(ctx, &req.target);
+        let scoped_ctx = scoped_context_for_request(ctx, &req);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
 
         if deny_h2c_upgrade_if_requested(&req, config, ctx, client).await? {
@@ -2251,7 +2289,7 @@ where
             reject_request_authority_mismatch(client, ctx).await?;
             return Ok(());
         }
-        let scoped_ctx = scoped_context_for_request(ctx, &req.target);
+        let scoped_ctx = scoped_context_for_request(ctx, &req);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
         let resolver = ctx.secret_resolver.as_deref();
 
@@ -2415,11 +2453,7 @@ mod tests {
     use openshell_core::provider_credentials::ProviderCredentialState;
     use std::collections::HashMap as TestHashMap;
     use std::path::PathBuf;
-    use std::sync::Mutex;
     use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
-    use tracing::instrument::WithSubscriber;
-    use tracing_subscriber::Layer;
-    use tracing_subscriber::layer::{Context as LayerContext, SubscriberExt};
 
     const TEST_POLICY: &str = include_str!("../../data/sandbox-policy.rego");
 
@@ -2456,60 +2490,26 @@ mod tests {
         (state, resolver)
     }
 
-    #[derive(Clone, Default)]
-    struct OcsfCapture {
-        events: Arc<Mutex<Vec<serde_json::Value>>>,
-    }
-
-    impl<S> Layer<S> for OcsfCapture
-    where
-        S: tracing::Subscriber,
-    {
-        fn on_event(&self, event: &tracing::Event<'_>, _ctx: LayerContext<'_, S>) {
-            if event.metadata().target() != openshell_ocsf::OCSF_TARGET {
-                return;
-            }
-            let Some(event) = openshell_ocsf::clone_current_event() else {
-                return;
-            };
-            self.events
-                .lock()
-                .expect("OCSF capture lock")
-                .push(event.to_json().expect("OCSF event JSON"));
-        }
-    }
-
-    impl OcsfCapture {
-        fn snapshot(&self) -> Vec<serde_json::Value> {
-            self.events.lock().expect("OCSF capture lock").clone()
-        }
-    }
-
     async fn run_single_config_credential_mismatch(
         config: L7EndpointConfig,
         engine: TunnelPolicyEngine,
         mut ctx: L7EvalContext,
         request: String,
         resolver: Arc<SecretResolver>,
-    ) -> (String, Vec<u8>, Vec<serde_json::Value>) {
+    ) -> (String, Vec<u8>) {
         ctx.secret_resolver = Some(resolver);
         let (mut app, mut relay_client) = tokio::io::duplex(8192);
         let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
-        let capture = OcsfCapture::default();
-        let subscriber = tracing_subscriber::registry().with(capture.clone());
-        let relay = tokio::spawn(
-            async move {
-                relay_with_inspection(
-                    &config,
-                    engine,
-                    &mut relay_client,
-                    &mut relay_upstream,
-                    &ctx,
-                )
-                .await
-            }
-            .with_subscriber(subscriber),
-        );
+        let relay = tokio::spawn(async move {
+            relay_with_inspection(
+                &config,
+                engine,
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+            )
+            .await
+        });
 
         app.write_all(request.as_bytes()).await.unwrap();
         let mut response = String::new();
@@ -2528,13 +2528,13 @@ mod tests {
 
         let mut forwarded = Vec::new();
         upstream.read_to_end(&mut forwarded).await.unwrap();
-        (response, forwarded, capture.snapshot())
+        (response, forwarded)
     }
 
     fn assert_single_config_credential_mismatch(
         response: &str,
         forwarded: &[u8],
-        events: &[serde_json::Value],
+        ctx: &L7EvalContext,
     ) {
         assert!(response.contains("403 Forbidden"), "{response}");
         assert!(
@@ -2546,9 +2546,19 @@ mod tests {
             "credential mismatch must not write upstream"
         );
 
-        let events = serde_json::to_string(events).unwrap();
-        assert!(events.contains("\"status_detail\":\"credential_endpoint_mismatch\""));
-        assert!(events.contains("openshell.provider_credential.endpoint_mismatch"));
+        let activity = build_credential_resolution_event(ctx, true)
+            .to_json()
+            .expect("serialize credential mismatch activity");
+        assert_eq!(activity["status_detail"], "credential_endpoint_mismatch");
+        assert_eq!(activity["action"], "Denied");
+        assert_eq!(activity["disposition"], "Blocked");
+        let finding = build_credential_endpoint_mismatch_finding(ctx)
+            .to_json()
+            .expect("serialize credential mismatch finding");
+        assert_eq!(
+            finding["finding_info"]["uid"],
+            "openshell.provider_credential.endpoint_mismatch"
+        );
     }
 
     async fn assert_credential_relay_rejected(
@@ -3025,6 +3035,7 @@ network_policies:
     #[tokio::test]
     async fn single_config_jsonrpc_credential_mismatch_is_typed_and_telemetry_safe() {
         let (config, engine, ctx) = jsonrpc_test_relay_context_with_path("/rpc/**");
+        let event_ctx = ctx.clone();
         let (_state, resolver) = endpoint_mismatch_resolver(TestHashMap::from([(
             "API_TOKEN".to_string(),
             "secret".to_string(),
@@ -3035,24 +3046,27 @@ network_policies:
             body.len()
         );
 
-        let (response, forwarded, events) =
+        let (response, forwarded) =
             run_single_config_credential_mismatch(config, engine, ctx, request, resolver).await;
-        assert_single_config_credential_mismatch(&response, &forwarded, &events);
+        assert_single_config_credential_mismatch(&response, &forwarded, &event_ctx);
 
-        let events = serde_json::to_string(&events).unwrap();
+        let redacted_target =
+            secrets::redact_target_for_policy("/rpc/openshell:resolve:env:v1_API_TOKEN")
+                .expect("policy target redaction");
         assert!(
-            events.contains("[CREDENTIAL]"),
-            "policy telemetry should contain the syntax-only redaction marker: {events}"
+            redacted_target.contains("[CREDENTIAL]"),
+            "policy telemetry should contain the syntax-only redaction marker: {redacted_target}"
         );
         assert!(
-            !events.contains("API_TOKEN"),
-            "policy telemetry must not expose credential environment keys: {events}"
+            !redacted_target.contains("API_TOKEN"),
+            "policy telemetry must not expose credential environment keys: {redacted_target}"
         );
     }
 
     #[tokio::test]
     async fn single_config_mcp_credential_mismatch_returns_typed_denial() {
         let (config, engine, ctx) = mcp_test_relay_context();
+        let event_ctx = ctx.clone();
         let (_state, resolver) = endpoint_mismatch_resolver(TestHashMap::from([(
             "API_TOKEN".to_string(),
             "secret".to_string(),
@@ -3063,14 +3077,15 @@ network_policies:
             body.len()
         );
 
-        let (response, forwarded, events) =
+        let (response, forwarded) =
             run_single_config_credential_mismatch(config, engine, ctx, request, resolver).await;
-        assert_single_config_credential_mismatch(&response, &forwarded, &events);
+        assert_single_config_credential_mismatch(&response, &forwarded, &event_ctx);
     }
 
     #[tokio::test]
     async fn single_config_graphql_credential_mismatch_returns_typed_denial() {
         let (config, engine, ctx) = graphql_test_relay_context();
+        let event_ctx = ctx.clone();
         let (_state, resolver) = endpoint_mismatch_resolver(TestHashMap::from([(
             "API_TOKEN".to_string(),
             "secret".to_string(),
@@ -3081,9 +3096,9 @@ network_policies:
             body.len()
         );
 
-        let (response, forwarded, events) =
+        let (response, forwarded) =
             run_single_config_credential_mismatch(config, engine, ctx, request, resolver).await;
-        assert_single_config_credential_mismatch(&response, &forwarded, &events);
+        assert_single_config_credential_mismatch(&response, &forwarded, &event_ctx);
     }
 
     fn authorization_header_count(headers: &str) -> usize {
@@ -3590,6 +3605,197 @@ network_policies:
             finding["finding_info"]["uid"],
             "openshell.http.request_authority_mismatch"
         );
+    }
+
+    async fn run_bound_credential_request(
+        port: u16,
+        request_default_port: u16,
+        request: impl FnOnce(&str) -> String,
+    ) -> (String, Vec<u8>) {
+        let engine = OpaEngine::from_strings(TEST_POLICY, "network_policies: {}\n").unwrap();
+        let generation_guard = engine
+            .generation_guard(engine.current_generation())
+            .unwrap();
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            TestHashMap::from([("API_TOKEN".to_string(), "secret".to_string())]),
+            TestHashMap::new(),
+            TestHashMap::new(),
+            TestHashMap::from([(
+                "API_TOKEN".to_string(),
+                StaticCredentialBinding {
+                    endpoints: vec![StaticCredentialEndpointBinding {
+                        host: "api.example.test".to_string(),
+                        port: u32::from(port),
+                        path: "/v1/**".to_string(),
+                    }],
+                    credential_identity: "provider-a:API_TOKEN".to_string(),
+                },
+            )]),
+            Vec::new(),
+        )
+        .expect("bound provider state");
+        let placeholder = state
+            .snapshot()
+            .child_env
+            .get("API_TOKEN")
+            .expect("placeholder")
+            .clone();
+        let ctx = L7EvalContext {
+            host: "api.example.test".into(),
+            port,
+            request_default_port: Some(request_default_port),
+            policy_name: "passthrough_api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            provider_credentials: Some(state),
+            ..Default::default()
+        };
+
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_passthrough_with_credentials(
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+                &generation_guard,
+                None,
+            )
+            .await
+        });
+
+        app.write_all(request(&placeholder).as_bytes())
+            .await
+            .unwrap();
+        let mut response = String::new();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            app.read_to_string(&mut response),
+        )
+        .await
+        .expect("credential denial should close the client stream")
+        .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should finish")
+            .unwrap()
+            .unwrap();
+        let mut forwarded = Vec::new();
+        upstream.read_to_end(&mut forwarded).await.unwrap();
+        (response, forwarded)
+    }
+
+    #[tokio::test]
+    async fn connect_http10_without_authority_cannot_resolve_static_credential() {
+        let (response, forwarded) = run_bound_credential_request(80, 80, |placeholder| {
+            format!(
+                "GET /v1/messages HTTP/1.0\r\nAuthorization: Bearer {placeholder}\r\nConnection: close\r\n\r\n"
+            )
+        })
+        .await;
+
+        assert!(response.contains("403 Forbidden"), "{response}");
+        assert!(
+            response.contains("request_authority_mismatch"),
+            "{response}"
+        );
+        assert!(
+            forwarded.is_empty(),
+            "authority-less credential request must not write upstream"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_origin_form_omitted_port_rejects_non_default_tunnel() {
+        let (response, forwarded) = run_bound_credential_request(8080, 80, |placeholder| {
+            format!(
+                "GET /v1/messages HTTP/1.1\r\nHost: api.example.test\r\nAuthorization: Bearer {placeholder}\r\nConnection: close\r\n\r\n"
+            )
+        })
+        .await;
+
+        assert!(response.contains("403 Forbidden"), "{response}");
+        assert!(
+            response.contains("request_authority_mismatch"),
+            "{response}"
+        );
+        assert!(
+            forwarded.is_empty(),
+            "origin-form request with the wrong effective port must not write upstream"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_absolute_form_omitted_port_rejects_non_default_tunnel() {
+        let (response, forwarded) = run_bound_credential_request(8080, 80, |placeholder| {
+            format!(
+                "GET http://api.example.test/v1/messages HTTP/1.1\r\nHost: api.example.test\r\nAuthorization: Bearer {placeholder}\r\nConnection: close\r\n\r\n"
+            )
+        })
+        .await;
+
+        assert!(response.contains("403 Forbidden"), "{response}");
+        assert!(
+            response.contains("request_authority_mismatch"),
+            "{response}"
+        );
+        assert!(
+            forwarded.is_empty(),
+            "absolute-form request with the wrong effective port must not write upstream"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_http10_without_authority_forwards_credential_free_request() {
+        let engine = OpaEngine::from_strings(TEST_POLICY, "network_policies: {}\n").unwrap();
+        let generation_guard = engine
+            .generation_guard(engine.current_generation())
+            .unwrap();
+        let ctx = L7EvalContext {
+            host: "api.example.test".into(),
+            port: 80,
+            request_default_port: Some(80),
+            policy_name: "passthrough_api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            ..Default::default()
+        };
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_passthrough_with_credentials(
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+                &generation_guard,
+                None,
+            )
+            .await
+        });
+
+        app.write_all(b"GET /v1/messages HTTP/1.0\r\nConnection: close\r\n\r\n")
+            .await
+            .unwrap();
+        let mut forwarded = [0u8; 512];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upstream.read(&mut forwarded),
+        )
+        .await
+        .expect("credential-free HTTP/1.0 request should reach upstream")
+        .unwrap();
+        assert!(String::from_utf8_lossy(&forwarded[..n]).starts_with("GET /v1/messages HTTP/1.0"));
+        upstream
+            .write_all(b"HTTP/1.0 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .await
+            .unwrap();
+        let mut response = String::new();
+        app.read_to_string(&mut response).await.unwrap();
+        assert!(response.contains("204 No Content"), "{response}");
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should finish")
+            .unwrap()
+            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -143,14 +143,16 @@ fn request_authority_matches_endpoint(
             }
             Err(_) => return false,
         };
-    let request_host = authority.authority.host().trim_end_matches('.');
-    let endpoint_host = ctx
-        .host
-        .trim()
+    let request_host = normalized_endpoint_host(authority.authority.host());
+    let endpoint_host = normalized_endpoint_host(&ctx.host);
+    request_host.eq_ignore_ascii_case(endpoint_host) && authority.effective_port == ctx.port
+}
+
+fn normalized_endpoint_host(host: &str) -> &str {
+    host.trim()
         .trim_start_matches('[')
         .trim_end_matches(']')
-        .trim_end_matches('.');
-    request_host.eq_ignore_ascii_case(endpoint_host) && authority.effective_port == ctx.port
+        .trim_end_matches('.')
 }
 
 async fn reject_request_authority_mismatch<W>(client: &mut W, ctx: &L7EvalContext) -> Result<()>
@@ -2543,6 +2545,29 @@ mod tests {
                 .resolve_placeholder("openshell:resolve:env:v42_API_TOKEN"),
             Some("secret")
         );
+    }
+
+    #[test]
+    fn bracketed_ipv6_host_matches_bracket_free_connect_endpoint() {
+        let request = crate::l7::provider::L7Request {
+            action: "GET".to_string(),
+            target: "/v1".to_string(),
+            query_params: TestHashMap::new(),
+            raw_header: b"GET /v1 HTTP/1.1\r\nHost: [2001:db8::1]:8443\r\n\r\n".to_vec(),
+            body_length: crate::l7::provider::BodyLength::None,
+        };
+        let ctx = L7EvalContext {
+            host: "2001:db8::1".to_string(),
+            port: 8443,
+            request_default_port: Some(8443),
+            ..Default::default()
+        };
+
+        let authority = crate::l7::rest::request_authority(&request.raw_header, Some(8443))
+            .expect("valid authority")
+            .expect("Host header");
+        assert_eq!(authority.authority.host(), "[2001:db8::1]");
+        assert!(request_authority_matches_endpoint(&request, &ctx));
     }
 
     async fn run_single_config_credential_mismatch(

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -699,13 +699,7 @@ where
             (false, EnforcementMode::Audit) => "audit",
             (false, EnforcementMode::Enforce) => "deny",
         };
-        let engine_type = match config.protocol {
-            L7Protocol::Graphql => "l7-graphql",
-            L7Protocol::Websocket => "l7-websocket",
-            L7Protocol::JsonRpc => "l7-jsonrpc",
-            L7Protocol::Mcp => "l7-mcp",
-            L7Protocol::Rest | L7Protocol::Sql => "l7",
-        };
+        let engine_type = engine_type_for_protocol(config.protocol);
         let protocol_summary =
             l7_protocol_log_summary(graphql_info.as_ref(), jsonrpc_info.as_ref());
         emit_l7_request_log(
@@ -876,7 +870,7 @@ fn l7_protocol_log_summary(
     jsonrpc_info: Option<&crate::l7::jsonrpc::JsonRpcRequestInfo>,
 ) -> String {
     if let Some(info) = graphql_info {
-        return format!(" {}", graphql_log_summary(info));
+        return format!(" {}", crate::l7::graphql::log_summary(info));
     }
 
     if let Some(info) = jsonrpc_info {
@@ -1684,7 +1678,7 @@ where
                     SeverityId::Informational,
                 ),
             };
-            let gql_summary = graphql_log_summary(&graphql_info);
+            let gql_summary = crate::l7::graphql::log_summary(&graphql_info);
             let event = HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
                 .activity(ActivityId::Other)
                 .action(action_id)
@@ -1801,34 +1795,6 @@ where
             return Ok(());
         }
     }
-}
-
-fn graphql_log_summary(info: &crate::l7::graphql::GraphqlRequestInfo) -> String {
-    if let Some(error) = &info.error {
-        return format!("graphql_error={error:?}");
-    }
-    let ops: Vec<String> = info
-        .operations
-        .iter()
-        .map(|op| {
-            let name = op.operation_name.as_deref().unwrap_or("-");
-            let fields = if op.fields.is_empty() {
-                "-".to_string()
-            } else {
-                op.fields.join(",")
-            };
-            let persisted = op
-                .persisted_query_hash
-                .as_deref()
-                .or(op.persisted_query_id.as_deref())
-                .unwrap_or("-");
-            format!(
-                "type={} name={} fields={} persisted={}",
-                op.operation_type, name, fields, persisted
-            )
-        })
-        .collect();
-    format!("graphql_ops={}", ops.join(";"))
 }
 
 pub(crate) fn jsonrpc_log_message(

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -79,6 +79,83 @@ fn scoped_context_for_request(ctx: &L7EvalContext, target: &str) -> Option<L7Eva
     Some(scoped)
 }
 
+fn request_authority_matches_endpoint(
+    request: &crate::l7::provider::L7Request,
+    ctx: &L7EvalContext,
+) -> bool {
+    let authority = match crate::l7::rest::request_host_authority(&request.raw_header) {
+        Ok(Some(authority)) => authority,
+        Ok(None) => return true,
+        Err(_) => return false,
+    };
+    let request_host = authority.host().trim_end_matches('.');
+    let endpoint_host = ctx
+        .host
+        .trim()
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .trim_end_matches('.');
+    request_host.eq_ignore_ascii_case(endpoint_host)
+        && authority.port_u16().is_none_or(|port| port == ctx.port)
+}
+
+async fn reject_request_authority_mismatch<W>(client: &mut W, ctx: &L7EvalContext) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let body = r#"{"error":"request_authority_mismatch","message":"HTTP request authority does not match the authorized tunnel endpoint"}"#;
+    let response = format!(
+        "HTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    client
+        .write_all(response.as_bytes())
+        .await
+        .into_diagnostic()?;
+    client.flush().await.into_diagnostic()?;
+
+    ocsf_emit!(build_request_authority_mismatch_event(ctx));
+    ocsf_emit!(build_request_authority_mismatch_finding(ctx));
+    Ok(())
+}
+
+fn build_request_authority_mismatch_event(ctx: &L7EvalContext) -> openshell_ocsf::OcsfEvent {
+    HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
+        .activity(ActivityId::Fail)
+        .action(ActionId::Denied)
+        .disposition(DispositionId::Blocked)
+        .severity(SeverityId::High)
+        .status(StatusId::Failure)
+        .dst_endpoint(Endpoint::from_domain(&ctx.host, ctx.port))
+        .firewall_rule(&ctx.policy_name, "request-authority")
+        .message(format!(
+            "HTTP request authority does not match authorized tunnel endpoint {}:{}",
+            ctx.host, ctx.port
+        ))
+        .status_detail("request_authority_mismatch")
+        .build()
+}
+
+fn build_request_authority_mismatch_finding(ctx: &L7EvalContext) -> openshell_ocsf::OcsfEvent {
+    DetectionFindingBuilder::new(openshell_ocsf::ctx::ctx())
+        .activity(ActivityId::Open)
+        .action(ActionId::Denied)
+        .disposition(DispositionId::Blocked)
+        .severity(SeverityId::High)
+        .is_alert(true)
+        .finding_info(FindingInfo::new(
+            "openshell.http.request_authority_mismatch",
+            "HTTP request authority does not match the authorized tunnel endpoint",
+        ))
+        .evidence_pairs(&[
+            ("policy", ctx.policy_name.as_str()),
+            ("host", ctx.host.as_str()),
+            ("disposition", "denied"),
+        ])
+        .message("HTTP request authority mismatch; request denied")
+        .build()
+}
+
 fn build_credential_resolution_event(
     ctx: &L7EvalContext,
     endpoint_mismatch: bool,
@@ -430,6 +507,10 @@ where
                 return Ok(());
             }
         };
+        if !request_authority_matches_endpoint(&req, ctx) {
+            reject_request_authority_mismatch(client, ctx).await?;
+            return Ok(());
+        }
 
         let route_target = match secrets::redact_target_for_policy(&req.target) {
             Ok(target) => target,
@@ -970,6 +1051,10 @@ where
                 return Ok(()); // Close connection on parse error
             }
         };
+        if !request_authority_matches_endpoint(&req, ctx) {
+            reject_request_authority_mismatch(client, ctx).await?;
+            return Ok(());
+        }
         let scoped_ctx = scoped_context_for_request(ctx, &req.target);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
 
@@ -1272,6 +1357,10 @@ where
 
         let req = parsed.request;
         let jsonrpc_info = parsed.info;
+        if !request_authority_matches_endpoint(&req, ctx) {
+            reject_request_authority_mismatch(client, ctx).await?;
+            return Ok(());
+        }
         let scoped_ctx = scoped_context_for_request(ctx, &req.target);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
 
@@ -1485,6 +1574,10 @@ where
 
         let req = parsed.request;
         let graphql_info = parsed.info;
+        if !request_authority_matches_endpoint(&req, ctx) {
+            reject_request_authority_mismatch(client, ctx).await?;
+            return Ok(());
+        }
         let scoped_ctx = scoped_context_for_request(ctx, &req.target);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
 
@@ -2154,6 +2247,10 @@ where
                 return Ok(());
             }
         };
+        if !request_authority_matches_endpoint(&req, ctx) {
+            reject_request_authority_mismatch(client, ctx).await?;
+            return Ok(());
+        }
         let scoped_ctx = scoped_context_for_request(ctx, &req.target);
         let ctx = scoped_ctx.as_ref().unwrap_or(ctx);
         let resolver = ctx.secret_resolver.as_deref();
@@ -3394,6 +3491,105 @@ network_policies:
             .expect("relay should finish")
             .unwrap()
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_rejects_credential_request_with_mismatched_host_authority() {
+        let engine = OpaEngine::from_strings(TEST_POLICY, "network_policies: {}\n").unwrap();
+        let generation_guard = engine
+            .generation_guard(engine.current_generation())
+            .unwrap();
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            TestHashMap::from([("API_TOKEN".to_string(), "secret".to_string())]),
+            TestHashMap::new(),
+            TestHashMap::new(),
+            TestHashMap::from([(
+                "API_TOKEN".to_string(),
+                StaticCredentialBinding {
+                    endpoints: vec![StaticCredentialEndpointBinding {
+                        host: "api.example.test".to_string(),
+                        port: 8080,
+                        path: "/v1/**".to_string(),
+                    }],
+                    credential_identity: "provider-a:API_TOKEN".to_string(),
+                },
+            )]),
+            Vec::new(),
+        )
+        .expect("bound provider state");
+        let placeholder = state
+            .snapshot()
+            .child_env
+            .get("API_TOKEN")
+            .expect("placeholder")
+            .clone();
+        let ctx = L7EvalContext {
+            host: "api.example.test".into(),
+            port: 8080,
+            policy_name: "passthrough_api".into(),
+            binary_path: "/usr/bin/curl".into(),
+            provider_credentials: Some(state),
+            ..Default::default()
+        };
+        let event_ctx = ctx.clone();
+
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_passthrough_with_credentials(
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+                &generation_guard,
+                None,
+            )
+            .await
+        });
+
+        let request = format!(
+            "POST /v1/messages HTTP/1.1\r\nHost: attacker.example.test\r\nAuthorization: Bearer {placeholder}\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{{}}"
+        );
+        app.write_all(request.as_bytes()).await.unwrap();
+
+        let mut response = String::new();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            app.read_to_string(&mut response),
+        )
+        .await
+        .expect("authority denial should close the client stream")
+        .unwrap();
+        assert!(response.contains("403 Forbidden"), "{response}");
+        assert!(
+            response.contains("request_authority_mismatch"),
+            "{response}"
+        );
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should finish")
+            .unwrap()
+            .unwrap();
+        let mut forwarded = Vec::new();
+        upstream.read_to_end(&mut forwarded).await.unwrap();
+        assert!(
+            forwarded.is_empty(),
+            "mismatched request authority must not write upstream"
+        );
+        let activity = build_request_authority_mismatch_event(&event_ctx)
+            .to_json()
+            .expect("serialize authority mismatch activity");
+        assert_eq!(activity["status_detail"], "request_authority_mismatch");
+        assert_eq!(activity["action"], "Denied");
+        assert_eq!(activity["disposition"], "Blocked");
+        let finding = build_request_authority_mismatch_finding(&event_ctx)
+            .to_json()
+            .expect("serialize authority mismatch finding");
+        assert_eq!(
+            finding["finding_info"]["uid"],
+            "openshell.http.request_authority_mismatch"
+        );
     }
 
     #[tokio::test]

--- a/crates/openshell-supervisor-network/src/l7/rest.rs
+++ b/crates/openshell-supervisor-network/src/l7/rest.rs
@@ -677,8 +677,8 @@ where
                 offered_subprotocols: request.subprotocols.clone(),
             });
 
-    let rewrite_result = rewrite_http_header_block(&header_bytes, options.resolver)
-        .map_err(|e| miette!("credential injection failed: {e}"))?;
+    let rewrite_result =
+        rewrite_http_header_block(&header_bytes, options.resolver).map_err(miette::Report::new)?;
 
     if let Some(guard) = options.generation_guard {
         guard.ensure_current()?;
@@ -713,12 +713,18 @@ where
             let session_token_placeholder =
                 openshell_core::secrets::placeholder_for_env_key("AWS_SESSION_TOKEN");
 
-            match (
-                resolver.resolve_placeholder(&access_key_placeholder),
-                resolver.resolve_placeholder(&secret_key_placeholder),
-            ) {
+            let access_key = resolver
+                .resolve_placeholder_checked(&access_key_placeholder, "sigv4")
+                .map_err(miette::Report::new)?;
+            let secret_key = resolver
+                .resolve_placeholder_checked(&secret_key_placeholder, "sigv4")
+                .map_err(miette::Report::new)?;
+            let session_token = resolver
+                .resolve_placeholder_checked(&session_token_placeholder, "sigv4")
+                .map_err(miette::Report::new)?;
+
+            match (access_key, secret_key) {
                 (Some(access_key), Some(secret_key)) => {
-                    let session_token = resolver.resolve_placeholder(&session_token_placeholder);
                     // Use explicit signing_region from policy if set,
                     // otherwise extract from hostname.
                     let region = if options.signing_region.is_empty() {
@@ -1295,7 +1301,7 @@ fn rewrite_buffered_body(
     } else {
         resolver
             .rewrite_text_placeholders(&mut text, "request_body")
-            .map_err(|e| miette!("credential injection failed: {e}"))?
+            .map_err(miette::Report::new)?
     };
     if replacements == 0 || contains_reserved_credential_marker(&text) {
         return Err(miette!(
@@ -1342,7 +1348,7 @@ fn rewrite_form_urlencoded_body(body: &str, resolver: &SecretResolver) -> Result
         let mut rewritten_value = decoded_value;
         let field_replacements = resolver
             .rewrite_text_placeholders(&mut rewritten_value, "request_body")
-            .map_err(|e| miette!("credential injection failed: {e}"))?;
+            .map_err(miette::Report::new)?;
         if field_replacements == 0 || contains_reserved_credential_marker(&rewritten_value) {
             return Err(miette!(
                 "request body credential rewrite left unresolved credential placeholders"

--- a/crates/openshell-supervisor-network/src/l7/rest.rs
+++ b/crates/openshell-supervisor-network/src/l7/rest.rs
@@ -416,11 +416,7 @@ pub(crate) fn request_authority(
         .next()
         .and_then(|line| line.split_whitespace().nth(1))
         .ok_or_else(|| miette!("HTTP request is missing a request target"))?;
-    let absolute_uri = request_target
-        .contains("://")
-        .then(|| request_target.parse::<http::Uri>())
-        .transpose()
-        .map_err(|_| miette!("HTTP absolute-form request target contains an invalid URI"))?;
+    let absolute_uri = absolute_form_uri(request_target)?;
     let (authority, default_port) = if let Some(uri) = absolute_uri {
         let authority = uri
             .authority()
@@ -464,12 +460,9 @@ fn validate_absolute_form_authority(
     target: &str,
     host_authority: Option<&http::uri::Authority>,
 ) -> Result<()> {
-    if !target.contains("://") {
+    let Some(uri) = absolute_form_uri(target)? else {
         return Ok(());
-    }
-    let uri = target
-        .parse::<http::Uri>()
-        .map_err(|_| miette!("HTTP absolute-form request target contains an invalid URI"))?;
+    };
     let request_authority = uri
         .authority()
         .ok_or_else(|| miette!("HTTP absolute-form request target is missing an authority"))?;
@@ -481,6 +474,18 @@ fn validate_absolute_form_authority(
         ));
     }
     Ok(())
+}
+
+/// Return a URI only when the request-target uses HTTP absolute form.
+///
+/// Origin-form request-targets can legitimately contain `://` in a path or
+/// query value, so a substring check would incorrectly make those requests
+/// participate in authority validation.
+fn absolute_form_uri(target: &str) -> Result<Option<http::Uri>> {
+    let uri = target
+        .parse::<http::Uri>()
+        .map_err(|_| miette!("HTTP absolute-form request target contains an invalid URI"))?;
+    Ok(uri.scheme().is_some().then_some(uri))
 }
 
 fn authorities_match(
@@ -4894,6 +4899,50 @@ mod tests {
                 .to_string()
                 .contains("request authority does not match the Host header"),
             "{error}"
+        );
+    }
+
+    #[test]
+    fn origin_form_targets_with_embedded_urls_use_host_authority() {
+        let host: http::uri::Authority = "api.example.test".parse().unwrap();
+
+        for target in ["/fetch/http://example.test", "/?next=http://example.test"] {
+            assert!(
+                absolute_form_uri(target).unwrap().is_none(),
+                "{target} must remain origin-form"
+            );
+            validate_absolute_form_authority(target, Some(&host))
+                .expect("embedded URL must not trigger absolute-form validation");
+
+            let raw = format!("GET {target} HTTP/1.1\r\nHost: api.example.test\r\n\r\n");
+            let authority = request_authority(raw.as_bytes(), Some(443))
+                .unwrap()
+                .expect("origin-form request with Host must have an authority");
+            assert_eq!(authority.authority, host);
+            assert_eq!(authority.effective_port, 443);
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_http_request_keeps_embedded_url_in_origin_form_path() {
+        let (mut client, mut peer) = tokio::io::duplex(1024);
+        peer.write_all(
+            b"GET /fetch/http://example.test?next=http://other.test HTTP/1.1\r\nHost: api.example.test\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        let request = parse_http_request(
+            &mut client,
+            &crate::l7::path::CanonicalizeOptions::default(),
+        )
+        .await
+        .expect("embedded URL origin-form request must parse")
+        .expect("request must be present");
+        assert_eq!(request.target, "/fetch/http:/example.test");
+        assert_eq!(
+            request.raw_header,
+            b"GET /fetch/http:/example.test?next=http://other.test HTTP/1.1\r\nHost: api.example.test\r\n\r\n",
         );
     }
 

--- a/crates/openshell-supervisor-network/src/l7/rest.rs
+++ b/crates/openshell-supervisor-network/src/l7/rest.rs
@@ -390,7 +390,16 @@ pub(crate) fn validate_http_request_header_block(headers: &[u8]) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn request_host_authority(raw_header: &[u8]) -> Result<Option<http::uri::Authority>> {
+#[derive(Debug)]
+pub(crate) struct RequestAuthority {
+    pub(crate) authority: http::uri::Authority,
+    pub(crate) effective_port: u16,
+}
+
+pub(crate) fn request_authority(
+    raw_header: &[u8],
+    transport_default_port: Option<u16>,
+) -> Result<Option<RequestAuthority>> {
     let header_end = raw_header
         .windows(4)
         .position(|window| window == b"\r\n\r\n")
@@ -398,7 +407,40 @@ pub(crate) fn request_host_authority(raw_header: &[u8]) -> Result<Option<http::u
         + 4;
     let headers = std::str::from_utf8(&raw_header[..header_end])
         .map_err(|_| miette!("HTTP headers contain invalid UTF-8"))?;
-    request_host_authority_from_str(headers)
+    let Some(host_authority) = request_host_authority_from_str(headers)? else {
+        return Ok(None);
+    };
+
+    let request_target = headers
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .ok_or_else(|| miette!("HTTP request is missing a request target"))?;
+    let absolute_uri = request_target
+        .contains("://")
+        .then(|| request_target.parse::<http::Uri>())
+        .transpose()
+        .map_err(|_| miette!("HTTP absolute-form request target contains an invalid URI"))?;
+    let (authority, default_port) = if let Some(uri) = absolute_uri {
+        let authority = uri
+            .authority()
+            .ok_or_else(|| miette!("HTTP absolute-form request target is missing an authority"))?
+            .clone();
+        let default_port = default_port_for_scheme(uri.scheme_str()).ok_or_else(|| {
+            miette!("HTTP absolute-form request target uses an unsupported scheme")
+        })?;
+        (authority, default_port)
+    } else {
+        let default_port = transport_default_port
+            .ok_or_else(|| miette!("HTTP origin-form request transport scheme is unavailable"))?;
+        (host_authority, default_port)
+    };
+
+    let effective_port = authority.port_u16().unwrap_or(default_port);
+    Ok(Some(RequestAuthority {
+        authority,
+        effective_port,
+    }))
 }
 
 fn request_host_authority_from_str(headers: &str) -> Result<Option<http::uri::Authority>> {
@@ -451,12 +493,16 @@ fn authorities_match(
     {
         return false;
     }
-    let default_port = match scheme {
+    let default_port = default_port_for_scheme(scheme);
+    left.port_u16().or(default_port) == right.port_u16().or(default_port)
+}
+
+fn default_port_for_scheme(scheme: Option<&str>) -> Option<u16> {
+    match scheme {
         Some(scheme) if scheme.eq_ignore_ascii_case("http") => Some(80),
         Some(scheme) if scheme.eq_ignore_ascii_case("https") => Some(443),
         _ => None,
-    };
-    left.port_u16().or(default_port) == right.port_u16().or(default_port)
+    }
 }
 
 fn normalized_authority_host(host: &str) -> &str {
@@ -784,21 +830,14 @@ where
             client.flush().await.into_diagnostic()?;
         }
         if let Some(resolver) = options.resolver {
-            let access_key_placeholder =
-                openshell_core::secrets::placeholder_for_env_key("AWS_ACCESS_KEY_ID");
-            let secret_key_placeholder =
-                openshell_core::secrets::placeholder_for_env_key("AWS_SECRET_ACCESS_KEY");
-            let session_token_placeholder =
-                openshell_core::secrets::placeholder_for_env_key("AWS_SESSION_TOKEN");
-
             let access_key = resolver
-                .resolve_placeholder_checked(&access_key_placeholder, "sigv4")
+                .resolve_current_env_key_checked("AWS_ACCESS_KEY_ID", "sigv4")
                 .map_err(miette::Report::new)?;
             let secret_key = resolver
-                .resolve_placeholder_checked(&secret_key_placeholder, "sigv4")
+                .resolve_current_env_key_checked("AWS_SECRET_ACCESS_KEY", "sigv4")
                 .map_err(miette::Report::new)?;
             let session_token = resolver
-                .resolve_placeholder_checked(&session_token_placeholder, "sigv4")
+                .resolve_current_env_key_checked("AWS_SESSION_TOKEN", "sigv4")
                 .map_err(miette::Report::new)?;
 
             match (access_key, secret_key) {

--- a/crates/openshell-supervisor-network/src/l7/rest.rs
+++ b/crates/openshell-supervisor-network/src/l7/rest.rs
@@ -717,6 +717,7 @@ where
         upstream,
         RelayRequestOptions {
             resolver,
+            credential_generation: None,
             generation_guard,
             websocket_extensions: WebSocketExtensionMode::Preserve,
             request_body_credential_rewrite: false,
@@ -740,6 +741,7 @@ pub(crate) enum WebSocketExtensionMode {
 #[derive(Clone, Copy, Default)]
 pub(crate) struct RelayRequestOptions<'a> {
     pub(crate) resolver: Option<&'a SecretResolver>,
+    pub(crate) credential_generation: Option<CredentialGenerationGuard<'a>>,
     pub(crate) generation_guard: Option<&'a PolicyGenerationGuard>,
     pub(crate) websocket_extensions: WebSocketExtensionMode,
     pub(crate) request_body_credential_rewrite: bool,
@@ -748,6 +750,38 @@ pub(crate) struct RelayRequestOptions<'a> {
     pub(crate) signing_region: &'a str,
     pub(crate) host: &'a str,
     pub(crate) port: u16,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct CredentialGenerationGuard<'a> {
+    state: &'a openshell_core::provider_credentials::ProviderCredentialState,
+    revision: u64,
+}
+
+impl<'a> CredentialGenerationGuard<'a> {
+    pub(crate) fn new(
+        state: &'a openshell_core::provider_credentials::ProviderCredentialState,
+        revision: u64,
+    ) -> Self {
+        Self { state, revision }
+    }
+
+    pub(crate) fn ensure_current(self) -> Result<()> {
+        if self.state.revision() == self.revision {
+            Ok(())
+        } else {
+            Err(miette!(
+                "provider credential generation changed before upstream write"
+            ))
+        }
+    }
+}
+
+fn ensure_credential_generation_current(options: RelayRequestOptions<'_>) -> Result<()> {
+    if let Some(guard) = options.credential_generation {
+        guard.ensure_current()?;
+    }
+    Ok(())
 }
 
 pub(crate) async fn relay_http_request_with_options_guarded<C, U>(
@@ -760,6 +794,7 @@ where
     C: AsyncRead + AsyncWrite + Unpin,
     U: AsyncRead + AsyncWrite + Unpin,
 {
+    ensure_credential_generation_current(options)?;
     let header_end = req
         .raw_header
         .windows(4)
@@ -938,6 +973,7 @@ where
                             secret_key,
                             session_token,
                         )?;
+                        ensure_credential_generation_current(options)?;
                         upstream.write_all(&signed).await.into_diagnostic()?;
                     } else {
                         // Sign headers only, stream body through.
@@ -957,6 +993,7 @@ where
                             session_token,
                             signable_body,
                         )?;
+                        ensure_credential_generation_current(options)?;
                         upstream
                             .write_all(&signed_headers)
                             .await
@@ -1040,11 +1077,13 @@ where
             options.generation_guard,
         )
         .await?;
+        ensure_credential_generation_current(options)?;
         upstream.write_all(&body.headers).await.into_diagnostic()?;
         if !body.body.is_empty() {
             upstream.write_all(&body.body).await.into_diagnostic()?;
         }
     } else {
+        ensure_credential_generation_current(options)?;
         upstream
             .write_all(&rewrite_result.rewritten)
             .await

--- a/crates/openshell-supervisor-network/src/l7/rest.rs
+++ b/crates/openshell-supervisor-network/src/l7/rest.rs
@@ -240,6 +240,11 @@ async fn parse_http_request<C: AsyncRead + Unpin>(
     if version != "HTTP/1.1" && version != "HTTP/1.0" {
         return Err(miette!("Unsupported HTTP version: {version}"));
     }
+    let host_authority = request_host_authority_from_str(header_str)?;
+    if version == "HTTP/1.1" && host_authority.is_none() {
+        return Err(miette!("HTTP/1.1 request is missing a Host header"));
+    }
+    validate_absolute_form_authority(&target, host_authority.as_ref())?;
 
     // Determine body framing from headers
     let body_length = parse_body_length(header_str)?;
@@ -383,6 +388,79 @@ pub(crate) fn validate_http_request_header_block(headers: &[u8]) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+pub(crate) fn request_host_authority(raw_header: &[u8]) -> Result<Option<http::uri::Authority>> {
+    let header_end = raw_header
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .ok_or_else(|| miette!("HTTP request headers are missing the CRLF terminator"))?
+        + 4;
+    let headers = std::str::from_utf8(&raw_header[..header_end])
+        .map_err(|_| miette!("HTTP headers contain invalid UTF-8"))?;
+    request_host_authority_from_str(headers)
+}
+
+fn request_host_authority_from_str(headers: &str) -> Result<Option<http::uri::Authority>> {
+    let mut authorities = headers.lines().skip(1).filter_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case("host").then_some(value.trim())
+    });
+    let Some(authority) = authorities.next() else {
+        return Ok(None);
+    };
+    if authorities.next().is_some() {
+        return Err(miette!("HTTP request contains multiple Host headers"));
+    }
+    authority
+        .parse()
+        .map(Some)
+        .map_err(|_| miette!("HTTP request Host header contains an invalid authority"))
+}
+
+fn validate_absolute_form_authority(
+    target: &str,
+    host_authority: Option<&http::uri::Authority>,
+) -> Result<()> {
+    if !target.contains("://") {
+        return Ok(());
+    }
+    let uri = target
+        .parse::<http::Uri>()
+        .map_err(|_| miette!("HTTP absolute-form request target contains an invalid URI"))?;
+    let request_authority = uri
+        .authority()
+        .ok_or_else(|| miette!("HTTP absolute-form request target is missing an authority"))?;
+    let host_authority = host_authority
+        .ok_or_else(|| miette!("HTTP absolute-form request is missing a Host header"))?;
+    if !authorities_match(request_authority, host_authority, uri.scheme_str()) {
+        return Err(miette!(
+            "HTTP absolute-form request authority does not match the Host header"
+        ));
+    }
+    Ok(())
+}
+
+fn authorities_match(
+    left: &http::uri::Authority,
+    right: &http::uri::Authority,
+    scheme: Option<&str>,
+) -> bool {
+    if !normalized_authority_host(left.host())
+        .eq_ignore_ascii_case(normalized_authority_host(right.host()))
+    {
+        return false;
+    }
+    let default_port = match scheme {
+        Some(scheme) if scheme.eq_ignore_ascii_case("http") => Some(80),
+        Some(scheme) if scheme.eq_ignore_ascii_case("https") => Some(443),
+        _ => None,
+    };
+    left.port_u16().or(default_port) == right.port_u16().or(default_port)
+}
+
+fn normalized_authority_host(host: &str) -> &str {
+    host.trim_end_matches('.')
 }
 
 fn validate_http_request_line(request_line: &str) -> Result<()> {
@@ -4715,6 +4793,29 @@ mod tests {
         assert_eq!(
             req.raw_header, b"GET /secret HTTP/1.1\r\nHost: api.example.com\r\n\r\n",
             "outbound request line must carry the canonical path"
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_http_request_rejects_absolute_authority_mismatched_with_host() {
+        let (mut client, mut peer) = tokio::io::duplex(1024);
+        peer.write_all(
+            b"GET http://attacker.example.test/v1 HTTP/1.1\r\nHost: api.example.test\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        let error = parse_http_request(
+            &mut client,
+            &crate::l7::path::CanonicalizeOptions::default(),
+        )
+        .await
+        .expect_err("absolute-form authority mismatch must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("request authority does not match the Host header"),
+            "{error}"
         );
     }
 

--- a/crates/openshell-supervisor-network/src/l7/websocket.rs
+++ b/crates/openshell-supervisor-network/src/l7/websocket.rs
@@ -14,8 +14,8 @@ use miette::{IntoDiagnostic, Result, miette};
 use openshell_core::provider_credentials::ProviderCredentialState;
 use openshell_core::secrets::{SecretResolver, contains_reserved_credential_marker};
 use openshell_ocsf::{
-    ActionId, ActivityId, DetectionFindingBuilder, DispositionId, Endpoint, FindingInfo,
-    NetworkActivityBuilder, SeverityId, StatusId, ocsf_emit,
+    ActionId, ActivityId, DispositionId, Endpoint, NetworkActivityBuilder, SeverityId, StatusId,
+    ocsf_emit,
 };
 use std::collections::HashMap;
 use std::future::Future;
@@ -149,26 +149,12 @@ fn emit_credential_endpoint_mismatch(host: &str, port: u16, policy_name: &str) {
             .status_detail("credential_endpoint_mismatch")
             .build()
     );
-    ocsf_emit!(
-        DetectionFindingBuilder::new(openshell_ocsf::ctx::ctx())
-            .activity(ActivityId::Open)
-            .action(ActionId::Denied)
-            .disposition(DispositionId::Blocked)
-            .severity(SeverityId::High)
-            .is_alert(true)
-            .finding_info(FindingInfo::new(
-                "openshell.provider_credential.endpoint_mismatch",
-                "Provider credential used at an unauthorized endpoint",
-            ))
-            .evidence_pairs(&[
-                ("policy", policy_name),
-                ("host", host),
-                ("protocol", "websocket"),
-                ("disposition", "denied"),
-            ])
-            .message("Provider credential endpoint binding mismatch; WebSocket closed")
-            .build()
-    );
+    ocsf_emit!(crate::l7::build_credential_endpoint_mismatch_finding(
+        policy_name,
+        host,
+        Some("websocket"),
+        "Provider credential endpoint binding mismatch; WebSocket closed",
+    ));
 }
 
 async fn relay_client_to_server<R, W>(

--- a/crates/openshell-supervisor-network/src/l7/websocket.rs
+++ b/crates/openshell-supervisor-network/src/l7/websocket.rs
@@ -11,10 +11,11 @@ use crate::l7::{EnforcementMode, L7RequestInfo};
 use crate::opa::TunnelPolicyEngine;
 use flate2::{Compress, Compression, Decompress, FlushCompress, FlushDecompress, Status};
 use miette::{IntoDiagnostic, Result, miette};
-use openshell_core::secrets::SecretResolver;
+use openshell_core::provider_credentials::ProviderCredentialState;
+use openshell_core::secrets::{SecretResolver, contains_reserved_credential_marker};
 use openshell_ocsf::{
-    ActionId, ActivityId, DispositionId, Endpoint, NetworkActivityBuilder, SeverityId, StatusId,
-    ocsf_emit,
+    ActionId, ActivityId, DetectionFindingBuilder, DispositionId, Endpoint, FindingInfo,
+    NetworkActivityBuilder, SeverityId, StatusId, ocsf_emit,
 };
 use std::collections::HashMap;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -28,6 +29,7 @@ const OPCODE_BINARY: u8 = 0x2;
 const OPCODE_CLOSE: u8 = 0x8;
 const OPCODE_PING: u8 = 0x9;
 const OPCODE_PONG: u8 = 0xA;
+const CREDENTIAL_ENDPOINT_MISMATCH: &str = "websocket credential endpoint mismatch";
 
 #[derive(Debug)]
 struct FrameHeader {
@@ -65,6 +67,8 @@ pub(super) struct InspectionOptions<'a> {
 pub(super) struct RelayOptions<'a> {
     pub(super) policy_name: &'a str,
     pub(super) resolver: Option<&'a SecretResolver>,
+    pub(super) provider_credentials: Option<&'a ProviderCredentialState>,
+    pub(super) target: &'a str,
     pub(super) inspector: Option<InspectionOptions<'a>>,
     pub(super) compression: WebSocketCompression,
 }
@@ -105,9 +109,65 @@ where
         result = client_to_server => result,
         result = server_to_client => result,
     };
+    if result
+        .as_ref()
+        .is_err_and(|error| error.to_string().contains(CREDENTIAL_ENDPOINT_MISMATCH))
+    {
+        emit_credential_endpoint_mismatch(host, port, options.policy_name);
+        write_policy_violation_close(&mut client_write).await?;
+    }
     let _ = upstream_write.shutdown().await;
     let _ = client_write.shutdown().await;
     result
+}
+
+async fn write_policy_violation_close<W: AsyncWrite + Unpin>(writer: &mut W) -> Result<()> {
+    let reason = b"credential endpoint mismatch";
+    let mut frame = Vec::with_capacity(reason.len() + 4);
+    frame.push(0x80 | OPCODE_CLOSE);
+    frame.push(u8::try_from(reason.len() + 2).expect("close reason fits one-byte length"));
+    frame.extend_from_slice(&1008u16.to_be_bytes());
+    frame.extend_from_slice(reason);
+    writer.write_all(&frame).await.into_diagnostic()?;
+    writer.flush().await.into_diagnostic()
+}
+
+fn emit_credential_endpoint_mismatch(host: &str, port: u16, policy_name: &str) {
+    ocsf_emit!(
+        NetworkActivityBuilder::new(openshell_ocsf::ctx::ctx())
+            .activity(ActivityId::Fail)
+            .action(ActionId::Denied)
+            .disposition(DispositionId::Blocked)
+            .severity(SeverityId::High)
+            .status(StatusId::Failure)
+            .dst_endpoint(Endpoint::from_domain(host, port))
+            .firewall_rule(policy_name, "credential-binding")
+            .message(format!(
+                "WebSocket credential use denied: credential is not authorized for {host}:{port}"
+            ))
+            .status_detail("credential_endpoint_mismatch")
+            .build()
+    );
+    ocsf_emit!(
+        DetectionFindingBuilder::new(openshell_ocsf::ctx::ctx())
+            .activity(ActivityId::Open)
+            .action(ActionId::Denied)
+            .disposition(DispositionId::Blocked)
+            .severity(SeverityId::High)
+            .is_alert(true)
+            .finding_info(FindingInfo::new(
+                "openshell.provider_credential.endpoint_mismatch",
+                "Provider credential used at an unauthorized endpoint",
+            ))
+            .evidence_pairs(&[
+                ("policy", policy_name),
+                ("host", host),
+                ("protocol", "websocket"),
+                ("disposition", "denied"),
+            ])
+            .message("Provider credential endpoint binding mismatch; WebSocket closed")
+            .build()
+    );
 }
 
 async fn relay_client_to_server<R, W>(
@@ -492,10 +552,24 @@ async fn relay_text_payload<W: AsyncWrite + Unpin>(
     };
     let mut text = String::from_utf8(message_payload)
         .map_err(|_| miette!("websocket text message is not valid UTF-8"))?;
-    let replacements = if let Some(resolver) = options.resolver {
+    let live_resolver = options
+        .provider_credentials
+        .and_then(|credentials| credentials.resolver_for_endpoint(host, port, options.target));
+    let resolver = live_resolver.as_deref().or(options.resolver);
+    let replacements = if let Some(resolver) = resolver {
         resolver
             .rewrite_websocket_text_placeholders(&mut text)
-            .map_err(|_| miette!("websocket credential placeholder resolution failed"))?
+            .map_err(|error| {
+                if error.is_endpoint_mismatch() {
+                    miette!(CREDENTIAL_ENDPOINT_MISMATCH)
+                } else {
+                    miette!("websocket credential placeholder resolution failed")
+                }
+            })?
+    } else if contains_reserved_credential_marker(&text) {
+        return Err(miette!(
+            "websocket credential placeholder resolution failed"
+        ));
     } else {
         0
     };
@@ -1226,6 +1300,8 @@ network_policies:
         let options = RelayOptions {
             policy_name: "test-policy",
             resolver: Some(&resolver),
+            provider_credentials: None,
+            target: "/",
             inspector: None,
             compression: WebSocketCompression::None,
         };
@@ -1284,6 +1360,8 @@ network_policies:
         let options = RelayOptions {
             policy_name: "graphql_ws",
             resolver,
+            provider_credentials: None,
+            target: "/graphql",
             inspector: Some(InspectionOptions {
                 engine: &tunnel_engine,
                 ctx: &ctx,
@@ -1320,6 +1398,8 @@ network_policies:
         let options = RelayOptions {
             policy_name: "test-policy",
             resolver: Some(&resolver),
+            provider_credentials: None,
+            target: "/",
             inspector: None,
             compression: WebSocketCompression::PermessageDeflate,
         };
@@ -1557,6 +1637,8 @@ network_policies:
                 RelayOptions {
                     policy_name: "test-policy",
                     resolver: Some(&resolver),
+                    provider_credentials: None,
+                    target: "/",
                     inspector: None,
                     compression: WebSocketCompression::None,
                 },

--- a/crates/openshell-supervisor-network/src/l7/websocket.rs
+++ b/crates/openshell-supervisor-network/src/l7/websocket.rs
@@ -554,8 +554,10 @@ async fn relay_text_payload<W: AsyncWrite + Unpin>(
         .map_err(|_| miette!("websocket text message is not valid UTF-8"))?;
     let live_resolver = options
         .provider_credentials
-        .and_then(|credentials| credentials.resolver_for_endpoint(host, port, options.target));
-    let resolver = live_resolver.as_deref().or(options.resolver);
+        .map(|credentials| credentials.resolver_for_endpoint(host, port, options.target));
+    let resolver = live_resolver
+        .as_ref()
+        .map_or(options.resolver, |resolver| resolver.as_deref());
     let replacements = if let Some(resolver) = resolver {
         resolver
             .rewrite_websocket_text_placeholders(&mut text)
@@ -1182,6 +1184,8 @@ mod tests {
     use super::*;
     use crate::l7::relay::L7EvalContext;
     use crate::opa::{NetworkInput, OpaEngine};
+    use openshell_core::proto::{StaticCredentialBinding, StaticCredentialEndpointBinding};
+    use openshell_core::provider_credentials::ProviderCredentialState;
     use openshell_core::secrets::SecretResolver;
     use std::path::PathBuf;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -1318,6 +1322,103 @@ network_policies:
         let mut output = Vec::new();
         upstream_read.read_to_end(&mut output).await.unwrap();
         result.map(|()| output)
+    }
+
+    fn bound_websocket_provider_state() -> ProviderCredentialState {
+        ProviderCredentialState::from_bound_environment(
+            1,
+            HashMap::from([("DISCORD_BOT_TOKEN".to_string(), "real-token".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([(
+                "DISCORD_BOT_TOKEN".to_string(),
+                StaticCredentialBinding {
+                    endpoints: vec![StaticCredentialEndpointBinding {
+                        host: "gateway.example.test".to_string(),
+                        port: 443,
+                        path: "/socket".to_string(),
+                    }],
+                    credential_identity: "provider-a:DISCORD_BOT_TOKEN".to_string(),
+                },
+            )]),
+            Vec::new(),
+        )
+        .expect("bound websocket provider state")
+    }
+
+    async fn relay_frame_after_live_state_change(
+        state: &ProviderCredentialState,
+        fallback: &SecretResolver,
+    ) -> (Result<()>, Vec<u8>) {
+        let placeholder = b"openshell:resolve:env:v1_DISCORD_BOT_TOKEN";
+        let input = masked_frame(true, 0x1, placeholder);
+        let (mut client_write, mut relay_read) = tokio::io::duplex(4096);
+        let (mut relay_write, mut upstream_read) = tokio::io::duplex(4096);
+        client_write.write_all(&input).await.unwrap();
+        drop(client_write);
+
+        let options = RelayOptions {
+            policy_name: "test-policy",
+            resolver: Some(fallback),
+            provider_credentials: Some(state),
+            target: "/socket",
+            inspector: None,
+            compression: WebSocketCompression::None,
+        };
+        let result = relay_client_to_server(
+            &mut relay_read,
+            &mut relay_write,
+            "gateway.example.test",
+            443,
+            &options,
+        )
+        .await;
+        drop(relay_write);
+        let mut output = Vec::new();
+        upstream_read.read_to_end(&mut output).await.unwrap();
+        (result, output)
+    }
+
+    #[tokio::test]
+    async fn established_websocket_does_not_restore_resolver_after_detach() {
+        let state = bound_websocket_provider_state();
+        let fallback = state.resolver().expect("upgrade-time resolver");
+        state.revoke_static_provider_environment(2);
+
+        let (result, output) = relay_frame_after_live_state_change(&state, fallback.as_ref()).await;
+        assert!(result.is_err(), "revoked placeholder must close the relay");
+        assert!(
+            output.is_empty(),
+            "revoked WebSocket credential must not reach upstream"
+        );
+    }
+
+    #[tokio::test]
+    async fn established_websocket_does_not_restore_resolver_after_invalid_refresh() {
+        let state = bound_websocket_provider_state();
+        let fallback = state.resolver().expect("upgrade-time resolver");
+        let refresh = state.install_bound_environment(
+            2,
+            HashMap::from([("DISCORD_BOT_TOKEN".to_string(), "rotated".to_string())]),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            Vec::new(),
+        );
+        assert!(
+            refresh.is_err(),
+            "incomplete bindings must revoke static state"
+        );
+
+        let (result, output) = relay_frame_after_live_state_change(&state, fallback.as_ref()).await;
+        assert!(
+            result.is_err(),
+            "invalid-refresh placeholder must close the relay"
+        );
+        assert!(
+            output.is_empty(),
+            "invalid-refresh credential must not reach upstream"
+        );
     }
 
     async fn run_client_to_server_with_graphql_policy(

--- a/crates/openshell-supervisor-network/src/l7/websocket.rs
+++ b/crates/openshell-supervisor-network/src/l7/websocket.rs
@@ -18,6 +18,7 @@ use openshell_ocsf::{
     NetworkActivityBuilder, SeverityId, StatusId, ocsf_emit,
 };
 use std::collections::HashMap;
+use std::future::Future;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 const MAX_TEXT_MESSAGE_BYTES: usize = 1024 * 1024;
@@ -545,6 +546,36 @@ async fn relay_text_payload<W: AsyncWrite + Unpin>(
     port: u16,
     options: &RelayOptions<'_>,
 ) -> Result<()> {
+    relay_text_payload_with_before_credential_write(
+        writer,
+        frame,
+        payload,
+        force_reframe,
+        compressed,
+        host,
+        port,
+        options,
+        std::future::ready(()),
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn relay_text_payload_with_before_credential_write<W, F>(
+    writer: &mut W,
+    frame: &FrameHeader,
+    payload: Vec<u8>,
+    force_reframe: bool,
+    compressed: bool,
+    host: &str,
+    port: u16,
+    options: &RelayOptions<'_>,
+    before_credential_write: F,
+) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+    F: Future<Output = ()>,
+{
     let message_payload = if compressed {
         decompress_permessage_deflate(&payload)?
     } else {
@@ -552,12 +583,17 @@ async fn relay_text_payload<W: AsyncWrite + Unpin>(
     };
     let mut text = String::from_utf8(message_payload)
         .map_err(|_| miette!("websocket text message is not valid UTF-8"))?;
-    let live_resolver = options
-        .provider_credentials
-        .map(|credentials| credentials.resolver_for_endpoint(host, port, options.target));
+    let live_resolver = options.provider_credentials.map(|credentials| {
+        let (resolver, revision) =
+            credentials.resolver_for_endpoint_with_revision(host, port, options.target);
+        (
+            resolver,
+            crate::l7::rest::CredentialGenerationGuard::new(credentials, revision),
+        )
+    });
     let resolver = live_resolver
         .as_ref()
-        .map_or(options.resolver, |resolver| resolver.as_deref());
+        .map_or(options.resolver, |(resolver, _)| resolver.as_deref());
     let replacements = if let Some(resolver) = resolver {
         resolver
             .rewrite_websocket_text_placeholders(&mut text)
@@ -598,11 +634,19 @@ async fn relay_text_payload<W: AsyncWrite + Unpin>(
     if replacements > 0 {
         emit_rewrite_event(host, port, options.policy_name, replacements);
     }
-    if compressed {
-        let compressed_payload = compress_permessage_deflate(text.as_bytes())?;
-        return write_masked_frame_with_rsv(writer, OPCODE_TEXT, 0x40, &compressed_payload).await;
+    let (rsv, frame_payload) = if compressed {
+        (0x40, compress_permessage_deflate(text.as_bytes())?)
+    } else {
+        (0, text.into_bytes())
+    };
+    let rewritten_frame = masked_frame_bytes(OPCODE_TEXT, rsv, &frame_payload);
+    if replacements > 0 {
+        before_credential_write.await;
+        if let Some((_, guard)) = live_resolver {
+            guard.ensure_current()?;
+        }
     }
-    write_masked_frame(writer, OPCODE_TEXT, text.as_bytes()).await
+    write_frame_bytes(writer, &rewritten_frame).await
 }
 
 fn inspect_websocket_text_message(
@@ -889,20 +933,7 @@ where
     Ok(())
 }
 
-async fn write_masked_frame<W: AsyncWrite + Unpin>(
-    writer: &mut W,
-    opcode: u8,
-    payload: &[u8],
-) -> Result<()> {
-    write_masked_frame_with_rsv(writer, opcode, 0, payload).await
-}
-
-async fn write_masked_frame_with_rsv<W: AsyncWrite + Unpin>(
-    writer: &mut W,
-    opcode: u8,
-    rsv: u8,
-    payload: &[u8],
-) -> Result<()> {
+fn masked_frame_bytes(opcode: u8, rsv: u8, payload: &[u8]) -> Vec<u8> {
     let mut header = Vec::with_capacity(14);
     header.push(0x80 | rsv | opcode);
     match payload.len() {
@@ -925,8 +956,12 @@ async fn write_masked_frame_with_rsv<W: AsyncWrite + Unpin>(
 
     let mut masked = payload.to_vec();
     apply_mask(&mut masked, mask_key);
-    writer.write_all(&header).await.into_diagnostic()?;
-    writer.write_all(&masked).await.into_diagnostic()?;
+    header.extend_from_slice(&masked);
+    header
+}
+
+async fn write_frame_bytes<W: AsyncWrite + Unpin>(writer: &mut W, frame: &[u8]) -> Result<()> {
+    writer.write_all(frame).await.into_diagnostic()?;
     writer.flush().await.into_diagnostic()?;
     Ok(())
 }
@@ -1418,6 +1453,69 @@ network_policies:
         assert!(
             output.is_empty(),
             "invalid-refresh credential must not reach upstream"
+        );
+    }
+
+    #[tokio::test]
+    async fn websocket_rewrite_rejects_revocation_before_frame_write() {
+        let state = bound_websocket_provider_state();
+        let fallback = state.resolver().expect("upgrade-time resolver");
+        let placeholder = b"openshell:resolve:env:v1_DISCORD_BOT_TOKEN";
+        let compressed = compress_permessage_deflate(placeholder).expect("compress placeholder");
+        let frame = FrameHeader {
+            fin: true,
+            rsv: 0x40,
+            opcode: OPCODE_TEXT,
+            masked: true,
+            payload_len: compressed.len() as u64,
+            mask_key: Some([0x37, 0xfa, 0x21, 0x3d]),
+            raw_header: Vec::new(),
+        };
+        let options = RelayOptions {
+            policy_name: "test-policy",
+            resolver: Some(fallback.as_ref()),
+            provider_credentials: Some(&state),
+            target: "/socket",
+            inspector: None,
+            compression: WebSocketCompression::PermessageDeflate,
+        };
+        let reached_write = tokio::sync::Barrier::new(2);
+        let release_write = tokio::sync::Barrier::new(2);
+        let (mut relay_write, mut upstream_read) = tokio::io::duplex(4096);
+
+        let relay = relay_text_payload_with_before_credential_write(
+            &mut relay_write,
+            &frame,
+            compressed,
+            false,
+            true,
+            "gateway.example.test",
+            443,
+            &options,
+            async {
+                reached_write.wait().await;
+                release_write.wait().await;
+            },
+        );
+        let revoke = async {
+            reached_write.wait().await;
+            state.revoke_static_provider_environment(2);
+            release_write.wait().await;
+        };
+        let (result, ()) = tokio::join!(relay, revoke);
+        assert!(
+            result
+                .as_ref()
+                .is_err_and(|error| error.to_string().contains("generation changed")),
+            "revoked credential generation must fail before the frame write: {result:?}"
+        );
+
+        drop(relay_write);
+        let mut output = Vec::new();
+        upstream_read.read_to_end(&mut output).await.unwrap();
+        assert!(
+            output.is_empty(),
+            "credential revoked before the write guard must not reach upstream"
         );
     }
 

--- a/crates/openshell-supervisor-network/src/l7/websocket.rs
+++ b/crates/openshell-supervisor-network/src/l7/websocket.rs
@@ -1100,7 +1100,10 @@ fn emit_websocket_l7_event(
             SeverityId::Informational,
         ),
     };
-    let summary = graphql.map(graphql_log_summary).unwrap_or_default();
+    let summary = graphql
+        .map(crate::l7::graphql::log_summary)
+        .map(|summary| format!(" {summary}"))
+        .unwrap_or_default();
     let event = NetworkActivityBuilder::new(openshell_ocsf::ctx::ctx())
         .activity(ActivityId::Other)
         .action(action_id)
@@ -1115,34 +1118,6 @@ fn emit_websocket_l7_event(
         ))
         .build();
     ocsf_emit!(event);
-}
-
-fn graphql_log_summary(info: &crate::l7::graphql::GraphqlRequestInfo) -> String {
-    if let Some(error) = info.error.as_deref() {
-        return format!(" graphql_error={error:?}");
-    }
-    let ops: Vec<String> = info
-        .operations
-        .iter()
-        .map(|op| {
-            let name = op.operation_name.as_deref().unwrap_or("-");
-            let fields = if op.fields.is_empty() {
-                "-".to_string()
-            } else {
-                op.fields.join(",")
-            };
-            let persisted = op
-                .persisted_query_hash
-                .as_deref()
-                .or(op.persisted_query_id.as_deref())
-                .unwrap_or("-");
-            format!(
-                "type={} name={} fields={} persisted={}",
-                op.operation_type, name, fields, persisted
-            )
-        })
-        .collect();
-    format!(" graphql_ops={}", ops.join(";"))
 }
 
 fn protocol_failure_class(error: &miette::Report) -> &'static str {
@@ -1772,7 +1747,7 @@ network_policies:
                 panic!("expected operation, got {other:?}")
             }
         };
-        let summary = graphql_log_summary(&graphql);
+        let summary = crate::l7::graphql::log_summary(&graphql);
 
         assert!(summary.contains("type=query"));
         assert!(summary.contains("fields=viewer"));

--- a/crates/openshell-supervisor-network/src/policy_local.rs
+++ b/crates/openshell-supervisor-network/src/policy_local.rs
@@ -1179,6 +1179,8 @@ fn network_endpoint_from_json(
         credential_signing: String::new(),
         signing_service: String::new(),
         signing_region: String::new(),
+        // policy.local proposals cannot reference a concrete sandbox provider.
+        credential_binding: None,
     })
 }
 

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -23,9 +23,8 @@ use openshell_core::policy::ProxyPolicy;
 use openshell_core::provider_credentials::ProviderCredentialState;
 use openshell_core::secrets::{self, SecretResolver, rewrite_header_line_checked};
 use openshell_ocsf::{
-    ActionId, ActivityId, DetectionFindingBuilder, DispositionId, Endpoint, FindingInfo,
-    HttpActivityBuilder, HttpRequest, NetworkActivityBuilder, Process, SeverityId, StatusId,
-    Url as OcsfUrl, ocsf_emit,
+    ActionId, ActivityId, DispositionId, Endpoint, HttpActivityBuilder, HttpRequest,
+    NetworkActivityBuilder, Process, SeverityId, StatusId, Url as OcsfUrl, ocsf_emit,
 };
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
@@ -78,23 +77,12 @@ fn emit_credential_endpoint_mismatch(host: &str, port: u16, policy_name: &str) {
         .status_detail("credential_endpoint_mismatch")
         .build();
     ocsf_emit!(event);
-    let finding = DetectionFindingBuilder::new(openshell_ocsf::ctx::ctx())
-        .activity(ActivityId::Open)
-        .action(ActionId::Denied)
-        .disposition(DispositionId::Blocked)
-        .severity(SeverityId::High)
-        .is_alert(true)
-        .finding_info(FindingInfo::new(
-            "openshell.provider_credential.endpoint_mismatch",
-            "Provider credential used at an unauthorized endpoint",
-        ))
-        .evidence_pairs(&[
-            ("policy", policy_name),
-            ("host", host),
-            ("disposition", "denied"),
-        ])
-        .message("Provider credential endpoint binding mismatch; request denied")
-        .build();
+    let finding = crate::l7::build_credential_endpoint_mismatch_finding(
+        policy_name,
+        host,
+        None,
+        "Provider credential endpoint binding mismatch; request denied",
+    );
     ocsf_emit!(finding);
 }
 

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -3646,18 +3646,11 @@ fn endpoint_credentials_for_request(
             revision: None,
         };
     };
-    let revision_before = credentials.revision();
-    let resolver = credentials.resolver_for_endpoint(host, port, canonical_path);
-    let revision_after = credentials.revision();
-    if revision_before != revision_after {
-        return ForwardEndpointCredentials {
-            resolver: None,
-            revision: None,
-        };
-    }
+    let (resolver, revision) =
+        credentials.resolver_for_endpoint_with_revision(host, port, canonical_path);
     ForwardEndpointCredentials {
         resolver,
-        revision: Some(revision_before),
+        revision: Some(revision),
     }
 }
 
@@ -8824,6 +8817,47 @@ network_policies:
         assert_eq!(malformed, "/[INVALID_REQUEST_TARGET]");
         assert!(!malformed.contains("API_TOKEN"));
         assert!(!malformed.contains("real-secret"));
+    }
+
+    #[test]
+    fn forward_credentials_capture_endpoint_resolver_and_revision_together() {
+        use openshell_core::proto::{StaticCredentialBinding, StaticCredentialEndpointBinding};
+
+        let state = ProviderCredentialState::from_bound_environment(
+            42,
+            TestHashMap::from([("API_TOKEN".to_string(), "secret".to_string())]),
+            TestHashMap::new(),
+            TestHashMap::new(),
+            TestHashMap::from([(
+                "API_TOKEN".to_string(),
+                StaticCredentialBinding {
+                    endpoints: vec![StaticCredentialEndpointBinding {
+                        host: "api.example.com".to_string(),
+                        port: 80,
+                        path: "/allowed/**".to_string(),
+                    }],
+                    credential_identity: "provider-a:API_TOKEN".to_string(),
+                },
+            )]),
+            Vec::new(),
+        )
+        .expect("bound provider state");
+
+        let credentials = endpoint_credentials_for_request(
+            Some(&state),
+            None,
+            "api.example.com",
+            80,
+            "/allowed/v1",
+        );
+        assert_eq!(credentials.revision, Some(42));
+        assert_eq!(
+            credentials
+                .resolver
+                .expect("endpoint resolver")
+                .resolve_placeholder("openshell:resolve:env:v42_API_TOKEN"),
+            Some("secret")
+        );
     }
 
     #[test]

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -1553,7 +1553,7 @@ async fn handle_tcp_connection(
     // gate needs it) and drives the raw-tunnel branch below.
 
     // Build request-processing context shared by CONNECT and forward HTTP.
-    let ctx = relay::http_context(
+    let mut ctx = relay::http_context(
         &decision,
         provider_credentials,
         secret_resolver.clone(),
@@ -1613,6 +1613,7 @@ async fn handle_tcp_connection(
     if tunnel_protocol == TunnelProtocol::Tls {
         // TLS detected — terminate unconditionally.
         if let Some(ref tls) = tls_state {
+            ctx.request_default_port = Some(443);
             let tls_result = async {
                 let mut tls_client =
                     crate::l7::tls::tls_terminate_client(client, tls, &host_lc).await?;
@@ -1692,6 +1693,7 @@ async fn handle_tcp_connection(
         }
     } else if tunnel_protocol == TunnelProtocol::Http1 {
         // Plaintext HTTP detected.
+        ctx.request_default_port = Some(80);
         let is_l7_relay = l7_route.is_some_and(|route| !route.configs.is_empty());
         let Some(relay_context) = relay::prepare_http_relay(l7_route, &opa_engine, &decision, &ctx)
         else {
@@ -4340,7 +4342,7 @@ async fn handle_forward_proxy(
             crate::l7::rest::parse_query_params(query).unwrap_or_default()
         });
     let secret_resolver = prepared_target.secret_resolver;
-    let l7_ctx = relay::http_context(
+    let mut l7_ctx = relay::http_context(
         &decision,
         provider_credentials,
         secret_resolver.clone(),
@@ -4348,6 +4350,11 @@ async fn handle_forward_proxy(
         dynamic_credentials.clone(),
         agent_proposals,
     );
+    l7_ctx.request_default_port = match scheme.as_str() {
+        "http" => Some(80),
+        "https" => Some(443),
+        _ => None,
+    };
     if let Some(route) = decision
         .endpoint
         .l7_route

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -911,6 +911,15 @@ fn build_forward_allow_ocsf_event(
         .build()
 }
 
+fn build_forward_parse_error_ocsf_event(path: &str) -> openshell_ocsf::OcsfEvent {
+    HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
+        .activity(ActivityId::Fail)
+        .severity(SeverityId::Low)
+        .status(StatusId::Failure)
+        .message(format!("FORWARD parse error for {path}"))
+        .build()
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_forward_policy_deny_ocsf_event(
     peer_addr: SocketAddr,
@@ -3584,6 +3593,71 @@ fn parse_proxy_uri(uri: &str) -> Result<(String, String, u16, String)> {
     Ok((scheme, host, port, path.to_string()))
 }
 
+/// Return a query-free, credential-redacted path suitable for forward-proxy
+/// telemetry. Malformed targets are represented by a fixed sentinel so parse
+/// errors cannot expose query strings or credential environment-key names.
+fn forward_telemetry_path(target_uri: &str) -> String {
+    let Ok((_, _, _, target)) = parse_proxy_uri(target_uri) else {
+        return "/[INVALID_REQUEST_TARGET]".to_string();
+    };
+    let path = target
+        .split_once('?')
+        .map_or(target.as_str(), |(path, _)| path);
+    secrets::redact_target_for_policy(path)
+        .unwrap_or_else(|_| "/[INVALID_REQUEST_TARGET]".to_string())
+}
+
+fn endpoint_secret_resolver(
+    provider_credentials: Option<&ProviderCredentialState>,
+    fallback: Option<Arc<SecretResolver>>,
+    host: &str,
+    port: u16,
+    canonical_path: &str,
+) -> Option<Arc<SecretResolver>> {
+    provider_credentials.map_or(fallback, |credentials| {
+        credentials.resolver_for_endpoint(host, port, canonical_path)
+    })
+}
+
+struct PreparedForwardTarget {
+    canonical_path: String,
+    raw_query: Option<String>,
+    upstream_target: String,
+    telemetry_path: String,
+    secret_resolver: Option<Arc<SecretResolver>>,
+}
+
+fn prepare_forward_target(
+    target: &str,
+    canonicalize_options: crate::l7::path::CanonicalizeOptions,
+    provider_credentials: Option<&ProviderCredentialState>,
+    fallback: Option<Arc<SecretResolver>>,
+    host: &str,
+    port: u16,
+) -> Result<PreparedForwardTarget, crate::l7::path::CanonicalizeError> {
+    let (canonical, raw_query) =
+        crate::l7::path::canonicalize_request_target(target, &canonicalize_options)?;
+    let telemetry_path = secrets::redact_target_for_policy(&canonical.path)
+        .unwrap_or_else(|_| "/[INVALID_REQUEST_TARGET]".to_string());
+    let upstream_target = raw_query
+        .as_deref()
+        .filter(|query| !query.is_empty())
+        .map_or_else(
+            || canonical.path.clone(),
+            |query| format!("{}?{query}", canonical.path),
+        );
+    let secret_resolver =
+        endpoint_secret_resolver(provider_credentials, fallback, host, port, &canonical.path);
+
+    Ok(PreparedForwardTarget {
+        canonical_path: canonical.path,
+        raw_query,
+        upstream_target,
+        telemetry_path,
+        secret_resolver,
+    })
+}
+
 /// Build the HTTP/1.1 `Host` value for a plain-HTTP absolute-form target.
 ///
 /// Forward proxy requests are restricted to `http`, so port 80 is omitted as
@@ -3860,6 +3934,11 @@ struct ForwardRelayOptions<'a> {
     websocket_extensions: crate::l7::rest::WebSocketExtensionMode,
     secret_resolver: Option<&'a SecretResolver>,
     request_body_credential_rewrite: bool,
+    credential_signing: crate::l7::CredentialSigning,
+    signing_service: &'a str,
+    signing_region: &'a str,
+    host: &'a str,
+    port: u16,
 }
 
 async fn relay_rewritten_forward_request<C, U>(
@@ -3898,11 +3977,11 @@ where
             generation_guard: Some(options.generation_guard),
             websocket_extensions: options.websocket_extensions,
             request_body_credential_rewrite: options.request_body_credential_rewrite,
-            credential_signing: crate::l7::CredentialSigning::None,
-            signing_service: "",
-            signing_region: "",
-            host: "",
-            port: 0,
+            credential_signing: options.credential_signing,
+            signing_service: options.signing_service,
+            signing_region: options.signing_region,
+            host: options.host,
+            port: options.port,
         },
     )
     .await
@@ -3968,29 +4047,16 @@ async fn handle_forward_proxy(
     denial_tx: Option<&mpsc::UnboundedSender<DenialEvent>>,
     activity_tx: Option<&ActivitySender>,
 ) -> Result<()> {
-    // 1. Parse the absolute-form URI. `path` is marked `mut` so that, when an
-    //    L7 config applies, the canonicalized form produced below replaces it
-    //    in-place — keeping OPA evaluation and the bytes written onto the wire
-    //    in sync. See the L7 block below.
-    let (scheme, host, port, mut path) = match parse_proxy_uri(target_uri) {
-        Ok(parsed) => parsed,
-        Err(e) => {
-            let event = HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
-                .activity(ActivityId::Fail)
-                .severity(SeverityId::Low)
-                .status(StatusId::Failure)
-                .message(format!("FORWARD parse error for {target_uri}: {e}"))
-                .build();
-            ocsf_emit!(event);
-            respond(client, b"HTTP/1.1 400 Bad Request\r\n\r\n").await?;
-            return Ok(());
-        }
+    let mut telemetry_path = forward_telemetry_path(target_uri);
+    // 1. Parse the absolute-form URI. Every external forward target is
+    // canonicalized below before credential binding, policy-path evaluation,
+    // upstream bytes, or telemetry consume it.
+    let Ok((scheme, host, port, mut path)) = parse_proxy_uri(target_uri) else {
+        ocsf_emit!(build_forward_parse_error_ocsf_event(&telemetry_path));
+        respond(client, b"HTTP/1.1 400 Bad Request\r\n\r\n").await?;
+        return Ok(());
     };
     let host_lc = host.to_ascii_lowercase();
-    let secret_resolver = provider_credentials
-        .as_ref()
-        .and_then(|credentials| credentials.resolver_for_endpoint(&host_lc, port, &path))
-        .or(secret_resolver);
 
     if host_lc == POLICY_LOCAL_HOST {
         if scheme != "http" || port != 80 {
@@ -4121,7 +4187,7 @@ async fn handle_forward_proxy(
                 method,
                 &host_lc,
                 port,
-                &path,
+                &telemetry_path,
                 &binary_str,
                 &pid_str,
                 &ancestors_str,
@@ -4144,7 +4210,7 @@ async fn handle_forward_proxy(
                     403,
                     "Forbidden",
                     "policy_denied",
-                    &format!("{method} {host_lc}:{port}{path} not permitted by policy"),
+                    &format!("{method} {host_lc}:{port}{telemetry_path} not permitted by policy"),
                 ),
             )
             .await?;
@@ -4186,14 +4252,13 @@ async fn handle_forward_proxy(
                     403,
                     "Forbidden",
                     "policy_denied",
-                    &format!("{method} {host_lc}:{port}{path} not permitted by policy"),
+                    &format!("{method} {host_lc}:{port}{telemetry_path} not permitted by policy"),
                 ),
             )
             .await?;
             return Ok(());
         }
     };
-    let mut upstream_target = path.clone();
     let mut websocket_extensions = crate::l7::rest::WebSocketExtensionMode::Preserve;
     let mut forward_tunnel_engine: Option<crate::opa::TunnelPolicyEngine> = None;
     // L7 endpoint config and evaluated request info, carried past the L7
@@ -4207,14 +4272,6 @@ async fn handle_forward_proxy(
     let mut forward_websocket_request =
         crate::l7::rest::request_is_websocket_upgrade(&forward_request_bytes);
     let mut request_body_credential_rewrite = false;
-    let l7_ctx = relay::http_context(
-        &decision,
-        provider_credentials,
-        secret_resolver.clone(),
-        activity_tx.cloned(),
-        dynamic_credentials.clone(),
-        agent_proposals,
-    );
     let mut l7_activity_pending = false;
 
     // 4b. If the endpoint has L7 config, evaluate the request against
@@ -4223,6 +4280,67 @@ async fn handle_forward_proxy(
     //     strips hop-by-hop `Connection` headers and drops the upstream after
     //     the response instead of asking the upstream to close it.
     hydrate_l7_route(&opa_engine, &mut decision);
+    let canonicalize_options = crate::l7::path::CanonicalizeOptions {
+        allow_encoded_slash: decision.endpoint.l7_route.as_ref().is_some_and(|route| {
+            route
+                .configs
+                .iter()
+                .any(|snapshot| snapshot.config.allow_encoded_slash)
+        }),
+        ..Default::default()
+    };
+    let prepared_target = match prepare_forward_target(
+        &path,
+        canonicalize_options,
+        provider_credentials.as_ref(),
+        secret_resolver,
+        &host_lc,
+        port,
+    ) {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            let event = NetworkActivityBuilder::new(openshell_ocsf::ctx::ctx())
+                .activity(ActivityId::Fail)
+                .severity(SeverityId::Medium)
+                .status(StatusId::Failure)
+                .dst_endpoint(Endpoint::from_domain(&host_lc, port))
+                .message(format!(
+                    "FORWARD rejecting non-canonical request-target: {error}"
+                ))
+                .build();
+            ocsf_emit!(event);
+            emit_activity_simple(activity_tx, true, "forward_parse_rejection");
+            respond(
+                client,
+                &build_json_error_response(
+                    400,
+                    "Bad Request",
+                    "invalid_request_target",
+                    "request-target must be canonical",
+                ),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+    path = prepared_target.canonical_path;
+    telemetry_path = prepared_target.telemetry_path;
+    let upstream_target = prepared_target.upstream_target;
+    let query_params = prepared_target
+        .raw_query
+        .as_deref()
+        .map_or_else(std::collections::HashMap::new, |query| {
+            crate::l7::rest::parse_query_params(query).unwrap_or_default()
+        });
+    let secret_resolver = prepared_target.secret_resolver;
+    let l7_ctx = relay::http_context(
+        &decision,
+        provider_credentials,
+        secret_resolver.clone(),
+        activity_tx.cloned(),
+        dynamic_credentials.clone(),
+        agent_proposals,
+    );
     if let Some(route) = decision
         .endpoint
         .l7_route
@@ -4255,7 +4373,7 @@ async fn handle_forward_proxy(
                     403,
                     "Forbidden",
                     "policy_denied",
-                    &format!("{method} {host_lc}:{port}{path} not permitted by policy"),
+                    &format!("{method} {host_lc}:{port}{telemetry_path} not permitted by policy"),
                 ),
             )
             .await?;
@@ -4280,7 +4398,9 @@ async fn handle_forward_proxy(
                         403,
                         "Forbidden",
                         "policy_denied",
-                        &format!("{method} {host_lc}:{port}{path} not permitted by policy"),
+                        &format!(
+                            "{method} {host_lc}:{port}{telemetry_path} not permitted by policy"
+                        ),
                     ),
                 )
                 .await?;
@@ -4288,62 +4408,6 @@ async fn handle_forward_proxy(
             }
         };
 
-        // Canonicalize the request-target. The canonical form is fed to OPA
-        // AND reassigned to the outer `path` variable so the later call to
-        // `rewrite_forward_request` writes canonical bytes to the upstream.
-        // This closes the policy/upstream parser-differential at this site;
-        // without this reassignment, OPA would evaluate the canonical form
-        // while the upstream re-normalizes the raw input and dispatches on a
-        // potentially different path.
-        let canonicalize_options = crate::l7::path::CanonicalizeOptions {
-            allow_encoded_slash: route
-                .configs
-                .iter()
-                .any(|snapshot| snapshot.config.allow_encoded_slash),
-            ..Default::default()
-        };
-        let query_params =
-            match crate::l7::path::canonicalize_request_target(&path, &canonicalize_options) {
-                Ok((canon, query)) => {
-                    upstream_target = match query.as_deref() {
-                        Some(raw_query) if !raw_query.is_empty() => {
-                            format!("{}?{raw_query}", canon.path)
-                        }
-                        _ => canon.path.clone(),
-                    };
-                    let params = query
-                        .as_deref()
-                        .map_or_else(std::collections::HashMap::new, |q| {
-                            crate::l7::rest::parse_query_params(q).unwrap_or_default()
-                        });
-                    path = canon.path;
-                    params
-                }
-                Err(e) => {
-                    let event = NetworkActivityBuilder::new(openshell_ocsf::ctx::ctx())
-                        .activity(ActivityId::Fail)
-                        .severity(SeverityId::Medium)
-                        .status(StatusId::Failure)
-                        .dst_endpoint(Endpoint::from_domain(&host_lc, port))
-                        .message(format!(
-                            "FORWARD_L7 rejecting non-canonical request-target: {e}"
-                        ))
-                        .build();
-                    ocsf_emit!(event);
-                    emit_activity_simple(activity_tx, true, "l7_parse_rejection");
-                    respond(
-                        client,
-                        &build_json_error_response(
-                            400,
-                            "Bad Request",
-                            "invalid_request_target",
-                            "request-target must be canonical",
-                        ),
-                    )
-                    .await?;
-                    return Ok(());
-                }
-            };
         let Ok(redacted_path) = secrets::redact_target_for_policy(&path) else {
             respond(
                 client,
@@ -4365,7 +4429,9 @@ async fn handle_forward_proxy(
                     403,
                     "Forbidden",
                     "policy_denied",
-                    &format!("{method} {host_lc}:{port}{path} did not match an L7 endpoint path"),
+                    &format!(
+                        "{method} {host_lc}:{port}{telemetry_path} did not match an L7 endpoint path"
+                    ),
                 ),
             )
             .await?;
@@ -4380,7 +4446,7 @@ async fn handle_forward_proxy(
                 .status(StatusId::Failure)
                 .http_request(HttpRequest::new(
                     method,
-                    OcsfUrl::new("http", &host_lc, &path, port),
+                    OcsfUrl::new("http", &host_lc, &telemetry_path, port),
                 ))
                 .dst_endpoint(Endpoint::from_domain(&host_lc, port))
                 .src_endpoint(Endpoint::from_ip(workload_addr.ip(), workload_addr.port()))
@@ -4390,7 +4456,7 @@ async fn handle_forward_proxy(
                 )
                 .firewall_rule(policy_str, "l7")
                 .message(format!(
-                    "FORWARD_L7 denied unsupported h2c upgrade for {method} {host_lc}:{port}{path}"
+                    "FORWARD_L7 denied unsupported h2c upgrade for {method} {host_lc}:{port}{telemetry_path}"
                 ))
                 .status_detail(crate::l7::rest::UNSUPPORTED_H2C_UPGRADE_DETAIL)
                 .build();
@@ -4600,11 +4666,11 @@ async fn handle_forward_proxy(
                             "FORWARD_L7"
                         };
                     format!(
-                        "{message_prefix} {decision_str} {method} {host_lc}:{port}{path} reason={reason}"
+                        "{message_prefix} {decision_str} {method} {host_lc}:{port}{telemetry_path} reason={reason}"
                     )
                 },
                 |jsonrpc_info| {
-                    let endpoint = format!("{host_lc}:{port}{path}");
+                    let endpoint = format!("{host_lc}:{port}{telemetry_path}");
                     crate::l7::relay::jsonrpc_log_message(
                         decision_str,
                         method,
@@ -4622,7 +4688,7 @@ async fn handle_forward_proxy(
                 .severity(severity)
                 .http_request(HttpRequest::new(
                     method,
-                    OcsfUrl::new("http", &host_lc, &path, port),
+                    OcsfUrl::new("http", &host_lc, &telemetry_path, port),
                 ))
                 .dst_endpoint(Endpoint::from_domain(&host_lc, port))
                 .src_endpoint(Endpoint::from_ip(workload_addr.ip(), workload_addr.port()))
@@ -4656,7 +4722,9 @@ async fn handle_forward_proxy(
                     403,
                     "Forbidden",
                     "policy_denied",
-                    &format!("{method} {host_lc}:{port}{path} denied by L7 policy: {reason}"),
+                    &format!(
+                        "{method} {host_lc}:{port}{telemetry_path} denied by L7 policy: {reason}"
+                    ),
                 ),
             )
             .await?;
@@ -4687,7 +4755,7 @@ async fn handle_forward_proxy(
                 method,
                 &host_lc,
                 port,
-                &path,
+                &telemetry_path,
                 &binary_str,
                 &pid_str,
                 &ancestors_str,
@@ -4724,7 +4792,7 @@ async fn handle_forward_proxy(
                 method,
                 &host_lc,
                 port,
-                &path,
+                &telemetry_path,
                 &binary_str,
                 &pid_str,
                 &ancestors_str,
@@ -4756,7 +4824,7 @@ async fn handle_forward_proxy(
                 403,
                 "Forbidden",
                 "policy_denied",
-                &format!("{method} {host_lc}:{port}{path} not permitted by policy"),
+                &format!("{method} {host_lc}:{port}{telemetry_path} not permitted by policy"),
             ),
         )
         .await?;
@@ -4776,7 +4844,7 @@ async fn handle_forward_proxy(
                 .status(StatusId::Failure)
                 .http_request(HttpRequest::new(
                     method,
-                    OcsfUrl::new("http", &host_lc, &path, port),
+                    OcsfUrl::new("http", &host_lc, &telemetry_path, port),
                 ))
                 .dst_endpoint(Endpoint::from_domain(&host_lc, port))
                 .src_endpoint(Endpoint::from_ip(workload_addr.ip(), workload_addr.port()))
@@ -4830,7 +4898,7 @@ async fn handle_forward_proxy(
                 403,
                 "Forbidden",
                 "policy_denied",
-                &format!("{method} {host_lc}:{port}{path} not permitted by policy"),
+                &format!("{method} {host_lc}:{port}{telemetry_path} not permitted by policy"),
             ),
         )
         .await?;
@@ -4963,15 +5031,26 @@ async fn handle_forward_proxy(
                 403,
                 "Forbidden",
                 "policy_denied",
-                &format!("{method} {host_lc}:{port}{path} not permitted by policy"),
+                &format!("{method} {host_lc}:{port}{telemetry_path} not permitted by policy"),
             ),
         )
         .await?;
         return Ok(());
     }
-    let outcome = relay_rewritten_forward_request(
+    let credential_signing = forward_upgrade_config
+        .as_ref()
+        .map_or(crate::l7::CredentialSigning::None, |config| {
+            config.credential_signing
+        });
+    let signing_service = forward_upgrade_config
+        .as_ref()
+        .map_or("", |config| config.signing_service.as_str());
+    let signing_region = forward_upgrade_config
+        .as_ref()
+        .map_or("", |config| config.signing_region.as_str());
+    let outcome = match relay_rewritten_forward_request(
         method,
-        &path,
+        &upstream_target,
         rewritten,
         client,
         &mut upstream,
@@ -4980,9 +5059,24 @@ async fn handle_forward_proxy(
             websocket_extensions,
             secret_resolver: secret_resolver.as_deref(),
             request_body_credential_rewrite,
+            credential_signing,
+            signing_service,
+            signing_region,
+            host: &host_lc,
+            port,
         },
     )
-    .await?;
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(report) => {
+            if let Some(error) = report.downcast_ref::<secrets::UnresolvedPlaceholderError>() {
+                crate::l7::relay::reject_credential_resolution(client, &l7_ctx, error).await?;
+                return Ok(());
+            }
+            return Err(report);
+        }
+    };
 
     // The request has now survived middleware, token grant, credential
     // rewriting, generation checks, and the HTTP relay. Only now record the
@@ -4992,7 +5086,7 @@ async fn handle_forward_proxy(
         method,
         &host_lc,
         port,
-        &path,
+        &telemetry_path,
         &binary_str,
         &pid_str,
         &ancestors_str,
@@ -5245,6 +5339,7 @@ fn is_benign_relay_error(err: &miette::Report) -> bool {
 mod tests {
     use super::*;
     use openshell_core::proposals::AgentProposals;
+    use std::collections::HashMap as TestHashMap;
     use std::future::Future;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
     use std::sync::Arc;
@@ -5437,6 +5532,64 @@ network_policies: {}
         assert_eq!(json["status_detail"], reason);
         assert_eq!(json["action"], "Denied");
         assert_eq!(json["disposition"], "Blocked");
+    }
+
+    #[test]
+    fn forward_ocsf_events_omit_queries_and_credential_key_names() {
+        let peer = "127.0.0.1:45123".parse().unwrap();
+        let path = forward_telemetry_path(
+            "http://api.example.com/v1/openshell:resolve:env:API_TOKEN?token=real-secret",
+        );
+        assert_eq!(path, "/v1/[CREDENTIAL]");
+
+        let allowed = build_forward_allow_ocsf_event(
+            peer,
+            "GET",
+            "api.example.com",
+            80,
+            &path,
+            "/usr/bin/curl",
+            "42",
+            "/usr/bin/bash",
+            "curl",
+            "allow_api",
+        )
+        .to_json()
+        .unwrap();
+        let denied = build_forward_policy_deny_ocsf_event(
+            peer,
+            "GET",
+            "api.example.com",
+            80,
+            &path,
+            "/usr/bin/curl",
+            "42",
+            "/usr/bin/bash",
+            "curl",
+            "policy denied",
+        )
+        .to_json()
+        .unwrap();
+        for event in [&allowed, &denied] {
+            assert_eq!(event["http_request"]["url"]["path"], "/v1/[CREDENTIAL]");
+            let serialized = event.to_string();
+            assert!(!serialized.contains("API_TOKEN"), "{serialized}");
+            assert!(!serialized.contains("real-secret"), "{serialized}");
+            assert!(!serialized.contains("?token="), "{serialized}");
+        }
+
+        let malformed = build_forward_parse_error_ocsf_event(&forward_telemetry_path(
+            "not-a-uri?token=real-secret&key=openshell:resolve:env:API_TOKEN",
+        ))
+        .to_json()
+        .unwrap();
+        assert_eq!(
+            malformed["message"],
+            "FORWARD parse error for /[INVALID_REQUEST_TARGET]"
+        );
+        let serialized = malformed.to_string();
+        assert!(!serialized.contains("API_TOKEN"), "{serialized}");
+        assert!(!serialized.contains("real-secret"), "{serialized}");
     }
 
     #[test]
@@ -6009,6 +6162,11 @@ network_policies:
                 websocket_extensions: crate::l7::rest::WebSocketExtensionMode::Preserve,
                 secret_resolver: resolver,
                 request_body_credential_rewrite,
+                credential_signing: crate::l7::CredentialSigning::None,
+                signing_service: "",
+                signing_region: "",
+                host: "",
+                port: 0,
             },
         )
         .await?;
@@ -6193,6 +6351,11 @@ network_policies:
                     websocket_extensions,
                     secret_resolver: None,
                     request_body_credential_rewrite: false,
+                    credential_signing: crate::l7::CredentialSigning::None,
+                    signing_service: "",
+                    signing_region: "",
+                    host: "",
+                    port: 0,
                 },
             )
             .await?;
@@ -8373,6 +8536,105 @@ network_policies:
     }
 
     #[test]
+    fn forward_telemetry_path_omits_queries_and_redacts_credential_syntax() {
+        let target = "http://host:80/v1/openshell:resolve:env:API_TOKEN?token=real-secret";
+        let redacted = forward_telemetry_path(target);
+        assert_eq!(redacted, "/v1/[CREDENTIAL]");
+        assert!(!redacted.contains("API_TOKEN"));
+        assert!(!redacted.contains("real-secret"));
+
+        let malformed = forward_telemetry_path(
+            "not-a-uri?token=real-secret&key=openshell:resolve:env:API_TOKEN",
+        );
+        assert_eq!(malformed, "/[INVALID_REQUEST_TARGET]");
+        assert!(!malformed.contains("API_TOKEN"));
+        assert!(!malformed.contains("real-secret"));
+    }
+
+    #[test]
+    fn forward_binding_uses_canonical_path_for_dot_segment_traversal() {
+        use openshell_core::proto::{StaticCredentialBinding, StaticCredentialEndpointBinding};
+
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            TestHashMap::from([("API_TOKEN".to_string(), "secret".to_string())]),
+            TestHashMap::new(),
+            TestHashMap::new(),
+            TestHashMap::from([(
+                "API_TOKEN".to_string(),
+                StaticCredentialBinding {
+                    endpoints: vec![StaticCredentialEndpointBinding {
+                        host: "api.example.com".to_string(),
+                        port: 80,
+                        path: "/allowed/**".to_string(),
+                    }],
+                    credential_identity: "provider-a:API_TOKEN".to_string(),
+                },
+            )]),
+            Vec::new(),
+        )
+        .expect("bound provider state");
+        let placeholder = "openshell:resolve:env:v1_API_TOKEN";
+
+        for raw_path in ["/allowed/../outside", "/allowed/%2e%2e/outside"] {
+            let prepared = prepare_forward_target(
+                raw_path,
+                crate::l7::path::CanonicalizeOptions::default(),
+                Some(&state),
+                state.resolver(),
+                "api.example.com",
+                80,
+            )
+            .expect("prepared target");
+            assert_eq!(prepared.canonical_path, "/outside");
+            let resolver = prepared.secret_resolver.expect("scoped resolver");
+            let error = resolver
+                .rewrite_header_value(placeholder)
+                .expect_err("canonical endpoint must deny traversal");
+            assert!(error.is_endpoint_mismatch());
+        }
+    }
+
+    #[test]
+    fn live_forward_state_is_authoritative_after_revocation() {
+        use openshell_core::proto::{StaticCredentialBinding, StaticCredentialEndpointBinding};
+
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            TestHashMap::from([("API_TOKEN".to_string(), "secret".to_string())]),
+            TestHashMap::new(),
+            TestHashMap::new(),
+            TestHashMap::from([(
+                "API_TOKEN".to_string(),
+                StaticCredentialBinding {
+                    endpoints: vec![StaticCredentialEndpointBinding {
+                        host: "api.example.com".to_string(),
+                        port: 80,
+                        path: "/**".to_string(),
+                    }],
+                    credential_identity: "provider-a:API_TOKEN".to_string(),
+                },
+            )]),
+            Vec::new(),
+        )
+        .expect("bound provider state");
+        let connection_open_resolver = state.resolver();
+        state.revoke_static_provider_environment(2);
+
+        assert!(
+            endpoint_secret_resolver(
+                Some(&state),
+                connection_open_resolver,
+                "api.example.com",
+                80,
+                "/v1",
+            )
+            .is_none(),
+            "live revocation must not fall back to the connection-open resolver"
+        );
+    }
+
+    #[test]
     fn test_parse_proxy_uri_ipv6() {
         let (_, host, port, path) = parse_proxy_uri("http://[::1]:8080/test").unwrap();
         assert_eq!(host, "::1");
@@ -9010,19 +9272,34 @@ network_policies:
     }
 
     #[tokio::test]
-    async fn forward_relay_unresolved_body_placeholder_fails_before_upstream_write() {
-        let (_, resolver) = SecretResolver::from_provider_env(
-            [("API_TOKEN".to_string(), "provider-real-token".to_string())]
-                .into_iter()
-                .collect(),
-        );
-        let resolver = resolver.expect("resolver");
-        let alias = "provider-OPENSHELL-RESOLVE-ENV-API_TOKEN";
-        let body = "token=provider-OPENSHELL-RESOLVE-ENV-MISSING_TOKEN";
+    async fn forward_relay_body_endpoint_mismatch_is_typed_before_upstream_write() {
+        use openshell_core::proto::{StaticCredentialBinding, StaticCredentialEndpointBinding};
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            TestHashMap::from([("API_TOKEN".to_string(), "provider-real-token".to_string())]),
+            TestHashMap::new(),
+            TestHashMap::new(),
+            TestHashMap::from([(
+                "API_TOKEN".to_string(),
+                StaticCredentialBinding {
+                    endpoints: vec![StaticCredentialEndpointBinding {
+                        host: "allowed.example.com".to_string(),
+                        port: 80,
+                        path: "/allowed/**".to_string(),
+                    }],
+                    credential_identity: "provider-a:API_TOKEN".to_string(),
+                },
+            )]),
+            Vec::new(),
+        )
+        .expect("bound provider state");
+        let resolver = state
+            .resolver_for_endpoint("api.example.com", 80, "/api/messages")
+            .expect("endpoint-scoped resolver");
+        let body = "token=openshell:resolve:env:v1_API_TOKEN";
         let raw = format!(
             "POST http://api.example.com/api/messages HTTP/1.1\r\n\
              Host: api.example.com\r\n\
-             Authorization: Bearer {alias}\r\n\
              Content-Type: application/x-www-form-urlencoded\r\n\
              Content-Length: {}\r\n\r\n{}",
             body.len(),
@@ -9052,19 +9329,104 @@ network_policies:
                 websocket_extensions: crate::l7::rest::WebSocketExtensionMode::Preserve,
                 secret_resolver: Some(&resolver),
                 request_body_credential_rewrite: true,
+                credential_signing: crate::l7::CredentialSigning::None,
+                signing_service: "",
+                signing_region: "",
+                host: "",
+                port: 0,
             },
         )
         .await
         .expect_err("unresolved body placeholder should fail closed");
 
+        let credential_error = err
+            .downcast_ref::<secrets::UnresolvedPlaceholderError>()
+            .expect("body mismatch must retain its typed error");
+        assert!(credential_error.is_endpoint_mismatch());
         assert!(!err.to_string().contains("provider-real-token"));
-        assert!(!err.to_string().contains("MISSING_TOKEN"));
+        assert!(!err.to_string().contains("API_TOKEN"));
         drop(proxy_to_upstream);
         let mut forwarded = Vec::new();
         upstream_side.read_to_end(&mut forwarded).await.unwrap();
         assert!(
             forwarded.is_empty(),
             "failed forward body rewrite must not reach upstream"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_relay_sigv4_endpoint_mismatch_is_typed_before_upstream_write() {
+        use openshell_core::proto::{StaticCredentialBinding, StaticCredentialEndpointBinding};
+        let values = TestHashMap::from([
+            ("AWS_ACCESS_KEY_ID".to_string(), "access".to_string()),
+            ("AWS_SECRET_ACCESS_KEY".to_string(), "secret".to_string()),
+            ("AWS_SESSION_TOKEN".to_string(), "session".to_string()),
+        ]);
+        let bindings = values
+            .keys()
+            .map(|key| {
+                (
+                    key.clone(),
+                    StaticCredentialBinding {
+                        endpoints: vec![StaticCredentialEndpointBinding {
+                            host: "allowed.example.com".to_string(),
+                            port: 80,
+                            path: "/allowed/**".to_string(),
+                        }],
+                        credential_identity: format!("provider-a:{key}"),
+                    },
+                )
+            })
+            .collect();
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            values,
+            TestHashMap::new(),
+            TestHashMap::new(),
+            bindings,
+            Vec::new(),
+        )
+        .expect("bound provider state");
+        let resolver = state
+            .resolver_for_endpoint("api.example.com", 80, "/api")
+            .expect("endpoint-scoped resolver");
+        let guard = forward_test_guard();
+        let rewritten =
+            b"GET /api HTTP/1.1\r\nHost: api.example.com\r\nContent-Length: 0\r\n\r\n".to_vec();
+        let (mut proxy_to_upstream, mut upstream_side) = tokio::io::duplex(8192);
+        let (mut _app_side, mut proxy_to_client) = tokio::io::duplex(8192);
+
+        let err = relay_rewritten_forward_request(
+            "GET",
+            "/api",
+            rewritten,
+            &mut proxy_to_client,
+            &mut proxy_to_upstream,
+            ForwardRelayOptions {
+                generation_guard: &guard,
+                websocket_extensions: crate::l7::rest::WebSocketExtensionMode::Preserve,
+                secret_resolver: Some(&resolver),
+                request_body_credential_rewrite: false,
+                credential_signing: crate::l7::CredentialSigning::SigV4NoBody,
+                signing_service: "execute-api",
+                signing_region: "us-west-2",
+                host: "api.example.com",
+                port: 80,
+            },
+        )
+        .await
+        .expect_err("SigV4 endpoint mismatch should fail closed");
+
+        let credential_error = err
+            .downcast_ref::<secrets::UnresolvedPlaceholderError>()
+            .expect("SigV4 mismatch must retain its typed error");
+        assert!(credential_error.is_endpoint_mismatch());
+        drop(proxy_to_upstream);
+        let mut forwarded = Vec::new();
+        upstream_side.read_to_end(&mut forwarded).await.unwrap();
+        assert!(
+            forwarded.is_empty(),
+            "failed SigV4 credential lookup must not reach upstream"
         );
     }
 
@@ -9132,6 +9494,11 @@ network_policies:
                 websocket_extensions: crate::l7::rest::WebSocketExtensionMode::Preserve,
                 secret_resolver: None,
                 request_body_credential_rewrite: false,
+                credential_signing: crate::l7::CredentialSigning::None,
+                signing_service: "",
+                signing_region: "",
+                host: "",
+                port: 0,
             },
         )
         .await;
@@ -9175,6 +9542,11 @@ network_policies:
                 websocket_extensions: crate::l7::rest::WebSocketExtensionMode::Preserve,
                 secret_resolver: None,
                 request_body_credential_rewrite: false,
+                credential_signing: crate::l7::CredentialSigning::None,
+                signing_service: "",
+                signing_region: "",
+                host: "",
+                port: 0,
             },
         )
         .await;

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -3616,6 +3616,7 @@ fn forward_telemetry_path(target_uri: &str) -> String {
         .unwrap_or_else(|_| "/[INVALID_REQUEST_TARGET]".to_string())
 }
 
+#[cfg(test)]
 fn endpoint_secret_resolver(
     provider_credentials: Option<&ProviderCredentialState>,
     fallback: Option<Arc<SecretResolver>>,
@@ -3623,9 +3624,41 @@ fn endpoint_secret_resolver(
     port: u16,
     canonical_path: &str,
 ) -> Option<Arc<SecretResolver>> {
-    provider_credentials.map_or(fallback, |credentials| {
-        credentials.resolver_for_endpoint(host, port, canonical_path)
-    })
+    endpoint_credentials_for_request(provider_credentials, fallback, host, port, canonical_path)
+        .resolver
+}
+
+struct ForwardEndpointCredentials {
+    resolver: Option<Arc<SecretResolver>>,
+    revision: Option<u64>,
+}
+
+fn endpoint_credentials_for_request(
+    provider_credentials: Option<&ProviderCredentialState>,
+    fallback: Option<Arc<SecretResolver>>,
+    host: &str,
+    port: u16,
+    canonical_path: &str,
+) -> ForwardEndpointCredentials {
+    let Some(credentials) = provider_credentials else {
+        return ForwardEndpointCredentials {
+            resolver: fallback,
+            revision: None,
+        };
+    };
+    let revision_before = credentials.revision();
+    let resolver = credentials.resolver_for_endpoint(host, port, canonical_path);
+    let revision_after = credentials.revision();
+    if revision_before != revision_after {
+        return ForwardEndpointCredentials {
+            resolver: None,
+            revision: None,
+        };
+    }
+    ForwardEndpointCredentials {
+        resolver,
+        revision: Some(revision_before),
+    }
 }
 
 struct PreparedForwardTarget {
@@ -3633,16 +3666,11 @@ struct PreparedForwardTarget {
     raw_query: Option<String>,
     upstream_target: String,
     telemetry_path: String,
-    secret_resolver: Option<Arc<SecretResolver>>,
 }
 
 fn prepare_forward_target(
     target: &str,
     canonicalize_options: crate::l7::path::CanonicalizeOptions,
-    provider_credentials: Option<&ProviderCredentialState>,
-    fallback: Option<Arc<SecretResolver>>,
-    host: &str,
-    port: u16,
 ) -> Result<PreparedForwardTarget, crate::l7::path::CanonicalizeError> {
     let (canonical, raw_query) =
         crate::l7::path::canonicalize_request_target(target, &canonicalize_options)?;
@@ -3655,15 +3683,11 @@ fn prepare_forward_target(
             || canonical.path.clone(),
             |query| format!("{}?{query}", canonical.path),
         );
-    let secret_resolver =
-        endpoint_secret_resolver(provider_credentials, fallback, host, port, &canonical.path);
-
     Ok(PreparedForwardTarget {
         canonical_path: canonical.path,
         raw_query,
         upstream_target,
         telemetry_path,
-        secret_resolver,
     })
 }
 
@@ -3861,18 +3885,16 @@ fn rewrite_forward_request(
     }
 
     // Fail-closed: scan for any remaining unresolved placeholders
-    if secret_resolver.is_some() {
-        let scan_end = if request_body_credential_rewrite {
-            rewritten_header_end
-        } else {
-            output.len()
-        };
-        let output_str = String::from_utf8_lossy(&output[..scan_end]);
-        if output_str.contains(secrets::PLACEHOLDER_PREFIX_PUBLIC)
-            || output_str.contains(secrets::PROVIDER_ALIAS_MARKER_PUBLIC)
-        {
-            return Err(secrets::UnresolvedPlaceholderError::unavailable("header"));
-        }
+    let scan_end = if request_body_credential_rewrite {
+        rewritten_header_end
+    } else {
+        output.len()
+    };
+    let output_str = String::from_utf8_lossy(&output[..scan_end]);
+    if output_str.contains(secrets::PLACEHOLDER_PREFIX_PUBLIC)
+        || output_str.contains(secrets::PROVIDER_ALIAS_MARKER_PUBLIC)
+    {
+        return Err(secrets::UnresolvedPlaceholderError::unavailable("header"));
     }
 
     Ok(output)
@@ -3940,6 +3962,7 @@ fn complete_chunked_body_prefix_len(bytes: &[u8]) -> Option<usize> {
 
 struct ForwardRelayOptions<'a> {
     generation_guard: &'a PolicyGenerationGuard,
+    credential_generation: Option<crate::l7::rest::CredentialGenerationGuard<'a>>,
     websocket_extensions: crate::l7::rest::WebSocketExtensionMode,
     secret_resolver: Option<&'a SecretResolver>,
     request_body_credential_rewrite: bool,
@@ -3983,6 +4006,7 @@ where
         upstream,
         crate::l7::rest::RelayRequestOptions {
             resolver: options.secret_resolver,
+            credential_generation: options.credential_generation,
             generation_guard: Some(options.generation_guard),
             websocket_extensions: options.websocket_extensions,
             request_body_credential_rewrite: options.request_body_credential_rewrite,
@@ -4298,14 +4322,7 @@ async fn handle_forward_proxy(
         }),
         ..Default::default()
     };
-    let prepared_target = match prepare_forward_target(
-        &path,
-        canonicalize_options,
-        provider_credentials.as_ref(),
-        secret_resolver,
-        &host_lc,
-        port,
-    ) {
+    let prepared_target = match prepare_forward_target(&path, canonicalize_options) {
         Ok(prepared) => prepared,
         Err(error) => {
             let event = NetworkActivityBuilder::new(openshell_ocsf::ctx::ctx())
@@ -4341,11 +4358,10 @@ async fn handle_forward_proxy(
         .map_or_else(std::collections::HashMap::new, |query| {
             crate::l7::rest::parse_query_params(query).unwrap_or_default()
         });
-    let secret_resolver = prepared_target.secret_resolver;
     let mut l7_ctx = relay::http_context(
         &decision,
         provider_credentials,
-        secret_resolver.clone(),
+        secret_resolver,
         activity_tx.cloned(),
         dynamic_credentials.clone(),
         agent_proposals,
@@ -4983,6 +4999,30 @@ async fn handle_forward_proxy(
             return Ok(());
         }
     };
+    // Static credentials are intentionally acquired only after every
+    // asynchronous admission step. Holding an endpoint-scoped resolver across
+    // middleware or token-grant awaits would let a revoked generation reach
+    // the upstream.
+    let endpoint_credentials = endpoint_credentials_for_request(
+        l7_ctx.provider_credentials.as_ref(),
+        l7_ctx.secret_resolver.clone(),
+        &host_lc,
+        port,
+        &path,
+    );
+    let secret_resolver = endpoint_credentials.resolver;
+    let credential_generation = match (
+        l7_ctx.provider_credentials.as_ref(),
+        endpoint_credentials.revision,
+    ) {
+        (Some(state), Some(revision)) => Some(crate::l7::rest::CredentialGenerationGuard::new(
+            state, revision,
+        )),
+        _ => None,
+    };
+    if let Some(guard) = credential_generation {
+        guard.ensure_current()?;
+    }
 
     // 9. Rewrite request and forward to upstream
     let rewritten = match rewrite_forward_request(
@@ -5070,6 +5110,7 @@ async fn handle_forward_proxy(
         &mut upstream,
         ForwardRelayOptions {
             generation_guard: &forward_generation_guard,
+            credential_generation,
             websocket_extensions,
             secret_resolver: secret_resolver.as_deref(),
             request_body_credential_rewrite,
@@ -5359,6 +5400,71 @@ mod tests {
     use std::sync::Arc;
     use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
     use tokio::net::{TcpListener, TcpStream};
+
+    struct BlockingForwardMiddleware {
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[tonic::async_trait]
+    impl openshell_core::proto::middleware::v1::supervisor_middleware_server::SupervisorMiddleware
+        for BlockingForwardMiddleware
+    {
+        async fn describe(
+            &self,
+            _request: tonic::Request<()>,
+        ) -> std::result::Result<
+            tonic::Response<openshell_core::proto::MiddlewareManifest>,
+            tonic::Status,
+        > {
+            Ok(tonic::Response::new(
+                openshell_core::proto::MiddlewareManifest {
+                    name: "test/blocking-forward".into(),
+                    service_version: "test".into(),
+                    bindings: vec![openshell_core::proto::MiddlewareBinding {
+                        operation: openshell_core::proto::SupervisorMiddlewareOperation::HttpRequest
+                            as i32,
+                        phase: openshell_core::proto::SupervisorMiddlewarePhase::PreCredentials
+                            as i32,
+                        max_body_bytes: 8192,
+                        timeout: String::new(),
+                    }],
+                },
+            ))
+        }
+
+        async fn validate_config(
+            &self,
+            _request: tonic::Request<openshell_core::proto::ValidateConfigRequest>,
+        ) -> std::result::Result<
+            tonic::Response<openshell_core::proto::ValidateConfigResponse>,
+            tonic::Status,
+        > {
+            Ok(tonic::Response::new(
+                openshell_core::proto::ValidateConfigResponse {
+                    valid: true,
+                    reason: String::new(),
+                },
+            ))
+        }
+
+        async fn evaluate_http_request(
+            &self,
+            _request: tonic::Request<openshell_core::proto::HttpRequestEvaluation>,
+        ) -> std::result::Result<
+            tonic::Response<openshell_core::proto::HttpRequestResult>,
+            tonic::Status,
+        > {
+            self.entered.notify_one();
+            self.release.notified().await;
+            Ok(tonic::Response::new(
+                openshell_core::proto::HttpRequestResult {
+                    decision: openshell_core::proto::Decision::Allow as i32,
+                    ..Default::default()
+                },
+            ))
+        }
+    }
 
     async fn drive_raw_request_through_handler(raw: Vec<u8>) -> Vec<u8> {
         let policy = include_str!("../data/sandbox-policy.rego");
@@ -6054,6 +6160,127 @@ network_policies:
         }
     }
 
+    #[tokio::test]
+    async fn forward_reacquires_static_credentials_after_blocked_middleware() {
+        use openshell_core::proto::{StaticCredentialBinding, StaticCredentialEndpointBinding};
+        let policy = include_str!("../data/sandbox-policy.rego");
+        let engine = OpaEngine::from_strings(policy, "network_policies: {}\n").unwrap();
+        let guard = engine
+            .generation_guard(engine.current_generation())
+            .expect("generation guard");
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let runner = openshell_supervisor_middleware::ChainRunner::new(Arc::new(
+            BlockingForwardMiddleware {
+                entered: Arc::clone(&entered),
+                release: Arc::clone(&release),
+            },
+        ));
+        let state = ProviderCredentialState::from_bound_environment(
+            1,
+            TestHashMap::from([("API_TOKEN".to_string(), "real-secret".to_string())]),
+            TestHashMap::new(),
+            TestHashMap::new(),
+            TestHashMap::from([(
+                "API_TOKEN".to_string(),
+                StaticCredentialBinding {
+                    endpoints: vec![StaticCredentialEndpointBinding {
+                        host: "api.example.test".to_string(),
+                        port: 80,
+                        path: "/allowed/**".to_string(),
+                    }],
+                    credential_identity: "provider-a:API_TOKEN".to_string(),
+                },
+            )]),
+            Vec::new(),
+        )
+        .expect("bound provider state");
+        let ctx = crate::l7::relay::L7EvalContext {
+            host: "api.example.test".into(),
+            port: 80,
+            request_default_port: Some(80),
+            policy_name: "forward".into(),
+            binary_path: "/usr/bin/node".into(),
+            provider_credentials: Some(state.clone()),
+            secret_resolver: state.resolver(),
+            ..Default::default()
+        };
+        let raw = b"GET http://api.example.test/allowed/../outside HTTP/1.1\r\nHost: api.example.test\r\nAuthorization: Bearer openshell:resolve:env:v1_API_TOKEN\r\n\r\n";
+        let prepared = prepare_forward_target(
+            "/allowed/../outside",
+            crate::l7::path::CanonicalizeOptions::default(),
+        )
+        .expect("canonical target");
+        assert_eq!(prepared.canonical_path, "/outside");
+        let request = crate::l7::rest::request_from_buffered_http(
+            "GET",
+            &prepared.canonical_path,
+            &prepared.upstream_target,
+            canonicalize_forward_host_header(raw, "api.example.test").unwrap(),
+        )
+        .unwrap();
+        let pipeline = ForwardMiddlewarePipeline {
+            ctx: &ctx,
+            scheme: "http",
+            runner: &runner,
+            generation_guard: &guard,
+            l7_reevaluation: None,
+        };
+        let chain = vec![openshell_supervisor_middleware::ChainEntry {
+            name: "blocker".into(),
+            implementation: "test/blocking-forward".into(),
+            order: 0,
+            config: prost_types::Struct::default(),
+            on_error: openshell_supervisor_middleware::OnError::FailClosed,
+        }];
+        let (_app, mut client) = tokio::io::duplex(8192);
+        let revoke = async {
+            entered.notified().await;
+            state.revoke_static_provider_environment(2);
+            release.notify_one();
+        };
+        let (outcome, ()) = tokio::join!(pipeline.apply(request, &mut client, chain), revoke);
+        let request = match outcome.expect("middleware pipeline") {
+            crate::l7::middleware::MiddlewareApplyResult::Allowed(request) => request,
+            crate::l7::middleware::MiddlewareApplyResult::Denied { .. } => {
+                panic!("blocking middleware should allow after release")
+            }
+        };
+
+        let credentials = endpoint_credentials_for_request(
+            ctx.provider_credentials.as_ref(),
+            ctx.secret_resolver.clone(),
+            &ctx.host,
+            ctx.port,
+            &prepared.canonical_path,
+        );
+        assert!(
+            credentials.resolver.is_none(),
+            "revoked live state must supersede the connection-open resolver"
+        );
+        let rewrite = rewrite_forward_request(
+            &request.raw_header,
+            request.raw_header.len(),
+            &prepared.upstream_target,
+            "api.example.test",
+            credentials.resolver.as_deref(),
+            false,
+        );
+        assert!(
+            rewrite.is_err(),
+            "revoked credential placeholder must fail before upstream relay"
+        );
+
+        let (proxy_upstream, mut upstream) = tokio::io::duplex(8192);
+        drop(proxy_upstream);
+        let mut forwarded = Vec::new();
+        upstream.read_to_end(&mut forwarded).await.unwrap();
+        assert!(
+            forwarded.is_empty(),
+            "revoked forward credential request must not reach upstream"
+        );
+    }
+
     #[test]
     fn forward_l7_allowed_activity_is_deferred_until_after_ssrf() {
         let (tx, mut rx) = mpsc::channel(4);
@@ -6197,6 +6424,7 @@ network_policies:
             &mut proxy_to_upstream,
             ForwardRelayOptions {
                 generation_guard: &guard,
+                credential_generation: None,
                 websocket_extensions: crate::l7::rest::WebSocketExtensionMode::Preserve,
                 secret_resolver: resolver,
                 request_body_credential_rewrite,
@@ -6386,6 +6614,7 @@ network_policies:
                 &mut proxy_to_upstream,
                 ForwardRelayOptions {
                     generation_guard: guard,
+                    credential_generation: None,
                     websocket_extensions,
                     secret_resolver: None,
                     request_body_credential_rewrite: false,
@@ -8623,17 +8852,18 @@ network_policies:
         let placeholder = "openshell:resolve:env:v1_API_TOKEN";
 
         for raw_path in ["/allowed/../outside", "/allowed/%2e%2e/outside"] {
-            let prepared = prepare_forward_target(
-                raw_path,
-                crate::l7::path::CanonicalizeOptions::default(),
+            let prepared =
+                prepare_forward_target(raw_path, crate::l7::path::CanonicalizeOptions::default())
+                    .expect("prepared target");
+            assert_eq!(prepared.canonical_path, "/outside");
+            let resolver = endpoint_secret_resolver(
                 Some(&state),
                 state.resolver(),
                 "api.example.com",
                 80,
+                &prepared.canonical_path,
             )
-            .expect("prepared target");
-            assert_eq!(prepared.canonical_path, "/outside");
-            let resolver = prepared.secret_resolver.expect("scoped resolver");
+            .expect("scoped resolver");
             let error = resolver
                 .rewrite_header_value(placeholder)
                 .expect_err("canonical endpoint must deny traversal");
@@ -9386,6 +9616,7 @@ network_policies:
             &mut proxy_to_upstream,
             ForwardRelayOptions {
                 generation_guard: &guard,
+                credential_generation: None,
                 websocket_extensions: crate::l7::rest::WebSocketExtensionMode::Preserve,
                 secret_resolver: Some(&resolver),
                 request_body_credential_rewrite: true,
@@ -9464,6 +9695,7 @@ network_policies:
             &mut proxy_to_upstream,
             ForwardRelayOptions {
                 generation_guard: &guard,
+                credential_generation: None,
                 websocket_extensions: crate::l7::rest::WebSocketExtensionMode::Preserve,
                 secret_resolver: Some(&resolver),
                 request_body_credential_rewrite: false,
@@ -9551,6 +9783,7 @@ network_policies:
             &mut proxy_to_upstream,
             ForwardRelayOptions {
                 generation_guard: &guard,
+                credential_generation: None,
                 websocket_extensions: crate::l7::rest::WebSocketExtensionMode::Preserve,
                 secret_resolver: None,
                 request_body_credential_rewrite: false,
@@ -9599,6 +9832,7 @@ network_policies:
             &mut proxy_to_upstream,
             ForwardRelayOptions {
                 generation_guard: &guard,
+                credential_generation: None,
                 websocket_extensions: crate::l7::rest::WebSocketExtensionMode::Preserve,
                 secret_resolver: None,
                 request_body_credential_rewrite: false,

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -6093,6 +6093,7 @@ network_policies:
         let ctx = crate::l7::relay::L7EvalContext {
             host: "api.example.test".into(),
             port: 80,
+            request_default_port: Some(80),
             policy_name: "jsonrpc_api".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],
@@ -6447,6 +6448,7 @@ network_policies:
         let ctx = crate::l7::relay::L7EvalContext {
             host: "api.example.test".into(),
             port: 8080,
+            request_default_port: Some(8080),
             policy_name: "rest_api".into(),
             binary_path: "/usr/bin/curl".into(),
             ancestors: vec![],
@@ -6508,6 +6510,7 @@ network_policies:
         let ctx = crate::l7::relay::L7EvalContext {
             host: host.to_string(),
             port,
+            request_default_port: Some(port),
             policy_name: policy_name.to_string(),
             binary_path: "/usr/bin/node".to_string(),
             ancestors: vec![],
@@ -6687,6 +6690,7 @@ network_policies:
         let ctx = crate::l7::relay::L7EvalContext {
             host: "gateway.example.test".to_string(),
             port: 80,
+            request_default_port: Some(80),
             policy_name: "ws_api".to_string(),
             binary_path: "/usr/bin/node".to_string(),
             ancestors: vec![],
@@ -6728,6 +6732,7 @@ network_policies:
         let ctx = crate::l7::relay::L7EvalContext {
             host: "gateway.example.test".to_string(),
             port: 80,
+            request_default_port: Some(80),
             policy_name: "rest_api".to_string(),
             binary_path: "/usr/bin/node".to_string(),
             ancestors: vec![],
@@ -9316,6 +9321,7 @@ network_policies:
         let ctx = crate::l7::relay::L7EvalContext {
             host: authority.into(),
             port: 80,
+            request_default_port: Some(80),
             policy_name: "test".into(),
             binary_path: "/usr/bin/node".into(),
             ancestors: vec![],

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -3533,23 +3533,32 @@ fn parse_proxy_uri(uri: &str) -> Result<(String, String, u16, String)> {
         .ok_or_else(|| miette::miette!("Missing scheme in proxy URI: {uri}"))?;
     let scheme = scheme.to_ascii_lowercase();
 
-    // Split authority from path
-    let (authority, path) = if rest.starts_with('[') {
-        // IPv6: [::1]:port/path
+    // Split authority from the request target. A query may immediately follow
+    // the authority when the absolute URI has no explicit path, so `/` alone
+    // is not a sufficient delimiter.
+    let target_start = if rest.starts_with('[') {
+        // IPv6: [::1]:port/path or [::1]?query
         let bracket_end = rest
             .find(']')
             .ok_or_else(|| miette::miette!("Unclosed IPv6 bracket in URI: {uri}"))?;
-        let after_bracket = &rest[bracket_end + 1..];
-        after_bracket.find('/').map_or((rest, "/"), |slash_pos| {
-            (
-                &rest[..=bracket_end + slash_pos],
-                &after_bracket[slash_pos..],
-            )
-        })
-    } else if let Some(slash_pos) = rest.find('/') {
-        (&rest[..slash_pos], &rest[slash_pos..])
+        rest[bracket_end + 1..]
+            .find(['/', '?', '#'])
+            .map(|position| bracket_end + 1 + position)
     } else {
-        (rest, "/")
+        rest.find(['/', '?', '#'])
+    };
+    let (authority, target) = target_start.map_or((rest, ""), |position| rest.split_at(position));
+    if target.contains('#') {
+        return Err(miette::miette!(
+            "Fragments are not allowed in proxy URI: {uri}"
+        ));
+    }
+    let path = match target.chars().next() {
+        None => "/".to_string(),
+        Some('/') => target.to_string(),
+        Some('?') => format!("/{target}"),
+        Some('#') => unreachable!("fragments were rejected above"),
+        Some(_) => unreachable!("target begins at a recognized delimiter"),
     };
 
     // Parse host and port from authority
@@ -3588,9 +3597,7 @@ fn parse_proxy_uri(uri: &str) -> Result<(String, String, u16, String)> {
         return Err(miette::miette!("Empty host in URI: {uri}"));
     }
 
-    let path = if path.is_empty() { "/" } else { path };
-
-    Ok((scheme, host, port, path.to_string()))
+    Ok((scheme, host, port, path))
 }
 
 /// Return a query-free, credential-redacted path suitable for forward-proxy
@@ -5577,6 +5584,30 @@ network_policies: {}
             assert!(!serialized.contains("real-secret"), "{serialized}");
             assert!(!serialized.contains("?token="), "{serialized}");
         }
+
+        let target = "http://api.example.com?token=real-secret";
+        let (_, host, port, path) = parse_proxy_uri(target).expect("absolute URI without a path");
+        assert_eq!(host, "api.example.com");
+        assert_eq!(path, "/?token=real-secret");
+        let no_path_query = build_forward_allow_ocsf_event(
+            peer,
+            "GET",
+            &host,
+            port,
+            &forward_telemetry_path(target),
+            "/usr/bin/curl",
+            "42",
+            "/usr/bin/bash",
+            "curl",
+            "allow_api",
+        )
+        .to_json()
+        .unwrap();
+        assert_eq!(no_path_query["dst_endpoint"]["domain"], "api.example.com");
+        assert_eq!(no_path_query["http_request"]["url"]["path"], "/");
+        let serialized = no_path_query.to_string();
+        assert!(!serialized.contains("real-secret"), "{serialized}");
+        assert!(!serialized.contains("?token="), "{serialized}");
 
         let malformed = build_forward_parse_error_ocsf_event(&forward_telemetry_path(
             "not-a-uri?token=real-secret&key=openshell:resolve:env:API_TOKEN",
@@ -8536,6 +8567,14 @@ network_policies:
     }
 
     #[test]
+    fn test_parse_proxy_uri_with_query_and_no_path() {
+        let (_, host, port, path) = parse_proxy_uri("http://host:8080?key=val&foo=bar").unwrap();
+        assert_eq!(host, "host");
+        assert_eq!(port, 8080);
+        assert_eq!(path, "/?key=val&foo=bar");
+    }
+
+    #[test]
     fn forward_telemetry_path_omits_queries_and_redacts_credential_syntax() {
         let target = "http://host:80/v1/openshell:resolve:env:API_TOKEN?token=real-secret";
         let redacted = forward_telemetry_path(target);
@@ -8648,6 +8687,20 @@ network_policies:
         assert_eq!(host, "fe80::1");
         assert_eq!(port, 80);
         assert_eq!(path, "/path");
+    }
+
+    #[test]
+    fn test_parse_proxy_uri_ipv6_with_query_and_no_path() {
+        let (_, host, port, path) = parse_proxy_uri("http://[fe80::1]:8080?key=val").unwrap();
+        assert_eq!(host, "fe80::1");
+        assert_eq!(port, 8080);
+        assert_eq!(path, "/?key=val");
+    }
+
+    #[test]
+    fn test_parse_proxy_uri_rejects_fragment() {
+        assert!(parse_proxy_uri("http://example.com#secret").is_err());
+        assert!(parse_proxy_uri("http://[fe80::1]#secret").is_err());
     }
 
     #[test]

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -23,8 +23,9 @@ use openshell_core::policy::ProxyPolicy;
 use openshell_core::provider_credentials::ProviderCredentialState;
 use openshell_core::secrets::{self, SecretResolver, rewrite_header_line_checked};
 use openshell_ocsf::{
-    ActionId, ActivityId, DispositionId, Endpoint, HttpActivityBuilder, HttpRequest,
-    NetworkActivityBuilder, Process, SeverityId, StatusId, Url as OcsfUrl, ocsf_emit,
+    ActionId, ActivityId, DetectionFindingBuilder, DispositionId, Endpoint, FindingInfo,
+    HttpActivityBuilder, HttpRequest, NetworkActivityBuilder, Process, SeverityId, StatusId,
+    Url as OcsfUrl, ocsf_emit,
 };
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
@@ -61,6 +62,41 @@ const INFERENCE_LOCAL_HOST: &str = "inference.local";
 const INFERENCE_LOCAL_PORT: u16 = 443;
 #[cfg(target_os = "linux")]
 const SIDECAR_SUPERVISOR_TOPOLOGY: &str = "sidecar";
+
+fn emit_credential_endpoint_mismatch(host: &str, port: u16, policy_name: &str) {
+    let event = HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
+        .activity(ActivityId::Fail)
+        .action(ActionId::Denied)
+        .disposition(DispositionId::Blocked)
+        .severity(SeverityId::High)
+        .status(StatusId::Failure)
+        .dst_endpoint(Endpoint::from_domain(host, port))
+        .firewall_rule(policy_name, "credential-binding")
+        .message(format!(
+            "Credential use denied: credential is not authorized for {host}:{port}"
+        ))
+        .status_detail("credential_endpoint_mismatch")
+        .build();
+    ocsf_emit!(event);
+    let finding = DetectionFindingBuilder::new(openshell_ocsf::ctx::ctx())
+        .activity(ActivityId::Open)
+        .action(ActionId::Denied)
+        .disposition(DispositionId::Blocked)
+        .severity(SeverityId::High)
+        .is_alert(true)
+        .finding_info(FindingInfo::new(
+            "openshell.provider_credential.endpoint_mismatch",
+            "Provider credential used at an unauthorized endpoint",
+        ))
+        .evidence_pairs(&[
+            ("policy", policy_name),
+            ("host", host),
+            ("disposition", "denied"),
+        ])
+        .message("Provider credential endpoint binding mismatch; request denied")
+        .build();
+    ocsf_emit!(finding);
+}
 
 /// Hostnames injected by compute drivers as `/etc/hosts` aliases for the host
 /// machine. Traffic to these names is eligible for the trusted-gateway SSRF
@@ -327,6 +363,7 @@ impl ProxyHandle {
                         let proposals = agent_proposals.clone();
                         let gw = trusted_host_gateway.clone();
                         let up_proxy = upstream_proxy.clone();
+                        let credentials = provider_credentials.clone();
                         let resolver = provider_credentials
                             .as_ref()
                             .and_then(ProviderCredentialState::resolver);
@@ -350,6 +387,7 @@ impl ProxyHandle {
                                 proposals,
                                 gw,
                                 up_proxy,
+                                credentials,
                                 resolver,
                                 dynamic_credentials,
                                 dtx,
@@ -1098,6 +1136,7 @@ async fn handle_tcp_connection(
     agent_proposals: openshell_core::proposals::AgentProposals,
     trusted_host_gateway: Arc<Option<IpAddr>>,
     upstream_proxy: Arc<Option<UpstreamProxyConfig>>,
+    provider_credentials: Option<ProviderCredentialState>,
     secret_resolver: Option<Arc<SecretResolver>>,
     dynamic_credentials: Option<
         Arc<
@@ -1167,6 +1206,7 @@ async fn handle_tcp_connection(
             policy_local_ctx,
             agent_proposals,
             trusted_host_gateway,
+            provider_credentials,
             secret_resolver,
             dynamic_credentials,
             denial_tx.as_ref(),
@@ -1506,6 +1546,7 @@ async fn handle_tcp_connection(
     // Build request-processing context shared by CONNECT and forward HTTP.
     let ctx = relay::http_context(
         &decision,
+        provider_credentials,
         secret_resolver.clone(),
         activity_tx.clone(),
         dynamic_credentials.clone(),
@@ -3747,7 +3788,7 @@ fn rewrite_forward_request(
         if output_str.contains(secrets::PLACEHOLDER_PREFIX_PUBLIC)
             || output_str.contains(secrets::PROVIDER_ALIAS_MARKER_PUBLIC)
         {
-            return Err(secrets::UnresolvedPlaceholderError { location: "header" });
+            return Err(secrets::UnresolvedPlaceholderError::unavailable("header"));
         }
     }
 
@@ -3915,6 +3956,7 @@ async fn handle_forward_proxy(
     policy_local_ctx: Option<Arc<PolicyLocalContext>>,
     agent_proposals: openshell_core::proposals::AgentProposals,
     trusted_host_gateway: Arc<Option<IpAddr>>,
+    provider_credentials: Option<ProviderCredentialState>,
     secret_resolver: Option<Arc<SecretResolver>>,
     dynamic_credentials: Option<
         Arc<
@@ -3945,6 +3987,10 @@ async fn handle_forward_proxy(
         }
     };
     let host_lc = host.to_ascii_lowercase();
+    let secret_resolver = provider_credentials
+        .as_ref()
+        .and_then(|credentials| credentials.resolver_for_endpoint(&host_lc, port, &path))
+        .or(secret_resolver);
 
     if host_lc == POLICY_LOCAL_HOST {
         if scheme != "http" || port != 80 {
@@ -4163,6 +4209,7 @@ async fn handle_forward_proxy(
     let mut request_body_credential_rewrite = false;
     let l7_ctx = relay::http_context(
         &decision,
+        provider_credentials,
         secret_resolver.clone(),
         activity_tx.cloned(),
         dynamic_credentials.clone(),
@@ -4297,7 +4344,20 @@ async fn handle_forward_proxy(
                     return Ok(());
                 }
             };
-        let Some(l7_config) = select_l7_config_for_path(&route.configs, &path) else {
+        let Ok(redacted_path) = secrets::redact_target_for_policy(&path) else {
+            respond(
+                client,
+                &build_json_error_response(
+                    400,
+                    "Bad Request",
+                    "invalid_credential_placeholder",
+                    "request-target contains an invalid credential placeholder",
+                ),
+            )
+            .await?;
+            return Ok(());
+        };
+        let Some(l7_config) = select_l7_config_for_path(&route.configs, &redacted_path) else {
             emit_activity_simple(activity_tx, true, "l7_policy");
             respond(
                 client,
@@ -4477,7 +4537,7 @@ async fn handle_forward_proxy(
         };
         let request_info = crate::l7::L7RequestInfo {
             action: method.to_string(),
-            target: path.clone(),
+            target: redacted_path,
             query_params,
             graphql,
             jsonrpc,
@@ -4859,16 +4919,30 @@ async fn handle_forward_proxy(
                 error = %e,
                 "credential injection failed in forward proxy"
             );
-            respond(
-                client,
-                &build_json_error_response(
-                    500,
-                    "Internal Server Error",
-                    "credential_injection_failed",
-                    "unresolved credential placeholder in request",
-                ),
-            )
-            .await?;
+            if e.is_endpoint_mismatch() {
+                emit_credential_endpoint_mismatch(&host_lc, port, policy_str);
+                respond(
+                    client,
+                    &build_json_error_response(
+                        403,
+                        "Forbidden",
+                        "credential_endpoint_mismatch",
+                        "credential is not authorized for this request endpoint",
+                    ),
+                )
+                .await?;
+            } else {
+                respond(
+                    client,
+                    &build_json_error_response(
+                        500,
+                        "Internal Server Error",
+                        "credential_injection_failed",
+                        "unresolved credential placeholder in request",
+                    ),
+                )
+                .await?;
+            }
             return Ok(());
         }
     };
@@ -5210,6 +5284,7 @@ network_policies: {}
             AgentProposals::default(),
             Arc::new(None),
             Arc::new(None),
+            None,
             None,
             None,
             None,
@@ -9580,6 +9655,7 @@ network_policies:
                 AgentProposals::default(), // agent_proposals
                 Arc::new(None),            // trusted_host_gateway
                 Arc::new(None),            // upstream_proxy
+                None,                      // provider_credentials
                 None,                      // secret_resolver
                 None,                      // dynamic_credentials
                 Some(denial_tx),           // denial_tx — positive allow/deny signal
@@ -9646,6 +9722,7 @@ network_policies:
             AgentProposals::default(),
             Arc::new(None),
             Arc::new(None),
+            None,
             None,
             None,
             Some(denial_tx),

--- a/crates/openshell-supervisor-network/src/proxy/relay.rs
+++ b/crates/openshell-supervisor-network/src/proxy/relay.rs
@@ -54,6 +54,7 @@ pub(super) fn http_context(
     L7EvalContext {
         host: decision.intent.destination.host.clone(),
         port: decision.intent.destination.port,
+        request_default_port: None,
         policy_name,
         binary_path: decision
             .binary
@@ -335,6 +336,7 @@ mod tests {
         L7EvalContext {
             host: "example.com".to_string(),
             port: 80,
+            request_default_port: Some(80),
             policy_name: "test".to_string(),
             binary_path: String::new(),
             ancestors: vec![],

--- a/crates/openshell-supervisor-network/src/proxy/relay.rs
+++ b/crates/openshell-supervisor-network/src/proxy/relay.rs
@@ -40,6 +40,7 @@ pub(super) struct RelayContext<'a> {
 /// Build the request-processing context shared by CONNECT and forward HTTP.
 pub(super) fn http_context(
     decision: &EgressDecision,
+    provider_credentials: Option<openshell_core::provider_credentials::ProviderCredentialState>,
     secret_resolver: Option<Arc<SecretResolver>>,
     activity_tx: Option<ActivitySender>,
     dynamic_credentials: Option<DynamicCredentials>,
@@ -70,6 +71,7 @@ pub(super) fn http_context(
             .map(|path| path.to_string_lossy().into_owned())
             .collect(),
         secret_resolver,
+        provider_credentials,
         activity_tx,
         dynamic_credentials: dynamic_credentials.clone(),
         token_grant_resolver: dynamic_credentials
@@ -338,6 +340,7 @@ mod tests {
             ancestors: vec![],
             cmdline_paths: vec![],
             secret_resolver: None,
+            provider_credentials: None,
             activity_tx: None,
             dynamic_credentials: None,
             token_grant_resolver: None,

--- a/crates/openshell-supervisor-network/src/proxy/relay.rs
+++ b/crates/openshell-supervisor-network/src/proxy/relay.rs
@@ -46,6 +46,13 @@ pub(super) fn http_context(
     dynamic_credentials: Option<DynamicCredentials>,
     agent_proposals: openshell_core::proposals::AgentProposals,
 ) -> L7EvalContext {
+    // Provider-backed credentials must be acquired from the live state for
+    // each request after middleware/token-grant awaits. Keep only the legacy
+    // resolver fallback when no live provider state exists.
+    let secret_resolver = provider_credentials
+        .is_none()
+        .then_some(secret_resolver)
+        .flatten();
     let policy_name = match &decision.action {
         NetworkAction::Allow { matched_policy } => matched_policy.clone().unwrap_or_default(),
         NetworkAction::Deny { .. } => String::new(),
@@ -73,6 +80,7 @@ pub(super) fn http_context(
             .collect(),
         secret_resolver,
         provider_credentials,
+        provider_credential_revision: None,
         activity_tx,
         dynamic_credentials: dynamic_credentials.clone(),
         token_grant_resolver: dynamic_credentials
@@ -343,6 +351,7 @@ mod tests {
             cmdline_paths: vec![],
             secret_resolver: None,
             provider_credentials: None,
+            provider_credential_revision: None,
             activity_tx: None,
             dynamic_credentials: None,
             token_grant_resolver: None,

--- a/crates/openshell-supervisor-network/src/proxy/tests/compatibility.rs
+++ b/crates/openshell-supervisor-network/src/proxy/tests/compatibility.rs
@@ -553,6 +553,7 @@ network_policies:
                                     None,
                                     None,
                                     None,
+                                    None,
                                 ))
                                 .await
                                 .unwrap();

--- a/docs/providers/aws-sigv4.mdx
+++ b/docs/providers/aws-sigv4.mdx
@@ -156,8 +156,9 @@ endpoints:
 
 - `credential_signing` and `request_body_credential_rewrite` are mutually exclusive on the same endpoint. The policy validator rejects policies that set both.
 - `credential_binding.provider` must name a provider attached to that sandbox. Use it only when the selected provider profile has no endpoints. Endpoint-bearing profiles already define their credential boundary.
+- OpenShell rejects a signed sandbox policy before activation unless the endpoint has a resolvable AWS credential source. An endpoint-bearing profile must declare `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and cover the signed host, port, and path. An endpointless profile must declare those keys and be selected with `credential_binding.provider` on the signed endpoint.
 - The `sigv4:body` mode buffers at most 10 MiB. Requests with larger bodies are rejected. Use `sigv4:no_body` or `sigv4` (auto-detect) for large payloads.
-- The proxy requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in the provider. If either is missing, the request fails with an error.
+- The active provider must contain current `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` values. If either becomes unavailable after policy activation, the request fails closed.
 
 ## Use from a Sandbox
 

--- a/docs/providers/aws-sigv4.mdx
+++ b/docs/providers/aws-sigv4.mdx
@@ -12,7 +12,8 @@ AWS SigV4 credential signing lets sandbox agents call AWS services (Bedrock, S3,
 ## Prerequisites
 
 - A provider with `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` credentials configured. Optionally include `AWS_SESSION_TOKEN` for STS temporary credentials.
-- A sandbox policy with `credential_signing` enabled on the target endpoint.
+- An endpointless `aws` provider profile when the sandbox policy defines the service endpoints, or an endpoint-bearing service profile such as `aws-s3`.
+- A sandbox policy with `credential_signing` enabled on the target endpoint. For the endpointless `aws` profile, the endpoint must also set `credential_binding.provider` to the attached provider name.
 
 ## Provider Setup
 
@@ -21,6 +22,7 @@ Create a provider with AWS credentials:
 ```shell
 openshell provider create \
   --name aws-prod \
+  --type aws \
   --credential AWS_ACCESS_KEY_ID=AKIA... \
   --credential AWS_SECRET_ACCESS_KEY=wJalr...
 ```
@@ -30,6 +32,7 @@ For STS temporary credentials, include the session token:
 ```shell
 openshell provider create \
   --name aws-sts \
+  --type aws \
   --credential AWS_ACCESS_KEY_ID=ASIA... \
   --credential AWS_SECRET_ACCESS_KEY=secret... \
   --credential AWS_SESSION_TOKEN=FwoGZX...
@@ -43,10 +46,13 @@ signer reads. See [Manage Providers](/sandboxes/manage-providers#aws-sts).
 
 ## Policy Configuration
 
-Enable SigV4 signing on a per-endpoint basis using three policy fields:
+Enable SigV4 signing on a per-endpoint basis. The binding selects which
+provider instance supplies credentials, while the signing fields control how
+the proxy applies them:
 
 | Field | Type | Required | Description |
 |---|---|---|---|
+| `credential_binding.provider` | string | For endpointless profiles | Exact name of the attached provider instance that supplies AWS credentials. |
 | `credential_signing` | string | Yes | Signing mode: `sigv4`, `sigv4:body`, or `sigv4:no_body`. |
 | `signing_service` | string | Yes | AWS service name for the SigV4 signature (e.g. `bedrock`, `s3`, `sts`). |
 | `signing_region` | string | No | AWS region override. When omitted, extracted from the endpoint hostname. Required for non-standard endpoints. |
@@ -60,6 +66,8 @@ network_policies:
       - host: bedrock-runtime.us-east-1.amazonaws.com
         port: 443
         protocol: rest
+        credential_binding:
+          provider: aws-prod
         credential_signing: sigv4
         signing_service: bedrock
         rules:
@@ -82,6 +90,8 @@ network_policies:
         port: 443
         protocol: rest
         access: full
+        credential_binding:
+          provider: aws-prod
         credential_signing: sigv4
         signing_service: s3
 ```
@@ -96,6 +106,8 @@ network_policies:
         port: 443
         protocol: rest
         access: full
+        credential_binding:
+          provider: aws-prod
         credential_signing: sigv4
         signing_service: sts
 ```
@@ -133,6 +145,8 @@ endpoints:
     port: 443
     protocol: rest
     access: full
+    credential_binding:
+      provider: aws-prod
     credential_signing: sigv4
     signing_service: s3
     signing_region: us-west-2
@@ -141,6 +155,7 @@ endpoints:
 ## Restrictions
 
 - `credential_signing` and `request_body_credential_rewrite` are mutually exclusive on the same endpoint. The policy validator rejects policies that set both.
+- `credential_binding.provider` must name a provider attached to that sandbox. Use it only when the selected provider profile has no endpoints. Endpoint-bearing profiles already define their credential boundary.
 - The `sigv4:body` mode buffers at most 10 MiB. Requests with larger bodies are rejected. Use `sigv4:no_body` or `sigv4` (auto-detect) for large payloads.
 - The proxy requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in the provider. If either is missing, the request fails with an error.
 

--- a/docs/reference/policy-schema.mdx
+++ b/docs/reference/policy-schema.mdx
@@ -176,6 +176,8 @@ Each endpoint defines a reachable destination and optional inspection rules.
 | `credential_signing` | string | No | Proxy-side credential signing mode. When set, the proxy strips the sandbox client's `Authorization` header and re-signs with real provider credentials. Values: `sigv4` (auto-detect payload mode from client headers), `sigv4:body` (buffer and hash body, max 10 MiB), `sigv4:no_body` (unsigned payload, stream body). Mutually exclusive with `request_body_credential_rewrite`. See [AWS SigV4](/providers/aws-sigv4). |
 | `signing_service` | string | No | AWS service name for SigV4 signing (e.g. `bedrock`, `s3`, `sts`). Required when `credential_signing` is set. |
 | `signing_region` | string | No | AWS region override for SigV4 signing (e.g. `us-east-1`). When omitted, the region is extracted from the endpoint hostname. Required for non-standard AWS endpoints where the region cannot be inferred. |
+| `credential_binding` | object | No | Binds static credentials from an attached provider to this endpoint when that provider's profile defines no endpoints. This field is valid only in a sandbox-scoped policy. |
+| `credential_binding.provider` | string | Yes with `credential_binding` | Exact name of the provider instance attached to the sandbox. The referenced provider must have a profile, and that profile must define no endpoints. |
 | `persisted_queries` | string | No | GraphQL hash-only behavior for `protocol: graphql` and GraphQL-over-WebSocket operation policy. Default is `deny`; use `allow_registered` only with `graphql_persisted_queries`. |
 | `graphql_persisted_queries` | map | No | Trusted GraphQL persisted-query registry keyed by hash or saved-query ID. Values contain `operation_type`, optional `operation_name`, and optional root `fields`. |
 | `graphql_max_body_bytes` | integer | No | Maximum GraphQL-over-HTTP request body bytes buffered for inspection. Defaults to `65536`. |
@@ -200,10 +202,30 @@ Each endpoint defines a reachable destination and optional inspection rules.
 Credential rewrite recognizes the canonical `openshell:resolve:env:KEY` placeholder form and whole-token provider-shaped aliases such as `provider-OPENSHELL-RESOLVE-ENV-API_TOKEN` when the referenced environment key exists in the configured provider credentials.
 
 Static provider placeholders also require the request host, port, and path to
-match an endpoint in the provider profile. Network policy admission does not
-expand that credential boundary. OpenShell rejects a mismatch with HTTP 403 and
+match their credential binding. Profile endpoints supply this boundary by
+default. An endpointless profile can instead use a sandbox policy endpoint with
+`credential_binding.provider` set to the exact attached provider name. OpenShell
+rejects unattached providers, profileless providers, endpointful profiles, and
+global policies that use this field. Network policy admission does not expand
+the credential boundary unless the endpoint explicitly supplies this binding.
+OpenShell rejects a request mismatch with HTTP 403 and
 `credential_endpoint_mismatch`. Refer to [Static Credential Endpoint
 Binding](/sandboxes/providers-v2#understand-static-credential-endpoint-binding).
+
+This example allows the sandbox to reach Google Cloud Storage and binds the
+static credentials from the attached `work-gcp` provider to that endpoint:
+
+```yaml showLineNumbers={false}
+network_policies:
+  gcp_storage:
+    endpoints:
+      - host: storage.googleapis.com
+        port: 443
+        protocol: rest
+        access: full
+        credential_binding:
+          provider: work-gcp
+```
 
 #### Access Levels
 

--- a/docs/reference/policy-schema.mdx
+++ b/docs/reference/policy-schema.mdx
@@ -199,6 +199,12 @@ Each endpoint defines a reachable destination and optional inspection rules.
 
 Credential rewrite recognizes the canonical `openshell:resolve:env:KEY` placeholder form and whole-token provider-shaped aliases such as `provider-OPENSHELL-RESOLVE-ENV-API_TOKEN` when the referenced environment key exists in the configured provider credentials.
 
+Static provider placeholders also require the request host, port, and path to
+match an endpoint in the provider profile. Network policy admission does not
+expand that credential boundary. OpenShell rejects a mismatch with HTTP 403 and
+`credential_endpoint_mismatch`. Refer to [Static Credential Endpoint
+Binding](/sandboxes/providers-v2#understand-static-credential-endpoint-binding).
+
 #### Access Levels
 
 The `access` field accepts one of the following values on REST, WebSocket, and GraphQL endpoints. MCP and JSON-RPC endpoints reject `access` because HTTP method/path presets cannot authorize JSON-RPC safely. Use explicit MCP rules, set `mcp.allow_all_known_mcp_methods: true` for the MCP method profile, or use explicit JSON-RPC rules.

--- a/docs/reference/policy-schema.mdx
+++ b/docs/reference/policy-schema.mdx
@@ -198,6 +198,7 @@ Each endpoint defines a reachable destination and optional inspection rules.
 - `rules: []` (empty list) is rejected; use `access: full` or remove `rules`.
 - Non-empty `rules` must contain at least one effective allow clause; rules where every entry lacks an allow are rejected as deny-all.
 - `deny_rules: []` (empty list) is rejected; remove it if no denials are needed.
+- `credential_signing` requires a resolvable AWS credential source before a sandbox policy can activate. Use an attached endpoint-bearing profile that declares `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and covers the signed endpoint, or bind an attached endpointless profile that declares those keys with `credential_binding.provider`.
 
 Credential rewrite recognizes the canonical `openshell:resolve:env:KEY` placeholder form and whole-token provider-shaped aliases such as `provider-OPENSHELL-RESOLVE-ENV-API_TOKEN` when the referenced environment key exists in the configured provider credentials.
 

--- a/docs/sandboxes/manage-providers.mdx
+++ b/docs/sandboxes/manage-providers.mdx
@@ -93,12 +93,11 @@ one file at a time and rejects stale resource versions. When
 instances of that type on the next sandbox config sync.
 
 <Warning>
-Static credentials require a built-in or imported provider profile with at
-least one endpoint. OpenShell does not activate static credentials from a
-profileless provider because it cannot determine where those credentials are
-safe to use. The legacy `generic` provider type has no built-in endpoint
-profile. Import a custom profile and use its ID as `--type` for custom
-credentials.
+Static credentials require a built-in or imported provider profile. Profiles
+normally define at least one endpoint. An endpointless profile requires an
+explicit `credential_binding.provider` on a sandbox policy endpoint. OpenShell
+does not activate static credentials from a profileless provider because it
+cannot determine which credential definition applies.
 </Warning>
 
 ## Manage Providers
@@ -260,7 +259,8 @@ openshell sandbox create --provider my-claude --provider my-github -- claude
 
 Each `--provider` flag attaches one provider. The sandbox receives eligible
 credentials from every attached provider as placeholders at runtime. Each
-static credential resolves only for endpoints in that provider's profile.
+static credential resolves only for endpoints in that provider's profile, or
+for explicitly bound sandbox policy endpoints when the profile is endpointless.
 Profile-managed providers also contribute provider-generated network policy
 entries when `providers_v2_enabled` is enabled at the gateway. When the setting
 is disabled, endpoint binding still applies, but provider-generated policy does
@@ -303,18 +303,22 @@ placeholder, the proxy resolves it immediately before forwarding the request.
 Static credential resolution has two independent authorization boundaries:
 
 1. Network policy must allow the calling binary and request destination.
-2. The credential's provider profile must include the request host, port, and
-   path.
+2. The credential binding must include the request host, port, and path. Profile
+   endpoints provide the binding by default. An endpointless profile can use a
+   sandbox policy endpoint that names the attached provider instance through
+   `credential_binding.provider`.
 
-Both checks must pass. Adding an endpoint to sandbox policy does not expand
-where an attached provider credential can resolve. Likewise, a provider profile
-endpoint does not grant network access unless provider policy composition or
-the sandbox's own policy allows the request.
+Both checks must pass. A provider profile endpoint does not grant network access
+unless provider policy composition or the sandbox's own policy allows the
+request. A plain sandbox policy endpoint does not grant credential use unless
+the profile already covers it or the endpoint explicitly binds an endpointless
+provider.
 
 Endpoint binding applies whether `providers_v2_enabled` is enabled or disabled.
 The setting controls provider policy composition only. Every static credential
-declared by a provider currently receives the complete endpoint set from that
-provider's profile.
+declared by a provider receives the complete endpoint set from that provider's
+profile, or the explicitly bound sandbox policy endpoints for an endpointless
+profile.
 
 Credential resolution requires the proxy to handle the request as HTTP. Raw
 `tls: skip` and non-HTTP tunnels remain opaque and do not support credential
@@ -340,7 +344,7 @@ bodies, or WebSocket binary frames.
 
 ### Fail-closed behavior
 
-If policy allows a request but the credential's profile does not include the
+If policy allows a request but the credential binding does not include the
 request endpoint, the proxy rejects the request with HTTP 403 and the
 `credential_endpoint_mismatch` reason. It emits a denied activity event and a
 security finding without recording the secret, placeholder, environment key, or
@@ -362,10 +366,11 @@ the profile's `api.github.com:443` and `github.com:443` endpoints. Even if a
 sandbox policy allows `uploads.example.com:443`, sending either placeholder
 there returns `credential_endpoint_mismatch`.
 
-For a custom service, define the credential and its allowed endpoints in a
-custom provider profile, import the profile, and create the provider with the
-profile ID as its type. Refer to [Provider Profiles](/sandboxes/providers-v2#provider-profiles)
-for the profile workflow and schema.
+For a custom service, define the credential in a custom provider profile. Put
+stable endpoints in the profile, or leave the profile endpointless and bind
+each concrete provider instance from sandbox policy. Refer to [Provider
+Profiles](/sandboxes/providers-v2#provider-profiles) for the profile workflow
+and schema.
 
 ## Supported Provider Types
 

--- a/docs/sandboxes/manage-providers.mdx
+++ b/docs/sandboxes/manage-providers.mdx
@@ -46,7 +46,7 @@ and stores them in the provider.
 Supply a credential value directly:
 
 ```shell
-openshell provider create --name my-api --type generic --credential API_KEY=sk-abc123
+openshell provider create --name my-nvidia --type nvidia --credential NVIDIA_API_KEY=nvapi-example
 ```
 
 ### Bare Key Form
@@ -55,10 +55,10 @@ Pass a key name without a value to read the value from the environment variable
 of that name:
 
 ```shell
-openshell provider create --name my-api --type generic --credential API_KEY
+openshell provider create --name my-nvidia --type nvidia --credential NVIDIA_API_KEY
 ```
 
-This looks up the current value of `$API_KEY` in your shell and stores it.
+This looks up the current value of `$NVIDIA_API_KEY` in your shell and stores it.
 
 Provider profile metadata is available for known provider types. Provider profile
 network policy is gateway opt-in:
@@ -67,7 +67,9 @@ network policy is gateway opt-in:
 openshell settings set --global --key providers_v2_enabled --value true
 ```
 
-Without `providers_v2_enabled=true`, provider behavior remains credential-only.
+Without `providers_v2_enabled=true`, attached provider profiles do not contribute
+network policy to the sandbox. Static credential endpoint binding remains active
+in either mode.
 
 When `providers_v2_enabled=true`, `--from-existing` uses profile-backed
 discovery instead of the legacy provider registry. The requested `--type` must
@@ -89,6 +91,15 @@ read-only. The target ID must match the profile ID in the file. Update accepts
 one file at a time and rejects stale resource versions. When
 `providers_v2_enabled=true`, updated profile policy applies to all provider
 instances of that type on the next sandbox config sync.
+
+<Warning>
+Static credentials require a built-in or imported provider profile with at
+least one endpoint. OpenShell does not activate static credentials from a
+profileless provider because it cannot determine where those credentials are
+safe to use. The legacy `generic` provider type has no built-in endpoint
+profile. Import a custom profile and use its ID as `--type` for custom
+credentials.
+</Warning>
 
 ## Manage Providers
 
@@ -247,11 +258,13 @@ Pass one or more `--provider` flags when creating a sandbox:
 openshell sandbox create --provider my-claude --provider my-github -- claude
 ```
 
-Each `--provider` flag attaches one provider. The sandbox receives all
-credentials from every attached provider at runtime. Profile-managed providers
-also contribute provider-generated network policy entries when
-`providers_v2_enabled` is enabled at the gateway. When the setting is disabled,
-providers keep the previous behavior and only provide credentials.
+Each `--provider` flag attaches one provider. The sandbox receives eligible
+credentials from every attached provider as placeholders at runtime. Each
+static credential resolves only for endpoints in that provider's profile.
+Profile-managed providers also contribute provider-generated network policy
+entries when `providers_v2_enabled` is enabled at the gateway. When the setting
+is disabled, endpoint binding still applies, but provider-generated policy does
+not.
 
 <Warning>
 Legacy provider attachment is fixed at sandbox creation time. Providers v2 adds
@@ -282,9 +295,31 @@ provider instance, and pass `--provider <name>` explicitly.
 
 ## How Credential Injection Works
 
-The agent process inside the sandbox never sees real credential values. At startup, the proxy replaces each credential with an opaque placeholder token in the agent's environment. When the agent sends an HTTP request containing a placeholder, the proxy resolves it to the real credential before forwarding upstream.
+The agent process inside the sandbox never sees real credential values. At
+startup, OpenShell replaces each credential with an opaque placeholder token in
+the agent's environment. When the agent sends an HTTP request containing a
+placeholder, the proxy resolves it immediately before forwarding the request.
 
-This resolution requires the proxy to see plaintext HTTP. Endpoints must use `protocol: rest` in the policy (which auto-terminates TLS) or explicit `tls: terminate`. Endpoints without TLS termination pass traffic through as an opaque stream, and credential placeholders are forwarded unresolved.
+Static credential resolution has two independent authorization boundaries:
+
+1. Network policy must allow the calling binary and request destination.
+2. The credential's provider profile must include the request host, port, and
+   path.
+
+Both checks must pass. Adding an endpoint to sandbox policy does not expand
+where an attached provider credential can resolve. Likewise, a provider profile
+endpoint does not grant network access unless provider policy composition or
+the sandbox's own policy allows the request.
+
+Endpoint binding applies whether `providers_v2_enabled` is enabled or disabled.
+The setting controls provider policy composition only. Every static credential
+declared by a provider currently receives the complete endpoint set from that
+provider's profile.
+
+Credential resolution requires the proxy to handle the request as HTTP. Raw
+`tls: skip` and non-HTTP tunnels remain opaque and do not support credential
+rewrite. Refer to [Providers v2](/sandboxes/providers-v2#understand-static-credential-endpoint-binding)
+for endpoint matching and migration guidance.
 
 ### Supported injection locations
 
@@ -296,30 +331,41 @@ The proxy resolves credential placeholders in the following parts of an HTTP req
 | Header value (Basic auth) | Agent base64-encodes `user:<placeholder>` in an `Authorization: Basic` header. The proxy decodes, resolves, and re-encodes. | `Authorization: Basic <base64>` |
 | Query parameter value | Agent places the placeholder in a URL query parameter. | `GET /api?key=<placeholder>` |
 | URL path segment | Agent builds a URL with the placeholder in the path. Supports concatenated patterns. | `POST /bot<placeholder>/sendMessage` |
+| Supported request body | An inspected REST endpoint opts in with `request_body_credential_rewrite: true`. | `{"api_key":"<placeholder>"}` |
+| WebSocket text message | A REST or WebSocket endpoint opts in with `websocket_credential_rewrite: true`. | `{"token":"<placeholder>"}` |
+| AWS SigV4 signing | An endpoint configures `credential_signing`, and the proxy signs with the endpoint-bound AWS credentials. | `credential_signing: sigv4` |
 
-The proxy does not modify request bodies, cookies, or response content.
+The proxy does not rewrite cookies, response content, unsupported request
+bodies, or WebSocket binary frames.
 
 ### Fail-closed behavior
 
-If the proxy detects a credential placeholder in a request but cannot resolve it, it rejects the request with HTTP 500 instead of forwarding the raw placeholder to the upstream server. This prevents accidental credential leakage in server logs or error responses.
+If policy allows a request but the credential's profile does not include the
+request endpoint, the proxy rejects the request with HTTP 403 and the
+`credential_endpoint_mismatch` reason. It emits a denied activity event and a
+security finding without recording the secret, placeholder, environment key, or
+query string.
 
-### Example: Telegram Bot API (path-based credential)
+Unknown, malformed, expired, or otherwise unresolved placeholders also fail
+closed instead of being forwarded to the upstream service.
 
-Create a provider with the Telegram bot token:
+### Inspect an Endpoint Binding
+
+Export the profile used by a provider to inspect its credential boundary:
 
 ```shell
-openshell provider create --name telegram --type generic --credential TELEGRAM_BOT_TOKEN=123456:ABC-DEF
+openshell provider profile export github -o yaml
 ```
 
-The agent reads `TELEGRAM_BOT_TOKEN` from its environment and builds a request like `POST /bot<placeholder>/sendMessage`. The proxy resolves the placeholder in the URL path and forwards `POST /bot123456:ABC-DEF/sendMessage` to the upstream.
+For the built-in GitHub profile, `GITHUB_TOKEN` and `GH_TOKEN` can resolve for
+the profile's `api.github.com:443` and `github.com:443` endpoints. Even if a
+sandbox policy allows `uploads.example.com:443`, sending either placeholder
+there returns `credential_endpoint_mismatch`.
 
-### Example: Google API (query parameter credential)
-
-```shell
-openshell provider create --name google --type generic --credential YOUTUBE_API_KEY=AIzaSy-secret
-```
-
-The agent sends `GET /youtube/v3/search?part=snippet&key=<placeholder>`. The proxy resolves the placeholder in the query parameter value and percent-encodes the result before forwarding.
+For a custom service, define the credential and its allowed endpoints in a
+custom provider profile, import the profile, and create the provider with the
+profile ID as its type. Refer to [Provider Profiles](/sandboxes/providers-v2#provider-profiles)
+for the profile workflow and schema.
 
 ## Supported Provider Types
 
@@ -333,7 +379,7 @@ The following provider types are supported.
 | `codex` | `OPENAI_API_KEY` | OpenAI Codex |
 | `copilot` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` | GitHub Copilot CLI |
 | `deepinfra` | `DEEPINFRA_API_KEY` | DeepInfra inference API |
-| `generic` | User-defined | Any service with custom credentials |
+| `generic` | User-defined | Legacy credential storage. Import an endpoint-bearing custom profile for credentials attached to a sandbox. |
 | `github` | `GITHUB_TOKEN`, `GH_TOKEN` | GitHub API and `gh` CLI. Refer to [GitHub Sandbox](/get-started/tutorials/github-sandbox). |
 | `gitlab` | `GITLAB_TOKEN`, `GLAB_TOKEN`, `CI_JOB_TOKEN` | GitLab API, `glab` CLI |
 | `nvidia` | `NVIDIA_API_KEY` | NVIDIA API Catalog |
@@ -345,8 +391,9 @@ The following provider types are supported.
 </Note>
 
 <Tip>
-Use the `generic` type for any service not listed above. You define the
-environment variable names and values yourself with `--credential`.
+For a service not listed above, import a custom provider profile that declares
+its credential environment variables and endpoints. Use the imported profile
+ID as the provider `--type`.
 
 </Tip>
 

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -329,6 +329,12 @@ Use the `request-body-credential-rewrite` endpoint option with `protocol: rest` 
 
 Credential rewrite recognizes the canonical `openshell:resolve:env:KEY` placeholder form and whole-token provider-shaped aliases such as `provider-OPENSHELL-RESOLVE-ENV-API_TOKEN` when the referenced environment key exists in the configured provider credentials.
 
+Static provider placeholders resolve only when the request host, port, and path
+also match an endpoint in the provider profile. A sandbox policy allow does not
+expand that binding. A mismatch returns HTTP 403 with
+`credential_endpoint_mismatch`. Refer to [Static Credential Endpoint
+Binding](/sandboxes/providers-v2#understand-static-credential-endpoint-binding).
+
 For example:
 
 - `api.github.com:443:read-only:rest` is valid.
@@ -539,8 +545,16 @@ When triaging denied requests, check:
 - Destination host and port to confirm which endpoint is missing.
 - Calling binary path to confirm which `binaries` entry needs to be added or adjusted.
 - HTTP method and path for REST endpoints, or `GET` / `WEBSOCKET_TEXT` and the upgraded request path for WebSocket endpoints, to confirm which `rules` entry needs to be added or adjusted.
+- `credential_endpoint_mismatch` in sandbox logs to confirm that policy admitted the request but the attached provider profile did not authorize its credential for that host, port, and path.
 
 Then push the updated policy as described above.
+
+Do not fix `credential_endpoint_mismatch` by widening sandbox policy. Export the
+provider profile with `openshell provider profile export <profile-id> -o yaml`.
+Update the custom provider profile only when the destination is an intended
+credential recipient. Refer to [Static Credential Endpoint
+Binding](/sandboxes/providers-v2#understand-static-credential-endpoint-binding)
+for the complete authorization model.
 
 For small changes, prefer `openshell policy update` over rewriting the full YAML:
 

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -546,6 +546,7 @@ When triaging denied requests, check:
 - Calling binary path to confirm which `binaries` entry needs to be added or adjusted.
 - HTTP method and path for REST endpoints, or `GET` / `WEBSOCKET_TEXT` and the upgraded request path for WebSocket endpoints, to confirm which `rules` entry needs to be added or adjusted.
 - `credential_endpoint_mismatch` in sandbox logs to confirm that policy admitted the request but the attached provider profile did not authorize its credential for that host, port, and path.
+- `request_authority_mismatch` in the response or sandbox logs to confirm that the HTTP request authority differs from the authorized tunnel endpoint. For a CONNECT tunnel to `api.example.com:8443`, send `Host: api.example.com:8443`; omitting the non-default port makes the request authority use the transport default and OpenShell rejects it. Absolute-form request targets must use the same host and port.
 
 Then push the updated policy as described above.
 

--- a/docs/sandboxes/providers-v2.mdx
+++ b/docs/sandboxes/providers-v2.mdx
@@ -153,6 +153,13 @@ headers, Basic and Bearer authorization, URL paths, query parameters, opted-in
 request bodies, AWS SigV4 signing, and opted-in WebSocket text messages. Raw
 `tls: skip` and non-HTTP tunnels do not perform static credential substitution.
 
+Before it activates a sandbox policy, OpenShell verifies that every endpoint
+with `credential_signing` has an attached profile that declares
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. An endpoint-bearing profile must
+cover the signed host, port, and path. An endpointless profile must be selected
+by `credential_binding.provider` on that endpoint. A missing or mismatched
+source rejects the whole policy update with `FAILED_PRECONDITION`.
+
 If an HTTP request contains a known placeholder at a destination outside its
 binding, OpenShell returns HTTP 403 with this response:
 

--- a/docs/sandboxes/providers-v2.mdx
+++ b/docs/sandboxes/providers-v2.mdx
@@ -25,7 +25,7 @@ Providers v2 keeps those pieces together:
 | Custom provider definitions | You can export, edit, lint, import, list, and delete custom profiles. |
 | Runtime provider lifecycle | You can list, attach, and detach providers on existing sandboxes. |
 | Credential rotation | Provider refresh metadata lets the gateway refresh short-lived access tokens and update provider records. |
-| Credential transport | Credential delivery uses environment placeholders and proxy rewrite. Static placeholders resolve only at profile endpoints. |
+| Credential transport | Credential delivery uses environment placeholders and proxy rewrite. Static placeholders resolve only at profile endpoints or explicitly bound sandbox policy endpoints for endpointless profiles. |
 
 ## Enable Providers v2
 
@@ -63,14 +63,16 @@ Providers v2 currently includes these user-facing features:
 - Credential refresh configuration with `openshell provider refresh status|configure|rotate|delete`.
 - Credential expiry metadata with `openshell provider update --credential-expires-at`; values accept Unix epoch milliseconds or ISO/RFC3339 timestamps.
 - Dynamic token grants that use the sandbox's SPIFFE JWT-SVID as an OAuth2 client assertion and inject short-lived tokens into supported headers for matching profile endpoints.
-- Endpoint-bound static credential placeholders. The sandbox proxy resolves a static credential only for request hosts, ports, and paths declared by its provider profile.
+- Endpoint-bound static credential placeholders. The sandbox proxy resolves a static credential only for request hosts, ports, and paths declared by its provider profile or explicitly bound in sandbox policy for an endpointless profile.
 
 ## Understand Static Credential Endpoint Binding
 
 Static credential endpoint binding prevents a placeholder for one service from
 resolving on a different policy-allowed service. OpenShell associates every
-static credential environment key with the endpoints in its provider profile.
-The proxy checks that association before it substitutes the real value.
+static credential environment key with an endpoint boundary. Profile endpoints
+supply that boundary by default. For an endpointless profile, a sandbox policy
+endpoint can name the attached provider instance explicitly. The proxy checks
+the resulting association before it substitutes the real value.
 
 A request can use a static credential only when all of these checks pass:
 
@@ -78,14 +80,14 @@ A request can use a static credential only when all of these checks pass:
 |---|---|
 | The placeholder belongs to the current attached provider state. | Sandbox provider attachment and current provider record. |
 | The calling binary and destination are allowed. | Effective sandbox network policy. |
-| The host, port, and canonical request path match the credential binding. | Provider profile endpoints. |
+| The host, port, and canonical request path match the credential binding. | Provider profile endpoints, or an explicit sandbox policy binding for an endpointless profile. |
 | The HTTP method, path, or protocol operation is allowed when L7 inspection is configured. | Effective sandbox network policy. |
 | The credential has not expired. | Provider credential expiry metadata. |
 
 Network policy and credential binding serve different purposes. Network policy
-authorizes traffic. Provider profile endpoints authorize use of the provider's
-credentials. A sandbox policy allow cannot widen a credential binding, and a
-credential binding cannot widen sandbox network policy.
+authorizes traffic. A credential binding authorizes use of one provider
+instance's credentials at an admitted endpoint. A credential binding cannot
+widen sandbox network policy.
 
 For example, this profile endpoint binds all static credential environment keys
 from the profile to `api.example.com:443` under `/v1`:
@@ -102,6 +104,49 @@ The path `/v1/**` matches `/v1` and its descendants. An empty path, `**`, or
 glob matching. OpenShell removes the query string and uses a canonical,
 secret-redacted path for this check, so a credential embedded in a request path
 does not need to be revealed before authorization.
+
+Use an explicit sandbox policy binding when the profile intentionally defines
+credentials without defining service endpoints. The policy names the concrete
+provider instance, not the profile type:
+
+```yaml showLineNumbers={false}
+network_policies:
+  gcp_storage:
+    endpoints:
+      - host: storage.googleapis.com
+        port: 443
+        protocol: rest
+        access: full
+        credential_binding:
+          provider: work-gcp
+```
+
+The provider must be attached to the sandbox and must select an endpointless
+profile. OpenShell rejects the complete policy update if the provider is
+unattached, has no profile, or selects a profile that already defines endpoints.
+This keeps one source of credential-binding authority for each provider.
+`credential_binding` is sandbox-scoped and is not accepted in a gateway-global
+policy.
+
+For AWS endpoints, the binding and signing fields have separate jobs.
+`credential_binding.provider` selects the provider instance that supplies
+credentials. `credential_signing`, `signing_service`, and `signing_region`
+control how the proxy applies those credentials:
+
+```yaml showLineNumbers={false}
+network_policies:
+  aws_s3:
+    endpoints:
+      - host: s3.us-west-2.amazonaws.com
+        port: 443
+        protocol: rest
+        access: full
+        credential_binding:
+          provider: work-aws
+        credential_signing: sigv4
+        signing_service: s3
+        signing_region: us-west-2
+```
 
 The binding applies to CONNECT and forward-proxy HTTP requests, including
 headers, Basic and Bearer authorization, URL paths, query parameters, opted-in
@@ -131,13 +176,11 @@ the provider revokes resolution for placeholders already held by running
 processes.
 
 <Warning>
-Static credentials from a selected provider profile require at least one usable
-endpoint. OpenShell withholds only the static credential keys and associated
-expiry and binding metadata from an endpointless selected profile. It retains
-that provider's generated non-secret configuration and valid endpoint-bound
-static credentials from other attached providers. For a custom static
-credential, import a profile with the intended endpoint selectors and use that
-profile as the provider type.
+Static credentials require at least one usable binding. OpenShell withholds only
+the static credential keys and associated expiry and binding metadata from an
+endpointless selected profile when no sandbox policy endpoint explicitly binds
+that provider. It retains that provider's generated non-secret configuration
+and valid endpoint-bound static credentials from other attached providers.
 </Warning>
 
 After upgrading a gateway and supervisor to a release with endpoint binding,
@@ -366,7 +409,7 @@ binaries:
 
 `category` groups profiles in `openshell provider list-profiles`. Use one of the values in the category enum.
 
-`credentials` declares the credential names, environment variables, auth metadata, optional refresh metadata, and optional dynamic token grant metadata for the provider type. The `auth_style` field accepts `basic`, `bearer`, `header`, `query`, or `path`. When `auth_style` is `path`, set `path_template` to a URL path containing the `{credential}` placeholder exactly once (for example, `/v1/{credential}/resources`). Static credentials are exposed as placeholder environment variables and resolved in outbound HTTP requests only at profile endpoints. Every static credential environment key currently receives the full profile endpoint set. Dynamic token grants are resolved by the sandbox proxy on demand for matching profile endpoints and support `bearer` or `header` placement. Credential environment variable names must not use the reserved `v<digits>_` prefix, such as `v10_GITHUB_TOKEN`, because OpenShell uses that namespace for revision-scoped placeholders.
+`credentials` declares the credential names, environment variables, auth metadata, optional refresh metadata, and optional dynamic token grant metadata for the provider type. The `auth_style` field accepts `basic`, `bearer`, `header`, `query`, or `path`. When `auth_style` is `path`, set `path_template` to a URL path containing the `{credential}` placeholder exactly once (for example, `/v1/{credential}/resources`). Static credentials are exposed as placeholder environment variables and resolved in outbound HTTP requests only at their binding endpoints. Every static credential environment key receives the full profile endpoint set when the profile defines endpoints. An endpointless profile requires explicit sandbox policy bindings for each attached provider instance. Dynamic token grants are resolved by the sandbox proxy on demand for matching profile endpoints and support `bearer` or `header` placement. Credential environment variable names must not use the reserved `v<digits>_` prefix, such as `v10_GITHUB_TOKEN`, because OpenShell uses that namespace for revision-scoped placeholders.
 
 `discovery` controls what `--from-existing` scans when
 `providers_v2_enabled=true`. Each entry in `discovery.credentials` must name a
@@ -552,7 +595,7 @@ Use an ISO/RFC3339 timestamp or Unix epoch milliseconds. Use `0` as the timestam
 
 OpenShell skips expired provider credentials when it builds a sandbox provider environment. Running sandboxes also reject expired retained credential generations during placeholder resolution, so stale placeholders fail closed instead of forwarding unresolved or expired credential material.
 
-The gateway sends a complete host, port, and path binding for every emitted static credential key. It withholds static credential keys from endpointless selected profiles with their expiry and binding metadata. Supervisors reject other incomplete binding metadata and clear previously active provider material when a refresh fails validation. Refer to [Static Credential Endpoint Binding](#understand-static-credential-endpoint-binding) for matching, denial, lifecycle, and migration behavior.
+The gateway sends a complete host, port, and path binding for every emitted static credential key. It derives bindings from profile endpoints or explicit sandbox policy endpoints for endpointless profiles. It withholds static credential keys from endpointless selected profiles that have no explicit policy binding. Supervisors reject other incomplete binding metadata and clear previously active provider material when a refresh fails validation. Refer to [Static Credential Endpoint Binding](#understand-static-credential-endpoint-binding) for matching, denial, lifecycle, and migration behavior.
 
 ## Configure Credential Refresh
 

--- a/docs/sandboxes/providers-v2.mdx
+++ b/docs/sandboxes/providers-v2.mdx
@@ -131,12 +131,13 @@ the provider revokes resolution for placeholders already held by running
 processes.
 
 <Warning>
-Static credentials require a provider profile with at least one usable
-endpoint. If any attached static provider lacks complete binding metadata, the
-sandbox rejects the provider environment update and keeps no static provider
-credentials active. Import a custom profile, create a replacement provider
-whose `--type` is that profile ID, attach the replacement, and detach the
-profileless provider.
+Static credentials from a selected provider profile require at least one usable
+endpoint. OpenShell withholds only the static credential keys and associated
+expiry and binding metadata from an endpointless selected profile. It retains
+that provider's generated non-secret configuration and valid endpoint-bound
+static credentials from other attached providers. For a custom static
+credential, import a profile with the intended endpoint selectors and use that
+profile as the provider type.
 </Warning>
 
 After upgrading a gateway and supervisor to a release with endpoint binding,
@@ -551,7 +552,7 @@ Use an ISO/RFC3339 timestamp or Unix epoch milliseconds. Use `0` as the timestam
 
 OpenShell skips expired provider credentials when it builds a sandbox provider environment. Running sandboxes also reject expired retained credential generations during placeholder resolution, so stale placeholders fail closed instead of forwarding unresolved or expired credential material.
 
-The gateway sends a complete host, port, and path binding for every static credential key. Supervisors reject incomplete binding metadata and clear previously active provider material when a refresh fails validation. Refer to [Static Credential Endpoint Binding](#understand-static-credential-endpoint-binding) for matching, denial, lifecycle, and migration behavior.
+The gateway sends a complete host, port, and path binding for every emitted static credential key. It withholds static credential keys from endpointless selected profiles with their expiry and binding metadata. Supervisors reject other incomplete binding metadata and clear previously active provider material when a refresh fails validation. Refer to [Static Credential Endpoint Binding](#understand-static-credential-endpoint-binding) for matching, denial, lifecycle, and migration behavior.
 
 ## Configure Credential Refresh
 

--- a/docs/sandboxes/providers-v2.mdx
+++ b/docs/sandboxes/providers-v2.mdx
@@ -108,8 +108,8 @@ headers, Basic and Bearer authorization, URL paths, query parameters, opted-in
 request bodies, AWS SigV4 signing, and opted-in WebSocket text messages. Raw
 `tls: skip` and non-HTTP tunnels do not perform static credential substitution.
 
-If a request contains a known placeholder at a destination outside its binding,
-OpenShell returns HTTP 403 with this response:
+If an HTTP request contains a known placeholder at a destination outside its
+binding, OpenShell returns HTTP 403 with this response:
 
 ```json
 {"error":"credential_endpoint_mismatch","message":"Credential is not authorized for this request endpoint"}
@@ -119,6 +119,10 @@ The sandbox logs include the destination and
 `credential_endpoint_mismatch`. OCSF output includes both the denied activity
 and a detection finding. These events omit credential values, placeholders,
 environment keys, and query strings.
+
+For opted-in WebSocket text-message rewriting, the mismatch can occur after the
+HTTP 101 upgrade has completed. OpenShell closes that WebSocket with policy
+violation code 1008 instead of returning an HTTP response.
 
 Binding updates apply to both current and retained placeholder generations.
 Credential rotation keeps the current endpoint set. Updating a provider profile

--- a/docs/sandboxes/providers-v2.mdx
+++ b/docs/sandboxes/providers-v2.mdx
@@ -25,7 +25,7 @@ Providers v2 keeps those pieces together:
 | Custom provider definitions | You can export, edit, lint, import, list, and delete custom profiles. |
 | Runtime provider lifecycle | You can list, attach, and detach providers on existing sandboxes. |
 | Credential rotation | Provider refresh metadata lets the gateway refresh short-lived access tokens and update provider records. |
-| Backward compatibility | Credential delivery still uses environment placeholders and proxy rewrite. |
+| Credential transport | Credential delivery uses environment placeholders and proxy rewrite. Static placeholders resolve only at profile endpoints. |
 
 ## Enable Providers v2
 
@@ -64,6 +64,82 @@ Providers v2 currently includes these user-facing features:
 - Credential expiry metadata with `openshell provider update --credential-expires-at`; values accept Unix epoch milliseconds or ISO/RFC3339 timestamps.
 - Dynamic token grants that use the sandbox's SPIFFE JWT-SVID as an OAuth2 client assertion and inject short-lived tokens into supported headers for matching profile endpoints.
 - Endpoint-bound static credential placeholders. The sandbox proxy resolves a static credential only for request hosts, ports, and paths declared by its provider profile.
+
+## Understand Static Credential Endpoint Binding
+
+Static credential endpoint binding prevents a placeholder for one service from
+resolving on a different policy-allowed service. OpenShell associates every
+static credential environment key with the endpoints in its provider profile.
+The proxy checks that association before it substitutes the real value.
+
+A request can use a static credential only when all of these checks pass:
+
+| Check | Configuration source |
+|---|---|
+| The placeholder belongs to the current attached provider state. | Sandbox provider attachment and current provider record. |
+| The calling binary and destination are allowed. | Effective sandbox network policy. |
+| The host, port, and canonical request path match the credential binding. | Provider profile endpoints. |
+| The HTTP method, path, or protocol operation is allowed when L7 inspection is configured. | Effective sandbox network policy. |
+| The credential has not expired. | Provider credential expiry metadata. |
+
+Network policy and credential binding serve different purposes. Network policy
+authorizes traffic. Provider profile endpoints authorize use of the provider's
+credentials. A sandbox policy allow cannot widen a credential binding, and a
+credential binding cannot widen sandbox network policy.
+
+For example, this profile endpoint binds all static credential environment keys
+from the profile to `api.example.com:443` under `/v1`:
+
+```yaml showLineNumbers={false}
+endpoints:
+  - host: api.example.com
+    port: 443
+    path: /v1/**
+```
+
+The path `/v1/**` matches `/v1` and its descendants. An empty path, `**`, or
+`/**` matches every path on the selected host and port. Other path values use
+glob matching. OpenShell removes the query string and uses a canonical,
+secret-redacted path for this check, so a credential embedded in a request path
+does not need to be revealed before authorization.
+
+The binding applies to CONNECT and forward-proxy HTTP requests, including
+headers, Basic and Bearer authorization, URL paths, query parameters, opted-in
+request bodies, AWS SigV4 signing, and opted-in WebSocket text messages. Raw
+`tls: skip` and non-HTTP tunnels do not perform static credential substitution.
+
+If a request contains a known placeholder at a destination outside its binding,
+OpenShell returns HTTP 403 with this response:
+
+```json
+{"error":"credential_endpoint_mismatch","message":"Credential is not authorized for this request endpoint"}
+```
+
+The sandbox logs include the destination and
+`credential_endpoint_mismatch`. OCSF output includes both the denied activity
+and a detection finding. These events omit credential values, placeholders,
+environment keys, and query strings.
+
+Binding updates apply to both current and retained placeholder generations.
+Credential rotation keeps the current endpoint set. Updating a provider profile
+changes the binding on the next sandbox provider-environment sync, and detaching
+the provider revokes resolution for placeholders already held by running
+processes.
+
+<Warning>
+Static credentials require a provider profile with at least one usable
+endpoint. If any attached static provider lacks complete binding metadata, the
+sandbox rejects the provider environment update and keeps no static provider
+credentials active. Import a custom profile, create a replacement provider
+whose `--type` is that profile ID, attach the replacement, and detach the
+profileless provider.
+</Warning>
+
+After upgrading a gateway and supervisor to a release with endpoint binding,
+restart or recreate older running sandboxes. A new gateway withholds static
+credential material from supervisors that do not advertise binding support.
+Rotate attached static credentials after upgrading when an older sandbox may
+have received their real values.
 
 ## Roadmap
 
@@ -285,7 +361,7 @@ binaries:
 
 `category` groups profiles in `openshell provider list-profiles`. Use one of the values in the category enum.
 
-`credentials` declares the credential names, environment variables, auth metadata, optional refresh metadata, and optional dynamic token grant metadata for the provider type. The `auth_style` field accepts `basic`, `bearer`, `header`, `query`, or `path`. When `auth_style` is `path`, set `path_template` to a URL path containing the `{credential}` placeholder exactly once (for example, `/v1/{credential}/resources`). Static credentials are exposed as placeholder environment variables and resolved in outbound HTTP requests. Dynamic token grants are resolved by the sandbox proxy on demand for matching profile endpoints and support `bearer` or `header` placement. Credential environment variable names must not use the reserved `v<digits>_` prefix, such as `v10_GITHUB_TOKEN`, because OpenShell uses that namespace for revision-scoped placeholders.
+`credentials` declares the credential names, environment variables, auth metadata, optional refresh metadata, and optional dynamic token grant metadata for the provider type. The `auth_style` field accepts `basic`, `bearer`, `header`, `query`, or `path`. When `auth_style` is `path`, set `path_template` to a URL path containing the `{credential}` placeholder exactly once (for example, `/v1/{credential}/resources`). Static credentials are exposed as placeholder environment variables and resolved in outbound HTTP requests only at profile endpoints. Every static credential environment key currently receives the full profile endpoint set. Dynamic token grants are resolved by the sandbox proxy on demand for matching profile endpoints and support `bearer` or `header` placement. Credential environment variable names must not use the reserved `v<digits>_` prefix, such as `v10_GITHUB_TOKEN`, because OpenShell uses that namespace for revision-scoped placeholders.
 
 `discovery` controls what `--from-existing` scans when
 `providers_v2_enabled=true`. Each entry in `discovery.credentials` must name a
@@ -471,7 +547,7 @@ Use an ISO/RFC3339 timestamp or Unix epoch milliseconds. Use `0` as the timestam
 
 OpenShell skips expired provider credentials when it builds a sandbox provider environment. Running sandboxes also reject expired retained credential generations during placeholder resolution, so stale placeholders fail closed instead of forwarding unresolved or expired credential material.
 
-The gateway sends a complete host, port, and path binding for every static credential key. Supervisors reject incomplete binding metadata and clear previously active provider material when a refresh fails validation. A credential used at a different endpoint returns HTTP 403 and produces secret-safe security telemetry.
+The gateway sends a complete host, port, and path binding for every static credential key. Supervisors reject incomplete binding metadata and clear previously active provider material when a refresh fails validation. Refer to [Static Credential Endpoint Binding](#understand-static-credential-endpoint-binding) for matching, denial, lifecycle, and migration behavior.
 
 ## Configure Credential Refresh
 

--- a/docs/sandboxes/providers-v2.mdx
+++ b/docs/sandboxes/providers-v2.mdx
@@ -35,7 +35,7 @@ Provider profile policy composition is controlled by the gateway-level `provider
 openshell settings set --global --key providers_v2_enabled --value true
 ```
 
-When the setting is disabled or unset, providers keep the existing credential-only behavior. Sandboxes still receive provider credential placeholders, but attached provider profiles do not add network policy entries to the effective policy.
+When the setting is disabled or unset, attached provider profiles do not add network policy entries to the effective policy. Static provider credential placeholders still use the profile endpoints as a resolution boundary.
 
 To disable provider profile policy composition, delete the setting:
 
@@ -44,7 +44,7 @@ openshell settings delete --global --key providers_v2_enabled
 ```
 
 <Note>
-The feature flag controls provider-derived policy layers. OpenShell still supports placeholder environment variables for provider credentials, and provider profiles can also declare dynamic token grants that the sandbox proxy resolves on demand for matching HTTP endpoints.
+The feature flag controls provider-derived policy layers. It does not disable endpoint binding for static credential placeholders. Provider profiles can also declare dynamic token grants that the sandbox proxy resolves on demand for matching HTTP endpoints.
 </Note>
 
 ## Available Features
@@ -63,6 +63,7 @@ Providers v2 currently includes these user-facing features:
 - Credential refresh configuration with `openshell provider refresh status|configure|rotate|delete`.
 - Credential expiry metadata with `openshell provider update --credential-expires-at`; values accept Unix epoch milliseconds or ISO/RFC3339 timestamps.
 - Dynamic token grants that use the sandbox's SPIFFE JWT-SVID as an OAuth2 client assertion and inject short-lived tokens into supported headers for matching profile endpoints.
+- Endpoint-bound static credential placeholders. The sandbox proxy resolves a static credential only for request hosts, ports, and paths declared by its provider profile.
 
 ## Roadmap
 
@@ -71,7 +72,7 @@ The following Providers v2 design items are not part of the current behavior:
 | Roadmap item | Current behavior |
 |---|---|
 | General profile-driven credential placement | Static `auth_style`, `header_name`, `query_param`, and `path_template` placement metadata is stored and validated, but static credential injection still depends on environment placeholders generated from provider credentials. Dynamic `token_grant` credentials support `bearer` and `header` placement for matching HTTP endpoints. |
-| Endpoint and binary scoped credential injection | Provider profile endpoints and binaries affect policy composition. Dynamic token grants are endpoint-scoped. Static placeholder injection is not yet restricted by profile endpoint or binary metadata. |
+| Binary-scoped credential injection | Provider profile binaries affect policy composition but do not yet restrict placeholder resolution by calling binary. Static and dynamic credentials are endpoint-scoped. |
 | Credential verification on create | `openshell provider create` does not yet probe provider verification endpoints or expose `--no-verify`. |
 | Automatic credential scope extraction | OpenShell does not yet inspect upstream provider responses to discover credential scopes. |
 | Inference mounting from attached providers | `inference_capable` is profile metadata. Attaching an inference-capable provider does not yet create `inference.local` routes. |
@@ -470,6 +471,8 @@ Use an ISO/RFC3339 timestamp or Unix epoch milliseconds. Use `0` as the timestam
 
 OpenShell skips expired provider credentials when it builds a sandbox provider environment. Running sandboxes also reject expired retained credential generations during placeholder resolution, so stale placeholders fail closed instead of forwarding unresolved or expired credential material.
 
+The gateway sends a complete host, port, and path binding for every static credential key. Supervisors reject incomplete binding metadata and clear previously active provider material when a refresh fails validation. A credential used at a different endpoint returns HTTP 403 and produces secret-safe security telemetry.
+
 ## Configure Credential Refresh
 
 Refresh configuration is stored separately from the current injectable credential value. The gateway refresh worker reads refresh state, mints a new short-lived token for supported strategies, writes the token back to the provider record, and updates credential expiry metadata.
@@ -610,7 +613,7 @@ openshell sandbox create \
   -- claude
 ```
 
-When `providers_v2_enabled=true`, each attached provider with a matching profile contributes a provider policy layer to the sandbox effective policy. The base policy is the user-authored sandbox policy that you can edit and apply. The effective policy is the composed policy that the sandbox enforces: base policy plus provider policy layers. When the setting is disabled, the sandbox receives provider credentials but not provider-derived policy entries.
+When `providers_v2_enabled=true`, each attached provider with a matching profile contributes a provider policy layer to the sandbox effective policy. The base policy is the user-authored sandbox policy that you can edit and apply. The effective policy is the composed policy that the sandbox enforces: base policy plus provider policy layers. When the setting is disabled, the sandbox still receives endpoint-bound provider credentials but not provider-derived policy entries.
 
 Updating a custom provider profile affects every provider instance whose `type` matches that profile ID. Provider instances are not rewritten, and sandbox-authored policies are not modified. Running sandboxes observe the updated provider-derived policy on their next config sync. If a gateway-global policy is active, provider-derived policy layers remain suppressed.
 
@@ -755,9 +758,9 @@ Provider attach and detach update the persisted sandbox provider list. Running s
 
 The policy effect applies to future effective policy reads after the sandbox observes the update. The credential environment effect applies only to new process launches after the update is observed, such as later SSH, exec, or SFTP sessions.
 
-Already-running processes keep the environment they started with. OpenShell does not mutate a live process environment after provider attach, detach, or credential update. If a long-running process needs a newly attached provider credential placeholder, restart that process or launch a new process after the sandbox has observed the provider update.
+Already-running processes keep the placeholder environment they started with. OpenShell does not mutate a live process environment after provider attach, detach, or credential update. The proxy resolves existing placeholders against current credentials and bindings, so rotation, expiry, endpoint changes, and detach take effect without restarting the process. If a long-running process needs a newly attached provider credential placeholder, restart that process or launch a new process after the sandbox has observed the provider update.
 
-Detaching a provider removes its provider policy layer from future effective policy reads and removes its credential placeholders from future process environments. It does not remove environment variables from already-running processes.
+Detaching a provider removes its provider policy layer from future effective policy reads, revokes resolution for its existing placeholders, and removes its credential placeholders from future process environments. It does not remove the placeholder strings from already-running process environments.
 
 OpenShell rejects provider updates and refresh configuration when they would make two providers attached to the same sandbox expose the same active credential environment key. It also rejects attached provider sets with ambiguous dynamic token grants at equal host/path specificity. Use provider-specific credential names and make one dynamic grant selector more specific when one sandbox needs multiple providers with overlapping upstream concepts.
 

--- a/e2e/python/test_sandbox_policy.py
+++ b/e2e/python/test_sandbox_policy.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+import grpc
 import pytest
 
 from openshell._proto import datamodel_pb2, sandbox_pb2
@@ -1960,8 +1961,8 @@ def test_overlapping_policies_with_conflicting_destination_metadata_are_rejected
     """OVL-1: Conflicting metadata on the same host:port fails closed.
 
     One endpoint permits any resolved address while the other constrains
-    ``allowed_ips``. The complete candidate is ambiguous and must not activate
-    either entry.
+    ``allowed_ips``. The complete candidate is ambiguous and must be rejected
+    before the sandbox is provisioned.
     """
     policy = _base_policy(
         network_policies={
@@ -1989,16 +1990,16 @@ def test_overlapping_policies_with_conflicting_destination_metadata_are_rejected
         },
     )
     spec = datamodel_pb2.SandboxSpec(policy=policy)
-    with sandbox(spec=spec, delete_on_exit=True) as sb:
-        result = sb.exec_python(
-            _forward_proxy_with_server(),
-            args=(_PROXY_HOST, _PROXY_PORT, _SANDBOX_IP, _FORWARD_PROXY_PORT),
-        )
-        assert result.exit_code == 0, result.stderr
-        assert "403" in result.stdout, (
-            "Conflicting overlapping policies should fail closed; "
-            f"expected 403, got: {result.stdout}"
-        )
+    with (
+        pytest.raises(grpc.RpcError) as exc_info,
+        sandbox(spec=spec, delete_on_exit=True),
+    ):
+        pytest.fail("ambiguous policy unexpectedly created a sandbox")
+
+    assert exc_info.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+    details = exc_info.value.details() or ""
+    assert "network endpoint ambiguity validation failed" in details
+    assert "allowed_ips" in details
 
 
 def test_overlapping_policies_l7_connect_does_not_crash(

--- a/e2e/python/test_sandbox_policy.py
+++ b/e2e/python/test_sandbox_policy.py
@@ -319,7 +319,11 @@ def _proxy_connect_then_http_with_server():
                     {"connect_status": connect_resp.strip(), "http_status": 0}
                 )
 
-            request = f"{method} {path} HTTP/1.1\r\nHost: {target_host}\r\nConnection: close\r\n\r\n"
+            request = (
+                f"{method} {path} HTTP/1.1\r\n"
+                f"Host: {target_host}:{target_port}\r\n"
+                "Connection: close\r\n\r\n"
+            )
             conn.sendall(request.encode())
 
             data = b""

--- a/e2e/python/test_sandbox_providers.py
+++ b/e2e/python/test_sandbox_providers.py
@@ -229,6 +229,52 @@ def test_profileless_provider_credentials_fail_closed(
             assert url == "NOT_SET"
 
 
+def test_endpointless_profile_credentials_use_explicit_policy_binding(
+    sandbox: Callable[..., Sandbox],
+    sandbox_client: SandboxClient,
+) -> None:
+    """An endpointless profile emits credentials only with an explicit binding."""
+    with provider(
+        sandbox_client._stub,
+        name="e2e-test-google-cloud-policy-binding",
+        provider_type="google-cloud",
+        credentials={"GCP_ADC_ACCESS_TOKEN": "gcp-e2e-token"},
+    ) as provider_name:
+        policy = _default_policy()
+        policy.network_policies["gcp_storage"].CopyFrom(
+            sandbox_pb2.NetworkPolicyRule(
+                name="gcp_storage",
+                endpoints=[
+                    sandbox_pb2.NetworkEndpoint(
+                        host="storage.googleapis.com",
+                        port=443,
+                        protocol="rest",
+                        access="full",
+                        credential_binding=sandbox_pb2.NetworkCredentialBinding(
+                            provider=provider_name
+                        ),
+                    )
+                ],
+            )
+        )
+        spec = datamodel_pb2.SandboxSpec(
+            policy=policy,
+            providers=[provider_name],
+        )
+
+        def read_gcp_token() -> str:
+            import os
+
+            return os.environ.get("GCP_ADC_ACCESS_TOKEN", "NOT_SET")
+
+        with sandbox(spec=spec, delete_on_exit=True) as sb:
+            result = sb.exec_python(read_gcp_token)
+            assert result.exit_code == 0, result.stderr
+            assert _is_placeholder_for_env_key(
+                result.stdout.strip(), "GCP_ADC_ACCESS_TOKEN"
+            )
+
+
 def test_nvidia_provider_injects_nvidia_api_key_env_var(
     sandbox: Callable[..., Sandbox],
     sandbox_client: SandboxClient,

--- a/e2e/python/test_sandbox_providers.py
+++ b/e2e/python/test_sandbox_providers.py
@@ -195,11 +195,11 @@ def test_provider_credentials_available_as_env_vars(
             assert value != "sk-e2e-test-key-12345"
 
 
-def test_generic_provider_credentials_available_as_env_vars(
+def test_profileless_provider_credentials_fail_closed(
     sandbox: Callable[..., Sandbox],
     sandbox_client: SandboxClient,
 ) -> None:
-    """Generic provider env vars are placeholders, not raw secrets."""
+    """Profileless credentials are withheld because they have no endpoint binding."""
     with provider(
         sandbox_client._stub,
         name="e2e-test-generic-provider-env",
@@ -225,8 +225,8 @@ def test_generic_provider_credentials_available_as_env_vars(
             result = sb.exec_python(read_generic_env_vars)
             assert result.exit_code == 0, result.stderr
             token, url = result.stdout.strip().split("|")
-            assert _is_placeholder_for_env_key(token, "CUSTOM_SERVICE_TOKEN")
-            assert _is_placeholder_for_env_key(url, "CUSTOM_SERVICE_URL")
+            assert token == "NOT_SET"
+            assert url == "NOT_SET"
 
 
 def test_nvidia_provider_injects_nvidia_api_key_env_var(
@@ -269,15 +269,15 @@ def test_attach_detach_updates_credentials_for_later_exec_launches(
     with provider(
         stub,
         name=provider_name,
-        provider_type="generic",
-        credentials={"CUSTOM_ATTACH_TOKEN": "token-attach-detach"},
+        provider_type="nvidia",
+        credentials={"NVIDIA_API_KEY": "token-attach-detach"},
     ):
         spec = datamodel_pb2.SandboxSpec(policy=_default_policy(), providers=[])
 
         def read_attach_token() -> str:
             import os
 
-            return os.environ.get("CUSTOM_ATTACH_TOKEN", "NOT_SET")
+            return os.environ.get("NVIDIA_API_KEY", "NOT_SET")
 
         def exec_token(sb: Sandbox) -> str:
             result = sb.exec_python(read_attach_token)
@@ -292,7 +292,7 @@ def test_attach_detach_updates_credentials_for_later_exec_launches(
                 if expected == "NOT_SET":
                     matched = last == expected
                 else:
-                    matched = _is_placeholder_for_env_key(last, "CUSTOM_ATTACH_TOKEN")
+                    matched = _is_placeholder_for_env_key(last, "NVIDIA_API_KEY")
                 if matched:
                     return
                 time.sleep(2)
@@ -310,7 +310,7 @@ def test_attach_detach_updates_credentials_for_later_exec_launches(
                 )
                 wait_for_token(
                     sb,
-                    "openshell:resolve:env:CUSTOM_ATTACH_TOKEN",
+                    "openshell:resolve:env:NVIDIA_API_KEY",
                 )
 
                 stub.DetachSandboxProvider(

--- a/e2e/python/test_sandbox_providers.py
+++ b/e2e/python/test_sandbox_providers.py
@@ -229,6 +229,33 @@ def test_profileless_provider_credentials_fail_closed(
             assert url == "NOT_SET"
 
 
+def test_endpointless_profile_credentials_fail_closed_without_policy_binding(
+    sandbox: Callable[..., Sandbox],
+    sandbox_client: SandboxClient,
+) -> None:
+    """Endpointless profile credentials are withheld without an explicit binding."""
+    with provider(
+        sandbox_client._stub,
+        name="e2e-test-google-cloud-without-policy-binding",
+        provider_type="google-cloud",
+        credentials={"GCP_ADC_ACCESS_TOKEN": "gcp-e2e-token"},
+    ) as provider_name:
+        spec = datamodel_pb2.SandboxSpec(
+            policy=_default_policy(),
+            providers=[provider_name],
+        )
+
+        def read_gcp_token() -> str:
+            import os
+
+            return os.environ.get("GCP_ADC_ACCESS_TOKEN", "NOT_SET")
+
+        with sandbox(spec=spec, delete_on_exit=True) as sb:
+            result = sb.exec_python(read_gcp_token)
+            assert result.exit_code == 0, result.stderr
+            assert result.stdout.strip() == "NOT_SET"
+
+
 def test_endpointless_profile_credentials_use_explicit_policy_binding(
     sandbox: Callable[..., Sandbox],
     sandbox_client: SandboxClient,

--- a/e2e/rust/tests/host_gateway_alias.rs
+++ b/e2e/rust/tests/host_gateway_alias.rs
@@ -9,7 +9,7 @@ use std::sync::Mutex;
 
 use openshell_e2e::harness::binary::openshell_cmd;
 use openshell_e2e::harness::sandbox::SandboxGuard;
-use tempfile::NamedTempFile;
+use tempfile::{Builder as TempFileBuilder, NamedTempFile};
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
@@ -157,7 +157,10 @@ fn write_binding_profile(
     host: &str,
     port: u16,
 ) -> Result<NamedTempFile, String> {
-    let mut file = NamedTempFile::new().map_err(|e| format!("create provider profile: {e}"))?;
+    let mut file = TempFileBuilder::new()
+        .suffix(".yaml")
+        .tempfile()
+        .map_err(|e| format!("create provider profile: {e}"))?;
     let profile = format!(
         r#"id: {id}
 display_name: {display_name}
@@ -208,13 +211,13 @@ network_policies:
     endpoints:
       - host: host.openshell.internal
         port: {port}
-        allowed_ips: ["10.0.0.0/8", "172.0.0.0/8", "192.168.0.0/16", "fc00::/7"]
+        path: /allowed/**
         protocol: rest
         access: full
         enforcement: enforce
       - host: host.docker.internal
         port: {port}
-        allowed_ips: ["10.0.0.0/8", "172.0.0.0/8", "192.168.0.0/16", "fc00::/7"]
+        path: /allowed/**
         protocol: rest
         access: full
         enforcement: enforce
@@ -447,12 +450,18 @@ async fn static_provider_credentials_are_bound_to_profile_endpoints() {
     .await
     .expect("run endpoint-binding requests");
 
+    let logs = wait_for_sandbox_logs(&guard.name, |logs| {
+        logs.contains("openshell.provider_credential.endpoint_mismatch")
+            && logs.contains("credential_endpoint_mismatch")
+    })
+    .await
+    .expect("fetch endpoint mismatch logs");
     assert!(
         guard
             .create_output
             .contains(r#"ALLOWED={"authorized":true}"#),
-        "credential should resolve at the bound endpoint:\n{}",
-        guard.create_output
+        "credential should resolve at the bound endpoint:\n{}\nlogs:\n{logs}",
+        guard.create_output,
     );
     assert!(
         guard.create_output.contains("DENIED=403"),
@@ -460,12 +469,6 @@ async fn static_provider_credentials_are_bound_to_profile_endpoints() {
         guard.create_output
     );
 
-    let logs = wait_for_sandbox_logs(&guard.name, |logs| {
-        logs.contains("openshell.provider_credential.endpoint_mismatch")
-            && logs.contains("credential_endpoint_mismatch")
-    })
-    .await
-    .expect("fetch endpoint mismatch logs");
     assert!(
         logs.contains("openshell.provider_credential.endpoint_mismatch")
             && logs.contains("credential_endpoint_mismatch"),

--- a/e2e/rust/tests/host_gateway_alias.rs
+++ b/e2e/rust/tests/host_gateway_alias.rs
@@ -17,6 +17,10 @@ use tokio::task::JoinHandle;
 
 const INFERENCE_PROVIDER_NAME: &str = "e2e-host-inference";
 const INFERENCE_PROVIDER_UNREACHABLE_NAME: &str = "e2e-host-inference-unreachable";
+const BINDING_PROVIDER_A_NAME: &str = "e2e-static-endpoint-binding-provider-a";
+const BINDING_PROVIDER_B_NAME: &str = "e2e-static-endpoint-binding-provider-b";
+const BINDING_PROFILE_A_ID: &str = "e2e-static-endpoint-binding-a";
+const BINDING_PROFILE_B_ID: &str = "e2e-static-endpoint-binding-b";
 static INFERENCE_ROUTE_LOCK: Mutex<()> = Mutex::new(());
 
 async fn run_cli(args: &[&str]) -> Result<String, String> {
@@ -43,6 +47,36 @@ async fn run_cli(args: &[&str]) -> Result<String, String> {
     Ok(combined)
 }
 
+async fn wait_for_sandbox_logs(
+    sandbox_name: &str,
+    expected: impl Fn(&str) -> bool,
+) -> Result<String, String> {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+
+    loop {
+        let logs = run_cli(&[
+            "logs",
+            sandbox_name,
+            "-n",
+            "500",
+            "--since",
+            "2m",
+            "--source",
+            "sandbox",
+        ])
+        .await?;
+        if expected(&logs) {
+            return Ok(logs);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!(
+                "timed out waiting for expected sandbox logs:\n{logs}"
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+}
+
 struct HostServer {
     port: u16,
     task: JoinHandle<()>,
@@ -50,6 +84,13 @@ struct HostServer {
 
 impl HostServer {
     async fn start(response_body: &str) -> Result<Self, String> {
+        Self::start_with_auth_check(response_body, None).await
+    }
+
+    async fn start_with_auth_check(
+        response_body: &str,
+        expected_authorization: Option<&str>,
+    ) -> Result<Self, String> {
         let listener = TcpListener::bind(("0.0.0.0", 0))
             .await
             .map_err(|e| format!("bind host test server: {e}"))?;
@@ -58,12 +99,14 @@ impl HostServer {
             .map_err(|e| format!("read host test server address: {e}"))?
             .port();
         let response_body = response_body.as_bytes().to_vec();
+        let expected_authorization = expected_authorization.map(str::to_string);
         let task = tokio::spawn(async move {
             loop {
                 let Ok((mut stream, _)) = listener.accept().await else {
                     break;
                 };
                 let body = response_body.clone();
+                let expected_authorization = expected_authorization.clone();
                 tokio::spawn(async move {
                     let mut request = Vec::new();
                     let mut buf = [0_u8; 1024];
@@ -80,6 +123,16 @@ impl HostServer {
                         }
                     }
 
+                    let body = expected_authorization.map_or(body, |expected| {
+                        let request = String::from_utf8_lossy(&request);
+                        format!(
+                            r#"{{"authorized":{}}}"#,
+                            request.lines().any(|line| {
+                                line.eq_ignore_ascii_case(&format!("Authorization: {expected}"))
+                            })
+                        )
+                        .into_bytes()
+                    });
                     let response = format!(
                         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
                         body.len()
@@ -95,6 +148,85 @@ impl HostServer {
 
         Ok(Self { port, task })
     }
+}
+
+fn write_binding_profile(
+    id: &str,
+    display_name: &str,
+    env_var: &str,
+    host: &str,
+    port: u16,
+) -> Result<NamedTempFile, String> {
+    let mut file = NamedTempFile::new().map_err(|e| format!("create provider profile: {e}"))?;
+    let profile = format!(
+        r#"id: {id}
+display_name: {display_name}
+category: other
+credentials:
+  - name: bound_token
+    env_vars: [{env_var}]
+    required: true
+    auth_style: bearer
+    header_name: authorization
+endpoints:
+  - host: {host}
+    port: {port}
+    path: /allowed/**
+    protocol: rest
+    access: full
+    enforcement: enforce
+binaries: [/usr/bin/curl]
+"#
+    );
+    file.write_all(profile.as_bytes())
+        .map_err(|e| format!("write provider profile: {e}"))?;
+    file.flush()
+        .map_err(|e| format!("flush provider profile: {e}"))?;
+    Ok(file)
+}
+
+fn write_binding_policy(port: u16) -> Result<NamedTempFile, String> {
+    let mut file = NamedTempFile::new().map_err(|e| format!("create binding policy: {e}"))?;
+    let policy = format!(
+        r#"version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only: [/usr, /lib, /proc, /dev/urandom, /app, /etc, /var/log]
+  read_write: [/sandbox, /tmp, /dev/null]
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  binding_test:
+    name: binding_test
+    endpoints:
+      - host: host.openshell.internal
+        port: {port}
+        allowed_ips: ["10.0.0.0/8", "172.0.0.0/8", "192.168.0.0/16", "fc00::/7"]
+        protocol: rest
+        access: full
+        enforcement: enforce
+      - host: host.docker.internal
+        port: {port}
+        allowed_ips: ["10.0.0.0/8", "172.0.0.0/8", "192.168.0.0/16", "fc00::/7"]
+        protocol: rest
+        access: full
+        enforcement: enforce
+    binaries:
+      - path: /usr/bin/curl
+"#
+    );
+    file.write_all(policy.as_bytes())
+        .map_err(|e| format!("write binding policy: {e}"))?;
+    file.flush()
+        .map_err(|e| format!("flush binding policy: {e}"))?;
+    Ok(file)
 }
 
 impl Drop for HostServer {
@@ -118,6 +250,17 @@ async fn delete_provider(name: &str) {
     cmd.arg("provider")
         .arg("delete")
         .arg(name)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let _ = cmd.status().await;
+}
+
+async fn delete_provider_profile(id: &str) {
+    let mut cmd = openshell_cmd();
+    cmd.arg("provider")
+        .arg("profile")
+        .arg("delete")
+        .arg(id)
         .stdout(Stdio::null())
         .stderr(Stdio::null());
     let _ = cmd.status().await;
@@ -221,6 +364,126 @@ async fn sandbox_reaches_host_openshell_internal_via_host_gateway_alias() {
         "expected sandbox to receive host echo response:\n{}",
         guard.create_output
     );
+}
+
+#[tokio::test]
+async fn static_provider_credentials_are_bound_to_profile_endpoints() {
+    let server = HostServer::start_with_auth_check("", Some("Bearer e2e-bound-secret"))
+        .await
+        .expect("start credential echo server");
+    let profile_a = write_binding_profile(
+        BINDING_PROFILE_A_ID,
+        "E2E static endpoint binding A",
+        "BOUND_TOKEN_A",
+        "host.openshell.internal",
+        server.port,
+    )
+    .expect("write provider A binding profile");
+    let profile_b = write_binding_profile(
+        BINDING_PROFILE_B_ID,
+        "E2E static endpoint binding B",
+        "BOUND_TOKEN_B",
+        "host.docker.internal",
+        server.port,
+    )
+    .expect("write provider B binding profile");
+    let policy = write_binding_policy(server.port).expect("write binding policy");
+    let profile_a_path = profile_a.path().to_string_lossy().into_owned();
+    let profile_b_path = profile_b.path().to_string_lossy().into_owned();
+    let policy_path = policy.path().to_string_lossy().into_owned();
+
+    delete_provider(BINDING_PROVIDER_A_NAME).await;
+    delete_provider(BINDING_PROVIDER_B_NAME).await;
+    delete_provider_profile(BINDING_PROFILE_A_ID).await;
+    delete_provider_profile(BINDING_PROFILE_B_ID).await;
+    run_cli(&["provider", "profile", "import", "--file", &profile_a_path])
+        .await
+        .expect("import provider A endpoint-binding profile");
+    run_cli(&["provider", "profile", "import", "--file", &profile_b_path])
+        .await
+        .expect("import provider B endpoint-binding profile");
+    run_cli(&[
+        "provider",
+        "create",
+        "--name",
+        BINDING_PROVIDER_A_NAME,
+        "--type",
+        BINDING_PROFILE_A_ID,
+        "--credential",
+        "BOUND_TOKEN_A=e2e-bound-secret",
+    ])
+    .await
+    .expect("create endpoint-bound provider A");
+    run_cli(&[
+        "provider",
+        "create",
+        "--name",
+        BINDING_PROVIDER_B_NAME,
+        "--type",
+        BINDING_PROFILE_B_ID,
+        "--credential",
+        "BOUND_TOKEN_B=e2e-provider-b-secret",
+    ])
+    .await
+    .expect("create endpoint-bound provider B");
+
+    let command = format!(
+        r#"allowed=$(curl --silent --show-error --max-time 15 -H "Authorization: Bearer $BOUND_TOKEN_A" http://host.openshell.internal:{}/allowed/check); denied=$(curl --silent --show-error --max-time 15 -o /tmp/denied-body -w "%{{http_code}}" -H "Authorization: Bearer $BOUND_TOKEN_A" http://host.docker.internal:{}/allowed/check); printf 'ALLOWED=%s DENIED=%s\n' "$allowed" "$denied""#,
+        server.port, server.port
+    );
+    let mut guard = SandboxGuard::create(&[
+        "--policy",
+        &policy_path,
+        "--provider",
+        BINDING_PROVIDER_A_NAME,
+        "--provider",
+        BINDING_PROVIDER_B_NAME,
+        "--no-auto-providers",
+        "--",
+        "sh",
+        "-c",
+        &command,
+    ])
+    .await
+    .expect("run endpoint-binding requests");
+
+    assert!(
+        guard
+            .create_output
+            .contains(r#"ALLOWED={"authorized":true}"#),
+        "credential should resolve at the bound endpoint:\n{}",
+        guard.create_output
+    );
+    assert!(
+        guard.create_output.contains("DENIED=403"),
+        "same placeholder must be denied at an unbound host:\n{}",
+        guard.create_output
+    );
+
+    let logs = wait_for_sandbox_logs(&guard.name, |logs| {
+        logs.contains("openshell.provider_credential.endpoint_mismatch")
+            && logs.contains("credential_endpoint_mismatch")
+    })
+    .await
+    .expect("fetch endpoint mismatch logs");
+    assert!(
+        logs.contains("openshell.provider_credential.endpoint_mismatch")
+            && logs.contains("credential_endpoint_mismatch"),
+        "OCSF logs should explain the endpoint-binding denial without secret material:\n{logs}"
+    );
+    assert!(
+        !logs.contains("e2e-bound-secret")
+            && !logs.contains("e2e-provider-b-secret")
+            && !logs.contains("BOUND_TOKEN_A")
+            && !logs.contains("BOUND_TOKEN_B"),
+        "OCSF logs must not contain credential values or environment keys:\n{logs}"
+    );
+
+    guard.cleanup().await;
+    delete_provider(BINDING_PROVIDER_A_NAME).await;
+    delete_provider(BINDING_PROVIDER_B_NAME).await;
+    delete_provider_profile(BINDING_PROFILE_A_ID).await;
+    delete_provider_profile(BINDING_PROFILE_B_ID).await;
 }
 
 #[tokio::test]

--- a/e2e/rust/tests/host_gateway_alias.rs
+++ b/e2e/rust/tests/host_gateway_alias.rs
@@ -211,13 +211,13 @@ network_policies:
     endpoints:
       - host: host.openshell.internal
         port: {port}
-        path: /allowed/**
+        path: /**
         protocol: rest
         access: full
         enforcement: enforce
       - host: host.docker.internal
         port: {port}
-        path: /allowed/**
+        path: /**
         protocol: rest
         access: full
         enforcement: enforce
@@ -431,8 +431,8 @@ async fn static_provider_credentials_are_bound_to_profile_endpoints() {
     .expect("create endpoint-bound provider B");
 
     let command = format!(
-        r#"allowed=$(curl --silent --show-error --max-time 15 -H "Authorization: Bearer $BOUND_TOKEN_A" http://host.openshell.internal:{}/allowed/check); denied=$(curl --silent --show-error --max-time 15 -o /tmp/denied-body -w "%{{http_code}}" -H "Authorization: Bearer $BOUND_TOKEN_A" http://host.docker.internal:{}/allowed/check); printf 'ALLOWED=%s DENIED=%s\n' "$allowed" "$denied""#,
-        server.port, server.port
+        r#"allowed=$(curl --silent --show-error --max-time 15 -H "Authorization: Bearer $BOUND_TOKEN_A" http://host.openshell.internal:{}/allowed/check); host_denied=$(curl --silent --show-error --max-time 15 -o /tmp/host-denied-body -w "%{{http_code}}" -H "Authorization: Bearer $BOUND_TOKEN_A" http://host.docker.internal:{}/allowed/check); path_denied=$(curl --silent --show-error --max-time 15 -o /tmp/path-denied-body -w "%{{http_code}}" -H "Authorization: Bearer $BOUND_TOKEN_A" http://host.openshell.internal:{}/other/check); printf 'ALLOWED=%s HOST_DENIED=%s PATH_DENIED=%s\n' "$allowed" "$host_denied" "$path_denied""#,
+        server.port, server.port, server.port
     );
     let mut guard = SandboxGuard::create(&[
         "--policy",
@@ -464,8 +464,13 @@ async fn static_provider_credentials_are_bound_to_profile_endpoints() {
         guard.create_output,
     );
     assert!(
-        guard.create_output.contains("DENIED=403"),
+        guard.create_output.contains("HOST_DENIED=403"),
         "same placeholder must be denied at an unbound host:\n{}",
+        guard.create_output
+    );
+    assert!(
+        guard.create_output.contains("PATH_DENIED=403"),
+        "same placeholder must be denied at an unbound path on its bound host:\n{}",
         guard.create_output
     );
 

--- a/e2e/rust/tests/proxy_egress_pipeline.rs
+++ b/e2e/rust/tests/proxy_egress_pipeline.rs
@@ -24,13 +24,14 @@ use std::sync::{
 use openshell_e2e::harness::binary::openshell_cmd;
 use openshell_e2e::harness::sandbox::SandboxGuard;
 use serde_json::Value;
-use tempfile::NamedTempFile;
+use tempfile::{Builder as TempFileBuilder, NamedTempFile};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
 
 const TEST_SERVER_HOST: &str = "host.openshell.internal";
 const PROVIDER_NAME: &str = "e2e-proxy-egress-credentials";
+const PROVIDER_PROFILE_ID: &str = "e2e-proxy-egress-credentials";
 const TOKEN_ENV: &str = "PROXY_E2E_TOKEN";
 const TEST_SECRET: &str = "sk-e2e-proxy-egress-secret";
 const PLACEHOLDER_PREFIX: &str = "openshell:resolve:env:";
@@ -102,7 +103,15 @@ async fn delete_provider(name: &str) {
     let _ = cmd.status().await;
 }
 
-async fn create_generic_provider(name: &str) -> Result<String, String> {
+async fn delete_provider_profile(id: &str) {
+    let mut cmd = openshell_cmd();
+    cmd.args(["provider", "profile", "delete", id])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let _ = cmd.status().await;
+}
+
+async fn create_bound_provider(name: &str) -> Result<String, String> {
     let credential = format!("{TOKEN_ENV}={TEST_SECRET}");
     run_cli(&[
         "provider",
@@ -110,11 +119,49 @@ async fn create_generic_provider(name: &str) -> Result<String, String> {
         "--name",
         name,
         "--type",
-        "generic",
+        PROVIDER_PROFILE_ID,
         "--credential",
         &credential,
     ])
     .await
+}
+
+fn write_credential_profile(port: u16) -> Result<NamedTempFile, String> {
+    let mut file = TempFileBuilder::new()
+        .suffix(".yaml")
+        .tempfile()
+        .map_err(|error| format!("create provider profile: {error}"))?;
+    let profile = format!(
+        r#"id: {PROVIDER_PROFILE_ID}
+display_name: E2E proxy egress credentials
+category: other
+credentials:
+  - name: proxy_e2e_token
+    env_vars: [{TOKEN_ENV}]
+    required: true
+    auth_style: bearer
+    header_name: authorization
+endpoints:
+  - host: {TEST_SERVER_HOST}
+    port: {port}
+    path: /probe
+    protocol: rest
+    access: full
+    enforcement: enforce
+    request_body_credential_rewrite: true
+    allowed_ips:
+      - "10.0.0.0/8"
+      - "172.0.0.0/8"
+      - "192.168.0.0/16"
+      - "fc00::/7"
+binaries: ["/**"]
+"#
+    );
+    file.write_all(profile.as_bytes())
+        .map_err(|error| format!("write provider profile: {error}"))?;
+    file.flush()
+        .map_err(|error| format!("flush provider profile: {error}"))?;
+    Ok(file)
 }
 
 fn write_policy_document(
@@ -1615,19 +1662,19 @@ async fn http_credentials_are_rewritten_in_headers_and_bodies_for_both_adapters(
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     delete_provider(PROVIDER_NAME).await;
-    create_generic_provider(PROVIDER_NAME)
-        .await
-        .expect("create generic provider");
+    delete_provider_profile(PROVIDER_PROFILE_ID).await;
 
     let result = async {
         let server = CredentialProbeServer::start().await?;
-        let endpoint_options = r#"        protocol: rest
+        let profile = write_credential_profile(server.port)?;
+        let profile_path = profile.path().to_string_lossy().into_owned();
+        run_cli(&["provider", "profile", "import", "--file", &profile_path]).await?;
+        create_bound_provider(PROVIDER_NAME).await?;
+        let endpoint_options = r#"        path: /probe
+        protocol: rest
         enforcement: enforce
         request_body_credential_rewrite: true
-        rules:
-          - allow:
-              method: POST
-              path: "/probe""#;
+        access: full"#;
         let policy = write_policy(TEST_SERVER_HOST, server.port, endpoint_options)?;
         let policy_path = policy_path(&policy);
         let script = format!(
@@ -1721,6 +1768,7 @@ print(json.dumps({{"connect": connect, "forward": forward}}, sort_keys=True))
     .await;
 
     delete_provider(PROVIDER_NAME).await;
+    delete_provider_profile(PROVIDER_PROFILE_ID).await;
 
     let guard = result.expect("sandbox create");
     let result = parse_json_line(&guard.create_output);

--- a/e2e/rust/tests/websocket_conformance.rs
+++ b/e2e/rust/tests/websocket_conformance.rs
@@ -19,13 +19,14 @@ use base64::Engine as _;
 use openshell_e2e::harness::binary::openshell_cmd;
 use openshell_e2e::harness::sandbox::SandboxGuard;
 use sha1::{Digest, Sha1};
-use tempfile::NamedTempFile;
+use tempfile::{Builder as TempFileBuilder, NamedTempFile};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
 
 const WEBSOCKET_GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 const PROVIDER_NAME: &str = "e2e-websocket-conformance";
+const PROVIDER_PROFILE_ID: &str = "e2e-websocket-conformance";
 const TEST_SERVER_HOST: &str = "host.openshell.internal";
 const TEST_SECRET: &str = "sk-e2e-websocket-conformance-secret";
 const TOKEN_ENV: &str = "WS_E2E_TOKEN";
@@ -66,7 +67,15 @@ async fn delete_provider(name: &str) {
     let _ = cmd.status().await;
 }
 
-async fn create_generic_provider(name: &str) -> Result<String, String> {
+async fn delete_provider_profile(id: &str) {
+    let mut cmd = openshell_cmd();
+    cmd.args(["provider", "profile", "delete", id])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let _ = cmd.status().await;
+}
+
+async fn create_bound_provider(name: &str) -> Result<String, String> {
     let credential = format!("{TOKEN_ENV}={TEST_SECRET}");
     run_cli(&[
         "provider",
@@ -74,11 +83,52 @@ async fn create_generic_provider(name: &str) -> Result<String, String> {
         "--name",
         name,
         "--type",
-        "generic",
+        PROVIDER_PROFILE_ID,
         "--credential",
         &credential,
     ])
     .await
+}
+
+fn write_credential_profile(port: u16) -> Result<NamedTempFile, String> {
+    let mut file = TempFileBuilder::new()
+        .suffix(".yaml")
+        .tempfile()
+        .map_err(|error| format!("create provider profile: {error}"))?;
+    let profile = format!(
+        r#"id: {PROVIDER_PROFILE_ID}
+display_name: E2E WebSocket conformance credentials
+category: other
+credentials:
+  - name: websocket_token
+    env_vars: [{TOKEN_ENV}]
+    required: true
+    auth_style: bearer
+    header_name: authorization
+endpoints:
+  - host: {TEST_SERVER_HOST}
+    port: {port}
+    path: /ws
+    protocol: websocket
+    enforcement: enforce
+    access: read-write
+    websocket_credential_rewrite: true
+    allowed_ips:
+      - "10.0.0.0/8"
+      - "172.0.0.0/8"
+      - "192.168.0.0/16"
+      - "fc00::/7"
+binaries:
+  - path: /usr/bin/python*
+  - path: /usr/local/bin/python*
+  - path: /sandbox/.uv/python/*/bin/python*
+"#
+    );
+    file.write_all(profile.as_bytes())
+        .map_err(|error| format!("write provider profile: {error}"))?;
+    file.flush()
+        .map_err(|error| format!("flush provider profile: {error}"))?;
+    Ok(file)
 }
 
 struct WebSocketProbeServer {
@@ -435,12 +485,14 @@ async fn websocket_text_placeholder_is_rewritten_through_both_adapters() {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     delete_provider(PROVIDER_NAME).await;
-    create_generic_provider(PROVIDER_NAME)
-        .await
-        .expect("create generic provider");
+    delete_provider_profile(PROVIDER_PROFILE_ID).await;
 
     let result = async {
         let server = WebSocketProbeServer::start().await?;
+        let profile = write_credential_profile(server.port)?;
+        let profile_path = profile.path().to_string_lossy().into_owned();
+        run_cli(&["provider", "profile", "import", "--file", &profile_path]).await?;
+        create_bound_provider(PROVIDER_NAME).await?;
         let policy = write_websocket_policy(TEST_SERVER_HOST, server.port)?;
         let policy_path = policy
             .path()
@@ -464,6 +516,7 @@ async fn websocket_text_placeholder_is_rewritten_through_both_adapters() {
     .await;
 
     delete_provider(PROVIDER_NAME).await;
+    delete_provider_profile(PROVIDER_PROFILE_ID).await;
 
     let guard = result.expect("sandbox create");
     assert!(

--- a/proto/openshell.proto
+++ b/proto/openshell.proto
@@ -1723,6 +1723,22 @@ message DeleteProviderProfileResponse {
 message GetSandboxProviderEnvironmentRequest {
   // The sandbox ID.
   string sandbox_id = 1;
+  // Whether the requesting supervisor enforces endpoint bindings for static
+  // provider credentials. Gateways withhold static credential material when
+  // this capability is absent.
+  bool supports_static_credential_bindings = 2;
+}
+
+// One network endpoint at which a static provider credential may be resolved.
+message StaticCredentialEndpointBinding {
+  string host = 1;
+  uint32 port = 2;
+  string path = 3;
+}
+
+// Endpoint allowlist for one static provider credential environment variable.
+message StaticCredentialBinding {
+  repeated StaticCredentialEndpointBinding endpoints = 1;
 }
 
 // Get sandbox provider environment response.
@@ -1737,6 +1753,12 @@ message GetSandboxProviderEnvironmentResponse {
   // Maps endpoint-bound provider metadata to credential metadata.
   // Supervisor uses this to inject Authorization headers for token grant credentials.
   map<string, ProviderProfileCredential> dynamic_credentials = 4;
+  // Endpoint allowlists for static credential environment variables. Every
+  // static credential in `environment` has a complete binding.
+  map<string, StaticCredentialBinding> static_credential_bindings = 5;
+  // Environment variables that contain provider configuration rather than
+  // credentials and therefore do not require endpoint-scoped resolution.
+  repeated string non_secret_environment_keys = 6;
 }
 
 // ---------------------------------------------------------------------------

--- a/proto/openshell.proto
+++ b/proto/openshell.proto
@@ -1739,6 +1739,10 @@ message StaticCredentialEndpointBinding {
 // Endpoint allowlist for one static provider credential environment variable.
 message StaticCredentialBinding {
   repeated StaticCredentialEndpointBinding endpoints = 1;
+  // Stable identity of the provider credential that produced this binding.
+  // Supervisors use it to retain old revision placeholders only across
+  // rotations of the same provider credential.
+  string credential_identity = 2;
 }
 
 // Get sandbox provider environment response.
@@ -1753,8 +1757,10 @@ message GetSandboxProviderEnvironmentResponse {
   // Maps endpoint-bound provider metadata to credential metadata.
   // Supervisor uses this to inject Authorization headers for token grant credentials.
   map<string, ProviderProfileCredential> dynamic_credentials = 4;
-  // Endpoint allowlists for static credential environment variables. Every
-  // static credential in `environment` has a complete binding.
+  // Endpoint allowlists for static credential environment variables. Metadata
+  // can be incomplete when a provider profile is invalid; capable supervisors
+  // reject all static material in that snapshot while preserving independently
+  // endpoint-bound dynamic credentials.
   map<string, StaticCredentialBinding> static_credential_bindings = 5;
   // Environment variables that contain provider configuration rather than
   // credentials and therefore do not require endpoint-scoped resolution.

--- a/proto/sandbox.proto
+++ b/proto/sandbox.proto
@@ -93,6 +93,13 @@ message MiddlewareEndpointSelector {
   repeated string exclude = 2;
 }
 
+// Binds a policy endpoint to static credentials from a sandbox provider.
+message NetworkCredentialBinding {
+  // Name of the provider attached to this sandbox whose static credentials
+  // may be resolved for requests admitted by this endpoint.
+  string provider = 1;
+}
+
 // A network endpoint (host + port) with optional L7 inspection config.
 message NetworkEndpoint {
   // Hostname or host glob pattern. Exact match is case-insensitive.
@@ -175,6 +182,10 @@ message NetworkEndpoint {
   uint32 json_rpc_max_body_bytes = 22;
   // MCP-only policy and inspection options. Only used when protocol is "mcp".
   McpOptions mcp = 23;
+  // Explicit binding authority for static credentials from an attached
+  // endpointless provider profile. Profiles that already define endpoints
+  // continue to use those profile endpoints as their credential boundary.
+  NetworkCredentialBinding credential_binding = 24;
 }
 
 // MCP options are grouped so MCP-specific policy can grow without adding more

--- a/sdk/go/openshell/v1/internal/converter/coverage_test.go
+++ b/sdk/go/openshell/v1/internal/converter/coverage_test.go
@@ -119,6 +119,7 @@ func TestConverterCoversAllProtoFields_NetworkEndpoint(t *testing.T) {
 		"signing_region":                  true,
 		"json_rpc_max_body_bytes":         true,
 		"mcp":                             true,
+		"credential_binding":              true,
 	}
 
 	assertAllFieldsCovered(t, (&sandboxpb.NetworkEndpoint{}).ProtoReflect().Descriptor(), handled, nil)

--- a/sdk/go/openshell/v1/internal/converter/network_policy.go
+++ b/sdk/go/openshell/v1/internal/converter/network_policy.go
@@ -85,6 +85,11 @@ func policyNetworkEndpointFromProto(ep *sbv1.NetworkEndpoint) types.PolicyNetwor
 	if mcp := ep.GetMcp(); mcp != nil {
 		result.Mcp = mcpOptionsFromProto(mcp)
 	}
+	if binding := ep.GetCredentialBinding(); binding != nil {
+		result.CredentialBinding = &types.NetworkCredentialBinding{
+			Provider: binding.GetProvider(),
+		}
+	}
 	if ports := ep.GetPorts(); len(ports) > 0 {
 		result.Ports = make([]uint32, len(ports))
 		copy(result.Ports, ports)
@@ -141,6 +146,11 @@ func policyNetworkEndpointToProto(ep *types.PolicyNetworkEndpoint) *sbv1.Network
 	}
 	if ep.Mcp != nil {
 		result.Mcp = mcpOptionsToProto(ep.Mcp)
+	}
+	if ep.CredentialBinding != nil {
+		result.CredentialBinding = &sbv1.NetworkCredentialBinding{
+			Provider: ep.CredentialBinding.Provider,
+		}
 	}
 	if len(ep.Ports) > 0 {
 		result.Ports = make([]uint32, len(ep.Ports))

--- a/sdk/go/openshell/v1/internal/converter/sandbox_test.go
+++ b/sdk/go/openshell/v1/internal/converter/sandbox_test.go
@@ -293,7 +293,14 @@ func TestSandboxRoundTrip(t *testing.T) {
 					"web": {
 						Name: "web",
 						Endpoints: []v1.PolicyNetworkEndpoint{
-							{Host: "api.example.com", Port: 443, Protocol: "rest"},
+							{
+								Host:     "api.example.com",
+								Port:     443,
+								Protocol: "rest",
+								CredentialBinding: &v1.NetworkCredentialBinding{
+									Provider: "api-credentials",
+								},
+							},
 						},
 					},
 				},
@@ -342,6 +349,8 @@ func TestSandboxRoundTrip(t *testing.T) {
 	assert.Equal(t, "web", webRule.Name)
 	require.Len(t, webRule.Endpoints, 1)
 	assert.Equal(t, "api.example.com", webRule.Endpoints[0].Host)
+	require.NotNil(t, webRule.Endpoints[0].CredentialBinding)
+	assert.Equal(t, "api-credentials", webRule.Endpoints[0].CredentialBinding.Provider)
 }
 
 func TestSandboxSpecToProto(t *testing.T) {

--- a/sdk/go/openshell/v1/types/network_policy.go
+++ b/sdk/go/openshell/v1/types/network_policy.go
@@ -40,6 +40,13 @@ type PolicyNetworkEndpoint struct {
 	SigningRegion                string
 	JsonRpcMaxBodyBytes          uint32
 	Mcp                          *McpOptions
+	CredentialBinding            *NetworkCredentialBinding
+}
+
+// NetworkCredentialBinding binds an endpoint to static credentials from an attached provider.
+type NetworkCredentialBinding struct {
+	// Provider is the attached provider whose static credentials may be resolved for the endpoint.
+	Provider string
 }
 
 // PolicyNetworkBinary identifies a binary subject to network policy enforcement.

--- a/sdk/go/proto/openshellv1/openshell.pb.go
+++ b/sdk/go/proto/openshellv1/openshell.pb.go
@@ -7120,9 +7120,13 @@ func (x *DeleteProviderProfileResponse) GetDeleted() bool {
 type GetSandboxProviderEnvironmentRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The sandbox ID.
-	SandboxId     string `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	SandboxId string `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	// Whether the requesting supervisor enforces endpoint bindings for static
+	// provider credentials. Gateways withhold static credential material when
+	// this capability is absent.
+	SupportsStaticCredentialBindings bool `protobuf:"varint,2,opt,name=supports_static_credential_bindings,json=supportsStaticCredentialBindings,proto3" json:"supports_static_credential_bindings,omitempty"`
+	unknownFields                    protoimpl.UnknownFields
+	sizeCache                        protoimpl.SizeCache
 }
 
 func (x *GetSandboxProviderEnvironmentRequest) Reset() {
@@ -7162,6 +7166,130 @@ func (x *GetSandboxProviderEnvironmentRequest) GetSandboxId() string {
 	return ""
 }
 
+func (x *GetSandboxProviderEnvironmentRequest) GetSupportsStaticCredentialBindings() bool {
+	if x != nil {
+		return x.SupportsStaticCredentialBindings
+	}
+	return false
+}
+
+// One network endpoint at which a static provider credential may be resolved.
+type StaticCredentialEndpointBinding struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Host          string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	Port          uint32                 `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	Path          string                 `protobuf:"bytes,3,opt,name=path,proto3" json:"path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StaticCredentialEndpointBinding) Reset() {
+	*x = StaticCredentialEndpointBinding{}
+	mi := &file_openshell_proto_msgTypes[101]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StaticCredentialEndpointBinding) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StaticCredentialEndpointBinding) ProtoMessage() {}
+
+func (x *StaticCredentialEndpointBinding) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_proto_msgTypes[101]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StaticCredentialEndpointBinding.ProtoReflect.Descriptor instead.
+func (*StaticCredentialEndpointBinding) Descriptor() ([]byte, []int) {
+	return file_openshell_proto_rawDescGZIP(), []int{101}
+}
+
+func (x *StaticCredentialEndpointBinding) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+func (x *StaticCredentialEndpointBinding) GetPort() uint32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+func (x *StaticCredentialEndpointBinding) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+// Endpoint allowlist for one static provider credential environment variable.
+type StaticCredentialBinding struct {
+	state     protoimpl.MessageState             `protogen:"open.v1"`
+	Endpoints []*StaticCredentialEndpointBinding `protobuf:"bytes,1,rep,name=endpoints,proto3" json:"endpoints,omitempty"`
+	// Stable identity of the provider credential that produced this binding.
+	// Supervisors use it to retain old revision placeholders only across
+	// rotations of the same provider credential.
+	CredentialIdentity string `protobuf:"bytes,2,opt,name=credential_identity,json=credentialIdentity,proto3" json:"credential_identity,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *StaticCredentialBinding) Reset() {
+	*x = StaticCredentialBinding{}
+	mi := &file_openshell_proto_msgTypes[102]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StaticCredentialBinding) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StaticCredentialBinding) ProtoMessage() {}
+
+func (x *StaticCredentialBinding) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_proto_msgTypes[102]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StaticCredentialBinding.ProtoReflect.Descriptor instead.
+func (*StaticCredentialBinding) Descriptor() ([]byte, []int) {
+	return file_openshell_proto_rawDescGZIP(), []int{102}
+}
+
+func (x *StaticCredentialBinding) GetEndpoints() []*StaticCredentialEndpointBinding {
+	if x != nil {
+		return x.Endpoints
+	}
+	return nil
+}
+
+func (x *StaticCredentialBinding) GetCredentialIdentity() string {
+	if x != nil {
+		return x.CredentialIdentity
+	}
+	return ""
+}
+
 // Get sandbox provider environment response.
 type GetSandboxProviderEnvironmentResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -7175,13 +7303,21 @@ type GetSandboxProviderEnvironmentResponse struct {
 	// Maps endpoint-bound provider metadata to credential metadata.
 	// Supervisor uses this to inject Authorization headers for token grant credentials.
 	DynamicCredentials map[string]*ProviderProfileCredential `protobuf:"bytes,4,rep,name=dynamic_credentials,json=dynamicCredentials,proto3" json:"dynamic_credentials,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Endpoint allowlists for static credential environment variables. Metadata
+	// can be incomplete when a provider profile is invalid; capable supervisors
+	// reject all static material in that snapshot while preserving independently
+	// endpoint-bound dynamic credentials.
+	StaticCredentialBindings map[string]*StaticCredentialBinding `protobuf:"bytes,5,rep,name=static_credential_bindings,json=staticCredentialBindings,proto3" json:"static_credential_bindings,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Environment variables that contain provider configuration rather than
+	// credentials and therefore do not require endpoint-scoped resolution.
+	NonSecretEnvironmentKeys []string `protobuf:"bytes,6,rep,name=non_secret_environment_keys,json=nonSecretEnvironmentKeys,proto3" json:"non_secret_environment_keys,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *GetSandboxProviderEnvironmentResponse) Reset() {
 	*x = GetSandboxProviderEnvironmentResponse{}
-	mi := &file_openshell_proto_msgTypes[101]
+	mi := &file_openshell_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7193,7 +7329,7 @@ func (x *GetSandboxProviderEnvironmentResponse) String() string {
 func (*GetSandboxProviderEnvironmentResponse) ProtoMessage() {}
 
 func (x *GetSandboxProviderEnvironmentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[101]
+	mi := &file_openshell_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7206,7 +7342,7 @@ func (x *GetSandboxProviderEnvironmentResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use GetSandboxProviderEnvironmentResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxProviderEnvironmentResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{101}
+	return file_openshell_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *GetSandboxProviderEnvironmentResponse) GetEnvironment() map[string]string {
@@ -7233,6 +7369,20 @@ func (x *GetSandboxProviderEnvironmentResponse) GetCredentialExpiresAtMs() map[s
 func (x *GetSandboxProviderEnvironmentResponse) GetDynamicCredentials() map[string]*ProviderProfileCredential {
 	if x != nil {
 		return x.DynamicCredentials
+	}
+	return nil
+}
+
+func (x *GetSandboxProviderEnvironmentResponse) GetStaticCredentialBindings() map[string]*StaticCredentialBinding {
+	if x != nil {
+		return x.StaticCredentialBindings
+	}
+	return nil
+}
+
+func (x *GetSandboxProviderEnvironmentResponse) GetNonSecretEnvironmentKeys() []string {
+	if x != nil {
+		return x.NonSecretEnvironmentKeys
 	}
 	return nil
 }
@@ -7284,7 +7434,7 @@ type UpdateConfigRequest struct {
 
 func (x *UpdateConfigRequest) Reset() {
 	*x = UpdateConfigRequest{}
-	mi := &file_openshell_proto_msgTypes[102]
+	mi := &file_openshell_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7296,7 +7446,7 @@ func (x *UpdateConfigRequest) String() string {
 func (*UpdateConfigRequest) ProtoMessage() {}
 
 func (x *UpdateConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[102]
+	mi := &file_openshell_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7309,7 +7459,7 @@ func (x *UpdateConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateConfigRequest.ProtoReflect.Descriptor instead.
 func (*UpdateConfigRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{102}
+	return file_openshell_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *UpdateConfigRequest) GetName() string {
@@ -7399,7 +7549,7 @@ type PolicyMergeOperation struct {
 
 func (x *PolicyMergeOperation) Reset() {
 	*x = PolicyMergeOperation{}
-	mi := &file_openshell_proto_msgTypes[103]
+	mi := &file_openshell_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7411,7 +7561,7 @@ func (x *PolicyMergeOperation) String() string {
 func (*PolicyMergeOperation) ProtoMessage() {}
 
 func (x *PolicyMergeOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[103]
+	mi := &file_openshell_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7424,7 +7574,7 @@ func (x *PolicyMergeOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyMergeOperation.ProtoReflect.Descriptor instead.
 func (*PolicyMergeOperation) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{103}
+	return file_openshell_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *PolicyMergeOperation) GetOperation() isPolicyMergeOperation_Operation {
@@ -7538,7 +7688,7 @@ type AddNetworkRule struct {
 
 func (x *AddNetworkRule) Reset() {
 	*x = AddNetworkRule{}
-	mi := &file_openshell_proto_msgTypes[104]
+	mi := &file_openshell_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7550,7 +7700,7 @@ func (x *AddNetworkRule) String() string {
 func (*AddNetworkRule) ProtoMessage() {}
 
 func (x *AddNetworkRule) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[104]
+	mi := &file_openshell_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7563,7 +7713,7 @@ func (x *AddNetworkRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddNetworkRule.ProtoReflect.Descriptor instead.
 func (*AddNetworkRule) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{104}
+	return file_openshell_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *AddNetworkRule) GetRuleName() string {
@@ -7591,7 +7741,7 @@ type RemoveNetworkEndpoint struct {
 
 func (x *RemoveNetworkEndpoint) Reset() {
 	*x = RemoveNetworkEndpoint{}
-	mi := &file_openshell_proto_msgTypes[105]
+	mi := &file_openshell_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7603,7 +7753,7 @@ func (x *RemoveNetworkEndpoint) String() string {
 func (*RemoveNetworkEndpoint) ProtoMessage() {}
 
 func (x *RemoveNetworkEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[105]
+	mi := &file_openshell_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7616,7 +7766,7 @@ func (x *RemoveNetworkEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveNetworkEndpoint.ProtoReflect.Descriptor instead.
 func (*RemoveNetworkEndpoint) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{105}
+	return file_openshell_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *RemoveNetworkEndpoint) GetRuleName() string {
@@ -7649,7 +7799,7 @@ type RemoveNetworkRule struct {
 
 func (x *RemoveNetworkRule) Reset() {
 	*x = RemoveNetworkRule{}
-	mi := &file_openshell_proto_msgTypes[106]
+	mi := &file_openshell_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7661,7 +7811,7 @@ func (x *RemoveNetworkRule) String() string {
 func (*RemoveNetworkRule) ProtoMessage() {}
 
 func (x *RemoveNetworkRule) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[106]
+	mi := &file_openshell_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7674,7 +7824,7 @@ func (x *RemoveNetworkRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveNetworkRule.ProtoReflect.Descriptor instead.
 func (*RemoveNetworkRule) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{106}
+	return file_openshell_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *RemoveNetworkRule) GetRuleName() string {
@@ -7695,7 +7845,7 @@ type AddDenyRules struct {
 
 func (x *AddDenyRules) Reset() {
 	*x = AddDenyRules{}
-	mi := &file_openshell_proto_msgTypes[107]
+	mi := &file_openshell_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7707,7 +7857,7 @@ func (x *AddDenyRules) String() string {
 func (*AddDenyRules) ProtoMessage() {}
 
 func (x *AddDenyRules) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[107]
+	mi := &file_openshell_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7720,7 +7870,7 @@ func (x *AddDenyRules) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddDenyRules.ProtoReflect.Descriptor instead.
 func (*AddDenyRules) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{107}
+	return file_openshell_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *AddDenyRules) GetHost() string {
@@ -7755,7 +7905,7 @@ type AddAllowRules struct {
 
 func (x *AddAllowRules) Reset() {
 	*x = AddAllowRules{}
-	mi := &file_openshell_proto_msgTypes[108]
+	mi := &file_openshell_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7767,7 +7917,7 @@ func (x *AddAllowRules) String() string {
 func (*AddAllowRules) ProtoMessage() {}
 
 func (x *AddAllowRules) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[108]
+	mi := &file_openshell_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7780,7 +7930,7 @@ func (x *AddAllowRules) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddAllowRules.ProtoReflect.Descriptor instead.
 func (*AddAllowRules) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{108}
+	return file_openshell_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *AddAllowRules) GetHost() string {
@@ -7814,7 +7964,7 @@ type RemoveNetworkBinary struct {
 
 func (x *RemoveNetworkBinary) Reset() {
 	*x = RemoveNetworkBinary{}
-	mi := &file_openshell_proto_msgTypes[109]
+	mi := &file_openshell_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7826,7 +7976,7 @@ func (x *RemoveNetworkBinary) String() string {
 func (*RemoveNetworkBinary) ProtoMessage() {}
 
 func (x *RemoveNetworkBinary) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[109]
+	mi := &file_openshell_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7839,7 +7989,7 @@ func (x *RemoveNetworkBinary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveNetworkBinary.ProtoReflect.Descriptor instead.
 func (*RemoveNetworkBinary) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{109}
+	return file_openshell_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *RemoveNetworkBinary) GetRuleName() string {
@@ -7875,7 +8025,7 @@ type UpdateConfigResponse struct {
 
 func (x *UpdateConfigResponse) Reset() {
 	*x = UpdateConfigResponse{}
-	mi := &file_openshell_proto_msgTypes[110]
+	mi := &file_openshell_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7887,7 +8037,7 @@ func (x *UpdateConfigResponse) String() string {
 func (*UpdateConfigResponse) ProtoMessage() {}
 
 func (x *UpdateConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[110]
+	mi := &file_openshell_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7900,7 +8050,7 @@ func (x *UpdateConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateConfigResponse.ProtoReflect.Descriptor instead.
 func (*UpdateConfigResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{110}
+	return file_openshell_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *UpdateConfigResponse) GetVersion() uint32 {
@@ -7955,7 +8105,7 @@ type GetSandboxPolicyStatusRequest struct {
 
 func (x *GetSandboxPolicyStatusRequest) Reset() {
 	*x = GetSandboxPolicyStatusRequest{}
-	mi := &file_openshell_proto_msgTypes[111]
+	mi := &file_openshell_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7967,7 +8117,7 @@ func (x *GetSandboxPolicyStatusRequest) String() string {
 func (*GetSandboxPolicyStatusRequest) ProtoMessage() {}
 
 func (x *GetSandboxPolicyStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[111]
+	mi := &file_openshell_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7980,7 +8130,7 @@ func (x *GetSandboxPolicyStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxPolicyStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxPolicyStatusRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{111}
+	return file_openshell_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *GetSandboxPolicyStatusRequest) GetName() string {
@@ -8024,7 +8174,7 @@ type GetSandboxPolicyStatusResponse struct {
 
 func (x *GetSandboxPolicyStatusResponse) Reset() {
 	*x = GetSandboxPolicyStatusResponse{}
-	mi := &file_openshell_proto_msgTypes[112]
+	mi := &file_openshell_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8036,7 +8186,7 @@ func (x *GetSandboxPolicyStatusResponse) String() string {
 func (*GetSandboxPolicyStatusResponse) ProtoMessage() {}
 
 func (x *GetSandboxPolicyStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[112]
+	mi := &file_openshell_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8049,7 +8199,7 @@ func (x *GetSandboxPolicyStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxPolicyStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxPolicyStatusResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{112}
+	return file_openshell_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *GetSandboxPolicyStatusResponse) GetRevision() *SandboxPolicyRevision {
@@ -8083,7 +8233,7 @@ type ListSandboxPoliciesRequest struct {
 
 func (x *ListSandboxPoliciesRequest) Reset() {
 	*x = ListSandboxPoliciesRequest{}
-	mi := &file_openshell_proto_msgTypes[113]
+	mi := &file_openshell_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8095,7 +8245,7 @@ func (x *ListSandboxPoliciesRequest) String() string {
 func (*ListSandboxPoliciesRequest) ProtoMessage() {}
 
 func (x *ListSandboxPoliciesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[113]
+	mi := &file_openshell_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8108,7 +8258,7 @@ func (x *ListSandboxPoliciesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxPoliciesRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxPoliciesRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{113}
+	return file_openshell_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *ListSandboxPoliciesRequest) GetName() string {
@@ -8156,7 +8306,7 @@ type ListSandboxPoliciesResponse struct {
 
 func (x *ListSandboxPoliciesResponse) Reset() {
 	*x = ListSandboxPoliciesResponse{}
-	mi := &file_openshell_proto_msgTypes[114]
+	mi := &file_openshell_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8168,7 +8318,7 @@ func (x *ListSandboxPoliciesResponse) String() string {
 func (*ListSandboxPoliciesResponse) ProtoMessage() {}
 
 func (x *ListSandboxPoliciesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[114]
+	mi := &file_openshell_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8181,7 +8331,7 @@ func (x *ListSandboxPoliciesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxPoliciesResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxPoliciesResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{114}
+	return file_openshell_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *ListSandboxPoliciesResponse) GetRevisions() []*SandboxPolicyRevision {
@@ -8208,7 +8358,7 @@ type ReportPolicyStatusRequest struct {
 
 func (x *ReportPolicyStatusRequest) Reset() {
 	*x = ReportPolicyStatusRequest{}
-	mi := &file_openshell_proto_msgTypes[115]
+	mi := &file_openshell_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8220,7 +8370,7 @@ func (x *ReportPolicyStatusRequest) String() string {
 func (*ReportPolicyStatusRequest) ProtoMessage() {}
 
 func (x *ReportPolicyStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[115]
+	mi := &file_openshell_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8233,7 +8383,7 @@ func (x *ReportPolicyStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportPolicyStatusRequest.ProtoReflect.Descriptor instead.
 func (*ReportPolicyStatusRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{115}
+	return file_openshell_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *ReportPolicyStatusRequest) GetSandboxId() string {
@@ -8273,7 +8423,7 @@ type ReportPolicyStatusResponse struct {
 
 func (x *ReportPolicyStatusResponse) Reset() {
 	*x = ReportPolicyStatusResponse{}
-	mi := &file_openshell_proto_msgTypes[116]
+	mi := &file_openshell_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8285,7 +8435,7 @@ func (x *ReportPolicyStatusResponse) String() string {
 func (*ReportPolicyStatusResponse) ProtoMessage() {}
 
 func (x *ReportPolicyStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[116]
+	mi := &file_openshell_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8298,7 +8448,7 @@ func (x *ReportPolicyStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportPolicyStatusResponse.ProtoReflect.Descriptor instead.
 func (*ReportPolicyStatusResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{116}
+	return file_openshell_proto_rawDescGZIP(), []int{118}
 }
 
 // A versioned policy revision with metadata.
@@ -8326,7 +8476,7 @@ type SandboxPolicyRevision struct {
 
 func (x *SandboxPolicyRevision) Reset() {
 	*x = SandboxPolicyRevision{}
-	mi := &file_openshell_proto_msgTypes[117]
+	mi := &file_openshell_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8338,7 +8488,7 @@ func (x *SandboxPolicyRevision) String() string {
 func (*SandboxPolicyRevision) ProtoMessage() {}
 
 func (x *SandboxPolicyRevision) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[117]
+	mi := &file_openshell_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8351,7 +8501,7 @@ func (x *SandboxPolicyRevision) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxPolicyRevision.ProtoReflect.Descriptor instead.
 func (*SandboxPolicyRevision) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{117}
+	return file_openshell_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *SandboxPolicyRevision) GetVersion() uint32 {
@@ -8431,7 +8581,7 @@ type GetSandboxLogsRequest struct {
 
 func (x *GetSandboxLogsRequest) Reset() {
 	*x = GetSandboxLogsRequest{}
-	mi := &file_openshell_proto_msgTypes[118]
+	mi := &file_openshell_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8443,7 +8593,7 @@ func (x *GetSandboxLogsRequest) String() string {
 func (*GetSandboxLogsRequest) ProtoMessage() {}
 
 func (x *GetSandboxLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[118]
+	mi := &file_openshell_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8456,7 +8606,7 @@ func (x *GetSandboxLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxLogsRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxLogsRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{118}
+	return file_openshell_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *GetSandboxLogsRequest) GetSandboxId() string {
@@ -8514,7 +8664,7 @@ type PushSandboxLogsRequest struct {
 
 func (x *PushSandboxLogsRequest) Reset() {
 	*x = PushSandboxLogsRequest{}
-	mi := &file_openshell_proto_msgTypes[119]
+	mi := &file_openshell_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8526,7 +8676,7 @@ func (x *PushSandboxLogsRequest) String() string {
 func (*PushSandboxLogsRequest) ProtoMessage() {}
 
 func (x *PushSandboxLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[119]
+	mi := &file_openshell_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8539,7 +8689,7 @@ func (x *PushSandboxLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PushSandboxLogsRequest.ProtoReflect.Descriptor instead.
 func (*PushSandboxLogsRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{119}
+	return file_openshell_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *PushSandboxLogsRequest) GetSandboxId() string {
@@ -8565,7 +8715,7 @@ type PushSandboxLogsResponse struct {
 
 func (x *PushSandboxLogsResponse) Reset() {
 	*x = PushSandboxLogsResponse{}
-	mi := &file_openshell_proto_msgTypes[120]
+	mi := &file_openshell_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8577,7 +8727,7 @@ func (x *PushSandboxLogsResponse) String() string {
 func (*PushSandboxLogsResponse) ProtoMessage() {}
 
 func (x *PushSandboxLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[120]
+	mi := &file_openshell_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8590,7 +8740,7 @@ func (x *PushSandboxLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PushSandboxLogsResponse.ProtoReflect.Descriptor instead.
 func (*PushSandboxLogsResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{120}
+	return file_openshell_proto_rawDescGZIP(), []int{122}
 }
 
 // Get sandbox logs response.
@@ -8606,7 +8756,7 @@ type GetSandboxLogsResponse struct {
 
 func (x *GetSandboxLogsResponse) Reset() {
 	*x = GetSandboxLogsResponse{}
-	mi := &file_openshell_proto_msgTypes[121]
+	mi := &file_openshell_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8618,7 +8768,7 @@ func (x *GetSandboxLogsResponse) String() string {
 func (*GetSandboxLogsResponse) ProtoMessage() {}
 
 func (x *GetSandboxLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[121]
+	mi := &file_openshell_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8631,7 +8781,7 @@ func (x *GetSandboxLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxLogsResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxLogsResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{121}
+	return file_openshell_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *GetSandboxLogsResponse) GetLogs() []*SandboxLogLine {
@@ -8664,7 +8814,7 @@ type SupervisorMessage struct {
 
 func (x *SupervisorMessage) Reset() {
 	*x = SupervisorMessage{}
-	mi := &file_openshell_proto_msgTypes[122]
+	mi := &file_openshell_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8676,7 +8826,7 @@ func (x *SupervisorMessage) String() string {
 func (*SupervisorMessage) ProtoMessage() {}
 
 func (x *SupervisorMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[122]
+	mi := &file_openshell_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8689,7 +8839,7 @@ func (x *SupervisorMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupervisorMessage.ProtoReflect.Descriptor instead.
 func (*SupervisorMessage) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{122}
+	return file_openshell_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *SupervisorMessage) GetPayload() isSupervisorMessage_Payload {
@@ -8780,7 +8930,7 @@ type GatewayMessage struct {
 
 func (x *GatewayMessage) Reset() {
 	*x = GatewayMessage{}
-	mi := &file_openshell_proto_msgTypes[123]
+	mi := &file_openshell_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8792,7 +8942,7 @@ func (x *GatewayMessage) String() string {
 func (*GatewayMessage) ProtoMessage() {}
 
 func (x *GatewayMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[123]
+	mi := &file_openshell_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8805,7 +8955,7 @@ func (x *GatewayMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GatewayMessage.ProtoReflect.Descriptor instead.
 func (*GatewayMessage) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{123}
+	return file_openshell_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *GatewayMessage) GetPayload() isGatewayMessage_Payload {
@@ -8907,7 +9057,7 @@ type SupervisorHello struct {
 
 func (x *SupervisorHello) Reset() {
 	*x = SupervisorHello{}
-	mi := &file_openshell_proto_msgTypes[124]
+	mi := &file_openshell_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8919,7 +9069,7 @@ func (x *SupervisorHello) String() string {
 func (*SupervisorHello) ProtoMessage() {}
 
 func (x *SupervisorHello) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[124]
+	mi := &file_openshell_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8932,7 +9082,7 @@ func (x *SupervisorHello) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupervisorHello.ProtoReflect.Descriptor instead.
 func (*SupervisorHello) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{124}
+	return file_openshell_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *SupervisorHello) GetSandboxId() string {
@@ -8962,7 +9112,7 @@ type SessionAccepted struct {
 
 func (x *SessionAccepted) Reset() {
 	*x = SessionAccepted{}
-	mi := &file_openshell_proto_msgTypes[125]
+	mi := &file_openshell_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8974,7 +9124,7 @@ func (x *SessionAccepted) String() string {
 func (*SessionAccepted) ProtoMessage() {}
 
 func (x *SessionAccepted) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[125]
+	mi := &file_openshell_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8987,7 +9137,7 @@ func (x *SessionAccepted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionAccepted.ProtoReflect.Descriptor instead.
 func (*SessionAccepted) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{125}
+	return file_openshell_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *SessionAccepted) GetSessionId() string {
@@ -9015,7 +9165,7 @@ type SessionRejected struct {
 
 func (x *SessionRejected) Reset() {
 	*x = SessionRejected{}
-	mi := &file_openshell_proto_msgTypes[126]
+	mi := &file_openshell_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9027,7 +9177,7 @@ func (x *SessionRejected) String() string {
 func (*SessionRejected) ProtoMessage() {}
 
 func (x *SessionRejected) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[126]
+	mi := &file_openshell_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9040,7 +9190,7 @@ func (x *SessionRejected) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionRejected.ProtoReflect.Descriptor instead.
 func (*SessionRejected) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{126}
+	return file_openshell_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *SessionRejected) GetReason() string {
@@ -9059,7 +9209,7 @@ type SupervisorHeartbeat struct {
 
 func (x *SupervisorHeartbeat) Reset() {
 	*x = SupervisorHeartbeat{}
-	mi := &file_openshell_proto_msgTypes[127]
+	mi := &file_openshell_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9071,7 +9221,7 @@ func (x *SupervisorHeartbeat) String() string {
 func (*SupervisorHeartbeat) ProtoMessage() {}
 
 func (x *SupervisorHeartbeat) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[127]
+	mi := &file_openshell_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9084,7 +9234,7 @@ func (x *SupervisorHeartbeat) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupervisorHeartbeat.ProtoReflect.Descriptor instead.
 func (*SupervisorHeartbeat) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{127}
+	return file_openshell_proto_rawDescGZIP(), []int{129}
 }
 
 // Gateway heartbeat.
@@ -9096,7 +9246,7 @@ type GatewayHeartbeat struct {
 
 func (x *GatewayHeartbeat) Reset() {
 	*x = GatewayHeartbeat{}
-	mi := &file_openshell_proto_msgTypes[128]
+	mi := &file_openshell_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9108,7 +9258,7 @@ func (x *GatewayHeartbeat) String() string {
 func (*GatewayHeartbeat) ProtoMessage() {}
 
 func (x *GatewayHeartbeat) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[128]
+	mi := &file_openshell_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9121,7 +9271,7 @@ func (x *GatewayHeartbeat) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GatewayHeartbeat.ProtoReflect.Descriptor instead.
 func (*GatewayHeartbeat) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{128}
+	return file_openshell_proto_rawDescGZIP(), []int{130}
 }
 
 // Gateway requests the supervisor to open a relay channel.
@@ -9150,7 +9300,7 @@ type RelayOpen struct {
 
 func (x *RelayOpen) Reset() {
 	*x = RelayOpen{}
-	mi := &file_openshell_proto_msgTypes[129]
+	mi := &file_openshell_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9162,7 +9312,7 @@ func (x *RelayOpen) String() string {
 func (*RelayOpen) ProtoMessage() {}
 
 func (x *RelayOpen) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[129]
+	mi := &file_openshell_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9175,7 +9325,7 @@ func (x *RelayOpen) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RelayOpen.ProtoReflect.Descriptor instead.
 func (*RelayOpen) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{129}
+	return file_openshell_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *RelayOpen) GetChannelId() string {
@@ -9242,7 +9392,7 @@ type SshRelayTarget struct {
 
 func (x *SshRelayTarget) Reset() {
 	*x = SshRelayTarget{}
-	mi := &file_openshell_proto_msgTypes[130]
+	mi := &file_openshell_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9254,7 +9404,7 @@ func (x *SshRelayTarget) String() string {
 func (*SshRelayTarget) ProtoMessage() {}
 
 func (x *SshRelayTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[130]
+	mi := &file_openshell_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9267,7 +9417,7 @@ func (x *SshRelayTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SshRelayTarget.ProtoReflect.Descriptor instead.
 func (*SshRelayTarget) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{130}
+	return file_openshell_proto_rawDescGZIP(), []int{132}
 }
 
 // TCP target dialed by the supervisor from inside the sandbox.
@@ -9283,7 +9433,7 @@ type TcpRelayTarget struct {
 
 func (x *TcpRelayTarget) Reset() {
 	*x = TcpRelayTarget{}
-	mi := &file_openshell_proto_msgTypes[131]
+	mi := &file_openshell_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9295,7 +9445,7 @@ func (x *TcpRelayTarget) String() string {
 func (*TcpRelayTarget) ProtoMessage() {}
 
 func (x *TcpRelayTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[131]
+	mi := &file_openshell_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9308,7 +9458,7 @@ func (x *TcpRelayTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TcpRelayTarget.ProtoReflect.Descriptor instead.
 func (*TcpRelayTarget) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{131}
+	return file_openshell_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *TcpRelayTarget) GetHost() string {
@@ -9336,7 +9486,7 @@ type RelayInit struct {
 
 func (x *RelayInit) Reset() {
 	*x = RelayInit{}
-	mi := &file_openshell_proto_msgTypes[132]
+	mi := &file_openshell_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9348,7 +9498,7 @@ func (x *RelayInit) String() string {
 func (*RelayInit) ProtoMessage() {}
 
 func (x *RelayInit) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[132]
+	mi := &file_openshell_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9361,7 +9511,7 @@ func (x *RelayInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RelayInit.ProtoReflect.Descriptor instead.
 func (*RelayInit) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{132}
+	return file_openshell_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *RelayInit) GetChannelId() string {
@@ -9388,7 +9538,7 @@ type RelayFrame struct {
 
 func (x *RelayFrame) Reset() {
 	*x = RelayFrame{}
-	mi := &file_openshell_proto_msgTypes[133]
+	mi := &file_openshell_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9400,7 +9550,7 @@ func (x *RelayFrame) String() string {
 func (*RelayFrame) ProtoMessage() {}
 
 func (x *RelayFrame) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[133]
+	mi := &file_openshell_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9413,7 +9563,7 @@ func (x *RelayFrame) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RelayFrame.ProtoReflect.Descriptor instead.
 func (*RelayFrame) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{133}
+	return file_openshell_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *RelayFrame) GetPayload() isRelayFrame_Payload {
@@ -9472,7 +9622,7 @@ type RelayOpenResult struct {
 
 func (x *RelayOpenResult) Reset() {
 	*x = RelayOpenResult{}
-	mi := &file_openshell_proto_msgTypes[134]
+	mi := &file_openshell_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9484,7 +9634,7 @@ func (x *RelayOpenResult) String() string {
 func (*RelayOpenResult) ProtoMessage() {}
 
 func (x *RelayOpenResult) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[134]
+	mi := &file_openshell_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9497,7 +9647,7 @@ func (x *RelayOpenResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RelayOpenResult.ProtoReflect.Descriptor instead.
 func (*RelayOpenResult) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{134}
+	return file_openshell_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *RelayOpenResult) GetChannelId() string {
@@ -9534,7 +9684,7 @@ type RelayClose struct {
 
 func (x *RelayClose) Reset() {
 	*x = RelayClose{}
-	mi := &file_openshell_proto_msgTypes[135]
+	mi := &file_openshell_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9546,7 +9696,7 @@ func (x *RelayClose) String() string {
 func (*RelayClose) ProtoMessage() {}
 
 func (x *RelayClose) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[135]
+	mi := &file_openshell_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9559,7 +9709,7 @@ func (x *RelayClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RelayClose.ProtoReflect.Descriptor instead.
 func (*RelayClose) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{135}
+	return file_openshell_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *RelayClose) GetChannelId() string {
@@ -9593,7 +9743,7 @@ type L7RequestSample struct {
 
 func (x *L7RequestSample) Reset() {
 	*x = L7RequestSample{}
-	mi := &file_openshell_proto_msgTypes[136]
+	mi := &file_openshell_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9605,7 +9755,7 @@ func (x *L7RequestSample) String() string {
 func (*L7RequestSample) ProtoMessage() {}
 
 func (x *L7RequestSample) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[136]
+	mi := &file_openshell_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9618,7 +9768,7 @@ func (x *L7RequestSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use L7RequestSample.ProtoReflect.Descriptor instead.
 func (*L7RequestSample) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{136}
+	return file_openshell_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *L7RequestSample) GetMethod() string {
@@ -9692,7 +9842,7 @@ type DenialSummary struct {
 
 func (x *DenialSummary) Reset() {
 	*x = DenialSummary{}
-	mi := &file_openshell_proto_msgTypes[137]
+	mi := &file_openshell_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9704,7 +9854,7 @@ func (x *DenialSummary) String() string {
 func (*DenialSummary) ProtoMessage() {}
 
 func (x *DenialSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[137]
+	mi := &file_openshell_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9717,7 +9867,7 @@ func (x *DenialSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DenialSummary.ProtoReflect.Descriptor instead.
 func (*DenialSummary) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{137}
+	return file_openshell_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *DenialSummary) GetSandboxId() string {
@@ -9852,7 +10002,7 @@ type DenialGroupCount struct {
 
 func (x *DenialGroupCount) Reset() {
 	*x = DenialGroupCount{}
-	mi := &file_openshell_proto_msgTypes[138]
+	mi := &file_openshell_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9864,7 +10014,7 @@ func (x *DenialGroupCount) String() string {
 func (*DenialGroupCount) ProtoMessage() {}
 
 func (x *DenialGroupCount) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[138]
+	mi := &file_openshell_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9877,7 +10027,7 @@ func (x *DenialGroupCount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DenialGroupCount.ProtoReflect.Descriptor instead.
 func (*DenialGroupCount) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{138}
+	return file_openshell_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *DenialGroupCount) GetDenyGroup() string {
@@ -9910,7 +10060,7 @@ type NetworkActivitySummary struct {
 
 func (x *NetworkActivitySummary) Reset() {
 	*x = NetworkActivitySummary{}
-	mi := &file_openshell_proto_msgTypes[139]
+	mi := &file_openshell_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9922,7 +10072,7 @@ func (x *NetworkActivitySummary) String() string {
 func (*NetworkActivitySummary) ProtoMessage() {}
 
 func (x *NetworkActivitySummary) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[139]
+	mi := &file_openshell_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9935,7 +10085,7 @@ func (x *NetworkActivitySummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkActivitySummary.ProtoReflect.Descriptor instead.
 func (*NetworkActivitySummary) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{139}
+	return file_openshell_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *NetworkActivitySummary) GetNetworkActivityCount() uint32 {
@@ -10009,7 +10159,7 @@ type PolicyChunk struct {
 
 func (x *PolicyChunk) Reset() {
 	*x = PolicyChunk{}
-	mi := &file_openshell_proto_msgTypes[140]
+	mi := &file_openshell_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10021,7 +10171,7 @@ func (x *PolicyChunk) String() string {
 func (*PolicyChunk) ProtoMessage() {}
 
 func (x *PolicyChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[140]
+	mi := &file_openshell_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10034,7 +10184,7 @@ func (x *PolicyChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyChunk.ProtoReflect.Descriptor instead.
 func (*PolicyChunk) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{140}
+	return file_openshell_proto_rawDescGZIP(), []int{142}
 }
 
 func (x *PolicyChunk) GetId() string {
@@ -10180,7 +10330,7 @@ type DraftPolicyUpdate struct {
 
 func (x *DraftPolicyUpdate) Reset() {
 	*x = DraftPolicyUpdate{}
-	mi := &file_openshell_proto_msgTypes[141]
+	mi := &file_openshell_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10192,7 +10342,7 @@ func (x *DraftPolicyUpdate) String() string {
 func (*DraftPolicyUpdate) ProtoMessage() {}
 
 func (x *DraftPolicyUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[141]
+	mi := &file_openshell_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10205,7 +10355,7 @@ func (x *DraftPolicyUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DraftPolicyUpdate.ProtoReflect.Descriptor instead.
 func (*DraftPolicyUpdate) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{141}
+	return file_openshell_proto_rawDescGZIP(), []int{143}
 }
 
 func (x *DraftPolicyUpdate) GetDraftVersion() uint64 {
@@ -10263,7 +10413,7 @@ type SubmitPolicyAnalysisRequest struct {
 
 func (x *SubmitPolicyAnalysisRequest) Reset() {
 	*x = SubmitPolicyAnalysisRequest{}
-	mi := &file_openshell_proto_msgTypes[142]
+	mi := &file_openshell_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10275,7 +10425,7 @@ func (x *SubmitPolicyAnalysisRequest) String() string {
 func (*SubmitPolicyAnalysisRequest) ProtoMessage() {}
 
 func (x *SubmitPolicyAnalysisRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[142]
+	mi := &file_openshell_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10288,7 +10438,7 @@ func (x *SubmitPolicyAnalysisRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitPolicyAnalysisRequest.ProtoReflect.Descriptor instead.
 func (*SubmitPolicyAnalysisRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{142}
+	return file_openshell_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *SubmitPolicyAnalysisRequest) GetSummaries() []*DenialSummary {
@@ -10351,7 +10501,7 @@ type SubmitPolicyAnalysisResponse struct {
 
 func (x *SubmitPolicyAnalysisResponse) Reset() {
 	*x = SubmitPolicyAnalysisResponse{}
-	mi := &file_openshell_proto_msgTypes[143]
+	mi := &file_openshell_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10363,7 +10513,7 @@ func (x *SubmitPolicyAnalysisResponse) String() string {
 func (*SubmitPolicyAnalysisResponse) ProtoMessage() {}
 
 func (x *SubmitPolicyAnalysisResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[143]
+	mi := &file_openshell_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10376,7 +10526,7 @@ func (x *SubmitPolicyAnalysisResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitPolicyAnalysisResponse.ProtoReflect.Descriptor instead.
 func (*SubmitPolicyAnalysisResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{143}
+	return file_openshell_proto_rawDescGZIP(), []int{145}
 }
 
 func (x *SubmitPolicyAnalysisResponse) GetAcceptedChunks() uint32 {
@@ -10422,7 +10572,7 @@ type GetDraftPolicyRequest struct {
 
 func (x *GetDraftPolicyRequest) Reset() {
 	*x = GetDraftPolicyRequest{}
-	mi := &file_openshell_proto_msgTypes[144]
+	mi := &file_openshell_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10434,7 +10584,7 @@ func (x *GetDraftPolicyRequest) String() string {
 func (*GetDraftPolicyRequest) ProtoMessage() {}
 
 func (x *GetDraftPolicyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[144]
+	mi := &file_openshell_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10447,7 +10597,7 @@ func (x *GetDraftPolicyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDraftPolicyRequest.ProtoReflect.Descriptor instead.
 func (*GetDraftPolicyRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{144}
+	return file_openshell_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *GetDraftPolicyRequest) GetName() string {
@@ -10487,7 +10637,7 @@ type GetDraftPolicyResponse struct {
 
 func (x *GetDraftPolicyResponse) Reset() {
 	*x = GetDraftPolicyResponse{}
-	mi := &file_openshell_proto_msgTypes[145]
+	mi := &file_openshell_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10499,7 +10649,7 @@ func (x *GetDraftPolicyResponse) String() string {
 func (*GetDraftPolicyResponse) ProtoMessage() {}
 
 func (x *GetDraftPolicyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[145]
+	mi := &file_openshell_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10512,7 +10662,7 @@ func (x *GetDraftPolicyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDraftPolicyResponse.ProtoReflect.Descriptor instead.
 func (*GetDraftPolicyResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{145}
+	return file_openshell_proto_rawDescGZIP(), []int{147}
 }
 
 func (x *GetDraftPolicyResponse) GetChunks() []*PolicyChunk {
@@ -10558,7 +10708,7 @@ type ApproveDraftChunkRequest struct {
 
 func (x *ApproveDraftChunkRequest) Reset() {
 	*x = ApproveDraftChunkRequest{}
-	mi := &file_openshell_proto_msgTypes[146]
+	mi := &file_openshell_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10570,7 +10720,7 @@ func (x *ApproveDraftChunkRequest) String() string {
 func (*ApproveDraftChunkRequest) ProtoMessage() {}
 
 func (x *ApproveDraftChunkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[146]
+	mi := &file_openshell_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10583,7 +10733,7 @@ func (x *ApproveDraftChunkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApproveDraftChunkRequest.ProtoReflect.Descriptor instead.
 func (*ApproveDraftChunkRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{146}
+	return file_openshell_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *ApproveDraftChunkRequest) GetName() string {
@@ -10619,7 +10769,7 @@ type ApproveDraftChunkResponse struct {
 
 func (x *ApproveDraftChunkResponse) Reset() {
 	*x = ApproveDraftChunkResponse{}
-	mi := &file_openshell_proto_msgTypes[147]
+	mi := &file_openshell_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10631,7 +10781,7 @@ func (x *ApproveDraftChunkResponse) String() string {
 func (*ApproveDraftChunkResponse) ProtoMessage() {}
 
 func (x *ApproveDraftChunkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[147]
+	mi := &file_openshell_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10644,7 +10794,7 @@ func (x *ApproveDraftChunkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApproveDraftChunkResponse.ProtoReflect.Descriptor instead.
 func (*ApproveDraftChunkResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{147}
+	return file_openshell_proto_rawDescGZIP(), []int{149}
 }
 
 func (x *ApproveDraftChunkResponse) GetPolicyVersion() uint32 {
@@ -10678,7 +10828,7 @@ type RejectDraftChunkRequest struct {
 
 func (x *RejectDraftChunkRequest) Reset() {
 	*x = RejectDraftChunkRequest{}
-	mi := &file_openshell_proto_msgTypes[148]
+	mi := &file_openshell_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10690,7 +10840,7 @@ func (x *RejectDraftChunkRequest) String() string {
 func (*RejectDraftChunkRequest) ProtoMessage() {}
 
 func (x *RejectDraftChunkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[148]
+	mi := &file_openshell_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10703,7 +10853,7 @@ func (x *RejectDraftChunkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RejectDraftChunkRequest.ProtoReflect.Descriptor instead.
 func (*RejectDraftChunkRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{148}
+	return file_openshell_proto_rawDescGZIP(), []int{150}
 }
 
 func (x *RejectDraftChunkRequest) GetName() string {
@@ -10742,7 +10892,7 @@ type RejectDraftChunkResponse struct {
 
 func (x *RejectDraftChunkResponse) Reset() {
 	*x = RejectDraftChunkResponse{}
-	mi := &file_openshell_proto_msgTypes[149]
+	mi := &file_openshell_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10754,7 +10904,7 @@ func (x *RejectDraftChunkResponse) String() string {
 func (*RejectDraftChunkResponse) ProtoMessage() {}
 
 func (x *RejectDraftChunkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[149]
+	mi := &file_openshell_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10767,7 +10917,7 @@ func (x *RejectDraftChunkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RejectDraftChunkResponse.ProtoReflect.Descriptor instead.
 func (*RejectDraftChunkResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{149}
+	return file_openshell_proto_rawDescGZIP(), []int{151}
 }
 
 // Approve all pending chunks.
@@ -10785,7 +10935,7 @@ type ApproveAllDraftChunksRequest struct {
 
 func (x *ApproveAllDraftChunksRequest) Reset() {
 	*x = ApproveAllDraftChunksRequest{}
-	mi := &file_openshell_proto_msgTypes[150]
+	mi := &file_openshell_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10797,7 +10947,7 @@ func (x *ApproveAllDraftChunksRequest) String() string {
 func (*ApproveAllDraftChunksRequest) ProtoMessage() {}
 
 func (x *ApproveAllDraftChunksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[150]
+	mi := &file_openshell_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10810,7 +10960,7 @@ func (x *ApproveAllDraftChunksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApproveAllDraftChunksRequest.ProtoReflect.Descriptor instead.
 func (*ApproveAllDraftChunksRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{150}
+	return file_openshell_proto_rawDescGZIP(), []int{152}
 }
 
 func (x *ApproveAllDraftChunksRequest) GetName() string {
@@ -10850,7 +11000,7 @@ type ApproveAllDraftChunksResponse struct {
 
 func (x *ApproveAllDraftChunksResponse) Reset() {
 	*x = ApproveAllDraftChunksResponse{}
-	mi := &file_openshell_proto_msgTypes[151]
+	mi := &file_openshell_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10862,7 +11012,7 @@ func (x *ApproveAllDraftChunksResponse) String() string {
 func (*ApproveAllDraftChunksResponse) ProtoMessage() {}
 
 func (x *ApproveAllDraftChunksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[151]
+	mi := &file_openshell_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10875,7 +11025,7 @@ func (x *ApproveAllDraftChunksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApproveAllDraftChunksResponse.ProtoReflect.Descriptor instead.
 func (*ApproveAllDraftChunksResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{151}
+	return file_openshell_proto_rawDescGZIP(), []int{153}
 }
 
 func (x *ApproveAllDraftChunksResponse) GetPolicyVersion() uint32 {
@@ -10923,7 +11073,7 @@ type EditDraftChunkRequest struct {
 
 func (x *EditDraftChunkRequest) Reset() {
 	*x = EditDraftChunkRequest{}
-	mi := &file_openshell_proto_msgTypes[152]
+	mi := &file_openshell_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10935,7 +11085,7 @@ func (x *EditDraftChunkRequest) String() string {
 func (*EditDraftChunkRequest) ProtoMessage() {}
 
 func (x *EditDraftChunkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[152]
+	mi := &file_openshell_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10948,7 +11098,7 @@ func (x *EditDraftChunkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EditDraftChunkRequest.ProtoReflect.Descriptor instead.
 func (*EditDraftChunkRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{152}
+	return file_openshell_proto_rawDescGZIP(), []int{154}
 }
 
 func (x *EditDraftChunkRequest) GetName() string {
@@ -10987,7 +11137,7 @@ type EditDraftChunkResponse struct {
 
 func (x *EditDraftChunkResponse) Reset() {
 	*x = EditDraftChunkResponse{}
-	mi := &file_openshell_proto_msgTypes[153]
+	mi := &file_openshell_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10999,7 +11149,7 @@ func (x *EditDraftChunkResponse) String() string {
 func (*EditDraftChunkResponse) ProtoMessage() {}
 
 func (x *EditDraftChunkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[153]
+	mi := &file_openshell_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11012,7 +11162,7 @@ func (x *EditDraftChunkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EditDraftChunkResponse.ProtoReflect.Descriptor instead.
 func (*EditDraftChunkResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{153}
+	return file_openshell_proto_rawDescGZIP(), []int{155}
 }
 
 // Reverse an approval (remove merged rule from active policy).
@@ -11030,7 +11180,7 @@ type UndoDraftChunkRequest struct {
 
 func (x *UndoDraftChunkRequest) Reset() {
 	*x = UndoDraftChunkRequest{}
-	mi := &file_openshell_proto_msgTypes[154]
+	mi := &file_openshell_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11042,7 +11192,7 @@ func (x *UndoDraftChunkRequest) String() string {
 func (*UndoDraftChunkRequest) ProtoMessage() {}
 
 func (x *UndoDraftChunkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[154]
+	mi := &file_openshell_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11055,7 +11205,7 @@ func (x *UndoDraftChunkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UndoDraftChunkRequest.ProtoReflect.Descriptor instead.
 func (*UndoDraftChunkRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{154}
+	return file_openshell_proto_rawDescGZIP(), []int{156}
 }
 
 func (x *UndoDraftChunkRequest) GetName() string {
@@ -11091,7 +11241,7 @@ type UndoDraftChunkResponse struct {
 
 func (x *UndoDraftChunkResponse) Reset() {
 	*x = UndoDraftChunkResponse{}
-	mi := &file_openshell_proto_msgTypes[155]
+	mi := &file_openshell_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11103,7 +11253,7 @@ func (x *UndoDraftChunkResponse) String() string {
 func (*UndoDraftChunkResponse) ProtoMessage() {}
 
 func (x *UndoDraftChunkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[155]
+	mi := &file_openshell_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11116,7 +11266,7 @@ func (x *UndoDraftChunkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UndoDraftChunkResponse.ProtoReflect.Descriptor instead.
 func (*UndoDraftChunkResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{155}
+	return file_openshell_proto_rawDescGZIP(), []int{157}
 }
 
 func (x *UndoDraftChunkResponse) GetPolicyVersion() uint32 {
@@ -11146,7 +11296,7 @@ type ClearDraftChunksRequest struct {
 
 func (x *ClearDraftChunksRequest) Reset() {
 	*x = ClearDraftChunksRequest{}
-	mi := &file_openshell_proto_msgTypes[156]
+	mi := &file_openshell_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11158,7 +11308,7 @@ func (x *ClearDraftChunksRequest) String() string {
 func (*ClearDraftChunksRequest) ProtoMessage() {}
 
 func (x *ClearDraftChunksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[156]
+	mi := &file_openshell_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11171,7 +11321,7 @@ func (x *ClearDraftChunksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClearDraftChunksRequest.ProtoReflect.Descriptor instead.
 func (*ClearDraftChunksRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{156}
+	return file_openshell_proto_rawDescGZIP(), []int{158}
 }
 
 func (x *ClearDraftChunksRequest) GetName() string {
@@ -11198,7 +11348,7 @@ type ClearDraftChunksResponse struct {
 
 func (x *ClearDraftChunksResponse) Reset() {
 	*x = ClearDraftChunksResponse{}
-	mi := &file_openshell_proto_msgTypes[157]
+	mi := &file_openshell_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11210,7 +11360,7 @@ func (x *ClearDraftChunksResponse) String() string {
 func (*ClearDraftChunksResponse) ProtoMessage() {}
 
 func (x *ClearDraftChunksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[157]
+	mi := &file_openshell_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11223,7 +11373,7 @@ func (x *ClearDraftChunksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClearDraftChunksResponse.ProtoReflect.Descriptor instead.
 func (*ClearDraftChunksResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{157}
+	return file_openshell_proto_rawDescGZIP(), []int{159}
 }
 
 func (x *ClearDraftChunksResponse) GetChunksCleared() uint32 {
@@ -11246,7 +11396,7 @@ type GetDraftHistoryRequest struct {
 
 func (x *GetDraftHistoryRequest) Reset() {
 	*x = GetDraftHistoryRequest{}
-	mi := &file_openshell_proto_msgTypes[158]
+	mi := &file_openshell_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11258,7 +11408,7 @@ func (x *GetDraftHistoryRequest) String() string {
 func (*GetDraftHistoryRequest) ProtoMessage() {}
 
 func (x *GetDraftHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[158]
+	mi := &file_openshell_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11271,7 +11421,7 @@ func (x *GetDraftHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDraftHistoryRequest.ProtoReflect.Descriptor instead.
 func (*GetDraftHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{158}
+	return file_openshell_proto_rawDescGZIP(), []int{160}
 }
 
 func (x *GetDraftHistoryRequest) GetName() string {
@@ -11305,7 +11455,7 @@ type DraftHistoryEntry struct {
 
 func (x *DraftHistoryEntry) Reset() {
 	*x = DraftHistoryEntry{}
-	mi := &file_openshell_proto_msgTypes[159]
+	mi := &file_openshell_proto_msgTypes[161]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11317,7 +11467,7 @@ func (x *DraftHistoryEntry) String() string {
 func (*DraftHistoryEntry) ProtoMessage() {}
 
 func (x *DraftHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[159]
+	mi := &file_openshell_proto_msgTypes[161]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11330,7 +11480,7 @@ func (x *DraftHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DraftHistoryEntry.ProtoReflect.Descriptor instead.
 func (*DraftHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{159}
+	return file_openshell_proto_rawDescGZIP(), []int{161}
 }
 
 func (x *DraftHistoryEntry) GetTimestampMs() int64 {
@@ -11371,7 +11521,7 @@ type GetDraftHistoryResponse struct {
 
 func (x *GetDraftHistoryResponse) Reset() {
 	*x = GetDraftHistoryResponse{}
-	mi := &file_openshell_proto_msgTypes[160]
+	mi := &file_openshell_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11383,7 +11533,7 @@ func (x *GetDraftHistoryResponse) String() string {
 func (*GetDraftHistoryResponse) ProtoMessage() {}
 
 func (x *GetDraftHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[160]
+	mi := &file_openshell_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11396,7 +11546,7 @@ func (x *GetDraftHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDraftHistoryResponse.ProtoReflect.Descriptor instead.
 func (*GetDraftHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{160}
+	return file_openshell_proto_rawDescGZIP(), []int{162}
 }
 
 func (x *GetDraftHistoryResponse) GetEntries() []*DraftHistoryEntry {
@@ -11425,7 +11575,7 @@ type PolicyRevisionPayload struct {
 
 func (x *PolicyRevisionPayload) Reset() {
 	*x = PolicyRevisionPayload{}
-	mi := &file_openshell_proto_msgTypes[161]
+	mi := &file_openshell_proto_msgTypes[163]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11437,7 +11587,7 @@ func (x *PolicyRevisionPayload) String() string {
 func (*PolicyRevisionPayload) ProtoMessage() {}
 
 func (x *PolicyRevisionPayload) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[161]
+	mi := &file_openshell_proto_msgTypes[163]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11450,7 +11600,7 @@ func (x *PolicyRevisionPayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyRevisionPayload.ProtoReflect.Descriptor instead.
 func (*PolicyRevisionPayload) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{161}
+	return file_openshell_proto_rawDescGZIP(), []int{163}
 }
 
 func (x *PolicyRevisionPayload) GetPolicy() *sandboxv1.SandboxPolicy {
@@ -11523,7 +11673,7 @@ type DraftChunkPayload struct {
 
 func (x *DraftChunkPayload) Reset() {
 	*x = DraftChunkPayload{}
-	mi := &file_openshell_proto_msgTypes[162]
+	mi := &file_openshell_proto_msgTypes[164]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11535,7 +11685,7 @@ func (x *DraftChunkPayload) String() string {
 func (*DraftChunkPayload) ProtoMessage() {}
 
 func (x *DraftChunkPayload) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[162]
+	mi := &file_openshell_proto_msgTypes[164]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11548,7 +11698,7 @@ func (x *DraftChunkPayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DraftChunkPayload.ProtoReflect.Descriptor instead.
 func (*DraftChunkPayload) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{162}
+	return file_openshell_proto_rawDescGZIP(), []int{164}
 }
 
 func (x *DraftChunkPayload) GetRuleName() string {
@@ -11654,7 +11804,7 @@ type StoredPolicyRevision struct {
 
 func (x *StoredPolicyRevision) Reset() {
 	*x = StoredPolicyRevision{}
-	mi := &file_openshell_proto_msgTypes[163]
+	mi := &file_openshell_proto_msgTypes[165]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11666,7 +11816,7 @@ func (x *StoredPolicyRevision) String() string {
 func (*StoredPolicyRevision) ProtoMessage() {}
 
 func (x *StoredPolicyRevision) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[163]
+	mi := &file_openshell_proto_msgTypes[165]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11679,7 +11829,7 @@ func (x *StoredPolicyRevision) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StoredPolicyRevision.ProtoReflect.Descriptor instead.
 func (*StoredPolicyRevision) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{163}
+	return file_openshell_proto_rawDescGZIP(), []int{165}
 }
 
 func (x *StoredPolicyRevision) GetId() string {
@@ -11782,7 +11932,7 @@ type StoredDraftChunk struct {
 
 func (x *StoredDraftChunk) Reset() {
 	*x = StoredDraftChunk{}
-	mi := &file_openshell_proto_msgTypes[164]
+	mi := &file_openshell_proto_msgTypes[166]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11794,7 +11944,7 @@ func (x *StoredDraftChunk) String() string {
 func (*StoredDraftChunk) ProtoMessage() {}
 
 func (x *StoredDraftChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[164]
+	mi := &file_openshell_proto_msgTypes[166]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11807,7 +11957,7 @@ func (x *StoredDraftChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StoredDraftChunk.ProtoReflect.Descriptor instead.
 func (*StoredDraftChunk) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{164}
+	return file_openshell_proto_rawDescGZIP(), []int{166}
 }
 
 func (x *StoredDraftChunk) GetId() string {
@@ -11956,7 +12106,7 @@ type CreateWorkspaceRequest struct {
 
 func (x *CreateWorkspaceRequest) Reset() {
 	*x = CreateWorkspaceRequest{}
-	mi := &file_openshell_proto_msgTypes[165]
+	mi := &file_openshell_proto_msgTypes[167]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11968,7 +12118,7 @@ func (x *CreateWorkspaceRequest) String() string {
 func (*CreateWorkspaceRequest) ProtoMessage() {}
 
 func (x *CreateWorkspaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[165]
+	mi := &file_openshell_proto_msgTypes[167]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11981,7 +12131,7 @@ func (x *CreateWorkspaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkspaceRequest.ProtoReflect.Descriptor instead.
 func (*CreateWorkspaceRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{165}
+	return file_openshell_proto_rawDescGZIP(), []int{167}
 }
 
 func (x *CreateWorkspaceRequest) GetName() string {
@@ -12008,7 +12158,7 @@ type CreateWorkspaceResponse struct {
 
 func (x *CreateWorkspaceResponse) Reset() {
 	*x = CreateWorkspaceResponse{}
-	mi := &file_openshell_proto_msgTypes[166]
+	mi := &file_openshell_proto_msgTypes[168]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12020,7 +12170,7 @@ func (x *CreateWorkspaceResponse) String() string {
 func (*CreateWorkspaceResponse) ProtoMessage() {}
 
 func (x *CreateWorkspaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[166]
+	mi := &file_openshell_proto_msgTypes[168]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12033,7 +12183,7 @@ func (x *CreateWorkspaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkspaceResponse.ProtoReflect.Descriptor instead.
 func (*CreateWorkspaceResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{166}
+	return file_openshell_proto_rawDescGZIP(), []int{168}
 }
 
 func (x *CreateWorkspaceResponse) GetWorkspace() *datamodelv1.Workspace {
@@ -12054,7 +12204,7 @@ type GetWorkspaceRequest struct {
 
 func (x *GetWorkspaceRequest) Reset() {
 	*x = GetWorkspaceRequest{}
-	mi := &file_openshell_proto_msgTypes[167]
+	mi := &file_openshell_proto_msgTypes[169]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12066,7 +12216,7 @@ func (x *GetWorkspaceRequest) String() string {
 func (*GetWorkspaceRequest) ProtoMessage() {}
 
 func (x *GetWorkspaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[167]
+	mi := &file_openshell_proto_msgTypes[169]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12079,7 +12229,7 @@ func (x *GetWorkspaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWorkspaceRequest.ProtoReflect.Descriptor instead.
 func (*GetWorkspaceRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{167}
+	return file_openshell_proto_rawDescGZIP(), []int{169}
 }
 
 func (x *GetWorkspaceRequest) GetName() string {
@@ -12099,7 +12249,7 @@ type GetWorkspaceResponse struct {
 
 func (x *GetWorkspaceResponse) Reset() {
 	*x = GetWorkspaceResponse{}
-	mi := &file_openshell_proto_msgTypes[168]
+	mi := &file_openshell_proto_msgTypes[170]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12111,7 +12261,7 @@ func (x *GetWorkspaceResponse) String() string {
 func (*GetWorkspaceResponse) ProtoMessage() {}
 
 func (x *GetWorkspaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[168]
+	mi := &file_openshell_proto_msgTypes[170]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12124,7 +12274,7 @@ func (x *GetWorkspaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWorkspaceResponse.ProtoReflect.Descriptor instead.
 func (*GetWorkspaceResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{168}
+	return file_openshell_proto_rawDescGZIP(), []int{170}
 }
 
 func (x *GetWorkspaceResponse) GetWorkspace() *datamodelv1.Workspace {
@@ -12147,7 +12297,7 @@ type ListWorkspacesRequest struct {
 
 func (x *ListWorkspacesRequest) Reset() {
 	*x = ListWorkspacesRequest{}
-	mi := &file_openshell_proto_msgTypes[169]
+	mi := &file_openshell_proto_msgTypes[171]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12159,7 +12309,7 @@ func (x *ListWorkspacesRequest) String() string {
 func (*ListWorkspacesRequest) ProtoMessage() {}
 
 func (x *ListWorkspacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[169]
+	mi := &file_openshell_proto_msgTypes[171]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12172,7 +12322,7 @@ func (x *ListWorkspacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspacesRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkspacesRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{169}
+	return file_openshell_proto_rawDescGZIP(), []int{171}
 }
 
 func (x *ListWorkspacesRequest) GetLimit() uint32 {
@@ -12206,7 +12356,7 @@ type ListWorkspacesResponse struct {
 
 func (x *ListWorkspacesResponse) Reset() {
 	*x = ListWorkspacesResponse{}
-	mi := &file_openshell_proto_msgTypes[170]
+	mi := &file_openshell_proto_msgTypes[172]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12218,7 +12368,7 @@ func (x *ListWorkspacesResponse) String() string {
 func (*ListWorkspacesResponse) ProtoMessage() {}
 
 func (x *ListWorkspacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[170]
+	mi := &file_openshell_proto_msgTypes[172]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12231,7 +12381,7 @@ func (x *ListWorkspacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspacesResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkspacesResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{170}
+	return file_openshell_proto_rawDescGZIP(), []int{172}
 }
 
 func (x *ListWorkspacesResponse) GetWorkspaces() []*datamodelv1.Workspace {
@@ -12252,7 +12402,7 @@ type DeleteWorkspaceRequest struct {
 
 func (x *DeleteWorkspaceRequest) Reset() {
 	*x = DeleteWorkspaceRequest{}
-	mi := &file_openshell_proto_msgTypes[171]
+	mi := &file_openshell_proto_msgTypes[173]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12264,7 +12414,7 @@ func (x *DeleteWorkspaceRequest) String() string {
 func (*DeleteWorkspaceRequest) ProtoMessage() {}
 
 func (x *DeleteWorkspaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[171]
+	mi := &file_openshell_proto_msgTypes[173]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12277,7 +12427,7 @@ func (x *DeleteWorkspaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWorkspaceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteWorkspaceRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{171}
+	return file_openshell_proto_rawDescGZIP(), []int{173}
 }
 
 func (x *DeleteWorkspaceRequest) GetName() string {
@@ -12297,7 +12447,7 @@ type DeleteWorkspaceResponse struct {
 
 func (x *DeleteWorkspaceResponse) Reset() {
 	*x = DeleteWorkspaceResponse{}
-	mi := &file_openshell_proto_msgTypes[172]
+	mi := &file_openshell_proto_msgTypes[174]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12309,7 +12459,7 @@ func (x *DeleteWorkspaceResponse) String() string {
 func (*DeleteWorkspaceResponse) ProtoMessage() {}
 
 func (x *DeleteWorkspaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[172]
+	mi := &file_openshell_proto_msgTypes[174]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12322,7 +12472,7 @@ func (x *DeleteWorkspaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWorkspaceResponse.ProtoReflect.Descriptor instead.
 func (*DeleteWorkspaceResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{172}
+	return file_openshell_proto_rawDescGZIP(), []int{174}
 }
 
 func (x *DeleteWorkspaceResponse) GetDeleted() bool {
@@ -12346,7 +12496,7 @@ type WorkspaceMember struct {
 
 func (x *WorkspaceMember) Reset() {
 	*x = WorkspaceMember{}
-	mi := &file_openshell_proto_msgTypes[173]
+	mi := &file_openshell_proto_msgTypes[175]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12358,7 +12508,7 @@ func (x *WorkspaceMember) String() string {
 func (*WorkspaceMember) ProtoMessage() {}
 
 func (x *WorkspaceMember) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[173]
+	mi := &file_openshell_proto_msgTypes[175]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12371,7 +12521,7 @@ func (x *WorkspaceMember) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkspaceMember.ProtoReflect.Descriptor instead.
 func (*WorkspaceMember) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{173}
+	return file_openshell_proto_rawDescGZIP(), []int{175}
 }
 
 func (x *WorkspaceMember) GetMetadata() *datamodelv1.ObjectMeta {
@@ -12410,7 +12560,7 @@ type AddWorkspaceMemberRequest struct {
 
 func (x *AddWorkspaceMemberRequest) Reset() {
 	*x = AddWorkspaceMemberRequest{}
-	mi := &file_openshell_proto_msgTypes[174]
+	mi := &file_openshell_proto_msgTypes[176]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12422,7 +12572,7 @@ func (x *AddWorkspaceMemberRequest) String() string {
 func (*AddWorkspaceMemberRequest) ProtoMessage() {}
 
 func (x *AddWorkspaceMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[174]
+	mi := &file_openshell_proto_msgTypes[176]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12435,7 +12585,7 @@ func (x *AddWorkspaceMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddWorkspaceMemberRequest.ProtoReflect.Descriptor instead.
 func (*AddWorkspaceMemberRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{174}
+	return file_openshell_proto_rawDescGZIP(), []int{176}
 }
 
 func (x *AddWorkspaceMemberRequest) GetWorkspace() string {
@@ -12469,7 +12619,7 @@ type AddWorkspaceMemberResponse struct {
 
 func (x *AddWorkspaceMemberResponse) Reset() {
 	*x = AddWorkspaceMemberResponse{}
-	mi := &file_openshell_proto_msgTypes[175]
+	mi := &file_openshell_proto_msgTypes[177]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12481,7 +12631,7 @@ func (x *AddWorkspaceMemberResponse) String() string {
 func (*AddWorkspaceMemberResponse) ProtoMessage() {}
 
 func (x *AddWorkspaceMemberResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[175]
+	mi := &file_openshell_proto_msgTypes[177]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12494,7 +12644,7 @@ func (x *AddWorkspaceMemberResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddWorkspaceMemberResponse.ProtoReflect.Descriptor instead.
 func (*AddWorkspaceMemberResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{175}
+	return file_openshell_proto_rawDescGZIP(), []int{177}
 }
 
 func (x *AddWorkspaceMemberResponse) GetMember() *WorkspaceMember {
@@ -12517,7 +12667,7 @@ type RemoveWorkspaceMemberRequest struct {
 
 func (x *RemoveWorkspaceMemberRequest) Reset() {
 	*x = RemoveWorkspaceMemberRequest{}
-	mi := &file_openshell_proto_msgTypes[176]
+	mi := &file_openshell_proto_msgTypes[178]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12529,7 +12679,7 @@ func (x *RemoveWorkspaceMemberRequest) String() string {
 func (*RemoveWorkspaceMemberRequest) ProtoMessage() {}
 
 func (x *RemoveWorkspaceMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[176]
+	mi := &file_openshell_proto_msgTypes[178]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12542,7 +12692,7 @@ func (x *RemoveWorkspaceMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveWorkspaceMemberRequest.ProtoReflect.Descriptor instead.
 func (*RemoveWorkspaceMemberRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{176}
+	return file_openshell_proto_rawDescGZIP(), []int{178}
 }
 
 func (x *RemoveWorkspaceMemberRequest) GetWorkspace() string {
@@ -12569,7 +12719,7 @@ type RemoveWorkspaceMemberResponse struct {
 
 func (x *RemoveWorkspaceMemberResponse) Reset() {
 	*x = RemoveWorkspaceMemberResponse{}
-	mi := &file_openshell_proto_msgTypes[177]
+	mi := &file_openshell_proto_msgTypes[179]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12581,7 +12731,7 @@ func (x *RemoveWorkspaceMemberResponse) String() string {
 func (*RemoveWorkspaceMemberResponse) ProtoMessage() {}
 
 func (x *RemoveWorkspaceMemberResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[177]
+	mi := &file_openshell_proto_msgTypes[179]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12594,7 +12744,7 @@ func (x *RemoveWorkspaceMemberResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveWorkspaceMemberResponse.ProtoReflect.Descriptor instead.
 func (*RemoveWorkspaceMemberResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{177}
+	return file_openshell_proto_rawDescGZIP(), []int{179}
 }
 
 func (x *RemoveWorkspaceMemberResponse) GetRemoved() bool {
@@ -12617,7 +12767,7 @@ type ListWorkspaceMembersRequest struct {
 
 func (x *ListWorkspaceMembersRequest) Reset() {
 	*x = ListWorkspaceMembersRequest{}
-	mi := &file_openshell_proto_msgTypes[178]
+	mi := &file_openshell_proto_msgTypes[180]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12629,7 +12779,7 @@ func (x *ListWorkspaceMembersRequest) String() string {
 func (*ListWorkspaceMembersRequest) ProtoMessage() {}
 
 func (x *ListWorkspaceMembersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[178]
+	mi := &file_openshell_proto_msgTypes[180]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12642,7 +12792,7 @@ func (x *ListWorkspaceMembersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspaceMembersRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkspaceMembersRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{178}
+	return file_openshell_proto_rawDescGZIP(), []int{180}
 }
 
 func (x *ListWorkspaceMembersRequest) GetWorkspace() string {
@@ -12676,7 +12826,7 @@ type ListWorkspaceMembersResponse struct {
 
 func (x *ListWorkspaceMembersResponse) Reset() {
 	*x = ListWorkspaceMembersResponse{}
-	mi := &file_openshell_proto_msgTypes[179]
+	mi := &file_openshell_proto_msgTypes[181]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12688,7 +12838,7 @@ func (x *ListWorkspaceMembersResponse) String() string {
 func (*ListWorkspaceMembersResponse) ProtoMessage() {}
 
 func (x *ListWorkspaceMembersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[179]
+	mi := &file_openshell_proto_msgTypes[181]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12701,7 +12851,7 @@ func (x *ListWorkspaceMembersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspaceMembersResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkspaceMembersResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{179}
+	return file_openshell_proto_rawDescGZIP(), []int{181}
 }
 
 func (x *ListWorkspaceMembersResponse) GetMembers() []*WorkspaceMember {
@@ -13228,15 +13378,25 @@ const file_openshell_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1c\n" +
 	"\tworkspace\x18\x02 \x01(\tR\tworkspace\"9\n" +
 	"\x1dDeleteProviderProfileResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\bR\adeleted\"E\n" +
+	"\adeleted\x18\x01 \x01(\bR\adeleted\"\x94\x01\n" +
 	"$GetSandboxProviderEnvironmentRequest\x12\x1d\n" +
 	"\n" +
-	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"\xcb\x05\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12M\n" +
+	"#supports_static_credential_bindings\x18\x02 \x01(\bR supportsStaticCredentialBindings\"]\n" +
+	"\x1fStaticCredentialEndpointBinding\x12\x12\n" +
+	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
+	"\x04port\x18\x02 \x01(\rR\x04port\x12\x12\n" +
+	"\x04path\x18\x03 \x01(\tR\x04path\"\x97\x01\n" +
+	"\x17StaticCredentialBinding\x12K\n" +
+	"\tendpoints\x18\x01 \x03(\v2-.openshell.v1.StaticCredentialEndpointBindingR\tendpoints\x12/\n" +
+	"\x13credential_identity\x18\x02 \x01(\tR\x12credentialIdentity\"\x90\b\n" +
 	"%GetSandboxProviderEnvironmentResponse\x12l\n" +
 	"\venvironment\x18\x01 \x03(\v2D.openshell.v1.GetSandboxProviderEnvironmentResponse.EnvironmentEntryB\x04\x88\xb5\x18\x01R\venvironment\x122\n" +
 	"\x15provider_env_revision\x18\x02 \x01(\x04R\x13providerEnvRevision\x12\x87\x01\n" +
 	"\x18credential_expires_at_ms\x18\x03 \x03(\v2N.openshell.v1.GetSandboxProviderEnvironmentResponse.CredentialExpiresAtMsEntryR\x15credentialExpiresAtMs\x12|\n" +
-	"\x13dynamic_credentials\x18\x04 \x03(\v2K.openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntryR\x12dynamicCredentials\x1a>\n" +
+	"\x13dynamic_credentials\x18\x04 \x03(\v2K.openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntryR\x12dynamicCredentials\x12\x8f\x01\n" +
+	"\x1astatic_credential_bindings\x18\x05 \x03(\v2Q.openshell.v1.GetSandboxProviderEnvironmentResponse.StaticCredentialBindingsEntryR\x18staticCredentialBindings\x12=\n" +
+	"\x1bnon_secret_environment_keys\x18\x06 \x03(\tR\x18nonSecretEnvironmentKeys\x1a>\n" +
 	"\x10EnvironmentEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aH\n" +
@@ -13245,7 +13405,10 @@ const file_openshell_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\x1an\n" +
 	"\x17DynamicCredentialsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12=\n" +
-	"\x05value\x18\x02 \x01(\v2'.openshell.v1.ProviderProfileCredentialR\x05value:\x028\x01\"\xce\x04\n" +
+	"\x05value\x18\x02 \x01(\v2'.openshell.v1.ProviderProfileCredentialR\x05value:\x028\x01\x1ar\n" +
+	"\x1dStaticCredentialBindingsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12;\n" +
+	"\x05value\x18\x02 \x01(\v2%.openshell.v1.StaticCredentialBindingR\x05value:\x028\x01\"\xce\x04\n" +
 	"\x13UpdateConfigRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12;\n" +
 	"\x06policy\x18\x02 \x01(\v2#.openshell.sandbox.v1.SandboxPolicyR\x06policy\x12\x1f\n" +
@@ -13869,7 +14032,7 @@ func file_openshell_proto_rawDescGZIP() []byte {
 }
 
 var file_openshell_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_openshell_proto_msgTypes = make([]protoimpl.MessageInfo, 203)
+var file_openshell_proto_msgTypes = make([]protoimpl.MessageInfo, 206)
 var file_openshell_proto_goTypes = []any{
 	(SandboxPhase)(0),                                    // 0: openshell.v1.SandboxPhase
 	(ProviderCredentialRefreshStrategy)(0),               // 1: openshell.v1.ProviderCredentialRefreshStrategy
@@ -13978,177 +14141,180 @@ var file_openshell_proto_goTypes = []any{
 	(*DeleteProviderProfileRequest)(nil),                 // 104: openshell.v1.DeleteProviderProfileRequest
 	(*DeleteProviderProfileResponse)(nil),                // 105: openshell.v1.DeleteProviderProfileResponse
 	(*GetSandboxProviderEnvironmentRequest)(nil),         // 106: openshell.v1.GetSandboxProviderEnvironmentRequest
-	(*GetSandboxProviderEnvironmentResponse)(nil),        // 107: openshell.v1.GetSandboxProviderEnvironmentResponse
-	(*UpdateConfigRequest)(nil),                          // 108: openshell.v1.UpdateConfigRequest
-	(*PolicyMergeOperation)(nil),                         // 109: openshell.v1.PolicyMergeOperation
-	(*AddNetworkRule)(nil),                               // 110: openshell.v1.AddNetworkRule
-	(*RemoveNetworkEndpoint)(nil),                        // 111: openshell.v1.RemoveNetworkEndpoint
-	(*RemoveNetworkRule)(nil),                            // 112: openshell.v1.RemoveNetworkRule
-	(*AddDenyRules)(nil),                                 // 113: openshell.v1.AddDenyRules
-	(*AddAllowRules)(nil),                                // 114: openshell.v1.AddAllowRules
-	(*RemoveNetworkBinary)(nil),                          // 115: openshell.v1.RemoveNetworkBinary
-	(*UpdateConfigResponse)(nil),                         // 116: openshell.v1.UpdateConfigResponse
-	(*GetSandboxPolicyStatusRequest)(nil),                // 117: openshell.v1.GetSandboxPolicyStatusRequest
-	(*GetSandboxPolicyStatusResponse)(nil),               // 118: openshell.v1.GetSandboxPolicyStatusResponse
-	(*ListSandboxPoliciesRequest)(nil),                   // 119: openshell.v1.ListSandboxPoliciesRequest
-	(*ListSandboxPoliciesResponse)(nil),                  // 120: openshell.v1.ListSandboxPoliciesResponse
-	(*ReportPolicyStatusRequest)(nil),                    // 121: openshell.v1.ReportPolicyStatusRequest
-	(*ReportPolicyStatusResponse)(nil),                   // 122: openshell.v1.ReportPolicyStatusResponse
-	(*SandboxPolicyRevision)(nil),                        // 123: openshell.v1.SandboxPolicyRevision
-	(*GetSandboxLogsRequest)(nil),                        // 124: openshell.v1.GetSandboxLogsRequest
-	(*PushSandboxLogsRequest)(nil),                       // 125: openshell.v1.PushSandboxLogsRequest
-	(*PushSandboxLogsResponse)(nil),                      // 126: openshell.v1.PushSandboxLogsResponse
-	(*GetSandboxLogsResponse)(nil),                       // 127: openshell.v1.GetSandboxLogsResponse
-	(*SupervisorMessage)(nil),                            // 128: openshell.v1.SupervisorMessage
-	(*GatewayMessage)(nil),                               // 129: openshell.v1.GatewayMessage
-	(*SupervisorHello)(nil),                              // 130: openshell.v1.SupervisorHello
-	(*SessionAccepted)(nil),                              // 131: openshell.v1.SessionAccepted
-	(*SessionRejected)(nil),                              // 132: openshell.v1.SessionRejected
-	(*SupervisorHeartbeat)(nil),                          // 133: openshell.v1.SupervisorHeartbeat
-	(*GatewayHeartbeat)(nil),                             // 134: openshell.v1.GatewayHeartbeat
-	(*RelayOpen)(nil),                                    // 135: openshell.v1.RelayOpen
-	(*SshRelayTarget)(nil),                               // 136: openshell.v1.SshRelayTarget
-	(*TcpRelayTarget)(nil),                               // 137: openshell.v1.TcpRelayTarget
-	(*RelayInit)(nil),                                    // 138: openshell.v1.RelayInit
-	(*RelayFrame)(nil),                                   // 139: openshell.v1.RelayFrame
-	(*RelayOpenResult)(nil),                              // 140: openshell.v1.RelayOpenResult
-	(*RelayClose)(nil),                                   // 141: openshell.v1.RelayClose
-	(*L7RequestSample)(nil),                              // 142: openshell.v1.L7RequestSample
-	(*DenialSummary)(nil),                                // 143: openshell.v1.DenialSummary
-	(*DenialGroupCount)(nil),                             // 144: openshell.v1.DenialGroupCount
-	(*NetworkActivitySummary)(nil),                       // 145: openshell.v1.NetworkActivitySummary
-	(*PolicyChunk)(nil),                                  // 146: openshell.v1.PolicyChunk
-	(*DraftPolicyUpdate)(nil),                            // 147: openshell.v1.DraftPolicyUpdate
-	(*SubmitPolicyAnalysisRequest)(nil),                  // 148: openshell.v1.SubmitPolicyAnalysisRequest
-	(*SubmitPolicyAnalysisResponse)(nil),                 // 149: openshell.v1.SubmitPolicyAnalysisResponse
-	(*GetDraftPolicyRequest)(nil),                        // 150: openshell.v1.GetDraftPolicyRequest
-	(*GetDraftPolicyResponse)(nil),                       // 151: openshell.v1.GetDraftPolicyResponse
-	(*ApproveDraftChunkRequest)(nil),                     // 152: openshell.v1.ApproveDraftChunkRequest
-	(*ApproveDraftChunkResponse)(nil),                    // 153: openshell.v1.ApproveDraftChunkResponse
-	(*RejectDraftChunkRequest)(nil),                      // 154: openshell.v1.RejectDraftChunkRequest
-	(*RejectDraftChunkResponse)(nil),                     // 155: openshell.v1.RejectDraftChunkResponse
-	(*ApproveAllDraftChunksRequest)(nil),                 // 156: openshell.v1.ApproveAllDraftChunksRequest
-	(*ApproveAllDraftChunksResponse)(nil),                // 157: openshell.v1.ApproveAllDraftChunksResponse
-	(*EditDraftChunkRequest)(nil),                        // 158: openshell.v1.EditDraftChunkRequest
-	(*EditDraftChunkResponse)(nil),                       // 159: openshell.v1.EditDraftChunkResponse
-	(*UndoDraftChunkRequest)(nil),                        // 160: openshell.v1.UndoDraftChunkRequest
-	(*UndoDraftChunkResponse)(nil),                       // 161: openshell.v1.UndoDraftChunkResponse
-	(*ClearDraftChunksRequest)(nil),                      // 162: openshell.v1.ClearDraftChunksRequest
-	(*ClearDraftChunksResponse)(nil),                     // 163: openshell.v1.ClearDraftChunksResponse
-	(*GetDraftHistoryRequest)(nil),                       // 164: openshell.v1.GetDraftHistoryRequest
-	(*DraftHistoryEntry)(nil),                            // 165: openshell.v1.DraftHistoryEntry
-	(*GetDraftHistoryResponse)(nil),                      // 166: openshell.v1.GetDraftHistoryResponse
-	(*PolicyRevisionPayload)(nil),                        // 167: openshell.v1.PolicyRevisionPayload
-	(*DraftChunkPayload)(nil),                            // 168: openshell.v1.DraftChunkPayload
-	(*StoredPolicyRevision)(nil),                         // 169: openshell.v1.StoredPolicyRevision
-	(*StoredDraftChunk)(nil),                             // 170: openshell.v1.StoredDraftChunk
-	(*CreateWorkspaceRequest)(nil),                       // 171: openshell.v1.CreateWorkspaceRequest
-	(*CreateWorkspaceResponse)(nil),                      // 172: openshell.v1.CreateWorkspaceResponse
-	(*GetWorkspaceRequest)(nil),                          // 173: openshell.v1.GetWorkspaceRequest
-	(*GetWorkspaceResponse)(nil),                         // 174: openshell.v1.GetWorkspaceResponse
-	(*ListWorkspacesRequest)(nil),                        // 175: openshell.v1.ListWorkspacesRequest
-	(*ListWorkspacesResponse)(nil),                       // 176: openshell.v1.ListWorkspacesResponse
-	(*DeleteWorkspaceRequest)(nil),                       // 177: openshell.v1.DeleteWorkspaceRequest
-	(*DeleteWorkspaceResponse)(nil),                      // 178: openshell.v1.DeleteWorkspaceResponse
-	(*WorkspaceMember)(nil),                              // 179: openshell.v1.WorkspaceMember
-	(*AddWorkspaceMemberRequest)(nil),                    // 180: openshell.v1.AddWorkspaceMemberRequest
-	(*AddWorkspaceMemberResponse)(nil),                   // 181: openshell.v1.AddWorkspaceMemberResponse
-	(*RemoveWorkspaceMemberRequest)(nil),                 // 182: openshell.v1.RemoveWorkspaceMemberRequest
-	(*RemoveWorkspaceMemberResponse)(nil),                // 183: openshell.v1.RemoveWorkspaceMemberResponse
-	(*ListWorkspaceMembersRequest)(nil),                  // 184: openshell.v1.ListWorkspaceMembersRequest
-	(*ListWorkspaceMembersResponse)(nil),                 // 185: openshell.v1.ListWorkspaceMembersResponse
-	nil,                                                  // 186: openshell.v1.SandboxSpec.EnvironmentEntry
-	nil,                                                  // 187: openshell.v1.SandboxTemplate.LabelsEntry
-	nil,                                                  // 188: openshell.v1.SandboxTemplate.AnnotationsEntry
-	nil,                                                  // 189: openshell.v1.SandboxTemplate.EnvironmentEntry
-	nil,                                                  // 190: openshell.v1.PlatformEvent.MetadataEntry
-	nil,                                                  // 191: openshell.v1.CreateSandboxRequest.LabelsEntry
-	nil,                                                  // 192: openshell.v1.CreateSandboxRequest.AnnotationsEntry
-	nil,                                                  // 193: openshell.v1.ExecSandboxRequest.EnvironmentEntry
-	nil,                                                  // 194: openshell.v1.SandboxLogLine.FieldsEntry
-	nil,                                                  // 195: openshell.v1.UpdateProviderRequest.CredentialExpiresAtMsEntry
-	nil,                                                  // 196: openshell.v1.StoredProviderCredentialRefreshState.MaterialEntry
-	nil,                                                  // 197: openshell.v1.StoredProviderCredentialRefreshState.AdditionalOutputKeysEntry
-	nil,                                                  // 198: openshell.v1.ConfigureProviderRefreshRequest.MaterialEntry
-	nil,                                                  // 199: openshell.v1.ProviderProfile.AnnotationsEntry
-	nil,                                                  // 200: openshell.v1.GetSandboxProviderEnvironmentResponse.EnvironmentEntry
-	nil,                                                  // 201: openshell.v1.GetSandboxProviderEnvironmentResponse.CredentialExpiresAtMsEntry
-	nil,                                                  // 202: openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntry
-	nil,                                                  // 203: openshell.v1.UpdateConfigRequest.AnnotationsEntry
-	nil,                                                  // 204: openshell.v1.UpdateConfigResponse.AnnotationsEntry
-	nil,                                                  // 205: openshell.v1.SandboxPolicyRevision.ProvenanceEntry
-	nil,                                                  // 206: openshell.v1.PolicyRevisionPayload.ProvenanceEntry
-	nil,                                                  // 207: openshell.v1.StoredPolicyRevision.ProvenanceEntry
-	nil,                                                  // 208: openshell.v1.CreateWorkspaceRequest.LabelsEntry
-	(*datamodelv1.ObjectMeta)(nil),                       // 209: openshell.datamodel.v1.ObjectMeta
-	(*sandboxv1.SandboxPolicy)(nil),                      // 210: openshell.sandbox.v1.SandboxPolicy
-	(*structpb.Struct)(nil),                              // 211: google.protobuf.Struct
-	(*datamodelv1.Provider)(nil),                         // 212: openshell.datamodel.v1.Provider
-	(*sandboxv1.NetworkEndpoint)(nil),                    // 213: openshell.sandbox.v1.NetworkEndpoint
-	(*sandboxv1.NetworkBinary)(nil),                      // 214: openshell.sandbox.v1.NetworkBinary
-	(*sandboxv1.SettingValue)(nil),                       // 215: openshell.sandbox.v1.SettingValue
-	(*sandboxv1.NetworkPolicyRule)(nil),                  // 216: openshell.sandbox.v1.NetworkPolicyRule
-	(*sandboxv1.L7DenyRule)(nil),                         // 217: openshell.sandbox.v1.L7DenyRule
-	(*sandboxv1.L7Rule)(nil),                             // 218: openshell.sandbox.v1.L7Rule
-	(*datamodelv1.Workspace)(nil),                        // 219: openshell.datamodel.v1.Workspace
-	(*sandboxv1.GetSandboxConfigRequest)(nil),            // 220: openshell.sandbox.v1.GetSandboxConfigRequest
-	(*sandboxv1.GetGatewayConfigRequest)(nil),            // 221: openshell.sandbox.v1.GetGatewayConfigRequest
-	(*sandboxv1.GetSandboxConfigResponse)(nil),           // 222: openshell.sandbox.v1.GetSandboxConfigResponse
-	(*sandboxv1.GetGatewayConfigResponse)(nil),           // 223: openshell.sandbox.v1.GetGatewayConfigResponse
+	(*StaticCredentialEndpointBinding)(nil),              // 107: openshell.v1.StaticCredentialEndpointBinding
+	(*StaticCredentialBinding)(nil),                      // 108: openshell.v1.StaticCredentialBinding
+	(*GetSandboxProviderEnvironmentResponse)(nil),        // 109: openshell.v1.GetSandboxProviderEnvironmentResponse
+	(*UpdateConfigRequest)(nil),                          // 110: openshell.v1.UpdateConfigRequest
+	(*PolicyMergeOperation)(nil),                         // 111: openshell.v1.PolicyMergeOperation
+	(*AddNetworkRule)(nil),                               // 112: openshell.v1.AddNetworkRule
+	(*RemoveNetworkEndpoint)(nil),                        // 113: openshell.v1.RemoveNetworkEndpoint
+	(*RemoveNetworkRule)(nil),                            // 114: openshell.v1.RemoveNetworkRule
+	(*AddDenyRules)(nil),                                 // 115: openshell.v1.AddDenyRules
+	(*AddAllowRules)(nil),                                // 116: openshell.v1.AddAllowRules
+	(*RemoveNetworkBinary)(nil),                          // 117: openshell.v1.RemoveNetworkBinary
+	(*UpdateConfigResponse)(nil),                         // 118: openshell.v1.UpdateConfigResponse
+	(*GetSandboxPolicyStatusRequest)(nil),                // 119: openshell.v1.GetSandboxPolicyStatusRequest
+	(*GetSandboxPolicyStatusResponse)(nil),               // 120: openshell.v1.GetSandboxPolicyStatusResponse
+	(*ListSandboxPoliciesRequest)(nil),                   // 121: openshell.v1.ListSandboxPoliciesRequest
+	(*ListSandboxPoliciesResponse)(nil),                  // 122: openshell.v1.ListSandboxPoliciesResponse
+	(*ReportPolicyStatusRequest)(nil),                    // 123: openshell.v1.ReportPolicyStatusRequest
+	(*ReportPolicyStatusResponse)(nil),                   // 124: openshell.v1.ReportPolicyStatusResponse
+	(*SandboxPolicyRevision)(nil),                        // 125: openshell.v1.SandboxPolicyRevision
+	(*GetSandboxLogsRequest)(nil),                        // 126: openshell.v1.GetSandboxLogsRequest
+	(*PushSandboxLogsRequest)(nil),                       // 127: openshell.v1.PushSandboxLogsRequest
+	(*PushSandboxLogsResponse)(nil),                      // 128: openshell.v1.PushSandboxLogsResponse
+	(*GetSandboxLogsResponse)(nil),                       // 129: openshell.v1.GetSandboxLogsResponse
+	(*SupervisorMessage)(nil),                            // 130: openshell.v1.SupervisorMessage
+	(*GatewayMessage)(nil),                               // 131: openshell.v1.GatewayMessage
+	(*SupervisorHello)(nil),                              // 132: openshell.v1.SupervisorHello
+	(*SessionAccepted)(nil),                              // 133: openshell.v1.SessionAccepted
+	(*SessionRejected)(nil),                              // 134: openshell.v1.SessionRejected
+	(*SupervisorHeartbeat)(nil),                          // 135: openshell.v1.SupervisorHeartbeat
+	(*GatewayHeartbeat)(nil),                             // 136: openshell.v1.GatewayHeartbeat
+	(*RelayOpen)(nil),                                    // 137: openshell.v1.RelayOpen
+	(*SshRelayTarget)(nil),                               // 138: openshell.v1.SshRelayTarget
+	(*TcpRelayTarget)(nil),                               // 139: openshell.v1.TcpRelayTarget
+	(*RelayInit)(nil),                                    // 140: openshell.v1.RelayInit
+	(*RelayFrame)(nil),                                   // 141: openshell.v1.RelayFrame
+	(*RelayOpenResult)(nil),                              // 142: openshell.v1.RelayOpenResult
+	(*RelayClose)(nil),                                   // 143: openshell.v1.RelayClose
+	(*L7RequestSample)(nil),                              // 144: openshell.v1.L7RequestSample
+	(*DenialSummary)(nil),                                // 145: openshell.v1.DenialSummary
+	(*DenialGroupCount)(nil),                             // 146: openshell.v1.DenialGroupCount
+	(*NetworkActivitySummary)(nil),                       // 147: openshell.v1.NetworkActivitySummary
+	(*PolicyChunk)(nil),                                  // 148: openshell.v1.PolicyChunk
+	(*DraftPolicyUpdate)(nil),                            // 149: openshell.v1.DraftPolicyUpdate
+	(*SubmitPolicyAnalysisRequest)(nil),                  // 150: openshell.v1.SubmitPolicyAnalysisRequest
+	(*SubmitPolicyAnalysisResponse)(nil),                 // 151: openshell.v1.SubmitPolicyAnalysisResponse
+	(*GetDraftPolicyRequest)(nil),                        // 152: openshell.v1.GetDraftPolicyRequest
+	(*GetDraftPolicyResponse)(nil),                       // 153: openshell.v1.GetDraftPolicyResponse
+	(*ApproveDraftChunkRequest)(nil),                     // 154: openshell.v1.ApproveDraftChunkRequest
+	(*ApproveDraftChunkResponse)(nil),                    // 155: openshell.v1.ApproveDraftChunkResponse
+	(*RejectDraftChunkRequest)(nil),                      // 156: openshell.v1.RejectDraftChunkRequest
+	(*RejectDraftChunkResponse)(nil),                     // 157: openshell.v1.RejectDraftChunkResponse
+	(*ApproveAllDraftChunksRequest)(nil),                 // 158: openshell.v1.ApproveAllDraftChunksRequest
+	(*ApproveAllDraftChunksResponse)(nil),                // 159: openshell.v1.ApproveAllDraftChunksResponse
+	(*EditDraftChunkRequest)(nil),                        // 160: openshell.v1.EditDraftChunkRequest
+	(*EditDraftChunkResponse)(nil),                       // 161: openshell.v1.EditDraftChunkResponse
+	(*UndoDraftChunkRequest)(nil),                        // 162: openshell.v1.UndoDraftChunkRequest
+	(*UndoDraftChunkResponse)(nil),                       // 163: openshell.v1.UndoDraftChunkResponse
+	(*ClearDraftChunksRequest)(nil),                      // 164: openshell.v1.ClearDraftChunksRequest
+	(*ClearDraftChunksResponse)(nil),                     // 165: openshell.v1.ClearDraftChunksResponse
+	(*GetDraftHistoryRequest)(nil),                       // 166: openshell.v1.GetDraftHistoryRequest
+	(*DraftHistoryEntry)(nil),                            // 167: openshell.v1.DraftHistoryEntry
+	(*GetDraftHistoryResponse)(nil),                      // 168: openshell.v1.GetDraftHistoryResponse
+	(*PolicyRevisionPayload)(nil),                        // 169: openshell.v1.PolicyRevisionPayload
+	(*DraftChunkPayload)(nil),                            // 170: openshell.v1.DraftChunkPayload
+	(*StoredPolicyRevision)(nil),                         // 171: openshell.v1.StoredPolicyRevision
+	(*StoredDraftChunk)(nil),                             // 172: openshell.v1.StoredDraftChunk
+	(*CreateWorkspaceRequest)(nil),                       // 173: openshell.v1.CreateWorkspaceRequest
+	(*CreateWorkspaceResponse)(nil),                      // 174: openshell.v1.CreateWorkspaceResponse
+	(*GetWorkspaceRequest)(nil),                          // 175: openshell.v1.GetWorkspaceRequest
+	(*GetWorkspaceResponse)(nil),                         // 176: openshell.v1.GetWorkspaceResponse
+	(*ListWorkspacesRequest)(nil),                        // 177: openshell.v1.ListWorkspacesRequest
+	(*ListWorkspacesResponse)(nil),                       // 178: openshell.v1.ListWorkspacesResponse
+	(*DeleteWorkspaceRequest)(nil),                       // 179: openshell.v1.DeleteWorkspaceRequest
+	(*DeleteWorkspaceResponse)(nil),                      // 180: openshell.v1.DeleteWorkspaceResponse
+	(*WorkspaceMember)(nil),                              // 181: openshell.v1.WorkspaceMember
+	(*AddWorkspaceMemberRequest)(nil),                    // 182: openshell.v1.AddWorkspaceMemberRequest
+	(*AddWorkspaceMemberResponse)(nil),                   // 183: openshell.v1.AddWorkspaceMemberResponse
+	(*RemoveWorkspaceMemberRequest)(nil),                 // 184: openshell.v1.RemoveWorkspaceMemberRequest
+	(*RemoveWorkspaceMemberResponse)(nil),                // 185: openshell.v1.RemoveWorkspaceMemberResponse
+	(*ListWorkspaceMembersRequest)(nil),                  // 186: openshell.v1.ListWorkspaceMembersRequest
+	(*ListWorkspaceMembersResponse)(nil),                 // 187: openshell.v1.ListWorkspaceMembersResponse
+	nil,                                                  // 188: openshell.v1.SandboxSpec.EnvironmentEntry
+	nil,                                                  // 189: openshell.v1.SandboxTemplate.LabelsEntry
+	nil,                                                  // 190: openshell.v1.SandboxTemplate.AnnotationsEntry
+	nil,                                                  // 191: openshell.v1.SandboxTemplate.EnvironmentEntry
+	nil,                                                  // 192: openshell.v1.PlatformEvent.MetadataEntry
+	nil,                                                  // 193: openshell.v1.CreateSandboxRequest.LabelsEntry
+	nil,                                                  // 194: openshell.v1.CreateSandboxRequest.AnnotationsEntry
+	nil,                                                  // 195: openshell.v1.ExecSandboxRequest.EnvironmentEntry
+	nil,                                                  // 196: openshell.v1.SandboxLogLine.FieldsEntry
+	nil,                                                  // 197: openshell.v1.UpdateProviderRequest.CredentialExpiresAtMsEntry
+	nil,                                                  // 198: openshell.v1.StoredProviderCredentialRefreshState.MaterialEntry
+	nil,                                                  // 199: openshell.v1.StoredProviderCredentialRefreshState.AdditionalOutputKeysEntry
+	nil,                                                  // 200: openshell.v1.ConfigureProviderRefreshRequest.MaterialEntry
+	nil,                                                  // 201: openshell.v1.ProviderProfile.AnnotationsEntry
+	nil,                                                  // 202: openshell.v1.GetSandboxProviderEnvironmentResponse.EnvironmentEntry
+	nil,                                                  // 203: openshell.v1.GetSandboxProviderEnvironmentResponse.CredentialExpiresAtMsEntry
+	nil,                                                  // 204: openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntry
+	nil,                                                  // 205: openshell.v1.GetSandboxProviderEnvironmentResponse.StaticCredentialBindingsEntry
+	nil,                                                  // 206: openshell.v1.UpdateConfigRequest.AnnotationsEntry
+	nil,                                                  // 207: openshell.v1.UpdateConfigResponse.AnnotationsEntry
+	nil,                                                  // 208: openshell.v1.SandboxPolicyRevision.ProvenanceEntry
+	nil,                                                  // 209: openshell.v1.PolicyRevisionPayload.ProvenanceEntry
+	nil,                                                  // 210: openshell.v1.StoredPolicyRevision.ProvenanceEntry
+	nil,                                                  // 211: openshell.v1.CreateWorkspaceRequest.LabelsEntry
+	(*datamodelv1.ObjectMeta)(nil),                       // 212: openshell.datamodel.v1.ObjectMeta
+	(*sandboxv1.SandboxPolicy)(nil),                      // 213: openshell.sandbox.v1.SandboxPolicy
+	(*structpb.Struct)(nil),                              // 214: google.protobuf.Struct
+	(*datamodelv1.Provider)(nil),                         // 215: openshell.datamodel.v1.Provider
+	(*sandboxv1.NetworkEndpoint)(nil),                    // 216: openshell.sandbox.v1.NetworkEndpoint
+	(*sandboxv1.NetworkBinary)(nil),                      // 217: openshell.sandbox.v1.NetworkBinary
+	(*sandboxv1.SettingValue)(nil),                       // 218: openshell.sandbox.v1.SettingValue
+	(*sandboxv1.NetworkPolicyRule)(nil),                  // 219: openshell.sandbox.v1.NetworkPolicyRule
+	(*sandboxv1.L7DenyRule)(nil),                         // 220: openshell.sandbox.v1.L7DenyRule
+	(*sandboxv1.L7Rule)(nil),                             // 221: openshell.sandbox.v1.L7Rule
+	(*datamodelv1.Workspace)(nil),                        // 222: openshell.datamodel.v1.Workspace
+	(*sandboxv1.GetSandboxConfigRequest)(nil),            // 223: openshell.sandbox.v1.GetSandboxConfigRequest
+	(*sandboxv1.GetGatewayConfigRequest)(nil),            // 224: openshell.sandbox.v1.GetGatewayConfigRequest
+	(*sandboxv1.GetSandboxConfigResponse)(nil),           // 225: openshell.sandbox.v1.GetSandboxConfigResponse
+	(*sandboxv1.GetGatewayConfigResponse)(nil),           // 226: openshell.sandbox.v1.GetGatewayConfigResponse
 }
 var file_openshell_proto_depIdxs = []int32{
 	4,   // 0: openshell.v1.HealthResponse.status:type_name -> openshell.v1.ServiceStatus
 	4,   // 1: openshell.v1.GetGatewayInfoResponse.status:type_name -> openshell.v1.ServiceStatus
 	16,  // 2: openshell.v1.GetGatewayInfoResponse.compute_drivers:type_name -> openshell.v1.ComputeDriverInfo
 	17,  // 3: openshell.v1.ComputeDriverInfo.capabilities:type_name -> openshell.v1.ComputeDriverCapabilities
-	209, // 4: openshell.v1.Sandbox.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	212, // 4: openshell.v1.Sandbox.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
 	19,  // 5: openshell.v1.Sandbox.spec:type_name -> openshell.v1.SandboxSpec
 	23,  // 6: openshell.v1.Sandbox.status:type_name -> openshell.v1.SandboxStatus
-	186, // 7: openshell.v1.SandboxSpec.environment:type_name -> openshell.v1.SandboxSpec.EnvironmentEntry
+	188, // 7: openshell.v1.SandboxSpec.environment:type_name -> openshell.v1.SandboxSpec.EnvironmentEntry
 	22,  // 8: openshell.v1.SandboxSpec.template:type_name -> openshell.v1.SandboxTemplate
-	210, // 9: openshell.v1.SandboxSpec.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
+	213, // 9: openshell.v1.SandboxSpec.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
 	20,  // 10: openshell.v1.SandboxSpec.resource_requirements:type_name -> openshell.v1.ResourceRequirements
 	21,  // 11: openshell.v1.ResourceRequirements.gpu:type_name -> openshell.v1.GpuResourceRequirements
-	187, // 12: openshell.v1.SandboxTemplate.labels:type_name -> openshell.v1.SandboxTemplate.LabelsEntry
-	188, // 13: openshell.v1.SandboxTemplate.annotations:type_name -> openshell.v1.SandboxTemplate.AnnotationsEntry
-	189, // 14: openshell.v1.SandboxTemplate.environment:type_name -> openshell.v1.SandboxTemplate.EnvironmentEntry
-	211, // 15: openshell.v1.SandboxTemplate.resources:type_name -> google.protobuf.Struct
-	211, // 16: openshell.v1.SandboxTemplate.driver_config:type_name -> google.protobuf.Struct
+	189, // 12: openshell.v1.SandboxTemplate.labels:type_name -> openshell.v1.SandboxTemplate.LabelsEntry
+	190, // 13: openshell.v1.SandboxTemplate.annotations:type_name -> openshell.v1.SandboxTemplate.AnnotationsEntry
+	191, // 14: openshell.v1.SandboxTemplate.environment:type_name -> openshell.v1.SandboxTemplate.EnvironmentEntry
+	214, // 15: openshell.v1.SandboxTemplate.resources:type_name -> google.protobuf.Struct
+	214, // 16: openshell.v1.SandboxTemplate.driver_config:type_name -> google.protobuf.Struct
 	24,  // 17: openshell.v1.SandboxStatus.conditions:type_name -> openshell.v1.SandboxCondition
 	0,   // 18: openshell.v1.SandboxStatus.phase:type_name -> openshell.v1.SandboxPhase
-	190, // 19: openshell.v1.PlatformEvent.metadata:type_name -> openshell.v1.PlatformEvent.MetadataEntry
+	192, // 19: openshell.v1.PlatformEvent.metadata:type_name -> openshell.v1.PlatformEvent.MetadataEntry
 	19,  // 20: openshell.v1.CreateSandboxRequest.spec:type_name -> openshell.v1.SandboxSpec
-	191, // 21: openshell.v1.CreateSandboxRequest.labels:type_name -> openshell.v1.CreateSandboxRequest.LabelsEntry
-	192, // 22: openshell.v1.CreateSandboxRequest.annotations:type_name -> openshell.v1.CreateSandboxRequest.AnnotationsEntry
+	193, // 21: openshell.v1.CreateSandboxRequest.labels:type_name -> openshell.v1.CreateSandboxRequest.LabelsEntry
+	194, // 22: openshell.v1.CreateSandboxRequest.annotations:type_name -> openshell.v1.CreateSandboxRequest.AnnotationsEntry
 	18,  // 23: openshell.v1.SandboxResponse.sandbox:type_name -> openshell.v1.Sandbox
 	18,  // 24: openshell.v1.ListSandboxesResponse.sandboxes:type_name -> openshell.v1.Sandbox
-	212, // 25: openshell.v1.ListSandboxProvidersResponse.providers:type_name -> openshell.datamodel.v1.Provider
+	215, // 25: openshell.v1.ListSandboxProvidersResponse.providers:type_name -> openshell.datamodel.v1.Provider
 	18,  // 26: openshell.v1.AttachSandboxProviderResponse.sandbox:type_name -> openshell.v1.Sandbox
 	18,  // 27: openshell.v1.DetachSandboxProviderResponse.sandbox:type_name -> openshell.v1.Sandbox
 	48,  // 28: openshell.v1.ListServicesResponse.services:type_name -> openshell.v1.ServiceEndpointResponse
-	209, // 29: openshell.v1.ServiceEndpoint.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	212, // 29: openshell.v1.ServiceEndpoint.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
 	47,  // 30: openshell.v1.ServiceEndpointResponse.endpoint:type_name -> openshell.v1.ServiceEndpoint
-	193, // 31: openshell.v1.ExecSandboxRequest.environment:type_name -> openshell.v1.ExecSandboxRequest.EnvironmentEntry
+	195, // 31: openshell.v1.ExecSandboxRequest.environment:type_name -> openshell.v1.ExecSandboxRequest.EnvironmentEntry
 	52,  // 32: openshell.v1.ExecSandboxEvent.stdout:type_name -> openshell.v1.ExecSandboxStdout
 	53,  // 33: openshell.v1.ExecSandboxEvent.stderr:type_name -> openshell.v1.ExecSandboxStderr
 	54,  // 34: openshell.v1.ExecSandboxEvent.exit:type_name -> openshell.v1.ExecSandboxExit
-	136, // 35: openshell.v1.TcpForwardInit.ssh:type_name -> openshell.v1.SshRelayTarget
-	137, // 36: openshell.v1.TcpForwardInit.tcp:type_name -> openshell.v1.TcpRelayTarget
+	138, // 35: openshell.v1.TcpForwardInit.ssh:type_name -> openshell.v1.SshRelayTarget
+	139, // 36: openshell.v1.TcpForwardInit.tcp:type_name -> openshell.v1.TcpRelayTarget
 	56,  // 37: openshell.v1.TcpForwardFrame.init:type_name -> openshell.v1.TcpForwardInit
 	51,  // 38: openshell.v1.ExecSandboxInput.start:type_name -> openshell.v1.ExecSandboxRequest
 	59,  // 39: openshell.v1.ExecSandboxInput.resize:type_name -> openshell.v1.ExecSandboxWindowResize
-	209, // 40: openshell.v1.SshSession.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	212, // 40: openshell.v1.SshSession.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
 	18,  // 41: openshell.v1.SandboxStreamEvent.sandbox:type_name -> openshell.v1.Sandbox
 	63,  // 42: openshell.v1.SandboxStreamEvent.log:type_name -> openshell.v1.SandboxLogLine
 	25,  // 43: openshell.v1.SandboxStreamEvent.event:type_name -> openshell.v1.PlatformEvent
 	64,  // 44: openshell.v1.SandboxStreamEvent.warning:type_name -> openshell.v1.SandboxStreamWarning
-	147, // 45: openshell.v1.SandboxStreamEvent.draft_policy_update:type_name -> openshell.v1.DraftPolicyUpdate
-	194, // 46: openshell.v1.SandboxLogLine.fields:type_name -> openshell.v1.SandboxLogLine.FieldsEntry
-	212, // 47: openshell.v1.CreateProviderRequest.provider:type_name -> openshell.datamodel.v1.Provider
-	212, // 48: openshell.v1.UpdateProviderRequest.provider:type_name -> openshell.datamodel.v1.Provider
-	195, // 49: openshell.v1.UpdateProviderRequest.credential_expires_at_ms:type_name -> openshell.v1.UpdateProviderRequest.CredentialExpiresAtMsEntry
-	212, // 50: openshell.v1.ProviderResponse.provider:type_name -> openshell.datamodel.v1.Provider
-	212, // 51: openshell.v1.ListProvidersResponse.providers:type_name -> openshell.datamodel.v1.Provider
+	149, // 45: openshell.v1.SandboxStreamEvent.draft_policy_update:type_name -> openshell.v1.DraftPolicyUpdate
+	196, // 46: openshell.v1.SandboxLogLine.fields:type_name -> openshell.v1.SandboxLogLine.FieldsEntry
+	215, // 47: openshell.v1.CreateProviderRequest.provider:type_name -> openshell.datamodel.v1.Provider
+	215, // 48: openshell.v1.UpdateProviderRequest.provider:type_name -> openshell.datamodel.v1.Provider
+	197, // 49: openshell.v1.UpdateProviderRequest.credential_expires_at_ms:type_name -> openshell.v1.UpdateProviderRequest.CredentialExpiresAtMsEntry
+	215, // 50: openshell.v1.ProviderResponse.provider:type_name -> openshell.datamodel.v1.Provider
+	215, // 51: openshell.v1.ListProvidersResponse.providers:type_name -> openshell.datamodel.v1.Provider
 	93,  // 52: openshell.v1.ProviderProfileImportItem.profile:type_name -> openshell.v1.ProviderProfile
 	76,  // 53: openshell.v1.ProviderCredentialTokenGrant.audience_overrides:type_name -> openshell.v1.ProviderCredentialTokenGrantAudienceOverride
 	81,  // 54: openshell.v1.ProviderProfileCredential.refresh:type_name -> openshell.v1.ProviderCredentialRefresh
@@ -14157,22 +14323,22 @@ var file_openshell_proto_depIdxs = []int32{
 	79,  // 57: openshell.v1.ProviderCredentialRefresh.material:type_name -> openshell.v1.ProviderCredentialRefreshMaterial
 	80,  // 58: openshell.v1.ProviderCredentialRefresh.additional_outputs:type_name -> openshell.v1.ProviderCredentialRefreshOutput
 	1,   // 59: openshell.v1.ProviderCredentialRefreshStatus.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
-	209, // 60: openshell.v1.StoredProviderCredentialRefreshState.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	212, // 60: openshell.v1.StoredProviderCredentialRefreshState.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
 	1,   // 61: openshell.v1.StoredProviderCredentialRefreshState.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
-	196, // 62: openshell.v1.StoredProviderCredentialRefreshState.material:type_name -> openshell.v1.StoredProviderCredentialRefreshState.MaterialEntry
-	197, // 63: openshell.v1.StoredProviderCredentialRefreshState.additional_output_keys:type_name -> openshell.v1.StoredProviderCredentialRefreshState.AdditionalOutputKeysEntry
+	198, // 62: openshell.v1.StoredProviderCredentialRefreshState.material:type_name -> openshell.v1.StoredProviderCredentialRefreshState.MaterialEntry
+	199, // 63: openshell.v1.StoredProviderCredentialRefreshState.additional_output_keys:type_name -> openshell.v1.StoredProviderCredentialRefreshState.AdditionalOutputKeysEntry
 	82,  // 64: openshell.v1.GetProviderRefreshStatusResponse.credentials:type_name -> openshell.v1.ProviderCredentialRefreshStatus
 	1,   // 65: openshell.v1.ConfigureProviderRefreshRequest.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
-	198, // 66: openshell.v1.ConfigureProviderRefreshRequest.material:type_name -> openshell.v1.ConfigureProviderRefreshRequest.MaterialEntry
+	200, // 66: openshell.v1.ConfigureProviderRefreshRequest.material:type_name -> openshell.v1.ConfigureProviderRefreshRequest.MaterialEntry
 	82,  // 67: openshell.v1.ConfigureProviderRefreshResponse.status:type_name -> openshell.v1.ProviderCredentialRefreshStatus
 	82,  // 68: openshell.v1.RotateProviderCredentialResponse.status:type_name -> openshell.v1.ProviderCredentialRefreshStatus
 	2,   // 69: openshell.v1.ProviderProfile.category:type_name -> openshell.v1.ProviderProfileCategory
 	78,  // 70: openshell.v1.ProviderProfile.credentials:type_name -> openshell.v1.ProviderProfileCredential
-	213, // 71: openshell.v1.ProviderProfile.endpoints:type_name -> openshell.sandbox.v1.NetworkEndpoint
-	214, // 72: openshell.v1.ProviderProfile.binaries:type_name -> openshell.sandbox.v1.NetworkBinary
+	216, // 71: openshell.v1.ProviderProfile.endpoints:type_name -> openshell.sandbox.v1.NetworkEndpoint
+	217, // 72: openshell.v1.ProviderProfile.binaries:type_name -> openshell.sandbox.v1.NetworkBinary
 	83,  // 73: openshell.v1.ProviderProfile.discovery:type_name -> openshell.v1.ProviderProfileDiscovery
-	199, // 74: openshell.v1.ProviderProfile.annotations:type_name -> openshell.v1.ProviderProfile.AnnotationsEntry
-	209, // 75: openshell.v1.StoredProviderProfile.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	201, // 74: openshell.v1.ProviderProfile.annotations:type_name -> openshell.v1.ProviderProfile.AnnotationsEntry
+	212, // 75: openshell.v1.StoredProviderProfile.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
 	93,  // 76: openshell.v1.StoredProviderProfile.profile:type_name -> openshell.v1.ProviderProfile
 	93,  // 77: openshell.v1.ProviderProfileResponse.profile:type_name -> openshell.v1.ProviderProfile
 	93,  // 78: openshell.v1.ListProviderProfilesResponse.profiles:type_name -> openshell.v1.ProviderProfile
@@ -14184,199 +14350,202 @@ var file_openshell_proto_depIdxs = []int32{
 	93,  // 84: openshell.v1.UpdateProviderProfilesResponse.profile:type_name -> openshell.v1.ProviderProfile
 	74,  // 85: openshell.v1.LintProviderProfilesRequest.profiles:type_name -> openshell.v1.ProviderProfileImportItem
 	75,  // 86: openshell.v1.LintProviderProfilesResponse.diagnostics:type_name -> openshell.v1.ProviderProfileDiagnostic
-	200, // 87: openshell.v1.GetSandboxProviderEnvironmentResponse.environment:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.EnvironmentEntry
-	201, // 88: openshell.v1.GetSandboxProviderEnvironmentResponse.credential_expires_at_ms:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.CredentialExpiresAtMsEntry
-	202, // 89: openshell.v1.GetSandboxProviderEnvironmentResponse.dynamic_credentials:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntry
-	210, // 90: openshell.v1.UpdateConfigRequest.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
-	215, // 91: openshell.v1.UpdateConfigRequest.setting_value:type_name -> openshell.sandbox.v1.SettingValue
-	109, // 92: openshell.v1.UpdateConfigRequest.merge_operations:type_name -> openshell.v1.PolicyMergeOperation
-	203, // 93: openshell.v1.UpdateConfigRequest.annotations:type_name -> openshell.v1.UpdateConfigRequest.AnnotationsEntry
-	110, // 94: openshell.v1.PolicyMergeOperation.add_rule:type_name -> openshell.v1.AddNetworkRule
-	111, // 95: openshell.v1.PolicyMergeOperation.remove_endpoint:type_name -> openshell.v1.RemoveNetworkEndpoint
-	112, // 96: openshell.v1.PolicyMergeOperation.remove_rule:type_name -> openshell.v1.RemoveNetworkRule
-	113, // 97: openshell.v1.PolicyMergeOperation.add_deny_rules:type_name -> openshell.v1.AddDenyRules
-	114, // 98: openshell.v1.PolicyMergeOperation.add_allow_rules:type_name -> openshell.v1.AddAllowRules
-	115, // 99: openshell.v1.PolicyMergeOperation.remove_binary:type_name -> openshell.v1.RemoveNetworkBinary
-	216, // 100: openshell.v1.AddNetworkRule.rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
-	217, // 101: openshell.v1.AddDenyRules.deny_rules:type_name -> openshell.sandbox.v1.L7DenyRule
-	218, // 102: openshell.v1.AddAllowRules.rules:type_name -> openshell.sandbox.v1.L7Rule
-	204, // 103: openshell.v1.UpdateConfigResponse.annotations:type_name -> openshell.v1.UpdateConfigResponse.AnnotationsEntry
-	123, // 104: openshell.v1.GetSandboxPolicyStatusResponse.revision:type_name -> openshell.v1.SandboxPolicyRevision
-	123, // 105: openshell.v1.ListSandboxPoliciesResponse.revisions:type_name -> openshell.v1.SandboxPolicyRevision
-	3,   // 106: openshell.v1.ReportPolicyStatusRequest.status:type_name -> openshell.v1.PolicyStatus
-	3,   // 107: openshell.v1.SandboxPolicyRevision.status:type_name -> openshell.v1.PolicyStatus
-	210, // 108: openshell.v1.SandboxPolicyRevision.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
-	205, // 109: openshell.v1.SandboxPolicyRevision.provenance:type_name -> openshell.v1.SandboxPolicyRevision.ProvenanceEntry
-	63,  // 110: openshell.v1.PushSandboxLogsRequest.logs:type_name -> openshell.v1.SandboxLogLine
-	63,  // 111: openshell.v1.GetSandboxLogsResponse.logs:type_name -> openshell.v1.SandboxLogLine
-	130, // 112: openshell.v1.SupervisorMessage.hello:type_name -> openshell.v1.SupervisorHello
-	133, // 113: openshell.v1.SupervisorMessage.heartbeat:type_name -> openshell.v1.SupervisorHeartbeat
-	140, // 114: openshell.v1.SupervisorMessage.relay_open_result:type_name -> openshell.v1.RelayOpenResult
-	141, // 115: openshell.v1.SupervisorMessage.relay_close:type_name -> openshell.v1.RelayClose
-	131, // 116: openshell.v1.GatewayMessage.session_accepted:type_name -> openshell.v1.SessionAccepted
-	132, // 117: openshell.v1.GatewayMessage.session_rejected:type_name -> openshell.v1.SessionRejected
-	134, // 118: openshell.v1.GatewayMessage.heartbeat:type_name -> openshell.v1.GatewayHeartbeat
-	135, // 119: openshell.v1.GatewayMessage.relay_open:type_name -> openshell.v1.RelayOpen
-	141, // 120: openshell.v1.GatewayMessage.relay_close:type_name -> openshell.v1.RelayClose
-	136, // 121: openshell.v1.RelayOpen.ssh:type_name -> openshell.v1.SshRelayTarget
-	137, // 122: openshell.v1.RelayOpen.tcp:type_name -> openshell.v1.TcpRelayTarget
-	138, // 123: openshell.v1.RelayFrame.init:type_name -> openshell.v1.RelayInit
-	142, // 124: openshell.v1.DenialSummary.l7_request_samples:type_name -> openshell.v1.L7RequestSample
-	144, // 125: openshell.v1.NetworkActivitySummary.denials_by_group:type_name -> openshell.v1.DenialGroupCount
-	216, // 126: openshell.v1.PolicyChunk.proposed_rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
-	143, // 127: openshell.v1.SubmitPolicyAnalysisRequest.summaries:type_name -> openshell.v1.DenialSummary
-	146, // 128: openshell.v1.SubmitPolicyAnalysisRequest.proposed_chunks:type_name -> openshell.v1.PolicyChunk
-	145, // 129: openshell.v1.SubmitPolicyAnalysisRequest.network_activity_summaries:type_name -> openshell.v1.NetworkActivitySummary
-	146, // 130: openshell.v1.GetDraftPolicyResponse.chunks:type_name -> openshell.v1.PolicyChunk
-	216, // 131: openshell.v1.EditDraftChunkRequest.proposed_rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
-	165, // 132: openshell.v1.GetDraftHistoryResponse.entries:type_name -> openshell.v1.DraftHistoryEntry
-	210, // 133: openshell.v1.PolicyRevisionPayload.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
-	206, // 134: openshell.v1.PolicyRevisionPayload.provenance:type_name -> openshell.v1.PolicyRevisionPayload.ProvenanceEntry
-	216, // 135: openshell.v1.DraftChunkPayload.proposed_rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
-	207, // 136: openshell.v1.StoredPolicyRevision.provenance:type_name -> openshell.v1.StoredPolicyRevision.ProvenanceEntry
-	208, // 137: openshell.v1.CreateWorkspaceRequest.labels:type_name -> openshell.v1.CreateWorkspaceRequest.LabelsEntry
-	219, // 138: openshell.v1.CreateWorkspaceResponse.workspace:type_name -> openshell.datamodel.v1.Workspace
-	219, // 139: openshell.v1.GetWorkspaceResponse.workspace:type_name -> openshell.datamodel.v1.Workspace
-	219, // 140: openshell.v1.ListWorkspacesResponse.workspaces:type_name -> openshell.datamodel.v1.Workspace
-	209, // 141: openshell.v1.WorkspaceMember.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
-	5,   // 142: openshell.v1.WorkspaceMember.role:type_name -> openshell.v1.WorkspaceRole
-	5,   // 143: openshell.v1.AddWorkspaceMemberRequest.role:type_name -> openshell.v1.WorkspaceRole
-	179, // 144: openshell.v1.AddWorkspaceMemberResponse.member:type_name -> openshell.v1.WorkspaceMember
-	179, // 145: openshell.v1.ListWorkspaceMembersResponse.members:type_name -> openshell.v1.WorkspaceMember
-	78,  // 146: openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntry.value:type_name -> openshell.v1.ProviderProfileCredential
-	10,  // 147: openshell.v1.OpenShell.Health:input_type -> openshell.v1.HealthRequest
-	12,  // 148: openshell.v1.OpenShell.GetCurrentUser:input_type -> openshell.v1.GetCurrentUserRequest
-	14,  // 149: openshell.v1.OpenShell.GetGatewayInfo:input_type -> openshell.v1.GetGatewayInfoRequest
-	26,  // 150: openshell.v1.OpenShell.CreateSandbox:input_type -> openshell.v1.CreateSandboxRequest
-	27,  // 151: openshell.v1.OpenShell.GetSandbox:input_type -> openshell.v1.GetSandboxRequest
-	28,  // 152: openshell.v1.OpenShell.ListSandboxes:input_type -> openshell.v1.ListSandboxesRequest
-	29,  // 153: openshell.v1.OpenShell.ListSandboxProviders:input_type -> openshell.v1.ListSandboxProvidersRequest
-	30,  // 154: openshell.v1.OpenShell.AttachSandboxProvider:input_type -> openshell.v1.AttachSandboxProviderRequest
-	31,  // 155: openshell.v1.OpenShell.DetachSandboxProvider:input_type -> openshell.v1.DetachSandboxProviderRequest
-	32,  // 156: openshell.v1.OpenShell.DeleteSandbox:input_type -> openshell.v1.DeleteSandboxRequest
-	39,  // 157: openshell.v1.OpenShell.CreateSshSession:input_type -> openshell.v1.CreateSshSessionRequest
-	41,  // 158: openshell.v1.OpenShell.ExposeService:input_type -> openshell.v1.ExposeServiceRequest
-	42,  // 159: openshell.v1.OpenShell.GetService:input_type -> openshell.v1.GetServiceRequest
-	43,  // 160: openshell.v1.OpenShell.ListServices:input_type -> openshell.v1.ListServicesRequest
-	45,  // 161: openshell.v1.OpenShell.DeleteService:input_type -> openshell.v1.DeleteServiceRequest
-	49,  // 162: openshell.v1.OpenShell.RevokeSshSession:input_type -> openshell.v1.RevokeSshSessionRequest
-	51,  // 163: openshell.v1.OpenShell.ExecSandbox:input_type -> openshell.v1.ExecSandboxRequest
-	57,  // 164: openshell.v1.OpenShell.ForwardTcp:input_type -> openshell.v1.TcpForwardFrame
-	58,  // 165: openshell.v1.OpenShell.ExecSandboxInteractive:input_type -> openshell.v1.ExecSandboxInput
-	65,  // 166: openshell.v1.OpenShell.CreateProvider:input_type -> openshell.v1.CreateProviderRequest
-	66,  // 167: openshell.v1.OpenShell.GetProvider:input_type -> openshell.v1.GetProviderRequest
-	67,  // 168: openshell.v1.OpenShell.ListProviders:input_type -> openshell.v1.ListProvidersRequest
-	72,  // 169: openshell.v1.OpenShell.ListProviderProfiles:input_type -> openshell.v1.ListProviderProfilesRequest
-	73,  // 170: openshell.v1.OpenShell.GetProviderProfile:input_type -> openshell.v1.GetProviderProfileRequest
-	97,  // 171: openshell.v1.OpenShell.ImportProviderProfiles:input_type -> openshell.v1.ImportProviderProfilesRequest
-	99,  // 172: openshell.v1.OpenShell.UpdateProviderProfiles:input_type -> openshell.v1.UpdateProviderProfilesRequest
-	101, // 173: openshell.v1.OpenShell.LintProviderProfiles:input_type -> openshell.v1.LintProviderProfilesRequest
-	68,  // 174: openshell.v1.OpenShell.UpdateProvider:input_type -> openshell.v1.UpdateProviderRequest
-	85,  // 175: openshell.v1.OpenShell.GetProviderRefreshStatus:input_type -> openshell.v1.GetProviderRefreshStatusRequest
-	87,  // 176: openshell.v1.OpenShell.ConfigureProviderRefresh:input_type -> openshell.v1.ConfigureProviderRefreshRequest
-	89,  // 177: openshell.v1.OpenShell.RotateProviderCredential:input_type -> openshell.v1.RotateProviderCredentialRequest
-	91,  // 178: openshell.v1.OpenShell.DeleteProviderRefresh:input_type -> openshell.v1.DeleteProviderRefreshRequest
-	69,  // 179: openshell.v1.OpenShell.DeleteProvider:input_type -> openshell.v1.DeleteProviderRequest
-	104, // 180: openshell.v1.OpenShell.DeleteProviderProfile:input_type -> openshell.v1.DeleteProviderProfileRequest
-	220, // 181: openshell.v1.OpenShell.GetSandboxConfig:input_type -> openshell.sandbox.v1.GetSandboxConfigRequest
-	221, // 182: openshell.v1.OpenShell.GetGatewayConfig:input_type -> openshell.sandbox.v1.GetGatewayConfigRequest
-	108, // 183: openshell.v1.OpenShell.UpdateConfig:input_type -> openshell.v1.UpdateConfigRequest
-	117, // 184: openshell.v1.OpenShell.GetSandboxPolicyStatus:input_type -> openshell.v1.GetSandboxPolicyStatusRequest
-	119, // 185: openshell.v1.OpenShell.ListSandboxPolicies:input_type -> openshell.v1.ListSandboxPoliciesRequest
-	121, // 186: openshell.v1.OpenShell.ReportPolicyStatus:input_type -> openshell.v1.ReportPolicyStatusRequest
-	106, // 187: openshell.v1.OpenShell.GetSandboxProviderEnvironment:input_type -> openshell.v1.GetSandboxProviderEnvironmentRequest
-	124, // 188: openshell.v1.OpenShell.GetSandboxLogs:input_type -> openshell.v1.GetSandboxLogsRequest
-	125, // 189: openshell.v1.OpenShell.PushSandboxLogs:input_type -> openshell.v1.PushSandboxLogsRequest
-	128, // 190: openshell.v1.OpenShell.ConnectSupervisor:input_type -> openshell.v1.SupervisorMessage
-	139, // 191: openshell.v1.OpenShell.RelayStream:input_type -> openshell.v1.RelayFrame
-	61,  // 192: openshell.v1.OpenShell.WatchSandbox:input_type -> openshell.v1.WatchSandboxRequest
-	148, // 193: openshell.v1.OpenShell.SubmitPolicyAnalysis:input_type -> openshell.v1.SubmitPolicyAnalysisRequest
-	150, // 194: openshell.v1.OpenShell.GetDraftPolicy:input_type -> openshell.v1.GetDraftPolicyRequest
-	152, // 195: openshell.v1.OpenShell.ApproveDraftChunk:input_type -> openshell.v1.ApproveDraftChunkRequest
-	154, // 196: openshell.v1.OpenShell.RejectDraftChunk:input_type -> openshell.v1.RejectDraftChunkRequest
-	156, // 197: openshell.v1.OpenShell.ApproveAllDraftChunks:input_type -> openshell.v1.ApproveAllDraftChunksRequest
-	158, // 198: openshell.v1.OpenShell.EditDraftChunk:input_type -> openshell.v1.EditDraftChunkRequest
-	160, // 199: openshell.v1.OpenShell.UndoDraftChunk:input_type -> openshell.v1.UndoDraftChunkRequest
-	162, // 200: openshell.v1.OpenShell.ClearDraftChunks:input_type -> openshell.v1.ClearDraftChunksRequest
-	164, // 201: openshell.v1.OpenShell.GetDraftHistory:input_type -> openshell.v1.GetDraftHistoryRequest
-	6,   // 202: openshell.v1.OpenShell.IssueSandboxToken:input_type -> openshell.v1.IssueSandboxTokenRequest
-	8,   // 203: openshell.v1.OpenShell.RefreshSandboxToken:input_type -> openshell.v1.RefreshSandboxTokenRequest
-	171, // 204: openshell.v1.OpenShell.CreateWorkspace:input_type -> openshell.v1.CreateWorkspaceRequest
-	173, // 205: openshell.v1.OpenShell.GetWorkspace:input_type -> openshell.v1.GetWorkspaceRequest
-	175, // 206: openshell.v1.OpenShell.ListWorkspaces:input_type -> openshell.v1.ListWorkspacesRequest
-	177, // 207: openshell.v1.OpenShell.DeleteWorkspace:input_type -> openshell.v1.DeleteWorkspaceRequest
-	180, // 208: openshell.v1.OpenShell.AddWorkspaceMember:input_type -> openshell.v1.AddWorkspaceMemberRequest
-	182, // 209: openshell.v1.OpenShell.RemoveWorkspaceMember:input_type -> openshell.v1.RemoveWorkspaceMemberRequest
-	184, // 210: openshell.v1.OpenShell.ListWorkspaceMembers:input_type -> openshell.v1.ListWorkspaceMembersRequest
-	11,  // 211: openshell.v1.OpenShell.Health:output_type -> openshell.v1.HealthResponse
-	13,  // 212: openshell.v1.OpenShell.GetCurrentUser:output_type -> openshell.v1.GetCurrentUserResponse
-	15,  // 213: openshell.v1.OpenShell.GetGatewayInfo:output_type -> openshell.v1.GetGatewayInfoResponse
-	33,  // 214: openshell.v1.OpenShell.CreateSandbox:output_type -> openshell.v1.SandboxResponse
-	33,  // 215: openshell.v1.OpenShell.GetSandbox:output_type -> openshell.v1.SandboxResponse
-	34,  // 216: openshell.v1.OpenShell.ListSandboxes:output_type -> openshell.v1.ListSandboxesResponse
-	35,  // 217: openshell.v1.OpenShell.ListSandboxProviders:output_type -> openshell.v1.ListSandboxProvidersResponse
-	36,  // 218: openshell.v1.OpenShell.AttachSandboxProvider:output_type -> openshell.v1.AttachSandboxProviderResponse
-	37,  // 219: openshell.v1.OpenShell.DetachSandboxProvider:output_type -> openshell.v1.DetachSandboxProviderResponse
-	38,  // 220: openshell.v1.OpenShell.DeleteSandbox:output_type -> openshell.v1.DeleteSandboxResponse
-	40,  // 221: openshell.v1.OpenShell.CreateSshSession:output_type -> openshell.v1.CreateSshSessionResponse
-	48,  // 222: openshell.v1.OpenShell.ExposeService:output_type -> openshell.v1.ServiceEndpointResponse
-	48,  // 223: openshell.v1.OpenShell.GetService:output_type -> openshell.v1.ServiceEndpointResponse
-	44,  // 224: openshell.v1.OpenShell.ListServices:output_type -> openshell.v1.ListServicesResponse
-	46,  // 225: openshell.v1.OpenShell.DeleteService:output_type -> openshell.v1.DeleteServiceResponse
-	50,  // 226: openshell.v1.OpenShell.RevokeSshSession:output_type -> openshell.v1.RevokeSshSessionResponse
-	55,  // 227: openshell.v1.OpenShell.ExecSandbox:output_type -> openshell.v1.ExecSandboxEvent
-	57,  // 228: openshell.v1.OpenShell.ForwardTcp:output_type -> openshell.v1.TcpForwardFrame
-	55,  // 229: openshell.v1.OpenShell.ExecSandboxInteractive:output_type -> openshell.v1.ExecSandboxEvent
-	70,  // 230: openshell.v1.OpenShell.CreateProvider:output_type -> openshell.v1.ProviderResponse
-	70,  // 231: openshell.v1.OpenShell.GetProvider:output_type -> openshell.v1.ProviderResponse
-	71,  // 232: openshell.v1.OpenShell.ListProviders:output_type -> openshell.v1.ListProvidersResponse
-	96,  // 233: openshell.v1.OpenShell.ListProviderProfiles:output_type -> openshell.v1.ListProviderProfilesResponse
-	95,  // 234: openshell.v1.OpenShell.GetProviderProfile:output_type -> openshell.v1.ProviderProfileResponse
-	98,  // 235: openshell.v1.OpenShell.ImportProviderProfiles:output_type -> openshell.v1.ImportProviderProfilesResponse
-	100, // 236: openshell.v1.OpenShell.UpdateProviderProfiles:output_type -> openshell.v1.UpdateProviderProfilesResponse
-	102, // 237: openshell.v1.OpenShell.LintProviderProfiles:output_type -> openshell.v1.LintProviderProfilesResponse
-	70,  // 238: openshell.v1.OpenShell.UpdateProvider:output_type -> openshell.v1.ProviderResponse
-	86,  // 239: openshell.v1.OpenShell.GetProviderRefreshStatus:output_type -> openshell.v1.GetProviderRefreshStatusResponse
-	88,  // 240: openshell.v1.OpenShell.ConfigureProviderRefresh:output_type -> openshell.v1.ConfigureProviderRefreshResponse
-	90,  // 241: openshell.v1.OpenShell.RotateProviderCredential:output_type -> openshell.v1.RotateProviderCredentialResponse
-	92,  // 242: openshell.v1.OpenShell.DeleteProviderRefresh:output_type -> openshell.v1.DeleteProviderRefreshResponse
-	103, // 243: openshell.v1.OpenShell.DeleteProvider:output_type -> openshell.v1.DeleteProviderResponse
-	105, // 244: openshell.v1.OpenShell.DeleteProviderProfile:output_type -> openshell.v1.DeleteProviderProfileResponse
-	222, // 245: openshell.v1.OpenShell.GetSandboxConfig:output_type -> openshell.sandbox.v1.GetSandboxConfigResponse
-	223, // 246: openshell.v1.OpenShell.GetGatewayConfig:output_type -> openshell.sandbox.v1.GetGatewayConfigResponse
-	116, // 247: openshell.v1.OpenShell.UpdateConfig:output_type -> openshell.v1.UpdateConfigResponse
-	118, // 248: openshell.v1.OpenShell.GetSandboxPolicyStatus:output_type -> openshell.v1.GetSandboxPolicyStatusResponse
-	120, // 249: openshell.v1.OpenShell.ListSandboxPolicies:output_type -> openshell.v1.ListSandboxPoliciesResponse
-	122, // 250: openshell.v1.OpenShell.ReportPolicyStatus:output_type -> openshell.v1.ReportPolicyStatusResponse
-	107, // 251: openshell.v1.OpenShell.GetSandboxProviderEnvironment:output_type -> openshell.v1.GetSandboxProviderEnvironmentResponse
-	127, // 252: openshell.v1.OpenShell.GetSandboxLogs:output_type -> openshell.v1.GetSandboxLogsResponse
-	126, // 253: openshell.v1.OpenShell.PushSandboxLogs:output_type -> openshell.v1.PushSandboxLogsResponse
-	129, // 254: openshell.v1.OpenShell.ConnectSupervisor:output_type -> openshell.v1.GatewayMessage
-	139, // 255: openshell.v1.OpenShell.RelayStream:output_type -> openshell.v1.RelayFrame
-	62,  // 256: openshell.v1.OpenShell.WatchSandbox:output_type -> openshell.v1.SandboxStreamEvent
-	149, // 257: openshell.v1.OpenShell.SubmitPolicyAnalysis:output_type -> openshell.v1.SubmitPolicyAnalysisResponse
-	151, // 258: openshell.v1.OpenShell.GetDraftPolicy:output_type -> openshell.v1.GetDraftPolicyResponse
-	153, // 259: openshell.v1.OpenShell.ApproveDraftChunk:output_type -> openshell.v1.ApproveDraftChunkResponse
-	155, // 260: openshell.v1.OpenShell.RejectDraftChunk:output_type -> openshell.v1.RejectDraftChunkResponse
-	157, // 261: openshell.v1.OpenShell.ApproveAllDraftChunks:output_type -> openshell.v1.ApproveAllDraftChunksResponse
-	159, // 262: openshell.v1.OpenShell.EditDraftChunk:output_type -> openshell.v1.EditDraftChunkResponse
-	161, // 263: openshell.v1.OpenShell.UndoDraftChunk:output_type -> openshell.v1.UndoDraftChunkResponse
-	163, // 264: openshell.v1.OpenShell.ClearDraftChunks:output_type -> openshell.v1.ClearDraftChunksResponse
-	166, // 265: openshell.v1.OpenShell.GetDraftHistory:output_type -> openshell.v1.GetDraftHistoryResponse
-	7,   // 266: openshell.v1.OpenShell.IssueSandboxToken:output_type -> openshell.v1.IssueSandboxTokenResponse
-	9,   // 267: openshell.v1.OpenShell.RefreshSandboxToken:output_type -> openshell.v1.RefreshSandboxTokenResponse
-	172, // 268: openshell.v1.OpenShell.CreateWorkspace:output_type -> openshell.v1.CreateWorkspaceResponse
-	174, // 269: openshell.v1.OpenShell.GetWorkspace:output_type -> openshell.v1.GetWorkspaceResponse
-	176, // 270: openshell.v1.OpenShell.ListWorkspaces:output_type -> openshell.v1.ListWorkspacesResponse
-	178, // 271: openshell.v1.OpenShell.DeleteWorkspace:output_type -> openshell.v1.DeleteWorkspaceResponse
-	181, // 272: openshell.v1.OpenShell.AddWorkspaceMember:output_type -> openshell.v1.AddWorkspaceMemberResponse
-	183, // 273: openshell.v1.OpenShell.RemoveWorkspaceMember:output_type -> openshell.v1.RemoveWorkspaceMemberResponse
-	185, // 274: openshell.v1.OpenShell.ListWorkspaceMembers:output_type -> openshell.v1.ListWorkspaceMembersResponse
-	211, // [211:275] is the sub-list for method output_type
-	147, // [147:211] is the sub-list for method input_type
-	147, // [147:147] is the sub-list for extension type_name
-	147, // [147:147] is the sub-list for extension extendee
-	0,   // [0:147] is the sub-list for field type_name
+	107, // 87: openshell.v1.StaticCredentialBinding.endpoints:type_name -> openshell.v1.StaticCredentialEndpointBinding
+	202, // 88: openshell.v1.GetSandboxProviderEnvironmentResponse.environment:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.EnvironmentEntry
+	203, // 89: openshell.v1.GetSandboxProviderEnvironmentResponse.credential_expires_at_ms:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.CredentialExpiresAtMsEntry
+	204, // 90: openshell.v1.GetSandboxProviderEnvironmentResponse.dynamic_credentials:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntry
+	205, // 91: openshell.v1.GetSandboxProviderEnvironmentResponse.static_credential_bindings:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.StaticCredentialBindingsEntry
+	213, // 92: openshell.v1.UpdateConfigRequest.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
+	218, // 93: openshell.v1.UpdateConfigRequest.setting_value:type_name -> openshell.sandbox.v1.SettingValue
+	111, // 94: openshell.v1.UpdateConfigRequest.merge_operations:type_name -> openshell.v1.PolicyMergeOperation
+	206, // 95: openshell.v1.UpdateConfigRequest.annotations:type_name -> openshell.v1.UpdateConfigRequest.AnnotationsEntry
+	112, // 96: openshell.v1.PolicyMergeOperation.add_rule:type_name -> openshell.v1.AddNetworkRule
+	113, // 97: openshell.v1.PolicyMergeOperation.remove_endpoint:type_name -> openshell.v1.RemoveNetworkEndpoint
+	114, // 98: openshell.v1.PolicyMergeOperation.remove_rule:type_name -> openshell.v1.RemoveNetworkRule
+	115, // 99: openshell.v1.PolicyMergeOperation.add_deny_rules:type_name -> openshell.v1.AddDenyRules
+	116, // 100: openshell.v1.PolicyMergeOperation.add_allow_rules:type_name -> openshell.v1.AddAllowRules
+	117, // 101: openshell.v1.PolicyMergeOperation.remove_binary:type_name -> openshell.v1.RemoveNetworkBinary
+	219, // 102: openshell.v1.AddNetworkRule.rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
+	220, // 103: openshell.v1.AddDenyRules.deny_rules:type_name -> openshell.sandbox.v1.L7DenyRule
+	221, // 104: openshell.v1.AddAllowRules.rules:type_name -> openshell.sandbox.v1.L7Rule
+	207, // 105: openshell.v1.UpdateConfigResponse.annotations:type_name -> openshell.v1.UpdateConfigResponse.AnnotationsEntry
+	125, // 106: openshell.v1.GetSandboxPolicyStatusResponse.revision:type_name -> openshell.v1.SandboxPolicyRevision
+	125, // 107: openshell.v1.ListSandboxPoliciesResponse.revisions:type_name -> openshell.v1.SandboxPolicyRevision
+	3,   // 108: openshell.v1.ReportPolicyStatusRequest.status:type_name -> openshell.v1.PolicyStatus
+	3,   // 109: openshell.v1.SandboxPolicyRevision.status:type_name -> openshell.v1.PolicyStatus
+	213, // 110: openshell.v1.SandboxPolicyRevision.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
+	208, // 111: openshell.v1.SandboxPolicyRevision.provenance:type_name -> openshell.v1.SandboxPolicyRevision.ProvenanceEntry
+	63,  // 112: openshell.v1.PushSandboxLogsRequest.logs:type_name -> openshell.v1.SandboxLogLine
+	63,  // 113: openshell.v1.GetSandboxLogsResponse.logs:type_name -> openshell.v1.SandboxLogLine
+	132, // 114: openshell.v1.SupervisorMessage.hello:type_name -> openshell.v1.SupervisorHello
+	135, // 115: openshell.v1.SupervisorMessage.heartbeat:type_name -> openshell.v1.SupervisorHeartbeat
+	142, // 116: openshell.v1.SupervisorMessage.relay_open_result:type_name -> openshell.v1.RelayOpenResult
+	143, // 117: openshell.v1.SupervisorMessage.relay_close:type_name -> openshell.v1.RelayClose
+	133, // 118: openshell.v1.GatewayMessage.session_accepted:type_name -> openshell.v1.SessionAccepted
+	134, // 119: openshell.v1.GatewayMessage.session_rejected:type_name -> openshell.v1.SessionRejected
+	136, // 120: openshell.v1.GatewayMessage.heartbeat:type_name -> openshell.v1.GatewayHeartbeat
+	137, // 121: openshell.v1.GatewayMessage.relay_open:type_name -> openshell.v1.RelayOpen
+	143, // 122: openshell.v1.GatewayMessage.relay_close:type_name -> openshell.v1.RelayClose
+	138, // 123: openshell.v1.RelayOpen.ssh:type_name -> openshell.v1.SshRelayTarget
+	139, // 124: openshell.v1.RelayOpen.tcp:type_name -> openshell.v1.TcpRelayTarget
+	140, // 125: openshell.v1.RelayFrame.init:type_name -> openshell.v1.RelayInit
+	144, // 126: openshell.v1.DenialSummary.l7_request_samples:type_name -> openshell.v1.L7RequestSample
+	146, // 127: openshell.v1.NetworkActivitySummary.denials_by_group:type_name -> openshell.v1.DenialGroupCount
+	219, // 128: openshell.v1.PolicyChunk.proposed_rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
+	145, // 129: openshell.v1.SubmitPolicyAnalysisRequest.summaries:type_name -> openshell.v1.DenialSummary
+	148, // 130: openshell.v1.SubmitPolicyAnalysisRequest.proposed_chunks:type_name -> openshell.v1.PolicyChunk
+	147, // 131: openshell.v1.SubmitPolicyAnalysisRequest.network_activity_summaries:type_name -> openshell.v1.NetworkActivitySummary
+	148, // 132: openshell.v1.GetDraftPolicyResponse.chunks:type_name -> openshell.v1.PolicyChunk
+	219, // 133: openshell.v1.EditDraftChunkRequest.proposed_rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
+	167, // 134: openshell.v1.GetDraftHistoryResponse.entries:type_name -> openshell.v1.DraftHistoryEntry
+	213, // 135: openshell.v1.PolicyRevisionPayload.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
+	209, // 136: openshell.v1.PolicyRevisionPayload.provenance:type_name -> openshell.v1.PolicyRevisionPayload.ProvenanceEntry
+	219, // 137: openshell.v1.DraftChunkPayload.proposed_rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
+	210, // 138: openshell.v1.StoredPolicyRevision.provenance:type_name -> openshell.v1.StoredPolicyRevision.ProvenanceEntry
+	211, // 139: openshell.v1.CreateWorkspaceRequest.labels:type_name -> openshell.v1.CreateWorkspaceRequest.LabelsEntry
+	222, // 140: openshell.v1.CreateWorkspaceResponse.workspace:type_name -> openshell.datamodel.v1.Workspace
+	222, // 141: openshell.v1.GetWorkspaceResponse.workspace:type_name -> openshell.datamodel.v1.Workspace
+	222, // 142: openshell.v1.ListWorkspacesResponse.workspaces:type_name -> openshell.datamodel.v1.Workspace
+	212, // 143: openshell.v1.WorkspaceMember.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	5,   // 144: openshell.v1.WorkspaceMember.role:type_name -> openshell.v1.WorkspaceRole
+	5,   // 145: openshell.v1.AddWorkspaceMemberRequest.role:type_name -> openshell.v1.WorkspaceRole
+	181, // 146: openshell.v1.AddWorkspaceMemberResponse.member:type_name -> openshell.v1.WorkspaceMember
+	181, // 147: openshell.v1.ListWorkspaceMembersResponse.members:type_name -> openshell.v1.WorkspaceMember
+	78,  // 148: openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntry.value:type_name -> openshell.v1.ProviderProfileCredential
+	108, // 149: openshell.v1.GetSandboxProviderEnvironmentResponse.StaticCredentialBindingsEntry.value:type_name -> openshell.v1.StaticCredentialBinding
+	10,  // 150: openshell.v1.OpenShell.Health:input_type -> openshell.v1.HealthRequest
+	12,  // 151: openshell.v1.OpenShell.GetCurrentUser:input_type -> openshell.v1.GetCurrentUserRequest
+	14,  // 152: openshell.v1.OpenShell.GetGatewayInfo:input_type -> openshell.v1.GetGatewayInfoRequest
+	26,  // 153: openshell.v1.OpenShell.CreateSandbox:input_type -> openshell.v1.CreateSandboxRequest
+	27,  // 154: openshell.v1.OpenShell.GetSandbox:input_type -> openshell.v1.GetSandboxRequest
+	28,  // 155: openshell.v1.OpenShell.ListSandboxes:input_type -> openshell.v1.ListSandboxesRequest
+	29,  // 156: openshell.v1.OpenShell.ListSandboxProviders:input_type -> openshell.v1.ListSandboxProvidersRequest
+	30,  // 157: openshell.v1.OpenShell.AttachSandboxProvider:input_type -> openshell.v1.AttachSandboxProviderRequest
+	31,  // 158: openshell.v1.OpenShell.DetachSandboxProvider:input_type -> openshell.v1.DetachSandboxProviderRequest
+	32,  // 159: openshell.v1.OpenShell.DeleteSandbox:input_type -> openshell.v1.DeleteSandboxRequest
+	39,  // 160: openshell.v1.OpenShell.CreateSshSession:input_type -> openshell.v1.CreateSshSessionRequest
+	41,  // 161: openshell.v1.OpenShell.ExposeService:input_type -> openshell.v1.ExposeServiceRequest
+	42,  // 162: openshell.v1.OpenShell.GetService:input_type -> openshell.v1.GetServiceRequest
+	43,  // 163: openshell.v1.OpenShell.ListServices:input_type -> openshell.v1.ListServicesRequest
+	45,  // 164: openshell.v1.OpenShell.DeleteService:input_type -> openshell.v1.DeleteServiceRequest
+	49,  // 165: openshell.v1.OpenShell.RevokeSshSession:input_type -> openshell.v1.RevokeSshSessionRequest
+	51,  // 166: openshell.v1.OpenShell.ExecSandbox:input_type -> openshell.v1.ExecSandboxRequest
+	57,  // 167: openshell.v1.OpenShell.ForwardTcp:input_type -> openshell.v1.TcpForwardFrame
+	58,  // 168: openshell.v1.OpenShell.ExecSandboxInteractive:input_type -> openshell.v1.ExecSandboxInput
+	65,  // 169: openshell.v1.OpenShell.CreateProvider:input_type -> openshell.v1.CreateProviderRequest
+	66,  // 170: openshell.v1.OpenShell.GetProvider:input_type -> openshell.v1.GetProviderRequest
+	67,  // 171: openshell.v1.OpenShell.ListProviders:input_type -> openshell.v1.ListProvidersRequest
+	72,  // 172: openshell.v1.OpenShell.ListProviderProfiles:input_type -> openshell.v1.ListProviderProfilesRequest
+	73,  // 173: openshell.v1.OpenShell.GetProviderProfile:input_type -> openshell.v1.GetProviderProfileRequest
+	97,  // 174: openshell.v1.OpenShell.ImportProviderProfiles:input_type -> openshell.v1.ImportProviderProfilesRequest
+	99,  // 175: openshell.v1.OpenShell.UpdateProviderProfiles:input_type -> openshell.v1.UpdateProviderProfilesRequest
+	101, // 176: openshell.v1.OpenShell.LintProviderProfiles:input_type -> openshell.v1.LintProviderProfilesRequest
+	68,  // 177: openshell.v1.OpenShell.UpdateProvider:input_type -> openshell.v1.UpdateProviderRequest
+	85,  // 178: openshell.v1.OpenShell.GetProviderRefreshStatus:input_type -> openshell.v1.GetProviderRefreshStatusRequest
+	87,  // 179: openshell.v1.OpenShell.ConfigureProviderRefresh:input_type -> openshell.v1.ConfigureProviderRefreshRequest
+	89,  // 180: openshell.v1.OpenShell.RotateProviderCredential:input_type -> openshell.v1.RotateProviderCredentialRequest
+	91,  // 181: openshell.v1.OpenShell.DeleteProviderRefresh:input_type -> openshell.v1.DeleteProviderRefreshRequest
+	69,  // 182: openshell.v1.OpenShell.DeleteProvider:input_type -> openshell.v1.DeleteProviderRequest
+	104, // 183: openshell.v1.OpenShell.DeleteProviderProfile:input_type -> openshell.v1.DeleteProviderProfileRequest
+	223, // 184: openshell.v1.OpenShell.GetSandboxConfig:input_type -> openshell.sandbox.v1.GetSandboxConfigRequest
+	224, // 185: openshell.v1.OpenShell.GetGatewayConfig:input_type -> openshell.sandbox.v1.GetGatewayConfigRequest
+	110, // 186: openshell.v1.OpenShell.UpdateConfig:input_type -> openshell.v1.UpdateConfigRequest
+	119, // 187: openshell.v1.OpenShell.GetSandboxPolicyStatus:input_type -> openshell.v1.GetSandboxPolicyStatusRequest
+	121, // 188: openshell.v1.OpenShell.ListSandboxPolicies:input_type -> openshell.v1.ListSandboxPoliciesRequest
+	123, // 189: openshell.v1.OpenShell.ReportPolicyStatus:input_type -> openshell.v1.ReportPolicyStatusRequest
+	106, // 190: openshell.v1.OpenShell.GetSandboxProviderEnvironment:input_type -> openshell.v1.GetSandboxProviderEnvironmentRequest
+	126, // 191: openshell.v1.OpenShell.GetSandboxLogs:input_type -> openshell.v1.GetSandboxLogsRequest
+	127, // 192: openshell.v1.OpenShell.PushSandboxLogs:input_type -> openshell.v1.PushSandboxLogsRequest
+	130, // 193: openshell.v1.OpenShell.ConnectSupervisor:input_type -> openshell.v1.SupervisorMessage
+	141, // 194: openshell.v1.OpenShell.RelayStream:input_type -> openshell.v1.RelayFrame
+	61,  // 195: openshell.v1.OpenShell.WatchSandbox:input_type -> openshell.v1.WatchSandboxRequest
+	150, // 196: openshell.v1.OpenShell.SubmitPolicyAnalysis:input_type -> openshell.v1.SubmitPolicyAnalysisRequest
+	152, // 197: openshell.v1.OpenShell.GetDraftPolicy:input_type -> openshell.v1.GetDraftPolicyRequest
+	154, // 198: openshell.v1.OpenShell.ApproveDraftChunk:input_type -> openshell.v1.ApproveDraftChunkRequest
+	156, // 199: openshell.v1.OpenShell.RejectDraftChunk:input_type -> openshell.v1.RejectDraftChunkRequest
+	158, // 200: openshell.v1.OpenShell.ApproveAllDraftChunks:input_type -> openshell.v1.ApproveAllDraftChunksRequest
+	160, // 201: openshell.v1.OpenShell.EditDraftChunk:input_type -> openshell.v1.EditDraftChunkRequest
+	162, // 202: openshell.v1.OpenShell.UndoDraftChunk:input_type -> openshell.v1.UndoDraftChunkRequest
+	164, // 203: openshell.v1.OpenShell.ClearDraftChunks:input_type -> openshell.v1.ClearDraftChunksRequest
+	166, // 204: openshell.v1.OpenShell.GetDraftHistory:input_type -> openshell.v1.GetDraftHistoryRequest
+	6,   // 205: openshell.v1.OpenShell.IssueSandboxToken:input_type -> openshell.v1.IssueSandboxTokenRequest
+	8,   // 206: openshell.v1.OpenShell.RefreshSandboxToken:input_type -> openshell.v1.RefreshSandboxTokenRequest
+	173, // 207: openshell.v1.OpenShell.CreateWorkspace:input_type -> openshell.v1.CreateWorkspaceRequest
+	175, // 208: openshell.v1.OpenShell.GetWorkspace:input_type -> openshell.v1.GetWorkspaceRequest
+	177, // 209: openshell.v1.OpenShell.ListWorkspaces:input_type -> openshell.v1.ListWorkspacesRequest
+	179, // 210: openshell.v1.OpenShell.DeleteWorkspace:input_type -> openshell.v1.DeleteWorkspaceRequest
+	182, // 211: openshell.v1.OpenShell.AddWorkspaceMember:input_type -> openshell.v1.AddWorkspaceMemberRequest
+	184, // 212: openshell.v1.OpenShell.RemoveWorkspaceMember:input_type -> openshell.v1.RemoveWorkspaceMemberRequest
+	186, // 213: openshell.v1.OpenShell.ListWorkspaceMembers:input_type -> openshell.v1.ListWorkspaceMembersRequest
+	11,  // 214: openshell.v1.OpenShell.Health:output_type -> openshell.v1.HealthResponse
+	13,  // 215: openshell.v1.OpenShell.GetCurrentUser:output_type -> openshell.v1.GetCurrentUserResponse
+	15,  // 216: openshell.v1.OpenShell.GetGatewayInfo:output_type -> openshell.v1.GetGatewayInfoResponse
+	33,  // 217: openshell.v1.OpenShell.CreateSandbox:output_type -> openshell.v1.SandboxResponse
+	33,  // 218: openshell.v1.OpenShell.GetSandbox:output_type -> openshell.v1.SandboxResponse
+	34,  // 219: openshell.v1.OpenShell.ListSandboxes:output_type -> openshell.v1.ListSandboxesResponse
+	35,  // 220: openshell.v1.OpenShell.ListSandboxProviders:output_type -> openshell.v1.ListSandboxProvidersResponse
+	36,  // 221: openshell.v1.OpenShell.AttachSandboxProvider:output_type -> openshell.v1.AttachSandboxProviderResponse
+	37,  // 222: openshell.v1.OpenShell.DetachSandboxProvider:output_type -> openshell.v1.DetachSandboxProviderResponse
+	38,  // 223: openshell.v1.OpenShell.DeleteSandbox:output_type -> openshell.v1.DeleteSandboxResponse
+	40,  // 224: openshell.v1.OpenShell.CreateSshSession:output_type -> openshell.v1.CreateSshSessionResponse
+	48,  // 225: openshell.v1.OpenShell.ExposeService:output_type -> openshell.v1.ServiceEndpointResponse
+	48,  // 226: openshell.v1.OpenShell.GetService:output_type -> openshell.v1.ServiceEndpointResponse
+	44,  // 227: openshell.v1.OpenShell.ListServices:output_type -> openshell.v1.ListServicesResponse
+	46,  // 228: openshell.v1.OpenShell.DeleteService:output_type -> openshell.v1.DeleteServiceResponse
+	50,  // 229: openshell.v1.OpenShell.RevokeSshSession:output_type -> openshell.v1.RevokeSshSessionResponse
+	55,  // 230: openshell.v1.OpenShell.ExecSandbox:output_type -> openshell.v1.ExecSandboxEvent
+	57,  // 231: openshell.v1.OpenShell.ForwardTcp:output_type -> openshell.v1.TcpForwardFrame
+	55,  // 232: openshell.v1.OpenShell.ExecSandboxInteractive:output_type -> openshell.v1.ExecSandboxEvent
+	70,  // 233: openshell.v1.OpenShell.CreateProvider:output_type -> openshell.v1.ProviderResponse
+	70,  // 234: openshell.v1.OpenShell.GetProvider:output_type -> openshell.v1.ProviderResponse
+	71,  // 235: openshell.v1.OpenShell.ListProviders:output_type -> openshell.v1.ListProvidersResponse
+	96,  // 236: openshell.v1.OpenShell.ListProviderProfiles:output_type -> openshell.v1.ListProviderProfilesResponse
+	95,  // 237: openshell.v1.OpenShell.GetProviderProfile:output_type -> openshell.v1.ProviderProfileResponse
+	98,  // 238: openshell.v1.OpenShell.ImportProviderProfiles:output_type -> openshell.v1.ImportProviderProfilesResponse
+	100, // 239: openshell.v1.OpenShell.UpdateProviderProfiles:output_type -> openshell.v1.UpdateProviderProfilesResponse
+	102, // 240: openshell.v1.OpenShell.LintProviderProfiles:output_type -> openshell.v1.LintProviderProfilesResponse
+	70,  // 241: openshell.v1.OpenShell.UpdateProvider:output_type -> openshell.v1.ProviderResponse
+	86,  // 242: openshell.v1.OpenShell.GetProviderRefreshStatus:output_type -> openshell.v1.GetProviderRefreshStatusResponse
+	88,  // 243: openshell.v1.OpenShell.ConfigureProviderRefresh:output_type -> openshell.v1.ConfigureProviderRefreshResponse
+	90,  // 244: openshell.v1.OpenShell.RotateProviderCredential:output_type -> openshell.v1.RotateProviderCredentialResponse
+	92,  // 245: openshell.v1.OpenShell.DeleteProviderRefresh:output_type -> openshell.v1.DeleteProviderRefreshResponse
+	103, // 246: openshell.v1.OpenShell.DeleteProvider:output_type -> openshell.v1.DeleteProviderResponse
+	105, // 247: openshell.v1.OpenShell.DeleteProviderProfile:output_type -> openshell.v1.DeleteProviderProfileResponse
+	225, // 248: openshell.v1.OpenShell.GetSandboxConfig:output_type -> openshell.sandbox.v1.GetSandboxConfigResponse
+	226, // 249: openshell.v1.OpenShell.GetGatewayConfig:output_type -> openshell.sandbox.v1.GetGatewayConfigResponse
+	118, // 250: openshell.v1.OpenShell.UpdateConfig:output_type -> openshell.v1.UpdateConfigResponse
+	120, // 251: openshell.v1.OpenShell.GetSandboxPolicyStatus:output_type -> openshell.v1.GetSandboxPolicyStatusResponse
+	122, // 252: openshell.v1.OpenShell.ListSandboxPolicies:output_type -> openshell.v1.ListSandboxPoliciesResponse
+	124, // 253: openshell.v1.OpenShell.ReportPolicyStatus:output_type -> openshell.v1.ReportPolicyStatusResponse
+	109, // 254: openshell.v1.OpenShell.GetSandboxProviderEnvironment:output_type -> openshell.v1.GetSandboxProviderEnvironmentResponse
+	129, // 255: openshell.v1.OpenShell.GetSandboxLogs:output_type -> openshell.v1.GetSandboxLogsResponse
+	128, // 256: openshell.v1.OpenShell.PushSandboxLogs:output_type -> openshell.v1.PushSandboxLogsResponse
+	131, // 257: openshell.v1.OpenShell.ConnectSupervisor:output_type -> openshell.v1.GatewayMessage
+	141, // 258: openshell.v1.OpenShell.RelayStream:output_type -> openshell.v1.RelayFrame
+	62,  // 259: openshell.v1.OpenShell.WatchSandbox:output_type -> openshell.v1.SandboxStreamEvent
+	151, // 260: openshell.v1.OpenShell.SubmitPolicyAnalysis:output_type -> openshell.v1.SubmitPolicyAnalysisResponse
+	153, // 261: openshell.v1.OpenShell.GetDraftPolicy:output_type -> openshell.v1.GetDraftPolicyResponse
+	155, // 262: openshell.v1.OpenShell.ApproveDraftChunk:output_type -> openshell.v1.ApproveDraftChunkResponse
+	157, // 263: openshell.v1.OpenShell.RejectDraftChunk:output_type -> openshell.v1.RejectDraftChunkResponse
+	159, // 264: openshell.v1.OpenShell.ApproveAllDraftChunks:output_type -> openshell.v1.ApproveAllDraftChunksResponse
+	161, // 265: openshell.v1.OpenShell.EditDraftChunk:output_type -> openshell.v1.EditDraftChunkResponse
+	163, // 266: openshell.v1.OpenShell.UndoDraftChunk:output_type -> openshell.v1.UndoDraftChunkResponse
+	165, // 267: openshell.v1.OpenShell.ClearDraftChunks:output_type -> openshell.v1.ClearDraftChunksResponse
+	168, // 268: openshell.v1.OpenShell.GetDraftHistory:output_type -> openshell.v1.GetDraftHistoryResponse
+	7,   // 269: openshell.v1.OpenShell.IssueSandboxToken:output_type -> openshell.v1.IssueSandboxTokenResponse
+	9,   // 270: openshell.v1.OpenShell.RefreshSandboxToken:output_type -> openshell.v1.RefreshSandboxTokenResponse
+	174, // 271: openshell.v1.OpenShell.CreateWorkspace:output_type -> openshell.v1.CreateWorkspaceResponse
+	176, // 272: openshell.v1.OpenShell.GetWorkspace:output_type -> openshell.v1.GetWorkspaceResponse
+	178, // 273: openshell.v1.OpenShell.ListWorkspaces:output_type -> openshell.v1.ListWorkspacesResponse
+	180, // 274: openshell.v1.OpenShell.DeleteWorkspace:output_type -> openshell.v1.DeleteWorkspaceResponse
+	183, // 275: openshell.v1.OpenShell.AddWorkspaceMember:output_type -> openshell.v1.AddWorkspaceMemberResponse
+	185, // 276: openshell.v1.OpenShell.RemoveWorkspaceMember:output_type -> openshell.v1.RemoveWorkspaceMemberResponse
+	187, // 277: openshell.v1.OpenShell.ListWorkspaceMembers:output_type -> openshell.v1.ListWorkspaceMembersResponse
+	214, // [214:278] is the sub-list for method output_type
+	150, // [150:214] is the sub-list for method input_type
+	150, // [150:150] is the sub-list for extension type_name
+	150, // [150:150] is the sub-list for extension extendee
+	0,   // [0:150] is the sub-list for field type_name
 }
 
 func init() { file_openshell_proto_init() }
@@ -14412,7 +14581,7 @@ func file_openshell_proto_init() {
 		(*SandboxStreamEvent_DraftPolicyUpdate)(nil),
 	}
 	file_openshell_proto_msgTypes[81].OneofWrappers = []any{}
-	file_openshell_proto_msgTypes[103].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[105].OneofWrappers = []any{
 		(*PolicyMergeOperation_AddRule)(nil),
 		(*PolicyMergeOperation_RemoveEndpoint)(nil),
 		(*PolicyMergeOperation_RemoveRule)(nil),
@@ -14420,36 +14589,36 @@ func file_openshell_proto_init() {
 		(*PolicyMergeOperation_AddAllowRules)(nil),
 		(*PolicyMergeOperation_RemoveBinary)(nil),
 	}
-	file_openshell_proto_msgTypes[122].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[124].OneofWrappers = []any{
 		(*SupervisorMessage_Hello)(nil),
 		(*SupervisorMessage_Heartbeat)(nil),
 		(*SupervisorMessage_RelayOpenResult)(nil),
 		(*SupervisorMessage_RelayClose)(nil),
 	}
-	file_openshell_proto_msgTypes[123].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[125].OneofWrappers = []any{
 		(*GatewayMessage_SessionAccepted)(nil),
 		(*GatewayMessage_SessionRejected)(nil),
 		(*GatewayMessage_Heartbeat)(nil),
 		(*GatewayMessage_RelayOpen)(nil),
 		(*GatewayMessage_RelayClose)(nil),
 	}
-	file_openshell_proto_msgTypes[129].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[131].OneofWrappers = []any{
 		(*RelayOpen_Ssh)(nil),
 		(*RelayOpen_Tcp)(nil),
 	}
-	file_openshell_proto_msgTypes[133].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[135].OneofWrappers = []any{
 		(*RelayFrame_Init)(nil),
 		(*RelayFrame_Data)(nil),
 	}
-	file_openshell_proto_msgTypes[163].OneofWrappers = []any{}
-	file_openshell_proto_msgTypes[164].OneofWrappers = []any{}
+	file_openshell_proto_msgTypes[165].OneofWrappers = []any{}
+	file_openshell_proto_msgTypes[166].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_openshell_proto_rawDesc), len(file_openshell_proto_rawDesc)),
 			NumEnums:      6,
-			NumMessages:   203,
+			NumMessages:   206,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sdk/go/proto/sandboxv1/sandbox.pb.go
+++ b/sdk/go/proto/sandboxv1/sandbox.pb.go
@@ -595,6 +595,53 @@ func (x *MiddlewareEndpointSelector) GetExclude() []string {
 	return nil
 }
 
+// Binds a policy endpoint to static credentials from a sandbox provider.
+type NetworkCredentialBinding struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Name of the provider attached to this sandbox whose static credentials
+	// may be resolved for requests admitted by this endpoint.
+	Provider      string `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NetworkCredentialBinding) Reset() {
+	*x = NetworkCredentialBinding{}
+	mi := &file_sandbox_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NetworkCredentialBinding) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NetworkCredentialBinding) ProtoMessage() {}
+
+func (x *NetworkCredentialBinding) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NetworkCredentialBinding.ProtoReflect.Descriptor instead.
+func (*NetworkCredentialBinding) Descriptor() ([]byte, []int) {
+	return file_sandbox_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *NetworkCredentialBinding) GetProvider() string {
+	if x != nil {
+		return x.Provider
+	}
+	return ""
+}
+
 // A network endpoint (host + port) with optional L7 inspection config.
 type NetworkEndpoint struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -678,14 +725,18 @@ type NetworkEndpoint struct {
 	// Defaults to 65536 when unset.
 	JsonRpcMaxBodyBytes uint32 `protobuf:"varint,22,opt,name=json_rpc_max_body_bytes,json=jsonRpcMaxBodyBytes,proto3" json:"json_rpc_max_body_bytes,omitempty"`
 	// MCP-only policy and inspection options. Only used when protocol is "mcp".
-	Mcp           *McpOptions `protobuf:"bytes,23,opt,name=mcp,proto3" json:"mcp,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Mcp *McpOptions `protobuf:"bytes,23,opt,name=mcp,proto3" json:"mcp,omitempty"`
+	// Explicit binding authority for static credentials from an attached
+	// endpointless provider profile. Profiles that already define endpoints
+	// continue to use those profile endpoints as their credential boundary.
+	CredentialBinding *NetworkCredentialBinding `protobuf:"bytes,24,opt,name=credential_binding,json=credentialBinding,proto3" json:"credential_binding,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *NetworkEndpoint) Reset() {
 	*x = NetworkEndpoint{}
-	mi := &file_sandbox_proto_msgTypes[7]
+	mi := &file_sandbox_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -697,7 +748,7 @@ func (x *NetworkEndpoint) String() string {
 func (*NetworkEndpoint) ProtoMessage() {}
 
 func (x *NetworkEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[7]
+	mi := &file_sandbox_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -710,7 +761,7 @@ func (x *NetworkEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkEndpoint.ProtoReflect.Descriptor instead.
 func (*NetworkEndpoint) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{7}
+	return file_sandbox_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *NetworkEndpoint) GetHost() string {
@@ -874,6 +925,13 @@ func (x *NetworkEndpoint) GetMcp() *McpOptions {
 	return nil
 }
 
+func (x *NetworkEndpoint) GetCredentialBinding() *NetworkCredentialBinding {
+	if x != nil {
+		return x.CredentialBinding
+	}
+	return nil
+}
+
 // MCP options are grouped so MCP-specific policy can grow without adding more
 // top-level NetworkEndpoint fields. Current enforcement targets the active
 // 2025-11-25 Streamable HTTP/tools behavior, while preserving space for
@@ -911,7 +969,7 @@ type McpOptions struct {
 
 func (x *McpOptions) Reset() {
 	*x = McpOptions{}
-	mi := &file_sandbox_proto_msgTypes[8]
+	mi := &file_sandbox_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -923,7 +981,7 @@ func (x *McpOptions) String() string {
 func (*McpOptions) ProtoMessage() {}
 
 func (x *McpOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[8]
+	mi := &file_sandbox_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -936,7 +994,7 @@ func (x *McpOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use McpOptions.ProtoReflect.Descriptor instead.
 func (*McpOptions) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{8}
+	return file_sandbox_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *McpOptions) GetStrictToolNames() bool {
@@ -968,7 +1026,7 @@ type GraphqlOperation struct {
 
 func (x *GraphqlOperation) Reset() {
 	*x = GraphqlOperation{}
-	mi := &file_sandbox_proto_msgTypes[9]
+	mi := &file_sandbox_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -980,7 +1038,7 @@ func (x *GraphqlOperation) String() string {
 func (*GraphqlOperation) ProtoMessage() {}
 
 func (x *GraphqlOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[9]
+	mi := &file_sandbox_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -993,7 +1051,7 @@ func (x *GraphqlOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphqlOperation.ProtoReflect.Descriptor instead.
 func (*GraphqlOperation) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{9}
+	return file_sandbox_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GraphqlOperation) GetOperationType() string {
@@ -1048,7 +1106,7 @@ type L7DenyRule struct {
 
 func (x *L7DenyRule) Reset() {
 	*x = L7DenyRule{}
-	mi := &file_sandbox_proto_msgTypes[10]
+	mi := &file_sandbox_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1060,7 +1118,7 @@ func (x *L7DenyRule) String() string {
 func (*L7DenyRule) ProtoMessage() {}
 
 func (x *L7DenyRule) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[10]
+	mi := &file_sandbox_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1073,7 +1131,7 @@ func (x *L7DenyRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use L7DenyRule.ProtoReflect.Descriptor instead.
 func (*L7DenyRule) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{10}
+	return file_sandbox_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *L7DenyRule) GetMethod() string {
@@ -1142,7 +1200,7 @@ type L7Rule struct {
 
 func (x *L7Rule) Reset() {
 	*x = L7Rule{}
-	mi := &file_sandbox_proto_msgTypes[11]
+	mi := &file_sandbox_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1154,7 +1212,7 @@ func (x *L7Rule) String() string {
 func (*L7Rule) ProtoMessage() {}
 
 func (x *L7Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[11]
+	mi := &file_sandbox_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1167,7 +1225,7 @@ func (x *L7Rule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use L7Rule.ProtoReflect.Descriptor instead.
 func (*L7Rule) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{11}
+	return file_sandbox_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *L7Rule) GetAllow() *L7Allow {
@@ -1207,7 +1265,7 @@ type L7Allow struct {
 
 func (x *L7Allow) Reset() {
 	*x = L7Allow{}
-	mi := &file_sandbox_proto_msgTypes[12]
+	mi := &file_sandbox_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1219,7 +1277,7 @@ func (x *L7Allow) String() string {
 func (*L7Allow) ProtoMessage() {}
 
 func (x *L7Allow) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[12]
+	mi := &file_sandbox_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1232,7 +1290,7 @@ func (x *L7Allow) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use L7Allow.ProtoReflect.Descriptor instead.
 func (*L7Allow) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{12}
+	return file_sandbox_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *L7Allow) GetMethod() string {
@@ -1304,7 +1362,7 @@ type L7QueryMatcher struct {
 
 func (x *L7QueryMatcher) Reset() {
 	*x = L7QueryMatcher{}
-	mi := &file_sandbox_proto_msgTypes[13]
+	mi := &file_sandbox_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1316,7 +1374,7 @@ func (x *L7QueryMatcher) String() string {
 func (*L7QueryMatcher) ProtoMessage() {}
 
 func (x *L7QueryMatcher) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[13]
+	mi := &file_sandbox_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1329,7 +1387,7 @@ func (x *L7QueryMatcher) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use L7QueryMatcher.ProtoReflect.Descriptor instead.
 func (*L7QueryMatcher) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{13}
+	return file_sandbox_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *L7QueryMatcher) GetGlob() string {
@@ -1360,7 +1418,7 @@ type NetworkBinary struct {
 
 func (x *NetworkBinary) Reset() {
 	*x = NetworkBinary{}
-	mi := &file_sandbox_proto_msgTypes[14]
+	mi := &file_sandbox_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1372,7 +1430,7 @@ func (x *NetworkBinary) String() string {
 func (*NetworkBinary) ProtoMessage() {}
 
 func (x *NetworkBinary) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[14]
+	mi := &file_sandbox_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1385,7 +1443,7 @@ func (x *NetworkBinary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkBinary.ProtoReflect.Descriptor instead.
 func (*NetworkBinary) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{14}
+	return file_sandbox_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *NetworkBinary) GetPath() string {
@@ -1414,7 +1472,7 @@ type GetSandboxConfigRequest struct {
 
 func (x *GetSandboxConfigRequest) Reset() {
 	*x = GetSandboxConfigRequest{}
-	mi := &file_sandbox_proto_msgTypes[15]
+	mi := &file_sandbox_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1426,7 +1484,7 @@ func (x *GetSandboxConfigRequest) String() string {
 func (*GetSandboxConfigRequest) ProtoMessage() {}
 
 func (x *GetSandboxConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[15]
+	mi := &file_sandbox_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1439,7 +1497,7 @@ func (x *GetSandboxConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxConfigRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{15}
+	return file_sandbox_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GetSandboxConfigRequest) GetSandboxId() string {
@@ -1458,7 +1516,7 @@ type GetGatewayConfigRequest struct {
 
 func (x *GetGatewayConfigRequest) Reset() {
 	*x = GetGatewayConfigRequest{}
-	mi := &file_sandbox_proto_msgTypes[16]
+	mi := &file_sandbox_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1470,7 +1528,7 @@ func (x *GetGatewayConfigRequest) String() string {
 func (*GetGatewayConfigRequest) ProtoMessage() {}
 
 func (x *GetGatewayConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[16]
+	mi := &file_sandbox_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1483,7 +1541,7 @@ func (x *GetGatewayConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGatewayConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetGatewayConfigRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{16}
+	return file_sandbox_proto_rawDescGZIP(), []int{17}
 }
 
 // Response containing gateway-global settings.
@@ -1500,7 +1558,7 @@ type GetGatewayConfigResponse struct {
 
 func (x *GetGatewayConfigResponse) Reset() {
 	*x = GetGatewayConfigResponse{}
-	mi := &file_sandbox_proto_msgTypes[17]
+	mi := &file_sandbox_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1512,7 +1570,7 @@ func (x *GetGatewayConfigResponse) String() string {
 func (*GetGatewayConfigResponse) ProtoMessage() {}
 
 func (x *GetGatewayConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[17]
+	mi := &file_sandbox_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1525,7 +1583,7 @@ func (x *GetGatewayConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGatewayConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetGatewayConfigResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{17}
+	return file_sandbox_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *GetGatewayConfigResponse) GetSettings() map[string]*SettingValue {
@@ -1558,7 +1616,7 @@ type SettingValue struct {
 
 func (x *SettingValue) Reset() {
 	*x = SettingValue{}
-	mi := &file_sandbox_proto_msgTypes[18]
+	mi := &file_sandbox_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1570,7 +1628,7 @@ func (x *SettingValue) String() string {
 func (*SettingValue) ProtoMessage() {}
 
 func (x *SettingValue) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[18]
+	mi := &file_sandbox_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1583,7 +1641,7 @@ func (x *SettingValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SettingValue.ProtoReflect.Descriptor instead.
 func (*SettingValue) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{18}
+	return file_sandbox_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SettingValue) GetValue() isSettingValue_Value {
@@ -1668,7 +1726,7 @@ type EffectiveSetting struct {
 
 func (x *EffectiveSetting) Reset() {
 	*x = EffectiveSetting{}
-	mi := &file_sandbox_proto_msgTypes[19]
+	mi := &file_sandbox_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1680,7 +1738,7 @@ func (x *EffectiveSetting) String() string {
 func (*EffectiveSetting) ProtoMessage() {}
 
 func (x *EffectiveSetting) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[19]
+	mi := &file_sandbox_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1693,7 +1751,7 @@ func (x *EffectiveSetting) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EffectiveSetting.ProtoReflect.Descriptor instead.
 func (*EffectiveSetting) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{19}
+	return file_sandbox_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *EffectiveSetting) GetValue() *SettingValue {
@@ -1748,7 +1806,7 @@ type GetSandboxConfigResponse struct {
 
 func (x *GetSandboxConfigResponse) Reset() {
 	*x = GetSandboxConfigResponse{}
-	mi := &file_sandbox_proto_msgTypes[20]
+	mi := &file_sandbox_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1760,7 +1818,7 @@ func (x *GetSandboxConfigResponse) String() string {
 func (*GetSandboxConfigResponse) ProtoMessage() {}
 
 func (x *GetSandboxConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[20]
+	mi := &file_sandbox_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1773,7 +1831,7 @@ func (x *GetSandboxConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxConfigResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{20}
+	return file_sandbox_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GetSandboxConfigResponse) GetPolicy() *SandboxPolicy {
@@ -1873,7 +1931,7 @@ type SupervisorMiddlewareService struct {
 
 func (x *SupervisorMiddlewareService) Reset() {
 	*x = SupervisorMiddlewareService{}
-	mi := &file_sandbox_proto_msgTypes[21]
+	mi := &file_sandbox_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1885,7 +1943,7 @@ func (x *SupervisorMiddlewareService) String() string {
 func (*SupervisorMiddlewareService) ProtoMessage() {}
 
 func (x *SupervisorMiddlewareService) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_proto_msgTypes[21]
+	mi := &file_sandbox_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1898,7 +1956,7 @@ func (x *SupervisorMiddlewareService) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupervisorMiddlewareService.ProtoReflect.Descriptor instead.
 func (*SupervisorMiddlewareService) Descriptor() ([]byte, []int) {
-	return file_sandbox_proto_rawDescGZIP(), []int{21}
+	return file_sandbox_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *SupervisorMiddlewareService) GetName() string {
@@ -1975,7 +2033,9 @@ const file_sandbox_proto_rawDesc = "" +
 	"\x05order\x18\x06 \x01(\x05R\x05order\"P\n" +
 	"\x1aMiddlewareEndpointSelector\x12\x18\n" +
 	"\ainclude\x18\x01 \x03(\tR\ainclude\x12\x18\n" +
-	"\aexclude\x18\x02 \x03(\tR\aexclude\"\x84\t\n" +
+	"\aexclude\x18\x02 \x03(\tR\aexclude\"6\n" +
+	"\x18NetworkCredentialBinding\x12\x1a\n" +
+	"\bprovider\x18\x01 \x01(\tR\bprovider\"\xe3\t\n" +
 	"\x0fNetworkEndpoint\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\rR\x04port\x12\x1a\n" +
@@ -2002,7 +2062,8 @@ const file_sandbox_proto_rawDesc = "" +
 	"\x0fsigning_service\x18\x14 \x01(\tR\x0esigningService\x12%\n" +
 	"\x0esigning_region\x18\x15 \x01(\tR\rsigningRegion\x124\n" +
 	"\x17json_rpc_max_body_bytes\x18\x16 \x01(\rR\x13jsonRpcMaxBodyBytes\x122\n" +
-	"\x03mcp\x18\x17 \x01(\v2 .openshell.sandbox.v1.McpOptionsR\x03mcp\x1ar\n" +
+	"\x03mcp\x18\x17 \x01(\v2 .openshell.sandbox.v1.McpOptionsR\x03mcp\x12]\n" +
+	"\x12credential_binding\x18\x18 \x01(\v2..openshell.sandbox.v1.NetworkCredentialBindingR\x11credentialBinding\x1ar\n" +
 	"\x1cGraphqlPersistedQueriesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12<\n" +
 	"\x05value\x18\x02 \x01(\v2&.openshell.sandbox.v1.GraphqlOperationR\x05value:\x028\x01\"\xb6\x01\n" +
@@ -2122,7 +2183,7 @@ func file_sandbox_proto_rawDescGZIP() []byte {
 }
 
 var file_sandbox_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_sandbox_proto_goTypes = []any{
 	(SettingScope)(0),                   // 0: openshell.sandbox.v1.SettingScope
 	(PolicySource)(0),                   // 1: openshell.sandbox.v1.PolicySource
@@ -2133,72 +2194,74 @@ var file_sandbox_proto_goTypes = []any{
 	(*NetworkPolicyRule)(nil),           // 6: openshell.sandbox.v1.NetworkPolicyRule
 	(*NetworkMiddlewareConfig)(nil),     // 7: openshell.sandbox.v1.NetworkMiddlewareConfig
 	(*MiddlewareEndpointSelector)(nil),  // 8: openshell.sandbox.v1.MiddlewareEndpointSelector
-	(*NetworkEndpoint)(nil),             // 9: openshell.sandbox.v1.NetworkEndpoint
-	(*McpOptions)(nil),                  // 10: openshell.sandbox.v1.McpOptions
-	(*GraphqlOperation)(nil),            // 11: openshell.sandbox.v1.GraphqlOperation
-	(*L7DenyRule)(nil),                  // 12: openshell.sandbox.v1.L7DenyRule
-	(*L7Rule)(nil),                      // 13: openshell.sandbox.v1.L7Rule
-	(*L7Allow)(nil),                     // 14: openshell.sandbox.v1.L7Allow
-	(*L7QueryMatcher)(nil),              // 15: openshell.sandbox.v1.L7QueryMatcher
-	(*NetworkBinary)(nil),               // 16: openshell.sandbox.v1.NetworkBinary
-	(*GetSandboxConfigRequest)(nil),     // 17: openshell.sandbox.v1.GetSandboxConfigRequest
-	(*GetGatewayConfigRequest)(nil),     // 18: openshell.sandbox.v1.GetGatewayConfigRequest
-	(*GetGatewayConfigResponse)(nil),    // 19: openshell.sandbox.v1.GetGatewayConfigResponse
-	(*SettingValue)(nil),                // 20: openshell.sandbox.v1.SettingValue
-	(*EffectiveSetting)(nil),            // 21: openshell.sandbox.v1.EffectiveSetting
-	(*GetSandboxConfigResponse)(nil),    // 22: openshell.sandbox.v1.GetSandboxConfigResponse
-	(*SupervisorMiddlewareService)(nil), // 23: openshell.sandbox.v1.SupervisorMiddlewareService
-	nil,                                 // 24: openshell.sandbox.v1.SandboxPolicy.NetworkPoliciesEntry
-	nil,                                 // 25: openshell.sandbox.v1.SandboxPolicy.NetworkMiddlewaresEntry
-	nil,                                 // 26: openshell.sandbox.v1.NetworkEndpoint.GraphqlPersistedQueriesEntry
-	nil,                                 // 27: openshell.sandbox.v1.L7DenyRule.QueryEntry
-	nil,                                 // 28: openshell.sandbox.v1.L7DenyRule.ParamsEntry
-	nil,                                 // 29: openshell.sandbox.v1.L7Allow.QueryEntry
-	nil,                                 // 30: openshell.sandbox.v1.L7Allow.ParamsEntry
-	nil,                                 // 31: openshell.sandbox.v1.GetGatewayConfigResponse.SettingsEntry
-	nil,                                 // 32: openshell.sandbox.v1.GetSandboxConfigResponse.SettingsEntry
-	(*structpb.Struct)(nil),             // 33: google.protobuf.Struct
+	(*NetworkCredentialBinding)(nil),    // 9: openshell.sandbox.v1.NetworkCredentialBinding
+	(*NetworkEndpoint)(nil),             // 10: openshell.sandbox.v1.NetworkEndpoint
+	(*McpOptions)(nil),                  // 11: openshell.sandbox.v1.McpOptions
+	(*GraphqlOperation)(nil),            // 12: openshell.sandbox.v1.GraphqlOperation
+	(*L7DenyRule)(nil),                  // 13: openshell.sandbox.v1.L7DenyRule
+	(*L7Rule)(nil),                      // 14: openshell.sandbox.v1.L7Rule
+	(*L7Allow)(nil),                     // 15: openshell.sandbox.v1.L7Allow
+	(*L7QueryMatcher)(nil),              // 16: openshell.sandbox.v1.L7QueryMatcher
+	(*NetworkBinary)(nil),               // 17: openshell.sandbox.v1.NetworkBinary
+	(*GetSandboxConfigRequest)(nil),     // 18: openshell.sandbox.v1.GetSandboxConfigRequest
+	(*GetGatewayConfigRequest)(nil),     // 19: openshell.sandbox.v1.GetGatewayConfigRequest
+	(*GetGatewayConfigResponse)(nil),    // 20: openshell.sandbox.v1.GetGatewayConfigResponse
+	(*SettingValue)(nil),                // 21: openshell.sandbox.v1.SettingValue
+	(*EffectiveSetting)(nil),            // 22: openshell.sandbox.v1.EffectiveSetting
+	(*GetSandboxConfigResponse)(nil),    // 23: openshell.sandbox.v1.GetSandboxConfigResponse
+	(*SupervisorMiddlewareService)(nil), // 24: openshell.sandbox.v1.SupervisorMiddlewareService
+	nil,                                 // 25: openshell.sandbox.v1.SandboxPolicy.NetworkPoliciesEntry
+	nil,                                 // 26: openshell.sandbox.v1.SandboxPolicy.NetworkMiddlewaresEntry
+	nil,                                 // 27: openshell.sandbox.v1.NetworkEndpoint.GraphqlPersistedQueriesEntry
+	nil,                                 // 28: openshell.sandbox.v1.L7DenyRule.QueryEntry
+	nil,                                 // 29: openshell.sandbox.v1.L7DenyRule.ParamsEntry
+	nil,                                 // 30: openshell.sandbox.v1.L7Allow.QueryEntry
+	nil,                                 // 31: openshell.sandbox.v1.L7Allow.ParamsEntry
+	nil,                                 // 32: openshell.sandbox.v1.GetGatewayConfigResponse.SettingsEntry
+	nil,                                 // 33: openshell.sandbox.v1.GetSandboxConfigResponse.SettingsEntry
+	(*structpb.Struct)(nil),             // 34: google.protobuf.Struct
 }
 var file_sandbox_proto_depIdxs = []int32{
 	3,  // 0: openshell.sandbox.v1.SandboxPolicy.filesystem:type_name -> openshell.sandbox.v1.FilesystemPolicy
 	4,  // 1: openshell.sandbox.v1.SandboxPolicy.landlock:type_name -> openshell.sandbox.v1.LandlockPolicy
 	5,  // 2: openshell.sandbox.v1.SandboxPolicy.process:type_name -> openshell.sandbox.v1.ProcessPolicy
-	24, // 3: openshell.sandbox.v1.SandboxPolicy.network_policies:type_name -> openshell.sandbox.v1.SandboxPolicy.NetworkPoliciesEntry
-	25, // 4: openshell.sandbox.v1.SandboxPolicy.network_middlewares:type_name -> openshell.sandbox.v1.SandboxPolicy.NetworkMiddlewaresEntry
-	9,  // 5: openshell.sandbox.v1.NetworkPolicyRule.endpoints:type_name -> openshell.sandbox.v1.NetworkEndpoint
-	16, // 6: openshell.sandbox.v1.NetworkPolicyRule.binaries:type_name -> openshell.sandbox.v1.NetworkBinary
-	33, // 7: openshell.sandbox.v1.NetworkMiddlewareConfig.config:type_name -> google.protobuf.Struct
+	25, // 3: openshell.sandbox.v1.SandboxPolicy.network_policies:type_name -> openshell.sandbox.v1.SandboxPolicy.NetworkPoliciesEntry
+	26, // 4: openshell.sandbox.v1.SandboxPolicy.network_middlewares:type_name -> openshell.sandbox.v1.SandboxPolicy.NetworkMiddlewaresEntry
+	10, // 5: openshell.sandbox.v1.NetworkPolicyRule.endpoints:type_name -> openshell.sandbox.v1.NetworkEndpoint
+	17, // 6: openshell.sandbox.v1.NetworkPolicyRule.binaries:type_name -> openshell.sandbox.v1.NetworkBinary
+	34, // 7: openshell.sandbox.v1.NetworkMiddlewareConfig.config:type_name -> google.protobuf.Struct
 	8,  // 8: openshell.sandbox.v1.NetworkMiddlewareConfig.endpoints:type_name -> openshell.sandbox.v1.MiddlewareEndpointSelector
-	13, // 9: openshell.sandbox.v1.NetworkEndpoint.rules:type_name -> openshell.sandbox.v1.L7Rule
-	12, // 10: openshell.sandbox.v1.NetworkEndpoint.deny_rules:type_name -> openshell.sandbox.v1.L7DenyRule
-	26, // 11: openshell.sandbox.v1.NetworkEndpoint.graphql_persisted_queries:type_name -> openshell.sandbox.v1.NetworkEndpoint.GraphqlPersistedQueriesEntry
-	10, // 12: openshell.sandbox.v1.NetworkEndpoint.mcp:type_name -> openshell.sandbox.v1.McpOptions
-	27, // 13: openshell.sandbox.v1.L7DenyRule.query:type_name -> openshell.sandbox.v1.L7DenyRule.QueryEntry
-	28, // 14: openshell.sandbox.v1.L7DenyRule.params:type_name -> openshell.sandbox.v1.L7DenyRule.ParamsEntry
-	14, // 15: openshell.sandbox.v1.L7Rule.allow:type_name -> openshell.sandbox.v1.L7Allow
-	29, // 16: openshell.sandbox.v1.L7Allow.query:type_name -> openshell.sandbox.v1.L7Allow.QueryEntry
-	30, // 17: openshell.sandbox.v1.L7Allow.params:type_name -> openshell.sandbox.v1.L7Allow.ParamsEntry
-	31, // 18: openshell.sandbox.v1.GetGatewayConfigResponse.settings:type_name -> openshell.sandbox.v1.GetGatewayConfigResponse.SettingsEntry
-	20, // 19: openshell.sandbox.v1.EffectiveSetting.value:type_name -> openshell.sandbox.v1.SettingValue
-	0,  // 20: openshell.sandbox.v1.EffectiveSetting.scope:type_name -> openshell.sandbox.v1.SettingScope
-	2,  // 21: openshell.sandbox.v1.GetSandboxConfigResponse.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
-	32, // 22: openshell.sandbox.v1.GetSandboxConfigResponse.settings:type_name -> openshell.sandbox.v1.GetSandboxConfigResponse.SettingsEntry
-	1,  // 23: openshell.sandbox.v1.GetSandboxConfigResponse.policy_source:type_name -> openshell.sandbox.v1.PolicySource
-	23, // 24: openshell.sandbox.v1.GetSandboxConfigResponse.supervisor_middleware_services:type_name -> openshell.sandbox.v1.SupervisorMiddlewareService
-	6,  // 25: openshell.sandbox.v1.SandboxPolicy.NetworkPoliciesEntry.value:type_name -> openshell.sandbox.v1.NetworkPolicyRule
-	7,  // 26: openshell.sandbox.v1.SandboxPolicy.NetworkMiddlewaresEntry.value:type_name -> openshell.sandbox.v1.NetworkMiddlewareConfig
-	11, // 27: openshell.sandbox.v1.NetworkEndpoint.GraphqlPersistedQueriesEntry.value:type_name -> openshell.sandbox.v1.GraphqlOperation
-	15, // 28: openshell.sandbox.v1.L7DenyRule.QueryEntry.value:type_name -> openshell.sandbox.v1.L7QueryMatcher
-	15, // 29: openshell.sandbox.v1.L7DenyRule.ParamsEntry.value:type_name -> openshell.sandbox.v1.L7QueryMatcher
-	15, // 30: openshell.sandbox.v1.L7Allow.QueryEntry.value:type_name -> openshell.sandbox.v1.L7QueryMatcher
-	15, // 31: openshell.sandbox.v1.L7Allow.ParamsEntry.value:type_name -> openshell.sandbox.v1.L7QueryMatcher
-	20, // 32: openshell.sandbox.v1.GetGatewayConfigResponse.SettingsEntry.value:type_name -> openshell.sandbox.v1.SettingValue
-	21, // 33: openshell.sandbox.v1.GetSandboxConfigResponse.SettingsEntry.value:type_name -> openshell.sandbox.v1.EffectiveSetting
-	34, // [34:34] is the sub-list for method output_type
-	34, // [34:34] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	14, // 9: openshell.sandbox.v1.NetworkEndpoint.rules:type_name -> openshell.sandbox.v1.L7Rule
+	13, // 10: openshell.sandbox.v1.NetworkEndpoint.deny_rules:type_name -> openshell.sandbox.v1.L7DenyRule
+	27, // 11: openshell.sandbox.v1.NetworkEndpoint.graphql_persisted_queries:type_name -> openshell.sandbox.v1.NetworkEndpoint.GraphqlPersistedQueriesEntry
+	11, // 12: openshell.sandbox.v1.NetworkEndpoint.mcp:type_name -> openshell.sandbox.v1.McpOptions
+	9,  // 13: openshell.sandbox.v1.NetworkEndpoint.credential_binding:type_name -> openshell.sandbox.v1.NetworkCredentialBinding
+	28, // 14: openshell.sandbox.v1.L7DenyRule.query:type_name -> openshell.sandbox.v1.L7DenyRule.QueryEntry
+	29, // 15: openshell.sandbox.v1.L7DenyRule.params:type_name -> openshell.sandbox.v1.L7DenyRule.ParamsEntry
+	15, // 16: openshell.sandbox.v1.L7Rule.allow:type_name -> openshell.sandbox.v1.L7Allow
+	30, // 17: openshell.sandbox.v1.L7Allow.query:type_name -> openshell.sandbox.v1.L7Allow.QueryEntry
+	31, // 18: openshell.sandbox.v1.L7Allow.params:type_name -> openshell.sandbox.v1.L7Allow.ParamsEntry
+	32, // 19: openshell.sandbox.v1.GetGatewayConfigResponse.settings:type_name -> openshell.sandbox.v1.GetGatewayConfigResponse.SettingsEntry
+	21, // 20: openshell.sandbox.v1.EffectiveSetting.value:type_name -> openshell.sandbox.v1.SettingValue
+	0,  // 21: openshell.sandbox.v1.EffectiveSetting.scope:type_name -> openshell.sandbox.v1.SettingScope
+	2,  // 22: openshell.sandbox.v1.GetSandboxConfigResponse.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
+	33, // 23: openshell.sandbox.v1.GetSandboxConfigResponse.settings:type_name -> openshell.sandbox.v1.GetSandboxConfigResponse.SettingsEntry
+	1,  // 24: openshell.sandbox.v1.GetSandboxConfigResponse.policy_source:type_name -> openshell.sandbox.v1.PolicySource
+	24, // 25: openshell.sandbox.v1.GetSandboxConfigResponse.supervisor_middleware_services:type_name -> openshell.sandbox.v1.SupervisorMiddlewareService
+	6,  // 26: openshell.sandbox.v1.SandboxPolicy.NetworkPoliciesEntry.value:type_name -> openshell.sandbox.v1.NetworkPolicyRule
+	7,  // 27: openshell.sandbox.v1.SandboxPolicy.NetworkMiddlewaresEntry.value:type_name -> openshell.sandbox.v1.NetworkMiddlewareConfig
+	12, // 28: openshell.sandbox.v1.NetworkEndpoint.GraphqlPersistedQueriesEntry.value:type_name -> openshell.sandbox.v1.GraphqlOperation
+	16, // 29: openshell.sandbox.v1.L7DenyRule.QueryEntry.value:type_name -> openshell.sandbox.v1.L7QueryMatcher
+	16, // 30: openshell.sandbox.v1.L7DenyRule.ParamsEntry.value:type_name -> openshell.sandbox.v1.L7QueryMatcher
+	16, // 31: openshell.sandbox.v1.L7Allow.QueryEntry.value:type_name -> openshell.sandbox.v1.L7QueryMatcher
+	16, // 32: openshell.sandbox.v1.L7Allow.ParamsEntry.value:type_name -> openshell.sandbox.v1.L7QueryMatcher
+	21, // 33: openshell.sandbox.v1.GetGatewayConfigResponse.SettingsEntry.value:type_name -> openshell.sandbox.v1.SettingValue
+	22, // 34: openshell.sandbox.v1.GetSandboxConfigResponse.SettingsEntry.value:type_name -> openshell.sandbox.v1.EffectiveSetting
+	35, // [35:35] is the sub-list for method output_type
+	35, // [35:35] is the sub-list for method input_type
+	35, // [35:35] is the sub-list for extension type_name
+	35, // [35:35] is the sub-list for extension extendee
+	0,  // [0:35] is the sub-list for field type_name
 }
 
 func init() { file_sandbox_proto_init() }
@@ -2206,8 +2269,8 @@ func file_sandbox_proto_init() {
 	if File_sandbox_proto != nil {
 		return
 	}
-	file_sandbox_proto_msgTypes[8].OneofWrappers = []any{}
-	file_sandbox_proto_msgTypes[18].OneofWrappers = []any{
+	file_sandbox_proto_msgTypes[9].OneofWrappers = []any{}
+	file_sandbox_proto_msgTypes[19].OneofWrappers = []any{
 		(*SettingValue_StringValue)(nil),
 		(*SettingValue_BoolValue)(nil),
 		(*SettingValue_IntValue)(nil),
@@ -2219,7 +2282,7 @@ func file_sandbox_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_sandbox_proto_rawDesc), len(file_sandbox_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   31,
+			NumMessages:   32,
 			NumExtensions: 0,
 			NumServices:   0,
 		},


### PR DESCRIPTION
## Summary

Bind static provider credentials to the provider identity and authorized host, port, and path where they may be used. A placeholder for one provider can no longer resolve merely because the destination is otherwise allowed by network policy.

This is a focused extension of the proxy refactor merged in #2373. Dynamic credential grants keep their existing behavior.

## Related Issue

Design: #2155  
Refactor foundation: #2373 (merged)

## User-facing behavior

### Profiles that define endpoints

No additional sandbox policy authoring is required. Each static credential environment key is automatically bound to the endpoints declared by its provider profile. The placeholder resolves only when the request matches both:

- the effective network policy; and
- the profile-derived credential boundary, including host, port, and canonical path.

Allowing another destination in network policy does not make that provider's credential usable there.

### Endpointless profiles

A sandbox policy must explicitly bind each authorized endpoint to the concrete attached provider instance:

```yaml
network_policies:
  aws_s3:
    endpoints:
      - host: s3.us-west-2.amazonaws.com
        port: 443
        protocol: rest
        access: full
        credential_binding:
          provider: work-aws
        credential_signing: sigv4
        signing_service: s3
        signing_region: us-west-2
```

`credential_binding.provider` names the attached provider instance (`work-aws`), not its profile type (`aws`). This keeps identity explicit when a sandbox attaches multiple providers of the same type. The binding chooses which provider may supply credentials; signing and rewrite fields continue to describe how the proxy applies them.

Explicit bindings are sandbox-scoped. They are rejected in gateway-global policy and are unnecessary—and rejected—for profiles that already define endpoints.

### Fail-closed behavior

- An endpointless profile with no policy binding contributes its non-secret configuration, but OpenShell withholds its static credential keys and binding metadata.
- A placeholder used outside its bound host, port, or path is denied before credentials reach the upstream. The denial is reported through OCSF.
- Policy submission fails with `FAILED_PRECONDITION` when a binding names an unattached provider, a provider without a selected profile, or an endpoint-bearing profile.
- Policy submission also fails when a `credential_signing` endpoint has no attached AWS credential source whose profile declares the required keys and whose binding covers that endpoint.
- The complete update is rejected without partial activation.
- Detaching a provider that an active sandbox policy references is rejected.
- Credential refresh and rotation retain the provider identity and binding. Expired, revoked, stale, or incomplete generations fail closed.
- CONNECT, forward-proxy, inspected HTTP, and WebSocket paths enforce the same identity boundary.

### Upgrade behavior

A gateway sends static credentials only to supervisors that advertise endpoint-binding support. Restart or recreate older running sandboxes after upgrading the gateway and supervisor, and rotate credentials if an older sandbox may previously have received real values.

### Compatibility notes

- Absolute-form HTTP requests must use an authority that matches the `Host` header. OpenShell rejects mismatches before forwarding the request.
- Forward-proxy absolute URIs containing fragments are rejected. Origin-form request targets containing `://` remain origin-form and are canonicalized without being mistaken for another authority.
- The provider-environment revision hash advances from v1 to v3 and now incorporates the provider `resource_version`, the selected profile scope, and explicit policy credential bindings. Supervisors observe a one-time revision change after upgrade and refresh the provider snapshot even when credential values are otherwise unchanged.

## Changes

- negotiate endpoint-binding capability and send non-secret binding metadata to compatible supervisors
- derive static credential bindings from profile endpoints or explicit sandbox policy bindings for endpointless profiles
- install, rotate, and revoke provider-scoped static credentials atomically while preserving dynamic credential behavior
- enforce provider identity and endpoint scope across CONNECT, forward-proxy, L7 HTTP, and WebSocket paths
- reject invalid binding lifecycle changes before persistence or partial activation
- emit fail-closed denial rationale through OCSF without logging credential material
- document provider setup, policy authoring, AWS SigV4 usage, failure behavior, and upgrade guidance
- add endpoint-isolation and lifecycle regression coverage

## Testing

- [x] `mise run pre-commit` passes
- [x] `mise run test` passes
- [x] Unit tests added/updated
- [x] `mise run e2e:rust` passes
- [x] `mise run e2e:python` passes (87 passed)
- [x] `mise run e2e:mcp` passes (3 scenarios)
- [x] E2E tests added/updated
- [x] Remote Docker, Podman, Kubernetes, and VM E2E matrices pass

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated
- [x] User-facing provider and policy docs updated

