### PR TITLE
fix(cli): preserve provider type on credential updates

### DIFF
--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -4962,17 +4962,39 @@ pub async fn provider_update(options: ProviderUpdateOptions<'_>) -> Result<()> {
     }
 
     let mut client = grpc_client(server, tls).await?;
+
+    // Look up the stored provider so the update can carry its type and profile
+    // workspace. Policy interceptors evaluate the request before the gateway
+    // merges it with stored state, so an update that omits them cannot be
+    // authorized against the profile that owns the provider.
+    //
+    // The read is best-effort. A caller holding `provider:write` without
+    // `provider:read` must still be able to rotate credentials, so a denied
+    // read keeps the previous behavior of sending empty metadata rather than
+    // failing the update. `--from-existing` and `--from-oidc-token` need the
+    // stored type, so they surface the error instead.
+    let existing = match client
+        .get_provider(GetProviderRequest {
+            name: name.to_string(),
+            workspace: workspace.to_string(),
+        })
+        .await
+    {
+        Ok(response) => response.into_inner().provider,
+        Err(status)
+            if status.code() == Code::PermissionDenied && !from_existing && !from_oidc_token =>
+        {
+            None
+        }
+        Err(status) => return Err(status).into_diagnostic(),
+    };
+
+    if existing.is_none() && (from_existing || from_oidc_token) {
+        return Err(miette::miette!("provider '{name}' not found"));
+    }
+
     let oidc_profile = if from_oidc_token {
-        let existing = client
-            .get_provider(GetProviderRequest {
-                name: name.to_string(),
-                workspace: workspace.to_string(),
-            })
-            .await
-            .into_diagnostic()?
-            .into_inner()
-            .provider
-            .ok_or_else(|| miette::miette!("provider '{name}' not found"))?;
+        let existing = existing.as_ref().expect("checked above");
         Some(
             fetch_provider_profile(&mut client, &existing.r#type, &existing.profile_workspace)
                 .await?,
@@ -4991,25 +5013,11 @@ pub async fn provider_update(options: ProviderUpdateOptions<'_>) -> Result<()> {
     credential_expires_at_ms.extend(oidc_credential_expires_at_ms);
 
     if from_existing {
-        // Fetch the existing provider to discover its type for credential lookup.
-        let existing = client
-            .get_provider(GetProviderRequest {
-                name: name.to_string(),
-                workspace: workspace.to_string(),
-            })
-            .await
-            .into_diagnostic()?
-            .into_inner()
-            .provider
-            .ok_or_else(|| miette::miette!("provider '{name}' not found"))?;
-
-        let provider_type = existing.r#type;
-        let discovered = discover_existing_provider_data(
-            &mut client,
-            &provider_type,
-            &existing.profile_workspace,
-        )
-        .await?;
+        let stored = existing.as_ref().expect("checked above");
+        let provider_type = stored.r#type.clone();
+        let discovered =
+            discover_existing_provider_data(&mut client, &provider_type, &stored.profile_workspace)
+                .await?;
         let Some(discovered) = discovered else {
             return Err(miette::miette!(
                 "no existing local credentials/config found for provider type '{provider_type}'"
@@ -5037,11 +5045,17 @@ pub async fn provider_update(options: ProviderUpdateOptions<'_>) -> Result<()> {
                     workspace: workspace.to_string(),
                     deletion_timestamp_ms: 0,
                 }),
-                r#type: String::new(),
+                r#type: existing
+                    .as_ref()
+                    .map(|provider| provider.r#type.clone())
+                    .unwrap_or_default(),
                 credentials: credential_map,
                 config: config_map,
                 credential_expires_at_ms: HashMap::new(),
-                profile_workspace: String::new(),
+                profile_workspace: existing
+                    .as_ref()
+                    .map(|provider| provider.profile_workspace.clone())
+                    .unwrap_or_default(),
                 credential_handles: HashMap::new(),
             }),
             credential_expires_at_ms,

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -1211,7 +1211,7 @@ async fn install_test_profile(ts: &TestServer, id: &str, credential_key: &str) {
 /// from the request workspace. The gateway treats it as immutable, so deriving
 /// it here would look like a change and be rejected.
 #[tokio::test]
-async fn provider_update_preserves_stored_type_when_readable() {
+async fn provider_update_preserves_stored_type_and_profile_workspace_when_readable() {
     let ts = run_server().await;
 
     run::provider_create(

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -1202,6 +1202,59 @@ async fn install_test_profile(ts: &TestServer, id: &str, credential_key: &str) {
     );
 }
 
+/// A readable provider must carry its stored type and profile workspace into
+/// the update request. Policy interceptors evaluate the request before the
+/// gateway merges it with stored state, so an update that omits them cannot be
+/// authorized against the profile that owns the provider.
+///
+/// The stored `profile_workspace` is forwarded verbatim rather than recomputed
+/// from the request workspace. The gateway treats it as immutable, so deriving
+/// it here would look like a change and be rejected.
+#[tokio::test]
+async fn provider_update_preserves_stored_type_when_readable() {
+    let ts = run_server().await;
+
+    run::provider_create(
+        &ts.endpoint,
+        "my-claude",
+        "claude",
+        false,
+        &["API_KEY=abc".to_string()],
+        false,
+        &[],
+        "default",
+        &ts.tls,
+    )
+    .await
+    .expect("provider create");
+
+    run::provider_update(run::ProviderUpdateOptions {
+        server: &ts.endpoint,
+        name: "my-claude",
+        from_existing: false,
+        from_oidc_token: false,
+        credentials: &["API_KEY=rotated".to_string()],
+        config: &[],
+        credential_expires_at: &[],
+        workspace: "default",
+        tls: &ts.tls,
+    })
+    .await
+    .expect("provider update");
+
+    let requests = ts.state.provider_update_requests.lock().await;
+    let request = requests.last().expect("provider update request");
+    // `claude` normalizes to the canonical `claude-code` at creation, so the
+    // update carries the stored type rather than the alias the caller typed.
+    assert_eq!(request.r#type, "claude-code");
+    // Forwarded verbatim rather than recomputed. The gateway treats
+    // profile_workspace as immutable, so any substitution here would look like
+    // a change and be rejected.
+    let stored = ts.state.providers.lock().await;
+    let stored = stored.get("my-claude").expect("stored provider");
+    assert_eq!(request.profile_workspace, stored.profile_workspace);
+}
+
 #[tokio::test]
 async fn provider_cli_run_functions_support_full_crud_flow() {
     let ts = run_server().await;


### PR DESCRIPTION
## Summary

`provider_update` built every `UpdateProviderRequest` with `r#type: String::new()` and `profile_workspace: String::new()`. Policy interceptors evaluate the request before the gateway merges it with stored state, so they cannot tell the target is a profile-managed provider and deny credential-only updates. Creating a provider from an interceptor-vended profile succeeds; rotating its credentials fails.

This looks up the stored provider and carries its type and profile workspace into the request.

## Related Issue

Refs #2991. That issue is `state:validated` rather than `state:accepted`, so this is submitted under the obvious-localized-bug-fix exemption rather than as a claim on accepted work. Closing it is a maintainer's call, not mine, and there is a design question below worth deciding first.

## Changes

- Look up the stored provider once in `provider_update` and forward its `r#type` and `profile_workspace` on the request.
- Forward `profile_workspace` verbatim rather than recomputing it. The gateway treats the field as immutable, so substituting the request workspace for an empty stored value would look like a change and be rejected.
- Make the lookup best-effort: a `PermissionDenied` read falls back to the previous empty-metadata behavior.
- Remove a duplicate `GetProvider` call. The old code fetched the same provider separately in the `--from-oidc-token` and `--from-existing` branches; both now share the single lookup.
- Add an integration test asserting a readable provider carries its stored type into the update request, and that `profile_workspace` matches the stored value rather than a derived one.

## Review feedback addressed

An earlier revision of this branch derived `profile_workspace` through a helper that substituted the request workspace when the stored value was empty. Copilot flagged that this could trip the gateway's immutability check and make a rotation fail harder than before the fix. The helper is gone; the stored value is now forwarded with no conditional, so the substitution is structurally impossible rather than merely untested. The integration test also asserts `profile_workspace` now, not just `r#type`.

This branch was also rebased after #2962 landed, which rewrote both fetch sites in this function to use the raw stored `profile_workspace`. The fix follows that convention rather than reintroducing the older fallback.

## Testing

- [ ] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

`mise` and Docker are not installed on this workstation, so I ran the pre-commit steps individually:

- `cargo fmt --all -- --check` clean.
- `cargo test -p openshell-cli` 410 passed, 0 failed. That includes the new integration test and the existing permission test, unchanged.
- `cargo clippy -p openshell-cli --all-targets -- -D warnings` clean for this crate, with `-A clippy::unused_async` for the Windows-only `connect_unix` stub in `openshell-extension-core`. The repository already allows that lint on Windows in `tasks/scripts/windows-msvc.ps1`.

**Not verified:** I have not run this against a real gateway with a policy interceptor. The evidence here is the mock server in the integration harness plus the code path, not a reproduction of the original APF denial. Someone with an interceptor-backed profile should confirm the rotation now authorizes.

One behavior note: a credential-only update now issues one `GetProvider` before the update when the caller can read. Callers who cannot read are unaffected.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)

---

AI assistance: an agent traced the request construction, wrote the fix and tests, and ran the checks. I reviewed it and can explain it. The defect is the two hardcoded empty strings in the `UpdateProviderRequest` built by `provider_update`; the constraint that shapes the fix is the write-without-read path the existing integration test pins.
