### PR TITLE
fix(drivers,server): fail closed on watch lag and paginate delete cleanup

### DIFF
--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -22,6 +22,11 @@ drive client provisioning UI, the driver attaches the shared
 clients to parse Kubernetes reasons, VM cache states, or other driver-local
 reason strings.
 
+Docker and VM watch streams fail closed when the in-process broadcast receiver
+lags (`resource_exhausted`). The gateway watch loop treats that as a stream
+error, reconnects, and relies on the periodic reconcile sweep to heal any
+missed Deleted/Updated events. Silently dropping lagged messages is not allowed.
+
 The capability RPC reports driver identity, version, and the default sandbox
 image used by the gateway. GPU availability stays driver-local and is validated
 when a sandbox create request asks for GPU resources.
@@ -50,7 +55,10 @@ An accepted delete (`deleted = true`) is finalized by the watcher. If the
 backend is already absent (`deleted = false`), the request removes gateway state
 synchronously. Sandbox row removal remains bound to the stable ID and resource
 version. Settings retain their existing best-effort name-based cleanup; SSH
-sessions, indexes, and watch/log buses are cleaned after confirmed removal.
+sessions and service endpoints are cleaned with paginated workspace scans
+(collect matching IDs, then delete) so large workspaces cannot leave orphaned
+rows behind a single 1,000-record page. Indexes and watch/log buses are cleaned
+after confirmed removal.
 
 The request acquires both locks before starting owned work, so cancellation
 while queued does not leave a delete armed. After that commitment point, the

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -65,6 +65,12 @@ use tracing::{info, warn};
 use url::Url;
 
 const WATCH_BUFFER: usize = 128;
+
+/// Translate a lagged broadcast receiver into the gRPC status the gateway
+/// watch loop already treats as a reconnect signal.
+fn watch_lag_status(skipped: u64) -> Status {
+    Status::resource_exhausted(format!("watch stream lagged; dropped {skipped} messages"))
+}
 const WATCH_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const WATCH_POLL_MAX_BACKOFF: Duration = Duration::from_secs(30);
 
@@ -1505,7 +1511,10 @@ impl ComputeDriver for DockerComputeDriver {
                             return;
                         }
                     }
-                    Err(broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        let _ = tx.send(Err(watch_lag_status(n))).await;
+                        return;
+                    }
                     Err(broadcast::error::RecvError::Closed) => return,
                 }
             }

--- a/crates/openshell-driver-docker/src/tests.rs
+++ b/crates/openshell-driver-docker/src/tests.rs
@@ -2226,3 +2226,14 @@ fn container_state_needs_resume_matches_startable_states() {
         );
     }
 }
+
+#[test]
+fn watch_lag_status_is_resource_exhausted() {
+    let status = watch_lag_status(17);
+    assert_eq!(status.code(), tonic::Code::ResourceExhausted);
+    assert!(
+        status.message().contains("lagged") && status.message().contains("17"),
+        "unexpected status message: {}",
+        status.message()
+    );
+}

--- a/crates/openshell-driver-vm/src/driver.rs
+++ b/crates/openshell-driver-vm/src/driver.rs
@@ -76,6 +76,12 @@ use url::{Host, Url};
 
 const DRIVER_NAME: &str = "openshell-driver-vm";
 const WATCH_BUFFER: usize = 256;
+
+/// Translate a lagged broadcast receiver into the gRPC status the gateway
+/// watch loop already treats as a reconnect signal.
+fn watch_lag_status(skipped: u64) -> Status {
+    Status::resource_exhausted(format!("watch stream lagged; dropped {skipped} messages"))
+}
 const DEFAULT_VCPUS: u8 = 2;
 const DEFAULT_MEM_MIB: u32 = 2048;
 const DEFAULT_OVERLAY_DISK_MIB: u64 = 4096;
@@ -3112,7 +3118,10 @@ impl ComputeDriver for VmDriver {
                             return;
                         }
                     }
-                    Err(broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        let _ = tx.send(Err(watch_lag_status(n))).await;
+                        return;
+                    }
                     Err(broadcast::error::RecvError::Closed) => return,
                 }
             }
@@ -5151,6 +5160,17 @@ mod tests {
 
     static ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
         std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
+    #[test]
+    fn watch_lag_status_is_resource_exhausted() {
+        let status = watch_lag_status(9);
+        assert_eq!(status.code(), Code::ResourceExhausted);
+        assert!(
+            status.message().contains("lagged") && status.message().contains("9"),
+            "unexpected status message: {}",
+            status.message()
+        );
+    }
 
     fn gpu_device_ids_config(device_ids: &[&str]) -> Struct {
         list_string_driver_config("gpu_device_ids", device_ids)

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -64,6 +64,8 @@ type SharedComputeDriver =
     Arc<dyn ComputeDriver<WatchSandboxesStream = DriverWatchStream> + Send + Sync>;
 
 const DELETE_PHASE_CAS_RETRY_LIMIT: usize = 3;
+/// Page size for sandbox-owned SSH session / service endpoint cleanup scans.
+const SANDBOX_CLEANUP_PAGE_SIZE: u32 = 1000;
 
 /// Serializes request-side deletes for the same stable sandbox ID.
 ///
@@ -1853,52 +1855,116 @@ impl ComputeRuntime {
         sandbox_id: &str,
         workspace: &str,
     ) -> Result<(), String> {
-        let records = self
-            .store
-            .list(SshSession::object_type(), workspace, 1000, 0)
-            .await
-            .map_err(|e| format!("list SSH sessions: {e}"))?;
+        self.cleanup_sandbox_ssh_sessions_paginated(
+            sandbox_id,
+            workspace,
+            SANDBOX_CLEANUP_PAGE_SIZE,
+        )
+        .await
+    }
 
-        for record in records {
-            if let Ok(session) = SshSession::decode(record.payload.as_slice())
-                && session.sandbox_id == sandbox_id
-            {
-                self.store
-                    .delete(SshSession::object_type(), session.object_id())
-                    .await
-                    .map_err(|e| format!("delete SSH session {}: {e}", session.object_id()))?;
+    /// Collect matching SSH session IDs across all workspace pages, then
+    /// delete. Collect-then-delete avoids offset drift from mutating the
+    /// store mid-pagination.
+    async fn cleanup_sandbox_ssh_sessions_paginated(
+        &self,
+        sandbox_id: &str,
+        workspace: &str,
+        page_size: u32,
+    ) -> Result<(), String> {
+        let mut to_delete = Vec::new();
+        let mut offset = 0u32;
+        loop {
+            let records = self
+                .store
+                .list(SshSession::object_type(), workspace, page_size, offset)
+                .await
+                .map_err(|e| format!("list SSH sessions: {e}"))?;
+            if records.is_empty() {
+                break;
             }
+            let page_len = u32::try_from(records.len())
+                .map_err(|_| "SSH session page size exceeded u32".to_string())?;
+            for record in records {
+                if let Ok(session) = SshSession::decode(record.payload.as_slice())
+                    && session.sandbox_id == sandbox_id
+                {
+                    to_delete.push(session.object_id().to_string());
+                }
+            }
+            offset = offset
+                .checked_add(page_len)
+                .ok_or_else(|| "SSH session pagination offset overflow".to_string())?;
+            if page_len < page_size {
+                break;
+            }
+        }
+
+        for session_id in to_delete {
+            self.store
+                .delete(SshSession::object_type(), &session_id)
+                .await
+                .map_err(|e| format!("delete SSH session {session_id}: {e}"))?;
         }
 
         Ok(())
     }
 
-    // TODO: introduce a per-sandbox cap on service endpoints and paginate
-    // this cleanup loop, or query by sandbox label instead of scanning the
-    // full workspace. Without a cap the flat 1,000-record page could miss
-    // endpoints in large workspaces.
     async fn cleanup_sandbox_service_endpoints(
         &self,
         sandbox_id: &str,
         workspace: &str,
     ) -> Result<(), String> {
-        let records = self
-            .store
-            .list(ServiceEndpoint::object_type(), workspace, 1000, 0)
-            .await
-            .map_err(|e| format!("list service endpoints: {e}"))?;
+        self.cleanup_sandbox_service_endpoints_paginated(
+            sandbox_id,
+            workspace,
+            SANDBOX_CLEANUP_PAGE_SIZE,
+        )
+        .await
+    }
 
-        for record in records {
-            if let Ok(endpoint) = ServiceEndpoint::decode(record.payload.as_slice())
-                && endpoint.sandbox_id == sandbox_id
-            {
-                self.store
-                    .delete(ServiceEndpoint::object_type(), endpoint.object_id())
-                    .await
-                    .map_err(|e| {
-                        format!("delete service endpoint {}: {e}", endpoint.object_id())
-                    })?;
+    /// Collect matching service endpoint IDs across all workspace pages, then
+    /// delete. Without pagination a flat 1,000-record page could miss
+    /// endpoints in large workspaces and leave live routing records behind.
+    async fn cleanup_sandbox_service_endpoints_paginated(
+        &self,
+        sandbox_id: &str,
+        workspace: &str,
+        page_size: u32,
+    ) -> Result<(), String> {
+        let mut to_delete = Vec::new();
+        let mut offset = 0u32;
+        loop {
+            let records = self
+                .store
+                .list(ServiceEndpoint::object_type(), workspace, page_size, offset)
+                .await
+                .map_err(|e| format!("list service endpoints: {e}"))?;
+            if records.is_empty() {
+                break;
             }
+            let page_len = u32::try_from(records.len())
+                .map_err(|_| "service endpoint page size exceeded u32".to_string())?;
+            for record in records {
+                if let Ok(endpoint) = ServiceEndpoint::decode(record.payload.as_slice())
+                    && endpoint.sandbox_id == sandbox_id
+                {
+                    to_delete.push(endpoint.object_id().to_string());
+                }
+            }
+            offset = offset
+                .checked_add(page_len)
+                .ok_or_else(|| "service endpoint pagination offset overflow".to_string())?;
+            if page_len < page_size {
+                break;
+            }
+        }
+
+        for endpoint_id in to_delete {
+            self.store
+                .delete(ServiceEndpoint::object_type(), &endpoint_id)
+                .await
+                .map_err(|e| format!("delete service endpoint {endpoint_id}: {e}"))?;
         }
 
         Ok(())
@@ -3418,6 +3484,128 @@ mod tests {
                 .is_some(),
             expected
         );
+    }
+
+    #[tokio::test]
+    async fn cleanup_service_endpoints_paginates_past_page_size() {
+        let runtime = test_runtime(Arc::new(NoopTestDriver)).await;
+        let target = sandbox_record("sb-target", "target", SandboxPhase::Ready);
+        let other = sandbox_record("sb-other", "other", SandboxPhase::Ready);
+
+        // page_size=3 with 7 target endpoints requires multiple pages; noise
+        // endpoints for another sandbox must survive.
+        for i in 0..7 {
+            let endpoint = ServiceEndpoint {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: format!("ep-target-{i}"),
+                    name: format!("{}--svc{i}", target.object_name()),
+                    created_at_ms: 1_000_000,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                    annotations: HashMap::new(),
+                    workspace: "default".to_string(),
+                    deletion_timestamp_ms: 0,
+                }),
+                sandbox_id: target.object_id().to_string(),
+                sandbox_name: target.object_name().to_string(),
+                service_name: format!("svc{i}"),
+                target_port: 8080 + i,
+                domain: true,
+            };
+            runtime.store.put_message(&endpoint).await.unwrap();
+        }
+        for i in 0..2 {
+            let endpoint = ServiceEndpoint {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    id: format!("ep-other-{i}"),
+                    name: format!("{}--noise{i}", other.object_name()),
+                    created_at_ms: 1_000_000,
+                    labels: HashMap::new(),
+                    resource_version: 0,
+                    annotations: HashMap::new(),
+                    workspace: "default".to_string(),
+                    deletion_timestamp_ms: 0,
+                }),
+                sandbox_id: other.object_id().to_string(),
+                sandbox_name: other.object_name().to_string(),
+                service_name: format!("noise{i}"),
+                target_port: 9000 + i,
+                domain: true,
+            };
+            runtime.store.put_message(&endpoint).await.unwrap();
+        }
+
+        runtime
+            .cleanup_sandbox_service_endpoints_paginated(target.object_id(), "default", 3)
+            .await
+            .unwrap();
+
+        for i in 0..7 {
+            assert!(
+                runtime
+                    .store
+                    .get_message::<ServiceEndpoint>(&format!("ep-target-{i}"))
+                    .await
+                    .unwrap()
+                    .is_none(),
+                "target endpoint {i} should be deleted across pages"
+            );
+        }
+        for i in 0..2 {
+            assert!(
+                runtime
+                    .store
+                    .get_message::<ServiceEndpoint>(&format!("ep-other-{i}"))
+                    .await
+                    .unwrap()
+                    .is_some(),
+                "unrelated endpoint {i} must remain"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cleanup_ssh_sessions_paginates_past_page_size() {
+        let runtime = test_runtime(Arc::new(NoopTestDriver)).await;
+        let target_id = "sb-ssh-target";
+        let other_id = "sb-ssh-other";
+
+        for i in 0..5 {
+            let session = ssh_session_record(&format!("sess-target-{i}"), target_id);
+            runtime.store.put_message(&session).await.unwrap();
+        }
+        for i in 0..2 {
+            let session = ssh_session_record(&format!("sess-other-{i}"), other_id);
+            runtime.store.put_message(&session).await.unwrap();
+        }
+
+        runtime
+            .cleanup_sandbox_ssh_sessions_paginated(target_id, "default", 2)
+            .await
+            .unwrap();
+
+        for i in 0..5 {
+            assert!(
+                runtime
+                    .store
+                    .get_message::<SshSession>(&format!("sess-target-{i}"))
+                    .await
+                    .unwrap()
+                    .is_none(),
+                "target session {i} should be deleted across pages"
+            );
+        }
+        for i in 0..2 {
+            assert!(
+                runtime
+                    .store
+                    .get_message::<SshSession>(&format!("sess-other-{i}"))
+                    .await
+                    .unwrap()
+                    .is_some(),
+                "unrelated session {i} must remain"
+            );
+        }
     }
 
     fn make_driver_condition(reason: &str, message: &str) -> DriverCondition {

--- a/crates/openshell-server/src/ssh_sessions.rs
+++ b/crates/openshell-server/src/ssh_sessions.rs
@@ -13,6 +13,9 @@ use tracing::{info, warn};
 
 use crate::persistence::{ObjectType, Store};
 
+/// Page size for the background SSH session reaper sweep.
+const REAPER_PAGE_SIZE: u32 = 1000;
+
 impl ObjectType for SshSession {
     fn object_type() -> &'static str {
         "ssh_session"
@@ -34,32 +37,54 @@ pub fn spawn_session_reaper(store: Arc<Store>, interval: Duration) {
 }
 
 async fn reap_expired_sessions(store: &Store) -> Result<(), String> {
+    reap_expired_sessions_paginated(store, REAPER_PAGE_SIZE).await
+}
+
+async fn reap_expired_sessions_paginated(store: &Store, page_size: u32) -> Result<(), String> {
     let now_ms = now_ms();
 
-    let records = store
-        .list_by_type(SshSession::object_type(), 1000, 0)
-        .await
-        .map_err(|e| e.to_string())?;
+    // Collect matching IDs across pages first so deletes do not shift
+    // offsets and leave expired/revoked sessions behind.
+    let mut to_delete = Vec::new();
+    let mut offset = 0u32;
+    loop {
+        let records = store
+            .list_by_type(SshSession::object_type(), page_size, offset)
+            .await
+            .map_err(|e| e.to_string())?;
+        if records.is_empty() {
+            break;
+        }
+        let page_len = u32::try_from(records.len())
+            .map_err(|_| "SSH session reaper page size exceeded u32".to_string())?;
+
+        for record in records {
+            let session: SshSession = match Message::decode(record.payload.as_slice()) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+
+            let should_delete =
+                (session.expires_at_ms > 0 && now_ms > session.expires_at_ms) || session.revoked;
+            if should_delete {
+                to_delete.push(session.object_id().to_string());
+            }
+        }
+
+        offset = offset
+            .checked_add(page_len)
+            .ok_or_else(|| "SSH session reaper pagination offset overflow".to_string())?;
+        if page_len < page_size {
+            break;
+        }
+    }
 
     let mut reaped = 0u32;
-    for record in records {
-        let session: SshSession = match Message::decode(record.payload.as_slice()) {
-            Ok(s) => s,
-            Err(_) => continue,
-        };
-
-        let should_delete =
-            (session.expires_at_ms > 0 && now_ms > session.expires_at_ms) || session.revoked;
-
-        if should_delete {
-            if let Err(e) = store
-                .delete(SshSession::object_type(), session.object_id())
-                .await
-            {
-                warn!(session_id = %session.object_id(), error = %e, "Failed to reap SSH session");
-            } else {
-                reaped += 1;
-            }
+    for session_id in to_delete {
+        if let Err(e) = store.delete(SshSession::object_type(), &session_id).await {
+            warn!(session_id = %session_id, error = %e, "Failed to reap SSH session");
+        } else {
+            reaped += 1;
         }
     }
 
@@ -95,6 +120,43 @@ mod tests {
             expires_at_ms,
             revoked,
         }
+    }
+
+    #[tokio::test]
+    async fn reaper_paginates_past_page_boundary() {
+        let store = test_store().await;
+        for i in 0..5 {
+            let expired = make_session(
+                &format!("expired-page-{i}"),
+                "sbx-page",
+                now_ms() - 60_000,
+                false,
+            );
+            store.put_message(&expired).await.unwrap();
+        }
+        let valid = make_session("valid-page", "sbx-page", now_ms() + 3_600_000, false);
+        store.put_message(&valid).await.unwrap();
+
+        reap_expired_sessions_paginated(&store, 2).await.unwrap();
+
+        for i in 0..5 {
+            assert!(
+                store
+                    .get_message::<SshSession>(&format!("expired-page-{i}"))
+                    .await
+                    .unwrap()
+                    .is_none(),
+                "expired session {i} should be reaped across pages"
+            );
+        }
+        assert!(
+            store
+                .get_message::<SshSession>("valid-page")
+                .await
+                .unwrap()
+                .is_some(),
+            "valid session should be kept"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Stop silently dropping lagged Docker/VM sandbox watch events, and paginate sandbox-owned cleanup so large workspaces cannot leave orphaned SSH sessions or service endpoints after delete.

## Related Issue

N/A — direct reliability fix. No open/closed/merged issue or PR covered silent `Lagged` drops or the documented 1,000-record cleanup truncation.

## Changes

- Docker and VM `watch_sandboxes`: on broadcast `Lagged`, emit `resource_exhausted` and close the stream (gateway reconnects + reconcile recovers)
- Paginate sandbox SSH session and service endpoint cleanup with collect-then-delete (avoids offset drift while deleting)
- Paginate the SSH session reaper the same way
- Document fail-closed watch lag and paginated cleanup in `architecture/compute-runtimes.md`
- Unit tests for lag status mapping, multi-page endpoint/session cleanup, and multi-page reaper sweeps

## Testing

- [ ] `mise run pre-commit` passes (`mise` not available in this environment; `cargo fmt` applied to touched crates)
- [x] Unit tests added/updated:
  - `cargo test -p openshell-driver-docker --lib watch_lag_status`
  - `cargo test -p openshell-driver-vm --lib watch_lag_status`
  - `cargo test -p openshell-server --lib paginat --features bundled-z3`
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)

Made with [Cursor](https://cursor.com)