### PR TITLE
ci: add Fedora conformance workflow

### DIFF
--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 60
     container:
-      image: fedora:latest
+      image: docker.io/library/fedora:44@sha256:be9d65e2344d805cc11114319c685ecaa96b6d9b4350a0a6460cdb931babbd19
     steps:
       - name: Install packaging dependencies
         run: |

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -61,6 +61,14 @@ jobs:
           ref: ${{ inputs.checkout-ref }}
           fetch-depth: 0
 
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: rpm-vendor-${{ inputs.arch }}
+          cache-targets: "false"
+          cache-bin: "false"
+          cache-on-failure: "true"
+
       - name: Download CLI artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build RPM
+
+on:
+  workflow_call:
+    inputs:
+      checkout-ref:
+        required: true
+        type: string
+      arch:
+        required: true
+        type: string
+      runner:
+        required: true
+        type: string
+      cli-target:
+        required: true
+        type: string
+      gateway-target:
+        required: true
+        type: string
+      rpm-version:
+        required: false
+        type: string
+        default: ""
+      rpm-release:
+        required: false
+        type: string
+        default: ""
+      cargo-version:
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build RPM Package (Linux ${{ inputs.arch }})
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 60
+    container:
+      image: fedora:latest
+    steps:
+      - name: Install packaging dependencies
+        run: |
+          dnf install -y \
+            packit rpm-build \
+            cargo cargo-rpm-macros git-core \
+            pandoc python3-devel systemd-rpm-macros
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout-ref }}
+          fetch-depth: 0
+
+      - name: Download CLI artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openshell-${{ inputs.cli-target }}
+          path: package-binaries/
+
+      - name: Download gateway artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openshell-gateway-${{ inputs.gateway-target }}
+          path: package-binaries/
+
+      - name: Configure package inputs
+        run: |
+          set -euo pipefail
+          chmod +x package-binaries/openshell{,-gateway}
+          ls -lah package-binaries
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Build RPMs via Packit
+        env:
+          OPENSHELL_RPM_VERSION: ${{ inputs.rpm-version }}
+          OPENSHELL_RPM_RELEASE: ${{ inputs.rpm-release }}
+          OPENSHELL_CARGO_VERSION: ${{ inputs.cargo-version }}
+          OPENSHELL_PREBUILT_BINARIES_DIR: ${{ github.workspace }}/package-binaries
+        run: packit build locally
+
+      - name: Collect RPM artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          mapfile -t rpms < <(find "$GITHUB_WORKSPACE" -maxdepth 3 -type f -name '*.rpm' ! -name '*.src.rpm' | sort)
+          if [ "${#rpms[@]}" -eq 0 ]; then
+            echo "::error::No RPM artifacts found under $GITHUB_WORKSPACE"
+            find "$GITHUB_WORKSPACE" -maxdepth 3 -type f | sort
+            exit 1
+          fi
+          cp "${rpms[@]}" artifacts/
+          echo "=== Built RPMs ==="
+          ls -lah artifacts/
+
+      - name: Upload RPM artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: rpm-linux-${{ inputs.arch }}
+          path: artifacts/*.rpm
+          retention-days: 5

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Conformance
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr_metadata:
+    name: Resolve PR metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - id: gate
+        uses: ./.github/actions/pr-gate
+
+  version:
+    needs: pr_metadata
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      cargo: ${{ steps.version.outputs.cargo }}
+      rpm_version: ${{ steps.version.outputs.rpm_version }}
+      rpm_release: ${{ steps.version.outputs.rpm_release }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Compute versions
+        id: version
+        run: |
+          cargo="$(python3 tasks/scripts/release.py get-version --cargo)"
+          rpm_version="$(python3 tasks/scripts/release.py get-version --rpm-version)"
+          rpm_release="$(python3 tasks/scripts/release.py get-version --rpm-release)"
+          {
+            echo "cargo=$cargo"
+            echo "rpm_version=$rpm_version"
+            echo "rpm_release=$rpm_release"
+          } >> "$GITHUB_OUTPUT"
+
+  build-cli:
+    needs: version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-cli-binaries.yml
+    with:
+      cargo-version: ${{ needs.version.outputs.cargo }}
+      checkout-ref: ${{ github.sha }}
+    secrets: inherit
+
+  build-gateway:
+    needs: version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-gateway-binaries.yml
+    with:
+      cargo-version: ${{ needs.version.outputs.cargo }}
+      checkout-ref: ${{ github.sha }}
+    secrets: inherit
+
+  build-rpm:
+    needs: [version, build-cli, build-gateway]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/rpm-package.yml
+    with:
+      checkout-ref: ${{ github.sha }}
+      cargo-version: ${{ needs.version.outputs.cargo }}
+      rpm-version: ${{ needs.version.outputs.rpm_version }}
+      rpm-release: ${{ needs.version.outputs.rpm_release }}
+
+  fedora:
+    name: Fedora clean install
+    needs: build-rpm
+    runs-on: linux-amd64-cpu8
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-nix
+
+      - name: Download RPM artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: rpm-linux-x86_64
+          path: rpm-input
+
+      - name: Install RPMs and check status
+        shell: bash
+        run: |
+          set -euo pipefail
+          nix run .#test-guest -- \
+            --distro fedora \
+            --with podman \
+            --with selinux \
+            --install rpm-input/openshell-[0-9]*.rpm \
+            --install rpm-input/openshell-gateway-[0-9]*.rpm \
+            -- bash -s <<'EOF'
+          set -euo pipefail
+
+          on_exit() {
+            rc=$?
+            trap - EXIT
+            if [ "$rc" -ne 0 ]; then
+              systemctl --user status openshell-gateway --no-pager || true
+              journalctl --user -u openshell-gateway --no-pager -n 200 || true
+              podman info || true
+              podman ps --all || true
+              getenforce || true
+            fi
+            exit "$rc"
+          }
+          trap on_exit EXIT
+
+          . /etc/os-release
+          echo "Testing on $PRETTY_NAME"
+          podman --version
+          test "$(podman info --format '{{.Host.Security.Rootless}}')" = true
+          test "$(podman info --format '{{.Host.CgroupsVersion}}')" = v2
+          test "$(getenforce)" = Enforcing
+          rpm -q openshell openshell-gateway
+          openshell --version
+          openshell-gateway --version
+
+          mkdir -p "$HOME/.config/openshell"
+          echo 'OPENSHELL_TELEMETRY_ENABLED=false' > "$HOME/.config/openshell/gateway.env"
+          systemctl --user enable --now openshell-gateway
+          openshell gateway add --local https://127.0.0.1:17670 --name openshell
+          openshell status
+          EOF

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -90,7 +90,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/build-binaries.yml
     with:
-      package: openshell-server
+      package: openshell-gateway
       binary: openshell-gateway
       triple: x86_64-unknown-linux-gnu
       runner: linux-amd64-cpu8

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -4,9 +4,6 @@
 name: Conformance
 
 on:
-  push:
-    branches:
-      - "pull-request/[0-9]+"
   workflow_dispatch: {}
 
 permissions: {}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -101,7 +101,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup-e2e-vm
+      - name: Enable KVM access
+        run: |
+          set -euo pipefail
+          if [[ ! -c /dev/kvm ]]; then
+            echo "::error::The runner did not expose /dev/kvm"
+            exit 1
+          fi
+          sudo chmod 0666 /dev/kvm
+          exec 3<>/dev/kvm
+          exec 3>&-
 
       - uses: ./.github/actions/setup-nix
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -120,7 +120,7 @@ jobs:
       rpm-release: ${{ needs.version.outputs.rpm_release }}
 
   fedora:
-    name: Fedora clean install
+    name: Fedora with Rootless Podman
     needs: [build-conformance, build-rpm]
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -99,6 +99,7 @@ jobs:
       runner: linux-amd64-cpu8
       dev-shell: .#devShells.x86_64-linux.glibc-2-28
       cargo-version: ${{ needs.version.outputs.cargo }}
+      image-tag: dev
       interpreter: /lib64/ld-linux-x86-64.so.2
       checkout-ref: ${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -115,13 +115,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          nix run .#test-guest -- \
-            --distro fedora \
-            --with podman \
-            --with selinux \
-            --install rpm-input/openshell-[0-9]*.rpm \
-            --install rpm-input/openshell-gateway-[0-9]*.rpm \
-            -- bash -s <<'EOF'
+          guest_script="$RUNNER_TEMP/conformance.sh"
+          cat > "$guest_script" <<'EOF'
           set -euo pipefail
 
           on_exit() {
@@ -154,3 +149,12 @@ jobs:
           openshell gateway add --local https://127.0.0.1:17670 --name openshell
           openshell status
           EOF
+
+          nix run .#test-guest -- \
+            --distro fedora \
+            --with podman \
+            --with selinux \
+            --install rpm-input/openshell-[0-9]*.rpm \
+            --install rpm-input/openshell-gateway-[0-9]*.rpm \
+            --copy "$guest_script:/tmp/conformance.sh" \
+            -- bash /tmp/conformance.sh

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -101,6 +101,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: ./.github/actions/setup-e2e-vm
+
       - uses: ./.github/actions/setup-nix
 
       - name: Download RPM artifacts

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -186,7 +186,7 @@ jobs:
 
           OPENSHELL_TEST_GUEST_CACHE_DISABLE=1 nix run .#test-guest -- \
             --distro fedora \
-            --with podman \
+            --with podman-rootless \
             --with selinux \
             --install rpm-input/openshell-[0-9]*.rpm \
             --install rpm-input/openshell-gateway-[0-9]*.rpm \

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -91,7 +91,7 @@ jobs:
   fedora:
     name: Fedora clean install
     needs: build-rpm
-    runs-on: linux-amd64-cpu8
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
       actions: read

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -61,8 +61,28 @@ jobs:
     needs: version
     permissions:
       contents: read
-    uses: ./.github/workflows/build-cli-binaries.yml
+    uses: ./.github/workflows/build-binaries.yml
     with:
+      package: openshell-cli
+      binary: openshell
+      triple: x86_64-unknown-linux-musl
+      runner: linux-amd64-cpu8
+      dev-shell: .#devShells.x86_64-linux.musl
+      cargo-version: ${{ needs.version.outputs.cargo }}
+      checkout-ref: ${{ github.sha }}
+    secrets: inherit
+
+  build-conformance:
+    needs: version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      package: openshell-conformance-cli
+      binary: openshell-conformance
+      triple: x86_64-unknown-linux-musl
+      runner: linux-amd64-cpu8
+      dev-shell: .#devShells.x86_64-linux.musl
       cargo-version: ${{ needs.version.outputs.cargo }}
       checkout-ref: ${{ github.sha }}
     secrets: inherit
@@ -71,9 +91,15 @@ jobs:
     needs: version
     permissions:
       contents: read
-    uses: ./.github/workflows/build-gateway-binaries.yml
+    uses: ./.github/workflows/build-binaries.yml
     with:
+      package: openshell-server
+      binary: openshell-gateway
+      triple: x86_64-unknown-linux-gnu
+      runner: linux-amd64-cpu8
+      dev-shell: .#devShells.x86_64-linux.glibc-2-28
       cargo-version: ${{ needs.version.outputs.cargo }}
+      interpreter: /lib64/ld-linux-x86-64.so.2
       checkout-ref: ${{ github.sha }}
     secrets: inherit
 
@@ -81,16 +107,20 @@ jobs:
     needs: [version, build-cli, build-gateway]
     permissions:
       contents: read
-    uses: ./.github/workflows/rpm-package.yml
+    uses: ./.github/workflows/build-rpm.yml
     with:
       checkout-ref: ${{ github.sha }}
+      arch: x86_64
+      runner: linux-amd64-cpu8
+      cli-target: x86_64-unknown-linux-musl
+      gateway-target: x86_64-unknown-linux-gnu
       cargo-version: ${{ needs.version.outputs.cargo }}
       rpm-version: ${{ needs.version.outputs.rpm_version }}
       rpm-release: ${{ needs.version.outputs.rpm_release }}
 
   fedora:
     name: Fedora clean install
-    needs: build-rpm
+    needs: [build-conformance, build-rpm]
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
@@ -120,10 +150,17 @@ jobs:
           name: rpm-linux-x86_64
           path: rpm-input
 
+      - name: Download conformance CLI
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openshell-conformance-x86_64-unknown-linux-musl
+          path: conformance-input
+
       - name: Install RPMs and check status
         shell: bash
         run: |
           set -euo pipefail
+          chmod +x conformance-input/openshell-conformance
           guest_script="$RUNNER_TEMP/conformance.sh"
           cat > "$guest_script" <<'EOF'
           set -euo pipefail
@@ -142,28 +179,19 @@ jobs:
           }
           trap on_exit EXIT
 
-          . /etc/os-release
-          echo "Testing on $PRETTY_NAME"
-          podman --version
-          test "$(podman info --format '{{.Host.Security.Rootless}}')" = true
-          test "$(podman info --format '{{.Host.CgroupsVersion}}')" = v2
-          test "$(getenforce)" = Enforcing
-          rpm -q openshell openshell-gateway
-          openshell --version
-          openshell-gateway --version
-
           mkdir -p "$HOME/.config/openshell"
           echo 'OPENSHELL_TELEMETRY_ENABLED=false' > "$HOME/.config/openshell/gateway.env"
           systemctl --user enable --now openshell-gateway
           openshell gateway add --local https://127.0.0.1:17670 --name openshell
-          openshell status
+          /tmp/openshell-conformance run smoke
           EOF
 
-          nix run .#test-guest -- \
+          OPENSHELL_TEST_GUEST_CACHE_DISABLE=1 nix run .#test-guest -- \
             --distro fedora \
             --with podman \
             --with selinux \
             --install rpm-input/openshell-[0-9]*.rpm \
             --install rpm-input/openshell-gateway-[0-9]*.rpm \
             --copy "$guest_script:/tmp/conformance.sh" \
+            --copy conformance-input/openshell-conformance:/tmp/openshell-conformance \
             -- bash /tmp/conformance.sh

--- a/.github/workflows/rpm-package.yml
+++ b/.github/workflows/rpm-package.yml
@@ -37,83 +37,20 @@ jobs:
       matrix:
         include:
           - arch: x86_64
-            artifact_arch: amd64
             runner: linux-amd64-cpu8
             cli_target: x86_64-unknown-linux-musl
-            gnu_target: x86_64-unknown-linux-gnu
+            gateway_target: x86_64-unknown-linux-gnu
           - arch: aarch64
-            artifact_arch: arm64
             runner: linux-arm64-cpu8
             cli_target: aarch64-unknown-linux-musl
-            gnu_target: aarch64-unknown-linux-gnu
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
-    container:
-      image: fedora:latest
-    steps:
-      - name: Install build dependencies
-        run: |
-          dnf install -y \
-            packit rpm-build \
-            rust cargo gcc gcc-c++ make cmake pkg-config \
-            clang-devel z3-devel systemd-rpm-macros \
-            pandoc python3-devel git-core \
-            cargo-rpm-macros
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.checkout-ref }}
-          fetch-depth: 0
-
-      - name: Download CLI artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: openshell-${{ matrix.cli_target }}
-          path: package-binaries/
-
-      - name: Download gateway artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: openshell-gateway-${{ matrix.gnu_target }}
-          path: package-binaries/
-
-      - name: Configure package inputs
-        run: |
-          set -euo pipefail
-          chmod +x package-binaries/openshell{,-gateway}
-          ls -lah package-binaries
-
-      - name: Mark workspace safe for git
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Fetch tags
-        run: git fetch --tags --force
-
-      - name: Build RPMs via Packit
-        env:
-          OPENSHELL_RPM_VERSION: ${{ inputs['rpm-version'] }}
-          OPENSHELL_RPM_RELEASE: ${{ inputs['rpm-release'] }}
-          OPENSHELL_CARGO_VERSION: ${{ inputs['cargo-version'] }}
-          OPENSHELL_PREBUILT_BINARIES_DIR: ${{ github.workspace }}/package-binaries
-        run: packit build locally
-
-      - name: Collect RPM artifacts
-        run: |
-          set -euo pipefail
-          mkdir -p artifacts
-          mapfile -t rpms < <(find "$GITHUB_WORKSPACE" -maxdepth 3 -type f -name '*.rpm' ! -name '*.src.rpm' | sort)
-          if [ "${#rpms[@]}" -eq 0 ]; then
-            echo "::error::No RPM artifacts found under $GITHUB_WORKSPACE"
-            find "$GITHUB_WORKSPACE" -maxdepth 3 -type f | sort
-            exit 1
-          fi
-          cp "${rpms[@]}" artifacts/
-          echo "=== Built RPMs ==="
-          ls -lah artifacts/
-
-      - name: Upload RPM artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: rpm-linux-${{ matrix.arch }}
-          path: artifacts/*.rpm
-          retention-days: 5
+            gateway_target: aarch64-unknown-linux-gnu
+    uses: ./.github/workflows/build-rpm.yml
+    with:
+      checkout-ref: ${{ inputs.checkout-ref }}
+      arch: ${{ matrix.arch }}
+      runner: ${{ matrix.runner }}
+      cli-target: ${{ matrix.cli_target }}
+      gateway-target: ${{ matrix.gateway_target }}
+      rpm-version: ${{ inputs.rpm-version }}
+      rpm-release: ${{ inputs.rpm-release }}
+      cargo-version: ${{ inputs.cargo-version }}

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,7 +11,6 @@ specfile_path: openshell.spec
 
 # Packages needed in the SRPM build environment to create vendor tarball
 srpm_build_deps:
-  - rust
   - cargo
   - git-core
 
@@ -45,10 +44,6 @@ actions:
     # dist-info stays at the RPM Version; dev build identity is carried by
     # Release so Fedora's Python RPM post-processing can normalize metadata.
     - 'bash -c "if [ -n \"${OPENSHELL_CARGO_VERSION:-}\" ]; then sed -i -r \"s/^%global openshell_cargo_version .*/%global openshell_cargo_version ${OPENSHELL_CARGO_VERSION}/\" openshell.spec; fi"'
-    # Override image_tag to 'latest' for tagged stable releases.
-    # For PR and commit-to-main builds the spec default ('dev') is kept,
-    # matching the :dev images pushed by release-dev.yml.
-    - 'bash -c "if git describe --exact-match --tags HEAD 2>/dev/null | grep -qE ''^v[0-9]+\.[0-9]+\.[0-9]+$''; then sed -i ''s/^%global image_tag.*/%global image_tag latest/'' openshell.spec; fi"'
 
 jobs:
   # Build on every pull request targeting main for CI validation

--- a/nix/test-guest/cache-seal.sh
+++ b/nix/test-guest/cache-seal.sh
@@ -49,7 +49,9 @@ sync
 # Deleted credentials can remain in allocated blocks. Fill free space with
 # zeroes so qemu-img convert can safely omit those blocks from the cache disk.
 zero_file=/var/tmp/openshell-cache-zero
-dd if=/dev/zero of="${zero_file}" bs=64M status=none 2>/dev/null || true
+echo "==> Cache sealing: zeroing free disk space"
+dd if=/dev/zero of="${zero_file}" bs=64M status=progress || true
+echo "==> Cache sealing: free disk space zeroed"
 rm -f "${zero_file}"
 sync
 

--- a/openshell.spec
+++ b/openshell.spec
@@ -12,12 +12,6 @@
 # in the format redhat-rpm-config expects (especially on EPEL).
 %global debug_package %{nil}
 
-# Default container image tag for supervisor and sandbox images.
-# Overridden to 'latest' by Packit's fix-spec-file action for tagged stable
-# releases (via git describe --exact-match). PR and commit-to-main builds
-# keep the default 'dev' so they track the development image stream.
-%global image_tag dev
-
 Name:           openshell
 Version:        %{openshell_version}
 Release:        1.20260518180028805757.podman.toml.gateway.listener.11.g8c0cb7c8%{?dist}
@@ -30,21 +24,9 @@ Source1: openshell-%{openshell_version}-vendor.tar.xz
 
 ExclusiveArch:  x86_64 aarch64
 
-# Rust build dependencies
-# NOTE: MSRV is 1.88 (Rust edition 2024). As of mid-2025, this requires
-# Fedora Rawhide or newer. Stable Fedora and EPEL-10 may ship older Rust;
-# adjust targets in .packit.yaml accordingly or provide a supplementary
-# Rust toolchain via additional_repos in the COPR build config.
-BuildRequires:  rust >= 1.88
+# Cargo metadata generation
 BuildRequires:  cargo
 BuildRequires:  cargo-rpm-macros >= 25
-BuildRequires:  gcc
-BuildRequires:  gcc-c++
-BuildRequires:  make
-BuildRequires:  cmake
-BuildRequires:  pkg-config
-BuildRequires:  clang-devel
-BuildRequires:  z3-devel
 BuildRequires:  systemd-rpm-macros
 
 # Man page generation
@@ -103,18 +85,8 @@ sed -i 's/^version = "0.0.0"/version = "%{openshell_cargo_version}"/' Cargo.toml
 grep -q 'version = "%{openshell_cargo_version}"' Cargo.toml || (echo "ERROR: Cargo.toml version patch failed" && exit 1)
 
 %build
-# Build the CLI and gateway binaries unless the release workflow supplied the
-# same prebuilt artifacts used for tarballs and Debian packages.
-export CARGO_BUILD_JOBS=%{_smp_build_ncpus}
-# Set the default container image tag so compiled-in image refs point at
-# real tags in the ghcr.io/nvidia/openshell registry.
-export OPENSHELL_IMAGE_TAG=%{image_tag}
-if [ -n "${OPENSHELL_PREBUILT_BINARIES_DIR:-}" ]; then
-  test -x "${OPENSHELL_PREBUILT_BINARIES_DIR}/openshell"
-  test -x "${OPENSHELL_PREBUILT_BINARIES_DIR}/openshell-gateway"
-else
-  cargo build --release --bin openshell --bin openshell-gateway
-fi
+test -x "${OPENSHELL_PREBUILT_BINARIES_DIR}/openshell"
+test -x "${OPENSHELL_PREBUILT_BINARIES_DIR}/openshell-gateway"
 
 # Generate vendored crate manifest and license metadata.
 # cargo-vendor.txt is consumed by an RPM generator (from cargo-rpm-macros)
@@ -129,18 +101,10 @@ pandoc -s -t man deploy/man/openshell-gateway.8.md -o openshell-gateway.8
 
 %install
 # --- CLI binary ---
-if [ -n "${OPENSHELL_PREBUILT_BINARIES_DIR:-}" ]; then
-  install -Dpm 0755 "${OPENSHELL_PREBUILT_BINARIES_DIR}/%{name}" %{buildroot}%{_bindir}/%{name}
-else
-  install -Dpm 0755 target/release/%{name} %{buildroot}%{_bindir}/%{name}
-fi
+install -Dpm 0755 "${OPENSHELL_PREBUILT_BINARIES_DIR}/%{name}" %{buildroot}%{_bindir}/%{name}
 
 # --- Gateway binary ---
-if [ -n "${OPENSHELL_PREBUILT_BINARIES_DIR:-}" ]; then
-  install -Dpm 0755 "${OPENSHELL_PREBUILT_BINARIES_DIR}/%{name}-gateway" %{buildroot}%{_bindir}/%{name}-gateway
-else
-  install -Dpm 0755 target/release/%{name}-gateway %{buildroot}%{_bindir}/%{name}-gateway
-fi
+install -Dpm 0755 "${OPENSHELL_PREBUILT_BINARIES_DIR}/%{name}-gateway" %{buildroot}%{_bindir}/%{name}-gateway
 
 # --- Default gateway TOML config template ---
 # Shipped as a read-only reference in %{_datadir}. The systemd unit seeds a


### PR DESCRIPTION
## Summary

Add an initial Fedora conformance workflow that builds the OpenShell RPMs from the PR commit, installs them in a disposable Fedora guest, and verifies the local gateway with `openshell status`.

## Related Issue

No issue required: this is an initial CI proof of concept for the RFC 014 conformance pipeline.

## Changes

- Add a `Conformance` workflow for PR mirror branches and manual dispatches
- Reuse the existing CLI, gateway, and RPM build workflows
- Boot a disposable Fedora guest with rootless Podman and enforcing SELinux
- Install the generated `openshell` and `openshell-gateway` RPMs
- Start and register the package-managed gateway
- Run `openshell status`
- Print gateway, Podman, and SELinux diagnostics when the guest check fails

## Testing

- [x] `nix run nixpkgs#actionlint -- .github/workflows/conformance.yml`
- [x] `git diff --check`
- [ ] `mise run pre-commit` — not run
- [ ] GitHub Actions conformance run — pending PR creation
- Unit tests are not applicable to this workflow-only change

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)
