### PR TITLE
feat(server): make the Postgres pool ceiling configurable

### DIFF
--- a/crates/openshell-server/src/persistence/postgres.rs
+++ b/crates/openshell-server/src/persistence/postgres.rs
@@ -25,10 +25,43 @@ pub struct PostgresStore {
     pool: PgPool,
 }
 
+/// Default pool ceiling, unchanged from the previously hardcoded value.
+const DEFAULT_MAX_CONNECTIONS: u32 = 10;
+
+/// Pool ceiling for the Postgres store.
+///
+/// A fixed ceiling makes the pool the throughput limit under concurrent
+/// sandbox creation: once every connection is checked out, callers queue on
+/// `acquire` and sqlx logs `time to acquire exceeded slow threshold`. The
+/// right ceiling depends on the deployment — how many gateway replicas share
+/// the server, and what `max_connections` the server itself allows — so it
+/// cannot be one number baked into the binary. See NVIDIA/OpenShell#2561.
+///
+/// Falls back to the default when unset, unparseable, or zero, so a typo
+/// degrades to today's behaviour instead of crash-looping the gateway.
+fn max_connections() -> u32 {
+    let Ok(raw) = std::env::var("OPENSHELL_DB_MAX_CONNECTIONS") else {
+        return DEFAULT_MAX_CONNECTIONS;
+    };
+    match raw.trim().parse::<u32>() {
+        Ok(n) if n > 0 => n,
+        _ => {
+            tracing::warn!(
+                value = %raw,
+                default = DEFAULT_MAX_CONNECTIONS,
+                "OPENSHELL_DB_MAX_CONNECTIONS is not a positive integer; using the default"
+            );
+            DEFAULT_MAX_CONNECTIONS
+        }
+    }
+}
+
 impl PostgresStore {
     pub async fn connect(url: &str) -> PersistenceResult<Self> {
+        let max_connections = max_connections();
+        tracing::info!(max_connections, "connecting Postgres store");
         let pool = PgPoolOptions::new()
-            .max_connections(10)
+            .max_connections(max_connections)
             .connect(url)
             .await
             .map_err(|e| map_db_error(&e))?;
@@ -1023,4 +1056,69 @@ fn row_to_draft_chunk_record(row: sqlx::postgres::PgRow) -> PersistenceResult<Dr
         created_at_ms,
         updated_at_ms,
     )
+}
+
+#[cfg(test)]
+mod max_connections_tests {
+    use super::{DEFAULT_MAX_CONNECTIONS, max_connections};
+
+    const KEY: &str = "OPENSHELL_DB_MAX_CONNECTIONS";
+
+    struct EnvVarGuard(Option<String>);
+
+    impl EnvVarGuard {
+        #[allow(unsafe_code)]
+        fn set(value: Option<&str>) -> Self {
+            let original = std::env::var(KEY).ok();
+            // SAFETY: tests serialize environment mutation with TEST_ENV_LOCK.
+            match value {
+                Some(v) => unsafe { std::env::set_var(KEY, v) },
+                None => unsafe { std::env::remove_var(KEY) },
+            }
+            Self(original)
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        #[allow(unsafe_code)]
+        fn drop(&mut self) {
+            // SAFETY: tests serialize environment mutation with TEST_ENV_LOCK.
+            match self.0.as_deref() {
+                Some(v) => unsafe { std::env::set_var(KEY, v) },
+                None => unsafe { std::env::remove_var(KEY) },
+            }
+        }
+    }
+
+    fn with_env(value: Option<&str>) -> u32 {
+        let _lock = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _env = EnvVarGuard::set(value);
+        max_connections()
+    }
+
+    #[test]
+    fn unset_keeps_the_previous_hardcoded_ceiling() {
+        assert_eq!(with_env(None), DEFAULT_MAX_CONNECTIONS);
+    }
+
+    #[test]
+    fn a_positive_integer_overrides_the_ceiling() {
+        assert_eq!(with_env(Some("64")), 64);
+        assert_eq!(with_env(Some("  32  ")), 32);
+    }
+
+    #[test]
+    fn unusable_values_fall_back_rather_than_crash_looping() {
+        // A typo must not take the gateway down on startup, and zero would
+        // deadlock every acquire.
+        for bad in ["", "0", "-5", "many", "10.5"] {
+            assert_eq!(
+                with_env(Some(bad)),
+                DEFAULT_MAX_CONNECTIONS,
+                "input {bad:?}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`PostgresStore::connect` hardcodes `max_connections(10)`. This makes the pool the throughput ceiling under concurrent sandbox creation, and it cannot be tuned without rebuilding the gateway.

`OPENSHELL_DB_MAX_CONNECTIONS` now sets it, defaulting to 10 so existing deployments are unchanged.

## Related Issue

Refs #2561.

## Changes

- `max_connections()` reads `OPENSHELL_DB_MAX_CONNECTIONS`, falling back to the previous hardcoded 10.
- Unset, unparseable, negative and zero all fall back to the default: a typo should degrade to today's behaviour rather than crash-loop the gateway, and zero would deadlock every `acquire`.
- The chosen ceiling is logged at startup, so the effective value is visible rather than inferred.

Matches the existing convention in this crate — `std::env::var("OPENSHELL_*")` read directly, as `compute/driver_config.rs` and `compute/lease.rs` already do. Threading a parameter through `Store::connect` was avoided because it has ~10 call sites, nearly all tests.

## Testing

`cargo test -p openshell-server --lib max_connections_tests` — 3 new tests: default when unset, override honoured (including surrounding whitespace), and each unusable input falling back rather than panicking. `mise run pre-commit` passes.

## Field evidence

Measured on a 1,000-sandbox load test against a gateway on SQLite (pool 5), where the pool was unambiguously the constraint:

```
WARN sqlx::pool::acquire: acquired connection, but time to acquire exceeded
     slow threshold  aquired_after_secs=9.30  slow_acquire_threshold_secs=2.0
```

42 of 1,000 forwarders reached ready after 40 minutes, and the retries became load in their own right — 1,552 sandbox pods for 1,000 requested.

For balance: the same 1,000-sandbox test against **Postgres** at the stock ceiling of 10 produced exactly **one** slow-acquire (at startup), zero pool timeouts and 527m gateway CPU. So on Postgres the current default holds well at that scale — this change is about removing a fixed ceiling that cannot be tuned as fleets grow, not about a default that is wrong today.

## Checklist

- [x] Conventional commit, signed off (DCO)
- [x] Default behaviour unchanged
- [x] Unit tests added
- [x] `mise run pre-commit` passes