### PR TITLE
fix(cli): prompt for fresh OIDC login after logout

### DIFF
--- a/crates/openshell-bootstrap/src/oidc_token.rs
+++ b/crates/openshell-bootstrap/src/oidc_token.rs
@@ -39,6 +39,11 @@ pub fn oidc_token_path(gateway_name: &str) -> Result<PathBuf> {
     Ok(user_gateway_dir(gateway_name)?.join("oidc_token.json"))
 }
 
+/// Path to the one-shot marker that asks the next browser login to prompt.
+pub fn oidc_login_prompt_required_path(gateway_name: &str) -> Result<PathBuf> {
+    Ok(user_gateway_dir(gateway_name)?.join("oidc_login_prompt_required"))
+}
+
 /// Store an OIDC token bundle for a gateway.
 pub fn store_oidc_token(gateway_name: &str, bundle: &OidcTokenBundle) -> Result<()> {
     let path = oidc_token_path(gateway_name)?;
@@ -50,6 +55,7 @@ pub fn store_oidc_token(gateway_name: &str, bundle: &OidcTokenBundle) -> Result<
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to write OIDC token to {}", path.display()))?;
     set_file_owner_only(&path)?;
+    clear_oidc_login_prompt(gateway_name)?;
     Ok(())
 }
 
@@ -68,6 +74,33 @@ pub fn load_oidc_token(gateway_name: &str) -> Option<OidcTokenBundle> {
 /// Remove a stored OIDC token.
 pub fn remove_oidc_token(gateway_name: &str) -> Result<()> {
     let path = oidc_token_path(gateway_name)?;
+    if path.exists() {
+        std::fs::remove_file(&path)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to remove {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Mark the next interactive OIDC login as requiring a fresh `IdP` prompt.
+pub fn request_oidc_login_prompt(gateway_name: &str) -> Result<()> {
+    let path = oidc_login_prompt_required_path(gateway_name)?;
+    ensure_parent_dir_restricted(&path)?;
+    std::fs::write(&path, b"1\n")
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+    set_file_owner_only(&path)?;
+    Ok(())
+}
+
+/// Return whether the next interactive OIDC login should request a fresh prompt.
+pub fn oidc_login_prompt_required(gateway_name: &str) -> bool {
+    oidc_login_prompt_required_path(gateway_name).is_ok_and(|path| path.exists())
+}
+
+/// Clear the one-shot fresh-login marker for a gateway.
+pub fn clear_oidc_login_prompt(gateway_name: &str) -> Result<()> {
+    let path = oidc_login_prompt_required_path(gateway_name)?;
     if path.exists() {
         std::fs::remove_file(&path)
             .into_diagnostic()
@@ -127,6 +160,38 @@ mod tests {
             assert!(store_oidc_token("../escape", &bundle).is_err());
             assert!(load_oidc_token("../escape").is_none());
             assert!(remove_oidc_token("../escape").is_err());
+        });
+    }
+
+    #[test]
+    fn oidc_login_prompt_marker_is_per_gateway() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_tmp_xdg(tmp.path(), || {
+            assert!(!oidc_login_prompt_required("alpha"));
+            assert!(!oidc_login_prompt_required("beta"));
+
+            request_oidc_login_prompt("alpha").unwrap();
+
+            assert!(oidc_login_prompt_required("alpha"));
+            assert!(!oidc_login_prompt_required("beta"));
+
+            let bundle = OidcTokenBundle {
+                access_token: "token".to_string(),
+                refresh_token: None,
+                expires_at: None,
+                issuer: "https://issuer.example.com".to_string(),
+                client_id: "openshell-cli".to_string(),
+            };
+            store_oidc_token("alpha", &bundle).unwrap();
+
+            assert!(!oidc_login_prompt_required("alpha"));
+
+            request_oidc_login_prompt("alpha").unwrap();
+            assert!(oidc_login_prompt_required("alpha"));
+
+            clear_oidc_login_prompt("alpha").unwrap();
+
+            assert!(!oidc_login_prompt_required("alpha"));
         });
     }
 }

--- a/crates/openshell-cli/src/commands/gateway.rs
+++ b/crates/openshell-cli/src/commands/gateway.rs
@@ -912,6 +912,7 @@ pub async fn gateway_add(
                 oidc_audience,
                 oidc_scopes,
                 gateway_insecure,
+                false,
             )
             .await
             {
@@ -1116,6 +1117,8 @@ pub async fn gateway_login(name: &str, gateway_insecure: bool) -> Result<()> {
                 .unwrap_or("openshell-cli");
             let audience = metadata.oidc_audience.as_deref();
             let scopes = metadata.oidc_scopes.as_deref();
+            let force_fresh_login =
+                openshell_bootstrap::oidc_token::oidc_login_prompt_required(name);
 
             let bundle = if std::env::var("OPENSHELL_OIDC_CLIENT_SECRET").is_ok() {
                 crate::oidc_auth::oidc_client_credentials_flow(
@@ -1133,12 +1136,14 @@ pub async fn gateway_login(name: &str, gateway_insecure: bool) -> Result<()> {
                     audience,
                     scopes,
                     gateway_insecure,
+                    force_fresh_login,
                 )
                 .await?
             };
 
             let username = jwt_preferred_username(&bundle.access_token);
             openshell_bootstrap::oidc_token::store_oidc_token(name, &bundle)?;
+            openshell_bootstrap::oidc_token::clear_oidc_login_prompt(name)?;
 
             if let Some(user) = username {
                 eprintln!(
@@ -1184,6 +1189,7 @@ pub fn gateway_logout(name: &str) -> Result<()> {
     match metadata.auth_mode.as_deref() {
         Some("oidc") => {
             openshell_bootstrap::oidc_token::remove_oidc_token(name)?;
+            openshell_bootstrap::oidc_token::request_oidc_login_prompt(name)?;
         }
         Some("cloudflare_jwt") => {
             openshell_bootstrap::edge_token::remove_edge_token(name)?;
@@ -1429,6 +1435,9 @@ fn remove_gateway_registration(name: &str) {
     }
     if let Err(err) = openshell_bootstrap::oidc_token::remove_oidc_token(name) {
         tracing::debug!("failed to remove oidc token: {err}");
+    }
+    if let Err(err) = openshell_bootstrap::oidc_token::clear_oidc_login_prompt(name) {
+        tracing::debug!("failed to clear oidc login prompt marker: {err}");
     }
     if let Err(err) = remove_gateway_metadata(name) {
         tracing::debug!("failed to remove gateway metadata: {err}");

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -1172,7 +1172,8 @@ enum GatewayCommands {
     /// Authenticate with an edge-authenticated or OIDC gateway.
     ///
     /// Opens a browser for the edge proxy's login flow and stores the
-    /// token locally. Use this to re-authenticate when a token expires.
+    /// token locally. After `gateway logout`, OIDC browser login requests a
+    /// fresh identity-provider prompt so you can switch users.
     #[command(help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
     Login {
         /// Gateway name (defaults to the active gateway).
@@ -1183,7 +1184,9 @@ enum GatewayCommands {
     /// Clear stored authentication credentials for a gateway.
     ///
     /// Removes the locally stored OIDC token or edge token so subsequent
-    /// commands require re-authentication via `gateway login`.
+    /// commands require re-authentication via `gateway login`. For OIDC
+    /// gateways, the next browser login asks the identity provider for a fresh
+    /// login instead of silently reusing an existing browser session.
     #[command(help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
     Logout {
         /// Gateway name (defaults to the active gateway).

--- a/crates/openshell-cli/src/oidc_auth.rs
+++ b/crates/openshell-cli/src/oidc_auth.rs
@@ -96,6 +96,20 @@ fn build_ci_scopes(scopes: Option<&str>) -> Vec<Scope> {
         .collect()
 }
 
+fn interactive_authorization_params(
+    audience: Option<&str>,
+    force_fresh_login: bool,
+) -> Vec<(&'static str, String)> {
+    let mut params = Vec::new();
+    if force_fresh_login {
+        params.push(("prompt", "login".to_string()));
+    }
+    if let Some(aud) = audience {
+        params.push(("audience", aud.to_string()));
+    }
+    params
+}
+
 /// Run the OIDC Authorization Code + PKCE browser flow.
 ///
 /// Opens the user's browser to the Keycloak login page and waits for
@@ -106,6 +120,7 @@ pub async fn oidc_browser_auth_flow(
     audience: Option<&str>,
     scopes: Option<&str>,
     insecure: bool,
+    force_fresh_login: bool,
 ) -> Result<OidcTokenBundle> {
     let discovery = discover(issuer, insecure).await?;
 
@@ -130,10 +145,14 @@ pub async fn oidc_browser_auth_flow(
 
     let (mut auth_url, csrf_token) = auth_request.url();
 
-    // Append audience parameter for providers like Entra ID where the API
-    // audience differs from the client ID.
-    if let Some(aud) = audience {
-        auth_url.query_pairs_mut().append_pair("audience", aud);
+    // After `gateway logout`, ask the IdP for a fresh login prompt so the user
+    // can switch browser identity. Ordinary repeated logins may reuse SSO.
+    let params = interactive_authorization_params(audience, force_fresh_login);
+    {
+        let mut query = auth_url.query_pairs_mut();
+        for (key, value) in &params {
+            query.append_pair(key, value);
+        }
     }
 
     let (tx, rx) = oneshot::channel::<String>();
@@ -535,6 +554,26 @@ mod tests {
     fn build_ci_scopes_empty_on_none() {
         let scopes = build_ci_scopes(None);
         assert!(scopes.is_empty());
+    }
+
+    #[test]
+    fn interactive_authorization_params_force_fresh_login() {
+        assert_eq!(
+            interactive_authorization_params(Some("api://openshell"), true),
+            vec![
+                ("prompt", "login".to_string()),
+                ("audience", "api://openshell".to_string()),
+            ]
+        );
+        assert_eq!(
+            interactive_authorization_params(None, true),
+            vec![("prompt", "login".to_string())]
+        );
+        assert_eq!(
+            interactive_authorization_params(Some("api://openshell"), false),
+            vec![("audience", "api://openshell".to_string())]
+        );
+        assert!(interactive_authorization_params(None, false).is_empty());
     }
 
     #[test]

--- a/docs/reference/gateway-auth.mdx
+++ b/docs/reference/gateway-auth.mdx
@@ -120,7 +120,7 @@ openshell gateway add https://gateway.example.com \
   --oidc-audience openshell-cli
 ```
 
-When you register or log in to an OIDC gateway, the CLI uses the Authorization Code flow with PKCE. It opens a browser, receives the authorization code on a localhost callback, exchanges the code for tokens, and stores the token bundle under the gateway credential directory. If `OPENSHELL_OIDC_CLIENT_SECRET` is set, the CLI uses the client credentials flow instead. Use that mode for CI and other non-interactive automation.
+When you register or log in to an OIDC gateway, the CLI uses the Authorization Code flow with PKCE. It opens a browser, receives the authorization code on a localhost callback, exchanges the code for tokens, and stores the token bundle under the gateway credential directory. After `openshell gateway logout`, the next browser login asks the identity provider for a fresh login prompt so you can choose a different browser user instead of silently reusing the previous session. If `OPENSHELL_OIDC_CLIENT_SECRET` is set, the CLI uses the client credentials flow instead. Use that mode for CI and other non-interactive automation.
 
 The connection flow:
 


### PR DESCRIPTION
## Summary
Fix OIDC logout/login behavior so openshell gateway logout causes the next browser-based openshell gateway login to request a fresh identity-provider prompt. This lets users switch browser identities instead  of silently reusing the previous SSO session.

## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->

## Changes
- Added a per-gateway one-shot marker requesting prompt=login after OIDC logout.
- Cleared the marker after a successful token store or gateway registration removal.
- Updated the browser OIDC auth flow to append prompt=login when the marker is present.
- Updated CLI help text and gateway auth docs to describe the fresh-login behavior.
- Added unit coverage for marker lifecycle and authorization URL parameters.

## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
