### PR TITLE
refactor(prover): separate outcome evaluation from rendering

### DIFF
--- a/crates/openshell-prover/src/lib.rs
+++ b/crates/openshell-prover/src/lib.rs
@@ -65,11 +65,13 @@ pub fn prove(
         findings = apply_accepted_risks(findings, &accepted);
     }
 
-    let exit_code = if compact {
-        render_compact(&findings, policy_path, credentials_path)
+    if compact {
+        render_compact(&findings);
     } else {
-        render_report(&findings, policy_path, credentials_path)
-    };
+        render_report(&findings, policy_path, credentials_path);
+    }
+
+    let exit_code = i32::from(findings.iter().any(|f| !f.accepted));
 
     Ok(exit_code)
 }
@@ -310,5 +312,66 @@ network_policies:
             findings.is_empty(),
             "deny-all policy should produce no findings, got: {findings:?}"
         );
+    }
+
+    fn outcome(findings: &[finding::Finding]) -> i32 {
+        i32::from(findings.iter().any(|f| !f.accepted))
+    }
+
+    #[test]
+    fn test_outcome_empty_findings() {
+        assert_eq!(outcome(&[]), 0);
+    }
+
+    #[test]
+    fn test_outcome_accepted_only() {
+        let f = finding::Finding {
+            query: finding::category::LINK_LOCAL_REACH.to_owned(),
+            title: String::new(),
+            description: String::new(),
+            paths: vec![],
+            remediation: vec![],
+            accepted: true,
+            accepted_reason: "accepted for test".to_owned(),
+        };
+        assert_eq!(outcome(&[f]), 0);
+    }
+
+    #[test]
+    fn test_outcome_unaccepted_finding() {
+        let f = finding::Finding {
+            query: finding::category::LINK_LOCAL_REACH.to_owned(),
+            title: String::new(),
+            description: String::new(),
+            paths: vec![finding::FindingPath::Exfil(finding::ExfilPath {
+                binary: "/usr/bin/curl".to_owned(),
+                endpoint_host: "169.254.169.254".to_owned(),
+                endpoint_port: 80,
+                mechanism: String::new(),
+                policy_name: "test".to_owned(),
+                category: finding::category::LINK_LOCAL_REACH.to_owned(),
+                method: String::new(),
+            })],
+            remediation: vec![],
+            accepted: false,
+            accepted_reason: String::new(),
+        };
+        assert_eq!(outcome(&[f]), 1);
+    }
+
+    // prove() returns Ok(1) for an unaccepted pathless finding;
+    // renderers show REVIEW, not PASS, when unaccepted findings exist regardless of path count.
+    #[test]
+    fn test_outcome_pathless_unaccepted() {
+        let f = finding::Finding {
+            query: finding::category::LINK_LOCAL_REACH.to_owned(),
+            title: String::new(),
+            description: String::new(),
+            paths: vec![],
+            remediation: vec![],
+            accepted: false,
+            accepted_reason: String::new(),
+        };
+        assert_eq!(outcome(&[f]), 1);
     }
 }

--- a/crates/openshell-prover/src/lib.rs
+++ b/crates/openshell-prover/src/lib.rs
@@ -26,6 +26,10 @@ use policy::parse_policy;
 use queries::run_all_queries;
 use report::{render_compact, render_report};
 
+fn outcome(findings: &[finding::Finding]) -> i32 {
+    i32::from(findings.iter().any(|finding| !finding.accepted))
+}
+
 /// Run the prover end-to-end and return a result containing an exit code.
 ///
 /// - `Ok(0)` — pass (no findings, or all accepted)
@@ -65,13 +69,13 @@ pub fn prove(
         findings = apply_accepted_risks(findings, &accepted);
     }
 
-    let exit_code = if compact {
-        render_compact(&findings, policy_path, credentials_path)
+    if compact {
+        render_compact(&findings);
     } else {
-        render_report(&findings, policy_path, credentials_path)
-    };
+        render_report(&findings, policy_path, credentials_path);
+    }
 
-    Ok(exit_code)
+    Ok(outcome(&findings))
 }
 
 // ===========================================================================
@@ -310,5 +314,62 @@ network_policies:
             findings.is_empty(),
             "deny-all policy should produce no findings, got: {findings:?}"
         );
+    }
+
+    #[test]
+    fn test_outcome_empty_findings() {
+        assert_eq!(outcome(&[]), 0);
+    }
+
+    #[test]
+    fn test_outcome_accepted_only() {
+        let f = finding::Finding {
+            query: finding::category::LINK_LOCAL_REACH.to_owned(),
+            title: String::new(),
+            description: String::new(),
+            paths: vec![],
+            remediation: vec![],
+            accepted: true,
+            accepted_reason: "accepted for test".to_owned(),
+        };
+        assert_eq!(outcome(&[f]), 0);
+    }
+
+    #[test]
+    fn test_outcome_unaccepted_finding() {
+        let f = finding::Finding {
+            query: finding::category::LINK_LOCAL_REACH.to_owned(),
+            title: String::new(),
+            description: String::new(),
+            paths: vec![finding::FindingPath::Exfil(finding::ExfilPath {
+                binary: "/usr/bin/curl".to_owned(),
+                endpoint_host: "169.254.169.254".to_owned(),
+                endpoint_port: 80,
+                mechanism: String::new(),
+                policy_name: "test".to_owned(),
+                category: finding::category::LINK_LOCAL_REACH.to_owned(),
+                method: String::new(),
+            })],
+            remediation: vec![],
+            accepted: false,
+            accepted_reason: String::new(),
+        };
+        assert_eq!(outcome(&[f]), 1);
+    }
+
+    // prove() returns Ok(1) for an unaccepted pathless finding;
+    // renderers show REVIEW, not PASS, when unaccepted findings exist regardless of path count.
+    #[test]
+    fn test_outcome_pathless_unaccepted() {
+        let f = finding::Finding {
+            query: finding::category::LINK_LOCAL_REACH.to_owned(),
+            title: String::new(),
+            description: String::new(),
+            paths: vec![],
+            remediation: vec![],
+            accepted: false,
+            accepted_reason: String::new(),
+        };
+        assert_eq!(outcome(&[f]), 1);
     }
 }

--- a/crates/openshell-prover/src/report.rs
+++ b/crates/openshell-prover/src/report.rs
@@ -76,8 +76,7 @@ fn format_path_line(query: &str, p: &crate::finding::ExfilPath) -> String {
 // ---------------------------------------------------------------------------
 
 /// Render compact output (one-line-per-finding-line for demos and CI).
-/// Returns exit code: 0 = pass, 1 = any findings present.
-pub fn render_compact(findings: &[Finding], _policy_path: &str, _credentials_path: &str) -> i32 {
+pub fn render_compact(findings: &[Finding]) {
     let active: Vec<&Finding> = findings.iter().filter(|f| !f.accepted).collect();
     let accepted: Vec<&Finding> = findings.iter().filter(|f| f.accepted).collect();
 
@@ -108,19 +107,17 @@ pub fn render_compact(findings: &[Finding], _policy_path: &str, _credentials_pat
         format!(", {} accepted", accepted.len())
     };
 
-    let path_count: usize = active.iter().map(|f| f.paths.len()).sum();
-    if path_count > 0 {
-        println!(
-            "   {}  {path_count} finding path(s) require review{accepted_note}",
-            " REVIEW ".black().bold().on_yellow()
-        );
-        1
-    } else {
+    if active.is_empty() {
         println!(
             "   {}  no findings{accepted_note}",
             " PASS ".white().bold().on_green()
         );
-        0
+    } else {
+        println!(
+            "   {}  {} finding(s) require review{accepted_note}",
+            " REVIEW ".black().bold().on_yellow(),
+            active.len()
+        );
     }
 }
 
@@ -129,8 +126,7 @@ pub fn render_compact(findings: &[Finding], _policy_path: &str, _credentials_pat
 // ---------------------------------------------------------------------------
 
 /// Render a full terminal report with finding panels.
-/// Returns exit code: 0 = pass, 1 = any findings present.
-pub fn render_report(findings: &[Finding], policy_path: &str, credentials_path: &str) -> i32 {
+pub fn render_report(findings: &[Finding], policy_path: &str, credentials_path: &str) {
     let policy_name = Path::new(policy_path)
         .file_name()
         .map_or("policy.yaml", |n| n.to_str().unwrap_or("policy.yaml"));
@@ -160,7 +156,7 @@ pub fn render_report(findings: &[Finding], policy_path: &str, credentials_path: 
 
     if active.is_empty() && accepted.is_empty() {
         println!("{}", "No findings. Policy posture is clean.".green().bold());
-        return 0;
+        return;
     }
 
     println!("{}", "Finding Summary".bold().underline());
@@ -207,26 +203,23 @@ pub fn render_report(findings: &[Finding], policy_path: &str, credentials_path: 
         }
     }
 
-    let path_count: usize = active.iter().map(|f| f.paths.len()).sum();
     let accepted_note = if accepted.is_empty() {
         String::new()
     } else {
         format!(" ({} accepted)", accepted.len())
     };
-    if path_count > 0 {
+    if active.is_empty() {
+        println!(
+            "{}{accepted_note}",
+            "PASS \u{2014} All findings accepted.".bold().green()
+        );
+    } else {
         println!(
             "{}{accepted_note}",
             "REVIEW \u{2014} prover findings require human attention."
                 .bold()
                 .yellow()
         );
-        1
-    } else {
-        println!(
-            "{}{accepted_note}",
-            "PASS \u{2014} All findings accepted.".bold().green()
-        );
-        0
     }
 }
 


### PR DESCRIPTION
## Summary
Moves exit-code logic out of the renderers and into prove(), so outcome evaluation happens once in a single place rather than independently in each renderer.

## Related Issue
Closes #2411 

## Changes
- render_compact and render_report return () instead of i32; all exit-code logic removed from both
- prove() computes exit code after rendering: i32::from(findings.iter().any(|f| !f.accepted))
- Call site in prove() drops unused policy_path/credentials_path args from render_compact
- Both renderer banners gate on active.is_empty() rather than path_count > 0, so terminal output and exit code agree for pathless unaccepted findings
- Four unit tests added covering: empty findings, all-accepted, unaccepted with paths, pathless unaccepted (the case the old renderers got wrong)

## Testing
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated - not applicable, no infrastructure, sandbox, or policy changes

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated - not applicable, internal refactor, no behavioral or API change