### PR TITLE
fix(provider): isolate unbound static credentials

### DIFF
--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -2569,7 +2569,28 @@ pub(super) async fn handle_get_sandbox_provider_environment(
         )
         .await?;
 
-    if !supports_static_credential_bindings {
+    if supports_static_credential_bindings {
+        let unbound_static_keys = provider_environment
+            .static_credential_keys
+            .iter()
+            .filter(|key| {
+                !provider_environment
+                    .static_credential_bindings
+                    .contains_key(*key)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        for key in unbound_static_keys {
+            warn!(
+                sandbox_id = %sandbox_id,
+                key = %key,
+                "withholding unbound static provider credential from binding-capable supervisor"
+            );
+            provider_environment.environment.remove(&key);
+            provider_environment.credential_expires_at_ms.remove(&key);
+            provider_environment.static_credential_keys.remove(&key);
+        }
+    } else {
         for key in &provider_environment.static_credential_keys {
             provider_environment.environment.remove(key);
             provider_environment.credential_expires_at_ms.remove(key);
@@ -8703,6 +8724,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn provider_environment_withholds_unbound_static_credentials_independently() {
+        use openshell_core::proto::GetSandboxProviderEnvironmentRequest;
+
+        let state = test_server_state().await;
+        state
+            .store
+            .put_message(&test_provider("work-github", "github"))
+            .await
+            .unwrap();
+        let mut profileless_openai = test_provider("gateway-openai", "openai");
+        profileless_openai.credentials =
+            HashMap::from([("OPENAI_API_KEY".to_string(), "openai-secret".to_string())]);
+        state.store.put_message(&profileless_openai).await.unwrap();
+        state
+            .store
+            .put_message(&test_sandbox(
+                "sb-unbound-provider-env",
+                "unbound-provider-env",
+                test_policy_with_rule("sandbox_only", "sandbox.example.com"),
+                vec!["work-github".to_string(), "gateway-openai".to_string()],
+            ))
+            .await
+            .unwrap();
+
+        let response = handle_get_sandbox_provider_environment(
+            &state,
+            with_user(Request::new(GetSandboxProviderEnvironmentRequest {
+                sandbox_id: "sb-unbound-provider-env".to_string(),
+                supports_static_credential_bindings: true,
+            })),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+        assert!(!response.environment.contains_key("OPENAI_API_KEY"));
+        assert!(
+            !response
+                .static_credential_bindings
+                .contains_key("OPENAI_API_KEY")
+        );
+        assert_eq!(
+            response.environment.get("GITHUB_TOKEN"),
+            Some(&"ghp-test".to_string())
+        );
+        assert!(
+            response
+                .static_credential_bindings
+                .get("GITHUB_TOKEN")
+                .is_some_and(|binding| !binding.endpoints.is_empty())
+        );
+    }
+
+    #[tokio::test]
     async fn provider_environment_uses_policy_binding_for_endpointless_profile() {
         use openshell_core::proto::{
             GetSandboxConfigRequest, GetSandboxProviderEnvironmentRequest,
@@ -8995,15 +9070,15 @@ mod tests {
         .expect("mixed snapshot must be returned")
         .into_inner();
 
-        assert_eq!(
-            response.environment.get("INVALID_TOKEN"),
-            Some(&"static-secret".to_string())
+        assert!(
+            !response.environment.contains_key("INVALID_TOKEN"),
+            "an unbound static credential must be withheld before the supervisor snapshot"
         );
         assert!(
             !response
                 .static_credential_bindings
                 .contains_key("INVALID_TOKEN"),
-            "incomplete static metadata must reach the supervisor for fail-closed rejection"
+            "an unbound static credential must not emit incomplete binding metadata"
         );
         assert!(
             !response.dynamic_credentials.is_empty(),


### PR DESCRIPTION
## Summary

Withhold unbound static credentials at the gateway response boundary instead of sending incomplete binding metadata that makes a binding-capable supervisor reject every static credential in the snapshot.

## Related Issue

No issue required: this is a localized fail-closed bug in the static credential binding path. A static credential without a binding cannot be safely projected by a binding-capable supervisor; the bug is that sending that invalid key causes the supervisor to revoke unrelated, correctly bound credentials too.

Design context: [OpenShell #2510](https://github.com/NVIDIA/OpenShell/pull/2510) states that an endpointless profile without a policy binding contributes non-secret configuration while OpenShell withholds its static credential keys and binding metadata. Its [implementation comment](https://github.com/NVIDIA/OpenShell/blob/0120535efc20953eca565773c9c77f8eb34db0b1/crates/openshell-server/src/grpc/provider.rs#L1111-L1118) explains that sending invalid metadata would let one rejected key revoke unrelated credentials. The released implementation covers the endpointless-profile case but misses the profileless `None` branch; this PR applies the same independent-withholding rationale to that missed case without asserting that #2510 already approved this exact implementation.

## Changes

- Preserve provider resolution behavior and sanitize the completed environment only when the requesting supervisor advertises static-credential-binding support.
- Remove each unbound static key independently from the environment, expiry metadata, and static-key set before returning the snapshot.
- Retain bound static credentials and valid dynamic credentials when an unrelated static key is unbound.
- Preserve the existing legacy-supervisor behavior, which withholds all static credentials when binding metadata is unsupported.

## Testing

- [ ] `mise run pre-commit` passes (`mise` is unavailable in this environment)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (not applicable; this is covered at the provider-environment boundary)

Verification performed:

- `cargo fmt --check`
- `cargo clippy -p openshell-server --features bundled-z3 --lib -- -D warnings`
- `cargo test -p openshell-server --features bundled-z3 --lib` (1,408 passed, 0 failed, 7 ignored)
- GitHub Branch Checks on `3596078a`: Rust passed on both `linux-amd64-cpu8` and `linux-arm64-cpu8`; all 21 applicable checks succeeded.
- Regression coverage verifies that a profileless `OPENAI_API_KEY` is withheld while a bound `GITHUB_TOKEN` remains active, and that an unbound static key does not suppress an unrelated dynamic credential.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; no public contract or architecture change)
