### PR TITLE
test: backfill coverage for OCSF logging

### DIFF
--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -7117,6 +7117,10 @@ pub async fn sandbox_logs(
 }
 
 fn print_log_line(log: &openshell_core::proto::SandboxLogLine) {
+    println!("{}", format_log_line(log));
+}
+
+fn format_log_line(log: &openshell_core::proto::SandboxLogLine) -> String {
     let source = if log.source.is_empty() {
         "gateway"
     } else {
@@ -7125,10 +7129,10 @@ fn print_log_line(log: &openshell_core::proto::SandboxLogLine) {
     let secs = log.timestamp_ms / 1000;
     let millis = log.timestamp_ms % 1000;
     if log.fields.is_empty() {
-        println!(
+        format!(
             "[{secs}.{millis:03}] [{source:<7}] [{:<5}] [{}] {}",
             log.level, log.target, log.message
-        );
+        )
     } else {
         let mut fields_str = String::new();
         let mut entries: Vec<_> = log.fields.iter().collect();
@@ -7141,10 +7145,10 @@ fn print_log_line(log: &openshell_core::proto::SandboxLogLine) {
             fields_str.push('=');
             fields_str.push_str(v);
         }
-        println!(
+        format!(
             "[{secs}.{millis:03}] [{source:<7}] [{:<5}] [{}] {} {}",
             log.level, log.target, log.message, fields_str
-        );
+        )
     }
 }
 
@@ -7509,7 +7513,7 @@ fn format_endpoint(endpoint: &openshell_core::proto::NetworkEndpoint) -> String 
 mod tests {
     use super::{
         PolicyGetView, ProvisioningStep, build_sandbox_resource_limits,
-        dockerfile_sources_supported_for_gateway, format_endpoint,
+        dockerfile_sources_supported_for_gateway, format_endpoint, format_log_line,
         format_provider_attachment_table, git_sync_files, has_main_process_result,
         inferred_provider_type, parse_cli_setting_value, parse_credential_expiry_cli_value,
         parse_credential_expiry_pairs, parse_credential_pairs, parse_driver_config_json,
@@ -8973,5 +8977,107 @@ mod tests {
         assert_eq!(json["policy_source"], "sandbox");
         assert!(json["revision"].is_null());
         assert!(json["policy"].is_null());
+    }
+
+    fn log_line(
+        level: &str,
+        target: &str,
+        message: &str,
+        source: &str,
+        fields: &[(&str, &str)],
+    ) -> openshell_core::proto::SandboxLogLine {
+        openshell_core::proto::SandboxLogLine {
+            sandbox_id: "sb-1".to_string(),
+            timestamp_ms: 1_234_567,
+            level: level.to_string(),
+            target: target.to_string(),
+            message: message.to_string(),
+            source: source.to_string(),
+            fields: fields
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn format_log_line_without_fields() {
+        let log = log_line("INFO", "openshell_server", "hello world", "sandbox", &[]);
+        assert_eq!(
+            format_log_line(&log),
+            "[1234.567] [sandbox] [INFO ] [openshell_server] hello world"
+        );
+    }
+
+    #[test]
+    fn format_log_line_empty_source_defaults_to_gateway() {
+        let log = log_line("WARN", "t", "msg", "", &[]);
+        assert_eq!(
+            format_log_line(&log),
+            "[1234.567] [gateway] [WARN ] [t] msg"
+        );
+    }
+
+    #[test]
+    fn format_log_line_pads_source_and_level() {
+        let log = log_line("OCSF", "ocsf", "NET:OPEN", "gateway", &[]);
+        assert_eq!(
+            format_log_line(&log),
+            "[1234.567] [gateway] [OCSF ] [ocsf] NET:OPEN"
+        );
+
+        let short_source = log_line("ERROR", "t", "m", "vm", &[]);
+        assert_eq!(
+            format_log_line(&short_source),
+            "[1234.567] [vm     ] [ERROR] [t] m"
+        );
+    }
+
+    #[test]
+    fn format_log_line_sorts_fields_alphabetically() {
+        let log = log_line(
+            "INFO",
+            "ocsf",
+            "CONNECT",
+            "sandbox",
+            &[("dst_port", "443"), ("action", "allow"), ("dst_host", "x")],
+        );
+        assert_eq!(
+            format_log_line(&log),
+            "[1234.567] [sandbox] [INFO ] [ocsf] CONNECT action=allow dst_host=x dst_port=443"
+        );
+    }
+
+    #[test]
+    fn format_log_line_keeps_empty_field_values() {
+        let log = log_line("INFO", "t", "m", "sandbox", &[("a", ""), ("b", "1")]);
+        assert_eq!(
+            format_log_line(&log),
+            "[1234.567] [sandbox] [INFO ] [t] m a= b=1"
+        );
+    }
+
+    #[test]
+    fn format_log_line_renders_empty_target_as_empty_brackets() {
+        let log = log_line("INFO", "", "m", "sandbox", &[]);
+        assert_eq!(format_log_line(&log), "[1234.567] [sandbox] [INFO ] [] m");
+    }
+
+    #[test]
+    fn format_log_line_zero_pads_millis() {
+        let mut log = log_line("INFO", "t", "m", "sandbox", &[]);
+        log.timestamp_ms = 1_000_007;
+        assert_eq!(format_log_line(&log), "[1000.007] [sandbox] [INFO ] [t] m");
+
+        log.timestamp_ms = 0;
+        assert_eq!(format_log_line(&log), "[0.000] [sandbox] [INFO ] [t] m");
+    }
+
+    #[test]
+    fn format_log_line_preserves_message_verbatim() {
+        // OCSF shorthand must pass through unchanged.
+        let message = "NET:OPEN [MED] DENIED /usr/bin/curl(4711) -> api.example.com:443";
+        let log = log_line("OCSF", "ocsf", message, "sandbox", &[]);
+        assert!(format_log_line(&log).ends_with(message));
     }
 }

--- a/crates/openshell-ocsf/tests/roundtrip.rs
+++ b/crates/openshell-ocsf/tests/roundtrip.rs
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `OcsfEvent` JSON round-trip fidelity.
+//!
+//! `Serialize` is written by hand and `Deserialize` dispatches on `class_uid`
+//! into independent per-variant paths, so a field can serialize correctly and
+//! still be dropped or rejected on the way back in.
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use openshell_ocsf::{
+    ActionId, ActivityId, AiModel, ApiActivityBuilder, AppLifecycleBuilder, Attack, AuthTypeId,
+    BaseEventBuilder, ConfidenceId, ConfigStateChangeBuilder, ConnectionInfo,
+    DetectionFindingBuilder, DispositionId, Endpoint, FindingInfo, HttpActivityBuilder, HttpMethod,
+    HttpRequest, HttpResponse, LaunchTypeId, NetworkActivityBuilder, OcsfEvent, Process,
+    ProcessActivityBuilder, RiskLevelId, SandboxContext, SecurityLevelId, SeverityId,
+    SshActivityBuilder, StateId, StatusId, Url,
+};
+
+fn ctx() -> SandboxContext {
+    SandboxContext {
+        sandbox_id: "sb-7f3a9c2e14b8".to_string(),
+        sandbox_name: "agent-workspace-01".to_string(),
+        container_image: "ghcr.io/nvidia/openshell/sandbox:0.42.1".to_string(),
+        hostname: "openshell-sb-7f3a9c2e14b8".to_string(),
+        product_version: "0.42.1".to_string(),
+        proxy_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+        proxy_port: 8888,
+    }
+}
+
+/// Assert an event survives `to_json -> from_value -> to_json` unchanged.
+fn assert_round_trips(label: &str, event: &OcsfEvent) {
+    let json = event.to_json().expect("serialize");
+
+    let decoded: OcsfEvent = serde_json::from_value(json.clone())
+        .unwrap_or_else(|e| panic!("{label}: deserialize failed: {e}\njson: {json}"));
+
+    let reserialized = decoded.to_json().expect("re-serialize");
+    assert_eq!(
+        json, reserialized,
+        "{label}: JSON changed across round trip"
+    );
+}
+
+#[test]
+fn network_activity_round_trips() {
+    let event = NetworkActivityBuilder::new(&ctx())
+        .activity(ActivityId::Open)
+        .activity_name("Open")
+        .action(ActionId::Denied)
+        .disposition(DispositionId::Blocked)
+        .severity(SeverityId::Medium)
+        .status(StatusId::Failure)
+        .dst_endpoint(Endpoint::from_domain("api.example.com", 443))
+        .src_endpoint_addr(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)), 51234)
+        .actor_process(
+            Process::new("/usr/bin/curl", 4711)
+                .with_cmd_line("curl -sS https://api.example.com")
+                .with_parent(Process::new("/bin/bash", 4700)),
+        )
+        .firewall_rule("default-deny-egress", "opa")
+        .connection_info(ConnectionInfo::new("tcp"))
+        .observation_point(3)
+        .status_detail("blocked by egress policy")
+        .log_source("/dev/kmsg")
+        .message("CONNECT denied api.example.com:443")
+        .unmapped("policy_version", 42)
+        .unmapped("engine", "opa")
+        .build();
+
+    assert_round_trips("network_activity", &event);
+}
+
+#[test]
+fn http_activity_round_trips() {
+    let event = HttpActivityBuilder::new(&ctx())
+        .activity(ActivityId::Open)
+        .action(ActionId::Allowed)
+        .disposition(DispositionId::Allowed)
+        .severity(SeverityId::Informational)
+        .status(StatusId::Success)
+        .http_request(HttpRequest {
+            http_method: HttpMethod::Post,
+            url: Some(Url::new("https", "api.example.com", "/v1/items", 443)),
+        })
+        .http_response(HttpResponse { code: 201 })
+        .src_endpoint(Endpoint::from_ip(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)),
+            51235,
+        ))
+        .dst_endpoint(Endpoint::from_domain("api.example.com", 443))
+        .actor_process(Process::new("/usr/bin/node", 4712))
+        .firewall_rule("allow-api", "l7")
+        .status_detail("allowed by L7 rule")
+        .message("POST /v1/items 201")
+        .unmapped("l7_decision", "allow")
+        .build();
+
+    assert_round_trips("http_activity", &event);
+}
+
+#[test]
+fn ssh_activity_round_trips() {
+    let event = SshActivityBuilder::new(&ctx())
+        .activity(ActivityId::Open)
+        .auth_type(AuthTypeId::Other, "publickey-nonce")
+        .protocol_ver("SSH-2.0-OpenSSH_9.6")
+        .severity(SeverityId::Informational)
+        .status(StatusId::Success)
+        .src_endpoint_addr(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9)), 44321)
+        .dst_endpoint(Endpoint::from_domain("sandbox.local", 22))
+        .message("ssh session accepted")
+        .build();
+
+    assert_round_trips("ssh_activity", &event);
+}
+
+#[test]
+fn process_activity_round_trips() {
+    let event = ProcessActivityBuilder::new(&ctx())
+        .activity(ActivityId::Open)
+        .process(
+            Process::new("/usr/bin/python3", 4713)
+                .with_cmd_line("python3 -m pytest")
+                .with_parent(Process::new("/bin/sh", 4701)),
+        )
+        .launch_type(LaunchTypeId::Other)
+        .exit_code(0)
+        .severity(SeverityId::Informational)
+        .status(StatusId::Success)
+        .message("process started")
+        .build();
+
+    assert_round_trips("process_activity", &event);
+}
+
+#[test]
+fn detection_finding_round_trips() {
+    let event = DetectionFindingBuilder::new(&ctx())
+        .finding_info(
+            FindingInfo::new("finding-001", "Sandbox bypass attempt")
+                .with_desc("Process attempted to reach the host network directly"),
+        )
+        .severity(SeverityId::High)
+        .is_alert(true)
+        .confidence(ConfidenceId::High)
+        .risk_level(RiskLevelId::High)
+        .attack(Attack::mitre(
+            "T1046",
+            "Network Service Discovery",
+            "TA0007",
+            "Discovery",
+        ))
+        .evidence_pairs(&[("dst_host", "169.254.169.254"), ("dst_port", "80")])
+        .evidence("binary", "/usr/bin/curl")
+        .remediation("Tighten the egress policy for this sandbox")
+        .log_source("/dev/kmsg")
+        .message("bypass attempt detected")
+        .unmapped("detector", "bypass_monitor")
+        .build();
+
+    assert_round_trips("detection_finding", &event);
+}
+
+#[test]
+fn application_lifecycle_round_trips() {
+    let event = AppLifecycleBuilder::new(&ctx())
+        .activity(ActivityId::Open)
+        .severity(SeverityId::Informational)
+        .message("supervisor started")
+        .build();
+
+    assert_round_trips("application_lifecycle", &event);
+}
+
+#[test]
+fn device_config_state_change_round_trips() {
+    let event = ConfigStateChangeBuilder::new(&ctx())
+        .state(StateId::Other, "policy-loaded")
+        .security_level(SecurityLevelId::Secure)
+        .prev_security_level(SecurityLevelId::AtRisk)
+        .severity(SeverityId::Informational)
+        .status(StatusId::Success)
+        .message("policy reloaded")
+        .unmapped("policy_version", 7)
+        .build();
+
+    assert_round_trips("device_config_state_change", &event);
+}
+
+#[test]
+fn api_activity_round_trips() {
+    let event = ApiActivityBuilder::new(&ctx(), "chat.completions")
+        .severity(SeverityId::Informational)
+        .status(StatusId::Success)
+        .http_request(HttpRequest {
+            http_method: HttpMethod::Post,
+            url: Some(Url::new("https", "inference.local", "/v1/chat", 443)),
+        })
+        .dst_endpoint(Endpoint::from_domain("inference.local", 443))
+        .ai_model(AiModel::new("llama-3.1-8b", "nvidia"))
+        .message("inference request routed")
+        .unmapped("route", "system")
+        .build();
+
+    assert_round_trips("api_activity", &event);
+}
+
+#[test]
+fn base_event_round_trips() {
+    let event = BaseEventBuilder::new(&ctx())
+        .activity_name("custom activity")
+        .severity(SeverityId::Low)
+        .message("base event")
+        .unmapped("detail", "value")
+        .build();
+
+    assert_round_trips("base_event", &event);
+}

--- a/crates/openshell-supervisor-process/src/log_push.rs
+++ b/crates/openshell-supervisor-process/src/log_push.rs
@@ -27,16 +27,19 @@ pub struct LogPushLayer {
 
 impl LogPushLayer {
     pub fn new(sandbox_id: String, tx: mpsc::Sender<SandboxLogLine>) -> Self {
-        let max_level = std::env::var("OPENSHELL_LOG_PUSH_LEVEL")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(tracing::Level::INFO);
+        let max_level = parse_max_level(std::env::var("OPENSHELL_LOG_PUSH_LEVEL").ok().as_deref());
         Self {
             sandbox_id,
             tx,
             max_level,
         }
     }
+}
+
+/// Resolve the push level filter, defaulting to `INFO` when unset or unparseable.
+fn parse_max_level(raw: Option<&str>) -> tracing::Level {
+    raw.and_then(|s| s.parse().ok())
+        .unwrap_or(tracing::Level::INFO)
 }
 
 impl<S: Subscriber> Layer<S> for LogPushLayer {
@@ -307,5 +310,211 @@ impl tracing::field::Visit for LogVisitor {
             self.fields
                 .push((field.name().to_string(), format!("{value:?}")));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openshell_ocsf::{
+        ActionId, ActivityId, DispositionId, Endpoint, NetworkActivityBuilder, SandboxContext,
+        SeverityId, StatusId, ocsf_emit,
+    };
+    use tracing_subscriber::layer::SubscriberExt;
+
+    fn ocsf_ctx() -> SandboxContext {
+        SandboxContext {
+            sandbox_id: "sb-test".to_string(),
+            sandbox_name: "test-sandbox".to_string(),
+            container_image: "openshell/sandbox:test".to_string(),
+            hostname: "test-host".to_string(),
+            product_version: "0.0.0".to_string(),
+            proxy_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            proxy_port: 8888,
+        }
+    }
+
+    /// Capture lines emitted by `f` with an `INFO` level filter.
+    fn capture(capacity: usize, f: impl FnOnce()) -> Vec<SandboxLogLine> {
+        let (tx, mut rx) = mpsc::channel::<SandboxLogLine>(capacity);
+        let layer = LogPushLayer {
+            sandbox_id: "sb-test".to_string(),
+            tx,
+            max_level: tracing::Level::INFO,
+        };
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, f);
+
+        let mut out = Vec::new();
+        while let Ok(line) = rx.try_recv() {
+            out.push(line);
+        }
+        out
+    }
+
+    #[test]
+    fn ocsf_events_push_shorthand_with_ocsf_level_and_no_fields() {
+        let event = NetworkActivityBuilder::new(&ocsf_ctx())
+            .activity(ActivityId::Open)
+            .action(ActionId::Denied)
+            .disposition(DispositionId::Blocked)
+            .severity(SeverityId::Medium)
+            .status(StatusId::Failure)
+            .dst_endpoint(Endpoint::from_domain("blocked.example.com", 443))
+            .message("CONNECT denied blocked.example.com:443".to_string())
+            .build();
+        let expected_shorthand = event.format_shorthand();
+
+        let lines = capture(16, || ocsf_emit!(event));
+
+        assert_eq!(lines.len(), 1);
+        let line = &lines[0];
+        assert_eq!(line.level, "OCSF");
+        assert_eq!(line.target, openshell_ocsf::OCSF_TARGET);
+        assert_eq!(line.source, "sandbox");
+        assert_eq!(line.sandbox_id, "sb-test");
+        assert_eq!(line.message, expected_shorthand);
+        assert!(line.fields.is_empty());
+        assert!(line.timestamp_ms > 0);
+    }
+
+    #[test]
+    fn non_ocsf_events_use_visitor_extraction() {
+        let lines = capture(16, || {
+            tracing::info!(target: "test_target", answer = 42, name = "widget", "hello");
+        });
+
+        assert_eq!(lines.len(), 1);
+        let line = &lines[0];
+        assert_eq!(line.level, "INFO");
+        assert_eq!(line.target, "test_target");
+        assert_eq!(line.source, "sandbox");
+        assert_eq!(line.message, "hello");
+        assert_eq!(line.fields.get("name").map(String::as_str), Some("widget"));
+        assert_eq!(line.fields.get("answer").map(String::as_str), Some("42"));
+        assert!(!line.fields.contains_key("message"));
+    }
+
+    #[test]
+    fn events_without_a_message_field_fall_back_to_the_event_name() {
+        let lines = capture(16, || {
+            tracing::info!(target: "test_target", answer = 1);
+        });
+
+        assert_eq!(lines.len(), 1);
+        assert!(
+            lines[0].message.starts_with("event "),
+            "expected event-name fallback, got {:?}",
+            lines[0].message
+        );
+    }
+
+    #[test]
+    fn events_below_the_max_level_are_filtered() {
+        let lines = capture(16, || {
+            tracing::debug!(target: "test_target", "debug line");
+            tracing::trace!(target: "test_target", "trace line");
+            tracing::info!(target: "test_target", "info line");
+            tracing::warn!(target: "test_target", "warn line");
+        });
+
+        let messages: Vec<_> = lines.iter().map(|l| l.message.as_str()).collect();
+        assert_eq!(messages, vec!["info line", "warn line"]);
+    }
+
+    #[test]
+    fn lines_are_dropped_when_the_channel_is_full() {
+        let lines = capture(2, || {
+            for i in 0..3 {
+                tracing::info!(target: "test_target", "line {i}");
+            }
+        });
+
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].message, "line 0");
+        assert_eq!(lines[1].message, "line 1");
+    }
+
+    #[test]
+    fn parse_max_level_defaults_to_info() {
+        assert_eq!(parse_max_level(None), tracing::Level::INFO);
+        assert_eq!(parse_max_level(Some("not-a-level")), tracing::Level::INFO);
+        assert_eq!(parse_max_level(Some("debug")), tracing::Level::DEBUG);
+        assert_eq!(parse_max_level(Some("TRACE")), tracing::Level::TRACE);
+        assert_eq!(parse_max_level(Some("warn")), tracing::Level::WARN);
+    }
+
+    fn test_line(message: &str) -> SandboxLogLine {
+        SandboxLogLine {
+            sandbox_id: "sb-test".to_string(),
+            timestamp_ms: 1,
+            level: "INFO".to_string(),
+            target: "t".to_string(),
+            message: message.to_string(),
+            source: "sandbox".to_string(),
+            fields: std::collections::HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_during_backoff_buffers_up_to_the_cap_and_drops_the_rest() {
+        let (tx, mut rx) = mpsc::channel::<SandboxLogLine>(1024);
+        for i in 0..250 {
+            tx.try_send(test_line(&format!("line {i}"))).unwrap();
+        }
+        drop(tx);
+
+        let mut batch = Vec::new();
+        drain_during_backoff(&mut rx, &mut batch, tokio::time::Duration::from_secs(30)).await;
+
+        assert_eq!(batch.len(), 200);
+        assert_eq!(batch[0].message, "line 0");
+        assert_eq!(batch[199].message, "line 199");
+    }
+
+    #[tokio::test]
+    async fn drain_during_backoff_preserves_an_existing_batch() {
+        let (tx, mut rx) = mpsc::channel::<SandboxLogLine>(16);
+        tx.try_send(test_line("new")).unwrap();
+        drop(tx);
+
+        let mut batch = vec![test_line("buffered")];
+        drain_during_backoff(&mut rx, &mut batch, tokio::time::Duration::from_secs(30)).await;
+
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[0].message, "buffered");
+        assert_eq!(batch[1].message, "new");
+    }
+
+    #[tokio::test]
+    async fn drain_during_backoff_returns_early_when_the_channel_closes() {
+        let (tx, mut rx) = mpsc::channel::<SandboxLogLine>(16);
+        tx.try_send(test_line("last")).unwrap();
+        drop(tx);
+
+        let mut batch = Vec::new();
+        tokio::time::timeout(
+            tokio::time::Duration::from_secs(5),
+            drain_during_backoff(&mut rx, &mut batch, tokio::time::Duration::from_secs(30)),
+        )
+        .await
+        .expect("closed channel should end the backoff drain");
+
+        assert_eq!(batch.len(), 1);
+    }
+
+    #[test]
+    fn log_visitor_into_parts_uses_the_fallback_only_without_a_message() {
+        let visitor = LogVisitor {
+            message: Some("explicit".to_string()),
+            fields: vec![("k".to_string(), "v".to_string())],
+        };
+        let (msg, fields) = visitor.into_parts("fallback");
+        assert_eq!(msg, "explicit");
+        assert_eq!(fields.get("k").map(String::as_str), Some("v"));
+
+        let (msg, fields) = LogVisitor::default().into_parts("fallback");
+        assert_eq!(msg, "fallback");
+        assert!(fields.is_empty());
     }
 }


### PR DESCRIPTION


## Summary
<!-- 1-3 sentences: what this PR does and why -->
This PR is to backfill some tests for upcoming changes to make sure those changes don't break this currently untested behavior.




## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->

Refs #1055

## Changes
<!-- Bullet list of key changes -->
- Pin the `openshell logs` output format, so a change to how that text is produced shows up as a diff rather than passing silently.
- Cover the supervisor log push layer.
- Assert OcsfEvent survives a JSON round trip. Serialization is written by hand and deserialization dispatches on class_uid into independent per-variant paths, so a field can serialize correctly and still be dropped or rejected on the way back in.


## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
