### PR TITLE
fix(sandbox): reject stale exit during restart

### DIFF
--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -1393,7 +1393,8 @@ impl ComputeRuntime {
                     let name = sandbox.object_name().to_string();
                     if matches!(phase, SandboxPhase::Stopping | SandboxPhase::Starting) {
                         let status = sandbox.status.get_or_insert_with(Default::default);
-                        status.main_process_instance_id.clear();
+                        // Retain the previous instance id as a tombstone until
+                        // the restarted supervisor registers its new id.
                         status.exit_code = None;
                     }
                     upsert_ready_condition(
@@ -2909,16 +2910,29 @@ impl ComputeRuntime {
             return Ok(());
         }
         if let Some(status) = existing.status.as_ref() {
-            if !status.main_process_instance_id.is_empty()
-                && status.main_process_instance_id != instance_id
-            {
-                tracing::warn!(
-                    sandbox_id,
-                    instance_id,
-                    active_instance_id = %status.main_process_instance_id,
-                    "ignoring stale main-process exit report"
-                );
-                return Ok(());
+            if !status.main_process_instance_id.is_empty() {
+                // While Starting, the stored id belongs to the stopped
+                // instance. A different id is the new process and its early
+                // exit must still be recorded.
+                if phase == SandboxPhase::Starting && status.main_process_instance_id == instance_id
+                {
+                    tracing::warn!(
+                        sandbox_id,
+                        instance_id,
+                        "ignoring main-process exit report from stopped instance while sandbox is starting"
+                    );
+                    return Ok(());
+                }
+                if phase != SandboxPhase::Starting && status.main_process_instance_id != instance_id
+                {
+                    tracing::warn!(
+                        sandbox_id,
+                        instance_id,
+                        active_instance_id = %status.main_process_instance_id,
+                        "ignoring stale main-process exit report"
+                    );
+                    return Ok(());
+                }
             }
             if let Some(current_exit_code) = status.exit_code {
                 if current_exit_code != exit_code {
@@ -5106,6 +5120,68 @@ mod tests {
             assert_eq!(stored.phase(), phase as i32);
             assert_eq!(stored.status.unwrap().exit_code, None);
         }
+    }
+
+    #[tokio::test]
+    async fn starting_uses_previous_main_process_instance_as_exit_tombstone() {
+        let runtime = test_runtime(Arc::new(TestDriver::default())).await;
+        let mut sandbox = sandbox_record("sb-1", "sandbox-a", SandboxPhase::Stopped);
+        sandbox.status = Some(SandboxStatus {
+            phase: SandboxPhase::Stopped as i32,
+            main_process_instance_id: "instance-old".into(),
+            exit_code: Some(143),
+            ..Default::default()
+        });
+        runtime.store.put_message(&sandbox).await.unwrap();
+        let stored = runtime
+            .store
+            .get_message::<Sandbox>("sb-1")
+            .await
+            .unwrap()
+            .unwrap();
+
+        let starting = runtime
+            .write_lifecycle_phase(
+                &stored,
+                SandboxPhase::Starting,
+                "Starting",
+                "Sandbox start requested",
+            )
+            .await
+            .unwrap();
+        let status = starting.status.as_ref().unwrap();
+        assert_eq!(status.main_process_instance_id, "instance-old");
+        assert_eq!(status.exit_code, None);
+
+        runtime
+            .main_process_exited("sb-1", "instance-old", 143)
+            .await
+            .unwrap();
+        let stored = runtime
+            .store
+            .get_message::<Sandbox>("sb-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.phase(), SandboxPhase::Starting as i32);
+        let status = stored.status.as_ref().unwrap();
+        assert_eq!(status.main_process_instance_id, "instance-old");
+        assert_eq!(status.exit_code, None);
+
+        runtime
+            .main_process_exited("sb-1", "instance-new", 1)
+            .await
+            .unwrap();
+        let stored = runtime
+            .store
+            .get_message::<Sandbox>("sb-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.phase(), SandboxPhase::Error as i32);
+        let status = stored.status.unwrap();
+        assert_eq!(status.main_process_instance_id, "instance-new");
+        assert_eq!(status.exit_code, Some(1));
     }
 
     fn ssh_session_record(id: &str, sandbox_id: &str) -> SshSession {


### PR DESCRIPTION
## Summary

Prevent a delayed canonical-process exit from the stopped sandbox instance from racing with restart and moving the sandbox from `Starting` to `Error`.

The Kubernetes v1beta1 combined E2E reproduced the same failure twice on the unpatched commit:

- https://github.com/NVIDIA/OpenShell/actions/runs/32434526234/job/96635981525?pr=2822
- https://github.com/NVIDIA/OpenShell/actions/runs/32434526234/job/96639911918?pr=2822

## Related Issue

No issue required: this is a localized lifecycle race with a focused regression test.

## Changes

- Preserve the previous main-process instance ID as a tombstone through stop/start transitions
- Ignore a matching exit report from the stopped instance while the sandbox is `Starting`
- Continue accepting an exit from a different instance so genuine failures of the new process remain terminal
- Add a regression test for both the stale-old and legitimate-new exit paths

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo test -p openshell-server --lib` passes (1,406 passed, 8 ignored)
- [x] Unit test added for the restart race
- [ ] E2E checks run in GitHub Actions

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)