### PR TITLE
test(podman): gate gateway discovery test on Linux

### DIFF
--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -1418,6 +1418,7 @@ mod tests {
         assert!(err.to_string().contains("slirp4netns"));
     }
 
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn constructor_preserves_required_network_gateway_discovery_error() {
         let (socket_path, _request_log, handle) = spawn_podman_stub(


### PR DESCRIPTION

## Summary
Run the constructor gateway-discovery error test only on Linux, matching the production branch that inspects the Podman bridge gateway. macOS uses its Podman machine callback path and correctly skips that inspection.

## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
