### PR TITLE
fix(podman): reuse IPv4 primary listener on macOS

### DIFF
--- a/e2e/with-podman-gateway.sh
+++ b/e2e/with-podman-gateway.sh
@@ -386,16 +386,8 @@ export OPENSHELL_E2E_GATEWAY_CA_CERT="${PKI_DIR}/ca.crt"
 
 HOST_PORT=$(e2e_pick_port)
 HEALTH_PORT=$(e2e_pick_port)
-if [ "$(uname -s)" = "Darwin" ]; then
-  # Podman Machine reserves IPv4 loopback for its callback-only listener.
-  PRIMARY_BIND_IP="::1"
-  CLI_ENDPOINT_HOST="localhost"
-  HEALTH_ENDPOINT_HOST="[::1]"
-else
-  PRIMARY_BIND_IP="127.0.0.1"
-  CLI_ENDPOINT_HOST="127.0.0.1"
-  HEALTH_ENDPOINT_HOST="127.0.0.1"
-fi
+CLI_ENDPOINT_HOST="127.0.0.1"
+HEALTH_ENDPOINT_HOST="127.0.0.1"
 STATE_DIR="${WORKDIR}/state"
 mkdir -p "${STATE_DIR}"
 export XDG_STATE_HOME="${STATE_DIR}"
@@ -427,9 +419,11 @@ GATEWAY_CONFIG="${STATE_DIR}/gateway.toml"
 
 # Start from the RPM default template so this e2e test exercises the same TOML
 # config path that RPM users get on first start. The template leaves
-# bind_address unset and sets compute_drivers = ["podman"]. On Podman Machine,
-# the driver reserves IPv4 loopback for its callback-only listener, so the
-# primary listener uses IPv6 loopback. Native Linux keeps the IPv4 default.
+# bind_address unset and sets compute_drivers = ["podman"]. The built-in IPv4
+# loopback primary covers Podman Machine's callback address, so the gateway
+# reuses it and relies on sandbox JWT authorization for callback RPCs. Native
+# Linux still creates an additional callback-only listener when its bridge or
+# rootless topology requires another address.
 #
 # We append the driver-specific table and override the port via CLI flag
 # (CLI > TOML in the merge precedence) so the test can use an ephemeral port.
@@ -468,9 +462,8 @@ cp "${ROOT}/deploy/rpm/gateway.toml.default" "${GATEWAY_CONFIG}"
 
 GATEWAY_ARGS=(
   --config "${GATEWAY_CONFIG}"
-  # compute_drivers comes from the RPM template. Override the loopback address
-  # and port so Podman Machine can keep its IPv4 callback listener distinct.
-  --bind-address "${PRIMARY_BIND_IP}"
+  # compute_drivers comes from the RPM template. Override only the port so this
+  # path continues to exercise the gateway's built-in IPv4 loopback default.
   --port "${HOST_PORT}"
   --health-port "${HEALTH_PORT}"
   --tls-cert "${PKI_DIR}/server/tls.crt"
@@ -535,8 +528,7 @@ while [ "${elapsed}" -lt "${timeout}" ]; do
     echo "ERROR: openshell-gateway exited before becoming healthy"
     exit 1
   fi
-  # Keep this loopback probe direct even when ::1 is absent from NO_PROXY.
-  if curl --noproxy '*' -sf "http://${HEALTH_ENDPOINT_HOST}:${HEALTH_PORT}/healthz" >/dev/null 2>&1; then
+  if curl -sf "http://${HEALTH_ENDPOINT_HOST}:${HEALTH_PORT}/healthz" >/dev/null 2>&1; then
     echo "Gateway healthy after ${elapsed}s."
     break
   fi

--- a/tasks/scripts/gateway.sh
+++ b/tasks/scripts/gateway.sh
@@ -35,8 +35,7 @@ Options:
 Environment:
   OPENSHELL_DRIVERS       Driver override used by openshell-gateway.
   OPENSHELL_GATEWAY_NAME  Gateway name for generic podman/kubernetes runs.
-  OPENSHELL_BIND_ADDRESS  Gateway listener address. Defaults to 127.0.0.1,
-                          or ::1 for Podman Machine on macOS.
+  OPENSHELL_BIND_ADDRESS  Gateway listener address. Defaults to 127.0.0.1.
   OPENSHELL_SERVER_PORT   Gateway port. Defaults to 8080 for Kubernetes,
                           18080 for Podman/Docker, and 18081 for VM.
   OPENSHELL_SUPERVISOR_IMAGE
@@ -304,17 +303,6 @@ GRPC_ENDPOINT="${OPENSHELL_GRPC_ENDPOINT:-}"
 LOG_LEVEL="${OPENSHELL_LOG_LEVEL:-info}"
 PRIMARY_BIND_IP="${OPENSHELL_BIND_ADDRESS:-127.0.0.1}"
 CLI_ENDPOINT_HOST="127.0.0.1"
-
-if [[ -z "${OPENSHELL_BIND_ADDRESS:-}" \
-  && "${DRIVER}" == "podman" \
-  && "$(uname -s)" == "Darwin" ]]; then
-  # Podman Machine reserves IPv4 loopback for its callback-only listener.
-  # Keep the primary listener distinct while using a hostname that resolves
-  # to IPv6 loopback for local CLI connections. An explicit bind address
-  # overrides this platform default.
-  PRIMARY_BIND_IP="::1"
-  CLI_ENDPOINT_HOST="localhost"
-fi
 
 if [[ "${DRIVER}" == "podman" ]]; then
   require_podman_service


### PR DESCRIPTION
## Summary

Remove the stale macOS Podman IPv6 listener split now that the gateway reuses a primary listener that covers the driver callback address. Local Podman workflows return to the standard `127.0.0.1` gateway endpoint.

## Related Issue

No issue required: this is a localized correction that removes the workaround introduced in #2622 after primary-listener reuse landed in #2739.

## Changes

- Remove the macOS Podman `::1` primary-listener override from the local gateway launcher.
- Exercise the gateway built-in IPv4 loopback default in the Podman E2E harness.
- Remove the IPv6-specific health-probe proxy bypass.
- Preserve driver callback-address discovery so Linux and explicit non-covering binds can still receive a callback-only listener.

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo test -p openshell-server gateway_listener` passes (17 tests)
- [ ] `mise run e2e:podman` (running separately in the main task)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)