### PR TITLE
fix(cli): print each provisioning step once in plain output

### DIFF
--- a/crates/openshell-cli/src/commands/common.rs
+++ b/crates/openshell-cli/src/commands/common.rs
@@ -444,9 +444,49 @@ pub fn noninteractive_active_label(step: ProvisioningStep) -> String {
     step.active_label().trim_end_matches('.').to_string()
 }
 
+/// Completed-step bookkeeping for plain (non-interactive) progress output.
+///
+/// [`ProvisioningDisplay`] holds this state internally, so an interactive
+/// terminal renders one line per step no matter how many times the gateway
+/// repeats a completion event. Plain output has no display to hold it, so it
+/// lives here and keeps both modes reporting the same step list.
+#[derive(Debug, Default)]
+pub struct PlainProgress {
+    /// Steps already reported, in order.
+    completed_steps: Vec<ProvisioningStep>,
+}
+
+impl PlainProgress {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Line to print for a completed step, or `None` when the step was already
+    /// reported and this event is a repeat.
+    pub fn complete_step(
+        &mut self,
+        step: ProvisioningStep,
+        label: &str,
+        elapsed: Duration,
+    ) -> Option<String> {
+        if self.completed_steps.contains(&step) {
+            return None;
+        }
+        self.completed_steps.push(step);
+        let ts = format_timestamp(elapsed);
+        Some(format!("{} {}", ts.dimmed(), label))
+    }
+}
+
+/// Where a provisioning progress event is rendered.
+pub enum ProgressTarget<'a> {
+    Interactive(&'a mut ProvisioningDisplay),
+    Plain(&'a mut PlainProgress),
+}
+
 pub fn handle_platform_progress_event(
     event: &PlatformEvent,
-    mut display: Option<&mut ProvisioningDisplay>,
+    mut target: ProgressTarget<'_>,
     provision_start: Instant,
 ) -> bool {
     let completed_step = event
@@ -472,34 +512,39 @@ pub fn handle_platform_progress_event(
             .metadata
             .get(PROGRESS_COMPLETE_LABEL_KEY)
             .map_or_else(|| step.completed_label(), String::as_str);
-        if let Some(d) = display.as_deref_mut() {
-            d.complete_step_with_label(step, label);
-        } else {
-            let ts = format_timestamp(provision_start.elapsed());
-            println!("{} {}", ts.dimmed(), label);
+        match &mut target {
+            ProgressTarget::Interactive(d) => d.complete_step_with_label(step, label),
+            ProgressTarget::Plain(p) => {
+                // The gateway repeats the completion event while a step is slow
+                // (notably an uncached image pull), so print the first one only.
+                if let Some(line) = p.complete_step(step, label, provision_start.elapsed()) {
+                    println!("{line}");
+                }
+            }
         }
     }
 
     if let Some(step) = active_step
-        && let Some(d) = display.as_deref_mut()
+        && let ProgressTarget::Interactive(d) = &mut target
     {
         d.set_active_step(step);
     }
 
     if let Some(detail) = active_detail {
-        if let Some(d) = display {
-            d.set_active_detail(detail);
-        } else {
-            let ts = format_timestamp(provision_start.elapsed());
-            if let Some(step) = active_step {
-                println!(
-                    "{} {} {}",
-                    ts.dimmed(),
-                    noninteractive_active_label(step),
-                    detail
-                );
-            } else {
-                println!("{} {}", ts.dimmed(), detail);
+        match &mut target {
+            ProgressTarget::Interactive(d) => d.set_active_detail(detail),
+            ProgressTarget::Plain(_) => {
+                let ts = format_timestamp(provision_start.elapsed());
+                if let Some(step) = active_step {
+                    println!(
+                        "{} {} {}",
+                        ts.dimmed(),
+                        noninteractive_active_label(step),
+                        detail
+                    );
+                } else {
+                    println!("{} {}", ts.dimmed(), detail);
+                }
             }
         }
     }
@@ -1072,31 +1117,32 @@ mod tests {
         assert!(err.to_string().contains("invalid duration"));
     }
 
-    #[test]
-    fn platform_progress_events_update_borrowed_display_without_duplicate_steps() {
-        let event = PlatformEvent {
+    fn completion_event(step: &str) -> PlatformEvent {
+        PlatformEvent {
             metadata: HashMap::from([
-                (
-                    PROGRESS_COMPLETE_STEP_KEY.to_string(),
-                    PROGRESS_STEP_REQUESTING_SANDBOX.to_string(),
-                ),
+                (PROGRESS_COMPLETE_STEP_KEY.to_string(), step.to_string()),
                 (
                     PROGRESS_ACTIVE_STEP_KEY.to_string(),
                     PROGRESS_STEP_STARTING_SANDBOX.to_string(),
                 ),
             ]),
             ..PlatformEvent::default()
-        };
+        }
+    }
+
+    #[test]
+    fn platform_progress_events_update_borrowed_display_without_duplicate_steps() {
+        let event = completion_event(PROGRESS_STEP_REQUESTING_SANDBOX);
         let mut display = ProvisioningDisplay::new();
 
         assert!(handle_platform_progress_event(
             &event,
-            Some(&mut display),
+            ProgressTarget::Interactive(&mut display),
             Instant::now(),
         ));
         assert!(handle_platform_progress_event(
             &event,
-            Some(&mut display),
+            ProgressTarget::Interactive(&mut display),
             Instant::now(),
         ));
 
@@ -1110,6 +1156,93 @@ mod tests {
             ProvisioningStep::StartingSandbox.active_label()
         );
         display.clear();
+    }
+
+    #[test]
+    fn plain_progress_reports_a_completed_step_once() {
+        let mut plain = PlainProgress::new();
+
+        let first = plain
+            .complete_step(
+                ProvisioningStep::RequestingSandbox,
+                "Sandbox allocated",
+                Duration::from_secs(0),
+            )
+            .expect("first completion should print");
+        assert!(first.contains("Sandbox allocated"));
+
+        // The gateway repeats the same completion event while the step is slow.
+        for _ in 0..5 {
+            assert!(
+                plain
+                    .complete_step(
+                        ProvisioningStep::RequestingSandbox,
+                        "Sandbox allocated",
+                        Duration::from_secs(30),
+                    )
+                    .is_none(),
+                "repeat completion events must not print again"
+            );
+        }
+
+        assert_eq!(
+            plain.completed_steps,
+            vec![ProvisioningStep::RequestingSandbox]
+        );
+    }
+
+    #[test]
+    fn plain_progress_still_reports_each_distinct_step() {
+        let mut plain = PlainProgress::new();
+
+        for step in [
+            ProvisioningStep::RequestingSandbox,
+            ProvisioningStep::PullingSandboxImage,
+            ProvisioningStep::StartingSandbox,
+        ] {
+            let line = plain
+                .complete_step(step, step.completed_label(), Duration::from_secs(1))
+                .expect("each distinct step should print once");
+            assert!(line.contains(step.completed_label()));
+        }
+
+        assert_eq!(
+            plain.completed_steps,
+            vec![
+                ProvisioningStep::RequestingSandbox,
+                ProvisioningStep::PullingSandboxImage,
+                ProvisioningStep::StartingSandbox,
+            ]
+        );
+    }
+
+    #[test]
+    fn platform_progress_events_deduplicate_completed_steps_in_plain_output() {
+        let allocated = completion_event(PROGRESS_STEP_REQUESTING_SANDBOX);
+        let started = completion_event(PROGRESS_STEP_STARTING_SANDBOX);
+        let mut plain = PlainProgress::new();
+
+        // Ten polls while the image pulls, all carrying the same completed step.
+        for _ in 0..10 {
+            assert!(handle_platform_progress_event(
+                &allocated,
+                ProgressTarget::Plain(&mut plain),
+                Instant::now(),
+            ));
+        }
+        assert!(handle_platform_progress_event(
+            &started,
+            ProgressTarget::Plain(&mut plain),
+            Instant::now(),
+        ));
+
+        assert_eq!(
+            plain.completed_steps,
+            vec![
+                ProvisioningStep::RequestingSandbox,
+                ProvisioningStep::StartingSandbox,
+            ]
+        );
     }
 
     // helper for building input

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -3,19 +3,19 @@
 
 //! CLI command implementations.
 
+use crate::commands::common::{
+    PlainProgress, ProgressTarget, ProvisioningDisplay, ProvisioningStep,
+    confirm_global_setting_delete, confirm_global_setting_takeover, format_epoch_ms,
+    format_optional_epoch_ms, format_setting_value, format_timestamp, format_timestamp_ms,
+    handle_platform_progress_event, is_provisioning_progress_event, non_empty_or,
+    parse_cli_setting_value, parse_credential_expiry_pairs, parse_credential_pairs,
+    parse_duration_to_ms, phase_name, print_policy_merge_warnings, print_sandbox_header,
+    print_sandbox_policy, provisioning_timeout_message, ready_false_condition_message,
+    scrub_git_env, short_hash, truncate_display, truncate_status_field,
+};
 pub use crate::commands::common::{
     PolicyGetView, parse_credential_expiry_cli_value, parse_env_pairs, parse_key_value_pairs,
     parse_secret_material_env_pairs, warn_credential_env_vars,
-};
-use crate::commands::common::{
-    ProvisioningDisplay, ProvisioningStep, confirm_global_setting_delete,
-    confirm_global_setting_takeover, format_epoch_ms, format_optional_epoch_ms,
-    format_setting_value, format_timestamp, format_timestamp_ms, handle_platform_progress_event,
-    is_provisioning_progress_event, non_empty_or, parse_cli_setting_value,
-    parse_credential_expiry_pairs, parse_credential_pairs, parse_duration_to_ms, phase_name,
-    print_policy_merge_warnings, print_sandbox_header, print_sandbox_policy,
-    provisioning_timeout_message, ready_false_condition_message, scrub_git_env, short_hash,
-    truncate_display, truncate_status_field,
 };
 pub use crate::commands::gateway::{
     gateway_add, gateway_info, gateway_info_not_configured, gateway_list, gateway_login,
@@ -95,7 +95,7 @@ enum SandboxUploadPlan {
 
 enum ProgressOutput {
     Interactive(ProvisioningDisplay),
-    Plain,
+    Plain(PlainProgress),
     Silent,
 }
 
@@ -115,7 +115,7 @@ impl ProgressOutput {
     }
 
     fn is_plain(&self) -> bool {
-        matches!(self, Self::Plain)
+        matches!(self, Self::Plain(_))
     }
 }
 
@@ -623,7 +623,7 @@ pub async fn sandbox_create(
     } else if interactive {
         ProgressOutput::Interactive(ProvisioningDisplay::new())
     } else {
-        ProgressOutput::Plain
+        ProgressOutput::Plain(PlainProgress::new())
     };
 
     if structured_output {
@@ -637,7 +637,7 @@ pub async fn sandbox_create(
             ProgressOutput::Interactive(d) => {
                 d.set_active_step(ProvisioningStep::RequestingSandbox);
             }
-            ProgressOutput::Plain => {
+            ProgressOutput::Plain(_) => {
                 let ts = format_timestamp(Duration::ZERO);
                 println!("  {} Requesting compute...", ts.dimmed());
             }
@@ -784,12 +784,16 @@ pub async fn sandbox_create(
                 // Silent mode suppresses all progress output; only update
                 // the deadline when applicable.
                 let handled = match &mut display {
-                    ProgressOutput::Interactive(d) => {
-                        handle_platform_progress_event(&ev, Some(d), provision_start)
-                    }
-                    ProgressOutput::Plain => {
-                        handle_platform_progress_event(&ev, None, provision_start)
-                    }
+                    ProgressOutput::Interactive(d) => handle_platform_progress_event(
+                        &ev,
+                        ProgressTarget::Interactive(d),
+                        provision_start,
+                    ),
+                    ProgressOutput::Plain(p) => handle_platform_progress_event(
+                        &ev,
+                        ProgressTarget::Plain(p),
+                        provision_start,
+                    ),
                     ProgressOutput::Silent => false,
                 };
                 if handled {
@@ -813,7 +817,7 @@ pub async fn sandbox_create(
                     ProgressOutput::Interactive(d) => {
                         d.println(&format!("  {} {}", "!".yellow().bold(), w.message.yellow()));
                     }
-                    ProgressOutput::Plain | ProgressOutput::Silent => {
+                    ProgressOutput::Plain(_) | ProgressOutput::Silent => {
                         let ts = format_timestamp(provision_start.elapsed());
                         eprintln!("  {} {} {}", ts.dimmed(), "WARN".yellow(), w.message);
                     }


### PR DESCRIPTION
## Summary

`openshell sandbox create` printed a new `Sandbox allocated` line for every gateway poll while a provisioning step was slow, flooding non-interactive output with dozens of identical lines during an uncached image pull. Plain output now reports each provisioning step once, matching what the interactive display has always done.

## Related Issue

Fixes #2674

## Changes

The two render modes had diverged. Interactive output goes through `ProvisioningDisplay`, whose `complete_step_with_label` checks `completed_steps.contains(&step)` and ignores repeats. Plain output was selected by passing `None` for the display, and that branch called `println!` unconditionally for every completion event — there was nowhere to keep the equivalent state.

- Add `PlainProgress` in `crates/openshell-cli/src/commands/common.rs`, holding the completed-step list for plain output. `complete_step` returns the line to print the first time a step completes and `None` for a repeat, so both the dedup decision and the line formatting are pure and directly testable.
- Replace `handle_platform_progress_event`'s `Option<&mut ProvisioningDisplay>` parameter with a `ProgressTarget` enum (`Interactive` / `Plain`). Encoding "plain" as the absence of a display is what left that mode with no place to store state; now each mode carries its own.
- Carry the state on `ProgressOutput::Plain(PlainProgress)` in `sandbox_create`.

Active-step **detail** lines are deliberately unchanged. They carry per-poll progress information (image name, layer progress), so collapsing them would drop real output. Only the completion events were duplicated, which matches the reported symptom and the triage finding.

Deduplication is per step rather than per consecutive event, which is exactly the interactive rule — the point is that both modes emit the same step list from the same event stream.

## Testing

- [x] `mise run pre-commit` passes — run as its underlying checks, see the environment note below
- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable) — no e2e change; this is CLI-local rendering with no gateway or sandbox behavior change

Three tests in `crates/openshell-cli/src/commands/common.rs`:

- `plain_progress_reports_a_completed_step_once` — one line for the first completion, `None` for five repeats.
- `plain_progress_still_reports_each_distinct_step` — all three distinct steps still print, so the guard does not over-collapse.
- `platform_progress_events_deduplicate_completed_steps_in_plain_output` — drives `handle_platform_progress_event` with ten identical `RequestingSandbox` completion events followed by `StartingSandbox`, and asserts the reported steps are `[RequestingSandbox, StartingSandbox]`.

The existing interactive test was updated for the new parameter type and still asserts the interactive path dedups.

I confirmed these are real regression tests rather than tests that merely pass: removing the `completed_steps.contains` guard makes two of them fail, and `--nocapture` shows the failing run emitting the exact reported symptom (ten consecutive `Sandbox allocated` lines) against one line when the guard is present.

Verification run:

```shell
cargo test -p openshell-cli                                  # 43 + 7 passed, 0 failed
cargo clippy -p openshell-cli --all-targets -- -D warnings   # clean
cargo fmt --all -- --check                                   # clean
python scripts/update_license_headers.py --check             # 862 files, all headers present
```

**Environment note:** I developed this on Windows (x86_64-pc-windows-msvc, Rust 1.95.0) without `mise`, so I ran the individual checks that `mise run pre-commit` composes rather than the task itself. One pre-existing, unrelated failure surfaces in a full-workspace clippy run on this platform: `clippy::unused_async` on the `#[cfg(not(unix))]` `connect_unix` stub in `crates/openshell-extension-core/src/transport.rs:185`, whose `#[cfg(unix)]` counterpart does await. It is untouched by this PR and should not appear on CI's Linux runners; I left it alone rather than widening this branch's scope. The clippy run above excludes only that lint.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — not applicable; no doc under `docs/` or `architecture/` describes the provisioning progress lines, and this restores the already-intended output rather than changing a documented behavior
