### PR TITLE
fix(release): handle prerelease tag builds

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -47,11 +47,11 @@ jobs:
         id: v
         run: |
           set -euo pipefail
-          echo "python=$(uv run python tasks/scripts/release.py get-version --python)" >> "$GITHUB_OUTPUT"
-          echo "cargo=$(uv run python tasks/scripts/release.py get-version --cargo)" >> "$GITHUB_OUTPUT"
-          echo "deb=$(uv run python tasks/scripts/release.py get-version --deb)" >> "$GITHUB_OUTPUT"
-          echo "rpm_version=$(uv run python tasks/scripts/release.py get-version --rpm-version)" >> "$GITHUB_OUTPUT"
-          echo "rpm_release=$(uv run python tasks/scripts/release.py get-version --rpm-release)" >> "$GITHUB_OUTPUT"
+          echo "python=$(uv run python tasks/scripts/release.py get-version --dev --python)" >> "$GITHUB_OUTPUT"
+          echo "cargo=$(uv run python tasks/scripts/release.py get-version --dev --cargo)" >> "$GITHUB_OUTPUT"
+          echo "deb=$(uv run python tasks/scripts/release.py get-version --dev --deb)" >> "$GITHUB_OUTPUT"
+          echo "rpm_version=$(uv run python tasks/scripts/release.py get-version --dev --rpm-version)" >> "$GITHUB_OUTPUT"
+          echo "rpm_release=$(uv run python tasks/scripts/release.py get-version --dev --rpm-release)" >> "$GITHUB_OUTPUT"
 
   build-cli:
     needs: compute-versions

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "v*.*.*"
-      - "!v*.*.*-pre.*"
   workflow_dispatch:
     inputs:
       tag:

--- a/python/release_tooling_test.py
+++ b/python/release_tooling_test.py
@@ -49,7 +49,7 @@ def test_prerelease_versions_share_tag_identity() -> None:
         (0, 1, 0), 1, "152d05940", "v0.1.0-pre.1"
     )
 
-    assert versions.python == "0.1.0-pre.1"
+    assert versions.python == "0.1.0rc1"
     assert versions.cargo == "0.1.0-pre.1"
     assert versions.npm == "0.1.0-pre.1"
     assert versions.docker == "0.1.0-pre.1"
@@ -73,3 +73,22 @@ def test_prerelease_tag_parser_requires_positive_sequence() -> None:
     assert release._parse_prerelease_tag("v0.1.0") is None
     assert release._parse_prerelease_tag("v0.1.0-pre.0") is None
     assert release._parse_prerelease_tag("v0.1.0-rc.1") is None
+
+
+def test_dev_versions_ignore_exact_prerelease_tag(monkeypatch) -> None:
+    def fake_git(args: list[str]) -> str:
+        if args == ["rev-parse", "--short=9", "HEAD"]:
+            return "152d05940"
+        if args == ["tag", "--merged", "HEAD", "--list", "v*.*.*"]:
+            return "v0.0.37\nv0.1.0-pre.1"
+        if args == ["rev-list", "v0.0.37..HEAD", "--count"]:
+            return "108"
+        raise AssertionError(f"unexpected git command: {args}")
+
+    monkeypatch.setattr(release, "_git", fake_git)
+
+    versions = release._compute_dev_versions()
+
+    assert versions.python == "0.0.38.dev108+g152d05940"
+    assert versions.cargo == "0.0.38-dev.108+g152d05940"
+    assert versions.git_tag == "v0.0.37"

--- a/tasks/scripts/release.py
+++ b/tasks/scripts/release.py
@@ -169,7 +169,7 @@ def _versions_from_prerelease(
 ) -> Versions:
     version = f"{_format_semver(base_version)}-pre.{sequence}"
     return Versions(
-        python=version,
+        python=f"{_format_semver(base_version)}rc{sequence}",
         cargo=version,
         npm=version,
         docker=version,
@@ -213,6 +213,21 @@ def _compute_versions() -> Versions:
     return _versions_from_parts(parsed_tag, git_distance, git_sha, git_tag)
 
 
+def _compute_dev_versions() -> Versions:
+    git_sha = _git(["rev-parse", "--short=9", "HEAD"])
+    git_tag = _latest_stable_tag()
+    if git_tag is None:
+        git_distance = int(_git(["rev-list", "--count", "HEAD"]))
+        return _versions_from_parts((0, 0, 0), git_distance, git_sha, "")
+
+    parsed_tag = _parse_semver_tag(git_tag)
+    if parsed_tag is None:
+        raise RuntimeError(f"invalid semantic release tag: {git_tag}")
+
+    git_distance = int(_git(["rev-list", f"{git_tag}..HEAD", "--count"]))
+    return _versions_from_parts(parsed_tag, git_distance, git_sha, git_tag)
+
+
 def _print_env(versions: Versions) -> None:
     print(f"VERSION_PY={versions.python}")
     print(f"VERSION_CARGO={versions.cargo}")
@@ -227,8 +242,8 @@ def _print_env(versions: Versions) -> None:
     print(f"GIT_DISTANCE={versions.git_distance}")
 
 
-def get_version(format: str) -> None:
-    versions = _compute_versions()
+def get_version(format: str, *, dev: bool = False) -> None:
+    versions = _compute_dev_versions() if dev else _compute_versions()
     if format == "python":
         print(versions.python)
     elif format == "cargo":
@@ -492,6 +507,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     get_version_parser = sub.add_parser("get-version", help="Print computed version.")
     get_version_parser.add_argument(
+        "--dev", action="store_true", help="Ignore exact tags and print a dev version."
+    )
+    get_version_parser.add_argument(
         "--python", action="store_true", help="Print Python version only."
     )
     get_version_parser.add_argument(
@@ -550,25 +568,25 @@ def main() -> None:
 
     if args.command == "get-version":
         if args.python:
-            get_version("python")
+            get_version("python", dev=args.dev)
         elif args.cargo:
-            get_version("cargo")
+            get_version("cargo", dev=args.dev)
         elif args.npm:
-            get_version("npm")
+            get_version("npm", dev=args.dev)
         elif args.docker:
-            get_version("docker")
+            get_version("docker", dev=args.dev)
         elif args.deb:
-            get_version("deb")
+            get_version("deb", dev=args.dev)
         elif args.snap:
-            get_version("snap")
+            get_version("snap", dev=args.dev)
         elif args.rpm_version:
-            get_version("rpm-version")
+            get_version("rpm-version", dev=args.dev)
         elif args.rpm_release:
-            get_version("rpm-release")
+            get_version("rpm-release", dev=args.dev)
         elif args.json:
-            get_version("json")
+            get_version("json", dev=args.dev)
         else:
-            get_version("all")
+            get_version("all", dev=args.dev)
     elif args.command == "generate-homebrew-formula":
         generate_homebrew_formula(
             release_tag=args.release_tag,


### PR DESCRIPTION
## Summary

Fix prerelease tag builds so tags such as `v0.1.0-pre.1` run the existing `Release Tag` workflow and publish prerelease artifacts without creating a GitHub Release.

## Related Issue

None. This is a localized fix for the prerelease release workflow.

## Changes

- Allow `Release Tag` to trigger for `v*.*.*-pre.*` tags.
- Keep prerelease publication in the existing tagged-release workflow.
- Normalize Python prerelease versions to PEP 440-compatible versions such as `0.1.0rc1`.
- Make `Release Dev` explicitly calculate a dev version, preventing concurrently created tags from changing its artifact versions.
- Add coverage confirming dev builds ignore exact prerelease tags.

## Testing

- `nix develop -c uv run pytest python/release_tooling_test.py -q`
  - 6 tests passed.
- `nix run nixpkgs#actionlint -- .github/workflows/release-dev.yml .github/workflows/release-tag.yml`
  - No workflow errors; only existing ShellCheck style/informational findings.
- `git diff --check`

## Checklist

- [x] The change is scoped to prerelease versioning and release workflow behavior.
- [x] Focused tests pass.
- [x] GitHub Actions workflows were validated with actionlint.
- [x] The commit includes a DCO sign-off.
- [ ] Pre-commit was not run, as requested.
