### PR TITLE
fix(vm): bump gvproxy to v0.8.9

### DIFF
--- a/crates/openshell-driver-vm/runtime/pins.env
+++ b/crates/openshell-driver-vm/runtime/pins.env
@@ -31,7 +31,7 @@ COMMUNITY_SANDBOX_IMAGE="${COMMUNITY_SANDBOX_IMAGE:-ghcr.io/nvidia/openshell-com
 
 # ── gvproxy (networking proxy) ──────────────────────────────────────────
 # Repo: https://github.com/containers/gvisor-tap-vsock
-GVPROXY_VERSION="${GVPROXY_VERSION:-v0.8.8}"
+GVPROXY_VERSION="${GVPROXY_VERSION:-v0.8.9}"
 
 # ── umoci (guest OCI unpacker) ──────────────────────────────────────────
 # Repo: https://github.com/opencontainers/umoci


### PR DESCRIPTION
> **🏗️ build-from-issue-agent**

## Summary

Update the VM runtime gvproxy pin to v0.8.9 so released macOS MicroVM runtime bundles include the upstream zero-byte UDP read tight-loop fix.

## Related Issue

Closes #2895

## Changes

- Bumped the centralized `GVPROXY_VERSION` runtime pin from v0.8.8 to v0.8.9.
- Verified the upstream macOS release asset is a universal x86_64/arm64 binary and reports v0.8.9.

### Deviations from Plan

None — implemented as planned.

## Testing

- [x] `mise run pre-commit` passes
- [x] Packaging-script syntax and runtime pin consumption checks pass
- [x] Verified upstream `gvproxy-darwin` v0.8.9 artifact availability and version
- [ ] E2E tests added/updated (not applicable: no `e2e/` changes; this is a bundled upstream binary pin)

**Tests added:**
- **Unit:** N/A — behavior is supplied by the pinned upstream binary.
- **Integration:** N/A — no local integration harness covers upstream network-disruption behavior.
- **E2E:** N/A — no `e2e/` changes; the release workflow rebuilds the bundled runtime artifact.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)

**Documentation updated:**
- None needed — no user-facing configuration or workflow changed.