### PR TITLE
test(network): avoid DNS socket bind race

### DIFF
--- a/crates/openshell-supervisor-network/src/policy_dns/resolver.rs
+++ b/crates/openshell-supervisor-network/src/policy_dns/resolver.rs
@@ -315,6 +315,23 @@ mod tests {
     use openshell_core::net::set_tcp_nodelay_best_effort;
     use tokio::net::TcpListener;
 
+    async fn bind_dns_test_server() -> (UdpSocket, TcpListener, SocketAddr) {
+        const MAX_BIND_ATTEMPTS: usize = 100;
+
+        for _ in 0..MAX_BIND_ATTEMPTS {
+            // Port zero only guarantees availability for the protocol being bound.
+            let tcp = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let server = tcp.local_addr().unwrap();
+            match UdpSocket::bind(server).await {
+                Ok(udp) => return (udp, tcp, server),
+                Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {}
+                Err(error) => panic!("failed to bind DNS test UDP socket: {error}"),
+            }
+        }
+
+        panic!("failed to bind DNS test TCP and UDP sockets to the same port");
+    }
+
     #[test]
     fn resolver_address_deduplication_preserves_answer_order() {
         let mut addresses = vec![
@@ -383,9 +400,7 @@ mod tests {
 
     #[tokio::test]
     async fn truncated_udp_retries_over_tcp_and_follows_cname() {
-        let udp = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-        let server = udp.local_addr().unwrap();
-        let tcp = TcpListener::bind(server).await.unwrap();
+        let (udp, tcp, server) = bind_dns_test_server().await;
 
         let udp_task = tokio::spawn(async move {
             let mut wire = [0_u8; MAX_DNS_MESSAGE_BYTES];


### PR DESCRIPTION

## Summary
<!-- 1-3 sentences: what this PR does and why -->
This changes the DNS resolver test fixture to retry until TCP and UDP can share an ephemeral port.

It fixes an issue seen in CI where a port that was successfully assigned for one protocol failed for the other:

```
────────────
     Summary [  43.398s] 5752 tests run: 5751 passed, 1 failed, 25 skipped
        FAIL [   0.007s] (4878/5752) openshell-supervisor-network policy_dns::resolver::tests::truncated_udp_retries_over_tcp_and_follows_cname
  stdout ───

    running 1 test
    test policy_dns::resolver::tests::truncated_udp_retries_over_tcp_and_follows_cname ... FAILED

    failures:

    failures:
        policy_dns::resolver::tests::truncated_udp_retries_over_tcp_and_follows_cname

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1265 filtered out; finished in 0.00s
    
  stderr ───

    thread 'policy_dns::resolver::tests::truncated_udp_retries_over_tcp_and_follows_cname' (29853) panicked at crates/openshell-supervisor-network/src/policy_dns/resolver.rs:388:51:
    called `Result::unwrap()` on an `Err` value: Os { code: 98, kind: AddrInUse, message: "Address already in use" }
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
