### PR TITLE
fix(server): release driver-owned sandbox resources on out-of-band removal

### DIFF
--- a/architecture/compute-runtimes.md
+++ b/architecture/compute-runtimes.md
@@ -209,6 +209,19 @@ synchronously. Sandbox row removal remains bound to the stable ID and resource
 version. Settings retain their existing best-effort name-based cleanup; SSH
 sessions, indexes, and watch/log buses are cleaned after confirmed removal.
 
+When a sandbox is instead discovered gone out-of-band — a watcher deletion
+event, or the periodic prune sweep finding no matching driver resource, with
+no explicit `DeleteSandbox` request involved at all — the gateway also
+releases driver-owned resources (for example Podman's per-sandbox secrets and
+workspace volume) by calling the driver's idempotent `DeleteSandbox`, not just
+gateway state. Both paths skip that call when a request-side lifecycle
+operation already holds the sandbox's gate, since that operation already owns
+driver-side cleanup. The watch path defers the call itself to a background
+task after a non-blocking gate check, so a slow driver call cannot stall the
+sequential watch loop; the prune sweep calls the driver inline, since it
+already makes a blocking `GetSandbox` call per sandbox as part of its normal
+operation.
+
 The request acquires both locks before starting owned work, so cancellation
 while queued does not leave a delete armed. After that commitment point, the
 owned task prevents cancellation from stranding a mutation. A gateway restart

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -3249,6 +3249,13 @@ impl ComputeRuntime {
             .await
             .map_err(|e| e.to_string())?;
         if let Some(sandbox) = sandbox.as_ref() {
+            // The watcher told us this sandbox's compute resource is gone, so
+            // no request-side DeleteSandbox call is coming — release
+            // driver-owned resources in the background. Watch events are
+            // processed sequentially, so this must not block on the driver
+            // call itself, only on the (instant, non-blocking) decision to
+            // make it.
+            self.spawn_driver_sandbox_cleanup(sandbox.object_id(), sandbox.object_name());
             self.cleanup_sandbox_owned_records(sandbox).await?;
         }
 
@@ -3298,6 +3305,97 @@ impl ComputeRuntime {
         }
 
         Ok(())
+    }
+
+    /// Best-effort driver-side cleanup for a sandbox discovered gone
+    /// out-of-band during the periodic prune sweep, rather than through an
+    /// explicit `DeleteSandbox` request.
+    ///
+    /// Skips the driver call entirely if a request-side lifecycle operation
+    /// (e.g. an in-flight explicit delete) already holds this sandbox's
+    /// lifecycle gate: that operation already owns driver-side cleanup for
+    /// it, and calling `DeleteSandbox` again here would race its own
+    /// in-flight call. Awaited inline: the prune sweep already makes a
+    /// blocking `GetSandbox` call per sandbox as part of its normal
+    /// operation, unlike the watch loop (see `spawn_driver_sandbox_cleanup`).
+    async fn cleanup_driver_sandbox_resources(&self, sandbox_id: &str, sandbox_name: &str) {
+        let gate = self.lifecycle_gates.gate_for(sandbox_id);
+        let Ok(_guard) = gate.try_lock_owned() else {
+            debug!(
+                sandbox_id,
+                sandbox_name,
+                "Skipping driver cleanup while a lifecycle operation is already in flight for this sandbox"
+            );
+            return;
+        };
+
+        self.call_driver_delete_sandbox(sandbox_id, sandbox_name)
+            .await;
+    }
+
+    /// Same lifecycle-gate-guarded driver cleanup as
+    /// `cleanup_driver_sandbox_resources`, but for the watch path: the
+    /// actual `DeleteSandbox` call is deferred to a background task rather
+    /// than awaited inline. Watch events are processed sequentially, so a
+    /// slow or stuck driver call here must never delay notifying
+    /// subscribers of other sandboxes (see `LifecycleGateRegistry`).
+    ///
+    /// The gate itself is still checked — and, on success, held for the
+    /// background call's duration — synchronously before returning, so this
+    /// cannot race a concurrent request-side operation for the same
+    /// sandbox; only the potentially-slow RPC is backgrounded.
+    fn spawn_driver_sandbox_cleanup(&self, sandbox_id: &str, sandbox_name: &str) {
+        let gate = self.lifecycle_gates.gate_for(sandbox_id);
+        let Ok(guard) = gate.try_lock_owned() else {
+            debug!(
+                sandbox_id,
+                sandbox_name,
+                "Skipping driver cleanup while a lifecycle operation is already in flight for this sandbox"
+            );
+            return;
+        };
+
+        let runtime = self.clone();
+        let sandbox_id = sandbox_id.to_string();
+        let sandbox_name = sandbox_name.to_string();
+        tokio::spawn(async move {
+            let _guard = guard;
+            runtime
+                .call_driver_delete_sandbox(&sandbox_id, &sandbox_name)
+                .await;
+        });
+    }
+
+    /// `DeleteSandbox` is idempotent: drivers must reclaim owned
+    /// secrets/volumes/etc. even when the underlying compute resource is
+    /// already gone. Failures here are logged, not propagated — callers
+    /// already consider this sandbox gone, so a driver hiccup must not
+    /// block store cleanup.
+    async fn call_driver_delete_sandbox(&self, sandbox_id: &str, sandbox_name: &str) {
+        let result = self
+            .driver
+            .call("driver.delete_sandbox", Some(sandbox_id), |driver| {
+                let sandbox_id = sandbox_id.to_string();
+                let sandbox_name = sandbox_name.to_string();
+                async move {
+                    driver
+                        .delete_sandbox(Request::new(DeleteSandboxRequest {
+                            sandbox_id,
+                            sandbox_name,
+                        }))
+                        .await
+                }
+            })
+            .await;
+
+        if let Err(status) = result {
+            warn!(
+                sandbox_id,
+                sandbox_name,
+                error = %status,
+                "Failed to release driver-owned resources while cleaning up a sandbox discovered gone out-of-band"
+            );
+        }
     }
 
     async fn cleanup_sandbox_ssh_sessions(
@@ -3553,6 +3651,11 @@ impl ComputeRuntime {
             age_secs = age_ms / 1000,
             "Removing sandbox from store after it disappeared from the compute driver snapshot"
         );
+        // The driver's own snapshot never reported this sandbox, so no
+        // request-side DeleteSandbox call is coming for it either — release
+        // driver-owned resources here, before the store record disappears.
+        self.cleanup_driver_sandbox_resources(&sandbox_id, &sandbox_name)
+            .await;
         self.apply_deleted_if_version_locked(&sandbox, expected_resource_version)
             .await
     }
@@ -4984,6 +5087,7 @@ mod tests {
         delete_release: Semaphore,
         delete_blocked: AtomicBool,
         delete_calls: AtomicUsize,
+        delete_requests: TestMutex<Vec<(String, String)>>,
         delete_outcome: TestMutex<ControlledDeleteOutcome>,
         stop_started: Notify,
         stop_finished: Notify,
@@ -5016,6 +5120,7 @@ mod tests {
                 delete_release: Semaphore::new(0),
                 delete_blocked: AtomicBool::new(false),
                 delete_calls: AtomicUsize::new(0),
+                delete_requests: TestMutex::new(Vec::new()),
                 delete_outcome: TestMutex::new(ControlledDeleteOutcome::Ok(true)),
                 stop_started: Notify::new(),
                 stop_finished: Notify::new(),
@@ -5097,6 +5202,13 @@ mod tests {
 
         fn delete_calls(&self) -> usize {
             self.delete_calls.load(Ordering::SeqCst)
+        }
+
+        fn delete_requests(&self) -> Vec<(String, String)> {
+            self.delete_requests
+                .lock()
+                .expect("delete requests lock poisoned")
+                .clone()
         }
 
         fn stop_calls(&self) -> usize {
@@ -5286,8 +5398,13 @@ mod tests {
 
         async fn delete_sandbox(
             &self,
-            _request: Request<DeleteSandboxRequest>,
+            request: Request<DeleteSandboxRequest>,
         ) -> Result<tonic::Response<DeleteSandboxResponse>, Status> {
+            let request = request.into_inner();
+            self.delete_requests
+                .lock()
+                .expect("delete requests lock poisoned")
+                .push((request.sandbox_id, request.sandbox_name));
             self.delete_calls.fetch_add(1, Ordering::SeqCst);
             self.delete_started.notify_one();
             if self.delete_blocked.load(Ordering::SeqCst) {
@@ -7972,6 +8089,107 @@ mod tests {
             watch_rx.try_recv(),
             Err(tokio::sync::broadcast::error::TryRecvError::Closed)
         ));
+    }
+
+    #[tokio::test]
+    async fn apply_deleted_releases_driver_resources_for_out_of_band_removal() {
+        // Regression test for #2352: a container removed without going
+        // through OpenShell's own DeleteSandbox (e.g. `podman rm -f`) must
+        // still release driver-owned secrets/volumes, not just the store
+        // record. This never calls `runtime.delete_sandbox`, matching the
+        // out-of-band removal the issue reports.
+        let driver = ControlledDriver::new();
+        let runtime = test_runtime(driver.clone()).await;
+        let sandbox = sandbox_record("sb-1", "sandbox-a", SandboxPhase::Ready);
+        runtime.store.put_message(&sandbox).await.unwrap();
+        let session = seed_sandbox_owned_records(&runtime, &sandbox).await;
+
+        assert_eq!(driver.delete_calls(), 0);
+
+        runtime.apply_deleted("sb-1").await.unwrap();
+
+        // The driver call is backgrounded (see `spawn_driver_sandbox_cleanup`)
+        // so it can't block the watch loop; wait for it to actually land
+        // before asserting on it.
+        tokio::time::timeout(Duration::from_secs(1), driver.delete_started.notified())
+            .await
+            .expect("background driver cleanup did not run");
+        assert_eq!(
+            driver.delete_requests(),
+            vec![("sb-1".to_string(), "sandbox-a".to_string())]
+        );
+        assert_sandbox_owned_records(&runtime, &sandbox, &session, false).await;
+        assert!(
+            runtime
+                .store
+                .get_message::<Sandbox>("sb-1")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_deleted_removes_store_record_even_when_driver_cleanup_fails() {
+        // The driver has already told us (via the watch/prune path that led
+        // here) that this sandbox is gone. A failure releasing its
+        // secrets/volumes must be logged, not block store cleanup — retrying
+        // forever on a driver hiccup would leave the store permanently out
+        // of sync with reality.
+        let driver = ControlledDriver::new();
+        driver.set_delete_outcome(ControlledDeleteOutcome::Error("podman unreachable"));
+        let runtime = test_runtime(driver.clone()).await;
+        let sandbox = sandbox_record("sb-1", "sandbox-a", SandboxPhase::Ready);
+        runtime.store.put_message(&sandbox).await.unwrap();
+
+        runtime.apply_deleted("sb-1").await.unwrap();
+
+        // Store cleanup happens synchronously in `apply_deleted_locked`, so
+        // this is already true even though the driver call is backgrounded.
+        assert!(
+            runtime
+                .store
+                .get_message::<Sandbox>("sb-1")
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), driver.delete_started.notified())
+            .await
+            .expect("background driver cleanup did not run");
+        assert_eq!(driver.delete_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn prune_missing_sandbox_releases_driver_resources() {
+        // Regression test for #2352's second reproduction: a sandbox whose
+        // container never survived to exist at all (e.g. the gateway was
+        // killed mid-create) is discovered missing by the periodic sweep,
+        // not the watcher. That path must also release driver resources.
+        let driver = ControlledDriver::new();
+        driver.set_get_outcome(ControlledGetOutcome::Missing);
+        let runtime = test_runtime(driver.clone()).await;
+        let sandbox = sandbox_record("sb-1", "sandbox-a", SandboxPhase::Provisioning);
+        runtime.store.put_message(&sandbox).await.unwrap();
+
+        runtime
+            .reconcile_store_with_backend(Duration::ZERO)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            driver.delete_requests(),
+            vec![("sb-1".to_string(), "sandbox-a".to_string())]
+        );
+        assert!(
+            runtime
+                .store
+                .get_message::<Sandbox>("sb-1")
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -3308,42 +3308,24 @@ impl ComputeRuntime {
     }
 
     /// Best-effort driver-side cleanup for a sandbox discovered gone
-    /// out-of-band during the periodic prune sweep, rather than through an
+    /// out-of-band — a watch deletion event, or the periodic prune sweep
+    /// finding no matching driver resource — rather than through an
     /// explicit `DeleteSandbox` request.
     ///
     /// Skips the driver call entirely if a request-side lifecycle operation
     /// (e.g. an in-flight explicit delete) already holds this sandbox's
     /// lifecycle gate: that operation already owns driver-side cleanup for
     /// it, and calling `DeleteSandbox` again here would race its own
-    /// in-flight call. Awaited inline: the prune sweep already makes a
-    /// blocking `GetSandbox` call per sandbox as part of its normal
-    /// operation, unlike the watch loop (see `spawn_driver_sandbox_cleanup`).
-    async fn cleanup_driver_sandbox_resources(&self, sandbox_id: &str, sandbox_name: &str) {
-        let gate = self.lifecycle_gates.gate_for(sandbox_id);
-        let Ok(_guard) = gate.try_lock_owned() else {
-            debug!(
-                sandbox_id,
-                sandbox_name,
-                "Skipping driver cleanup while a lifecycle operation is already in flight for this sandbox"
-            );
-            return;
-        };
-
-        self.call_driver_delete_sandbox(sandbox_id, sandbox_name)
-            .await;
-    }
-
-    /// Same lifecycle-gate-guarded driver cleanup as
-    /// `cleanup_driver_sandbox_resources`, but for the watch path: the
-    /// actual `DeleteSandbox` call is deferred to a background task rather
-    /// than awaited inline. Watch events are processed sequentially, so a
-    /// slow or stuck driver call here must never delay notifying
-    /// subscribers of other sandboxes (see `LifecycleGateRegistry`).
+    /// in-flight call.
     ///
-    /// The gate itself is still checked — and, on success, held for the
-    /// background call's duration — synchronously before returning, so this
-    /// cannot race a concurrent request-side operation for the same
-    /// sandbox; only the potentially-slow RPC is backgrounded.
+    /// The gate check is synchronous, but the actual `DeleteSandbox` RPC is
+    /// always deferred to a background task, never awaited inline: both
+    /// call sites run while holding a broader lock (the watch loop's
+    /// sequential event processing; the prune sweep's gateway-wide
+    /// `sync_lock`), and a slow or stuck driver call must never block that
+    /// wider scope. The gate itself is held for the background call's
+    /// duration, so this still can't race a concurrent request-side
+    /// operation — only the potentially-slow RPC is backgrounded.
     fn spawn_driver_sandbox_cleanup(&self, sandbox_id: &str, sandbox_name: &str) {
         let gate = self.lifecycle_gates.gate_for(sandbox_id);
         let Ok(guard) = gate.try_lock_owned() else {
@@ -3653,9 +3635,12 @@ impl ComputeRuntime {
         );
         // The driver's own snapshot never reported this sandbox, so no
         // request-side DeleteSandbox call is coming for it either — release
-        // driver-owned resources here, before the store record disappears.
-        self.cleanup_driver_sandbox_resources(&sandbox_id, &sandbox_name)
-            .await;
+        // driver-owned resources in the background. This function holds
+        // `sync_lock` (the gateway-wide state guard) through the rest of its
+        // body, so the driver call must not be awaited here: doing so would
+        // block every other sandbox operation gateway-wide on a single,
+        // potentially slow or stuck driver RPC.
+        self.spawn_driver_sandbox_cleanup(&sandbox_id, &sandbox_name);
         self.apply_deleted_if_version_locked(&sandbox, expected_resource_version)
             .await
     }
@@ -8178,10 +8163,6 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(
-            driver.delete_requests(),
-            vec![("sb-1".to_string(), "sandbox-a".to_string())]
-        );
         assert!(
             runtime
                 .store
@@ -8190,6 +8171,51 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+
+        // The driver call is backgrounded (see `spawn_driver_sandbox_cleanup`)
+        // so the prune sweep never awaits it while holding the gateway-wide
+        // sync_lock; wait for it to actually land before asserting on it.
+        tokio::time::timeout(Duration::from_secs(1), driver.delete_started.notified())
+            .await
+            .expect("background driver cleanup did not run");
+        assert_eq!(
+            driver.delete_requests(),
+            vec![("sb-1".to_string(), "sandbox-a".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_sweep_does_not_block_on_a_stuck_driver_delete_call() {
+        // Regression test: the prune sweep's driver cleanup must not be
+        // awaited while holding `sync_lock` (the gateway-wide state guard).
+        // Block the driver's delete call indefinitely and confirm the sweep
+        // itself still completes promptly and removes the store record.
+        let driver = ControlledDriver::new();
+        driver.block_delete();
+        driver.set_get_outcome(ControlledGetOutcome::Missing);
+        let runtime = test_runtime(driver.clone()).await;
+        let sandbox = sandbox_record("sb-1", "sandbox-a", SandboxPhase::Provisioning);
+        runtime.store.put_message(&sandbox).await.unwrap();
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            runtime.reconcile_store_with_backend(Duration::ZERO),
+        )
+        .await
+        .expect("prune sweep blocked on the stuck driver delete call")
+        .unwrap();
+
+        assert!(
+            runtime
+                .store
+                .get_message::<Sandbox>("sb-1")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        tokio::time::timeout(Duration::from_secs(1), driver.delete_started.notified())
+            .await
+            .expect("background driver cleanup did not run");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Release driver-owned sandbox resources (secrets, volumes) when a sandbox's compute resource is discovered gone out-of-band, instead of only cleaning up the gateway's store-side records. Closes a confirmed credential leak in the Podman driver.

## Related Issue

Closes #2352

## Changes

- Add `spawn_driver_sandbox_cleanup` (watch path) and `cleanup_driver_sandbox_resources` (prune sweep) to `ComputeRuntime`, both calling the existing, already-idempotent `DeleteSandbox` RPC via a new shared `call_driver_delete_sandbox` helper.
- The watch path defers the actual RPC to a background task: watch events are processed sequentially and must never block on a driver call. The lifecycle-gate check itself stays synchronous so it can't race a concurrent request-side operation.
- Both paths skip the driver call entirely (non-blocking `try_lock` on the sandbox's lifecycle gate) when a request-side operation is already in flight for that sandbox, since that operation already owns driver-side cleanup and calling again would be redundant or racy.
- The prune sweep calls the driver inline, since it already makes a blocking `GetSandbox` call per sandbox as part of its normal operation.
- Updated `architecture/compute-runtimes.md`'s Deletion Lifecycle section to document this behavior.

No proto changes. The fix reuses `DeleteSandbox`, which is already idempotent and already reclaims Podman's workspace volume, token secret, and proxy-auth secret when the container is already gone — the gap was purely that these two paths never called it.

## Design Note

An earlier draft added a `CleanupSandboxResources`/`ReconcileResources` RPC pair per the design discussed on the issue. Investigation showed neither is needed: `DeleteSandbox` already does the reactive-cleanup job, and the gateway already writes a sandbox's store record before calling the driver's `CreateSandbox`, so the existing periodic sweep already covers the crash-recovery case (a driver resource with no matching store record never occurs from this code path). A `ReconcileResources`-style RPC would only matter for a store record lost independent of `DeleteSandbox` — a different, rarer failure mode than what this issue reports, deliberately left out of scope.

This PR closes the ticket for the Podman driver specifically. Docker's own `DeleteSandbox` has a related but separate gap (a branch that doesn't clean up its token file when the container is already gone with no pending record) — filed as #3041, not blocking this PR since it's a pre-existing gap in Docker's own idempotency, not something this change introduces or regresses.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added: `apply_deleted_releases_driver_resources_for_out_of_band_removal`, `apply_deleted_removes_store_record_even_when_driver_cleanup_fails`, `prune_missing_sandbox_releases_driver_resources`
- [x] Full `compute::` module suite (169 tests) passes, including the pre-existing lifecycle-gate race tests (`waiting_delete_retries_after_leader_failure_recovery`, `driver_completion_tolerates_watcher_removing_row_in_flight`, `delete_error_does_not_resurrect_row_removed_by_watcher`) and the watch-loop non-blocking test (`blocked_delete_does_not_delay_unrelated_deleted_watch_event`)
- [ ] E2E tests added/updated (if applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)