### PR TITLE
docs(contributing): add gh-stack workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,6 +292,29 @@ Use [GitHub Stacked PRs](https://github.github.com/gh-stack/) when a change has 
 
 GitHub Stacked PRs is currently in private preview and must be enabled for the repository before a stack can be submitted.
 
+Install the CLI extension and configure the repository once:
+
+```shell
+gh extension install github/gh-stack
+git config rerere.enabled true
+git config remote.pushDefault origin
+```
+
+Create, submit, and inspect a two-layer stack:
+
+```shell
+gh stack init --base main feature-foundation
+# Make and commit the foundational change.
+
+gh stack add feature-follow-up
+# Make and commit the dependent change.
+
+gh stack submit --auto --remote origin
+gh stack view --json
+```
+
+The `--auto` submission creates draft PRs with titles derived from their commits. Mark the PRs ready for review after their descriptions follow the project PR template.
+
 ### Commit Messages
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/). All commit messages must follow the format:


### PR DESCRIPTION
## Summary

Add the concrete gh-stack setup and two-layer workflow on top of the stacked-PR overview in #2528.

## Related Issue

Depends on #2528. This is the second layer of a small gh-stack workflow test.

## Changes

- Add extension and repository setup commands
- Add non-interactive stack creation, submission, and inspection commands
- Explain draft PR behavior

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated (documentation-only change)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)