### PR TITLE
test(e2e): promote portable CLI workflows

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -182,6 +182,8 @@ mise run e2e:cli-conformance
 The conformance task selects existing test targets explicitly. Driver suites
 enable the same profile when they run overlapping portable targets; the test
 implementations are shared instead of duplicated as driver-specific coverage.
+VM overlay and TLS-key permission assertions remain in the VM suite instead of
+the portable smoke workflow.
 
 Run the Podman-backed Rust CLI e2e suite:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -149,8 +149,8 @@ Suites:
 
 - Common suite (`--features e2e`) - driver-neutral CLI behavior, sandbox lifecycle, sync, port forwarding, policy, and provider tests.
 - CLI conformance (`--features e2e-cli-conformance`) - a curated portable CLI
-  baseline selected from existing E2E test targets. The initial profile contains
-  the gateway smoke workflow and remains additive to the regular E2E suites.
+  baseline selected from existing E2E test targets. The profile contains gateway
+  smoke, sandbox lifecycle, and sandbox label workflows.
 - Docker suite (`--features e2e-docker`) - common suite plus Docker-only coverage such as Dockerfile image builds, Docker preflight checks, and managed Docker gateway start.
 - Docker GPU suite (`--features e2e-docker-gpu`) - Docker suite plus GPU sandbox smoke coverage.
 - VM suite (`--features e2e-vm`) - runs e2e tests on a VM.
@@ -179,8 +179,9 @@ gateway:
 mise run e2e:cli-conformance
 ```
 
-The conformance task selects existing test targets explicitly. Adding a test
-to the profile does not remove it from the regular E2E suites.
+The conformance task selects existing test targets explicitly. Driver suites
+enable the same profile when they run overlapping portable targets; the test
+implementations are shared instead of duplicated as driver-specific coverage.
 
 Run the Podman-backed Rust CLI e2e suite:
 

--- a/e2e/rust/Cargo.toml
+++ b/e2e/rust/Cargo.toml
@@ -46,6 +46,21 @@ path = "tests/oidc_pkce.rs"
 required-features = ["e2e-oidc-pkce"]
 
 [[test]]
+name = "smoke"
+path = "tests/smoke.rs"
+required-features = ["e2e-cli-conformance"]
+
+[[test]]
+name = "sandbox_lifecycle"
+path = "tests/sandbox_lifecycle.rs"
+required-features = ["e2e-cli-conformance"]
+
+[[test]]
+name = "sandbox_labels"
+path = "tests/sandbox_labels.rs"
+required-features = ["e2e-cli-conformance"]
+
+[[test]]
 name = "custom_image"
 path = "tests/custom_image.rs"
 required-features = ["e2e-docker"]

--- a/e2e/rust/Cargo.toml
+++ b/e2e/rust/Cargo.toml
@@ -61,6 +61,11 @@ path = "tests/sandbox_labels.rs"
 required-features = ["e2e-cli-conformance"]
 
 [[test]]
+name = "vm_overlay"
+path = "tests/vm_overlay.rs"
+required-features = ["e2e-vm"]
+
+[[test]]
 name = "custom_image"
 path = "tests/custom_image.rs"
 required-features = ["e2e-docker"]

--- a/e2e/rust/e2e-docker.sh
+++ b/e2e/rust/e2e-docker.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 E2E_TEST="${OPENSHELL_E2E_DOCKER_TEST:-smoke}"
-E2E_FEATURES="${OPENSHELL_E2E_DOCKER_FEATURES:-e2e,e2e-docker}"
+E2E_FEATURES="${OPENSHELL_E2E_DOCKER_FEATURES:-e2e-docker,e2e-cli-conformance}"
 DEFAULT_WORKLOAD_MANIFEST="${ROOT}/e2e/gpu/images/.build/workloads.yaml"
 
 if [ "${E2E_TEST}" = "gpu" ] && [ -z "${OPENSHELL_E2E_WORKLOAD_MANIFEST:-}" ] && [ ! -f "${DEFAULT_WORKLOAD_MANIFEST}" ]; then

--- a/e2e/rust/e2e-kubernetes.sh
+++ b/e2e/rust/e2e-kubernetes.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-E2E_FEATURES="${OPENSHELL_E2E_KUBERNETES_FEATURES:-e2e,e2e-host-gateway,e2e-kubernetes}"
+E2E_FEATURES="${OPENSHELL_E2E_KUBERNETES_FEATURES:-e2e,e2e-cli-conformance,e2e-host-gateway,e2e-kubernetes}"
 
 # Docker and Podman build their local gateway and CLI together in the shared
 # gateway wrapper. Kubernetes consumes published gateway images, so only its

--- a/e2e/rust/e2e-podman.sh
+++ b/e2e/rust/e2e-podman.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 E2E_TEST="${OPENSHELL_E2E_PODMAN_TEST:-}"
-E2E_FEATURES="${OPENSHELL_E2E_PODMAN_FEATURES:-e2e-podman}"
+E2E_FEATURES="${OPENSHELL_E2E_PODMAN_FEATURES:-e2e-podman,e2e-cli-conformance}"
 DEFAULT_WORKLOAD_MANIFEST="${ROOT}/e2e/gpu/images/.build/workloads.yaml"
 
 if [ "${E2E_TEST}" = "gpu" ] && [ -z "${OPENSHELL_E2E_WORKLOAD_MANIFEST:-}" ] && [ ! -f "${DEFAULT_WORKLOAD_MANIFEST}" ]; then

--- a/e2e/rust/e2e-vm.sh
+++ b/e2e/rust/e2e-vm.sh
@@ -371,7 +371,6 @@ fi
 # The CLI uses the raw endpoint but still resolves matching metadata so it
 # can find the mTLS client bundle.
 
-export OPENSHELL_E2E_EXPECT_VM_OVERLAY=1
 export OPENSHELL_E2E_DRIVER="vm"
 export OPENSHELL_E2E_VM_STATE_DIR="${RUN_STATE_DIR}"
 e2e_export_gateway_restart_metadata \
@@ -405,5 +404,6 @@ if [ -n "${E2E_TEST_OVERRIDE}" ]; then
 else
   run_e2e_test smoke
   run_e2e_test host_gateway_alias
+  run_e2e_test vm_overlay
   run_e2e_test vm_gateway_start
 fi

--- a/e2e/rust/e2e-vm.sh
+++ b/e2e/rust/e2e-vm.sh
@@ -52,7 +52,7 @@ GATEWAY_BIN="${OPENSHELL_GATEWAY_BIN:-${ROOT}/target/debug/openshell-gateway}"
 DRIVER_BIN="${OPENSHELL_VM_DRIVER_BIN:-${ROOT}/target/debug/openshell-driver-vm}"
 CLI_BIN="${OPENSHELL_BIN:-${ROOT}/target/debug/openshell}"
 E2E_TEST_OVERRIDE="${OPENSHELL_E2E_VM_TEST:-}"
-E2E_FEATURES="${OPENSHELL_E2E_VM_FEATURES:-e2e-vm}"
+E2E_FEATURES="${OPENSHELL_E2E_VM_FEATURES:-e2e-vm,e2e-cli-conformance}"
 SANDBOX_IMAGE="${OPENSHELL_SANDBOX_IMAGE:-${COMMUNITY_SANDBOX_IMAGE:-ghcr.io/nvidia/openshell-community/sandboxes/base:latest}}"
 
 # The VM driver places `compute-driver.sock` under `[openshell.drivers.vm].state_dir`.

--- a/e2e/rust/tests/smoke.rs
+++ b/e2e/rust/tests/smoke.rs
@@ -68,10 +68,6 @@ async fn gateway_smoke() {
         sb.create_output,
     );
 
-    if std::env::var_os("OPENSHELL_E2E_EXPECT_VM_OVERLAY").is_some() {
-        assert_vm_overlay_root(&sb.name).await;
-    }
-
     // ── 3. Verify the sandbox appeared in the list ───────────────────
     let mut list_cmd = openshell_cmd();
     list_cmd
@@ -98,42 +94,4 @@ async fn gateway_smoke() {
 
     // ── 4. Cleanup ───────────────────────────────────────────────────
     sb.cleanup().await;
-}
-
-async fn assert_vm_overlay_root(sandbox_name: &str) {
-    let script = concat!(
-        "set -eu; ",
-        "test \"$(stat -f -c %T /)\" = \"overlayfs\"; ",
-        "printf \"overlay-write\\n\" > /sandbox/overlay-check; ",
-        "test \"$(cat /sandbox/overlay-check)\" = \"overlay-write\"; ",
-        "if [ -e /opt/openshell/tls/tls.key ]; then ",
-        "test \"$(stat -c %a /opt/openshell/tls/tls.key)\" = \"600\"; ",
-        "fi; ",
-        "echo vm-overlay-ok",
-    );
-
-    let mut exec_cmd = openshell_cmd();
-    exec_cmd
-        .args(["sandbox", "exec", "--name", sandbox_name, "--no-tty", "--"])
-        .arg("sh")
-        .arg("-lc")
-        .arg(script)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    let output = exec_cmd
-        .output()
-        .await
-        .expect("failed to run VM overlay assertion");
-    let combined = strip_ansi(&format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    ));
-
-    assert!(
-        output.status.success() && combined.contains("vm-overlay-ok"),
-        "VM overlay assertion failed (status {:?}):\n{combined}",
-        output.status.code(),
-    );
 }

--- a/e2e/rust/tests/vm_overlay.rs
+++ b/e2e/rust/tests/vm_overlay.rs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! VM-driver-specific assertions for the sandbox root filesystem.
+
+use std::process::Stdio;
+
+use openshell_e2e::harness::binary::openshell_cmd;
+use openshell_e2e::harness::output::strip_ansi;
+use openshell_e2e::harness::sandbox::SandboxGuard;
+
+#[tokio::test]
+async fn vm_overlay() {
+    let mut sandbox = SandboxGuard::create(&["--", "echo", "vm-sandbox-ready"])
+        .await
+        .expect("sandbox create should succeed");
+
+    let script = concat!(
+        "set -eu; ",
+        "test \"$(stat -f -c %T /)\" = \"overlayfs\"; ",
+        "printf \"overlay-write\\n\" > /sandbox/overlay-check; ",
+        "test \"$(cat /sandbox/overlay-check)\" = \"overlay-write\"; ",
+        "if [ -e /opt/openshell/tls/tls.key ]; then ",
+        "test \"$(stat -c %a /opt/openshell/tls/tls.key)\" = \"600\"; ",
+        "fi; ",
+        "echo vm-overlay-ok",
+    );
+
+    let mut exec_cmd = openshell_cmd();
+    exec_cmd
+        .args(["sandbox", "exec", "--name", &sandbox.name, "--no-tty", "--"])
+        .arg("sh")
+        .arg("-lc")
+        .arg(script)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let output = exec_cmd
+        .output()
+        .await
+        .expect("failed to run VM overlay assertion");
+    let combined = strip_ansi(&format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    ));
+    assert!(
+        output.status.success() && combined.contains("vm-overlay-ok"),
+        "VM overlay assertion failed (status {:?}):\n{combined}",
+        output.status.code(),
+    );
+
+    sandbox.cleanup().await;
+}

--- a/tasks/test.toml
+++ b/tasks/test.toml
@@ -83,13 +83,13 @@ hide = true
 ["e2e:rust"]
 description = "Run Rust CLI e2e tests against a Docker-backed gateway"
 run = [
-  "e2e/with-docker-gateway.sh cargo test --manifest-path e2e/rust/Cargo.toml --features e2e-docker",
+  "e2e/with-docker-gateway.sh cargo test --manifest-path e2e/rust/Cargo.toml --features e2e-docker,e2e-cli-conformance",
 ]
 
 ["e2e:cli-conformance"]
 description = "Run the portable CLI conformance baseline against a Docker-backed gateway"
 run = [
-  "e2e/with-docker-gateway.sh cargo test --manifest-path e2e/rust/Cargo.toml --features e2e-docker,e2e-cli-conformance --test smoke",
+  "e2e/with-docker-gateway.sh cargo test --manifest-path e2e/rust/Cargo.toml --features e2e-docker,e2e-cli-conformance --test smoke --test sandbox_lifecycle --test sandbox_labels",
 ]
 
 ["e2e:websocket-conformance"]


### PR DESCRIPTION
## Summary

Promote existing portable CLI workflows into the conformance profile instead of treating them as implicit common E2E coverage. The test implementations remain shared, while VM-only filesystem assertions move out of the portable smoke workflow.

This is stack 2/3 and is based on `codex/2183-cli-conformance-minimal`.

## Related Issue

- #2183
- Depends on the preceding CLI conformance PR
- Prototype/reference: #2182

## Changes

- classify `smoke`, `sandbox_lifecycle`, and `sandbox_labels` as CLI conformance targets
- enable the CLI conformance profile in Docker, Podman, Kubernetes, and VM E2E wrappers where those targets already run
- keep the canonical Docker E2E task running the promoted targets
- extract VM overlay and TLS-key permission assertions into the VM-specific `vm_overlay` target
- document the portable and driver-specific boundary

## Testing

- [x] locked compilation of smoke, lifecycle, labels, and VM overlay targets
- [x] Rust formatting checks
- [x] shell syntax checks for modified E2E wrappers
- [x] `git diff --check`
- [ ] live driver-backed CLI conformance runs
- [ ] `mise run pre-commit` (`mise` is unavailable in the current environment)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Portable test implementations are reused rather than duplicated
- [x] Driver-specific VM assertions remain outside conformance
- [x] Documentation updated
