### PR TITLE
fix(build): preserve version prefixes in mise lockfile

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -198,6 +198,9 @@ backend = "go:google.golang.org/protobuf/cmd/protoc-gen-go"
 version = "4.2.0"
 backend = "aqua:helm/helm"
 
+[tools.helm.options]
+"vars.version_prefix" = "v"
+
 [tools.helm."platforms.linux-arm64"]
 checksum = "sha256:1f8de130dfbd04de64978e7b852a7a547be1404956a366608276d2520b678670"
 url = "https://get.helm.sh/helm-v4.2.0-linux-arm64.tar.gz"
@@ -265,6 +268,9 @@ url_api = "https://api.github.com/repos/k3d-io/k3d/releases/assets/229450011"
 [[tools.kubectl]]
 version = "1.36.1"
 backend = "aqua:kubernetes/kubernetes/kubectl"
+
+[tools.kubectl.options]
+"vars.version_prefix" = "v"
 
 [tools.kubectl."platforms.linux-arm64"]
 checksum = "sha256:59f7ee8e477fae658447607dc3c8790ac17a1b016c01c622c12070e969e2d4e7"
@@ -365,18 +371,19 @@ backend = "core:rust"
 version = "2.20.0"
 backend = "aqua:GoogleContainerTools/skaffold"
 
+[tools.skaffold.options]
+"vars.version_prefix" = "v"
+
 [tools.skaffold."platforms.linux-arm64"]
 url = "https://storage.googleapis.com/skaffold/releases/v2.20.0/skaffold-linux-arm64"
 
 [tools.skaffold."platforms.linux-x64"]
-checksum = "blake3:4de6b14984ff1c7e5f107dd12d15890feb4b6600032d61158162c243a81d9156"
 url = "https://storage.googleapis.com/skaffold/releases/v2.20.0/skaffold-linux-amd64"
 
 [tools.skaffold."platforms.macos-arm64"]
 url = "https://storage.googleapis.com/skaffold/releases/v2.20.0/skaffold-darwin-arm64"
 
 [tools.skaffold."platforms.windows-x64"]
-checksum = "blake3:f6db036671e29118d0fdc4457dc563e99d7bff8a39f0f2f72e3e5d857d9013a3"
 url = "https://storage.googleapis.com/skaffold/releases/v2.20.0/skaffold-windows-amd64.exe"
 
 [[tools.uv]]

--- a/mise.toml
+++ b/mise.toml
@@ -22,7 +22,7 @@ lockfile_platforms = ["linux-x64", "linux-arm64", "macos-arm64", "windows-x64"]
 python = "3.14.5"
 rust = "1.95.0"
 node = "24.15.0"
-kubectl = "1.36.1"
+kubectl = { version = "1.36.1", version_prefix = "v" }
 uv = "0.10.12"
 protoc = "29.6"
 go = "1.26"
@@ -31,9 +31,9 @@ go = "1.26"
 "go:google.golang.org/grpc/cmd/protoc-gen-go-grpc" = "1.6.2"
 "go:golang.org/x/tools/cmd/goimports" = "0.48.0"
 buf = "1.72.0"
-helm = "4.2.0"
+helm = { version = "4.2.0", version_prefix = "v" }
 helm-docs = "1.14.2"
-skaffold = { version = "2.20.0", os = ["linux", "macos"] }
+skaffold = { version = "2.20.0", os = ["linux", "macos"], version_prefix = "v" }
 # Keep k3d out of Linux CI images until upstream ships a release rebuilt with
 # patched Go/container dependencies. Linux Kubernetes E2E uses kind or an
 # externally provided cluster context.


### PR DESCRIPTION
## Summary

Preserve the `v` release prefix for Helm, kubectl, and Skaffold when mise regenerates its lockfile. This prevents `mise lock` from rewriting valid artifact URLs and failing the lockfile consistency check observed in [Branch Checks](https://github.com/NVIDIA/OpenShell/actions/runs/32037939475/job/95413562871).

## Related Issue

No issue required: localized build-tooling fix for reproducible mise lock generation.

## Changes

- Configure explicit `v` version prefixes for the affected Aqua-backed tools
- Regenerate `mise.lock` while keeping all pinned tool versions unchanged

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated (not applicable; configuration-only change)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; build metadata only)