### PR TITLE
ci: add focused macOS Rust lint

### DIFF
--- a/.github/workflows/branch-checks.yml
+++ b/.github/workflows/branch-checks.yml
@@ -106,7 +106,7 @@ jobs:
         run: mise install --locked
 
       - name: Cache Rust target and registry
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # Keep branch-check caches partitioned by runner architecture; lint
           # and test intentionally share the same job-local target directory.
@@ -138,6 +138,47 @@ jobs:
             echo "::warning::sccache stats unavailable (exit $status)"
           fi
           exit 0
+
+  rust-macos:
+    name: Rust lint (macOS)
+    needs: pr_metadata
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install mise
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://mise.run | MISE_VERSION=v2026.4.25 sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/share/mise/shims" >> "$GITHUB_PATH"
+
+      - name: Configure GHA sccache backend
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - name: Install Rust and Clippy
+        run: |
+          mise install --locked rust
+          rustup component add clippy
+
+      - name: Cache Rust target and registry
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: rust-clippy-macos
+          cache-on-failure: "true"
+
+      - name: Lint macOS-sensitive crates
+        # Formatting is target-independent and already checked by the Linux jobs.
+        # The full mise lint covers every workspace/E2E target and requires extra
+        # native dependencies such as Z3; keep this guard focused on macOS cfgs.
+        run: |
+          cargo clippy \
+            -p openshell-sandbox \
+            -p openshell-core \
+            -p openshell-cli \
+            --all-targets \
+            -- -D warnings
 
   python:
     name: Python (${{ matrix.runner }})


### PR DESCRIPTION
## Summary

Add a focused native macOS Rust lint job to Branch Checks so target-gated warnings are caught before merge. This follows up on the macOS-only unused-import regression fixed by #2513.

## Related Issue

Follow-up to #2498 and #2513.

## Changes

- Add a standard `macos-latest` Branch Checks job with a 20-minute timeout
- Install the locked Rust toolchain through mise and cache Cargo artifacts
- Lint all targets for `openshell-sandbox`, `openshell-core`, and `openshell-cli` with warnings denied
- Keep formatting and the full workspace/E2E lint on Linux to avoid redundant checks and additional native dependencies
- Document the full `rust-cache` action release tag in Branch Checks

## Testing

- [x] Workflow YAML parses successfully
- [x] `git diff --check` passes
- [ ] `mise run pre-commit` passes (skipped by request for this GitHub Actions-only change; an attempted local run was blocked by the host environment's missing `z3.h`)
- [ ] Unit tests added/updated (not applicable)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)
