### PR TITLE
fix(cli): isolate subprocess tests from host OPENSHELL_ env vars

### DIFF
--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -1921,26 +1921,29 @@ async fn run_cli_sandbox_create(
         fs::copy(server.dir.path().join(filename), tls_dir.join(filename)).unwrap();
     }
 
-    tokio::process::Command::new(env!("CARGO_BIN_EXE_openshell"))
-        .args([
-            "--gateway",
-            "openshell",
-            "--gateway-endpoint",
-            &server.endpoint,
-            "sandbox",
-            "create",
-            "--name",
-            name,
-            "--no-tty",
-            "--no-auto-providers",
-        ])
-        .args(extra_args)
-        .env("XDG_CONFIG_HOME", xdg_dir.path())
-        .env("HOME", xdg_dir.path())
-        .env("OPENSHELL_PROVISION_TIMEOUT", "5")
-        .output()
-        .await
-        .unwrap()
+    let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_openshell"));
+    for (key, _) in std::env::vars().filter(|(k, _)| k.starts_with("OPENSHELL_")) {
+        cmd.env_remove(&key);
+    }
+    cmd.args([
+        "--gateway",
+        "openshell",
+        "--gateway-endpoint",
+        &server.endpoint,
+        "sandbox",
+        "create",
+        "--name",
+        name,
+        "--no-tty",
+        "--no-auto-providers",
+    ])
+    .args(extra_args)
+    .env("XDG_CONFIG_HOME", xdg_dir.path())
+    .env("HOME", xdg_dir.path())
+    .env("OPENSHELL_PROVISION_TIMEOUT", "5")
+    .output()
+    .await
+    .unwrap()
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

The subprocess integration tests inherit the full parent environment. If the developer has `OPENSHELL_GATEWAY_INSECURE=true` set in their shell, the spawned CLI process connects with `.with_no_client_auth()`, skipping the mTLS client certificate. The test server requires mTLS and responds with `CertificateRequired`.

## Related Issue

Follow-up to #2504. Root cause identified by @sjenning.

## Changes

- Strip `OPENSHELL_GATEWAY_INSECURE`, `OPENSHELL_GATEWAY`, `OPENSHELL_GATEWAY_ENDPOINT`, and `OPENSHELL_WORKSPACE` from the subprocess environment via `env_remove()`
- The test already sets `--gateway` and `--gateway-endpoint` explicitly via CLI args, so these env vars should not influence subprocess behavior

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] Verified: test fails with `OPENSHELL_GATEWAY_INSECURE=true` before fix, passes after
- [x] Full test suite (22/22) passes with and without the env var set
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)