### PR TITLE
test(bazel): Add Rustfmt checks for binaries

### DIFF
--- a/crates/openshell-cli/BUILD.bazel
+++ b/crates/openshell-cli/BUILD.bazel
@@ -2,6 +2,7 @@ load("@crates//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rustfmt_test")
 load("@workspace_version//:version.bzl", "WORKSPACE_VERSION")
 
 rust_library(
@@ -24,11 +25,21 @@ rust_binary(
     deps = all_crate_deps(normal = True) + [":openshell-cli"],
 )
 
+rustfmt_test(
+    name = "openshell_rustfmt_test",
+    targets = [":openshell"],
+)
+
 rust_binary(
     name = "fake-forward-process",
     testonly = True,
     srcs = ["tests/fixtures/fake_forward.rs"],
     crate_root = "tests/fixtures/fake_forward.rs",
+)
+
+rustfmt_test(
+    name = "fake-forward-process_rustfmt_test",
+    targets = [":fake-forward-process"],
 )
 
 rust_test(

--- a/crates/openshell-driver-kubernetes/BUILD.bazel
+++ b/crates/openshell-driver-kubernetes/BUILD.bazel
@@ -2,6 +2,7 @@ load("@crates//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rustfmt_test")
 
 rust_library(
     name = "openshell-driver-kubernetes",
@@ -21,6 +22,11 @@ rust_binary(
     binary_name = "openshell-driver-kubernetes",
     visibility = ["//visibility:public"],
     deps = all_crate_deps(normal = True) + [":openshell-driver-kubernetes"],
+)
+
+rustfmt_test(
+    name = "openshell-driver-kubernetes_bin_rustfmt_test",
+    targets = [":openshell-driver-kubernetes_bin"],
 )
 
 rust_test(

--- a/crates/openshell-driver-podman/BUILD.bazel
+++ b/crates/openshell-driver-podman/BUILD.bazel
@@ -2,6 +2,7 @@ load("@crates//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rustfmt_test")
 
 rust_library(
     name = "openshell-driver-podman",
@@ -21,6 +22,11 @@ rust_binary(
     binary_name = "openshell-driver-podman",
     visibility = ["//visibility:public"],
     deps = all_crate_deps(normal = True) + [":openshell-driver-podman"],
+)
+
+rustfmt_test(
+    name = "openshell-driver-podman_bin_rustfmt_test",
+    targets = [":openshell-driver-podman_bin"],
 )
 
 rust_test(

--- a/crates/openshell-sandbox/BUILD.bazel
+++ b/crates/openshell-sandbox/BUILD.bazel
@@ -2,6 +2,7 @@ load("@crates//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rustfmt_test")
 load("@workspace_version//:version.bzl", "WORKSPACE_VERSION")
 
 rust_library(
@@ -26,6 +27,11 @@ rust_binary(
     version = WORKSPACE_VERSION,
     visibility = ["//visibility:public"],
     deps = all_crate_deps(normal = True) + [":openshell-sandbox"],
+)
+
+rustfmt_test(
+    name = "openshell-sandbox-bin_rustfmt_test",
+    targets = [":openshell-sandbox-bin"],
 )
 
 rust_test(

--- a/crates/openshell-server/BUILD.bazel
+++ b/crates/openshell-server/BUILD.bazel
@@ -2,6 +2,7 @@ load("@crates//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rustfmt_test")
 
 rust_library(
     name = "openshell-server",
@@ -25,6 +26,11 @@ rust_binary(
     aliases = aliases(),
     visibility = ["//visibility:public"],
     deps = all_crate_deps(normal = True) + [":openshell-server"],
+)
+
+rustfmt_test(
+    name = "openshell-gateway_rustfmt_test",
+    targets = [":openshell-gateway"],
 )
 
 rust_test(


### PR DESCRIPTION


## Summary
Create an explicit rustfmt_test target for every Rust binary so Bazel test runs can detect formatting regressions. Keep each check scoped to its paired binary to avoid redundant transitive formatting work.

## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- What testing was done? -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
