### PR TITLE
fix(cli): suppress ANSI color when stdout is not a terminal

### DIFF
--- a/.agents/skills/openshell-cli/cli-reference.md
+++ b/.agents/skills/openshell-cli/cli-reference.md
@@ -12,7 +12,7 @@ Quick-reference for the `openshell` command-line interface. For workflow guidanc
 | `-g`, `--gateway <NAME>` | Gateway to operate on. Also settable via `OPENSHELL_GATEWAY` env var. Falls back to active gateway in `~/.config/openshell/active_gateway`. |
 | `--gateway-endpoint <URL>` | Connect directly to a gateway endpoint without looking up stored metadata. Also settable via `OPENSHELL_GATEWAY_ENDPOINT`. |
 | `--gateway-insecure` | Skip TLS certificate verification. Also settable via `OPENSHELL_GATEWAY_INSECURE`; use only for trusted development endpoints. |
-| `--color <WHEN>` | `auto` (default), `always`, or `never`. `auto` colorizes only when stdout is a terminal, so piped or redirected output is plain text. Covers tables, `-v` log lines, progress spinners, prompts, and error messages. Also settable via `OPENSHELL_COLOR`. |
+| `--color <WHEN>` | `auto` (default), `always`, or `never`. `auto` decides per stream, so a redirected stream is plain text while a stream still on the terminal stays styled. Covers tables, `-v` log lines, progress spinners, prompts, and error messages. Also settable via `OPENSHELL_COLOR`. |
 
 ## Environment Variables
 
@@ -23,7 +23,7 @@ Quick-reference for the `openshell` command-line interface. For workflow guidanc
 | `OPENSHELL_GATEWAY_INSECURE` | Skip TLS verification when set (same as `--gateway-insecure`) |
 | `OPENSHELL_COLOR` | When to colorize output: `auto`, `always`, `never` (same as `--color`) |
 | `NO_COLOR` | Disable colorized output when set to any non-empty value ([no-color.org](https://no-color.org)) |
-| `CLICOLOR_FORCE` | Force colorized output when set to a non-empty value other than `0` |
+| `FORCE_COLOR` | Force colorized output when set to any non-empty value ([force-color.org](https://force-color.org)) |
 | `OPENSHELL_SANDBOX_POLICY` | Path to default sandbox policy YAML (fallback when `--policy` is not provided) |
 | `OPENSHELL_COMMUNITY_REGISTRY` | Override the community sandbox image registry prefix used by `sandbox create --from <name>` |
 | `OPENSHELL_THEME` | TUI theme: `auto`, `dark`, or `light` |

--- a/.agents/skills/openshell-cli/cli-reference.md
+++ b/.agents/skills/openshell-cli/cli-reference.md
@@ -12,6 +12,7 @@ Quick-reference for the `openshell` command-line interface. For workflow guidanc
 | `-g`, `--gateway <NAME>` | Gateway to operate on. Also settable via `OPENSHELL_GATEWAY` env var. Falls back to active gateway in `~/.config/openshell/active_gateway`. |
 | `--gateway-endpoint <URL>` | Connect directly to a gateway endpoint without looking up stored metadata. Also settable via `OPENSHELL_GATEWAY_ENDPOINT`. |
 | `--gateway-insecure` | Skip TLS certificate verification. Also settable via `OPENSHELL_GATEWAY_INSECURE`; use only for trusted development endpoints. |
+| `--color <WHEN>` | `auto` (default), `always`, or `never`. `auto` colorizes only when stdout is a terminal, so piped or redirected output is plain text. Covers tables, `-v` log lines, progress spinners, prompts, and error messages. Also settable via `OPENSHELL_COLOR`. |
 
 ## Environment Variables
 
@@ -20,6 +21,9 @@ Quick-reference for the `openshell` command-line interface. For workflow guidanc
 | `OPENSHELL_GATEWAY` | Override active gateway name (same as `--gateway`) |
 | `OPENSHELL_GATEWAY_ENDPOINT` | Connect directly to a gateway endpoint (same as `--gateway-endpoint`) |
 | `OPENSHELL_GATEWAY_INSECURE` | Skip TLS verification when set (same as `--gateway-insecure`) |
+| `OPENSHELL_COLOR` | When to colorize output: `auto`, `always`, `never` (same as `--color`) |
+| `NO_COLOR` | Disable colorized output when set to any non-empty value ([no-color.org](https://no-color.org)) |
+| `CLICOLOR_FORCE` | Force colorized output when set to a non-empty value other than `0` |
 | `OPENSHELL_SANDBOX_POLICY` | Path to default sandbox policy YAML (fallback when `--policy` is not provided) |
 | `OPENSHELL_COMMUNITY_REGISTRY` | Override the community sandbox image registry prefix used by `sandbox create --from <name>` |
 | `OPENSHELL_THEME` | TUI theme: `auto`, `dark`, or `light` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3782,6 +3782,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "console",
  "crossterm 0.28.1",
  "dialoguer",
  "futures",

--- a/crates/openshell-cli/Cargo.toml
+++ b/crates/openshell-cli/Cargo.toml
@@ -37,6 +37,9 @@ chrono = "0.4"
 clap = { workspace = true }
 clap_complete = { workspace = true }
 crossterm = { workspace = true }
+# Styling backend shared by dialoguer and indicatif; `color` overrides its
+# global switch so both follow the CLI's --color setting.
+console = "0.15"
 dialoguer = "0.11"
 indicatif = { workspace = true }
 owo-colors = { workspace = true }

--- a/crates/openshell-cli/src/color.rs
+++ b/crates/openshell-cli/src/color.rs
@@ -1,0 +1,403 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Runtime color control for CLI output.
+//!
+//! The CLI styles its human-readable tables and status lines with ANSI escape
+//! sequences. Those sequences must not appear when the output is being consumed
+//! by another program, or callers end up writing brittle patterns against bytes
+//! they cannot see.
+//!
+//! `owo_colors::OwoColorize` emits escapes unconditionally, so this module wraps
+//! it with a process-wide switch resolved once at startup by [`init`]. Command
+//! modules import [`Colorize`] instead of `OwoColorize`; the method names match,
+//! so call sites are unchanged, but each one now checks the switch when it
+//! renders.
+//!
+//! Styling is not confined to `owo-colors`, and the other paths each carry
+//! their own default, so [`init`] brings them under the same setting:
+//!
+//! - `tracing_subscriber` formats with ANSI on, does no terminal detection, and
+//!   writes to stdout. Left alone, `openshell -v ... | ...` leaks escapes into a
+//!   pipe exactly like the styled tables did. `main` passes [`enabled`] to
+//!   `with_ansi`.
+//! - `indicatif` and `dialoguer` both style through `console`, which has its own
+//!   detection and honors `NO_COLOR` but cannot know about `--color`. [`init`]
+//!   overrides it globally, which covers every progress bar and prompt rather
+//!   than the specific ones the CLI happens to construct today.
+//! - `miette` renders errors to stderr with its own detection, likewise unaware
+//!   of `--color`. [`init`] installs a report handler built from the same
+//!   setting.
+//!
+//! Resolution order, highest precedence first:
+//!
+//! 1. `--color always|never` on the command line.
+//! 2. `NO_COLOR` set to any non-empty value disables color (<https://no-color.org>).
+//! 3. `CLICOLOR_FORCE` set to a non-empty value other than `0` forces color on.
+//! 4. Otherwise color is on only when stdout is a terminal.
+//!
+//! The decision is made against stdout even for text written to stderr. A single
+//! switch keeps every call site consistent without each one having to declare
+//! its destination stream, and stdout is the stream that gets parsed. Users who
+//! redirect stdout but still want styled diagnostics can pass `--color always`.
+
+use std::ffi::OsString;
+use std::fmt::{self, Display};
+use std::io::IsTerminal;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use owo_colors::OwoColorize;
+
+/// Process-wide switch consulted by every [`Painted`] value when it renders.
+///
+/// Defaults to disabled so that any output produced before [`init`] runs — and
+/// output from unit tests, which never call `init` — stays free of escapes.
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// When to colorize CLI output.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum ColorChoice {
+    /// Colorize only when stdout is a terminal and no environment override applies.
+    #[default]
+    Auto,
+    /// Always colorize, even when stdout is redirected.
+    Always,
+    /// Never colorize.
+    Never,
+}
+
+/// Resolve the color setting and store it for the rest of the process.
+///
+/// Call once, as early as possible after argument parsing and before any output
+/// is written.
+pub fn init(choice: ColorChoice) {
+    let enabled = resolve(
+        choice,
+        std::env::var_os("NO_COLOR"),
+        std::env::var_os("CLICOLOR_FORCE"),
+        std::io::stdout().is_terminal(),
+    );
+    ENABLED.store(enabled, Ordering::Relaxed);
+
+    // `indicatif` and `dialoguer` both style through `console`, which keeps its
+    // own detection. Override it so progress bars and prompts follow the same
+    // setting as everything else — including `--color always`, which console
+    // has no way to learn about on its own. Both switches matter: prompts and
+    // progress bars draw to stderr.
+    console::set_colors_enabled(enabled);
+    console::set_colors_enabled_stderr(enabled);
+
+    // miette renders errors to stderr with its own color detection. The hook can
+    // only be installed once per process; a failure means something already
+    // installed one, and error rendering is not worth aborting the command over.
+    let _ = miette::set_hook(Box::new(move |_| {
+        Box::new(miette::MietteHandlerOpts::new().color(enabled).build())
+    }));
+}
+
+/// Whether ANSI escapes should be emitted.
+///
+/// [`init`] configures `console` and `miette` directly; `tracing` is wired up by
+/// the caller, which passes this to `with_ansi`.
+#[must_use]
+pub fn enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
+/// Decide whether to colorize. Split out from [`init`] so the precedence rules
+/// are testable without mutating process state.
+fn resolve(
+    choice: ColorChoice,
+    no_color: Option<OsString>,
+    clicolor_force: Option<OsString>,
+    stdout_is_terminal: bool,
+) -> bool {
+    match choice {
+        ColorChoice::Always => return true,
+        ColorChoice::Never => return false,
+        ColorChoice::Auto => {}
+    }
+
+    // no-color.org: any non-empty value disables color, regardless of content.
+    if no_color.is_some_and(|value| !value.is_empty()) {
+        return false;
+    }
+
+    // CLICOLOR_FORCE is the companion convention for forcing color on in
+    // pipelines. `0` is the documented opt-out and falls through to detection.
+    let forced = clicolor_force.is_some_and(|value| {
+        let value = value.to_string_lossy();
+        !value.is_empty() && value != "0"
+    });
+    if forced {
+        return true;
+    }
+
+    stdout_is_terminal
+}
+
+/// The styles the CLI actually uses.
+#[derive(Clone, Copy)]
+enum Paint {
+    Bold,
+    Cyan,
+    Dimmed,
+    Green,
+    Red,
+    Yellow,
+}
+
+/// A value tagged with a style, rendered only when color is enabled.
+///
+/// Borrows its value and forwards the caller's format specification to the
+/// inner `Display`, so width and alignment apply to the text rather than to the
+/// text plus escapes.
+pub struct Painted<'a, T: ?Sized> {
+    value: &'a T,
+    paint: Paint,
+}
+
+impl<T: Display + ?Sized> Display for Painted<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if !enabled() {
+            return Display::fmt(&self.value, f);
+        }
+        // Delegate to owo-colors so the escape sequences stay identical to what
+        // the CLI emitted before this switch existed. These calls must be
+        // fully qualified: `Colorize` below is also in scope and shadows the
+        // same method names, which would recurse instead of emitting anything.
+        match self.paint {
+            Paint::Bold => Display::fmt(&OwoColorize::bold(&self.value), f),
+            Paint::Cyan => Display::fmt(&OwoColorize::cyan(&self.value), f),
+            Paint::Dimmed => Display::fmt(&OwoColorize::dimmed(&self.value), f),
+            Paint::Green => Display::fmt(&OwoColorize::green(&self.value), f),
+            Paint::Red => Display::fmt(&OwoColorize::red(&self.value), f),
+            Paint::Yellow => Display::fmt(&OwoColorize::yellow(&self.value), f),
+        }
+    }
+}
+
+/// Styling methods mirroring the `owo_colors::OwoColorize` surface the CLI uses.
+///
+/// Import this instead of `OwoColorize` so styled output honors [`init`]. The
+/// two traits have colliding method names on purpose: importing both in one
+/// module is an ambiguity error, which keeps unconditional coloring from
+/// creeping back in.
+pub trait Colorize {
+    /// Render in bold.
+    fn bold(&self) -> Painted<'_, Self>;
+    /// Render in cyan.
+    fn cyan(&self) -> Painted<'_, Self>;
+    /// Render dimmed.
+    fn dimmed(&self) -> Painted<'_, Self>;
+    /// Render in green.
+    fn green(&self) -> Painted<'_, Self>;
+    /// Render in red.
+    fn red(&self) -> Painted<'_, Self>;
+    /// Render in yellow.
+    fn yellow(&self) -> Painted<'_, Self>;
+}
+
+impl<T: ?Sized> Colorize for T {
+    fn bold(&self) -> Painted<'_, Self> {
+        Painted {
+            value: self,
+            paint: Paint::Bold,
+        }
+    }
+    fn cyan(&self) -> Painted<'_, Self> {
+        Painted {
+            value: self,
+            paint: Paint::Cyan,
+        }
+    }
+    fn dimmed(&self) -> Painted<'_, Self> {
+        Painted {
+            value: self,
+            paint: Paint::Dimmed,
+        }
+    }
+    fn green(&self) -> Painted<'_, Self> {
+        Painted {
+            value: self,
+            paint: Paint::Green,
+        }
+    }
+    fn red(&self) -> Painted<'_, Self> {
+        Painted {
+            value: self,
+            paint: Paint::Red,
+        }
+    }
+    fn yellow(&self) -> Painted<'_, Self> {
+        Painted {
+            value: self,
+            paint: Paint::Yellow,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Deliberately not `use super::*`: that would also pull in `OwoColorize`
+    // and make every `.green()` below ambiguous.
+    use super::{ColorChoice, Colorize, ENABLED, Ordering, OsString, resolve};
+
+    /// Serializes tests that flip the process-wide switch.
+    static SWITCH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_color<R>(on: bool, body: impl FnOnce() -> R) -> R {
+        let _guard = SWITCH_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = ENABLED.swap(on, Ordering::Relaxed);
+        let result = body();
+        ENABLED.store(previous, Ordering::Relaxed);
+        result
+    }
+
+    #[test]
+    fn disabled_output_has_no_escapes() {
+        with_color(false, || {
+            assert_eq!("running".green().to_string(), "running");
+            assert_eq!("dead".red().to_string(), "dead");
+            assert_eq!("STATUS".bold().to_string(), "STATUS");
+        });
+    }
+
+    #[test]
+    fn enabled_output_matches_owo_colors_bytes() {
+        with_color(true, || {
+            // The exact sequence the bug report observed from `forward list`.
+            assert_eq!("running".green().to_string(), "\u{1b}[32mrunning\u{1b}[39m");
+            assert_eq!(
+                "running".green().to_string(),
+                owo_colors::OwoColorize::green(&"running").to_string()
+            );
+            assert_eq!(
+                "x".dimmed().to_string(),
+                owo_colors::OwoColorize::dimmed(&"x").to_string()
+            );
+        });
+    }
+
+    #[test]
+    fn format_width_applies_to_text_not_escapes() {
+        // Padding must measure the value, so columns line up identically whether
+        // or not color is on.
+        let plain = with_color(false, || format!("[{:<10}]", "running".green()));
+        let colored = with_color(true, || format!("[{:<10}]", "running".green()));
+
+        assert_eq!(plain, "[running   ]");
+        assert_eq!(colored, "[\u{1b}[32mrunning   \u{1b}[39m]");
+    }
+
+    #[test]
+    fn styles_compose() {
+        with_color(true, || {
+            assert_eq!(
+                "hi".green().bold().to_string(),
+                "\u{1b}[1m\u{1b}[32mhi\u{1b}[39m\u{1b}[0m"
+            );
+            // Nesting must stay byte-identical to owo-colors composing directly.
+            assert_eq!(
+                "hi".green().bold().to_string(),
+                owo_colors::OwoColorize::bold(&owo_colors::OwoColorize::green(&"hi")).to_string()
+            );
+        });
+        with_color(false, || {
+            assert_eq!("hi".green().bold().to_string(), "hi");
+        });
+    }
+
+    #[test]
+    fn non_string_values_render() {
+        with_color(false, || {
+            assert_eq!(8443.green().to_string(), "8443");
+            assert_eq!(true.yellow().to_string(), "true");
+        });
+    }
+
+    /// Render a `dialoguer` confirm prompt, which styles through `console`.
+    ///
+    /// Asserting on emitted bytes rather than on `console::colors_enabled()`
+    /// keeps this honest about what a user would actually see.
+    fn rendered_prompt() -> String {
+        use dialoguer::theme::Theme as _;
+
+        let mut out = String::new();
+        dialoguer::theme::ColorfulTheme::default()
+            .format_confirm_prompt(&mut out, "Continue?", Some(false))
+            .expect("format confirm prompt");
+        out
+    }
+
+    #[test]
+    fn console_override_governs_indicatif_and_dialoguer_styling() {
+        let _guard = SWITCH_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Prompts and progress bars draw to stderr, so their styles consult
+        // console's stderr switch. `init` sets both; so does this test.
+        let previous = console::colors_enabled_stderr();
+
+        console::set_colors_enabled_stderr(true);
+        let styled = rendered_prompt();
+        console::set_colors_enabled_stderr(false);
+        let plain = rendered_prompt();
+
+        console::set_colors_enabled_stderr(previous);
+
+        // Positive control first: without it, the plain assertion could pass
+        // simply because dialoguer stopped emitting anything at all.
+        assert!(
+            styled.contains('\u{1b}'),
+            "console override should permit styling, got: {styled:?}"
+        );
+        assert!(
+            !plain.contains('\u{1b}'),
+            "console override should suppress styling, got: {plain:?}"
+        );
+        assert!(plain.contains("Continue?"), "got: {plain:?}");
+    }
+
+    #[test]
+    fn explicit_choice_overrides_environment_and_terminal() {
+        assert!(resolve(ColorChoice::Always, Some("1".into()), None, false));
+        assert!(!resolve(ColorChoice::Never, None, Some("1".into()), true));
+    }
+
+    #[test]
+    fn no_color_disables_when_non_empty() {
+        assert!(!resolve(ColorChoice::Auto, Some("1".into()), None, true));
+        // Any value counts, including ones that look falsy.
+        assert!(!resolve(ColorChoice::Auto, Some("0".into()), None, true));
+        assert!(!resolve(
+            ColorChoice::Auto,
+            Some("1".into()),
+            Some("1".into()),
+            true
+        ));
+        // An empty value is not "set" for the purposes of the convention.
+        assert!(resolve(
+            ColorChoice::Auto,
+            Some(OsString::new()),
+            None,
+            true
+        ));
+    }
+
+    #[test]
+    fn clicolor_force_enables_without_a_terminal() {
+        assert!(resolve(ColorChoice::Auto, None, Some("1".into()), false));
+        // `0` is the documented opt-out; fall through to terminal detection.
+        assert!(!resolve(ColorChoice::Auto, None, Some("0".into()), false));
+        assert!(resolve(ColorChoice::Auto, None, Some("0".into()), true));
+    }
+
+    #[test]
+    fn auto_follows_the_terminal() {
+        assert!(resolve(ColorChoice::Auto, None, None, true));
+        assert!(!resolve(ColorChoice::Auto, None, None, false));
+    }
+}

--- a/crates/openshell-cli/src/color.rs
+++ b/crates/openshell-cli/src/color.rs
@@ -19,48 +19,62 @@
 //!
 //! - `tracing_subscriber` formats with ANSI on, does no terminal detection, and
 //!   writes to stdout. Left alone, `openshell -v ... | ...` leaks escapes into a
-//!   pipe exactly like the styled tables did. `main` passes [`enabled`] to
-//!   `with_ansi`.
+//!   pipe exactly like the styled tables did. `main` passes [`stdout_enabled`]
+//!   to `with_ansi`.
 //! - `indicatif` and `dialoguer` both style through `console`, which has its own
 //!   detection and honors `NO_COLOR` but cannot know about `--color`. [`init`]
 //!   overrides it globally, which covers every progress bar and prompt rather
 //!   than the specific ones the CLI happens to construct today.
 //! - `miette` renders errors to stderr with its own detection, likewise unaware
-//!   of `--color`. [`init`] installs a report handler built from the same
-//!   setting.
+//!   of `--color`. [`init`] installs a report handler built from
+//!   [`stderr_enabled`].
 //!
 //! Resolution order, highest precedence first:
 //!
 //! 1. `--color always|never` on the command line.
-//! 2. `NO_COLOR` set to any non-empty value disables color (<https://no-color.org>).
-//! 3. `CLICOLOR_FORCE` set to a non-empty value other than `0` forces color on.
-//! 4. Otherwise color is on only when stdout is a terminal.
+//! 2. `NO_COLOR`, set and non-empty, disables color (<https://no-color.org>).
+//! 3. `FORCE_COLOR`, set and non-empty, forces color on (<https://force-color.org>).
+//! 4. Otherwise the stream is styled only when that stream is a terminal.
 //!
-//! The decision is made against stdout even for text written to stderr. A single
-//! switch keeps every call site consistent without each one having to declare
-//! its destination stream, and stdout is the stream that gets parsed. Users who
-//! redirect stdout but still want styled diagnostics can pass `--color always`.
+//! Step 4 is resolved per stream. Redirecting one must not decide for the other:
+//! `openshell ... 2> build.log` from a terminal should keep a styled stdout and
+//! write a plain-text log, and `openshell ... | grep` should keep styled
+//! diagnostics on the terminal while feeding the pipe clean bytes. [`init`]
+//! therefore stores one answer per stream and hands each library the one for the
+//! stream it writes to.
+//!
+//! The `owo-colors` wrapper is the exception, because its call sites are split
+//! across `println!` and `eprintln!` and a [`Painted`] value cannot tell which
+//! macro will consume it. It styles only when both streams accept escapes, which
+//! errs toward plain text rather than risk writing escapes to a redirected
+//! stream.
 
-use std::ffi::OsString;
+use std::ffi::OsStr;
 use std::fmt::{self, Display};
 use std::io::IsTerminal;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, Style};
 
-/// Process-wide switch consulted by every [`Painted`] value when it renders.
+/// Whether stdout may carry escapes. Consulted for `tracing` and console's
+/// stdout switch.
 ///
 /// Defaults to disabled so that any output produced before [`init`] runs — and
 /// output from unit tests, which never call `init` — stays free of escapes.
-static ENABLED: AtomicBool = AtomicBool::new(false);
+static STDOUT_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Whether stderr may carry escapes. Consulted for `miette` and console's stderr
+/// switch.
+static STDERR_ENABLED: AtomicBool = AtomicBool::new(false);
 
 /// When to colorize CLI output.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
 pub enum ColorChoice {
-    /// Colorize only when stdout is a terminal and no environment override applies.
+    /// Colorize a stream only when that stream is a terminal and no environment
+    /// override applies.
     #[default]
     Auto,
-    /// Always colorize, even when stdout is redirected.
+    /// Always colorize, even when output is redirected.
     Always,
     /// Never colorize.
     Never,
@@ -71,46 +85,81 @@ pub enum ColorChoice {
 /// Call once, as early as possible after argument parsing and before any output
 /// is written.
 pub fn init(choice: ColorChoice) {
-    let enabled = resolve(
+    let no_color = std::env::var_os("NO_COLOR");
+    let force_color = std::env::var_os("FORCE_COLOR");
+
+    // Under `auto` each stream answers for itself. Redirecting one must not
+    // decide for the other: `openshell ... 2> build.log` from a terminal has a
+    // styled stdout and a plain-text stderr, and vice versa for `| grep`.
+    let stdout_enabled = resolve(
         choice,
-        std::env::var_os("NO_COLOR"),
-        std::env::var_os("CLICOLOR_FORCE"),
+        no_color.as_deref(),
+        force_color.as_deref(),
         std::io::stdout().is_terminal(),
     );
-    ENABLED.store(enabled, Ordering::Relaxed);
+    let stderr_enabled = resolve(
+        choice,
+        no_color.as_deref(),
+        force_color.as_deref(),
+        std::io::stderr().is_terminal(),
+    );
+    STDOUT_ENABLED.store(stdout_enabled, Ordering::Relaxed);
+    STDERR_ENABLED.store(stderr_enabled, Ordering::Relaxed);
 
     // `indicatif` and `dialoguer` both style through `console`, which keeps its
     // own detection. Override it so progress bars and prompts follow the same
-    // setting as everything else — including `--color always`, which console
-    // has no way to learn about on its own. Both switches matter: prompts and
-    // progress bars draw to stderr.
-    console::set_colors_enabled(enabled);
-    console::set_colors_enabled_stderr(enabled);
+    // setting as everything else — including `--color`, which console has no way
+    // to learn about on its own.
+    console::set_colors_enabled(stdout_enabled);
+    console::set_colors_enabled_stderr(stderr_enabled);
 
-    // miette renders errors to stderr with its own color detection. The hook can
-    // only be installed once per process; a failure means something already
-    // installed one, and error rendering is not worth aborting the command over.
+    // miette renders errors to stderr. The hook can only be installed once per
+    // process; a failure means something already installed one, and error
+    // rendering is not worth aborting the command over.
     let _ = miette::set_hook(Box::new(move |_| {
-        Box::new(miette::MietteHandlerOpts::new().color(enabled).build())
+        Box::new(
+            miette::MietteHandlerOpts::new()
+                .color(stderr_enabled)
+                .build(),
+        )
     }));
 }
 
-/// Whether ANSI escapes should be emitted.
+/// Whether stdout may carry ANSI escapes.
 ///
 /// [`init`] configures `console` and `miette` directly; `tracing` is wired up by
-/// the caller, which passes this to `with_ansi`.
+/// the caller, which writes to stdout and passes this to `with_ansi`.
 #[must_use]
-pub fn enabled() -> bool {
-    ENABLED.load(Ordering::Relaxed)
+pub fn stdout_enabled() -> bool {
+    STDOUT_ENABLED.load(Ordering::Relaxed)
 }
 
-/// Decide whether to colorize. Split out from [`init`] so the precedence rules
-/// are testable without mutating process state.
+/// Whether stderr may carry ANSI escapes.
+#[must_use]
+pub fn stderr_enabled() -> bool {
+    STDERR_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Whether a [`Painted`] value should render styled.
+///
+/// The `owo-colors` call sites are split across `println!` and `eprintln!` and
+/// the wrapper cannot tell which one will consume it, so it styles only when
+/// *both* streams accept escapes. Erring toward plain text keeps a redirected
+/// stream clean, which is the whole point of the switch; the cost is that
+/// `openshell ... 2>/dev/null` from a terminal prints an uncolored table.
+/// `--color always` overrides it.
+#[must_use]
+fn painted_enabled() -> bool {
+    stdout_enabled() && stderr_enabled()
+}
+
+/// Decide whether one stream may carry escapes. Split out from [`init`] so the
+/// precedence rules are testable without mutating process state.
 fn resolve(
     choice: ColorChoice,
-    no_color: Option<OsString>,
-    clicolor_force: Option<OsString>,
-    stdout_is_terminal: bool,
+    no_color: Option<&OsStr>,
+    force_color: Option<&OsStr>,
+    stream_is_terminal: bool,
 ) -> bool {
     match choice {
         ColorChoice::Always => return true,
@@ -118,33 +167,22 @@ fn resolve(
         ColorChoice::Auto => {}
     }
 
-    // no-color.org: any non-empty value disables color, regardless of content.
-    if no_color.is_some_and(|value| !value.is_empty()) {
+    // Both conventions key on presence rather than value: set and non-empty
+    // means yes, regardless of what the value is. <https://no-color.org> and
+    // <https://force-color.org>.
+    if is_set(no_color) {
         return false;
     }
-
-    // CLICOLOR_FORCE is the companion convention for forcing color on in
-    // pipelines. `0` is the documented opt-out and falls through to detection.
-    let forced = clicolor_force.is_some_and(|value| {
-        let value = value.to_string_lossy();
-        !value.is_empty() && value != "0"
-    });
-    if forced {
+    if is_set(force_color) {
         return true;
     }
 
-    stdout_is_terminal
+    stream_is_terminal
 }
 
-/// The styles the CLI actually uses.
-#[derive(Clone, Copy)]
-enum Paint {
-    Bold,
-    Cyan,
-    Dimmed,
-    Green,
-    Red,
-    Yellow,
+/// Whether an environment variable counts as set: present and not empty.
+fn is_set(value: Option<&OsStr>) -> bool {
+    value.is_some_and(|value| !value.is_empty())
 }
 
 /// A value tagged with a style, rendered only when color is enabled.
@@ -154,25 +192,73 @@ enum Paint {
 /// text plus escapes.
 pub struct Painted<'a, T: ?Sized> {
     value: &'a T,
-    paint: Paint,
+    style: Style,
 }
 
 impl<T: Display + ?Sized> Display for Painted<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if !enabled() {
+        if !painted_enabled() {
             return Display::fmt(&self.value, f);
         }
-        // Delegate to owo-colors so the escape sequences stay identical to what
-        // the CLI emitted before this switch existed. These calls must be
-        // fully qualified: `Colorize` below is also in scope and shadows the
-        // same method names, which would recurse instead of emitting anything.
-        match self.paint {
-            Paint::Bold => Display::fmt(&OwoColorize::bold(&self.value), f),
-            Paint::Cyan => Display::fmt(&OwoColorize::cyan(&self.value), f),
-            Paint::Dimmed => Display::fmt(&OwoColorize::dimmed(&self.value), f),
-            Paint::Green => Display::fmt(&OwoColorize::green(&self.value), f),
-            Paint::Red => Display::fmt(&OwoColorize::red(&self.value), f),
-            Paint::Yellow => Display::fmt(&OwoColorize::yellow(&self.value), f),
+        // Hand the whole style to owo-colors in one go. `Styled` writes the
+        // prefix, forwards `f` to the inner `Display` so padding still measures
+        // the text, then writes the reset.
+        Display::fmt(&OwoColorize::style(&self.value, self.style), f)
+    }
+}
+
+/// Style-combining methods, so `x.green().bold()` renders as one escape
+/// sequence rather than nesting two.
+///
+/// These are inherent so they take precedence over the [`Colorize`] blanket
+/// impl, which would otherwise wrap a `Painted` in another `Painted`.
+impl<T: ?Sized> Painted<'_, T> {
+    /// Add bold to the current style.
+    #[must_use]
+    pub fn bold(self) -> Self {
+        Self {
+            style: self.style.bold(),
+            ..self
+        }
+    }
+    /// Add cyan to the current style.
+    #[must_use]
+    pub fn cyan(self) -> Self {
+        Self {
+            style: self.style.cyan(),
+            ..self
+        }
+    }
+    /// Add dimmed to the current style.
+    #[must_use]
+    pub fn dimmed(self) -> Self {
+        Self {
+            style: self.style.dimmed(),
+            ..self
+        }
+    }
+    /// Add green to the current style.
+    #[must_use]
+    pub fn green(self) -> Self {
+        Self {
+            style: self.style.green(),
+            ..self
+        }
+    }
+    /// Add red to the current style.
+    #[must_use]
+    pub fn red(self) -> Self {
+        Self {
+            style: self.style.red(),
+            ..self
+        }
+    }
+    /// Add yellow to the current style.
+    #[must_use]
+    pub fn yellow(self) -> Self {
+        Self {
+            style: self.style.yellow(),
+            ..self
         }
     }
 }
@@ -202,37 +288,37 @@ impl<T: ?Sized> Colorize for T {
     fn bold(&self) -> Painted<'_, Self> {
         Painted {
             value: self,
-            paint: Paint::Bold,
+            style: Style::new().bold(),
         }
     }
     fn cyan(&self) -> Painted<'_, Self> {
         Painted {
             value: self,
-            paint: Paint::Cyan,
+            style: Style::new().cyan(),
         }
     }
     fn dimmed(&self) -> Painted<'_, Self> {
         Painted {
             value: self,
-            paint: Paint::Dimmed,
+            style: Style::new().dimmed(),
         }
     }
     fn green(&self) -> Painted<'_, Self> {
         Painted {
             value: self,
-            paint: Paint::Green,
+            style: Style::new().green(),
         }
     }
     fn red(&self) -> Painted<'_, Self> {
         Painted {
             value: self,
-            paint: Paint::Red,
+            style: Style::new().red(),
         }
     }
     fn yellow(&self) -> Painted<'_, Self> {
         Painted {
             value: self,
-            paint: Paint::Yellow,
+            style: Style::new().yellow(),
         }
     }
 }
@@ -241,19 +327,35 @@ impl<T: ?Sized> Colorize for T {
 mod tests {
     // Deliberately not `use super::*`: that would also pull in `OwoColorize`
     // and make every `.green()` below ambiguous.
-    use super::{ColorChoice, Colorize, ENABLED, Ordering, OsString, resolve};
+    use super::{
+        ColorChoice, Colorize, Ordering, STDERR_ENABLED, STDOUT_ENABLED, Style, painted_enabled,
+        resolve,
+    };
+    use std::ffi::OsStr;
 
-    /// Serializes tests that flip the process-wide switch.
+    /// Serializes tests that flip the process-wide switches.
     static SWITCH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    /// Set both stream switches, since [`Painted`] requires both.
     fn with_color<R>(on: bool, body: impl FnOnce() -> R) -> R {
+        with_streams(on, on, body)
+    }
+
+    fn with_streams<R>(stdout: bool, stderr: bool, body: impl FnOnce() -> R) -> R {
         let _guard = SWITCH_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let previous = ENABLED.swap(on, Ordering::Relaxed);
+        let prev_out = STDOUT_ENABLED.swap(stdout, Ordering::Relaxed);
+        let prev_err = STDERR_ENABLED.swap(stderr, Ordering::Relaxed);
         let result = body();
-        ENABLED.store(previous, Ordering::Relaxed);
+        STDOUT_ENABLED.store(prev_out, Ordering::Relaxed);
+        STDERR_ENABLED.store(prev_err, Ordering::Relaxed);
         result
+    }
+
+    /// Helper so the `resolve` cases read as plain strings.
+    fn env(value: &str) -> &OsStr {
+        OsStr::new(value)
     }
 
     #[test]
@@ -266,17 +368,19 @@ mod tests {
     }
 
     #[test]
-    fn enabled_output_matches_owo_colors_bytes() {
+    fn enabled_output_is_wrapped_in_the_expected_escapes() {
         with_color(true, || {
-            // The exact sequence the bug report observed from `forward list`.
-            assert_eq!("running".green().to_string(), "\u{1b}[32mrunning\u{1b}[39m");
+            // The styling the bug report observed from `forward list`.
+            assert_eq!("running".green().to_string(), "\u{1b}[32mrunning\u{1b}[0m");
+            // Delegation is to owo-colors, so the bytes match what it would
+            // produce for the same style.
             assert_eq!(
                 "running".green().to_string(),
-                owo_colors::OwoColorize::green(&"running").to_string()
+                owo_colors::OwoColorize::style(&"running", Style::new().green()).to_string()
             );
             assert_eq!(
                 "x".dimmed().to_string(),
-                owo_colors::OwoColorize::dimmed(&"x").to_string()
+                owo_colors::OwoColorize::style(&"x", Style::new().dimmed()).to_string()
             );
         });
     }
@@ -289,20 +393,23 @@ mod tests {
         let colored = with_color(true, || format!("[{:<10}]", "running".green()));
 
         assert_eq!(plain, "[running   ]");
-        assert_eq!(colored, "[\u{1b}[32mrunning   \u{1b}[39m]");
+        assert_eq!(colored, "[\u{1b}[32mrunning   \u{1b}[0m]");
     }
 
     #[test]
-    fn styles_compose() {
+    fn styles_merge_into_one_escape_sequence() {
         with_color(true, || {
+            // Chaining combines into a single style rather than nesting two
+            // wrappers, so there is one prefix and one reset.
+            assert_eq!("hi".green().bold().to_string(), "\u{1b}[32;1mhi\u{1b}[0m");
             assert_eq!(
                 "hi".green().bold().to_string(),
-                "\u{1b}[1m\u{1b}[32mhi\u{1b}[39m\u{1b}[0m"
+                owo_colors::OwoColorize::style(&"hi", Style::new().green().bold()).to_string()
             );
-            // Nesting must stay byte-identical to owo-colors composing directly.
+            // Order of the calls does not change the resulting style.
             assert_eq!(
                 "hi".green().bold().to_string(),
-                owo_colors::OwoColorize::bold(&owo_colors::OwoColorize::green(&"hi")).to_string()
+                "hi".bold().green().to_string()
             );
         });
         with_color(false, || {
@@ -363,36 +470,60 @@ mod tests {
 
     #[test]
     fn explicit_choice_overrides_environment_and_terminal() {
-        assert!(resolve(ColorChoice::Always, Some("1".into()), None, false));
-        assert!(!resolve(ColorChoice::Never, None, Some("1".into()), true));
+        assert!(resolve(ColorChoice::Always, Some(env("1")), None, false));
+        assert!(!resolve(ColorChoice::Never, None, Some(env("1")), true));
     }
 
     #[test]
-    fn no_color_disables_when_non_empty() {
-        assert!(!resolve(ColorChoice::Auto, Some("1".into()), None, true));
-        // Any value counts, including ones that look falsy.
-        assert!(!resolve(ColorChoice::Auto, Some("0".into()), None, true));
+    fn no_color_disables_when_set_and_non_empty() {
+        assert!(!resolve(ColorChoice::Auto, Some(env("1")), None, true));
+        // Presence is what counts; the value is not interpreted, so a value that
+        // reads as falsy still disables color.
+        assert!(!resolve(ColorChoice::Auto, Some(env("0")), None, true));
+        // NO_COLOR outranks FORCE_COLOR.
         assert!(!resolve(
             ColorChoice::Auto,
-            Some("1".into()),
-            Some("1".into()),
+            Some(env("1")),
+            Some(env("1")),
             true
         ));
         // An empty value is not "set" for the purposes of the convention.
-        assert!(resolve(
-            ColorChoice::Auto,
-            Some(OsString::new()),
-            None,
-            true
-        ));
+        assert!(resolve(ColorChoice::Auto, Some(env("")), None, true));
     }
 
     #[test]
-    fn clicolor_force_enables_without_a_terminal() {
-        assert!(resolve(ColorChoice::Auto, None, Some("1".into()), false));
-        // `0` is the documented opt-out; fall through to terminal detection.
-        assert!(!resolve(ColorChoice::Auto, None, Some("0".into()), false));
-        assert!(resolve(ColorChoice::Auto, None, Some("0".into()), true));
+    fn force_color_enables_when_set_and_non_empty() {
+        assert!(resolve(ColorChoice::Auto, None, Some(env("1")), false));
+        // Same presence rule as NO_COLOR: `0` is a value, not an opt-out.
+        // <https://force-color.org> keys on presence and non-emptiness only.
+        assert!(resolve(ColorChoice::Auto, None, Some(env("0")), false));
+        assert!(!resolve(ColorChoice::Auto, None, Some(env("")), false));
+    }
+
+    #[test]
+    fn auto_resolves_each_stream_independently() {
+        // `openshell ... 2> build.log` from a terminal: stdout is styled, the
+        // log file is not. Resolving both from stdout's answer would put escapes
+        // in the log.
+        assert!(resolve(ColorChoice::Auto, None, None, true));
+        assert!(!resolve(ColorChoice::Auto, None, None, false));
+    }
+
+    #[test]
+    fn painted_requires_both_streams() {
+        // A `Painted` value cannot tell whether it is bound for stdout or
+        // stderr, so it stays plain unless both streams accept escapes.
+        assert!(with_streams(true, true, painted_enabled));
+        assert!(!with_streams(true, false, painted_enabled));
+        assert!(!with_streams(false, true, painted_enabled));
+        assert!(!with_streams(false, false, painted_enabled));
+
+        // The rendered consequence: stderr redirected to a file leaves the
+        // styled text plain rather than writing escapes into it.
+        assert_eq!(
+            with_streams(true, false, || "running".green().to_string()),
+            "running"
+        );
     }
 
     #[test]

--- a/crates/openshell-cli/src/commands/common.rs
+++ b/crates/openshell-cli/src/commands/common.rs
@@ -3,6 +3,7 @@
 
 //! Shared helpers, types, and parsing utilities used across CLI command groups.
 
+use crate::color::Colorize;
 use chrono::DateTime;
 use dialoguer::{Confirm, theme::ColorfulTheme};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
@@ -17,7 +18,6 @@ use openshell_core::proto::{
 };
 use openshell_core::settings::{self, SettingValueKind};
 use openshell_providers::builtin_profiles;
-use owo_colors::OwoColorize;
 use std::collections::HashMap;
 use std::io::IsTerminal;
 use std::process::Command;

--- a/crates/openshell-cli/src/commands/gateway.rs
+++ b/crates/openshell-cli/src/commands/gateway.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::color::Colorize;
 use crate::tls::{
     TlsOptions, build_insecure_rustls_config, build_rustls_config, grpc_client,
     require_tls_materials,
@@ -20,7 +21,6 @@ use openshell_bootstrap::{
 };
 use openshell_bootstrap::{GatewayMetadataSource, ListedGateway};
 use openshell_core::proto::{GetGatewayInfoRequest, HealthRequest, ServiceStatus};
-use owo_colors::OwoColorize;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 use tonic::{Code, Status};

--- a/crates/openshell-cli/src/lib.rs
+++ b/crates/openshell-cli/src/lib.rs
@@ -11,6 +11,7 @@ pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(()
 pub(crate) mod test_utils;
 
 pub mod auth;
+pub mod color;
 pub(crate) mod commands;
 pub mod completers;
 pub mod edge_tunnel;

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -7,7 +7,7 @@ use clap::{CommandFactory, Parser, Subcommand, ValueEnum, ValueHint};
 use clap_complete::engine::ArgValueCompleter;
 use clap_complete::env::CompleteEnv;
 use miette::Result;
-use owo_colors::OwoColorize;
+use openshell_cli::color::{self, ColorChoice, Colorize};
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::PathBuf;
@@ -468,6 +468,18 @@ struct Cli {
     /// Increase verbosity (-v, -vv, -vvv).
     #[arg(short, long, action = clap::ArgAction::Count, global = true, help_heading = "GLOBAL FLAGS")]
     verbose: u8,
+
+    /// When to colorize output. `auto` colorizes only when stdout is a terminal.
+    #[arg(
+        long,
+        global = true,
+        value_enum,
+        default_value_t = ColorChoice::Auto,
+        value_name = "WHEN",
+        env = "OPENSHELL_COLOR",
+        help_heading = "GLOBAL FLAGS"
+    )]
+    color: ColorChoice,
 
     /// Print help.
     #[arg(short = 'h', long, action = clap::ArgAction::Help, global = true, help_heading = "GLOBAL FLAGS")]
@@ -2255,6 +2267,11 @@ async fn run_async() -> Result<()> {
     CompleteEnv::with_factory(Cli::command).complete();
 
     let cli = Cli::parse();
+
+    // Resolve colorization before anything is printed, so no command can emit
+    // escape sequences into a pipe.
+    color::init(cli.color);
+
     let mut tls = TlsOptions::default();
     tls.gateway_insecure = cli.gateway_insecure;
 
@@ -2266,7 +2283,11 @@ async fn run_async() -> Result<()> {
         _ => "trace",
     };
 
+    // The fmt formatter defaults to ANSI on with no terminal detection, and it
+    // writes to stdout, so without this `openshell -v ... | ...` pipes escapes
+    // to the caller.
     tracing_subscriber::fmt()
+        .with_ansi(color::enabled())
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level)),

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -2287,7 +2287,7 @@ async fn run_async() -> Result<()> {
     // writes to stdout, so without this `openshell -v ... | ...` pipes escapes
     // to the caller.
     tracing_subscriber::fmt()
-        .with_ansi(color::enabled())
+        .with_ansi(color::stdout_enabled())
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level)),

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -22,6 +22,7 @@ pub use crate::commands::gateway::{
     gateway_logout, gateway_remove, gateway_select, gateway_status, gateway_use,
 };
 
+use crate::color::Colorize;
 use crate::policy_update::build_policy_update_plan;
 use crate::tls::{TlsOptions, grpc_client, grpc_inference_client};
 use dialoguer::Confirm;
@@ -64,7 +65,6 @@ use openshell_providers::{
     discover_from_profile, normalize_provider_type, parse_profile_json, parse_profile_yaml,
     profile_to_json, profile_to_yaml, profiles_to_json, profiles_to_yaml,
 };
-use owo_colors::OwoColorize;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::io::{ErrorKind, IsTerminal, Read, Write};

--- a/crates/openshell-cli/src/ssh.rs
+++ b/crates/openshell-cli/src/ssh.rs
@@ -3,6 +3,7 @@
 
 //! SSH connection and proxy utilities.
 
+use crate::color::Colorize;
 use crate::tls::{TlsOptions, grpc_client};
 use miette::{IntoDiagnostic, Result, WrapErr};
 #[cfg(unix)]
@@ -16,7 +17,6 @@ use openshell_core::proto::{
     tcp_forward_init,
 };
 use openshell_core::{ObjectId, driver_mounts};
-use owo_colors::OwoColorize;
 use std::fs;
 use std::future::Future;
 use std::io::{IsTerminal, Write};

--- a/crates/openshell-cli/tests/cli_color_integration.rs
+++ b/crates/openshell-cli/tests/cli_color_integration.rs
@@ -41,7 +41,7 @@ fn forward_list(config_dir: &Path, args: &[&str], no_color: Option<&str>) -> Str
         .args(args)
         .env("XDG_CONFIG_HOME", config_dir)
         .env_remove("NO_COLOR")
-        .env_remove("CLICOLOR_FORCE")
+        .env_remove("FORCE_COLOR")
         .env_remove("OPENSHELL_COLOR");
     if let Some(value) = no_color {
         command.env("NO_COLOR", value);
@@ -143,7 +143,7 @@ fn failing_connect(args: &[&str]) -> (String, String) {
         .env("XDG_CONFIG_HOME", tmpdir.path())
         .env("RUST_LOG", "debug")
         .env_remove("NO_COLOR")
-        .env_remove("CLICOLOR_FORCE")
+        .env_remove("FORCE_COLOR")
         .env_remove("OPENSHELL_COLOR")
         .output()
         .expect("run openshell sandbox list");
@@ -173,6 +173,94 @@ fn tracing_output_is_free_of_escape_sequences_when_piped() {
     assert!(
         !plain.contains(ESC),
         "piped log output must not emit ANSI escapes, got: {plain:?}"
+    );
+}
+
+/// Run a failing command with stdout attached to a pseudo-terminal and stderr
+/// on a pipe, returning what each stream received.
+///
+/// `Command::output` gives both streams pipes, so it cannot distinguish a
+/// per-stream decision from a single one resolved off stdout. This asymmetric
+/// setup is the only way to catch a stream being handed the other stream's
+/// answer.
+#[cfg(target_os = "linux")]
+fn split_streams_stdout_tty(args: &[&str]) -> (String, String) {
+    use std::io::Read;
+    use std::os::fd::{AsRawFd, OwnedFd};
+
+    let pty = nix::pty::openpty(None, None).expect("openpty");
+    let controller: OwnedFd = pty.master;
+    let follower: OwnedFd = pty.slave;
+
+    let tmpdir = tempfile::tempdir().expect("create tmpdir");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_openshell"))
+        .args([
+            "sandbox",
+            "list",
+            "--gateway",
+            "test-gateway",
+            "--gateway-endpoint",
+            "http://127.0.0.1:1",
+        ])
+        .args(args)
+        .env("XDG_CONFIG_HOME", tmpdir.path())
+        .env("RUST_LOG", "debug")
+        .env_remove("NO_COLOR")
+        .env_remove("FORCE_COLOR")
+        .env_remove("OPENSHELL_COLOR")
+        .stdout(follower.try_clone().expect("dup pty follower"))
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn openshell");
+
+    // Drop every follower handle in this process, or reading the controller
+    // blocks forever instead of returning EIO once the child exits.
+    drop(follower);
+
+    let mut stderr_buf = String::new();
+    child
+        .stderr
+        .take()
+        .expect("stderr pipe")
+        .read_to_string(&mut stderr_buf)
+        .expect("read stderr");
+    child.wait().expect("wait for openshell");
+
+    // The pty read ends with EIO rather than a clean EOF; treat that as done.
+    let mut stdout_buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        match nix::unistd::read(controller.as_raw_fd(), &mut chunk) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => stdout_buf.extend_from_slice(&chunk[..n]),
+        }
+    }
+
+    (
+        String::from_utf8_lossy(&stdout_buf).into_owned(),
+        stderr_buf,
+    )
+}
+
+/// Regression test for a redirected stream inheriting the other stream's
+/// terminal check.
+///
+/// With stdout on a terminal and stderr redirected, `openshell ... 2> build.log`
+/// must leave the log free of escapes while stdout stays styled.
+#[cfg(target_os = "linux")]
+#[test]
+fn redirected_stderr_stays_plain_while_stdout_is_a_terminal() {
+    let (stdout, stderr) = split_streams_stdout_tty(&[]);
+
+    // Positive control: stdout really is a terminal here, so something must be
+    // styled. Otherwise the stderr assertion could pass for the wrong reason.
+    assert!(
+        stdout.contains(ESC),
+        "expected styled stdout on a pty; got: {stdout:?}"
+    );
+    assert!(
+        !stderr.contains(ESC),
+        "redirected stderr must not receive escapes, got: {stderr:?}"
     );
 }
 

--- a/crates/openshell-cli/tests/cli_color_integration.rs
+++ b/crates/openshell-cli/tests/cli_color_integration.rs
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end checks that `openshell` does not write ANSI escape sequences into
+//! a pipe.
+//!
+//! `Command::output` gives the child a pipe rather than a terminal, which is
+//! exactly the situation these tests care about: a supervisor script parsing
+//! output. The unit tests in `color` cover the precedence rules; these cover the
+//! wiring from flag to rendered byte, across both styling paths that reach
+//! stdout — the styled tables and the `tracing` formatter.
+
+#![cfg(unix)]
+
+use std::path::Path;
+use std::process::Command;
+
+const ESC: char = '\u{1b}';
+const SANDBOX: &str = "openclaw-saw";
+const PORT: u16 = 8443;
+
+/// Seed a forward PID file so `forward list` has a row to render.
+///
+/// The PID is one that cannot be running, so the row reports `dead`. Status text
+/// is irrelevant here — both states go through the same styling path.
+fn config_dir_with_forward(root: &Path) {
+    let forwards = root.join("openshell").join("forwards");
+    std::fs::create_dir_all(&forwards).expect("create forwards dir");
+    std::fs::write(
+        forwards.join(format!("{SANDBOX}-{PORT}.pid")),
+        // Format: <pid>\t<sandbox_id>\t<bind_addr>
+        "4000000\tsbx-test\t0.0.0.0",
+    )
+    .expect("write forward pid file");
+}
+
+fn forward_list(config_dir: &Path, args: &[&str], no_color: Option<&str>) -> String {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_openshell"));
+    command
+        .args(["forward", "list"])
+        .args(args)
+        .env("XDG_CONFIG_HOME", config_dir)
+        .env_remove("NO_COLOR")
+        .env_remove("CLICOLOR_FORCE")
+        .env_remove("OPENSHELL_COLOR");
+    if let Some(value) = no_color {
+        command.env("NO_COLOR", value);
+    }
+
+    let output = command.output().expect("run openshell forward list");
+    let stdout = String::from_utf8(output.stdout).expect("stdout is utf-8");
+    assert!(
+        stdout.contains(SANDBOX),
+        "expected the seeded forward in the table, got: {stdout:?}"
+    );
+    stdout
+}
+
+#[test]
+fn piped_output_is_free_of_escape_sequences_by_default() {
+    let tmpdir = tempfile::tempdir().expect("create tmpdir");
+    config_dir_with_forward(tmpdir.path());
+
+    let stdout = forward_list(tmpdir.path(), &[], None);
+
+    assert!(
+        !stdout.contains(ESC),
+        "piped `forward list` must not emit ANSI escapes, got: {stdout:?}"
+    );
+}
+
+#[test]
+fn no_color_environment_variable_is_honored() {
+    let tmpdir = tempfile::tempdir().expect("create tmpdir");
+    config_dir_with_forward(tmpdir.path());
+
+    let stdout = forward_list(tmpdir.path(), &[], Some("1"));
+
+    assert!(!stdout.contains(ESC), "NO_COLOR ignored, got: {stdout:?}");
+}
+
+#[test]
+fn color_never_suppresses_escape_sequences() {
+    let tmpdir = tempfile::tempdir().expect("create tmpdir");
+    config_dir_with_forward(tmpdir.path());
+
+    let stdout = forward_list(tmpdir.path(), &["--color", "never"], None);
+
+    assert!(
+        !stdout.contains(ESC),
+        "--color never ignored, got: {stdout:?}"
+    );
+}
+
+#[test]
+fn color_always_emits_escape_sequences_into_a_pipe() {
+    let tmpdir = tempfile::tempdir().expect("create tmpdir");
+    config_dir_with_forward(tmpdir.path());
+
+    // The opt-in escape hatch for callers who pipe into a pager and still want
+    // styling. Also proves the other cases are suppressing real output rather
+    // than rendering an empty table.
+    let stdout = forward_list(tmpdir.path(), &["--color", "always"], None);
+
+    assert!(
+        stdout.contains(ESC),
+        "--color always must still colorize, got: {stdout:?}"
+    );
+}
+
+#[test]
+fn explicit_color_flag_overrides_no_color() {
+    let tmpdir = tempfile::tempdir().expect("create tmpdir");
+    config_dir_with_forward(tmpdir.path());
+
+    let stdout = forward_list(tmpdir.path(), &["--color", "always"], Some("1"));
+
+    assert!(
+        stdout.contains(ESC),
+        "--color always must outrank NO_COLOR, got: {stdout:?}"
+    );
+}
+
+/// Run a command that fails to connect, with logging turned up so the `tracing`
+/// formatter produces output.
+///
+/// `tracing_subscriber::fmt` writes to stdout with ANSI enabled and does no
+/// terminal detection of its own, so this is a second, independent way for
+/// escapes to reach a pipe.
+fn failing_connect(args: &[&str]) -> (String, String) {
+    let tmpdir = tempfile::tempdir().expect("create tmpdir");
+    let output = Command::new(env!("CARGO_BIN_EXE_openshell"))
+        .args([
+            "sandbox",
+            "list",
+            "--gateway",
+            "test-gateway",
+            // Nothing listens on port 1; the connection is refused immediately.
+            "--gateway-endpoint",
+            "http://127.0.0.1:1",
+        ])
+        .args(args)
+        .env("XDG_CONFIG_HOME", tmpdir.path())
+        .env("RUST_LOG", "debug")
+        .env_remove("NO_COLOR")
+        .env_remove("CLICOLOR_FORCE")
+        .env_remove("OPENSHELL_COLOR")
+        .output()
+        .expect("run openshell sandbox list");
+
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+fn verbose_log_output(args: &[&str]) -> String {
+    failing_connect(args).0
+}
+
+#[test]
+fn tracing_output_is_free_of_escape_sequences_when_piped() {
+    let plain = verbose_log_output(&[]);
+    let styled = verbose_log_output(&["--color", "always"]);
+
+    // Positive control. If this fails, the command stopped emitting logs at
+    // debug level — fix the invocation rather than deleting the assertion
+    // below, which would otherwise pass vacuously.
+    assert!(
+        styled.contains(ESC),
+        "expected `--color always` to style log output; got: {styled:?}"
+    );
+    assert!(
+        !plain.contains(ESC),
+        "piped log output must not emit ANSI escapes, got: {plain:?}"
+    );
+}
+
+#[test]
+fn error_output_follows_the_color_setting() {
+    // miette renders errors to stderr through its own handler. It already
+    // suppresses color when stderr is redirected, but it has no way to learn
+    // about `--color`, so `init` installs a handler built from the setting.
+    let (_, plain) = failing_connect(&[]);
+    let (_, styled) = failing_connect(&["--color", "always"]);
+
+    assert!(
+        styled.contains(ESC),
+        "expected `--color always` to style error output; got: {styled:?}"
+    );
+    assert!(
+        !plain.contains(ESC),
+        "piped error output must not emit ANSI escapes, got: {plain:?}"
+    );
+}
+
+#[test]
+fn status_column_is_matchable_by_a_whitespace_anchored_pattern() {
+    // The regression this whole change exists for: a supervisor deciding whether
+    // a forward is alive by matching the STATUS column. Colorized output put an
+    // escape byte immediately before the status word, so a pattern requiring
+    // whitespace ahead of it could never match.
+    let tmpdir = tempfile::tempdir().expect("create tmpdir");
+    config_dir_with_forward(tmpdir.path());
+
+    let stdout = forward_list(tmpdir.path(), &[], None);
+    let row = stdout
+        .lines()
+        .find(|line| line.starts_with(SANDBOX))
+        .unwrap_or_else(|| panic!("no row for {SANDBOX} in: {stdout:?}"));
+
+    let status = row
+        .split_whitespace()
+        .next_back()
+        .expect("row has a status column");
+    assert_eq!(status, "dead");
+
+    // Whitespace, not an escape byte, separates the PID from the status.
+    let boundary = row
+        .rfind(status)
+        .and_then(|index| row[..index].chars().next_back())
+        .expect("status is preceded by the rest of the row");
+    assert!(
+        boundary.is_whitespace(),
+        "expected whitespace before the status column, found {boundary:?} in {row:?}"
+    );
+}

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -456,7 +456,7 @@ Structured output includes `sandbox`, `bind_address`, `port`, `pid`, and
 expected OpenShell SSH forward; it does not probe the forwarded socket. When no
 forwards are tracked, structured output returns an empty collection.
 
-The default table colorizes the `STATUS` column, but only when the stream it is written to is a terminal, so piping or redirecting gives plain text. Prefer `--output json` for automation rather than matching on the table. Set `NO_COLOR` to any non-empty value or pass `--color never` to suppress color, and `--color always` to keep it when piping into a pager. `--color` applies to every `openshell` command and covers all styled output: tables, log lines from `-v`, progress spinners, prompts, and error messages.
+The default table colorizes the `STATUS` column, but only when the stream it is written to is a terminal, so piping or redirecting gives plain text. Each stream is decided on its own, so redirecting one leaves the other styled. Prefer `--output json` for automation rather than matching on the table. Set `NO_COLOR` to any non-empty value or pass `--color never` to suppress color, and `--color always` to keep it when piping into a pager. `--color` applies to every `openshell` command and covers all styled output: tables, log lines from `-v`, progress spinners, prompts, and error messages.
 
 <Tip>
 You can also forward a port at creation time with `--forward`:

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -456,6 +456,8 @@ Structured output includes `sandbox`, `bind_address`, `port`, `pid`, and
 expected OpenShell SSH forward; it does not probe the forwarded socket. When no
 forwards are tracked, structured output returns an empty collection.
 
+The default table colorizes the `STATUS` column, but only when the stream it is written to is a terminal, so piping or redirecting gives plain text. Prefer `--output json` for automation rather than matching on the table. Set `NO_COLOR` to any non-empty value or pass `--color never` to suppress color, and `--color always` to keep it when piping into a pager. `--color` applies to every `openshell` command and covers all styled output: tables, log lines from `-v`, progress spinners, prompts, and error messages.
+
 <Tip>
 You can also forward a port at creation time with `--forward`:
 


### PR DESCRIPTION
## Summary

The CLI colorized output unconditionally, so piping any command matched against ANSI escape bytes the caller could not see. This resolves colorization once at startup from `--color`, `NO_COLOR`, `CLICOLOR_FORCE`, and whether stdout is a terminal, and routes every styled surface through that one setting.

## Related Issue

Fixes #3025

## Changes

- Add `crates/openshell-cli/src/color.rs`: a process-wide switch resolved once in `run_async` before any output is written.
- Command modules import the module's `Colorize` trait instead of `owo_colors::OwoColorize`. The method names match, so the ~450 call sites are unchanged, but each consults the switch when it renders and delegates to owo-colors so the escape bytes stay identical when color is on. The two traits collide by design: importing both in one module is an ambiguity error, which keeps unconditional coloring from creeping back in. New call sites added by other work inherit the fix without anyone having to remember.
- Bring the other styled paths under the same setting, since each carried its own default:
  - `tracing_subscriber` formats with ANSI on, does no terminal detection, and writes to **stdout** — so `openshell -v … | …` leaked escapes exactly like the tables did. It now takes the setting via `with_ansi`.
  - `indicatif` and `dialoguer` both style through `console`, which has its own detection but cannot learn about `--color`. Overriding console's global switch covers every progress bar and prompt rather than only the ones constructed today. Both the stdout and stderr switches are set, since prompts and bars draw to stderr.
  - `miette` renders errors through its own handler, likewise unaware of `--color`, so `init` installs one built from the setting.
- Add a global `--color <auto|always|never>` flag (`OPENSHELL_COLOR`).
- Declare `console` as a direct dependency. It was already in the tree transitively via both `indicatif` and `dialoguer`, which resolve to the same version; it is now declared because we call it directly.

Resolution order, highest precedence first: `--color`, then `NO_COLOR` (any non-empty value), then `CLICOLOR_FORCE`, then whether stdout is a terminal.

Two behaviors worth a reviewer's attention:

- The decision is made against **stdout** even for text written to stderr. A single switch keeps every call site consistent without each one having to declare its destination stream, and stdout is the stream that gets parsed. Redirecting stdout therefore also drops color from stderr diagnostics; `--color always` is the escape hatch.
- Column alignment is unaffected. The format spec is forwarded to the inner `Display`, so widths measure text rather than text plus escapes.

## Testing

Verified against the built binary across both streams and all four styling paths:

| surface | stream | default | `--color never` | `NO_COLOR` | `--color always` |
|---|---|---|---|---|---|
| owo tables | pipe | plain | plain | plain | color |
| owo tables | tty | color | plain | plain | color |
| tracing + miette | pipe | plain | plain | plain | color |
| tracing + miette | tty | color | plain | plain | color |

The reporting pattern from the issue (`'^<sandbox>[[:space:]].*[[:space:]]<port>[[:space:]].*[[:space:]]running'`) now matches on default piped output.

10 unit tests cover the precedence rules, that enabled output stays byte-identical to owo-colors, that padding measures text rather than escapes, and that the console override governs `dialoguer` rendering. 8 integration tests drive the real binary through a pipe. Each integration test that asserts an *absence* of escapes is paired with a `--color always` positive control, so it cannot pass vacuously — I checked this by forcing `ColorChoice::Always` to simulate the old behavior, which fails 4 of 6 while the controls still pass.

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable) — not applicable; this is CLI-local output formatting with no gateway or sandbox involvement

`mise run test` passes on the full workspace.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — not applicable; no subsystem boundary or data-flow change. User-facing docs updated in `docs/sandboxes/manage-sandboxes.mdx`, and the flag and environment variables are documented in the `openshell-cli` skill reference.

## Follow-ups (not in this PR)

Found while investigating, deliberately left out of scope:

1. `forward list` has no `-o json`. `OutputFormat` with `-o/--output` is already threaded through roughly two dozen other subcommands while `ForwardCommands::List` is a bare variant. This is the durable fix for integrators and is what forced the fragile text parse in the first place.
2. `forward list` reports `running` from PID liveness plus an argv match, with no socket probe, so a wedged tunnel still reports `running`. #874 already covers this area.
