### PR TITLE
fix(server): stabilize flaky delete telemetry unit test

### DIFF
--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -2477,9 +2477,9 @@ mod tests {
             )
             .await
         });
-        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
             while state.compute.delete_gate_entry_count() == 0 {
-                tokio::task::yield_now().await;
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             }
         })
         .await


### PR DESCRIPTION
## Summary

- Fix flaky unit test `delete_handler_ends_telemetry_for_the_resolved_sandbox_id` by replacing `yield_now()` spin-loop with `sleep(10ms)` polling and increasing the timeout from 1s to 5s

## Related Issue

Pre-existing flake observed on `main` — the test intermittently times out under CI load.

## Changes

The test holds the global `sandbox_sync_guard` and spawns a delete handler, then polls for `delete_gate_entry_count()` to become non-zero. The spawned task must complete two SQLite queries (via `spawn_blocking`) before acquiring the delete gate. In the single-threaded `#[tokio::test]` runtime, `yield_now()` creates a CPU-bound spin-loop that starves the blocking thread pool, causing the 1-second timeout to expire on loaded CI machines.

- Replace `tokio::task::yield_now()` with `tokio::time::sleep(10ms)` to release CPU between polls
- Increase timeout from 1s to 5s, consistent with the similar `create_sandbox_with_providers_waits_for_sandbox_sync_guard` test

## Testing

- [x] Test passes 10/10 consecutive runs locally
- [x] `mise run pre-commit` passes

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
