### PR TITLE
fix(driver-podman): compile container spec on macOS

### DIFF
--- a/.github/workflows/branch-checks.yml
+++ b/.github/workflows/branch-checks.yml
@@ -199,6 +199,12 @@ jobs:
             -p openshell-sandbox \
             -p openshell-core \
             -p openshell-cli \
+            -p openshell-driver-db-credstore \
+            -p openshell-driver-docker \
+            -p openshell-driver-kubernetes \
+            -p openshell-driver-kubernetes-secrets \
+            -p openshell-driver-podman \
+            -p openshell-driver-vault \
             --all-targets \
             -- -D warnings
 

--- a/crates/openshell-driver-podman/src/container.rs
+++ b/crates/openshell-driver-podman/src/container.rs
@@ -14,7 +14,6 @@ use openshell_core::{driver_mounts, proto_struct};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashSet};
-#[cfg(target_os = "linux")]
 use std::path::Path;
 
 /// Returns `true` when `SELinux` is enabled (enforcing or permissive).


### PR DESCRIPTION
## Summary

Fix the macOS Podman driver compilation failure and extend the existing macOS Clippy guard to cover portable non-VM driver crates. This prevents the same cfg regression from reaching a release build.

## Related Issue

No issue required: localized CI coverage maintenance and an obvious compilation fix following a release-build regression.

Regression links:

- [Original release build: Build Gateway Binary (macOS)](https://github.com/NVIDIA/OpenShell/actions/runs/32080109769/job/95649384644)
- [First PR commit only: Rust lint (macOS)](https://github.com/NVIDIA/OpenShell/actions/runs/32129464913/job/95687235484)

## Changes

- Import `Path` unconditionally because it appears in an unconditional Podman container-spec function signature.
- Add the db-credstore, Docker, Kubernetes, Kubernetes Secrets, Podman, and Vault driver crates to macOS Clippy.
- Keep the VM driver excluded because its build script embeds runtime assets.

## Testing

- [ ] `mise run pre-commit` passes (not run: `mise` and `cargo` are unavailable in this shell)
- [ ] Unit tests added/updated (not run: `cargo` is unavailable in this shell)
- [x] Actions workflow YAML parses successfully
- [x] `git diff --check` passes
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)