### PR TITLE
fix(sandbox): reconcile early container exits

### DIFF
--- a/crates/openshell-server/src/compute/mod.rs
+++ b/crates/openshell-server/src/compute/mod.rs
@@ -3637,7 +3637,17 @@ impl ComputeRuntime {
 
 fn apply_main_process_exit(sandbox: &mut Sandbox, instance_id: &str, exit_code: i32) {
     let sandbox_name = sandbox.object_name().to_string();
-    let preserve_infrastructure_error = sandbox.phase() == SandboxPhase::Error as i32;
+    // A driver can observe the container exit before the supervisor's
+    // authoritative main-process report arrives. In that ordering,
+    // ContainerExited is only a provisional classification: replace it with
+    // the canonical process result once its exit code is known. Preserve all
+    // other infrastructure errors.
+    let preserve_infrastructure_error = sandbox.phase() == SandboxPhase::Error as i32
+        && !sandbox.status.as_ref().is_some_and(|status| {
+            status.conditions.iter().any(|condition| {
+                condition.r#type == "Ready" && condition.reason == "ContainerExited"
+            })
+        });
     let status = sandbox.status.get_or_insert_with(|| SandboxStatus {
         sandbox_name: sandbox_name.clone(),
         ..Default::default()
@@ -5487,6 +5497,42 @@ mod tests {
             condition.r#type == "Ready"
                 && condition.status == "False"
                 && condition.reason == "MainProcessFailed"
+        }));
+    }
+
+    #[test]
+    fn main_process_exit_replaces_provisional_container_exit() {
+        let mut sandbox = error_sandbox_record("sb-1", "sandbox-a", "ContainerExited");
+        apply_main_process_exit(&mut sandbox, "instance-1", 0);
+
+        assert_eq!(
+            SandboxPhase::try_from(sandbox.phase()),
+            Ok(SandboxPhase::Completed)
+        );
+        let status = sandbox.status.as_ref().unwrap();
+        assert_eq!(status.exit_code, Some(0));
+        assert_eq!(status.main_process_instance_id, "instance-1");
+        assert!(status.conditions.iter().any(|condition| {
+            condition.r#type == "Ready"
+                && condition.status == "False"
+                && condition.reason == "MainProcessCompleted"
+        }));
+    }
+
+    #[test]
+    fn main_process_exit_preserves_specific_infrastructure_error() {
+        let mut sandbox = error_sandbox_record("sb-1", "sandbox-a", "BackendResourceMissing");
+        apply_main_process_exit(&mut sandbox, "instance-1", 0);
+
+        assert_eq!(
+            SandboxPhase::try_from(sandbox.phase()),
+            Ok(SandboxPhase::Error)
+        );
+        let status = sandbox.status.as_ref().unwrap();
+        assert_eq!(status.exit_code, Some(0));
+        assert_eq!(status.main_process_instance_id, "instance-1");
+        assert!(status.conditions.iter().any(|condition| {
+            condition.r#type == "Ready" && condition.reason == "BackendResourceMissing"
         }));
     }
 

--- a/e2e/rust/tests/oidc_pkce.rs
+++ b/e2e/rust/tests/oidc_pkce.rs
@@ -1372,8 +1372,10 @@ async fn delete_workspace(admin: &LoginSession, workspace: &str) {
     }
 }
 
+// Keep RBAC fixtures running until cleanup so authorization checks do not also
+// exercise fast canonical-process completion. That lifecycle belongs to the
+// dedicated sandbox_lifecycle suite.
 async fn assert_can_create_sandbox(session: &LoginSession, workspace: &str, sandbox_name: &str) {
-    let marker = format!("{sandbox_name}-ready");
     let create = run_workspace_cli(
         session,
         workspace,
@@ -1383,9 +1385,10 @@ async fn assert_can_create_sandbox(session: &LoginSession, workspace: &str, sand
             "--name",
             sandbox_name,
             "--no-tty",
+            "--detach",
             "--",
-            "echo",
-            &marker,
+            "sleep",
+            "infinity",
         ],
     )
     .await;
@@ -1405,10 +1408,6 @@ async fn assert_can_create_sandbox(session: &LoginSession, workspace: &str, sand
     let cleanup = run_workspace_cli(session, workspace, &["sandbox", "delete", sandbox_name]).await;
 
     assert!(
-        create_output.contains(&marker),
-        "sandbox command output should contain {marker}:\n{create_output}"
-    );
-    assert!(
         list.status.success() && list_output.contains(sandbox_name),
         "created sandbox {sandbox_name} should appear in the sandbox list:\n{list_output}"
     );
@@ -1420,7 +1419,6 @@ async fn assert_can_create_sandbox(session: &LoginSession, workspace: &str, sand
 }
 
 async fn assert_can_delete_sandbox(session: &LoginSession, workspace: &str, sandbox_name: &str) {
-    let marker = format!("{sandbox_name}-ready");
     let create = run_workspace_cli(
         session,
         workspace,
@@ -1430,9 +1428,10 @@ async fn assert_can_delete_sandbox(session: &LoginSession, workspace: &str, sand
             "--name",
             sandbox_name,
             "--no-tty",
+            "--detach",
             "--",
-            "echo",
-            &marker,
+            "sleep",
+            "infinity",
         ],
     )
     .await;


### PR DESCRIPTION
## Summary

Reconcile a generic driver `ContainerExited` result with a later authoritative supervisor main-process exit report. This prevents short-lived successful commands from being reported as provisioning failures when the Docker watcher wins the ordering race. The OIDC authorization fixtures are also made durable so RBAC coverage does not depend on fast-process lifecycle timing already exercised by the dedicated lifecycle suite.

## Related Issue

No issue required: this is a localized lifecycle race exposed by the OIDC-PKCE Docker E2E lane.

## Changes

- Treat `ContainerExited` as provisional when the supervisor subsequently reports the canonical process exit code
- Continue preserving specific infrastructure errors
- Add regression tests for both reconciliation and error preservation
- Use detached durable sandboxes for positive OIDC RBAC create/delete fixtures

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo test -p openshell-server compute::tests::main_process_exit -- --nocapture` passes
- [x] OIDC-PKCE E2E test target compiles with `--no-run`
- [ ] Docker OIDC-PKCE E2E (running in CI)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)