### PR TITLE
fix(ocsf): make exported events valid and attributable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4314,6 +4314,7 @@ dependencies = [
  "serde_repr",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/openshell-ocsf/Cargo.toml
+++ b/crates/openshell-ocsf/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_repr = "0.1"
 tracing = { workspace = true }
+uuid = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]

--- a/crates/openshell-ocsf/src/builders/mod.rs
+++ b/crates/openshell-ocsf/src/builders/mod.rs
@@ -205,21 +205,24 @@ impl SandboxContext {
             version: OCSF_VERSION.to_string(),
             product: Product::openshell_sandbox(&self.product_version),
             profiles: profiles.iter().map(|s| (*s).to_string()).collect(),
-            uid: Some(self.sandbox_id.clone()),
+            uid: Some(uuid::Uuid::new_v4().to_string()),
             log_source: None,
         }
     }
 
-    /// Build the OCSF `Container` object.
+    /// Build the OCSF `Container` object when the event concerns a sandbox.
     #[must_use]
-    pub fn container(&self) -> Container {
-        Container {
+    pub fn container(&self) -> Option<Container> {
+        if self.sandbox_id.is_empty() {
+            return None;
+        }
+        Some(Container {
             name: self.sandbox_name.clone(),
             uid: Some(self.sandbox_id.clone()),
-            image: Some(Image {
+            image: (!self.container_image.is_empty()).then(|| Image {
                 name: self.container_image.clone(),
             }),
-        }
+        })
     }
 
     /// Build the OCSF `Device` object.
@@ -249,7 +252,9 @@ impl SandboxContext {
             base.set_message(m);
         }
         base.set_device(self.device());
-        base.set_container(self.container());
+        if let Some(container) = self.container() {
+            base.set_container(container);
+        }
     }
 }
 
@@ -277,13 +282,15 @@ mod tests {
         assert_eq!(meta.version, "1.8.0");
         assert_eq!(meta.product.name, "OpenShell Sandbox Supervisor");
         assert_eq!(meta.profiles.len(), 2);
-        assert_eq!(meta.uid.as_deref(), Some("sandbox-abc123"));
+        let uid = meta.uid.as_deref().expect("uid is set");
+        assert!(!uid.is_empty());
+        assert_ne!(uid, "sandbox-abc123");
     }
 
     #[test]
     fn test_sandbox_context_container() {
         let ctx = test_sandbox_context();
-        let container = ctx.container();
+        let container = ctx.container().expect("sandbox context has a container");
         assert_eq!(container.name, "my-sandbox");
         assert_eq!(container.uid.as_deref(), Some("sandbox-abc123"));
     }

--- a/crates/openshell-ocsf/src/enums/device_type.rs
+++ b/crates/openshell-ocsf/src/enums/device_type.rs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! OCSF `device.type_id` enum.
+
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+/// OCSF Device Type ID.
+///
+/// Only the values `OpenShell` can produce are modelled; the schema defines a
+/// wider set (desktop, mobile, firewall, router, ...).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+pub enum DeviceTypeId {
+    /// 0 — Unknown
+    Unknown = 0,
+    /// 1 — Server
+    Server = 1,
+    /// 99 — Other
+    Other = 99,
+}
+
+impl DeviceTypeId {
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Unknown => "Unknown",
+            Self::Server => "Server",
+            Self::Other => "Other",
+        }
+    }
+
+    #[must_use]
+    pub fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_type_labels() {
+        assert_eq!(DeviceTypeId::Unknown.label(), "Unknown");
+        assert_eq!(DeviceTypeId::Server.label(), "Server");
+        assert_eq!(DeviceTypeId::Other.label(), "Other");
+    }
+
+    #[test]
+    fn device_type_json_roundtrip() {
+        let json = serde_json::to_value(DeviceTypeId::Server).unwrap();
+        assert_eq!(json, serde_json::json!(1));
+        let decoded: DeviceTypeId = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded, DeviceTypeId::Server);
+    }
+}

--- a/crates/openshell-ocsf/src/enums/mod.rs
+++ b/crates/openshell-ocsf/src/enums/mod.rs
@@ -6,6 +6,7 @@
 mod action;
 mod activity;
 mod auth;
+mod device_type;
 mod disposition;
 mod http_method;
 mod launch;
@@ -16,6 +17,7 @@ mod status;
 pub use action::ActionId;
 pub use activity::ActivityId;
 pub use auth::AuthTypeId;
+pub use device_type::DeviceTypeId;
 pub use disposition::DispositionId;
 pub use http_method::HttpMethod;
 pub use launch::LaunchTypeId;

--- a/crates/openshell-ocsf/src/lib.rs
+++ b/crates/openshell-ocsf/src/lib.rs
@@ -44,8 +44,8 @@ pub use events::{
 
 // --- Enum types ---
 pub use enums::{
-    ActionId, ActivityId, AuthTypeId, ConfidenceId, DispositionId, HttpMethod, LaunchTypeId,
-    OcsfEnum, RiskLevelId, SecurityLevelId, SeverityId, StateId, StatusId,
+    ActionId, ActivityId, AuthTypeId, ConfidenceId, DeviceTypeId, DispositionId, HttpMethod,
+    LaunchTypeId, OcsfEnum, RiskLevelId, SecurityLevelId, SeverityId, StateId, StatusId,
 };
 
 // --- Object types ---

--- a/crates/openshell-ocsf/src/objects/device.rs
+++ b/crates/openshell-ocsf/src/objects/device.rs
@@ -5,11 +5,28 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::enums::DeviceTypeId;
+
 /// OCSF Device object.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Device {
     /// Device hostname.
     pub hostname: String,
+
+    /// Administrator-assigned device name, when one exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// Stable unique identifier for the device.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
+
+    /// Device type id. Required by the OCSF schema.
+    pub type_id: DeviceTypeId,
+
+    /// Sibling label for `type_id`.
+    #[serde(rename = "type")]
+    pub type_label: String,
 
     /// Operating system info.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -29,6 +46,10 @@ impl Device {
     pub fn linux(hostname: &str) -> Self {
         Self {
             hostname: hostname.to_string(),
+            name: None,
+            uid: None,
+            type_id: DeviceTypeId::Server,
+            type_label: DeviceTypeId::Server.label().to_string(),
             os: Some(OsInfo {
                 name: "Linux".to_string(),
             }),
@@ -46,5 +67,21 @@ mod tests {
         let json = serde_json::to_value(&device).unwrap();
         assert_eq!(json["hostname"], "sandbox-abc123");
         assert_eq!(json["os"]["name"], "Linux");
+    }
+
+    #[test]
+    fn device_emits_the_schema_required_type_id() {
+        let json = serde_json::to_value(Device::linux("sandbox-abc123")).unwrap();
+        assert_eq!(json["type_id"], DeviceTypeId::Server.as_u8());
+        assert_eq!(json["type"], "Server");
+    }
+
+    #[test]
+    fn device_round_trips() {
+        let device = Device::linux("sandbox-abc123");
+        let json = serde_json::to_value(&device).unwrap();
+        let decoded: Device = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(decoded, device);
+        assert_eq!(serde_json::to_value(&decoded).unwrap(), json);
     }
 }

--- a/crates/openshell-ocsf/src/objects/metadata.rs
+++ b/crates/openshell-ocsf/src/objects/metadata.rs
@@ -18,7 +18,7 @@ pub struct Metadata {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub profiles: Vec<String>,
 
-    /// Unique event source identifier (sandbox ID).
+    /// Unique event identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uid: Option<String>,
 

--- a/crates/openshell-ocsf/tests/event_identity.rs
+++ b/crates/openshell-ocsf/tests/event_identity.rs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `metadata.uid` identifies the event; `container.uid` identifies the sandbox.
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use openshell_ocsf::{ActivityId, NetworkActivityBuilder, OcsfEvent, SandboxContext, SeverityId};
+
+fn sandbox_ctx(container_image: &str) -> SandboxContext {
+    SandboxContext {
+        sandbox_id: "sb-1".to_string(),
+        sandbox_name: "agent-01".to_string(),
+        container_image: container_image.to_string(),
+        hostname: "openshell-sb-1".to_string(),
+        product_version: "0.42.1".to_string(),
+        proxy_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+        proxy_port: 8888,
+    }
+}
+
+fn event(ctx: &SandboxContext) -> OcsfEvent {
+    NetworkActivityBuilder::new(ctx)
+        .activity(ActivityId::Open)
+        .severity(SeverityId::Medium)
+        .message("CONNECT api.example.com:443")
+        .build()
+}
+
+#[test]
+fn each_event_gets_its_own_metadata_uid() {
+    let ctx = sandbox_ctx("ghcr.io/nvidia/openshell/sandbox:0.42.1");
+    let first = event(&ctx);
+    let second = event(&ctx);
+
+    let first_uid = first.base().metadata.uid.clone().expect("uid is set");
+    let second_uid = second.base().metadata.uid.clone().expect("uid is set");
+
+    assert!(!first_uid.is_empty());
+    assert_ne!(first_uid, second_uid);
+}
+
+#[test]
+fn metadata_uid_is_no_longer_the_sandbox_id() {
+    let event = event(&sandbox_ctx("ghcr.io/nvidia/openshell/sandbox:0.42.1"));
+    assert_ne!(event.base().metadata.uid.as_deref(), Some("sb-1"));
+}
+
+#[test]
+fn the_sandbox_id_is_carried_by_the_container() {
+    let json = event(&sandbox_ctx("ghcr.io/nvidia/openshell/sandbox:0.42.1"))
+        .to_json()
+        .expect("serializes");
+
+    assert_eq!(json["container"]["uid"], "sb-1");
+    assert_eq!(json["container"]["name"], "agent-01");
+}
+
+#[test]
+fn a_container_without_an_image_omits_the_image() {
+    let json = event(&sandbox_ctx("")).to_json().expect("serializes");
+    assert!(json["container"].get("image").is_none());
+}

--- a/crates/openshell-server/src/service_routing.rs
+++ b/crates/openshell-server/src/service_routing.rs
@@ -1337,7 +1337,11 @@ mod tests {
         );
 
         assert_eq!(
-            event.base().metadata.uid.as_deref(),
+            event
+                .base()
+                .container
+                .as_ref()
+                .and_then(|container| container.uid.as_deref()),
             Some("sandbox-1"),
             "resolved sandbox id should reach the event"
         );

--- a/crates/openshell-server/src/tracing_bus.rs
+++ b/crates/openshell-server/src/tracing_bus.rs
@@ -180,7 +180,11 @@ where
         let (visitor_sandbox_id, visitor_message) = if meta.target() == OCSF_TARGET {
             openshell_ocsf::clone_current_event().map_or((None, None), |ocsf_event| {
                 (
-                    ocsf_event.base().metadata.uid.clone(),
+                    ocsf_event
+                        .base()
+                        .container
+                        .as_ref()
+                        .and_then(|container| container.uid.clone()),
                     Some(ocsf_event.format_shorthand()),
                 )
             })


### PR DESCRIPTION
Before:

```
{
	"metadata": { "uid": "sandbox-123" },
	"device": {
	  "hostname": "openshell-sandbox",
	  "os": { "name": "Linux" }
	},
	"container": {
	  "uid": "sandbox-123",
	  "image": { "name": "" }
	}
}
```

After:

```
{
	"metadata": { "uid": "<unique-event-uuid>" },
	"device": {
	  "hostname": "openshell-sandbox",
	  "type_id": 1,
	  "type": "Server",
	  "os": { "name": "Linux" }
	},
	"container": { "uid": "sandbox-123" }
}
```


The important differences are:

- metadata.uid uniquely identifies each event.
- container.uid continues to identify the sandbox.
- The required device type is present.
- An unknown image is omitted instead of emitted with an empty name.
- Events without a sandbox omit the container entirely.

## Summary
<!-- 1-3 sentences: what this PR does and why -->
- Deserialize action_id and disposition_id on ApiActivityEvent so round trips preserve the recorded decision.
- Emit the schema-required device.type_id and its sibling label.
- Identify gateway-origin events as the gateway rather than the sandbox they concern. Emit the operator-assigned gateway name as device.name and the per-replica identity as both device.uid and hostname.
- Generate a distinct metadata.uid for each event, keep sandbox identity in container.uid, and omit empty container and image objects.


## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->
Refs #1055

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
