### PR TITLE
fix(gateway): batch SSH session cleanup writes

### DIFF
--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -191,6 +191,9 @@ backend is already absent (`deleted = false`), the request removes gateway state
 synchronously. Sandbox row removal remains bound to the stable ID and resource
 version. Settings retain their existing best-effort name-based cleanup; SSH
 sessions, indexes, and watch/log buses are cleaned after confirmed removal.
+Owned-record cleanup discovers records before mutating them and uses bounded
+set-based deletes so teardown cannot amplify one sandbox into an unbounded
+sequence of individual persistence writes.
 
 The request acquires both locks before starting owned work, so cancellation
 while queued does not leave a delete armed. After that commitment point, the

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -20,8 +20,8 @@ pub use vm::VmComputeConfig;
 use crate::grpc::policy::SANDBOX_SETTINGS_OBJECT_TYPE;
 use crate::otel_tracing::TraceContextInterceptor;
 use crate::persistence::{
-    DRAFT_CHUNK_OBJECT_TYPE, ObjectId, ObjectName, ObjectRecord, ObjectType, POLICY_OBJECT_TYPE,
-    Store, WriteCondition,
+    DRAFT_CHUNK_OBJECT_TYPE, ObjectCursor, ObjectId, ObjectName, ObjectRecord, ObjectType,
+    POLICY_OBJECT_TYPE, Store, WriteCondition,
 };
 use crate::sandbox_index::SandboxIndex;
 use crate::sandbox_watch::SandboxWatchBus;
@@ -3085,7 +3085,7 @@ impl ComputeRuntime {
         workspace: &str,
     ) -> Result<(), String> {
         let started = Instant::now();
-        let mut offset = 0_u32;
+        let mut cursor = None;
         let mut scanned = 0_usize;
         let mut decode_failures = 0_usize;
         let mut session_ids = Vec::new();
@@ -3093,17 +3093,18 @@ impl ComputeRuntime {
         loop {
             let records = self
                 .store
-                .list(
+                .list_after(
                     SshSession::object_type(),
                     workspace,
+                    cursor.as_ref(),
                     LIFECYCLE_SWEEP_PAGE_SIZE,
-                    offset,
                 )
                 .await
                 .map_err(|e| format!("list SSH sessions: {e}"))?;
             let page_len = records.len();
             scanned += page_len;
 
+            cursor = records.last().map(ObjectCursor::from);
             for record in records {
                 match SshSession::decode(record.payload.as_slice()) {
                     Ok(session) if session.sandbox_id == sandbox_id => {
@@ -3117,11 +3118,6 @@ impl ComputeRuntime {
             if page_len < LIFECYCLE_SWEEP_PAGE_SIZE as usize {
                 break;
             }
-            let page_len = u32::try_from(page_len)
-                .map_err(|_| "SSH session cleanup page length overflow".to_string())?;
-            offset = offset
-                .checked_add(page_len)
-                .ok_or_else(|| "SSH session cleanup pagination overflow".to_string())?;
         }
 
         let matched = session_ids.len();

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -69,7 +69,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex as StdMutex, Weak};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 #[cfg(unix)]
 use tokio::net::UnixStream;
 use tokio::sync::{Mutex, watch};
@@ -3084,21 +3084,64 @@ impl ComputeRuntime {
         sandbox_id: &str,
         workspace: &str,
     ) -> Result<(), String> {
-        let records = self
-            .store
-            .list(SshSession::object_type(), workspace, 1000, 0)
-            .await
-            .map_err(|e| format!("list SSH sessions: {e}"))?;
+        let started = Instant::now();
+        let mut offset = 0_u32;
+        let mut scanned = 0_usize;
+        let mut decode_failures = 0_usize;
+        let mut session_ids = Vec::new();
 
-        for record in records {
-            if let Ok(session) = SshSession::decode(record.payload.as_slice())
-                && session.sandbox_id == sandbox_id
-            {
-                self.store
-                    .delete(SshSession::object_type(), session.object_id())
-                    .await
-                    .map_err(|e| format!("delete SSH session {}: {e}", session.object_id()))?;
+        loop {
+            let records = self
+                .store
+                .list(
+                    SshSession::object_type(),
+                    workspace,
+                    LIFECYCLE_SWEEP_PAGE_SIZE,
+                    offset,
+                )
+                .await
+                .map_err(|e| format!("list SSH sessions: {e}"))?;
+            let page_len = records.len();
+            scanned += page_len;
+
+            for record in records {
+                match SshSession::decode(record.payload.as_slice()) {
+                    Ok(session) if session.sandbox_id == sandbox_id => {
+                        session_ids.push(session.object_id().to_string());
+                    }
+                    Ok(_) => {}
+                    Err(_) => decode_failures += 1,
+                }
             }
+
+            if page_len < LIFECYCLE_SWEEP_PAGE_SIZE as usize {
+                break;
+            }
+            let page_len = u32::try_from(page_len)
+                .map_err(|_| "SSH session cleanup page length overflow".to_string())?;
+            offset = offset
+                .checked_add(page_len)
+                .ok_or_else(|| "SSH session cleanup pagination overflow".to_string())?;
+        }
+
+        let matched = session_ids.len();
+        let deleted = self
+            .store
+            .delete_many(SshSession::object_type(), &session_ids)
+            .await
+            .map_err(|e| format!("delete sandbox SSH sessions: {e}"))?;
+
+        if matched > 0 || decode_failures > 0 {
+            debug!(
+                sandbox_id,
+                workspace,
+                scanned,
+                matched,
+                deleted,
+                decode_failures,
+                elapsed_ms = started.elapsed().as_millis(),
+                "Sandbox SSH session cleanup complete"
+            );
         }
 
         Ok(())
@@ -7149,6 +7192,43 @@ mod tests {
         .await
         .expect("detached delete worker did not finish cleanup");
         assert_eq!(driver.delete_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn sandbox_ssh_session_cleanup_batches_across_list_pages() {
+        let runtime = test_runtime(ControlledDriver::new()).await;
+        for idx in 0..(LIFECYCLE_SWEEP_PAGE_SIZE + 5) {
+            let session = ssh_session_record(&format!("owned-{idx:04}"), "sb-owned");
+            runtime.store.put_message(&session).await.unwrap();
+        }
+        for idx in 0..7 {
+            let session = ssh_session_record(&format!("unrelated-{idx:04}"), "sb-unrelated");
+            runtime.store.put_message(&session).await.unwrap();
+        }
+
+        runtime
+            .cleanup_sandbox_ssh_sessions("sb-owned", "default")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            runtime
+                .store
+                .count_in_workspace(SshSession::object_type(), "default")
+                .await
+                .unwrap(),
+            7
+        );
+        for idx in 0..7 {
+            assert!(
+                runtime
+                    .store
+                    .get_message::<SshSession>(&format!("unrelated-{idx:04}"))
+                    .await
+                    .unwrap()
+                    .is_some()
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/persistence/mod.rs
+++ b/crates/openshell-server/src/persistence/mod.rs
@@ -26,6 +26,12 @@ pub const DRAFT_CHUNK_OBJECT_TYPE: &str = "draft_policy_chunk";
 
 pub type PersistenceResult<T> = Result<T, PersistenceError>;
 
+/// Maximum number of object ids sent in one set-based delete statement.
+///
+/// Keep this well below `SQLite`'s bind-variable limit. Backends split larger
+/// requests into independently retryable, bounded write statements.
+pub const DELETE_MANY_BATCH_SIZE: usize = 128;
+
 /// Persistence-layer error type.
 #[derive(Debug, Error, Clone)]
 pub enum PersistenceError {
@@ -413,6 +419,22 @@ impl Store {
     )]
     pub async fn delete(&self, object_type: &str, id: &str) -> PersistenceResult<bool> {
         store_dispatch_traced!(self.delete(object_type, id))
+    }
+
+    /// Delete objects of one type by id in bounded, set-based statements.
+    #[tracing::instrument(
+        name = "store",
+        skip_all,
+        fields(
+            otel.name = "store.delete_many",
+            otel.status_code = tracing::field::Empty,
+            object_type = %object_type,
+            object_count = ids.len(),
+            batch_count = ids.len().div_ceil(DELETE_MANY_BATCH_SIZE),
+        )
+    )]
+    pub async fn delete_many(&self, object_type: &str, ids: &[String]) -> PersistenceResult<u64> {
+        store_dispatch_traced!(self.delete_many(object_type, ids))
     }
 
     /// Count objects of a given type within a workspace.

--- a/crates/openshell-server/src/persistence/mod.rs
+++ b/crates/openshell-server/src/persistence/mod.rs
@@ -107,6 +107,30 @@ pub struct ObjectRecord {
     pub resource_version: u64,
 }
 
+/// Stable position in the global object-listing order.
+///
+/// Keyset consumers must use the matching store method for the order encoded
+/// here: workspace-scoped lists use `created_at_ms`, `name`, and `id`; global
+/// lists additionally include `workspace`.
+#[derive(Debug, Clone)]
+pub struct ObjectCursor {
+    pub created_at_ms: i64,
+    pub name: String,
+    pub workspace: String,
+    pub id: String,
+}
+
+impl From<&ObjectRecord> for ObjectCursor {
+    fn from(record: &ObjectRecord) -> Self {
+        Self {
+            created_at_ms: record.created_at_ms,
+            name: record.name.clone(),
+            workspace: record.workspace.clone(),
+            id: record.id.clone(),
+        }
+    }
+}
+
 /// Write condition for compare-and-swap operations.
 #[derive(Debug, Clone, Copy)]
 pub enum WriteCondition {
@@ -519,6 +543,46 @@ impl Store {
         offset: u32,
     ) -> PersistenceResult<Vec<ObjectRecord>> {
         store_dispatch_traced!(self.list_by_type(object_type, limit, offset))
+    }
+
+    /// List workspace objects after a stable cursor, without offset drift.
+    #[tracing::instrument(
+        name = "store",
+        skip_all,
+        fields(
+            otel.name = "store.list_after",
+            otel.status_code = tracing::field::Empty,
+            object_type = %object_type,
+            workspace = %workspace,
+        )
+    )]
+    pub async fn list_after(
+        &self,
+        object_type: &str,
+        workspace: &str,
+        after: Option<&ObjectCursor>,
+        limit: u32,
+    ) -> PersistenceResult<Vec<ObjectRecord>> {
+        store_dispatch_traced!(self.list_after(object_type, workspace, after, limit))
+    }
+
+    /// List objects across workspaces after a stable cursor, without offset drift.
+    #[tracing::instrument(
+        name = "store",
+        skip_all,
+        fields(
+            otel.name = "store.list_by_type_after",
+            otel.status_code = tracing::field::Empty,
+            object_type = %object_type,
+        )
+    )]
+    pub async fn list_by_type_after(
+        &self,
+        object_type: &str,
+        after: Option<&ObjectCursor>,
+        limit: u32,
+    ) -> PersistenceResult<Vec<ObjectRecord>> {
+        store_dispatch_traced!(self.list_by_type_after(object_type, after, limit))
     }
 
     /// List objects by type and application-owned scope.

--- a/crates/openshell-server/src/persistence/postgres.rs
+++ b/crates/openshell-server/src/persistence/postgres.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    DraftChunkRecord, ObjectRecord, PersistenceError, PersistenceResult, PolicyRecord,
-    WriteCondition, WriteResult, current_time_ms, map_db_error, map_migrate_error,
+    DraftChunkRecord, ObjectCursor, ObjectRecord, PersistenceError, PersistenceResult,
+    PolicyRecord, WriteCondition, WriteResult, current_time_ms, map_db_error, map_migrate_error,
 };
 use crate::policy_store::{
     AtomicPolicyRevisionWrite, draft_chunk_payload_from_record, draft_chunk_record_from_parts,
@@ -520,6 +520,33 @@ LIMIT $2 OFFSET $3
         .await
         .map_err(|e| map_db_error(&e))?;
 
+        Ok(rows.into_iter().map(row_to_object_record).collect())
+    }
+    pub async fn list_after(
+        &self,
+        object_type: &str,
+        workspace: &str,
+        after: Option<&ObjectCursor>,
+        limit: u32,
+    ) -> PersistenceResult<Vec<ObjectRecord>> {
+        let rows = if let Some(cursor) = after {
+            sqlx::query("SELECT object_type, id, name, workspace, payload, created_at_ms, updated_at_ms, labels, resource_version FROM objects WHERE object_type = $1 AND workspace = $2 AND (created_at_ms, name, id) > ($3, $4, $5) ORDER BY created_at_ms, name, id LIMIT $6").bind(object_type).bind(workspace).bind(cursor.created_at_ms).bind(&cursor.name).bind(&cursor.id).bind(i64::from(limit)).fetch_all(&self.pool).await
+        } else {
+            sqlx::query("SELECT object_type, id, name, workspace, payload, created_at_ms, updated_at_ms, labels, resource_version FROM objects WHERE object_type = $1 AND workspace = $2 ORDER BY created_at_ms, name, id LIMIT $3").bind(object_type).bind(workspace).bind(i64::from(limit)).fetch_all(&self.pool).await
+        }.map_err(|e| map_db_error(&e))?;
+        Ok(rows.into_iter().map(row_to_object_record).collect())
+    }
+    pub async fn list_by_type_after(
+        &self,
+        object_type: &str,
+        after: Option<&ObjectCursor>,
+        limit: u32,
+    ) -> PersistenceResult<Vec<ObjectRecord>> {
+        let rows = if let Some(cursor) = after {
+            sqlx::query("SELECT object_type, id, name, workspace, payload, created_at_ms, updated_at_ms, labels, resource_version FROM objects WHERE object_type = $1 AND (created_at_ms, name, workspace, id) > ($2, $3, $4, $5) ORDER BY created_at_ms, name, workspace, id LIMIT $6").bind(object_type).bind(cursor.created_at_ms).bind(&cursor.name).bind(&cursor.workspace).bind(&cursor.id).bind(i64::from(limit)).fetch_all(&self.pool).await
+        } else {
+            sqlx::query("SELECT object_type, id, name, workspace, payload, created_at_ms, updated_at_ms, labels, resource_version FROM objects WHERE object_type = $1 ORDER BY created_at_ms, name, workspace, id LIMIT $2").bind(object_type).bind(i64::from(limit)).fetch_all(&self.pool).await
+        }.map_err(|e| map_db_error(&e))?;
         Ok(rows.into_iter().map(row_to_object_record).collect())
     }
 

--- a/crates/openshell-server/src/persistence/postgres.rs
+++ b/crates/openshell-server/src/persistence/postgres.rs
@@ -14,11 +14,11 @@ use openshell_core::SetResourceVersion;
 use openshell_core::proto::Sandbox;
 use prost::Message;
 use sqlx::postgres::PgPoolOptions;
-use sqlx::{Connection, PgPool, Row};
+use sqlx::{Connection, PgPool, Postgres, QueryBuilder, Row};
 
 static POSTGRES_MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations/postgres");
 
-use super::{DRAFT_CHUNK_OBJECT_TYPE, POLICY_OBJECT_TYPE};
+use super::{DELETE_MANY_BATCH_SIZE, DRAFT_CHUNK_OBJECT_TYPE, POLICY_OBJECT_TYPE};
 
 #[derive(Debug, Clone)]
 pub struct PostgresStore {
@@ -389,6 +389,28 @@ WHERE object_type = $1 AND workspace = $2 AND name = $3
             .await
             .map_err(|e| map_db_error(&e))?;
         Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn delete_many(&self, object_type: &str, ids: &[String]) -> PersistenceResult<u64> {
+        let mut deleted = 0_u64;
+        for ids in ids.chunks(DELETE_MANY_BATCH_SIZE) {
+            let mut query =
+                QueryBuilder::<Postgres>::new("DELETE FROM objects WHERE object_type = ");
+            query.push_bind(object_type).push(" AND id IN (");
+            let mut separated = query.separated(", ");
+            for id in ids {
+                separated.push_bind(id);
+            }
+            separated.push_unseparated(")");
+
+            deleted += query
+                .build()
+                .execute(&self.pool)
+                .await
+                .map_err(|e| map_db_error(&e))?
+                .rows_affected();
+        }
+        Ok(deleted)
     }
 
     pub async fn count_in_workspace(

--- a/crates/openshell-server/src/persistence/sqlite.rs
+++ b/crates/openshell-server/src/persistence/sqlite.rs
@@ -15,13 +15,13 @@ use openshell_core::paths::set_file_owner_only;
 use openshell_core::proto::Sandbox;
 use prost::Message;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
-use sqlx::{Connection, Row, SqlitePool};
+use sqlx::{Connection, QueryBuilder, Row, Sqlite, SqlitePool};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 static SQLITE_MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations/sqlite");
 
-use super::{DRAFT_CHUNK_OBJECT_TYPE, POLICY_OBJECT_TYPE};
+use super::{DELETE_MANY_BATCH_SIZE, DRAFT_CHUNK_OBJECT_TYPE, POLICY_OBJECT_TYPE};
 
 #[derive(Debug, Clone)]
 pub struct SqliteStore {
@@ -414,6 +414,27 @@ WHERE "object_type" = ?1 AND "id" = ?2
         .await
         .map_err(|e| map_db_error(&e))?;
         Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn delete_many(&self, object_type: &str, ids: &[String]) -> PersistenceResult<u64> {
+        let mut deleted = 0_u64;
+        for ids in ids.chunks(DELETE_MANY_BATCH_SIZE) {
+            let mut query = QueryBuilder::<Sqlite>::new("DELETE FROM objects WHERE object_type = ");
+            query.push_bind(object_type).push(" AND id IN (");
+            let mut separated = query.separated(", ");
+            for id in ids {
+                separated.push_bind(id);
+            }
+            separated.push_unseparated(")");
+
+            deleted += query
+                .build()
+                .execute(&self.pool)
+                .await
+                .map_err(|e| map_db_error(&e))?
+                .rows_affected();
+        }
+        Ok(deleted)
     }
 
     pub async fn count_in_workspace(

--- a/crates/openshell-server/src/persistence/sqlite.rs
+++ b/crates/openshell-server/src/persistence/sqlite.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    DraftChunkRecord, ObjectRecord, PersistenceError, PersistenceResult, PolicyRecord,
-    WriteCondition, WriteResult, current_time_ms, map_db_error, map_migrate_error,
+    DraftChunkRecord, ObjectCursor, ObjectRecord, PersistenceError, PersistenceResult,
+    PolicyRecord, WriteCondition, WriteResult, current_time_ms, map_db_error, map_migrate_error,
 };
 use crate::policy_store::{
     AtomicPolicyRevisionWrite, draft_chunk_payload_from_record, draft_chunk_record_from_parts,
@@ -560,6 +560,77 @@ LIMIT ?2 OFFSET ?3
         .await
         .map_err(|e| map_db_error(&e))?;
 
+        Ok(rows.into_iter().map(row_to_object_record).collect())
+    }
+    pub async fn list_after(
+        &self,
+        object_type: &str,
+        workspace: &str,
+        after: Option<&ObjectCursor>,
+        limit: u32,
+    ) -> PersistenceResult<Vec<ObjectRecord>> {
+        let rows = if let Some(cursor) = after {
+            sqlx::query(
+                r#"
+SELECT "object_type", "id", "name", "workspace", "payload", "created_at_ms", "updated_at_ms", "labels", "resource_version"
+FROM "objects"
+WHERE "object_type" = ?1 AND "workspace" = ?2
+  AND ("created_at_ms", "name", "id") > (?3, ?4, ?5)
+ORDER BY "created_at_ms" ASC, "name" ASC, "id" ASC
+LIMIT ?6
+"#,
+            )
+            .bind(object_type)
+            .bind(workspace)
+            .bind(cursor.created_at_ms)
+            .bind(&cursor.name)
+            .bind(&cursor.id)
+            .bind(i64::from(limit))
+            .fetch_all(&self.pool)
+            .await
+        } else {
+            sqlx::query(
+                r#"
+SELECT "object_type", "id", "name", "workspace", "payload", "created_at_ms", "updated_at_ms", "labels", "resource_version"
+FROM "objects"
+WHERE "object_type" = ?1 AND "workspace" = ?2
+ORDER BY "created_at_ms" ASC, "name" ASC, "id" ASC
+LIMIT ?3
+"#,
+            )
+            .bind(object_type)
+            .bind(workspace)
+            .bind(i64::from(limit))
+            .fetch_all(&self.pool)
+            .await
+        }
+        .map_err(|e| map_db_error(&e))?;
+        Ok(rows.into_iter().map(row_to_object_record).collect())
+    }
+    pub async fn list_by_type_after(
+        &self,
+        object_type: &str,
+        after: Option<&ObjectCursor>,
+        limit: u32,
+    ) -> PersistenceResult<Vec<ObjectRecord>> {
+        let rows = if let Some(cursor) = after {
+            sqlx::query(r#"
+SELECT "object_type", "id", "name", "workspace", "payload", "created_at_ms", "updated_at_ms", "labels", "resource_version"
+FROM "objects"
+WHERE "object_type" = ?1
+  AND ("created_at_ms", "name", "workspace", "id") > (?2, ?3, ?4, ?5)
+ORDER BY "created_at_ms" ASC, "name" ASC, "workspace" ASC, "id" ASC
+LIMIT ?6
+"#).bind(object_type).bind(cursor.created_at_ms).bind(&cursor.name).bind(&cursor.workspace).bind(&cursor.id).bind(i64::from(limit)).fetch_all(&self.pool).await
+        } else {
+            sqlx::query(r#"
+SELECT "object_type", "id", "name", "workspace", "payload", "created_at_ms", "updated_at_ms", "labels", "resource_version"
+FROM "objects"
+WHERE "object_type" = ?1
+ORDER BY "created_at_ms" ASC, "name" ASC, "workspace" ASC, "id" ASC
+LIMIT ?2
+"#).bind(object_type).bind(i64::from(limit)).fetch_all(&self.pool).await
+        }.map_err(|e| map_db_error(&e))?;
         Ok(rows.into_iter().map(row_to_object_record).collect())
     }
 

--- a/crates/openshell-server/src/persistence/tests.rs
+++ b/crates/openshell-server/src/persistence/tests.rs
@@ -367,6 +367,116 @@ async fn sqlite_delete_behavior() {
 }
 
 #[tokio::test]
+async fn delete_many_is_bounded_idempotent_and_type_scoped() {
+    let store = test_store().await;
+    let mut ids = Vec::new();
+    for idx in 0..(super::DELETE_MANY_BATCH_SIZE + 12) {
+        let id = format!("sandbox-{idx}");
+        store
+            .put(
+                "sandbox",
+                &id,
+                &format!("name-{idx}"),
+                "default",
+                b"payload",
+                None,
+            )
+            .await
+            .unwrap();
+        ids.push(id);
+    }
+    store
+        .put(
+            "provider",
+            "other-type",
+            "other-type",
+            "default",
+            b"payload",
+            None,
+        )
+        .await
+        .unwrap();
+
+    ids.extend([
+        "missing".to_string(),
+        "other-type".to_string(),
+        "sandbox-0".to_string(),
+    ]);
+    let expected = u64::try_from(super::DELETE_MANY_BATCH_SIZE + 12).unwrap();
+    assert_eq!(store.delete_many("sandbox", &ids).await.unwrap(), expected);
+    assert_eq!(store.delete_many("sandbox", &ids).await.unwrap(), 0);
+    assert_eq!(store.delete_many("sandbox", &[]).await.unwrap(), 0);
+    assert!(store.get("provider", "other-type").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn file_backed_sqlite_bulk_delete_allows_concurrent_control_reads() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite:{}?mode=rwc", tmp.path().join("bulk.db").display());
+    let store = Store::connect(&url)
+        .await
+        .expect("connect file-backed store");
+    store
+        .put(
+            "provider",
+            "control-row",
+            "control-row",
+            "default",
+            b"control",
+            None,
+        )
+        .await
+        .unwrap();
+
+    let mut ids = Vec::new();
+    for idx in 0..500 {
+        let id = format!("session-{idx}");
+        store
+            .put("ssh_session", &id, &id, "default", b"payload", None)
+            .await
+            .unwrap();
+        ids.push(id);
+    }
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let read_store = store.clone();
+    let read_stop = stop.clone();
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let reader = tokio::spawn(async move {
+        let mut reads = 0_usize;
+        let mut started_tx = Some(started_tx);
+        while !read_stop.load(Ordering::Relaxed) {
+            read_store
+                .get("provider", "control-row")
+                .await
+                .map_err(|error| error.to_string())?
+                .ok_or_else(|| "control row disappeared".to_string())?;
+            reads += 1;
+            if let Some(started_tx) = started_tx.take() {
+                let _ = started_tx.send(());
+            }
+            tokio::task::yield_now().await;
+        }
+        Ok::<usize, String>(reads)
+    });
+    started_rx.await.expect("reader started");
+
+    assert_eq!(store.delete_many("ssh_session", &ids).await.unwrap(), 500);
+    stop.store(true, Ordering::Relaxed);
+    assert!(reader.await.unwrap().unwrap() > 0);
+    assert!(
+        store
+            .get("provider", "control-row")
+            .await
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[tokio::test]
 async fn sqlite_protobuf_round_trip() {
     let store = test_store().await;
 

--- a/crates/openshell-server/src/ssh_sessions.rs
+++ b/crates/openshell-server/src/ssh_sessions.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::{info, warn};
 
-use crate::persistence::{ObjectType, Store};
+use crate::persistence::{ObjectCursor, ObjectType, Store};
 
 const SESSION_REAPER_PAGE_SIZE: u32 = 1000;
 
@@ -50,7 +50,7 @@ where
 {
     let now_ms = now_ms();
     let started = std::time::Instant::now();
-    let mut offset = 0_u32;
+    let mut cursor = None;
     let mut page_number = 0_usize;
     let mut scanned = 0_usize;
     let mut decode_failures = 0_usize;
@@ -58,12 +58,17 @@ where
 
     loop {
         let records = store
-            .list_by_type(SshSession::object_type(), SESSION_REAPER_PAGE_SIZE, offset)
+            .list_by_type_after(
+                SshSession::object_type(),
+                cursor.as_ref(),
+                SESSION_REAPER_PAGE_SIZE,
+            )
             .await
             .map_err(|e| e.to_string())?;
         let page_len = records.len();
         scanned += page_len;
 
+        cursor = records.last().map(ObjectCursor::from);
         for record in records {
             let Ok(session) = SshSession::decode(record.payload.as_slice()) else {
                 decode_failures += 1;
@@ -79,11 +84,6 @@ where
         }
         page_number += 1;
         after_page(page_number).await;
-        let page_len = u32::try_from(page_len)
-            .map_err(|_| "SSH session reaper page length overflow".to_string())?;
-        offset = offset
-            .checked_add(page_len)
-            .ok_or_else(|| "SSH session reaper pagination overflow".to_string())?;
     }
 
     let matched = session_ids.len();

--- a/crates/openshell-server/src/ssh_sessions.rs
+++ b/crates/openshell-server/src/ssh_sessions.rs
@@ -7,6 +7,7 @@ use openshell_core::ObjectId;
 use openshell_core::proto::SshSession;
 use openshell_core::time::now_ms;
 use prost::Message;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{info, warn};
@@ -36,9 +37,21 @@ pub fn spawn_session_reaper(store: Arc<Store>, interval: Duration) {
 }
 
 async fn reap_expired_sessions(store: &Store) -> Result<(), String> {
+    reap_expired_sessions_after_page(store, |_| std::future::ready(())).await
+}
+
+async fn reap_expired_sessions_after_page<F, Fut>(
+    store: &Store,
+    mut after_page: F,
+) -> Result<(), String>
+where
+    F: FnMut(usize) -> Fut,
+    Fut: Future<Output = ()>,
+{
     let now_ms = now_ms();
     let started = std::time::Instant::now();
     let mut offset = 0_u32;
+    let mut page_number = 0_usize;
     let mut scanned = 0_usize;
     let mut decode_failures = 0_usize;
     let mut session_ids = Vec::new();
@@ -64,6 +77,8 @@ async fn reap_expired_sessions(store: &Store) -> Result<(), String> {
         if page_len < SESSION_REAPER_PAGE_SIZE as usize {
             break;
         }
+        page_number += 1;
+        after_page(page_number).await;
         let page_len = u32::try_from(page_len)
             .map_err(|_| "SSH session reaper page length overflow".to_string())?;
         offset = offset
@@ -227,6 +242,39 @@ mod tests {
                 .await
                 .unwrap()
                 .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn reaper_removes_every_expired_session_when_an_earlier_page_row_is_deleted() {
+        let store = test_store().await;
+        for idx in 0..=SESSION_REAPER_PAGE_SIZE {
+            let session = make_session(&format!("reap-{idx:04}"), "sbx1", now_ms() - 1, false);
+            store.put_message(&session).await.unwrap();
+        }
+
+        let delete_store = store.clone();
+        reap_expired_sessions_after_page(&store, move |page_number| {
+            let delete_store = delete_store.clone();
+            async move {
+                if page_number == 1 {
+                    delete_store
+                        .delete(SshSession::object_type(), "reap-0000")
+                        .await
+                        .unwrap();
+                }
+            }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            store
+                .count_in_workspace(SshSession::object_type(), "default")
+                .await
+                .unwrap(),
+            0,
+            "the reaper must not leave an expired session behind"
         );
     }
 }

--- a/crates/openshell-server/src/ssh_sessions.rs
+++ b/crates/openshell-server/src/ssh_sessions.rs
@@ -13,6 +13,8 @@ use tracing::{info, warn};
 
 use crate::persistence::{ObjectType, Store};
 
+const SESSION_REAPER_PAGE_SIZE: u32 = 1000;
+
 impl ObjectType for SshSession {
     fn object_type() -> &'static str {
         "ssh_session"
@@ -35,36 +37,54 @@ pub fn spawn_session_reaper(store: Arc<Store>, interval: Duration) {
 
 async fn reap_expired_sessions(store: &Store) -> Result<(), String> {
     let now_ms = now_ms();
+    let started = std::time::Instant::now();
+    let mut offset = 0_u32;
+    let mut scanned = 0_usize;
+    let mut decode_failures = 0_usize;
+    let mut session_ids = Vec::new();
 
-    let records = store
-        .list_by_type(SshSession::object_type(), 1000, 0)
-        .await
-        .map_err(|e| e.to_string())?;
+    loop {
+        let records = store
+            .list_by_type(SshSession::object_type(), SESSION_REAPER_PAGE_SIZE, offset)
+            .await
+            .map_err(|e| e.to_string())?;
+        let page_len = records.len();
+        scanned += page_len;
 
-    let mut reaped = 0u32;
-    for record in records {
-        let session: SshSession = match Message::decode(record.payload.as_slice()) {
-            Ok(s) => s,
-            Err(_) => continue,
-        };
-
-        let should_delete =
-            (session.expires_at_ms > 0 && now_ms > session.expires_at_ms) || session.revoked;
-
-        if should_delete {
-            if let Err(e) = store
-                .delete(SshSession::object_type(), session.object_id())
-                .await
-            {
-                warn!(session_id = %session.object_id(), error = %e, "Failed to reap SSH session");
-            } else {
-                reaped += 1;
+        for record in records {
+            let Ok(session) = SshSession::decode(record.payload.as_slice()) else {
+                decode_failures += 1;
+                continue;
+            };
+            if (session.expires_at_ms > 0 && now_ms > session.expires_at_ms) || session.revoked {
+                session_ids.push(session.object_id().to_string());
             }
         }
+
+        if page_len < SESSION_REAPER_PAGE_SIZE as usize {
+            break;
+        }
+        let page_len = u32::try_from(page_len)
+            .map_err(|_| "SSH session reaper page length overflow".to_string())?;
+        offset = offset
+            .checked_add(page_len)
+            .ok_or_else(|| "SSH session reaper pagination overflow".to_string())?;
     }
 
-    if reaped > 0 {
-        info!(count = reaped, "SSH session reaper: cleaned up sessions");
+    let matched = session_ids.len();
+    let deleted = store
+        .delete_many(SshSession::object_type(), &session_ids)
+        .await
+        .map_err(|e| e.to_string())?;
+    if matched > 0 || decode_failures > 0 {
+        info!(
+            scanned,
+            matched,
+            deleted,
+            decode_failures,
+            elapsed_ms = started.elapsed().as_millis(),
+            "SSH session reaper sweep complete"
+        );
     }
     Ok(())
 }
@@ -173,6 +193,40 @@ mod tests {
                 .unwrap()
                 .is_some(),
             "session with no expiry should be preserved"
+        );
+    }
+
+    #[tokio::test]
+    async fn reaper_batches_expired_and_revoked_sessions() {
+        let store = test_store().await;
+        let session_count = crate::persistence::DELETE_MANY_BATCH_SIZE + 9;
+        for idx in 0..session_count {
+            let session = make_session(
+                &format!("reap-{idx}"),
+                "sbx1",
+                if idx % 2 == 0 { now_ms() - 1 } else { 0 },
+                idx % 2 != 0,
+            );
+            store.put_message(&session).await.unwrap();
+        }
+        let active = make_session("keep", "sbx1", now_ms() + 60_000, false);
+        store.put_message(&active).await.unwrap();
+
+        reap_expired_sessions(&store).await.unwrap();
+
+        assert_eq!(
+            store
+                .count_in_workspace(SshSession::object_type(), "default")
+                .await
+                .unwrap(),
+            1
+        );
+        assert!(
+            store
+                .get_message::<SshSession>("keep")
+                .await
+                .unwrap()
+                .is_some()
         );
     }
 }


### PR DESCRIPTION
## Summary

Batch SSH-session persistence cleanup into bounded set-based deletes so sandbox teardown and the session reaper do not issue one database write per session. This addresses the gateway-side contention risk reported in #2999 without changing SQLite journal settings, timeouts, or session ownership schema.

## Related Issue

Part of #2999.

This is PR 1 of 2. The issue does not currently carry an accepted-state label; the direct implementation and ready-for-review request authorized this submission, while maintainers retain the acceptance and merge decision.

## Changes

- add a backend-neutral `delete_many` store operation with fixed 128-ID chunks for SQLite and Postgres
- paginate SSH-session discovery before mutation and batch sandbox-owned cleanup writes
- batch expired/revoked session reaping and replace token-bearing per-session errors with aggregate telemetry
- add persistence, pagination, type-isolation, reaper, and file-backed SQLite concurrency coverage
- document the bounded owned-record cleanup invariant

## Testing

- [x] `mise run pre-commit`
- [x] `mise run test` (review rerun: 1,443 server tests passed)
- [x] focused persistence, compute cleanup, and reaper regression tests
- [x] exact OpenClaw fixture reproduced on `main`, then passed on this PR and the combined branches
- [x] `mise run e2e:docker`
- [ ] `mise run ci` passes locally — all Rust, Python, TypeScript, lint, compile, and policy checks passed; three unrelated Go gateway fixture tests fail because this workstation's hard-coded `/etc/openshell/gateways/default` is included as an unexpected system fixture

## Review

A full line-by-line review covered both persistence backends, chunk bounds, empty/duplicate/missing IDs, object-type isolation, pagination before mutation, partial-chunk idempotency, cleanup/reaper telemetry, secret-safe logging, tests, and architecture documentation. No actionable findings remained.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
