### PR TITLE
test(server): stabilize watch span cancellation test

### DIFF
--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -2609,7 +2609,7 @@ mod tests {
 
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
             while traced.spans_named("disconnected_watch_request").is_empty() {
-                tokio::task::yield_now().await;
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             }
         })
         .await

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -2607,7 +2607,7 @@ mod tests {
         drop(stream);
         drop(request_span);
 
-        tokio::time::timeout(std::time::Duration::from_millis(200), async {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
             while traced.spans_named("disconnected_watch_request").is_empty() {
                 tokio::task::yield_now().await;
             }


### PR DESCRIPTION
## Summary

Stabilize `watch_producer_releases_request_span_when_client_disconnects` by giving the detached producer and tracing exporter a five-second bounded observation window instead of 200 ms. The wait polls every 10 ms and matches the existing timeout pattern used by neighboring asynchronous server tests.

Observed failures:
- [linux-arm64 CI failure](https://github.com/NVIDIA/OpenShell/actions/runs/30670650321/job/91288158107#step:10:5289)
- [linux-amd64 CI failure](https://github.com/NVIDIA/OpenShell/actions/runs/30670707117/job/91288202486#step:10:5289)

## Related Issue

No issue required: this is a localized flaky unit-test timeout fix.

## Changes

- Increase the watch producer span-release test timeout from 200 ms to five seconds.
- Poll the exporter every 10 ms, consistent with the neighboring asynchronous test pattern.
- Audit the remaining sub-second server test timeouts; they are intentional negative assertions or per-attempt TLS handshakes within a longer deadline, so no other tests need this change.

## Testing

- [x] `mise run pre-commit` passes
- [x] `mise run test:rust` passes
- [x] Focused watch producer span-release test passes
- [ ] E2E tests added/updated (not applicable: test-only timeout change)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)