### PR TITLE
fix(gateway-interceptors): apply tls-native-roots for HTTPS interceptor endpoints

### DIFF
--- a/crates/openshell-gateway-interceptors/src/plan.rs
+++ b/crates/openshell-gateway-interceptors/src/plan.rs
@@ -862,14 +862,17 @@ async fn connect_endpoint(endpoint: &str) -> Result<Channel> {
     if let Some(path) = endpoint.strip_prefix("unix://") {
         return connect_unix_endpoint(PathBuf::from(path)).await;
     }
-    let mut ep = Endpoint::from_shared(endpoint.to_string())
-        .map_err(|e| {
-            InterceptorError::Config(format!("invalid interceptor endpoint '{endpoint}': {e}"))
-        })?;
-    if endpoint.starts_with("https://") {
-        ep = ep.tls_config(ClientTlsConfig::new().with_enabled_roots()).map_err(|e| {
-            InterceptorError::Config(format!("TLS config for interceptor endpoint '{endpoint}': {e}"))
-        })?;
+    let mut ep = Endpoint::from_shared(endpoint.to_string()).map_err(|e| {
+        InterceptorError::Config(format!("invalid interceptor endpoint '{endpoint}': {e}"))
+    })?;
+    if ep.uri().scheme_str() == Some("https") {
+        ep = ep
+            .tls_config(ClientTlsConfig::new().with_enabled_roots())
+            .map_err(|e| {
+                InterceptorError::Config(format!(
+                    "TLS config for interceptor endpoint '{endpoint}': {e}"
+                ))
+            })?;
     }
     ep.connect()
         .await

--- a/crates/openshell-gateway-interceptors/src/plan.rs
+++ b/crates/openshell-gateway-interceptors/src/plan.rs
@@ -19,7 +19,7 @@ use openshell_core::proto::gateway_interceptor::v1::{
 use tokio::net::UnixStream;
 use tonic::Request;
 use tonic::codegen::http::Uri;
-use tonic::transport::{Channel, Endpoint};
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 use tower::service_fn;
 use tracing::{info, warn};
 
@@ -862,11 +862,16 @@ async fn connect_endpoint(endpoint: &str) -> Result<Channel> {
     if let Some(path) = endpoint.strip_prefix("unix://") {
         return connect_unix_endpoint(PathBuf::from(path)).await;
     }
-    Endpoint::from_shared(endpoint.to_string())
+    let mut ep = Endpoint::from_shared(endpoint.to_string())
         .map_err(|e| {
             InterceptorError::Config(format!("invalid interceptor endpoint '{endpoint}': {e}"))
-        })?
-        .connect()
+        })?;
+    if endpoint.starts_with("https://") {
+        ep = ep.tls_config(ClientTlsConfig::new().with_enabled_roots()).map_err(|e| {
+            InterceptorError::Config(format!("TLS config for interceptor endpoint '{endpoint}': {e}"))
+        })?;
+    }
+    ep.connect()
         .await
         .map_err(|e| InterceptorError::Transport(format!("connect {endpoint}: {e}")))
 }


### PR DESCRIPTION
## Summary

`Endpoint::connect()` in `connect_endpoint()` does not apply TLS configuration for `https://` interceptor endpoints. Even though the crate enables `tls-native-roots`, `ClientTlsConfig::new()` defaults to `with_native_roots: false` — the feature makes the method available but does not activate it automatically. This prevents gateway interceptors from being deployed as external HTTPS services.

## Changes

- Add explicit `.tls_config(ClientTlsConfig::new().with_enabled_roots())` when the endpoint URL starts with `https://`
- Import `ClientTlsConfig` from `tonic::transport`
- `with_enabled_roots()` activates all TLS root certificate sources enabled via feature flags (`tls-native-roots`, `tls-webpki-roots`)

## Testing

Tested with a governance interceptor deployed as a Kubernetes pod with TLS (envoy sidecar + OpenShift serving cert), exposed via an OpenShift Route (re-encrypt). Before this fix, the gateway fails with `transport error`. After, it connects and initializes interceptor bindings successfully.

Fixes #2665