### PR TITLE
chore(docs): relicense Fern stylesheet under Apache 2.0

### DIFF
--- a/fern/main.css
+++ b/fern/main.css
@@ -1,13 +1,6 @@
 /*!
  * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
- *
- * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
- * property and proprietary rights in and to this material, related
- * documentation and any modifications thereto. Any use, reproduction,
- * disclosure or distribution of this material and related documentation
- * without an express license agreement from NVIDIA CORPORATION or
- * its affiliates is strictly prohibited.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /* Color themes for light and dark modes */


### PR DESCRIPTION
## Summary

Relicense the Fern custom stylesheet under Apache-2.0 so it can be included in the OpenShell open-source release.

## Related Issue

No issue required: this is a localized license-header correction requested during OSRB review (NvBug 5544518).

## Changes

- Replace `LicenseRef-NvidiaProprietary` with `Apache-2.0` in `fern/main.css`
- Remove the proprietary-use restriction from the file header
- Retain the existing NVIDIA copyright attribution

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated (not applicable: header-only change)
- [ ] E2E tests added/updated (not applicable: header-only change)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
