### PR TITLE
feat(helm): scope ClusterRole/ClusterRoleBinding names by release namespace

### DIFF
--- a/deploy/helm/openshell/templates/clusterrole.yaml
+++ b/deploy/helm/openshell/templates/clusterrole.yaml
@@ -5,7 +5,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "openshell.fullname" . }}-node-reader
+  name: {{ include "openshell.fullname" . }}-node-reader-{{ .Release.Namespace }}
   labels:
     {{- include "openshell.labels" . | nindent 4 }}
 rules:

--- a/deploy/helm/openshell/templates/clusterrolebinding.yaml
+++ b/deploy/helm/openshell/templates/clusterrolebinding.yaml
@@ -4,13 +4,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "openshell.fullname" . }}-node-reader
+  name: {{ include "openshell.fullname" . }}-node-reader-{{ .Release.Namespace }}
   labels:
     {{- include "openshell.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "openshell.fullname" . }}-node-reader
+  name: {{ include "openshell.fullname" . }}-node-reader-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "openshell.serviceAccountName" . }}

--- a/deploy/helm/openshell/tests/clusterrole_test.yaml
+++ b/deploy/helm/openshell/tests/clusterrole_test.yaml
@@ -9,6 +9,12 @@ release:
   namespace: my-namespace
 
 tests:
+  - it: includes the release namespace in the ClusterRole name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: openshell-node-reader-my-namespace
+
   - it: grants managed namespace NetworkPolicy apply permissions
     set:
       server.drivers.kubernetes.workspaceMode: managed

--- a/deploy/helm/openshell/tests/clusterrolebinding_test.yaml
+++ b/deploy/helm/openshell/tests/clusterrolebinding_test.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: ClusterRoleBinding RBAC
+templates:
+  - templates/clusterrolebinding.yaml
+release:
+  name: openshell
+  namespace: my-namespace
+
+tests:
+  - it: includes the release namespace in the ClusterRoleBinding name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: openshell-node-reader-my-namespace
+
+  - it: references the namespace-scoped ClusterRole in roleRef
+    asserts:
+      - equal:
+          path: roleRef.name
+          value: openshell-node-reader-my-namespace
+
+  - it: binds the service account in the release namespace
+    asserts:
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: openshell
+            namespace: my-namespace


### PR DESCRIPTION
## Summary

- Appends `.Release.Namespace` to the ClusterRole and ClusterRoleBinding `metadata.name` fields in `clusterrole.yaml` and `clusterrolebinding.yaml`
- Each Helm release now gets its own cluster-scoped resources (e.g. `openshell-gateway-node-reader-ns-a`, `openshell-gateway-node-reader-ns-b`), eliminating ownership annotation conflicts in multi-tenant deployments
- No new values or toggles -- the chart unconditionally creates the resources, just with unique names

## Motivation

The chart creates a `ClusterRole` and `ClusterRoleBinding` with a fixed name (`openshell-gateway-node-reader`). Helm tracks ownership via `meta.helm.sh/release-namespace` annotations. When two releases coexist on the same cluster (e.g. [HyperShell](https://github.com/openshift-online/hypershell) deploying multiple gateways), the second install fails:

```
ClusterRole "openshell-gateway-node-reader" exists and cannot be imported:
key "meta.helm.sh/release-namespace" must equal "ns-a": current value is "ns-b"
```

Scoping the names by namespace makes each release's cluster-scoped resources independent. The rules are identical and small, so the duplication is harmless.

## Test plan

- [ ] `helm template -n ns-a` renders `openshell-gateway-node-reader-ns-a` for both ClusterRole and ClusterRoleBinding
- [ ] `helm template -n ns-b` renders `openshell-gateway-node-reader-ns-b`
- [ ] Two releases on the same cluster install without conflict
- [ ] Existing single-release deployments: `helm upgrade` creates the new named resources; the old fixed-name resources can be cleaned up manually or left as orphans

🤖 Generated with [Claude Code](https://claude.com/claude-code)