### PR TITLE
fix(server): suppress expected session errors on shutdown

### DIFF
--- a/crates/openshell-server/src/lib.rs
+++ b/crates/openshell-server/src/lib.rs
@@ -62,7 +62,10 @@ use std::net::SocketAddr;
 use std::path::Path;
 #[cfg(test)]
 use std::sync::LazyLock;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
@@ -295,6 +298,10 @@ pub struct ServerState {
     /// query session state to surface supervisor readiness.
     pub supervisor_sessions: Arc<supervisor_session::SupervisorSessionRegistry>,
 
+    /// Set once graceful gateway shutdown begins so stream handlers can
+    /// distinguish expected transport closes from runtime failures.
+    pub(crate) gateway_shutting_down: AtomicBool,
+
     /// Validated built-in and operator-registered supervisor middleware.
     pub middleware_registry: Arc<MiddlewareRegistry>,
 
@@ -411,6 +418,7 @@ impl ServerState {
             ssh_connections_by_sandbox: Mutex::new(HashMap::new()),
             settings_mutex: tokio::sync::Mutex::new(()),
             supervisor_sessions,
+            gateway_shutting_down: AtomicBool::new(false),
             extension_mint_limiter: auth::extension_mint_limit::ExtensionMintLimiter::default(),
             middleware_registry: Arc::new(MiddlewareRegistry::default()),
             oidc_cache,
@@ -807,6 +815,7 @@ pub(crate) async fn run_server(
 
     shutdown_signal().await;
     info!("Shutdown signal received; stopping gateway");
+    state.gateway_shutting_down.store(true, Ordering::Release);
     let _ = shutdown_tx.send(true);
 
     for task in listener_tasks {

--- a/crates/openshell-server/src/supervisor_session.rs
+++ b/crates/openshell-server/src/supervisor_session.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 use std::pin::Pin;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -666,9 +667,23 @@ async fn expected_transport_close_during_session_teardown(
     let session_no_longer_current = !state
         .supervisor_sessions
         .is_current_session(sandbox_id, session_id);
+    expected_transport_close_during_session_state(
+        status,
+        state.gateway_shutting_down.load(Ordering::Acquire),
+        session_no_longer_current,
+        sandbox_is_terminating_or_gone(state, sandbox_id).await,
+    )
+}
+
+fn expected_transport_close_during_session_state(
+    status: &Status,
+    gateway_shutting_down: bool,
+    session_no_longer_current: bool,
+    sandbox_terminating_or_gone: bool,
+) -> bool {
     expected_transport_close_during_shutdown(
         status,
-        session_no_longer_current || sandbox_is_terminating_or_gone(state, sandbox_id).await,
+        gateway_shutting_down || session_no_longer_current || sandbox_terminating_or_gone,
     )
 }
 
@@ -1445,6 +1460,16 @@ mod tests {
         let status = Status::internal("policy evaluation failed");
 
         assert!(!expected_transport_close_during_shutdown(&status, true));
+    }
+
+    #[test]
+    fn gateway_shutdown_makes_session_transport_close_nonfatal() {
+        let status =
+            Status::unknown("h2 protocol error: error reading a body from connection: broken pipe");
+
+        assert!(expected_transport_close_during_session_state(
+            &status, true, false, false,
+        ));
     }
 
     #[test]


### PR DESCRIPTION
I found this while running a local dev gateway, though I imagine it would show up elsewhere.

## Summary
<!-- 1-3 sentences: what this PR does and why -->
Ctrl-C closes gateway listeners while supervisor sessions are still current, causing benign HTTP/2 broken pipes to be logged as warnings. Track gateway shutdown so recognized transport closes are treated as expected.

## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
