### PR TITLE
fix(cli): deduplicate plain provisioning progress

### DIFF
--- a/crates/openshell-cli/src/commands/common.rs
+++ b/crates/openshell-cli/src/commands/common.rs
@@ -444,9 +444,26 @@ pub fn noninteractive_active_label(step: ProvisioningStep) -> String {
     step.active_label().trim_end_matches('.').to_string()
 }
 
+#[derive(Default)]
+pub struct PlainProvisioningProgress {
+    last_completion: Option<(ProvisioningStep, String)>,
+}
+
+impl PlainProvisioningProgress {
+    fn should_print_completion(&mut self, step: ProvisioningStep, label: &str) -> bool {
+        let completion = (step, label.to_string());
+        if self.last_completion.as_ref() == Some(&completion) {
+            return false;
+        }
+        self.last_completion = Some(completion);
+        true
+    }
+}
+
 pub fn handle_platform_progress_event(
     event: &PlatformEvent,
     mut display: Option<&mut ProvisioningDisplay>,
+    plain_progress: &mut PlainProvisioningProgress,
     provision_start: Instant,
 ) -> bool {
     let completed_step = event
@@ -474,7 +491,7 @@ pub fn handle_platform_progress_event(
             .map_or_else(|| step.completed_label(), String::as_str);
         if let Some(d) = display.as_deref_mut() {
             d.complete_step_with_label(step, label);
-        } else {
+        } else if plain_progress.should_print_completion(step, label) {
             let ts = format_timestamp(provision_start.elapsed());
             println!("{} {}", ts.dimmed(), label);
         }
@@ -1057,6 +1074,17 @@ mod tests {
     use super::*;
 
     #[test]
+    fn plain_progress_suppresses_only_consecutive_identical_completions() {
+        let mut state = PlainProvisioningProgress::default();
+
+        assert!(state.should_print_completion(ProvisioningStep::RequestingSandbox, "allocated"));
+        assert!(!state.should_print_completion(ProvisioningStep::RequestingSandbox, "allocated"));
+        assert!(state.should_print_completion(ProvisioningStep::RequestingSandbox, "ready"));
+        assert!(state.should_print_completion(ProvisioningStep::PullingSandboxImage, "pulled"));
+        assert!(state.should_print_completion(ProvisioningStep::RequestingSandbox, "allocated"));
+    }
+
+    #[test]
     fn parse_duration_to_ms_parses_supported_units() {
         assert_eq!(parse_duration_to_ms("30s").expect("parse"), 30_000);
         assert_eq!(parse_duration_to_ms("5m").expect("parse"), 300_000);
@@ -1089,14 +1117,17 @@ mod tests {
         };
         let mut display = ProvisioningDisplay::new();
 
+        let mut plain_progress = PlainProvisioningProgress::default();
         assert!(handle_platform_progress_event(
             &event,
             Some(&mut display),
+            &mut plain_progress,
             Instant::now(),
         ));
         assert!(handle_platform_progress_event(
             &event,
             Some(&mut display),
+            &mut plain_progress,
             Instant::now(),
         ));
 

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -3,19 +3,19 @@
 
 //! CLI command implementations.
 
+use crate::commands::common::{
+    PlainProvisioningProgress, ProvisioningDisplay, ProvisioningStep,
+    confirm_global_setting_delete, confirm_global_setting_takeover, format_epoch_ms,
+    format_optional_epoch_ms, format_setting_value, format_timestamp, format_timestamp_ms,
+    handle_platform_progress_event, is_provisioning_progress_event, non_empty_or,
+    parse_cli_setting_value, parse_credential_expiry_pairs, parse_credential_pairs,
+    parse_duration_to_ms, phase_name, print_policy_merge_warnings, print_sandbox_header,
+    print_sandbox_policy, provisioning_timeout_message, ready_false_condition_message,
+    scrub_git_env, short_hash, truncate_display, truncate_status_field,
+};
 pub use crate::commands::common::{
     PolicyGetView, parse_credential_expiry_cli_value, parse_env_pairs, parse_key_value_pairs,
     parse_secret_material_env_pairs, warn_credential_env_vars,
-};
-use crate::commands::common::{
-    ProvisioningDisplay, ProvisioningStep, confirm_global_setting_delete,
-    confirm_global_setting_takeover, format_epoch_ms, format_optional_epoch_ms,
-    format_setting_value, format_timestamp, format_timestamp_ms, handle_platform_progress_event,
-    is_provisioning_progress_event, non_empty_or, parse_cli_setting_value,
-    parse_credential_expiry_pairs, parse_credential_pairs, parse_duration_to_ms, phase_name,
-    print_policy_merge_warnings, print_sandbox_header, print_sandbox_policy,
-    provisioning_timeout_message, ready_false_condition_message, scrub_git_env, short_hash,
-    truncate_display, truncate_status_field,
 };
 pub use crate::commands::gateway::{
     gateway_add, gateway_info, gateway_info_not_configured, gateway_list, gateway_login,
@@ -628,6 +628,7 @@ pub async fn sandbox_create(
 
     // Non-interactive mode: track start time for timestamps.
     let provision_start = Instant::now();
+    let mut plain_progress = PlainProvisioningProgress::default();
 
     // Don't use stop_on_terminal on the server — the Kubernetes CRD may
     // briefly report a stale Ready status before the controller reconciles
@@ -765,12 +766,18 @@ pub async fn sandbox_create(
                 // Silent mode suppresses all progress output; only update
                 // the deadline when applicable.
                 let handled = match &mut display {
-                    ProgressOutput::Interactive(d) => {
-                        handle_platform_progress_event(&ev, Some(d), provision_start)
-                    }
-                    ProgressOutput::Plain => {
-                        handle_platform_progress_event(&ev, None, provision_start)
-                    }
+                    ProgressOutput::Interactive(d) => handle_platform_progress_event(
+                        &ev,
+                        Some(d),
+                        &mut plain_progress,
+                        provision_start,
+                    ),
+                    ProgressOutput::Plain => handle_platform_progress_event(
+                        &ev,
+                        None,
+                        &mut plain_progress,
+                        provision_start,
+                    ),
                     ProgressOutput::Silent => false,
                 };
                 if handled {


### PR DESCRIPTION
## Summary

- track the last completion emitted by plain provisioning output
- suppress only consecutive duplicate step/label pairs
- preserve changed labels and later non-consecutive events

Fixes #2674

## Testing

- `cargo test -p openshell-cli`
- `cargo clippy -p openshell-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

AI assistance was used during investigation and implementation. I reviewed the code and independently validated the full test and lint results.