### PR TITLE
feat(auth): grant platform admin by OIDC subject in gateway config

### DIFF
--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -554,9 +554,9 @@ pub struct OidcConfig {
     /// privileges regardless of their JWT role claims. Works alongside
     /// `admin_role` — either mechanism grants admin access.
     ///
-    /// This is a no-op in auth-only mode (when both `admin_role` and
-    /// `user_role` are empty), because every authenticated user is already
-    /// a platform admin in that mode.
+    /// When `admin_subjects` is set but `admin_role` and `user_role` are
+    /// empty, only listed subjects receive Platform Admin — overriding the
+    /// default auth-only behavior where every authenticated user is admin.
     #[serde(default)]
     pub admin_subjects: Vec<String>,
 }

--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -549,6 +549,16 @@ pub struct OidcConfig {
     /// Keycloak: `scope` (space-delimited string). Okta: `scp` (JSON array).
     #[serde(default)]
     pub scopes_claim: String,
+
+    /// OIDC subjects (`sub` claim values) that are granted Platform Admin
+    /// privileges regardless of their JWT role claims. Works alongside
+    /// `admin_role` — either mechanism grants admin access.
+    ///
+    /// This is a no-op in auth-only mode (when both `admin_role` and
+    /// `user_role` are empty), because every authenticated user is already
+    /// a platform admin in that mode.
+    #[serde(default)]
+    pub admin_subjects: Vec<String>,
 }
 
 /// mTLS user authentication for local, single-user gateways.

--- a/crates/openshell-server/src/auth/authz.rs
+++ b/crates/openshell-server/src/auth/authz.rs
@@ -12,6 +12,8 @@
 //! authentication is handled by explicit application-layer authenticators,
 //! authorization is a gateway concern.
 
+use std::collections::HashSet;
+
 use super::identity::Identity;
 use super::{descriptor_authz, method_authz};
 use tonic::Status;
@@ -35,6 +37,8 @@ pub struct AuthzPolicy {
     pub user_role: String,
     /// When true, enforce scope-based permissions on top of roles.
     pub scopes_enabled: bool,
+    /// OIDC subjects granted Platform Admin regardless of roles.
+    pub admin_subjects: HashSet<String>,
 }
 
 impl AuthzPolicy {
@@ -83,10 +87,12 @@ impl AuthzPolicy {
             && !required.is_empty()
         {
             // Admin role implicitly satisfies user role requirements.
+            // Admin subjects also implicitly satisfy any role requirement.
             let has_role = identity.roles.iter().any(|r| r == required)
                 || (!self.admin_role.is_empty()
                     && required == &self.user_role
-                    && identity.roles.iter().any(|r| r == &self.admin_role));
+                    && identity.roles.iter().any(|r| r == &self.admin_role))
+                || self.admin_subjects.contains(&identity.subject);
 
             if !has_role {
                 debug!(
@@ -152,6 +158,7 @@ mod tests {
             admin_role: "openshell-admin".to_string(),
             user_role: "openshell-user".to_string(),
             scopes_enabled: false,
+            admin_subjects: HashSet::new(),
         }
     }
 
@@ -160,6 +167,7 @@ mod tests {
             admin_role: "openshell-admin".to_string(),
             user_role: "openshell-user".to_string(),
             scopes_enabled: true,
+            admin_subjects: HashSet::new(),
         }
     }
 
@@ -271,6 +279,7 @@ mod tests {
             admin_role: String::new(),
             user_role: String::new(),
             scopes_enabled: false,
+            admin_subjects: HashSet::new(),
         };
         assert!(
             policy
@@ -291,6 +300,7 @@ mod tests {
             admin_role: "OpenShell.Admin".to_string(),
             user_role: "OpenShell.User".to_string(),
             scopes_enabled: false,
+            admin_subjects: HashSet::new(),
         };
         assert!(
             policy
@@ -316,6 +326,7 @@ mod tests {
             admin_role: String::new(),
             user_role: String::new(),
             scopes_enabled: false,
+            admin_subjects: HashSet::new(),
         };
         assert!(policy.validate().is_ok());
     }
@@ -326,6 +337,7 @@ mod tests {
             admin_role: "admin".to_string(),
             user_role: String::new(),
             scopes_enabled: false,
+            admin_subjects: HashSet::new(),
         };
         assert!(policy.validate().is_err());
     }
@@ -336,6 +348,7 @@ mod tests {
             admin_role: String::new(),
             user_role: "user".to_string(),
             scopes_enabled: false,
+            admin_subjects: HashSet::new(),
         };
         assert!(policy.validate().is_err());
     }
@@ -590,6 +603,7 @@ mod tests {
             admin_role: String::new(),
             user_role: String::new(),
             scopes_enabled: true,
+            admin_subjects: HashSet::new(),
         };
         let id_with_scope = identity_with_roles_and_scopes(&[], &["sandbox:read"]);
         assert!(
@@ -601,6 +615,62 @@ mod tests {
         assert!(
             policy
                 .check(&id_without_scope, "/openshell.v1.OpenShell/ListSandboxes")
+                .is_err()
+        );
+    }
+
+    // ---- Admin subjects tests ----
+
+    #[test]
+    fn admin_subject_can_access_platform_admin_methods() {
+        let policy = AuthzPolicy {
+            admin_role: "openshell-admin".to_string(),
+            user_role: "openshell-user".to_string(),
+            scopes_enabled: false,
+            admin_subjects: HashSet::from(["special-sub".to_string()]),
+        };
+        let id = Identity {
+            subject: "special-sub".to_string(),
+            display_name: None,
+            roles: vec![],
+            scopes: vec![],
+            provider: IdentityProvider::Oidc,
+        };
+        assert!(
+            policy
+                .check(&id, "/openshell.v1.OpenShell/CreateWorkspace")
+                .is_ok()
+        );
+        assert!(
+            policy
+                .check(&id, "/openshell.v1.OpenShell/GetGatewayInfo")
+                .is_ok()
+        );
+        assert!(
+            policy
+                .check(&id, "/openshell.v1.OpenShell/ListSandboxes")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn non_admin_subject_still_denied() {
+        let policy = AuthzPolicy {
+            admin_role: "openshell-admin".to_string(),
+            user_role: "openshell-user".to_string(),
+            scopes_enabled: false,
+            admin_subjects: HashSet::from(["special-sub".to_string()]),
+        };
+        let id = Identity {
+            subject: "other-sub".to_string(),
+            display_name: None,
+            roles: vec![],
+            scopes: vec![],
+            provider: IdentityProvider::Oidc,
+        };
+        assert!(
+            policy
+                .check(&id, "/openshell.v1.OpenShell/ListSandboxes")
                 .is_err()
         );
     }

--- a/crates/openshell-server/src/auth/authz.rs
+++ b/crates/openshell-server/src/auth/authz.rs
@@ -64,8 +64,11 @@ impl AuthzPolicy {
     /// Check whether the identity is authorized to call the given method.
     ///
     /// Returns `Ok(())` if authorized, `Err(PERMISSION_DENIED)` if not.
-    /// When both role names are empty, all authenticated callers are authorized
-    /// (authentication-only mode for providers like GitHub).
+    /// When both role names and `admin_subjects` are empty, all authenticated
+    /// callers are authorized (authentication-only mode for providers like
+    /// GitHub). When `admin_subjects` is set but role names are empty,
+    /// admin methods are restricted to listed subjects while user-level
+    /// methods remain open to all authenticated callers.
     ///
     /// Methods annotated with `global_role` (e.g. `"platform_admin"`) require
     /// the `admin_role` OIDC claim. Methods annotated with `workspace_role`
@@ -74,37 +77,57 @@ impl AuthzPolicy {
     /// annotation requires authentication only.
     #[allow(clippy::result_large_err)]
     pub fn check(&self, identity: &Identity, method: &str) -> Result<(), Status> {
-        let required = match descriptor_authz::lookup(method) {
-            Some(entry) if entry.global_role.is_some() => Some(&self.admin_role),
-            Some(entry) if entry.workspace_role.is_some() => Some(&self.user_role),
-            Some(_) => None,
-            None => Some(&self.user_role),
+        // Track whether this method needs admin-level access so we can
+        // enforce admin_subjects even when admin_role is empty.
+        let (required, needs_admin) = match descriptor_authz::lookup(method) {
+            Some(entry) if entry.global_role.is_some() => (Some(&self.admin_role), true),
+            Some(entry) if entry.workspace_role.is_some() => (Some(&self.user_role), false),
+            Some(_) => (None, false),
+            None => (Some(&self.user_role), false),
         };
 
-        // Empty role name = skip role check for this level (auth-only mode).
-        // Scope enforcement still applies if enabled.
-        if let Some(required) = required
-            && !required.is_empty()
-        {
-            // Admin role implicitly satisfies user role requirements.
-            // Admin subjects also implicitly satisfy any role requirement.
-            let has_role = identity.roles.iter().any(|r| r == required)
-                || (!self.admin_role.is_empty()
-                    && required == &self.user_role
-                    && identity.roles.iter().any(|r| r == &self.admin_role))
-                || self.admin_subjects.contains(&identity.subject);
+        // In auth-only mode (empty role names), skip role enforcement UNLESS
+        // admin_subjects is configured and this is an admin method — in that
+        // case, only listed subjects get admin access.
+        if let Some(required) = required {
+            let enforce = !required.is_empty() || (needs_admin && !self.admin_subjects.is_empty());
 
-            if !has_role {
-                debug!(
-                    sub = %identity.subject,
-                    required_role = required,
-                    user_roles = ?identity.roles,
-                    method = method,
-                    "authorization denied: missing role"
-                );
-                return Err(Status::permission_denied(format!(
-                    "role '{required}' required"
-                )));
+            if enforce {
+                // Admin role implicitly satisfies user role requirements.
+                // Admin subjects also implicitly satisfy any role requirement.
+                // Guard empty-string comparisons: when admin_role/user_role is
+                // "", skip the role-match branch entirely — only
+                // admin_subjects can grant access in that case.
+                let has_role = (!required.is_empty()
+                    && identity.roles.iter().any(|r| r == required))
+                    || (!self.admin_role.is_empty()
+                        && required == &self.user_role
+                        && identity.roles.iter().any(|r| r == &self.admin_role))
+                    || self.admin_subjects.contains(&identity.subject);
+
+                if !has_role {
+                    let role_label = if required.is_empty() {
+                        "(admin_subjects)"
+                    } else {
+                        required.as_str()
+                    };
+                    debug!(
+                        sub = %identity.subject,
+                        required_role = role_label,
+                        user_roles = ?identity.roles,
+                        method = method,
+                        "authorization denied: missing role"
+                    );
+                    return if needs_admin && self.admin_role.is_empty() {
+                        Err(Status::permission_denied(
+                            "platform admin access required",
+                        ))
+                    } else {
+                        Err(Status::permission_denied(format!(
+                            "role '{required}' required"
+                        )))
+                    };
+                }
             }
         }
 
@@ -672,6 +695,76 @@ mod tests {
             policy
                 .check(&id, "/openshell.v1.OpenShell/ListSandboxes")
                 .is_err()
+        );
+    }
+
+    // ---- Subjects-only mode (no roles, admin_subjects set) ----
+
+    #[test]
+    fn subjects_only_admin_method_denied_without_subject() {
+        let policy = AuthzPolicy {
+            admin_role: String::new(),
+            user_role: String::new(),
+            scopes_enabled: false,
+            admin_subjects: HashSet::from(["admin-sub".to_string()]),
+        };
+        let id = Identity {
+            subject: "regular-user".to_string(),
+            display_name: None,
+            roles: vec![],
+            scopes: vec![],
+            provider: IdentityProvider::Oidc,
+        };
+        // Admin method should be denied — not in admin_subjects.
+        let err = policy
+            .check(&id, "/openshell.v1.OpenShell/CreateWorkspace")
+            .unwrap_err();
+        assert_eq!(err.message(), "platform admin access required");
+    }
+
+    #[test]
+    fn subjects_only_admin_method_allowed_with_subject() {
+        let policy = AuthzPolicy {
+            admin_role: String::new(),
+            user_role: String::new(),
+            scopes_enabled: false,
+            admin_subjects: HashSet::from(["admin-sub".to_string()]),
+        };
+        let id = Identity {
+            subject: "admin-sub".to_string(),
+            display_name: None,
+            roles: vec![],
+            scopes: vec![],
+            provider: IdentityProvider::Oidc,
+        };
+        // Admin method should be allowed — subject is in admin_subjects.
+        assert!(
+            policy
+                .check(&id, "/openshell.v1.OpenShell/CreateWorkspace")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn subjects_only_user_method_still_open() {
+        let policy = AuthzPolicy {
+            admin_role: String::new(),
+            user_role: String::new(),
+            scopes_enabled: false,
+            admin_subjects: HashSet::from(["admin-sub".to_string()]),
+        };
+        let id = Identity {
+            subject: "regular-user".to_string(),
+            display_name: None,
+            roles: vec![],
+            scopes: vec![],
+            provider: IdentityProvider::Oidc,
+        };
+        // User-level method should still be open — no user_role gate.
+        assert!(
+            policy
+                .check(&id, "/openshell.v1.OpenShell/ListSandboxes")
+                .is_ok()
         );
     }
 }

--- a/crates/openshell-server/src/auth/workspace_authz.rs
+++ b/crates/openshell-server/src/auth/workspace_authz.rs
@@ -8,11 +8,48 @@
 //! auth mode + scope + global role; this module validates workspace membership
 //! and workspace-level role.
 
+use std::collections::HashSet;
+
 use super::principal::Principal;
 use openshell_core::proto::WorkspaceRole as ProtoWorkspaceRole;
 use tonic::Status;
 
 use crate::persistence::Store;
+
+/// Bundles the criteria for granting Platform Admin status.
+///
+/// A caller is a Platform Admin if:
+/// - their OIDC roles include `admin_role`, OR
+/// - their OIDC `sub` is in `admin_subjects`, OR
+/// - `admin_role` is empty (auth-only mode — everyone is admin).
+#[derive(Debug, Clone)]
+pub struct AdminPolicy {
+    /// Role name that grants admin access. Empty in auth-only mode.
+    pub admin_role: String,
+    /// Set of OIDC subject (`sub`) values granted Platform Admin.
+    pub admin_subjects: HashSet<String>,
+}
+
+impl AdminPolicy {
+    /// Create an `AdminPolicy` from an `OidcConfig`.
+    pub fn from_oidc(oidc: &openshell_core::OidcConfig) -> Self {
+        Self {
+            admin_role: oidc.admin_role.clone(),
+            admin_subjects: oidc.admin_subjects.iter().cloned().collect(),
+        }
+    }
+
+    /// Create an empty `AdminPolicy` (auth-only mode).
+    ///
+    /// When `admin_role` is empty, every authenticated user is treated as
+    /// Platform Admin — matching the existing behavior.
+    pub fn auth_only() -> Self {
+        Self {
+            admin_role: String::new(),
+            admin_subjects: HashSet::new(),
+        }
+    }
+}
 
 fn shell_quote_for_hint(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
@@ -67,7 +104,7 @@ pub enum AuthGrant {
 #[allow(clippy::result_large_err)]
 pub async fn authorize_workspace(
     store: &Store,
-    admin_role: &str,
+    admin_policy: &AdminPolicy,
     principal: &Principal,
     workspace: &str,
     min_role: MinWorkspaceRole,
@@ -76,7 +113,7 @@ pub async fn authorize_workspace(
 
     match principal {
         Principal::User(user) => {
-            if is_platform_admin(&user.identity.roles, admin_role) {
+            if is_platform_admin(&user.identity.subject, &user.identity.roles, admin_policy) {
                 return Ok(AuthorizedWorkspace {
                     workspace,
                     grant: AuthGrant::PlatformAdmin,
@@ -137,22 +174,29 @@ pub async fn authorize_workspace(
 #[allow(clippy::result_large_err)]
 pub async fn authorize_sandbox_workspace(
     store: &Store,
-    admin_role: &str,
+    admin_policy: &AdminPolicy,
     principal: &Principal,
     sandbox_workspace: &str,
     min_role: MinWorkspaceRole,
 ) -> Result<AuthGrant, Status> {
     let result =
-        authorize_workspace(store, admin_role, principal, sandbox_workspace, min_role).await?;
+        authorize_workspace(store, admin_policy, principal, sandbox_workspace, min_role).await?;
     Ok(result.grant)
 }
 
 /// Require Platform Admin status. Used for cross-workspace operations like
 /// `list_*` with `all_workspaces: true`.
 #[allow(clippy::result_large_err)]
-pub fn require_platform_admin(admin_role: &str, principal: &Principal) -> Result<(), Status> {
+pub fn require_platform_admin(
+    admin_policy: &AdminPolicy,
+    principal: &Principal,
+) -> Result<(), Status> {
     match principal {
-        Principal::User(user) if is_platform_admin(&user.identity.roles, admin_role) => Ok(()),
+        Principal::User(user)
+            if is_platform_admin(&user.identity.subject, &user.identity.roles, admin_policy) =>
+        {
+            Ok(())
+        }
         Principal::User(_) => Err(Status::permission_denied(
             "platform admin role required for cross-workspace operations",
         )),
@@ -163,16 +207,24 @@ pub fn require_platform_admin(admin_role: &str, principal: &Principal) -> Result
     }
 }
 
-/// Check whether the caller's OIDC roles include the platform admin role.
+/// Check whether the caller is a Platform Admin.
 ///
-/// When `admin_role` is empty (OIDC not configured), returns `true` —
-/// matching the existing behavior where empty role names skip RBAC.
-pub fn is_platform_admin_principal(identity_roles: &[String], admin_role: &str) -> bool {
-    is_platform_admin(identity_roles, admin_role)
+/// Returns `true` if:
+/// - `admin_role` is empty (auth-only mode — everyone is admin), OR
+/// - the caller’s roles include `admin_role`, OR
+/// - the caller’s `sub` is in `admin_subjects`.
+pub fn is_platform_admin_principal(
+    subject: &str,
+    identity_roles: &[String],
+    admin_policy: &AdminPolicy,
+) -> bool {
+    is_platform_admin(subject, identity_roles, admin_policy)
 }
 
-fn is_platform_admin(identity_roles: &[String], admin_role: &str) -> bool {
-    admin_role.is_empty() || identity_roles.iter().any(|r| r == admin_role)
+fn is_platform_admin(subject: &str, identity_roles: &[String], admin_policy: &AdminPolicy) -> bool {
+    admin_policy.admin_role.is_empty()
+        || identity_roles.iter().any(|r| r == &admin_policy.admin_role)
+        || admin_policy.admin_subjects.contains(subject)
 }
 
 /// Check whether `member_role` satisfies the `min_role` requirement.
@@ -205,6 +257,13 @@ mod tests {
 
     async fn test_store() -> Store {
         crate::persistence::test_store().await
+    }
+
+    fn rbac_policy() -> AdminPolicy {
+        AdminPolicy {
+            admin_role: "openshell-admin".to_string(),
+            admin_subjects: HashSet::new(),
+        }
     }
 
     fn user_principal(subject: &str, roles: &[&str]) -> Principal {
@@ -250,10 +309,11 @@ mod tests {
     #[tokio::test]
     async fn platform_admin_bypasses_membership_check() {
         let store = test_store().await;
+        let policy = rbac_policy();
         let principal = user_principal("admin-user", &["openshell-admin", "openshell-user"]);
         let result = authorize_workspace(
             &store,
-            "openshell-admin",
+            &policy,
             &principal,
             "any-workspace",
             MinWorkspaceRole::Admin,
@@ -264,13 +324,109 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn admin_subject_bypasses_membership_check() {
+        let store = test_store().await;
+        let policy = AdminPolicy {
+            admin_role: "openshell-admin".to_string(),
+            admin_subjects: HashSet::from(["subject-admin".to_string()]),
+        };
+        // User has no admin role but their sub is in admin_subjects.
+        let principal = user_principal("subject-admin", &["openshell-user"]);
+        let result = authorize_workspace(
+            &store,
+            &policy,
+            &principal,
+            "any-workspace",
+            MinWorkspaceRole::Admin,
+        )
+        .await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().grant, AuthGrant::PlatformAdmin);
+    }
+
+    #[tokio::test]
+    async fn admin_subject_and_role_coexist() {
+        let store = test_store().await;
+        let policy = AdminPolicy {
+            admin_role: "openshell-admin".to_string(),
+            admin_subjects: HashSet::from(["subject-admin".to_string()]),
+        };
+        // User with admin role (not in admin_subjects) still works.
+        let role_admin = user_principal("role-admin", &["openshell-admin"]);
+        let result = authorize_workspace(
+            &store,
+            &policy,
+            &role_admin,
+            "default",
+            MinWorkspaceRole::Admin,
+        )
+        .await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().grant, AuthGrant::PlatformAdmin);
+
+        // User in admin_subjects (without admin role) also works.
+        let sub_admin = user_principal("subject-admin", &["openshell-user"]);
+        let result = authorize_workspace(
+            &store,
+            &policy,
+            &sub_admin,
+            "default",
+            MinWorkspaceRole::Admin,
+        )
+        .await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().grant, AuthGrant::PlatformAdmin);
+    }
+
+    #[tokio::test]
+    async fn admin_subjects_no_op_in_auth_only_mode() {
+        let store = test_store().await;
+        let policy = AdminPolicy {
+            admin_role: String::new(),
+            admin_subjects: HashSet::from(["specific-sub".to_string()]),
+        };
+        // In auth-only mode, everyone is admin regardless of admin_subjects.
+        let principal = user_principal("random-user", &[]);
+        let result = authorize_workspace(
+            &store,
+            &policy,
+            &principal,
+            "default",
+            MinWorkspaceRole::Admin,
+        )
+        .await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().grant, AuthGrant::PlatformAdmin);
+    }
+
+    #[tokio::test]
+    async fn non_admin_subject_not_granted_admin() {
+        let store = test_store().await;
+        let policy = AdminPolicy {
+            admin_role: "openshell-admin".to_string(),
+            admin_subjects: HashSet::from(["special-sub".to_string()]),
+        };
+        let principal = user_principal("other-sub", &["openshell-user"]);
+        let result = authorize_workspace(
+            &store,
+            &policy,
+            &principal,
+            "default",
+            MinWorkspaceRole::Admin,
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
     async fn workspace_admin_member_passes_admin_check() {
         let store = test_store().await;
+        let policy = rbac_policy();
         add_member(&store, "default", "user-a", ProtoWorkspaceRole::Admin).await;
         let principal = user_principal("user-a", &["openshell-user"]);
         let result = authorize_workspace(
             &store,
-            "openshell-admin",
+            &policy,
             &principal,
             "default",
             MinWorkspaceRole::Admin,
@@ -286,11 +442,12 @@ mod tests {
     #[tokio::test]
     async fn workspace_user_member_passes_user_check() {
         let store = test_store().await;
+        let policy = rbac_policy();
         add_member(&store, "default", "user-b", ProtoWorkspaceRole::User).await;
         let principal = user_principal("user-b", &["openshell-user"]);
         let result = authorize_workspace(
             &store,
-            "openshell-admin",
+            &policy,
             &principal,
             "default",
             MinWorkspaceRole::User,
@@ -306,11 +463,12 @@ mod tests {
     #[tokio::test]
     async fn workspace_user_member_rejected_for_admin_check() {
         let store = test_store().await;
+        let policy = rbac_policy();
         add_member(&store, "default", "user-c", ProtoWorkspaceRole::User).await;
         let principal = user_principal("user-c", &["openshell-user"]);
         let result = authorize_workspace(
             &store,
-            "openshell-admin",
+            &policy,
             &principal,
             "default",
             MinWorkspaceRole::Admin,
@@ -329,10 +487,11 @@ mod tests {
     #[tokio::test]
     async fn non_member_rejected() {
         let store = test_store().await;
+        let policy = rbac_policy();
         let principal = user_principal("stranger", &["openshell-user"]);
         let result = authorize_workspace(
             &store,
-            "openshell-admin",
+            &policy,
             &principal,
             "default",
             MinWorkspaceRole::User,
@@ -351,10 +510,11 @@ mod tests {
     #[tokio::test]
     async fn non_member_remediation_shell_quotes_untrusted_subject() {
         let store = test_store().await;
+        let policy = rbac_policy();
         let principal = user_principal("user'; echo pwned; '$(id)", &["openshell-user"]);
         let result = authorize_workspace(
             &store,
-            "openshell-admin",
+            &policy,
             &principal,
             "team-a",
             MinWorkspaceRole::User,
@@ -372,9 +532,10 @@ mod tests {
     #[tokio::test]
     async fn anonymous_principal_rejected() {
         let store = test_store().await;
+        let policy = rbac_policy();
         let result = authorize_workspace(
             &store,
-            "openshell-admin",
+            &policy,
             &Principal::Anonymous,
             "default",
             MinWorkspaceRole::User,
@@ -387,10 +548,11 @@ mod tests {
     #[tokio::test]
     async fn sandbox_principal_passes_through() {
         let store = test_store().await;
+        let policy = rbac_policy();
         let principal = sandbox_principal();
         let result = authorize_workspace(
             &store,
-            "openshell-admin",
+            &policy,
             &principal,
             "default",
             MinWorkspaceRole::User,
@@ -403,16 +565,11 @@ mod tests {
     #[tokio::test]
     async fn empty_workspace_normalizes_to_default() {
         let store = test_store().await;
+        let policy = rbac_policy();
         add_member(&store, "default", "user-d", ProtoWorkspaceRole::User).await;
         let principal = user_principal("user-d", &["openshell-user"]);
-        let result = authorize_workspace(
-            &store,
-            "openshell-admin",
-            &principal,
-            "",
-            MinWorkspaceRole::User,
-        )
-        .await;
+        let result =
+            authorize_workspace(&store, &policy, &principal, "", MinWorkspaceRole::User).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap().workspace, "default");
     }
@@ -420,9 +577,16 @@ mod tests {
     #[tokio::test]
     async fn auth_disabled_empty_admin_role_is_platform_admin() {
         let store = test_store().await;
+        let policy = AdminPolicy::auth_only();
         let principal = user_principal("any-user", &[]);
-        let result =
-            authorize_workspace(&store, "", &principal, "default", MinWorkspaceRole::Admin).await;
+        let result = authorize_workspace(
+            &store,
+            &policy,
+            &principal,
+            "default",
+            MinWorkspaceRole::Admin,
+        )
+        .await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap().grant, AuthGrant::PlatformAdmin);
     }
@@ -430,11 +594,12 @@ mod tests {
     #[tokio::test]
     async fn workspace_admin_member_passes_user_check() {
         let store = test_store().await;
+        let policy = rbac_policy();
         add_member(&store, "default", "admin-member", ProtoWorkspaceRole::Admin).await;
         let principal = user_principal("admin-member", &["openshell-user"]);
         let result = authorize_workspace(
             &store,
-            "openshell-admin",
+            &policy,
             &principal,
             "default",
             MinWorkspaceRole::User,

--- a/crates/openshell-server/src/auth/workspace_authz.rs
+++ b/crates/openshell-server/src/auth/workspace_authz.rs
@@ -41,8 +41,9 @@ impl AdminPolicy {
 
     /// Create an empty `AdminPolicy` (auth-only mode).
     ///
-    /// When `admin_role` is empty, every authenticated user is treated as
-    /// Platform Admin — matching the existing behavior.
+    /// When both `admin_role` and `admin_subjects` are empty, every
+    /// authenticated user is treated as Platform Admin — matching the
+    /// existing auth-only behavior.
     pub fn auth_only() -> Self {
         Self {
             admin_role: String::new(),
@@ -210,9 +211,10 @@ pub fn require_platform_admin(
 /// Check whether the caller is a Platform Admin.
 ///
 /// Returns `true` if:
-/// - `admin_role` is empty (auth-only mode — everyone is admin), OR
-/// - the caller’s roles include `admin_role`, OR
-/// - the caller’s `sub` is in `admin_subjects`.
+/// - auth-only mode (`admin_role` empty AND `admin_subjects` empty) —
+///   every authenticated user is admin, OR
+/// - the caller's roles include `admin_role`, OR
+/// - the caller's `sub` is in `admin_subjects`.
 pub fn is_platform_admin_principal(
     subject: &str,
     identity_roles: &[String],
@@ -222,8 +224,9 @@ pub fn is_platform_admin_principal(
 }
 
 fn is_platform_admin(subject: &str, identity_roles: &[String], admin_policy: &AdminPolicy) -> bool {
-    admin_policy.admin_role.is_empty()
-        || identity_roles.iter().any(|r| r == &admin_policy.admin_role)
+    (admin_policy.admin_role.is_empty() && admin_policy.admin_subjects.is_empty())
+        || (!admin_policy.admin_role.is_empty()
+            && identity_roles.iter().any(|r| r == &admin_policy.admin_role))
         || admin_policy.admin_subjects.contains(subject)
 }
 
@@ -379,14 +382,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn admin_subjects_no_op_in_auth_only_mode() {
+    async fn admin_subjects_only_restricts_admin_access() {
         let store = test_store().await;
         let policy = AdminPolicy {
             admin_role: String::new(),
             admin_subjects: HashSet::from(["specific-sub".to_string()]),
         };
-        // In auth-only mode, everyone is admin regardless of admin_subjects.
+        // When admin_subjects is set (even without admin_role), only
+        // listed subjects should get Platform Admin.
         let principal = user_principal("random-user", &[]);
+        let result = authorize_workspace(
+            &store,
+            &policy,
+            &principal,
+            "default",
+            MinWorkspaceRole::Admin,
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn admin_subjects_only_grants_listed_subject() {
+        let store = test_store().await;
+        let policy = AdminPolicy {
+            admin_role: String::new(),
+            admin_subjects: HashSet::from(["specific-sub".to_string()]),
+        };
+        let principal = user_principal("specific-sub", &[]);
         let result = authorize_workspace(
             &store,
             &policy,

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -423,6 +423,8 @@ fn prepare_server_config(args: &mut RunArgs, matches: &ArgMatches) -> Result<Ser
             admin_role: args.oidc_admin_role.clone(),
             user_role: args.oidc_user_role.clone(),
             scopes_claim: args.oidc_scopes_claim.clone(),
+            // clap's `value_delimiter` + `default_value = ""` produces
+            // `vec![""]` when the user supplies no value — filter it out.
             admin_subjects: args
                 .oidc_admin_subjects
                 .iter()

--- a/crates/openshell-server/src/cli.rs
+++ b/crates/openshell-server/src/cli.rs
@@ -185,6 +185,16 @@ struct RunArgs {
     #[arg(long, env = "OPENSHELL_OIDC_SCOPES_CLAIM", default_value = "")]
     oidc_scopes_claim: String,
 
+    /// OIDC subjects (`sub` claim values) granted Platform Admin privileges
+    /// regardless of their JWT role claims. Comma-separated.
+    #[arg(
+        long,
+        env = "OPENSHELL_OIDC_ADMIN_SUBJECTS",
+        value_delimiter = ',',
+        default_value = ""
+    )]
+    oidc_admin_subjects: Vec<String>,
+
     /// Maximum gRPC requests allowed per rate-limit window. Set to 0 to disable.
     #[arg(long, env = "OPENSHELL_GRPC_RATE_LIMIT_REQUESTS")]
     grpc_rate_limit_requests: Option<u64>,
@@ -413,6 +423,12 @@ fn prepare_server_config(args: &mut RunArgs, matches: &ArgMatches) -> Result<Ser
             admin_role: args.oidc_admin_role.clone(),
             user_role: args.oidc_user_role.clone(),
             scopes_claim: args.oidc_scopes_claim.clone(),
+            admin_subjects: args
+                .oidc_admin_subjects
+                .iter()
+                .filter(|s| !s.is_empty())
+                .cloned()
+                .collect(),
         });
     }
 
@@ -677,6 +693,9 @@ fn merge_file_into_args(args: &mut RunArgs, file: &GatewayFileSection, matches: 
         }
         if arg_defaulted(matches, "oidc_scopes_claim") {
             args.oidc_scopes_claim.clone_from(&oidc.scopes_claim);
+        }
+        if arg_defaulted(matches, "oidc_admin_subjects") && !oidc.admin_subjects.is_empty() {
+            args.oidc_admin_subjects.clone_from(&oidc.admin_subjects);
         }
     }
     if let Some(requests) = file.grpc_rate_limit_requests

--- a/crates/openshell-server/src/grpc/mod.rs
+++ b/crates/openshell-server/src/grpc/mod.rs
@@ -751,8 +751,8 @@ pub mod test_support {
     ///
     /// The dev principal matches the unauthenticated dev user: subject
     /// `"dev-user"`, roles `["openshell-admin", "openshell-user"]`.
-    /// Since `test_server_state()` has an empty `admin_role`, `authorize_workspace()`
-    /// treats every authenticated user as Platform Admin.
+    /// Since `test_server_state()` has an empty `admin_policy.admin_role`,
+    /// `authorize_workspace()` treats every authenticated user as Platform Admin.
     pub fn authed_request<T>(inner: T) -> Request<T> {
         let mut req = Request::new(inner);
         req.extensions_mut().insert(Principal::User(UserPrincipal {

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -1682,7 +1682,7 @@ async fn handle_update_config_inner(
     let req = request.into_inner();
     validate_annotations(&req.annotations, "annotations")?;
     let workspace = if req.global {
-        require_platform_admin(&state.admin_role, principal)?;
+        require_platform_admin(&state.admin_policy, principal)?;
         String::new()
     } else {
         let min_role = if sandbox_caller {
@@ -1692,7 +1692,7 @@ async fn handle_update_config_inner(
         };
         authorize_sandbox_workspace(
             &state.store,
-            &state.admin_role,
+            &state.admin_policy,
             principal,
             &req.workspace,
             min_role,
@@ -2315,12 +2315,12 @@ pub(super) async fn handle_get_sandbox_policy_status(
     let principal = super::extract_principal(&request)?;
     let req = request.into_inner();
     let workspace = if req.global {
-        require_platform_admin(&state.admin_role, &principal)?;
+        require_platform_admin(&state.admin_policy, &principal)?;
         String::new()
     } else {
         let authz = authorize_workspace(
             &state.store,
-            &state.admin_role,
+            &state.admin_policy,
             &principal,
             &req.workspace,
             MinWorkspaceRole::User,
@@ -2383,12 +2383,12 @@ pub(super) async fn handle_list_sandbox_policies(
     let principal = super::extract_principal(&request)?;
     let req = request.into_inner();
     let workspace = if req.global {
-        require_platform_admin(&state.admin_role, &principal)?;
+        require_platform_admin(&state.admin_policy, &principal)?;
         String::new()
     } else {
         let authz = authorize_workspace(
             &state.store,
-            &state.admin_role,
+            &state.admin_policy,
             &principal,
             &req.workspace,
             MinWorkspaceRole::User,
@@ -2930,7 +2930,7 @@ pub(super) async fn handle_get_draft_policy(
     let req = request.into_inner();
     authorize_sandbox_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::User,
@@ -3011,7 +3011,7 @@ async fn handle_approve_draft_chunk_inner(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::Admin,
@@ -3123,7 +3123,7 @@ async fn handle_reject_draft_chunk_inner(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::Admin,
@@ -3233,7 +3233,7 @@ async fn handle_approve_all_draft_chunks_inner(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::Admin,
@@ -3367,7 +3367,7 @@ pub(super) async fn handle_edit_draft_chunk(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::Admin,
@@ -3443,7 +3443,7 @@ async fn handle_undo_draft_chunk_inner(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::Admin,
@@ -3540,7 +3540,7 @@ pub(super) async fn handle_clear_draft_chunks(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::Admin,
@@ -3588,7 +3588,7 @@ pub(super) async fn handle_get_draft_history(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::User,
@@ -4893,7 +4893,7 @@ mod tests {
         use openshell_core::proto::{WorkspaceMember, WorkspaceRole};
 
         let mut state = test_server_state().await;
-        Arc::get_mut(&mut state).unwrap().admin_role = "openshell-admin".to_string();
+        Arc::get_mut(&mut state).unwrap().admin_policy.admin_role = "openshell-admin".to_string();
         let sandbox = Sandbox {
             metadata: Some(ObjectMeta {
                 id: "sandbox-b-id".to_string(),
@@ -4949,7 +4949,7 @@ mod tests {
         use openshell_core::proto::{WorkspaceMember, WorkspaceRole};
 
         let mut state = test_server_state().await;
-        Arc::get_mut(&mut state).unwrap().admin_role = "openshell-admin".to_string();
+        Arc::get_mut(&mut state).unwrap().admin_policy.admin_role = "openshell-admin".to_string();
         let member = WorkspaceMember {
             metadata: Some(ObjectMeta {
                 id: "default-admin-member-id".to_string(),
@@ -4984,7 +4984,7 @@ mod tests {
     #[tokio::test]
     async fn global_policy_reads_require_platform_admin() {
         let mut state = test_server_state().await;
-        Arc::get_mut(&mut state).unwrap().admin_role = "openshell-admin".to_string();
+        Arc::get_mut(&mut state).unwrap().admin_policy.admin_role = "openshell-admin".to_string();
 
         let get_error = handle_get_sandbox_policy_status(
             &state,
@@ -13315,7 +13315,7 @@ mod tests {
     #[tokio::test]
     async fn non_member_gets_permission_denied_not_workspace_oracle() {
         let mut state = test_server_state().await;
-        Arc::get_mut(&mut state).unwrap().admin_role = "openshell-admin".to_string();
+        Arc::get_mut(&mut state).unwrap().admin_policy.admin_role = "openshell-admin".to_string();
 
         fn non_member_request<T>(inner: T) -> Request<T> {
             let mut req = Request::new(inner);
@@ -13514,7 +13514,7 @@ mod tests {
     #[tokio::test]
     async fn id_based_policy_handlers_hide_cross_workspace_sandboxes() {
         let mut state = test_server_state().await;
-        Arc::get_mut(&mut state).unwrap().admin_role = "openshell-admin".to_string();
+        Arc::get_mut(&mut state).unwrap().admin_policy.admin_role = "openshell-admin".to_string();
 
         fn non_member_request<T>(inner: T) -> Request<T> {
             let mut req = Request::new(inner);
@@ -13574,7 +13574,7 @@ mod tests {
     #[tokio::test]
     async fn get_gateway_config_accessible_without_platform_admin() {
         let mut state = test_server_state().await;
-        Arc::get_mut(&mut state).unwrap().admin_role = "openshell-admin".to_string();
+        Arc::get_mut(&mut state).unwrap().admin_policy.admin_role = "openshell-admin".to_string();
 
         let mut req = Request::new(GetGatewayConfigRequest {});
         req.extensions_mut().insert(Principal::User(UserPrincipal {

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -1335,7 +1335,7 @@ async fn authorize_and_resolve_profile_workspace(
     min_workspace_role: MinWorkspaceRole,
 ) -> Result<super::workspace::ResolvedWorkspace, Status> {
     if workspace.is_empty() {
-        require_platform_admin(&state.admin_role, principal)?;
+        require_platform_admin(&state.admin_policy, principal)?;
         Ok(super::workspace::ResolvedWorkspace {
             name: String::new(),
             terminating: false,
@@ -1343,7 +1343,7 @@ async fn authorize_and_resolve_profile_workspace(
     } else {
         let authz = authorize_workspace(
             &state.store,
-            &state.admin_role,
+            &state.admin_policy,
             principal,
             workspace,
             min_workspace_role,
@@ -1361,7 +1361,7 @@ pub(super) async fn handle_create_provider(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::Admin,
@@ -1419,7 +1419,7 @@ pub(super) async fn handle_get_provider(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::User,
@@ -1449,7 +1449,7 @@ pub(super) async fn handle_list_providers(
     let limit = clamp_limit(request.limit, 100, MAX_PAGE_SIZE);
 
     let providers = if request.all_workspaces {
-        require_platform_admin(&state.admin_role, &principal)?;
+        require_platform_admin(&state.admin_policy, &principal)?;
         let all: Vec<Provider> = state
             .store
             .list_all_messages(limit, request.offset)
@@ -1459,7 +1459,7 @@ pub(super) async fn handle_list_providers(
     } else {
         let authz = authorize_workspace(
             &state.store,
-            &state.admin_role,
+            &state.admin_policy,
             &principal,
             &request.workspace,
             MinWorkspaceRole::User,
@@ -2411,7 +2411,7 @@ pub(super) async fn handle_update_provider(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::Admin,
@@ -2469,7 +2469,7 @@ pub(super) async fn handle_get_provider_refresh_status(
     let request = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &request.workspace,
         MinWorkspaceRole::User,
@@ -2522,7 +2522,7 @@ pub(super) async fn handle_configure_provider_refresh(
     let request = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &request.workspace,
         MinWorkspaceRole::Admin,
@@ -2820,7 +2820,7 @@ pub(super) async fn handle_rotate_provider_credential(
     let request = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &request.workspace,
         MinWorkspaceRole::Admin,
@@ -2888,7 +2888,7 @@ pub(super) async fn handle_delete_provider_refresh(
     let request = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &request.workspace,
         MinWorkspaceRole::Admin,
@@ -2965,7 +2965,7 @@ pub(super) async fn handle_delete_provider(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::Admin,
@@ -8873,7 +8873,8 @@ mod tests {
     #[tokio::test]
     async fn platform_provider_profile_operations_require_platform_admin() {
         let mut state = test_server_state().await;
-        Arc::get_mut(&mut state).unwrap().admin_role = "required-platform-admin".to_string();
+        Arc::get_mut(&mut state).unwrap().admin_policy.admin_role =
+            "required-platform-admin".to_string();
 
         let catalog_error = handle_list_provider_profiles(
             &state,
@@ -9666,7 +9667,7 @@ mod tests {
         }
 
         let mut state = test_server_state().await;
-        Arc::get_mut(&mut state).unwrap().admin_role = "openshell-admin".to_string();
+        Arc::get_mut(&mut state).unwrap().admin_policy.admin_role = "openshell-admin".to_string();
 
         // --- Regular provider handlers (9) ---
 

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -75,7 +75,7 @@ pub(super) async fn fetch_and_authorize_sandbox(
         .ok_or_else(|| Status::not_found("sandbox not found"))?;
     authorize_sandbox_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         principal,
         sandbox.object_workspace(),
         MinWorkspaceRole::User,
@@ -182,7 +182,7 @@ async fn handle_create_sandbox_inner(
 
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &request.workspace,
         MinWorkspaceRole::User,
@@ -306,7 +306,7 @@ pub(super) async fn handle_get_sandbox(
     }
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::User,
@@ -342,7 +342,7 @@ pub(super) async fn handle_list_sandboxes(
     let limit = clamp_limit(request.limit, 100, MAX_PAGE_SIZE);
 
     let sandboxes: Vec<Sandbox> = if request.all_workspaces {
-        require_platform_admin(&state.admin_role, &principal)?;
+        require_platform_admin(&state.admin_policy, &principal)?;
         if request.label_selector.is_empty() {
             state
                 .store
@@ -360,7 +360,7 @@ pub(super) async fn handle_list_sandboxes(
     } else {
         let authz = authorize_workspace(
             &state.store,
-            &state.admin_role,
+            &state.admin_policy,
             &principal,
             &request.workspace,
             MinWorkspaceRole::User,
@@ -403,7 +403,7 @@ pub(super) async fn handle_list_sandbox_providers(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::User,
@@ -425,7 +425,7 @@ pub(super) async fn handle_attach_sandbox_provider(
     let request = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &request.workspace,
         MinWorkspaceRole::User,
@@ -555,7 +555,7 @@ pub(super) async fn handle_detach_sandbox_provider(
     let request = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &request.workspace,
         MinWorkspaceRole::User,
@@ -663,7 +663,7 @@ async fn handle_delete_sandbox_inner(
     }
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::User,
@@ -1602,7 +1602,7 @@ pub(super) async fn handle_revoke_ssh_session(
     };
     authorize_sandbox_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         session.object_workspace(),
         MinWorkspaceRole::User,
@@ -4156,7 +4156,7 @@ mod tests {
         }
 
         let mut state = test_server_state().await;
-        Arc::get_mut(&mut state).unwrap().admin_role = "openshell-admin".to_string();
+        Arc::get_mut(&mut state).unwrap().admin_policy.admin_role = "openshell-admin".to_string();
 
         // --- handle_create_sandbox ---
         // Provide a spec so the handler passes the "spec is required" check
@@ -4300,7 +4300,7 @@ mod tests {
         }
 
         let mut state = test_server_state().await;
-        Arc::get_mut(&mut state).unwrap().admin_role = "openshell-admin".to_string();
+        Arc::get_mut(&mut state).unwrap().admin_policy.admin_role = "openshell-admin".to_string();
 
         let mut sandbox = test_sandbox("cross-ws", Vec::new());
         sandbox.metadata.as_mut().unwrap().workspace = "other-workspace".to_string();

--- a/crates/openshell-server/src/grpc/service.rs
+++ b/crates/openshell-server/src/grpc/service.rs
@@ -30,7 +30,7 @@ pub(super) async fn handle_expose_service(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::User,
@@ -149,7 +149,7 @@ pub(super) async fn handle_get_service(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::User,
@@ -185,7 +185,7 @@ pub(super) async fn handle_list_services(
 
     let limit = super::clamp_limit(req.limit, 100, super::MAX_PAGE_SIZE);
     let endpoints: Vec<ServiceEndpoint> = if req.all_workspaces {
-        require_platform_admin(&state.admin_role, &principal)?;
+        require_platform_admin(&state.admin_policy, &principal)?;
         if !req.sandbox.is_empty() {
             return Err(Status::invalid_argument(
                 "sandbox filter is not supported with all_workspaces",
@@ -195,7 +195,7 @@ pub(super) async fn handle_list_services(
     } else {
         let authz = authorize_workspace(
             &state.store,
-            &state.admin_role,
+            &state.admin_policy,
             &principal,
             &req.workspace,
             MinWorkspaceRole::User,
@@ -239,7 +239,7 @@ pub(super) async fn handle_delete_service(
     let req = request.into_inner();
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::User,
@@ -884,7 +884,7 @@ mod tests {
         }
 
         let mut state = test_server_state().await;
-        Arc::get_mut(&mut state).unwrap().admin_role = "openshell-admin".to_string();
+        Arc::get_mut(&mut state).unwrap().admin_policy.admin_role = "openshell-admin".to_string();
 
         let err = handle_expose_service(
             &state,

--- a/crates/openshell-server/src/grpc/workspace.rs
+++ b/crates/openshell-server/src/grpc/workspace.rs
@@ -57,8 +57,9 @@ fn membership_filter_subject<'a>(
     match principal {
         Principal::User(u) => {
             if crate::auth::workspace_authz::is_platform_admin_principal(
+                &u.identity.subject,
                 &u.identity.roles,
-                &state.admin_role,
+                &state.admin_policy,
             ) {
                 Ok(None)
             } else {
@@ -222,7 +223,7 @@ pub(super) async fn handle_get_workspace(
     }
     authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &name,
         MinWorkspaceRole::User,
@@ -447,7 +448,7 @@ pub(super) async fn handle_add_workspace_member(
 
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::Admin,
@@ -553,7 +554,7 @@ pub(super) async fn handle_remove_workspace_member(
 
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::Admin,
@@ -589,7 +590,7 @@ pub(super) async fn handle_list_workspace_members(
 
     let authz = authorize_workspace(
         &state.store,
-        &state.admin_role,
+        &state.admin_policy,
         &principal,
         &req.workspace,
         MinWorkspaceRole::User,
@@ -1472,7 +1473,7 @@ mod tests {
         }
 
         let mut state = test_server_state().await;
-        Arc::get_mut(&mut state).unwrap().admin_role = "openshell-admin".to_string();
+        Arc::get_mut(&mut state).unwrap().admin_policy.admin_role = "openshell-admin".to_string();
 
         let err = handle_get_workspace(
             &state,

--- a/crates/openshell-server/src/inference.rs
+++ b/crates/openshell-server/src/inference.rs
@@ -94,7 +94,7 @@ impl Inference for InferenceService {
         let req = request.into_inner();
         let authz = authorize_workspace(
             &self.state.store,
-            &self.state.admin_role,
+            &self.state.admin_policy,
             &principal,
             &req.workspace,
             MinWorkspaceRole::Admin,
@@ -143,7 +143,7 @@ impl Inference for InferenceService {
         let req = request.into_inner();
         let authz = authorize_workspace(
             &self.state.store,
-            &self.state.admin_role,
+            &self.state.admin_policy,
             &principal,
             &req.workspace,
             MinWorkspaceRole::User,
@@ -195,7 +195,7 @@ impl Inference for InferenceService {
         let req = request.into_inner();
         let authz = authorize_workspace(
             &self.state.store,
-            &self.state.admin_role,
+            &self.state.admin_policy,
             &principal,
             &req.workspace,
             MinWorkspaceRole::Admin,
@@ -3459,7 +3459,7 @@ mod tests {
         }
 
         let mut state = test_server_state().await;
-        Arc::get_mut(&mut state).unwrap().admin_role = "openshell-admin".to_string();
+        Arc::get_mut(&mut state).unwrap().admin_policy.admin_role = "openshell-admin".to_string();
 
         let svc = InferenceService::new(state.clone());
 

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -170,10 +170,9 @@ pub struct ServerState {
     /// on demand when the user source is configured.
     pub(crate) provider_profile_sources: provider_profile_sources::ProviderProfileSources,
 
-    /// OIDC admin role name for workspace-level authorization.
-    /// Empty when OIDC is not configured — `authorize_workspace()` treats
-    /// every authenticated user as Platform Admin in that case.
-    pub admin_role: String,
+    /// Policy for determining Platform Admin status.
+    /// Bundles admin role name and admin subjects for workspace authorization.
+    pub admin_policy: auth::workspace_authz::AdminPolicy,
 }
 
 fn is_benign_tls_handshake_failure(error: &std::io::Error) -> bool {
@@ -202,10 +201,10 @@ impl ServerState {
         oidc_cache: Option<Arc<auth::oidc::JwksCache>>,
     ) -> Self {
         let grpc_rate_limiter = multiplex::GrpcRateLimiter::from_config(&config);
-        let admin_role = config
-            .oidc
-            .as_ref()
-            .map_or_else(String::new, |oidc| oidc.admin_role.clone());
+        let admin_policy = config.oidc.as_ref().map_or_else(
+            auth::workspace_authz::AdminPolicy::auth_only,
+            auth::workspace_authz::AdminPolicy::from_oidc,
+        );
         Self {
             config,
             store,
@@ -227,7 +226,7 @@ impl ServerState {
             gateway_interceptors: None,
             provider_profile_sources:
                 provider_profile_sources::ProviderProfileSources::with_default_sources(),
-            admin_role,
+            admin_policy,
         }
     }
 }
@@ -285,6 +284,7 @@ pub(crate) async fn run_server(
             admin_role: oidc.admin_role.clone(),
             user_role: oidc.user_role.clone(),
             scopes_enabled: !oidc.scopes_claim.is_empty(),
+            admin_subjects: oidc.admin_subjects.iter().cloned().collect(),
         };
         policy.validate().map_err(Error::config)?;
 

--- a/crates/openshell-server/src/multiplex.rs
+++ b/crates/openshell-server/src/multiplex.rs
@@ -286,6 +286,7 @@ impl MultiplexService {
             admin_role: oidc.admin_role.clone(),
             user_role: oidc.user_role.clone(),
             scopes_enabled: !oidc.scopes_claim.is_empty(),
+            admin_subjects: oidc.admin_subjects.iter().cloned().collect(),
         });
         let authenticator_chain = build_authenticator_chain(&self.state);
         let grpc_service = AuthGrpcRouter::with_peer_identity(
@@ -2779,6 +2780,7 @@ mod tests {
                 admin_role: "openshell-admin".to_string(),
                 user_role: "openshell-user".to_string(),
                 scopes_enabled: true,
+                admin_subjects: std::collections::HashSet::new(),
             };
 
             for path in [

--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -207,6 +207,7 @@ add `ci/values-spire.yaml` to the OpenShell release values files.
 | server.hostGatewayIP | string | `""` | Host gateway IP for sandbox pod hostAliases. When set, sandbox pods get hostAliases entries mapping host.docker.internal and host.openshell.internal to this IP, allowing them to reach services running on the Docker host. Auto-detected by the cluster entrypoint script. |
 | server.logLevel | string | `"info"` | Gateway log level. |
 | server.oidc.adminRole | string | `""` | Role name for admin access. Leave empty (with userRole also empty) for authentication-only mode. Both must be set or both empty. |
+| server.oidc.adminSubjects | list | `[]` | OIDC subjects (sub claim values) granted Platform Admin regardless of JWT roles. Works alongside adminRole — either grants admin. |
 | server.oidc.audience | string | `"openshell-cli"` | Expected audience claim for the API resource server. This should match the server's --oidc-audience, NOT the CLI client ID. |
 | server.oidc.caConfigMapName | string | `""` | Name of a ConfigMap containing a CA certificate bundle (key: ca.crt) for verifying the OIDC issuer's TLS certificate. Required when the issuer uses a non-public CA (e.g. OpenShift ingress, private PKI). |
 | server.oidc.issuer | string | `""` | OIDC issuer URL (e.g. https://keycloak.example.com/realms/openshell). |

--- a/deploy/helm/openshell/templates/gateway-config.yaml
+++ b/deploy/helm/openshell/templates/gateway-config.yaml
@@ -109,6 +109,9 @@ data:
     {{- if .Values.server.oidc.scopesClaim }}
     scopes_claim  = {{ .Values.server.oidc.scopesClaim | quote }}
     {{- end }}
+    {{- if .Values.server.oidc.adminSubjects }}
+    admin_subjects = [{{ range $i, $s := .Values.server.oidc.adminSubjects }}{{ if $i }}, {{ end }}{{ $s | quote }}{{ end }}]
+    {{- end }}
     {{- end }}
 
     [openshell.drivers.kubernetes]

--- a/deploy/helm/openshell/tests/gateway_config_test.yaml
+++ b/deploy/helm/openshell/tests/gateway_config_test.yaml
@@ -475,6 +475,36 @@ tests:
           path: data["gateway.toml"]
           pattern: '\[openshell\.gateway\.spiffe\]'
 
+  - it: omits admin_subjects when not configured
+    template: templates/gateway-config.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["gateway.toml"]
+          pattern: 'admin_subjects\s*='
+
+  - it: renders admin_subjects array under [openshell.gateway.oidc]
+    template: templates/gateway-config.yaml
+    set:
+      server.oidc.issuer: https://idp.example.com/realms/openshell
+      server.oidc.adminSubjects:
+        - "sub-1"
+        - "sub-2"
+    asserts:
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?ms)\[openshell\.gateway\.oidc\].*?admin_subjects\s*=\s*\["sub-1", "sub-2"\]'
+
+  - it: renders a single admin_subjects entry
+    template: templates/gateway-config.yaml
+    set:
+      server.oidc.issuer: https://idp.example.com/realms/openshell
+      server.oidc.adminSubjects:
+        - "only-admin"
+    asserts:
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?ms)\[openshell\.gateway\.oidc\].*?admin_subjects\s*=\s*\["only-admin"\]'
+
   - it: keeps the gateway sandbox JWT secret mounted when provider SPIFFE grants are enabled
     set:
       server.providerTokenGrants.spiffe.enabled: true

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -307,6 +307,9 @@ server:
     userRole: ""
     # -- Dot-separated path to the scopes array in the JWT claims.
     scopesClaim: ""
+    # -- OIDC subjects (sub claim values) granted Platform Admin regardless
+    # of JWT roles. Works alongside adminRole — either grants admin.
+    adminSubjects: []
     # -- Name of a ConfigMap containing a CA certificate bundle (key: ca.crt)
     # for verifying the OIDC issuer's TLS certificate. Required when the
     # issuer uses a non-public CA (e.g. OpenShift ingress, private PKI).

--- a/docs/reference/gateway-auth.mdx
+++ b/docs/reference/gateway-auth.mdx
@@ -82,7 +82,8 @@ openshell-gateway \
   --oidc-audience openshell-cli \
   --oidc-roles-claim realm_access.roles \
   --oidc-admin-role openshell-admin \
-  --oidc-user-role openshell-user
+  --oidc-user-role openshell-user \
+  --oidc-admin-subjects user-id-1,user-id-2
 ```
 
 The same settings are available through environment variables:
@@ -95,6 +96,7 @@ The same settings are available through environment variables:
 | `OPENSHELL_OIDC_ROLES_CLAIM` | Dot-separated claim path containing roles. | `realm_access.roles` |
 | `OPENSHELL_OIDC_ADMIN_ROLE` | Role required for admin operations. | `openshell-admin` |
 | `OPENSHELL_OIDC_USER_ROLE` | Role required for standard user operations. | `openshell-user` |
+| `OPENSHELL_OIDC_ADMIN_SUBJECTS` | Comma-separated OIDC subject (`sub`) values granted Platform Admin regardless of roles. Works alongside `OPENSHELL_OIDC_ADMIN_ROLE`. | Empty |
 | `OPENSHELL_OIDC_SCOPES_CLAIM` | Dot-separated claim path containing scopes. Empty disables scope enforcement. | Empty |
 
 For Helm deployments, set the same values under `server.oidc`:
@@ -107,6 +109,7 @@ server:
     rolesClaim: realm_access.roles
     adminRole: openshell-admin
     userRole: openshell-user
+    adminSubjects: []
     scopesClaim: ""
 ```
 
@@ -129,7 +132,7 @@ The connection flow:
 3. The CLI connects to the gateway and attaches `authorization: Bearer <token>` metadata to each gRPC request.
 4. The gateway validates the JWT signature, issuer, audience, expiration, and key ID against the issuer's JWKS.
 5. The gateway extracts roles and optional scopes from the configured claim paths.
-6. The gateway authorizes the gRPC method. Platform-scoped methods require the configured admin role. Workspace-scoped methods require the configured user role and a sufficient membership in the target workspace. Admin role holders satisfy user-role checks and bypass workspace membership checks.
+6. The gateway authorizes the gRPC method. Platform-scoped methods require the configured admin role or a matching `admin_subjects` entry. Workspace-scoped methods require the configured user role and a sufficient membership in the target workspace. Admin role holders and admin subjects satisfy user-role checks and bypass workspace membership checks.
 
 For the Platform Admin, Workspace Admin, and Workspace User permissions, refer
 to [Manage Workspaces and Access](/sandboxes/manage-workspaces).

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -157,6 +157,7 @@ roles_claim   = "realm_access.roles"
 admin_role    = "openshell-admin"
 user_role     = "openshell-user"
 scopes_claim  = ""
+admin_subjects = []
 
 [[openshell.gateway.interceptors]]
 name               = "quota"


### PR DESCRIPTION
## Summary

Add `admin_subjects` to the OIDC gateway config — a list of OIDC subject (`sub` claim) values that are granted Platform Admin regardless of their JWT role claims. Works alongside `admin_role` — either mechanism grants admin access. This is a no-op in auth-only mode (when both `admin_role` and `user_role` are empty).

This enables granting admin to specific identity-provider users without requiring a dedicated admin role assignment in the IdP, which is useful for bootstrapping, break-glass access, and IdPs where role management is inconvenient.

## Related Issue

No issue required: self-contained auth enhancement with config, server, Helm, and docs changes in a single commit.

## Changes

- **`openshell-core`**: Add `admin_subjects: Vec<String>` to `OidcConfig` (serde-default, backward compatible).
- **`openshell-server/auth/authz.rs`**: `AuthzPolicy` gains `admin_subjects: HashSet<String>`. Role checks now also pass if the caller's `sub` is in `admin_subjects`.
- **`openshell-server/auth/workspace_authz.rs`**: Extract `AdminPolicy` struct bundling `admin_role` + `admin_subjects`. Replace bare `&str` admin-role parameters with `&AdminPolicy` across `authorize_workspace`, `authorize_sandbox_workspace`, `require_platform_admin`, and `is_platform_admin_principal`.
- **`openshell-server` gRPC handlers**: Thread `AdminPolicy` through all RPC handlers that check platform admin (sandbox, workspace, policy, provider, inference, service).
- **`openshell-server/cli.rs`**: Log `admin_subjects` count at startup when non-empty.
- **Helm chart**: Add `server.oidc.adminSubjects` list value, render `admin_subjects = [...]` in `gateway-config.yaml`.
- **Docs**: Add `admin_subjects` row to `docs/reference/gateway-config.mdx`.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated (authz.rs: 3 new tests, workspace_authz.rs: 4 new tests)
- [x] Validated on dev cluster (ROSA, Keycloak): removed `openshell-admin` role from test user, confirmed Platform Admin access via `admin_subjects` match alone
- [ ] E2E tests added/updated (not applicable — OIDC e2e infra does not yet support per-user subject assertions)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
