### PR TITLE
fix(ci): preserve VM runtime embedding inputs

### DIFF
--- a/.github/workflows/build-vm-driver.yml
+++ b/.github/workflows/build-vm-driver.yml
@@ -67,31 +67,17 @@ jobs:
       - name: Build VM runtime
         run: nix build .#vm-runtime
 
-      - name: Compress Linux VM runtime
-        if: runner.os == 'Linux'
+      - name: Assemble compressed VM runtime
         run: |
-          install -d target/vm-runtime-compressed
-          zstd -19 -T0 result/libkrun.so -o target/vm-runtime-compressed/libkrun.so.zst
-          zstd -19 -T0 result/libkrunfw.so.5 -o target/vm-runtime-compressed/libkrunfw.so.5.zst
-          zstd -19 -T0 result/gvproxy -o target/vm-runtime-compressed/gvproxy.zst
-          zstd -19 -T0 result/umoci -o target/vm-runtime-compressed/umoci.zst
-
-      - name: Compress macOS VM runtime
-        if: runner.os == 'macOS'
-        run: |
-          install -d target/vm-runtime-compressed
-          zstd -19 -T0 result/libkrun.dylib -o target/vm-runtime-compressed/libkrun.dylib.zst
-          zstd -19 -T0 result/libkrunfw.5.dylib -o target/vm-runtime-compressed/libkrunfw.5.dylib.zst
-          zstd -19 -T0 result/gvproxy -o target/vm-runtime-compressed/gvproxy.zst
-          zstd -19 -T0 result/umoci -o target/vm-runtime-compressed/umoci.zst
-
-      - name: Add openshell-sandbox to VM runtime
-        run: zstd -19 -T0 sandbox/openshell-sandbox -o target/vm-runtime-compressed/openshell-sandbox.zst
+          compressed_dir="${RUNNER_TEMP}/vm-runtime-compressed"
+          install -d "$compressed_dir"
+          cp result/compressed/*.zst "$compressed_dir/"
+          zstd -19 -T1 sandbox/openshell-sandbox -o "$compressed_dir/openshell-sandbox.zst"
 
       - name: Build openshell-driver-vm
         uses: ./.github/actions/build-rust-binary
         env:
-          OPENSHELL_VM_RUNTIME_COMPRESSED_DIR: ${{ github.workspace }}/target/vm-runtime-compressed
+          OPENSHELL_VM_RUNTIME_COMPRESSED_DIR: ${{ runner.temp }}/vm-runtime-compressed
         with:
           package: openshell-driver-vm
           binary: openshell-driver-vm

--- a/architecture/build.md
+++ b/architecture/build.md
@@ -174,7 +174,12 @@ Runtime layout:
   `/usr/libexec/openshell/openshell-driver-vm` in Linux packages and published
   as a release artifact. Linux GNU VM driver binaries must not reference
   `GLIBC_*` symbols newer than `GLIBC_2.28`; release workflows verify this
-  before publishing artifacts.
+  before publishing artifacts. Nix produces the platform-specific compressed
+  runtime inputs. CI combines them with the matching supervisor artifact in a
+  runner-temporary directory outside Cargo's `target/` before the shared Rust
+  cache action runs. An explicitly configured VM runtime bundle is required to
+  contain every non-empty embedding input; the driver build fails before
+  packaging when an input is absent or empty.
 - **Supervisor**: Alpine base with `nftables`, static binary at
   `/openshell-sandbox` (musl by default; see `SUPERVISOR_LIBC` above). Static
   linkage keeps the binary usable when the image is mounted/extracted into

--- a/crates/openshell-driver-vm/build.rs
+++ b/crates/openshell-driver-vm/build.rs
@@ -62,24 +62,11 @@ fn main() {
         return;
     };
 
-    if !compressed_dir.is_dir() {
-        println!(
-            "cargo:warning=Compressed runtime dir not found: {}",
-            compressed_dir.display()
-        );
-        println!("cargo:warning=Run: mise run vm:setup && mise run vm:supervisor");
-        generate_stub_resources(
-            &out_dir,
-            &[
-                &format!("{libkrun_name}.zst"),
-                &format!("{libkrunfw_name}.zst"),
-                "gvproxy.zst",
-                "openshell-sandbox.zst",
-                "umoci.zst",
-            ],
-        );
-        return;
-    }
+    assert!(
+        compressed_dir.is_dir(),
+        "Compressed runtime dir not found: {}. Run: mise run vm:setup && mise run vm:supervisor",
+        compressed_dir.display()
+    );
 
     let files = [
         (format!("{libkrun_name}.zst"), format!("{libkrun_name}.zst")),
@@ -95,19 +82,29 @@ fn main() {
         ("umoci.zst".to_string(), "umoci.zst".to_string()),
     ];
 
-    let mut all_found = true;
+    for (src_name, _) in &files {
+        let src_path = compressed_dir.join(src_name);
+        let metadata = fs::metadata(&src_path).unwrap_or_else(|e| {
+            panic!(
+                "Required compressed artifact unavailable: {}: {e}",
+                src_path.display()
+            )
+        });
+        assert!(
+            metadata.is_file(),
+            "Required compressed artifact is not a file: {}",
+            src_path.display()
+        );
+        assert!(
+            metadata.len() != 0,
+            "Required compressed artifact is empty: {}",
+            src_path.display()
+        );
+    }
+
     for (src_name, dst_name) in &files {
         let src_path = compressed_dir.join(src_name);
         let dst_path = out_dir.join(dst_name);
-
-        if !src_path.exists() {
-            println!(
-                "cargo:warning=Missing compressed artifact: {}",
-                src_path.display()
-            );
-            all_found = false;
-            continue;
-        }
 
         if dst_path.exists() {
             let _ = fs::remove_file(&dst_path);
@@ -122,22 +119,6 @@ fn main() {
         });
         let size = fs::metadata(&dst_path).map_or(0, |m| m.len());
         println!("cargo:warning=Embedded {src_name}: {size} bytes");
-    }
-
-    if !all_found {
-        println!(
-            "cargo:warning=Some artifacts missing. Run: mise run vm:setup && mise run vm:supervisor"
-        );
-        generate_stub_resources(
-            &out_dir,
-            &[
-                &format!("{libkrun_name}.zst"),
-                &format!("{libkrunfw_name}.zst"),
-                "gvproxy.zst",
-                "openshell-sandbox.zst",
-                "umoci.zst",
-            ],
-        );
     }
 }
 

--- a/nix/pkgs/vm-runtime.nix
+++ b/nix/pkgs/vm-runtime.nix
@@ -3,6 +3,7 @@
 
 {
   fetchurl,
+  lib,
   stdenv,
   zstd,
 }:
@@ -13,14 +14,32 @@ let
       x86_64-linux = {
         platform = "linux-x86_64";
         hash = "sha256-dw3Lc7IapCyNeE7j6dnlgd/b8Yc91/7IOi3XJORyILQ=";
+        artifacts = [
+          "libkrun.so"
+          "libkrunfw.so.5"
+          "gvproxy"
+          "umoci"
+        ];
       };
       aarch64-linux = {
         platform = "linux-aarch64";
         hash = "sha256-aJDuDb7AsuH9R+AyXA/JIxE9fJmZ5kP0Lkhg6F0Ot5A=";
+        artifacts = [
+          "libkrun.so"
+          "libkrunfw.so.5"
+          "gvproxy"
+          "umoci"
+        ];
       };
       aarch64-darwin = {
         platform = "darwin-aarch64";
         hash = "sha256-BDSeY5XGDozaBZzHTiQQX90jzsSc6shJZs5zdzludX0=";
+        artifacts = [
+          "libkrun.dylib"
+          "libkrunfw.5.dylib"
+          "gvproxy"
+          "umoci"
+        ];
       };
     }
     .${stdenv.hostPlatform.system};
@@ -40,6 +59,13 @@ stdenv.mkDerivation {
 
     mkdir -p "$out"
     tar --extract --file ${archive} --directory "$out"
+
+    mkdir -p "$out/compressed"
+    for artifact in ${lib.escapeShellArgs runtime.artifacts}; do
+      zstd -19 -T1 "$out/$artifact" -o "$out/compressed/$artifact.zst"
+      test -s "$out/compressed/$artifact.zst"
+      zstd --test --quiet "$out/compressed/$artifact.zst"
+    done
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Summary

Preserve the VM driver's embedded runtime and supervisor inputs across Rust
cache restoration.

Move platform-specific runtime compression into the Nix VM runtime package,
assemble the complete bundle outside Cargo's `target/`, and fail the driver
build when a configured embedding input is missing or empty.

This prevents fallback cache restores from producing a buildable but unusable
VM driver.

## Related Issue

Closes #3038

## Changes

- Emit validated zstd-compressed runtime artifacts from `vm-runtime.nix`.
- Assemble the runtime and supervisor under the runner temporary directory.
- Reject missing, non-file, and empty inputs during the VM driver build.
- Document the VM driver artifact assembly boundary.

## Testing

- `nix build --no-link .#vm-runtime`
- Validated all generated frames with `zstd --test`.
- Evaluated `.#packages.aarch64-darwin.vm-runtime.drvPath`.
- Ran Actionlint on `.github/workflows/build-vm-driver.yml`.
- Verified a complete configured bundle passes `cargo check`.
- Verified missing and empty configured inputs fail `cargo check`.
- Verified an unconfigured workspace build retains stub behavior.
- Full PR checks will run in GitHub Actions.

## Checklist

- [x] Follows Conventional Commits
- [x] Commit includes DCO sign-off
- [x] Architecture documentation updated
- [ ] `mise run pre-commit` passes
- [ ] Managed and external-driver VM E2E pass
