### PR TITLE
fix(dev): inherit non-expiring sandbox JWT in local gateway scripts

### DIFF
--- a/tasks/scripts/gateway-docker.sh
+++ b/tasks/scripts/gateway-docker.sh
@@ -183,7 +183,6 @@ signing_key_path = "${TLS_DIR}/jwt/signing.pem"
 public_key_path = "${TLS_DIR}/jwt/public.pem"
 kid_path = "${TLS_DIR}/jwt/kid"
 gateway_id = "${GATEWAY_NAME}"
-ttl_secs = 3600
 
 [openshell.drivers.docker]
 default_image = "${SANDBOX_IMAGE}"

--- a/tasks/scripts/gateway-vm.sh
+++ b/tasks/scripts/gateway-vm.sh
@@ -335,7 +335,6 @@ signing_key_path = "${TLS_DIR}/jwt/signing.pem"
 public_key_path = "${TLS_DIR}/jwt/public.pem"
 kid_path = "${TLS_DIR}/jwt/kid"
 gateway_id = "${GATEWAY_NAME}"
-ttl_secs = 3600
 
 [openshell.drivers.vm]
 default_image = "${SANDBOX_IMAGE}"

--- a/tasks/scripts/gateway.sh
+++ b/tasks/scripts/gateway.sh
@@ -356,8 +356,14 @@ signing_key_path = "${TLS_DIR}/jwt/signing.pem"
 public_key_path = "${TLS_DIR}/jwt/public.pem"
 kid_path = "${TLS_DIR}/jwt/kid"
 gateway_id = "${GATEWAY_NAME}"
-ttl_secs = 3600
 EOF
+
+# Kubernetes is a shared deployment, so its sandbox JWTs must expire. Local
+# drivers omit ttl_secs and inherit the gateway's non-expiring default, so a
+# sandbox restarted while the gateway is down can still reconnect.
+if [[ "${DRIVER}" == "kubernetes" ]]; then
+  printf 'ttl_secs = 3600\n' >>"${CONFIG_PATH}"
+fi
 
 case "${DRIVER}" in
   kubernetes)

--- a/tasks/scripts/gateway.sh
+++ b/tasks/scripts/gateway.sh
@@ -339,6 +339,15 @@ CONFIG_PATH="${STATE_DIR}/gateway.toml"
 # The config may reference credential-bearing material (e.g. proxy_auth_file);
 # keep it owner-only regardless of the ambient umask.
 install -m 600 /dev/null "${CONFIG_PATH}"
+
+# Kubernetes is a shared deployment, so its sandbox JWTs must expire. Local
+# drivers omit ttl_secs and inherit the gateway's non-expiring default, so a
+# sandbox restarted while the gateway is down can still reconnect.
+GATEWAY_JWT_TTL_CONFIG=""
+if [[ "${DRIVER}" == "kubernetes" ]]; then
+  GATEWAY_JWT_TTL_CONFIG="ttl_secs = 3600"
+fi
+
 cat >"${CONFIG_PATH}" <<EOF
 [openshell]
 version = 1
@@ -356,14 +365,8 @@ signing_key_path = "${TLS_DIR}/jwt/signing.pem"
 public_key_path = "${TLS_DIR}/jwt/public.pem"
 kid_path = "${TLS_DIR}/jwt/kid"
 gateway_id = "${GATEWAY_NAME}"
+${GATEWAY_JWT_TTL_CONFIG}
 EOF
-
-# Kubernetes is a shared deployment, so its sandbox JWTs must expire. Local
-# drivers omit ttl_secs and inherit the gateway's non-expiring default, so a
-# sandbox restarted while the gateway is down can still reconnect.
-if [[ "${DRIVER}" == "kubernetes" ]]; then
-  printf 'ttl_secs = 3600\n' >>"${CONFIG_PATH}"
-fi
 
 case "${DRIVER}" in
   kubernetes)


### PR DESCRIPTION
## Summary

For local gateways, we removed the `ttl_secs` for the supervisor JWT before, since for these it's possible the user closes their laptop, opens it again and the sandbox JWT expired and cannot be refreshed anymore, making the sandbox unusable.

That was changed in #1721 to have JWTs not expire for local gateways.

However, local gateways started through our dev scripts still use `3600` as TTL, so gateways started through these run into the same issue. This is a fix for that.

Observed on a local Docker gateway: two sandboxes at ~5,600 restarts each over 8 days, both stuck in `Provisioning`.

```
Error: × Policy fetch failed after 5 attempts: code: 'The request does not have
  │ valid authentication credentials', message: "invalid token: ExpiredSignature"
WARN openshell_core::grpc_client: RefreshSandboxToken returned Unauthenticated;
     static token sources cannot rebootstrap automatically
```

The `ttl_secs = 3600` lines predate the fix - all three were added by fa84e437 (#1575, 2026-05-26), eight days before e4bcfdf (#1721, 2026-06-03). They are leftovers the fix missed, not a deliberate later mitigation.

## Related Issue

Relates to #1603 and #1721. #1721 fixed the gateway default and the Kubernetes/Helm path; this covers the dev-workflow launchers it left behind. #1603 is closed, so this is the remaining follow-up rather than new accepted work - happy to open a fresh issue if maintainers prefer that.

## Changes

- `tasks/scripts/gateway-docker.sh`, `tasks/scripts/gateway-vm.sh`: removed the hardcoded `ttl_secs = 3600`. Both are local-driver-only, so they now inherit the non-expiring default from `crates/openshell-server/src/defaults.rs`.
- `tasks/scripts/gateway.sh`: this script also serves the `kubernetes` driver, which is a shared deployment and must keep a positive TTL, so a plain removal would have been wrong. The value is now emitted conditionally for that driver only, appended after the heredoc but before the `case` writes any `[openshell.drivers.*]` header so it still lands in the `gateway_jwt` table.

Removing the line rather than setting `ttl_secs = 0` keeps one source of truth, so a future change to the default propagates on its own.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated - not applicable, shell config generation only
- [ ] E2E tests added/updated


## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) - not needed; `architecture/gateway.md` and `docs/reference/gateway-config.mdx` already document `ttl_secs = 0` as the local default, and this change makes the scripts match what is documented
