### PR TITLE
fix(supervisor-network): canonicalize dot-segments before policy evaluation

### DIFF
--- a/crates/openshell-supervisor-network/src/l7/path.rs
+++ b/crates/openshell-supervisor-network/src/l7/path.rs
@@ -218,6 +218,20 @@ pub fn canonicalize_request_target(
     ))
 }
 
+/// Report whether a canonical path carries a `%2F` that survived
+/// canonicalization.
+///
+/// Callers that canonicalize before they know which endpoint config applies
+/// use this to re-check the result against the config that actually matched.
+///
+/// The test is exact: [`build_canonical_path`] emits the literal `%2F` only
+/// for the encoded-slash sentinel, and percent-encodes any other `%` byte as
+/// `%25`, so no `%2F` substring can reach the output by another route.
+#[must_use]
+pub fn canonical_path_has_encoded_slash(canonical_path: &str) -> bool {
+    canonical_path.contains("%2F")
+}
+
 // ---------------------------------------------------------------------------
 // Internals
 // ---------------------------------------------------------------------------
@@ -682,6 +696,35 @@ mod tests {
             canon_with("/repos/group%2fproject/issues", opts).unwrap(),
             "/repos/group%2Fproject/issues"
         );
+    }
+
+    #[test]
+    fn encoded_slash_detection_on_canonical_paths_is_exact() {
+        let opts = CanonicalizeOptions {
+            allow_encoded_slash: true,
+            ..CanonicalizeOptions::default()
+        };
+
+        // A surviving sentinel is detected.
+        let slug = canon_with("/repos/group%2fproject/issues", opts).unwrap();
+        assert_eq!(slug, "/repos/group%2Fproject/issues");
+        assert!(canonical_path_has_encoded_slash(&slug));
+
+        // Ordinary paths are not.
+        assert!(!canonical_path_has_encoded_slash(
+            &canon("/public/secret").unwrap()
+        ));
+
+        // A literal `%` in the input is re-emitted as `%25`, so it cannot
+        // fabricate a `%2F` substring — including when the input spells out
+        // `%252F`, which decodes to the three characters `%`, `2`, `F`.
+        let escaped = canon("/a/%252F/b").unwrap();
+        assert_eq!(escaped, "/a/%252F/b");
+        assert!(!canonical_path_has_encoded_slash(&escaped));
+
+        let percent = canon("/a/100%25/b").unwrap();
+        assert_eq!(percent, "/a/100%25/b");
+        assert!(!canonical_path_has_encoded_slash(&percent));
     }
 
     #[test]

--- a/crates/openshell-supervisor-network/src/l7/path.rs
+++ b/crates/openshell-supervisor-network/src/l7/path.rs
@@ -22,7 +22,11 @@
 //!   request-target, raw non-ASCII bytes, and paths that cannot be parsed
 //!   as origin-form.
 //! - Strip trailing `;params` from each segment by default (Tomcat-class
-//!   `;jsessionid` ACL-bypass mitigation).
+//!   `;jsessionid` ACL-bypass mitigation). Stripping happens *before*
+//!   dot-segment resolution so that `..;` cannot evade the traversal guard
+//!   and then revert to `..` on the way out.
+//! - Reject any `.`/`..` that survives to the end of canonicalization. The
+//!   policy engine trusts this function to have removed them.
 //! - Reject `%2F` (encoded slash) inside a segment by default. Operators
 //!   can opt in per-endpoint for APIs that rely on encoded slashes in
 //!   slugs.
@@ -44,6 +48,8 @@ pub enum CanonicalizeError {
     NonAscii,
     #[error("request-target's `..` segment would escape the path root")]
     TraversalAboveRoot,
+    #[error("request-target still contains a `.`/`..` segment after canonicalization")]
+    ResidualDotSegment,
     #[error("request-target exceeds the configured maximum length")]
     PathTooLong,
     #[error("request-target is not a valid origin-form path")]
@@ -172,9 +178,31 @@ pub fn canonicalize_request_target(
     //    with a real path separator.
     let decoded = percent_decode_with_sentinel(raw_path.as_bytes(), opts.allow_encoded_slash)?;
 
-    // 9. Split on literal `/` and resolve dot-segments.
+    // 9. Split on literal `/`, then strip `;params` *before* resolving
+    //    dot-segments. Stripping afterwards would let a `..;` segment slip
+    //    past the traversal guard (it is not byte-equal to `..`) and then
+    //    revert to a bare `..` during reconstruction.
     let segments = split_path_segments(&decoded);
+    let segments: Vec<&[u8]> = if opts.strip_path_parameters {
+        segments.into_iter().map(strip_path_parameters).collect()
+    } else {
+        segments
+    };
     let resolved = resolve_dot_segments(segments)?;
+
+    // 9b. Defense in depth: no `.`/`..` may survive canonicalization. The
+    //     policy engine trusts this function to have removed them, so a
+    //     residual dot-segment is always a bug or an attack. This also
+    //     catches a `..` hidden behind a `%2F` sentinel on endpoints that
+    //     opted into `allow_encoded_slash`, where the sentinel keeps the
+    //     dot-segment inside its segment and out of `resolve_dot_segments`.
+    for seg in &resolved {
+        for part in seg.split(|&b| b == ENCODED_SLASH_SENTINEL) {
+            if part == b".." || part == b"." {
+                return Err(CanonicalizeError::ResidualDotSegment);
+            }
+        }
+    }
 
     // 10. Reconstruct. Strip `;params` per segment if requested; re-encode
     //     any byte that must be percent-encoded in the pchar set.
@@ -238,6 +266,13 @@ fn percent_decode_with_sentinel(
     Ok(out)
 }
 
+/// Drop a trailing `;params` suffix from a single path segment.
+fn strip_path_parameters(seg: &[u8]) -> &[u8] {
+    seg.iter()
+        .position(|&b| b == b';')
+        .map_or(seg, |pos| &seg[..pos])
+}
+
 fn split_path_segments(decoded: &[u8]) -> Vec<&[u8]> {
     // decoded is guaranteed to start with `/`. Skip the leading `/` and
     // split on subsequent `/` bytes. The sentinel byte for encoded slashes
@@ -286,10 +321,7 @@ fn build_canonical_path(
             out.push('/');
         }
         let trimmed: &[u8] = if opts.strip_path_parameters {
-            match seg.iter().position(|&b| b == b';') {
-                Some(pos) => &seg[..pos],
-                None => seg,
-            }
+            strip_path_parameters(seg)
         } else {
             seg
         };
@@ -581,5 +613,96 @@ mod tests {
     #[test]
     fn regression_dot_slash_dotdot() {
         assert_eq!(canon("/public/./../secret").unwrap(), "/secret");
+    }
+
+    // ---------------------------------------------------------------------
+    // A `;params` suffix on the dot segment itself must not let the segment
+    // slip past the traversal guard. Stripping used to run after dot-segment
+    // resolution, so `..;` was not byte-equal to `..` when the guard looked
+    // at it, and reverted to a bare `..` during reconstruction — handing the
+    // policy engine and the upstream a path that still escaped its prefix.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn regression_dotdot_with_path_parameter_is_resolved_not_smuggled() {
+        assert_eq!(canon("/public/..;/secret").unwrap(), "/secret");
+        assert_eq!(canon("/public/..;x/secret").unwrap(), "/secret");
+        assert_eq!(
+            canon("/public/..;jsessionid=xyz/secret").unwrap(),
+            "/secret"
+        );
+        assert_eq!(canon("/public/.;/secret").unwrap(), "/public/secret");
+        assert_eq!(canon("/public/.;x/secret").unwrap(), "/public/secret");
+    }
+
+    #[test]
+    fn regression_percent_encoded_dotdot_with_path_parameter() {
+        // `%2e%2e;` and `..%3B` both decode to `..;` before segmentation.
+        assert_eq!(canon("/public/%2e%2e;/secret").unwrap(), "/secret");
+        assert_eq!(canon("/public/..%3B/secret").unwrap(), "/secret");
+        assert_eq!(canon("/public/..%3b/secret").unwrap(), "/secret");
+    }
+
+    #[test]
+    fn regression_chained_dotdot_with_path_parameters_hits_root_guard() {
+        assert_eq!(
+            canon("/public/..;/..;/secret"),
+            Err(CanonicalizeError::TraversalAboveRoot)
+        );
+        assert_eq!(
+            canon("/api/v1/..;/..;/..;/admin/keys"),
+            Err(CanonicalizeError::TraversalAboveRoot)
+        );
+        assert_eq!(canon("/..;"), Err(CanonicalizeError::TraversalAboveRoot));
+    }
+
+    #[test]
+    fn regression_dotdot_behind_encoded_slash_is_rejected_when_opted_in() {
+        // With `allow_encoded_slash`, the `%2F` sentinel keeps the dot-segment
+        // inside its segment, so `resolve_dot_segments` never sees it. The
+        // residual guard is what closes this.
+        let opts = CanonicalizeOptions {
+            allow_encoded_slash: true,
+            ..CanonicalizeOptions::default()
+        };
+        assert_eq!(
+            canon_with("/public/..%2fsecret", opts),
+            Err(CanonicalizeError::ResidualDotSegment)
+        );
+        assert_eq!(
+            canon_with("/public/..%2f..%2fsecret", opts),
+            Err(CanonicalizeError::ResidualDotSegment)
+        );
+        assert_eq!(
+            canon_with("/public/.%2fsecret", opts),
+            Err(CanonicalizeError::ResidualDotSegment)
+        );
+        // A legitimate encoded-slash slug still round-trips.
+        assert_eq!(
+            canon_with("/repos/group%2fproject/issues", opts).unwrap(),
+            "/repos/group%2Fproject/issues"
+        );
+    }
+
+    #[test]
+    fn canonical_output_never_contains_dot_segments() {
+        // The contract the policy engine relies on: whatever comes back is
+        // free of `.`/`..`, so rego never has to defend against them.
+        for target in [
+            "/public/..;/secret",
+            "/public/.;/secret",
+            "/public/%2e%2e;/secret",
+            "/a;jsessionid=xyz/b",
+            "/public//../secret",
+            "/a/b/..",
+            "/a/b/.",
+        ] {
+            if let Ok(path) = canon(target) {
+                assert!(
+                    !path.split('/').any(|seg| seg == ".." || seg == "."),
+                    "{target} canonicalized to {path}, which still has a dot-segment"
+                );
+            }
+        }
     }
 }

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -569,14 +569,20 @@ where
         // on this host:port. Re-check it against the config that actually
         // matched: the opt-in is per-endpoint, and one endpoint enabling it
         // must not loosen parsing for the others.
+        // Check `req.target`, not `route_target`: redaction percent-decodes any
+        // segment holding a credential placeholder and re-inserts the redacted
+        // form without re-encoding, so a `%2F` sharing that segment becomes a
+        // literal `/` and would escape this check.
         if !config.allow_encoded_slash
-            && crate::l7::path::canonical_path_has_encoded_slash(&route_target)
+            && crate::l7::path::canonical_path_has_encoded_slash(&req.target)
         {
+            let detail = "request-target contains an encoded '/' (%2F) which is not allowed on this endpoint";
+            emit_parse_rejection(ctx, detail, engine_type_for_protocol(config.protocol));
             crate::l7::rest::RestProvider::default()
                 .deny_with_redacted_target(
                     &req,
                     &ctx.policy_name,
-                    "request-target contains an encoded '/' (%2F) which is not allowed on this endpoint",
+                    detail,
                     client,
                     None,
                     Some(crate::l7::rest::DenyResponseContext::from_l7_context(ctx)),
@@ -6184,7 +6190,11 @@ network_policies:
             .clone_engine_for_tunnel(engine.current_generation())
             .unwrap();
         let configs = encoded_slash_scoping_configs();
-        let ctx = encoded_slash_scoping_ctx();
+        let (activity_tx, mut activity_rx) = tokio::sync::mpsc::channel(1);
+        let ctx = L7EvalContext {
+            activity_tx: Some(activity_tx),
+            ..encoded_slash_scoping_ctx()
+        };
 
         let (mut app, mut relay_client) = tokio::io::duplex(8192);
         let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
@@ -6215,6 +6225,85 @@ network_policies:
         assert!(
             response.contains("not allowed on this endpoint"),
             "denial must name the encoded-slash reason: {response}"
+        );
+
+        let mut upstream_bytes = [0u8; 16];
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            upstream.read(&mut upstream_bytes),
+        )
+        .await;
+        assert!(
+            matches!(result, Err(_) | Ok(Ok(0))),
+            "request must not reach upstream"
+        );
+        let activity = tokio::time::timeout(std::time::Duration::from_secs(1), activity_rx.recv())
+            .await
+            .expect("parse rejection activity should be emitted")
+            .expect("activity channel should remain open");
+        assert!(activity.denied);
+        assert_eq!(activity.deny_group, "l7_parse_rejection");
+
+        drop(app);
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should finish")
+            .unwrap()
+            .unwrap();
+    }
+
+    /// Credential redaction percent-decodes any segment holding a placeholder
+    /// and re-inserts the redacted form without re-encoding it. A `%2F` sharing
+    /// that segment therefore becomes a literal `/` in the redacted target, so
+    /// the scoping check must read the canonical target rather than the
+    /// redacted one — otherwise a placeholder is enough to smuggle an encoded
+    /// slash past an endpoint that never opted in.
+    #[tokio::test]
+    async fn route_selected_encoded_slash_check_survives_credential_redaction() {
+        let engine = OpaEngine::from_strings(TEST_POLICY, ENCODED_SLASH_SCOPING_POLICY).unwrap();
+        let tunnel_engine = engine
+            .clone_engine_for_tunnel(engine.current_generation())
+            .unwrap();
+        let configs = encoded_slash_scoping_configs();
+        let (child_env, resolver) = SecretResolver::from_provider_env(
+            std::iter::once(("TOKEN".to_string(), "real-token".to_string())).collect(),
+        );
+        let placeholder = child_env.get("TOKEN").expect("placeholder env").clone();
+        let ctx = L7EvalContext {
+            secret_resolver: resolver.map(Arc::new),
+            ..encoded_slash_scoping_ctx()
+        };
+
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_with_route_selection(
+                &configs,
+                tunnel_engine,
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+            )
+            .await
+        });
+
+        // Placeholder and encoded slash in the same segment, on the endpoint
+        // that did NOT opt into encoded slashes.
+        let request = format!(
+            "GET /admin/{placeholder}%2Fx HTTP/1.1\r\nHost: gateway.example.test\r\nConnection: close\r\n\r\n"
+        );
+        app.write_all(request.as_bytes()).await.unwrap();
+
+        let mut response = [0u8; 1024];
+        let n = tokio::time::timeout(std::time::Duration::from_secs(1), app.read(&mut response))
+            .await
+            .expect("denial should reach client")
+            .unwrap();
+        let response = String::from_utf8_lossy(&response[..n]);
+        assert!(response.contains("403 Forbidden"), "{response}");
+        assert!(
+            response.contains("not allowed on this endpoint"),
+            "redaction must not hide the encoded slash: {response}"
         );
 
         let mut upstream_bytes = [0u8; 16];

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -564,6 +564,26 @@ where
                 .await?;
             return Ok(());
         };
+        // The request was canonicalized before the matching config was known,
+        // so `allow_encoded_slash` was taken permissively across every config
+        // on this host:port. Re-check it against the config that actually
+        // matched: the opt-in is per-endpoint, and one endpoint enabling it
+        // must not loosen parsing for the others.
+        if !config.allow_encoded_slash
+            && crate::l7::path::canonical_path_has_encoded_slash(&route_target)
+        {
+            crate::l7::rest::RestProvider::default()
+                .deny_with_redacted_target(
+                    &req,
+                    &ctx.policy_name,
+                    "request-target contains an encoded '/' (%2F) which is not allowed on this endpoint",
+                    client,
+                    None,
+                    Some(crate::l7::rest::DenyResponseContext::from_l7_context(ctx)),
+                )
+                .await?;
+            return Ok(());
+        }
         if deny_h2c_upgrade_if_requested(&req, config, ctx, client).await? {
             return Ok(());
         }
@@ -6084,6 +6104,186 @@ network_policies:
             .expect("relay should finish")
             .unwrap()
             .unwrap();
+    }
+
+    /// Policy allowing GET on both `/repos/**` and `/admin/**` for the same
+    /// host:port, so an encoded-slash denial can only come from the
+    /// per-endpoint `allow_encoded_slash` scoping.
+    const ENCODED_SLASH_SCOPING_POLICY: &str = r#"
+network_policies:
+  route_api:
+    name: route_api
+    endpoints:
+      - host: gateway.example.test
+        port: 443
+        path: /repos/**
+        protocol: rest
+        enforcement: enforce
+        allow_encoded_slash: true
+        rules:
+          - allow:
+              method: GET
+              path: "/repos/**"
+      - host: gateway.example.test
+        port: 443
+        path: /admin/**
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow:
+              method: GET
+              path: "/admin/**"
+    binaries:
+      - { path: /usr/bin/node }
+"#;
+
+    fn encoded_slash_scoping_configs() -> Vec<L7EndpointConfig> {
+        let rest = |path: &str, allow_encoded_slash: bool| L7EndpointConfig {
+            protocol: L7Protocol::Rest,
+            path: path.into(),
+            tls: crate::l7::TlsMode::Auto,
+            enforcement: EnforcementMode::Enforce,
+            graphql_max_body_bytes: 0,
+            json_rpc_max_body_bytes: crate::l7::jsonrpc::DEFAULT_MAX_BODY_BYTES,
+            mcp_strict_tool_names: true,
+            allow_encoded_slash,
+            websocket_credential_rewrite: false,
+            request_body_credential_rewrite: false,
+            websocket_graphql_policy: false,
+            credential_signing: crate::l7::CredentialSigning::None,
+            signing_service: String::new(),
+            signing_region: String::new(),
+        };
+        // One endpoint opts in, the other does not.
+        vec![rest("/repos/**", true), rest("/admin/**", false)]
+    }
+
+    fn encoded_slash_scoping_ctx() -> L7EvalContext {
+        L7EvalContext {
+            host: "gateway.example.test".into(),
+            port: 443,
+            request_default_port: Some(443),
+            policy_name: "route_api".into(),
+            binary_path: "/usr/bin/node".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+            secret_resolver: None,
+            ..Default::default()
+        }
+    }
+
+    /// Canonicalization runs before the matching config is known, so
+    /// `allow_encoded_slash` is taken permissively across the whole
+    /// host:port. The endpoint that did *not* opt in must still reject a
+    /// `%2F`, otherwise one endpoint's opt-in silently loosens every other
+    /// endpoint sharing that host:port.
+    #[tokio::test]
+    async fn route_selected_encoded_slash_optin_does_not_leak_to_other_endpoints() {
+        let engine = OpaEngine::from_strings(TEST_POLICY, ENCODED_SLASH_SCOPING_POLICY).unwrap();
+        let tunnel_engine = engine
+            .clone_engine_for_tunnel(engine.current_generation())
+            .unwrap();
+        let configs = encoded_slash_scoping_configs();
+        let ctx = encoded_slash_scoping_ctx();
+
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_with_route_selection(
+                &configs,
+                tunnel_engine,
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+            )
+            .await
+        });
+
+        app.write_all(
+            b"GET /admin/x%2Fy HTTP/1.1\r\nHost: gateway.example.test\r\nConnection: close\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        let mut response = [0u8; 1024];
+        let n = tokio::time::timeout(std::time::Duration::from_secs(1), app.read(&mut response))
+            .await
+            .expect("denial should reach client")
+            .unwrap();
+        let response = String::from_utf8_lossy(&response[..n]);
+        assert!(response.contains("403 Forbidden"), "{response}");
+        assert!(
+            response.contains("not allowed on this endpoint"),
+            "denial must name the encoded-slash reason: {response}"
+        );
+
+        let mut upstream_bytes = [0u8; 16];
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            upstream.read(&mut upstream_bytes),
+        )
+        .await;
+        assert!(
+            matches!(result, Err(_) | Ok(Ok(0))),
+            "request must not reach upstream"
+        );
+
+        drop(app);
+        tokio::time::timeout(std::time::Duration::from_secs(1), relay)
+            .await
+            .expect("relay should finish")
+            .unwrap()
+            .unwrap();
+    }
+
+    /// The converse: tightening the scope must not break the endpoint that
+    /// legitimately opted in. A GitLab-style encoded slug still reaches the
+    /// upstream verbatim.
+    #[tokio::test]
+    async fn route_selected_encoded_slash_still_allowed_on_opted_in_endpoint() {
+        let engine = OpaEngine::from_strings(TEST_POLICY, ENCODED_SLASH_SCOPING_POLICY).unwrap();
+        let tunnel_engine = engine
+            .clone_engine_for_tunnel(engine.current_generation())
+            .unwrap();
+        let configs = encoded_slash_scoping_configs();
+        let ctx = encoded_slash_scoping_ctx();
+
+        let (mut app, mut relay_client) = tokio::io::duplex(8192);
+        let (mut relay_upstream, mut upstream) = tokio::io::duplex(8192);
+        let relay = tokio::spawn(async move {
+            relay_with_route_selection(
+                &configs,
+                tunnel_engine,
+                &mut relay_client,
+                &mut relay_upstream,
+                &ctx,
+            )
+            .await
+        });
+
+        app.write_all(
+            b"GET /repos/group%2Fproject HTTP/1.1\r\nHost: gateway.example.test\r\nConnection: close\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+        let mut upstream_bytes = [0u8; 512];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            upstream.read(&mut upstream_bytes),
+        )
+        .await
+        .expect("opted-in request should reach upstream")
+        .unwrap();
+        let forwarded = String::from_utf8_lossy(&upstream_bytes[..n]);
+        assert!(
+            forwarded.contains("GET /repos/group%2Fproject "),
+            "encoded slug must be forwarded verbatim: {forwarded}"
+        );
+
+        drop(app);
+        drop(upstream);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(1), relay).await;
     }
 
     #[tokio::test]

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -4448,6 +4448,39 @@ async fn handle_forward_proxy(
             .await?;
             return Ok(());
         };
+        // `canonicalize_options` was built before the matching config was
+        // known, so `allow_encoded_slash` was taken permissively across every
+        // config on this route. Re-check it against the config that actually
+        // matched: the opt-in is per-endpoint, and one endpoint enabling it
+        // must not loosen parsing for the others. Rejecting here yields the
+        // same response the parser would have produced had the option been
+        // scoped correctly from the start.
+        if !l7_config.config.allow_encoded_slash
+            && crate::l7::path::canonical_path_has_encoded_slash(&path)
+        {
+            let event = NetworkActivityBuilder::new(openshell_ocsf::ctx::ctx())
+                .activity(ActivityId::Fail)
+                .severity(SeverityId::Medium)
+                .status(StatusId::Failure)
+                .dst_endpoint(Endpoint::from_domain(&host_lc, port))
+                .message(
+                    "FORWARD rejecting non-canonical request-target: request-target contains an encoded '/' (%2F) which is not allowed on this endpoint".to_string(),
+                )
+                .build();
+            ocsf_emit!(event);
+            emit_activity_simple(activity_tx, true, "forward_parse_rejection");
+            respond(
+                client,
+                &build_json_error_response(
+                    400,
+                    "Bad Request",
+                    "invalid_request_target",
+                    "request-target must be canonical",
+                ),
+            )
+            .await?;
+            return Ok(());
+        }
         if crate::l7::rest::request_is_h2c_upgrade(&forward_request_bytes) {
             let event = HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
                 .activity(ActivityId::Other)

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -59,6 +59,8 @@ const TUNNEL_PROTOCOL_PEEK_POLL: std::time::Duration = std::time::Duration::from
 const TUNNEL_PROTOCOL_PEEK_POLL: std::time::Duration = std::time::Duration::from_millis(1);
 const INFERENCE_LOCAL_HOST: &str = "inference.local";
 const INFERENCE_LOCAL_PORT: u16 = 443;
+const FORWARD_ENCODED_SLASH_REJECTION_DETAIL: &str =
+    "request-target contains an encoded '/' (%2F) which is not allowed on this endpoint";
 #[cfg(target_os = "linux")]
 const SIDECAR_SUPERVISOR_TOPOLOGY: &str = "sidecar";
 
@@ -905,6 +907,41 @@ fn build_forward_parse_error_ocsf_event(path: &str) -> openshell_ocsf::OcsfEvent
         .severity(SeverityId::Low)
         .status(StatusId::Failure)
         .message(format!("FORWARD parse error for {path}"))
+        .build()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_forward_l7_parse_rejection_ocsf_event(
+    peer_addr: SocketAddr,
+    method: &str,
+    host: &str,
+    port: u16,
+    path: &str,
+    binary: &str,
+    pid: &str,
+    ancestors: &str,
+    cmdline: &str,
+    policy: &str,
+    detail: &str,
+) -> openshell_ocsf::OcsfEvent {
+    HttpActivityBuilder::new(openshell_ocsf::ctx::ctx())
+        .activity(ActivityId::Other)
+        .action(ActionId::Denied)
+        .disposition(DispositionId::Blocked)
+        .severity(SeverityId::Medium)
+        .status(StatusId::Failure)
+        .http_request(HttpRequest::new(
+            method,
+            OcsfUrl::new("http", host, path, port),
+        ))
+        .dst_endpoint(Endpoint::from_domain(host, port))
+        .src_endpoint(Endpoint::from_ip(peer_addr.ip(), peer_addr.port()))
+        .actor_process(Process::from_bypass(binary, pid, ancestors).with_cmd_line(cmdline))
+        .firewall_rule(policy, "l7")
+        .message(format!(
+            "FORWARD_L7 denied non-canonical request-target for {method} {host}:{port}{path}"
+        ))
+        .status_detail(detail)
         .build()
 }
 
@@ -4458,16 +4495,19 @@ async fn handle_forward_proxy(
         if !l7_config.config.allow_encoded_slash
             && crate::l7::path::canonical_path_has_encoded_slash(&path)
         {
-            let event = NetworkActivityBuilder::new(openshell_ocsf::ctx::ctx())
-                .activity(ActivityId::Fail)
-                .severity(SeverityId::Medium)
-                .status(StatusId::Failure)
-                .dst_endpoint(Endpoint::from_domain(&host_lc, port))
-                .message(
-                    "FORWARD rejecting non-canonical request-target: request-target contains an encoded '/' (%2F) which is not allowed on this endpoint".to_string(),
-                )
-                .build();
-            ocsf_emit!(event);
+            ocsf_emit!(build_forward_l7_parse_rejection_ocsf_event(
+                workload_addr,
+                method,
+                &host_lc,
+                port,
+                &telemetry_path,
+                &binary_str,
+                &pid_str,
+                &ancestors_str,
+                &cmdline_str,
+                policy_str,
+                FORWARD_ENCODED_SLASH_REJECTION_DETAIL,
+            ));
             emit_activity_simple(activity_tx, true, "forward_parse_rejection");
             respond(
                 client,
@@ -5643,6 +5683,42 @@ network_policies: {}
         assert_eq!(json["status_detail"], reason);
         assert_eq!(json["action"], "Denied");
         assert_eq!(json["disposition"], "Blocked");
+    }
+
+    #[test]
+    fn forward_l7_parse_rejection_ocsf_includes_denial_context() {
+        let event = build_forward_l7_parse_rejection_ocsf_event(
+            "127.0.0.1:45123".parse().unwrap(),
+            "GET",
+            "api.example.com",
+            80,
+            "/admin/x%2Fy",
+            "/usr/bin/curl",
+            "42",
+            "/usr/bin/bash",
+            "curl http://api.example.com/admin/x%2Fy",
+            "allow_api",
+            FORWARD_ENCODED_SLASH_REJECTION_DETAIL,
+        );
+        let json = event.to_json().unwrap();
+
+        assert_eq!(json["class_name"], "HTTP Activity");
+        assert_eq!(json["activity_name"], "Other");
+        assert_eq!(json["action"], "Denied");
+        assert_eq!(json["disposition"], "Blocked");
+        assert_eq!(json["severity"], "Medium");
+        assert_eq!(json["status"], "Failure");
+        assert_eq!(json["http_request"]["http_method"], "GET");
+        assert_eq!(json["http_request"]["url"]["path"], "/admin/x%2Fy");
+        assert_eq!(json["dst_endpoint"]["domain"], "api.example.com");
+        assert_eq!(json["dst_endpoint"]["port"], 80);
+        assert_eq!(json["actor"]["process"]["name"], "/usr/bin/curl");
+        assert_eq!(json["firewall_rule"]["name"], "allow_api");
+        assert_eq!(json["firewall_rule"]["type"], "l7");
+        assert_eq!(
+            json["status_detail"],
+            FORWARD_ENCODED_SLASH_REJECTION_DETAIL
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The L7 request-target canonicalizer could return a path that still contained a `.`/`..` segment. Since that canonical path is simultaneously the OPA policy input and the bytes forwarded upstream, a residual dot-segment let a request escape the path prefix its policy allowed. This PR fixes the ordering that produced it, adds a defense-in-depth guard, and scopes the `allow_encoded_slash` opt-in to the endpoint that actually matched.

## Related Issue

No issue required: security fix. Per [SECURITY.md](../blob/main/SECURITY.md)

## Changes

**`fix(supervisor-network): strip path parameters before dot-segment resolution`**

- `canonicalize_request_target` stripped `;params` *after* resolving dot-segments. A dot segment carrying a path parameter was therefore not byte-equal to `..` when the traversal guard inspected it, and reverted to a bare `..` during reconstruction. Stripping now runs first.
- Added a residual guard: any `.`/`..` surviving canonicalization is rejected with a new `CanonicalizeError::ResidualDotSegment`. This also covers a dot-segment held inside a segment by the `%2F` sentinel on endpoints that opted into `allow_encoded_slash`.
- Extracted `strip_path_parameters` and reused it in `build_canonical_path`.
- Module docs updated to state the ordering requirement and the no-residual-dot-segment invariant the policy engine relies on.

**`fix(supervisor-network): scope allow_encoded_slash to the matched L7 endpoint`**

- Both multi-config L7 paths computed `allow_encoded_slash` with `.any()` across every config sharing a `host:port`, because canonicalization runs before the matching config is known. One endpoint opting in loosened path parsing for every other endpoint on that host — contrary to the per-endpoint opt-in that the passthrough path documents.
- After config selection, the canonical path is re-checked against the config that actually matched (`l7/relay.rs` and `proxy.rs`). A surviving `%2F` is rejected when that config did not opt in. The rejection mirrors the parser's own response, so a correctly-scoped request is indistinguishable from one rejected at parse time.
- New `canonical_path_has_encoded_slash` helper. The check is exact: `build_canonical_path` emits a literal `%2F` only for the sentinel and percent-encodes any other `%` as `%25`.

## Testing

`mise run ci` green (lint + compile + tests). 31 tests in `l7::path`, all 25 pre-existing ones unchanged and passing.

- Unit tests for the ordering fix: `;` on the dot segment (`..;`, `..;x`, `..;jsessionid=…`, `.;`), percent-encoded forms (`%2e%2e;`, `..%3B`, `..%3b`), chained traversal hitting the root guard, and `..` behind a `%2F` sentinel under the opt-in.
- An invariant test asserting no canonical output ever contains a dot-segment.
- An exactness test for the encoded-slash helper, including `%252F`, which decodes to the three characters `%`, `2`, `F` and must not be mistaken for a sentinel.
- Relay integration tests driving the real `relay_with_route_selection` with two endpoints on one `host:port` — one opted into `allow_encoded_slash`, one not — asserting the non-opted-in endpoint rejects `%2F` without reaching upstream, and that the opted-in endpoint still forwards an encoded slug verbatim.

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)

### Notes for reviewers

- **Behavior change:** request-targets that previously canonicalized successfully are now rejected — `..;`-style targets, and `%2F` on an endpoint that did not itself opt in. Both were only reachable through non-canonical input, but operators relying on the accidental cross-endpoint `%2F` leniency will see 4xx where they previously saw traffic pass.
- **Out of scope, deliberately:** a `%2F` in an early segment can still change *which* config matches (`/admin%2Fx` does not match a `/admin/**` subtree). That fails closed — no match means denial — and fixing it means revisiting route matching itself.
- **Unrelated flake observed:** `proxy::tests::forward_handler_preserves_ssrf_response_and_denial_stage` failed once during this work and passed on re-run. It is unreachable from these changes (the SSRF denial returns well before L7 config selection), but it looks intermittent and probably deserves its own issue.
