### PR TITLE
feat(helm): expose sandbox_uid and sandbox_gid as chart values

### DIFF
--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -267,6 +267,7 @@ discovery endpoint or its TLS CA.
 | server.policyValidationFailureMode | string | `"fail_closed"` | Posture when a candidate sandbox policy fails validation. `fail_closed` deactivates the previous policy; `retain_last_valid` keeps it active. |
 | server.providerTokenGrants.spiffe.enabled | bool | `false` | Mount the SPIFFE Workload API socket into gateway and sandbox pods for dynamic provider token grants. |
 | server.providerTokenGrants.spiffe.workloadApiSocketPath | string | `"/spiffe-workload-api/spire-agent.sock"` | Path to the SPIFFE Workload API socket mounted into gateway and sandbox pods. |
+| server.sandboxGid | string | `""` | Explicit GID paired with sandboxUid. Empty (default) = omit the field; the driver then reuses the resolved UID as the GID. Setting this without sandboxUid has no effect on UID resolution. Any non-root GID is valid. |
 | server.sandboxImage | string | `"ghcr.io/nvidia/openshell-community/sandboxes/base:latest"` | Default sandbox image used when requests do not specify one. |
 | server.sandboxImagePullPolicy | string | `""` | Kubernetes imagePullPolicy for sandbox pods. Empty = Kubernetes default (Always for :latest, IfNotPresent otherwise). Set to "Always" for dev clusters so new images are picked up without manual eviction. |
 | server.sandboxImagePullSecrets | list | `[]` | Image pull secrets attached to sandbox pods. Referenced Secrets must exist in the sandbox namespace. |
@@ -276,6 +277,7 @@ discovery endpoint or its TLS CA.
 | server.sandboxJwt.signingSecretName | string | `""` | Name of the Opaque Secret holding the signing key material. Empty falls back to the chart fullname with "-jwt-keys" appended. |
 | server.sandboxJwt.ttlSecs | int | `3600` | Token TTL in seconds. Defaults to 3600 (1h). |
 | server.sandboxNamespace | string | `""` | Namespace where sandbox pods are created. Defaults to the Helm release namespace (.Release.Namespace) when left empty. |
+| server.sandboxUid | string | `""` | Explicit UID for sandbox processes, the supervisor container securityContext, and the workspace PVC init container. Empty (default) = omit the field, letting the driver auto-detect from the OpenShift SCC annotation openshift.io/sa.scc.uid-range on the sandbox namespace and fall back to 1000 when that is absent. Set this on non-OpenShift clusters to pin a sandbox UID without the OpenShift-specific annotation. Any non-root UID is valid. |
 | server.telemetryEnabled | bool | `true` | Enable anonymous OpenShell telemetry from the gateway and the sandbox supervisors it launches. |
 | server.tls.certSecretName | string | `"openshell-server-tls"` | K8s secret (type kubernetes.io/tls) with tls.crt and tls.key for the server. |
 | server.tls.clientCaSecretName | string | `"openshell-server-client-ca"` | K8s secret with ca.crt for client certificate verification (mTLS). Set to "" to disable mTLS and run HTTPS-only (use OIDC for auth instead). |

--- a/deploy/helm/openshell/templates/gateway-config.yaml
+++ b/deploy/helm/openshell/templates/gateway-config.yaml
@@ -204,6 +204,12 @@ data:
     {{- if .Values.server.appArmorProfile }}
     app_armor_profile            = {{ .Values.server.appArmorProfile | quote }}
     {{- end }}
+    {{- if .Values.server.sandboxUid }}
+    sandbox_uid                  = {{ .Values.server.sandboxUid }}
+    {{- end }}
+    {{- if .Values.server.sandboxGid }}
+    sandbox_gid                  = {{ .Values.server.sandboxGid }}
+    {{- end }}
     {{- if .Values.supervisor.image.pullPolicy }}
     supervisor_image_pull_policy = {{ .Values.supervisor.image.pullPolicy | quote }}
     {{- end }}

--- a/deploy/helm/openshell/tests/gateway_config_test.yaml
+++ b/deploy/helm/openshell/tests/gateway_config_test.yaml
@@ -284,6 +284,46 @@ tests:
           path: data["gateway.toml"]
           pattern: 'app_armor_profile\s*='
 
+  - it: omits the sandbox UID and GID by default
+    template: templates/gateway-config.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["gateway.toml"]
+          pattern: 'sandbox_uid\s*='
+      - notMatchRegex:
+          path: data["gateway.toml"]
+          pattern: 'sandbox_gid\s*='
+
+  # The driver parses both as TOML integers, so the trailing `$` anchors
+  # matter: a quoted scalar would be rejected at gateway startup rather
+  # than at render time.
+  - it: renders an explicit sandbox UID and GID under [openshell.drivers.kubernetes]
+    template: templates/gateway-config.yaml
+    set:
+      server.sandboxUid: 1500
+      server.sandboxGid: 1600
+    asserts:
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?ms)\[openshell\.drivers\.kubernetes\].*?sandbox_uid\s*=\s*1500$'
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?ms)\[openshell\.drivers\.kubernetes\].*?sandbox_gid\s*=\s*1600$'
+
+  # resolve_sandbox_gid() falls back to the configured UID, so a bare
+  # sandboxUid must not drag an empty sandbox_gid into the config.
+  - it: renders the sandbox UID without a GID when only sandboxUid is set
+    template: templates/gateway-config.yaml
+    set:
+      server.sandboxUid: 1500
+    asserts:
+      - matchRegex:
+          path: data["gateway.toml"]
+          pattern: '(?m)^\s*sandbox_uid\s*=\s*1500$'
+      - notMatchRegex:
+          path: data["gateway.toml"]
+          pattern: 'sandbox_gid\s*='
+
   - it: does not reuse gateway image pull secrets for sandbox pods
     template: templates/gateway-config.yaml
     set:

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -263,6 +263,19 @@ server:
   # the field, "RuntimeDefault" to force the runtime default profile, or
   # "Localhost/profile-name" for an operator-managed localhost profile.
   appArmorProfile: "Unconfined"
+  # -- Explicit UID for sandbox processes, the supervisor container
+  # securityContext, and the workspace PVC init container. Empty (default)
+  # = omit the field, letting the driver auto-detect from the OpenShift SCC
+  # annotation openshift.io/sa.scc.uid-range on the sandbox namespace and
+  # fall back to 1000 when that is absent. Set this on non-OpenShift
+  # clusters to pin a sandbox UID without the OpenShift-specific
+  # annotation. Any non-root UID is valid.
+  sandboxUid: ""
+  # -- Explicit GID paired with sandboxUid. Empty (default) = omit the
+  # field; the driver then reuses the resolved UID as the GID. Setting this
+  # without sandboxUid has no effect on UID resolution. Any non-root GID is
+  # valid.
+  sandboxGid: ""
   # Kubernetes compute driver settings.
   drivers:
     kubernetes:

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -565,6 +565,8 @@ The Kubernetes driver auto-detects the sandbox UID from OpenShift SCC namespace 
 
 You can override autodetection with explicit `sandbox_uid` / `sandbox_gid` config in `[openshell.drivers.kubernetes]`. When set, the driver skips namespace annotation lookup entirely.
 
+On a Helm-installed gateway, set the `server.sandboxUid` / `server.sandboxGid` chart values; they render into those same config keys. This is the platform-agnostic way to pin a sandbox identity on non-OpenShift clusters, where the SCC annotation is not otherwise used.
+
 The resolved UID/GID appear in:
 
 - Supervisor container environment variables (`OPENSHELL_SANDBOX_UID`, `OPENSHELL_SANDBOX_GID`) for direct kernel-level privilege dropping without `/etc/passwd` lookups.


### PR DESCRIPTION
## Summary

The Kubernetes driver has accepted `sandbox_uid` / `sandbox_gid` as first-class config for a while, but the chart's gateway ConfigMap never rendered them, so a Helm-installed gateway had no way to reach them. Today the only lever is the `openshift.io/sa.scc.uid-range` namespace annotation, which is awkward on non-OpenShift clusters and lives on a resource the chart doesn't own. This adds `server.sandboxUid` / `server.sandboxGid` and renders them into `[openshell.drivers.kubernetes]`.

## Related Issue

Closes #2697

## Changes

- `templates/gateway-config.yaml` — render `sandbox_uid` / `sandbox_gid` when set, using the same `{{- if .Values.server.X }}` idiom as the sibling optional fields immediately above (`app_armor_profile`, `default_runtime_class_name`, `workspace_storage_class`, etc.).
- `values.yaml` — both default to `""`, so nothing renders unless you opt in. Existing installs get a byte-identical ConfigMap.
- Both are emitted **unquoted**. The driver deserializes them as `Option<u32>`, so a quoted scalar would fail at gateway startup rather than at render time. That's what the trailing `$` in the test regexes is guarding.
- Three unittest cases: absent by default, both rendered under the right table, and UID-set-with-GID-unset. The last one matters because `resolve_sandbox_gid()` already falls back to the configured UID, so an empty `sandbox_gid` must not leak into the config.
- Docs — the UID resolution section of `sandbox-compute-drivers.mdx` only mentioned the SCC annotation, so I pointed it at the chart values too. `gateway-config.mdx` already documents the underlying TOML keys, so I left that page alone.

No Rust changed; the driver side already works.

## Testing

- [ ] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

I ran the checks that this change can actually affect, on Windows:

- `helm:lint` — defaults plus all 16 `ci/values-*.yaml` variants, 17/17 clean.
- `helm:docs:check` — README regenerated with helm-docs and in sync.
- `helm:test` — 112 tests / 10 suites pass.
- `fern check` — 0 errors (the 2 warnings are pre-existing: the unauthenticated redirect check and a theme contrast ratio).
- `markdownlint-cli2` — 0 issues across all 132 files.

I did not run the full `mise run pre-commit`, so I've left that box unchecked rather than claim it: the Rust half of `lint` doesn't build on Windows (`openssh` is unix-only), and this PR touches no Rust, Python, or proto. I also can't run the Kubernetes e2e lane locally. Since both values default to `""` and render nothing, I verified with `helm template` that a default install produces zero `sandbox_uid` / `sandbox_gid` lines, and that setting them yields `sandbox_uid = 1500` / `sandbox_gid = 1600` as bare integers.

As a sanity check that the new tests actually bite, I stashed just the template change and re-ran the suite — the two rendering assertions fail without it.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — n/a, no architectural change
