### PR TITLE
fix(kubernetes): prevent stop-start relay race

### DIFF
--- a/crates/openshell-driver-kubernetes/README.md
+++ b/crates/openshell-driver-kubernetes/README.md
@@ -79,9 +79,9 @@ its pod. The driver sets `spec.operatingMode: Suspended` for `v1beta1` or
 `spec.replicas: 0` for `v1alpha1`. Start sets `Running` or one replica for the
 same resource, so the replacement pod mounts the existing claim. Delete is the
 only lifecycle operation that removes the Sandbox resource and its owned
-storage. The driver confirms the stop from the published `Suspended`
-condition when available. Legacy `v1alpha1` controllers omit a zero replica
-count from status, so the driver confirms that their backing pod is gone.
+storage. The driver confirms the stop from both the published `Suspended`
+condition and deletion of the backing pod. Legacy `v1alpha1` controllers omit
+a usable stopped condition, so pod deletion alone confirms their stop.
 
 The workspace PVC size defaults to `workspace_default_storage_size`. Set
 `workspace_storage_class` to pin the PVC to a specific `StorageClass`; an empty

--- a/crates/openshell-driver-kubernetes/src/driver.rs
+++ b/crates/openshell-driver-kubernetes/src/driver.rs
@@ -1623,8 +1623,7 @@ impl KubernetesComputeDriver {
         let (agent_sandbox_api, kube_name, pod_name, namespace, stop_timeout) = self
             .patch_sandbox_operating_state(sandbox_id, false)
             .await?;
-        let legacy_pod_api = (agent_sandbox_api.resource.version == SANDBOX_VERSION_V1ALPHA1)
-            .then(|| Api::<Pod>::namespaced(self.client.clone(), &namespace));
+        let pod_api = Api::<Pod>::namespaced(self.client.clone(), &namespace);
 
         let deadline = tokio::time::Instant::now() + stop_timeout;
         let mut poll_interval = STOP_INITIAL_POLL_INTERVAL;
@@ -1649,17 +1648,18 @@ impl KubernetesComputeDriver {
                 ))
             })?
             .map_err(KubernetesDriverError::from_kube)?;
-            if kubernetes_sandbox_has_stopped_condition(&object) {
-                return Ok(());
-            }
             if let Some(error) = kubernetes_sandbox_stop_failure(&object) {
                 return Err(KubernetesDriverError::Message(error));
             }
-            if let Some(pod_api) = legacy_pod_api.as_ref()
-                && kubernetes_sandbox_pod_is_gone(pod_api, &pod_name, deadline)
-                    .await
-                    .map_err(KubernetesDriverError::Message)?
-            {
+            let pod_is_gone = kubernetes_sandbox_pod_is_gone(&pod_api, &pod_name, deadline)
+                .await
+                .map_err(KubernetesDriverError::Message)?;
+            let stop_is_complete = kubernetes_sandbox_stop_is_complete(
+                &agent_sandbox_api.resource.version,
+                &object,
+                pod_is_gone,
+            );
+            if stop_is_complete {
                 return Ok(());
             }
             let now = tokio::time::Instant::now();
@@ -4560,6 +4560,19 @@ fn kubernetes_sandbox_has_stopped_condition(obj: &DynamicObject) -> bool {
         })
 }
 
+fn kubernetes_sandbox_stop_is_complete(
+    api_version: &str,
+    obj: &DynamicObject,
+    pod_is_gone: bool,
+) -> bool {
+    if api_version == SANDBOX_VERSION_V1ALPHA1 {
+        // v1alpha1 omits a usable stopped condition.
+        pod_is_gone
+    } else {
+        kubernetes_sandbox_has_stopped_condition(obj) && pod_is_gone
+    }
+}
+
 fn kubernetes_sandbox_stop_failure(obj: &DynamicObject) -> Option<String> {
     obj.data
         .get("status")?
@@ -5390,6 +5403,43 @@ mod tests {
             }
         });
         assert!(kubernetes_sandbox_has_stopped_condition(&sandbox));
+    }
+
+    #[test]
+    fn beta_stop_requires_suspended_condition_and_deleted_pod() {
+        let resource = ApiResource::from_gvk(&GroupVersionKind::gvk(
+            SANDBOX_GROUP,
+            SANDBOX_VERSION_V1BETA1,
+            SANDBOX_KIND,
+        ));
+        let mut sandbox = DynamicObject::new("sandbox", &resource);
+
+        assert!(!kubernetes_sandbox_stop_is_complete(
+            SANDBOX_VERSION_V1BETA1,
+            &sandbox,
+            true,
+        ));
+
+        sandbox.data = serde_json::json!({
+            "status": {
+                "conditions": [{"type": "Suspended", "status": "True"}]
+            }
+        });
+        assert!(!kubernetes_sandbox_stop_is_complete(
+            SANDBOX_VERSION_V1BETA1,
+            &sandbox,
+            false,
+        ));
+        assert!(kubernetes_sandbox_stop_is_complete(
+            SANDBOX_VERSION_V1BETA1,
+            &sandbox,
+            true,
+        ));
+        assert!(kubernetes_sandbox_stop_is_complete(
+            SANDBOX_VERSION_V1ALPHA1,
+            &DynamicObject::new("sandbox", &resource),
+            true,
+        ));
     }
 
     #[test]

--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -3183,6 +3183,17 @@ impl ComputeRuntime {
         else {
             return Ok(());
         };
+        let phase = SandboxPhase::try_from(sandbox.phase()).unwrap_or(SandboxPhase::Unknown);
+        if matches!(
+            phase,
+            SandboxPhase::Deleting | SandboxPhase::Stopping | SandboxPhase::Stopped
+        ) {
+            // Lifecycle shutdown intentionally discards the canonical process
+            // result. Finalization must still acknowledge that discarded
+            // result so the supervisor can exit before the compute backend's
+            // termination grace period expires.
+            return Ok(());
+        }
         let Some(status) = sandbox.status.as_ref() else {
             return Err("main-process exit has not been reported".to_string());
         };
@@ -5600,6 +5611,10 @@ mod tests {
                 .main_process_exited(id, "instance-1", 143)
                 .await
                 .unwrap();
+            runtime
+                .finalize_main_process_exit(id, "instance-1")
+                .await
+                .expect("intentional shutdown finalization should be acknowledged");
 
             let stored = runtime
                 .store

--- a/docs/reference/sandbox-compute-drivers.mdx
+++ b/docs/reference/sandbox-compute-drivers.mdx
@@ -436,7 +436,9 @@ The Kubernetes driver creates namespaced `agents.x-k8s.io` `Sandbox` resources f
 Stop patches the existing resource rather than deleting it. For `v1beta1`,
 the driver sets `spec.operatingMode` to `Suspended` or `Running`. For
 `v1alpha1`, it sets `spec.replicas` to `0` or `1`. The Sandbox resource and its
-workspace PVC keep their identity across both operations.
+workspace PVC keep their identity across both operations. Stop returns only
+after the controller reports suspension and deletes the old pod, so an
+immediate start cannot race the prior pod's termination.
 
 If Agent Sandbox is upgraded in place, restart the OpenShell gateway after the controller and CRD rollout completes so the gateway can detect the served API versions again.
 


### PR DESCRIPTION
## Summary

Fix a Kubernetes v1beta1 stop/start race that allowed a sandbox to report `Stopped` and restart while its previous pod was still terminating. The old supervisor could then close the newly claimed exec relay before reporting an exit status.

The regression was exposed by #2884: intentional lifecycle shutdown discards the canonical process exit result, but the new terminal-finalization loop treated that discarded result as unfinalized and retried until Kubernetes exhausted its 30-second termination grace period.

### Affected CI evidence

Each linked job failed in `sandbox_stop_start_preserves_workspace` with `exec relay closed before the command reported an exit status`:

- [PR #3040](https://github.com/NVIDIA/OpenShell/actions/runs/33411156091/job/99553454179)
- [PR #3040 merge queue](https://github.com/NVIDIA/OpenShell/actions/runs/33411931593/job/99556734218)
- [PR #2823](https://github.com/NVIDIA/OpenShell/actions/runs/33429217548/job/99620439577)
- [PR #2643](https://github.com/NVIDIA/OpenShell/actions/runs/33426019324/job/99602448372)
- [PR #3042](https://github.com/NVIDIA/OpenShell/actions/runs/33422088329/job/99589358407)
- [PR #2962](https://github.com/NVIDIA/OpenShell/actions/runs/33429266845/job/99623760630)

## Related Issue

No issue required: this is a localized regression fix with an existing deterministic lifecycle E2E test and CI evidence across unrelated PRs.

## Changes

- Acknowledge main-process finalization during intentional `Deleting`, `Stopping`, and `Stopped` lifecycle transitions so the supervisor can terminate promptly.
- Require both `Suspended=True` and deletion of the old pod before a Kubernetes v1beta1 stop completes.
- Preserve the v1alpha1 fallback, where pod deletion alone is the usable stop-completion signal.
- Add unit coverage for the finalization and stop-completion invariants.
- Document the stronger Kubernetes stop contract in the driver and published compute-driver reference.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [x] Existing Kubernetes lifecycle E2E regression coverage exercised
- [x] `cargo test -p openshell-driver-kubernetes --lib` (228 passed)
- [x] `OPENSHELL_E2E_KUBE_TEST=sandbox_lifecycle mise run e2e:kubernetes` (7 passed, including `sandbox_stop_start_preserves_workspace`)

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; driver and published behavior references updated)
