### PR TITLE
fix(test-guest): pin HVF runtime dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,10 +34,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-test-guest": {
+      "locked": {
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-test-guest": "nixpkgs-test-guest",
         "rust-overlay": "rust-overlay",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,9 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Keep the QEMU and OVMF runtime used by Apple Silicon test guests on a
+    # known-good release. Development shells and cross toolchains use nixpkgs.
+    nixpkgs-test-guest.url = "github:NixOS/nixpkgs/0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -29,6 +32,7 @@
     {
       flake-utils,
       nixpkgs,
+      nixpkgs-test-guest,
       treefmt-nix,
       rust-overlay,
       ...
@@ -40,6 +44,7 @@
           inherit system;
           overlays = [ (import rust-overlay) ];
         };
+        testGuestPkgs = import nixpkgs-test-guest { inherit system; };
         commonDevShellPackages = with pkgs; [
           # Assemble Debian artifacts on macOS and Linux.
           dpkg
@@ -55,7 +60,11 @@
         rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
         z3-static = pkgs.callPackage ./nix/pkgs/z3-static.nix { };
         aws-lc-static = pkgs.callPackage ./nix/pkgs/aws-lc-static.nix { };
-        testGuest = import ./nix/test-guest { inherit pkgs; };
+        testGuest = import ./nix/test-guest {
+          inherit pkgs;
+          qemuPkgs = testGuestPkgs;
+          firmwarePkgs = testGuestPkgs;
+        };
       in
       {
         apps.test-guest = testGuest.app;

--- a/nix/test-guest/README.md
+++ b/nix/test-guest/README.md
@@ -16,6 +16,12 @@ This prototype uses Nix, QEMU, and Ansible to boot and configure disposable Linu
 
 The first run downloads the selected cloud image and VM runtime. Nix reuses those immutable inputs on later runs, while each guest starts from a fresh writable overlay.
 
+On Apple Silicon, test guests deliberately take QEMU 11.0.2 and its matching OVMF
+firmware from a separately pinned Nixpkgs revision. All other guest-runtime tools,
+development dependencies, and cross-toolchain dependencies continue to use the main
+current Nixpkgs input. This avoids a QEMU 11.1 HVF guest boot regression. Update
+this pair only after validating an ARM64 Ubuntu guest boot with HVF.
+
 ## Directory structure
 
 ```text

--- a/nix/test-guest/default.nix
+++ b/nix/test-guest/default.nix
@@ -3,13 +3,17 @@
 
 # PROTOTYPE: Composable distro VMs for installing and exercising artifacts.
 
-{ pkgs }:
+{
+  pkgs,
+  qemuPkgs ? pkgs,
+  firmwarePkgs ? pkgs,
+}:
 
 let
   isAarch64 = pkgs.stdenv.hostPlatform.isAarch64;
   isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
   architecture = if isAarch64 then "aarch64" else "x86_64";
-  qemu = pkgs.qemu.override { hostCpuOnly = true; };
+  qemu = qemuPkgs.qemu.override { hostCpuOnly = true; };
   qemuBinary =
     if isAarch64 then "${qemu}/bin/qemu-system-aarch64" else "${qemu}/bin/qemu-system-x86_64";
 
@@ -75,8 +79,8 @@ let
     export OPENSHELL_TEST_GUEST_RUNNER=${./run.sh}
     export TEST_GUEST_BASH=${pkgs.bash}/bin/bash
     export TEST_GUEST_QEMU=${qemuBinary}
-    export TEST_GUEST_FIRMWARE_CODE=${pkgs.OVMF.firmware}
-    export TEST_GUEST_FIRMWARE_VARS=${pkgs.OVMF.variables}
+    export TEST_GUEST_FIRMWARE_CODE=${firmwarePkgs.OVMF.firmware}
+    export TEST_GUEST_FIRMWARE_VARS=${firmwarePkgs.OVMF.variables}
     export TEST_GUEST_MACHINE=${if isAarch64 then "virt" else "q35"}
     export TEST_GUEST_ACCELERATOR=${if isDarwin then "hvf" else "kvm"}
     export TEST_GUEST_ARCHITECTURE=${architecture}


### PR DESCRIPTION
## Summary

Pin the QEMU 11.0.2 and matching OVMF pair used by Apple Silicon test guests, while retaining current Nixpkgs for all other guest tools and development/cross-toolchain dependencies.

## Related Issue

No issue required: localized regression workaround with a documented upstream validation path.

## Changes

- Add a locked Nixpkgs input for the known-good QEMU and OVMF pair.
- Inject only that pair into the test-guest runtime; retain current Nixpkgs for all other tools.
- Document the Apple Silicon HVF validation requirement.

## Analysis

Current Nixpkgs revision `ffb3c9b7` provides QEMU 11.1.0. On Apple Silicon with HVF, Ubuntu ARM64 reaches UEFI, loads the kernel and initrd, then stalls after `EFI stub: Exiting boot services...`; QEMU consumes CPU and SSH never becomes ready. The known-good runtime revision `0954f7ee` provides QEMU 11.0.2 and boots the same guest in 6–8 seconds.

The prepared guest cache was not involved in the comparison: each control below used `OPENSHELL_TEST_GUEST_CACHE_DISABLE=1` and a pinned Ubuntu cloud image.

| QEMU source | OVMF source | Remaining guest tools | Result |
| --- | --- | --- | --- |
| current 11.1.0 | current | current | stalls after EFI handoff (original regression) |
| pinned 11.0.2 | current | current | stalls after EFI handoff |
| current 11.1.0 | pinned | current | stalls/times out |
| pinned 11.0.2 | pinned | current | SSH ready in 8s; `uname -m` returns `aarch64` |

This supports pinning the matching QEMU/OVMF pair, not the entire test-guest runtime. OVMF reports version `202605` in both revisions, so the relevant distinction is the exact Nix derivation/runtime pair rather than its version string.

Upstream context:

- Nixpkgs [#532038](https://github.com/NixOS/nixpkgs/issues/532038) is related historical context but not this failure: it reports a QEMU 11.0 VCPU-initialization assertion caused by building against Apple SDK 14.4. Current QEMU 11.1.0 is built against Apple SDK 15.5, so that package fix is already present here.
- QEMU [#3228](https://gitlab.com/qemu-project/qemu/-/work_items/3228) is a closer symptom match: Apple Silicon HVF Linux boot deadlock after the bootloader. This PR does not claim a confirmed root cause; its matrix is suitable evidence for an upstream follow-up.

## Testing

- [x] `nix flake check --no-build`
- [x] `nix fmt`
- [x] Apple Silicon smoke: `OPENSHELL_TEST_GUEST_CACHE_DISABLE=1 nix run .#test-guest -- --distro ubuntu -- uname -m` returned `aarch64` with the pinned QEMU+OVMF pair (8s boot).
- [x] Reproduction controls: pinned QEMU with current OVMF and current QEMU with pinned OVMF both stalled after EFI handoff.
- [ ] `mise run pre-commit` could not run because `mise` is absent on the host. The Nix fallback spent its 10-minute bound compiling mise itself and did not reach the checks.
- [ ] E2E tests not run; this change affects the local Apple Silicon guest runtime.

## Checklist

- [x] Follows Conventional Commits
- [x] Commit is signed off (DCO)