### PR TITLE
docs(fern): remove alpha announcement

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -12,9 +12,6 @@ title: NVIDIA OpenShell
 
 global-theme: nvidia
 
-announcement:
-  message: "🔔 NVIDIA OpenShell is <strong>alpha software</strong>. APIs and behavior may change without notice. Do not use in production."
-
 footer: ./components/CustomFooter.tsx
 
 layout:


### PR DESCRIPTION
## Summary

Remove the alpha software announcement banner from the OpenShell documentation site.

## Related Issue

No issue required: localized Fern configuration cleanup.

## Changes

- Remove the `announcement` block from `fern/docs.yml`.

## Testing

- [ ] `mise run pre-commit` passes (docs, Python, Helm, Markdown, license, and other checks passed; the Rust portion is blocked locally because `z3.h` is unavailable)
- [x] `MISE_DISABLE_TOOLS=github:anchore/syft,github:rust-cross/cargo-zigbuild,github:mozilla/sccache mise run docs` passes (0 errors; 1 warning)
- [x] `git diff --check origin/main...HEAD` passes
- [ ] Unit tests added/updated (not applicable; configuration-only change)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; Fern configuration only)