### PR TITLE
fix(podman): wait for container stop completion

### DIFF
--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -99,6 +99,10 @@ same resource. The gateway requires a fresh supervisor session before a
 starting sandbox returns to `Ready`; stale driver snapshots and supervisor
 sessions cannot promote a `Stopped` row.
 
+A driver stop operation does not complete while its backend still reports an
+in-progress stop. This prevents an immediate start from racing the previous
+run's delayed exit event and regressing the new run to `Error`.
+
 Persisted `Stopping` and `Starting` rows are retried at startup. Stable
 `Stopped` rows remain stopped. Docker and Podman retain the stopped container
 and attached storage, Kubernetes retains the Sandbox CR and PVC while scaling

--- a/crates/openshell-driver-podman/README.md
+++ b/crates/openshell-driver-podman/README.md
@@ -28,6 +28,10 @@ volume. Stopped managed containers remain visible through list and watch
 reconciliation. Delete remains responsible for removing the container,
 driver-owned secrets, and workspace volume.
 
+The stop call waits until Podman reports the container as stopped or exited.
+This keeps an immediate start from racing a rootless Podman stop that is still
+finishing after its API request returns.
+
 ## Architecture
 
 The Podman driver communicates with the Podman daemon over a Unix socket and

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -36,6 +36,9 @@ use std::time::Duration;
 use tracing::{debug, info, warn};
 use url::Url;
 
+const STOP_COMPLETION_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const STOP_COMPLETION_TIMEOUT_HEADROOM: Duration = Duration::from_secs(5);
+
 impl From<PodmanApiError> for ComputeDriverError {
     fn from(value: PodmanApiError) -> Self {
         match value {
@@ -914,22 +917,65 @@ impl PodmanComputeDriver {
         Ok(entries.into_iter().next())
     }
 
+    async fn wait_for_container_stopped(
+        &self,
+        sandbox_id: &str,
+        container_id: &str,
+    ) -> Result<(), ComputeDriverError> {
+        let timeout = Duration::from_secs(u64::from(self.config.stop_timeout_secs))
+            + STOP_COMPLETION_TIMEOUT_HEADROOM;
+        let deadline = tokio::time::Instant::now() + timeout;
+
+        loop {
+            let inspect = self
+                .client
+                .inspect_container(container_id)
+                .await
+                .map_err(ComputeDriverError::from)?;
+            if matches!(inspect.state.status.as_str(), "exited" | "stopped") {
+                return Ok(());
+            }
+
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return Err(ComputeDriverError::Message(format!(
+                    "container {container_id} for sandbox {sandbox_id} did not finish stopping within {timeout:?} (last state: {})",
+                    inspect.state.status,
+                )));
+            }
+            tokio::time::sleep(STOP_COMPLETION_POLL_INTERVAL.min(deadline - now)).await;
+        }
+    }
+
     /// Stop a sandbox container without deleting it.
     pub async fn stop_sandbox(&self, sandbox_id: &str) -> Result<(), ComputeDriverError> {
         let container = self
             .find_container(sandbox_id)
             .await?
             .ok_or(ComputeDriverError::NotFound)?;
+        let container_id = container.id;
+        if container.state == "stopping" {
+            return self
+                .wait_for_container_stopped(sandbox_id, &container_id)
+                .await;
+        }
         if container.state != "running" {
             return Ok(());
         }
-        let container_id = container.id;
         info!(sandbox_id = %sandbox_id, container = %container_id, "Stopping sandbox container");
 
         self.client
             .stop_container(&container_id, self.config.stop_timeout_secs)
             .await
-            .map_err(ComputeDriverError::from)
+            .map_err(ComputeDriverError::from)?;
+
+        // Libpod can acknowledge the stop request while the container still
+        // reports `stopping`, especially after escalating from SIGTERM to
+        // SIGKILL in rootless mode. Do not let a following start race that
+        // transition: its delayed die event would otherwise regress the new
+        // run from Starting to Error.
+        self.wait_for_container_stopped(sandbox_id, &container_id)
+            .await
     }
 
     /// Start a previously stopped sandbox container.
@@ -1437,6 +1483,10 @@ mod tests {
             vec![
                 StubResponse::new(StatusCode::OK, r#"[{"Id":"ctr-1","State":"running"}]"#),
                 StubResponse::new(StatusCode::NO_CONTENT, ""),
+                StubResponse::new(
+                    StatusCode::OK,
+                    r#"{"Id":"ctr-1","Name":"sandbox","State":{"Status":"exited","Running":false,"FinishedAt":"2026-08-12T16:39:13Z"},"Config":{}}"#,
+                ),
             ],
         );
         test_driver(stop_socket.clone())
@@ -1452,6 +1502,12 @@ mod tests {
                 "POST {}",
                 api_path("/libpod/containers/ctr-1/stop?timeout=10")
             )
+        );
+        assert_eq!(
+            stop_requests
+                .lock()
+                .expect("request log lock should not be poisoned")[2],
+            format!("GET {}", api_path("/libpod/containers/ctr-1/json"))
         );
 
         let (start_socket, start_requests, start_handle) = spawn_podman_stub(
@@ -1485,6 +1541,74 @@ mod tests {
 
         let _ = fs::remove_file(stop_socket);
         let _ = fs::remove_file(start_socket);
+    }
+
+    #[tokio::test]
+    async fn stop_waits_for_the_container_to_leave_stopping_state() {
+        let (socket, requests, handle) = spawn_podman_stub(
+            "lifecycle-stop-wait",
+            vec![
+                StubResponse::new(StatusCode::OK, r#"[{"Id":"ctr-1","State":"running"}]"#),
+                StubResponse::new(StatusCode::NO_CONTENT, ""),
+                StubResponse::new(
+                    StatusCode::OK,
+                    r#"{"Id":"ctr-1","Name":"sandbox","State":{"Status":"stopping","Running":true},"Config":{}}"#,
+                ),
+                StubResponse::new(
+                    StatusCode::OK,
+                    r#"{"Id":"ctr-1","Name":"sandbox","State":{"Status":"exited","Running":false,"FinishedAt":"2026-08-12T16:39:13Z"},"Config":{}}"#,
+                ),
+            ],
+        );
+
+        test_driver(socket.clone())
+            .stop_sandbox("sandbox-1")
+            .await
+            .expect("stop should wait for the terminal container state");
+        handle.await.expect("stop stub should finish");
+
+        let requests = requests
+            .lock()
+            .expect("request log lock should not be poisoned");
+        assert_eq!(requests.len(), 4);
+        assert_eq!(
+            requests[2],
+            format!("GET {}", api_path("/libpod/containers/ctr-1/json"))
+        );
+        assert_eq!(requests[3], requests[2]);
+
+        let _ = fs::remove_file(socket);
+    }
+
+    #[tokio::test]
+    async fn stop_retry_waits_for_an_existing_stopping_container() {
+        let (socket, requests, handle) = spawn_podman_stub(
+            "lifecycle-stop-retry",
+            vec![
+                StubResponse::new(StatusCode::OK, r#"[{"Id":"ctr-1","State":"stopping"}]"#),
+                StubResponse::new(
+                    StatusCode::OK,
+                    r#"{"Id":"ctr-1","Name":"sandbox","State":{"Status":"exited","Running":false,"FinishedAt":"2026-08-12T16:39:13Z"},"Config":{}}"#,
+                ),
+            ],
+        );
+
+        test_driver(socket.clone())
+            .stop_sandbox("sandbox-1")
+            .await
+            .expect("stop retry should wait for the terminal container state");
+        handle.await.expect("stop retry stub should finish");
+
+        let requests = requests
+            .lock()
+            .expect("request log lock should not be poisoned");
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[1],
+            format!("GET {}", api_path("/libpod/containers/ctr-1/json"))
+        );
+
+        let _ = fs::remove_file(socket);
     }
 
     #[test]

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -969,11 +969,11 @@ impl PodmanComputeDriver {
             .await
             .map_err(ComputeDriverError::from)?;
 
-        // Libpod can acknowledge the stop request while the container still
-        // reports `stopping`, especially after escalating from SIGTERM to
-        // SIGKILL in rootless mode. Do not let a following start race that
-        // transition: its delayed die event would otherwise regress the new
-        // run from Starting to Error.
+        // Podman can return from the stop request before inspect reports the
+        // container as exited. If start runs during that interval, the exit
+        // event from the previous run can arrive after the gateway has moved
+        // the same sandbox to Starting, causing it to regress to Error. Wait
+        // for the terminal container state before allowing a restart.
         self.wait_for_container_stopped(sandbox_id, &container_id)
             .await
     }


### PR DESCRIPTION
## Summary

Wait for Podman to report a sandbox container as fully stopped before allowing the stop operation to complete. This prevents an immediate restart from being regressed to `Error` by the previous container run's delayed exit event.

## Related Issue

No issue required: this is a localized fix for a confirmed race in the recently added Podman stop/start lifecycle.

## Changes

- Poll Podman inspect after a stop request until the container reaches `exited` or `stopped`.
- Apply the same wait when retrying a stop while Podman already reports `stopping`.
- Bound the wait by the configured stop timeout plus five seconds of completion headroom.
- Add regression coverage for both the initial stop and idempotent retry paths.
- Document the lifecycle completion invariant in the compute-runtime architecture and Podman driver README.

### Race

A representative failure followed this sequence:

1. `StopSandbox` asked rootless Podman to stop the container.
2. The supervisor did not exit before the 15-second grace period, so Podman escalated from `SIGTERM` to `SIGKILL`.
3. The stop API returned while the container still reported `stopping`.
4. The test immediately called `StartSandbox`. Since the prior exit had not completed, the existing event fence had no `FinishedAt` timestamp to record.
5. A delayed `die`/`stop` event from the previous run arrived after the new run entered `Starting`. The watcher reported exit code 137 and the gateway changed the sandbox from `Starting` to `Error`.

`StartSandbox` restarts the same logical sandbox and retained Podman container; it does not create a new sandbox. In compact form, the race is:

```text
sandbox cc95, run 1: stop -> delayed die event
sandbox cc95, run 2: start -> Starting
delayed run-1 event -> update sandbox cc95 -> Error
```

Waiting for a terminal Podman state closes the gap between steps 3 and 4. The existing timestamp fence can then identify any delayed event from the completed prior run.

### Failing jobs

- [First observed pre-merge failure on the stop/start feature PR](https://github.com/NVIDIA/OpenShell/actions/runs/31616561489/job/94184579250)
- [August 17 failure](https://github.com/NVIDIA/OpenShell/actions/runs/32074628920/job/95530150431)
- [August 17 failure on another SHA](https://github.com/NVIDIA/OpenShell/actions/runs/32063837846/job/95530476446)
- [August 18 failure](https://github.com/NVIDIA/OpenShell/actions/runs/32146294580/job/95745742631)
- [August 18 failure on another SHA](https://github.com/NVIDIA/OpenShell/actions/runs/32177392052/job/95858141999)

### Introduction context

The evidence points to the race being introduced with stop/start itself, rather than by a later regression:

- Stop/start was developed in [PR #2653](https://github.com/NVIDIA/OpenShell/pull/2653) on August 12 and merged on August 13 as `0f8fad23`.
- The `sandbox_stop_start_preserves_workspace` E2E test was added in that same PR, so there is no test history from before the feature existed.
- The first feature-branch E2E run failed with this exact test and `Starting -> Error` / exit-code-137 signature at 16:39 UTC on August 12, shortly after the initial implementation.
- An event-fencing mitigation was added to the feature branch later that day, but post-merge runs continued to reproduce the race because the stop API could return before `FinishedAt` was available.
- The lifecycle test and default Podman stop configuration have not materially changed since the feature merged.

The CI history establishes that the race existed in the initial implementation: the new test failed before merge and continued to fail afterward. It does not establish that the failure rate recently increased or that concurrent Branch E2E activity changed its frequency. The observed `SIGTERM`-to-`SIGKILL` path explains the race window, but the available evidence does not support a broader claim about why failures clustered over time.

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p openshell-driver-podman --all-targets -- -D warnings`
- [x] `cargo test -p openshell-driver-podman` (176 passed)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (existing `sandbox_stop_start_preserves_workspace` covers this path; rootless Podman execution is delegated to CI)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
