### PR TITLE
test(e2e): coordinate podman cleanup with creation

### DIFF
--- a/e2e/rust/src/harness/sandbox.rs
+++ b/e2e/rust/src/harness/sandbox.rs
@@ -7,10 +7,11 @@
 //! is dropped, replacing the `trap cleanup EXIT` pattern from the bash tests.
 
 use std::process::Stdio;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 use tokio::time::timeout;
 
 use super::binary::openshell_cmd;
@@ -30,6 +31,44 @@ fn extract_sandbox_name(output: &str) -> Option<String> {
 /// base image), so 600s accommodates extraction + workspace-init + pod
 /// startup.
 const SANDBOX_READY_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Upper bound for best-effort sandbox deletion during test teardown.
+const SANDBOX_CLEANUP_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Coordinates sandbox creation and cleanup across the E2E suite.
+///
+/// Parallel tests share an external gateway and compute runtime. Without
+/// coordination, automatic cleanup from one test can overlap sandbox creation
+/// in another test, leaking teardown across test boundaries and exposing
+/// backend-specific lifecycle races.
+///
+/// Creates take a shared lock so concurrent-create coverage is preserved.
+/// Cleanup takes an exclusive lock so lifecycle teardown never overlaps
+/// creation in this test harness. This is intentionally not a
+/// production-driver lock: serializing a driver would reduce supported
+/// lifecycle concurrency.
+static E2E_LIFECYCLE_GATE: OnceLock<Arc<RwLock<()>>> = OnceLock::new();
+
+async fn create_guard() -> OwnedRwLockReadGuard<()> {
+    Arc::clone(E2E_LIFECYCLE_GATE.get_or_init(|| Arc::new(RwLock::new(()))))
+        .read_owned()
+        .await
+}
+
+async fn cleanup_guard() -> OwnedRwLockWriteGuard<()> {
+    Arc::clone(E2E_LIFECYCLE_GATE.get_or_init(|| Arc::new(RwLock::new(()))))
+        .write_owned()
+        .await
+}
+
+async fn delete_sandbox(name: &str) {
+    let _lifecycle_guard = cleanup_guard().await;
+    let mut cmd = openshell_cmd();
+    cmd.arg("sandbox").arg("delete").arg(name);
+    cmd.stdout(Stdio::null()).stderr(Stdio::null());
+
+    let _ = timeout(SANDBOX_CLEANUP_TIMEOUT, cmd.status()).await;
+}
 
 /// RAII guard that deletes a sandbox on drop.
 ///
@@ -67,6 +106,7 @@ impl SandboxGuard {
     /// Returns an error if the CLI exits with a non-zero status or the sandbox
     /// name cannot be parsed from the output.
     pub async fn create(args: &[&str]) -> Result<Self, String> {
+        let _lifecycle_guard = create_guard().await;
         let mut cmd = openshell_cmd();
         cmd.arg("sandbox").arg("create");
         for arg in args {
@@ -139,6 +179,7 @@ impl SandboxGuard {
         command: &[&str],
         ready_marker: &str,
     ) -> Result<Self, String> {
+        let _lifecycle_guard = create_guard().await;
         let mut cmd = openshell_cmd();
         cmd.arg("sandbox").arg("create").arg("--keep");
         for arg in create_args {
@@ -264,6 +305,7 @@ impl SandboxGuard {
         uploads: &[(&str, &str)],
         command: &[&str],
     ) -> Result<Self, String> {
+        let _lifecycle_guard = create_guard().await;
         let mut cmd = openshell_cmd();
         cmd.arg("sandbox").arg("create");
         for (local, dest) in uploads {
@@ -511,12 +553,7 @@ impl SandboxGuard {
             let _ = child.wait().await;
         }
 
-        // Delete the sandbox.
-        let mut cmd = openshell_cmd();
-        cmd.arg("sandbox").arg("delete").arg(&self.name);
-        cmd.stdout(Stdio::null()).stderr(Stdio::null());
-
-        let _ = cmd.status().await;
+        delete_sandbox(&self.name).await;
     }
 }
 
@@ -526,14 +563,15 @@ impl Drop for SandboxGuard {
             return;
         }
 
-        // We need to run async cleanup in a sync Drop. Use block_in_place to
-        // avoid blocking the tokio runtime. This is acceptable for test code.
         let name = self.name.clone();
         let mut child = self.child.take();
 
-        // Attempt cleanup with a new runtime if we're not inside one, or
-        // block_in_place if we are.
-        std::thread::spawn(move || {
+        // Cleanup uses a separate runtime because Drop cannot await. Join the
+        // thread so teardown completes before the guard disappears; detaching
+        // it allowed cleanup to leak into a later test or be terminated when
+        // the test process exited.
+        let cleanup_name = name.clone();
+        let cleanup = std::thread::spawn(move || {
             let rt = tokio::runtime::Runtime::new().expect("create cleanup runtime");
             rt.block_on(async {
                 if let Some(ref mut child) = child {
@@ -541,11 +579,11 @@ impl Drop for SandboxGuard {
                     let _ = child.wait().await;
                 }
 
-                let mut cmd = openshell_cmd();
-                cmd.arg("sandbox").arg("delete").arg(&name);
-                cmd.stdout(Stdio::null()).stderr(Stdio::null());
-                let _ = cmd.status().await;
+                delete_sandbox(&name).await;
             });
         });
+        if cleanup.join().is_err() {
+            eprintln!("sandbox cleanup thread panicked for {cleanup_name}");
+        }
     }
 }

--- a/e2e/rust/src/harness/sandbox.rs
+++ b/e2e/rust/src/harness/sandbox.rs
@@ -35,30 +35,43 @@ const SANDBOX_READY_TIMEOUT: Duration = Duration::from_secs(600);
 /// Upper bound for best-effort sandbox deletion during test teardown.
 const SANDBOX_CLEANUP_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Coordinates sandbox creation and cleanup across the E2E suite.
+/// Coordinates sandbox creation and cleanup in the Podman E2E lane.
 ///
-/// Parallel tests share an external gateway and compute runtime. Without
-/// coordination, automatic cleanup from one test can overlap sandbox creation
-/// in another test, leaking teardown across test boundaries and exposing
-/// backend-specific lifecycle races.
+/// A standalone Podman reproducer confirmed that removing a container with an
+/// image volume can race with another container attaching the same image. The
+/// E2E suite can trigger that Podman issue when automatic cleanup from one test
+/// overlaps sandbox creation in another test.
 ///
 /// Creates take a shared lock so concurrent-create coverage is preserved.
-/// Cleanup takes an exclusive lock so lifecycle teardown never overlaps
-/// creation in this test harness. This is intentionally not a
-/// production-driver lock: serializing a driver would reduce supported
-/// lifecycle concurrency.
-static E2E_LIFECYCLE_GATE: OnceLock<Arc<RwLock<()>>> = OnceLock::new();
+/// Cleanup takes an exclusive lock so Podman image-volume detach never overlaps
+/// attach in this test harness. This is intentionally not a production-driver
+/// lock: serializing the driver would reduce supported lifecycle concurrency.
+static PODMAN_E2E_LIFECYCLE_GATE: OnceLock<Arc<RwLock<()>>> = OnceLock::new();
 
-async fn create_guard() -> OwnedRwLockReadGuard<()> {
-    Arc::clone(E2E_LIFECYCLE_GATE.get_or_init(|| Arc::new(RwLock::new(()))))
-        .read_owned()
-        .await
+fn is_podman_e2e() -> bool {
+    std::env::var("OPENSHELL_E2E_DRIVER").as_deref() == Ok("podman")
 }
 
-async fn cleanup_guard() -> OwnedRwLockWriteGuard<()> {
-    Arc::clone(E2E_LIFECYCLE_GATE.get_or_init(|| Arc::new(RwLock::new(()))))
-        .write_owned()
-        .await
+async fn create_guard() -> Option<OwnedRwLockReadGuard<()>> {
+    if !is_podman_e2e() {
+        return None;
+    }
+    Some(
+        Arc::clone(PODMAN_E2E_LIFECYCLE_GATE.get_or_init(|| Arc::new(RwLock::new(()))))
+            .read_owned()
+            .await,
+    )
+}
+
+async fn cleanup_guard() -> Option<OwnedRwLockWriteGuard<()>> {
+    if !is_podman_e2e() {
+        return None;
+    }
+    Some(
+        Arc::clone(PODMAN_E2E_LIFECYCLE_GATE.get_or_init(|| Arc::new(RwLock::new(()))))
+            .write_owned()
+            .await,
+    )
 }
 
 async fn delete_sandbox(name: &str) {


### PR DESCRIPTION
## Summary

Prevent automatic Podman E2E sandbox cleanup from overlapping sandbox creation in another test. The Podman lane still permits concurrent creates, while teardown is exclusive against creation; other compute backends retain their existing lifecycle concurrency.

This was exposed by an intermittent Podman E2E failure and confirmed with a standalone Podman reproducer: deleting a container using an image volume can race with another container attaching the same image.

## Related Issue

No issue required: this is a localized E2E harness reliability fix with the investigation and design tradeoffs documented here.

## Changes

- Add a Podman-specific read/write lifecycle gate to `SandboxGuard`
  - creates take a shared lock, preserving concurrent-create coverage
  - cleanup takes an exclusive lock, preventing teardown from overlapping creation or another cleanup
- Join fallback cleanup from `Drop` instead of detaching a thread that can escape into a later test or be terminated at process exit
- Bound best-effort sandbox deletion to 60 seconds
- Leave Docker, Kubernetes, and VM lifecycle concurrency unchanged
- Keep production compute-driver lifecycle concurrency unchanged

## Potential issue

The Podman driver mounts the supervisor OCI image directly into every sandbox using an image volume. A standalone Podman reproducer confirmed that one container removal can race with another container attaching the same image volume. In OpenShell, that can leave the new sandbox with an incomplete supervisor mount.

The E2E harness amplified this unlikely runtime race. `SandboxGuard::drop()` previously spawned deletion in a detached thread and returned immediately, so teardown from a completed test could overlap creation in another test. The detached thread could also be terminated when an integration-test process exited.

The read/write lifecycle gate is therefore enabled only when `OPENSHELL_E2E_DRIVER=podman`. Joined, bounded fallback cleanup remains generic test-harness hygiene. The PR does not add a production mutex.

## Longer-term Podman and Docker consistency

The more durable production design may be to make Podman deliver the supervisor binary in the same way as Docker: extract the binary from the supervisor image, cache it by immutable image ID, and bind-mount the cached file read-only into each sandbox instead of mounting the complete OCI image.

Podman exposes the required stopped-container archive operation through its Docker-compatible API:
https://docs.podman.io/en/v3.0/_static/api-static.html

Implementing that design would require:

- adding binary response streaming and the container archive endpoint to `PodmanClient`
- pulling and inspecting the supervisor image and keying the cache by immutable image ID
- creating a temporary stopped container and extracting the supervisor from the returned tar archive
- sharing or extracting Docker driver utilities for archive parsing, ELF validation, atomic cache writes, and digest-keyed paths
- preserving mutable-tag refresh behavior
- mounting the driver-owned cache file read-only with the appropriate SELinux label
- defining cache permissions and stale-cache cleanup
- validating host-path behavior with Podman Machine and remote Podman, where bind sources resolve on the Podman server rather than necessarily on the API client

If host-cache binds are not portable to Podman Machine, a digest-keyed, driver-owned Podman named volume could provide a daemon-side alternative.

This larger change should be reviewed with the original Podman driver author because image-volume sideloading was an intentional part of that driver design.

## Alternatives considered

- **Production-wide mutex:** prevents the race but serializes all sandbox creates and deletes. It is also process-local, so multiple gateways connected to the same Podman service would not coordinate.
- **Production read/write lock:** preserves concurrent creates but still changes supported production lifecycle concurrency and remains process-local.
- **Single-threaded Podman E2E:** simple, but slows the complete suite and removes useful concurrent-create coverage.
- **Targeted production retry:** could preserve concurrency, but requires precise classification of the transient Podman error and safe handling of partially created containers.
- **Digest-keyed Podman named volume:** keeps supervisor delivery daemon-side and avoids per-sandbox image mounts, but adds population, versioning, and garbage-collection logic.
- **Upstream Podman fix:** the standalone reproducer can support an upstream report, but OpenShell still needs stable CI while affected Podman versions remain supported.

## Testing

- [x] `mise run pre-commit` passes
- [x] E2E harness unit tests pass: 21 passed
- [x] All E2E test binaries compile with `e2e-podman`
- [x] E2E harness Clippy passes with warnings denied
- [x] Standalone Podman reproducer confirms the image-volume attach/remove race
- [ ] Full OpenShell Podman E2E run was not available in this worktree

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; production architecture is unchanged)
