### PR TITLE
build(bazel): add OpenTelemetry crate targets

### DIFF
--- a/crates/openshell-otel/BUILD.bazel
+++ b/crates/openshell-otel/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@crates//:defs.bzl", "aliases", "all_crate_deps")
+load("@rules_rs//rs:rust_library.bzl", "rust_library")
+load("@rules_rs//rs:rust_test.bzl", "rust_test")
+
+rust_library(
+    name = "openshell-otel",
+    srcs = glob(["src/**/*.rs"]),
+    aliases = aliases(),
+    visibility = ["//visibility:public"],
+    deps = all_crate_deps(normal = True),
+)
+
+rust_test(
+    name = "openshell-otel_test",
+    crate = ":openshell-otel",
+    deps = all_crate_deps(normal_dev = True),
+)

--- a/crates/openshell-sandbox/BUILD.bazel
+++ b/crates/openshell-sandbox/BUILD.bazel
@@ -30,6 +30,7 @@ rust_binary(
 
 rust_test(
     name = "openshell-sandbox_lib_test",
+    compile_data = ["//crates/openshell-supervisor-network:sandbox-policy-rego"],
     crate = ":openshell-sandbox",
     crate_features = ["telemetry"],
     deps = all_crate_deps(normal_dev = True),

--- a/crates/openshell-supervisor-network/BUILD.bazel
+++ b/crates/openshell-supervisor-network/BUILD.bazel
@@ -2,6 +2,12 @@ load("@crates//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
 
+filegroup(
+    name = "sandbox-policy-rego",
+    srcs = ["data/sandbox-policy.rego"],
+    visibility = ["//crates/openshell-sandbox:__pkg__"],
+)
+
 rust_library(
     name = "openshell-supervisor-network",
     srcs = glob(["src/**/*.rs"]),


### PR DESCRIPTION
## Summary
Adds OpenTelemetry crate to the Bazel build graph and fixes a bug with the sandbox test files.

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
