### PR TITLE
fix(gateway): respect OPENSHELL_BIND_ADDRESS in dev task

### DIFF
--- a/tasks/scripts/gateway.sh
+++ b/tasks/scripts/gateway.sh
@@ -35,6 +35,8 @@ Options:
 Environment:
   OPENSHELL_DRIVERS       Driver override used by openshell-gateway.
   OPENSHELL_GATEWAY_NAME  Gateway name for generic podman/kubernetes runs.
+  OPENSHELL_BIND_ADDRESS  Gateway listener address. Defaults to 127.0.0.1,
+                          or ::1 for Podman Machine on macOS.
   OPENSHELL_SERVER_PORT   Gateway port. Defaults to 8080 for Kubernetes,
                           18080 for Podman/Docker, and 18081 for VM.
   OPENSHELL_SUPERVISOR_IMAGE
@@ -300,13 +302,16 @@ SANDBOX_IMAGE="${OPENSHELL_SANDBOX_IMAGE:-ghcr.io/nvidia/openshell-community/san
 SANDBOX_IMAGE_PULL_POLICY="${OPENSHELL_SANDBOX_IMAGE_PULL_POLICY:-IfNotPresent}"
 GRPC_ENDPOINT="${OPENSHELL_GRPC_ENDPOINT:-}"
 LOG_LEVEL="${OPENSHELL_LOG_LEVEL:-info}"
-PRIMARY_BIND_IP="127.0.0.1"
+PRIMARY_BIND_IP="${OPENSHELL_BIND_ADDRESS:-127.0.0.1}"
 CLI_ENDPOINT_HOST="127.0.0.1"
 
-if [[ "${DRIVER}" == "podman" && "$(uname -s)" == "Darwin" ]]; then
+if [[ -z "${OPENSHELL_BIND_ADDRESS:-}" \
+  && "${DRIVER}" == "podman" \
+  && "$(uname -s)" == "Darwin" ]]; then
   # Podman Machine reserves IPv4 loopback for its callback-only listener.
   # Keep the primary listener distinct while using a hostname that resolves
-  # to IPv6 loopback for local CLI connections.
+  # to IPv6 loopback for local CLI connections. An explicit bind address
+  # overrides this platform default.
   PRIMARY_BIND_IP="::1"
   CLI_ENDPOINT_HOST="localhost"
 fi
@@ -437,6 +442,7 @@ register_gateway_metadata "${GATEWAY_NAME}" "${GATEWAY_ENDPOINT}" "${PORT}"
 echo "Starting standalone ${DRIVER} gateway..."
 echo "  gateway:   ${GATEWAY_NAME}"
 echo "  endpoint:  ${GATEWAY_ENDPOINT}"
+echo "  bind:      ${PRIMARY_BIND_IP}:${PORT}"
 echo "  namespace: ${SANDBOX_NAMESPACE}"
 echo "  state dir: ${STATE_DIR}"
 if [[ "${DRIVER}" == "podman" ]]; then


### PR DESCRIPTION
This is convenient when you want to run a local gateway pointed at a remote compute driver so that the supervisor can reach across the network to the gateway which is listening on 0.0.0.0.

## Summary
<!-- 1-3 sentences: what this PR does and why -->

## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
