### PR TITLE
ci(e2e): reuse prebuilt gateway and CLI artifacts

### DIFF
--- a/.github/actions/resolve-sha-artifacts/action.yml
+++ b/.github/actions/resolve-sha-artifacts/action.yml
@@ -1,0 +1,73 @@
+name: Resolve SHA Artifacts
+description: Download and verify a digest-pinned OpenShell SHA artifact bundle from GHCR.
+
+inputs:
+  manifest-ref:
+    description: "Digest-pinned OCI artifact manifest reference"
+    required: true
+  source-sha:
+    description: "Expected full source commit SHA"
+    required: true
+  token:
+    description: "Token with packages:read permission"
+    required: true
+  path:
+    description: "Directory into which the verified bundle is extracted"
+    required: false
+    default: .sha-artifacts
+
+outputs:
+  path:
+    description: "Directory containing the verified artifact files"
+    value: ${{ steps.resolve.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install ORAS
+      uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v2.0.1
+
+    - name: Download and verify SHA artifacts
+      id: resolve
+      shell: bash
+      env:
+        MANIFEST_REF: ${{ inputs.manifest-ref }}
+        EXPECTED_SOURCE_SHA: ${{ inputs.source-sha }}
+        GH_TOKEN: ${{ inputs.token }}
+        OUTPUT_PATH: ${{ inputs.path }}
+      run: |
+        set -euo pipefail
+        test "${#EXPECTED_SOURCE_SHA}" -eq 40
+        case "$MANIFEST_REF" in
+          ghcr.io/*@sha256:*) ;;
+          *)
+            echo "manifest-ref must be a digest-pinned GHCR reference" >&2
+            exit 1
+            ;;
+        esac
+        if [ -e "$OUTPUT_PATH" ]; then
+          echo "artifact output path already exists: $OUTPUT_PATH" >&2
+          exit 1
+        fi
+        mkdir -p "$OUTPUT_PATH"
+        echo "$GH_TOKEN" | oras login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+        oras pull "$MANIFEST_REF" -o "$OUTPUT_PATH"
+        manifest="$OUTPUT_PATH/sha-artifacts.json"
+        bundle="$OUTPUT_PATH/sha-artifacts.tar.gz"
+        test -f "$manifest"
+        test -f "$bundle"
+        actual_source_sha="$(jq -r '.source.sha' "$manifest")"
+        if [ "$actual_source_sha" != "$EXPECTED_SOURCE_SHA" ]; then
+          echo "artifact manifest source SHA does not match the expected commit" >&2
+          exit 1
+        fi
+        jq -e '.schema_version == 1 and (.artifacts | type == "array" and length > 0)' "$manifest" >/dev/null
+        mkdir "$OUTPUT_PATH/bundle"
+        tar -xzf "$bundle" --no-same-owner -C "$OUTPUT_PATH/bundle"
+        jq -e 'all(.artifacts[]; (.sha256 | test("^[0-9a-f]{64}$")) and (.path | test("^(?!/)(?!.*(^|/)\\.\\.(/|$)).+$")))' "$manifest" >/dev/null
+        jq -r '.artifacts[] | "\(.sha256)  \(.path)"' "$manifest" > "$OUTPUT_PATH/checksums.txt"
+        (
+          cd "$OUTPUT_PATH/bundle"
+          sha256sum -c ../checksums.txt
+        )
+        echo "path=$OUTPUT_PATH/bundle" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/branch-e2e.yml
+++ b/.github/workflows/branch-e2e.yml
@@ -140,7 +140,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -163,7 +162,7 @@ jobs:
         id: artifacts
         uses: ./.github/actions/resolve-sha-artifacts
         with:
-          manifest-ref: ${{ needs.publish-sha-artifacts.outputs.manifest_ref }}
+          manifest-ref: ${{ needs.publish-sha-artifacts.outputs.manifest-ref }}
           source-sha: ${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/branch-e2e.yml
+++ b/.github/workflows/branch-e2e.yml
@@ -157,11 +157,13 @@ jobs:
       contents: read
       packages: read
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Resolve published SHA artifacts
         id: artifacts
         uses: ./.github/actions/resolve-sha-artifacts
         with:
-          manifest-ref: ${{ needs.publish-sha-artifacts.outputs.manifest-ref }}
+          manifest-ref: ${{ needs.publish-sha-artifacts.outputs.manifest_ref }}
           source-sha: ${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/branch-e2e.yml
+++ b/.github/workflows/branch-e2e.yml
@@ -87,6 +87,17 @@ jobs:
       component: gateway
       image-tag: ${{ github.sha }}
 
+  build-gateway-external:
+    needs: [pr_metadata]
+    if: needs.pr_metadata.outputs.should_run == 'true' && needs.pr_metadata.outputs.run_core_e2e == 'true'
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      component: gateway-external
+      image-tag: ${{ github.sha }}
+
   build-supervisor:
     needs: [pr_metadata]
     if: needs.pr_metadata.outputs.should_run == 'true' && needs.pr_metadata.outputs.run_any_e2e == 'true'
@@ -124,7 +135,7 @@ jobs:
         [{"arch":"amd64","runner":"linux-amd64-cpu8","target":"x86_64-unknown-linux-gnu","zig_target":"x86_64-unknown-linux-gnu.2.28","platform":"linux-x86_64","guest_arch":"x86_64"}]
 
   e2e:
-    needs: [pr_metadata, build-gateway, build-supervisor, build-cli, build-driver-vm-linux]
+    needs: [pr_metadata, build-gateway, build-gateway-external, build-supervisor, build-cli, build-driver-vm-linux]
     if: needs.pr_metadata.outputs.should_run == 'true' && needs.pr_metadata.outputs.run_core_e2e == 'true'
     permissions:
       actions: read
@@ -136,6 +147,7 @@ jobs:
       runner: linux-arm64-cpu8
       cli-artifact-prefix: rust-binary-cli
       gateway-artifact-prefix: rust-binary-gateway
+      external-gateway-artifact-prefix: rust-binary-gateway-external
       vm-driver-artifact-name: driver-vm-linux-amd64
 
   gpu-e2e:

--- a/.github/workflows/branch-e2e.yml
+++ b/.github/workflows/branch-e2e.yml
@@ -147,6 +147,7 @@ jobs:
     with:
       source-sha: ${{ github.sha }}
       artifact-set: branch-e2e
+    secrets: inherit
 
   verify-sha-artifacts:
     needs: [pr_metadata, publish-sha-artifacts]

--- a/.github/workflows/branch-e2e.yml
+++ b/.github/workflows/branch-e2e.yml
@@ -149,6 +149,31 @@ jobs:
       source-sha: ${{ github.sha }}
       artifact-set: branch-e2e
 
+  verify-sha-artifacts:
+    needs: [pr_metadata, publish-sha-artifacts]
+    if: needs.pr_metadata.outputs.should_run == 'true' && needs.pr_metadata.outputs.run_core_e2e == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Resolve published SHA artifacts
+        id: artifacts
+        uses: ./.github/actions/resolve-sha-artifacts
+        with:
+          manifest-ref: ${{ needs.publish-sha-artifacts.outputs.manifest-ref }}
+          source-sha: ${{ github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify amd64 binaries execute
+        env:
+          ARTIFACTS_DIR: ${{ steps.artifacts.outputs.path }}
+        run: |
+          set -euo pipefail
+          "$ARTIFACTS_DIR/rust-binary-cli-linux-amd64/openshell" --version
+          "$ARTIFACTS_DIR/rust-binary-gateway-linux-amd64/openshell-gateway" --version
+          "$ARTIFACTS_DIR/rust-binary-gateway-external-linux-amd64/openshell-gateway" --version
+
   e2e:
     needs: [pr_metadata, build-gateway, build-gateway-external, build-supervisor, build-cli, build-driver-vm-linux]
     if: needs.pr_metadata.outputs.should_run == 'true' && needs.pr_metadata.outputs.run_core_e2e == 'true'

--- a/.github/workflows/branch-e2e.yml
+++ b/.github/workflows/branch-e2e.yml
@@ -92,7 +92,7 @@ jobs:
     if: needs.pr_metadata.outputs.should_run == 'true' && needs.pr_metadata.outputs.run_core_e2e == 'true'
     permissions:
       contents: read
-      packages: read
+      packages: write
     uses: ./.github/workflows/docker-build.yml
     with:
       component: gateway-external

--- a/.github/workflows/branch-e2e.yml
+++ b/.github/workflows/branch-e2e.yml
@@ -134,6 +134,21 @@ jobs:
       driver-targets: >-
         [{"arch":"amd64","runner":"linux-amd64-cpu8","target":"x86_64-unknown-linux-gnu","zig_target":"x86_64-unknown-linux-gnu.2.28","platform":"linux-x86_64","guest_arch":"x86_64"}]
 
+  publish-sha-artifacts:
+    needs: [pr_metadata, build-gateway, build-gateway-external, build-cli]
+    if: needs.pr_metadata.outputs.should_run == 'true' && needs.pr_metadata.outputs.run_core_e2e == 'true'
+    permissions:
+      actions: read
+      attestations: write
+      artifact-metadata: write
+      contents: read
+      id-token: write
+      packages: write
+    uses: ./.github/workflows/publish-sha-artifacts.yml
+    with:
+      source-sha: ${{ github.sha }}
+      artifact-set: branch-e2e
+
   e2e:
     needs: [pr_metadata, build-gateway, build-gateway-external, build-supervisor, build-cli, build-driver-vm-linux]
     if: needs.pr_metadata.outputs.should_run == 'true' && needs.pr_metadata.outputs.run_core_e2e == 'true'

--- a/.github/workflows/branch-e2e.yml
+++ b/.github/workflows/branch-e2e.yml
@@ -162,7 +162,7 @@ jobs:
         id: artifacts
         uses: ./.github/actions/resolve-sha-artifacts
         with:
-          manifest-ref: ${{ needs.publish-sha-artifacts.outputs.manifest-ref }}
+          manifest-ref: ${{ needs.publish-sha-artifacts.outputs.manifest_ref }}
           source-sha: ${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -191,6 +191,7 @@ jobs:
       image-tag: ${{ needs.resolve.outputs.image_tag_base }}
       checkout-ref: ${{ inputs['checkout-ref'] }}
       features: ${{ needs.resolve.outputs.features }}
+      no-default-features: ${{ needs.resolve.outputs.no_default_features == 'true' }}
       auditable: ${{ inputs.auditable }}
       artifact-name: ${{ needs.resolve.outputs.artifact_prefix }}-linux-${{ matrix.arch }}
     secrets: inherit

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -77,6 +77,7 @@ jobs:
       artifact_prefix: ${{ steps.resolve.outputs.artifact_prefix }}
       image_tag_base: ${{ steps.resolve.outputs.image_tag_base }}
       features: ${{ steps.resolve.outputs.features }}
+      no_default_features: ${{ steps.resolve.outputs.no_default_features }}
       has_image: ${{ steps.resolve.outputs.has_image }}
     steps:
       - name: Resolve component and platform matrix
@@ -91,6 +92,13 @@ jobs:
               binary_name=openshell-gateway
               features="bundled-z3"
               has_image=true
+              ;;
+            gateway-external)
+              binary_component=gateway
+              binary_name=openshell-gateway
+              features="telemetry"
+              no_default_features=true
+              has_image=false
               ;;
             supervisor)
               binary_component=sandbox
@@ -162,6 +170,7 @@ jobs:
             echo "artifact_prefix=rust-binary-${component}"
             echo "image_tag_base=$image_tag_base"
             echo "features=$features"
+            echo "no_default_features=${no_default_features:-false}"
             echo "has_image=$has_image"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: string
         default: ""
+      external-gateway-artifact-prefix:
+        description: "Prebuilt gateway artifact prefix for external-driver suites"
+        required: false
+        type: string
+        default: ""
       vm-driver-artifact-name:
         description: "Optional prebuilt VM driver artifact name"
         required: false
@@ -60,7 +65,7 @@ jobs:
             cmd: "mise run --no-deps --skip-deps e2e:rust"
             apt_packages: "openssh-client"
           - suite: rust-docker-external-driver
-            cmd: "env -u OPENSHELL_GATEWAY_BIN mise run --no-deps --skip-deps e2e:docker:external-driver"
+            cmd: "mise run --no-deps --skip-deps e2e:docker:external-driver"
             apt_packages: "openssh-client"
           - suite: mcp
             cmd: "mise run --no-deps --skip-deps e2e:mcp"
@@ -95,10 +100,16 @@ jobs:
           artifact-prefix: ${{ inputs.cli-artifact-prefix }}
 
       - name: Use prebuilt OpenShell gateway
-        if: inputs.gateway-artifact-prefix != ''
+        if: inputs.gateway-artifact-prefix != '' && matrix.suite != 'rust-docker-external-driver'
         uses: ./.github/actions/setup-e2e-gateway
         with:
           artifact-prefix: ${{ inputs.gateway-artifact-prefix }}
+
+      - name: Use prebuilt external-driver gateway
+        if: inputs.external-gateway-artifact-prefix != '' && matrix.suite == 'rust-docker-external-driver'
+        uses: ./.github/actions/setup-e2e-gateway
+        with:
+          artifact-prefix: ${{ inputs.external-gateway-artifact-prefix }}
 
       - name: Check out MCP conformance tests
         if: matrix.suite == 'mcp'
@@ -156,7 +167,7 @@ jobs:
             podman_major: "5"
             podman_package_version: "5.7.0+ds2-3build1"
             conmon_package_version: "2.1.13+ds1-2"
-            cmd: "env -u OPENSHELL_GATEWAY_BIN mise run --no-deps --skip-deps e2e:podman:external-driver"
+            cmd: "mise run --no-deps --skip-deps e2e:podman:external-driver"
           - suite: provider-refresh-keycloak
             runner: ubuntu-26.04
             podman_major: "5"
@@ -185,10 +196,16 @@ jobs:
           artifact-prefix: ${{ inputs.cli-artifact-prefix }}
 
       - name: Use prebuilt OpenShell gateway
-        if: inputs.gateway-artifact-prefix != ''
+        if: inputs.gateway-artifact-prefix != '' && matrix.suite != 'external-driver'
         uses: ./.github/actions/setup-e2e-gateway
         with:
           artifact-prefix: ${{ inputs.gateway-artifact-prefix }}
+
+      - name: Use prebuilt external-driver gateway
+        if: inputs.external-gateway-artifact-prefix != '' && matrix.suite == 'external-driver'
+        uses: ./.github/actions/setup-e2e-gateway
+        with:
+          artifact-prefix: ${{ inputs.external-gateway-artifact-prefix }}
 
       - name: Install mise
         run: |
@@ -325,7 +342,7 @@ jobs:
           - suite: managed
             cmd: "mise run --no-deps --skip-deps e2e:vm"
           - suite: external-driver
-            cmd: "env -u OPENSHELL_GATEWAY_BIN mise run --no-deps --skip-deps e2e:vm:external-driver"
+            cmd: "mise run --no-deps --skip-deps e2e:vm:external-driver"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -342,10 +359,16 @@ jobs:
           artifact-prefix: ${{ inputs.cli-artifact-prefix }}
 
       - name: Use prebuilt OpenShell gateway
-        if: inputs.gateway-artifact-prefix != ''
+        if: inputs.gateway-artifact-prefix != '' && matrix.suite != 'external-driver'
         uses: ./.github/actions/setup-e2e-gateway
         with:
           artifact-prefix: ${{ inputs.gateway-artifact-prefix }}
+
+      - name: Use prebuilt external-driver gateway
+        if: inputs.external-gateway-artifact-prefix != '' && matrix.suite == 'external-driver'
+        uses: ./.github/actions/setup-e2e-gateway
+        with:
+          artifact-prefix: ${{ inputs.external-gateway-artifact-prefix }}
 
       - name: Use prebuilt OpenShell VM driver
         if: inputs.vm-driver-artifact-name != ''

--- a/.github/workflows/publish-sha-artifacts.yml
+++ b/.github/workflows/publish-sha-artifacts.yml
@@ -17,7 +17,7 @@ on:
         type: string
         default: "rust-binary-*"
     outputs:
-      manifest-ref:
+      manifest_ref:
         description: "Digest-pinned OCI manifest reference"
         value: ${{ jobs.publish.outputs.manifest_ref }}
 

--- a/.github/workflows/publish-sha-artifacts.yml
+++ b/.github/workflows/publish-sha-artifacts.yml
@@ -1,0 +1,96 @@
+name: Publish SHA Artifacts
+
+on:
+  workflow_call:
+    inputs:
+      source-sha:
+        description: "Full source commit SHA represented by the artifacts"
+        required: true
+        type: string
+      artifact-set:
+        description: "Named build-profile variant for this artifact set"
+        required: true
+        type: string
+      artifact-pattern:
+        description: "GitHub Actions artifact pattern to publish"
+        required: false
+        type: string
+        default: "rust-binary-*"
+    outputs:
+      manifest-ref:
+        description: "Digest-pinned OCI manifest reference"
+        value: ${{ jobs.publish.outputs.manifest_ref }}
+
+permissions:
+  actions: read
+  attestations: write
+  artifact-metadata: write
+  contents: read
+  id-token: write
+  packages: write
+
+jobs:
+  publish:
+    name: Publish SHA artifact manifest
+    runs-on: linux-amd64-cpu8
+    timeout-minutes: 15
+    outputs:
+      manifest_ref: ${{ steps.publish.outputs.manifest_ref }}
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: ${{ inputs.artifact-pattern }}
+          path: artifacts
+
+      - name: Install ORAS
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v2.0.1
+
+      - name: Assemble deterministic artifact bundle
+        env:
+          SOURCE_SHA: ${{ inputs.source-sha }}
+          ARTIFACT_SET: ${{ inputs.artifact-set }}
+        run: |
+          set -euo pipefail
+          test "${#SOURCE_SHA}" -eq 40
+          mkdir -p bundle
+          cp -a artifacts/. bundle/
+          find bundle -type f -print0 | sort -z | xargs -0 sha256sum > artifact-checksums.txt
+          jq -n \
+            --arg schema_version "1" \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg artifact_set "$ARTIFACT_SET" \
+            --argjson artifacts "$(jq -R -s -c 'split("\n") | map(select(length > 0) | capture("^(?<sha256>[0-9a-f]{64})  (?<path>.+)$"))' artifact-checksums.txt)" \
+            '{schema_version: ($schema_version | tonumber), source: {repository: env.GITHUB_REPOSITORY, sha: $source_sha}, artifact_set: $artifact_set, artifacts: $artifacts}' \
+            > sha-artifacts.json
+          tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner -C bundle -cf - . | gzip -n > sha-artifacts.tar.gz
+
+      - name: Publish immutable OCI artifact
+        id: publish
+        env:
+          SOURCE_SHA: ${{ inputs.source-sha }}
+          ARTIFACT_SET: ${{ inputs.artifact-set }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          repository="ghcr.io/${GITHUB_REPOSITORY,,}/ci-artifacts"
+          tag="sha-${SOURCE_SHA}-${ARTIFACT_SET}"
+          ref="${repository}:${tag}"
+          echo "$GH_TOKEN" | oras login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+          if oras manifest fetch --descriptor "$ref" >/dev/null 2>&1; then
+            echo "refusing to overwrite existing SHA artifact manifest: $ref" >&2
+            exit 1
+          fi
+          digest="$(oras push --format json \
+            --artifact-type application/vnd.nvidia.openshell.sha-artifacts.v1 \
+            --annotation "org.opencontainers.image.revision=${SOURCE_SHA}" \
+            --annotation "io.openshell.artifact-set=${ARTIFACT_SET}" \
+            "$ref" \
+            sha-artifacts.json:application/vnd.nvidia.openshell.sha-artifacts.manifest.v1+json \
+            sha-artifacts.tar.gz:application/vnd.nvidia.openshell.sha-artifacts.bundle.v1+gzip | jq -r '.digest')"
+          echo "manifest_ref=${repository}@${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Attest SHA artifact manifest
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-path: sha-artifacts.json

--- a/.github/workflows/publish-sha-artifacts.yml
+++ b/.github/workflows/publish-sha-artifacts.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   publish:
     name: Publish SHA artifact manifest
-    runs-on: linux-amd64-cpu8
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
       manifest_ref: ${{ steps.publish.outputs.manifest_ref }}

--- a/.github/workflows/publish-sha-artifacts.yml
+++ b/.github/workflows/publish-sha-artifacts.yml
@@ -17,14 +17,13 @@ on:
         type: string
         default: "rust-binary-*"
     outputs:
-      manifest_ref:
+      manifest-ref:
         description: "Digest-pinned OCI manifest reference"
         value: ${{ jobs.publish.outputs.manifest_ref }}
 
 permissions:
   actions: read
   attestations: write
-  artifact-metadata: write
   contents: read
   id-token: write
   packages: write

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -69,8 +69,25 @@ jobs:
       cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
       auditable: true
 
+  build-cli:
+    needs: [compute-versions]
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      component: cli
+      cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
+      auditable: true
+      platform: linux/amd64,linux/arm64
+
+  build-gateway-external:
+    needs: [compute-versions]
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      component: gateway-external
+      cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
+      auditable: true
+
   e2e:
-    needs: [build-gateway, build-supervisor]
+    needs: [build-gateway, build-supervisor, build-cli, build-gateway-external]
     permissions:
       actions: read
       contents: read
@@ -79,6 +96,9 @@ jobs:
     with:
       image-tag: ${{ github.sha }}
       runner: linux-arm64-cpu8
+      cli-artifact-prefix: rust-binary-cli
+      gateway-artifact-prefix: rust-binary-gateway
+      external-gateway-artifact-prefix: rust-binary-gateway-external
 
   tag-ghcr-dev:
     name: Tag GHCR Images as Dev

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -93,8 +93,29 @@ jobs:
       checkout-ref: ${{ inputs.tag || github.ref }}
       auditable: true
 
+  build-cli:
+    needs: [compute-versions]
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      component: cli
+      cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
+      image-tag: ${{ needs.compute-versions.outputs.source_sha }}
+      checkout-ref: ${{ inputs.tag || github.ref }}
+      auditable: true
+      platform: linux/amd64,linux/arm64
+
+  build-gateway-external:
+    needs: [compute-versions]
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      component: gateway-external
+      cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
+      image-tag: ${{ needs.compute-versions.outputs.source_sha }}
+      checkout-ref: ${{ inputs.tag || github.ref }}
+      auditable: true
+
   e2e:
-    needs: [compute-versions, build-gateway, build-supervisor]
+    needs: [compute-versions, build-gateway, build-supervisor, build-cli, build-gateway-external]
     permissions:
       actions: read
       contents: read
@@ -104,6 +125,9 @@ jobs:
       image-tag: ${{ needs.compute-versions.outputs.source_sha }}
       checkout-ref: ${{ inputs.tag || github.ref }}
       runner: linux-arm64-cpu8
+      cli-artifact-prefix: rust-binary-cli
+      gateway-artifact-prefix: rust-binary-gateway
+      external-gateway-artifact-prefix: rust-binary-gateway-external
 
   tag-ghcr-release:
     name: Tag GHCR Images for Release

--- a/.github/workflows/rust-native-build.yml
+++ b/.github/workflows/rust-native-build.yml
@@ -40,6 +40,11 @@ on:
         required: false
         type: string
         default: ""
+      no-default-features:
+        description: "Build without Cargo default features"
+        required: false
+        type: boolean
+        default: false
       auditable:
         description: "Embed cargo-auditable dependency metadata in the binary"
         required: false
@@ -299,6 +304,9 @@ jobs:
           )
           if [[ -n "$FEATURES" ]]; then
             args+=(--features "$FEATURES")
+          fi
+          if [[ "${{ inputs['no-default-features'] }}" == "true" ]]; then
+            args+=(--no-default-features)
           fi
           if [[ -n "${{ steps.version.outputs.cargo_version }}" ]]; then
             export GIT_DIR=/nonexistent

--- a/e2e/rust/e2e-podman.sh
+++ b/e2e/rust/e2e-podman.sh
@@ -22,7 +22,11 @@ if [ -z "${E2E_TEST}" ] || [ "${E2E_TEST}" = "provider_token_exchange" ]; then
   export OPENSHELL_E2E_SPIFFE_FIXTURE="${OPENSHELL_E2E_SPIFFE_FIXTURE:-1}"
 fi
 
-cargo build -p openshell-cli
+if [ -z "${OPENSHELL_BIN:-}" ]; then
+  cargo build -p openshell-cli
+else
+  echo "Using prebuilt openshell CLI at ${OPENSHELL_BIN}"
+fi
 
 TEST_ARGS=(
   cargo test --manifest-path "${ROOT}/e2e/rust/Cargo.toml"


### PR DESCRIPTION
## Summary

Reuse the workflow-built gateway and CLI artifacts in merge-queue and release E2E jobs. This removes the remaining Podman CLI rebuild, including the rootless lane.

## Related Issue

Relates to #2946.

## Changes

- Build an external-driver gateway variant with the required feature set.
- Pass prebuilt CLI and gateway artifacts into Release Dev and Release Tag E2E jobs.
- Make Podman E2E honor `OPENSHELL_BIN`, including rootless execution.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated (CI workflow change only)
- [ ] E2E tests added/updated (will be exercised by this PR)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable: CI-only implementation slice)