### PR TITLE
fix(cli): allow multiple provider profiles to be deleted

### DIFF
--- a/.agents/skills/openshell-cli/cli-reference.md
+++ b/.agents/skills/openshell-cli/cli-reference.md
@@ -555,7 +555,7 @@ Delete one or more providers by name.
 - `openshell provider profile import (--file <path>|--from <dir>)`
 - `openshell provider profile update <id> --file <path>`
 - `openshell provider profile lint (--file <path>|--from <dir>)`
-- `openshell provider profile delete <id>`
+- `openshell provider profile delete <id>...`
 
 ### Provider credential refresh
 

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -1093,8 +1093,9 @@ enum ProviderProfileCommands {
     /// Delete a custom provider profile.
     #[command(help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
     Delete {
-        /// Provider profile id.
-        id: String,
+        /// Provider profile id(s).
+        #[arg(required = true, num_args = 1.., value_name = "ID")]
+        ids: Vec<String>,
 
         /// Target platform-scoped profile (ignores --workspace).
         #[arg(long)]
@@ -3551,10 +3552,10 @@ async fn run_async() -> Result<()> {
                             )
                             .await?;
                         }
-                        ProviderProfileCommands::Delete { id, global } => {
+                        ProviderProfileCommands::Delete { ids, global } => {
                             run::provider_profile_delete(
                                 endpoint,
-                                &id,
+                                &ids,
                                 profile_workspace(global),
                                 &tls,
                             )
@@ -4502,17 +4503,23 @@ mod tests {
             }) if id == "custom-api"
         ));
 
-        let delete =
-            Cli::try_parse_from(["openshell", "provider", "profile", "delete", "custom-api"])
-                .expect("provider profile delete should parse");
+        let delete = Cli::try_parse_from([
+            "openshell",
+            "provider",
+            "profile",
+            "delete",
+            "custom-api",
+            "custom-alt",
+        ])
+        .expect("provider profile delete should parse");
         assert!(matches!(
             delete.command,
             Some(Commands::Provider {
                 command: Some(ProviderCommands::Profile(ProviderProfileCommands::Delete {
-                    id,
+                    ids,
                     ..
                 }))
-            }) if id == "custom-api"
+            }) if ids == vec!["custom-api".to_string(), "custom-alt".to_string()]
         ));
     }
 

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -4380,23 +4380,25 @@ pub async fn provider_profile_lint(
 
 pub async fn provider_profile_delete(
     server: &str,
-    id: &str,
+    ids: &[String],
     workspace: &str,
     tls: &TlsOptions,
 ) -> Result<()> {
     let mut client = grpc_client(server, tls).await?;
-    let response = client
-        .delete_provider_profile(DeleteProviderProfileRequest {
-            id: id.to_string(),
-            workspace: workspace.to_string(),
-        })
-        .await
-        .into_diagnostic()?
-        .into_inner();
-    if response.deleted {
-        println!("Deleted provider profile '{id}'.");
-    } else {
-        println!("Provider profile '{id}' was not deleted.");
+    for id in ids {
+        let response = client
+            .delete_provider_profile(DeleteProviderProfileRequest {
+                id: id.clone(),
+                workspace: workspace.to_string(),
+            })
+            .await
+            .into_diagnostic()?
+            .into_inner();
+        if response.deleted {
+            println!("{} Deleted provider profile {id}", "✓".green().bold());
+        } else {
+            println!("{} Provider profile {id} not found", "!".yellow());
+        }
     }
     Ok(())
 }

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -1858,6 +1858,21 @@ binaries: [/usr/bin/custom]
         .expect("custom provider should be stored");
     assert_eq!(provider.r#type, "custom-api");
 
+    let mut custom_alt_profile = ts
+        .state
+        .profiles
+        .lock()
+        .await
+        .get("custom-api")
+        .cloned()
+        .expect("custom-api profile should be stored");
+    custom_alt_profile.id = "custom-alt".to_string();
+    ts.state
+        .profiles
+        .lock()
+        .await
+        .insert("custom-alt".to_string(), custom_alt_profile);
+
     run::provider_delete(
         &ts.endpoint,
         &["custom-provider".to_string()],
@@ -1866,9 +1881,17 @@ binaries: [/usr/bin/custom]
     )
     .await
     .expect("custom provider delete");
-    run::provider_profile_delete(&ts.endpoint, "custom-api", "default", &ts.tls)
-        .await
-        .expect("profile delete");
+    run::provider_profile_delete(
+        &ts.endpoint,
+        &["custom-api".to_string(), "custom-alt".to_string()],
+        "default",
+        &ts.tls,
+    )
+    .await
+    .expect("profile delete");
+    let profiles = ts.state.profiles.lock().await;
+    assert!(!profiles.contains_key("custom-api"));
+    assert!(!profiles.contains_key("custom-alt"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
Makes provider profile deletion more consistent with that of sandboxes and profiles by allowing the deletion of multiple items.

## Related Issue
Closes #3029 

## Changes
- Allow multiple profiles to be specified in the `provider profile delete` command.

## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
