### PR TITLE
fix(cli): route auto-detected interactive tty sessions to streaming exec

### DIFF
--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -1466,7 +1466,7 @@ pub async fn sandbox_exec_grpc(
     let tty = tty_override
         .unwrap_or_else(|| std::io::stdin().is_terminal() && std::io::stdout().is_terminal());
 
-    if tty_override == Some(true) && std::io::stdin().is_terminal() {
+    if tty && std::io::stdin().is_terminal() {
         return sandbox_exec_interactive_grpc(
             client,
             &sandbox,


### PR DESCRIPTION
## Summary
`openshell sandbox exec` silently allocates a broken 1x1 pty for interactive sessions unless `--tty` is passed explicitly, breaking any terminal-aware program run without that flag.

## Related Issue
No issue required: minimal, localized one-line routing fix; root cause and repro included below.

## Changes
- `crates/openshell-cli/src/run.rs`: `sandbox_exec_grpc` computed the auto-detected `tty` value correctly (both stdin and stdout are terminals) but routed to the interactive streaming exec path only when `tty_override == Some(true)` — true only if `--tty` was passed explicitly. Without that flag, execution fell through to the one-shot exec path, which allocates a PTY with a hardcoded `0, 0` size in `run_exec_with_russh` (`crates/openshell-server/src/grpc/sandbox.rs`), clamped to `1x1` downstream in the supervisor. The fix uses the already-computed `tty` value instead of `tty_override`, so auto-detection correctly routes fully interactive sessions to the path that sets a real terminal size and forwards `SIGWINCH`.

## Testing
- Reproduced before the fix: `openshell sandbox exec -n <sandbox> -- stty size` returned `1 1` with no flags, in a normal interactive terminal, while host `stty size` reported the real dimensions.
- After the fix: same command returns the correct, matching size with no flags required.
- Verified an interactive TUI program starts and behaves correctly through this path post-fix.
- `mise run ci` passes locally, including full `test:rust` suite (server integration tests: relay, websocket tunnel, supervisor relay — all passing).
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)