### PR TITLE
test(e2e): align detached sandbox assertions

### DIFF
--- a/e2e/rust/tests/oidc_pkce.rs
+++ b/e2e/rust/tests/oidc_pkce.rs
@@ -1388,6 +1388,7 @@ async fn assert_can_create_sandbox(session: &LoginSession, workspace: &str, sand
             "--name",
             sandbox_name,
             "--no-tty",
+            "--detach",
             "--",
             "sh",
             "-c",
@@ -1413,10 +1414,6 @@ async fn assert_can_create_sandbox(session: &LoginSession, workspace: &str, sand
     let cleanup = run_workspace_cli(session, workspace, &["sandbox", "delete", sandbox_name]).await;
 
     assert!(
-        create_output.contains(&marker),
-        "sandbox command output should contain {marker}:\n{create_output}"
-    );
-    assert!(
         list.status.success() && list_output.contains(sandbox_name),
         "created sandbox {sandbox_name} should appear in the sandbox list:\n{list_output}"
     );
@@ -1438,6 +1435,7 @@ async fn assert_can_delete_sandbox(session: &LoginSession, workspace: &str, sand
             "--name",
             sandbox_name,
             "--no-tty",
+            "--detach",
             "--",
             "sh",
             "-c",

--- a/e2e/rust/tests/workspace_namespace_managed.rs
+++ b/e2e/rust/tests/workspace_namespace_managed.rs
@@ -148,6 +148,7 @@ async fn managed_creates_namespace_with_labels() {
         &ws,
         "--name",
         "mgd-sb",
+        "--detach",
         "--",
         "sh",
         "-c",
@@ -157,10 +158,6 @@ async fn managed_creates_namespace_with_labels() {
     ])
     .await;
     assert!(ok, "sandbox create failed: {out}");
-    assert!(
-        out.contains("managed-ok"),
-        "sandbox output missing expected string: {out}"
-    );
 
     // Verify the managed namespace was created.
     let (ok, out) = kubectl(&["get", "namespace", &ns]).await;
@@ -460,6 +457,7 @@ async fn managed_workspace_delete_removes_namespace() {
         &ws,
         "--name",
         "del-sb",
+        "--detach",
         "--",
         "sh",
         "-c",
@@ -469,10 +467,6 @@ async fn managed_workspace_delete_removes_namespace() {
     ])
     .await;
     assert!(ok, "sandbox create failed: {out}");
-    assert!(
-        out.contains("del-ok"),
-        "sandbox output missing expected string: {out}"
-    );
 
     let (ok, _) = kubectl(&["get", "namespace", &ns]).await;
     assert!(
@@ -535,6 +529,7 @@ async fn managed_tls_secret_copied_to_namespace() {
         &ws,
         "--name",
         "tls-sb",
+        "--detach",
         "--",
         "sh",
         "-c",
@@ -544,10 +539,6 @@ async fn managed_tls_secret_copied_to_namespace() {
     ])
     .await;
     assert!(ok, "sandbox create failed: {out}");
-    assert!(
-        out.contains("tls-ok"),
-        "sandbox output missing expected string: {out}"
-    );
 
     let (ok, out) = kubectl(&["get", "secret", "openshell-client-tls", "-n", &ns]).await;
     assert!(

--- a/e2e/rust/tests/workspace_namespace_operator.rs
+++ b/e2e/rust/tests/workspace_namespace_operator.rs
@@ -162,7 +162,6 @@ async fn operator_sandbox_in_labeled_namespace() {
 
     // Poll until the gateway's namespace watcher discovers the labeled namespace
     // and sandbox creation succeeds (up to 30s).
-    let mut sandbox_out = String::new();
     let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         let (ok, out) = run_cli(&[
@@ -172,6 +171,7 @@ async fn operator_sandbox_in_labeled_namespace() {
             &ns,
             "--name",
             "op-sb",
+            "--detach",
             "--",
             "sh",
             "-c",
@@ -181,7 +181,6 @@ async fn operator_sandbox_in_labeled_namespace() {
         ])
         .await;
         if ok {
-            sandbox_out = out;
             break;
         }
         if tokio::time::Instant::now() >= deadline {
@@ -189,10 +188,6 @@ async fn operator_sandbox_in_labeled_namespace() {
         }
         tokio::time::sleep(Duration::from_secs(2)).await;
     }
-    assert!(
-        sandbox_out.contains("operator-ok"),
-        "sandbox output missing expected string: {sandbox_out}"
-    );
 
     // Verify the sandbox CR lives in the pre-provisioned namespace.
     let (ok, out) = kubectl(&["get", "sandbox.agents.x-k8s.io", "-n", &ns, "-o", "name"]).await;


### PR DESCRIPTION
## Summary

Fix the remaining detached-main E2E assertions exposed after #2854 merged. Persistent non-interactive sandbox creation detaches before canonical-main output is streamed, so these tests now validate the resources and authorization behavior they own instead of expecting main-process stdout from the create command.

## Related Issue

No issue required: localized test correction following #2854 and the failing Release Dev run https://github.com/NVIDIA/OpenShell/actions/runs/32429131484.

## Changes

- Make the affected OIDC and Kubernetes sandbox creates explicitly detached.
- Remove detached main-process stdout assertions from OIDC create authorization coverage.
- Remove the same latent stdout assertions from managed and operator Kubernetes workspace coverage.
- Preserve sandbox listing, Kubernetes resource, authorization, and cleanup assertions.

## Testing

- [x] mise run pre-commit passes
- [x] Unit tests added/updated (not applicable; E2E-only correction)
- [x] E2E tests added/updated
- [x] Docker OIDC PKCE can_create_sandbox tests: 4 passed, including the exact three failures from Release Dev run 32429131484
- [x] Kubernetes managed workspace suite with CI-equivalent k3d and Helm setup: 9 passed
- [x] Kubernetes operator workspace suite with CI-equivalent k3d and Helm setup: 5 passed
- [x] OIDC PKCE, Kubernetes managed, and Kubernetes operator E2E test binaries compile with their required features

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; test-only correction)