### PR TITLE
fix(cli): include provider identity metadata for interceptors on update

### DIFF
--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -4822,22 +4822,17 @@ pub async fn provider_update(options: ProviderUpdateOptions<'_>) -> Result<()> {
     }
 
     let mut client = grpc_client(server, tls).await?;
-    // Preserve the managed profile identity in the update request. Policy
-    // interceptors evaluate this request before the server merges it with the
-    // stored provider, so an empty type/profile workspace makes a legitimate
-    // credential rotation indistinguishable from an unbound mutation.
-    let existing = client
-        .get_provider(GetProviderRequest {
-            name: name.to_string(),
-            workspace: workspace.to_string(),
-        })
-        .await
-        .into_diagnostic()?
-        .into_inner()
-        .provider
-        .ok_or_else(|| miette::miette!("provider '{name}' not found"))?;
-
     let oidc_profile = if from_oidc_token {
+        let existing = client
+            .get_provider(GetProviderRequest {
+                name: name.to_string(),
+                workspace: workspace.to_string(),
+            })
+            .await
+            .into_diagnostic()?
+            .into_inner()
+            .provider
+            .ok_or_else(|| miette::miette!("provider '{name}' not found"))?;
         let profile_workspace = if existing.profile_workspace.is_empty() {
             workspace
         } else {
@@ -4858,9 +4853,21 @@ pub async fn provider_update(options: ProviderUpdateOptions<'_>) -> Result<()> {
     credential_expires_at_ms.extend(oidc_credential_expires_at_ms);
 
     if from_existing {
-        let provider_type = &existing.r#type;
+        // Fetch the existing provider to discover its type for credential lookup.
+        let existing = client
+            .get_provider(GetProviderRequest {
+                name: name.to_string(),
+                workspace: workspace.to_string(),
+            })
+            .await
+            .into_diagnostic()?
+            .into_inner()
+            .provider
+            .ok_or_else(|| miette::miette!("provider '{name}' not found"))?;
+
+        let provider_type = existing.r#type;
         let discovered =
-            discover_existing_provider_data(&mut client, provider_type, workspace).await?;
+            discover_existing_provider_data(&mut client, &provider_type, workspace).await?;
         let Some(discovered) = discovered else {
             return Err(miette::miette!(
                 "no existing local credentials/config found for provider type '{provider_type}'"
@@ -4888,11 +4895,11 @@ pub async fn provider_update(options: ProviderUpdateOptions<'_>) -> Result<()> {
                     workspace: workspace.to_string(),
                     deletion_timestamp_ms: 0,
                 }),
-                r#type: existing.r#type,
+                r#type: String::new(),
                 credentials: credential_map,
                 config: config_map,
                 credential_expires_at_ms: HashMap::new(),
-                profile_workspace: existing.profile_workspace,
+                profile_workspace: String::new(),
                 credential_handles: HashMap::new(),
             }),
             credential_expires_at_ms,

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -4822,18 +4822,22 @@ pub async fn provider_update(options: ProviderUpdateOptions<'_>) -> Result<()> {
     }
 
     let mut client = grpc_client(server, tls).await?;
+    // Preserve the managed profile identity in the update request. Policy
+    // interceptors evaluate this request before the server merges it with the
+    // stored provider, so an empty type/profile workspace makes a legitimate
+    // credential rotation indistinguishable from an unbound mutation.
+    let existing = client
+        .get_provider(GetProviderRequest {
+            name: name.to_string(),
+            workspace: workspace.to_string(),
+        })
+        .await
+        .into_diagnostic()?
+        .into_inner()
+        .provider
+        .ok_or_else(|| miette::miette!("provider '{name}' not found"))?;
 
     let oidc_profile = if from_oidc_token {
-        let existing = client
-            .get_provider(GetProviderRequest {
-                name: name.to_string(),
-                workspace: workspace.to_string(),
-            })
-            .await
-            .into_diagnostic()?
-            .into_inner()
-            .provider
-            .ok_or_else(|| miette::miette!("provider '{name}' not found"))?;
         let profile_workspace = if existing.profile_workspace.is_empty() {
             workspace
         } else {
@@ -4854,21 +4858,9 @@ pub async fn provider_update(options: ProviderUpdateOptions<'_>) -> Result<()> {
     credential_expires_at_ms.extend(oidc_credential_expires_at_ms);
 
     if from_existing {
-        // Fetch the existing provider to discover its type for credential lookup.
-        let existing = client
-            .get_provider(GetProviderRequest {
-                name: name.to_string(),
-                workspace: workspace.to_string(),
-            })
-            .await
-            .into_diagnostic()?
-            .into_inner()
-            .provider
-            .ok_or_else(|| miette::miette!("provider '{name}' not found"))?;
-
-        let provider_type = existing.r#type;
+        let provider_type = &existing.r#type;
         let discovered =
-            discover_existing_provider_data(&mut client, &provider_type, workspace).await?;
+            discover_existing_provider_data(&mut client, provider_type, workspace).await?;
         let Some(discovered) = discovered else {
             return Err(miette::miette!(
                 "no existing local credentials/config found for provider type '{provider_type}'"
@@ -4896,11 +4888,11 @@ pub async fn provider_update(options: ProviderUpdateOptions<'_>) -> Result<()> {
                     workspace: workspace.to_string(),
                     deletion_timestamp_ms: 0,
                 }),
-                r#type: String::new(),
+                r#type: existing.r#type,
                 credentials: credential_map,
                 config: config_map,
                 credential_expires_at_ms: HashMap::new(),
-                profile_workspace: String::new(),
+                profile_workspace: existing.profile_workspace,
                 credential_handles: HashMap::new(),
             }),
             credential_expires_at_ms,

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -32,6 +32,7 @@ use openshell_core::proto::{
 use openshell_core::{ObjectId, ObjectName};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, mpsc};
@@ -46,6 +47,7 @@ struct ProviderState {
     refresh_statuses: Arc<Mutex<HashMap<(String, String), ProviderCredentialRefreshStatus>>>,
     refresh_requests: Arc<Mutex<Vec<ProviderRefreshRequestLog>>>,
     provider_update_requests: Arc<Mutex<Vec<Provider>>>,
+    deny_provider_reads: Arc<AtomicBool>,
     delete_provider_requests: Arc<Mutex<Vec<String>>>,
     fail_configure_refresh_message: Arc<Mutex<Option<String>>>,
     fail_rotate_refresh_message: Arc<Mutex<Option<String>>>,
@@ -433,6 +435,9 @@ impl OpenShell for TestOpenShell {
         &self,
         request: tonic::Request<GetProviderRequest>,
     ) -> Result<Response<ProviderResponse>, Status> {
+        if self.state.deny_provider_reads.load(Ordering::SeqCst) {
+            return Err(Status::permission_denied("scope 'provider:read' required"));
+        }
         let name = request.into_inner().name;
         let providers = self.state.providers.lock().await;
         let provider = providers
@@ -1204,6 +1209,10 @@ async fn provider_cli_run_functions_support_full_crud_flow() {
     .await
     .expect("provider list");
 
+    // A credential-only update must remain available to callers that have
+    // provider:write but not provider:read.
+    ts.state.deny_provider_reads.store(true, Ordering::SeqCst);
+
     run::provider_update(run::ProviderUpdateOptions {
         server: &ts.endpoint,
         name: "my-claude",
@@ -1220,8 +1229,8 @@ async fn provider_cli_run_functions_support_full_crud_flow() {
 
     let requests = ts.state.provider_update_requests.lock().await;
     let request = requests.last().expect("provider update request");
-    assert_eq!(request.r#type, "claude-code");
-    assert_eq!(request.profile_workspace, "default");
+    assert!(request.r#type.is_empty());
+    assert!(request.profile_workspace.is_empty());
     drop(requests);
 
     run::provider_delete(&ts.endpoint, &["my-claude".to_string()], "default", &ts.tls)

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -45,6 +45,7 @@ struct ProviderState {
     profiles: Arc<Mutex<HashMap<String, ProviderProfile>>>,
     refresh_statuses: Arc<Mutex<HashMap<(String, String), ProviderCredentialRefreshStatus>>>,
     refresh_requests: Arc<Mutex<Vec<ProviderRefreshRequestLog>>>,
+    provider_update_requests: Arc<Mutex<Vec<Provider>>>,
     delete_provider_requests: Arc<Mutex<Vec<String>>>,
     fail_configure_refresh_message: Arc<Mutex<Option<String>>>,
     fail_rotate_refresh_message: Arc<Mutex<Option<String>>>,
@@ -611,6 +612,11 @@ impl OpenShell for TestOpenShell {
             .into_inner()
             .provider
             .ok_or_else(|| Status::invalid_argument("provider is required"))?;
+        self.state
+            .provider_update_requests
+            .lock()
+            .await
+            .push(provider.clone());
 
         let mut providers = self.state.providers.lock().await;
         let existing = providers
@@ -1211,6 +1217,12 @@ async fn provider_cli_run_functions_support_full_crud_flow() {
     })
     .await
     .expect("provider update");
+
+    let requests = ts.state.provider_update_requests.lock().await;
+    let request = requests.last().expect("provider update request");
+    assert_eq!(request.r#type, "claude-code");
+    assert_eq!(request.profile_workspace, "default");
+    drop(requests);
 
     run::provider_delete(&ts.endpoint, &["my-claude".to_string()], "default", &ts.tls)
         .await

--- a/crates/openshell-server/src/multiplex.rs
+++ b/crates/openshell-server/src/multiplex.rs
@@ -17,15 +17,19 @@ use hyper_util::{
     service::TowerToHyperService,
 };
 use metrics::{counter, histogram};
-use openshell_core::Config;
 use openshell_core::proto::{
     inference_server::InferenceServer, open_shell_server::OpenShellServer,
+};
+use openshell_core::{
+    Config,
+    proto::{Provider, UpdateProviderRequest},
 };
 use openshell_gateway_interceptors::{EvaluationContext, GatewayInterceptorRuntime};
 use openshell_otel::HeaderMapExtractor;
 use opentelemetry::propagation::TextMapPropagator;
 use opentelemetry::trace::TraceContextExt as _;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
+use prost::Message;
 use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::future::Future;
@@ -46,6 +50,7 @@ use crate::{
     auth::identity::Identity,
     auth::oidc::{self, OidcAuthenticator},
     auth::principal::{Principal, UserPrincipal},
+    auth::workspace_authz::{MinWorkspaceRole, authorize_workspace},
     gateway_listener::GatewayListenerScope,
     http_router,
     inference::InferenceService,
@@ -267,8 +272,11 @@ impl MultiplexService {
     {
         let openshell = OpenShellServer::new(OpenShellService::new(self.state.clone()))
             .max_decoding_message_size(MAX_GRPC_DECODE_SIZE);
-        let openshell =
-            GatewayInterceptorGrpcService::new(openshell, self.state.gateway_interceptors.clone());
+        let openshell = GatewayInterceptorGrpcService::new(
+            openshell,
+            self.state.gateway_interceptors.clone(),
+            Some(self.state.clone()),
+        );
         let inference = InferenceServer::new(InferenceService::new(self.state.clone()))
             .max_decoding_message_size(MAX_GRPC_DECODE_SIZE);
         let authz_policy = self.state.config.oidc.as_ref().map(|oidc| AuthzPolicy {
@@ -394,13 +402,19 @@ where
 struct GatewayInterceptorGrpcService<S> {
     inner: S,
     interceptors: Option<GatewayInterceptorRuntime>,
+    state: Option<Arc<ServerState>>,
 }
 
 impl<S> GatewayInterceptorGrpcService<S> {
-    fn new(inner: S, interceptors: Option<GatewayInterceptorRuntime>) -> Self {
+    fn new(
+        inner: S,
+        interceptors: Option<GatewayInterceptorRuntime>,
+        state: Option<Arc<ServerState>>,
+    ) -> Self {
         Self {
             inner,
             interceptors,
+            state,
         }
     }
 }
@@ -424,6 +438,7 @@ where
 
     fn call(&mut self, req: Request<BoxBody>) -> Self::Future {
         let interceptors = self.interceptors.clone();
+        let state = self.state.clone();
         let mut inner = self.inner.clone();
 
         Box::pin(async move {
@@ -437,11 +452,21 @@ where
             }
 
             let context = gateway_interceptor_context(req.extensions());
+            let principal = req.extensions().get::<Principal>().cloned();
             let (parts, body) = req.into_parts();
-            let body = match collect_intercepted_grpc_body(body).await {
+            let mut body = match collect_intercepted_grpc_body(body).await {
                 Ok(body) => body,
                 Err(status) => return Ok(status.into_http()),
             };
+            if let Some(state) = state.as_ref() {
+                body =
+                    match hydrate_update_provider_identity(&path, body, state, principal.as_ref())
+                        .await
+                    {
+                        Ok(body) => body,
+                        Err(status) => return Ok(status.into_http()),
+                    };
+            }
 
             let intercepted = match interceptors.evaluate_request(&path, &body, &context).await {
                 Ok(intercepted) => intercepted,
@@ -495,6 +520,104 @@ where
             Ok(response)
         })
     }
+}
+
+const UPDATE_PROVIDER_PATH: &str = "/openshell.v1.OpenShell/UpdateProvider";
+const GRPC_FRAME_HEADER_LEN: usize = 5;
+
+/// Complete immutable provider identity before policy interception.
+///
+/// Update requests intentionally omit immutable fields. Loading them here keeps
+/// `provider update` a write-only operation while giving policy interceptors a
+/// canonical proposed operation derived from trusted gateway state.
+async fn hydrate_update_provider_identity(
+    path: &str,
+    body: Bytes,
+    state: &ServerState,
+    principal: Option<&Principal>,
+) -> Result<Bytes, tonic::Status> {
+    if path != UPDATE_PROVIDER_PATH {
+        return Ok(body);
+    }
+
+    let mut request = decode_unary_grpc_message::<UpdateProviderRequest>(&body)?;
+    let Some(provider) = request.provider.as_mut() else {
+        return Ok(body);
+    };
+    if !provider.r#type.is_empty() && !provider.profile_workspace.is_empty() {
+        return Ok(body);
+    }
+    let name = provider
+        .metadata
+        .as_ref()
+        .map(|metadata| metadata.name.as_str())
+        .unwrap_or_default();
+    if name.is_empty() {
+        return Ok(body);
+    }
+
+    let principal =
+        principal.ok_or_else(|| tonic::Status::unauthenticated("authentication required"))?;
+    let authorized = authorize_workspace(
+        state.store.as_ref(),
+        &state.admin_role,
+        principal,
+        &request.workspace,
+        MinWorkspaceRole::Admin,
+    )
+    .await?;
+    let workspace =
+        crate::grpc::workspace::resolve_workspace(state.store.as_ref(), &authorized.workspace)
+            .await?
+            .name;
+    let existing = state
+        .store
+        .get_message_by_name::<Provider>(&workspace, name)
+        .await
+        .map_err(|error| tonic::Status::internal(format!("provider lookup failed: {error}")))?
+        .ok_or_else(|| tonic::Status::not_found(format!("provider '{name}' not found")))?;
+
+    if provider.r#type.is_empty() {
+        provider.r#type = existing.r#type;
+    }
+    if provider.profile_workspace.is_empty() {
+        provider.profile_workspace = existing.profile_workspace;
+    }
+
+    encode_unary_grpc_message(&request)
+}
+
+fn decode_unary_grpc_message<M>(body: &[u8]) -> Result<M, tonic::Status>
+where
+    M: Message + Default,
+{
+    if body.len() < GRPC_FRAME_HEADER_LEN {
+        return Err(tonic::Status::invalid_argument("gRPC frame is too short"));
+    }
+    if body[0] != 0 {
+        return Err(tonic::Status::unimplemented(
+            "gateway interceptors do not support compressed gRPC frames",
+        ));
+    }
+    let message_len = u32::from_be_bytes([body[1], body[2], body[3], body[4]]) as usize;
+    if body.len() != GRPC_FRAME_HEADER_LEN + message_len {
+        return Err(tonic::Status::invalid_argument(
+            "gRPC body must contain exactly one frame",
+        ));
+    }
+    M::decode(&body[GRPC_FRAME_HEADER_LEN..])
+        .map_err(|error| tonic::Status::invalid_argument(format!("invalid gRPC message: {error}")))
+}
+
+fn encode_unary_grpc_message<M: Message>(message: &M) -> Result<Bytes, tonic::Status> {
+    let message = message.encode_to_vec();
+    let message_len = u32::try_from(message.len())
+        .map_err(|_| tonic::Status::resource_exhausted("gRPC message exceeds u32"))?;
+    let mut frame = Vec::with_capacity(GRPC_FRAME_HEADER_LEN + message.len());
+    frame.push(0);
+    frame.extend_from_slice(&message_len.to_be_bytes());
+    frame.extend_from_slice(&message);
+    Ok(Bytes::from(frame))
 }
 
 async fn collect_intercepted_grpc_body(body: BoxBody) -> Result<Bytes, tonic::Status> {
@@ -1325,7 +1448,6 @@ mod tests {
         ProviderProfileSnapshotRequest,
         gateway_interceptor_server::{GatewayInterceptor, GatewayInterceptorServer},
     };
-    use prost::Message as _;
     use std::convert::Infallible;
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1654,6 +1776,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_provider_interception_hydrates_identity_from_trusted_state() {
+        let state = crate::grpc::test_support::test_server_state().await;
+        let existing = Provider {
+            metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                id: "provider-id".to_string(),
+                name: "managed-provider".to_string(),
+                workspace: "default".to_string(),
+                ..Default::default()
+            }),
+            r#type: "agent-tool-gateway".to_string(),
+            profile_workspace: "default".to_string(),
+            ..Default::default()
+        };
+        state.store.put_message(&existing).await.unwrap();
+
+        let request = UpdateProviderRequest {
+            provider: Some(Provider {
+                metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                    name: "managed-provider".to_string(),
+                    workspace: "default".to_string(),
+                    ..Default::default()
+                }),
+                credentials: std::collections::HashMap::from([(
+                    "TOKEN".to_string(),
+                    "rotated".to_string(),
+                )]),
+                ..Default::default()
+            }),
+            workspace: "default".to_string(),
+            ..Default::default()
+        };
+        let authed = crate::grpc::test_support::authed_request(());
+        let principal = authed.extensions().get::<Principal>().unwrap();
+
+        let hydrated = hydrate_update_provider_identity(
+            UPDATE_PROVIDER_PATH,
+            grpc_frame(&request.encode_to_vec()),
+            state.as_ref(),
+            Some(principal),
+        )
+        .await
+        .unwrap();
+        let hydrated = decode_unary_grpc_message::<UpdateProviderRequest>(&hydrated).unwrap();
+        let provider = hydrated.provider.unwrap();
+
+        assert_eq!(provider.r#type, "agent-tool-gateway");
+        assert_eq!(provider.profile_workspace, "default");
+        assert_eq!(provider.credentials.get("TOKEN").unwrap(), "rotated");
+    }
+
+    #[tokio::test]
     async fn intercepted_grpc_response_preserves_body_and_trailers() {
         let bytes = Bytes::from_static(b"committed-response");
         let mut trailers = http::HeaderMap::new();
@@ -1720,7 +1893,7 @@ mod tests {
                 )))
             }
         });
-        let mut service = GatewayInterceptorGrpcService::new(inner, Some(runtime));
+        let mut service = GatewayInterceptorGrpcService::new(inner, Some(runtime), None);
         let request_body = grpc_frame(&CreateSandboxRequest::default().encode_to_vec());
         let request = Request::builder()
             .uri("/openshell.v1.OpenShell/CreateSandbox")
@@ -2539,6 +2712,18 @@ mod tests {
             })
         }
 
+        fn provider_writer_principal() -> Principal {
+            Principal::User(UserPrincipal {
+                identity: Identity {
+                    subject: "provider-rotation-job".to_string(),
+                    display_name: None,
+                    roles: vec!["openshell-admin".to_string()],
+                    scopes: vec!["provider:write".to_string()],
+                    provider: IdentityProvider::Oidc,
+                },
+            })
+        }
+
         fn mtls_identity(subject: &str) -> Identity {
             Identity {
                 subject: subject.to_string(),
@@ -2793,6 +2978,41 @@ mod tests {
                 // grpc-status=7 (PERMISSION_DENIED).
                 assert_eq!(grpc_status(&res).as_deref(), Some("7"), "{path}");
             }
+        }
+
+        #[tokio::test]
+        async fn provider_write_scope_allows_update_without_provider_read() {
+            let policy = AuthzPolicy {
+                admin_role: "openshell-admin".to_string(),
+                user_role: "openshell-user".to_string(),
+                scopes_enabled: true,
+            };
+
+            let mock = Arc::new(MockAuthenticator::returning(Ok(Some(
+                provider_writer_principal(),
+            ))));
+            let chain = AuthenticatorChain::new(vec![mock]);
+            let (recorder, seen) = PrincipalRecorder::new();
+            let mut router = AuthGrpcRouter::new(recorder, Some(chain), Some(policy.clone()));
+            let response = router
+                .call(empty_request(UPDATE_PROVIDER_PATH))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert!(seen.lock().unwrap().is_some());
+
+            let mock = Arc::new(MockAuthenticator::returning(Ok(Some(
+                provider_writer_principal(),
+            ))));
+            let chain = AuthenticatorChain::new(vec![mock]);
+            let (recorder, seen) = PrincipalRecorder::new();
+            let mut router = AuthGrpcRouter::new(recorder, Some(chain), Some(policy));
+            let response = router
+                .call(empty_request("/openshell.v1.OpenShell/GetProvider"))
+                .await
+                .unwrap();
+            assert_eq!(grpc_status(&response).as_deref(), Some("7"));
+            assert!(seen.lock().unwrap().is_none());
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Summary
Addresses https://github.com/NVIDIA/OpenShell/issues/2991 by preserving the appropriate provider metadata during a credential update.

## Related Issue
https://github.com/NVIDIA/OpenShell/issues/2991

## Changes
  - Fetch the existing provider before constructing an update request.
  - Preserve the provider type and profile workspace in credential and configuration updates.
  - Allow policy interceptors to identify and authorize updates to managed provider profiles before gateway-side state merging.
  - Reuse the fetched provider metadata for `--from-existing` and `--from-oidc-token`.
  - Extend the CLI provider integration test to verify that update requests retain provider identity.


## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [ ] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)

Added assertions to `provider_commands_integration` verifying that the raw `UpdateProviderRequest` contains the existing provider type and profile workspace before the server merges stored state.

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
