### PR TITLE
feat(build): add Nix-native Linux toolchains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -310,14 +310,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785318670,
-        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785476452,
-        "narHash": "sha256-/CXwCFPS41rb/JI2VitKCgVK6V5E6/sfw5ke3B9zyVQ=",
+        "lastModified": 1787281715,
+        "narHash": "sha256-5yIL5XL31hCZBPWDdUOvUy4cYAl27XZrke7JELhHlnI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6ef009bf4c4873cdc1a621826722bdea7c03e62c",
+        "rev": "89abdfd661ea493cde2f73d7b1332cb34150aa43",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,13 @@
 {
   description = "OpenShell development environment";
 
+  nixConfig = {
+    extra-substituters = [ "https://openshell.cachix.org" ];
+    extra-trusted-public-keys = [
+      "openshell.cachix.org-1:OAr5MunsfH5PZvUsfD08OtGx5RtcwdNZGJdU5FqLm5w="
+    ];
+  };
+
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

--- a/flake.nix
+++ b/flake.nix
@@ -33,34 +33,40 @@
           inherit system;
           overlays = [ (import rust-overlay) ];
         };
+        commonDevShellPackages = with pkgs; [
+          # Assemble Debian artifacts on macOS and Linux.
+          dpkg
+          # Required to find packages.
+          pkg-config
+          # Coverage.
+          lcov
+        ];
         treefmtEval = treefmt-nix.lib.evalModule pkgs {
           projectRootFile = "flake.nix";
           programs.nixfmt.enable = true;
         };
         rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        z3-static = pkgs.callPackage ./nix/pkgs/z3-static.nix { };
+        aws-lc-static = pkgs.callPackage ./nix/pkgs/aws-lc-static.nix { };
         testGuest = import ./nix/test-guest { inherit pkgs; };
       in
       {
         apps.test-guest = testGuest.app;
         apps.test-guest-cache = testGuest.cacheApp;
 
-        devShells.default = pkgs.mkShell {
-          packages = with pkgs; [
-            rustToolchain
-            # Assemble Debian artifacts on macOS and Linux.
-            dpkg
-            # Required to find packages
-            pkg-config
-            # Required for bindgen generation.
-            llvmPackages.libclang
-            # system dependency for openshell-prover
-            z3
-            # Coverage
-            lcov
-          ];
-
-          env = {
-            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+        devShells = {
+          default = pkgs.mkShell {
+            packages = [
+              rustToolchain
+              z3-static
+              aws-lc-static
+            ]
+            ++ commonDevShellPackages;
+          };
+        }
+        // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+          glibc-2-28 = import ./nix/devShells/glibc-2-28.nix {
+            inherit pkgs rust-overlay commonDevShellPackages;
           };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -62,14 +62,22 @@
         apps.test-guest-cache = testGuest.cacheApp;
 
         devShells = {
-          default = pkgs.mkShell {
-            packages = [
-              rustToolchain
-              z3-static
-              aws-lc-static
-            ]
-            ++ commonDevShellPackages;
-          };
+          default =
+            (pkgs.mkShell.override {
+              stdenv =
+                if pkgs.stdenv.hostPlatform.isLinux then
+                  pkgs.stdenvAdapters.useMoldLinker pkgs.stdenv
+                else
+                  pkgs.stdenv;
+            })
+              {
+                packages = [
+                  rustToolchain
+                  z3-static
+                  aws-lc-static
+                ]
+                ++ commonDevShellPackages;
+              };
         }
         // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
           glibc-2-28 = import ./nix/devShells/glibc-2-28.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,9 @@
           glibc-2-28 = import ./nix/devShells/glibc-2-28.nix {
             inherit pkgs rust-overlay commonDevShellPackages;
           };
+          musl = import ./nix/devShells/musl.nix {
+            inherit pkgs rust-overlay commonDevShellPackages;
+          };
         };
 
         formatter = treefmtEval.config.build.wrapper;

--- a/nix/devShells/glibc-2-28.nix
+++ b/nix/devShells/glibc-2-28.nix
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{
+  pkgs,
+  rust-overlay,
+  commonDevShellPackages,
+}:
+
+let
+  toolchain = import ../toolchains/linux-gnu-2.28 { inherit pkgs; };
+  z3-static = pkgs.callPackage ../pkgs/z3-static.nix {
+    stdenv = toolchain.stdenv;
+  };
+  aws-lc-static = pkgs.callPackage ../pkgs/aws-lc-static.nix {
+    stdenv = toolchain.stdenv;
+  };
+  rustScope = {
+    stdenv = toolchain.stdenv;
+    gccForLibs.lib = toolchain.sharedRuntime;
+    pkgsTargetTarget = pkgs.pkgsTargetTarget // {
+      stdenv = toolchain.stdenv;
+    };
+  };
+  rust-bin = rust-overlay.lib.mkRustBin { } (
+    pkgs
+    // rustScope
+    // {
+      callPackage = pkgs.newScope rustScope;
+    }
+  );
+in
+(pkgs.mkShell.override { stdenv = toolchain.stdenv; }) {
+  packages = [
+    (rust-bin.fromRustupToolchainFile ../../rust-toolchain.toml)
+    z3-static
+    aws-lc-static
+  ]
+  ++ commonDevShellPackages;
+}

--- a/nix/devShells/musl.nix
+++ b/nix/devShells/musl.nix
@@ -9,12 +9,13 @@
 
 let
   muslPkgs = pkgs.pkgsMusl;
+  stdenv = pkgs.stdenvAdapters.useMoldLinker muslPkgs.stdenv;
   rust-bin = rust-overlay.lib.mkRustBin { } muslPkgs;
   rustToolchain = (rust-bin.fromRustupToolchainFile ../../rust-toolchain.toml).override {
     enableLibsecret = false;
   };
 in
-muslPkgs.mkShell {
+(muslPkgs.mkShell.override { inherit stdenv; }) {
   packages = [
     rustToolchain
     (muslPkgs.callPackage ../pkgs/z3-static.nix { })

--- a/nix/devShells/musl.nix
+++ b/nix/devShells/musl.nix
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{
+  pkgs,
+  rust-overlay,
+  commonDevShellPackages,
+}:
+
+let
+  muslPkgs = pkgs.pkgsMusl;
+  rust-bin = rust-overlay.lib.mkRustBin { } muslPkgs;
+  rustToolchain = (rust-bin.fromRustupToolchainFile ../../rust-toolchain.toml).override {
+    enableLibsecret = false;
+  };
+in
+muslPkgs.mkShell {
+  packages = [
+    rustToolchain
+    (muslPkgs.callPackage ../pkgs/z3-static.nix { })
+    (muslPkgs.callPackage ../pkgs/aws-lc-static.nix {
+      rust-bindgen = pkgs.rust-bindgen;
+    })
+  ]
+  ++ commonDevShellPackages;
+}

--- a/nix/pkgs/aws-lc-static.nix
+++ b/nix/pkgs/aws-lc-static.nix
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{ aws-lc, stdenv }:
+
+aws-lc.override {
+  inherit stdenv;
+  useSharedLibraries = false;
+  withRustBindings = true;
+}

--- a/nix/pkgs/aws-lc-static.nix
+++ b/nix/pkgs/aws-lc-static.nix
@@ -1,10 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-{ aws-lc, stdenv }:
+{
+  aws-lc,
+  rust-bindgen,
+  stdenv,
+}:
 
 aws-lc.override {
-  inherit stdenv;
+  inherit stdenv rust-bindgen;
   useSharedLibraries = false;
   withRustBindings = true;
 }

--- a/nix/pkgs/z3-static.nix
+++ b/nix/pkgs/z3-static.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{ z3, stdenv }:
+
+(z3.override {
+  inherit stdenv;
+  pythonBindings = false;
+}).overrideAttrs
+  (old: {
+    cmakeFlags = old.cmakeFlags ++ [ "-DZ3_BUILD_LIBZ3_SHARED=OFF" ];
+  })

--- a/nix/toolchains/linux-gnu-2.28/default.nix
+++ b/nix/toolchains/linux-gnu-2.28/default.nix
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{ pkgs }:
+
+let
+  glibc = pkgs.callPackage ./libc.nix { };
+  mkStdenv =
+    {
+      libraryPaths ? [ ],
+      ldflags ? null,
+    }:
+    let
+      runtime = pkgs.buildEnv {
+        name = "gcc-static-runtime";
+        paths = libraryPaths ++ map pkgs.lib.getDev libraryPaths;
+        pathsToLink = [
+          "/include"
+          "/include-cxx"
+          "/lib"
+        ];
+        postBuild = ''
+          mkdir -p $out/lib
+          find $out/lib -type l ! \( -name '*.a' -o -name 'crt*.o' \) -delete
+          printf 'GROUP ( libgcc.a libgcc_eh.a )\n' > $out/lib/libgcc_s.a
+        '';
+        passthru.isGNU = true;
+      };
+    in
+    pkgs.stdenvAdapters.useMoldLinker (
+      pkgs.overrideCC pkgs.stdenv (
+        pkgs.wrapCCWith {
+          cc = pkgs.gccNGPackages.gcc-unwrapped.overrideAttrs (old: {
+            configureFlags = old.configureFlags ++ [ "--disable-fixincludes" ];
+          });
+          bintools = pkgs.wrapBintoolsWith {
+            bintools = pkgs.binutils-unwrapped;
+            libc = glibc;
+          };
+          extraPackages = [ runtime ];
+          libcxx = runtime;
+          nixSupport = {
+            cc-cflags = [
+              "-isystem${pkgs.linuxHeaders}/include"
+              "-static-libgcc"
+              "-B${runtime}/lib"
+            ];
+          }
+          // pkgs.lib.optionalAttrs (ldflags != null) { cc-ldflags = ldflags; };
+        }
+      )
+    );
+  libgcc =
+    (pkgs.gccNGPackages.libgcc.override {
+      stdenv = mkStdenv { };
+    }).overrideAttrs
+      (old: {
+        makeFlags = old.makeFlags ++ [ "SHLIB_LC=-lc" ];
+      });
+  libssp =
+    (pkgs.gccNGPackages.libssp.override {
+      stdenv = mkStdenv { libraryPaths = [ libgcc ]; };
+    }).overrideAttrs
+      {
+        dontDisableStatic = true;
+      };
+  libstdcxxStdenv = mkStdenv {
+    libraryPaths = [
+      libgcc
+      libssp
+    ];
+  };
+  libstdcxx =
+    (pkgs.gccNGPackages.libstdcxx.override {
+      stdenv = libstdcxxStdenv;
+      inherit libgcc;
+      libbacktrace = pkgs.libbacktrace.override {
+        stdenv = libstdcxxStdenv;
+      };
+    }).overrideAttrs
+      {
+        dontDisableStatic = true;
+      };
+  sharedRuntime = pkgs.buildEnv {
+    name = "gcc-shared-runtime";
+    paths = [
+      libgcc
+      libstdcxx
+    ];
+    pathsToLink = [ "/lib" ];
+  };
+  stdenv = mkStdenv {
+    libraryPaths = [
+      libgcc
+      libssp
+      libstdcxx
+    ];
+    ldflags = [ "-lssp" ];
+  };
+in
+{
+  inherit sharedRuntime stdenv;
+}

--- a/nix/toolchains/linux-gnu-2.28/libc.nix
+++ b/nix/toolchains/linux-gnu-2.28/libc.nix
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{
+  stdenv,
+  fetchurl,
+  linuxHeaders,
+  bison,
+  gawk,
+  python3,
+}:
+
+stdenv.mkDerivation {
+  pname = "glibc";
+  version = "2.28";
+  enableParallelBuilding = true;
+  hardeningDisable = [
+    "fortify"
+    "pic"
+  ];
+
+  src = fetchurl {
+    url = "https://ftp.gnu.org/gnu/glibc/glibc-2.28.tar.gz";
+    hash = "sha256-8xjW4/H07Qt00oMqxPSR0PuSjkUcntpZTL8cO+569Hw=";
+  };
+
+  postPatch = ''
+    substituteInPlace sysdeps/gnu/Makefile \
+      --replace-fail \
+        '$(object-suffixes) $(object-suffixes:=.d)' \
+        '$(object-suffixes)'
+  '';
+
+  nativeBuildInputs = [
+    bison
+    gawk
+    python3
+  ];
+
+  configureFlags = [
+    "--with-headers=${linuxHeaders}/include"
+    "--disable-werror"
+  ];
+
+  preConfigure = ''
+    mkdir build
+    cd build
+    configureScript=../configure
+  '';
+
+  postConfigure = ''
+    export NIX_DONT_SET_RPATH=1
+  '';
+
+  postFixup = ''
+    if grep -q "$out/lib64/" "$out/bin/ldd"; then
+      substituteInPlace "$out/bin/ldd" \
+        --replace-fail "$out/lib64/" "$out/lib/"
+    fi
+  '';
+
+  env.NIX_NO_SELF_RPATH = true;
+  passthru.threadModel = "posix";
+}


### PR DESCRIPTION
## Goal

This PR introduces Nix-managed Linux toolchains that aim to replace `cargo-zigbuild` for release builds.

The existing `cargo-zigbuild` CI workflows remain in place for now. These development shells establish and validate the replacement toolchains before CI is migrated.

## Toolchains

Two Linux development shells are added:

- `glibc-2-28` builds dynamically linked GNU binaries compatible with glibc 2.28.
- `musl` uses musl-native Rust, Cargo, and C toolchains to produce static PIE binaries.

Both environments support plain Cargo commands without target-specific linker configuration.

## System dependencies

Another goal is to vendor external system dependencies through Nix, especially native dependencies that are expensive to compile.

Z3 and AWS-LC are built as static Nix packages and discovered by their Rust `-sys` crates instead of being rebuilt from bundled sources by Cargo. This allows those builds to be cached and reused while keeping incremental Cargo builds focused on Rust code.

Additional native dependencies can follow the same pattern where it provides a meaningful build-time improvement.

## Link performance

Both toolchains use mold.

OpenShell has a large dependency graph and produces many binaries, test executables, proc-macro shared objects, and other linked artifacts. Link time therefore represents a significant portion of clean builds and development iterations. Using mold keeps these linker-heavy workloads practical without requiring Cargo-specific linker wrappers or flags.

## Validation

- Built OpenShell binaries in both development shells.
- Ran the workspace tests with the both toolchains.
- Verified the glibc binary’s required symbol versions and runtime dependencies.
- Verified that musl binaries are static PIE executables with no ELF interpreter or shared-library dependencies.
- Verified through the ELF `.comment` section that mold performed the links.