### PR TITLE
feat(mise): run fmt as part of pre-commit

### DIFF
--- a/tasks/ci.toml
+++ b/tasks/ci.toml
@@ -65,5 +65,5 @@ hide = true
 
 ["pre-commit"]
 description = "Run lint, formatting, and license checks"
-depends = ["lint"]
+depends = ["fmt", "lint"]
 hide = true


### PR DESCRIPTION
## Summary
Include fmt as a dependency of pre-commit so that the subsequent lint doesn't just fail on format and require manually running fmt and then pre-commit again.

The existing comment seems to still hold.

## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
