### PR TITLE
fix(gateway): let Ready win over stale Suspended in derive_phase

### DIFF
--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -3980,10 +3980,24 @@ fn derive_phase(status: Option<&DriverSandboxStatus>) -> SandboxPhase {
             return SandboxPhase::Deleting;
         }
 
-        if status.conditions.iter().any(|condition| {
-            condition.r#type.eq_ignore_ascii_case("Suspended")
+        // `Ready=True` means the sandbox is usable through this gateway and must
+        // win over a `Suspended=True` condition. Agent Sandbox v1beta1 sets
+        // `Suspended=True (PodTerminated)` on stop and does not clear it on resume,
+        // so a resumed CR carries both `Ready=True` and a stale `Suspended=True`.
+        // Treating any `Suspended=True` as Stopped would pin the resumed sandbox at
+        // Starting forever (issue #2932). A genuine stop leaves `Ready` unset or
+        // False, so `Suspended` still resolves to Stopped in that case.
+        let ready = status.conditions.iter().any(|condition| {
+            condition.r#type.eq_ignore_ascii_case("Ready")
                 && condition.status.eq_ignore_ascii_case("true")
-        }) {
+        });
+
+        if !ready
+            && status.conditions.iter().any(|condition| {
+                condition.r#type.eq_ignore_ascii_case("Suspended")
+                    && condition.status.eq_ignore_ascii_case("true")
+            })
+        {
             return SandboxPhase::Stopped;
         }
 
@@ -6456,6 +6470,56 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(current.phase(), SandboxPhase::Stopped as i32);
+    }
+
+    #[tokio::test]
+    async fn resumed_v1beta1_snapshot_with_stale_suspended_reaches_ready() {
+        // Reproduces issue #2932: on Agent Sandbox v1beta1 a resumed CR reports
+        // Ready=True (DependenciesReady) alongside a stale Suspended=True
+        // (PodTerminated). Starting from the Starting phase that `start` sets, the
+        // reconciled sandbox must advance to Ready rather than being pinned at
+        // Starting by the stale Suspended condition.
+        let runtime = test_runtime(Arc::new(TestDriver::default())).await;
+        let sandbox = sandbox_record("sb-resumed", "sandbox-resumed", SandboxPhase::Starting);
+        runtime.store.put_message(&sandbox).await.unwrap();
+        register_test_supervisor_session(&runtime, sandbox.object_id());
+
+        let mut resumed = ready_driver_sandbox(sandbox.object_id(), sandbox.object_name());
+        resumed.status = Some(DriverSandboxStatus {
+            sandbox_name: sandbox.object_name().to_string(),
+            instance_id: format!("{}-pod", sandbox.object_name()),
+            conditions: vec![
+                DriverCondition {
+                    r#type: "Ready".to_string(),
+                    status: "True".to_string(),
+                    reason: "DependenciesReady".to_string(),
+                    message: "Sandbox is ready".to_string(),
+                    last_transition_time: String::new(),
+                },
+                DriverCondition {
+                    r#type: "Suspended".to_string(),
+                    status: "True".to_string(),
+                    reason: "PodTerminated".to_string(),
+                    message: "Pod terminated".to_string(),
+                    last_transition_time: String::new(),
+                },
+            ],
+            ..Default::default()
+        });
+
+        runtime.apply_sandbox_update(resumed).await.unwrap();
+
+        let current = runtime
+            .store
+            .get_message::<Sandbox>(sandbox.object_id())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            current.phase(),
+            SandboxPhase::Ready as i32,
+            "a resumed, Ready sandbox must not stay Starting because of a stale Suspended condition"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

On Agent Sandbox **v1beta1**, `openshell sandbox stop` followed by `openshell sandbox start` left the sandbox stuck at phase `Starting` and `start` timed out after 300s, even though the workload pod was `Running 1/1` and the CR reported `Ready=True`. This makes the gateway's readiness contract robust to a stale `Suspended` condition so a resumed, Ready sandbox reaches `Ready`.

## Related Issue

Fixes #2932

## Changes

- `crates/openshell-server/src/compute/mod.rs`: `derive_phase` now treats `Ready=True` as authoritative — it only resolves `Stopped` from a `Suspended=True` condition when `Ready` is not `True`. A genuine stop leaves `Ready` unset or `False`, so it still resolves to `Stopped`.
- Added a regression test (`resumed_v1beta1_snapshot_with_stale_suspended_reaches_ready`) that drives the real reconciliation with the exact conditions a resumed v1beta1 CR produces (`Ready=True (DependenciesReady)` + stale `Suspended=True (PodTerminated)`) starting from `Starting`, and asserts the sandbox advances to `Ready`.

### Root cause

The gateway derives phase from the Sandbox CR conditions. The Agent Sandbox v1beta1 controller (`v0.5.0`) sets `Suspended=True (PodTerminated)` on stop and does **not** clear it on resume, so a resumed CR carries both `Ready=True` and a stale `Suspended=True`. `derive_phase` treated any `Suspended=True` as `Stopped` before consulting `Ready`, so the resumed-but-Ready sandbox was read as not-running and the `Starting` phase never advanced. v1alpha1 encodes desired state as `spec.replicas` and emits no lingering `Suspended` condition, so it was unaffected — and remains so.

The stale condition itself is an **upstream bug** in the agent-sandbox controller, fixed by kubernetes-sigs/agent-sandbox#1150 (present in `v0.5.6`, absent in `v0.5.0`). This gateway change keeps OpenShell resilient regardless of the deployed controller version; operators are also encouraged to upgrade the Agent Sandbox controller to a release containing that fix.

## Testing

- Reproduced the bug deterministically against unfixed code: the new test lands at phase `Starting` (proto `SANDBOX_PHASE_STARTING = 8`) instead of `Ready` (`2`); the fix makes it reach `Ready`.
- Independently reproduced the upstream trigger live on an Agent Sandbox v0.5.0 (v1beta1) cluster at the raw CR level: create → `Ready=True`; suspend → `Ready=False`, `Suspended=True`; resume → `Ready=True` **and stale `Suspended=True`**, pod `Running 1/1`.
- `cargo test -p openshell-server --lib` — 1421 passed, 0 failed.
- `cargo test -p openshell-driver-kubernetes --lib` — 209 passed, 0 failed.
- `mise run pre-commit` — passed.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests added/updated and passing
- [x] `mise run pre-commit` passes
- [x] Linked to an accepted issue (#2932)
- [x] No secrets or credentials committed
