### PR TITLE
perf(supervisor-network): avoid reparsing native policy input

### DIFF
--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -1929,7 +1929,7 @@ fn evaluate_l7_request_once(
         ));
     }
 
-    let input_json = serde_json::json!({
+    let input = serde_json::json!({
         "network": {
             "host": ctx.host,
             "port": ctx.port,
@@ -1953,9 +1953,10 @@ fn evaluate_l7_request_once(
         .lock()
         .map_err(|_| miette!("OPA engine lock poisoned"))?;
 
-    engine
-        .set_input_json(&input_json.to_string())
-        .map_err(|e| miette!("{e}"))?;
+    // Regorus's infallible `From<serde_json::Value>` maps conversion errors to `Undefined`.
+    // Convert fallibly so failures remain evaluator errors instead of becoming policy input.
+    let input = serde_json::from_value::<regorus::Value>(input).map_err(|e| miette!("{e}"))?;
+    engine.set_input(input);
 
     let allowed = engine
         .eval_rule("data.openshell.sandbox.allow_request".into())

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -1953,10 +1953,7 @@ fn evaluate_l7_request_once(
         .lock()
         .map_err(|_| miette!("OPA engine lock poisoned"))?;
 
-    // Regorus's infallible `From<serde_json::Value>` maps conversion errors to `Undefined`.
-    // Convert fallibly so failures remain evaluator errors instead of becoming policy input.
-    let input = serde_json::from_value::<regorus::Value>(input).map_err(|e| miette!("{e}"))?;
-    engine.set_input(input);
+    crate::opa::set_regorus_input(&mut engine, input)?;
 
     let allowed = engine
         .eval_rule("data.openshell.sandbox.allow_request".into())

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -461,9 +461,7 @@ impl OpaEngine {
             });
         }
 
-        engine
-            .set_input_json(&input_json.to_string())
-            .map_err(|e| miette::miette!("{e}"))?;
+        set_regorus_input(&mut engine, input_json)?;
 
         let allowed = engine
             .eval_rule("data.openshell.sandbox.allow_network".into())
@@ -524,9 +522,7 @@ impl OpaEngine {
             return Ok((NetworkAction::Deny { reason }, generation));
         }
 
-        engine
-            .set_input_json(&input_json.to_string())
-            .map_err(|e| miette::miette!("{e}"))?;
+        set_regorus_input(&mut engine, input_json)?;
 
         let action_val = engine
             .eval_rule("data.openshell.sandbox.network_action".into())
@@ -823,9 +819,7 @@ impl OpaEngine {
             .map_err(|_| miette::miette!("OPA engine lock poisoned"))?;
         let generation = self.current_generation();
 
-        engine
-            .set_input_json(&input_json.to_string())
-            .map_err(|e| miette::miette!("{e}"))?;
+        set_regorus_input(&mut engine, input_json)?;
 
         let val = engine
             .eval_rule("data.openshell.sandbox._matching_endpoint_configs".into())
@@ -883,9 +877,7 @@ impl OpaEngine {
             .lock()
             .map_err(|_| miette::miette!("OPA engine lock poisoned"))?;
 
-        engine
-            .set_input_json(&input_json.to_string())
-            .map_err(|e| miette::miette!("{e}"))?;
+        set_regorus_input(&mut engine, input_json)?;
 
         let val = engine
             .eval_rule("data.openshell.sandbox.exact_declared_endpoint_host".into())
@@ -998,6 +990,20 @@ fn network_input_json(input: &NetworkInput) -> serde_json::Value {
             "port": input.port,
         }
     })
+}
+
+/// Sets an already-built JSON value as Regorus input without encoding and reparsing JSON text.
+///
+/// The explicit fallible conversion preserves evaluator errors because Regorus's infallible
+/// `From<serde_json::Value>` conversion maps failures to [`regorus::Value::Undefined`].
+pub(crate) fn set_regorus_input(
+    engine: &mut regorus::Engine,
+    input: serde_json::Value,
+) -> Result<()> {
+    let input =
+        serde_json::from_value::<regorus::Value>(input).map_err(|e| miette::miette!("{e}"))?;
+    engine.set_input(input);
+    Ok(())
 }
 
 fn query_middleware_chain_locked(
@@ -2788,7 +2794,7 @@ process:
 
     fn eval_l7(engine: &OpaEngine, input: &serde_json::Value) -> bool {
         let mut eng = engine.engine.lock().unwrap();
-        eng.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut eng, input.clone()).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
@@ -2803,7 +2809,7 @@ process:
         engine
             .add_data_json(&data.to_string())
             .expect("add raw data json");
-        engine.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut engine, input).unwrap();
         let val = engine
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
@@ -3080,7 +3086,7 @@ process:
             }]),
         );
         let mut eng = engine.engine.lock().unwrap();
-        eng.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut eng, input).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.request_deny_reason".into())
             .unwrap();
@@ -4383,7 +4389,7 @@ network_policies:
         let engine = l7_engine();
         let input = l7_input("api.example.com", 8080, "DELETE", "/repos/myorg/foo");
         let mut eng = engine.engine.lock().unwrap();
-        eng.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut eng, input).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.request_deny_reason".into())
             .unwrap();
@@ -4777,7 +4783,7 @@ network_policies:
         // Verify the cloned engine can evaluate
         let input_json = l7_input("api.example.com", 8080, "GET", "/repos/myorg/foo");
         let mut eng = cloned.engine().lock().unwrap();
-        eng.set_input_json(&input_json.to_string()).unwrap();
+        set_regorus_input(&mut eng, input_json).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
@@ -4819,7 +4825,7 @@ network_policies:
             .clone_engine_for_tunnel(engine.current_generation())
             .unwrap();
         let mut eng = cloned.engine().lock().unwrap();
-        eng.set_input_json(&input_json.to_string()).unwrap();
+        set_regorus_input(&mut eng, input_json).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
@@ -5019,7 +5025,7 @@ process:
             "/repos/myorg/pulls/123/reviews",
         );
         let mut eng = engine.engine.lock().unwrap();
-        eng.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut eng, input).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
@@ -5036,7 +5042,7 @@ process:
         // GET repos/issues is allowed and not denied
         let input = l7_input("api.github.com", 443, "GET", "/repos/myorg/issues");
         let mut eng = engine.engine.lock().unwrap();
-        eng.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut eng, input).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
@@ -5053,7 +5059,7 @@ process:
         // POST to issues is allowed (deny only targets reviews)
         let input = l7_input("api.github.com", 443, "POST", "/repos/myorg/issues");
         let mut eng = engine.engine.lock().unwrap();
-        eng.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut eng, input).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
@@ -5070,7 +5076,7 @@ process:
         // GET /repos/myorg/rulesets should be denied (method: "*")
         let input = l7_input("api.github.com", 443, "GET", "/repos/myorg/rulesets");
         let mut eng = engine.engine.lock().unwrap();
-        eng.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut eng, input).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
@@ -5091,7 +5097,7 @@ process:
             "/repos/myorg/branches/main/protection",
         );
         let mut eng = engine.engine.lock().unwrap();
-        eng.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut eng, input).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
@@ -5112,7 +5118,7 @@ process:
             "/repos/myorg/pulls/123/reviews",
         );
         let mut eng = engine.engine.lock().unwrap();
-        eng.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut eng, input).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.request_deny_reason".into())
             .unwrap();
@@ -5138,7 +5144,7 @@ process:
             serde_json::json!({"force": ["true"]}),
         );
         let mut eng = engine.engine.lock().unwrap();
-        eng.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut eng, input).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
@@ -5161,7 +5167,7 @@ process:
             serde_json::json!({"force": ["false"]}),
         );
         let mut eng = engine.engine.lock().unwrap();
-        eng.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut eng, input).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
@@ -5186,7 +5192,7 @@ process:
             serde_json::json!({"force": ["true", "false"]}),
         );
         let mut eng = engine.engine.lock().unwrap();
-        eng.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut eng, input).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
@@ -5204,7 +5210,7 @@ process:
         // so no match (key not present) and request should be allowed
         let input = l7_input("api.restricted.com", 443, "POST", "/admin/settings");
         let mut eng = engine.engine.lock().unwrap();
-        eng.set_input_json(&input.to_string()).unwrap();
+        set_regorus_input(&mut eng, input).unwrap();
         let val = eng
             .eval_rule("data.openshell.sandbox.allow_request".into())
             .unwrap();
@@ -7721,11 +7727,11 @@ host_match if {
         ];
         for (pattern, host) in cases {
             let rust = openshell_core::host_pattern::host_matches(pattern, host).unwrap();
-            engine
-                .set_input_json(
-                    &serde_json::json!({ "pattern": pattern, "host": host }).to_string(),
-                )
-                .unwrap();
+            set_regorus_input(
+                &mut engine,
+                serde_json::json!({ "pattern": pattern, "host": host }),
+            )
+            .unwrap();
             let rego = engine.eval_rule("data.test.host_match".into()).unwrap()
                 == regorus::Value::from(true);
             assert_eq!(


### PR DESCRIPTION
## Summary
OpenShell currently builds a `serde_json::Value`, serializes it to JSON text, and asks Regorus to parse that text into its own value representation. Convert the existing `serde_json::Value` directly into `regorus::Value`, then pass it to `Engine::set_input`. This removes the intermediate string and JSON text parse while continuing to return conversion errors before policy evaluation.

## Changes
- Rename the constructed native-policy input from `input_json` to `input`.
- Convert the existing `serde_json::Value` directly into `regorus::Value` without serializing and reparsing JSON text.
- Return conversion errors before policy evaluation instead of allowing Regorus's infallible `From<serde_json::Value>` conversion to map failures to `Undefined`.

## Testing
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
