### PR TITLE
test(server): stabilize async root span assertions

### DIFF
--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -6193,9 +6193,14 @@ mod tests {
             .await
             .unwrap();
 
-        // Other tests drive their own reconcile loops into the shared
-        // exporter, so match on the shape of a sweep rather than assuming
-        // there is exactly one.
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while traced.spans_named("reconcile.sandboxes").is_empty() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("the sweep records a span of its own");
+
         let spans = traced.finished_spans();
         let roots = traced.spans_named("reconcile.sandboxes");
         assert!(

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -6148,6 +6148,17 @@ mod tests {
             .await
             .unwrap();
 
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while traced
+                .spans_named("driver_watch.sandbox_deleted")
+                .is_empty()
+            {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("the event records a span of its own");
+
         let spans = traced.finished_spans();
         let root = spans
             .iter()

--- a/crates/openshell-server/src/provider_refresh.rs
+++ b/crates/openshell-server/src/provider_refresh.rs
@@ -1534,6 +1534,17 @@ mod tests {
         let traced = test_exporter::install_traced();
         run_refresh_worker_tick(&store).await.unwrap();
 
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while traced
+                .spans_named("refresh.provider_credentials")
+                .is_empty()
+            {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("the tick records a span of its own");
+
         let spans = traced.finished_spans();
         let root = spans
             .iter()

--- a/crates/openshell-server/src/provider_refresh.rs
+++ b/crates/openshell-server/src/provider_refresh.rs
@@ -1026,6 +1026,7 @@ async fn run_refresh_worker_tick(store: &Store) -> Result<(), Status> {
     let span = tracing::Span::current();
     span.record("watched_count", watched_count);
     span.record("due_count", due_count);
+    drop(span);
     info!(
         watched_count,
         due_count, rotation_requested_count, "provider credential refresh worker sweep"


### PR DESCRIPTION
## Summary

Stabilizes async OpenTelemetry root-span assertions that can snapshot the in-memory exporter after child spans finish but before the root span is observable.

The reported linux-arm64 failure showed completed driver and store child spans without the expected `reconcile.sandboxes` root span: [Actions failure](https://github.com/NVIDIA/OpenShell/actions/runs/30676532792/job/91304858792#step:10:5291).

A follow-up linux-amd64 run exposed the same symptom in the provider refresh test because its explicit current-span handle remained alive while the assertion polled: [Actions failure](https://github.com/NVIDIA/OpenShell/actions/runs/30678674909/job/91311070599).

This uses the same bounded polling pattern already used by the disconnected watch-span test added in #2582.

## Related Issue

No issue required: this is an obvious localized CI test flake.

## Changes

- Wait up to five seconds for the reconciliation root span, polling every 10 ms before taking the assertion snapshot.
- Audit the remaining async root-span tests and apply the same pattern to driver watch events and provider refresh ticks.
- Explicitly release the provider refresh current-span handle after recording attributes so the root span can close before exporter polling.
- Leave exporter tests that already explicitly drop their span handles unchanged.

## Testing

- [x] `mise run pre-commit` passes
- [x] Focused async root-span tests pass
- [x] `mise run test` passes, including all 1,228 server tests
- [ ] `mise run ci` completed lint and compile checks, but a supervisor-process test binary hung locally after its visible tests passed; stopped after five minutes
- [x] E2E tests not applicable for telemetry test stabilization

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs not applicable for telemetry test stabilization