### PR TITLE
ci(branch-checks): run Rust checks in Nix shells

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,5 @@
+[profile.ci]
+fail-fast = false
+status-level = "fail"
+final-status-level = "fail"
+failure-output = "immediate-final"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 [profile.ci]
 fail-fast = false
 status-level = "fail"

--- a/.github/workflows/branch-checks.yml
+++ b/.github/workflows/branch-checks.yml
@@ -84,19 +84,23 @@ jobs:
     needs: pr_metadata
     if: needs.pr_metadata.outputs.should_run == 'true'
     runs-on: linux-amd64-cpu8
-    container:
-      image: ghcr.io/nvidia/openshell/ci:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: nix develop .#devShells.x86_64-linux.default -c bash -euo pipefail {0}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install tools
-        run: mise install --locked
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: openshell
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Check dependencies
-        run: mise run rust:deny:policy
+        run: cargo deny check licenses bans sources
 
   rust:
     name: Rust (${{ matrix.system }})

--- a/.github/workflows/branch-checks.yml
+++ b/.github/workflows/branch-checks.yml
@@ -99,114 +99,69 @@ jobs:
         run: mise run rust:deny:policy
 
   rust:
-    name: Rust (${{ matrix.runner }})
+    name: Rust (${{ matrix.system }})
     needs: pr_metadata
     if: needs.pr_metadata.outputs.should_run == 'true'
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-amd64-cpu8, linux-arm64-cpu8]
+        include:
+          - runner: linux-amd64-cpu8
+            system: x86_64-linux
+          - runner: linux-arm64-cpu8
+            system: aarch64-linux
+          - runner: macos-latest
+            system: aarch64-darwin
     runs-on: ${{ matrix.runner }}
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_VERSION: branch-checks-rust-${{ matrix.runner }}
-    container:
-      image: ghcr.io/nvidia/openshell/ci:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: nix develop .#devShells.${{ matrix.system }}.default -c bash -euo pipefail {0}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Configure GHA sccache backend
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install tools
-        run: mise install --locked
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: openshell
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Realize Nix development shell
+        shell: bash
+        run: nix build --no-link ".#devShells.${{ matrix.system }}.default"
 
       - name: Cache Rust target and registry
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          # Keep branch-check caches partitioned by runner architecture; lint
+          # Keep branch-check caches partitioned by target system; lint
           # and test intentionally share the same job-local target directory.
-          shared-key: rust-checks-${{ matrix.runner }}
+          shared-key: rust-checks-${{ matrix.system }}
           # Preserve compiled artifacts from failed lint/test runs so the next
           # push to the same PR branch does not start from a cold cache.
           cache-on-failure: "true"
+          cache-bin: "false"
+          cmd-format: nix develop .#devShells.${{ matrix.system }}.default -c {0}
 
       - name: Format
-        run: mise run rust:format:check
+        run: |
+          cargo fmt --all -- --check
+          cargo fmt --manifest-path e2e/rust/Cargo.toml --all -- --check
+          cargo fmt --manifest-path examples/governance-interceptor/Cargo.toml --all -- --check
 
       - name: Lint
-        run: mise run rust:lint
+        run: |
+          cargo clippy --workspace --all-targets -- -D warnings
+          cargo clippy --manifest-path e2e/rust/Cargo.toml --all-targets -- -D warnings
+          cargo check --manifest-path examples/governance-interceptor/Cargo.toml --all-targets
 
       - name: Test
-        run: mise run test:rust
-
-      - name: Verify telemetry can be compiled out
-        run: mise run rust:verify:telemetry-off
-
-      - name: Verify system CA roots build mode compiles and excludes bundled Mozilla roots
-        run: mise run rust:verify:system-ca-roots
-
-      - name: sccache stats
-        if: always()
+        env:
+          OPENSHELL_TELEMETRY_ENABLED: "false"
         run: |
-          set +e
-          stats_bin="${SCCACHE_PATH:-sccache}"
-          "$stats_bin" --show-stats
-          status=$?
-          if [ "$status" -ne 0 ]; then
-            echo "::warning::sccache stats unavailable (exit $status)"
-          fi
-          exit 0
-
-  rust-macos:
-    name: Rust lint (macOS)
-    needs: pr_metadata
-    if: needs.pr_metadata.outputs.should_run == 'true'
-    runs-on: macos-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Install mise
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://mise.run | MISE_VERSION=v2026.4.25 sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          echo "$HOME/.local/share/mise/shims" >> "$GITHUB_PATH"
-
-      - name: Configure GHA sccache backend
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-
-      - name: Install Rust and Clippy
-        run: |
-          mise install --locked rust
-          rustup component add clippy
-
-      - name: Cache Rust target and registry
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-        with:
-          shared-key: rust-clippy-macos
-          cache-on-failure: "true"
-
-      - name: Lint macOS-sensitive crates
-        # Formatting is target-independent and already checked by the Linux jobs.
-        # The full mise lint covers every workspace/E2E target and requires extra
-        # native dependencies such as Z3; keep this guard focused on macOS cfgs.
-        run: |
-          cargo clippy \
-            -p openshell-sandbox \
-            -p openshell-core \
-            -p openshell-cli \
-            -p openshell-driver-db-credstore \
-            -p openshell-driver-docker \
-            -p openshell-driver-kubernetes \
-            -p openshell-driver-kubernetes-secrets \
-            -p openshell-driver-podman \
-            -p openshell-driver-vault \
-            --all-targets \
-            -- -D warnings
+          cargo test --workspace --exclude openshell-server
+          cargo test -p openshell-server --features test-support
 
   python:
     name: Python (${{ matrix.runner }})

--- a/.github/workflows/branch-checks.yml
+++ b/.github/workflows/branch-checks.yml
@@ -141,6 +141,7 @@ jobs:
           # Preserve compiled artifacts from failed lint/test runs so the next
           # push to the same PR branch does not start from a cold cache.
           cache-on-failure: "true"
+          cache-workspace-crates: "true"
           cache-bin: "false"
           cmd-format: nix develop .#devShells.${{ matrix.system }}.default -c {0}
 

--- a/.github/workflows/branch-checks.yml
+++ b/.github/workflows/branch-checks.yml
@@ -110,7 +110,7 @@ jobs:
             system: x86_64-linux
           - runner: linux-arm64-cpu8
             system: aarch64-linux
-          - runner: macos-latest
+          - runner: macos-15-xlarge
             system: aarch64-darwin
     runs-on: ${{ matrix.runner }}
     defaults:
@@ -160,8 +160,7 @@ jobs:
         env:
           OPENSHELL_TELEMETRY_ENABLED: "false"
         run: |
-          cargo test --workspace --exclude openshell-server
-          cargo test -p openshell-server --features test-support
+          cargo nextest run --profile ci --workspace --features openshell-server/test-support
 
   python:
     name: Python (${{ matrix.runner }})

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
         };
         testGuestPkgs = import nixpkgs-test-guest { inherit system; };
         commonDevShellPackages = with pkgs; [
+          cargo-nextest
           # Assemble Debian artifacts on macOS and Linux.
           dpkg
           # Required to find packages.

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
         };
         testGuestPkgs = import nixpkgs-test-guest { inherit system; };
         commonDevShellPackages = with pkgs; [
+          cargo-deny
           cargo-nextest
           # Assemble Debian artifacts on macOS and Linux.
           dpkg


### PR DESCRIPTION
## Summary

Run Rust branch checks through the flake’s default development shell, keeping CI toolchains and native dependencies consistent with local development.

## Related Issue

No issue required: localized CI workflow refactor.

## Changes

- Run Rust checks on `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.
- Replace the CI container, mise, and sccache with Nix and Cachix.
- Retain `rust-cache` for Cargo registry and build artifacts.
- Remove brittle telemetry and CA-root dependency checks.

## Testing

- [ ] `mise run pre-commit` passes
- [x] Unit tests not required for this CI-only change
- [x] E2E tests not required
- [x] Workflow passes `actionlint` validation

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [x] Architecture docs not required