### PR TITLE
fix(tui): expose workspace switching from providers

### DIFF
--- a/.agents/skills/tui-development/SKILL.md
+++ b/.agents/skills/tui-development/SKILL.md
@@ -384,7 +384,7 @@ All actions are accessible via keyboard shortcuts displayed in the nav bar. The 
 `[Tab] Switch Panel  [Enter] Select  [j/k] Navigate  │  [:] Command  [q] Quit`
 
 **Dashboard (Providers focus):**
-`[Tab] Switch Panel  [h/l] Switch Tab  [j/k] Navigate  [Enter] Detail  [c] Create  [u] Update  [d] Delete  │  [:] Command  [q] Quit`
+`[Tab] Switch Panel  [h/l] Switch Tab  [j/k] Navigate  [Enter] Detail  [c] Create  [u] Update  [d] Delete  [w] Workspace  │  [:] Command  [q] Quit`
 
 **Dashboard (Global Settings focus):**
 `[Tab] Switch Panel  [h/l] Switch Tab  [j/k] Navigate  [Enter] Edit  [d] Delete  │  [:] Command  [q] Quit`
@@ -535,7 +535,7 @@ On launch, before the event loop starts:
 
 ### Workspace switching lifecycle
 
-1. User presses `[w]` on the sandboxes panel → `cycle_workspace()` advances through discovered workspace names, then "all"
+1. User presses `[w]` on the providers or sandboxes panel → `cycle_workspace()` advances through discovered workspace names, then "all"
 2. `pending_workspace_refresh = true` is set, cursor indices are reset
 3. Event loop calls `refresh_providers()` and `refresh_sandboxes()` with the new workspace scope
 

--- a/crates/openshell-tui/src/app.rs
+++ b/crates/openshell-tui/src/app.rs
@@ -1407,6 +1407,9 @@ impl App {
                 self.input_mode = InputMode::Command;
                 self.command_input.clear();
             }
+            KeyCode::Char('w') => {
+                self.cycle_workspace();
+            }
             KeyCode::Char('j') | KeyCode::Down => {
                 if self.provider_count > 0 && self.provider_selected < self.provider_count - 1 {
                     self.provider_selected += 1;
@@ -3823,6 +3826,32 @@ mod tests {
         };
 
         assert_eq!(gateway.source_label(), "unknown");
+    }
+
+    #[tokio::test]
+    async fn providers_workspace_shortcut_cycles_scope_and_resets_selections() {
+        let mut app = test_app();
+        app.screen = Screen::Dashboard;
+        app.focus = Focus::Providers;
+        app.workspace_names = vec!["default".to_string(), "team-b".to_string()];
+        app.provider_selected = 3;
+        app.sandbox_selected = 4;
+
+        app.handle_key(key(KeyCode::Char('w')));
+
+        assert_eq!(app.current_workspace, "team-b");
+        assert!(!app.all_workspaces);
+        assert_eq!(app.provider_selected, 0);
+        assert_eq!(app.sandbox_selected, 0);
+        assert!(app.pending_workspace_refresh);
+
+        app.handle_key(key(KeyCode::Char('w')));
+        assert!(app.all_workspaces);
+        assert_eq!(app.workspace_display(), "all");
+
+        app.handle_key(key(KeyCode::Char('w')));
+        assert!(!app.all_workspaces);
+        assert_eq!(app.current_workspace, "default");
     }
 
     // -- selected_sandbox_workspace ----------------------------------------

--- a/crates/openshell-tui/src/ui/mod.rs
+++ b/crates/openshell-tui/src/ui/mod.rs
@@ -223,6 +223,9 @@ fn draw_nav_bar(frame: &mut Frame<'_>, app: &App, area: Rect) {
                 Span::styled("  ", t.text),
                 Span::styled("[c/u/d]", t.key_hint),
                 Span::styled(" Create/Update/Delete", t.text),
+                Span::styled("  ", t.text),
+                Span::styled("[w]", t.key_hint),
+                Span::styled(" Workspace", t.text),
                 Span::styled("  |  ", t.border),
                 Span::styled("[:]", t.muted),
                 Span::styled(" Command  ", t.muted),
@@ -661,4 +664,47 @@ pub fn centered_popup(percent_x: u16, height: u16, area: Rect) -> Rect {
             Constraint::Percentage((100 - percent_x) / 2),
         ])
         .split(vert[1])[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openshell_core::auth::EdgeAuthInterceptor;
+    use openshell_core::proto::open_shell_client::OpenShellClient;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn test_app() -> App {
+        let channel = tonic::transport::Endpoint::from_static("http://127.0.0.1:1").connect_lazy();
+        let client = OpenShellClient::with_interceptor(channel, EdgeAuthInterceptor::noop());
+        let mut app = App::new(
+            client,
+            "test".to_string(),
+            "http://127.0.0.1:1".to_string(),
+            "default".to_string(),
+            Theme::dark(),
+        );
+        app.screen = Screen::Dashboard;
+        app.focus = Focus::Providers;
+        app
+    }
+
+    #[tokio::test]
+    async fn providers_navigation_advertises_workspace_shortcut() {
+        let app = test_app();
+        let mut terminal = Terminal::new(TestBackend::new(180, 1)).unwrap();
+
+        terminal
+            .draw(|frame| draw_nav_bar(frame, &app, frame.size()))
+            .unwrap();
+
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+        assert!(text.contains("[w] Workspace"), "nav bar was: {text:?}");
+    }
 }


### PR DESCRIPTION
> **🏗️ build-from-issue-agent**

## Summary

Expose the dashboard-wide workspace switch while the Providers tab is focused. The new binding reuses the existing workspace cycle and refresh path, and the Providers navigation bar now advertises the shortcut.

## Related Issue

Closes #3112

## Changes

- Route Providers-tab `w` input through `App::cycle_workspace`.
- Display `[w] Workspace` in the Providers navigation hints.
- Cover workspace sequencing, provider and sandbox cursor resets, pending refresh state, and the rendered hint.
- Update the TUI development skill's shortcut table and workspace-switch lifecycle.

### Deviations from Plan

- Updated `.agents/skills/tui-development/SKILL.md` after the agent-infrastructure maintenance map identified its exhaustive shortcut and lifecycle references.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (not applicable; no `e2e/` files or gateway/sandbox infrastructure changed)
- [x] `cargo test -p openshell-tui --lib` — 78 passed
- [x] `mise run test` — full suite passed (with `tag.gpgSign=false` scoped to the process so temporary test tags remain lightweight)

**Tests added:**

- **Unit:** `crates/openshell-tui/src/app.rs` — Providers-focused workspace cycle, both cursor resets, pending refresh, and `all` sequence.
- **Unit/render:** `crates/openshell-tui/src/ui/mod.rs` — Providers navigation displays `[w] Workspace`.
- **Integration:** N/A.
- **E2E:** N/A.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)

**Documentation updated:**

- `.agents/skills/tui-development/SKILL.md`: aligned the TUI shortcut reference and workspace-switch lifecycle.
- Published and architecture docs: none needed; this is a localized in-product shortcut and hint change.