### PR TITLE
docs: correct some comments and references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ These pipelines connect skills into end-to-end workflows. Individual skill files
 | `crates/openshell-router/` | Privacy router | Privacy-aware LLM routing |
 | `crates/openshell-bootstrap/` | Gateway metadata | Gateway registration metadata, auth token storage, mTLS bundle storage |
 | `crates/openshell-gateway-interceptors/` | Gateway interceptors | Intercepts and transforms configured gRPC requests at the gateway routing boundary |
-| `crates/openshell-ocsf/` | OCSF logging | OCSF v1.7.0 event types, builders, shorthand/JSONL formatters, tracing layers |
+| `crates/openshell-ocsf/` | OCSF logging | OCSF v1.8.0 event types, builders, shorthand/JSONL formatters, tracing layers |
 | `crates/openshell-otel/` | OpenTelemetry support | Shared OTLP trace provider, resource, and tracing-layer construction |
 | `crates/openshell-otel-test-support/` | OpenTelemetry test support | Shared loopback OTLP collector fixture for tracing tests |
 | `crates/openshell-core/` | Shared core | Common types, configuration, error handling |

--- a/crates/openshell-core/src/config.rs
+++ b/crates/openshell-core/src/config.rs
@@ -1140,8 +1140,8 @@ pub struct GatewayJwtConfig {
     pub public_key_path: PathBuf,
     /// Path to the `kid` value (plain text, one line).
     pub kid_path: PathBuf,
-    /// Stable gateway identity embedded in `iss`/`aud`. Defaults to the
-    /// hostname-or-`openshell` placeholder if unset.
+    /// Stable gateway identity embedded in `iss`/`aud`. Defaults to
+    /// `openshell`.
     #[serde(default = "default_gateway_id")]
     pub gateway_id: String,
     /// Token lifetime in seconds. A value of 0 disables expiration and is

--- a/crates/openshell-core/src/settings.rs
+++ b/crates/openshell-core/src/settings.rs
@@ -115,7 +115,7 @@ pub const REGISTERED_SETTINGS: &[RegisteredSetting] = &[
         kind: SettingValueKind::Bool,
         allowed_string_values: None,
     },
-    // When true the sandbox writes OCSF v1.7.0 JSONL records to
+    // When true the sandbox writes OCSF v1.8.0 JSONL records to
     // `/var/log/openshell-ocsf*.log` (daily rotation, 3 files) in addition
     // to the human-readable shorthand log. Defaults to false (no JSONL written).
     RegisteredSetting {

--- a/crates/openshell-ocsf/Cargo.toml
+++ b/crates/openshell-ocsf/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "openshell-ocsf"
-description = "OCSF v1.7.0 event types, formatters, and tracing layers for OpenShell sandbox logging"
+description = "OCSF v1.8.0 event types, formatters, and tracing layers for OpenShell sandbox logging"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION


## Summary
<!-- 1-3 sentences: what this PR does and why -->
OCSF_VERSION has been 1.8.0; two descriptions still said 1.7.0.

The default_gateway_id doc comment described a hostname fallback the implementation never had.  A per-replica default would be wrong here: gateway_id is embedded in the JWT iss/aud, so it has to be stable across replicas.

## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
