### PR TITLE
chore(deps): replace serde_yml with noyalib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3241,16 +3241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3559,6 +3549,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "noyalib"
+version = "0.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f075ef19fa3bcf8697c0ef96c37d5c435d339a40ab8081cae3aac3a4e7fee9a"
+dependencies = [
+ "hashbrown 0.17.0",
+ "indexmap",
+ "libm",
+ "memchr",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_core",
+ "smallvec",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3793,6 +3799,7 @@ dependencies = [
  "indicatif",
  "miette",
  "nix 0.29.0",
+ "noyalib",
  "oauth2",
  "openshell-bootstrap",
  "openshell-core",
@@ -3808,7 +3815,6 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
- "serde_yml",
  "tar",
  "temp-env",
  "tempfile",
@@ -3991,11 +3997,11 @@ version = "0.0.0"
 dependencies = [
  "base64 0.22.1",
  "futures",
+ "noyalib",
  "openshell-core",
  "openshell-policy",
  "serde",
  "serde_json",
- "serde_yml",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4212,11 +4218,11 @@ version = "0.0.0"
 dependencies = [
  "hickory-proto",
  "miette",
+ "noyalib",
  "openshell-core",
  "prost-types",
  "serde",
  "serde_json",
- "serde_yml",
 ]
 
 [[package]]
@@ -4226,9 +4232,9 @@ dependencies = [
  "glob",
  "include_dir",
  "miette",
+ "noyalib",
  "owo-colors",
  "serde",
- "serde_yml",
  "z3",
 ]
 
@@ -4237,11 +4243,11 @@ name = "openshell-providers"
 version = "0.0.0"
 dependencies = [
  "glob",
+ "noyalib",
  "openshell-core",
  "openshell-policy",
  "serde",
  "serde_json",
- "serde_yml",
  "thiserror 2.0.18",
  "url",
 ]
@@ -4251,11 +4257,11 @@ name = "openshell-router"
 version = "0.0.0"
 dependencies = [
  "bytes",
+ "noyalib",
  "openshell-core",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_yml",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4471,6 +4477,7 @@ dependencies = [
  "ipnet",
  "libc",
  "miette",
+ "noyalib",
  "openshell-core",
  "openshell-ocsf",
  "openshell-policy",
@@ -4486,7 +4493,6 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
- "serde_yml",
  "sha1 0.10.6",
  "sha2 0.10.9",
  "spiffe",
@@ -6307,21 +6313,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ socket2 = "0.6"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yml = "0.0.12"
+serde_yml = { package = "noyalib", version = "0.0.28", default-features = false, features = ["std", "compat-serde-yaml"] }
 toml = "0.8"
 apollo-parser = "0.8.5"
 tower-mcp-types = "0.12.0"

--- a/crates/openshell-providers/src/profiles.rs
+++ b/crates/openshell-providers/src/profiles.rs
@@ -4157,8 +4157,9 @@ endpoints:
         assert!(parse_profile_yaml(yaml).is_err());
         assert!(parse_profile_catalog_yamls(&[yaml]).is_err());
 
-        let value = serde_yml::from_str(yaml).expect("generic YAML value must parse");
-        assert!(serde_yml::from_value::<ProviderTypeProfile>(value).is_err());
+        let value =
+            serde_yml::from_str::<serde_yml::Value>(yaml).expect("generic YAML value must parse");
+        assert!(serde_yml::from_value::<ProviderTypeProfile>(&value).is_err());
 
         for json in [
             r#"{"id":"mcp-example","display_name":"MCP Example","endpoints":[{"host":"mcp.example.com","port":443,"protocol":"mcp","mcp":null}]}"#,
@@ -4220,8 +4221,9 @@ mcp:
             endpoint_yaml.trim_start().replace('\n', "\n    ")
         );
         assert!(parse_profile_yaml(&profile_yaml).is_err());
-        let value = serde_yml::from_str(&profile_yaml).expect("generic YAML value must parse");
-        assert!(serde_yml::from_value::<ProviderTypeProfile>(value).is_err());
+        let value = serde_yml::from_str::<serde_yml::Value>(&profile_yaml)
+            .expect("generic YAML value must parse");
+        assert!(serde_yml::from_value::<ProviderTypeProfile>(&value).is_err());
 
         let profile_json = format!(
             r#"{{"id":"mcp-example","display_name":"MCP Example","endpoints":[{endpoint_json}]}}"#

--- a/e2e/rust/Cargo.lock
+++ b/e2e/rust/Cargo.lock
@@ -646,6 +646,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -696,14 +698,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
+name = "libm"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -774,6 +772,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "noyalib"
+version = "0.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f075ef19fa3bcf8697c0ef96c37d5c435d339a40ab8081cae3aac3a4e7fee9a"
+dependencies = [
+ "hashbrown",
+ "indexmap",
+ "libm",
+ "memchr",
+ "rustc-hash",
+ "serde",
+ "serde_core",
+ "smallvec",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,11 +841,11 @@ dependencies = [
  "hyper-util",
  "jsonwebtoken",
  "nix",
+ "noyalib",
  "prost",
  "rand",
  "serde",
  "serde_json",
- "serde_yml",
  "serial_test",
  "sha1",
  "sha2",
@@ -1039,6 +1053,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,21 +1153,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]

--- a/e2e/rust/Cargo.toml
+++ b/e2e/rust/Cargo.toml
@@ -217,7 +217,7 @@ hex = "0.4"
 rand = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yml = "0.0.12"
+serde_yml = { package = "noyalib", version = "0.0.28", default-features = false, features = ["std", "compat-serde-yaml"] }
 tonic = { version = "0.14", features = ["transport"] }
 tonic-prost = "0.14"
 tower = "0.5"

--- a/examples/governance-interceptor/Cargo.lock
+++ b/examples/governance-interceptor/Cargo.lock
@@ -698,6 +698,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -809,14 +811,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
+name = "libm"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -932,6 +930,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "noyalib"
+version = "0.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f075ef19fa3bcf8697c0ef96c37d5c435d339a40ab8081cae3aac3a4e7fee9a"
+dependencies = [
+ "hashbrown 0.17.1",
+ "indexmap",
+ "libm",
+ "memchr",
+ "rustc-hash",
+ "serde",
+ "serde_core",
+ "smallvec",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +1044,7 @@ name = "openshell-governance-interceptor-example"
 version = "0.0.0"
 dependencies = [
  "jsonwebtoken",
+ "noyalib",
  "openshell-core",
  "openshell-policy",
  "openshell-providers",
@@ -1039,7 +1054,6 @@ dependencies = [
  "rcgen",
  "serde",
  "serde_json",
- "serde_yml",
  "sha2",
  "tokio",
  "tonic",
@@ -1051,11 +1065,11 @@ version = "0.0.0"
 dependencies = [
  "hickory-proto",
  "miette",
+ "noyalib",
  "openshell-core",
  "prost-types",
  "serde",
  "serde_json",
- "serde_yml",
 ]
 
 [[package]]
@@ -1063,11 +1077,11 @@ name = "openshell-providers"
 version = "0.0.0"
 dependencies = [
  "glob",
+ "noyalib",
  "openshell-core",
  "openshell-policy",
  "serde",
  "serde_json",
- "serde_yml",
  "thiserror",
  "url",
 ]
@@ -1463,6 +1477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,12 +1565,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1656,21 +1670,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]

--- a/examples/governance-interceptor/Cargo.toml
+++ b/examples/governance-interceptor/Cargo.toml
@@ -21,7 +21,7 @@ prost-types = "0.14"
 rcgen = { version = "0.13", features = ["crypto", "pem"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yml = "0.0.12"
+serde_yml = { package = "noyalib", version = "0.0.28", default-features = false, features = ["std", "compat-serde-yaml"] }
 sha2 = "0.10"
 tokio = { version = "1.43", features = ["macros", "rt-multi-thread", "fs", "signal"] }
 tonic = { version = "0.14", features = ["transport"] }

--- a/examples/governance-interceptor/src/main.rs
+++ b/examples/governance-interceptor/src/main.rs
@@ -863,11 +863,8 @@ fn load_provider_profile_source(
     let mapping = value
         .as_mapping_mut()
         .ok_or_else(|| format!("provider profile {source} must be a YAML mapping"))?;
-    mapping.insert(
-        serde_yml::Value::String("id".to_string()),
-        serde_yml::Value::String(profile_id.to_string()),
-    );
-    let profile = serde_yml::from_value::<ProviderTypeProfile>(value)
+    mapping.insert("id", serde_yml::Value::String(profile_id.to_string()));
+    let profile = serde_yml::from_value::<ProviderTypeProfile>(&value)
         .map_err(|err| format!("failed to decode provider profile {source}: {err}"))?
         .to_proto();
     Ok(LoadedProviderProfile { profile })


### PR DESCRIPTION
## Summary

Replace direct `serde_yml` usage with a `noyalib` compatibility alias across the root workspace, Rust e2e harness, and governance interceptor example. This removes the direct `libyml` dependency that backs Dependabot alerts 1, 8, and 11 while keeping existing `serde_yml::` call sites mostly stable.

## Related Issue

Refs #2018

Addresses GitHub Dependabot security alerts for `libyml` via `serde_yml 0.0.12`:

- [Dependabot alert 1](https://github.com/NVIDIA/OpenShell/security/dependabot/1)
- [Dependabot alert 8](https://github.com/NVIDIA/OpenShell/security/dependabot/8)
- [Dependabot alert 11](https://github.com/NVIDIA/OpenShell/security/dependabot/11)

This does not close #2018 because the separate kube-client `serde_yaml` / `unsafe-libyaml` path remains out of scope.

## Changes

- Switched direct `serde_yml` dependency declarations to `noyalib 0.0.28` with `compat-serde-yaml`.
- Regenerated root, e2e, and governance example lockfiles, removing `libyml` from all three graphs.
- Adjusted the governance interceptor profile loader for `noyalib` mapping/from-value API differences.

## Testing

- [ ] `mise run pre-commit` passes
- [x] `dev-openshell shell mise run pre-commit` attempted; failed in existing `helm:lint` because chart metadata is missing `postgresql`
- [x] `cargo tree -i libyml` no longer finds the package in root, e2e, or governance example graphs
- [x] `dev-openshell shell mise exec -- cargo check --all-targets -p openshell-policy -p openshell-prover -p openshell-providers -p openshell-router -p openshell-supervisor-network -p openshell-cli -p openshell-driver-mxc`
- [x] `dev-openshell shell mise exec -- cargo check --manifest-path e2e/rust/Cargo.toml --all-targets --all-features`
- [x] `dev-openshell shell mise exec -- cargo check --manifest-path examples/governance-interceptor/Cargo.toml --all-targets`
- [x] `dev-openshell shell mise exec -- cargo test -p openshell-policy -p openshell-providers -p openshell-router -p openshell-prover`
- [x] `dev-openshell shell mise exec -- cargo test -p openshell-supervisor-network opa`
- [x] `dev-openshell shell mise exec -- cargo test -p openshell-cli output`
- [x] `dev-openshell shell mise exec -- cargo test -p openshell-driver-mxc policy_mapper_matrix`
- [x] Focused Clippy passed for root YAML users, governance example, and e2e GPU target
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
