### PR TITLE
fix(cli): continue multi-item deletes after failures

### DIFF
--- a/crates/openshell-cli/src/run.rs
+++ b/crates/openshell-cli/src/run.rs
@@ -119,6 +119,20 @@ impl ProgressOutput {
     }
 }
 
+fn aggregate_delete_failures(resource: &str, failures: &[String]) -> Result<()> {
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(miette!(
+            "failed to delete {} {}{}: {}",
+            failures.len(),
+            resource,
+            if failures.len() == 1 { "" } else { "s" },
+            failures.join(", ")
+        ))
+    }
+}
+
 #[derive(Debug, Clone)]
 struct CurrentUserView {
     subject: String,
@@ -2518,6 +2532,7 @@ pub async fn sandbox_delete(
         names.to_vec()
     };
 
+    let mut failures = Vec::new();
     for name in &names_to_delete {
         // Stop any background port forwards for this sandbox before deleting.
         if let Ok(stopped) = stop_forwards_for_sandbox(name) {
@@ -2542,7 +2557,14 @@ pub async fn sandbox_delete(
                 println!("{} Sandbox {name} already deleted", "✓".green().bold());
                 continue;
             }
-            Err(status) => return Err(status).into_diagnostic(),
+            Err(status) => {
+                eprintln!(
+                    "{} Failed to delete sandbox {name}: {status}",
+                    "!".red().bold()
+                );
+                failures.push(name.clone());
+                continue;
+            }
         };
 
         let deleted = response.into_inner().deleted;
@@ -2554,7 +2576,7 @@ pub async fn sandbox_delete(
         }
     }
 
-    Ok(())
+    aggregate_delete_failures("sandbox", &failures)
 }
 
 /// Stop a sandbox while retaining its persistent workspace.
@@ -4423,22 +4445,32 @@ pub async fn provider_profile_delete(
     tls: &TlsOptions,
 ) -> Result<()> {
     let mut client = grpc_client(server, tls).await?;
+    let mut failures = Vec::new();
     for id in ids {
-        let response = client
+        let response = match client
             .delete_provider_profile(DeleteProviderProfileRequest {
                 id: id.clone(),
                 workspace: workspace.to_string(),
             })
             .await
-            .into_diagnostic()?
-            .into_inner();
+        {
+            Ok(response) => response.into_inner(),
+            Err(status) => {
+                eprintln!(
+                    "{} Failed to delete provider profile {id}: {status}",
+                    "!".red().bold()
+                );
+                failures.push(id.clone());
+                continue;
+            }
+        };
         if response.deleted {
             println!("{} Deleted provider profile {id}", "✓".green().bold());
         } else {
             println!("{} Provider profile {id} not found", "!".yellow());
         }
     }
-    Ok(())
+    aggregate_delete_failures("provider profile", &failures)
 }
 
 pub async fn provider_refresh_status(
@@ -5070,21 +5102,32 @@ pub async fn provider_delete(
     tls: &TlsOptions,
 ) -> Result<()> {
     let mut client = grpc_client(server, tls).await?;
+    let mut failures = Vec::new();
     for name in names {
-        let response = client
+        let response = match client
             .delete_provider(DeleteProviderRequest {
                 name: name.clone(),
                 workspace: workspace.to_string(),
             })
             .await
-            .into_diagnostic()?;
+        {
+            Ok(response) => response,
+            Err(status) => {
+                eprintln!(
+                    "{} Failed to delete provider {name}: {status}",
+                    "!".red().bold()
+                );
+                failures.push(name.clone());
+                continue;
+            }
+        };
         if response.into_inner().deleted {
             println!("{} Deleted provider {name}", "✓".green().bold());
         } else {
             println!("{} Provider {name} not found", "!".yellow());
         }
     }
-    Ok(())
+    aggregate_delete_failures("provider", &failures)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -51,9 +51,11 @@ struct ProviderState {
     provider_update_requests: Arc<Mutex<Vec<Provider>>>,
     deny_provider_reads: Arc<AtomicBool>,
     delete_provider_requests: Arc<Mutex<Vec<String>>>,
+    delete_provider_profile_requests: Arc<Mutex<Vec<String>>>,
     fail_configure_refresh_message: Arc<Mutex<Option<String>>>,
     fail_rotate_refresh_message: Arc<Mutex<Option<String>>>,
     fail_delete_provider_message: Arc<Mutex<Option<String>>>,
+    fail_delete_provider_profile_message: Arc<Mutex<Option<String>>>,
     sandbox_providers: Arc<Mutex<HashMap<String, Vec<String>>>>,
     sandbox_provider_requests: Arc<Mutex<Vec<SandboxProviderRequestLog>>>,
     global_settings: Arc<Mutex<HashMap<String, SettingValue>>>,
@@ -888,6 +890,20 @@ impl OpenShell for TestOpenShell {
         request: tonic::Request<openshell_core::proto::DeleteProviderProfileRequest>,
     ) -> Result<Response<openshell_core::proto::DeleteProviderProfileResponse>, Status> {
         let id = request.into_inner().id;
+        self.state
+            .delete_provider_profile_requests
+            .lock()
+            .await
+            .push(id.clone());
+        let delete_failure = self
+            .state
+            .fail_delete_provider_profile_message
+            .lock()
+            .await
+            .take();
+        if let Some(message) = delete_failure {
+            return Err(Status::internal(message));
+        }
         let deleted = self.state.profiles.lock().await.remove(&id).is_some();
         Ok(Response::new(
             openshell_core::proto::DeleteProviderProfileResponse { deleted },
@@ -1199,6 +1215,62 @@ async fn install_test_profile(ts: &TestServer, id: &str, credential_key: &str) {
             }],
             ..Default::default()
         },
+    );
+}
+
+#[tokio::test]
+async fn provider_delete_continues_after_entry_failure() {
+    let ts = run_server().await;
+    *ts.state.fail_delete_provider_message.lock().await =
+        Some("simulated provider delete failure".to_string());
+
+    let err = run::provider_delete(
+        &ts.endpoint,
+        &["failing-provider".to_string(), "later-provider".to_string()],
+        "default",
+        &ts.tls,
+    )
+    .await
+    .expect_err("provider delete should report aggregate failure");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("failed to delete 1 provider: failing-provider"),
+        "unexpected error: {msg}"
+    );
+    assert_eq!(
+        ts.state.delete_provider_requests.lock().await.clone(),
+        vec!["failing-provider".to_string(), "later-provider".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn provider_profile_delete_continues_after_entry_failure() {
+    let ts = run_server().await;
+    *ts.state.fail_delete_provider_profile_message.lock().await =
+        Some("simulated provider profile delete failure".to_string());
+
+    let err = run::provider_profile_delete(
+        &ts.endpoint,
+        &["failing-profile".to_string(), "later-profile".to_string()],
+        "default",
+        &ts.tls,
+    )
+    .await
+    .expect_err("provider profile delete should report aggregate failure");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("failed to delete 1 provider profile: failing-profile"),
+        "unexpected error: {msg}"
+    );
+    assert_eq!(
+        ts.state
+            .delete_provider_profile_requests
+            .lock()
+            .await
+            .clone(),
+        vec!["failing-profile".to_string(), "later-profile".to_string()]
     );
 }
 

--- a/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
+++ b/crates/openshell-cli/tests/sandbox_create_lifecycle_integration.rs
@@ -46,6 +46,7 @@ use tonic::{Response, Status};
 struct SandboxState {
     deleted_names: Arc<Mutex<Vec<Vec<String>>>>,
     create_requests: Arc<Mutex<Vec<CreateSandboxRequest>>>,
+    fail_delete_sandbox_message: Arc<Mutex<Option<String>>>,
     vm_error_after_started: Arc<AtomicBool>,
     vm_error_with_observed_exit: Arc<AtomicBool>,
     vm_slow_progress_before_ready: Arc<AtomicBool>,
@@ -209,7 +210,11 @@ impl OpenShell for TestOpenShell {
             .deleted_names
             .lock()
             .await
-            .push(vec![request.name]);
+            .push(vec![request.name.clone()]);
+        let delete_failure = self.state.fail_delete_sandbox_message.lock().await.take();
+        if let Some(message) = delete_failure {
+            return Err(Status::internal(message));
+        }
         Ok(Response::new(DeleteSandboxResponse { deleted: true }))
     }
 
@@ -1223,6 +1228,42 @@ fn test_config() -> run::SandboxCreateConfig<'static> {
         auto_providers_override: Some(false),
         ..Default::default()
     }
+}
+
+#[tokio::test]
+async fn sandbox_delete_continues_after_entry_failure() {
+    let server = run_server().await;
+    let tls = test_tls(&server);
+    *server
+        .openshell
+        .state
+        .fail_delete_sandbox_message
+        .lock()
+        .await = Some("simulated sandbox delete failure".to_string());
+
+    let err = run::sandbox_delete(
+        &server.endpoint,
+        &["failing-sandbox".to_string(), "later-sandbox".to_string()],
+        false,
+        "default",
+        &tls,
+        "openshell",
+    )
+    .await
+    .expect_err("sandbox delete should report aggregate failure");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("failed to delete 1 sandbox: failing-sandbox"),
+        "unexpected error: {msg}"
+    );
+    assert_eq!(
+        deleted_names(&server).await,
+        vec![
+            vec!["failing-sandbox".to_string()],
+            vec!["later-sandbox".to_string()]
+        ]
+    );
 }
 
 #[tokio::test]

--- a/docs/sandboxes/manage-providers.mdx
+++ b/docs/sandboxes/manage-providers.mdx
@@ -122,6 +122,16 @@ read-only. The target ID must match the profile ID in the file. Update accepts
 one file at a time and rejects stale resource versions. Updated profile policy
 applies to all provider instances of that type on the next sandbox config sync.
 
+Delete one or more custom provider profiles by ID:
+
+```shell
+openshell provider profile delete custom-api custom-alt
+```
+
+When a multi-profile delete fails for one entry, the CLI reports that profile's
+failure and continues with the remaining IDs. The command exits with an error
+after it attempts every requested deletion if any entry failed.
+
 <Warning>
 Static credentials require a built-in or imported provider profile. Profiles
 normally define at least one endpoint. An endpointless profile requires an
@@ -276,6 +286,16 @@ Delete a provider:
 ```shell
 openshell provider delete my-claude
 ```
+
+Delete multiple providers by listing their names in one command:
+
+```shell
+openshell provider delete my-claude my-github
+```
+
+When a multi-provider delete fails for one entry, the CLI reports that
+provider's failure and continues with the remaining names. The command exits
+with an error after it attempts every requested deletion if any entry failed.
 
 ## Attach Providers to Sandboxes
 

--- a/docs/sandboxes/manage-sandboxes.mdx
+++ b/docs/sandboxes/manage-sandboxes.mdx
@@ -555,6 +555,16 @@ Deleting a sandbox stops all processes, releases resources, and purges injected 
 openshell sandbox delete my-sandbox
 ```
 
+Delete multiple sandboxes by listing their names in one command:
+
+```shell
+openshell sandbox delete sandbox-a sandbox-b
+```
+
+When a multi-sandbox delete fails for one entry, the CLI reports that sandbox's
+failure and continues with the remaining names. The command exits with an error
+after it attempts every requested deletion if any entry failed.
+
 ## Sandbox Lifecycle
 
 Every sandbox moves through a defined set of phases:


### PR DESCRIPTION
## Summary
CLI delete commands that accept multiple targets (sandbox delete, provider delete, provider profile delete) previously aborted on the first failing entry, leaving the remaining requested items untouched. This makes multi-item deletes fail-soft: each entry is attempted, per-item failures are reported to stderr as they happen, and the command exits with a single aggregated error once every requested deletion has been attempted.

## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->
Fixes #3102

## Changes
- sandbox_delete, provider_delete, and provider_profile_delete now collect per-item failures and continue instead of returning on the first error. Each failure is printed to stderr; the aggregated error is returned at the end.
- documentation updated to include example of multi-delete and describe the fail-soft behaviour
- 
## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
