### PR TITLE
ci(codeql): run nightly scans on main

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -11,5 +11,7 @@ paths:
   - python/openshell
 
 paths-ignore:
+  # Integration-test targets are not removed by the Rust cfg override.
+  - crates/*/tests
   - python/openshell/_proto
   - sdk/typescript/src/gen

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,13 +4,8 @@
 name: CodeQL
 
 on:
-  pull_request:
-  merge_group:
-    types: [checks_requested]
-  push:
-    branches: [main]
   schedule:
-    - cron: "29 5 * * 6"
+    - cron: "29 5 * * *"
   workflow_dispatch:
 
 permissions:
@@ -26,6 +21,9 @@ jobs:
     name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    env:
+      # Keep Rust test fixtures out of production-focused security results.
+      CODEQL_EXTRACTOR_RUST_OPTION_CARGO_CFG_OVERRIDES: "-test"
     strategy:
       fail-fast: false
       matrix:

--- a/CI.md
+++ b/CI.md
@@ -29,12 +29,12 @@ The GitHub ruleset should require the `OpenShell / ...` statuses published by `R
 ## Informational security reports
 
 Security analysis that does not need NVIDIA infrastructure runs directly on
-GitHub-hosted runners. These workflows receive no secrets and run on fork pull
-requests without waiting for copy-pr-bot. Scanner jobs request
-`security-events: write` to publish SARIF to Code Scanning. GitHub permits
-Code Scanning uploads from `pull_request` runs even when fork and Dependabot
-contexts receive a read-only `GITHUB_TOKEN`, so each scanner uploads results
-directly and also retains report artifacts:
+GitHub-hosted runners. These workflows receive no secrets. The PR-oriented
+reports run on fork pull requests without waiting for copy-pr-bot. Scanner jobs
+request `security-events: write` to publish SARIF to Code Scanning. GitHub
+permits Code Scanning uploads from `pull_request` runs even when fork and
+Dependabot contexts receive a read-only `GITHUB_TOKEN`, so those scanners upload
+results directly and also retain report artifacts:
 
 - `Workflow Security Reports` runs Actionlint and Zizmor. Actionlint reports
   workflow syntax and expression findings. Zizmor reports only High severity,
@@ -46,13 +46,15 @@ directly and also retains report artifacts:
   a warning, so the workflow remains neutral until the repository feature is
   available.
 - `CodeQL` analyzes product Rust code, examples, and the Go, Python, and
-  TypeScript SDKs. E2E test code is excluded. Results are uploaded to Code
-  Scanning and always retained as workflow artifacts.
+  TypeScript SDKs. Rust `cfg(test)` blocks, Rust integration-test targets, and
+  E2E test code are excluded. It runs nightly on `main`, remains manually
+  dispatchable for diagnostics, uploads results to Code Scanning, and retains
+  workflow artifacts.
 
 Findings do not fail these workflows. Tool startup, configuration, build, and
-analysis failures still fail so a broken scanner cannot appear healthy. These
-workflows also run on merge groups, but their checks are not required statuses
-and do not gate merges.
+analysis failures still fail so a broken scanner cannot appear healthy. The
+PR-oriented reports also run on merge groups; CodeQL is not a PR or merge-queue
+check. None of these reports are required statuses or gate merges.
 
 Run the workflow-definition scanners locally with:
 
@@ -184,7 +186,7 @@ The bot's full administrator documentation is internal to NVIDIA. The only comma
 | `.github/workflows/e2e-label-help.yml` | When a `test:e2e*` label is applied, posts a PR comment telling the maintainer the next manual step (re-run an existing workflow run, or `/ok to test <SHA>` to refresh the mirror). |
 | `.github/workflows/workflow-security.yml` | Runs informational Actionlint and High-severity Zizmor reports on GitHub-hosted runners. |
 | `.github/workflows/dependency-review.yml` | Reports dependency changes when GitHub Dependency Graph is available; otherwise publishes a neutral warning. |
-| `.github/workflows/codeql.yml` | Runs informational CodeQL analysis for Rust and the Go, Python, and TypeScript SDKs and retains SARIF artifacts. |
+| `.github/workflows/codeql.yml` | Runs nightly informational CodeQL analysis on `main` for Rust and the Go, Python, and TypeScript SDKs and retains SARIF artifacts. |
 
 ## Release workflows
 

--- a/architecture/build.md
+++ b/architecture/build.md
@@ -284,18 +284,22 @@ disables emission for Rust tests, E2E runs, and release canaries. This prevents
 synthetic activity from contributing to product usage metrics.
 
 Static security checks are deliberately outside the mirror-branch path. They run
-directly on GitHub-hosted runners with no secrets, so they also cover fork pull
-requests and consume no NVIDIA self-hosted capacity. Scanner jobs request
-`security-events: write` and upload SARIF to Code Scanning directly on every
-event they run on, including fork and Dependabot pull requests, which Code
-Scanning permits for `pull_request` runs despite their read-only `GITHUB_TOKEN`.
-Each scanner also retains its report as a workflow artifact. No privileged
-intermediate workflow relays those uploads.
-Triggers differ by workflow: `.github/workflows/workflow-security.yml` and
-`.github/workflows/codeql.yml` run on `pull_request`, `merge_group`, `main`, and
-a weekly schedule; `.github/workflows/dependency-review.yml` runs on
-`pull_request` and `merge_group` only, because it needs a base and head commit
-to compare.
+directly on GitHub-hosted runners with no secrets, so the pull-request-triggered
+ones also cover fork pull requests, and none of them consume NVIDIA self-hosted
+capacity. Scanner jobs request `security-events: write` and upload SARIF to Code
+Scanning directly on every event they run on, including fork and Dependabot pull
+requests, which Code Scanning permits for `pull_request` runs despite their
+read-only `GITHUB_TOKEN`. Each scanner also retains its report as a workflow
+artifact. No privileged intermediate workflow relays those uploads.
+Triggers differ by workflow: `.github/workflows/workflow-security.yml` runs on
+`pull_request`, `merge_group`, `main`, and a weekly schedule;
+`.github/workflows/dependency-review.yml` runs on `pull_request` and
+`merge_group` only, because it needs a base and head commit to compare; and
+`.github/workflows/codeql.yml` runs nightly on the default branch (`main`) via
+`schedule`, with `workflow_dispatch` kept for manual diagnostics. CodeQL does
+not run on `pull_request`, `merge_group`, or pushes to `main`, so it reports
+repository-level Code Scanning state on the default branch instead of per-PR
+results, and its four-language matrix stays off the per-change critical path.
 
 - **Actionlint and Zizmor** analyze the workflow definitions themselves.
   Repository configuration lives in `.github/actionlint.yml` (self-hosted runner
@@ -311,10 +315,15 @@ to compare.
   reporting on its own once the feature is enabled. Reviews run in warn-only
   mode.
 - **CodeQL** analyzes product Rust code, examples, and the Go, Python, and
-  TypeScript SDKs, scoped by `.github/codeql/codeql-config.yml`; E2E test code is
-  excluded. Only Go requires a build; the other languages use build mode `none`.
-  Results are uploaded to Code Scanning and always retained as workflow
-  artifacts.
+  TypeScript SDKs, scoped by `.github/codeql/codeql-config.yml`. Rust test code
+  is excluded in two layers: the analyze job sets
+  `CODEQL_EXTRACTOR_RUST_OPTION_CARGO_CFG_OVERRIDES=-test` so the extractor skips
+  `#[cfg(test)]` blocks, and `paths-ignore` drops `crates/*/tests`, whose
+  integration targets the cfg override does not reach. Examples remain in scope,
+  and E2E test code stays excluded because `e2e/` is not an analyzed path. Only
+  Go requires a build; the other languages use build mode `none`. Analysis runs
+  on the nightly schedule or by manual dispatch. Results are uploaded to Code
+  Scanning and always retained as workflow artifacts.
 
 Findings never fail these checks; scanner and build failures do. A scanner that
 cannot run, a CodeQL analyzer that does not complete, and an unexpected


### PR DESCRIPTION
## Summary

Move the expensive CodeQL matrix off the pull-request and merge-queue critical paths and run it nightly on `main`. Reduce Rust test-fixture noise while preserving production security coverage.

## Related Issue

No issue required: localized CI scheduling and scanner-scope maintenance.

## Changes

- run CodeQL nightly at 05:29 UTC, with manual dispatch retained for diagnostics
- stop automatic CodeQL runs on pull requests, merge groups, and pushes to `main`
- exclude Rust `#[cfg(test)]` blocks and dedicated integration-test targets
- document the nightly trigger and production-focused scan scope

## Testing

- [ ] `mise run pre-commit` passes — blocked locally because the unpacked third-party `codeql/` test bundle is scanned for project SPDX headers
- [x] CodeQL 2.26.4 Rust analysis completed with no execution warnings and no test-code findings (9 production findings, down from 27 total)
- [x] `mise run markdown:lint:md`
- [x] `git diff --check`
- [ ] Unit tests added/updated — not applicable; no product runtime code changed
- [ ] E2E tests added/updated — not applicable; no sandbox or deployment behavior changed

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commit is signed and includes DCO sign-off
- [x] Architecture docs updated