### PR TITLE
fix(compute): allow retry after failed sandbox provisioning

### DIFF
--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -1092,6 +1092,19 @@ impl DockerComputeDriver {
             ),
         );
         self.publish_sandbox_snapshot(snapshot);
+
+        // Provisioning failures are terminal: there is no usable Docker resource to
+        // recover, and retaining the pending record would reserve the name
+        // until the user manually deletes the failed sandbox. Publish the
+        // failure snapshot first so the create watcher can report the cause,
+        // then remove the driver and gateway records so the name is reusable.
+        let removed = {
+            let mut pending = self.pending.lock().await;
+            pending.remove(&sandbox.id).is_some()
+        };
+        if removed {
+            self.publish_deleted(sandbox.id.clone());
+        }
     }
 
     async fn publish_container_snapshot(

--- a/crates/openshell-driver-docker/src/tests.rs
+++ b/crates/openshell-driver-docker/src/tests.rs
@@ -2167,6 +2167,54 @@ fn pending_sandbox_snapshot_uses_docker_namespace_and_starting_condition() {
     assert_eq!(status.conditions[0].message, "Docker container is starting");
 }
 
+#[tokio::test]
+async fn failed_provisioning_removes_pending_sandbox_and_publishes_deleted() {
+    let driver = test_driver_with_config(runtime_config());
+    let sandbox = test_sandbox();
+    let mut events = driver.events.subscribe();
+
+    driver.reserve_pending_sandbox(&sandbox).await.unwrap();
+    driver
+        .fail_pending_sandbox(
+            &sandbox,
+            &DockerProvisioningFailure::new("ImagePullFailed", "image not found"),
+        )
+        .await;
+
+    assert!(
+        driver
+            .pending_snapshot(&sandbox.id, &sandbox.name)
+            .await
+            .is_none()
+    );
+
+    let mut saw_error_snapshot = false;
+    let mut deleted = false;
+    while let Ok(event) = events.try_recv() {
+        match event.payload {
+            Some(watch_sandboxes_event::Payload::Sandbox(event)) => {
+                let snapshot = event.sandbox.expect("sandbox snapshot");
+                saw_error_snapshot = snapshot
+                    .status
+                    .and_then(|status| status.conditions.into_iter().next())
+                    .is_some_and(|condition| condition.reason == "ImagePullFailed");
+            }
+            Some(watch_sandboxes_event::Payload::Deleted(event)) => {
+                deleted = event.sandbox_id == sandbox.id;
+            }
+            _ => {}
+        }
+    }
+    assert!(
+        saw_error_snapshot,
+        "failed provisioning should publish the failure before deletion"
+    );
+    assert!(
+        deleted,
+        "failed provisioning should publish a deletion event"
+    );
+}
+
 #[test]
 fn validate_linux_elf_binary_rejects_non_elf_files() {
     let tempdir = TempDir::new().unwrap();

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -886,6 +886,8 @@ impl ComputeRuntime {
         let mut driver_sandbox = driver_sandbox_from_public(&sandbox, &self.driver_info.name)
             .map_err(|status| *status)?;
 
+        self.remove_failed_sandbox_for_create(&sandbox).await?;
+
         // Create with MustCreate condition to prevent duplicate creation race
         self.sandbox_index.update_from_sandbox(&sandbox);
         let mut sandbox = sandbox;
@@ -979,6 +981,39 @@ impl ComputeRuntime {
                 )))
             }
         }
+    }
+
+    async fn remove_failed_sandbox_for_create(&self, sandbox: &Sandbox) -> Result<(), Status> {
+        let _guard = self.sync_lock.lock().await;
+        let Some(record) = self
+            .store
+            .get_by_name(
+                Sandbox::object_type(),
+                sandbox.object_workspace(),
+                sandbox.object_name(),
+            )
+            .await
+            .map_err(|e| Status::internal(format!("fetch existing sandbox failed: {e}")))?
+        else {
+            return Ok(());
+        };
+        let existing = decode_sandbox_record(&record)
+            .map_err(|e| Status::internal(format!("decode existing sandbox failed: {e}")))?;
+        if SandboxPhase::try_from(existing.phase()).unwrap_or(SandboxPhase::Unknown)
+            != SandboxPhase::Error
+        {
+            return Ok(());
+        }
+
+        self.cleanup_sandbox_owned_records(&existing)
+            .await
+            .map_err(|e| Status::internal(format!("cleanup failed sandbox: {e}")))?;
+        self.store
+            .delete(Sandbox::object_type(), existing.object_id())
+            .await
+            .map_err(|e| Status::internal(format!("delete failed sandbox: {e}")))?;
+        self.cleanup_removed_sandbox_state(existing.object_id());
+        Ok(())
     }
 
     pub(crate) async fn delete_sandbox(
@@ -7106,6 +7141,34 @@ mod tests {
             stored.metadata.as_ref().unwrap().resource_version,
             1,
             "database should have resource_version: 1 after create"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_sandbox_replaces_failed_same_name_without_waiting_for_deleted_event() {
+        let runtime = test_runtime(Arc::new(TestDriver::default())).await;
+        let failed = sandbox_record("sb-failed", "retryable-sandbox", SandboxPhase::Error);
+        runtime.store.put_message(&failed).await.unwrap();
+
+        let retry = sandbox_record("sb-retry", "retryable-sandbox", SandboxPhase::Provisioning);
+        let created = runtime.create_sandbox(retry, None).await.unwrap();
+
+        assert_eq!(created.object_id(), "sb-retry");
+        assert!(
+            runtime
+                .store
+                .get_message::<Sandbox>("sb-failed")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            runtime
+                .store
+                .get_message::<Sandbox>("sb-retry")
+                .await
+                .unwrap()
+                .is_some()
         );
     }
 


### PR DESCRIPTION
## Summary

Allow immediate retries after sandbox provisioning fails by cleaning up stale failed sandbox records before creating a new sandbox with the same name.

## Related Issue

Closes #2675

## Changes

- Remove failed Docker pending resources and publish deletion after provisioning failure.
- Allow the gateway to replace an Error-phase sandbox when a same-name retry arrives before the Deleted event is processed.
- Add regression tests for cleanup publication and immediate retry behavior.

## Testing

- [ ] mise run pre-commit passes (blocked: mise is not installed in the environment)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (local gateway build blocked by missing host libz3)
- [x] cargo clippy -p openshell-server --tests --features bundled-z3 -- -D warnings
- [x] cargo fmt --all -- --check

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable)