### PR TITLE
ci(conformance): add Ubuntu package smoke test

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -27,7 +27,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 defaults:
   run:
@@ -38,11 +37,6 @@ jobs:
     name: Build Debian Package (Linux ${{ inputs.arch }})
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 20
-    container:
-      image: ghcr.io/nvidia/openshell/ci:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build Debian Package
+
+on:
+  workflow_call:
+    inputs:
+      deb-version:
+        required: true
+        type: string
+      checkout-ref:
+        required: true
+        type: string
+      arch:
+        required: true
+        type: string
+      runner:
+        required: true
+        type: string
+      cli-target:
+        required: true
+        type: string
+      gnu-target:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build Debian Package (Linux ${{ inputs.arch }})
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 20
+    container:
+      image: ghcr.io/nvidia/openshell/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs['checkout-ref'] }}
+
+      - name: Download CLI artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openshell-${{ inputs['cli-target'] }}
+          path: package-binaries/
+
+      - name: Download gateway artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openshell-gateway-${{ inputs['gnu-target'] }}
+          path: package-binaries/
+
+      - name: Download VM driver artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openshell-driver-vm-${{ inputs['gnu-target'] }}
+          path: package-binaries/
+
+      - name: Configure package inputs
+        run: |
+          set -euo pipefail
+          chmod +x package-binaries/openshell{,-gateway,-driver-vm}
+          ls -lah package-binaries
+
+      - name: Build Debian package
+        run: |
+          set -euo pipefail
+          OPENSHELL_CLI_BINARY="${PWD}/package-binaries/openshell" \
+          OPENSHELL_GATEWAY_BINARY="${PWD}/package-binaries/openshell-gateway" \
+          OPENSHELL_DRIVER_VM_BINARY="${PWD}/package-binaries/openshell-driver-vm" \
+          OPENSHELL_DEB_VERSION="${INPUTS_DEB_VERSION}" \
+          OPENSHELL_DEB_ARCH="${{ inputs.arch }}" \
+          OPENSHELL_OUTPUT_DIR=artifacts \
+            tasks/scripts/package-deb.sh
+        env:
+          INPUTS_DEB_VERSION: ${{ inputs['deb-version'] }}
+
+      - name: Upload Debian package artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: deb-linux-${{ inputs.arch }}
+          path: artifacts/*.deb
+          retention-days: 5

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 60
     container:
-      image: fedora:latest
+      image: docker.io/library/fedora:44@sha256:be9d65e2344d805cc11114319c685ecaa96b6d9b4350a0a6460cdb931babbd19
     steps:
       - name: Install packaging dependencies
         run: |

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -61,6 +61,14 @@ jobs:
           ref: ${{ inputs.checkout-ref }}
           fetch-depth: 0
 
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: rpm-vendor-${{ inputs.arch }}
+          cache-targets: "false"
+          cache-bin: "false"
+          cache-on-failure: "true"
+
       - name: Download CLI artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build RPM
+
+on:
+  workflow_call:
+    inputs:
+      checkout-ref:
+        required: true
+        type: string
+      arch:
+        required: true
+        type: string
+      runner:
+        required: true
+        type: string
+      cli-target:
+        required: true
+        type: string
+      gateway-target:
+        required: true
+        type: string
+      rpm-version:
+        required: false
+        type: string
+        default: ""
+      rpm-release:
+        required: false
+        type: string
+        default: ""
+      cargo-version:
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build RPM Package (Linux ${{ inputs.arch }})
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 60
+    container:
+      image: fedora:latest
+    steps:
+      - name: Install packaging dependencies
+        run: |
+          dnf install -y \
+            packit rpm-build \
+            cargo cargo-rpm-macros git-core \
+            pandoc python3-devel systemd-rpm-macros
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout-ref }}
+          fetch-depth: 0
+
+      - name: Download CLI artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openshell-${{ inputs.cli-target }}
+          path: package-binaries/
+
+      - name: Download gateway artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openshell-gateway-${{ inputs.gateway-target }}
+          path: package-binaries/
+
+      - name: Configure package inputs
+        run: |
+          set -euo pipefail
+          chmod +x package-binaries/openshell{,-gateway}
+          ls -lah package-binaries
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Build RPMs via Packit
+        env:
+          OPENSHELL_RPM_VERSION: ${{ inputs.rpm-version }}
+          OPENSHELL_RPM_RELEASE: ${{ inputs.rpm-release }}
+          OPENSHELL_CARGO_VERSION: ${{ inputs.cargo-version }}
+          OPENSHELL_PREBUILT_BINARIES_DIR: ${{ github.workspace }}/package-binaries
+        run: packit build locally
+
+      - name: Collect RPM artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          mapfile -t rpms < <(find "$GITHUB_WORKSPACE" -maxdepth 3 -type f -name '*.rpm' ! -name '*.src.rpm' | sort)
+          if [ "${#rpms[@]}" -eq 0 ]; then
+            echo "::error::No RPM artifacts found under $GITHUB_WORKSPACE"
+            find "$GITHUB_WORKSPACE" -maxdepth 3 -type f | sort
+            exit 1
+          fi
+          cp "${rpms[@]}" artifacts/
+          echo "=== Built RPMs ==="
+          ls -lah artifacts/
+
+      - name: Upload RPM artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: rpm-linux-${{ inputs.arch }}
+          path: artifacts/*.rpm
+          retention-days: 5

--- a/.github/workflows/build-vm-driver-binary.yml
+++ b/.github/workflows/build-vm-driver-binary.yml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build VM Driver Binary
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      triple:
+        required: true
+        type: string
+      runner:
+        required: true
+        type: string
+      dev-shell:
+        required: true
+        type: string
+      interpreter:
+        required: false
+        type: string
+        default: ""
+      cargo-version:
+        required: true
+        type: string
+      image-tag:
+        required: false
+        type: string
+        default: ""
+      checkout-ref:
+        required: false
+        type: string
+        default: ""
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: openshell-driver-vm (${{ inputs.triple }})
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: nix develop ${{ inputs['dev-shell'] }} -c bash -euo pipefail {0}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs['checkout-ref'] || github.sha }}
+
+      - uses: ./.github/actions/setup-nix
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Download openshell-sandbox
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openshell-sandbox-${{ inputs.arch }}-unknown-linux-musl
+          path: sandbox
+
+      - name: Build VM runtime
+        run: nix build .#vm-runtime
+
+      - name: Assemble compressed VM runtime
+        run: |
+          compressed_dir="${RUNNER_TEMP}/vm-runtime-compressed"
+          install -d "$compressed_dir"
+          cp result/compressed/*.zst "$compressed_dir/"
+          zstd -19 -T1 sandbox/openshell-sandbox -o "$compressed_dir/openshell-sandbox.zst"
+
+      - name: Build openshell-driver-vm
+        uses: ./.github/actions/build-rust-binary
+        env:
+          OPENSHELL_VM_RUNTIME_COMPRESSED_DIR: ${{ runner.temp }}/vm-runtime-compressed
+        with:
+          package: openshell-driver-vm
+          binary: openshell-driver-vm
+          triple: ${{ inputs.triple }}
+          dev-shell: ${{ inputs['dev-shell'] }}
+          cargo-version: ${{ inputs['cargo-version'] }}
+          image-tag: ${{ inputs['image-tag'] }}
+          interpreter: ${{ inputs.interpreter }}

--- a/.github/workflows/build-vm-driver.yml
+++ b/.github/workflows/build-vm-driver.yml
@@ -26,7 +26,6 @@ permissions:
 
 jobs:
   build:
-    name: openshell-driver-vm (${{ matrix.triple }})
     strategy:
       matrix:
         include:
@@ -44,45 +43,14 @@ jobs:
             triple: aarch64-apple-darwin
             runner: macos-15-xlarge
             dev_shell: .#devShells.aarch64-darwin.default
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
-    defaults:
-      run:
-        shell: nix develop ${{ matrix.dev_shell }} -c bash -euo pipefail {0}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs['checkout-ref'] || github.sha }}
-
-      - uses: ./.github/actions/setup-nix
-        with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-
-      - name: Download openshell-sandbox
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: openshell-sandbox-${{ matrix.arch }}-unknown-linux-musl
-          path: sandbox
-
-      - name: Build VM runtime
-        run: nix build .#vm-runtime
-
-      - name: Assemble compressed VM runtime
-        run: |
-          compressed_dir="${RUNNER_TEMP}/vm-runtime-compressed"
-          install -d "$compressed_dir"
-          cp result/compressed/*.zst "$compressed_dir/"
-          zstd -19 -T1 sandbox/openshell-sandbox -o "$compressed_dir/openshell-sandbox.zst"
-
-      - name: Build openshell-driver-vm
-        uses: ./.github/actions/build-rust-binary
-        env:
-          OPENSHELL_VM_RUNTIME_COMPRESSED_DIR: ${{ runner.temp }}/vm-runtime-compressed
-        with:
-          package: openshell-driver-vm
-          binary: openshell-driver-vm
-          triple: ${{ matrix.triple }}
-          dev-shell: ${{ matrix.dev_shell }}
-          cargo-version: ${{ inputs['cargo-version'] }}
-          image-tag: ${{ inputs['image-tag'] }}
-          interpreter: ${{ matrix.interpreter }}
+    uses: ./.github/workflows/build-vm-driver-binary.yml
+    with:
+      arch: ${{ matrix.arch }}
+      triple: ${{ matrix.triple }}
+      runner: ${{ matrix.runner }}
+      dev-shell: ${{ matrix.dev_shell }}
+      interpreter: ${{ matrix.interpreter }}
+      cargo-version: ${{ inputs['cargo-version'] }}
+      image-tag: ${{ inputs['image-tag'] }}
+      checkout-ref: ${{ inputs['checkout-ref'] }}
+    secrets: inherit

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Conformance
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr_metadata:
+    name: Resolve PR metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - id: gate
+        uses: ./.github/actions/pr-gate
+
+  version:
+    needs: pr_metadata
+    if: needs.pr_metadata.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      cargo: ${{ steps.version.outputs.cargo }}
+      rpm_version: ${{ steps.version.outputs.rpm_version }}
+      rpm_release: ${{ steps.version.outputs.rpm_release }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Compute versions
+        id: version
+        run: |
+          cargo="$(python3 tasks/scripts/release.py get-version --cargo)"
+          rpm_version="$(python3 tasks/scripts/release.py get-version --rpm-version)"
+          rpm_release="$(python3 tasks/scripts/release.py get-version --rpm-release)"
+          {
+            echo "cargo=$cargo"
+            echo "rpm_version=$rpm_version"
+            echo "rpm_release=$rpm_release"
+          } >> "$GITHUB_OUTPUT"
+
+  build-cli:
+    needs: version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-cli-binaries.yml
+    with:
+      cargo-version: ${{ needs.version.outputs.cargo }}
+      checkout-ref: ${{ github.sha }}
+    secrets: inherit
+
+  build-gateway:
+    needs: version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-gateway-binaries.yml
+    with:
+      cargo-version: ${{ needs.version.outputs.cargo }}
+      checkout-ref: ${{ github.sha }}
+    secrets: inherit
+
+  build-rpm:
+    needs: [version, build-cli, build-gateway]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/rpm-package.yml
+    with:
+      checkout-ref: ${{ github.sha }}
+      cargo-version: ${{ needs.version.outputs.cargo }}
+      rpm-version: ${{ needs.version.outputs.rpm_version }}
+      rpm-release: ${{ needs.version.outputs.rpm_release }}
+
+  fedora:
+    name: Fedora clean install
+    needs: build-rpm
+    runs-on: linux-amd64-cpu8
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-nix
+
+      - name: Download RPM artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: rpm-linux-x86_64
+          path: rpm-input
+
+      - name: Install RPMs and check status
+        shell: bash
+        run: |
+          set -euo pipefail
+          nix run .#test-guest -- \
+            --distro fedora \
+            --with podman \
+            --with selinux \
+            --install rpm-input/openshell-[0-9]*.rpm \
+            --install rpm-input/openshell-gateway-[0-9]*.rpm \
+            -- bash -s <<'EOF'
+          set -euo pipefail
+
+          on_exit() {
+            rc=$?
+            trap - EXIT
+            if [ "$rc" -ne 0 ]; then
+              systemctl --user status openshell-gateway --no-pager || true
+              journalctl --user -u openshell-gateway --no-pager -n 200 || true
+              podman info || true
+              podman ps --all || true
+              getenforce || true
+            fi
+            exit "$rc"
+          }
+          trap on_exit EXIT
+
+          . /etc/os-release
+          echo "Testing on $PRETTY_NAME"
+          podman --version
+          test "$(podman info --format '{{.Host.Security.Rootless}}')" = true
+          test "$(podman info --format '{{.Host.CgroupsVersion}}')" = v2
+          test "$(getenforce)" = Enforcing
+          rpm -q openshell openshell-gateway
+          openshell --version
+          openshell-gateway --version
+
+          mkdir -p "$HOME/.config/openshell"
+          echo 'OPENSHELL_TELEMETRY_ENABLED=false' > "$HOME/.config/openshell/gateway.env"
+          systemctl --user enable --now openshell-gateway
+          openshell gateway add --local https://127.0.0.1:17670 --name openshell
+          openshell status
+          EOF

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -90,7 +90,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/build-binaries.yml
     with:
-      package: openshell-server
+      package: openshell-gateway
       binary: openshell-gateway
       triple: x86_64-unknown-linux-gnu
       runner: linux-amd64-cpu8

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -4,9 +4,6 @@
 name: Conformance
 
 on:
-  push:
-    branches:
-      - "pull-request/[0-9]+"
   workflow_dispatch: {}
 
 permissions: {}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -101,7 +101,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup-e2e-vm
+      - name: Enable KVM access
+        run: |
+          set -euo pipefail
+          if [[ ! -c /dev/kvm ]]; then
+            echo "::error::The runner did not expose /dev/kvm"
+            exit 1
+          fi
+          sudo chmod 0666 /dev/kvm
+          exec 3<>/dev/kvm
+          exec 3>&-
 
       - uses: ./.github/actions/setup-nix
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -120,7 +120,7 @@ jobs:
       rpm-release: ${{ needs.version.outputs.rpm_release }}
 
   fedora:
-    name: Fedora clean install
+    name: Fedora with Rootless Podman
     needs: [build-conformance, build-rpm]
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -99,6 +99,7 @@ jobs:
       runner: linux-amd64-cpu8
       dev-shell: .#devShells.x86_64-linux.glibc-2-28
       cargo-version: ${{ needs.version.outputs.cargo }}
+      image-tag: dev
       interpreter: /lib64/ld-linux-x86-64.so.2
       checkout-ref: ${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -115,13 +115,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          nix run .#test-guest -- \
-            --distro fedora \
-            --with podman \
-            --with selinux \
-            --install rpm-input/openshell-[0-9]*.rpm \
-            --install rpm-input/openshell-gateway-[0-9]*.rpm \
-            -- bash -s <<'EOF'
+          guest_script="$RUNNER_TEMP/conformance.sh"
+          cat > "$guest_script" <<'EOF'
           set -euo pipefail
 
           on_exit() {
@@ -154,3 +149,12 @@ jobs:
           openshell gateway add --local https://127.0.0.1:17670 --name openshell
           openshell status
           EOF
+
+          nix run .#test-guest -- \
+            --distro fedora \
+            --with podman \
+            --with selinux \
+            --install rpm-input/openshell-[0-9]*.rpm \
+            --install rpm-input/openshell-gateway-[0-9]*.rpm \
+            --copy "$guest_script:/tmp/conformance.sh" \
+            -- bash /tmp/conformance.sh

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -35,6 +35,7 @@ jobs:
       contents: read
     outputs:
       cargo: ${{ steps.version.outputs.cargo }}
+      deb_version: ${{ steps.version.outputs.deb_version }}
       rpm_version: ${{ steps.version.outputs.rpm_version }}
       rpm_release: ${{ steps.version.outputs.rpm_release }}
     steps:
@@ -46,10 +47,12 @@ jobs:
         id: version
         run: |
           cargo="$(python3 tasks/scripts/release.py get-version --cargo)"
+          deb_version="$(python3 tasks/scripts/release.py get-version --deb)"
           rpm_version="$(python3 tasks/scripts/release.py get-version --rpm-version)"
           rpm_release="$(python3 tasks/scripts/release.py get-version --rpm-release)"
           {
             echo "cargo=$cargo"
+            echo "deb_version=$deb_version"
             echo "rpm_version=$rpm_version"
             echo "rpm_release=$rpm_release"
           } >> "$GITHUB_OUTPUT"
@@ -101,6 +104,38 @@ jobs:
       checkout-ref: ${{ github.sha }}
     secrets: inherit
 
+  build-sandbox:
+    needs: version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      package: openshell-sandbox
+      binary: openshell-sandbox
+      triple: x86_64-unknown-linux-musl
+      runner: linux-amd64-cpu8
+      dev-shell: .#devShells.x86_64-linux.musl
+      cargo-version: ${{ needs.version.outputs.cargo }}
+      image-tag: dev
+      checkout-ref: ${{ github.sha }}
+    secrets: inherit
+
+  build-vm-driver:
+    needs: [version, build-sandbox]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-vm-driver-binary.yml
+    with:
+      arch: x86_64
+      triple: x86_64-unknown-linux-gnu
+      runner: linux-amd64-cpu8
+      dev-shell: .#devShells.x86_64-linux.glibc-2-28
+      interpreter: /lib64/ld-linux-x86-64.so.2
+      cargo-version: ${{ needs.version.outputs.cargo }}
+      image-tag: dev
+      checkout-ref: ${{ github.sha }}
+    secrets: inherit
+
   build-rpm:
     needs: [version, build-cli, build-gateway]
     permissions:
@@ -115,6 +150,20 @@ jobs:
       cargo-version: ${{ needs.version.outputs.cargo }}
       rpm-version: ${{ needs.version.outputs.rpm_version }}
       rpm-release: ${{ needs.version.outputs.rpm_release }}
+
+  build-deb:
+    needs: [version, build-cli, build-gateway, build-vm-driver]
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/build-deb.yml
+    with:
+      deb-version: ${{ needs.version.outputs.deb_version }}
+      checkout-ref: ${{ github.sha }}
+      arch: amd64
+      runner: linux-amd64-cpu8
+      cli-target: x86_64-unknown-linux-musl
+      gnu-target: x86_64-unknown-linux-gnu
 
   fedora:
     name: Fedora with Rootless Podman
@@ -154,42 +203,72 @@ jobs:
           name: openshell-conformance-x86_64-unknown-linux-musl
           path: conformance-input
 
-      - name: Install RPMs and check status
+      - name: Run Fedora package conformance
         shell: bash
+        env:
+          OPENSHELL_TEST_GUEST_DRIVER: podman
         run: |
           set -euo pipefail
           chmod +x conformance-input/openshell-conformance
-          guest_script="$RUNNER_TEMP/conformance.sh"
-          cat > "$guest_script" <<'EOF'
-          set -euo pipefail
-
-          on_exit() {
-            rc=$?
-            trap - EXIT
-            if [ "$rc" -ne 0 ]; then
-              systemctl --user status openshell-gateway --no-pager || true
-              journalctl --user -u openshell-gateway --no-pager -n 200 || true
-              podman info || true
-              podman ps --all || true
-              getenforce || true
-            fi
-            exit "$rc"
-          }
-          trap on_exit EXIT
-
-          mkdir -p "$HOME/.config/openshell"
-          echo 'OPENSHELL_TELEMETRY_ENABLED=false' > "$HOME/.config/openshell/gateway.env"
-          systemctl --user enable --now openshell-gateway
-          openshell gateway add --local https://127.0.0.1:17670 --name openshell
-          /tmp/openshell-conformance run smoke
-          EOF
-
           OPENSHELL_TEST_GUEST_CACHE_DISABLE=1 nix run .#test-guest -- \
             --distro fedora \
             --with podman-rootless \
             --with selinux \
             --install rpm-input/openshell-[0-9]*.rpm \
             --install rpm-input/openshell-gateway-[0-9]*.rpm \
-            --copy "$guest_script:/tmp/conformance.sh" \
             --copy conformance-input/openshell-conformance:/tmp/openshell-conformance \
-            -- bash /tmp/conformance.sh
+            --provision openshell-package \
+            -- /tmp/openshell-conformance run smoke
+
+  ubuntu:
+    name: Ubuntu 24.04 with Docker
+    needs: [build-conformance, build-deb]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Enable KVM access
+        run: |
+          set -euo pipefail
+          if [[ ! -c /dev/kvm ]]; then
+            echo "::error::The runner did not expose /dev/kvm"
+            exit 1
+          fi
+          sudo chmod 0666 /dev/kvm
+          exec 3<>/dev/kvm
+          exec 3>&-
+
+      - uses: ./.github/actions/setup-nix
+
+      - name: Download DEB artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: deb-linux-amd64
+          path: deb-input
+
+      - name: Download conformance CLI
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openshell-conformance-x86_64-unknown-linux-musl
+          path: conformance-input
+
+      - name: Run Ubuntu package conformance
+        shell: bash
+        env:
+          OPENSHELL_TEST_GUEST_DRIVER: docker
+        run: |
+          set -euo pipefail
+          chmod +x conformance-input/openshell-conformance
+          OPENSHELL_TEST_GUEST_CACHE_DISABLE=1 nix run .#test-guest -- \
+            --distro ubuntu-24-04 \
+            --with docker \
+            --install deb-input/*.deb \
+            --copy conformance-input/openshell-conformance:/tmp/openshell-conformance \
+            --provision openshell-package \
+            -- /tmp/openshell-conformance run smoke

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -155,7 +155,6 @@ jobs:
     needs: [version, build-cli, build-gateway, build-vm-driver]
     permissions:
       contents: read
-      packages: read
     uses: ./.github/workflows/build-deb.yml
     with:
       deb-version: ${{ needs.version.outputs.deb_version }}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -101,6 +101,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: ./.github/actions/setup-e2e-vm
+
       - uses: ./.github/actions/setup-nix
 
       - name: Download RPM artifacts

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -186,7 +186,7 @@ jobs:
 
           OPENSHELL_TEST_GUEST_CACHE_DISABLE=1 nix run .#test-guest -- \
             --distro fedora \
-            --with podman \
+            --with podman-rootless \
             --with selinux \
             --install rpm-input/openshell-[0-9]*.rpm \
             --install rpm-input/openshell-gateway-[0-9]*.rpm \

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -91,7 +91,7 @@ jobs:
   fedora:
     name: Fedora clean install
     needs: build-rpm
-    runs-on: linux-amd64-cpu8
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
       actions: read

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -61,8 +61,28 @@ jobs:
     needs: version
     permissions:
       contents: read
-    uses: ./.github/workflows/build-cli-binaries.yml
+    uses: ./.github/workflows/build-binaries.yml
     with:
+      package: openshell-cli
+      binary: openshell
+      triple: x86_64-unknown-linux-musl
+      runner: linux-amd64-cpu8
+      dev-shell: .#devShells.x86_64-linux.musl
+      cargo-version: ${{ needs.version.outputs.cargo }}
+      checkout-ref: ${{ github.sha }}
+    secrets: inherit
+
+  build-conformance:
+    needs: version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      package: openshell-conformance-cli
+      binary: openshell-conformance
+      triple: x86_64-unknown-linux-musl
+      runner: linux-amd64-cpu8
+      dev-shell: .#devShells.x86_64-linux.musl
       cargo-version: ${{ needs.version.outputs.cargo }}
       checkout-ref: ${{ github.sha }}
     secrets: inherit
@@ -71,9 +91,15 @@ jobs:
     needs: version
     permissions:
       contents: read
-    uses: ./.github/workflows/build-gateway-binaries.yml
+    uses: ./.github/workflows/build-binaries.yml
     with:
+      package: openshell-server
+      binary: openshell-gateway
+      triple: x86_64-unknown-linux-gnu
+      runner: linux-amd64-cpu8
+      dev-shell: .#devShells.x86_64-linux.glibc-2-28
       cargo-version: ${{ needs.version.outputs.cargo }}
+      interpreter: /lib64/ld-linux-x86-64.so.2
       checkout-ref: ${{ github.sha }}
     secrets: inherit
 
@@ -81,16 +107,20 @@ jobs:
     needs: [version, build-cli, build-gateway]
     permissions:
       contents: read
-    uses: ./.github/workflows/rpm-package.yml
+    uses: ./.github/workflows/build-rpm.yml
     with:
       checkout-ref: ${{ github.sha }}
+      arch: x86_64
+      runner: linux-amd64-cpu8
+      cli-target: x86_64-unknown-linux-musl
+      gateway-target: x86_64-unknown-linux-gnu
       cargo-version: ${{ needs.version.outputs.cargo }}
       rpm-version: ${{ needs.version.outputs.rpm_version }}
       rpm-release: ${{ needs.version.outputs.rpm_release }}
 
   fedora:
     name: Fedora clean install
-    needs: build-rpm
+    needs: [build-conformance, build-rpm]
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
@@ -120,10 +150,17 @@ jobs:
           name: rpm-linux-x86_64
           path: rpm-input
 
+      - name: Download conformance CLI
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openshell-conformance-x86_64-unknown-linux-musl
+          path: conformance-input
+
       - name: Install RPMs and check status
         shell: bash
         run: |
           set -euo pipefail
+          chmod +x conformance-input/openshell-conformance
           guest_script="$RUNNER_TEMP/conformance.sh"
           cat > "$guest_script" <<'EOF'
           set -euo pipefail
@@ -142,28 +179,19 @@ jobs:
           }
           trap on_exit EXIT
 
-          . /etc/os-release
-          echo "Testing on $PRETTY_NAME"
-          podman --version
-          test "$(podman info --format '{{.Host.Security.Rootless}}')" = true
-          test "$(podman info --format '{{.Host.CgroupsVersion}}')" = v2
-          test "$(getenforce)" = Enforcing
-          rpm -q openshell openshell-gateway
-          openshell --version
-          openshell-gateway --version
-
           mkdir -p "$HOME/.config/openshell"
           echo 'OPENSHELL_TELEMETRY_ENABLED=false' > "$HOME/.config/openshell/gateway.env"
           systemctl --user enable --now openshell-gateway
           openshell gateway add --local https://127.0.0.1:17670 --name openshell
-          openshell status
+          /tmp/openshell-conformance run smoke
           EOF
 
-          nix run .#test-guest -- \
+          OPENSHELL_TEST_GUEST_CACHE_DISABLE=1 nix run .#test-guest -- \
             --distro fedora \
             --with podman \
             --with selinux \
             --install rpm-input/openshell-[0-9]*.rpm \
             --install rpm-input/openshell-gateway-[0-9]*.rpm \
             --copy "$guest_script:/tmp/conformance.sh" \
+            --copy conformance-input/openshell-conformance:/tmp/openshell-conformance \
             -- bash /tmp/conformance.sh

--- a/.github/workflows/deb-package.yml
+++ b/.github/workflows/deb-package.yml
@@ -20,72 +20,22 @@ defaults:
 
 jobs:
   build-deb-linux:
-    name: Build Debian Package (Linux ${{ matrix.arch }})
     strategy:
       matrix:
         include:
           - arch: amd64
             runner: linux-amd64-cpu8
-            deb_arch: amd64
             cli_target: x86_64-unknown-linux-musl
             gnu_target: x86_64-unknown-linux-gnu
           - arch: arm64
             runner: linux-arm64-cpu8
-            deb_arch: arm64
             cli_target: aarch64-unknown-linux-musl
             gnu_target: aarch64-unknown-linux-gnu
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 20
-    container:
-      image: ghcr.io/nvidia/openshell/ci:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs['checkout-ref'] }}
-
-      - name: Download CLI artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: openshell-${{ matrix.cli_target }}
-          path: package-binaries/
-
-      - name: Download gateway artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: openshell-gateway-${{ matrix.gnu_target }}
-          path: package-binaries/
-
-      - name: Download VM driver artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: openshell-driver-vm-${{ matrix.gnu_target }}
-          path: package-binaries/
-
-      - name: Configure package inputs
-        run: |
-          set -euo pipefail
-          chmod +x package-binaries/openshell{,-gateway,-driver-vm}
-          ls -lah package-binaries
-
-      - name: Build Debian package
-        run: |
-          set -euo pipefail
-          OPENSHELL_CLI_BINARY="${PWD}/package-binaries/openshell" \
-          OPENSHELL_GATEWAY_BINARY="${PWD}/package-binaries/openshell-gateway" \
-          OPENSHELL_DRIVER_VM_BINARY="${PWD}/package-binaries/openshell-driver-vm" \
-          OPENSHELL_DEB_VERSION="${INPUTS_DEB_VERSION}" \
-          OPENSHELL_DEB_ARCH="${{ matrix.deb_arch }}" \
-          OPENSHELL_OUTPUT_DIR=artifacts \
-            tasks/scripts/package-deb.sh
-        env:
-          INPUTS_DEB_VERSION: ${{ inputs['deb-version'] }}
-
-      - name: Upload Debian package artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: deb-linux-${{ matrix.arch }}
-          path: artifacts/*.deb
-          retention-days: 5
+    uses: ./.github/workflows/build-deb.yml
+    with:
+      deb-version: ${{ inputs['deb-version'] }}
+      checkout-ref: ${{ inputs['checkout-ref'] }}
+      arch: ${{ matrix.arch }}
+      runner: ${{ matrix.runner }}
+      cli-target: ${{ matrix.cli_target }}
+      gnu-target: ${{ matrix.gnu_target }}

--- a/.github/workflows/deb-package.yml
+++ b/.github/workflows/deb-package.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 defaults:
   run:

--- a/.github/workflows/rpm-package.yml
+++ b/.github/workflows/rpm-package.yml
@@ -37,83 +37,20 @@ jobs:
       matrix:
         include:
           - arch: x86_64
-            artifact_arch: amd64
             runner: linux-amd64-cpu8
             cli_target: x86_64-unknown-linux-musl
-            gnu_target: x86_64-unknown-linux-gnu
+            gateway_target: x86_64-unknown-linux-gnu
           - arch: aarch64
-            artifact_arch: arm64
             runner: linux-arm64-cpu8
             cli_target: aarch64-unknown-linux-musl
-            gnu_target: aarch64-unknown-linux-gnu
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
-    container:
-      image: fedora:latest
-    steps:
-      - name: Install build dependencies
-        run: |
-          dnf install -y \
-            packit rpm-build \
-            rust cargo gcc gcc-c++ make cmake pkg-config \
-            clang-devel z3-devel systemd-rpm-macros \
-            pandoc python3-devel git-core \
-            cargo-rpm-macros
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.checkout-ref }}
-          fetch-depth: 0
-
-      - name: Download CLI artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: openshell-${{ matrix.cli_target }}
-          path: package-binaries/
-
-      - name: Download gateway artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: openshell-gateway-${{ matrix.gnu_target }}
-          path: package-binaries/
-
-      - name: Configure package inputs
-        run: |
-          set -euo pipefail
-          chmod +x package-binaries/openshell{,-gateway}
-          ls -lah package-binaries
-
-      - name: Mark workspace safe for git
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Fetch tags
-        run: git fetch --tags --force
-
-      - name: Build RPMs via Packit
-        env:
-          OPENSHELL_RPM_VERSION: ${{ inputs['rpm-version'] }}
-          OPENSHELL_RPM_RELEASE: ${{ inputs['rpm-release'] }}
-          OPENSHELL_CARGO_VERSION: ${{ inputs['cargo-version'] }}
-          OPENSHELL_PREBUILT_BINARIES_DIR: ${{ github.workspace }}/package-binaries
-        run: packit build locally
-
-      - name: Collect RPM artifacts
-        run: |
-          set -euo pipefail
-          mkdir -p artifacts
-          mapfile -t rpms < <(find "$GITHUB_WORKSPACE" -maxdepth 3 -type f -name '*.rpm' ! -name '*.src.rpm' | sort)
-          if [ "${#rpms[@]}" -eq 0 ]; then
-            echo "::error::No RPM artifacts found under $GITHUB_WORKSPACE"
-            find "$GITHUB_WORKSPACE" -maxdepth 3 -type f | sort
-            exit 1
-          fi
-          cp "${rpms[@]}" artifacts/
-          echo "=== Built RPMs ==="
-          ls -lah artifacts/
-
-      - name: Upload RPM artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: rpm-linux-${{ matrix.arch }}
-          path: artifacts/*.rpm
-          retention-days: 5
+            gateway_target: aarch64-unknown-linux-gnu
+    uses: ./.github/workflows/build-rpm.yml
+    with:
+      checkout-ref: ${{ inputs.checkout-ref }}
+      arch: ${{ matrix.arch }}
+      runner: ${{ matrix.runner }}
+      cli-target: ${{ matrix.cli_target }}
+      gateway-target: ${{ matrix.gateway_target }}
+      rpm-version: ${{ inputs.rpm-version }}
+      rpm-release: ${{ inputs.rpm-release }}
+      cargo-version: ${{ inputs.cargo-version }}

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,7 +11,6 @@ specfile_path: openshell.spec
 
 # Packages needed in the SRPM build environment to create vendor tarball
 srpm_build_deps:
-  - rust
   - cargo
   - git-core
 
@@ -45,10 +44,6 @@ actions:
     # dist-info stays at the RPM Version; dev build identity is carried by
     # Release so Fedora's Python RPM post-processing can normalize metadata.
     - 'bash -c "if [ -n \"${OPENSHELL_CARGO_VERSION:-}\" ]; then sed -i -r \"s/^%global openshell_cargo_version .*/%global openshell_cargo_version ${OPENSHELL_CARGO_VERSION}/\" openshell.spec; fi"'
-    # Override image_tag to 'latest' for tagged stable releases.
-    # For PR and commit-to-main builds the spec default ('dev') is kept,
-    # matching the :dev images pushed by release-dev.yml.
-    - 'bash -c "if git describe --exact-match --tags HEAD 2>/dev/null | grep -qE ''^v[0-9]+\.[0-9]+\.[0-9]+$''; then sed -i ''s/^%global image_tag.*/%global image_tag latest/'' openshell.spec; fi"'
 
 jobs:
   # Build on every pull request targeting main for CI validation

--- a/architecture/build.md
+++ b/architecture/build.md
@@ -245,6 +245,8 @@ The Nix test guest harness under `nix/test-guest` boots native-architecture clou
 through QEMU for package, release, and E2E validation. A prepared cache entry is
 captured after the exact ordered Ansible configuration list and before
 test-specific packages, copied binaries, forwarded ports, or commands.
+Per-run Ansible provisioners execute after artifact installation and before the
+guest command, so package setup remains separate from conformance assertions.
 
 Prepared disks are flattened, sanitized QCOW2 images. The local cache keeps them
 read-only and each test receives a fresh writable overlay and cloud-init

--- a/nix/test-guest/README.md
+++ b/nix/test-guest/README.md
@@ -38,16 +38,18 @@ nix/test-guest/
 │   ├── centos.nix
 │   ├── fedora.nix
 │   └── rocky.nix
-└── configuration/
-    ├── docker.yml
-    ├── podman-rootless.yml
-    ├── tasks/
-    │   ├── podman-common.yml
-    │   └── podman-rootless/
-    │       ├── fedora.yml
-    │       ├── shared.yml
-    │       └── ubuntu.yml
-    └── selinux.yml
+├── configuration/
+│   ├── docker.yml
+│   ├── podman-rootless.yml
+│   ├── tasks/
+│   │   ├── podman-common.yml
+│   │   └── podman-rootless/
+│   │       ├── fedora.yml
+│   │       ├── shared.yml
+│   │       └── ubuntu.yml
+│   └── selinux.yml
+└── provisioners/
+    └── openshell-package.yml
 ```
 
 - `default.nix` assembles the guest and cache flake apps. It selects host architecture and acceleration, supplies the runtime tools, and exposes distro profiles and configuration playbooks as Nix-store catalogs.
@@ -57,6 +59,7 @@ nix/test-guest/
 - `cache-seal.sh` removes per-instance state and zeroes free space inside a prepared guest before capture.
 - `distros/*.nix` define the immutable base-image catalog. Each record pins and exports the image URL and hash and declares the expected OS ID, version, and package family.
 - `configuration/*.yml` are host-executed Ansible playbooks that layer optional capabilities onto a base guest. Configurations remain independent and run in the order supplied with repeated `--with` arguments.
+- `provisioners/*.yml` are host-executed Ansible playbooks that configure test-specific artifacts after installation. They run in the order supplied with repeated `--provision` arguments.
 - `README.md` documents the supported combinations and developer interface.
 
 The root [`flake.nix`](../../flake.nix) exposes this directory as the `test-guest` and `test-guest-cache` apps. Debian artifact creation remains outside the guest harness in [`tasks/scripts/package-deb.sh`](../../tasks/scripts/package-deb.sh); the runner only installs or copies artifacts that already exist.
@@ -139,9 +142,28 @@ Configurations are Ansible playbooks stored under `nix/test-guest/configuration/
 
 Configurations run in the order provided on the command line. OpenShell packages and copied files are installed after all configurations succeed.
 
-`--install` packages and `--copy` files are applied by a dedicated per-run
-Ansible playbook. `--copy` preserves each source file's ordinary permission
-bits. They are not stored in prepared VM cache entries.
+`--install` packages and `--copy` files are applied during the per-run artifact
+phase. `--copy` preserves each source file's ordinary permission bits. They are
+not stored in prepared VM cache entries.
+
+## Ansible provisioners
+
+Provisioners are Ansible playbooks stored under `nix/test-guest/provisioners/`.
+They run after all packages and copied files are available and before the guest
+command. Provisioners affect only the disposable overlay and are not stored in
+prepared VM cache entries.
+
+The `openshell-package` provisioner configures and starts an installed OpenShell
+gateway. Select its compute driver explicitly in the host environment:
+
+```shell
+OPENSHELL_TEST_GUEST_DRIVER=docker nix run .#test-guest -- \
+  --distro ubuntu-24-04 \
+  --with docker \
+  --install artifacts/openshell_0.0.0-local_amd64.deb \
+  --provision openshell-package \
+  -- openshell status
+```
 
 ## Prepared VM cache
 
@@ -272,6 +294,7 @@ The destination must be an absolute guest path. Copied files are installed with 
 ```text
 --distro NAME       Base distro: ubuntu-24-04, ubuntu-26-04, centos, fedora, or rocky
 --with NAME         Apply docker, podman-rootless, selinux, or snapd; repeatable
+--provision NAME    Apply a post-artifact provisioner; repeatable
 --install PATH      Install a .deb or .rpm package; repeatable
 --copy SRC:DEST     Copy a regular file into the guest, preserving its host mode;
                     repeatable
@@ -279,7 +302,7 @@ The destination must be an absolute guest path. Copied files are installed with 
 --forward-port HOST_PORT:GUEST_PORT
                     Forward a loopback host port to a guest port; repeatable
 --keep              Preserve the disk overlay and logs after shutdown
---list              List distros and configurations
+--list              List distros, configurations, and provisioners
 ```
 
 Each `--forward-port` binds only `127.0.0.1` on the host. Both ports must be unprivileged values from 1024 through 65535, and each host port may appear only once.
@@ -298,8 +321,9 @@ The runner then:
 3. Creates a fresh cloud-init instance and ephemeral SSH key.
 4. Applies the selected Ansible configurations only when the base is not prepared.
 5. Installs or copies the supplied artifacts.
-6. Opens SSH or executes the requested guest command.
-7. Powers off QEMU and deletes the writable overlay.
+6. Applies the selected post-artifact Ansible provisioners.
+7. Opens SSH or executes the requested guest command.
+8. Powers off QEMU and deletes the writable overlay.
 
 Prepared cache disks remain read-only. Test-specific state exists only in the disposable overlay.
 

--- a/nix/test-guest/cache-seal.sh
+++ b/nix/test-guest/cache-seal.sh
@@ -49,7 +49,9 @@ sync
 # Deleted credentials can remain in allocated blocks. Fill free space with
 # zeroes so qemu-img convert can safely omit those blocks from the cache disk.
 zero_file=/var/tmp/openshell-cache-zero
-dd if=/dev/zero of="${zero_file}" bs=64M status=none 2>/dev/null || true
+echo "==> Cache sealing: zeroing free disk space"
+dd if=/dev/zero of="${zero_file}" bs=64M status=progress || true
+echo "==> Cache sealing: free disk space zeroed"
 rm -f "${zero_file}"
 sync
 

--- a/nix/test-guest/configuration/docker.yml
+++ b/nix/test-guest/configuration/docker.yml
@@ -62,6 +62,21 @@
         append: true
       register: docker_group_membership
 
+    - name: Resolve the test user ID
+      ansible.builtin.command:
+        argv:
+          - id
+          - -u
+          - openshell
+      register: test_user_id
+      changed_when: false
+
+    - name: Refresh the test user's systemd manager groups
+      ansible.builtin.systemd_service:
+        name: "user@{{ test_user_id.stdout }}.service"
+        state: restarted
+      when: docker_group_membership.changed
+
     - name: Refresh the test user's group membership
       ansible.builtin.meta: reset_connection
       when: docker_group_membership.changed

--- a/nix/test-guest/default.nix
+++ b/nix/test-guest/default.nix
@@ -32,6 +32,10 @@ let
     snapd = ./configuration/snapd.yml;
   };
 
+  provisioners = {
+    openshell-package = ./provisioners/openshell-package.yml;
+  };
+
   configurationTasks = [
     "podman-common.yml"
     "podman-rootless/fedora.yml"
@@ -67,6 +71,10 @@ let
     }) configurationTasks)
   );
 
+  provisionerCatalog = pkgs.linkFarm "openshell-test-guest-provisioners" (
+    pkgs.lib.mapAttrsToList (name: path: { inherit name path; }) provisioners
+  );
+
   runtimeInputs = [
     qemu
     pkgs.python3Packages.ansible-core
@@ -86,6 +94,7 @@ let
     export OPENSHELL_TEST_GUEST_RUNTIME=1
     export OPENSHELL_TEST_GUEST_DISTROS=${distroCatalog}
     export OPENSHELL_TEST_GUEST_CONFIGURATIONS=${configurationCatalog}
+    export OPENSHELL_TEST_GUEST_PROVISIONERS=${provisionerCatalog}
     export OPENSHELL_TEST_GUEST_CACHE_LIB=${./cache-lib.sh}
     export OPENSHELL_TEST_GUEST_CACHE_RUNNER=${./cache.sh}
     export OPENSHELL_TEST_GUEST_CACHE_SEAL=${./cache-seal.sh}

--- a/nix/test-guest/provisioners/openshell-package.yml
+++ b/nix/test-guest/provisioners/openshell-package.yml
@@ -1,0 +1,46 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Configure the gateway supplied by packages installed by test-guest.
+
+- name: Provision packaged OpenShell gateway
+  hosts: test_vm
+  gather_facts: false
+
+  vars:
+    openshell_driver: "{{ lookup('ansible.builtin.env', 'OPENSHELL_TEST_GUEST_DRIVER') }}"
+
+  tasks:
+    - name: Create the OpenShell configuration directory
+      ansible.builtin.file:
+        path: /home/openshell/.config/openshell
+        state: directory
+        mode: "0700"
+
+    - name: Configure the packaged gateway
+      ansible.builtin.copy:
+        dest: /home/openshell/.config/openshell/gateway.env
+        mode: "0600"
+        content: |
+          OPENSHELL_DRIVERS={{ openshell_driver }}
+          OPENSHELL_TELEMETRY_ENABLED=false
+
+    - name: Start the packaged gateway
+      ansible.builtin.systemd_service:
+        name: openshell-gateway
+        daemon_reload: true
+        enabled: true
+        state: started
+        scope: user
+
+    - name: Register the packaged gateway
+      ansible.builtin.command:
+        argv:
+          - openshell
+          - gateway
+          - add
+          - --local
+          - https://127.0.0.1:17670
+          - --name
+          - openshell

--- a/nix/test-guest/run.sh
+++ b/nix/test-guest/run.sh
@@ -14,6 +14,7 @@ Usage:
 Options:
   --distro NAME       Base distro: ubuntu-24-04, ubuntu-26-04, centos, fedora, or rocky
   --with NAME         Apply a configuration; repeatable (docker, podman-rootless, selinux, snapd)
+  --provision NAME    Apply a post-artifact provisioner; repeatable
   --install PATH      Install a .deb or .rpm package; repeatable
   --copy SRC:DEST     Copy a regular file to an absolute guest path, preserving
                       its host mode; repeatable
@@ -21,7 +22,7 @@ Options:
   --forward-port HOST_PORT:GUEST_PORT
                       Forward a loopback host port to a guest port; repeatable
   --keep              Keep the disposable disk and logs after shutdown
-  --list              List distros and configurations
+  --list              List distros, configurations, and provisioners
   -h, --help          Show this help
 
 With no COMMAND, the runner opens an interactive SSH session.
@@ -31,6 +32,7 @@ EOF
 if [ "${OPENSHELL_TEST_GUEST_RUNTIME:-}" != 1 ] ||
 	[ ! -d "${OPENSHELL_TEST_GUEST_DISTROS:-}" ] ||
 	[ ! -d "${OPENSHELL_TEST_GUEST_CONFIGURATIONS:-}" ] ||
+	[ ! -d "${OPENSHELL_TEST_GUEST_PROVISIONERS:-}" ] ||
 	[ ! -r "${OPENSHELL_TEST_GUEST_CACHE_LIB:-}" ] ||
 	[ ! -r "${OPENSHELL_TEST_GUEST_CACHE_RUNNER:-}" ]; then
 	echo "run this script through 'nix run .#test-guest -- ...'" >&2
@@ -70,6 +72,7 @@ requested_ssh_port=
 keep=0
 list=0
 configurations=()
+provisions=()
 packages=()
 copies=()
 forward_ports=()
@@ -85,6 +88,11 @@ while [ "$#" -gt 0 ]; do
 	--with)
 		require_value "$@"
 		configurations+=("$2")
+		shift 2
+		;;
+	--provision)
+		require_value "$@"
+		provisions+=("$2")
 		shift 2
 		;;
 	--install)
@@ -145,6 +153,11 @@ if [ "${list}" -eq 1 ]; then
 		[ -f "${entry}" ] || continue
 		printf '  %s\n' "${entry##*/}"
 	done
+	echo "Provisioners:"
+	for entry in "${OPENSHELL_TEST_GUEST_PROVISIONERS}"/*; do
+		[ -f "${entry}" ] || continue
+		printf '  %s\n' "${entry##*/}"
+	done
 	exit 0
 fi
 
@@ -166,6 +179,13 @@ fi
 		if [[ ! ${item} =~ ^[a-z0-9][a-z0-9-]*$ ]] ||
 		[ ! -f "${OPENSHELL_TEST_GUEST_CONFIGURATIONS}/${item}" ]; then
 		echo "unknown configuration: ${item:-<empty>}" >&2
+		exit 2
+	fi
+done
+for item in "${provisions[@]}"; do
+	if [[ ! ${item} =~ ^[a-z0-9][a-z0-9-]*$ ]] ||
+		[ ! -f "${OPENSHELL_TEST_GUEST_PROVISIONERS}/${item}" ]; then
+		echo "unknown provisioner: ${item:-<empty>}" >&2
 		exit 2
 	fi
 done
@@ -656,6 +676,16 @@ if [ "${#packages[@]}" -gt 0 ] || [ "${#copies[@]}" -gt 0 ]; then
 	ssh "${ssh_args[@]}" openshell@127.0.0.1 \
 		"rm -rf -- '${artifact_staging_dir}'"
 	report_timing "artifact transfer" "${phase_started_at}"
+fi
+
+if [ "${#provisions[@]}" -gt 0 ]; then
+	phase_started_at=${SECONDS}
+	for item in "${provisions[@]}"; do
+		echo "==> Applying provisioner: ${item}"
+		ANSIBLE_CONFIG="${ansible_config}" ANSIBLE_NOCOLOR=1 \
+			ansible-playbook "${OPENSHELL_TEST_GUEST_PROVISIONERS}/${item}"
+	done
+	report_timing "system provisioning" "${phase_started_at}"
 fi
 
 # Configuration may change the test user's groups. Close the SSH control

--- a/openshell.spec
+++ b/openshell.spec
@@ -12,12 +12,6 @@
 # in the format redhat-rpm-config expects (especially on EPEL).
 %global debug_package %{nil}
 
-# Default container image tag for supervisor and sandbox images.
-# Overridden to 'latest' by Packit's fix-spec-file action for tagged stable
-# releases (via git describe --exact-match). PR and commit-to-main builds
-# keep the default 'dev' so they track the development image stream.
-%global image_tag dev
-
 Name:           openshell
 Version:        %{openshell_version}
 Release:        1.20260518180028805757.podman.toml.gateway.listener.11.g8c0cb7c8%{?dist}
@@ -30,21 +24,9 @@ Source1: openshell-%{openshell_version}-vendor.tar.xz
 
 ExclusiveArch:  x86_64 aarch64
 
-# Rust build dependencies
-# NOTE: MSRV is 1.88 (Rust edition 2024). As of mid-2025, this requires
-# Fedora Rawhide or newer. Stable Fedora and EPEL-10 may ship older Rust;
-# adjust targets in .packit.yaml accordingly or provide a supplementary
-# Rust toolchain via additional_repos in the COPR build config.
-BuildRequires:  rust >= 1.88
+# Cargo metadata generation
 BuildRequires:  cargo
 BuildRequires:  cargo-rpm-macros >= 25
-BuildRequires:  gcc
-BuildRequires:  gcc-c++
-BuildRequires:  make
-BuildRequires:  cmake
-BuildRequires:  pkg-config
-BuildRequires:  clang-devel
-BuildRequires:  z3-devel
 BuildRequires:  systemd-rpm-macros
 
 # Man page generation
@@ -103,18 +85,8 @@ sed -i 's/^version = "0.0.0"/version = "%{openshell_cargo_version}"/' Cargo.toml
 grep -q 'version = "%{openshell_cargo_version}"' Cargo.toml || (echo "ERROR: Cargo.toml version patch failed" && exit 1)
 
 %build
-# Build the CLI and gateway binaries unless the release workflow supplied the
-# same prebuilt artifacts used for tarballs and Debian packages.
-export CARGO_BUILD_JOBS=%{_smp_build_ncpus}
-# Set the default container image tag so compiled-in image refs point at
-# real tags in the ghcr.io/nvidia/openshell registry.
-export OPENSHELL_IMAGE_TAG=%{image_tag}
-if [ -n "${OPENSHELL_PREBUILT_BINARIES_DIR:-}" ]; then
-  test -x "${OPENSHELL_PREBUILT_BINARIES_DIR}/openshell"
-  test -x "${OPENSHELL_PREBUILT_BINARIES_DIR}/openshell-gateway"
-else
-  cargo build --release --bin openshell --bin openshell-gateway
-fi
+test -x "${OPENSHELL_PREBUILT_BINARIES_DIR}/openshell"
+test -x "${OPENSHELL_PREBUILT_BINARIES_DIR}/openshell-gateway"
 
 # Generate vendored crate manifest and license metadata.
 # cargo-vendor.txt is consumed by an RPM generator (from cargo-rpm-macros)
@@ -129,18 +101,10 @@ pandoc -s -t man deploy/man/openshell-gateway.8.md -o openshell-gateway.8
 
 %install
 # --- CLI binary ---
-if [ -n "${OPENSHELL_PREBUILT_BINARIES_DIR:-}" ]; then
-  install -Dpm 0755 "${OPENSHELL_PREBUILT_BINARIES_DIR}/%{name}" %{buildroot}%{_bindir}/%{name}
-else
-  install -Dpm 0755 target/release/%{name} %{buildroot}%{_bindir}/%{name}
-fi
+install -Dpm 0755 "${OPENSHELL_PREBUILT_BINARIES_DIR}/%{name}" %{buildroot}%{_bindir}/%{name}
 
 # --- Gateway binary ---
-if [ -n "${OPENSHELL_PREBUILT_BINARIES_DIR:-}" ]; then
-  install -Dpm 0755 "${OPENSHELL_PREBUILT_BINARIES_DIR}/%{name}-gateway" %{buildroot}%{_bindir}/%{name}-gateway
-else
-  install -Dpm 0755 target/release/%{name}-gateway %{buildroot}%{_bindir}/%{name}-gateway
-fi
+install -Dpm 0755 "${OPENSHELL_PREBUILT_BINARIES_DIR}/%{name}-gateway" %{buildroot}%{_bindir}/%{name}-gateway
 
 # --- Default gateway TOML config template ---
 # Shipped as a read-only reference in %{_datadir}. The systemd unit seeds a


### PR DESCRIPTION
## Summary

Add an Ubuntu 24.04 conformance target that builds and installs the amd64 Debian package, then runs the shared smoke suite against Docker. Reuse single-target build workflows so conformance consumes the same artifacts as the existing packaging pipelines.

## Related Issue

No issue required: this is localized CI coverage and test-harness maintenance.

This change is stacked on the Fedora package conformance work.

## Changes

- Extract reusable single-target VM driver and Debian package build workflows
- Preserve the existing multi-platform VM driver and Debian package matrices
- Build one amd64 Debian package from the conformance pipeline’s existing binary artifacts
- Install and exercise the Debian package in an Ubuntu 24.04 guest with Docker
- Add post-artifact Ansible provisioners to the test-guest harness
- Configure and start installed RPM and DEB gateways through a shared Ansible playbook
- Keep the conformance smoke command explicit and separate from package provisioning
- Move the Fedora rootless Podman target onto the same package provisioning path

## Testing

- [x] `nix fmt -- --ci nix/test-guest/default.nix`
- [x] `bash -n nix/test-guest/run.sh`
- [x] ShellCheck
- [x] Ansible playbook syntax check
- [x] `nix run .#test-guest -- --list`
- [x] Actionlint on the affected workflows
- [x] `git diff --check`
- [ ] `mise run pre-commit` (not run, per request)
- [ ] VM-backed package conformance (runs in GitHub Actions)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
