### PR TITLE
test: disable tests flaky under parallel stress

### DIFF
--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -1738,6 +1738,7 @@ async fn sandbox_forward_background_tracks_owned_child_when_pid_discovery_fails(
 }
 
 #[tokio::test]
+#[ignore = "flaky under concurrent test execution"]
 async fn sandbox_forward_foreground_fails_when_ssh_exits_before_listener_opens() {
     let server = run_server().await;
     let fake_ssh_dir = tempfile::tempdir().unwrap();
@@ -1768,6 +1769,7 @@ async fn sandbox_forward_foreground_fails_when_ssh_exits_before_listener_opens()
 }
 
 #[tokio::test]
+#[ignore = "flaky under concurrent test execution"]
 async fn sandbox_forward_background_terminates_owned_child_when_listener_never_opens() {
     let server = run_server().await;
     let fake_ssh_dir = tempfile::tempdir().unwrap();

--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -1273,6 +1273,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[ignore = "flaky under concurrent test execution"]
     fn podman_socket_probe_accepts_successful_ping_response() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let socket_path = temp_dir.path().join("podman.sock");
@@ -1296,6 +1297,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[ignore = "flaky under concurrent test execution"]
     fn podman_socket_probe_rejects_docker_ping_response() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let socket_path = temp_dir.path().join("podman.sock");
@@ -1319,6 +1321,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[ignore = "flaky under concurrent test execution"]
     fn docker_socket_probe_accepts_successful_ping_response() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let socket_path = temp_dir.path().join("docker.sock");
@@ -1342,6 +1345,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[ignore = "flaky under concurrent test execution"]
     fn docker_socket_probe_rejects_podman_ping_response() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let socket_path = temp_dir.path().join("podman.sock");
@@ -1377,6 +1381,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[ignore = "flaky under concurrent test execution"]
     fn docker_socket_detection_returns_the_responsive_candidate() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let inactive_path = temp_dir.path().join("inactive.sock");
@@ -1418,6 +1423,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[ignore = "flaky under concurrent test execution"]
     fn podman_socket_detection_returns_the_responsive_candidate() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let inactive_path = temp_dir.path().join("inactive.sock");

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -6223,6 +6223,7 @@ mod tests {
     /// Driver watch events arrive on a background stream, so the store writes
     /// they trigger land outside the request that caused them.
     #[tokio::test]
+    #[ignore = "flaky under concurrent test execution"]
     async fn driver_watch_events_are_roots_and_store_operations_have_parents() {
         use crate::otel_tracing::test_exporter;
 
@@ -6268,6 +6269,7 @@ mod tests {
     /// The reconciler runs on a timer with no inbound request, so without a
     /// span of its own each store call becomes its own anonymous trace.
     #[tokio::test]
+    #[ignore = "flaky under concurrent test execution"]
     async fn reconcile_sweeps_are_roots_and_operations_have_parents() {
         use crate::otel_tracing::test_exporter;
 

--- a/crates/openshell-server/src/gateway_listener.rs
+++ b/crates/openshell-server/src/gateway_listener.rs
@@ -682,6 +682,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg(target_os = "linux")]
+    #[ignore = "flaky under concurrent test execution"]
     async fn gateway_listeners_bind_ipv6_wildcard_and_ipv4_callback_on_same_port() {
         let probe = TcpListener::bind("[::1]:0")
             .await

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -2625,6 +2625,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "flaky under concurrent test execution"]
     async fn watch_producer_releases_request_span_when_client_disconnects() {
         use crate::otel_tracing::test_exporter;
         use tokio_stream::StreamExt as _;

--- a/crates/openshell-server/src/persistence/tests.rs
+++ b/crates/openshell-server/src/persistence/tests.rs
@@ -35,6 +35,7 @@ async fn failed_store_calls_are_marked_on_the_span() {
 /// the span must stay clean — otherwise every lease a replica does not win, and
 /// every gateway restart, exports as a failure.
 #[tokio::test]
+#[ignore = "flaky under concurrent test execution"]
 async fn expected_conflicts_leave_the_span_unmarked() {
     use crate::otel_tracing::test_exporter;
 
@@ -78,6 +79,7 @@ async fn expected_conflicts_leave_the_span_unmarked() {
 /// Span names stay low-cardinality so they group across object types; what
 /// each call touched is carried as attributes.
 #[tokio::test]
+#[ignore = "flaky under concurrent test execution"]
 async fn store_spans_record_what_they_touched_as_attributes() {
     use crate::otel_tracing::test_exporter;
 
@@ -2182,6 +2184,7 @@ async fn membership_selector_escapes_adversarial_label_key() {
 /// so a trace decomposes an RPC into the storage work it did rather than
 /// bottoming out at the request boundary.
 #[tokio::test]
+#[ignore = "flaky under concurrent test execution"]
 async fn store_operations_export_spans_with_parents() {
     use tracing::Instrument as _;
 

--- a/crates/openshell-server/src/provider_refresh.rs
+++ b/crates/openshell-server/src/provider_refresh.rs
@@ -1526,6 +1526,7 @@ mod tests {
     /// The worker ticks on a timer with no inbound request, so without a span
     /// of its own its store reads export as anonymous single-span traces.
     #[tokio::test]
+    #[ignore = "flaky under concurrent test execution"]
     async fn refresh_worker_ticks_are_roots_and_store_operations_have_parents() {
         use crate::otel_tracing::test_exporter;
 


### PR DESCRIPTION
Repeated Bazel test targets with --runs_per_test at 10, 20, 50, 100, and 200 runs. The tests failed intermittently when multiple instances ran concurrently. This indicates timing, shared tracing state, socket readiness, or parallel-safety issues that need focused follow-up before re-enabling the tests.

A normal non-repeated bazel test //... run passes with these tests ignored.

Disabled tests:
- sandbox_forward_foreground_fails_when_ssh_exits_before_listener_opens
- sandbox_forward_background_terminates_owned_child_when_listener_never_opens
- podman_socket_probe_accepts_successful_ping_response
- podman_socket_probe_rejects_docker_ping_response
- docker_socket_probe_accepts_successful_ping_response
- docker_socket_probe_rejects_podman_ping_response
- docker_socket_detection_returns_the_responsive_candidate
- podman_socket_detection_returns_the_responsive_candidate
- driver_watch_events_are_roots_and_store_operations_have_parents
- reconcile_sweeps_are_roots_and_operations_have_parents
- gateway_listeners_bind_ipv6_wildcard_and_ipv4_callback_on_same_port
- watch_producer_releases_request_span_when_client_disconnects
- expected_conflicts_leave_the_span_unmarked
- store_spans_record_what_they_touched_as_attributes
- store_operations_export_spans_with_parents
- refresh_worker_ticks_are_roots_and_store_operations_have_parents

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
