### PR TITLE
fix(driver-podman): make std::path::Path import unconditional

### DIFF
--- a/crates/openshell-driver-podman/src/container.rs
+++ b/crates/openshell-driver-podman/src/container.rs
@@ -14,7 +14,6 @@ use openshell_core::{driver_mounts, proto_struct};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashSet};
-#[cfg(target_os = "linux")]
 use std::path::Path;
 
 /// Returns `true` when `SELinux` is enabled (enforcing or permissive).


### PR DESCRIPTION
## Summary
- PR #2562 (userns config) added `supervisor_bin_path: Option<&Path>` to `build_container_spec_for_image` without a cfg gate, but the `use std::path::Path` import was still gated behind `#[cfg(target_os = "linux")]` (added by #2188 when `Path` was only used in the Linux-only `selinux_enabled()`). This breaks compilation on macOS.

## Related Issue
Regression from #2562, reverses the now-incorrect gate from #2188.

## Changes
- Removed `#[cfg(target_os = "linux")]` from `use std::path::Path` since `Path` is now used in platform-independent code.

## Testing
- [x] `cargo check` passes on macOS
- [x] `mise run pre-commit` passes

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)