### PR TITLE
Fix Konflux hermetic lockfiles to use UBI repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,6 +227,9 @@ rfc.md
 # Markdown/mermaid lint tooling deps
 scripts/lint-mermaid/node_modules/
 
+# Hermeto prefetch output
+/hermeto-output/
+
 # Nix
 /result
 /result-*

--- a/deploy/docker/Dockerfile.konflux.gateway
+++ b/deploy/docker/Dockerfile.konflux.gateway
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1.4
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Gateway image for RHEL/Konflux (hermetic build).
+#
+# Multi-stage build that compiles openshell-gateway from source on UBI9.
+# Requires prefetched dependencies via Hermeto (cargo, rpm, generic).
+# See deploy/konflux/ for prefetch configs.
+#
+# Local build:  ./deploy/konflux/build-local.sh gateway
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9/ubi:9.6@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc AS builder
+
+RUN dnf install -y --nodocs \
+        rust cargo \
+        gcc gcc-c++ make cmake \
+        openssl-devel git-core clang-devel \
+        gcc-toolset-14 gcc-toolset-14-gcc-c++ \
+    && dnf clean all
+
+# gcc-toolset-14 provides C++20 <format> header required by bundled Z3.
+# Same pattern as ~/git/builder (AIPCC-10154).
+ENV PATH=/opt/rh/gcc-toolset-14/root/usr/bin:${PATH} \
+    LD_LIBRARY_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64:/opt/rh/gcc-toolset-14/root/usr/lib \
+    CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY .cargo/ .cargo/
+COPY crates/ crates/
+COPY proto/ proto/
+COPY providers/ providers/
+
+# z3-sys bundled build needs prefetched Z3 source.
+ARG Z3_VERSION=4.16.0
+RUN mkdir -p /tmp/z3-src \
+    && tar xzf /cachi2/deps/generic/z3-${Z3_VERSION}.tar.gz -C /tmp/z3-src --strip-components=1 \
+    && Z3_SYS_BUNDLED_DIR_OVERRIDE=/tmp/z3-src \
+    cargo build --release \
+        --package openshell-server \
+        --features bundled-z3
+
+# ---------------------------------------------------------------------------
+# Runtime
+# ---------------------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6@sha256:34880b64c07f28f64d95737f82f891516de9a3b43583f39970f7bf8e4cfa48b7
+
+RUN microdnf install -y --nodocs ca-certificates \
+    && microdnf clean all
+
+COPY --from=builder --chmod=0555 \
+    /build/target/release/openshell-gateway \
+    /usr/local/bin/openshell-gateway
+
+LABEL com.redhat.component="odh-openshell-gateway-container" \
+      description="gRPC/HTTP control-plane server for OpenShell sandboxed AI agent runtimes" \
+      summary="gRPC/HTTP control-plane server for OpenShell sandboxed AI agent runtimes" \
+      name="rhoai/odh-openshell-gateway-rhel9" \
+      maintainer="['managed-open-data-hub@redhat.com']" \
+      io.openshift.expose-services="8080:http" \
+      io.k8s.display-name="odh-openshell-gateway" \
+      io.k8s.description="odh-openshell-gateway" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+
+USER 1000:1000
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/openshell-gateway"]
+CMD ["--bind-address", "0.0.0.0", "--port", "8080"]

--- a/deploy/docker/Dockerfile.konflux.supervisor
+++ b/deploy/docker/Dockerfile.konflux.supervisor
@@ -1,0 +1,113 @@
+# syntax=docker/dockerfile:1.4
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Supervisor image for RHEL/Konflux (hermetic build).
+#
+# The supervisor binary is extracted and injected into arbitrary user
+# containers (Alpine, Debian, distroless, UBI) so it MUST be a fully-static
+# musl binary. musl libc is built from source since UBI9 does not ship it.
+#
+# Requires prefetched dependencies via Hermeto (cargo, rpm, generic).
+# See deploy/konflux/ for prefetch configs.
+#
+# Local build:  ./deploy/konflux/build-local.sh supervisor
+
+ARG RUST_VERSION=1.92.0
+ARG MUSL_VERSION=1.2.5
+
+# ---------------------------------------------------------------------------
+# Stage 1: build musl libc from source
+# ---------------------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9/ubi:9.6@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc AS musl-toolchain
+
+ARG MUSL_VERSION
+
+RUN dnf install -y --nodocs gcc make tar gzip \
+    && dnf clean all
+
+WORKDIR /tmp/musl-build
+
+RUN tar xzf /cachi2/deps/generic/musl-${MUSL_VERSION}.tar.gz --strip-components=1 \
+    && ./configure --prefix=/usr/local/musl --disable-shared \
+    && make -j"$(nproc)" \
+    && make install
+
+# ---------------------------------------------------------------------------
+# Stage 2: compile supervisor (static musl binary)
+# ---------------------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9/ubi:9.6@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc AS builder
+
+ARG RUST_VERSION
+ARG TARGETARCH
+
+RUN dnf install -y --nodocs \
+        gcc gcc-c++ make cmake \
+        openssl-devel git-core xz \
+    && dnf clean all
+
+# Map TARGETARCH (amd64/arm64) to Rust triple components
+RUN RUST_ARCH=$(case "${TARGETARCH}" in amd64) echo x86_64;; arm64) echo aarch64;; *) echo "${TARGETARCH}";; esac) && \
+    RUST_TRIPLE="${RUST_ARCH}-unknown-linux-gnu" && \
+    MUSL_TRIPLE="${RUST_ARCH}-unknown-linux-musl" && \
+    mkdir -p /tmp/rust-toolchain && \
+    tar xJf /cachi2/deps/generic/rust-${RUST_VERSION}-${RUST_TRIPLE}.tar.xz -C /tmp/rust-toolchain --strip-components=1 && \
+    /tmp/rust-toolchain/install.sh --prefix=/usr/local && \
+    rm -rf /tmp/rust-toolchain && \
+    mkdir -p /tmp/musl-std && \
+    tar xJf /cachi2/deps/generic/rust-std-${RUST_VERSION}-${MUSL_TRIPLE}.tar.xz -C /tmp/musl-std --strip-components=1 && \
+    /tmp/musl-std/install.sh --prefix=/usr/local && \
+    rm -rf /tmp/musl-std
+
+COPY --from=musl-toolchain /usr/local/musl /usr/local/musl
+
+# CC and target vars use the native arch musl triple
+RUN RUST_ARCH=$(case "${TARGETARCH}" in amd64) echo x86_64;; arm64) echo aarch64;; *) echo "${TARGETARCH}";; esac) && \
+    echo "MUSL_TARGET=${RUST_ARCH}-unknown-linux-musl" > /tmp/build-env
+ENV PATH="/usr/local/musl/bin:${PATH}" \
+    CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY .cargo/ .cargo/
+COPY crates/ crates/
+COPY proto/ proto/
+
+RUN . /tmp/build-env && \
+    export CC_${MUSL_TARGET//-/_}=musl-gcc && \
+    cargo build --release \
+        --target "${MUSL_TARGET}" \
+        --package openshell-sandbox && \
+    mkdir -p /build/output && \
+    cp /build/target/${MUSL_TARGET}/release/openshell-sandbox /build/output/
+
+# ---------------------------------------------------------------------------
+# Runtime
+# ---------------------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6@sha256:34880b64c07f28f64d95737f82f891516de9a3b43583f39970f7bf8e4cfa48b7
+
+ARG TARGETARCH
+
+RUN microdnf install -y --nodocs \
+        nftables \
+        iptables-nft \
+        iproute \
+        util-linux-core \
+    && microdnf clean all
+
+# Copy the static binary from the arch-specific target directory.
+# Builder writes the target to /tmp/build-env; we resolve it here.
+COPY --from=builder --chmod=0555 /build/output/openshell-sandbox /openshell-sandbox
+
+LABEL com.redhat.component="odh-openshell-supervisor-container" \
+      description="Static musl-linked sandbox supervisor for OpenShell, injected into arbitrary user containers" \
+      summary="Static musl-linked sandbox supervisor for OpenShell, injected into arbitrary user containers" \
+      name="rhoai/odh-openshell-supervisor-rhel9" \
+      maintainer="['managed-open-data-hub@redhat.com']" \
+      io.openshift.expose-services="" \
+      io.k8s.display-name="odh-openshell-supervisor" \
+      io.k8s.description="odh-openshell-supervisor" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+
+ENTRYPOINT ["/openshell-sandbox"]

--- a/deploy/konflux/build-local.sh
+++ b/deploy/konflux/build-local.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Build Konflux images locally using Hermeto prefetched dependencies.
+# Replicates the Konflux hermetic build pipeline (--network none).
+#
+# Prerequisites:
+#   - hermeto (pip install git+https://github.com/hermetoproject/hermeto.git)
+#   - podman
+#   - createrepo_c
+#   - Red Hat CDN CA trusted (sudo cp /etc/rhsm/ca/redhat-uep.pem /etc/pki/ca-trust/source/anchors/ && sudo update-ca-trust)
+#
+# Usage:
+#   ./deploy/konflux/build-local.sh gateway
+#   ./deploy/konflux/build-local.sh supervisor
+#   ./deploy/konflux/build-local.sh all
+#
+# Override architecture (default: host arch via uname -m):
+#   PLATFORM=linux/arm64 ./deploy/konflux/build-local.sh supervisor
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUTPUT_DIR="${REPO_ROOT}/hermeto-output"
+
+# Detect or override platform
+HOST_ARCH=$(uname -m)
+case "${HOST_ARCH}" in
+    x86_64)  DEFAULT_PLATFORM="linux/amd64" ;;
+    aarch64) DEFAULT_PLATFORM="linux/arm64" ;;
+    *)       DEFAULT_PLATFORM="linux/${HOST_ARCH}" ;;
+esac
+PLATFORM="${PLATFORM:-${DEFAULT_PLATFORM}}"
+
+CLEANUP_PATHS=()
+cleanup() {
+    for p in "${CLEANUP_PATHS[@]}"; do
+        rm -rf "$p"
+    done
+    git -C "${REPO_ROOT}" checkout .cargo/config.toml 2>/dev/null || true
+}
+trap cleanup EXIT
+
+build_image() {
+    local component="$1"
+    local dockerfile konfig_dir output_dir repos_dir
+
+    case "$component" in
+        gateway)
+            dockerfile="deploy/docker/Dockerfile.konflux.gateway"
+            konfig_dir="deploy/konflux/gateway"
+            ;;
+        supervisor)
+            dockerfile="deploy/docker/Dockerfile.konflux.supervisor"
+            konfig_dir="deploy/konflux/supervisor"
+            ;;
+        *)
+            echo "Unknown component: $component" >&2
+            exit 1
+            ;;
+    esac
+
+    output_dir="${OUTPUT_DIR}/${component}"
+    repos_dir=$(mktemp -d)
+    CLEANUP_PATHS+=("${repos_dir}")
+
+    echo "=== Prefetching ${component} dependencies ==="
+    rm -rf "${output_dir}"
+    hermeto fetch-deps \
+        --source "${REPO_ROOT}" \
+        --output "${output_dir}" \
+        "[
+            {\"path\": \".\", \"type\": \"cargo\"},
+            {\"path\": \"${konfig_dir}\", \"type\": \"rpm\"},
+            {\"path\": \"${konfig_dir}\", \"type\": \"generic\", \"lockfile\": \"generic-fetcher.yaml\"}
+        ]"
+
+    echo "=== Injecting files ==="
+    hermeto inject-files "${output_dir}" --for-output-dir /cachi2
+    hermeto generate-env "${output_dir}" \
+        --format env --for-output-dir /cachi2 \
+        --output "${output_dir}/cachi2.env"
+
+    echo "=== Preparing RPM repos ==="
+    find "${output_dir}" -name "hermeto.repo" -execdir cp {} cachi2.repo \;
+    local rpm_arch
+    rpm_arch=$(uname -m)
+    cp "${output_dir}/deps/rpm/${rpm_arch}/repos.d/cachi2.repo" "${repos_dir}/"
+    chmod -R go+rX "${repos_dir}"
+
+    echo "=== Building ${component} (--network none, platform ${PLATFORM}) ==="
+    local hermetic_dockerfile
+    hermetic_dockerfile=$(mktemp)
+    CLEANUP_PATHS+=("${hermetic_dockerfile}")
+    cp "${REPO_ROOT}/${dockerfile}" "${hermetic_dockerfile}"
+    sed -i 's|^\s*RUN |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "${hermetic_dockerfile}"
+
+    podman build \
+        -f "${hermetic_dockerfile}" \
+        --platform "${PLATFORM}" \
+        --volume "$(realpath "${output_dir}"):/cachi2:Z" \
+        --volume "$(realpath "${repos_dir}"):/etc/yum.repos.d:Z" \
+        --network none \
+        -t "openshell-${component}-konflux" \
+        "${REPO_ROOT}"
+
+    echo "=== ${component} built successfully ==="
+    podman run --rm --platform "${PLATFORM}" "openshell-${component}-konflux" --help 2>&1 | head -3
+    echo ""
+}
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: $0 {gateway|supervisor|all}" >&2
+    exit 1
+fi
+
+target="$1"
+if [[ "$target" == "all" ]]; then
+    build_image gateway
+    build_image supervisor
+else
+    build_image "$target"
+fi

--- a/deploy/konflux/build-local.sh
+++ b/deploy/konflux/build-local.sh
@@ -5,8 +5,6 @@
 # Prerequisites:
 #   - hermeto (pip install git+https://github.com/hermetoproject/hermeto.git)
 #   - podman
-#   - createrepo_c
-#   - Red Hat CDN CA trusted (sudo cp /etc/rhsm/ca/redhat-uep.pem /etc/pki/ca-trust/source/anchors/ && sudo update-ca-trust)
 #
 # Usage:
 #   ./deploy/konflux/build-local.sh gateway

--- a/deploy/konflux/gateway/generic-fetcher.yaml
+++ b/deploy/konflux/gateway/generic-fetcher.yaml
@@ -1,0 +1,12 @@
+# Generic fetcher artifacts for Dockerfile.konflux.gateway
+# These are prefetched by Hermeto and mounted at /cachi2/deps/generic/
+# Include in prefetch-input alongside cargo and rpm types.
+#
+# To update hashes: curl -sL <url> | sha256sum
+metadata:
+  version: "1.0"
+artifacts:
+  # Z3 source (z3-sys bundled build downloads from GitHub at build time)
+  - download_url: https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.16.0.tar.gz
+    checksum: "sha256:c68c3e5e4810b16126b8cb4c47eee85c1ac3e24a81914c8e371b40de9dd33ac7"
+    filename: z3-4.16.0.tar.gz

--- a/deploy/konflux/gateway/rpms.in.yaml
+++ b/deploy/konflux/gateway/rpms.in.yaml
@@ -1,0 +1,29 @@
+# RPM dependencies for Dockerfile.konflux.gateway
+# Build + runtime stages combined. Generate lockfile with:
+#   rpm-lockfile-prototype --image registry.access.redhat.com/ubi9/ubi:9.6 \
+#       --arch x86_64 \
+#       --outfile deploy/konflux/gateway/rpms.lock.yaml \
+#       deploy/konflux/gateway/rpms.in.yaml
+#
+contentOrigin:
+  repofiles:
+    - /etc/yum.repos.d/ubi.repo
+packages:
+  # Build stage: Rust toolchain
+  - rust
+  - cargo
+  # Build stage: C/C++ toolchain
+  - gcc
+  - gcc-c++
+  - make
+  - cmake
+  # Build stage: gcc-toolset-14 for C++20 <format> (required by bundled Z3)
+  - gcc-toolset-14
+  - gcc-toolset-14-gcc-c++
+  # Build stage: z3-sys bindgen needs libclang
+  - clang-devel
+  # Build stage: other
+  - openssl-devel
+  - git-core
+  # Runtime stage
+  - ca-certificates

--- a/deploy/konflux/gateway/rpms.lock.yaml
+++ b/deploy/konflux/gateway/rpms.lock.yaml
@@ -1,0 +1,893 @@
+arches:
+- arch: x86_64
+  packages:
+  - evra: 2.4.0-1.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/acl-2.4.0-1.el9_8.x86_64.rpm
+  - evra: 1.24-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/alternatives-1.24-2.el9.x86_64.rpm
+  - evra: 3.1.5-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/audit-libs-3.1.5-8.el9.x86_64.rpm
+  - evra: 11-13.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/basesystem-11-13.el9.noarch.rpm
+  - evra: 5.1.8-9.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/bash-5.1.8-9.el9.x86_64.rpm
+  - evra: 2.35.2-72.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-72.el9.x86_64.rpm
+  - evra: 2.35.2-72.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.x86_64.rpm
+  - evra: 1.0.8-11.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/bzip2-libs-1.0.8-11.el9.x86_64.rpm
+  - evra: 2025.2.80_v9.0.305-91.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.noarch.rpm
+  - evra: 3.6-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/checkpolicy-3.6-1.el9.x86_64.rpm
+  - evra: 21.1.8-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-21.1.8-2.el9.x86_64.rpm
+  - evra: 21.1.8-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-libs-21.1.8-2.el9.x86_64.rpm
+  - evra: 21.1.8-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-resource-filesystem-21.1.8-2.el9.x86_64.rpm
+  - evra: 21.1.8-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-tools-extra-21.1.8-2.el9.x86_64.rpm
+  - evra: 3.31.8-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-3.31.8-3.el9.x86_64.rpm
+  - evra: 3.31.8-3.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-data-3.31.8-3.el9.noarch.rpm
+  - evra: 3.31.8-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-filesystem-3.31.8-3.el9.x86_64.rpm
+  - evra: 3.31.8-3.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-rpm-macros-3.31.8-3.el9.noarch.rpm
+  - evra: 8.32-41.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.x86_64.rpm
+  - evra: 8.32-41.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.x86_64.rpm
+  - evra: 8.32-41.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-single-8.32-41.el9_8.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cpp-11.5.0-14.el9.x86_64.rpm
+  - evra: 2.9.6-28.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cracklib-2.9.6-28.el9.x86_64.rpm
+  - evra: 2.9.6-28.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-28.el9.x86_64.rpm
+  - evra: 20260224-1.gitea0f072.el9_8.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/crypto-policies-20260224-1.gitea0f072.el9_8.noarch.rpm
+  - evra: 2.8.1-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cryptsetup-libs-2.8.1-3.el9.x86_64.rpm
+  - evra: 7.76.1-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/curl-7.76.1-40.el9.x86_64.rpm
+  - evra: 7.76.1-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/curl-minimal-7.76.1-40.el9.x86_64.rpm
+  - evra: 2.1.27-22.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-22.el9.x86_64.rpm
+  - evra: 1.12.20-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-1.12.20-8.el9.x86_64.rpm
+  - evra: 28-7.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-broker-28-7.el9.x86_64.rpm
+  - evra: 1.12.20-8.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
+  - evra: 1.02.207-4.el9_8.1.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/device-mapper-1.02.207-4.el9_8.1.x86_64.rpm
+  - evra: 1.02.207-4.el9_8.1.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/device-mapper-libs-1.02.207-4.el9_8.1.x86_64.rpm
+  - evra: 3.7-12.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/diffutils-3.7-12.el9.x86_64.rpm
+  - evra: 0.194-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.x86_64.rpm
+  - evra: 0.194-1.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-default-yama-scope-0.194-1.el9.noarch.rpm
+  - evra: 0.194-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.x86_64.rpm
+  - evra: 0.194-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.x86_64.rpm
+  - evra: 27.2-18.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
+  - evra: 5.3.0-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/environment-modules-5.3.0-2.el9.x86_64.rpm
+  - evra: 2.5.0-6.el9_8.1.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/expat-2.5.0-6.el9_8.1.x86_64.rpm
+  - evra: 3.16-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/filesystem-3.16-5.el9.x86_64.rpm
+  - evra: 4.8.0-7.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/findutils-4.8.0-7.el9.x86_64.rpm
+  - evra: 1.2.0-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fips-provider-next-1.2.0-5.el9.x86_64.rpm
+  - evra: 5.1.0-6.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gawk-5.1.0-6.el9.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-11.5.0-14.el9.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-c++-11.5.0-14.el9.x86_64.rpm
+  - evra: 12.88-1.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-annobin-docs-12.88-1.el9.noarch.rpm
+  - evra: 12.88-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-annobin-plugin-gcc-12.88-1.el9.x86_64.rpm
+  - evra: 2.41-6.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-binutils-2.41-6.el9.x86_64.rpm
+  - evra: 0.14-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-dwz-0.14-1.el9.x86_64.rpm
+  - evra: 14.2.1-13.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-gcc-14.2.1-13.el9.x86_64.rpm
+  - evra: 14.2.1-13.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-gcc-c++-14.2.1-13.el9.x86_64.rpm
+  - evra: 14.2.1-13.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-gcc-gfortran-14.2.1-13.el9.x86_64.rpm
+  - evra: 14.2.1-13.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-libquadmath-devel-14.2.1-13.el9.x86_64.rpm
+  - evra: 14.2.1-13.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-libstdc++-devel-14.2.1-13.el9.x86_64.rpm
+  - evra: 14.0-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-runtime-14.0-2.el9.x86_64.rpm
+  - evra: 2.44-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-binutils-2.44-5.el9.x86_64.rpm
+  - evra: 15.2.1-7.1.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-gcc-15.2.1-7.1.el9_8.x86_64.rpm
+  - evra: 15.2.1-7.1.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-gcc-c++-15.2.1-7.1.el9_8.x86_64.rpm
+  - evra: 15.2.1-7.1.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-libstdc++-devel-15.2.1-7.1.el9_8.x86_64.rpm
+  - evra: 15.0-9.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-runtime-15.0-9.el9.x86_64.rpm
+  - evra: 1.23-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-all-langpacks-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-common-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-langpack-en-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-274.el9_8.x86_64.rpm
+  - evra: 6.2.0-13.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gmp-6.2.0-13.el9.x86_64.rpm
+  - evra: 3.6-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/grep-3.6-5.el9.x86_64.rpm
+  - evra: 1.22.4-10.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.x86_64.rpm
+  - evra: 1.12-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
+  - evra: 6.7-15.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/i/info-6.7-15.el9.x86_64.rpm
+  - evra: 2.14-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/j/jansson-2.14-1.el9.x86_64.rpm
+  - evra: 0.14-11.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/j/json-c-0.14-11.el9.x86_64.rpm
+  - evra: 2.4.0-11.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kbd-2.4.0-11.el9.x86_64.rpm
+  - evra: 2.4.0-11.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kbd-legacy-2.4.0-11.el9.noarch.rpm
+  - evra: 2.4.0-11.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kbd-misc-2.4.0-11.el9.noarch.rpm
+  - evra: 5.14.0-687.30.1.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.30.1.el9_8.x86_64.rpm
+  - evra: 1.6.3-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/keyutils-libs-1.6.3-1.el9.x86_64.rpm
+  - evra: 28-11.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kmod-28-11.el9.x86_64.rpm
+  - evra: 28-11.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kmod-libs-28-11.el9.x86_64.rpm
+  - evra: 1.21.1-10.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/krb5-libs-1.21.1-10.el9_8.x86_64.rpm
+  - evra: 590-6.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/less-590-6.el9.x86_64.rpm
+  - evra: 2.4.0-1.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libacl-2.4.0-1.el9_8.x86_64.rpm
+  - evra: 3.5.3-9.el9_7.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libarchive-3.5.3-9.el9_7.x86_64.rpm
+  - evra: 2.5.1-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libattr-2.5.1-3.el9.x86_64.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libblkid-2.37.4-25.el9.x86_64.rpm
+  - evra: 1.0.9-9.el9_7.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libbrotli-1.0.9-9.el9_7.x86_64.rpm
+  - evra: 2.48-10.el9_8.1.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcap-2.48-10.el9_8.1.x86_64.rpm
+  - evra: 0.8.2-7.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcap-ng-0.8.2-7.el9.x86_64.rpm
+  - evra: 0.7.0-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.x86_64.rpm
+  - evra: 1.46.5-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcom_err-1.46.5-8.el9.x86_64.rpm
+  - evra: 7.76.1-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcurl-7.76.1-40.el9.x86_64.rpm
+  - evra: 7.76.1-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcurl-minimal-7.76.1-40.el9.x86_64.rpm
+  - evra: 5.3.28-57.el9_6.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.x86_64.rpm
+  - evra: 0.4.1-7.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libeconf-0.4.1-7.el9_8.x86_64.rpm
+  - evra: 3.1-39.20210216cvs.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.x86_64.rpm
+  - evra: 3.1-39.20210216cvs.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libedit-devel-3.1-39.20210216cvs.el9.x86_64.rpm
+  - evra: 2.1.12-8.el9_4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libevent-2.1.12-8.el9_4.x86_64.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfdisk-2.37.4-25.el9.x86_64.rpm
+  - evra: 3.4.2-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libffi-3.4.2-8.el9.x86_64.rpm
+  - evra: 1.13.0-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgcc-11.5.0-14.el9.x86_64.rpm
+  - evra: 1.10.0-11.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgfortran-11.5.0-14.el9.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.x86_64.rpm
+  - evra: 1.42-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgpg-error-1.42-5.el9.x86_64.rpm
+  - evra: 2.3.0-7.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libidn2-2.3.0-7.el9.x86_64.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libmount-2.37.4-25.el9.x86_64.rpm
+  - evra: 1.2.1-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
+  - evra: 1.43.0-6.el9_8.1.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9_8.1.x86_64.rpm
+  - evra: 1.5.3-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.x86_64.rpm
+  - evra: 1.7.3-10.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
+  - evra: 0.21.1-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpsl-0.21.1-5.el9.x86_64.rpm
+  - evra: 1.4.4-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libquadmath-11.5.0-14.el9.x86_64.rpm
+  - evra: 2.5.2-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
+  - evra: 3.6-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libselinux-3.6-3.el9.x86_64.rpm
+  - evra: 3.6-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.x86_64.rpm
+  - evra: 3.6-5.el9_6.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.x86_64.rpm
+  - evra: 3.6-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsepol-3.6-3.el9.x86_64.rpm
+  - evra: 2.13-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsigsegv-2.13-4.el9.x86_64.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsmartcols-2.37.4-25.el9.x86_64.rpm
+  - evra: 0.10.4-18.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libssh-0.10.4-18.el9.x86_64.rpm
+  - evra: 0.10.4-18.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libssh-config-0.10.4-18.el9.noarch.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libstdc++-11.5.0-14.el9.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libstdc++-devel-11.5.0-14.el9.x86_64.rpm
+  - evra: 4.16.0-10.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libtasn1-4.16.0-10.el9_8.x86_64.rpm
+  - evra: 2.4.6-46.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libtool-ltdl-2.4.6-46.el9.x86_64.rpm
+  - evra: 0.9.10-15.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libunistring-0.9.10-15.el9.x86_64.rpm
+  - evra: 1.2.1-6.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.x86_64.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libuuid-2.37.4-25.el9.x86_64.rpm
+  - evra: 1.42.0-2.el9_4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.x86_64.rpm
+  - evra: 0.3.2-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libverto-0.3.2-3.el9.x86_64.rpm
+  - evra: 4.4.18-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libxcrypt-4.4.18-3.el9.x86_64.rpm
+  - evra: 4.4.18-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.x86_64.rpm
+  - evra: 2.9.13-14.el9_8.2.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libxml2-2.9.13-14.el9_8.2.x86_64.rpm
+  - evra: 1.5.5-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libzstd-1.5.5-1.el9.x86_64.rpm
+  - evra: 1.5.5-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libzstd-devel-1.5.5-1.el9.x86_64.rpm
+  - evra: 21.1.8-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-21.1.8-2.el9.x86_64.rpm
+  - evra: 21.1.8-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-devel-21.1.8-2.el9.x86_64.rpm
+  - evra: 21.1.8-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-filesystem-21.1.8-2.el9.x86_64.rpm
+  - evra: 21.1.8-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-googletest-21.1.8-2.el9.x86_64.rpm
+  - evra: 21.1.8-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-libs-21.1.8-2.el9.x86_64.rpm
+  - evra: 21.1.8-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-static-21.1.8-2.el9.x86_64.rpm
+  - evra: 21.1.8-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-test-21.1.8-2.el9.x86_64.rpm
+  - evra: 5.4.4-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/lua-libs-5.4.4-4.el9.x86_64.rpm
+  - evra: 1.9.3-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/lz4-libs-1.9.3-5.el9.x86_64.rpm
+  - evra: 4.3-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
+  - evra: 2.9.3-9.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/man-db-2.9.3-9.el9.x86_64.rpm
+  - evra: 4.1.0-10.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/mpfr-4.1.0-10.el9.x86_64.rpm
+  - evra: 6.2-12.20210508.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-base-6.2-12.20210508.el9.noarch.rpm
+  - evra: 6.2-12.20210508.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/ncurses-c++-libs-6.2-12.20210508.el9.x86_64.rpm
+  - evra: 6.2-12.20210508.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/ncurses-devel-6.2-12.20210508.el9.x86_64.rpm
+  - evra: 6.2-12.20210508.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-libs-6.2-12.20210508.el9.x86_64.rpm
+  - evra: 2.6.8-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openldap-2.6.8-4.el9.x86_64.rpm
+  - evra: 9.9p1-7.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-9.9p1-7.el9_8.x86_64.rpm
+  - evra: 9.9p1-7.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-clients-9.9p1-7.el9_8.x86_64.rpm
+  - evra: 3.5.5-5.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.5.5-5.el9_8.x86_64.rpm
+  - evra: 3.5.5-5.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/openssl-devel-3.5.5-5.el9_8.x86_64.rpm
+  - evra: 3.0.7-11.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_8.x86_64.rpm
+  - evra: 3.0.7-11.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_8.x86_64.rpm
+  - evra: 3.5.5-5.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-libs-3.5.5-5.el9_8.x86_64.rpm
+  - evra: 0.26.2-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/p11-kit-0.26.2-1.el9.x86_64.rpm
+  - evra: 0.26.2-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/p11-kit-trust-0.26.2-1.el9.x86_64.rpm
+  - evra: 1.5.1-28.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pam-1.5.1-28.el9.x86_64.rpm
+  - evra: 8.44-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pcre-8.44-4.el9.x86_64.rpm
+  - evra: 10.40-6.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pcre2-10.40-6.el9.x86_64.rpm
+  - evra: 10.40-6.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pcre2-syntax-10.40-6.el9.noarch.rpm
+  - evra: 1.7.3-10.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
+  - evra: 1.7.3-10.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+  - evra: 1.7.3-10.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
+  - evra: 3.6-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/policycoreutils-3.6-5.el9.x86_64.rpm
+  - evra: 3.6-5.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/policycoreutils-python-utils-3.6-5.el9.noarch.rpm
+  - evra: 1.18-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/popt-1.18-8.el9.x86_64.rpm
+  - evra: 3.3.17-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.x86_64.rpm
+  - evra: 20210518-3.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/publicsuffix-list-dafsa-20210518-3.el9.noarch.rpm
+  - evra: 3.9.25-7.el9_8.2.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-3.9.25-7.el9_8.2.x86_64.rpm
+  - evra: 3.1.5-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-audit-3.1.5-8.el9.x86_64.rpm
+  - evra: 1.5.0-7.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-distro-1.5.0-7.el9.noarch.rpm
+  - evra: 3.9.25-7.el9_8.2.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-libs-3.9.25-7.el9_8.2.x86_64.rpm
+  - evra: 3.6-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-libselinux-3.6-3.el9.x86_64.rpm
+  - evra: 3.6-5.el9_6.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-libsemanage-3.6-5.el9_6.x86_64.rpm
+  - evra: 21.3.1-2.el9_8.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-2.el9_8.noarch.rpm
+  - evra: 3.6-5.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-policycoreutils-3.6-5.el9.noarch.rpm
+  - evra: 4.4.4-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setools-4.4.4-1.el9.x86_64.rpm
+  - evra: 53.0.0-15.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setuptools-53.0.0-15.el9.noarch.rpm
+  - evra: 53.0.0-15.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-15.el9.noarch.rpm
+  - evra: 8.1-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/readline-8.1-4.el9.x86_64.rpm
+  - evra: 9.8-1.0.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/redhat-release-9.8-1.0.el9.x86_64.rpm
+  - evra: 4.16.1.3-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rpm-4.16.1.3-40.el9.x86_64.rpm
+  - evra: 4.16.1.3-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rpm-libs-4.16.1.3-40.el9.x86_64.rpm
+  - evra: 1.92.0-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-1.92.0-1.el9.x86_64.rpm
+  - evra: 1.92.0-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-std-static-1.92.0-1.el9.x86_64.rpm
+  - evra: 2.0.3-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.x86_64.rpm
+  - evra: 4.8-10.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/sed-4.8-10.el9.x86_64.rpm
+  - evra: 2.13.7-10.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/setup-2.13.7-10.el9.noarch.rpm
+  - evra: 4.9-16.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/shadow-utils-4.9-16.el9.x86_64.rpm
+  - evra: 3.34.1-10.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.x86_64.rpm
+  - evra: 252-67.el9_8.4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-252-67.el9_8.4.x86_64.rpm
+  - evra: 252-67.el9_8.4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-libs-252-67.el9_8.4.x86_64.rpm
+  - evra: 252-67.el9_8.4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-pam-252-67.el9_8.4.x86_64.rpm
+  - evra: 252-67.el9_8.4.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-67.el9_8.4.noarch.rpm
+  - evra: 252-67.el9_8.4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-udev-252-67.el9_8.4.x86_64.rpm
+  - evra: 8.6.10-7.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tcl-8.6.10-7.el9.x86_64.rpm
+  - evra: 3.2.3-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.x86_64.rpm
+  - evra: 2026b-1.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tzdata-2026b-1.el9.noarch.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/util-linux-2.37.4-25.el9.x86_64.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/util-linux-core-2.37.4-25.el9.x86_64.rpm
+  - evra: 8.2.2637-26.el9_8.10.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.10.noarch.rpm
+  - evra: 5.2.5-8.el9_0.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.x86_64.rpm
+  - evra: 1.2.11-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/z/zlib-1.2.11-40.el9.x86_64.rpm
+  - evra: 1.92.0-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cargo-1.92.0-1.el9.x86_64.rpm
+  - evra: 21.1.8-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-devel-21.1.8-2.el9.x86_64.rpm
+  - evra: 14.0-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-14.0-2.el9.x86_64.rpm
+  - evra: 2.52.0-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-2.52.0-1.el9.x86_64.rpm
+  source: []
+- arch: aarch64
+  packages:
+  - evra: 2.4.0-1.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/acl-2.4.0-1.el9_8.aarch64.rpm
+  - evra: 1.24-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/alternatives-1.24-2.el9.aarch64.rpm
+  - evra: 3.1.5-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/audit-libs-3.1.5-8.el9.aarch64.rpm
+  - evra: 11-13.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/basesystem-11-13.el9.noarch.rpm
+  - evra: 5.1.8-9.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/bash-5.1.8-9.el9.aarch64.rpm
+  - evra: 2.35.2-72.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-2.35.2-72.el9.aarch64.rpm
+  - evra: 2.35.2-72.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.aarch64.rpm
+  - evra: 1.0.8-11.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/bzip2-libs-1.0.8-11.el9.aarch64.rpm
+  - evra: 2025.2.80_v9.0.305-91.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.noarch.rpm
+  - evra: 3.6-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/checkpolicy-3.6-1.el9.aarch64.rpm
+  - evra: 21.1.8-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-21.1.8-2.el9.aarch64.rpm
+  - evra: 21.1.8-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-libs-21.1.8-2.el9.aarch64.rpm
+  - evra: 21.1.8-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-resource-filesystem-21.1.8-2.el9.aarch64.rpm
+  - evra: 21.1.8-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-tools-extra-21.1.8-2.el9.aarch64.rpm
+  - evra: 3.31.8-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-3.31.8-3.el9.aarch64.rpm
+  - evra: 3.31.8-3.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-data-3.31.8-3.el9.noarch.rpm
+  - evra: 3.31.8-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-filesystem-3.31.8-3.el9.aarch64.rpm
+  - evra: 3.31.8-3.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-rpm-macros-3.31.8-3.el9.noarch.rpm
+  - evra: 8.32-41.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.aarch64.rpm
+  - evra: 8.32-41.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.aarch64.rpm
+  - evra: 8.32-41.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-single-8.32-41.el9_8.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cpp-11.5.0-14.el9.aarch64.rpm
+  - evra: 2.9.6-28.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cracklib-2.9.6-28.el9.aarch64.rpm
+  - evra: 2.9.6-28.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cracklib-dicts-2.9.6-28.el9.aarch64.rpm
+  - evra: 20260224-1.gitea0f072.el9_8.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/crypto-policies-20260224-1.gitea0f072.el9_8.noarch.rpm
+  - evra: 2.8.1-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cryptsetup-libs-2.8.1-3.el9.aarch64.rpm
+  - evra: 7.76.1-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/curl-7.76.1-40.el9.aarch64.rpm
+  - evra: 7.76.1-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/curl-minimal-7.76.1-40.el9.aarch64.rpm
+  - evra: 2.1.27-22.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-22.el9.aarch64.rpm
+  - evra: 1.12.20-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-1.12.20-8.el9.aarch64.rpm
+  - evra: 28-7.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-broker-28-7.el9.aarch64.rpm
+  - evra: 1.12.20-8.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
+  - evra: 1.02.207-4.el9_8.1.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/device-mapper-1.02.207-4.el9_8.1.aarch64.rpm
+  - evra: 1.02.207-4.el9_8.1.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/device-mapper-libs-1.02.207-4.el9_8.1.aarch64.rpm
+  - evra: 3.7-12.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/diffutils-3.7-12.el9.aarch64.rpm
+  - evra: 0.194-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.aarch64.rpm
+  - evra: 0.194-1.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-default-yama-scope-0.194-1.el9.noarch.rpm
+  - evra: 0.194-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.aarch64.rpm
+  - evra: 0.194-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.aarch64.rpm
+  - evra: 27.2-18.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
+  - evra: 5.3.0-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/environment-modules-5.3.0-2.el9.aarch64.rpm
+  - evra: 2.5.0-6.el9_8.1.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/expat-2.5.0-6.el9_8.1.aarch64.rpm
+  - evra: 3.16-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/filesystem-3.16-5.el9.aarch64.rpm
+  - evra: 4.8.0-7.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/findutils-4.8.0-7.el9.aarch64.rpm
+  - evra: 1.2.0-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fips-provider-next-1.2.0-5.el9.aarch64.rpm
+  - evra: 5.1.0-6.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gawk-5.1.0-6.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-11.5.0-14.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-c++-11.5.0-14.el9.aarch64.rpm
+  - evra: 12.88-1.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-annobin-docs-12.88-1.el9.noarch.rpm
+  - evra: 12.88-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-annobin-plugin-gcc-12.88-1.el9.aarch64.rpm
+  - evra: 2.41-6.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-binutils-2.41-6.el9.aarch64.rpm
+  - evra: 0.14-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-dwz-0.14-1.el9.aarch64.rpm
+  - evra: 14.2.1-13.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-gcc-14.2.1-13.el9.aarch64.rpm
+  - evra: 14.2.1-13.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-gcc-c++-14.2.1-13.el9.aarch64.rpm
+  - evra: 14.2.1-13.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-gcc-gfortran-14.2.1-13.el9.aarch64.rpm
+  - evra: 14.2.1-13.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-libstdc++-devel-14.2.1-13.el9.aarch64.rpm
+  - evra: 14.0-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-runtime-14.0-2.el9.aarch64.rpm
+  - evra: 2.44-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-binutils-2.44-5.el9.aarch64.rpm
+  - evra: 15.2.1-7.1.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-gcc-15.2.1-7.1.el9_8.aarch64.rpm
+  - evra: 15.2.1-7.1.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-gcc-c++-15.2.1-7.1.el9_8.aarch64.rpm
+  - evra: 15.2.1-7.1.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-libstdc++-devel-15.2.1-7.1.el9_8.aarch64.rpm
+  - evra: 15.0-9.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-runtime-15.0-9.el9.aarch64.rpm
+  - evra: 1.23-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-2.34-274.el9_8.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-all-langpacks-2.34-274.el9_8.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-common-2.34-274.el9_8.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/glibc-devel-2.34-274.el9_8.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-gconv-extra-2.34-274.el9_8.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-langpack-en-2.34-274.el9_8.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-274.el9_8.aarch64.rpm
+  - evra: 6.2.0-13.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gmp-6.2.0-13.el9.aarch64.rpm
+  - evra: 3.6-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/grep-3.6-5.el9.aarch64.rpm
+  - evra: 1.22.4-10.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.aarch64.rpm
+  - evra: 1.12-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gzip-1.12-1.el9.aarch64.rpm
+  - evra: 6.7-15.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/i/info-6.7-15.el9.aarch64.rpm
+  - evra: 2.14-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/j/jansson-2.14-1.el9.aarch64.rpm
+  - evra: 0.14-11.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/j/json-c-0.14-11.el9.aarch64.rpm
+  - evra: 2.4.0-11.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kbd-2.4.0-11.el9.aarch64.rpm
+  - evra: 2.4.0-11.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kbd-legacy-2.4.0-11.el9.noarch.rpm
+  - evra: 2.4.0-11.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kbd-misc-2.4.0-11.el9.noarch.rpm
+  - evra: 5.14.0-687.31.1.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.31.1.el9_8.aarch64.rpm
+  - evra: 1.6.3-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/keyutils-libs-1.6.3-1.el9.aarch64.rpm
+  - evra: 28-11.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kmod-28-11.el9.aarch64.rpm
+  - evra: 28-11.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kmod-libs-28-11.el9.aarch64.rpm
+  - evra: 1.21.1-10.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/krb5-libs-1.21.1-10.el9_8.aarch64.rpm
+  - evra: 590-6.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/less-590-6.el9.aarch64.rpm
+  - evra: 2.4.0-1.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libacl-2.4.0-1.el9_8.aarch64.rpm
+  - evra: 3.5.3-9.el9_7.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libarchive-3.5.3-9.el9_7.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libasan-11.5.0-14.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libatomic-11.5.0-14.el9.aarch64.rpm
+  - evra: 2.5.1-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libattr-2.5.1-3.el9.aarch64.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libblkid-2.37.4-25.el9.aarch64.rpm
+  - evra: 1.0.9-9.el9_7.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libbrotli-1.0.9-9.el9_7.aarch64.rpm
+  - evra: 2.48-10.el9_8.1.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcap-2.48-10.el9_8.1.aarch64.rpm
+  - evra: 0.8.2-7.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcap-ng-0.8.2-7.el9.aarch64.rpm
+  - evra: 0.7.0-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.aarch64.rpm
+  - evra: 1.46.5-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcom_err-1.46.5-8.el9.aarch64.rpm
+  - evra: 7.76.1-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcurl-7.76.1-40.el9.aarch64.rpm
+  - evra: 7.76.1-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcurl-minimal-7.76.1-40.el9.aarch64.rpm
+  - evra: 5.3.28-57.el9_6.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.aarch64.rpm
+  - evra: 0.4.1-7.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libeconf-0.4.1-7.el9_8.aarch64.rpm
+  - evra: 3.1-39.20210216cvs.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.aarch64.rpm
+  - evra: 3.1-39.20210216cvs.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libedit-devel-3.1-39.20210216cvs.el9.aarch64.rpm
+  - evra: 2.1.12-8.el9_4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libevent-2.1.12-8.el9_4.aarch64.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libfdisk-2.37.4-25.el9.aarch64.rpm
+  - evra: 3.4.2-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libffi-3.4.2-8.el9.aarch64.rpm
+  - evra: 1.13.0-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgcc-11.5.0-14.el9.aarch64.rpm
+  - evra: 1.10.0-11.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgfortran-11.5.0-14.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.aarch64.rpm
+  - evra: 1.42-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgpg-error-1.42-5.el9.aarch64.rpm
+  - evra: 2.3.0-7.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libidn2-2.3.0-7.el9.aarch64.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libmount-2.37.4-25.el9.aarch64.rpm
+  - evra: 1.2.1-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.aarch64.rpm
+  - evra: 1.43.0-6.el9_8.1.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9_8.1.aarch64.rpm
+  - evra: 1.5.3-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.aarch64.rpm
+  - evra: 1.7.3-10.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.aarch64.rpm
+  - evra: 0.21.1-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpsl-0.21.1-5.el9.aarch64.rpm
+  - evra: 1.4.4-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.aarch64.rpm
+  - evra: 2.5.2-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.aarch64.rpm
+  - evra: 3.6-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libselinux-3.6-3.el9.aarch64.rpm
+  - evra: 3.6-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.aarch64.rpm
+  - evra: 3.6-5.el9_6.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.aarch64.rpm
+  - evra: 3.6-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsepol-3.6-3.el9.aarch64.rpm
+  - evra: 2.13-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsigsegv-2.13-4.el9.aarch64.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsmartcols-2.37.4-25.el9.aarch64.rpm
+  - evra: 0.10.4-18.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libssh-0.10.4-18.el9.aarch64.rpm
+  - evra: 0.10.4-18.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libssh-config-0.10.4-18.el9.noarch.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libstdc++-11.5.0-14.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libstdc++-devel-11.5.0-14.el9.aarch64.rpm
+  - evra: 4.16.0-10.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libtasn1-4.16.0-10.el9_8.aarch64.rpm
+  - evra: 2.4.6-46.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libtool-ltdl-2.4.6-46.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libubsan-11.5.0-14.el9.aarch64.rpm
+  - evra: 0.9.10-15.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libunistring-0.9.10-15.el9.aarch64.rpm
+  - evra: 1.2.1-6.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.aarch64.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libuuid-2.37.4-25.el9.aarch64.rpm
+  - evra: 1.42.0-2.el9_4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.aarch64.rpm
+  - evra: 0.3.2-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libverto-0.3.2-3.el9.aarch64.rpm
+  - evra: 4.4.18-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libxcrypt-4.4.18-3.el9.aarch64.rpm
+  - evra: 4.4.18-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.aarch64.rpm
+  - evra: 2.9.13-14.el9_8.2.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libxml2-2.9.13-14.el9_8.2.aarch64.rpm
+  - evra: 1.5.5-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libzstd-1.5.5-1.el9.aarch64.rpm
+  - evra: 1.5.5-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libzstd-devel-1.5.5-1.el9.aarch64.rpm
+  - evra: 21.1.8-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-21.1.8-2.el9.aarch64.rpm
+  - evra: 21.1.8-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-devel-21.1.8-2.el9.aarch64.rpm
+  - evra: 21.1.8-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-filesystem-21.1.8-2.el9.aarch64.rpm
+  - evra: 21.1.8-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-googletest-21.1.8-2.el9.aarch64.rpm
+  - evra: 21.1.8-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-libs-21.1.8-2.el9.aarch64.rpm
+  - evra: 21.1.8-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-static-21.1.8-2.el9.aarch64.rpm
+  - evra: 21.1.8-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-test-21.1.8-2.el9.aarch64.rpm
+  - evra: 5.4.4-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/lua-libs-5.4.4-4.el9.aarch64.rpm
+  - evra: 1.9.3-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/lz4-libs-1.9.3-5.el9.aarch64.rpm
+  - evra: 4.3-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/make-4.3-8.el9.aarch64.rpm
+  - evra: 2.9.3-9.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/man-db-2.9.3-9.el9.aarch64.rpm
+  - evra: 4.1.0-10.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/mpfr-4.1.0-10.el9.aarch64.rpm
+  - evra: 6.2-12.20210508.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/ncurses-base-6.2-12.20210508.el9.noarch.rpm
+  - evra: 6.2-12.20210508.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/n/ncurses-c++-libs-6.2-12.20210508.el9.aarch64.rpm
+  - evra: 6.2-12.20210508.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/n/ncurses-devel-6.2-12.20210508.el9.aarch64.rpm
+  - evra: 6.2-12.20210508.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/ncurses-libs-6.2-12.20210508.el9.aarch64.rpm
+  - evra: 2.6.8-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openldap-2.6.8-4.el9.aarch64.rpm
+  - evra: 9.9p1-7.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-9.9p1-7.el9_8.aarch64.rpm
+  - evra: 9.9p1-7.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-clients-9.9p1-7.el9_8.aarch64.rpm
+  - evra: 3.5.5-6.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-3.5.5-6.el9_8.aarch64.rpm
+  - evra: 3.5.5-6.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/openssl-devel-3.5.5-6.el9_8.aarch64.rpm
+  - evra: 3.0.7-11.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_8.aarch64.rpm
+  - evra: 3.0.7-11.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_8.aarch64.rpm
+  - evra: 3.5.5-6.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-libs-3.5.5-6.el9_8.aarch64.rpm
+  - evra: 0.26.2-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/p11-kit-0.26.2-1.el9.aarch64.rpm
+  - evra: 0.26.2-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/p11-kit-trust-0.26.2-1.el9.aarch64.rpm
+  - evra: 1.5.1-28.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pam-1.5.1-28.el9.aarch64.rpm
+  - evra: 8.44-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pcre-8.44-4.el9.aarch64.rpm
+  - evra: 10.40-6.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pcre2-10.40-6.el9.aarch64.rpm
+  - evra: 10.40-6.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pcre2-syntax-10.40-6.el9.noarch.rpm
+  - evra: 1.7.3-10.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.aarch64.rpm
+  - evra: 1.7.3-10.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+  - evra: 1.7.3-10.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.aarch64.rpm
+  - evra: 3.6-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/policycoreutils-3.6-5.el9.aarch64.rpm
+  - evra: 3.6-5.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/policycoreutils-python-utils-3.6-5.el9.noarch.rpm
+  - evra: 1.18-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/popt-1.18-8.el9.aarch64.rpm
+  - evra: 3.3.17-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.aarch64.rpm
+  - evra: 20210518-3.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/publicsuffix-list-dafsa-20210518-3.el9.noarch.rpm
+  - evra: 3.9.25-7.el9_8.2.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-3.9.25-7.el9_8.2.aarch64.rpm
+  - evra: 3.1.5-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-audit-3.1.5-8.el9.aarch64.rpm
+  - evra: 1.5.0-7.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-distro-1.5.0-7.el9.noarch.rpm
+  - evra: 3.9.25-7.el9_8.2.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-libs-3.9.25-7.el9_8.2.aarch64.rpm
+  - evra: 3.6-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-libselinux-3.6-3.el9.aarch64.rpm
+  - evra: 3.6-5.el9_6.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-libsemanage-3.6-5.el9_6.aarch64.rpm
+  - evra: 21.3.1-2.el9_8.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-2.el9_8.noarch.rpm
+  - evra: 3.6-5.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-policycoreutils-3.6-5.el9.noarch.rpm
+  - evra: 4.4.4-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setools-4.4.4-1.el9.aarch64.rpm
+  - evra: 53.0.0-15.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setuptools-53.0.0-15.el9.noarch.rpm
+  - evra: 53.0.0-15.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-15.el9.noarch.rpm
+  - evra: 8.1-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/readline-8.1-4.el9.aarch64.rpm
+  - evra: 9.8-1.0.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/redhat-release-9.8-1.0.el9.aarch64.rpm
+  - evra: 4.16.1.3-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/rpm-4.16.1.3-40.el9.aarch64.rpm
+  - evra: 4.16.1.3-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/rpm-libs-4.16.1.3-40.el9.aarch64.rpm
+  - evra: 1.92.0-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/r/rust-1.92.0-1.el9.aarch64.rpm
+  - evra: 1.92.0-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/r/rust-std-static-1.92.0-1.el9.aarch64.rpm
+  - evra: 2.0.3-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.aarch64.rpm
+  - evra: 4.8-10.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/sed-4.8-10.el9.aarch64.rpm
+  - evra: 2.13.7-10.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/setup-2.13.7-10.el9.noarch.rpm
+  - evra: 4.9-16.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/shadow-utils-4.9-16.el9.aarch64.rpm
+  - evra: 3.34.1-10.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.aarch64.rpm
+  - evra: 252-67.el9_8.4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-252-67.el9_8.4.aarch64.rpm
+  - evra: 252-67.el9_8.4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-libs-252-67.el9_8.4.aarch64.rpm
+  - evra: 252-67.el9_8.4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-pam-252-67.el9_8.4.aarch64.rpm
+  - evra: 252-67.el9_8.4.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-rpm-macros-252-67.el9_8.4.noarch.rpm
+  - evra: 252-67.el9_8.4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-udev-252-67.el9_8.4.aarch64.rpm
+  - evra: 8.6.10-7.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tcl-8.6.10-7.el9.aarch64.rpm
+  - evra: 3.2.3-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.aarch64.rpm
+  - evra: 2026b-1.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tzdata-2026b-1.el9.noarch.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/util-linux-2.37.4-25.el9.aarch64.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/util-linux-core-2.37.4-25.el9.aarch64.rpm
+  - evra: 8.2.2637-26.el9_8.10.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.10.noarch.rpm
+  - evra: 5.2.5-8.el9_0.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.aarch64.rpm
+  - evra: 1.2.11-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/z/zlib-1.2.11-40.el9.aarch64.rpm
+  - evra: 1.92.0-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cargo-1.92.0-1.el9.aarch64.rpm
+  - evra: 21.1.8-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-devel-21.1.8-2.el9.aarch64.rpm
+  - evra: 14.0-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-14.0-2.el9.aarch64.rpm
+  - evra: 2.52.0-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-core-2.52.0-1.el9.aarch64.rpm
+  source: []
+lockfileVendor: redhat
+lockfileVersion: 1

--- a/deploy/konflux/gateway/rpms.lock.yaml
+++ b/deploy/konflux/gateway/rpms.lock.yaml
@@ -1,893 +1,1531 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
 arches:
-- arch: x86_64
-  packages:
-  - evra: 2.4.0-1.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/acl-2.4.0-1.el9_8.x86_64.rpm
-  - evra: 1.24-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/alternatives-1.24-2.el9.x86_64.rpm
-  - evra: 3.1.5-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/audit-libs-3.1.5-8.el9.x86_64.rpm
-  - evra: 11-13.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/basesystem-11-13.el9.noarch.rpm
-  - evra: 5.1.8-9.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/bash-5.1.8-9.el9.x86_64.rpm
-  - evra: 2.35.2-72.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-72.el9.x86_64.rpm
-  - evra: 2.35.2-72.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.x86_64.rpm
-  - evra: 1.0.8-11.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/bzip2-libs-1.0.8-11.el9.x86_64.rpm
-  - evra: 2025.2.80_v9.0.305-91.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.noarch.rpm
-  - evra: 3.6-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/checkpolicy-3.6-1.el9.x86_64.rpm
-  - evra: 21.1.8-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-21.1.8-2.el9.x86_64.rpm
-  - evra: 21.1.8-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-libs-21.1.8-2.el9.x86_64.rpm
-  - evra: 21.1.8-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-resource-filesystem-21.1.8-2.el9.x86_64.rpm
-  - evra: 21.1.8-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-tools-extra-21.1.8-2.el9.x86_64.rpm
-  - evra: 3.31.8-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-3.31.8-3.el9.x86_64.rpm
-  - evra: 3.31.8-3.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-data-3.31.8-3.el9.noarch.rpm
-  - evra: 3.31.8-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-filesystem-3.31.8-3.el9.x86_64.rpm
-  - evra: 3.31.8-3.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-rpm-macros-3.31.8-3.el9.noarch.rpm
-  - evra: 8.32-41.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.x86_64.rpm
-  - evra: 8.32-41.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.x86_64.rpm
-  - evra: 8.32-41.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-single-8.32-41.el9_8.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cpp-11.5.0-14.el9.x86_64.rpm
-  - evra: 2.9.6-28.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cracklib-2.9.6-28.el9.x86_64.rpm
-  - evra: 2.9.6-28.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-28.el9.x86_64.rpm
-  - evra: 20260224-1.gitea0f072.el9_8.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/crypto-policies-20260224-1.gitea0f072.el9_8.noarch.rpm
-  - evra: 2.8.1-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cryptsetup-libs-2.8.1-3.el9.x86_64.rpm
-  - evra: 7.76.1-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/curl-7.76.1-40.el9.x86_64.rpm
-  - evra: 7.76.1-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/curl-minimal-7.76.1-40.el9.x86_64.rpm
-  - evra: 2.1.27-22.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-22.el9.x86_64.rpm
-  - evra: 1.12.20-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-1.12.20-8.el9.x86_64.rpm
-  - evra: 28-7.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-broker-28-7.el9.x86_64.rpm
-  - evra: 1.12.20-8.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
-  - evra: 1.02.207-4.el9_8.1.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/device-mapper-1.02.207-4.el9_8.1.x86_64.rpm
-  - evra: 1.02.207-4.el9_8.1.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/device-mapper-libs-1.02.207-4.el9_8.1.x86_64.rpm
-  - evra: 3.7-12.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/diffutils-3.7-12.el9.x86_64.rpm
-  - evra: 0.194-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.x86_64.rpm
-  - evra: 0.194-1.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-default-yama-scope-0.194-1.el9.noarch.rpm
-  - evra: 0.194-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.x86_64.rpm
-  - evra: 0.194-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.x86_64.rpm
-  - evra: 27.2-18.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
-  - evra: 5.3.0-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/environment-modules-5.3.0-2.el9.x86_64.rpm
-  - evra: 2.5.0-6.el9_8.1.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/expat-2.5.0-6.el9_8.1.x86_64.rpm
-  - evra: 3.16-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/filesystem-3.16-5.el9.x86_64.rpm
-  - evra: 4.8.0-7.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/findutils-4.8.0-7.el9.x86_64.rpm
-  - evra: 1.2.0-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fips-provider-next-1.2.0-5.el9.x86_64.rpm
-  - evra: 5.1.0-6.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gawk-5.1.0-6.el9.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-11.5.0-14.el9.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-c++-11.5.0-14.el9.x86_64.rpm
-  - evra: 12.88-1.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-annobin-docs-12.88-1.el9.noarch.rpm
-  - evra: 12.88-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-annobin-plugin-gcc-12.88-1.el9.x86_64.rpm
-  - evra: 2.41-6.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-binutils-2.41-6.el9.x86_64.rpm
-  - evra: 0.14-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-dwz-0.14-1.el9.x86_64.rpm
-  - evra: 14.2.1-13.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-gcc-14.2.1-13.el9.x86_64.rpm
-  - evra: 14.2.1-13.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-gcc-c++-14.2.1-13.el9.x86_64.rpm
-  - evra: 14.2.1-13.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-gcc-gfortran-14.2.1-13.el9.x86_64.rpm
-  - evra: 14.2.1-13.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-libquadmath-devel-14.2.1-13.el9.x86_64.rpm
-  - evra: 14.2.1-13.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-libstdc++-devel-14.2.1-13.el9.x86_64.rpm
-  - evra: 14.0-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-runtime-14.0-2.el9.x86_64.rpm
-  - evra: 2.44-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-binutils-2.44-5.el9.x86_64.rpm
-  - evra: 15.2.1-7.1.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-gcc-15.2.1-7.1.el9_8.x86_64.rpm
-  - evra: 15.2.1-7.1.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-gcc-c++-15.2.1-7.1.el9_8.x86_64.rpm
-  - evra: 15.2.1-7.1.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-libstdc++-devel-15.2.1-7.1.el9_8.x86_64.rpm
-  - evra: 15.0-9.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-runtime-15.0-9.el9.x86_64.rpm
-  - evra: 1.23-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-all-langpacks-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-common-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-langpack-en-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-274.el9_8.x86_64.rpm
-  - evra: 6.2.0-13.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gmp-6.2.0-13.el9.x86_64.rpm
-  - evra: 3.6-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/grep-3.6-5.el9.x86_64.rpm
-  - evra: 1.22.4-10.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.x86_64.rpm
-  - evra: 1.12-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
-  - evra: 6.7-15.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/i/info-6.7-15.el9.x86_64.rpm
-  - evra: 2.14-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/j/jansson-2.14-1.el9.x86_64.rpm
-  - evra: 0.14-11.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/j/json-c-0.14-11.el9.x86_64.rpm
-  - evra: 2.4.0-11.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kbd-2.4.0-11.el9.x86_64.rpm
-  - evra: 2.4.0-11.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kbd-legacy-2.4.0-11.el9.noarch.rpm
-  - evra: 2.4.0-11.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kbd-misc-2.4.0-11.el9.noarch.rpm
-  - evra: 5.14.0-687.30.1.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.30.1.el9_8.x86_64.rpm
-  - evra: 1.6.3-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/keyutils-libs-1.6.3-1.el9.x86_64.rpm
-  - evra: 28-11.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kmod-28-11.el9.x86_64.rpm
-  - evra: 28-11.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kmod-libs-28-11.el9.x86_64.rpm
-  - evra: 1.21.1-10.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/krb5-libs-1.21.1-10.el9_8.x86_64.rpm
-  - evra: 590-6.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/less-590-6.el9.x86_64.rpm
-  - evra: 2.4.0-1.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libacl-2.4.0-1.el9_8.x86_64.rpm
-  - evra: 3.5.3-9.el9_7.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libarchive-3.5.3-9.el9_7.x86_64.rpm
-  - evra: 2.5.1-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libattr-2.5.1-3.el9.x86_64.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libblkid-2.37.4-25.el9.x86_64.rpm
-  - evra: 1.0.9-9.el9_7.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libbrotli-1.0.9-9.el9_7.x86_64.rpm
-  - evra: 2.48-10.el9_8.1.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcap-2.48-10.el9_8.1.x86_64.rpm
-  - evra: 0.8.2-7.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcap-ng-0.8.2-7.el9.x86_64.rpm
-  - evra: 0.7.0-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.x86_64.rpm
-  - evra: 1.46.5-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcom_err-1.46.5-8.el9.x86_64.rpm
-  - evra: 7.76.1-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcurl-7.76.1-40.el9.x86_64.rpm
-  - evra: 7.76.1-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcurl-minimal-7.76.1-40.el9.x86_64.rpm
-  - evra: 5.3.28-57.el9_6.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.x86_64.rpm
-  - evra: 0.4.1-7.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libeconf-0.4.1-7.el9_8.x86_64.rpm
-  - evra: 3.1-39.20210216cvs.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.x86_64.rpm
-  - evra: 3.1-39.20210216cvs.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libedit-devel-3.1-39.20210216cvs.el9.x86_64.rpm
-  - evra: 2.1.12-8.el9_4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libevent-2.1.12-8.el9_4.x86_64.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfdisk-2.37.4-25.el9.x86_64.rpm
-  - evra: 3.4.2-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libffi-3.4.2-8.el9.x86_64.rpm
-  - evra: 1.13.0-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgcc-11.5.0-14.el9.x86_64.rpm
-  - evra: 1.10.0-11.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgfortran-11.5.0-14.el9.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.x86_64.rpm
-  - evra: 1.42-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgpg-error-1.42-5.el9.x86_64.rpm
-  - evra: 2.3.0-7.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libidn2-2.3.0-7.el9.x86_64.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libmount-2.37.4-25.el9.x86_64.rpm
-  - evra: 1.2.1-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
-  - evra: 1.43.0-6.el9_8.1.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9_8.1.x86_64.rpm
-  - evra: 1.5.3-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.x86_64.rpm
-  - evra: 1.7.3-10.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
-  - evra: 0.21.1-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpsl-0.21.1-5.el9.x86_64.rpm
-  - evra: 1.4.4-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libquadmath-11.5.0-14.el9.x86_64.rpm
-  - evra: 2.5.2-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
-  - evra: 3.6-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libselinux-3.6-3.el9.x86_64.rpm
-  - evra: 3.6-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.x86_64.rpm
-  - evra: 3.6-5.el9_6.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.x86_64.rpm
-  - evra: 3.6-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsepol-3.6-3.el9.x86_64.rpm
-  - evra: 2.13-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsigsegv-2.13-4.el9.x86_64.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsmartcols-2.37.4-25.el9.x86_64.rpm
-  - evra: 0.10.4-18.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libssh-0.10.4-18.el9.x86_64.rpm
-  - evra: 0.10.4-18.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libssh-config-0.10.4-18.el9.noarch.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libstdc++-11.5.0-14.el9.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libstdc++-devel-11.5.0-14.el9.x86_64.rpm
-  - evra: 4.16.0-10.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libtasn1-4.16.0-10.el9_8.x86_64.rpm
-  - evra: 2.4.6-46.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libtool-ltdl-2.4.6-46.el9.x86_64.rpm
-  - evra: 0.9.10-15.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libunistring-0.9.10-15.el9.x86_64.rpm
-  - evra: 1.2.1-6.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.x86_64.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libuuid-2.37.4-25.el9.x86_64.rpm
-  - evra: 1.42.0-2.el9_4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.x86_64.rpm
-  - evra: 0.3.2-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libverto-0.3.2-3.el9.x86_64.rpm
-  - evra: 4.4.18-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libxcrypt-4.4.18-3.el9.x86_64.rpm
-  - evra: 4.4.18-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.x86_64.rpm
-  - evra: 2.9.13-14.el9_8.2.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libxml2-2.9.13-14.el9_8.2.x86_64.rpm
-  - evra: 1.5.5-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libzstd-1.5.5-1.el9.x86_64.rpm
-  - evra: 1.5.5-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libzstd-devel-1.5.5-1.el9.x86_64.rpm
-  - evra: 21.1.8-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-21.1.8-2.el9.x86_64.rpm
-  - evra: 21.1.8-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-devel-21.1.8-2.el9.x86_64.rpm
-  - evra: 21.1.8-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-filesystem-21.1.8-2.el9.x86_64.rpm
-  - evra: 21.1.8-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-googletest-21.1.8-2.el9.x86_64.rpm
-  - evra: 21.1.8-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-libs-21.1.8-2.el9.x86_64.rpm
-  - evra: 21.1.8-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-static-21.1.8-2.el9.x86_64.rpm
-  - evra: 21.1.8-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-test-21.1.8-2.el9.x86_64.rpm
-  - evra: 5.4.4-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/lua-libs-5.4.4-4.el9.x86_64.rpm
-  - evra: 1.9.3-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/lz4-libs-1.9.3-5.el9.x86_64.rpm
-  - evra: 4.3-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
-  - evra: 2.9.3-9.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/man-db-2.9.3-9.el9.x86_64.rpm
-  - evra: 4.1.0-10.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/mpfr-4.1.0-10.el9.x86_64.rpm
-  - evra: 6.2-12.20210508.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-base-6.2-12.20210508.el9.noarch.rpm
-  - evra: 6.2-12.20210508.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/ncurses-c++-libs-6.2-12.20210508.el9.x86_64.rpm
-  - evra: 6.2-12.20210508.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/ncurses-devel-6.2-12.20210508.el9.x86_64.rpm
-  - evra: 6.2-12.20210508.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-libs-6.2-12.20210508.el9.x86_64.rpm
-  - evra: 2.6.8-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openldap-2.6.8-4.el9.x86_64.rpm
-  - evra: 9.9p1-7.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-9.9p1-7.el9_8.x86_64.rpm
-  - evra: 9.9p1-7.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-clients-9.9p1-7.el9_8.x86_64.rpm
-  - evra: 3.5.5-5.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.5.5-5.el9_8.x86_64.rpm
-  - evra: 3.5.5-5.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/openssl-devel-3.5.5-5.el9_8.x86_64.rpm
-  - evra: 3.0.7-11.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_8.x86_64.rpm
-  - evra: 3.0.7-11.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_8.x86_64.rpm
-  - evra: 3.5.5-5.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-libs-3.5.5-5.el9_8.x86_64.rpm
-  - evra: 0.26.2-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/p11-kit-0.26.2-1.el9.x86_64.rpm
-  - evra: 0.26.2-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/p11-kit-trust-0.26.2-1.el9.x86_64.rpm
-  - evra: 1.5.1-28.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pam-1.5.1-28.el9.x86_64.rpm
-  - evra: 8.44-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pcre-8.44-4.el9.x86_64.rpm
-  - evra: 10.40-6.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pcre2-10.40-6.el9.x86_64.rpm
-  - evra: 10.40-6.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pcre2-syntax-10.40-6.el9.noarch.rpm
-  - evra: 1.7.3-10.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
-  - evra: 1.7.3-10.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
-  - evra: 1.7.3-10.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
-  - evra: 3.6-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/policycoreutils-3.6-5.el9.x86_64.rpm
-  - evra: 3.6-5.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/policycoreutils-python-utils-3.6-5.el9.noarch.rpm
-  - evra: 1.18-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/popt-1.18-8.el9.x86_64.rpm
-  - evra: 3.3.17-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.x86_64.rpm
-  - evra: 20210518-3.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/publicsuffix-list-dafsa-20210518-3.el9.noarch.rpm
-  - evra: 3.9.25-7.el9_8.2.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-3.9.25-7.el9_8.2.x86_64.rpm
-  - evra: 3.1.5-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-audit-3.1.5-8.el9.x86_64.rpm
-  - evra: 1.5.0-7.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-distro-1.5.0-7.el9.noarch.rpm
-  - evra: 3.9.25-7.el9_8.2.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-libs-3.9.25-7.el9_8.2.x86_64.rpm
-  - evra: 3.6-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-libselinux-3.6-3.el9.x86_64.rpm
-  - evra: 3.6-5.el9_6.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-libsemanage-3.6-5.el9_6.x86_64.rpm
-  - evra: 21.3.1-2.el9_8.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-2.el9_8.noarch.rpm
-  - evra: 3.6-5.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-policycoreutils-3.6-5.el9.noarch.rpm
-  - evra: 4.4.4-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setools-4.4.4-1.el9.x86_64.rpm
-  - evra: 53.0.0-15.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setuptools-53.0.0-15.el9.noarch.rpm
-  - evra: 53.0.0-15.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-15.el9.noarch.rpm
-  - evra: 8.1-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/readline-8.1-4.el9.x86_64.rpm
-  - evra: 9.8-1.0.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/redhat-release-9.8-1.0.el9.x86_64.rpm
-  - evra: 4.16.1.3-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rpm-4.16.1.3-40.el9.x86_64.rpm
-  - evra: 4.16.1.3-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rpm-libs-4.16.1.3-40.el9.x86_64.rpm
-  - evra: 1.92.0-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-1.92.0-1.el9.x86_64.rpm
-  - evra: 1.92.0-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-std-static-1.92.0-1.el9.x86_64.rpm
-  - evra: 2.0.3-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.x86_64.rpm
-  - evra: 4.8-10.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/sed-4.8-10.el9.x86_64.rpm
-  - evra: 2.13.7-10.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/setup-2.13.7-10.el9.noarch.rpm
-  - evra: 4.9-16.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/shadow-utils-4.9-16.el9.x86_64.rpm
-  - evra: 3.34.1-10.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.x86_64.rpm
-  - evra: 252-67.el9_8.4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-252-67.el9_8.4.x86_64.rpm
-  - evra: 252-67.el9_8.4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-libs-252-67.el9_8.4.x86_64.rpm
-  - evra: 252-67.el9_8.4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-pam-252-67.el9_8.4.x86_64.rpm
-  - evra: 252-67.el9_8.4.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-67.el9_8.4.noarch.rpm
-  - evra: 252-67.el9_8.4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-udev-252-67.el9_8.4.x86_64.rpm
-  - evra: 8.6.10-7.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tcl-8.6.10-7.el9.x86_64.rpm
-  - evra: 3.2.3-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.x86_64.rpm
-  - evra: 2026b-1.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tzdata-2026b-1.el9.noarch.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/util-linux-2.37.4-25.el9.x86_64.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/util-linux-core-2.37.4-25.el9.x86_64.rpm
-  - evra: 8.2.2637-26.el9_8.10.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.10.noarch.rpm
-  - evra: 5.2.5-8.el9_0.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.x86_64.rpm
-  - evra: 1.2.11-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/z/zlib-1.2.11-40.el9.x86_64.rpm
-  - evra: 1.92.0-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cargo-1.92.0-1.el9.x86_64.rpm
-  - evra: 21.1.8-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-devel-21.1.8-2.el9.x86_64.rpm
-  - evra: 14.0-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-14.0-2.el9.x86_64.rpm
-  - evra: 2.52.0-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-2.52.0-1.el9.x86_64.rpm
-  source: []
 - arch: aarch64
   packages:
-  - evra: 2.4.0-1.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/acl-2.4.0-1.el9_8.aarch64.rpm
-  - evra: 1.24-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/alternatives-1.24-2.el9.aarch64.rpm
-  - evra: 3.1.5-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/audit-libs-3.1.5-8.el9.aarch64.rpm
-  - evra: 11-13.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/basesystem-11-13.el9.noarch.rpm
-  - evra: 5.1.8-9.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/bash-5.1.8-9.el9.aarch64.rpm
-  - evra: 2.35.2-72.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-2.35.2-72.el9.aarch64.rpm
-  - evra: 2.35.2-72.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.aarch64.rpm
-  - evra: 1.0.8-11.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/bzip2-libs-1.0.8-11.el9.aarch64.rpm
-  - evra: 2025.2.80_v9.0.305-91.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.noarch.rpm
-  - evra: 3.6-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/checkpolicy-3.6-1.el9.aarch64.rpm
-  - evra: 21.1.8-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-21.1.8-2.el9.aarch64.rpm
-  - evra: 21.1.8-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-libs-21.1.8-2.el9.aarch64.rpm
-  - evra: 21.1.8-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-resource-filesystem-21.1.8-2.el9.aarch64.rpm
-  - evra: 21.1.8-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-tools-extra-21.1.8-2.el9.aarch64.rpm
-  - evra: 3.31.8-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-3.31.8-3.el9.aarch64.rpm
-  - evra: 3.31.8-3.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-data-3.31.8-3.el9.noarch.rpm
-  - evra: 3.31.8-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-filesystem-3.31.8-3.el9.aarch64.rpm
-  - evra: 3.31.8-3.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-rpm-macros-3.31.8-3.el9.noarch.rpm
-  - evra: 8.32-41.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.aarch64.rpm
-  - evra: 8.32-41.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.aarch64.rpm
-  - evra: 8.32-41.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-single-8.32-41.el9_8.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cpp-11.5.0-14.el9.aarch64.rpm
-  - evra: 2.9.6-28.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cracklib-2.9.6-28.el9.aarch64.rpm
-  - evra: 2.9.6-28.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cracklib-dicts-2.9.6-28.el9.aarch64.rpm
-  - evra: 20260224-1.gitea0f072.el9_8.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/crypto-policies-20260224-1.gitea0f072.el9_8.noarch.rpm
-  - evra: 2.8.1-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cryptsetup-libs-2.8.1-3.el9.aarch64.rpm
-  - evra: 7.76.1-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/curl-7.76.1-40.el9.aarch64.rpm
-  - evra: 7.76.1-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/curl-minimal-7.76.1-40.el9.aarch64.rpm
-  - evra: 2.1.27-22.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-22.el9.aarch64.rpm
-  - evra: 1.12.20-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-1.12.20-8.el9.aarch64.rpm
-  - evra: 28-7.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-broker-28-7.el9.aarch64.rpm
-  - evra: 1.12.20-8.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
-  - evra: 1.02.207-4.el9_8.1.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/device-mapper-1.02.207-4.el9_8.1.aarch64.rpm
-  - evra: 1.02.207-4.el9_8.1.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/device-mapper-libs-1.02.207-4.el9_8.1.aarch64.rpm
-  - evra: 3.7-12.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/diffutils-3.7-12.el9.aarch64.rpm
-  - evra: 0.194-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.aarch64.rpm
-  - evra: 0.194-1.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-default-yama-scope-0.194-1.el9.noarch.rpm
-  - evra: 0.194-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.aarch64.rpm
-  - evra: 0.194-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.aarch64.rpm
-  - evra: 27.2-18.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
-  - evra: 5.3.0-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/environment-modules-5.3.0-2.el9.aarch64.rpm
-  - evra: 2.5.0-6.el9_8.1.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/expat-2.5.0-6.el9_8.1.aarch64.rpm
-  - evra: 3.16-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/filesystem-3.16-5.el9.aarch64.rpm
-  - evra: 4.8.0-7.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/findutils-4.8.0-7.el9.aarch64.rpm
-  - evra: 1.2.0-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fips-provider-next-1.2.0-5.el9.aarch64.rpm
-  - evra: 5.1.0-6.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gawk-5.1.0-6.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-11.5.0-14.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-c++-11.5.0-14.el9.aarch64.rpm
-  - evra: 12.88-1.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-annobin-docs-12.88-1.el9.noarch.rpm
-  - evra: 12.88-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-annobin-plugin-gcc-12.88-1.el9.aarch64.rpm
-  - evra: 2.41-6.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-binutils-2.41-6.el9.aarch64.rpm
-  - evra: 0.14-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-dwz-0.14-1.el9.aarch64.rpm
-  - evra: 14.2.1-13.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-gcc-14.2.1-13.el9.aarch64.rpm
-  - evra: 14.2.1-13.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-gcc-c++-14.2.1-13.el9.aarch64.rpm
-  - evra: 14.2.1-13.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-gcc-gfortran-14.2.1-13.el9.aarch64.rpm
-  - evra: 14.2.1-13.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-libstdc++-devel-14.2.1-13.el9.aarch64.rpm
-  - evra: 14.0-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-runtime-14.0-2.el9.aarch64.rpm
-  - evra: 2.44-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-binutils-2.44-5.el9.aarch64.rpm
-  - evra: 15.2.1-7.1.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-gcc-15.2.1-7.1.el9_8.aarch64.rpm
-  - evra: 15.2.1-7.1.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-gcc-c++-15.2.1-7.1.el9_8.aarch64.rpm
-  - evra: 15.2.1-7.1.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-libstdc++-devel-15.2.1-7.1.el9_8.aarch64.rpm
-  - evra: 15.0-9.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-runtime-15.0-9.el9.aarch64.rpm
-  - evra: 1.23-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-2.34-274.el9_8.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-all-langpacks-2.34-274.el9_8.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-common-2.34-274.el9_8.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/glibc-devel-2.34-274.el9_8.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-gconv-extra-2.34-274.el9_8.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-langpack-en-2.34-274.el9_8.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-274.el9_8.aarch64.rpm
-  - evra: 6.2.0-13.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gmp-6.2.0-13.el9.aarch64.rpm
-  - evra: 3.6-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/grep-3.6-5.el9.aarch64.rpm
-  - evra: 1.22.4-10.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.aarch64.rpm
-  - evra: 1.12-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gzip-1.12-1.el9.aarch64.rpm
-  - evra: 6.7-15.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/i/info-6.7-15.el9.aarch64.rpm
-  - evra: 2.14-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/j/jansson-2.14-1.el9.aarch64.rpm
-  - evra: 0.14-11.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/j/json-c-0.14-11.el9.aarch64.rpm
-  - evra: 2.4.0-11.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kbd-2.4.0-11.el9.aarch64.rpm
-  - evra: 2.4.0-11.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kbd-legacy-2.4.0-11.el9.noarch.rpm
-  - evra: 2.4.0-11.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kbd-misc-2.4.0-11.el9.noarch.rpm
-  - evra: 5.14.0-687.31.1.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.31.1.el9_8.aarch64.rpm
-  - evra: 1.6.3-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/keyutils-libs-1.6.3-1.el9.aarch64.rpm
-  - evra: 28-11.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kmod-28-11.el9.aarch64.rpm
-  - evra: 28-11.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kmod-libs-28-11.el9.aarch64.rpm
-  - evra: 1.21.1-10.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/krb5-libs-1.21.1-10.el9_8.aarch64.rpm
-  - evra: 590-6.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/less-590-6.el9.aarch64.rpm
-  - evra: 2.4.0-1.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libacl-2.4.0-1.el9_8.aarch64.rpm
-  - evra: 3.5.3-9.el9_7.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libarchive-3.5.3-9.el9_7.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libasan-11.5.0-14.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libatomic-11.5.0-14.el9.aarch64.rpm
-  - evra: 2.5.1-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libattr-2.5.1-3.el9.aarch64.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libblkid-2.37.4-25.el9.aarch64.rpm
-  - evra: 1.0.9-9.el9_7.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libbrotli-1.0.9-9.el9_7.aarch64.rpm
-  - evra: 2.48-10.el9_8.1.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcap-2.48-10.el9_8.1.aarch64.rpm
-  - evra: 0.8.2-7.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcap-ng-0.8.2-7.el9.aarch64.rpm
-  - evra: 0.7.0-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.aarch64.rpm
-  - evra: 1.46.5-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcom_err-1.46.5-8.el9.aarch64.rpm
-  - evra: 7.76.1-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcurl-7.76.1-40.el9.aarch64.rpm
-  - evra: 7.76.1-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcurl-minimal-7.76.1-40.el9.aarch64.rpm
-  - evra: 5.3.28-57.el9_6.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.aarch64.rpm
-  - evra: 0.4.1-7.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libeconf-0.4.1-7.el9_8.aarch64.rpm
-  - evra: 3.1-39.20210216cvs.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.aarch64.rpm
-  - evra: 3.1-39.20210216cvs.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libedit-devel-3.1-39.20210216cvs.el9.aarch64.rpm
-  - evra: 2.1.12-8.el9_4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libevent-2.1.12-8.el9_4.aarch64.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libfdisk-2.37.4-25.el9.aarch64.rpm
-  - evra: 3.4.2-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libffi-3.4.2-8.el9.aarch64.rpm
-  - evra: 1.13.0-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgcc-11.5.0-14.el9.aarch64.rpm
-  - evra: 1.10.0-11.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgfortran-11.5.0-14.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.aarch64.rpm
-  - evra: 1.42-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgpg-error-1.42-5.el9.aarch64.rpm
-  - evra: 2.3.0-7.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libidn2-2.3.0-7.el9.aarch64.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libmount-2.37.4-25.el9.aarch64.rpm
-  - evra: 1.2.1-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.aarch64.rpm
-  - evra: 1.43.0-6.el9_8.1.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9_8.1.aarch64.rpm
-  - evra: 1.5.3-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.aarch64.rpm
-  - evra: 1.7.3-10.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.aarch64.rpm
-  - evra: 0.21.1-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpsl-0.21.1-5.el9.aarch64.rpm
-  - evra: 1.4.4-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.aarch64.rpm
-  - evra: 2.5.2-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.aarch64.rpm
-  - evra: 3.6-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libselinux-3.6-3.el9.aarch64.rpm
-  - evra: 3.6-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.aarch64.rpm
-  - evra: 3.6-5.el9_6.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.aarch64.rpm
-  - evra: 3.6-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsepol-3.6-3.el9.aarch64.rpm
-  - evra: 2.13-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsigsegv-2.13-4.el9.aarch64.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsmartcols-2.37.4-25.el9.aarch64.rpm
-  - evra: 0.10.4-18.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libssh-0.10.4-18.el9.aarch64.rpm
-  - evra: 0.10.4-18.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libssh-config-0.10.4-18.el9.noarch.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libstdc++-11.5.0-14.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libstdc++-devel-11.5.0-14.el9.aarch64.rpm
-  - evra: 4.16.0-10.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libtasn1-4.16.0-10.el9_8.aarch64.rpm
-  - evra: 2.4.6-46.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libtool-ltdl-2.4.6-46.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libubsan-11.5.0-14.el9.aarch64.rpm
-  - evra: 0.9.10-15.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libunistring-0.9.10-15.el9.aarch64.rpm
-  - evra: 1.2.1-6.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.aarch64.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libuuid-2.37.4-25.el9.aarch64.rpm
-  - evra: 1.42.0-2.el9_4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.aarch64.rpm
-  - evra: 0.3.2-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libverto-0.3.2-3.el9.aarch64.rpm
-  - evra: 4.4.18-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libxcrypt-4.4.18-3.el9.aarch64.rpm
-  - evra: 4.4.18-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.aarch64.rpm
-  - evra: 2.9.13-14.el9_8.2.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libxml2-2.9.13-14.el9_8.2.aarch64.rpm
-  - evra: 1.5.5-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libzstd-1.5.5-1.el9.aarch64.rpm
-  - evra: 1.5.5-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libzstd-devel-1.5.5-1.el9.aarch64.rpm
-  - evra: 21.1.8-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-21.1.8-2.el9.aarch64.rpm
-  - evra: 21.1.8-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-devel-21.1.8-2.el9.aarch64.rpm
-  - evra: 21.1.8-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-filesystem-21.1.8-2.el9.aarch64.rpm
-  - evra: 21.1.8-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-googletest-21.1.8-2.el9.aarch64.rpm
-  - evra: 21.1.8-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-libs-21.1.8-2.el9.aarch64.rpm
-  - evra: 21.1.8-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-static-21.1.8-2.el9.aarch64.rpm
-  - evra: 21.1.8-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-test-21.1.8-2.el9.aarch64.rpm
-  - evra: 5.4.4-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/lua-libs-5.4.4-4.el9.aarch64.rpm
-  - evra: 1.9.3-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/lz4-libs-1.9.3-5.el9.aarch64.rpm
-  - evra: 4.3-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/make-4.3-8.el9.aarch64.rpm
-  - evra: 2.9.3-9.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/man-db-2.9.3-9.el9.aarch64.rpm
-  - evra: 4.1.0-10.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/mpfr-4.1.0-10.el9.aarch64.rpm
-  - evra: 6.2-12.20210508.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/ncurses-base-6.2-12.20210508.el9.noarch.rpm
-  - evra: 6.2-12.20210508.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/n/ncurses-c++-libs-6.2-12.20210508.el9.aarch64.rpm
-  - evra: 6.2-12.20210508.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/n/ncurses-devel-6.2-12.20210508.el9.aarch64.rpm
-  - evra: 6.2-12.20210508.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/ncurses-libs-6.2-12.20210508.el9.aarch64.rpm
-  - evra: 2.6.8-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openldap-2.6.8-4.el9.aarch64.rpm
-  - evra: 9.9p1-7.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-9.9p1-7.el9_8.aarch64.rpm
-  - evra: 9.9p1-7.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-clients-9.9p1-7.el9_8.aarch64.rpm
-  - evra: 3.5.5-6.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-3.5.5-6.el9_8.aarch64.rpm
-  - evra: 3.5.5-6.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/openssl-devel-3.5.5-6.el9_8.aarch64.rpm
-  - evra: 3.0.7-11.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_8.aarch64.rpm
-  - evra: 3.0.7-11.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_8.aarch64.rpm
-  - evra: 3.5.5-6.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-libs-3.5.5-6.el9_8.aarch64.rpm
-  - evra: 0.26.2-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/p11-kit-0.26.2-1.el9.aarch64.rpm
-  - evra: 0.26.2-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/p11-kit-trust-0.26.2-1.el9.aarch64.rpm
-  - evra: 1.5.1-28.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pam-1.5.1-28.el9.aarch64.rpm
-  - evra: 8.44-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pcre-8.44-4.el9.aarch64.rpm
-  - evra: 10.40-6.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pcre2-10.40-6.el9.aarch64.rpm
-  - evra: 10.40-6.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pcre2-syntax-10.40-6.el9.noarch.rpm
-  - evra: 1.7.3-10.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.aarch64.rpm
-  - evra: 1.7.3-10.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
-  - evra: 1.7.3-10.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.aarch64.rpm
-  - evra: 3.6-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/policycoreutils-3.6-5.el9.aarch64.rpm
-  - evra: 3.6-5.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/policycoreutils-python-utils-3.6-5.el9.noarch.rpm
-  - evra: 1.18-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/popt-1.18-8.el9.aarch64.rpm
-  - evra: 3.3.17-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.aarch64.rpm
-  - evra: 20210518-3.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/publicsuffix-list-dafsa-20210518-3.el9.noarch.rpm
-  - evra: 3.9.25-7.el9_8.2.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-3.9.25-7.el9_8.2.aarch64.rpm
-  - evra: 3.1.5-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-audit-3.1.5-8.el9.aarch64.rpm
-  - evra: 1.5.0-7.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-distro-1.5.0-7.el9.noarch.rpm
-  - evra: 3.9.25-7.el9_8.2.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-libs-3.9.25-7.el9_8.2.aarch64.rpm
-  - evra: 3.6-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-libselinux-3.6-3.el9.aarch64.rpm
-  - evra: 3.6-5.el9_6.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-libsemanage-3.6-5.el9_6.aarch64.rpm
-  - evra: 21.3.1-2.el9_8.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-2.el9_8.noarch.rpm
-  - evra: 3.6-5.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-policycoreutils-3.6-5.el9.noarch.rpm
-  - evra: 4.4.4-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setools-4.4.4-1.el9.aarch64.rpm
-  - evra: 53.0.0-15.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setuptools-53.0.0-15.el9.noarch.rpm
-  - evra: 53.0.0-15.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-15.el9.noarch.rpm
-  - evra: 8.1-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/readline-8.1-4.el9.aarch64.rpm
-  - evra: 9.8-1.0.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/redhat-release-9.8-1.0.el9.aarch64.rpm
-  - evra: 4.16.1.3-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/rpm-4.16.1.3-40.el9.aarch64.rpm
-  - evra: 4.16.1.3-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/rpm-libs-4.16.1.3-40.el9.aarch64.rpm
-  - evra: 1.92.0-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/r/rust-1.92.0-1.el9.aarch64.rpm
-  - evra: 1.92.0-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/r/rust-std-static-1.92.0-1.el9.aarch64.rpm
-  - evra: 2.0.3-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.aarch64.rpm
-  - evra: 4.8-10.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/sed-4.8-10.el9.aarch64.rpm
-  - evra: 2.13.7-10.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/setup-2.13.7-10.el9.noarch.rpm
-  - evra: 4.9-16.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/shadow-utils-4.9-16.el9.aarch64.rpm
-  - evra: 3.34.1-10.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.aarch64.rpm
-  - evra: 252-67.el9_8.4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-252-67.el9_8.4.aarch64.rpm
-  - evra: 252-67.el9_8.4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-libs-252-67.el9_8.4.aarch64.rpm
-  - evra: 252-67.el9_8.4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-pam-252-67.el9_8.4.aarch64.rpm
-  - evra: 252-67.el9_8.4.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-rpm-macros-252-67.el9_8.4.noarch.rpm
-  - evra: 252-67.el9_8.4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-udev-252-67.el9_8.4.aarch64.rpm
-  - evra: 8.6.10-7.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tcl-8.6.10-7.el9.aarch64.rpm
-  - evra: 3.2.3-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.aarch64.rpm
-  - evra: 2026b-1.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tzdata-2026b-1.el9.noarch.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/util-linux-2.37.4-25.el9.aarch64.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/util-linux-core-2.37.4-25.el9.aarch64.rpm
-  - evra: 8.2.2637-26.el9_8.10.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.10.noarch.rpm
-  - evra: 5.2.5-8.el9_0.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.aarch64.rpm
-  - evra: 1.2.11-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/z/zlib-1.2.11-40.el9.aarch64.rpm
-  - evra: 1.92.0-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cargo-1.92.0-1.el9.aarch64.rpm
-  - evra: 21.1.8-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-devel-21.1.8-2.el9.aarch64.rpm
-  - evra: 14.0-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-14.0-2.el9.aarch64.rpm
-  - evra: 2.52.0-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-core-2.52.0-1.el9.aarch64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cargo-1.92.0-1.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 8530651
+    checksum: sha256:14ac2d264369b0ac4442d6b773224765413282ea996dac29cf576c176c8cdcba
+    name: cargo
+    evr: 1.92.0-1.el9
+    sourcerpm: rust-1.92.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/checkpolicy-3.6-1.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 360096
+    checksum: sha256:be68ea8774a5aa3b0220043aa21aa93213d4ec0e1cf0c1e9114369ed16ada37e
+    name: checkpolicy
+    evr: 3.6-1.el9
+    sourcerpm: checkpolicy-3.6-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 7554569
+    checksum: sha256:cb1188aa89484232468c58a1296fa61de218744eb75b22e150b477d60d231f97
+    name: clang
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-devel-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 4494280
+    checksum: sha256:06192b7daf820f880f8feb8842928e07d88df155cffbb3332f6ed4ce872a7c3a
+    name: clang-devel
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-libs-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 31039242
+    checksum: sha256:12caacb5a1ca774ad9a41179d74c721e8243a043a48c0d286ea720394c724a83
+    name: clang-libs
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-resource-filesystem-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 25797
+    checksum: sha256:5087b19492047a7139b1f1144e40d5091dcee5c95f35fa354781039b5c756a0d
+    name: clang-resource-filesystem
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/clang-tools-extra-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 19364965
+    checksum: sha256:8ba62cb3611971be4a01354c067b51b8c73787fb64958cafd2e77989db9e5d46
+    name: clang-tools-extra
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-3.31.8-3.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 11655593
+    checksum: sha256:2a77fe1c3784083dcdebdd548c16d823b3e4a5adb8d6c00e36841aa633eab53b
+    name: cmake
+    evr: 3.31.8-3.el9
+    sourcerpm: cmake-3.31.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-data-3.31.8-3.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2829291
+    checksum: sha256:1cdc2e88a996c575b750483c8f562674e4b50a6ab414c7bbe6f6b641c1db7bd9
+    name: cmake-data
+    evr: 3.31.8-3.el9
+    sourcerpm: cmake-3.31.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-filesystem-3.31.8-3.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 19282
+    checksum: sha256:69a498723354740357fc3f4b4cd235da38fadd98835da193bec0c0850f68f3ad
+    name: cmake-filesystem
+    evr: 3.31.8-3.el9
+    sourcerpm: cmake-3.31.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/compiler-rt-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2377154
+    checksum: sha256:2adf2397bd2231a95d85dc6db88e9eb539981f0411462fe518b741688ddde3c2
+    name: compiler-rt
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cpp-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 10798392
+    checksum: sha256:eb16ef369b981c0dca6149e971a63f74ea09c09f1c638086e3cda1e0591ac21b
+    name: cpp
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 9495
+    checksum: sha256:49d7b88a05a72c15b78191a987e6def04fda8e2e4ff75711f715d0c0ecadc60f
+    name: emacs-filesystem
+    evr: 1:27.2-18.el9
+    sourcerpm: emacs-27.2-18.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 31291354
+    checksum: sha256:542e635ac17b548cc03ab4347438d49f96837c1d91d12714b6b2764ec566156c
+    name: gcc
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-c++-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 12994215
+    checksum: sha256:aabe892798a2272d65c269fd6aa14d3b3dfc782c98f92f8fda30c2a4fa33bf6d
+    name: gcc-c++
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-14.0-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 10516
+    checksum: sha256:176ce522a37ef114051b114969cc72bf3da8ecb697368a18260fcf58eeee4bb2
+    name: gcc-toolset-14
+    evr: 14.0-2.el9
+    sourcerpm: gcc-toolset-14-14.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-annobin-docs-12.88-1.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 89636
+    checksum: sha256:80d5c6c300561524fb2f855fce1867546d4452ea5c72cfb5d53f2117153e9805
+    name: gcc-toolset-14-annobin-docs
+    evr: 12.88-1.el9
+    sourcerpm: gcc-toolset-14-annobin-12.88-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-annobin-plugin-gcc-12.88-1.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 1001441
+    checksum: sha256:1e671eaaa6265094d89aaed03dfef45bc780619e62de032dafd24f70146f1304
+    name: gcc-toolset-14-annobin-plugin-gcc
+    evr: 12.88-1.el9
+    sourcerpm: gcc-toolset-14-annobin-12.88-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-binutils-2.41-6.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 7357899
+    checksum: sha256:e23944e5ba23c055df25efebe7c3fe848755225b2441923110c519165b543ecf
+    name: gcc-toolset-14-binutils
+    evr: 2.41-6.el9
+    sourcerpm: gcc-toolset-14-binutils-2.41-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-dwz-0.14-1.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 128077
+    checksum: sha256:f4bcee0025b49e9653dbb3d939140d4fc9b6b8734156ebca2fc7b3c70d5e89bd
+    name: gcc-toolset-14-dwz
+    evr: 0.14-1.el9
+    sourcerpm: gcc-toolset-14-dwz-0.14-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-gcc-14.2.1-13.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 44178202
+    checksum: sha256:759df2069e08b4725204c86e1c367316af41adb713233876c1c323f0e383e395
+    name: gcc-toolset-14-gcc
+    evr: 14.2.1-13.el9
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-gcc-c++-14.2.1-13.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 13751718
+    checksum: sha256:4c1232051eaefabe1258ca799a80837a696637e8ac5e3b1ca54ac0d5f3f36394
+    name: gcc-toolset-14-gcc-c++
+    evr: 14.2.1-13.el9
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-gcc-gfortran-14.2.1-13.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 13520354
+    checksum: sha256:2a8e9ccfdde357bc2ecc47ae1d1631d3e07945b4cd44a9fb6b08e8d40795fd6f
+    name: gcc-toolset-14-gcc-gfortran
+    evr: 14.2.1-13.el9
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-libstdc++-devel-14.2.1-13.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 3783154
+    checksum: sha256:50354426d57fa9c93b656a51f97c72a39fe662dd7e694ec6d2865c527186ae88
+    name: gcc-toolset-14-libstdc++-devel
+    evr: 14.2.1-13.el9
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-14-runtime-14.0-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 58526
+    checksum: sha256:afe549f07bbaf06f2619d47b18155eaa1f8416dadbff5cbeb99cf17033d7ac25
+    name: gcc-toolset-14-runtime
+    evr: 14.0-2.el9
+    sourcerpm: gcc-toolset-14-14.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-binutils-2.44-5.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 6565787
+    checksum: sha256:80da34e7f0ab8f9239fc71e43f2f75f75e4cb9bcdc5d89b9a8b54b96bc04acee
+    name: gcc-toolset-15-binutils
+    evr: 2.44-5.el9
+    sourcerpm: gcc-toolset-15-binutils-2.44-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-gcc-15.2.1-7.1.el9_8.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 48931221
+    checksum: sha256:a98dbc56b02c315701efab486373b361126e471fbb792729511da4b26ebd2340
+    name: gcc-toolset-15-gcc
+    evr: 15.2.1-7.1.el9_8
+    sourcerpm: gcc-toolset-15-gcc-15.2.1-7.1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-gcc-c++-15.2.1-7.1.el9_8.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 15465405
+    checksum: sha256:9b5c6d7dbe8d479062b4ae3847aa3e23add35ce496bafe7759b5678b91587211
+    name: gcc-toolset-15-gcc-c++
+    evr: 15.2.1-7.1.el9_8
+    sourcerpm: gcc-toolset-15-gcc-15.2.1-7.1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-libatomic-devel-15.2.1-7.1.el9_8.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 37805
+    checksum: sha256:261d7bbe9e76fb8521d43f08cb8e78452ceb79ee0d302f90d4f26486a8b54551
+    name: gcc-toolset-15-libatomic-devel
+    evr: 15.2.1-7.1.el9_8
+    sourcerpm: gcc-toolset-15-gcc-15.2.1-7.1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-libstdc++-devel-15.2.1-7.1.el9_8.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 3953483
+    checksum: sha256:fef924530e3a52b2fb599efd4d88dd338e3c50ab8906af5677c9c0dc96fde128
+    name: gcc-toolset-15-libstdc++-devel
+    evr: 15.2.1-7.1.el9_8
+    sourcerpm: gcc-toolset-15-gcc-15.2.1-7.1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-toolset-15-runtime-15.0-9.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 54344
+    checksum: sha256:4ea3558c3d09059ee9cefa2fca97fc7f127e8b479f30c64445a095c1cf5ce4fc
+    name: gcc-toolset-15-runtime
+    evr: 15.0-9.el9
+    sourcerpm: gcc-toolset-15-15.0-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-core-2.52.0-1.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 5392428
+    checksum: sha256:7082917982981bf611c089e7d9d53b63e969af61a37cfd65b5c4081d5b260a1c
+    name: git-core
+    evr: 2.52.0-1.el9
+    sourcerpm: git-2.52.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/glibc-devel-2.34-274.el9_8.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 577056
+    checksum: sha256:09cdfbba4c2517445ee2512c1c5c965b7d7ebdcf05665627dee83e0d824a5cff
+    name: glibc-devel
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.31.1.el9_8.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2861893
+    checksum: sha256:c7bc9b3d12d85dafcf2c41d080338f4871289142b7c007ad121767a38d08b5ff
+    name: kernel-headers
+    evr: 5.14.0-687.31.1.el9_8
+    sourcerpm: kernel-5.14.0-687.31.1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libasan-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 409047
+    checksum: sha256:854a84e72d40c2a062d112b93f8a694044fd7dc5b3afe7a869a448a12844c3e6
+    name: libasan
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libedit-devel-3.1-39.20210216cvs.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 54302
+    checksum: sha256:7f13c7aa8cf52c8f64c0c4e64b821d119ca9e3c4844ed8b24b377cbd90a4db33
+    name: libedit-devel
+    evr: 3.1-39.20210216cvs.el9
+    sourcerpm: libedit-3.1-39.20210216cvs.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 67120
+    checksum: sha256:3763354a5f45d886f9976eec20eb34f8afc2144c69ffba07de546f2820893c70
+    name: libmpc
+    evr: 1.2.1-4.el9
+    sourcerpm: libmpc-1.2.1-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libomp-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 813991
+    checksum: sha256:04dfb9a02d03b62eacde6b2855c73a54bd3297e0c33a548472fb3396cc9797f1
+    name: libomp
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libomp-devel-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 280491
+    checksum: sha256:8c205694cd8f05c51684c03d6bd753f2492ba8326ca31f993502bfa55a795f7f
+    name: libomp-devel
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libstdc++-devel-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2520018
+    checksum: sha256:5a2474c2e817b008212e5a94770d8bfbaad17e9ebba2a38d734907e594ac2aac
+    name: libstdc++-devel
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libubsan-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 178996
+    checksum: sha256:d0adfda8f1d8ddf05a46292228e31cf887d731e7999154603e148e3d70d1f182
+    name: libubsan
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 150129
+    checksum: sha256:4dc8a40da74e0f9823356460ee11f183c70f382953700fffef0c448198a677cc
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+    sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 33051
+    checksum: sha256:9d621f33df35b9c274b8d65457d6c67fc1522b6c62cf7b2341a4a99f39a93507
+    name: libxcrypt-devel
+    evr: 4.4.18-3.el9
+    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libzstd-devel-1.5.5-1.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 53186
+    checksum: sha256:4eb008a503fdb6437022c77acef155b2822c62622cb486551d3253c28dd00660
+    name: libzstd-devel
+    evr: 1.5.5-1.el9
+    sourcerpm: zstd-1.5.5-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 24409660
+    checksum: sha256:cf84a4f681a81b75922b81f462a25c1eda2329c7512c844489691b37c8367816
+    name: llvm
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-devel-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 6394014
+    checksum: sha256:c64d836b57bada150c36de67a88aea4747685f21b8b23bd4d0d0922b56381d29
+    name: llvm-devel
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-filesystem-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 20175
+    checksum: sha256:87b55002280f29f59e8452cf184307ce0ffcf613a8967f726cb5b3438ecbc70a
+    name: llvm-filesystem
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-googletest-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 474811
+    checksum: sha256:62528321de99e8ccf8b82deb55a6837fac3ae6575a5d0b4ab57c79c8a7b92906
+    name: llvm-googletest
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-libs-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 31011258
+    checksum: sha256:47a47b60c922d628f7e0fa6c7e58484cd416221d6fbcd2b4708f5c901d6aecb4
+    name: llvm-libs
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-static-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 46022845
+    checksum: sha256:27e1bd90729ad393e1abf9a3dd66c5500b06d55b611d87e9c6005f9a77c90f0d
+    name: llvm-static
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-test-21.1.8-2.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 759720
+    checksum: sha256:37e49775e95417bf1be7e4e9bdd5034c03457a218a6c3c67853c613fa6376796
+    name: llvm-test
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/n/ncurses-c++-libs-6.2-12.20210508.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 36630
+    checksum: sha256:925b0aded13b838171c10781d54e71060de5f4db26eff1c05525ec7a89c6f54e
+    name: ncurses-c++-libs
+    evr: 6.2-12.20210508.el9
+    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/n/ncurses-devel-6.2-12.20210508.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 745479
+    checksum: sha256:712408157ed0145b0b179b3abf69e458a28f0095c3906179fea1a0b396feb832
+    name: ncurses-devel
+    evr: 6.2-12.20210508.el9
+    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/openssl-devel-3.5.5-6.el9_8.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 5028889
+    checksum: sha256:c92e750163820a817ca5562935010872f8db5ca5712a517b01beafcb87221670
+    name: openssl-devel
+    evr: 1:3.5.5-6.el9_8
+    sourcerpm: openssl-3.5.5-6.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/policycoreutils-python-utils-3.6-5.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 84137
+    checksum: sha256:fae42a122e2848cfe99736012348f9c008c4d35e818e72e590e993e58d9858ad
+    name: policycoreutils-python-utils
+    evr: 3.6-5.el9
+    sourcerpm: policycoreutils-3.6-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-audit-3.1.5-8.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 91000
+    checksum: sha256:4bc818f51fdd6846442e1e961b83e2ba777736e1fd28519e4ffdcc8e73c49154
+    name: python3-audit
+    evr: 3.1.5-8.el9
+    sourcerpm: audit-3.1.5-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-distro-1.5.0-7.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 41452
+    checksum: sha256:5cf4276217a72649895226707d4c0e3edd6ea64b66702793fab3907177c73069
+    name: python3-distro
+    evr: 1.5.0-7.el9
+    sourcerpm: python-distro-1.5.0-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-libselinux-3.6-3.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 191826
+    checksum: sha256:dcc609ec4df45a30606ce85999c9cf45e819d4f8e8479662dfaf6bfb1b27dd2d
+    name: python3-libselinux
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-libsemanage-3.6-5.el9_6.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 82350
+    checksum: sha256:1a32b9c090a98ddffe5ef70e4485dae8c295d942d87e15753e1cb5f01e23bc97
+    name: python3-libsemanage
+    evr: 3.6-5.el9_6
+    sourcerpm: libsemanage-3.6-5.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python3-policycoreutils-3.6-5.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2219410
+    checksum: sha256:eb5d83e26cee47b23b4b802d98cae521f41d8d0d8451a9e5029cd9b5016dd00b
+    name: python3-policycoreutils
+    evr: 3.6-5.el9
+    sourcerpm: policycoreutils-3.6-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/r/rust-1.92.0-1.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 29421295
+    checksum: sha256:43a1b0f5168a39ceea3fd90d42b23bc05d006d639cd35cfdad82a4f94aa58453
+    name: rust
+    evr: 1.92.0-1.el9
+    sourcerpm: rust-1.92.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/r/rust-std-static-1.92.0-1.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 41493155
+    checksum: sha256:3b3a70a8e11f53559c4b84927ebd0565a073052bac2c53edda6cb328bfb28090
+    name: rust-std-static
+    evr: 1.92.0-1.el9
+    sourcerpm: rust-1.92.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 42050
+    checksum: sha256:b7c093e050e3d127b98bd1002e46dee9cfbbc6279978aee17d7fad30b42a41ec
+    name: scl-utils
+    evr: 1:2.0.3-4.el9
+    sourcerpm: scl-utils-2.0.3-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/audit-libs-3.1.5-8.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 128901
+    checksum: sha256:11880ec70b575841843cbee0853e03e50a0506321ea0a6f76c0c8145d79ae531
+    name: audit-libs
+    evr: 3.1.5-8.el9
+    sourcerpm: audit-3.1.5-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-2.35.2-72.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 5021411
+    checksum: sha256:72e9fd9c4976413060df02e37d358fca208ab144d78e321f448a488d50967155
+    name: binutils
+    evr: 2.35.2-72.el9
+    sourcerpm: binutils-2.35.2-72.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 908723
+    checksum: sha256:269bb24ded2f23dcdb74c04597b13281ce6ac47a87a14831ee639d985323bd04
+    name: binutils-gold
+    evr: 2.35.2-72.el9
+    sourcerpm: binutils-2.35.2-72.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/diffutils-3.7-12.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 405687
+    checksum: sha256:524412f7ce56095508190116cb8ae141737857e4447979330c3cf75ca7017e6b
+    name: diffutils
+    evr: 3.7-12.el9
+    sourcerpm: diffutils-3.7-12.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 42824
+    checksum: sha256:bbcf05d0b46d42c85807d774788edc39528a6898bd880baf11fb77729f59272d
+    name: elfutils-debuginfod-client
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 203006
+    checksum: sha256:04ff63b7b669b16827f3688baa0be4a2782f1405db3c6d3ee03c0e4cebc2cdf2
+    name: elfutils-libelf
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 271645
+    checksum: sha256:b90a6ad3e465995538785a2536986ad705625daf606d6258bf23d1dd29aec208
+    name: elfutils-libs
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/environment-modules-5.3.0-2.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 605165
+    checksum: sha256:569419a5a9256714a4d0f665ff2bada6f565bcc104479115c584cdbe897cf6bf
+    name: environment-modules
+    evr: 5.3.0-2.el9
+    sourcerpm: environment-modules-5.3.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-2.34-274.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 1813548
+    checksum: sha256:0d52ce006fc399127ea7da1f2acfeed702b48ba75f5d1567491be35e1d620b09
+    name: glibc
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-common-2.34-274.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 312799
+    checksum: sha256:86d8e468d28880e34bb92a6e99a82fa2d5946d56cf2cedbb6fd9ca0cd1f65755
+    name: glibc-common
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-langpack-en-2.34-274.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 684496
+    checksum: sha256:0883e1f9ac411a052c434f7339e6929c34cf4a47330a38e036a3c15c17322fa1
+    name: glibc-langpack-en
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-274.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 30937
+    checksum: sha256:33a17677cc85823259a2ddd3f24887117dc95d7a9ec0af64640df6ab26ddc094
+    name: glibc-minimal-langpack
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 1088949
+    checksum: sha256:452cfe5372c834bb174ef1f6eed4d0aa6179420fd572163467ac9036fc7a3a1d
+    name: groff-base
+    evr: 1.22.4-10.el9
+    sourcerpm: groff-1.22.4-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/i/info-6.7-15.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 230301
+    checksum: sha256:c5ae65876c73c6f4e240081431745f5ba0a91d10a4bfb8a5d162ca3d6f039202
+    name: info
+    evr: 6.7-15.el9
+    sourcerpm: texinfo-6.7-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/j/jansson-2.14-1.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 50251
+    checksum: sha256:7c002eb9c81bad49b8a11d9790af6220cce5fb882be7ca11335882d079d1473f
+    name: jansson
+    evr: 2.14-1.el9
+    sourcerpm: jansson-2.14-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/less-590-6.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 165028
+    checksum: sha256:fa762484ba40e0b7eb1c25531a66a0b578b6141cabb6f73d865c13ccdf75c1c9
+    name: less
+    evr: 590-6.el9
+    sourcerpm: less-590-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libatomic-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 26108
+    checksum: sha256:bebe2e8fd98c64d1667e3de1eb3751b7b641bf5d0cd870ed6445fea5c4526326
+    name: libatomic
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 59368
+    checksum: sha256:93a2f44044ab11225b1123bc9df4f4d09c0a5f3251818e7d144ca64fd12c0957
+    name: libcbor
+    evr: 0.7.0-5.el9
+    sourcerpm: libcbor-0.7.0-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 110092
+    checksum: sha256:93964f8c06574404f4a5b44781b698f556fbc22f7ae3c82d4d540619772f6816
+    name: libedit
+    evr: 3.1-39.20210216cvs.el9
+    sourcerpm: libedit-3.1-39.20210216cvs.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 100573
+    checksum: sha256:e56e963635b92f407471c7c5698d602135b135bda4515ecc75ac52dd1d38c7e4
+    name: libfido2
+    evr: 1.13.0-2.el9
+    sourcerpm: libfido2-1.13.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgcc-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 81211
+    checksum: sha256:6923218fdef581189a4b51c7ba158083597f1c6df08cae021a1d90e9d61938a9
+    name: libgcc
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgfortran-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 435007
+    checksum: sha256:dffccd2856eae33a06d19180c60cf3d6944e9e6e08712b54cf83c49d77b21903
+    name: libgfortran
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 262138
+    checksum: sha256:c8b3788fee442304e4158c802ff413df27d394b82f19c0f34ff43b5d3760470c
+    name: libgomp
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 52161
+    checksum: sha256:32d8aea6849a815e201cdce925fb3c6de2088cfcb7f6621e93495b605abe2f13
+    name: libpipeline
+    evr: 1.5.3-4.el9
+    sourcerpm: libpipeline-1.5.3-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 38310
+    checksum: sha256:9bdfccf6b092e0683aa6984f7c6caa737b30c0b1495e16abb03b5d1a5f8e787a
+    name: libpkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 197588
+    checksum: sha256:63fc5e8f22ddff6ae1428b6802f7cfc4ef75c50199de107abecbff3937ad0c35
+    name: libselinux-utils
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libstdc++-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 723913
+    checksum: sha256:ae00c5009a2ee4682ec732cde66d3f4fcfc1a7099ba7b3701767d1748a4f2683
+    name: libstdc++
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/make-4.3-8.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 550249
+    checksum: sha256:351a22b0e6744bd329b1b0f22d9c3b69a6da970b575e6c76190cc84b0fe77450
+    name: make
+    evr: 1:4.3-8.el9
+    sourcerpm: make-4.3-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/man-db-2.9.3-9.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 1233088
+    checksum: sha256:44d2f613bd962c7ddd7202780d648dbdb1c9030965c36e57e72ad7b2e56fd6e2
+    name: man-db
+    evr: 2.9.3-9.el9
+    sourcerpm: man-db-2.9.3-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/ncurses-base-6.2-12.20210508.el9.noarch.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 97840
+    checksum: sha256:d62dfd41f9688efa2cf1ceedb96084c63e297fbdcfd1e72bc6757c730092b60c
+    name: ncurses-base
+    evr: 6.2-12.20210508.el9
+    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/ncurses-libs-6.2-12.20210508.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 324624
+    checksum: sha256:b5dd452392d2f97bb050c9f5e5376998652c567dcbd8f035d26659b1b551b5c9
+    name: ncurses-libs
+    evr: 6.2-12.20210508.el9
+    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-9.9p1-7.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 431979
+    checksum: sha256:be18971dc20baa2fc820ec357d145bc5f9dbd88fd87e04b4016d8f77183525ae
+    name: openssh
+    evr: 9.9p1-7.el9_8
+    sourcerpm: openssh-9.9p1-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-clients-9.9p1-7.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 768861
+    checksum: sha256:37ac77703fc47951b231cab696f52f00485f0811ed893d7c68a038eef81c9d8f
+    name: openssh-clients
+    evr: 9.9p1-7.el9_8
+    sourcerpm: openssh-9.9p1-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-3.5.5-6.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 1541002
+    checksum: sha256:9f10be36d0d532c65a3f9a41f7d0cd3190b0b908f60850862cc24cab06cd1101
+    name: openssl
+    evr: 1:3.5.5-6.el9_8
+    sourcerpm: openssl-3.5.5-6.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 14220
+    checksum: sha256:158193d2f965db318148ec76e9347b530ac1f5379d849012c0a04d3c50cda478
+    name: openssl-fips-provider
+    evr: 3.0.7-11.el9_8
+    sourcerpm: openssl-fips-provider-3.0.7-11.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 529340
+    checksum: sha256:22374a51f8a529dcfcf3b3ebbb2095103e0e811a28953535e5a62e26d1233301
+    name: openssl-fips-provider-so
+    evr: 3.0.7-11.el9_8
+    sourcerpm: openssl-fips-provider-3.0.7-11.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-libs-3.5.5-6.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 2290581
+    checksum: sha256:9af799c6be853cb42999a1228a2768da20a21895b7dcac111dba3be13a397b67
+    name: openssl-libs
+    evr: 1:3.5.5-6.el9_8
+    sourcerpm: openssl-3.5.5-6.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 45196
+    checksum: sha256:aa38a3951a690d721a815ea8f9b01995a85f35a8540d8075205821011d0385e6
+    name: pkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 16054
+    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
+    name: pkgconf-m4
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 12398
+    checksum: sha256:47f1f744f96a2f3d360bc129837738dcebb1ee5032effc4472a891eea1d6a907
+    name: pkgconf-pkg-config
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/policycoreutils-3.6-5.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 251069
+    checksum: sha256:1c94341d45d675a1d583f86e16ff91eacf7fd4d6a89a987ba2c4c4c1783d35ce
+    name: policycoreutils
+    evr: 3.6-5.el9
+    sourcerpm: policycoreutils-3.6-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 363344
+    checksum: sha256:a8c7514beb4c3cafa6341f43bbe285319d863b2893a34d91159dc8e90f615dd2
+    name: procps-ng
+    evr: 3.3.17-14.el9
+    sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setools-4.4.4-1.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 613411
+    checksum: sha256:f8e347a37155ff1b805c7d7ed1ad98db8df8fdfcf3d04c13c819e796604c892f
+    name: python3-setools
+    evr: 4.4.4-1.el9
+    sourcerpm: setools-4.4.4-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tcl-8.6.10-7.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 1137015
+    checksum: sha256:a7cf45af14e65509a7f4d33422499372f6fb869bb82695dd4e9004e5c2e4ac1a
+    name: tcl
+    evr: 1:8.6.10-7.el9
+    sourcerpm: tcl-8.6.10-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.10.noarch.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 22399
+    checksum: sha256:9fc9ef3ba0b22a599b2a7b34bd0b025afd5f2623e9132b4ead19e98f9c62e97d
+    name: vim-filesystem
+    evr: 2:8.2.2637-26.el9_8.10
+    sourcerpm: vim-8.2.2637-26.el9_8.10.src.rpm
   source: []
-lockfileVendor: redhat
-lockfileVersion: 1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cargo-1.92.0-1.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 9100626
+    checksum: sha256:3c4afc2cb56734d01aaaaa8d0c317688f6fe143ad239079342f4fe9b631ded0f
+    name: cargo
+    evr: 1.92.0-1.el9
+    sourcerpm: rust-1.92.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/checkpolicy-3.6-1.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 365931
+    checksum: sha256:3d12bc7e21276434108c97561f75d1854283afb73d4fface3b836acee09f8d98
+    name: checkpolicy
+    evr: 3.6-1.el9
+    sourcerpm: checkpolicy-3.6-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 7531133
+    checksum: sha256:d1d0a8e2c3c568a0fd4551ce982f6db5de0e0675e55e4083563df7d66324129b
+    name: clang
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-devel-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 4508426
+    checksum: sha256:16e04e008dbc07e4dbb6bc34ef4bbf0dc6aae119103b35ac5bce86e2e4072395
+    name: clang-devel
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-libs-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 32793031
+    checksum: sha256:0d674d34e4ade76a3e2e273b3b967979dd8678870693b2b3d5670b48354c6673
+    name: clang-libs
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-resource-filesystem-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 25845
+    checksum: sha256:d5cd22de3ab8fd0ee362d1fc7d030efbfabd573e776164987b9e92b7e88d1926
+    name: clang-resource-filesystem
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/clang-tools-extra-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 19688837
+    checksum: sha256:bf8f41f5f6e19c5e613c2a08552a09e5d73130fdd6e8163791731217286ab715
+    name: clang-tools-extra
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-3.31.8-3.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 13989883
+    checksum: sha256:e67ea7aef1edd470e4ec22982e97871655abcdc0990754d4e8f147d4e7de317a
+    name: cmake
+    evr: 3.31.8-3.el9
+    sourcerpm: cmake-3.31.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-data-3.31.8-3.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2829291
+    checksum: sha256:1cdc2e88a996c575b750483c8f562674e4b50a6ab414c7bbe6f6b641c1db7bd9
+    name: cmake-data
+    evr: 3.31.8-3.el9
+    sourcerpm: cmake-3.31.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-filesystem-3.31.8-3.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 19309
+    checksum: sha256:b5ea81385a9e4e6a1ae2bb1175cd774af82f9c570a37008cde873ead466ba5f7
+    name: cmake-filesystem
+    evr: 3.31.8-3.el9
+    sourcerpm: cmake-3.31.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/compiler-rt-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2887211
+    checksum: sha256:29303ae9c424f796f2c82751bfd05ef273175a6850904956f13100f9dab90f3a
+    name: compiler-rt
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cpp-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 11226193
+    checksum: sha256:3c0ee1cb8b72f3f5176f8945ab518eb733ccc9f950d317fb5d5ac327d0eb9c90
+    name: cpp
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 9495
+    checksum: sha256:49d7b88a05a72c15b78191a987e6def04fda8e2e4ff75711f715d0c0ecadc60f
+    name: emacs-filesystem
+    evr: 1:27.2-18.el9
+    sourcerpm: emacs-27.2-18.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 33982584
+    checksum: sha256:2082784165bbb246b6e5ef5921ed823f0a9709cacdf5823aa60695fd6d4819a2
+    name: gcc
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-c++-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 13474286
+    checksum: sha256:b073d8965ad8eed7520a2a1c9b7c961232511ad9188dcc8c92356160a9d51e37
+    name: gcc-c++
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-14.0-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 10548
+    checksum: sha256:fd91c081a55265fe32d33db984799fad71776a58b385d2fab5573c69b5b9bf90
+    name: gcc-toolset-14
+    evr: 14.0-2.el9
+    sourcerpm: gcc-toolset-14-14.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-annobin-docs-12.88-1.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 89636
+    checksum: sha256:80d5c6c300561524fb2f855fce1867546d4452ea5c72cfb5d53f2117153e9805
+    name: gcc-toolset-14-annobin-docs
+    evr: 12.88-1.el9
+    sourcerpm: gcc-toolset-14-annobin-12.88-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-annobin-plugin-gcc-12.88-1.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 1001848
+    checksum: sha256:0e5d40903d0dbd89956f16c78ad40341dc8dd3da7fb55000cca7bb5f09333086
+    name: gcc-toolset-14-annobin-plugin-gcc
+    evr: 12.88-1.el9
+    sourcerpm: gcc-toolset-14-annobin-12.88-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-binutils-2.41-6.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 6901423
+    checksum: sha256:5decfcda1ae0231cd9c13706c4c0d7d816d2e8c1bbe3a291721df29c5a81a832
+    name: gcc-toolset-14-binutils
+    evr: 2.41-6.el9
+    sourcerpm: gcc-toolset-14-binutils-2.41-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-dwz-0.14-1.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 130028
+    checksum: sha256:401e7ffc147e0b640c54160ad884fa0ff8aaf2f853844efa4089449bee724593
+    name: gcc-toolset-14-dwz
+    evr: 0.14-1.el9
+    sourcerpm: gcc-toolset-14-dwz-0.14-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-gcc-14.2.1-13.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 49276047
+    checksum: sha256:88394bf3285516aafeb46142137eef4cfcbaec6dea65069300fa83b1b9591212
+    name: gcc-toolset-14-gcc
+    evr: 14.2.1-13.el9
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-gcc-c++-14.2.1-13.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 15461951
+    checksum: sha256:58526a393176dfb8e09febeec740e83184cb516071789640544a016c38900dec
+    name: gcc-toolset-14-gcc-c++
+    evr: 14.2.1-13.el9
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-gcc-gfortran-14.2.1-13.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 16316399
+    checksum: sha256:cfe1f8d7b41dff526d0f4557d2a174a0ca3316f09b598af00e707318941ff3c6
+    name: gcc-toolset-14-gcc-gfortran
+    evr: 14.2.1-13.el9
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-libquadmath-devel-14.2.1-13.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 199281
+    checksum: sha256:b87c01a01aca2e966d43510928f6474a1cbb5d19cffab5932c36e1f184f428e2
+    name: gcc-toolset-14-libquadmath-devel
+    evr: 14.2.1-13.el9
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-libstdc++-devel-14.2.1-13.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 3828722
+    checksum: sha256:56127110cd31f460a4cc4b42477459ad546fba010a170b3c35ca6b0922595311
+    name: gcc-toolset-14-libstdc++-devel
+    evr: 14.2.1-13.el9
+    sourcerpm: gcc-toolset-14-gcc-14.2.1-13.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-14-runtime-14.0-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 58568
+    checksum: sha256:fd93bde11241e6ed3c9dbfad9ce9a9683645b9242ab679a7c7daeb314fdc3367
+    name: gcc-toolset-14-runtime
+    evr: 14.0-2.el9
+    sourcerpm: gcc-toolset-14-14.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-binutils-2.44-5.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 6198721
+    checksum: sha256:6d230ef471ed2995ea3cb5eed9780e7f17f4ba95988f41acff3756007978d89d
+    name: gcc-toolset-15-binutils
+    evr: 2.44-5.el9
+    sourcerpm: gcc-toolset-15-binutils-2.44-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-gcc-15.2.1-7.1.el9_8.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 54282132
+    checksum: sha256:64fea64a38e095f75e929e0cf0e85a93bb978dc2afe0cd83f4af5415549fc259
+    name: gcc-toolset-15-gcc
+    evr: 15.2.1-7.1.el9_8
+    sourcerpm: gcc-toolset-15-gcc-15.2.1-7.1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-gcc-c++-15.2.1-7.1.el9_8.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 17108710
+    checksum: sha256:bc0a9ab7188a36a022047d1f83a3b80d5c6b29b8762250726391990a6cf47dba
+    name: gcc-toolset-15-gcc-c++
+    evr: 15.2.1-7.1.el9_8
+    sourcerpm: gcc-toolset-15-gcc-15.2.1-7.1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-libatomic-devel-15.2.1-7.1.el9_8.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 37347
+    checksum: sha256:ef7ccc962fd7219318a6b824614a4c77599cfa110724507c687b83a999b6a773
+    name: gcc-toolset-15-libatomic-devel
+    evr: 15.2.1-7.1.el9_8
+    sourcerpm: gcc-toolset-15-gcc-15.2.1-7.1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-libstdc++-devel-15.2.1-7.1.el9_8.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 3994173
+    checksum: sha256:ea2e288330c49cd34dde9c681957ee9deac567eb1c7d235f72abebee987d4569
+    name: gcc-toolset-15-libstdc++-devel
+    evr: 15.2.1-7.1.el9_8
+    sourcerpm: gcc-toolset-15-gcc-15.2.1-7.1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-toolset-15-runtime-15.0-9.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 54379
+    checksum: sha256:61549a047ab9510897119b3d7191be6f1a2d4ddaa45163a08e82daa0e653c0bf
+    name: gcc-toolset-15-runtime
+    evr: 15.0-9.el9
+    sourcerpm: gcc-toolset-15-15.0-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-2.52.0-1.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 5293286
+    checksum: sha256:6264aa556d583604f34def3674f5830a70cfee0aac283719e4df295db38acb53
+    name: git-core
+    evr: 2.52.0-1.el9
+    sourcerpm: git-2.52.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-274.el9_8.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 46571
+    checksum: sha256:e6176ffaf004619a3c4c6d69fc3499a90697cfea221c46e014d605e452bb859d
+    name: glibc-devel
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-274.el9_8.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 567160
+    checksum: sha256:98c8a2b2939f7decf299713dd4625c1ca1e8a3b536d6607db3cde04e32799bcd
+    name: glibc-headers
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.31.1.el9_8.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2901125
+    checksum: sha256:f9c558adfc811feb7c1d2461c5a0a4646bbf1b77e5cc079eb66cee6992b3d88d
+    name: kernel-headers
+    evr: 5.14.0-687.31.1.el9_8
+    sourcerpm: kernel-5.14.0-687.31.1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libedit-devel-3.1-39.20210216cvs.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 54318
+    checksum: sha256:2ffb25f591c2df48d9c2b189c925cc1d2930e998239a8aa21fefad852d22a6a9
+    name: libedit-devel
+    evr: 3.1-39.20210216cvs.el9
+    sourcerpm: libedit-3.1-39.20210216cvs.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 66075
+    checksum: sha256:b97b4e98c3c6f41dcfc2ceb4ffa1aba7a338b7cfd9e6c4f63e3160dd3cc033d3
+    name: libmpc
+    evr: 1.2.1-4.el9
+    sourcerpm: libmpc-1.2.1-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libomp-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 863958
+    checksum: sha256:8953b4c466290476f82836fa204bccef5760d01fe1120c8691c8aa8f42d35642
+    name: libomp
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libomp-devel-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 280569
+    checksum: sha256:c488e65e6a3298ec444eba093b0a40b2173633ff3953ac5f25f7da8ef593e1da
+    name: libomp-devel
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libstdc++-devel-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2524816
+    checksum: sha256:2d031d05fe073adc74919b8372763ae322615d9df23f4a2c642050ab4b389ce5
+    name: libstdc++-devel
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 154427
+    checksum: sha256:e1fab39251239ccaad2fb4dbe6c55ec1ae60f76d4ae81582b06e6a58e30879b2
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+    sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 33101
+    checksum: sha256:c1d171391a7d2e043a6953efd3df3e01edc9b4c6cdb54517e1608d204a5fce18
+    name: libxcrypt-devel
+    evr: 4.4.18-3.el9
+    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libzstd-devel-1.5.5-1.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 53219
+    checksum: sha256:5eff37e589fce787982840ace9bd4fa9a869287b186727be87d829e525e16624
+    name: libzstd-devel
+    evr: 1.5.5-1.el9
+    sourcerpm: zstd-1.5.5-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 25095576
+    checksum: sha256:f8c20cee6bf4384b2e7f878c4497471f93f2335e07a31fc692e479ed72301a12
+    name: llvm
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-devel-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 6395510
+    checksum: sha256:e921941858f2e6cea6665bbb12c3856d1f6fec2cad215538dcd1ad3a6652c64b
+    name: llvm-devel
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-filesystem-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 20224
+    checksum: sha256:b54fc55927e26da6954bbf9a396735a2a29383b15fe9e3d70b9d24cd90b1c500
+    name: llvm-filesystem
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-googletest-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 472823
+    checksum: sha256:67371a6df47643a3881eaeaf5ac490639953b14dd1b21b66fb73dc677e0f17df
+    name: llvm-googletest
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-libs-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 32586819
+    checksum: sha256:6c71c84a680f89a551b312eac90c9ae2899c3bdfaacdc809e39d7da968657d5a
+    name: llvm-libs
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-static-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 47099677
+    checksum: sha256:017f7ceabd6fd81e284b3506b220785b44928c852de13d0d1da1a07d6778d391
+    name: llvm-static
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-test-21.1.8-2.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 774709
+    checksum: sha256:e9461f6b89564ba94cc6bee94e480d6aeffd4bca4d913fea2f2a6d4e01677f5d
+    name: llvm-test
+    evr: 21.1.8-2.el9
+    sourcerpm: llvm-21.1.8-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/ncurses-c++-libs-6.2-12.20210508.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 38116
+    checksum: sha256:e9538f14a6430ca3a637ff753a421cb5ba6fae5594ad5178ce90b81d7be6a230
+    name: ncurses-c++-libs
+    evr: 6.2-12.20210508.el9
+    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/ncurses-devel-6.2-12.20210508.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 745592
+    checksum: sha256:c5edeb1aebfe38d19b91b493503efccbc8baebbef505023e114ee51547985a9d
+    name: ncurses-devel
+    evr: 6.2-12.20210508.el9
+    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/openssl-devel-3.5.5-6.el9_8.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 5029526
+    checksum: sha256:84e54b3467ecfe70c75688f28dbc0e071e268d845db17b28a1f35a35d45640cd
+    name: openssl-devel
+    evr: 1:3.5.5-6.el9_8
+    sourcerpm: openssl-3.5.5-6.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/policycoreutils-python-utils-3.6-5.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 84137
+    checksum: sha256:fae42a122e2848cfe99736012348f9c008c4d35e818e72e590e993e58d9858ad
+    name: policycoreutils-python-utils
+    evr: 3.6-5.el9
+    sourcerpm: policycoreutils-3.6-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-audit-3.1.5-8.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 90891
+    checksum: sha256:493229df98414e566fd0e16e06058e7902329f0b188ced24c8d434d2e097ec82
+    name: python3-audit
+    evr: 3.1.5-8.el9
+    sourcerpm: audit-3.1.5-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-distro-1.5.0-7.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 41452
+    checksum: sha256:5cf4276217a72649895226707d4c0e3edd6ea64b66702793fab3907177c73069
+    name: python3-distro
+    evr: 1.5.0-7.el9
+    sourcerpm: python-distro-1.5.0-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-libselinux-3.6-3.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 196472
+    checksum: sha256:7af821a0ee7c7b56df79de25fe35cc2d0fd6f45df5c3bcec2c5e72d7378ba265
+    name: python3-libselinux
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-libsemanage-3.6-5.el9_6.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 82730
+    checksum: sha256:8a17df19f0ff5dbb98fe608999cb2370983d8565658df01d0993b3028cbf28d6
+    name: python3-libsemanage
+    evr: 3.6-5.el9_6
+    sourcerpm: libsemanage-3.6-5.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-policycoreutils-3.6-5.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2219410
+    checksum: sha256:eb5d83e26cee47b23b4b802d98cae521f41d8d0d8451a9e5029cd9b5016dd00b
+    name: python3-policycoreutils
+    evr: 3.6-5.el9
+    sourcerpm: policycoreutils-3.6-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-1.92.0-1.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 31511504
+    checksum: sha256:fbc70b11f38999206d70a104789d1f7f21ca9f9090c7a73d6db337bff4f5205b
+    name: rust
+    evr: 1.92.0-1.el9
+    sourcerpm: rust-1.92.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-std-static-1.92.0-1.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 42991765
+    checksum: sha256:d286394aaa75a796a06db130d2a980bee8e6ab4cbaa38a3b84e12379fbae4671
+    name: rust-std-static
+    evr: 1.92.0-1.el9
+    sourcerpm: rust-1.92.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 42223
+    checksum: sha256:164d245bec95c7dcbba881fd88ee567bc6d5859329c91ae05a6ad5429700bdbc
+    name: scl-utils
+    evr: 1:2.0.3-4.el9
+    sourcerpm: scl-utils-2.0.3-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/audit-libs-3.1.5-8.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 130600
+    checksum: sha256:637ac2995ce1a6c222772b60f6bc6e6f2829355d2c88dfb1262fb76146d985ae
+    name: audit-libs
+    evr: 3.1.5-8.el9
+    sourcerpm: audit-3.1.5-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-72.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 4821853
+    checksum: sha256:bda706d43bf47267e31db8ac62fe3206122f97ff035daa6c93ce9cd5063a63ca
+    name: binutils
+    evr: 2.35.2-72.el9
+    sourcerpm: binutils-2.35.2-72.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 758393
+    checksum: sha256:4d429d1030d8e1c610ba5aea83f8c63090033f440b2c8f788f0e0acd4a3c51b3
+    name: binutils-gold
+    evr: 2.35.2-72.el9
+    sourcerpm: binutils-2.35.2-72.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/diffutils-3.7-12.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 411559
+    checksum: sha256:2d4c4fdfc10215af3c957c24995b79a26e27e6d76de4ed1f5198d25bf7ef9671
+    name: diffutils
+    evr: 3.7-12.el9
+    sourcerpm: diffutils-3.7-12.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 43826
+    checksum: sha256:1635fd1ecaa9492fa925956dfd56d10063ca336619218f124ab45df0a38b41b0
+    name: elfutils-debuginfod-client
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 205864
+    checksum: sha256:00bbe4776149d8ccedcdf19dd6ceb08c3bb42ff41b98d744abe101af0b11a6c5
+    name: elfutils-libelf
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 274670
+    checksum: sha256:ad4f6d425cbc975cead56a2c982e38b0146d00944cbd9b3072d3d1f1271237a5
+    name: elfutils-libs
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/environment-modules-5.3.0-2.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 604214
+    checksum: sha256:abee5229dce8c09f567626c0a6d741e8e3b30f8fd54d860365a25bec901cd680
+    name: environment-modules
+    evr: 5.3.0-2.el9
+    sourcerpm: environment-modules-5.3.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-2.34-274.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 2083155
+    checksum: sha256:3a68581527ea2aa67a57610951bd9722019cc32db691cace00dc7478cab312ec
+    name: glibc
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-common-2.34-274.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 321676
+    checksum: sha256:d741ab036ed8b97022052adb291a749a0ca1d5e492bd906aa7da95af9866bd2b
+    name: glibc-common
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-langpack-en-2.34-274.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 684459
+    checksum: sha256:1491343a7653599e4fbea03780731c6777df85dc998bafb237658cde3728b663
+    name: glibc-langpack-en
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-274.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 30969
+    checksum: sha256:da6b677193283cedf470f17894638ef1a633c114e4b51464c49548a19166a68e
+    name: glibc-minimal-langpack
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 1133828
+    checksum: sha256:4d8ff13569b3b231b3fb847e9e22615c6e08215d1f2c0c78eac2e345b9efd394
+    name: groff-base
+    evr: 1.22.4-10.el9
+    sourcerpm: groff-1.22.4-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/i/info-6.7-15.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 233806
+    checksum: sha256:3643f98b45cc973073096608aaa45976d722fe284590ff7c1d5f93ad77ba0f8b
+    name: info
+    evr: 6.7-15.el9
+    sourcerpm: texinfo-6.7-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/j/jansson-2.14-1.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 49137
+    checksum: sha256:4e9aec51ee46d7265d6edd1245b5d5ab5e8336dc2a4ca17f2cace2ce8bae3761
+    name: jansson
+    evr: 2.14-1.el9
+    sourcerpm: jansson-2.14-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/less-590-6.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 166025
+    checksum: sha256:5bd040f9dd813167935fc390d546c119d90e0a9c77447a3d9ed1ef69c6f5a32a
+    name: less
+    evr: 590-6.el9
+    sourcerpm: less-590-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libatomic-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 23497
+    checksum: sha256:737264639167a5806a10f2057d77f5a47f38931a83518218dc40f5d8392f1c2b
+    name: libatomic
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 60575
+    checksum: sha256:588e8736af3376abfb3cdf372c10baef02c40d916a55958f3bee9767f9ad8526
+    name: libcbor
+    evr: 0.7.0-5.el9
+    sourcerpm: libcbor-0.7.0-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 112056
+    checksum: sha256:65a730688dfea27934b75af3acf30150c6d254c89d8b68b63233ae7f8b6c9b94
+    name: libedit
+    evr: 3.1-39.20210216cvs.el9
+    sourcerpm: libedit-3.1-39.20210216cvs.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 102746
+    checksum: sha256:6da940c0528f3e4453db84cb85b402c8f4293a197b1921158df9651edb4845e0
+    name: libfido2
+    evr: 1.13.0-2.el9
+    sourcerpm: libfido2-1.13.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgcc-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 87280
+    checksum: sha256:77c66827ffc14df2f43612b26128b1fd58d5c9597d4d4e564aa239b161272872
+    name: libgcc
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgfortran-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 813380
+    checksum: sha256:11d2f1c6c2ca35bdf7e866e80615d17d10601bc512905c8ef4f74ff8b0a3015a
+    name: libgfortran
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 263723
+    checksum: sha256:87b9a7316760374111290e6e4c76ee4d093566f08a7c7c91ad7827c5948afb69
+    name: libgomp
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 52912
+    checksum: sha256:c972030a8fbaa2d981f0e5fdfc42d6d5173dd047c94d86ab7732e3e53fc4e97a
+    name: libpipeline
+    evr: 1.5.3-4.el9
+    sourcerpm: libpipeline-1.5.3-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 38387
+    checksum: sha256:4feae5941b73640bd86b8d506a657cac5b770043db1464fbcd207721b2159dda
+    name: libpkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libquadmath-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 188925
+    checksum: sha256:6fd5a850dc8e0a5b17c95089a8da0319beb8bf6ba68b633366d509458b332448
+    name: libquadmath
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 198410
+    checksum: sha256:e5d79885864cd5b2a307065b43ba1af1523ec7ac26eace2717c70ede1b6e4c56
+    name: libselinux-utils
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libstdc++-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 763021
+    checksum: sha256:513df35338962e053052b9d52429e8a5f3d60dfe6b1757cd9faaf61d6abda955
+    name: libstdc++
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 553896
+    checksum: sha256:561f0c2251e9217c81a6c88de4d2d9231a039aaab37e8a0d2559d36ce9fa85fd
+    name: make
+    evr: 1:4.3-8.el9
+    sourcerpm: make-4.3-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/man-db-2.9.3-9.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 1239738
+    checksum: sha256:e808c97dbacfb05e1d9096fb062e1851201307ac80b63f57b561c9234141f550
+    name: man-db
+    evr: 2.9.3-9.el9
+    sourcerpm: man-db-2.9.3-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-base-6.2-12.20210508.el9.noarch.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 97840
+    checksum: sha256:d62dfd41f9688efa2cf1ceedb96084c63e297fbdcfd1e72bc6757c730092b60c
+    name: ncurses-base
+    evr: 6.2-12.20210508.el9
+    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-libs-6.2-12.20210508.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 336270
+    checksum: sha256:f3e1f8e59c7116278aa19b6705a1443f6307d4d6fbdde75a23d2f5d60636cb16
+    name: ncurses-libs
+    evr: 6.2-12.20210508.el9
+    sourcerpm: ncurses-6.2-12.20210508.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-9.9p1-7.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 442163
+    checksum: sha256:e699c3fd161d4741658320f10064bb82ab7530d07d3d34850142ccc102ce7c82
+    name: openssh
+    evr: 9.9p1-7.el9_8
+    sourcerpm: openssh-9.9p1-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-clients-9.9p1-7.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 798466
+    checksum: sha256:5663973f870ce57e55bb94e94b84ff020d6b24cbaabdca9fed99665f6513c847
+    name: openssh-clients
+    evr: 9.9p1-7.el9_8
+    sourcerpm: openssh-9.9p1-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.5.5-6.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 1564334
+    checksum: sha256:1c502507f42674119318b66b111448f618efe2767a55edde5fadddcecb47ac64
+    name: openssl
+    evr: 1:3.5.5-6.el9_8
+    sourcerpm: openssl-3.5.5-6.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 14256
+    checksum: sha256:c00860e9c5a1d90488aa2eb65fe41f62926b38c6b3669d331a8b97e4a60223ac
+    name: openssl-fips-provider
+    evr: 3.0.7-11.el9_8
+    sourcerpm: openssl-fips-provider-3.0.7-11.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 595008
+    checksum: sha256:60d36ad3a67d6b00e67bb0a19c0902fbb2ecdd873cf7f280a3039d04a092790c
+    name: openssl-fips-provider-so
+    evr: 3.0.7-11.el9_8
+    sourcerpm: openssl-fips-provider-3.0.7-11.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-libs-3.5.5-6.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 2427181
+    checksum: sha256:a289cdf4da547031cd39a4f31decd0bb22649bbcb5fe4f88b939d341a83708be
+    name: openssl-libs
+    evr: 1:3.5.5-6.el9_8
+    sourcerpm: openssl-3.5.5-6.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 45675
+    checksum: sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26
+    name: pkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 16054
+    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
+    name: pkgconf-m4
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 12438
+    checksum: sha256:9a502d81d73d3303ceb53a06ad7ce525c97117ea64352174a33708bf3429283d
+    name: pkgconf-pkg-config
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/policycoreutils-3.6-5.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 250930
+    checksum: sha256:fffd2206493e48409306c0494f53a549fb5e2944a7f53ad7377ed76a4b28f671
+    name: policycoreutils
+    evr: 3.6-5.el9
+    sourcerpm: policycoreutils-3.6-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 361526
+    checksum: sha256:506ad778f63821e8d9647ca8e0a3ff21b8af9c1666060d5200f9b26ee718333c
+    name: procps-ng
+    evr: 3.3.17-14.el9
+    sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setools-4.4.4-1.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 623460
+    checksum: sha256:91946d729d2b03b4abe1c43962f22d110468db0163241cda7b1d549c615d0261
+    name: python3-setools
+    evr: 4.4.4-1.el9
+    sourcerpm: setools-4.4.4-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tcl-8.6.10-7.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 1152092
+    checksum: sha256:2062dce4bed26d3684de4dad68f32307ebacf5c7d50d3aa7bf6470e66fb36df5
+    name: tcl
+    evr: 1:8.6.10-7.el9
+    sourcerpm: tcl-8.6.10-7.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.10.noarch.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 22399
+    checksum: sha256:9fc9ef3ba0b22a599b2a7b34bd0b025afd5f2623e9132b4ead19e98f9c62e97d
+    name: vim-filesystem
+    evr: 2:8.2.2637-26.el9_8.10
+    sourcerpm: vim-8.2.2637-26.el9_8.10.src.rpm
+  source: []
+  module_metadata: []

--- a/deploy/konflux/supervisor/generic-fetcher.yaml
+++ b/deploy/konflux/supervisor/generic-fetcher.yaml
@@ -1,0 +1,32 @@
+# Generic fetcher artifacts for Dockerfile.konflux.supervisor
+# These are prefetched by Hermeto and mounted at /cachi2/deps/generic/
+# Include in prefetch-input alongside cargo and rpm types.
+#
+# To update hashes: curl -sL <url> | sha256sum
+metadata:
+  version: "1.0"
+artifacts:
+  # musl libc source (arch-independent, built from source in Dockerfile)
+  - download_url: https://musl.libc.org/releases/musl-1.2.5.tar.gz
+    checksum: "sha256:a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4"
+    filename: musl-1.2.5.tar.gz
+
+  # Rust toolchain x86_64
+  - download_url: https://static.rust-lang.org/dist/rust-1.92.0-x86_64-unknown-linux-gnu.tar.xz
+    checksum: "sha256:d2ccef59dd9f7439f2c694948069f789a044dc1addcc0803613232af8f88ee0c"
+    filename: rust-1.92.0-x86_64-unknown-linux-gnu.tar.xz
+
+  # Rust toolchain aarch64
+  - download_url: https://static.rust-lang.org/dist/rust-1.92.0-aarch64-unknown-linux-gnu.tar.xz
+    checksum: "sha256:3e383f8b4fca710d0600d0c1de97b78281672be2cda6575ecbe1c183a12e3822"
+    filename: rust-1.92.0-aarch64-unknown-linux-gnu.tar.xz
+
+  # rust-std for musl target x86_64
+  - download_url: https://static.rust-lang.org/dist/rust-std-1.92.0-x86_64-unknown-linux-musl.tar.xz
+    checksum: "sha256:11f0b7efccdb5e7972e3c0fc23693a487abc28b624675c08161d055a016d527e"
+    filename: rust-std-1.92.0-x86_64-unknown-linux-musl.tar.xz
+
+  # rust-std for musl target aarch64
+  - download_url: https://static.rust-lang.org/dist/rust-std-1.92.0-aarch64-unknown-linux-musl.tar.xz
+    checksum: "sha256:94b9f84f21d29825c55a27fbb6b4b9fb9296a4a841aa54d85b95c42445623363"
+    filename: rust-std-1.92.0-aarch64-unknown-linux-musl.tar.xz

--- a/deploy/konflux/supervisor/rpms.in.yaml
+++ b/deploy/konflux/supervisor/rpms.in.yaml
@@ -1,0 +1,29 @@
+# RPM dependencies for Dockerfile.konflux.supervisor
+# Build + runtime stages combined. Generate lockfile with:
+#   rpm-lockfile-prototype --containerfile deploy/docker/Dockerfile.konflux.supervisor \
+#       --arch x86_64 \
+#       --outfile deploy/konflux/supervisor/rpms.lock.yaml \
+#       deploy/konflux/supervisor/rpms.in.yaml
+#
+contentOrigin:
+  repofiles:
+    - /etc/yum.repos.d/ubi.repo
+packages:
+  # Build stage: musl toolchain build
+  - gcc
+  - make
+  - tar
+  - gzip
+  - xz
+  # Build stage: Rust compilation (rustup provides rust/cargo)
+  - gcc-c++
+  - cmake
+  - openssl-devel
+  - git-core
+  # Runtime stage: network enforcement
+  - nftables
+  - iptables-nft
+  # Runtime stage: network namespace setup
+  - iproute
+  # Runtime stage: namespace entry
+  - util-linux-core

--- a/deploy/konflux/supervisor/rpms.lock.yaml
+++ b/deploy/konflux/supervisor/rpms.lock.yaml
@@ -1,0 +1,717 @@
+arches:
+- arch: x86_64
+  packages:
+  - evra: 2.4.0-1.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/acl-2.4.0-1.el9_8.x86_64.rpm
+  - evra: 1.24-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/alternatives-1.24-2.el9.x86_64.rpm
+  - evra: 3.1.5-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/audit-libs-3.1.5-8.el9.x86_64.rpm
+  - evra: 11-13.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/basesystem-11-13.el9.noarch.rpm
+  - evra: 5.1.8-9.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/bash-5.1.8-9.el9.x86_64.rpm
+  - evra: 2.35.2-72.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-72.el9.x86_64.rpm
+  - evra: 2.35.2-72.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.x86_64.rpm
+  - evra: 1.0.8-11.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/bzip2-libs-1.0.8-11.el9.x86_64.rpm
+  - evra: 2025.2.80_v9.0.305-91.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.noarch.rpm
+  - evra: 3.31.8-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-3.31.8-3.el9.x86_64.rpm
+  - evra: 3.31.8-3.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-data-3.31.8-3.el9.noarch.rpm
+  - evra: 3.31.8-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-filesystem-3.31.8-3.el9.x86_64.rpm
+  - evra: 3.31.8-3.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-rpm-macros-3.31.8-3.el9.noarch.rpm
+  - evra: 8.32-41.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.x86_64.rpm
+  - evra: 8.32-41.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.x86_64.rpm
+  - evra: 8.32-41.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-single-8.32-41.el9_8.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cpp-11.5.0-14.el9.x86_64.rpm
+  - evra: 2.9.6-28.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cracklib-2.9.6-28.el9.x86_64.rpm
+  - evra: 2.9.6-28.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-28.el9.x86_64.rpm
+  - evra: 20260224-1.gitea0f072.el9_8.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/crypto-policies-20260224-1.gitea0f072.el9_8.noarch.rpm
+  - evra: 2.8.1-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cryptsetup-libs-2.8.1-3.el9.x86_64.rpm
+  - evra: 7.76.1-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/curl-7.76.1-40.el9.x86_64.rpm
+  - evra: 7.76.1-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/curl-minimal-7.76.1-40.el9.x86_64.rpm
+  - evra: 2.1.27-22.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-22.el9.x86_64.rpm
+  - evra: 1.12.20-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-1.12.20-8.el9.x86_64.rpm
+  - evra: 28-7.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-broker-28-7.el9.x86_64.rpm
+  - evra: 1.12.20-8.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
+  - evra: 1.02.207-4.el9_8.1.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/device-mapper-1.02.207-4.el9_8.1.x86_64.rpm
+  - evra: 1.02.207-4.el9_8.1.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/device-mapper-libs-1.02.207-4.el9_8.1.x86_64.rpm
+  - evra: 0.194-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.x86_64.rpm
+  - evra: 0.194-1.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-default-yama-scope-0.194-1.el9.noarch.rpm
+  - evra: 0.194-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.x86_64.rpm
+  - evra: 0.194-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.x86_64.rpm
+  - evra: 27.2-18.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
+  - evra: 2.5.0-6.el9_8.1.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/expat-2.5.0-6.el9_8.1.x86_64.rpm
+  - evra: 3.16-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/filesystem-3.16-5.el9.x86_64.rpm
+  - evra: 4.8.0-7.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/findutils-4.8.0-7.el9.x86_64.rpm
+  - evra: 1.2.0-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fips-provider-next-1.2.0-5.el9.x86_64.rpm
+  - evra: 5.1.0-6.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gawk-5.1.0-6.el9.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-11.5.0-14.el9.x86_64.rpm
+  - evra: 1.23-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-all-langpacks-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-common-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-langpack-en-2.34-274.el9_8.x86_64.rpm
+  - evra: 2.34-274.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-274.el9_8.x86_64.rpm
+  - evra: 6.2.0-13.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gmp-6.2.0-13.el9.x86_64.rpm
+  - evra: 3.6-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/grep-3.6-5.el9.x86_64.rpm
+  - evra: 1.12-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
+  - evra: 1.8.10-11.el9_5.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/i/iptables-libs-1.8.10-11.el9_5.x86_64.rpm
+  - evra: 2.14-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/j/jansson-2.14-1.el9.x86_64.rpm
+  - evra: 0.14-11.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/j/json-c-0.14-11.el9.x86_64.rpm
+  - evra: 2.4.0-11.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kbd-2.4.0-11.el9.x86_64.rpm
+  - evra: 2.4.0-11.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kbd-legacy-2.4.0-11.el9.noarch.rpm
+  - evra: 2.4.0-11.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kbd-misc-2.4.0-11.el9.noarch.rpm
+  - evra: 5.14.0-687.30.1.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.30.1.el9_8.x86_64.rpm
+  - evra: 1.6.3-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/keyutils-libs-1.6.3-1.el9.x86_64.rpm
+  - evra: 28-11.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kmod-28-11.el9.x86_64.rpm
+  - evra: 28-11.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kmod-libs-28-11.el9.x86_64.rpm
+  - evra: 1.21.1-10.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/krb5-libs-1.21.1-10.el9_8.x86_64.rpm
+  - evra: 590-6.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/less-590-6.el9.x86_64.rpm
+  - evra: 2.4.0-1.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libacl-2.4.0-1.el9_8.x86_64.rpm
+  - evra: 3.5.3-9.el9_7.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libarchive-3.5.3-9.el9_7.x86_64.rpm
+  - evra: 2.5.1-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libattr-2.5.1-3.el9.x86_64.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libblkid-2.37.4-25.el9.x86_64.rpm
+  - evra: 1.5.0-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libbpf-1.5.0-3.el9.x86_64.rpm
+  - evra: 1.0.9-9.el9_7.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libbrotli-1.0.9-9.el9_7.x86_64.rpm
+  - evra: 2.48-10.el9_8.1.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcap-2.48-10.el9_8.1.x86_64.rpm
+  - evra: 0.8.2-7.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcap-ng-0.8.2-7.el9.x86_64.rpm
+  - evra: 0.7.0-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.x86_64.rpm
+  - evra: 1.46.5-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcom_err-1.46.5-8.el9.x86_64.rpm
+  - evra: 7.76.1-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcurl-7.76.1-40.el9.x86_64.rpm
+  - evra: 7.76.1-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcurl-minimal-7.76.1-40.el9.x86_64.rpm
+  - evra: 5.3.28-57.el9_6.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.x86_64.rpm
+  - evra: 0.4.1-7.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libeconf-0.4.1-7.el9_8.x86_64.rpm
+  - evra: 3.1-39.20210216cvs.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.x86_64.rpm
+  - evra: 2.1.12-8.el9_4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libevent-2.1.12-8.el9_4.x86_64.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfdisk-2.37.4-25.el9.x86_64.rpm
+  - evra: 3.4.2-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libffi-3.4.2-8.el9.x86_64.rpm
+  - evra: 1.13.0-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgcc-11.5.0-14.el9.x86_64.rpm
+  - evra: 1.10.0-11.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.x86_64.rpm
+  - evra: 1.42-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgpg-error-1.42-5.el9.x86_64.rpm
+  - evra: 2.3.0-7.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libidn2-2.3.0-7.el9.x86_64.rpm
+  - evra: 1.0.4-16.el9_4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libmnl-1.0.4-16.el9_4.x86_64.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libmount-2.37.4-25.el9.x86_64.rpm
+  - evra: 1.2.1-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
+  - evra: 1.0.9-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.x86_64.rpm
+  - evra: 1.0.1-23.el9_5.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnfnetlink-1.0.1-23.el9_5.x86_64.rpm
+  - evra: 1.2.6-4.el9_4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnftnl-1.2.6-4.el9_4.x86_64.rpm
+  - evra: 1.43.0-6.el9_8.1.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9_8.1.x86_64.rpm
+  - evra: 1.7.3-10.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
+  - evra: 0.21.1-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpsl-0.21.1-5.el9.x86_64.rpm
+  - evra: 1.4.4-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.x86_64.rpm
+  - evra: 2.5.2-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
+  - evra: 3.6-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libselinux-3.6-3.el9.x86_64.rpm
+  - evra: 3.6-5.el9_6.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.x86_64.rpm
+  - evra: 3.6-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsepol-3.6-3.el9.x86_64.rpm
+  - evra: 2.13-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsigsegv-2.13-4.el9.x86_64.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsmartcols-2.37.4-25.el9.x86_64.rpm
+  - evra: 0.10.4-18.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libssh-0.10.4-18.el9.x86_64.rpm
+  - evra: 0.10.4-18.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libssh-config-0.10.4-18.el9.noarch.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libstdc++-11.5.0-14.el9.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libstdc++-devel-11.5.0-14.el9.x86_64.rpm
+  - evra: 4.16.0-10.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libtasn1-4.16.0-10.el9_8.x86_64.rpm
+  - evra: 2.4.6-46.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libtool-ltdl-2.4.6-46.el9.x86_64.rpm
+  - evra: 0.9.10-15.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libunistring-0.9.10-15.el9.x86_64.rpm
+  - evra: 1.2.1-6.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.x86_64.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libuuid-2.37.4-25.el9.x86_64.rpm
+  - evra: 1.42.0-2.el9_4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.x86_64.rpm
+  - evra: 0.3.2-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libverto-0.3.2-3.el9.x86_64.rpm
+  - evra: 4.4.18-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libxcrypt-4.4.18-3.el9.x86_64.rpm
+  - evra: 4.4.18-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.x86_64.rpm
+  - evra: 2.9.13-14.el9_8.2.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libxml2-2.9.13-14.el9_8.2.x86_64.rpm
+  - evra: 1.5.5-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libzstd-1.5.5-1.el9.x86_64.rpm
+  - evra: 5.4.4-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/lua-libs-5.4.4-4.el9.x86_64.rpm
+  - evra: 1.9.3-5.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/lz4-libs-1.9.3-5.el9.x86_64.rpm
+  - evra: 4.3-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
+  - evra: 4.1.0-10.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/mpfr-4.1.0-10.el9.x86_64.rpm
+  - evra: 6.2-12.20210508.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-base-6.2-12.20210508.el9.noarch.rpm
+  - evra: 6.2-12.20210508.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-libs-6.2-12.20210508.el9.x86_64.rpm
+  - evra: 2.6.8-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openldap-2.6.8-4.el9.x86_64.rpm
+  - evra: 9.9p1-7.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-9.9p1-7.el9_8.x86_64.rpm
+  - evra: 9.9p1-7.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-clients-9.9p1-7.el9_8.x86_64.rpm
+  - evra: 3.5.5-5.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.5.5-5.el9_8.x86_64.rpm
+  - evra: 3.5.5-5.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/openssl-devel-3.5.5-5.el9_8.x86_64.rpm
+  - evra: 3.0.7-11.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_8.x86_64.rpm
+  - evra: 3.0.7-11.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_8.x86_64.rpm
+  - evra: 3.5.5-5.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-libs-3.5.5-5.el9_8.x86_64.rpm
+  - evra: 0.26.2-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/p11-kit-0.26.2-1.el9.x86_64.rpm
+  - evra: 0.26.2-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/p11-kit-trust-0.26.2-1.el9.x86_64.rpm
+  - evra: 1.5.1-28.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pam-1.5.1-28.el9.x86_64.rpm
+  - evra: 8.44-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pcre-8.44-4.el9.x86_64.rpm
+  - evra: 10.40-6.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pcre2-10.40-6.el9.x86_64.rpm
+  - evra: 10.40-6.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pcre2-syntax-10.40-6.el9.noarch.rpm
+  - evra: 1.7.3-10.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
+  - evra: 1.7.3-10.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+  - evra: 1.7.3-10.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
+  - evra: 1.18-8.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/popt-1.18-8.el9.x86_64.rpm
+  - evra: 23.4-3.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/psmisc-23.4-3.el9.x86_64.rpm
+  - evra: 20210518-3.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/publicsuffix-list-dafsa-20210518-3.el9.noarch.rpm
+  - evra: 3.9.25-7.el9_8.2.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-3.9.25-7.el9_8.2.x86_64.rpm
+  - evra: 3.9.25-7.el9_8.2.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-libs-3.9.25-7.el9_8.2.x86_64.rpm
+  - evra: 21.3.1-2.el9_8.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-2.el9_8.noarch.rpm
+  - evra: 53.0.0-15.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-15.el9.noarch.rpm
+  - evra: 8.1-4.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/readline-8.1-4.el9.x86_64.rpm
+  - evra: 9.8-1.0.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/redhat-release-9.8-1.0.el9.x86_64.rpm
+  - evra: 4.16.1.3-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rpm-4.16.1.3-40.el9.x86_64.rpm
+  - evra: 4.16.1.3-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rpm-libs-4.16.1.3-40.el9.x86_64.rpm
+  - evra: 4.8-10.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/sed-4.8-10.el9.x86_64.rpm
+  - evra: 2.13.7-10.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/setup-2.13.7-10.el9.noarch.rpm
+  - evra: 4.9-16.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/shadow-utils-4.9-16.el9.x86_64.rpm
+  - evra: 3.34.1-10.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.x86_64.rpm
+  - evra: 252-67.el9_8.4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-252-67.el9_8.4.x86_64.rpm
+  - evra: 252-67.el9_8.4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-libs-252-67.el9_8.4.x86_64.rpm
+  - evra: 252-67.el9_8.4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-pam-252-67.el9_8.4.x86_64.rpm
+  - evra: 252-67.el9_8.4.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-67.el9_8.4.noarch.rpm
+  - evra: 252-67.el9_8.4.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-udev-252-67.el9_8.4.x86_64.rpm
+  - evra: 3.2.3-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.x86_64.rpm
+  - evra: 2026b-1.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tzdata-2026b-1.el9.noarch.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/util-linux-2.37.4-25.el9.x86_64.rpm
+  - evra: 2.37.4-25.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/util-linux-core-2.37.4-25.el9.x86_64.rpm
+  - evra: 8.2.2637-26.el9_8.10.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.10.noarch.rpm
+  - evra: 5.2.5-8.el9_0.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.x86_64.rpm
+  - evra: 1.2.11-40.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/z/zlib-1.2.11-40.el9.x86_64.rpm
+  - evra: 11.5.0-14.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-c++-11.5.0-14.el9.x86_64.rpm
+  - evra: 2.52.0-1.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-2.52.0-1.el9.x86_64.rpm
+  - evra: 6.17.0-2.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/i/iproute-6.17.0-2.el9.x86_64.rpm
+  - evra: 1.8.10-11.el9_5.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/i/iptables-nft-1.8.10-11.el9_5.x86_64.rpm
+  - evra: 1.0.9-7.el9_8.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/nftables-1.0.9-7.el9_8.x86_64.rpm
+  - evra: 1.34-11.el9.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tar-1.34-11.el9.x86_64.rpm
+  - evra: 5.2.5-8.el9_0.x86_64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.x86_64.rpm
+  source: []
+- arch: aarch64
+  packages:
+  - evra: 2.4.0-1.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/acl-2.4.0-1.el9_8.aarch64.rpm
+  - evra: 1.24-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/alternatives-1.24-2.el9.aarch64.rpm
+  - evra: 3.1.5-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/audit-libs-3.1.5-8.el9.aarch64.rpm
+  - evra: 11-13.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/basesystem-11-13.el9.noarch.rpm
+  - evra: 5.1.8-9.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/bash-5.1.8-9.el9.aarch64.rpm
+  - evra: 2.35.2-72.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-2.35.2-72.el9.aarch64.rpm
+  - evra: 2.35.2-72.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.aarch64.rpm
+  - evra: 1.0.8-11.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/bzip2-libs-1.0.8-11.el9.aarch64.rpm
+  - evra: 2025.2.80_v9.0.305-91.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.noarch.rpm
+  - evra: 3.31.8-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-3.31.8-3.el9.aarch64.rpm
+  - evra: 3.31.8-3.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-data-3.31.8-3.el9.noarch.rpm
+  - evra: 3.31.8-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-filesystem-3.31.8-3.el9.aarch64.rpm
+  - evra: 3.31.8-3.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-rpm-macros-3.31.8-3.el9.noarch.rpm
+  - evra: 8.32-41.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.aarch64.rpm
+  - evra: 8.32-41.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.aarch64.rpm
+  - evra: 8.32-41.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-single-8.32-41.el9_8.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cpp-11.5.0-14.el9.aarch64.rpm
+  - evra: 2.9.6-28.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cracklib-2.9.6-28.el9.aarch64.rpm
+  - evra: 2.9.6-28.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cracklib-dicts-2.9.6-28.el9.aarch64.rpm
+  - evra: 20260224-1.gitea0f072.el9_8.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/crypto-policies-20260224-1.gitea0f072.el9_8.noarch.rpm
+  - evra: 2.8.1-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cryptsetup-libs-2.8.1-3.el9.aarch64.rpm
+  - evra: 7.76.1-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/curl-7.76.1-40.el9.aarch64.rpm
+  - evra: 7.76.1-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/curl-minimal-7.76.1-40.el9.aarch64.rpm
+  - evra: 2.1.27-22.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-22.el9.aarch64.rpm
+  - evra: 1.12.20-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-1.12.20-8.el9.aarch64.rpm
+  - evra: 28-7.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-broker-28-7.el9.aarch64.rpm
+  - evra: 1.12.20-8.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
+  - evra: 1.02.207-4.el9_8.1.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/device-mapper-1.02.207-4.el9_8.1.aarch64.rpm
+  - evra: 1.02.207-4.el9_8.1.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/device-mapper-libs-1.02.207-4.el9_8.1.aarch64.rpm
+  - evra: 0.194-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.aarch64.rpm
+  - evra: 0.194-1.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-default-yama-scope-0.194-1.el9.noarch.rpm
+  - evra: 0.194-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.aarch64.rpm
+  - evra: 0.194-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.aarch64.rpm
+  - evra: 27.2-18.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
+  - evra: 2.5.0-6.el9_8.1.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/expat-2.5.0-6.el9_8.1.aarch64.rpm
+  - evra: 3.16-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/filesystem-3.16-5.el9.aarch64.rpm
+  - evra: 4.8.0-7.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/findutils-4.8.0-7.el9.aarch64.rpm
+  - evra: 1.2.0-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fips-provider-next-1.2.0-5.el9.aarch64.rpm
+  - evra: 5.1.0-6.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gawk-5.1.0-6.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-11.5.0-14.el9.aarch64.rpm
+  - evra: 1.23-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-2.34-274.el9_8.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-all-langpacks-2.34-274.el9_8.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-common-2.34-274.el9_8.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/glibc-devel-2.34-274.el9_8.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-gconv-extra-2.34-274.el9_8.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-langpack-en-2.34-274.el9_8.aarch64.rpm
+  - evra: 2.34-274.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-274.el9_8.aarch64.rpm
+  - evra: 6.2.0-13.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gmp-6.2.0-13.el9.aarch64.rpm
+  - evra: 3.6-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/grep-3.6-5.el9.aarch64.rpm
+  - evra: 1.12-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gzip-1.12-1.el9.aarch64.rpm
+  - evra: 1.8.10-11.el9_5.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/i/iptables-libs-1.8.10-11.el9_5.aarch64.rpm
+  - evra: 2.14-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/j/jansson-2.14-1.el9.aarch64.rpm
+  - evra: 0.14-11.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/j/json-c-0.14-11.el9.aarch64.rpm
+  - evra: 2.4.0-11.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kbd-2.4.0-11.el9.aarch64.rpm
+  - evra: 2.4.0-11.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kbd-legacy-2.4.0-11.el9.noarch.rpm
+  - evra: 2.4.0-11.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kbd-misc-2.4.0-11.el9.noarch.rpm
+  - evra: 5.14.0-687.31.1.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.31.1.el9_8.aarch64.rpm
+  - evra: 1.6.3-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/keyutils-libs-1.6.3-1.el9.aarch64.rpm
+  - evra: 28-11.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kmod-28-11.el9.aarch64.rpm
+  - evra: 28-11.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kmod-libs-28-11.el9.aarch64.rpm
+  - evra: 1.21.1-10.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/krb5-libs-1.21.1-10.el9_8.aarch64.rpm
+  - evra: 590-6.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/less-590-6.el9.aarch64.rpm
+  - evra: 2.4.0-1.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libacl-2.4.0-1.el9_8.aarch64.rpm
+  - evra: 3.5.3-9.el9_7.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libarchive-3.5.3-9.el9_7.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libasan-11.5.0-14.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libatomic-11.5.0-14.el9.aarch64.rpm
+  - evra: 2.5.1-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libattr-2.5.1-3.el9.aarch64.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libblkid-2.37.4-25.el9.aarch64.rpm
+  - evra: 1.5.0-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libbpf-1.5.0-3.el9.aarch64.rpm
+  - evra: 1.0.9-9.el9_7.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libbrotli-1.0.9-9.el9_7.aarch64.rpm
+  - evra: 2.48-10.el9_8.1.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcap-2.48-10.el9_8.1.aarch64.rpm
+  - evra: 0.8.2-7.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcap-ng-0.8.2-7.el9.aarch64.rpm
+  - evra: 0.7.0-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.aarch64.rpm
+  - evra: 1.46.5-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcom_err-1.46.5-8.el9.aarch64.rpm
+  - evra: 7.76.1-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcurl-7.76.1-40.el9.aarch64.rpm
+  - evra: 7.76.1-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcurl-minimal-7.76.1-40.el9.aarch64.rpm
+  - evra: 5.3.28-57.el9_6.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.aarch64.rpm
+  - evra: 0.4.1-7.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libeconf-0.4.1-7.el9_8.aarch64.rpm
+  - evra: 3.1-39.20210216cvs.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.aarch64.rpm
+  - evra: 2.1.12-8.el9_4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libevent-2.1.12-8.el9_4.aarch64.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libfdisk-2.37.4-25.el9.aarch64.rpm
+  - evra: 3.4.2-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libffi-3.4.2-8.el9.aarch64.rpm
+  - evra: 1.13.0-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgcc-11.5.0-14.el9.aarch64.rpm
+  - evra: 1.10.0-11.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.aarch64.rpm
+  - evra: 1.42-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgpg-error-1.42-5.el9.aarch64.rpm
+  - evra: 2.3.0-7.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libidn2-2.3.0-7.el9.aarch64.rpm
+  - evra: 1.0.4-16.el9_4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libmnl-1.0.4-16.el9_4.aarch64.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libmount-2.37.4-25.el9.aarch64.rpm
+  - evra: 1.2.1-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.aarch64.rpm
+  - evra: 1.0.9-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.aarch64.rpm
+  - evra: 1.0.1-23.el9_5.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnfnetlink-1.0.1-23.el9_5.aarch64.rpm
+  - evra: 1.2.6-4.el9_4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnftnl-1.2.6-4.el9_4.aarch64.rpm
+  - evra: 1.43.0-6.el9_8.1.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9_8.1.aarch64.rpm
+  - evra: 1.7.3-10.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.aarch64.rpm
+  - evra: 0.21.1-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpsl-0.21.1-5.el9.aarch64.rpm
+  - evra: 1.4.4-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.aarch64.rpm
+  - evra: 2.5.2-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.aarch64.rpm
+  - evra: 3.6-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libselinux-3.6-3.el9.aarch64.rpm
+  - evra: 3.6-5.el9_6.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.aarch64.rpm
+  - evra: 3.6-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsepol-3.6-3.el9.aarch64.rpm
+  - evra: 2.13-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsigsegv-2.13-4.el9.aarch64.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsmartcols-2.37.4-25.el9.aarch64.rpm
+  - evra: 0.10.4-18.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libssh-0.10.4-18.el9.aarch64.rpm
+  - evra: 0.10.4-18.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libssh-config-0.10.4-18.el9.noarch.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libstdc++-11.5.0-14.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libstdc++-devel-11.5.0-14.el9.aarch64.rpm
+  - evra: 4.16.0-10.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libtasn1-4.16.0-10.el9_8.aarch64.rpm
+  - evra: 2.4.6-46.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libtool-ltdl-2.4.6-46.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libubsan-11.5.0-14.el9.aarch64.rpm
+  - evra: 0.9.10-15.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libunistring-0.9.10-15.el9.aarch64.rpm
+  - evra: 1.2.1-6.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.aarch64.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libuuid-2.37.4-25.el9.aarch64.rpm
+  - evra: 1.42.0-2.el9_4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.aarch64.rpm
+  - evra: 0.3.2-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libverto-0.3.2-3.el9.aarch64.rpm
+  - evra: 4.4.18-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libxcrypt-4.4.18-3.el9.aarch64.rpm
+  - evra: 4.4.18-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.aarch64.rpm
+  - evra: 2.9.13-14.el9_8.2.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libxml2-2.9.13-14.el9_8.2.aarch64.rpm
+  - evra: 1.5.5-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libzstd-1.5.5-1.el9.aarch64.rpm
+  - evra: 5.4.4-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/lua-libs-5.4.4-4.el9.aarch64.rpm
+  - evra: 1.9.3-5.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/lz4-libs-1.9.3-5.el9.aarch64.rpm
+  - evra: 4.3-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/make-4.3-8.el9.aarch64.rpm
+  - evra: 4.1.0-10.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/mpfr-4.1.0-10.el9.aarch64.rpm
+  - evra: 6.2-12.20210508.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/ncurses-base-6.2-12.20210508.el9.noarch.rpm
+  - evra: 6.2-12.20210508.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/ncurses-libs-6.2-12.20210508.el9.aarch64.rpm
+  - evra: 2.6.8-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openldap-2.6.8-4.el9.aarch64.rpm
+  - evra: 9.9p1-7.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-9.9p1-7.el9_8.aarch64.rpm
+  - evra: 9.9p1-7.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-clients-9.9p1-7.el9_8.aarch64.rpm
+  - evra: 3.5.5-6.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-3.5.5-6.el9_8.aarch64.rpm
+  - evra: 3.5.5-6.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/openssl-devel-3.5.5-6.el9_8.aarch64.rpm
+  - evra: 3.0.7-11.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_8.aarch64.rpm
+  - evra: 3.0.7-11.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_8.aarch64.rpm
+  - evra: 3.5.5-6.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-libs-3.5.5-6.el9_8.aarch64.rpm
+  - evra: 0.26.2-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/p11-kit-0.26.2-1.el9.aarch64.rpm
+  - evra: 0.26.2-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/p11-kit-trust-0.26.2-1.el9.aarch64.rpm
+  - evra: 1.5.1-28.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pam-1.5.1-28.el9.aarch64.rpm
+  - evra: 8.44-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pcre-8.44-4.el9.aarch64.rpm
+  - evra: 10.40-6.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pcre2-10.40-6.el9.aarch64.rpm
+  - evra: 10.40-6.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pcre2-syntax-10.40-6.el9.noarch.rpm
+  - evra: 1.7.3-10.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.aarch64.rpm
+  - evra: 1.7.3-10.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+  - evra: 1.7.3-10.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.aarch64.rpm
+  - evra: 1.18-8.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/popt-1.18-8.el9.aarch64.rpm
+  - evra: 23.4-3.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/psmisc-23.4-3.el9.aarch64.rpm
+  - evra: 20210518-3.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/publicsuffix-list-dafsa-20210518-3.el9.noarch.rpm
+  - evra: 3.9.25-7.el9_8.2.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-3.9.25-7.el9_8.2.aarch64.rpm
+  - evra: 3.9.25-7.el9_8.2.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-libs-3.9.25-7.el9_8.2.aarch64.rpm
+  - evra: 21.3.1-2.el9_8.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-2.el9_8.noarch.rpm
+  - evra: 53.0.0-15.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-15.el9.noarch.rpm
+  - evra: 8.1-4.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/readline-8.1-4.el9.aarch64.rpm
+  - evra: 9.8-1.0.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/redhat-release-9.8-1.0.el9.aarch64.rpm
+  - evra: 4.16.1.3-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/rpm-4.16.1.3-40.el9.aarch64.rpm
+  - evra: 4.16.1.3-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/rpm-libs-4.16.1.3-40.el9.aarch64.rpm
+  - evra: 4.8-10.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/sed-4.8-10.el9.aarch64.rpm
+  - evra: 2.13.7-10.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/setup-2.13.7-10.el9.noarch.rpm
+  - evra: 4.9-16.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/shadow-utils-4.9-16.el9.aarch64.rpm
+  - evra: 3.34.1-10.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.aarch64.rpm
+  - evra: 252-67.el9_8.4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-252-67.el9_8.4.aarch64.rpm
+  - evra: 252-67.el9_8.4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-libs-252-67.el9_8.4.aarch64.rpm
+  - evra: 252-67.el9_8.4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-pam-252-67.el9_8.4.aarch64.rpm
+  - evra: 252-67.el9_8.4.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-rpm-macros-252-67.el9_8.4.noarch.rpm
+  - evra: 252-67.el9_8.4.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-udev-252-67.el9_8.4.aarch64.rpm
+  - evra: 3.2.3-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.aarch64.rpm
+  - evra: 2026b-1.el9.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tzdata-2026b-1.el9.noarch.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/util-linux-2.37.4-25.el9.aarch64.rpm
+  - evra: 2.37.4-25.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/util-linux-core-2.37.4-25.el9.aarch64.rpm
+  - evra: 8.2.2637-26.el9_8.10.noarch
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.10.noarch.rpm
+  - evra: 5.2.5-8.el9_0.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.aarch64.rpm
+  - evra: 1.2.11-40.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/z/zlib-1.2.11-40.el9.aarch64.rpm
+  - evra: 11.5.0-14.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-c++-11.5.0-14.el9.aarch64.rpm
+  - evra: 2.52.0-1.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-core-2.52.0-1.el9.aarch64.rpm
+  - evra: 6.17.0-2.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/i/iproute-6.17.0-2.el9.aarch64.rpm
+  - evra: 1.8.10-11.el9_5.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/i/iptables-nft-1.8.10-11.el9_5.aarch64.rpm
+  - evra: 1.0.9-7.el9_8.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/nftables-1.0.9-7.el9_8.aarch64.rpm
+  - evra: 1.34-11.el9.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tar-1.34-11.el9.aarch64.rpm
+  - evra: 5.2.5-8.el9_0.aarch64
+    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.aarch64.rpm
+  source: []
+lockfileVendor: redhat
+lockfileVersion: 1

--- a/deploy/konflux/supervisor/rpms.lock.yaml
+++ b/deploy/konflux/supervisor/rpms.lock.yaml
@@ -1,717 +1,1055 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
 arches:
-- arch: x86_64
-  packages:
-  - evra: 2.4.0-1.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/acl-2.4.0-1.el9_8.x86_64.rpm
-  - evra: 1.24-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/alternatives-1.24-2.el9.x86_64.rpm
-  - evra: 3.1.5-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/audit-libs-3.1.5-8.el9.x86_64.rpm
-  - evra: 11-13.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/basesystem-11-13.el9.noarch.rpm
-  - evra: 5.1.8-9.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/bash-5.1.8-9.el9.x86_64.rpm
-  - evra: 2.35.2-72.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-72.el9.x86_64.rpm
-  - evra: 2.35.2-72.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.x86_64.rpm
-  - evra: 1.0.8-11.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/bzip2-libs-1.0.8-11.el9.x86_64.rpm
-  - evra: 2025.2.80_v9.0.305-91.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.noarch.rpm
-  - evra: 3.31.8-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-3.31.8-3.el9.x86_64.rpm
-  - evra: 3.31.8-3.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-data-3.31.8-3.el9.noarch.rpm
-  - evra: 3.31.8-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-filesystem-3.31.8-3.el9.x86_64.rpm
-  - evra: 3.31.8-3.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-rpm-macros-3.31.8-3.el9.noarch.rpm
-  - evra: 8.32-41.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.x86_64.rpm
-  - evra: 8.32-41.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.x86_64.rpm
-  - evra: 8.32-41.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/coreutils-single-8.32-41.el9_8.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cpp-11.5.0-14.el9.x86_64.rpm
-  - evra: 2.9.6-28.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cracklib-2.9.6-28.el9.x86_64.rpm
-  - evra: 2.9.6-28.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-28.el9.x86_64.rpm
-  - evra: 20260224-1.gitea0f072.el9_8.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/crypto-policies-20260224-1.gitea0f072.el9_8.noarch.rpm
-  - evra: 2.8.1-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cryptsetup-libs-2.8.1-3.el9.x86_64.rpm
-  - evra: 7.76.1-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/curl-7.76.1-40.el9.x86_64.rpm
-  - evra: 7.76.1-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/curl-minimal-7.76.1-40.el9.x86_64.rpm
-  - evra: 2.1.27-22.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-22.el9.x86_64.rpm
-  - evra: 1.12.20-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-1.12.20-8.el9.x86_64.rpm
-  - evra: 28-7.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-broker-28-7.el9.x86_64.rpm
-  - evra: 1.12.20-8.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
-  - evra: 1.02.207-4.el9_8.1.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/device-mapper-1.02.207-4.el9_8.1.x86_64.rpm
-  - evra: 1.02.207-4.el9_8.1.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/device-mapper-libs-1.02.207-4.el9_8.1.x86_64.rpm
-  - evra: 0.194-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.x86_64.rpm
-  - evra: 0.194-1.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-default-yama-scope-0.194-1.el9.noarch.rpm
-  - evra: 0.194-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.x86_64.rpm
-  - evra: 0.194-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.x86_64.rpm
-  - evra: 27.2-18.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
-  - evra: 2.5.0-6.el9_8.1.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/expat-2.5.0-6.el9_8.1.x86_64.rpm
-  - evra: 3.16-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/filesystem-3.16-5.el9.x86_64.rpm
-  - evra: 4.8.0-7.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/findutils-4.8.0-7.el9.x86_64.rpm
-  - evra: 1.2.0-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fips-provider-next-1.2.0-5.el9.x86_64.rpm
-  - evra: 5.1.0-6.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gawk-5.1.0-6.el9.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-11.5.0-14.el9.x86_64.rpm
-  - evra: 1.23-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-all-langpacks-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-common-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-langpack-en-2.34-274.el9_8.x86_64.rpm
-  - evra: 2.34-274.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-274.el9_8.x86_64.rpm
-  - evra: 6.2.0-13.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gmp-6.2.0-13.el9.x86_64.rpm
-  - evra: 3.6-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/grep-3.6-5.el9.x86_64.rpm
-  - evra: 1.12-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
-  - evra: 1.8.10-11.el9_5.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/i/iptables-libs-1.8.10-11.el9_5.x86_64.rpm
-  - evra: 2.14-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/j/jansson-2.14-1.el9.x86_64.rpm
-  - evra: 0.14-11.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/j/json-c-0.14-11.el9.x86_64.rpm
-  - evra: 2.4.0-11.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kbd-2.4.0-11.el9.x86_64.rpm
-  - evra: 2.4.0-11.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kbd-legacy-2.4.0-11.el9.noarch.rpm
-  - evra: 2.4.0-11.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kbd-misc-2.4.0-11.el9.noarch.rpm
-  - evra: 5.14.0-687.30.1.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.30.1.el9_8.x86_64.rpm
-  - evra: 1.6.3-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/keyutils-libs-1.6.3-1.el9.x86_64.rpm
-  - evra: 28-11.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kmod-28-11.el9.x86_64.rpm
-  - evra: 28-11.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kmod-libs-28-11.el9.x86_64.rpm
-  - evra: 1.21.1-10.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/krb5-libs-1.21.1-10.el9_8.x86_64.rpm
-  - evra: 590-6.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/less-590-6.el9.x86_64.rpm
-  - evra: 2.4.0-1.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libacl-2.4.0-1.el9_8.x86_64.rpm
-  - evra: 3.5.3-9.el9_7.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libarchive-3.5.3-9.el9_7.x86_64.rpm
-  - evra: 2.5.1-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libattr-2.5.1-3.el9.x86_64.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libblkid-2.37.4-25.el9.x86_64.rpm
-  - evra: 1.5.0-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libbpf-1.5.0-3.el9.x86_64.rpm
-  - evra: 1.0.9-9.el9_7.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libbrotli-1.0.9-9.el9_7.x86_64.rpm
-  - evra: 2.48-10.el9_8.1.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcap-2.48-10.el9_8.1.x86_64.rpm
-  - evra: 0.8.2-7.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcap-ng-0.8.2-7.el9.x86_64.rpm
-  - evra: 0.7.0-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.x86_64.rpm
-  - evra: 1.46.5-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcom_err-1.46.5-8.el9.x86_64.rpm
-  - evra: 7.76.1-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcurl-7.76.1-40.el9.x86_64.rpm
-  - evra: 7.76.1-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcurl-minimal-7.76.1-40.el9.x86_64.rpm
-  - evra: 5.3.28-57.el9_6.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.x86_64.rpm
-  - evra: 0.4.1-7.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libeconf-0.4.1-7.el9_8.x86_64.rpm
-  - evra: 3.1-39.20210216cvs.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.x86_64.rpm
-  - evra: 2.1.12-8.el9_4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libevent-2.1.12-8.el9_4.x86_64.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfdisk-2.37.4-25.el9.x86_64.rpm
-  - evra: 3.4.2-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libffi-3.4.2-8.el9.x86_64.rpm
-  - evra: 1.13.0-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgcc-11.5.0-14.el9.x86_64.rpm
-  - evra: 1.10.0-11.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.x86_64.rpm
-  - evra: 1.42-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgpg-error-1.42-5.el9.x86_64.rpm
-  - evra: 2.3.0-7.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libidn2-2.3.0-7.el9.x86_64.rpm
-  - evra: 1.0.4-16.el9_4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libmnl-1.0.4-16.el9_4.x86_64.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libmount-2.37.4-25.el9.x86_64.rpm
-  - evra: 1.2.1-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
-  - evra: 1.0.9-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.x86_64.rpm
-  - evra: 1.0.1-23.el9_5.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnfnetlink-1.0.1-23.el9_5.x86_64.rpm
-  - evra: 1.2.6-4.el9_4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnftnl-1.2.6-4.el9_4.x86_64.rpm
-  - evra: 1.43.0-6.el9_8.1.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9_8.1.x86_64.rpm
-  - evra: 1.7.3-10.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
-  - evra: 0.21.1-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpsl-0.21.1-5.el9.x86_64.rpm
-  - evra: 1.4.4-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.x86_64.rpm
-  - evra: 2.5.2-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
-  - evra: 3.6-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libselinux-3.6-3.el9.x86_64.rpm
-  - evra: 3.6-5.el9_6.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.x86_64.rpm
-  - evra: 3.6-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsepol-3.6-3.el9.x86_64.rpm
-  - evra: 2.13-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsigsegv-2.13-4.el9.x86_64.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsmartcols-2.37.4-25.el9.x86_64.rpm
-  - evra: 0.10.4-18.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libssh-0.10.4-18.el9.x86_64.rpm
-  - evra: 0.10.4-18.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libssh-config-0.10.4-18.el9.noarch.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libstdc++-11.5.0-14.el9.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libstdc++-devel-11.5.0-14.el9.x86_64.rpm
-  - evra: 4.16.0-10.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libtasn1-4.16.0-10.el9_8.x86_64.rpm
-  - evra: 2.4.6-46.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libtool-ltdl-2.4.6-46.el9.x86_64.rpm
-  - evra: 0.9.10-15.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libunistring-0.9.10-15.el9.x86_64.rpm
-  - evra: 1.2.1-6.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.x86_64.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libuuid-2.37.4-25.el9.x86_64.rpm
-  - evra: 1.42.0-2.el9_4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.x86_64.rpm
-  - evra: 0.3.2-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libverto-0.3.2-3.el9.x86_64.rpm
-  - evra: 4.4.18-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libxcrypt-4.4.18-3.el9.x86_64.rpm
-  - evra: 4.4.18-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.x86_64.rpm
-  - evra: 2.9.13-14.el9_8.2.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libxml2-2.9.13-14.el9_8.2.x86_64.rpm
-  - evra: 1.5.5-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libzstd-1.5.5-1.el9.x86_64.rpm
-  - evra: 5.4.4-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/lua-libs-5.4.4-4.el9.x86_64.rpm
-  - evra: 1.9.3-5.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/lz4-libs-1.9.3-5.el9.x86_64.rpm
-  - evra: 4.3-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
-  - evra: 4.1.0-10.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/mpfr-4.1.0-10.el9.x86_64.rpm
-  - evra: 6.2-12.20210508.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-base-6.2-12.20210508.el9.noarch.rpm
-  - evra: 6.2-12.20210508.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-libs-6.2-12.20210508.el9.x86_64.rpm
-  - evra: 2.6.8-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openldap-2.6.8-4.el9.x86_64.rpm
-  - evra: 9.9p1-7.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-9.9p1-7.el9_8.x86_64.rpm
-  - evra: 9.9p1-7.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-clients-9.9p1-7.el9_8.x86_64.rpm
-  - evra: 3.5.5-5.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.5.5-5.el9_8.x86_64.rpm
-  - evra: 3.5.5-5.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/openssl-devel-3.5.5-5.el9_8.x86_64.rpm
-  - evra: 3.0.7-11.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_8.x86_64.rpm
-  - evra: 3.0.7-11.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_8.x86_64.rpm
-  - evra: 3.5.5-5.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-libs-3.5.5-5.el9_8.x86_64.rpm
-  - evra: 0.26.2-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/p11-kit-0.26.2-1.el9.x86_64.rpm
-  - evra: 0.26.2-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/p11-kit-trust-0.26.2-1.el9.x86_64.rpm
-  - evra: 1.5.1-28.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pam-1.5.1-28.el9.x86_64.rpm
-  - evra: 8.44-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pcre-8.44-4.el9.x86_64.rpm
-  - evra: 10.40-6.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pcre2-10.40-6.el9.x86_64.rpm
-  - evra: 10.40-6.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pcre2-syntax-10.40-6.el9.noarch.rpm
-  - evra: 1.7.3-10.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
-  - evra: 1.7.3-10.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
-  - evra: 1.7.3-10.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
-  - evra: 1.18-8.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/popt-1.18-8.el9.x86_64.rpm
-  - evra: 23.4-3.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/psmisc-23.4-3.el9.x86_64.rpm
-  - evra: 20210518-3.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/publicsuffix-list-dafsa-20210518-3.el9.noarch.rpm
-  - evra: 3.9.25-7.el9_8.2.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-3.9.25-7.el9_8.2.x86_64.rpm
-  - evra: 3.9.25-7.el9_8.2.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-libs-3.9.25-7.el9_8.2.x86_64.rpm
-  - evra: 21.3.1-2.el9_8.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-2.el9_8.noarch.rpm
-  - evra: 53.0.0-15.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-15.el9.noarch.rpm
-  - evra: 8.1-4.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/readline-8.1-4.el9.x86_64.rpm
-  - evra: 9.8-1.0.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/redhat-release-9.8-1.0.el9.x86_64.rpm
-  - evra: 4.16.1.3-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rpm-4.16.1.3-40.el9.x86_64.rpm
-  - evra: 4.16.1.3-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rpm-libs-4.16.1.3-40.el9.x86_64.rpm
-  - evra: 4.8-10.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/sed-4.8-10.el9.x86_64.rpm
-  - evra: 2.13.7-10.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/setup-2.13.7-10.el9.noarch.rpm
-  - evra: 4.9-16.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/shadow-utils-4.9-16.el9.x86_64.rpm
-  - evra: 3.34.1-10.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.x86_64.rpm
-  - evra: 252-67.el9_8.4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-252-67.el9_8.4.x86_64.rpm
-  - evra: 252-67.el9_8.4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-libs-252-67.el9_8.4.x86_64.rpm
-  - evra: 252-67.el9_8.4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-pam-252-67.el9_8.4.x86_64.rpm
-  - evra: 252-67.el9_8.4.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-67.el9_8.4.noarch.rpm
-  - evra: 252-67.el9_8.4.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-udev-252-67.el9_8.4.x86_64.rpm
-  - evra: 3.2.3-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.x86_64.rpm
-  - evra: 2026b-1.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tzdata-2026b-1.el9.noarch.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/util-linux-2.37.4-25.el9.x86_64.rpm
-  - evra: 2.37.4-25.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/util-linux-core-2.37.4-25.el9.x86_64.rpm
-  - evra: 8.2.2637-26.el9_8.10.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.10.noarch.rpm
-  - evra: 5.2.5-8.el9_0.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.x86_64.rpm
-  - evra: 1.2.11-40.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/z/zlib-1.2.11-40.el9.x86_64.rpm
-  - evra: 11.5.0-14.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-c++-11.5.0-14.el9.x86_64.rpm
-  - evra: 2.52.0-1.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-2.52.0-1.el9.x86_64.rpm
-  - evra: 6.17.0-2.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/i/iproute-6.17.0-2.el9.x86_64.rpm
-  - evra: 1.8.10-11.el9_5.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/i/iptables-nft-1.8.10-11.el9_5.x86_64.rpm
-  - evra: 1.0.9-7.el9_8.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/nftables-1.0.9-7.el9_8.x86_64.rpm
-  - evra: 1.34-11.el9.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tar-1.34-11.el9.x86_64.rpm
-  - evra: 5.2.5-8.el9_0.x86_64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.x86_64.rpm
-  source: []
 - arch: aarch64
   packages:
-  - evra: 2.4.0-1.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/acl-2.4.0-1.el9_8.aarch64.rpm
-  - evra: 1.24-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/alternatives-1.24-2.el9.aarch64.rpm
-  - evra: 3.1.5-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/audit-libs-3.1.5-8.el9.aarch64.rpm
-  - evra: 11-13.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/basesystem-11-13.el9.noarch.rpm
-  - evra: 5.1.8-9.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/bash-5.1.8-9.el9.aarch64.rpm
-  - evra: 2.35.2-72.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-2.35.2-72.el9.aarch64.rpm
-  - evra: 2.35.2-72.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.aarch64.rpm
-  - evra: 1.0.8-11.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/bzip2-libs-1.0.8-11.el9.aarch64.rpm
-  - evra: 2025.2.80_v9.0.305-91.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.noarch.rpm
-  - evra: 3.31.8-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-3.31.8-3.el9.aarch64.rpm
-  - evra: 3.31.8-3.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-data-3.31.8-3.el9.noarch.rpm
-  - evra: 3.31.8-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-filesystem-3.31.8-3.el9.aarch64.rpm
-  - evra: 3.31.8-3.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-rpm-macros-3.31.8-3.el9.noarch.rpm
-  - evra: 8.32-41.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-8.32-41.el9_8.aarch64.rpm
-  - evra: 8.32-41.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-common-8.32-41.el9_8.aarch64.rpm
-  - evra: 8.32-41.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/coreutils-single-8.32-41.el9_8.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cpp-11.5.0-14.el9.aarch64.rpm
-  - evra: 2.9.6-28.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cracklib-2.9.6-28.el9.aarch64.rpm
-  - evra: 2.9.6-28.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cracklib-dicts-2.9.6-28.el9.aarch64.rpm
-  - evra: 20260224-1.gitea0f072.el9_8.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/crypto-policies-20260224-1.gitea0f072.el9_8.noarch.rpm
-  - evra: 2.8.1-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cryptsetup-libs-2.8.1-3.el9.aarch64.rpm
-  - evra: 7.76.1-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/curl-7.76.1-40.el9.aarch64.rpm
-  - evra: 7.76.1-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/curl-minimal-7.76.1-40.el9.aarch64.rpm
-  - evra: 2.1.27-22.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-22.el9.aarch64.rpm
-  - evra: 1.12.20-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-1.12.20-8.el9.aarch64.rpm
-  - evra: 28-7.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-broker-28-7.el9.aarch64.rpm
-  - evra: 1.12.20-8.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
-  - evra: 1.02.207-4.el9_8.1.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/device-mapper-1.02.207-4.el9_8.1.aarch64.rpm
-  - evra: 1.02.207-4.el9_8.1.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/device-mapper-libs-1.02.207-4.el9_8.1.aarch64.rpm
-  - evra: 0.194-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.aarch64.rpm
-  - evra: 0.194-1.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-default-yama-scope-0.194-1.el9.noarch.rpm
-  - evra: 0.194-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.aarch64.rpm
-  - evra: 0.194-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.aarch64.rpm
-  - evra: 27.2-18.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
-  - evra: 2.5.0-6.el9_8.1.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/expat-2.5.0-6.el9_8.1.aarch64.rpm
-  - evra: 3.16-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/filesystem-3.16-5.el9.aarch64.rpm
-  - evra: 4.8.0-7.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/findutils-4.8.0-7.el9.aarch64.rpm
-  - evra: 1.2.0-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fips-provider-next-1.2.0-5.el9.aarch64.rpm
-  - evra: 5.1.0-6.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gawk-5.1.0-6.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-11.5.0-14.el9.aarch64.rpm
-  - evra: 1.23-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-2.34-274.el9_8.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-all-langpacks-2.34-274.el9_8.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-common-2.34-274.el9_8.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/glibc-devel-2.34-274.el9_8.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-gconv-extra-2.34-274.el9_8.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-langpack-en-2.34-274.el9_8.aarch64.rpm
-  - evra: 2.34-274.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-274.el9_8.aarch64.rpm
-  - evra: 6.2.0-13.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gmp-6.2.0-13.el9.aarch64.rpm
-  - evra: 3.6-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/grep-3.6-5.el9.aarch64.rpm
-  - evra: 1.12-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gzip-1.12-1.el9.aarch64.rpm
-  - evra: 1.8.10-11.el9_5.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/i/iptables-libs-1.8.10-11.el9_5.aarch64.rpm
-  - evra: 2.14-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/j/jansson-2.14-1.el9.aarch64.rpm
-  - evra: 0.14-11.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/j/json-c-0.14-11.el9.aarch64.rpm
-  - evra: 2.4.0-11.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kbd-2.4.0-11.el9.aarch64.rpm
-  - evra: 2.4.0-11.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kbd-legacy-2.4.0-11.el9.noarch.rpm
-  - evra: 2.4.0-11.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kbd-misc-2.4.0-11.el9.noarch.rpm
-  - evra: 5.14.0-687.31.1.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.31.1.el9_8.aarch64.rpm
-  - evra: 1.6.3-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/keyutils-libs-1.6.3-1.el9.aarch64.rpm
-  - evra: 28-11.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kmod-28-11.el9.aarch64.rpm
-  - evra: 28-11.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kmod-libs-28-11.el9.aarch64.rpm
-  - evra: 1.21.1-10.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/krb5-libs-1.21.1-10.el9_8.aarch64.rpm
-  - evra: 590-6.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/less-590-6.el9.aarch64.rpm
-  - evra: 2.4.0-1.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libacl-2.4.0-1.el9_8.aarch64.rpm
-  - evra: 3.5.3-9.el9_7.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libarchive-3.5.3-9.el9_7.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libasan-11.5.0-14.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libatomic-11.5.0-14.el9.aarch64.rpm
-  - evra: 2.5.1-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libattr-2.5.1-3.el9.aarch64.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libblkid-2.37.4-25.el9.aarch64.rpm
-  - evra: 1.5.0-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libbpf-1.5.0-3.el9.aarch64.rpm
-  - evra: 1.0.9-9.el9_7.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libbrotli-1.0.9-9.el9_7.aarch64.rpm
-  - evra: 2.48-10.el9_8.1.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcap-2.48-10.el9_8.1.aarch64.rpm
-  - evra: 0.8.2-7.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcap-ng-0.8.2-7.el9.aarch64.rpm
-  - evra: 0.7.0-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.aarch64.rpm
-  - evra: 1.46.5-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcom_err-1.46.5-8.el9.aarch64.rpm
-  - evra: 7.76.1-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcurl-7.76.1-40.el9.aarch64.rpm
-  - evra: 7.76.1-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcurl-minimal-7.76.1-40.el9.aarch64.rpm
-  - evra: 5.3.28-57.el9_6.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.aarch64.rpm
-  - evra: 0.4.1-7.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libeconf-0.4.1-7.el9_8.aarch64.rpm
-  - evra: 3.1-39.20210216cvs.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.aarch64.rpm
-  - evra: 2.1.12-8.el9_4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libevent-2.1.12-8.el9_4.aarch64.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libfdisk-2.37.4-25.el9.aarch64.rpm
-  - evra: 3.4.2-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libffi-3.4.2-8.el9.aarch64.rpm
-  - evra: 1.13.0-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgcc-11.5.0-14.el9.aarch64.rpm
-  - evra: 1.10.0-11.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.aarch64.rpm
-  - evra: 1.42-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgpg-error-1.42-5.el9.aarch64.rpm
-  - evra: 2.3.0-7.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libidn2-2.3.0-7.el9.aarch64.rpm
-  - evra: 1.0.4-16.el9_4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libmnl-1.0.4-16.el9_4.aarch64.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libmount-2.37.4-25.el9.aarch64.rpm
-  - evra: 1.2.1-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.aarch64.rpm
-  - evra: 1.0.9-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.aarch64.rpm
-  - evra: 1.0.1-23.el9_5.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnfnetlink-1.0.1-23.el9_5.aarch64.rpm
-  - evra: 1.2.6-4.el9_4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnftnl-1.2.6-4.el9_4.aarch64.rpm
-  - evra: 1.43.0-6.el9_8.1.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9_8.1.aarch64.rpm
-  - evra: 1.7.3-10.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.aarch64.rpm
-  - evra: 0.21.1-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpsl-0.21.1-5.el9.aarch64.rpm
-  - evra: 1.4.4-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.aarch64.rpm
-  - evra: 2.5.2-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.aarch64.rpm
-  - evra: 3.6-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libselinux-3.6-3.el9.aarch64.rpm
-  - evra: 3.6-5.el9_6.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.aarch64.rpm
-  - evra: 3.6-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsepol-3.6-3.el9.aarch64.rpm
-  - evra: 2.13-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsigsegv-2.13-4.el9.aarch64.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsmartcols-2.37.4-25.el9.aarch64.rpm
-  - evra: 0.10.4-18.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libssh-0.10.4-18.el9.aarch64.rpm
-  - evra: 0.10.4-18.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libssh-config-0.10.4-18.el9.noarch.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libstdc++-11.5.0-14.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libstdc++-devel-11.5.0-14.el9.aarch64.rpm
-  - evra: 4.16.0-10.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libtasn1-4.16.0-10.el9_8.aarch64.rpm
-  - evra: 2.4.6-46.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libtool-ltdl-2.4.6-46.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libubsan-11.5.0-14.el9.aarch64.rpm
-  - evra: 0.9.10-15.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libunistring-0.9.10-15.el9.aarch64.rpm
-  - evra: 1.2.1-6.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.aarch64.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libuuid-2.37.4-25.el9.aarch64.rpm
-  - evra: 1.42.0-2.el9_4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.aarch64.rpm
-  - evra: 0.3.2-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libverto-0.3.2-3.el9.aarch64.rpm
-  - evra: 4.4.18-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libxcrypt-4.4.18-3.el9.aarch64.rpm
-  - evra: 4.4.18-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.aarch64.rpm
-  - evra: 2.9.13-14.el9_8.2.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libxml2-2.9.13-14.el9_8.2.aarch64.rpm
-  - evra: 1.5.5-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libzstd-1.5.5-1.el9.aarch64.rpm
-  - evra: 5.4.4-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/lua-libs-5.4.4-4.el9.aarch64.rpm
-  - evra: 1.9.3-5.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/lz4-libs-1.9.3-5.el9.aarch64.rpm
-  - evra: 4.3-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/make-4.3-8.el9.aarch64.rpm
-  - evra: 4.1.0-10.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/mpfr-4.1.0-10.el9.aarch64.rpm
-  - evra: 6.2-12.20210508.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/ncurses-base-6.2-12.20210508.el9.noarch.rpm
-  - evra: 6.2-12.20210508.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/ncurses-libs-6.2-12.20210508.el9.aarch64.rpm
-  - evra: 2.6.8-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openldap-2.6.8-4.el9.aarch64.rpm
-  - evra: 9.9p1-7.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-9.9p1-7.el9_8.aarch64.rpm
-  - evra: 9.9p1-7.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-clients-9.9p1-7.el9_8.aarch64.rpm
-  - evra: 3.5.5-6.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-3.5.5-6.el9_8.aarch64.rpm
-  - evra: 3.5.5-6.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/openssl-devel-3.5.5-6.el9_8.aarch64.rpm
-  - evra: 3.0.7-11.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_8.aarch64.rpm
-  - evra: 3.0.7-11.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_8.aarch64.rpm
-  - evra: 3.5.5-6.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-libs-3.5.5-6.el9_8.aarch64.rpm
-  - evra: 0.26.2-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/p11-kit-0.26.2-1.el9.aarch64.rpm
-  - evra: 0.26.2-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/p11-kit-trust-0.26.2-1.el9.aarch64.rpm
-  - evra: 1.5.1-28.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pam-1.5.1-28.el9.aarch64.rpm
-  - evra: 8.44-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pcre-8.44-4.el9.aarch64.rpm
-  - evra: 10.40-6.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pcre2-10.40-6.el9.aarch64.rpm
-  - evra: 10.40-6.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pcre2-syntax-10.40-6.el9.noarch.rpm
-  - evra: 1.7.3-10.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.aarch64.rpm
-  - evra: 1.7.3-10.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
-  - evra: 1.7.3-10.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.aarch64.rpm
-  - evra: 1.18-8.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/popt-1.18-8.el9.aarch64.rpm
-  - evra: 23.4-3.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/psmisc-23.4-3.el9.aarch64.rpm
-  - evra: 20210518-3.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/publicsuffix-list-dafsa-20210518-3.el9.noarch.rpm
-  - evra: 3.9.25-7.el9_8.2.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-3.9.25-7.el9_8.2.aarch64.rpm
-  - evra: 3.9.25-7.el9_8.2.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-libs-3.9.25-7.el9_8.2.aarch64.rpm
-  - evra: 21.3.1-2.el9_8.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-2.el9_8.noarch.rpm
-  - evra: 53.0.0-15.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-15.el9.noarch.rpm
-  - evra: 8.1-4.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/readline-8.1-4.el9.aarch64.rpm
-  - evra: 9.8-1.0.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/redhat-release-9.8-1.0.el9.aarch64.rpm
-  - evra: 4.16.1.3-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/rpm-4.16.1.3-40.el9.aarch64.rpm
-  - evra: 4.16.1.3-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/rpm-libs-4.16.1.3-40.el9.aarch64.rpm
-  - evra: 4.8-10.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/sed-4.8-10.el9.aarch64.rpm
-  - evra: 2.13.7-10.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/setup-2.13.7-10.el9.noarch.rpm
-  - evra: 4.9-16.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/shadow-utils-4.9-16.el9.aarch64.rpm
-  - evra: 3.34.1-10.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/sqlite-libs-3.34.1-10.el9_8.aarch64.rpm
-  - evra: 252-67.el9_8.4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-252-67.el9_8.4.aarch64.rpm
-  - evra: 252-67.el9_8.4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-libs-252-67.el9_8.4.aarch64.rpm
-  - evra: 252-67.el9_8.4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-pam-252-67.el9_8.4.aarch64.rpm
-  - evra: 252-67.el9_8.4.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-rpm-macros-252-67.el9_8.4.noarch.rpm
-  - evra: 252-67.el9_8.4.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-udev-252-67.el9_8.4.aarch64.rpm
-  - evra: 3.2.3-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.aarch64.rpm
-  - evra: 2026b-1.el9.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tzdata-2026b-1.el9.noarch.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/util-linux-2.37.4-25.el9.aarch64.rpm
-  - evra: 2.37.4-25.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/util-linux-core-2.37.4-25.el9.aarch64.rpm
-  - evra: 8.2.2637-26.el9_8.10.noarch
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.10.noarch.rpm
-  - evra: 5.2.5-8.el9_0.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.aarch64.rpm
-  - evra: 1.2.11-40.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/z/zlib-1.2.11-40.el9.aarch64.rpm
-  - evra: 11.5.0-14.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-c++-11.5.0-14.el9.aarch64.rpm
-  - evra: 2.52.0-1.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-core-2.52.0-1.el9.aarch64.rpm
-  - evra: 6.17.0-2.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/i/iproute-6.17.0-2.el9.aarch64.rpm
-  - evra: 1.8.10-11.el9_5.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/i/iptables-nft-1.8.10-11.el9_5.aarch64.rpm
-  - evra: 1.0.9-7.el9_8.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/nftables-1.0.9-7.el9_8.aarch64.rpm
-  - evra: 1.34-11.el9.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tar-1.34-11.el9.aarch64.rpm
-  - evra: 5.2.5-8.el9_0.aarch64
-    url: https://cdn.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.aarch64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-3.31.8-3.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 11655593
+    checksum: sha256:2a77fe1c3784083dcdebdd548c16d823b3e4a5adb8d6c00e36841aa633eab53b
+    name: cmake
+    evr: 3.31.8-3.el9
+    sourcerpm: cmake-3.31.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-data-3.31.8-3.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2829291
+    checksum: sha256:1cdc2e88a996c575b750483c8f562674e4b50a6ab414c7bbe6f6b641c1db7bd9
+    name: cmake-data
+    evr: 3.31.8-3.el9
+    sourcerpm: cmake-3.31.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-filesystem-3.31.8-3.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 19282
+    checksum: sha256:69a498723354740357fc3f4b4cd235da38fadd98835da193bec0c0850f68f3ad
+    name: cmake-filesystem
+    evr: 3.31.8-3.el9
+    sourcerpm: cmake-3.31.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cpp-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 10798392
+    checksum: sha256:eb16ef369b981c0dca6149e971a63f74ea09c09f1c638086e3cda1e0591ac21b
+    name: cpp
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 9495
+    checksum: sha256:49d7b88a05a72c15b78191a987e6def04fda8e2e4ff75711f715d0c0ecadc60f
+    name: emacs-filesystem
+    evr: 1:27.2-18.el9
+    sourcerpm: emacs-27.2-18.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 31291354
+    checksum: sha256:542e635ac17b548cc03ab4347438d49f96837c1d91d12714b6b2764ec566156c
+    name: gcc
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-c++-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 12994215
+    checksum: sha256:aabe892798a2272d65c269fd6aa14d3b3dfc782c98f92f8fda30c2a4fa33bf6d
+    name: gcc-c++
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/git-core-2.52.0-1.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 5392428
+    checksum: sha256:7082917982981bf611c089e7d9d53b63e969af61a37cfd65b5c4081d5b260a1c
+    name: git-core
+    evr: 2.52.0-1.el9
+    sourcerpm: git-2.52.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/glibc-devel-2.34-274.el9_8.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 577056
+    checksum: sha256:09cdfbba4c2517445ee2512c1c5c965b7d7ebdcf05665627dee83e0d824a5cff
+    name: glibc-devel
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.31.1.el9_8.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2861893
+    checksum: sha256:c7bc9b3d12d85dafcf2c41d080338f4871289142b7c007ad121767a38d08b5ff
+    name: kernel-headers
+    evr: 5.14.0-687.31.1.el9_8
+    sourcerpm: kernel-5.14.0-687.31.1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libasan-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 409047
+    checksum: sha256:854a84e72d40c2a062d112b93f8a694044fd7dc5b3afe7a869a448a12844c3e6
+    name: libasan
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 67120
+    checksum: sha256:3763354a5f45d886f9976eec20eb34f8afc2144c69ffba07de546f2820893c70
+    name: libmpc
+    evr: 1.2.1-4.el9
+    sourcerpm: libmpc-1.2.1-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libstdc++-devel-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2520018
+    checksum: sha256:5a2474c2e817b008212e5a94770d8bfbaad17e9ebba2a38d734907e594ac2aac
+    name: libstdc++-devel
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libubsan-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 178996
+    checksum: sha256:d0adfda8f1d8ddf05a46292228e31cf887d731e7999154603e148e3d70d1f182
+    name: libubsan
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 150129
+    checksum: sha256:4dc8a40da74e0f9823356460ee11f183c70f382953700fffef0c448198a677cc
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+    sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 33051
+    checksum: sha256:9d621f33df35b9c274b8d65457d6c67fc1522b6c62cf7b2341a4a99f39a93507
+    name: libxcrypt-devel
+    evr: 4.4.18-3.el9
+    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/openssl-devel-3.5.5-6.el9_8.aarch64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 5028889
+    checksum: sha256:c92e750163820a817ca5562935010872f8db5ca5712a517b01beafcb87221670
+    name: openssl-devel
+    evr: 1:3.5.5-6.el9_8
+    sourcerpm: openssl-3.5.5-6.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-2.35.2-72.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 5021411
+    checksum: sha256:72e9fd9c4976413060df02e37d358fca208ab144d78e321f448a488d50967155
+    name: binutils
+    evr: 2.35.2-72.el9
+    sourcerpm: binutils-2.35.2-72.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 908723
+    checksum: sha256:269bb24ded2f23dcdb74c04597b13281ce6ac47a87a14831ee639d985323bd04
+    name: binutils-gold
+    evr: 2.35.2-72.el9
+    sourcerpm: binutils-2.35.2-72.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cracklib-2.9.6-28.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 102026
+    checksum: sha256:d85216b672a15e5dd8cc771b853e3b73e832034949ee23998d8403609fba00a2
+    name: cracklib
+    evr: 2.9.6-28.el9
+    sourcerpm: cracklib-2.9.6-28.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cracklib-dicts-2.9.6-28.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 3829400
+    checksum: sha256:807345f95c448cb58d4db8d059f76e4c139ef029887d59b431efd20db934745a
+    name: cracklib-dicts
+    evr: 2.9.6-28.el9
+    sourcerpm: cracklib-2.9.6-28.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 42824
+    checksum: sha256:bbcf05d0b46d42c85807d774788edc39528a6898bd880baf11fb77729f59272d
+    name: elfutils-debuginfod-client
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-default-yama-scope-0.194-1.el9.noarch.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 8949
+    checksum: sha256:c473f42c0fec97e2830580110509e4522bc62d9b11761d062499354a0bf58959
+    name: elfutils-default-yama-scope
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 203006
+    checksum: sha256:04ff63b7b669b16827f3688baa0be4a2782f1405db3c6d3ee03c0e4cebc2cdf2
+    name: elfutils-libelf
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 271645
+    checksum: sha256:b90a6ad3e465995538785a2536986ad705625daf606d6258bf23d1dd29aec208
+    name: elfutils-libs
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/expat-2.5.0-6.el9_8.1.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 120882
+    checksum: sha256:7cc4e533f63bdec0ead003d176cb262b8d4d2583dfd57b2e9cfeeed4ead13475
+    name: expat
+    evr: 2.5.0-6.el9_8.1
+    sourcerpm: expat-2.5.0-6.el9_8.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-2.34-274.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 1813548
+    checksum: sha256:0d52ce006fc399127ea7da1f2acfeed702b48ba75f5d1567491be35e1d620b09
+    name: glibc
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-common-2.34-274.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 312799
+    checksum: sha256:86d8e468d28880e34bb92a6e99a82fa2d5946d56cf2cedbb6fd9ca0cd1f65755
+    name: glibc-common
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-langpack-en-2.34-274.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 684496
+    checksum: sha256:0883e1f9ac411a052c434f7339e6929c34cf4a47330a38e036a3c15c17322fa1
+    name: glibc-langpack-en
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-274.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 30937
+    checksum: sha256:33a17677cc85823259a2ddd3f24887117dc95d7a9ec0af64640df6ab26ddc094
+    name: glibc-minimal-langpack
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gzip-1.12-1.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 169809
+    checksum: sha256:45710df49b439ddc4a2848fd3877367761b574234ae28b6be46f1cf54f3fcdca
+    name: gzip
+    evr: 1.12-1.el9
+    sourcerpm: gzip-1.12-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/i/iproute-6.17.0-2.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 899705
+    checksum: sha256:39b4f03d65fdcf8b5ea922b6d8de51c969f9c531af4264be4e56c2f13871064e
+    name: iproute
+    evr: 6.17.0-2.el9
+    sourcerpm: iproute-6.17.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/i/iptables-libs-1.8.10-11.el9_5.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 477723
+    checksum: sha256:73eadf9d16ea9ebb340664873522ef83ad0c28106751783d61c6315a8f0d466f
+    name: iptables-libs
+    evr: 1.8.10-11.el9_5
+    sourcerpm: iptables-1.8.10-11.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/i/iptables-nft-1.8.10-11.el9_5.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 212143
+    checksum: sha256:5789f27966252aadd8bf0eae25d324defc2528312ff21b21c4ddb80d1c0b104d
+    name: iptables-nft
+    evr: 1.8.10-11.el9_5
+    sourcerpm: iptables-1.8.10-11.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/j/jansson-2.14-1.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 50251
+    checksum: sha256:7c002eb9c81bad49b8a11d9790af6220cce5fb882be7ca11335882d079d1473f
+    name: jansson
+    evr: 2.14-1.el9
+    sourcerpm: jansson-2.14-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/less-590-6.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 165028
+    checksum: sha256:fa762484ba40e0b7eb1c25531a66a0b578b6141cabb6f73d865c13ccdf75c1c9
+    name: less
+    evr: 590-6.el9
+    sourcerpm: less-590-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libblkid-2.37.4-25.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 113931
+    checksum: sha256:2c38ac06d3a267b62fc5ea4e149a25c4287c19157f4f18e0f7edea4787b27e15
+    name: libblkid
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libbpf-1.5.0-3.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 188694
+    checksum: sha256:2a9b81f70ed90d0f711f9f47db6437124b30f89d1c4b009b2fa961684e2b3eb8
+    name: libbpf
+    evr: 2:1.5.0-3.el9
+    sourcerpm: libbpf-1.5.0-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 59368
+    checksum: sha256:93a2f44044ab11225b1123bc9df4f4d09c0a5f3251818e7d144ca64fd12c0957
+    name: libcbor
+    evr: 0.7.0-5.el9
+    sourcerpm: libcbor-0.7.0-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 727417
+    checksum: sha256:3a912b2a0a6226695a5773138ce5ce090c9fb155151dffe732b8d52e6dd22d63
+    name: libdb
+    evr: 5.3.28-57.el9_6
+    sourcerpm: libdb-5.3.28-57.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libeconf-0.4.1-7.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 32324
+    checksum: sha256:8a5e117c2690c82835c6013f1fbac37b026f3e953fbffbd84c2f5ef6cf8df571
+    name: libeconf
+    evr: 0.4.1-7.el9_8
+    sourcerpm: libeconf-0.4.1-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 110092
+    checksum: sha256:93964f8c06574404f4a5b44781b698f556fbc22f7ae3c82d4d540619772f6816
+    name: libedit
+    evr: 3.1-39.20210216cvs.el9
+    sourcerpm: libedit-3.1-39.20210216cvs.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libfdisk-2.37.4-25.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 156711
+    checksum: sha256:af043918fc50ce5b3de50c48c3de0143140b692fbf639db6f259270c4211a776
+    name: libfdisk
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 100573
+    checksum: sha256:e56e963635b92f407471c7c5698d602135b135bda4515ecc75ac52dd1d38c7e4
+    name: libfido2
+    evr: 1.13.0-2.el9
+    sourcerpm: libfido2-1.13.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgcc-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 81211
+    checksum: sha256:6923218fdef581189a4b51c7ba158083597f1c6df08cae021a1d90e9d61938a9
+    name: libgcc
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 262138
+    checksum: sha256:c8b3788fee442304e4158c802ff413df27d394b82f19c0f34ff43b5d3760470c
+    name: libgomp
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libmnl-1.0.4-16.el9_4.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 30479
+    checksum: sha256:b07344f5116a1913e746042748b05f978d284833282d9633e29f3d595ab596e9
+    name: libmnl
+    evr: 1.0.4-16.el9_4
+    sourcerpm: libmnl-1.0.4-16.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libmount-2.37.4-25.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 140081
+    checksum: sha256:152aee3abc8d97a37ff4ce2f5027d7e16e93ff2c77d25e900258da54e6fcc64e
+    name: libmount
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 61151
+    checksum: sha256:28d0047c487c8d8bc6b9544fa0a6ac837a50c309641c689e834a4959d6f1ac01
+    name: libnetfilter_conntrack
+    evr: 1.0.9-1.el9
+    sourcerpm: libnetfilter_conntrack-1.0.9-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnfnetlink-1.0.1-23.el9_5.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 31790
+    checksum: sha256:3bc75fd1a2cf80c51709901538ad65555406ffb0805a91fd59ce02f1a8ddd67c
+    name: libnfnetlink
+    evr: 1.0.1-23.el9_5
+    sourcerpm: libnfnetlink-1.0.1-23.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libnftnl-1.2.6-4.el9_4.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 88780
+    checksum: sha256:3e5aa1f38999f45d1720a28af8363a0989e41e8627d70cb18556f2c96841700f
+    name: libnftnl
+    evr: 1.2.6-4.el9_4
+    sourcerpm: libnftnl-1.2.6-4.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 38310
+    checksum: sha256:9bdfccf6b092e0683aa6984f7c6caa737b30c0b1495e16abb03b5d1a5f8e787a
+    name: libpkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 125712
+    checksum: sha256:1657d94bbd79f93dc7a79d474316813bde681ce3a7f62f73314ec4d630e39349
+    name: libpwquality
+    evr: 1.4.4-8.el9
+    sourcerpm: libpwquality-1.4.4-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libsmartcols-2.37.4-25.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 67440
+    checksum: sha256:1704e73a566c920796d877c7bc3e5a96ea0c0c4194109c7b085c1128c01856af
+    name: libsmartcols
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libstdc++-11.5.0-14.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 723913
+    checksum: sha256:ae00c5009a2ee4682ec732cde66d3f4fcfc1a7099ba7b3701767d1748a4f2683
+    name: libstdc++
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 30505
+    checksum: sha256:d352371cbb7d5bd0c53fc699df953c8c1f184b056690b3c4571e57a6634015c5
+    name: libutempter
+    evr: 1.2.1-6.el9
+    sourcerpm: libutempter-1.2.1-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libuuid-2.37.4-25.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 32555
+    checksum: sha256:4d7bb4144053a30067a82423fb6e88fd08c7a69bd256eb21b08c0e3f4dbbaee6
+    name: libuuid
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/make-4.3-8.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 550249
+    checksum: sha256:351a22b0e6744bd329b1b0f22d9c3b69a6da970b575e6c76190cc84b0fe77450
+    name: make
+    evr: 1:4.3-8.el9
+    sourcerpm: make-4.3-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/nftables-1.0.9-7.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 431040
+    checksum: sha256:a0af6ffaa225c77236875ff68230286b6559b8a857414e278af819f843a4fabb
+    name: nftables
+    evr: 1:1.0.9-7.el9_8
+    sourcerpm: nftables-1.0.9-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-9.9p1-7.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 431979
+    checksum: sha256:be18971dc20baa2fc820ec357d145bc5f9dbd88fd87e04b4016d8f77183525ae
+    name: openssh
+    evr: 9.9p1-7.el9_8
+    sourcerpm: openssh-9.9p1-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssh-clients-9.9p1-7.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 768861
+    checksum: sha256:37ac77703fc47951b231cab696f52f00485f0811ed893d7c68a038eef81c9d8f
+    name: openssh-clients
+    evr: 9.9p1-7.el9_8
+    sourcerpm: openssh-9.9p1-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-3.5.5-6.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 1541002
+    checksum: sha256:9f10be36d0d532c65a3f9a41f7d0cd3190b0b908f60850862cc24cab06cd1101
+    name: openssl
+    evr: 1:3.5.5-6.el9_8
+    sourcerpm: openssl-3.5.5-6.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 14220
+    checksum: sha256:158193d2f965db318148ec76e9347b530ac1f5379d849012c0a04d3c50cda478
+    name: openssl-fips-provider
+    evr: 3.0.7-11.el9_8
+    sourcerpm: openssl-fips-provider-3.0.7-11.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 529340
+    checksum: sha256:22374a51f8a529dcfcf3b3ebbb2095103e0e811a28953535e5a62e26d1233301
+    name: openssl-fips-provider-so
+    evr: 3.0.7-11.el9_8
+    sourcerpm: openssl-fips-provider-3.0.7-11.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-libs-3.5.5-6.el9_8.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 2290581
+    checksum: sha256:9af799c6be853cb42999a1228a2768da20a21895b7dcac111dba3be13a397b67
+    name: openssl-libs
+    evr: 1:3.5.5-6.el9_8
+    sourcerpm: openssl-3.5.5-6.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pam-1.5.1-28.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 635826
+    checksum: sha256:eab9afe4a8ef70912d8c59c0d8c429c0474436e756d37bcd9ee0589f9a1c9311
+    name: pam
+    evr: 1.5.1-28.el9
+    sourcerpm: pam-1.5.1-28.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 45196
+    checksum: sha256:aa38a3951a690d721a815ea8f9b01995a85f35a8540d8075205821011d0385e6
+    name: pkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 16054
+    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
+    name: pkgconf-m4
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 12398
+    checksum: sha256:47f1f744f96a2f3d360bc129837738dcebb1ee5032effc4472a891eea1d6a907
+    name: pkgconf-pkg-config
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/psmisc-23.4-3.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 252522
+    checksum: sha256:609ffc1ea49d733bf2fabf521851acf20e62cd873c3679f735bc7486b2434359
+    name: psmisc
+    evr: 23.4-3.el9
+    sourcerpm: psmisc-23.4-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/t/tar-1.34-11.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 904777
+    checksum: sha256:62f985a87e048caa3ef883966d6176448398abc42df00ebff07e7311ff5f425d
+    name: tar
+    evr: 2:1.34-11.el9
+    sourcerpm: tar-1.34-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/util-linux-2.37.4-25.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 2390152
+    checksum: sha256:3681bbe37d46309673f366135787f5713f0ef575e3cd413cd221af2512e3634b
+    name: util-linux
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/util-linux-core-2.37.4-25.el9.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 472949
+    checksum: sha256:de7ad826dd42b383d93f6dc6b720a26d4cd4815d00c0f093c2e28037a8881424
+    name: util-linux-core
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.10.noarch.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 22399
+    checksum: sha256:9fc9ef3ba0b22a599b2a7b34bd0b025afd5f2623e9132b4ead19e98f9c62e97d
+    name: vim-filesystem
+    evr: 2:8.2.2637-26.el9_8.10
+    sourcerpm: vim-8.2.2637-26.el9_8.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.aarch64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 235798
+    checksum: sha256:26ac21be6c1e396c7bcbaa9d4786e3275e996d9d78c01f75bbbc6962e6c9bef7
+    name: xz
+    evr: 5.2.5-8.el9_0
+    sourcerpm: xz-5.2.5-8.el9_0.src.rpm
   source: []
-lockfileVendor: redhat
-lockfileVersion: 1
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-3.31.8-3.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 13989883
+    checksum: sha256:e67ea7aef1edd470e4ec22982e97871655abcdc0990754d4e8f147d4e7de317a
+    name: cmake
+    evr: 3.31.8-3.el9
+    sourcerpm: cmake-3.31.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-data-3.31.8-3.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2829291
+    checksum: sha256:1cdc2e88a996c575b750483c8f562674e4b50a6ab414c7bbe6f6b641c1db7bd9
+    name: cmake-data
+    evr: 3.31.8-3.el9
+    sourcerpm: cmake-3.31.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-filesystem-3.31.8-3.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 19309
+    checksum: sha256:b5ea81385a9e4e6a1ae2bb1175cd774af82f9c570a37008cde873ead466ba5f7
+    name: cmake-filesystem
+    evr: 3.31.8-3.el9
+    sourcerpm: cmake-3.31.8-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cpp-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 11226193
+    checksum: sha256:3c0ee1cb8b72f3f5176f8945ab518eb733ccc9f950d317fb5d5ac327d0eb9c90
+    name: cpp
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/e/emacs-filesystem-27.2-18.el9.noarch.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 9495
+    checksum: sha256:49d7b88a05a72c15b78191a987e6def04fda8e2e4ff75711f715d0c0ecadc60f
+    name: emacs-filesystem
+    evr: 1:27.2-18.el9
+    sourcerpm: emacs-27.2-18.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 33982584
+    checksum: sha256:2082784165bbb246b6e5ef5921ed823f0a9709cacdf5823aa60695fd6d4819a2
+    name: gcc
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-c++-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 13474286
+    checksum: sha256:b073d8965ad8eed7520a2a1c9b7c961232511ad9188dcc8c92356160a9d51e37
+    name: gcc-c++
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-2.52.0-1.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 5293286
+    checksum: sha256:6264aa556d583604f34def3674f5830a70cfee0aac283719e4df295db38acb53
+    name: git-core
+    evr: 2.52.0-1.el9
+    sourcerpm: git-2.52.0-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-274.el9_8.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 46571
+    checksum: sha256:e6176ffaf004619a3c4c6d69fc3499a90697cfea221c46e014d605e452bb859d
+    name: glibc-devel
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-274.el9_8.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 567160
+    checksum: sha256:98c8a2b2939f7decf299713dd4625c1ca1e8a3b536d6607db3cde04e32799bcd
+    name: glibc-headers
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.31.1.el9_8.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2901125
+    checksum: sha256:f9c558adfc811feb7c1d2461c5a0a4646bbf1b77e5cc079eb66cee6992b3d88d
+    name: kernel-headers
+    evr: 5.14.0-687.31.1.el9_8
+    sourcerpm: kernel-5.14.0-687.31.1.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 66075
+    checksum: sha256:b97b4e98c3c6f41dcfc2ceb4ffa1aba7a338b7cfd9e6c4f63e3160dd3cc033d3
+    name: libmpc
+    evr: 1.2.1-4.el9
+    sourcerpm: libmpc-1.2.1-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libstdc++-devel-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 2524816
+    checksum: sha256:2d031d05fe073adc74919b8372763ae322615d9df23f4a2c642050ab4b389ce5
+    name: libstdc++-devel
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 154427
+    checksum: sha256:e1fab39251239ccaad2fb4dbe6c55ec1ae60f76d4ae81582b06e6a58e30879b2
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+    sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 33101
+    checksum: sha256:c1d171391a7d2e043a6953efd3df3e01edc9b4c6cdb54517e1608d204a5fce18
+    name: libxcrypt-devel
+    evr: 4.4.18-3.el9
+    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/openssl-devel-3.5.5-6.el9_8.x86_64.rpm
+    repoid: ubi-9-appstream-rpms
+    size: 5029526
+    checksum: sha256:84e54b3467ecfe70c75688f28dbc0e071e268d845db17b28a1f35a35d45640cd
+    name: openssl-devel
+    evr: 1:3.5.5-6.el9_8
+    sourcerpm: openssl-3.5.5-6.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-72.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 4821853
+    checksum: sha256:bda706d43bf47267e31db8ac62fe3206122f97ff035daa6c93ce9cd5063a63ca
+    name: binutils
+    evr: 2.35.2-72.el9
+    sourcerpm: binutils-2.35.2-72.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 758393
+    checksum: sha256:4d429d1030d8e1c610ba5aea83f8c63090033f440b2c8f788f0e0acd4a3c51b3
+    name: binutils-gold
+    evr: 2.35.2-72.el9
+    sourcerpm: binutils-2.35.2-72.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cracklib-2.9.6-28.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 102444
+    checksum: sha256:3b415381d4bd307686268ec42f646c7770f6a815de73a40a88aab7a7061b30a9
+    name: cracklib
+    evr: 2.9.6-28.el9
+    sourcerpm: cracklib-2.9.6-28.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-28.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 3829431
+    checksum: sha256:61c11d3c23b62016b9939f917bb7f7e03cba324eb4ad35b375387ce9f18e25a1
+    name: cracklib-dicts
+    evr: 2.9.6-28.el9
+    sourcerpm: cracklib-2.9.6-28.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 43826
+    checksum: sha256:1635fd1ecaa9492fa925956dfd56d10063ca336619218f124ab45df0a38b41b0
+    name: elfutils-debuginfod-client
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-default-yama-scope-0.194-1.el9.noarch.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 8949
+    checksum: sha256:c473f42c0fec97e2830580110509e4522bc62d9b11761d062499354a0bf58959
+    name: elfutils-default-yama-scope
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 205864
+    checksum: sha256:00bbe4776149d8ccedcdf19dd6ceb08c3bb42ff41b98d744abe101af0b11a6c5
+    name: elfutils-libelf
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 274670
+    checksum: sha256:ad4f6d425cbc975cead56a2c982e38b0146d00944cbd9b3072d3d1f1271237a5
+    name: elfutils-libs
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/expat-2.5.0-6.el9_8.1.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 126909
+    checksum: sha256:6a0c98d67b643fe620297e4cd7e990f99a86ed6bc90a8295a952c626ecbb9f62
+    name: expat
+    evr: 2.5.0-6.el9_8.1
+    sourcerpm: expat-2.5.0-6.el9_8.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-2.34-274.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 2083155
+    checksum: sha256:3a68581527ea2aa67a57610951bd9722019cc32db691cace00dc7478cab312ec
+    name: glibc
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-common-2.34-274.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 321676
+    checksum: sha256:d741ab036ed8b97022052adb291a749a0ca1d5e492bd906aa7da95af9866bd2b
+    name: glibc-common
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-langpack-en-2.34-274.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 684459
+    checksum: sha256:1491343a7653599e4fbea03780731c6777df85dc998bafb237658cde3728b663
+    name: glibc-langpack-en
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-274.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 30969
+    checksum: sha256:da6b677193283cedf470f17894638ef1a633c114e4b51464c49548a19166a68e
+    name: glibc-minimal-langpack
+    evr: 2.34-274.el9_8
+    sourcerpm: glibc-2.34-274.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 171206
+    checksum: sha256:c8b3e0414d55b1eedb0185a564ac6cb2368bee2fd5f995447d045f6a714488ac
+    name: gzip
+    evr: 1.12-1.el9
+    sourcerpm: gzip-1.12-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/i/iproute-6.17.0-2.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 894459
+    checksum: sha256:008c615c830a69009a560ce44d9eb5924a793ee89b977856a91f1b7099bad1d5
+    name: iproute
+    evr: 6.17.0-2.el9
+    sourcerpm: iproute-6.17.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/i/iptables-libs-1.8.10-11.el9_5.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 476678
+    checksum: sha256:3e79ca4cc3d35c1f1e0ac6c9f05c5be56b7ab6dd1f8ae719a21ec1b9e3bfa018
+    name: iptables-libs
+    evr: 1.8.10-11.el9_5
+    sourcerpm: iptables-1.8.10-11.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/i/iptables-nft-1.8.10-11.el9_5.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 214056
+    checksum: sha256:54e031813637738af285ff4b1c2e4a20b913f2ea643a29940a07ccaf8bd197f5
+    name: iptables-nft
+    evr: 1.8.10-11.el9_5
+    sourcerpm: iptables-1.8.10-11.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/j/jansson-2.14-1.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 49137
+    checksum: sha256:4e9aec51ee46d7265d6edd1245b5d5ab5e8336dc2a4ca17f2cace2ce8bae3761
+    name: jansson
+    evr: 2.14-1.el9
+    sourcerpm: jansson-2.14-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/less-590-6.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 166025
+    checksum: sha256:5bd040f9dd813167935fc390d546c119d90e0a9c77447a3d9ed1ef69c6f5a32a
+    name: less
+    evr: 590-6.el9
+    sourcerpm: less-590-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libblkid-2.37.4-25.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 114192
+    checksum: sha256:a858400abe83a7955ae509c920f835a950ea2cf1156916823c595a23ba46d536
+    name: libblkid
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libbpf-1.5.0-3.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 188749
+    checksum: sha256:72673b289f5b720462aca02125411285b259139988be54dff7646d7639f7b26d
+    name: libbpf
+    evr: 2:1.5.0-3.el9
+    sourcerpm: libbpf-1.5.0-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 60575
+    checksum: sha256:588e8736af3376abfb3cdf372c10baef02c40d916a55958f3bee9767f9ad8526
+    name: libcbor
+    evr: 0.7.0-5.el9
+    sourcerpm: libcbor-0.7.0-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 755192
+    checksum: sha256:3246e76f197e2b60eb470b9b55d3e0dda2301b029f295fed9c38ff70b87c5b6b
+    name: libdb
+    evr: 5.3.28-57.el9_6
+    sourcerpm: libdb-5.3.28-57.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libeconf-0.4.1-7.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 33179
+    checksum: sha256:a570c5baaedeb1445bc2e4f3930b0a709411bbefbdbf463c3e006cbfc7018894
+    name: libeconf
+    evr: 0.4.1-7.el9_8
+    sourcerpm: libeconf-0.4.1-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 112056
+    checksum: sha256:65a730688dfea27934b75af3acf30150c6d254c89d8b68b63233ae7f8b6c9b94
+    name: libedit
+    evr: 3.1-39.20210216cvs.el9
+    sourcerpm: libedit-3.1-39.20210216cvs.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfdisk-2.37.4-25.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 161769
+    checksum: sha256:1b861f267752e718ce696a80dcc06ef1dde8e9aa73fa2abed3775626d719c124
+    name: libfdisk
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 102746
+    checksum: sha256:6da940c0528f3e4453db84cb85b402c8f4293a197b1921158df9651edb4845e0
+    name: libfido2
+    evr: 1.13.0-2.el9
+    sourcerpm: libfido2-1.13.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgcc-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 87280
+    checksum: sha256:77c66827ffc14df2f43612b26128b1fd58d5c9597d4d4e564aa239b161272872
+    name: libgcc
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 263723
+    checksum: sha256:87b9a7316760374111290e6e4c76ee4d093566f08a7c7c91ad7827c5948afb69
+    name: libgomp
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libmnl-1.0.4-16.el9_4.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 30949
+    checksum: sha256:badfd4eb5b7cd3622da84168674002ec718ef810ce615a1113d3e19e265b777e
+    name: libmnl
+    evr: 1.0.4-16.el9_4
+    sourcerpm: libmnl-1.0.4-16.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libmount-2.37.4-25.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 142467
+    checksum: sha256:a9a2022eb9e39301bfcd3273573a108486b2b315c89247f147870016b2e9222c
+    name: libmount
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 62066
+    checksum: sha256:beeb73e78390077c6afd9ed6177bad8bad278dbfaae9d90edf7243cdf6a44a3f
+    name: libnetfilter_conntrack
+    evr: 1.0.9-1.el9
+    sourcerpm: libnetfilter_conntrack-1.0.9-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnfnetlink-1.0.1-23.el9_5.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 32236
+    checksum: sha256:177882bfe48c9c9effc7b1bce6b58b2466988c53e400c07fb1ba2d3a4ebe6f40
+    name: libnfnetlink
+    evr: 1.0.1-23.el9_5
+    sourcerpm: libnfnetlink-1.0.1-23.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libnftnl-1.2.6-4.el9_4.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 91380
+    checksum: sha256:e64d7b270be4be36af80ed220852cb760a1069e34667b1ba9eec7a02762a14bf
+    name: libnftnl
+    evr: 1.2.6-4.el9_4
+    sourcerpm: libnftnl-1.2.6-4.el9_4.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 38387
+    checksum: sha256:4feae5941b73640bd86b8d506a657cac5b770043db1464fbcd207721b2159dda
+    name: libpkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 126104
+    checksum: sha256:14b7ff2f7fdaf8ebec90261f4619ea7f7c3564c4de8483666de7ed4b1f49b66f
+    name: libpwquality
+    evr: 1.4.4-8.el9
+    sourcerpm: libpwquality-1.4.4-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libsmartcols-2.37.4-25.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 68692
+    checksum: sha256:c1da912799780b89cd44db4acc318ea4a83adba0d8d99aad1b877879f40dbd48
+    name: libsmartcols
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libstdc++-11.5.0-14.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 763021
+    checksum: sha256:513df35338962e053052b9d52429e8a5f3d60dfe6b1757cd9faaf61d6abda955
+    name: libstdc++
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 30354
+    checksum: sha256:0f1df5e0d48c2ac9914bfffa7ed569cd58e42b17ba96bb3f7cf74d1e80de2597
+    name: libutempter
+    evr: 1.2.1-6.el9
+    sourcerpm: libutempter-1.2.1-6.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libuuid-2.37.4-25.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 32757
+    checksum: sha256:5694aafca42c707f85af66bba11d102f7636ee17f586466b3ff80254e995ed7b
+    name: libuuid
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 553896
+    checksum: sha256:561f0c2251e9217c81a6c88de4d2d9231a039aaab37e8a0d2559d36ce9fa85fd
+    name: make
+    evr: 1:4.3-8.el9
+    sourcerpm: make-4.3-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/nftables-1.0.9-7.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 437853
+    checksum: sha256:175e5a5110125df894ef6f7cf7cb657cf16a3c5cee2b2847cb6e285d56c79396
+    name: nftables
+    evr: 1:1.0.9-7.el9_8
+    sourcerpm: nftables-1.0.9-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-9.9p1-7.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 442163
+    checksum: sha256:e699c3fd161d4741658320f10064bb82ab7530d07d3d34850142ccc102ce7c82
+    name: openssh
+    evr: 9.9p1-7.el9_8
+    sourcerpm: openssh-9.9p1-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-clients-9.9p1-7.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 798466
+    checksum: sha256:5663973f870ce57e55bb94e94b84ff020d6b24cbaabdca9fed99665f6513c847
+    name: openssh-clients
+    evr: 9.9p1-7.el9_8
+    sourcerpm: openssh-9.9p1-7.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.5.5-6.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 1564334
+    checksum: sha256:1c502507f42674119318b66b111448f618efe2767a55edde5fadddcecb47ac64
+    name: openssl
+    evr: 1:3.5.5-6.el9_8
+    sourcerpm: openssl-3.5.5-6.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 14256
+    checksum: sha256:c00860e9c5a1d90488aa2eb65fe41f62926b38c6b3669d331a8b97e4a60223ac
+    name: openssl-fips-provider
+    evr: 3.0.7-11.el9_8
+    sourcerpm: openssl-fips-provider-3.0.7-11.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 595008
+    checksum: sha256:60d36ad3a67d6b00e67bb0a19c0902fbb2ecdd873cf7f280a3039d04a092790c
+    name: openssl-fips-provider-so
+    evr: 3.0.7-11.el9_8
+    sourcerpm: openssl-fips-provider-3.0.7-11.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-libs-3.5.5-6.el9_8.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 2427181
+    checksum: sha256:a289cdf4da547031cd39a4f31decd0bb22649bbcb5fe4f88b939d341a83708be
+    name: openssl-libs
+    evr: 1:3.5.5-6.el9_8
+    sourcerpm: openssl-3.5.5-6.el9_8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pam-1.5.1-28.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 637912
+    checksum: sha256:15a0a5000af6f57f47c30682f7aacf3959903788e68255132b6a05bb4b713ab1
+    name: pam
+    evr: 1.5.1-28.el9
+    sourcerpm: pam-1.5.1-28.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 45675
+    checksum: sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26
+    name: pkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 16054
+    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
+    name: pkgconf-m4
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 12438
+    checksum: sha256:9a502d81d73d3303ceb53a06ad7ce525c97117ea64352174a33708bf3429283d
+    name: pkgconf-pkg-config
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/psmisc-23.4-3.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 253357
+    checksum: sha256:30ad5408417c7f06fb945dc321bef3ce31f813f25389707dd1efa7c1d337b806
+    name: psmisc
+    evr: 23.4-3.el9
+    sourcerpm: psmisc-23.4-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tar-1.34-11.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 913256
+    checksum: sha256:58b622ab7bc225731a2473e677f16c9eb51b1ed218a86a7aa039a6fed665f245
+    name: tar
+    evr: 2:1.34-11.el9
+    sourcerpm: tar-1.34-11.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/util-linux-2.37.4-25.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 2382511
+    checksum: sha256:35e0b73e574a7d8e93af0adf54adb2303f03423fd5761e357df86288f59d7933
+    name: util-linux
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/util-linux-core-2.37.4-25.el9.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 476811
+    checksum: sha256:5575c8fc753d5a81022786dac33e172a6d1602ef41d247a58465754d3f952726
+    name: util-linux-core
+    evr: 2.37.4-25.el9
+    sourcerpm: util-linux-2.37.4-25.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-26.el9_8.10.noarch.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 22399
+    checksum: sha256:9fc9ef3ba0b22a599b2a7b34bd0b025afd5f2623e9132b4ead19e98f9c62e97d
+    name: vim-filesystem
+    evr: 2:8.2.2637-26.el9_8.10
+    sourcerpm: vim-8.2.2637-26.el9_8.10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.x86_64.rpm
+    repoid: ubi-9-baseos-rpms
+    size: 235693
+    checksum: sha256:f16d17c26a241400586ddc3d734ce863e3f19d433881ec640a47bedf0dafd07b
+    name: xz
+    evr: 5.2.5-8.el9_0
+    sourcerpm: xz-5.2.5-8.el9_0.src.rpm
+  source: []
+  module_metadata: []


### PR DESCRIPTION
## Summary

Regenerate both rpms.lock.yaml files using an unregistered UBI9 container so all URLs use cdn-ubi.redhat.com (public, no auth) instead of cdn.redhat.com (requires Red Hat CDN CA certificate). Both x86_64 and aarch64 arches are included.

Remove createrepo_c and Red Hat CDN CA prerequisites from the build-local.sh script since they are no longer needed.
