### PR TITLE
ci(vouch): close approved request discussions

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/vouch-request.yml
+++ b/.github/DISCUSSION_TEMPLATE/vouch-request.yml
@@ -8,7 +8,7 @@ body:
 
         OpenShell uses a vouch system for first-time contributors. Fill out this
         form to request approval. A maintainer will review and comment `/vouch`
-        if approved.
+        if approved. Approved requests are closed automatically.
 
         **Write in your own words.** Do not have an AI generate this request.
         Requests that read like LLM output will be denied.

--- a/.github/workflows/vouch-command.yml
+++ b/.github/workflows/vouch-command.yml
@@ -53,6 +53,16 @@ jobs:
               await github.graphql(mutation, { discussionId, body });
             }
 
+            async function closeDiscussion() {
+              const discussionId = await getDiscussionId();
+              const mutation = `mutation($discussionId: ID!) {
+                closeDiscussion(input: {discussionId: $discussionId}) {
+                  discussion { id }
+                }
+              }`;
+              await github.graphql(mutation, { discussionId });
+            }
+
             // --- Authorization ---
 
             let isMaintainer = false;
@@ -134,6 +144,7 @@ jobs:
               await postDiscussionComment(
                 `@${discussionAuthor} is already vouched. They can submit pull requests.`
               );
+              await closeDiscussion();
               return;
             }
 
@@ -185,4 +196,6 @@ jobs:
               'Please read [CONTRIBUTING.md](https://github.com/NVIDIA/OpenShell/blob/main/CONTRIBUTING.md) before submitting.',
             ].join('\n'));
 
-            console.log(`Vouched ${discussionAuthor} (approved by ${commenter}).`);
+            await closeDiscussion();
+
+            console.log(`Vouched ${discussionAuthor} (approved by ${commenter}) and closed the discussion.`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,8 @@ We use a vouch system. This exists because AI makes it trivial to generate plaus
 1. Open a [Vouch Request](https://github.com/NVIDIA/OpenShell/discussions/new?category=vouch-request) discussion.
 2. Describe what you want to change and why.
 3. Write in your own words. AI-generated vouch requests will be denied.
-4. A maintainer will comment `/vouch` if approved.
+4. A maintainer will comment `/vouch` if approved, and the request discussion
+   will close automatically.
 5. Once vouched, you can submit pull requests.
 
 **If you are not vouched, any pull request you open will be automatically closed.** Org members and collaborators with push access bypass this check.


### PR DESCRIPTION
## Summary

Close vouch-request discussions after a maintainer successfully approves a contributor, so completed requests no longer remain open.

## Related Issue

No issue required: localized contribution-workflow maintenance requested directly.

## Changes

- Close a discussion after committing a new vouch and posting the approval confirmation.
- Close still-open discussions for contributors who were already vouched.
- Document automatic closure in the vouch template and contributor guide.

## Testing

- [ ] `mise run pre-commit` passes (not run: `mise` is not installed in this environment)
- [x] YAML parsing of the workflow and discussion template
- [x] `git diff --check`
- [x] No unit tests needed for this workflow-only change
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)