### PR TITLE
fix(cli): size auto-detected interactive exec terminals

### DIFF
--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -1545,7 +1545,7 @@ pub async fn sandbox_exec_grpc(
     let tty = tty_override
         .unwrap_or_else(|| std::io::stdin().is_terminal() && std::io::stdout().is_terminal());
 
-    if tty_override == Some(true) && std::io::stdin().is_terminal() {
+    if tty && std::io::stdin().is_terminal() {
         return sandbox_exec_interactive_grpc(
             client,
             &sandbox,

--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -1477,6 +1477,12 @@ pub async fn sandbox_get(
 /// data into memory before the server rejects an oversized message.
 const MAX_STDIN_PAYLOAD: usize = 4 * 1024 * 1024;
 
+fn local_terminal_size() -> Option<(u32, u32)> {
+    crossterm::terminal::size()
+        .ok()
+        .map(|(cols, rows)| (u32::from(cols), u32::from(rows)))
+}
+
 /// Execute a command in a running sandbox via gRPC, streaming output to the terminal.
 ///
 /// Returns the remote command's exit code.
@@ -1558,6 +1564,12 @@ pub async fn sandbox_exec_grpc(
         .await;
     }
 
+    let (cols, rows) = if tty {
+        local_terminal_size().unwrap_or_default()
+    } else {
+        (0, 0)
+    };
+
     // Make the streaming gRPC call.
     let mut stream = client
         .exec_sandbox(ExecSandboxRequest {
@@ -1568,8 +1580,9 @@ pub async fn sandbox_exec_grpc(
             timeout_seconds,
             stdin: stdin_payload,
             tty,
+            cols,
+            rows,
             no_login_shell,
-            ..Default::default()
         })
         .await
         .into_diagnostic()?
@@ -1925,7 +1938,7 @@ async fn sandbox_exec_interactive_grpc(
     use openshell_core::proto::{ExecSandboxInput, exec_sandbox_input};
     use tokio_stream::wrappers::ReceiverStream;
 
-    let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
+    let (cols, rows) = local_terminal_size().unwrap_or((80, 24));
 
     let (input_tx, input_rx) = tokio::sync::mpsc::channel::<ExecSandboxInput>(4096);
 
@@ -1941,8 +1954,8 @@ async fn sandbox_exec_interactive_grpc(
                 timeout_seconds,
                 stdin: Vec::new(),
                 tty: true,
-                cols: u32::from(cols),
-                rows: u32::from(rows),
+                cols,
+                rows,
             })),
         })
         .await
@@ -1992,13 +2005,10 @@ async fn sandbox_exec_interactive_grpc(
                 tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())
                     .expect("failed to register SIGWINCH handler");
             while sig.recv().await.is_some() {
-                if let Ok((c, r)) = crossterm::terminal::size() {
+                if let Some((cols, rows)) = local_terminal_size() {
                     let msg = ExecSandboxInput {
                         payload: Some(exec_sandbox_input::Payload::Resize(
-                            ExecSandboxWindowResize {
-                                cols: u32::from(c),
-                                rows: u32::from(r),
-                            },
+                            ExecSandboxWindowResize { cols, rows },
                         )),
                     };
                     if resize_tx.send(msg).await.is_err() {

--- a/crates/openshell-server/src/grpc/sandbox.rs
+++ b/crates/openshell-server/src/grpc/sandbox.rs
@@ -1195,6 +1195,16 @@ fn is_watch_terminal(phase: SandboxPhase) -> bool {
 // Exec handler
 // ---------------------------------------------------------------------------
 
+const DEFAULT_PTY_COLS: u32 = 80;
+const DEFAULT_PTY_ROWS: u32 = 24;
+
+fn pty_dimensions(cols: u32, rows: u32) -> (u32, u32) {
+    (
+        if cols == 0 { DEFAULT_PTY_COLS } else { cols },
+        if rows == 0 { DEFAULT_PTY_ROWS } else { rows },
+    )
+}
+
 pub(super) async fn handle_exec_sandbox(
     state: &Arc<ServerState>,
     request: Request<ExecSandboxRequest>,
@@ -1236,6 +1246,7 @@ pub(super) async fn handle_exec_sandbox(
     let stdin_payload = req.stdin;
     let timeout_seconds = req.timeout_seconds;
     let request_tty = req.tty;
+    let (cols, rows) = pty_dimensions(req.cols, req.rows);
 
     let sandbox_id = sandbox.object_id().to_string();
 
@@ -1260,6 +1271,8 @@ pub(super) async fn handle_exec_sandbox(
             timeout_seconds,
             request_tty,
             no_login_shell,
+            cols,
+            rows,
         )
         .await
         {
@@ -1671,8 +1684,7 @@ pub(super) async fn handle_exec_sandbox_interactive(
     let request_tty = req.tty;
     let no_login_shell = req.no_login_shell;
     let timeout_seconds = req.timeout_seconds;
-    let cols = if req.cols == 0 { 80 } else { req.cols };
-    let rows = if req.rows == 0 { 24 } else { req.rows };
+    let (cols, rows) = pty_dimensions(req.cols, req.rows);
 
     let sandbox_id = sandbox.object_id().to_string();
 
@@ -1997,6 +2009,8 @@ async fn stream_exec_over_relay(
     timeout_seconds: u32,
     request_tty: bool,
     no_login_shell: bool,
+    cols: u32,
+    rows: u32,
 ) -> Result<(), Status> {
     let command_preview: String = command
         .chars()
@@ -2022,6 +2036,7 @@ async fn stream_exec_over_relay(
         stdin_payload,
         request_tty,
         no_login_shell,
+        (cols, rows),
         tx.clone(),
     );
 
@@ -2373,8 +2388,11 @@ async fn run_exec_with_russh(
     stdin_payload: Vec<u8>,
     request_tty: bool,
     no_shell_login: bool,
+    pty_size: (u32, u32),
     tx: mpsc::Sender<Result<ExecSandboxEvent, Status>>,
 ) -> Result<i32, Status> {
+    let (cols, rows) = pty_size;
+
     // Defense-in-depth: validate command at the transport boundary.
     if command.as_bytes().contains(&0) {
         return Err(Status::invalid_argument(
@@ -2423,7 +2441,7 @@ async fn run_exec_with_russh(
 
     if request_tty {
         channel
-            .request_pty(false, "xterm-256color", 0, 0, 0, 0, &[])
+            .request_pty(false, "xterm-256color", cols, rows, 0, 0, &[])
             .await
             .map_err(|e| Status::internal(format!("failed to allocate PTY: {e}")))?;
     }
@@ -2550,6 +2568,13 @@ mod tests {
     }
 
     // ---- shell_escape ----
+
+    #[test]
+    fn pty_dimensions_default_zero_values_without_overwriting_explicit_values() {
+        assert_eq!(pty_dimensions(0, 0), (80, 24));
+        assert_eq!(pty_dimensions(120, 40), (120, 40));
+        assert_eq!(pty_dimensions(0, 40), (80, 40));
+    }
 
     #[test]
     fn watch_terminal_phases_include_command_results_and_errors() {


### PR DESCRIPTION
## Summary

Fix remote PTY sizing for auto-detected interactive sandbox exec sessions and ensure unary exec never sends a zero-sized SSH PTY.

## Related Issue

Closes #3080

## Changes

- Route auto-detected interactive terminals through ExecSandboxInteractive, which sends initial dimensions and resize events.
- Populate unary ExecSandbox requests with local dimensions when a TTY is requested and the local terminal can be queried.
- Normalize zero protocol dimensions to the documented 80×24 default before either gateway execution path allocates an SSH PTY.
- Add regression coverage for the gateway zero-dimension default.

## Testing

- [x] git diff --check passes
- [ ] mise run pre-commit (cargo, rustfmt, and mise are unavailable in this workspace)
- [x] Unit test added (not run; Rust toolchain unavailable in this workspace)
- [ ] Test suite run (Rust toolchain unavailable in this workspace)
- [ ] E2E tests run (not run)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)