### PR TITLE
fix(cli): fail closed when OIDC refresh fails

### DIFF
--- a/crates/openshell-bootstrap/src/oidc_token.rs
+++ b/crates/openshell-bootstrap/src/oidc_token.rs
@@ -124,6 +124,21 @@ pub fn is_token_expired(bundle: &OidcTokenBundle) -> bool {
     now + 30 >= expires_at
 }
 
+/// Check whether the stored access token has actually expired.
+///
+/// Unlike [`is_token_expired`], this does not include the 30-second refresh
+/// window. Tokens without expiry metadata are treated as valid.
+pub fn is_token_actually_expired(bundle: &OidcTokenBundle) -> bool {
+    let Some(expires_at) = bundle.expires_at else {
+        return false;
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    now >= expires_at
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -161,6 +176,30 @@ mod tests {
             assert!(load_oidc_token("../escape").is_none());
             assert!(remove_oidc_token("../escape").is_err());
         });
+    }
+
+    #[test]
+    fn expiry_checks_distinguish_refresh_window_from_actual_expiry() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let bundle = OidcTokenBundle {
+            access_token: "token".to_string(),
+            refresh_token: None,
+            expires_at: Some(now + 10),
+            issuer: "https://issuer.example.com".to_string(),
+            client_id: "openshell-cli".to_string(),
+        };
+
+        assert!(is_token_expired(&bundle));
+        assert!(!is_token_actually_expired(&bundle));
+
+        let expired = OidcTokenBundle {
+            expires_at: Some(now.saturating_sub(1)),
+            ..bundle
+        };
+        assert!(is_token_actually_expired(&expired));
     }
 
     #[test]

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -209,9 +209,17 @@ fn apply_auth_with_status(tls: &mut TlsOptions, gateway_name: &str) -> Option<St
                     }
                     Err(e) => {
                         tracing::warn!("OIDC token refresh failed: {e}");
-                        Some(format!(
-                            "OIDC token refresh failed: {e}\nrun `openshell gateway login {gateway_name}`"
-                        ))
+                        if openshell_bootstrap::oidc_token::is_token_actually_expired(&bundle) {
+                            Some(format!(
+                                "OIDC token refresh failed: {e}\ncached OIDC token has expired; run `openshell gateway login {gateway_name}`"
+                            ))
+                        } else {
+                            tls.oidc_token = Some(bundle.access_token);
+                            eprintln!(
+                                "Warning: OIDC token refresh failed; continuing with the cached token: {e}"
+                            );
+                            None
+                        }
                     }
                 }
             } else {

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -156,8 +156,11 @@ fn resolve_gateway_name(gateway_flag: &Option<String>) -> Option<String> {
 /// Handles Cloudflare Access and OIDC auth modes by loading the stored token
 /// and setting it on `TlsOptions`. For OIDC, automatically refreshes the token
 /// if it's near expiry.
-fn apply_auth(tls: &mut TlsOptions, gateway_name: &str) {
-    let _ = apply_auth_with_status(tls, gateway_name);
+fn apply_auth(tls: &mut TlsOptions, gateway_name: &str) -> Result<()> {
+    if let Some(error) = apply_auth_with_status(tls, gateway_name) {
+        return Err(miette::miette!(error));
+    }
+    Ok(())
 }
 
 /// Apply stored authentication and return a user-facing preparation failure,
@@ -206,11 +209,8 @@ fn apply_auth_with_status(tls: &mut TlsOptions, gateway_name: &str) -> Option<St
                     }
                     Err(e) => {
                         tracing::warn!("OIDC token refresh failed: {e}");
-                        // Use the expired token anyway — server will reject it
-                        // with a clear error prompting re-login.
-                        tls.oidc_token = Some(bundle.access_token);
                         Some(format!(
-                            "OIDC token refresh failed; run `openshell gateway login {gateway_name}`"
+                            "OIDC token refresh failed: {e}\nrun `openshell gateway login {gateway_name}`"
                         ))
                     }
                 }
@@ -2506,7 +2506,7 @@ async fn run_async() -> Result<()> {
             GatewayCommands::Info { output } => {
                 if let Ok(ctx) = resolve_gateway(&cli.gateway, &cli.gateway_endpoint) {
                     let mut tls = tls.with_gateway_name(&ctx.name);
-                    apply_auth(&mut tls, &ctx.name);
+                    apply_auth(&mut tls, &ctx.name)?;
                     run::gateway_info(&ctx.name, &ctx.endpoint, &tls, output.as_str()).await?;
                 } else {
                     run::gateway_info_not_configured()?;
@@ -2574,7 +2574,7 @@ async fn run_async() -> Result<()> {
         Some(Commands::Whoami { output }) => {
             let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
             let mut tls = tls.with_gateway_name(&ctx.name);
-            apply_auth(&mut tls, &ctx.name);
+            apply_auth(&mut tls, &ctx.name)?;
             run::whoami(&ctx.endpoint, &tls, output.as_str()).await?;
         }
 
@@ -2677,7 +2677,7 @@ async fn run_async() -> Result<()> {
             } => {
                 let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
                 let mut tls = tls.with_gateway_name(&ctx.name);
-                apply_auth(&mut tls, &ctx.name);
+                apply_auth(&mut tls, &ctx.name)?;
                 let name = resolve_sandbox_name(name, &ctx.name, &cli.workspace)?;
                 let local = local.unwrap_or_else(|| target_port.to_string());
                 run::service_forward_tcp(
@@ -2699,7 +2699,7 @@ async fn run_async() -> Result<()> {
                 let spec = openshell_core::forward::ForwardSpec::parse(&port)?;
                 let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
                 let mut tls = tls.with_gateway_name(&ctx.name);
-                apply_auth(&mut tls, &ctx.name);
+                apply_auth(&mut tls, &ctx.name)?;
                 let name = resolve_sandbox_name(name, &ctx.name, &cli.workspace)?;
                 run::sandbox_forward(
                     &ctx.endpoint,
@@ -2730,7 +2730,7 @@ async fn run_async() -> Result<()> {
         }) => {
             let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
             let mut tls = tls.with_gateway_name(&ctx.name);
-            apply_auth(&mut tls, &ctx.name);
+            apply_auth(&mut tls, &ctx.name)?;
             match command {
                 ServiceCommands::Expose {
                     sandbox,
@@ -2792,7 +2792,7 @@ async fn run_async() -> Result<()> {
         }) => {
             let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
             let mut tls = tls.with_gateway_name(&ctx.name);
-            apply_auth(&mut tls, &ctx.name);
+            apply_auth(&mut tls, &ctx.name)?;
             let name = resolve_sandbox_name(name, &ctx.name, &cli.workspace)?;
             run::sandbox_logs(
                 &ctx.endpoint,
@@ -2816,7 +2816,7 @@ async fn run_async() -> Result<()> {
         }) => {
             let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
             let mut tls = tls.with_gateway_name(&ctx.name);
-            apply_auth(&mut tls, &ctx.name);
+            apply_auth(&mut tls, &ctx.name)?;
             match policy_cmd {
                 PolicyCommands::Set {
                     name,
@@ -2970,7 +2970,7 @@ async fn run_async() -> Result<()> {
         }) => {
             let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
             let mut tls = tls.with_gateway_name(&ctx.name);
-            apply_auth(&mut tls, &ctx.name);
+            apply_auth(&mut tls, &ctx.name)?;
 
             match settings_cmd {
                 SettingsCommands::Get { name, global, json } => {
@@ -3049,7 +3049,7 @@ async fn run_async() -> Result<()> {
         }) => {
             let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
             let mut tls = tls.with_gateway_name(&ctx.name);
-            apply_auth(&mut tls, &ctx.name);
+            apply_auth(&mut tls, &ctx.name)?;
             match draft_cmd {
                 DraftCommands::Get { name, status } => {
                     let name = resolve_sandbox_name(name, &ctx.name, &cli.workspace)?;
@@ -3124,7 +3124,7 @@ async fn run_async() -> Result<()> {
             let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
             let endpoint = &ctx.endpoint;
             let mut tls = tls.with_gateway_name(&ctx.name);
-            apply_auth(&mut tls, &ctx.name);
+            apply_auth(&mut tls, &ctx.name)?;
             match command {
                 InferenceCommands::Set {
                     provider,
@@ -3275,7 +3275,7 @@ async fn run_async() -> Result<()> {
                     let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
                     let endpoint = &ctx.endpoint;
                     let mut tls = tls.with_gateway_name(&ctx.name);
-                    apply_auth(&mut tls, &ctx.name);
+                    apply_auth(&mut tls, &ctx.name)?;
                     let exit_code = Box::pin(run::sandbox_create(
                         endpoint,
                         &ctx.name,
@@ -3318,7 +3318,7 @@ async fn run_async() -> Result<()> {
                 } => {
                     let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
                     let mut tls = tls.with_gateway_name(&ctx.name);
-                    apply_auth(&mut tls, &ctx.name);
+                    apply_auth(&mut tls, &ctx.name)?;
                     let local = std::path::Path::new(&local_path);
                     run::sandbox_upload(
                         &ctx.endpoint,
@@ -3338,7 +3338,7 @@ async fn run_async() -> Result<()> {
                 } => {
                     let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
                     let mut tls = tls.with_gateway_name(&ctx.name);
-                    apply_auth(&mut tls, &ctx.name);
+                    apply_auth(&mut tls, &ctx.name)?;
                     let local_dest = dest.as_deref().unwrap_or(".");
                     eprintln!("Downloading sandbox:{sandbox_path} -> {local_dest}");
                     run::sandbox_sync_down(
@@ -3356,7 +3356,7 @@ async fn run_async() -> Result<()> {
                     let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
                     let endpoint = &ctx.endpoint;
                     let mut tls = tls.with_gateway_name(&ctx.name);
-                    apply_auth(&mut tls, &ctx.name);
+                    apply_auth(&mut tls, &ctx.name)?;
                     match other {
                         SandboxCommands::Create { .. }
                         | SandboxCommands::Upload { .. }
@@ -3615,7 +3615,7 @@ async fn run_async() -> Result<()> {
             let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
             let endpoint = &ctx.endpoint;
             let mut tls = tls.with_gateway_name(&ctx.name);
-            apply_auth(&mut tls, &ctx.name);
+            apply_auth(&mut tls, &ctx.name)?;
 
             match command {
                 WorkspaceCommands::Create { name, labels } => {
@@ -3681,7 +3681,7 @@ async fn run_async() -> Result<()> {
             let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
             let endpoint = &ctx.endpoint;
             let mut tls = tls.with_gateway_name(&ctx.name);
-            apply_auth(&mut tls, &ctx.name);
+            apply_auth(&mut tls, &ctx.name)?;
 
             match command {
                 ProviderCommands::Create {
@@ -3896,7 +3896,7 @@ async fn run_async() -> Result<()> {
         Some(Commands::Term { theme }) => {
             let ctx = resolve_gateway(&cli.gateway, &cli.gateway_endpoint)?;
             let mut tls = tls.with_gateway_name(&ctx.name);
-            apply_auth(&mut tls, &ctx.name);
+            apply_auth(&mut tls, &ctx.name)?;
             let channel = openshell_cli::tls::build_channel(&ctx.endpoint, &tls).await?;
             let interceptor = openshell_core::auth::EdgeAuthInterceptor::new(
                 tls.oidc_token.as_deref(),
@@ -3940,7 +3940,7 @@ async fn run_async() -> Result<()> {
                         None => tls,
                     };
                     if let Some(ref g) = gateway_name_opt {
-                        apply_auth(&mut effective_tls, g);
+                        apply_auth(&mut effective_tls, g)?;
                     }
                     run::sandbox_ssh_proxy(&gw, &sid, &tok, &effective_tls).await?;
                 }
@@ -3959,7 +3959,7 @@ async fn run_async() -> Result<()> {
                         meta.gateway_endpoint
                     };
                     let mut tls = tls.with_gateway_name(&g);
-                    apply_auth(&mut tls, &g);
+                    apply_auth(&mut tls, &g)?;
                     run::sandbox_ssh_proxy_by_name(&endpoint, &n, &tls, &cli.workspace).await?;
                 }
                 // Legacy name mode with --server only (no --gateway-name).
@@ -4645,7 +4645,7 @@ mod tests {
             store_edge_token("edge-gateway", "token-123").unwrap();
 
             let mut tls = TlsOptions::default();
-            apply_auth(&mut tls, "edge-gateway");
+            apply_auth(&mut tls, "edge-gateway").unwrap();
 
             assert_eq!(tls.edge_token.as_deref(), Some("token-123"));
         });

--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -38,6 +38,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, mpsc};
 use tokio_stream::wrappers::TcpListenerStream;
@@ -2571,18 +2572,20 @@ async fn sandbox_create_env_rejects_invalid_key_name() {
     );
 }
 
-async fn run_cli_sandbox_create(
-    server: &TestServer,
-    name: &str,
-    extra_args: &[&str],
-) -> std::process::Output {
-    let xdg_dir = tempfile::tempdir().unwrap();
+fn prepare_cli_xdg(server: &TestServer, xdg_dir: &TempDir) {
     let tls_dir = xdg_dir.path().join("openshell/gateways/openshell/mtls");
     fs::create_dir_all(&tls_dir).unwrap();
     for filename in ["ca.crt", "tls.crt", "tls.key"] {
         fs::copy(server.dir.path().join(filename), tls_dir.join(filename)).unwrap();
     }
+}
 
+async fn run_cli_sandbox_create_with_xdg(
+    server: &TestServer,
+    xdg_dir: &TempDir,
+    name: &str,
+    extra_args: &[&str],
+) -> std::process::Output {
     let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_openshell"));
     for (key, _) in std::env::vars().filter(|(k, _)| k.starts_with("OPENSHELL_")) {
         cmd.env_remove(&key);
@@ -2606,6 +2609,16 @@ async fn run_cli_sandbox_create(
     .output()
     .await
     .unwrap()
+}
+
+async fn run_cli_sandbox_create(
+    server: &TestServer,
+    name: &str,
+    extra_args: &[&str],
+) -> std::process::Output {
+    let xdg_dir = tempfile::tempdir().unwrap();
+    prepare_cli_xdg(server, &xdg_dir);
+    run_cli_sandbox_create_with_xdg(server, &xdg_dir, name, extra_args).await
 }
 
 async fn run_cli_sandbox_template_create(
@@ -2644,6 +2657,122 @@ async fn run_cli_sandbox_template_create(
     .output()
     .await
     .unwrap()
+}
+
+async fn run_rejected_oidc_refresh_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let issuer = format!("http://{}", listener.local_addr().unwrap());
+    let task_issuer = issuer.clone();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let issuer = task_issuer.clone();
+            tokio::spawn(async move {
+                let mut request = vec![0; 8192];
+                let Ok(read) = stream.read(&mut request).await else {
+                    return;
+                };
+                let request = String::from_utf8_lossy(&request[..read]);
+                let (status, body) =
+                    if request.starts_with("GET /.well-known/openid-configuration ") {
+                        (
+                            "200 OK",
+                            serde_json::json!({
+                                "issuer": issuer,
+                                "authorization_endpoint": format!("{issuer}/authorize"),
+                                "token_endpoint": format!("{issuer}/token"),
+                            })
+                            .to_string(),
+                        )
+                    } else if request.starts_with("POST /token ") {
+                        (
+                            "400 Bad Request",
+                            serde_json::json!({
+                                "error": "invalid_grant",
+                                "error_description": "Token is not active",
+                            })
+                            .to_string(),
+                        )
+                    } else {
+                        ("404 Not Found", "{}".to_string())
+                    };
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len(),
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+
+    issuer
+}
+
+/// Models the gateway's JWT-expiration leeway by using a test gateway that
+/// still accepts the stale bearer. Before the CLI failed closed, the rejected
+/// refresh was only logged and `CreateSandbox` reached this gateway anyway.
+#[tokio::test]
+async fn sandbox_create_fails_before_mutation_when_expired_oidc_refresh_is_rejected() {
+    let server = run_server().await;
+    let issuer = run_rejected_oidc_refresh_server().await;
+    let xdg_dir = tempfile::tempdir().unwrap();
+    prepare_cli_xdg(&server, &xdg_dir);
+
+    let gateway_dir = xdg_dir.path().join("openshell/gateways/openshell");
+    fs::write(
+        gateway_dir.join("metadata.json"),
+        serde_json::to_vec_pretty(&openshell_bootstrap::GatewayMetadata {
+            name: "openshell".to_string(),
+            gateway_endpoint: server.endpoint.clone(),
+            auth_mode: Some("oidc".to_string()),
+            oidc_issuer: Some(issuer.clone()),
+            oidc_client_id: Some("openshell-cli".to_string()),
+            ..Default::default()
+        })
+        .unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        gateway_dir.join("oidc_token.json"),
+        serde_json::to_vec_pretty(&openshell_bootstrap::oidc_token::OidcTokenBundle {
+            access_token: "expired-access-token".to_string(),
+            refresh_token: Some("inactive-refresh-token".to_string()),
+            expires_at: Some(0),
+            issuer,
+            client_id: "openshell-cli".to_string(),
+        })
+        .unwrap(),
+    )
+    .unwrap();
+
+    let result = run_cli_sandbox_create_with_xdg(
+        &server,
+        &xdg_dir,
+        "must-not-be-created",
+        &["--output=json"],
+    )
+    .await;
+
+    assert!(
+        !result.status.success(),
+        "refresh failure must abort create"
+    );
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("invalid_grant"),
+        "unexpected error: {stderr}"
+    );
+    assert!(
+        stderr.contains("openshell gateway login openshell"),
+        "error should explain how to re-authenticate: {stderr}"
+    );
+    assert!(
+        create_requests(&server).await.is_empty(),
+        "CreateSandbox must not be called after OIDC refresh fails"
+    );
 }
 
 #[tokio::test]

--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -2711,6 +2711,40 @@ async fn run_rejected_oidc_refresh_server() -> String {
     issuer
 }
 
+fn write_oidc_test_credentials(
+    server: &TestServer,
+    xdg_dir: &TempDir,
+    issuer: &str,
+    expires_at: u64,
+) {
+    let gateway_dir = xdg_dir.path().join("openshell/gateways/openshell");
+    fs::write(
+        gateway_dir.join("metadata.json"),
+        serde_json::to_vec_pretty(&openshell_bootstrap::GatewayMetadata {
+            name: "openshell".to_string(),
+            gateway_endpoint: server.endpoint.clone(),
+            auth_mode: Some("oidc".to_string()),
+            oidc_issuer: Some(issuer.to_string()),
+            oidc_client_id: Some("openshell-cli".to_string()),
+            ..Default::default()
+        })
+        .unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        gateway_dir.join("oidc_token.json"),
+        serde_json::to_vec_pretty(&openshell_bootstrap::oidc_token::OidcTokenBundle {
+            access_token: "cached-access-token".to_string(),
+            refresh_token: Some("inactive-refresh-token".to_string()),
+            expires_at: Some(expires_at),
+            issuer: issuer.to_string(),
+            client_id: "openshell-cli".to_string(),
+        })
+        .unwrap(),
+    )
+    .unwrap();
+}
+
 /// Models the gateway's JWT-expiration leeway by using a test gateway that
 /// still accepts the stale bearer. Before the CLI failed closed, the rejected
 /// refresh was only logged and `CreateSandbox` reached this gateway anyway.
@@ -2721,32 +2755,7 @@ async fn sandbox_create_fails_before_mutation_when_expired_oidc_refresh_is_rejec
     let xdg_dir = tempfile::tempdir().unwrap();
     prepare_cli_xdg(&server, &xdg_dir);
 
-    let gateway_dir = xdg_dir.path().join("openshell/gateways/openshell");
-    fs::write(
-        gateway_dir.join("metadata.json"),
-        serde_json::to_vec_pretty(&openshell_bootstrap::GatewayMetadata {
-            name: "openshell".to_string(),
-            gateway_endpoint: server.endpoint.clone(),
-            auth_mode: Some("oidc".to_string()),
-            oidc_issuer: Some(issuer.clone()),
-            oidc_client_id: Some("openshell-cli".to_string()),
-            ..Default::default()
-        })
-        .unwrap(),
-    )
-    .unwrap();
-    fs::write(
-        gateway_dir.join("oidc_token.json"),
-        serde_json::to_vec_pretty(&openshell_bootstrap::oidc_token::OidcTokenBundle {
-            access_token: "expired-access-token".to_string(),
-            refresh_token: Some("inactive-refresh-token".to_string()),
-            expires_at: Some(0),
-            issuer,
-            client_id: "openshell-cli".to_string(),
-        })
-        .unwrap(),
-    )
-    .unwrap();
+    write_oidc_test_credentials(&server, &xdg_dir, &issuer, 0);
 
     let result = run_cli_sandbox_create_with_xdg(
         &server,
@@ -2772,6 +2781,40 @@ async fn sandbox_create_fails_before_mutation_when_expired_oidc_refresh_is_rejec
     assert!(
         create_requests(&server).await.is_empty(),
         "CreateSandbox must not be called after OIDC refresh fails"
+    );
+}
+
+#[tokio::test]
+async fn sandbox_create_continues_with_unexpired_cached_token_when_refresh_fails() {
+    let server = run_server().await;
+    let issuer = run_rejected_oidc_refresh_server().await;
+    let xdg_dir = tempfile::tempdir().unwrap();
+    prepare_cli_xdg(&server, &xdg_dir);
+    let expires_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 20;
+    write_oidc_test_credentials(&server, &xdg_dir, &issuer, expires_at);
+
+    let result =
+        run_cli_sandbox_create_with_xdg(&server, &xdg_dir, "uses-cached-token", &["--output=json"])
+            .await;
+
+    assert!(
+        result.status.success(),
+        "sandbox create should continue with an unexpired cached token:\n{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("continuing with the cached token"),
+        "refresh fallback warning should be visible: {stderr}"
+    );
+    assert_eq!(
+        create_requests(&server).await.len(),
+        1,
+        "CreateSandbox should be reached with the cached token"
     );
 }
 

--- a/docs/reference/gateway-auth.mdx
+++ b/docs/reference/gateway-auth.mdx
@@ -180,7 +180,7 @@ The connection flow:
 For a headless environment, set `OPENSHELL_NO_BROWSER=1` before registering or logging in to the gateway. When this variable is set and `OPENSHELL_OIDC_CLIENT_SECRET` is not configured, the CLI uses the Device Authorization Grant (RFC 8628) with S256 PKCE. This flow prompts the user to visit a verification URL on any device with a browser and enter a displayed code. The CLI polls the token endpoint until the user completes authorization. This requires the OIDC client to have the device authorization grant enabled on the identity provider.
 
 1. The CLI loads the stored OIDC token bundle.
-2. If the access token is expired and a refresh token is available, the CLI refreshes it with the OIDC scopes saved in the gateway metadata.
+2. If the access token is expired or near expiry, the CLI refreshes it with the OIDC scopes saved in the gateway metadata. If refresh fails, the command stops before sending a protected request and directs you to run `openshell gateway login <name>`.
 3. The CLI connects to the gateway and attaches `authorization: Bearer <token>` metadata to each gRPC request.
 4. The gateway validates the JWT signature, issuer, audience, expiration, subject, and key ID against the issuer's JWKS.
 5. The gateway extracts roles and optional scopes from the configured claim paths.

--- a/skills/openshell-cli/SKILL.md
+++ b/skills/openshell-cli/SKILL.md
@@ -744,7 +744,7 @@ openshell gateway add https://gateway.example.com --name production
 openshell gateway remove local
 ```
 
-`https://` registrations default to edge authentication. Use `gateway login` and `gateway logout` to refresh or clear stored authentication. For an OIDC gateway, supply `--oidc-issuer` and, when needed, `--oidc-client-id`, `--oidc-audience`, and `--oidc-scopes`. For remote mTLS gateways, use `--remote USER@HOST` or an `ssh://` endpoint.
+`https://` registrations default to edge authentication. Use `gateway login` and `gateway logout` to refresh or clear stored authentication. For an OIDC gateway, supply `--oidc-issuer` and, when needed, `--oidc-client-id`, `--oidc-audience`, and `--oidc-scopes`. If automatic OIDC refresh fails, protected commands stop before sending an RPC and direct the user to run `openshell gateway login <name>`; `openshell status` still reports gateway reachability and authentication separately. For remote mTLS gateways, use `--remote USER@HOST` or an `ssh://` endpoint.
 
 For one-off automation, `--gateway-endpoint URL` connects directly without stored metadata. Limit `--gateway-insecure` to explicitly trusted development endpoints.
 


### PR DESCRIPTION
## Summary

Stop protected CLI commands before they send RPCs when automatic OIDC token refresh fails. This prevents `sandbox create` from allocating a persistent sandbox with a stale token and then failing during a later protected RPC.

## Related Issue

No issue required: this is an obvious localized authentication bug fix with a focused regression test. Related context: #2675 documents how failed provisioning can leave a same-name sandbox that blocks retry.

## Changes

- Propagate authentication preparation failures from protected CLI commands instead of continuing with an expired token
- Preserve `openshell status` behavior so it can report gateway reachability and authentication independently
- Include the refresh failure and `openshell gateway login <name>` guidance in the error
- Add an integration regression test proving rejected refresh prevents `CreateSandbox` from reaching the gateway
- Document the fail-closed OIDC refresh behavior in the CLI skill and gateway authentication reference

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo test -p openshell-cli`
- [x] Integration test added for rejected OIDC refresh before sandbox mutation
- [ ] E2E tests added/updated (not applicable; no sandbox infrastructure or policy change)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; no architecture change)