### PR TITLE
ci(stale): increase stale workflow processing budget

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,21 +9,22 @@ permissions:
   contents: read
 
 jobs:
-  stale:
+  stale-issues:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           stale-issue-label: state:stale
-          stale-pr-label: state:stale
 
           days-before-issue-stale: 14
           days-before-issue-close: -1 # -1 puts this into dry-run mode. Update to 7 to enable closing.
-          days-before-pr-stale: 14
-          days-before-pr-close: -1 # -1 puts this into dry-run mode. Update to 7 to enable closing.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          operations-per-run: 300
+          sort-by: updated
 
           exempt-issue-labels: state:triage-needed,state:validated,state:accepted,agent:plan-requested,agent:plan-ready,agent:implementation-requested,agent:in-progress,agent:pr-opened,roadmap
           close-issue-reason: not_planned
@@ -35,6 +36,24 @@ jobs:
           close-issue-message: >
             Closing this issue after 7 days with no activity since it was marked stale.
             Reopen it if the work is still relevant.
+  stale-pull-requests:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
+        with:
+          stale-pr-label: state:stale
+
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 14
+          days-before-pr-close: -1 # -1 puts this into dry-run mode. Update to 7 to enable closing.
+
+          operations-per-run: 300
+          sort-by: updated
+
           stale-pr-message: >
             This pull request has had no activity for 14 days and is now marked stale.
             It may be closed in 7 days if there is no further activity.


### PR DESCRIPTION
## Summary

Increase the stale workflow processing budget and split stale handling into separate issue and pull-request jobs. This keeps issue cleanup from competing with PR cleanup and gives the action enough operations to remove `state:stale` after human activity.

## Related Issue

No issue required: localized CI workflow maintenance from triage-duty recommendation R-05.

## Changes

- Split the stale workflow into `stale-issues` and `stale-pull-requests` jobs.
- Set `operations-per-run: 300` for each job.
- Sort stale processing by `updated` so recently active stale items are handled early.

## Testing

- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

Could not run `mise run pre-commit` locally because `mise` is not available on PATH in this Codex environment. Ran `git diff --check -- .github/workflows/stale.yml` and Ruby YAML parsing successfully.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
