### PR TITLE
fix(ci): preserve KVM access across udev restarts

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -337,7 +337,7 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
             | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
+          sudo udevadm trigger --settle --name-match=kvm
 
           ls -l /dev/kvm
           exec 3<>/dev/kvm

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -305,21 +305,6 @@ jobs:
         with:
           artifact-name: ${{ inputs.vm-driver-artifact-name }}
 
-      - name: Enable KVM access
-        run: |
-          set -euo pipefail
-          if [[ ! -c /dev/kvm ]]; then
-            echo "::error::The GitHub-hosted runner did not expose /dev/kvm"
-            lscpu
-            grep -m1 -E '^(flags|Features)' /proc/cpuinfo || true
-            ls -la /dev
-            exit 1
-          fi
-          sudo chmod 0666 /dev/kvm
-          ls -l /dev/kvm
-          test -r /dev/kvm
-          test -w /dev/kvm
-
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -334,6 +319,29 @@ jobs:
             pkg-config \
             socat \
             zstd
+
+      - name: Enable KVM access
+        run: |
+          set -euo pipefail
+          if [[ ! -c /dev/kvm ]]; then
+            echo "::error::The GitHub-hosted runner did not expose /dev/kvm"
+            lscpu
+            grep -m1 -E '^(flags|Features)' /proc/cpuinfo || true
+            ls -la /dev
+            exit 1
+          fi
+
+          # Package installation can restart systemd-udevd, which reapplies
+          # the default root:kvm 0660 mode. Install a persistent rule after
+          # dependencies so later udev events preserve runner access.
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+          ls -l /dev/kvm
+          exec 3<>/dev/kvm
+          exec 3>&-
 
       - name: Validate VM host tools
         run: |


### PR DESCRIPTION
## Summary

Keep VM E2E KVM access intact when package installation restarts `systemd-udevd`. Configure a persistent udev rule after dependencies and verify that the runner can actually open `/dev/kvm` before continuing.

## Related Issue

Related to the failed Release Tag job: https://github.com/NVIDIA/OpenShell/actions/runs/30553217578/job/90914553277

## Changes

- Configure KVM access after package installation so `needrestart` cannot immediately undo the setup.
- Install a persistent udev rule that preserves mode `0666` across subsequent device events.
- Replace permission-bit checks with an actual open of `/dev/kvm`.

## Testing

- [x] `mise run pre-commit`
- [ ] VM E2E test (requires a Linux KVM runner; draft PR CI will exercise it)

## Checklist

- [x] Follows Conventional Commits
- [x] Commit is signed off for DCO
- [x] Reviewed related agent skills; no updates required