### PR TITLE
feat(cli): add structured output to list commands

### DIFF
--- a/.agents/skills/openshell-cli/SKILL.md
+++ b/.agents/skills/openshell-cli/SKILL.md
@@ -333,9 +333,14 @@ provider instead of passing API keys, tokens, or other secrets to `sandbox exec`
 
 ```bash
 openshell sandbox provider list my-sandbox
+openshell sandbox provider list my-sandbox --output json
 openshell sandbox provider attach my-sandbox my-github
 openshell sandbox provider detach my-sandbox my-github
 ```
+
+Structured attachment output contains provider names, types, and sorted
+credential and config key names. It never contains credential, handle, or
+config values.
 
 ### View logs
 
@@ -498,6 +503,7 @@ View all revisions to understand how the policy evolved:
 
 ```bash
 openshell policy list dev --limit 50
+openshell policy list dev --output json
 ```
 
 Fetch a specific historical revision:
@@ -575,6 +581,17 @@ openshell forward stop 8080 my-app
 openshell sandbox delete my-app
 openshell sandbox create --from ./Dockerfile --name my-app --forward 8080
 ```
+
+Use structured output when automation needs the tracked forward metadata and
+validated process state:
+
+```bash
+openshell forward list --output json
+```
+
+Each record includes `sandbox`, `bind_address`, `port`, `pid`, and `alive`.
+The `alive` boolean validates the tracked process identity; it does not probe
+the forwarded socket.
 
 Create and forward in one command:
 
@@ -738,6 +755,7 @@ openshell forward service my-app --target-port 8000 --local 127.0.0.1:0
 # Expose and manage an HTTP service through the gateway.
 openshell service expose my-app 8080 web
 openshell service list my-app
+openshell service list my-app --output json
 openshell service get my-app web
 openshell service delete my-app web
 ```

--- a/.agents/skills/openshell-cli/cli-reference.md
+++ b/.agents/skills/openshell-cli/cli-reference.md
@@ -57,17 +57,17 @@ openshell
 │   ├── download <name> <path> [dest]
 │   ├── ssh-config [name]
 │   └── provider
-│       ├── list [name]
+│       ├── list [name] [-o table|yaml|json]
 │       ├── attach <name> <provider>
 │       └── detach <name> <provider>
 ├── forward
 │   ├── start <port> [name] [-d]
 │   ├── stop <port> [name]
-│   ├── list
+│   ├── list [-o table|yaml|json]
 │   └── service [name] --target-port <port> [opts]
 ├── service
 │   ├── expose <sandbox> <target-port> [service]
-│   ├── list [sandbox]
+│   ├── list [sandbox] [-o table|yaml|json]
 │   ├── get <sandbox> [service]
 │   └── delete <sandbox> [service]
 ├── logs [name] [opts]
@@ -75,7 +75,7 @@ openshell
 │   ├── set [name] --policy <path> [--global] [--wait]
 │   ├── update [name] [opts]
 │   ├── get [name] [--full|--base] [--global]
-│   ├── list [name] [--global]
+│   ├── list [name] [--global] [-o table|yaml|json]
 │   ├── delete --global
 │   └── prove --policy <path> --credentials <path> [opts]
 ├── settings
@@ -107,6 +107,15 @@ openshell
 │   │   └── delete <id>
 │   ├── update <name> [opts]
 │   └── delete <name>...
+├── workspace
+│   ├── create <name>
+│   ├── get <name>
+│   ├── list [opts]
+│   ├── delete <name>...
+│   └── member
+│       ├── add --workspace <name> --subject <subject> --role <role>
+│       ├── remove --workspace <name> --subject <subject>
+│       └── list --workspace <name> [-o table|yaml|json]
 ├── doctor
 │   └── check
 ├── term
@@ -321,9 +330,12 @@ Print an SSH config `Host` block. The name defaults to the last-used sandbox.
 
 Manage providers on an existing sandbox:
 
-- `openshell sandbox provider list [name]`
+- `openshell sandbox provider list [name] [--output table|yaml|json]`
 - `openshell sandbox provider attach <name> <provider>`
 - `openshell sandbox provider detach <name> <provider>`
+
+Structured list output contains `name`, `type`, and sorted `credential_keys`
+and `config_keys` arrays. It excludes all credential, handle, and config values.
 
 ---
 
@@ -343,9 +355,15 @@ Start forwarding a local port to a sandbox.
 
 Stop a background port forward. When the sandbox name is omitted, it is inferred from active forwards.
 
-### `openshell forward list`
+### `openshell forward list [--output table|yaml|json]`
 
-List all active port forwards (sandbox, port, PID, status).
+List all tracked port forwards. Table output shows the sandbox, bind address,
+port, PID, and status. JSON and YAML output expose `sandbox`, `bind_address`,
+`port`, `pid`, and the boolean `alive`; an empty result is an empty collection.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-o`, `--output <FORMAT>` | `table` | Output format: `table`, `yaml`, or `json` |
 
 ### `openshell forward service [name] --target-port <port>`
 
@@ -364,9 +382,12 @@ Forward a local TCP port to a loopback service inside a sandbox over the gRPC re
 Gateway-managed HTTP service endpoints:
 
 - `openshell service expose <sandbox> <target-port> [service]`
-- `openshell service list [sandbox] [--limit N] [--offset N]`
+- `openshell service list [sandbox] [--limit N] [--offset N] [--output table|yaml|json]`
 - `openshell service get <sandbox> [service]`
 - `openshell service delete <sandbox> [service]`
+
+Structured list records contain `workspace`, `sandbox`, `service`,
+`target_port`, and `url`. Empty lists serialize as empty collections.
 
 ---
 
@@ -454,6 +475,11 @@ List policy revision history (version, hash, status, created, error).
 |------|---------|-------------|
 | `--limit <N>` | 20 | Max revisions to return |
 | `--global` | false | List global policy revisions |
+| `-o`, `--output <FORMAT>` | `table` | Output format: `table`, `yaml`, or `json` |
+
+Structured records use the policy metadata contract from `policy get`: scope,
+sandbox when applicable, version, full hash, normalized status, and available
+timestamps, load error, and provenance.
 
 ### `openshell policy delete --global`
 
@@ -483,6 +509,16 @@ Review agent-authored network rule proposals. This command group is intentionall
 - `openshell rule history [name]`
 
 Sandbox names default to the last-used sandbox. The CLI fetches and submits each proposal's current review token; a changed live candidate remains pending until it is reviewed again. Bulk approval of security-flagged proposals requires explicit `--include-security-flagged`.
+
+---
+
+## Workspace Member Commands
+
+### `openshell workspace member list --workspace <name>`
+
+List workspace members. Add `--output table|yaml|json` to select the format.
+Structured records contain `subject` and a normalized `role` of `admin`,
+`user`, or `unknown`; empty lists serialize as empty collections.
 
 ---
 

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -742,7 +742,7 @@ fn normalize_completion_script(output: Vec<u8>, executable: &std::path::Path) ->
     Ok(script.replace(executable.to_string_lossy().as_ref(), "openshell"))
 }
 
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Clone, Debug, PartialEq, Eq, ValueEnum)]
 enum OutputFormat {
     Table,
     Yaml,
@@ -1691,6 +1691,10 @@ enum SandboxProviderCommands {
         /// Sandbox name (defaults to last-used sandbox).
         #[arg(add = ArgValueCompleter::new(completers::complete_sandbox_names))]
         name: Option<String>,
+
+        /// Output format.
+        #[arg(short = 'o', long = "output", value_enum, default_value_t = OutputFormat::Table)]
+        output: OutputFormat,
     },
 
     /// Attach a provider to a sandbox.
@@ -1905,6 +1909,10 @@ enum PolicyCommands {
         /// List global policy revisions.
         #[arg(long)]
         global: bool,
+
+        /// Output format.
+        #[arg(short = 'o', long = "output", value_enum, default_value_t = OutputFormat::Table)]
+        output: OutputFormat,
     },
 
     /// Delete the gateway-global policy lock, restoring sandbox-level policy control.
@@ -2011,9 +2019,13 @@ enum ForwardCommands {
         name: Option<String>,
     },
 
-    /// List active port forwards.
+    /// List tracked port forwards.
     #[command(help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
-    List,
+    List {
+        /// Output format.
+        #[arg(short = 'o', long = "output", value_enum, default_value_t = OutputFormat::Table)]
+        output: OutputFormat,
+    },
 
     /// Forward a local TCP port to a loopback service inside a sandbox over gRPC.
     #[command(help_template = LEAF_HELP_TEMPLATE, next_help_heading = "FLAGS")]
@@ -2071,6 +2083,10 @@ enum ServiceCommands {
         /// List services across all workspaces (overrides --workspace).
         #[arg(long)]
         all_workspaces: bool,
+
+        /// Output format.
+        #[arg(short = 'o', long = "output", value_enum, default_value_t = OutputFormat::Table)]
+        output: OutputFormat,
     },
 
     /// Show one exposed sandbox service endpoint.
@@ -2195,6 +2211,10 @@ enum WorkspaceMemberCommands {
         /// Offset into the member list.
         #[arg(long, default_value_t = 0)]
         offset: u32,
+
+        /// Output format.
+        #[arg(short = 'o', long = "output", value_enum, default_value_t = OutputFormat::Table)]
+        output: OutputFormat,
     },
 }
 
@@ -2445,8 +2465,23 @@ async fn run_async() -> Result<()> {
                     );
                 }
             }
-            ForwardCommands::List => {
+            ForwardCommands::List { output } => {
                 let forwards = run::list_forwards()?;
+                if openshell_cli::output::print_output_collection(
+                    output.as_str(),
+                    &forwards,
+                    |forward| {
+                        serde_json::json!({
+                            "sandbox": forward.sandbox_name,
+                            "bind_address": forward.bind_addr,
+                            "port": forward.port,
+                            "pid": forward.pid,
+                            "alive": forward.validated_alive,
+                        })
+                    },
+                )? {
+                    return Ok(());
+                }
                 if forwards.is_empty() {
                     eprintln!("No active forwards.");
                 } else {
@@ -2574,6 +2609,7 @@ async fn run_async() -> Result<()> {
                     limit,
                     offset,
                     all_workspaces,
+                    output,
                 } => {
                     run::service_list(
                         &ctx.endpoint,
@@ -2582,6 +2618,7 @@ async fn run_async() -> Result<()> {
                         offset,
                         &cli.workspace,
                         all_workspaces,
+                        output.as_str(),
                         &tls,
                     )
                     .await?;
@@ -2745,14 +2782,28 @@ async fn run_async() -> Result<()> {
                     name,
                     limit,
                     global,
+                    output,
                 } => {
                     if global {
-                        run::sandbox_policy_list_global(&ctx.endpoint, limit, &cli.workspace, &tls)
-                            .await?;
+                        run::sandbox_policy_list_global(
+                            &ctx.endpoint,
+                            limit,
+                            output.as_str(),
+                            &cli.workspace,
+                            &tls,
+                        )
+                        .await?;
                     } else {
                         let name = resolve_sandbox_name(name, &ctx.name, &cli.workspace)?;
-                        run::sandbox_policy_list(&ctx.endpoint, &name, limit, &cli.workspace, &tls)
-                            .await?;
+                        run::sandbox_policy_list(
+                            &ctx.endpoint,
+                            &name,
+                            limit,
+                            output.as_str(),
+                            &cli.workspace,
+                            &tls,
+                        )
+                        .await?;
                     }
                 }
                 PolicyCommands::Delete { global, yes } => {
@@ -3289,10 +3340,16 @@ async fn run_async() -> Result<()> {
                             run::print_ssh_config(&ctx.name, &name, &cli.workspace);
                         }
                         SandboxCommands::Provider(command) => match command {
-                            SandboxProviderCommands::List { name } => {
+                            SandboxProviderCommands::List { name, output } => {
                                 let name = resolve_sandbox_name(name, &ctx.name, &cli.workspace)?;
-                                run::sandbox_provider_list(endpoint, &name, &cli.workspace, &tls)
-                                    .await?;
+                                run::sandbox_provider_list(
+                                    endpoint,
+                                    &name,
+                                    output.as_str(),
+                                    &cli.workspace,
+                                    &tls,
+                                )
+                                .await?;
                             }
                             SandboxProviderCommands::Attach { name, provider } => {
                                 run::sandbox_provider_attach(
@@ -3373,9 +3430,17 @@ async fn run_async() -> Result<()> {
                         workspace,
                         limit,
                         offset,
+                        output,
                     } => {
-                        run::workspace_member_list(endpoint, &workspace, limit, offset, &tls)
-                            .await?;
+                        run::workspace_member_list(
+                            endpoint,
+                            &workspace,
+                            limit,
+                            offset,
+                            output.as_str(),
+                            &tls,
+                        )
+                        .await?;
                     }
                 },
             }
@@ -4525,6 +4590,152 @@ mod tests {
                 }))
             }) if id == "custom-api"
         ));
+    }
+
+    #[test]
+    fn forward_list_default_output_is_table() {
+        let cli = Cli::try_parse_from(["openshell", "forward", "list"])
+            .expect("forward list should parse");
+
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Forward {
+                command: Some(ForwardCommands::List {
+                    output: OutputFormat::Table,
+                })
+            })
+        ));
+    }
+
+    #[test]
+    fn forward_list_accepts_structured_output() {
+        for (format, expected) in [("json", OutputFormat::Json), ("yaml", OutputFormat::Yaml)] {
+            let cli = Cli::try_parse_from(["openshell", "forward", "list", "-o", format])
+                .unwrap_or_else(|error| panic!("forward list -o {format} should parse: {error}"));
+
+            let Some(Commands::Forward {
+                command: Some(ForwardCommands::List { output }),
+            }) = cli.command
+            else {
+                panic!("expected forward list command");
+            };
+            assert_eq!(output, expected, "unexpected output format for {format}");
+        }
+    }
+
+    #[test]
+    fn remaining_list_commands_default_output_to_table() {
+        let sandbox_provider = Cli::try_parse_from(["openshell", "sandbox", "provider", "list"])
+            .expect("sandbox provider list should parse");
+        assert!(matches!(
+            sandbox_provider.command,
+            Some(Commands::Sandbox {
+                command: Some(SandboxCommands::Provider(SandboxProviderCommands::List {
+                    output: OutputFormat::Table,
+                    ..
+                })),
+            })
+        ));
+
+        let policy =
+            Cli::try_parse_from(["openshell", "policy", "list"]).expect("policy list should parse");
+        assert!(matches!(
+            policy.command,
+            Some(Commands::Policy {
+                command: Some(PolicyCommands::List {
+                    output: OutputFormat::Table,
+                    ..
+                }),
+            })
+        ));
+
+        let service = Cli::try_parse_from(["openshell", "service", "list"])
+            .expect("service list should parse");
+        assert!(matches!(
+            service.command,
+            Some(Commands::Service {
+                command: Some(ServiceCommands::List {
+                    output: OutputFormat::Table,
+                    ..
+                }),
+            })
+        ));
+
+        let workspace_member = Cli::try_parse_from([
+            "openshell",
+            "workspace",
+            "member",
+            "list",
+            "--workspace",
+            "default",
+        ])
+        .expect("workspace member list should parse");
+        assert!(matches!(
+            workspace_member.command,
+            Some(Commands::Workspace {
+                command: Some(WorkspaceCommands::Member(WorkspaceMemberCommands::List {
+                    output: OutputFormat::Table,
+                    ..
+                })),
+            })
+        ));
+    }
+
+    #[test]
+    fn remaining_list_commands_accept_structured_output() {
+        for (format, expected) in [("json", OutputFormat::Json), ("yaml", OutputFormat::Yaml)] {
+            let sandbox_provider =
+                Cli::try_parse_from(["openshell", "sandbox", "provider", "list", "-o", format])
+                    .unwrap_or_else(|error| panic!("sandbox provider list -o {format}: {error}"));
+            let Some(Commands::Sandbox {
+                command:
+                    Some(SandboxCommands::Provider(SandboxProviderCommands::List { output, .. })),
+            }) = sandbox_provider.command
+            else {
+                panic!("expected sandbox provider list command");
+            };
+            assert_eq!(output, expected);
+
+            let policy = Cli::try_parse_from(["openshell", "policy", "list", "--output", format])
+                .unwrap_or_else(|error| panic!("policy list --output {format}: {error}"));
+            let Some(Commands::Policy {
+                command: Some(PolicyCommands::List { output, .. }),
+            }) = policy.command
+            else {
+                panic!("expected policy list command");
+            };
+            assert_eq!(output, expected);
+
+            let service = Cli::try_parse_from(["openshell", "service", "list", "-o", format])
+                .unwrap_or_else(|error| panic!("service list -o {format}: {error}"));
+            let Some(Commands::Service {
+                command: Some(ServiceCommands::List { output, .. }),
+            }) = service.command
+            else {
+                panic!("expected service list command");
+            };
+            assert_eq!(output, expected);
+
+            let workspace_member = Cli::try_parse_from([
+                "openshell",
+                "workspace",
+                "member",
+                "list",
+                "--workspace",
+                "default",
+                "-o",
+                format,
+            ])
+            .unwrap_or_else(|error| panic!("workspace member list -o {format}: {error}"));
+            let Some(Commands::Workspace {
+                command:
+                    Some(WorkspaceCommands::Member(WorkspaceMemberCommands::List { output, .. })),
+            }) = workspace_member.command
+            else {
+                panic!("expected workspace member list command");
+            };
+            assert_eq!(output, expected);
+        }
     }
 
     #[test]

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -2249,6 +2249,7 @@ fn sandbox_detail_to_json(
 pub async fn sandbox_provider_list(
     server: &str,
     name: &str,
+    output: &str,
     workspace: &str,
     tls: &TlsOptions,
 ) -> Result<()> {
@@ -2261,6 +2262,10 @@ pub async fn sandbox_provider_list(
         .await
         .into_diagnostic()?;
     let providers = response.into_inner().providers;
+
+    if crate::output::print_output_collection(output, &providers, attached_provider_to_json)? {
+        return Ok(());
+    }
 
     if providers.is_empty() {
         println!("No providers attached to sandbox {name}.");
@@ -2385,6 +2390,18 @@ pub async fn sandbox_provider_detach(
 
 fn print_provider_attachment_table(providers: &[Provider]) {
     print!("{}", format_provider_attachment_table(providers, true));
+}
+
+fn attached_provider_to_json(provider: &Provider) -> serde_json::Value {
+    let mut config_keys = provider.config.keys().cloned().collect::<Vec<_>>();
+    config_keys.sort();
+
+    serde_json::json!({
+        "name": provider.object_name(),
+        "type": provider.r#type,
+        "credential_keys": provider_credential_keys(provider),
+        "config_keys": config_keys,
+    })
 }
 
 fn format_provider_attachment_table(providers: &[Provider], color: bool) -> String {
@@ -3003,6 +3020,7 @@ fn service_expose_status_error(status: Status) -> miette::Report {
     service_status_error("expose service", "sandbox:write", status)
 }
 
+#[allow(clippy::too_many_arguments)] // user-facing CLI command
 pub async fn service_list(
     server: &str,
     sandbox: Option<&str>,
@@ -3010,6 +3028,7 @@ pub async fn service_list(
     offset: u32,
     workspace: &str,
     all_workspaces: bool,
+    output: &str,
     tls: &TlsOptions,
 ) -> Result<()> {
     let mut client = grpc_client(server, tls).await?;
@@ -3028,6 +3047,15 @@ pub async fn service_list(
         .await
         .map_err(|status| service_status_error("list services", "sandbox:read", status))?
         .into_inner();
+
+    let services = response
+        .services
+        .iter()
+        .filter_map(|response| service_endpoint_to_json(response, server))
+        .collect::<Vec<_>>();
+    if crate::output::print_output_collection(output, &services, Clone::clone)? {
+        return Ok(());
+    }
 
     if response.services.is_empty() {
         if let Some(sandbox) = sandbox {
@@ -3215,6 +3243,30 @@ fn print_service_endpoint_table(
             );
         }
     }
+}
+
+fn service_endpoint_to_json(
+    response: &ServiceEndpointResponse,
+    gateway_endpoint: &str,
+) -> Option<serde_json::Value> {
+    let endpoint = response.endpoint.as_ref()?;
+    let workspace = endpoint
+        .metadata
+        .as_ref()
+        .map_or("", |metadata| metadata.workspace.as_str());
+    let url = if response.url.is_empty() {
+        String::new()
+    } else {
+        service_url_for_gateway(&response.url, gateway_endpoint)
+    };
+
+    Some(serde_json::json!({
+        "workspace": workspace,
+        "sandbox": endpoint.sandbox_name,
+        "service": endpoint.service_name,
+        "target_port": endpoint.target_port,
+        "url": url,
+    }))
 }
 
 fn service_display_name(service: &str) -> &str {
@@ -5317,9 +5369,10 @@ pub async fn workspace_member_list(
     workspace: &str,
     limit: u32,
     offset: u32,
+    output: &str,
     tls: &TlsOptions,
 ) -> Result<()> {
-    use openshell_core::proto::{ListWorkspaceMembersRequest, WorkspaceRole};
+    use openshell_core::proto::ListWorkspaceMembersRequest;
 
     let mut client = grpc_client(server, tls).await?;
     let response = client
@@ -5331,6 +5384,10 @@ pub async fn workspace_member_list(
         .await
         .into_diagnostic()?;
     let members = response.into_inner().members;
+
+    if crate::output::print_output_collection(output, &members, workspace_member_to_json)? {
+        return Ok(());
+    }
 
     if members.is_empty() {
         println!("No members found in workspace {workspace}.");
@@ -5347,15 +5404,28 @@ pub async fn workspace_member_list(
     println!("{:<subject_width$}  {}", "SUBJECT".bold(), "ROLE".bold());
 
     for member in &members {
-        let role_str = match WorkspaceRole::try_from(member.role) {
-            Ok(WorkspaceRole::Admin) => "admin",
-            Ok(WorkspaceRole::User) => "user",
-            _ => "unknown",
-        };
+        let role_str = workspace_member_role_name(member.role);
         println!("{:<subject_width$}  {}", member.principal_subject, role_str);
     }
 
     Ok(())
+}
+
+fn workspace_member_role_name(role: i32) -> &'static str {
+    use openshell_core::proto::WorkspaceRole;
+
+    match WorkspaceRole::try_from(role) {
+        Ok(WorkspaceRole::Admin) => "admin",
+        Ok(WorkspaceRole::User) => "user",
+        _ => "unknown",
+    }
+}
+
+fn workspace_member_to_json(member: &openshell_core::proto::WorkspaceMember) -> serde_json::Value {
+    serde_json::json!({
+        "subject": member.principal_subject,
+        "role": workspace_member_role_name(member.role),
+    })
 }
 
 fn workspace_phase_str(workspace: &openshell_core::proto::Workspace) -> &'static str {
@@ -6924,6 +6994,7 @@ pub async fn sandbox_policy_list(
     server: &str,
     name: &str,
     limit: u32,
+    output: &str,
     workspace: &str,
     tls: &TlsOptions,
 ) -> Result<()> {
@@ -6941,6 +7012,11 @@ pub async fn sandbox_policy_list(
         .into_diagnostic()?;
 
     let revisions = resp.into_inner().revisions;
+    let structured = policy_revision_list_json("sandbox", Some(name), &revisions)?;
+    if crate::output::print_output_collection(output, &structured, Clone::clone)? {
+        return Ok(());
+    }
+
     if revisions.is_empty() {
         eprintln!("No policy history found for sandbox '{name}'");
         return Ok(());
@@ -6953,6 +7029,7 @@ pub async fn sandbox_policy_list(
 pub async fn sandbox_policy_list_global(
     server: &str,
     limit: u32,
+    output: &str,
     workspace: &str,
     tls: &TlsOptions,
 ) -> Result<()> {
@@ -6970,6 +7047,11 @@ pub async fn sandbox_policy_list_global(
         .into_diagnostic()?;
 
     let revisions = resp.into_inner().revisions;
+    let structured = policy_revision_list_json("global", None, &revisions)?;
+    if crate::output::print_output_collection(output, &structured, Clone::clone)? {
+        return Ok(());
+    }
+
     if revisions.is_empty() {
         eprintln!("No global policy history found");
         return Ok(());
@@ -6977,6 +7059,28 @@ pub async fn sandbox_policy_list_global(
 
     print_policy_revision_table(&revisions);
     Ok(())
+}
+
+fn policy_revision_list_json(
+    scope: &str,
+    sandbox: Option<&str>,
+    revisions: &[openshell_core::proto::SandboxPolicyRevision],
+) -> Result<Vec<serde_json::Value>> {
+    revisions
+        .iter()
+        .map(|revision| {
+            let status =
+                PolicyStatus::try_from(revision.status).unwrap_or(PolicyStatus::Unspecified);
+            policy_revision_to_json(
+                scope,
+                sandbox,
+                None,
+                revision,
+                status,
+                PolicyGetView::Metadata,
+            )
+        })
+        .collect()
 }
 
 fn print_policy_revision_table(revisions: &[openshell_core::proto::SandboxPolicyRevision]) {
@@ -7512,16 +7616,16 @@ fn format_endpoint(endpoint: &openshell_core::proto::NetworkEndpoint) -> String 
 #[cfg(test)]
 mod tests {
     use super::{
-        PolicyGetView, ProvisioningStep, build_sandbox_resource_limits,
+        PolicyGetView, ProvisioningStep, attached_provider_to_json, build_sandbox_resource_limits,
         dockerfile_sources_supported_for_gateway, format_endpoint, format_log_line,
         format_provider_attachment_table, git_sync_files, has_main_process_result,
         inferred_provider_type, parse_cli_setting_value, parse_credential_expiry_cli_value,
         parse_credential_expiry_pairs, parse_credential_pairs, parse_driver_config_json,
-        parse_secret_material_env_pairs, policy_revision_to_json,
+        parse_secret_material_env_pairs, policy_revision_list_json, policy_revision_to_json,
         provider_profile_allows_empty_credentials, provisioning_timeout_message,
         ready_false_condition_message, refresh_status_header, refresh_status_row, resolve_from,
-        sandbox_should_persist, sandbox_upload_plan, service_expose_status_error,
-        service_url_for_gateway,
+        sandbox_should_persist, sandbox_upload_plan, service_endpoint_to_json,
+        service_expose_status_error, service_url_for_gateway, workspace_member_to_json,
     };
     use crate::TEST_ENV_LOCK;
     use crate::commands::common::progress_step_from_metadata;
@@ -7538,12 +7642,13 @@ mod tests {
         PROGRESS_STEP_STARTING_SANDBOX,
     };
     use openshell_core::proto::{
-        GetSandboxConfigResponse, GpuResourceRequirements, PolicySource, PolicyStatus, Provider,
-        ProviderCredentialRefresh, ProviderCredentialRefreshRecoveryAction,
+        CredentialHandle, GetSandboxConfigResponse, GpuResourceRequirements, PolicySource,
+        PolicyStatus, Provider, ProviderCredentialRefresh, ProviderCredentialRefreshRecoveryAction,
         ProviderCredentialRefreshStatus, ProviderCredentialRefreshStrategy,
         ProviderCredentialTokenGrant, ProviderProfile, ProviderProfileCredential,
-        ResourceRequirements, Sandbox, SandboxCondition, SandboxPhase, SandboxPolicyRevision,
-        SandboxStatus, datamodel::v1::ObjectMeta,
+        ResourceRequirements, Sandbox, SandboxCondition, SandboxPhase, SandboxPolicy,
+        SandboxPolicyRevision, SandboxStatus, ServiceEndpoint, ServiceEndpointResponse,
+        WorkspaceMember, WorkspaceRole, datamodel::v1::ObjectMeta,
     };
 
     #[test]
@@ -7572,6 +7677,174 @@ mod tests {
             json["provenance"]["openshell.nvidia.com/policy-signature"],
             "signed"
         );
+    }
+
+    #[test]
+    fn policy_list_json_reuses_metadata_contract() {
+        let load_error = "policy failed after checking café.example/非常に長いパス";
+        let revisions = vec![SandboxPolicyRevision {
+            version: 7,
+            policy_hash: "0123456789abcdef".to_string(),
+            status: PolicyStatus::Failed as i32,
+            load_error: load_error.to_string(),
+            created_at_ms: 100,
+            loaded_at_ms: 200,
+            policy: Some(SandboxPolicy::default()),
+            provenance: std::collections::HashMap::from([(
+                "source".to_string(),
+                "provider-composition".to_string(),
+            )]),
+        }];
+
+        let values = policy_revision_list_json("sandbox", Some("dev"), &revisions)
+            .expect("policy list JSON");
+
+        assert_eq!(
+            values[0],
+            serde_json::json!({
+                "scope": "sandbox",
+                "sandbox": "dev",
+                "version": 7,
+                "hash": "0123456789abcdef",
+                "status": "failed",
+                "created_at_ms": 100,
+                "loaded_at_ms": 200,
+                "load_error": load_error,
+                "provenance": {"source": "provider-composition"},
+            })
+        );
+        assert!(values[0].get("policy").is_none());
+        assert!(values[0].get("active_version").is_none());
+
+        let unknown = policy_revision_list_json(
+            "global",
+            None,
+            &[SandboxPolicyRevision {
+                version: 8,
+                status: 999,
+                ..Default::default()
+            }],
+        )
+        .expect("global policy list JSON");
+        assert_eq!(unknown[0]["scope"], "global");
+        assert_eq!(unknown[0]["status"], "unspecified");
+        assert!(unknown[0].get("sandbox").is_none());
+    }
+
+    #[test]
+    fn attached_provider_json_is_sorted_and_secret_safe() {
+        let provider = Provider {
+            metadata: Some(ObjectMeta {
+                name: "github".to_string(),
+                ..Default::default()
+            }),
+            r#type: "github".to_string(),
+            credentials: std::collections::HashMap::from([
+                ("Z_TOKEN".to_string(), "inline-secret".to_string()),
+                ("SHARED".to_string(), "shared-secret".to_string()),
+            ]),
+            config: std::collections::HashMap::from([
+                ("Z_URL".to_string(), "https://secret.example".to_string()),
+                ("A_MODE".to_string(), "sensitive-config".to_string()),
+            ]),
+            credential_expires_at_ms: std::collections::HashMap::from([(
+                "Z_TOKEN".to_string(),
+                123,
+            )]),
+            profile_workspace: "internal".to_string(),
+            credential_handles: std::collections::HashMap::from([
+                (
+                    "A_HANDLE".to_string(),
+                    CredentialHandle {
+                        driver: "vault".to_string(),
+                        handle: "opaque-secret-handle".to_string(),
+                        metadata: std::collections::HashMap::from([(
+                            "internal".to_string(),
+                            "metadata-value".to_string(),
+                        )]),
+                    },
+                ),
+                ("SHARED".to_string(), CredentialHandle::default()),
+            ]),
+        };
+
+        let value = attached_provider_to_json(&provider);
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "name": "github",
+                "type": "github",
+                "credential_keys": ["A_HANDLE", "SHARED", "Z_TOKEN"],
+                "config_keys": ["A_MODE", "Z_URL"],
+            })
+        );
+        let serialized = value.to_string();
+        for secret in [
+            "inline-secret",
+            "shared-secret",
+            "https://secret.example",
+            "sensitive-config",
+            "opaque-secret-handle",
+            "metadata-value",
+            "internal",
+            "123",
+        ] {
+            assert!(!serialized.contains(secret), "leaked {secret}");
+        }
+    }
+
+    #[test]
+    fn service_endpoint_json_has_raw_fields_and_normalized_url() {
+        let response = ServiceEndpointResponse {
+            endpoint: Some(ServiceEndpoint {
+                metadata: Some(ObjectMeta {
+                    workspace: "team-a".to_string(),
+                    ..Default::default()
+                }),
+                sandbox_name: "api".to_string(),
+                service_name: String::new(),
+                target_port: 8080,
+                ..Default::default()
+            }),
+            url: "https://api.openshell.localhost:3000/".to_string(),
+        };
+
+        let value = service_endpoint_to_json(&response, "https://gateway.example:17670")
+            .expect("service endpoint JSON");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "workspace": "team-a",
+                "sandbox": "api",
+                "service": "",
+                "target_port": 8080,
+                "url": "https://api.openshell.localhost:17670/",
+            })
+        );
+        assert!(service_endpoint_to_json(&ServiceEndpointResponse::default(), "unused").is_none());
+    }
+
+    #[test]
+    fn workspace_member_json_uses_stable_role_names() {
+        for (role, expected) in [
+            (WorkspaceRole::Admin as i32, "admin"),
+            (WorkspaceRole::User as i32, "user"),
+            (999, "unknown"),
+        ] {
+            let value = workspace_member_to_json(&WorkspaceMember {
+                metadata: Some(ObjectMeta {
+                    id: "internal-id".to_string(),
+                    ..Default::default()
+                }),
+                principal_subject: "oidc-subject".to_string(),
+                role,
+            });
+            assert_eq!(
+                value,
+                serde_json::json!({"subject": "oidc-subject", "role": expected})
+            );
+            assert!(!value.to_string().contains("internal-id"));
+        }
     }
 
     #[test]

--- a/crates/openshell-cli/tests/forward_list_integration.rs
+++ b/crates/openshell-cli/tests/forward_list_integration.rs
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+const DEAD_PID: u32 = u32::MAX;
+
+fn run_forward_list(config_dir: &Path, args: &[&str]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_openshell"));
+    for (key, _) in std::env::vars().filter(|(key, _)| key.starts_with("OPENSHELL_")) {
+        command.env_remove(key);
+    }
+    command
+        .args(["forward", "list"])
+        .args(args)
+        .env("XDG_CONFIG_HOME", config_dir)
+        .env("HOME", config_dir)
+        .output()
+        .expect("run openshell forward list")
+}
+
+fn write_dead_forward(config_dir: &Path) {
+    let forward_dir = config_dir.join("openshell/forwards");
+    fs::create_dir_all(&forward_dir).expect("create forward directory");
+    fs::write(
+        forward_dir.join("my-sandbox-8443.pid"),
+        format!("{DEAD_PID}\tsandbox-id\t0.0.0.0"),
+    )
+    .expect("write forward PID record");
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "forward list failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn forward_list_json_emits_machine_readable_records() {
+    let config_dir = tempfile::tempdir().expect("create config directory");
+    write_dead_forward(config_dir.path());
+
+    let output = run_forward_list(config_dir.path(), &["--output", "json"]);
+    assert_success(&output);
+    assert!(
+        output.stderr.is_empty(),
+        "structured output wrote to stderr"
+    );
+    assert!(
+        !output.stdout.contains(&0x1b),
+        "JSON contained ANSI escapes"
+    );
+
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should contain only JSON");
+    assert_eq!(
+        value,
+        serde_json::json!([{
+            "sandbox": "my-sandbox",
+            "bind_address": "0.0.0.0",
+            "port": 8443,
+            "pid": DEAD_PID,
+            "alive": false,
+        }])
+    );
+}
+
+#[test]
+fn forward_list_yaml_emits_equivalent_records() {
+    let config_dir = tempfile::tempdir().expect("create config directory");
+    write_dead_forward(config_dir.path());
+
+    let output = run_forward_list(config_dir.path(), &["-o", "yaml"]);
+    assert_success(&output);
+    assert!(
+        output.stderr.is_empty(),
+        "structured output wrote to stderr"
+    );
+    assert!(
+        !output.stdout.contains(&0x1b),
+        "YAML contained ANSI escapes"
+    );
+
+    let value: serde_json::Value =
+        serde_yml::from_slice(&output.stdout).expect("stdout should contain only YAML");
+    assert_eq!(
+        value,
+        serde_json::json!([{
+            "sandbox": "my-sandbox",
+            "bind_address": "0.0.0.0",
+            "port": 8443,
+            "pid": DEAD_PID,
+            "alive": false,
+        }])
+    );
+}
+
+#[test]
+fn forward_list_structured_output_emits_empty_collections() {
+    let config_dir = tempfile::tempdir().expect("create config directory");
+
+    for format in ["json", "yaml"] {
+        let output = run_forward_list(config_dir.path(), &["--output", format]);
+        assert_success(&output);
+        assert!(output.stderr.is_empty(), "{format} output wrote to stderr");
+
+        let value: serde_json::Value = match format {
+            "json" => serde_json::from_slice(&output.stdout).expect("parse empty JSON collection"),
+            "yaml" => serde_yml::from_slice(&output.stdout).expect("parse empty YAML collection"),
+            _ => unreachable!(),
+        };
+        assert_eq!(value, serde_json::json!([]));
+    }
+}
+
+#[test]
+fn forward_list_table_output_keeps_existing_columns() {
+    let config_dir = tempfile::tempdir().expect("create config directory");
+    write_dead_forward(config_dir.path());
+
+    let output = run_forward_list(config_dir.path(), &[]);
+    assert_success(&output);
+    assert!(output.stderr.is_empty(), "table output wrote to stderr");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let rows: Vec<Vec<&str>> = stdout
+        .lines()
+        .map(|line| line.split_whitespace().collect())
+        .collect();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], vec!["SANDBOX", "BIND", "PORT", "PID", "STATUS"]);
+    assert_eq!(
+        &rows[1][..4],
+        ["my-sandbox", "0.0.0.0", "8443", "4294967295"]
+    );
+    assert!(rows[1][4].contains("dead"));
+}
+
+#[test]
+fn forward_list_help_documents_output_flag() {
+    let config_dir = tempfile::tempdir().expect("create config directory");
+    let output = run_forward_list(config_dir.path(), &["--help"]);
+    assert_success(&output);
+
+    let stdout = String::from_utf8(output.stdout).expect("help should be UTF-8");
+    assert!(stdout.contains("-o, --output <OUTPUT>"), "{stdout}");
+    assert!(stdout.contains("[default: table]"), "{stdout}");
+    assert!(
+        stdout.contains("possible values: table, yaml, json"),
+        "{stdout}"
+    );
+}

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -1686,7 +1686,7 @@ async fn sandbox_provider_cli_run_functions_wire_requests_and_idempotent_results
     )
     .await
     .expect("sandbox provider attach is idempotent");
-    run::sandbox_provider_list(&ts.endpoint, "dev-sandbox", "default", &ts.tls)
+    run::sandbox_provider_list(&ts.endpoint, "dev-sandbox", "table", "default", &ts.tls)
         .await
         .expect("sandbox provider list");
     run::sandbox_provider_detach(

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -335,6 +335,17 @@ List endpoints for one sandbox:
 openshell service list my-sandbox
 ```
 
+Use structured output for automation:
+
+```shell
+openshell service list --output json
+openshell service list my-sandbox --output yaml
+```
+
+Each record contains `workspace`, `sandbox`, `service`, `target_port`, and
+`url`. The unnamed service uses an empty `service` string. An empty result is
+an empty collection.
+
 Show or delete one endpoint:
 
 ```shell
@@ -432,6 +443,18 @@ List and stop active forwards:
 openshell forward list
 openshell forward stop 8000 my-sandbox
 ```
+
+Use JSON or YAML output when inspecting tracked forwards from automation:
+
+```shell
+openshell forward list --output json
+openshell forward list --output yaml
+```
+
+Structured output includes `sandbox`, `bind_address`, `port`, `pid`, and
+`alive`. The `alive` boolean reports whether the tracked PID still matches the
+expected OpenShell SSH forward; it does not probe the forwarded socket. When no
+forwards are tracked, structured output returns an empty collection.
 
 <Tip>
 You can also forward a port at creation time with `--forward`:

--- a/docs/sandboxes/manage-workspaces.mdx
+++ b/docs/sandboxes/manage-workspaces.mdx
@@ -121,6 +121,10 @@ openshell workspace member remove \
   --subject 'oidc-subject-for-user'
 ```
 
+Add `--output json` or `--output yaml` to list membership records for
+automation. Each record contains `subject` and a normalized `role` of `admin`,
+`user`, or `unknown`. An empty result is an empty collection.
+
 To change a member's role, remove the existing membership and add it again
 with the new role. A Platform Admin must perform any change to `admin`.
 

--- a/docs/sandboxes/policies.mdx
+++ b/docs/sandboxes/policies.mdx
@@ -232,6 +232,11 @@ The following steps outline the hot-reload policy update workflow.
    openshell policy list <name>
    ```
 
+   Add `--output json` or `--output yaml` for automation. Structured policy
+   history contains the scope, sandbox name when applicable, version, full
+   hash, status, and available revision timestamps, load error, and provenance.
+   Use `openshell policy list --global --output json` for global history.
+
 ### Validation failures
 
 OpenShell validates a complete candidate policy before activating any part of it. Endpoints may overlap when their connection and request-processing metadata agree. For example, two `api.example.com:443` REST entries can contribute different allow and deny rules when they use the same TLS, destination, credential, parser, and enforcement settings. A plain L4 endpoint may overlap an L7 endpoint because it authorizes the destination without contributing request-processing metadata. A more-specific path endpoint may override request-processing metadata from a broader endpoint, such as a `/graphql` GraphQL endpoint alongside a general REST endpoint for the same host. OpenShell rejects the candidate when overlapping exact or wildcard host selectors can both contribute equally specific endpoint configuration and disagree on those fields.

--- a/docs/sandboxes/providers-v2.mdx
+++ b/docs/sandboxes/providers-v2.mdx
@@ -861,6 +861,9 @@ openshell sandbox provider list provider-demo
 ```
 
 The list output includes provider name, provider type, credential key count, and config key count.
+Add `--output json` or `--output yaml` to return the provider name and type plus
+sorted `credential_keys` and `config_keys` arrays. Structured output never
+includes credential values, opaque credential handles, or config values.
 
 ## Policy Composition
 


### PR DESCRIPTION
## Summary

Add consistent `table`, `json`, and `yaml` output to `forward list` and the remaining literal list commands so automation can consume typed records without parsing human-oriented tables. Existing table output remains the default and retains its current behavior.

## Related Issue

Closes #3066

## Changes

- Add `-o/--output <table|json|yaml>` to service, policy, attached-provider, workspace-member, and forward lists.
- Return typed, empty structured collections without ANSI styling or prose; preserve full policy metadata and normalized service URLs.
- Keep attached-provider output secret-safe by exposing only sorted credential and config key names.
- Add CLI parsing, serializer, secret-safety, table-compatibility, empty-collection, and forward integration coverage.
- Update published CLI documentation and the `openshell-cli` skill reference.

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo test -p openshell-cli` passes after rebase (446 passed, 2 existing ignored tests, 0 failed)
- [x] Unit tests added/updated
- [x] CLI integration tests added/updated
- [x] `mise run docs` passes (0 errors)
- [x] E2E tests not applicable; this changes client-side rendering only and does not change gateway or sandbox behavior

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs not applicable; command behavior is documented in the published CLI pages and skill reference
