### PR TITLE
fix(deps): remediate h2 advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/deny.toml
+++ b/deny.toml
@@ -21,9 +21,6 @@ ignore = [
     { id = "RUSTSEC-2026-0204", reason = "crossbeam-epoch pointer deref — transitive via metrics/quanta" },
     { id = "RUSTSEC-2023-0071", reason = "rsa Marvin attack — transitive via spiffe, no direct exposure" },
     { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained — transitive via older kube/hyper" },
-    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki URI name constraints — transitive via older rustls" },
-    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki wildcard name constraints — transitive via older rustls" },
-    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki CRL parsing panic — transitive via older rustls" },
     { id = "RUSTSEC-2025-0068", reason = "serde_yml unsound+unmaintained — direct dep, no maintained alternative yet" },
 ]
 


### PR DESCRIPTION
## Summary

Update the remaining h2 dependency to the RUSTSEC-2026-0258 fixed release after the legacy Rustls/WebPKI path is removed.

## Related Issue

Depends on #3013. No public issue is created for this RustSec advisory remediation.

## Changes

- Update h2 from 0.4.13 to 0.4.16 in Cargo.lock.
- Remove three Rustls/WebPKI advisory ignores made obsolete by #3013.

## Testing

- [x] `mise run rust:deny` passes.
- [x] `mise run pre-commit` passes.
- [ ] E2E tests not run; dependency-only change.

## Checklist

- [x] Follows Conventional Commits.
- [x] Commit is signed off.