### PR TITLE
feat(gateway): identify gateways in exported traces

### DIFF
--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -730,12 +730,14 @@ between a trace and its log lines. Store and compute-driver spans become
 children of the request span. Reconciliation, provider refresh, and
 driver-watch loops create their own operation spans because they have no
 inbound request to provide a parent. gRPC status is recorded when response
-trailers arrive.
+trailers arrive. Gateway spans carry resource attributes for the gateway
+identity and configured compute driver.
 
-The gateway forwards OTLP configuration and W3C trace context to managed
-external drivers. Built-in drivers use dedicated in-process providers that
-preserve the same RPC trace boundary. Each driver exports to the configured
-collector under its own service name.
+The gateway forwards OTLP configuration, its configured gateway name, and W3C
+trace context to managed external drivers. Built-in drivers use dedicated
+in-process providers that preserve the same RPC trace boundary. Each driver
+exports to the configured collector under its own service name and carries the
+gateway name as a resource attribute.
 
 Two invariants shape the failure behavior. Telemetry is diagnostic, so no OTLP
 failure stops the gateway from serving: a malformed endpoint is logged at

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -673,6 +673,15 @@ Driver implementation settings live in the TOML driver tables. See
 `docs/reference/gateway-config.mdx` for worked per-driver examples and RFC
 0003 for the full schema.
 
+Each installation has an operator-assigned gateway name. Configure it with
+`[openshell.gateway].name`, `--name`, or `OPENSHELL_GATEWAY_NAME`.
+The built-in default is `openshell`; the Helm chart defaults it to the chart
+fullname so every replica in one installation reports the same identity.
+Operators must set a globally distinct name when one telemetry collector serves
+installations in multiple Kubernetes namespaces or clusters.
+The name identifies the gateway installation independently of client-side
+aliases, network names, and the sandbox JWT issuer.
+
 `database_url` is env-only and rejected when present in the file
 (`OPENSHELL_DB_URL` / `--db-url`).
 

--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -29,6 +29,9 @@ pub const DEFAULT_SSH_PORT: u16 = 2222;
 /// Default gateway server port.
 pub const DEFAULT_SERVER_PORT: u16 = 17670;
 
+/// Default operator-facing name for a gateway installation.
+pub const DEFAULT_GATEWAY_NAME: &str = "openshell";
+
 /// Default container stop timeout in seconds (SIGTERM → SIGKILL).
 pub const DEFAULT_STOP_TIMEOUT_SECS: u32 = 10;
 
@@ -757,6 +760,9 @@ fn docker_socket_responds(path: &Path) -> bool {
 /// `Deserialize` impls for that purpose).
 #[derive(Debug, Clone)]
 pub struct Config {
+    /// Operator-assigned name for this gateway installation.
+    pub name: String,
+
     /// Address to bind the server to.
     pub bind_address: SocketAddr,
 
@@ -1164,6 +1170,7 @@ impl Config {
     /// Create a new config with optional TLS.
     pub fn new(tls: Option<TlsConfig>) -> Self {
         Self {
+            name: DEFAULT_GATEWAY_NAME.to_string(),
             bind_address: default_bind_address(),
             health_bind_address: None,
             metrics_bind_address: None,
@@ -1189,6 +1196,13 @@ impl Config {
             grpc_rate_limit_window_secs: None,
             service_routing: ServiceRoutingConfig::default(),
         }
+    }
+
+    /// Create a new configuration with the gateway installation name.
+    #[must_use]
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
     }
 
     /// Create a new configuration with the given bind address.
@@ -1567,6 +1581,15 @@ mod tests {
         .expect("gateway JWT config should deserialize with default ttl");
 
         assert_eq!(cfg.ttl_secs, 0);
+    }
+
+    #[test]
+    fn name_defaults_and_can_be_overridden() {
+        assert_eq!(Config::new(None).name, "openshell");
+        assert_eq!(
+            Config::new(None).with_name("production-us-west").name,
+            "production-us-west"
+        );
     }
 
     #[test]

--- a/crates/openshell-driver-docker/src/main.rs
+++ b/crates/openshell-driver-docker/src/main.rs
@@ -38,13 +38,18 @@ struct Args {
 
     #[arg(long, env = "OPENSHELL_OTLP_ENDPOINT")]
     otlp_endpoint: Option<String>,
+
+    #[arg(long, env = "OPENSHELL_GATEWAY_NAME")]
+    gateway_name: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-    let (tracer_provider, setup_error) =
-        openshell_driver_docker::otel_tracing::provider_for(args.otlp_endpoint.as_deref());
+    let (tracer_provider, setup_error) = openshell_driver_docker::otel_tracing::provider_for(
+        args.otlp_endpoint.as_deref(),
+        args.gateway_name.as_deref(),
+    );
     tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&args.log_level)))
         .with(tracing_subscriber::fmt::layer())

--- a/crates/openshell-driver-docker/src/otel_tracing.rs
+++ b/crates/openshell-driver-docker/src/otel_tracing.rs
@@ -90,13 +90,28 @@ pub(crate) fn compute_driver_rpc_operation(path: &str) -> (&'static str, &'stati
     }
 }
 
+/// Build a tracer provider for the configured OTLP/gRPC endpoint and gateway.
 #[must_use]
-pub fn provider_for(endpoint: Option<&str>) -> (Option<SdkTracerProvider>, Option<SetupError>) {
-    openshell_otel::provider_for(endpoint.map(|endpoint| OtlpTraceConfig {
-        endpoint,
-        service_name: ServiceName::Fixed(SERVICE_NAME),
-        service_version: Some(openshell_core::VERSION),
-        resource_attributes: Vec::new(),
+pub fn provider_for(
+    endpoint: Option<&str>,
+    gateway_name: Option<&str>,
+) -> (Option<SdkTracerProvider>, Option<SetupError>) {
+    openshell_otel::provider_for(endpoint.map(|endpoint| {
+        OtlpTraceConfig {
+            endpoint,
+            service_name: ServiceName::Fixed(SERVICE_NAME),
+            service_version: Some(openshell_core::VERSION),
+            resource_attributes: gateway_name
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(|name| {
+                    vec![opentelemetry::KeyValue::new(
+                        "openshell.gateway.name",
+                        name.to_string(),
+                    )]
+                })
+                .unwrap_or_default(),
+        }
     }))
 }
 
@@ -151,11 +166,11 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn tracing_docker_driver_spans_reach_otlp_collector_with_distinct_service_name() {
+    async fn tracing_docker_driver_spans_reach_otlp_collector_with_resource_identity() {
         let _tracing_lock = super::test_lock().await;
         let collector = OtlpTestServer::start().await;
 
-        let (provider, error) = super::provider_for(Some(collector.endpoint()));
+        let (provider, error) = super::provider_for(Some(collector.endpoint()), Some("docker-dev"));
         assert!(error.is_none());
         let provider = provider.expect("provider");
         let subscriber = tracing_subscriber::registry().with(super::layer(&provider));
@@ -175,6 +190,7 @@ mod tests {
                 .iter()
                 .any(|span| span.name == "docker.schedule_sandbox")
         );
+        assert_eq!(received.gateway_names, ["docker-dev"]);
         assert!(
             received
                 .service_names

--- a/crates/openshell-driver-kubernetes/Cargo.toml
+++ b/crates/openshell-driver-kubernetes/Cargo.toml
@@ -19,6 +19,7 @@ openshell-core = { path = "../openshell-core", default-features = false }
 openshell-otel = { path = "../openshell-otel" }
 openshell-policy = { path = "../openshell-policy" }
 
+opentelemetry = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true, features = ["transport"] }
 prost = { workspace = true }
@@ -39,7 +40,6 @@ notify = "8"
 
 [dev-dependencies]
 openshell-otel-test-support = { path = "../openshell-otel-test-support" }
-opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 bytes = { workspace = true }
 http = { workspace = true }

--- a/crates/openshell-driver-kubernetes/README.md
+++ b/crates/openshell-driver-kubernetes/README.md
@@ -23,7 +23,9 @@ When the gateway configures `[openshell.gateway.otlp]`, Kubernetes
 compute-driver spans export to the same OTLP/gRPC collector with the service
 name `openshell-driver-kubernetes`. The driver preserves the gateway trace
 context and uses the same compute-driver RPC span names in its in-process and
-standalone forms.
+standalone forms. Standalone deployments set `--gateway-name` or
+`OPENSHELL_GATEWAY_NAME` so exported spans carry the same
+`openshell.gateway.name` resource attribute as gateway spans.
 
 When it creates an Agent Sandbox resource, the driver serializes the active W3C
 trace context into the controller-reserved `opentelemetry.io/trace-context`

--- a/crates/openshell-driver-kubernetes/src/main.rs
+++ b/crates/openshell-driver-kubernetes/src/main.rs
@@ -42,6 +42,9 @@ struct Args {
     #[arg(long, env = "OPENSHELL_OTLP_ENDPOINT")]
     otlp_endpoint: Option<String>,
 
+    #[arg(long, env = "OPENSHELL_GATEWAY_NAME")]
+    gateway_name: Option<String>,
+
     #[arg(long, env = "OPENSHELL_WORKSPACE_MODE", default_value = "shared")]
     workspace_mode: WorkspaceMode,
 
@@ -215,8 +218,10 @@ async fn shutdown_signal() {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-    let (tracer_provider, setup_error) =
-        openshell_driver_kubernetes::otel_tracing::provider_for(args.otlp_endpoint.as_deref());
+    let (tracer_provider, setup_error) = openshell_driver_kubernetes::otel_tracing::provider_for(
+        args.otlp_endpoint.as_deref(),
+        args.gateway_name.as_deref(),
+    );
     tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&args.log_level)))
         .with(tracing_subscriber::fmt::layer())
@@ -349,11 +354,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn accepts_gateway_otlp_endpoint() {
+    fn accepts_gateway_otlp_configuration() {
         let args = Args::try_parse_from([
             "openshell-driver-kubernetes",
             "--otlp-endpoint",
             "http://collector.example:4317",
+            "--gateway-name",
+            "kubernetes-dev",
         ])
         .expect("OTLP endpoint should parse");
 
@@ -361,5 +368,6 @@ mod tests {
             args.otlp_endpoint.as_deref(),
             Some("http://collector.example:4317")
         );
+        assert_eq!(args.gateway_name.as_deref(), Some("kubernetes-dev"));
     }
 }

--- a/crates/openshell-driver-kubernetes/src/otel_tracing.rs
+++ b/crates/openshell-driver-kubernetes/src/otel_tracing.rs
@@ -12,13 +12,28 @@ const SERVICE_NAME: &str = "openshell-driver-kubernetes";
 const INSTRUMENTATION_SCOPE: &str = "openshell-driver-kubernetes";
 pub const IN_PROCESS_TARGET_PREFIX: &str = "openshell_driver_kubernetes";
 
+/// Build a tracer provider for the configured OTLP/gRPC endpoint and gateway.
 #[must_use]
-pub fn provider_for(endpoint: Option<&str>) -> (Option<SdkTracerProvider>, Option<SetupError>) {
-    openshell_otel::provider_for(endpoint.map(|endpoint| OtlpTraceConfig {
-        endpoint,
-        service_name: ServiceName::Fixed(SERVICE_NAME),
-        service_version: Some(openshell_core::VERSION),
-        resource_attributes: Vec::new(),
+pub fn provider_for(
+    endpoint: Option<&str>,
+    gateway_name: Option<&str>,
+) -> (Option<SdkTracerProvider>, Option<SetupError>) {
+    openshell_otel::provider_for(endpoint.map(|endpoint| {
+        OtlpTraceConfig {
+            endpoint,
+            service_name: ServiceName::Fixed(SERVICE_NAME),
+            service_version: Some(openshell_core::VERSION),
+            resource_attributes: gateway_name
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(|name| {
+                    vec![opentelemetry::KeyValue::new(
+                        "openshell.gateway.name",
+                        name.to_string(),
+                    )]
+                })
+                .unwrap_or_default(),
+        }
     }))
 }
 
@@ -75,10 +90,11 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn tracing_kubernetes_driver_spans_reach_otlp_collector_with_distinct_service_name() {
+    async fn tracing_kubernetes_driver_spans_reach_otlp_collector_with_resource_identity() {
         let _tracing_lock = super::test_lock().await;
         let collector = OtlpTestServer::start().await;
-        let (provider, error) = super::provider_for(Some(collector.endpoint()));
+        let (provider, error) =
+            super::provider_for(Some(collector.endpoint()), Some("kubernetes-dev"));
         assert!(error.is_none());
         let provider = provider.expect("provider");
         let subscriber = tracing_subscriber::registry().with(super::layer(&provider));
@@ -98,6 +114,7 @@ mod tests {
                 .iter()
                 .any(|span| span.name == "kubernetes.create_sandbox")
         );
+        assert_eq!(received.gateway_names, ["kubernetes-dev"]);
         assert!(
             received
                 .service_names

--- a/crates/openshell-driver-podman/src/main.rs
+++ b/crates/openshell-driver-podman/src/main.rs
@@ -40,6 +40,9 @@ struct Args {
     #[arg(long, env = "OPENSHELL_OTLP_ENDPOINT")]
     otlp_endpoint: Option<String>,
 
+    #[arg(long, env = "OPENSHELL_GATEWAY_NAME")]
+    gateway_name: Option<String>,
+
     /// Path to the Podman API Unix socket.
     #[arg(long, env = "OPENSHELL_PODMAN_SOCKET")]
     podman_socket: Option<PathBuf>,
@@ -174,8 +177,10 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-    let (tracer_provider, setup_error) =
-        openshell_driver_podman::otel_tracing::provider_for(args.otlp_endpoint.as_deref());
+    let (tracer_provider, setup_error) = openshell_driver_podman::otel_tracing::provider_for(
+        args.otlp_endpoint.as_deref(),
+        args.gateway_name.as_deref(),
+    );
     tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&args.log_level)))
         .with(tracing_subscriber::fmt::layer())
@@ -306,17 +311,20 @@ mod tests {
     }
 
     #[test]
-    fn accepts_gateway_otlp_endpoint() {
+    fn accepts_gateway_otlp_configuration() {
         let args = Args::try_parse_from([
             "openshell-driver-podman",
             "--otlp-endpoint",
             "http://collector.internal:4317",
+            "--gateway-name",
+            "production-us-west",
         ])
-        .expect("OTLP endpoint should be accepted");
+        .expect("OTLP configuration should be accepted");
 
         assert_eq!(
             args.otlp_endpoint.as_deref(),
             Some("http://collector.internal:4317")
         );
+        assert_eq!(args.gateway_name.as_deref(), Some("production-us-west"));
     }
 }

--- a/crates/openshell-driver-podman/src/otel_tracing.rs
+++ b/crates/openshell-driver-podman/src/otel_tracing.rs
@@ -12,13 +12,28 @@ const SERVICE_NAME: &str = "openshell-driver-podman";
 const INSTRUMENTATION_SCOPE: &str = "openshell-driver-podman";
 pub const IN_PROCESS_TARGET_PREFIX: &str = "openshell_driver_podman";
 
+/// Build a tracer provider for the configured OTLP/gRPC endpoint and gateway.
 #[must_use]
-pub fn provider_for(endpoint: Option<&str>) -> (Option<SdkTracerProvider>, Option<SetupError>) {
-    openshell_otel::provider_for(endpoint.map(|endpoint| OtlpTraceConfig {
-        endpoint,
-        service_name: ServiceName::Fixed(SERVICE_NAME),
-        service_version: Some(openshell_core::VERSION),
-        resource_attributes: Vec::new(),
+pub fn provider_for(
+    endpoint: Option<&str>,
+    gateway_name: Option<&str>,
+) -> (Option<SdkTracerProvider>, Option<SetupError>) {
+    openshell_otel::provider_for(endpoint.map(|endpoint| {
+        OtlpTraceConfig {
+            endpoint,
+            service_name: ServiceName::Fixed(SERVICE_NAME),
+            service_version: Some(openshell_core::VERSION),
+            resource_attributes: gateway_name
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(|name| {
+                    vec![opentelemetry::KeyValue::new(
+                        "openshell.gateway.name",
+                        name.to_string(),
+                    )]
+                })
+                .unwrap_or_default(),
+        }
     }))
 }
 
@@ -114,11 +129,12 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn podman_driver_spans_reach_otlp_collector_with_distinct_service_name() {
+    async fn podman_driver_spans_reach_otlp_collector_with_resource_identity() {
         let _tracing_lock = super::test_lock().await;
         let collector = OtlpTestServer::start().await;
 
-        let (provider, error) = super::provider_for(Some(collector.endpoint()));
+        let (provider, error) =
+            super::provider_for(Some(collector.endpoint()), Some("production-us-west"));
         assert!(error.is_none());
         let provider = provider.expect("provider");
         let subscriber = tracing_subscriber::registry().with(super::layer(&provider));
@@ -138,6 +154,7 @@ mod tests {
                 .iter()
                 .any(|span| span.name == "podman.create")
         );
+        assert_eq!(received.gateway_names, ["production-us-west"]);
         assert!(
             received
                 .service_names

--- a/crates/openshell-driver-vm/README.md
+++ b/crates/openshell-driver-vm/README.md
@@ -40,7 +40,10 @@ First run takes a few minutes while `mise run vm:setup` stages libkrun/libkrunfw
 By default `mise run gateway:vm`:
 
 - Listens on plaintext HTTP at `127.0.0.1:18081`.
-- Registers the CLI gateway `vm-dev` by writing `~/.config/openshell/gateways/vm-dev/metadata.json`. It does not modify the workspace `.env`.
+- Configures the gateway installation name as `vm-dev` and registers the same
+  name with the CLI by writing
+  `~/.config/openshell/gateways/vm-dev/metadata.json`. It does not modify the
+  workspace `.env`.
 - Persists the gateway SQLite DB under `.cache/gateway-vm/gateway.db`.
 - Places the VM driver state (per-sandbox `overlay.ext4`, image cache, and `run/compute-driver.sock`) under `/tmp/openshell-vm-driver-$USER-vm-dev/` so the AF_UNIX socket path stays under macOS `SUN_LEN`.
 - Writes `.cache/gateway-vm/gateway.toml` with `[openshell.drivers.vm].driver_dir = "$PWD/target/debug"` so the freshly built `openshell-driver-vm` is used instead of an older installed copy from `~/.local/libexec/openshell`, `/usr/libexec/openshell`, or `/usr/local/libexec`.
@@ -68,7 +71,7 @@ Override defaults via environment:
 # custom port (fails fast if in use)
 OPENSHELL_SERVER_PORT=18091 mise run gateway:vm
 
-# custom CLI gateway name + namespace
+# custom gateway installation/CLI name + namespace
 OPENSHELL_VM_GATEWAY_NAME=vm-feature-a \
 OPENSHELL_SANDBOX_NAMESPACE=vm-feature-a \
 mise run gateway:vm

--- a/crates/openshell-driver-vm/src/main.rs
+++ b/crates/openshell-driver-vm/src/main.rs
@@ -91,6 +91,9 @@ struct Args {
     #[arg(long, env = "OPENSHELL_OTLP_ENDPOINT")]
     otlp_endpoint: Option<String>,
 
+    #[arg(long, env = "OPENSHELL_GATEWAY_NAME")]
+    gateway_name: Option<String>,
+
     #[arg(long, env = "OPENSHELL_GRPC_ENDPOINT")]
     openshell_endpoint: Option<String>,
 
@@ -186,8 +189,10 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let (tracer_provider, setup_error) =
-        openshell_driver_vm::otel_tracing::provider_for(args.otlp_endpoint.as_deref());
+    let (tracer_provider, setup_error) = openshell_driver_vm::otel_tracing::provider_for(
+        args.otlp_endpoint.as_deref(),
+        args.gateway_name.as_deref(),
+    );
     tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&args.log_level)))
         .with(tracing_subscriber::fmt::layer())
@@ -691,11 +696,13 @@ mod tests {
     }
 
     #[test]
-    fn accepts_gateway_otlp_endpoint() {
+    fn accepts_gateway_otlp_configuration() {
         let args = Args::try_parse_from([
             "openshell-driver-vm",
             "--otlp-endpoint",
             "http://127.0.0.1:4317",
+            "--gateway-name",
+            "production-us-west",
         ]);
         assert!(
             args.is_ok(),

--- a/crates/openshell-driver-vm/src/otel_tracing.rs
+++ b/crates/openshell-driver-vm/src/otel_tracing.rs
@@ -11,14 +11,28 @@ use tracing_subscriber::registry::LookupSpan;
 const SERVICE_NAME: &str = "openshell-driver-vm";
 const INSTRUMENTATION_SCOPE: &str = "openshell-driver-vm";
 
-/// Build a tracer provider for the configured OTLP/gRPC endpoint.
+/// Build a tracer provider for the configured OTLP/gRPC endpoint and gateway.
 #[must_use]
-pub fn provider_for(endpoint: Option<&str>) -> (Option<SdkTracerProvider>, Option<SetupError>) {
-    openshell_otel::provider_for(endpoint.map(|endpoint| OtlpTraceConfig {
-        endpoint,
-        service_name: ServiceName::Fixed(SERVICE_NAME),
-        service_version: Some(openshell_core::VERSION),
-        resource_attributes: Vec::new(),
+pub fn provider_for(
+    endpoint: Option<&str>,
+    gateway_name: Option<&str>,
+) -> (Option<SdkTracerProvider>, Option<SetupError>) {
+    openshell_otel::provider_for(endpoint.map(|endpoint| {
+        OtlpTraceConfig {
+            endpoint,
+            service_name: ServiceName::Fixed(SERVICE_NAME),
+            service_version: Some(openshell_core::VERSION),
+            resource_attributes: gateway_name
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(|name| {
+                    vec![opentelemetry::KeyValue::new(
+                        "openshell.gateway.name",
+                        name.to_string(),
+                    )]
+                })
+                .unwrap_or_default(),
+        }
     }))
 }
 
@@ -83,10 +97,11 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn vm_driver_spans_reach_otlp_collector_with_distinct_service_name() {
+    async fn vm_driver_spans_reach_otlp_collector_with_resource_identity() {
         let collector = OtlpTestServer::start().await;
 
-        let (provider, error) = super::provider_for(Some(collector.endpoint()));
+        let (provider, error) =
+            super::provider_for(Some(collector.endpoint()), Some("production-us-west"));
         assert!(error.is_none(), "valid OTLP endpoint should configure");
         let provider = provider.expect("provider");
         let subscriber = tracing_subscriber::registry().with(super::layer(&provider));
@@ -113,5 +128,6 @@ mod tests {
             "VM spans should use a distinct service name, got {:?}",
             received.service_names
         );
+        assert_eq!(received.gateway_names, ["production-us-west"]);
     }
 }

--- a/crates/openshell-otel-test-support/src/lib.rs
+++ b/crates/openshell-otel-test-support/src/lib.rs
@@ -16,6 +16,7 @@ use opentelemetry_proto::tonic::trace::v1::Span;
 pub struct ReceivedTraces {
     pub spans: Vec<Span>,
     pub service_names: Vec<String>,
+    pub gateway_names: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -37,18 +38,22 @@ impl TraceService for Collector {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             for resource_span in request.into_inner().resource_spans {
                 if let Some(resource) = resource_span.resource {
-                    received.service_names.extend(
-                        resource
-                            .attributes
-                            .into_iter()
-                            .filter(|attribute| attribute.key == "service.name")
-                            .filter_map(|attribute| attribute.value)
-                            .filter_map(|value| value.value)
-                            .filter_map(|value| match value {
-                                opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => Some(value),
-                                _ => None,
-                            }),
-                    );
+                    for attribute in resource.attributes {
+                        let Some(value) = attribute.value.and_then(|value| value.value) else {
+                            continue;
+                        };
+                        let opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                            value,
+                        ) = value
+                        else {
+                            continue;
+                        };
+                        match attribute.key.as_str() {
+                            "service.name" => received.service_names.push(value),
+                            "openshell.gateway.name" => received.gateway_names.push(value),
+                            _ => {}
+                        }
+                    }
                 }
                 for scope_span in resource_span.scope_spans {
                     received.spans.extend(scope_span.spans);

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -509,12 +509,17 @@ async fn run_from_args(
         .config_file
         .as_ref()
         .and_then(|f| f.openshell.gateway.otlp.as_ref());
+    let gateway_resource = crate::otel_tracing::GatewayResourceAttributes::new(
+        Some(prepared.config.name.as_str()),
+        Some(compute_driver.name()),
+    );
     let (tracing_handle, setup_error) = crate::tracing_setup::install(
         EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| EnvFilter::new(&prepared.config.log_level)),
         &tracing_log_bus,
         otlp_config,
         &compute_driver,
+        gateway_resource,
     );
 
     let has_client_ca = prepared

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -7,7 +7,7 @@ use clap::parser::ValueSource;
 use clap::{ArgAction, ArgMatches, Command, CommandFactory, FromArgMatches, Parser};
 use miette::{IntoDiagnostic, Result};
 use openshell_core::ComputeDriverKind;
-use openshell_core::config::DEFAULT_SERVER_PORT;
+use openshell_core::config::{DEFAULT_GATEWAY_NAME, DEFAULT_SERVER_PORT};
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use tracing::{error, info, warn};
@@ -54,6 +54,14 @@ struct RunArgs {
     /// variables continue to take precedence over gateway file values.
     #[arg(long, env = "OPENSHELL_GATEWAY_CONFIG")]
     config: Option<PathBuf>,
+
+    /// Operator-assigned name for this gateway installation.
+    #[arg(
+        long = "name",
+        default_value = DEFAULT_GATEWAY_NAME,
+        env = "OPENSHELL_GATEWAY_NAME"
+    )]
+    name: String,
 
     /// IP address to bind the server, health, and metrics listeners to.
     #[arg(long, default_value = "127.0.0.1", env = "OPENSHELL_BIND_ADDRESS")]
@@ -336,7 +344,13 @@ fn prepare_server_config(
         .clone()
         .expect("runtime defaults populate db_url");
 
+    let name = args.name.trim();
+    if name.is_empty() {
+        return Err(miette::miette!("gateway name must not be empty"));
+    }
+
     let mut config = openshell_core::Config::new(tls)
+        .with_name(name)
         .with_bind_address(bind)
         .with_log_level(&args.log_level);
     if let Some(auth) = file.as_ref().and_then(|f| f.openshell.gateway.auth.clone()) {
@@ -651,6 +665,11 @@ fn resolve_aux_listener(
 /// The function intentionally does not touch `database_url` — that secret is
 /// env-only and the loader already rejected it when it appears in the file.
 fn merge_file_into_args(args: &mut RunArgs, file: &GatewayFileSection, matches: &ArgMatches) {
+    if let Some(name) = &file.name
+        && arg_defaulted(matches, "name")
+    {
+        args.name.clone_from(name);
+    }
     if let Some(addr) = file.bind_address {
         if arg_defaulted(matches, "bind_address") {
             args.bind_address = addr.ip();
@@ -1447,12 +1466,14 @@ enabled = false
         let _g1 = EnvVarGuard::remove("OPENSHELL_BIND_ADDRESS");
         let _g2 = EnvVarGuard::remove("OPENSHELL_SERVER_PORT");
         let _g3 = EnvVarGuard::remove("OPENSHELL_LOG_LEVEL");
+        let _g4 = EnvVarGuard::remove("OPENSHELL_GATEWAY_NAME");
 
         let (mut args, matches) =
             parse_with_args(&["openshell-gateway", "--db-url", "sqlite::memory:"]);
         let file = config_file_from_toml(
             r#"
 [openshell.gateway]
+name = "production-us-west"
 bind_address = "0.0.0.0:9090"
 log_level = "debug"
 "#,
@@ -1462,6 +1483,7 @@ log_level = "debug"
         assert_eq!(args.bind_address, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
         assert_eq!(args.port, 9090);
         assert_eq!(args.log_level, "debug");
+        assert_eq!(args.name, "production-us-west");
     }
 
     #[test]
@@ -1471,6 +1493,7 @@ log_level = "debug"
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _g1 = EnvVarGuard::remove("OPENSHELL_BIND_ADDRESS");
         let _g2 = EnvVarGuard::remove("OPENSHELL_LOG_LEVEL");
+        let _g3 = EnvVarGuard::remove("OPENSHELL_GATEWAY_NAME");
 
         let (mut args, matches) = parse_with_args(&[
             "openshell-gateway",
@@ -1478,16 +1501,20 @@ log_level = "debug"
             "sqlite::memory:",
             "--log-level",
             "warn",
+            "--name",
+            "cli-gateway",
         ]);
         let file = config_file_from_toml(
             r#"
 [openshell.gateway]
+name = "file-gateway"
 log_level = "debug"
 "#,
         );
         merge_file_into_args(&mut args, &file.openshell.gateway, &matches);
 
         assert_eq!(args.log_level, "warn", "CLI flag must win over file");
+        assert_eq!(args.name, "cli-gateway");
     }
 
     #[test]
@@ -1496,18 +1523,21 @@ log_level = "debug"
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _g = EnvVarGuard::set("OPENSHELL_LOG_LEVEL", "trace");
+        let _g2 = EnvVarGuard::set("OPENSHELL_GATEWAY_NAME", "env-gateway");
 
         let (mut args, matches) =
             parse_with_args(&["openshell-gateway", "--db-url", "sqlite::memory:"]);
         let file = config_file_from_toml(
             r#"
 [openshell.gateway]
+name = "file-gateway"
 log_level = "debug"
 "#,
         );
         merge_file_into_args(&mut args, &file.openshell.gateway, &matches);
 
         assert_eq!(args.log_level, "trace", "env var must win over file");
+        assert_eq!(args.name, "env-gateway");
     }
 
     #[test]

--- a/crates/openshell-server/src/compute/vm.rs
+++ b/crates/openshell-server/src/compute/vm.rs
@@ -478,7 +478,7 @@ pub async fn spawn(
         .arg("--expected-peer-pid")
         .arg(std::process::id().to_string());
     command.arg("--log-level").arg(&config.log_level);
-    append_otlp_args(&mut command, otlp_config);
+    append_otlp_args(&mut command, otlp_config, &config.name);
     command
         .arg("--openshell-endpoint")
         .arg(&vm_config.grpc_endpoint);
@@ -521,9 +521,10 @@ pub async fn spawn(
 }
 
 #[cfg(unix)]
-fn append_otlp_args(command: &mut Command, otlp_config: Option<&OtlpConfig>) {
+fn append_otlp_args(command: &mut Command, otlp_config: Option<&OtlpConfig>, gateway_name: &str) {
     if let Some(config) = otlp_config {
         command.arg("--otlp-endpoint").arg(&config.endpoint);
+        command.arg("--gateway-name").arg(gateway_name);
     }
 }
 
@@ -621,7 +622,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn vm_driver_command_includes_gateway_otlp_endpoint() {
+    fn vm_driver_command_includes_gateway_otlp_configuration() {
         let mut command = tokio::process::Command::new("openshell-driver-vm");
         append_otlp_args(
             &mut command,
@@ -629,6 +630,7 @@ mod tests {
                 endpoint: "http://collector.internal:4317".to_string(),
                 service_name: Some("custom-gateway".to_string()),
             }),
+            "production-us-west",
         );
 
         let args = command
@@ -636,7 +638,15 @@ mod tests {
             .get_args()
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect::<Vec<_>>();
-        assert_eq!(args, ["--otlp-endpoint", "http://collector.internal:4317"]);
+        assert_eq!(
+            args,
+            [
+                "--otlp-endpoint",
+                "http://collector.internal:4317",
+                "--gateway-name",
+                "production-us-west"
+            ]
+        );
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/config_file.rs
+++ b/crates/openshell-server/src/config_file.rs
@@ -87,6 +87,11 @@ pub struct OpenShellRoot {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct GatewayFileSection {
+    // ── Identity ─────────────────────────────────────────────────────────
+    /// Operator-assigned name for this gateway installation.
+    #[serde(default)]
+    pub name: Option<String>,
+
     // ── Listeners ────────────────────────────────────────────────────────
     #[serde(default)]
     pub bind_address: Option<SocketAddr>,

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -583,13 +583,8 @@ pub(crate) async fn run_server(
     let sandbox_index = SandboxIndex::new();
     let sandbox_watch_bus = SandboxWatchBus::new();
     let supervisor_sessions = Arc::new(supervisor_session::SupervisorSessionRegistry::new());
-    let driver_startup = compute::driver_config::DriverStartupContext {
-        file: config_file.as_ref(),
-        guest_tls: guest_tls.as_ref(),
-        gateway_port: config.bind_address.port(),
-        gateway_tls_enabled: config.tls.is_some(),
-        endpoint_overrides: &config.compute_driver_endpoints,
-    };
+    let driver_startup =
+        compute_driver_startup_context(&config, config_file.as_ref(), guest_tls.as_ref());
     let (compute, operator_allowlist) = build_compute_runtime(
         &config,
         driver_startup,
@@ -1631,6 +1626,20 @@ async fn build_compute_runtime(
     Ok((runtime, operator_allowlist))
 }
 
+fn compute_driver_startup_context<'a>(
+    config: &'a Config,
+    config_file: Option<&'a config_file::ConfigFile>,
+    guest_tls: Option<&'a compute::driver_config::GuestTlsPaths>,
+) -> compute::driver_config::DriverStartupContext<'a> {
+    compute::driver_config::DriverStartupContext {
+        file: config_file,
+        guest_tls,
+        gateway_port: config.bind_address.port(),
+        gateway_tls_enabled: config.tls.is_some(),
+        endpoint_overrides: &config.compute_driver_endpoints,
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum ConfiguredComputeDriver {
     Registered(ComputeDriverRegistration),
@@ -1638,7 +1647,7 @@ pub(crate) enum ConfiguredComputeDriver {
 }
 
 impl ConfiguredComputeDriver {
-    fn name(&self) -> &str {
+    pub(crate) fn name(&self) -> &str {
         match self {
             Self::Registered(registration) => &registration.name,
             Self::Remote { name } => name,

--- a/crates/openshell-server/src/otel_tracing.rs
+++ b/crates/openshell-server/src/otel_tracing.rs
@@ -37,7 +37,31 @@ const DEFAULT_SERVICE_NAME: &str = "openshell-gateway";
 /// Instrumentation scope recorded on spans this gateway emits.
 const INSTRUMENTATION_SCOPE: &str = "openshell-gateway";
 
-fn trace_config(cfg: &OtlpConfig) -> OtlpTraceConfig<'_> {
+/// Gateway identity recorded on every exported span.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GatewayResourceAttributes<'a> {
+    name: Option<&'a str>,
+    compute_driver: Option<&'a str>,
+}
+
+impl<'a> GatewayResourceAttributes<'a> {
+    pub fn new(name: Option<&'a str>, compute_driver: Option<&'a str>) -> Self {
+        Self {
+            name,
+            compute_driver,
+        }
+    }
+
+    /// The configured gateway installation name, if any.
+    pub fn name(&self) -> Option<&'a str> {
+        self.name
+    }
+}
+
+fn trace_config<'cfg>(
+    cfg: &'cfg OtlpConfig,
+    gateway: GatewayResourceAttributes<'_>,
+) -> OtlpTraceConfig<'cfg> {
     let service_name = cfg
         .service_name
         .as_deref()
@@ -48,17 +72,35 @@ fn trace_config(cfg: &OtlpConfig) -> OtlpTraceConfig<'_> {
             ServiceName::Fixed,
         );
 
+    let mut resource_attributes = Vec::new();
+    if let Some(name) = gateway.name.map(str::trim).filter(|s| !s.is_empty()) {
+        resource_attributes.push(opentelemetry::KeyValue::new(
+            "openshell.gateway.name",
+            name.to_string(),
+        ));
+    }
+    if let Some(compute_driver) = gateway
+        .compute_driver
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        resource_attributes.push(opentelemetry::KeyValue::new(
+            "openshell.gateway.compute_driver",
+            compute_driver.to_string(),
+        ));
+    }
+
     OtlpTraceConfig {
         endpoint: &cfg.endpoint,
         service_name,
         service_version: Some(openshell_core::VERSION),
-        resource_attributes: Vec::new(),
+        resource_attributes,
     }
 }
 
 #[cfg(test)]
-fn build_resource(cfg: &OtlpConfig) -> Resource {
-    openshell_otel::resource_for(&trace_config(cfg))
+fn build_resource(cfg: &OtlpConfig, gateway: GatewayResourceAttributes<'_>) -> Resource {
+    openshell_otel::resource_for(&trace_config(cfg, gateway))
 }
 
 /// Build a tracer provider exporting over OTLP/gRPC to the configured endpoint.
@@ -70,8 +112,11 @@ fn build_resource(cfg: &OtlpConfig) -> Resource {
 /// The sampler and span limits are left at the SDK's defaults, which are
 /// themselves resolved from `OTEL_*` env vars (see the module docs).
 #[cfg(test)]
-fn build_provider(cfg: &OtlpConfig) -> Result<SdkTracerProvider, SetupError> {
-    openshell_otel::build_provider(&trace_config(cfg))
+fn build_provider(
+    cfg: &OtlpConfig,
+    gateway: GatewayResourceAttributes<'_>,
+) -> Result<SdkTracerProvider, SetupError> {
+    openshell_otel::build_provider(&trace_config(cfg, gateway))
 }
 
 /// Resolve the tracer provider for a gateway config file's optional
@@ -82,8 +127,11 @@ fn build_provider(cfg: &OtlpConfig) -> Result<SdkTracerProvider, SetupError> {
 ///
 /// The error is returned rather than logged because the provider is built
 /// before the subscriber it attaches to, so logging here would go nowhere.
-pub fn provider_for(cfg: Option<&OtlpConfig>) -> (Option<SdkTracerProvider>, Option<SetupError>) {
-    openshell_otel::provider_for(cfg.map(trace_config))
+pub fn provider_for(
+    cfg: Option<&OtlpConfig>,
+    gateway: GatewayResourceAttributes<'_>,
+) -> (Option<SdkTracerProvider>, Option<SetupError>) {
+    openshell_otel::provider_for(cfg.map(|cfg| trace_config(cfg, gateway)))
 }
 
 /// Build the gateway layer while routing one selected in-process driver to
@@ -259,6 +307,10 @@ mod tests {
         }
     }
 
+    fn build_test_resource(cfg: &OtlpConfig) -> Resource {
+        build_resource(cfg, GatewayResourceAttributes::default())
+    }
+
     #[test]
     fn resource_defaults_the_service_name() {
         let _lock = crate::TEST_ENV_LOCK
@@ -267,7 +319,7 @@ mod tests {
         let _env = EnvVarGuard::remove("OTEL_SERVICE_NAME");
 
         assert_eq!(
-            service_name_of(&build_resource(&config())),
+            service_name_of(&build_test_resource(&config())),
             Some(DEFAULT_SERVICE_NAME.to_string())
         );
     }
@@ -276,7 +328,7 @@ mod tests {
     fn resource_honors_configured_service_name_and_carries_version() {
         let mut cfg = config();
         cfg.service_name = Some("gateway-staging".into());
-        let resource = build_resource(&cfg);
+        let resource = build_test_resource(&cfg);
 
         assert_eq!(
             resource
@@ -289,6 +341,31 @@ mod tests {
                 .get(&opentelemetry::Key::from_static_str("service.version"))
                 .map(|v| v.to_string()),
             Some(openshell_core::VERSION.to_string())
+        );
+    }
+
+    #[test]
+    fn resource_carries_gateway_name_and_compute_driver() {
+        let resource = build_resource(
+            &config(),
+            GatewayResourceAttributes::new(Some("vm-dev"), Some("vm")),
+        );
+
+        assert_eq!(
+            resource
+                .get(&opentelemetry::Key::from_static_str(
+                    "openshell.gateway.name",
+                ))
+                .map(|v| v.to_string()),
+            Some("vm-dev".to_string())
+        );
+        assert_eq!(
+            resource
+                .get(&opentelemetry::Key::from_static_str(
+                    "openshell.gateway.compute_driver",
+                ))
+                .map(|v| v.to_string()),
+            Some("vm".to_string())
         );
     }
 
@@ -346,7 +423,7 @@ mod tests {
         cfg.service_name = Some("from-config".into());
 
         assert_eq!(
-            service_name_of(&build_resource(&cfg)),
+            service_name_of(&build_test_resource(&cfg)),
             Some("from-config".to_string())
         );
     }
@@ -361,7 +438,7 @@ mod tests {
         let _env = EnvVarGuard::set("OTEL_SERVICE_NAME", "from-env");
 
         assert_eq!(
-            service_name_of(&build_resource(&config())),
+            service_name_of(&build_test_resource(&config())),
             Some("from-env".to_string())
         );
     }
@@ -376,7 +453,7 @@ mod tests {
         let mut cfg = config();
         cfg.service_name = Some("   ".into());
         assert_eq!(
-            service_name_of(&build_resource(&cfg)),
+            service_name_of(&build_test_resource(&cfg)),
             Some(DEFAULT_SERVICE_NAME.to_string())
         );
     }
@@ -385,7 +462,8 @@ mod tests {
     fn provider_rejects_a_malformed_endpoint() {
         let mut cfg = config();
         cfg.endpoint = "definitely not a url".into();
-        let err = build_provider(&cfg).expect_err("malformed endpoint");
+        let err = build_provider(&cfg, GatewayResourceAttributes::default())
+            .expect_err("malformed endpoint");
         assert!(
             err.to_string().contains("definitely not a url"),
             "error names the offending endpoint: {err}"
@@ -396,7 +474,10 @@ mod tests {
     fn provider_rejects_an_empty_endpoint() {
         let mut cfg = config();
         cfg.endpoint = "   ".into();
-        assert!(build_provider(&cfg).is_err(), "empty endpoint is rejected");
+        assert!(
+            build_provider(&cfg, GatewayResourceAttributes::default()).is_err(),
+            "empty endpoint is rejected"
+        );
     }
 
     #[tokio::test]
@@ -404,7 +485,8 @@ mod tests {
         // The OTLP batch exporter connects lazily, so a valid endpoint must
         // build even when nothing is listening — the gateway must not fail to
         // start because its collector is down.
-        let provider = build_provider(&config()).expect("provider builds");
+        let provider = build_provider(&config(), GatewayResourceAttributes::default())
+            .expect("provider builds");
         provider.shutdown().ok();
     }
 
@@ -413,7 +495,7 @@ mod tests {
     /// error for the caller to log — see the misconfigured-endpoint test.
     #[tokio::test]
     async fn absent_otlp_table_disables_export() {
-        let (provider, err) = provider_for(None);
+        let (provider, err) = provider_for(None, GatewayResourceAttributes::default());
         assert!(provider.is_none(), "export is off");
         assert!(
             err.is_none(),
@@ -423,7 +505,7 @@ mod tests {
 
     #[tokio::test]
     async fn present_otlp_table_enables_export() {
-        let (provider, err) = provider_for(Some(&config()));
+        let (provider, err) = provider_for(Some(&config()), GatewayResourceAttributes::default());
         assert!(err.is_none());
         provider.expect("provider is present").shutdown().ok();
     }
@@ -436,7 +518,7 @@ mod tests {
         let mut cfg = config();
         cfg.endpoint = "definitely not a url".into();
 
-        let (provider, err) = provider_for(Some(&cfg));
+        let (provider, err) = provider_for(Some(&cfg), GatewayResourceAttributes::default());
         assert!(
             provider.is_none(),
             "a bad endpoint degrades to no export rather than failing startup"

--- a/crates/openshell-server/src/tracing_setup.rs
+++ b/crates/openshell-server/src/tracing_setup.rs
@@ -13,7 +13,7 @@ use tracing_subscriber::prelude::*;
 
 use crate::ConfiguredComputeDriver;
 use crate::config_file::OtlpConfig;
-use crate::otel_tracing::SetupError;
+use crate::otel_tracing::{GatewayResourceAttributes, SetupError};
 use crate::tracing_bus::TracingLogBus;
 
 pub struct TracingHandle {
@@ -94,16 +94,17 @@ fn in_process_driver_target_prefix(driver: Option<InProcessDriverTracing>) -> Op
 fn in_process_driver_provider(
     driver: Option<InProcessDriverTracing>,
     endpoint: Option<&str>,
+    gateway_name: Option<&str>,
 ) -> (Option<SdkTracerProvider>, Option<SetupError>) {
     match driver {
         Some(InProcessDriverTracing::Docker) => {
-            openshell_driver_docker::otel_tracing::provider_for(endpoint)
+            openshell_driver_docker::otel_tracing::provider_for(endpoint, gateway_name)
         }
         Some(InProcessDriverTracing::Kubernetes) => {
-            openshell_driver_kubernetes::otel_tracing::provider_for(endpoint)
+            openshell_driver_kubernetes::otel_tracing::provider_for(endpoint, gateway_name)
         }
         Some(InProcessDriverTracing::Podman) => {
-            openshell_driver_podman::otel_tracing::provider_for(endpoint)
+            openshell_driver_podman::otel_tracing::provider_for(endpoint, gateway_name)
         }
         None => (None, None),
     }
@@ -113,6 +114,7 @@ fn in_process_driver_provider(
 fn in_process_driver_provider(
     _driver: Option<InProcessDriverTracing>,
     _endpoint: Option<&str>,
+    _gateway_name: Option<&str>,
 ) -> (Option<SdkTracerProvider>, Option<SetupError>) {
     (None, None)
 }
@@ -155,8 +157,9 @@ pub fn install(
     tracing_log_bus: &TracingLogBus,
     otlp_config: Option<&OtlpConfig>,
     driver: &ConfiguredComputeDriver,
+    gateway: GatewayResourceAttributes<'_>,
 ) -> (TracingHandle, Option<SetupError>) {
-    let (tracer_provider, setup_error) = crate::otel_tracing::provider_for(otlp_config);
+    let (tracer_provider, setup_error) = crate::otel_tracing::provider_for(otlp_config, gateway);
     let selected_driver = in_process_driver_tracing(driver);
     let driver_endpoint = selected_driver
         .is_some()
@@ -164,7 +167,7 @@ pub fn install(
         .flatten()
         .map(|config| config.endpoint.as_str());
     let (driver_tracer_provider, driver_setup_error) =
-        in_process_driver_provider(selected_driver, driver_endpoint);
+        in_process_driver_provider(selected_driver, driver_endpoint, gateway.name());
 
     tracing_subscriber::registry()
         .with(env_filter)

--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -253,6 +253,7 @@ discovery endpoint or its TLS CA.
 | server.grpcRateLimit.windowSeconds | int | `0` | gRPC rate-limit window length in seconds. Must be positive (alongside requests) to enable rate limiting; 0 (default) disables it. |
 | server.hostGatewayIP | string | `""` | Host gateway IP for sandbox pod hostAliases. When set, sandbox pods get hostAliases entries mapping host.docker.internal and host.openshell.internal to this IP, allowing them to reach services running on the Docker host. Auto-detected by the cluster entrypoint script. |
 | server.logLevel | string | `"info"` | Gateway log level. |
+| server.name | string | `""` | Operator-facing gateway name. Defaults to the chart fullname so all replicas in one installation share an identity. Set explicitly when one telemetry collector receives spans from multiple namespaces or clusters. |
 | server.oidc.adminRole | string | `""` | Role name for admin access. Leave empty (with userRole also empty) for authentication-only mode. Both must be set or both empty. |
 | server.oidc.audience | string | `"openshell-cli"` | Expected audience claim for the API resource server. This should match the server's --oidc-audience, NOT the CLI client ID. |
 | server.oidc.caConfigMapName | string | `""` | Name of a ConfigMap containing a CA certificate bundle (key: ca.crt) for verifying the OIDC issuer's TLS certificate. Required when the issuer uses a non-public CA (e.g. OpenShift ingress, private PKI). |

--- a/deploy/helm/openshell/templates/gateway-config.yaml
+++ b/deploy/helm/openshell/templates/gateway-config.yaml
@@ -35,6 +35,7 @@ data:
     version = 1
 
     [openshell.gateway]
+    name                  = {{ .Values.server.name | default (include "openshell.fullname" .) | quote }}
     bind_address          = "0.0.0.0:{{ .Values.service.port }}"
     {{- if .Values.service.healthPort }}
     health_bind_address   = "0.0.0.0:{{ .Values.service.healthPort }}"

--- a/deploy/helm/openshell/tests/gateway_config_test.yaml
+++ b/deploy/helm/openshell/tests/gateway_config_test.yaml
@@ -11,6 +11,22 @@ release:
   namespace: my-namespace
 
 tests:
+  - it: identifies the gateway by chart fullname by default
+    template: templates/gateway-config.yaml
+    asserts:
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?m)^name\s*=\s*"openshell"$'
+
+  - it: renders an explicit gateway name
+    template: templates/gateway-config.yaml
+    set:
+      server.name: production-us-west
+    asserts:
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?m)^name\s*=\s*"production-us-west"$'
+
   # Regression for Drew's P2: a ConfigMap-only mutation in `helm upgrade`
   # must roll the StatefulSet, otherwise pods keep running with stale config.
   - it: annotates the StatefulSet pod template with a ConfigMap checksum

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -189,6 +189,10 @@ affinity: {}
 
 # Server configuration
 server:
+  # -- Operator-facing gateway name. Defaults to the chart fullname so all
+  # replicas in one installation share an identity. Set explicitly when one
+  # telemetry collector receives spans from multiple namespaces or clusters.
+  name: ""
   # -- Gateway log level.
   logLevel: info
   # OpenTelemetry trace export over OTLP/gRPC. Leave endpoint empty to disable.

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -18,6 +18,8 @@ Gateway CLI flag  >  gateway OPENSHELL_* env var  >  TOML file  >  built-in defa
 
 `database_url` is env-only. The loader rejects it when it appears in the file. When `OPENSHELL_DB_URL` is unset, the gateway stores its SQLite database under `$XDG_STATE_HOME/openshell/gateway/openshell.db`.
 
+`name` assigns an operator-facing identity to the gateway installation. Set it with `[openshell.gateway].name`, `--name`, or `OPENSHELL_GATEWAY_NAME`. It defaults to `openshell`; the Helm chart defaults it to the chart fullname so all replicas in one installation share a name. Chart fullnames are only unique within their Kubernetes namespace, so set `server.name` explicitly when one collector receives telemetry from multiple namespaces or clusters. This identity is independent of client-side gateway aliases, TLS names, and `gateway_jwt.gateway_id`.
+
 ## Package-Managed Locations
 
 Package-managed gateways do not require a TOML file. Create one at the package's optional config location when you need to override built-in defaults. Set `OPENSHELL_GATEWAY_CONFIG` in the launch environment to use a different file.
@@ -69,6 +71,7 @@ A complete gateway configuration covering every section. Trim to the fields you 
 version = 1
 
 [openshell.gateway]
+name                  = "production-us-west"
 bind_address          = "0.0.0.0:8080"
 health_bind_address   = "0.0.0.0:8081"
 metrics_bind_address  = "0.0.0.0:9090"

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -231,11 +231,11 @@ The transport is **OTLP over gRPC only**. HTTP/protobuf and HTTP/JSON are not su
 
 The OpenTelemetry SDK logs export failures after startup. Spans in a failed batch are dropped rather than retried.
 
-`service_name` sets the gateway's `service.name` resource attribute and defaults to `openshell-gateway`. The gateway also reports `service.version`.
+`service_name` sets the gateway's `service.name` resource attribute and defaults to `openshell-gateway`. The gateway also reports `service.version`, `openshell.gateway.name` from the gateway's configured `name`, and `openshell.gateway.compute_driver`.
 
 Only OpenTelemetry traces are exported. Inbound gRPC and HTTP requests produce server spans named for the RPC or HTTP method. Store and compute-driver operations appear as child spans. Internal reconciliation, credential-refresh, and driver-watch loops create operation roots for their store work because no inbound request supplies a parent. The gateway continues valid W3C `traceparent` context and starts a new trace when none is supplied. Request spans carry `method`, `path`, and the `request_id` that also appears in gateway logs. Health endpoint spans use DEBUG level and are not exported by the default INFO filter.
 
-The gateway forwards the OTLP configuration and W3C trace context to managed external drivers. Built-in Docker and Podman drivers also export their spans to the same collector through dedicated in-process providers. Driver spans retain the gateway trace context and use a distinct service name such as `openshell-driver-docker` or `openshell-driver-podman`.
+The gateway forwards the OTLP configuration, configured gateway name, and W3C trace context to managed external drivers. Built-in drivers also export their spans to the same collector through dedicated in-process providers. Driver spans retain the gateway trace context, use a distinct service name such as `openshell-driver-docker` or `openshell-driver-podman`, and carry the gateway name as the `openshell.gateway.name` resource attribute. Operator-run external drivers own their own telemetry configuration.
 
 For Helm deployments, set `server.otlp.endpoint` to render this table. The
 optional `server.otlp.serviceName` value overrides the gateway service name;
@@ -245,6 +245,11 @@ The local `mise run helm:k3s:create` workflow installs a trace collector and UI,
 enables Agent Sandbox controller tracing on supported releases, and configures
 both the controller and the existing Skaffold deployment to export traces to it
 automatically.
+The local `gateway`, `gateway:docker`, `gateway:podman`, and `gateway:vm` tasks
+also set the gateway installation name in their generated configuration. Their
+defaults are driver-specific (`kubernetes-dev`, `docker-dev`, `podman-dev`, and
+`vm-dev`), and their documented `OPENSHELL_*_GATEWAY_NAME` overrides update both
+CLI registration and exported telemetry identity.
 Run `mise run helm:k3s:forward` to forward OTLP/gRPC to local port `4317` and
 the trace UI to local port `18888`. When Skaffold has deployed a Kubernetes
 gateway, the task also forwards it to local port `8090`; otherwise it continues

--- a/tasks/scripts/gateway-docker.sh
+++ b/tasks/scripts/gateway-docker.sh
@@ -199,6 +199,7 @@ cat >"${CONFIG_PATH}" <<EOF
 version = 1
 
 [openshell.gateway]
+name = "${GATEWAY_NAME}"
 compute_drivers = ["docker"]
 disable_tls = true
 

--- a/tasks/scripts/gateway-podman.sh
+++ b/tasks/scripts/gateway-podman.sh
@@ -8,7 +8,7 @@
 #
 # Defaults:
 # - Plaintext HTTP on 127.0.0.1:18080 (IPv6 loopback on macOS Podman Machine)
-# - Dedicated CLI gateway "podman-dev"
+# - Gateway installation and CLI registration name "podman-dev"
 # - Persistent state under .cache/gateway-podman
 # - Supervisor sideload image openshell/supervisor:dev, refreshed on launch
 #
@@ -203,6 +203,7 @@ cat >"${CONFIG_PATH}" <<EOF
 version = 1
 
 [openshell.gateway]
+name = "${GATEWAY_NAME}"
 compute_drivers = ["podman"]
 default_image = "${SANDBOX_IMAGE}"
 disable_tls = true

--- a/tasks/scripts/gateway-vm.sh
+++ b/tasks/scripts/gateway-vm.sh
@@ -11,7 +11,7 @@
 #
 # Defaults:
 # - Plaintext HTTP on 127.0.0.1:18081
-# - Dedicated CLI gateway "vm-dev"
+# - Gateway installation and CLI registration name "vm-dev"
 # - Persistent gateway state (SQLite DB) under .cache/gateway-vm
 # - Per-sandbox VM driver state (rootfs + compute-driver.sock) under
 #   /tmp/openshell-vm-driver-<user>-<gateway-name> so the AF_UNIX socket
@@ -324,6 +324,7 @@ cat >"${CONFIG_PATH}" <<EOF
 version = 1
 
 [openshell.gateway]
+name = "${GATEWAY_NAME}"
 compute_drivers = ["vm"]
 disable_tls = ${DISABLE_TLS}
 

--- a/tasks/scripts/gateway.sh
+++ b/tasks/scripts/gateway.sh
@@ -247,6 +247,7 @@ cat >"${CONFIG_PATH}" <<EOF
 version = 1
 
 [openshell.gateway]
+name = "${GATEWAY_NAME}"
 compute_drivers = ["${DRIVER}"]
 default_image = "${SANDBOX_IMAGE}"
 disable_tls = true


### PR DESCRIPTION
## Summary
Now that we can trace gateways, we also need to identify which gateways spans are coming from, as an operator may have multiple gateways sending spans to the same collector. This adds a new configuration to the gateway, `name`, which will be used solely for adding a resource attribute showing which gateway the spans came from.

We might in the future choose to use this name as the default name when registering a gateway with the CLI (rather than the hostname, as at present), but that would require a mechanism for the CLI to discover it, and that's out of scope for this change.

## Related Issue
Refs #2507

## Changes
- Add `[openshell.gateway].name` / `--name` / `OPENSHELL_GATEWAY_NAME` (default `openshell`); Helm `server.name` defaults to the chart fullname so all replicas in one installation share an identity
- Export `openshell.gateway.name` and `openshell.gateway.compute_driver` as resource attributes on gateway spans
- Forward the gateway name to the managed VM driver (`--gateway-name`) so its spans carry the same installation identity
- Carry the gateway name on podman driver spans, both in-process (forwarded from the gateway config) and standalone (`--gateway-name` / `OPENSHELL_GATEWAY_NAME`)
- Document the new configuration in `docs/reference/gateway-config.mdx`, `architecture/gateway.md`, and the Helm chart README

## Testing
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)