### PR TITLE
fix(gateway)!: handle delayed Podman bridge listeners

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -117,10 +117,18 @@ jobs:
       rpm-release: ${{ needs.version.outputs.rpm_release }}
 
   fedora:
-    name: Fedora with Rootless Podman
+    name: Fedora with ${{ matrix.name }} Podman
     needs: [build-conformance, build-rpm]
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Rootless
+            configuration: podman-rootless
+          - name: Rootful
+            configuration: podman-rootful
     permissions:
       actions: read
       contents: read
@@ -154,8 +162,10 @@ jobs:
           name: openshell-conformance-x86_64-unknown-linux-musl
           path: conformance-input
 
-      - name: Run RPM gateway continuity conformance
+      - name: Run RPM gateway conformance
         shell: bash
+        env:
+          PODMAN_CONFIGURATION: ${{ matrix.configuration }}
         run: |
           set -euo pipefail
           chmod +x conformance-input/openshell-conformance
@@ -171,7 +181,7 @@ jobs:
 
           OPENSHELL_TEST_GUEST_CACHE_DISABLE=1 nix run .#test-guest -- \
             --distro fedora \
-            --with podman-rootless \
+            --with "${PODMAN_CONFIGURATION}" \
             --with selinux \
             --copy "${candidate_cli_package[0]}:/var/lib/openshell-test-guest/artifacts/openshell.rpm" \
             --copy "${candidate_gateway_package[0]}:/var/lib/openshell-test-guest/artifacts/openshell-gateway.rpm" \
@@ -179,4 +189,5 @@ jobs:
             --copy nix/test-guest/conformance-plans/gateway-restart.toml:/tmp/conformance-plan.toml \
             --provision openshell-candidate-rpm-source \
             --provision gateway-podman \
-            -- /tmp/openshell-conformance run --plan /tmp/conformance-plan.toml
+            -- /home/openshell/.local/bin/openshell-test-guest-as-gateway-user \
+            /tmp/openshell-conformance run --plan /tmp/conformance-plan.toml

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -66,6 +66,24 @@ reflection, non-callback inference APIs, and HTTP routes before normal request
 authentication. The operator-configured primary listener retains the full
 multiplexed API surface.
 
+Rootful Podman can report a private bridge gateway before netavark assigns that
+address. If an exact built-in Podman callback bind fails with
+`EADDRNOTAVAIL`, the Linux gateway retries the same address with
+`IP_FREEBIND`. The listener remains callback-only and becomes reachable when
+the first sandbox materializes the bridge. If delayed exact binding also fails
+while the gateway itself runs in a container, the gateway replaces the
+loopback primary and missing bridge sockets with one IPv4 wildcard socket. The
+wildcard defaults to callback-only authorization; only traffic addressed to
+the configured loopback endpoint receives primary scope. This keeps user and
+administrator APIs off the container's non-loopback interfaces, but it does
+make the sandbox-callable gRPC surface reachable on every IPv4 interface in
+that container namespace for the lifetime of the gateway process. Sandbox
+mTLS/JWT authentication and the RPC allowlist remain mandatory defenses.
+Delayed binding does not apply to rootless Podman, an explicit
+`host_gateway_ip`, Docker or external drivers, public callback addresses, or
+bind errors other than `EADDRNOTAVAIL`. A host gateway never uses the wildcard
+fallback.
+
 The `rpc_auth` classification is also the source of truth for negotiated
 listener exposure: marking an RPC as `sandbox` or `dual` makes it callable on
 these listeners. Review such changes as both authorization and network-surface

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -41,8 +41,8 @@ use openshell_core::proto::compute::v1::{
     CreateSandboxRequest, CreateSandboxResponse, DeleteSandboxRequest, DeleteSandboxResponse,
     DeleteWorkspaceRequest, DeleteWorkspaceResponse, DriverCondition, DriverPlatformEvent,
     DriverSandbox, DriverSandboxStatus, DriverSandboxTemplate, EnsureWorkspaceRequest,
-    EnsureWorkspaceResponse, GatewayListenerRequirement, GetCapabilitiesRequest,
-    GetCapabilitiesResponse, GetGatewayListenerRequirementsRequest,
+    EnsureWorkspaceResponse, GatewayExactBindAddressRequirement, GatewayListenerRequirement,
+    GetCapabilitiesRequest, GetCapabilitiesResponse, GetGatewayListenerRequirementsRequest,
     GetGatewayListenerRequirementsResponse, GetSandboxRequest, GetSandboxResponse,
     GpuResourceRequirements, ListSandboxesRequest, ListSandboxesResponse, StartSandboxRequest,
     StartSandboxResponse, StopSandboxRequest, StopSandboxResponse, ValidateSandboxCreateRequest,
@@ -1876,7 +1876,12 @@ impl ComputeDriver for DockerComputeDriver {
                             DockerGatewayRoute::HostGateway => "docker host-gateway IPv4 loopback",
                         }
                         .to_string(),
-                        selector: Some(Selector::ExactBindAddress(bind_address.to_string())),
+                        selector: Some(Selector::ExactBindAddress(
+                            GatewayExactBindAddressRequirement {
+                                address: bind_address.to_string(),
+                                allow_delayed_bind: false,
+                            },
+                        )),
                     }]
                 });
         Ok(Response::new(GetGatewayListenerRequirementsResponse {

--- a/crates/openshell-driver-docker/src/tests.rs
+++ b/crates/openshell-driver-docker/src/tests.rs
@@ -14,8 +14,8 @@ use openshell_core::progress::{
 };
 use openshell_core::proto::compute::v1::{
     DriverResourceRequirements, DriverSandboxSpec, DriverSandboxTemplate,
-    GetGatewayListenerRequirementsRequest, GpuResourceRequirements, ResourceRequirements,
-    gateway_listener_requirement::Selector,
+    GatewayExactBindAddressRequirement, GetGatewayListenerRequirementsRequest,
+    GpuResourceRequirements, ResourceRequirements, gateway_listener_requirement::Selector,
 };
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -777,7 +777,12 @@ async fn gateway_listener_requirements_report_managed_bridge_address() {
     assert_eq!(response.requirements.len(), 1);
     assert_eq!(
         response.requirements[0].selector,
-        Some(Selector::ExactBindAddress(expected_address.to_string()))
+        Some(Selector::ExactBindAddress(
+            GatewayExactBindAddressRequirement {
+                address: expected_address.to_string(),
+                allow_delayed_bind: false,
+            }
+        ))
     );
 }
 
@@ -813,7 +818,12 @@ async fn host_gateway_route_reports_ipv4_loopback_callback_listener() {
     assert_eq!(response.requirements.len(), 1);
     assert_eq!(
         response.requirements[0].selector,
-        Some(Selector::ExactBindAddress("127.0.0.1:17670".to_string()))
+        Some(Selector::ExactBindAddress(
+            GatewayExactBindAddressRequirement {
+                address: "127.0.0.1:17670".to_string(),
+                allow_delayed_bind: false,
+            }
+        ))
     );
 }
 

--- a/crates/openshell-driver-podman/NETWORKING.md
+++ b/crates/openshell-driver-podman/NETWORKING.md
@@ -281,6 +281,25 @@ the supervisor's RPCs. Otherwise, it creates an additional listener that
 exposes only the gateway's sandbox-callable gRPC methods. Operator, health,
 reflection, and HTTP requests must use the primary listener.
 
+Netavark may not assign a rootful managed bridge gateway until the first
+sandbox joins the network. If that exact private callback address fails to bind
+with `EADDRNOTAVAIL`, the Linux gateway uses `IP_FREEBIND` to bind the same
+address before the interface exists. The listener remains callback-only and
+becomes reachable when netavark materializes the bridge. Only the in-process
+built-in Podman driver can mark its discovered rootful managed-bridge address
+as eligible; rootless Podman, explicit `host_gateway_ip` values, and external
+drivers cannot activate delayed binding.
+
+If delayed exact binding fails while both the gateway and rootful Podman run
+inside another Linux container, the gateway uses one scoped IPv4 wildcard
+listener for that process. Connections addressed to loopback retain primary
+scope; connections addressed to the Podman bridge or any other IPv4 interface
+are callback-only. This exposes the sandbox-callable gRPC surface on every
+IPv4 interface in the outer container namespace, so deployments should still
+restrict that namespace at the container-network boundary. A gateway running
+directly on a host never uses the wildcard fallback. Neither strategy exposes
+operator, health, reflection, or HTTP routes on non-loopback interfaces.
+
 ### Layer 3 Inner Sandbox Network Namespace
 
 Inside the container, the supervisor creates another network namespace for the

--- a/crates/openshell-driver-podman/src/driver.rs
+++ b/crates/openshell-driver-podman/src/driver.rs
@@ -20,13 +20,15 @@ use openshell_core::gpu::{
     CdiGpuDefaultSelector, CdiGpuInventory, CdiGpuSelectionError, driver_gpu_requirements,
     effective_driver_gpu_count, validate_specific_gpu_device_request,
 };
-#[cfg(target_os = "linux")]
-use openshell_core::proto::compute::v1::GatewayDefaultRouteInterfaceRequirement;
 #[cfg(target_os = "macos")]
 use openshell_core::proto::compute::v1::GatewayLoopbackInterfaceRequirement;
 use openshell_core::proto::compute::v1::{
     DriverSandbox, GatewayListenerRequirement, GetCapabilitiesResponse, GpuResourceRequirements,
     gateway_listener_requirement::Selector,
+};
+#[cfg(target_os = "linux")]
+use openshell_core::proto::compute::v1::{
+    GatewayDefaultRouteInterfaceRequirement, GatewayExactBindAddressRequirement,
 };
 #[cfg(target_os = "linux")]
 use std::net::{IpAddr, SocketAddr};
@@ -587,7 +589,14 @@ impl PodmanComputeDriver {
             Ok(vec![GatewayListenerRequirement {
                 reason: format!("Podman network '{}' host gateway", self.config.network_name),
                 selector: Some(Selector::ExactBindAddress(
-                    SocketAddr::new(gateway_ip, callback_port).to_string(),
+                    GatewayExactBindAddressRequirement {
+                        address: SocketAddr::new(gateway_ip, callback_port).to_string(),
+                        // A rootful managed bridge can be created after gateway
+                        // startup. An explicit override is operator-owned, and
+                        // rootless networking must never broaden the listener.
+                        allow_delayed_bind: !self.rootless
+                            && self.config.host_gateway_ip.trim().is_empty(),
+                    },
                 )),
             }])
         }
@@ -2179,7 +2188,12 @@ mod tests {
         assert_eq!(requirements.len(), 1);
         assert_eq!(
             requirements[0].selector,
-            Some(Selector::ExactBindAddress("10.89.1.1:17670".to_string()))
+            Some(Selector::ExactBindAddress(
+                GatewayExactBindAddressRequirement {
+                    address: "10.89.1.1:17670".to_string(),
+                    allow_delayed_bind: true,
+                }
+            ))
         );
     }
 
@@ -2199,7 +2213,12 @@ mod tests {
 
         assert_eq!(
             requirements[0].selector,
-            Some(Selector::ExactBindAddress("10.90.1.1:17670".to_string()))
+            Some(Selector::ExactBindAddress(
+                GatewayExactBindAddressRequirement {
+                    address: "10.90.1.1:17670".to_string(),
+                    allow_delayed_bind: false,
+                }
+            ))
         );
     }
 

--- a/crates/openshell-server/Cargo.toml
+++ b/crates/openshell-server/Cargo.toml
@@ -34,7 +34,7 @@ k8s-openapi = { workspace = true }
 
 # Async runtime
 tokio = { workspace = true }
-socket2 = { workspace = true }
+socket2 = { workspace = true, features = ["all"] }
 nix = { workspace = true }
 
 # gRPC

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -178,6 +178,7 @@ pub enum GatewayListenerRequirement {
         address: SocketAddr,
         driver_name: String,
         reason: String,
+        allow_delayed_bind: bool,
     },
     DefaultRouteInterface {
         driver_name: String,
@@ -187,6 +188,12 @@ pub enum GatewayListenerRequirement {
         driver_name: String,
         reason: String,
     },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GatewayListenerBindPolicy {
+    Deny,
+    TrustedBuiltinPodman,
 }
 
 impl GatewayListenerRequirement {
@@ -627,6 +634,7 @@ impl ComputeRuntime {
         driver_name: String,
         driver: SharedComputeDriver,
         driver_process: Option<Arc<ManagedDriverProcess>>,
+        listener_bind_policy: GatewayListenerBindPolicy,
         store: Arc<Store>,
         sandbox_index: SandboxIndex,
         sandbox_watch_bus: SandboxWatchBus,
@@ -672,16 +680,20 @@ impl ComputeRuntime {
                         )));
                     };
                     match selector {
-                        Selector::ExactBindAddress(bind_address) => {
-                            let address = bind_address.parse::<SocketAddr>().map_err(|err| {
+                        Selector::ExactBindAddress(exact_bind_address) => {
+                            let address = exact_bind_address.address.parse::<SocketAddr>().map_err(|err| {
                                 ComputeError::Message(format!(
-                                    "compute driver '{driver_name}' returned invalid gateway listener address '{bind_address}': {err}"
+                                    "compute driver '{driver_name}' returned invalid gateway listener address '{}': {err}",
+                                    exact_bind_address.address
                                 ))
                             })?;
                             Ok(GatewayListenerRequirement::Exact {
                                 address,
                                 driver_name: driver_name.clone(),
                                 reason: requirement.reason,
+                                allow_delayed_bind: listener_bind_policy
+                                    == GatewayListenerBindPolicy::TrustedBuiltinPodman
+                                    && exact_bind_address.allow_delayed_bind,
                             })
                         }
                         Selector::DefaultRouteInterface(_) => {
@@ -764,6 +776,7 @@ impl ComputeRuntime {
             endpoint.name,
             driver,
             endpoint.driver_process,
+            GatewayListenerBindPolicy::Deny,
             store,
             sandbox_index,
             sandbox_watch_bus,
@@ -10608,6 +10621,7 @@ mod tests {
             "test-driver".to_string(),
             Arc::new(TestDriver::default()),
             None,
+            GatewayListenerBindPolicy::Deny,
             store,
             SandboxIndex::new(),
             SandboxWatchBus::new(),
@@ -10795,6 +10809,7 @@ mod tests {
                 address: "172.19.0.1:17670".parse().unwrap(),
                 driver_name: "docker".to_string(),
                 reason: "external driver managed bridge".to_string(),
+                allow_delayed_bind: false,
             }]
         );
 

--- a/crates/openshell-server/src/gateway_listener.rs
+++ b/crates/openshell-server/src/gateway_listener.rs
@@ -4,9 +4,12 @@
 use crate::compute::GatewayListenerRequirement;
 use openshell_core::{Error, Result};
 use socket2::{Domain, Protocol, Socket, Type};
+use std::io::ErrorKind;
 use std::net::{IpAddr, SocketAddr};
+#[cfg(target_os = "linux")]
+use std::path::Path;
 use tokio::net::TcpListener;
-use tracing::info;
+use tracing::{info, warn};
 
 /// Authorization scope associated with a gateway listener.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -27,6 +30,7 @@ pub struct GatewayListenerSpec {
     pub scope: GatewayListenerScope,
     covered_addresses: Vec<CoveredGatewayAddress>,
     provenance: Option<GatewayListenerProvenance>,
+    allows_delayed_bind: bool,
 }
 
 /// Diagnostic source of a driver-requested listener.
@@ -49,14 +53,28 @@ impl GatewayListenerSpec {
             scope,
             covered_addresses: Vec::new(),
             provenance: None,
+            allows_delayed_bind: false,
         }
     }
 
     pub fn scope_for_local_addr(&self, local_addr: SocketAddr) -> GatewayListenerScope {
+        self.route_for_local_addr(local_addr).scope
+    }
+
+    pub fn allows_plaintext_service_http_for_local_addr(&self, local_addr: SocketAddr) -> bool {
+        let route = self.route_for_local_addr(local_addr);
+        route.scope == GatewayListenerScope::Primary && route.address.ip().is_loopback()
+    }
+
+    fn route_for_local_addr(&self, local_addr: SocketAddr) -> CoveredGatewayAddress {
         self.covered_addresses
             .iter()
             .find(|covered| covered.address == local_addr)
-            .map_or(self.scope, |covered| covered.scope)
+            .copied()
+            .unwrap_or(CoveredGatewayAddress {
+                address: self.address,
+                scope: self.scope,
+            })
     }
 
     fn bind_to(mut self, local_addr: SocketAddr) -> Self {
@@ -177,6 +195,13 @@ fn callback_listener_spec(
     address: SocketAddr,
     requirement: &GatewayListenerRequirement,
 ) -> GatewayListenerSpec {
+    let allows_delayed_bind = matches!(
+        requirement,
+        GatewayListenerRequirement::Exact {
+            allow_delayed_bind: true,
+            ..
+        }
+    );
     GatewayListenerSpec {
         address,
         scope: GatewayListenerScope::ComputeDriverCallback,
@@ -185,6 +210,7 @@ fn callback_listener_spec(
             driver_name: requirement.driver_name().to_string(),
             reason: requirement.reason().to_string(),
         }),
+        allows_delayed_bind,
     }
 }
 
@@ -272,9 +298,77 @@ pub async fn bind_gateway_listeners(
         ) && specs.iter().any(|candidate| {
             candidate.address.port() == spec.address.port() && candidate.address.is_ipv4()
         });
-        let listener = bind_gateway_listener(spec.address, ipv6_only)
-            .await
-            .map_err(|e| Error::transport(format!("failed to bind to {}: {e}", spec.address)))?;
+        let listener = bind_gateway_listener(spec.address, ipv6_only).await;
+        let listener = match listener {
+            Ok(listener) => listener,
+            Err(err) => {
+                let delayed_bind_eligible = podman_delayed_bind_is_eligible(spec, err.kind());
+                if delayed_bind_eligible {
+                    match bind_gateway_listener_freebind(spec.address) {
+                        Ok(listener) => {
+                            let provenance = spec
+                                .provenance
+                                .as_ref()
+                                .expect("delayed callback listener must include provenance");
+                            warn!(
+                                address = %spec.address,
+                                listener_purpose = "compute-driver-callback-delayed-bind",
+                                driver = %provenance.driver_name,
+                                reason = %provenance.reason,
+                                bind_strategy = "linux-ip-freebind",
+                                authorization_scope = "sandbox-callable-grpc-only",
+                                "Podman bridge address is not available yet; gateway bound the exact callback address for delayed activation"
+                            );
+                            listener
+                        }
+                        Err(freebind_err) => {
+                            let Some(fallback_spec) = nested_podman_wildcard_fallback_spec(
+                                &specs,
+                                spec,
+                                err.kind(),
+                                running_in_linux_container(),
+                            ) else {
+                                return Err(Error::transport(format!(
+                                    "failed to bind Podman callback address {} ({err}); delayed exact bind also failed: {freebind_err}",
+                                    spec.address
+                                )));
+                            };
+
+                            // The wildcard cannot coexist with the already-bound loopback
+                            // socket on the same port. Dropping the partial listener set is
+                            // safe because none of it has been returned to the server yet.
+                            drop(listeners);
+                            let listener = bind_gateway_listener(fallback_spec.address, false)
+                                .await
+                                .map_err(|fallback_err| {
+                                    Error::transport(format!(
+                                        "failed to bind Podman callback address {} ({err}); delayed exact bind failed ({freebind_err}); scoped wildcard fallback {} also failed: {fallback_err}",
+                                        spec.address, fallback_spec.address
+                                    ))
+                                })?;
+                            let local_addr = listener.local_addr().unwrap_or(fallback_spec.address);
+                            let fallback_spec = fallback_spec.bind_to(local_addr);
+                            warn!(
+                                address = %local_addr,
+                                unavailable_callback_address = %spec.address,
+                                listener_purpose = "nested-podman-callback-fallback",
+                                authorization_scope = "primary-on-loopback; sandbox-callable-grpc-only-on-other-ipv4-interfaces",
+                                "Podman bridge address is not available yet and delayed exact binding failed; gateway callback listener is exposed on all container IPv4 interfaces for this gateway process"
+                            );
+                            return Ok(vec![BoundGatewayListener {
+                                listener,
+                                spec: fallback_spec,
+                            }]);
+                        }
+                    }
+                } else {
+                    return Err(Error::transport(format!(
+                        "failed to bind to {}: {err}",
+                        spec.address
+                    )));
+                }
+            }
+        };
         let local_addr = listener.local_addr().unwrap_or(spec.address);
         match spec.scope {
             GatewayListenerScope::Primary => {
@@ -306,6 +400,83 @@ pub async fn bind_gateway_listeners(
         });
     }
     Ok(listeners)
+}
+
+fn nested_podman_wildcard_fallback_spec(
+    specs: &[GatewayListenerSpec],
+    failed_spec: &GatewayListenerSpec,
+    error_kind: ErrorKind,
+    running_in_container: bool,
+) -> Option<GatewayListenerSpec> {
+    if !running_in_container
+        || specs.len() != 2
+        || !podman_delayed_bind_is_eligible(failed_spec, error_kind)
+    {
+        return None;
+    }
+
+    let primary = specs
+        .iter()
+        .find(|spec| spec.scope == GatewayListenerScope::Primary)?;
+    let callback = specs.iter().find(|spec| {
+        spec.scope == GatewayListenerScope::ComputeDriverCallback && *spec == failed_spec
+    })?;
+    let callback_provenance = callback.provenance.as_ref()?;
+    let (IpAddr::V4(primary_ip), IpAddr::V4(_)) = (primary.address.ip(), callback.address.ip())
+    else {
+        return None;
+    };
+    if !primary_ip.is_loopback()
+        || primary.address.port() == 0
+        || primary.address.port() != callback.address.port()
+    {
+        return None;
+    }
+
+    Some(GatewayListenerSpec {
+        address: SocketAddr::from((std::net::Ipv4Addr::UNSPECIFIED, primary.address.port())),
+        // The broader socket is callback-only by default. Only connections
+        // addressed to the original loopback endpoint retain primary scope.
+        scope: GatewayListenerScope::ComputeDriverCallback,
+        covered_addresses: vec![CoveredGatewayAddress {
+            address: primary.address,
+            scope: GatewayListenerScope::Primary,
+        }],
+        provenance: Some(callback_provenance.clone()),
+        allows_delayed_bind: true,
+    })
+}
+
+fn podman_delayed_bind_is_eligible(
+    failed_spec: &GatewayListenerSpec,
+    error_kind: ErrorKind,
+) -> bool {
+    if error_kind != ErrorKind::AddrNotAvailable
+        || failed_spec.scope != GatewayListenerScope::ComputeDriverCallback
+    {
+        return false;
+    }
+
+    let Some(callback_provenance) = failed_spec.provenance.as_ref() else {
+        return false;
+    };
+    let IpAddr::V4(callback_ip) = failed_spec.address.ip() else {
+        return false;
+    };
+
+    callback_ip.is_private()
+        && failed_spec.allows_delayed_bind
+        && callback_provenance.driver_name == "podman"
+}
+
+#[cfg(target_os = "linux")]
+fn running_in_linux_container() -> bool {
+    Path::new("/.dockerenv").exists() || Path::new("/run/.containerenv").exists()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn running_in_linux_container() -> bool {
+    false
 }
 
 fn resolve_bound_covered_addresses(
@@ -356,6 +527,32 @@ async fn bind_gateway_listener(
     TcpListener::bind(address).await
 }
 
+#[cfg(target_os = "linux")]
+fn bind_gateway_listener_freebind(address: SocketAddr) -> std::io::Result<TcpListener> {
+    if !address.is_ipv4() {
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
+            "delayed gateway listener binding requires an IPv4 address",
+        ));
+    }
+    let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))?;
+    socket.set_reuse_address(true)?;
+    socket.set_freebind_v4(true)?;
+    socket.set_nonblocking(true)?;
+    socket.bind(&address.into())?;
+    socket.listen(1024)?;
+    let listener: std::net::TcpListener = socket.into();
+    TcpListener::from_std(listener)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn bind_gateway_listener_freebind(_address: SocketAddr) -> std::io::Result<TcpListener> {
+    Err(std::io::Error::new(
+        ErrorKind::Unsupported,
+        "delayed gateway listener binding is supported only on Linux",
+    ))
+}
+
 fn listener_covers(existing: SocketAddr, requested: SocketAddr) -> bool {
     if existing == requested {
         return true;
@@ -376,9 +573,11 @@ mod tests {
     use super::{
         GatewayListenerProvenance, GatewayListenerScope, GatewayListenerSpec,
         bind_gateway_listeners, gateway_listener_specs,
-        gateway_listener_specs_with_default_route_ip,
+        gateway_listener_specs_with_default_route_ip, nested_podman_wildcard_fallback_spec,
+        podman_delayed_bind_is_eligible,
     };
     use crate::compute::GatewayListenerRequirement;
+    use std::io::ErrorKind;
     use std::net::SocketAddr;
     use std::sync::atomic::{AtomicBool, Ordering};
     use tokio::net::TcpListener;
@@ -416,6 +615,8 @@ mod tests {
             spec.scope_for_local_addr(loopback),
             GatewayListenerScope::Primary,
         );
+        assert!(!spec.allows_plaintext_service_http_for_local_addr(callback));
+        assert!(!spec.allows_plaintext_service_http_for_local_addr(loopback));
     }
 
     #[test]
@@ -435,6 +636,7 @@ mod tests {
                     scope: GatewayListenerScope::Primary,
                     covered_addresses: Vec::new(),
                     provenance: None,
+                    allows_delayed_bind: false,
                 },
                 GatewayListenerSpec {
                     address: callback,
@@ -444,6 +646,7 @@ mod tests {
                         driver_name: "alpha".to_string(),
                         reason: "managed bridge".to_string(),
                     }),
+                    allows_delayed_bind: false,
                 },
             ]
         );
@@ -456,6 +659,7 @@ mod tests {
             address: "172.18.0.1:8080".parse().unwrap(),
             driver_name: "external-test".to_string(),
             reason: "external bridge".to_string(),
+            allow_delayed_bind: false,
         };
 
         let specs = gateway_listener_specs(primary, &[requirement]).unwrap();
@@ -620,6 +824,58 @@ mod tests {
         assert_eq!(specs[1].scope, GatewayListenerScope::ComputeDriverCallback);
     }
 
+    #[test]
+    fn podman_delayed_bind_does_not_depend_on_primary_listener_topology() {
+        let callback: SocketAddr = "10.89.1.1:8080".parse().unwrap();
+
+        for primary in ["192.168.20.20:8080", "[::1]:8080"] {
+            let primary = primary.parse().unwrap();
+            let specs = gateway_listener_specs(primary, &[delayed_podman_requirement(callback)])
+                .expect("delayed Podman callback requirement should be valid");
+
+            assert!(podman_delayed_bind_is_eligible(
+                &specs[1],
+                ErrorKind::AddrNotAvailable,
+            ));
+        }
+    }
+
+    #[test]
+    fn nested_podman_wildcard_fallback_remains_loopback_primary_only() {
+        let callback: SocketAddr = "10.89.1.1:8080".parse().unwrap();
+
+        for primary in ["192.168.20.20:8080", "[::1]:8080"] {
+            let primary = primary.parse().unwrap();
+            let specs = gateway_listener_specs(primary, &[delayed_podman_requirement(callback)])
+                .expect("delayed Podman callback requirement should be valid");
+
+            assert!(
+                nested_podman_wildcard_fallback_spec(
+                    &specs,
+                    &specs[1],
+                    ErrorKind::AddrNotAvailable,
+                    true,
+                )
+                .is_none(),
+                "wildcard fallback should reject primary listener {primary}",
+            );
+        }
+
+        let primary: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+        let specs = gateway_listener_specs(primary, &[delayed_podman_requirement(callback)])
+            .expect("delayed Podman callback requirement should be valid");
+        let fallback = nested_podman_wildcard_fallback_spec(
+            &specs,
+            &specs[1],
+            ErrorKind::AddrNotAvailable,
+            true,
+        )
+        .expect("loopback primary should permit the nested wildcard fallback");
+        assert_eq!(fallback.address, "0.0.0.0:8080".parse().unwrap());
+        assert!(fallback.allows_plaintext_service_http_for_local_addr(primary));
+        assert!(!fallback.allows_plaintext_service_http_for_local_addr(callback));
+    }
+
     #[tokio::test]
     async fn failed_bind_does_not_return_partially_bound_listeners() {
         let occupied_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -676,6 +932,7 @@ mod tests {
             address,
             driver_name: "alpha".to_string(),
             reason: "managed bridge".to_string(),
+            allow_delayed_bind: false,
         }
     }
 
@@ -684,6 +941,16 @@ mod tests {
             address,
             driver_name: "beta".to_string(),
             reason: "managed bridge".to_string(),
+            allow_delayed_bind: false,
+        }
+    }
+
+    fn delayed_podman_requirement(address: SocketAddr) -> GatewayListenerRequirement {
+        GatewayListenerRequirement::Exact {
+            address,
+            driver_name: "podman".to_string(),
+            reason: "managed bridge".to_string(),
+            allow_delayed_bind: true,
         }
     }
 
@@ -707,6 +974,7 @@ mod tests {
             scope: GatewayListenerScope::Primary,
             covered_addresses: Vec::new(),
             provenance: None,
+            allows_delayed_bind: false,
         }
     }
 
@@ -723,6 +991,7 @@ mod tests {
                 driver_name: driver_name.to_string(),
                 reason: reason.to_string(),
             }),
+            allows_delayed_bind: false,
         }
     }
 }

--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -839,11 +839,21 @@ async fn serve_gateway_listener(
                 continue;
             }
         };
-        let listener_scope = match stream.local_addr() {
-            Ok(local_addr) => spec.scope_for_local_addr(local_addr),
+        let connection = match stream.local_addr() {
+            Ok(local_addr) => GatewayConnectionContext {
+                listen_addr: local_addr,
+                listener_scope: spec.scope_for_local_addr(local_addr),
+                listener_allows_plaintext_service_http: spec
+                    .allows_plaintext_service_http_for_local_addr(local_addr),
+            },
             Err(e) => {
                 debug!(error = %e, client = %addr, listen = %listen_addr, "Failed to inspect accepted local address");
-                spec.scope
+                GatewayConnectionContext {
+                    listen_addr,
+                    listener_scope: spec.scope,
+                    listener_allows_plaintext_service_http: spec
+                        .allows_plaintext_service_http_for_local_addr(listen_addr),
+                }
             }
         };
 
@@ -852,8 +862,7 @@ async fn serve_gateway_listener(
         spawn_gateway_connection(
             stream,
             addr,
-            listen_addr,
-            listener_scope,
+            connection,
             service.clone(),
             tls_acceptor.clone(),
             enable_loopback_service_http,
@@ -912,34 +921,40 @@ fn looks_like_http(prefix: &[u8]) -> bool {
 
 fn allow_plaintext_service_http(
     enabled: bool,
-    listen_addr: SocketAddr,
     peer_addr: SocketAddr,
-    listener_scope: GatewayListenerScope,
+    listener_allows_plaintext_service_http: bool,
 ) -> bool {
-    enabled
-        && matches!(listener_scope, GatewayListenerScope::Primary)
-        && listen_addr.ip().is_loopback()
-        && peer_addr.ip().is_loopback()
+    enabled && listener_allows_plaintext_service_http && peer_addr.ip().is_loopback()
+}
+
+#[derive(Clone, Copy, Debug)]
+struct GatewayConnectionContext {
+    listen_addr: SocketAddr,
+    listener_scope: GatewayListenerScope,
+    listener_allows_plaintext_service_http: bool,
 }
 
 fn spawn_gateway_connection(
     stream: TcpStream,
     addr: SocketAddr,
-    listen_addr: SocketAddr,
-    listener_scope: GatewayListenerScope,
+    connection: GatewayConnectionContext,
     service: MultiplexService,
     tls_acceptor: Option<TlsAcceptor>,
     enable_loopback_service_http: bool,
 ) {
+    let GatewayConnectionContext {
+        listen_addr,
+        listener_scope,
+        listener_allows_plaintext_service_http,
+    } = connection;
     if let Some(acceptor) = tls_acceptor {
         tokio::spawn(async move {
             match classify_connection_protocol(&stream).await {
                 Ok(ConnectionProtocol::PlainHttp)
                     if allow_plaintext_service_http(
                         enable_loopback_service_http,
-                        listen_addr,
                         addr,
-                        listener_scope,
+                        listener_allows_plaintext_service_http,
                     ) =>
                 {
                     if let Err(e) = service
@@ -1401,20 +1416,28 @@ async fn build_compute_runtime(
             };
             let instance = registration.factory.build(build_context).await?;
             match instance {
-                ComputeDriverInstance::InProcess(driver) => ComputeRuntime::from_driver(
-                    registration.name,
-                    driver,
-                    None,
-                    store,
-                    sandbox_index,
-                    sandbox_watch_bus,
-                    tracing_log_bus,
-                    supervisor_sessions,
-                )
-                .await
-                .map_err(|error| {
-                    Error::execution(format!("failed to create compute runtime: {error}"))
-                })?,
+                ComputeDriverInstance::InProcess(driver) => {
+                    let listener_bind_policy = if registration.name == "podman" {
+                        compute::GatewayListenerBindPolicy::TrustedBuiltinPodman
+                    } else {
+                        compute::GatewayListenerBindPolicy::Deny
+                    };
+                    ComputeRuntime::from_driver(
+                        registration.name,
+                        driver,
+                        None,
+                        listener_bind_policy,
+                        store,
+                        sandbox_index,
+                        sandbox_watch_bus,
+                        tracing_log_bus,
+                        supervisor_sessions,
+                    )
+                    .await
+                    .map_err(|error| {
+                        Error::execution(format!("failed to create compute runtime: {error}"))
+                    })?
+                }
                 ComputeDriverInstance::ManagedRemote(mut endpoint) => {
                     endpoint.name = registration.name;
                     ComputeRuntime::new_remote_driver(
@@ -1932,28 +1955,14 @@ mod tests {
     }
 
     #[test]
-    fn plaintext_service_http_requires_loopback_listener_and_peer() {
-        let loopback: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+    fn plaintext_service_http_requires_enabled_listener_and_loopback_peer() {
         let peer: SocketAddr = "127.0.0.1:54000".parse().unwrap();
-        let wildcard: SocketAddr = "0.0.0.0:8080".parse().unwrap();
         let remote_peer: SocketAddr = "192.0.2.10:54000".parse().unwrap();
-        let primary = GatewayListenerScope::Primary;
-        let callback = GatewayListenerScope::ComputeDriverCallback;
 
-        assert!(allow_plaintext_service_http(true, loopback, peer, primary));
-        assert!(!allow_plaintext_service_http(
-            false, loopback, peer, primary
-        ));
-        assert!(!allow_plaintext_service_http(true, wildcard, peer, primary));
-        assert!(!allow_plaintext_service_http(
-            true,
-            loopback,
-            remote_peer,
-            primary
-        ));
-        assert!(!allow_plaintext_service_http(
-            true, loopback, peer, callback
-        ));
+        assert!(allow_plaintext_service_http(true, peer, true));
+        assert!(!allow_plaintext_service_http(false, peer, true));
+        assert!(!allow_plaintext_service_http(true, remote_peer, true));
+        assert!(!allow_plaintext_service_http(true, peer, false));
     }
 
     #[tokio::test]
@@ -2296,6 +2305,7 @@ mod tests {
             address,
             driver_name: "docker".to_string(),
             reason: "managed bridge".to_string(),
+            allow_delayed_bind: false,
         }
     }
 }

--- a/crates/openshell-server/src/test_support.rs
+++ b/crates/openshell-server/src/test_support.rs
@@ -9,8 +9,8 @@ use openshell_core::proto::compute::v1::compute_driver_server::ComputeDriverServ
 use openshell_core::proto::compute::v1::{
     CreateSandboxRequest, CreateSandboxResponse, DeleteSandboxRequest, DeleteSandboxResponse,
     DeleteWorkspaceRequest, DeleteWorkspaceResponse, DriverSandbox, EnsureWorkspaceRequest,
-    EnsureWorkspaceResponse, GatewayListenerRequirement, GetCapabilitiesRequest,
-    GetCapabilitiesResponse, GetGatewayListenerRequirementsRequest,
+    EnsureWorkspaceResponse, GatewayExactBindAddressRequirement, GatewayListenerRequirement,
+    GetCapabilitiesRequest, GetCapabilitiesResponse, GetGatewayListenerRequirementsRequest,
     GetGatewayListenerRequirementsResponse, GetSandboxRequest, GetSandboxResponse,
     ListSandboxesRequest, ListSandboxesResponse, StartSandboxRequest, StartSandboxResponse,
     StopSandboxRequest, StopSandboxResponse, ValidateSandboxCreateRequest,
@@ -142,7 +142,12 @@ impl FakeComputeDriver {
                 .gateway_listener_requirements
                 .push(GatewayListenerRequirement {
                     reason: reason.into(),
-                    selector: Some(Selector::ExactBindAddress(bind_address.into())),
+                    selector: Some(Selector::ExactBindAddress(
+                        GatewayExactBindAddressRequirement {
+                            address: bind_address.into(),
+                            allow_delayed_bind: false,
+                        },
+                    )),
                 });
         });
         self

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -148,6 +148,24 @@ HTTP requests. A `PermissionDenied` response from an additional callback-only
 listener is expected for those requests. Do not broaden the primary listener
 to `0.0.0.0` solely to make sandbox callbacks reachable.
 
+For rootful Podman on Linux, the bridge gateway may not exist until the first
+sandbox joins. If the exact private bridge bind fails with `EADDRNOTAVAIL`,
+OpenShell binds that future address with `IP_FREEBIND`. The callback-only
+listener becomes reachable when netavark materializes the bridge. This applies
+only to the managed bridge discovered by the built-in Podman driver; rootless
+Podman, explicit `host_gateway_ip` values, and external drivers remain
+ordinary exact-bind only.
+
+If delayed exact binding also fails while the gateway is nested inside a Linux
+container, OpenShell falls back to one IPv4 wildcard socket for that gateway
+process. Loopback traffic still receives primary scope; every other IPv4
+interface receives callback-only scope. The fallback therefore exposes the
+sandbox-callable gRPC surface—not administrator, health, reflection, or HTTP
+routes—on all IPv4 interfaces in the outer container namespace. Restrict access
+to that namespace with the surrounding container network, and retain mTLS and
+sandbox JWT authentication. Gateways running directly on a host never use the
+wildcard fallback.
+
 ## Docker Driver
 
 [Docker](https://www.docker.com/get-started/)-backed sandboxes run as containers on the gateway host. Use Docker for local development, single-machine gateways, and hosts that already use Docker Desktop or Docker Engine.

--- a/nix/test-guest/README.md
+++ b/nix/test-guest/README.md
@@ -243,6 +243,23 @@ target-side candidate apply command. Stage the CLI and gateway packages as
 `/var/lib/openshell-test-guest/artifacts/openshell.rpm` and
 `/var/lib/openshell-test-guest/artifacts/openshell-gateway.rpm`.
 
+For example, run candidate RPMs through rootful Podman conformance with:
+
+```shell
+nix run .#test-guest -- \
+  --distro fedora --with podman-rootful --with selinux \
+  --copy ./openshell.rpm:/var/lib/openshell-test-guest/artifacts/openshell.rpm \
+  --copy ./openshell-gateway.rpm:/var/lib/openshell-test-guest/artifacts/openshell-gateway.rpm \
+  --copy ./openshell-conformance:/tmp/openshell-conformance \
+  --copy nix/test-guest/conformance-plans/gateway-restart.toml:/tmp/conformance-plan.toml \
+  --provision openshell-candidate-rpm-source \
+  --provision gateway-podman \
+  -- /tmp/openshell-conformance run --plan /tmp/conformance-plan.toml
+```
+
+Use `podman-rootless` for the equivalent rootless run. All copied binaries and
+RPMs must match the guest architecture.
+
 `openshell-latest-release-rpm-source` downloads the latest stable OpenShell GitHub
 release for the guest architecture, stores its versioned RPMs under
 `/var/lib/openshell-conformance/baseline`, and publishes a target-side
@@ -268,6 +285,10 @@ Versioned plans under `nix/test-guest/conformance-plans/` bind conformance
 scenarios to the stable action-command contracts installed by provisioners.
 Copy the applicable plan to the guest and pass it to `openshell-conformance run
 --plan`.
+
+`gateway-restart.toml` tests the installed version with smoke coverage and
+sandbox continuity across a gateway restart. `gateway-upgrade-restart.toml`
+retains the upgrade action contract for dedicated upgrade testing.
 
 ## Prepared VM cache
 

--- a/proto/compute_driver.proto
+++ b/proto/compute_driver.proto
@@ -110,9 +110,10 @@ message GatewayListenerRequirement {
   string reason = 1;
 
   oneof selector {
-    // Concrete IP:port address requested by the driver. The port must match
-    // the gateway's configured primary listener port.
-    string exact_bind_address = 2;
+    // Concrete IP:port address requested by the driver, together with any
+    // trusted bind behavior. The port must match the gateway's configured
+    // primary listener port.
+    GatewayExactBindAddressRequirement exact_bind_address = 2;
     // Ask the gateway to bind the IPv4 address selected by its default route.
     // This matches rootless pasta's default upstream-interface selection.
     GatewayDefaultRouteInterfaceRequirement default_route_interface = 3;
@@ -120,6 +121,17 @@ message GatewayListenerRequirement {
     // covers runtimes whose host forwarder terminates on gateway loopback.
     GatewayLoopbackInterfaceRequirement loopback_interface = 4;
   }
+}
+
+message GatewayExactBindAddressRequirement {
+  // Concrete IP:port address requested by the driver.
+  string address = 1;
+
+  // Indicates that the address belongs to a driver-managed bridge that may
+  // not exist until the first sandbox joins it. Gateways must honor this only
+  // for a trusted built-in driver; external drivers cannot authorize a
+  // nonlocal or wildcard listener.
+  bool allow_delayed_bind = 2;
 }
 
 message GatewayDefaultRouteInterfaceRequirement {}

--- a/skills/debug-openshell-cluster/SKILL.md
+++ b/skills/debug-openshell-cluster/SKILL.md
@@ -235,6 +235,20 @@ Common findings:
 - Current gateways reuse the primary listener when it covers Podman's callback
   address. If the primary does not cover that address, inspect the gateway
   startup logs for the additional callback-only listener and its provenance.
+- For rootful Podman, a missing managed bridge address can trigger
+  `listener_purpose="compute-driver-callback-delayed-bind"`. Confirm the exact
+  private address belongs to the built-in driver's discovered managed bridge,
+  the initial bind error is `EADDRNOTAVAIL`, and the log reports
+  `bind_strategy="linux-ip-freebind"`. The listener is callback-only and
+  becomes reachable when the first sandbox materializes the bridge.
+- In a nested Linux container with rootful Podman, a missing bridge address can
+  trigger `listener_purpose="nested-podman-callback-fallback"` only when the
+  delayed exact bind also fails. Confirm the failed exact address is the
+  built-in driver's discovered managed bridge (not rootless Podman, an explicit
+  `host_gateway_ip`, or an external driver), and the wildcard socket is
+  callback-only off loopback. The callback RPC surface is reachable on every
+  IPv4 interface in the outer container namespace for that gateway process, so
+  also inspect the surrounding container-network boundary.
 - Rootless slirp4netns, another named helper, or missing helper metadata
   requires an explicitly remote `grpc_endpoint`. An explicit `host_gateway_ip`
   cannot bypass slirp4netns host-loopback isolation. Do not work around
@@ -680,6 +694,8 @@ configuration — check that the gateway spawned the driver binary you expect
 | `BatchSpanProcessor.ExportError` repeatedly reports connection refused on `127.0.0.1:4317` | The local gateway started with OTLP configured but the collector forwarding task later stopped, or the config was created manually | Restart `gateway:docker`, `gateway:podman`, or `gateway:vm` so it re-detects the listener; inspect the generated `gateway.toml` for `[openshell.gateway.otlp]` |
 | Gateway starts but sandbox create fails | Compute driver cannot reach runtime | Docker/Podman/Kubernetes/VM driver logs |
 | Gateway exits while resolving compute-driver listener requirements | Callback alias topology is unsupported, the Podman network cannot be inspected, or the selected address is not private/authorized | Gateway startup error, `podman info --debug`, Podman network inspection, host IPv4 default route |
+| Rootful Podman gateway logs `compute-driver-callback-delayed-bind` | Podman reported a private bridge gateway before netavark assigned it | Confirm the listener uses `linux-ip-freebind`; create a sandbox and verify the managed bridge acquires the logged address |
+| Nested rootful Podman gateway logs `nested-podman-callback-fallback` | Both the ordinary and delayed exact binds failed before netavark assigned the bridge | Verify non-loopback destinations receive callback-only scope and restrict the outer container network |
 | Admin, health, reflection, or HTTP request is denied on an additional Docker/Podman callback-only listener | Additional callback listeners intentionally expose only sandbox-callable gRPC methods | Retry through the gateway's primary endpoint; inspect the listener-purpose startup log if the address was unexpected |
 | Docker or Podman sandbox never registers | Wrong callback endpoint or supervisor startup failure | Gateway logs and sandbox container logs |
 | Docker GPU sandbox fails before startup | NVIDIA CDI specs are missing or Docker has not discovered them | `docker info --format '{{json .DiscoveredDevices}}'`, `/etc/cdi`, `/var/run/cdi`, `nvidia-cdi-refresh.service` |


### PR DESCRIPTION
## Summary

Fix rootful Podman gateway startup when Podman has allocated a managed bridge gateway address but netavark has not assigned that address yet. The gateway uses delayed exact binding where Linux supports it and a narrowly scoped fallback for the nested Fedora canary topology.

This PR is the third change in the #3181 → #3165 → #2874 stack. It also builds on the reusable rootful Podman test-guest configuration merged in #3184.

## Related Issue

No issue required: this is a focused fix for a reliably failing Fedora release-canary regression. Longer-term driver-owned callback relay work remains tracked in #2540.

Release Canary reference: https://github.com/NVIDIA/OpenShell/actions/runs/32448768823/job/96673135310

## Changes

- Replace the scalar `exact_bind_address` listener selector with a structured `GatewayExactBindAddressRequirement`, allowing trusted built-in drivers to identify addresses eligible for delayed binding.
- Allow only the built-in rootful Podman driver, using its automatically discovered managed-bridge address, to request delayed binding.
- Use Linux `IP_FREEBIND` when the bridge gateway address has not yet been assigned.
- When delayed exact binding is unavailable in the nested Linux container topology, use an IPv4 wildcard socket with primary scope only for loopback destinations and callback-only scope elsewhere.
- Document the listener behavior and Podman networking constraints.
- Run Fedora conformance against candidate RPMs in rootless and rootful Podman modes with sandbox lifecycle and gateway-restart continuity coverage.

### Security impact

The nested-container fallback exposes only the sandbox-callable gRPC surface on non-loopback IPv4 destinations in the outer container namespace. User, administrator, health, reflection, non-callback inference, and HTTP routes remain unavailable there. Sandbox authentication and the surrounding container-network boundary remain required defenses.

## Testing

- [x] `mise run pre-commit`
- [x] Focused Docker and Podman gateway-listener tests
- [x] `git diff --check origin/codex/sandbox-lifecycle-conformance..HEAD`
- [ ] Fedora rootless and rootful conformance lanes (GitHub Actions)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
