### PR TITLE
fix(cli): bracket IPv6 bind literals in SSH forwards

### DIFF
--- a/crates/openshell-core/src/forward.rs
+++ b/crates/openshell-core/src/forward.rs
@@ -8,6 +8,7 @@
 
 use crate::paths::{create_dir_restricted, xdg_config_dir};
 use miette::{IntoDiagnostic, Result, WrapErr};
+use std::borrow::Cow;
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::Command;
@@ -580,18 +581,28 @@ impl ForwardSpec {
     }
 
     /// The SSH `-L` local-forward argument: `bind_addr:port:127.0.0.1:port`.
+    ///
+    /// IPv6 bind literals are bracketed (`::1` → `[::1]`) because OpenSSH
+    /// rejects an unbracketed IPv6 address in a forward specification.
     pub fn ssh_forward_arg(&self) -> String {
-        format!("{}:{}:127.0.0.1:{}", self.bind_addr, self.port, self.port)
+        format!(
+            "{}:{}:127.0.0.1:{}",
+            bracket_ipv6_host(&self.bind_addr),
+            self.port,
+            self.port
+        )
     }
 
     /// A human-readable URL for the forwarded port.
     pub fn access_url(&self) -> String {
+        // Wildcard binds are not connectable targets, so display a reachable
+        // loopback host instead.
         let host = if self.bind_addr == "0.0.0.0" || self.bind_addr == "::" {
             "localhost"
         } else {
             &self.bind_addr
         };
-        format!("http://{host}:{}/", self.port)
+        format!("{}/", format_gateway_url("http", host, self.port))
     }
 }
 
@@ -747,18 +758,24 @@ pub fn resolve_ssh_gateway(
     (gateway_host.to_string(), gateway_port)
 }
 
-/// Format a gateway URL, bracketing IPv6 literals when needed.
-pub fn format_gateway_url(scheme: &str, host: &str, port: u16) -> String {
-    let host = if host
+/// Bracket a bare IPv6 literal (e.g. `::1` → `[::1]`) so it can be embedded in
+/// `host:port` syntax. Non-IPv6 hosts (DNS names, IPv4) and already-bracketed
+/// literals are returned unchanged.
+fn bracket_ipv6_host(host: &str) -> Cow<'_, str> {
+    if host
         .parse::<std::net::IpAddr>()
         .is_ok_and(|ip| ip.is_ipv6())
         && !host.starts_with('[')
     {
-        format!("[{host}]")
+        Cow::Owned(format!("[{host}]"))
     } else {
-        host.to_string()
-    };
-    format!("{scheme}://{host}:{port}")
+        Cow::Borrowed(host)
+    }
+}
+
+/// Format a gateway URL, bracketing IPv6 literals when needed.
+pub fn format_gateway_url(scheme: &str, host: &str, port: u16) -> String {
+    format!("{scheme}://{}:{port}", bracket_ipv6_host(host))
 }
 
 /// Shell-escape a value for use inside a `ProxyCommand` string.
@@ -1414,6 +1431,17 @@ mod tests {
     }
 
     #[test]
+    fn forward_spec_ssh_forward_arg_brackets_ipv6_literal() {
+        // OpenSSH rejects an unbracketed IPv6 bind address in a `-L`
+        // specification; the literal must be wrapped in brackets.
+        let spec = ForwardSpec::parse("::1:8080").unwrap();
+        assert_eq!(spec.ssh_forward_arg(), "[::1]:8080:127.0.0.1:8080");
+
+        let spec = ForwardSpec::parse(":::8080").unwrap();
+        assert_eq!(spec.ssh_forward_arg(), "[::]:8080:127.0.0.1:8080");
+    }
+
+    #[test]
     fn ssh_forward_command_matches_exact_l_argument() {
         let command = "ssh -o ProxyCommand=openshell ssh-proxy --sandbox-id sbx-1 -N -L 80:127.0.0.1:80 sandbox";
         let compact = "ssh -o ProxyCommand=openshell ssh-proxy --sandbox-id sbx-1 -N -L80:127.0.0.1:80 sandbox";
@@ -1660,6 +1688,18 @@ mod tests {
         assert_eq!(spec.access_url(), "http://127.0.0.1:8080/");
 
         let spec = ForwardSpec::parse("0.0.0.0:8080").unwrap();
+        assert_eq!(spec.access_url(), "http://localhost:8080/");
+    }
+
+    #[test]
+    fn forward_spec_access_url_ipv6() {
+        // A specific IPv6 loopback literal must be bracketed for a valid URL.
+        let spec = ForwardSpec::parse("::1:8080").unwrap();
+        assert_eq!(spec.access_url(), "http://[::1]:8080/");
+
+        // The IPv6 wildcard bind is not a connectable target, so it maps to a
+        // reachable host for display.
+        let spec = ForwardSpec::parse(":::8080").unwrap();
         assert_eq!(spec.access_url(), "http://localhost:8080/");
     }
 


### PR DESCRIPTION
## Summary

`openshell forward start ::1:8080 <sandbox>` built an invalid SSH local-forward argument and an invalid access URL because IPv6 bind literals were never bracketed. This fix brackets IPv6 literals so OpenSSH accepts the `-L` specification and the displayed URL is valid.

## Related Issue

Fixes #2279

## Changes

- Extracted a shared `bracket_ipv6_host()` helper in `crates/openshell-core/src/forward.rs`.
- `ForwardSpec::ssh_forward_arg()` now brackets IPv6 bind literals (`::1:8080:127.0.0.1:8080` → `[::1]:8080:127.0.0.1:8080`), which OpenSSH accepts.
- `ForwardSpec::access_url()` now formats via the existing `format_gateway_url()` helper, producing `http://[::1]:8080/` while keeping the wildcard (`::`/`0.0.0.0`) → `localhost` display mapping.
- Refactored `format_gateway_url()` to reuse the new helper (DRY).
- Added regression tests covering IPv6 loopback and wildcard binds for both methods.

The reverse process-matching in `ssh_forward_arg_matches_openshell_loopback_port` matches on the `:{port}:127.0.0.1:{port}` suffix, so bracketed bind prefixes still match — background-forward validation is unaffected.

## Testing

- [x] `mise run pre-commit` passes (Rust lint/format/tests clean; the unrelated pre-existing `helm:lint` chart-metadata error is not touched by this change)
- [x] Unit tests added/updated (`forward_spec_ssh_forward_arg_brackets_ipv6_literal`, `forward_spec_access_url_ipv6`)
- [ ] E2E tests added/updated (if applicable) — not applicable; pure CLI argument-formatting fix covered by unit tests

Verified locally: `cargo test -p openshell-core --lib` (362 passed) and `cargo test -p openshell-cli --lib ssh::` (40 passed).

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — not applicable
