### PR TITLE
fix(cli): reference a published sandbox image

### DIFF
--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -312,7 +312,7 @@ const SANDBOX_EXAMPLES: &str = "\x1b[1mALIAS\x1b[0m
 
 \x1b[1mEXAMPLES\x1b[0m
   $ openshell sandbox create
-  $ openshell sandbox create --from python
+  $ openshell sandbox create --from base
   $ openshell sandbox connect my-sandbox
   $ openshell sandbox list
   $ openshell sandbox delete my-sandbox

--- a/crates/openshell-sdk/src/types.rs
+++ b/crates/openshell-sdk/src/types.rs
@@ -98,7 +98,7 @@ impl From<i32> for SandboxPhase {
 pub struct SandboxSpec {
     /// Optional user-supplied sandbox name. When empty the server generates one.
     pub name: Option<String>,
-    /// Container image reference (e.g. `ghcr.io/nvidia/openshell-community/sandboxes/python:latest`).
+    /// Container image reference (e.g. `ghcr.io/nvidia/openshell-community/sandboxes/base:latest`).
     pub image: Option<String>,
     /// Labels attached to the sandbox.
     pub labels: HashMap<String, String>,


### PR DESCRIPTION
## Summary

Replace stale references to the unpublished `python` community sandbox with the published `base` image so users can follow the CLI and SDK examples successfully.

## Related Issue

Closes #2888

## Changes

- Updated the `openshell sandbox` help example to use `--from base`
- Updated the Rust SDK image-reference documentation to show the published `base` image

## Testing

- [x] `git diff --check` passes
- [ ] `mise run pre-commit` (not run: `mise` is unavailable in this environment)
- [ ] Unit tests added/updated (not applicable: string and documentation examples only)
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)