### PR TITLE
fix(providers): preserve authoritative profile lifecycle

### DIFF
--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -5013,12 +5013,10 @@ pub async fn provider_update(options: ProviderUpdateOptions<'_>) -> Result<()> {
             .into_inner()
             .provider
             .ok_or_else(|| miette::miette!("provider '{name}' not found"))?;
-        let profile_workspace = if existing.profile_workspace.is_empty() {
-            workspace
-        } else {
-            &existing.profile_workspace
-        };
-        Some(fetch_provider_profile(&mut client, &existing.r#type, profile_workspace).await?)
+        Some(
+            fetch_provider_profile(&mut client, &existing.r#type, &existing.profile_workspace)
+                .await?,
+        )
     } else {
         None
     };
@@ -5046,8 +5044,12 @@ pub async fn provider_update(options: ProviderUpdateOptions<'_>) -> Result<()> {
             .ok_or_else(|| miette::miette!("provider '{name}' not found"))?;
 
         let provider_type = existing.r#type;
-        let discovered =
-            discover_existing_provider_data(&mut client, &provider_type, workspace).await?;
+        let discovered = discover_existing_provider_data(
+            &mut client,
+            &provider_type,
+            &existing.profile_workspace,
+        )
+        .await?;
         let Some(discovered) = discovered else {
             return Err(miette::miette!(
                 "no existing local credentials/config found for provider type '{provider_type}'"

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -23,11 +23,12 @@ use openshell_core::proto::{
     HealthRequest, HealthResponse, ListProvidersRequest, ListProvidersResponse,
     ListSandboxProvidersRequest, ListSandboxProvidersResponse, ListSandboxesRequest,
     ListSandboxesResponse, Provider, ProviderCredentialRefresh, ProviderCredentialRefreshStatus,
-    ProviderCredentialRefreshStrategy, ProviderProfile, ProviderProfileCredential,
-    ProviderProfileDiscovery, ProviderResponse, RevokeSshSessionRequest, RevokeSshSessionResponse,
-    RotateProviderCredentialRequest, RotateProviderCredentialResponse, Sandbox, SandboxResponse,
-    SandboxStreamEvent, ServiceStatus, SettingValue, SupervisorMessage, UpdateProviderRequest,
-    WatchSandboxRequest, setting_value,
+    ProviderCredentialRefreshStrategy, ProviderCredentialTokenGrant,
+    ProviderCredentialTokenGrantSubjectToken, ProviderCredentialTokenGrantType, ProviderProfile,
+    ProviderProfileCredential, ProviderProfileDiscovery, ProviderResponse, RevokeSshSessionRequest,
+    RevokeSshSessionResponse, RotateProviderCredentialRequest, RotateProviderCredentialResponse,
+    Sandbox, SandboxResponse, SandboxStreamEvent, ServiceStatus, SettingValue, SupervisorMessage,
+    UpdateProviderRequest, WatchSandboxRequest, setting_value,
 };
 use openshell_core::{ObjectId, ObjectName};
 use std::collections::HashMap;
@@ -44,6 +45,7 @@ use tonic::{Response, Status};
 struct ProviderState {
     providers: Arc<Mutex<HashMap<String, Provider>>>,
     profiles: Arc<Mutex<HashMap<String, ProviderProfile>>>,
+    scoped_profiles: Arc<Mutex<HashMap<(String, String), ProviderProfile>>>,
     refresh_statuses: Arc<Mutex<HashMap<(String, String), ProviderCredentialRefreshStatus>>>,
     refresh_requests: Arc<Mutex<Vec<ProviderRefreshRequestLog>>>,
     provider_update_requests: Arc<Mutex<Vec<Provider>>>,
@@ -489,8 +491,18 @@ impl OpenShell for TestOpenShell {
         &self,
         request: tonic::Request<openshell_core::proto::GetProviderProfileRequest>,
     ) -> Result<Response<openshell_core::proto::ProviderProfileResponse>, Status> {
-        let id = request.into_inner().id;
-        let profile = if let Some(profile) = openshell_providers::builtin_profiles()
+        let request = request.into_inner();
+        let id = request.id;
+        let scoped_profile = self
+            .state
+            .scoped_profiles
+            .lock()
+            .await
+            .get(&(request.workspace, id.clone()))
+            .cloned();
+        let profile = if let Some(profile) = scoped_profile {
+            profile
+        } else if let Some(profile) = openshell_providers::builtin_profiles()
             .iter()
             .find(|profile| profile.id == id)
         {
@@ -2164,6 +2176,148 @@ async fn provider_update_from_existing_uses_profile_discovery_when_v2_enabled() 
     assert_eq!(
         provider.credentials.get("CUSTOM_UPDATE_DISCOVERY_API_KEY"),
         Some(&"updated-profile-secret".to_string())
+    );
+}
+
+#[tokio::test]
+async fn provider_update_from_existing_preserves_global_profile_scope() {
+    let ts = run_server().await;
+    enable_providers_v2(&ts).await;
+    let profile_id = "shadowed-update-discovery";
+    for (profile_workspace, env_var) in [
+        ("", "GLOBAL_UPDATE_DISCOVERY_API_KEY"),
+        ("default", "WORKSPACE_UPDATE_DISCOVERY_API_KEY"),
+    ] {
+        ts.state.scoped_profiles.lock().await.insert(
+            (profile_workspace.to_string(), profile_id.to_string()),
+            ProviderProfile {
+                id: profile_id.to_string(),
+                credentials: vec![ProviderProfileCredential {
+                    name: "api_key".to_string(),
+                    env_vars: vec![env_var.to_string()],
+                    required: true,
+                    ..Default::default()
+                }],
+                discovery: Some(ProviderProfileDiscovery {
+                    credentials: vec!["api_key".to_string()],
+                }),
+                ..Default::default()
+            },
+        );
+    }
+    ts.state.providers.lock().await.insert(
+        "global-update".to_string(),
+        Provider {
+            metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                id: "id-global-update".to_string(),
+                name: "global-update".to_string(),
+                workspace: "default".to_string(),
+                ..Default::default()
+            }),
+            r#type: profile_id.to_string(),
+            profile_workspace: String::new(),
+            ..Default::default()
+        },
+    );
+    let _env = EnvVarGuard::set(&[
+        ("GLOBAL_UPDATE_DISCOVERY_API_KEY", "global-secret"),
+        ("WORKSPACE_UPDATE_DISCOVERY_API_KEY", "workspace-secret"),
+    ]);
+
+    run::provider_update(run::ProviderUpdateOptions {
+        server: &ts.endpoint,
+        name: "global-update",
+        from_existing: true,
+        from_oidc_token: false,
+        credentials: &[],
+        config: &[],
+        credential_expires_at: &[],
+        workspace: "default",
+        tls: &ts.tls,
+    })
+    .await
+    .expect("global profile-backed provider update --from-existing");
+
+    let provider = ts
+        .state
+        .providers
+        .lock()
+        .await
+        .get("global-update")
+        .cloned()
+        .expect("global provider should still be stored");
+    assert_eq!(
+        provider.credentials.get("GLOBAL_UPDATE_DISCOVERY_API_KEY"),
+        Some(&"global-secret".to_string())
+    );
+    assert!(
+        !provider
+            .credentials
+            .contains_key("WORKSPACE_UPDATE_DISCOVERY_API_KEY")
+    );
+}
+
+#[tokio::test]
+async fn provider_update_from_oidc_token_preserves_global_profile_scope() {
+    let ts = run_server().await;
+    let profile_id = "shadowed-oidc-update";
+    for (profile_workspace, subject_credential) in [
+        ("", "GLOBAL_SUBJECT_TOKEN"),
+        ("default", "WORKSPACE_SUBJECT_TOKEN"),
+    ] {
+        ts.state.scoped_profiles.lock().await.insert(
+            (profile_workspace.to_string(), profile_id.to_string()),
+            ProviderProfile {
+                id: profile_id.to_string(),
+                credentials: vec![ProviderProfileCredential {
+                    name: "dynamic_token".to_string(),
+                    token_grant: Some(ProviderCredentialTokenGrant {
+                        grant_type: ProviderCredentialTokenGrantType::TokenExchange as i32,
+                        subject_token: Some(ProviderCredentialTokenGrantSubjectToken {
+                            source: "provider_credential".to_string(),
+                            credential: subject_credential.to_string(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        );
+    }
+    ts.state.providers.lock().await.insert(
+        "global-oidc-update".to_string(),
+        Provider {
+            metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
+                id: "id-global-oidc-update".to_string(),
+                name: "global-oidc-update".to_string(),
+                workspace: "default".to_string(),
+                ..Default::default()
+            }),
+            r#type: profile_id.to_string(),
+            profile_workspace: String::new(),
+            ..Default::default()
+        },
+    );
+
+    let err = run::provider_update(run::ProviderUpdateOptions {
+        server: &ts.endpoint,
+        name: "global-oidc-update",
+        from_existing: false,
+        from_oidc_token: true,
+        credentials: &["GLOBAL_SUBJECT_TOKEN".to_string()],
+        config: &[],
+        credential_expires_at: &[],
+        workspace: "default",
+        tls: &ts.tls,
+    })
+    .await
+    .expect_err("unnamed test gateway should stop after profile validation");
+
+    assert!(
+        err.to_string().contains("active named OIDC gateway"),
+        "global profile should accept GLOBAL_SUBJECT_TOKEN before OIDC loading: {err}"
     );
 }
 

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -645,6 +645,55 @@ where
     Ok(out)
 }
 
+async fn providers_using_profile(
+    store: &Store,
+    workspace: &str,
+    profile_id: &str,
+) -> Result<Vec<String>, Status> {
+    let is_platform_scope = workspace.is_empty();
+    let mut offset = 0u32;
+    let mut blocking = Vec::new();
+    loop {
+        let records = if is_platform_scope {
+            store
+                .list_by_type(Provider::object_type(), 1000, offset)
+                .await
+        } else {
+            store
+                .list(Provider::object_type(), workspace, 1000, offset)
+                .await
+        }
+        .map_err(|e| Status::internal(format!("list providers failed: {e}")))?;
+        if records.is_empty() {
+            break;
+        }
+        offset = offset
+            .checked_add(
+                u32::try_from(records.len())
+                    .map_err(|_| Status::internal("provider page size exceeded u32"))?,
+            )
+            .ok_or_else(|| Status::internal("provider pagination offset overflow"))?;
+        for record in records {
+            let provider = Provider::decode(record.payload.as_slice())
+                .map_err(|e| Status::internal(format!("decode provider failed: {e}")))?;
+            if provider.profile_workspace != workspace
+                || normalize_profile_id(&provider.r#type).as_deref() != Some(profile_id)
+            {
+                continue;
+            }
+            let label = if is_platform_scope {
+                format!("{}/{}", provider.object_workspace(), provider.object_name())
+            } else {
+                provider.object_name().to_string()
+            };
+            blocking.push(label);
+        }
+    }
+    blocking.sort();
+    blocking.dedup();
+    Ok(blocking)
+}
+
 async fn sandboxes_using_provider(
     store: &Store,
     workspace: &str,
@@ -2377,6 +2426,7 @@ pub(super) async fn handle_create_provider(
     if state.credentials.stores_provider_credentials() && !provider.credentials.is_empty() {
         state.compute.ensure_workspace(&workspace).await?;
     }
+    let _sandbox_sync_guard = state.compute.sandbox_sync_guard().await;
     let catalog = state
         .provider_profile_sources
         .snapshot_catalog(state.store.as_ref(), &workspace)
@@ -2824,11 +2874,11 @@ pub(super) async fn handle_delete_provider_profile(
         return Err(Status::not_found("provider profile not found"));
     }
 
-    let blocking_sandboxes = sandboxes_using_profile(state.store.as_ref(), &workspace, &id).await?;
-    if !blocking_sandboxes.is_empty() {
+    let blocking_providers = providers_using_profile(state.store.as_ref(), &workspace, &id).await?;
+    if !blocking_providers.is_empty() {
         return Err(Status::failed_precondition(format!(
-            "provider profile '{id}' is in use by sandboxes: {}",
-            blocking_sandboxes.join(", ")
+            "provider profile '{id}' is in use by providers: {}",
+            blocking_providers.join(", ")
         )));
     }
 
@@ -3435,72 +3485,6 @@ fn has_errors(diagnostics: &[ProfileValidationDiagnostic]) -> bool {
     diagnostics
         .iter()
         .any(|diagnostic| diagnostic.severity == "error")
-}
-
-async fn sandboxes_using_profile(
-    store: &Store,
-    workspace: &str,
-    profile_id: &str,
-) -> Result<Vec<String>, Status> {
-    let is_platform_scope = workspace.is_empty();
-
-    let candidates = if is_platform_scope {
-        scan_sandboxes_all(store, |sandbox| {
-            let has_providers = sandbox
-                .spec
-                .as_ref()
-                .is_some_and(|s| !s.providers.is_empty());
-            has_providers.then_some(sandbox)
-        })
-        .await?
-    } else {
-        scan_sandboxes(store, workspace, |sandbox| {
-            let has_providers = sandbox
-                .spec
-                .as_ref()
-                .is_some_and(|s| !s.providers.is_empty());
-            has_providers.then_some(sandbox)
-        })
-        .await?
-    };
-
-    let mut blocking = Vec::new();
-    for sandbox in candidates {
-        let sandbox_workspace = sandbox.object_workspace().to_string();
-        let spec = sandbox.spec.as_ref().expect("filtered by scan_sandboxes");
-        for provider_name in &spec.providers {
-            let provider_ws = if is_platform_scope {
-                &sandbox_workspace
-            } else {
-                workspace
-            };
-            let Some(provider) = store
-                .get_message_by_name::<Provider>(provider_ws, provider_name)
-                .await
-                .map_err(|e| Status::internal(format!("fetch provider failed: {e}")))?
-            else {
-                continue;
-            };
-            if is_platform_scope && !provider.profile_workspace.is_empty() {
-                continue;
-            }
-            if !is_platform_scope && provider.profile_workspace.is_empty() {
-                continue;
-            }
-            if normalize_profile_id(&provider.r#type).as_deref() == Some(profile_id) {
-                let label = if is_platform_scope {
-                    format!("{}/{}", sandbox_workspace, sandbox.object_name())
-                } else {
-                    sandbox.object_name().to_string()
-                };
-                blocking.push(label);
-                break;
-            }
-        }
-    }
-    blocking.sort();
-    blocking.dedup();
-    Ok(blocking)
 }
 
 pub(super) async fn handle_update_provider(
@@ -4749,17 +4733,17 @@ mod tests {
     use crate::grpc::{MAX_MAP_KEY_LEN, MAX_PROVIDER_TYPE_LEN};
     use crate::persistence::test_store;
     use openshell_core::proto::{
-        ConfigureProviderRefreshRequest, CreateProviderRequest, CreateWorkspaceRequest,
-        DeleteProviderProfileRequest, DeleteProviderRefreshRequest, DeleteProviderRequest,
-        GetProviderProfileRequest, GetProviderRefreshStatusRequest, GetProviderRequest,
-        ImportProviderProfilesRequest, L7Allow, L7Rule, LintProviderProfilesRequest,
-        ListProviderProfilesRequest, ListProvidersRequest, NetworkBinary, NetworkEndpoint,
-        NetworkPolicyRule, ProviderCredentialRefresh, ProviderCredentialRefreshMaterial,
-        ProviderCredentialRefreshRecoveryAction, ProviderCredentialTokenGrant,
-        ProviderCredentialTokenGrantAudienceOverride, ProviderProfile, ProviderProfileCategory,
-        ProviderProfileCredential, ProviderProfileImportItem, RotateProviderCredentialRequest,
-        Sandbox, SandboxPolicy, SandboxSpec, StoredProviderProfile, UpdateProviderProfilesRequest,
-        UpdateProviderRequest,
+        AttachSandboxProviderRequest, ConfigureProviderRefreshRequest, CreateProviderRequest,
+        CreateWorkspaceRequest, DeleteProviderProfileRequest, DeleteProviderRefreshRequest,
+        DeleteProviderRequest, GetProviderProfileRequest, GetProviderRefreshStatusRequest,
+        GetProviderRequest, ImportProviderProfilesRequest, L7Allow, L7Rule,
+        LintProviderProfilesRequest, ListProviderProfilesRequest, ListProvidersRequest,
+        NetworkBinary, NetworkEndpoint, NetworkPolicyRule, ProviderCredentialRefresh,
+        ProviderCredentialRefreshMaterial, ProviderCredentialRefreshRecoveryAction,
+        ProviderCredentialTokenGrant, ProviderCredentialTokenGrantAudienceOverride,
+        ProviderProfile, ProviderProfileCategory, ProviderProfileCredential,
+        ProviderProfileImportItem, RotateProviderCredentialRequest, Sandbox, SandboxPolicy,
+        SandboxSpec, StoredProviderProfile, UpdateProviderProfilesRequest, UpdateProviderRequest,
     };
     use openshell_core::{ObjectId, ObjectName};
     use tonic::{Code, Request};
@@ -6295,7 +6279,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_provider_profile_rejects_builtin_and_in_use_custom_profiles() {
+    async fn delete_provider_profile_rejects_builtin_and_provider_referenced_profiles() {
         let state = test_server_state().await;
         handle_import_provider_profiles(
             &state,
@@ -6333,7 +6317,7 @@ mod tests {
             .put_message(&Sandbox {
                 metadata: Some(openshell_core::proto::datamodel::v1::ObjectMeta {
                     id: "sandbox-id".to_string(),
-                    name: "sandbox-using-custom".to_string(),
+                    name: "sandbox-custom".to_string(),
                     created_at_ms: 0,
                     labels: HashMap::new(),
                     resource_version: 0,
@@ -6342,7 +6326,7 @@ mod tests {
                     deletion_timestamp_ms: 0,
                 }),
                 spec: Some(SandboxSpec {
-                    providers: vec!["custom-provider".to_string()],
+                    providers: Vec::new(),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -6360,7 +6344,57 @@ mod tests {
         .await
         .unwrap_err();
         assert_eq!(in_use_err.code(), Code::FailedPrecondition);
-        assert!(in_use_err.message().contains("sandbox-using-custom"));
+        assert!(in_use_err.message().contains("custom-provider"));
+
+        let attached = super::super::sandbox::handle_attach_sandbox_provider(
+            &state,
+            authed_request(AttachSandboxProviderRequest {
+                sandbox_name: "sandbox-custom".to_string(),
+                provider_name: "custom-provider".to_string(),
+                expected_resource_version: 0,
+                workspace: "default".to_string(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        assert!(attached.attached);
+    }
+
+    #[tokio::test]
+    async fn delete_global_provider_profile_checks_providers_in_every_workspace() {
+        let state = test_server_state().await;
+        state
+            .store
+            .put_message(&stored_provider_profile_for_workspace(
+                custom_profile("global-custom"),
+                "",
+            ))
+            .await
+            .unwrap();
+        let catalog = state
+            .provider_profile_sources
+            .snapshot_catalog(state.store.as_ref(), "default")
+            .await
+            .unwrap();
+        let mut provider = provider_with_values("global-provider", "global-custom");
+        provider.profile_workspace = String::new();
+        create_provider_record_with_catalog(state.store.as_ref(), &catalog, "default", provider)
+            .await
+            .unwrap();
+
+        let err = handle_delete_provider_profile(
+            &state,
+            authed_request(DeleteProviderProfileRequest {
+                id: "global-custom".to_string(),
+                workspace: String::new(),
+            }),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.code(), Code::FailedPrecondition);
+        assert!(err.message().contains("default/global-provider"));
     }
 
     #[tokio::test]
@@ -7703,6 +7737,54 @@ mod tests {
             .expect("delete should succeed")
             .into_inner();
         assert!(response.deleted);
+    }
+
+    #[tokio::test]
+    async fn create_provider_waits_for_provider_profile_delete_guard() {
+        let state = test_server_state().await;
+        handle_import_provider_profiles(
+            &state,
+            authed_request(ImportProviderProfilesRequest {
+                profiles: vec![ProviderProfileImportItem {
+                    profile: Some(custom_profile("guarded-create")),
+                    source: "guarded-create.yaml".to_string(),
+                }],
+                workspace: "default".to_string(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        let guard = state.compute.sandbox_sync_guard().await;
+        let task_state = state.clone();
+        let task = tokio::spawn(async move {
+            handle_create_provider(
+                &task_state,
+                authed_request(CreateProviderRequest {
+                    provider: Some(provider_with_values("guarded-provider", "guarded-create")),
+                    workspace: "default".to_string(),
+                }),
+            )
+            .await
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(
+            !task.is_finished(),
+            "provider create should wait for provider profile mutation guard"
+        );
+        drop(guard);
+
+        let response = tokio::time::timeout(std::time::Duration::from_secs(5), task)
+            .await
+            .expect("create should finish after guard release")
+            .expect("join create task")
+            .expect("create should succeed")
+            .into_inner();
+        assert_eq!(
+            response.provider.expect("provider").object_name(),
+            "guarded-provider"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fix two authoritative-profile lifecycle gaps reported in the post-merge review of #2962. Provider updates now resolve discovery and OIDC metadata from the provider persisted profile scope, and custom profiles cannot be deleted while any provider still references them.

## Related Issue

Follow-up to #2962, which implemented #1988.

## Changes

- Preserve global versus workspace profile scope during provider update discovery and OIDC subject-token inference
- Reject custom profile deletion while matching provider records exist, including global profiles referenced across workspaces
- Serialize provider creation with profile import, update, and deletion to close the create/delete race
- Add same-ID scope-shadowing, unattached-provider deletion, attach-after-rejected-delete, global-scope, and mutation-guard regressions

## Testing

- [x] `mise run pre-commit` passes
- [x] `mise run test` passes (with local tag signing disabled for throwaway release-range fixture repositories)
- [x] Unit and integration tests added/updated
- [ ] E2E tests added/updated (not applicable)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)