### PR TITLE
fix(gateway-interceptors): decouple reconnect probe from poll interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3912,6 +3912,7 @@ dependencies = [
 name = "openshell-gateway-interceptors"
 version = "0.0.0"
 dependencies = [
+ "arc-swap",
  "hyper-util",
  "json-patch",
  "metrics",
@@ -3923,6 +3924,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tower 0.5.3",
  "tracing",

--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -448,6 +448,10 @@ pub struct Config {
     /// Disabled-by-default gateway interceptor service configs.
     pub gateway_interceptors: Vec<GatewayInterceptorConfig>,
 
+    /// Interval in seconds between gateway interceptor manifest refresh polls.
+    /// Defaults to 10 seconds when interceptors are configured.
+    pub gateway_interceptor_refresh_interval_secs: Option<u64>,
+
     /// Ordered provider-profile sources used to build the effective catalog.
     pub provider_profile_sources: Vec<GatewayProviderProfileSourceConfig>,
 
@@ -789,6 +793,7 @@ impl Config {
             oidc: None,
             auth: GatewayAuthConfig::default(),
             gateway_interceptors: Vec::new(),
+            gateway_interceptor_refresh_interval_secs: None,
             provider_profile_sources: vec![
                 GatewayProviderProfileSourceConfig::Builtin,
                 GatewayProviderProfileSourceConfig::User,
@@ -910,6 +915,13 @@ impl Config {
         I: IntoIterator<Item = GatewayInterceptorConfig>,
     {
         self.gateway_interceptors = interceptors.into_iter().collect();
+        self
+    }
+
+    /// Set the gateway interceptor manifest refresh interval.
+    #[must_use]
+    pub fn with_gateway_interceptor_refresh_interval(mut self, secs: Option<u64>) -> Self {
+        self.gateway_interceptor_refresh_interval_secs = secs;
         self
     }
 

--- a/crates/openshell-gateway-interceptors/Cargo.toml
+++ b/crates/openshell-gateway-interceptors/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 [dependencies]
 openshell-core = { path = "../openshell-core", default-features = false }
 
+arc-swap = "1"
 hyper-util = { workspace = true, features = ["client", "http1", "http2", "tokio"] }
 json-patch = "1.4"
 metrics = { workspace = true }
@@ -28,6 +29,7 @@ tower = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+tokio-stream = { workspace = true, features = ["net"] }
 tracing-subscriber = { workspace = true }
 
 [lints]

--- a/crates/openshell-gateway-interceptors/src/plan.rs
+++ b/crates/openshell-gateway-interceptors/src/plan.rs
@@ -23,6 +23,8 @@ use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 use tower::service_fn;
 use tracing::{info, warn};
 
+use sha2::Digest as _;
+
 use crate::profile_source::GatewayInterceptorProfileSource;
 use crate::routes::OpenShellRouteIndex;
 use crate::{InterceptorError, Result};
@@ -171,6 +173,7 @@ pub struct ExecutionPlan {
     profile_sources: BTreeMap<String, GatewayInterceptorProfileSource>,
     routes: OpenShellRouteIndex,
     handles: Vec<InterceptorHandle>,
+    manifest_fingerprint: String,
 }
 
 impl ExecutionPlan {
@@ -181,6 +184,7 @@ impl ExecutionPlan {
             profile_sources: BTreeMap::new(),
             routes,
             handles: Vec::new(),
+            manifest_fingerprint: String::new(),
         }
     }
 
@@ -194,6 +198,8 @@ impl ExecutionPlan {
         let mut bindings: BTreeMap<(RpcSelector, Phase), Vec<BindingPlan>> = BTreeMap::new();
         let mut profile_sources = BTreeMap::new();
         let mut handles = Vec::new();
+        let mut fingerprint_hasher = sha2::Sha256::new();
+        fingerprint_hasher.update(b"openshell-interceptor-manifest-v1");
 
         for config in configs {
             let channel = connect_endpoint(&config.grpc_endpoint).await?;
@@ -223,6 +229,7 @@ impl ExecutionPlan {
                         ))
                     })?
                     .into_inner();
+            fingerprint_hasher.update(prost::Message::encode_to_vec(&manifest));
             let service_default = match config.binding_policy {
                 GatewayInterceptorBindingPolicy::Dynamic => {
                     let manifest_default = parse_optional_failure_policy(&manifest.failure_policy)?;
@@ -312,6 +319,7 @@ impl ExecutionPlan {
             handles.push(InterceptorHandle { config, channel });
         }
 
+        let manifest_fingerprint = format!("sha256:{:x}", fingerprint_hasher.finalize());
         let count: usize = bindings.values().map(Vec::len).sum();
         info!(
             bindings = count,
@@ -323,6 +331,7 @@ impl ExecutionPlan {
             profile_sources,
             routes,
             handles,
+            manifest_fingerprint,
         })
     }
 
@@ -371,6 +380,10 @@ impl ExecutionPlan {
         self.bindings.keys().cloned().collect()
     }
 
+    pub(crate) fn manifest_fingerprint(&self) -> &str {
+        &self.manifest_fingerprint
+    }
+
     pub(crate) fn interceptor_clients(&self) -> Vec<(String, GatewayInterceptorClient<Channel>)> {
         self.handles
             .iter()
@@ -391,6 +404,8 @@ impl ExecutionPlan {
         let mut bindings: BTreeMap<(RpcSelector, Phase), Vec<BindingPlan>> = BTreeMap::new();
         let mut profile_sources = BTreeMap::new();
         let mut new_handles = Vec::new();
+        let mut fingerprint_hasher = sha2::Sha256::new();
+        fingerprint_hasher.update(b"openshell-interceptor-manifest-v1");
 
         for handle in &self.handles {
             let config = &handle.config;
@@ -421,6 +436,7 @@ impl ExecutionPlan {
                         ))
                     })?
                     .into_inner();
+            fingerprint_hasher.update(prost::Message::encode_to_vec(&manifest));
 
             let service_default = match config.binding_policy {
                 GatewayInterceptorBindingPolicy::Dynamic => {
@@ -505,11 +521,13 @@ impl ExecutionPlan {
             });
         }
 
+        let manifest_fingerprint = format!("sha256:{:x}", fingerprint_hasher.finalize());
         Ok(Self {
             bindings,
             profile_sources,
             routes: self.routes.clone(),
             handles: new_handles,
+            manifest_fingerprint,
         })
     }
 }

--- a/crates/openshell-gateway-interceptors/src/plan.rs
+++ b/crates/openshell-gateway-interceptors/src/plan.rs
@@ -31,6 +31,12 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const HTTP2_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
 const KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(20);
 
+#[derive(Clone, Debug)]
+pub struct InterceptorHandle {
+    pub config: GatewayInterceptorConfig,
+    pub channel: Channel,
+}
+
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_millis(500);
 pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 1_048_576;
 pub const DEFAULT_MAX_PATCHES: usize = 32;
@@ -164,6 +170,7 @@ pub struct ExecutionPlan {
     bindings: BTreeMap<(RpcSelector, Phase), Vec<BindingPlan>>,
     profile_sources: BTreeMap<String, GatewayInterceptorProfileSource>,
     routes: OpenShellRouteIndex,
+    handles: Vec<InterceptorHandle>,
 }
 
 impl ExecutionPlan {
@@ -173,6 +180,7 @@ impl ExecutionPlan {
             bindings: BTreeMap::new(),
             profile_sources: BTreeMap::new(),
             routes,
+            handles: Vec::new(),
         }
     }
 
@@ -185,6 +193,7 @@ impl ExecutionPlan {
 
         let mut bindings: BTreeMap<(RpcSelector, Phase), Vec<BindingPlan>> = BTreeMap::new();
         let mut profile_sources = BTreeMap::new();
+        let mut handles = Vec::new();
 
         for config in configs {
             let channel = connect_endpoint(&config.grpc_endpoint).await?;
@@ -299,6 +308,8 @@ impl ExecutionPlan {
                     ),
                 );
             }
+
+            handles.push(InterceptorHandle { config, channel });
         }
 
         let count: usize = bindings.values().map(Vec::len).sum();
@@ -311,6 +322,7 @@ impl ExecutionPlan {
             bindings,
             profile_sources,
             routes,
+            handles,
         })
     }
 
@@ -349,6 +361,140 @@ impl ExecutionPlan {
 
     pub(crate) fn has_binding(&self, selector: &RpcSelector, phase: Phase) -> bool {
         self.bindings.contains_key(&(selector.clone(), phase))
+    }
+
+    pub(crate) fn profile_sources_map(&self) -> &BTreeMap<String, GatewayInterceptorProfileSource> {
+        &self.profile_sources
+    }
+
+    pub(crate) fn binding_keys(&self) -> BTreeSet<(RpcSelector, Phase)> {
+        self.bindings.keys().cloned().collect()
+    }
+
+    pub(crate) async fn refresh(&self) -> Result<Self> {
+        let mut bindings: BTreeMap<(RpcSelector, Phase), Vec<BindingPlan>> = BTreeMap::new();
+        let mut profile_sources = BTreeMap::new();
+        let mut new_handles = Vec::new();
+
+        for handle in &self.handles {
+            let config = &handle.config;
+            let channel = handle.channel.clone();
+            let timeout = match config.timeout.as_deref() {
+                Some(timeout) => parse_duration(timeout)?,
+                None => DEFAULT_TIMEOUT,
+            };
+            let max_response_bytes = config
+                .max_response_bytes
+                .unwrap_or(DEFAULT_MAX_RESPONSE_BYTES);
+            let max_patches = config.max_patches.unwrap_or(DEFAULT_MAX_PATCHES);
+            let mut client = GatewayInterceptorClient::new(channel.clone())
+                .max_decoding_message_size(max_response_bytes);
+            let manifest =
+                tokio::time::timeout(timeout, client.describe(Request::new(DescribeRequest {})))
+                    .await
+                    .map_err(|_| {
+                        InterceptorError::Transport(format!(
+                            "Describe timed out for '{}' during refresh",
+                            config.name
+                        ))
+                    })?
+                    .map_err(|status| {
+                        InterceptorError::Transport(format!(
+                            "Describe failed for '{}' during refresh: {status}",
+                            config.name
+                        ))
+                    })?
+                    .into_inner();
+
+            let service_default = match config.binding_policy {
+                GatewayInterceptorBindingPolicy::Dynamic => {
+                    let manifest_default = parse_optional_failure_policy(&manifest.failure_policy)?;
+                    config
+                        .failure_policy
+                        .map(FailurePolicy::from)
+                        .or(manifest_default)
+                        .unwrap_or(FailurePolicy::FailClosed)
+                }
+                GatewayInterceptorBindingPolicy::Allowlist
+                | GatewayInterceptorBindingPolicy::Exact => config
+                    .failure_policy
+                    .map_or(FailurePolicy::FailClosed, FailurePolicy::from),
+            };
+
+            let normalized_bindings = match config.binding_policy {
+                GatewayInterceptorBindingPolicy::Dynamic => normalize_dynamic_bindings(
+                    &config.name,
+                    &manifest.bindings,
+                    service_default,
+                    &config.bindings,
+                )?,
+                GatewayInterceptorBindingPolicy::Allowlist
+                | GatewayInterceptorBindingPolicy::Exact => normalize_strict_bindings(
+                    &config.name,
+                    &manifest.bindings,
+                    service_default,
+                    &config.bindings,
+                    config.binding_policy,
+                )?,
+            };
+            for normalized in normalized_bindings {
+                if !self
+                    .routes
+                    .is_interceptable(&normalized.selector.service, &normalized.selector.method)
+                {
+                    return Err(InterceptorError::Config(format!(
+                        "interceptor '{}' binding '{}' targets non-interceptable RPC '{}'",
+                        config.name,
+                        normalized.binding_id,
+                        normalized.selector.rpc()
+                    )));
+                }
+                for phase in normalized.phases {
+                    let plan = BindingPlan {
+                        interceptor_name: config.name.clone(),
+                        binding_id: normalized.binding_id.clone(),
+                        selector: normalized.selector.clone(),
+                        phase,
+                        failure_policy: normalized.failure_policy,
+                        timeout,
+                        max_response_bytes,
+                        max_patches,
+                        client: GatewayInterceptorClient::new(channel.clone())
+                            .max_decoding_message_size(max_response_bytes),
+                    };
+                    bindings
+                        .entry((normalized.selector.clone(), phase))
+                        .or_default()
+                        .push(plan);
+                }
+            }
+
+            if manifest.provider_profiles {
+                let source_id = format!("interceptor/{}", config.name);
+                profile_sources.insert(
+                    config.name.clone(),
+                    GatewayInterceptorProfileSource::new(
+                        config.name.clone(),
+                        source_id,
+                        timeout,
+                        GatewayInterceptorClient::new(channel.clone())
+                            .max_decoding_message_size(max_response_bytes),
+                    ),
+                );
+            }
+
+            new_handles.push(InterceptorHandle {
+                config: config.clone(),
+                channel,
+            });
+        }
+
+        Ok(Self {
+            bindings,
+            profile_sources,
+            routes: self.routes.clone(),
+            handles: new_handles,
+        })
     }
 }
 

--- a/crates/openshell-gateway-interceptors/src/plan.rs
+++ b/crates/openshell-gateway-interceptors/src/plan.rs
@@ -371,6 +371,22 @@ impl ExecutionPlan {
         self.bindings.keys().cloned().collect()
     }
 
+    pub(crate) fn interceptor_clients(&self) -> Vec<(String, GatewayInterceptorClient<Channel>)> {
+        self.handles
+            .iter()
+            .map(|h| {
+                let max = h
+                    .config
+                    .max_response_bytes
+                    .unwrap_or(DEFAULT_MAX_RESPONSE_BYTES);
+                (
+                    h.config.name.clone(),
+                    GatewayInterceptorClient::new(h.channel.clone()).max_decoding_message_size(max),
+                )
+            })
+            .collect()
+    }
+
     pub(crate) async fn refresh(&self) -> Result<Self> {
         let mut bindings: BTreeMap<(RpcSelector, Phase), Vec<BindingPlan>> = BTreeMap::new();
         let mut profile_sources = BTreeMap::new();

--- a/crates/openshell-gateway-interceptors/src/runtime.rs
+++ b/crates/openshell-gateway-interceptors/src/runtime.rs
@@ -44,6 +44,7 @@ pub struct EvaluationContext {
 pub struct InterceptedRequest {
     pub body: Vec<u8>,
     selector: RpcSelector,
+    plan: Arc<ExecutionPlan>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -172,7 +173,11 @@ impl GatewayInterceptorRuntime {
         .encode()
         .map_err(|err| Status::invalid_argument(err.to_string()))?;
 
-        Ok(InterceptedRequest { body, selector })
+        Ok(InterceptedRequest {
+            body,
+            selector,
+            plan,
+        })
     }
 
     pub async fn evaluate_post_commit(
@@ -181,8 +186,8 @@ impl GatewayInterceptorRuntime {
         response_body: &[u8],
         context: &EvaluationContext,
     ) -> std::result::Result<(), Status> {
-        let plan = self.plan.load_full();
-        let output_type = plan
+        let output_type = intercepted
+            .plan
             .output_type(&intercepted.selector)
             .ok_or_else(|| Status::invalid_argument("unknown OpenShell method"))?;
         let frame = GrpcFrame::decode(response_body)?;
@@ -194,7 +199,7 @@ impl GatewayInterceptorRuntime {
             ValidatedOperation::new(&self.codec, output_type, committed_response)
                 .map_err(|err| Status::invalid_argument(err.to_string()))?;
         self.evaluate_phase_with_plan(
-            &plan,
+            &intercepted.plan,
             &intercepted.selector,
             Phase::PostCommit,
             output_type,
@@ -207,28 +212,29 @@ impl GatewayInterceptorRuntime {
 
     #[must_use]
     pub fn has_post_commit(&self, intercepted: &InterceptedRequest) -> bool {
-        self.plan
-            .load_full()
+        intercepted
+            .plan
             .has_binding(&intercepted.selector, Phase::PostCommit)
     }
 
     pub async fn refresh(&self) -> Result<bool> {
         let current = self.plan.load_full();
         let new_plan = current.refresh().await?;
-        if current.binding_keys() == new_plan.binding_keys()
-            && current.profile_sources_map().keys().collect::<Vec<_>>()
-                == new_plan.profile_sources_map().keys().collect::<Vec<_>>()
-        {
-            return Ok(false);
-        }
+        let bindings_changed = current.binding_keys() != new_plan.binding_keys();
+        let sources_changed = current.profile_sources_map().keys().collect::<Vec<_>>()
+            != new_plan.profile_sources_map().keys().collect::<Vec<_>>();
         let count: usize = new_plan.binding_keys().len();
-        info!(
-            bindings = count,
-            profile_sources = new_plan.profile_sources_map().len(),
-            "gateway interceptor manifest refreshed"
-        );
         self.plan.store(Arc::new(new_plan));
-        Ok(true)
+        let changed = bindings_changed || sources_changed;
+        if changed {
+            info!(
+                bindings = count,
+                bindings_changed,
+                sources_changed,
+                "gateway interceptor manifest refreshed with structural changes"
+            );
+        }
+        Ok(changed)
     }
 
     pub fn profile_sources_map(&self) -> BTreeMap<String, GatewayInterceptorProfileSource> {

--- a/crates/openshell-gateway-interceptors/src/runtime.rs
+++ b/crates/openshell-gateway-interceptors/src/runtime.rs
@@ -241,6 +241,12 @@ impl GatewayInterceptorRuntime {
         self.plan.load_full().profile_sources_map().clone()
     }
 
+    pub fn interceptor_clients(
+        &self,
+    ) -> Vec<(String, openshell_core::proto::gateway_interceptor::v1::gateway_interceptor_client::GatewayInterceptorClient<tonic::transport::Channel>)>{
+        self.plan.load_full().interceptor_clients()
+    }
+
     async fn evaluate_phase_with_plan(
         &self,
         plan: &ExecutionPlan,

--- a/crates/openshell-gateway-interceptors/src/runtime.rs
+++ b/crates/openshell-gateway-interceptors/src/runtime.rs
@@ -7,6 +7,8 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Instant;
 
+use arc_swap::ArcSwap;
+
 use json_patch::{PatchOperation, patch};
 use metrics::{counter, histogram};
 use openshell_core::config::GatewayInterceptorConfig;
@@ -28,7 +30,7 @@ const GRPC_HEADER_LEN: usize = 5;
 
 #[derive(Debug, Clone)]
 pub struct GatewayInterceptorRuntime {
-    plan: Arc<ExecutionPlan>,
+    plan: Arc<ArcSwap<ExecutionPlan>>,
     codec: ProtoJsonCodec,
 }
 
@@ -82,7 +84,7 @@ impl GatewayInterceptorRuntime {
         let routes = routes::OpenShellRouteIndex::from_descriptor_pool(codec.descriptor_pool())?;
         let plan = ExecutionPlan::load(configs, routes).await?;
         Ok(Self {
-            plan: Arc::new(plan),
+            plan: Arc::new(ArcSwap::from(Arc::new(plan))),
             codec,
         })
     }
@@ -92,12 +94,12 @@ impl GatewayInterceptorRuntime {
         &self,
         interceptor_name: &str,
     ) -> Option<GatewayInterceptorProfileSource> {
-        self.plan.profile_source(interceptor_name)
+        self.plan.load_full().profile_source(interceptor_name)
     }
 
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.plan.is_empty()
+        self.plan.load_full().is_empty()
     }
 
     #[must_use]
@@ -105,7 +107,7 @@ impl GatewayInterceptorRuntime {
         let Some(selector) = RpcSelector::from_grpc_path(path) else {
             return false;
         };
-        self.plan.should_intercept(&selector)
+        self.plan.load_full().should_intercept(&selector)
     }
 
     pub async fn evaluate_request(
@@ -114,10 +116,10 @@ impl GatewayInterceptorRuntime {
         body: &[u8],
         context: &EvaluationContext,
     ) -> std::result::Result<InterceptedRequest, Status> {
+        let plan = self.plan.load_full();
         let selector = RpcSelector::from_grpc_path(path)
             .ok_or_else(|| Status::invalid_argument("invalid gRPC method path"))?;
-        let input_type = self
-            .plan
+        let input_type = plan
             .input_type(&selector)
             .ok_or_else(|| Status::invalid_argument("unknown OpenShell method"))?
             .to_string();
@@ -130,7 +132,8 @@ impl GatewayInterceptorRuntime {
             .map_err(|err| Status::invalid_argument(err.to_string()))?;
 
         operation = self
-            .evaluate_phase(
+            .evaluate_phase_with_plan(
+                &plan,
                 &selector,
                 Phase::ModifyOperation,
                 &input_type,
@@ -139,7 +142,14 @@ impl GatewayInterceptorRuntime {
             )
             .await?;
         operation = self
-            .evaluate_phase(&selector, Phase::Validate, &input_type, operation, context)
+            .evaluate_phase_with_plan(
+                &plan,
+                &selector,
+                Phase::Validate,
+                &input_type,
+                operation,
+                context,
+            )
             .await?;
 
         let encoded_operation = self
@@ -171,8 +181,8 @@ impl GatewayInterceptorRuntime {
         response_body: &[u8],
         context: &EvaluationContext,
     ) -> std::result::Result<(), Status> {
-        let output_type = self
-            .plan
+        let plan = self.plan.load_full();
+        let output_type = plan
             .output_type(&intercepted.selector)
             .ok_or_else(|| Status::invalid_argument("unknown OpenShell method"))?;
         let frame = GrpcFrame::decode(response_body)?;
@@ -183,7 +193,8 @@ impl GatewayInterceptorRuntime {
         let committed_response =
             ValidatedOperation::new(&self.codec, output_type, committed_response)
                 .map_err(|err| Status::invalid_argument(err.to_string()))?;
-        self.evaluate_phase(
+        self.evaluate_phase_with_plan(
+            &plan,
             &intercepted.selector,
             Phase::PostCommit,
             output_type,
@@ -197,18 +208,43 @@ impl GatewayInterceptorRuntime {
     #[must_use]
     pub fn has_post_commit(&self, intercepted: &InterceptedRequest) -> bool {
         self.plan
+            .load_full()
             .has_binding(&intercepted.selector, Phase::PostCommit)
     }
 
-    async fn evaluate_phase(
+    pub async fn refresh(&self) -> Result<bool> {
+        let current = self.plan.load_full();
+        let new_plan = current.refresh().await?;
+        if current.binding_keys() == new_plan.binding_keys()
+            && current.profile_sources_map().keys().collect::<Vec<_>>()
+                == new_plan.profile_sources_map().keys().collect::<Vec<_>>()
+        {
+            return Ok(false);
+        }
+        let count: usize = new_plan.binding_keys().len();
+        info!(
+            bindings = count,
+            profile_sources = new_plan.profile_sources_map().len(),
+            "gateway interceptor manifest refreshed"
+        );
+        self.plan.store(Arc::new(new_plan));
+        Ok(true)
+    }
+
+    pub fn profile_sources_map(&self) -> BTreeMap<String, GatewayInterceptorProfileSource> {
+        self.plan.load_full().profile_sources_map().clone()
+    }
+
+    async fn evaluate_phase_with_plan(
         &self,
+        plan: &ExecutionPlan,
         selector: &RpcSelector,
         phase: Phase,
         operation_type: &str,
         operation: ValidatedOperation,
         context: &EvaluationContext,
     ) -> std::result::Result<ValidatedOperation, Status> {
-        let Some(plans) = self.plan.bindings(selector, phase) else {
+        let Some(plans) = plan.bindings(selector, phase) else {
             return Ok(operation);
         };
 
@@ -962,7 +998,7 @@ mod tests {
             routes::OpenShellRouteIndex::from_descriptor_set(openshell_core::FILE_DESCRIPTOR_SET)
                 .unwrap();
         let runtime = GatewayInterceptorRuntime {
-            plan: Arc::new(ExecutionPlan::empty(routes)),
+            plan: Arc::new(ArcSwap::from(Arc::new(ExecutionPlan::empty(routes)))),
             codec: codec.clone(),
         };
         let body = GrpcFrame {
@@ -998,7 +1034,7 @@ mod tests {
             routes::OpenShellRouteIndex::from_descriptor_set(openshell_core::FILE_DESCRIPTOR_SET)
                 .unwrap();
         let runtime = GatewayInterceptorRuntime {
-            plan: Arc::new(ExecutionPlan::empty(routes)),
+            plan: Arc::new(ArcSwap::from(Arc::new(ExecutionPlan::empty(routes)))),
             codec: codec.clone(),
         };
         let request = UpdateConfigRequest {
@@ -1383,5 +1419,257 @@ mod tests {
         assert_eq!(TestRecorder::count(&recorder.patches), 1);
         assert_eq!(TestRecorder::count(&recorder.fail_open), 0);
         assert_eq!(TestRecorder::count(&recorder.fail_closed), 0);
+    }
+
+    mod refresh_tests {
+        use super::*;
+        use openshell_core::config::GatewayInterceptorConfig;
+        use openshell_core::proto::gateway_interceptor::v1::{
+            DescribeRequest, GatewayInterceptorPhase, InterceptorBinding, InterceptorEvaluation,
+            InterceptorManifest, InterceptorResult, InterceptorSelector, ProviderProfileSnapshot,
+            ProviderProfileSnapshotRequest,
+            gateway_interceptor_server::{GatewayInterceptor, GatewayInterceptorServer},
+        };
+        use std::sync::Mutex;
+        use std::sync::atomic::AtomicU32;
+        use tokio_stream::wrappers::TcpListenerStream;
+
+        #[derive(Clone)]
+        struct MutableInterceptor {
+            manifest: Arc<Mutex<InterceptorManifest>>,
+        }
+
+        #[tonic::async_trait]
+        impl GatewayInterceptor for MutableInterceptor {
+            async fn describe(
+                &self,
+                _request: Request<DescribeRequest>,
+            ) -> std::result::Result<tonic::Response<InterceptorManifest>, Status> {
+                let manifest = self.manifest.lock().unwrap().clone();
+                Ok(tonic::Response::new(manifest))
+            }
+
+            async fn evaluate(
+                &self,
+                _request: Request<InterceptorEvaluation>,
+            ) -> std::result::Result<tonic::Response<InterceptorResult>, Status> {
+                Ok(tonic::Response::new(InterceptorResult {
+                    allowed: true,
+                    ..InterceptorResult::default()
+                }))
+            }
+
+            async fn snapshot_provider_profiles(
+                &self,
+                _request: Request<ProviderProfileSnapshotRequest>,
+            ) -> std::result::Result<tonic::Response<ProviderProfileSnapshot>, Status> {
+                Err(Status::unimplemented("not supported"))
+            }
+        }
+
+        fn test_manifest(bindings: Vec<InterceptorBinding>) -> InterceptorManifest {
+            InterceptorManifest {
+                name: "test-interceptor".to_string(),
+                failure_policy: "fail_open".to_string(),
+                bindings,
+                provider_profiles: false,
+            }
+        }
+
+        fn test_binding(id: &str, rpc: &str) -> InterceptorBinding {
+            InterceptorBinding {
+                id: id.to_string(),
+                selector: Some(InterceptorSelector {
+                    rpc: rpc.to_string(),
+                    service: String::new(),
+                    method: String::new(),
+                }),
+                phases: vec![GatewayInterceptorPhase::Validate as i32],
+                failure_policy: "fail_open".to_string(),
+            }
+        }
+
+        async fn start_mock_interceptor(
+            manifest: InterceptorManifest,
+        ) -> (
+            Arc<Mutex<InterceptorManifest>>,
+            String,
+            tokio::task::JoinHandle<()>,
+        ) {
+            let manifest = Arc::new(Mutex::new(manifest));
+            let interceptor = MutableInterceptor {
+                manifest: manifest.clone(),
+            };
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = format!("http://{}", listener.local_addr().unwrap());
+            let task = tokio::spawn(async move {
+                tonic::transport::Server::builder()
+                    .add_service(GatewayInterceptorServer::new(interceptor))
+                    .serve_with_incoming(TcpListenerStream::new(listener))
+                    .await
+                    .unwrap();
+            });
+            tokio::task::yield_now().await;
+            (manifest, address, task)
+        }
+
+        async fn build_runtime(address: &str) -> GatewayInterceptorRuntime {
+            crate::initialize(vec![GatewayInterceptorConfig {
+                name: "test-interceptor".to_string(),
+                grpc_endpoint: address.to_string(),
+                ..GatewayInterceptorConfig::default()
+            }])
+            .await
+            .unwrap()
+            .expect("runtime should be created")
+        }
+
+        #[tokio::test]
+        async fn refresh_returns_false_when_manifest_unchanged() {
+            let manifest = test_manifest(vec![test_binding(
+                "validate-create",
+                "openshell.v1.OpenShell/CreateSandbox",
+            )]);
+            let (_shared, address, _task) = start_mock_interceptor(manifest).await;
+            let runtime = build_runtime(&address).await;
+
+            let changed = runtime.refresh().await.unwrap();
+            assert!(
+                !changed,
+                "refresh should return false when manifest is unchanged"
+            );
+        }
+
+        #[tokio::test]
+        async fn refresh_returns_true_when_binding_added() {
+            let manifest = test_manifest(vec![test_binding(
+                "validate-create",
+                "openshell.v1.OpenShell/CreateSandbox",
+            )]);
+            let (shared, address, _task) = start_mock_interceptor(manifest).await;
+            let runtime = build_runtime(&address).await;
+
+            assert!(
+                runtime.should_intercept_path("/openshell.v1.OpenShell/CreateSandbox"),
+                "initial binding should be active"
+            );
+            assert!(
+                !runtime.should_intercept_path("/openshell.v1.OpenShell/UpdateConfig"),
+                "UpdateConfig should not be intercepted initially"
+            );
+
+            {
+                let mut manifest = shared.lock().unwrap();
+                manifest.bindings.push(test_binding(
+                    "validate-update",
+                    "openshell.v1.OpenShell/UpdateConfig",
+                ));
+            }
+
+            let changed = runtime.refresh().await.unwrap();
+            assert!(changed, "refresh should detect the new binding");
+            assert!(
+                runtime.should_intercept_path("/openshell.v1.OpenShell/UpdateConfig"),
+                "new binding should be active after refresh"
+            );
+        }
+
+        #[tokio::test]
+        async fn refresh_returns_true_when_binding_removed() {
+            let manifest = test_manifest(vec![
+                test_binding("validate-create", "openshell.v1.OpenShell/CreateSandbox"),
+                test_binding("validate-update", "openshell.v1.OpenShell/UpdateConfig"),
+            ]);
+            let (shared, address, _task) = start_mock_interceptor(manifest).await;
+            let runtime = build_runtime(&address).await;
+
+            assert!(runtime.should_intercept_path("/openshell.v1.OpenShell/UpdateConfig"));
+
+            {
+                let mut manifest = shared.lock().unwrap();
+                manifest.bindings.retain(|b| b.id != "validate-update");
+            }
+
+            let changed = runtime.refresh().await.unwrap();
+            assert!(changed, "refresh should detect the removed binding");
+            assert!(
+                !runtime.should_intercept_path("/openshell.v1.OpenShell/UpdateConfig"),
+                "removed binding should no longer be active"
+            );
+        }
+
+        #[derive(Clone)]
+        struct FailOnRefreshInterceptor {
+            manifest: Arc<Mutex<InterceptorManifest>>,
+            call_count: Arc<AtomicU32>,
+        }
+
+        #[tonic::async_trait]
+        impl GatewayInterceptor for FailOnRefreshInterceptor {
+            async fn describe(
+                &self,
+                _request: Request<DescribeRequest>,
+            ) -> std::result::Result<tonic::Response<InterceptorManifest>, Status> {
+                let count = self.call_count.fetch_add(1, Ordering::Relaxed);
+                if count > 0 {
+                    return Err(Status::unavailable("simulated interceptor outage"));
+                }
+                let manifest = self.manifest.lock().unwrap().clone();
+                Ok(tonic::Response::new(manifest))
+            }
+
+            async fn evaluate(
+                &self,
+                _request: Request<InterceptorEvaluation>,
+            ) -> std::result::Result<tonic::Response<InterceptorResult>, Status> {
+                Ok(tonic::Response::new(InterceptorResult {
+                    allowed: true,
+                    ..InterceptorResult::default()
+                }))
+            }
+
+            async fn snapshot_provider_profiles(
+                &self,
+                _request: Request<ProviderProfileSnapshotRequest>,
+            ) -> std::result::Result<tonic::Response<ProviderProfileSnapshot>, Status> {
+                Err(Status::unimplemented("not supported"))
+            }
+        }
+
+        #[tokio::test]
+        async fn refresh_preserves_old_plan_on_describe_failure() {
+            let manifest = test_manifest(vec![test_binding(
+                "validate-create",
+                "openshell.v1.OpenShell/CreateSandbox",
+            )]);
+            let interceptor = FailOnRefreshInterceptor {
+                manifest: Arc::new(Mutex::new(manifest)),
+                call_count: Arc::new(AtomicU32::new(0)),
+            };
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = format!("http://{}", listener.local_addr().unwrap());
+            let _task = tokio::spawn(async move {
+                tonic::transport::Server::builder()
+                    .add_service(GatewayInterceptorServer::new(interceptor))
+                    .serve_with_incoming(TcpListenerStream::new(listener))
+                    .await
+                    .unwrap();
+            });
+            tokio::task::yield_now().await;
+
+            let runtime = build_runtime(&address).await;
+            assert!(runtime.should_intercept_path("/openshell.v1.OpenShell/CreateSandbox"));
+
+            let result = runtime.refresh().await;
+            assert!(
+                result.is_err(),
+                "refresh should fail when describe returns error"
+            );
+
+            assert!(
+                runtime.should_intercept_path("/openshell.v1.OpenShell/CreateSandbox"),
+                "old plan should be preserved on refresh failure"
+            );
+        }
     }
 }

--- a/crates/openshell-gateway-interceptors/src/runtime.rs
+++ b/crates/openshell-gateway-interceptors/src/runtime.rs
@@ -220,20 +220,15 @@ impl GatewayInterceptorRuntime {
     pub async fn refresh(&self) -> Result<bool> {
         let current = self.plan.load_full();
         let new_plan = current.refresh().await?;
-        let bindings_changed = current.binding_keys() != new_plan.binding_keys();
-        let sources_changed = current.profile_sources_map().keys().collect::<Vec<_>>()
-            != new_plan.profile_sources_map().keys().collect::<Vec<_>>();
-        let count: usize = new_plan.binding_keys().len();
-        self.plan.store(Arc::new(new_plan));
-        let changed = bindings_changed || sources_changed;
+        let changed = current.manifest_fingerprint() != new_plan.manifest_fingerprint();
         if changed {
             info!(
-                bindings = count,
-                bindings_changed,
-                sources_changed,
-                "gateway interceptor manifest refreshed with structural changes"
+                bindings = new_plan.binding_keys().len(),
+                profile_sources = new_plan.profile_sources_map().len(),
+                "gateway interceptor manifest changed"
             );
         }
+        self.plan.store(Arc::new(new_plan));
         Ok(changed)
     }
 

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -377,6 +377,10 @@ fn prepare_server_config(args: &mut RunArgs, matches: &ArgMatches) -> Result<Ser
                 .map(|f| f.openshell.gateway.interceptors.clone())
                 .unwrap_or_default(),
         )
+        .with_gateway_interceptor_refresh_interval(
+            file.as_ref()
+                .and_then(|f| f.openshell.gateway.interceptor_refresh_interval_secs),
+        )
         .with_server_sans(args.server_sans.clone())
         .with_loopback_service_http(args.enable_loopback_service_http);
     if let Some(sources) = file

--- a/crates/openshell-server/src/config_file.rs
+++ b/crates/openshell-server/src/config_file.rs
@@ -170,6 +170,8 @@ pub struct GatewayFileSection {
     #[serde(default)]
     pub interceptors: Vec<GatewayInterceptorConfig>,
     #[serde(default)]
+    pub interceptor_refresh_interval_secs: Option<u64>,
+    #[serde(default)]
     pub provider_profile_sources: Option<Vec<GatewayProviderProfileSourceConfig>>,
     #[serde(default)]
     pub mtls_auth: Option<MtlsAuthConfig>,

--- a/crates/openshell-server/src/interceptor_refresh.rs
+++ b/crates/openshell-server/src/interceptor_refresh.rs
@@ -5,36 +5,91 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use metrics::counter;
+use openshell_core::proto::gateway_interceptor::v1::DescribeRequest;
+use openshell_core::proto::gateway_interceptor::v1::gateway_interceptor_client::GatewayInterceptorClient;
+use tokio::sync::mpsc;
+use tonic::transport::Channel;
 use tracing::{debug, info, warn};
 
-pub fn spawn_interceptor_refresh_worker(state: Arc<crate::ServerState>, interval: Duration) {
+const RECONNECT_PROBE_INTERVAL: Duration = Duration::from_secs(2);
+const RECONNECT_BACKOFF_MAX: Duration = Duration::from_secs(30);
+const DESCRIBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub fn spawn_interceptor_refresh_worker(state: Arc<crate::ServerState>, poll_interval: Duration) {
+    let Some(ref interceptors) = state.gateway_interceptors else {
+        return;
+    };
+
+    let clients = interceptors.interceptor_clients();
+    if clients.is_empty() {
+        return;
+    }
+
     info!(
-        interval_seconds = interval.as_secs(),
-        "gateway interceptor refresh worker started"
+        poll_interval_secs = poll_interval.as_secs(),
+        interceptors = clients.len(),
+        "gateway interceptor refresh worker started (reconnect + poll)"
     );
+
+    let (tx, mut rx) = mpsc::channel::<String>(16);
+
+    for (name, client) in clients {
+        let tx = tx.clone();
+        tokio::spawn(watch_interceptor_connection(name, client, tx));
+    }
+
+    let state = state.clone();
     tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(interval);
-        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        ticker.tick().await;
+        let mut poll_ticker = tokio::time::interval(poll_interval);
+        poll_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        poll_ticker.tick().await;
+
         loop {
-            ticker.tick().await;
+            let trigger = tokio::select! {
+                _ = poll_ticker.tick() => "poll",
+                name = rx.recv() => {
+                    if let Some(name) = name {
+                        info!(
+                            interceptor = %name,
+                            "interceptor reconnected, triggering manifest refresh"
+                        );
+                    } else {
+                        break;
+                    }
+                    "reconnect"
+                }
+            };
+
             let Some(ref interceptors) = state.gateway_interceptors else {
                 continue;
             };
+
             match interceptors.refresh().await {
                 Ok(structural_change) => {
-                    counter!("openshell_gateway_interceptor_refresh_total", "result" => "success")
-                        .increment(1);
+                    counter!(
+                        "openshell_gateway_interceptor_refresh_total",
+                        "trigger" => trigger,
+                        "result" => "success"
+                    )
+                    .increment(1);
                     if structural_change {
-                        info!("gateway interceptor manifest refreshed with structural changes");
+                        info!(
+                            trigger,
+                            "gateway interceptor manifest refreshed with structural changes"
+                        );
                     } else {
-                        debug!("gateway interceptor manifest refreshed");
+                        debug!(trigger, "gateway interceptor manifest refreshed");
                     }
                 }
                 Err(err) => {
-                    counter!("openshell_gateway_interceptor_refresh_total", "result" => "error")
-                        .increment(1);
+                    counter!(
+                        "openshell_gateway_interceptor_refresh_total",
+                        "trigger" => trigger,
+                        "result" => "error"
+                    )
+                    .increment(1);
                     warn!(
+                        trigger,
                         error = %err,
                         "gateway interceptor manifest refresh failed; keeping previous plan"
                     );
@@ -42,4 +97,43 @@ pub fn spawn_interceptor_refresh_worker(state: Arc<crate::ServerState>, interval
             }
         }
     });
+}
+
+async fn watch_interceptor_connection(
+    name: String,
+    mut client: GatewayInterceptorClient<Channel>,
+    tx: mpsc::Sender<String>,
+) {
+    let mut connected = true;
+    let mut backoff = RECONNECT_PROBE_INTERVAL;
+
+    loop {
+        let sleep_duration = if connected {
+            backoff = RECONNECT_PROBE_INTERVAL;
+            RECONNECT_BACKOFF_MAX
+        } else {
+            backoff
+        };
+        tokio::time::sleep(sleep_duration).await;
+
+        let result = tokio::time::timeout(
+            DESCRIBE_TIMEOUT,
+            client.describe(tonic::Request::new(DescribeRequest {})),
+        )
+        .await;
+
+        if let Ok(Ok(_)) = result {
+            if !connected {
+                connected = true;
+                backoff = RECONNECT_PROBE_INTERVAL;
+                let _ = tx.send(name.clone()).await;
+            }
+        } else {
+            if connected {
+                warn!(interceptor = %name, "interceptor connection lost");
+                connected = false;
+            }
+            backoff = (backoff * 2).min(RECONNECT_BACKOFF_MAX);
+        }
+    }
 }

--- a/crates/openshell-server/src/interceptor_refresh.rs
+++ b/crates/openshell-server/src/interceptor_refresh.rs
@@ -22,15 +22,14 @@ pub fn spawn_interceptor_refresh_worker(state: Arc<crate::ServerState>, interval
                 continue;
             };
             match interceptors.refresh().await {
-                Ok(true) => {
+                Ok(structural_change) => {
                     counter!("openshell_gateway_interceptor_refresh_total", "result" => "success")
                         .increment(1);
-                    info!("gateway interceptor manifest refreshed with new bindings");
-                }
-                Ok(false) => {
-                    counter!("openshell_gateway_interceptor_refresh_total", "result" => "unchanged")
-                        .increment(1);
-                    debug!("gateway interceptor manifest unchanged");
+                    if structural_change {
+                        info!("gateway interceptor manifest refreshed with structural changes");
+                    } else {
+                        debug!("gateway interceptor manifest refreshed");
+                    }
                 }
                 Err(err) => {
                     counter!("openshell_gateway_interceptor_refresh_total", "result" => "error")

--- a/crates/openshell-server/src/interceptor_refresh.rs
+++ b/crates/openshell-server/src/interceptor_refresh.rs
@@ -35,12 +35,7 @@ pub fn spawn_interceptor_refresh_worker(state: Arc<crate::ServerState>, poll_int
 
     for (name, client) in clients {
         let tx = tx.clone();
-        tokio::spawn(watch_interceptor_connection(
-            name,
-            client,
-            tx,
-            poll_interval,
-        ));
+        tokio::spawn(watch_interceptor_connection(name, client, tx));
     }
 
     let state = state.clone();
@@ -104,11 +99,14 @@ pub fn spawn_interceptor_refresh_worker(state: Arc<crate::ServerState>, poll_int
     });
 }
 
+/// Probes an interceptor channel and sends the interceptor name on `tx` when
+/// a reconnection is detected (transition from unhealthy → healthy).  Healthy
+/// channels are re-probed every [`RECONNECT_PROBE_INTERVAL`] so that short
+/// outages are detected within seconds regardless of the poll interval.
 async fn watch_interceptor_connection(
     name: String,
     mut client: GatewayInterceptorClient<Channel>,
     tx: mpsc::Sender<String>,
-    healthy_probe_interval: Duration,
 ) {
     let mut connected = true;
     let mut backoff = RECONNECT_PROBE_INTERVAL;
@@ -116,7 +114,7 @@ async fn watch_interceptor_connection(
     loop {
         let sleep_duration = if connected {
             backoff = RECONNECT_PROBE_INTERVAL;
-            healthy_probe_interval
+            RECONNECT_PROBE_INTERVAL
         } else {
             backoff
         };
@@ -141,5 +139,132 @@ async fn watch_interceptor_connection(
             }
             backoff = (backoff * 2).min(RECONNECT_BACKOFF_MAX);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openshell_core::proto::gateway_interceptor::v1::{
+        DescribeRequest, InterceptorEvaluation, InterceptorManifest, InterceptorResult,
+        ProviderProfileSnapshot, ProviderProfileSnapshotRequest,
+        gateway_interceptor_server::{GatewayInterceptor, GatewayInterceptorServer},
+    };
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::{Request, Status};
+
+    #[derive(Clone)]
+    struct ToggleInterceptor {
+        healthy: Arc<AtomicBool>,
+    }
+
+    #[tonic::async_trait]
+    impl GatewayInterceptor for ToggleInterceptor {
+        async fn describe(
+            &self,
+            _request: Request<DescribeRequest>,
+        ) -> Result<tonic::Response<InterceptorManifest>, Status> {
+            if self.healthy.load(Ordering::Relaxed) {
+                Ok(tonic::Response::new(InterceptorManifest {
+                    name: "toggle".to_string(),
+                    ..InterceptorManifest::default()
+                }))
+            } else {
+                Err(Status::unavailable("simulated outage"))
+            }
+        }
+
+        async fn evaluate(
+            &self,
+            _request: Request<InterceptorEvaluation>,
+        ) -> Result<tonic::Response<InterceptorResult>, Status> {
+            Err(Status::unimplemented("not needed"))
+        }
+
+        async fn snapshot_provider_profiles(
+            &self,
+            _request: Request<ProviderProfileSnapshotRequest>,
+        ) -> Result<tonic::Response<ProviderProfileSnapshot>, Status> {
+            Err(Status::unimplemented("not needed"))
+        }
+    }
+
+    #[tokio::test]
+    async fn watcher_detects_reconnect_and_sends_notification() {
+        let healthy = Arc::new(AtomicBool::new(true));
+        let interceptor = ToggleInterceptor {
+            healthy: healthy.clone(),
+        };
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = format!("http://{}", listener.local_addr().unwrap());
+        let _server = tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(GatewayInterceptorServer::new(interceptor))
+                .serve_with_incoming(TcpListenerStream::new(listener))
+                .await
+                .unwrap();
+        });
+        tokio::task::yield_now().await;
+
+        let client = GatewayInterceptorClient::connect(addr).await.unwrap();
+        let (tx, mut rx) = mpsc::channel::<String>(16);
+
+        tokio::spawn(watch_interceptor_connection(
+            "toggle".to_string(),
+            client,
+            tx,
+        ));
+
+        healthy.store(false, Ordering::Relaxed);
+
+        tokio::time::sleep(Duration::from_secs(4)).await;
+        assert!(
+            rx.try_recv().is_err(),
+            "no reconnect notification while still unhealthy"
+        );
+
+        healthy.store(true, Ordering::Relaxed);
+
+        let notification = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+            .await
+            .expect("watcher should detect reconnect within timeout")
+            .expect("channel should not be closed");
+
+        assert_eq!(notification, "toggle");
+    }
+
+    #[tokio::test]
+    async fn watcher_does_not_notify_when_continuously_healthy() {
+        let healthy = Arc::new(AtomicBool::new(true));
+        let interceptor = ToggleInterceptor {
+            healthy: healthy.clone(),
+        };
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = format!("http://{}", listener.local_addr().unwrap());
+        let _server = tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(GatewayInterceptorServer::new(interceptor))
+                .serve_with_incoming(TcpListenerStream::new(listener))
+                .await
+                .unwrap();
+        });
+        tokio::task::yield_now().await;
+
+        let client = GatewayInterceptorClient::connect(addr).await.unwrap();
+        let (tx, mut rx) = mpsc::channel::<String>(16);
+
+        tokio::spawn(watch_interceptor_connection(
+            "stable".to_string(),
+            client,
+            tx,
+        ));
+
+        tokio::time::sleep(Duration::from_secs(6)).await;
+
+        assert!(
+            rx.try_recv().is_err(),
+            "no notification when interceptor stays healthy"
+        );
     }
 }

--- a/crates/openshell-server/src/interceptor_refresh.rs
+++ b/crates/openshell-server/src/interceptor_refresh.rs
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use metrics::counter;
+use tracing::{debug, info, warn};
+
+pub fn spawn_interceptor_refresh_worker(state: Arc<crate::ServerState>, interval: Duration) {
+    info!(
+        interval_seconds = interval.as_secs(),
+        "gateway interceptor refresh worker started"
+    );
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let Some(ref interceptors) = state.gateway_interceptors else {
+                continue;
+            };
+            match interceptors.refresh().await {
+                Ok(true) => {
+                    counter!("openshell_gateway_interceptor_refresh_total", "result" => "success")
+                        .increment(1);
+                    info!("gateway interceptor manifest refreshed with new bindings");
+                }
+                Ok(false) => {
+                    counter!("openshell_gateway_interceptor_refresh_total", "result" => "unchanged")
+                        .increment(1);
+                    debug!("gateway interceptor manifest unchanged");
+                }
+                Err(err) => {
+                    counter!("openshell_gateway_interceptor_refresh_total", "result" => "error")
+                        .increment(1);
+                    warn!(
+                        error = %err,
+                        "gateway interceptor manifest refresh failed; keeping previous plan"
+                    );
+                }
+            }
+        }
+    });
+}

--- a/crates/openshell-server/src/interceptor_refresh.rs
+++ b/crates/openshell-server/src/interceptor_refresh.rs
@@ -35,7 +35,12 @@ pub fn spawn_interceptor_refresh_worker(state: Arc<crate::ServerState>, poll_int
 
     for (name, client) in clients {
         let tx = tx.clone();
-        tokio::spawn(watch_interceptor_connection(name, client, tx));
+        tokio::spawn(watch_interceptor_connection(
+            name,
+            client,
+            tx,
+            poll_interval,
+        ));
     }
 
     let state = state.clone();
@@ -103,6 +108,7 @@ async fn watch_interceptor_connection(
     name: String,
     mut client: GatewayInterceptorClient<Channel>,
     tx: mpsc::Sender<String>,
+    healthy_probe_interval: Duration,
 ) {
     let mut connected = true;
     let mut backoff = RECONNECT_PROBE_INTERVAL;
@@ -110,7 +116,7 @@ async fn watch_interceptor_connection(
     loop {
         let sleep_duration = if connected {
             backoff = RECONNECT_PROBE_INTERVAL;
-            RECONNECT_BACKOFF_MAX
+            healthy_probe_interval
         } else {
             backoff
         };

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -509,10 +509,14 @@ pub(crate) async fn run_server(
         let refresh_secs = config
             .gateway_interceptor_refresh_interval_secs
             .unwrap_or(10);
-        interceptor_refresh::spawn_interceptor_refresh_worker(
-            state.clone(),
-            Duration::from_secs(refresh_secs),
-        );
+        if refresh_secs > 0 {
+            interceptor_refresh::spawn_interceptor_refresh_worker(
+                state.clone(),
+                Duration::from_secs(refresh_secs),
+            );
+        } else {
+            info!("gateway interceptor manifest refresh disabled (interval = 0)");
+        }
     }
 
     // Create the multiplexed service

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -34,6 +34,7 @@ mod gateway_listener;
 mod grpc;
 mod http;
 mod inference;
+mod interceptor_refresh;
 mod middleware;
 mod multiplex;
 mod otel_tracing;
@@ -167,7 +168,7 @@ pub struct ServerState {
     /// Gateway-wide gRPC request rate limiter shared by every multiplex path.
     pub(crate) grpc_rate_limiter: Option<multiplex::GrpcRateLimiter>,
 
-    /// Immutable gateway interceptor execution plan. `None` when disabled.
+    /// Gateway interceptor execution plan with hot-reload. `None` when disabled.
     pub(crate) gateway_interceptors:
         Option<openshell_gateway_interceptors::GatewayInterceptorRuntime>,
 
@@ -504,6 +505,15 @@ pub(crate) async fn run_server(
     ssh_sessions::spawn_session_reaper(store.clone(), Duration::from_secs(3600));
     supervisor_session::spawn_relay_reaper(state.clone(), Duration::from_secs(30));
     provider_refresh::spawn_refresh_worker(state.clone(), Duration::from_secs(60));
+    if state.gateway_interceptors.is_some() {
+        let refresh_secs = config
+            .gateway_interceptor_refresh_interval_secs
+            .unwrap_or(10);
+        interceptor_refresh::spawn_interceptor_refresh_worker(
+            state.clone(),
+            Duration::from_secs(refresh_secs),
+        );
+    }
 
     // Create the multiplexed service
     let service = MultiplexService::new(state.clone());

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -301,7 +301,7 @@ The gateway validates snapshot structure and provider-profile semantics. It trea
 
 `failure_policy` accepts `fail_closed` or `fail_open`. `timeout` accepts `ms` and `s` suffixes. In `dynamic` mode, binding overrides may select a manifest binding by `id`, `rpc`, or `service` plus `method`; they can disable a binding, narrow its phases, or override its failure policy.
 
-`interceptor_refresh_interval_secs` sets the periodic safety-net interval for re-fetching interceptor manifests. The gateway also monitors each interceptor channel and triggers an immediate refresh when a reconnection is detected (e.g., after an interceptor pod restart). Set to `0` to disable both the reconnect watcher and the periodic poll. Defaults to `10` when interceptors are configured.
+`interceptor_refresh_interval_secs` sets the periodic safety-net interval for re-fetching interceptor manifests. The gateway also monitors each interceptor channel every 2 seconds and triggers a manifest refresh when a reconnection is detected (e.g., after an interceptor pod restart). Set to `0` to disable both the reconnect watcher and the periodic poll. Defaults to `10` when interceptors are configured.
 
 ```toml
 [openshell.gateway]

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -301,6 +301,13 @@ The gateway validates snapshot structure and provider-profile semantics. It trea
 
 `failure_policy` accepts `fail_closed` or `fail_open`. `timeout` accepts `ms` and `s` suffixes. In `dynamic` mode, binding overrides may select a manifest binding by `id`, `rpc`, or `service` plus `method`; they can disable a binding, narrow its phases, or override its failure policy.
 
+`interceptor_refresh_interval_secs` sets the periodic safety-net interval for re-fetching interceptor manifests. The gateway also monitors each interceptor channel and triggers an immediate refresh when a reconnection is detected (e.g., after an interceptor pod restart). Set to `0` to disable both the reconnect watcher and the periodic poll. Defaults to `10` when interceptors are configured.
+
+```toml
+[openshell.gateway]
+interceptor_refresh_interval_secs = 30
+```
+
 `image_pull_policy` is intentionally not a shared gateway key. Kubernetes and Docker use `Always`, `IfNotPresent`, or `Never`. Podman uses `always`, `missing`, `never`, or `newer`. Set it inside the relevant driver table.
 
 ## Credential Drivers

--- a/mise.lock
+++ b/mise.lock
@@ -70,28 +70,6 @@ provenance = "github-attestations"
 version = "0.16.0"
 backend = "github:mozilla/sccache"
 
-[tools."github:mozilla/sccache".options]
-asset_pattern = "sccache-v*x86_64*linux*.tar.gz"
-
-[tools."github:mozilla/sccache"."platforms.linux-arm64"]
-checksum = "sha256:f73a5c39f96bb6ebb89cc7915cf182260d4cbf30765322c5e793d0fe8bd80784"
-url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060468"
-
-[tools."github:mozilla/sccache"."platforms.linux-x64"]
-checksum = "sha256:aec995a83ad3dff3d14b6314e08858b7b73d35ca85a5bcf3d3a9ec07dee35588"
-url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060682"
-
-[tools."github:mozilla/sccache"."platforms.macos-arm64"]
-checksum = "sha256:ded590cae2c72042c61178632906bef62d635fa20d45f8b22110a2241f430960"
-url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060416"
-
-[[tools."github:mozilla/sccache"]]
-version = "0.16.0"
-backend = "github:mozilla/sccache"
-
 [tools."github:mozilla/sccache"."platforms.linux-arm64"]
 checksum = "sha256:f73a5c39f96bb6ebb89cc7915cf182260d4cbf30765322c5e793d0fe8bd80784"
 url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-unknown-linux-musl.tar.gz"


### PR DESCRIPTION
## Summary

- Reconnect watcher now probes healthy channels every 2s (`RECONNECT_PROBE_INTERVAL`) instead of at the configurable `poll_interval`, so short interceptor outages are detected within seconds regardless of `interceptor_refresh_interval_secs`.
- Adds unit tests for the reconnect watcher: detection of disconnect→reconnect transitions and no spurious notifications when continuously healthy.
- Updates docs to accurately describe the 2s monitoring cadence.

## Related Issue

Refs #2667

## Changes

- `crates/openshell-server/src/interceptor_refresh.rs`: Removed `healthy_probe_interval` parameter from `watch_interceptor_connection`, hardcoded healthy probes to `RECONNECT_PROBE_INTERVAL`. Added two unit tests.
- `docs/reference/gateway-config.mdx`: Updated wording from "immediate refresh" to "monitors every 2 seconds".

## Testing

- `cargo test -p openshell-server --lib "watcher_detects"` — passes
- `cargo test -p openshell-server --lib "watcher_does_not"` — passes
- `cargo test -p openshell-gateway-interceptors refresh_tests` — passes (no regression)
- `cargo clippy -p openshell-server --lib -- -D warnings` — clean

## Checklist

- [x] Conventional commit format
- [x] Tests added
- [x] Docs updated
- [x] No secrets committed