### PR TITLE
fix(podman): combine sandbox stop and removal

### DIFF
--- a/crates/openshell-driver-podman/Cargo.toml
+++ b/crates/openshell-driver-podman/Cargo.toml
@@ -38,6 +38,7 @@ miette = { workspace = true }
 [dev-dependencies]
 prost-types = { workspace = true }
 temp-env = "0.3"
+tokio = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/openshell-driver-podman/src/client.rs
+++ b/crates/openshell-driver-podman/src/client.rs
@@ -479,15 +479,28 @@ impl PodmanClient {
         }
     }
 
-    /// Force-remove a container and its anonymous volumes.
-    pub async fn remove_container(&self, name: &str) -> Result<(), PodmanApiError> {
+    /// Gracefully stop, then force-remove a container and its anonymous volumes.
+    pub async fn remove_container(
+        &self,
+        name: &str,
+        timeout_secs: u32,
+    ) -> Result<(), PodmanApiError> {
         validate_name(name)?;
-        self.request_ok(
-            hyper::Method::DELETE,
-            &format!("/libpod/containers/{name}?force=true&v=true"),
-            None,
-        )
-        .await
+        let http_timeout = Duration::from_secs(u64::from(timeout_secs) + 5);
+        let (status, bytes) = self
+            .request(
+                hyper::Method::DELETE,
+                &format!("/libpod/containers/{name}?force=true&v=true&timeout={timeout_secs}"),
+                None,
+                http_timeout,
+            )
+            .await?;
+        let code = status.as_u16();
+        if status.is_success() || code == 304 {
+            Ok(())
+        } else {
+            Err(error_from_response(code, &bytes))
+        }
     }
 
     /// Inspect a container by name or ID.
@@ -959,6 +972,30 @@ mod tests {
                 .expect("request log lock should not be poisoned")
                 .as_slice(),
             ["GET /v5.0.0/libpod/images/example%2Fimage%3Alatest/json"]
+        );
+        let _ = std::fs::remove_file(socket_path);
+    }
+
+    #[tokio::test]
+    async fn remove_container_uses_atomic_timed_libpod_removal() {
+        let (socket_path, request_log, handle) = spawn_podman_stub(
+            "remove-container",
+            vec![StubResponse::new(StatusCode::NO_CONTENT, "")],
+        );
+        let client = PodmanClient::new(socket_path.clone());
+
+        client
+            .remove_container("sandbox-123", 10)
+            .await
+            .expect("container removal should succeed");
+
+        handle.await.expect("stub task should finish");
+        assert_eq!(
+            request_log
+                .lock()
+                .expect("request log lock should not be poisoned")
+                .as_slice(),
+            ["DELETE /v5.0.0/libpod/containers/sandbox-123?force=true&v=true&timeout=10"]
         );
         let _ = std::fs::remove_file(socket_path);
     }

--- a/crates/openshell-driver-podman/src/client.rs
+++ b/crates/openshell-driver-podman/src/client.rs
@@ -479,7 +479,10 @@ impl PodmanClient {
         }
     }
 
-    /// Gracefully stop, then force-remove a container and its anonymous volumes.
+    /// Remove a container in one timed, forced Libpod delete operation.
+    ///
+    /// The Libpod endpoint uses `volumes` for anonymous-volume removal. Its
+    /// Docker-compatible counterpart uses the shorter `v` parameter.
     pub async fn remove_container(
         &self,
         name: &str,
@@ -490,7 +493,9 @@ impl PodmanClient {
         let (status, bytes) = self
             .request(
                 hyper::Method::DELETE,
-                &format!("/libpod/containers/{name}?force=true&v=true&timeout={timeout_secs}"),
+                &format!(
+                    "/libpod/containers/{name}?force=true&volumes=true&timeout={timeout_secs}"
+                ),
                 None,
                 http_timeout,
             )
@@ -977,7 +982,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remove_container_uses_atomic_timed_libpod_removal() {
+    async fn remove_container_uses_single_timed_libpod_removal() {
         let (socket_path, request_log, handle) = spawn_podman_stub(
             "remove-container",
             vec![StubResponse::new(StatusCode::NO_CONTENT, "")],
@@ -995,7 +1000,7 @@ mod tests {
                 .lock()
                 .expect("request log lock should not be poisoned")
                 .as_slice(),
-            ["DELETE /v5.0.0/libpod/containers/sandbox-123?force=true&v=true&timeout=10"]
+            ["DELETE /v5.0.0/libpod/containers/sandbox-123?force=true&volumes=true&timeout=10"]
         );
         let _ = std::fs::remove_file(socket_path);
     }

--- a/crates/openshell-driver-podman/src/client.rs
+++ b/crates/openshell-driver-podman/src/client.rs
@@ -489,7 +489,10 @@ impl PodmanClient {
         timeout_secs: u32,
     ) -> Result<(), PodmanApiError> {
         validate_name(name)?;
-        let http_timeout = Duration::from_secs(u64::from(timeout_secs) + 5);
+        // The delete request covers both the graceful stop and the subsequent
+        // storage, network, and anonymous-volume cleanup. Preserve the normal
+        // API timeout as cleanup headroom after the stop grace period.
+        let http_timeout = Duration::from_secs(u64::from(timeout_secs)) + API_TIMEOUT;
         let (status, bytes) = self
             .request(
                 hyper::Method::DELETE,
@@ -1002,6 +1005,23 @@ mod tests {
                 .as_slice(),
             ["DELETE /v5.0.0/libpod/containers/sandbox-123?force=true&volumes=true&timeout=10"]
         );
+        let _ = std::fs::remove_file(socket_path);
+    }
+
+    #[tokio::test]
+    async fn remove_container_allows_cleanup_after_stop_timeout() {
+        let (socket_path, _request_log, handle) = spawn_podman_stub(
+            "remove-container-delayed",
+            vec![StubResponse::new(StatusCode::NO_CONTENT, "").with_delay(Duration::from_secs(6))],
+        );
+        let client = PodmanClient::new(socket_path.clone());
+
+        client
+            .remove_container("sandbox-123", 0)
+            .await
+            .expect("container removal should retain the API timeout for cleanup");
+
+        handle.await.expect("stub task should finish");
         let _ = std::fs::remove_file(socket_path);
     }
 }

--- a/crates/openshell-driver-podman/src/client.rs
+++ b/crates/openshell-driver-podman/src/client.rs
@@ -1008,17 +1008,28 @@ mod tests {
         let _ = std::fs::remove_file(socket_path);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn remove_container_allows_cleanup_after_stop_timeout() {
-        let (socket_path, _request_log, handle) = spawn_podman_stub(
+        let (socket_path, request_log, handle) = spawn_podman_stub(
             "remove-container-delayed",
             vec![StubResponse::new(StatusCode::NO_CONTENT, "").with_delay(Duration::from_secs(6))],
         );
         let client = PodmanClient::new(socket_path.clone());
 
-        client
-            .remove_container("sandbox-123", 0)
+        let removal = tokio::spawn(async move { client.remove_container("sandbox-123", 0).await });
+        while request_log
+            .lock()
+            .expect("request log lock should not be poisoned")
+            .is_empty()
+        {
+            tokio::task::yield_now().await;
+        }
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(6)).await;
+
+        removal
             .await
+            .expect("removal task should finish")
             .expect("container removal should retain the API timeout for cleanup");
 
         handle.await.expect("stub task should finish");

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -682,7 +682,10 @@ impl PodmanComputeDriver {
                 error = %e,
                 "Failed to start container; cleaning up"
             );
-            let _ = self.client.remove_container(&name).await;
+            let _ = self
+                .client
+                .remove_container(&name, self.config.stop_timeout_secs)
+                .await;
             cleanup_created().await;
             return Err(ComputeDriverError::from(e));
         }
@@ -748,13 +751,14 @@ impl PodmanComputeDriver {
         };
         info!(sandbox_id = %sandbox_id, container = %container_id, "Deleting sandbox container");
 
-        // Stop (best-effort).
-        let _ = self
+        // Keep stop, timeout, and removal in one Podman operation. Splitting
+        // stop and remove can race with another container starting an image
+        // mount when the stop reaches its timeout.
+        let container_existed = match self
             .client
-            .stop_container(&container_id, self.config.stop_timeout_secs)
-            .await;
-
-        let container_existed = match self.client.remove_container(&container_id).await {
+            .remove_container(&container_id, self.config.stop_timeout_secs)
+            .await
+        {
             Ok(()) => true,
             Err(PodmanApiError::NotFound(_)) => false,
             Err(e) => return Err(ComputeDriverError::from(e)),
@@ -1798,9 +1802,7 @@ mod tests {
             vec![
                 // list_containers by label
                 StubResponse::new(StatusCode::OK, list_body),
-                // stop_container
-                StubResponse::new(StatusCode::NO_CONTENT, ""),
-                // remove_container
+                // atomic stop and remove_container
                 StubResponse::new(StatusCode::NO_CONTENT, ""),
                 // remove_volume
                 StubResponse::new(StatusCode::NO_CONTENT, ""),
@@ -1820,10 +1822,17 @@ mod tests {
             .expect("request log lock should not be poisoned")
             .clone();
         assert!(requests[0].contains("/libpod/containers/json"));
-        assert!(requests[1].contains(&format!("/libpod/containers/{container_id}/stop")));
-        assert!(requests[2].contains(&format!("/libpod/containers/{container_id}")));
         assert_eq!(
-            requests[3],
+            requests[1],
+            format!(
+                "DELETE {}",
+                api_path(&format!(
+                    "/libpod/containers/{container_id}?force=true&v=true&timeout=10"
+                ))
+            )
+        );
+        assert_eq!(
+            requests[2],
             format!(
                 "DELETE {}",
                 api_path(&format!("/libpod/volumes/{volume_name}"))

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -1802,7 +1802,7 @@ mod tests {
             vec![
                 // list_containers by label
                 StubResponse::new(StatusCode::OK, list_body),
-                // atomic stop and remove_container
+                // single timed remove_container operation
                 StubResponse::new(StatusCode::NO_CONTENT, ""),
                 // remove_volume
                 StubResponse::new(StatusCode::NO_CONTENT, ""),
@@ -1827,7 +1827,7 @@ mod tests {
             format!(
                 "DELETE {}",
                 api_path(&format!(
-                    "/libpod/containers/{container_id}?force=true&v=true&timeout=10"
+                    "/libpod/containers/{container_id}?force=true&volumes=true&timeout=10"
                 ))
             )
         );

--- a/crates/openshell-driver-podman/src/test_utils.rs
+++ b/crates/openshell-driver-podman/src/test_utils.rs
@@ -13,7 +13,7 @@ use std::collections::VecDeque;
 use std::convert::Infallible;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::net::UnixListener;
 
 /// A canned HTTP response for the Podman stub server.
@@ -21,6 +21,7 @@ use tokio::net::UnixListener;
 pub struct StubResponse {
     pub status: StatusCode,
     pub body: String,
+    pub delay: Duration,
 }
 
 impl StubResponse {
@@ -28,7 +29,13 @@ impl StubResponse {
         Self {
             status,
             body: body.into(),
+            delay: Duration::ZERO,
         }
+    }
+
+    pub fn with_delay(mut self, delay: Duration) -> Self {
+        self.delay = delay;
+        self
     }
 }
 
@@ -97,6 +104,7 @@ pub fn spawn_podman_stub(
                                 .expect("response queue lock should not be poisoned")
                                 .pop_front()
                                 .expect("stub response should exist");
+                            tokio::time::sleep(response.delay).await;
                             Ok::<_, Infallible>(
                                 hyper::Response::builder()
                                     .status(response.status)


### PR DESCRIPTION
## Summary

Collapse the Podman driver's separate stop and remove requests into one timed Libpod delete request. Graceful shutdown behavior already existed and is preserved; the change removes the externally scheduled interval between the requests and explicitly applies OpenShell's configured stop timeout to removal.

This mitigates the Podman `type=image` mount lifecycle race observed when one sandbox reaches its stop timeout while another sandbox starts, without globally serializing sandbox lifecycle operations.

The change also corrects anonymous-volume removal to use the Libpod endpoint's `volumes=true` parameter. The Docker-compatible endpoint uses `v=true`; OpenShell calls the Libpod endpoint.

## Related Issue

Related to the investigation in #2568.

No issue required: this is a localized compatibility fix for the Podman sandbox driver.

## Changes

- Replace the best-effort stop request followed by forced removal with one documented Libpod delete request:
  `DELETE ...?force=true&volumes=true&timeout=<configured stop timeout>`
- Allow the Podman HTTP request to remain active for the configured stop timeout plus a five-second transport margin.
- Use the same timed removal path when cleaning up a container after a failed start.
- Correct anonymous-volume cleanup from the Docker-compatible `v=true` parameter to the Libpod-specific `volumes=true` parameter.
- Update driver and client tests to assert that deletion uses one combined operation.

## Why `volumes=true`, not `v=true`

Podman's generated API documentation currently shows `v` for `ContainerDeleteLibpod`, but the server handler distinguishes the two API families:

- Libpod requests populate `RmOptions.Volumes` from the `volumes` query parameter.
- Docker-compatible requests populate it from the shorter `v` query parameter.

This behavior is present in both the affected [Podman 4.9.3 handler](https://github.com/containers/podman/blob/v4.9.3/pkg/api/handlers/compat/containers.go#L33-L66) and the [Podman 6.0.1 handler](https://github.com/containers/podman/blob/v6.0.1/pkg/api/handlers/compat/containers.go#L39-L72). OpenShell sends requests to `/libpod/containers/...`, so `volumes=true` is the parameter the implementation consumes.

The previous driver sent `v=true`, which the Libpod handler ignored. This did not cause the image-mount race, and OpenShell separately removes its named sandbox volume, but it meant the request did not remove anonymous volumes as intended.

## Reproduction and evidence

The failure was reproduced without OpenShell using:

- Ubuntu 24.04
- Rootless Podman 4.9.3, API 4.9.3, Go 1.22.2, Linux arm64
- `crun` 1.14.1
- SQLite state and native overlay storage
- Concurrent remote clients through the Podman REST service, matching the driver transport
- Supervisor image `ghcr.io/nvidia/openshell/supervisor:02e890ccf1995bf8671a81ec84baf44328b7f5b8`

The standalone reproducer stopped old containers and started pre-created replacements around the ten-second stop-timeout boundary before removing the old containers. On batch 8, two replacement starts failed because their OCI specifications referenced Podman-owned image-overlay mount sources that no longer existed. The missing paths belonged to the new containers, not the containers being removed.

Starting replacements concurrently with the beginning of immediate teardown did not reproduce across thousands of overlaps. The sensitive window was the transition from stop timeout into final removal.

Changing the lifecycle shape to a single timed forced removal completed 40/40 deliberately timed overlaps without reproducing the missing mount source.

## Semantics and confidence

The old and new successful paths both stop a running container gracefully before removal:

- Old: `POST /stop?t=<configured timeout>`, followed by `DELETE ?force=true` after the container stopped.
- New: one `DELETE ?force=true&timeout=<configured timeout>` operation; Podman stops the running container and then removes it.

The new behavior does not introduce graceful shutdown. It preserves it while eliminating the inter-request scheduling boundary and explicitly applying OpenShell's configured timeout to the forced delete.

The intentional edge-case difference is that the old driver ignored failure from its preliminary stop request. If the container remained running, the subsequent forced removal could make another stop attempt using the container's configured stop timeout, normally ten seconds. The combined operation makes one shutdown attempt with OpenShell's configured timeout and returns its error, avoiding both a possible second timeout period and the inter-request window.

This is an evidence-backed mitigation, not proof that Podman's underlying storage race is impossible:

- Podman's removal path can temporarily release the container lock while stopping.
- Forty successful overlaps substantially increase confidence but are not a concurrency guarantee.
- The confirmed reproduction is on Podman 4.9.3, as shipped by Ubuntu 24.04; this PR does not claim the race reproduces on current upstream Podman.
- If the failure recurs, stronger driver-side serialization of create/start against deletion, recovery by recreating a container with a stale mount specification, or an upstream Podman fix remain alternatives.

## Testing

- [x] `mise run pre-commit` passes
- [x] `mise exec -- cargo test -p openshell-driver-podman` (135 passed)
- [x] Scoped rootless Podman lifecycle E2E (2 passed) using the supervisor image from the failing workflow
- [x] Standalone Podman reproducer: separate stop/removal reproduced; combined timed removal passed 40/40 timed overlaps

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; no architecture or configuration contract changed)
