### PR TITLE
fix(deps): bump h2 to patch RUSTSEC-2026-0258 (GHSA-q83h-524g-xf6h)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.13",
+ "h2 0.4.16",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -2227,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2499,7 +2499,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -7404,7 +7404,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.13",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",


### PR DESCRIPTION
Automated dependency bump to address a disclosed advisory.

- **Advisory:** [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258.html) / [GHSA-q83h-524g-xf6h](https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h)
- **Severity:** low (RustSec classification) — denial-of-service via unbounded memory growth
- **Package:** `h2` `0.4.13` → `0.4.16`

`h2` 0.4.13 accepts and queues empty HTTP/2 DATA frames without limit when a stream isn't actively drained, which can grow memory unboundedly or panic on a length overflow. This instance is pulled in transitively via `hyper`/`hyper-util` into `openshell-server`'s gRPC+HTTP multiplexed listener (`crates/openshell-server/src/multiplex.rs`), which serves inbound connections directly — the flaw sits at the HTTP/2 framing layer, beneath any application-level auth or body-size limiting.

This is a lockfile-only change: `h2` has no entry in any `Cargo.toml` (pulled in transitively), so only `Cargo.lock` moves, to the same-major bugfix release `0.4.16` (no API changes, identical dependency set). The other `h2` instance in the lockfile (`h2 0.3.27`, pulled in by the AWS SDK's outbound `aws-smithy-http-client`) is untouched — it's used only as an outbound client to AWS's own endpoints and has no fix available in the 0.3.x line.

Verified `cargo metadata --locked` passes against the updated lockfile (internally consistent, no re-resolution needed beyond the two pinned entries).

Detected by [osv-scanner](https://google.github.io/osv-scanner/) + manual dataflow verification (confirming the dependency is compiled into the production listener, not just a client-side/dev-only code path) before filing.

---
Filed by [Aeon](https://github.com/aeonfun/aeon), an automated security-research agent. Per SECURITY.md, new vulnerability *reports* for OpenShell go through psirt@nvidia.com / the NVIDIA PSIRT form, not GitHub — this PR is a routine dependency-CVE fix (already public, upstream-patched), not a vulnerability report, so it's filed as a normal PR per your dependency-bump convention. Happy to adjust the commit/PR to fit your process, or close this if you'd rather track it another way.