### PR TITLE
fix(supervisor-middleware): configure HTTP/2 keepalive on middleware gRPC channel

### DIFF
--- a/crates/openshell-supervisor-middleware/src/remote.rs
+++ b/crates/openshell-supervisor-middleware/src/remote.rs
@@ -16,6 +16,8 @@ use tonic::{Request, Response, Status};
 use crate::MIDDLEWARE_GRPC_MESSAGE_BYTES;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const HTTP2_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
+const HTTP2_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Clone)]
 pub struct RemoteMiddlewareService {
@@ -30,7 +32,12 @@ impl RemoteMiddlewareService {
                 format!(
                     "middleware registration '{registration_name}' has an invalid grpc_endpoint"
                 )
-            })?;
+            })?
+            .http2_keep_alive_interval(HTTP2_KEEP_ALIVE_INTERVAL)
+            .keep_alive_while_idle(true)
+            .keep_alive_timeout(HTTP2_KEEP_ALIVE_TIMEOUT)
+            .http2_adaptive_window(true);
+
         if grpc_endpoint.starts_with("https://") {
             endpoint = endpoint
                 .tls_config(ClientTlsConfig::new().with_enabled_roots())
@@ -39,6 +46,7 @@ impl RemoteMiddlewareService {
                     format!("middleware registration '{registration_name}' could not configure TLS")
                 })?;
         }
+
         let channel = endpoint
             .connect_timeout(CONNECT_TIMEOUT)
             .connect()
@@ -49,6 +57,7 @@ impl RemoteMiddlewareService {
                     "middleware registration '{registration_name}' could not connect to {grpc_endpoint}"
                 )
             })?;
+
         Ok(Self {
             client: SupervisorMiddlewareClient::new(channel)
                 .max_decoding_message_size(MIDDLEWARE_GRPC_MESSAGE_BYTES)


### PR DESCRIPTION
## Summary
The middleware gRPC channel was the only long-lived client in the repo without HTTP/2 keepalive config. Without it, idle connections are silently reaped by intermediaries and dead peers go undetected until the next evaluation attempt.

This is a prerequisite for #2428 (WebSocket middleware), where long-lived bidirectional streams make a stale connection  session-fatal rather than a single-retry inconvenience.

## Related Issue
#2474

## Changes
- Added `http2_keep_alive_interval`, `keep_alive_while_idle`, `keep_alive_timeout`, and `http2_adaptive_window` to the Endpoint builder in `crates/openshell-supervisor-middleware/src/remote.rs`.  The configuration is the same as in the `crates/openshell-core/src/grpc_client.rs` gRPC channel builder.

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
