### PR TITLE
fix(release): provide conformance binary to e2e

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -63,6 +63,30 @@ jobs:
       image-tag: dev
     secrets: inherit
 
+  build-conformance:
+    needs: compute-versions
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - triple: x86_64-unknown-linux-musl
+            runner: linux-amd64-cpu8
+            dev_shell: .#devShells.x86_64-linux.musl
+          - triple: aarch64-unknown-linux-musl
+            runner: linux-arm64-cpu8
+            dev_shell: .#devShells.aarch64-linux.musl
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      package: openshell-conformance-cli
+      binary: openshell-conformance
+      artifact-name: openshell-conformance-${{ matrix.triple }}
+      triple: ${{ matrix.triple }}
+      runner: ${{ matrix.runner }}
+      dev-shell: ${{ matrix.dev_shell }}
+      cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
+    secrets: inherit
+
   build-gateway:
     needs: compute-versions
     permissions:
@@ -125,7 +149,7 @@ jobs:
     secrets: inherit
 
   docker-e2e:
-    needs: [build-cli, build-gateway, build-supervisor-image]
+    needs: [build-cli, build-conformance, build-gateway, build-supervisor-image]
     permissions:
       actions: read
       contents: read
@@ -134,9 +158,10 @@ jobs:
     with:
       image-tag: ${{ github.sha }}
       runner: linux-arm64-cpu8
+      conformance-artifact-prefix: openshell-conformance
 
   podman-e2e:
-    needs: [build-cli, build-gateway, build-supervisor-image]
+    needs: [build-cli, build-conformance, build-gateway, build-supervisor-image]
     permissions:
       actions: read
       contents: read
@@ -144,14 +169,17 @@ jobs:
     uses: ./.github/workflows/e2e-podman-test.yml
     with:
       image-tag: ${{ github.sha }}
+      conformance-artifact-prefix: openshell-conformance
 
   vm-e2e:
-    needs: [build-cli, build-gateway, build-vm-driver]
+    needs: [build-cli, build-conformance, build-gateway, build-vm-driver]
     permissions:
       actions: read
       contents: read
       packages: read
     uses: ./.github/workflows/e2e-vm-test.yml
+    with:
+      conformance-artifact-prefix: openshell-conformance
 
   tag-ghcr-dev:
     name: Tag GHCR Images as Dev

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -96,6 +96,31 @@ jobs:
       checkout-ref: ${{ inputs.tag || github.ref }}
     secrets: inherit
 
+  build-conformance:
+    needs: compute-versions
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - triple: x86_64-unknown-linux-musl
+            runner: linux-amd64-cpu8
+            dev_shell: .#devShells.x86_64-linux.musl
+          - triple: aarch64-unknown-linux-musl
+            runner: linux-arm64-cpu8
+            dev_shell: .#devShells.aarch64-linux.musl
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      package: openshell-conformance-cli
+      binary: openshell-conformance
+      artifact-name: openshell-conformance-${{ matrix.triple }}
+      triple: ${{ matrix.triple }}
+      runner: ${{ matrix.runner }}
+      dev-shell: ${{ matrix.dev_shell }}
+      cargo-version: ${{ needs.compute-versions.outputs.cargo_version }}
+      checkout-ref: ${{ inputs.tag || github.ref }}
+    secrets: inherit
+
   build-gateway:
     needs: compute-versions
     permissions:
@@ -165,7 +190,7 @@ jobs:
     secrets: inherit
 
   docker-e2e:
-    needs: [compute-versions, build-cli, build-gateway, build-supervisor-image]
+    needs: [compute-versions, build-cli, build-conformance, build-gateway, build-supervisor-image]
     permissions:
       actions: read
       contents: read
@@ -175,9 +200,10 @@ jobs:
       image-tag: ${{ needs.compute-versions.outputs.source_sha }}
       checkout-ref: ${{ inputs.tag || github.ref }}
       runner: linux-arm64-cpu8
+      conformance-artifact-prefix: openshell-conformance
 
   podman-e2e:
-    needs: [compute-versions, build-cli, build-gateway, build-supervisor-image]
+    needs: [compute-versions, build-cli, build-conformance, build-gateway, build-supervisor-image]
     permissions:
       actions: read
       contents: read
@@ -186,9 +212,10 @@ jobs:
     with:
       image-tag: ${{ needs.compute-versions.outputs.source_sha }}
       checkout-ref: ${{ inputs.tag || github.ref }}
+      conformance-artifact-prefix: openshell-conformance
 
   vm-e2e:
-    needs: [compute-versions, build-cli, build-gateway, build-vm-driver]
+    needs: [compute-versions, build-cli, build-conformance, build-gateway, build-vm-driver]
     permissions:
       actions: read
       contents: read
@@ -196,6 +223,7 @@ jobs:
     uses: ./.github/workflows/e2e-vm-test.yml
     with:
       checkout-ref: ${{ inputs.tag || github.ref }}
+      conformance-artifact-prefix: openshell-conformance
 
   tag-ghcr-release:
     name: Tag GHCR Images


### PR DESCRIPTION
## Summary

Fix `Release Dev` and `Release Tag` E2E failures caused by the standalone conformance binary not being built or downloaded.

The conformance E2E changes added the required artifact wiring to branch E2E, but the two release workflows were missed. As a result, release E2E jobs attempted to execute a nonexistent fallback at `target/debug/openshell-conformance`.

## Related Issue

None. This is a localized regression fix following the conformance E2E changes in #2925.

## Changes

- Build `openshell-conformance` artifacts for x86_64 and ARM64 Linux in both release workflows.
- Make Docker, Podman, and VM E2E jobs depend on the conformance build.
- Pass `conformance-artifact-prefix: openshell-conformance` so each E2E job downloads the architecture-matched binary.
- Preserve the tagged checkout when building conformance for `Release Tag`.

## Testing

- `nix run nixpkgs#actionlint -- .github/workflows/release-dev.yml .github/workflows/release-tag.yml`
  - No workflow errors.
  - Only pre-existing ShellCheck style and informational findings were reported.
- `git diff --check`

## Checklist

- [x] The change is limited to release E2E artifact wiring.
- [x] The implementation matches the existing `branch-e2e.yml` pattern.
- [x] The affected workflows pass actionlint validation.
- [x] The commit includes a DCO sign-off.
- [ ] Pre-commit was not run, as requested.
