### PR TITLE
chore(build): bump sccache to 0.16.0

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -66,6 +66,25 @@ checksum = "sha256:ded590cae2c72042c61178632906bef62d635fa20d45f8b22110a2241f430
 url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060416"
 
+[[tools."github:mozilla/sccache"]]
+version = "0.16.0"
+backend = "github:mozilla/sccache"
+
+[tools."github:mozilla/sccache"."platforms.linux-arm64"]
+checksum = "sha256:f73a5c39f96bb6ebb89cc7915cf182260d4cbf30765322c5e793d0fe8bd80784"
+url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060468"
+
+[tools."github:mozilla/sccache"."platforms.linux-x64"]
+checksum = "sha256:aec995a83ad3dff3d14b6314e08858b7b73d35ca85a5bcf3d3a9ec07dee35588"
+url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060682"
+
+[tools."github:mozilla/sccache"."platforms.macos-arm64"]
+checksum = "sha256:ded590cae2c72042c61178632906bef62d635fa20d45f8b22110a2241f430960"
+url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060416"
+
 [[tools."github:rust-cross/cargo-zigbuild"]]
 version = "0.22.3"
 backend = "github:rust-cross/cargo-zigbuild"

--- a/mise.lock
+++ b/mise.lock
@@ -45,35 +45,26 @@ url_api = "https://api.github.com/repos/anchore/syft/releases/assets/410001187"
 provenance = "github-attestations"
 
 [[tools."github:mozilla/sccache"]]
-version = "0.14.0"
-backend = "github:mozilla/sccache"
-
-[tools."github:mozilla/sccache"."platforms.linux-arm64"]
-checksum = "sha256:62a6c942c47c93333bc0174704800cef7edfa0416d08e1356c1d3e39f0b462f2"
-url = "https://github.com/mozilla/sccache/releases/download/v0.14.0/sccache-v0.14.0-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/353136010"
-
-[tools."github:mozilla/sccache"."platforms.linux-x64"]
-checksum = "sha256:8424b38cda4ecce616a1557d81328f3d7c96503a171eab79942fad618b42af44"
-url = "https://github.com/mozilla/sccache/releases/download/v0.14.0/sccache-v0.14.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/353136108"
-
-[tools."github:mozilla/sccache"."platforms.macos-arm64"]
-checksum = "sha256:a781e8018260ab128e7690d8497736fa231b6ca895d57131d5b5b966ca987594"
-url = "https://github.com/mozilla/sccache/releases/download/v0.14.0/sccache-v0.14.0-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/353135984"
-
-[[tools."github:mozilla/sccache"]]
-version = "0.14.0"
+version = "0.16.0"
 backend = "github:mozilla/sccache"
 
 [tools."github:mozilla/sccache".options]
 asset_pattern = "sccache-v*x86_64*linux*.tar.gz"
 
+[tools."github:mozilla/sccache"."platforms.linux-arm64"]
+checksum = "sha256:f73a5c39f96bb6ebb89cc7915cf182260d4cbf30765322c5e793d0fe8bd80784"
+url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060468"
+
 [tools."github:mozilla/sccache"."platforms.linux-x64"]
-checksum = "sha256:8424b38cda4ecce616a1557d81328f3d7c96503a171eab79942fad618b42af44"
-url = "https://github.com/mozilla/sccache/releases/download/v0.14.0/sccache-v0.14.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/353136108"
+checksum = "sha256:aec995a83ad3dff3d14b6314e08858b7b73d35ca85a5bcf3d3a9ec07dee35588"
+url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060682"
+
+[tools."github:mozilla/sccache"."platforms.macos-arm64"]
+checksum = "sha256:ded590cae2c72042c61178632906bef62d635fa20d45f8b22110a2241f430960"
+url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060416"
 
 [[tools."github:rust-cross/cargo-zigbuild"]]
 version = "0.22.3"

--- a/mise.toml
+++ b/mise.toml
@@ -39,7 +39,7 @@ zig = "0.14.1"
 "npm:markdownlint-cli2" = "0.22.0"
 
 [tools."github:mozilla/sccache"]
-version = "0.14.0"
+version = "0.16.0"
 
 [tools."github:mozilla/sccache".platforms]
 # NOTE: this override is necessary only for linux-x64, otherwise it selects an invalid artifact (sccache-dist-vx.y.z-x86_64-unknown-linux-musl.tar.gz)


### PR DESCRIPTION
## Summary

Bump sccache to 0.16.0 to pick up the upstream compiler-resolution fix needed by the Docker E2E cargo-zigbuild path. The failure occurs before the smoke tests run, while cross-compiling `openshell-sandbox` for `aarch64-unknown-linux-musl`.

## Failure details

`mise run e2e:docker` builds the gateway and CLI, then stages the Docker supervisor with `cargo zigbuild`. The mise environment globally sets `RUSTC_WRAPPER=sccache`, so every Rust compiler invocation passes through sccache.

With sccache 0.14.0, sccache could select the configured wrapper again while trying to resolve the real compiler behind cargo-zigbuild and its generated Zig compiler shim. Compiler discovery then failed and sccache surfaced the result as an unsupported compiler:

```text
sccache: error: Compiler not supported: "error: unable to create compilation: AccessDenied\n"
```

This aborts the supervisor cross-compile before Docker E2E tests start. Setting `SCCACHE_DISABLE=1` does not avoid the failure because it disables caching behavior but does not remove Cargo’s `RUSTC_WRAPPER`; Cargo still launches sccache.

## Why 0.16.0 fixes it

The official [sccache 0.16.0 release notes](https://github.com/mozilla/sccache/releases/tag/v0.16.0) list the relevant correctness change: **“avoid the sccache wrapper when resolving the real compiler”** ([mozilla/sccache#2720](https://github.com/mozilla/sccache/pull/2720)). That prevents wrapper selection from interfering with discovery of cargo-zigbuild’s actual compiler command.

## Related Issue

No issue required: localized build-tool maintenance fix for a known upstream defect.

## Changes

- Pin sccache 0.16.0 in `mise.toml`
- Regenerate sccache lock entries and checksums for macOS arm64, Linux arm64, and Linux x64
- Preserve cargo-zigbuild 0.22.3 and the Linux x64 asset-selection override

## Testing

- [x] `mise run pre-commit` passes
- [x] Clean `aarch64-unknown-linux-musl` supervisor build passes with `RUSTC_WRAPPER=sccache`
- [x] `mise run e2e:docker` passes

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; build-tool pin only)