### PR TITLE
fix(dev): separate Podman Machine loopback listeners

### DIFF
--- a/tasks/scripts/gateway.sh
+++ b/tasks/scripts/gateway.sh
@@ -300,6 +300,16 @@ SANDBOX_IMAGE="${OPENSHELL_SANDBOX_IMAGE:-ghcr.io/nvidia/openshell-community/san
 SANDBOX_IMAGE_PULL_POLICY="${OPENSHELL_SANDBOX_IMAGE_PULL_POLICY:-IfNotPresent}"
 GRPC_ENDPOINT="${OPENSHELL_GRPC_ENDPOINT:-}"
 LOG_LEVEL="${OPENSHELL_LOG_LEVEL:-info}"
+PRIMARY_BIND_IP="127.0.0.1"
+CLI_ENDPOINT_HOST="127.0.0.1"
+
+if [[ "${DRIVER}" == "podman" && "$(uname -s)" == "Darwin" ]]; then
+  # Podman Machine reserves IPv4 loopback for its callback-only listener.
+  # Keep the primary listener distinct while using a hostname that resolves
+  # to IPv6 loopback for local CLI connections.
+  PRIMARY_BIND_IP="::1"
+  CLI_ENDPOINT_HOST="localhost"
+fi
 
 if [[ "${DRIVER}" == "podman" ]]; then
   require_podman_service
@@ -421,7 +431,7 @@ EOF
     ;;
 esac
 
-GATEWAY_ENDPOINT="http://127.0.0.1:${PORT}"
+GATEWAY_ENDPOINT="http://${CLI_ENDPOINT_HOST}:${PORT}"
 register_gateway_metadata "${GATEWAY_NAME}" "${GATEWAY_ENDPOINT}" "${PORT}"
 
 echo "Starting standalone ${DRIVER} gateway..."
@@ -438,6 +448,7 @@ echo
 
 exec "${GATEWAY_BIN}" \
   --config "${CONFIG_PATH}" \
+  --bind-address "${PRIMARY_BIND_IP}" \
   --port "${PORT}" \
   --log-level "${LOG_LEVEL}" \
   --drivers "${DRIVER}" \


### PR DESCRIPTION
This fixes `mise run gateway` when auto-detection would select Podman on macOS.

On macOS, bind the standalone Podman gateway to IPv6 loopback while registering localhost as the TLS endpoint. This keeps IPv4 loopback available for the callback-only listener, matching the e2e fix in commit 4cb77a9.

## Summary
<!-- 1-3 sentences: what this PR does and why -->

## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- What testing was done? -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
