### PR TITLE
fix(server): notify watchers after atomic policy commits

### DIFF
--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -2234,6 +2234,7 @@ async fn handle_update_config_inner(
         })?
     };
     response_annotations = committed_annotations;
+    state.sandbox_watch_bus.notify(&sandbox_id);
 
     if backfill_policy.is_some() {
         info!(
@@ -12517,6 +12518,7 @@ mod tests {
             )
             .await
             .unwrap();
+        let mut watch_rx = state.sandbox_watch_bus.subscribe("sb-same-hash");
 
         let response = handle_update_config(
             &state,
@@ -12535,6 +12537,16 @@ mod tests {
         .into_inner();
 
         assert_eq!(response.version, 2);
+        watch_rx
+            .try_recv()
+            .expect("new provenance revision must notify the sandbox watcher");
+        assert!(
+            matches!(
+                watch_rx.try_recv(),
+                Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+            ),
+            "one committed revision must wake the sandbox watcher exactly once"
+        );
         assert_eq!(
             response
                 .annotations


### PR DESCRIPTION
## Summary

Notify sandbox watchers after an atomic `UpdateConfig` policy revision commits.
Without this notification, live `WatchSandbox(follow_status=true)` consumers can
continue showing stale sandbox state until another event occurs. Sandbox
supervisors poll `GetSandboxConfig` independently and are not affected by this
notification gap.

## Related Issue

Fixes #2517

## Changes

- Notify the sandbox watch bus only after `put_policy_revision_atomic` succeeds.
- Extend the existing same-policy/new-provenance regression test to assert that
  one committed revision emits exactly one watcher notification.
- Preserve conflict retry and failure behavior so unsuccessful writes do not
  notify observers.

## Testing

- [x] `CARGO_INCREMENTAL=0 mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (not applicable)

Focused test:

```text
CARGO_INCREMENTAL=0 mise exec -- cargo test -p openshell-server \
  update_config_same_policy_hash_with_new_provenance_creates_revision --lib

test result: ok. 1 passed; 0 failed
```

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)
