### PR TITLE
perf(supervisor-middleware): remove body clones from local dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3714,6 +3714,7 @@ dependencies = [
 name = "openshell-core"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "base64 0.22.1",
  "chrono",
  "glob",
@@ -4188,6 +4189,7 @@ dependencies = [
 name = "openshell-supervisor-middleware-builtins"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "miette",
  "openshell-core",
  "prost-types",
@@ -4195,7 +4197,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tonic",
 ]
 
 [[package]]

--- a/architecture/sandbox.md
+++ b/architecture/sandbox.md
@@ -108,11 +108,7 @@ host selectors choose the chain independently of the network rule that admitted
 the request. Policy-local map keys identify configs, while built-in names or
 operator-owned registration names identify implementations.
 
-Built-ins run in-process; operator services use the same bounded gRPC contract.
-`openshell-policy` validates policy-owned structure, and the active middleware
-registry validates implementation-owned config. The generic registry and chain
-runner live in `openshell-supervisor-middleware`; first-party implementations
-live in `openshell-supervisor-middleware-builtins`.
+Built-ins run in-process against a borrowed view of the chain's current request state. Operator services retain the bounded protobuf/gRPC contract, and the remote adapter materializes an owned evaluation only when the request crosses that transport boundary. `openshell-policy` validates policy-owned structure, and the active middleware registry validates implementation-owned config. The generic registry and chain runner live in `openshell-supervisor-middleware`; first-party implementations live in `openshell-supervisor-middleware-builtins`.
 
 The supervisor installs policy and middleware registry changes as one runtime
 generation and preserves the last-known-good generation if preparation fails.

--- a/crates/openshell-core/Cargo.toml
+++ b/crates/openshell-core/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+async-trait = "0.1"
 glob = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }

--- a/crates/openshell-core/src/middleware.rs
+++ b/crates/openshell-core/src/middleware.rs
@@ -1,9 +1,196 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Platform-wide supervisor middleware limits.
+//! Supervisor middleware in-process contracts and platform-wide limits.
 
 use std::time::Duration;
+
+use miette::Result;
+
+use crate::proto::{
+    HttpHeader, HttpRequestResult, HttpRequestTarget, MiddlewareManifest, RequestContext,
+    SupervisorMiddlewarePhase,
+};
+
+/// Borrowed request state exposed to one in-process middleware invocation.
+///
+/// The view reflects every transformation applied by earlier stages. It is valid
+/// only for the current invocation and cannot be retained by the middleware.
+#[derive(Clone, Copy)]
+pub struct HttpRequestView<'a> {
+    phase: SupervisorMiddlewarePhase,
+    context: &'a RequestContext,
+    config: &'a prost_types::Struct,
+    target: &'a HttpRequestTarget,
+    headers: &'a [HttpHeader],
+    body: &'a [u8],
+    middleware_name: &'a str,
+}
+
+impl<'a> HttpRequestView<'a> {
+    /// Create a view over the chain's current request state for one stage.
+    #[must_use]
+    pub fn new(
+        phase: SupervisorMiddlewarePhase,
+        context: &'a RequestContext,
+        config: &'a prost_types::Struct,
+        target: &'a HttpRequestTarget,
+        headers: &'a [HttpHeader],
+        body: &'a [u8],
+        middleware_name: &'a str,
+    ) -> Self {
+        Self {
+            phase,
+            context,
+            config,
+            target,
+            headers,
+            body,
+            middleware_name,
+        }
+    }
+
+    /// Return the typed middleware phase selected for this invocation.
+    #[must_use]
+    pub fn phase(self) -> SupervisorMiddlewarePhase {
+        self.phase
+    }
+
+    /// Return the request and sandbox identity shared by every chain stage.
+    #[must_use]
+    pub fn context(self) -> &'a RequestContext {
+        self.context
+    }
+
+    /// Return the validated configuration for this policy-selected stage.
+    #[must_use]
+    pub fn config(self) -> &'a prost_types::Struct {
+        self.config
+    }
+
+    /// Return the admitted destination and HTTP request target.
+    #[must_use]
+    pub fn target(self) -> &'a HttpRequestTarget {
+        self.target
+    }
+
+    /// Return visible request headers in wire order, including repeated names.
+    #[must_use]
+    pub fn headers(self) -> &'a [HttpHeader] {
+        self.headers
+    }
+
+    /// Return the current body, including replacements made by earlier stages.
+    #[must_use]
+    pub fn body(self) -> &'a [u8] {
+        self.body
+    }
+
+    /// Return the in-process middleware manifest or attachment name selected by
+    /// policy, including custom implementation names.
+    #[must_use]
+    pub fn middleware_name(self) -> &'a str {
+        self.middleware_name
+    }
+}
+
+/// Asynchronous contract for supervisor middleware that runs in the process.
+///
+/// Remote services use the protobuf `SupervisorMiddleware` contract instead.
+/// The borrowed view remains valid for the evaluation future, so implementations
+/// can yield without constructing an owned protobuf request envelope.
+///
+/// Downstream implementations must apply `#[async_trait::async_trait]` to each
+/// `impl InProcessMiddleware` block. The macro's default expansion creates
+/// `Send` futures, matching this trait's generated method signatures; do not
+/// use the `?Send` form.
+///
+/// An implementing crate must declare `async-trait` as a direct dependency
+/// because `openshell-core`'s dependency does not make the procedural macro
+/// available in downstream source. The example also names `miette` and
+/// `prost-types`, so standalone crates must declare those dependencies when
+/// using those paths.
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::Arc;
+///
+/// use miette::Result;
+/// use openshell_core::middleware::{HttpRequestView, InProcessMiddleware};
+/// use openshell_core::proto::{
+///     Decision, HttpRequestResult, MiddlewareBinding, MiddlewareManifest,
+///     SupervisorMiddlewareOperation, SupervisorMiddlewarePhase,
+/// };
+/// use prost_types::Struct;
+///
+/// struct Service;
+///
+/// #[async_trait::async_trait]
+/// impl InProcessMiddleware for Service {
+///     async fn describe(&self) -> MiddlewareManifest {
+///         MiddlewareManifest {
+///             name: "example/audit".into(),
+///             service_version: "1".into(),
+///             bindings: vec![MiddlewareBinding {
+///                 operation: SupervisorMiddlewareOperation::HttpRequest as i32,
+///                 phase: SupervisorMiddlewarePhase::PreCredentials as i32,
+///                 max_body_bytes: 1024,
+///                 timeout: String::new(),
+///             }],
+///         }
+///     }
+///
+///     async fn validate_config(
+///         &self,
+///         _middleware_name: &str,
+///         _config: &Struct,
+///     ) -> Result<()> {
+///         Ok(())
+///     }
+///
+///     async fn evaluate_http_request(
+///         &self,
+///         _request: HttpRequestView<'_>,
+///     ) -> Result<HttpRequestResult> {
+///         Ok(HttpRequestResult {
+///             decision: Decision::Allow as i32,
+///             ..Default::default()
+///         })
+///     }
+/// }
+///
+/// let service: Arc<dyn InProcessMiddleware> = Arc::new(Service);
+/// assert_eq!(Arc::strong_count(&service), 1);
+/// ```
+#[async_trait::async_trait]
+pub trait InProcessMiddleware: Send + Sync {
+    /// Return the immutable manifest describing this implementation.
+    async fn describe(&self) -> MiddlewareManifest;
+
+    /// Validate implementation-owned configuration for one policy attachment.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the implementation name is unknown or the
+    /// configuration is malformed or unsupported.
+    async fn validate_config(
+        &self,
+        middleware_name: &str,
+        config: &prost_types::Struct,
+    ) -> Result<()>;
+
+    /// Evaluate one request using borrowed chain state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the selected implementation cannot evaluate the
+    /// request or its validated configuration.
+    async fn evaluate_http_request(
+        &self,
+        request: HttpRequestView<'_>,
+    ) -> Result<HttpRequestResult>;
+}
 
 /// Default timeout for one supervisor middleware RPC.
 pub const DEFAULT_MIDDLEWARE_TIMEOUT: Duration = Duration::from_millis(500);

--- a/crates/openshell-supervisor-middleware-builtins/Cargo.toml
+++ b/crates/openshell-supervisor-middleware-builtins/Cargo.toml
@@ -13,12 +13,12 @@ rust-version.workspace = true
 [dependencies]
 openshell-core = { path = "../openshell-core", default-features = false }
 
+async-trait = "0.1"
 miette = { workspace = true }
 prost-types = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tonic = { workspace = true, features = ["server"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/openshell-supervisor-middleware-builtins/src/lib.rs
+++ b/crates/openshell-supervisor-middleware-builtins/src/lib.rs
@@ -8,17 +8,13 @@ mod regex;
 use std::sync::Arc;
 
 use miette::{Result, miette};
-use openshell_core::proto::middleware::v1::supervisor_middleware_server::SupervisorMiddleware;
-use openshell_core::proto::{
-    HttpRequestEvaluation, HttpRequestResult, MiddlewareManifest, ValidateConfigRequest,
-    ValidateConfigResponse,
-};
-use tonic::{Request, Response, Status};
+use openshell_core::middleware::{HttpRequestView, InProcessMiddleware};
+use openshell_core::proto::{HttpRequestResult, MiddlewareManifest};
 
 pub use regex::{NAME as BUILTIN_REGEX, RegexConfig, RegexMode};
 
-/// Return the first-party services that the gateway and supervisor install.
-pub fn services() -> Vec<Arc<dyn SupervisorMiddleware>> {
+/// Return the first-party in-process services installed by the gateway and supervisor.
+pub fn services() -> Vec<Arc<dyn InProcessMiddleware>> {
     vec![Arc::new(BuiltinMiddlewareService)]
 }
 
@@ -32,59 +28,42 @@ pub fn validate_config(implementation: &str, config: &prost_types::Struct) -> Re
     }
 }
 
-fn evaluate_http_request(evaluation: &HttpRequestEvaluation) -> Result<HttpRequestResult> {
-    match evaluation.middleware_name.as_str() {
-        BUILTIN_REGEX => regex::evaluate_http_request(evaluation),
+fn evaluate_http_request(request: HttpRequestView<'_>) -> Result<HttpRequestResult> {
+    match request.middleware_name() {
+        BUILTIN_REGEX => regex::evaluate_http_request(request.config(), request.body()),
         other => Err(miette!(
             "middleware implementation '{other}' is not a registered OpenShell built-in"
         )),
     }
 }
 
-/// Built-in regex service exposed through the standard middleware contract.
+/// Aggregate service exposing first-party middleware through the borrowed in-process contract.
 #[derive(Debug, Default)]
 pub struct BuiltinMiddlewareService;
 
-#[tonic::async_trait]
-impl SupervisorMiddleware for BuiltinMiddlewareService {
-    async fn describe(
-        &self,
-        _request: Request<()>,
-    ) -> Result<Response<MiddlewareManifest>, Status> {
-        Ok(Response::new(MiddlewareManifest {
+#[async_trait::async_trait]
+impl InProcessMiddleware for BuiltinMiddlewareService {
+    async fn describe(&self) -> MiddlewareManifest {
+        MiddlewareManifest {
             name: BUILTIN_REGEX.into(),
             service_version: env!("CARGO_PKG_VERSION").into(),
             bindings: vec![regex::describe()],
-        }))
+        }
     }
 
     async fn validate_config(
         &self,
-        request: Request<ValidateConfigRequest>,
-    ) -> Result<Response<ValidateConfigResponse>, Status> {
-        let request = request.into_inner();
-        let config = request.config.unwrap_or_default();
-        Ok(Response::new(
-            match validate_config(&request.middleware_name, &config) {
-                Ok(()) => ValidateConfigResponse {
-                    valid: true,
-                    reason: String::new(),
-                },
-                Err(error) => ValidateConfigResponse {
-                    valid: false,
-                    reason: error.to_string(),
-                },
-            },
-        ))
+        middleware_name: &str,
+        config: &prost_types::Struct,
+    ) -> Result<()> {
+        validate_config(middleware_name, config)
     }
 
     async fn evaluate_http_request(
         &self,
-        request: Request<HttpRequestEvaluation>,
-    ) -> Result<Response<HttpRequestResult>, Status> {
-        evaluate_http_request(&request.into_inner())
-            .map(Response::new)
-            .map_err(|error| Status::invalid_argument(error.to_string()))
+        request: HttpRequestView<'_>,
+    ) -> Result<HttpRequestResult> {
+        evaluate_http_request(request)
     }
 }
 
@@ -92,7 +71,8 @@ impl SupervisorMiddleware for BuiltinMiddlewareService {
 mod tests {
     use super::*;
     use openshell_core::proto::{
-        Decision, SupervisorMiddlewareOperation, SupervisorMiddlewarePhase,
+        Decision, HttpRequestTarget, RequestContext, SupervisorMiddlewareOperation,
+        SupervisorMiddlewarePhase,
     };
 
     fn string_config(key: &str, value: &str) -> prost_types::Struct {
@@ -107,13 +87,23 @@ mod tests {
         }
     }
 
+    fn evaluate_body(body: &[u8], config: &prost_types::Struct) -> Result<HttpRequestResult> {
+        let context = RequestContext::default();
+        let target = HttpRequestTarget::default();
+        evaluate_http_request(HttpRequestView::new(
+            SupervisorMiddlewarePhase::PreCredentials,
+            &context,
+            config,
+            &target,
+            &[],
+            body,
+            BUILTIN_REGEX,
+        ))
+    }
+
     #[tokio::test]
     async fn service_describes_regex_binding() {
-        let manifest = BuiltinMiddlewareService
-            .describe(Request::new(()))
-            .await
-            .expect("describe")
-            .into_inner();
+        let manifest = BuiltinMiddlewareService.describe().await;
         assert_eq!(manifest.bindings.len(), 1);
         assert_eq!(
             manifest.bindings[0].operation,
@@ -158,13 +148,22 @@ mod tests {
     }
 
     #[test]
+    fn registry_rejects_unknown_builtin_name() {
+        let error = validate_config("openshell/unknown", &prost_types::Struct::default())
+            .expect_err("unknown built-in");
+        assert!(
+            error
+                .to_string()
+                .contains("is not a registered OpenShell built-in")
+        );
+    }
+
+    #[test]
     fn regex_replacement_evaluates_through_binding() {
-        let result = evaluate_http_request(&HttpRequestEvaluation {
-            middleware_name: BUILTIN_REGEX.into(),
-            body: br#"{"password":"top-secret","token":"sk-ABCDEFGHIJKLMNOP"}"#.to_vec(),
-            config: Some(prost_types::Struct::default()),
-            ..Default::default()
-        })
+        let result = evaluate_body(
+            br#"{"password":"top-secret","token":"sk-ABCDEFGHIJKLMNOP"}"#,
+            &prost_types::Struct::default(),
+        )
         .expect("evaluate regex binding");
 
         assert_eq!(result.decision, Decision::Allow as i32);
@@ -186,17 +185,19 @@ mod tests {
             r#"{"password":"alpha beta","secret":"alpha,beta","api_key":"alpha\"beta"}"#,
             "\npassword=alpha\nnotpassword=omega"
         );
-        let result = evaluate_http_request(&HttpRequestEvaluation {
-            middleware_name: BUILTIN_REGEX.into(),
-            body: body.as_bytes().to_vec(),
-            config: Some(prost_types::Struct::default()),
-            ..Default::default()
-        })
-        .expect("evaluate regex binding");
+        let result = evaluate_body(body.as_bytes(), &prost_types::Struct::default())
+            .expect("evaluate regex binding");
 
         assert_eq!(result.decision, Decision::Allow as i32);
         assert!(!result.has_body);
-        assert_eq!(result.body, body.as_bytes());
+        assert!(result.body.is_empty());
         assert!(result.findings.is_empty());
+    }
+
+    #[test]
+    fn regex_rejects_non_utf8_borrowed_body() {
+        let error =
+            evaluate_body(&[0xff], &prost_types::Struct::default()).expect_err("non-UTF-8 body");
+        assert!(error.to_string().contains("requires UTF-8 request bodies"));
     }
 }

--- a/crates/openshell-supervisor-middleware-builtins/src/regex.rs
+++ b/crates/openshell-supervisor-middleware-builtins/src/regex.rs
@@ -8,13 +8,14 @@
 //! scanner or a parser-aware redactor. It provides no guarantee that sensitive
 //! values will be detected or fully removed.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use miette::{Result, miette};
 use openshell_core::proto::{
-    Decision, Finding, HttpRequestEvaluation, HttpRequestResult, MiddlewareBinding,
-    SupervisorMiddlewareOperation, SupervisorMiddlewarePhase,
+    Decision, Finding, HttpRequestResult, MiddlewareBinding, SupervisorMiddlewareOperation,
+    SupervisorMiddlewarePhase,
 };
 use regex::Regex;
 use serde::Deserialize;
@@ -37,6 +38,7 @@ pub enum RegexMode {
 }
 
 impl RegexConfig {
+    /// Parse and validate regex middleware configuration from protobuf form.
     pub fn from_struct(config: &prost_types::Struct) -> Result<Self> {
         serde_json::from_value(openshell_core::proto_struct::struct_to_json_value(config)).map_err(
             |error| {
@@ -46,6 +48,7 @@ impl RegexConfig {
     }
 }
 
+/// Describe the HTTP request phase and body limit supported by the regex middleware.
 pub fn describe() -> MiddlewareBinding {
     MiddlewareBinding {
         operation: SupervisorMiddlewareOperation::HttpRequest as i32,
@@ -75,24 +78,32 @@ impl ReplacementPattern {
 static REPLACEMENT_PATTERNS: LazyLock<[ReplacementPattern; 1]> =
     LazyLock::new(|| [ReplacementPattern::new("openai", r"sk-[A-Za-z0-9_-]{16,}")]);
 
+/// Validate one regex middleware configuration.
 pub fn validate_config(config: &prost_types::Struct) -> Result<()> {
     RegexConfig::from_struct(config).map(|_| ())
 }
 
-pub fn evaluate_http_request(evaluation: &HttpRequestEvaluation) -> Result<HttpRequestResult> {
-    let default_config = prost_types::Struct::default();
-    validate_config(evaluation.config.as_ref().unwrap_or(&default_config))?;
-    let text = String::from_utf8(evaluation.body.clone())
-        .map_err(|_| miette!("{NAME} requires UTF-8 request bodies"))?;
-    let (body, matches) = apply_replacements(&text);
+/// Evaluate a borrowed HTTP body and return a replacement only when a pattern matches.
+pub fn evaluate_http_request(
+    config: &prost_types::Struct,
+    body: &[u8],
+) -> Result<HttpRequestResult> {
+    validate_config(config)?;
+    let text =
+        std::str::from_utf8(body).map_err(|_| miette!("{NAME} requires UTF-8 request bodies"))?;
+    let (body, matches) = apply_replacements(text);
     let total: u32 = matches
         .iter()
         .fold(0u32, |acc, (_, count)| acc.saturating_add(*count));
+    let has_body = !matches.is_empty();
     let mut result = HttpRequestResult {
         decision: Decision::Allow as i32,
         reason: String::new(),
-        body: body.into_bytes(),
-        has_body: !matches.is_empty(),
+        body: match body {
+            Cow::Borrowed(_) => Vec::new(),
+            Cow::Owned(body) => body.into_bytes(),
+        },
+        has_body,
         header_mutations: Vec::new(),
         findings: Vec::new(),
         metadata: HashMap::new(),
@@ -115,18 +126,21 @@ pub fn evaluate_http_request(evaluation: &HttpRequestEvaluation) -> Result<HttpR
     Ok(result)
 }
 
-fn apply_replacements(input: &str) -> (String, Vec<(&'static str, u32)>) {
-    let mut output = input.to_string();
+fn apply_replacements(input: &str) -> (Cow<'_, str>, Vec<(&'static str, u32)>) {
+    let mut output = Cow::Borrowed(input);
     let mut matches = Vec::new();
     for pattern in REPLACEMENT_PATTERNS.iter() {
-        let count = u32::try_from(pattern.regex.find_iter(&output).count()).unwrap_or(u32::MAX);
+        let count =
+            u32::try_from(pattern.regex.find_iter(output.as_ref()).count()).unwrap_or(u32::MAX);
         if count > 0 {
             matches.push((pattern.kind, count));
+            output = Cow::Owned(
+                pattern
+                    .regex
+                    .replace_all(output.as_ref(), "[REDACTED]")
+                    .into_owned(),
+            );
         }
-        output = pattern
-            .regex
-            .replace_all(&output, "[REDACTED]")
-            .into_owned();
     }
     (output, matches)
 }

--- a/crates/openshell-supervisor-middleware/src/headers.rs
+++ b/crates/openshell-supervisor-middleware/src/headers.rs
@@ -3,7 +3,7 @@
 
 //! Validation and logical application of middleware request-header mutations.
 
-use openshell_core::proto::{ExistingHeaderAction, HeaderMutation, header_mutation};
+use openshell_core::proto::{ExistingHeaderAction, HeaderMutation, HttpHeader, header_mutation};
 
 pub const MAX_HEADER_MUTATIONS: usize = 64;
 pub const MAX_HEADER_MUTATION_BYTES: usize = 32 * 1024;
@@ -105,10 +105,10 @@ impl std::error::Error for HeaderMutationError {}
 /// state observed by the next middleware. Repeated values and wire order are
 /// preserved; comparisons are case-insensitive.
 pub fn apply(
-    existing_headers: &[(String, String)],
+    existing_headers: &[HttpHeader],
     connection_nominated_headers: &[String],
     mutations: &[HeaderMutation],
-) -> Result<Vec<(String, String)>, HeaderMutationError> {
+) -> Result<Vec<HttpHeader>, HeaderMutationError> {
     if mutations.len() > MAX_HEADER_MUTATIONS {
         return Err(HeaderMutationError::TooMany {
             count: mutations.len(),
@@ -148,12 +148,18 @@ pub fn apply(
                         name: write.name.clone(),
                     });
                 }
-                let exists = headers.iter().any(|(existing, _)| *existing == name);
+                let exists = headers.iter().any(|existing| existing.name == name);
                 if !exists || action == ExistingHeaderAction::Append {
-                    headers.push((name, write.value.clone()));
+                    headers.push(HttpHeader {
+                        name,
+                        value: write.value.clone(),
+                    });
                 } else if action == ExistingHeaderAction::Overwrite {
-                    headers.retain(|(existing, _)| *existing != name);
-                    headers.push((name, write.value.clone()));
+                    headers.retain(|existing| existing.name != name);
+                    headers.push(HttpHeader {
+                        name,
+                        value: write.value.clone(),
+                    });
                 } else if action != ExistingHeaderAction::Skip {
                     return Err(HeaderMutationError::UnsupportedExistingAction);
                 }
@@ -167,7 +173,7 @@ pub fn apply(
                 }
                 mutation_bytes = mutation_bytes.saturating_add(name.len());
                 enforce_size_limit(mutation_bytes)?;
-                headers.retain(|(existing, _)| *existing != name);
+                headers.retain(|existing| existing.name != name);
             }
             None => return Err(HeaderMutationError::Empty),
         }
@@ -276,6 +282,13 @@ mod tests {
         }
     }
 
+    fn header(name: &str, value: &str) -> HttpHeader {
+        HttpHeader {
+            name: name.into(),
+            value: value.into(),
+        }
+    }
+
     #[test]
     fn protected_header_write_is_rejected() {
         let error = apply(
@@ -313,8 +326,8 @@ mod tests {
     #[test]
     fn existing_header_write_obeys_collision_action() {
         let existing = [
-            ("x-openshell-middleware-tag".to_string(), "one".to_string()),
-            ("accept".to_string(), "application/json".to_string()),
+            header("x-openshell-middleware-tag", "one"),
+            header("accept", "application/json"),
         ];
         let appended = apply(
             &existing,
@@ -329,9 +342,9 @@ mod tests {
         assert_eq!(
             appended,
             vec![
-                ("x-openshell-middleware-tag".into(), "one".into()),
-                ("accept".into(), "application/json".into()),
-                ("x-openshell-middleware-tag".into(), "two".into()),
+                header("x-openshell-middleware-tag", "one"),
+                header("accept", "application/json"),
+                header("x-openshell-middleware-tag", "two"),
             ]
         );
 
@@ -348,8 +361,8 @@ mod tests {
         assert_eq!(
             overwritten,
             vec![
-                ("accept".into(), "application/json".into()),
-                ("x-openshell-middleware-tag".into(), "two".into()),
+                header("accept", "application/json"),
+                header("x-openshell-middleware-tag", "two"),
             ]
         );
 
@@ -369,12 +382,12 @@ mod tests {
     #[test]
     fn remove_drops_every_case_insensitive_value() {
         let existing = [
-            ("x-trace".to_string(), "one".to_string()),
-            ("accept".to_string(), "application/json".to_string()),
-            ("x-trace".to_string(), "two".to_string()),
+            header("x-trace", "one"),
+            header("accept", "application/json"),
+            header("x-trace", "two"),
         ];
         let updated = apply(&existing, &[], &[remove("X-Trace")]).expect("remove visible header");
-        assert_eq!(updated, vec![("accept".into(), "application/json".into())]);
+        assert_eq!(updated, vec![header("accept", "application/json")]);
     }
 
     #[test]

--- a/crates/openshell-supervisor-middleware/src/lib.rs
+++ b/crates/openshell-supervisor-middleware/src/lib.rs
@@ -16,21 +16,26 @@ use std::time::Duration;
 use miette::{Result, miette};
 use prost::Message;
 
-use openshell_core::proto::middleware::v1::supervisor_middleware_server::SupervisorMiddleware;
 use openshell_core::proto::{
-    Decision, Finding, HeaderMutation, HttpHeader, HttpRequestEvaluation, HttpRequestTarget,
-    MiddlewareBinding, MiddlewareManifest, NetworkMiddlewareConfig, RequestContext, SandboxPolicy,
+    Decision, Finding, HeaderMutation, HttpHeader, HttpRequestTarget, MiddlewareBinding,
+    MiddlewareManifest, NetworkMiddlewareConfig, RequestContext, SandboxPolicy,
     SupervisorMiddlewareOperation, SupervisorMiddlewarePhase, SupervisorMiddlewareService,
-    ValidateConfigRequest,
+    ValidateConfigResponse,
 };
 use tokio::sync::OnceCell;
+
+#[cfg(test)]
+use openshell_core::proto::middleware::v1::supervisor_middleware_server::SupervisorMiddleware;
+#[cfg(test)]
+use openshell_core::proto::{HttpRequestEvaluation, ValidateConfigRequest};
+#[cfg(test)]
 use tonic::Request;
 
 pub use openshell_core::middleware::{
-    DEFAULT_MIDDLEWARE_TIMEOUT, MAX_MIDDLEWARE_CHAIN_FINDINGS, MAX_MIDDLEWARE_CHAIN_STAGES,
-    MAX_MIDDLEWARE_CONFIGS, MAX_MIDDLEWARE_FINDINGS_PER_STAGE, MAX_MIDDLEWARE_SELECTOR_PATTERNS,
-    MAX_MIDDLEWARE_TIMEOUT, MIN_MIDDLEWARE_TIMEOUT, middleware_timeout_or_default,
-    parse_middleware_timeout,
+    DEFAULT_MIDDLEWARE_TIMEOUT, HttpRequestView, InProcessMiddleware,
+    MAX_MIDDLEWARE_CHAIN_FINDINGS, MAX_MIDDLEWARE_CHAIN_STAGES, MAX_MIDDLEWARE_CONFIGS,
+    MAX_MIDDLEWARE_FINDINGS_PER_STAGE, MAX_MIDDLEWARE_SELECTOR_PATTERNS, MAX_MIDDLEWARE_TIMEOUT,
+    MIN_MIDDLEWARE_TIMEOUT, middleware_timeout_or_default, parse_middleware_timeout,
 };
 
 /// Largest request or replacement body accepted by the middleware platform.
@@ -298,12 +303,67 @@ pub struct ChainRunner {
     registry: Arc<MiddlewareRegistry>,
 }
 
+enum MiddlewareService {
+    /// Built-ins borrow the current request state and never construct protobuf.
+    InProcess(Arc<dyn InProcessMiddleware>),
+    /// Operator services receive an owned protobuf through the gRPC adapter.
+    Grpc(remote::GrpcMiddlewareService),
+}
+
+impl MiddlewareService {
+    async fn describe(
+        &self,
+    ) -> std::result::Result<tonic::Response<MiddlewareManifest>, tonic::Status> {
+        match self {
+            Self::InProcess(service) => Ok(tonic::Response::new(service.describe().await)),
+            Self::Grpc(service) => service.describe().await,
+        }
+    }
+
+    async fn validate_config(
+        &self,
+        middleware_name: &str,
+        config: &prost_types::Struct,
+    ) -> std::result::Result<tonic::Response<ValidateConfigResponse>, tonic::Status> {
+        match self {
+            Self::InProcess(service) => Ok(tonic::Response::new(
+                match service.validate_config(middleware_name, config).await {
+                    Ok(()) => ValidateConfigResponse {
+                        valid: true,
+                        reason: String::new(),
+                    },
+                    Err(error) => ValidateConfigResponse {
+                        valid: false,
+                        reason: error.to_string(),
+                    },
+                },
+            )),
+            Self::Grpc(service) => service.validate_config(middleware_name, config).await,
+        }
+    }
+
+    async fn evaluate_http_request(
+        &self,
+        request: HttpRequestView<'_>,
+    ) -> std::result::Result<tonic::Response<openshell_core::proto::HttpRequestResult>, tonic::Status>
+    {
+        match self {
+            Self::InProcess(service) => service
+                .evaluate_http_request(request)
+                .await
+                .map(tonic::Response::new)
+                .map_err(|error| tonic::Status::invalid_argument(error.to_string())),
+            Self::Grpc(service) => service.evaluate_http_request(request).await,
+        }
+    }
+}
+
 struct MiddlewareServiceState {
     /// Policy-facing built-in name or operator-owned registration name. The
     /// single-service test constructor leaves this empty and uses the manifest
     /// name after Describe.
     attachment_name: Option<String>,
-    service: Arc<dyn SupervisorMiddleware>,
+    service: MiddlewareService,
     manifest: OnceCell<MiddlewareManifest>,
     diagnostic_policy: MiddlewareDiagnosticPolicy,
     operator_max_body_bytes: Option<usize>,
@@ -573,44 +633,27 @@ fn normalize_untrusted_diagnostics(
     }
 }
 
-fn validate_request_envelope(
-    evaluation: &HttpRequestEvaluation,
-) -> std::result::Result<(), &'static str> {
-    if evaluation.body.len() > MAX_MIDDLEWARE_BODY_BYTES {
+fn validate_request_view(request: HttpRequestView<'_>) -> std::result::Result<(), &'static str> {
+    if request.body().len() > MAX_MIDDLEWARE_BODY_BYTES {
         return Err("request_body_over_capacity");
     }
-    if evaluation
-        .config
-        .as_ref()
-        .is_some_and(|config| config.encoded_len() > MAX_MIDDLEWARE_CONFIG_BYTES)
-    {
+    if request.config().encoded_len() > MAX_MIDDLEWARE_CONFIG_BYTES {
         return Err("request_config_over_capacity");
     }
-    if evaluation
-        .context
-        .as_ref()
-        .is_some_and(|context| context.encoded_len() > MAX_MIDDLEWARE_CONTEXT_BYTES)
-    {
+    if request.context().encoded_len() > MAX_MIDDLEWARE_CONTEXT_BYTES {
         return Err("request_context_over_capacity");
     }
-    if evaluation
-        .target
-        .as_ref()
-        .is_some_and(|target| target.encoded_len() > MAX_MIDDLEWARE_TARGET_BYTES)
-    {
+    if request.target().encoded_len() > MAX_MIDDLEWARE_TARGET_BYTES {
         return Err("request_target_over_capacity");
     }
-    if evaluation.headers.len() > MAX_MIDDLEWARE_HEADERS {
+    if request.headers().len() > MAX_MIDDLEWARE_HEADERS {
         return Err("request_header_count_over_capacity");
     }
-    let header_bytes = evaluation.headers.iter().fold(0usize, |total, header| {
+    let header_bytes = request.headers().iter().fold(0usize, |total, header| {
         total.saturating_add(header.encoded_len())
     });
     if header_bytes > MAX_MIDDLEWARE_HEADER_BYTES {
         return Err("request_header_bytes_over_capacity");
-    }
-    if evaluation.encoded_len() > MIDDLEWARE_GRPC_MESSAGE_BYTES {
-        return Err("request_envelope_over_capacity");
     }
     Ok(())
 }
@@ -668,7 +711,7 @@ impl MiddlewareRegistry {
     /// Describe in-process services, then connect and validate every
     /// operator-provided service registration.
     pub async fn connect_services(
-        in_process_services: Vec<Arc<dyn SupervisorMiddleware>>,
+        in_process_services: Vec<Arc<dyn InProcessMiddleware>>,
         registrations: Vec<SupervisorMiddlewareService>,
     ) -> Result<Self> {
         let mut services = Vec::with_capacity(in_process_services.len() + registrations.len());
@@ -676,19 +719,17 @@ impl MiddlewareRegistry {
         let mut middleware_names = HashSet::new();
 
         for service in in_process_services {
-            let manifest = call_with_timeout(
-                DEFAULT_MIDDLEWARE_TIMEOUT,
-                "Describe",
-                service.describe(Request::new(())),
-            )
-            .await
-            .map(tonic::Response::into_inner)
-            .map_err(|error| {
-                miette!(
-                    "in-process middleware Describe failed: {}",
-                    safe_reason(&error.to_string())
-                )
-            })?;
+            let service = MiddlewareService::InProcess(service);
+            let manifest =
+                call_with_timeout(DEFAULT_MIDDLEWARE_TIMEOUT, "Describe", service.describe())
+                    .await
+                    .map(tonic::Response::into_inner)
+                    .map_err(|error| {
+                        miette!(
+                            "in-process middleware Describe failed: {}",
+                            safe_reason(&error.to_string())
+                        )
+                    })?;
             let source = if manifest.name.trim().is_empty() {
                 "in-process middleware service".to_string()
             } else {
@@ -737,27 +778,23 @@ impl MiddlewareRegistry {
                         registration.name
                     )
                 })?;
-            let service = Arc::new(
-                remote::RemoteMiddlewareService::connect(
+            let service = MiddlewareService::Grpc(
+                remote::GrpcMiddlewareService::connect(
                     &registration.name,
                     &registration.grpc_endpoint,
                 )
                 .await?,
             );
-            let manifest = call_with_timeout(
-                operator_timeout,
-                "Describe",
-                service.describe(Request::new(())),
-            )
-            .await
-            .map(tonic::Response::into_inner)
-            .map_err(|error| {
-                miette!(
-                    "middleware registration '{}' Describe failed: {}",
-                    registration.name,
-                    safe_reason(&error.to_string())
-                )
-            })?;
+            let manifest = call_with_timeout(operator_timeout, "Describe", service.describe())
+                .await
+                .map(tonic::Response::into_inner)
+                .map_err(|error| {
+                    miette!(
+                        "middleware registration '{}' Describe failed: {}",
+                        registration.name,
+                        safe_reason(&error.to_string())
+                    )
+                })?;
             validate_external_manifest(&registration, &manifest, operator_max_body_bytes)?;
             let manifest_cell = OnceCell::new();
             manifest_cell
@@ -846,7 +883,13 @@ impl Default for ChainRunner {
 }
 
 impl ChainRunner {
-    pub fn new(service: Arc<dyn SupervisorMiddleware>) -> Self {
+    /// Construct a runner around one in-process middleware implementation.
+    #[must_use]
+    pub fn new(service: Arc<dyn InProcessMiddleware>) -> Self {
+        Self::from_service(MiddlewareService::InProcess(service))
+    }
+
+    fn from_service(service: MiddlewareService) -> Self {
         Self {
             registry: Arc::new(MiddlewareRegistry {
                 services: Arc::new(vec![Arc::new(MiddlewareServiceState {
@@ -863,6 +906,13 @@ impl ChainRunner {
         }
     }
 
+    #[cfg(test)]
+    fn new_protobuf_for_tests(service: Arc<dyn SupervisorMiddleware>) -> Self {
+        Self::from_service(MiddlewareService::Grpc(
+            remote::GrpcMiddlewareService::from_service(service),
+        ))
+    }
+
     pub fn from_registry(registry: MiddlewareRegistry) -> Self {
         Self {
             registry: Arc::new(registry),
@@ -875,19 +925,15 @@ impl ChainRunner {
             let manifest = state
                 .manifest
                 .get_or_try_init(|| async {
-                    call_with_timeout(
-                        state.operator_timeout,
-                        "Describe",
-                        state.service.describe(Request::new(())),
-                    )
-                    .await
-                    .map(tonic::Response::into_inner)
-                    .map_err(|error| {
-                        miette!(
-                            "middleware Describe failed: {}",
-                            safe_reason(&error.to_string())
-                        )
-                    })
+                    call_with_timeout(state.operator_timeout, "Describe", state.service.describe())
+                        .await
+                        .map(tonic::Response::into_inner)
+                        .map_err(|error| {
+                            miette!(
+                                "middleware Describe failed: {}",
+                                safe_reason(&error.to_string())
+                            )
+                        })
                 })
                 .await?;
             manifests.push((Arc::clone(state), manifest.clone()));
@@ -985,12 +1031,7 @@ impl ChainRunner {
         let response = call_with_timeout(
             state.timeout_for_binding(binding)?,
             "ValidateConfig",
-            state
-                .service
-                .validate_config(Request::new(ValidateConfigRequest {
-                    config: Some(config),
-                    middleware_name: middleware_name.into(),
-                })),
+            state.service.validate_config(middleware_name, &config),
         )
         .await
         .map(tonic::Response::into_inner)
@@ -1043,15 +1084,47 @@ impl ChainRunner {
         transformed_body_policy: TransformedBodyPolicy<'_>,
     ) -> Result<ChainOutcome> {
         ensure_chain_capacity(entries.len())?;
-        let mut headers = input.headers.clone();
-        let mut body = input.body.clone();
+        let HttpRequestInput {
+            request_id,
+            sandbox_id,
+            scheme,
+            host,
+            port,
+            method,
+            path,
+            query,
+            headers,
+            connection_nominated_headers,
+            body,
+        } = input;
+        // The request envelope is moved into one stable chain state. Built-ins
+        // borrow these values for every stage; only the gRPC adapter clones them
+        // when an operator service requires an owned protobuf message.
+        let context = RequestContext {
+            request_id,
+            sandbox_id,
+            originating_process: None,
+        };
+        let target = HttpRequestTarget {
+            scheme,
+            host,
+            port: u32::from(port),
+            method,
+            path,
+            query,
+        };
+        let mut headers: Vec<HttpHeader> = headers
+            .into_iter()
+            .map(|(name, value)| HttpHeader { name, value })
+            .collect();
+        let mut body = body;
         let mut header_mutations = Vec::new();
         let mut findings = Vec::new();
         let mut metadata = BTreeMap::new();
         let mut applied = Vec::new();
 
         for entry in entries {
-            let Some(binding) = entry.binding.as_ref() else {
+            let Some(_binding) = entry.binding.as_ref() else {
                 match apply_on_error(entry, "binding_not_described", &mut applied) {
                     OnErrorAction::FailOpen => continue,
                     OnErrorAction::FailClosed(reason) => {
@@ -1085,8 +1158,16 @@ impl ChainRunner {
                     }
                 }
             }
-            let evaluation = build_evaluation(entry, binding, &input, &headers, &body);
-            if let Err(reason) = validate_request_envelope(&evaluation) {
+            let request = HttpRequestView::new(
+                PRE_CREDENTIALS_PHASE,
+                &context,
+                &entry.entry.config,
+                &target,
+                &headers,
+                &body,
+                &entry.entry.implementation,
+            );
+            if let Err(reason) = validate_request_view(request) {
                 match apply_on_error(entry, reason, &mut applied) {
                     OnErrorAction::FailOpen => continue,
                     OnErrorAction::FailClosed(reason) => {
@@ -1109,9 +1190,7 @@ impl ChainRunner {
             let mut result = match call_with_timeout(
                 entry.timeout,
                 "EvaluateHttpRequest",
-                service
-                    .service
-                    .evaluate_http_request(Request::new(evaluation)),
+                service.service.evaluate_http_request(request),
             )
             .await
             {
@@ -1245,40 +1324,48 @@ impl ChainRunner {
             // Validate and apply the entire stage atomically. Under fail-open,
             // one malformed mutation must not leave earlier mutations from the
             // same response visible to later middleware.
-            let updated_headers = match headers::apply(
-                &headers,
-                &input.connection_nominated_headers,
-                &result.header_mutations,
-            ) {
-                Ok(updated) => updated,
-                Err(error) => {
-                    let reason = service
-                        .diagnostic_policy
-                        .header_mutation_error_reason(&error);
-                    match apply_on_error(entry, &reason, &mut applied) {
-                        OnErrorAction::FailOpen => continue,
-                        OnErrorAction::FailClosed(reason) => {
-                            return Ok(ChainOutcome {
-                                allowed: false,
-                                reason,
-                                body,
-                                header_mutations,
-                                findings,
-                                metadata,
-                                applied,
-                                denial: None,
-                            });
+            let updated_headers = if result.header_mutations.is_empty() {
+                None
+            } else {
+                match headers::apply(
+                    &headers,
+                    &connection_nominated_headers,
+                    &result.header_mutations,
+                ) {
+                    Ok(updated) => Some(updated),
+                    Err(error) => {
+                        let reason = service
+                            .diagnostic_policy
+                            .header_mutation_error_reason(&error);
+                        match apply_on_error(entry, &reason, &mut applied) {
+                            OnErrorAction::FailOpen => continue,
+                            OnErrorAction::FailClosed(reason) => {
+                                return Ok(ChainOutcome {
+                                    allowed: false,
+                                    reason,
+                                    body,
+                                    header_mutations,
+                                    findings,
+                                    metadata,
+                                    applied,
+                                    denial: None,
+                                });
+                            }
                         }
                     }
                 }
             };
-            let headers_transformed = updated_headers != headers;
-            headers = updated_headers;
-            header_mutations.extend(result.header_mutations.iter().cloned());
+            let headers_transformed = updated_headers
+                .as_ref()
+                .is_some_and(|updated| updated != &headers);
+            if let Some(updated) = updated_headers {
+                headers = updated;
+            }
+            header_mutations.extend(std::mem::take(&mut result.header_mutations));
 
             let body_transformed = result.has_body;
             if body_transformed {
-                result.body.clone_into(&mut body);
+                body = std::mem::take(&mut result.body);
             }
             for finding in result.findings {
                 findings.push(NamespacedFinding {
@@ -1289,7 +1376,7 @@ impl ChainRunner {
             if !result.metadata.is_empty() {
                 metadata.insert(
                     entry.entry.name.clone(),
-                    result.metadata.clone().into_iter().collect(),
+                    result.metadata.into_iter().collect(),
                 );
             }
             applied.push(MiddlewareInvocation {
@@ -1370,41 +1457,6 @@ fn ensure_chain_capacity(count: usize) -> Result<()> {
     Ok(())
 }
 
-fn build_evaluation(
-    entry: &DescribedChainEntry,
-    binding: &MiddlewareBinding,
-    input: &HttpRequestInput,
-    headers: &[(String, String)],
-    body: &[u8],
-) -> HttpRequestEvaluation {
-    HttpRequestEvaluation {
-        phase: binding.phase,
-        context: Some(RequestContext {
-            request_id: input.request_id.clone(),
-            sandbox_id: input.sandbox_id.clone(),
-            originating_process: None,
-        }),
-        config: Some(entry.entry.config.clone()),
-        target: Some(HttpRequestTarget {
-            scheme: input.scheme.clone(),
-            host: input.host.clone(),
-            port: u32::from(input.port),
-            method: input.method.clone(),
-            path: input.path.clone(),
-            query: input.query.clone(),
-        }),
-        headers: headers
-            .iter()
-            .map(|(name, value)| HttpHeader {
-                name: name.clone(),
-                value: value.clone(),
-            })
-            .collect(),
-        body: body.to_vec(),
-        middleware_name: entry.entry.implementation.clone(),
-    }
-}
-
 pub(crate) fn safe_reason(reason: &str) -> String {
     reason
         .chars()
@@ -1478,28 +1530,320 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct RequestAddresses {
+        phase: SupervisorMiddlewarePhase,
+        context: usize,
+        request_id: usize,
+        config: usize,
+        target: usize,
+        host: usize,
+        headers: usize,
+        first_header_name: usize,
+        body: usize,
+        originating_process_present: bool,
+        middleware_name: String,
+    }
+
+    /// Records borrowed addresses so the test can detect an owned envelope
+    /// being reconstructed between otherwise no-op in-process stages.
+    struct BorrowedRecordingService {
+        manifest_name: String,
+        received: std::sync::Mutex<Vec<RequestAddresses>>,
+    }
+
+    #[tonic::async_trait]
+    impl InProcessMiddleware for BorrowedRecordingService {
+        async fn describe(&self) -> MiddlewareManifest {
+            MiddlewareManifest {
+                name: self.manifest_name.clone(),
+                service_version: "test".into(),
+                bindings: vec![MiddlewareBinding {
+                    operation: SupervisorMiddlewareOperation::HttpRequest as i32,
+                    phase: SupervisorMiddlewarePhase::PreCredentials as i32,
+                    max_body_bytes: 4096,
+                    timeout: String::new(),
+                }],
+            }
+        }
+
+        async fn validate_config(
+            &self,
+            _middleware_name: &str,
+            _config: &prost_types::Struct,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn evaluate_http_request(
+            &self,
+            request: HttpRequestView<'_>,
+        ) -> Result<openshell_core::proto::HttpRequestResult> {
+            let addresses = RequestAddresses {
+                phase: request.phase(),
+                context: std::ptr::from_ref(request.context()).addr(),
+                request_id: request.context().request_id.as_ptr().addr(),
+                config: std::ptr::from_ref(request.config()).addr(),
+                target: std::ptr::from_ref(request.target()).addr(),
+                host: request.target().host.as_ptr().addr(),
+                headers: request.headers().as_ptr().addr(),
+                first_header_name: request
+                    .headers()
+                    .first()
+                    .map_or(0, |header| header.name.as_ptr().addr()),
+                body: request.body().as_ptr().addr(),
+                originating_process_present: request.context().originating_process.is_some(),
+                middleware_name: request.middleware_name().to_string(),
+            };
+            self.received
+                .lock()
+                .expect("borrowed request recorder lock")
+                .push(addresses);
+            Ok(allow_result())
+        }
+    }
+
     #[tokio::test]
-    async fn phase_one_evaluation_omits_originating_process() {
-        let entries = builtin_runner()
-            .describe_chain(&[entry("redact", OnError::FailClosed)])
+    async fn in_process_stages_share_one_borrowed_request_envelope() {
+        let service = Arc::new(BorrowedRecordingService {
+            manifest_name: "acme/redactor".into(),
+            received: std::sync::Mutex::new(Vec::new()),
+        });
+        let runner = ChainRunner::new(service.clone());
+        let entries = [
+            ChainEntry {
+                name: "first".into(),
+                implementation: "acme/redactor".into(),
+                order: 0,
+                config: prost_types::Struct::default(),
+                on_error: OnError::FailClosed,
+            },
+            ChainEntry {
+                name: "second".into(),
+                implementation: "acme/redactor".into(),
+                order: 10,
+                config: prost_types::Struct::default(),
+                on_error: OnError::FailClosed,
+            },
+        ];
+        let described = runner
+            .describe_chain(&entries)
             .await
             .expect("describe chain");
-        let entry = &entries[0];
-        let binding = entry.binding.as_ref().expect("described binding");
-        let input = input("payload");
-        let evaluation = build_evaluation(entry, binding, &input, &[], b"payload");
+        let expected_configs: Vec<_> = described
+            .iter()
+            .map(|entry| std::ptr::from_ref(&entry.entry.config).addr())
+            .collect();
+        let mut request = input("payload");
+        request.headers = vec![("x-test".into(), "value".into())];
+        let expected_body = request.body.as_ptr().addr();
+        let expected_request_id = request.request_id.as_ptr().addr();
+        let expected_host = request.host.as_ptr().addr();
+        let expected_header_name = request.headers[0].0.as_ptr().addr();
 
-        assert_eq!(
-            evaluation.phase,
-            SupervisorMiddlewarePhase::PreCredentials as i32
-        );
+        let outcome = runner
+            .evaluate_described(&described, request)
+            .await
+            .expect("evaluate borrowed chain");
+        let received = service.received.lock().expect("borrowed requests");
+
+        assert!(outcome.allowed);
+        assert_eq!(outcome.body.as_ptr().addr(), expected_body);
+        assert_eq!(received.len(), 2);
+        assert_eq!(received[0].phase, SupervisorMiddlewarePhase::PreCredentials);
+        assert!(!received[0].originating_process_present);
+        assert_eq!(received[0].request_id, expected_request_id);
+        assert_eq!(received[0].host, expected_host);
+        assert_eq!(received[0].first_header_name, expected_header_name);
+        assert_eq!(received[0].body, expected_body);
+        assert_eq!(received[0].config, expected_configs[0]);
+        assert_eq!(received[1].config, expected_configs[1]);
+        assert_eq!(received[0].context, received[1].context);
+        assert_eq!(received[0].target, received[1].target);
+        assert_eq!(received[0].headers, received[1].headers);
+        assert_eq!(received[0].body, received[1].body);
         assert!(
-            evaluation
-                .context
-                .expect("request context")
-                .originating_process
-                .is_none()
+            received
+                .iter()
+                .all(|request| request.middleware_name == "acme/redactor")
         );
+    }
+
+    const TEST_REPLACEMENT_BODY: &[u8] = b"stage-one-replacement";
+
+    /// Records both sides of a successful body replacement so the test can
+    /// distinguish ownership transfer from a content-preserving body copy.
+    #[derive(Debug, Default)]
+    struct ReplacementTransferRecord {
+        invocations: usize,
+        returned_body: Option<usize>,
+        second_body: Option<usize>,
+        second_body_bytes: Vec<u8>,
+    }
+
+    /// Replaces the first request body and observes the body borrowed by the
+    /// second stage without replacing it again.
+    struct ReplacementTransferService {
+        record: std::sync::Mutex<ReplacementTransferRecord>,
+    }
+
+    #[tonic::async_trait]
+    impl InProcessMiddleware for ReplacementTransferService {
+        async fn describe(&self) -> MiddlewareManifest {
+            MiddlewareManifest {
+                name: "test/replacement-transfer".into(),
+                service_version: "test".into(),
+                bindings: vec![MiddlewareBinding {
+                    operation: SupervisorMiddlewareOperation::HttpRequest as i32,
+                    phase: SupervisorMiddlewarePhase::PreCredentials as i32,
+                    max_body_bytes: 4096,
+                    timeout: String::new(),
+                }],
+            }
+        }
+
+        async fn validate_config(
+            &self,
+            _middleware_name: &str,
+            _config: &prost_types::Struct,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn evaluate_http_request(
+            &self,
+            request: HttpRequestView<'_>,
+        ) -> Result<openshell_core::proto::HttpRequestResult> {
+            let mut record = self.record.lock().expect("replacement transfer record");
+            let invocation = record.invocations;
+            record.invocations += 1;
+
+            if invocation == 0 {
+                let replacement = TEST_REPLACEMENT_BODY.to_vec();
+                record.returned_body = Some(replacement.as_ptr().addr());
+                let mut result = allow_result();
+                result.body = replacement;
+                result.has_body = true;
+                Ok(result)
+            } else {
+                record.second_body = Some(request.body().as_ptr().addr());
+                record.second_body_bytes = request.body().to_vec();
+                Ok(allow_result())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn replacement_body_allocation_moves_through_next_stage_and_outcome() {
+        let service = Arc::new(ReplacementTransferService {
+            record: std::sync::Mutex::new(ReplacementTransferRecord::default()),
+        });
+        let runner = ChainRunner::new(service.clone());
+        let entries = [
+            ChainEntry {
+                name: "replace".into(),
+                implementation: "test/replacement-transfer".into(),
+                order: 0,
+                config: prost_types::Struct::default(),
+                on_error: OnError::FailClosed,
+            },
+            ChainEntry {
+                name: "observe".into(),
+                implementation: "test/replacement-transfer".into(),
+                order: 10,
+                config: prost_types::Struct::default(),
+                on_error: OnError::FailClosed,
+            },
+        ];
+
+        let outcome = runner
+            .evaluate(&entries, input("original-body"))
+            .await
+            .expect("evaluate replacement transfer chain");
+        let record = service.record.lock().expect("replacement transfer record");
+        let returned_body = record
+            .returned_body
+            .expect("first-stage replacement pointer");
+
+        assert!(outcome.allowed);
+        assert_eq!(record.invocations, 2);
+        assert_eq!(record.second_body_bytes, TEST_REPLACEMENT_BODY);
+        assert_eq!(record.second_body, Some(returned_body));
+        assert_eq!(outcome.body, TEST_REPLACEMENT_BODY);
+        assert_eq!(outcome.body.as_ptr().addr(), returned_body);
+    }
+
+    /// An in-process service that yields forever so the runtime must enforce
+    /// the binding timeout around borrowed validation and evaluation futures.
+    struct PendingInProcessService;
+
+    #[tonic::async_trait]
+    impl InProcessMiddleware for PendingInProcessService {
+        async fn describe(&self) -> MiddlewareManifest {
+            MiddlewareManifest {
+                name: "test/pending".into(),
+                service_version: "test".into(),
+                bindings: vec![MiddlewareBinding {
+                    operation: SupervisorMiddlewareOperation::HttpRequest as i32,
+                    phase: SupervisorMiddlewarePhase::PreCredentials as i32,
+                    max_body_bytes: 4096,
+                    timeout: "10ms".into(),
+                }],
+            }
+        }
+
+        async fn validate_config(
+            &self,
+            _middleware_name: &str,
+            _config: &prost_types::Struct,
+        ) -> Result<()> {
+            std::future::pending().await
+        }
+
+        async fn evaluate_http_request(
+            &self,
+            _request: HttpRequestView<'_>,
+        ) -> Result<openshell_core::proto::HttpRequestResult> {
+            std::future::pending().await
+        }
+    }
+
+    #[tokio::test]
+    async fn in_process_evaluation_remains_interruptible_by_stage_timeout() {
+        let runner = ChainRunner::new(Arc::new(PendingInProcessService));
+        let entry = |on_error| ChainEntry {
+            name: "pending".into(),
+            implementation: "test/pending".into(),
+            order: 0,
+            config: prost_types::Struct::default(),
+            on_error,
+        };
+        let closed = runner
+            .evaluate(&[entry(OnError::FailClosed)], input("payload"))
+            .await
+            .expect("timed-out in-process evaluation");
+        let open = runner
+            .evaluate(&[entry(OnError::FailOpen)], input("payload"))
+            .await
+            .expect("fail-open timed-out in-process evaluation");
+
+        assert!(!closed.allowed);
+        assert_eq!(closed.reason, "middleware_failed: middleware_timeout");
+        assert!(closed.applied[0].failed);
+        assert!(open.allowed);
+        assert!(open.applied[0].failed);
+    }
+
+    #[tokio::test]
+    async fn in_process_validation_remains_interruptible_by_binding_timeout() {
+        let runner = ChainRunner::new(Arc::new(PendingInProcessService));
+        let error = runner
+            .validate_config("test/pending", prost_types::Struct::default())
+            .await
+            .expect_err("timed-out in-process validation");
+
+        assert!(error.to_string().contains("ValidateConfig failed"));
+        assert!(error.to_string().contains("timed out"));
     }
 
     #[tokio::test]
@@ -1535,6 +1879,13 @@ mod tests {
             r#"token="[REDACTED]""#
         );
         assert_eq!(outcome.applied.len(), 2);
+        assert_eq!(
+            [
+                outcome.applied[0].transformed,
+                outcome.applied[1].transformed,
+            ],
+            [true, false]
+        );
     }
 
     #[tokio::test]
@@ -1644,15 +1995,13 @@ mod tests {
 
     #[tokio::test]
     async fn injected_services_cannot_duplicate_middleware_names() {
-        let first: Arc<dyn SupervisorMiddleware> = Arc::new(ScriptedService {
+        let first: Arc<dyn InProcessMiddleware> = Arc::new(BorrowedRecordingService {
             manifest_name: "openshell/test".into(),
-            max_body_bytes: 1024,
-            result: allow_result(),
+            received: std::sync::Mutex::new(Vec::new()),
         });
-        let second: Arc<dyn SupervisorMiddleware> = Arc::new(ScriptedService {
+        let second: Arc<dyn InProcessMiddleware> = Arc::new(BorrowedRecordingService {
             manifest_name: "openshell/test".into(),
-            max_body_bytes: 1024,
-            result: allow_result(),
+            received: std::sync::Mutex::new(Vec::new()),
         });
 
         let error = MiddlewareRegistry::connect_services(vec![first, second], Vec::new())
@@ -1695,16 +2044,11 @@ mod tests {
         async fn validate_config(
             &self,
             _request: Request<ValidateConfigRequest>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::ValidateConfigResponse>,
-            tonic::Status,
-        > {
-            Ok(tonic::Response::new(
-                openshell_core::proto::ValidateConfigResponse {
-                    valid: true,
-                    reason: String::new(),
-                },
-            ))
+        ) -> std::result::Result<tonic::Response<ValidateConfigResponse>, tonic::Status> {
+            Ok(tonic::Response::new(ValidateConfigResponse {
+                valid: true,
+                reason: String::new(),
+            }))
         }
 
         async fn evaluate_http_request(
@@ -1744,17 +2088,12 @@ mod tests {
         async fn validate_config(
             &self,
             _request: Request<ValidateConfigRequest>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::ValidateConfigResponse>,
-            tonic::Status,
-        > {
+        ) -> std::result::Result<tonic::Response<ValidateConfigResponse>, tonic::Status> {
             tokio::time::sleep(self.delay).await;
-            Ok(tonic::Response::new(
-                openshell_core::proto::ValidateConfigResponse {
-                    valid: true,
-                    reason: String::new(),
-                },
-            ))
+            Ok(tonic::Response::new(ValidateConfigResponse {
+                valid: true,
+                reason: String::new(),
+            }))
         }
 
         async fn evaluate_http_request(
@@ -1797,16 +2136,11 @@ mod tests {
         async fn validate_config(
             &self,
             _request: Request<ValidateConfigRequest>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::ValidateConfigResponse>,
-            tonic::Status,
-        > {
-            Ok(tonic::Response::new(
-                openshell_core::proto::ValidateConfigResponse {
-                    valid: true,
-                    reason: String::new(),
-                },
-            ))
+        ) -> std::result::Result<tonic::Response<ValidateConfigResponse>, tonic::Status> {
+            Ok(tonic::Response::new(ValidateConfigResponse {
+                valid: true,
+                reason: String::new(),
+            }))
         }
 
         async fn evaluate_http_request(
@@ -1845,7 +2179,7 @@ mod tests {
         let service: Arc<dyn SupervisorMiddleware> = Arc::new(TwoStageService {
             second_ran: Arc::clone(&second_ran),
         });
-        let runner = ChainRunner::new(service);
+        let runner = ChainRunner::new_protobuf_for_tests(service);
         let transform = ChainEntry {
             name: "transform".into(),
             implementation: "test/two-stage".into(),
@@ -1907,7 +2241,7 @@ mod tests {
         let service: Arc<dyn SupervisorMiddleware> = Arc::new(TwoStageService {
             second_ran: Arc::clone(&second_ran),
         });
-        let runner = ChainRunner::new(service);
+        let runner = ChainRunner::new_protobuf_for_tests(service);
         let transform = ChainEntry {
             name: "transform".into(),
             implementation: "test/two-stage".into(),
@@ -1959,7 +2293,7 @@ mod tests {
         let service: Arc<dyn SupervisorMiddleware> = Arc::new(TwoStageService {
             second_ran: Arc::clone(&second_ran),
         });
-        let runner = ChainRunner::new(service);
+        let runner = ChainRunner::new_protobuf_for_tests(service);
         let entries = [
             ChainEntry {
                 name: "transform".into(),
@@ -2061,20 +2395,15 @@ mod tests {
         async fn validate_config(
             &self,
             request: Request<ValidateConfigRequest>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::ValidateConfigResponse>,
-            tonic::Status,
-        > {
+        ) -> std::result::Result<tonic::Response<ValidateConfigResponse>, tonic::Status> {
             self.validated
                 .lock()
                 .expect("validated config lock")
                 .push(request.into_inner());
-            Ok(tonic::Response::new(
-                openshell_core::proto::ValidateConfigResponse {
-                    valid: true,
-                    reason: String::new(),
-                },
-            ))
+            Ok(tonic::Response::new(ValidateConfigResponse {
+                valid: true,
+                reason: String::new(),
+            }))
         }
 
         async fn evaluate_http_request(
@@ -2120,16 +2449,11 @@ mod tests {
         async fn validate_config(
             &self,
             _request: Request<ValidateConfigRequest>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::ValidateConfigResponse>,
-            tonic::Status,
-        > {
-            Ok(tonic::Response::new(
-                openshell_core::proto::ValidateConfigResponse {
-                    valid: true,
-                    reason: String::new(),
-                },
-            ))
+        ) -> std::result::Result<tonic::Response<ValidateConfigResponse>, tonic::Status> {
+            Ok(tonic::Response::new(ValidateConfigResponse {
+                valid: true,
+                reason: String::new(),
+            }))
         }
 
         async fn evaluate_http_request(
@@ -2175,7 +2499,7 @@ mod tests {
                 second_action: action,
                 received: std::sync::Mutex::new(Vec::new()),
             });
-            let runner = ChainRunner::new(service.clone());
+            let runner = ChainRunner::new_protobuf_for_tests(service.clone());
             let entries = [
                 ChainEntry {
                     name: "first".into(),
@@ -2227,16 +2551,34 @@ mod tests {
             received: std::sync::Mutex::new(Vec::new()),
         });
         let recorder: Arc<dyn SupervisorMiddleware> = service.clone();
-        let runner = ChainRunner::new(recorder);
+        let runner = ChainRunner::new_protobuf_for_tests(recorder);
+        let validation_config = prost_types::Struct {
+            fields: std::iter::once((
+                "required".into(),
+                prost_types::Value {
+                    kind: Some(prost_types::value::Kind::StringValue("present".into())),
+                },
+            ))
+            .collect(),
+        };
         runner
-            .validate_config("test/recorder", prost_types::Struct::default())
+            .validate_config("test/recorder", validation_config.clone())
             .await
             .expect("validate recorder config");
+        let evaluation_config = prost_types::Struct {
+            fields: std::iter::once((
+                "evaluation".into(),
+                prost_types::Value {
+                    kind: Some(prost_types::value::Kind::StringValue("preserved".into())),
+                },
+            ))
+            .collect(),
+        };
         let recorder_entry = ChainEntry {
             name: "recorder".into(),
             implementation: "test/recorder".into(),
             order: 0,
-            config: prost_types::Struct::default(),
+            config: evaluation_config.clone(),
             on_error: OnError::FailClosed,
         };
         let mut request = input("payload");
@@ -2245,6 +2587,8 @@ mod tests {
             ("accept".into(), "application/json".into()),
             ("x-api-key".into(), "second-value".into()),
         ];
+        request.query = "page=2".into();
+        let original_body = request.body.as_ptr().addr();
 
         let outcome = runner
             .evaluate(&[recorder_entry], request)
@@ -2255,11 +2599,31 @@ mod tests {
         let validated = service.validated.lock().expect("validated configs");
         assert_eq!(validated.len(), 1);
         assert_eq!(validated[0].middleware_name, "test/recorder");
+        assert_eq!(validated[0].config.as_ref(), Some(&validation_config));
         drop(validated);
 
         let received = service.received.lock().expect("recorded evaluations");
         assert_eq!(received.len(), 1);
+        assert_eq!(outcome.body.as_ptr().addr(), original_body);
+        assert_ne!(received[0].body.as_ptr().addr(), original_body);
+        assert_eq!(received[0].body, b"payload");
+        assert_eq!(
+            received[0].phase,
+            SupervisorMiddlewarePhase::PreCredentials as i32
+        );
         assert_eq!(received[0].middleware_name, "test/recorder");
+        assert_eq!(received[0].config.as_ref(), Some(&evaluation_config));
+        let context = received[0].context.as_ref().expect("request context");
+        assert_eq!(context.request_id, "req");
+        assert_eq!(context.sandbox_id, "sbx");
+        assert!(context.originating_process.is_none());
+        let target = received[0].target.as_ref().expect("request target");
+        assert_eq!(target.scheme, "https");
+        assert_eq!(target.host, "api.example.com");
+        assert_eq!(target.port, 443);
+        assert_eq!(target.method, "POST");
+        assert_eq!(target.path, "/v1");
+        assert_eq!(target.query, "page=2");
         let headers: Vec<(&str, &str)> = received[0]
             .headers
             .iter()
@@ -2292,11 +2656,7 @@ mod tests {
             .into_iter()
             .next()
             .expect("built-in middleware service");
-        let builtin_manifest = builtin_service
-            .describe(Request::new(()))
-            .await
-            .expect("describe built-in service")
-            .into_inner();
+        let builtin_manifest = builtin_service.describe().await;
         validate_manifest_bindings("test built-in service", &builtin_manifest, None)
             .expect("valid built-in manifest");
         let builtin_name = builtin_manifest.name.clone();
@@ -2321,7 +2681,7 @@ mod tests {
             services: Arc::new(vec![
                 Arc::new(MiddlewareServiceState {
                     attachment_name: Some(builtin_name.clone()),
-                    service: builtin_service,
+                    service: MiddlewareService::InProcess(builtin_service),
                     manifest: builtin_manifest_cell,
                     diagnostic_policy: MiddlewareDiagnosticPolicy::Preserve,
                     operator_max_body_bytes: None,
@@ -2329,7 +2689,9 @@ mod tests {
                 }),
                 Arc::new(MiddlewareServiceState {
                     attachment_name: Some(registration_name.clone()),
-                    service,
+                    service: MiddlewareService::Grpc(remote::GrpcMiddlewareService::from_service(
+                        service,
+                    )),
                     manifest: manifest_cell,
                     diagnostic_policy: MiddlewareDiagnosticPolicy::Normalize,
                     operator_max_body_bytes: Some(operator_max_body_bytes),
@@ -2363,7 +2725,7 @@ mod tests {
 
     #[tokio::test]
     async fn descriptors_are_resolved_from_any_middleware_service() {
-        let runner = ChainRunner::new(Arc::new(ScriptedService {
+        let runner = ChainRunner::new_protobuf_for_tests(Arc::new(ScriptedService {
             manifest_name: "test/middleware".into(),
             max_body_bytes: 4096,
             result: allow_result(),
@@ -3032,7 +3394,7 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_reason_code_is_a_middleware_failure() {
-        let runner = ChainRunner::new(Arc::new(scripted_service(
+        let runner = ChainRunner::new_protobuf_for_tests(Arc::new(scripted_service(
             openshell_core::proto::HttpRequestResult {
                 decision: Decision::Deny as i32,
                 reason_code: "Secret value!".into(),
@@ -3192,7 +3554,7 @@ mod tests {
 
     #[tokio::test]
     async fn maximum_chain_retains_findings_from_every_stage() {
-        let runner = ChainRunner::new(Arc::new(ScriptedService {
+        let runner = ChainRunner::new_protobuf_for_tests(Arc::new(ScriptedService {
             manifest_name: "test/middleware".into(),
             max_body_bytes: 4096,
             result: openshell_core::proto::HttpRequestResult {
@@ -3242,7 +3604,7 @@ mod tests {
 
     #[tokio::test]
     async fn deny_decision_short_circuits_chain() {
-        let runner = ChainRunner::new(Arc::new(scripted_service(
+        let runner = ChainRunner::new_protobuf_for_tests(Arc::new(scripted_service(
             openshell_core::proto::HttpRequestResult {
                 decision: Decision::Deny as i32,
                 reason: "blocked_by_policy".into(),
@@ -3277,7 +3639,7 @@ mod tests {
 
     #[tokio::test]
     async fn deny_decision_ignores_unsafe_mutations_under_fail_open() {
-        let runner = ChainRunner::new(Arc::new(scripted_service(
+        let runner = ChainRunner::new_protobuf_for_tests(Arc::new(scripted_service(
             openshell_core::proto::HttpRequestResult {
                 decision: Decision::Deny as i32,
                 reason: "blocked_by_policy".into(),
@@ -3305,7 +3667,7 @@ mod tests {
 
     #[tokio::test]
     async fn deny_decision_ignores_oversized_replacement_under_fail_open() {
-        let runner = ChainRunner::new(Arc::new(ScriptedService {
+        let runner = ChainRunner::new_protobuf_for_tests(Arc::new(ScriptedService {
             manifest_name: BUILTIN_REGEX.into(),
             max_body_bytes: 4,
             result: openshell_core::proto::HttpRequestResult {
@@ -3333,7 +3695,7 @@ mod tests {
 
     #[tokio::test]
     async fn metadata_and_findings_are_namespaced_per_config() {
-        let runner = ChainRunner::new(Arc::new(scripted_service(
+        let runner = ChainRunner::new_protobuf_for_tests(Arc::new(scripted_service(
             openshell_core::proto::HttpRequestResult {
                 findings: vec![Finding {
                     r#type: "pii.email".into(),
@@ -3390,7 +3752,7 @@ mod tests {
 
     #[tokio::test]
     async fn malformed_response_headers_fail_closed_denies() {
-        let runner = ChainRunner::new(Arc::new(unsafe_header_service()));
+        let runner = ChainRunner::new_protobuf_for_tests(Arc::new(unsafe_header_service()));
         let outcome = runner
             .evaluate(&[entry("redact", OnError::FailClosed)], input("hello"))
             .await
@@ -3412,7 +3774,7 @@ mod tests {
 
     #[tokio::test]
     async fn malformed_response_headers_fail_open_continues() {
-        let runner = ChainRunner::new(Arc::new(unsafe_header_service()));
+        let runner = ChainRunner::new_protobuf_for_tests(Arc::new(unsafe_header_service()));
         let outcome = runner
             .evaluate(&[entry("redact", OnError::FailOpen)], input("hello"))
             .await
@@ -3426,7 +3788,7 @@ mod tests {
 
     #[tokio::test]
     async fn oversized_replacement_body_honors_on_error() {
-        let runner = ChainRunner::new(Arc::new(ScriptedService {
+        let runner = ChainRunner::new_protobuf_for_tests(Arc::new(ScriptedService {
             manifest_name: BUILTIN_REGEX.into(),
             max_body_bytes: 4,
             result: openshell_core::proto::HttpRequestResult {
@@ -3461,7 +3823,7 @@ mod tests {
 
     #[tokio::test]
     async fn oversized_request_body_honors_on_error() {
-        let runner = ChainRunner::new(Arc::new(ScriptedService {
+        let runner = ChainRunner::new_protobuf_for_tests(Arc::new(ScriptedService {
             manifest_name: BUILTIN_REGEX.into(),
             max_body_bytes: 4,
             result: allow_result(),
@@ -3492,7 +3854,7 @@ mod tests {
 
     #[tokio::test]
     async fn unspecified_decision_uses_fail_closed() {
-        let runner = ChainRunner::new(Arc::new(scripted_service(
+        let runner = ChainRunner::new_protobuf_for_tests(Arc::new(scripted_service(
             openshell_core::proto::HttpRequestResult {
                 decision: Decision::Unspecified as i32,
                 ..allow_result()

--- a/crates/openshell-supervisor-middleware/src/remote.rs
+++ b/crates/openshell-supervisor-middleware/src/remote.rs
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use miette::{IntoDiagnostic, Result, WrapErr};
+use openshell_core::middleware::HttpRequestView;
 use openshell_core::proto::middleware::v1::supervisor_middleware_client::SupervisorMiddlewareClient;
 use openshell_core::proto::middleware::v1::supervisor_middleware_server::SupervisorMiddleware;
 use openshell_core::proto::{
@@ -18,6 +20,67 @@ use crate::MIDDLEWARE_GRPC_MESSAGE_BYTES;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const HTTP2_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
 const HTTP2_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Adapts the borrowed runtime request contract to the owned protobuf service
+/// contract only when dispatch crosses a gRPC-shaped boundary.
+#[derive(Clone)]
+pub struct GrpcMiddlewareService {
+    service: Arc<dyn SupervisorMiddleware>,
+}
+
+impl GrpcMiddlewareService {
+    /// Connect an operator registration and wrap its generated gRPC client.
+    pub async fn connect(registration_name: &str, grpc_endpoint: &str) -> Result<Self> {
+        Ok(Self {
+            service: Arc::new(
+                RemoteMiddlewareService::connect(registration_name, grpc_endpoint).await?,
+            ),
+        })
+    }
+
+    /// Wrap a protobuf-shaped service used by transport-boundary tests.
+    #[cfg(test)]
+    pub fn from_service(service: Arc<dyn SupervisorMiddleware>) -> Self {
+        Self { service }
+    }
+
+    /// Forward a manifest request through the protobuf service contract.
+    pub async fn describe(&self) -> std::result::Result<Response<MiddlewareManifest>, Status> {
+        self.service.describe(Request::new(())).await
+    }
+
+    /// Materialize the owned configuration request required by gRPC.
+    pub async fn validate_config(
+        &self,
+        middleware_name: &str,
+        config: &prost_types::Struct,
+    ) -> std::result::Result<Response<ValidateConfigResponse>, Status> {
+        self.service
+            .validate_config(Request::new(ValidateConfigRequest {
+                config: Some(config.clone()),
+                middleware_name: middleware_name.to_string(),
+            }))
+            .await
+    }
+
+    /// Materialize an owned protobuf evaluation immediately before transport.
+    pub async fn evaluate_http_request(
+        &self,
+        request: HttpRequestView<'_>,
+    ) -> std::result::Result<Response<HttpRequestResult>, Status> {
+        self.service
+            .evaluate_http_request(Request::new(HttpRequestEvaluation {
+                phase: request.phase() as i32,
+                context: Some(request.context().clone()),
+                config: Some(request.config().clone()),
+                target: Some(request.target().clone()),
+                headers: request.headers().to_vec(),
+                body: request.body().to_vec(),
+                middleware_name: request.middleware_name().to_string(),
+            }))
+            .await
+    }
+}
 
 #[derive(Clone)]
 pub struct RemoteMiddlewareService {

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -4230,62 +4230,39 @@ network_policies:
     }
 
     #[tonic::async_trait]
-    impl openshell_core::proto::middleware::v1::supervisor_middleware_server::SupervisorMiddleware
-        for BlockingAllowService
-    {
-        async fn describe(
-            &self,
-            _request: tonic::Request<()>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::MiddlewareManifest>,
-            tonic::Status,
-        > {
-            Ok(tonic::Response::new(
-                openshell_core::proto::MiddlewareManifest {
-                    name: "test/blocking-allow".into(),
-                    service_version: "test".into(),
-                    bindings: vec![openshell_core::proto::MiddlewareBinding {
-                        operation: openshell_core::proto::SupervisorMiddlewareOperation::HttpRequest
-                            as i32,
-                        phase: openshell_core::proto::SupervisorMiddlewarePhase::PreCredentials
-                            as i32,
-                        max_body_bytes: 8192,
-                        timeout: String::new(),
-                    }],
-                },
-            ))
+    impl openshell_core::middleware::InProcessMiddleware for BlockingAllowService {
+        async fn describe(&self) -> openshell_core::proto::MiddlewareManifest {
+            openshell_core::proto::MiddlewareManifest {
+                name: "test/blocking-allow".into(),
+                service_version: "test".into(),
+                bindings: vec![openshell_core::proto::MiddlewareBinding {
+                    operation: openshell_core::proto::SupervisorMiddlewareOperation::HttpRequest
+                        as i32,
+                    phase: openshell_core::proto::SupervisorMiddlewarePhase::PreCredentials as i32,
+                    max_body_bytes: 8192,
+                    timeout: String::new(),
+                }],
+            }
         }
 
         async fn validate_config(
             &self,
-            _request: tonic::Request<openshell_core::proto::ValidateConfigRequest>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::ValidateConfigResponse>,
-            tonic::Status,
-        > {
-            Ok(tonic::Response::new(
-                openshell_core::proto::ValidateConfigResponse {
-                    valid: true,
-                    reason: String::new(),
-                },
-            ))
+            _middleware_name: &str,
+            _config: &prost_types::Struct,
+        ) -> Result<()> {
+            Ok(())
         }
 
         async fn evaluate_http_request(
             &self,
-            _request: tonic::Request<openshell_core::proto::HttpRequestEvaluation>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::HttpRequestResult>,
-            tonic::Status,
-        > {
+            _request: openshell_core::middleware::HttpRequestView<'_>,
+        ) -> Result<openshell_core::proto::HttpRequestResult> {
             self.entered.notify_one();
             self.release.notified().await;
-            Ok(tonic::Response::new(
-                openshell_core::proto::HttpRequestResult {
-                    decision: openshell_core::proto::Decision::Allow as i32,
-                    ..Default::default()
-                },
-            ))
+            Ok(openshell_core::proto::HttpRequestResult {
+                decision: openshell_core::proto::Decision::Allow as i32,
+                ..Default::default()
+            })
         }
     }
 
@@ -4398,62 +4375,39 @@ network_policies:
     }
 
     #[tonic::async_trait]
-    impl openshell_core::proto::middleware::v1::supervisor_middleware_server::SupervisorMiddleware
-        for BodyReplacingService
-    {
-        async fn describe(
-            &self,
-            _request: tonic::Request<()>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::MiddlewareManifest>,
-            tonic::Status,
-        > {
-            Ok(tonic::Response::new(
-                openshell_core::proto::MiddlewareManifest {
-                    name: "test/rewriter".into(),
-                    service_version: "test".into(),
-                    bindings: vec![openshell_core::proto::MiddlewareBinding {
-                        operation: openshell_core::proto::SupervisorMiddlewareOperation::HttpRequest
-                            as i32,
-                        phase: openshell_core::proto::SupervisorMiddlewarePhase::PreCredentials
-                            as i32,
-                        max_body_bytes: 8192,
-                        timeout: String::new(),
-                    }],
-                },
-            ))
+    impl openshell_core::middleware::InProcessMiddleware for BodyReplacingService {
+        async fn describe(&self) -> openshell_core::proto::MiddlewareManifest {
+            openshell_core::proto::MiddlewareManifest {
+                name: "test/rewriter".into(),
+                service_version: "test".into(),
+                bindings: vec![openshell_core::proto::MiddlewareBinding {
+                    operation: openshell_core::proto::SupervisorMiddlewareOperation::HttpRequest
+                        as i32,
+                    phase: openshell_core::proto::SupervisorMiddlewarePhase::PreCredentials as i32,
+                    max_body_bytes: 8192,
+                    timeout: String::new(),
+                }],
+            }
         }
 
         async fn validate_config(
             &self,
-            _request: tonic::Request<openshell_core::proto::ValidateConfigRequest>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::ValidateConfigResponse>,
-            tonic::Status,
-        > {
-            Ok(tonic::Response::new(
-                openshell_core::proto::ValidateConfigResponse {
-                    valid: true,
-                    reason: String::new(),
-                },
-            ))
+            _middleware_name: &str,
+            _config: &prost_types::Struct,
+        ) -> Result<()> {
+            Ok(())
         }
 
         async fn evaluate_http_request(
             &self,
-            _request: tonic::Request<openshell_core::proto::HttpRequestEvaluation>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::HttpRequestResult>,
-            tonic::Status,
-        > {
-            Ok(tonic::Response::new(
-                openshell_core::proto::HttpRequestResult {
-                    decision: openshell_core::proto::Decision::Allow as i32,
-                    body: self.replacement.to_vec(),
-                    has_body: true,
-                    ..Default::default()
-                },
-            ))
+            _request: openshell_core::middleware::HttpRequestView<'_>,
+        ) -> Result<openshell_core::proto::HttpRequestResult> {
+            Ok(openshell_core::proto::HttpRequestResult {
+                decision: openshell_core::proto::Decision::Allow as i32,
+                body: self.replacement.to_vec(),
+                has_body: true,
+                ..Default::default()
+            })
         }
     }
 
@@ -4888,21 +4842,13 @@ network_policies:
     }
 
     #[tonic::async_trait]
-    impl openshell_core::proto::middleware::v1::supervisor_middleware_server::SupervisorMiddleware
-        for LimitService
-    {
-        async fn describe(
-            &self,
-            _request: tonic::Request<()>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::MiddlewareManifest>,
-            tonic::Status,
-        > {
+    impl openshell_core::middleware::InProcessMiddleware for LimitService {
+        async fn describe(&self) -> openshell_core::proto::MiddlewareManifest {
             use openshell_core::proto::{
                 MiddlewareBinding, MiddlewareManifest, SupervisorMiddlewareOperation,
                 SupervisorMiddlewarePhase,
             };
-            Ok(tonic::Response::new(MiddlewareManifest {
+            MiddlewareManifest {
                 name: self.name.into(),
                 service_version: "test".into(),
                 bindings: vec![MiddlewareBinding {
@@ -4911,32 +4857,21 @@ network_policies:
                     max_body_bytes: self.max_body_bytes,
                     timeout: String::new(),
                 }],
-            }))
+            }
         }
 
         async fn validate_config(
             &self,
-            _request: tonic::Request<openshell_core::proto::ValidateConfigRequest>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::ValidateConfigResponse>,
-            tonic::Status,
-        > {
-            Ok(tonic::Response::new(
-                openshell_core::proto::ValidateConfigResponse {
-                    valid: true,
-                    reason: String::new(),
-                },
-            ))
+            _middleware_name: &str,
+            _config: &prost_types::Struct,
+        ) -> Result<()> {
+            Ok(())
         }
 
         async fn evaluate_http_request(
             &self,
-            request: tonic::Request<openshell_core::proto::HttpRequestEvaluation>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::HttpRequestResult>,
-            tonic::Status,
-        > {
-            let _evaluation = request.into_inner();
+            _request: openshell_core::middleware::HttpRequestView<'_>,
+        ) -> Result<openshell_core::proto::HttpRequestResult> {
             let mut result = openshell_core::proto::HttpRequestResult {
                 decision: openshell_core::proto::Decision::Allow as i32,
                 ..Default::default()
@@ -4945,7 +4880,7 @@ network_policies:
                 result.body = replacement.to_vec();
                 result.has_body = true;
             }
-            Ok(tonic::Response::new(result))
+            Ok(result)
         }
     }
 

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -5388,62 +5388,39 @@ mod tests {
     }
 
     #[tonic::async_trait]
-    impl openshell_core::proto::middleware::v1::supervisor_middleware_server::SupervisorMiddleware
-        for BlockingForwardMiddleware
-    {
-        async fn describe(
-            &self,
-            _request: tonic::Request<()>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::MiddlewareManifest>,
-            tonic::Status,
-        > {
-            Ok(tonic::Response::new(
-                openshell_core::proto::MiddlewareManifest {
-                    name: "test/blocking-forward".into(),
-                    service_version: "test".into(),
-                    bindings: vec![openshell_core::proto::MiddlewareBinding {
-                        operation: openshell_core::proto::SupervisorMiddlewareOperation::HttpRequest
-                            as i32,
-                        phase: openshell_core::proto::SupervisorMiddlewarePhase::PreCredentials
-                            as i32,
-                        max_body_bytes: 8192,
-                        timeout: String::new(),
-                    }],
-                },
-            ))
+    impl openshell_core::middleware::InProcessMiddleware for BlockingForwardMiddleware {
+        async fn describe(&self) -> openshell_core::proto::MiddlewareManifest {
+            openshell_core::proto::MiddlewareManifest {
+                name: "test/blocking-forward".into(),
+                service_version: "test".into(),
+                bindings: vec![openshell_core::proto::MiddlewareBinding {
+                    operation: openshell_core::proto::SupervisorMiddlewareOperation::HttpRequest
+                        as i32,
+                    phase: openshell_core::proto::SupervisorMiddlewarePhase::PreCredentials as i32,
+                    max_body_bytes: 8192,
+                    timeout: String::new(),
+                }],
+            }
         }
 
         async fn validate_config(
             &self,
-            _request: tonic::Request<openshell_core::proto::ValidateConfigRequest>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::ValidateConfigResponse>,
-            tonic::Status,
-        > {
-            Ok(tonic::Response::new(
-                openshell_core::proto::ValidateConfigResponse {
-                    valid: true,
-                    reason: String::new(),
-                },
-            ))
+            _middleware_name: &str,
+            _config: &prost_types::Struct,
+        ) -> Result<()> {
+            Ok(())
         }
 
         async fn evaluate_http_request(
             &self,
-            _request: tonic::Request<openshell_core::proto::HttpRequestEvaluation>,
-        ) -> std::result::Result<
-            tonic::Response<openshell_core::proto::HttpRequestResult>,
-            tonic::Status,
-        > {
+            _request: openshell_core::middleware::HttpRequestView<'_>,
+        ) -> Result<openshell_core::proto::HttpRequestResult> {
             self.entered.notify_one();
             self.release.notified().await;
-            Ok(tonic::Response::new(
-                openshell_core::proto::HttpRequestResult {
-                    decision: openshell_core::proto::Decision::Allow as i32,
-                    ..Default::default()
-                },
-            ))
+            Ok(openshell_core::proto::HttpRequestResult {
+                decision: openshell_core::proto::Decision::Allow as i32,
+                ..Default::default()
+            })
         }
     }
 


### PR DESCRIPTION
## Summary
Add an asynchronous borrowed `HttpRequestView` contract so every selected in-process middleware stage reads the request context, target, headers, and body already owned by the chain runner. Previously, each stage was treated like a remote service and received a newly allocated, protobuf-shaped `HttpRequestEvaluation`, including a complete clone of the current request body. The new path constructs an owned protobuf request only in the gRPC adapter immediately before remote dispatch, removing redundant in-process allocations and memory copies without changing middleware decisions, transformations, timeouts, or the external protobuf contract.

## Related Issue
Closes #2678

## Changes
- Add the borrowed `HttpRequestView<'a>` and asynchronous, object-safe `InProcessMiddleware` interface to `openshell-core`.
- Split runtime dispatch between in-process middleware and `GrpcMiddlewareService`, leaving the sole production `HttpRequestEvaluation` construction at the remote transport boundary.
- Move request storage and successful body-replacement outputs through the chain, preserve header mutation atomicity, reuse body storage when a stage returns no replacement, reuse header storage on the empty-mutation application path, and clone current headers for atomic processing of every non-empty mutation list that reaches application.
- Update the regex built-in to borrow configuration and request bytes, using `Cow` so unmatched bodies remain borrowed and replacements allocate only when needed.
- Add regression coverage for stable in-process request addresses, transformed-body handoff between stages, replacement-allocation pointer preservation through later stages and the final outcome, custom in-process manifest names, non-default `ValidateConfig` values, remote request fidelity and ownership, cooperative timeouts, transformations, repeated headers, and invalid UTF-8 bodies.
- Document the in-process and remote middleware ownership boundary in the sandbox architecture guide.

## Testing
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
