### PR TITLE
feat(build): embed auditable Rust dependency metadata

### DIFF
--- a/.agents/skills/sbom/SKILL.md
+++ b/.agents/skills/sbom/SKILL.md
@@ -9,14 +9,36 @@ Generate CycloneDX SBOMs, resolve missing licenses, and export to CSV for compli
 
 ## Overview
 
-The OpenShell SBOM tooling produces CycloneDX JSON SBOMs using Syft, resolves missing or hash-based licenses by querying public registries (crates.io, npm, PyPI), and exports the results to CSV for stakeholder review.
+The OpenShell SBOM tooling produces source-tree CycloneDX JSON SBOMs using Syft, resolves missing or hash-based licenses by querying public registries (crates.io, npm, PyPI), and exports the results to CSV for stakeholder review.
 
 SBOMs are **release artifacts only** -- they are generated on demand and not committed to the repository. Output lands in `deploy/sbom/output/` (gitignored).
+
+Release Dev and Release Tag image builds separately embed cargo-auditable metadata in the staged gateway and supervisor binaries. This metadata describes the binary's Rust dependency graph and lets Syft discover Cargo packages from the binary itself. It is not a complete image SBOM and is not an OCI SBOM attestation; publishing such an attestation remains separate work.
 
 ## Prerequisites
 
 - `mise install` has been run (installs Syft and other tools)
 - The repository is checked out at the root
+
+## Inspecting an Auditable Image Binary
+
+Opt into auditable metadata when staging a local image binary:
+
+```bash
+OPENSHELL_AUDITABLE=1 PREBUILT_ARCH=amd64 \
+  tasks/scripts/stage-prebuilt-binaries.sh gateway
+```
+
+Scan the staged binary rather than the source tree:
+
+```bash
+mise x -- syft \
+  "file:deploy/docker/.build/prebuilt-binaries/amd64/openshell-gateway" \
+  -o cyclonedx-json
+```
+
+This output is limited to packages Syft discovers from that binary. Use
+`mise run sbom` for the broader source-tree license-compliance inventory.
 
 ## Workflow 1: Full SBOM Generation (One Command)
 

--- a/.agents/skills/sbom/SKILL.md
+++ b/.agents/skills/sbom/SKILL.md
@@ -9,14 +9,40 @@ Generate CycloneDX SBOMs, resolve missing licenses, and export to CSV for compli
 
 ## Overview
 
-The OpenShell SBOM tooling produces CycloneDX JSON SBOMs using Syft, resolves missing or hash-based licenses by querying public registries (crates.io, npm, PyPI), and exports the results to CSV for stakeholder review.
+The OpenShell SBOM tooling produces source-tree CycloneDX JSON SBOMs using Syft, resolves missing or hash-based licenses by querying public registries (crates.io, npm, PyPI), and exports the results to CSV for stakeholder review.
 
 SBOMs are **release artifacts only** -- they are generated on demand and not committed to the repository. Output lands in `deploy/sbom/output/` (gitignored).
+
+Release Dev and Release Tag image builds separately embed cargo-auditable
+metadata in the staged gateway and supervisor binaries. This metadata describes
+the binary's Rust dependency graph and lets Syft discover Cargo packages from
+the binary itself. It is not a complete image SBOM and is not an OCI SBOM
+attestation; publishing such an attestation remains separate work.
 
 ## Prerequisites
 
 - `mise install` has been run (installs Syft and other tools)
 - The repository is checked out at the root
+
+## Inspecting an Auditable Image Binary
+
+Opt into auditable metadata when staging a local image binary:
+
+```bash
+OPENSHELL_AUDITABLE=1 PREBUILT_ARCH=amd64 \
+  tasks/scripts/stage-prebuilt-binaries.sh gateway
+```
+
+Scan the staged binary rather than the source tree:
+
+```bash
+mise x -- syft \
+  "file:deploy/docker/.build/prebuilt-binaries/amd64/openshell-gateway" \
+  -o cyclonedx-json
+```
+
+This output is limited to packages Syft discovers from that binary. Use
+`mise run sbom` for the broader source-tree license-compliance inventory.
 
 ## Workflow 1: Full SBOM Generation (One Command)
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: ""
+      auditable:
+        description: "Embed cargo-auditable dependency metadata in image binaries"
+        required: false
+        type: boolean
+        default: false
       image-tag:
         description: "Image tag base to build/push (defaults to the GitHub SHA)"
         required: false
@@ -177,6 +182,7 @@ jobs:
       image-tag: ${{ needs.resolve.outputs.image_tag_base }}
       checkout-ref: ${{ inputs['checkout-ref'] }}
       features: ${{ needs.resolve.outputs.features }}
+      auditable: ${{ inputs.auditable }}
       artifact-name: ${{ needs.resolve.outputs.artifact_prefix }}-linux-${{ matrix.arch }}
     secrets: inherit
 

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -59,6 +59,7 @@ jobs:
     with:
       component: gateway
       cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
+      auditable: true
 
   build-supervisor:
     needs: [compute-versions]
@@ -66,6 +67,7 @@ jobs:
     with:
       component: supervisor
       cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
+      auditable: true
 
   e2e:
     needs: [build-gateway, build-supervisor]

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -81,6 +81,7 @@ jobs:
       cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
       image-tag: ${{ needs.compute-versions.outputs.source_sha }}
       checkout-ref: ${{ inputs.tag || github.ref }}
+      auditable: true
 
   build-supervisor:
     needs: [compute-versions]
@@ -90,6 +91,7 @@ jobs:
       cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
       image-tag: ${{ needs.compute-versions.outputs.source_sha }}
       checkout-ref: ${{ inputs.tag || github.ref }}
+      auditable: true
 
   e2e:
     needs: [compute-versions, build-gateway, build-supervisor]

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -79,6 +79,7 @@ jobs:
       cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
       image-tag: ${{ needs.compute-versions.outputs.source_sha }}
       checkout-ref: ${{ inputs.tag || github.ref }}
+      auditable: true
 
   build-supervisor:
     needs: [compute-versions]
@@ -88,6 +89,7 @@ jobs:
       cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
       image-tag: ${{ needs.compute-versions.outputs.source_sha }}
       checkout-ref: ${{ inputs.tag || github.ref }}
+      auditable: true
 
   e2e:
     needs: [compute-versions, build-gateway, build-supervisor]

--- a/.github/workflows/rust-native-build.yml
+++ b/.github/workflows/rust-native-build.yml
@@ -40,6 +40,11 @@ on:
         required: false
         type: string
         default: ""
+      auditable:
+        description: "Embed cargo-auditable dependency metadata in the binary"
+        required: false
+        type: boolean
+        default: false
       retention-days:
         description: "Artifact retention period"
         required: false
@@ -265,6 +270,7 @@ jobs:
           mise x -- rustup target add "${{ steps.target.outputs.target }}"
           
           cargo_cmd=(cargo build)
+          cargo_env=()
           build_target="${{ steps.target.outputs.target }}"
           args=()
           
@@ -278,6 +284,13 @@ jobs:
             # accepts -static for *-linux-gnu and links dynamically anyway.
             export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static"
           fi
+          if [[ "${{ inputs.auditable }}" == "true" ]]; then
+            cargo_cmd=("${cargo_cmd[0]}" auditable "${cargo_cmd[@]:1}")
+            # mise.toml injects RUSTC_WRAPPER=sccache. Unset it after mise has
+            # constructed the environment so it cannot wrap cargo-auditable's
+            # RUSTC_WORKSPACE_WRAPPER and misidentify that wrapper as rustc.
+            cargo_env=(env -u RUSTC_WRAPPER)
+          fi
           args+=(
             --release
             --target "$build_target"
@@ -290,7 +303,7 @@ jobs:
           if [[ -n "${{ steps.version.outputs.cargo_version }}" ]]; then
             export GIT_DIR=/nonexistent
           fi
-          mise x -- "${cargo_cmd[@]}" "${args[@]}"
+          mise x -- "${cargo_env[@]}" "${cargo_cmd[@]}" "${args[@]}"
 
       - name: Verify packaged binary
         run: |
@@ -306,6 +319,22 @@ jobs:
             echo "gateway binary must not depend on shared libz3; enable bundled-z3 for image artifacts" >&2
             exit 1
           fi
+
+      - name: Verify auditable dependency metadata
+        if: inputs.auditable
+        run: |
+          set -euo pipefail
+          BIN="target/${{ steps.target.outputs.target }}/release/${{ steps.target.outputs.binary }}"
+          cargo_packages="$(
+            SYFT_CHECK_FOR_APP_UPDATE=false \
+              mise x -- syft "file:$BIN" -o cyclonedx-json |
+              jq '[.components[]? | select((.purl // "") | startswith("pkg:cargo/"))] | length'
+          )"
+          if [[ "$cargo_packages" -eq 0 ]]; then
+            echo "Syft did not decode any Cargo packages from $BIN" >&2
+            exit 1
+          fi
+          echo "auditable dependency metadata: $cargo_packages Cargo packages"
 
       - name: Verify glibc symbol floor
         if: inputs.component == 'gateway'

--- a/architecture/build.md
+++ b/architecture/build.md
@@ -130,6 +130,27 @@ step via the `rust-native-build.yml` workflow (per-architecture, per-component)
 and uploads the result as an artifact that the image build job downloads back
 into the staging directory before running Buildx.
 
+Gateway and supervisor binaries staged into Release Dev and Release Tag images
+are compiled through `cargo auditable` (pinned in `mise.toml`), which embeds a
+`.dep-v0` section describing the Rust dependencies actually compiled into the
+binary. That section holds data rather than symbols, so it survives the
+workspace's `strip = true` release profile, and Syft can catalog the crates
+present in image binaries instead of inferring them from the source tree. This
+is a different artifact from the source SBOM produced by `syft dir:.` in
+`tasks/sbom.toml`, which describes the checkout, and from an OCI SBOM
+attestation, which remains out of scope.
+
+Only release image builds are auditable. `docker-build.yml` and
+`rust-native-build.yml` take an `auditable` input that defaults to false, so PR
+and E2E image builds and standalone release artifacts remain non-auditable. The
+CI image gains the pinned `cargo-auditable` tool through `mise install --locked`
+but ships no auditable OpenShell binary of its own. Local staging opts in with
+`OPENSHELL_AUDITABLE=1`. sccache's `RUSTC_WRAPPER` is unset only around auditable
+builds, because it would otherwise wrap `cargo-auditable`'s workspace wrapper and
+be misidentified as `rustc`. Auditable builds are verified by scanning the built
+binary with Syft and requiring at least one decoded Cargo package; the check runs
+only for those builds.
+
 Runtime layout:
 
 - **Gateway**: `gcr.io/distroless/cc-debian13:nonroot` base, GNU-linked binary at

--- a/architecture/build.md
+++ b/architecture/build.md
@@ -129,6 +129,27 @@ step via the `rust-native-build.yml` workflow (per-architecture, per-component)
 and uploads the result as an artifact that the image build job downloads back
 into the staging directory before running Buildx.
 
+Gateway and supervisor binaries staged into Release Dev and Release Tag images
+are compiled through `cargo auditable` (pinned in `mise.toml`), which embeds a
+`.dep-v0` section describing the Rust dependencies actually compiled into the
+binary. That section holds data rather than symbols, so it survives the
+workspace's `strip = true` release profile, and Syft can catalog the crates
+present in image binaries instead of inferring them from the source tree. This
+is a different artifact from the source SBOM produced by `syft dir:.` in
+`tasks/sbom.toml`, which describes the checkout, and from an OCI SBOM
+attestation, which remains out of scope.
+
+Only release image builds are auditable. `docker-build.yml` and
+`rust-native-build.yml` take an `auditable` input that defaults to false, so PR
+and E2E image builds and standalone release artifacts remain non-auditable. The
+CI image gains the pinned `cargo-auditable` tool through `mise install --locked`
+but ships no auditable OpenShell binary of its own. Local staging opts in with
+`OPENSHELL_AUDITABLE=1`. sccache's `RUSTC_WRAPPER` is unset only around auditable
+builds, because it would otherwise wrap `cargo-auditable`'s workspace wrapper and
+be misidentified as `rustc`. Auditable builds are verified by scanning the built
+binary with Syft and requiring at least one decoded Cargo package; the check runs
+only for those builds.
+
 Runtime layout:
 
 - **Gateway**: `gcr.io/distroless/cc-debian13:nonroot` base, GNU-linked binary at

--- a/mise.lock
+++ b/mise.lock
@@ -158,6 +158,30 @@ checksum = "sha256:675804464634cf068dc206e9fafc1bd4557ffcc0b1638a1ff246d899b776f
 url = "https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.22.3/cargo-zigbuild-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/rust-cross/cargo-zigbuild/releases/assets/405676944"
 
+[[tools."github:rust-secure-code/cargo-auditable"]]
+version = "0.7.5"
+backend = "github:rust-secure-code/cargo-auditable"
+
+[tools."github:rust-secure-code/cargo-auditable"."platforms.linux-arm64"]
+checksum = "sha256:6d364879b516fa914f98504e551faddedf35b71543b4331a6d26e4e217778cfa"
+url = "https://github.com/rust-secure-code/cargo-auditable/releases/download/v0.7.5/cargo-auditable-aarch64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/rust-secure-code/cargo-auditable/releases/assets/426566627"
+
+[tools."github:rust-secure-code/cargo-auditable"."platforms.linux-x64"]
+checksum = "sha256:322eda09f24e5dba97371c6c2c6949569c411ddf893852e88135cc5b51d5a719"
+url = "https://github.com/rust-secure-code/cargo-auditable/releases/download/v0.7.5/cargo-auditable-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/rust-secure-code/cargo-auditable/releases/assets/426566663"
+
+[tools."github:rust-secure-code/cargo-auditable"."platforms.macos-arm64"]
+checksum = "sha256:92720fff2be27492ca7b216510a27e88a835b526e9e94e46bc36b502ba17d8f0"
+url = "https://github.com/rust-secure-code/cargo-auditable/releases/download/v0.7.5/cargo-auditable-aarch64-apple-darwin.tar.xz"
+url_api = "https://api.github.com/repos/rust-secure-code/cargo-auditable/releases/assets/426566625"
+
+[tools."github:rust-secure-code/cargo-auditable"."platforms.windows-x64"]
+checksum = "sha256:83a7d5955c7ac96ede5d896ac9ede5f7ecce9ece0e95d9e47acd766b09e2ef1b"
+url = "https://github.com/rust-secure-code/cargo-auditable/releases/download/v0.7.5/cargo-auditable-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/rust-secure-code/cargo-auditable/releases/assets/426566657"
+
 [[tools.go]]
 version = "1.26.5"
 backend = "core:go"

--- a/mise.lock
+++ b/mise.lock
@@ -87,28 +87,6 @@ provenance = "github-attestations"
 version = "0.16.0"
 backend = "github:mozilla/sccache"
 
-[tools."github:mozilla/sccache".options]
-asset_pattern = "sccache-v*x86_64*linux*.tar.gz"
-
-[tools."github:mozilla/sccache"."platforms.linux-arm64"]
-checksum = "sha256:f73a5c39f96bb6ebb89cc7915cf182260d4cbf30765322c5e793d0fe8bd80784"
-url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060468"
-
-[tools."github:mozilla/sccache"."platforms.linux-x64"]
-checksum = "sha256:aec995a83ad3dff3d14b6314e08858b7b73d35ca85a5bcf3d3a9ec07dee35588"
-url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060682"
-
-[tools."github:mozilla/sccache"."platforms.macos-arm64"]
-checksum = "sha256:ded590cae2c72042c61178632906bef62d635fa20d45f8b22110a2241f430960"
-url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060416"
-
-[[tools."github:mozilla/sccache"]]
-version = "0.16.0"
-backend = "github:mozilla/sccache"
-
 [tools."github:mozilla/sccache"."platforms.linux-arm64"]
 checksum = "sha256:f73a5c39f96bb6ebb89cc7915cf182260d4cbf30765322c5e793d0fe8bd80784"
 url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-unknown-linux-musl.tar.gz"
@@ -152,6 +130,30 @@ url_api = "https://api.github.com/repos/rust-cross/cargo-zigbuild/releases/asset
 checksum = "sha256:675804464634cf068dc206e9fafc1bd4557ffcc0b1638a1ff246d899b776fe35"
 url = "https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.22.3/cargo-zigbuild-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/rust-cross/cargo-zigbuild/releases/assets/405676944"
+
+[[tools."github:rust-secure-code/cargo-auditable"]]
+version = "0.7.5"
+backend = "github:rust-secure-code/cargo-auditable"
+
+[tools."github:rust-secure-code/cargo-auditable"."platforms.linux-arm64"]
+checksum = "sha256:6d364879b516fa914f98504e551faddedf35b71543b4331a6d26e4e217778cfa"
+url = "https://github.com/rust-secure-code/cargo-auditable/releases/download/v0.7.5/cargo-auditable-aarch64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/rust-secure-code/cargo-auditable/releases/assets/426566627"
+
+[tools."github:rust-secure-code/cargo-auditable"."platforms.linux-x64"]
+checksum = "sha256:322eda09f24e5dba97371c6c2c6949569c411ddf893852e88135cc5b51d5a719"
+url = "https://github.com/rust-secure-code/cargo-auditable/releases/download/v0.7.5/cargo-auditable-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/rust-secure-code/cargo-auditable/releases/assets/426566663"
+
+[tools."github:rust-secure-code/cargo-auditable"."platforms.macos-arm64"]
+checksum = "sha256:92720fff2be27492ca7b216510a27e88a835b526e9e94e46bc36b502ba17d8f0"
+url = "https://github.com/rust-secure-code/cargo-auditable/releases/download/v0.7.5/cargo-auditable-aarch64-apple-darwin.tar.xz"
+url_api = "https://api.github.com/repos/rust-secure-code/cargo-auditable/releases/assets/426566625"
+
+[tools."github:rust-secure-code/cargo-auditable"."platforms.windows-x64"]
+checksum = "sha256:83a7d5955c7ac96ede5d896ac9ede5f7ecce9ece0e95d9e47acd766b09e2ef1b"
+url = "https://github.com/rust-secure-code/cargo-auditable/releases/download/v0.7.5/cargo-auditable-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/rust-secure-code/cargo-auditable/releases/assets/426566657"
 
 [[tools.go]]
 version = "1.26.5"

--- a/mise.toml
+++ b/mise.toml
@@ -42,6 +42,7 @@ k3d = { version = "5.8.3", os = ["macos"] }
 "github:EmbarkStudios/cargo-about" = { version = "0.8.4", version_prefix = "" }
 "github:EmbarkStudios/cargo-deny" = { version = "0.20.2", version_prefix = "" }
 zig = "0.14.1"
+"github:rust-secure-code/cargo-auditable" = "0.7.5"
 "github:rust-cross/cargo-zigbuild" = "0.22.3"
 "npm:markdownlint-cli2" = "0.22.0"
 

--- a/mise.toml
+++ b/mise.toml
@@ -41,6 +41,7 @@ k3d = { version = "5.8.3", os = ["macos"] }
 "github:anchore/syft" = { version = "1.44.0" }
 "github:EmbarkStudios/cargo-about" = { version = "0.8.4", version_prefix = "" }
 zig = "0.14.1"
+"github:rust-secure-code/cargo-auditable" = "0.7.5"
 "github:rust-cross/cargo-zigbuild" = "0.22.3"
 "npm:markdownlint-cli2" = "0.22.0"
 

--- a/tasks/scripts/stage-prebuilt-binaries.sh
+++ b/tasks/scripts/stage-prebuilt-binaries.sh
@@ -165,7 +165,8 @@ build_component_for_arch() {
   local target
   local stage
   local features
-  local cargo_subcommand
+  local -a cargo_subcommand
+  local -a cargo_env
   local build_target
   local current_host_os
   local current_host_arch
@@ -183,6 +184,7 @@ build_component_for_arch() {
   current_host_arch="$(host_arch)"
 
   cargo_subcommand=(cargo build)
+  cargo_env=()
   build_target="$target"
   build_rustflags="${RUSTFLAGS:-}"
 
@@ -221,6 +223,13 @@ build_component_for_arch() {
     fi
   fi
 
+  if [[ "${OPENSHELL_AUDITABLE:-0}" == "1" ]]; then
+    cargo_subcommand=("${cargo_subcommand[0]}" auditable "${cargo_subcommand[@]:1}")
+    # mise.toml injects RUSTC_WRAPPER=sccache. Unset it after mise constructs
+    # the environment so it cannot wrap cargo-auditable's workspace wrapper.
+    cargo_env=(env -u RUSTC_WRAPPER)
+  fi
+
   echo "Building ${binary} for linux/${arch} (${build_target}, libc: ${target_libc})..."
   mise x -- rustup target add "$target" >/dev/null 2>&1 || true
 
@@ -245,7 +254,7 @@ build_component_for_arch() {
     if [[ -n "$build_rustflags" ]]; then
       export RUSTFLAGS="$build_rustflags"
     fi
-    CARGO_INCREMENTAL=0 mise x -- "${cargo_subcommand[@]}" "${args[@]}"
+    CARGO_INCREMENTAL=0 mise x -- "${cargo_env[@]}" "${cargo_subcommand[@]}" "${args[@]}"
   )
 
   binary_path="${ROOT}/target/${target}/release/${binary}"
@@ -268,6 +277,14 @@ if [[ "$#" -gt 0 ]]; then
   usage
   exit 1
 fi
+
+case "${OPENSHELL_AUDITABLE:-0}" in
+  0|1) ;;
+  *)
+    echo "unsupported OPENSHELL_AUDITABLE: ${OPENSHELL_AUDITABLE} (expected 0 or 1)" >&2
+    exit 1
+    ;;
+esac
 
 restore_cargo_toml=0
 trap restore_workspace_version EXIT


### PR DESCRIPTION
## Summary

Embed the linked Rust dependency graph in gateway and supervisor binaries used by Release Dev and Release Tag images. This makes shipped binaries directly inspectable by Syft and other cargo-auditable consumers while keeping PR, E2E, and standalone artifact builds unchanged by default.

## Related Issue

Closes #2686

## Changes

- Pin cargo-auditable 0.7.5 with locked artifacts for all supported mise platforms
- Add an opt-in `auditable` input through the Docker and native Rust build workflows
- Enable auditable builds only for release gateway and supervisor images
- Unset sccache around auditable compiler invocations to avoid wrapper chaining failures
- Verify release binaries by requiring Syft to decode Cargo packages
- Add `OPENSHELL_AUDITABLE=1` for equivalent local prebuilt staging
- Document auditable binary metadata and its distinction from source-tree and OCI SBOMs

## Testing

- [x] `mise run pre-commit`
- [x] `mise run test`
- [x] Built auditable amd64 gateway and supervisor prebuilts locally
- [x] Syft decoded 491 gateway and 358 supervisor Cargo packages
- [x] Gateway retained its GLIBC 2.28 symbol floor
- [x] Supervisor remained fully static
- [ ] Release amd64/arm64 matrix — exercised by Release Dev after merge

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)

## Coordination

PR #2677 also updates `mise.toml` and `mise.lock`; if it merges first, the lockfile should be regenerated with both tools present.