### PR TITLE
feat(sdk): add OAuth Client Credentials support to SDKs

### DIFF
--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -193,8 +193,9 @@ Python and Go SDK client-credentials providers can use the same registered
 issuer, client ID, audience, and scope metadata; the TypeScript provider accepts
 those fields explicitly. All three own a separate in-memory lifecycle, repeat
 the grant before expiry, and never persist the client secret or acquired access
-token into the CLI token cache. This keeps non-interactive SDK authentication
-independent from refresh-token rotation and shared disk state.
+token into the CLI token cache. They require TLS when sending renewable bearer
+credentials to non-loopback gateways. This keeps non-interactive SDK
+authentication independent from refresh-token rotation and shared disk state.
 
 Gateway health and user authentication are separate probes. `OpenShell.Health`
 remains unauthenticated so deployment and load-balancer health checks do not

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -189,6 +189,12 @@ reuses them when refreshing an access token. This preserves the intended API
 resource selection for identity providers that bind access-token audiences to
 OAuth scopes.
 
+SDK client-credentials providers use the same registered issuer, client ID,
+audience, and scope metadata but own a separate in-memory lifecycle. They repeat
+the grant before expiry and never persist the client secret or acquired access
+token into the CLI token cache. This keeps non-interactive SDK authentication
+independent from refresh-token rotation and shared disk state.
+
 Gateway health and user authentication are separate probes. `OpenShell.Health`
 remains unauthenticated so deployment and load-balancer health checks do not
 depend on user credentials. The CLI uses the existing, side-effect-free

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -189,9 +189,10 @@ reuses them when refreshing an access token. This preserves the intended API
 resource selection for identity providers that bind access-token audiences to
 OAuth scopes.
 
-SDK client-credentials providers use the same registered issuer, client ID,
-audience, and scope metadata but own a separate in-memory lifecycle. They repeat
-the grant before expiry and never persist the client secret or acquired access
+Python and Go SDK client-credentials providers can use the same registered
+issuer, client ID, audience, and scope metadata; the TypeScript provider accepts
+those fields explicitly. All three own a separate in-memory lifecycle, repeat
+the grant before expiry, and never persist the client secret or acquired access
 token into the CLI token cache. This keeps non-interactive SDK authentication
 independent from refresh-token rotation and shared disk state.
 

--- a/docs/reference/gateway-auth.mdx
+++ b/docs/reference/gateway-auth.mdx
@@ -127,7 +127,8 @@ authentication directly. Configure the service account at the identity provider
 with the audience, roles, scopes, and workspace membership required by the
 gateway. The SDKs discover the token endpoint, attach the bearer token to each
 RPC, and repeat the grant before expiry. They keep the client secret and access
-token in memory and do not update the CLI's `oidc_token.json`.
+token in memory and do not update the CLI's `oidc_token.json`. SDK clients
+require TLS when sending these credentials to a non-loopback gateway.
 
 <Tabs>
   <Tab title="Python">

--- a/docs/reference/gateway-auth.mdx
+++ b/docs/reference/gateway-auth.mdx
@@ -122,6 +122,58 @@ openshell gateway add https://gateway.example.com \
 
 When you register or log in to an OIDC gateway, the CLI uses the Authorization Code flow with PKCE. It opens a browser, receives the authorization code on a localhost callback, exchanges the code for tokens, and stores the token bundle under the gateway credential directory. After `openshell gateway logout`, the next browser login asks the identity provider for a fresh login prompt so you can choose a different browser user instead of silently reusing the previous session. If `OPENSHELL_OIDC_CLIENT_SECRET` is set, the CLI uses the client credentials flow instead. Use that mode for CI and other non-interactive automation.
 
+Official Python, TypeScript, and Go SDKs can perform renewable client-credentials
+authentication directly. Configure the service account at the identity provider
+with the audience, roles, scopes, and workspace membership required by the
+gateway. The SDKs discover the token endpoint, attach the bearer token to each
+RPC, and repeat the grant before expiry. They keep the client secret and access
+token in memory and do not update the CLI's `oidc_token.json`.
+
+<Tabs>
+  <Tab title="Python">
+
+```python
+from openshell import ClientCredentialsAuth, SandboxClient
+
+auth = ClientCredentialsAuth(
+    client_secret=lambda: load_secret(),
+    # Omit issuer/client_id/scopes/audience to use active gateway metadata.
+)
+client = SandboxClient.from_active_cluster(client_credentials=auth)
+```
+
+  </Tab>
+  <Tab title="TypeScript">
+
+```ts
+import { clientCredentials, OpenShellClient } from '@nvidia/openshell-sdk'
+
+const client = await OpenShellClient.connect({
+  gateway: 'https://gateway.example.com',
+  oidcTokenProvider: clientCredentials({
+    issuer: 'https://idp.example.com/realms/openshell',
+    clientId: 'openshell-service',
+    clientSecret: () => loadSecret(),
+    audience: 'openshell-gateway',
+    scopes: ['sandbox:read', 'sandbox:write'],
+  }),
+})
+```
+
+  </Tab>
+  <Tab title="Go">
+
+```go
+auth, err := oidc.NewClientCredentialsAuth(
+    oidc.WithGateway("production"),
+    oidc.WithClientSecretProvider(loadSecret),
+)
+client, err := v1.NewClient(v1.Config{Address: address, Auth: auth, TLS: tlsConfig})
+```
+
+  </Tab>
+</Tabs>
+
 The connection flow:
 
 For a headless environment, set `OPENSHELL_NO_BROWSER=1` before registering or logging in to the gateway. When this variable is set and `OPENSHELL_OIDC_CLIENT_SECRET` is not configured, the CLI uses the Device Authorization Grant (RFC 8628) with S256 PKCE. This flow prompts the user to visit a verification URL on any device with a browser and enter a displayed code. The CLI polls the token endpoint until the user completes authorization. This requires the OIDC client to have the device authorization grant enabled on the identity provider.

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -269,7 +269,7 @@ with SandboxClient.from_active_cluster() as client:
 
 For non-interactive automation, pass a renewable client-credentials provider.
 Omitted issuer, client ID, audience, and scopes are read from the active
-gateway's metadata:
+gateway's metadata. The client requires TLS for non-loopback gateways:
 
 ```python
 from openshell import ClientCredentialsAuth, SandboxClient

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -276,7 +276,7 @@ from openshell import ClientCredentialsAuth, SandboxClient
 
 auth = ClientCredentialsAuth(client_secret=lambda: load_secret())
 with SandboxClient.from_active_cluster(client_credentials=auth) as client:
-    sandboxes = client.list()
+    sandboxes = client.list(workspace="default")
 ```
 
 ## Expose Long Running Services

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -267,6 +267,18 @@ with SandboxClient.from_active_cluster() as client:
     assert sandbox.id in {s.id for s in matches}
 ```
 
+For non-interactive automation, pass a renewable client-credentials provider.
+Omitted issuer, client ID, audience, and scopes are read from the active
+gateway's metadata:
+
+```python
+from openshell import ClientCredentialsAuth, SandboxClient
+
+auth = ClientCredentialsAuth(client_secret=lambda: load_secret())
+with SandboxClient.from_active_cluster(client_credentials=auth) as client:
+    sandboxes = client.list()
+```
+
 ## Expose Long Running Services
 
 Service forwarding makes a long-running process inside a sandbox reachable through a gateway-managed URL. Use it for development servers, notebooks, dashboards, or other services that keep listening after the sandbox starts. Run the service on loopback inside the sandbox, expose its port, then open the URL printed by OpenShell.

--- a/e2e/python/oidc/oidc_auth_test.py
+++ b/e2e/python/oidc/oidc_auth_test.py
@@ -15,17 +15,23 @@ from __future__ import annotations
 
 import contextlib
 import os
+import urllib.parse
+from pathlib import Path
 
 import grpc
 import pytest
 
+from openshell import ClientCredentialsAuth, SandboxClient, TlsConfig
 from openshell._proto import datamodel_pb2, openshell_pb2, openshell_pb2_grpc
 
 from .helpers import (
+    KEYCLOAK_REALM,
+    _gateway_endpoint,
+    _mtls_dir,
     extract_sub,
-    get_ci_token,
     get_token,
     grpc_channel,
+    keycloak_url,
     stub_with_token,
 )
 
@@ -180,9 +186,28 @@ class TestClientCredentials:
     def test_ci_token_can_list_sandboxes(self) -> None:
         admin_token = get_token("admin@test", "admin", scopes="openid openshell:all")
         admin_stub, admin_md = stub_with_token(admin_token)
-        ci_token = get_ci_token()
+        auth = ClientCredentialsAuth(
+            issuer=f"{keycloak_url()}/realms/{KEYCLOAK_REALM}",
+            client_id="openshell-ci",
+            client_secret="ci-test-secret",
+        )
+        ci_token = auth()
         ci_sub = extract_sub(ci_token)
-        ci_stub, ci_md = stub_with_token(ci_token)
+        gateway_endpoint, is_tls = _gateway_endpoint()
+        parsed = urllib.parse.urlparse(gateway_endpoint)
+        target = f"{parsed.hostname}:{parsed.port or (443 if is_tls else 80)}"
+        tls = None
+        if is_tls:
+            if ca_path := os.environ.get("OPENSHELL_E2E_GATEWAY_CA_CERT"):
+                tls = TlsConfig(ca_path=Path(ca_path))
+            else:
+                mtls = _mtls_dir()
+                tls = TlsConfig(
+                    ca_path=mtls / "ca.crt",
+                    cert_path=mtls / "tls.crt",
+                    key_path=mtls / "tls.key",
+                )
+        ci_client = SandboxClient(target, tls=tls, client_credentials=auth)
 
         with contextlib.suppress(grpc.RpcError):
             admin_stub.AddWorkspaceMember(
@@ -194,8 +219,9 @@ class TestClientCredentials:
                 metadata=admin_md,
             )
         try:
-            ci_stub.ListSandboxes(openshell_pb2.ListSandboxesRequest(), metadata=ci_md)
+            ci_client.list(workspace="default")
         finally:
+            ci_client.close()
             with contextlib.suppress(grpc.RpcError):
                 admin_stub.RemoveWorkspaceMember(
                     openshell_pb2.RemoveWorkspaceMemberRequest(

--- a/python/openshell/__init__.py
+++ b/python/openshell/__init__.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from .sandbox import (
+    ClientCredentialsAuth,
     ExecChunk,
     ExecResult,
     InferenceRouteClient,
@@ -29,6 +30,7 @@ except Exception:
     __version__ = "0.0.0"
 
 __all__ = [
+    "ClientCredentialsAuth",
     "ExecChunk",
     "ExecResult",
     "InferenceRouteClient",

--- a/python/openshell/sandbox.py
+++ b/python/openshell/sandbox.py
@@ -130,6 +130,22 @@ def _normalize_bearer(
     return lambda: token
 
 
+def _is_loopback_host(hostname: str | None) -> bool:
+    if hostname is None:
+        return False
+    if hostname.lower() == "localhost":
+        return True
+    with contextlib.suppress(ValueError):
+        return ipaddress.ip_address(hostname).is_loopback
+    return False
+
+
+def _is_local_grpc_endpoint(endpoint: str) -> bool:
+    if endpoint.startswith("unix:"):
+        return True
+    return _is_loopback_host(urlparse(f"//{endpoint}").hostname)
+
+
 def _validate_oauth_url(name: str, raw: str) -> str:
     """Validate an OAuth endpoint without reflecting attacker-controlled URLs."""
     parsed = urlparse(raw)
@@ -139,11 +155,7 @@ def _validate_oauth_url(name: str, raw: str) -> str:
         raise SandboxError(f"OAuth {name} URL must not contain a fragment")
     if parsed.scheme == "https":
         return raw
-    loopback = parsed.hostname.lower() == "localhost"
-    if not loopback:
-        with contextlib.suppress(ValueError):
-            loopback = ipaddress.ip_address(parsed.hostname).is_loopback
-    if parsed.scheme == "http" and loopback:
+    if parsed.scheme == "http" and _is_loopback_host(parsed.hostname):
         return raw
     raise SandboxError(
         f"OAuth {name} URL must use HTTPS (HTTP is allowed only for loopback hosts)"
@@ -510,7 +522,8 @@ class SandboxClient:
                 the gateway uses mTLS for transport identity and OIDC
                 for user identity.
             client_credentials: renewable OAuth client-credentials provider.
-                Mutually exclusive with `bearer_token`.
+                Mutually exclusive with `bearer_token`. A non-loopback endpoint
+                requires `tls` so the acquired bearer is never sent in cleartext.
             timeout: default per-call timeout in seconds.
             cluster_name: optional friendly name for error messages.
             _bearer_close: internal — wired by `from_active_cluster`
@@ -523,6 +536,14 @@ class SandboxClient:
         if bearer_token is not None and client_credentials is not None:
             raise SandboxError(
                 "bearer_token and client_credentials are mutually exclusive"
+            )
+        if (
+            client_credentials is not None
+            and tls is None
+            and not _is_local_grpc_endpoint(endpoint)
+        ):
+            raise SandboxError(
+                "OAuth client credentials require TLS for non-loopback gateway endpoints"
             )
         self._endpoint = endpoint
         self._timeout = timeout
@@ -592,7 +613,7 @@ class SandboxClient:
             client_credentials: renewable OAuth client-credentials provider.
                 Omitted issuer, client ID, audience, and scopes are filled from
                 the registered gateway metadata. This provider does not read or
-                write `oidc_token.json`.
+                write `oidc_token.json`. Remote plaintext gateways are rejected.
         """
         cluster_name = cluster or _resolve_active_cluster()
         gateway_dir = _xdg_config_home() / "openshell" / "gateways" / cluster_name
@@ -638,7 +659,6 @@ class SandboxClient:
                     f"gateway '{cluster_name}' is not configured for OIDC"
                 )
             client_credentials._apply_gateway_metadata(metadata, insecure=insecure)
-            bearer_token = client_credentials
         elif metadata.get("auth_mode") == "oidc":
             bearer_token, bearer_close = _make_cluster_bearer_provider(
                 gateway_dir,
@@ -652,6 +672,7 @@ class SandboxClient:
             endpoint,
             tls=tls,
             bearer_token=bearer_token,
+            client_credentials=client_credentials,
             timeout=timeout,
             cluster_name=cluster_name,
             _bearer_close=bearer_close,

--- a/python/openshell/sandbox.py
+++ b/python/openshell/sandbox.py
@@ -191,7 +191,7 @@ class ClientCredentialsAuth:
         client_secret: str | Callable[[], str],
         issuer: str | None = None,
         client_id: str | None = None,
-        scopes: Sequence[str] = (),
+        scopes: Sequence[str] | None = None,
         audience: str | None = None,
         insecure: bool = False,
         timeout: float = 30.0,
@@ -204,7 +204,7 @@ class ClientCredentialsAuth:
         self._secret = client_secret
         self._issuer = issuer
         self._client_id = client_id
-        self._scopes = tuple(scopes)
+        self._scopes = tuple(scopes) if scopes is not None else None
         self._audience = audience
         self._insecure = insecure
         self._timeout = timeout
@@ -221,8 +221,10 @@ class ClientCredentialsAuth:
             f"scopes={self._scopes!r}, audience={self._audience!r})"
         )
 
-    def _apply_gateway_metadata(self, metadata: Mapping[str, object]) -> None:
-        """Fill omitted public fields from registered gateway metadata."""
+    def _apply_gateway_metadata(
+        self, metadata: Mapping[str, object], *, insecure: bool = False
+    ) -> None:
+        """Fill omitted fields and apply active-gateway transport settings."""
         if self._issuer is None:
             value = metadata.get("oidc_issuer")
             self._issuer = value if isinstance(value, str) and value else None
@@ -232,10 +234,13 @@ class ClientCredentialsAuth:
         if self._audience is None:
             value = metadata.get("oidc_audience")
             self._audience = value if isinstance(value, str) and value else None
-        if not self._scopes:
+        if self._scopes is None:
             value = metadata.get("oidc_scopes")
             if isinstance(value, str):
                 self._scopes = tuple(value.split())
+        # Preserve an explicit provider-level opt-in while also honoring the
+        # active-gateway construction flag used by the existing OIDC refresher.
+        self._insecure = self._insecure or insecure
 
     def __call__(self) -> str:
         if (
@@ -632,7 +637,7 @@ class SandboxClient:
                 raise SandboxError(
                     f"gateway '{cluster_name}' is not configured for OIDC"
                 )
-            client_credentials._apply_gateway_metadata(metadata)
+            client_credentials._apply_gateway_metadata(metadata, insecure=insecure)
             bearer_token = client_credentials
         elif metadata.get("auth_mode") == "oidc":
             bearer_token, bearer_close = _make_cluster_bearer_provider(

--- a/python/openshell/sandbox.py
+++ b/python/openshell/sandbox.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import base64
 import contextlib
 import errno
+import ipaddress
 import json
+import math
 import os
 import pathlib
 import sys
@@ -33,6 +35,8 @@ _ClientCallDetailsBase = namedtuple(
     "_ClientCallDetailsBase",
     ("method", "timeout", "metadata", "credentials", "wait_for_ready", "compression"),
 )
+
+_OAUTH_MAX_RESPONSE_BYTES = 1 << 20
 
 
 class _ClientCallDetails(_ClientCallDetailsBase, grpc.ClientCallDetails):
@@ -124,6 +128,221 @@ def _normalize_bearer(
         return cast("Callable[[], str]", bearer)
     token = bearer
     return lambda: token
+
+
+def _validate_oauth_url(name: str, raw: str) -> str:
+    """Validate an OAuth endpoint without reflecting attacker-controlled URLs."""
+    parsed = urlparse(raw)
+    if not parsed.scheme or not parsed.hostname or parsed.username or parsed.password:
+        raise SandboxError(f"invalid OAuth {name} URL")
+    if parsed.fragment:
+        raise SandboxError(f"OAuth {name} URL must not contain a fragment")
+    if parsed.scheme == "https":
+        return raw
+    loopback = parsed.hostname.lower() == "localhost"
+    if not loopback:
+        with contextlib.suppress(ValueError):
+            loopback = ipaddress.ip_address(parsed.hostname).is_loopback
+    if parsed.scheme == "http" and loopback:
+        return raw
+    raise SandboxError(
+        f"OAuth {name} URL must use HTTPS (HTTP is allowed only for loopback hosts)"
+    )
+
+
+def _oauth_json_request(
+    client: httpx.Client,
+    method: str,
+    url: str,
+    *,
+    kind: str,
+    headers: Mapping[str, str],
+    data: Mapping[str, str] | None = None,
+) -> tuple[int, dict[str, object]]:
+    """Read a bounded JSON response without retaining arbitrary error bodies."""
+    with client.stream(method, url, headers=headers, data=data) as response:
+        if response.status_code != 200:
+            return response.status_code, {}
+        content = bytearray()
+        for chunk in response.iter_bytes():
+            content.extend(chunk)
+            if len(content) > _OAUTH_MAX_RESPONSE_BYTES:
+                raise SandboxError(f"OAuth {kind} response is too large")
+    try:
+        payload = json.loads(content)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise SandboxError(f"OAuth {kind} returned invalid JSON") from None
+    if not isinstance(payload, dict):
+        raise SandboxError(f"OAuth {kind} returned invalid JSON")
+    return 200, payload
+
+
+class ClientCredentialsAuth:
+    """Renewable OAuth 2.0 client-credentials bearer provider.
+
+    Tokens and client secrets remain in memory. The first RPC lazily performs
+    discovery and an exchange; later RPCs share the cached token until it is
+    within 30 seconds of expiry. Concurrent callers share one exchange.
+    """
+
+    def __init__(
+        self,
+        *,
+        client_secret: str | Callable[[], str],
+        issuer: str | None = None,
+        client_id: str | None = None,
+        scopes: Sequence[str] = (),
+        audience: str | None = None,
+        insecure: bool = False,
+        timeout: float = 30.0,
+        _transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if not isinstance(client_secret, str) and not callable(client_secret):
+            raise TypeError("client_secret must be a string or zero-argument callable")
+        if isinstance(client_secret, str) and not client_secret:
+            raise SandboxError("OAuth client secret must not be empty")
+        self._secret = client_secret
+        self._issuer = issuer
+        self._client_id = client_id
+        self._scopes = tuple(scopes)
+        self._audience = audience
+        self._insecure = insecure
+        self._timeout = timeout
+        self._transport = _transport
+        self._lock = threading.Lock()
+        self._access_token: str | None = None
+        self._expires_at = 0.0
+        self._token_endpoint: str | None = None
+
+    def __repr__(self) -> str:
+        return (
+            "ClientCredentialsAuth(issuer="
+            f"{self._issuer!r}, client_id={self._client_id!r}, "
+            f"scopes={self._scopes!r}, audience={self._audience!r})"
+        )
+
+    def _apply_gateway_metadata(self, metadata: Mapping[str, object]) -> None:
+        """Fill omitted public fields from registered gateway metadata."""
+        if self._issuer is None:
+            value = metadata.get("oidc_issuer")
+            self._issuer = value if isinstance(value, str) and value else None
+        if self._client_id is None:
+            value = metadata.get("oidc_client_id")
+            self._client_id = value if isinstance(value, str) and value else None
+        if self._audience is None:
+            value = metadata.get("oidc_audience")
+            self._audience = value if isinstance(value, str) and value else None
+        if not self._scopes:
+            value = metadata.get("oidc_scopes")
+            if isinstance(value, str):
+                self._scopes = tuple(value.split())
+
+    def __call__(self) -> str:
+        if (
+            self._access_token is not None
+            and time.time() + _OIDC_TOKEN_EXPIRY_GRACE_SECONDS < self._expires_at
+        ):
+            return self._access_token
+        with self._lock:
+            if (
+                self._access_token is not None
+                and time.time() + _OIDC_TOKEN_EXPIRY_GRACE_SECONDS < self._expires_at
+            ):
+                return self._access_token
+            token, expires_at = self._exchange()
+            self._access_token = token
+            self._expires_at = expires_at
+            return token
+
+    def _exchange(self) -> tuple[str, float]:
+        if not self._issuer or not self._client_id:
+            raise SandboxError("OAuth client credentials require issuer and client_id")
+        issuer = _validate_oauth_url("issuer", self._issuer).rstrip("/")
+        headers = {"accept": "application/json"}
+        try:
+            with httpx.Client(
+                verify=not self._insecure,
+                follow_redirects=False,
+                timeout=self._timeout,
+                transport=self._transport,
+            ) as client:
+                if self._token_endpoint is None:
+                    status, discovery = _oauth_json_request(
+                        client,
+                        "GET",
+                        f"{issuer}/.well-known/openid-configuration",
+                        kind="discovery",
+                        headers=headers,
+                    )
+                    if status != 200:
+                        raise SandboxError(f"OAuth discovery failed with HTTP {status}")
+                    discovered = discovery.get("issuer")
+                    if (
+                        not isinstance(discovered, str)
+                        or discovered.rstrip("/") != issuer
+                    ):
+                        raise SandboxError("OAuth discovery issuer mismatch")
+                    endpoint = discovery.get("token_endpoint")
+                    if not isinstance(endpoint, str) or not endpoint:
+                        raise SandboxError(
+                            "OAuth discovery document is missing token_endpoint"
+                        )
+                    self._token_endpoint = _validate_oauth_url(
+                        "token endpoint", endpoint
+                    )
+                secret = self._resolve_secret()
+                data = {
+                    "grant_type": "client_credentials",
+                    "client_id": self._client_id,
+                    "client_secret": secret,
+                }
+                if self._scopes:
+                    data["scope"] = " ".join(self._scopes)
+                if self._audience:
+                    data["audience"] = self._audience
+                status, payload = _oauth_json_request(
+                    client,
+                    "POST",
+                    self._token_endpoint,
+                    kind="client credentials response",
+                    data=data,
+                    headers=headers,
+                )
+        except SandboxError:
+            raise
+        except httpx.HTTPError:
+            raise SandboxError("OAuth client credentials request failed") from None
+        if status != 200:
+            raise SandboxError(
+                f"OAuth client credentials exchange failed with HTTP {status}"
+            )
+        access_token = payload.get("access_token")
+        expires_in = payload.get("expires_in")
+        if not isinstance(access_token, str) or not access_token:
+            raise SandboxError(
+                "OAuth client credentials response is missing access_token"
+            )
+        if (
+            isinstance(expires_in, bool)
+            or not isinstance(expires_in, (int, float))
+            or not math.isfinite(expires_in)
+            or expires_in <= 0
+        ):
+            raise SandboxError(
+                "OAuth client credentials response requires a positive finite expires_in"
+            )
+        return access_token, time.time() + float(expires_in)
+
+    def _resolve_secret(self) -> str:
+        if isinstance(self._secret, str):
+            return self._secret
+        try:
+            value = self._secret()
+        except Exception:
+            raise SandboxError("OAuth client secret supplier failed") from None
+        if not isinstance(value, str) or not value:
+            raise SandboxError("OAuth client secret supplier returned an empty secret")
+        return value
 
 
 @dataclass(frozen=True)
@@ -270,6 +489,7 @@ class SandboxClient:
         *,
         tls: TlsConfig | None = None,
         bearer_token: str | Callable[[], str] | None = None,
+        client_credentials: ClientCredentialsAuth | None = None,
         timeout: float = 30.0,
         cluster_name: str | None = None,
         _bearer_close: Callable[[], None] | None = None,
@@ -284,6 +504,8 @@ class SandboxClient:
                 runtime refresh). Combines with `tls` — pass both when
                 the gateway uses mTLS for transport identity and OIDC
                 for user identity.
+            client_credentials: renewable OAuth client-credentials provider.
+                Mutually exclusive with `bearer_token`.
             timeout: default per-call timeout in seconds.
             cluster_name: optional friendly name for error messages.
             _bearer_close: internal — wired by `from_active_cluster`
@@ -293,6 +515,10 @@ class SandboxClient:
                 lifecycle of any callable they supplied as
                 `bearer_token`.
         """
+        if bearer_token is not None and client_credentials is not None:
+            raise SandboxError(
+                "bearer_token and client_credentials are mutually exclusive"
+            )
         self._endpoint = endpoint
         self._timeout = timeout
         self._cluster_name = cluster_name
@@ -312,7 +538,7 @@ class SandboxClient:
                 ),
             )
             self._channel = grpc.secure_channel(endpoint, credentials)
-        provider = _normalize_bearer(bearer_token)
+        provider = _normalize_bearer(client_credentials or bearer_token)
         if provider is not None:
             self._channel = grpc.intercept_channel(
                 self._channel,
@@ -329,6 +555,7 @@ class SandboxClient:
         auto_refresh: bool = True,
         write_back: bool = True,
         insecure: bool = False,
+        client_credentials: ClientCredentialsAuth | None = None,
     ) -> SandboxClient:
         """Construct a `SandboxClient` from the active gateway's on-disk state.
 
@@ -357,6 +584,10 @@ class SandboxClient:
                 for OIDC discovery and refresh calls. Mirrors the Rust
                 CLI's `--insecure` flag for issuers behind self-signed
                 certs. Off by default.
+            client_credentials: renewable OAuth client-credentials provider.
+                Omitted issuer, client ID, audience, and scopes are filled from
+                the registered gateway metadata. This provider does not read or
+                write `oidc_token.json`.
         """
         cluster_name = cluster or _resolve_active_cluster()
         gateway_dir = _xdg_config_home() / "openshell" / "gateways" / cluster_name
@@ -396,7 +627,14 @@ class SandboxClient:
         # a non-OIDC gateway should NOT cause us to attach a bearer.
         bearer_token: Callable[[], str] | None = None
         bearer_close: Callable[[], None] | None = None
-        if metadata.get("auth_mode") == "oidc":
+        if client_credentials is not None:
+            if metadata.get("auth_mode") != "oidc":
+                raise SandboxError(
+                    f"gateway '{cluster_name}' is not configured for OIDC"
+                )
+            client_credentials._apply_gateway_metadata(metadata)
+            bearer_token = client_credentials
+        elif metadata.get("auth_mode") == "oidc":
             bearer_token, bearer_close = _make_cluster_bearer_provider(
                 gateway_dir,
                 cluster_name,
@@ -905,10 +1143,12 @@ class Sandbox:
         auto_refresh: bool = True,
         write_back: bool = True,
         insecure: bool = False,
+        client_credentials: ClientCredentialsAuth | None = None,
     ) -> None:
         """Bind a Sandbox context to the active gateway.
 
-        OIDC kwargs (`auto_refresh`, `write_back`, `insecure`) forward
+        OIDC kwargs (`auto_refresh`, `write_back`, `insecure`, and
+        `client_credentials`) forward
         directly to `SandboxClient.from_active_cluster` and have the
         same semantics. They're surfaced on `Sandbox` so callers using
         the higher-level wrapper get parity with `SandboxClient` for
@@ -928,6 +1168,7 @@ class Sandbox:
         self._auto_refresh = auto_refresh
         self._write_back = write_back
         self._insecure = insecure
+        self._client_credentials = client_credentials
         self._client: SandboxClient | None = None
         self._session: SandboxSession | None = None
 
@@ -959,6 +1200,7 @@ class Sandbox:
             auto_refresh=self._auto_refresh,
             write_back=self._write_back,
             insecure=self._insecure,
+            client_credentials=self._client_credentials,
         )
         self._client = client
 

--- a/python/openshell/sandbox_test.py
+++ b/python/openshell/sandbox_test.py
@@ -111,6 +111,39 @@ def test_client_credentials_auth_exact_form_cache_and_redaction() -> None:
     assert "conformance-secret" not in repr(auth)
 
 
+def test_client_credentials_auth_preserves_explicit_empty_scopes() -> None:
+    import httpx
+
+    form: dict[str, str] = {}
+
+    def handler(request: Any) -> Any:
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "issuer": "https://issuer.example.com",
+                    "token_endpoint": "https://issuer.example.com/token",
+                },
+            )
+        form.update(
+            __import__("urllib.parse").parse.parse_qsl(request.content.decode())
+        )
+        return httpx.Response(200, json={"access_token": "token", "expires_in": 120})
+
+    auth = ClientCredentialsAuth(
+        issuer="https://issuer.example.com",
+        client_id="client",
+        client_secret="secret",
+        scopes=(),
+        _transport=httpx.MockTransport(handler),
+    )
+    auth._apply_gateway_metadata({"oidc_scopes": "sandbox:read sandbox:write"})
+
+    assert auth() == "token"
+    assert auth._scopes == ()
+    assert "scope" not in form
+
+
 @pytest.mark.parametrize(
     "expires_in", _client_credentials_fixture()["expiry"]["invalid_expires_in"]
 )
@@ -1518,12 +1551,16 @@ def test_from_active_cluster_fills_client_credentials_from_metadata(
     )
     metadata_path.write_text(json.dumps(metadata))
     auth = ClientCredentialsAuth(client_secret="secret")
-    client = SandboxClient.from_active_cluster(client_credentials=auth)
+    client = SandboxClient.from_active_cluster(
+        client_credentials=auth,
+        insecure=True,
+    )
     try:
         assert auth._issuer == "https://issuer.example.com"
         assert auth._client_id == "service-client"
         assert auth._audience == "gateway"
         assert auth._scopes == ("sandbox:read", "sandbox:write")
+        assert auth._insecure is True
     finally:
         client.close()
 

--- a/python/openshell/sandbox_test.py
+++ b/python/openshell/sandbox_test.py
@@ -19,8 +19,10 @@ import pytest
 import openshell.sandbox as sandbox_module
 from openshell._proto import openshell_pb2
 from openshell.sandbox import (
+    _OIDC_TOKEN_EXPIRY_GRACE_SECONDS,
     _PYTHON_CLOUDPICKLE_BOOTSTRAP,
     _SANDBOX_PYTHON_BIN,
+    ClientCredentialsAuth,
     InferenceRouteClient,
     Sandbox,
     SandboxClient,
@@ -36,7 +38,319 @@ from openshell.sandbox import (
     _OidcRefresher,
     _read_oidc_token_bundle,
     _sandbox_ref,
+    _validate_oauth_url,
 )
+
+
+def _client_credentials_fixture() -> dict[str, Any]:
+    return json.loads(
+        (
+            Path(__file__).parents[2] / "sdk/conformance/oauth-client-credentials.json"
+        ).read_text()
+    )
+
+
+def test_oauth_client_credentials_conformance_fixture() -> None:
+    fixture = _client_credentials_fixture()
+    assert fixture["expiry"]["leeway_seconds"] == _OIDC_TOKEN_EXPIRY_GRACE_SECONDS
+    for value in fixture["urls"]["allowed"]:
+        assert _validate_oauth_url("issuer", value) == value
+    for value in fixture["urls"]["rejected"]:
+        with pytest.raises(SandboxError):
+            _validate_oauth_url("issuer", value)
+
+
+def test_client_credentials_auth_exact_form_cache_and_redaction() -> None:
+    fixture = _client_credentials_fixture()
+    seen: list[tuple[str, bytes]] = []
+
+    def handler(request: Any) -> Any:
+        import httpx
+
+        seen.append((str(request.url), bytes(request.content)))
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "issuer": "https://issuer.example.com/",
+                    "token_endpoint": "https://issuer.example.com/token",
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "service-token",
+                "expires_in": fixture["expiry"]["valid_expires_in"],
+            },
+        )
+
+    import httpx
+
+    auth = ClientCredentialsAuth(
+        issuer="https://issuer.example.com",
+        client_id="service-client",
+        client_secret="conformance-secret",
+        scopes=("sandbox:read", "sandbox:write"),
+        audience="openshell-gateway",
+        _transport=httpx.MockTransport(handler),
+    )
+    assert auth() == "service-token"
+    assert auth() == "service-token"
+    assert len(seen) == 2
+    form = dict(__import__("urllib.parse").parse.parse_qsl(seen[1][1].decode()))
+    assert form == {
+        field: fixture["request"][field]
+        for field in (
+            "grant_type",
+            "client_id",
+            "client_secret",
+            "scope",
+            "audience",
+        )
+    }
+    assert "conformance-secret" not in repr(auth)
+
+
+@pytest.mark.parametrize(
+    "expires_in", _client_credentials_fixture()["expiry"]["invalid_expires_in"]
+)
+def test_client_credentials_auth_rejects_invalid_expiry(expires_in: object) -> None:
+    import httpx
+
+    fixture = _client_credentials_fixture()
+
+    def handler(request: Any) -> Any:
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "issuer": fixture["discovery"]["matching_issuer"],
+                    "token_endpoint": "https://issuer.example.com/token",
+                },
+            )
+        return httpx.Response(
+            200, json={"access_token": "token", "expires_in": expires_in}
+        )
+
+    auth = ClientCredentialsAuth(
+        issuer=fixture["discovery"]["configured_issuer"],
+        client_id="client",
+        client_secret="secret",
+        _transport=httpx.MockTransport(handler),
+    )
+    with pytest.raises(SandboxError, match="positive finite expires_in"):
+        auth()
+
+
+@pytest.mark.parametrize(
+    "status", _client_credentials_fixture()["discovery"]["redirect_statuses"]
+)
+def test_client_credentials_auth_refuses_discovery_redirect(status: int) -> None:
+    import httpx
+
+    requests = 0
+
+    def handler(_request: Any) -> Any:
+        nonlocal requests
+        requests += 1
+        return httpx.Response(
+            status,
+            headers={"location": "https://attacker.example.com/discovery"},
+        )
+
+    auth = ClientCredentialsAuth(
+        issuer="https://issuer.example.com",
+        client_id="client",
+        client_secret="secret",
+        _transport=httpx.MockTransport(handler),
+    )
+    with pytest.raises(SandboxError, match=f"HTTP {status}"):
+        auth()
+    assert requests == 1
+
+
+@pytest.mark.parametrize(
+    "status", _client_credentials_fixture()["discovery"]["redirect_statuses"]
+)
+def test_client_credentials_auth_refuses_token_redirect(status: int) -> None:
+    import httpx
+
+    requests: list[str] = []
+
+    def handler(request: Any) -> Any:
+        requests.append(str(request.url))
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "issuer": "https://issuer.example.com",
+                    "token_endpoint": "https://issuer.example.com/token",
+                },
+            )
+        return httpx.Response(
+            status,
+            headers={"location": "https://attacker.example.com/token"},
+        )
+
+    auth = ClientCredentialsAuth(
+        issuer="https://issuer.example.com",
+        client_id="client",
+        client_secret="secret",
+        _transport=httpx.MockTransport(handler),
+    )
+    with pytest.raises(SandboxError, match=f"HTTP {status}"):
+        auth()
+    assert requests == [
+        "https://issuer.example.com/.well-known/openid-configuration",
+        "https://issuer.example.com/token",
+    ]
+
+
+def test_client_credentials_auth_rejects_discovery_issuer_mismatch() -> None:
+    import httpx
+
+    fixture = _client_credentials_fixture()
+    auth = ClientCredentialsAuth(
+        issuer=fixture["discovery"]["configured_issuer"],
+        client_id="client",
+        client_secret="secret",
+        _transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                200,
+                json={
+                    "issuer": fixture["discovery"]["mismatched_issuer"],
+                    "token_endpoint": "https://attacker.example.com/token",
+                },
+            )
+        ),
+    )
+    with pytest.raises(SandboxError, match="issuer mismatch"):
+        auth()
+
+
+def test_client_credentials_auth_rejects_oversized_response() -> None:
+    import httpx
+
+    fixture = _client_credentials_fixture()
+    auth = ClientCredentialsAuth(
+        issuer="https://issuer.example.com",
+        client_id="client",
+        client_secret="secret",
+        _transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                200, content=b"x" * (fixture["limits"]["max_response_bytes"] + 1)
+            )
+        ),
+    )
+    with pytest.raises(SandboxError, match="too large"):
+        auth()
+
+
+def test_client_credentials_auth_single_flight_and_retry() -> None:
+    import httpx
+
+    token_calls = 0
+    release = threading.Event()
+
+    def handler(request: Any) -> Any:
+        nonlocal token_calls
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "issuer": "http://127.0.0.1:8080",
+                    "token_endpoint": "http://127.0.0.1:8080/token",
+                },
+            )
+        token_calls += 1
+        release.wait(timeout=2)
+        return httpx.Response(200, json={"access_token": "shared", "expires_in": 120})
+
+    auth = ClientCredentialsAuth(
+        issuer="http://127.0.0.1:8080",
+        client_id="client",
+        client_secret="secret",
+        _transport=httpx.MockTransport(handler),
+    )
+    results: list[str] = []
+    threads = [
+        threading.Thread(target=lambda: results.append(auth())) for _ in range(8)
+    ]
+    for thread in threads:
+        thread.start()
+    while token_calls == 0:
+        time.sleep(0.001)
+    release.set()
+    for thread in threads:
+        thread.join()
+    assert results == ["shared"] * 8
+    assert token_calls == 1
+
+
+def test_client_credentials_auth_fails_closed_and_redacts_errors() -> None:
+    import httpx
+
+    def supplier() -> str:
+        raise RuntimeError("supplier-sensitive-detail")
+
+    auth = ClientCredentialsAuth(
+        issuer="http://localhost:8080",
+        client_id="client",
+        client_secret=supplier,
+        _transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                200,
+                json={
+                    "issuer": "http://localhost:8080",
+                    "token_endpoint": "http://localhost:8080/token",
+                },
+            )
+        ),
+    )
+    with pytest.raises(SandboxError, match="supplier failed") as exc_info:
+        auth()
+    assert "supplier-sensitive-detail" not in str(exc_info.value)
+    with pytest.raises(SandboxError, match="must use HTTPS"):
+        ClientCredentialsAuth(
+            issuer="http://remote.example.com",
+            client_id="client",
+            client_secret="secret",
+        )()
+
+
+def test_client_credentials_auth_does_not_use_stale_token_after_renewal_failure() -> (
+    None
+):
+    import httpx
+
+    exchanges = 0
+
+    def handler(request: Any) -> Any:
+        nonlocal exchanges
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "issuer": "http://localhost:8080",
+                    "token_endpoint": "http://localhost:8080/token",
+                },
+            )
+        exchanges += 1
+        if exchanges == 1:
+            return httpx.Response(200, json={"access_token": "stale", "expires_in": 30})
+        return httpx.Response(503, json={"error": "provider-sensitive-detail"})
+
+    auth = ClientCredentialsAuth(
+        issuer="http://localhost:8080",
+        client_id="client",
+        client_secret="secret",
+        _transport=httpx.MockTransport(handler),
+    )
+    assert auth() == "stale"
+    with pytest.raises(SandboxError, match="HTTP 503") as exc_info:
+        auth()
+    assert "stale" not in str(exc_info.value)
+    assert "provider-sensitive-detail" not in str(exc_info.value)
 
 
 class _FakeStub:
@@ -1185,6 +1499,47 @@ def test_sandbox_client_close_invokes_bearer_close() -> None:
     # close() is idempotent — re-invoking does not double-call.
     client.close()
     assert closed[0] == 1
+
+
+def test_from_active_cluster_fills_client_credentials_from_metadata(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    gateway_dir = _setup_gateway_dir(tmp_path, monkeypatch, auth_mode="oidc")
+    metadata_path = gateway_dir / "metadata.json"
+    metadata = json.loads(metadata_path.read_text())
+    metadata.update(
+        {
+            "oidc_issuer": "https://issuer.example.com",
+            "oidc_client_id": "service-client",
+            "oidc_audience": "gateway",
+            "oidc_scopes": "sandbox:read sandbox:write",
+        }
+    )
+    metadata_path.write_text(json.dumps(metadata))
+    auth = ClientCredentialsAuth(client_secret="secret")
+    client = SandboxClient.from_active_cluster(client_credentials=auth)
+    try:
+        assert auth._issuer == "https://issuer.example.com"
+        assert auth._client_id == "service-client"
+        assert auth._audience == "gateway"
+        assert auth._scopes == ("sandbox:read", "sandbox:write")
+    finally:
+        client.close()
+
+
+def test_sandbox_client_rejects_ambiguous_bearer_configuration() -> None:
+    auth = ClientCredentialsAuth(
+        issuer="https://issuer.example.com",
+        client_id="client",
+        client_secret="secret",
+    )
+    with pytest.raises(SandboxError, match="mutually exclusive"):
+        SandboxClient(
+            "localhost:50051",
+            bearer_token="static",
+            client_credentials=auth,
+        )
 
 
 def test_sandbox_client_close_releases_refresher_http_client(

--- a/python/openshell/sandbox_test.py
+++ b/python/openshell/sandbox_test.py
@@ -1565,6 +1565,68 @@ def test_from_active_cluster_fills_client_credentials_from_metadata(
         client.close()
 
 
+def test_sandbox_client_rejects_client_credentials_on_remote_plaintext(
+    monkeypatch: Any,
+) -> None:
+    channel_opened = False
+
+    def insecure_channel(_endpoint: str) -> Any:
+        nonlocal channel_opened
+        channel_opened = True
+        raise AssertionError("plaintext channel must not be opened")
+
+    monkeypatch.setattr(sandbox_module.grpc, "insecure_channel", insecure_channel)
+    auth = ClientCredentialsAuth(
+        issuer="https://issuer.example.com",
+        client_id="client",
+        client_secret="secret",
+    )
+    with pytest.raises(SandboxError, match="require TLS"):
+        SandboxClient("gateway.example.com:50051", client_credentials=auth)
+    assert not channel_opened
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    ["localhost:50051", "127.42.0.1:50051", "[::1]:50051"],
+)
+def test_sandbox_client_allows_client_credentials_on_plaintext_loopback(
+    endpoint: str,
+) -> None:
+    auth = ClientCredentialsAuth(
+        issuer="https://issuer.example.com",
+        client_id="client",
+        client_secret="secret",
+    )
+    client = SandboxClient(endpoint, client_credentials=auth)
+    client.close()
+
+
+def test_from_active_cluster_rejects_client_credentials_on_remote_plaintext(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    gateway_dir = _setup_gateway_dir(
+        tmp_path,
+        monkeypatch,
+        endpoint="http://gateway.example.com:8080",
+        auth_mode="oidc",
+    )
+    metadata_path = gateway_dir / "metadata.json"
+    metadata = json.loads(metadata_path.read_text())
+    metadata.update(
+        {
+            "oidc_issuer": "https://issuer.example.com",
+            "oidc_client_id": "service-client",
+        }
+    )
+    metadata_path.write_text(json.dumps(metadata))
+
+    auth = ClientCredentialsAuth(client_secret="secret")
+    with pytest.raises(SandboxError, match="require TLS"):
+        SandboxClient.from_active_cluster(client_credentials=auth)
+
+
 def test_sandbox_client_rejects_ambiguous_bearer_configuration() -> None:
     auth = ClientCredentialsAuth(
         issuer="https://issuer.example.com",

--- a/sdk/conformance/oauth-client-credentials.json
+++ b/sdk/conformance/oauth-client-credentials.json
@@ -1,0 +1,44 @@
+{
+  "request": {
+    "grant_type": "client_credentials",
+    "client_id": "service-client",
+    "client_secret": "conformance-secret",
+    "scopes": ["sandbox:read", "sandbox:write"],
+    "scope": "sandbox:read sandbox:write",
+    "audience": "openshell-gateway",
+    "forbidden_implicit_scopes": ["openid", "profile", "email"]
+  },
+  "expiry": {
+    "leeway_seconds": 30,
+    "valid_expires_in": 120,
+    "invalid_expires_in": [0, -1, "NaN", null]
+  },
+  "discovery": {
+    "configured_issuer": "https://issuer.example.com",
+    "matching_issuer": "https://issuer.example.com/",
+    "mismatched_issuer": "https://attacker.example.com",
+    "redirect_statuses": [301, 302, 307, 308]
+  },
+  "limits": {
+    "max_response_bytes": 1048576
+  },
+  "urls": {
+    "allowed": [
+      "https://issuer.example.com",
+      "http://localhost:8080",
+      "http://127.0.0.1:8080",
+      "http://127.42.0.1:8080",
+      "http://[::1]:8080"
+    ],
+    "rejected": [
+      "http://issuer.example.com",
+      "https://user@issuer.example.com",
+      "https://issuer.example.com/#fragment"
+    ]
+  },
+  "redaction": {
+    "secret": "conformance-secret",
+    "supplier_error": "supplier-sensitive-detail",
+    "provider_body": "provider-sensitive-detail"
+  }
+}

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -179,14 +179,34 @@ token, err := oidc.DeviceLogin(ctx,
 )
 ```
 
-For service accounts, use client credentials:
+For a one-shot service-account token exchange, use `ClientCredentials`. For a
+long-running SDK client, attach the renewable, memory-only auth provider:
 
 ```go
-token, err := oidc.ClientCredentials(ctx,
+auth, err := oidc.NewClientCredentialsAuth(
     oidc.WithGateway("my-gateway"),
-    oidc.WithClientSecret("service-secret"),
+    oidc.WithClientSecretProvider(func(context.Context) (string, error) {
+        return os.Getenv("OPENSHELL_OIDC_CLIENT_SECRET"), nil
+    }),
 )
+if err != nil {
+    log.Fatal(err)
+}
+
+client, err := v1.NewClient(v1.Config{
+    Address: "gateway.example.com:443",
+    Auth:    auth,
+    TLS:     tlsConfig,
+})
+if err != nil {
+    log.Fatal(err)
+}
+defer client.Close()
 ```
+
+You can use explicit `WithIssuer`, `WithClientID`, `WithScopes`, and
+`WithAudience` options instead of `WithGateway`. The provider repeats the grant
+before expiry and never writes the secret or access token to disk.
 
 See the [oidc package docs](https://pkg.go.dev/github.com/NVIDIA/OpenShell/sdk/go/openshell/v1/oidc) for all options and flows.
 
@@ -281,7 +301,7 @@ consumers import a single package. See the [Architecture](https://ro14nd.de/open
 | Typed errors (`IsNotFound`, `IsAlreadyExists`, `IsConflict`, ...) | `StatusError` | [Error Handling](https://ro14nd.de/openshell-sdk-go/error-handling.html) |
 | Real-time watch with auto-stop on terminal phase | `WatchInterface[T]` | [Sandboxes](https://ro14nd.de/openshell-sdk-go/api/sandboxes.html) |
 | Fake client for testing (no gRPC server needed) | `fake.Client` | [Testing](https://ro14nd.de/openshell-sdk-go/testing.html) |
-| OIDC login (browser, keyboard, device code, client credentials) | `oidc.Login`, `oidc.DeviceLogin`, `oidc.ClientCredentials` | [OIDC](https://pkg.go.dev/github.com/NVIDIA/OpenShell/sdk/go/openshell/v1/oidc) |
+| OIDC login and renewable service auth | `oidc.Login`, `oidc.DeviceLogin`, `oidc.ClientCredentials`, `oidc.NewClientCredentialsAuth` | [OIDC](https://pkg.go.dev/github.com/NVIDIA/OpenShell/sdk/go/openshell/v1/oidc) |
 | Gateway config convenience (load CLI gateway configs, auto-wire auth) | `gateway.NewClient`, `gateway.LoadConfig` | [Gateway](https://ro14nd.de/openshell-sdk-go/api/gateway.html) |
 
 ## Prerequisites

--- a/sdk/go/docs/src/api/oidc.md
+++ b/sdk/go/docs/src/api/oidc.md
@@ -69,6 +69,17 @@ Performs a non-interactive OAuth2 client credentials grant. Requires
 combined with `WithClientSecret`). The client secret is never included
 in error messages.
 
+### NewClientCredentialsAuth
+
+```go
+func NewClientCredentialsAuth(opts ...LoginOption) (types.AuthProvider, error)
+```
+
+Returns a lazy renewable auth provider for `v1.Config.Auth` or
+`gateway.WithAuth`. It caches access tokens in memory, renews within 30 seconds
+of expiry, coalesces concurrent exchanges, and fails closed if renewal fails.
+Use `WithClientSecretProvider` when the application rotates secret material.
+
 ## Options
 
 | Option | Description |
@@ -76,7 +87,9 @@ in error messages.
 | `WithIssuer(url)` | OIDC provider issuer URL |
 | `WithClientID(id)` | OAuth2 client ID |
 | `WithClientSecret(secret)` | OAuth2 client secret (for client credentials) |
-| `WithScopes(scopes...)` | Custom scopes (default: openid, profile, email) |
+| `WithClientSecretProvider(provider)` | Resolve the client secret for each exchange |
+| `WithAudience(audience)` | Optional OAuth2 resource-server audience |
+| `WithScopes(scopes...)` | Custom scopes (client credentials has no implicit scopes) |
 | `WithCallbackPort(port)` | Fixed port for localhost callback (default: tries 8000, then 18000) |
 | `WithTimeout(d)` | Auth flow timeout (default: 2 minutes) |
 | `WithKeyboardFlow()` | Use keyboard flow instead of browser |

--- a/sdk/go/openshell/v1/gateway/config.go
+++ b/sdk/go/openshell/v1/gateway/config.go
@@ -76,6 +76,12 @@ type Config struct {
 	// OIDCClientID is the OAuth2 client ID read from metadata.json.
 	// Empty when the gateway does not use OIDC auth.
 	OIDCClientID string
+
+	// OIDCAudience is the optional resource-server audience.
+	OIDCAudience string
+
+	// OIDCScopes contains the configured space-separated OAuth2 scopes.
+	OIDCScopes string
 }
 
 // Info is a lightweight summary of a gateway for listing purposes.
@@ -100,6 +106,8 @@ type metadataJSON struct {
 	Name         string `json:"name"`
 	OIDCIssuer   string `json:"oidc_issuer"`
 	OIDCClientID string `json:"oidc_client_id"`
+	OIDCAudience string `json:"oidc_audience"`
+	OIDCScopes   string `json:"oidc_scopes"`
 }
 
 // parseAuthMode converts a raw auth_mode string to the typed AuthMode.
@@ -153,5 +161,7 @@ func parseMetadata(dir string) (*Config, error) {
 		Dir:          dir,
 		OIDCIssuer:   meta.OIDCIssuer,
 		OIDCClientID: meta.OIDCClientID,
+		OIDCAudience: meta.OIDCAudience,
+		OIDCScopes:   meta.OIDCScopes,
 	}, nil
 }

--- a/sdk/go/openshell/v1/gateway/config_test.go
+++ b/sdk/go/openshell/v1/gateway/config_test.go
@@ -158,6 +158,8 @@ func TestParseMetadata_OIDCFields(t *testing.T) {
 		"name":"oidc-gw",
 		"oidc_issuer":"https://auth.example.com",
 		"oidc_client_id":"my-client-id"
+		,"oidc_audience":"openshell-api",
+		"oidc_scopes":"sandbox:read sandbox:write"
 	}`)
 
 	cfg, err := parseMetadata(dir)
@@ -166,6 +168,8 @@ func TestParseMetadata_OIDCFields(t *testing.T) {
 	assert.Equal(t, AuthModeOIDC, cfg.AuthMode)
 	assert.Equal(t, "https://auth.example.com", cfg.OIDCIssuer)
 	assert.Equal(t, "my-client-id", cfg.OIDCClientID)
+	assert.Equal(t, "openshell-api", cfg.OIDCAudience)
+	assert.Equal(t, "sandbox:read sandbox:write", cfg.OIDCScopes)
 }
 
 func TestParseMetadata_OIDCFieldsMissing(t *testing.T) {

--- a/sdk/go/openshell/v1/oidc/credentials.go
+++ b/sdk/go/openshell/v1/oidc/credentials.go
@@ -28,6 +28,14 @@ import (
 //
 // The client secret is never included in error messages (FR-014).
 func ClientCredentials(ctx context.Context, opts ...LoginOption) (*oauth2.Token, error) {
+	cfg, err := resolveClientCredentialsConfig(opts...)
+	if err != nil {
+		return nil, err
+	}
+	return exchangeClientCredentials(ctx, cfg)
+}
+
+func resolveClientCredentialsConfig(opts ...LoginOption) (*loginConfig, error) {
 	cfg := &loginConfig{}
 	for _, opt := range opts {
 		opt(cfg)
@@ -50,14 +58,19 @@ func ClientCredentials(ctx context.Context, opts ...LoginOption) (*oauth2.Token,
 		if err != nil {
 			return nil, fmt.Errorf("failed to load gateway %q: %w", cfg.gateway, err)
 		}
-		if gwCfg.OIDCIssuer == "" || gwCfg.OIDCClientID == "" {
-			return nil, fmt.Errorf(
-				"%w: gateway %q has no OIDC configuration (missing oidc_issuer or oidc_client_id in metadata.json)",
-				ErrOIDCConfig, cfg.gateway,
-			)
+		if cfg.issuer == "" {
+			cfg.issuer = gwCfg.OIDCIssuer
 		}
-		cfg.issuer = gwCfg.OIDCIssuer
-		cfg.clientID = gwCfg.OIDCClientID
+		if cfg.clientID == "" {
+			cfg.clientID = gwCfg.OIDCClientID
+		}
+		if !cfg.audienceSet {
+			cfg.audience = gwCfg.OIDCAudience
+		}
+		if !cfg.scopesSet && gwCfg.OIDCScopes != "" {
+			cfg.scopes = strings.Fields(gwCfg.OIDCScopes)
+			cfg.scopesSet = true
+		}
 	}
 
 	// Validate required configuration.
@@ -67,11 +80,26 @@ func ClientCredentials(ctx context.Context, opts ...LoginOption) (*oauth2.Token,
 			ErrOIDCConfig,
 		)
 	}
-	if cfg.clientSecret == "" {
+	if cfg.clientSecret == "" && cfg.secretProvider == nil {
 		return nil, fmt.Errorf(
-			"%w: client secret is required (use WithClientSecret)",
+			"%w: client secret is required (use WithClientSecret or WithClientSecretProvider)",
 			ErrClientCredentials,
 		)
+	}
+	return cfg, nil
+}
+
+func exchangeClientCredentials(ctx context.Context, cfg *loginConfig) (*oauth2.Token, error) {
+	secret := cfg.clientSecret
+	if cfg.secretProvider != nil {
+		value, err := cfg.secretProvider(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("%w: client secret provider failed", ErrClientCredentials)
+		}
+		secret = value
+	}
+	if secret == "" {
+		return nil, fmt.Errorf("%w: client secret must not be empty", ErrClientCredentials)
 	}
 
 	// Discover provider endpoints.
@@ -84,10 +112,13 @@ func ClientCredentials(ctx context.Context, opts ...LoginOption) (*oauth2.Token,
 	data := url.Values{
 		"grant_type":    {"client_credentials"},
 		"client_id":     {cfg.clientID},
-		"client_secret": {cfg.clientSecret},
+		"client_secret": {secret},
 	}
 	if len(cfg.scopes) > 0 {
 		data.Set("scope", strings.Join(cfg.scopes, " "))
+	}
+	if cfg.audience != "" {
+		data.Set("audience", cfg.audience)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.TokenEndpoint, strings.NewReader(data.Encode()))
@@ -110,9 +141,12 @@ func ClientCredentials(ctx context.Context, opts ...LoginOption) (*oauth2.Token,
 	defer func() { _ = resp.Body.Close() }()
 
 	const maxResponseBytes = 1 << 20
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to read token response", ErrClientCredentials)
+	}
+	if len(body) > maxResponseBytes {
+		return nil, fmt.Errorf("%w: token response is too large", ErrClientCredentials)
 	}
 
 	var tokResp tokenResponse
@@ -121,16 +155,7 @@ func ClientCredentials(ctx context.Context, opts ...LoginOption) (*oauth2.Token,
 	}
 
 	if resp.StatusCode != http.StatusOK || tokResp.Error != "" {
-		// FR-014: Never include the client secret in error messages.
-		// Only include the provider's error code and description.
-		msg := "client credentials exchange failed"
-		if tokResp.Error != "" {
-			msg = fmt.Sprintf("provider error: %s", tokResp.Error)
-			if tokResp.ErrorDesc != "" {
-				msg += ": " + tokResp.ErrorDesc
-			}
-		}
-		return nil, fmt.Errorf("%w: %s", ErrClientCredentials, msg)
+		return nil, fmt.Errorf("%w: provider rejected the exchange (HTTP %d)", ErrClientCredentials, resp.StatusCode)
 	}
 
 	if tokResp.AccessToken == "" {
@@ -142,9 +167,10 @@ func ClientCredentials(ctx context.Context, opts ...LoginOption) (*oauth2.Token,
 		RefreshToken: tokResp.RefreshToken,
 		TokenType:    tokResp.TokenType,
 	}
-	if tokResp.ExpiresIn > 0 {
-		tok.Expiry = time.Now().Add(time.Duration(tokResp.ExpiresIn) * time.Second)
+	if tokResp.ExpiresIn <= 0 {
+		return nil, fmt.Errorf("%w: token response requires a positive expires_in", ErrClientCredentials)
 	}
+	tok.Expiry = time.Now().Add(time.Duration(tokResp.ExpiresIn) * time.Second)
 
 	return tok, nil
 }

--- a/sdk/go/openshell/v1/oidc/credentials.go
+++ b/sdk/go/openshell/v1/oidc/credentials.go
@@ -32,7 +32,7 @@ func ClientCredentials(ctx context.Context, opts ...LoginOption) (*oauth2.Token,
 	if err != nil {
 		return nil, err
 	}
-	return exchangeClientCredentials(ctx, cfg)
+	return exchangeClientCredentials(ctx, cfg, false)
 }
 
 func resolveClientCredentialsConfig(opts ...LoginOption) (*loginConfig, error) {
@@ -89,7 +89,7 @@ func resolveClientCredentialsConfig(opts ...LoginOption) (*loginConfig, error) {
 	return cfg, nil
 }
 
-func exchangeClientCredentials(ctx context.Context, cfg *loginConfig) (*oauth2.Token, error) {
+func exchangeClientCredentials(ctx context.Context, cfg *loginConfig, requirePositiveExpiry bool) (*oauth2.Token, error) {
 	secret := cfg.clientSecret
 	if cfg.secretProvider != nil {
 		value, err := cfg.secretProvider(ctx)
@@ -153,6 +153,10 @@ func exchangeClientCredentials(ctx context.Context, cfg *loginConfig) (*oauth2.T
 	if err := json.Unmarshal(body, &tokResp); err != nil {
 		return nil, fmt.Errorf("%w: invalid token response JSON", ErrClientCredentials)
 	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return nil, fmt.Errorf("%w: invalid token response JSON", ErrClientCredentials)
+	}
 
 	if resp.StatusCode != http.StatusOK || tokResp.Error != "" {
 		return nil, fmt.Errorf("%w: provider rejected the exchange (HTTP %d)", ErrClientCredentials, resp.StatusCode)
@@ -167,8 +171,15 @@ func exchangeClientCredentials(ctx context.Context, cfg *loginConfig) (*oauth2.T
 		RefreshToken: tokResp.RefreshToken,
 		TokenType:    tokResp.TokenType,
 	}
-	if tokResp.ExpiresIn <= 0 {
+	_, expiresInPresent := fields["expires_in"]
+	if expiresInPresent && tokResp.ExpiresIn <= 0 {
 		return nil, fmt.Errorf("%w: token response requires a positive expires_in", ErrClientCredentials)
+	}
+	if !expiresInPresent {
+		if requirePositiveExpiry {
+			return nil, fmt.Errorf("%w: token response requires a positive expires_in", ErrClientCredentials)
+		}
+		return tok, nil
 	}
 	tok.Expiry = time.Now().Add(time.Duration(tokResp.ExpiresIn) * time.Second)
 

--- a/sdk/go/openshell/v1/oidc/credentials_auth.go
+++ b/sdk/go/openshell/v1/oidc/credentials_auth.go
@@ -47,7 +47,7 @@ func (a *clientCredentialsAuth) GetRequestMetadata(ctx context.Context, _ ...str
 	result := a.group.DoChan("exchange", func() (any, error) {
 		exchangeCtx, cancel := context.WithTimeout(context.Background(), a.cfg.timeout)
 		defer cancel()
-		token, err := exchangeClientCredentials(exchangeCtx, a.cfg)
+		token, err := exchangeClientCredentials(exchangeCtx, a.cfg, true)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/go/openshell/v1/oidc/credentials_auth.go
+++ b/sdk/go/openshell/v1/oidc/credentials_auth.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package oidc
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/NVIDIA/OpenShell/sdk/go/openshell/v1/types"
+)
+
+const clientCredentialsLeeway = 30 * time.Second
+
+type clientCredentialsAuth struct {
+	cfg   *loginConfig
+	mu    sync.Mutex
+	token *oauth2.Token
+	group singleflight.Group
+}
+
+// NewClientCredentialsAuth returns a renewable, memory-only client-credentials
+// AuthProvider suitable for v1.Config.Auth or gateway.WithAuth. Acquisition is
+// lazy, concurrent RPCs share one exchange, and expired tokens are never used
+// when renewal fails.
+func NewClientCredentialsAuth(opts ...LoginOption) (types.AuthProvider, error) {
+	cfg, err := resolveClientCredentialsConfig(opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &clientCredentialsAuth{cfg: cfg}, nil
+}
+
+func (a *clientCredentialsAuth) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
+	a.mu.Lock()
+	if a.token != nil && time.Now().Add(clientCredentialsLeeway).Before(a.token.Expiry) {
+		accessToken := a.token.AccessToken
+		a.mu.Unlock()
+		return map[string]string{"authorization": "Bearer " + accessToken}, nil
+	}
+	a.mu.Unlock()
+
+	result := a.group.DoChan("exchange", func() (any, error) {
+		exchangeCtx, cancel := context.WithTimeout(context.Background(), a.cfg.timeout)
+		defer cancel()
+		token, err := exchangeClientCredentials(exchangeCtx, a.cfg)
+		if err != nil {
+			return nil, err
+		}
+		a.mu.Lock()
+		a.token = token
+		a.mu.Unlock()
+		return token.AccessToken, nil
+	})
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case exchange := <-result:
+		if exchange.Err != nil {
+			return nil, exchange.Err
+		}
+		return map[string]string{"authorization": "Bearer " + exchange.Val.(string)}, nil
+	}
+}
+
+func (*clientCredentialsAuth) RequireTransportSecurity() bool { return true }
+
+func (*clientCredentialsAuth) String() string { return "oidc.ClientCredentialsAuth" }
+
+func (*clientCredentialsAuth) GoString() string { return "oidc.ClientCredentialsAuth{}" }

--- a/sdk/go/openshell/v1/oidc/credentials_test.go
+++ b/sdk/go/openshell/v1/oidc/credentials_test.go
@@ -7,8 +7,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,6 +23,337 @@ import (
 
 	"github.com/NVIDIA/OpenShell/sdk/go/openshell/v1/gateway"
 )
+
+type clientCredentialsFixture struct {
+	Request struct {
+		GrantType    string   `json:"grant_type"`
+		ClientID     string   `json:"client_id"`
+		ClientSecret string   `json:"client_secret"`
+		Scopes       []string `json:"scopes"`
+		Scope        string   `json:"scope"`
+		Audience     string   `json:"audience"`
+	} `json:"request"`
+	Expiry struct {
+		LeewaySeconds    int               `json:"leeway_seconds"`
+		ValidExpiresIn   int64             `json:"valid_expires_in"`
+		InvalidExpiresIn []json.RawMessage `json:"invalid_expires_in"`
+	} `json:"expiry"`
+	Discovery struct {
+		ConfiguredIssuer string `json:"configured_issuer"`
+		MatchingIssuer   string `json:"matching_issuer"`
+		MismatchedIssuer string `json:"mismatched_issuer"`
+		RedirectStatuses []int  `json:"redirect_statuses"`
+	} `json:"discovery"`
+	Limits struct {
+		MaxResponseBytes int `json:"max_response_bytes"`
+	} `json:"limits"`
+	URLs struct {
+		Allowed  []string `json:"allowed"`
+		Rejected []string `json:"rejected"`
+	} `json:"urls"`
+}
+
+func loadClientCredentialsFixture(t *testing.T) clientCredentialsFixture {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "conformance", "oauth-client-credentials.json"))
+	require.NoError(t, err)
+	var fixture clientCredentialsFixture
+	require.NoError(t, json.Unmarshal(data, &fixture))
+	return fixture
+}
+
+func TestClientCredentialsConformanceFixture(t *testing.T) {
+	fixture := loadClientCredentialsFixture(t)
+	assert.Equal(t, int(clientCredentialsLeeway/time.Second), fixture.Expiry.LeewaySeconds)
+	for _, raw := range fixture.URLs.Allowed {
+		assert.NoError(t, validateSecureURL("issuer", raw), raw)
+	}
+	for _, raw := range fixture.URLs.Rejected {
+		assert.Error(t, validateSecureURL("issuer", raw), raw)
+	}
+}
+
+func TestClientCredentialsRejectsInvalidExpiryConformance(t *testing.T) {
+	fixture := loadClientCredentialsFixture(t)
+	for _, raw := range fixture.Expiry.InvalidExpiresIn {
+		raw := raw
+		t.Run(string(raw), func(t *testing.T) {
+			resetDiscoveryCache()
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/.well-known/openid-configuration" {
+					_ = json.NewEncoder(w).Encode(map[string]string{
+						"issuer":                 server.URL,
+						"authorization_endpoint": server.URL + "/authorize",
+						"token_endpoint":         server.URL + "/token",
+					})
+					return
+				}
+				_, _ = fmt.Fprintf(w, `{"access_token":"sensitive-access-token","expires_in":%s}`, raw)
+			}))
+			t.Cleanup(server.Close)
+
+			_, err := ClientCredentials(
+				context.Background(),
+				WithIssuer(server.URL),
+				WithClientID("client"),
+				WithClientSecret("secret"),
+			)
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "sensitive-access-token")
+		})
+	}
+}
+
+func TestClientCredentialsRefusesRedirectsConformance(t *testing.T) {
+	fixture := loadClientCredentialsFixture(t)
+	for _, status := range fixture.Discovery.RedirectStatuses {
+		status := status
+		for _, endpoint := range []string{"discovery", "token"} {
+			endpoint := endpoint
+			t.Run(fmt.Sprintf("%s_%d", endpoint, status), func(t *testing.T) {
+				resetDiscoveryCache()
+				var server *httptest.Server
+				var redirected atomic.Bool
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/.well-known/openid-configuration":
+						if endpoint == "discovery" {
+							w.Header().Set("Location", server.URL+"/redirected")
+							w.WriteHeader(status)
+							return
+						}
+						_ = json.NewEncoder(w).Encode(map[string]string{
+							"issuer":                 server.URL,
+							"authorization_endpoint": server.URL + "/authorize",
+							"token_endpoint":         server.URL + "/token",
+						})
+					case "/token":
+						w.Header().Set("Location", server.URL+"/redirected")
+						w.WriteHeader(status)
+					case "/redirected":
+						redirected.Store(true)
+					}
+				}))
+				t.Cleanup(server.Close)
+
+				_, err := ClientCredentials(
+					context.Background(),
+					WithIssuer(server.URL),
+					WithClientID("client"),
+					WithClientSecret("secret"),
+				)
+				require.Error(t, err)
+				assert.False(t, redirected.Load())
+			})
+		}
+	}
+}
+
+func TestClientCredentialsRejectsMismatchedIssuerConformance(t *testing.T) {
+	resetDiscoveryCache()
+	fixture := loadClientCredentialsFixture(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"issuer":                 fixture.Discovery.MismatchedIssuer,
+			"authorization_endpoint": fixture.Discovery.MismatchedIssuer + "/authorize",
+			"token_endpoint":         fixture.Discovery.MismatchedIssuer + "/token",
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := ClientCredentials(
+		context.Background(),
+		WithIssuer(server.URL),
+		WithClientID("client"),
+		WithClientSecret("secret"),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "issuer")
+}
+
+func TestClientCredentialsRejectsOversizedResponseConformance(t *testing.T) {
+	resetDiscoveryCache()
+	fixture := loadClientCredentialsFixture(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(make([]byte, fixture.Limits.MaxResponseBytes+1))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := ClientCredentials(
+		context.Background(),
+		WithIssuer(server.URL),
+		WithClientID("client"),
+		WithClientSecret("secret"),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too large")
+}
+
+func TestClientCredentialsAuthSingleFlightRenewalAndFields(t *testing.T) {
+	resetDiscoveryCache()
+	fixture := loadClientCredentialsFixture(t)
+	var server *httptest.Server
+	var calls atomic.Int32
+	var formsMu sync.Mutex
+	var forms []url.Values
+	release := make(chan struct{})
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"issuer":                 server.URL,
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+			})
+			return
+		}
+		if calls.Add(1) == 1 {
+			<-release
+		}
+		require.NoError(t, r.ParseForm())
+		formsMu.Lock()
+		forms = append(forms, r.Form)
+		formsMu.Unlock()
+		_, _ = w.Write([]byte(tokenResponseJSON("token", "", 3600)))
+	}))
+	t.Cleanup(server.Close)
+
+	auth, err := NewClientCredentialsAuth(
+		WithIssuer(server.URL),
+		WithClientID(fixture.Request.ClientID),
+		WithClientSecret(fixture.Request.ClientSecret),
+		WithScopes(fixture.Request.Scopes...),
+		WithAudience(fixture.Request.Audience),
+	)
+	require.NoError(t, err)
+	assert.NotContains(t, fmt.Sprintf("%#v", auth), "secret")
+
+	results := make(chan error, 12)
+	for range 12 {
+		go func() {
+			metadata, callErr := auth.GetRequestMetadata(context.Background())
+			if callErr == nil && metadata["authorization"] != "Bearer token" {
+				callErr = errors.New("unexpected authorization metadata")
+			}
+			results <- callErr
+		}()
+	}
+	require.Eventually(t, func() bool { return calls.Load() == 1 }, time.Second, time.Millisecond)
+	close(release)
+	for range 12 {
+		require.NoError(t, <-results)
+	}
+	assert.Equal(t, int32(1), calls.Load())
+	require.Len(t, forms, 1)
+	assert.Equal(t, fixture.Request.GrantType, forms[0].Get("grant_type"))
+	assert.Equal(t, fixture.Request.ClientID, forms[0].Get("client_id"))
+	assert.Equal(t, fixture.Request.ClientSecret, forms[0].Get("client_secret"))
+	assert.Equal(t, fixture.Request.Scope, forms[0].Get("scope"))
+	assert.Equal(t, fixture.Request.Audience, forms[0].Get("audience"))
+
+	concrete := auth.(*clientCredentialsAuth)
+	concrete.mu.Lock()
+	concrete.token.Expiry = time.Now()
+	concrete.mu.Unlock()
+	_, err = auth.GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestClientCredentialsAuthCancellationDoesNotPoisonSharedExchange(t *testing.T) {
+	resetDiscoveryCache()
+	var server *httptest.Server
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"issuer":                 server.URL,
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+			})
+			return
+		}
+		close(started)
+		<-release
+		_, _ = w.Write([]byte(tokenResponseJSON("token", "", 3600)))
+	}))
+	t.Cleanup(server.Close)
+	auth, err := NewClientCredentialsAuth(
+		WithIssuer(server.URL), WithClientID("client"), WithClientSecret("secret"),
+	)
+	require.NoError(t, err)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	first := make(chan error, 1)
+	go func() {
+		_, callErr := auth.GetRequestMetadata(canceled)
+		first <- callErr
+	}()
+	<-started
+	second := make(chan error, 1)
+	go func() {
+		_, callErr := auth.GetRequestMetadata(context.Background())
+		second <- callErr
+	}()
+	cancel()
+	assert.ErrorIs(t, <-first, context.Canceled)
+	close(release)
+	require.NoError(t, <-second)
+}
+
+func TestClientCredentialsAuthRedactsSecretProviderError(t *testing.T) {
+	auth, err := NewClientCredentialsAuth(
+		WithIssuer("http://localhost:8080"),
+		WithClientID("client"),
+		WithClientSecretProvider(func(context.Context) (string, error) {
+			return "", errors.New("supplier-sensitive-detail")
+		}),
+	)
+	require.NoError(t, err)
+	_, err = auth.GetRequestMetadata(context.Background())
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "supplier-sensitive-detail")
+}
+
+func TestClientCredentialsAuthFailsClosedOnRenewalError(t *testing.T) {
+	resetDiscoveryCache()
+	var server *httptest.Server
+	var fail atomic.Bool
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"issuer":                 server.URL,
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+			})
+			return
+		}
+		if fail.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"provider-sensitive-detail"}`))
+			return
+		}
+		_, _ = w.Write([]byte(tokenResponseJSON("stale", "", 3600)))
+	}))
+	t.Cleanup(server.Close)
+	auth, err := NewClientCredentialsAuth(
+		WithIssuer(server.URL), WithClientID("client"), WithClientSecret("secret"),
+	)
+	require.NoError(t, err)
+	_, err = auth.GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	concrete := auth.(*clientCredentialsAuth)
+	concrete.mu.Lock()
+	concrete.token.Expiry = time.Now()
+	concrete.mu.Unlock()
+	fail.Store(true)
+	metadata, err := auth.GetRequestMetadata(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, metadata)
+	assert.NotContains(t, err.Error(), "stale")
+	assert.NotContains(t, err.Error(), "provider-sensitive-detail")
+}
 
 // --- T023: Client credentials tests ---
 

--- a/sdk/go/openshell/v1/oidc/credentials_test.go
+++ b/sdk/go/openshell/v1/oidc/credentials_test.go
@@ -105,6 +105,39 @@ func TestClientCredentialsRejectsInvalidExpiryConformance(t *testing.T) {
 	}
 }
 
+func TestClientCredentialsMissingExpiryCompatibility(t *testing.T) {
+	resetDiscoveryCache()
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"issuer":                 server.URL,
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+			})
+			return
+		}
+		_, _ = w.Write([]byte(`{"access_token":"token","token_type":"Bearer"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	opts := []LoginOption{
+		WithIssuer(server.URL),
+		WithClientID("client"),
+		WithClientSecret("secret"),
+	}
+	token, err := ClientCredentials(context.Background(), opts...)
+	require.NoError(t, err)
+	assert.True(t, token.Expiry.IsZero())
+
+	auth, err := NewClientCredentialsAuth(opts...)
+	require.NoError(t, err)
+	metadata, err := auth.GetRequestMetadata(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, metadata)
+	assert.Contains(t, err.Error(), "positive expires_in")
+}
+
 func TestClientCredentialsRefusesRedirectsConformance(t *testing.T) {
 	fixture := loadClientCredentialsFixture(t)
 	for _, status := range fixture.Discovery.RedirectStatuses {

--- a/sdk/go/openshell/v1/oidc/discovery.go
+++ b/sdk/go/openshell/v1/oidc/discovery.go
@@ -16,7 +16,12 @@ import (
 	"time"
 )
 
-var oidcHTTPClient = &http.Client{Timeout: 30 * time.Second}
+var oidcHTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+	CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
 
 // providerConfig holds parsed fields from an OIDC discovery document
 // (.well-known/openid-configuration).
@@ -115,9 +120,12 @@ func fetchDiscovery(ctx context.Context, issuer string) (*providerConfig, error)
 	}
 
 	const maxResponseBytes = 1 << 20
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to read discovery response: %v", ErrDiscovery, err)
+	}
+	if len(body) > maxResponseBytes {
+		return nil, fmt.Errorf("%w: discovery response is too large", ErrDiscovery)
 	}
 
 	var cfg providerConfig
@@ -125,7 +133,7 @@ func fetchDiscovery(ctx context.Context, issuer string) (*providerConfig, error)
 		return nil, fmt.Errorf("%w: invalid discovery JSON: %v", ErrDiscovery, err)
 	}
 	if normalizeIssuer(cfg.Issuer) != normalizeIssuer(issuer) {
-		return nil, fmt.Errorf("%w: discovery issuer %q does not match configured issuer %q", ErrDiscovery, cfg.Issuer, issuer)
+		return nil, fmt.Errorf("%w: discovery issuer does not match configured issuer", ErrDiscovery)
 	}
 
 	if cfg.TokenEndpoint == "" {

--- a/sdk/go/openshell/v1/oidc/doc.go
+++ b/sdk/go/openshell/v1/oidc/doc.go
@@ -48,7 +48,7 @@
 //
 // For non-interactive service accounts:
 //
-//	token, err := oidc.ClientCredentials(ctx,
+//	auth, err := oidc.NewClientCredentialsAuth(
 //	    oidc.WithIssuer("https://auth.example.com"),
 //	    oidc.WithClientID("my-service"),
 //	    oidc.WithClientSecret("secret"),

--- a/sdk/go/openshell/v1/oidc/options.go
+++ b/sdk/go/openshell/v1/oidc/options.go
@@ -4,6 +4,7 @@
 package oidc
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -22,17 +23,20 @@ const defaultTimeout = 2 * time.Minute
 // attempt. It is built by applying [LoginOption] functions to a
 // zero-value struct and then filling in defaults.
 type loginConfig struct {
-	issuer       string
-	clientID     string
-	clientSecret string
-	scopes       []string
-	scopesSet    bool
-	callbackPort int
-	timeout      time.Duration
-	keyboardFlow bool
-	inMemory     bool
-	displayFunc  func(verificationURL, userCode string)
-	gateway      string
+	issuer         string
+	clientID       string
+	clientSecret   string
+	secretProvider func(context.Context) (string, error)
+	audience       string
+	audienceSet    bool
+	scopes         []string
+	scopesSet      bool
+	callbackPort   int
+	timeout        time.Duration
+	keyboardFlow   bool
+	inMemory       bool
+	displayFunc    func(verificationURL, userCode string)
+	gateway        string
 
 	// Internal fields for testing. Not exposed via public API.
 	tokenDir        string                                     // override token directory
@@ -75,10 +79,26 @@ func WithClientID(id string) LoginOption {
 }
 
 // WithClientSecret sets the client secret for the client credentials
-// grant. Required for [ClientCredentials].
+// grant. Required for [ClientCredentials] and [NewClientCredentialsAuth].
 func WithClientSecret(secret string) LoginOption {
 	return func(c *loginConfig) {
 		c.clientSecret = secret
+	}
+}
+
+// WithClientSecretProvider resolves the client secret for each exchange.
+// Provider errors and returned secrets are never included in SDK errors.
+func WithClientSecretProvider(provider func(context.Context) (string, error)) LoginOption {
+	return func(c *loginConfig) {
+		c.secretProvider = provider
+	}
+}
+
+// WithAudience sets the optional OAuth2 resource-server audience.
+func WithAudience(audience string) LoginOption {
+	return func(c *loginConfig) {
+		c.audience = audience
+		c.audienceSet = true
 	}
 }
 
@@ -134,10 +154,9 @@ func WithDisplayFunc(fn func(verificationURL, userCode string)) LoginOption {
 	}
 }
 
-// WithGateway sets the gateway name for [DeviceLogin] and
-// [ClientCredentials]. When set, OIDC config is read from the
-// gateway's metadata.json and tokens are persisted to the gateway
-// directory.
+// WithGateway sets the gateway name for [DeviceLogin], [ClientCredentials],
+// and [NewClientCredentialsAuth]. OIDC configuration is read from the
+// gateway's metadata.json. Client-credentials tokens are never persisted.
 func WithGateway(name string) LoginOption {
 	return func(c *loginConfig) {
 		c.gateway = name

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -45,10 +45,29 @@ await client.sandbox.delete(sandbox.name)
 ```
 
 `connect()` constructs a lazy client; call `health()` when startup must verify
-gateway reachability. Authentication material is static for the client's
-lifetime, so create a new client after refreshing an OIDC or edge token. The
-root client has no explicit close method because Connect does not retain a
-dedicated session. Close operation-scoped streams and forward handles instead.
+gateway reachability. Static `oidcToken` and `edgeToken` values remain fixed for
+the client's lifetime. For long-running service automation, use the renewable
+client-credentials provider:
+
+```ts
+import { clientCredentials, OpenShellClient } from '@nvidia/openshell-sdk'
+
+const client = await OpenShellClient.connect({
+  gateway,
+  oidcTokenProvider: clientCredentials({
+    issuer: 'https://idp.example.com/realms/openshell',
+    clientId: 'openshell-service',
+    clientSecret: () => process.env.OPENSHELL_OIDC_CLIENT_SECRET!,
+    scopes: ['sandbox:read', 'sandbox:write'],
+    audience: 'openshell-gateway',
+  }),
+})
+```
+
+The provider discovers and validates the issuer, keeps credentials and tokens
+in memory, and renews before expiry. The root client has no explicit close
+method because Connect does not retain a dedicated session. Close
+operation-scoped streams and forward handles instead.
 
 Express the create-time safety boundary with `policy`. Sandbox-scoped `setPolicy`
 cannot introduce static policy fields later, so set filesystem, landlock,

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -3,11 +3,6 @@
 
 // Public API surface for @nvidia/openshell-sdk.
 //
-// OidcRefresher (single-flight OIDC refresh) is intentionally not yet exported.
-// It is the one piece of genuinely shared, cross-language behavior; it will be
-// added alongside a conformance suite that pins it byte-identical across the
-// TypeScript, Python, and Go SDKs.
-
 export type {
   ConnectOptions,
   EffectiveSettingView,
@@ -42,3 +37,5 @@ export type {
 export { errorCode, OpenShellClient, SandboxClient } from './client.js';
 export type { SdkErrorCode } from './errors.js';
 export { SdkError } from './errors.js';
+export type { ClientCredentialsOptions, OidcTokenProvider } from './oidc.js';
+export { clientCredentials } from './oidc.js';

--- a/sdk/typescript/src/oidc.test.ts
+++ b/sdk/typescript/src/oidc.test.ts
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { clientCredentials } from './oidc.js';
+
+const conformance = JSON.parse(
+  readFileSync(new URL('../../conformance/oauth-client-credentials.json', import.meta.url), 'utf8'),
+) as {
+  request: Record<string, string | string[]>;
+  urls: { allowed: string[]; rejected: string[] };
+  expiry: { leeway_seconds: number; valid_expires_in: number; invalid_expires_in: unknown[] };
+  discovery: {
+    configured_issuer: string;
+    matching_issuer: string;
+    mismatched_issuer: string;
+    redirect_statuses: number[];
+  };
+  limits: { max_response_bytes: number };
+};
+
+const servers: ReturnType<typeof createServer>[] = [];
+afterEach(async () => {
+  vi.useRealTimers();
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+});
+
+async function providerServer(
+  expiresIn: unknown = conformance.expiry.valid_expires_in,
+): Promise<{ issuer: string; forms: URLSearchParams[] }> {
+  const forms: URLSearchParams[] = [];
+  let issuer = '';
+  const server = createServer((req, res) => {
+    if (req.url === '/.well-known/openid-configuration') {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ issuer, token_endpoint: `${issuer}/token` }));
+      return;
+    }
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => {
+      forms.push(new URLSearchParams(body));
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ access_token: `token-${forms.length}`, expires_in: expiresIn }));
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing address');
+  issuer = `http://127.0.0.1:${address.port}`;
+  return { issuer, forms };
+}
+
+describe('clientCredentials', () => {
+  it('accepts and rejects the shared URL vectors', () => {
+    for (const issuer of conformance.urls.allowed) {
+      expect(() => clientCredentials({ issuer, clientId: 'client', clientSecret: 'secret' })).not.toThrow();
+    }
+    for (const issuer of conformance.urls.rejected) {
+      expect(() => clientCredentials({ issuer, clientId: 'client', clientSecret: 'secret' })).toThrow();
+    }
+    expect(conformance.expiry.leeway_seconds).toBe(30);
+  });
+
+  it('sends exact explicit fields without interactive scopes and caches the token', async () => {
+    const { issuer, forms } = await providerServer();
+    const provider = clientCredentials({
+      issuer,
+      clientId: conformance.request.client_id as string,
+      clientSecret: conformance.request.client_secret as string,
+      scopes: conformance.request.scopes as string[],
+      audience: conformance.request.audience as string,
+    });
+    expect(await provider.getToken()).toBe('token-1');
+    expect(await provider.getToken()).toBe('token-1');
+    expect(forms).toHaveLength(1);
+    expect(Object.fromEntries(forms[0])).toEqual(
+      Object.fromEntries(
+        ['grant_type', 'client_id', 'client_secret', 'scope', 'audience'].map((field) => [
+          field,
+          conformance.request[field],
+        ]),
+      ),
+    );
+  });
+
+  it('coalesces concurrent acquisition', async () => {
+    const { issuer, forms } = await providerServer();
+    const provider = clientCredentials({ issuer, clientId: 'client', clientSecret: 'secret' });
+    expect(await Promise.all(Array.from({ length: 12 }, () => provider.getToken()))).toEqual(Array(12).fill('token-1'));
+    expect(forms).toHaveLength(1);
+  });
+
+  it('renews inside the leeway instead of returning a stale token', async () => {
+    const { issuer, forms } = await providerServer(30);
+    const provider = clientCredentials({ issuer, clientId: 'client', clientSecret: 'secret' });
+    expect(await provider.getToken()).toBe('token-1');
+    expect(await provider.getToken()).toBe('token-2');
+    expect(forms).toHaveLength(2);
+  });
+
+  it.each(conformance.expiry.invalid_expires_in)('rejects invalid expires_in value %j', async (expiresIn) => {
+    const { issuer } = await providerServer(expiresIn);
+    const provider = clientCredentials({ issuer, clientId: 'client', clientSecret: 'secret' });
+    await expect(provider.getToken()).rejects.toThrow(/positive finite expires_in/);
+  });
+
+  it.each(conformance.discovery.redirect_statuses)('refuses discovery redirect status %i', async (status) => {
+    let issuer = '';
+    let redirected = false;
+    const server = createServer((req, res) => {
+      if (req.url === '/redirected') redirected = true;
+      res.writeHead(status, { location: `${issuer}/redirected` });
+      res.end();
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('missing address');
+    issuer = `http://127.0.0.1:${address.port}`;
+    const provider = clientCredentials({ issuer, clientId: 'client', clientSecret: 'secret' });
+    await expect(provider.getToken()).rejects.toThrow(new RegExp(`HTTP ${status}`));
+    expect(redirected).toBe(false);
+  });
+
+  it.each(conformance.discovery.redirect_statuses)('refuses token redirect status %i', async (status) => {
+    let issuer = '';
+    let redirected = false;
+    const server = createServer((req, res) => {
+      if (req.url === '/.well-known/openid-configuration') {
+        res.end(JSON.stringify({ issuer, token_endpoint: `${issuer}/token` }));
+        return;
+      }
+      if (req.url === '/redirected') redirected = true;
+      res.writeHead(status, { location: `${issuer}/redirected` });
+      res.end();
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('missing address');
+    issuer = `http://127.0.0.1:${address.port}`;
+    const provider = clientCredentials({ issuer, clientId: 'client', clientSecret: 'secret' });
+    await expect(provider.getToken()).rejects.toThrow(new RegExp(`HTTP ${status}`));
+    expect(redirected).toBe(false);
+  });
+
+  it('rejects a mismatched discovery issuer', async () => {
+    let issuer = '';
+    const server = createServer((_req, res) => {
+      res.end(
+        JSON.stringify({
+          issuer: conformance.discovery.mismatched_issuer,
+          token_endpoint: `${issuer}/token`,
+        }),
+      );
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('missing address');
+    issuer = `http://127.0.0.1:${address.port}`;
+    const provider = clientCredentials({ issuer, clientId: 'client', clientSecret: 'secret' });
+    await expect(provider.getToken()).rejects.toThrow(/issuer mismatch/);
+  });
+
+  it('rejects responses larger than the shared bound', async () => {
+    let issuer = '';
+    const server = createServer((req, res) => {
+      if (req.url === '/.well-known/openid-configuration') {
+        res.end('x'.repeat(conformance.limits.max_response_bytes + 1));
+        return;
+      }
+      res.end(JSON.stringify({ issuer, token_endpoint: `${issuer}/token` }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('missing address');
+    issuer = `http://127.0.0.1:${address.port}`;
+    const provider = clientCredentials({ issuer, clientId: 'client', clientSecret: 'secret' });
+    await expect(provider.getToken()).rejects.toThrow(/too large/);
+  });
+
+  it('lets one waiter cancel without canceling the shared exchange', async () => {
+    let issuer = '';
+    let releaseToken!: () => void;
+    let markStarted!: () => void;
+    const release = new Promise<void>((resolve) => (releaseToken = resolve));
+    const started = new Promise<void>((resolve) => (markStarted = resolve));
+    const server = createServer(async (req, res) => {
+      if (req.url === '/.well-known/openid-configuration') {
+        res.end(JSON.stringify({ issuer, token_endpoint: `${issuer}/token` }));
+        return;
+      }
+      markStarted();
+      await release;
+      res.end(JSON.stringify({ access_token: 'shared', expires_in: 120 }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('missing address');
+    issuer = `http://127.0.0.1:${address.port}`;
+    const provider = clientCredentials({ issuer, clientId: 'client', clientSecret: 'secret' });
+    const controller = new AbortController();
+    const canceled = provider.getToken(controller.signal);
+    await started;
+    const remaining = provider.getToken();
+    controller.abort();
+    await expect(canceled).rejects.toThrow(/canceled/);
+    releaseToken();
+    await expect(remaining).resolves.toBe('shared');
+  });
+
+  it('rejects remote plaintext and redacts supplier errors', async () => {
+    expect(() => clientCredentials({ issuer: 'http://example.com', clientId: 'c', clientSecret: 's' })).toThrow(
+      /HTTPS/,
+    );
+    const { issuer } = await providerServer();
+    const provider = clientCredentials({
+      issuer,
+      clientId: 'client',
+      clientSecret: () => {
+        throw new Error('supplier-sensitive-detail');
+      },
+    });
+    await expect(provider.getToken()).rejects.not.toThrow(/supplier-sensitive-detail/);
+  });
+});

--- a/sdk/typescript/src/oidc.test.ts
+++ b/sdk/typescript/src/oidc.test.ts
@@ -186,6 +186,34 @@ describe('clientCredentials', () => {
     await expect(provider.getToken()).rejects.toThrow(/too large/);
   });
 
+  it('times out while reading a stalled body and retries cleanly', async () => {
+    let issuer = '';
+    let discoveryCalls = 0;
+    const server = createServer((req, res) => {
+      if (req.url === '/.well-known/openid-configuration') {
+        discoveryCalls += 1;
+        if (discoveryCalls === 1) {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.write('{"issuer":');
+          return;
+        }
+        res.end(JSON.stringify({ issuer, token_endpoint: `${issuer}/token` }));
+        return;
+      }
+      res.end(JSON.stringify({ access_token: 'recovered', expires_in: 120 }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('missing address');
+    issuer = `http://127.0.0.1:${address.port}`;
+    const provider = clientCredentials({ issuer, clientId: 'client', clientSecret: 'secret', timeoutMs: 100 });
+
+    await expect(provider.getToken()).rejects.toThrow(/discovery request timed out/);
+    await expect(provider.getToken()).resolves.toBe('recovered');
+    expect(discoveryCalls).toBe(2);
+  });
+
   it('lets one waiter cancel without canceling the shared exchange', async () => {
     let issuer = '';
     let releaseToken!: () => void;

--- a/sdk/typescript/src/oidc.ts
+++ b/sdk/typescript/src/oidc.ts
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isIP } from 'node:net';
+import { SdkError } from './errors.js';
+
+const EXPIRY_LEEWAY_MS = 30_000;
+const MAX_RESPONSE_BYTES = 1 << 20;
+
+export interface OidcTokenProvider {
+  getToken(signal?: AbortSignal): Promise<string>;
+}
+
+export interface ClientCredentialsOptions {
+  issuer: string;
+  clientId: string;
+  clientSecret: string | (() => string | Promise<string>);
+  scopes?: readonly string[];
+  audience?: string;
+  timeoutMs?: number;
+}
+
+interface CachedToken {
+  accessToken: string;
+  expiresAt: number;
+}
+
+function isLoopback(hostname: string): boolean {
+  const host = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+  if (host.toLowerCase() === 'localhost' || host === '::1') return true;
+  if (isIP(host) === 4) return host.startsWith('127.');
+  return false;
+}
+
+function secureUrl(name: string, raw: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new SdkError('invalid_config', `invalid OAuth ${name} URL`);
+  }
+  if (url.username || url.password || url.hash) {
+    throw new SdkError('invalid_config', `OAuth ${name} URL must not contain userinfo or a fragment`);
+  }
+  if (url.protocol !== 'https:' && !(url.protocol === 'http:' && isLoopback(url.hostname))) {
+    throw new SdkError('invalid_config', `OAuth ${name} URL must use HTTPS (HTTP is allowed only for loopback hosts)`);
+  }
+  return url;
+}
+
+function withoutTrailingSlash(raw: string): string {
+  return raw.replace(/\/+$/, '');
+}
+
+async function boundedJson(response: Response, kind: string): Promise<Record<string, unknown>> {
+  if (!response.body) throw new SdkError('auth', `OAuth ${kind} returned an empty response`);
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > MAX_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw new SdkError('auth', `OAuth ${kind} response is too large`);
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    const value: unknown = JSON.parse(new TextDecoder().decode(bytes));
+    if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('not an object');
+    return value as Record<string, unknown>;
+  } catch {
+    throw new SdkError('auth', `OAuth ${kind} returned invalid JSON`);
+  }
+}
+
+function waitFor<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(new SdkError('canceled', 'OAuth token request was canceled'));
+  return new Promise<T>((resolve, reject) => {
+    const canceled = () => reject(new SdkError('canceled', 'OAuth token request was canceled'));
+    signal.addEventListener('abort', canceled, { once: true });
+    promise.then(resolve, reject).finally(() => signal.removeEventListener('abort', canceled));
+  });
+}
+
+class ClientCredentialsProvider implements OidcTokenProvider {
+  readonly #options: ClientCredentialsOptions;
+  readonly #issuer: string;
+  #tokenEndpoint?: string;
+  #cached?: CachedToken;
+  #inFlight?: Promise<string>;
+
+  constructor(options: ClientCredentialsOptions) {
+    if (!options.clientId) throw new SdkError('invalid_config', 'OAuth clientId is required');
+    if (typeof options.clientSecret === 'string' && !options.clientSecret) {
+      throw new SdkError('invalid_config', 'OAuth clientSecret must not be empty');
+    }
+    this.#issuer = withoutTrailingSlash(secureUrl('issuer', options.issuer).toString());
+    this.#options = { ...options, scopes: options.scopes ? [...options.scopes] : undefined };
+  }
+
+  async getToken(signal?: AbortSignal): Promise<string> {
+    if (this.#cached && Date.now() + EXPIRY_LEEWAY_MS < this.#cached.expiresAt) return this.#cached.accessToken;
+    if (!this.#inFlight) {
+      this.#inFlight = this.#exchange().finally(() => {
+        this.#inFlight = undefined;
+      });
+    }
+    return waitFor(this.#inFlight, signal);
+  }
+
+  async #secret(): Promise<string> {
+    try {
+      const value =
+        typeof this.#options.clientSecret === 'string'
+          ? this.#options.clientSecret
+          : await this.#options.clientSecret();
+      if (!value) throw new Error('empty');
+      return value;
+    } catch {
+      throw new SdkError('auth', 'OAuth client secret supplier failed');
+    }
+  }
+
+  async #request(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.#options.timeoutMs ?? 30_000);
+    try {
+      return await fetch(url, { ...init, redirect: 'manual', signal: controller.signal });
+    } catch {
+      throw new SdkError('auth', 'OAuth client credentials request failed');
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async #exchange(): Promise<string> {
+    if (!this.#tokenEndpoint) {
+      const response = await this.#request(`${this.#issuer}/.well-known/openid-configuration`, {
+        headers: { accept: 'application/json' },
+      });
+      if (response.status !== 200) {
+        await response.body?.cancel();
+        throw new SdkError('auth', `OAuth discovery failed with HTTP ${response.status}`);
+      }
+      const discovery = await boundedJson(response, 'discovery');
+      if (typeof discovery.issuer !== 'string' || withoutTrailingSlash(discovery.issuer) !== this.#issuer) {
+        throw new SdkError('auth', 'OAuth discovery issuer mismatch');
+      }
+      if (typeof discovery.token_endpoint !== 'string') {
+        throw new SdkError('auth', 'OAuth discovery document is missing token_endpoint');
+      }
+      this.#tokenEndpoint = secureUrl('token endpoint', discovery.token_endpoint).toString();
+    }
+
+    const form = new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: this.#options.clientId,
+      client_secret: await this.#secret(),
+    });
+    if (this.#options.scopes?.length) form.set('scope', this.#options.scopes.join(' '));
+    if (this.#options.audience) form.set('audience', this.#options.audience);
+    const response = await this.#request(this.#tokenEndpoint, {
+      method: 'POST',
+      headers: { accept: 'application/json', 'content-type': 'application/x-www-form-urlencoded' },
+      body: form,
+    });
+    if (response.status !== 200) {
+      await response.body?.cancel();
+      throw new SdkError('auth', `OAuth client credentials exchange failed with HTTP ${response.status}`);
+    }
+    const token = await boundedJson(response, 'client credentials response');
+    if (typeof token.access_token !== 'string' || !token.access_token) {
+      throw new SdkError('auth', 'OAuth client credentials response is missing access_token');
+    }
+    if (typeof token.expires_in !== 'number' || !Number.isFinite(token.expires_in) || token.expires_in <= 0) {
+      throw new SdkError('auth', 'OAuth client credentials response requires a positive finite expires_in');
+    }
+    this.#cached = { accessToken: token.access_token, expiresAt: Date.now() + token.expires_in * 1000 };
+    return token.access_token;
+  }
+}
+
+export function clientCredentials(options: ClientCredentialsOptions): OidcTokenProvider {
+  return new ClientCredentialsProvider(options);
+}

--- a/sdk/typescript/src/oidc.ts
+++ b/sdk/typescript/src/oidc.ts
@@ -17,6 +17,7 @@ export interface ClientCredentialsOptions {
   clientSecret: string | (() => string | Promise<string>);
   scopes?: readonly string[];
   audience?: string;
+  /** Timeout for each complete discovery or token response, including its body. */
   timeoutMs?: number;
 }
 
@@ -131,12 +132,26 @@ class ClientCredentialsProvider implements OidcTokenProvider {
     }
   }
 
-  async #request(url: string, init: RequestInit): Promise<Response> {
+  async #requestJson(
+    url: string,
+    init: RequestInit,
+    responseKind: string,
+    operation: string,
+  ): Promise<Record<string, unknown>> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.#options.timeoutMs ?? 30_000);
     try {
-      return await fetch(url, { ...init, redirect: 'manual', signal: controller.signal });
-    } catch {
+      const response = await fetch(url, { ...init, redirect: 'manual', signal: controller.signal });
+      if (response.status !== 200) {
+        await response.body?.cancel();
+        throw new SdkError('auth', `OAuth ${operation} failed with HTTP ${response.status}`);
+      }
+      return await boundedJson(response, responseKind);
+    } catch (error) {
+      if (error instanceof SdkError) throw error;
+      if (controller.signal.aborted) {
+        throw new SdkError('auth', `OAuth ${operation} request timed out`);
+      }
       throw new SdkError('auth', 'OAuth client credentials request failed');
     } finally {
       clearTimeout(timeout);
@@ -145,14 +160,12 @@ class ClientCredentialsProvider implements OidcTokenProvider {
 
   async #exchange(): Promise<string> {
     if (!this.#tokenEndpoint) {
-      const response = await this.#request(`${this.#issuer}/.well-known/openid-configuration`, {
-        headers: { accept: 'application/json' },
-      });
-      if (response.status !== 200) {
-        await response.body?.cancel();
-        throw new SdkError('auth', `OAuth discovery failed with HTTP ${response.status}`);
-      }
-      const discovery = await boundedJson(response, 'discovery');
+      const discovery = await this.#requestJson(
+        `${this.#issuer}/.well-known/openid-configuration`,
+        { headers: { accept: 'application/json' } },
+        'discovery',
+        'discovery',
+      );
       if (typeof discovery.issuer !== 'string' || withoutTrailingSlash(discovery.issuer) !== this.#issuer) {
         throw new SdkError('auth', 'OAuth discovery issuer mismatch');
       }
@@ -169,16 +182,16 @@ class ClientCredentialsProvider implements OidcTokenProvider {
     });
     if (this.#options.scopes?.length) form.set('scope', this.#options.scopes.join(' '));
     if (this.#options.audience) form.set('audience', this.#options.audience);
-    const response = await this.#request(this.#tokenEndpoint, {
-      method: 'POST',
-      headers: { accept: 'application/json', 'content-type': 'application/x-www-form-urlencoded' },
-      body: form,
-    });
-    if (response.status !== 200) {
-      await response.body?.cancel();
-      throw new SdkError('auth', `OAuth client credentials exchange failed with HTTP ${response.status}`);
-    }
-    const token = await boundedJson(response, 'client credentials response');
+    const token = await this.#requestJson(
+      this.#tokenEndpoint,
+      {
+        method: 'POST',
+        headers: { accept: 'application/json', 'content-type': 'application/x-www-form-urlencoded' },
+        body: form,
+      },
+      'client credentials response',
+      'client credentials exchange',
+    );
     if (typeof token.access_token !== 'string' || !token.access_token) {
       throw new SdkError('auth', 'OAuth client credentials response is missing access_token');
     }

--- a/sdk/typescript/src/transport.test.ts
+++ b/sdk/typescript/src/transport.test.ts
@@ -63,6 +63,12 @@ describe('buildTransport token exclusivity', () => {
     }
   });
 
+  it('rejects a renewable provider combined with another token', () => {
+    const oidcTokenProvider = { getToken: async () => 'token' };
+    const fn = () => buildTransport({ gateway: 'https://gw.local', oidcToken: 'a', oidcTokenProvider });
+    expect(fn).toThrow(/mutually exclusive/);
+  });
+
   it('rejects edge tokens that could inject cookies or headers', () => {
     for (const edgeToken of ['', 'jwt; other=value', 'jwt\r\nx-injected: yes', 'jwt with spaces']) {
       const fn = () => buildTransport({ gateway: 'https://gw.local', edgeToken });

--- a/sdk/typescript/src/transport.test.ts
+++ b/sdk/typescript/src/transport.test.ts
@@ -5,9 +5,9 @@
 // contract without a live gateway: only PEM bytes are validated, no handshake
 // is performed.
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { errorCode } from './errors.js';
-import { buildTransport } from './transport.js';
+import { authInterceptor, buildTransport } from './transport.js';
 
 const pem = (label: string) => Buffer.from(`-----BEGIN ${label}-----\ntest\n-----END ${label}-----\n`);
 
@@ -85,6 +85,29 @@ describe('buildTransport token exclusivity', () => {
     expect(
       buildTransport({ gateway: 'https://gw.local', edgeToken: 'eyJhbGciOiJSUzI1NiJ9.payload_signature' }),
     ).toBeTruthy();
+  });
+});
+
+describe('renewable bearer interceptor', () => {
+  it('awaits the provider and attaches its current token to every request', async () => {
+    const signal = new AbortController().signal;
+    const getToken = vi.fn().mockResolvedValueOnce('token-1').mockResolvedValueOnce('token-2');
+    const seen: string[] = [];
+    const next = vi.fn(async (req: { header: Headers }) => {
+      seen.push(req.header.get('authorization') ?? '');
+      return {} as never;
+    });
+    const invoke = authInterceptor({
+      gateway: 'https://gw.local',
+      oidcTokenProvider: { getToken },
+    })(next as never);
+
+    await invoke({ header: new Headers(), signal } as never);
+    await invoke({ header: new Headers(), signal } as never);
+
+    expect(seen).toEqual(['Bearer token-1', 'Bearer token-2']);
+    expect(getToken).toHaveBeenNthCalledWith(1, signal);
+    expect(getToken).toHaveBeenNthCalledWith(2, signal);
   });
 });
 

--- a/sdk/typescript/src/transport.ts
+++ b/sdk/typescript/src/transport.ts
@@ -37,16 +37,18 @@ export interface ConnectOptions {
   /** Disable TLS verification (dev/debug only). */
   insecureSkipVerify?: boolean;
   /**
-   * Permit sending an auth token (oidcToken/edgeToken) over plaintext `http://`
-   * to a non-loopback host. Off by default: tokens over cleartext to a remote
-   * host leak credentials on the wire. Loopback hosts are always allowed.
+   * Permit sending an auth token (oidcToken/oidcTokenProvider/edgeToken) over
+   * plaintext `http://` to a non-loopback host. Off by default: tokens over
+   * cleartext to a remote host leak credentials on the wire. Loopback hosts are
+   * always allowed.
    */
   allowInsecureAuth?: boolean;
 }
 
 // OIDC bearer takes precedence; otherwise attach the Cloudflare Access header +
 // cookie. No-op when neither token is set.
-function authInterceptor(opts: ConnectOptions): Interceptor {
+/** @internal Exported for transport contract tests; not part of the package root API. */
+export function authInterceptor(opts: ConnectOptions): Interceptor {
   return (next) => async (req) => {
     if (opts.oidcTokenProvider) {
       req.header.set('authorization', `Bearer ${await opts.oidcTokenProvider.getToken(req.signal)}`);

--- a/sdk/typescript/src/transport.ts
+++ b/sdk/typescript/src/transport.ts
@@ -13,6 +13,7 @@
 import type { Interceptor, Transport } from '@connectrpc/connect';
 import { createGrpcTransport } from '@connectrpc/connect-node';
 import { SdkError } from './errors.js';
+import type { OidcTokenProvider } from './oidc.js';
 
 export interface ConnectOptions {
   /** Gateway URL (`http://...` or `https://...`). */
@@ -29,6 +30,8 @@ export interface ConnectOptions {
   clientKey?: Buffer;
   /** Bearer token for direct OIDC auth. Mutually exclusive with edgeToken. */
   oidcToken?: string;
+  /** Renewable OIDC bearer provider. Mutually exclusive with oidcToken and edgeToken. */
+  oidcTokenProvider?: OidcTokenProvider;
   /** Cloudflare Access token. See the sidecar note above for CF-fronted gateways. */
   edgeToken?: string;
   /** Disable TLS verification (dev/debug only). */
@@ -45,7 +48,9 @@ export interface ConnectOptions {
 // cookie. No-op when neither token is set.
 function authInterceptor(opts: ConnectOptions): Interceptor {
   return (next) => async (req) => {
-    if (opts.oidcToken) {
+    if (opts.oidcTokenProvider) {
+      req.header.set('authorization', `Bearer ${await opts.oidcTokenProvider.getToken(req.signal)}`);
+    } else if (opts.oidcToken) {
       req.header.set('authorization', `Bearer ${opts.oidcToken}`);
     } else if (opts.edgeToken) {
       req.header.set('cf-access-jwt-assertion', opts.edgeToken);
@@ -71,8 +76,11 @@ function assertMtlsPair(opts: ConnectOptions): void {
 // silently prefers OIDC when both are set. Reject that ambiguity up front so a
 // caller does not think an edge token is in effect when it is being ignored.
 function assertTokenExclusivity(opts: ConnectOptions): void {
-  if (opts.oidcToken !== undefined && opts.edgeToken !== undefined) {
-    throw new SdkError('invalid_config', 'oidcToken and edgeToken are mutually exclusive');
+  const configured = [opts.oidcToken, opts.oidcTokenProvider, opts.edgeToken].filter(
+    (value) => value !== undefined,
+  ).length;
+  if (configured > 1) {
+    throw new SdkError('invalid_config', 'oidcToken, oidcTokenProvider, and edgeToken are mutually exclusive');
   }
 }
 
@@ -96,7 +104,7 @@ function isLoopbackHost(host: string): boolean {
 // host puts the credential on the wire in the clear. Refuse it unless the caller
 // explicitly opts in. Loopback (local-dev / edge-sidecar) is always fine.
 function assertTokenTransportSecurity(opts: ConnectOptions): void {
-  const hasToken = opts.oidcToken !== undefined || opts.edgeToken !== undefined;
+  const hasToken = opts.oidcToken !== undefined || opts.oidcTokenProvider !== undefined || opts.edgeToken !== undefined;
   if (!hasToken || opts.allowInsecureAuth || opts.gateway.startsWith('https://')) return;
   let host: string;
   try {


### PR DESCRIPTION
> **🏗️ build-from-issue-agent**

## Summary

Add first-class renewable OAuth 2.0 client-credentials authentication to the Python, TypeScript, and Go SDK clients. All three implementations lazily acquire and renew in-memory access tokens, coalesce concurrent exchanges, preserve existing auth APIs, and share a security-focused conformance fixture.

## Related Issue

Closes #2803

## Changes

- Python exports `ClientCredentialsAuth`, supports direct and active-gateway construction, and forwards the provider through the high-level `Sandbox` API.
- TypeScript exports `clientCredentials()` and `OidcTokenProvider`, with async bearer attachment through the Connect transport.
- Go exports `oidc.NewClientCredentialsAuth`, supports literal or callback secrets, and resolves audience/scopes from gateway metadata.
- All SDKs enforce issuer matching, protected remote transport, redirect refusal, bounded responses, positive expiry, fail-closed renewal, and secret-safe errors/representations.
- A shared conformance fixture pins request, expiry, URL, redirect, response-bound, and redaction behavior.
- The existing Keycloak OIDC E2E now authenticates through the public Python SDK API.

### Deviations from Plan

None — implemented as planned. TypeScript remains explicit-only because it has no registered-gateway abstraction.

## Testing

- [x] `mise run test:python` — 108 passed
- [x] `mise run sdk:ts:ci` — 91 passed; lint, typecheck, coverage, and build passed
- [x] `mise run go:ci` — race tests, lint, build, proto, and docs checks passed
- [x] `mise run e2e:oidc-python:docker` — 84 passed
- [x] `mise run pre-commit` passed
- [x] `env -u OPENSHELL_NO_BROWSER mise run ci` passed

**Tests added:**

- **Unit/conformance:** Python, TypeScript, and Go coverage for exact forms, no implicit interactive scopes, audience, renewal, concurrency, cancellation where supported, invalid expiry, redirect/TLS posture, response bounds, failure handling, and redaction.
- **Integration:** Mock HTTP identity providers in all three SDK suites; transport/per-RPC bearer attachment coverage.
- **E2E:** `e2e/python/oidc/oidc_auth_test.py` exercises public Python client-credentials authentication against Keycloak and a Docker gateway.

## Checklist

- [x] Follows Conventional Commits
- [x] Commit is signed off (DCO)
- [x] Existing static-token and caller-provided provider APIs remain compatible
- [x] No secrets or access tokens are persisted

**Documentation updated:**

- `docs/reference/gateway-auth.mdx` and `docs/sandboxes/manage-sandboxes.mdx`: service-account workflows and authorization prerequisites.
- `sdk/typescript/README.md`, `sdk/go/README.md`, and Go OIDC API docs: language-specific usage.
- `architecture/gateway.md`: stable in-memory SDK token lifecycle boundary.