### PR TITLE
feat(sandbox)!: introduce reusable sandbox templates

### DIFF
--- a/.agents/skills/openshell-cli/SKILL.md
+++ b/.agents/skills/openshell-cli/SKILL.md
@@ -202,7 +202,7 @@ Key flags:
 - `--policy`: Custom policy YAML (otherwise uses built-in default or `OPENSHELL_SANDBOX_POLICY` env var)
 - `--gpu [COUNT]`: Request the driver's default GPU selection or a specific GPU count
 - `--cpu`, `--memory`: Set per-sandbox compute sizing. Docker/Podman apply limits; Kubernetes applies matching requests and limits.
-- `--driver-config-json`: Pass experimental driver-specific sandbox configuration
+- `--template NAME`: Create from a named sandbox template. Use templates for driver-specific configuration.
 - `--label KEY=VALUE`: Add labels for later selection (repeatable)
 - `--env KEY=VALUE`: Set non-secret sandbox environment variables (repeatable); use `--provider` for credentials
 - `--approval-mode manual|auto`: Control handling of agent-authored policy proposals; `manual` is the default
@@ -211,6 +211,42 @@ Key flags:
 - `--no-keep`: Delete the sandbox after the initial command or shell exits
 - `--forward [BIND_ADDRESS:]PORT`: Forward a local port and keep the sandbox alive
 - `--editor vscode|cursor`: Open a remote editor after creation and keep the sandbox alive
+
+Direct `sandbox create --driver-config-json` is rejected. Driver-specific
+settings belong to reusable sandbox templates:
+
+```bash
+openshell sandbox template create gpu-kata \
+  --from ghcr.io/nvidia/openshell-community/sandboxes/python:latest \
+  --driver-config-json '{"kubernetes":{"pod":{"node_selector":{"pool":"gpu"}}}}' \
+  --gpu 1
+
+openshell sandbox create --name my-sandbox --template gpu-kata --provider my-github
+```
+
+`--template` uses the template workload, so it cannot be combined with inline
+workload flags such as `--from`, `--gpu`, `--cpu`, `--memory`, `--env`, or
+`--driver-config-json`. Keep per-run policy, providers, labels, uploads,
+forwarding, editor launch, and the initial command on `sandbox create`.
+
+### Manage sandbox templates
+
+```bash
+openshell sandbox template create gpu-kata \
+  --from ghcr.io/nvidia/openshell-community/sandboxes/python:latest \
+  --cpu 2 \
+  --memory 4Gi \
+  --gpu 1 \
+  --driver-config-json '{"kubernetes":{}}'
+openshell sandbox template list
+openshell sandbox template list --all-workspaces --output json
+openshell sandbox template get gpu-kata
+openshell sandbox template delete gpu-kata
+```
+
+Template `--from` accepts image references and community sandbox names in this
+release. It does not build local Dockerfiles or directories; use direct
+`sandbox create --from ./Dockerfile` for local BYOC builds.
 
 ### List and inspect sandboxes
 
@@ -706,6 +742,11 @@ $ openshell sandbox upload --help
 | Create sandbox (interactive) | `openshell sandbox create` |
 | Create sandbox with tool | `openshell sandbox create -- claude` |
 | Create sandbox with GPUs | `openshell sandbox create --gpu 1` |
+| Create sandbox from template | `openshell sandbox create --template <template>` |
+| Create sandbox template | `openshell sandbox template create <name> --from <image> --driver-config-json '{"kubernetes":{}}'` |
+| List sandbox templates | `openshell sandbox template list` |
+| Inspect sandbox template | `openshell sandbox template get <name>` |
+| Delete sandbox template | `openshell sandbox template delete <name>` |
 | Create with custom policy | `openshell sandbox create --policy ./p.yaml` |
 | Connect to sandbox | `openshell sandbox connect <name>` |
 | Stop sandbox compute | `openshell sandbox stop [name]` |

--- a/.agents/skills/openshell-cli/cli-reference.md
+++ b/.agents/skills/openshell-cli/cli-reference.md
@@ -209,13 +209,13 @@ Create a sandbox through the selected gateway, wait for readiness, then connect,
 | Flag | Description |
 |------|-------------|
 | `--name <NAME>` | Sandbox name (auto-generated if omitted) |
+| `--template <NAME>` | Create from a named sandbox template |
 | `--from <SOURCE>` | Community name, Dockerfile path, directory, or image reference (BYOC) |
 | `--no-keep` | Delete the sandbox after the initial command or shell exits |
 | `--editor vscode|cursor` | Launch a remote editor and keep the sandbox alive |
 | `--gpu [COUNT]` | Request the driver's default GPU selection or a specific count |
 | `--cpu <QUANTITY>` | CPU limit (for example: `500m`, `1`, `2.5`) |
 | `--memory <QUANTITY>` | Memory limit (for example: `512Mi`, `4Gi`, `8G`) |
-| `--driver-config-json <JSON>` | Experimental driver-keyed configuration object |
 | `--provider <NAME>` | Provider to attach (repeatable) |
 | `--policy <PATH>` | Custom policy YAML; overrides the built-in default and `OPENSHELL_SANDBOX_POLICY` |
 | `--forward <[BIND:]PORT>` | Start a local port forward and keep the sandbox alive |
@@ -228,6 +228,53 @@ Create a sandbox through the selected gateway, wait for readiness, then connect,
 | `--upload <PATH>[:<DEST>]` | Upload local files to the working directory or an explicit destination (repeatable) |
 | `--no-git-ignore` | Disable `.gitignore` filtering for `--upload` |
 | `[-- COMMAND...]` | Initial command (defaults to an interactive shell) |
+
+Direct sandbox create rejects `--driver-config-json`; use `sandbox template
+create --driver-config-json` and then `sandbox create --template <NAME>`.
+`--template` conflicts with inline workload flags: `--from`, `--gpu`, `--cpu`,
+`--memory`, `--env`, and `--driver-config-json`.
+
+### `openshell sandbox template create NAME [OPTIONS]`
+
+Create a reusable sandbox template. Templates hold workload defaults and
+driver-specific configuration for later `sandbox create --template NAME` calls.
+
+| Flag | Description |
+|------|-------------|
+| `--from <SOURCE>` | Image reference or community sandbox name; local Dockerfiles/directories are not supported for templates |
+| `--env <KEY=VALUE>` | Set a non-secret template workload environment variable (repeatable) |
+| `--cpu <QUANTITY>` | CPU limit for sandboxes created from the template |
+| `--memory <QUANTITY>` | Memory limit for sandboxes created from the template |
+| `--gpu [COUNT]` | Request GPU resources for sandboxes created from the template |
+| `--driver-config-json <JSON>` | Driver-keyed configuration object owned by the template |
+| `--ready-within <DURATION>` | Desired time for template-created sandboxes to become ready |
+| `--max-burst <N>` | Maximum expected startup burst for this template |
+| `--label <KEY=VALUE>` | Attach a template label (repeatable) |
+| `--annotation <KEY=VALUE>` | Attach a template annotation (repeatable) |
+| `--output table|yaml|json` | Output format |
+
+### `openshell sandbox template get NAME`
+
+Show a sandbox template.
+
+| Flag | Description |
+|------|-------------|
+| `--output table|yaml|json` | Output format |
+
+### `openshell sandbox template list`
+
+List sandbox templates.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--limit <N>` | 100 | Maximum templates |
+| `--offset <N>` | 0 | Pagination offset |
+| `--all-workspaces` | false | List templates across all workspaces; requires platform-admin permissions |
+| `--output table|yaml|json` | `table` | Output format |
+
+### `openshell sandbox template delete NAME...`
+
+Delete one or more sandbox templates by name.
 
 ### `openshell sandbox get [name]`
 

--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -165,9 +165,11 @@ through the driver configuration. The Helm chart defaults sandbox agents to
 `Unconfined` so runtime/default AppArmor profiles do not block supervisor
 network namespace setup on AppArmor-enabled nodes.
 
-Resource requirements enter the driver layer through `SandboxSpec.resource_requirements`. This includes a set of GPU requirements, where a user
-can request a specific number of GPUs or the driver-specific default behaviour.
-For all in-tree drivers, this is equivalent to selecting a single GPU.
+Resource requirements enter the driver layer through
+`SandboxSpec.workload.resources`. CPU and memory use portable quantity strings,
+and GPU requests use an optional `gpu_count`. For all in-tree drivers, omitting
+the GPU count while requesting GPU access is equivalent to selecting a single
+GPU.
 
 VM runtime state paths are derived only from driver-validated sandbox IDs
 matching `[A-Za-z0-9._-]{1,128}`. The gateway-owned VM driver socket uses a

--- a/crates/openshell-cli/src/commands/common.rs
+++ b/crates/openshell-cli/src/commands/common.rs
@@ -592,7 +592,7 @@ pub fn ready_false_condition_message(
 
 pub fn provisioning_timeout_message(
     timeout_secs: u64,
-    resource_requirements: Option<&openshell_core::proto::ResourceRequirements>,
+    resources: Option<&openshell_core::proto::SandboxResources>,
     condition_message: Option<&str>,
 ) -> String {
     let mut message = format!("sandbox provisioning timed out after {timeout_secs}s");
@@ -602,7 +602,7 @@ pub fn provisioning_timeout_message(
         message.push_str(condition_message);
     }
 
-    if resource_requirements.is_some_and(|requirements| requirements.gpu.is_some()) {
+    if resources.is_some_and(|resources| resources.gpu_count.is_some()) {
         message.push_str(
             ". Hint: this may be because the available GPU is already in use by another sandbox.",
         );

--- a/crates/openshell-cli/src/commands/common.rs
+++ b/crates/openshell-cli/src/commands/common.rs
@@ -727,18 +727,24 @@ pub fn parse_duration_to_ms(s: &str) -> Result<i64> {
     }
     // Split off the last character by its UTF-8 length: indexing by byte
     // length would panic on multi-byte units (e.g. "5\u{20ac}").
-    let last_len = s.chars().last().map_or(0, char::len_utf8);
-    let (num_str, unit) = s.split_at(s.len() - last_len);
+    let (num_str, unit) = s.strip_suffix("ms").map_or_else(
+        || {
+            let last_len = s.chars().last().map_or(0, char::len_utf8);
+            s.split_at(s.len() - last_len)
+        },
+        |num| (num, "ms"),
+    );
     let num: i64 = num_str
         .parse()
         .map_err(|_| miette::miette!("invalid duration: {s} (expected e.g. 5m, 1h, 30s)"))?;
     let multiplier = match unit {
+        "ms" => 1,
         "s" => 1_000,
         "m" => 60_000,
         "h" => 3_600_000,
         _ => {
             return Err(miette::miette!(
-                "unknown duration unit: {unit} (use s, m, or h)"
+                "unknown duration unit: {unit} (use ms, s, m, or h)"
             ));
         }
     };
@@ -1059,6 +1065,7 @@ mod tests {
     #[test]
     fn parse_duration_to_ms_parses_supported_units() {
         assert_eq!(parse_duration_to_ms("30s").expect("parse"), 30_000);
+        assert_eq!(parse_duration_to_ms("500ms").expect("parse"), 500);
         assert_eq!(parse_duration_to_ms("5m").expect("parse"), 300_000);
         assert_eq!(parse_duration_to_ms("1h").expect("parse"), 3_600_000);
     }

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -138,6 +138,16 @@ fn parse_gpu_request(value: &str) -> std::result::Result<GpuCliRequest, String> 
     Ok(GpuCliRequest::Count(count))
 }
 
+fn parse_positive_u32(value: &str) -> std::result::Result<u32, String> {
+    let count = value
+        .parse::<u32>()
+        .map_err(|_| "value must be a positive integer".to_string())?;
+    if count == 0 {
+        return Err("value must be greater than 0".to_string());
+    }
+    Ok(count)
+}
+
 fn resolve_gateway_name(gateway_flag: &Option<String>) -> Option<String> {
     gateway_flag
         .clone()
@@ -1326,6 +1336,10 @@ enum SandboxCommands {
         #[arg(long, add = ArgValueCompleter::new(completers::complete_sandbox_names))]
         name: Option<String>,
 
+        /// Create the sandbox from a named sandbox template.
+        #[arg(long, conflicts_with_all = ["from", "gpu", "cpu", "memory", "driver_config_json", "envs"])]
+        template: Option<String>,
+
         /// Sandbox source: a community sandbox name (e.g., `ollama`), a path
         /// to a Dockerfile or directory containing one, or a full container
         /// image reference (e.g., `myregistry.com/img:tag`).
@@ -1649,6 +1663,104 @@ enum SandboxCommands {
     /// Manage providers attached to a sandbox.
     #[command(subcommand)]
     Provider(SandboxProviderCommands),
+
+    /// Manage reusable sandbox templates.
+    #[command(subcommand, help_template = SUBCOMMAND_HELP_TEMPLATE)]
+    Template(SandboxTemplateCommands),
+}
+
+#[derive(Subcommand, Debug)]
+#[allow(clippy::large_enum_variant)]
+enum SandboxTemplateCommands {
+    /// Create a sandbox template.
+    #[command(help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
+    Create {
+        /// Template name.
+        name: String,
+
+        /// Container image reference or community sandbox name.
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Set a non-secret environment variable in the template workload.
+        #[arg(long = "env", value_name = "KEY=VALUE")]
+        envs: Vec<String>,
+
+        /// CPU limit for sandboxes created from the template.
+        #[arg(long)]
+        cpu: Option<String>,
+
+        /// Memory limit for sandboxes created from the template.
+        #[arg(long)]
+        memory: Option<String>,
+
+        /// Request GPU resources for sandboxes created from the template.
+        #[arg(long, num_args = 0..=1, value_name = "COUNT", default_missing_value = "", value_parser = parse_gpu_request)]
+        gpu: Option<GpuCliRequest>,
+
+        /// Driver-keyed JSON object for template-owned driver-specific settings.
+        #[arg(long, value_name = "JSON")]
+        driver_config_json: Option<String>,
+
+        /// Desired time for a sandbox created from this template to become ready.
+        #[arg(long, value_name = "DURATION")]
+        ready_within: Option<String>,
+
+        /// Maximum expected startup burst for this template.
+        #[arg(long, value_parser = parse_positive_u32)]
+        max_burst: Option<u32>,
+
+        /// Attach labels to the template (key=value format, repeatable).
+        #[arg(long = "label")]
+        labels: Vec<String>,
+
+        /// Attach annotations to the template (key=value format, repeatable).
+        #[arg(long = "annotation")]
+        annotations: Vec<String>,
+
+        /// Output format.
+        #[arg(short = 'o', long = "output", value_enum, default_value_t = OutputFormat::Table)]
+        output: OutputFormat,
+    },
+
+    /// Fetch a sandbox template by name.
+    #[command(help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
+    Get {
+        /// Template name.
+        name: String,
+
+        /// Output format.
+        #[arg(short = 'o', long = "output", value_enum, default_value_t = OutputFormat::Table)]
+        output: OutputFormat,
+    },
+
+    /// List sandbox templates.
+    #[command(help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
+    List {
+        /// Maximum number of templates to return.
+        #[arg(long, default_value_t = 100)]
+        limit: u32,
+
+        /// Offset into the template list.
+        #[arg(long, default_value_t = 0)]
+        offset: u32,
+
+        /// Output format.
+        #[arg(short = 'o', long = "output", value_enum, default_value_t = OutputFormat::Table)]
+        output: OutputFormat,
+
+        /// List templates across all workspaces (overrides --workspace).
+        #[arg(long)]
+        all_workspaces: bool,
+    },
+
+    /// Delete sandbox templates by name.
+    #[command(help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
+    Delete {
+        /// Template names.
+        #[arg(required = true, num_args = 1.., value_name = "NAME")]
+        names: Vec<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -2958,6 +3070,7 @@ async fn run_async() -> Result<()> {
             match command {
                 SandboxCommands::Create {
                     name,
+                    template,
                     from,
                     upload,
                     no_git_ignore,
@@ -3050,6 +3163,7 @@ async fn run_async() -> Result<()> {
                         &ctx.name,
                         run::SandboxCreateConfig {
                             name: name.as_deref(),
+                            template: template.as_deref(),
                             from: from.as_deref(),
                             uploads: &upload_specs,
                             keep,
@@ -3242,6 +3356,82 @@ async fn run_async() -> Result<()> {
                             let name = resolve_sandbox_name(name, &ctx.name, &cli.workspace)?;
                             run::print_ssh_config(&ctx.name, &name, &cli.workspace);
                         }
+                        SandboxCommands::Template(command) => match command {
+                            SandboxTemplateCommands::Create {
+                                name,
+                                from,
+                                envs,
+                                cpu,
+                                memory,
+                                gpu,
+                                driver_config_json,
+                                ready_within,
+                                max_burst,
+                                labels,
+                                annotations,
+                                output,
+                            } => {
+                                run::sandbox_template_create(
+                                    endpoint,
+                                    run::SandboxTemplateCreateConfig {
+                                        name,
+                                        from,
+                                        environment: run::parse_env_pairs(&envs)?,
+                                        cpu,
+                                        memory,
+                                        gpu_count: gpu.map(Into::into),
+                                        driver_config_json,
+                                        ready_within,
+                                        max_burst,
+                                        labels: run::parse_key_value_pairs(&labels, "--label")?,
+                                        annotations: run::parse_key_value_pairs(
+                                            &annotations,
+                                            "--annotation",
+                                        )?,
+                                        output: output.as_str().to_string(),
+                                    },
+                                    &cli.workspace,
+                                    &tls,
+                                )
+                                .await?;
+                            }
+                            SandboxTemplateCommands::Get { name, output } => {
+                                run::sandbox_template_get(
+                                    endpoint,
+                                    &name,
+                                    output.as_str(),
+                                    &cli.workspace,
+                                    &tls,
+                                )
+                                .await?;
+                            }
+                            SandboxTemplateCommands::List {
+                                limit,
+                                offset,
+                                output,
+                                all_workspaces,
+                            } => {
+                                run::sandbox_template_list(
+                                    endpoint,
+                                    limit,
+                                    offset,
+                                    output.as_str(),
+                                    &cli.workspace,
+                                    all_workspaces,
+                                    &tls,
+                                )
+                                .await?;
+                            }
+                            SandboxTemplateCommands::Delete { names } => {
+                                run::sandbox_template_delete(
+                                    endpoint,
+                                    &names,
+                                    &cli.workspace,
+                                    &tls,
+                                )
+                                .await?;
+                            }
+                        },
                         SandboxCommands::Provider(command) => match command {
                             SandboxProviderCommands::List { name } => {
                                 let name = resolve_sandbox_name(name, &ctx.name, &cli.workspace)?;
@@ -5252,6 +5442,197 @@ mod tests {
             }
             other => panic!("expected SandboxCommands::Create, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn sandbox_create_template_flag_parses() {
+        let cli = Cli::try_parse_from([
+            "openshell",
+            "sandbox",
+            "create",
+            "--template",
+            "gpu-kata",
+            "--provider",
+            "github",
+            "--",
+            "claude",
+        ])
+        .expect("sandbox create --template should parse");
+
+        match cli.command {
+            Some(Commands::Sandbox {
+                command:
+                    Some(SandboxCommands::Create {
+                        template,
+                        providers,
+                        command,
+                        ..
+                    }),
+                ..
+            }) => {
+                assert_eq!(template.as_deref(), Some("gpu-kata"));
+                assert_eq!(providers, vec!["github".to_string()]);
+                assert_eq!(command, vec!["claude".to_string()]);
+            }
+            other => panic!("expected SandboxCommands::Create, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sandbox_create_template_conflicts_with_inline_workload_flags() {
+        for (label, extra_args) in [
+            ("--from", &["--from", "python:3.12"][..]),
+            ("--cpu", &["--cpu", "2"][..]),
+            ("--env", &["--env", "FOO=bar"][..]),
+        ] {
+            let args = ["openshell", "sandbox", "create", "--template", "gpu-kata"]
+                .into_iter()
+                .chain(extra_args.iter().copied());
+            let result = Cli::try_parse_from(args);
+            assert!(result.is_err(), "--template should conflict with {label}");
+        }
+    }
+
+    #[test]
+    fn sandbox_template_create_parses_image_driver_config_and_startup() {
+        let json = r#"{"kubernetes":{"pod":{"runtime_class_name":"kata-containers"}}}"#;
+        let cli = Cli::try_parse_from([
+            "openshell",
+            "sandbox",
+            "template",
+            "create",
+            "gpu-kata",
+            "--from",
+            "cuda:latest",
+            "--env",
+            "MODE=on",
+            "--cpu",
+            "2",
+            "--memory",
+            "8Gi",
+            "--gpu",
+            "2",
+            "--driver-config-json",
+            json,
+            "--ready-within",
+            "30s",
+            "--max-burst",
+            "5",
+            "--label",
+            "tier=gold",
+            "--annotation",
+            "owner=platform",
+            "--output",
+            "json",
+        ])
+        .expect("sandbox template create should parse");
+
+        match cli.command {
+            Some(Commands::Sandbox {
+                command:
+                    Some(SandboxCommands::Template(SandboxTemplateCommands::Create {
+                        name,
+                        from,
+                        envs,
+                        cpu,
+                        memory,
+                        gpu,
+                        driver_config_json,
+                        ready_within,
+                        max_burst,
+                        labels,
+                        annotations,
+                        output,
+                    })),
+                ..
+            }) => {
+                assert_eq!(name, "gpu-kata");
+                assert_eq!(from.as_deref(), Some("cuda:latest"));
+                assert_eq!(envs, vec!["MODE=on".to_string()]);
+                assert_eq!(cpu.as_deref(), Some("2"));
+                assert_eq!(memory.as_deref(), Some("8Gi"));
+                assert_eq!(gpu, Some(GpuCliRequest::Count(2)));
+                assert_eq!(driver_config_json.as_deref(), Some(json));
+                assert_eq!(ready_within.as_deref(), Some("30s"));
+                assert_eq!(max_burst, Some(5));
+                assert_eq!(labels, vec!["tier=gold".to_string()]);
+                assert_eq!(annotations, vec!["owner=platform".to_string()]);
+                assert!(matches!(output, OutputFormat::Json));
+            }
+            other => panic!("expected SandboxTemplateCommands::Create, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sandbox_template_create_allows_omitted_from() {
+        let cli = Cli::try_parse_from([
+            "openshell",
+            "sandbox",
+            "template",
+            "create",
+            "default-image",
+            "--cpu",
+            "2",
+        ])
+        .expect("sandbox template create should allow omitting --from");
+
+        match cli.command {
+            Some(Commands::Sandbox {
+                command:
+                    Some(SandboxCommands::Template(SandboxTemplateCommands::Create {
+                        name,
+                        from,
+                        cpu,
+                        ..
+                    })),
+                ..
+            }) => {
+                assert_eq!(name, "default-image");
+                assert!(from.is_none());
+                assert_eq!(cpu.as_deref(), Some("2"));
+            }
+            other => panic!("expected SandboxTemplateCommands::Create, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sandbox_template_create_rejects_zero_max_burst() {
+        let result = Cli::try_parse_from([
+            "openshell",
+            "sandbox",
+            "template",
+            "create",
+            "gpu-kata",
+            "--from",
+            "cuda:latest",
+            "--max-burst",
+            "0",
+        ]);
+        assert!(result.is_err(), "--max-burst 0 should be rejected");
+    }
+
+    #[test]
+    fn sandbox_template_list_json_output_parses() {
+        let cli = Cli::try_parse_from([
+            "openshell",
+            "sandbox",
+            "template",
+            "list",
+            "--output",
+            "json",
+        ])
+        .expect("sandbox template list --output json should parse");
+
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Sandbox {
+                command: Some(SandboxCommands::Template(SandboxTemplateCommands::List {
+                    output,
+                    ..
+                })),
+                ..
+            }) if matches!(output, OutputFormat::Json)
+        ));
     }
 
     #[test]

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -19,8 +19,6 @@ use openshell_bootstrap::{
 use openshell_cli::completers;
 use openshell_cli::run;
 use openshell_cli::tls::TlsOptions;
-use openshell_core::proto::GpuResourceRequirements;
-
 /// Resolved gateway context: name + gateway endpoint.
 struct GatewayContext {
     /// The gateway name (used for TLS cert directory, metadata lookup, etc.).
@@ -35,11 +33,11 @@ enum GpuCliRequest {
     Count(u32),
 }
 
-impl From<GpuCliRequest> for GpuResourceRequirements {
+impl From<GpuCliRequest> for u32 {
     fn from(gpu: GpuCliRequest) -> Self {
         match gpu {
-            GpuCliRequest::Count(count) => Self { count: Some(count) },
-            GpuCliRequest::DriverDefault => Self { count: None },
+            GpuCliRequest::Count(count) => count,
+            GpuCliRequest::DriverDefault => 1,
         }
     }
 }
@@ -1383,11 +1381,11 @@ enum SandboxCommands {
         #[arg(long)]
         memory: Option<String>,
 
-        /// Experimental driver-keyed JSON object for driver-specific sandbox settings.
-        /// Validation behavior is not yet finalized.
+        /// Deprecated direct-create driver config.
         ///
-        /// For Kubernetes, pass a value such as
-        /// `{"kubernetes":{"pod":{"node_selector":{"pool":"gpu"}}}}`.
+        /// Driver-specific sandbox settings are supported through named sandbox
+        /// templates. Direct inline workload creates are portable and reject
+        /// this flag.
         #[arg(long, value_name = "JSON")]
         driver_config_json: Option<String>,
 
@@ -3041,7 +3039,7 @@ async fn run_async() -> Result<()> {
                         .map(|s| openshell_core::forward::ForwardSpec::parse(&s))
                         .transpose()?;
                     let keep = keep || !no_keep || editor.is_some() || forward.is_some();
-                    let gpu_requirements: Option<GpuResourceRequirements> = gpu.map(Into::into);
+                    let gpu_requirements: Option<u32> = gpu.map(Into::into);
 
                     let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
                     let endpoint = &ctx.endpoint;
@@ -4264,23 +4262,23 @@ mod tests {
 
     #[test]
     fn gpu_cli_request_option_maps_absent_gpu_to_no_requirements() {
-        let gpu: Option<GpuResourceRequirements> = Option::<GpuCliRequest>::None.map(Into::into);
+        let gpu: Option<u32> = Option::<GpuCliRequest>::None.map(Into::into);
 
         assert_eq!(gpu, None);
     }
 
     #[test]
-    fn gpu_cli_request_driver_default_converts_to_requirements() {
-        let gpu = GpuResourceRequirements::from(GpuCliRequest::DriverDefault);
+    fn gpu_cli_request_driver_default_converts_to_one_gpu() {
+        let gpu = u32::from(GpuCliRequest::DriverDefault);
 
-        assert_eq!(gpu.count, None);
+        assert_eq!(gpu, 1);
     }
 
     #[test]
-    fn gpu_cli_request_count_converts_to_requirements() {
-        let gpu = GpuResourceRequirements::from(GpuCliRequest::Count(2));
+    fn gpu_cli_request_count_converts_to_count() {
+        let gpu = u32::from(GpuCliRequest::Count(2));
 
-        assert_eq!(gpu.count, Some(2));
+        assert_eq!(gpu, 2);
     }
 
     #[test]

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -33,6 +33,7 @@ use openshell_bootstrap::{
 };
 use openshell_core::net::set_tcp_nodelay_best_effort;
 use openshell_core::proto::ProviderProfileCategory;
+use openshell_core::proto::create_sandbox_request;
 use openshell_core::proto::{
     ApproveAllDraftChunksRequest, ApproveDraftChunkRequest, AttachSandboxProviderRequest,
     ClearDraftChunksRequest, ConfigureProviderRefreshRequest, CreateProviderRequest,
@@ -43,14 +44,14 @@ use openshell_core::proto::{
     GetGatewayConfigRequest, GetInferenceRouteRequest, GetProviderProfileRequest,
     GetProviderRefreshStatusRequest, GetProviderRequest, GetSandboxConfigRequest,
     GetSandboxConfigResponse, GetSandboxLogsRequest, GetSandboxPolicyStatusRequest,
-    GetSandboxRequest, GetServiceRequest, GpuResourceRequirements, ImportProviderProfilesRequest,
+    GetSandboxRequest, GetServiceRequest, ImportProviderProfilesRequest,
     LintProviderProfilesRequest, ListProviderProfilesRequest, ListProvidersRequest,
     ListSandboxPoliciesRequest, ListSandboxProvidersRequest, ListSandboxesRequest,
     ListServicesRequest, PolicySource, PolicyStatus, Provider, ProviderCredentialRefreshStatus,
     ProviderCredentialRefreshStrategy, ProviderProfile, ProviderProfileDiagnostic,
-    ProviderProfileImportItem, RejectDraftChunkRequest, ResourceRequirements,
-    RevokeSshSessionRequest, RotateProviderCredentialRequest, Sandbox, SandboxPhase, SandboxPolicy,
-    SandboxSpec, SandboxTemplate, ServiceEndpointResponse, SetInferenceRouteRequest, SettingScope,
+    ProviderProfileImportItem, RejectDraftChunkRequest, RevokeSshSessionRequest,
+    RotateProviderCredentialRequest, Sandbox, SandboxPhase, SandboxPolicy, SandboxResources,
+    SandboxWorkloadConfig, ServiceEndpointResponse, SetInferenceRouteRequest, SettingScope,
     StartSandboxRequest, StopSandboxRequest, TcpForwardFrame, TcpForwardInit, TcpRelayTarget,
     UpdateConfigRequest, UpdateProviderProfilesRequest, UpdateProviderRequest, WatchSandboxRequest,
     exec_sandbox_event, setting_value, tcp_forward_init,
@@ -225,40 +226,19 @@ fn sandbox_should_persist(keep: bool, forward: Option<&ForwardSpec>) -> bool {
 fn build_sandbox_resource_limits(
     cpu: Option<&str>,
     memory: Option<&str>,
-) -> Result<Option<prost_types::Struct>> {
-    use prost_types::{Struct, Value, value::Kind};
-
-    fn string_value(value: String) -> Value {
-        Value {
-            kind: Some(Kind::StringValue(value)),
-        }
-    }
-
-    let mut limits = std::collections::BTreeMap::new();
+) -> Result<Option<SandboxResources>> {
+    let mut resources = SandboxResources::default();
     if let Some(cpu) = cpu {
-        limits.insert("cpu".to_string(), string_value(validate_cpu_quantity(cpu)?));
+        resources.cpu = validate_cpu_quantity(cpu)?;
     }
     if let Some(memory) = memory {
-        limits.insert(
-            "memory".to_string(),
-            string_value(validate_memory_quantity(memory)?),
-        );
+        resources.memory = validate_memory_quantity(memory)?;
     }
 
-    if limits.is_empty() {
-        return Ok(None);
-    }
-
-    let mut fields = std::collections::BTreeMap::new();
-    fields.insert(
-        "limits".to_string(),
-        Value {
-            kind: Some(Kind::StructValue(Struct { fields: limits })),
-        },
-    );
-    Ok(Some(Struct { fields }))
+    Ok((!resources.cpu.is_empty() || !resources.memory.is_empty()).then_some(resources))
 }
 
+#[cfg(test)]
 fn parse_driver_config_json(value: &str) -> Result<prost_types::Struct> {
     let parsed: serde_json::Value = serde_json::from_str(value)
         .into_diagnostic()
@@ -368,7 +348,7 @@ pub struct SandboxCreateConfig<'a> {
     pub from: Option<&'a str>,
     pub uploads: &'a [(String, Option<String>, bool)],
     pub keep: bool,
-    pub gpu_requirements: Option<GpuResourceRequirements>,
+    pub gpu_requirements: Option<u32>,
     pub cpu: Option<&'a str>,
     pub memory: Option<&'a str>,
     pub driver_config_json: Option<&'a str>,
@@ -503,33 +483,30 @@ pub async fn sandbox_create(
     .await?;
 
     let policy = load_sandbox_policy(policy)?;
-    let resource_limits = build_sandbox_resource_limits(cpu, memory)?;
-    let driver_config = driver_config_json
-        .map(parse_driver_config_json)
-        .transpose()?;
-
-    let template = if image.is_some() || resource_limits.is_some() || driver_config.is_some() {
-        Some(SandboxTemplate {
-            image: image.unwrap_or_default(),
-            resources: resource_limits,
-            driver_config,
-            ..SandboxTemplate::default()
-        })
-    } else {
-        None
+    if driver_config_json.is_some() {
+        return Err(miette!(
+            "--driver-config-json is only supported through named sandbox templates"
+        ));
+    }
+    let mut resources = build_sandbox_resource_limits(cpu, memory)?.unwrap_or_default();
+    if let Some(gpu_count) = gpu_requirements {
+        resources.gpu_count = Some(gpu_count);
+    }
+    let resources = (!resources.cpu.is_empty()
+        || !resources.memory.is_empty()
+        || resources.gpu_count.is_some())
+    .then_some(resources);
+    let timeout_resources = resources.clone();
+    let workload = SandboxWorkloadConfig {
+        image: image.unwrap_or_default(),
+        environment,
+        resources,
     };
 
-    let resource_requirements = gpu_requirements.map(|gpu| ResourceRequirements { gpu: Some(gpu) });
-
     let request = CreateSandboxRequest {
-        spec: Some(SandboxSpec {
-            resource_requirements,
-            environment,
-            policy,
-            providers: configured_providers,
-            template,
-            ..SandboxSpec::default()
-        }),
+        workload_source: Some(create_sandbox_request::WorkloadSource::Workload(workload)),
+        policy,
+        providers: configured_providers,
         name: name.unwrap_or_default().to_string(),
         labels,
         annotations: HashMap::new(),
@@ -681,7 +658,7 @@ pub async fn sandbox_create(
         if remaining.is_zero() {
             let timeout_message = provisioning_timeout_message(
                 provision_timeout.as_secs(),
-                resource_requirements.as_ref(),
+                timeout_resources.as_ref(),
                 last_condition_message.as_deref(),
             );
             if let Some(d) = display.as_interactive_mut() {
@@ -702,7 +679,7 @@ pub async fn sandbox_create(
                 // Timeout fired — the stream was idle for too long.
                 let timeout_message = provisioning_timeout_message(
                     provision_timeout.as_secs(),
-                    resource_requirements.as_ref(),
+                    timeout_resources.as_ref(),
                     last_condition_message.as_deref(),
                 );
                 if let Some(d) = display.as_interactive_mut() {
@@ -7153,11 +7130,11 @@ mod tests {
         PROGRESS_STEP_STARTING_SANDBOX,
     };
     use openshell_core::proto::{
-        GetSandboxConfigResponse, GpuResourceRequirements, PolicySource, PolicyStatus, Provider,
-        ProviderCredentialRefresh, ProviderCredentialRefreshStatus,
-        ProviderCredentialRefreshStrategy, ProviderCredentialTokenGrant, ProviderProfile,
-        ProviderProfileCredential, ResourceRequirements, Sandbox, SandboxCondition, SandboxPhase,
-        SandboxPolicyRevision, SandboxStatus, datamodel::v1::ObjectMeta,
+        GetSandboxConfigResponse, PolicySource, PolicyStatus, Provider, ProviderCredentialRefresh,
+        ProviderCredentialRefreshStatus, ProviderCredentialRefreshStrategy,
+        ProviderCredentialTokenGrant, ProviderProfile, ProviderProfileCredential, Sandbox,
+        SandboxCondition, SandboxPhase, SandboxPolicyRevision, SandboxResources, SandboxStatus,
+        datamodel::v1::ObjectMeta,
     };
 
     #[test]
@@ -7531,39 +7508,9 @@ mod tests {
             .expect("resource limits should parse")
             .expect("resource limits should be present");
 
-        let limits = resources
-            .fields
-            .get("limits")
-            .and_then(|value| value.kind.as_ref())
-            .and_then(|kind| match kind {
-                prost_types::value::Kind::StructValue(inner) => Some(inner),
-                _ => None,
-            })
-            .expect("limits should be a struct");
-
-        assert_eq!(
-            limits
-                .fields
-                .get("cpu")
-                .and_then(|value| value.kind.as_ref())
-                .and_then(|kind| match kind {
-                    prost_types::value::Kind::StringValue(value) => Some(value.as_str()),
-                    _ => None,
-                }),
-            Some("500m")
-        );
-        assert_eq!(
-            limits
-                .fields
-                .get("memory")
-                .and_then(|value| value.kind.as_ref())
-                .and_then(|kind| match kind {
-                    prost_types::value::Kind::StringValue(value) => Some(value.as_str()),
-                    _ => None,
-                }),
-            Some("2Gi")
-        );
-        assert!(!resources.fields.contains_key("requests"));
+        assert_eq!(resources.cpu, "500m");
+        assert_eq!(resources.memory, "2Gi");
+        assert_eq!(resources.gpu_count, None);
     }
 
     #[test]
@@ -7869,12 +7816,13 @@ mod tests {
 
     #[test]
     fn provisioning_timeout_message_includes_condition_and_gpu_hint() {
-        let resource_requirements = ResourceRequirements {
-            gpu: Some(GpuResourceRequirements { count: None }),
+        let resources = SandboxResources {
+            gpu_count: Some(1),
+            ..SandboxResources::default()
         };
         let message = provisioning_timeout_message(
             120,
-            Some(&resource_requirements),
+            Some(&resources),
             Some("DependenciesNotReady: Pod exists with phase: Pending; Service Exists"),
         );
 
@@ -7892,8 +7840,8 @@ mod tests {
 
     #[test]
     fn provisioning_timeout_message_omits_gpu_hint_without_gpu_requirements() {
-        let resource_requirements = ResourceRequirements { gpu: None };
-        let message = provisioning_timeout_message(120, Some(&resource_requirements), None);
+        let resources = SandboxResources::default();
+        let message = provisioning_timeout_message(120, Some(&resources), None);
 
         assert_eq!(message, "sandbox provisioning timed out after 120s");
     }

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -37,20 +37,22 @@ use openshell_core::proto::create_sandbox_request;
 use openshell_core::proto::{
     ApproveAllDraftChunksRequest, ApproveDraftChunkRequest, AttachSandboxProviderRequest,
     ClearDraftChunksRequest, ConfigureProviderRefreshRequest, CreateProviderRequest,
-    CreateSandboxRequest, CreateSshSessionRequest, DeleteInferenceRouteRequest,
-    DeleteProviderProfileRequest, DeleteProviderRefreshRequest, DeleteProviderRequest,
-    DeleteSandboxRequest, DeleteServiceRequest, DetachSandboxProviderRequest, ExecSandboxRequest,
-    ExposeServiceRequest, GetCurrentUserRequest, GetDraftHistoryRequest, GetDraftPolicyRequest,
-    GetGatewayConfigRequest, GetInferenceRouteRequest, GetProviderProfileRequest,
-    GetProviderRefreshStatusRequest, GetProviderRequest, GetSandboxConfigRequest,
-    GetSandboxConfigResponse, GetSandboxLogsRequest, GetSandboxPolicyStatusRequest,
-    GetSandboxRequest, GetServiceRequest, ImportProviderProfilesRequest,
-    LintProviderProfilesRequest, ListProviderProfilesRequest, ListProvidersRequest,
-    ListSandboxPoliciesRequest, ListSandboxProvidersRequest, ListSandboxesRequest,
-    ListServicesRequest, PolicySource, PolicyStatus, Provider, ProviderCredentialRefreshStatus,
+    CreateSandboxRequest, CreateSandboxTemplateRequest, CreateSshSessionRequest,
+    DeleteInferenceRouteRequest, DeleteProviderProfileRequest, DeleteProviderRefreshRequest,
+    DeleteProviderRequest, DeleteSandboxRequest, DeleteSandboxTemplateRequest,
+    DeleteServiceRequest, DetachSandboxProviderRequest, ExecSandboxRequest, ExposeServiceRequest,
+    GetCurrentUserRequest, GetDraftHistoryRequest, GetDraftPolicyRequest, GetGatewayConfigRequest,
+    GetInferenceRouteRequest, GetProviderProfileRequest, GetProviderRefreshStatusRequest,
+    GetProviderRequest, GetSandboxConfigRequest, GetSandboxConfigResponse, GetSandboxLogsRequest,
+    GetSandboxPolicyStatusRequest, GetSandboxRequest, GetSandboxTemplateRequest, GetServiceRequest,
+    ImportProviderProfilesRequest, LintProviderProfilesRequest, ListProviderProfilesRequest,
+    ListProvidersRequest, ListSandboxPoliciesRequest, ListSandboxProvidersRequest,
+    ListSandboxTemplatesRequest, ListSandboxesRequest, ListServicesRequest, ObjectMeta,
+    PolicySource, PolicyStatus, Provider, ProviderCredentialRefreshStatus,
     ProviderCredentialRefreshStrategy, ProviderProfile, ProviderProfileDiagnostic,
     ProviderProfileImportItem, RejectDraftChunkRequest, RevokeSshSessionRequest,
     RotateProviderCredentialRequest, Sandbox, SandboxPhase, SandboxPolicy, SandboxResources,
+    SandboxServiceLevel, SandboxStartup, SandboxTemplate, SandboxTemplateSpec,
     SandboxWorkloadConfig, ServiceEndpointResponse, SetInferenceRouteRequest, SettingScope,
     StartSandboxRequest, StopSandboxRequest, TcpForwardFrame, TcpForwardInit, TcpRelayTarget,
     UpdateConfigRequest, UpdateProviderProfilesRequest, UpdateProviderRequest, WatchSandboxRequest,
@@ -238,8 +240,7 @@ fn build_sandbox_resource_limits(
     Ok((!resources.cpu.is_empty() || !resources.memory.is_empty()).then_some(resources))
 }
 
-#[cfg(test)]
-fn parse_driver_config_json(value: &str) -> Result<prost_types::Struct> {
+pub fn parse_driver_config_json(value: &str) -> Result<prost_types::Struct> {
     let parsed: serde_json::Value = serde_json::from_str(value)
         .into_diagnostic()
         .wrap_err("--driver-config-json must be valid JSON")?;
@@ -345,6 +346,7 @@ async fn finalize_sandbox_create_session(
 #[derive(Debug)]
 pub struct SandboxCreateConfig<'a> {
     pub name: Option<&'a str>,
+    pub template: Option<&'a str>,
     pub from: Option<&'a str>,
     pub uploads: &'a [(String, Option<String>, bool)],
     pub keep: bool,
@@ -369,6 +371,7 @@ impl Default for SandboxCreateConfig<'_> {
     fn default() -> Self {
         Self {
             name: None,
+            template: None,
             from: None,
             uploads: &[],
             keep: false,
@@ -401,6 +404,7 @@ pub async fn sandbox_create(
 ) -> Result<()> {
     let SandboxCreateConfig {
         name,
+        template,
         from,
         uploads,
         keep,
@@ -426,6 +430,18 @@ pub async fn sandbox_create(
             "--editor cannot be used with a trailing command; use `openshell sandbox connect <name> --editor ...` after the sandbox is ready"
         ));
     }
+    if template.is_some()
+        && (from.is_some()
+            || cpu.is_some()
+            || memory.is_some()
+            || gpu_requirements.is_some()
+            || driver_config_json.is_some()
+            || !environment.is_empty())
+    {
+        return Err(miette!(
+            "--template cannot be used with inline workload flags such as --from, --cpu, --memory, --gpu, --env, or --driver-config-json"
+        ));
+    }
 
     // Check port availability *before* creating the sandbox so we don't
     // leave an orphaned sandbox behind when the forward would fail.
@@ -444,22 +460,31 @@ pub async fn sandbox_create(
     let effective_tls = tls.clone();
 
     // Resolve the --from flag into a container image reference, building from
-    // a Dockerfile first if necessary.
-    let image: Option<String> = match from {
-        Some(val) => {
-            let resolved = resolve_from(val)?;
-            match resolved {
-                ResolvedSource::Image(img) => Some(img),
-                ResolvedSource::Dockerfile {
-                    dockerfile,
-                    context,
-                } => {
-                    let tag = build_from_dockerfile(&dockerfile, &context, gateway_name).await?;
-                    Some(tag)
+    // a Dockerfile first if necessary. Template-based creates resolve workload
+    // shape on the gateway and must not build or override an image.
+    let image: Option<String> = if template.is_some() {
+        if from.is_some() {
+            return Err(miette!("--from cannot be used with --template"));
+        }
+        None
+    } else {
+        match from {
+            Some(val) => {
+                let resolved = resolve_from(val)?;
+                match resolved {
+                    ResolvedSource::Image(img) => Some(img),
+                    ResolvedSource::Dockerfile {
+                        dockerfile,
+                        context,
+                    } => {
+                        let tag =
+                            build_from_dockerfile(&dockerfile, &context, gateway_name).await?;
+                        Some(tag)
+                    }
                 }
             }
+            None => None,
         }
-        None => None,
     };
     let inferred_provider = inferred_provider_type(command);
     let providers_v2_enabled =
@@ -488,23 +513,37 @@ pub async fn sandbox_create(
             "--driver-config-json is only supported through named sandbox templates"
         ));
     }
-    let mut resources = build_sandbox_resource_limits(cpu, memory)?.unwrap_or_default();
-    if let Some(gpu_count) = gpu_requirements {
+    let mut resources = if template.is_some() {
+        SandboxResources::default()
+    } else {
+        build_sandbox_resource_limits(cpu, memory)?.unwrap_or_default()
+    };
+    if template.is_none()
+        && let Some(gpu_count) = gpu_requirements
+    {
         resources.gpu_count = Some(gpu_count);
     }
-    let resources = (!resources.cpu.is_empty()
-        || !resources.memory.is_empty()
-        || resources.gpu_count.is_some())
+    let resources = (template.is_none()
+        && (!resources.cpu.is_empty()
+            || !resources.memory.is_empty()
+            || resources.gpu_count.is_some()))
     .then_some(resources);
     let timeout_resources = resources.clone();
-    let workload = SandboxWorkloadConfig {
-        image: image.unwrap_or_default(),
-        environment,
-        resources,
-    };
+    let workload_source = template.map_or_else(
+        || {
+            create_sandbox_request::WorkloadSource::Workload(SandboxWorkloadConfig {
+                image: image.unwrap_or_default(),
+                environment,
+                resources,
+            })
+        },
+        |template| {
+            create_sandbox_request::WorkloadSource::WorkloadTemplateName(template.to_string())
+        },
+    );
 
     let request = CreateSandboxRequest {
-        workload_source: Some(create_sandbox_request::WorkloadSource::Workload(workload)),
+        workload_source: Some(workload_source),
         policy,
         providers: configured_providers,
         name: name.unwrap_or_default().to_string(),
@@ -2524,6 +2563,416 @@ async fn wait_for_lifecycle_phase(
     }
 }
 
+pub struct SandboxTemplateCreateConfig {
+    pub name: String,
+    pub from: Option<String>,
+    pub environment: HashMap<String, String>,
+    pub cpu: Option<String>,
+    pub memory: Option<String>,
+    pub gpu_count: Option<u32>,
+    pub driver_config_json: Option<String>,
+    pub ready_within: Option<String>,
+    pub max_burst: Option<u32>,
+    pub labels: HashMap<String, String>,
+    pub annotations: HashMap<String, String>,
+    pub output: String,
+}
+
+pub async fn sandbox_template_create(
+    server: &str,
+    config: SandboxTemplateCreateConfig,
+    workspace: &str,
+    tls: &TlsOptions,
+) -> Result<()> {
+    let SandboxTemplateCreateConfig {
+        name,
+        from,
+        environment,
+        cpu,
+        memory,
+        gpu_count,
+        driver_config_json,
+        ready_within,
+        max_burst,
+        labels,
+        annotations,
+        output,
+    } = config;
+
+    if let Some(from) = from.as_deref()
+        && (Path::new(from).exists() || value_looks_like_local_source(from))
+    {
+        return Err(miette!(
+            "sandbox template --from only supports image references and community sandbox names in this release"
+        ));
+    }
+    let image = from.as_deref().map_or_else(String::new, |from| {
+        openshell_core::image::resolve_community_image(from)
+    });
+
+    let mut resources =
+        build_sandbox_resource_limits(cpu.as_deref(), memory.as_deref())?.unwrap_or_default();
+    if let Some(gpu_count) = gpu_count {
+        resources.gpu_count = Some(gpu_count);
+    }
+    let resources = (!resources.cpu.is_empty()
+        || !resources.memory.is_empty()
+        || resources.gpu_count.is_some())
+    .then_some(resources);
+
+    let driver_config = driver_config_json
+        .as_deref()
+        .map(parse_driver_config_json)
+        .transpose()?;
+    let ready_within = ready_within
+        .as_deref()
+        .map(parse_ready_within_duration)
+        .transpose()?;
+    let desired_service_level =
+        (ready_within.is_some() || max_burst.is_some()).then(|| SandboxServiceLevel {
+            startup: Some(SandboxStartup {
+                ready_within,
+                max_burst: max_burst.unwrap_or_default(),
+            }),
+        });
+
+    let template = SandboxTemplate {
+        metadata: Some(ObjectMeta {
+            name,
+            labels,
+            annotations,
+            workspace: workspace.to_string(),
+            ..ObjectMeta::default()
+        }),
+        spec: Some(SandboxTemplateSpec {
+            workload: Some(SandboxWorkloadConfig {
+                image,
+                environment,
+                resources,
+            }),
+            driver_config,
+            desired_service_level,
+        }),
+    };
+
+    let mut client = grpc_client(server, tls).await?;
+    let response = client
+        .create_sandbox_template(CreateSandboxTemplateRequest {
+            template: Some(template),
+            workspace: workspace.to_string(),
+        })
+        .await
+        .into_diagnostic()?;
+    let template = response
+        .into_inner()
+        .template
+        .ok_or_else(|| miette!("sandbox template missing from response"))?;
+    print_sandbox_template(&template, &output)
+}
+
+pub async fn sandbox_template_get(
+    server: &str,
+    name: &str,
+    output: &str,
+    workspace: &str,
+    tls: &TlsOptions,
+) -> Result<()> {
+    let mut client = grpc_client(server, tls).await?;
+    let response = client
+        .get_sandbox_template(GetSandboxTemplateRequest {
+            name: name.to_string(),
+            workspace: workspace.to_string(),
+        })
+        .await
+        .into_diagnostic()?;
+    let template = response
+        .into_inner()
+        .template
+        .ok_or_else(|| miette!("sandbox template missing from response"))?;
+    print_sandbox_template(&template, output)
+}
+
+pub async fn sandbox_template_list(
+    server: &str,
+    limit: u32,
+    offset: u32,
+    output: &str,
+    workspace: &str,
+    all_workspaces: bool,
+    tls: &TlsOptions,
+) -> Result<()> {
+    let mut client = grpc_client(server, tls).await?;
+    let response = client
+        .list_sandbox_templates(ListSandboxTemplatesRequest {
+            limit,
+            offset,
+            workspace: if all_workspaces {
+                String::new()
+            } else {
+                workspace.to_string()
+            },
+            all_workspaces,
+        })
+        .await
+        .into_diagnostic()?;
+    let templates = response.into_inner().templates;
+
+    if crate::output::print_output_collection(output, &templates, sandbox_template_to_json)? {
+        return Ok(());
+    }
+
+    if templates.is_empty() {
+        println!("No sandbox templates found.");
+        return Ok(());
+    }
+
+    let name_width = templates
+        .iter()
+        .map(|template| template.object_name().len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let image_width = templates
+        .iter()
+        .map(|template| template_image(template).len())
+        .max()
+        .unwrap_or(5)
+        .clamp(5, 48);
+
+    println!(
+        "{:<name_width$}  {:<image_width$}  {:<8}  {:<8}  {:<5}  {:<12}  {:<9}  {}",
+        "NAME".bold(),
+        "IMAGE".bold(),
+        "CPU".bold(),
+        "MEMORY".bold(),
+        "GPU".bold(),
+        "READY_WITHIN".bold(),
+        "MAX_BURST".bold(),
+        "CREATED".bold(),
+    );
+    for template in &templates {
+        println!(
+            "{:<name_width$}  {:<image_width$}  {:<8}  {:<8}  {:<5}  {:<12}  {:<9}  {}",
+            template.object_name(),
+            truncate_display(&template_image(template), image_width),
+            template_resource_cpu(template),
+            template_resource_memory(template),
+            template_resource_gpu(template),
+            template_ready_within(template),
+            template_max_burst(template),
+            template_age(template),
+        );
+    }
+    Ok(())
+}
+
+pub async fn sandbox_template_delete(
+    server: &str,
+    names: &[String],
+    workspace: &str,
+    tls: &TlsOptions,
+) -> Result<()> {
+    let mut client = grpc_client(server, tls).await?;
+    for name in names {
+        let response = client
+            .delete_sandbox_template(DeleteSandboxTemplateRequest {
+                name: name.clone(),
+                workspace: workspace.to_string(),
+            })
+            .await
+            .into_diagnostic()?;
+        if response.into_inner().deleted {
+            println!("{} Deleted sandbox template {name}", "✓".green().bold());
+        } else {
+            println!("{} Sandbox template {name} not found", "!".yellow());
+        }
+    }
+    Ok(())
+}
+
+fn parse_ready_within_duration(value: &str) -> Result<prost_types::Duration> {
+    let millis = parse_duration_to_ms(value)?;
+    if millis < 0 {
+        return Err(miette!(
+            "--ready-within must be greater than or equal to zero"
+        ));
+    }
+    Ok(prost_types::Duration {
+        seconds: millis / 1_000,
+        nanos: i32::try_from((millis % 1_000) * 1_000_000)
+            .expect("millisecond remainder fits in prost Duration nanos"),
+    })
+}
+
+fn print_sandbox_template(template: &SandboxTemplate, output: &str) -> Result<()> {
+    if crate::output::print_output_single(output, template, sandbox_template_to_json)? {
+        return Ok(());
+    }
+
+    println!("{}", "Sandbox Template".cyan().bold());
+    println!();
+    println!("  {} {}", "Name:".dimmed(), template.object_name());
+    println!(
+        "  {} {}",
+        "Workspace:".dimmed(),
+        template.object_workspace()
+    );
+    println!("  {} {}", "Image:".dimmed(), template_image(template));
+    println!("  {} {}", "CPU:".dimmed(), template_resource_cpu(template));
+    println!(
+        "  {} {}",
+        "Memory:".dimmed(),
+        template_resource_memory(template)
+    );
+    println!("  {} {}", "GPU:".dimmed(), template_resource_gpu(template));
+    println!(
+        "  {} {}",
+        "Driver config:".dimmed(),
+        non_empty_or(&template_driver_config_keys(template).join(", "), "-")
+    );
+    println!(
+        "  {} {}",
+        "Ready within:".dimmed(),
+        template_ready_within(template)
+    );
+    println!(
+        "  {} {}",
+        "Max burst:".dimmed(),
+        template_max_burst(template)
+    );
+    if let Some(meta) = template.metadata.as_ref() {
+        println!(
+            "  {} {}",
+            "Resource version:".dimmed(),
+            meta.resource_version
+        );
+        println!(
+            "  {} {}",
+            "Created:".dimmed(),
+            format_epoch_ms(meta.created_at_ms)
+        );
+    }
+    Ok(())
+}
+
+fn sandbox_template_to_json(template: &SandboxTemplate) -> serde_json::Value {
+    let meta = template.metadata.as_ref();
+    serde_json::json!({
+        "id": meta.map_or("", |m| m.id.as_str()),
+        "name": template.object_name(),
+        "workspace": template.object_workspace(),
+        "resource_version": meta.map_or(0, |m| m.resource_version),
+        "created_at": meta.map_or_else(String::new, |m| format_epoch_ms(m.created_at_ms)),
+        "labels": meta.map_or_else(|| serde_json::json!({}), |m| serde_json::json!(m.labels)),
+        "annotations": meta.map_or_else(|| serde_json::json!({}), |m| serde_json::json!(m.annotations)),
+        "image": template_image(template),
+        "environment": template.spec.as_ref()
+            .and_then(|spec| spec.workload.as_ref())
+            .map_or_else(|| serde_json::json!({}), |workload| serde_json::json!(workload.environment)),
+        "resources": {
+            "cpu": template_resource_cpu(template),
+            "memory": template_resource_memory(template),
+            "gpu_count": template_resources(template).and_then(|resources| resources.gpu_count),
+        },
+        "driver_config_keys": template_driver_config_keys(template),
+        "ready_within": template_ready_within(template),
+        "max_burst": template.spec.as_ref()
+            .and_then(|spec| spec.desired_service_level.as_ref())
+            .and_then(|level| level.startup.as_ref())
+            .map_or(0, |startup| startup.max_burst),
+    })
+}
+
+fn template_image(template: &SandboxTemplate) -> String {
+    template
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.workload.as_ref())
+        .map_or_else(String::new, |workload| workload.image.clone())
+}
+
+fn template_resources(template: &SandboxTemplate) -> Option<&SandboxResources> {
+    template
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.workload.as_ref())
+        .and_then(|workload| workload.resources.as_ref())
+}
+
+fn template_resource_cpu(template: &SandboxTemplate) -> String {
+    non_empty_or(
+        template_resources(template).map_or("", |r| r.cpu.as_str()),
+        "-",
+    )
+    .to_string()
+}
+
+fn template_resource_memory(template: &SandboxTemplate) -> String {
+    non_empty_or(
+        template_resources(template).map_or("", |r| r.memory.as_str()),
+        "-",
+    )
+    .to_string()
+}
+
+fn template_resource_gpu(template: &SandboxTemplate) -> String {
+    template_resources(template)
+        .and_then(|resources| resources.gpu_count)
+        .map_or_else(|| "-".to_string(), |count| count.to_string())
+}
+
+fn template_driver_config_keys(template: &SandboxTemplate) -> Vec<String> {
+    let mut keys = template
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.driver_config.as_ref())
+        .map(|driver_config| driver_config.fields.keys().cloned().collect::<Vec<_>>())
+        .unwrap_or_default();
+    keys.sort();
+    keys
+}
+
+fn template_ready_within(template: &SandboxTemplate) -> String {
+    template
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.desired_service_level.as_ref())
+        .and_then(|level| level.startup.as_ref())
+        .and_then(|startup| startup.ready_within.as_ref())
+        .map_or_else(|| "-".to_string(), format_proto_duration)
+}
+
+fn template_max_burst(template: &SandboxTemplate) -> String {
+    template
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.desired_service_level.as_ref())
+        .and_then(|level| level.startup.as_ref())
+        .map_or_else(|| "-".to_string(), |startup| startup.max_burst.to_string())
+}
+
+fn template_age(template: &SandboxTemplate) -> String {
+    template.metadata.as_ref().map_or_else(
+        || "-".to_string(),
+        |meta| format_epoch_ms(meta.created_at_ms),
+    )
+}
+
+fn format_proto_duration(duration: &prost_types::Duration) -> String {
+    let millis = duration.seconds.saturating_mul(1_000) + i64::from(duration.nanos / 1_000_000);
+    if millis == 0 {
+        "0ms".to_string()
+    } else if millis % 3_600_000 == 0 {
+        format!("{}h", millis / 3_600_000)
+    } else if millis % 60_000 == 0 {
+        format!("{}m", millis / 60_000)
+    } else if millis % 1_000 == 0 {
+        format!("{}s", millis / 1_000)
+    } else {
+        format!("{millis}ms")
+    }
+}
+
 /// Return the provider type inferred from the trailing command, if any.
 fn inferred_provider_type(command: &[String]) -> Option<String> {
     detect_provider_from_command(command).map(str::to_string)
@@ -2726,7 +3175,7 @@ async fn auto_create_provider(
         // Explicit name: create with exactly that name, no retries.
         let request = CreateProviderRequest {
             provider: Some(Provider {
-                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                metadata: Some(ObjectMeta {
                     id: String::new(),
                     name: exact_name.to_string(),
                     created_at_ms: 0,
@@ -2774,7 +3223,7 @@ async fn auto_create_provider(
 
             let request = CreateProviderRequest {
                 provider: Some(Provider {
-                    metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    metadata: Some(ObjectMeta {
                         id: String::new(),
                         name: name.clone(),
                         created_at_ms: 0,
@@ -3537,7 +3986,7 @@ pub async fn provider_create_with_options(
     let response = client
         .create_provider(CreateProviderRequest {
             provider: Some(Provider {
-                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                metadata: Some(ObjectMeta {
                     id: String::new(),
                     name: name.to_string(),
                     created_at_ms: 0,
@@ -4634,7 +5083,7 @@ pub async fn provider_update(
     let response = client
         .update_provider(UpdateProviderRequest {
             provider: Some(Provider {
-                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                metadata: Some(ObjectMeta {
                     id: String::new(),
                     name: name.to_string(),
                     created_at_ms: 0,

--- a/crates/openshell-cli/tests/ensure_providers_integration.rs
+++ b/crates/openshell-cli/tests/ensure_providers_integration.rs
@@ -139,6 +139,34 @@ impl OpenShell for TestOpenShell {
         Ok(Response::new(ListSandboxesResponse::default()))
     }
 
+    async fn create_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::CreateSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::GetSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn list_sandbox_templates(
+        &self,
+        _: tonic::Request<openshell_core::proto::ListSandboxTemplatesRequest>,
+    ) -> Result<Response<openshell_core::proto::ListSandboxTemplatesResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn delete_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::DeleteSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::DeleteSandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
     async fn list_sandbox_providers(
         &self,
         _request: tonic::Request<ListSandboxProvidersRequest>,

--- a/crates/openshell-cli/tests/mtls_integration.rs
+++ b/crates/openshell-cli/tests/mtls_integration.rs
@@ -98,6 +98,34 @@ impl OpenShell for TestOpenShell {
         ))
     }
 
+    async fn create_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::CreateSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::GetSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn list_sandbox_templates(
+        &self,
+        _: tonic::Request<openshell_core::proto::ListSandboxTemplatesRequest>,
+    ) -> Result<Response<openshell_core::proto::ListSandboxTemplatesResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn delete_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::DeleteSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::DeleteSandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
     async fn list_sandbox_providers(
         &self,
         _request: tonic::Request<openshell_core::proto::ListSandboxProvidersRequest>,

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -163,6 +163,7 @@ impl OpenShell for TestOpenShell {
                 }),
                 spec: None,
                 status: None,
+                created_from_template: None,
             }),
         }))
     }
@@ -172,6 +173,34 @@ impl OpenShell for TestOpenShell {
         _request: tonic::Request<ListSandboxesRequest>,
     ) -> Result<Response<ListSandboxesResponse>, Status> {
         Ok(Response::new(ListSandboxesResponse::default()))
+    }
+
+    async fn create_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::CreateSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::GetSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn list_sandbox_templates(
+        &self,
+        _: tonic::Request<openshell_core::proto::ListSandboxTemplatesRequest>,
+    ) -> Result<Response<openshell_core::proto::ListSandboxTemplatesResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn delete_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::DeleteSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::DeleteSandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
     }
 
     async fn list_sandbox_providers(

--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -20,14 +20,13 @@ use openshell_core::proto::{
     ExecSandboxInput, ExecSandboxRequest, GatewayMessage, GetGatewayConfigRequest,
     GetGatewayConfigResponse, GetProviderRequest, GetSandboxConfigRequest,
     GetSandboxConfigResponse, GetSandboxProviderEnvironmentRequest,
-    GetSandboxProviderEnvironmentResponse, GetSandboxRequest, GpuResourceRequirements,
-    HealthRequest, HealthResponse, ListProvidersRequest, ListProvidersResponse,
-    ListSandboxProvidersRequest, ListSandboxProvidersResponse, ListSandboxesRequest,
-    ListSandboxesResponse, PlatformEvent, ProviderResponse, RevokeSshSessionRequest,
-    RevokeSshSessionResponse, Sandbox, SandboxCondition, SandboxLogLine, SandboxPhase,
-    SandboxResponse, SandboxStatus, SandboxStreamEvent, ServiceStatus, SettingValue,
-    SupervisorMessage, UpdateProviderRequest, WatchSandboxRequest, sandbox_stream_event,
-    setting_value,
+    GetSandboxProviderEnvironmentResponse, GetSandboxRequest, HealthRequest, HealthResponse,
+    ListProvidersRequest, ListProvidersResponse, ListSandboxProvidersRequest,
+    ListSandboxProvidersResponse, ListSandboxesRequest, ListSandboxesResponse, PlatformEvent,
+    ProviderResponse, RevokeSshSessionRequest, RevokeSshSessionResponse, Sandbox, SandboxCondition,
+    SandboxLogLine, SandboxPhase, SandboxResponse, SandboxStatus, SandboxStreamEvent,
+    SandboxWorkloadConfig, ServiceStatus, SettingValue, SupervisorMessage, UpdateProviderRequest,
+    WatchSandboxRequest, create_sandbox_request, sandbox_stream_event, setting_value,
 };
 use std::collections::HashMap;
 use std::fs;
@@ -159,6 +158,34 @@ impl OpenShell for TestOpenShell {
         _request: tonic::Request<ListSandboxesRequest>,
     ) -> Result<Response<ListSandboxesResponse>, Status> {
         Ok(Response::new(ListSandboxesResponse::default()))
+    }
+
+    async fn create_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::CreateSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::GetSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn list_sandbox_templates(
+        &self,
+        _: tonic::Request<openshell_core::proto::ListSandboxTemplatesRequest>,
+    ) -> Result<Response<openshell_core::proto::ListSandboxTemplatesResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn delete_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::DeleteSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::DeleteSandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
     }
 
     async fn list_sandbox_providers(
@@ -1141,8 +1168,15 @@ fn test_tls(server: &TestServer) -> TlsOptions {
     server.tls.with_gateway_name("openshell")
 }
 
-fn gpu_requirements(count: Option<u32>) -> GpuResourceRequirements {
-    GpuResourceRequirements { count }
+fn gpu_requirements(count: Option<u32>) -> u32 {
+    count.unwrap_or(1)
+}
+
+fn inline_workload(request: &CreateSandboxRequest) -> &SandboxWorkloadConfig {
+    match request.workload_source.as_ref() {
+        Some(create_sandbox_request::WorkloadSource::Workload(workload)) => workload,
+        other => panic!("expected inline workload, got {other:?}"),
+    }
 }
 
 /// Shared defaults for integration tests. Note: `keep` is `true` here (most
@@ -1249,49 +1283,16 @@ async fn sandbox_create_sends_cpu_and_memory_limits_only() {
     .expect("sandbox create should succeed");
 
     let requests = create_requests(&server).await;
-    let resources = requests[0]
-        .spec
+    let resources = inline_workload(&requests[0])
+        .resources
         .as_ref()
-        .and_then(|spec| spec.template.as_ref())
-        .and_then(|template| template.resources.as_ref())
         .expect("resource limits should be sent");
-    let limits = resources
-        .fields
-        .get("limits")
-        .and_then(|value| value.kind.as_ref())
-        .and_then(|kind| match kind {
-            prost_types::value::Kind::StructValue(inner) => Some(inner),
-            _ => None,
-        })
-        .expect("limits should be a struct");
-
-    assert_eq!(
-        limits
-            .fields
-            .get("cpu")
-            .and_then(|value| value.kind.as_ref())
-            .and_then(|kind| match kind {
-                prost_types::value::Kind::StringValue(value) => Some(value.as_str()),
-                _ => None,
-            }),
-        Some("500m")
-    );
-    assert_eq!(
-        limits
-            .fields
-            .get("memory")
-            .and_then(|value| value.kind.as_ref())
-            .and_then(|kind| match kind {
-                prost_types::value::Kind::StringValue(value) => Some(value.as_str()),
-                _ => None,
-            }),
-        Some("2Gi")
-    );
-    assert!(!resources.fields.contains_key("requests"));
+    assert_eq!(resources.cpu, "500m");
+    assert_eq!(resources.memory, "2Gi");
 }
 
 #[tokio::test]
-async fn sandbox_create_sends_driver_config_json() {
+async fn sandbox_create_rejects_direct_driver_config_json() {
     let server = run_server().await;
     let fake_ssh_dir = tempfile::tempdir().unwrap();
     let xdg_dir = tempfile::tempdir().unwrap();
@@ -1299,7 +1300,7 @@ async fn sandbox_create_sends_driver_config_json() {
     let tls = test_tls(&server);
     install_fake_ssh(&fake_ssh_dir);
 
-    run::sandbox_create(
+    let err = run::sandbox_create(
         &server.endpoint,
         "openshell",
         run::SandboxCreateConfig {
@@ -1314,43 +1315,11 @@ async fn sandbox_create_sends_driver_config_json() {
         &tls,
     )
     .await
-    .expect("sandbox create should succeed");
-
-    let requests = create_requests(&server).await;
-    let driver_config = requests[0]
-        .spec
-        .as_ref()
-        .and_then(|spec| spec.template.as_ref())
-        .and_then(|template| template.driver_config.as_ref())
-        .expect("driver config should be sent");
-    let kubernetes = driver_config
-        .fields
-        .get("kubernetes")
-        .and_then(|value| value.kind.as_ref())
-        .and_then(|kind| match kind {
-            prost_types::value::Kind::StructValue(inner) => Some(inner),
-            _ => None,
-        })
-        .expect("kubernetes block should be a struct");
-    let pod = kubernetes
-        .fields
-        .get("pod")
-        .and_then(|value| value.kind.as_ref())
-        .and_then(|kind| match kind {
-            prost_types::value::Kind::StructValue(inner) => Some(inner),
-            _ => None,
-        })
-        .expect("pod block should be a struct");
-
-    assert_eq!(
-        pod.fields
-            .get("priority_class_name")
-            .and_then(|value| value.kind.as_ref())
-            .and_then(|kind| match kind {
-                prost_types::value::Kind::StringValue(value) => Some(value.as_str()),
-                _ => None,
-            }),
-        Some("batch-low")
+    .expect_err("inline driver config should be rejected");
+    assert!(
+        err.to_string()
+            .contains("--driver-config-json is only supported through named sandbox templates"),
+        "unexpected error: {err:?}"
     );
 }
 
@@ -1379,14 +1348,13 @@ async fn sandbox_create_sends_gpu_default_request() {
     .expect("sandbox create should succeed");
 
     let requests = create_requests(&server).await;
-    let gpu = requests[0]
-        .spec
+    let gpu_count = inline_workload(&requests[0])
+        .resources
         .as_ref()
-        .and_then(|spec| spec.resource_requirements.as_ref())
-        .and_then(|requirements| requirements.gpu.as_ref())
+        .and_then(|resources| resources.gpu_count)
         .expect("GPU requirement should be sent");
 
-    assert_eq!(gpu.count, None);
+    assert_eq!(gpu_count, 1);
 }
 
 #[tokio::test]
@@ -1414,14 +1382,13 @@ async fn sandbox_create_sends_gpu_count_request() {
     .expect("sandbox create should succeed");
 
     let requests = create_requests(&server).await;
-    let gpu = requests[0]
-        .spec
+    let gpu_count = inline_workload(&requests[0])
+        .resources
         .as_ref()
-        .and_then(|spec| spec.resource_requirements.as_ref())
-        .and_then(|requirements| requirements.gpu.as_ref())
+        .and_then(|resources| resources.gpu_count)
         .expect("GPU requirement should be sent");
 
-    assert_eq!(gpu.count, Some(2));
+    assert_eq!(gpu_count, 2);
 }
 
 #[tokio::test]
@@ -1450,12 +1417,7 @@ async fn sandbox_create_does_not_infer_command_providers_when_v2_enabled() {
     .expect("sandbox create should succeed without inferred provider");
 
     let requests = create_requests(&server).await;
-    let providers = requests[0]
-        .spec
-        .as_ref()
-        .expect("sandbox spec should be sent")
-        .providers
-        .clone();
+    let providers = requests[0].providers.clone();
     assert!(
         providers.is_empty(),
         "providers v2 should not infer command providers, got {providers:?}"
@@ -1871,11 +1833,7 @@ async fn sandbox_create_sends_environment_variables() {
     .expect("sandbox create should succeed");
 
     let requests = create_requests(&server).await;
-    let environment = &requests[0]
-        .spec
-        .as_ref()
-        .expect("spec should be present")
-        .environment;
+    let environment = &inline_workload(&requests[0]).environment;
     assert_eq!(environment.get("FOO").map(String::as_str), Some("bar"));
     assert_eq!(
         environment.get("BAZ").map(String::as_str),

--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -14,19 +14,23 @@ use openshell_cli::tls::TlsOptions;
 use openshell_core::proto::open_shell_server::{OpenShell, OpenShellServer};
 use openshell_core::proto::{
     AttachSandboxProviderRequest, AttachSandboxProviderResponse, CreateProviderRequest,
-    CreateSandboxRequest, CreateSshSessionRequest, CreateSshSessionResponse, DeleteProviderRequest,
-    DeleteProviderResponse, DeleteSandboxRequest, DeleteSandboxResponse,
+    CreateSandboxRequest, CreateSandboxTemplateRequest, CreateSshSessionRequest,
+    CreateSshSessionResponse, DeleteProviderRequest, DeleteProviderResponse, DeleteSandboxRequest,
+    DeleteSandboxResponse, DeleteSandboxTemplateRequest, DeleteSandboxTemplateResponse,
     DetachSandboxProviderRequest, DetachSandboxProviderResponse, ExecSandboxEvent,
     ExecSandboxInput, ExecSandboxRequest, GatewayMessage, GetGatewayConfigRequest,
     GetGatewayConfigResponse, GetProviderRequest, GetSandboxConfigRequest,
     GetSandboxConfigResponse, GetSandboxProviderEnvironmentRequest,
-    GetSandboxProviderEnvironmentResponse, GetSandboxRequest, HealthRequest, HealthResponse,
-    ListProvidersRequest, ListProvidersResponse, ListSandboxProvidersRequest,
-    ListSandboxProvidersResponse, ListSandboxesRequest, ListSandboxesResponse, PlatformEvent,
-    ProviderResponse, RevokeSshSessionRequest, RevokeSshSessionResponse, Sandbox, SandboxCondition,
-    SandboxLogLine, SandboxPhase, SandboxResponse, SandboxStatus, SandboxStreamEvent,
-    SandboxWorkloadConfig, ServiceStatus, SettingValue, SupervisorMessage, UpdateProviderRequest,
-    WatchSandboxRequest, create_sandbox_request, sandbox_stream_event, setting_value,
+    GetSandboxProviderEnvironmentResponse, GetSandboxRequest, GetSandboxTemplateRequest,
+    HealthRequest, HealthResponse, ListProvidersRequest, ListProvidersResponse,
+    ListSandboxProvidersRequest, ListSandboxProvidersResponse, ListSandboxTemplatesRequest,
+    ListSandboxTemplatesResponse, ListSandboxesRequest, ListSandboxesResponse, ObjectMeta,
+    PlatformEvent, Provider, ProviderResponse, RevokeSshSessionRequest, RevokeSshSessionResponse,
+    Sandbox, SandboxCondition, SandboxLogLine, SandboxPhase, SandboxResponse, SandboxServiceLevel,
+    SandboxStartup, SandboxStatus, SandboxStreamEvent, SandboxTemplate, SandboxTemplateResponse,
+    SandboxTemplateSpec, SandboxWorkloadConfig, ServiceStatus, SettingValue, SupervisorMessage,
+    UpdateProviderRequest, WatchSandboxRequest, create_sandbox_request, sandbox_stream_event,
+    setting_value,
 };
 use std::collections::HashMap;
 use std::fs;
@@ -45,6 +49,10 @@ use tonic::{Response, Status};
 struct SandboxState {
     deleted_names: Arc<Mutex<Vec<Vec<String>>>>,
     create_requests: Arc<Mutex<Vec<CreateSandboxRequest>>>,
+    create_template_requests: Arc<Mutex<Vec<CreateSandboxTemplateRequest>>>,
+    get_template_requests: Arc<Mutex<Vec<GetSandboxTemplateRequest>>>,
+    list_template_requests: Arc<Mutex<Vec<ListSandboxTemplatesRequest>>>,
+    delete_template_requests: Arc<Mutex<Vec<DeleteSandboxTemplateRequest>>>,
     vm_error_after_started: Arc<AtomicBool>,
     vm_slow_progress_before_ready: Arc<AtomicBool>,
     vm_log_churn_before_ready: Arc<AtomicBool>,
@@ -55,6 +63,38 @@ struct SandboxState {
 #[derive(Clone, Default)]
 struct TestOpenShell {
     state: SandboxState,
+}
+
+fn test_template(name: &str, workspace: &str) -> SandboxTemplate {
+    SandboxTemplate {
+        metadata: Some(ObjectMeta {
+            id: format!("template-{name}"),
+            name: name.to_string(),
+            created_at_ms: 0,
+            labels: HashMap::new(),
+            resource_version: 1,
+            annotations: HashMap::new(),
+            workspace: workspace.to_string(),
+            deletion_timestamp_ms: 0,
+        }),
+        spec: Some(SandboxTemplateSpec {
+            workload: Some(SandboxWorkloadConfig {
+                image: "python:3.12".to_string(),
+                environment: HashMap::new(),
+                resources: None,
+            }),
+            driver_config: None,
+            desired_service_level: Some(SandboxServiceLevel {
+                startup: Some(SandboxStartup {
+                    ready_within: Some(prost_types::Duration {
+                        seconds: 30,
+                        nanos: 0,
+                    }),
+                    max_burst: 5,
+                }),
+            }),
+        }),
+    }
 }
 
 #[tonic::async_trait]
@@ -97,7 +137,7 @@ impl OpenShell for TestOpenShell {
         };
 
         let mut sandbox = Sandbox {
-            metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+            metadata: Some(ObjectMeta {
                 id: format!("id-{sandbox_name}"),
                 name: sandbox_name,
                 created_at_ms: 0,
@@ -135,7 +175,7 @@ impl OpenShell for TestOpenShell {
     ) -> Result<Response<SandboxResponse>, Status> {
         let name = request.into_inner().name;
         let mut sandbox = Sandbox {
-            metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+            metadata: Some(ObjectMeta {
                 id: format!("id-{name}"),
                 name,
                 created_at_ms: 0,
@@ -162,30 +202,77 @@ impl OpenShell for TestOpenShell {
 
     async fn create_sandbox_template(
         &self,
-        _: tonic::Request<openshell_core::proto::CreateSandboxTemplateRequest>,
-    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
-        Err(Status::unimplemented("unused"))
+        request: tonic::Request<CreateSandboxTemplateRequest>,
+    ) -> Result<Response<SandboxTemplateResponse>, Status> {
+        let request = request.into_inner();
+        let mut template = request.template.clone().unwrap_or_default();
+        if template.metadata.is_none() {
+            template.metadata = Some(ObjectMeta::default());
+        }
+        if let Some(metadata) = template.metadata.as_mut() {
+            if metadata.id.is_empty() {
+                metadata.id = format!("template-{}", metadata.name);
+            }
+            if metadata.workspace.is_empty() {
+                metadata.workspace.clone_from(&request.workspace);
+            }
+            metadata.resource_version = metadata.resource_version.max(1);
+        }
+        self.state
+            .create_template_requests
+            .lock()
+            .await
+            .push(request);
+        Ok(Response::new(SandboxTemplateResponse {
+            template: Some(template),
+        }))
     }
 
     async fn get_sandbox_template(
         &self,
-        _: tonic::Request<openshell_core::proto::GetSandboxTemplateRequest>,
-    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
-        Err(Status::unimplemented("unused"))
+        request: tonic::Request<GetSandboxTemplateRequest>,
+    ) -> Result<Response<SandboxTemplateResponse>, Status> {
+        let request = request.into_inner();
+        self.state
+            .get_template_requests
+            .lock()
+            .await
+            .push(request.clone());
+        Ok(Response::new(SandboxTemplateResponse {
+            template: Some(test_template(&request.name, &request.workspace)),
+        }))
     }
 
     async fn list_sandbox_templates(
         &self,
-        _: tonic::Request<openshell_core::proto::ListSandboxTemplatesRequest>,
-    ) -> Result<Response<openshell_core::proto::ListSandboxTemplatesResponse>, Status> {
-        Err(Status::unimplemented("unused"))
+        request: tonic::Request<ListSandboxTemplatesRequest>,
+    ) -> Result<Response<ListSandboxTemplatesResponse>, Status> {
+        let request = request.into_inner();
+        self.state
+            .list_template_requests
+            .lock()
+            .await
+            .push(request.clone());
+        Ok(Response::new(ListSandboxTemplatesResponse {
+            templates: vec![
+                test_template("python", &request.workspace),
+                test_template("gpu-kata", &request.workspace),
+            ],
+        }))
     }
 
     async fn delete_sandbox_template(
         &self,
-        _: tonic::Request<openshell_core::proto::DeleteSandboxTemplateRequest>,
-    ) -> Result<Response<openshell_core::proto::DeleteSandboxTemplateResponse>, Status> {
-        Err(Status::unimplemented("unused"))
+        request: tonic::Request<DeleteSandboxTemplateRequest>,
+    ) -> Result<Response<DeleteSandboxTemplateResponse>, Status> {
+        self.state
+            .delete_template_requests
+            .lock()
+            .await
+            .push(request.into_inner());
+        Ok(Response::new(DeleteSandboxTemplateResponse {
+            deleted: true,
+        }))
     }
 
     async fn list_sandbox_providers(
@@ -321,7 +408,21 @@ impl OpenShell for TestOpenShell {
         &self,
         _request: tonic::Request<ListProvidersRequest>,
     ) -> Result<Response<ListProvidersResponse>, Status> {
-        Ok(Response::new(ListProvidersResponse::default()))
+        Ok(Response::new(ListProvidersResponse {
+            providers: vec![Provider {
+                metadata: Some(ObjectMeta {
+                    id: "id-github".to_string(),
+                    name: "github".to_string(),
+                    ..ObjectMeta::default()
+                }),
+                r#type: "github".to_string(),
+                credentials: HashMap::new(),
+                config: HashMap::new(),
+                credential_expires_at_ms: HashMap::new(),
+                profile_workspace: "default".to_string(),
+                credential_handles: HashMap::new(),
+            }],
+        }))
     }
 
     async fn list_provider_profiles(
@@ -429,7 +530,7 @@ impl OpenShell for TestOpenShell {
 
         tokio::spawn(async move {
             let mut provisioning = Sandbox {
-                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                metadata: Some(ObjectMeta {
                     id: sandbox_id.clone(),
                     name: sandbox_id.trim_start_matches("id-").to_string(),
                     created_at_ms: 0,
@@ -1155,6 +1256,46 @@ async fn create_requests(server: &TestServer) -> Vec<CreateSandboxRequest> {
     server.openshell.state.create_requests.lock().await.clone()
 }
 
+async fn create_template_requests(server: &TestServer) -> Vec<CreateSandboxTemplateRequest> {
+    server
+        .openshell
+        .state
+        .create_template_requests
+        .lock()
+        .await
+        .clone()
+}
+
+async fn get_template_requests(server: &TestServer) -> Vec<GetSandboxTemplateRequest> {
+    server
+        .openshell
+        .state
+        .get_template_requests
+        .lock()
+        .await
+        .clone()
+}
+
+async fn list_template_requests(server: &TestServer) -> Vec<ListSandboxTemplatesRequest> {
+    server
+        .openshell
+        .state
+        .list_template_requests
+        .lock()
+        .await
+        .clone()
+}
+
+async fn delete_template_requests(server: &TestServer) -> Vec<DeleteSandboxTemplateRequest> {
+    server
+        .openshell
+        .state
+        .delete_template_requests
+        .lock()
+        .await
+        .clone()
+}
+
 async fn enable_providers_v2(server: &TestServer) {
     server.openshell.state.global_settings.lock().await.insert(
         openshell_core::settings::PROVIDERS_V2_ENABLED_KEY.to_string(),
@@ -1321,6 +1462,233 @@ async fn sandbox_create_rejects_direct_driver_config_json() {
             .contains("--driver-config-json is only supported through named sandbox templates"),
         "unexpected error: {err:?}"
     );
+}
+
+#[tokio::test]
+async fn sandbox_create_with_template_sends_workload_template_provider_and_policy() {
+    let server = run_server().await;
+    let fake_ssh_dir = tempfile::tempdir().unwrap();
+    let xdg_dir = tempfile::tempdir().unwrap();
+    let _env = test_env(&fake_ssh_dir, &xdg_dir);
+    let tls = test_tls(&server);
+    install_fake_ssh(&fake_ssh_dir);
+    let providers = vec!["github".to_string()];
+    let policy_path = xdg_dir.path().join("policy.yaml");
+    fs::write(
+        &policy_path,
+        openshell_policy::serialize_sandbox_policy(&openshell_policy::restrictive_default_policy())
+            .expect("default policy should serialize"),
+    )
+    .unwrap();
+    let policy_path = policy_path.to_string_lossy().to_string();
+
+    run::sandbox_create(
+        &server.endpoint,
+        "openshell",
+        run::SandboxCreateConfig {
+            name: Some("templated"),
+            template: Some("gpu-kata"),
+            providers: &providers,
+            policy: Some(&policy_path),
+            command: &["echo".into(), "OK".into()],
+            ..test_config()
+        },
+        "team-a",
+        &tls,
+    )
+    .await
+    .expect("sandbox create from template should succeed");
+
+    let requests = create_requests(&server).await;
+    assert_eq!(requests.len(), 1);
+    assert!(matches!(
+        requests[0].workload_source.as_ref(),
+        Some(create_sandbox_request::WorkloadSource::WorkloadTemplateName(name)) if name == "gpu-kata"
+    ));
+    assert!(
+        requests[0].policy.is_some(),
+        "template-based sandbox creates should still send policy"
+    );
+    assert_eq!(requests[0].providers, vec!["github".to_string()]);
+    assert_eq!(requests[0].workspace, "team-a");
+}
+
+#[tokio::test]
+async fn sandbox_template_create_sends_template_spec() {
+    let server = run_server().await;
+    let tls = test_tls(&server);
+    let mut environment = HashMap::new();
+    environment.insert("MODE".to_string(), "on".to_string());
+    let mut labels = HashMap::new();
+    labels.insert("tier".to_string(), "gold".to_string());
+    let mut annotations = HashMap::new();
+    annotations.insert("owner".to_string(), "platform".to_string());
+
+    run::sandbox_template_create(
+        &server.endpoint,
+        run::SandboxTemplateCreateConfig {
+            name: "gpu-kata".to_string(),
+            from: Some("cuda:latest".to_string()),
+            environment,
+            cpu: Some("2".to_string()),
+            memory: Some("8Gi".to_string()),
+            gpu_count: Some(2),
+            driver_config_json: Some(
+                r#"{"kubernetes":{"pod":{"runtime_class_name":"kata-containers"}}}"#.to_string(),
+            ),
+            ready_within: Some("30s".to_string()),
+            max_burst: Some(5),
+            labels,
+            annotations,
+            output: "json".to_string(),
+        },
+        "team-a",
+        &tls,
+    )
+    .await
+    .expect("sandbox template create should succeed");
+
+    let requests = create_template_requests(&server).await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].workspace, "team-a");
+    let template = requests[0]
+        .template
+        .as_ref()
+        .expect("template should be sent");
+    let metadata = template
+        .metadata
+        .as_ref()
+        .expect("template metadata should be sent");
+    assert_eq!(metadata.name, "gpu-kata");
+    assert_eq!(metadata.workspace, "team-a");
+    assert_eq!(
+        metadata.labels.get("tier").map(String::as_str),
+        Some("gold")
+    );
+    assert_eq!(
+        metadata.annotations.get("owner").map(String::as_str),
+        Some("platform")
+    );
+
+    let spec = template
+        .spec
+        .as_ref()
+        .expect("template spec should be sent");
+    let workload = spec.workload.as_ref().expect("workload should be sent");
+    assert_eq!(workload.image, "cuda:latest");
+    assert_eq!(
+        workload.environment.get("MODE").map(String::as_str),
+        Some("on")
+    );
+    let resources = workload
+        .resources
+        .as_ref()
+        .expect("resources should be sent");
+    assert_eq!(resources.cpu, "2");
+    assert_eq!(resources.memory, "8Gi");
+    assert_eq!(resources.gpu_count, Some(2));
+    assert!(
+        spec.driver_config
+            .as_ref()
+            .is_some_and(|config| config.fields.contains_key("kubernetes")),
+        "driver config should keep the kubernetes block"
+    );
+    let startup = spec
+        .desired_service_level
+        .as_ref()
+        .and_then(|level| level.startup.as_ref())
+        .expect("startup service level should be sent");
+    assert_eq!(startup.ready_within.as_ref().map(|d| d.seconds), Some(30));
+    assert_eq!(startup.max_burst, 5);
+}
+
+#[tokio::test]
+async fn sandbox_template_create_omits_service_level_without_startup_flags() {
+    let server = run_server().await;
+    let tls = test_tls(&server);
+
+    run::sandbox_template_create(
+        &server.endpoint,
+        run::SandboxTemplateCreateConfig {
+            name: "python".to_string(),
+            from: None,
+            environment: HashMap::new(),
+            cpu: None,
+            memory: None,
+            gpu_count: None,
+            driver_config_json: None,
+            ready_within: None,
+            max_burst: None,
+            labels: HashMap::new(),
+            annotations: HashMap::new(),
+            output: "json".to_string(),
+        },
+        "team-a",
+        &tls,
+    )
+    .await
+    .expect("sandbox template create should succeed");
+
+    let requests = create_template_requests(&server).await;
+    let spec = requests[0]
+        .template
+        .as_ref()
+        .and_then(|template| template.spec.as_ref())
+        .expect("template spec should be sent");
+    assert_eq!(
+        spec.workload
+            .as_ref()
+            .map(|workload| workload.image.as_str()),
+        Some(""),
+        "omitted --from should leave the image empty for the gateway default"
+    );
+    assert!(
+        spec.desired_service_level.is_none(),
+        "service level should be omitted when startup flags are absent"
+    );
+}
+
+#[tokio::test]
+async fn sandbox_template_get_list_and_delete_send_workspace() {
+    let server = run_server().await;
+    let tls = test_tls(&server);
+
+    run::sandbox_template_get(&server.endpoint, "gpu-kata", "json", "team-a", &tls)
+        .await
+        .expect("sandbox template get should succeed");
+    run::sandbox_template_list(&server.endpoint, 50, 10, "json", "team-a", false, &tls)
+        .await
+        .expect("sandbox template list should succeed");
+    run::sandbox_template_list(&server.endpoint, 100, 0, "json", "default", true, &tls)
+        .await
+        .expect("sandbox template list --all-workspaces should succeed");
+    run::sandbox_template_delete(
+        &server.endpoint,
+        &["gpu-kata".to_string(), "python".to_string()],
+        "team-a",
+        &tls,
+    )
+    .await
+    .expect("sandbox template delete should succeed");
+
+    let get_requests = get_template_requests(&server).await;
+    assert_eq!(get_requests[0].name, "gpu-kata");
+    assert_eq!(get_requests[0].workspace, "team-a");
+    let list_requests = list_template_requests(&server).await;
+    assert_eq!(list_requests[0].limit, 50);
+    assert_eq!(list_requests[0].offset, 10);
+    assert_eq!(list_requests[0].workspace, "team-a");
+    assert!(!list_requests[0].all_workspaces);
+    assert_eq!(list_requests[1].limit, 100);
+    assert_eq!(list_requests[1].offset, 0);
+    assert_eq!(list_requests[1].workspace, "");
+    assert!(list_requests[1].all_workspaces);
+    let delete_requests = delete_template_requests(&server).await;
+    assert_eq!(delete_requests.len(), 2);
+    assert_eq!(delete_requests[0].name, "gpu-kata");
+    assert_eq!(delete_requests[0].workspace, "team-a");
+    assert_eq!(delete_requests[1].name, "python");
+    assert_eq!(delete_requests[1].workspace, "team-a");
 }
 
 #[tokio::test]

--- a/crates/openshell-cli/tests/sandbox_name_fallback_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_name_fallback_integration.rs
@@ -123,6 +123,34 @@ impl OpenShell for TestOpenShell {
         Ok(Response::new(ListSandboxesResponse::default()))
     }
 
+    async fn create_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::CreateSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::GetSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn list_sandbox_templates(
+        &self,
+        _: tonic::Request<openshell_core::proto::ListSandboxTemplatesRequest>,
+    ) -> Result<Response<openshell_core::proto::ListSandboxTemplatesResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn delete_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::DeleteSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::DeleteSandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
     async fn list_sandbox_providers(
         &self,
         _request: tonic::Request<ListSandboxProvidersRequest>,

--- a/crates/openshell-core/src/gpu.rs
+++ b/crates/openshell-core/src/gpu.rs
@@ -9,7 +9,7 @@ use std::sync::RwLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::config::CDI_GPU_DEVICE_ALL;
-use crate::proto::ResourceRequirements as SandboxResourceRequirements;
+use crate::proto::SandboxResources;
 use crate::proto::compute::v1::{
     GpuResourceRequirements as DriverGpuResourceRequirements,
     ResourceRequirements as DriverResourceRequirements,
@@ -17,18 +17,16 @@ use crate::proto::compute::v1::{
 
 /// Return whether sandbox resource requirements request a GPU.
 #[must_use]
-pub fn sandbox_gpu_requested(resources: Option<&SandboxResourceRequirements>) -> bool {
+pub fn sandbox_gpu_requested(resources: Option<&SandboxResources>) -> bool {
     resources
-        .and_then(|resources| resources.gpu.as_ref())
+        .and_then(|resources| resources.gpu_count)
         .is_some()
 }
 
 /// Return the requested sandbox GPU count, if one was specified.
 #[must_use]
-pub fn sandbox_gpu_count(resources: Option<&SandboxResourceRequirements>) -> Option<u32> {
-    resources
-        .and_then(|resources| resources.gpu.as_ref())
-        .and_then(|gpu| gpu.count)
+pub fn sandbox_gpu_count(resources: Option<&SandboxResources>) -> Option<u32> {
+    resources.and_then(|resources| resources.gpu_count)
 }
 
 /// Return the effective compute-driver GPU count.

--- a/crates/openshell-core/src/metadata.rs
+++ b/crates/openshell-core/src/metadata.rs
@@ -6,8 +6,9 @@
 //! These traits provide uniform access to `ObjectMeta` fields across all resource types.
 
 use crate::proto::{
-    InferenceRoute, ObjectForTest, Provider, Sandbox, SandboxStatus, ServiceEndpoint, SshSession,
-    StoredProviderCredentialRefreshState, StoredProviderProfile, Workspace, WorkspaceMember,
+    InferenceRoute, ObjectForTest, Provider, Sandbox, SandboxStatus, SandboxTemplate,
+    ServiceEndpoint, SshSession, StoredProviderCredentialRefreshState, StoredProviderProfile,
+    Workspace, WorkspaceMember,
 };
 use std::collections::HashMap;
 
@@ -76,6 +77,48 @@ impl GetResourceVersion for Sandbox {
 }
 
 impl ObjectWorkspace for Sandbox {
+    fn object_workspace(&self) -> &str {
+        self.metadata.as_ref().map_or("", |m| m.workspace.as_str())
+    }
+    fn requires_workspace() -> bool {
+        true
+    }
+}
+
+// Implementations for SandboxTemplate
+impl ObjectId for SandboxTemplate {
+    fn object_id(&self) -> &str {
+        self.metadata.as_ref().map_or("", |m| m.id.as_str())
+    }
+}
+
+impl ObjectName for SandboxTemplate {
+    fn object_name(&self) -> &str {
+        self.metadata.as_ref().map_or("", |m| m.name.as_str())
+    }
+}
+
+impl ObjectLabels for SandboxTemplate {
+    fn object_labels(&self) -> Option<HashMap<String, String>> {
+        self.metadata.as_ref().map(|m| m.labels.clone())
+    }
+}
+
+impl SetResourceVersion for SandboxTemplate {
+    fn set_resource_version(&mut self, version: u64) {
+        if let Some(meta) = self.metadata.as_mut() {
+            meta.resource_version = version;
+        }
+    }
+}
+
+impl GetResourceVersion for SandboxTemplate {
+    fn get_resource_version(&self) -> u64 {
+        self.metadata.as_ref().map_or(0, |m| m.resource_version)
+    }
+}
+
+impl ObjectWorkspace for SandboxTemplate {
     fn object_workspace(&self) -> &str {
         self.metadata.as_ref().map_or("", |m| m.workspace.as_str())
     }

--- a/crates/openshell-gateway-interceptors/src/proto_json.rs
+++ b/crates/openshell-gateway-interceptors/src/proto_json.rs
@@ -290,8 +290,8 @@ mod tests {
     use std::collections::HashMap;
 
     use openshell_core::proto::{
-        CreateProviderRequest, CreateSandboxRequest, GpuResourceRequirements, Provider,
-        SandboxSpec, UpdateConfigRequest,
+        CreateProviderRequest, CreateSandboxRequest, Provider, SandboxResources,
+        SandboxWorkloadConfig, UpdateConfigRequest, create_sandbox_request,
     };
     use prost::Message as _;
     use prost_types::{
@@ -308,10 +308,11 @@ mod tests {
         let codec =
             ProtoJsonCodec::from_descriptor_set(openshell_core::FILE_DESCRIPTOR_SET).unwrap();
         let request = CreateSandboxRequest {
-            spec: Some(SandboxSpec {
-                providers: vec!["github".to_string()],
-                ..SandboxSpec::default()
-            }),
+            workload_source: Some(create_sandbox_request::WorkloadSource::Workload(
+                SandboxWorkloadConfig::default(),
+            )),
+            policy: None,
+            providers: vec!["github".to_string()],
             name: "demo".to_string(),
             labels: HashMap::from([("team".to_string(), "agent".to_string())]),
             annotations: HashMap::new(),
@@ -321,7 +322,7 @@ mod tests {
         let json = codec
             .decode_bytes_to_json("openshell.v1.CreateSandboxRequest", &bytes)
             .unwrap();
-        assert_eq!(json["spec"]["providers"][0], "github");
+        assert_eq!(json["providers"][0], "github");
         assert_eq!(json["labels"]["team"], "agent");
         let encoded = codec
             .encode_json_to_message("openshell.v1.CreateSandboxRequest", &json)
@@ -399,10 +400,12 @@ mod tests {
     fn generic_sandbox_environment_remains_visible() {
         let codec = ProtoJsonCodec::openshell().unwrap();
         let request = CreateSandboxRequest {
-            spec: Some(SandboxSpec {
-                environment: HashMap::from([("FEATURE_FLAG".to_string(), "on".to_string())]),
-                ..SandboxSpec::default()
-            }),
+            workload_source: Some(create_sandbox_request::WorkloadSource::Workload(
+                SandboxWorkloadConfig {
+                    environment: HashMap::from([("FEATURE_FLAG".to_string(), "on".to_string())]),
+                    ..Default::default()
+                },
+            )),
             ..CreateSandboxRequest::default()
         };
 
@@ -413,7 +416,7 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(interceptor["spec"]["environment"]["FEATURE_FLAG"], "on");
+        assert_eq!(interceptor["workload"]["environment"]["FEATURE_FLAG"], "on");
     }
 
     #[test]
@@ -624,20 +627,26 @@ mod tests {
             ProtoJsonCodec::from_descriptor_set(openshell_core::FILE_DESCRIPTOR_SET).unwrap();
 
         for request in [
-            GpuResourceRequirements { count: None },
-            GpuResourceRequirements { count: Some(0) },
-            GpuResourceRequirements { count: Some(2) },
+            SandboxResources {
+                gpu_count: None,
+                ..Default::default()
+            },
+            SandboxResources {
+                gpu_count: Some(0),
+                ..Default::default()
+            },
+            SandboxResources {
+                gpu_count: Some(2),
+                ..Default::default()
+            },
         ] {
             let json = codec
-                .decode_bytes_to_json(
-                    "openshell.v1.GpuResourceRequirements",
-                    &request.encode_to_vec(),
-                )
+                .decode_bytes_to_json("openshell.v1.SandboxResources", &request.encode_to_vec())
                 .unwrap();
             let encoded = codec
-                .encode_json_to_message("openshell.v1.GpuResourceRequirements", &json)
+                .encode_json_to_message("openshell.v1.SandboxResources", &json)
                 .unwrap();
-            let decoded = GpuResourceRequirements::decode(encoded.as_slice()).unwrap();
+            let decoded = SandboxResources::decode(encoded.as_slice()).unwrap();
             assert_eq!(decoded, request);
         }
     }

--- a/crates/openshell-gateway-interceptors/src/runtime.rs
+++ b/crates/openshell-gateway-interceptors/src/runtime.rs
@@ -603,8 +603,7 @@ mod tests {
     use super::*;
     use openshell_core::proto::gateway_interceptor::v1::gateway_interceptor_client::GatewayInterceptorClient;
     use openshell_core::proto::{
-        CreateProviderRequest, CreateSandboxRequest, Provider, SandboxSpec, SandboxTemplate,
-        UpdateConfigRequest,
+        CreateProviderRequest, CreateSandboxRequest, Provider, UpdateConfigRequest,
     };
     use openshell_extension_core::BearerTokenInterceptor;
     use serde_json::json;
@@ -1048,29 +1047,20 @@ mod tests {
         let codec =
             ProtoJsonCodec::from_descriptor_set(openshell_core::FILE_DESCRIPTOR_SET).unwrap();
         let request = CreateSandboxRequest {
-            spec: Some(SandboxSpec {
-                template: Some(SandboxTemplate {
-                    resources: Some(
-                        json_to_struct(json!({
-                            "limits": {
-                                "cpu": "2",
-                                "memory": "4Gi"
-                            }
-                        }))
-                        .unwrap(),
-                    ),
-                    driver_config: Some(
-                        json_to_struct(json!({
-                            "docker": {
-                                "userns": "host"
-                            }
-                        }))
-                        .unwrap(),
-                    ),
-                    ..SandboxTemplate::default()
-                }),
-                ..SandboxSpec::default()
-            }),
+            workload_source: Some(
+                openshell_core::proto::create_sandbox_request::WorkloadSource::Workload(
+                    openshell_core::proto::SandboxWorkloadConfig {
+                        resources: Some(openshell_core::proto::SandboxResources {
+                            cpu: "2".to_string(),
+                            memory: "4Gi".to_string(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                ),
+            ),
+            policy: None,
+            providers: Vec::new(),
             name: "demo".to_string(),
             labels: HashMap::new(),
             annotations: HashMap::new(),
@@ -1082,16 +1072,8 @@ mod tests {
             .decode_bytes_to_json("openshell.v1.CreateSandboxRequest", &bytes)
             .unwrap();
 
-        assert_eq!(json["spec"]["template"]["resources"]["limits"]["cpu"], "2");
-        assert_eq!(
-            json["spec"]["template"]["driverConfig"]["docker"]["userns"],
-            "host"
-        );
-        assert!(
-            json["spec"]["template"]["resources"]
-                .get("fields")
-                .is_none()
-        );
+        assert_eq!(json["workload"]["resources"]["cpu"], "2");
+        assert!(json["workload"]["resources"].get("fields").is_none());
 
         let encoded = codec
             .encode_json_to_message("openshell.v1.CreateSandboxRequest", &json)
@@ -1145,13 +1127,13 @@ mod tests {
         let cases = [
             (
                 "openshell.v1.CreateSandboxRequest",
-                json!({"name": "demo", "spec": {}}),
-                patch("replace", "/spec", json!("not-a-message")),
+                json!({"name": "demo", "workload": {}}),
+                patch("replace", "/workload", json!("not-a-message")),
             ),
             (
                 "openshell.v1.CreateSandboxRequest",
-                json!({"name": "demo", "spec": {"providers": []}}),
-                patch("replace", "/spec/providers", json!({"provider": "github"})),
+                json!({"name": "demo", "workload": {}, "providers": []}),
+                patch("replace", "/providers", json!({"provider": "github"})),
             ),
             (
                 "openshell.v1.ReportPolicyStatusRequest",

--- a/crates/openshell-sdk/README.md
+++ b/crates/openshell-sdk/README.md
@@ -9,7 +9,8 @@ gateway-name resolution.
 ## Two layers
 
 - `OpenShellClient` — the curated, sandbox-focused surface: health, sandbox
-  CRUD, readiness/deletion waits, and non-streaming exec.
+  CRUD, template-based creation, sandbox template CRUD, readiness/deletion
+  waits, and non-streaming exec.
 - `raw` — direct access to the generated tonic clients for RPCs the curated
   surface doesn't yet cover (inference, providers, policy, logs, settings, SSH,
   forwarding).
@@ -43,11 +44,14 @@ mTLS (client certificates) is not supported.
 ## Public surface
 
 `OpenShellClient::connect(ClientConfig)` returns a connected client exposing
-`health`, `create_sandbox`, `get_sandbox`, `list_sandboxes`, `delete_sandbox`,
-`wait_ready`, `wait_deleted`, and `exec`. Curated types (`SandboxSpec`,
-`SandboxRef`, `Health`, `ListOptions`, `ExecOptions`, `SandboxPhase`) use
-SDK-shaped enums rather than raw proto integers. Failures map to a typed
-`SdkError` with a discriminable kind.
+`health`, `create_sandbox`, `create_sandbox_from_template`, sandbox template
+CRUD, `get_sandbox`, `list_sandboxes`, `delete_sandbox`, `wait_ready`,
+`wait_deleted`, and `exec`. Curated types (`SandboxSpec`,
+`SandboxTemplateCreateSpec`, `SandboxRef`, `Health`, `ListOptions`,
+`ExecOptions`, `SandboxPhase`) use SDK-shaped enums rather than raw proto
+integers. Template resources use the generated proto shape because templates
+are an administrative resource with driver-specific configuration. Failures map
+to a typed `SdkError` with a discriminable kind.
 
 ## Modules
 

--- a/crates/openshell-sdk/src/client.rs
+++ b/crates/openshell-sdk/src/client.rs
@@ -16,7 +16,7 @@ use crate::refresh::{RefreshedToken, TokenSource};
 use crate::transport;
 use crate::types::{
     ExecOptions, ExecResult, Health, ListOptions, SandboxPhase, SandboxRef, SandboxSpec,
-    WorkspaceRef,
+    SandboxTemplate, SandboxTemplateCreateSpec, SandboxTemplateListOptions, WorkspaceRef,
 };
 use futures::StreamExt;
 use openshell_core::proto;
@@ -161,6 +161,85 @@ impl OpenShellClient {
             })
             .await?;
         sandbox_from_response(response.sandbox)
+    }
+
+    /// Create a new sandbox from a workspace-scoped template name.
+    pub async fn create_sandbox_from_template(
+        &self,
+        spec: SandboxTemplateCreateSpec,
+    ) -> Result<SandboxRef> {
+        let request = create_sandbox_from_template_request(spec);
+        let response = self
+            .unary(|mut grpc| {
+                let request = request.clone();
+                async move { grpc.create_sandbox(request).await }
+            })
+            .await?;
+        sandbox_from_response(response.sandbox)
+    }
+
+    /// Create a reusable sandbox template in the default workspace.
+    pub async fn create_sandbox_template(
+        &self,
+        template: SandboxTemplate,
+    ) -> Result<SandboxTemplate> {
+        let response = self
+            .unary(|mut grpc| {
+                let request = proto::CreateSandboxTemplateRequest {
+                    template: Some(template.clone()),
+                    workspace: String::new(),
+                };
+                async move { grpc.create_sandbox_template(request).await }
+            })
+            .await?;
+        sandbox_template_from_response(response.template)
+    }
+
+    /// Fetch a sandbox template by name from the default workspace.
+    pub async fn get_sandbox_template(&self, name: &str) -> Result<SandboxTemplate> {
+        let response = self
+            .unary(|mut grpc| {
+                let request = proto::GetSandboxTemplateRequest {
+                    name: name.to_string(),
+                    workspace: String::new(),
+                };
+                async move { grpc.get_sandbox_template(request).await }
+            })
+            .await?;
+        sandbox_template_from_response(response.template)
+    }
+
+    /// List sandbox templates in the default workspace or across all workspaces.
+    pub async fn list_sandbox_templates(
+        &self,
+        opts: SandboxTemplateListOptions,
+    ) -> Result<Vec<SandboxTemplate>> {
+        let response = self
+            .unary(|mut grpc| {
+                let request = proto::ListSandboxTemplatesRequest {
+                    limit: opts.limit,
+                    offset: opts.offset,
+                    workspace: String::new(),
+                    all_workspaces: opts.all_workspaces,
+                };
+                async move { grpc.list_sandbox_templates(request).await }
+            })
+            .await?;
+        Ok(response.templates)
+    }
+
+    /// Delete a sandbox template by name from the default workspace.
+    pub async fn delete_sandbox_template(&self, name: &str) -> Result<bool> {
+        let response = self
+            .unary(|mut grpc| {
+                let request = proto::DeleteSandboxTemplateRequest {
+                    name: name.to_string(),
+                    workspace: String::new(),
+                };
+                async move { grpc.delete_sandbox_template(request).await }
+            })
+            .await?;
+        Ok(response.deleted)
     }
 
     /// Fetch a sandbox by name.
@@ -562,6 +641,95 @@ impl WorkspaceScopedClient {
         sandbox_from_response(response.sandbox)
     }
 
+    /// Create a new sandbox from a template in this workspace.
+    pub async fn create_sandbox_from_template(
+        &self,
+        spec: SandboxTemplateCreateSpec,
+    ) -> Result<SandboxRef> {
+        let mut request = create_sandbox_from_template_request(spec);
+        request.workspace = self.workspace.clone();
+        let response = self
+            .client
+            .unary(|mut grpc| {
+                let request = request.clone();
+                async move { grpc.create_sandbox(request).await }
+            })
+            .await?;
+        sandbox_from_response(response.sandbox)
+    }
+
+    /// Create a reusable sandbox template in this workspace.
+    pub async fn create_sandbox_template(
+        &self,
+        template: SandboxTemplate,
+    ) -> Result<SandboxTemplate> {
+        let response = self
+            .client
+            .unary(|mut grpc| {
+                let request = proto::CreateSandboxTemplateRequest {
+                    template: Some(template.clone()),
+                    workspace: self.workspace.clone(),
+                };
+                async move { grpc.create_sandbox_template(request).await }
+            })
+            .await?;
+        sandbox_template_from_response(response.template)
+    }
+
+    /// Fetch a sandbox template by name in this workspace.
+    pub async fn get_sandbox_template(&self, name: &str) -> Result<SandboxTemplate> {
+        let response = self
+            .client
+            .unary(|mut grpc| {
+                let request = proto::GetSandboxTemplateRequest {
+                    name: name.to_string(),
+                    workspace: self.workspace.clone(),
+                };
+                async move { grpc.get_sandbox_template(request).await }
+            })
+            .await?;
+        sandbox_template_from_response(response.template)
+    }
+
+    /// List sandbox templates in this workspace.
+    pub async fn list_sandbox_templates(
+        &self,
+        opts: SandboxTemplateListOptions,
+    ) -> Result<Vec<SandboxTemplate>> {
+        let response = self
+            .client
+            .unary(|mut grpc| {
+                let request = proto::ListSandboxTemplatesRequest {
+                    limit: opts.limit,
+                    offset: opts.offset,
+                    workspace: if opts.all_workspaces {
+                        String::new()
+                    } else {
+                        self.workspace.clone()
+                    },
+                    all_workspaces: opts.all_workspaces,
+                };
+                async move { grpc.list_sandbox_templates(request).await }
+            })
+            .await?;
+        Ok(response.templates)
+    }
+
+    /// Delete a sandbox template by name in this workspace.
+    pub async fn delete_sandbox_template(&self, name: &str) -> Result<bool> {
+        let response = self
+            .client
+            .unary(|mut grpc| {
+                let request = proto::DeleteSandboxTemplateRequest {
+                    name: name.to_string(),
+                    workspace: self.workspace.clone(),
+                };
+                async move { grpc.delete_sandbox_template(request).await }
+            })
+            .await?;
+        Ok(response.deleted)
+    }
+
     /// Fetch a sandbox by name in this workspace.
     pub async fn get_sandbox(&self, name: &str) -> Result<SandboxRef> {
         let response = self
@@ -822,10 +990,39 @@ fn create_sandbox_request(spec: SandboxSpec) -> proto::CreateSandboxRequest {
     }
 }
 
+fn create_sandbox_from_template_request(
+    spec: SandboxTemplateCreateSpec,
+) -> proto::CreateSandboxRequest {
+    let SandboxTemplateCreateSpec {
+        name,
+        template_name,
+        labels,
+        providers,
+    } = spec;
+    proto::CreateSandboxRequest {
+        workload_source: Some(
+            proto::create_sandbox_request::WorkloadSource::WorkloadTemplateName(template_name),
+        ),
+        policy: None,
+        providers,
+        name: name.unwrap_or_default(),
+        labels,
+        annotations: HashMap::new(),
+        workspace: String::new(),
+    }
+}
+
 fn sandbox_from_response(sandbox: Option<proto::Sandbox>) -> Result<SandboxRef> {
     sandbox
         .map(SandboxRef::from_proto)
         .ok_or_else(|| SdkError::invalid_config("sandbox missing from gateway response"))
+}
+
+fn sandbox_template_from_response(
+    template: Option<proto::SandboxTemplate>,
+) -> Result<SandboxTemplate> {
+    template
+        .ok_or_else(|| SdkError::invalid_config("sandbox template missing from gateway response"))
 }
 
 fn map_status(status: tonic::Status) -> SdkError {

--- a/crates/openshell-sdk/src/client.rs
+++ b/crates/openshell-sdk/src/client.rs
@@ -800,21 +800,21 @@ fn create_sandbox_request(spec: SandboxSpec) -> proto::CreateSandboxRequest {
         providers,
         gpu,
     } = spec;
-    let template = image.map(|image| proto::SandboxTemplate {
-        image,
-        ..proto::SandboxTemplate::default()
+    let resources = gpu.then_some(proto::SandboxResources {
+        gpu_count: Some(1),
+        ..proto::SandboxResources::default()
     });
-    let resource_requirements = gpu.then_some(proto::ResourceRequirements {
-        gpu: Some(proto::GpuResourceRequirements { count: None }),
-    });
+    let workload = proto::SandboxWorkloadConfig {
+        image: image.unwrap_or_default(),
+        environment,
+        resources,
+    };
     proto::CreateSandboxRequest {
-        spec: Some(proto::SandboxSpec {
-            environment,
-            template,
-            providers,
-            resource_requirements,
-            ..proto::SandboxSpec::default()
-        }),
+        workload_source: Some(proto::create_sandbox_request::WorkloadSource::Workload(
+            workload,
+        )),
+        policy: None,
+        providers,
         name: name.unwrap_or_default(),
         labels,
         annotations: HashMap::new(),

--- a/crates/openshell-sdk/src/lib.rs
+++ b/crates/openshell-sdk/src/lib.rs
@@ -5,8 +5,9 @@
 //!
 //! Two layers:
 //!
-//! - [`OpenShellClient`] — the high-level sandbox-focused MVP surface:
-//!   health, sandbox CRUD, readiness/deletion waits, non-streaming exec.
+//! - [`OpenShellClient`] — the high-level sandbox-focused surface:
+//!   health, sandbox CRUD, template-based creation, sandbox template CRUD,
+//!   readiness/deletion waits, non-streaming exec.
 //! - [`raw`] — direct access to the generated tonic clients for RPCs the
 //!   curated surface doesn't yet cover (inference, providers, policy, logs,
 //!   settings, SSH, forwarding).
@@ -47,5 +48,6 @@ pub use error::SdkError;
 pub use refresh::{Refresh, RefreshError, RefreshedToken, TokenSource};
 pub use types::{
     ExecOptions, ExecResult, Health, ListOptions, SandboxPhase, SandboxRef, SandboxSpec,
+    SandboxTemplate, SandboxTemplateCreateSpec, SandboxTemplateListOptions, SandboxTemplateSpec,
     ServiceStatus, WorkspaceRef,
 };

--- a/crates/openshell-sdk/src/raw.rs
+++ b/crates/openshell-sdk/src/raw.rs
@@ -6,8 +6,8 @@
 //!
 //! Use this module when the curated high-level surface in
 //! [`crate::client::OpenShellClient`] doesn't expose the RPC or field you
-//! need. The high-level surface is sandbox-focused for MVP; inference,
-//! providers, policy, logs, settings, SSH, and forwarding all live here.
+//! need. The high-level surface is sandbox-focused; inference, providers,
+//! policy, logs, settings, SSH, and forwarding all live here.
 //!
 //! ```ignore
 //! use openshell_sdk::{ClientConfig, OpenShellClient};
@@ -22,11 +22,13 @@ pub use openshell_core::proto;
 pub use openshell_core::proto::inference_client::InferenceClient;
 pub use openshell_core::proto::open_shell_client::OpenShellClient as GrpcClient;
 pub use openshell_core::proto::{
-    CreateSandboxRequest, CreateWorkspaceRequest, DeleteSandboxRequest, DeleteWorkspaceRequest,
-    ExecSandboxRequest, GetSandboxRequest, GetWorkspaceRequest, HealthRequest,
-    ListProvidersRequest, ListSandboxesRequest, ListWorkspacesRequest, Sandbox,
-    SandboxPhase as ProtoSandboxPhase, SandboxSpec as ProtoSandboxSpec, SandboxTemplate,
-    ServiceStatus as ProtoServiceStatus, StartSandboxRequest, StopSandboxRequest, Workspace,
+    CreateSandboxRequest, CreateSandboxTemplateRequest, CreateWorkspaceRequest,
+    DeleteSandboxRequest, DeleteSandboxTemplateRequest, DeleteWorkspaceRequest, ExecSandboxRequest,
+    GetSandboxRequest, GetSandboxTemplateRequest, GetWorkspaceRequest, HealthRequest,
+    ListProvidersRequest, ListSandboxTemplatesRequest, ListSandboxesRequest, ListWorkspacesRequest,
+    Sandbox, SandboxPhase as ProtoSandboxPhase, SandboxSpec as ProtoSandboxSpec, SandboxTemplate,
+    SandboxTemplateResponse, SandboxTemplateSpec, ServiceStatus as ProtoServiceStatus,
+    StartSandboxRequest, StopSandboxRequest, Workspace,
 };
 
 /// Type alias for the gRPC client wrapped in the SDK's auth interceptor.

--- a/crates/openshell-sdk/src/types.rs
+++ b/crates/openshell-sdk/src/types.rs
@@ -91,9 +91,9 @@ impl From<i32> for SandboxPhase {
 
 /// Caller intent for a new sandbox.
 ///
-/// Only the most commonly used fields are exposed. Callers that need the
-/// full proto surface (volume claim templates, runtime classes, struct
-/// resources, etc.) should drop down to [`crate::raw`].
+/// Only the most commonly used portable fields are exposed. Callers that need
+/// named sandbox templates or operator-controlled driver config should drop
+/// down to [`crate::raw`].
 #[derive(Clone, Debug, Default)]
 pub struct SandboxSpec {
     /// Optional user-supplied sandbox name. When empty the server generates one.
@@ -106,8 +106,8 @@ pub struct SandboxSpec {
     pub environment: HashMap<String, String>,
     /// Provider names to attach.
     pub providers: Vec<String>,
-    /// Request a GPU. Driver-specific device selection is configured via
-    /// driver config on the raw proto surface (see [`crate::raw`]).
+    /// Request a GPU. Driver-specific device selection is configured through
+    /// named sandbox templates on the raw proto surface (see [`crate::raw`]).
     pub gpu: bool,
 }
 

--- a/crates/openshell-sdk/src/types.rs
+++ b/crates/openshell-sdk/src/types.rs
@@ -92,8 +92,8 @@ impl From<i32> for SandboxPhase {
 /// Caller intent for a new sandbox.
 ///
 /// Only the most commonly used portable fields are exposed. Callers that need
-/// named sandbox templates or operator-controlled driver config should drop
-/// down to [`crate::raw`].
+/// operator-controlled driver config should create a named sandbox template and
+/// launch it with [`SandboxTemplateCreateSpec`].
 #[derive(Clone, Debug, Default)]
 pub struct SandboxSpec {
     /// Optional user-supplied sandbox name. When empty the server generates one.
@@ -107,9 +107,28 @@ pub struct SandboxSpec {
     /// Provider names to attach.
     pub providers: Vec<String>,
     /// Request a GPU. Driver-specific device selection is configured through
-    /// named sandbox templates on the raw proto surface (see [`crate::raw`]).
+    /// named sandbox templates.
     pub gpu: bool,
 }
+
+/// Caller intent for creating a sandbox from a named sandbox template.
+#[derive(Clone, Debug, Default)]
+pub struct SandboxTemplateCreateSpec {
+    /// Optional user-supplied sandbox name. When empty the server generates one.
+    pub name: Option<String>,
+    /// Workspace-scoped template name to resolve at creation time.
+    pub template_name: String,
+    /// Labels attached to the sandbox.
+    pub labels: HashMap<String, String>,
+    /// Provider names to attach.
+    pub providers: Vec<String>,
+}
+
+/// Reusable workspace-scoped sandbox template resource.
+pub type SandboxTemplate = proto::SandboxTemplate;
+
+/// Desired reusable workload shape for a sandbox template.
+pub type SandboxTemplateSpec = proto::SandboxTemplateSpec;
 
 /// Reference to a sandbox owned by the gateway.
 #[derive(Clone, Debug)]
@@ -175,6 +194,17 @@ pub struct ListOptions {
     pub offset: u32,
     /// Optional Kubernetes-style label selector (e.g. `env=prod,team=core`).
     pub label_selector: Option<String>,
+}
+
+/// Options for listing sandbox templates.
+#[derive(Clone, Debug, Default)]
+pub struct SandboxTemplateListOptions {
+    /// Maximum templates to return. `0` defers to the server default.
+    pub limit: u32,
+    /// Offset into the result list.
+    pub offset: u32,
+    /// List across all workspaces. Requires platform-admin permissions.
+    pub all_workspaces: bool,
 }
 
 /// Options for [`crate::client::OpenShellClient::exec`].

--- a/crates/openshell-sdk/tests/client_mock.rs
+++ b/crates/openshell-sdk/tests/client_mock.rs
@@ -10,9 +10,11 @@
 
 use openshell_core::proto;
 use openshell_core::proto::open_shell_server::{OpenShell, OpenShellServer};
+use openshell_core::proto_struct::json_object_to_struct;
 use openshell_sdk::{
     AuthConfig, ClientConfig, ExecOptions, ListOptions, OpenShellClient, Refresh, RefreshError,
-    RefreshedToken, SandboxPhase, SandboxSpec, ServiceStatus as SdkServiceStatus,
+    RefreshedToken, SandboxPhase, SandboxSpec, SandboxTemplateCreateSpec,
+    SandboxTemplateListOptions, ServiceStatus as SdkServiceStatus,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -34,6 +36,10 @@ struct MockState {
     last_stop: Mutex<Option<proto::StopSandboxRequest>>,
     last_start: Mutex<Option<proto::StartSandboxRequest>>,
     last_list_request: Mutex<Option<proto::ListSandboxesRequest>>,
+    last_create_template: Mutex<Option<proto::CreateSandboxTemplateRequest>>,
+    last_get_template: Mutex<Option<proto::GetSandboxTemplateRequest>>,
+    last_list_templates: Mutex<Option<proto::ListSandboxTemplatesRequest>>,
+    last_delete_template: Mutex<Option<proto::DeleteSandboxTemplateRequest>>,
     last_exec_request: Mutex<Option<proto::ExecSandboxRequest>>,
     last_workspace_request: Mutex<Option<String>>,
     get_calls: AtomicU32,
@@ -95,6 +101,38 @@ fn workspace_proto(name: &str, phase: proto::datamodel::v1::WorkspacePhase) -> p
         }),
         status: Some(proto::datamodel::v1::WorkspaceStatus {
             phase: phase.into(),
+        }),
+    }
+}
+
+fn sandbox_template_proto(name: &str, workspace: &str) -> proto::SandboxTemplate {
+    let driver_config = serde_json::json!({"kubernetes": {}});
+    proto::SandboxTemplate {
+        metadata: Some(proto::datamodel::v1::ObjectMeta {
+            id: format!("template-{name}"),
+            name: name.to_string(),
+            created_at_ms: 1_000_000,
+            labels: HashMap::new(),
+            annotations: HashMap::new(),
+            resource_version: 1,
+            deletion_timestamp_ms: 0,
+            workspace: workspace.to_string(),
+        }),
+        spec: Some(proto::SandboxTemplateSpec {
+            workload: Some(proto::SandboxWorkloadConfig {
+                image: "ghcr.io/nvidia/openshell/python:latest".to_string(),
+                ..Default::default()
+            }),
+            driver_config: Some(
+                json_object_to_struct(
+                    driver_config
+                        .as_object()
+                        .expect("driver config object")
+                        .clone(),
+                )
+                .expect("driver config should convert to protobuf Struct"),
+            ),
+            desired_service_level: None,
         }),
     }
 }
@@ -243,30 +281,43 @@ impl OpenShell for TestOpenShell {
 
     async fn create_sandbox_template(
         &self,
-        _: tonic::Request<proto::CreateSandboxTemplateRequest>,
+        request: tonic::Request<proto::CreateSandboxTemplateRequest>,
     ) -> Result<Response<proto::SandboxTemplateResponse>, Status> {
-        Err(Status::unimplemented("unused"))
+        let request = request.into_inner();
+        let template = request.template.clone();
+        *self.state.last_create_template.lock().await = Some(request);
+        Ok(Response::new(proto::SandboxTemplateResponse { template }))
     }
 
     async fn get_sandbox_template(
         &self,
-        _: tonic::Request<proto::GetSandboxTemplateRequest>,
+        request: tonic::Request<proto::GetSandboxTemplateRequest>,
     ) -> Result<Response<proto::SandboxTemplateResponse>, Status> {
-        Err(Status::unimplemented("unused"))
+        let request = request.into_inner();
+        let template = Some(sandbox_template_proto(&request.name, &request.workspace));
+        *self.state.last_get_template.lock().await = Some(request);
+        Ok(Response::new(proto::SandboxTemplateResponse { template }))
     }
 
     async fn list_sandbox_templates(
         &self,
-        _: tonic::Request<proto::ListSandboxTemplatesRequest>,
+        request: tonic::Request<proto::ListSandboxTemplatesRequest>,
     ) -> Result<Response<proto::ListSandboxTemplatesResponse>, Status> {
-        Err(Status::unimplemented("unused"))
+        let request = request.into_inner();
+        *self.state.last_list_templates.lock().await = Some(request);
+        Ok(Response::new(proto::ListSandboxTemplatesResponse {
+            templates: vec![sandbox_template_proto("gpu-kata", "default")],
+        }))
     }
 
     async fn delete_sandbox_template(
         &self,
-        _: tonic::Request<proto::DeleteSandboxTemplateRequest>,
+        request: tonic::Request<proto::DeleteSandboxTemplateRequest>,
     ) -> Result<Response<proto::DeleteSandboxTemplateResponse>, Status> {
-        Err(Status::unimplemented("unused"))
+        *self.state.last_delete_template.lock().await = Some(request.into_inner());
+        Ok(Response::new(proto::DeleteSandboxTemplateResponse {
+            deleted: true,
+        }))
     }
 
     async fn list_sandbox_providers(
@@ -826,6 +877,36 @@ async fn create_sandbox_passes_spec_through() {
 }
 
 #[tokio::test]
+async fn create_sandbox_from_template_sends_template_name() {
+    let state = Arc::new(MockState::default());
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+
+    let labels = HashMap::from([("team".to_string(), "core".to_string())]);
+    let spec = SandboxTemplateCreateSpec {
+        name: Some("templated-box".to_string()),
+        template_name: "gpu-kata".to_string(),
+        labels: labels.clone(),
+        providers: vec!["aws".to_string()],
+    };
+
+    let sandbox = client.create_sandbox_from_template(spec).await.unwrap();
+    assert_eq!(sandbox.name, "templated-box");
+
+    let observed = state.last_create.lock().await.clone().unwrap();
+    assert_eq!(observed.name, "templated-box");
+    assert_eq!(observed.labels, labels);
+    assert_eq!(observed.providers, vec!["aws".to_string()]);
+    assert!(observed.workspace.is_empty());
+    match observed.workload_source.as_ref() {
+        Some(proto::create_sandbox_request::WorkloadSource::WorkloadTemplateName(name)) => {
+            assert_eq!(name, "gpu-kata");
+        }
+        other => panic!("expected template workload source, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn get_sandbox_sends_name_and_maps_phase() {
     let state = Arc::new(MockState {
         phase_sequence: vec![proto::SandboxPhase::Ready],
@@ -1169,6 +1250,120 @@ async fn list_sandboxes_all_workspaces_sets_flag() {
     assert_eq!(items.len(), 2);
 
     let observed = state.last_list_request.lock().await.clone().unwrap();
+    assert!(observed.all_workspaces);
+    assert!(observed.workspace.is_empty());
+}
+
+#[tokio::test]
+async fn workspace_scoped_create_sandbox_from_template_passes_workspace() {
+    let state = Arc::new(MockState::default());
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+
+    client
+        .workspace("team-a")
+        .create_sandbox_from_template(SandboxTemplateCreateSpec {
+            name: Some("templated-box".to_string()),
+            template_name: "gpu-kata".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let observed = state.last_create.lock().await.clone().unwrap();
+    assert_eq!(observed.workspace, "team-a");
+    match observed.workload_source.as_ref() {
+        Some(proto::create_sandbox_request::WorkloadSource::WorkloadTemplateName(name)) => {
+            assert_eq!(name, "gpu-kata");
+        }
+        other => panic!("expected template workload source, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn sandbox_template_crud_sends_requests() {
+    let state = Arc::new(MockState::default());
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+    let workspace = client.workspace("team-a");
+
+    let template = sandbox_template_proto("gpu-kata", "team-a");
+    let created = workspace
+        .create_sandbox_template(template.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        created.metadata.as_ref().expect("template metadata").name,
+        "gpu-kata"
+    );
+
+    let observed_create = state.last_create_template.lock().await.clone().unwrap();
+    assert_eq!(observed_create.workspace, "team-a");
+    let observed_template = observed_create.template.expect("created template");
+    assert_eq!(
+        observed_template
+            .metadata
+            .as_ref()
+            .expect("template metadata")
+            .name,
+        "gpu-kata"
+    );
+    assert!(
+        observed_template
+            .spec
+            .as_ref()
+            .and_then(|spec| spec.driver_config.as_ref())
+            .is_some_and(|driver_config| driver_config.fields.contains_key("kubernetes"))
+    );
+
+    let got = workspace.get_sandbox_template("gpu-kata").await.unwrap();
+    assert_eq!(
+        got.metadata.as_ref().expect("template metadata").name,
+        "gpu-kata"
+    );
+    let observed_get = state.last_get_template.lock().await.clone().unwrap();
+    assert_eq!(observed_get.name, "gpu-kata");
+    assert_eq!(observed_get.workspace, "team-a");
+
+    let templates = workspace
+        .list_sandbox_templates(SandboxTemplateListOptions {
+            limit: 10,
+            offset: 2,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(templates.len(), 1);
+    let observed_list = state.last_list_templates.lock().await.clone().unwrap();
+    assert_eq!(observed_list.limit, 10);
+    assert_eq!(observed_list.offset, 2);
+    assert_eq!(observed_list.workspace, "team-a");
+    assert!(!observed_list.all_workspaces);
+
+    let deleted = workspace.delete_sandbox_template("gpu-kata").await.unwrap();
+    assert!(deleted);
+    let observed_delete = state.last_delete_template.lock().await.clone().unwrap();
+    assert_eq!(observed_delete.name, "gpu-kata");
+    assert_eq!(observed_delete.workspace, "team-a");
+}
+
+#[tokio::test]
+async fn sandbox_template_list_all_workspaces_clears_workspace() {
+    let state = Arc::new(MockState::default());
+    let endpoint = start_mock(state.clone()).await;
+    let client = connect(&endpoint).await;
+
+    let templates = client
+        .workspace("team-a")
+        .list_sandbox_templates(SandboxTemplateListOptions {
+            all_workspaces: true,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(templates.len(), 1);
+
+    let observed = state.last_list_templates.lock().await.clone().unwrap();
     assert!(observed.all_workspaces);
     assert!(observed.workspace.is_empty());
 }

--- a/crates/openshell-sdk/tests/client_mock.rs
+++ b/crates/openshell-sdk/tests/client_mock.rs
@@ -77,6 +77,7 @@ fn sandbox_with_phase_ws(
             phase: phase.into(),
             ..Default::default()
         }),
+        created_from_template: None,
     }
 }
 
@@ -238,6 +239,34 @@ impl OpenShell for TestOpenShell {
                 sandbox_with_phase("beta", proto::SandboxPhase::Provisioning),
             ],
         }))
+    }
+
+    async fn create_sandbox_template(
+        &self,
+        _: tonic::Request<proto::CreateSandboxTemplateRequest>,
+    ) -> Result<Response<proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_sandbox_template(
+        &self,
+        _: tonic::Request<proto::GetSandboxTemplateRequest>,
+    ) -> Result<Response<proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn list_sandbox_templates(
+        &self,
+        _: tonic::Request<proto::ListSandboxTemplatesRequest>,
+    ) -> Result<Response<proto::ListSandboxTemplatesResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn delete_sandbox_template(
+        &self,
+        _: tonic::Request<proto::DeleteSandboxTemplateRequest>,
+    ) -> Result<Response<proto::DeleteSandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
     }
 
     async fn list_sandbox_providers(
@@ -782,18 +811,18 @@ async fn create_sandbox_passes_spec_through() {
     assert_eq!(observed.name, "my-box");
     assert_eq!(observed.labels, labels);
     assert!(observed.annotations.is_empty());
-    let observed_spec = observed.spec.unwrap();
-    assert!(
-        observed_spec
-            .resource_requirements
-            .as_ref()
-            .and_then(|r| r.gpu.as_ref())
-            .is_some()
-    );
+    let workload = match observed.workload_source.as_ref() {
+        Some(proto::create_sandbox_request::WorkloadSource::Workload(workload)) => workload,
+        other => panic!("expected inline workload, got {other:?}"),
+    };
     assert_eq!(
-        observed_spec.template.as_ref().unwrap().image,
-        "ghcr.io/foo:bar"
+        workload
+            .resources
+            .as_ref()
+            .and_then(|resources| resources.gpu_count),
+        Some(1)
     );
+    assert_eq!(workload.image, "ghcr.io/foo:bar");
 }
 
 #[tokio::test]

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -45,8 +45,8 @@ use openshell_core::proto::compute::v1::{
     gateway_listener_requirement::Selector, watch_sandboxes_event,
 };
 use openshell_core::proto::{
-    PlatformEvent, Sandbox, SandboxCondition, SandboxPhase, SandboxSpec, SandboxStatus,
-    SandboxTemplate, ServiceEndpoint, SshSession,
+    PlatformEvent, Sandbox, SandboxCondition, SandboxPhase, SandboxResources, SandboxSpec,
+    SandboxStatus, SandboxWorkloadConfig, ServiceEndpoint, SshSession,
 };
 use openshell_core::{ObjectLabels, ObjectWorkspace};
 #[cfg(not(target_os = "windows"))]
@@ -3194,37 +3194,45 @@ fn driver_sandbox_spec_from_public(
     driver_name: &str,
 ) -> Result<DriverSandboxSpec, Box<Status>> {
     Ok(DriverSandboxSpec {
-        log_level: spec.log_level.clone(),
-        environment: spec.environment.clone(),
-        template: spec
-            .template
+        log_level: String::new(),
+        environment: spec
+            .workload
             .as_ref()
-            .map(|template| driver_sandbox_template_from_public(template, driver_name))
+            .map_or_else(Default::default, |workload| workload.environment.clone()),
+        template: spec
+            .workload
+            .as_ref()
+            .map(|workload| {
+                driver_sandbox_template_from_public(workload, &spec.driver_config, driver_name)
+            })
             .transpose()?,
-        resource_requirements: spec.resource_requirements.as_ref().map(|requirements| {
-            DriverSandboxResourceRequirements {
-                gpu: requirements
-                    .gpu
-                    .as_ref()
-                    .map(|gpu| DriverGpuResourceRequirements { count: gpu.count }),
-            }
+        resource_requirements: spec.workload.as_ref().and_then(|workload| {
+            let resources = workload.resources.as_ref()?;
+            openshell_core::gpu::sandbox_gpu_requested(Some(resources)).then_some(
+                DriverSandboxResourceRequirements {
+                    gpu: Some(DriverGpuResourceRequirements {
+                        count: resources.gpu_count,
+                    }),
+                },
+            )
         }),
         sandbox_token: String::new(),
     })
 }
 
 fn driver_sandbox_template_from_public(
-    template: &SandboxTemplate,
+    workload: &SandboxWorkloadConfig,
+    driver_config: &Option<prost_types::Struct>,
     driver_name: &str,
 ) -> Result<DriverSandboxTemplate, Box<Status>> {
     Ok(DriverSandboxTemplate {
-        image: template.image.clone(),
-        agent_socket_path: template.agent_socket.clone(),
-        labels: template.labels.clone(),
-        environment: template.environment.clone(),
-        resources: extract_typed_resources(&template.resources),
-        platform_config: build_platform_config(template),
-        driver_config: select_driver_config(&template.driver_config, driver_name)?,
+        image: workload.image.clone(),
+        agent_socket_path: String::new(),
+        labels: HashMap::default(),
+        environment: workload.environment.clone(),
+        resources: extract_typed_resources(workload.resources.as_ref()),
+        platform_config: None,
+        driver_config: select_driver_config(driver_config, driver_name)?,
     })
 }
 
@@ -3241,40 +3249,21 @@ fn select_driver_config(
     match value.kind.as_ref() {
         Some(prost_types::value::Kind::StructValue(inner)) => Ok(Some(inner.clone())),
         _ => Err(Box::new(Status::invalid_argument(format!(
-            "template.driver_config.{driver_name} must be an object"
+            "driver_config.{driver_name} must be an object"
         )))),
     }
 }
 
-/// Extract typed CPU/memory quantities from the public `resources` Struct.
-///
-/// The public API exposes resources as an untyped `google.protobuf.Struct`
-/// with the Kubernetes limits/requests shape. We pull out the well-known
-/// keys into the typed `DriverResourceRequirements` message.
+/// Extract typed CPU/memory quantities from portable public resources.
 fn extract_typed_resources(
-    resources: &Option<prost_types::Struct>,
+    resources: Option<&SandboxResources>,
 ) -> Option<DriverResourceRequirements> {
-    fn get_quantity(s: &prost_types::Struct, section: &str, key: &str) -> String {
-        s.fields
-            .get(section)
-            .and_then(|v| match v.kind.as_ref() {
-                Some(prost_types::value::Kind::StructValue(inner)) => inner.fields.get(key),
-                _ => None,
-            })
-            .and_then(|v| match v.kind.as_ref() {
-                Some(prost_types::value::Kind::StringValue(val)) => Some(val.clone()),
-                _ => None,
-            })
-            .unwrap_or_default()
-    }
-
-    let s = resources.as_ref()?;
-
+    let resources = resources?;
     let req = DriverResourceRequirements {
-        cpu_request: get_quantity(s, "requests", "cpu"),
-        cpu_limit: get_quantity(s, "limits", "cpu"),
-        memory_request: get_quantity(s, "requests", "memory"),
-        memory_limit: get_quantity(s, "limits", "memory"),
+        cpu_request: resources.cpu.clone(),
+        cpu_limit: resources.cpu.clone(),
+        memory_request: resources.memory.clone(),
+        memory_limit: resources.memory.clone(),
     };
 
     // Return None when all fields are empty so drivers can distinguish
@@ -3287,130 +3276,6 @@ fn extract_typed_resources(
         None
     } else {
         Some(req)
-    }
-}
-
-/// Build the opaque `platform_config` Struct from platform-specific public
-/// template fields (`runtime_class_name`, annotations) plus any resource fields
-/// beyond CPU/memory.
-fn build_platform_config(template: &SandboxTemplate) -> Option<prost_types::Struct> {
-    use prost_types::{Struct, Value, value::Kind};
-
-    let mut fields = std::collections::BTreeMap::new();
-
-    if !template.runtime_class_name.is_empty() {
-        fields.insert(
-            "runtime_class_name".to_string(),
-            Value {
-                kind: Some(Kind::StringValue(template.runtime_class_name.clone())),
-            },
-        );
-    }
-
-    if !template.annotations.is_empty() {
-        let annotation_fields = template
-            .annotations
-            .iter()
-            .map(|(k, v)| {
-                (
-                    k.clone(),
-                    Value {
-                        kind: Some(Kind::StringValue(v.clone())),
-                    },
-                )
-            })
-            .collect();
-        fields.insert(
-            "annotations".to_string(),
-            Value {
-                kind: Some(Kind::StructValue(Struct {
-                    fields: annotation_fields,
-                })),
-            },
-        );
-    }
-
-    // Invert: the public API uses `user_namespaces: true` (positive sense)
-    // while the K8s driver expects `host_users: false` (K8s convention).
-    // The driver inverts this back via `!host_users` to resolve the final
-    // pod-level `hostUsers` field.
-    if let Some(user_ns) = template.user_namespaces {
-        fields.insert(
-            "host_users".to_string(),
-            Value {
-                kind: Some(Kind::BoolValue(!user_ns)),
-            },
-        );
-    }
-
-    // Pass through any resource fields that do not map to the typed
-    // DriverResourceRequirements so platform-specific drivers can still see
-    // custom resources such as GPU limits.
-    if let Some(res) = build_platform_resources_config(&template.resources) {
-        fields.insert(
-            "resources_raw".to_string(),
-            Value {
-                kind: Some(Kind::StructValue(res)),
-            },
-        );
-    }
-
-    if fields.is_empty() {
-        None
-    } else {
-        Some(Struct { fields })
-    }
-}
-
-fn build_platform_resources_config(
-    resources: &Option<prost_types::Struct>,
-) -> Option<prost_types::Struct> {
-    use prost_types::{Struct, Value, value::Kind};
-
-    let resources = resources.as_ref()?;
-    let mut fields = std::collections::BTreeMap::new();
-
-    for (section_name, value) in &resources.fields {
-        if !matches!(section_name.as_str(), "limits" | "requests") {
-            fields.insert(section_name.clone(), value.clone());
-            continue;
-        }
-
-        let Some(Kind::StructValue(section)) = value.kind.as_ref() else {
-            fields.insert(section_name.clone(), value.clone());
-            continue;
-        };
-
-        let section_fields = section
-            .fields
-            .iter()
-            .filter_map(|(resource_name, resource_value)| {
-                let is_typed_quantity = matches!(resource_name.as_str(), "cpu" | "memory")
-                    && matches!(resource_value.kind.as_ref(), Some(Kind::StringValue(_)));
-                if is_typed_quantity {
-                    None
-                } else {
-                    Some((resource_name.clone(), resource_value.clone()))
-                }
-            })
-            .collect::<std::collections::BTreeMap<_, _>>();
-
-        if !section_fields.is_empty() {
-            fields.insert(
-                section_name.clone(),
-                Value {
-                    kind: Some(Kind::StructValue(Struct {
-                        fields: section_fields,
-                    })),
-                },
-            );
-        }
-    }
-
-    if fields.is_empty() {
-        None
-    } else {
-        Some(Struct { fields })
     }
 }
 
@@ -3442,6 +3307,12 @@ fn driver_condition_from_public(condition: &SandboxCondition) -> DriverCondition
 impl ObjectType for Sandbox {
     fn object_type() -> &'static str {
         "sandbox"
+    }
+}
+
+impl ObjectType for openshell_core::proto::SandboxTemplate {
+    fn object_type() -> &'static str {
+        "sandbox_template"
     }
 }
 
@@ -3773,7 +3644,8 @@ fn derive_phase(status: Option<&DriverSandboxStatus>) -> SandboxPhase {
 
 fn rewrite_user_facing_conditions(status: &mut Option<SandboxStatus>, spec: Option<&SandboxSpec>) {
     let gpu_requested = spec
-        .and_then(|sandbox_spec| sandbox_spec.resource_requirements.as_ref())
+        .and_then(|sandbox_spec| sandbox_spec.workload.as_ref())
+        .and_then(|workload| workload.resources.as_ref())
         .is_some_and(|requirements| openshell_core::gpu::sandbox_gpu_requested(Some(requirements)));
     if !gpu_requested {
         return;
@@ -4031,12 +3903,6 @@ mod tests {
         }
     }
 
-    fn number_value(value: f64) -> prost_types::Value {
-        prost_types::Value {
-            kind: Some(prost_types::value::Kind::NumberValue(value)),
-        }
-    }
-
     fn struct_value(
         fields: impl IntoIterator<Item = (impl Into<String>, prost_types::Value)>,
     ) -> prost_types::Value {
@@ -4053,8 +3919,12 @@ mod tests {
     #[test]
     fn driver_sandbox_spec_from_public_preserves_gpu_requirement() {
         let public = SandboxSpec {
-            resource_requirements: Some(openshell_core::proto::ResourceRequirements {
-                gpu: Some(openshell_core::proto::GpuResourceRequirements { count: Some(2) }),
+            workload: Some(SandboxWorkloadConfig {
+                resources: Some(SandboxResources {
+                    gpu_count: Some(2),
+                    ..Default::default()
+                }),
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -4135,7 +4005,7 @@ mod tests {
         let err = select_driver_config(&Some(config), "kubernetes").unwrap_err();
 
         assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("template.driver_config.kubernetes"));
+        assert!(err.message().contains("driver_config.kubernetes"));
     }
 
     #[derive(Debug, Default)]
@@ -5075,123 +4945,6 @@ mod tests {
     }
 
     #[test]
-    fn build_platform_config_omits_typed_cpu_and_memory_resources() {
-        let template = SandboxTemplate {
-            resources: Some(prost_types::Struct {
-                fields: [
-                    (
-                        "limits",
-                        struct_value([("cpu", string_value("2")), ("memory", string_value("1Gi"))]),
-                    ),
-                    (
-                        "requests",
-                        struct_value([
-                            ("cpu", string_value("500m")),
-                            ("memory", string_value("512Mi")),
-                        ]),
-                    ),
-                ]
-                .into_iter()
-                .map(|(key, value)| (key.to_string(), value))
-                .collect(),
-            }),
-            ..Default::default()
-        };
-
-        assert!(build_platform_config(&template).is_none());
-    }
-
-    #[test]
-    fn build_platform_config_preserves_non_typed_resource_fields() {
-        let template = SandboxTemplate {
-            resources: Some(prost_types::Struct {
-                fields: [
-                    (
-                        "limits",
-                        struct_value([
-                            ("cpu", string_value("2")),
-                            ("memory", string_value("1Gi")),
-                            ("nvidia.com/gpu", string_value("1")),
-                        ]),
-                    ),
-                    (
-                        "requests",
-                        struct_value([
-                            ("cpu", string_value("500m")),
-                            ("memory", string_value("512Mi")),
-                            ("hugepages-2Mi", string_value("4Mi")),
-                        ]),
-                    ),
-                    ("opaque_cpu", number_value(2.0)),
-                ]
-                .into_iter()
-                .map(|(key, value)| (key.to_string(), value))
-                .collect(),
-            }),
-            ..Default::default()
-        };
-
-        let platform_config = build_platform_config(&template).unwrap();
-        let resources_raw = platform_config
-            .fields
-            .get("resources_raw")
-            .and_then(|value| value.kind.as_ref())
-            .and_then(|kind| match kind {
-                prost_types::value::Kind::StructValue(inner) => Some(inner),
-                _ => None,
-            })
-            .unwrap();
-
-        let limits = resources_raw
-            .fields
-            .get("limits")
-            .and_then(|value| value.kind.as_ref())
-            .and_then(|kind| match kind {
-                prost_types::value::Kind::StructValue(inner) => Some(inner),
-                _ => None,
-            })
-            .unwrap();
-        assert!(!limits.fields.contains_key("cpu"));
-        assert!(!limits.fields.contains_key("memory"));
-        assert_eq!(
-            limits
-                .fields
-                .get("nvidia.com/gpu")
-                .and_then(|value| value.kind.as_ref())
-                .and_then(|kind| match kind {
-                    prost_types::value::Kind::StringValue(value) => Some(value.as_str()),
-                    _ => None,
-                }),
-            Some("1")
-        );
-
-        let requests = resources_raw
-            .fields
-            .get("requests")
-            .and_then(|value| value.kind.as_ref())
-            .and_then(|kind| match kind {
-                prost_types::value::Kind::StructValue(inner) => Some(inner),
-                _ => None,
-            })
-            .unwrap();
-        assert!(!requests.fields.contains_key("cpu"));
-        assert!(!requests.fields.contains_key("memory"));
-        assert_eq!(
-            requests
-                .fields
-                .get("hugepages-2Mi")
-                .and_then(|value| value.kind.as_ref())
-                .and_then(|kind| match kind {
-                    prost_types::value::Kind::StringValue(value) => Some(value.as_str()),
-                    _ => None,
-                }),
-            Some("4Mi")
-        );
-
-        assert!(resources_raw.fields.contains_key("opaque_cpu"));
-    }
-
-    #[test]
     fn rewrite_user_facing_conditions_rewrites_gpu_unschedulable_message() {
         let mut status = Some(SandboxStatus {
             sandbox_name: "test".to_string(),
@@ -5209,8 +4962,12 @@ mod tests {
         rewrite_user_facing_conditions(
             &mut status,
             Some(&SandboxSpec {
-                resource_requirements: Some(openshell_core::proto::ResourceRequirements {
-                    gpu: Some(openshell_core::proto::GpuResourceRequirements { count: None }),
+                workload: Some(SandboxWorkloadConfig {
+                    resources: Some(SandboxResources {
+                        gpu_count: Some(1),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
                 }),
                 ..Default::default()
             }),
@@ -6156,8 +5913,7 @@ mod tests {
         let runtime = test_runtime(Arc::new(TestDriver::default())).await;
         let mut sandbox = sandbox_record("sb-1", "sandbox-a", SandboxPhase::Provisioning);
         sandbox.spec = Some(SandboxSpec {
-            log_level: "debug".to_string(),
-            template: Some(SandboxTemplate {
+            workload: Some(SandboxWorkloadConfig {
                 image: "example.test/sandbox:complete".to_string(),
                 ..Default::default()
             }),
@@ -6180,8 +5936,8 @@ mod tests {
             stored
                 .spec
                 .as_ref()
-                .and_then(|spec| spec.template.as_ref())
-                .map(|template| template.image.as_str()),
+                .and_then(|spec| spec.workload.as_ref())
+                .map(|workload| workload.image.as_str()),
             Some("example.test/sandbox:complete")
         );
         assert_eq!(
@@ -6937,7 +6693,10 @@ mod tests {
         let runtime = test_runtime(driver).await;
         let mut sandbox = sandbox_record("sb-1", "sandbox-a", SandboxPhase::Ready);
         sandbox.spec = Some(SandboxSpec {
-            log_level: "debug".to_string(),
+            workload: Some(SandboxWorkloadConfig {
+                environment: HashMap::from([("DEBUG_MARKER".to_string(), "true".to_string())]),
+                ..Default::default()
+            }),
             ..Default::default()
         });
         runtime.store.put_message(&sandbox).await.unwrap();
@@ -6961,8 +6720,13 @@ mod tests {
         );
         assert_sandbox_owned_records(&runtime, &sandbox, &session, true).await;
         assert_eq!(
-            stored.spec.as_ref().map(|spec| spec.log_level.as_str()),
-            Some("debug")
+            stored
+                .spec
+                .as_ref()
+                .and_then(|spec| spec.workload.as_ref())
+                .and_then(|workload| workload.environment.get("DEBUG_MARKER"))
+                .map(String::as_str),
+            Some("true")
         );
     }
 
@@ -7696,8 +7460,12 @@ mod tests {
 
         let sandbox = Sandbox {
             spec: Some(SandboxSpec {
-                resource_requirements: Some(openshell_core::proto::ResourceRequirements {
-                    gpu: Some(openshell_core::proto::GpuResourceRequirements { count: None }),
+                workload: Some(SandboxWorkloadConfig {
+                    resources: Some(SandboxResources {
+                        gpu_count: Some(1),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
                 }),
                 ..Default::default()
             }),
@@ -7723,7 +7491,12 @@ mod tests {
             SandboxPhase::Ready
         );
         assert!(stored.spec.as_ref().is_some_and(|spec| {
-            openshell_core::gpu::sandbox_gpu_requested(spec.resource_requirements.as_ref())
+            spec.workload
+                .as_ref()
+                .and_then(|workload| workload.resources.as_ref())
+                .is_some_and(|resources| {
+                    openshell_core::gpu::sandbox_gpu_requested(Some(resources))
+                })
         }));
     }
 
@@ -8199,48 +7972,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn build_platform_config_inverts_user_namespaces_to_host_users() {
-        use prost_types::value::Kind;
-
-        // user_namespaces: true  → host_users: false
-        let mut template = SandboxTemplate {
-            user_namespaces: Some(true),
-            ..SandboxTemplate::default()
-        };
-        let config = build_platform_config(&template).expect("config should be Some");
-        let host_users = config
-            .fields
-            .get("host_users")
-            .expect("host_users must exist");
-        assert_eq!(
-            host_users.kind,
-            Some(Kind::BoolValue(false)),
-            "user_namespaces: true must produce host_users: false"
-        );
-
-        // user_namespaces: false → host_users: true
-        template.user_namespaces = Some(false);
-        let config = build_platform_config(&template).expect("config should be Some");
-        let host_users = config
-            .fields
-            .get("host_users")
-            .expect("host_users must exist");
-        assert_eq!(
-            host_users.kind,
-            Some(Kind::BoolValue(true)),
-            "user_namespaces: false must produce host_users: true"
-        );
-
-        // user_namespaces: None → host_users absent
-        template.user_namespaces = None;
-        let config = build_platform_config(&template);
-        assert!(
-            config.is_none() || !config.as_ref().unwrap().fields.contains_key("host_users"),
-            "unset user_namespaces must not produce host_users"
-        );
-    }
-
     #[tokio::test]
     async fn compute_driver_initialization_records_an_operation_span() {
         use crate::otel_tracing::test_exporter;
@@ -8444,24 +8175,23 @@ mod tests {
 
         let mut sandbox = sandbox_record("sb-uds", "uds-sandbox", SandboxPhase::Provisioning);
         sandbox.spec = Some(SandboxSpec {
-            log_level: "debug".to_string(),
-            template: Some(SandboxTemplate {
+            workload: Some(SandboxWorkloadConfig {
                 image: "ghcr.io/nvidia/openshell/sandbox:test".to_string(),
-                driver_config: Some(prost_types::Struct {
-                    fields: [
-                        (
-                            "external-test".to_string(),
-                            struct_value([("pool", string_value("ci"))]),
-                        ),
-                        (
-                            "docker".to_string(),
-                            struct_value([("network_mode", string_value("bridge"))]),
-                        ),
-                    ]
-                    .into_iter()
-                    .collect(),
-                }),
                 ..Default::default()
+            }),
+            driver_config: Some(prost_types::Struct {
+                fields: [
+                    (
+                        "external-test".to_string(),
+                        struct_value([("pool", string_value("ci"))]),
+                    ),
+                    (
+                        "docker".to_string(),
+                        struct_value([("network_mode", string_value("bridge"))]),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
             }),
             ..Default::default()
         });

--- a/crates/openshell-server/src/grpc/mod.rs
+++ b/crates/openshell-server/src/grpc/mod.rs
@@ -17,27 +17,29 @@ use openshell_core::proto::{
     AttachSandboxProviderRequest, AttachSandboxProviderResponse, ClearDraftChunksRequest,
     ClearDraftChunksResponse, ComputeDriverCapabilities, ComputeDriverInfo,
     ConfigureProviderRefreshRequest, ConfigureProviderRefreshResponse, CreateProviderRequest,
-    CreateSandboxRequest, CreateSshSessionRequest, CreateSshSessionResponse,
-    CreateWorkspaceRequest, CreateWorkspaceResponse, DeleteProviderProfileRequest,
-    DeleteProviderProfileResponse, DeleteProviderRefreshRequest, DeleteProviderRefreshResponse,
-    DeleteProviderRequest, DeleteProviderResponse, DeleteSandboxRequest, DeleteSandboxResponse,
-    DeleteServiceRequest, DeleteServiceResponse, DeleteWorkspaceRequest, DeleteWorkspaceResponse,
-    DetachSandboxProviderRequest, DetachSandboxProviderResponse, EditDraftChunkRequest,
-    EditDraftChunkResponse, ExecSandboxEvent, ExecSandboxInput, ExecSandboxRequest,
-    ExposeServiceRequest, GatewayMessage, GetCurrentUserRequest, GetCurrentUserResponse,
-    GetDraftHistoryRequest, GetDraftHistoryResponse, GetDraftPolicyRequest, GetDraftPolicyResponse,
-    GetGatewayConfigRequest, GetGatewayConfigResponse, GetGatewayInfoRequest,
-    GetGatewayInfoResponse, GetProviderProfileRequest, GetProviderRefreshStatusRequest,
-    GetProviderRefreshStatusResponse, GetProviderRequest, GetSandboxConfigRequest,
-    GetSandboxConfigResponse, GetSandboxLogsRequest, GetSandboxLogsResponse,
-    GetSandboxPolicyStatusRequest, GetSandboxPolicyStatusResponse,
+    CreateSandboxRequest, CreateSandboxTemplateRequest, CreateSshSessionRequest,
+    CreateSshSessionResponse, CreateWorkspaceRequest, CreateWorkspaceResponse,
+    DeleteProviderProfileRequest, DeleteProviderProfileResponse, DeleteProviderRefreshRequest,
+    DeleteProviderRefreshResponse, DeleteProviderRequest, DeleteProviderResponse,
+    DeleteSandboxRequest, DeleteSandboxResponse, DeleteSandboxTemplateRequest,
+    DeleteSandboxTemplateResponse, DeleteServiceRequest, DeleteServiceResponse,
+    DeleteWorkspaceRequest, DeleteWorkspaceResponse, DetachSandboxProviderRequest,
+    DetachSandboxProviderResponse, EditDraftChunkRequest, EditDraftChunkResponse, ExecSandboxEvent,
+    ExecSandboxInput, ExecSandboxRequest, ExposeServiceRequest, GatewayMessage,
+    GetCurrentUserRequest, GetCurrentUserResponse, GetDraftHistoryRequest, GetDraftHistoryResponse,
+    GetDraftPolicyRequest, GetDraftPolicyResponse, GetGatewayConfigRequest,
+    GetGatewayConfigResponse, GetGatewayInfoRequest, GetGatewayInfoResponse,
+    GetProviderProfileRequest, GetProviderRefreshStatusRequest, GetProviderRefreshStatusResponse,
+    GetProviderRequest, GetSandboxConfigRequest, GetSandboxConfigResponse, GetSandboxLogsRequest,
+    GetSandboxLogsResponse, GetSandboxPolicyStatusRequest, GetSandboxPolicyStatusResponse,
     GetSandboxProviderEnvironmentRequest, GetSandboxProviderEnvironmentResponse, GetSandboxRequest,
-    GetServiceRequest, GetWorkspaceRequest, GetWorkspaceResponse, HealthRequest, HealthResponse,
-    ImportProviderProfilesRequest, ImportProviderProfilesResponse, IssueSandboxTokenRequest,
-    IssueSandboxTokenResponse, LintProviderProfilesRequest, LintProviderProfilesResponse,
-    ListProviderProfilesRequest, ListProviderProfilesResponse, ListProvidersRequest,
-    ListProvidersResponse, ListSandboxPoliciesRequest, ListSandboxPoliciesResponse,
-    ListSandboxProvidersRequest, ListSandboxProvidersResponse, ListSandboxesRequest,
+    GetSandboxTemplateRequest, GetServiceRequest, GetWorkspaceRequest, GetWorkspaceResponse,
+    HealthRequest, HealthResponse, ImportProviderProfilesRequest, ImportProviderProfilesResponse,
+    IssueSandboxTokenRequest, IssueSandboxTokenResponse, LintProviderProfilesRequest,
+    LintProviderProfilesResponse, ListProviderProfilesRequest, ListProviderProfilesResponse,
+    ListProvidersRequest, ListProvidersResponse, ListSandboxPoliciesRequest,
+    ListSandboxPoliciesResponse, ListSandboxProvidersRequest, ListSandboxProvidersResponse,
+    ListSandboxTemplatesRequest, ListSandboxTemplatesResponse, ListSandboxesRequest,
     ListSandboxesResponse, ListServicesRequest, ListServicesResponse, ListWorkspaceMembersRequest,
     ListWorkspaceMembersResponse, ListWorkspacesRequest, ListWorkspacesResponse,
     ProviderProfileResponse, ProviderResponse, PushSandboxLogsRequest, PushSandboxLogsResponse,
@@ -45,10 +47,10 @@ use openshell_core::proto::{
     RejectDraftChunkResponse, RelayFrame, RemoveWorkspaceMemberRequest,
     RemoveWorkspaceMemberResponse, ReportPolicyStatusRequest, ReportPolicyStatusResponse,
     RevokeSshSessionRequest, RevokeSshSessionResponse, RotateProviderCredentialRequest,
-    RotateProviderCredentialResponse, SandboxResponse, ServiceEndpointResponse, ServiceStatus,
-    StartSandboxRequest, StopSandboxRequest, SubmitPolicyAnalysisRequest,
-    SubmitPolicyAnalysisResponse, SupervisorMessage, TcpForwardFrame, UndoDraftChunkRequest,
-    UndoDraftChunkResponse, UpdateConfigRequest, UpdateConfigResponse,
+    RotateProviderCredentialResponse, SandboxResponse, SandboxTemplateResponse,
+    ServiceEndpointResponse, ServiceStatus, StartSandboxRequest, StopSandboxRequest,
+    SubmitPolicyAnalysisRequest, SubmitPolicyAnalysisResponse, SupervisorMessage, TcpForwardFrame,
+    UndoDraftChunkRequest, UndoDraftChunkResponse, UpdateConfigRequest, UpdateConfigResponse,
     UpdateProviderProfilesRequest, UpdateProviderProfilesResponse, UpdateProviderRequest,
     WatchSandboxRequest, open_shell_server::OpenShell,
 };
@@ -129,8 +131,6 @@ const MAX_NAME_LEN: usize = 253;
 const MAX_ROUTABLE_NAME_LEN: usize = 19;
 /// Maximum number of providers that can be attached to a sandbox.
 const MAX_PROVIDERS: usize = 32;
-/// Maximum length for the `log_level` field.
-const MAX_LOG_LEVEL_LEN: usize = 32;
 /// Maximum number of entries in `spec.environment`.
 const MAX_ENVIRONMENT_ENTRIES: usize = 128;
 /// Maximum length for an environment map key (bytes).
@@ -139,8 +139,6 @@ const MAX_MAP_KEY_LEN: usize = 256;
 const MAX_MAP_VALUE_LEN: usize = 8192;
 /// Maximum length for template string fields.
 const MAX_TEMPLATE_STRING_LEN: usize = 1024;
-/// Maximum number of entries in template map fields.
-const MAX_TEMPLATE_MAP_ENTRIES: usize = 128;
 /// Maximum number of entries in metadata annotations.
 const MAX_METADATA_ANNOTATIONS_ENTRIES: usize = 128;
 /// Maximum serialized size (bytes) for template Struct fields.
@@ -294,6 +292,34 @@ impl OpenShell for OpenShellService {
         request: Request<ListSandboxesRequest>,
     ) -> Result<Response<ListSandboxesResponse>, Status> {
         sandbox::handle_list_sandboxes(&self.state, request).await
+    }
+
+    async fn create_sandbox_template(
+        &self,
+        request: Request<CreateSandboxTemplateRequest>,
+    ) -> Result<Response<SandboxTemplateResponse>, Status> {
+        sandbox::handle_create_sandbox_template(&self.state, request).await
+    }
+
+    async fn get_sandbox_template(
+        &self,
+        request: Request<GetSandboxTemplateRequest>,
+    ) -> Result<Response<SandboxTemplateResponse>, Status> {
+        sandbox::handle_get_sandbox_template(&self.state, request).await
+    }
+
+    async fn list_sandbox_templates(
+        &self,
+        request: Request<ListSandboxTemplatesRequest>,
+    ) -> Result<Response<ListSandboxTemplatesResponse>, Status> {
+        sandbox::handle_list_sandbox_templates(&self.state, request).await
+    }
+
+    async fn delete_sandbox_template(
+        &self,
+        request: Request<DeleteSandboxTemplateRequest>,
+    ) -> Result<Response<DeleteSandboxTemplateResponse>, Status> {
+        sandbox::handle_delete_sandbox_template(&self.state, request).await
     }
 
     async fn list_sandbox_providers(

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -9107,6 +9107,7 @@ mod tests {
                 ..SandboxSpec::default()
             }),
             status: None,
+            created_from_template: None,
         };
         sandbox.set_phase(SandboxPhase::Ready as i32);
         store.put_message(&sandbox).await.unwrap();
@@ -9143,6 +9144,7 @@ mod tests {
             }),
             spec: Some(SandboxSpec::default()),
             status: None,
+            created_from_template: None,
         };
         sandbox.set_phase(SandboxPhase::Ready as i32);
         store.put_message(&sandbox).await.unwrap();

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -18,21 +18,24 @@ use futures::future;
 use openshell_core::net::set_tcp_nodelay_best_effort;
 use openshell_core::proto::{
     AttachSandboxProviderRequest, AttachSandboxProviderResponse, CreateSandboxRequest,
-    CreateSshSessionRequest, CreateSshSessionResponse, DeleteSandboxRequest, DeleteSandboxResponse,
-    DetachSandboxProviderRequest, DetachSandboxProviderResponse, ExecSandboxEvent, ExecSandboxExit,
-    ExecSandboxInput, ExecSandboxRequest, ExecSandboxStderr, ExecSandboxStdout, GetSandboxRequest,
-    ListSandboxProvidersRequest, ListSandboxProvidersResponse, ListSandboxesRequest,
-    ListSandboxesResponse, Provider, RevokeSshSessionRequest, RevokeSshSessionResponse,
-    SandboxResponse, SandboxStreamEvent, SshRelayTarget, StartSandboxRequest, StopSandboxRequest,
-    TcpForwardFrame, TcpForwardInit, TcpRelayTarget, WatchSandboxRequest, relay_open,
-    tcp_forward_init,
+    CreateSandboxTemplateRequest, CreateSshSessionRequest, CreateSshSessionResponse,
+    DeleteSandboxRequest, DeleteSandboxResponse, DeleteSandboxTemplateRequest,
+    DeleteSandboxTemplateResponse, DetachSandboxProviderRequest, DetachSandboxProviderResponse,
+    ExecSandboxEvent, ExecSandboxExit, ExecSandboxInput, ExecSandboxRequest, ExecSandboxStderr,
+    ExecSandboxStdout, GetSandboxRequest, GetSandboxTemplateRequest, ListSandboxProvidersRequest,
+    ListSandboxProvidersResponse, ListSandboxTemplatesRequest, ListSandboxTemplatesResponse,
+    ListSandboxesRequest, ListSandboxesResponse, Provider, RevokeSshSessionRequest,
+    RevokeSshSessionResponse, SandboxResponse, SandboxSpec, SandboxStreamEvent,
+    SandboxTemplateProvenance, SandboxTemplateResponse, SshRelayTarget, StartSandboxRequest,
+    StopSandboxRequest, TcpForwardFrame, TcpForwardInit, TcpRelayTarget, WatchSandboxRequest,
+    create_sandbox_request, relay_open, tcp_forward_init,
 };
 use openshell_core::proto::{Sandbox, SandboxPhase, SandboxTemplate, SshSession};
 use openshell_core::telemetry::{
     LifecycleOperation, LifecycleResource, SandboxTemplateSource, TelemetryComputeDriver,
     TelemetryOutcome,
 };
-use openshell_core::{ObjectId, ObjectName, ObjectWorkspace};
+use openshell_core::{ObjectId, ObjectName, ObjectWorkspace, SetResourceVersion};
 use prost::Message;
 use std::collections::HashMap;
 use std::net::IpAddr;
@@ -54,8 +57,8 @@ use super::provider::{
 };
 use super::validation::{
     level_matches, normalize_process_identity_for_driver, source_matches,
-    validate_exec_request_fields, validate_no_reserved_provider_policy_keys,
-    validate_policy_safety, validate_sandbox_spec,
+    validate_create_sandbox_request, validate_exec_request_fields,
+    validate_no_reserved_provider_policy_keys, validate_policy_safety, validate_sandbox_spec,
 };
 use super::{MAX_PAGE_SIZE, MAX_PROVIDERS, MAX_ROUTABLE_NAME_LEN, clamp_limit};
 use crate::persistence::current_time_ms;
@@ -173,33 +176,28 @@ fn emit_sandbox_create_telemetry(
     outcome: TelemetryOutcome,
 ) {
     let compute_driver = telemetry_compute_driver(state.compute.driver_kind());
-    let Some(spec) = request.spec.as_ref() else {
-        openshell_core::telemetry::emit_sandbox_create(
-            outcome,
-            false,
-            0,
-            false,
-            SandboxTemplateSource::Undefined,
-            compute_driver,
-        );
-        return;
+    let (gpu_requested, template_source) = match request.workload_source.as_ref() {
+        Some(create_sandbox_request::WorkloadSource::Workload(workload)) => {
+            let gpu_requested = workload.resources.as_ref().is_some_and(|resources| {
+                openshell_core::gpu::sandbox_gpu_requested(Some(resources))
+            });
+            let template_source = if workload.image.trim().is_empty() {
+                SandboxTemplateSource::Default
+            } else {
+                SandboxTemplateSource::Image
+            };
+            (gpu_requested, template_source)
+        }
+        Some(create_sandbox_request::WorkloadSource::WorkloadTemplateName(_)) => {
+            (false, SandboxTemplateSource::Image)
+        }
+        None => (false, SandboxTemplateSource::Undefined),
     };
-    let template_source = if spec
-        .template
-        .as_ref()
-        .is_some_and(|template| !template.image.trim().is_empty())
-    {
-        SandboxTemplateSource::Image
-    } else {
-        SandboxTemplateSource::Default
-    };
-    let gpu_requested =
-        openshell_core::gpu::sandbox_gpu_requested(spec.resource_requirements.as_ref());
     openshell_core::telemetry::emit_sandbox_create(
         outcome,
         gpu_requested,
-        spec.providers.len() as u64,
-        spec.policy.is_some(),
+        request.providers.len() as u64,
+        request.policy.is_some(),
         template_source,
         compute_driver,
     );
@@ -217,12 +215,9 @@ async fn handle_create_sandbox_inner(
 ) -> Result<Response<SandboxResponse>, Status> {
     let principal = super::extract_principal(&request)?;
     let request = request.into_inner();
-    let spec = request
-        .spec
-        .ok_or_else(|| Status::invalid_argument("spec is required"))?;
 
     // Validate field sizes before any I/O (fail fast on oversized payloads).
-    validate_sandbox_spec(&request.name, &spec)?;
+    validate_create_sandbox_request(&request)?;
 
     // Validate labels (keys and values must meet Kubernetes requirements).
     for (key, value) in &request.labels {
@@ -243,14 +238,14 @@ async fn handle_create_sandbox_inner(
         .await?
         .ensure_active()?;
 
-    let _sandbox_sync_guard = if spec.providers.is_empty() {
+    let _sandbox_sync_guard = if request.providers.is_empty() {
         None
     } else {
         Some(state.compute.sandbox_sync_guard().await)
     };
 
     // Validate provider names exist (fail fast).
-    for name in &spec.providers {
+    for name in &request.providers {
         state
             .store
             .get_message_by_name::<Provider>(&workspace, name)
@@ -258,15 +253,57 @@ async fn handle_create_sandbox_inner(
             .map_err(|e| Status::internal(format!("fetch provider failed: {e}")))?
             .ok_or_else(|| Status::failed_precondition(format!("provider '{name}' not found")))?;
     }
-    validate_provider_environment_keys_unique(state.store.as_ref(), &workspace, &spec.providers)
+    validate_provider_environment_keys_unique(state.store.as_ref(), &workspace, &request.providers)
         .await?;
 
-    // Ensure the template always carries the resolved image.
-    let mut spec = spec;
-    let template = spec.template.get_or_insert_with(SandboxTemplate::default);
-    if template.image.is_empty() {
-        template.image = state.compute.default_image().to_string();
+    let mut created_from_template = None;
+    let (mut workload, driver_config) = match request.workload_source.clone() {
+        Some(create_sandbox_request::WorkloadSource::Workload(workload)) => (workload, None),
+        Some(create_sandbox_request::WorkloadSource::WorkloadTemplateName(template_name)) => {
+            let template_name = template_name.trim();
+            if template_name.is_empty() {
+                return Err(Status::invalid_argument(
+                    "workload_template_name must not be empty",
+                ));
+            }
+            let template = state
+                .store
+                .get_message_by_name::<SandboxTemplate>(&workspace, template_name)
+                .await
+                .map_err(|e| Status::internal(format!("fetch sandbox template failed: {e}")))?
+                .ok_or_else(|| Status::not_found("sandbox template not found"))?;
+            let spec = template
+                .spec
+                .ok_or_else(|| Status::failed_precondition("sandbox template spec is required"))?;
+            let metadata = template.metadata.as_ref();
+            created_from_template = Some(SandboxTemplateProvenance {
+                name: template_name.to_string(),
+                resource_version: metadata
+                    .map_or(0, |metadata| metadata.resource_version)
+                    .to_string(),
+            });
+            let workload = spec.workload.ok_or_else(|| {
+                Status::failed_precondition("sandbox template workload is required")
+            })?;
+            (workload, spec.driver_config)
+        }
+        None => {
+            return Err(Status::invalid_argument(
+                "one of workload or workload_template_name is required",
+            ));
+        }
+    };
+
+    if workload.image.trim().is_empty() {
+        workload.image = state.compute.default_image().to_string();
     }
+
+    let mut spec = SandboxSpec {
+        workload: Some(workload),
+        driver_config,
+        policy: request.policy.clone(),
+        providers: request.providers.clone(),
+    };
 
     // Docker and Podman preserve omitted identity fields for OCI USER
     // fallback. Other drivers retain the legacy persisted sandbox defaults.
@@ -299,6 +336,7 @@ async fn handle_create_sandbox_inner(
         }),
         spec: Some(spec),
         status: None,
+        created_from_template,
     };
     sandbox.set_phase(SandboxPhase::Provisioning as i32);
 
@@ -455,6 +493,169 @@ pub(super) async fn handle_list_sandboxes(
     };
 
     Ok(Response::new(ListSandboxesResponse { sandboxes }))
+}
+
+pub(super) async fn handle_create_sandbox_template(
+    state: &Arc<ServerState>,
+    request: Request<CreateSandboxTemplateRequest>,
+) -> Result<Response<SandboxTemplateResponse>, Status> {
+    let principal = super::extract_principal(&request)?;
+    let req = request.into_inner();
+    let authz = authorize_workspace(
+        &state.store,
+        &state.admin_role,
+        &principal,
+        &req.workspace,
+        MinWorkspaceRole::Admin,
+    )
+    .await?;
+    let workspace = super::workspace::resolve_workspace(state.store.as_ref(), &authz.workspace)
+        .await?
+        .ensure_active()?;
+
+    let Some(mut template) = req.template else {
+        return Err(Status::invalid_argument("template is required"));
+    };
+    crate::grpc::validation::validate_sandbox_template(&template)?;
+
+    let metadata = template
+        .metadata
+        .get_or_insert_with(openshell_core::proto::datamodel::v1::ObjectMeta::default);
+    if metadata.name.is_empty() {
+        return Err(Status::invalid_argument(
+            "template metadata.name is required",
+        ));
+    }
+    metadata.id = uuid::Uuid::new_v4().to_string();
+    metadata.created_at_ms = current_time_ms();
+    metadata.resource_version = 0;
+    metadata.workspace = workspace;
+    metadata.deletion_timestamp_ms = 0;
+    super::validation::validate_object_metadata(template.metadata.as_ref(), "sandbox_template")?;
+
+    let labels_json = template.object_labels().and_then(|labels| {
+        (!labels.is_empty())
+            .then(|| serde_json::to_string(&labels).ok())
+            .flatten()
+    });
+    let result = state
+        .store
+        .put_if(
+            SandboxTemplate::object_type(),
+            template.object_id(),
+            template.object_name(),
+            template.object_workspace(),
+            &template.encode_to_vec(),
+            labels_json.as_deref(),
+            WriteCondition::MustCreate,
+        )
+        .await
+        .map_err(|e| Status::internal(format!("create sandbox template failed: {e}")))?;
+    template.set_resource_version(result.resource_version);
+
+    Ok(Response::new(SandboxTemplateResponse {
+        template: Some(template),
+    }))
+}
+
+pub(super) async fn handle_get_sandbox_template(
+    state: &Arc<ServerState>,
+    request: Request<GetSandboxTemplateRequest>,
+) -> Result<Response<SandboxTemplateResponse>, Status> {
+    let principal = super::extract_principal(&request)?;
+    let req = request.into_inner();
+    if req.name.is_empty() {
+        return Err(Status::invalid_argument("name is required"));
+    }
+    let authz = authorize_workspace(
+        &state.store,
+        &state.admin_role,
+        &principal,
+        &req.workspace,
+        MinWorkspaceRole::User,
+    )
+    .await?;
+    let workspace = super::workspace::resolve_workspace(state.store.as_ref(), &authz.workspace)
+        .await?
+        .name;
+    let template = state
+        .store
+        .get_message_by_name::<SandboxTemplate>(&workspace, &req.name)
+        .await
+        .map_err(|e| Status::internal(format!("fetch sandbox template failed: {e}")))?
+        .ok_or_else(|| Status::not_found("sandbox template not found"))?;
+    Ok(Response::new(SandboxTemplateResponse {
+        template: Some(template),
+    }))
+}
+
+pub(super) async fn handle_list_sandbox_templates(
+    state: &Arc<ServerState>,
+    request: Request<ListSandboxTemplatesRequest>,
+) -> Result<Response<ListSandboxTemplatesResponse>, Status> {
+    let principal = super::extract_principal(&request)?;
+    let request = request.into_inner();
+    if request.all_workspaces && !request.workspace.is_empty() {
+        return Err(Status::invalid_argument(
+            "all_workspaces and workspace are mutually exclusive",
+        ));
+    }
+    let limit = clamp_limit(request.limit, 100, MAX_PAGE_SIZE);
+    let templates = if request.all_workspaces {
+        require_platform_admin(&state.admin_role, &principal)?;
+        state
+            .store
+            .list_all_messages(limit, request.offset)
+            .await
+            .map_err(|e| Status::internal(format!("list sandbox templates failed: {e}")))?
+    } else {
+        let authz = authorize_workspace(
+            &state.store,
+            &state.admin_role,
+            &principal,
+            &request.workspace,
+            MinWorkspaceRole::User,
+        )
+        .await?;
+        let workspace = super::workspace::resolve_workspace(state.store.as_ref(), &authz.workspace)
+            .await?
+            .name;
+        state
+            .store
+            .list_messages(&workspace, limit, request.offset)
+            .await
+            .map_err(|e| Status::internal(format!("list sandbox templates failed: {e}")))?
+    };
+
+    Ok(Response::new(ListSandboxTemplatesResponse { templates }))
+}
+
+pub(super) async fn handle_delete_sandbox_template(
+    state: &Arc<ServerState>,
+    request: Request<DeleteSandboxTemplateRequest>,
+) -> Result<Response<DeleteSandboxTemplateResponse>, Status> {
+    let principal = super::extract_principal(&request)?;
+    let req = request.into_inner();
+    if req.name.is_empty() {
+        return Err(Status::invalid_argument("name is required"));
+    }
+    let authz = authorize_workspace(
+        &state.store,
+        &state.admin_role,
+        &principal,
+        &req.workspace,
+        MinWorkspaceRole::Admin,
+    )
+    .await?;
+    let workspace = super::workspace::resolve_workspace(state.store.as_ref(), &authz.workspace)
+        .await?
+        .name;
+    let deleted = state
+        .store
+        .delete_by_name(SandboxTemplate::object_type(), &workspace, &req.name)
+        .await
+        .map_err(|e| Status::internal(format!("delete sandbox template failed: {e}")))?;
+    Ok(Response::new(DeleteSandboxTemplateResponse { deleted }))
 }
 
 pub(super) async fn handle_list_sandbox_providers(
@@ -2734,8 +2935,7 @@ mod tests {
                 workspace: "default".to_string(),
                 deletion_timestamp_ms: 0,
             }),
-            spec: Some(openshell_core::proto::SandboxSpec {
-                log_level: "debug".to_string(),
+            spec: Some(SandboxSpec {
                 policy: Some(openshell_core::proto::SandboxPolicy::default()),
                 providers,
                 ..Default::default()
@@ -2745,6 +2945,20 @@ mod tests {
         sandbox.set_phase(SandboxPhase::Ready as i32);
         sandbox.set_current_policy_version(7);
         sandbox
+    }
+
+    fn test_create_sandbox_request(name: &str) -> CreateSandboxRequest {
+        CreateSandboxRequest {
+            workload_source: Some(create_sandbox_request::WorkloadSource::Workload(
+                openshell_core::proto::SandboxWorkloadConfig::default(),
+            )),
+            policy: None,
+            providers: Vec::new(),
+            name: name.to_string(),
+            labels: HashMap::new(),
+            annotations: HashMap::new(),
+            workspace: String::new(),
+        }
     }
 
     #[tokio::test]
@@ -2885,7 +3099,6 @@ mod tests {
         assert_eq!(sandbox.current_policy_version(), 7);
         let spec = sandbox.spec.unwrap();
         assert_eq!(spec.providers, vec!["work-github"]);
-        assert_eq!(spec.log_level, "debug");
     }
 
     #[tokio::test]
@@ -3262,13 +3475,8 @@ mod tests {
             &state,
             authed_request(CreateSandboxRequest {
                 name: "collision".to_string(),
-                spec: Some(openshell_core::proto::SandboxSpec {
-                    providers: vec!["provider-a".to_string(), "provider-b".to_string()],
-                    ..Default::default()
-                }),
-                labels: HashMap::new(),
-                annotations: HashMap::new(),
-                workspace: String::new(),
+                providers: vec!["provider-a".to_string(), "provider-b".to_string()],
+                ..test_create_sandbox_request("")
             }),
         )
         .await
@@ -3296,13 +3504,8 @@ mod tests {
             &state,
             authed_request(CreateSandboxRequest {
                 name: "reserved-policy-key".to_string(),
-                spec: Some(openshell_core::proto::SandboxSpec {
-                    policy: Some(policy),
-                    ..Default::default()
-                }),
-                labels: HashMap::new(),
-                annotations: HashMap::new(),
-                workspace: String::new(),
+                policy: Some(policy),
+                ..test_create_sandbox_request("")
             }),
         )
         .await
@@ -3323,10 +3526,8 @@ mod tests {
             &state,
             authed_request(CreateSandboxRequest {
                 name: "annotated".to_string(),
-                spec: Some(openshell_core::proto::SandboxSpec::default()),
-                labels: HashMap::new(),
                 annotations: HashMap::from([(annotation_key.clone(), annotation_value.clone())]),
-                workspace: String::new(),
+                ..test_create_sandbox_request("")
             }),
         )
         .await
@@ -3380,13 +3581,8 @@ mod tests {
             &state,
             authed_request(CreateSandboxRequest {
                 name: "partial-id".to_string(),
-                spec: Some(openshell_core::proto::SandboxSpec {
-                    policy: Some(policy),
-                    ..Default::default()
-                }),
-                labels: HashMap::new(),
-                annotations: HashMap::new(),
-                workspace: String::new(),
+                policy: Some(policy),
+                ..test_create_sandbox_request("")
             }),
         )
         .await
@@ -3445,13 +3641,8 @@ mod tests {
             &state,
             authed_request(CreateSandboxRequest {
                 name: "kube-partial-id".to_string(),
-                spec: Some(openshell_core::proto::SandboxSpec {
-                    policy: Some(policy),
-                    ..Default::default()
-                }),
-                labels: HashMap::new(),
-                annotations: HashMap::new(),
-                workspace: String::new(),
+                policy: Some(policy),
+                ..test_create_sandbox_request("")
             }),
         )
         .await
@@ -3478,10 +3669,8 @@ mod tests {
             &state,
             authed_request(CreateSandboxRequest {
                 name: "bad-label".to_string(),
-                spec: Some(openshell_core::proto::SandboxSpec::default()),
                 labels: HashMap::from([("team".to_string(), "x".repeat(512))]),
-                annotations: HashMap::new(),
-                workspace: String::new(),
+                ..test_create_sandbox_request("")
             }),
         )
         .await
@@ -3489,6 +3678,62 @@ mod tests {
 
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
         assert!(err.message().contains("label value exceeds"));
+    }
+
+    #[tokio::test]
+    async fn create_sandbox_from_template_defaults_empty_image() {
+        let state = test_server_state().await;
+        let template = SandboxTemplate {
+            metadata: Some(ObjectMeta {
+                id: "template-default-image".to_string(),
+                name: "default-image".to_string(),
+                created_at_ms: 1_000_000,
+                labels: HashMap::new(),
+                resource_version: 42,
+                annotations: HashMap::new(),
+                workspace: "default".to_string(),
+                deletion_timestamp_ms: 0,
+            }),
+            spec: Some(openshell_core::proto::SandboxTemplateSpec {
+                workload: Some(openshell_core::proto::SandboxWorkloadConfig {
+                    image: "  ".to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        };
+        state.store.put_message(&template).await.unwrap();
+
+        let response = handle_create_sandbox(
+            &state,
+            authed_request(CreateSandboxRequest {
+                name: "from-template".to_string(),
+                workload_source: Some(
+                    create_sandbox_request::WorkloadSource::WorkloadTemplateName(
+                        "default-image".to_string(),
+                    ),
+                ),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("template create should default image")
+        .into_inner();
+
+        let sandbox = response.sandbox.expect("created sandbox");
+        let workload = sandbox
+            .spec
+            .as_ref()
+            .and_then(|spec| spec.workload.as_ref())
+            .expect("created sandbox should persist workload");
+        assert_eq!(workload.image, state.compute.default_image());
+        assert_eq!(
+            sandbox
+                .created_from_template
+                .as_ref()
+                .map(|provenance| provenance.name.as_str()),
+            Some("default-image")
+        );
     }
 
     #[tokio::test]
@@ -3507,13 +3752,8 @@ mod tests {
                 &task_state,
                 authed_request(CreateSandboxRequest {
                     name: "guarded-create".to_string(),
-                    spec: Some(openshell_core::proto::SandboxSpec {
-                        providers: vec!["work-github".to_string()],
-                        ..Default::default()
-                    }),
-                    labels: HashMap::new(),
-                    annotations: HashMap::new(),
-                    workspace: String::new(),
+                    providers: vec!["work-github".to_string()],
+                    ..test_create_sandbox_request("")
                 }),
             )
             .await
@@ -4406,8 +4646,7 @@ mod tests {
             &state,
             non_member_request(CreateSandboxRequest {
                 workspace: "no-such-ws".into(),
-                spec: Some(openshell_core::proto::SandboxSpec::default()),
-                ..Default::default()
+                ..test_create_sandbox_request("")
             }),
         )
         .await

--- a/crates/openshell-server/src/grpc/validation.rs
+++ b/crates/openshell-server/src/grpc/validation.rs
@@ -11,17 +11,16 @@
 use openshell_core::ComputeDriverKind;
 use openshell_core::proto::{
     CredentialHandle, ExecSandboxRequest, Provider, SandboxPolicy as ProtoSandboxPolicy,
-    SandboxTemplate,
+    SandboxTemplate, SandboxTemplateSpec, SandboxWorkloadConfig, create_sandbox_request,
 };
 use prost::Message;
 use tonic::Status;
 
 use super::{
-    MAX_ENVIRONMENT_ENTRIES, MAX_LABEL_SELECTOR_PAIRS, MAX_LOG_LEVEL_LEN, MAX_MAP_KEY_LEN,
-    MAX_MAP_VALUE_LEN, MAX_METADATA_ANNOTATIONS_ENTRIES, MAX_NAME_LEN, MAX_POLICY_SIZE,
-    MAX_PROVIDER_CONFIG_ENTRIES, MAX_PROVIDER_CREDENTIALS_ENTRIES, MAX_PROVIDER_TYPE_LEN,
-    MAX_PROVIDERS, MAX_ROUTABLE_NAME_LEN, MAX_TEMPLATE_MAP_ENTRIES, MAX_TEMPLATE_STRING_LEN,
-    MAX_TEMPLATE_STRUCT_SIZE,
+    MAX_ENVIRONMENT_ENTRIES, MAX_LABEL_SELECTOR_PAIRS, MAX_MAP_KEY_LEN, MAX_MAP_VALUE_LEN,
+    MAX_METADATA_ANNOTATIONS_ENTRIES, MAX_NAME_LEN, MAX_POLICY_SIZE, MAX_PROVIDER_CONFIG_ENTRIES,
+    MAX_PROVIDER_CREDENTIALS_ENTRIES, MAX_PROVIDER_TYPE_LEN, MAX_PROVIDERS, MAX_ROUTABLE_NAME_LEN,
+    MAX_TEMPLATE_STRING_LEN, MAX_TEMPLATE_STRUCT_SIZE,
 };
 
 // ---------------------------------------------------------------------------
@@ -164,11 +163,67 @@ pub(super) fn validate_dns1123_label(name: &str, field: &str) -> Result<(), Stat
 /// Validate field sizes on a `CreateSandboxRequest` before persisting.
 ///
 /// Returns `INVALID_ARGUMENT` on the first field that exceeds its limit.
+pub(super) fn validate_create_sandbox_request(
+    request: &openshell_core::proto::CreateSandboxRequest,
+) -> Result<(), Status> {
+    // --- request.name ---
+    if !request.name.is_empty() && request.name.len() > MAX_ROUTABLE_NAME_LEN {
+        return Err(Status::invalid_argument(format!(
+            "name exceeds maximum length ({} > {MAX_ROUTABLE_NAME_LEN})",
+            request.name.len()
+        )));
+    }
+    validate_dns1123_label(&request.name, "name")?;
+
+    // --- request.providers ---
+    if request.providers.len() > MAX_PROVIDERS {
+        return Err(Status::invalid_argument(format!(
+            "providers list exceeds maximum ({} > {MAX_PROVIDERS})",
+            request.providers.len()
+        )));
+    }
+
+    match request.workload_source.as_ref() {
+        Some(create_sandbox_request::WorkloadSource::Workload(workload)) => {
+            validate_sandbox_workload(workload, "workload")?;
+        }
+        Some(create_sandbox_request::WorkloadSource::WorkloadTemplateName(template_name)) => {
+            if template_name.trim().is_empty() {
+                return Err(Status::invalid_argument(
+                    "workload_template_name must not be empty",
+                ));
+            }
+            if template_name.len() > MAX_TEMPLATE_STRING_LEN {
+                return Err(Status::invalid_argument(format!(
+                    "workload_template_name exceeds maximum length ({} > {MAX_TEMPLATE_STRING_LEN})",
+                    template_name.len()
+                )));
+            }
+        }
+        None => {
+            return Err(Status::invalid_argument(
+                "one of workload or workload_template_name is required",
+            ));
+        }
+    }
+
+    // --- spec.policy serialized size ---
+    if let Some(ref policy) = request.policy {
+        let size = policy.encoded_len();
+        if size > MAX_POLICY_SIZE {
+            return Err(Status::invalid_argument(format!(
+                "policy serialized size exceeds maximum ({size} > {MAX_POLICY_SIZE})"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 pub(super) fn validate_sandbox_spec(
     name: &str,
     spec: &openshell_core::proto::SandboxSpec,
 ) -> Result<(), Status> {
-    // --- request.name ---
     if !name.is_empty() && name.len() > MAX_ROUTABLE_NAME_LEN {
         return Err(Status::invalid_argument(format!(
             "name exceeds maximum length ({} > {MAX_ROUTABLE_NAME_LEN})",
@@ -177,7 +232,6 @@ pub(super) fn validate_sandbox_spec(
     }
     validate_dns1123_label(name, "name")?;
 
-    // --- spec.providers ---
     if spec.providers.len() > MAX_PROVIDERS {
         return Err(Status::invalid_argument(format!(
             "providers list exceeds maximum ({} > {MAX_PROVIDERS})",
@@ -185,34 +239,19 @@ pub(super) fn validate_sandbox_spec(
         )));
     }
 
-    // --- spec.log_level ---
-    if spec.log_level.len() > MAX_LOG_LEVEL_LEN {
-        return Err(Status::invalid_argument(format!(
-            "log_level exceeds maximum length ({} > {MAX_LOG_LEVEL_LEN})",
-            spec.log_level.len()
-        )));
+    if let Some(workload) = spec.workload.as_ref() {
+        validate_sandbox_workload(workload, "spec.workload")?;
     }
 
-    // --- spec.environment ---
-    validate_string_map(
-        &spec.environment,
-        MAX_ENVIRONMENT_ENTRIES,
-        MAX_MAP_KEY_LEN,
-        MAX_MAP_VALUE_LEN,
-        "spec.environment",
-    )?;
-    validate_env_entries(&spec.environment, "spec.environment")?;
-
-    // --- spec.template ---
-    if let Some(ref tmpl) = spec.template {
-        validate_sandbox_template(tmpl)?;
-        validate_env_entries(&tmpl.environment, "spec.template.environment")?;
+    if let Some(ref s) = spec.driver_config {
+        let size = s.encoded_len();
+        if size > MAX_TEMPLATE_STRUCT_SIZE {
+            return Err(Status::invalid_argument(format!(
+                "spec.driver_config serialized size exceeds maximum ({size} > {MAX_TEMPLATE_STRUCT_SIZE})"
+            )));
+        }
     }
 
-    // --- spec.resource_requirements.gpu ---
-    validate_gpu_request_fields(spec)?;
-
-    // --- spec.policy serialized size ---
     if let Some(ref policy) = spec.policy {
         let size = policy.encoded_len();
         if size > MAX_POLICY_SIZE {
@@ -225,8 +264,23 @@ pub(super) fn validate_sandbox_spec(
     Ok(())
 }
 
-fn validate_gpu_request_fields(spec: &openshell_core::proto::SandboxSpec) -> Result<(), Status> {
-    if openshell_core::gpu::sandbox_gpu_count(spec.resource_requirements.as_ref()) == Some(0) {
+fn validate_sandbox_workload(workload: &SandboxWorkloadConfig, field: &str) -> Result<(), Status> {
+    if workload.image.len() > MAX_TEMPLATE_STRING_LEN {
+        return Err(Status::invalid_argument(format!(
+            "{field}.image exceeds maximum length ({} > {MAX_TEMPLATE_STRING_LEN})",
+            workload.image.len()
+        )));
+    }
+    validate_string_map(
+        &workload.environment,
+        MAX_ENVIRONMENT_ENTRIES,
+        MAX_MAP_KEY_LEN,
+        MAX_MAP_VALUE_LEN,
+        &format!("{field}.environment"),
+    )?;
+    validate_env_entries(&workload.environment, &format!("{field}.environment"))?;
+
+    if openshell_core::gpu::sandbox_gpu_count(workload.resources.as_ref()) == Some(0) {
         return Err(Status::invalid_argument("gpu count must be greater than 0"));
     }
 
@@ -234,58 +288,26 @@ fn validate_gpu_request_fields(spec: &openshell_core::proto::SandboxSpec) -> Res
 }
 
 /// Validate template-level field sizes.
-fn validate_sandbox_template(tmpl: &SandboxTemplate) -> Result<(), Status> {
-    // String fields.
-    for (field, value) in [
-        ("template.image", &tmpl.image),
-        ("template.runtime_class_name", &tmpl.runtime_class_name),
-        ("template.agent_socket", &tmpl.agent_socket),
-    ] {
-        if value.len() > MAX_TEMPLATE_STRING_LEN {
-            return Err(Status::invalid_argument(format!(
-                "{field} exceeds maximum length ({} > {MAX_TEMPLATE_STRING_LEN})",
-                value.len()
-            )));
-        }
-    }
+pub(super) fn validate_sandbox_template(tmpl: &SandboxTemplate) -> Result<(), Status> {
+    validate_sandbox_template_spec(
+        tmpl.spec
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("template spec is required"))?,
+    )
+}
 
-    // Map fields.
-    validate_string_map(
-        &tmpl.labels,
-        MAX_TEMPLATE_MAP_ENTRIES,
-        MAX_MAP_KEY_LEN,
-        MAX_MAP_VALUE_LEN,
-        "template.labels",
-    )?;
-    validate_string_map(
-        &tmpl.annotations,
-        MAX_TEMPLATE_MAP_ENTRIES,
-        MAX_MAP_KEY_LEN,
-        MAX_MAP_VALUE_LEN,
-        "template.annotations",
-    )?;
-    validate_string_map(
-        &tmpl.environment,
-        MAX_TEMPLATE_MAP_ENTRIES,
-        MAX_MAP_KEY_LEN,
-        MAX_MAP_VALUE_LEN,
-        "template.environment",
-    )?;
+pub(super) fn validate_sandbox_template_spec(spec: &SandboxTemplateSpec) -> Result<(), Status> {
+    let workload = spec
+        .workload
+        .as_ref()
+        .ok_or_else(|| Status::invalid_argument("template workload is required"))?;
+    validate_sandbox_workload(workload, "template.spec.workload")?;
 
-    // Struct fields (serialized size).
-    if let Some(ref s) = tmpl.resources {
+    if let Some(ref s) = spec.driver_config {
         let size = s.encoded_len();
         if size > MAX_TEMPLATE_STRUCT_SIZE {
             return Err(Status::invalid_argument(format!(
-                "template.resources serialized size exceeds maximum ({size} > {MAX_TEMPLATE_STRUCT_SIZE})"
-            )));
-        }
-    }
-    if let Some(ref s) = tmpl.driver_config {
-        let size = s.encoded_len();
-        if size > MAX_TEMPLATE_STRUCT_SIZE {
-            return Err(Status::invalid_argument(format!(
-                "template.driver_config serialized size exceeds maximum ({size} > {MAX_TEMPLATE_STRUCT_SIZE})"
+                "template.spec.driver_config serialized size exceeds maximum ({size} > {MAX_TEMPLATE_STRUCT_SIZE})"
             )));
         }
     }
@@ -957,21 +979,30 @@ pub(super) fn level_matches(log_level: &str, min_level: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openshell_core::proto::SandboxSpec;
+    use openshell_core::proto::{SandboxResources, SandboxSpec};
     use std::collections::HashMap;
     use tonic::Code;
 
     use crate::grpc::{
-        MAX_ENVIRONMENT_ENTRIES, MAX_LOG_LEVEL_LEN, MAX_MAP_KEY_LEN, MAX_MAP_VALUE_LEN,
-        MAX_NAME_LEN, MAX_POLICY_SIZE, MAX_PROVIDER_CONFIG_ENTRIES,
-        MAX_PROVIDER_CREDENTIALS_ENTRIES, MAX_PROVIDER_TYPE_LEN, MAX_PROVIDERS,
-        MAX_TEMPLATE_MAP_ENTRIES, MAX_TEMPLATE_STRING_LEN, MAX_TEMPLATE_STRUCT_SIZE,
+        MAX_ENVIRONMENT_ENTRIES, MAX_MAP_KEY_LEN, MAX_MAP_VALUE_LEN, MAX_NAME_LEN, MAX_POLICY_SIZE,
+        MAX_PROVIDER_CONFIG_ENTRIES, MAX_PROVIDER_CREDENTIALS_ENTRIES, MAX_PROVIDER_TYPE_LEN,
+        MAX_PROVIDERS, MAX_TEMPLATE_STRING_LEN, MAX_TEMPLATE_STRUCT_SIZE,
     };
 
     // ---- Sandbox spec validation ----
 
     fn default_spec() -> SandboxSpec {
         SandboxSpec::default()
+    }
+
+    fn spec_with_env(env: HashMap<String, String>) -> SandboxSpec {
+        SandboxSpec {
+            workload: Some(SandboxWorkloadConfig {
+                environment: env,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -983,8 +1014,12 @@ mod tests {
     #[test]
     fn validate_sandbox_spec_accepts_gpu_flag() {
         let spec = SandboxSpec {
-            resource_requirements: Some(openshell_core::proto::ResourceRequirements {
-                gpu: Some(openshell_core::proto::GpuResourceRequirements { count: None }),
+            workload: Some(SandboxWorkloadConfig {
+                resources: Some(SandboxResources {
+                    gpu_count: Some(1),
+                    ..Default::default()
+                }),
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -994,8 +1029,12 @@ mod tests {
     #[test]
     fn validate_sandbox_spec_accepts_gpu_count() {
         let spec = SandboxSpec {
-            resource_requirements: Some(openshell_core::proto::ResourceRequirements {
-                gpu: Some(openshell_core::proto::GpuResourceRequirements { count: Some(2) }),
+            workload: Some(SandboxWorkloadConfig {
+                resources: Some(SandboxResources {
+                    gpu_count: Some(2),
+                    ..Default::default()
+                }),
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -1005,8 +1044,12 @@ mod tests {
     #[test]
     fn validate_sandbox_spec_rejects_zero_gpu_count() {
         let spec = SandboxSpec {
-            resource_requirements: Some(openshell_core::proto::ResourceRequirements {
-                gpu: Some(openshell_core::proto::GpuResourceRequirements { count: Some(0) }),
+            workload: Some(SandboxWorkloadConfig {
+                resources: Some(SandboxResources {
+                    gpu_count: Some(0),
+                    ..Default::default()
+                }),
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -1078,25 +1121,11 @@ mod tests {
     }
 
     #[test]
-    fn validate_sandbox_spec_rejects_over_limit_log_level() {
-        let spec = SandboxSpec {
-            log_level: "x".repeat(MAX_LOG_LEVEL_LEN + 1),
-            ..Default::default()
-        };
-        let err = validate_sandbox_spec("ok", &spec).unwrap_err();
-        assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("log_level"));
-    }
-
-    #[test]
     fn validate_sandbox_spec_rejects_too_many_env_entries() {
         let env: HashMap<String, String> = (0..=MAX_ENVIRONMENT_ENTRIES)
             .map(|i| (format!("K{i}"), "v".to_string()))
             .collect();
-        let spec = SandboxSpec {
-            environment: env,
-            ..Default::default()
-        };
+        let spec = spec_with_env(env);
         let err = validate_sandbox_spec("ok", &spec).unwrap_err();
         assert_eq!(err.code(), Code::InvalidArgument);
         assert!(err.message().contains("environment"));
@@ -1106,10 +1135,7 @@ mod tests {
     fn validate_sandbox_spec_rejects_oversized_env_key() {
         let mut env = HashMap::new();
         env.insert("k".repeat(MAX_MAP_KEY_LEN + 1), "v".to_string());
-        let spec = SandboxSpec {
-            environment: env,
-            ..Default::default()
-        };
+        let spec = spec_with_env(env);
         let err = validate_sandbox_spec("ok", &spec).unwrap_err();
         assert_eq!(err.code(), Code::InvalidArgument);
         assert!(err.message().contains("key"));
@@ -1119,10 +1145,7 @@ mod tests {
     fn validate_sandbox_spec_rejects_oversized_env_value() {
         let mut env = HashMap::new();
         env.insert("KEY".to_string(), "v".repeat(MAX_MAP_VALUE_LEN + 1));
-        let spec = SandboxSpec {
-            environment: env,
-            ..Default::default()
-        };
+        let spec = spec_with_env(env);
         let err = validate_sandbox_spec("ok", &spec).unwrap_err();
         assert_eq!(err.code(), Code::InvalidArgument);
         assert!(err.message().contains("value"));
@@ -1131,7 +1154,7 @@ mod tests {
     #[test]
     fn validate_sandbox_spec_rejects_oversized_template_image() {
         let spec = SandboxSpec {
-            template: Some(SandboxTemplate {
+            workload: Some(SandboxWorkloadConfig {
                 image: "x".repeat(MAX_TEMPLATE_STRING_LEN + 1),
                 ..Default::default()
             }),
@@ -1139,28 +1162,11 @@ mod tests {
         };
         let err = validate_sandbox_spec("ok", &spec).unwrap_err();
         assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("template.image"));
+        assert!(err.message().contains("spec.workload.image"));
     }
 
     #[test]
-    fn validate_sandbox_spec_rejects_too_many_template_labels() {
-        let labels: HashMap<String, String> = (0..=MAX_TEMPLATE_MAP_ENTRIES)
-            .map(|i| (format!("k{i}"), "v".to_string()))
-            .collect();
-        let spec = SandboxSpec {
-            template: Some(SandboxTemplate {
-                labels,
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let err = validate_sandbox_spec("ok", &spec).unwrap_err();
-        assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("template.labels"));
-    }
-
-    #[test]
-    fn validate_sandbox_spec_rejects_oversized_template_struct() {
+    fn validate_sandbox_spec_rejects_oversized_driver_config_struct() {
         use prost_types::{Struct, Value, value::Kind};
 
         let mut fields = std::collections::BTreeMap::new();
@@ -1173,15 +1179,12 @@ mod tests {
         );
         let big_struct = Struct { fields };
         let spec = SandboxSpec {
-            template: Some(SandboxTemplate {
-                resources: Some(big_struct),
-                ..Default::default()
-            }),
+            driver_config: Some(big_struct),
             ..Default::default()
         };
         let err = validate_sandbox_spec("ok", &spec).unwrap_err();
         assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("template.resources"));
+        assert!(err.message().contains("spec.driver_config"));
     }
 
     #[test]
@@ -1206,13 +1209,10 @@ mod tests {
     #[test]
     fn validate_sandbox_spec_accepts_valid_spec() {
         let spec = SandboxSpec {
-            log_level: "debug".to_string(),
             providers: vec!["p1".to_string()],
-            environment: std::iter::once(("KEY".to_string(), "val".to_string())).collect(),
-            template: Some(SandboxTemplate {
+            workload: Some(SandboxWorkloadConfig {
                 image: "nvcr.io/test:latest".to_string(),
-                runtime_class_name: "kata".to_string(),
-                labels: std::iter::once(("app".to_string(), "test".to_string())).collect(),
+                environment: std::iter::once(("KEY".to_string(), "val".to_string())).collect(),
                 ..Default::default()
             }),
             ..Default::default()
@@ -1222,32 +1222,9 @@ mod tests {
 
     #[test]
     fn validate_sandbox_spec_rejects_reserved_env_key() {
-        let spec = SandboxSpec {
-            environment: std::iter::once(("OPENSHELL_SECRET".to_string(), "val".to_string()))
-                .collect(),
-            ..Default::default()
-        };
-        let err = validate_sandbox_spec("s", &spec).unwrap_err();
-        assert!(
-            err.message().contains("OPENSHELL_") && err.message().contains("reserved"),
-            "expected reserved key error, got: {}",
-            err.message()
+        let spec = spec_with_env(
+            std::iter::once(("OPENSHELL_SECRET".to_string(), "val".to_string())).collect(),
         );
-    }
-
-    #[test]
-    fn validate_sandbox_spec_rejects_reserved_template_env_key() {
-        let spec = SandboxSpec {
-            template: Some(SandboxTemplate {
-                environment: std::iter::once((
-                    "OPENSHELL_ENDPOINT".to_string(),
-                    "evil".to_string(),
-                ))
-                .collect(),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
         let err = validate_sandbox_spec("s", &spec).unwrap_err();
         assert!(
             err.message().contains("OPENSHELL_") && err.message().contains("reserved"),
@@ -1286,28 +1263,9 @@ mod tests {
     }
 
     #[test]
-    fn validate_sandbox_spec_rejects_template_env_value_with_control_chars() {
-        let spec = SandboxSpec {
-            template: Some(SandboxTemplate {
-                environment: std::iter::once(("KEY".to_string(), "val\nue".to_string())).collect(),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let err = validate_sandbox_spec("s", &spec).unwrap_err();
-        assert!(
-            err.message().contains("newline"),
-            "expected control char error, got: {}",
-            err.message()
-        );
-    }
-
-    #[test]
     fn validate_sandbox_spec_rejects_invalid_env_key_name() {
-        let spec = SandboxSpec {
-            environment: std::iter::once(("1BAD".to_string(), "val".to_string())).collect(),
-            ..Default::default()
-        };
+        let spec =
+            spec_with_env(std::iter::once(("1BAD".to_string(), "val".to_string())).collect());
         let err = validate_sandbox_spec("s", &spec).unwrap_err();
         assert!(
             err.message().contains("1BAD"),
@@ -1318,31 +1276,12 @@ mod tests {
 
     #[test]
     fn validate_sandbox_spec_rejects_env_value_with_control_chars() {
-        let spec = SandboxSpec {
-            environment: std::iter::once(("KEY".to_string(), "val\nue".to_string())).collect(),
-            ..Default::default()
-        };
+        let spec =
+            spec_with_env(std::iter::once(("KEY".to_string(), "val\nue".to_string())).collect());
         let err = validate_sandbox_spec("s", &spec).unwrap_err();
         assert!(
             err.message().contains("newline"),
             "expected control char error, got: {}",
-            err.message()
-        );
-    }
-
-    #[test]
-    fn validate_sandbox_spec_rejects_invalid_template_env_key_name() {
-        let spec = SandboxSpec {
-            template: Some(SandboxTemplate {
-                environment: std::iter::once(("BAD-NAME".to_string(), "val".to_string())).collect(),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let err = validate_sandbox_spec("s", &spec).unwrap_err();
-        assert!(
-            err.message().contains("BAD-NAME"),
-            "expected invalid key error, got: {}",
             err.message()
         );
     }

--- a/crates/openshell-server/src/persistence/tests.rs
+++ b/crates/openshell-server/src/persistence/tests.rs
@@ -1650,6 +1650,7 @@ async fn cas_update_message_cas_succeeds() {
         }),
         spec: None,
         status: None,
+        created_from_template: None,
     };
 
     store.put_message(&sandbox).await.unwrap();
@@ -1692,6 +1693,7 @@ async fn cas_update_message_cas_conflicts_on_concurrent_updates() {
         }),
         spec: None,
         status: None,
+        created_from_template: None,
     };
 
     store.put_message(&sandbox).await.unwrap();
@@ -1762,6 +1764,7 @@ async fn cas_update_message_cas_rejects_workspace_change() {
         }),
         spec: None,
         status: None,
+        created_from_template: None,
     };
 
     store.put_message(&sandbox).await.unwrap();
@@ -1804,6 +1807,7 @@ async fn cas_update_message_cas_rejects_name_change() {
         }),
         spec: None,
         status: None,
+        created_from_template: None,
     };
 
     store.put_message(&sandbox).await.unwrap();

--- a/crates/openshell-server/tests/common/mod.rs
+++ b/crates/openshell-server/tests/common/mod.rs
@@ -14,17 +14,20 @@ use hyper_util::{
     server::conn::auto::Builder,
 };
 use openshell_core::proto::{
-    CreateProviderRequest, CreateSandboxRequest, CreateSshSessionRequest, CreateSshSessionResponse,
-    DeleteProviderRequest, DeleteProviderResponse, DeleteSandboxRequest, DeleteSandboxResponse,
-    ExecSandboxEvent, ExecSandboxInput, ExecSandboxRequest, GatewayMessage,
-    GetGatewayConfigRequest, GetGatewayConfigResponse, GetProviderRequest, GetSandboxConfigRequest,
+    CreateProviderRequest, CreateSandboxRequest, CreateSandboxTemplateRequest,
+    CreateSshSessionRequest, CreateSshSessionResponse, DeleteProviderRequest,
+    DeleteProviderResponse, DeleteSandboxRequest, DeleteSandboxResponse,
+    DeleteSandboxTemplateRequest, DeleteSandboxTemplateResponse, ExecSandboxEvent,
+    ExecSandboxInput, ExecSandboxRequest, GatewayMessage, GetGatewayConfigRequest,
+    GetGatewayConfigResponse, GetProviderRequest, GetSandboxConfigRequest,
     GetSandboxConfigResponse, GetSandboxProviderEnvironmentRequest,
-    GetSandboxProviderEnvironmentResponse, GetSandboxRequest, HealthRequest, HealthResponse,
-    IssueSandboxTokenRequest, IssueSandboxTokenResponse, ListProvidersRequest,
-    ListProvidersResponse, ListSandboxesRequest, ListSandboxesResponse, ProviderResponse,
+    GetSandboxProviderEnvironmentResponse, GetSandboxRequest, GetSandboxTemplateRequest,
+    HealthRequest, HealthResponse, IssueSandboxTokenRequest, IssueSandboxTokenResponse,
+    ListProvidersRequest, ListProvidersResponse, ListSandboxTemplatesRequest,
+    ListSandboxTemplatesResponse, ListSandboxesRequest, ListSandboxesResponse, ProviderResponse,
     RefreshSandboxTokenRequest, RefreshSandboxTokenResponse, RelayFrame, RevokeSshSessionRequest,
-    RevokeSshSessionResponse, SandboxResponse, SandboxStreamEvent, ServiceStatus,
-    SupervisorMessage, TcpForwardFrame, UpdateProviderRequest, WatchSandboxRequest,
+    RevokeSshSessionResponse, SandboxResponse, SandboxStreamEvent, SandboxTemplateResponse,
+    ServiceStatus, SupervisorMessage, TcpForwardFrame, UpdateProviderRequest, WatchSandboxRequest,
     open_shell_client::OpenShellClient,
     open_shell_server::{OpenShell, OpenShellServer},
 };
@@ -109,6 +112,34 @@ impl OpenShell for TestOpenShell {
         _request: tonic::Request<ListSandboxesRequest>,
     ) -> Result<Response<ListSandboxesResponse>, Status> {
         Ok(Response::new(ListSandboxesResponse::default()))
+    }
+
+    async fn create_sandbox_template(
+        &self,
+        _request: tonic::Request<CreateSandboxTemplateRequest>,
+    ) -> Result<Response<SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_sandbox_template(
+        &self,
+        _request: tonic::Request<GetSandboxTemplateRequest>,
+    ) -> Result<Response<SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn list_sandbox_templates(
+        &self,
+        _request: tonic::Request<ListSandboxTemplatesRequest>,
+    ) -> Result<Response<ListSandboxTemplatesResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn delete_sandbox_template(
+        &self,
+        _request: tonic::Request<DeleteSandboxTemplateRequest>,
+    ) -> Result<Response<DeleteSandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
     }
 
     async fn list_sandbox_providers(

--- a/crates/openshell-server/tests/supervisor_relay_integration.rs
+++ b/crates/openshell-server/tests/supervisor_relay_integration.rs
@@ -85,6 +85,34 @@ impl OpenShell for RelayGateway {
         Err(Status::unimplemented("unused"))
     }
 
+    async fn create_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::CreateSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn get_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::GetSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::SandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn list_sandbox_templates(
+        &self,
+        _: tonic::Request<openshell_core::proto::ListSandboxTemplatesRequest>,
+    ) -> Result<Response<openshell_core::proto::ListSandboxTemplatesResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
+    async fn delete_sandbox_template(
+        &self,
+        _: tonic::Request<openshell_core::proto::DeleteSandboxTemplateRequest>,
+    ) -> Result<Response<openshell_core::proto::DeleteSandboxTemplateResponse>, Status> {
+        Err(Status::unimplemented("unused"))
+    }
+
     type ExecSandboxStream =
         ReceiverStream<Result<openshell_core::proto::ExecSandboxEvent, Status>>;
     async fn exec_sandbox(

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -18,7 +18,7 @@ use openshell_supervisor_middleware::{ChainEntry, ChainRunner, MiddlewareRegistr
 use std::path::{Path, PathBuf};
 use std::sync::{
     Arc, Mutex, RwLock,
-    atomic::{AtomicU64, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
 };
 use tokio::sync::watch;
 use tracing::info;
@@ -123,6 +123,7 @@ pub struct SandboxConfig {
 pub struct OpaEngine {
     engine: Mutex<regorus::Engine>,
     generation: Arc<AtomicU64>,
+    require_binary_identity: AtomicBool,
     middleware_runner: RwLock<ChainRunner>,
     websocket_assembly_budget: crate::l7::websocket::WebSocketAssemblyBudget,
     generation_tx: watch::Sender<u64>,
@@ -250,12 +251,13 @@ impl OpaEngine {
         self.websocket_assembly_budget.clone()
     }
 
-    fn with_engine(engine: regorus::Engine) -> Self {
+    fn with_engine(engine: regorus::Engine, require_binary_identity: bool) -> Self {
         let generation = Arc::new(AtomicU64::new(0));
         let (generation_tx, _) = watch::channel(0);
         Self {
             engine: Mutex::new(engine),
             generation,
+            require_binary_identity: AtomicBool::new(require_binary_identity),
             middleware_runner: RwLock::new(ChainRunner::default()),
             websocket_assembly_budget: crate::l7::websocket::WebSocketAssemblyBudget::default(),
             generation_tx,
@@ -309,7 +311,7 @@ impl OpaEngine {
         engine
             .add_data_json(&data_json)
             .map_err(|e| miette::miette!("{e}"))?;
-        Ok(Self::with_engine(engine))
+        Ok(Self::with_engine(engine, require_binary_identity))
     }
 
     /// Load policy rules and data from strings (data is YAML).
@@ -360,7 +362,7 @@ impl OpaEngine {
         engine
             .add_data_json(&data_json)
             .map_err(|e| miette::miette!("{e}"))?;
-        Ok(Self::with_engine(engine))
+        Ok(Self::with_engine(engine, require_binary_identity))
     }
 
     /// Create OPA engine from a typed proto policy.
@@ -447,7 +449,7 @@ impl OpaEngine {
         engine
             .add_data_json(&data_json)
             .map_err(|e| miette::miette!("{e}"))?;
-        Ok(Self::with_engine(engine))
+        Ok(Self::with_engine(engine, require_binary_identity))
     }
 
     /// Evaluate a network access request against the loaded policy.
@@ -572,6 +574,7 @@ impl OpaEngine {
     /// expansion) to maintain consistency with `from_strings()`.
     pub fn reload(&self, policy: &str, data_yaml: &str) -> Result<()> {
         let new = Self::from_strings(policy, data_yaml)?;
+        let require_binary_identity = new.binary_identity_required();
         let new_engine = new
             .engine
             .into_inner()
@@ -585,6 +588,8 @@ impl OpaEngine {
             .fail_closed_reason
             .write()
             .map_err(|_| miette::miette!("OPA fail-closed state lock poisoned"))? = None;
+        self.require_binary_identity
+            .store(require_binary_identity, Ordering::Release);
         self.advance_generation();
         Ok(())
     }
@@ -611,6 +616,7 @@ impl OpaEngine {
     ) -> Result<()> {
         // Build a complete new engine through the same validated pipeline.
         let new = Self::from_proto_with_pid(proto, entrypoint_pid)?;
+        let require_binary_identity = new.binary_identity_required();
         let new_engine = new
             .engine
             .into_inner()
@@ -624,6 +630,8 @@ impl OpaEngine {
             .fail_closed_reason
             .write()
             .map_err(|_| miette::miette!("OPA fail-closed state lock poisoned"))? = None;
+        self.require_binary_identity
+            .store(require_binary_identity, Ordering::Release);
         self.advance_generation();
         Ok(())
     }
@@ -641,6 +649,7 @@ impl OpaEngine {
         registry: MiddlewareRegistry,
     ) -> Result<()> {
         let new = Self::from_proto_with_pid(proto, entrypoint_pid)?;
+        let require_binary_identity = new.binary_identity_required();
         let new_engine = new
             .engine
             .into_inner()
@@ -662,6 +671,8 @@ impl OpaEngine {
             .fail_closed_reason
             .write()
             .map_err(|_| miette::miette!("OPA fail-closed state lock poisoned"))? = None;
+        self.require_binary_identity
+            .store(require_binary_identity, Ordering::Release);
         self.advance_generation();
         Ok(())
     }
@@ -716,6 +727,10 @@ impl OpaEngine {
     /// Current policy generation. Successful reloads increment this value.
     pub fn current_generation(&self) -> u64 {
         self.generation.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn binary_identity_required(&self) -> bool {
+        self.require_binary_identity.load(Ordering::Acquire)
     }
 
     /// Replace the complete middleware service registry and invalidate
@@ -3218,7 +3233,7 @@ network_policies:
             .expect("policy should load");
         rego.add_data_json(&data_json.to_string())
             .expect("data should load");
-        let engine = OpaEngine::with_engine(rego);
+        let engine = OpaEngine::with_engine(rego, true);
         let input = l7_websocket_graphql_input(
             "realtime.graphql.com",
             serde_json::json!([{

--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -2026,7 +2026,7 @@ fn authorize_egress_intent(
         }
     };
 
-    if !crate::opa::network_binary_identity_required() {
+    if !engine.binary_identity_required() {
         let result = evaluate_endpoint_only_opa(engine, intent);
         debug!(
             "authorize_egress_intent endpoint-only: host={} port={} transport={:?} action={:?}",
@@ -2178,7 +2178,7 @@ fn authorize_egress_intent(
     _entrypoint_pid: &AtomicU32,
     intent: EgressIntent,
 ) -> EgressDecision {
-    if !crate::opa::network_binary_identity_required() {
+    if !engine.binary_identity_required() {
         return evaluate_endpoint_only_opa(engine, intent);
     }
 
@@ -5763,8 +5763,12 @@ network_policies:
             executable = executable.display(),
         );
         let engine = Arc::new(
-            OpaEngine::from_strings(include_str!("../data/sandbox-policy.rego"), &data)
-                .expect("load policy"),
+            OpaEngine::from_strings_with_binary_identity_required(
+                include_str!("../data/sandbox-policy.rego"),
+                &data,
+                false,
+            )
+            .expect("load policy"),
         );
         let registry = openshell_supervisor_middleware::MiddlewareRegistry::connect_services(
             vec![openshell_supervisor_middleware::in_process_endpoint(
@@ -5877,8 +5881,12 @@ network_policies:
             executable = executable.display(),
         );
         let engine = Arc::new(
-            OpaEngine::from_strings(include_str!("../data/sandbox-policy.rego"), &data)
-                .expect("load policy"),
+            OpaEngine::from_strings_with_binary_identity_required(
+                include_str!("../data/sandbox-policy.rego"),
+                &data,
+                false,
+            )
+            .expect("load policy"),
         );
         let registry = openshell_supervisor_middleware::MiddlewareRegistry::connect_services(
             openshell_supervisor_middleware_builtins::services(),
@@ -6252,6 +6260,47 @@ network_policies:
             matches!(denied.action, NetworkAction::Deny { .. }),
             "endpoint-only mode must still deny undeclared endpoints"
         );
+    }
+
+    #[test]
+    fn authorize_egress_intent_honors_engine_endpoint_only_mode() {
+        let policy = include_str!("../data/sandbox-policy.rego");
+        let data = r#"
+network_policies:
+  test_endpoint:
+    name: test_endpoint
+    endpoints:
+      - host: api.example.test
+        port: 443
+    binaries:
+      - path: /does/not/matter
+"#;
+        let engine = OpaEngine::from_strings_with_binary_identity_required(policy, data, false)
+            .expect("endpoint-only engine");
+        let connection = crate::procfs::WorkloadProxyTcpConnection::new(
+            "127.0.0.1:50000".parse().unwrap(),
+            "127.0.0.1:3128".parse().unwrap(),
+        );
+
+        let decision = authorize_egress_intent(
+            connection,
+            &engine,
+            &BinaryIdentityCache::new(),
+            &AtomicU32::new(0),
+            EgressIntent::connect("api.example.test".to_string(), 443),
+        );
+
+        assert_eq!(
+            decision.action,
+            NetworkAction::Allow {
+                matched_policy: Some("test_endpoint".to_string()),
+            }
+        );
+        assert_eq!(
+            decision.identity,
+            ProcessIdentityEvidence::Unavailable(IdentityUnavailableReason::EndpointOnlyMode)
+        );
+        assert!(decision.binary.is_none());
     }
 
     fn websocket_l7_config(

--- a/crates/openshell-tui/src/lib.rs
+++ b/crates/openshell-tui/src/lib.rs
@@ -1376,14 +1376,10 @@ fn spawn_create_sandbox(app: &mut App, tx: mpsc::UnboundedSender<Event>) {
 
     tokio::spawn(async move {
         let has_custom_image = !image.is_empty();
-        let template = if has_custom_image {
-            let resolved = openshell_core::image::resolve_community_image(&image);
-            Some(openshell_core::proto::SandboxTemplate {
-                image: resolved,
-                ..Default::default()
-            })
+        let workload_image = if has_custom_image {
+            openshell_core::image::resolve_community_image(&image)
         } else {
-            None
+            String::new()
         };
 
         // For custom images, provide a restrictive default policy so the
@@ -1398,12 +1394,16 @@ fn spawn_create_sandbox(app: &mut App, tx: mpsc::UnboundedSender<Event>) {
 
         let req = openshell_core::proto::CreateSandboxRequest {
             name,
-            spec: Some(openshell_core::proto::SandboxSpec {
-                providers: selected_providers,
-                template,
-                policy,
-                ..Default::default()
-            }),
+            workload_source: Some(
+                openshell_core::proto::create_sandbox_request::WorkloadSource::Workload(
+                    openshell_core::proto::SandboxWorkloadConfig {
+                        image: workload_image,
+                        ..Default::default()
+                    },
+                ),
+            ),
+            policy,
+            providers: selected_providers,
             labels: HashMap::new(),
             annotations: HashMap::new(),
             workspace: workspace.clone(),
@@ -2517,8 +2517,8 @@ async fn refresh_sandboxes(app: &mut App) {
                 .map(|s| {
                     s.spec
                         .as_ref()
-                        .and_then(|spec| spec.template.as_ref())
-                        .map(|t| t.image.as_str())
+                        .and_then(|spec| spec.workload.as_ref())
+                        .map(|workload| workload.image.as_str())
                         .filter(|img| !img.is_empty())
                         .unwrap_or("-")
                         .to_string()

--- a/docs/kubernetes/topology.mdx
+++ b/docs/kubernetes/topology.mdx
@@ -196,17 +196,13 @@ workload boundary, not as a replacement for the combined topology's full
 supervisor controls.
 
 You can set a default runtime class in the Kubernetes driver configuration or
-override it for sandboxes created from a named template with Kubernetes driver
-config:
+override it for sandboxes created from a named template:
 
-```json
-{
-  "kubernetes": {
-    "pod": {
-      "runtime_class_name": "kata-containers"
-    }
-  }
-}
+```shell
+openshell sandbox template create kata-python \
+  --driver-config-json '{"kubernetes":{"pod":{"runtime_class_name":"kata-containers"}}}'
+
+openshell sandbox create --template kata-python
 ```
 
 ## Enable Sidecar Mode

--- a/docs/kubernetes/topology.mdx
+++ b/docs/kubernetes/topology.mdx
@@ -196,12 +196,17 @@ workload boundary, not as a replacement for the combined topology's full
 supervisor controls.
 
 You can set a default runtime class in the Kubernetes driver configuration or
-override it per sandbox with driver config:
+override it for sandboxes created from a named template with Kubernetes driver
+config:
 
-```shell
-openshell sandbox create \
-  --driver-config-json '{"kubernetes":{"pod":{"runtime_class_name":"kata-containers"}}}' \
-  -- claude
+```json
+{
+  "kubernetes": {
+    "pod": {
+      "runtime_class_name": "kata-containers"
+    }
+  }
+}
 ```
 
 ## Enable Sidecar Mode

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -747,7 +747,8 @@ Extension drivers run outside the gateway and expose the
 name; built-in names such as `vm`, `docker`, `podman`, and `kubernetes` cannot
 be selected through unmanaged socket endpoints. The selected driver name is the
 key used for driver-owned sandbox template config such as
-`SandboxTemplate.spec.driver_config.<name>`.
+`SandboxTemplate.spec.driver_config.<name>`. Attach driver-owned config through
+`openshell sandbox template create --driver-config-json`.
 
 ```toml
 [openshell]

--- a/docs/reference/gateway-config.mdx
+++ b/docs/reference/gateway-config.mdx
@@ -746,7 +746,8 @@ Extension drivers run outside the gateway and expose the
 `compute_driver.proto` gRPC service on a Unix socket. Use a non-reserved driver
 name; built-in names such as `vm`, `docker`, `podman`, and `kubernetes` cannot
 be selected through unmanaged socket endpoints. The selected driver name is the
-key used for driver-owned sandbox config such as `template.driver_config.<name>`.
+key used for driver-owned sandbox template config such as
+`SandboxTemplate.spec.driver_config.<name>`.
 
 ```toml
 [openshell]

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -69,24 +69,30 @@ Docker and Podman apply them as runtime limits. Kubernetes applies them as both
 container requests and limits. The VM driver accepts the fields but currently
 ignores them.
 
-Sandbox create also accepts experimental driver-owned config through
-`--driver-config-json`. The value is a JSON object keyed by driver name. The
-gateway forwards only the block for the active driver, so a Kubernetes gateway
-receives the `kubernetes` object from a value such as:
+Sandbox templates accept experimental driver-owned config through
+`SandboxTemplate.spec.driver_config`. The value is a JSON object keyed by driver
+name. The gateway forwards only the block for the active driver, so a
+Kubernetes gateway receives the `kubernetes` object from a value such as:
 
 Nested keys inside each driver block use snake_case. The top-level envelope keys
 are driver names, such as `kubernetes`, and are not part of the nested schema.
 
-```shell
-openshell sandbox create \
-  --driver-config-json '{"kubernetes":{"pod":{"runtime_class_name":"kata-containers","priority_class_name":"batch-low"}}}' \
-  -- claude
+```json
+{
+  "kubernetes": {
+    "pod": {
+      "runtime_class_name": "kata-containers",
+      "priority_class_name": "batch-low"
+    }
+  }
+}
 ```
 
-Driver config is for fields without a stable public flag. Prefer `--cpu`,
-`--memory`, and `--gpu` for supported resource intent. When `--gpu` is present
-without a count, OpenShell treats it as a request for one GPU. Pass
-`--gpu COUNT` when requesting more than one GPU.
+Driver config is for operator-controlled templates and fields without a stable
+public flag. Direct sandbox create remains portable; prefer `--cpu`, `--memory`,
+and `--gpu` for supported resource intent. When `--gpu` is present without a
+count, OpenShell treats it as a request for one GPU. Pass `--gpu COUNT` when
+requesting more than one GPU.
 
 Kubernetes maps the GPU count to the `nvidia.com/gpu` pod resource limit.
 Docker and Podman satisfy count-only GPU requests by selecting the requested
@@ -97,9 +103,10 @@ creates. On WSL2 all-only runtimes, Docker or Podman can use
 `nvidia.com/gpu=all` as a compatibility fallback, where it counts as one
 selectable device.
 
-Exact GPU device selection remains driver-owned and requires `--gpu`. Docker
-and Podman accept `cdi_devices` as opaque CDI device names; replace the
-top-level `docker` key with `podman` when using the Podman driver, for example
+Exact GPU device selection remains driver-owned and belongs in template driver
+config alongside `--gpu` resource intent. Docker and Podman accept
+`cdi_devices` as opaque CDI device names; replace the top-level `docker` key
+with `podman` when using the Podman driver, for example
 `{"docker":{"cdi_devices":["nvidia.com/gpu=0"]}}`. Explicit CDI device lists
 must not contain duplicates, and their length must match the effective GPU
 count. A single exact CDI device is compatible with the default `--gpu`
@@ -109,9 +116,8 @@ accepts at most one entry and allows either `--gpu` or `--gpu 1` when
 `gpu_device_ids` is set.
 
 For Kubernetes, `pod.runtime_class_name` maps to PodSpec `runtimeClassName`.
-It overrides the gateway's configured default runtime class for that sandbox,
-while a typed `SandboxTemplate.runtime_class_name` value from the API still
-takes precedence.
+Template driver config overrides the gateway's configured default runtime class
+for sandboxes created from that template.
 
 Docker and Podman report the address through which their sandboxes can reach
 the gateway. If the primary listener covers that address, the gateway reuses
@@ -154,14 +160,24 @@ Docker local-driver named volumes created with bind options also expose
 gateway-host paths, so OpenShell treats them like bind mounts and requires
 `enable_bind_mounts = true`.
 
-Use a `volume` mount for existing Docker named volumes:
+Use a `volume` mount for existing Docker named volumes. Create the volume
+before referencing it from template driver config:
 
 ```shell
 docker volume create openshell-work
+```
 
-openshell sandbox create \
-  --driver-config-json '{"docker":{"mounts":[{"type":"volume","source":"openshell-work","target":"/sandbox/work","read_only":false}]}}' \
-  -- claude
+```json
+{
+  "docker": {
+    "mounts": [{
+      "type": "volume",
+      "source": "openshell-work",
+      "target": "/sandbox/work",
+      "read_only": false
+    }]
+  }
+}
 ```
 
 <Warning>
@@ -178,10 +194,17 @@ Use a `bind` mount only after enabling it in the Docker driver table:
 enable_bind_mounts = true
 ```
 
-```shell
-openshell sandbox create \
-  --driver-config-json '{"docker":{"mounts":[{"type":"bind","source":"/srv/openshell/work","target":"/sandbox/work","read_only":false}]}}' \
-  -- claude
+```json
+{
+  "docker": {
+    "mounts": [{
+      "type": "bind",
+      "source": "/srv/openshell/work",
+      "target": "/sandbox/work",
+      "read_only": false
+    }]
+  }
+}
 ```
 
 Docker mount schema:
@@ -229,14 +252,24 @@ OpenShell treats them like bind mounts and requires `enable_bind_mounts = true`.
 Host bind mounts expose gateway host paths to sandbox requests, so they are
 disabled by default.
 
-Use a `volume` mount for existing Podman named volumes:
+Use a `volume` mount for existing Podman named volumes. Create the volume
+before referencing it from template driver config:
 
 ```shell
 podman volume create openshell-work
+```
 
-openshell sandbox create \
-  --driver-config-json '{"podman":{"mounts":[{"type":"volume","source":"openshell-work","target":"/sandbox/work","read_only":false}]}}' \
-  -- claude
+```json
+{
+  "podman": {
+    "mounts": [{
+      "type": "volume",
+      "source": "openshell-work",
+      "target": "/sandbox/work",
+      "read_only": false
+    }]
+  }
+}
 ```
 
 <Warning>
@@ -253,10 +286,17 @@ Use a `bind` mount only after enabling it in the Podman driver table:
 enable_bind_mounts = true
 ```
 
-```shell
-openshell sandbox create \
-  --driver-config-json '{"podman":{"mounts":[{"type":"bind","source":"/srv/openshell/work","target":"/sandbox/work","read_only":false}]}}' \
-  -- claude
+```json
+{
+  "podman": {
+    "mounts": [{
+      "type": "bind",
+      "source": "/srv/openshell/work",
+      "target": "/sandbox/work",
+      "read_only": false
+    }]
+  }
+}
 ```
 
 Podman mount schema:
@@ -423,38 +463,36 @@ agent container. Use this when storage is provisioned outside OpenShell and a
 sandbox should mount selected PVC subpaths instead of using the default
 OpenShell-created `/sandbox` workspace PVC.
 
-```shell
-openshell sandbox create \
-  --driver-config-json '{
-    "kubernetes": {
-      "volumes": [{
-        "name": "user-data",
-        "persistent_volume_claim": {
-          "claim_name": "pvc-user-data-123",
-          "read_only": false
-        }
-      }],
-      "containers": {
-        "agent": {
-          "volume_mounts": [
-            {
-              "name": "user-data",
-              "mount_path": "/sandbox/.openshell/workspace",
-              "sub_path": "workspace",
-              "read_only": false
-            },
-            {
-              "name": "user-data",
-              "mount_path": "/sandbox/.openshell/memory",
-              "sub_path": "memory",
-              "read_only": false
-            }
-          ]
-        }
+```json
+{
+  "kubernetes": {
+    "volumes": [{
+      "name": "user-data",
+      "persistent_volume_claim": {
+        "claim_name": "pvc-user-data-123",
+        "read_only": false
+      }
+    }],
+    "containers": {
+      "agent": {
+        "volume_mounts": [
+          {
+            "name": "user-data",
+            "mount_path": "/sandbox/.openshell/workspace",
+            "sub_path": "workspace",
+            "read_only": false
+          },
+          {
+            "name": "user-data",
+            "mount_path": "/sandbox/.openshell/memory",
+            "sub_path": "memory",
+            "read_only": false
+          }
+        ]
       }
     }
-  }' \
-  -- claude
+  }
+}
 ```
 
 Kubernetes PVC mount schema:

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -70,23 +70,24 @@ container requests and limits. The VM driver accepts the fields but currently
 ignores them.
 
 Sandbox templates accept experimental driver-owned config through
-`SandboxTemplate.spec.driver_config`. The value is a JSON object keyed by driver
-name. The gateway forwards only the block for the active driver, so a
-Kubernetes gateway receives the `kubernetes` object from a value such as:
+`SandboxTemplate.spec.driver_config`. Attach it through
+`openshell sandbox template create --driver-config-json`, then create sandboxes
+from that template:
+
+```shell
+openshell sandbox template create batch-kata \
+  --driver-config-json '{"kubernetes":{"pod":{"runtime_class_name":"kata-containers","priority_class_name":"batch-low"}}}'
+
+openshell sandbox create --template batch-kata
+```
+
+When `--from` is omitted, sandboxes created from the template use the gateway's
+default sandbox image. The driver config value is a JSON object keyed by driver
+name. The gateway forwards only the block for the active driver, so a Kubernetes
+gateway receives the `kubernetes` object from the value above.
 
 Nested keys inside each driver block use snake_case. The top-level envelope keys
 are driver names, such as `kubernetes`, and are not part of the nested schema.
-
-```json
-{
-  "kubernetes": {
-    "pod": {
-      "runtime_class_name": "kata-containers",
-      "priority_class_name": "batch-low"
-    }
-  }
-}
-```
 
 Driver config is for operator-controlled templates and fields without a stable
 public flag. Direct sandbox create remains portable; prefer `--cpu`, `--memory`,

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -64,6 +64,29 @@ openshell sandbox template create gpu-kata \
 openshell sandbox create --template gpu-kata -- claude
 ```
 
+The Python SDK exposes the same workflow through `SandboxTemplateClient` and
+`create_from_template`:
+
+```python
+from openshell import SandboxClient, SandboxTemplate, SandboxTemplateClient, SandboxWorkloadConfig
+
+with SandboxClient.from_active_cluster() as sandboxes:
+    templates = SandboxTemplateClient.from_sandbox_client(sandboxes)
+    template = SandboxTemplate()
+    template.metadata.name = "gpu-kata"
+    template.spec.workload.CopyFrom(SandboxWorkloadConfig(image="cuda:latest"))
+    template.spec.driver_config.update(
+        {"kubernetes": {"pod": {"runtime_class_name": "kata-containers"}}}
+    )
+    templates.create(workspace="default", template=template)
+
+    sandbox = sandboxes.create_from_template(
+        workspace="default",
+        template_name="gpu-kata",
+        name="gpu-job",
+    )
+```
+
 Template `driver_config` values are JSON objects keyed by driver name. The
 gateway forwards only the block for its configured compute driver:
 

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -52,9 +52,20 @@ does not change VM allocation.
 ### Driver-Specific Configuration
 
 Driver-specific sandbox settings belong in named sandbox templates, not direct
-sandbox create requests. Template `driver_config` values are JSON objects keyed
-by driver name. The gateway forwards only the block for its configured compute
-driver:
+sandbox create requests. Create the template with an image and driver-keyed
+JSON, then create sandboxes from the template:
+
+```shell
+openshell sandbox template create gpu-kata \
+  --from cuda:latest \
+  --gpu 1 \
+  --driver-config-json '{"kubernetes":{"pod":{"runtime_class_name":"kata-containers","node_selector":{"pool":"gpu"}}}}'
+
+openshell sandbox create --template gpu-kata -- claude
+```
+
+Template `driver_config` values are JSON objects keyed by driver name. The
+gateway forwards only the block for its configured compute driver:
 
 Nested keys inside each driver block use snake_case. The top-level envelope keys
 are driver names, such as `kubernetes`, and are not part of the nested schema.
@@ -73,6 +84,31 @@ are driver names, such as `kubernetes`, and are not part of the nested schema.
 Use template driver config only for driver-specific fields that do not have a
 stable CLI flag. Prefer stable direct-create flags such as `--cpu`, `--memory`,
 and `--gpu` when they cover the same behavior.
+
+### Sandbox Templates
+
+Use templates when multiple sandboxes should share the same image, resources,
+driver-specific settings, or startup service objective:
+
+```shell
+openshell sandbox template create python-fast \
+  --cpu 2 \
+  --memory 4Gi \
+  --ready-within 30s \
+  --max-burst 5
+
+openshell sandbox template list
+openshell sandbox template get python-fast
+openshell sandbox create --template python-fast --provider github -- claude
+openshell sandbox template delete python-fast
+```
+
+Templates own workload shape, so `sandbox create --template` cannot be combined
+with `--from`, `--cpu`, `--memory`, `--gpu`, `--env`, or
+`--driver-config-json`. Sandbox create still owns sandbox-specific metadata,
+policy, providers, and the command to run after creation.
+
+Omit `--from` when the template should use the gateway's default sandbox image.
 
 ### GPU Resources
 

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -51,22 +51,28 @@ does not change VM allocation.
 
 ### Driver-Specific Configuration
 
-Pass experimental driver-owned settings with `--driver-config-json`. The value
-must be a JSON object keyed by driver name. The gateway forwards only the block
-for its configured compute driver:
+Driver-specific sandbox settings belong in named sandbox templates, not direct
+sandbox create requests. Template `driver_config` values are JSON objects keyed
+by driver name. The gateway forwards only the block for its configured compute
+driver:
 
 Nested keys inside each driver block use snake_case. The top-level envelope keys
 are driver names, such as `kubernetes`, and are not part of the nested schema.
 
-```shell
-openshell sandbox create \
-  --driver-config-json '{"kubernetes":{"pod":{"runtime_class_name":"kata-containers","node_selector":{"pool":"gpu"}}}}' \
-  -- claude
+```json
+{
+  "kubernetes": {
+    "pod": {
+      "runtime_class_name": "kata-containers",
+      "node_selector": {"pool": "gpu"}
+    }
+  }
+}
 ```
 
-Use this only for driver-specific fields that do not have a stable CLI flag.
-Prefer stable flags such as `--cpu`, `--memory`, and `--gpu` when they cover
-the same behavior.
+Use template driver config only for driver-specific fields that do not have a
+stable CLI flag. Prefer stable direct-create flags such as `--cpu`, `--memory`,
+and `--gpu` when they cover the same behavior.
 
 ### GPU Resources
 
@@ -98,18 +104,12 @@ be reflected in later sandbox creates. On WSL2 all-only runtimes, the default
 can fall back to `nvidia.com/gpu=all`; that fallback counts as one selectable
 device.
 
-Exact GPU device selection is driver-specific and still requires `--gpu`. For
-Docker or Podman, pass CDI IDs through `cdi_devices`. The top-level key must
-match the active driver; replace `docker` with `podman` when using Podman. CDI
-IDs are treated as opaque strings. The list must not contain duplicate IDs, and
-its length must match the effective GPU count:
-
-```shell
-openshell sandbox create \
-  --gpu \
-  --driver-config-json '{"docker":{"cdi_devices":["nvidia.com/gpu=0"]}}' \
-  -- claude
-```
+Exact GPU device selection is driver-specific and still requires `--gpu`
+resource intent. For Docker or Podman, put CDI IDs in template driver config
+through `cdi_devices`. The top-level key must match the active driver; replace
+`docker` with `podman` when using Podman. CDI IDs are treated as opaque strings.
+The list must not contain duplicate IDs, and its length must match the
+effective GPU count.
 
 ### Custom Containers
 

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -72,7 +72,7 @@ This provides defense-in-depth: even if a container escape vulnerability exists,
 | Aspect | Detail |
 |---|---|
 | Default | Disabled. Set `server.enableUserNamespaces: true` in Helm values or `enable_user_namespaces = true` in the gateway config to enable cluster-wide. |
-| What you can change | Enable cluster-wide through Helm or gateway config. Override per-sandbox through the `user_namespaces` field on `SandboxTemplate` in the API. |
+| What you can change | Enable cluster-wide through Helm or gateway config. Override sandboxes created from a named template through Kubernetes driver config. |
 | Prerequisites | Kubernetes 1.33+ with user namespace support available (beta through 1.35, GA in 1.36+), a container runtime that supports user namespaces (containerd 2.0+, CRI-O 1.25+), and Linux 5.12+ for ID-mapped mounts. |
 | Risk if enabled with GPU | NVIDIA device plugin compatibility with user namespaces is unverified. OpenShell logs a warning when both GPU and user namespaces are active on the same sandbox. |
 | Recommendation | Enable on non-GPU clusters running Kubernetes with user namespace support available (1.33+ beta, 1.36+ GA) for stronger host isolation. Test GPU workloads separately before enabling on GPU clusters. |

--- a/e2e/python/conftest.py
+++ b/e2e/python/conftest.py
@@ -41,9 +41,7 @@ def _gateway_config_guard(
     (``getbasetemp().parent``), which is common to all xdist workers.
     """
     lock_path = tmp_path_factory.getbasetemp().parent / "gateway-config.lock"
-    exclusive = (
-        request.node.get_closest_marker("exclusive_gateway_config") is not None
-    )
+    exclusive = request.node.get_closest_marker("exclusive_gateway_config") is not None
     with lock_path.open("w") as lock_file:
         fcntl.flock(lock_file, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
         yield
@@ -88,17 +86,45 @@ def ensure_sandbox_persistence_ready(sandbox_client: SandboxClient) -> None:
 @pytest.fixture
 def sandbox(cluster_name: str | None) -> Callable[..., Sandbox]:
     def _create(*, spec: object | None = None, delete_on_exit: bool = True) -> Sandbox:
+        create_kwargs = _sandbox_create_kwargs_from_spec(spec)
         return Sandbox(
             workspace="default",
             cluster=cluster_name,
-            spec=spec,
             delete_on_exit=delete_on_exit,
+            **create_kwargs,
             # The sandbox image is large (Python, Node.js, coding agents) so the
             # first pod in the cluster may need extra time for the image pull.
             ready_timeout_seconds=300.0,
         )
 
     return _create
+
+
+def _sandbox_create_kwargs_from_spec(spec: object | None) -> dict[str, object]:
+    if spec is None:
+        return {}
+    if _has_proto_field(spec, "driver_config"):
+        raise ValueError(
+            "sandbox fixture spec.driver_config is no longer a direct create input; "
+            "create a named sandbox template and use template_name instead"
+        )
+
+    kwargs: dict[str, object] = {}
+    if _has_proto_field(spec, "workload"):
+        kwargs["workload"] = spec.workload
+    if _has_proto_field(spec, "policy"):
+        kwargs["policy"] = spec.policy
+    providers = list(getattr(spec, "providers", ()))
+    if providers:
+        kwargs["providers"] = providers
+    return kwargs
+
+
+def _has_proto_field(message: object, field: str) -> bool:
+    try:
+        return bool(message.HasField(field))  # type: ignore[attr-defined]
+    except ValueError:
+        return False
 
 
 @pytest.fixture(scope="session")

--- a/e2e/python/test_policy_validation.py
+++ b/e2e/python/test_policy_validation.py
@@ -64,11 +64,15 @@ def test_create_sandbox_rejects_root_user(
             run_as_group="sandbox",
         ),
     )
-    spec = datamodel_pb2.SandboxSpec(policy=policy)
-
     stub = sandbox_client._stub
     with pytest.raises(grpc.RpcError) as exc_info:
-        stub.CreateSandbox(openshell_pb2.CreateSandboxRequest(name="", spec=spec))
+        stub.CreateSandbox(
+            openshell_pb2.CreateSandboxRequest(
+                name="",
+                workload=openshell_pb2.SandboxWorkloadConfig(),
+                policy=policy,
+            )
+        )
 
     assert exc_info.value.code() == grpc.StatusCode.INVALID_ARGUMENT
     assert "root" in exc_info.value.details().lower()
@@ -88,11 +92,15 @@ def test_create_sandbox_rejects_path_traversal(
         landlock=_SAFE_LANDLOCK,
         process=_SAFE_PROCESS,
     )
-    spec = datamodel_pb2.SandboxSpec(policy=policy)
-
     stub = sandbox_client._stub
     with pytest.raises(grpc.RpcError) as exc_info:
-        stub.CreateSandbox(openshell_pb2.CreateSandboxRequest(name="", spec=spec))
+        stub.CreateSandbox(
+            openshell_pb2.CreateSandboxRequest(
+                name="",
+                workload=openshell_pb2.SandboxWorkloadConfig(),
+                policy=policy,
+            )
+        )
 
     assert exc_info.value.code() == grpc.StatusCode.INVALID_ARGUMENT
     assert "traversal" in exc_info.value.details().lower()
@@ -112,11 +120,15 @@ def test_create_sandbox_rejects_overly_broad_paths(
         landlock=_SAFE_LANDLOCK,
         process=_SAFE_PROCESS,
     )
-    spec = datamodel_pb2.SandboxSpec(policy=policy)
-
     stub = sandbox_client._stub
     with pytest.raises(grpc.RpcError) as exc_info:
-        stub.CreateSandbox(openshell_pb2.CreateSandboxRequest(name="", spec=spec))
+        stub.CreateSandbox(
+            openshell_pb2.CreateSandboxRequest(
+                name="",
+                workload=openshell_pb2.SandboxWorkloadConfig(),
+                policy=policy,
+            )
+        )
 
     assert exc_info.value.code() == grpc.StatusCode.INVALID_ARGUMENT
     assert "broad" in exc_info.value.details().lower()

--- a/e2e/python/test_sandbox_providers.py
+++ b/e2e/python/test_sandbox_providers.py
@@ -127,8 +127,7 @@ def providers_v2_enabled(
     config = stub.GetGatewayConfig(sandbox_pb2.GetGatewayConfigRequest())
     prior_value = sandbox_pb2.SettingValue()
     had_prior = (
-        key in config.settings
-        and config.settings[key].WhichOneof("value") is not None
+        key in config.settings and config.settings[key].WhichOneof("value") is not None
     )
     if had_prior:
         prior_value.CopyFrom(config.settings[key])
@@ -326,9 +325,7 @@ def test_nvidia_provider_injects_nvidia_api_key_env_var(
         with sandbox(spec=spec, delete_on_exit=True) as sb:
             result = sb.exec_python(read_nvidia_key)
             assert result.exit_code == 0, result.stderr
-            assert _is_placeholder_for_env_key(
-                result.stdout.strip(), "NVIDIA_API_KEY"
-            )
+            assert _is_placeholder_for_env_key(result.stdout.strip(), "NVIDIA_API_KEY")
 
 
 def test_attach_detach_updates_credentials_for_later_exec_launches(
@@ -420,7 +417,11 @@ def test_create_sandbox_rejects_unknown_provider(
         providers=["nonexistent-provider-xyz"],
     )
     with pytest.raises(grpc.RpcError) as exc_info:
-        sandbox_client.create(workspace="default", spec=spec)
+        sandbox_client.create(
+            workspace="default",
+            policy=spec.policy,
+            providers=list(spec.providers),
+        )
 
     assert exc_info.value.code() == grpc.StatusCode.FAILED_PRECONDITION
     assert "nonexistent-provider-xyz" in (exc_info.value.details() or "")
@@ -446,7 +447,7 @@ def test_credentials_not_in_persisted_spec_environment(
             fetched = sandbox_client._stub.GetSandbox(
                 openshell_pb2.GetSandboxRequest(name=sb.sandbox.name)
             )
-            persisted_env = dict(fetched.sandbox.spec.environment)
+            persisted_env = dict(fetched.sandbox.spec.workload.environment)
             assert "ANTHROPIC_API_KEY" not in persisted_env, (
                 "credentials should not be persisted in sandbox spec environment"
             )

--- a/proto/openshell.proto
+++ b/proto/openshell.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 package openshell.v1;
 
 import "datamodel.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "options.proto";
 import "sandbox.proto";
@@ -66,6 +67,46 @@ service OpenShell {
       auth_mode: "bearer"
       scope: "sandbox:read"
       workspace_role: "user"
+    };
+  }
+
+  // Create a reusable sandbox workload template.
+  rpc CreateSandboxTemplate(CreateSandboxTemplateRequest)
+      returns (SandboxTemplateResponse) {
+    option (openshell.options.v1.authorization) = {
+      auth_mode: "bearer"
+      scope: "sandbox:write"
+      workspace_role: "admin"
+    };
+  }
+
+  // Fetch a sandbox workload template by name.
+  rpc GetSandboxTemplate(GetSandboxTemplateRequest)
+      returns (SandboxTemplateResponse) {
+    option (openshell.options.v1.authorization) = {
+      auth_mode: "bearer"
+      scope: "sandbox:read"
+      workspace_role: "user"
+    };
+  }
+
+  // List sandbox workload templates.
+  rpc ListSandboxTemplates(ListSandboxTemplatesRequest)
+      returns (ListSandboxTemplatesResponse) {
+    option (openshell.options.v1.authorization) = {
+      auth_mode: "bearer"
+      scope: "sandbox:read"
+      workspace_role: "user"
+    };
+  }
+
+  // Delete a sandbox workload template by name.
+  rpc DeleteSandboxTemplate(DeleteSandboxTemplateRequest)
+      returns (DeleteSandboxTemplateResponse) {
+    option (openshell.options.v1.authorization) = {
+      auth_mode: "bearer"
+      scope: "sandbox:write"
+      workspace_role: "admin"
     };
   }
 
@@ -789,77 +830,80 @@ message Sandbox {
   SandboxSpec spec = 2;
   // Latest user-facing observed status derived by the gateway.
   SandboxStatus status = 3;
+  // Read-only provenance for sandboxes created from a named template.
+  SandboxTemplateProvenance created_from_template = 4;
 
-  reserved 4, 5;
+  reserved 5;
   reserved "phase", "current_policy_version";
 }
 
-// Desired sandbox configuration provided through the public API.
+// Resolved desired sandbox configuration stored by the gateway.
 message SandboxSpec {
-  // Log level exposed to processes running inside the sandbox.
-  string log_level = 1;
-  // Environment variables injected into the sandbox runtime.
-  map<string, string> environment = 5;
-  // Container or VM template used to provision the sandbox.
-  SandboxTemplate template = 6;
+  // Portable workload shape used to provision the sandbox.
+  SandboxWorkloadConfig workload = 12;
+  // Driver-keyed opaque config envelope resolved at create time.
+  google.protobuf.Struct driver_config = 13;
   // Required sandbox policy configuration.
-  openshell.sandbox.v1.SandboxPolicy policy = 7;
+  openshell.sandbox.v1.SandboxPolicy policy = 14;
   // Provider names to attach to this sandbox.
-  repeated string providers = 8;
+  repeated string providers = 15;
+  reserved 1, 5, 6, 7, 8, 9, 10, 11;
+  reserved "environment", "gpu_device", "log_level", "proposal_approval_mode",
+      "resource_requirements", "template";
+}
+
+message SandboxWorkloadConfig {
+  // Fully-qualified OCI image reference used to boot the sandbox.
+  string image = 1;
+  // Environment variables injected into the sandbox runtime.
+  map<string, string> environment = 2;
   // Portable resource requirements used by the gateway for driver selection
   // and by drivers for provisioning.
-  ResourceRequirements resource_requirements = 9;
+  SandboxResources resources = 3;
   reserved 10;
   reserved "gpu_device";
-  // Field 11 was `proposal_approval_mode`. The approval mode is now a
-  // runtime setting (gateway or sandbox scope) read via UpdateConfig /
-  // GetSandboxConfig, so it can be flipped on a running sandbox and
-  // managed fleet-wide.
   reserved 11;
   reserved "proposal_approval_mode";
 }
 
-message ResourceRequirements {
-  // GPU requirements for the sandbox. Presence indicates a GPU request.
-  GpuResourceRequirements gpu = 1;
+message SandboxResources {
+  // Portable CPU quantity, for example "500m" or "2".
+  string cpu = 1;
+  // Portable memory quantity, for example "512Mi" or "2Gi".
+  string memory = 2;
+  // Optional number of GPUs requested.
+  optional uint32 gpu_count = 3;
 }
 
-// Public GPU resource requirements.
-message GpuResourceRequirements {
-  // Optional number of GPUs requested. When omitted, the request is for one
-  // GPU using the selected driver's default assignment behavior.
-  optional uint32 count = 1;
-}
-
-// Public sandbox template mapped onto compute-driver template inputs.
+// Reusable sandbox template resource scoped to a workspace.
 message SandboxTemplate {
-  // Fully-qualified OCI image reference used to boot the sandbox.
-  string image = 1;
-  // Optional runtime class name requested from the compute platform.
-  string runtime_class_name = 2;
-  // Optional agent socket path exposed to the workload.
-  string agent_socket = 3;
-  // Labels applied to compute-platform resources for this sandbox.
-  map<string, string> labels = 4;
-  // Annotations applied to compute-platform resources for this sandbox.
-  map<string, string> annotations = 5;
-  // Additional environment variables injected by the template.
-  map<string, string> environment = 6;
-  // Platform-specific compute resource requirements and limits.
-  google.protobuf.Struct resources = 7;
-  reserved 9;
-  reserved "volume_claim_templates";
-  // Enable Kubernetes user namespace isolation (hostUsers: false).
-  // When true, container UID 0 maps to a non-root host UID and capabilities
-  // become namespaced. Requires Kubernetes 1.33+ with user namespace support
-  // available (beta through 1.35, GA in 1.36+) and a supporting runtime.
-  // When unset, the cluster-wide default is used.
-  optional bool user_namespaces = 10;
-  // Driver-keyed opaque config envelope supplied by the caller.
-  // The gateway selects the block matching the active compute driver and
-  // forwards only that inner Struct to DriverSandboxTemplate.driver_config.
-  // The selected driver owns nested schema validation.
-  google.protobuf.Struct driver_config = 11;
+  // Kubernetes-style metadata (id, name, labels, timestamps, resource version).
+  openshell.datamodel.v1.ObjectMeta metadata = 1;
+  // Desired reusable workload shape.
+  SandboxTemplateSpec spec = 2;
+}
+
+message SandboxTemplateSpec {
+  // Portable workload shape.
+  SandboxWorkloadConfig workload = 1;
+  // Driver-keyed opaque config envelope supplied by the template owner.
+  google.protobuf.Struct driver_config = 2;
+  // Desired service level associated with this template.
+  SandboxServiceLevel desired_service_level = 3;
+}
+
+message SandboxServiceLevel {
+  SandboxStartup startup = 1;
+}
+
+message SandboxStartup {
+  google.protobuf.Duration ready_within = 1;
+  uint32 max_burst = 2;
+}
+
+message SandboxTemplateProvenance {
+  string name = 1;
+  string resource_version = 2;
 }
 
 // User-facing sandbox status derived by the gateway from compute-driver observations.
@@ -930,15 +974,65 @@ message PlatformEvent {
 
 // Create sandbox request.
 message CreateSandboxRequest {
-  SandboxSpec spec = 1;
+  oneof workload_source {
+    // Inline portable workload config for this sandbox.
+    SandboxWorkloadConfig workload = 6;
+    // Workspace-scoped template name to resolve at creation time.
+    string workload_template_name = 7;
+  }
+  // Required sandbox policy configuration.
+  openshell.sandbox.v1.SandboxPolicy policy = 8;
+  // Provider names to attach to this sandbox.
+  repeated string providers = 9;
   // Optional user-supplied sandbox name. When empty the server generates one.
-  string name = 2;
+  string name = 10;
   // Optional labels for the sandbox (key-value metadata).
-  map<string, string> labels = 3;
+  map<string, string> labels = 11;
   // Optional annotations for the sandbox (non-selector metadata).
-  map<string, string> annotations = 4;
+  map<string, string> annotations = 12;
   // Workspace for the sandbox. Empty defaults to "default".
-  string workspace = 5;
+  string workspace = 13;
+  reserved 1, 2, 3, 4, 5;
+  reserved "spec";
+}
+
+message CreateSandboxTemplateRequest {
+  SandboxTemplate template = 1;
+  // Workspace for the template. Empty defaults to "default".
+  string workspace = 2;
+}
+
+message GetSandboxTemplateRequest {
+  string name = 1;
+  // Workspace scope. Empty defaults to "default".
+  string workspace = 2;
+}
+
+message ListSandboxTemplatesRequest {
+  uint32 limit = 1;
+  uint32 offset = 2;
+  // Workspace scope. Empty defaults to "default".
+  string workspace = 3;
+  // List across all workspaces. Mutually exclusive with workspace.
+  bool all_workspaces = 4;
+}
+
+message DeleteSandboxTemplateRequest {
+  string name = 1;
+  // Workspace scope. Empty defaults to "default".
+  string workspace = 2;
+}
+
+message SandboxTemplateResponse {
+  SandboxTemplate template = 1;
+}
+
+message ListSandboxTemplatesResponse {
+  repeated SandboxTemplate templates = 1;
+}
+
+message DeleteSandboxTemplateResponse {
+  bool deleted = 1;
 }
 
 // Get sandbox request.

--- a/python/openshell/__init__.py
+++ b/python/openshell/__init__.py
@@ -5,6 +5,11 @@
 
 from __future__ import annotations
 
+from ._proto.openshell_pb2 import (
+    SandboxTemplate,
+    SandboxTemplateSpec,
+    SandboxWorkloadConfig,
+)
 from .sandbox import (
     ExecChunk,
     ExecResult,
@@ -16,6 +21,7 @@ from .sandbox import (
     SandboxRef,
     SandboxSession,
     SandboxStatusRef,
+    SandboxTemplateClient,
     TlsConfig,
     WorkspaceClient,
     WorkspaceRef,
@@ -39,6 +45,10 @@ __all__ = [
     "SandboxRef",
     "SandboxSession",
     "SandboxStatusRef",
+    "SandboxTemplate",
+    "SandboxTemplateClient",
+    "SandboxTemplateSpec",
+    "SandboxWorkloadConfig",
     "TlsConfig",
     "WorkspaceClient",
     "WorkspaceRef",

--- a/python/openshell/openshell_test.py
+++ b/python/openshell/openshell_test.py
@@ -9,3 +9,10 @@ import openshell
 def test_version() -> None:
     """Test that version is defined."""
     assert openshell.__version__
+
+
+def test_sandbox_template_exports() -> None:
+    assert openshell.SandboxWorkloadConfig is not None
+    assert openshell.SandboxTemplate is not None
+    assert openshell.SandboxTemplateSpec is not None
+    assert openshell.SandboxTemplateClient is not None

--- a/python/openshell/sandbox.py
+++ b/python/openshell/sandbox.py
@@ -445,13 +445,14 @@ class SandboxClient:
         labels: Mapping[str, str] | None = None,
     ) -> SandboxRef:
         request_spec = spec if spec is not None else _default_spec()
+        request = _create_sandbox_request(
+            spec=request_spec,
+            name=name or "",
+            labels=dict(labels) if labels else {},
+            workspace=workspace,
+        )
         response = self._stub.CreateSandbox(
-            openshell_pb2.CreateSandboxRequest(
-                spec=request_spec,
-                name=name or "",
-                labels=dict(labels) if labels else {},
-                workspace=workspace,
-            ),
+            request,
             timeout=self._timeout,
         )
         sandbox_ref = _sandbox_ref(response.sandbox)
@@ -1104,6 +1105,28 @@ def _default_spec() -> openshell_pb2.SandboxSpec:
     # container image and ensures sandboxes get the full dev-sandbox-policy
     # (including network_policies) out of the box.
     return openshell_pb2.SandboxSpec()
+
+
+def _create_sandbox_request(
+    *,
+    spec: openshell_pb2.SandboxSpec,
+    name: str,
+    labels: Mapping[str, str],
+    workspace: str,
+) -> openshell_pb2.CreateSandboxRequest:
+    request = openshell_pb2.CreateSandboxRequest(
+        name=name,
+        labels=dict(labels),
+        workspace=workspace,
+    )
+    if spec.HasField("workload"):
+        request.workload.CopyFrom(spec.workload)
+    else:
+        request.workload.CopyFrom(openshell_pb2.SandboxWorkloadConfig())
+    if spec.HasField("policy"):
+        request.policy.CopyFrom(spec.policy)
+    request.providers.extend(spec.providers)
+    return request
 
 
 def _xdg_config_home() -> pathlib.Path:

--- a/python/openshell/sandbox.py
+++ b/python/openshell/sandbox.py
@@ -440,13 +440,43 @@ class SandboxClient:
         self,
         *,
         workspace: str,
-        spec: openshell_pb2.SandboxSpec | None = None,
+        workload: openshell_pb2.SandboxWorkloadConfig | None = None,
+        policy: Any | None = None,
+        providers: Sequence[str] | None = None,
         name: str | None = None,
         labels: Mapping[str, str] | None = None,
     ) -> SandboxRef:
-        request_spec = spec if spec is not None else _default_spec()
         request = _create_sandbox_request(
-            spec=request_spec,
+            workload=workload,
+            policy=policy,
+            providers=providers,
+            name=name or "",
+            labels=dict(labels) if labels else {},
+            workspace=workspace,
+        )
+        response = self._stub.CreateSandbox(
+            request,
+            timeout=self._timeout,
+        )
+        sandbox_ref = _sandbox_ref(response.sandbox)
+        if sandbox_ref.id == "":
+            raise SandboxError("CreateSandbox returned empty sandbox id")
+        return sandbox_ref
+
+    def create_from_template(
+        self,
+        *,
+        workspace: str,
+        template_name: str,
+        policy: Any | None = None,
+        providers: Sequence[str] | None = None,
+        name: str | None = None,
+        labels: Mapping[str, str] | None = None,
+    ) -> SandboxRef:
+        request = _create_sandbox_from_template_request(
+            template_name=template_name,
+            policy=policy,
+            providers=providers,
             name=name or "",
             labels=dict(labels) if labels else {},
             workspace=workspace,
@@ -464,12 +494,44 @@ class SandboxClient:
         self,
         *,
         workspace: str,
-        spec: openshell_pb2.SandboxSpec | None = None,
+        workload: openshell_pb2.SandboxWorkloadConfig | None = None,
+        policy: Any | None = None,
+        providers: Sequence[str] | None = None,
         name: str | None = None,
         labels: Mapping[str, str] | None = None,
     ) -> SandboxSession:
         return SandboxSession(
-            self, self.create(workspace=workspace, spec=spec, name=name, labels=labels)
+            self,
+            self.create(
+                workspace=workspace,
+                workload=workload,
+                policy=policy,
+                providers=providers,
+                name=name,
+                labels=labels,
+            ),
+        )
+
+    def create_session_from_template(
+        self,
+        *,
+        workspace: str,
+        template_name: str,
+        policy: Any | None = None,
+        providers: Sequence[str] | None = None,
+        name: str | None = None,
+        labels: Mapping[str, str] | None = None,
+    ) -> SandboxSession:
+        return SandboxSession(
+            self,
+            self.create_from_template(
+                workspace=workspace,
+                template_name=template_name,
+                policy=policy,
+                providers=providers,
+                name=name,
+                labels=labels,
+            ),
         )
 
     def get(self, sandbox_name: str, *, workspace: str) -> SandboxRef:
@@ -745,6 +807,80 @@ class SandboxClient:
         )
 
 
+class SandboxTemplateClient:
+    """gRPC client for reusable sandbox template lifecycle operations."""
+
+    def __init__(self, channel: grpc.Channel, *, timeout: float = 30.0) -> None:
+        self._stub = openshell_pb2_grpc.OpenShellStub(channel)
+        self._timeout = timeout
+
+    @classmethod
+    def from_sandbox_client(cls, client: SandboxClient) -> SandboxTemplateClient:
+        return cls(client._channel, timeout=client._timeout)
+
+    def create(
+        self,
+        *,
+        workspace: str,
+        template: openshell_pb2.SandboxTemplate,
+    ) -> openshell_pb2.SandboxTemplate:
+        response = self._stub.CreateSandboxTemplate(
+            openshell_pb2.CreateSandboxTemplateRequest(
+                workspace=workspace,
+                template=template,
+            ),
+            timeout=self._timeout,
+        )
+        return response.template
+
+    def get(self, name: str, *, workspace: str) -> openshell_pb2.SandboxTemplate:
+        response = self._stub.GetSandboxTemplate(
+            openshell_pb2.GetSandboxTemplateRequest(name=name, workspace=workspace),
+            timeout=self._timeout,
+        )
+        return response.template
+
+    def list(
+        self,
+        *,
+        workspace: str,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> builtins.list[openshell_pb2.SandboxTemplate]:
+        response = self._stub.ListSandboxTemplates(
+            openshell_pb2.ListSandboxTemplatesRequest(
+                workspace=workspace,
+                limit=limit,
+                offset=offset,
+            ),
+            timeout=self._timeout,
+        )
+        return list(response.templates)
+
+    def list_for_all_workspaces(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> builtins.list[openshell_pb2.SandboxTemplate]:
+        response = self._stub.ListSandboxTemplates(
+            openshell_pb2.ListSandboxTemplatesRequest(
+                all_workspaces=True,
+                limit=limit,
+                offset=offset,
+            ),
+            timeout=self._timeout,
+        )
+        return list(response.templates)
+
+    def delete(self, name: str, *, workspace: str) -> bool:
+        response = self._stub.DeleteSandboxTemplate(
+            openshell_pb2.DeleteSandboxTemplateRequest(name=name, workspace=workspace),
+            timeout=self._timeout,
+        )
+        return bool(response.deleted)
+
+
 @dataclass(frozen=True)
 class InferenceRouteConfig:
     provider_name: str
@@ -897,7 +1033,10 @@ class Sandbox:
         cluster: str | None = None,
         sandbox: str | SandboxRef | None = None,
         delete_on_exit: bool = True,
-        spec: openshell_pb2.SandboxSpec | None = None,
+        workload: openshell_pb2.SandboxWorkloadConfig | None = None,
+        template_name: str | None = None,
+        policy: Any | None = None,
+        providers: Sequence[str] | None = None,
         name: str | None = None,
         labels: Mapping[str, str] | None = None,
         timeout: float = 30.0,
@@ -919,7 +1058,10 @@ class Sandbox:
         self._cluster = cluster
         self._sandbox_input = sandbox
         self._delete_on_exit = delete_on_exit
-        self._spec = spec
+        self._workload = workload
+        self._template_name = template_name
+        self._policy = policy
+        self._providers = tuple(providers) if providers is not None else None
         self._name = name
         # Copy so later caller mutation cannot change what gets sent on enter.
         self._labels = dict(labels) if labels is not None else None
@@ -947,10 +1089,15 @@ class Sandbox:
         # Creation metadata cannot be applied when attaching to an existing
         # sandbox; reject it before opening a connection.
         if self._sandbox_input is not None and (
-            self._name is not None or self._labels is not None
+            self._name is not None
+            or self._labels is not None
+            or self._workload is not None
+            or self._template_name is not None
+            or self._policy is not None
+            or self._providers is not None
         ):
             raise SandboxError(
-                "name and labels cannot be set when attaching to an existing sandbox"
+                "create options cannot be set when attaching to an existing sandbox"
             )
 
         client = SandboxClient.from_active_cluster(
@@ -963,12 +1110,28 @@ class Sandbox:
         self._client = client
 
         if self._sandbox_input is None:
-            self._session = client.create_session(
-                workspace=self._workspace,
-                spec=self._spec,
-                name=self._name,
-                labels=self._labels,
-            )
+            if self._template_name is not None:
+                if self._workload is not None:
+                    raise SandboxError(
+                        "workload cannot be set when creating from a template"
+                    )
+                self._session = client.create_session_from_template(
+                    workspace=self._workspace,
+                    template_name=self._template_name,
+                    policy=self._policy,
+                    providers=self._providers,
+                    name=self._name,
+                    labels=self._labels,
+                )
+            else:
+                self._session = client.create_session(
+                    workspace=self._workspace,
+                    workload=self._workload,
+                    policy=self._policy,
+                    providers=self._providers,
+                    name=self._name,
+                    labels=self._labels,
+                )
         elif isinstance(self._sandbox_input, SandboxRef):
             self._session = SandboxSession(client, self._sandbox_input)
         else:
@@ -1098,18 +1261,11 @@ def _sandbox_ref(sandbox: openshell_pb2.Sandbox) -> SandboxRef:
     )
 
 
-def _default_spec() -> openshell_pb2.SandboxSpec:
-    # Omit the policy field so the sandbox container discovers its policy
-    # from /etc/openshell/policy.yaml (baked into the image at build time).
-    # This avoids duplicating policy defaults between the SDK and the
-    # container image and ensures sandboxes get the full dev-sandbox-policy
-    # (including network_policies) out of the box.
-    return openshell_pb2.SandboxSpec()
-
-
 def _create_sandbox_request(
     *,
-    spec: openshell_pb2.SandboxSpec,
+    workload: openshell_pb2.SandboxWorkloadConfig | None,
+    policy: Any | None,
+    providers: Sequence[str] | None,
     name: str,
     labels: Mapping[str, str],
     workspace: str,
@@ -1119,13 +1275,33 @@ def _create_sandbox_request(
         labels=dict(labels),
         workspace=workspace,
     )
-    if spec.HasField("workload"):
-        request.workload.CopyFrom(spec.workload)
-    else:
-        request.workload.CopyFrom(openshell_pb2.SandboxWorkloadConfig())
-    if spec.HasField("policy"):
-        request.policy.CopyFrom(spec.policy)
-    request.providers.extend(spec.providers)
+    request.workload.CopyFrom(workload or openshell_pb2.SandboxWorkloadConfig())
+    if policy is not None:
+        request.policy.CopyFrom(policy)
+    request.providers.extend(providers or [])
+    return request
+
+
+def _create_sandbox_from_template_request(
+    *,
+    template_name: str,
+    policy: Any | None,
+    providers: Sequence[str] | None,
+    name: str,
+    labels: Mapping[str, str],
+    workspace: str,
+) -> openshell_pb2.CreateSandboxRequest:
+    if template_name == "":
+        raise SandboxError("template_name is required")
+    request = openshell_pb2.CreateSandboxRequest(
+        name=name,
+        labels=dict(labels),
+        workspace=workspace,
+        workload_template_name=template_name,
+    )
+    if policy is not None:
+        request.policy.CopyFrom(policy)
+    request.providers.extend(providers or [])
     return request
 
 

--- a/python/openshell/sandbox_test.py
+++ b/python/openshell/sandbox_test.py
@@ -27,6 +27,7 @@ from openshell.sandbox import (
     SandboxError,
     SandboxRef,
     SandboxStatusRef,
+    SandboxTemplateClient,
     TlsConfig,
     _atomic_replace,
     _BearerAuthInterceptor,
@@ -85,6 +86,13 @@ class _FakeInferenceStub:
 
 def _client_with_fake_stub(stub: object) -> SandboxClient:
     client = cast("SandboxClient", object.__new__(SandboxClient))
+    client._timeout = 30.0
+    client._stub = cast("Any", stub)
+    return client
+
+
+def _template_client_with_fake_stub(stub: object) -> SandboxTemplateClient:
+    client = cast("SandboxTemplateClient", object.__new__(SandboxTemplateClient))
     client._timeout = 30.0
     client._stub = cast("Any", stub)
     return client
@@ -1545,7 +1553,18 @@ class _FakeSandboxStub:
         self.delete_request: openshell_pb2.DeleteSandboxRequest | None = None
         self.stop_request: openshell_pb2.StopSandboxRequest | None = None
         self.start_request: openshell_pb2.StartSandboxRequest | None = None
+        self.create_template_request: (
+            openshell_pb2.CreateSandboxTemplateRequest | None
+        ) = None
+        self.get_template_request: openshell_pb2.GetSandboxTemplateRequest | None = None
+        self.list_template_request: openshell_pb2.ListSandboxTemplatesRequest | None = (
+            None
+        )
+        self.delete_template_request: (
+            openshell_pb2.DeleteSandboxTemplateRequest | None
+        ) = None
         self._listed = listed or []
+        self._templates: list[openshell_pb2.SandboxTemplate] = []
 
     def GetSandbox(
         self,
@@ -1626,6 +1645,46 @@ class _FakeSandboxStub:
         _ = timeout
         return SimpleNamespace(sandboxes=list(self._listed))
 
+    def CreateSandboxTemplate(
+        self,
+        request: openshell_pb2.CreateSandboxTemplateRequest,
+        timeout: float | None = None,
+    ) -> Any:
+        self.create_template_request = request
+        _ = timeout
+        self._templates.append(request.template)
+        return SimpleNamespace(template=request.template)
+
+    def GetSandboxTemplate(
+        self,
+        request: openshell_pb2.GetSandboxTemplateRequest,
+        timeout: float | None = None,
+    ) -> Any:
+        self.get_template_request = request
+        _ = timeout
+        template = openshell_pb2.SandboxTemplate()
+        template.metadata.name = request.name
+        template.metadata.workspace = request.workspace
+        return SimpleNamespace(template=template)
+
+    def ListSandboxTemplates(
+        self,
+        request: openshell_pb2.ListSandboxTemplatesRequest,
+        timeout: float | None = None,
+    ) -> Any:
+        self.list_template_request = request
+        _ = timeout
+        return SimpleNamespace(templates=list(self._templates))
+
+    def DeleteSandboxTemplate(
+        self,
+        request: openshell_pb2.DeleteSandboxTemplateRequest,
+        timeout: float | None = None,
+    ) -> Any:
+        self.delete_template_request = request
+        _ = timeout
+        return SimpleNamespace(deleted=True)
+
 
 class _RecordingHighLevelClient:
     """A stand-in for SandboxClient used to observe high-level forwarding."""
@@ -1637,13 +1696,39 @@ class _RecordingHighLevelClient:
         self,
         *,
         workspace: str,
-        spec: Any = None,
+        workload: Any = None,
+        policy: Any = None,
+        providers: Any = None,
         name: str | None = None,
         labels: Any = None,
     ) -> Any:
         self.create_kwargs = {
             "workspace": workspace,
-            "spec": spec,
+            "workload": workload,
+            "policy": policy,
+            "providers": providers,
+            "template_name": None,
+            "name": name,
+            "labels": labels,
+        }
+        return SimpleNamespace(sandbox=SimpleNamespace(name=name or "generated"))
+
+    def create_session_from_template(
+        self,
+        *,
+        workspace: str,
+        template_name: str,
+        policy: Any = None,
+        providers: Any = None,
+        name: str | None = None,
+        labels: Any = None,
+    ) -> Any:
+        self.create_kwargs = {
+            "workspace": workspace,
+            "workload": None,
+            "policy": policy,
+            "providers": providers,
+            "template_name": template_name,
             "name": name,
             "labels": labels,
         }
@@ -1717,24 +1802,103 @@ def test_create_copies_caller_labels() -> None:
     assert dict(stub.create_request.labels) == {"aiq": "deep-research"}
 
 
-def test_create_forwards_spec_workload_and_providers() -> None:
+def test_create_forwards_workload_and_providers() -> None:
     stub = _FakeSandboxStub()
     client = _client_with_fake_stub(stub)
-    spec = openshell_pb2.SandboxSpec(
-        workload=openshell_pb2.SandboxWorkloadConfig(
-            image="python:3.12",
-            environment={"LANG": "C.UTF-8"},
-        ),
-        providers=["github"],
+    workload = openshell_pb2.SandboxWorkloadConfig(
+        image="python:3.12",
+        environment={"LANG": "C.UTF-8"},
     )
 
-    client.create(workspace="default", spec=spec)
+    client.create(workspace="default", workload=workload, providers=["github"])
 
     assert stub.create_request is not None
     assert stub.create_request.HasField("workload")
     assert stub.create_request.workload.image == "python:3.12"
     assert dict(stub.create_request.workload.environment) == {"LANG": "C.UTF-8"}
     assert list(stub.create_request.providers) == ["github"]
+
+
+def test_create_from_template_forwards_template_name_and_providers() -> None:
+    stub = _FakeSandboxStub()
+    client = _client_with_fake_stub(stub)
+
+    client.create_from_template(
+        workspace="default",
+        template_name="gpu-kata",
+        name="job-1",
+        providers=["github"],
+        labels={"team": "aiq"},
+    )
+
+    assert stub.create_request is not None
+    assert stub.create_request.workload_template_name == "gpu-kata"
+    assert not stub.create_request.HasField("workload")
+    assert stub.create_request.name == "job-1"
+    assert list(stub.create_request.providers) == ["github"]
+    assert dict(stub.create_request.labels) == {"team": "aiq"}
+
+
+def test_create_from_template_rejects_empty_template_name() -> None:
+    stub = _FakeSandboxStub()
+    client = _client_with_fake_stub(stub)
+
+    with pytest.raises(SandboxError):
+        client.create_from_template(workspace="default", template_name="")
+
+
+def test_sandbox_template_client_crud_forwards_requests() -> None:
+    stub = _FakeSandboxStub()
+    client = _template_client_with_fake_stub(stub)
+    template = openshell_pb2.SandboxTemplate()
+    template.metadata.name = "gpu-kata"
+    template.spec.workload.image = "python:3.12"
+    template.spec.driver_config.update({"kubernetes": {"runtime_class_name": "kata"}})
+
+    created = client.create(workspace="default", template=template)
+
+    assert created.metadata.name == "gpu-kata"
+    assert stub.create_template_request is not None
+    assert stub.create_template_request.workspace == "default"
+    assert stub.create_template_request.template.spec.workload.image == "python:3.12"
+    assert (
+        stub.create_template_request.template.spec.driver_config["kubernetes"][
+            "runtime_class_name"
+        ]
+        == "kata"
+    )
+
+    got = client.get("gpu-kata", workspace="default")
+    assert got.metadata.name == "gpu-kata"
+    assert stub.get_template_request is not None
+    assert stub.get_template_request.name == "gpu-kata"
+    assert stub.get_template_request.workspace == "default"
+
+    listed = client.list(workspace="default", limit=50, offset=10)
+    assert len(listed) == 1
+    assert stub.list_template_request is not None
+    assert stub.list_template_request.workspace == "default"
+    assert stub.list_template_request.limit == 50
+    assert stub.list_template_request.offset == 10
+    assert not stub.list_template_request.all_workspaces
+
+    assert client.delete("gpu-kata", workspace="default") is True
+    assert stub.delete_template_request is not None
+    assert stub.delete_template_request.name == "gpu-kata"
+    assert stub.delete_template_request.workspace == "default"
+
+
+def test_sandbox_template_list_for_all_workspaces_clears_workspace() -> None:
+    stub = _FakeSandboxStub()
+    client = _template_client_with_fake_stub(stub)
+
+    client.list_for_all_workspaces(limit=100, offset=5)
+
+    assert stub.list_template_request is not None
+    assert stub.list_template_request.all_workspaces
+    assert stub.list_template_request.workspace == ""
+    assert stub.list_template_request.limit == 100
+    assert stub.list_template_request.offset == 5
 
 
 def test_create_session_forwards_name_and_labels() -> None:
@@ -1882,9 +2046,42 @@ def test_high_level_creation_forwards_name_and_labels(
 
     assert recording.create_kwargs == {
         "workspace": "staging",
-        "spec": None,
+        "workload": None,
+        "policy": None,
+        "providers": None,
+        "template_name": None,
         "name": "job-1",
         "labels": {"aiq": "deep-research"},
+    }
+
+
+def test_high_level_creation_from_template_forwards_template_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recording = _RecordingHighLevelClient()
+    monkeypatch.setattr(
+        SandboxClient,
+        "from_active_cluster",
+        classmethod(lambda _cls, **_kwargs: recording),
+    )
+
+    sandbox = Sandbox(
+        workspace="staging",
+        template_name="gpu-kata",
+        name="job-1",
+        providers=["github"],
+        delete_on_exit=False,
+    )
+    sandbox.__enter__()
+
+    assert recording.create_kwargs == {
+        "workspace": "staging",
+        "workload": None,
+        "policy": None,
+        "providers": ("github",),
+        "template_name": "gpu-kata",
+        "name": "job-1",
+        "labels": None,
     }
 
 

--- a/python/openshell/sandbox_test.py
+++ b/python/openshell/sandbox_test.py
@@ -1702,6 +1702,7 @@ def test_create_without_args_sends_empty_metadata() -> None:
     assert stub.create_request.name == ""
     assert dict(stub.create_request.labels) == {}
     assert stub.create_request.workspace == "default"
+    assert stub.create_request.HasField("workload")
 
 
 def test_create_copies_caller_labels() -> None:
@@ -1714,6 +1715,26 @@ def test_create_copies_caller_labels() -> None:
 
     assert stub.create_request is not None
     assert dict(stub.create_request.labels) == {"aiq": "deep-research"}
+
+
+def test_create_forwards_spec_workload_and_providers() -> None:
+    stub = _FakeSandboxStub()
+    client = _client_with_fake_stub(stub)
+    spec = openshell_pb2.SandboxSpec(
+        workload=openshell_pb2.SandboxWorkloadConfig(
+            image="python:3.12",
+            environment={"LANG": "C.UTF-8"},
+        ),
+        providers=["github"],
+    )
+
+    client.create(workspace="default", spec=spec)
+
+    assert stub.create_request is not None
+    assert stub.create_request.HasField("workload")
+    assert stub.create_request.workload.image == "python:3.12"
+    assert dict(stub.create_request.workload.environment) == {"LANG": "C.UTF-8"}
+    assert list(stub.create_request.providers) == ["github"]
 
 
 def test_create_session_forwards_name_and_labels() -> None:

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -21,7 +21,7 @@ This SDK is modeled after
 Kubernetes client library that every Go operator developer already knows. The
 patterns will look familiar:
 
-- **Typed sub-clients per resource**: `client.Sandboxes()`, `client.Providers()`,
+- **Typed sub-clients per resource**: `client.Sandboxes()`, `client.SandboxTemplates()`, `client.Providers()`,
   `client.Exec()`, just like `clientset.CoreV1().Pods()`
 - **Domain types separated from wire formats**: clean Go structs in a `types`
   package, no proto leakage into the public API (like `k8s.io/api`)
@@ -52,9 +52,15 @@ if err != nil {
 defer client.Close()
 
 // Create a sandbox and wait until it's ready
-sandbox, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{
-    Template: &v1.SandboxTemplate{Image: "python:3.12"},
-}, nil)
+sandbox, err := client.Sandboxes().Create(
+    ctx,
+    "default",
+    "my-sandbox",
+    &v1.SandboxWorkloadConfig{Image: "python:3.12"},
+    nil,
+    nil,
+    nil,
+)
 if err != nil {
     log.Fatal(err)
 }
@@ -242,6 +248,7 @@ if err != nil {
 ```
 Client
   ├── Sandboxes()   → SandboxInterface    (create, get, list, delete, watch, wait, logs)
+  ├── SandboxTemplates() → SandboxTemplateInterface (create, get, list, delete)
   ├── Exec()        → ExecInterface       (run, stream, interactive)
   ├── Files()       → FileInterface       (upload, download)
   ├── Health()      → HealthInterface     (health check, gateway info, current user)
@@ -263,6 +270,7 @@ consumers import a single package. See the [Architecture](https://ro14nd.de/open
 | Feature | Interface | Docs |
 |---------|-----------|------|
 | Sandbox lifecycle (create, get, list, delete, watch, wait) | `SandboxInterface` | [Sandboxes](https://ro14nd.de/openshell-sdk-go/api/sandboxes.html) |
+| Sandbox templates (create, get, list, delete) | `SandboxTemplateInterface` | [Sandbox Templates](https://ro14nd.de/openshell-sdk-go/api/sandbox-templates.html) |
 | Command execution (collected, streamed, interactive PTY) | `ExecInterface` | [Exec](https://ro14nd.de/openshell-sdk-go/api/exec.html) |
 | Provider management (CRUD + idempotent ensure) | `ProviderInterface` | [Providers](https://ro14nd.de/openshell-sdk-go/api/providers.html) |
 | Provider profiles (list, import, lint, update) | `ProfileInterface` | [Profiles](https://ro14nd.de/openshell-sdk-go/api/profiles.html) |

--- a/sdk/go/docs/src/SUMMARY.md
+++ b/sdk/go/docs/src/SUMMARY.md
@@ -15,6 +15,7 @@
 - [Overview](api/overview.md)
 - [Client](api/client.md)
 - [Sandboxes](api/sandboxes.md)
+- [Sandbox Templates](api/sandbox-templates.md)
 - [Exec](api/exec.md)
 - [Providers](api/providers.md)
 - [Profiles](api/profiles.md)

--- a/sdk/go/docs/src/api/client.md
+++ b/sdk/go/docs/src/api/client.md
@@ -10,6 +10,7 @@ typed accessors for each resource domain and manages the underlying gRPC connect
 | Accessor | Returns | Description |
 |----------|---------|-------------|
 | `Sandboxes()` | `SandboxInterface` | Sandbox lifecycle management |
+| `SandboxTemplates()` | `SandboxTemplateInterface` | Sandbox template management |
 | `Providers()` | `ProviderInterface` | Provider CRUD and idempotent ensure |
 | `Services()` | `ServiceInterface` | Service exposure and management |
 | `Exec()` | `ExecInterface` | Command execution (run, stream, interactive) |

--- a/sdk/go/docs/src/api/fake.md
+++ b/sdk/go/docs/src/api/fake.md
@@ -19,7 +19,7 @@ func TestSandboxLifecycle(t *testing.T) {
 
     ctx := context.Background()
 
-    sb, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{}, nil)
+    sb, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", nil, nil, nil, nil)
     require.NoError(t, err)
     assert.Equal(t, types.SandboxProvisioning, sb.Status.Phase)
 
@@ -83,6 +83,7 @@ The fake client implements every interface in `v1.ClientInterface`:
 | Accessor | Interface | Behavior |
 |----------|-----------|----------|
 | `Sandboxes()` | `SandboxInterface` | Full CRUD, Watch, WaitReady |
+| `SandboxTemplates()` | `SandboxTemplateInterface` | Full CRUD |
 | `Providers()` | `ProviderInterface` | Full CRUD, Ensure |
 | `Workspaces()` | `WorkspaceInterface` | Full CRUD, Members |
 | `Health()` | `HealthInterface` | Configurable result |

--- a/sdk/go/docs/src/api/overview.md
+++ b/sdk/go/docs/src/api/overview.md
@@ -1,6 +1,6 @@
 # API Overview
 
-The OpenShell Go SDK exposes 12 interfaces through the sub-client pattern. You access each interface through a typed accessor on the `Client`.
+The OpenShell Go SDK exposes 13 interfaces through the sub-client pattern. You access each interface through a typed accessor on the `Client`.
 
 ## Interface Summary
 
@@ -9,6 +9,7 @@ The OpenShell Go SDK exposes 12 interfaces through the sub-client pattern. You a
 | Interface | Accessor | Description |
 |-----------|----------|-------------|
 | [SandboxInterface](sandboxes.md) | `client.Sandboxes()` | Create, manage, and watch sandbox lifecycle |
+| [SandboxTemplateInterface](sandbox-templates.md) | `client.SandboxTemplates()` | Manage reusable sandbox templates |
 | [ExecInterface](exec.md) | `client.Exec()` | Run commands, stream output, interactive sessions |
 | [ProviderInterface](providers.md) | `client.Providers()` | Manage compute providers and their lifecycle |
 | [ServiceInterface](services.md) | `client.Services()` | Expose and manage HTTP services inside sandboxes |
@@ -39,6 +40,7 @@ These are accessed through `client.Providers()`:
 Each interface has a reference page with method signatures and usage examples:
 
 - **[Sandboxes](sandboxes.md)**: Create sandboxes, wait for readiness, watch state changes, manage providers, retrieve logs.
+- **[Sandbox Templates](sandbox-templates.md)**: Manage reusable template definitions used by `CreateFromTemplate`.
 - **[Exec](exec.md)**: Execute commands with one-shot, streaming, or interactive modes.
 - **[Providers](providers.md)**: Register and manage compute providers. Includes sub-clients for profiles and credential refresh.
 - **[Services](services.md)**: Expose and manage HTTP services inside sandboxes.

--- a/sdk/go/docs/src/api/sandbox-templates.md
+++ b/sdk/go/docs/src/api/sandbox-templates.md
@@ -1,0 +1,66 @@
+# Sandbox Templates
+
+Accessor: `client.SandboxTemplates()`
+
+Manage reusable workspace-scoped sandbox templates. Templates carry driver-specific configuration such as runtime isolation, mounts, and startup behavior. Create sandboxes from templates with `client.Sandboxes().CreateFromTemplate(...)`.
+
+## Create
+
+```go
+template, err := client.SandboxTemplates().Create(ctx, "default", &v1.SandboxTemplate{
+    Name: "gpu-kata",
+    Spec: v1.SandboxTemplateSpec{
+        Workload: &v1.SandboxWorkloadConfig{Image: "python:3.12"},
+        DriverConfig: map[string]any{
+            "kubernetes": map[string]any{
+                "runtime_class_name": "kata",
+            },
+        },
+    },
+})
+```
+
+## Get
+
+```go
+template, err := client.SandboxTemplates().Get(ctx, "default", "gpu-kata")
+fmt.Println(template.Spec.Workload.Image)
+```
+
+## List
+
+```go
+templates, err := client.SandboxTemplates().List(ctx, "default")
+
+templates, err = client.SandboxTemplates().List(ctx, "default", v1.ListOptions{
+    Limit: 50,
+})
+```
+
+Platform administrators can list across workspaces:
+
+```go
+templates, err := client.SandboxTemplates().List(ctx, "default", v1.ListOptions{
+    AllWorkspaces: true,
+})
+```
+
+## Delete
+
+```go
+err := client.SandboxTemplates().Delete(ctx, "default", "gpu-kata")
+```
+
+## Create From Template
+
+```go
+sandbox, err := client.Sandboxes().CreateFromTemplate(
+    ctx,
+    "default",
+    "gpu-job",
+    "gpu-kata",
+    nil,
+    []string{"openai"},
+    nil,
+)
+```

--- a/sdk/go/docs/src/api/sandboxes.md
+++ b/sdk/go/docs/src/api/sandboxes.md
@@ -7,17 +7,18 @@ wait for readiness, watch state changes, and retrieve logs.
 
 ## Create
 
-Creates a new sandbox with the given name, spec, and labels.
+Creates a new sandbox with the given name, portable workload, policy, providers, and labels.
 
 ```go
-sb, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{
-    Template: &v1.SandboxTemplate{
-        Image: "nvcr.io/nvidia/openshell:latest",
-    },
-    Providers: []string{"openai"},
-}, map[string]string{
-    "team": "platform",
-})
+workload := &v1.SandboxWorkloadConfig{Image: "nvcr.io/nvidia/openshell:latest"}
+labels := map[string]string{"team": "platform"}
+sb, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", workload, nil, []string{"openai"}, labels)
+```
+
+Create from a workspace-scoped named template:
+
+```go
+sb, err := client.Sandboxes().CreateFromTemplate(ctx, "default", "gpu-job", "gpu-kata", nil, []string{"openai"}, nil)
 ```
 
 ## Get

--- a/sdk/go/docs/src/error-handling.md
+++ b/sdk/go/docs/src/error-handling.md
@@ -55,7 +55,7 @@ Handle missing resources gracefully:
 sb, err := client.Sandboxes().Get(ctx, "default", "my-sandbox")
 if v1.IsNotFound(err) {
     fmt.Println("Sandbox does not exist, creating...")
-    sb, err = client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{}, nil)
+    sb, err = client.Sandboxes().Create(ctx, "default", "my-sandbox", nil, nil, nil, nil)
 }
 if err != nil {
     log.Fatal(err)

--- a/sdk/go/docs/src/getting-started.md
+++ b/sdk/go/docs/src/getting-started.md
@@ -65,10 +65,11 @@ Verify the gateway is reachable:
 Create a sandbox with a Python image:
 
 ```go
-    sandbox, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{
-        Template: &v1.SandboxTemplate{Image: "python:3.12"},
+    workload := &v1.SandboxWorkloadConfig{
+        Image: "python:3.12",
         Environment: map[string]string{"LANG": "en_US.UTF-8"},
-    }, nil)
+    }
+    sandbox, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", workload, nil, nil, nil)
     if err != nil {
         log.Fatal(err)
     }

--- a/sdk/go/docs/src/testing.md
+++ b/sdk/go/docs/src/testing.md
@@ -18,7 +18,7 @@ func TestMyOperator(t *testing.T) {
     ctx := context.Background()
 
     // Use client exactly like the real SDK
-    sb, err := client.Sandboxes().Create(ctx, "default", "test-sandbox", &v1.SandboxSpec{}, nil)
+    sb, err := client.Sandboxes().Create(ctx, "default", "test-sandbox", nil, nil, nil, nil)
     require.NoError(t, err)
     assert.Equal(t, "Provisioning", string(sb.Status.Phase))
 }
@@ -79,7 +79,7 @@ client := fake.NewClient()
 ctx := context.Background()
 
 // Create starts in Provisioning
-sb, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{}, nil)
+sb, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", nil, nil, nil, nil)
 assert.Equal(t, types.SandboxProvisioning, sb.Status.Phase)
 
 // WaitReady transitions to Ready (synchronous in fake)
@@ -109,7 +109,7 @@ require.NoError(t, err)
 defer watcher.Stop()
 
 // Create a sandbox — triggers an ADDED event
-client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{}, nil)
+client.Sandboxes().Create(ctx, "default", "my-sandbox", nil, nil, nil, nil)
 
 // Read the event from the channel
 event := <-watcher.ResultChan()
@@ -128,7 +128,7 @@ watcher, err := client.Sandboxes().Watch(ctx, "default", "my-sandbox", v1.WatchO
 require.NoError(t, err)
 
 // Create and transition to Ready
-client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{}, nil)
+client.Sandboxes().Create(ctx, "default", "my-sandbox", nil, nil, nil, nil)
 client.Sandboxes().WaitReady(ctx, "default", "my-sandbox")
 
 // Drain events — channel closes after the Ready event

--- a/sdk/go/openshell/v1/client.go
+++ b/sdk/go/openshell/v1/client.go
@@ -18,6 +18,7 @@ type Config = types.Config
 // ClientInterface defines the top-level SDK surface.
 type ClientInterface interface {
 	Sandboxes() SandboxInterface
+	SandboxTemplates() SandboxTemplateInterface
 	Providers() ProviderInterface
 	Services() ServiceInterface
 	Exec() ExecInterface
@@ -50,6 +51,7 @@ type Client struct {
 	closeErr  error
 
 	sandboxes  SandboxInterface
+	templates  SandboxTemplateInterface
 	providers  ProviderInterface
 	services   ServiceInterface
 	exec       ExecInterface
@@ -94,6 +96,7 @@ func NewClient(cfg Config) (*Client, error) {
 	}
 
 	c.sandboxes = newSandboxClient(conn)
+	c.templates = newSandboxTemplateClient(conn)
 	c.providers = newProviderClient(conn)
 	c.services = newServiceClient(conn)
 	c.exec = newExecClient(conn, c.sandboxes)
@@ -111,6 +114,9 @@ func NewClient(cfg Config) (*Client, error) {
 
 // Sandboxes returns the sandbox sub-client.
 func (c *Client) Sandboxes() SandboxInterface { return c.sandboxes }
+
+// SandboxTemplates returns the sandbox template sub-client.
+func (c *Client) SandboxTemplates() SandboxTemplateInterface { return c.templates }
 
 // Providers returns the provider sub-client.
 func (c *Client) Providers() ProviderInterface { return c.providers }

--- a/sdk/go/openshell/v1/client_test.go
+++ b/sdk/go/openshell/v1/client_test.go
@@ -26,6 +26,7 @@ func TestNewClient_ValidConfig(t *testing.T) {
 	require.NotNil(t, client)
 
 	assert.NotNil(t, client.Sandboxes())
+	assert.NotNil(t, client.SandboxTemplates())
 	assert.NotNil(t, client.Providers())
 	assert.NotNil(t, client.Exec())
 	assert.NotNil(t, client.Files())

--- a/sdk/go/openshell/v1/doc.go
+++ b/sdk/go/openshell/v1/doc.go
@@ -21,12 +21,11 @@
 //
 // # Sandbox Lifecycle
 //
-//	sandbox, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{
-//	    Workload: &v1.SandboxWorkloadConfig{
-//	        Image:       "python:3.12",
-//	        Environment: map[string]string{"LANG": "en_US.UTF-8"},
-//	    },
-//	}, nil)
+//	workload := &v1.SandboxWorkloadConfig{
+//	    Image:       "python:3.12",
+//	    Environment: map[string]string{"LANG": "en_US.UTF-8"},
+//	}
+//	sandbox, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", workload, nil, nil, nil)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
@@ -279,28 +278,34 @@
 //
 // Set an initial security policy when creating a sandbox:
 //
-//	sandbox, err := client.Sandboxes().Create(ctx, "default", "secure-sandbox", &v1.SandboxSpec{
-//	    Workload: &v1.SandboxWorkloadConfig{Image: "python:3.12"},
-//	    Policy: &v1.SandboxPolicy{
-//	        Version: 1,
-//	        Filesystem: &v1.FilesystemPolicy{
-//	            IncludeWorkdir: true,
-//	            ReadOnly:       []string{"/usr", "/lib"},
-//	        },
-//	        Process: &v1.ProcessPolicy{
-//	            RunAsUser:  "sandbox",
-//	            RunAsGroup: "sandbox",
-//	        },
-//	        NetworkPolicies: map[string]v1.NetworkPolicyRule{
-//	            "allow-api": {
-//	                Name: "allow-api",
-//	                Endpoints: []v1.PolicyNetworkEndpoint{
-//	                    {Host: "api.example.com", Port: 443, Protocol: "tcp"},
-//	                },
+//	policy := &v1.SandboxPolicy{
+//	    Version: 1,
+//	    Filesystem: &v1.FilesystemPolicy{
+//	        IncludeWorkdir: true,
+//	        ReadOnly:       []string{"/usr", "/lib"},
+//	    },
+//	    Process: &v1.ProcessPolicy{
+//	        RunAsUser:  "sandbox",
+//	        RunAsGroup: "sandbox",
+//	    },
+//	    NetworkPolicies: map[string]v1.NetworkPolicyRule{
+//	        "allow-api": {
+//	            Name: "allow-api",
+//	            Endpoints: []v1.PolicyNetworkEndpoint{
+//	                {Host: "api.example.com", Port: 443, Protocol: "tcp"},
 //	            },
 //	        },
 //	    },
-//	}, nil)
+//	}
+//	sandbox, err := client.Sandboxes().Create(
+//	    ctx,
+//	    "default",
+//	    "secure-sandbox",
+//	    &v1.SandboxWorkloadConfig{Image: "python:3.12"},
+//	    policy,
+//	    nil,
+//	    nil,
+//	)
 //
 // Replace the full policy at runtime via configuration update:
 //

--- a/sdk/go/openshell/v1/doc.go
+++ b/sdk/go/openshell/v1/doc.go
@@ -22,8 +22,10 @@
 // # Sandbox Lifecycle
 //
 //	sandbox, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{
-//	    Template: &v1.SandboxTemplate{Image: "python:3.12"},
-//	    Environment: map[string]string{"LANG": "en_US.UTF-8"},
+//	    Workload: &v1.SandboxWorkloadConfig{
+//	        Image:       "python:3.12",
+//	        Environment: map[string]string{"LANG": "en_US.UTF-8"},
+//	    },
 //	}, nil)
 //	if err != nil {
 //	    log.Fatal(err)
@@ -278,7 +280,7 @@
 // Set an initial security policy when creating a sandbox:
 //
 //	sandbox, err := client.Sandboxes().Create(ctx, "default", "secure-sandbox", &v1.SandboxSpec{
-//	    Template: &v1.SandboxTemplate{Image: "python:3.12"},
+//	    Workload: &v1.SandboxWorkloadConfig{Image: "python:3.12"},
 //	    Policy: &v1.SandboxPolicy{
 //	        Version: 1,
 //	        Filesystem: &v1.FilesystemPolicy{

--- a/sdk/go/openshell/v1/example_fake_test.go
+++ b/sdk/go/openshell/v1/example_fake_test.go
@@ -104,7 +104,7 @@ func ExampleNewClient_watchEvents() {
 	defer watcher.Stop()
 
 	// Create triggers an ADDED event
-	_, err = client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{}, nil)
+	_, err = client.Sandboxes().Create(ctx, "default", "my-sandbox", nil, nil, nil, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func ExampleNewClient_stopOnTerminal() {
 	}
 
 	// Create and transition to Ready
-	_, err = client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{}, nil)
+	_, err = client.Sandboxes().Create(ctx, "default", "my-sandbox", nil, nil, nil, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sdk/go/openshell/v1/example_test.go
+++ b/sdk/go/openshell/v1/example_test.go
@@ -21,7 +21,7 @@ func ExampleClient_Sandboxes() {
 	ctx := context.Background()
 
 	// Create a sandbox
-	sb, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{}, nil)
+	sb, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", nil, nil, nil, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -154,13 +154,13 @@ func ExampleIsAlreadyExists() {
 	ctx := context.Background()
 
 	// Create a sandbox
-	_, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{}, nil)
+	_, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", nil, nil, nil, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Try to create the same sandbox again
-	_, err = client.Sandboxes().Create(ctx, "default", "my-sandbox", &v1.SandboxSpec{}, nil)
+	_, err = client.Sandboxes().Create(ctx, "default", "my-sandbox", nil, nil, nil, nil)
 	if v1.IsAlreadyExists(err) {
 		fmt.Println("Sandbox already exists")
 	}

--- a/sdk/go/openshell/v1/exec_client_test.go
+++ b/sdk/go/openshell/v1/exec_client_test.go
@@ -34,7 +34,10 @@ func (r *stubSandboxResolver) Get(_ context.Context, _, name string) (*Sandbox, 
 	return &Sandbox{ID: "sb-" + name, Name: name}, nil
 }
 
-func (r *stubSandboxResolver) Create(context.Context, string, string, *SandboxSpec, map[string]string, ...CreateOptions) (*Sandbox, error) {
+func (r *stubSandboxResolver) Create(context.Context, string, string, *SandboxWorkloadConfig, *SandboxPolicy, []string, map[string]string, ...CreateOptions) (*Sandbox, error) {
+	panic("not implemented")
+}
+func (r *stubSandboxResolver) CreateFromTemplate(context.Context, string, string, string, *SandboxPolicy, []string, map[string]string, ...CreateOptions) (*Sandbox, error) {
 	panic("not implemented")
 }
 func (r *stubSandboxResolver) List(context.Context, string, ...ListOptions) ([]*Sandbox, error) {

--- a/sdk/go/openshell/v1/fake/doc.go
+++ b/sdk/go/openshell/v1/fake/doc.go
@@ -22,12 +22,12 @@
 //	    ctx := context.Background()
 //
 //	    // Create a sandbox — starts in Provisioning phase
-//	    sb, err := client.Sandboxes().Create(ctx, "my-sandbox", &v1.SandboxSpec{}, nil)
+//	    sb, err := client.Sandboxes().Create(ctx, "default", "my-sandbox", nil, nil, nil, nil)
 //	    require.NoError(t, err)
 //	    assert.Equal(t, types.SandboxProvisioning, sb.Status.Phase)
 //
 //	    // Wait until ready — transitions synchronously in the fake
-//	    sb, err = client.Sandboxes().WaitReady(ctx, "my-sandbox")
+//	    sb, err = client.Sandboxes().WaitReady(ctx, "default", "my-sandbox")
 //	    require.NoError(t, err)
 //	    assert.Equal(t, types.SandboxReady, sb.Status.Phase)
 //

--- a/sdk/go/openshell/v1/fake/fake.go
+++ b/sdk/go/openshell/v1/fake/fake.go
@@ -15,12 +15,14 @@ import (
 // real gRPC connection. Create one with NewClient.
 type Client struct {
 	sandboxStore       *objectStore[*types.Sandbox]
+	templateStore      *objectStore[*types.SandboxTemplate]
 	providerStore      *objectStore[*types.Provider]
 	workspaceStore     *objectStore[*types.Workspace]
 	memberStore        *objectStore[*types.WorkspaceMember]
 	sandboxBroadcaster *watchBroadcaster[*types.Sandbox]
 
 	sandboxes  v1.SandboxInterface
+	templates  v1.SandboxTemplateInterface
 	providers  v1.ProviderInterface
 	services   v1.ServiceInterface
 	exec       v1.ExecInterface
@@ -70,13 +72,15 @@ func WithCurrentUser(user *types.CurrentUser) ClientOption {
 func NewClient(opts ...ClientOption) *Client {
 	fc := &Client{
 		sandboxStore:       newobjectStore(sandboxName, copySandbox),
+		templateStore:      newobjectStore(sandboxTemplateName, copySandboxTemplatePtr),
 		providerStore:      newobjectStore(providerName, copyProvider),
 		workspaceStore:     newobjectStore(workspaceName, copyWorkspace),
 		memberStore:        newobjectStore(memberName, copyMember),
 		sandboxBroadcaster: newWatchBroadcaster[*types.Sandbox](),
 	}
 
-	fc.sandboxes = newFakeSandboxClient(fc.sandboxStore, fc.sandboxBroadcaster, fc.isClosed)
+	fc.sandboxes = newFakeSandboxClient(fc.sandboxStore, fc.templateStore, fc.sandboxBroadcaster, fc.isClosed)
+	fc.templates = newFakeSandboxTemplateClient(fc.templateStore, fc.isClosed)
 	fc.providers = newFakeProviderClient(fc.providerStore, fc.isClosed)
 	fc.services = newFakeServiceClient(fc.isClosed)
 	fc.exec = newFakeExecClient(fc.isClosed)
@@ -106,6 +110,9 @@ func (fc *Client) isClosed() bool {
 
 // Sandboxes returns the sandbox sub-client.
 func (fc *Client) Sandboxes() v1.SandboxInterface { return fc.sandboxes }
+
+// SandboxTemplates returns the sandbox template sub-client.
+func (fc *Client) SandboxTemplates() v1.SandboxTemplateInterface { return fc.templates }
 
 // Providers returns the provider sub-client.
 func (fc *Client) Providers() v1.ProviderInterface { return fc.providers }

--- a/sdk/go/openshell/v1/fake/fake_test.go
+++ b/sdk/go/openshell/v1/fake/fake_test.go
@@ -130,7 +130,9 @@ func TestFakeClient_AddSandbox(t *testing.T) {
 
 	sb := &types.Sandbox{
 		Name: "pre-seeded",
-		Spec: types.SandboxSpec{LogLevel: "debug"},
+		Spec: types.SandboxSpec{
+			Workload: &types.SandboxWorkloadConfig{Image: "preseed:v1"},
+		},
 		Status: types.SandboxStatus{
 			Phase: types.SandboxReady,
 		},
@@ -141,7 +143,8 @@ func TestFakeClient_AddSandbox(t *testing.T) {
 	got, err := fc.Sandboxes().Get(ctx, "default", "pre-seeded")
 	require.NoError(t, err)
 	assert.Equal(t, "pre-seeded", got.Name)
-	assert.Equal(t, "debug", got.Spec.LogLevel)
+	require.NotNil(t, got.Spec.Workload)
+	assert.Equal(t, "preseed:v1", got.Spec.Workload.Image)
 	assert.Equal(t, types.SandboxReady, got.Status.Phase)
 }
 

--- a/sdk/go/openshell/v1/fake/fake_test.go
+++ b/sdk/go/openshell/v1/fake/fake_test.go
@@ -38,7 +38,18 @@ func TestFakeClient_Sandboxes_AfterClose(t *testing.T) {
 
 	_ = fc.Close()
 
-	_, err := fc.Sandboxes().Create(ctx, "default", "test", &types.SandboxSpec{}, nil)
+	_, err := fc.Sandboxes().Create(ctx, "default", "test", nil, nil, nil, nil)
+	require.Error(t, err)
+	assert.True(t, types.IsUnavailable(err))
+}
+
+func TestFakeClient_SandboxTemplates_AfterClose(t *testing.T) {
+	fc := NewClient()
+	ctx := context.Background()
+
+	_ = fc.Close()
+
+	_, err := fc.SandboxTemplates().Create(ctx, "default", &types.SandboxTemplate{Name: "gpu-kata"})
 	require.Error(t, err)
 	assert.True(t, types.IsUnavailable(err))
 }
@@ -116,6 +127,7 @@ func TestFakeClient_SubClients(t *testing.T) {
 	fc := NewClient()
 
 	assert.NotNil(t, fc.Sandboxes())
+	assert.NotNil(t, fc.SandboxTemplates())
 	assert.NotNil(t, fc.Providers())
 	assert.NotNil(t, fc.Exec())
 	assert.NotNil(t, fc.Files())

--- a/sdk/go/openshell/v1/fake/sandbox.go
+++ b/sdk/go/openshell/v1/fake/sandbox.go
@@ -32,24 +32,43 @@ func copySandbox(sb *types.Sandbox) *types.Sandbox {
 		t := *sb.DeletionTimestamp
 		cp.DeletionTimestamp = &t
 	}
+	if sb.CreatedFromTemplate != nil {
+		t := *sb.CreatedFromTemplate
+		cp.CreatedFromTemplate = &t
+	}
 	cp.Spec = copySandboxSpec(sb.Spec)
 	cp.Status = copySandboxStatus(sb.Status)
 	return &cp
 }
 
 func copySandboxSpec(s types.SandboxSpec) types.SandboxSpec {
-	s.Environment = copyStringMap(s.Environment)
+	s.Workload = copySandboxWorkloadConfig(s.Workload)
+	s.DriverConfig = copyAnyMap(s.DriverConfig)
 	s.Providers = copyStringSlice(s.Providers)
-	if s.Template != nil {
-		t := copySandboxTemplate(*s.Template)
-		s.Template = &t
-	}
-	if s.GPUCount != nil {
-		v := *s.GPUCount
-		s.GPUCount = &v
-	}
 	s.Policy = copySandboxPolicy(s.Policy)
 	return s
+}
+
+func copySandboxWorkloadConfig(w *types.SandboxWorkloadConfig) *types.SandboxWorkloadConfig {
+	if w == nil {
+		return nil
+	}
+	cp := *w
+	cp.Environment = copyStringMap(w.Environment)
+	cp.Resources = copySandboxResources(w.Resources)
+	return &cp
+}
+
+func copySandboxResources(r *types.SandboxResources) *types.SandboxResources {
+	if r == nil {
+		return nil
+	}
+	cp := *r
+	if r.GPUCount != nil {
+		v := *r.GPUCount
+		cp.GPUCount = &v
+	}
+	return &cp
 }
 
 // copySandboxPolicy returns a deep copy of a SandboxPolicy pointer.
@@ -185,14 +204,31 @@ func copyL7QueryMap(m map[string]types.L7QueryMatcher) map[string]types.L7QueryM
 func copySandboxTemplate(t types.SandboxTemplate) types.SandboxTemplate {
 	t.Labels = copyStringMap(t.Labels)
 	t.Annotations = copyStringMap(t.Annotations)
-	t.Environment = copyStringMap(t.Environment)
-	if t.UserNamespaces != nil {
-		v := *t.UserNamespaces
-		t.UserNamespaces = &v
+	if t.DeletionTimestamp != nil {
+		ts := *t.DeletionTimestamp
+		t.DeletionTimestamp = &ts
 	}
-	t.Resources = copyAnyMap(t.Resources)
-	t.DriverConfig = copyAnyMap(t.DriverConfig)
+	t.Spec = copySandboxTemplateSpec(t.Spec)
 	return t
+}
+
+func copySandboxTemplateSpec(s types.SandboxTemplateSpec) types.SandboxTemplateSpec {
+	s.Workload = copySandboxWorkloadConfig(s.Workload)
+	s.DriverConfig = copyAnyMap(s.DriverConfig)
+	s.DesiredServiceLevel = copySandboxServiceLevel(s.DesiredServiceLevel)
+	return s
+}
+
+func copySandboxServiceLevel(sl *types.SandboxServiceLevel) *types.SandboxServiceLevel {
+	if sl == nil {
+		return nil
+	}
+	cp := *sl
+	if sl.Startup != nil {
+		startup := *sl.Startup
+		cp.Startup = &startup
+	}
+	return &cp
 }
 
 func copyAnyMap(m map[string]any) map[string]any {

--- a/sdk/go/openshell/v1/fake/sandbox.go
+++ b/sdk/go/openshell/v1/fake/sandbox.go
@@ -291,47 +291,83 @@ func copyStringSlice(s []string) []string {
 // fakeSandboxClient implements v1.SandboxInterface backed by an in-memory
 // objectStore and watchBroadcaster.
 type fakeSandboxClient struct {
-	store       *objectStore[*types.Sandbox]
-	broadcaster *watchBroadcaster[*types.Sandbox]
-	closedFunc  func() bool
+	store         *objectStore[*types.Sandbox]
+	templateStore *objectStore[*types.SandboxTemplate]
+	broadcaster   *watchBroadcaster[*types.Sandbox]
+	closedFunc    func() bool
 }
 
 // newFakeSandboxClient creates a new fakeSandboxClient.
 func newFakeSandboxClient(
 	store *objectStore[*types.Sandbox],
+	templateStore *objectStore[*types.SandboxTemplate],
 	broadcaster *watchBroadcaster[*types.Sandbox],
 	closedFunc func() bool,
 ) *fakeSandboxClient {
 	return &fakeSandboxClient{
-		store:       store,
-		broadcaster: broadcaster,
-		closedFunc:  closedFunc,
+		store:         store,
+		templateStore: templateStore,
+		broadcaster:   broadcaster,
+		closedFunc:    closedFunc,
 	}
 }
 
-// Create creates a new sandbox with Provisioning phase.
-func (c *fakeSandboxClient) Create(_ context.Context, workspace, name string, spec *types.SandboxSpec, labels map[string]string, opts ...types.CreateOptions) (*types.Sandbox, error) {
+// Create creates a new sandbox from an inline workload with Provisioning phase.
+func (c *fakeSandboxClient) Create(_ context.Context, workspace, name string, workload *types.SandboxWorkloadConfig, policy *types.SandboxPolicy, providers []string, labels map[string]string, opts ...types.CreateOptions) (*types.Sandbox, error) {
+	spec := types.SandboxSpec{
+		Workload:  copySandboxWorkloadConfig(workload),
+		Providers: copyStringSlice(providers),
+		Policy:    copySandboxPolicy(policy),
+	}
+	return c.create(workspace, name, spec, nil, labels, opts...)
+}
+
+// CreateFromTemplate creates a new sandbox from a named template with Provisioning phase.
+func (c *fakeSandboxClient) CreateFromTemplate(_ context.Context, workspace, name, templateName string, policy *types.SandboxPolicy, providers []string, labels map[string]string, opts ...types.CreateOptions) (*types.Sandbox, error) {
+	if templateName == "" {
+		return nil, &types.StatusError{Code: types.ErrorInvalidArgument, Message: "template name is required"}
+	}
 	if c.closedFunc() {
 		return nil, &types.StatusError{Code: types.ErrorUnavailable, Message: "client is closed"}
 	}
-
-	if spec == nil {
-		spec = &types.SandboxSpec{}
+	if c.templateStore == nil {
+		return nil, &types.StatusError{Code: types.ErrorNotFound, Message: fmt.Sprintf("%s not found", templateName)}
 	}
+	template, err := c.templateStore.Get(workspace, templateName)
+	if err != nil {
+		return nil, err
+	}
+	spec := types.SandboxSpec{
+		Workload:     copySandboxWorkloadConfig(template.Spec.Workload),
+		DriverConfig: copyAnyMap(template.Spec.DriverConfig),
+		Providers:    copyStringSlice(providers),
+		Policy:       copySandboxPolicy(policy),
+	}
+	provenance := &types.SandboxTemplateProvenance{
+		Name:            template.Name,
+		ResourceVersion: fmt.Sprintf("%d", template.ResourceVersion),
+	}
+	return c.create(workspace, name, spec, provenance, labels, opts...)
+}
 
+func (c *fakeSandboxClient) create(workspace, name string, spec types.SandboxSpec, provenance *types.SandboxTemplateProvenance, labels map[string]string, opts ...types.CreateOptions) (*types.Sandbox, error) {
+	if c.closedFunc() {
+		return nil, &types.StatusError{Code: types.ErrorUnavailable, Message: "client is closed"}
+	}
 	var annotations map[string]string
 	if len(opts) > 0 {
 		annotations = copyStringMap(opts[0].Annotations)
 	}
 
 	sb := &types.Sandbox{
-		Name:            name,
-		Workspace:       workspace,
-		CreatedAt:       time.Now(),
-		Labels:          copyStringMap(labels),
-		Annotations:     annotations,
-		ResourceVersion: 1,
-		Spec:            copySandboxSpec(*spec),
+		Name:                name,
+		Workspace:           workspace,
+		CreatedAt:           time.Now(),
+		Labels:              copyStringMap(labels),
+		Annotations:         annotations,
+		ResourceVersion:     1,
+		CreatedFromTemplate: provenance,
+		Spec:                copySandboxSpec(spec),
 		Status: types.SandboxStatus{
 			SandboxName: name,
 			Phase:       types.SandboxProvisioning,

--- a/sdk/go/openshell/v1/fake/sandbox_template.go
+++ b/sdk/go/openshell/v1/fake/sandbox_template.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	"context"
+	"time"
+
+	v1 "github.com/NVIDIA/OpenShell/sdk/go/openshell/v1"
+	"github.com/NVIDIA/OpenShell/sdk/go/openshell/v1/types"
+)
+
+func sandboxTemplateName(template *types.SandboxTemplate) string {
+	return template.Name
+}
+
+func copySandboxTemplatePtr(template *types.SandboxTemplate) *types.SandboxTemplate {
+	if template == nil {
+		return nil
+	}
+	copied := copySandboxTemplate(*template)
+	return &copied
+}
+
+type fakeSandboxTemplateClient struct {
+	store      *objectStore[*types.SandboxTemplate]
+	closedFunc func() bool
+}
+
+func newFakeSandboxTemplateClient(
+	store *objectStore[*types.SandboxTemplate],
+	closedFunc func() bool,
+) *fakeSandboxTemplateClient {
+	return &fakeSandboxTemplateClient{
+		store:      store,
+		closedFunc: closedFunc,
+	}
+}
+
+func (c *fakeSandboxTemplateClient) Create(_ context.Context, workspace string, template *types.SandboxTemplate) (*types.SandboxTemplate, error) {
+	if c.closedFunc() {
+		return nil, &types.StatusError{Code: types.ErrorUnavailable, Message: "client is closed"}
+	}
+	if template == nil {
+		return nil, &types.StatusError{Code: types.ErrorInvalidArgument, Message: "template must not be nil"}
+	}
+
+	t := copySandboxTemplatePtr(template)
+	t.Workspace = workspace
+	t.CreatedAt = time.Now()
+	t.ResourceVersion = 1
+
+	return c.store.Create(workspace, t)
+}
+
+func (c *fakeSandboxTemplateClient) Get(_ context.Context, workspace, name string) (*types.SandboxTemplate, error) {
+	if c.closedFunc() {
+		return nil, &types.StatusError{Code: types.ErrorUnavailable, Message: "client is closed"}
+	}
+	return c.store.Get(workspace, name)
+}
+
+func (c *fakeSandboxTemplateClient) List(_ context.Context, workspace string, opts ...v1.ListOptions) ([]*types.SandboxTemplate, error) {
+	if c.closedFunc() {
+		return nil, &types.StatusError{Code: types.ErrorUnavailable, Message: "client is closed"}
+	}
+	if len(opts) > 0 && opts[0].AllWorkspaces {
+		return c.store.ListAll(), nil
+	}
+	return c.store.List(workspace), nil
+}
+
+func (c *fakeSandboxTemplateClient) Delete(_ context.Context, workspace, name string) error {
+	if c.closedFunc() {
+		return &types.StatusError{Code: types.ErrorUnavailable, Message: "client is closed"}
+	}
+	c.store.Delete(workspace, name)
+	return nil
+}

--- a/sdk/go/openshell/v1/fake/sandbox_template_test.go
+++ b/sdk/go/openshell/v1/fake/sandbox_template_test.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/OpenShell/sdk/go/openshell/v1/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSandboxTemplateClient() *fakeSandboxTemplateClient {
+	store := newobjectStore(sandboxTemplateName, copySandboxTemplatePtr)
+	return newFakeSandboxTemplateClient(store, func() bool { return false })
+}
+
+func TestSandboxTemplate_CreateGetListDelete(t *testing.T) {
+	tc := newTestSandboxTemplateClient()
+	ctx := context.Background()
+
+	template := &types.SandboxTemplate{
+		Name:   "gpu-kata",
+		Labels: map[string]string{"team": "platform"},
+		Spec: types.SandboxTemplateSpec{
+			Workload:     &types.SandboxWorkloadConfig{Image: "python:3.12"},
+			DriverConfig: map[string]any{"kubernetes": map[string]any{"runtime_class_name": "kata"}},
+			DesiredServiceLevel: &types.SandboxServiceLevel{
+				Startup: &types.SandboxStartup{ReadyWithin: 30 * time.Second, MaxBurst: 4},
+			},
+		},
+	}
+
+	created, err := tc.Create(ctx, "default", template)
+	require.NoError(t, err)
+	assert.Equal(t, "gpu-kata", created.Name)
+	assert.Equal(t, "default", created.Workspace)
+	assert.Equal(t, uint64(1), created.ResourceVersion)
+	assert.NotZero(t, created.CreatedAt)
+
+	got, err := tc.Get(ctx, "default", "gpu-kata")
+	require.NoError(t, err)
+	assert.Equal(t, "python:3.12", got.Spec.Workload.Image)
+	assert.Equal(t, "kata", got.Spec.DriverConfig["kubernetes"].(map[string]any)["runtime_class_name"])
+
+	listed, err := tc.List(ctx, "default")
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, "gpu-kata", listed[0].Name)
+
+	err = tc.Delete(ctx, "default", "gpu-kata")
+	require.NoError(t, err)
+	_, err = tc.Get(ctx, "default", "gpu-kata")
+	require.Error(t, err)
+	assert.True(t, types.IsNotFound(err))
+}
+
+func TestSandboxTemplate_CreateAlreadyExists(t *testing.T) {
+	tc := newTestSandboxTemplateClient()
+	ctx := context.Background()
+
+	template := &types.SandboxTemplate{Name: "gpu-kata"}
+	_, err := tc.Create(ctx, "default", template)
+	require.NoError(t, err)
+
+	_, err = tc.Create(ctx, "default", template)
+	require.Error(t, err)
+	assert.True(t, types.IsAlreadyExists(err))
+}
+
+func TestSandboxTemplate_ListAllWorkspaces(t *testing.T) {
+	tc := newTestSandboxTemplateClient()
+	ctx := context.Background()
+
+	_, _ = tc.Create(ctx, "default", &types.SandboxTemplate{Name: "default-template"})
+	_, _ = tc.Create(ctx, "team-a", &types.SandboxTemplate{Name: "team-template"})
+
+	listed, err := tc.List(ctx, "default", types.ListOptions{AllWorkspaces: true})
+	require.NoError(t, err)
+	assert.Len(t, listed, 2)
+}
+
+func TestSandboxTemplate_DeepCopy(t *testing.T) {
+	tc := newTestSandboxTemplateClient()
+	ctx := context.Background()
+
+	template := &types.SandboxTemplate{
+		Name: "gpu-kata",
+		Spec: types.SandboxTemplateSpec{
+			Workload: &types.SandboxWorkloadConfig{
+				Image:       "python:3.12",
+				Environment: map[string]string{"KEY": "value"},
+			},
+			DriverConfig: map[string]any{"kubernetes": map[string]any{"runtime_class_name": "kata"}},
+		},
+	}
+
+	created, err := tc.Create(ctx, "default", template)
+	require.NoError(t, err)
+
+	template.Spec.Workload.Image = "mutated"
+	template.Spec.Workload.Environment["KEY"] = "mutated"
+	template.Spec.DriverConfig["kubernetes"].(map[string]any)["runtime_class_name"] = "mutated"
+	created.Spec.Workload.Image = "mutated-return"
+
+	got, err := tc.Get(ctx, "default", "gpu-kata")
+	require.NoError(t, err)
+	assert.Equal(t, "python:3.12", got.Spec.Workload.Image)
+	assert.Equal(t, "value", got.Spec.Workload.Environment["KEY"])
+	assert.Equal(t, "kata", got.Spec.DriverConfig["kubernetes"].(map[string]any)["runtime_class_name"])
+}
+
+func TestSandboxTemplate_CreateNil(t *testing.T) {
+	tc := newTestSandboxTemplateClient()
+	ctx := context.Background()
+
+	_, err := tc.Create(ctx, "default", nil)
+	require.Error(t, err)
+	assert.True(t, types.IsInvalidArgument(err))
+}
+
+func TestSandboxTemplate_ClosedReturnsUnavailable(t *testing.T) {
+	store := newobjectStore(sandboxTemplateName, copySandboxTemplatePtr)
+	tc := newFakeSandboxTemplateClient(store, func() bool { return true })
+	ctx := context.Background()
+
+	_, err := tc.Create(ctx, "default", &types.SandboxTemplate{Name: "gpu-kata"})
+	require.Error(t, err)
+	assert.True(t, types.IsUnavailable(err))
+}

--- a/sdk/go/openshell/v1/fake/sandbox_test.go
+++ b/sdk/go/openshell/v1/fake/sandbox_test.go
@@ -20,8 +20,9 @@ import (
 // helper to build a minimal fake sandbox client for testing.
 func newTestSandboxClient() *fakeSandboxClient {
 	store := newobjectStore(sandboxName, copySandbox)
+	templateStore := newobjectStore(sandboxTemplateName, copySandboxTemplatePtr)
 	broadcaster := newWatchBroadcaster[*types.Sandbox]()
-	return newFakeSandboxClient(store, broadcaster, func() bool { return false })
+	return newFakeSandboxClient(store, templateStore, broadcaster, func() bool { return false })
 }
 
 // --- T008: Sandbox CRUD tests ---
@@ -30,9 +31,7 @@ func TestSandbox_Create(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	sb, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{
-		Workload: &types.SandboxWorkloadConfig{Image: "img:v1"},
-	}, map[string]string{"env": "test"})
+	sb, err := sc.Create(ctx, "default", "test-sb", &types.SandboxWorkloadConfig{Image: "img:v1"}, nil, nil, map[string]string{"env": "test"})
 	require.NoError(t, err)
 	assert.Equal(t, "test-sb", sb.Name)
 	require.NotNil(t, sb.Spec.Workload)
@@ -47,10 +46,10 @@ func TestSandbox_Create_AlreadyExists(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	_, err := sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	_, err = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	_, err = sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.Error(t, err)
 	assert.True(t, types.IsAlreadyExists(err))
 }
@@ -59,7 +58,7 @@ func TestSandbox_Create_WithAnnotations(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	sb, err := sc.Create(ctx, "default", "annotated", &types.SandboxSpec{}, nil,
+	sb, err := sc.Create(ctx, "default", "annotated", nil, nil, nil, nil,
 		types.CreateOptions{Annotations: map[string]string{"source": "cli", "user": "admin"}})
 	require.NoError(t, err)
 	assert.Equal(t, "cli", sb.Annotations["source"])
@@ -75,7 +74,7 @@ func TestSandbox_Create_WithAnnotationsDeepCopy(t *testing.T) {
 	ctx := context.Background()
 
 	input := map[string]string{"key": "original"}
-	sb, err := sc.Create(ctx, "default", "dc-test", &types.SandboxSpec{}, nil,
+	sb, err := sc.Create(ctx, "default", "dc-test", nil, nil, nil, nil,
 		types.CreateOptions{Annotations: input})
 	require.NoError(t, err)
 
@@ -87,7 +86,7 @@ func TestSandbox_Create_NoAnnotations(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	sb, err := sc.Create(ctx, "default", "no-ann", &types.SandboxSpec{}, nil)
+	sb, err := sc.Create(ctx, "default", "no-ann", nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Nil(t, sb.Annotations)
 }
@@ -165,22 +164,113 @@ func TestCopySandboxTemplate_ResourcesDeepCopy(t *testing.T) {
 	assert.Equal(t, "val", copiedNested["key"])
 }
 
-func TestSandbox_Create_NilSpec(t *testing.T) {
+func TestSandbox_Create_NilWorkload(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	sb, err := sc.Create(ctx, "default", "test-sb", nil, nil)
+	sb, err := sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "test-sb", sb.Name)
+}
+
+func TestSandbox_CreateFromTemplate(t *testing.T) {
+	sc := newTestSandboxClient()
+	ctx := context.Background()
+	gpuCount := uint32(1)
+	sc.templateStore.Insert("default", &types.SandboxTemplate{
+		Name:            "gpu-kata",
+		ResourceVersion: 7,
+		Spec: types.SandboxTemplateSpec{
+			Workload: &types.SandboxWorkloadConfig{
+				Image:       "python:3.12",
+				Environment: map[string]string{"MODE": "template"},
+				Resources: &types.SandboxResources{
+					CPU:      "2",
+					Memory:   "4Gi",
+					GPUCount: &gpuCount,
+				},
+			},
+			DriverConfig: map[string]any{
+				"kubernetes": map[string]any{"runtime_class_name": "kata"},
+			},
+		},
+	})
+
+	sb, err := sc.CreateFromTemplate(ctx, "default", "templated", "gpu-kata", nil, []string{"openai"}, map[string]string{"env": "test"})
+	require.NoError(t, err)
+	assert.Equal(t, "templated", sb.Name)
+	require.NotNil(t, sb.CreatedFromTemplate)
+	assert.Equal(t, "gpu-kata", sb.CreatedFromTemplate.Name)
+	assert.Equal(t, "7", sb.CreatedFromTemplate.ResourceVersion)
+	require.NotNil(t, sb.Spec.Workload)
+	assert.Equal(t, "python:3.12", sb.Spec.Workload.Image)
+	assert.Equal(t, "template", sb.Spec.Workload.Environment["MODE"])
+	require.NotNil(t, sb.Spec.Workload.Resources)
+	assert.Equal(t, "2", sb.Spec.Workload.Resources.CPU)
+	assert.Equal(t, "4Gi", sb.Spec.Workload.Resources.Memory)
+	require.NotNil(t, sb.Spec.Workload.Resources.GPUCount)
+	assert.Equal(t, uint32(1), *sb.Spec.Workload.Resources.GPUCount)
+	assert.Equal(t, "kata", sb.Spec.DriverConfig["kubernetes"].(map[string]any)["runtime_class_name"])
+	assert.Equal(t, []string{"openai"}, sb.Spec.Providers)
+	assert.Equal(t, "test", sb.Labels["env"])
+
+	storedTemplate, err := sc.templateStore.Get("default", "gpu-kata")
+	require.NoError(t, err)
+	storedTemplate.Spec.Workload.Image = "mutated"
+	storedTemplate.Spec.DriverConfig["kubernetes"].(map[string]any)["runtime_class_name"] = "mutated"
+	assert.Equal(t, "python:3.12", sb.Spec.Workload.Image)
+	assert.Equal(t, "kata", sb.Spec.DriverConfig["kubernetes"].(map[string]any)["runtime_class_name"])
+}
+
+func TestSandbox_CreateFromTemplate_EmptyTemplateName(t *testing.T) {
+	sc := newTestSandboxClient()
+	ctx := context.Background()
+
+	_, err := sc.CreateFromTemplate(ctx, "default", "templated", "", nil, nil, nil)
+	require.Error(t, err)
+	assert.True(t, types.IsInvalidArgument(err))
+}
+
+func TestSandbox_CreateFromTemplate_NotFound(t *testing.T) {
+	sc := newTestSandboxClient()
+	ctx := context.Background()
+
+	_, err := sc.CreateFromTemplate(ctx, "default", "templated", "missing-template", nil, nil, nil)
+	require.Error(t, err)
+	assert.True(t, types.IsNotFound(err))
+}
+
+func TestSandbox_CreateFromTemplate_UsesWorkspaceScopedTemplate(t *testing.T) {
+	sc := newTestSandboxClient()
+	ctx := context.Background()
+
+	sc.templateStore.Insert("team-a", &types.SandboxTemplate{
+		Name:            "gpu-kata",
+		ResourceVersion: 3,
+		Spec: types.SandboxTemplateSpec{
+			Workload:     &types.SandboxWorkloadConfig{Image: "team-a:latest"},
+			DriverConfig: map[string]any{"kubernetes": map[string]any{"runtime_class_name": "team-a"}},
+		},
+	})
+
+	_, err := sc.CreateFromTemplate(ctx, "default", "templated", "gpu-kata", nil, nil, nil)
+	require.Error(t, err)
+	assert.True(t, types.IsNotFound(err))
+
+	sb, err := sc.CreateFromTemplate(ctx, "team-a", "templated", "gpu-kata", nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, sb.Spec.Workload)
+	assert.Equal(t, "team-a:latest", sb.Spec.Workload.Image)
+	require.NotNil(t, sb.CreatedFromTemplate)
+	assert.Equal(t, "3", sb.CreatedFromTemplate.ResourceVersion)
+	assert.Equal(t, "team-a", sb.Spec.DriverConfig["kubernetes"].(map[string]any)["runtime_class_name"])
 }
 
 func TestSandbox_Get(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{
-		Workload: &types.SandboxWorkloadConfig{Image: "img:v1"},
-	}, nil)
+	_, err := sc.Create(ctx, "default", "test-sb", &types.SandboxWorkloadConfig{Image: "img:v1"}, nil, nil, nil)
 	require.NoError(t, err)
 
 	got, err := sc.Get(ctx, "default", "test-sb")
@@ -212,8 +302,8 @@ func TestSandbox_List(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, _ = sc.Create(ctx, "default", "sb-1", &types.SandboxSpec{}, nil)
-	_, _ = sc.Create(ctx, "default", "sb-2", &types.SandboxSpec{}, nil)
+	_, _ = sc.Create(ctx, "default", "sb-1", nil, nil, nil, nil)
+	_, _ = sc.Create(ctx, "default", "sb-2", nil, nil, nil, nil)
 
 	list, err := sc.List(ctx, "default")
 	require.NoError(t, err)
@@ -224,7 +314,7 @@ func TestSandbox_Delete(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, _ = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	_, _ = sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 
 	err := sc.Delete(ctx, "default", "test-sb")
 	require.NoError(t, err)
@@ -255,7 +345,7 @@ func TestSandbox_DeepCopy_OnCreate(t *testing.T) {
 		},
 	}
 
-	sb, err := sc.Create(ctx, "default", "test-sb", spec, labels)
+	sb, err := sc.Create(ctx, "default", "test-sb", spec.Workload, spec.Policy, spec.Providers, labels)
 	require.NoError(t, err)
 
 	// Mutating inputs should not affect stored object
@@ -281,11 +371,9 @@ func TestSandbox_DeepCopy_OnGet(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, _ = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{
-		Workload: &types.SandboxWorkloadConfig{
-			Environment: map[string]string{"KEY": "value"},
-		},
-	}, nil)
+	_, _ = sc.Create(ctx, "default", "test-sb", &types.SandboxWorkloadConfig{
+		Environment: map[string]string{"KEY": "value"},
+	}, nil, nil, nil)
 
 	got, err := sc.Get(ctx, "default", "test-sb")
 	require.NoError(t, err)
@@ -303,7 +391,7 @@ func TestSandbox_WaitReady(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	_, err := sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	sb, err := sc.WaitReady(ctx, "default", "test-sb")
@@ -328,7 +416,7 @@ func TestSandbox_WaitReady_NotFound(t *testing.T) {
 func TestSandbox_WaitReady_ContextCancellation(t *testing.T) {
 	sc := newTestSandboxClient()
 
-	_, err := sc.Create(context.Background(), "default", "test-sb", &types.SandboxSpec{}, nil)
+	_, err := sc.Create(context.Background(), "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -343,7 +431,7 @@ func TestSandbox_WaitReady_ContextCancellation(t *testing.T) {
 func TestSandbox_WaitReady_ContextDeadlineExceeded(t *testing.T) {
 	sc := newTestSandboxClient()
 
-	_, err := sc.Create(context.Background(), "default", "test-sb", &types.SandboxSpec{}, nil)
+	_, err := sc.Create(context.Background(), "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
@@ -358,7 +446,7 @@ func TestSandbox_WaitReady_AlreadyReady(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, _ = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	_, _ = sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 
 	// Make it ready
 	_, err := sc.WaitReady(ctx, "default", "test-sb")
@@ -374,7 +462,7 @@ func TestSandbox_WaitReady_IncrementsResourceVersion(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	created, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	created, err := sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 	initialVersion := created.ResourceVersion
 
@@ -386,7 +474,7 @@ func TestSandbox_WaitReady_IncrementsResourceVersion(t *testing.T) {
 func TestSandbox_WaitReady_ContextTimeout(t *testing.T) {
 	sc := newTestSandboxClient()
 
-	_, err := sc.Create(context.Background(), "default", "test-sb", &types.SandboxSpec{}, nil)
+	_, err := sc.Create(context.Background(), "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
@@ -410,9 +498,7 @@ func TestSandbox_Watch_AddedOnCreate(t *testing.T) {
 	require.NoError(t, err)
 	defer w.Stop()
 
-	_, err = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{
-		Workload: &types.SandboxWorkloadConfig{Image: "watch:v1"},
-	}, nil)
+	_, err = sc.Create(ctx, "default", "test-sb", &types.SandboxWorkloadConfig{Image: "watch:v1"}, nil, nil, nil)
 	require.NoError(t, err)
 
 	select {
@@ -430,7 +516,7 @@ func TestSandbox_Watch_DeletedOnDelete(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, _ = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	_, _ = sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 
 	w, err := sc.Watch(ctx, "default", "")
 	require.NoError(t, err)
@@ -452,7 +538,7 @@ func TestSandbox_Watch_ModifiedOnWaitReady(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, _ = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	_, _ = sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 
 	w, err := sc.Watch(ctx, "default", "")
 	require.NoError(t, err)
@@ -480,10 +566,10 @@ func TestSandbox_Watch_NameFiltering(t *testing.T) {
 	defer w.Stop()
 
 	// Create "beta" — should not be received
-	_, _ = sc.Create(ctx, "default", "beta", &types.SandboxSpec{}, nil)
+	_, _ = sc.Create(ctx, "default", "beta", nil, nil, nil, nil)
 
 	// Create "alpha" — should be received
-	_, _ = sc.Create(ctx, "default", "alpha", &types.SandboxSpec{}, nil)
+	_, _ = sc.Create(ctx, "default", "alpha", nil, nil, nil, nil)
 
 	select {
 	case ev := <-w.ResultChan():
@@ -506,7 +592,7 @@ func TestSandbox_Watch_MultipleWatchers(t *testing.T) {
 	require.NoError(t, err)
 	defer w2.Stop()
 
-	_, _ = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	_, _ = sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 
 	for _, w := range []types.WatchInterface[*types.Sandbox]{w1, w2} {
 		select {
@@ -536,9 +622,7 @@ func TestSandbox_Watch_DeletedEventContainsFullObject(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, _ = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{
-		Workload: &types.SandboxWorkloadConfig{Image: "deleted:v1"},
-	}, map[string]string{"env": "test"})
+	_, _ = sc.Create(ctx, "default", "test-sb", &types.SandboxWorkloadConfig{Image: "deleted:v1"}, nil, nil, map[string]string{"env": "test"})
 
 	w, err := sc.Watch(ctx, "default", "")
 	require.NoError(t, err)
@@ -587,9 +671,7 @@ func TestSandbox_ConcurrentCreateGetDeleteWatch(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < opsPerGoroutine; j++ {
 				name := fmt.Sprintf("sb-%d-%d", id, j)
-				_, _ = sc.Create(ctx, "default", name, &types.SandboxSpec{
-					Workload: &types.SandboxWorkloadConfig{Image: "concurrent:v1"},
-				}, nil)
+				_, _ = sc.Create(ctx, "default", name, &types.SandboxWorkloadConfig{Image: "concurrent:v1"}, nil, nil, nil)
 				_, _ = sc.Get(ctx, "default", name)
 				_, _ = sc.List(ctx, "default")
 				_, _ = sc.WaitReady(ctx, "default", name)
@@ -610,7 +692,7 @@ func TestSandbox_AttachProvider(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	sb, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	sb, err := sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	result, err := sc.AttachProvider(ctx, "default", "test-sb", "openai", sb.ResourceVersion)
@@ -624,7 +706,7 @@ func TestSandbox_AttachProvider_AlreadyAttached(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	sb, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	sb, err := sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	result, err := sc.AttachProvider(ctx, "default", "test-sb", "openai", sb.ResourceVersion)
@@ -650,7 +732,7 @@ func TestSandbox_DetachProvider(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	sb, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	sb, err := sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	result, err := sc.AttachProvider(ctx, "default", "test-sb", "openai", sb.ResourceVersion)
@@ -666,7 +748,7 @@ func TestSandbox_DetachProvider_NotAttached(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	sb, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	sb, err := sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	result, err := sc.DetachProvider(ctx, "default", "test-sb", "openai", sb.ResourceVersion)
@@ -687,7 +769,7 @@ func TestSandbox_ListProviders(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	sb, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	sb, err := sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// No providers yet
@@ -727,7 +809,7 @@ func TestSandbox_AttachProvider_BroadcastsModified(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	sb, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	sb, err := sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	w, err := sc.Watch(ctx, "default", "")
@@ -752,7 +834,7 @@ func TestSandbox_Watch_StopOnTerminal_Ready(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	_, err := sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	w, err := sc.Watch(ctx, "default", "test-sb", v1.WatchOptions{StopOnTerminal: true})
@@ -777,7 +859,7 @@ func TestSandbox_Watch_StopOnTerminal_Error(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	sb, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	sb, err := sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	w, err := sc.Watch(ctx, "default", "test-sb", v1.WatchOptions{StopOnTerminal: true})
@@ -807,7 +889,7 @@ func TestSandbox_Watch_StopOnTerminal_False_DoesNotClose(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{}, nil)
+	_, err := sc.Create(ctx, "default", "test-sb", nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Watch WITHOUT StopOnTerminal
@@ -872,7 +954,7 @@ func TestFakeSandboxCreateWithPolicy(t *testing.T) {
 		},
 	}
 
-	created, err := sc.Create(ctx, "default", "policy-sb", spec, nil)
+	created, err := sc.Create(ctx, "default", "policy-sb", spec.Workload, spec.Policy, spec.Providers, nil)
 	require.NoError(t, err)
 
 	// Verify created sandbox has policy
@@ -929,9 +1011,7 @@ func TestFakeSandboxCreateWithNilPolicy(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	created, err := sc.Create(ctx, "default", "no-policy-sb", &types.SandboxSpec{
-		Workload: &types.SandboxWorkloadConfig{Image: "no-policy:v1"},
-	}, nil)
+	created, err := sc.Create(ctx, "default", "no-policy-sb", &types.SandboxWorkloadConfig{Image: "no-policy:v1"}, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Nil(t, created.Spec.Policy)
 
@@ -951,8 +1031,9 @@ func TestSandbox_GetLogs_ReturnsUnimplemented(t *testing.T) {
 
 func TestSandbox_GetLogs_ClosedReturnsUnavailable(t *testing.T) {
 	store := newobjectStore(sandboxName, copySandbox)
+	templateStore := newobjectStore(sandboxTemplateName, copySandboxTemplatePtr)
 	broadcaster := newWatchBroadcaster[*types.Sandbox]()
-	sc := newFakeSandboxClient(store, broadcaster, func() bool { return true })
+	sc := newFakeSandboxClient(store, templateStore, broadcaster, func() bool { return true })
 	_, err := sc.GetLogs(context.Background(), "default", "sb-1")
 	require.Error(t, err)
 	assert.True(t, types.IsUnavailable(err))

--- a/sdk/go/openshell/v1/fake/sandbox_test.go
+++ b/sdk/go/openshell/v1/fake/sandbox_test.go
@@ -30,10 +30,13 @@ func TestSandbox_Create(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	sb, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{LogLevel: "debug"}, map[string]string{"env": "test"})
+	sb, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{
+		Workload: &types.SandboxWorkloadConfig{Image: "img:v1"},
+	}, map[string]string{"env": "test"})
 	require.NoError(t, err)
 	assert.Equal(t, "test-sb", sb.Name)
-	assert.Equal(t, "debug", sb.Spec.LogLevel)
+	require.NotNil(t, sb.Spec.Workload)
+	assert.Equal(t, "img:v1", sb.Spec.Workload.Image)
 	assert.Equal(t, "test", sb.Labels["env"])
 	assert.Equal(t, types.SandboxProvisioning, sb.Status.Phase)
 	assert.NotZero(t, sb.CreatedAt)
@@ -137,22 +140,28 @@ func TestCopyAnyMap(t *testing.T) {
 
 func TestCopySandboxTemplate_ResourcesDeepCopy(t *testing.T) {
 	tmpl := types.SandboxTemplate{
-		Image:        "img:v1",
-		Resources:    map[string]any{"cpu": "2", "nested": map[string]any{"key": "val"}},
-		DriverConfig: map[string]any{"runtime": "kata"},
+		Spec: types.SandboxTemplateSpec{
+			Workload: &types.SandboxWorkloadConfig{
+				Image: "img:v1",
+				Resources: &types.SandboxResources{
+					CPU: "2",
+				},
+			},
+			DriverConfig: map[string]any{"runtime": "kata", "nested": map[string]any{"key": "val"}},
+		},
 	}
 
 	copied := copySandboxTemplate(tmpl)
 
-	tmpl.Resources["cpu"] = "MUTATED"
-	assert.Equal(t, "2", copied.Resources["cpu"])
+	tmpl.Spec.Workload.Resources.CPU = "MUTATED"
+	assert.Equal(t, "2", copied.Spec.Workload.Resources.CPU)
 
-	tmpl.DriverConfig["runtime"] = "MUTATED"
-	assert.Equal(t, "kata", copied.DriverConfig["runtime"])
+	tmpl.Spec.DriverConfig["runtime"] = "MUTATED"
+	assert.Equal(t, "kata", copied.Spec.DriverConfig["runtime"])
 
-	nested := tmpl.Resources["nested"].(map[string]any)
+	nested := tmpl.Spec.DriverConfig["nested"].(map[string]any)
 	nested["key"] = "MUTATED"
-	copiedNested := copied.Resources["nested"].(map[string]any)
+	copiedNested := copied.Spec.DriverConfig["nested"].(map[string]any)
 	assert.Equal(t, "val", copiedNested["key"])
 }
 
@@ -169,13 +178,16 @@ func TestSandbox_Get(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{LogLevel: "info"}, nil)
+	_, err := sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{
+		Workload: &types.SandboxWorkloadConfig{Image: "img:v1"},
+	}, nil)
 	require.NoError(t, err)
 
 	got, err := sc.Get(ctx, "default", "test-sb")
 	require.NoError(t, err)
 	assert.Equal(t, "test-sb", got.Name)
-	assert.Equal(t, "info", got.Spec.LogLevel)
+	require.NotNil(t, got.Spec.Workload)
+	assert.Equal(t, "img:v1", got.Spec.Workload.Image)
 }
 
 func TestSandbox_Get_NotFound(t *testing.T) {
@@ -237,8 +249,10 @@ func TestSandbox_DeepCopy_OnCreate(t *testing.T) {
 
 	labels := map[string]string{"env": "test"}
 	spec := &types.SandboxSpec{
-		LogLevel:    "debug",
-		Environment: map[string]string{"KEY": "value"},
+		Workload: &types.SandboxWorkloadConfig{
+			Image:       "img:v1",
+			Environment: map[string]string{"KEY": "value"},
+		},
 	}
 
 	sb, err := sc.Create(ctx, "default", "test-sb", spec, labels)
@@ -246,14 +260,15 @@ func TestSandbox_DeepCopy_OnCreate(t *testing.T) {
 
 	// Mutating inputs should not affect stored object
 	labels["env"] = "mutated"
-	spec.LogLevel = "mutated"
-	spec.Environment["KEY"] = "mutated"
+	spec.Workload.Image = "mutated"
+	spec.Workload.Environment["KEY"] = "mutated"
 
 	got, err := sc.Get(ctx, "default", "test-sb")
 	require.NoError(t, err)
 	assert.Equal(t, "test", got.Labels["env"])
-	assert.Equal(t, "debug", got.Spec.LogLevel)
-	assert.Equal(t, "value", got.Spec.Environment["KEY"])
+	require.NotNil(t, got.Spec.Workload)
+	assert.Equal(t, "img:v1", got.Spec.Workload.Image)
+	assert.Equal(t, "value", got.Spec.Workload.Environment["KEY"])
 
 	// Mutating returned object should not affect stored object
 	sb.Labels["env"] = "mutated-return"
@@ -267,17 +282,19 @@ func TestSandbox_DeepCopy_OnGet(t *testing.T) {
 	ctx := context.Background()
 
 	_, _ = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{
-		Environment: map[string]string{"KEY": "value"},
+		Workload: &types.SandboxWorkloadConfig{
+			Environment: map[string]string{"KEY": "value"},
+		},
 	}, nil)
 
 	got, err := sc.Get(ctx, "default", "test-sb")
 	require.NoError(t, err)
 
-	got.Spec.Environment["KEY"] = "mutated"
+	got.Spec.Workload.Environment["KEY"] = "mutated"
 
 	got2, err := sc.Get(ctx, "default", "test-sb")
 	require.NoError(t, err)
-	assert.Equal(t, "value", got2.Spec.Environment["KEY"])
+	assert.Equal(t, "value", got2.Spec.Workload.Environment["KEY"])
 }
 
 // --- T009: WaitReady tests ---
@@ -393,14 +410,17 @@ func TestSandbox_Watch_AddedOnCreate(t *testing.T) {
 	require.NoError(t, err)
 	defer w.Stop()
 
-	_, err = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{LogLevel: "info"}, nil)
+	_, err = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{
+		Workload: &types.SandboxWorkloadConfig{Image: "watch:v1"},
+	}, nil)
 	require.NoError(t, err)
 
 	select {
 	case ev := <-w.ResultChan():
 		assert.Equal(t, types.EventAdded, ev.Type)
 		assert.Equal(t, "test-sb", ev.Object.Name)
-		assert.Equal(t, "info", ev.Object.Spec.LogLevel)
+		require.NotNil(t, ev.Object.Spec.Workload)
+		assert.Equal(t, "watch:v1", ev.Object.Spec.Workload.Image)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for ADDED event")
 	}
@@ -516,7 +536,9 @@ func TestSandbox_Watch_DeletedEventContainsFullObject(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	_, _ = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{LogLevel: "debug"}, map[string]string{"env": "test"})
+	_, _ = sc.Create(ctx, "default", "test-sb", &types.SandboxSpec{
+		Workload: &types.SandboxWorkloadConfig{Image: "deleted:v1"},
+	}, map[string]string{"env": "test"})
 
 	w, err := sc.Watch(ctx, "default", "")
 	require.NoError(t, err)
@@ -528,7 +550,8 @@ func TestSandbox_Watch_DeletedEventContainsFullObject(t *testing.T) {
 	case ev := <-w.ResultChan():
 		assert.Equal(t, types.EventDeleted, ev.Type)
 		// Verify the DELETED event contains the full last-known object
-		assert.Equal(t, "debug", ev.Object.Spec.LogLevel)
+		require.NotNil(t, ev.Object.Spec.Workload)
+		assert.Equal(t, "deleted:v1", ev.Object.Spec.Workload.Image)
 		assert.Equal(t, "test", ev.Object.Labels["env"])
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for DELETED event")
@@ -564,7 +587,9 @@ func TestSandbox_ConcurrentCreateGetDeleteWatch(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < opsPerGoroutine; j++ {
 				name := fmt.Sprintf("sb-%d-%d", id, j)
-				_, _ = sc.Create(ctx, "default", name, &types.SandboxSpec{LogLevel: "info"}, nil)
+				_, _ = sc.Create(ctx, "default", name, &types.SandboxSpec{
+					Workload: &types.SandboxWorkloadConfig{Image: "concurrent:v1"},
+				}, nil)
 				_, _ = sc.Get(ctx, "default", name)
 				_, _ = sc.List(ctx, "default")
 				_, _ = sc.WaitReady(ctx, "default", name)
@@ -821,7 +846,7 @@ func TestFakeSandboxCreateWithPolicy(t *testing.T) {
 	ctx := context.Background()
 
 	spec := &types.SandboxSpec{
-		LogLevel: "debug",
+		Workload: &types.SandboxWorkloadConfig{Image: "policy:v1"},
 		Policy: &types.SandboxPolicy{
 			Version: 3,
 			Filesystem: &types.FilesystemPolicy{
@@ -904,7 +929,9 @@ func TestFakeSandboxCreateWithNilPolicy(t *testing.T) {
 	sc := newTestSandboxClient()
 	ctx := context.Background()
 
-	created, err := sc.Create(ctx, "default", "no-policy-sb", &types.SandboxSpec{LogLevel: "info"}, nil)
+	created, err := sc.Create(ctx, "default", "no-policy-sb", &types.SandboxSpec{
+		Workload: &types.SandboxWorkloadConfig{Image: "no-policy:v1"},
+	}, nil)
 	require.NoError(t, err)
 	assert.Nil(t, created.Spec.Policy)
 

--- a/sdk/go/openshell/v1/integration_test.go
+++ b/sdk/go/openshell/v1/integration_test.go
@@ -50,9 +50,7 @@ func TestIntegration_SandboxExecSmoke(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	_, err = client.Sandboxes().Create(ctx, "default", name, &SandboxSpec{
-		Template: &SandboxTemplate{Image: image},
-	}, nil)
+	_, err = client.Sandboxes().Create(ctx, "default", name, &SandboxWorkloadConfig{Image: image}, nil, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Minute)

--- a/sdk/go/openshell/v1/internal/converter/coverage_test.go
+++ b/sdk/go/openshell/v1/internal/converter/coverage_test.go
@@ -23,31 +23,78 @@ import (
 
 func TestConverterCoversAllProtoFields_SandboxSpec(t *testing.T) {
 	handled := fieldSet{
-		"log_level":             true,
-		"environment":           true,
-		"template":              true,
-		"policy":                true,
-		"providers":             true,
-		"resource_requirements": true,
+		"workload":      true,
+		"driver_config": true,
+		"policy":        true,
+		"providers":     true,
 	}
 
 	assertAllFieldsCovered(t, (&pb.SandboxSpec{}).ProtoReflect().Descriptor(), handled, nil)
 }
 
+func TestConverterCoversAllProtoFields_SandboxWorkloadConfig(t *testing.T) {
+	handled := fieldSet{
+		"image":       true,
+		"environment": true,
+		"resources":   true,
+	}
+
+	assertAllFieldsCovered(t, (&pb.SandboxWorkloadConfig{}).ProtoReflect().Descriptor(), handled, nil)
+}
+
+func TestConverterCoversAllProtoFields_SandboxResources(t *testing.T) {
+	handled := fieldSet{
+		"cpu":       true,
+		"memory":    true,
+		"gpu_count": true,
+	}
+
+	assertAllFieldsCovered(t, (&pb.SandboxResources{}).ProtoReflect().Descriptor(), handled, nil)
+}
+
 func TestConverterCoversAllProtoFields_SandboxTemplate(t *testing.T) {
 	handled := fieldSet{
-		"image":              true,
-		"runtime_class_name": true,
-		"agent_socket":       true,
-		"labels":             true,
-		"annotations":        true,
-		"environment":        true,
-		"resources":          true,
-		"user_namespaces":    true,
-		"driver_config":      true,
+		"metadata": true,
+		"spec":     true,
 	}
 
 	assertAllFieldsCovered(t, (&pb.SandboxTemplate{}).ProtoReflect().Descriptor(), handled, nil)
+}
+
+func TestConverterCoversAllProtoFields_SandboxTemplateSpec(t *testing.T) {
+	handled := fieldSet{
+		"workload":              true,
+		"driver_config":         true,
+		"desired_service_level": true,
+	}
+
+	assertAllFieldsCovered(t, (&pb.SandboxTemplateSpec{}).ProtoReflect().Descriptor(), handled, nil)
+}
+
+func TestConverterCoversAllProtoFields_SandboxServiceLevel(t *testing.T) {
+	handled := fieldSet{
+		"startup": true,
+	}
+
+	assertAllFieldsCovered(t, (&pb.SandboxServiceLevel{}).ProtoReflect().Descriptor(), handled, nil)
+}
+
+func TestConverterCoversAllProtoFields_SandboxStartup(t *testing.T) {
+	handled := fieldSet{
+		"ready_within": true,
+		"max_burst":    true,
+	}
+
+	assertAllFieldsCovered(t, (&pb.SandboxStartup{}).ProtoReflect().Descriptor(), handled, nil)
+}
+
+func TestConverterCoversAllProtoFields_SandboxTemplateProvenance(t *testing.T) {
+	handled := fieldSet{
+		"name":             true,
+		"resource_version": true,
+	}
+
+	assertAllFieldsCovered(t, (&pb.SandboxTemplateProvenance{}).ProtoReflect().Descriptor(), handled, nil)
 }
 
 func TestConverterCoversAllProtoFields_SandboxStatus(t *testing.T) {

--- a/sdk/go/openshell/v1/internal/converter/sandbox.go
+++ b/sdk/go/openshell/v1/internal/converter/sandbox.go
@@ -212,6 +212,11 @@ func SandboxSpecToProtoChecked(spec *types.SandboxSpec) (*pb.SandboxSpec, error)
 	return SandboxSpecToProto(spec)
 }
 
+// SandboxWorkloadToProto converts an SDK SandboxWorkloadConfig to proto.
+func SandboxWorkloadToProto(workload *types.SandboxWorkloadConfig) *pb.SandboxWorkloadConfig {
+	return sandboxWorkloadToProto(workload)
+}
+
 func sandboxWorkloadToProto(workload *types.SandboxWorkloadConfig) *pb.SandboxWorkloadConfig {
 	if workload == nil {
 		return nil

--- a/sdk/go/openshell/v1/internal/converter/sandbox.go
+++ b/sdk/go/openshell/v1/internal/converter/sandbox.go
@@ -5,10 +5,12 @@ package converter
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/NVIDIA/OpenShell/sdk/go/openshell/v1/types"
 	dm "github.com/NVIDIA/OpenShell/sdk/go/proto/datamodelv1"
 	pb "github.com/NVIDIA/OpenShell/sdk/go/proto/openshellv1"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -30,6 +32,12 @@ func SandboxFromProto(s *pb.Sandbox) *types.Sandbox {
 		result.Workspace = m.GetWorkspace()
 		result.DeletionTimestamp = TimeFromMillisPtr(m.GetDeletionTimestampMs())
 	}
+	if provenance := s.GetCreatedFromTemplate(); provenance != nil {
+		result.CreatedFromTemplate = &types.SandboxTemplateProvenance{
+			Name:            provenance.GetName(),
+			ResourceVersion: provenance.GetResourceVersion(),
+		}
+	}
 
 	if spec := s.GetSpec(); spec != nil {
 		result.Spec = sandboxSpecFromProto(spec)
@@ -46,38 +54,35 @@ func SandboxFromProto(s *pb.Sandbox) *types.Sandbox {
 
 func sandboxSpecFromProto(spec *pb.SandboxSpec) types.SandboxSpec {
 	result := types.SandboxSpec{
-		LogLevel:    spec.GetLogLevel(),
-		Environment: CopyStringMap(spec.GetEnvironment()),
-		Providers:   CopyStringSlice(spec.GetProviders()),
-		Policy:      SandboxPolicyFromProto(spec.GetPolicy()),
-	}
-
-	if tmpl := spec.GetTemplate(); tmpl != nil {
-		t := &types.SandboxTemplate{
-			Image:            tmpl.GetImage(),
-			RuntimeClassName: tmpl.GetRuntimeClassName(),
-			AgentSocket:      tmpl.GetAgentSocket(),
-			Labels:           CopyStringMap(tmpl.GetLabels()),
-			Annotations:      CopyStringMap(tmpl.GetAnnotations()),
-			Environment:      CopyStringMap(tmpl.GetEnvironment()),
-			UserNamespaces:   CopyBoolPtr(tmpl.UserNamespaces),
-		}
-		if res := tmpl.GetResources(); res != nil {
-			t.Resources = res.AsMap()
-		}
-		if dc := tmpl.GetDriverConfig(); dc != nil {
-			t.DriverConfig = dc.AsMap()
-		}
-		result.Template = t
-	}
-
-	if rr := spec.GetResourceRequirements(); rr != nil {
-		if gpu := rr.GetGpu(); gpu != nil && gpu.Count != nil {
-			result.GPUCount = gpu.Count
-		}
+		Workload:     sandboxWorkloadFromProto(spec.GetWorkload()),
+		DriverConfig: structToMap(spec.GetDriverConfig()),
+		Providers:    CopyStringSlice(spec.GetProviders()),
+		Policy:       SandboxPolicyFromProto(spec.GetPolicy()),
 	}
 
 	return result
+}
+
+func sandboxWorkloadFromProto(workload *pb.SandboxWorkloadConfig) *types.SandboxWorkloadConfig {
+	if workload == nil {
+		return nil
+	}
+	return &types.SandboxWorkloadConfig{
+		Image:       workload.GetImage(),
+		Environment: CopyStringMap(workload.GetEnvironment()),
+		Resources:   sandboxResourcesFromProto(workload.GetResources()),
+	}
+}
+
+func sandboxResourcesFromProto(resources *pb.SandboxResources) *types.SandboxResources {
+	if resources == nil {
+		return nil
+	}
+	return &types.SandboxResources{
+		CPU:      resources.GetCpu(),
+		Memory:   resources.GetMemory(),
+		GPUCount: resources.GpuCount,
+	}
 }
 
 func sandboxStatusFromProto(status *pb.SandboxStatus) types.SandboxStatus {
@@ -152,9 +157,13 @@ func SandboxPhaseToProto(phase types.SandboxPhase) pb.SandboxPhase {
 }
 
 // SandboxToProto converts an SDK Sandbox to a proto Sandbox.
-func SandboxToProto(s *types.Sandbox) *pb.Sandbox {
+func SandboxToProto(s *types.Sandbox) (*pb.Sandbox, error) {
 	if s == nil {
-		return nil
+		return nil, nil
+	}
+	spec, err := SandboxSpecToProto(&s.Spec)
+	if err != nil {
+		return nil, err
 	}
 
 	return &pb.Sandbox{
@@ -168,89 +177,205 @@ func SandboxToProto(s *types.Sandbox) *pb.Sandbox {
 			Workspace:           s.Workspace,
 			DeletionTimestampMs: MillisFromTimePtr(s.DeletionTimestamp),
 		},
-		Spec: SandboxSpecToProto(&s.Spec),
-	}
+		CreatedFromTemplate: sandboxTemplateProvenanceToProto(s.CreatedFromTemplate),
+		Spec:                spec,
+	}, nil
 }
 
 // SandboxSpecToProto converts an SDK SandboxSpec to a proto SandboxSpec.
-func SandboxSpecToProto(spec *types.SandboxSpec) *pb.SandboxSpec {
+func SandboxSpecToProto(spec *types.SandboxSpec) (*pb.SandboxSpec, error) {
 	if spec == nil {
-		return nil
+		return nil, nil
 	}
 
-	result := &pb.SandboxSpec{
-		LogLevel:    spec.LogLevel,
-		Environment: CopyStringMap(spec.Environment),
-		Providers:   CopyStringSlice(spec.Providers),
-		Policy:      SandboxPolicyToProto(spec.Policy),
-	}
-
-	if spec.Template != nil {
-		tmpl := &pb.SandboxTemplate{
-			Image:            spec.Template.Image,
-			RuntimeClassName: spec.Template.RuntimeClassName,
-			AgentSocket:      spec.Template.AgentSocket,
-			Labels:           CopyStringMap(spec.Template.Labels),
-			Annotations:      CopyStringMap(spec.Template.Annotations),
-			Environment:      CopyStringMap(spec.Template.Environment),
-			UserNamespaces:   CopyBoolPtr(spec.Template.UserNamespaces),
-		}
-		if spec.Template.Resources != nil {
-			// Non-JSON-compatible values (e.g., chan, func) are silently dropped.
-			// Round-trip data from structpb.AsMap is always re-serializable.
-			s, err := structpb.NewStruct(spec.Template.Resources)
-			if err == nil {
-				tmpl.Resources = s
-			}
-		}
-		if spec.Template.DriverConfig != nil {
-			s, err := structpb.NewStruct(spec.Template.DriverConfig)
-			if err == nil {
-				tmpl.DriverConfig = s
-			}
-		}
-		result.Template = tmpl
-	}
-
-	if spec.GPUCount != nil {
-		result.ResourceRequirements = &pb.ResourceRequirements{
-			Gpu: &pb.GpuResourceRequirements{
-				Count: spec.GPUCount,
-			},
-		}
-	}
-
-	return result
-}
-
-// SandboxSpecToProtoChecked converts an SDK SandboxSpec and reports values
-// that protobuf Struct cannot represent instead of silently dropping them.
-func SandboxSpecToProtoChecked(spec *types.SandboxSpec) (*pb.SandboxSpec, error) {
-	result := SandboxSpecToProto(spec)
-	if spec == nil {
-		return result, nil
+	driverConfig, err := mapToStruct(spec.DriverConfig)
+	if err != nil {
+		return nil, fmt.Errorf("convert driver config: %w", err)
 	}
 	policy, err := SandboxPolicyToProtoChecked(spec.Policy)
 	if err != nil {
 		return nil, fmt.Errorf("policy: %w", err)
 	}
-	result.Policy = policy
-	if spec.Template == nil {
-		return result, nil
+	result := &pb.SandboxSpec{
+		Workload:     sandboxWorkloadToProto(spec.Workload),
+		DriverConfig: driverConfig,
+		Providers:    CopyStringSlice(spec.Providers),
+		Policy:       policy,
 	}
-	if spec.Template.Resources != nil {
-		resources, err := structpb.NewStruct(spec.Template.Resources)
-		if err != nil {
-			return nil, fmt.Errorf("template resources: %w", err)
-		}
-		result.Template.Resources = resources
-	}
-	if spec.Template.DriverConfig != nil {
-		driverConfig, err := structpb.NewStruct(spec.Template.DriverConfig)
-		if err != nil {
-			return nil, fmt.Errorf("template driver config: %w", err)
-		}
-		result.Template.DriverConfig = driverConfig
-	}
+
 	return result, nil
+}
+
+// SandboxSpecToProtoChecked converts an SDK SandboxSpec and reports values
+// that protobuf Struct cannot represent instead of silently dropping them.
+func SandboxSpecToProtoChecked(spec *types.SandboxSpec) (*pb.SandboxSpec, error) {
+	return SandboxSpecToProto(spec)
+}
+
+func sandboxWorkloadToProto(workload *types.SandboxWorkloadConfig) *pb.SandboxWorkloadConfig {
+	if workload == nil {
+		return nil
+	}
+	return &pb.SandboxWorkloadConfig{
+		Image:       workload.Image,
+		Environment: CopyStringMap(workload.Environment),
+		Resources:   sandboxResourcesToProto(workload.Resources),
+	}
+}
+
+func sandboxResourcesToProto(resources *types.SandboxResources) *pb.SandboxResources {
+	if resources == nil {
+		return nil
+	}
+	return &pb.SandboxResources{
+		Cpu:      resources.CPU,
+		Memory:   resources.Memory,
+		GpuCount: resources.GPUCount,
+	}
+}
+
+func sandboxTemplateProvenanceToProto(provenance *types.SandboxTemplateProvenance) *pb.SandboxTemplateProvenance {
+	if provenance == nil {
+		return nil
+	}
+	return &pb.SandboxTemplateProvenance{
+		Name:            provenance.Name,
+		ResourceVersion: provenance.ResourceVersion,
+	}
+}
+
+// SandboxTemplateFromProto converts a proto SandboxTemplate to an SDK SandboxTemplate.
+func SandboxTemplateFromProto(template *pb.SandboxTemplate) *types.SandboxTemplate {
+	if template == nil {
+		return nil
+	}
+	result := &types.SandboxTemplate{}
+	if m := template.GetMetadata(); m != nil {
+		result.ID = m.GetId()
+		result.Name = m.GetName()
+		result.CreatedAt = TimeFromMillis(m.GetCreatedAtMs())
+		result.Labels = CopyStringMap(m.GetLabels())
+		result.Annotations = CopyStringMap(m.GetAnnotations())
+		result.ResourceVersion = m.GetResourceVersion()
+		result.Workspace = m.GetWorkspace()
+		result.DeletionTimestamp = TimeFromMillisPtr(m.GetDeletionTimestampMs())
+	}
+	result.Spec = sandboxTemplateSpecFromProto(template.GetSpec())
+	return result
+}
+
+func sandboxTemplateSpecFromProto(spec *pb.SandboxTemplateSpec) types.SandboxTemplateSpec {
+	if spec == nil {
+		return types.SandboxTemplateSpec{}
+	}
+	return types.SandboxTemplateSpec{
+		Workload:            sandboxWorkloadFromProto(spec.GetWorkload()),
+		DriverConfig:        structToMap(spec.GetDriverConfig()),
+		DesiredServiceLevel: sandboxServiceLevelFromProto(spec.GetDesiredServiceLevel()),
+	}
+}
+
+func sandboxServiceLevelFromProto(serviceLevel *pb.SandboxServiceLevel) *types.SandboxServiceLevel {
+	if serviceLevel == nil {
+		return nil
+	}
+	return &types.SandboxServiceLevel{
+		Startup: sandboxStartupFromProto(serviceLevel.GetStartup()),
+	}
+}
+
+func sandboxStartupFromProto(startup *pb.SandboxStartup) *types.SandboxStartup {
+	if startup == nil {
+		return nil
+	}
+	return &types.SandboxStartup{
+		ReadyWithin: durationFromProto(startup.GetReadyWithin()),
+		MaxBurst:    startup.GetMaxBurst(),
+	}
+}
+
+// SandboxTemplateToProto converts an SDK SandboxTemplate to a proto SandboxTemplate.
+func SandboxTemplateToProto(template *types.SandboxTemplate) (*pb.SandboxTemplate, error) {
+	if template == nil {
+		return nil, nil
+	}
+	spec, err := sandboxTemplateSpecToProto(&template.Spec)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.SandboxTemplate{
+		Metadata: &dm.ObjectMeta{
+			Id:                  template.ID,
+			Name:                template.Name,
+			CreatedAtMs:         MillisFromTime(template.CreatedAt),
+			Labels:              CopyStringMap(template.Labels),
+			Annotations:         CopyStringMap(template.Annotations),
+			ResourceVersion:     template.ResourceVersion,
+			Workspace:           template.Workspace,
+			DeletionTimestampMs: MillisFromTimePtr(template.DeletionTimestamp),
+		},
+		Spec: spec,
+	}, nil
+}
+
+func sandboxTemplateSpecToProto(spec *types.SandboxTemplateSpec) (*pb.SandboxTemplateSpec, error) {
+	if spec == nil {
+		return nil, nil
+	}
+	driverConfig, err := mapToStruct(spec.DriverConfig)
+	if err != nil {
+		return nil, fmt.Errorf("convert template driver config: %w", err)
+	}
+	return &pb.SandboxTemplateSpec{
+		Workload:            sandboxWorkloadToProto(spec.Workload),
+		DriverConfig:        driverConfig,
+		DesiredServiceLevel: sandboxServiceLevelToProto(spec.DesiredServiceLevel),
+	}, nil
+}
+
+func sandboxServiceLevelToProto(serviceLevel *types.SandboxServiceLevel) *pb.SandboxServiceLevel {
+	if serviceLevel == nil {
+		return nil
+	}
+	return &pb.SandboxServiceLevel{
+		Startup: sandboxStartupToProto(serviceLevel.Startup),
+	}
+}
+
+func sandboxStartupToProto(startup *types.SandboxStartup) *pb.SandboxStartup {
+	if startup == nil {
+		return nil
+	}
+	return &pb.SandboxStartup{
+		ReadyWithin: durationToProto(startup.ReadyWithin),
+		MaxBurst:    startup.MaxBurst,
+	}
+}
+
+func durationFromProto(duration *durationpb.Duration) time.Duration {
+	if duration == nil {
+		return 0
+	}
+	return duration.AsDuration()
+}
+
+func durationToProto(duration time.Duration) *durationpb.Duration {
+	if duration == 0 {
+		return nil
+	}
+	return durationpb.New(duration)
+}
+
+func structToMap(s *structpb.Struct) map[string]any {
+	if s == nil {
+		return nil
+	}
+	return s.AsMap()
+}
+
+func mapToStruct(m map[string]any) (*structpb.Struct, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return structpb.NewStruct(m)
 }

--- a/sdk/go/openshell/v1/internal/converter/sandbox_test.go
+++ b/sdk/go/openshell/v1/internal/converter/sandbox_test.go
@@ -12,12 +12,11 @@ import (
 	pb "github.com/NVIDIA/OpenShell/sdk/go/proto/openshellv1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestSandboxFromProto(t *testing.T) {
-	userNS := true
 	gpuCount := uint32(2)
 	proto := &pb.Sandbox{
 		Metadata: &dm.ObjectMeta{
@@ -30,32 +29,24 @@ func TestSandboxFromProto(t *testing.T) {
 			Workspace:           "prod",
 			DeletionTimestampMs: 1700000060000,
 		},
+		CreatedFromTemplate: &pb.SandboxTemplateProvenance{
+			Name:            "python",
+			ResourceVersion: "7",
+		},
 		Spec: &pb.SandboxSpec{
-			LogLevel:    "debug",
-			Environment: map[string]string{"FOO": "bar"},
-			Template: &pb.SandboxTemplate{
-				Image:            "nvidia/sandbox:latest",
-				RuntimeClassName: "kata",
-				AgentSocket:      "/var/run/agent.sock",
-				Labels:           map[string]string{"app": "test"},
-				Annotations:      map[string]string{"note": "hello"},
-				Environment:      map[string]string{"TMPL_VAR": "val"},
-				UserNamespaces:   &userNS,
-				Resources: func() *structpb.Struct {
-					s, _ := structpb.NewStruct(map[string]any{"cpu": "2", "memory": "4Gi"})
-					return s
-				}(),
-				DriverConfig: func() *structpb.Struct {
-					s, _ := structpb.NewStruct(map[string]any{"runtime": "kata", "nested": map[string]any{"key": "val"}})
-					return s
-				}(),
-			},
-			Providers: []string{"claude", "github"},
-			ResourceRequirements: &pb.ResourceRequirements{
-				Gpu: &pb.GpuResourceRequirements{
-					Count: &gpuCount,
+			Workload: &pb.SandboxWorkloadConfig{
+				Image:       "python:3.12",
+				Environment: map[string]string{"FOO": "bar"},
+				Resources: &pb.SandboxResources{
+					Cpu:      "2",
+					Memory:   "4Gi",
+					GpuCount: &gpuCount,
 				},
 			},
+			DriverConfig: structpb.NewStructValue(&structpb.Struct{
+				Fields: map[string]*structpb.Value{"kubernetes": structpb.NewBoolValue(true)},
+			}).GetStructValue(),
+			Providers: []string{"claude", "github"},
 		},
 		Status: &pb.SandboxStatus{
 			SandboxName:          "sb-compute-1",
@@ -88,31 +79,21 @@ func TestSandboxFromProto(t *testing.T) {
 	assert.Equal(t, "prod", s.Workspace)
 	require.NotNil(t, s.DeletionTimestamp)
 	assert.Equal(t, time.UnixMilli(1700000060000).UTC(), *s.DeletionTimestamp)
+	require.NotNil(t, s.CreatedFromTemplate)
+	assert.Equal(t, "python", s.CreatedFromTemplate.Name)
+	assert.Equal(t, "7", s.CreatedFromTemplate.ResourceVersion)
 
-	// Spec
-	assert.Equal(t, "debug", s.Spec.LogLevel)
-	assert.Equal(t, map[string]string{"FOO": "bar"}, s.Spec.Environment)
+	require.NotNil(t, s.Spec.Workload)
+	assert.Equal(t, "python:3.12", s.Spec.Workload.Image)
+	assert.Equal(t, map[string]string{"FOO": "bar"}, s.Spec.Workload.Environment)
+	require.NotNil(t, s.Spec.Workload.Resources)
+	assert.Equal(t, "2", s.Spec.Workload.Resources.CPU)
+	assert.Equal(t, "4Gi", s.Spec.Workload.Resources.Memory)
+	require.NotNil(t, s.Spec.Workload.Resources.GPUCount)
+	assert.Equal(t, uint32(2), *s.Spec.Workload.Resources.GPUCount)
+	assert.Equal(t, map[string]any{"kubernetes": true}, s.Spec.DriverConfig)
 	assert.Equal(t, []string{"claude", "github"}, s.Spec.Providers)
-	require.NotNil(t, s.Spec.GPUCount)
-	assert.Equal(t, uint32(2), *s.Spec.GPUCount)
 
-	// Template
-	require.NotNil(t, s.Spec.Template)
-	assert.Equal(t, "nvidia/sandbox:latest", s.Spec.Template.Image)
-	assert.Equal(t, "kata", s.Spec.Template.RuntimeClassName)
-	assert.Equal(t, "/var/run/agent.sock", s.Spec.Template.AgentSocket)
-	assert.Equal(t, map[string]string{"app": "test"}, s.Spec.Template.Labels)
-	assert.Equal(t, map[string]string{"note": "hello"}, s.Spec.Template.Annotations)
-	assert.Equal(t, map[string]string{"TMPL_VAR": "val"}, s.Spec.Template.Environment)
-	require.NotNil(t, s.Spec.Template.UserNamespaces)
-	assert.True(t, *s.Spec.Template.UserNamespaces)
-	assert.Equal(t, map[string]any{"cpu": "2", "memory": "4Gi"}, s.Spec.Template.Resources)
-	assert.Equal(t, "kata", s.Spec.Template.DriverConfig["runtime"])
-	nested, ok := s.Spec.Template.DriverConfig["nested"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "val", nested["key"])
-
-	// Status
 	assert.Equal(t, "sb-compute-1", s.Status.SandboxName)
 	assert.Equal(t, "agent-pod-xyz", s.Status.AgentPod)
 	assert.Equal(t, "fd-agent", s.Status.AgentFd)
@@ -127,50 +108,19 @@ func TestSandboxFromProto(t *testing.T) {
 	assert.Equal(t, "2024-01-01T00:00:00Z", s.Status.Conditions[0].LastTransitionTime)
 }
 
-func TestSandboxFromProto_TemplateResourcesDeepCopy(t *testing.T) {
-	proto := &pb.Sandbox{
-		Spec: &pb.SandboxSpec{
-			Template: &pb.SandboxTemplate{
-				Image: "img:v1",
-				Resources: func() *structpb.Struct {
-					s, _ := structpb.NewStruct(map[string]any{"cpu": "2"})
-					return s
-				}(),
-				DriverConfig: func() *structpb.Struct {
-					s, _ := structpb.NewStruct(map[string]any{"runtime": "kata"})
-					return s
-				}(),
-			},
-		},
-	}
-
-	s := SandboxFromProto(proto)
-	require.NotNil(t, s)
-
-	proto.Spec.Template.Resources.Fields["cpu"] = structpb.NewStringValue("MUTATED")
-	assert.Equal(t, "2", s.Spec.Template.Resources["cpu"], "Resources must be deep copied")
-
-	proto.Spec.Template.DriverConfig.Fields["runtime"] = structpb.NewStringValue("MUTATED")
-	assert.Equal(t, "kata", s.Spec.Template.DriverConfig["runtime"], "DriverConfig must be deep copied")
-}
-
 func TestSandboxFromProto_NilFields(t *testing.T) {
-	proto := &pb.Sandbox{}
-
-	s := SandboxFromProto(proto)
+	s := SandboxFromProto(&pb.Sandbox{})
 
 	require.NotNil(t, s)
 	assert.Empty(t, s.ID)
 	assert.Empty(t, s.Name)
 	assert.True(t, s.CreatedAt.IsZero())
-	assert.Nil(t, s.Spec.Template)
-	assert.Nil(t, s.Spec.GPUCount)
+	assert.Nil(t, s.Spec.Workload)
 	assert.Equal(t, v1.SandboxUnknown, s.Status.Phase)
 }
 
 func TestSandboxFromProto_Nil(t *testing.T) {
-	s := SandboxFromProto(nil)
-	assert.Nil(t, s)
+	assert.Nil(t, SandboxFromProto(nil))
 }
 
 func TestSandboxPhaseFromProto(t *testing.T) {
@@ -183,9 +133,6 @@ func TestSandboxPhaseFromProto(t *testing.T) {
 		{pb.SandboxPhase_SANDBOX_PHASE_ERROR, v1.SandboxError},
 		{pb.SandboxPhase_SANDBOX_PHASE_DELETING, v1.SandboxDeleting},
 		{pb.SandboxPhase_SANDBOX_PHASE_UNKNOWN, v1.SandboxUnknown},
-		{pb.SandboxPhase_SANDBOX_PHASE_STOPPING, v1.SandboxStopping},
-		{pb.SandboxPhase_SANDBOX_PHASE_STOPPED, v1.SandboxStopped},
-		{pb.SandboxPhase_SANDBOX_PHASE_STARTING, v1.SandboxStarting},
 		{pb.SandboxPhase_SANDBOX_PHASE_UNSPECIFIED, v1.SandboxUnknown},
 		{pb.SandboxPhase(999), v1.SandboxUnknown},
 	}
@@ -205,9 +152,6 @@ func TestSandboxPhaseToProto(t *testing.T) {
 		{v1.SandboxError, pb.SandboxPhase_SANDBOX_PHASE_ERROR},
 		{v1.SandboxDeleting, pb.SandboxPhase_SANDBOX_PHASE_DELETING},
 		{v1.SandboxUnknown, pb.SandboxPhase_SANDBOX_PHASE_UNKNOWN},
-		{v1.SandboxStopping, pb.SandboxPhase_SANDBOX_PHASE_STOPPING},
-		{v1.SandboxStopped, pb.SandboxPhase_SANDBOX_PHASE_STOPPED},
-		{v1.SandboxStarting, pb.SandboxPhase_SANDBOX_PHASE_STARTING},
 		{v1.SandboxPhase("bogus"), pb.SandboxPhase_SANDBOX_PHASE_UNKNOWN},
 	}
 
@@ -217,7 +161,6 @@ func TestSandboxPhaseToProto(t *testing.T) {
 }
 
 func TestSandboxToProto(t *testing.T) {
-	userNS := true
 	gpuCount := uint32(4)
 	delTime := time.UnixMilli(1700000060000).UTC()
 	s := &v1.Sandbox{
@@ -229,25 +172,27 @@ func TestSandboxToProto(t *testing.T) {
 		ResourceVersion:   3,
 		Workspace:         "prod",
 		DeletionTimestamp: &delTime,
+		CreatedFromTemplate: &v1.SandboxTemplateProvenance{
+			Name:            "python",
+			ResourceVersion: "9",
+		},
 		Spec: v1.SandboxSpec{
-			LogLevel:    "info",
-			Environment: map[string]string{"KEY": "val"},
-			Template: &v1.SandboxTemplate{
-				Image:            "img:v1",
-				RuntimeClassName: "runc",
-				AgentSocket:      "/sock",
-				Labels:           map[string]string{"l": "v"},
-				Annotations:      map[string]string{"a": "v"},
-				Environment:      map[string]string{"E": "V"},
-				UserNamespaces:   &userNS,
+			Workload: &v1.SandboxWorkloadConfig{
+				Image:       "img:v1",
+				Environment: map[string]string{"E": "V"},
+				Resources: &v1.SandboxResources{
+					CPU:      "500m",
+					Memory:   "1Gi",
+					GPUCount: &gpuCount,
+				},
 			},
-			Providers: []string{"prov-a"},
-			GPUCount:  &gpuCount,
+			DriverConfig: map[string]any{"kubernetes": map[string]any{"runtime_class_name": "kata"}},
+			Providers:    []string{"prov-a"},
 		},
 	}
 
-	p := SandboxToProto(s)
-
+	p, err := SandboxToProto(s)
+	require.NoError(t, err)
 	require.NotNil(t, p)
 	require.NotNil(t, p.Metadata)
 	assert.Equal(t, "sb-1", p.Metadata.Id)
@@ -258,49 +203,38 @@ func TestSandboxToProto(t *testing.T) {
 	assert.Equal(t, uint64(3), p.Metadata.ResourceVersion)
 	assert.Equal(t, "prod", p.Metadata.Workspace)
 	assert.Equal(t, int64(1700000060000), p.Metadata.DeletionTimestampMs)
+	require.NotNil(t, p.CreatedFromTemplate)
+	assert.Equal(t, "python", p.CreatedFromTemplate.Name)
+	assert.Equal(t, "9", p.CreatedFromTemplate.ResourceVersion)
 
 	require.NotNil(t, p.Spec)
-	assert.Equal(t, "info", p.Spec.LogLevel)
-	assert.Equal(t, map[string]string{"KEY": "val"}, p.Spec.Environment)
+	require.NotNil(t, p.Spec.Workload)
+	assert.Equal(t, "img:v1", p.Spec.Workload.Image)
+	assert.Equal(t, map[string]string{"E": "V"}, p.Spec.Workload.Environment)
+	require.NotNil(t, p.Spec.Workload.Resources)
+	assert.Equal(t, "500m", p.Spec.Workload.Resources.Cpu)
+	assert.Equal(t, "1Gi", p.Spec.Workload.Resources.Memory)
+	assert.Equal(t, uint32(4), p.Spec.Workload.Resources.GetGpuCount())
 	assert.Equal(t, []string{"prov-a"}, p.Spec.Providers)
-
-	require.NotNil(t, p.Spec.ResourceRequirements)
-	require.NotNil(t, p.Spec.ResourceRequirements.Gpu)
-	assert.Equal(t, uint32(4), p.Spec.ResourceRequirements.Gpu.GetCount())
-
-	require.NotNil(t, p.Spec.Template)
-	assert.Equal(t, "img:v1", p.Spec.Template.Image)
-	assert.Equal(t, "runc", p.Spec.Template.RuntimeClassName)
-	assert.Equal(t, "/sock", p.Spec.Template.AgentSocket)
-	assert.Equal(t, map[string]string{"l": "v"}, p.Spec.Template.Labels)
-	assert.Equal(t, map[string]string{"a": "v"}, p.Spec.Template.Annotations)
-	assert.Equal(t, map[string]string{"E": "V"}, p.Spec.Template.Environment)
-	require.NotNil(t, p.Spec.Template.UserNamespaces)
-	assert.True(t, *p.Spec.Template.UserNamespaces)
+	require.NotNil(t, p.Spec.DriverConfig)
+	assert.Equal(t, "kata", p.Spec.DriverConfig.Fields["kubernetes"].GetStructValue().Fields["runtime_class_name"].GetStringValue())
 }
 
 func TestSandboxToProto_Nil(t *testing.T) {
-	p := SandboxToProto(nil)
+	p, err := SandboxToProto(nil)
+	require.NoError(t, err)
 	assert.Nil(t, p)
 }
 
-func TestSandboxToProto_NilTemplate(t *testing.T) {
-	s := &v1.Sandbox{
-		Spec: v1.SandboxSpec{
-			LogLevel: "warn",
-		},
-	}
-
-	p := SandboxToProto(s)
-
+func TestSandboxToProto_NilWorkload(t *testing.T) {
+	p, err := SandboxToProto(&v1.Sandbox{})
+	require.NoError(t, err)
 	require.NotNil(t, p)
 	require.NotNil(t, p.Spec)
-	assert.Nil(t, p.Spec.Template)
-	assert.Nil(t, p.Spec.ResourceRequirements)
+	assert.Nil(t, p.Spec.Workload)
 }
 
 func TestSandboxRoundTrip(t *testing.T) {
-	userNS := false
 	gpuCount := uint32(1)
 	rtDelTime := time.UnixMilli(1700000090000).UTC()
 	original := &v1.Sandbox{
@@ -313,14 +247,13 @@ func TestSandboxRoundTrip(t *testing.T) {
 		Workspace:         "staging",
 		DeletionTimestamp: &rtDelTime,
 		Spec: v1.SandboxSpec{
-			LogLevel:    "trace",
-			Environment: map[string]string{"A": "B"},
-			Template: &v1.SandboxTemplate{
-				Image:          "img:rt",
-				UserNamespaces: &userNS,
+			Workload: &v1.SandboxWorkloadConfig{
+				Image: "img:rt",
+				Resources: &v1.SandboxResources{
+					GPUCount: &gpuCount,
+				},
 			},
 			Providers: []string{"p1", "p2"},
-			GPUCount:  &gpuCount,
 			Policy: &v1.SandboxPolicy{
 				Version: 3,
 				Filesystem: &v1.FilesystemPolicy{
@@ -339,14 +272,7 @@ func TestSandboxRoundTrip(t *testing.T) {
 					"web": {
 						Name: "web",
 						Endpoints: []v1.PolicyNetworkEndpoint{
-							{
-								Host:     "api.example.com",
-								Port:     443,
-								Protocol: "rest",
-								CredentialBinding: &v1.NetworkCredentialBinding{
-									Provider: "api-credentials",
-								},
-							},
+							{Host: "api.example.com", Port: 443, Protocol: "rest"},
 						},
 					},
 				},
@@ -354,7 +280,8 @@ func TestSandboxRoundTrip(t *testing.T) {
 		},
 	}
 
-	p := SandboxToProto(original)
+	p, err := SandboxToProto(original)
+	require.NoError(t, err)
 	back := SandboxFromProto(p)
 
 	assert.Equal(t, original.ID, back.ID)
@@ -366,17 +293,13 @@ func TestSandboxRoundTrip(t *testing.T) {
 	assert.Equal(t, original.Workspace, back.Workspace)
 	require.NotNil(t, back.DeletionTimestamp)
 	assert.Equal(t, *original.DeletionTimestamp, *back.DeletionTimestamp)
-	assert.Equal(t, original.Spec.LogLevel, back.Spec.LogLevel)
-	assert.Equal(t, original.Spec.Environment, back.Spec.Environment)
+	require.NotNil(t, back.Spec.Workload)
+	assert.Equal(t, original.Spec.Workload.Image, back.Spec.Workload.Image)
+	require.NotNil(t, back.Spec.Workload.Resources)
+	require.NotNil(t, back.Spec.Workload.Resources.GPUCount)
+	assert.Equal(t, *original.Spec.Workload.Resources.GPUCount, *back.Spec.Workload.Resources.GPUCount)
 	assert.Equal(t, original.Spec.Providers, back.Spec.Providers)
-	require.NotNil(t, back.Spec.GPUCount)
-	assert.Equal(t, *original.Spec.GPUCount, *back.Spec.GPUCount)
-	require.NotNil(t, back.Spec.Template)
-	assert.Equal(t, original.Spec.Template.Image, back.Spec.Template.Image)
-	require.NotNil(t, back.Spec.Template.UserNamespaces)
-	assert.Equal(t, *original.Spec.Template.UserNamespaces, *back.Spec.Template.UserNamespaces)
 
-	// Policy round-trip
 	require.NotNil(t, back.Spec.Policy)
 	assert.Equal(t, uint32(3), back.Spec.Policy.Version)
 	require.NotNil(t, back.Spec.Policy.Filesystem)
@@ -394,22 +317,21 @@ func TestSandboxRoundTrip(t *testing.T) {
 	assert.Equal(t, "web", webRule.Name)
 	require.Len(t, webRule.Endpoints, 1)
 	assert.Equal(t, "api.example.com", webRule.Endpoints[0].Host)
-	require.NotNil(t, webRule.Endpoints[0].CredentialBinding)
-	assert.Equal(t, "api-credentials", webRule.Endpoints[0].CredentialBinding.Provider)
 }
 
 func TestSandboxSpecToProto(t *testing.T) {
 	gpuCount := uint32(3)
 	spec := &v1.SandboxSpec{
-		LogLevel:    "debug",
-		Environment: map[string]string{"X": "Y"},
-		Template: &v1.SandboxTemplate{
-			Image:        "img:spec",
-			Resources:    map[string]any{"cpu": "4"},
-			DriverConfig: map[string]any{"runtime": "kata"},
+		Workload: &v1.SandboxWorkloadConfig{
+			Image:       "img:spec",
+			Environment: map[string]string{"X": "Y"},
+			Resources: &v1.SandboxResources{
+				CPU:      "2",
+				Memory:   "8Gi",
+				GPUCount: &gpuCount,
+			},
 		},
 		Providers: []string{"prov"},
-		GPUCount:  &gpuCount,
 		Policy: &v1.SandboxPolicy{
 			Version: 2,
 			Filesystem: &v1.FilesystemPolicy{
@@ -418,22 +340,18 @@ func TestSandboxSpecToProto(t *testing.T) {
 		},
 	}
 
-	p := SandboxSpecToProto(spec)
-
+	p, err := SandboxSpecToProto(spec)
+	require.NoError(t, err)
 	require.NotNil(t, p)
-	assert.Equal(t, "debug", p.LogLevel)
-	assert.Equal(t, map[string]string{"X": "Y"}, p.Environment)
+	require.NotNil(t, p.Workload)
+	assert.Equal(t, "img:spec", p.Workload.Image)
+	assert.Equal(t, map[string]string{"X": "Y"}, p.Workload.Environment)
+	require.NotNil(t, p.Workload.Resources)
+	assert.Equal(t, "2", p.Workload.Resources.Cpu)
+	assert.Equal(t, "8Gi", p.Workload.Resources.Memory)
+	assert.Equal(t, uint32(3), p.Workload.Resources.GetGpuCount())
 	assert.Equal(t, []string{"prov"}, p.Providers)
-	require.NotNil(t, p.ResourceRequirements)
-	assert.Equal(t, uint32(3), p.ResourceRequirements.Gpu.GetCount())
-	require.NotNil(t, p.Template)
-	assert.Equal(t, "img:spec", p.Template.Image)
-	require.NotNil(t, p.Template.Resources)
-	assert.Equal(t, "4", p.Template.Resources.Fields["cpu"].GetStringValue())
-	require.NotNil(t, p.Template.DriverConfig)
-	assert.Equal(t, "kata", p.Template.DriverConfig.Fields["runtime"].GetStringValue())
 
-	// Policy conversion
 	require.NotNil(t, p.Policy)
 	assert.Equal(t, uint32(2), p.Policy.Version)
 	require.NotNil(t, p.Policy.Filesystem)
@@ -441,9 +359,80 @@ func TestSandboxSpecToProto(t *testing.T) {
 }
 
 func TestSandboxSpecToProto_Nil(t *testing.T) {
-	p := SandboxSpecToProto(nil)
+	p, err := SandboxSpecToProto(nil)
+	require.NoError(t, err)
 	assert.Nil(t, p)
 }
 
-// Verify proto import is used (suppress unused import warning).
-var _ = proto.Marshal
+func TestSandboxSpecToProto_InvalidMapReturnsError(t *testing.T) {
+	spec := &v1.SandboxSpec{
+		DriverConfig: map[string]any{"bad": make(chan int)},
+	}
+
+	p, err := SandboxSpecToProto(spec)
+	require.Error(t, err, "SandboxSpecToProto must return an error for unconvertible map values")
+	assert.Nil(t, p)
+	assert.Contains(t, err.Error(), "convert driver config")
+}
+
+func TestSandboxTemplateRoundTrip(t *testing.T) {
+	readyWithin := 15 * time.Second
+	template := &v1.SandboxTemplate{
+		ID:              "tmpl-1",
+		Name:            "python",
+		CreatedAt:       time.UnixMilli(1700000000000).UTC(),
+		Labels:          map[string]string{"runtime": "python"},
+		ResourceVersion: 5,
+		Workspace:       "default",
+		Spec: v1.SandboxTemplateSpec{
+			Workload: &v1.SandboxWorkloadConfig{Image: "python:3.12"},
+			DriverConfig: map[string]any{
+				"kubernetes": map[string]any{"runtime_class_name": "kata"},
+			},
+			DesiredServiceLevel: &v1.SandboxServiceLevel{
+				Startup: &v1.SandboxStartup{
+					ReadyWithin: readyWithin,
+					MaxBurst:    2,
+				},
+			},
+		},
+	}
+
+	p, err := SandboxTemplateToProto(template)
+	require.NoError(t, err)
+	back := SandboxTemplateFromProto(p)
+
+	require.NotNil(t, back)
+	assert.Equal(t, template.ID, back.ID)
+	assert.Equal(t, template.Name, back.Name)
+	assert.Equal(t, template.CreatedAt, back.CreatedAt)
+	assert.Equal(t, template.Labels, back.Labels)
+	assert.Equal(t, template.ResourceVersion, back.ResourceVersion)
+	assert.Equal(t, template.Workspace, back.Workspace)
+	require.NotNil(t, back.Spec.Workload)
+	assert.Equal(t, "python:3.12", back.Spec.Workload.Image)
+	assert.Equal(t, map[string]any{"kubernetes": map[string]any{"runtime_class_name": "kata"}}, back.Spec.DriverConfig)
+	require.NotNil(t, back.Spec.DesiredServiceLevel)
+	require.NotNil(t, back.Spec.DesiredServiceLevel.Startup)
+	assert.Equal(t, readyWithin, back.Spec.DesiredServiceLevel.Startup.ReadyWithin)
+	assert.Equal(t, uint32(2), back.Spec.DesiredServiceLevel.Startup.MaxBurst)
+}
+
+func TestSandboxTemplateFromProto_Duration(t *testing.T) {
+	template := SandboxTemplateFromProto(&pb.SandboxTemplate{
+		Spec: &pb.SandboxTemplateSpec{
+			DesiredServiceLevel: &pb.SandboxServiceLevel{
+				Startup: &pb.SandboxStartup{
+					ReadyWithin: durationpb.New(30 * time.Second),
+					MaxBurst:    4,
+				},
+			},
+		},
+	})
+
+	require.NotNil(t, template)
+	require.NotNil(t, template.Spec.DesiredServiceLevel)
+	require.NotNil(t, template.Spec.DesiredServiceLevel.Startup)
+	assert.Equal(t, 30*time.Second, template.Spec.DesiredServiceLevel.Startup.ReadyWithin)
+	assert.Equal(t, uint32(4), template.Spec.DesiredServiceLevel.Startup.MaxBurst)
+}

--- a/sdk/go/openshell/v1/sandbox.go
+++ b/sdk/go/openshell/v1/sandbox.go
@@ -18,6 +18,24 @@ type SandboxSpec = types.SandboxSpec
 // SandboxTemplate defines the container template for a sandbox.
 type SandboxTemplate = types.SandboxTemplate
 
+// SandboxWorkloadConfig defines the portable workload for a sandbox.
+type SandboxWorkloadConfig = types.SandboxWorkloadConfig
+
+// SandboxResources defines portable sandbox resource requirements.
+type SandboxResources = types.SandboxResources
+
+// SandboxTemplateSpec holds reusable sandbox template settings.
+type SandboxTemplateSpec = types.SandboxTemplateSpec
+
+// SandboxServiceLevel describes desired operational characteristics.
+type SandboxServiceLevel = types.SandboxServiceLevel
+
+// SandboxStartup describes desired startup characteristics.
+type SandboxStartup = types.SandboxStartup
+
+// SandboxTemplateProvenance identifies the template revision used to create a sandbox.
+type SandboxTemplateProvenance = types.SandboxTemplateProvenance
+
 // SandboxStatus holds the observed state of a sandbox.
 type SandboxStatus = types.SandboxStatus
 

--- a/sdk/go/openshell/v1/sandbox.go
+++ b/sdk/go/openshell/v1/sandbox.go
@@ -71,7 +71,8 @@ var WithLogMinLevel = types.WithLogMinLevel
 
 // SandboxInterface defines lifecycle operations on sandboxes.
 type SandboxInterface interface {
-	Create(ctx context.Context, workspace, name string, spec *SandboxSpec, labels map[string]string, opts ...CreateOptions) (*Sandbox, error)
+	Create(ctx context.Context, workspace, name string, workload *SandboxWorkloadConfig, policy *SandboxPolicy, providers []string, labels map[string]string, opts ...CreateOptions) (*Sandbox, error)
+	CreateFromTemplate(ctx context.Context, workspace, name, templateName string, policy *SandboxPolicy, providers []string, labels map[string]string, opts ...CreateOptions) (*Sandbox, error)
 	Get(ctx context.Context, workspace, name string) (*Sandbox, error)
 	List(ctx context.Context, workspace string, opts ...ListOptions) ([]*Sandbox, error)
 	Stop(ctx context.Context, workspace, name string) (*Sandbox, error)

--- a/sdk/go/openshell/v1/sandbox_client.go
+++ b/sdk/go/openshell/v1/sandbox_client.go
@@ -25,23 +25,48 @@ func newSandboxClient(conn grpc.ClientConnInterface) *sandboxClient {
 	return &sandboxClient{client: pb.NewOpenShellClient(conn)}
 }
 
-func (s *sandboxClient) Create(ctx context.Context, workspace, name string, spec *SandboxSpec, labels map[string]string, opts ...CreateOptions) (*Sandbox, error) {
-	protoSpec, err := converter.SandboxSpecToProtoChecked(spec)
+func (s *sandboxClient) Create(ctx context.Context, workspace, name string, workload *SandboxWorkloadConfig, policy *SandboxPolicy, providers []string, labels map[string]string, opts ...CreateOptions) (*Sandbox, error) {
+	protoPolicy, err := converter.SandboxPolicyToProtoChecked(policy)
 	if err != nil {
 		return nil, &StatusError{Code: ErrorInvalidArgument, Message: err.Error()}
 	}
 	req := &pb.CreateSandboxRequest{
+		WorkloadSource: &pb.CreateSandboxRequest_Workload{
+			Workload: converter.SandboxWorkloadToProto(workload),
+		},
+		Policy:    protoPolicy,
+		Providers: converter.CopyStringSlice(providers),
 		Name:      name,
-		Labels:    labels,
+		Labels:    converter.CopyStringMap(labels),
 		Workspace: workspace,
 	}
+	return s.create(ctx, req, opts...)
+}
+
+func (s *sandboxClient) CreateFromTemplate(ctx context.Context, workspace, name, templateName string, policy *SandboxPolicy, providers []string, labels map[string]string, opts ...CreateOptions) (*Sandbox, error) {
+	if templateName == "" {
+		return nil, &StatusError{Code: ErrorInvalidArgument, Message: "template name is required"}
+	}
+	protoPolicy, err := converter.SandboxPolicyToProtoChecked(policy)
+	if err != nil {
+		return nil, &StatusError{Code: ErrorInvalidArgument, Message: err.Error()}
+	}
+	req := &pb.CreateSandboxRequest{
+		WorkloadSource: &pb.CreateSandboxRequest_WorkloadTemplateName{
+			WorkloadTemplateName: templateName,
+		},
+		Policy:    protoPolicy,
+		Providers: converter.CopyStringSlice(providers),
+		Name:      name,
+		Labels:    converter.CopyStringMap(labels),
+		Workspace: workspace,
+	}
+	return s.create(ctx, req, opts...)
+}
+
+func (s *sandboxClient) create(ctx context.Context, req *pb.CreateSandboxRequest, opts ...CreateOptions) (*Sandbox, error) {
 	if len(opts) > 0 {
 		req.Annotations = converter.CopyStringMap(opts[0].Annotations)
-	}
-	if protoSpec != nil {
-		req.WorkloadSource = &pb.CreateSandboxRequest_Workload{Workload: protoSpec.GetWorkload()}
-		req.Policy = protoSpec.GetPolicy()
-		req.Providers = protoSpec.GetProviders()
 	}
 	resp, err := s.client.CreateSandbox(ctx, req)
 	if err != nil {

--- a/sdk/go/openshell/v1/sandbox_client.go
+++ b/sdk/go/openshell/v1/sandbox_client.go
@@ -32,12 +32,16 @@ func (s *sandboxClient) Create(ctx context.Context, workspace, name string, spec
 	}
 	req := &pb.CreateSandboxRequest{
 		Name:      name,
-		Spec:      protoSpec,
 		Labels:    labels,
 		Workspace: workspace,
 	}
 	if len(opts) > 0 {
 		req.Annotations = converter.CopyStringMap(opts[0].Annotations)
+	}
+	if protoSpec != nil {
+		req.WorkloadSource = &pb.CreateSandboxRequest_Workload{Workload: protoSpec.GetWorkload()}
+		req.Policy = protoSpec.GetPolicy()
+		req.Providers = protoSpec.GetProviders()
 	}
 	resp, err := s.client.CreateSandbox(ctx, req)
 	if err != nil {

--- a/sdk/go/openshell/v1/sandbox_client_test.go
+++ b/sdk/go/openshell/v1/sandbox_client_test.go
@@ -28,6 +28,7 @@ type mockSandboxServer struct {
 	sandboxes          map[string]*pb.Sandbox
 	providers          map[string][]*dm.Provider
 	createErr          error
+	lastCreate         *pb.CreateSandboxRequest
 	getErr             error
 	listErr            error
 	deleteErr          error
@@ -59,6 +60,7 @@ func (s *mockSandboxServer) CreateSandbox(_ context.Context, req *pb.CreateSandb
 	if s.createErr != nil {
 		return nil, s.createErr
 	}
+	s.lastCreate = proto.Clone(req).(*pb.CreateSandboxRequest)
 	spec := &pb.SandboxSpec{
 		Workload:  req.GetWorkload(),
 		Policy:    req.GetPolicy(),
@@ -253,13 +255,11 @@ func TestSandboxCreate(t *testing.T) {
 	client, cleanup := setupSandboxTest(t, mock)
 	defer cleanup()
 
-	spec := &SandboxSpec{
-		Workload:  &SandboxWorkloadConfig{Image: "python:3.12", Environment: map[string]string{"FOO": "bar"}},
-		Providers: []string{"claude"},
-	}
+	workload := &SandboxWorkloadConfig{Image: "python:3.12", Environment: map[string]string{"FOO": "bar"}}
+	providers := []string{"claude"}
 	labels := map[string]string{"env": "dev"}
 
-	result, err := client.Create(context.Background(), "default", "my-sandbox", spec, labels)
+	result, err := client.Create(context.Background(), "default", "my-sandbox", workload, nil, providers, labels)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -267,16 +267,41 @@ func TestSandboxCreate(t *testing.T) {
 	assert.Equal(t, "sb-my-sandbox", result.ID)
 	assert.Equal(t, map[string]string{"env": "dev"}, result.Labels)
 	assert.Equal(t, SandboxProvisioning, result.Status.Phase)
+	mock.mu.Lock()
+	req := mock.lastCreate
+	mock.mu.Unlock()
+	require.NotNil(t, req)
+	assert.Equal(t, "default", req.GetWorkspace())
+	assert.Equal(t, "python:3.12", req.GetWorkload().GetImage())
+	assert.Equal(t, map[string]string{"FOO": "bar"}, req.GetWorkload().GetEnvironment())
+	assert.Equal(t, []string{"claude"}, req.GetProviders())
+	assert.Empty(t, req.GetWorkloadTemplateName())
 }
 
-func TestSandboxCreate_RejectsUnrepresentableResourcesBeforeRPC(t *testing.T) {
+func TestSandboxCreateFromTemplate(t *testing.T) {
 	mock := newMockSandboxServer()
 	client, cleanup := setupSandboxTest(t, mock)
 	defer cleanup()
 
-	_, err := client.Create(context.Background(), "default", "bad", &SandboxSpec{
-		DriverConfig: map[string]any{"invalid": make(chan int)},
-	}, nil)
+	result, err := client.CreateFromTemplate(context.Background(), "default", "templated", "gpu-kata", nil, []string{"claude"}, map[string]string{"env": "dev"})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	mock.mu.Lock()
+	req := mock.lastCreate
+	mock.mu.Unlock()
+	require.NotNil(t, req)
+	assert.Equal(t, "gpu-kata", req.GetWorkloadTemplateName())
+	assert.Nil(t, req.GetWorkload())
+	assert.Equal(t, []string{"claude"}, req.GetProviders())
+}
+
+func TestSandboxCreateFromTemplate_RejectsEmptyTemplateName(t *testing.T) {
+	mock := newMockSandboxServer()
+	client, cleanup := setupSandboxTest(t, mock)
+	defer cleanup()
+
+	_, err := client.CreateFromTemplate(context.Background(), "default", "bad", "", nil, nil, nil)
 	require.Error(t, err)
 	assert.True(t, IsInvalidArgument(err))
 	mock.mu.Lock()
@@ -290,7 +315,7 @@ func TestSandboxCreate_AlreadyExists(t *testing.T) {
 	client, cleanup := setupSandboxTest(t, mock)
 	defer cleanup()
 
-	_, err := client.Create(context.Background(), "default", "dup", &SandboxSpec{}, nil)
+	_, err := client.Create(context.Background(), "default", "dup", nil, nil, nil, nil)
 
 	require.Error(t, err)
 	assert.True(t, IsAlreadyExists(err))

--- a/sdk/go/openshell/v1/sandbox_client_test.go
+++ b/sdk/go/openshell/v1/sandbox_client_test.go
@@ -59,6 +59,11 @@ func (s *mockSandboxServer) CreateSandbox(_ context.Context, req *pb.CreateSandb
 	if s.createErr != nil {
 		return nil, s.createErr
 	}
+	spec := &pb.SandboxSpec{
+		Workload:  req.GetWorkload(),
+		Policy:    req.GetPolicy(),
+		Providers: req.GetProviders(),
+	}
 	sb := &pb.Sandbox{
 		Metadata: &dm.ObjectMeta{
 			Id:              "sb-" + req.GetName(),
@@ -67,7 +72,7 @@ func (s *mockSandboxServer) CreateSandbox(_ context.Context, req *pb.CreateSandb
 			Labels:          req.GetLabels(),
 			ResourceVersion: 1,
 		},
-		Spec:   req.GetSpec(),
+		Spec:   spec,
 		Status: &pb.SandboxStatus{Phase: pb.SandboxPhase_SANDBOX_PHASE_PROVISIONING},
 	}
 	s.sandboxes[req.GetName()] = sb
@@ -249,9 +254,8 @@ func TestSandboxCreate(t *testing.T) {
 	defer cleanup()
 
 	spec := &SandboxSpec{
-		LogLevel:    "debug",
-		Environment: map[string]string{"FOO": "bar"},
-		Providers:   []string{"claude"},
+		Workload:  &SandboxWorkloadConfig{Image: "python:3.12", Environment: map[string]string{"FOO": "bar"}},
+		Providers: []string{"claude"},
 	}
 	labels := map[string]string{"env": "dev"}
 
@@ -271,7 +275,7 @@ func TestSandboxCreate_RejectsUnrepresentableResourcesBeforeRPC(t *testing.T) {
 	defer cleanup()
 
 	_, err := client.Create(context.Background(), "default", "bad", &SandboxSpec{
-		Template: &SandboxTemplate{Resources: map[string]any{"invalid": make(chan int)}},
+		DriverConfig: map[string]any{"invalid": make(chan int)},
 	}, nil)
 	require.Error(t, err)
 	assert.True(t, IsInvalidArgument(err))
@@ -296,7 +300,7 @@ func TestSandboxGet(t *testing.T) {
 	mock := newMockSandboxServer()
 	mock.sandboxes["existing"] = &pb.Sandbox{
 		Metadata: &dm.ObjectMeta{Id: "sb-1", Name: "existing", ResourceVersion: 5},
-		Spec:     &pb.SandboxSpec{LogLevel: "info"},
+		Spec:     &pb.SandboxSpec{Workload: &pb.SandboxWorkloadConfig{Image: "python:3.12"}},
 		Status:   &pb.SandboxStatus{Phase: pb.SandboxPhase_SANDBOX_PHASE_READY},
 	}
 	client, cleanup := setupSandboxTest(t, mock)

--- a/sdk/go/openshell/v1/sandbox_template.go
+++ b/sdk/go/openshell/v1/sandbox_template.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import "context"
+
+// SandboxTemplateInterface defines CRUD operations on sandbox templates.
+type SandboxTemplateInterface interface {
+	Create(ctx context.Context, workspace string, template *SandboxTemplate) (*SandboxTemplate, error)
+	Get(ctx context.Context, workspace, name string) (*SandboxTemplate, error)
+	List(ctx context.Context, workspace string, opts ...ListOptions) ([]*SandboxTemplate, error)
+	Delete(ctx context.Context, workspace, name string) error
+}

--- a/sdk/go/openshell/v1/sandbox_template_client.go
+++ b/sdk/go/openshell/v1/sandbox_template_client.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"context"
+
+	"github.com/NVIDIA/OpenShell/sdk/go/openshell/v1/internal/converter"
+	pb "github.com/NVIDIA/OpenShell/sdk/go/proto/openshellv1"
+	"google.golang.org/grpc"
+)
+
+type sandboxTemplateClient struct {
+	client pb.OpenShellClient
+}
+
+func newSandboxTemplateClient(conn grpc.ClientConnInterface) *sandboxTemplateClient {
+	return &sandboxTemplateClient{client: pb.NewOpenShellClient(conn)}
+}
+
+func (s *sandboxTemplateClient) Create(ctx context.Context, workspace string, template *SandboxTemplate) (*SandboxTemplate, error) {
+	if template == nil {
+		return nil, &StatusError{Code: ErrorInvalidArgument, Message: "template must not be nil"}
+	}
+	protoTemplate, err := converter.SandboxTemplateToProto(template)
+	if err != nil {
+		return nil, &StatusError{Code: ErrorInvalidArgument, Message: err.Error()}
+	}
+	resp, err := s.client.CreateSandboxTemplate(ctx, &pb.CreateSandboxTemplateRequest{
+		Template:  protoTemplate,
+		Workspace: workspace,
+	})
+	if err != nil {
+		return nil, converter.FromGRPCError(err)
+	}
+	return converter.SandboxTemplateFromProto(resp.GetTemplate()), nil
+}
+
+func (s *sandboxTemplateClient) Get(ctx context.Context, workspace, name string) (*SandboxTemplate, error) {
+	resp, err := s.client.GetSandboxTemplate(ctx, &pb.GetSandboxTemplateRequest{
+		Name:      name,
+		Workspace: workspace,
+	})
+	if err != nil {
+		return nil, converter.FromGRPCError(err)
+	}
+	return converter.SandboxTemplateFromProto(resp.GetTemplate()), nil
+}
+
+func (s *sandboxTemplateClient) List(ctx context.Context, workspace string, opts ...ListOptions) ([]*SandboxTemplate, error) {
+	req := &pb.ListSandboxTemplatesRequest{
+		Workspace: workspace,
+	}
+	if len(opts) > 0 {
+		if opts[0].Limit < 0 {
+			return nil, &StatusError{Code: ErrorInvalidArgument, Message: "limit must not be negative"}
+		}
+		if opts[0].Offset < 0 {
+			return nil, &StatusError{Code: ErrorInvalidArgument, Message: "offset must not be negative"}
+		}
+		req.Limit = uint32(opts[0].Limit)
+		req.Offset = uint32(opts[0].Offset)
+		req.AllWorkspaces = opts[0].AllWorkspaces
+		if req.AllWorkspaces {
+			req.Workspace = ""
+		}
+	}
+
+	resp, err := s.client.ListSandboxTemplates(ctx, req)
+	if err != nil {
+		return nil, converter.FromGRPCError(err)
+	}
+
+	templates := make([]*SandboxTemplate, 0, len(resp.GetTemplates()))
+	for _, proto := range resp.GetTemplates() {
+		templates = append(templates, converter.SandboxTemplateFromProto(proto))
+	}
+	return templates, nil
+}
+
+func (s *sandboxTemplateClient) Delete(ctx context.Context, workspace, name string) error {
+	_, err := s.client.DeleteSandboxTemplate(ctx, &pb.DeleteSandboxTemplateRequest{
+		Name:      name,
+		Workspace: workspace,
+	})
+	if err != nil {
+		return converter.FromGRPCError(err)
+	}
+	return nil
+}

--- a/sdk/go/openshell/v1/sandbox_template_client_test.go
+++ b/sdk/go/openshell/v1/sandbox_template_client_test.go
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	dm "github.com/NVIDIA/OpenShell/sdk/go/proto/datamodelv1"
+	pb "github.com/NVIDIA/OpenShell/sdk/go/proto/openshellv1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type mockTemplateServer struct {
+	pb.UnimplementedOpenShellServer
+	mu        sync.Mutex
+	templates map[string]*pb.SandboxTemplate
+
+	lastCreate *pb.CreateSandboxTemplateRequest
+	lastGet    *pb.GetSandboxTemplateRequest
+	lastList   *pb.ListSandboxTemplatesRequest
+	lastDelete *pb.DeleteSandboxTemplateRequest
+}
+
+func newMockTemplateServer() *mockTemplateServer {
+	return &mockTemplateServer{templates: make(map[string]*pb.SandboxTemplate)}
+}
+
+func (s *mockTemplateServer) CreateSandboxTemplate(_ context.Context, req *pb.CreateSandboxTemplateRequest) (*pb.SandboxTemplateResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastCreate = proto.Clone(req).(*pb.CreateSandboxTemplateRequest)
+	template := proto.Clone(req.GetTemplate()).(*pb.SandboxTemplate)
+	if template.Metadata == nil {
+		template.Metadata = &dm.ObjectMeta{}
+	}
+	template.Metadata.Workspace = req.GetWorkspace()
+	template.Metadata.ResourceVersion = 1
+	s.templates[template.GetMetadata().GetName()] = template
+	return &pb.SandboxTemplateResponse{Template: template}, nil
+}
+
+func (s *mockTemplateServer) GetSandboxTemplate(_ context.Context, req *pb.GetSandboxTemplateRequest) (*pb.SandboxTemplateResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastGet = proto.Clone(req).(*pb.GetSandboxTemplateRequest)
+	return &pb.SandboxTemplateResponse{Template: s.templates[req.GetName()]}, nil
+}
+
+func (s *mockTemplateServer) ListSandboxTemplates(_ context.Context, req *pb.ListSandboxTemplatesRequest) (*pb.ListSandboxTemplatesResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastList = proto.Clone(req).(*pb.ListSandboxTemplatesRequest)
+	templates := make([]*pb.SandboxTemplate, 0, len(s.templates))
+	for _, template := range s.templates {
+		templates = append(templates, proto.Clone(template).(*pb.SandboxTemplate))
+	}
+	return &pb.ListSandboxTemplatesResponse{Templates: templates}, nil
+}
+
+func (s *mockTemplateServer) DeleteSandboxTemplate(_ context.Context, req *pb.DeleteSandboxTemplateRequest) (*pb.DeleteSandboxTemplateResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastDelete = proto.Clone(req).(*pb.DeleteSandboxTemplateRequest)
+	_, existed := s.templates[req.GetName()]
+	delete(s.templates, req.GetName())
+	return &pb.DeleteSandboxTemplateResponse{Deleted: existed}, nil
+}
+
+func setupTemplateTest(t *testing.T, srv *mockTemplateServer) (*sandboxTemplateClient, func()) {
+	t.Helper()
+	lis := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer()
+	pb.RegisterOpenShellServer(server, srv)
+	go func() {
+		_ = server.Serve(lis)
+	}()
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	return newSandboxTemplateClient(conn), func() {
+		require.NoError(t, conn.Close())
+		server.Stop()
+		require.NoError(t, lis.Close())
+	}
+}
+
+func TestSandboxTemplateCRUD(t *testing.T) {
+	mock := newMockTemplateServer()
+	client, cleanup := setupTemplateTest(t, mock)
+	defer cleanup()
+
+	template := &SandboxTemplate{
+		Name:   "gpu-kata",
+		Labels: map[string]string{"team": "platform"},
+		Spec: SandboxTemplateSpec{
+			Workload: &SandboxWorkloadConfig{Image: "python:3.12"},
+			DriverConfig: map[string]any{
+				"kubernetes": map[string]any{"runtime_class_name": "kata"},
+			},
+			DesiredServiceLevel: &SandboxServiceLevel{
+				Startup: &SandboxStartup{ReadyWithin: 30 * time.Second, MaxBurst: 4},
+			},
+		},
+	}
+
+	created, err := client.Create(context.Background(), "default", template)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	assert.Equal(t, "gpu-kata", created.Name)
+	mock.mu.Lock()
+	createReq := mock.lastCreate
+	mock.mu.Unlock()
+	require.NotNil(t, createReq)
+	assert.Equal(t, "default", createReq.GetWorkspace())
+	assert.Equal(t, "python:3.12", createReq.GetTemplate().GetSpec().GetWorkload().GetImage())
+	assert.Equal(t, "kata", createReq.GetTemplate().GetSpec().GetDriverConfig().GetFields()["kubernetes"].GetStructValue().GetFields()["runtime_class_name"].GetStringValue())
+	assert.Equal(t, durationpb.New(30*time.Second).AsDuration(), createReq.GetTemplate().GetSpec().GetDesiredServiceLevel().GetStartup().GetReadyWithin().AsDuration())
+	assert.Equal(t, uint32(4), createReq.GetTemplate().GetSpec().GetDesiredServiceLevel().GetStartup().GetMaxBurst())
+
+	got, err := client.Get(context.Background(), "default", "gpu-kata")
+	require.NoError(t, err)
+	assert.Equal(t, "gpu-kata", got.Name)
+
+	listed, err := client.List(context.Background(), "default", ListOptions{Limit: 50, Offset: 10})
+	require.NoError(t, err)
+	assert.Len(t, listed, 1)
+	mock.mu.Lock()
+	listReq := mock.lastList
+	mock.mu.Unlock()
+	require.NotNil(t, listReq)
+	assert.Equal(t, "default", listReq.GetWorkspace())
+	assert.False(t, listReq.GetAllWorkspaces())
+	assert.Equal(t, uint32(50), listReq.GetLimit())
+	assert.Equal(t, uint32(10), listReq.GetOffset())
+
+	err = client.Delete(context.Background(), "default", "gpu-kata")
+	require.NoError(t, err)
+	mock.mu.Lock()
+	deleteReq := mock.lastDelete
+	mock.mu.Unlock()
+	require.NotNil(t, deleteReq)
+	assert.Equal(t, "gpu-kata", deleteReq.GetName())
+	assert.Equal(t, "default", deleteReq.GetWorkspace())
+}
+
+func TestSandboxTemplateListAllWorkspacesClearsWorkspace(t *testing.T) {
+	mock := newMockTemplateServer()
+	client, cleanup := setupTemplateTest(t, mock)
+	defer cleanup()
+
+	_, err := client.List(context.Background(), "default", ListOptions{AllWorkspaces: true})
+	require.NoError(t, err)
+
+	mock.mu.Lock()
+	req := mock.lastList
+	mock.mu.Unlock()
+	require.NotNil(t, req)
+	assert.True(t, req.GetAllWorkspaces())
+	assert.Empty(t, req.GetWorkspace())
+}
+
+func TestSandboxTemplateListRejectsNegativePagination(t *testing.T) {
+	client, cleanup := setupTemplateTest(t, newMockTemplateServer())
+	defer cleanup()
+
+	_, err := client.List(context.Background(), "default", ListOptions{Limit: -1})
+	require.Error(t, err)
+	assert.True(t, IsInvalidArgument(err))
+
+	_, err = client.List(context.Background(), "default", ListOptions{Offset: -1})
+	require.Error(t, err)
+	assert.True(t, IsInvalidArgument(err))
+}
+
+func TestSandboxTemplateCreateRejectsNil(t *testing.T) {
+	client, cleanup := setupTemplateTest(t, newMockTemplateServer())
+	defer cleanup()
+
+	_, err := client.Create(context.Background(), "default", nil)
+	require.Error(t, err)
+	assert.True(t, IsInvalidArgument(err))
+}

--- a/sdk/go/openshell/v1/ssh_client_test.go
+++ b/sdk/go/openshell/v1/ssh_client_test.go
@@ -134,7 +134,11 @@ type mockSandboxResolver struct {
 	err       error
 }
 
-func (m *mockSandboxResolver) Create(_ context.Context, _, _ string, _ *SandboxSpec, _ map[string]string, _ ...CreateOptions) (*Sandbox, error) {
+func (m *mockSandboxResolver) Create(_ context.Context, _, _ string, _ *SandboxWorkloadConfig, _ *SandboxPolicy, _ []string, _ map[string]string, _ ...CreateOptions) (*Sandbox, error) {
+	return nil, nil
+}
+
+func (m *mockSandboxResolver) CreateFromTemplate(_ context.Context, _, _, _ string, _ *SandboxPolicy, _ []string, _ map[string]string, _ ...CreateOptions) (*Sandbox, error) {
 	return nil, nil
 }
 

--- a/sdk/go/openshell/v1/tcp_client_test.go
+++ b/sdk/go/openshell/v1/tcp_client_test.go
@@ -993,7 +993,10 @@ func (r *flippableResolver) Get(_ context.Context, _, name string) (*Sandbox, er
 	return &Sandbox{ID: "sb-" + name, Name: name}, nil
 }
 
-func (r *flippableResolver) Create(context.Context, string, string, *SandboxSpec, map[string]string, ...CreateOptions) (*Sandbox, error) {
+func (r *flippableResolver) Create(context.Context, string, string, *SandboxWorkloadConfig, *SandboxPolicy, []string, map[string]string, ...CreateOptions) (*Sandbox, error) {
+	panic("not implemented")
+}
+func (r *flippableResolver) CreateFromTemplate(context.Context, string, string, string, *SandboxPolicy, []string, map[string]string, ...CreateOptions) (*Sandbox, error) {
 	panic("not implemented")
 }
 func (r *flippableResolver) List(context.Context, string, ...ListOptions) ([]*Sandbox, error) {

--- a/sdk/go/openshell/v1/types/sandbox.go
+++ b/sdk/go/openshell/v1/types/sandbox.go
@@ -7,6 +7,44 @@ import "time"
 
 // Sandbox represents a sandbox instance.
 type Sandbox struct {
+	ID                  string
+	Name                string
+	CreatedAt           time.Time
+	Labels              map[string]string
+	Annotations         map[string]string
+	ResourceVersion     uint64
+	Workspace           string
+	DeletionTimestamp   *time.Time
+	CreatedFromTemplate *SandboxTemplateProvenance
+	Spec                SandboxSpec
+	Status              SandboxStatus
+}
+
+// SandboxSpec holds the desired state of a sandbox.
+type SandboxSpec struct {
+	Workload     *SandboxWorkloadConfig
+	DriverConfig map[string]any
+	Providers    []string
+	// Policy is the security policy for the sandbox. Nil means no policy specified.
+	Policy *SandboxPolicy
+}
+
+// SandboxWorkloadConfig defines the portable workload for a sandbox.
+type SandboxWorkloadConfig struct {
+	Image       string
+	Environment map[string]string
+	Resources   *SandboxResources
+}
+
+// SandboxResources defines portable sandbox resource requirements.
+type SandboxResources struct {
+	CPU      string
+	Memory   string
+	GPUCount *uint32
+}
+
+// SandboxTemplate is a reusable workspace-scoped sandbox template resource.
+type SandboxTemplate struct {
 	ID                string
 	Name              string
 	CreatedAt         time.Time
@@ -15,32 +53,31 @@ type Sandbox struct {
 	ResourceVersion   uint64
 	Workspace         string
 	DeletionTimestamp *time.Time
-	Spec              SandboxSpec
-	Status            SandboxStatus
+	Spec              SandboxTemplateSpec
 }
 
-// SandboxSpec holds the desired state of a sandbox.
-type SandboxSpec struct {
-	LogLevel    string
-	Environment map[string]string
-	Template    *SandboxTemplate
-	Providers   []string
-	GPUCount    *uint32
-	// Policy is the security policy for the sandbox. Nil means no policy specified.
-	Policy *SandboxPolicy
+// SandboxTemplateSpec holds reusable sandbox template settings.
+type SandboxTemplateSpec struct {
+	Workload            *SandboxWorkloadConfig
+	DriverConfig        map[string]any
+	DesiredServiceLevel *SandboxServiceLevel
 }
 
-// SandboxTemplate defines the container template for a sandbox.
-type SandboxTemplate struct {
-	Image            string
-	RuntimeClassName string
-	AgentSocket      string
-	Labels           map[string]string
-	Annotations      map[string]string
-	Environment      map[string]string
-	UserNamespaces   *bool
-	Resources        map[string]any
-	DriverConfig     map[string]any
+// SandboxServiceLevel describes desired operational characteristics.
+type SandboxServiceLevel struct {
+	Startup *SandboxStartup
+}
+
+// SandboxStartup describes desired startup characteristics.
+type SandboxStartup struct {
+	ReadyWithin time.Duration
+	MaxBurst    uint32
+}
+
+// SandboxTemplateProvenance identifies the template revision used to create a sandbox.
+type SandboxTemplateProvenance struct {
+	Name            string
+	ResourceVersion string
 }
 
 // SandboxStatus holds the observed state of a sandbox.

--- a/sdk/go/proto/openshellv1/openshell.pb.go
+++ b/sdk/go/proto/openshellv1/openshell.pb.go
@@ -15,6 +15,7 @@ import (
 	sandboxv1 "github.com/NVIDIA/OpenShell/sdk/go/proto/sandboxv1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 	reflect "reflect"
 	sync "sync"
@@ -1041,9 +1042,11 @@ type Sandbox struct {
 	// Desired sandbox configuration submitted through the API.
 	Spec *SandboxSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
 	// Latest user-facing observed status derived by the gateway.
-	Status        *SandboxStatus `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Status *SandboxStatus `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
+	// Read-only provenance for sandboxes created from a named template.
+	CreatedFromTemplate *SandboxTemplateProvenance `protobuf:"bytes,4,opt,name=created_from_template,json=createdFromTemplate,proto3" json:"created_from_template,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *Sandbox) Reset() {
@@ -1097,24 +1100,26 @@ func (x *Sandbox) GetStatus() *SandboxStatus {
 	return nil
 }
 
-// Desired sandbox configuration provided through the public API.
+func (x *Sandbox) GetCreatedFromTemplate() *SandboxTemplateProvenance {
+	if x != nil {
+		return x.CreatedFromTemplate
+	}
+	return nil
+}
+
+// Resolved desired sandbox configuration stored by the gateway.
 type SandboxSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Log level exposed to processes running inside the sandbox.
-	LogLevel string `protobuf:"bytes,1,opt,name=log_level,json=logLevel,proto3" json:"log_level,omitempty"`
-	// Environment variables injected into the sandbox runtime.
-	Environment map[string]string `protobuf:"bytes,5,rep,name=environment,proto3" json:"environment,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// Container or VM template used to provision the sandbox.
-	Template *SandboxTemplate `protobuf:"bytes,6,opt,name=template,proto3" json:"template,omitempty"`
+	// Portable workload shape used to provision the sandbox.
+	Workload *SandboxWorkloadConfig `protobuf:"bytes,12,opt,name=workload,proto3" json:"workload,omitempty"`
+	// Driver-keyed opaque config envelope resolved at create time.
+	DriverConfig *structpb.Struct `protobuf:"bytes,13,opt,name=driver_config,json=driverConfig,proto3" json:"driver_config,omitempty"`
 	// Required sandbox policy configuration.
-	Policy *sandboxv1.SandboxPolicy `protobuf:"bytes,7,opt,name=policy,proto3" json:"policy,omitempty"`
+	Policy *sandboxv1.SandboxPolicy `protobuf:"bytes,14,opt,name=policy,proto3" json:"policy,omitempty"`
 	// Provider names to attach to this sandbox.
-	Providers []string `protobuf:"bytes,8,rep,name=providers,proto3" json:"providers,omitempty"`
-	// Portable resource requirements used by the gateway for driver selection
-	// and by drivers for provisioning.
-	ResourceRequirements *ResourceRequirements `protobuf:"bytes,9,opt,name=resource_requirements,json=resourceRequirements,proto3" json:"resource_requirements,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	Providers     []string `protobuf:"bytes,15,rep,name=providers,proto3" json:"providers,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SandboxSpec) Reset() {
@@ -1147,23 +1152,16 @@ func (*SandboxSpec) Descriptor() ([]byte, []int) {
 	return file_openshell_proto_rawDescGZIP(), []int{13}
 }
 
-func (x *SandboxSpec) GetLogLevel() string {
+func (x *SandboxSpec) GetWorkload() *SandboxWorkloadConfig {
 	if x != nil {
-		return x.LogLevel
-	}
-	return ""
-}
-
-func (x *SandboxSpec) GetEnvironment() map[string]string {
-	if x != nil {
-		return x.Environment
+		return x.Workload
 	}
 	return nil
 }
 
-func (x *SandboxSpec) GetTemplate() *SandboxTemplate {
+func (x *SandboxSpec) GetDriverConfig() *structpb.Struct {
 	if x != nil {
-		return x.Template
+		return x.DriverConfig
 	}
 	return nil
 }
@@ -1182,35 +1180,33 @@ func (x *SandboxSpec) GetProviders() []string {
 	return nil
 }
 
-func (x *SandboxSpec) GetResourceRequirements() *ResourceRequirements {
-	if x != nil {
-		return x.ResourceRequirements
-	}
-	return nil
-}
-
-type ResourceRequirements struct {
+type SandboxWorkloadConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// GPU requirements for the sandbox. Presence indicates a GPU request.
-	Gpu           *GpuResourceRequirements `protobuf:"bytes,1,opt,name=gpu,proto3" json:"gpu,omitempty"`
+	// Fully-qualified OCI image reference used to boot the sandbox.
+	Image string `protobuf:"bytes,1,opt,name=image,proto3" json:"image,omitempty"`
+	// Environment variables injected into the sandbox runtime.
+	Environment map[string]string `protobuf:"bytes,2,rep,name=environment,proto3" json:"environment,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Portable resource requirements used by the gateway for driver selection
+	// and by drivers for provisioning.
+	Resources     *SandboxResources `protobuf:"bytes,3,opt,name=resources,proto3" json:"resources,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ResourceRequirements) Reset() {
-	*x = ResourceRequirements{}
+func (x *SandboxWorkloadConfig) Reset() {
+	*x = SandboxWorkloadConfig{}
 	mi := &file_openshell_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ResourceRequirements) String() string {
+func (x *SandboxWorkloadConfig) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ResourceRequirements) ProtoMessage() {}
+func (*SandboxWorkloadConfig) ProtoMessage() {}
 
-func (x *ResourceRequirements) ProtoReflect() protoreflect.Message {
+func (x *SandboxWorkloadConfig) ProtoReflect() protoreflect.Message {
 	mi := &file_openshell_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1222,42 +1218,58 @@ func (x *ResourceRequirements) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ResourceRequirements.ProtoReflect.Descriptor instead.
-func (*ResourceRequirements) Descriptor() ([]byte, []int) {
+// Deprecated: Use SandboxWorkloadConfig.ProtoReflect.Descriptor instead.
+func (*SandboxWorkloadConfig) Descriptor() ([]byte, []int) {
 	return file_openshell_proto_rawDescGZIP(), []int{14}
 }
 
-func (x *ResourceRequirements) GetGpu() *GpuResourceRequirements {
+func (x *SandboxWorkloadConfig) GetImage() string {
 	if x != nil {
-		return x.Gpu
+		return x.Image
+	}
+	return ""
+}
+
+func (x *SandboxWorkloadConfig) GetEnvironment() map[string]string {
+	if x != nil {
+		return x.Environment
 	}
 	return nil
 }
 
-// Public GPU resource requirements.
-type GpuResourceRequirements struct {
+func (x *SandboxWorkloadConfig) GetResources() *SandboxResources {
+	if x != nil {
+		return x.Resources
+	}
+	return nil
+}
+
+type SandboxResources struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Optional number of GPUs requested. When omitted, the request is for one
-	// GPU using the selected driver's default assignment behavior.
-	Count         *uint32 `protobuf:"varint,1,opt,name=count,proto3,oneof" json:"count,omitempty"`
+	// Portable CPU quantity, for example "500m" or "2".
+	Cpu string `protobuf:"bytes,1,opt,name=cpu,proto3" json:"cpu,omitempty"`
+	// Portable memory quantity, for example "512Mi" or "2Gi".
+	Memory string `protobuf:"bytes,2,opt,name=memory,proto3" json:"memory,omitempty"`
+	// Optional number of GPUs requested.
+	GpuCount      *uint32 `protobuf:"varint,3,opt,name=gpu_count,json=gpuCount,proto3,oneof" json:"gpu_count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GpuResourceRequirements) Reset() {
-	*x = GpuResourceRequirements{}
+func (x *SandboxResources) Reset() {
+	*x = SandboxResources{}
 	mi := &file_openshell_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GpuResourceRequirements) String() string {
+func (x *SandboxResources) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GpuResourceRequirements) ProtoMessage() {}
+func (*SandboxResources) ProtoMessage() {}
 
-func (x *GpuResourceRequirements) ProtoReflect() protoreflect.Message {
+func (x *SandboxResources) ProtoReflect() protoreflect.Message {
 	mi := &file_openshell_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1269,46 +1281,39 @@ func (x *GpuResourceRequirements) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GpuResourceRequirements.ProtoReflect.Descriptor instead.
-func (*GpuResourceRequirements) Descriptor() ([]byte, []int) {
+// Deprecated: Use SandboxResources.ProtoReflect.Descriptor instead.
+func (*SandboxResources) Descriptor() ([]byte, []int) {
 	return file_openshell_proto_rawDescGZIP(), []int{15}
 }
 
-func (x *GpuResourceRequirements) GetCount() uint32 {
-	if x != nil && x.Count != nil {
-		return *x.Count
+func (x *SandboxResources) GetCpu() string {
+	if x != nil {
+		return x.Cpu
+	}
+	return ""
+}
+
+func (x *SandboxResources) GetMemory() string {
+	if x != nil {
+		return x.Memory
+	}
+	return ""
+}
+
+func (x *SandboxResources) GetGpuCount() uint32 {
+	if x != nil && x.GpuCount != nil {
+		return *x.GpuCount
 	}
 	return 0
 }
 
-// Public sandbox template mapped onto compute-driver template inputs.
+// Reusable sandbox template resource scoped to a workspace.
 type SandboxTemplate struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Fully-qualified OCI image reference used to boot the sandbox.
-	Image string `protobuf:"bytes,1,opt,name=image,proto3" json:"image,omitempty"`
-	// Optional runtime class name requested from the compute platform.
-	RuntimeClassName string `protobuf:"bytes,2,opt,name=runtime_class_name,json=runtimeClassName,proto3" json:"runtime_class_name,omitempty"`
-	// Optional agent socket path exposed to the workload.
-	AgentSocket string `protobuf:"bytes,3,opt,name=agent_socket,json=agentSocket,proto3" json:"agent_socket,omitempty"`
-	// Labels applied to compute-platform resources for this sandbox.
-	Labels map[string]string `protobuf:"bytes,4,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// Annotations applied to compute-platform resources for this sandbox.
-	Annotations map[string]string `protobuf:"bytes,5,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// Additional environment variables injected by the template.
-	Environment map[string]string `protobuf:"bytes,6,rep,name=environment,proto3" json:"environment,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// Platform-specific compute resource requirements and limits.
-	Resources *structpb.Struct `protobuf:"bytes,7,opt,name=resources,proto3" json:"resources,omitempty"`
-	// Enable Kubernetes user namespace isolation (hostUsers: false).
-	// When true, container UID 0 maps to a non-root host UID and capabilities
-	// become namespaced. Requires Kubernetes 1.33+ with user namespace support
-	// available (beta through 1.35, GA in 1.36+) and a supporting runtime.
-	// When unset, the cluster-wide default is used.
-	UserNamespaces *bool `protobuf:"varint,10,opt,name=user_namespaces,json=userNamespaces,proto3,oneof" json:"user_namespaces,omitempty"`
-	// Driver-keyed opaque config envelope supplied by the caller.
-	// The gateway selects the block matching the active compute driver and
-	// forwards only that inner Struct to DriverSandboxTemplate.driver_config.
-	// The selected driver owns nested schema validation.
-	DriverConfig  *structpb.Struct `protobuf:"bytes,11,opt,name=driver_config,json=driverConfig,proto3" json:"driver_config,omitempty"`
+	// Kubernetes-style metadata (id, name, labels, timestamps, resource version).
+	Metadata *datamodelv1.ObjectMeta `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	// Desired reusable workload shape.
+	Spec          *SandboxTemplateSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1343,67 +1348,229 @@ func (*SandboxTemplate) Descriptor() ([]byte, []int) {
 	return file_openshell_proto_rawDescGZIP(), []int{16}
 }
 
-func (x *SandboxTemplate) GetImage() string {
+func (x *SandboxTemplate) GetMetadata() *datamodelv1.ObjectMeta {
 	if x != nil {
-		return x.Image
-	}
-	return ""
-}
-
-func (x *SandboxTemplate) GetRuntimeClassName() string {
-	if x != nil {
-		return x.RuntimeClassName
-	}
-	return ""
-}
-
-func (x *SandboxTemplate) GetAgentSocket() string {
-	if x != nil {
-		return x.AgentSocket
-	}
-	return ""
-}
-
-func (x *SandboxTemplate) GetLabels() map[string]string {
-	if x != nil {
-		return x.Labels
+		return x.Metadata
 	}
 	return nil
 }
 
-func (x *SandboxTemplate) GetAnnotations() map[string]string {
+func (x *SandboxTemplate) GetSpec() *SandboxTemplateSpec {
 	if x != nil {
-		return x.Annotations
+		return x.Spec
 	}
 	return nil
 }
 
-func (x *SandboxTemplate) GetEnvironment() map[string]string {
+type SandboxTemplateSpec struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Portable workload shape.
+	Workload *SandboxWorkloadConfig `protobuf:"bytes,1,opt,name=workload,proto3" json:"workload,omitempty"`
+	// Driver-keyed opaque config envelope supplied by the template owner.
+	DriverConfig *structpb.Struct `protobuf:"bytes,2,opt,name=driver_config,json=driverConfig,proto3" json:"driver_config,omitempty"`
+	// Desired service level associated with this template.
+	DesiredServiceLevel *SandboxServiceLevel `protobuf:"bytes,3,opt,name=desired_service_level,json=desiredServiceLevel,proto3" json:"desired_service_level,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *SandboxTemplateSpec) Reset() {
+	*x = SandboxTemplateSpec{}
+	mi := &file_openshell_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SandboxTemplateSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SandboxTemplateSpec) ProtoMessage() {}
+
+func (x *SandboxTemplateSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_proto_msgTypes[17]
 	if x != nil {
-		return x.Environment
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SandboxTemplateSpec.ProtoReflect.Descriptor instead.
+func (*SandboxTemplateSpec) Descriptor() ([]byte, []int) {
+	return file_openshell_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *SandboxTemplateSpec) GetWorkload() *SandboxWorkloadConfig {
+	if x != nil {
+		return x.Workload
 	}
 	return nil
 }
 
-func (x *SandboxTemplate) GetResources() *structpb.Struct {
-	if x != nil {
-		return x.Resources
-	}
-	return nil
-}
-
-func (x *SandboxTemplate) GetUserNamespaces() bool {
-	if x != nil && x.UserNamespaces != nil {
-		return *x.UserNamespaces
-	}
-	return false
-}
-
-func (x *SandboxTemplate) GetDriverConfig() *structpb.Struct {
+func (x *SandboxTemplateSpec) GetDriverConfig() *structpb.Struct {
 	if x != nil {
 		return x.DriverConfig
 	}
 	return nil
+}
+
+func (x *SandboxTemplateSpec) GetDesiredServiceLevel() *SandboxServiceLevel {
+	if x != nil {
+		return x.DesiredServiceLevel
+	}
+	return nil
+}
+
+type SandboxServiceLevel struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Startup       *SandboxStartup        `protobuf:"bytes,1,opt,name=startup,proto3" json:"startup,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SandboxServiceLevel) Reset() {
+	*x = SandboxServiceLevel{}
+	mi := &file_openshell_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SandboxServiceLevel) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SandboxServiceLevel) ProtoMessage() {}
+
+func (x *SandboxServiceLevel) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SandboxServiceLevel.ProtoReflect.Descriptor instead.
+func (*SandboxServiceLevel) Descriptor() ([]byte, []int) {
+	return file_openshell_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *SandboxServiceLevel) GetStartup() *SandboxStartup {
+	if x != nil {
+		return x.Startup
+	}
+	return nil
+}
+
+type SandboxStartup struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ReadyWithin   *durationpb.Duration   `protobuf:"bytes,1,opt,name=ready_within,json=readyWithin,proto3" json:"ready_within,omitempty"`
+	MaxBurst      uint32                 `protobuf:"varint,2,opt,name=max_burst,json=maxBurst,proto3" json:"max_burst,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SandboxStartup) Reset() {
+	*x = SandboxStartup{}
+	mi := &file_openshell_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SandboxStartup) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SandboxStartup) ProtoMessage() {}
+
+func (x *SandboxStartup) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SandboxStartup.ProtoReflect.Descriptor instead.
+func (*SandboxStartup) Descriptor() ([]byte, []int) {
+	return file_openshell_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *SandboxStartup) GetReadyWithin() *durationpb.Duration {
+	if x != nil {
+		return x.ReadyWithin
+	}
+	return nil
+}
+
+func (x *SandboxStartup) GetMaxBurst() uint32 {
+	if x != nil {
+		return x.MaxBurst
+	}
+	return 0
+}
+
+type SandboxTemplateProvenance struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Name            string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	ResourceVersion string                 `protobuf:"bytes,2,opt,name=resource_version,json=resourceVersion,proto3" json:"resource_version,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *SandboxTemplateProvenance) Reset() {
+	*x = SandboxTemplateProvenance{}
+	mi := &file_openshell_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SandboxTemplateProvenance) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SandboxTemplateProvenance) ProtoMessage() {}
+
+func (x *SandboxTemplateProvenance) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SandboxTemplateProvenance.ProtoReflect.Descriptor instead.
+func (*SandboxTemplateProvenance) Descriptor() ([]byte, []int) {
+	return file_openshell_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *SandboxTemplateProvenance) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *SandboxTemplateProvenance) GetResourceVersion() string {
+	if x != nil {
+		return x.ResourceVersion
+	}
+	return ""
 }
 
 // User-facing sandbox status derived by the gateway from compute-driver observations.
@@ -1431,7 +1598,7 @@ type SandboxStatus struct {
 
 func (x *SandboxStatus) Reset() {
 	*x = SandboxStatus{}
-	mi := &file_openshell_proto_msgTypes[17]
+	mi := &file_openshell_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1443,7 +1610,7 @@ func (x *SandboxStatus) String() string {
 func (*SandboxStatus) ProtoMessage() {}
 
 func (x *SandboxStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[17]
+	mi := &file_openshell_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1456,7 +1623,7 @@ func (x *SandboxStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxStatus.ProtoReflect.Descriptor instead.
 func (*SandboxStatus) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{17}
+	return file_openshell_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *SandboxStatus) GetSandboxName() string {
@@ -1527,7 +1694,7 @@ type SandboxCondition struct {
 
 func (x *SandboxCondition) Reset() {
 	*x = SandboxCondition{}
-	mi := &file_openshell_proto_msgTypes[18]
+	mi := &file_openshell_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1539,7 +1706,7 @@ func (x *SandboxCondition) String() string {
 func (*SandboxCondition) ProtoMessage() {}
 
 func (x *SandboxCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[18]
+	mi := &file_openshell_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1552,7 +1719,7 @@ func (x *SandboxCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxCondition.ProtoReflect.Descriptor instead.
 func (*SandboxCondition) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{18}
+	return file_openshell_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *SandboxCondition) GetType() string {
@@ -1611,7 +1778,7 @@ type PlatformEvent struct {
 
 func (x *PlatformEvent) Reset() {
 	*x = PlatformEvent{}
-	mi := &file_openshell_proto_msgTypes[19]
+	mi := &file_openshell_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1623,7 +1790,7 @@ func (x *PlatformEvent) String() string {
 func (*PlatformEvent) ProtoMessage() {}
 
 func (x *PlatformEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[19]
+	mi := &file_openshell_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1636,7 +1803,7 @@ func (x *PlatformEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlatformEvent.ProtoReflect.Descriptor instead.
 func (*PlatformEvent) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{19}
+	return file_openshell_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *PlatformEvent) GetTimestampMs() int64 {
@@ -1684,22 +1851,30 @@ func (x *PlatformEvent) GetMetadata() map[string]string {
 // Create sandbox request.
 type CreateSandboxRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	Spec  *SandboxSpec           `protobuf:"bytes,1,opt,name=spec,proto3" json:"spec,omitempty"`
+	// Types that are valid to be assigned to WorkloadSource:
+	//
+	//	*CreateSandboxRequest_Workload
+	//	*CreateSandboxRequest_WorkloadTemplateName
+	WorkloadSource isCreateSandboxRequest_WorkloadSource `protobuf_oneof:"workload_source"`
+	// Required sandbox policy configuration.
+	Policy *sandboxv1.SandboxPolicy `protobuf:"bytes,8,opt,name=policy,proto3" json:"policy,omitempty"`
+	// Provider names to attach to this sandbox.
+	Providers []string `protobuf:"bytes,9,rep,name=providers,proto3" json:"providers,omitempty"`
 	// Optional user-supplied sandbox name. When empty the server generates one.
-	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Name string `protobuf:"bytes,10,opt,name=name,proto3" json:"name,omitempty"`
 	// Optional labels for the sandbox (key-value metadata).
-	Labels map[string]string `protobuf:"bytes,3,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels map[string]string `protobuf:"bytes,11,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Optional annotations for the sandbox (non-selector metadata).
-	Annotations map[string]string `protobuf:"bytes,4,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Annotations map[string]string `protobuf:"bytes,12,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Workspace for the sandbox. Empty defaults to "default".
-	Workspace     string `protobuf:"bytes,5,opt,name=workspace,proto3" json:"workspace,omitempty"`
+	Workspace     string `protobuf:"bytes,13,opt,name=workspace,proto3" json:"workspace,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateSandboxRequest) Reset() {
 	*x = CreateSandboxRequest{}
-	mi := &file_openshell_proto_msgTypes[20]
+	mi := &file_openshell_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1711,7 +1886,7 @@ func (x *CreateSandboxRequest) String() string {
 func (*CreateSandboxRequest) ProtoMessage() {}
 
 func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[20]
+	mi := &file_openshell_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1724,12 +1899,44 @@ func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*CreateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{20}
+	return file_openshell_proto_rawDescGZIP(), []int{24}
 }
 
-func (x *CreateSandboxRequest) GetSpec() *SandboxSpec {
+func (x *CreateSandboxRequest) GetWorkloadSource() isCreateSandboxRequest_WorkloadSource {
 	if x != nil {
-		return x.Spec
+		return x.WorkloadSource
+	}
+	return nil
+}
+
+func (x *CreateSandboxRequest) GetWorkload() *SandboxWorkloadConfig {
+	if x != nil {
+		if x, ok := x.WorkloadSource.(*CreateSandboxRequest_Workload); ok {
+			return x.Workload
+		}
+	}
+	return nil
+}
+
+func (x *CreateSandboxRequest) GetWorkloadTemplateName() string {
+	if x != nil {
+		if x, ok := x.WorkloadSource.(*CreateSandboxRequest_WorkloadTemplateName); ok {
+			return x.WorkloadTemplateName
+		}
+	}
+	return ""
+}
+
+func (x *CreateSandboxRequest) GetPolicy() *sandboxv1.SandboxPolicy {
+	if x != nil {
+		return x.Policy
+	}
+	return nil
+}
+
+func (x *CreateSandboxRequest) GetProviders() []string {
+	if x != nil {
+		return x.Providers
 	}
 	return nil
 }
@@ -1762,6 +1969,385 @@ func (x *CreateSandboxRequest) GetWorkspace() string {
 	return ""
 }
 
+type isCreateSandboxRequest_WorkloadSource interface {
+	isCreateSandboxRequest_WorkloadSource()
+}
+
+type CreateSandboxRequest_Workload struct {
+	// Inline portable workload config for this sandbox.
+	Workload *SandboxWorkloadConfig `protobuf:"bytes,6,opt,name=workload,proto3,oneof"`
+}
+
+type CreateSandboxRequest_WorkloadTemplateName struct {
+	// Workspace-scoped template name to resolve at creation time.
+	WorkloadTemplateName string `protobuf:"bytes,7,opt,name=workload_template_name,json=workloadTemplateName,proto3,oneof"`
+}
+
+func (*CreateSandboxRequest_Workload) isCreateSandboxRequest_WorkloadSource() {}
+
+func (*CreateSandboxRequest_WorkloadTemplateName) isCreateSandboxRequest_WorkloadSource() {}
+
+type CreateSandboxTemplateRequest struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Template *SandboxTemplate       `protobuf:"bytes,1,opt,name=template,proto3" json:"template,omitempty"`
+	// Workspace for the template. Empty defaults to "default".
+	Workspace     string `protobuf:"bytes,2,opt,name=workspace,proto3" json:"workspace,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateSandboxTemplateRequest) Reset() {
+	*x = CreateSandboxTemplateRequest{}
+	mi := &file_openshell_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateSandboxTemplateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateSandboxTemplateRequest) ProtoMessage() {}
+
+func (x *CreateSandboxTemplateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateSandboxTemplateRequest.ProtoReflect.Descriptor instead.
+func (*CreateSandboxTemplateRequest) Descriptor() ([]byte, []int) {
+	return file_openshell_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *CreateSandboxTemplateRequest) GetTemplate() *SandboxTemplate {
+	if x != nil {
+		return x.Template
+	}
+	return nil
+}
+
+func (x *CreateSandboxTemplateRequest) GetWorkspace() string {
+	if x != nil {
+		return x.Workspace
+	}
+	return ""
+}
+
+type GetSandboxTemplateRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Workspace scope. Empty defaults to "default".
+	Workspace     string `protobuf:"bytes,2,opt,name=workspace,proto3" json:"workspace,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSandboxTemplateRequest) Reset() {
+	*x = GetSandboxTemplateRequest{}
+	mi := &file_openshell_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSandboxTemplateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSandboxTemplateRequest) ProtoMessage() {}
+
+func (x *GetSandboxTemplateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSandboxTemplateRequest.ProtoReflect.Descriptor instead.
+func (*GetSandboxTemplateRequest) Descriptor() ([]byte, []int) {
+	return file_openshell_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *GetSandboxTemplateRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *GetSandboxTemplateRequest) GetWorkspace() string {
+	if x != nil {
+		return x.Workspace
+	}
+	return ""
+}
+
+type ListSandboxTemplatesRequest struct {
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Limit  uint32                 `protobuf:"varint,1,opt,name=limit,proto3" json:"limit,omitempty"`
+	Offset uint32                 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`
+	// Workspace scope. Empty defaults to "default".
+	Workspace string `protobuf:"bytes,3,opt,name=workspace,proto3" json:"workspace,omitempty"`
+	// List across all workspaces. Mutually exclusive with workspace.
+	AllWorkspaces bool `protobuf:"varint,4,opt,name=all_workspaces,json=allWorkspaces,proto3" json:"all_workspaces,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSandboxTemplatesRequest) Reset() {
+	*x = ListSandboxTemplatesRequest{}
+	mi := &file_openshell_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSandboxTemplatesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSandboxTemplatesRequest) ProtoMessage() {}
+
+func (x *ListSandboxTemplatesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSandboxTemplatesRequest.ProtoReflect.Descriptor instead.
+func (*ListSandboxTemplatesRequest) Descriptor() ([]byte, []int) {
+	return file_openshell_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *ListSandboxTemplatesRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *ListSandboxTemplatesRequest) GetOffset() uint32 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+func (x *ListSandboxTemplatesRequest) GetWorkspace() string {
+	if x != nil {
+		return x.Workspace
+	}
+	return ""
+}
+
+func (x *ListSandboxTemplatesRequest) GetAllWorkspaces() bool {
+	if x != nil {
+		return x.AllWorkspaces
+	}
+	return false
+}
+
+type DeleteSandboxTemplateRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Workspace scope. Empty defaults to "default".
+	Workspace     string `protobuf:"bytes,2,opt,name=workspace,proto3" json:"workspace,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSandboxTemplateRequest) Reset() {
+	*x = DeleteSandboxTemplateRequest{}
+	mi := &file_openshell_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSandboxTemplateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSandboxTemplateRequest) ProtoMessage() {}
+
+func (x *DeleteSandboxTemplateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteSandboxTemplateRequest.ProtoReflect.Descriptor instead.
+func (*DeleteSandboxTemplateRequest) Descriptor() ([]byte, []int) {
+	return file_openshell_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *DeleteSandboxTemplateRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *DeleteSandboxTemplateRequest) GetWorkspace() string {
+	if x != nil {
+		return x.Workspace
+	}
+	return ""
+}
+
+type SandboxTemplateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Template      *SandboxTemplate       `protobuf:"bytes,1,opt,name=template,proto3" json:"template,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SandboxTemplateResponse) Reset() {
+	*x = SandboxTemplateResponse{}
+	mi := &file_openshell_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SandboxTemplateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SandboxTemplateResponse) ProtoMessage() {}
+
+func (x *SandboxTemplateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SandboxTemplateResponse.ProtoReflect.Descriptor instead.
+func (*SandboxTemplateResponse) Descriptor() ([]byte, []int) {
+	return file_openshell_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *SandboxTemplateResponse) GetTemplate() *SandboxTemplate {
+	if x != nil {
+		return x.Template
+	}
+	return nil
+}
+
+type ListSandboxTemplatesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Templates     []*SandboxTemplate     `protobuf:"bytes,1,rep,name=templates,proto3" json:"templates,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSandboxTemplatesResponse) Reset() {
+	*x = ListSandboxTemplatesResponse{}
+	mi := &file_openshell_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSandboxTemplatesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSandboxTemplatesResponse) ProtoMessage() {}
+
+func (x *ListSandboxTemplatesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSandboxTemplatesResponse.ProtoReflect.Descriptor instead.
+func (*ListSandboxTemplatesResponse) Descriptor() ([]byte, []int) {
+	return file_openshell_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *ListSandboxTemplatesResponse) GetTemplates() []*SandboxTemplate {
+	if x != nil {
+		return x.Templates
+	}
+	return nil
+}
+
+type DeleteSandboxTemplateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Deleted       bool                   `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSandboxTemplateResponse) Reset() {
+	*x = DeleteSandboxTemplateResponse{}
+	mi := &file_openshell_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSandboxTemplateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSandboxTemplateResponse) ProtoMessage() {}
+
+func (x *DeleteSandboxTemplateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteSandboxTemplateResponse.ProtoReflect.Descriptor instead.
+func (*DeleteSandboxTemplateResponse) Descriptor() ([]byte, []int) {
+	return file_openshell_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *DeleteSandboxTemplateResponse) GetDeleted() bool {
+	if x != nil {
+		return x.Deleted
+	}
+	return false
+}
+
 // Get sandbox request.
 type GetSandboxRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1775,7 +2361,7 @@ type GetSandboxRequest struct {
 
 func (x *GetSandboxRequest) Reset() {
 	*x = GetSandboxRequest{}
-	mi := &file_openshell_proto_msgTypes[21]
+	mi := &file_openshell_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1787,7 +2373,7 @@ func (x *GetSandboxRequest) String() string {
 func (*GetSandboxRequest) ProtoMessage() {}
 
 func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[21]
+	mi := &file_openshell_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1800,7 +2386,7 @@ func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{21}
+	return file_openshell_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetSandboxRequest) GetName() string {
@@ -1834,7 +2420,7 @@ type ListSandboxesRequest struct {
 
 func (x *ListSandboxesRequest) Reset() {
 	*x = ListSandboxesRequest{}
-	mi := &file_openshell_proto_msgTypes[22]
+	mi := &file_openshell_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1846,7 +2432,7 @@ func (x *ListSandboxesRequest) String() string {
 func (*ListSandboxesRequest) ProtoMessage() {}
 
 func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[22]
+	mi := &file_openshell_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1859,7 +2445,7 @@ func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{22}
+	return file_openshell_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ListSandboxesRequest) GetLimit() uint32 {
@@ -1910,7 +2496,7 @@ type ListSandboxProvidersRequest struct {
 
 func (x *ListSandboxProvidersRequest) Reset() {
 	*x = ListSandboxProvidersRequest{}
-	mi := &file_openshell_proto_msgTypes[23]
+	mi := &file_openshell_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1922,7 +2508,7 @@ func (x *ListSandboxProvidersRequest) String() string {
 func (*ListSandboxProvidersRequest) ProtoMessage() {}
 
 func (x *ListSandboxProvidersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[23]
+	mi := &file_openshell_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1935,7 +2521,7 @@ func (x *ListSandboxProvidersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxProvidersRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxProvidersRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{23}
+	return file_openshell_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ListSandboxProvidersRequest) GetSandboxName() string {
@@ -1972,7 +2558,7 @@ type AttachSandboxProviderRequest struct {
 
 func (x *AttachSandboxProviderRequest) Reset() {
 	*x = AttachSandboxProviderRequest{}
-	mi := &file_openshell_proto_msgTypes[24]
+	mi := &file_openshell_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1984,7 +2570,7 @@ func (x *AttachSandboxProviderRequest) String() string {
 func (*AttachSandboxProviderRequest) ProtoMessage() {}
 
 func (x *AttachSandboxProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[24]
+	mi := &file_openshell_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1997,7 +2583,7 @@ func (x *AttachSandboxProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachSandboxProviderRequest.ProtoReflect.Descriptor instead.
 func (*AttachSandboxProviderRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{24}
+	return file_openshell_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *AttachSandboxProviderRequest) GetSandboxName() string {
@@ -2048,7 +2634,7 @@ type DetachSandboxProviderRequest struct {
 
 func (x *DetachSandboxProviderRequest) Reset() {
 	*x = DetachSandboxProviderRequest{}
-	mi := &file_openshell_proto_msgTypes[25]
+	mi := &file_openshell_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2060,7 +2646,7 @@ func (x *DetachSandboxProviderRequest) String() string {
 func (*DetachSandboxProviderRequest) ProtoMessage() {}
 
 func (x *DetachSandboxProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[25]
+	mi := &file_openshell_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2073,7 +2659,7 @@ func (x *DetachSandboxProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DetachSandboxProviderRequest.ProtoReflect.Descriptor instead.
 func (*DetachSandboxProviderRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{25}
+	return file_openshell_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *DetachSandboxProviderRequest) GetSandboxName() string {
@@ -2117,7 +2703,7 @@ type DeleteSandboxRequest struct {
 
 func (x *DeleteSandboxRequest) Reset() {
 	*x = DeleteSandboxRequest{}
-	mi := &file_openshell_proto_msgTypes[26]
+	mi := &file_openshell_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2129,7 +2715,7 @@ func (x *DeleteSandboxRequest) String() string {
 func (*DeleteSandboxRequest) ProtoMessage() {}
 
 func (x *DeleteSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[26]
+	mi := &file_openshell_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2142,7 +2728,7 @@ func (x *DeleteSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSandboxRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{26}
+	return file_openshell_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *DeleteSandboxRequest) GetName() string {
@@ -2172,7 +2758,7 @@ type StopSandboxRequest struct {
 
 func (x *StopSandboxRequest) Reset() {
 	*x = StopSandboxRequest{}
-	mi := &file_openshell_proto_msgTypes[27]
+	mi := &file_openshell_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2184,7 +2770,7 @@ func (x *StopSandboxRequest) String() string {
 func (*StopSandboxRequest) ProtoMessage() {}
 
 func (x *StopSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[27]
+	mi := &file_openshell_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2197,7 +2783,7 @@ func (x *StopSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopSandboxRequest.ProtoReflect.Descriptor instead.
 func (*StopSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{27}
+	return file_openshell_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *StopSandboxRequest) GetName() string {
@@ -2227,7 +2813,7 @@ type StartSandboxRequest struct {
 
 func (x *StartSandboxRequest) Reset() {
 	*x = StartSandboxRequest{}
-	mi := &file_openshell_proto_msgTypes[28]
+	mi := &file_openshell_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2239,7 +2825,7 @@ func (x *StartSandboxRequest) String() string {
 func (*StartSandboxRequest) ProtoMessage() {}
 
 func (x *StartSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[28]
+	mi := &file_openshell_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2252,7 +2838,7 @@ func (x *StartSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartSandboxRequest.ProtoReflect.Descriptor instead.
 func (*StartSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{28}
+	return file_openshell_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *StartSandboxRequest) GetName() string {
@@ -2279,7 +2865,7 @@ type SandboxResponse struct {
 
 func (x *SandboxResponse) Reset() {
 	*x = SandboxResponse{}
-	mi := &file_openshell_proto_msgTypes[29]
+	mi := &file_openshell_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2291,7 +2877,7 @@ func (x *SandboxResponse) String() string {
 func (*SandboxResponse) ProtoMessage() {}
 
 func (x *SandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[29]
+	mi := &file_openshell_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2304,7 +2890,7 @@ func (x *SandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxResponse.ProtoReflect.Descriptor instead.
 func (*SandboxResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{29}
+	return file_openshell_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *SandboxResponse) GetSandbox() *Sandbox {
@@ -2324,7 +2910,7 @@ type ListSandboxesResponse struct {
 
 func (x *ListSandboxesResponse) Reset() {
 	*x = ListSandboxesResponse{}
-	mi := &file_openshell_proto_msgTypes[30]
+	mi := &file_openshell_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2336,7 +2922,7 @@ func (x *ListSandboxesResponse) String() string {
 func (*ListSandboxesResponse) ProtoMessage() {}
 
 func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[30]
+	mi := &file_openshell_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2349,7 +2935,7 @@ func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{30}
+	return file_openshell_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ListSandboxesResponse) GetSandboxes() []*Sandbox {
@@ -2369,7 +2955,7 @@ type ListSandboxProvidersResponse struct {
 
 func (x *ListSandboxProvidersResponse) Reset() {
 	*x = ListSandboxProvidersResponse{}
-	mi := &file_openshell_proto_msgTypes[31]
+	mi := &file_openshell_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2381,7 +2967,7 @@ func (x *ListSandboxProvidersResponse) String() string {
 func (*ListSandboxProvidersResponse) ProtoMessage() {}
 
 func (x *ListSandboxProvidersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[31]
+	mi := &file_openshell_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2394,7 +2980,7 @@ func (x *ListSandboxProvidersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxProvidersResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxProvidersResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{31}
+	return file_openshell_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ListSandboxProvidersResponse) GetProviders() []*datamodelv1.Provider {
@@ -2416,7 +3002,7 @@ type AttachSandboxProviderResponse struct {
 
 func (x *AttachSandboxProviderResponse) Reset() {
 	*x = AttachSandboxProviderResponse{}
-	mi := &file_openshell_proto_msgTypes[32]
+	mi := &file_openshell_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2428,7 +3014,7 @@ func (x *AttachSandboxProviderResponse) String() string {
 func (*AttachSandboxProviderResponse) ProtoMessage() {}
 
 func (x *AttachSandboxProviderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[32]
+	mi := &file_openshell_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2441,7 +3027,7 @@ func (x *AttachSandboxProviderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachSandboxProviderResponse.ProtoReflect.Descriptor instead.
 func (*AttachSandboxProviderResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{32}
+	return file_openshell_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *AttachSandboxProviderResponse) GetSandbox() *Sandbox {
@@ -2470,7 +3056,7 @@ type DetachSandboxProviderResponse struct {
 
 func (x *DetachSandboxProviderResponse) Reset() {
 	*x = DetachSandboxProviderResponse{}
-	mi := &file_openshell_proto_msgTypes[33]
+	mi := &file_openshell_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2482,7 +3068,7 @@ func (x *DetachSandboxProviderResponse) String() string {
 func (*DetachSandboxProviderResponse) ProtoMessage() {}
 
 func (x *DetachSandboxProviderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[33]
+	mi := &file_openshell_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2495,7 +3081,7 @@ func (x *DetachSandboxProviderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DetachSandboxProviderResponse.ProtoReflect.Descriptor instead.
 func (*DetachSandboxProviderResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{33}
+	return file_openshell_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *DetachSandboxProviderResponse) GetSandbox() *Sandbox {
@@ -2522,7 +3108,7 @@ type DeleteSandboxResponse struct {
 
 func (x *DeleteSandboxResponse) Reset() {
 	*x = DeleteSandboxResponse{}
-	mi := &file_openshell_proto_msgTypes[34]
+	mi := &file_openshell_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2534,7 +3120,7 @@ func (x *DeleteSandboxResponse) String() string {
 func (*DeleteSandboxResponse) ProtoMessage() {}
 
 func (x *DeleteSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[34]
+	mi := &file_openshell_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2547,7 +3133,7 @@ func (x *DeleteSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSandboxResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{34}
+	return file_openshell_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *DeleteSandboxResponse) GetDeleted() bool {
@@ -2568,7 +3154,7 @@ type CreateSshSessionRequest struct {
 
 func (x *CreateSshSessionRequest) Reset() {
 	*x = CreateSshSessionRequest{}
-	mi := &file_openshell_proto_msgTypes[35]
+	mi := &file_openshell_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2580,7 +3166,7 @@ func (x *CreateSshSessionRequest) String() string {
 func (*CreateSshSessionRequest) ProtoMessage() {}
 
 func (x *CreateSshSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[35]
+	mi := &file_openshell_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2593,7 +3179,7 @@ func (x *CreateSshSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSshSessionRequest.ProtoReflect.Descriptor instead.
 func (*CreateSshSessionRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{35}
+	return file_openshell_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *CreateSshSessionRequest) GetSandboxId() string {
@@ -2636,7 +3222,7 @@ type CreateSshSessionResponse struct {
 
 func (x *CreateSshSessionResponse) Reset() {
 	*x = CreateSshSessionResponse{}
-	mi := &file_openshell_proto_msgTypes[36]
+	mi := &file_openshell_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2648,7 +3234,7 @@ func (x *CreateSshSessionResponse) String() string {
 func (*CreateSshSessionResponse) ProtoMessage() {}
 
 func (x *CreateSshSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[36]
+	mi := &file_openshell_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2661,7 +3247,7 @@ func (x *CreateSshSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSshSessionResponse.ProtoReflect.Descriptor instead.
 func (*CreateSshSessionResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{36}
+	return file_openshell_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *CreateSshSessionResponse) GetSandboxId() string {
@@ -2732,7 +3318,7 @@ type ExposeServiceRequest struct {
 
 func (x *ExposeServiceRequest) Reset() {
 	*x = ExposeServiceRequest{}
-	mi := &file_openshell_proto_msgTypes[37]
+	mi := &file_openshell_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2744,7 +3330,7 @@ func (x *ExposeServiceRequest) String() string {
 func (*ExposeServiceRequest) ProtoMessage() {}
 
 func (x *ExposeServiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[37]
+	mi := &file_openshell_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2757,7 +3343,7 @@ func (x *ExposeServiceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExposeServiceRequest.ProtoReflect.Descriptor instead.
 func (*ExposeServiceRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{37}
+	return file_openshell_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *ExposeServiceRequest) GetSandbox() string {
@@ -2810,7 +3396,7 @@ type GetServiceRequest struct {
 
 func (x *GetServiceRequest) Reset() {
 	*x = GetServiceRequest{}
-	mi := &file_openshell_proto_msgTypes[38]
+	mi := &file_openshell_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2822,7 +3408,7 @@ func (x *GetServiceRequest) String() string {
 func (*GetServiceRequest) ProtoMessage() {}
 
 func (x *GetServiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[38]
+	mi := &file_openshell_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2835,7 +3421,7 @@ func (x *GetServiceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetServiceRequest.ProtoReflect.Descriptor instead.
 func (*GetServiceRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{38}
+	return file_openshell_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *GetServiceRequest) GetSandbox() string {
@@ -2878,7 +3464,7 @@ type ListServicesRequest struct {
 
 func (x *ListServicesRequest) Reset() {
 	*x = ListServicesRequest{}
-	mi := &file_openshell_proto_msgTypes[39]
+	mi := &file_openshell_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2890,7 +3476,7 @@ func (x *ListServicesRequest) String() string {
 func (*ListServicesRequest) ProtoMessage() {}
 
 func (x *ListServicesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[39]
+	mi := &file_openshell_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2903,7 +3489,7 @@ func (x *ListServicesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListServicesRequest.ProtoReflect.Descriptor instead.
 func (*ListServicesRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{39}
+	return file_openshell_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *ListServicesRequest) GetSandbox() string {
@@ -2951,7 +3537,7 @@ type ListServicesResponse struct {
 
 func (x *ListServicesResponse) Reset() {
 	*x = ListServicesResponse{}
-	mi := &file_openshell_proto_msgTypes[40]
+	mi := &file_openshell_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2963,7 +3549,7 @@ func (x *ListServicesResponse) String() string {
 func (*ListServicesResponse) ProtoMessage() {}
 
 func (x *ListServicesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[40]
+	mi := &file_openshell_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2976,7 +3562,7 @@ func (x *ListServicesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListServicesResponse.ProtoReflect.Descriptor instead.
 func (*ListServicesResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{40}
+	return file_openshell_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ListServicesResponse) GetServices() []*ServiceEndpointResponse {
@@ -3001,7 +3587,7 @@ type DeleteServiceRequest struct {
 
 func (x *DeleteServiceRequest) Reset() {
 	*x = DeleteServiceRequest{}
-	mi := &file_openshell_proto_msgTypes[41]
+	mi := &file_openshell_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3013,7 +3599,7 @@ func (x *DeleteServiceRequest) String() string {
 func (*DeleteServiceRequest) ProtoMessage() {}
 
 func (x *DeleteServiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[41]
+	mi := &file_openshell_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3026,7 +3612,7 @@ func (x *DeleteServiceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteServiceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteServiceRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{41}
+	return file_openshell_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *DeleteServiceRequest) GetSandbox() string {
@@ -3061,7 +3647,7 @@ type DeleteServiceResponse struct {
 
 func (x *DeleteServiceResponse) Reset() {
 	*x = DeleteServiceResponse{}
-	mi := &file_openshell_proto_msgTypes[42]
+	mi := &file_openshell_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3073,7 +3659,7 @@ func (x *DeleteServiceResponse) String() string {
 func (*DeleteServiceResponse) ProtoMessage() {}
 
 func (x *DeleteServiceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[42]
+	mi := &file_openshell_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3086,7 +3672,7 @@ func (x *DeleteServiceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteServiceResponse.ProtoReflect.Descriptor instead.
 func (*DeleteServiceResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{42}
+	return file_openshell_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *DeleteServiceResponse) GetDeleted() bool {
@@ -3117,7 +3703,7 @@ type ServiceEndpoint struct {
 
 func (x *ServiceEndpoint) Reset() {
 	*x = ServiceEndpoint{}
-	mi := &file_openshell_proto_msgTypes[43]
+	mi := &file_openshell_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3129,7 +3715,7 @@ func (x *ServiceEndpoint) String() string {
 func (*ServiceEndpoint) ProtoMessage() {}
 
 func (x *ServiceEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[43]
+	mi := &file_openshell_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3142,7 +3728,7 @@ func (x *ServiceEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceEndpoint.ProtoReflect.Descriptor instead.
 func (*ServiceEndpoint) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{43}
+	return file_openshell_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ServiceEndpoint) GetMetadata() *datamodelv1.ObjectMeta {
@@ -3198,7 +3784,7 @@ type ServiceEndpointResponse struct {
 
 func (x *ServiceEndpointResponse) Reset() {
 	*x = ServiceEndpointResponse{}
-	mi := &file_openshell_proto_msgTypes[44]
+	mi := &file_openshell_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3210,7 +3796,7 @@ func (x *ServiceEndpointResponse) String() string {
 func (*ServiceEndpointResponse) ProtoMessage() {}
 
 func (x *ServiceEndpointResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[44]
+	mi := &file_openshell_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3223,7 +3809,7 @@ func (x *ServiceEndpointResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceEndpointResponse.ProtoReflect.Descriptor instead.
 func (*ServiceEndpointResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{44}
+	return file_openshell_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *ServiceEndpointResponse) GetEndpoint() *ServiceEndpoint {
@@ -3251,7 +3837,7 @@ type RevokeSshSessionRequest struct {
 
 func (x *RevokeSshSessionRequest) Reset() {
 	*x = RevokeSshSessionRequest{}
-	mi := &file_openshell_proto_msgTypes[45]
+	mi := &file_openshell_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3263,7 +3849,7 @@ func (x *RevokeSshSessionRequest) String() string {
 func (*RevokeSshSessionRequest) ProtoMessage() {}
 
 func (x *RevokeSshSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[45]
+	mi := &file_openshell_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3276,7 +3862,7 @@ func (x *RevokeSshSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeSshSessionRequest.ProtoReflect.Descriptor instead.
 func (*RevokeSshSessionRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{45}
+	return file_openshell_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *RevokeSshSessionRequest) GetToken() string {
@@ -3297,7 +3883,7 @@ type RevokeSshSessionResponse struct {
 
 func (x *RevokeSshSessionResponse) Reset() {
 	*x = RevokeSshSessionResponse{}
-	mi := &file_openshell_proto_msgTypes[46]
+	mi := &file_openshell_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3309,7 +3895,7 @@ func (x *RevokeSshSessionResponse) String() string {
 func (*RevokeSshSessionResponse) ProtoMessage() {}
 
 func (x *RevokeSshSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[46]
+	mi := &file_openshell_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3322,7 +3908,7 @@ func (x *RevokeSshSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeSshSessionResponse.ProtoReflect.Descriptor instead.
 func (*RevokeSshSessionResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{46}
+	return file_openshell_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *RevokeSshSessionResponse) GetRevoked() bool {
@@ -3359,7 +3945,7 @@ type ExecSandboxRequest struct {
 
 func (x *ExecSandboxRequest) Reset() {
 	*x = ExecSandboxRequest{}
-	mi := &file_openshell_proto_msgTypes[47]
+	mi := &file_openshell_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3371,7 +3957,7 @@ func (x *ExecSandboxRequest) String() string {
 func (*ExecSandboxRequest) ProtoMessage() {}
 
 func (x *ExecSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[47]
+	mi := &file_openshell_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3384,7 +3970,7 @@ func (x *ExecSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSandboxRequest.ProtoReflect.Descriptor instead.
 func (*ExecSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{47}
+	return file_openshell_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *ExecSandboxRequest) GetSandboxId() string {
@@ -3460,7 +4046,7 @@ type ExecSandboxStdout struct {
 
 func (x *ExecSandboxStdout) Reset() {
 	*x = ExecSandboxStdout{}
-	mi := &file_openshell_proto_msgTypes[48]
+	mi := &file_openshell_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3472,7 +4058,7 @@ func (x *ExecSandboxStdout) String() string {
 func (*ExecSandboxStdout) ProtoMessage() {}
 
 func (x *ExecSandboxStdout) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[48]
+	mi := &file_openshell_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3485,7 +4071,7 @@ func (x *ExecSandboxStdout) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSandboxStdout.ProtoReflect.Descriptor instead.
 func (*ExecSandboxStdout) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{48}
+	return file_openshell_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *ExecSandboxStdout) GetData() []byte {
@@ -3505,7 +4091,7 @@ type ExecSandboxStderr struct {
 
 func (x *ExecSandboxStderr) Reset() {
 	*x = ExecSandboxStderr{}
-	mi := &file_openshell_proto_msgTypes[49]
+	mi := &file_openshell_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3517,7 +4103,7 @@ func (x *ExecSandboxStderr) String() string {
 func (*ExecSandboxStderr) ProtoMessage() {}
 
 func (x *ExecSandboxStderr) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[49]
+	mi := &file_openshell_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3530,7 +4116,7 @@ func (x *ExecSandboxStderr) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSandboxStderr.ProtoReflect.Descriptor instead.
 func (*ExecSandboxStderr) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{49}
+	return file_openshell_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *ExecSandboxStderr) GetData() []byte {
@@ -3550,7 +4136,7 @@ type ExecSandboxExit struct {
 
 func (x *ExecSandboxExit) Reset() {
 	*x = ExecSandboxExit{}
-	mi := &file_openshell_proto_msgTypes[50]
+	mi := &file_openshell_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3562,7 +4148,7 @@ func (x *ExecSandboxExit) String() string {
 func (*ExecSandboxExit) ProtoMessage() {}
 
 func (x *ExecSandboxExit) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[50]
+	mi := &file_openshell_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3575,7 +4161,7 @@ func (x *ExecSandboxExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSandboxExit.ProtoReflect.Descriptor instead.
 func (*ExecSandboxExit) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{50}
+	return file_openshell_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *ExecSandboxExit) GetExitCode() int32 {
@@ -3600,7 +4186,7 @@ type ExecSandboxEvent struct {
 
 func (x *ExecSandboxEvent) Reset() {
 	*x = ExecSandboxEvent{}
-	mi := &file_openshell_proto_msgTypes[51]
+	mi := &file_openshell_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3612,7 +4198,7 @@ func (x *ExecSandboxEvent) String() string {
 func (*ExecSandboxEvent) ProtoMessage() {}
 
 func (x *ExecSandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[51]
+	mi := &file_openshell_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3625,7 +4211,7 @@ func (x *ExecSandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSandboxEvent.ProtoReflect.Descriptor instead.
 func (*ExecSandboxEvent) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{51}
+	return file_openshell_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *ExecSandboxEvent) GetPayload() isExecSandboxEvent_Payload {
@@ -3707,7 +4293,7 @@ type TcpForwardInit struct {
 
 func (x *TcpForwardInit) Reset() {
 	*x = TcpForwardInit{}
-	mi := &file_openshell_proto_msgTypes[52]
+	mi := &file_openshell_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3719,7 +4305,7 @@ func (x *TcpForwardInit) String() string {
 func (*TcpForwardInit) ProtoMessage() {}
 
 func (x *TcpForwardInit) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[52]
+	mi := &file_openshell_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3732,7 +4318,7 @@ func (x *TcpForwardInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TcpForwardInit.ProtoReflect.Descriptor instead.
 func (*TcpForwardInit) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{52}
+	return file_openshell_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *TcpForwardInit) GetSandboxId() string {
@@ -3811,7 +4397,7 @@ type TcpForwardFrame struct {
 
 func (x *TcpForwardFrame) Reset() {
 	*x = TcpForwardFrame{}
-	mi := &file_openshell_proto_msgTypes[53]
+	mi := &file_openshell_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3823,7 +4409,7 @@ func (x *TcpForwardFrame) String() string {
 func (*TcpForwardFrame) ProtoMessage() {}
 
 func (x *TcpForwardFrame) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[53]
+	mi := &file_openshell_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3836,7 +4422,7 @@ func (x *TcpForwardFrame) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TcpForwardFrame.ProtoReflect.Descriptor instead.
 func (*TcpForwardFrame) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{53}
+	return file_openshell_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *TcpForwardFrame) GetPayload() isTcpForwardFrame_Payload {
@@ -3895,7 +4481,7 @@ type ExecSandboxInput struct {
 
 func (x *ExecSandboxInput) Reset() {
 	*x = ExecSandboxInput{}
-	mi := &file_openshell_proto_msgTypes[54]
+	mi := &file_openshell_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3907,7 +4493,7 @@ func (x *ExecSandboxInput) String() string {
 func (*ExecSandboxInput) ProtoMessage() {}
 
 func (x *ExecSandboxInput) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[54]
+	mi := &file_openshell_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3920,7 +4506,7 @@ func (x *ExecSandboxInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSandboxInput.ProtoReflect.Descriptor instead.
 func (*ExecSandboxInput) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{54}
+	return file_openshell_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ExecSandboxInput) GetPayload() isExecSandboxInput_Payload {
@@ -3993,7 +4579,7 @@ type ExecSandboxWindowResize struct {
 
 func (x *ExecSandboxWindowResize) Reset() {
 	*x = ExecSandboxWindowResize{}
-	mi := &file_openshell_proto_msgTypes[55]
+	mi := &file_openshell_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4005,7 +4591,7 @@ func (x *ExecSandboxWindowResize) String() string {
 func (*ExecSandboxWindowResize) ProtoMessage() {}
 
 func (x *ExecSandboxWindowResize) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[55]
+	mi := &file_openshell_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4018,7 +4604,7 @@ func (x *ExecSandboxWindowResize) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSandboxWindowResize.ProtoReflect.Descriptor instead.
 func (*ExecSandboxWindowResize) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{55}
+	return file_openshell_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *ExecSandboxWindowResize) GetCols() uint32 {
@@ -4055,7 +4641,7 @@ type SshSession struct {
 
 func (x *SshSession) Reset() {
 	*x = SshSession{}
-	mi := &file_openshell_proto_msgTypes[56]
+	mi := &file_openshell_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4067,7 +4653,7 @@ func (x *SshSession) String() string {
 func (*SshSession) ProtoMessage() {}
 
 func (x *SshSession) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[56]
+	mi := &file_openshell_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4080,7 +4666,7 @@ func (x *SshSession) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SshSession.ProtoReflect.Descriptor instead.
 func (*SshSession) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{56}
+	return file_openshell_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *SshSession) GetMetadata() *datamodelv1.ObjectMeta {
@@ -4148,7 +4734,7 @@ type WatchSandboxRequest struct {
 
 func (x *WatchSandboxRequest) Reset() {
 	*x = WatchSandboxRequest{}
-	mi := &file_openshell_proto_msgTypes[57]
+	mi := &file_openshell_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4160,7 +4746,7 @@ func (x *WatchSandboxRequest) String() string {
 func (*WatchSandboxRequest) ProtoMessage() {}
 
 func (x *WatchSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[57]
+	mi := &file_openshell_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4173,7 +4759,7 @@ func (x *WatchSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSandboxRequest.ProtoReflect.Descriptor instead.
 func (*WatchSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{57}
+	return file_openshell_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *WatchSandboxRequest) GetId() string {
@@ -4263,7 +4849,7 @@ type SandboxStreamEvent struct {
 
 func (x *SandboxStreamEvent) Reset() {
 	*x = SandboxStreamEvent{}
-	mi := &file_openshell_proto_msgTypes[58]
+	mi := &file_openshell_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4275,7 +4861,7 @@ func (x *SandboxStreamEvent) String() string {
 func (*SandboxStreamEvent) ProtoMessage() {}
 
 func (x *SandboxStreamEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[58]
+	mi := &file_openshell_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4288,7 +4874,7 @@ func (x *SandboxStreamEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxStreamEvent.ProtoReflect.Descriptor instead.
 func (*SandboxStreamEvent) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{58}
+	return file_openshell_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *SandboxStreamEvent) GetPayload() isSandboxStreamEvent_Payload {
@@ -4401,7 +4987,7 @@ type SandboxLogLine struct {
 
 func (x *SandboxLogLine) Reset() {
 	*x = SandboxLogLine{}
-	mi := &file_openshell_proto_msgTypes[59]
+	mi := &file_openshell_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4413,7 +4999,7 @@ func (x *SandboxLogLine) String() string {
 func (*SandboxLogLine) ProtoMessage() {}
 
 func (x *SandboxLogLine) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[59]
+	mi := &file_openshell_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4426,7 +5012,7 @@ func (x *SandboxLogLine) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxLogLine.ProtoReflect.Descriptor instead.
 func (*SandboxLogLine) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{59}
+	return file_openshell_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *SandboxLogLine) GetSandboxId() string {
@@ -4487,7 +5073,7 @@ type SandboxStreamWarning struct {
 
 func (x *SandboxStreamWarning) Reset() {
 	*x = SandboxStreamWarning{}
-	mi := &file_openshell_proto_msgTypes[60]
+	mi := &file_openshell_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4499,7 +5085,7 @@ func (x *SandboxStreamWarning) String() string {
 func (*SandboxStreamWarning) ProtoMessage() {}
 
 func (x *SandboxStreamWarning) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[60]
+	mi := &file_openshell_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4512,7 +5098,7 @@ func (x *SandboxStreamWarning) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxStreamWarning.ProtoReflect.Descriptor instead.
 func (*SandboxStreamWarning) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{60}
+	return file_openshell_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *SandboxStreamWarning) GetMessage() string {
@@ -4534,7 +5120,7 @@ type CreateProviderRequest struct {
 
 func (x *CreateProviderRequest) Reset() {
 	*x = CreateProviderRequest{}
-	mi := &file_openshell_proto_msgTypes[61]
+	mi := &file_openshell_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4546,7 +5132,7 @@ func (x *CreateProviderRequest) String() string {
 func (*CreateProviderRequest) ProtoMessage() {}
 
 func (x *CreateProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[61]
+	mi := &file_openshell_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4559,7 +5145,7 @@ func (x *CreateProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateProviderRequest.ProtoReflect.Descriptor instead.
 func (*CreateProviderRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{61}
+	return file_openshell_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *CreateProviderRequest) GetProvider() *datamodelv1.Provider {
@@ -4588,7 +5174,7 @@ type GetProviderRequest struct {
 
 func (x *GetProviderRequest) Reset() {
 	*x = GetProviderRequest{}
-	mi := &file_openshell_proto_msgTypes[62]
+	mi := &file_openshell_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4600,7 +5186,7 @@ func (x *GetProviderRequest) String() string {
 func (*GetProviderRequest) ProtoMessage() {}
 
 func (x *GetProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[62]
+	mi := &file_openshell_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4613,7 +5199,7 @@ func (x *GetProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProviderRequest.ProtoReflect.Descriptor instead.
 func (*GetProviderRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{62}
+	return file_openshell_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *GetProviderRequest) GetName() string {
@@ -4645,7 +5231,7 @@ type ListProvidersRequest struct {
 
 func (x *ListProvidersRequest) Reset() {
 	*x = ListProvidersRequest{}
-	mi := &file_openshell_proto_msgTypes[63]
+	mi := &file_openshell_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4657,7 +5243,7 @@ func (x *ListProvidersRequest) String() string {
 func (*ListProvidersRequest) ProtoMessage() {}
 
 func (x *ListProvidersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[63]
+	mi := &file_openshell_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4670,7 +5256,7 @@ func (x *ListProvidersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListProvidersRequest.ProtoReflect.Descriptor instead.
 func (*ListProvidersRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{63}
+	return file_openshell_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *ListProvidersRequest) GetLimit() uint32 {
@@ -4716,7 +5302,7 @@ type UpdateProviderRequest struct {
 
 func (x *UpdateProviderRequest) Reset() {
 	*x = UpdateProviderRequest{}
-	mi := &file_openshell_proto_msgTypes[64]
+	mi := &file_openshell_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4728,7 +5314,7 @@ func (x *UpdateProviderRequest) String() string {
 func (*UpdateProviderRequest) ProtoMessage() {}
 
 func (x *UpdateProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[64]
+	mi := &file_openshell_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4741,7 +5327,7 @@ func (x *UpdateProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProviderRequest.ProtoReflect.Descriptor instead.
 func (*UpdateProviderRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{64}
+	return file_openshell_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *UpdateProviderRequest) GetProvider() *datamodelv1.Provider {
@@ -4777,7 +5363,7 @@ type DeleteProviderRequest struct {
 
 func (x *DeleteProviderRequest) Reset() {
 	*x = DeleteProviderRequest{}
-	mi := &file_openshell_proto_msgTypes[65]
+	mi := &file_openshell_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4789,7 +5375,7 @@ func (x *DeleteProviderRequest) String() string {
 func (*DeleteProviderRequest) ProtoMessage() {}
 
 func (x *DeleteProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[65]
+	mi := &file_openshell_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4802,7 +5388,7 @@ func (x *DeleteProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProviderRequest.ProtoReflect.Descriptor instead.
 func (*DeleteProviderRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{65}
+	return file_openshell_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *DeleteProviderRequest) GetName() string {
@@ -4829,7 +5415,7 @@ type ProviderResponse struct {
 
 func (x *ProviderResponse) Reset() {
 	*x = ProviderResponse{}
-	mi := &file_openshell_proto_msgTypes[66]
+	mi := &file_openshell_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4841,7 +5427,7 @@ func (x *ProviderResponse) String() string {
 func (*ProviderResponse) ProtoMessage() {}
 
 func (x *ProviderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[66]
+	mi := &file_openshell_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4854,7 +5440,7 @@ func (x *ProviderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderResponse.ProtoReflect.Descriptor instead.
 func (*ProviderResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{66}
+	return file_openshell_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *ProviderResponse) GetProvider() *datamodelv1.Provider {
@@ -4874,7 +5460,7 @@ type ListProvidersResponse struct {
 
 func (x *ListProvidersResponse) Reset() {
 	*x = ListProvidersResponse{}
-	mi := &file_openshell_proto_msgTypes[67]
+	mi := &file_openshell_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4886,7 +5472,7 @@ func (x *ListProvidersResponse) String() string {
 func (*ListProvidersResponse) ProtoMessage() {}
 
 func (x *ListProvidersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[67]
+	mi := &file_openshell_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4899,7 +5485,7 @@ func (x *ListProvidersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListProvidersResponse.ProtoReflect.Descriptor instead.
 func (*ListProvidersResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{67}
+	return file_openshell_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *ListProvidersResponse) GetProviders() []*datamodelv1.Provider {
@@ -4923,7 +5509,7 @@ type ListProviderProfilesRequest struct {
 
 func (x *ListProviderProfilesRequest) Reset() {
 	*x = ListProviderProfilesRequest{}
-	mi := &file_openshell_proto_msgTypes[68]
+	mi := &file_openshell_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4935,7 +5521,7 @@ func (x *ListProviderProfilesRequest) String() string {
 func (*ListProviderProfilesRequest) ProtoMessage() {}
 
 func (x *ListProviderProfilesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[68]
+	mi := &file_openshell_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4948,7 +5534,7 @@ func (x *ListProviderProfilesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListProviderProfilesRequest.ProtoReflect.Descriptor instead.
 func (*ListProviderProfilesRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{68}
+	return file_openshell_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *ListProviderProfilesRequest) GetLimit() uint32 {
@@ -4986,7 +5572,7 @@ type GetProviderProfileRequest struct {
 
 func (x *GetProviderProfileRequest) Reset() {
 	*x = GetProviderProfileRequest{}
-	mi := &file_openshell_proto_msgTypes[69]
+	mi := &file_openshell_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4998,7 +5584,7 @@ func (x *GetProviderProfileRequest) String() string {
 func (*GetProviderProfileRequest) ProtoMessage() {}
 
 func (x *GetProviderProfileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[69]
+	mi := &file_openshell_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5011,7 +5597,7 @@ func (x *GetProviderProfileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProviderProfileRequest.ProtoReflect.Descriptor instead.
 func (*GetProviderProfileRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{69}
+	return file_openshell_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *GetProviderProfileRequest) GetId() string {
@@ -5039,7 +5625,7 @@ type ProviderProfileImportItem struct {
 
 func (x *ProviderProfileImportItem) Reset() {
 	*x = ProviderProfileImportItem{}
-	mi := &file_openshell_proto_msgTypes[70]
+	mi := &file_openshell_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5051,7 +5637,7 @@ func (x *ProviderProfileImportItem) String() string {
 func (*ProviderProfileImportItem) ProtoMessage() {}
 
 func (x *ProviderProfileImportItem) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[70]
+	mi := &file_openshell_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5064,7 +5650,7 @@ func (x *ProviderProfileImportItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderProfileImportItem.ProtoReflect.Descriptor instead.
 func (*ProviderProfileImportItem) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{70}
+	return file_openshell_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *ProviderProfileImportItem) GetProfile() *ProviderProfile {
@@ -5095,7 +5681,7 @@ type ProviderProfileDiagnostic struct {
 
 func (x *ProviderProfileDiagnostic) Reset() {
 	*x = ProviderProfileDiagnostic{}
-	mi := &file_openshell_proto_msgTypes[71]
+	mi := &file_openshell_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5107,7 +5693,7 @@ func (x *ProviderProfileDiagnostic) String() string {
 func (*ProviderProfileDiagnostic) ProtoMessage() {}
 
 func (x *ProviderProfileDiagnostic) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[71]
+	mi := &file_openshell_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5120,7 +5706,7 @@ func (x *ProviderProfileDiagnostic) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderProfileDiagnostic.ProtoReflect.Descriptor instead.
 func (*ProviderProfileDiagnostic) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{71}
+	return file_openshell_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *ProviderProfileDiagnostic) GetSource() string {
@@ -5177,7 +5763,7 @@ type ProviderCredentialTokenGrantAudienceOverride struct {
 
 func (x *ProviderCredentialTokenGrantAudienceOverride) Reset() {
 	*x = ProviderCredentialTokenGrantAudienceOverride{}
-	mi := &file_openshell_proto_msgTypes[72]
+	mi := &file_openshell_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5189,7 +5775,7 @@ func (x *ProviderCredentialTokenGrantAudienceOverride) String() string {
 func (*ProviderCredentialTokenGrantAudienceOverride) ProtoMessage() {}
 
 func (x *ProviderCredentialTokenGrantAudienceOverride) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[72]
+	mi := &file_openshell_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5202,7 +5788,7 @@ func (x *ProviderCredentialTokenGrantAudienceOverride) ProtoReflect() protorefle
 
 // Deprecated: Use ProviderCredentialTokenGrantAudienceOverride.ProtoReflect.Descriptor instead.
 func (*ProviderCredentialTokenGrantAudienceOverride) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{72}
+	return file_openshell_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *ProviderCredentialTokenGrantAudienceOverride) GetHost() string {
@@ -5267,7 +5853,7 @@ type ProviderCredentialTokenGrant struct {
 
 func (x *ProviderCredentialTokenGrant) Reset() {
 	*x = ProviderCredentialTokenGrant{}
-	mi := &file_openshell_proto_msgTypes[73]
+	mi := &file_openshell_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5279,7 +5865,7 @@ func (x *ProviderCredentialTokenGrant) String() string {
 func (*ProviderCredentialTokenGrant) ProtoMessage() {}
 
 func (x *ProviderCredentialTokenGrant) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[73]
+	mi := &file_openshell_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5292,7 +5878,7 @@ func (x *ProviderCredentialTokenGrant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderCredentialTokenGrant.ProtoReflect.Descriptor instead.
 func (*ProviderCredentialTokenGrant) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{73}
+	return file_openshell_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *ProviderCredentialTokenGrant) GetTokenEndpoint() string {
@@ -5363,7 +5949,7 @@ type ProviderProfileCredential struct {
 
 func (x *ProviderProfileCredential) Reset() {
 	*x = ProviderProfileCredential{}
-	mi := &file_openshell_proto_msgTypes[74]
+	mi := &file_openshell_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5375,7 +5961,7 @@ func (x *ProviderProfileCredential) String() string {
 func (*ProviderProfileCredential) ProtoMessage() {}
 
 func (x *ProviderProfileCredential) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[74]
+	mi := &file_openshell_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5388,7 +5974,7 @@ func (x *ProviderProfileCredential) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderProfileCredential.ProtoReflect.Descriptor instead.
 func (*ProviderProfileCredential) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{74}
+	return file_openshell_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *ProviderProfileCredential) GetName() string {
@@ -5473,7 +6059,7 @@ type ProviderCredentialRefreshMaterial struct {
 
 func (x *ProviderCredentialRefreshMaterial) Reset() {
 	*x = ProviderCredentialRefreshMaterial{}
-	mi := &file_openshell_proto_msgTypes[75]
+	mi := &file_openshell_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5485,7 +6071,7 @@ func (x *ProviderCredentialRefreshMaterial) String() string {
 func (*ProviderCredentialRefreshMaterial) ProtoMessage() {}
 
 func (x *ProviderCredentialRefreshMaterial) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[75]
+	mi := &file_openshell_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5498,7 +6084,7 @@ func (x *ProviderCredentialRefreshMaterial) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ProviderCredentialRefreshMaterial.ProtoReflect.Descriptor instead.
 func (*ProviderCredentialRefreshMaterial) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{75}
+	return file_openshell_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *ProviderCredentialRefreshMaterial) GetName() string {
@@ -5543,7 +6129,7 @@ type ProviderCredentialRefreshOutput struct {
 
 func (x *ProviderCredentialRefreshOutput) Reset() {
 	*x = ProviderCredentialRefreshOutput{}
-	mi := &file_openshell_proto_msgTypes[76]
+	mi := &file_openshell_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5555,7 +6141,7 @@ func (x *ProviderCredentialRefreshOutput) String() string {
 func (*ProviderCredentialRefreshOutput) ProtoMessage() {}
 
 func (x *ProviderCredentialRefreshOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[76]
+	mi := &file_openshell_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5568,7 +6154,7 @@ func (x *ProviderCredentialRefreshOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderCredentialRefreshOutput.ProtoReflect.Descriptor instead.
 func (*ProviderCredentialRefreshOutput) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{76}
+	return file_openshell_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *ProviderCredentialRefreshOutput) GetOutput() string {
@@ -5600,7 +6186,7 @@ type ProviderCredentialRefresh struct {
 
 func (x *ProviderCredentialRefresh) Reset() {
 	*x = ProviderCredentialRefresh{}
-	mi := &file_openshell_proto_msgTypes[77]
+	mi := &file_openshell_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5612,7 +6198,7 @@ func (x *ProviderCredentialRefresh) String() string {
 func (*ProviderCredentialRefresh) ProtoMessage() {}
 
 func (x *ProviderCredentialRefresh) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[77]
+	mi := &file_openshell_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5625,7 +6211,7 @@ func (x *ProviderCredentialRefresh) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderCredentialRefresh.ProtoReflect.Descriptor instead.
 func (*ProviderCredentialRefresh) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{77}
+	return file_openshell_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *ProviderCredentialRefresh) GetStrategy() ProviderCredentialRefreshStrategy {
@@ -5694,7 +6280,7 @@ type ProviderCredentialRefreshStatus struct {
 
 func (x *ProviderCredentialRefreshStatus) Reset() {
 	*x = ProviderCredentialRefreshStatus{}
-	mi := &file_openshell_proto_msgTypes[78]
+	mi := &file_openshell_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5706,7 +6292,7 @@ func (x *ProviderCredentialRefreshStatus) String() string {
 func (*ProviderCredentialRefreshStatus) ProtoMessage() {}
 
 func (x *ProviderCredentialRefreshStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[78]
+	mi := &file_openshell_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5719,7 +6305,7 @@ func (x *ProviderCredentialRefreshStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderCredentialRefreshStatus.ProtoReflect.Descriptor instead.
 func (*ProviderCredentialRefreshStatus) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{78}
+	return file_openshell_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *ProviderCredentialRefreshStatus) GetProviderName() string {
@@ -5796,7 +6382,7 @@ type ProviderProfileDiscovery struct {
 
 func (x *ProviderProfileDiscovery) Reset() {
 	*x = ProviderProfileDiscovery{}
-	mi := &file_openshell_proto_msgTypes[79]
+	mi := &file_openshell_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5808,7 +6394,7 @@ func (x *ProviderProfileDiscovery) String() string {
 func (*ProviderProfileDiscovery) ProtoMessage() {}
 
 func (x *ProviderProfileDiscovery) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[79]
+	mi := &file_openshell_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5821,7 +6407,7 @@ func (x *ProviderProfileDiscovery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderProfileDiscovery.ProtoReflect.Descriptor instead.
 func (*ProviderProfileDiscovery) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{79}
+	return file_openshell_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *ProviderProfileDiscovery) GetCredentials() []string {
@@ -5860,7 +6446,7 @@ type StoredProviderCredentialRefreshState struct {
 
 func (x *StoredProviderCredentialRefreshState) Reset() {
 	*x = StoredProviderCredentialRefreshState{}
-	mi := &file_openshell_proto_msgTypes[80]
+	mi := &file_openshell_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5872,7 +6458,7 @@ func (x *StoredProviderCredentialRefreshState) String() string {
 func (*StoredProviderCredentialRefreshState) ProtoMessage() {}
 
 func (x *StoredProviderCredentialRefreshState) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[80]
+	mi := &file_openshell_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5885,7 +6471,7 @@ func (x *StoredProviderCredentialRefreshState) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use StoredProviderCredentialRefreshState.ProtoReflect.Descriptor instead.
 func (*StoredProviderCredentialRefreshState) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{80}
+	return file_openshell_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *StoredProviderCredentialRefreshState) GetMetadata() *datamodelv1.ObjectMeta {
@@ -6019,7 +6605,7 @@ type GetProviderRefreshStatusRequest struct {
 
 func (x *GetProviderRefreshStatusRequest) Reset() {
 	*x = GetProviderRefreshStatusRequest{}
-	mi := &file_openshell_proto_msgTypes[81]
+	mi := &file_openshell_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6031,7 +6617,7 @@ func (x *GetProviderRefreshStatusRequest) String() string {
 func (*GetProviderRefreshStatusRequest) ProtoMessage() {}
 
 func (x *GetProviderRefreshStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[81]
+	mi := &file_openshell_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6044,7 +6630,7 @@ func (x *GetProviderRefreshStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProviderRefreshStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetProviderRefreshStatusRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{81}
+	return file_openshell_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *GetProviderRefreshStatusRequest) GetProvider() string {
@@ -6077,7 +6663,7 @@ type GetProviderRefreshStatusResponse struct {
 
 func (x *GetProviderRefreshStatusResponse) Reset() {
 	*x = GetProviderRefreshStatusResponse{}
-	mi := &file_openshell_proto_msgTypes[82]
+	mi := &file_openshell_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6089,7 +6675,7 @@ func (x *GetProviderRefreshStatusResponse) String() string {
 func (*GetProviderRefreshStatusResponse) ProtoMessage() {}
 
 func (x *GetProviderRefreshStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[82]
+	mi := &file_openshell_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6102,7 +6688,7 @@ func (x *GetProviderRefreshStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProviderRefreshStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetProviderRefreshStatusResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{82}
+	return file_openshell_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *GetProviderRefreshStatusResponse) GetCredentials() []*ProviderCredentialRefreshStatus {
@@ -6128,7 +6714,7 @@ type ConfigureProviderRefreshRequest struct {
 
 func (x *ConfigureProviderRefreshRequest) Reset() {
 	*x = ConfigureProviderRefreshRequest{}
-	mi := &file_openshell_proto_msgTypes[83]
+	mi := &file_openshell_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6140,7 +6726,7 @@ func (x *ConfigureProviderRefreshRequest) String() string {
 func (*ConfigureProviderRefreshRequest) ProtoMessage() {}
 
 func (x *ConfigureProviderRefreshRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[83]
+	mi := &file_openshell_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6153,7 +6739,7 @@ func (x *ConfigureProviderRefreshRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigureProviderRefreshRequest.ProtoReflect.Descriptor instead.
 func (*ConfigureProviderRefreshRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{83}
+	return file_openshell_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *ConfigureProviderRefreshRequest) GetProvider() string {
@@ -6214,7 +6800,7 @@ type ConfigureProviderRefreshResponse struct {
 
 func (x *ConfigureProviderRefreshResponse) Reset() {
 	*x = ConfigureProviderRefreshResponse{}
-	mi := &file_openshell_proto_msgTypes[84]
+	mi := &file_openshell_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6226,7 +6812,7 @@ func (x *ConfigureProviderRefreshResponse) String() string {
 func (*ConfigureProviderRefreshResponse) ProtoMessage() {}
 
 func (x *ConfigureProviderRefreshResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[84]
+	mi := &file_openshell_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6239,7 +6825,7 @@ func (x *ConfigureProviderRefreshResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigureProviderRefreshResponse.ProtoReflect.Descriptor instead.
 func (*ConfigureProviderRefreshResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{84}
+	return file_openshell_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *ConfigureProviderRefreshResponse) GetStatus() *ProviderCredentialRefreshStatus {
@@ -6261,7 +6847,7 @@ type RotateProviderCredentialRequest struct {
 
 func (x *RotateProviderCredentialRequest) Reset() {
 	*x = RotateProviderCredentialRequest{}
-	mi := &file_openshell_proto_msgTypes[85]
+	mi := &file_openshell_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6273,7 +6859,7 @@ func (x *RotateProviderCredentialRequest) String() string {
 func (*RotateProviderCredentialRequest) ProtoMessage() {}
 
 func (x *RotateProviderCredentialRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[85]
+	mi := &file_openshell_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6286,7 +6872,7 @@ func (x *RotateProviderCredentialRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RotateProviderCredentialRequest.ProtoReflect.Descriptor instead.
 func (*RotateProviderCredentialRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{85}
+	return file_openshell_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *RotateProviderCredentialRequest) GetProvider() string {
@@ -6319,7 +6905,7 @@ type RotateProviderCredentialResponse struct {
 
 func (x *RotateProviderCredentialResponse) Reset() {
 	*x = RotateProviderCredentialResponse{}
-	mi := &file_openshell_proto_msgTypes[86]
+	mi := &file_openshell_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6331,7 +6917,7 @@ func (x *RotateProviderCredentialResponse) String() string {
 func (*RotateProviderCredentialResponse) ProtoMessage() {}
 
 func (x *RotateProviderCredentialResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[86]
+	mi := &file_openshell_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6344,7 +6930,7 @@ func (x *RotateProviderCredentialResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RotateProviderCredentialResponse.ProtoReflect.Descriptor instead.
 func (*RotateProviderCredentialResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{86}
+	return file_openshell_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *RotateProviderCredentialResponse) GetStatus() *ProviderCredentialRefreshStatus {
@@ -6366,7 +6952,7 @@ type DeleteProviderRefreshRequest struct {
 
 func (x *DeleteProviderRefreshRequest) Reset() {
 	*x = DeleteProviderRefreshRequest{}
-	mi := &file_openshell_proto_msgTypes[87]
+	mi := &file_openshell_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6378,7 +6964,7 @@ func (x *DeleteProviderRefreshRequest) String() string {
 func (*DeleteProviderRefreshRequest) ProtoMessage() {}
 
 func (x *DeleteProviderRefreshRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[87]
+	mi := &file_openshell_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6391,7 +6977,7 @@ func (x *DeleteProviderRefreshRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProviderRefreshRequest.ProtoReflect.Descriptor instead.
 func (*DeleteProviderRefreshRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{87}
+	return file_openshell_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *DeleteProviderRefreshRequest) GetProvider() string {
@@ -6424,7 +7010,7 @@ type DeleteProviderRefreshResponse struct {
 
 func (x *DeleteProviderRefreshResponse) Reset() {
 	*x = DeleteProviderRefreshResponse{}
-	mi := &file_openshell_proto_msgTypes[88]
+	mi := &file_openshell_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6436,7 +7022,7 @@ func (x *DeleteProviderRefreshResponse) String() string {
 func (*DeleteProviderRefreshResponse) ProtoMessage() {}
 
 func (x *DeleteProviderRefreshResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[88]
+	mi := &file_openshell_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6449,7 +7035,7 @@ func (x *DeleteProviderRefreshResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProviderRefreshResponse.ProtoReflect.Descriptor instead.
 func (*DeleteProviderRefreshResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{88}
+	return file_openshell_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *DeleteProviderRefreshResponse) GetDeleted() bool {
@@ -6489,7 +7075,7 @@ type ProviderProfile struct {
 
 func (x *ProviderProfile) Reset() {
 	*x = ProviderProfile{}
-	mi := &file_openshell_proto_msgTypes[89]
+	mi := &file_openshell_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6501,7 +7087,7 @@ func (x *ProviderProfile) String() string {
 func (*ProviderProfile) ProtoMessage() {}
 
 func (x *ProviderProfile) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[89]
+	mi := &file_openshell_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6514,7 +7100,7 @@ func (x *ProviderProfile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderProfile.ProtoReflect.Descriptor instead.
 func (*ProviderProfile) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{89}
+	return file_openshell_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *ProviderProfile) GetId() string {
@@ -6619,7 +7205,7 @@ type StoredProviderProfile struct {
 
 func (x *StoredProviderProfile) Reset() {
 	*x = StoredProviderProfile{}
-	mi := &file_openshell_proto_msgTypes[90]
+	mi := &file_openshell_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6631,7 +7217,7 @@ func (x *StoredProviderProfile) String() string {
 func (*StoredProviderProfile) ProtoMessage() {}
 
 func (x *StoredProviderProfile) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[90]
+	mi := &file_openshell_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6644,7 +7230,7 @@ func (x *StoredProviderProfile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StoredProviderProfile.ProtoReflect.Descriptor instead.
 func (*StoredProviderProfile) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{90}
+	return file_openshell_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *StoredProviderProfile) GetMetadata() *datamodelv1.ObjectMeta {
@@ -6671,7 +7257,7 @@ type ProviderProfileResponse struct {
 
 func (x *ProviderProfileResponse) Reset() {
 	*x = ProviderProfileResponse{}
-	mi := &file_openshell_proto_msgTypes[91]
+	mi := &file_openshell_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6683,7 +7269,7 @@ func (x *ProviderProfileResponse) String() string {
 func (*ProviderProfileResponse) ProtoMessage() {}
 
 func (x *ProviderProfileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[91]
+	mi := &file_openshell_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6696,7 +7282,7 @@ func (x *ProviderProfileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderProfileResponse.ProtoReflect.Descriptor instead.
 func (*ProviderProfileResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{91}
+	return file_openshell_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *ProviderProfileResponse) GetProfile() *ProviderProfile {
@@ -6716,7 +7302,7 @@ type ListProviderProfilesResponse struct {
 
 func (x *ListProviderProfilesResponse) Reset() {
 	*x = ListProviderProfilesResponse{}
-	mi := &file_openshell_proto_msgTypes[92]
+	mi := &file_openshell_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6728,7 +7314,7 @@ func (x *ListProviderProfilesResponse) String() string {
 func (*ListProviderProfilesResponse) ProtoMessage() {}
 
 func (x *ListProviderProfilesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[92]
+	mi := &file_openshell_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6741,7 +7327,7 @@ func (x *ListProviderProfilesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListProviderProfilesResponse.ProtoReflect.Descriptor instead.
 func (*ListProviderProfilesResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{92}
+	return file_openshell_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *ListProviderProfilesResponse) GetProfiles() []*ProviderProfile {
@@ -6764,7 +7350,7 @@ type ImportProviderProfilesRequest struct {
 
 func (x *ImportProviderProfilesRequest) Reset() {
 	*x = ImportProviderProfilesRequest{}
-	mi := &file_openshell_proto_msgTypes[93]
+	mi := &file_openshell_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6776,7 +7362,7 @@ func (x *ImportProviderProfilesRequest) String() string {
 func (*ImportProviderProfilesRequest) ProtoMessage() {}
 
 func (x *ImportProviderProfilesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[93]
+	mi := &file_openshell_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6789,7 +7375,7 @@ func (x *ImportProviderProfilesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportProviderProfilesRequest.ProtoReflect.Descriptor instead.
 func (*ImportProviderProfilesRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{93}
+	return file_openshell_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *ImportProviderProfilesRequest) GetProfiles() []*ProviderProfileImportItem {
@@ -6818,7 +7404,7 @@ type ImportProviderProfilesResponse struct {
 
 func (x *ImportProviderProfilesResponse) Reset() {
 	*x = ImportProviderProfilesResponse{}
-	mi := &file_openshell_proto_msgTypes[94]
+	mi := &file_openshell_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6830,7 +7416,7 @@ func (x *ImportProviderProfilesResponse) String() string {
 func (*ImportProviderProfilesResponse) ProtoMessage() {}
 
 func (x *ImportProviderProfilesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[94]
+	mi := &file_openshell_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6843,7 +7429,7 @@ func (x *ImportProviderProfilesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportProviderProfilesResponse.ProtoReflect.Descriptor instead.
 func (*ImportProviderProfilesResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{94}
+	return file_openshell_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *ImportProviderProfilesResponse) GetDiagnostics() []*ProviderProfileDiagnostic {
@@ -6887,7 +7473,7 @@ type UpdateProviderProfilesRequest struct {
 
 func (x *UpdateProviderProfilesRequest) Reset() {
 	*x = UpdateProviderProfilesRequest{}
-	mi := &file_openshell_proto_msgTypes[95]
+	mi := &file_openshell_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6899,7 +7485,7 @@ func (x *UpdateProviderProfilesRequest) String() string {
 func (*UpdateProviderProfilesRequest) ProtoMessage() {}
 
 func (x *UpdateProviderProfilesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[95]
+	mi := &file_openshell_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6912,7 +7498,7 @@ func (x *UpdateProviderProfilesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProviderProfilesRequest.ProtoReflect.Descriptor instead.
 func (*UpdateProviderProfilesRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{95}
+	return file_openshell_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *UpdateProviderProfilesRequest) GetProfile() *ProviderProfileImportItem {
@@ -6955,7 +7541,7 @@ type UpdateProviderProfilesResponse struct {
 
 func (x *UpdateProviderProfilesResponse) Reset() {
 	*x = UpdateProviderProfilesResponse{}
-	mi := &file_openshell_proto_msgTypes[96]
+	mi := &file_openshell_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6967,7 +7553,7 @@ func (x *UpdateProviderProfilesResponse) String() string {
 func (*UpdateProviderProfilesResponse) ProtoMessage() {}
 
 func (x *UpdateProviderProfilesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[96]
+	mi := &file_openshell_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6980,7 +7566,7 @@ func (x *UpdateProviderProfilesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProviderProfilesResponse.ProtoReflect.Descriptor instead.
 func (*UpdateProviderProfilesResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{96}
+	return file_openshell_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *UpdateProviderProfilesResponse) GetDiagnostics() []*ProviderProfileDiagnostic {
@@ -7017,7 +7603,7 @@ type LintProviderProfilesRequest struct {
 
 func (x *LintProviderProfilesRequest) Reset() {
 	*x = LintProviderProfilesRequest{}
-	mi := &file_openshell_proto_msgTypes[97]
+	mi := &file_openshell_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7029,7 +7615,7 @@ func (x *LintProviderProfilesRequest) String() string {
 func (*LintProviderProfilesRequest) ProtoMessage() {}
 
 func (x *LintProviderProfilesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[97]
+	mi := &file_openshell_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7042,7 +7628,7 @@ func (x *LintProviderProfilesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LintProviderProfilesRequest.ProtoReflect.Descriptor instead.
 func (*LintProviderProfilesRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{97}
+	return file_openshell_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *LintProviderProfilesRequest) GetProfiles() []*ProviderProfileImportItem {
@@ -7070,7 +7656,7 @@ type LintProviderProfilesResponse struct {
 
 func (x *LintProviderProfilesResponse) Reset() {
 	*x = LintProviderProfilesResponse{}
-	mi := &file_openshell_proto_msgTypes[98]
+	mi := &file_openshell_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7082,7 +7668,7 @@ func (x *LintProviderProfilesResponse) String() string {
 func (*LintProviderProfilesResponse) ProtoMessage() {}
 
 func (x *LintProviderProfilesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[98]
+	mi := &file_openshell_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7095,7 +7681,7 @@ func (x *LintProviderProfilesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LintProviderProfilesResponse.ProtoReflect.Descriptor instead.
 func (*LintProviderProfilesResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{98}
+	return file_openshell_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *LintProviderProfilesResponse) GetDiagnostics() []*ProviderProfileDiagnostic {
@@ -7122,7 +7708,7 @@ type DeleteProviderResponse struct {
 
 func (x *DeleteProviderResponse) Reset() {
 	*x = DeleteProviderResponse{}
-	mi := &file_openshell_proto_msgTypes[99]
+	mi := &file_openshell_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7134,7 +7720,7 @@ func (x *DeleteProviderResponse) String() string {
 func (*DeleteProviderResponse) ProtoMessage() {}
 
 func (x *DeleteProviderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[99]
+	mi := &file_openshell_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7147,7 +7733,7 @@ func (x *DeleteProviderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProviderResponse.ProtoReflect.Descriptor instead.
 func (*DeleteProviderResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{99}
+	return file_openshell_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *DeleteProviderResponse) GetDeleted() bool {
@@ -7170,7 +7756,7 @@ type DeleteProviderProfileRequest struct {
 
 func (x *DeleteProviderProfileRequest) Reset() {
 	*x = DeleteProviderProfileRequest{}
-	mi := &file_openshell_proto_msgTypes[100]
+	mi := &file_openshell_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7182,7 +7768,7 @@ func (x *DeleteProviderProfileRequest) String() string {
 func (*DeleteProviderProfileRequest) ProtoMessage() {}
 
 func (x *DeleteProviderProfileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[100]
+	mi := &file_openshell_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7195,7 +7781,7 @@ func (x *DeleteProviderProfileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProviderProfileRequest.ProtoReflect.Descriptor instead.
 func (*DeleteProviderProfileRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{100}
+	return file_openshell_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *DeleteProviderProfileRequest) GetId() string {
@@ -7222,7 +7808,7 @@ type DeleteProviderProfileResponse struct {
 
 func (x *DeleteProviderProfileResponse) Reset() {
 	*x = DeleteProviderProfileResponse{}
-	mi := &file_openshell_proto_msgTypes[101]
+	mi := &file_openshell_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7234,7 +7820,7 @@ func (x *DeleteProviderProfileResponse) String() string {
 func (*DeleteProviderProfileResponse) ProtoMessage() {}
 
 func (x *DeleteProviderProfileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[101]
+	mi := &file_openshell_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7247,7 +7833,7 @@ func (x *DeleteProviderProfileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProviderProfileResponse.ProtoReflect.Descriptor instead.
 func (*DeleteProviderProfileResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{101}
+	return file_openshell_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *DeleteProviderProfileResponse) GetDeleted() bool {
@@ -7272,7 +7858,7 @@ type GetSandboxProviderEnvironmentRequest struct {
 
 func (x *GetSandboxProviderEnvironmentRequest) Reset() {
 	*x = GetSandboxProviderEnvironmentRequest{}
-	mi := &file_openshell_proto_msgTypes[102]
+	mi := &file_openshell_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7284,7 +7870,7 @@ func (x *GetSandboxProviderEnvironmentRequest) String() string {
 func (*GetSandboxProviderEnvironmentRequest) ProtoMessage() {}
 
 func (x *GetSandboxProviderEnvironmentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[102]
+	mi := &file_openshell_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7297,7 +7883,7 @@ func (x *GetSandboxProviderEnvironmentRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use GetSandboxProviderEnvironmentRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxProviderEnvironmentRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{102}
+	return file_openshell_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *GetSandboxProviderEnvironmentRequest) GetSandboxId() string {
@@ -7326,7 +7912,7 @@ type StaticCredentialEndpointBinding struct {
 
 func (x *StaticCredentialEndpointBinding) Reset() {
 	*x = StaticCredentialEndpointBinding{}
-	mi := &file_openshell_proto_msgTypes[103]
+	mi := &file_openshell_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7338,7 +7924,7 @@ func (x *StaticCredentialEndpointBinding) String() string {
 func (*StaticCredentialEndpointBinding) ProtoMessage() {}
 
 func (x *StaticCredentialEndpointBinding) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[103]
+	mi := &file_openshell_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7351,7 +7937,7 @@ func (x *StaticCredentialEndpointBinding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StaticCredentialEndpointBinding.ProtoReflect.Descriptor instead.
 func (*StaticCredentialEndpointBinding) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{103}
+	return file_openshell_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *StaticCredentialEndpointBinding) GetHost() string {
@@ -7389,7 +7975,7 @@ type StaticCredentialBinding struct {
 
 func (x *StaticCredentialBinding) Reset() {
 	*x = StaticCredentialBinding{}
-	mi := &file_openshell_proto_msgTypes[104]
+	mi := &file_openshell_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7401,7 +7987,7 @@ func (x *StaticCredentialBinding) String() string {
 func (*StaticCredentialBinding) ProtoMessage() {}
 
 func (x *StaticCredentialBinding) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[104]
+	mi := &file_openshell_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7414,7 +8000,7 @@ func (x *StaticCredentialBinding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StaticCredentialBinding.ProtoReflect.Descriptor instead.
 func (*StaticCredentialBinding) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{104}
+	return file_openshell_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *StaticCredentialBinding) GetEndpoints() []*StaticCredentialEndpointBinding {
@@ -7458,7 +8044,7 @@ type GetSandboxProviderEnvironmentResponse struct {
 
 func (x *GetSandboxProviderEnvironmentResponse) Reset() {
 	*x = GetSandboxProviderEnvironmentResponse{}
-	mi := &file_openshell_proto_msgTypes[105]
+	mi := &file_openshell_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7470,7 +8056,7 @@ func (x *GetSandboxProviderEnvironmentResponse) String() string {
 func (*GetSandboxProviderEnvironmentResponse) ProtoMessage() {}
 
 func (x *GetSandboxProviderEnvironmentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[105]
+	mi := &file_openshell_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7483,7 +8069,7 @@ func (x *GetSandboxProviderEnvironmentResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use GetSandboxProviderEnvironmentResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxProviderEnvironmentResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{105}
+	return file_openshell_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *GetSandboxProviderEnvironmentResponse) GetEnvironment() map[string]string {
@@ -7575,7 +8161,7 @@ type UpdateConfigRequest struct {
 
 func (x *UpdateConfigRequest) Reset() {
 	*x = UpdateConfigRequest{}
-	mi := &file_openshell_proto_msgTypes[106]
+	mi := &file_openshell_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7587,7 +8173,7 @@ func (x *UpdateConfigRequest) String() string {
 func (*UpdateConfigRequest) ProtoMessage() {}
 
 func (x *UpdateConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[106]
+	mi := &file_openshell_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7600,7 +8186,7 @@ func (x *UpdateConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateConfigRequest.ProtoReflect.Descriptor instead.
 func (*UpdateConfigRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{106}
+	return file_openshell_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *UpdateConfigRequest) GetName() string {
@@ -7690,7 +8276,7 @@ type PolicyMergeOperation struct {
 
 func (x *PolicyMergeOperation) Reset() {
 	*x = PolicyMergeOperation{}
-	mi := &file_openshell_proto_msgTypes[107]
+	mi := &file_openshell_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7702,7 +8288,7 @@ func (x *PolicyMergeOperation) String() string {
 func (*PolicyMergeOperation) ProtoMessage() {}
 
 func (x *PolicyMergeOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[107]
+	mi := &file_openshell_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7715,7 +8301,7 @@ func (x *PolicyMergeOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyMergeOperation.ProtoReflect.Descriptor instead.
 func (*PolicyMergeOperation) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{107}
+	return file_openshell_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *PolicyMergeOperation) GetOperation() isPolicyMergeOperation_Operation {
@@ -7829,7 +8415,7 @@ type AddNetworkRule struct {
 
 func (x *AddNetworkRule) Reset() {
 	*x = AddNetworkRule{}
-	mi := &file_openshell_proto_msgTypes[108]
+	mi := &file_openshell_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7841,7 +8427,7 @@ func (x *AddNetworkRule) String() string {
 func (*AddNetworkRule) ProtoMessage() {}
 
 func (x *AddNetworkRule) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[108]
+	mi := &file_openshell_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7854,7 +8440,7 @@ func (x *AddNetworkRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddNetworkRule.ProtoReflect.Descriptor instead.
 func (*AddNetworkRule) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{108}
+	return file_openshell_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *AddNetworkRule) GetRuleName() string {
@@ -7882,7 +8468,7 @@ type RemoveNetworkEndpoint struct {
 
 func (x *RemoveNetworkEndpoint) Reset() {
 	*x = RemoveNetworkEndpoint{}
-	mi := &file_openshell_proto_msgTypes[109]
+	mi := &file_openshell_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7894,7 +8480,7 @@ func (x *RemoveNetworkEndpoint) String() string {
 func (*RemoveNetworkEndpoint) ProtoMessage() {}
 
 func (x *RemoveNetworkEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[109]
+	mi := &file_openshell_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7907,7 +8493,7 @@ func (x *RemoveNetworkEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveNetworkEndpoint.ProtoReflect.Descriptor instead.
 func (*RemoveNetworkEndpoint) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{109}
+	return file_openshell_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *RemoveNetworkEndpoint) GetRuleName() string {
@@ -7940,7 +8526,7 @@ type RemoveNetworkRule struct {
 
 func (x *RemoveNetworkRule) Reset() {
 	*x = RemoveNetworkRule{}
-	mi := &file_openshell_proto_msgTypes[110]
+	mi := &file_openshell_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7952,7 +8538,7 @@ func (x *RemoveNetworkRule) String() string {
 func (*RemoveNetworkRule) ProtoMessage() {}
 
 func (x *RemoveNetworkRule) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[110]
+	mi := &file_openshell_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7965,7 +8551,7 @@ func (x *RemoveNetworkRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveNetworkRule.ProtoReflect.Descriptor instead.
 func (*RemoveNetworkRule) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{110}
+	return file_openshell_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *RemoveNetworkRule) GetRuleName() string {
@@ -7986,7 +8572,7 @@ type AddDenyRules struct {
 
 func (x *AddDenyRules) Reset() {
 	*x = AddDenyRules{}
-	mi := &file_openshell_proto_msgTypes[111]
+	mi := &file_openshell_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7998,7 +8584,7 @@ func (x *AddDenyRules) String() string {
 func (*AddDenyRules) ProtoMessage() {}
 
 func (x *AddDenyRules) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[111]
+	mi := &file_openshell_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8011,7 +8597,7 @@ func (x *AddDenyRules) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddDenyRules.ProtoReflect.Descriptor instead.
 func (*AddDenyRules) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{111}
+	return file_openshell_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *AddDenyRules) GetHost() string {
@@ -8046,7 +8632,7 @@ type AddAllowRules struct {
 
 func (x *AddAllowRules) Reset() {
 	*x = AddAllowRules{}
-	mi := &file_openshell_proto_msgTypes[112]
+	mi := &file_openshell_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8058,7 +8644,7 @@ func (x *AddAllowRules) String() string {
 func (*AddAllowRules) ProtoMessage() {}
 
 func (x *AddAllowRules) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[112]
+	mi := &file_openshell_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8071,7 +8657,7 @@ func (x *AddAllowRules) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddAllowRules.ProtoReflect.Descriptor instead.
 func (*AddAllowRules) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{112}
+	return file_openshell_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *AddAllowRules) GetHost() string {
@@ -8105,7 +8691,7 @@ type RemoveNetworkBinary struct {
 
 func (x *RemoveNetworkBinary) Reset() {
 	*x = RemoveNetworkBinary{}
-	mi := &file_openshell_proto_msgTypes[113]
+	mi := &file_openshell_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8117,7 +8703,7 @@ func (x *RemoveNetworkBinary) String() string {
 func (*RemoveNetworkBinary) ProtoMessage() {}
 
 func (x *RemoveNetworkBinary) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[113]
+	mi := &file_openshell_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8130,7 +8716,7 @@ func (x *RemoveNetworkBinary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveNetworkBinary.ProtoReflect.Descriptor instead.
 func (*RemoveNetworkBinary) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{113}
+	return file_openshell_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *RemoveNetworkBinary) GetRuleName() string {
@@ -8166,7 +8752,7 @@ type UpdateConfigResponse struct {
 
 func (x *UpdateConfigResponse) Reset() {
 	*x = UpdateConfigResponse{}
-	mi := &file_openshell_proto_msgTypes[114]
+	mi := &file_openshell_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8178,7 +8764,7 @@ func (x *UpdateConfigResponse) String() string {
 func (*UpdateConfigResponse) ProtoMessage() {}
 
 func (x *UpdateConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[114]
+	mi := &file_openshell_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8191,7 +8777,7 @@ func (x *UpdateConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateConfigResponse.ProtoReflect.Descriptor instead.
 func (*UpdateConfigResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{114}
+	return file_openshell_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *UpdateConfigResponse) GetVersion() uint32 {
@@ -8246,7 +8832,7 @@ type GetSandboxPolicyStatusRequest struct {
 
 func (x *GetSandboxPolicyStatusRequest) Reset() {
 	*x = GetSandboxPolicyStatusRequest{}
-	mi := &file_openshell_proto_msgTypes[115]
+	mi := &file_openshell_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8258,7 +8844,7 @@ func (x *GetSandboxPolicyStatusRequest) String() string {
 func (*GetSandboxPolicyStatusRequest) ProtoMessage() {}
 
 func (x *GetSandboxPolicyStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[115]
+	mi := &file_openshell_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8271,7 +8857,7 @@ func (x *GetSandboxPolicyStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxPolicyStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxPolicyStatusRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{115}
+	return file_openshell_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *GetSandboxPolicyStatusRequest) GetName() string {
@@ -8315,7 +8901,7 @@ type GetSandboxPolicyStatusResponse struct {
 
 func (x *GetSandboxPolicyStatusResponse) Reset() {
 	*x = GetSandboxPolicyStatusResponse{}
-	mi := &file_openshell_proto_msgTypes[116]
+	mi := &file_openshell_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8327,7 +8913,7 @@ func (x *GetSandboxPolicyStatusResponse) String() string {
 func (*GetSandboxPolicyStatusResponse) ProtoMessage() {}
 
 func (x *GetSandboxPolicyStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[116]
+	mi := &file_openshell_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8340,7 +8926,7 @@ func (x *GetSandboxPolicyStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxPolicyStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxPolicyStatusResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{116}
+	return file_openshell_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *GetSandboxPolicyStatusResponse) GetRevision() *SandboxPolicyRevision {
@@ -8374,7 +8960,7 @@ type ListSandboxPoliciesRequest struct {
 
 func (x *ListSandboxPoliciesRequest) Reset() {
 	*x = ListSandboxPoliciesRequest{}
-	mi := &file_openshell_proto_msgTypes[117]
+	mi := &file_openshell_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8386,7 +8972,7 @@ func (x *ListSandboxPoliciesRequest) String() string {
 func (*ListSandboxPoliciesRequest) ProtoMessage() {}
 
 func (x *ListSandboxPoliciesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[117]
+	mi := &file_openshell_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8399,7 +8985,7 @@ func (x *ListSandboxPoliciesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxPoliciesRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxPoliciesRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{117}
+	return file_openshell_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *ListSandboxPoliciesRequest) GetName() string {
@@ -8447,7 +9033,7 @@ type ListSandboxPoliciesResponse struct {
 
 func (x *ListSandboxPoliciesResponse) Reset() {
 	*x = ListSandboxPoliciesResponse{}
-	mi := &file_openshell_proto_msgTypes[118]
+	mi := &file_openshell_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8459,7 +9045,7 @@ func (x *ListSandboxPoliciesResponse) String() string {
 func (*ListSandboxPoliciesResponse) ProtoMessage() {}
 
 func (x *ListSandboxPoliciesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[118]
+	mi := &file_openshell_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8472,7 +9058,7 @@ func (x *ListSandboxPoliciesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxPoliciesResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxPoliciesResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{118}
+	return file_openshell_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *ListSandboxPoliciesResponse) GetRevisions() []*SandboxPolicyRevision {
@@ -8499,7 +9085,7 @@ type ReportPolicyStatusRequest struct {
 
 func (x *ReportPolicyStatusRequest) Reset() {
 	*x = ReportPolicyStatusRequest{}
-	mi := &file_openshell_proto_msgTypes[119]
+	mi := &file_openshell_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8511,7 +9097,7 @@ func (x *ReportPolicyStatusRequest) String() string {
 func (*ReportPolicyStatusRequest) ProtoMessage() {}
 
 func (x *ReportPolicyStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[119]
+	mi := &file_openshell_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8524,7 +9110,7 @@ func (x *ReportPolicyStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportPolicyStatusRequest.ProtoReflect.Descriptor instead.
 func (*ReportPolicyStatusRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{119}
+	return file_openshell_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *ReportPolicyStatusRequest) GetSandboxId() string {
@@ -8564,7 +9150,7 @@ type ReportPolicyStatusResponse struct {
 
 func (x *ReportPolicyStatusResponse) Reset() {
 	*x = ReportPolicyStatusResponse{}
-	mi := &file_openshell_proto_msgTypes[120]
+	mi := &file_openshell_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8576,7 +9162,7 @@ func (x *ReportPolicyStatusResponse) String() string {
 func (*ReportPolicyStatusResponse) ProtoMessage() {}
 
 func (x *ReportPolicyStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[120]
+	mi := &file_openshell_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8589,7 +9175,7 @@ func (x *ReportPolicyStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportPolicyStatusResponse.ProtoReflect.Descriptor instead.
 func (*ReportPolicyStatusResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{120}
+	return file_openshell_proto_rawDescGZIP(), []int{131}
 }
 
 // A versioned policy revision with metadata.
@@ -8617,7 +9203,7 @@ type SandboxPolicyRevision struct {
 
 func (x *SandboxPolicyRevision) Reset() {
 	*x = SandboxPolicyRevision{}
-	mi := &file_openshell_proto_msgTypes[121]
+	mi := &file_openshell_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8629,7 +9215,7 @@ func (x *SandboxPolicyRevision) String() string {
 func (*SandboxPolicyRevision) ProtoMessage() {}
 
 func (x *SandboxPolicyRevision) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[121]
+	mi := &file_openshell_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8642,7 +9228,7 @@ func (x *SandboxPolicyRevision) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxPolicyRevision.ProtoReflect.Descriptor instead.
 func (*SandboxPolicyRevision) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{121}
+	return file_openshell_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *SandboxPolicyRevision) GetVersion() uint32 {
@@ -8722,7 +9308,7 @@ type GetSandboxLogsRequest struct {
 
 func (x *GetSandboxLogsRequest) Reset() {
 	*x = GetSandboxLogsRequest{}
-	mi := &file_openshell_proto_msgTypes[122]
+	mi := &file_openshell_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8734,7 +9320,7 @@ func (x *GetSandboxLogsRequest) String() string {
 func (*GetSandboxLogsRequest) ProtoMessage() {}
 
 func (x *GetSandboxLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[122]
+	mi := &file_openshell_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8747,7 +9333,7 @@ func (x *GetSandboxLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxLogsRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxLogsRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{122}
+	return file_openshell_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *GetSandboxLogsRequest) GetSandboxId() string {
@@ -8805,7 +9391,7 @@ type PushSandboxLogsRequest struct {
 
 func (x *PushSandboxLogsRequest) Reset() {
 	*x = PushSandboxLogsRequest{}
-	mi := &file_openshell_proto_msgTypes[123]
+	mi := &file_openshell_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8817,7 +9403,7 @@ func (x *PushSandboxLogsRequest) String() string {
 func (*PushSandboxLogsRequest) ProtoMessage() {}
 
 func (x *PushSandboxLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[123]
+	mi := &file_openshell_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8830,7 +9416,7 @@ func (x *PushSandboxLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PushSandboxLogsRequest.ProtoReflect.Descriptor instead.
 func (*PushSandboxLogsRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{123}
+	return file_openshell_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *PushSandboxLogsRequest) GetSandboxId() string {
@@ -8856,7 +9442,7 @@ type PushSandboxLogsResponse struct {
 
 func (x *PushSandboxLogsResponse) Reset() {
 	*x = PushSandboxLogsResponse{}
-	mi := &file_openshell_proto_msgTypes[124]
+	mi := &file_openshell_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8868,7 +9454,7 @@ func (x *PushSandboxLogsResponse) String() string {
 func (*PushSandboxLogsResponse) ProtoMessage() {}
 
 func (x *PushSandboxLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[124]
+	mi := &file_openshell_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8881,7 +9467,7 @@ func (x *PushSandboxLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PushSandboxLogsResponse.ProtoReflect.Descriptor instead.
 func (*PushSandboxLogsResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{124}
+	return file_openshell_proto_rawDescGZIP(), []int{135}
 }
 
 // Get sandbox logs response.
@@ -8897,7 +9483,7 @@ type GetSandboxLogsResponse struct {
 
 func (x *GetSandboxLogsResponse) Reset() {
 	*x = GetSandboxLogsResponse{}
-	mi := &file_openshell_proto_msgTypes[125]
+	mi := &file_openshell_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8909,7 +9495,7 @@ func (x *GetSandboxLogsResponse) String() string {
 func (*GetSandboxLogsResponse) ProtoMessage() {}
 
 func (x *GetSandboxLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[125]
+	mi := &file_openshell_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8922,7 +9508,7 @@ func (x *GetSandboxLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxLogsResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxLogsResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{125}
+	return file_openshell_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *GetSandboxLogsResponse) GetLogs() []*SandboxLogLine {
@@ -8955,7 +9541,7 @@ type SupervisorMessage struct {
 
 func (x *SupervisorMessage) Reset() {
 	*x = SupervisorMessage{}
-	mi := &file_openshell_proto_msgTypes[126]
+	mi := &file_openshell_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8967,7 +9553,7 @@ func (x *SupervisorMessage) String() string {
 func (*SupervisorMessage) ProtoMessage() {}
 
 func (x *SupervisorMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[126]
+	mi := &file_openshell_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8980,7 +9566,7 @@ func (x *SupervisorMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupervisorMessage.ProtoReflect.Descriptor instead.
 func (*SupervisorMessage) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{126}
+	return file_openshell_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *SupervisorMessage) GetPayload() isSupervisorMessage_Payload {
@@ -9071,7 +9657,7 @@ type GatewayMessage struct {
 
 func (x *GatewayMessage) Reset() {
 	*x = GatewayMessage{}
-	mi := &file_openshell_proto_msgTypes[127]
+	mi := &file_openshell_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9083,7 +9669,7 @@ func (x *GatewayMessage) String() string {
 func (*GatewayMessage) ProtoMessage() {}
 
 func (x *GatewayMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[127]
+	mi := &file_openshell_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9096,7 +9682,7 @@ func (x *GatewayMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GatewayMessage.ProtoReflect.Descriptor instead.
 func (*GatewayMessage) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{127}
+	return file_openshell_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *GatewayMessage) GetPayload() isGatewayMessage_Payload {
@@ -9198,7 +9784,7 @@ type SupervisorHello struct {
 
 func (x *SupervisorHello) Reset() {
 	*x = SupervisorHello{}
-	mi := &file_openshell_proto_msgTypes[128]
+	mi := &file_openshell_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9210,7 +9796,7 @@ func (x *SupervisorHello) String() string {
 func (*SupervisorHello) ProtoMessage() {}
 
 func (x *SupervisorHello) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[128]
+	mi := &file_openshell_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9223,7 +9809,7 @@ func (x *SupervisorHello) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupervisorHello.ProtoReflect.Descriptor instead.
 func (*SupervisorHello) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{128}
+	return file_openshell_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *SupervisorHello) GetSandboxId() string {
@@ -9253,7 +9839,7 @@ type SessionAccepted struct {
 
 func (x *SessionAccepted) Reset() {
 	*x = SessionAccepted{}
-	mi := &file_openshell_proto_msgTypes[129]
+	mi := &file_openshell_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9265,7 +9851,7 @@ func (x *SessionAccepted) String() string {
 func (*SessionAccepted) ProtoMessage() {}
 
 func (x *SessionAccepted) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[129]
+	mi := &file_openshell_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9278,7 +9864,7 @@ func (x *SessionAccepted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionAccepted.ProtoReflect.Descriptor instead.
 func (*SessionAccepted) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{129}
+	return file_openshell_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *SessionAccepted) GetSessionId() string {
@@ -9306,7 +9892,7 @@ type SessionRejected struct {
 
 func (x *SessionRejected) Reset() {
 	*x = SessionRejected{}
-	mi := &file_openshell_proto_msgTypes[130]
+	mi := &file_openshell_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9318,7 +9904,7 @@ func (x *SessionRejected) String() string {
 func (*SessionRejected) ProtoMessage() {}
 
 func (x *SessionRejected) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[130]
+	mi := &file_openshell_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9331,7 +9917,7 @@ func (x *SessionRejected) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionRejected.ProtoReflect.Descriptor instead.
 func (*SessionRejected) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{130}
+	return file_openshell_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *SessionRejected) GetReason() string {
@@ -9350,7 +9936,7 @@ type SupervisorHeartbeat struct {
 
 func (x *SupervisorHeartbeat) Reset() {
 	*x = SupervisorHeartbeat{}
-	mi := &file_openshell_proto_msgTypes[131]
+	mi := &file_openshell_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9362,7 +9948,7 @@ func (x *SupervisorHeartbeat) String() string {
 func (*SupervisorHeartbeat) ProtoMessage() {}
 
 func (x *SupervisorHeartbeat) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[131]
+	mi := &file_openshell_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9375,7 +9961,7 @@ func (x *SupervisorHeartbeat) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupervisorHeartbeat.ProtoReflect.Descriptor instead.
 func (*SupervisorHeartbeat) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{131}
+	return file_openshell_proto_rawDescGZIP(), []int{142}
 }
 
 // Gateway heartbeat.
@@ -9387,7 +9973,7 @@ type GatewayHeartbeat struct {
 
 func (x *GatewayHeartbeat) Reset() {
 	*x = GatewayHeartbeat{}
-	mi := &file_openshell_proto_msgTypes[132]
+	mi := &file_openshell_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9399,7 +9985,7 @@ func (x *GatewayHeartbeat) String() string {
 func (*GatewayHeartbeat) ProtoMessage() {}
 
 func (x *GatewayHeartbeat) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[132]
+	mi := &file_openshell_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9412,7 +9998,7 @@ func (x *GatewayHeartbeat) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GatewayHeartbeat.ProtoReflect.Descriptor instead.
 func (*GatewayHeartbeat) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{132}
+	return file_openshell_proto_rawDescGZIP(), []int{143}
 }
 
 // Gateway requests the supervisor to open a relay channel.
@@ -9441,7 +10027,7 @@ type RelayOpen struct {
 
 func (x *RelayOpen) Reset() {
 	*x = RelayOpen{}
-	mi := &file_openshell_proto_msgTypes[133]
+	mi := &file_openshell_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9453,7 +10039,7 @@ func (x *RelayOpen) String() string {
 func (*RelayOpen) ProtoMessage() {}
 
 func (x *RelayOpen) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[133]
+	mi := &file_openshell_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9466,7 +10052,7 @@ func (x *RelayOpen) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RelayOpen.ProtoReflect.Descriptor instead.
 func (*RelayOpen) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{133}
+	return file_openshell_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *RelayOpen) GetChannelId() string {
@@ -9533,7 +10119,7 @@ type SshRelayTarget struct {
 
 func (x *SshRelayTarget) Reset() {
 	*x = SshRelayTarget{}
-	mi := &file_openshell_proto_msgTypes[134]
+	mi := &file_openshell_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9545,7 +10131,7 @@ func (x *SshRelayTarget) String() string {
 func (*SshRelayTarget) ProtoMessage() {}
 
 func (x *SshRelayTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[134]
+	mi := &file_openshell_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9558,7 +10144,7 @@ func (x *SshRelayTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SshRelayTarget.ProtoReflect.Descriptor instead.
 func (*SshRelayTarget) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{134}
+	return file_openshell_proto_rawDescGZIP(), []int{145}
 }
 
 // TCP target dialed by the supervisor from inside the sandbox.
@@ -9574,7 +10160,7 @@ type TcpRelayTarget struct {
 
 func (x *TcpRelayTarget) Reset() {
 	*x = TcpRelayTarget{}
-	mi := &file_openshell_proto_msgTypes[135]
+	mi := &file_openshell_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9586,7 +10172,7 @@ func (x *TcpRelayTarget) String() string {
 func (*TcpRelayTarget) ProtoMessage() {}
 
 func (x *TcpRelayTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[135]
+	mi := &file_openshell_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9599,7 +10185,7 @@ func (x *TcpRelayTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TcpRelayTarget.ProtoReflect.Descriptor instead.
 func (*TcpRelayTarget) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{135}
+	return file_openshell_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *TcpRelayTarget) GetHost() string {
@@ -9627,7 +10213,7 @@ type RelayInit struct {
 
 func (x *RelayInit) Reset() {
 	*x = RelayInit{}
-	mi := &file_openshell_proto_msgTypes[136]
+	mi := &file_openshell_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9639,7 +10225,7 @@ func (x *RelayInit) String() string {
 func (*RelayInit) ProtoMessage() {}
 
 func (x *RelayInit) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[136]
+	mi := &file_openshell_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9652,7 +10238,7 @@ func (x *RelayInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RelayInit.ProtoReflect.Descriptor instead.
 func (*RelayInit) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{136}
+	return file_openshell_proto_rawDescGZIP(), []int{147}
 }
 
 func (x *RelayInit) GetChannelId() string {
@@ -9679,7 +10265,7 @@ type RelayFrame struct {
 
 func (x *RelayFrame) Reset() {
 	*x = RelayFrame{}
-	mi := &file_openshell_proto_msgTypes[137]
+	mi := &file_openshell_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9691,7 +10277,7 @@ func (x *RelayFrame) String() string {
 func (*RelayFrame) ProtoMessage() {}
 
 func (x *RelayFrame) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[137]
+	mi := &file_openshell_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9704,7 +10290,7 @@ func (x *RelayFrame) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RelayFrame.ProtoReflect.Descriptor instead.
 func (*RelayFrame) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{137}
+	return file_openshell_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *RelayFrame) GetPayload() isRelayFrame_Payload {
@@ -9763,7 +10349,7 @@ type RelayOpenResult struct {
 
 func (x *RelayOpenResult) Reset() {
 	*x = RelayOpenResult{}
-	mi := &file_openshell_proto_msgTypes[138]
+	mi := &file_openshell_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9775,7 +10361,7 @@ func (x *RelayOpenResult) String() string {
 func (*RelayOpenResult) ProtoMessage() {}
 
 func (x *RelayOpenResult) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[138]
+	mi := &file_openshell_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9788,7 +10374,7 @@ func (x *RelayOpenResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RelayOpenResult.ProtoReflect.Descriptor instead.
 func (*RelayOpenResult) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{138}
+	return file_openshell_proto_rawDescGZIP(), []int{149}
 }
 
 func (x *RelayOpenResult) GetChannelId() string {
@@ -9825,7 +10411,7 @@ type RelayClose struct {
 
 func (x *RelayClose) Reset() {
 	*x = RelayClose{}
-	mi := &file_openshell_proto_msgTypes[139]
+	mi := &file_openshell_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9837,7 +10423,7 @@ func (x *RelayClose) String() string {
 func (*RelayClose) ProtoMessage() {}
 
 func (x *RelayClose) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[139]
+	mi := &file_openshell_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9850,7 +10436,7 @@ func (x *RelayClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RelayClose.ProtoReflect.Descriptor instead.
 func (*RelayClose) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{139}
+	return file_openshell_proto_rawDescGZIP(), []int{150}
 }
 
 func (x *RelayClose) GetChannelId() string {
@@ -9884,7 +10470,7 @@ type L7RequestSample struct {
 
 func (x *L7RequestSample) Reset() {
 	*x = L7RequestSample{}
-	mi := &file_openshell_proto_msgTypes[140]
+	mi := &file_openshell_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9896,7 +10482,7 @@ func (x *L7RequestSample) String() string {
 func (*L7RequestSample) ProtoMessage() {}
 
 func (x *L7RequestSample) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[140]
+	mi := &file_openshell_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9909,7 +10495,7 @@ func (x *L7RequestSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use L7RequestSample.ProtoReflect.Descriptor instead.
 func (*L7RequestSample) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{140}
+	return file_openshell_proto_rawDescGZIP(), []int{151}
 }
 
 func (x *L7RequestSample) GetMethod() string {
@@ -9983,7 +10569,7 @@ type DenialSummary struct {
 
 func (x *DenialSummary) Reset() {
 	*x = DenialSummary{}
-	mi := &file_openshell_proto_msgTypes[141]
+	mi := &file_openshell_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9995,7 +10581,7 @@ func (x *DenialSummary) String() string {
 func (*DenialSummary) ProtoMessage() {}
 
 func (x *DenialSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[141]
+	mi := &file_openshell_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10008,7 +10594,7 @@ func (x *DenialSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DenialSummary.ProtoReflect.Descriptor instead.
 func (*DenialSummary) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{141}
+	return file_openshell_proto_rawDescGZIP(), []int{152}
 }
 
 func (x *DenialSummary) GetSandboxId() string {
@@ -10143,7 +10729,7 @@ type DenialGroupCount struct {
 
 func (x *DenialGroupCount) Reset() {
 	*x = DenialGroupCount{}
-	mi := &file_openshell_proto_msgTypes[142]
+	mi := &file_openshell_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10155,7 +10741,7 @@ func (x *DenialGroupCount) String() string {
 func (*DenialGroupCount) ProtoMessage() {}
 
 func (x *DenialGroupCount) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[142]
+	mi := &file_openshell_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10168,7 +10754,7 @@ func (x *DenialGroupCount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DenialGroupCount.ProtoReflect.Descriptor instead.
 func (*DenialGroupCount) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{142}
+	return file_openshell_proto_rawDescGZIP(), []int{153}
 }
 
 func (x *DenialGroupCount) GetDenyGroup() string {
@@ -10201,7 +10787,7 @@ type NetworkActivitySummary struct {
 
 func (x *NetworkActivitySummary) Reset() {
 	*x = NetworkActivitySummary{}
-	mi := &file_openshell_proto_msgTypes[143]
+	mi := &file_openshell_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10213,7 +10799,7 @@ func (x *NetworkActivitySummary) String() string {
 func (*NetworkActivitySummary) ProtoMessage() {}
 
 func (x *NetworkActivitySummary) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[143]
+	mi := &file_openshell_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10226,7 +10812,7 @@ func (x *NetworkActivitySummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkActivitySummary.ProtoReflect.Descriptor instead.
 func (*NetworkActivitySummary) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{143}
+	return file_openshell_proto_rawDescGZIP(), []int{154}
 }
 
 func (x *NetworkActivitySummary) GetNetworkActivityCount() uint32 {
@@ -10300,7 +10886,7 @@ type PolicyChunk struct {
 
 func (x *PolicyChunk) Reset() {
 	*x = PolicyChunk{}
-	mi := &file_openshell_proto_msgTypes[144]
+	mi := &file_openshell_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10312,7 +10898,7 @@ func (x *PolicyChunk) String() string {
 func (*PolicyChunk) ProtoMessage() {}
 
 func (x *PolicyChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[144]
+	mi := &file_openshell_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10325,7 +10911,7 @@ func (x *PolicyChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyChunk.ProtoReflect.Descriptor instead.
 func (*PolicyChunk) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{144}
+	return file_openshell_proto_rawDescGZIP(), []int{155}
 }
 
 func (x *PolicyChunk) GetId() string {
@@ -10471,7 +11057,7 @@ type DraftPolicyUpdate struct {
 
 func (x *DraftPolicyUpdate) Reset() {
 	*x = DraftPolicyUpdate{}
-	mi := &file_openshell_proto_msgTypes[145]
+	mi := &file_openshell_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10483,7 +11069,7 @@ func (x *DraftPolicyUpdate) String() string {
 func (*DraftPolicyUpdate) ProtoMessage() {}
 
 func (x *DraftPolicyUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[145]
+	mi := &file_openshell_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10496,7 +11082,7 @@ func (x *DraftPolicyUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DraftPolicyUpdate.ProtoReflect.Descriptor instead.
 func (*DraftPolicyUpdate) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{145}
+	return file_openshell_proto_rawDescGZIP(), []int{156}
 }
 
 func (x *DraftPolicyUpdate) GetDraftVersion() uint64 {
@@ -10554,7 +11140,7 @@ type SubmitPolicyAnalysisRequest struct {
 
 func (x *SubmitPolicyAnalysisRequest) Reset() {
 	*x = SubmitPolicyAnalysisRequest{}
-	mi := &file_openshell_proto_msgTypes[146]
+	mi := &file_openshell_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10566,7 +11152,7 @@ func (x *SubmitPolicyAnalysisRequest) String() string {
 func (*SubmitPolicyAnalysisRequest) ProtoMessage() {}
 
 func (x *SubmitPolicyAnalysisRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[146]
+	mi := &file_openshell_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10579,7 +11165,7 @@ func (x *SubmitPolicyAnalysisRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitPolicyAnalysisRequest.ProtoReflect.Descriptor instead.
 func (*SubmitPolicyAnalysisRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{146}
+	return file_openshell_proto_rawDescGZIP(), []int{157}
 }
 
 func (x *SubmitPolicyAnalysisRequest) GetSummaries() []*DenialSummary {
@@ -10642,7 +11228,7 @@ type SubmitPolicyAnalysisResponse struct {
 
 func (x *SubmitPolicyAnalysisResponse) Reset() {
 	*x = SubmitPolicyAnalysisResponse{}
-	mi := &file_openshell_proto_msgTypes[147]
+	mi := &file_openshell_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10654,7 +11240,7 @@ func (x *SubmitPolicyAnalysisResponse) String() string {
 func (*SubmitPolicyAnalysisResponse) ProtoMessage() {}
 
 func (x *SubmitPolicyAnalysisResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[147]
+	mi := &file_openshell_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10667,7 +11253,7 @@ func (x *SubmitPolicyAnalysisResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitPolicyAnalysisResponse.ProtoReflect.Descriptor instead.
 func (*SubmitPolicyAnalysisResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{147}
+	return file_openshell_proto_rawDescGZIP(), []int{158}
 }
 
 func (x *SubmitPolicyAnalysisResponse) GetAcceptedChunks() uint32 {
@@ -10713,7 +11299,7 @@ type GetDraftPolicyRequest struct {
 
 func (x *GetDraftPolicyRequest) Reset() {
 	*x = GetDraftPolicyRequest{}
-	mi := &file_openshell_proto_msgTypes[148]
+	mi := &file_openshell_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10725,7 +11311,7 @@ func (x *GetDraftPolicyRequest) String() string {
 func (*GetDraftPolicyRequest) ProtoMessage() {}
 
 func (x *GetDraftPolicyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[148]
+	mi := &file_openshell_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10738,7 +11324,7 @@ func (x *GetDraftPolicyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDraftPolicyRequest.ProtoReflect.Descriptor instead.
 func (*GetDraftPolicyRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{148}
+	return file_openshell_proto_rawDescGZIP(), []int{159}
 }
 
 func (x *GetDraftPolicyRequest) GetName() string {
@@ -10778,7 +11364,7 @@ type GetDraftPolicyResponse struct {
 
 func (x *GetDraftPolicyResponse) Reset() {
 	*x = GetDraftPolicyResponse{}
-	mi := &file_openshell_proto_msgTypes[149]
+	mi := &file_openshell_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10790,7 +11376,7 @@ func (x *GetDraftPolicyResponse) String() string {
 func (*GetDraftPolicyResponse) ProtoMessage() {}
 
 func (x *GetDraftPolicyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[149]
+	mi := &file_openshell_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10803,7 +11389,7 @@ func (x *GetDraftPolicyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDraftPolicyResponse.ProtoReflect.Descriptor instead.
 func (*GetDraftPolicyResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{149}
+	return file_openshell_proto_rawDescGZIP(), []int{160}
 }
 
 func (x *GetDraftPolicyResponse) GetChunks() []*PolicyChunk {
@@ -10849,7 +11435,7 @@ type ApproveDraftChunkRequest struct {
 
 func (x *ApproveDraftChunkRequest) Reset() {
 	*x = ApproveDraftChunkRequest{}
-	mi := &file_openshell_proto_msgTypes[150]
+	mi := &file_openshell_proto_msgTypes[161]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10861,7 +11447,7 @@ func (x *ApproveDraftChunkRequest) String() string {
 func (*ApproveDraftChunkRequest) ProtoMessage() {}
 
 func (x *ApproveDraftChunkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[150]
+	mi := &file_openshell_proto_msgTypes[161]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10874,7 +11460,7 @@ func (x *ApproveDraftChunkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApproveDraftChunkRequest.ProtoReflect.Descriptor instead.
 func (*ApproveDraftChunkRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{150}
+	return file_openshell_proto_rawDescGZIP(), []int{161}
 }
 
 func (x *ApproveDraftChunkRequest) GetName() string {
@@ -10910,7 +11496,7 @@ type ApproveDraftChunkResponse struct {
 
 func (x *ApproveDraftChunkResponse) Reset() {
 	*x = ApproveDraftChunkResponse{}
-	mi := &file_openshell_proto_msgTypes[151]
+	mi := &file_openshell_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10922,7 +11508,7 @@ func (x *ApproveDraftChunkResponse) String() string {
 func (*ApproveDraftChunkResponse) ProtoMessage() {}
 
 func (x *ApproveDraftChunkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[151]
+	mi := &file_openshell_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10935,7 +11521,7 @@ func (x *ApproveDraftChunkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApproveDraftChunkResponse.ProtoReflect.Descriptor instead.
 func (*ApproveDraftChunkResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{151}
+	return file_openshell_proto_rawDescGZIP(), []int{162}
 }
 
 func (x *ApproveDraftChunkResponse) GetPolicyVersion() uint32 {
@@ -10969,7 +11555,7 @@ type RejectDraftChunkRequest struct {
 
 func (x *RejectDraftChunkRequest) Reset() {
 	*x = RejectDraftChunkRequest{}
-	mi := &file_openshell_proto_msgTypes[152]
+	mi := &file_openshell_proto_msgTypes[163]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10981,7 +11567,7 @@ func (x *RejectDraftChunkRequest) String() string {
 func (*RejectDraftChunkRequest) ProtoMessage() {}
 
 func (x *RejectDraftChunkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[152]
+	mi := &file_openshell_proto_msgTypes[163]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10994,7 +11580,7 @@ func (x *RejectDraftChunkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RejectDraftChunkRequest.ProtoReflect.Descriptor instead.
 func (*RejectDraftChunkRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{152}
+	return file_openshell_proto_rawDescGZIP(), []int{163}
 }
 
 func (x *RejectDraftChunkRequest) GetName() string {
@@ -11033,7 +11619,7 @@ type RejectDraftChunkResponse struct {
 
 func (x *RejectDraftChunkResponse) Reset() {
 	*x = RejectDraftChunkResponse{}
-	mi := &file_openshell_proto_msgTypes[153]
+	mi := &file_openshell_proto_msgTypes[164]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11045,7 +11631,7 @@ func (x *RejectDraftChunkResponse) String() string {
 func (*RejectDraftChunkResponse) ProtoMessage() {}
 
 func (x *RejectDraftChunkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[153]
+	mi := &file_openshell_proto_msgTypes[164]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11058,7 +11644,7 @@ func (x *RejectDraftChunkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RejectDraftChunkResponse.ProtoReflect.Descriptor instead.
 func (*RejectDraftChunkResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{153}
+	return file_openshell_proto_rawDescGZIP(), []int{164}
 }
 
 // Approve all pending chunks.
@@ -11076,7 +11662,7 @@ type ApproveAllDraftChunksRequest struct {
 
 func (x *ApproveAllDraftChunksRequest) Reset() {
 	*x = ApproveAllDraftChunksRequest{}
-	mi := &file_openshell_proto_msgTypes[154]
+	mi := &file_openshell_proto_msgTypes[165]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11088,7 +11674,7 @@ func (x *ApproveAllDraftChunksRequest) String() string {
 func (*ApproveAllDraftChunksRequest) ProtoMessage() {}
 
 func (x *ApproveAllDraftChunksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[154]
+	mi := &file_openshell_proto_msgTypes[165]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11101,7 +11687,7 @@ func (x *ApproveAllDraftChunksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApproveAllDraftChunksRequest.ProtoReflect.Descriptor instead.
 func (*ApproveAllDraftChunksRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{154}
+	return file_openshell_proto_rawDescGZIP(), []int{165}
 }
 
 func (x *ApproveAllDraftChunksRequest) GetName() string {
@@ -11141,7 +11727,7 @@ type ApproveAllDraftChunksResponse struct {
 
 func (x *ApproveAllDraftChunksResponse) Reset() {
 	*x = ApproveAllDraftChunksResponse{}
-	mi := &file_openshell_proto_msgTypes[155]
+	mi := &file_openshell_proto_msgTypes[166]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11153,7 +11739,7 @@ func (x *ApproveAllDraftChunksResponse) String() string {
 func (*ApproveAllDraftChunksResponse) ProtoMessage() {}
 
 func (x *ApproveAllDraftChunksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[155]
+	mi := &file_openshell_proto_msgTypes[166]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11166,7 +11752,7 @@ func (x *ApproveAllDraftChunksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApproveAllDraftChunksResponse.ProtoReflect.Descriptor instead.
 func (*ApproveAllDraftChunksResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{155}
+	return file_openshell_proto_rawDescGZIP(), []int{166}
 }
 
 func (x *ApproveAllDraftChunksResponse) GetPolicyVersion() uint32 {
@@ -11214,7 +11800,7 @@ type EditDraftChunkRequest struct {
 
 func (x *EditDraftChunkRequest) Reset() {
 	*x = EditDraftChunkRequest{}
-	mi := &file_openshell_proto_msgTypes[156]
+	mi := &file_openshell_proto_msgTypes[167]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11226,7 +11812,7 @@ func (x *EditDraftChunkRequest) String() string {
 func (*EditDraftChunkRequest) ProtoMessage() {}
 
 func (x *EditDraftChunkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[156]
+	mi := &file_openshell_proto_msgTypes[167]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11239,7 +11825,7 @@ func (x *EditDraftChunkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EditDraftChunkRequest.ProtoReflect.Descriptor instead.
 func (*EditDraftChunkRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{156}
+	return file_openshell_proto_rawDescGZIP(), []int{167}
 }
 
 func (x *EditDraftChunkRequest) GetName() string {
@@ -11278,7 +11864,7 @@ type EditDraftChunkResponse struct {
 
 func (x *EditDraftChunkResponse) Reset() {
 	*x = EditDraftChunkResponse{}
-	mi := &file_openshell_proto_msgTypes[157]
+	mi := &file_openshell_proto_msgTypes[168]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11290,7 +11876,7 @@ func (x *EditDraftChunkResponse) String() string {
 func (*EditDraftChunkResponse) ProtoMessage() {}
 
 func (x *EditDraftChunkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[157]
+	mi := &file_openshell_proto_msgTypes[168]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11303,7 +11889,7 @@ func (x *EditDraftChunkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EditDraftChunkResponse.ProtoReflect.Descriptor instead.
 func (*EditDraftChunkResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{157}
+	return file_openshell_proto_rawDescGZIP(), []int{168}
 }
 
 // Reverse an approval (remove merged rule from active policy).
@@ -11321,7 +11907,7 @@ type UndoDraftChunkRequest struct {
 
 func (x *UndoDraftChunkRequest) Reset() {
 	*x = UndoDraftChunkRequest{}
-	mi := &file_openshell_proto_msgTypes[158]
+	mi := &file_openshell_proto_msgTypes[169]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11333,7 +11919,7 @@ func (x *UndoDraftChunkRequest) String() string {
 func (*UndoDraftChunkRequest) ProtoMessage() {}
 
 func (x *UndoDraftChunkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[158]
+	mi := &file_openshell_proto_msgTypes[169]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11346,7 +11932,7 @@ func (x *UndoDraftChunkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UndoDraftChunkRequest.ProtoReflect.Descriptor instead.
 func (*UndoDraftChunkRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{158}
+	return file_openshell_proto_rawDescGZIP(), []int{169}
 }
 
 func (x *UndoDraftChunkRequest) GetName() string {
@@ -11382,7 +11968,7 @@ type UndoDraftChunkResponse struct {
 
 func (x *UndoDraftChunkResponse) Reset() {
 	*x = UndoDraftChunkResponse{}
-	mi := &file_openshell_proto_msgTypes[159]
+	mi := &file_openshell_proto_msgTypes[170]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11394,7 +11980,7 @@ func (x *UndoDraftChunkResponse) String() string {
 func (*UndoDraftChunkResponse) ProtoMessage() {}
 
 func (x *UndoDraftChunkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[159]
+	mi := &file_openshell_proto_msgTypes[170]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11407,7 +11993,7 @@ func (x *UndoDraftChunkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UndoDraftChunkResponse.ProtoReflect.Descriptor instead.
 func (*UndoDraftChunkResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{159}
+	return file_openshell_proto_rawDescGZIP(), []int{170}
 }
 
 func (x *UndoDraftChunkResponse) GetPolicyVersion() uint32 {
@@ -11437,7 +12023,7 @@ type ClearDraftChunksRequest struct {
 
 func (x *ClearDraftChunksRequest) Reset() {
 	*x = ClearDraftChunksRequest{}
-	mi := &file_openshell_proto_msgTypes[160]
+	mi := &file_openshell_proto_msgTypes[171]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11449,7 +12035,7 @@ func (x *ClearDraftChunksRequest) String() string {
 func (*ClearDraftChunksRequest) ProtoMessage() {}
 
 func (x *ClearDraftChunksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[160]
+	mi := &file_openshell_proto_msgTypes[171]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11462,7 +12048,7 @@ func (x *ClearDraftChunksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClearDraftChunksRequest.ProtoReflect.Descriptor instead.
 func (*ClearDraftChunksRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{160}
+	return file_openshell_proto_rawDescGZIP(), []int{171}
 }
 
 func (x *ClearDraftChunksRequest) GetName() string {
@@ -11489,7 +12075,7 @@ type ClearDraftChunksResponse struct {
 
 func (x *ClearDraftChunksResponse) Reset() {
 	*x = ClearDraftChunksResponse{}
-	mi := &file_openshell_proto_msgTypes[161]
+	mi := &file_openshell_proto_msgTypes[172]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11501,7 +12087,7 @@ func (x *ClearDraftChunksResponse) String() string {
 func (*ClearDraftChunksResponse) ProtoMessage() {}
 
 func (x *ClearDraftChunksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[161]
+	mi := &file_openshell_proto_msgTypes[172]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11514,7 +12100,7 @@ func (x *ClearDraftChunksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClearDraftChunksResponse.ProtoReflect.Descriptor instead.
 func (*ClearDraftChunksResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{161}
+	return file_openshell_proto_rawDescGZIP(), []int{172}
 }
 
 func (x *ClearDraftChunksResponse) GetChunksCleared() uint32 {
@@ -11537,7 +12123,7 @@ type GetDraftHistoryRequest struct {
 
 func (x *GetDraftHistoryRequest) Reset() {
 	*x = GetDraftHistoryRequest{}
-	mi := &file_openshell_proto_msgTypes[162]
+	mi := &file_openshell_proto_msgTypes[173]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11549,7 +12135,7 @@ func (x *GetDraftHistoryRequest) String() string {
 func (*GetDraftHistoryRequest) ProtoMessage() {}
 
 func (x *GetDraftHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[162]
+	mi := &file_openshell_proto_msgTypes[173]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11562,7 +12148,7 @@ func (x *GetDraftHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDraftHistoryRequest.ProtoReflect.Descriptor instead.
 func (*GetDraftHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{162}
+	return file_openshell_proto_rawDescGZIP(), []int{173}
 }
 
 func (x *GetDraftHistoryRequest) GetName() string {
@@ -11596,7 +12182,7 @@ type DraftHistoryEntry struct {
 
 func (x *DraftHistoryEntry) Reset() {
 	*x = DraftHistoryEntry{}
-	mi := &file_openshell_proto_msgTypes[163]
+	mi := &file_openshell_proto_msgTypes[174]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11608,7 +12194,7 @@ func (x *DraftHistoryEntry) String() string {
 func (*DraftHistoryEntry) ProtoMessage() {}
 
 func (x *DraftHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[163]
+	mi := &file_openshell_proto_msgTypes[174]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11621,7 +12207,7 @@ func (x *DraftHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DraftHistoryEntry.ProtoReflect.Descriptor instead.
 func (*DraftHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{163}
+	return file_openshell_proto_rawDescGZIP(), []int{174}
 }
 
 func (x *DraftHistoryEntry) GetTimestampMs() int64 {
@@ -11662,7 +12248,7 @@ type GetDraftHistoryResponse struct {
 
 func (x *GetDraftHistoryResponse) Reset() {
 	*x = GetDraftHistoryResponse{}
-	mi := &file_openshell_proto_msgTypes[164]
+	mi := &file_openshell_proto_msgTypes[175]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11674,7 +12260,7 @@ func (x *GetDraftHistoryResponse) String() string {
 func (*GetDraftHistoryResponse) ProtoMessage() {}
 
 func (x *GetDraftHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[164]
+	mi := &file_openshell_proto_msgTypes[175]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11687,7 +12273,7 @@ func (x *GetDraftHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDraftHistoryResponse.ProtoReflect.Descriptor instead.
 func (*GetDraftHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{164}
+	return file_openshell_proto_rawDescGZIP(), []int{175}
 }
 
 func (x *GetDraftHistoryResponse) GetEntries() []*DraftHistoryEntry {
@@ -11716,7 +12302,7 @@ type PolicyRevisionPayload struct {
 
 func (x *PolicyRevisionPayload) Reset() {
 	*x = PolicyRevisionPayload{}
-	mi := &file_openshell_proto_msgTypes[165]
+	mi := &file_openshell_proto_msgTypes[176]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11728,7 +12314,7 @@ func (x *PolicyRevisionPayload) String() string {
 func (*PolicyRevisionPayload) ProtoMessage() {}
 
 func (x *PolicyRevisionPayload) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[165]
+	mi := &file_openshell_proto_msgTypes[176]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11741,7 +12327,7 @@ func (x *PolicyRevisionPayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyRevisionPayload.ProtoReflect.Descriptor instead.
 func (*PolicyRevisionPayload) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{165}
+	return file_openshell_proto_rawDescGZIP(), []int{176}
 }
 
 func (x *PolicyRevisionPayload) GetPolicy() *sandboxv1.SandboxPolicy {
@@ -11814,7 +12400,7 @@ type DraftChunkPayload struct {
 
 func (x *DraftChunkPayload) Reset() {
 	*x = DraftChunkPayload{}
-	mi := &file_openshell_proto_msgTypes[166]
+	mi := &file_openshell_proto_msgTypes[177]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11826,7 +12412,7 @@ func (x *DraftChunkPayload) String() string {
 func (*DraftChunkPayload) ProtoMessage() {}
 
 func (x *DraftChunkPayload) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[166]
+	mi := &file_openshell_proto_msgTypes[177]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11839,7 +12425,7 @@ func (x *DraftChunkPayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DraftChunkPayload.ProtoReflect.Descriptor instead.
 func (*DraftChunkPayload) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{166}
+	return file_openshell_proto_rawDescGZIP(), []int{177}
 }
 
 func (x *DraftChunkPayload) GetRuleName() string {
@@ -11945,7 +12531,7 @@ type StoredPolicyRevision struct {
 
 func (x *StoredPolicyRevision) Reset() {
 	*x = StoredPolicyRevision{}
-	mi := &file_openshell_proto_msgTypes[167]
+	mi := &file_openshell_proto_msgTypes[178]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11957,7 +12543,7 @@ func (x *StoredPolicyRevision) String() string {
 func (*StoredPolicyRevision) ProtoMessage() {}
 
 func (x *StoredPolicyRevision) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[167]
+	mi := &file_openshell_proto_msgTypes[178]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11970,7 +12556,7 @@ func (x *StoredPolicyRevision) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StoredPolicyRevision.ProtoReflect.Descriptor instead.
 func (*StoredPolicyRevision) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{167}
+	return file_openshell_proto_rawDescGZIP(), []int{178}
 }
 
 func (x *StoredPolicyRevision) GetId() string {
@@ -12073,7 +12659,7 @@ type StoredDraftChunk struct {
 
 func (x *StoredDraftChunk) Reset() {
 	*x = StoredDraftChunk{}
-	mi := &file_openshell_proto_msgTypes[168]
+	mi := &file_openshell_proto_msgTypes[179]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12085,7 +12671,7 @@ func (x *StoredDraftChunk) String() string {
 func (*StoredDraftChunk) ProtoMessage() {}
 
 func (x *StoredDraftChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[168]
+	mi := &file_openshell_proto_msgTypes[179]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12098,7 +12684,7 @@ func (x *StoredDraftChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StoredDraftChunk.ProtoReflect.Descriptor instead.
 func (*StoredDraftChunk) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{168}
+	return file_openshell_proto_rawDescGZIP(), []int{179}
 }
 
 func (x *StoredDraftChunk) GetId() string {
@@ -12247,7 +12833,7 @@ type CreateWorkspaceRequest struct {
 
 func (x *CreateWorkspaceRequest) Reset() {
 	*x = CreateWorkspaceRequest{}
-	mi := &file_openshell_proto_msgTypes[169]
+	mi := &file_openshell_proto_msgTypes[180]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12259,7 +12845,7 @@ func (x *CreateWorkspaceRequest) String() string {
 func (*CreateWorkspaceRequest) ProtoMessage() {}
 
 func (x *CreateWorkspaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[169]
+	mi := &file_openshell_proto_msgTypes[180]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12272,7 +12858,7 @@ func (x *CreateWorkspaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkspaceRequest.ProtoReflect.Descriptor instead.
 func (*CreateWorkspaceRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{169}
+	return file_openshell_proto_rawDescGZIP(), []int{180}
 }
 
 func (x *CreateWorkspaceRequest) GetName() string {
@@ -12299,7 +12885,7 @@ type CreateWorkspaceResponse struct {
 
 func (x *CreateWorkspaceResponse) Reset() {
 	*x = CreateWorkspaceResponse{}
-	mi := &file_openshell_proto_msgTypes[170]
+	mi := &file_openshell_proto_msgTypes[181]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12311,7 +12897,7 @@ func (x *CreateWorkspaceResponse) String() string {
 func (*CreateWorkspaceResponse) ProtoMessage() {}
 
 func (x *CreateWorkspaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[170]
+	mi := &file_openshell_proto_msgTypes[181]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12324,7 +12910,7 @@ func (x *CreateWorkspaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkspaceResponse.ProtoReflect.Descriptor instead.
 func (*CreateWorkspaceResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{170}
+	return file_openshell_proto_rawDescGZIP(), []int{181}
 }
 
 func (x *CreateWorkspaceResponse) GetWorkspace() *datamodelv1.Workspace {
@@ -12345,7 +12931,7 @@ type GetWorkspaceRequest struct {
 
 func (x *GetWorkspaceRequest) Reset() {
 	*x = GetWorkspaceRequest{}
-	mi := &file_openshell_proto_msgTypes[171]
+	mi := &file_openshell_proto_msgTypes[182]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12357,7 +12943,7 @@ func (x *GetWorkspaceRequest) String() string {
 func (*GetWorkspaceRequest) ProtoMessage() {}
 
 func (x *GetWorkspaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[171]
+	mi := &file_openshell_proto_msgTypes[182]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12370,7 +12956,7 @@ func (x *GetWorkspaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWorkspaceRequest.ProtoReflect.Descriptor instead.
 func (*GetWorkspaceRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{171}
+	return file_openshell_proto_rawDescGZIP(), []int{182}
 }
 
 func (x *GetWorkspaceRequest) GetName() string {
@@ -12390,7 +12976,7 @@ type GetWorkspaceResponse struct {
 
 func (x *GetWorkspaceResponse) Reset() {
 	*x = GetWorkspaceResponse{}
-	mi := &file_openshell_proto_msgTypes[172]
+	mi := &file_openshell_proto_msgTypes[183]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12402,7 +12988,7 @@ func (x *GetWorkspaceResponse) String() string {
 func (*GetWorkspaceResponse) ProtoMessage() {}
 
 func (x *GetWorkspaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[172]
+	mi := &file_openshell_proto_msgTypes[183]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12415,7 +13001,7 @@ func (x *GetWorkspaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWorkspaceResponse.ProtoReflect.Descriptor instead.
 func (*GetWorkspaceResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{172}
+	return file_openshell_proto_rawDescGZIP(), []int{183}
 }
 
 func (x *GetWorkspaceResponse) GetWorkspace() *datamodelv1.Workspace {
@@ -12438,7 +13024,7 @@ type ListWorkspacesRequest struct {
 
 func (x *ListWorkspacesRequest) Reset() {
 	*x = ListWorkspacesRequest{}
-	mi := &file_openshell_proto_msgTypes[173]
+	mi := &file_openshell_proto_msgTypes[184]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12450,7 +13036,7 @@ func (x *ListWorkspacesRequest) String() string {
 func (*ListWorkspacesRequest) ProtoMessage() {}
 
 func (x *ListWorkspacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[173]
+	mi := &file_openshell_proto_msgTypes[184]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12463,7 +13049,7 @@ func (x *ListWorkspacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspacesRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkspacesRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{173}
+	return file_openshell_proto_rawDescGZIP(), []int{184}
 }
 
 func (x *ListWorkspacesRequest) GetLimit() uint32 {
@@ -12497,7 +13083,7 @@ type ListWorkspacesResponse struct {
 
 func (x *ListWorkspacesResponse) Reset() {
 	*x = ListWorkspacesResponse{}
-	mi := &file_openshell_proto_msgTypes[174]
+	mi := &file_openshell_proto_msgTypes[185]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12509,7 +13095,7 @@ func (x *ListWorkspacesResponse) String() string {
 func (*ListWorkspacesResponse) ProtoMessage() {}
 
 func (x *ListWorkspacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[174]
+	mi := &file_openshell_proto_msgTypes[185]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12522,7 +13108,7 @@ func (x *ListWorkspacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspacesResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkspacesResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{174}
+	return file_openshell_proto_rawDescGZIP(), []int{185}
 }
 
 func (x *ListWorkspacesResponse) GetWorkspaces() []*datamodelv1.Workspace {
@@ -12543,7 +13129,7 @@ type DeleteWorkspaceRequest struct {
 
 func (x *DeleteWorkspaceRequest) Reset() {
 	*x = DeleteWorkspaceRequest{}
-	mi := &file_openshell_proto_msgTypes[175]
+	mi := &file_openshell_proto_msgTypes[186]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12555,7 +13141,7 @@ func (x *DeleteWorkspaceRequest) String() string {
 func (*DeleteWorkspaceRequest) ProtoMessage() {}
 
 func (x *DeleteWorkspaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[175]
+	mi := &file_openshell_proto_msgTypes[186]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12568,7 +13154,7 @@ func (x *DeleteWorkspaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWorkspaceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteWorkspaceRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{175}
+	return file_openshell_proto_rawDescGZIP(), []int{186}
 }
 
 func (x *DeleteWorkspaceRequest) GetName() string {
@@ -12588,7 +13174,7 @@ type DeleteWorkspaceResponse struct {
 
 func (x *DeleteWorkspaceResponse) Reset() {
 	*x = DeleteWorkspaceResponse{}
-	mi := &file_openshell_proto_msgTypes[176]
+	mi := &file_openshell_proto_msgTypes[187]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12600,7 +13186,7 @@ func (x *DeleteWorkspaceResponse) String() string {
 func (*DeleteWorkspaceResponse) ProtoMessage() {}
 
 func (x *DeleteWorkspaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[176]
+	mi := &file_openshell_proto_msgTypes[187]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12613,7 +13199,7 @@ func (x *DeleteWorkspaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWorkspaceResponse.ProtoReflect.Descriptor instead.
 func (*DeleteWorkspaceResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{176}
+	return file_openshell_proto_rawDescGZIP(), []int{187}
 }
 
 func (x *DeleteWorkspaceResponse) GetDeleted() bool {
@@ -12637,7 +13223,7 @@ type WorkspaceMember struct {
 
 func (x *WorkspaceMember) Reset() {
 	*x = WorkspaceMember{}
-	mi := &file_openshell_proto_msgTypes[177]
+	mi := &file_openshell_proto_msgTypes[188]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12649,7 +13235,7 @@ func (x *WorkspaceMember) String() string {
 func (*WorkspaceMember) ProtoMessage() {}
 
 func (x *WorkspaceMember) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[177]
+	mi := &file_openshell_proto_msgTypes[188]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12662,7 +13248,7 @@ func (x *WorkspaceMember) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkspaceMember.ProtoReflect.Descriptor instead.
 func (*WorkspaceMember) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{177}
+	return file_openshell_proto_rawDescGZIP(), []int{188}
 }
 
 func (x *WorkspaceMember) GetMetadata() *datamodelv1.ObjectMeta {
@@ -12701,7 +13287,7 @@ type AddWorkspaceMemberRequest struct {
 
 func (x *AddWorkspaceMemberRequest) Reset() {
 	*x = AddWorkspaceMemberRequest{}
-	mi := &file_openshell_proto_msgTypes[178]
+	mi := &file_openshell_proto_msgTypes[189]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12713,7 +13299,7 @@ func (x *AddWorkspaceMemberRequest) String() string {
 func (*AddWorkspaceMemberRequest) ProtoMessage() {}
 
 func (x *AddWorkspaceMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[178]
+	mi := &file_openshell_proto_msgTypes[189]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12726,7 +13312,7 @@ func (x *AddWorkspaceMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddWorkspaceMemberRequest.ProtoReflect.Descriptor instead.
 func (*AddWorkspaceMemberRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{178}
+	return file_openshell_proto_rawDescGZIP(), []int{189}
 }
 
 func (x *AddWorkspaceMemberRequest) GetWorkspace() string {
@@ -12760,7 +13346,7 @@ type AddWorkspaceMemberResponse struct {
 
 func (x *AddWorkspaceMemberResponse) Reset() {
 	*x = AddWorkspaceMemberResponse{}
-	mi := &file_openshell_proto_msgTypes[179]
+	mi := &file_openshell_proto_msgTypes[190]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12772,7 +13358,7 @@ func (x *AddWorkspaceMemberResponse) String() string {
 func (*AddWorkspaceMemberResponse) ProtoMessage() {}
 
 func (x *AddWorkspaceMemberResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[179]
+	mi := &file_openshell_proto_msgTypes[190]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12785,7 +13371,7 @@ func (x *AddWorkspaceMemberResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddWorkspaceMemberResponse.ProtoReflect.Descriptor instead.
 func (*AddWorkspaceMemberResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{179}
+	return file_openshell_proto_rawDescGZIP(), []int{190}
 }
 
 func (x *AddWorkspaceMemberResponse) GetMember() *WorkspaceMember {
@@ -12808,7 +13394,7 @@ type RemoveWorkspaceMemberRequest struct {
 
 func (x *RemoveWorkspaceMemberRequest) Reset() {
 	*x = RemoveWorkspaceMemberRequest{}
-	mi := &file_openshell_proto_msgTypes[180]
+	mi := &file_openshell_proto_msgTypes[191]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12820,7 +13406,7 @@ func (x *RemoveWorkspaceMemberRequest) String() string {
 func (*RemoveWorkspaceMemberRequest) ProtoMessage() {}
 
 func (x *RemoveWorkspaceMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[180]
+	mi := &file_openshell_proto_msgTypes[191]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12833,7 +13419,7 @@ func (x *RemoveWorkspaceMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveWorkspaceMemberRequest.ProtoReflect.Descriptor instead.
 func (*RemoveWorkspaceMemberRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{180}
+	return file_openshell_proto_rawDescGZIP(), []int{191}
 }
 
 func (x *RemoveWorkspaceMemberRequest) GetWorkspace() string {
@@ -12860,7 +13446,7 @@ type RemoveWorkspaceMemberResponse struct {
 
 func (x *RemoveWorkspaceMemberResponse) Reset() {
 	*x = RemoveWorkspaceMemberResponse{}
-	mi := &file_openshell_proto_msgTypes[181]
+	mi := &file_openshell_proto_msgTypes[192]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12872,7 +13458,7 @@ func (x *RemoveWorkspaceMemberResponse) String() string {
 func (*RemoveWorkspaceMemberResponse) ProtoMessage() {}
 
 func (x *RemoveWorkspaceMemberResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[181]
+	mi := &file_openshell_proto_msgTypes[192]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12885,7 +13471,7 @@ func (x *RemoveWorkspaceMemberResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveWorkspaceMemberResponse.ProtoReflect.Descriptor instead.
 func (*RemoveWorkspaceMemberResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{181}
+	return file_openshell_proto_rawDescGZIP(), []int{192}
 }
 
 func (x *RemoveWorkspaceMemberResponse) GetRemoved() bool {
@@ -12908,7 +13494,7 @@ type ListWorkspaceMembersRequest struct {
 
 func (x *ListWorkspaceMembersRequest) Reset() {
 	*x = ListWorkspaceMembersRequest{}
-	mi := &file_openshell_proto_msgTypes[182]
+	mi := &file_openshell_proto_msgTypes[193]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12920,7 +13506,7 @@ func (x *ListWorkspaceMembersRequest) String() string {
 func (*ListWorkspaceMembersRequest) ProtoMessage() {}
 
 func (x *ListWorkspaceMembersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[182]
+	mi := &file_openshell_proto_msgTypes[193]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12933,7 +13519,7 @@ func (x *ListWorkspaceMembersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspaceMembersRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkspaceMembersRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{182}
+	return file_openshell_proto_rawDescGZIP(), []int{193}
 }
 
 func (x *ListWorkspaceMembersRequest) GetWorkspace() string {
@@ -12967,7 +13553,7 @@ type ListWorkspaceMembersResponse struct {
 
 func (x *ListWorkspaceMembersResponse) Reset() {
 	*x = ListWorkspaceMembersResponse{}
-	mi := &file_openshell_proto_msgTypes[183]
+	mi := &file_openshell_proto_msgTypes[194]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12979,7 +13565,7 @@ func (x *ListWorkspaceMembersResponse) String() string {
 func (*ListWorkspaceMembersResponse) ProtoMessage() {}
 
 func (x *ListWorkspaceMembersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[183]
+	mi := &file_openshell_proto_msgTypes[194]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12992,7 +13578,7 @@ func (x *ListWorkspaceMembersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspaceMembersResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkspaceMembersResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{183}
+	return file_openshell_proto_rawDescGZIP(), []int{194}
 }
 
 func (x *ListWorkspaceMembersResponse) GetMembers() []*WorkspaceMember {
@@ -13020,7 +13606,7 @@ type ExtensionServiceCredential struct {
 
 func (x *ExtensionServiceCredential) Reset() {
 	*x = ExtensionServiceCredential{}
-	mi := &file_openshell_proto_msgTypes[184]
+	mi := &file_openshell_proto_msgTypes[195]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13032,7 +13618,7 @@ func (x *ExtensionServiceCredential) String() string {
 func (*ExtensionServiceCredential) ProtoMessage() {}
 
 func (x *ExtensionServiceCredential) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_proto_msgTypes[184]
+	mi := &file_openshell_proto_msgTypes[195]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13045,7 +13631,7 @@ func (x *ExtensionServiceCredential) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtensionServiceCredential.ProtoReflect.Descriptor instead.
 func (*ExtensionServiceCredential) Descriptor() ([]byte, []int) {
-	return file_openshell_proto_rawDescGZIP(), []int{184}
+	return file_openshell_proto_rawDescGZIP(), []int{195}
 }
 
 func (x *ExtensionServiceCredential) GetServiceName() string {
@@ -13073,7 +13659,7 @@ var File_openshell_proto protoreflect.FileDescriptor
 
 const file_openshell_proto_rawDesc = "" +
 	"\n" +
-	"\x0fopenshell.proto\x12\fopenshell.v1\x1a\x0fdatamodel.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\roptions.proto\x1a\rsandbox.proto\"\x1a\n" +
+	"\x0fopenshell.proto\x12\fopenshell.v1\x1a\x0fdatamodel.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\roptions.proto\x1a\rsandbox.proto\"\x1a\n" +
 	"\x18IssueSandboxTokenRequest\"[\n" +
 	"\x19IssueSandboxTokenResponse\x12\x1a\n" +
 	"\x05token\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01R\x05token\x12\"\n" +
@@ -13106,50 +13692,50 @@ const file_openshell_proto_rawDesc = "" +
 	"\x19ComputeDriverCapabilities\x12\x1f\n" +
 	"\vdriver_name\x18\x01 \x01(\tR\n" +
 	"driverName\x12%\n" +
-	"\x0edriver_version\x18\x02 \x01(\tR\rdriverVersion\"\xd8\x01\n" +
+	"\x0edriver_version\x18\x02 \x01(\tR\rdriverVersion\"\xaf\x02\n" +
 	"\aSandbox\x12>\n" +
 	"\bmetadata\x18\x01 \x01(\v2\".openshell.datamodel.v1.ObjectMetaR\bmetadata\x12-\n" +
 	"\x04spec\x18\x02 \x01(\v2\x19.openshell.v1.SandboxSpecR\x04spec\x123\n" +
-	"\x06status\x18\x03 \x01(\v2\x1b.openshell.v1.SandboxStatusR\x06statusJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\x05phaseR\x16current_policy_version\"\xd7\x03\n" +
-	"\vSandboxSpec\x12\x1b\n" +
-	"\tlog_level\x18\x01 \x01(\tR\blogLevel\x12L\n" +
-	"\venvironment\x18\x05 \x03(\v2*.openshell.v1.SandboxSpec.EnvironmentEntryR\venvironment\x129\n" +
-	"\btemplate\x18\x06 \x01(\v2\x1d.openshell.v1.SandboxTemplateR\btemplate\x12;\n" +
-	"\x06policy\x18\a \x01(\v2#.openshell.sandbox.v1.SandboxPolicyR\x06policy\x12\x1c\n" +
-	"\tproviders\x18\b \x03(\tR\tproviders\x12W\n" +
-	"\x15resource_requirements\x18\t \x01(\v2\".openshell.v1.ResourceRequirementsR\x14resourceRequirements\x1a>\n" +
+	"\x06status\x18\x03 \x01(\v2\x1b.openshell.v1.SandboxStatusR\x06status\x12[\n" +
+	"\x15created_from_template\x18\x04 \x01(\v2'.openshell.v1.SandboxTemplateProvenanceR\x13createdFromTemplateJ\x04\b\x05\x10\x06R\x05phaseR\x16current_policy_version\"\xf4\x02\n" +
+	"\vSandboxSpec\x12?\n" +
+	"\bworkload\x18\f \x01(\v2#.openshell.v1.SandboxWorkloadConfigR\bworkload\x12<\n" +
+	"\rdriver_config\x18\r \x01(\v2\x17.google.protobuf.StructR\fdriverConfig\x12;\n" +
+	"\x06policy\x18\x0e \x01(\v2#.openshell.sandbox.v1.SandboxPolicyR\x06policy\x12\x1c\n" +
+	"\tproviders\x18\x0f \x03(\tR\tprovidersJ\x04\b\x01\x10\x02J\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
+	"J\x04\b\n" +
+	"\x10\vJ\x04\b\v\x10\fR\venvironmentR\n" +
+	"gpu_deviceR\tlog_levelR\x16proposal_approval_modeR\x15resource_requirementsR\btemplate\"\xb3\x02\n" +
+	"\x15SandboxWorkloadConfig\x12\x14\n" +
+	"\x05image\x18\x01 \x01(\tR\x05image\x12V\n" +
+	"\venvironment\x18\x02 \x03(\v24.openshell.v1.SandboxWorkloadConfig.EnvironmentEntryR\venvironment\x12<\n" +
+	"\tresources\x18\x03 \x01(\v2\x1e.openshell.v1.SandboxResourcesR\tresources\x1a>\n" +
 	"\x10EnvironmentEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\n" +
 	"\x10\vJ\x04\b\v\x10\fR\n" +
-	"gpu_deviceR\x16proposal_approval_mode\"O\n" +
-	"\x14ResourceRequirements\x127\n" +
-	"\x03gpu\x18\x01 \x01(\v2%.openshell.v1.GpuResourceRequirementsR\x03gpu\">\n" +
-	"\x17GpuResourceRequirements\x12\x19\n" +
-	"\x05count\x18\x01 \x01(\rH\x00R\x05count\x88\x01\x01B\b\n" +
-	"\x06_count\"\xef\x05\n" +
-	"\x0fSandboxTemplate\x12\x14\n" +
-	"\x05image\x18\x01 \x01(\tR\x05image\x12,\n" +
-	"\x12runtime_class_name\x18\x02 \x01(\tR\x10runtimeClassName\x12!\n" +
-	"\fagent_socket\x18\x03 \x01(\tR\vagentSocket\x12A\n" +
-	"\x06labels\x18\x04 \x03(\v2).openshell.v1.SandboxTemplate.LabelsEntryR\x06labels\x12P\n" +
-	"\vannotations\x18\x05 \x03(\v2..openshell.v1.SandboxTemplate.AnnotationsEntryR\vannotations\x12P\n" +
-	"\venvironment\x18\x06 \x03(\v2..openshell.v1.SandboxTemplate.EnvironmentEntryR\venvironment\x125\n" +
-	"\tresources\x18\a \x01(\v2\x17.google.protobuf.StructR\tresources\x12,\n" +
-	"\x0fuser_namespaces\x18\n" +
-	" \x01(\bH\x00R\x0euserNamespaces\x88\x01\x01\x12<\n" +
-	"\rdriver_config\x18\v \x01(\v2\x17.google.protobuf.StructR\fdriverConfig\x1a9\n" +
-	"\vLabelsEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +
-	"\x10AnnotationsEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +
-	"\x10EnvironmentEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x12\n" +
-	"\x10_user_namespacesJ\x04\b\t\x10\n" +
-	"R\x16volume_claim_templates\"\xb1\x02\n" +
+	"gpu_deviceR\x16proposal_approval_mode\"l\n" +
+	"\x10SandboxResources\x12\x10\n" +
+	"\x03cpu\x18\x01 \x01(\tR\x03cpu\x12\x16\n" +
+	"\x06memory\x18\x02 \x01(\tR\x06memory\x12 \n" +
+	"\tgpu_count\x18\x03 \x01(\rH\x00R\bgpuCount\x88\x01\x01B\f\n" +
+	"\n" +
+	"_gpu_count\"\x88\x01\n" +
+	"\x0fSandboxTemplate\x12>\n" +
+	"\bmetadata\x18\x01 \x01(\v2\".openshell.datamodel.v1.ObjectMetaR\bmetadata\x125\n" +
+	"\x04spec\x18\x02 \x01(\v2!.openshell.v1.SandboxTemplateSpecR\x04spec\"\xeb\x01\n" +
+	"\x13SandboxTemplateSpec\x12?\n" +
+	"\bworkload\x18\x01 \x01(\v2#.openshell.v1.SandboxWorkloadConfigR\bworkload\x12<\n" +
+	"\rdriver_config\x18\x02 \x01(\v2\x17.google.protobuf.StructR\fdriverConfig\x12U\n" +
+	"\x15desired_service_level\x18\x03 \x01(\v2!.openshell.v1.SandboxServiceLevelR\x13desiredServiceLevel\"M\n" +
+	"\x13SandboxServiceLevel\x126\n" +
+	"\astartup\x18\x01 \x01(\v2\x1c.openshell.v1.SandboxStartupR\astartup\"k\n" +
+	"\x0eSandboxStartup\x12<\n" +
+	"\fready_within\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\vreadyWithin\x12\x1b\n" +
+	"\tmax_burst\x18\x02 \x01(\rR\bmaxBurst\"Z\n" +
+	"\x19SandboxTemplateProvenance\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12)\n" +
+	"\x10resource_version\x18\x02 \x01(\tR\x0fresourceVersion\"\xb1\x02\n" +
 	"\rSandboxStatus\x12!\n" +
 	"\fsandbox_name\x18\x01 \x01(\tR\vsandboxName\x12\x1b\n" +
 	"\tagent_pod\x18\x02 \x01(\tR\bagentPod\x12\x19\n" +
@@ -13176,19 +13762,44 @@ const file_openshell_proto_rawDesc = "" +
 	"\bmetadata\x18\x06 \x03(\v2).openshell.v1.PlatformEvent.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x91\x03\n" +
-	"\x14CreateSandboxRequest\x12-\n" +
-	"\x04spec\x18\x01 \x01(\v2\x19.openshell.v1.SandboxSpecR\x04spec\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\x12F\n" +
-	"\x06labels\x18\x03 \x03(\v2..openshell.v1.CreateSandboxRequest.LabelsEntryR\x06labels\x12U\n" +
-	"\vannotations\x18\x04 \x03(\v23.openshell.v1.CreateSandboxRequest.AnnotationsEntryR\vannotations\x12\x1c\n" +
-	"\tworkspace\x18\x05 \x01(\tR\tworkspace\x1a9\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xef\x04\n" +
+	"\x14CreateSandboxRequest\x12A\n" +
+	"\bworkload\x18\x06 \x01(\v2#.openshell.v1.SandboxWorkloadConfigH\x00R\bworkload\x126\n" +
+	"\x16workload_template_name\x18\a \x01(\tH\x00R\x14workloadTemplateName\x12;\n" +
+	"\x06policy\x18\b \x01(\v2#.openshell.sandbox.v1.SandboxPolicyR\x06policy\x12\x1c\n" +
+	"\tproviders\x18\t \x03(\tR\tproviders\x12\x12\n" +
+	"\x04name\x18\n" +
+	" \x01(\tR\x04name\x12F\n" +
+	"\x06labels\x18\v \x03(\v2..openshell.v1.CreateSandboxRequest.LabelsEntryR\x06labels\x12U\n" +
+	"\vannotations\x18\f \x03(\v23.openshell.v1.CreateSandboxRequest.AnnotationsEntryR\vannotations\x12\x1c\n" +
+	"\tworkspace\x18\r \x01(\tR\tworkspace\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +
 	"\x10AnnotationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"E\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x11\n" +
+	"\x0fworkload_sourceJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\x04spec\"w\n" +
+	"\x1cCreateSandboxTemplateRequest\x129\n" +
+	"\btemplate\x18\x01 \x01(\v2\x1d.openshell.v1.SandboxTemplateR\btemplate\x12\x1c\n" +
+	"\tworkspace\x18\x02 \x01(\tR\tworkspace\"M\n" +
+	"\x19GetSandboxTemplateRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
+	"\tworkspace\x18\x02 \x01(\tR\tworkspace\"\x90\x01\n" +
+	"\x1bListSandboxTemplatesRequest\x12\x14\n" +
+	"\x05limit\x18\x01 \x01(\rR\x05limit\x12\x16\n" +
+	"\x06offset\x18\x02 \x01(\rR\x06offset\x12\x1c\n" +
+	"\tworkspace\x18\x03 \x01(\tR\tworkspace\x12%\n" +
+	"\x0eall_workspaces\x18\x04 \x01(\bR\rallWorkspaces\"P\n" +
+	"\x1cDeleteSandboxTemplateRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
+	"\tworkspace\x18\x02 \x01(\tR\tworkspace\"T\n" +
+	"\x17SandboxTemplateResponse\x129\n" +
+	"\btemplate\x18\x01 \x01(\v2\x1d.openshell.v1.SandboxTemplateR\btemplate\"[\n" +
+	"\x1cListSandboxTemplatesResponse\x12;\n" +
+	"\ttemplates\x18\x01 \x03(\v2\x1d.openshell.v1.SandboxTemplateR\ttemplates\"9\n" +
+	"\x1dDeleteSandboxTemplateResponse\x12\x18\n" +
+	"\adeleted\x18\x01 \x01(\bR\adeleted\"E\n" +
 	"\x11GetSandboxRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
 	"\tworkspace\x18\x02 \x01(\tR\tworkspace\"\xb0\x01\n" +
@@ -14108,7 +14719,7 @@ const file_openshell_proto_rawDesc = "" +
 	"\rWorkspaceRole\x12\x1e\n" +
 	"\x1aWORKSPACE_ROLE_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13WORKSPACE_ROLE_USER\x10\x01\x12\x18\n" +
-	"\x14WORKSPACE_ROLE_ADMIN\x10\x022\x94D\n" +
+	"\x14WORKSPACE_ROLE_ADMIN\x10\x022\xd7H\n" +
 	"\tOpenShell\x12Z\n" +
 	"\x06Health\x12\x1b.openshell.v1.HealthRequest\x1a\x1c.openshell.v1.HealthResponse\"\x15\x82\xb5\x18\x11\n" +
 	"\x0funauthenticated\x12i\n" +
@@ -14122,7 +14733,15 @@ const file_openshell_proto_rawDesc = "" +
 	"GetSandbox\x12\x1f.openshell.v1.GetSandboxRequest\x1a\x1d.openshell.v1.SandboxResponse\" \x82\xb5\x18\x1c\n" +
 	"\x06bearer\x12\x04user\"\fsandbox:read\x12z\n" +
 	"\rListSandboxes\x12\".openshell.v1.ListSandboxesRequest\x1a#.openshell.v1.ListSandboxesResponse\" \x82\xb5\x18\x1c\n" +
+	"\x06bearer\x12\x04user\"\fsandbox:read\x12\x8e\x01\n" +
+	"\x15CreateSandboxTemplate\x12*.openshell.v1.CreateSandboxTemplateRequest\x1a%.openshell.v1.SandboxTemplateResponse\"\"\x82\xb5\x18\x1e\n" +
+	"\x06bearer\x12\x05admin\"\rsandbox:write\x12\x86\x01\n" +
+	"\x12GetSandboxTemplate\x12'.openshell.v1.GetSandboxTemplateRequest\x1a%.openshell.v1.SandboxTemplateResponse\" \x82\xb5\x18\x1c\n" +
 	"\x06bearer\x12\x04user\"\fsandbox:read\x12\x8f\x01\n" +
+	"\x14ListSandboxTemplates\x12).openshell.v1.ListSandboxTemplatesRequest\x1a*.openshell.v1.ListSandboxTemplatesResponse\" \x82\xb5\x18\x1c\n" +
+	"\x06bearer\x12\x04user\"\fsandbox:read\x12\x94\x01\n" +
+	"\x15DeleteSandboxTemplate\x12*.openshell.v1.DeleteSandboxTemplateRequest\x1a+.openshell.v1.DeleteSandboxTemplateResponse\"\"\x82\xb5\x18\x1e\n" +
+	"\x06bearer\x12\x05admin\"\rsandbox:write\x12\x8f\x01\n" +
 	"\x14ListSandboxProviders\x12).openshell.v1.ListSandboxProvidersRequest\x1a*.openshell.v1.ListSandboxProvidersResponse\" \x82\xb5\x18\x1c\n" +
 	"\x06bearer\x12\x04user\"\fsandbox:read\x12\x93\x01\n" +
 	"\x15AttachSandboxProvider\x12*.openshell.v1.AttachSandboxProviderRequest\x1a+.openshell.v1.AttachSandboxProviderResponse\"!\x82\xb5\x18\x1d\n" +
@@ -14259,7 +14878,7 @@ func file_openshell_proto_rawDescGZIP() []byte {
 }
 
 var file_openshell_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_openshell_proto_msgTypes = make([]protoimpl.MessageInfo, 209)
+var file_openshell_proto_msgTypes = make([]protoimpl.MessageInfo, 217)
 var file_openshell_proto_goTypes = []any{
 	(SandboxPhase)(0),                                    // 0: openshell.v1.SandboxPhase
 	(ProviderCredentialRefreshStrategy)(0),               // 1: openshell.v1.ProviderCredentialRefreshStrategy
@@ -14281,506 +14900,530 @@ var file_openshell_proto_goTypes = []any{
 	(*ComputeDriverCapabilities)(nil),                    // 17: openshell.v1.ComputeDriverCapabilities
 	(*Sandbox)(nil),                                      // 18: openshell.v1.Sandbox
 	(*SandboxSpec)(nil),                                  // 19: openshell.v1.SandboxSpec
-	(*ResourceRequirements)(nil),                         // 20: openshell.v1.ResourceRequirements
-	(*GpuResourceRequirements)(nil),                      // 21: openshell.v1.GpuResourceRequirements
+	(*SandboxWorkloadConfig)(nil),                        // 20: openshell.v1.SandboxWorkloadConfig
+	(*SandboxResources)(nil),                             // 21: openshell.v1.SandboxResources
 	(*SandboxTemplate)(nil),                              // 22: openshell.v1.SandboxTemplate
-	(*SandboxStatus)(nil),                                // 23: openshell.v1.SandboxStatus
-	(*SandboxCondition)(nil),                             // 24: openshell.v1.SandboxCondition
-	(*PlatformEvent)(nil),                                // 25: openshell.v1.PlatformEvent
-	(*CreateSandboxRequest)(nil),                         // 26: openshell.v1.CreateSandboxRequest
-	(*GetSandboxRequest)(nil),                            // 27: openshell.v1.GetSandboxRequest
-	(*ListSandboxesRequest)(nil),                         // 28: openshell.v1.ListSandboxesRequest
-	(*ListSandboxProvidersRequest)(nil),                  // 29: openshell.v1.ListSandboxProvidersRequest
-	(*AttachSandboxProviderRequest)(nil),                 // 30: openshell.v1.AttachSandboxProviderRequest
-	(*DetachSandboxProviderRequest)(nil),                 // 31: openshell.v1.DetachSandboxProviderRequest
-	(*DeleteSandboxRequest)(nil),                         // 32: openshell.v1.DeleteSandboxRequest
-	(*StopSandboxRequest)(nil),                           // 33: openshell.v1.StopSandboxRequest
-	(*StartSandboxRequest)(nil),                          // 34: openshell.v1.StartSandboxRequest
-	(*SandboxResponse)(nil),                              // 35: openshell.v1.SandboxResponse
-	(*ListSandboxesResponse)(nil),                        // 36: openshell.v1.ListSandboxesResponse
-	(*ListSandboxProvidersResponse)(nil),                 // 37: openshell.v1.ListSandboxProvidersResponse
-	(*AttachSandboxProviderResponse)(nil),                // 38: openshell.v1.AttachSandboxProviderResponse
-	(*DetachSandboxProviderResponse)(nil),                // 39: openshell.v1.DetachSandboxProviderResponse
-	(*DeleteSandboxResponse)(nil),                        // 40: openshell.v1.DeleteSandboxResponse
-	(*CreateSshSessionRequest)(nil),                      // 41: openshell.v1.CreateSshSessionRequest
-	(*CreateSshSessionResponse)(nil),                     // 42: openshell.v1.CreateSshSessionResponse
-	(*ExposeServiceRequest)(nil),                         // 43: openshell.v1.ExposeServiceRequest
-	(*GetServiceRequest)(nil),                            // 44: openshell.v1.GetServiceRequest
-	(*ListServicesRequest)(nil),                          // 45: openshell.v1.ListServicesRequest
-	(*ListServicesResponse)(nil),                         // 46: openshell.v1.ListServicesResponse
-	(*DeleteServiceRequest)(nil),                         // 47: openshell.v1.DeleteServiceRequest
-	(*DeleteServiceResponse)(nil),                        // 48: openshell.v1.DeleteServiceResponse
-	(*ServiceEndpoint)(nil),                              // 49: openshell.v1.ServiceEndpoint
-	(*ServiceEndpointResponse)(nil),                      // 50: openshell.v1.ServiceEndpointResponse
-	(*RevokeSshSessionRequest)(nil),                      // 51: openshell.v1.RevokeSshSessionRequest
-	(*RevokeSshSessionResponse)(nil),                     // 52: openshell.v1.RevokeSshSessionResponse
-	(*ExecSandboxRequest)(nil),                           // 53: openshell.v1.ExecSandboxRequest
-	(*ExecSandboxStdout)(nil),                            // 54: openshell.v1.ExecSandboxStdout
-	(*ExecSandboxStderr)(nil),                            // 55: openshell.v1.ExecSandboxStderr
-	(*ExecSandboxExit)(nil),                              // 56: openshell.v1.ExecSandboxExit
-	(*ExecSandboxEvent)(nil),                             // 57: openshell.v1.ExecSandboxEvent
-	(*TcpForwardInit)(nil),                               // 58: openshell.v1.TcpForwardInit
-	(*TcpForwardFrame)(nil),                              // 59: openshell.v1.TcpForwardFrame
-	(*ExecSandboxInput)(nil),                             // 60: openshell.v1.ExecSandboxInput
-	(*ExecSandboxWindowResize)(nil),                      // 61: openshell.v1.ExecSandboxWindowResize
-	(*SshSession)(nil),                                   // 62: openshell.v1.SshSession
-	(*WatchSandboxRequest)(nil),                          // 63: openshell.v1.WatchSandboxRequest
-	(*SandboxStreamEvent)(nil),                           // 64: openshell.v1.SandboxStreamEvent
-	(*SandboxLogLine)(nil),                               // 65: openshell.v1.SandboxLogLine
-	(*SandboxStreamWarning)(nil),                         // 66: openshell.v1.SandboxStreamWarning
-	(*CreateProviderRequest)(nil),                        // 67: openshell.v1.CreateProviderRequest
-	(*GetProviderRequest)(nil),                           // 68: openshell.v1.GetProviderRequest
-	(*ListProvidersRequest)(nil),                         // 69: openshell.v1.ListProvidersRequest
-	(*UpdateProviderRequest)(nil),                        // 70: openshell.v1.UpdateProviderRequest
-	(*DeleteProviderRequest)(nil),                        // 71: openshell.v1.DeleteProviderRequest
-	(*ProviderResponse)(nil),                             // 72: openshell.v1.ProviderResponse
-	(*ListProvidersResponse)(nil),                        // 73: openshell.v1.ListProvidersResponse
-	(*ListProviderProfilesRequest)(nil),                  // 74: openshell.v1.ListProviderProfilesRequest
-	(*GetProviderProfileRequest)(nil),                    // 75: openshell.v1.GetProviderProfileRequest
-	(*ProviderProfileImportItem)(nil),                    // 76: openshell.v1.ProviderProfileImportItem
-	(*ProviderProfileDiagnostic)(nil),                    // 77: openshell.v1.ProviderProfileDiagnostic
-	(*ProviderCredentialTokenGrantAudienceOverride)(nil), // 78: openshell.v1.ProviderCredentialTokenGrantAudienceOverride
-	(*ProviderCredentialTokenGrant)(nil),                 // 79: openshell.v1.ProviderCredentialTokenGrant
-	(*ProviderProfileCredential)(nil),                    // 80: openshell.v1.ProviderProfileCredential
-	(*ProviderCredentialRefreshMaterial)(nil),            // 81: openshell.v1.ProviderCredentialRefreshMaterial
-	(*ProviderCredentialRefreshOutput)(nil),              // 82: openshell.v1.ProviderCredentialRefreshOutput
-	(*ProviderCredentialRefresh)(nil),                    // 83: openshell.v1.ProviderCredentialRefresh
-	(*ProviderCredentialRefreshStatus)(nil),              // 84: openshell.v1.ProviderCredentialRefreshStatus
-	(*ProviderProfileDiscovery)(nil),                     // 85: openshell.v1.ProviderProfileDiscovery
-	(*StoredProviderCredentialRefreshState)(nil),         // 86: openshell.v1.StoredProviderCredentialRefreshState
-	(*GetProviderRefreshStatusRequest)(nil),              // 87: openshell.v1.GetProviderRefreshStatusRequest
-	(*GetProviderRefreshStatusResponse)(nil),             // 88: openshell.v1.GetProviderRefreshStatusResponse
-	(*ConfigureProviderRefreshRequest)(nil),              // 89: openshell.v1.ConfigureProviderRefreshRequest
-	(*ConfigureProviderRefreshResponse)(nil),             // 90: openshell.v1.ConfigureProviderRefreshResponse
-	(*RotateProviderCredentialRequest)(nil),              // 91: openshell.v1.RotateProviderCredentialRequest
-	(*RotateProviderCredentialResponse)(nil),             // 92: openshell.v1.RotateProviderCredentialResponse
-	(*DeleteProviderRefreshRequest)(nil),                 // 93: openshell.v1.DeleteProviderRefreshRequest
-	(*DeleteProviderRefreshResponse)(nil),                // 94: openshell.v1.DeleteProviderRefreshResponse
-	(*ProviderProfile)(nil),                              // 95: openshell.v1.ProviderProfile
-	(*StoredProviderProfile)(nil),                        // 96: openshell.v1.StoredProviderProfile
-	(*ProviderProfileResponse)(nil),                      // 97: openshell.v1.ProviderProfileResponse
-	(*ListProviderProfilesResponse)(nil),                 // 98: openshell.v1.ListProviderProfilesResponse
-	(*ImportProviderProfilesRequest)(nil),                // 99: openshell.v1.ImportProviderProfilesRequest
-	(*ImportProviderProfilesResponse)(nil),               // 100: openshell.v1.ImportProviderProfilesResponse
-	(*UpdateProviderProfilesRequest)(nil),                // 101: openshell.v1.UpdateProviderProfilesRequest
-	(*UpdateProviderProfilesResponse)(nil),               // 102: openshell.v1.UpdateProviderProfilesResponse
-	(*LintProviderProfilesRequest)(nil),                  // 103: openshell.v1.LintProviderProfilesRequest
-	(*LintProviderProfilesResponse)(nil),                 // 104: openshell.v1.LintProviderProfilesResponse
-	(*DeleteProviderResponse)(nil),                       // 105: openshell.v1.DeleteProviderResponse
-	(*DeleteProviderProfileRequest)(nil),                 // 106: openshell.v1.DeleteProviderProfileRequest
-	(*DeleteProviderProfileResponse)(nil),                // 107: openshell.v1.DeleteProviderProfileResponse
-	(*GetSandboxProviderEnvironmentRequest)(nil),         // 108: openshell.v1.GetSandboxProviderEnvironmentRequest
-	(*StaticCredentialEndpointBinding)(nil),              // 109: openshell.v1.StaticCredentialEndpointBinding
-	(*StaticCredentialBinding)(nil),                      // 110: openshell.v1.StaticCredentialBinding
-	(*GetSandboxProviderEnvironmentResponse)(nil),        // 111: openshell.v1.GetSandboxProviderEnvironmentResponse
-	(*UpdateConfigRequest)(nil),                          // 112: openshell.v1.UpdateConfigRequest
-	(*PolicyMergeOperation)(nil),                         // 113: openshell.v1.PolicyMergeOperation
-	(*AddNetworkRule)(nil),                               // 114: openshell.v1.AddNetworkRule
-	(*RemoveNetworkEndpoint)(nil),                        // 115: openshell.v1.RemoveNetworkEndpoint
-	(*RemoveNetworkRule)(nil),                            // 116: openshell.v1.RemoveNetworkRule
-	(*AddDenyRules)(nil),                                 // 117: openshell.v1.AddDenyRules
-	(*AddAllowRules)(nil),                                // 118: openshell.v1.AddAllowRules
-	(*RemoveNetworkBinary)(nil),                          // 119: openshell.v1.RemoveNetworkBinary
-	(*UpdateConfigResponse)(nil),                         // 120: openshell.v1.UpdateConfigResponse
-	(*GetSandboxPolicyStatusRequest)(nil),                // 121: openshell.v1.GetSandboxPolicyStatusRequest
-	(*GetSandboxPolicyStatusResponse)(nil),               // 122: openshell.v1.GetSandboxPolicyStatusResponse
-	(*ListSandboxPoliciesRequest)(nil),                   // 123: openshell.v1.ListSandboxPoliciesRequest
-	(*ListSandboxPoliciesResponse)(nil),                  // 124: openshell.v1.ListSandboxPoliciesResponse
-	(*ReportPolicyStatusRequest)(nil),                    // 125: openshell.v1.ReportPolicyStatusRequest
-	(*ReportPolicyStatusResponse)(nil),                   // 126: openshell.v1.ReportPolicyStatusResponse
-	(*SandboxPolicyRevision)(nil),                        // 127: openshell.v1.SandboxPolicyRevision
-	(*GetSandboxLogsRequest)(nil),                        // 128: openshell.v1.GetSandboxLogsRequest
-	(*PushSandboxLogsRequest)(nil),                       // 129: openshell.v1.PushSandboxLogsRequest
-	(*PushSandboxLogsResponse)(nil),                      // 130: openshell.v1.PushSandboxLogsResponse
-	(*GetSandboxLogsResponse)(nil),                       // 131: openshell.v1.GetSandboxLogsResponse
-	(*SupervisorMessage)(nil),                            // 132: openshell.v1.SupervisorMessage
-	(*GatewayMessage)(nil),                               // 133: openshell.v1.GatewayMessage
-	(*SupervisorHello)(nil),                              // 134: openshell.v1.SupervisorHello
-	(*SessionAccepted)(nil),                              // 135: openshell.v1.SessionAccepted
-	(*SessionRejected)(nil),                              // 136: openshell.v1.SessionRejected
-	(*SupervisorHeartbeat)(nil),                          // 137: openshell.v1.SupervisorHeartbeat
-	(*GatewayHeartbeat)(nil),                             // 138: openshell.v1.GatewayHeartbeat
-	(*RelayOpen)(nil),                                    // 139: openshell.v1.RelayOpen
-	(*SshRelayTarget)(nil),                               // 140: openshell.v1.SshRelayTarget
-	(*TcpRelayTarget)(nil),                               // 141: openshell.v1.TcpRelayTarget
-	(*RelayInit)(nil),                                    // 142: openshell.v1.RelayInit
-	(*RelayFrame)(nil),                                   // 143: openshell.v1.RelayFrame
-	(*RelayOpenResult)(nil),                              // 144: openshell.v1.RelayOpenResult
-	(*RelayClose)(nil),                                   // 145: openshell.v1.RelayClose
-	(*L7RequestSample)(nil),                              // 146: openshell.v1.L7RequestSample
-	(*DenialSummary)(nil),                                // 147: openshell.v1.DenialSummary
-	(*DenialGroupCount)(nil),                             // 148: openshell.v1.DenialGroupCount
-	(*NetworkActivitySummary)(nil),                       // 149: openshell.v1.NetworkActivitySummary
-	(*PolicyChunk)(nil),                                  // 150: openshell.v1.PolicyChunk
-	(*DraftPolicyUpdate)(nil),                            // 151: openshell.v1.DraftPolicyUpdate
-	(*SubmitPolicyAnalysisRequest)(nil),                  // 152: openshell.v1.SubmitPolicyAnalysisRequest
-	(*SubmitPolicyAnalysisResponse)(nil),                 // 153: openshell.v1.SubmitPolicyAnalysisResponse
-	(*GetDraftPolicyRequest)(nil),                        // 154: openshell.v1.GetDraftPolicyRequest
-	(*GetDraftPolicyResponse)(nil),                       // 155: openshell.v1.GetDraftPolicyResponse
-	(*ApproveDraftChunkRequest)(nil),                     // 156: openshell.v1.ApproveDraftChunkRequest
-	(*ApproveDraftChunkResponse)(nil),                    // 157: openshell.v1.ApproveDraftChunkResponse
-	(*RejectDraftChunkRequest)(nil),                      // 158: openshell.v1.RejectDraftChunkRequest
-	(*RejectDraftChunkResponse)(nil),                     // 159: openshell.v1.RejectDraftChunkResponse
-	(*ApproveAllDraftChunksRequest)(nil),                 // 160: openshell.v1.ApproveAllDraftChunksRequest
-	(*ApproveAllDraftChunksResponse)(nil),                // 161: openshell.v1.ApproveAllDraftChunksResponse
-	(*EditDraftChunkRequest)(nil),                        // 162: openshell.v1.EditDraftChunkRequest
-	(*EditDraftChunkResponse)(nil),                       // 163: openshell.v1.EditDraftChunkResponse
-	(*UndoDraftChunkRequest)(nil),                        // 164: openshell.v1.UndoDraftChunkRequest
-	(*UndoDraftChunkResponse)(nil),                       // 165: openshell.v1.UndoDraftChunkResponse
-	(*ClearDraftChunksRequest)(nil),                      // 166: openshell.v1.ClearDraftChunksRequest
-	(*ClearDraftChunksResponse)(nil),                     // 167: openshell.v1.ClearDraftChunksResponse
-	(*GetDraftHistoryRequest)(nil),                       // 168: openshell.v1.GetDraftHistoryRequest
-	(*DraftHistoryEntry)(nil),                            // 169: openshell.v1.DraftHistoryEntry
-	(*GetDraftHistoryResponse)(nil),                      // 170: openshell.v1.GetDraftHistoryResponse
-	(*PolicyRevisionPayload)(nil),                        // 171: openshell.v1.PolicyRevisionPayload
-	(*DraftChunkPayload)(nil),                            // 172: openshell.v1.DraftChunkPayload
-	(*StoredPolicyRevision)(nil),                         // 173: openshell.v1.StoredPolicyRevision
-	(*StoredDraftChunk)(nil),                             // 174: openshell.v1.StoredDraftChunk
-	(*CreateWorkspaceRequest)(nil),                       // 175: openshell.v1.CreateWorkspaceRequest
-	(*CreateWorkspaceResponse)(nil),                      // 176: openshell.v1.CreateWorkspaceResponse
-	(*GetWorkspaceRequest)(nil),                          // 177: openshell.v1.GetWorkspaceRequest
-	(*GetWorkspaceResponse)(nil),                         // 178: openshell.v1.GetWorkspaceResponse
-	(*ListWorkspacesRequest)(nil),                        // 179: openshell.v1.ListWorkspacesRequest
-	(*ListWorkspacesResponse)(nil),                       // 180: openshell.v1.ListWorkspacesResponse
-	(*DeleteWorkspaceRequest)(nil),                       // 181: openshell.v1.DeleteWorkspaceRequest
-	(*DeleteWorkspaceResponse)(nil),                      // 182: openshell.v1.DeleteWorkspaceResponse
-	(*WorkspaceMember)(nil),                              // 183: openshell.v1.WorkspaceMember
-	(*AddWorkspaceMemberRequest)(nil),                    // 184: openshell.v1.AddWorkspaceMemberRequest
-	(*AddWorkspaceMemberResponse)(nil),                   // 185: openshell.v1.AddWorkspaceMemberResponse
-	(*RemoveWorkspaceMemberRequest)(nil),                 // 186: openshell.v1.RemoveWorkspaceMemberRequest
-	(*RemoveWorkspaceMemberResponse)(nil),                // 187: openshell.v1.RemoveWorkspaceMemberResponse
-	(*ListWorkspaceMembersRequest)(nil),                  // 188: openshell.v1.ListWorkspaceMembersRequest
-	(*ListWorkspaceMembersResponse)(nil),                 // 189: openshell.v1.ListWorkspaceMembersResponse
-	(*ExtensionServiceCredential)(nil),                   // 190: openshell.v1.ExtensionServiceCredential
-	nil,                                                  // 191: openshell.v1.SandboxSpec.EnvironmentEntry
-	nil,                                                  // 192: openshell.v1.SandboxTemplate.LabelsEntry
-	nil,                                                  // 193: openshell.v1.SandboxTemplate.AnnotationsEntry
-	nil,                                                  // 194: openshell.v1.SandboxTemplate.EnvironmentEntry
-	nil,                                                  // 195: openshell.v1.PlatformEvent.MetadataEntry
-	nil,                                                  // 196: openshell.v1.CreateSandboxRequest.LabelsEntry
-	nil,                                                  // 197: openshell.v1.CreateSandboxRequest.AnnotationsEntry
-	nil,                                                  // 198: openshell.v1.ExecSandboxRequest.EnvironmentEntry
-	nil,                                                  // 199: openshell.v1.SandboxLogLine.FieldsEntry
-	nil,                                                  // 200: openshell.v1.UpdateProviderRequest.CredentialExpiresAtMsEntry
-	nil,                                                  // 201: openshell.v1.StoredProviderCredentialRefreshState.MaterialEntry
-	nil,                                                  // 202: openshell.v1.StoredProviderCredentialRefreshState.AdditionalOutputKeysEntry
-	nil,                                                  // 203: openshell.v1.ConfigureProviderRefreshRequest.MaterialEntry
-	nil,                                                  // 204: openshell.v1.ProviderProfile.AnnotationsEntry
-	nil,                                                  // 205: openshell.v1.GetSandboxProviderEnvironmentResponse.EnvironmentEntry
-	nil,                                                  // 206: openshell.v1.GetSandboxProviderEnvironmentResponse.CredentialExpiresAtMsEntry
-	nil,                                                  // 207: openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntry
-	nil,                                                  // 208: openshell.v1.GetSandboxProviderEnvironmentResponse.StaticCredentialBindingsEntry
-	nil,                                                  // 209: openshell.v1.UpdateConfigRequest.AnnotationsEntry
-	nil,                                                  // 210: openshell.v1.UpdateConfigResponse.AnnotationsEntry
-	nil,                                                  // 211: openshell.v1.SandboxPolicyRevision.ProvenanceEntry
-	nil,                                                  // 212: openshell.v1.PolicyRevisionPayload.ProvenanceEntry
-	nil,                                                  // 213: openshell.v1.StoredPolicyRevision.ProvenanceEntry
-	nil,                                                  // 214: openshell.v1.CreateWorkspaceRequest.LabelsEntry
-	(*datamodelv1.ObjectMeta)(nil),                       // 215: openshell.datamodel.v1.ObjectMeta
-	(*sandboxv1.SandboxPolicy)(nil),                      // 216: openshell.sandbox.v1.SandboxPolicy
-	(*structpb.Struct)(nil),                              // 217: google.protobuf.Struct
-	(*datamodelv1.Provider)(nil),                         // 218: openshell.datamodel.v1.Provider
-	(*sandboxv1.NetworkEndpoint)(nil),                    // 219: openshell.sandbox.v1.NetworkEndpoint
-	(*sandboxv1.NetworkBinary)(nil),                      // 220: openshell.sandbox.v1.NetworkBinary
-	(*sandboxv1.SettingValue)(nil),                       // 221: openshell.sandbox.v1.SettingValue
-	(*sandboxv1.NetworkPolicyRule)(nil),                  // 222: openshell.sandbox.v1.NetworkPolicyRule
-	(*sandboxv1.L7DenyRule)(nil),                         // 223: openshell.sandbox.v1.L7DenyRule
-	(*sandboxv1.L7Rule)(nil),                             // 224: openshell.sandbox.v1.L7Rule
-	(*datamodelv1.Workspace)(nil),                        // 225: openshell.datamodel.v1.Workspace
-	(*sandboxv1.GetSandboxConfigRequest)(nil),            // 226: openshell.sandbox.v1.GetSandboxConfigRequest
-	(*sandboxv1.GetGatewayConfigRequest)(nil),            // 227: openshell.sandbox.v1.GetGatewayConfigRequest
-	(*sandboxv1.GetSandboxConfigResponse)(nil),           // 228: openshell.sandbox.v1.GetSandboxConfigResponse
-	(*sandboxv1.GetGatewayConfigResponse)(nil),           // 229: openshell.sandbox.v1.GetGatewayConfigResponse
+	(*SandboxTemplateSpec)(nil),                          // 23: openshell.v1.SandboxTemplateSpec
+	(*SandboxServiceLevel)(nil),                          // 24: openshell.v1.SandboxServiceLevel
+	(*SandboxStartup)(nil),                               // 25: openshell.v1.SandboxStartup
+	(*SandboxTemplateProvenance)(nil),                    // 26: openshell.v1.SandboxTemplateProvenance
+	(*SandboxStatus)(nil),                                // 27: openshell.v1.SandboxStatus
+	(*SandboxCondition)(nil),                             // 28: openshell.v1.SandboxCondition
+	(*PlatformEvent)(nil),                                // 29: openshell.v1.PlatformEvent
+	(*CreateSandboxRequest)(nil),                         // 30: openshell.v1.CreateSandboxRequest
+	(*CreateSandboxTemplateRequest)(nil),                 // 31: openshell.v1.CreateSandboxTemplateRequest
+	(*GetSandboxTemplateRequest)(nil),                    // 32: openshell.v1.GetSandboxTemplateRequest
+	(*ListSandboxTemplatesRequest)(nil),                  // 33: openshell.v1.ListSandboxTemplatesRequest
+	(*DeleteSandboxTemplateRequest)(nil),                 // 34: openshell.v1.DeleteSandboxTemplateRequest
+	(*SandboxTemplateResponse)(nil),                      // 35: openshell.v1.SandboxTemplateResponse
+	(*ListSandboxTemplatesResponse)(nil),                 // 36: openshell.v1.ListSandboxTemplatesResponse
+	(*DeleteSandboxTemplateResponse)(nil),                // 37: openshell.v1.DeleteSandboxTemplateResponse
+	(*GetSandboxRequest)(nil),                            // 38: openshell.v1.GetSandboxRequest
+	(*ListSandboxesRequest)(nil),                         // 39: openshell.v1.ListSandboxesRequest
+	(*ListSandboxProvidersRequest)(nil),                  // 40: openshell.v1.ListSandboxProvidersRequest
+	(*AttachSandboxProviderRequest)(nil),                 // 41: openshell.v1.AttachSandboxProviderRequest
+	(*DetachSandboxProviderRequest)(nil),                 // 42: openshell.v1.DetachSandboxProviderRequest
+	(*DeleteSandboxRequest)(nil),                         // 43: openshell.v1.DeleteSandboxRequest
+	(*StopSandboxRequest)(nil),                           // 44: openshell.v1.StopSandboxRequest
+	(*StartSandboxRequest)(nil),                          // 45: openshell.v1.StartSandboxRequest
+	(*SandboxResponse)(nil),                              // 46: openshell.v1.SandboxResponse
+	(*ListSandboxesResponse)(nil),                        // 47: openshell.v1.ListSandboxesResponse
+	(*ListSandboxProvidersResponse)(nil),                 // 48: openshell.v1.ListSandboxProvidersResponse
+	(*AttachSandboxProviderResponse)(nil),                // 49: openshell.v1.AttachSandboxProviderResponse
+	(*DetachSandboxProviderResponse)(nil),                // 50: openshell.v1.DetachSandboxProviderResponse
+	(*DeleteSandboxResponse)(nil),                        // 51: openshell.v1.DeleteSandboxResponse
+	(*CreateSshSessionRequest)(nil),                      // 52: openshell.v1.CreateSshSessionRequest
+	(*CreateSshSessionResponse)(nil),                     // 53: openshell.v1.CreateSshSessionResponse
+	(*ExposeServiceRequest)(nil),                         // 54: openshell.v1.ExposeServiceRequest
+	(*GetServiceRequest)(nil),                            // 55: openshell.v1.GetServiceRequest
+	(*ListServicesRequest)(nil),                          // 56: openshell.v1.ListServicesRequest
+	(*ListServicesResponse)(nil),                         // 57: openshell.v1.ListServicesResponse
+	(*DeleteServiceRequest)(nil),                         // 58: openshell.v1.DeleteServiceRequest
+	(*DeleteServiceResponse)(nil),                        // 59: openshell.v1.DeleteServiceResponse
+	(*ServiceEndpoint)(nil),                              // 60: openshell.v1.ServiceEndpoint
+	(*ServiceEndpointResponse)(nil),                      // 61: openshell.v1.ServiceEndpointResponse
+	(*RevokeSshSessionRequest)(nil),                      // 62: openshell.v1.RevokeSshSessionRequest
+	(*RevokeSshSessionResponse)(nil),                     // 63: openshell.v1.RevokeSshSessionResponse
+	(*ExecSandboxRequest)(nil),                           // 64: openshell.v1.ExecSandboxRequest
+	(*ExecSandboxStdout)(nil),                            // 65: openshell.v1.ExecSandboxStdout
+	(*ExecSandboxStderr)(nil),                            // 66: openshell.v1.ExecSandboxStderr
+	(*ExecSandboxExit)(nil),                              // 67: openshell.v1.ExecSandboxExit
+	(*ExecSandboxEvent)(nil),                             // 68: openshell.v1.ExecSandboxEvent
+	(*TcpForwardInit)(nil),                               // 69: openshell.v1.TcpForwardInit
+	(*TcpForwardFrame)(nil),                              // 70: openshell.v1.TcpForwardFrame
+	(*ExecSandboxInput)(nil),                             // 71: openshell.v1.ExecSandboxInput
+	(*ExecSandboxWindowResize)(nil),                      // 72: openshell.v1.ExecSandboxWindowResize
+	(*SshSession)(nil),                                   // 73: openshell.v1.SshSession
+	(*WatchSandboxRequest)(nil),                          // 74: openshell.v1.WatchSandboxRequest
+	(*SandboxStreamEvent)(nil),                           // 75: openshell.v1.SandboxStreamEvent
+	(*SandboxLogLine)(nil),                               // 76: openshell.v1.SandboxLogLine
+	(*SandboxStreamWarning)(nil),                         // 77: openshell.v1.SandboxStreamWarning
+	(*CreateProviderRequest)(nil),                        // 78: openshell.v1.CreateProviderRequest
+	(*GetProviderRequest)(nil),                           // 79: openshell.v1.GetProviderRequest
+	(*ListProvidersRequest)(nil),                         // 80: openshell.v1.ListProvidersRequest
+	(*UpdateProviderRequest)(nil),                        // 81: openshell.v1.UpdateProviderRequest
+	(*DeleteProviderRequest)(nil),                        // 82: openshell.v1.DeleteProviderRequest
+	(*ProviderResponse)(nil),                             // 83: openshell.v1.ProviderResponse
+	(*ListProvidersResponse)(nil),                        // 84: openshell.v1.ListProvidersResponse
+	(*ListProviderProfilesRequest)(nil),                  // 85: openshell.v1.ListProviderProfilesRequest
+	(*GetProviderProfileRequest)(nil),                    // 86: openshell.v1.GetProviderProfileRequest
+	(*ProviderProfileImportItem)(nil),                    // 87: openshell.v1.ProviderProfileImportItem
+	(*ProviderProfileDiagnostic)(nil),                    // 88: openshell.v1.ProviderProfileDiagnostic
+	(*ProviderCredentialTokenGrantAudienceOverride)(nil), // 89: openshell.v1.ProviderCredentialTokenGrantAudienceOverride
+	(*ProviderCredentialTokenGrant)(nil),                 // 90: openshell.v1.ProviderCredentialTokenGrant
+	(*ProviderProfileCredential)(nil),                    // 91: openshell.v1.ProviderProfileCredential
+	(*ProviderCredentialRefreshMaterial)(nil),            // 92: openshell.v1.ProviderCredentialRefreshMaterial
+	(*ProviderCredentialRefreshOutput)(nil),              // 93: openshell.v1.ProviderCredentialRefreshOutput
+	(*ProviderCredentialRefresh)(nil),                    // 94: openshell.v1.ProviderCredentialRefresh
+	(*ProviderCredentialRefreshStatus)(nil),              // 95: openshell.v1.ProviderCredentialRefreshStatus
+	(*ProviderProfileDiscovery)(nil),                     // 96: openshell.v1.ProviderProfileDiscovery
+	(*StoredProviderCredentialRefreshState)(nil),         // 97: openshell.v1.StoredProviderCredentialRefreshState
+	(*GetProviderRefreshStatusRequest)(nil),              // 98: openshell.v1.GetProviderRefreshStatusRequest
+	(*GetProviderRefreshStatusResponse)(nil),             // 99: openshell.v1.GetProviderRefreshStatusResponse
+	(*ConfigureProviderRefreshRequest)(nil),              // 100: openshell.v1.ConfigureProviderRefreshRequest
+	(*ConfigureProviderRefreshResponse)(nil),             // 101: openshell.v1.ConfigureProviderRefreshResponse
+	(*RotateProviderCredentialRequest)(nil),              // 102: openshell.v1.RotateProviderCredentialRequest
+	(*RotateProviderCredentialResponse)(nil),             // 103: openshell.v1.RotateProviderCredentialResponse
+	(*DeleteProviderRefreshRequest)(nil),                 // 104: openshell.v1.DeleteProviderRefreshRequest
+	(*DeleteProviderRefreshResponse)(nil),                // 105: openshell.v1.DeleteProviderRefreshResponse
+	(*ProviderProfile)(nil),                              // 106: openshell.v1.ProviderProfile
+	(*StoredProviderProfile)(nil),                        // 107: openshell.v1.StoredProviderProfile
+	(*ProviderProfileResponse)(nil),                      // 108: openshell.v1.ProviderProfileResponse
+	(*ListProviderProfilesResponse)(nil),                 // 109: openshell.v1.ListProviderProfilesResponse
+	(*ImportProviderProfilesRequest)(nil),                // 110: openshell.v1.ImportProviderProfilesRequest
+	(*ImportProviderProfilesResponse)(nil),               // 111: openshell.v1.ImportProviderProfilesResponse
+	(*UpdateProviderProfilesRequest)(nil),                // 112: openshell.v1.UpdateProviderProfilesRequest
+	(*UpdateProviderProfilesResponse)(nil),               // 113: openshell.v1.UpdateProviderProfilesResponse
+	(*LintProviderProfilesRequest)(nil),                  // 114: openshell.v1.LintProviderProfilesRequest
+	(*LintProviderProfilesResponse)(nil),                 // 115: openshell.v1.LintProviderProfilesResponse
+	(*DeleteProviderResponse)(nil),                       // 116: openshell.v1.DeleteProviderResponse
+	(*DeleteProviderProfileRequest)(nil),                 // 117: openshell.v1.DeleteProviderProfileRequest
+	(*DeleteProviderProfileResponse)(nil),                // 118: openshell.v1.DeleteProviderProfileResponse
+	(*GetSandboxProviderEnvironmentRequest)(nil),         // 119: openshell.v1.GetSandboxProviderEnvironmentRequest
+	(*StaticCredentialEndpointBinding)(nil),              // 120: openshell.v1.StaticCredentialEndpointBinding
+	(*StaticCredentialBinding)(nil),                      // 121: openshell.v1.StaticCredentialBinding
+	(*GetSandboxProviderEnvironmentResponse)(nil),        // 122: openshell.v1.GetSandboxProviderEnvironmentResponse
+	(*UpdateConfigRequest)(nil),                          // 123: openshell.v1.UpdateConfigRequest
+	(*PolicyMergeOperation)(nil),                         // 124: openshell.v1.PolicyMergeOperation
+	(*AddNetworkRule)(nil),                               // 125: openshell.v1.AddNetworkRule
+	(*RemoveNetworkEndpoint)(nil),                        // 126: openshell.v1.RemoveNetworkEndpoint
+	(*RemoveNetworkRule)(nil),                            // 127: openshell.v1.RemoveNetworkRule
+	(*AddDenyRules)(nil),                                 // 128: openshell.v1.AddDenyRules
+	(*AddAllowRules)(nil),                                // 129: openshell.v1.AddAllowRules
+	(*RemoveNetworkBinary)(nil),                          // 130: openshell.v1.RemoveNetworkBinary
+	(*UpdateConfigResponse)(nil),                         // 131: openshell.v1.UpdateConfigResponse
+	(*GetSandboxPolicyStatusRequest)(nil),                // 132: openshell.v1.GetSandboxPolicyStatusRequest
+	(*GetSandboxPolicyStatusResponse)(nil),               // 133: openshell.v1.GetSandboxPolicyStatusResponse
+	(*ListSandboxPoliciesRequest)(nil),                   // 134: openshell.v1.ListSandboxPoliciesRequest
+	(*ListSandboxPoliciesResponse)(nil),                  // 135: openshell.v1.ListSandboxPoliciesResponse
+	(*ReportPolicyStatusRequest)(nil),                    // 136: openshell.v1.ReportPolicyStatusRequest
+	(*ReportPolicyStatusResponse)(nil),                   // 137: openshell.v1.ReportPolicyStatusResponse
+	(*SandboxPolicyRevision)(nil),                        // 138: openshell.v1.SandboxPolicyRevision
+	(*GetSandboxLogsRequest)(nil),                        // 139: openshell.v1.GetSandboxLogsRequest
+	(*PushSandboxLogsRequest)(nil),                       // 140: openshell.v1.PushSandboxLogsRequest
+	(*PushSandboxLogsResponse)(nil),                      // 141: openshell.v1.PushSandboxLogsResponse
+	(*GetSandboxLogsResponse)(nil),                       // 142: openshell.v1.GetSandboxLogsResponse
+	(*SupervisorMessage)(nil),                            // 143: openshell.v1.SupervisorMessage
+	(*GatewayMessage)(nil),                               // 144: openshell.v1.GatewayMessage
+	(*SupervisorHello)(nil),                              // 145: openshell.v1.SupervisorHello
+	(*SessionAccepted)(nil),                              // 146: openshell.v1.SessionAccepted
+	(*SessionRejected)(nil),                              // 147: openshell.v1.SessionRejected
+	(*SupervisorHeartbeat)(nil),                          // 148: openshell.v1.SupervisorHeartbeat
+	(*GatewayHeartbeat)(nil),                             // 149: openshell.v1.GatewayHeartbeat
+	(*RelayOpen)(nil),                                    // 150: openshell.v1.RelayOpen
+	(*SshRelayTarget)(nil),                               // 151: openshell.v1.SshRelayTarget
+	(*TcpRelayTarget)(nil),                               // 152: openshell.v1.TcpRelayTarget
+	(*RelayInit)(nil),                                    // 153: openshell.v1.RelayInit
+	(*RelayFrame)(nil),                                   // 154: openshell.v1.RelayFrame
+	(*RelayOpenResult)(nil),                              // 155: openshell.v1.RelayOpenResult
+	(*RelayClose)(nil),                                   // 156: openshell.v1.RelayClose
+	(*L7RequestSample)(nil),                              // 157: openshell.v1.L7RequestSample
+	(*DenialSummary)(nil),                                // 158: openshell.v1.DenialSummary
+	(*DenialGroupCount)(nil),                             // 159: openshell.v1.DenialGroupCount
+	(*NetworkActivitySummary)(nil),                       // 160: openshell.v1.NetworkActivitySummary
+	(*PolicyChunk)(nil),                                  // 161: openshell.v1.PolicyChunk
+	(*DraftPolicyUpdate)(nil),                            // 162: openshell.v1.DraftPolicyUpdate
+	(*SubmitPolicyAnalysisRequest)(nil),                  // 163: openshell.v1.SubmitPolicyAnalysisRequest
+	(*SubmitPolicyAnalysisResponse)(nil),                 // 164: openshell.v1.SubmitPolicyAnalysisResponse
+	(*GetDraftPolicyRequest)(nil),                        // 165: openshell.v1.GetDraftPolicyRequest
+	(*GetDraftPolicyResponse)(nil),                       // 166: openshell.v1.GetDraftPolicyResponse
+	(*ApproveDraftChunkRequest)(nil),                     // 167: openshell.v1.ApproveDraftChunkRequest
+	(*ApproveDraftChunkResponse)(nil),                    // 168: openshell.v1.ApproveDraftChunkResponse
+	(*RejectDraftChunkRequest)(nil),                      // 169: openshell.v1.RejectDraftChunkRequest
+	(*RejectDraftChunkResponse)(nil),                     // 170: openshell.v1.RejectDraftChunkResponse
+	(*ApproveAllDraftChunksRequest)(nil),                 // 171: openshell.v1.ApproveAllDraftChunksRequest
+	(*ApproveAllDraftChunksResponse)(nil),                // 172: openshell.v1.ApproveAllDraftChunksResponse
+	(*EditDraftChunkRequest)(nil),                        // 173: openshell.v1.EditDraftChunkRequest
+	(*EditDraftChunkResponse)(nil),                       // 174: openshell.v1.EditDraftChunkResponse
+	(*UndoDraftChunkRequest)(nil),                        // 175: openshell.v1.UndoDraftChunkRequest
+	(*UndoDraftChunkResponse)(nil),                       // 176: openshell.v1.UndoDraftChunkResponse
+	(*ClearDraftChunksRequest)(nil),                      // 177: openshell.v1.ClearDraftChunksRequest
+	(*ClearDraftChunksResponse)(nil),                     // 178: openshell.v1.ClearDraftChunksResponse
+	(*GetDraftHistoryRequest)(nil),                       // 179: openshell.v1.GetDraftHistoryRequest
+	(*DraftHistoryEntry)(nil),                            // 180: openshell.v1.DraftHistoryEntry
+	(*GetDraftHistoryResponse)(nil),                      // 181: openshell.v1.GetDraftHistoryResponse
+	(*PolicyRevisionPayload)(nil),                        // 182: openshell.v1.PolicyRevisionPayload
+	(*DraftChunkPayload)(nil),                            // 183: openshell.v1.DraftChunkPayload
+	(*StoredPolicyRevision)(nil),                         // 184: openshell.v1.StoredPolicyRevision
+	(*StoredDraftChunk)(nil),                             // 185: openshell.v1.StoredDraftChunk
+	(*CreateWorkspaceRequest)(nil),                       // 186: openshell.v1.CreateWorkspaceRequest
+	(*CreateWorkspaceResponse)(nil),                      // 187: openshell.v1.CreateWorkspaceResponse
+	(*GetWorkspaceRequest)(nil),                          // 188: openshell.v1.GetWorkspaceRequest
+	(*GetWorkspaceResponse)(nil),                         // 189: openshell.v1.GetWorkspaceResponse
+	(*ListWorkspacesRequest)(nil),                        // 190: openshell.v1.ListWorkspacesRequest
+	(*ListWorkspacesResponse)(nil),                       // 191: openshell.v1.ListWorkspacesResponse
+	(*DeleteWorkspaceRequest)(nil),                       // 192: openshell.v1.DeleteWorkspaceRequest
+	(*DeleteWorkspaceResponse)(nil),                      // 193: openshell.v1.DeleteWorkspaceResponse
+	(*WorkspaceMember)(nil),                              // 194: openshell.v1.WorkspaceMember
+	(*AddWorkspaceMemberRequest)(nil),                    // 195: openshell.v1.AddWorkspaceMemberRequest
+	(*AddWorkspaceMemberResponse)(nil),                   // 196: openshell.v1.AddWorkspaceMemberResponse
+	(*RemoveWorkspaceMemberRequest)(nil),                 // 197: openshell.v1.RemoveWorkspaceMemberRequest
+	(*RemoveWorkspaceMemberResponse)(nil),                // 198: openshell.v1.RemoveWorkspaceMemberResponse
+	(*ListWorkspaceMembersRequest)(nil),                  // 199: openshell.v1.ListWorkspaceMembersRequest
+	(*ListWorkspaceMembersResponse)(nil),                 // 200: openshell.v1.ListWorkspaceMembersResponse
+	(*ExtensionServiceCredential)(nil),                   // 201: openshell.v1.ExtensionServiceCredential
+	nil,                                                  // 202: openshell.v1.SandboxWorkloadConfig.EnvironmentEntry
+	nil,                                                  // 203: openshell.v1.PlatformEvent.MetadataEntry
+	nil,                                                  // 204: openshell.v1.CreateSandboxRequest.LabelsEntry
+	nil,                                                  // 205: openshell.v1.CreateSandboxRequest.AnnotationsEntry
+	nil,                                                  // 206: openshell.v1.ExecSandboxRequest.EnvironmentEntry
+	nil,                                                  // 207: openshell.v1.SandboxLogLine.FieldsEntry
+	nil,                                                  // 208: openshell.v1.UpdateProviderRequest.CredentialExpiresAtMsEntry
+	nil,                                                  // 209: openshell.v1.StoredProviderCredentialRefreshState.MaterialEntry
+	nil,                                                  // 210: openshell.v1.StoredProviderCredentialRefreshState.AdditionalOutputKeysEntry
+	nil,                                                  // 211: openshell.v1.ConfigureProviderRefreshRequest.MaterialEntry
+	nil,                                                  // 212: openshell.v1.ProviderProfile.AnnotationsEntry
+	nil,                                                  // 213: openshell.v1.GetSandboxProviderEnvironmentResponse.EnvironmentEntry
+	nil,                                                  // 214: openshell.v1.GetSandboxProviderEnvironmentResponse.CredentialExpiresAtMsEntry
+	nil,                                                  // 215: openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntry
+	nil,                                                  // 216: openshell.v1.GetSandboxProviderEnvironmentResponse.StaticCredentialBindingsEntry
+	nil,                                                  // 217: openshell.v1.UpdateConfigRequest.AnnotationsEntry
+	nil,                                                  // 218: openshell.v1.UpdateConfigResponse.AnnotationsEntry
+	nil,                                                  // 219: openshell.v1.SandboxPolicyRevision.ProvenanceEntry
+	nil,                                                  // 220: openshell.v1.PolicyRevisionPayload.ProvenanceEntry
+	nil,                                                  // 221: openshell.v1.StoredPolicyRevision.ProvenanceEntry
+	nil,                                                  // 222: openshell.v1.CreateWorkspaceRequest.LabelsEntry
+	(*datamodelv1.ObjectMeta)(nil),                       // 223: openshell.datamodel.v1.ObjectMeta
+	(*structpb.Struct)(nil),                              // 224: google.protobuf.Struct
+	(*sandboxv1.SandboxPolicy)(nil),                      // 225: openshell.sandbox.v1.SandboxPolicy
+	(*durationpb.Duration)(nil),                          // 226: google.protobuf.Duration
+	(*datamodelv1.Provider)(nil),                         // 227: openshell.datamodel.v1.Provider
+	(*sandboxv1.NetworkEndpoint)(nil),                    // 228: openshell.sandbox.v1.NetworkEndpoint
+	(*sandboxv1.NetworkBinary)(nil),                      // 229: openshell.sandbox.v1.NetworkBinary
+	(*sandboxv1.SettingValue)(nil),                       // 230: openshell.sandbox.v1.SettingValue
+	(*sandboxv1.NetworkPolicyRule)(nil),                  // 231: openshell.sandbox.v1.NetworkPolicyRule
+	(*sandboxv1.L7DenyRule)(nil),                         // 232: openshell.sandbox.v1.L7DenyRule
+	(*sandboxv1.L7Rule)(nil),                             // 233: openshell.sandbox.v1.L7Rule
+	(*datamodelv1.Workspace)(nil),                        // 234: openshell.datamodel.v1.Workspace
+	(*sandboxv1.GetSandboxConfigRequest)(nil),            // 235: openshell.sandbox.v1.GetSandboxConfigRequest
+	(*sandboxv1.GetGatewayConfigRequest)(nil),            // 236: openshell.sandbox.v1.GetGatewayConfigRequest
+	(*sandboxv1.GetSandboxConfigResponse)(nil),           // 237: openshell.sandbox.v1.GetSandboxConfigResponse
+	(*sandboxv1.GetGatewayConfigResponse)(nil),           // 238: openshell.sandbox.v1.GetGatewayConfigResponse
 }
 var file_openshell_proto_depIdxs = []int32{
-	190, // 0: openshell.v1.RefreshSandboxTokenResponse.extension_credentials:type_name -> openshell.v1.ExtensionServiceCredential
+	201, // 0: openshell.v1.RefreshSandboxTokenResponse.extension_credentials:type_name -> openshell.v1.ExtensionServiceCredential
 	4,   // 1: openshell.v1.HealthResponse.status:type_name -> openshell.v1.ServiceStatus
 	4,   // 2: openshell.v1.GetGatewayInfoResponse.status:type_name -> openshell.v1.ServiceStatus
 	16,  // 3: openshell.v1.GetGatewayInfoResponse.compute_drivers:type_name -> openshell.v1.ComputeDriverInfo
 	17,  // 4: openshell.v1.ComputeDriverInfo.capabilities:type_name -> openshell.v1.ComputeDriverCapabilities
-	215, // 5: openshell.v1.Sandbox.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	223, // 5: openshell.v1.Sandbox.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
 	19,  // 6: openshell.v1.Sandbox.spec:type_name -> openshell.v1.SandboxSpec
-	23,  // 7: openshell.v1.Sandbox.status:type_name -> openshell.v1.SandboxStatus
-	191, // 8: openshell.v1.SandboxSpec.environment:type_name -> openshell.v1.SandboxSpec.EnvironmentEntry
-	22,  // 9: openshell.v1.SandboxSpec.template:type_name -> openshell.v1.SandboxTemplate
-	216, // 10: openshell.v1.SandboxSpec.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
-	20,  // 11: openshell.v1.SandboxSpec.resource_requirements:type_name -> openshell.v1.ResourceRequirements
-	21,  // 12: openshell.v1.ResourceRequirements.gpu:type_name -> openshell.v1.GpuResourceRequirements
-	192, // 13: openshell.v1.SandboxTemplate.labels:type_name -> openshell.v1.SandboxTemplate.LabelsEntry
-	193, // 14: openshell.v1.SandboxTemplate.annotations:type_name -> openshell.v1.SandboxTemplate.AnnotationsEntry
-	194, // 15: openshell.v1.SandboxTemplate.environment:type_name -> openshell.v1.SandboxTemplate.EnvironmentEntry
-	217, // 16: openshell.v1.SandboxTemplate.resources:type_name -> google.protobuf.Struct
-	217, // 17: openshell.v1.SandboxTemplate.driver_config:type_name -> google.protobuf.Struct
-	24,  // 18: openshell.v1.SandboxStatus.conditions:type_name -> openshell.v1.SandboxCondition
-	0,   // 19: openshell.v1.SandboxStatus.phase:type_name -> openshell.v1.SandboxPhase
-	195, // 20: openshell.v1.PlatformEvent.metadata:type_name -> openshell.v1.PlatformEvent.MetadataEntry
-	19,  // 21: openshell.v1.CreateSandboxRequest.spec:type_name -> openshell.v1.SandboxSpec
-	196, // 22: openshell.v1.CreateSandboxRequest.labels:type_name -> openshell.v1.CreateSandboxRequest.LabelsEntry
-	197, // 23: openshell.v1.CreateSandboxRequest.annotations:type_name -> openshell.v1.CreateSandboxRequest.AnnotationsEntry
-	18,  // 24: openshell.v1.SandboxResponse.sandbox:type_name -> openshell.v1.Sandbox
-	18,  // 25: openshell.v1.ListSandboxesResponse.sandboxes:type_name -> openshell.v1.Sandbox
-	218, // 26: openshell.v1.ListSandboxProvidersResponse.providers:type_name -> openshell.datamodel.v1.Provider
-	18,  // 27: openshell.v1.AttachSandboxProviderResponse.sandbox:type_name -> openshell.v1.Sandbox
-	18,  // 28: openshell.v1.DetachSandboxProviderResponse.sandbox:type_name -> openshell.v1.Sandbox
-	50,  // 29: openshell.v1.ListServicesResponse.services:type_name -> openshell.v1.ServiceEndpointResponse
-	215, // 30: openshell.v1.ServiceEndpoint.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
-	49,  // 31: openshell.v1.ServiceEndpointResponse.endpoint:type_name -> openshell.v1.ServiceEndpoint
-	198, // 32: openshell.v1.ExecSandboxRequest.environment:type_name -> openshell.v1.ExecSandboxRequest.EnvironmentEntry
-	54,  // 33: openshell.v1.ExecSandboxEvent.stdout:type_name -> openshell.v1.ExecSandboxStdout
-	55,  // 34: openshell.v1.ExecSandboxEvent.stderr:type_name -> openshell.v1.ExecSandboxStderr
-	56,  // 35: openshell.v1.ExecSandboxEvent.exit:type_name -> openshell.v1.ExecSandboxExit
-	140, // 36: openshell.v1.TcpForwardInit.ssh:type_name -> openshell.v1.SshRelayTarget
-	141, // 37: openshell.v1.TcpForwardInit.tcp:type_name -> openshell.v1.TcpRelayTarget
-	58,  // 38: openshell.v1.TcpForwardFrame.init:type_name -> openshell.v1.TcpForwardInit
-	53,  // 39: openshell.v1.ExecSandboxInput.start:type_name -> openshell.v1.ExecSandboxRequest
-	61,  // 40: openshell.v1.ExecSandboxInput.resize:type_name -> openshell.v1.ExecSandboxWindowResize
-	215, // 41: openshell.v1.SshSession.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
-	18,  // 42: openshell.v1.SandboxStreamEvent.sandbox:type_name -> openshell.v1.Sandbox
-	65,  // 43: openshell.v1.SandboxStreamEvent.log:type_name -> openshell.v1.SandboxLogLine
-	25,  // 44: openshell.v1.SandboxStreamEvent.event:type_name -> openshell.v1.PlatformEvent
-	66,  // 45: openshell.v1.SandboxStreamEvent.warning:type_name -> openshell.v1.SandboxStreamWarning
-	151, // 46: openshell.v1.SandboxStreamEvent.draft_policy_update:type_name -> openshell.v1.DraftPolicyUpdate
-	199, // 47: openshell.v1.SandboxLogLine.fields:type_name -> openshell.v1.SandboxLogLine.FieldsEntry
-	218, // 48: openshell.v1.CreateProviderRequest.provider:type_name -> openshell.datamodel.v1.Provider
-	218, // 49: openshell.v1.UpdateProviderRequest.provider:type_name -> openshell.datamodel.v1.Provider
-	200, // 50: openshell.v1.UpdateProviderRequest.credential_expires_at_ms:type_name -> openshell.v1.UpdateProviderRequest.CredentialExpiresAtMsEntry
-	218, // 51: openshell.v1.ProviderResponse.provider:type_name -> openshell.datamodel.v1.Provider
-	218, // 52: openshell.v1.ListProvidersResponse.providers:type_name -> openshell.datamodel.v1.Provider
-	95,  // 53: openshell.v1.ProviderProfileImportItem.profile:type_name -> openshell.v1.ProviderProfile
-	78,  // 54: openshell.v1.ProviderCredentialTokenGrant.audience_overrides:type_name -> openshell.v1.ProviderCredentialTokenGrantAudienceOverride
-	83,  // 55: openshell.v1.ProviderProfileCredential.refresh:type_name -> openshell.v1.ProviderCredentialRefresh
-	79,  // 56: openshell.v1.ProviderProfileCredential.token_grant:type_name -> openshell.v1.ProviderCredentialTokenGrant
-	1,   // 57: openshell.v1.ProviderCredentialRefresh.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
-	81,  // 58: openshell.v1.ProviderCredentialRefresh.material:type_name -> openshell.v1.ProviderCredentialRefreshMaterial
-	82,  // 59: openshell.v1.ProviderCredentialRefresh.additional_outputs:type_name -> openshell.v1.ProviderCredentialRefreshOutput
-	1,   // 60: openshell.v1.ProviderCredentialRefreshStatus.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
-	215, // 61: openshell.v1.StoredProviderCredentialRefreshState.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
-	1,   // 62: openshell.v1.StoredProviderCredentialRefreshState.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
-	201, // 63: openshell.v1.StoredProviderCredentialRefreshState.material:type_name -> openshell.v1.StoredProviderCredentialRefreshState.MaterialEntry
-	202, // 64: openshell.v1.StoredProviderCredentialRefreshState.additional_output_keys:type_name -> openshell.v1.StoredProviderCredentialRefreshState.AdditionalOutputKeysEntry
-	84,  // 65: openshell.v1.GetProviderRefreshStatusResponse.credentials:type_name -> openshell.v1.ProviderCredentialRefreshStatus
-	1,   // 66: openshell.v1.ConfigureProviderRefreshRequest.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
-	203, // 67: openshell.v1.ConfigureProviderRefreshRequest.material:type_name -> openshell.v1.ConfigureProviderRefreshRequest.MaterialEntry
-	84,  // 68: openshell.v1.ConfigureProviderRefreshResponse.status:type_name -> openshell.v1.ProviderCredentialRefreshStatus
-	84,  // 69: openshell.v1.RotateProviderCredentialResponse.status:type_name -> openshell.v1.ProviderCredentialRefreshStatus
-	2,   // 70: openshell.v1.ProviderProfile.category:type_name -> openshell.v1.ProviderProfileCategory
-	80,  // 71: openshell.v1.ProviderProfile.credentials:type_name -> openshell.v1.ProviderProfileCredential
-	219, // 72: openshell.v1.ProviderProfile.endpoints:type_name -> openshell.sandbox.v1.NetworkEndpoint
-	220, // 73: openshell.v1.ProviderProfile.binaries:type_name -> openshell.sandbox.v1.NetworkBinary
-	85,  // 74: openshell.v1.ProviderProfile.discovery:type_name -> openshell.v1.ProviderProfileDiscovery
-	204, // 75: openshell.v1.ProviderProfile.annotations:type_name -> openshell.v1.ProviderProfile.AnnotationsEntry
-	215, // 76: openshell.v1.StoredProviderProfile.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
-	95,  // 77: openshell.v1.StoredProviderProfile.profile:type_name -> openshell.v1.ProviderProfile
-	95,  // 78: openshell.v1.ProviderProfileResponse.profile:type_name -> openshell.v1.ProviderProfile
-	95,  // 79: openshell.v1.ListProviderProfilesResponse.profiles:type_name -> openshell.v1.ProviderProfile
-	76,  // 80: openshell.v1.ImportProviderProfilesRequest.profiles:type_name -> openshell.v1.ProviderProfileImportItem
-	77,  // 81: openshell.v1.ImportProviderProfilesResponse.diagnostics:type_name -> openshell.v1.ProviderProfileDiagnostic
-	95,  // 82: openshell.v1.ImportProviderProfilesResponse.profiles:type_name -> openshell.v1.ProviderProfile
-	76,  // 83: openshell.v1.UpdateProviderProfilesRequest.profile:type_name -> openshell.v1.ProviderProfileImportItem
-	77,  // 84: openshell.v1.UpdateProviderProfilesResponse.diagnostics:type_name -> openshell.v1.ProviderProfileDiagnostic
-	95,  // 85: openshell.v1.UpdateProviderProfilesResponse.profile:type_name -> openshell.v1.ProviderProfile
-	76,  // 86: openshell.v1.LintProviderProfilesRequest.profiles:type_name -> openshell.v1.ProviderProfileImportItem
-	77,  // 87: openshell.v1.LintProviderProfilesResponse.diagnostics:type_name -> openshell.v1.ProviderProfileDiagnostic
-	109, // 88: openshell.v1.StaticCredentialBinding.endpoints:type_name -> openshell.v1.StaticCredentialEndpointBinding
-	205, // 89: openshell.v1.GetSandboxProviderEnvironmentResponse.environment:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.EnvironmentEntry
-	206, // 90: openshell.v1.GetSandboxProviderEnvironmentResponse.credential_expires_at_ms:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.CredentialExpiresAtMsEntry
-	207, // 91: openshell.v1.GetSandboxProviderEnvironmentResponse.dynamic_credentials:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntry
-	208, // 92: openshell.v1.GetSandboxProviderEnvironmentResponse.static_credential_bindings:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.StaticCredentialBindingsEntry
-	216, // 93: openshell.v1.UpdateConfigRequest.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
-	221, // 94: openshell.v1.UpdateConfigRequest.setting_value:type_name -> openshell.sandbox.v1.SettingValue
-	113, // 95: openshell.v1.UpdateConfigRequest.merge_operations:type_name -> openshell.v1.PolicyMergeOperation
-	209, // 96: openshell.v1.UpdateConfigRequest.annotations:type_name -> openshell.v1.UpdateConfigRequest.AnnotationsEntry
-	114, // 97: openshell.v1.PolicyMergeOperation.add_rule:type_name -> openshell.v1.AddNetworkRule
-	115, // 98: openshell.v1.PolicyMergeOperation.remove_endpoint:type_name -> openshell.v1.RemoveNetworkEndpoint
-	116, // 99: openshell.v1.PolicyMergeOperation.remove_rule:type_name -> openshell.v1.RemoveNetworkRule
-	117, // 100: openshell.v1.PolicyMergeOperation.add_deny_rules:type_name -> openshell.v1.AddDenyRules
-	118, // 101: openshell.v1.PolicyMergeOperation.add_allow_rules:type_name -> openshell.v1.AddAllowRules
-	119, // 102: openshell.v1.PolicyMergeOperation.remove_binary:type_name -> openshell.v1.RemoveNetworkBinary
-	222, // 103: openshell.v1.AddNetworkRule.rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
-	223, // 104: openshell.v1.AddDenyRules.deny_rules:type_name -> openshell.sandbox.v1.L7DenyRule
-	224, // 105: openshell.v1.AddAllowRules.rules:type_name -> openshell.sandbox.v1.L7Rule
-	210, // 106: openshell.v1.UpdateConfigResponse.annotations:type_name -> openshell.v1.UpdateConfigResponse.AnnotationsEntry
-	127, // 107: openshell.v1.GetSandboxPolicyStatusResponse.revision:type_name -> openshell.v1.SandboxPolicyRevision
-	127, // 108: openshell.v1.ListSandboxPoliciesResponse.revisions:type_name -> openshell.v1.SandboxPolicyRevision
-	3,   // 109: openshell.v1.ReportPolicyStatusRequest.status:type_name -> openshell.v1.PolicyStatus
-	3,   // 110: openshell.v1.SandboxPolicyRevision.status:type_name -> openshell.v1.PolicyStatus
-	216, // 111: openshell.v1.SandboxPolicyRevision.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
-	211, // 112: openshell.v1.SandboxPolicyRevision.provenance:type_name -> openshell.v1.SandboxPolicyRevision.ProvenanceEntry
-	65,  // 113: openshell.v1.PushSandboxLogsRequest.logs:type_name -> openshell.v1.SandboxLogLine
-	65,  // 114: openshell.v1.GetSandboxLogsResponse.logs:type_name -> openshell.v1.SandboxLogLine
-	134, // 115: openshell.v1.SupervisorMessage.hello:type_name -> openshell.v1.SupervisorHello
-	137, // 116: openshell.v1.SupervisorMessage.heartbeat:type_name -> openshell.v1.SupervisorHeartbeat
-	144, // 117: openshell.v1.SupervisorMessage.relay_open_result:type_name -> openshell.v1.RelayOpenResult
-	145, // 118: openshell.v1.SupervisorMessage.relay_close:type_name -> openshell.v1.RelayClose
-	135, // 119: openshell.v1.GatewayMessage.session_accepted:type_name -> openshell.v1.SessionAccepted
-	136, // 120: openshell.v1.GatewayMessage.session_rejected:type_name -> openshell.v1.SessionRejected
-	138, // 121: openshell.v1.GatewayMessage.heartbeat:type_name -> openshell.v1.GatewayHeartbeat
-	139, // 122: openshell.v1.GatewayMessage.relay_open:type_name -> openshell.v1.RelayOpen
-	145, // 123: openshell.v1.GatewayMessage.relay_close:type_name -> openshell.v1.RelayClose
-	140, // 124: openshell.v1.RelayOpen.ssh:type_name -> openshell.v1.SshRelayTarget
-	141, // 125: openshell.v1.RelayOpen.tcp:type_name -> openshell.v1.TcpRelayTarget
-	142, // 126: openshell.v1.RelayFrame.init:type_name -> openshell.v1.RelayInit
-	146, // 127: openshell.v1.DenialSummary.l7_request_samples:type_name -> openshell.v1.L7RequestSample
-	148, // 128: openshell.v1.NetworkActivitySummary.denials_by_group:type_name -> openshell.v1.DenialGroupCount
-	222, // 129: openshell.v1.PolicyChunk.proposed_rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
-	147, // 130: openshell.v1.SubmitPolicyAnalysisRequest.summaries:type_name -> openshell.v1.DenialSummary
-	150, // 131: openshell.v1.SubmitPolicyAnalysisRequest.proposed_chunks:type_name -> openshell.v1.PolicyChunk
-	149, // 132: openshell.v1.SubmitPolicyAnalysisRequest.network_activity_summaries:type_name -> openshell.v1.NetworkActivitySummary
-	150, // 133: openshell.v1.GetDraftPolicyResponse.chunks:type_name -> openshell.v1.PolicyChunk
-	222, // 134: openshell.v1.EditDraftChunkRequest.proposed_rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
-	169, // 135: openshell.v1.GetDraftHistoryResponse.entries:type_name -> openshell.v1.DraftHistoryEntry
-	216, // 136: openshell.v1.PolicyRevisionPayload.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
-	212, // 137: openshell.v1.PolicyRevisionPayload.provenance:type_name -> openshell.v1.PolicyRevisionPayload.ProvenanceEntry
-	222, // 138: openshell.v1.DraftChunkPayload.proposed_rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
-	213, // 139: openshell.v1.StoredPolicyRevision.provenance:type_name -> openshell.v1.StoredPolicyRevision.ProvenanceEntry
-	214, // 140: openshell.v1.CreateWorkspaceRequest.labels:type_name -> openshell.v1.CreateWorkspaceRequest.LabelsEntry
-	225, // 141: openshell.v1.CreateWorkspaceResponse.workspace:type_name -> openshell.datamodel.v1.Workspace
-	225, // 142: openshell.v1.GetWorkspaceResponse.workspace:type_name -> openshell.datamodel.v1.Workspace
-	225, // 143: openshell.v1.ListWorkspacesResponse.workspaces:type_name -> openshell.datamodel.v1.Workspace
-	215, // 144: openshell.v1.WorkspaceMember.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
-	5,   // 145: openshell.v1.WorkspaceMember.role:type_name -> openshell.v1.WorkspaceRole
-	5,   // 146: openshell.v1.AddWorkspaceMemberRequest.role:type_name -> openshell.v1.WorkspaceRole
-	183, // 147: openshell.v1.AddWorkspaceMemberResponse.member:type_name -> openshell.v1.WorkspaceMember
-	183, // 148: openshell.v1.ListWorkspaceMembersResponse.members:type_name -> openshell.v1.WorkspaceMember
-	80,  // 149: openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntry.value:type_name -> openshell.v1.ProviderProfileCredential
-	110, // 150: openshell.v1.GetSandboxProviderEnvironmentResponse.StaticCredentialBindingsEntry.value:type_name -> openshell.v1.StaticCredentialBinding
-	10,  // 151: openshell.v1.OpenShell.Health:input_type -> openshell.v1.HealthRequest
-	12,  // 152: openshell.v1.OpenShell.GetCurrentUser:input_type -> openshell.v1.GetCurrentUserRequest
-	14,  // 153: openshell.v1.OpenShell.GetGatewayInfo:input_type -> openshell.v1.GetGatewayInfoRequest
-	26,  // 154: openshell.v1.OpenShell.CreateSandbox:input_type -> openshell.v1.CreateSandboxRequest
-	27,  // 155: openshell.v1.OpenShell.GetSandbox:input_type -> openshell.v1.GetSandboxRequest
-	28,  // 156: openshell.v1.OpenShell.ListSandboxes:input_type -> openshell.v1.ListSandboxesRequest
-	29,  // 157: openshell.v1.OpenShell.ListSandboxProviders:input_type -> openshell.v1.ListSandboxProvidersRequest
-	30,  // 158: openshell.v1.OpenShell.AttachSandboxProvider:input_type -> openshell.v1.AttachSandboxProviderRequest
-	31,  // 159: openshell.v1.OpenShell.DetachSandboxProvider:input_type -> openshell.v1.DetachSandboxProviderRequest
-	32,  // 160: openshell.v1.OpenShell.DeleteSandbox:input_type -> openshell.v1.DeleteSandboxRequest
-	33,  // 161: openshell.v1.OpenShell.StopSandbox:input_type -> openshell.v1.StopSandboxRequest
-	34,  // 162: openshell.v1.OpenShell.StartSandbox:input_type -> openshell.v1.StartSandboxRequest
-	41,  // 163: openshell.v1.OpenShell.CreateSshSession:input_type -> openshell.v1.CreateSshSessionRequest
-	43,  // 164: openshell.v1.OpenShell.ExposeService:input_type -> openshell.v1.ExposeServiceRequest
-	44,  // 165: openshell.v1.OpenShell.GetService:input_type -> openshell.v1.GetServiceRequest
-	45,  // 166: openshell.v1.OpenShell.ListServices:input_type -> openshell.v1.ListServicesRequest
-	47,  // 167: openshell.v1.OpenShell.DeleteService:input_type -> openshell.v1.DeleteServiceRequest
-	51,  // 168: openshell.v1.OpenShell.RevokeSshSession:input_type -> openshell.v1.RevokeSshSessionRequest
-	53,  // 169: openshell.v1.OpenShell.ExecSandbox:input_type -> openshell.v1.ExecSandboxRequest
-	59,  // 170: openshell.v1.OpenShell.ForwardTcp:input_type -> openshell.v1.TcpForwardFrame
-	60,  // 171: openshell.v1.OpenShell.ExecSandboxInteractive:input_type -> openshell.v1.ExecSandboxInput
-	67,  // 172: openshell.v1.OpenShell.CreateProvider:input_type -> openshell.v1.CreateProviderRequest
-	68,  // 173: openshell.v1.OpenShell.GetProvider:input_type -> openshell.v1.GetProviderRequest
-	69,  // 174: openshell.v1.OpenShell.ListProviders:input_type -> openshell.v1.ListProvidersRequest
-	74,  // 175: openshell.v1.OpenShell.ListProviderProfiles:input_type -> openshell.v1.ListProviderProfilesRequest
-	75,  // 176: openshell.v1.OpenShell.GetProviderProfile:input_type -> openshell.v1.GetProviderProfileRequest
-	99,  // 177: openshell.v1.OpenShell.ImportProviderProfiles:input_type -> openshell.v1.ImportProviderProfilesRequest
-	101, // 178: openshell.v1.OpenShell.UpdateProviderProfiles:input_type -> openshell.v1.UpdateProviderProfilesRequest
-	103, // 179: openshell.v1.OpenShell.LintProviderProfiles:input_type -> openshell.v1.LintProviderProfilesRequest
-	70,  // 180: openshell.v1.OpenShell.UpdateProvider:input_type -> openshell.v1.UpdateProviderRequest
-	87,  // 181: openshell.v1.OpenShell.GetProviderRefreshStatus:input_type -> openshell.v1.GetProviderRefreshStatusRequest
-	89,  // 182: openshell.v1.OpenShell.ConfigureProviderRefresh:input_type -> openshell.v1.ConfigureProviderRefreshRequest
-	91,  // 183: openshell.v1.OpenShell.RotateProviderCredential:input_type -> openshell.v1.RotateProviderCredentialRequest
-	93,  // 184: openshell.v1.OpenShell.DeleteProviderRefresh:input_type -> openshell.v1.DeleteProviderRefreshRequest
-	71,  // 185: openshell.v1.OpenShell.DeleteProvider:input_type -> openshell.v1.DeleteProviderRequest
-	106, // 186: openshell.v1.OpenShell.DeleteProviderProfile:input_type -> openshell.v1.DeleteProviderProfileRequest
-	226, // 187: openshell.v1.OpenShell.GetSandboxConfig:input_type -> openshell.sandbox.v1.GetSandboxConfigRequest
-	227, // 188: openshell.v1.OpenShell.GetGatewayConfig:input_type -> openshell.sandbox.v1.GetGatewayConfigRequest
-	112, // 189: openshell.v1.OpenShell.UpdateConfig:input_type -> openshell.v1.UpdateConfigRequest
-	121, // 190: openshell.v1.OpenShell.GetSandboxPolicyStatus:input_type -> openshell.v1.GetSandboxPolicyStatusRequest
-	123, // 191: openshell.v1.OpenShell.ListSandboxPolicies:input_type -> openshell.v1.ListSandboxPoliciesRequest
-	125, // 192: openshell.v1.OpenShell.ReportPolicyStatus:input_type -> openshell.v1.ReportPolicyStatusRequest
-	108, // 193: openshell.v1.OpenShell.GetSandboxProviderEnvironment:input_type -> openshell.v1.GetSandboxProviderEnvironmentRequest
-	128, // 194: openshell.v1.OpenShell.GetSandboxLogs:input_type -> openshell.v1.GetSandboxLogsRequest
-	129, // 195: openshell.v1.OpenShell.PushSandboxLogs:input_type -> openshell.v1.PushSandboxLogsRequest
-	132, // 196: openshell.v1.OpenShell.ConnectSupervisor:input_type -> openshell.v1.SupervisorMessage
-	143, // 197: openshell.v1.OpenShell.RelayStream:input_type -> openshell.v1.RelayFrame
-	63,  // 198: openshell.v1.OpenShell.WatchSandbox:input_type -> openshell.v1.WatchSandboxRequest
-	152, // 199: openshell.v1.OpenShell.SubmitPolicyAnalysis:input_type -> openshell.v1.SubmitPolicyAnalysisRequest
-	154, // 200: openshell.v1.OpenShell.GetDraftPolicy:input_type -> openshell.v1.GetDraftPolicyRequest
-	156, // 201: openshell.v1.OpenShell.ApproveDraftChunk:input_type -> openshell.v1.ApproveDraftChunkRequest
-	158, // 202: openshell.v1.OpenShell.RejectDraftChunk:input_type -> openshell.v1.RejectDraftChunkRequest
-	160, // 203: openshell.v1.OpenShell.ApproveAllDraftChunks:input_type -> openshell.v1.ApproveAllDraftChunksRequest
-	162, // 204: openshell.v1.OpenShell.EditDraftChunk:input_type -> openshell.v1.EditDraftChunkRequest
-	164, // 205: openshell.v1.OpenShell.UndoDraftChunk:input_type -> openshell.v1.UndoDraftChunkRequest
-	166, // 206: openshell.v1.OpenShell.ClearDraftChunks:input_type -> openshell.v1.ClearDraftChunksRequest
-	168, // 207: openshell.v1.OpenShell.GetDraftHistory:input_type -> openshell.v1.GetDraftHistoryRequest
-	6,   // 208: openshell.v1.OpenShell.IssueSandboxToken:input_type -> openshell.v1.IssueSandboxTokenRequest
-	8,   // 209: openshell.v1.OpenShell.RefreshSandboxToken:input_type -> openshell.v1.RefreshSandboxTokenRequest
-	175, // 210: openshell.v1.OpenShell.CreateWorkspace:input_type -> openshell.v1.CreateWorkspaceRequest
-	177, // 211: openshell.v1.OpenShell.GetWorkspace:input_type -> openshell.v1.GetWorkspaceRequest
-	179, // 212: openshell.v1.OpenShell.ListWorkspaces:input_type -> openshell.v1.ListWorkspacesRequest
-	181, // 213: openshell.v1.OpenShell.DeleteWorkspace:input_type -> openshell.v1.DeleteWorkspaceRequest
-	184, // 214: openshell.v1.OpenShell.AddWorkspaceMember:input_type -> openshell.v1.AddWorkspaceMemberRequest
-	186, // 215: openshell.v1.OpenShell.RemoveWorkspaceMember:input_type -> openshell.v1.RemoveWorkspaceMemberRequest
-	188, // 216: openshell.v1.OpenShell.ListWorkspaceMembers:input_type -> openshell.v1.ListWorkspaceMembersRequest
-	11,  // 217: openshell.v1.OpenShell.Health:output_type -> openshell.v1.HealthResponse
-	13,  // 218: openshell.v1.OpenShell.GetCurrentUser:output_type -> openshell.v1.GetCurrentUserResponse
-	15,  // 219: openshell.v1.OpenShell.GetGatewayInfo:output_type -> openshell.v1.GetGatewayInfoResponse
-	35,  // 220: openshell.v1.OpenShell.CreateSandbox:output_type -> openshell.v1.SandboxResponse
-	35,  // 221: openshell.v1.OpenShell.GetSandbox:output_type -> openshell.v1.SandboxResponse
-	36,  // 222: openshell.v1.OpenShell.ListSandboxes:output_type -> openshell.v1.ListSandboxesResponse
-	37,  // 223: openshell.v1.OpenShell.ListSandboxProviders:output_type -> openshell.v1.ListSandboxProvidersResponse
-	38,  // 224: openshell.v1.OpenShell.AttachSandboxProvider:output_type -> openshell.v1.AttachSandboxProviderResponse
-	39,  // 225: openshell.v1.OpenShell.DetachSandboxProvider:output_type -> openshell.v1.DetachSandboxProviderResponse
-	40,  // 226: openshell.v1.OpenShell.DeleteSandbox:output_type -> openshell.v1.DeleteSandboxResponse
-	35,  // 227: openshell.v1.OpenShell.StopSandbox:output_type -> openshell.v1.SandboxResponse
-	35,  // 228: openshell.v1.OpenShell.StartSandbox:output_type -> openshell.v1.SandboxResponse
-	42,  // 229: openshell.v1.OpenShell.CreateSshSession:output_type -> openshell.v1.CreateSshSessionResponse
-	50,  // 230: openshell.v1.OpenShell.ExposeService:output_type -> openshell.v1.ServiceEndpointResponse
-	50,  // 231: openshell.v1.OpenShell.GetService:output_type -> openshell.v1.ServiceEndpointResponse
-	46,  // 232: openshell.v1.OpenShell.ListServices:output_type -> openshell.v1.ListServicesResponse
-	48,  // 233: openshell.v1.OpenShell.DeleteService:output_type -> openshell.v1.DeleteServiceResponse
-	52,  // 234: openshell.v1.OpenShell.RevokeSshSession:output_type -> openshell.v1.RevokeSshSessionResponse
-	57,  // 235: openshell.v1.OpenShell.ExecSandbox:output_type -> openshell.v1.ExecSandboxEvent
-	59,  // 236: openshell.v1.OpenShell.ForwardTcp:output_type -> openshell.v1.TcpForwardFrame
-	57,  // 237: openshell.v1.OpenShell.ExecSandboxInteractive:output_type -> openshell.v1.ExecSandboxEvent
-	72,  // 238: openshell.v1.OpenShell.CreateProvider:output_type -> openshell.v1.ProviderResponse
-	72,  // 239: openshell.v1.OpenShell.GetProvider:output_type -> openshell.v1.ProviderResponse
-	73,  // 240: openshell.v1.OpenShell.ListProviders:output_type -> openshell.v1.ListProvidersResponse
-	98,  // 241: openshell.v1.OpenShell.ListProviderProfiles:output_type -> openshell.v1.ListProviderProfilesResponse
-	97,  // 242: openshell.v1.OpenShell.GetProviderProfile:output_type -> openshell.v1.ProviderProfileResponse
-	100, // 243: openshell.v1.OpenShell.ImportProviderProfiles:output_type -> openshell.v1.ImportProviderProfilesResponse
-	102, // 244: openshell.v1.OpenShell.UpdateProviderProfiles:output_type -> openshell.v1.UpdateProviderProfilesResponse
-	104, // 245: openshell.v1.OpenShell.LintProviderProfiles:output_type -> openshell.v1.LintProviderProfilesResponse
-	72,  // 246: openshell.v1.OpenShell.UpdateProvider:output_type -> openshell.v1.ProviderResponse
-	88,  // 247: openshell.v1.OpenShell.GetProviderRefreshStatus:output_type -> openshell.v1.GetProviderRefreshStatusResponse
-	90,  // 248: openshell.v1.OpenShell.ConfigureProviderRefresh:output_type -> openshell.v1.ConfigureProviderRefreshResponse
-	92,  // 249: openshell.v1.OpenShell.RotateProviderCredential:output_type -> openshell.v1.RotateProviderCredentialResponse
-	94,  // 250: openshell.v1.OpenShell.DeleteProviderRefresh:output_type -> openshell.v1.DeleteProviderRefreshResponse
-	105, // 251: openshell.v1.OpenShell.DeleteProvider:output_type -> openshell.v1.DeleteProviderResponse
-	107, // 252: openshell.v1.OpenShell.DeleteProviderProfile:output_type -> openshell.v1.DeleteProviderProfileResponse
-	228, // 253: openshell.v1.OpenShell.GetSandboxConfig:output_type -> openshell.sandbox.v1.GetSandboxConfigResponse
-	229, // 254: openshell.v1.OpenShell.GetGatewayConfig:output_type -> openshell.sandbox.v1.GetGatewayConfigResponse
-	120, // 255: openshell.v1.OpenShell.UpdateConfig:output_type -> openshell.v1.UpdateConfigResponse
-	122, // 256: openshell.v1.OpenShell.GetSandboxPolicyStatus:output_type -> openshell.v1.GetSandboxPolicyStatusResponse
-	124, // 257: openshell.v1.OpenShell.ListSandboxPolicies:output_type -> openshell.v1.ListSandboxPoliciesResponse
-	126, // 258: openshell.v1.OpenShell.ReportPolicyStatus:output_type -> openshell.v1.ReportPolicyStatusResponse
-	111, // 259: openshell.v1.OpenShell.GetSandboxProviderEnvironment:output_type -> openshell.v1.GetSandboxProviderEnvironmentResponse
-	131, // 260: openshell.v1.OpenShell.GetSandboxLogs:output_type -> openshell.v1.GetSandboxLogsResponse
-	130, // 261: openshell.v1.OpenShell.PushSandboxLogs:output_type -> openshell.v1.PushSandboxLogsResponse
-	133, // 262: openshell.v1.OpenShell.ConnectSupervisor:output_type -> openshell.v1.GatewayMessage
-	143, // 263: openshell.v1.OpenShell.RelayStream:output_type -> openshell.v1.RelayFrame
-	64,  // 264: openshell.v1.OpenShell.WatchSandbox:output_type -> openshell.v1.SandboxStreamEvent
-	153, // 265: openshell.v1.OpenShell.SubmitPolicyAnalysis:output_type -> openshell.v1.SubmitPolicyAnalysisResponse
-	155, // 266: openshell.v1.OpenShell.GetDraftPolicy:output_type -> openshell.v1.GetDraftPolicyResponse
-	157, // 267: openshell.v1.OpenShell.ApproveDraftChunk:output_type -> openshell.v1.ApproveDraftChunkResponse
-	159, // 268: openshell.v1.OpenShell.RejectDraftChunk:output_type -> openshell.v1.RejectDraftChunkResponse
-	161, // 269: openshell.v1.OpenShell.ApproveAllDraftChunks:output_type -> openshell.v1.ApproveAllDraftChunksResponse
-	163, // 270: openshell.v1.OpenShell.EditDraftChunk:output_type -> openshell.v1.EditDraftChunkResponse
-	165, // 271: openshell.v1.OpenShell.UndoDraftChunk:output_type -> openshell.v1.UndoDraftChunkResponse
-	167, // 272: openshell.v1.OpenShell.ClearDraftChunks:output_type -> openshell.v1.ClearDraftChunksResponse
-	170, // 273: openshell.v1.OpenShell.GetDraftHistory:output_type -> openshell.v1.GetDraftHistoryResponse
-	7,   // 274: openshell.v1.OpenShell.IssueSandboxToken:output_type -> openshell.v1.IssueSandboxTokenResponse
-	9,   // 275: openshell.v1.OpenShell.RefreshSandboxToken:output_type -> openshell.v1.RefreshSandboxTokenResponse
-	176, // 276: openshell.v1.OpenShell.CreateWorkspace:output_type -> openshell.v1.CreateWorkspaceResponse
-	178, // 277: openshell.v1.OpenShell.GetWorkspace:output_type -> openshell.v1.GetWorkspaceResponse
-	180, // 278: openshell.v1.OpenShell.ListWorkspaces:output_type -> openshell.v1.ListWorkspacesResponse
-	182, // 279: openshell.v1.OpenShell.DeleteWorkspace:output_type -> openshell.v1.DeleteWorkspaceResponse
-	185, // 280: openshell.v1.OpenShell.AddWorkspaceMember:output_type -> openshell.v1.AddWorkspaceMemberResponse
-	187, // 281: openshell.v1.OpenShell.RemoveWorkspaceMember:output_type -> openshell.v1.RemoveWorkspaceMemberResponse
-	189, // 282: openshell.v1.OpenShell.ListWorkspaceMembers:output_type -> openshell.v1.ListWorkspaceMembersResponse
-	217, // [217:283] is the sub-list for method output_type
-	151, // [151:217] is the sub-list for method input_type
-	151, // [151:151] is the sub-list for extension type_name
-	151, // [151:151] is the sub-list for extension extendee
-	0,   // [0:151] is the sub-list for field type_name
+	27,  // 7: openshell.v1.Sandbox.status:type_name -> openshell.v1.SandboxStatus
+	26,  // 8: openshell.v1.Sandbox.created_from_template:type_name -> openshell.v1.SandboxTemplateProvenance
+	20,  // 9: openshell.v1.SandboxSpec.workload:type_name -> openshell.v1.SandboxWorkloadConfig
+	224, // 10: openshell.v1.SandboxSpec.driver_config:type_name -> google.protobuf.Struct
+	225, // 11: openshell.v1.SandboxSpec.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
+	202, // 12: openshell.v1.SandboxWorkloadConfig.environment:type_name -> openshell.v1.SandboxWorkloadConfig.EnvironmentEntry
+	21,  // 13: openshell.v1.SandboxWorkloadConfig.resources:type_name -> openshell.v1.SandboxResources
+	223, // 14: openshell.v1.SandboxTemplate.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	23,  // 15: openshell.v1.SandboxTemplate.spec:type_name -> openshell.v1.SandboxTemplateSpec
+	20,  // 16: openshell.v1.SandboxTemplateSpec.workload:type_name -> openshell.v1.SandboxWorkloadConfig
+	224, // 17: openshell.v1.SandboxTemplateSpec.driver_config:type_name -> google.protobuf.Struct
+	24,  // 18: openshell.v1.SandboxTemplateSpec.desired_service_level:type_name -> openshell.v1.SandboxServiceLevel
+	25,  // 19: openshell.v1.SandboxServiceLevel.startup:type_name -> openshell.v1.SandboxStartup
+	226, // 20: openshell.v1.SandboxStartup.ready_within:type_name -> google.protobuf.Duration
+	28,  // 21: openshell.v1.SandboxStatus.conditions:type_name -> openshell.v1.SandboxCondition
+	0,   // 22: openshell.v1.SandboxStatus.phase:type_name -> openshell.v1.SandboxPhase
+	203, // 23: openshell.v1.PlatformEvent.metadata:type_name -> openshell.v1.PlatformEvent.MetadataEntry
+	20,  // 24: openshell.v1.CreateSandboxRequest.workload:type_name -> openshell.v1.SandboxWorkloadConfig
+	225, // 25: openshell.v1.CreateSandboxRequest.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
+	204, // 26: openshell.v1.CreateSandboxRequest.labels:type_name -> openshell.v1.CreateSandboxRequest.LabelsEntry
+	205, // 27: openshell.v1.CreateSandboxRequest.annotations:type_name -> openshell.v1.CreateSandboxRequest.AnnotationsEntry
+	22,  // 28: openshell.v1.CreateSandboxTemplateRequest.template:type_name -> openshell.v1.SandboxTemplate
+	22,  // 29: openshell.v1.SandboxTemplateResponse.template:type_name -> openshell.v1.SandboxTemplate
+	22,  // 30: openshell.v1.ListSandboxTemplatesResponse.templates:type_name -> openshell.v1.SandboxTemplate
+	18,  // 31: openshell.v1.SandboxResponse.sandbox:type_name -> openshell.v1.Sandbox
+	18,  // 32: openshell.v1.ListSandboxesResponse.sandboxes:type_name -> openshell.v1.Sandbox
+	227, // 33: openshell.v1.ListSandboxProvidersResponse.providers:type_name -> openshell.datamodel.v1.Provider
+	18,  // 34: openshell.v1.AttachSandboxProviderResponse.sandbox:type_name -> openshell.v1.Sandbox
+	18,  // 35: openshell.v1.DetachSandboxProviderResponse.sandbox:type_name -> openshell.v1.Sandbox
+	61,  // 36: openshell.v1.ListServicesResponse.services:type_name -> openshell.v1.ServiceEndpointResponse
+	223, // 37: openshell.v1.ServiceEndpoint.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	60,  // 38: openshell.v1.ServiceEndpointResponse.endpoint:type_name -> openshell.v1.ServiceEndpoint
+	206, // 39: openshell.v1.ExecSandboxRequest.environment:type_name -> openshell.v1.ExecSandboxRequest.EnvironmentEntry
+	65,  // 40: openshell.v1.ExecSandboxEvent.stdout:type_name -> openshell.v1.ExecSandboxStdout
+	66,  // 41: openshell.v1.ExecSandboxEvent.stderr:type_name -> openshell.v1.ExecSandboxStderr
+	67,  // 42: openshell.v1.ExecSandboxEvent.exit:type_name -> openshell.v1.ExecSandboxExit
+	151, // 43: openshell.v1.TcpForwardInit.ssh:type_name -> openshell.v1.SshRelayTarget
+	152, // 44: openshell.v1.TcpForwardInit.tcp:type_name -> openshell.v1.TcpRelayTarget
+	69,  // 45: openshell.v1.TcpForwardFrame.init:type_name -> openshell.v1.TcpForwardInit
+	64,  // 46: openshell.v1.ExecSandboxInput.start:type_name -> openshell.v1.ExecSandboxRequest
+	72,  // 47: openshell.v1.ExecSandboxInput.resize:type_name -> openshell.v1.ExecSandboxWindowResize
+	223, // 48: openshell.v1.SshSession.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	18,  // 49: openshell.v1.SandboxStreamEvent.sandbox:type_name -> openshell.v1.Sandbox
+	76,  // 50: openshell.v1.SandboxStreamEvent.log:type_name -> openshell.v1.SandboxLogLine
+	29,  // 51: openshell.v1.SandboxStreamEvent.event:type_name -> openshell.v1.PlatformEvent
+	77,  // 52: openshell.v1.SandboxStreamEvent.warning:type_name -> openshell.v1.SandboxStreamWarning
+	162, // 53: openshell.v1.SandboxStreamEvent.draft_policy_update:type_name -> openshell.v1.DraftPolicyUpdate
+	207, // 54: openshell.v1.SandboxLogLine.fields:type_name -> openshell.v1.SandboxLogLine.FieldsEntry
+	227, // 55: openshell.v1.CreateProviderRequest.provider:type_name -> openshell.datamodel.v1.Provider
+	227, // 56: openshell.v1.UpdateProviderRequest.provider:type_name -> openshell.datamodel.v1.Provider
+	208, // 57: openshell.v1.UpdateProviderRequest.credential_expires_at_ms:type_name -> openshell.v1.UpdateProviderRequest.CredentialExpiresAtMsEntry
+	227, // 58: openshell.v1.ProviderResponse.provider:type_name -> openshell.datamodel.v1.Provider
+	227, // 59: openshell.v1.ListProvidersResponse.providers:type_name -> openshell.datamodel.v1.Provider
+	106, // 60: openshell.v1.ProviderProfileImportItem.profile:type_name -> openshell.v1.ProviderProfile
+	89,  // 61: openshell.v1.ProviderCredentialTokenGrant.audience_overrides:type_name -> openshell.v1.ProviderCredentialTokenGrantAudienceOverride
+	94,  // 62: openshell.v1.ProviderProfileCredential.refresh:type_name -> openshell.v1.ProviderCredentialRefresh
+	90,  // 63: openshell.v1.ProviderProfileCredential.token_grant:type_name -> openshell.v1.ProviderCredentialTokenGrant
+	1,   // 64: openshell.v1.ProviderCredentialRefresh.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
+	92,  // 65: openshell.v1.ProviderCredentialRefresh.material:type_name -> openshell.v1.ProviderCredentialRefreshMaterial
+	93,  // 66: openshell.v1.ProviderCredentialRefresh.additional_outputs:type_name -> openshell.v1.ProviderCredentialRefreshOutput
+	1,   // 67: openshell.v1.ProviderCredentialRefreshStatus.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
+	223, // 68: openshell.v1.StoredProviderCredentialRefreshState.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	1,   // 69: openshell.v1.StoredProviderCredentialRefreshState.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
+	209, // 70: openshell.v1.StoredProviderCredentialRefreshState.material:type_name -> openshell.v1.StoredProviderCredentialRefreshState.MaterialEntry
+	210, // 71: openshell.v1.StoredProviderCredentialRefreshState.additional_output_keys:type_name -> openshell.v1.StoredProviderCredentialRefreshState.AdditionalOutputKeysEntry
+	95,  // 72: openshell.v1.GetProviderRefreshStatusResponse.credentials:type_name -> openshell.v1.ProviderCredentialRefreshStatus
+	1,   // 73: openshell.v1.ConfigureProviderRefreshRequest.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
+	211, // 74: openshell.v1.ConfigureProviderRefreshRequest.material:type_name -> openshell.v1.ConfigureProviderRefreshRequest.MaterialEntry
+	95,  // 75: openshell.v1.ConfigureProviderRefreshResponse.status:type_name -> openshell.v1.ProviderCredentialRefreshStatus
+	95,  // 76: openshell.v1.RotateProviderCredentialResponse.status:type_name -> openshell.v1.ProviderCredentialRefreshStatus
+	2,   // 77: openshell.v1.ProviderProfile.category:type_name -> openshell.v1.ProviderProfileCategory
+	91,  // 78: openshell.v1.ProviderProfile.credentials:type_name -> openshell.v1.ProviderProfileCredential
+	228, // 79: openshell.v1.ProviderProfile.endpoints:type_name -> openshell.sandbox.v1.NetworkEndpoint
+	229, // 80: openshell.v1.ProviderProfile.binaries:type_name -> openshell.sandbox.v1.NetworkBinary
+	96,  // 81: openshell.v1.ProviderProfile.discovery:type_name -> openshell.v1.ProviderProfileDiscovery
+	212, // 82: openshell.v1.ProviderProfile.annotations:type_name -> openshell.v1.ProviderProfile.AnnotationsEntry
+	223, // 83: openshell.v1.StoredProviderProfile.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	106, // 84: openshell.v1.StoredProviderProfile.profile:type_name -> openshell.v1.ProviderProfile
+	106, // 85: openshell.v1.ProviderProfileResponse.profile:type_name -> openshell.v1.ProviderProfile
+	106, // 86: openshell.v1.ListProviderProfilesResponse.profiles:type_name -> openshell.v1.ProviderProfile
+	87,  // 87: openshell.v1.ImportProviderProfilesRequest.profiles:type_name -> openshell.v1.ProviderProfileImportItem
+	88,  // 88: openshell.v1.ImportProviderProfilesResponse.diagnostics:type_name -> openshell.v1.ProviderProfileDiagnostic
+	106, // 89: openshell.v1.ImportProviderProfilesResponse.profiles:type_name -> openshell.v1.ProviderProfile
+	87,  // 90: openshell.v1.UpdateProviderProfilesRequest.profile:type_name -> openshell.v1.ProviderProfileImportItem
+	88,  // 91: openshell.v1.UpdateProviderProfilesResponse.diagnostics:type_name -> openshell.v1.ProviderProfileDiagnostic
+	106, // 92: openshell.v1.UpdateProviderProfilesResponse.profile:type_name -> openshell.v1.ProviderProfile
+	87,  // 93: openshell.v1.LintProviderProfilesRequest.profiles:type_name -> openshell.v1.ProviderProfileImportItem
+	88,  // 94: openshell.v1.LintProviderProfilesResponse.diagnostics:type_name -> openshell.v1.ProviderProfileDiagnostic
+	120, // 95: openshell.v1.StaticCredentialBinding.endpoints:type_name -> openshell.v1.StaticCredentialEndpointBinding
+	213, // 96: openshell.v1.GetSandboxProviderEnvironmentResponse.environment:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.EnvironmentEntry
+	214, // 97: openshell.v1.GetSandboxProviderEnvironmentResponse.credential_expires_at_ms:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.CredentialExpiresAtMsEntry
+	215, // 98: openshell.v1.GetSandboxProviderEnvironmentResponse.dynamic_credentials:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntry
+	216, // 99: openshell.v1.GetSandboxProviderEnvironmentResponse.static_credential_bindings:type_name -> openshell.v1.GetSandboxProviderEnvironmentResponse.StaticCredentialBindingsEntry
+	225, // 100: openshell.v1.UpdateConfigRequest.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
+	230, // 101: openshell.v1.UpdateConfigRequest.setting_value:type_name -> openshell.sandbox.v1.SettingValue
+	124, // 102: openshell.v1.UpdateConfigRequest.merge_operations:type_name -> openshell.v1.PolicyMergeOperation
+	217, // 103: openshell.v1.UpdateConfigRequest.annotations:type_name -> openshell.v1.UpdateConfigRequest.AnnotationsEntry
+	125, // 104: openshell.v1.PolicyMergeOperation.add_rule:type_name -> openshell.v1.AddNetworkRule
+	126, // 105: openshell.v1.PolicyMergeOperation.remove_endpoint:type_name -> openshell.v1.RemoveNetworkEndpoint
+	127, // 106: openshell.v1.PolicyMergeOperation.remove_rule:type_name -> openshell.v1.RemoveNetworkRule
+	128, // 107: openshell.v1.PolicyMergeOperation.add_deny_rules:type_name -> openshell.v1.AddDenyRules
+	129, // 108: openshell.v1.PolicyMergeOperation.add_allow_rules:type_name -> openshell.v1.AddAllowRules
+	130, // 109: openshell.v1.PolicyMergeOperation.remove_binary:type_name -> openshell.v1.RemoveNetworkBinary
+	231, // 110: openshell.v1.AddNetworkRule.rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
+	232, // 111: openshell.v1.AddDenyRules.deny_rules:type_name -> openshell.sandbox.v1.L7DenyRule
+	233, // 112: openshell.v1.AddAllowRules.rules:type_name -> openshell.sandbox.v1.L7Rule
+	218, // 113: openshell.v1.UpdateConfigResponse.annotations:type_name -> openshell.v1.UpdateConfigResponse.AnnotationsEntry
+	138, // 114: openshell.v1.GetSandboxPolicyStatusResponse.revision:type_name -> openshell.v1.SandboxPolicyRevision
+	138, // 115: openshell.v1.ListSandboxPoliciesResponse.revisions:type_name -> openshell.v1.SandboxPolicyRevision
+	3,   // 116: openshell.v1.ReportPolicyStatusRequest.status:type_name -> openshell.v1.PolicyStatus
+	3,   // 117: openshell.v1.SandboxPolicyRevision.status:type_name -> openshell.v1.PolicyStatus
+	225, // 118: openshell.v1.SandboxPolicyRevision.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
+	219, // 119: openshell.v1.SandboxPolicyRevision.provenance:type_name -> openshell.v1.SandboxPolicyRevision.ProvenanceEntry
+	76,  // 120: openshell.v1.PushSandboxLogsRequest.logs:type_name -> openshell.v1.SandboxLogLine
+	76,  // 121: openshell.v1.GetSandboxLogsResponse.logs:type_name -> openshell.v1.SandboxLogLine
+	145, // 122: openshell.v1.SupervisorMessage.hello:type_name -> openshell.v1.SupervisorHello
+	148, // 123: openshell.v1.SupervisorMessage.heartbeat:type_name -> openshell.v1.SupervisorHeartbeat
+	155, // 124: openshell.v1.SupervisorMessage.relay_open_result:type_name -> openshell.v1.RelayOpenResult
+	156, // 125: openshell.v1.SupervisorMessage.relay_close:type_name -> openshell.v1.RelayClose
+	146, // 126: openshell.v1.GatewayMessage.session_accepted:type_name -> openshell.v1.SessionAccepted
+	147, // 127: openshell.v1.GatewayMessage.session_rejected:type_name -> openshell.v1.SessionRejected
+	149, // 128: openshell.v1.GatewayMessage.heartbeat:type_name -> openshell.v1.GatewayHeartbeat
+	150, // 129: openshell.v1.GatewayMessage.relay_open:type_name -> openshell.v1.RelayOpen
+	156, // 130: openshell.v1.GatewayMessage.relay_close:type_name -> openshell.v1.RelayClose
+	151, // 131: openshell.v1.RelayOpen.ssh:type_name -> openshell.v1.SshRelayTarget
+	152, // 132: openshell.v1.RelayOpen.tcp:type_name -> openshell.v1.TcpRelayTarget
+	153, // 133: openshell.v1.RelayFrame.init:type_name -> openshell.v1.RelayInit
+	157, // 134: openshell.v1.DenialSummary.l7_request_samples:type_name -> openshell.v1.L7RequestSample
+	159, // 135: openshell.v1.NetworkActivitySummary.denials_by_group:type_name -> openshell.v1.DenialGroupCount
+	231, // 136: openshell.v1.PolicyChunk.proposed_rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
+	158, // 137: openshell.v1.SubmitPolicyAnalysisRequest.summaries:type_name -> openshell.v1.DenialSummary
+	161, // 138: openshell.v1.SubmitPolicyAnalysisRequest.proposed_chunks:type_name -> openshell.v1.PolicyChunk
+	160, // 139: openshell.v1.SubmitPolicyAnalysisRequest.network_activity_summaries:type_name -> openshell.v1.NetworkActivitySummary
+	161, // 140: openshell.v1.GetDraftPolicyResponse.chunks:type_name -> openshell.v1.PolicyChunk
+	231, // 141: openshell.v1.EditDraftChunkRequest.proposed_rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
+	180, // 142: openshell.v1.GetDraftHistoryResponse.entries:type_name -> openshell.v1.DraftHistoryEntry
+	225, // 143: openshell.v1.PolicyRevisionPayload.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
+	220, // 144: openshell.v1.PolicyRevisionPayload.provenance:type_name -> openshell.v1.PolicyRevisionPayload.ProvenanceEntry
+	231, // 145: openshell.v1.DraftChunkPayload.proposed_rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
+	221, // 146: openshell.v1.StoredPolicyRevision.provenance:type_name -> openshell.v1.StoredPolicyRevision.ProvenanceEntry
+	222, // 147: openshell.v1.CreateWorkspaceRequest.labels:type_name -> openshell.v1.CreateWorkspaceRequest.LabelsEntry
+	234, // 148: openshell.v1.CreateWorkspaceResponse.workspace:type_name -> openshell.datamodel.v1.Workspace
+	234, // 149: openshell.v1.GetWorkspaceResponse.workspace:type_name -> openshell.datamodel.v1.Workspace
+	234, // 150: openshell.v1.ListWorkspacesResponse.workspaces:type_name -> openshell.datamodel.v1.Workspace
+	223, // 151: openshell.v1.WorkspaceMember.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	5,   // 152: openshell.v1.WorkspaceMember.role:type_name -> openshell.v1.WorkspaceRole
+	5,   // 153: openshell.v1.AddWorkspaceMemberRequest.role:type_name -> openshell.v1.WorkspaceRole
+	194, // 154: openshell.v1.AddWorkspaceMemberResponse.member:type_name -> openshell.v1.WorkspaceMember
+	194, // 155: openshell.v1.ListWorkspaceMembersResponse.members:type_name -> openshell.v1.WorkspaceMember
+	91,  // 156: openshell.v1.GetSandboxProviderEnvironmentResponse.DynamicCredentialsEntry.value:type_name -> openshell.v1.ProviderProfileCredential
+	121, // 157: openshell.v1.GetSandboxProviderEnvironmentResponse.StaticCredentialBindingsEntry.value:type_name -> openshell.v1.StaticCredentialBinding
+	10,  // 158: openshell.v1.OpenShell.Health:input_type -> openshell.v1.HealthRequest
+	12,  // 159: openshell.v1.OpenShell.GetCurrentUser:input_type -> openshell.v1.GetCurrentUserRequest
+	14,  // 160: openshell.v1.OpenShell.GetGatewayInfo:input_type -> openshell.v1.GetGatewayInfoRequest
+	30,  // 161: openshell.v1.OpenShell.CreateSandbox:input_type -> openshell.v1.CreateSandboxRequest
+	38,  // 162: openshell.v1.OpenShell.GetSandbox:input_type -> openshell.v1.GetSandboxRequest
+	39,  // 163: openshell.v1.OpenShell.ListSandboxes:input_type -> openshell.v1.ListSandboxesRequest
+	31,  // 164: openshell.v1.OpenShell.CreateSandboxTemplate:input_type -> openshell.v1.CreateSandboxTemplateRequest
+	32,  // 165: openshell.v1.OpenShell.GetSandboxTemplate:input_type -> openshell.v1.GetSandboxTemplateRequest
+	33,  // 166: openshell.v1.OpenShell.ListSandboxTemplates:input_type -> openshell.v1.ListSandboxTemplatesRequest
+	34,  // 167: openshell.v1.OpenShell.DeleteSandboxTemplate:input_type -> openshell.v1.DeleteSandboxTemplateRequest
+	40,  // 168: openshell.v1.OpenShell.ListSandboxProviders:input_type -> openshell.v1.ListSandboxProvidersRequest
+	41,  // 169: openshell.v1.OpenShell.AttachSandboxProvider:input_type -> openshell.v1.AttachSandboxProviderRequest
+	42,  // 170: openshell.v1.OpenShell.DetachSandboxProvider:input_type -> openshell.v1.DetachSandboxProviderRequest
+	43,  // 171: openshell.v1.OpenShell.DeleteSandbox:input_type -> openshell.v1.DeleteSandboxRequest
+	44,  // 172: openshell.v1.OpenShell.StopSandbox:input_type -> openshell.v1.StopSandboxRequest
+	45,  // 173: openshell.v1.OpenShell.StartSandbox:input_type -> openshell.v1.StartSandboxRequest
+	52,  // 174: openshell.v1.OpenShell.CreateSshSession:input_type -> openshell.v1.CreateSshSessionRequest
+	54,  // 175: openshell.v1.OpenShell.ExposeService:input_type -> openshell.v1.ExposeServiceRequest
+	55,  // 176: openshell.v1.OpenShell.GetService:input_type -> openshell.v1.GetServiceRequest
+	56,  // 177: openshell.v1.OpenShell.ListServices:input_type -> openshell.v1.ListServicesRequest
+	58,  // 178: openshell.v1.OpenShell.DeleteService:input_type -> openshell.v1.DeleteServiceRequest
+	62,  // 179: openshell.v1.OpenShell.RevokeSshSession:input_type -> openshell.v1.RevokeSshSessionRequest
+	64,  // 180: openshell.v1.OpenShell.ExecSandbox:input_type -> openshell.v1.ExecSandboxRequest
+	70,  // 181: openshell.v1.OpenShell.ForwardTcp:input_type -> openshell.v1.TcpForwardFrame
+	71,  // 182: openshell.v1.OpenShell.ExecSandboxInteractive:input_type -> openshell.v1.ExecSandboxInput
+	78,  // 183: openshell.v1.OpenShell.CreateProvider:input_type -> openshell.v1.CreateProviderRequest
+	79,  // 184: openshell.v1.OpenShell.GetProvider:input_type -> openshell.v1.GetProviderRequest
+	80,  // 185: openshell.v1.OpenShell.ListProviders:input_type -> openshell.v1.ListProvidersRequest
+	85,  // 186: openshell.v1.OpenShell.ListProviderProfiles:input_type -> openshell.v1.ListProviderProfilesRequest
+	86,  // 187: openshell.v1.OpenShell.GetProviderProfile:input_type -> openshell.v1.GetProviderProfileRequest
+	110, // 188: openshell.v1.OpenShell.ImportProviderProfiles:input_type -> openshell.v1.ImportProviderProfilesRequest
+	112, // 189: openshell.v1.OpenShell.UpdateProviderProfiles:input_type -> openshell.v1.UpdateProviderProfilesRequest
+	114, // 190: openshell.v1.OpenShell.LintProviderProfiles:input_type -> openshell.v1.LintProviderProfilesRequest
+	81,  // 191: openshell.v1.OpenShell.UpdateProvider:input_type -> openshell.v1.UpdateProviderRequest
+	98,  // 192: openshell.v1.OpenShell.GetProviderRefreshStatus:input_type -> openshell.v1.GetProviderRefreshStatusRequest
+	100, // 193: openshell.v1.OpenShell.ConfigureProviderRefresh:input_type -> openshell.v1.ConfigureProviderRefreshRequest
+	102, // 194: openshell.v1.OpenShell.RotateProviderCredential:input_type -> openshell.v1.RotateProviderCredentialRequest
+	104, // 195: openshell.v1.OpenShell.DeleteProviderRefresh:input_type -> openshell.v1.DeleteProviderRefreshRequest
+	82,  // 196: openshell.v1.OpenShell.DeleteProvider:input_type -> openshell.v1.DeleteProviderRequest
+	117, // 197: openshell.v1.OpenShell.DeleteProviderProfile:input_type -> openshell.v1.DeleteProviderProfileRequest
+	235, // 198: openshell.v1.OpenShell.GetSandboxConfig:input_type -> openshell.sandbox.v1.GetSandboxConfigRequest
+	236, // 199: openshell.v1.OpenShell.GetGatewayConfig:input_type -> openshell.sandbox.v1.GetGatewayConfigRequest
+	123, // 200: openshell.v1.OpenShell.UpdateConfig:input_type -> openshell.v1.UpdateConfigRequest
+	132, // 201: openshell.v1.OpenShell.GetSandboxPolicyStatus:input_type -> openshell.v1.GetSandboxPolicyStatusRequest
+	134, // 202: openshell.v1.OpenShell.ListSandboxPolicies:input_type -> openshell.v1.ListSandboxPoliciesRequest
+	136, // 203: openshell.v1.OpenShell.ReportPolicyStatus:input_type -> openshell.v1.ReportPolicyStatusRequest
+	119, // 204: openshell.v1.OpenShell.GetSandboxProviderEnvironment:input_type -> openshell.v1.GetSandboxProviderEnvironmentRequest
+	139, // 205: openshell.v1.OpenShell.GetSandboxLogs:input_type -> openshell.v1.GetSandboxLogsRequest
+	140, // 206: openshell.v1.OpenShell.PushSandboxLogs:input_type -> openshell.v1.PushSandboxLogsRequest
+	143, // 207: openshell.v1.OpenShell.ConnectSupervisor:input_type -> openshell.v1.SupervisorMessage
+	154, // 208: openshell.v1.OpenShell.RelayStream:input_type -> openshell.v1.RelayFrame
+	74,  // 209: openshell.v1.OpenShell.WatchSandbox:input_type -> openshell.v1.WatchSandboxRequest
+	163, // 210: openshell.v1.OpenShell.SubmitPolicyAnalysis:input_type -> openshell.v1.SubmitPolicyAnalysisRequest
+	165, // 211: openshell.v1.OpenShell.GetDraftPolicy:input_type -> openshell.v1.GetDraftPolicyRequest
+	167, // 212: openshell.v1.OpenShell.ApproveDraftChunk:input_type -> openshell.v1.ApproveDraftChunkRequest
+	169, // 213: openshell.v1.OpenShell.RejectDraftChunk:input_type -> openshell.v1.RejectDraftChunkRequest
+	171, // 214: openshell.v1.OpenShell.ApproveAllDraftChunks:input_type -> openshell.v1.ApproveAllDraftChunksRequest
+	173, // 215: openshell.v1.OpenShell.EditDraftChunk:input_type -> openshell.v1.EditDraftChunkRequest
+	175, // 216: openshell.v1.OpenShell.UndoDraftChunk:input_type -> openshell.v1.UndoDraftChunkRequest
+	177, // 217: openshell.v1.OpenShell.ClearDraftChunks:input_type -> openshell.v1.ClearDraftChunksRequest
+	179, // 218: openshell.v1.OpenShell.GetDraftHistory:input_type -> openshell.v1.GetDraftHistoryRequest
+	6,   // 219: openshell.v1.OpenShell.IssueSandboxToken:input_type -> openshell.v1.IssueSandboxTokenRequest
+	8,   // 220: openshell.v1.OpenShell.RefreshSandboxToken:input_type -> openshell.v1.RefreshSandboxTokenRequest
+	186, // 221: openshell.v1.OpenShell.CreateWorkspace:input_type -> openshell.v1.CreateWorkspaceRequest
+	188, // 222: openshell.v1.OpenShell.GetWorkspace:input_type -> openshell.v1.GetWorkspaceRequest
+	190, // 223: openshell.v1.OpenShell.ListWorkspaces:input_type -> openshell.v1.ListWorkspacesRequest
+	192, // 224: openshell.v1.OpenShell.DeleteWorkspace:input_type -> openshell.v1.DeleteWorkspaceRequest
+	195, // 225: openshell.v1.OpenShell.AddWorkspaceMember:input_type -> openshell.v1.AddWorkspaceMemberRequest
+	197, // 226: openshell.v1.OpenShell.RemoveWorkspaceMember:input_type -> openshell.v1.RemoveWorkspaceMemberRequest
+	199, // 227: openshell.v1.OpenShell.ListWorkspaceMembers:input_type -> openshell.v1.ListWorkspaceMembersRequest
+	11,  // 228: openshell.v1.OpenShell.Health:output_type -> openshell.v1.HealthResponse
+	13,  // 229: openshell.v1.OpenShell.GetCurrentUser:output_type -> openshell.v1.GetCurrentUserResponse
+	15,  // 230: openshell.v1.OpenShell.GetGatewayInfo:output_type -> openshell.v1.GetGatewayInfoResponse
+	46,  // 231: openshell.v1.OpenShell.CreateSandbox:output_type -> openshell.v1.SandboxResponse
+	46,  // 232: openshell.v1.OpenShell.GetSandbox:output_type -> openshell.v1.SandboxResponse
+	47,  // 233: openshell.v1.OpenShell.ListSandboxes:output_type -> openshell.v1.ListSandboxesResponse
+	35,  // 234: openshell.v1.OpenShell.CreateSandboxTemplate:output_type -> openshell.v1.SandboxTemplateResponse
+	35,  // 235: openshell.v1.OpenShell.GetSandboxTemplate:output_type -> openshell.v1.SandboxTemplateResponse
+	36,  // 236: openshell.v1.OpenShell.ListSandboxTemplates:output_type -> openshell.v1.ListSandboxTemplatesResponse
+	37,  // 237: openshell.v1.OpenShell.DeleteSandboxTemplate:output_type -> openshell.v1.DeleteSandboxTemplateResponse
+	48,  // 238: openshell.v1.OpenShell.ListSandboxProviders:output_type -> openshell.v1.ListSandboxProvidersResponse
+	49,  // 239: openshell.v1.OpenShell.AttachSandboxProvider:output_type -> openshell.v1.AttachSandboxProviderResponse
+	50,  // 240: openshell.v1.OpenShell.DetachSandboxProvider:output_type -> openshell.v1.DetachSandboxProviderResponse
+	51,  // 241: openshell.v1.OpenShell.DeleteSandbox:output_type -> openshell.v1.DeleteSandboxResponse
+	46,  // 242: openshell.v1.OpenShell.StopSandbox:output_type -> openshell.v1.SandboxResponse
+	46,  // 243: openshell.v1.OpenShell.StartSandbox:output_type -> openshell.v1.SandboxResponse
+	53,  // 244: openshell.v1.OpenShell.CreateSshSession:output_type -> openshell.v1.CreateSshSessionResponse
+	61,  // 245: openshell.v1.OpenShell.ExposeService:output_type -> openshell.v1.ServiceEndpointResponse
+	61,  // 246: openshell.v1.OpenShell.GetService:output_type -> openshell.v1.ServiceEndpointResponse
+	57,  // 247: openshell.v1.OpenShell.ListServices:output_type -> openshell.v1.ListServicesResponse
+	59,  // 248: openshell.v1.OpenShell.DeleteService:output_type -> openshell.v1.DeleteServiceResponse
+	63,  // 249: openshell.v1.OpenShell.RevokeSshSession:output_type -> openshell.v1.RevokeSshSessionResponse
+	68,  // 250: openshell.v1.OpenShell.ExecSandbox:output_type -> openshell.v1.ExecSandboxEvent
+	70,  // 251: openshell.v1.OpenShell.ForwardTcp:output_type -> openshell.v1.TcpForwardFrame
+	68,  // 252: openshell.v1.OpenShell.ExecSandboxInteractive:output_type -> openshell.v1.ExecSandboxEvent
+	83,  // 253: openshell.v1.OpenShell.CreateProvider:output_type -> openshell.v1.ProviderResponse
+	83,  // 254: openshell.v1.OpenShell.GetProvider:output_type -> openshell.v1.ProviderResponse
+	84,  // 255: openshell.v1.OpenShell.ListProviders:output_type -> openshell.v1.ListProvidersResponse
+	109, // 256: openshell.v1.OpenShell.ListProviderProfiles:output_type -> openshell.v1.ListProviderProfilesResponse
+	108, // 257: openshell.v1.OpenShell.GetProviderProfile:output_type -> openshell.v1.ProviderProfileResponse
+	111, // 258: openshell.v1.OpenShell.ImportProviderProfiles:output_type -> openshell.v1.ImportProviderProfilesResponse
+	113, // 259: openshell.v1.OpenShell.UpdateProviderProfiles:output_type -> openshell.v1.UpdateProviderProfilesResponse
+	115, // 260: openshell.v1.OpenShell.LintProviderProfiles:output_type -> openshell.v1.LintProviderProfilesResponse
+	83,  // 261: openshell.v1.OpenShell.UpdateProvider:output_type -> openshell.v1.ProviderResponse
+	99,  // 262: openshell.v1.OpenShell.GetProviderRefreshStatus:output_type -> openshell.v1.GetProviderRefreshStatusResponse
+	101, // 263: openshell.v1.OpenShell.ConfigureProviderRefresh:output_type -> openshell.v1.ConfigureProviderRefreshResponse
+	103, // 264: openshell.v1.OpenShell.RotateProviderCredential:output_type -> openshell.v1.RotateProviderCredentialResponse
+	105, // 265: openshell.v1.OpenShell.DeleteProviderRefresh:output_type -> openshell.v1.DeleteProviderRefreshResponse
+	116, // 266: openshell.v1.OpenShell.DeleteProvider:output_type -> openshell.v1.DeleteProviderResponse
+	118, // 267: openshell.v1.OpenShell.DeleteProviderProfile:output_type -> openshell.v1.DeleteProviderProfileResponse
+	237, // 268: openshell.v1.OpenShell.GetSandboxConfig:output_type -> openshell.sandbox.v1.GetSandboxConfigResponse
+	238, // 269: openshell.v1.OpenShell.GetGatewayConfig:output_type -> openshell.sandbox.v1.GetGatewayConfigResponse
+	131, // 270: openshell.v1.OpenShell.UpdateConfig:output_type -> openshell.v1.UpdateConfigResponse
+	133, // 271: openshell.v1.OpenShell.GetSandboxPolicyStatus:output_type -> openshell.v1.GetSandboxPolicyStatusResponse
+	135, // 272: openshell.v1.OpenShell.ListSandboxPolicies:output_type -> openshell.v1.ListSandboxPoliciesResponse
+	137, // 273: openshell.v1.OpenShell.ReportPolicyStatus:output_type -> openshell.v1.ReportPolicyStatusResponse
+	122, // 274: openshell.v1.OpenShell.GetSandboxProviderEnvironment:output_type -> openshell.v1.GetSandboxProviderEnvironmentResponse
+	142, // 275: openshell.v1.OpenShell.GetSandboxLogs:output_type -> openshell.v1.GetSandboxLogsResponse
+	141, // 276: openshell.v1.OpenShell.PushSandboxLogs:output_type -> openshell.v1.PushSandboxLogsResponse
+	144, // 277: openshell.v1.OpenShell.ConnectSupervisor:output_type -> openshell.v1.GatewayMessage
+	154, // 278: openshell.v1.OpenShell.RelayStream:output_type -> openshell.v1.RelayFrame
+	75,  // 279: openshell.v1.OpenShell.WatchSandbox:output_type -> openshell.v1.SandboxStreamEvent
+	164, // 280: openshell.v1.OpenShell.SubmitPolicyAnalysis:output_type -> openshell.v1.SubmitPolicyAnalysisResponse
+	166, // 281: openshell.v1.OpenShell.GetDraftPolicy:output_type -> openshell.v1.GetDraftPolicyResponse
+	168, // 282: openshell.v1.OpenShell.ApproveDraftChunk:output_type -> openshell.v1.ApproveDraftChunkResponse
+	170, // 283: openshell.v1.OpenShell.RejectDraftChunk:output_type -> openshell.v1.RejectDraftChunkResponse
+	172, // 284: openshell.v1.OpenShell.ApproveAllDraftChunks:output_type -> openshell.v1.ApproveAllDraftChunksResponse
+	174, // 285: openshell.v1.OpenShell.EditDraftChunk:output_type -> openshell.v1.EditDraftChunkResponse
+	176, // 286: openshell.v1.OpenShell.UndoDraftChunk:output_type -> openshell.v1.UndoDraftChunkResponse
+	178, // 287: openshell.v1.OpenShell.ClearDraftChunks:output_type -> openshell.v1.ClearDraftChunksResponse
+	181, // 288: openshell.v1.OpenShell.GetDraftHistory:output_type -> openshell.v1.GetDraftHistoryResponse
+	7,   // 289: openshell.v1.OpenShell.IssueSandboxToken:output_type -> openshell.v1.IssueSandboxTokenResponse
+	9,   // 290: openshell.v1.OpenShell.RefreshSandboxToken:output_type -> openshell.v1.RefreshSandboxTokenResponse
+	187, // 291: openshell.v1.OpenShell.CreateWorkspace:output_type -> openshell.v1.CreateWorkspaceResponse
+	189, // 292: openshell.v1.OpenShell.GetWorkspace:output_type -> openshell.v1.GetWorkspaceResponse
+	191, // 293: openshell.v1.OpenShell.ListWorkspaces:output_type -> openshell.v1.ListWorkspacesResponse
+	193, // 294: openshell.v1.OpenShell.DeleteWorkspace:output_type -> openshell.v1.DeleteWorkspaceResponse
+	196, // 295: openshell.v1.OpenShell.AddWorkspaceMember:output_type -> openshell.v1.AddWorkspaceMemberResponse
+	198, // 296: openshell.v1.OpenShell.RemoveWorkspaceMember:output_type -> openshell.v1.RemoveWorkspaceMemberResponse
+	200, // 297: openshell.v1.OpenShell.ListWorkspaceMembers:output_type -> openshell.v1.ListWorkspaceMembersResponse
+	228, // [228:298] is the sub-list for method output_type
+	158, // [158:228] is the sub-list for method input_type
+	158, // [158:158] is the sub-list for extension type_name
+	158, // [158:158] is the sub-list for extension extendee
+	0,   // [0:158] is the sub-list for field type_name
 }
 
 func init() { file_openshell_proto_init() }
@@ -14789,34 +15432,37 @@ func file_openshell_proto_init() {
 		return
 	}
 	file_openshell_proto_msgTypes[15].OneofWrappers = []any{}
-	file_openshell_proto_msgTypes[16].OneofWrappers = []any{}
-	file_openshell_proto_msgTypes[51].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[24].OneofWrappers = []any{
+		(*CreateSandboxRequest_Workload)(nil),
+		(*CreateSandboxRequest_WorkloadTemplateName)(nil),
+	}
+	file_openshell_proto_msgTypes[62].OneofWrappers = []any{
 		(*ExecSandboxEvent_Stdout)(nil),
 		(*ExecSandboxEvent_Stderr)(nil),
 		(*ExecSandboxEvent_Exit)(nil),
 	}
-	file_openshell_proto_msgTypes[52].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[63].OneofWrappers = []any{
 		(*TcpForwardInit_Ssh)(nil),
 		(*TcpForwardInit_Tcp)(nil),
 	}
-	file_openshell_proto_msgTypes[53].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[64].OneofWrappers = []any{
 		(*TcpForwardFrame_Init)(nil),
 		(*TcpForwardFrame_Data)(nil),
 	}
-	file_openshell_proto_msgTypes[54].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[65].OneofWrappers = []any{
 		(*ExecSandboxInput_Start)(nil),
 		(*ExecSandboxInput_Stdin)(nil),
 		(*ExecSandboxInput_Resize)(nil),
 	}
-	file_openshell_proto_msgTypes[58].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[69].OneofWrappers = []any{
 		(*SandboxStreamEvent_Sandbox)(nil),
 		(*SandboxStreamEvent_Log)(nil),
 		(*SandboxStreamEvent_Event)(nil),
 		(*SandboxStreamEvent_Warning)(nil),
 		(*SandboxStreamEvent_DraftPolicyUpdate)(nil),
 	}
-	file_openshell_proto_msgTypes[83].OneofWrappers = []any{}
-	file_openshell_proto_msgTypes[107].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[94].OneofWrappers = []any{}
+	file_openshell_proto_msgTypes[118].OneofWrappers = []any{
 		(*PolicyMergeOperation_AddRule)(nil),
 		(*PolicyMergeOperation_RemoveEndpoint)(nil),
 		(*PolicyMergeOperation_RemoveRule)(nil),
@@ -14824,36 +15470,36 @@ func file_openshell_proto_init() {
 		(*PolicyMergeOperation_AddAllowRules)(nil),
 		(*PolicyMergeOperation_RemoveBinary)(nil),
 	}
-	file_openshell_proto_msgTypes[126].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[137].OneofWrappers = []any{
 		(*SupervisorMessage_Hello)(nil),
 		(*SupervisorMessage_Heartbeat)(nil),
 		(*SupervisorMessage_RelayOpenResult)(nil),
 		(*SupervisorMessage_RelayClose)(nil),
 	}
-	file_openshell_proto_msgTypes[127].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[138].OneofWrappers = []any{
 		(*GatewayMessage_SessionAccepted)(nil),
 		(*GatewayMessage_SessionRejected)(nil),
 		(*GatewayMessage_Heartbeat)(nil),
 		(*GatewayMessage_RelayOpen)(nil),
 		(*GatewayMessage_RelayClose)(nil),
 	}
-	file_openshell_proto_msgTypes[133].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[144].OneofWrappers = []any{
 		(*RelayOpen_Ssh)(nil),
 		(*RelayOpen_Tcp)(nil),
 	}
-	file_openshell_proto_msgTypes[137].OneofWrappers = []any{
+	file_openshell_proto_msgTypes[148].OneofWrappers = []any{
 		(*RelayFrame_Init)(nil),
 		(*RelayFrame_Data)(nil),
 	}
-	file_openshell_proto_msgTypes[167].OneofWrappers = []any{}
-	file_openshell_proto_msgTypes[168].OneofWrappers = []any{}
+	file_openshell_proto_msgTypes[178].OneofWrappers = []any{}
+	file_openshell_proto_msgTypes[179].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_openshell_proto_rawDesc), len(file_openshell_proto_rawDesc)),
 			NumEnums:      6,
-			NumMessages:   209,
+			NumMessages:   217,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sdk/go/proto/openshellv1/openshell_grpc.pb.go
+++ b/sdk/go/proto/openshellv1/openshell_grpc.pb.go
@@ -29,6 +29,10 @@ const (
 	OpenShell_CreateSandbox_FullMethodName                 = "/openshell.v1.OpenShell/CreateSandbox"
 	OpenShell_GetSandbox_FullMethodName                    = "/openshell.v1.OpenShell/GetSandbox"
 	OpenShell_ListSandboxes_FullMethodName                 = "/openshell.v1.OpenShell/ListSandboxes"
+	OpenShell_CreateSandboxTemplate_FullMethodName         = "/openshell.v1.OpenShell/CreateSandboxTemplate"
+	OpenShell_GetSandboxTemplate_FullMethodName            = "/openshell.v1.OpenShell/GetSandboxTemplate"
+	OpenShell_ListSandboxTemplates_FullMethodName          = "/openshell.v1.OpenShell/ListSandboxTemplates"
+	OpenShell_DeleteSandboxTemplate_FullMethodName         = "/openshell.v1.OpenShell/DeleteSandboxTemplate"
 	OpenShell_ListSandboxProviders_FullMethodName          = "/openshell.v1.OpenShell/ListSandboxProviders"
 	OpenShell_AttachSandboxProvider_FullMethodName         = "/openshell.v1.OpenShell/AttachSandboxProvider"
 	OpenShell_DetachSandboxProvider_FullMethodName         = "/openshell.v1.OpenShell/DetachSandboxProvider"
@@ -116,6 +120,14 @@ type OpenShellClient interface {
 	GetSandbox(ctx context.Context, in *GetSandboxRequest, opts ...grpc.CallOption) (*SandboxResponse, error)
 	// List sandboxes.
 	ListSandboxes(ctx context.Context, in *ListSandboxesRequest, opts ...grpc.CallOption) (*ListSandboxesResponse, error)
+	// Create a reusable sandbox workload template.
+	CreateSandboxTemplate(ctx context.Context, in *CreateSandboxTemplateRequest, opts ...grpc.CallOption) (*SandboxTemplateResponse, error)
+	// Fetch a sandbox workload template by name.
+	GetSandboxTemplate(ctx context.Context, in *GetSandboxTemplateRequest, opts ...grpc.CallOption) (*SandboxTemplateResponse, error)
+	// List sandbox workload templates.
+	ListSandboxTemplates(ctx context.Context, in *ListSandboxTemplatesRequest, opts ...grpc.CallOption) (*ListSandboxTemplatesResponse, error)
+	// Delete a sandbox workload template by name.
+	DeleteSandboxTemplate(ctx context.Context, in *DeleteSandboxTemplateRequest, opts ...grpc.CallOption) (*DeleteSandboxTemplateResponse, error)
 	// List provider records attached to a sandbox.
 	ListSandboxProviders(ctx context.Context, in *ListSandboxProvidersRequest, opts ...grpc.CallOption) (*ListSandboxProvidersResponse, error)
 	// Attach a provider record to an existing sandbox.
@@ -339,6 +351,46 @@ func (c *openShellClient) ListSandboxes(ctx context.Context, in *ListSandboxesRe
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListSandboxesResponse)
 	err := c.cc.Invoke(ctx, OpenShell_ListSandboxes_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *openShellClient) CreateSandboxTemplate(ctx context.Context, in *CreateSandboxTemplateRequest, opts ...grpc.CallOption) (*SandboxTemplateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SandboxTemplateResponse)
+	err := c.cc.Invoke(ctx, OpenShell_CreateSandboxTemplate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *openShellClient) GetSandboxTemplate(ctx context.Context, in *GetSandboxTemplateRequest, opts ...grpc.CallOption) (*SandboxTemplateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SandboxTemplateResponse)
+	err := c.cc.Invoke(ctx, OpenShell_GetSandboxTemplate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *openShellClient) ListSandboxTemplates(ctx context.Context, in *ListSandboxTemplatesRequest, opts ...grpc.CallOption) (*ListSandboxTemplatesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListSandboxTemplatesResponse)
+	err := c.cc.Invoke(ctx, OpenShell_ListSandboxTemplates_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *openShellClient) DeleteSandboxTemplate(ctx context.Context, in *DeleteSandboxTemplateRequest, opts ...grpc.CallOption) (*DeleteSandboxTemplateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteSandboxTemplateResponse)
+	err := c.cc.Invoke(ctx, OpenShell_DeleteSandboxTemplate_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1003,6 +1055,14 @@ type OpenShellServer interface {
 	GetSandbox(context.Context, *GetSandboxRequest) (*SandboxResponse, error)
 	// List sandboxes.
 	ListSandboxes(context.Context, *ListSandboxesRequest) (*ListSandboxesResponse, error)
+	// Create a reusable sandbox workload template.
+	CreateSandboxTemplate(context.Context, *CreateSandboxTemplateRequest) (*SandboxTemplateResponse, error)
+	// Fetch a sandbox workload template by name.
+	GetSandboxTemplate(context.Context, *GetSandboxTemplateRequest) (*SandboxTemplateResponse, error)
+	// List sandbox workload templates.
+	ListSandboxTemplates(context.Context, *ListSandboxTemplatesRequest) (*ListSandboxTemplatesResponse, error)
+	// Delete a sandbox workload template by name.
+	DeleteSandboxTemplate(context.Context, *DeleteSandboxTemplateRequest) (*DeleteSandboxTemplateResponse, error)
 	// List provider records attached to a sandbox.
 	ListSandboxProviders(context.Context, *ListSandboxProvidersRequest) (*ListSandboxProvidersResponse, error)
 	// Attach a provider record to an existing sandbox.
@@ -1189,6 +1249,18 @@ func (UnimplementedOpenShellServer) GetSandbox(context.Context, *GetSandboxReque
 }
 func (UnimplementedOpenShellServer) ListSandboxes(context.Context, *ListSandboxesRequest) (*ListSandboxesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListSandboxes not implemented")
+}
+func (UnimplementedOpenShellServer) CreateSandboxTemplate(context.Context, *CreateSandboxTemplateRequest) (*SandboxTemplateResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateSandboxTemplate not implemented")
+}
+func (UnimplementedOpenShellServer) GetSandboxTemplate(context.Context, *GetSandboxTemplateRequest) (*SandboxTemplateResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSandboxTemplate not implemented")
+}
+func (UnimplementedOpenShellServer) ListSandboxTemplates(context.Context, *ListSandboxTemplatesRequest) (*ListSandboxTemplatesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListSandboxTemplates not implemented")
+}
+func (UnimplementedOpenShellServer) DeleteSandboxTemplate(context.Context, *DeleteSandboxTemplateRequest) (*DeleteSandboxTemplateResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteSandboxTemplate not implemented")
 }
 func (UnimplementedOpenShellServer) ListSandboxProviders(context.Context, *ListSandboxProvidersRequest) (*ListSandboxProvidersResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListSandboxProviders not implemented")
@@ -1495,6 +1567,78 @@ func _OpenShell_ListSandboxes_Handler(srv interface{}, ctx context.Context, dec 
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(OpenShellServer).ListSandboxes(ctx, req.(*ListSandboxesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _OpenShell_CreateSandboxTemplate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateSandboxTemplateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OpenShellServer).CreateSandboxTemplate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OpenShell_CreateSandboxTemplate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OpenShellServer).CreateSandboxTemplate(ctx, req.(*CreateSandboxTemplateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _OpenShell_GetSandboxTemplate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSandboxTemplateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OpenShellServer).GetSandboxTemplate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OpenShell_GetSandboxTemplate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OpenShellServer).GetSandboxTemplate(ctx, req.(*GetSandboxTemplateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _OpenShell_ListSandboxTemplates_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListSandboxTemplatesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OpenShellServer).ListSandboxTemplates(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OpenShell_ListSandboxTemplates_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OpenShellServer).ListSandboxTemplates(ctx, req.(*ListSandboxTemplatesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _OpenShell_DeleteSandboxTemplate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteSandboxTemplateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OpenShellServer).DeleteSandboxTemplate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OpenShell_DeleteSandboxTemplate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OpenShellServer).DeleteSandboxTemplate(ctx, req.(*DeleteSandboxTemplateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2540,6 +2684,22 @@ var OpenShell_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListSandboxes",
 			Handler:    _OpenShell_ListSandboxes_Handler,
+		},
+		{
+			MethodName: "CreateSandboxTemplate",
+			Handler:    _OpenShell_CreateSandboxTemplate_Handler,
+		},
+		{
+			MethodName: "GetSandboxTemplate",
+			Handler:    _OpenShell_GetSandboxTemplate_Handler,
+		},
+		{
+			MethodName: "ListSandboxTemplates",
+			Handler:    _OpenShell_ListSandboxTemplates_Handler,
+		},
+		{
+			MethodName: "DeleteSandboxTemplate",
+			Handler:    _OpenShell_DeleteSandboxTemplate_Handler,
 		},
 		{
 			MethodName: "ListSandboxProviders",

--- a/sdk/typescript/src/client.test.ts
+++ b/sdk/typescript/src/client.test.ts
@@ -20,7 +20,7 @@ import {
   SCOPE_NAMES,
   STATUS_NAMES,
 } from './client.js';
-import { OpenShell, SandboxPhase, ServiceStatus } from './gen/openshell_pb.js';
+import { type CreateSandboxRequest, OpenShell, SandboxPhase, ServiceStatus } from './gen/openshell_pb.js';
 import { PolicySource, SettingScope } from './gen/sandbox_pb.js';
 
 function client(impl: Partial<ServiceImpl<typeof OpenShell>>): SandboxClient {
@@ -203,8 +203,8 @@ describe('exec / execStream', () => {
 });
 
 describe('create', () => {
-  it('sends the curated policy through spec.policy', async () => {
-    let created: { spec?: { policy?: { version?: number } } } = {};
+  it('sends the curated policy through the create request', async () => {
+    let created: CreateSandboxRequest | undefined;
     const sandbox = client({
       createSandbox: (req) => {
         created = req;
@@ -212,17 +212,11 @@ describe('create', () => {
       },
     });
     await sandbox.create({ image: 'img', policy: { version: 1, networkPolicies: {} } });
-    expect(created.spec?.policy?.version).toBe(1);
+    expect(created?.policy?.version).toBe(1);
   });
 
-  it('rawSpec reaches an ungated field and overrides a curated one', async () => {
-    let created: {
-      spec?: {
-        logLevel?: string;
-        template?: { image?: string };
-        providers?: string[];
-      };
-    } = {};
+  it('rawCreateRequest reaches ungated fields and overrides curated ones', async () => {
+    let created: CreateSandboxRequest | undefined;
     const sandbox = client({
       createSandbox: (req) => {
         created = req;
@@ -232,14 +226,23 @@ describe('create', () => {
     await sandbox.create({
       image: 'curated-image',
       providers: ['claude'],
-      rawSpec: { logLevel: 'debug', template: { image: 'raw-image' } },
+      rawCreateRequest: {
+        annotations: { owner: 'sdk-test' },
+        workloadSource: {
+          case: 'workload',
+          value: { image: 'raw-image' },
+        },
+      },
     });
-    // Ungated field only reachable via rawSpec.
-    expect(created.spec?.logLevel).toBe('debug');
-    // rawSpec wins on a field the curated shape also sets.
-    expect(created.spec?.template?.image).toBe('raw-image');
-    // Curated fields rawSpec does not touch survive.
-    expect(created.spec?.providers).toEqual(['claude']);
+    // Ungated field only reachable via rawCreateRequest.
+    expect(created?.annotations?.owner).toBe('sdk-test');
+    // rawCreateRequest wins on a field the curated shape also sets.
+    expect(created?.workloadSource.case).toBe('workload');
+    expect(created?.workloadSource.case === 'workload' ? created.workloadSource.value.image : undefined).toBe(
+      'raw-image',
+    );
+    // Curated fields rawCreateRequest does not touch survive.
+    expect(created?.providers).toEqual(['claude']);
   });
 
   it('rejects gateway sandboxes missing required metadata', async () => {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -19,10 +19,10 @@ import { errorCode, fromConnect, SdkError } from './errors.js';
 import type { Provider } from './gen/datamodel_pb.js';
 import type { Sandbox, UpdateConfigResponse } from './gen/openshell_pb.js';
 import {
+  type CreateSandboxRequestSchema,
   type ExecSandboxInputSchema,
   OpenShell,
   SandboxPhase,
-  type SandboxSpecSchema,
   ServiceStatus,
   type TcpForwardFrameSchema,
 } from './gen/openshell_pb.js';
@@ -89,13 +89,11 @@ export interface SandboxSpec {
    */
   policy?: MessageInitShape<typeof SandboxPolicySchema>;
   /**
-   * Advanced escape hatch: the full generated proto spec. Curated fields build
-   * the base spec, then `rawSpec` shallow-overrides at the top spec level, so
-   * any field it sets wins. Use it to reach proto spec fields the curated shape
-   * does not surface (template runtime class, resource limits, log level, and
-   * future additions) without an SDK change.
+   * Advanced escape hatch: the full generated create request. Curated fields
+   * build the base request, then `rawCreateRequest` shallow-overrides at the
+   * top request level, so any field it sets wins.
    */
-  rawSpec?: MessageInitShape<typeof SandboxSpecSchema>;
+  rawCreateRequest?: MessageInitShape<typeof CreateSandboxRequestSchema>;
 }
 
 export interface SandboxRef {
@@ -551,24 +549,23 @@ export class SandboxClient {
 
   async create(spec: SandboxSpec): Promise<SandboxRef> {
     try {
-      // Curated fields build the base spec; rawSpec then shallow-overrides at
-      // the top spec level (Object.assign, so any field it sets wins). The
-      // runtime assign avoids the generated $typeName upgrading the literal and
-      // rejecting the curated `template: { image }` init shorthand.
-      const specInit: MessageInitShape<typeof SandboxSpecSchema> = {
-        environment: spec.environment ?? {},
-        providers: spec.providers ?? [],
-        template: spec.image ? { image: spec.image } : undefined,
-        resourceRequirements: spec.gpu ? { gpu: {} } : undefined,
-        policy: spec.policy,
-      };
-      if (spec.rawSpec) Object.assign(specInit, spec.rawSpec);
-
-      const resp = await this.grpc.createSandbox({
+      const createInit: MessageInitShape<typeof CreateSandboxRequestSchema> = {
         name: spec.name ?? '',
         labels: spec.labels ?? {},
-        spec: specInit,
-      });
+        workloadSource: {
+          case: 'workload',
+          value: {
+            image: spec.image ?? '',
+            environment: spec.environment ?? {},
+            resources: spec.gpu ? { gpuCount: 1 } : undefined,
+          },
+        },
+        providers: spec.providers ?? [],
+        policy: spec.policy,
+      };
+      if (spec.rawCreateRequest) Object.assign(createInit, spec.rawCreateRequest);
+
+      const resp = await this.grpc.createSandbox(createInit);
       return sandboxRef(resp.sandbox);
     } catch (e) {
       throw fromConnect(e);


### PR DESCRIPTION
## Summary
Introduce workspace-scoped reusable sandbox templates and move driver-specific sandbox configuration behind those named templates. Direct sandbox creates now use a portable workload shape, while templates can  own shared image, environment, resources, driver config, and startup service objectives.

Note: this is a breaking change!

```
openshell sandbox template create my-template --cpu 0.2 
openshell sandbox create my-sandbox --template my-template
```

## Related Issue
Fixes https://github.com/NVIDIA/OpenShell/issues/2680

## Changes
- Add sandbox template API methods for create, get, list, and delete, with workspace authorization and persistence.
- Reshape `CreateSandboxRequest` to accept either an inline `SandboxWorkloadConfig` or a `workload_template_name`, with policy and providers promoted to top-level request fields.
- Persist resolved sandbox workload, selected driver config, and template provenance on created sandboxes.
- Add `openshell sandbox template create|get|list|delete` CLI commands.
- Add `openshell sandbox create --template <name>` and reject conflicting inline workload flags such as `--from`, `--cpu`, `--memory`, `--gpu`, `--env`, and `--driver-config-json`.
- Move direct driver config from `sandbox create --driver-config-json` to template creation.
- Update Rust, Go, TypeScript, and Python SDK/client paths for the new create request shape and template-related types.
- Update docs for sandbox templates, driver-owned config, GPU behavior, and compute-driver examples.

## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
