### PR TITLE
fix(helm): omit podSecurityContext block when value is null

### DIFF
--- a/deploy/helm/openshell/templates/_gateway-workload.tpl
+++ b/deploy/helm/openshell/templates/_gateway-workload.tpl
@@ -34,8 +34,10 @@ spec:
         - host.docker.internal
         - host.openshell.internal
   {{- end }}
+  {{- with .Values.podSecurityContext }}
   securityContext:
-    {{- toYaml .Values.podSecurityContext | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   containers:
     - name: openshell-gateway
       securityContext:

--- a/deploy/helm/openshell/tests/gateway_pod_security_context_test.yaml
+++ b/deploy/helm/openshell/tests/gateway_pod_security_context_test.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: gateway pod securityContext
+templates:
+  - templates/gateway-config.yaml
+  - templates/statefulset.yaml
+release:
+  name: openshell
+  namespace: my-namespace
+
+tests:
+  - it: renders the pod securityContext from podSecurityContext by default
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+
+  - it: renders an explicitly set podSecurityContext
+    template: templates/statefulset.yaml
+    set:
+      podSecurityContext:
+        fsGroup: 2000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+
+  - it: omits the pod securityContext block when podSecurityContext is null
+    template: templates/statefulset.yaml
+    set:
+      podSecurityContext: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext


### PR DESCRIPTION
## Summary

The gateway pod template rendered `securityContext:` unconditionally, so setting `podSecurityContext: null` produced `securityContext: null` instead of omitting the block. This wraps the block in `{{- with .Values.podSecurityContext }}` so a null value omits it cleanly — the supported way to let OpenShift's SCC assign the UID/GID range — while an explicit value renders unchanged.

## Related Issue

Fixes #3033

## Changes

- `deploy/helm/openshell/templates/_gateway-workload.tpl`: guard the pod-level `securityContext` block with `{{- with .Values.podSecurityContext }}` so a null value omits it.
- `deploy/helm/openshell/tests/gateway_pod_security_context_test.yaml`: new helm-unittest suite covering the default (`fsGroup: 1000`), an explicit override, and the null-omission case.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated (`mise run helm:test` — 112 passed, including the new `gateway pod securityContext` suite)
- [ ] E2E tests added/updated (if applicable) — n/a (chart-render change; exercised end-to-end by the OpenShift e2e work in #2956)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — n/a
