### PR TITLE
fix(sandbox): gate Linux-only ordering import

### DIFF
--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -17,7 +17,9 @@ mod sidecar_control;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use std::future::Future;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+#[cfg(target_os = "linux")]
+use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, AtomicU32};
 use std::time::Duration;
 use tracing::{debug, info, warn};
 


### PR DESCRIPTION
## Summary

Gate the `Ordering` import in `openshell-sandbox` to Linux, matching its only non-test uses. This fixes the macOS Clippy failure introduced by the Linux-gated sidecar entrypoint handling in #2498.

## Related Issue

Follow-up to #2498.

## Changes

- Import `std::sync::atomic::Ordering` only when targeting Linux
- Keep `AtomicBool` and `AtomicU32` available on all supported platforms

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo clippy -p openshell-sandbox --all-targets -- -D warnings` passes on aarch64 macOS
- [ ] Unit tests added/updated (not applicable; this is a compile-time platform lint)
- [ ] E2E tests added/updated (not applicable)

Branch Checks currently run Rust linting on Linux amd64 and arm64 only. Both platforms compile the Linux-gated function and therefore cannot detect this unused import. A native macOS Clippy job would catch the regression, but adding and provisioning a new macOS runner is broader than this narrowly scoped follow-up.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)
