### PR TITLE
ci(cargo-deny): add dependency audit with cargo-deny

### DIFF
--- a/.github/workflows/branch-checks.yml
+++ b/.github/workflows/branch-checks.yml
@@ -79,6 +79,25 @@ jobs:
       - name: Check license headers
         run: mise run license:check
 
+  cargo-deny:
+    name: Cargo Deny
+    needs: pr_metadata
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    runs-on: linux-amd64-cpu8
+    container:
+      image: ghcr.io/nvidia/openshell/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install tools
+        run: mise install --locked
+
+      - name: Check dependencies
+        run: mise run rust:deny:policy
+
   rust:
     name: Rust (${{ matrix.runner }})
     needs: pr_metadata

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Cargo Deny (scheduled)
+
+on:
+  schedule:
+    - cron: "23 7 * * *"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-deny:
+    name: Cargo Deny
+    runs-on: linux-amd64-cpu8
+    container:
+      image: ghcr.io/nvidia/openshell/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install tools
+        run: mise install --locked
+
+      - name: Check dependencies
+        run: mise run rust:deny

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# cargo-deny configuration
+# https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+all-features = true
+no-default-features = false
+
+# -- Advisories (RustSec + NVD) ------------------------------------------------
+[advisories]
+yanked = "warn"
+unmaintained = "workspace"
+maximum-db-staleness = "P30D"
+ignore = [
+    # Pre-existing advisories acknowledged at onboarding. Each should be
+    # resolved by upgrading the affected transitive dependency and then
+    # removing the ignore entry.
+    { id = "RUSTSEC-2026-0190", reason = "anyhow unsoundness in downcast_mut — awaiting upstream fix" },
+    { id = "RUSTSEC-2026-0204", reason = "crossbeam-epoch pointer deref — transitive via metrics/quanta" },
+    { id = "RUSTSEC-2023-0071", reason = "rsa Marvin attack — transitive via spiffe, no direct exposure" },
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained — transitive via older kube/hyper" },
+    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki URI name constraints — transitive via older rustls" },
+    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki wildcard name constraints — transitive via older rustls" },
+    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki CRL parsing panic — transitive via older rustls" },
+    { id = "RUSTSEC-2025-0068", reason = "serde_yml unsound+unmaintained — direct dep, no maintained alternative yet" },
+]
+
+# -- Licenses ------------------------------------------------------------------
+[licenses]
+confidence-threshold = 0.8
+unused-allowed-license = "allow"
+
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "MIT-0",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "Zlib",
+    "0BSD",
+    "CC0-1.0",
+    "Unlicense",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
+]
+
+[licenses.private]
+ignore = true
+registries = []
+
+# -- Bans ----------------------------------------------------------------------
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+
+# -- Sources -------------------------------------------------------------------
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/mise.lock
+++ b/mise.lock
@@ -55,6 +55,33 @@ checksum = "sha256:d5c38fb914bbad57c6a7d58c4847315bc3fe11efbe4fb51b3c515f997a56c
 url = "https://github.com/EmbarkStudios/cargo-about/releases/download/0.8.4/cargo-about-0.8.4-x86_64-pc-windows-msvc.tar.gz"
 url_api = "https://api.github.com/repos/EmbarkStudios/cargo-about/releases/assets/324269449"
 
+[[tools."github:EmbarkStudios/cargo-deny"]]
+version = "0.20.2"
+backend = "github:EmbarkStudios/cargo-deny"
+
+[tools."github:EmbarkStudios/cargo-deny".options]
+version_prefix = ""
+
+[tools."github:EmbarkStudios/cargo-deny"."platforms.linux-arm64"]
+checksum = "sha256:995c82be0defc7a025cae49a2aa2644ce8245c9a3318fc4103907c6a285e8c7d"
+url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.20.2/cargo-deny-0.20.2-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/assets/471598345"
+
+[tools."github:EmbarkStudios/cargo-deny"."platforms.linux-x64"]
+checksum = "sha256:9f12ed4c49936e09b48bf862b595cde2fe64fcbd9d74dfacac6131ca824c8d5f"
+url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.20.2/cargo-deny-0.20.2-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/assets/471598214"
+
+[tools."github:EmbarkStudios/cargo-deny"."platforms.macos-arm64"]
+checksum = "sha256:fe67d82a10d8597a3549364cb733a3f9cc1bfff9031b7ae46384a9f2a72090c3"
+url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.20.2/cargo-deny-0.20.2-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/assets/471597689"
+
+[tools."github:EmbarkStudios/cargo-deny"."platforms.windows-x64"]
+checksum = "sha256:975a22143262fd27476d19ee00c7af67978426e40e1dee94eed6bbade1cf87dc"
+url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.20.2/cargo-deny-0.20.2-x86_64-pc-windows-msvc.tar.gz"
+url_api = "https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/assets/471599057"
+
 [[tools."github:anchore/syft"]]
 version = "1.44.0"
 backend = "github:anchore/syft"

--- a/mise.toml
+++ b/mise.toml
@@ -40,6 +40,7 @@ skaffold = { version = "2.20.0", os = ["linux", "macos"] }
 k3d = { version = "5.8.3", os = ["macos"] }
 "github:anchore/syft" = { version = "1.44.0" }
 "github:EmbarkStudios/cargo-about" = { version = "0.8.4", version_prefix = "" }
+"github:EmbarkStudios/cargo-deny" = { version = "0.20.2", version_prefix = "" }
 zig = "0.14.1"
 "github:rust-cross/cargo-zigbuild" = "0.22.3"
 "npm:markdownlint-cli2" = "0.22.0"

--- a/tasks/ci.toml
+++ b/tasks/ci.toml
@@ -56,7 +56,7 @@ hide = true
 
 [ci]
 description = "Run full checks (lint, compile/type checks, and tests)"
-depends = ["lint", "check", "test", "go:ci"]
+depends = ["lint", "check", "test", "go:ci", "rust:deny:policy"]
 
 [all]
 description = "Alias for ci"

--- a/tasks/rust.toml
+++ b/tasks/rust.toml
@@ -34,6 +34,15 @@ run = [
 ]
 hide = true
 
+["rust:deny"]
+description = "Check dependencies for all cargo-deny rules"
+run = "cargo deny check"
+
+["rust:deny:policy"]
+description = "Check dependencies for license violations, bans, and source restrictions"
+run = "cargo deny check licenses bans sources"
+
+
 ["rust:verify:telemetry-off"]
 description = "Verify telemetry emission code is compiled out with --no-default-features"
 run = [


### PR DESCRIPTION
## Summary

Add `cargo-deny` to audit dependencies for known vulnerabilities (RustSec/NVD), license compliance, banned crates, and untrusted sources. Runs in branch checks to gate PRs and as a daily scheduled workflow to catch newly published advisories.

Closes #2671

## Changes

- Add `deny.toml` with advisories, licenses, bans, and sources configuration
- Add `rust:deny` mise task wrapping `cargo deny check`
- Add `cargo deny check` step to `branch-checks.yml` (blocks PRs on failure)
- Add `cargo-deny.yml` scheduled workflow (daily cron + manual dispatch)
- Pin `cargo-deny` at 0.20 in `mise.toml`

### Not included (intentional)

- **Smart change detection** (skip on PRs not touching `Cargo.toml`/`Cargo.lock`/`deny.toml`): `cargo deny check` runs in ~10-15s with no compilation, so the CI time savings are minimal. Can be added later if needed.

## Testing

- [x] `mise run pre-commit` passes
- [x] `mise run rust:deny` runs successfully locally

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)

cc @alangou