### PR TITLE
fix(policy): ignore advisor provenance during contract inference

### DIFF
--- a/crates/openshell-policy/src/merge.rs
+++ b/crates/openshell-policy/src/merge.rs
@@ -45,9 +45,11 @@ pub fn canonicalize_advisor_add_rule(
         })
         .cloned()
         .map(|mut endpoint| {
-            // This marker is derived from provider/credential context by the
-            // gateway and must never be persisted from an advisor proposal.
+            // Provenance does not change the endpoint contract. The gateway
+            // derives the credential marker, and the advisor marker records
+            // where a persisted endpoint came from.
             endpoint.provider_credentialed = false;
+            endpoint.advisor_proposed = false;
             // A denial observes one binary-to-port authorization. Preserve the
             // existing inspection contract, but never copy sibling ports from
             // a multi-port endpoint into the proposal.
@@ -84,6 +86,7 @@ pub fn canonicalize_advisor_add_rule(
                 .any(|endpoint| {
                     let mut normalized = endpoint.clone();
                     normalized.provider_credentialed = false;
+                    normalized.advisor_proposed = false;
                     normalize_endpoint(&mut normalized);
                     normalized == contract
                 })
@@ -92,6 +95,12 @@ pub fn canonicalize_advisor_add_rule(
         .collect::<Vec<_>>();
     sandbox_owners.sort();
 
+    let mut contract = contract;
+    if sandbox_owners.is_empty() {
+        // A provider-owned contract is mirrored into a new sandbox-owned
+        // advisor overlay, so retain the incoming proposal provenance.
+        contract.advisor_proposed = incoming_endpoint.advisor_proposed;
+    }
     let target_name = sandbox_owners
         .first()
         .cloned()
@@ -2220,6 +2229,7 @@ mod tests {
         assert_eq!(canonical.endpoints[0].protocol, "rest");
         assert_eq!(canonical.endpoints[0].access, "read-only");
         assert!(!canonical.endpoints[0].provider_credentialed);
+        assert!(canonical.endpoints[0].advisor_proposed);
         assert_eq!(
             effective.network_policies["_provider_example"].endpoints[0],
             provider_endpoint

--- a/crates/openshell-policy/src/merge.rs
+++ b/crates/openshell-policy/src/merge.rs
@@ -2227,6 +2227,58 @@ mod tests {
     }
 
     #[test]
+    fn canonicalize_advisor_ignores_endpoint_provenance_when_inferring_contract() {
+        let mut provider_endpoint = endpoint("api.example.com", 443);
+        provider_endpoint.protocol = "rest".to_string();
+        provider_endpoint.enforcement = "enforce".to_string();
+        provider_endpoint.access = "read-only".to_string();
+        provider_endpoint.provider_credentialed = true;
+
+        let mut advisor_endpoint = provider_endpoint.clone();
+        advisor_endpoint.provider_credentialed = false;
+        advisor_endpoint.advisor_proposed = true;
+
+        let mut base = SandboxPolicy::default();
+        base.network_policies.insert(
+            "existing_advisor".to_string(),
+            NetworkPolicyRule {
+                name: "existing-advisor".to_string(),
+                endpoints: vec![advisor_endpoint],
+                binaries: vec![advisor_binary("/usr/bin/curl")],
+            },
+        );
+
+        let mut effective = base.clone();
+        effective.network_policies.insert(
+            "_provider_example".to_string(),
+            NetworkPolicyRule {
+                name: "provider-example".to_string(),
+                endpoints: vec![provider_endpoint],
+                binaries: vec![binary("/usr/bin/gh")],
+            },
+        );
+
+        let incoming = NetworkPolicyRule {
+            name: "advisor_example".to_string(),
+            endpoints: vec![NetworkEndpoint {
+                host: "api.example.com".to_string(),
+                port: 443,
+                advisor_proposed: true,
+                ..Default::default()
+            }],
+            binaries: vec![advisor_binary("/usr/bin/python")],
+        };
+
+        let (rule_name, canonical) =
+            canonicalize_advisor_add_rule(&base, &effective, "advisor_example", &incoming)
+                .expect("provenance alone must not create multiple endpoint contracts");
+
+        assert_eq!(rule_name, "existing_advisor");
+        assert_eq!(canonical.endpoints[0].protocol, "rest");
+        assert_eq!(canonical.endpoints[0].access, "read-only");
+    }
+
+    #[test]
     fn canonicalize_advisor_narrows_multi_port_contract_and_keeps_overlay() {
         let mut existing_endpoint = endpoint("index.crates.io", 443);
         existing_endpoint.port = 80;

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -12973,7 +12973,7 @@ mod tests {
         let canonical = chunk.proposed_rule.as_ref().unwrap();
         assert_eq!(canonical.endpoints[0].protocol, "rest");
         assert_eq!(canonical.endpoints[0].access, "read-only");
-        assert!(!canonical.endpoints[0].advisor_proposed);
+        assert!(canonical.endpoints[0].advisor_proposed);
 
         let revision = state
             .store
@@ -12994,6 +12994,7 @@ mod tests {
         assert_eq!(curl_rule.endpoints[0].ports, vec![443]);
         assert_eq!(curl_rule.endpoints[0].protocol, "rest");
         assert_eq!(curl_rule.endpoints[0].access, "read-only");
+        assert!(curl_rule.endpoints[0].advisor_proposed);
         assert_eq!(curl_rule.binaries.len(), 1);
         assert_eq!(curl_rule.binaries[0].path, "/usr/bin/curl");
     }

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -12973,7 +12973,10 @@ mod tests {
         let canonical = chunk.proposed_rule.as_ref().unwrap();
         assert_eq!(canonical.endpoints[0].protocol, "rest");
         assert_eq!(canonical.endpoints[0].access, "read-only");
-        assert!(canonical.endpoints[0].advisor_proposed);
+        assert!(
+            canonical.endpoints[0].advisor_proposed,
+            "a new advisor overlay must retain proposal provenance"
+        );
 
         let revision = state
             .store
@@ -12994,7 +12997,10 @@ mod tests {
         assert_eq!(curl_rule.endpoints[0].ports, vec![443]);
         assert_eq!(curl_rule.endpoints[0].protocol, "rest");
         assert_eq!(curl_rule.endpoints[0].access, "read-only");
-        assert!(curl_rule.endpoints[0].advisor_proposed);
+        assert!(
+            curl_rule.endpoints[0].advisor_proposed,
+            "the persisted advisor overlay must retain proposal provenance"
+        );
         assert_eq!(curl_rule.binaries.len(), 1);
         assert_eq!(curl_rule.binaries[0].path, "/usr/bin/curl");
     }


### PR DESCRIPTION
## Summary

Prevent policy-advisor contract inference from treating otherwise identical endpoints as distinct solely because one endpoint carries advisor provenance. This fixes the late follow-up identified on #2935, where a subsequent mechanistic proposal could be stored with an application error instead of being auto-approved.

## Related Issue

No issue required: localized regression follow-up to #2935 and [review comment](https://github.com/NVIDIA/OpenShell/pull/2935#discussion_r3899894232).

## Changes

- Ignore `provider_credentialed` and `advisor_proposed` provenance while deduplicating effective endpoint contracts.
- Ignore the same provenance while selecting an existing sandbox-owned rule.
- Preserve the incoming advisor marker when mirroring a provider-owned contract into a new sandbox overlay.
- Add the focused regression reproducer supplied in the review comment.

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo test -p openshell-policy` passes (236 tests)
- [x] Unit tests added/updated
- [x] E2E tests not required; the regression is isolated to policy-library canonicalization

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs not required for this localized behavior correction
