### PR TITLE
fix(release): publish prerelease helm charts

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -732,7 +732,6 @@ jobs:
   release-helm:
     name: Release Helm Chart (OCI)
     needs: [compute-versions, release, tag-ghcr-release]
-    if: needs.compute-versions.outputs.is_prerelease != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary

Publish Helm charts for tagged pre-releases so Kubernetes users and qualification workflows can install the chart matching an immutable `X.Y.Z-pre.N` release.

## Related Issue

No issue required: this is a localized release workflow fix.

## Changes

- Run the existing Helm OCI publication job for both stable and pre-release tags.
- Publish charts using the same version as the corresponding gateway and supervisor images.

## Testing

- [ ] `mise run pre-commit` passes — not run
- [ ] Unit tests added/updated — not applicable; this only changes a workflow condition
- [ ] E2E tests added/updated — not applicable; no chart templates or runtime behavior changed
- [x] `git diff --check`
- [x] `actionlint` completed with only two pre-existing informational ShellCheck notices

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable)