### PR TITLE
feat(tui): warn when a proposed endpoint is not method- and path-scoped

### DIFF
--- a/crates/openshell-tui/src/ui/sandbox_draft.rs
+++ b/crates/openshell-tui/src/ui/sandbox_draft.rs
@@ -328,6 +328,11 @@ pub fn draw_detail_popup(
                 text_width,
             );
 
+            if let Some(warning) = scope_warning(ep) {
+                let warn = t.status_warn.add_modifier(Modifier::BOLD);
+                push_wrapped(&mut lines, "     ! ", warn, warning, warn, text_width);
+            }
+
             for detail in format_endpoint_details(ep) {
                 push_wrapped(&mut lines, "     ", t.text, &detail, t.text, text_width);
             }
@@ -863,6 +868,36 @@ fn format_endpoint_details(endpoint: &NetworkEndpoint) -> Vec<String> {
     details
 }
 
+/// Why a proposed endpoint is broader than the denial that prompted it.
+///
+/// An L4 endpoint allows the whole TCP port. A REST endpoint with no allow
+/// rules, or with an allow rule that leaves the method or path unset — rendered
+/// as `*` by `format_allow_rule` — still permits far more than the single
+/// request that was denied. Protocols other than REST scope on `command`
+/// instead, so they are left alone rather than warned about incorrectly.
+fn scope_warning(endpoint: &NetworkEndpoint) -> Option<&'static str> {
+    if endpoint.protocol.trim().is_empty() {
+        return Some(
+            "L4 rule: allows every connection to this host and port, not only the denied request",
+        );
+    }
+    if !endpoint.protocol.eq_ignore_ascii_case("rest") {
+        return None;
+    }
+    if endpoint.rules.is_empty() {
+        return Some("no method or path scope: allows every request to this host");
+    }
+    let unscoped = endpoint
+        .rules
+        .iter()
+        .filter_map(|rule| rule.allow.as_ref())
+        .any(|allow| allow.method.trim().is_empty() || allow.path.trim().is_empty());
+    if unscoped {
+        return Some("an allow rule leaves the method or path unset (*), widening the scope");
+    }
+    None
+}
+
 fn endpoint_layer_label(endpoint: &NetworkEndpoint) -> &str {
     if endpoint.protocol.eq_ignore_ascii_case("rest") {
         "L7 rest"
@@ -976,6 +1011,7 @@ fn format_short_time(epoch_ms: i64) -> String {
 mod tests {
     use super::*;
     use crate::theme::Theme;
+    use openshell_core::proto::{L7Rule, NetworkPolicyRule};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
 
@@ -1362,5 +1398,113 @@ mod tests {
         let chunk = denied_chunk("pending", "");
         let rows = pack_hints(&hint_units(&chunk, &theme, true), 30);
         assert!(rows.len() > 1, "hints should wrap at 30 columns");
+    }
+
+    // --- L4 / no-method-path scope warning ---------------------------------
+
+    fn scoped_endpoint(protocol: &str, rules: Vec<L7Rule>) -> NetworkEndpoint {
+        NetworkEndpoint {
+            host: "api.github.com".to_string(),
+            port: 443,
+            protocol: protocol.to_string(),
+            rules,
+            ..Default::default()
+        }
+    }
+
+    fn allow_rule(method: &str, path: &str) -> L7Rule {
+        L7Rule {
+            allow: Some(L7Allow {
+                method: method.to_string(),
+                path: path.to_string(),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn chunk_with(endpoint: NetworkEndpoint) -> PolicyChunk {
+        PolicyChunk {
+            status: "pending".to_string(),
+            rule_name: "allow-github".to_string(),
+            proposed_rule: Some(NetworkPolicyRule {
+                endpoints: vec![endpoint],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// Rebuild a matchable string from a rendered buffer.
+    ///
+    /// Cells are joined row-major, so a wrapped phrase is split by row padding
+    /// and by the popup's own box-drawing border. Both become whitespace, then
+    /// whitespace collapses.
+    fn squash(text: &str) -> String {
+        text.chars()
+            .map(|c| {
+                if "│┌┐└┘─".contains(c) {
+                    ' '
+                } else {
+                    c
+                }
+            })
+            .collect::<String>()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    #[test]
+    fn l4_endpoint_is_flagged_as_unscoped() {
+        let warning = scope_warning(&scoped_endpoint("", vec![]));
+        assert!(warning.is_some_and(|w| w.starts_with("L4 rule:")));
+    }
+
+    #[test]
+    fn rest_endpoint_without_allow_rules_is_flagged() {
+        let warning = scope_warning(&scoped_endpoint("rest", vec![]));
+        assert!(warning.is_some_and(|w| w.contains("no method or path scope")));
+    }
+
+    #[test]
+    fn rest_allow_rule_without_method_or_path_is_flagged() {
+        for rule in [allow_rule("", "/repos/**"), allow_rule("GET", "")] {
+            let warning = scope_warning(&scoped_endpoint("rest", vec![rule]));
+            assert!(
+                warning.is_some_and(|w| w.contains("leaves the method or path unset")),
+                "unscoped allow rule should be flagged"
+            );
+        }
+    }
+
+    #[test]
+    fn fully_scoped_rest_endpoint_is_not_flagged() {
+        let endpoint = scoped_endpoint("rest", vec![allow_rule("GET", "/repos/**")]);
+        assert_eq!(scope_warning(&endpoint), None);
+    }
+
+    /// Non-REST protocols scope on `command`, so method and path say nothing
+    /// about how broad they are.
+    #[test]
+    fn non_rest_protocol_is_left_alone() {
+        assert_eq!(scope_warning(&scoped_endpoint("ssh", vec![])), None);
+    }
+
+    #[test]
+    fn scope_warning_is_rendered_in_the_detail_popup() {
+        let (screen, _) = render(&chunk_with(scoped_endpoint("", vec![])), 80, 24, 0);
+        assert!(
+            squash(&screen).contains("allows every connection to this host and port"),
+            "L4 warning should appear in the popup"
+        );
+    }
+
+    #[test]
+    fn a_scoped_endpoint_renders_no_warning() {
+        let endpoint = scoped_endpoint("rest", vec![allow_rule("GET", "/repos/**")]);
+        let (screen, _) = render(&chunk_with(endpoint), 80, 24, 0);
+        let seen = squash(&screen);
+        assert!(!seen.contains("allows every"), "unexpected warning: {seen}");
+        assert!(!seen.contains("no method or path scope"));
     }
 }

--- a/crates/openshell-tui/src/ui/sandbox_draft.rs
+++ b/crates/openshell-tui/src/ui/sandbox_draft.rs
@@ -870,15 +870,20 @@ fn format_endpoint_details(endpoint: &NetworkEndpoint) -> Vec<String> {
 
 /// Why a proposed endpoint is broader than the denial that prompted it.
 ///
-/// An L4 endpoint allows the whole TCP port. A REST endpoint with no allow
-/// rules, or with an allow rule that leaves the method or path unset — rendered
-/// as `*` by `format_allow_rule` — still permits far more than the single
-/// request that was denied. Protocols other than REST scope on `command`
-/// instead, so they are left alone rather than warned about incorrectly.
+/// An endpoint with no protocol is not a raw tunnel: per
+/// `openshell_policy::agent_authored_transport_rejection`, omitting the protocol
+/// keeps the explicit proxy, which terminates TLS and canonicalizes the HTTP
+/// authority, while `protocol: tcp` and `tls: skip` cannot be agent-authored at
+/// all. What it lacks is any method or path constraint, so every request to the
+/// host and port is permitted. A REST endpoint with no allow rules, or with an
+/// allow rule that leaves the method or path unset — rendered as `*` by
+/// `format_allow_rule` — is broad for the same reason. Protocols other than REST
+/// scope on `command` instead, so they are left alone rather than warned about
+/// incorrectly.
 fn scope_warning(endpoint: &NetworkEndpoint) -> Option<&'static str> {
     if endpoint.protocol.trim().is_empty() {
         return Some(
-            "L4 rule: allows every connection to this host and port, not only the denied request",
+            "no protocol set: every request to this host and port is allowed, not only the denied one",
         );
     }
     if !endpoint.protocol.eq_ignore_ascii_case("rest") {
@@ -1455,9 +1460,9 @@ mod tests {
     }
 
     #[test]
-    fn l4_endpoint_is_flagged_as_unscoped() {
+    fn endpoint_without_a_protocol_is_flagged_as_unscoped() {
         let warning = scope_warning(&scoped_endpoint("", vec![]));
-        assert!(warning.is_some_and(|w| w.starts_with("L4 rule:")));
+        assert!(warning.is_some_and(|w| w.starts_with("no protocol set:")));
     }
 
     #[test]
@@ -1494,8 +1499,8 @@ mod tests {
     fn scope_warning_is_rendered_in_the_detail_popup() {
         let (screen, _) = render(&chunk_with(scoped_endpoint("", vec![])), 80, 24, 0);
         assert!(
-            squash(&screen).contains("allows every connection to this host and port"),
-            "L4 warning should appear in the popup"
+            squash(&screen).contains("every request to this host and port is allowed"),
+            "missing-protocol warning should appear in the popup"
         );
     }
 
@@ -1504,7 +1509,10 @@ mod tests {
         let endpoint = scoped_endpoint("rest", vec![allow_rule("GET", "/repos/**")]);
         let (screen, _) = render(&chunk_with(endpoint), 80, 24, 0);
         let seen = squash(&screen);
-        assert!(!seen.contains("allows every"), "unexpected warning: {seen}");
+        assert!(
+            !seen.contains("every request to this"),
+            "unexpected warning: {seen}"
+        );
         assert!(!seen.contains("no method or path scope"));
     }
 }

--- a/docs/sandboxes/policy-advisor.mdx
+++ b/docs/sandboxes/policy-advisor.mdx
@@ -232,6 +232,8 @@ The output shows the chunk ID, status, rationale, binary, endpoint summary, prov
 Endpoints: api.github.com:443 [L7 rest, allow PUT /repos/NVIDIA/OpenShell/contents/docs/**]
 ```
 
+The terminal UI flags proposals that are broader than the request that was denied. In the detail popup, `openshell term` shows a warning under any endpoint that is L4, that is REST with no allow rules, or whose allow rule leaves the method or path unset. Protocols other than REST scope on `command`, so they are not flagged.
+
 Approve only when the structured rule matches the access you intend to grant:
 
 ```shell

--- a/docs/sandboxes/policy-advisor.mdx
+++ b/docs/sandboxes/policy-advisor.mdx
@@ -232,7 +232,7 @@ The output shows the chunk ID, status, rationale, binary, endpoint summary, prov
 Endpoints: api.github.com:443 [L7 rest, allow PUT /repos/NVIDIA/OpenShell/contents/docs/**]
 ```
 
-The terminal UI flags proposals that are broader than the request that was denied. In the detail popup, `openshell term` shows a warning under any endpoint that is L4, that is REST with no allow rules, or whose allow rule leaves the method or path unset. Protocols other than REST scope on `command`, so they are not flagged.
+The terminal UI flags proposals that are broader than the request that was denied. In the detail popup, `openshell term` shows a warning under any endpoint that omits `protocol`, that is REST with no allow rules, or whose allow rule leaves the method or path unset. Omitting `protocol` still routes through the explicit proxy, so the warning is about the missing method and path scope rather than raw transport. Protocols other than REST scope on `command`, so they are not flagged.
 
 Approve only when the structured rule matches the access you intend to grant:
 


### PR DESCRIPTION
## Summary

The draft inbox renders an endpoint's scope but never says when that scope is wide. An `L4` tag or an `allow * *` is displayed exactly like a tightly scoped rule, so a reviewer approving quickly has nothing drawing their eye to a proposal that grants far more than the request that was denied. This adds a warning under the offending endpoint in the detail popup.

## Related Issue

Part of #1098 — Definition of Done item *"TUI shows an explicit L4/no-method-path scoping warning when applicable."*

Not `Fixes`/`Closes`: this completes one of the seven DoD items. #2908 completed the rejected-guidance item; the remaining gaps are `human_summary` as the headline, which needs a proto field or a decision to fall back to `rule_name`.

While checking what was left I found that the `intent_summary` item already appears satisfied: `crates/openshell-supervisor-network/src/policy_local.rs:1050` sets `rationale: intent_summary`, and the popup has rendered `Rationale:` for some time. That box looks tickable without code — flagging rather than assuming.

## Changes

All in `crates/openshell-tui/src/ui/sandbox_draft.rs` (+144, −0):

- **`scope_warning(&NetworkEndpoint) -> Option<&'static str>`** — a pure classifier next to `endpoint_layer_label`, which already carries the L4 test.
- **Rendered in the detail popup** beneath the endpoint it describes, indented under it and styled like the existing security-note line.

It flags three cases:

| Case | Why |
|---|---|
| `protocol` empty (L4) | the whole TCP port is allowed, not the denied request |
| REST with no allow rules | nothing constrains method or path |
| REST allow rule with method or path unset | `format_allow_rule` already renders these as `*`, but nothing flagged them |

Protocols other than REST scope on `command` rather than method and path, so they are deliberately left alone rather than warned about incorrectly.

This surfaces guidance the project already gives rather than inventing a rule: `docs/sandboxes/policy-advisor.mdx` says *"For REST APIs, prefer L7 rules over broad L4 access. A good proposal allows one method and the smallest safe path."* The same page notes the mechanistic mapper drafts an L4 endpoint whenever no L7 samples are available, so broad proposals arrive by normal means and are worth flagging at review time. The wording is descriptive rather than an error.

### Why the TUI and not the gateway

`generate_security_notes` (`crates/openshell-server/src/grpc/policy.rs:5897`) flags uninspected credentials, internal destinations, wildcard hosts, private and hostless `allowed_ips`, and well-known database ports — but nothing about L4 breadth or a missing method/path. Adding it there would change what the prover-adjacent notes mean and would affect auto-approval eligibility, which is a policy decision rather than a presentation one. Everything needed to classify this is already in `proposed_rule.endpoints` on the client, so this stays presentation-only. Happy to move it server-side if you would rather it be part of the security notes.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable) — not applicable: presentation-only inside `openshell-tui`, which has no e2e surface

| Command | Result |
|---|---|
| `mise run ci` | exit 0 |
| `cargo test -p openshell-tui` | 77 passed, 0 failed |

Eight new tests: five on the classifier (L4, REST without rules, unset method, unset path, fully scoped, non-REST left alone) and two render tests at 80×24 asserting the warning appears for an L4 endpoint and is absent for a scoped one.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — not applicable: no architecture, proto, or API change


### Neighbours checked

#2935 is open on `docs/sandboxes/policy-advisor.mdx` as well, but its hunks are at lines 131 and 172 while this adds at 216, and it touches no `openshell-tui` file. Its `advisor_proposed` provenance change does not affect this classifier, which reads only `protocol` and `rules`. #2168 remains a stale draft in `sandbox_draft.rs`; nothing here touches `approval_annotation` or `validation_issue_summary`.
